### PR TITLE
Fix gateway startup readiness race

### DIFF
--- a/src/opensquilla/cli/gateway_cmd.py
+++ b/src/opensquilla/cli/gateway_cmd.py
@@ -105,7 +105,7 @@ def _lifecycle_manager(
     port: int,
     bind: str,
     listen: str,
-    health_timeout: float = 10.0,
+    health_timeout: float = 60.0,
     shutdown_timeout: float = 10.0,
 ) -> GatewayLifecycleManager:
     return GatewayLifecycleManager(
@@ -133,10 +133,10 @@ def start_gateway(
     port: int = typer.Option(18790, "--port", "-p", help="Port to bind"),
     bind: str = typer.Option("127.0.0.1", "--bind", "-b", help="Host to bind"),
     listen: str = typer.Option("", "--listen", help="Host to bind (wins over --bind)"),
-    health_timeout: float = typer.Option(10.0, "--timeout", help="Health wait timeout"),
+    health_timeout: float = typer.Option(60.0, "--timeout", help="Readiness wait timeout"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
-    """Start the gateway in the background and wait for health."""
+    """Start the gateway in the background and wait for readiness."""
 
     manager = _lifecycle_manager(
         port=port,
@@ -181,7 +181,7 @@ def restart_gateway(
     port: int = typer.Option(18790, "--port", "-p", help="Port to restart"),
     bind: str = typer.Option("127.0.0.1", "--bind", "-b", help="Host to restart"),
     listen: str = typer.Option("", "--listen", help="Host to restart (wins over --bind)"),
-    health_timeout: float = typer.Option(10.0, "--timeout", help="Health wait timeout"),
+    health_timeout: float = typer.Option(60.0, "--timeout", help="Readiness wait timeout"),
     shutdown_timeout: float = typer.Option(
         10.0, "--shutdown-timeout", help="Shutdown wait timeout"
     ),

--- a/src/opensquilla/cli/gateway_lifecycle.py
+++ b/src/opensquilla/cli/gateway_lifecycle.py
@@ -100,7 +100,7 @@ class GatewayLifecycleManager:
         host: str = "127.0.0.1",
         port: int = 18790,
         config_path: str | None = None,
-        health_timeout: float = 10.0,
+        health_timeout: float = 60.0,
         shutdown_timeout: float = 10.0,
         poll_interval: float = 0.2,
     ) -> None:
@@ -241,7 +241,7 @@ class GatewayLifecycleManager:
             pid=process.pid,
             managed=True,
             code="HEALTH_TIMEOUT",
-            message="Gateway did not become healthy before the timeout.",
+            message="Gateway did not become ready before the timeout.",
             exit_code_value=1,
         )
 
@@ -495,10 +495,29 @@ class GatewayLifecycleManager:
                 continue
         return False
 
+    def _probe_ready(self) -> bool:
+        saw_ready_endpoint = False
+        for path in ("ready", "readyz"):
+            request = Request(f"{_http_url(self.probe_host, self.port)}/{path}", method="GET")
+            try:
+                with urlopen(request, timeout=0.5) as response:  # noqa: S310 - local readiness probe.
+                    saw_ready_endpoint = True
+                    if 200 <= int(response.status) < 300:
+                        return True
+            except HTTPError as exc:
+                if int(getattr(exc, "code", 0)) != 404:
+                    saw_ready_endpoint = True
+                continue
+            except (OSError, URLError, TimeoutError):
+                continue
+        if saw_ready_endpoint:
+            return False
+        return self._probe_health()
+
     def _wait_for_health(self) -> bool:
         deadline = time.monotonic() + max(self.health_timeout, 0.0)
         while time.monotonic() <= deadline:
-            if self._probe_health():
+            if self._probe_ready():
                 return True
             time.sleep(self.poll_interval)
         return False

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -312,10 +312,10 @@ def gateway_start(
     port: int = typer.Option(18790, "--port", "-p", help="Port to bind"),
     bind: str = typer.Option("127.0.0.1", "--bind", "-b", help="Host to bind"),
     listen: str = typer.Option("", "--listen", help="Host to bind (wins over --bind)"),
-    health_timeout: float = typer.Option(10.0, "--timeout", help="Health wait timeout"),
+    health_timeout: float = typer.Option(60.0, "--timeout", help="Readiness wait timeout"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
-    """Start the gateway in the background and wait for health."""
+    """Start the gateway in the background and wait for readiness."""
     from opensquilla.cli.gateway_cmd import start_gateway
 
     start_gateway(
@@ -365,7 +365,7 @@ def gateway_restart(
     port: int = typer.Option(18790, "--port", "-p", help="Port to restart"),
     bind: str = typer.Option("127.0.0.1", "--bind", "-b", help="Host to restart"),
     listen: str = typer.Option("", "--listen", help="Host to restart (wins over --bind)"),
-    health_timeout: float = typer.Option(10.0, "--timeout", help="Health wait timeout"),
+    health_timeout: float = typer.Option(60.0, "--timeout", help="Readiness wait timeout"),
     shutdown_timeout: float = typer.Option(
         10.0, "--shutdown-timeout", help="Shutdown wait timeout"
     ),

--- a/src/opensquilla/gateway/app.py
+++ b/src/opensquilla/gateway/app.py
@@ -76,7 +76,13 @@ def create_gateway_app(
 
     async def ready(request: Request) -> JSONResponse:
         uptime = int((time.time() - _start_time) * 1000)
-        return JSONResponse({"ready": True, "uptime_ms": uptime})
+        is_ready = bool(getattr(request.app.state, "gateway_ready", True))
+        payload = {
+            "ready": is_ready,
+            "status": "ready" if is_ready else "starting",
+            "uptime_ms": uptime,
+        }
+        return JSONResponse(payload, status_code=200 if is_ready else 503)
 
     async def api_config(request: Request) -> JSONResponse:
         ctx = _make_ctx(request)

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -1848,6 +1848,7 @@ async def start_gateway_server(
         memory_retrievers=svc.memory_retrievers,
         extra_routes=webhook_routes or None,
     )
+    app.state.gateway_ready = False
 
     server_handle = GatewayServer(app=app, config=config)
     server_handle._channel_manager = channel_manager
@@ -1892,4 +1893,5 @@ async def start_gateway_server(
             else:
                 log.warning("gateway.channel_failed", channel=name)
 
+    app.state.gateway_ready = True
     return server_handle

--- a/src/opensquilla/gateway/websocket.py
+++ b/src/opensquilla/gateway/websocket.py
@@ -209,7 +209,10 @@ async def handle_ws_connection(
 
     # Step 1: Send connect.challenge
     nonce = str(uuid.uuid4())
-    await conn.send_event("connect.challenge", {"nonce": nonce})
+    try:
+        await conn.send_event("connect.challenge", {"nonce": nonce})
+    except WebSocketDisconnect:
+        return
 
     # Step 2: Pre-auth timeout — client must send connect request
     try:

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -169,6 +169,38 @@ def test_gateway_start_uses_same_interpreter_cli_boundary(tmp_path, monkeypatch)
     assert kwargs["shell"] is False
 
 
+def test_gateway_start_waits_for_readiness_after_liveness(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "home"))
+    calls = []
+    health_checks = 0
+    ready_checks = []
+
+    def fake_popen(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return SimpleNamespace(pid=4244)
+
+    def fake_health(self):
+        nonlocal health_checks
+        health_checks += 1
+        return health_checks > 1
+
+    def fake_ready(self):
+        ready_checks.append(True)
+        return len(ready_checks) > 1
+
+    monkeypatch.setattr(gateway_lifecycle.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(Manager, "_probe_health", fake_health)
+    monkeypatch.setattr(Manager, "_probe_ready", fake_ready, raising=False)
+    monkeypatch.setattr(gateway_lifecycle.time, "sleep", lambda _seconds: None)
+
+    result = runner.invoke(app, ["gateway", "start", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    assert _payload(result)["state"] == "running"
+    assert calls
+    assert len(ready_checks) == 2
+
+
 def test_gateway_health_probe_uses_loopback_for_wildcard_bind(monkeypatch) -> None:
     urls = []
 

--- a/tests/test_gateway/test_readiness.py
+++ b/tests/test_gateway/test_readiness.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from opensquilla.gateway.app import create_gateway_app
+from opensquilla.gateway.config import GatewayConfig
+
+
+def test_ready_endpoint_reports_starting_until_gateway_marks_ready() -> None:
+    app = create_gateway_app(GatewayConfig())
+    app.state.gateway_ready = False
+
+    with TestClient(app) as client:
+        starting = client.get("/ready")
+        assert starting.status_code == 503
+        assert starting.json()["ready"] is False
+
+        app.state.gateway_ready = True
+        ready = client.get("/ready")
+        assert ready.status_code == 200
+        assert ready.json()["ready"] is True

--- a/tests/test_gateway/test_websocket_handshake.py
+++ b/tests/test_gateway/test_websocket_handshake.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from starlette.websockets import WebSocketDisconnect, WebSocketState
+
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.websocket import handle_ws_connection
+
+
+class _DisconnectingChallengeWebSocket:
+    client_state = WebSocketState.CONNECTED
+    client = SimpleNamespace(host="127.0.0.1", port=12345)
+
+    def __init__(self) -> None:
+        self.accepted = False
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def send_text(self, _text: str) -> None:
+        raise WebSocketDisconnect(code=1006)
+
+
+@pytest.mark.asyncio
+async def test_websocket_handshake_ignores_disconnect_while_sending_challenge() -> None:
+    ws = _DisconnectingChallengeWebSocket()
+
+    await handle_ws_connection(ws, GatewayConfig(), dispatcher=object())
+
+    assert ws.accepted is True


### PR DESCRIPTION
## Bug

`opensquilla gateway start` could report success as soon as `/health` became live, while channel startup was still in progress. With Feishu websocket enabled, an immediate `opensquilla channels status` could race that startup window and fail during the WebSocket opening handshake.

The same startup window also allowed a client disconnect while the server was sending `connect.challenge`, which surfaced as an ASGI stack trace instead of a normal early disconnect.

## Root Cause

The lifecycle manager only waited on `/health`/`/healthz`, which represents liveness rather than operator-facing readiness. Channel adapters are started after the ASGI server is created, so `/health` can be reachable before channel startup and WebSocket RPC are ready for CLI use.

## Fix

- Keep `/health` as a live endpoint.
- Make `/ready` reflect startup state, returning `503` while channels are still starting and `200` once startup is ready.
- Make background `gateway start` / `restart` wait on readiness instead of liveness.
- Increase the default readiness wait timeout to 60 seconds for slower first startup and channel initialization.
- Treat disconnects during `connect.challenge` as a normal early client disconnect.
- Add regression coverage for readiness state, lifecycle readiness waiting, and the WebSocket challenge disconnect path.

## Verification

- `uv run --extra dev ruff check src/opensquilla/cli/gateway_lifecycle.py src/opensquilla/cli/gateway_cmd.py src/opensquilla/cli/main.py src/opensquilla/gateway/app.py src/opensquilla/gateway/boot.py src/opensquilla/gateway/websocket.py tests/test_cli/test_gateway_cmd.py tests/test_gateway/test_readiness.py tests/test_gateway/test_websocket_handshake.py`
- `uv run --extra dev pytest tests/test_cli/test_gateway_cmd.py tests/test_gateway/test_readiness.py tests/test_gateway/test_websocket_handshake.py tests/test_cli/test_gateway_client_keepalive.py tests/test_gateway/test_rpc_sessions.py -q`
- `uv run --extra dev --extra model-router pytest -q`

## Not Tested

- Live Feishu smoke from this branch. The earlier live gateway state was left untouched during the local branch work.