### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Both paths can start from `git clone`. In the install path, the clone is only
 the source package the installer reads from. In the development path, the clone
 is the live workspace.
 
-1. Install prerequisites: [git-lfs](https://git-lfs.com/) and
+1. Install prerequisites: [git](https://git-scm.com), [git-lfs](https://git-lfs.com/) and
    [uv](https://docs.astral.sh/uv/).
 
 2. Clone with LFS assets:

--- a/migrations/V009__transcript_reasoning_content.py
+++ b/migrations/V009__transcript_reasoning_content.py
@@ -1,0 +1,65 @@
+"""V009 - persist assistant reasoning content for DeepSeek replay.
+
+DeepSeek thinking mode requires prior assistant ``reasoning_content`` to be
+passed back on later turns. The transcript table therefore needs an optional
+text column so the runtime can preserve that provider-specific replay state.
+"""
+
+from __future__ import annotations
+
+from yoyo import step
+
+__depends__: set[str] = {"V008__scheduler_job_tool_policy"}
+
+TABLE = "transcript_entries"
+COLUMN = "reasoning_content"
+ADD_COLUMN_DDL = f"ALTER TABLE {TABLE} ADD COLUMN {COLUMN} TEXT"
+DROP_COLUMN_DDL = f"ALTER TABLE {TABLE} DROP COLUMN {COLUMN}"
+
+
+def _table_exists(conn, table: str) -> bool:
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    )
+    return cur.fetchone() is not None
+
+
+def _has_column(conn, table: str, column: str) -> bool:
+    cur = conn.cursor()
+    cur.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cur.fetchall())
+
+
+def _sqlite_version(conn) -> tuple[int, int, int]:
+    cur = conn.cursor()
+    cur.execute("SELECT sqlite_version()")
+    raw = cur.fetchone()[0]
+    parts = raw.split(".")
+    while len(parts) < 3:
+        parts.append("0")
+    return (int(parts[0]), int(parts[1]), int(parts[2]))
+
+
+def apply_step(conn) -> None:
+    if not _table_exists(conn, TABLE):
+        return
+    if _has_column(conn, TABLE, COLUMN):
+        return
+    cur = conn.cursor()
+    cur.execute(ADD_COLUMN_DDL)
+
+
+def rollback_step(conn) -> None:
+    if not _table_exists(conn, TABLE):
+        return
+    if not _has_column(conn, TABLE, COLUMN):
+        return
+    if _sqlite_version(conn) < (3, 35, 0):
+        return
+    cur = conn.cursor()
+    cur.execute(DROP_COLUMN_DDL)
+
+
+steps = [step(apply_step, rollback_step)]

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -76,7 +76,7 @@ base_url = "https://openrouter.ai/api/v1"
 #
 # Example direct DeepSeek config:
 # provider = "deepseek"
-# model = "deepseek-chat"
+# model = "deepseek-v4-flash"
 # api_key = ""          # env DEEPSEEK_API_KEY also works
 # base_url = "https://api.deepseek.com"
 

--- a/src/opensquilla/cli/init_cmd.py
+++ b/src/opensquilla/cli/init_cmd.py
@@ -10,6 +10,15 @@ from opensquilla.cli.ui import console
 from opensquilla.paths import default_opensquilla_home
 
 
+def _default_model_for_provider(provider: str) -> str:
+    normalized = provider.strip().lower()
+    if normalized == "openrouter":
+        return "deepseek/deepseek-v4-flash"
+    if normalized == "deepseek":
+        return "deepseek-v4-flash"
+    return "openai/gpt-4o-mini"
+
+
 def run_init() -> None:
     """Create a basic OpenSquilla home with env and config files."""
     home = default_opensquilla_home()
@@ -32,7 +41,7 @@ def run_init() -> None:
 
     default_model = questionary.text(
         "Default model:",
-        default="openai/gpt-4o-mini" if provider != "openrouter" else "deepseek/deepseek-v4-flash",
+        default=_default_model_for_provider(provider),
     ).ask()
     if not default_model:
         raise typer.Exit(1)

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -97,6 +97,11 @@ def _is_deepseek_model_id(model_id: str | None) -> bool:
     return normalized.startswith("deepseek") or "/deepseek" in normalized
 
 
+def _is_direct_deepseek_v4_model_id(model_id: str | None) -> bool:
+    normalized = (model_id or "").strip().lower()
+    return normalized in {"deepseek-v4-flash", "deepseek-v4-pro"}
+
+
 _TOOL_RESULT_SUMMARY_SYSTEM = (
     "You compress tool output before it is passed to another agent. Preserve exact "
     "filenames, paths, ids, numbers, commands, error messages, and code-relevant snippets. "
@@ -704,11 +709,18 @@ class Agent:
         self._write_context_stage("session:loaded", loaded_history)
         sanitized_history, sanitize_result = sanitize_session_messages(loaded_history)
         sanitized_history = repair_tool_pairing(sanitized_history)
+        caps_reasoning_format = (
+            getattr(self.config.model_capabilities, "reasoning_format", "")
+            if self.config.model_capabilities is not None
+            else ""
+        )
         preserve_reasoning_content = bool(
-            thinking_enabled
-            and self.config.model_capabilities is not None
-            and getattr(self.config.model_capabilities, "reasoning_format", "") == "deepseek"
-            and _is_deepseek_model_id(self.config.model_id)
+            _is_direct_deepseek_v4_model_id(self.config.model_id)
+            or (
+                thinking_enabled
+                and caps_reasoning_format == "deepseek"
+                and _is_deepseek_model_id(self.config.model_id)
+            )
         )
         sanitized_history = drop_reasoning(
             sanitized_history,

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -91,6 +91,12 @@ from .types import (
 
 logger = structlog.get_logger("opensquilla.engine.agent")
 
+
+def _is_deepseek_model_id(model_id: str | None) -> bool:
+    normalized = (model_id or "").strip().lower()
+    return normalized.startswith("deepseek") or "/deepseek" in normalized
+
+
 _TOOL_RESULT_SUMMARY_SYSTEM = (
     "You compress tool output before it is passed to another agent. Preserve exact "
     "filenames, paths, ids, numbers, commands, error messages, and code-relevant snippets. "
@@ -702,6 +708,7 @@ class Agent:
             thinking_enabled
             and self.config.model_capabilities is not None
             and getattr(self.config.model_capabilities, "reasoning_format", "") == "deepseek"
+            and _is_deepseek_model_id(self.config.model_id)
         )
         sanitized_history = drop_reasoning(
             sanitized_history,
@@ -793,6 +800,7 @@ class Agent:
         window_input_tokens = 0
         window_output_tokens = 0
         final_text_parts: list[str] = []
+        final_reasoning_parts: list[str] = []
         _fallback = FallbackPolicy(
             max_retries=self.config.max_provider_retries,
             base_backoff_ms=self.config.retry_base_backoff_ms,
@@ -1445,6 +1453,9 @@ class Agent:
                     yield terminal_error
                     break
 
+                if iter_reasoning_content:
+                    final_reasoning_parts.append(iter_reasoning_content)
+
                 window_input_tokens += iter_input_tokens
                 window_output_tokens += iter_output_tokens
 
@@ -1818,6 +1829,9 @@ class Agent:
                 model=done_model,
                 runtime_context_hash=runtime_context_hash,
                 runtime_context_chars=len(runtime_context),
+                reasoning_content=(
+                    "\n".join(final_reasoning_parts) if final_reasoning_parts else None
+                ),
             )
         # Reset for next turn
         self._state = AgentState.IDLE

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -698,9 +698,15 @@ class Agent:
         self._write_context_stage("session:loaded", loaded_history)
         sanitized_history, sanitize_result = sanitize_session_messages(loaded_history)
         sanitized_history = repair_tool_pairing(sanitized_history)
+        preserve_reasoning_content = bool(
+            thinking_enabled
+            and self.config.model_capabilities is not None
+            and getattr(self.config.model_capabilities, "reasoning_format", "") == "deepseek"
+        )
         sanitized_history = drop_reasoning(
             sanitized_history,
             preserve_tool_call_reasoning=thinking_enabled,
+            preserve_reasoning_content=preserve_reasoning_content,
         )
         sanitized_history = _strip_historical_image_blocks(sanitized_history)
         self._write_context_stage(

--- a/src/opensquilla/engine/history.py
+++ b/src/opensquilla/engine/history.py
@@ -132,6 +132,7 @@ def reconstruct_messages_from_entry(
     role: str,
     content: Any,
     tool_calls: list[dict[str, Any]] | None,
+    reasoning_content: str | None = None,
 ) -> list[Message]:
     """Rebuild provider Messages from one persisted transcript entry.
 
@@ -161,7 +162,13 @@ def reconstruct_messages_from_entry(
 
     if not tool_calls:
         if content:
-            return [Message(role="assistant", content=content)]
+            return [
+                Message(
+                    role="assistant",
+                    content=content,
+                    reasoning_content=reasoning_content,
+                )
+            ]
         return []
 
     messages: list[Message] = []
@@ -269,5 +276,10 @@ def reconstruct_messages_from_entry(
                     content_blocks.append(ContentBlockText(text=marker_text))
             elif not messages:
                 messages.append(Message(role="assistant", content=marker_text))
+
+    if reasoning_content:
+        first_assistant = next((m for m in messages if m.role == "assistant"), None)
+        if first_assistant is not None:
+            first_assistant.reasoning_content = reasoning_content
 
     return messages

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -1601,7 +1601,7 @@ class TurnRunner:
 
             # Resolve max_tokens & context_window from model catalog
             user_max_tokens = getattr(getattr(self._config, "llm", None), "max_tokens", 0)
-            if self._model_catalog:
+            if self._model_catalog is not None:
                 max_tokens = self._model_catalog.resolve_max_tokens(
                     resolved_model, user_override=user_max_tokens
                 )
@@ -1612,7 +1612,7 @@ class TurnRunner:
 
             # Resolve model capabilities for reasoning support
             model_caps = None
-            if self._model_catalog:
+            if self._model_catalog is not None:
                 provider_name = getattr(
                     getattr(self._config, "llm", None), "provider", "openrouter"
                 )

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -111,6 +111,12 @@ _IMAGE_GENERATION_TOOL_NAMES: Final[frozenset[str]] = frozenset(
     {"image_generate"}
 )
 
+
+def _is_deepseek_model_id(model: str) -> bool:
+    normalized = model.strip().lower()
+    return normalized.startswith("deepseek") or "/deepseek" in normalized
+
+
 # Tools that are safe to run concurrently within a single LLM turn.
 # Any tool name absent from this set is treated as mutex (serial dispatch).
 # See docs/dev/tool-concurrency-spec.md for the dispatch contract.
@@ -1992,6 +1998,12 @@ class TurnRunner:
                     "content": persisted_content,
                     "tool_calls": turn_segments if turn_segments else None,
                 }
+                if (
+                    done_event is not None
+                    and done_event.reasoning_content
+                    and _is_deepseek_model_id(done_event.model or resolved_model or "")
+                ):
+                    append_kwargs["reasoning_content"] = done_event.reasoning_content
                 if _accepts_keyword_arg(self._session_manager.append_message, "token_count"):
                     append_kwargs["token_count"] = (
                         done_event.output_tokens if done_event is not None else None
@@ -3928,7 +3940,14 @@ class TurnRunner:
                 content = self._maybe_unpack_assistant_artifacts(raw_content)
             else:
                 content = raw_content
-            history.extend(reconstruct_messages_from_entry(entry.role, content, entry.tool_calls))
+            history.extend(
+                reconstruct_messages_from_entry(
+                    entry.role,
+                    content,
+                    entry.tool_calls,
+                    getattr(entry, "reasoning_content", None),
+                )
+            )
             last_entry_was_user = entry.role == "user"
         # Strip the caller-appended user turn only when the transcript really
         # ended on a user entry; an assistant entry that reconstructs into

--- a/src/opensquilla/engine/thinking.py
+++ b/src/opensquilla/engine/thinking.py
@@ -15,12 +15,13 @@ def drop_reasoning(
     messages: list[Message],
     *,
     preserve_tool_call_reasoning: bool = False,
+    preserve_reasoning_content: bool = False,
 ) -> list[Message]:
     """Strip thinking blocks AND reasoning_content from assistant messages.
 
     - Removes ContentBlockThinking blocks from content lists (Anthropic)
     - Clears reasoning_content field (DeepSeek/OpenRouter)
-    - Optionally preserves reasoning_content on assistant tool-call messages
+    - Optionally preserves reasoning_content on assistant messages
     - Inserts placeholder text block if content becomes empty
     - Returns original list reference if nothing changed
     """
@@ -30,13 +31,14 @@ def drop_reasoning(
     for msg in messages:
         # Clear reasoning_content on any assistant message that has it
         if msg.role == "assistant" and msg.reasoning_content is not None:
-            keep_reasoning = preserve_tool_call_reasoning and _has_tool_use(msg.content)
+            keep_tool_reasoning = preserve_tool_call_reasoning and _has_tool_use(msg.content)
+            keep_reasoning_content = preserve_reasoning_content or keep_tool_reasoning
             touched = True
             if isinstance(msg.content, list):
                 filtered = [
                     b
                     for b in msg.content
-                    if keep_reasoning or not isinstance(b, ContentBlockThinking)
+                    if keep_tool_reasoning or not isinstance(b, ContentBlockThinking)
                 ]
                 if not filtered:
                     filtered = [ContentBlockText(text="")]
@@ -44,7 +46,9 @@ def drop_reasoning(
                     Message(
                         role="assistant",
                         content=filtered,
-                        reasoning_content=msg.reasoning_content if keep_reasoning else None,
+                        reasoning_content=(
+                            msg.reasoning_content if keep_reasoning_content else None
+                        ),
                     )
                 )
             else:
@@ -52,7 +56,9 @@ def drop_reasoning(
                     Message(
                         role="assistant",
                         content=msg.content,
-                        reasoning_content=msg.reasoning_content if keep_reasoning else None,
+                        reasoning_content=(
+                            msg.reasoning_content if keep_reasoning_content else None
+                        ),
                     )
                 )
             continue

--- a/src/opensquilla/engine/types.py
+++ b/src/opensquilla/engine/types.py
@@ -144,6 +144,7 @@ class DoneEvent:
     # (notably DoneEvent(...) without kwargs) does not silently shift earlier
     # args.
     cache_write_tokens: int = 0
+    reasoning_content: str | None = None
 
     @property
     def upstream_cost_usd(self) -> float:

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -1122,11 +1122,13 @@ async def build_services(
             )
 
     # ── Model catalog (boot order: after provider selector) ──────────
-    model_catalog = None
-    if api_key and config.llm.provider == "openrouter":
-        from opensquilla.provider.model_catalog import ModelCatalog
+    # Keep a catalog for every provider so direct-provider runtime paths still
+    # get static fallback capabilities (for example DeepSeek v4 thinking
+    # replay) even when only OpenRouter performs a remote model-list fetch.
+    from opensquilla.provider.model_catalog import ModelCatalog
 
-        model_catalog = ModelCatalog()
+    model_catalog = ModelCatalog()
+    if api_key and config.llm.provider == "openrouter":
         try:
             await asyncio.wait_for(
                 model_catalog.fetch_openrouter(api_key, resolved_base, proxy),

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -155,6 +155,19 @@ class LlmProviderConfig(BaseSettings):
     # send provider.only=[name] while allowing OpenRouter fallback within that pin.
     provider_routing: dict[str, str] = Field(default_factory=dict)
 
+    @model_validator(mode="after")
+    def _normalize_direct_deepseek_model(self) -> LlmProviderConfig:
+        if str(self.provider or "").strip().lower() != "deepseek":
+            return self
+        aliases = {
+            "deepseek/deepseek-v4-flash": "deepseek-v4-flash",
+            "deepseek/deepseek-v4-pro": "deepseek-v4-pro",
+        }
+        model = str(self.model or "").strip()
+        if model in aliases:
+            self.model = aliases[model]
+        return self
+
 
 # Module-level dedupe state for the legacy ``enabled`` deprecation warning.
 # A plain ``bool`` flag guarded by a ``Lock`` makes the check-and-set atomic
@@ -1412,6 +1425,28 @@ class GatewayConfig(BaseSettings):
     control_ui: ControlUiConfig = Field(default_factory=ControlUiConfig)
     diagnostics_enabled: bool = False
     channel_admin_senders: dict[str, list[str]] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _default_squilla_router_profile_for_direct_provider(self) -> GatewayConfig:
+        router = self.squilla_router
+        if not router or not getattr(router, "enabled", False):
+            return self
+        if getattr(router, "tier_profile", None):
+            return self
+        provider = str(getattr(self.llm, "provider", "") or "").strip().lower()
+        if provider == "openrouter" or provider not in ROUTER_TIER_PROFILE_IDS:
+            return self
+        fields_set = set(getattr(router, "model_fields_set", set()))
+        has_custom_tiers = (
+            "tiers" in fields_set and getattr(router, "tiers", {}) != _default_tiers()
+        )
+        if "tier_profile" in fields_set or has_custom_tiers:
+            return self
+        payload = router.model_dump(mode="python")
+        payload["tier_profile"] = provider
+        payload.pop("tiers", None)
+        self.squilla_router = SquillaRouterConfig(**payload)
+        return self
 
     @model_validator(mode="after")
     def _validate_squilla_router_tier_profile_provider(self) -> GatewayConfig:

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -880,31 +880,43 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
         "moonshot": {
             "t0": {
                 "provider": "moonshot",
-                "model": "moonshot-v1-8k",
-                "description": "Moonshot fast tier: Moonshot V1 8K for simple text tasks.",
-                "supports_image": False,
+                "model": "kimi-k2.5",
+                "description": (
+                    "Moonshot fast tier: Kimi K2.5 for cost-efficient agent work "
+                    "with 256K context."
+                ),
+                "supports_image": True,
+                "thinking_level": "low",
             },
             "t1": {
                 "provider": "moonshot",
-                "model": "moonshot-v1-128k",
+                "model": "kimi-k2.5",
                 "description": (
-                    "Moonshot balanced tier: Moonshot V1 128K for normal agent work."
+                    "Moonshot balanced tier: Kimi K2.5 for normal multimodal "
+                    "agent work."
                 ),
-                "supports_image": False,
+                "supports_image": True,
+                "thinking_level": "medium",
             },
             "t2": {
                 "provider": "moonshot",
-                "model": "kimi-k2.5",
-                "description": "Moonshot strong tier: Kimi K2.5 for complex text tasks.",
-                "supports_image": False,
+                "model": "kimi-k2.6",
+                "description": (
+                    "Moonshot strong tier: Kimi K2.6 for complex coding, reasoning, "
+                    "and multimodal tasks."
+                ),
+                "supports_image": True,
+                "thinking_level": "medium",
             },
             "t3": {
                 "provider": "moonshot",
                 "model": "kimi-k2.6",
                 "description": (
-                    "Moonshot highest tier: Kimi K2.6 with fixed sampling constraints."
+                    "Moonshot highest tier: Kimi K2.6 for the hardest long-horizon "
+                    "agent work."
                 ),
-                "supports_image": False,
+                "supports_image": True,
+                "thinking_level": "high",
             },
         },
         "volcengine": {

--- a/src/opensquilla/gateway/rpc_config.py
+++ b/src/opensquilla/gateway/rpc_config.py
@@ -58,6 +58,52 @@ def _collect_paths(payload: Any, prefix: str = "") -> set[str]:
     return paths
 
 
+def _align_auto_router_profile_for_provider_patch(
+    source_config: Any,
+    cfg_dict: dict[str, Any],
+    explicit_paths: set[str],
+) -> None:
+    if "llm.provider" not in explicit_paths:
+        return
+    if any(
+        path == "squilla_router" or path.startswith("squilla_router.")
+        for path in explicit_paths
+    ):
+        return
+
+    llm = cfg_dict.get("llm")
+    router = cfg_dict.get("squilla_router")
+    if not isinstance(llm, dict) or not isinstance(router, dict):
+        return
+
+    old_provider = str(getattr(getattr(source_config, "llm", None), "provider", "") or "")
+    old_provider = old_provider.strip().lower()
+    new_provider = str(llm.get("provider") or "").strip().lower()
+    if not old_provider or not new_provider or old_provider == new_provider:
+        return
+
+    profile = str(router.get("tier_profile") or "").strip().lower()
+    if profile != old_provider:
+        return
+
+    from opensquilla.gateway.config import ROUTER_TIER_PROFILE_IDS, _router_tier_profile_defaults
+
+    try:
+        old_defaults = _router_tier_profile_defaults(old_provider)
+    except ValueError:
+        return
+    if router.get("tiers") != old_defaults:
+        return
+
+    if new_provider in ROUTER_TIER_PROFILE_IDS and new_provider != "openrouter":
+        router["tier_profile"] = new_provider
+        router["tiers"] = _router_tier_profile_defaults(new_provider)
+        return
+
+    router.pop("tier_profile", None)
+    router.pop("tiers", None)
+
+
 _REDACTED_PUBLIC_VALUE = "[redacted]"
 
 
@@ -344,12 +390,14 @@ async def _handle_config_patch(params: dict | None, ctx: RpcContext) -> dict[str
         redacted_paths.update(merge_restored_paths)
         cfg_dict = _deep_merge(cfg_dict, patch_data)
 
-    from opensquilla.gateway.config import GatewayConfig
-
-    new_config = GatewayConfig(**cfg_dict)
     explicit_paths = set(dot_patches.keys()) | _collect_paths(patch_data)
     for path, value in dot_patches.items():
         explicit_paths.update(_collect_paths(value, path))
+    _align_auto_router_profile_for_provider_patch(ctx.config, cfg_dict, explicit_paths)
+
+    from opensquilla.gateway.config import GatewayConfig
+
+    new_config = GatewayConfig(**cfg_dict)
     if _memory_restart_required_for_paths(explicit_paths):
         _validate_memory_embedding_semantics(new_config)
     _inherit_runtime_secrets(ctx.config, new_config)

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -436,22 +436,28 @@ def _is_direct_deepseek_v4_model_id(model: str) -> bool:
     return model.strip().lower() in {"deepseek-v4-flash", "deepseek-v4-pro"}
 
 
+def _is_direct_deepseek_v4_request(provider_kind: str, model: str) -> bool:
+    return provider_kind == "deepseek" and _is_direct_deepseek_v4_model_id(model)
+
+
 def _should_replay_reasoning_content(
     *,
     provider_kind: str,
     model: str,
     caps: ModelCapabilities | None,
-    thinking: bool,
 ) -> bool:
+    if provider_kind == "openrouter":
+        if not caps or not caps.supports_reasoning:
+            return False
+        return caps.reasoning_format == "openrouter"
+    if _is_direct_deepseek_v4_request(provider_kind, model):
+        return True
     if not caps or not caps.supports_reasoning:
         return False
-    if provider_kind == "openrouter":
-        return caps.reasoning_format == "openrouter"
     return (
         provider_kind == "deepseek"
         and caps.reasoning_format == "deepseek"
         and _is_direct_deepseek_v4_model_id(model)
-        and thinking
     )
 
 
@@ -646,7 +652,6 @@ class OpenAIProvider:
             provider_kind=self._provider_kind,
             model=self._model,
             caps=caps,
-            thinking=cfg.thinking,
         )
         if cfg.system:
             explicit_cache_supported = self._provider_kind == "openrouter" and (
@@ -673,11 +678,7 @@ class OpenAIProvider:
                     m,
                     include_reasoning_content=include_reasoning_content,
                     require_assistant_reasoning_content=(
-                        self._provider_kind == "deepseek"
-                        and caps is not None
-                        and caps.reasoning_format == "deepseek"
-                        and _is_direct_deepseek_v4_model_id(self._model)
-                        and cfg.thinking
+                        _is_direct_deepseek_v4_request(self._provider_kind, self._model)
                     ),
                 )
             )
@@ -725,27 +726,33 @@ class OpenAIProvider:
                 }
 
         # Reasoning injection (gated on thinking being enabled)
-        if caps and caps.supports_reasoning and cfg.thinking:
+        direct_deepseek_v4 = _is_direct_deepseek_v4_request(self._provider_kind, self._model)
+        if (caps and caps.supports_reasoning and cfg.thinking) or (
+            direct_deepseek_v4 and cfg.thinking
+        ):
             effort = _resolve_reasoning_effort(cfg.thinking_level, cfg.thinking_budget_tokens)
-            if caps.reasoning_format == "openrouter":
+            reasoning_format = caps.reasoning_format if caps is not None else "deepseek"
+            if reasoning_format == "openrouter":
                 payload["reasoning"] = {"effort": effort}
-            elif caps.reasoning_format == "openai":
+            elif reasoning_format == "openai":
                 payload["reasoning_effort"] = effort
-            elif caps.reasoning_format == "deepseek":
+            elif reasoning_format == "deepseek":
                 payload["thinking"] = {"type": "enabled"}
                 payload["reasoning_effort"] = _resolve_deepseek_reasoning_effort(
                     cfg.thinking_level
                 )
-            elif caps.reasoning_format == "gemini":
+            elif reasoning_format == "gemini":
                 payload["reasoning_effort"] = effort
-            elif caps.reasoning_format == "zai":
+            elif reasoning_format == "zai":
                 payload["thinking"] = {"type": "enabled"}
-            elif caps.reasoning_format == "dashscope":
+            elif reasoning_format == "dashscope":
                 payload["enable_thinking"] = True
                 payload["thinking_budget"] = cfg.thinking_budget_tokens
-            elif caps.reasoning_format in {"moonshot", "volcengine"}:
+            elif reasoning_format in {"moonshot", "volcengine"}:
                 payload["thinking"] = {"type": "enabled"}
-        elif caps and caps.supports_reasoning and caps.reasoning_format == "deepseek":
+        elif direct_deepseek_v4 or (
+            caps and caps.supports_reasoning and caps.reasoning_format == "deepseek"
+        ):
             payload["thinking"] = {"type": "disabled"}
         elif (
             caps

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -419,15 +419,14 @@ def _attach_reasoning_content(
     payload: dict[str, Any],
     *,
     include_reasoning_content: bool = True,
-    require_tool_call_reasoning_content: bool = False,
+    require_assistant_reasoning_content: bool = False,
 ) -> dict[str, Any]:
     if include_reasoning_content and msg.role == "assistant" and msg.reasoning_content:
         payload["reasoning_content"] = msg.reasoning_content
     elif (
         include_reasoning_content
-        and require_tool_call_reasoning_content
+        and require_assistant_reasoning_content
         and msg.role == "assistant"
-        and "tool_calls" in payload
     ):
         payload["reasoning_content"] = ""
     return payload
@@ -460,7 +459,7 @@ def _build_openai_messages(
     msg: Message,
     *,
     include_reasoning_content: bool = True,
-    require_tool_call_reasoning_content: bool = False,
+    require_assistant_reasoning_content: bool = False,
 ) -> list[dict[str, Any]]:
     """Convert a opensquilla Message into one or more OpenAI-format message dicts.
 
@@ -477,7 +476,7 @@ def _build_openai_messages(
                 msg,
                 {"role": msg.role, "content": msg.content},
                 include_reasoning_content=include_reasoning_content,
-                require_tool_call_reasoning_content=require_tool_call_reasoning_content,
+                require_assistant_reasoning_content=require_assistant_reasoning_content,
             )
         ]
 
@@ -537,7 +536,7 @@ def _build_openai_messages(
                 msg,
                 result,
                 include_reasoning_content=include_reasoning_content,
-                require_tool_call_reasoning_content=require_tool_call_reasoning_content,
+                require_assistant_reasoning_content=require_assistant_reasoning_content,
             )
         ]
 
@@ -549,7 +548,7 @@ def _build_openai_messages(
                 msg,
                 {"role": msg.role, "content": parts},
                 include_reasoning_content=include_reasoning_content,
-                require_tool_call_reasoning_content=require_tool_call_reasoning_content,
+                require_assistant_reasoning_content=require_assistant_reasoning_content,
             )
         ]
     content_text = " ".join(p["text"] for p in parts if p["type"] == "text")
@@ -558,7 +557,7 @@ def _build_openai_messages(
             msg,
             {"role": msg.role, "content": content_text},
             include_reasoning_content=include_reasoning_content,
-            require_tool_call_reasoning_content=require_tool_call_reasoning_content,
+            require_assistant_reasoning_content=require_assistant_reasoning_content,
         )
     ]
 
@@ -673,7 +672,7 @@ class OpenAIProvider:
                 _build_openai_messages(
                     m,
                     include_reasoning_content=include_reasoning_content,
-                    require_tool_call_reasoning_content=(
+                    require_assistant_reasoning_content=(
                         self._provider_kind == "deepseek"
                         and caps is not None
                         and caps.reasoning_format == "deepseek"

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -27,6 +27,7 @@ from .types import (
     DoneEvent,
     ErrorEvent,
     Message,
+    ModelCapabilities,
     ModelInfo,
     StreamEvent,
     TextDeltaEvent,
@@ -418,16 +419,48 @@ def _attach_reasoning_content(
     payload: dict[str, Any],
     *,
     include_reasoning_content: bool = True,
+    require_tool_call_reasoning_content: bool = False,
 ) -> dict[str, Any]:
     if include_reasoning_content and msg.role == "assistant" and msg.reasoning_content:
         payload["reasoning_content"] = msg.reasoning_content
+    elif (
+        include_reasoning_content
+        and require_tool_call_reasoning_content
+        and msg.role == "assistant"
+        and "tool_calls" in payload
+    ):
+        payload["reasoning_content"] = ""
     return payload
+
+
+def _is_direct_deepseek_v4_model_id(model: str) -> bool:
+    return model.strip().lower() in {"deepseek-v4-flash", "deepseek-v4-pro"}
+
+
+def _should_replay_reasoning_content(
+    *,
+    provider_kind: str,
+    model: str,
+    caps: ModelCapabilities | None,
+    thinking: bool,
+) -> bool:
+    if not caps or not caps.supports_reasoning:
+        return False
+    if provider_kind == "openrouter":
+        return caps.reasoning_format == "openrouter"
+    return (
+        provider_kind == "deepseek"
+        and caps.reasoning_format == "deepseek"
+        and _is_direct_deepseek_v4_model_id(model)
+        and thinking
+    )
 
 
 def _build_openai_messages(
     msg: Message,
     *,
     include_reasoning_content: bool = True,
+    require_tool_call_reasoning_content: bool = False,
 ) -> list[dict[str, Any]]:
     """Convert a opensquilla Message into one or more OpenAI-format message dicts.
 
@@ -444,6 +477,7 @@ def _build_openai_messages(
                 msg,
                 {"role": msg.role, "content": msg.content},
                 include_reasoning_content=include_reasoning_content,
+                require_tool_call_reasoning_content=require_tool_call_reasoning_content,
             )
         ]
 
@@ -503,6 +537,7 @@ def _build_openai_messages(
                 msg,
                 result,
                 include_reasoning_content=include_reasoning_content,
+                require_tool_call_reasoning_content=require_tool_call_reasoning_content,
             )
         ]
 
@@ -514,6 +549,7 @@ def _build_openai_messages(
                 msg,
                 {"role": msg.role, "content": parts},
                 include_reasoning_content=include_reasoning_content,
+                require_tool_call_reasoning_content=require_tool_call_reasoning_content,
             )
         ]
     content_text = " ".join(p["text"] for p in parts if p["type"] == "text")
@@ -522,6 +558,7 @@ def _build_openai_messages(
             msg,
             {"role": msg.role, "content": content_text},
             include_reasoning_content=include_reasoning_content,
+            require_tool_call_reasoning_content=require_tool_call_reasoning_content,
         )
     ]
 
@@ -606,13 +643,11 @@ class OpenAIProvider:
     ) -> AsyncIterator[StreamEvent]:
         openai_messages: list[dict[str, Any]] = []
         caps = cfg.model_capabilities
-        include_reasoning_content = bool(
-            caps
-            and caps.supports_reasoning
-            and (
-                (self._provider_kind == "openrouter" and caps.reasoning_format == "openrouter")
-                or caps.reasoning_format == "deepseek"
-            )
+        include_reasoning_content = _should_replay_reasoning_content(
+            provider_kind=self._provider_kind,
+            model=self._model,
+            caps=caps,
+            thinking=cfg.thinking,
         )
         if cfg.system:
             explicit_cache_supported = self._provider_kind == "openrouter" and (
@@ -638,6 +673,13 @@ class OpenAIProvider:
                 _build_openai_messages(
                     m,
                     include_reasoning_content=include_reasoning_content,
+                    require_tool_call_reasoning_content=(
+                        self._provider_kind == "deepseek"
+                        and caps is not None
+                        and caps.reasoning_format == "deepseek"
+                        and _is_direct_deepseek_v4_model_id(self._model)
+                        and cfg.thinking
+                    ),
                 )
             )
 

--- a/src/opensquilla/session/manager.py
+++ b/src/opensquilla/session/manager.py
@@ -617,6 +617,7 @@ class SessionManager:
         *,
         tool_calls: list[dict[str, Any]] | None = None,
         tool_call_id: str | None = None,
+        reasoning_content: str | None = None,
         token_count: int | None = None,
         provenance: dict[str, Any] | None = None,
     ) -> TranscriptEntry:
@@ -635,6 +636,7 @@ class SessionManager:
             content=content,
             tool_calls=tool_calls,
             tool_call_id=tool_call_id,
+            reasoning_content=reasoning_content if role == "assistant" else None,
             token_count=token_count,
         )
 

--- a/src/opensquilla/session/models.py
+++ b/src/opensquilla/session/models.py
@@ -174,6 +174,7 @@ class TranscriptEntry(SQLModel, table=True):
     content: str | None = None
     tool_calls: list[dict[str, Any]] | None = Field(default=None, sa_column=Column(JSON))
     tool_call_id: str | None = None
+    reasoning_content: str | None = None
     created_at: int = Field(default_factory=_now_ms)
     token_count: int | None = None
 

--- a/src/opensquilla/session/storage.py
+++ b/src/opensquilla/session/storage.py
@@ -22,8 +22,8 @@ class StaleEpochError(Exception):
 
 
 # Bumped whenever the schema is widened or narrowed via migration.
-# Version 2 added the epoch column.
-SCHEMA_VERSION = 2
+# Version 2 added the epoch column. Version 3 added transcript reasoning replay.
+SCHEMA_VERSION = 3
 
 # SQLite CREATE statements derived from SQLModel metadata
 _CREATE_SESSIONS = """
@@ -95,6 +95,7 @@ CREATE TABLE IF NOT EXISTS transcript_entries (
     content TEXT,
     tool_calls TEXT,
     tool_call_id TEXT,
+    reasoning_content TEXT,
     created_at INTEGER NOT NULL,
     token_count INTEGER,
     provenance_kind TEXT,
@@ -271,6 +272,7 @@ class SessionStorage:
         await self._conn.commit()
         # Migrate older databases — add the epoch column if missing.
         await self._migrate_epoch_column()
+        await self._migrate_transcript_reasoning_content_column()
         await self.mark_abandoned_agent_tasks()
 
     async def _migrate_epoch_column(self) -> None:
@@ -297,6 +299,17 @@ class SessionStorage:
         if null_count > 0:
             await self._conn.execute(
                 "UPDATE sessions SET epoch = 0 WHERE epoch IS NULL"
+            )
+            await self._conn.commit()
+
+    async def _migrate_transcript_reasoning_content_column(self) -> None:
+        """Idempotently add assistant reasoning replay storage to transcripts."""
+        assert self._conn is not None
+        async with self._conn.execute("PRAGMA table_info(transcript_entries)") as cur:
+            columns = [row[1] for row in await cur.fetchall()]
+        if "reasoning_content" not in columns:
+            await self._conn.execute(
+                "ALTER TABLE transcript_entries ADD COLUMN reasoning_content TEXT"
             )
             await self._conn.commit()
 
@@ -595,7 +608,7 @@ class SessionStorage:
                 raise StaleEpochError(
                     f"Epoch mismatch for {entry.session_key}: "
                     f"expected {expected_epoch}, got {actual}"
-                )
+            )
             await self.conn.commit()
         else:
             sql = f"INSERT INTO transcript_entries ({', '.join(cols)}) VALUES ({placeholders})"

--- a/tests/test_cli/test_init_cmd.py
+++ b/tests/test_cli/test_init_cmd.py
@@ -1,0 +1,9 @@
+from opensquilla.cli.init_cmd import _default_model_for_provider
+
+
+def test_init_uses_direct_deepseek_model_default() -> None:
+    assert _default_model_for_provider("deepseek") == "deepseek-v4-flash"
+
+
+def test_init_keeps_openrouter_model_default() -> None:
+    assert _default_model_for_provider("openrouter") == "deepseek/deepseek-v4-flash"

--- a/tests/test_engine/test_agent_invalid_provider_response.py
+++ b/tests/test_engine/test_agent_invalid_provider_response.py
@@ -12,6 +12,7 @@ from opensquilla.engine.usage import UsageTracker
 from opensquilla.provider import (
     ChatConfig,
     Message,
+    ModelCapabilities,
     ToolDefinition,
     ToolInputSchema,
 )
@@ -88,6 +89,43 @@ class _CacheReport:
 
     def to_log_dict(self) -> dict[str, Any]:
         return {}
+
+
+@pytest.mark.asyncio
+async def test_final_done_returns_openrouter_deepseek_reasoning_content() -> None:
+    provider = _SequenceProvider(
+        [
+            [
+                ProviderText(text="ok"),
+                ProviderDone(
+                    stop_reason="stop",
+                    input_tokens=10,
+                    output_tokens=1,
+                    reasoning_tokens=4,
+                    reasoning_content="I reasoned through the OpenRouter response.",
+                    model="deepseek/deepseek-v4-flash",
+                ),
+            ]
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=ThinkingLevel.HIGH,
+            model_id="deepseek/deepseek-v4-flash",
+            model_capabilities=ModelCapabilities(
+                supports_reasoning=True,
+                supports_tools=True,
+                reasoning_format="openrouter",
+            ),
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    done = next(event for event in events if event.kind == "done")
+    assert done.text == "ok"
+    assert done.reasoning_content == "I reasoned through the OpenRouter response."
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_session_sanitize.py
+++ b/tests/test_engine/test_session_sanitize.py
@@ -517,6 +517,37 @@ async def test_agent_preserves_reasoning_content_for_deepseek_text_replay() -> N
 
 
 @pytest.mark.asyncio
+async def test_agent_preserves_direct_deepseek_v4_reasoning_without_capabilities() -> None:
+    provider = CapturingProvider()
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_iterations=1,
+            thinking=ThinkingLevel.HIGH,
+            model_id="deepseek-v4-flash",
+            model_capabilities=None,
+        ),
+    )
+    agent.set_history(
+        [
+            Message(role="user", content="old question"),
+            Message(
+                role="assistant",
+                content=[ContentBlockText(text="old answer")],
+                reasoning_content="I reasoned before answering.",
+            ),
+        ]
+    )
+
+    events = [event async for event in agent.run_turn("continue")]
+
+    assert any(event.kind == "done" for event in events)
+    assert provider.calls
+    sent_assistant = provider.calls[0]["messages"][1]
+    assert sent_assistant.reasoning_content == "I reasoned before answering."
+
+
+@pytest.mark.asyncio
 async def test_agent_drops_reasoning_content_when_model_is_not_deepseek() -> None:
     provider = CapturingProvider()
     agent = Agent(

--- a/tests/test_engine/test_session_sanitize.py
+++ b/tests/test_engine/test_session_sanitize.py
@@ -456,6 +456,7 @@ async def test_agent_preserves_reasoning_content_for_deepseek_tool_replay() -> N
         config=AgentConfig(
             max_iterations=2,
             thinking=ThinkingLevel.HIGH,
+            model_id="deepseek-v4-flash",
             model_capabilities=ModelCapabilities(
                 supports_reasoning=True,
                 supports_tools=True,
@@ -488,6 +489,7 @@ async def test_agent_preserves_reasoning_content_for_deepseek_text_replay() -> N
         config=AgentConfig(
             max_iterations=1,
             thinking=ThinkingLevel.HIGH,
+            model_id="deepseek-v4-flash",
             model_capabilities=ModelCapabilities(
                 supports_reasoning=True,
                 supports_tools=True,
@@ -512,3 +514,38 @@ async def test_agent_preserves_reasoning_content_for_deepseek_text_replay() -> N
     assert provider.calls
     sent_assistant = provider.calls[0]["messages"][1]
     assert sent_assistant.reasoning_content == "I reasoned before answering."
+
+
+@pytest.mark.asyncio
+async def test_agent_drops_reasoning_content_when_model_is_not_deepseek() -> None:
+    provider = CapturingProvider()
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_iterations=1,
+            thinking=ThinkingLevel.HIGH,
+            model_id="custom-reasoning-model",
+            model_capabilities=ModelCapabilities(
+                supports_reasoning=True,
+                supports_tools=True,
+                reasoning_format="deepseek",
+            ),
+        ),
+    )
+    agent.set_history(
+        [
+            Message(role="user", content="old question"),
+            Message(
+                role="assistant",
+                content=[ContentBlockText(text="old answer")],
+                reasoning_content="I reasoned before answering.",
+            ),
+        ]
+    )
+
+    events = [event async for event in agent.run_turn("continue")]
+
+    assert any(event.kind == "done" for event in events)
+    assert provider.calls
+    sent_assistant = provider.calls[0]["messages"][1]
+    assert sent_assistant.reasoning_content is None

--- a/tests/test_engine/test_session_sanitize.py
+++ b/tests/test_engine/test_session_sanitize.py
@@ -478,3 +478,37 @@ async def test_agent_preserves_reasoning_content_for_deepseek_tool_replay() -> N
         and any(getattr(block, "type", None) == "tool_use" for block in message.content)
     )
     assert assistant_replay.reasoning_content == "I should call echo before finalizing."
+
+
+@pytest.mark.asyncio
+async def test_agent_preserves_reasoning_content_for_deepseek_text_replay() -> None:
+    provider = CapturingProvider()
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_iterations=1,
+            thinking=ThinkingLevel.HIGH,
+            model_capabilities=ModelCapabilities(
+                supports_reasoning=True,
+                supports_tools=True,
+                reasoning_format="deepseek",
+            ),
+        ),
+    )
+    agent.set_history(
+        [
+            Message(role="user", content="old question"),
+            Message(
+                role="assistant",
+                content=[ContentBlockText(text="old answer")],
+                reasoning_content="I reasoned before answering.",
+            ),
+        ]
+    )
+
+    events = [event async for event in agent.run_turn("continue")]
+
+    assert any(event.kind == "done" for event in events)
+    assert provider.calls
+    sent_assistant = provider.calls[0]["messages"][1]
+    assert sent_assistant.reasoning_content == "I reasoned before answering."

--- a/tests/test_engine/test_stream_wrappers.py
+++ b/tests/test_engine/test_stream_wrappers.py
@@ -37,11 +37,12 @@ async def test_heartbeat_stream_preserves_upstream_idle_timeout() -> None:
 @pytest.mark.asyncio
 async def test_upstream_run_heartbeat_resets_idle_timeout_stream() -> None:
     async def source():
-        await asyncio.sleep(0.04)
-        yield RunHeartbeatEvent(phase="tool", message="tool still running")
-        await asyncio.sleep(0.04)
+        for _ in range(5):
+            await asyncio.sleep(0.03)
+            yield RunHeartbeatEvent(phase="tool", message="tool still running")
+        await asyncio.sleep(0.03)
         yield TextDeltaEvent(text="done")
 
-    events = [event async for event in idle_timeout_stream(source(), timeout=0.06)]
+    events = [event async for event in idle_timeout_stream(source(), timeout=0.15)]
 
-    assert [event.kind for event in events] == ["run_heartbeat", "text_delta"]
+    assert [event.kind for event in events] == ["run_heartbeat"] * 5 + ["text_delta"]

--- a/tests/test_gateway/test_boot_provider_env.py
+++ b/tests/test_gateway/test_boot_provider_env.py
@@ -124,8 +124,10 @@ async def test_config_patch_runtime_env_key_is_not_persisted(monkeypatch, tmp_pa
 
     await _handle_config_patch({"patch": {"llm": {"provider": "deepseek"}}}, ctx)
 
+    assert ctx.config.squilla_router.tier_profile == "deepseek"
     assert ctx.config.llm.api_key == "deepseek-key"
     assert selector.synced.api_key == "deepseek-key"
     assert "api_key" not in ctx.config.to_toml_dict()["llm"]
     persisted = tomllib.loads((tmp_path / "config.toml").read_text())
+    assert persisted["squilla_router"]["tier_profile"] == "deepseek"
     assert "api_key" not in persisted["llm"]

--- a/tests/test_model_router_defaults.py
+++ b/tests/test_model_router_defaults.py
@@ -5,7 +5,10 @@ from pathlib import Path
 import pytest
 import yaml
 
+from opensquilla.gateway.config import ROUTER_TIER_PROFILE_IDS
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
+DIRECT_ROUTER_PROFILE_IDS = sorted(ROUTER_TIER_PROFILE_IDS - {"openrouter"})
 
 
 def _squilla_router_config_cls():
@@ -107,14 +110,50 @@ def test_provider_profile_accepts_matching_llm_provider() -> None:
     assert cfg.squilla_router.tiers["t0"]["model"] == "qwen3.6-flash"
 
 
-def test_unset_tier_profile_preserves_legacy_behavior_even_with_non_openrouter_llm() -> None:
+@pytest.mark.parametrize("provider_id", DIRECT_ROUTER_PROFILE_IDS)
+def test_unset_tier_profile_uses_matching_direct_provider_profile(provider_id: str) -> None:
+    from opensquilla.gateway.config import _router_tier_profile_defaults
+
     gateway_config_cls = _gateway_config_cls()
 
-    cfg = gateway_config_cls(llm={"provider": "deepseek"})
+    cfg = gateway_config_cls(llm={"provider": provider_id})
 
-    assert cfg.squilla_router.tier_profile is None
-    assert cfg.squilla_router.tiers["t0"]["provider"] == "openrouter"
-    assert cfg.squilla_router.tiers["t0"]["model"] == "deepseek/deepseek-v4-flash"
+    expected = _router_tier_profile_defaults(provider_id)
+    assert cfg.squilla_router.tier_profile == provider_id
+    for tier in ("t0", "t1", "t2", "t3"):
+        assert cfg.squilla_router.tiers[tier]["provider"] == provider_id
+        assert cfg.squilla_router.tiers[tier]["model"] == expected[tier]["model"]
+
+
+@pytest.mark.parametrize("provider_id", DIRECT_ROUTER_PROFILE_IDS)
+def test_direct_legacy_openrouter_router_defaults_are_migrated(provider_id: str) -> None:
+    from opensquilla.gateway.config import _router_tier_profile_defaults
+
+    gateway_config_cls = _gateway_config_cls()
+
+    cfg = gateway_config_cls(
+        llm={"provider": provider_id},
+        squilla_router={"enabled": True, "tiers": _router_tier_profile_defaults("openrouter")},
+    )
+
+    expected = _router_tier_profile_defaults(provider_id)
+    assert cfg.squilla_router.tier_profile == provider_id
+    for tier in ("t0", "t1", "t2", "t3"):
+        assert cfg.squilla_router.tiers[tier]["provider"] == provider_id
+        assert cfg.squilla_router.tiers[tier]["model"] == expected[tier]["model"]
+
+
+def test_deepseek_direct_legacy_openrouter_model_default_is_normalized() -> None:
+    gateway_config_cls = _gateway_config_cls()
+
+    cfg = gateway_config_cls(
+        llm={
+            "provider": "deepseek",
+            "model": "deepseek/deepseek-v4-pro",
+        }
+    )
+
+    assert cfg.llm.model == "deepseek-v4-pro"
 
 
 def test_each_provider_profile_has_four_text_tiers_without_default_image_model() -> None:

--- a/tests/test_model_router_defaults.py
+++ b/tests/test_model_router_defaults.py
@@ -212,10 +212,13 @@ def test_moonshot_profile_uses_kimi_for_strong_tiers() -> None:
 
     cfg = squilla_router_config_cls(tier_profile="moonshot")
 
-    assert cfg.tiers["t0"]["model"] == "moonshot-v1-8k"
-    assert cfg.tiers["t1"]["model"] == "moonshot-v1-128k"
-    assert cfg.tiers["t2"]["model"] == "kimi-k2.5"
+    assert cfg.tiers["t0"]["model"] == "kimi-k2.5"
+    assert cfg.tiers["t1"]["model"] == "kimi-k2.5"
+    assert cfg.tiers["t2"]["model"] == "kimi-k2.6"
     assert cfg.tiers["t3"]["model"] == "kimi-k2.6"
+    assert all(
+        cfg.tiers[tier]["supports_image"] is True for tier in ("t0", "t1", "t2", "t3")
+    )
 
 
 def test_volcengine_profile_uses_seed_2_capability_ladder() -> None:

--- a/tests/test_provider_model_catalog.py
+++ b/tests/test_provider_model_catalog.py
@@ -13,6 +13,10 @@ def test_deepseek_v4_direct_models_use_official_context_and_output_windows() -> 
     for model in ("deepseek-v4-flash", "deepseek-v4-pro"):
         assert catalog.resolve_context_window(model) == 1_048_576
         assert catalog.resolve_max_tokens(model) == 393_216
+        caps = catalog.get_capabilities(model, provider_name="deepseek")
+        assert caps.supports_reasoning is True
+        assert caps.supports_tools is True
+        assert caps.reasoning_format == "deepseek"
 
 
 def test_direct_profile_static_fallbacks_cover_context_windows() -> None:

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -331,6 +331,43 @@ def test_deepseek_v4_tool_replay_adds_empty_reasoning_content_when_missing(
     assert captured["payload"]["messages"][0]["reasoning_content"] == ""
 
 
+def test_deepseek_v4_text_replay_adds_empty_reasoning_content_when_missing(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek-v4-flash",
+        base_url="https://api.deepseek.com",
+        provider_kind="deepseek",
+    )
+    messages = [
+        Message(role="assistant", content="Prior non-thinking assistant turn."),
+        Message(role="user", content="continue in thinking mode"),
+    ]
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="deepseek",
+        ),
+    )
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    assert captured["payload"]["messages"][0] == {
+        "role": "assistant",
+        "content": "Prior non-thinking assistant turn.",
+        "reasoning_content": "",
+    }
+
+
 def test_deepseek_v4_non_thinking_strips_prior_reasoning_content(
     monkeypatch: Any,
 ) -> None:

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -368,7 +368,7 @@ def test_deepseek_v4_text_replay_adds_empty_reasoning_content_when_missing(
     }
 
 
-def test_deepseek_v4_non_thinking_strips_prior_reasoning_content(
+def test_deepseek_v4_non_thinking_replays_prior_reasoning_content(
     monkeypatch: Any,
 ) -> None:
     captured: dict[str, Any] = {}
@@ -383,7 +383,7 @@ def test_deepseek_v4_non_thinking_strips_prior_reasoning_content(
         Message(
             role="assistant",
             content="previous answer",
-            reasoning_content="prior thinking must not be sent with disabled thinking",
+            reasoning_content="prior thinking from earlier deepseek turn",
         ),
         Message(role="user", content="continue"),
     ]
@@ -403,7 +403,45 @@ def test_deepseek_v4_non_thinking_strips_prior_reasoning_content(
     asyncio.run(_run())
 
     assert captured["payload"]["thinking"] == {"type": "disabled"}
-    assert "reasoning_content" not in captured["payload"]["messages"][0]
+    assert (
+        captured["payload"]["messages"][0]["reasoning_content"]
+        == "prior thinking from earlier deepseek turn"
+    )
+
+
+def test_deepseek_v4_replays_reasoning_content_without_catalog_capabilities(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek-v4-flash",
+        base_url="https://api.deepseek.com",
+        provider_kind="deepseek",
+    )
+    messages = [
+        Message(
+            role="assistant",
+            content="previous answer",
+            reasoning_content="prior thinking from direct deepseek",
+        ),
+        Message(role="user", content="continue"),
+    ]
+    cfg = ChatConfig(thinking=True, model_capabilities=None)
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    assert captured["payload"]["thinking"] == {"type": "enabled"}
+    assert captured["payload"]["reasoning_effort"] == "high"
+    assert (
+        captured["payload"]["messages"][0]["reasoning_content"]
+        == "prior thinking from direct deepseek"
+    )
 
 
 def test_openrouter_reasoning_model_replays_reasoning_content_by_capability(

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -58,6 +58,27 @@ def _patch_transport(monkeypatch: Any, captured: dict[str, Any]) -> None:
     monkeypatch.setattr("opensquilla.provider.openai.httpx.AsyncClient", patched_async_client)
 
 
+def _patch_transport_body(monkeypatch: Any, captured: dict[str, Any], body: bytes) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = request.headers
+        captured["payload"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=body,
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("opensquilla.provider.openai.httpx.AsyncClient", patched_async_client)
+
+
 def _collect(provider: OpenAIProvider, cfg: ChatConfig) -> DoneEvent:
     async def _run() -> DoneEvent:
         done: DoneEvent | None = None
@@ -68,6 +89,61 @@ def _collect(provider: OpenAIProvider, cfg: ChatConfig) -> DoneEvent:
         return done
 
     return asyncio.run(_run())
+
+
+def test_openrouter_deepseek_v4_returns_reasoning_content_from_details(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    chunks = [
+        {
+            "model": "deepseek/deepseek-v4-flash",
+            "choices": [
+                {
+                    "delta": {
+                        "reasoning_details": [
+                            {"type": "reasoning.text", "text": "I considered the request."}
+                        ],
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "model": "deepseek/deepseek-v4-flash",
+            "choices": [{"delta": {"content": "ok"}, "finish_reason": None}],
+        },
+        {
+            "model": "deepseek/deepseek-v4-flash",
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+        },
+    ]
+    body = b"".join(f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks)
+    body += b"data: [DONE]\n\n"
+    _patch_transport_body(monkeypatch, captured, body)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek/deepseek-v4-flash",
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="openrouter",
+        provider_routing={"deepseek/deepseek-v4-flash": "deepseek"},
+    )
+    cfg = ChatConfig(
+        thinking=True,
+        thinking_level=ThinkingLevel.HIGH,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="openrouter",
+        ),
+    )
+
+    done = _collect(provider, cfg)
+
+    assert captured["payload"]["provider"]["only"] == ["deepseek"]
+    assert captured["payload"]["reasoning"] == {"effort": "high"}
+    assert done.reasoning_content == "I considered the request."
 
 
 def _collect_events(
@@ -202,6 +278,246 @@ def test_deepseek_tool_replay_preserves_reasoning_content_in_payload(
         "tool_call_id": "call_lookup",
         "content": "cache is warm",
     }
+
+
+def test_deepseek_v4_tool_replay_adds_empty_reasoning_content_when_missing(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek-v4-flash",
+        base_url="https://api.deepseek.com",
+        provider_kind="deepseek",
+    )
+    messages = [
+        Message(
+            role="assistant",
+            content=[
+                ContentBlockToolUse(
+                    id="call_lookup",
+                    name="lookup",
+                    input={"q": "cache"},
+                )
+            ],
+        ),
+        Message(
+            role="user",
+            content=[
+                ContentBlockToolResult(
+                    tool_use_id="call_lookup",
+                    content="cache is warm",
+                )
+            ],
+        ),
+        Message(role="user", content="continue"),
+    ]
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="deepseek",
+        ),
+    )
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    assert captured["payload"]["messages"][0]["reasoning_content"] == ""
+
+
+def test_deepseek_v4_non_thinking_strips_prior_reasoning_content(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek-v4-flash",
+        base_url="https://api.deepseek.com",
+        provider_kind="deepseek",
+    )
+    messages = [
+        Message(
+            role="assistant",
+            content="previous answer",
+            reasoning_content="prior thinking must not be sent with disabled thinking",
+        ),
+        Message(role="user", content="continue"),
+    ]
+    cfg = ChatConfig(
+        thinking=False,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="deepseek",
+        ),
+    )
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    assert captured["payload"]["thinking"] == {"type": "disabled"}
+    assert "reasoning_content" not in captured["payload"]["messages"][0]
+
+
+def test_openrouter_reasoning_model_replays_reasoning_content_by_capability(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="anthropic/claude-sonnet-4.5",
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="openrouter",
+    )
+    messages = [
+        Message(
+            role="assistant",
+            content="previous answer",
+            reasoning_content="openrouter-native reasoning should be replayed",
+        ),
+        Message(role="user", content="continue"),
+    ]
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="openrouter",
+        ),
+    )
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    assert (
+        captured["payload"]["messages"][0]["reasoning_content"]
+        == "openrouter-native reasoning should be replayed"
+    )
+
+
+def test_non_deepseek_reasoning_model_does_not_replay_reasoning_content(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="gemini-2.5-pro",
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        provider_kind="gemini",
+    )
+    messages = [
+        Message(
+            role="assistant",
+            content="previous answer",
+            reasoning_content="provider-internal reasoning must not be replayed",
+        ),
+        Message(role="user", content="continue"),
+    ]
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="gemini",
+        ),
+    )
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    assert "reasoning_content" not in captured["payload"]["messages"][0]
+
+
+def test_deepseek_non_v4_model_does_not_replay_reasoning_content(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek-chat",
+        base_url="https://api.deepseek.com/v1",
+        provider_kind="deepseek",
+    )
+    messages = [
+        Message(
+            role="assistant",
+            content="previous answer",
+            reasoning_content="must not be replayed for non-v4 direct DeepSeek",
+        ),
+        Message(role="user", content="continue"),
+    ]
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="deepseek",
+        ),
+    )
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    assert "reasoning_content" not in captured["payload"]["messages"][0]
+
+
+def test_deepseek_reasoning_format_without_deepseek_model_does_not_replay_reasoning_content(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="custom-reasoning-model",
+        base_url="https://api.deepseek.com/v1",
+        provider_kind="deepseek",
+    )
+    messages = [
+        Message(
+            role="assistant",
+            content="previous answer",
+            reasoning_content="must not be replayed for a non-DeepSeek model",
+        ),
+        Message(role="user", content="continue"),
+    ]
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="deepseek",
+        ),
+    )
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    assert "reasoning_content" not in captured["payload"]["messages"][0]
 
 
 def test_gemini_reasoning_uses_openai_compatible_reasoning_effort(monkeypatch: Any) -> None:


### PR DESCRIPTION
 ## Summary

  This PR fixes DeepSeek direct API multi-turn thinking mode and updates Moonshot direct router defaults.

  ## Changes

  - Fix DeepSeek direct API error where `reasoning_content` must be passed back in thinking mode.
  - Persist and replay assistant reasoning content for providers that require it.
  - Keep reasoning replay scoped to provider-specific behavior, so unrelated providers and OpenRouter are not changed.
  - Update Moonshot direct Squilla router defaults:
    - `t0`: `kimi-k2.5`
    - `t1`: `kimi-k2.5`
    - `t2`: `kimi-k2.6`
    - `t3`: `kimi-k2.6`

  ## Verification

  - Added/updated provider payload tests.
  - Added/updated session/history tests.
  - Ran live DeepSeek direct multi-turn validation.
  - Ran live gateway smoke tests for direct providers including DeepSeek, Moonshot, DashScope, and Volcengine.
