### PR TITLE
Guard empty extras array in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,26 +75,33 @@ if [[ -n "${cli_extras}" ]]; then
     extras_csv="${extras_csv}${extras_csv:+,}${cli_extras}"
 fi
 extras_csv="${extras_csv// /,}"
-IFS=',' read -r -a raw_extras <<< "${extras_csv}"
+raw_extras=()
+if [[ -n "${extras_csv}" ]]; then
+    IFS=',' read -r -a raw_extras <<< "${extras_csv}"
+fi
 install_extras=()
-for extra in "${raw_extras[@]}"; do
-    [[ -n "${extra}" ]] || continue
-    if [[ "${valid_extras}" != *" ${extra} "* ]]; then
-        echo "install.sh: unsupported extra '${extra}'." >&2
-        echo "install.sh: supported extras:${valid_extras}" >&2
-        exit 1
-    fi
-    duplicate=0
-    for existing in "${install_extras[@]}"; do
-        if [[ "${existing}" == "${extra}" ]]; then
-            duplicate=1
-            break
+if (( ${#raw_extras[@]} > 0 )); then
+    for extra in "${raw_extras[@]}"; do
+        [[ -n "${extra}" ]] || continue
+        if [[ "${valid_extras}" != *" ${extra} "* ]]; then
+            echo "install.sh: unsupported extra '${extra}'." >&2
+            echo "install.sh: supported extras:${valid_extras}" >&2
+            exit 1
+        fi
+        duplicate=0
+        if (( ${#install_extras[@]} > 0 )); then
+            for existing in "${install_extras[@]}"; do
+                if [[ "${existing}" == "${extra}" ]]; then
+                    duplicate=1
+                    break
+                fi
+            done
+        fi
+        if [[ "${duplicate}" -eq 0 ]]; then
+            install_extras+=("${extra}")
         fi
     done
-    if [[ "${duplicate}" -eq 0 ]]; then
-        install_extras+=("${extra}")
-    fi
-done
+fi
 
 case "${profile}" in
     core|minimal)
@@ -110,7 +117,9 @@ case "${profile}" in
         exit 1
         ;;
 esac
-target_extras+=("${install_extras[@]}")
+if (( ${#install_extras[@]} > 0 )); then
+    target_extras+=("${install_extras[@]}")
+fi
 if (( ${#target_extras[@]} > 0 )); then
     joined_extras="$(IFS=,; echo "${target_extras[*]}")"
     install_target=".[${joined_extras}]"


### PR DESCRIPTION
## Summary
Guards `install.sh` against unbound-variable / empty-array expansion errors when the extras CSV is empty (e.g. profile-only install with no `--extra` flags). When `extras_csv` is empty, `read -r -a raw_extras` leaves `raw_extras` unset, which then trips `set -u` on later `"${raw_extras[@]}"` / `"${install_extras[@]}"` expansions.

## Changes
- Initialize `raw_extras=()` and only populate it via `read` when `extras_csv` is non-empty.
- Wrap the validation loop with a length check.
- Guard the duplicate-check inner loop the same way.
- Guard `target_extras+=("${install_extras[@]}")` against expanding an empty array.

Pure defensive change; no behavior change for non-empty extras input.

## Test plan
- [ ] `bash install.sh --profile minimal` (no extras) succeeds under `set -u`
- [ ] `bash install.sh --profile core --extra docs` still installs `docs` extra
- [ ] `bash install.sh --extra bogus` still errors with the unsupported-extra message