### PR TITLE
Clarify source setup and router defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,89 @@ config schema.
 
 ## Quick start
 
-The fastest path to a running OpenSquilla on your local machine.
+Choose the path that matches how you want to use OpenSquilla:
 
-Choose one path and stay on it:
-
-| Goal | Use this path | Commands use |
+| User type | Path | Status |
 | --- | --- | --- |
-| Run OpenSquilla as a local app | [Install](#install) | `opensquilla ...` |
-| Modify or debug OpenSquilla source | [Develop from source](#develop-from-source) | `uv run opensquilla ...` |
+| New user | [Release package](#release-package-coming-soon) | Coming soon |
+| Command-line user | [Install from source](#install-from-source) | Available now |
+| Developer | [Develop from source](#develop-from-source) | Available now |
 
-Both paths can start from `git clone`. In the install path, the clone is only
-the source package the installer reads from. In the development path, the clone
-is the live workspace.
+SquillaRouter is included by default in every currently available install path.
+Only choose the `core` profile or `--router disabled` if you intentionally want
+to skip the bundled router.
 
-1. Install prerequisites: [git-lfs](https://git-lfs.com/) and
-   [uv](https://docs.astral.sh/uv/).
+### Release package — coming soon
+
+This will be the recommended path for non-developers: download a release
+package, extract it, set an API key, start OpenSquilla, and open the Web UI.
+Public release packages are not published yet. Until release packages are
+published, new users should use Install from source.
+
+### Install from source
+
+Use this path when you want to run OpenSquilla as a local app from the current
+source tree. The clone is only the package source the installer reads from; after
+installing, use `opensquilla ...` commands, not `uv run`.
+
+1. Install prerequisites: Git, Git LFS, and uv.
+
+   Download links:
+   - Git: <https://git-scm.com/downloads>
+   - Git LFS: <https://git-lfs.com/>
+   - uv: <https://docs.astral.sh/uv/getting-started/installation/>
+
+   <details>
+   <summary>Optional: install prerequisites from a terminal</summary>
+
+   Windows PowerShell:
+
+   ```powershell
+   winget install --id Git.Git -e
+   winget install --id GitHub.GitLFS -e
+   powershell -ExecutionPolicy Bypass -c "irm https://astral.sh/uv/install.ps1 | iex"
+   git lfs install
+   ```
+
+   macOS, if you already use Homebrew:
+
+   ```sh
+   brew install git git-lfs uv
+   git lfs install
+   ```
+
+   Homebrew is optional: <https://brew.sh/>. If you do not use Homebrew, use the
+   download links above.
+
+   Debian / Ubuntu:
+
+   ```sh
+   sudo apt update
+   sudo apt install -y git git-lfs
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   git lfs install
+   ```
+
+   Fedora:
+
+   ```sh
+   sudo dnf install -y git git-lfs
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   git lfs install
+   ```
+
+   Arch:
+
+   ```sh
+   sudo pacman -S --needed git git-lfs
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   git lfs install
+   ```
+
+   Open a new terminal if `git`, `git lfs`, or `uv` is not found after
+   installation.
+
+   </details>
 
 2. Clone with LFS assets:
 
@@ -51,6 +119,7 @@ is the live workspace.
 
 3. Install with the recommended profile. This creates a user-local
    `opensquilla` command. The checkout-local `.venv`, if any, is not used.
+   The normal install commands above already install SquillaRouter.
 
    macOS / Linux:
 
@@ -61,21 +130,61 @@ is the live workspace.
    Windows PowerShell:
 
    ```powershell
-   pwsh -ExecutionPolicy Bypass -File install.ps1
+   powershell -ExecutionPolicy Bypass -File .\install.ps1
    ```
 
-   Optional channel adapters are installed only when requested. For example,
-   add Feishu websocket support with `-Extras feishu` on Windows or
-   `OPENSQUILLA_INSTALL_EXTRAS=feishu` on macOS/Linux.
+   PowerShell 7 users can run `pwsh -ExecutionPolicy Bypass -File .\install.ps1`.
+
+   Optional: add a channel adapter only if you need one. For example, add
+   Feishu websocket channel support with these full install commands:
+
+   Windows PowerShell:
+
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File .\install.ps1 -Extras feishu
+   ```
+
+   macOS / Linux:
+
+   ```sh
+   OPENSQUILLA_INSTALL_EXTRAS=feishu bash install.sh
+   ```
 
    Only set `OPENSQUILLA_INSTALL_PROFILE=core` if you intentionally want
    to skip the bundled router.
 
+   Open a new terminal if `opensquilla` is not found after installation.
+
 4. Configure. Use the installed `opensquilla` command below. Do not prefix
    these commands with `uv run` unless you chose **Develop from source**.
 
+   Recommended for beginners:
+
    ```sh
    opensquilla onboard
+   ```
+
+   The wizard asks you to choose a provider and enter or reference its API key.
+
+   For automation, this OpenRouter example is copy-pasteable. If you choose
+   OpenRouter, create a key at <https://openrouter.ai/docs/api-keys>, then
+   replace `sk-...` with the real key value. The `export` and `$env:` examples
+   below set the key for the current terminal only.
+   OpenRouter is only an example; substitute any supported provider and its API
+   key variable.
+
+   macOS / Linux:
+
+   ```sh
+   export OPENROUTER_API_KEY="sk-..."
+   opensquilla onboard --provider openrouter --api-key-env OPENROUTER_API_KEY
+   ```
+
+   Windows PowerShell:
+
+   ```powershell
+   $env:OPENROUTER_API_KEY="sk-..."
+   opensquilla onboard --provider openrouter --api-key-env OPENROUTER_API_KEY
    ```
 
 5. Run the gateway:
@@ -84,27 +193,44 @@ is the live workspace.
    opensquilla gateway run
    ```
 
-Open the Web UI at <http://127.0.0.1:18790/control/>.
+Wait until the gateway says it is running before opening the Web UI at
+<http://127.0.0.1:18790/control/>. Press `Ctrl+C` to stop the foreground
+gateway. If Windows lacks the Visual C++ Redistributable, the gateway still
+starts but the bundled router falls back to a safe direct route. If Windows
+prints an `onnxruntime` or `DLL load failed` warning, see the Visual C++ runtime
+note in [Prerequisites](#prerequisites).
 
-## Advanced usage
+## Setup details and troubleshooting
 
-A complete tutorial that covers every step in Quick start plus the
-options Quick start glosses over. Sections marked **(optional)** can be
-skipped depending on your environment; everything else is required for
-a working install.
+Setup details expands the Quick start paths; it is not a separate install path.
+Use Install from source when you only want to run OpenSquilla. Use Develop from
+source only when you want to edit, test, or debug the code.
+
+Sections marked **(optional)** can be skipped depending on your environment;
+everything else is required for a working source install.
 
 ### Prerequisites
 
-- **Python 3.12+** — required for source and `uv` installs. **(optional)**
-  for portable-zip users, since the release zip already bundles its own
-  CPython.
+- **Python 3.12+** — required only when you skip `uv` and use the `pip --user`
+  fallback, or when you develop from source. **(optional)** for portable-zip
+  users, since the release zip already bundles its own CPython.
 - **Git and Git LFS** — required. The bundled SquillaRouter assets are
   stored as LFS pointers; without `git-lfs` the `recommended` profile
   fails with `version https://git-lfs.github.com/spec/v1` pointer files
   in place of the model bytes. Install once: <https://git-lfs.com/>.
-- **`uv` or `pip` ≥ 23** — required. The installer scripts prefer
-  `uv tool install` and fall back to `pip --user`. Install `uv` once:
-  <https://docs.astral.sh/uv/>.
+- **`uv`** — recommended for normal source installs. The installer scripts use
+  `uv tool install` when available. Install once: <https://docs.astral.sh/uv/>.
+- **`pip` >= 23** — fallback only when `uv` is unavailable. The scripts fall
+  back to `python -m pip install --user`.
+- **Windows Visual C++ runtime** — recommended when using the bundled router
+  on Windows. `install.ps1` tries to install the Microsoft Visual C++
+  Redistributable for Visual Studio 2015-2022 (x64) with `winget` when it is
+  missing. If startup still prints `DLL load failed while importing
+  onnxruntime_pybind11_state`, install it manually, then restart PowerShell:
+  <https://aka.ms/vs/17/release/vc_redist.x64.exe>. If `winget` is not present,
+  download and run the Visual C++ installer manually. If you need to run while
+  fixing the runtime, use the `--router disabled --minimal` workaround in
+  [First-run config](#first-run-config).
 
 ### Clone the repo
 
@@ -115,16 +241,23 @@ cd opensquilla
 git lfs pull --include="src/opensquilla/squilla_router/models/**"
 ```
 
-### Install
+`git lfs install` is idempotent and safe to run again.
+
+### Install from source (detailed)
 
 Use this path when you want to run OpenSquilla, not edit its source.
 The clone is only the package source for the installer. After install,
 use `opensquilla ...`; do not use `uv run`.
 
 The scripts install `.[recommended]` by default. `recommended` is the
-normal runtime profile: router, memory, and local model dependencies.
+normal runtime profile: SquillaRouter, memory, and local model dependencies.
 Messaging channel adapters are opt-in extras. Most users do not need
 every chat platform SDK.
+
+The install scripts default to the `recommended` profile, which installs
+`.[recommended]`. That path includes SquillaRouter dependencies and checks the
+bundled router model assets before installing. The only normal opt-out is the
+`core` profile.
 
 macOS / Linux:
 
@@ -135,15 +268,18 @@ bash install.sh
 Windows PowerShell:
 
 ```powershell
-pwsh -ExecutionPolicy Bypass -File install.ps1
+powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
-Install channel extras into the same user-local command:
+PowerShell 7 users can run `pwsh -ExecutionPolicy Bypass -File .\install.ps1`.
+
+Install channel extras into the same user-local command. Feishu is shown only
+as an example channel adapter:
 
 Windows PowerShell:
 
 ```powershell
-pwsh -ExecutionPolicy Bypass -File install.ps1 -Extras feishu
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -Extras feishu
 ```
 
 macOS/Linux:
@@ -152,8 +288,9 @@ macOS/Linux:
 OPENSQUILLA_INSTALL_EXTRAS=feishu bash install.sh
 ```
 
-Supported extras include `feishu`, `telegram`, `dingtalk`, `wecom`,
-`qq`, `msteams`, `matrix`, `matrix-e2e`, and `document-extras`.
+Supported channel extras include `dingtalk`, `feishu`, `matrix`, `matrix-e2e`,
+`msteams`, `qq`, `telegram`, and `wecom`. The optional non-channel extra is
+`document-extras`.
 
 The scripts prefer `uv tool install` and fall back to
 `python -m pip install --user`. The installed command uses its own
@@ -181,6 +318,9 @@ where.exe opensquilla
 command -v opensquilla
 ```
 
+If a new terminal still cannot find it, run `uv tool update-shell`, reopen the
+terminal, and try again.
+
 After reinstalling from a local checkout, restart the gateway process so it
 loads the updated package.
 
@@ -194,6 +334,10 @@ executes against the live source tree.
 uv sync --extra recommended
 uv run opensquilla --help
 ```
+
+The `recommended` extra includes SquillaRouter for development too. Use
+`uv sync` without `--extra recommended` only when you are intentionally testing
+a minimal environment.
 
 Install extras into the same environment you run:
 
@@ -212,7 +356,7 @@ command runs in a different Python environment.
 entrypoint for first-run setup and automation. It writes the active
 config file, skips when an LLM provider is already configured, and keeps
 provider secrets in environment variables when you pass `--api-key-env`.
-The router defaults to `recommended`, which enables SquillaRouter for
+The router defaults to `recommended`; `recommended` enables SquillaRouter for
 supported provider profiles. Pass `--router disabled` only if you
 intentionally want direct single-model routing, or `--router
 openrouter-mix` to keep the built-in OpenRouter mixed model routes.
@@ -233,6 +377,56 @@ export OPENROUTER_API_KEY="sk-..."
 opensquilla onboard \
   --provider openrouter \
   --api-key-env OPENROUTER_API_KEY
+```
+
+For example, with OpenAI:
+
+```sh
+export OPENAI_API_KEY="sk-..."
+opensquilla onboard --provider openai --api-key-env OPENAI_API_KEY
+```
+
+To persist the key on macOS or Linux, add the same `export` line to your shell
+profile.
+
+Windows PowerShell:
+
+```powershell
+$env:OPENROUTER_API_KEY="sk-..."
+opensquilla onboard --provider openrouter --api-key-env OPENROUTER_API_KEY
+```
+
+To persist the key for future PowerShell windows:
+
+```powershell
+setx OPENROUTER_API_KEY "sk-..."
+```
+
+Close and reopen PowerShell after `setx`, then run:
+
+```powershell
+opensquilla onboard --provider openrouter --api-key-env OPENROUTER_API_KEY
+```
+
+If a Windows machine cannot initialize `onnxruntime` and logs
+`DLL load failed while importing onnxruntime_pybind11_state`, OpenSquilla will
+keep running with a safe router fallback, but the bundled router runtime is not
+active until the Visual C++ runtime is fixed. To make a first install quiet and
+direct while fixing the Windows runtime, use:
+
+```powershell
+$env:OPENROUTER_API_KEY="sk-..."
+opensquilla onboard --provider openrouter --api-key-env OPENROUTER_API_KEY --router disabled --minimal
+opensquilla gateway run
+```
+
+After installing the Visual C++ Redistributable and reopening PowerShell, restore
+the recommended router. If you used only `$env:OPENROUTER_API_KEY`, set it again
+in the new PowerShell window.
+
+```powershell
+opensquilla onboard --provider openrouter --api-key-env OPENROUTER_API_KEY --router recommended
+opensquilla gateway restart
 ```
 
 **(optional)** Re-configure one section later without redoing the whole

--- a/install.ps1
+++ b/install.ps1
@@ -5,6 +5,8 @@
 #   - prefers uv tool install; falls back to pip --user; errors clearly if neither exists
 #   - defaults to the "recommended" runtime profile (memory + bundled v4 router)
 #     and allows `$env:OPENSQUILLA_INSTALL_PROFILE="core"` to opt back down
+#   - on Windows, best-effort installs Microsoft Visual C++ Redistributable
+#     before the recommended router profile because onnxruntime requires it
 #   - prints a post-install banner documenting the default bind
 #     (127.0.0.1:18790) and the explicit opt-in required to expose the gateway
 #     on the network (-Listen 0.0.0.0 or $env:OPENSQUILLA_LISTEN="0.0.0.0")
@@ -33,6 +35,11 @@ if ($env:OPENSQUILLA_PREFIX) {
 }
 
 $dryRun = $env:OPENSQUILLA_INSTALL_DRY_RUN -eq '1'
+$script:isWindowsHost = if (Get-Variable IsWindows -ErrorAction SilentlyContinue) {
+    $IsWindows
+} else {
+    $env:OS -eq 'Windows_NT'
+}
 $profile = if ($Profile) {
     $Profile
 } elseif ($env:OPENSQUILLA_INSTALL_PROFILE) {
@@ -161,6 +168,65 @@ function Test-SquillaRouterAssets {
     }
 }
 
+function Test-WindowsVCRedistInstalled {
+    if (-not $script:isWindowsHost) {
+        return $true
+    }
+
+    $runtimeKeys = @(
+        'HKLM:\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64'
+    )
+    foreach ($key in $runtimeKeys) {
+        if (-not (Test-Path $key)) {
+            continue
+        }
+        $runtime = Get-ItemProperty -Path $key -ErrorAction SilentlyContinue
+        if ($runtime -and $runtime.Installed -eq 1 -and $runtime.Major -ge 14) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Install-WindowsVCRedistIfNeeded {
+    if (-not $script:isWindowsHost -or $profile -ne 'recommended') {
+        return
+    }
+    if ($env:OPENSQUILLA_SKIP_VC_REDIST -eq '1') {
+        Write-Host 'install.ps1: skipping Microsoft Visual C++ Redistributable check because OPENSQUILLA_SKIP_VC_REDIST=1.'
+        return
+    }
+    if (Test-WindowsVCRedistInstalled) {
+        Write-Host 'install.ps1: Microsoft Visual C++ Redistributable is already installed.'
+        return
+    }
+
+    $redistUrl = 'https://aka.ms/vs/17/release/vc_redist.x64.exe'
+    $winget = Get-Command winget -ErrorAction SilentlyContinue
+    if ($winget) {
+        Write-Host 'install.ps1: Microsoft Visual C++ Redistributable not detected; installing with winget.'
+        $wingetArgs = @(
+            'install',
+            '--id',
+            'Microsoft.VCRedist.2015+.x64',
+            '--exact',
+            '--silent',
+            '--accept-package-agreements',
+            '--accept-source-agreements'
+        )
+        & winget @wingetArgs
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host 'install.ps1: Microsoft Visual C++ Redistributable installation completed.'
+            return
+        }
+        Write-Warning "install.ps1: winget could not install Microsoft Visual C++ Redistributable (exit $LASTEXITCODE)."
+    }
+
+    Write-Warning 'install.ps1: Microsoft Visual C++ Redistributable is needed for the bundled router on many Windows machines.'
+    Write-Warning "install.ps1: install it from $redistUrl, then restart PowerShell if onnxruntime reports DLL load failures."
+}
+
 # --- installer selection ----------------------------------------------------
 
 $installer = $null
@@ -187,8 +253,8 @@ $installCmd = if ($installer -eq 'uv') {
 
 function Write-Banner {
     @"
-────────────────────────────────────────────────────────────────────────────
-OpenSquilla installed via $installer → $prefix (profile: $profile)
+----------------------------------------------------------------------------
+OpenSquilla installed via $installer -> $prefix (profile: $profile)
 Extras: $(if ($installExtras.Count -gt 0) { $installExtras -join ', ' } else { 'none' })
 
 Default gateway bind: 127.0.0.1:18790 (loopback only)
@@ -199,13 +265,13 @@ must use one of:
 
 Reminder: only expose 0.0.0.0 behind a trusted reverse proxy or VPN. The
 gateway's first-class auth assumes loopback-scope by default.
-────────────────────────────────────────────────────────────────────────────
+----------------------------------------------------------------------------
 "@ | Write-Host
 }
 
 function Write-ListenWarning {
     @"
-⚠  WARNING: you have selected network-exposed default — ensure you
+WARNING: you have selected network-exposed default - ensure you
    understand the blast radius. The gateway will bind to 0.0.0.0 and be
    reachable from every interface on this host.
 "@ | Write-Host
@@ -224,6 +290,7 @@ if ($dryRun) {
 
 # --- execute ---------------------------------------------------------------
 
+Install-WindowsVCRedistIfNeeded
 Test-SquillaRouterAssets
 
 Write-Host "install.ps1: installing via $installer into prefix $prefix"
@@ -232,6 +299,11 @@ if ($installer -eq 'uv') {
     & uv @installArgs
 } else {
     & python @installArgs
+}
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "install.ps1: install command failed with exit code $LASTEXITCODE."
+    Write-Error 'install.ps1: Close any running OpenSquilla gateway or shell using the existing tool environment, then retry.'
+    exit $LASTEXITCODE
 }
 
 Write-Banner

--- a/install.sh
+++ b/install.sh
@@ -188,8 +188,8 @@ install_cmd="${install_args[*]}"
 
 print_banner() {
     cat <<BANNER
-────────────────────────────────────────────────────────────────────────────
-OpenSquilla installed via ${installer} → ${prefix} (profile: ${profile})
+----------------------------------------------------------------------------
+OpenSquilla installed via ${installer} -> ${prefix} (profile: ${profile})
 Extras: $(if (( ${#install_extras[@]} > 0 )); then IFS=,; echo "${install_extras[*]}"; else echo "none"; fi)
 
 Default gateway bind: 127.0.0.1:18790 (loopback only)
@@ -200,13 +200,13 @@ must use one of:
 
 Reminder: only expose 0.0.0.0 behind a trusted reverse proxy or VPN. The
 gateway's first-class auth assumes loopback-scope by default.
-────────────────────────────────────────────────────────────────────────────
+----------------------------------------------------------------------------
 BANNER
 }
 
 print_listen_warning() {
     cat <<WARNING
-⚠  WARNING: you have selected network-exposed default — ensure you
+WARNING: you have selected network-exposed default - ensure you
    understand the blast radius. The gateway will bind to 0.0.0.0 and be
    reachable from every interface on this host.
 WARNING

--- a/src/opensquilla/engine/steps/squilla_router.py
+++ b/src/opensquilla/engine/steps/squilla_router.py
@@ -199,6 +199,31 @@ class RoutingDecision:
     source: str  # "image_route" | "v4_phase3" | "v4_unavailable" | "default"
 
 
+class _UnavailableV4Strategy:
+    source = "v4_unavailable"
+    requires_history = True
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def classify(
+        self,
+        message: str,
+        valid_tiers: list[str],
+        routing_history: list[dict] | None = None,
+        **kwargs: object,
+    ) -> tuple[str, float, str, dict]:
+        tier = "t1" if "t1" in valid_tiers else (valid_tiers[0] if valid_tiers else "t1")
+        return tier, 0.0, "v4_unavailable", {
+            "route_class": "R1",
+            "top1_label": "R1",
+            "thinking_mode": "T1",
+            "prompt_policy": "P1",
+            "model_version": "unavailable",
+            "error": str(self.error),
+        }
+
+
 def _strategy_cache_key(config: object) -> tuple:
     strategy_name = _strategy_name(config)
     confidence = getattr(config, "confidence_threshold", 0.5)
@@ -236,15 +261,19 @@ def _get_strategy(config: object) -> RouterStrategy:
             _history_store.clear()
         from opensquilla.squilla_router.v4_phase3 import V4Phase3Strategy
 
-        strategy = cast(
-            RouterStrategy,
-            V4Phase3Strategy(
-                bundle_dir=getattr(config, "v4_bundle_dir", None),
-                confidence_threshold=getattr(config, "confidence_threshold", 0.5),
-                require_router_runtime=getattr(config, "require_router_runtime", False),
-                use_aux_head=getattr(config, "v4_use_aux_head", None),
-            ),
-        )
+        try:
+            strategy = cast(
+                RouterStrategy,
+                V4Phase3Strategy(
+                    bundle_dir=getattr(config, "v4_bundle_dir", None),
+                    confidence_threshold=getattr(config, "confidence_threshold", 0.5),
+                    require_router_runtime=getattr(config, "require_router_runtime", False),
+                    use_aux_head=getattr(config, "v4_use_aux_head", None),
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.warning("squilla_router.strategy_unavailable", error=str(exc))
+            strategy = _UnavailableV4Strategy(exc)
         _strategy = strategy
         _strategy_key = key
         return strategy

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -11,6 +11,32 @@ def test_install_scripts_force_refresh_local_uv_tool_package() -> None:
     assert "--force --reinstall-package opensquilla" in sh
 
 
+def test_windows_installer_stops_when_native_install_command_fails() -> None:
+    ps1 = (ROOT / "install.ps1").read_text(encoding="utf-8")
+
+    assert 'if ($LASTEXITCODE -ne 0) {' in ps1
+    assert "install.ps1: install command failed with exit code $LASTEXITCODE." in ps1
+    assert (
+        "Close any running OpenSquilla gateway or shell using the existing "
+        "tool environment, then retry."
+        in ps1
+    )
+    assert "exit $LASTEXITCODE" in ps1
+
+
+def test_install_script_banners_are_ascii_for_windows_terminals() -> None:
+    ps1 = (ROOT / "install.ps1").read_text(encoding="utf-8")
+    sh = (ROOT / "install.sh").read_text(encoding="utf-8")
+
+    for script in (ps1, sh):
+        assert "OpenSquilla installed via" in script
+        assert "->" in script
+        assert "----" in script
+        assert "→" not in script
+        assert "─" not in script
+        assert "⚠" not in script
+
+
 def test_install_scripts_support_optional_extras() -> None:
     ps1 = (ROOT / "install.ps1").read_text(encoding="utf-8")
     sh = (ROOT / "install.sh").read_text(encoding="utf-8")
@@ -21,3 +47,180 @@ def test_install_scripts_support_optional_extras() -> None:
     assert "OPENSQUILLA_INSTALL_EXTRAS" in sh
     assert "--extras" in sh
     assert "feishu telegram dingtalk wecom qq msteams matrix matrix-e2e document-extras" in sh
+
+
+def test_windows_installer_bootstraps_vc_redist_for_router_runtime() -> None:
+    ps1 = (ROOT / "install.ps1").read_text(encoding="utf-8")
+
+    assert "Install-WindowsVCRedistIfNeeded" in ps1
+    assert "OPENSQUILLA_SKIP_VC_REDIST" in ps1
+    assert "Microsoft.VCRedist.2015+.x64" in ps1
+    assert "https://aka.ms/vs/17/release/vc_redist.x64.exe" in ps1
+
+
+def test_readme_splits_user_paths_and_keeps_release_marked_unpublished() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    normalized = " ".join(readme.split())
+    release_section = readme.split("### Release package — coming soon", 1)[1]
+    release_section = release_section.split("### Install from source", 1)[0]
+
+    assert "| New user | [Release package](#release-package-coming-soon) | Coming soon |" in readme
+    assert (
+        "| Command-line user | [Install from source](#install-from-source) | "
+        "Available now |"
+        in readme
+    )
+    assert "| Developer | [Develop from source](#develop-from-source) | Available now |" in readme
+    assert "Public release packages are not published yet." in readme
+    assert (
+        "Until release packages are published, new users should use Install "
+        "from source."
+        in normalized
+    )
+    assert release_section.count("Install from source") == 1
+
+
+def test_readme_documents_router_defaults_and_feishu_as_channel_extra() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    normalized = " ".join(readme.split())
+
+    assert (
+        "SquillaRouter is included by default in every currently available "
+        "install path"
+        in readme
+    )
+    assert "The normal install commands above already install SquillaRouter." in readme
+    assert (
+        "The install scripts default to the `recommended` profile, which "
+        "installs `.[recommended]`."
+        in normalized
+    )
+    assert "recommended` enables SquillaRouter" in readme
+    assert "Install channel extras into the same user-local command" in readme
+    assert "Feishu websocket channel support" in readme
+    assert "Optional: add a channel adapter only if you need one." in readme
+    assert "powershell -ExecutionPolicy Bypass -File .\\install.ps1 -Extras feishu" in readme
+    assert "OPENSQUILLA_INSTALL_EXTRAS=feishu bash install.sh" in readme
+    assert "Supported channel extras include `dingtalk`, `feishu`" in readme
+    assert "The optional non-channel extra is `document-extras`." in normalized
+    assert "Most users do not need every chat platform SDK." in normalized
+
+
+def test_readme_keeps_prerequisite_install_commands_in_optional_details() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    normalized = " ".join(readme.split())
+
+    assert "<summary>Optional: install prerequisites from a terminal</summary>" in readme
+    assert "winget install --id Git.Git -e" in readme
+    assert "winget install --id GitHub.GitLFS -e" in readme
+    windows_prereq = readme.split("Windows PowerShell:", 1)[1]
+    windows_prereq = windows_prereq.split(
+        "macOS, if you already use Homebrew:",
+        1,
+    )[0]
+
+    assert "git lfs install" in windows_prereq
+    assert "brew install git git-lfs uv" in readme
+    assert "sudo apt install -y git git-lfs" in readme
+    assert "sudo dnf install -y git git-lfs" in readme
+    assert "sudo pacman -S --needed git git-lfs" in readme
+    assert "https://brew.sh/" in readme
+    assert (
+        "Open a new terminal if `git`, `git lfs`, or `uv` is not found after "
+        "installation."
+        in normalized
+    )
+    assert (
+        "If `winget` is not present, download and run the Visual C++ installer "
+        "manually."
+        in normalized
+    )
+    assert (
+        "To persist the key on macOS or Linux, add the same `export` line to "
+        "your shell profile."
+        in normalized
+    )
+
+
+def test_readme_quickstart_covers_path_key_and_gateway_runtime_gotchas() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    normalized = " ".join(readme.split())
+    quickstart_config = readme.split("4. Configure.", 1)[1].split("5. Run the gateway:", 1)[0]
+    quickstart_config_normalized = " ".join(quickstart_config.split())
+
+    assert "Open a new terminal if `opensquilla` is not found after installation." in readme
+    assert "Recommended for beginners:" in readme
+    assert "The wizard asks you to choose a provider and enter or reference its API key." in readme
+    assert "For automation, this OpenRouter example is copy-pasteable." in readme
+    assert (
+        "OpenRouter is only an example; substitute any supported provider and "
+        "its API key variable."
+        in normalized
+    )
+    assert (
+        "If you choose OpenRouter, create a key at "
+        "<https://openrouter.ai/docs/api-keys>"
+        in normalized
+    )
+    assert "replace `sk-...` with the real key value" in normalized
+    assert (
+        "The `export` and `$env:` examples below set the key for the current "
+        "terminal only."
+        in normalized
+    )
+    assert quickstart_config_normalized.index(
+        "opensquilla onboard"
+    ) < quickstart_config_normalized.index("If you choose OpenRouter")
+    assert "Press `Ctrl+C` to stop the foreground gateway." in normalized
+    assert "Wait until the gateway says it is running before opening the Web UI" in normalized
+    assert (
+        "the gateway still starts but the bundled router falls back to a safe "
+        "direct route"
+        in normalized
+    )
+    assert "If Windows prints an `onnxruntime` or `DLL load failed` warning" in normalized
+
+
+def test_readme_explains_setup_details_vs_development_path() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    normalized = " ".join(readme.split())
+
+    assert "## Setup details and troubleshooting" in readme
+    assert (
+        "Setup details expands the Quick start paths; it is not a separate "
+        "install path."
+        in normalized
+    )
+    assert "Use Install from source when you only want to run OpenSquilla." in normalized
+    assert (
+        "Use Develop from source only when you want to edit, test, or debug "
+        "the code."
+        in normalized
+    )
+    assert "`git lfs install` is idempotent and safe to run again." in readme
+    assert "If a new terminal still cannot find it, run `uv tool update-shell`" in normalized
+    assert "To check which command your shell will run:" in readme
+    assert "where.exe opensquilla" in readme
+    assert "command -v opensquilla" in readme
+    assert "opensquilla onboard --provider openai --api-key-env OPENAI_API_KEY" in readme
+
+
+def test_readme_keeps_windows_powershell_commands_restart_safe() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    normalized = " ".join(readme.split())
+
+    assert "pwsh -ExecutionPolicy Bypass -File .\\install.ps1" in readme
+    assert (
+        "If you used only `$env:OPENROUTER_API_KEY`, set it again in the new "
+        "PowerShell window."
+        in normalized
+    )
+
+
+def test_readme_marks_python_and_pip_as_fallback_prerequisites() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    normalized = " ".join(readme.split())
+
+    assert "required only when you skip `uv` and use the `pip --user` fallback" in normalized
+    assert "**`uv`** — recommended for normal source installs." in readme
+    assert "**`pip` >= 23** — fallback only when `uv` is unavailable." in readme

--- a/tests/test_model_router_behavior.py
+++ b/tests/test_model_router_behavior.py
@@ -57,11 +57,23 @@ class ContextAwareFakeStrategy(FakeStrategy):
         return self.tier, self.confidence, "v4_phase3", dict(self.extra)
 
 
+class ExplodingV4Strategy:
+    def __init__(self, *args, **kwargs) -> None:
+        raise RuntimeError(
+            "failed to initialize V4 Phase 3 router: DLL load failed while importing "
+            "onnxruntime_pybind11_state"
+        )
+
+
 @pytest.fixture(autouse=True)
 def reset_squilla_router_state(monkeypatch: pytest.MonkeyPatch) -> None:
     squilla_router_step._history_store.clear()
+    squilla_router_step._strategy = None
+    squilla_router_step._strategy_key = None
     yield
     squilla_router_step._history_store.clear()
+    squilla_router_step._strategy = None
+    squilla_router_step._strategy_key = None
     monkeypatch.undo()
 
 
@@ -714,6 +726,23 @@ async def test_repeated_message_across_sessions_is_classified_each_time(
     assert first.metadata["routing_source"] == "v4_phase3"
     assert second.metadata["routing_source"] == "v4_phase3"
     assert strategy.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_required_router_runtime_failure_falls_back_to_default_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import opensquilla.squilla_router.v4_phase3 as v4_phase3
+
+    monkeypatch.setattr(v4_phase3, "V4Phase3Strategy", ExplodingV4Strategy)
+    ctx = make_context("Explain the setup steps.")
+    ctx.config.squilla_router.require_router_runtime = True
+
+    routed = await apply_squilla_router(ctx)
+
+    assert routed.metadata["routing_source"] == "v4_unavailable"
+    assert routed.metadata["routed_tier"] == "t1"
+    assert routed.metadata["routing_confidence"] == 0.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -483,15 +483,16 @@ def test_channel_saved_output_separates_configured_from_connected(capsys):
 def test_readme_distinguishes_recommended_profile_from_channel_extras() -> None:
     readme = Path("README.md").read_text(encoding="utf-8")
 
-    assert "Choose one path and stay on it:" in readme
-    assert "| Run OpenSquilla as a local app | [Install](#install) | `opensquilla ...` |" in readme
+    assert "| New user | [Release package](#release-package-coming-soon) | Coming soon |" in readme
     assert (
-        "| Modify or debug OpenSquilla source | [Develop from source](#develop-from-source) | "
-        "`uv run opensquilla ...` |"
+        "| Command-line user | [Install from source](#install-from-source) | Available now |"
     ) in readme
+    assert "| Developer | [Develop from source](#develop-from-source) | Available now |" in readme
+    assert "Public release packages are not published yet." in readme
     assert "`recommended` is the\nnormal runtime profile" in readme
     assert "Messaging channel adapters are opt-in extras." in readme
-    assert "pwsh -ExecutionPolicy Bypass -File install.ps1 -Extras feishu" in readme
+    assert "Feishu is shown only\nas an example channel adapter" in readme
+    assert "powershell -ExecutionPolicy Bypass -File .\\install.ps1 -Extras feishu" in readme
     assert "OPENSQUILLA_INSTALL_EXTRAS=feishu bash install.sh" in readme
     assert "Install extras into the same environment you run:" in readme
     assert "uv sync --extra recommended --extra feishu" in readme


### PR DESCRIPTION
## Summary
- clarify the current source-install path while release packages are not yet published
- document that SquillaRouter is installed by default in normal installs
- keep optional channel adapters, including Feishu, clearly marked as opt-in examples
- add install-script/runtime guardrails for Windows terminals and router fallback behavior

## Tests
- uv run ruff check src tests
- uv run pytest tests/test_install_scripts.py tests/test_model_router_behavior.py tests/test_gateway/test_router_boot.py tests/test_cli/test_onboard_cmd.py tests/test_onboarding/test_flow.py -q