### PR TITLE
Keep shell installer runnable from Windows checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+*.sh text eol=lf
+
 src/opensquilla/squilla_router/models/*.pkl filter=lfs diff=lfs merge=lfs -text
 src/opensquilla/squilla_router/models/*.txt filter=lfs diff=lfs merge=lfs -text
 src/opensquilla/squilla_router/models/embeddings/**/*.onnx filter=lfs diff=lfs merge=lfs -text

--- a/install.sh
+++ b/install.sh
@@ -68,7 +68,7 @@ check_squilla_router_assets() {
             missing+=("${path}")
             continue
         fi
-        if [[ "$(head -n 1 "${path}" 2>/dev/null)" == "${pointer_line}" ]]; then
+        if LC_ALL=C grep -q -m 1 -F -x "${pointer_line}" "${path}" 2>/dev/null; then
             pointers+=("${path}")
         fi
     done


### PR DESCRIPTION
## Summary
- force shell scripts to check out with LF line endings
- make the shell installer detect Git LFS pointer files without reading binary model assets into a shell variable

## Why
After PR #2 clarified the default router-enabled install path, a Windows checkout with `core.autocrlf=true` still left `install.sh` with CRLF line endings. Running the documented `bash install.sh` command through Git Bash failed on `bash\r`. Once line endings were fixed, dry-run also surfaced a binary-command-substitution warning from the router asset check.

## Verification
- `OPENSQUILLA_INSTALL_DRY_RUN=1 ./install.sh` under bash
- `pwsh -ExecutionPolicy Bypass -File install.ps1` with `OPENSQUILLA_INSTALL_DRY_RUN=1`
- `git diff --check`

## Not tested
- full non-dry-run installer