### PR TITLE
Tolerate empty payload rows when loading scheduler jobs

### DIFF
--- a/src/opensquilla/scheduler/persistence.py
+++ b/src/opensquilla/scheduler/persistence.py
@@ -98,7 +98,10 @@ def _row_to_job(row: aiosqlite.Row) -> CronJob:
         except (IndexError, KeyError):
             return default
 
-    raw_payload = json.loads(row["payload"])
+    try:
+        raw_payload = json.loads(row["payload"] or "{}")
+    except json.JSONDecodeError:
+        raw_payload = {}
     raw_target = SessionTarget(_get("session_target", "isolated"))
     raw_session_key = _get("session_key", "") or ""
     raw_origin_session_key = _get("origin_session_key", "") or ""

--- a/tests/test_scheduler/test_persistence.py
+++ b/tests/test_scheduler/test_persistence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from opensquilla.compat import aiosqlite
 from opensquilla.scheduler.persistence import JobStore
 from opensquilla.scheduler.types import CronJob
 
@@ -35,3 +36,39 @@ async def test_scheduler_persistence_round_trips_tool_policy(tmp_path) -> None:
         "also_allow": ["memory_search"],
         "deny": ["web_fetch"],
     }
+
+
+@pytest.mark.asyncio
+async def test_get_handles_empty_payload_row(tmp_path) -> None:
+    """An empty `payload` cell must not crash _row_to_job.
+
+    `_normalize_legacy_jobs` already tolerates `payload=''` /
+    `JSONDecodeError`; the `_row_to_job` path used by `get` / `list_active`
+    / `iter_due` must do the same so a single legacy or externally-written
+    row cannot wedge the whole scheduler.
+    """
+    db_path = tmp_path / "scheduler.db"
+    store = JobStore(str(db_path))
+    await store.open()
+    try:
+        async with aiosqlite.connect(str(db_path)) as raw_db:
+            now = "2026-01-01T00:00:00+00:00"
+            await raw_db.execute(
+                """
+                INSERT INTO scheduler_jobs
+                    (id, name, cron_expr, handler_key, payload,
+                     status, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("legacy", "Legacy", "*/5 * * * *", "agent_run", "",
+                 "pending", now, now),
+            )
+            await raw_db.commit()
+
+        loaded = await store.get("legacy")
+    finally:
+        await store.close()
+
+    assert loaded is not None
+    assert loaded.id == "legacy"
+    assert loaded.payload == {} or isinstance(loaded.payload, dict)


### PR DESCRIPTION
## Summary
- `_row_to_job` is the read path used by `JobStore.get`, `list_active`, `list_by_status`, and `iter_due`. It crashed with `JSONDecodeError` on any row whose `payload` cell was an empty string — a single bad row (interrupted migration, external writer, legacy install) would wedge the entire scheduler load path.
- Sibling helper `_normalize_legacy_jobs` already guards the same `json.loads` with `row["payload"] or "{}"` plus a `JSONDecodeError` fallback. Mirror that protection in `_row_to_job` so a malformed row degrades to an empty payload instead of taking down `list_*`.

## Test plan
- [x] Regression test inserts a `payload=''` row directly via `aiosqlite` and verifies `JobStore.get` returns the job (previously raised `JSONDecodeError`).
- [ ] Existing scheduler tests still pass (no behavior change for well-formed rows).