### PR TITLE
Refresh 0.1.0rc1 release fixes

### DIFF
--- a/scripts/build_wheelhouse_zip.py
+++ b/scripts/build_wheelhouse_zip.py
@@ -1071,7 +1071,8 @@ def render_start_cmd() -> str:
         'cd /d "%~dp0"\r\n'
         'set "OSQ_POWERSHELL=powershell.exe"\r\n'
         'where pwsh.exe >nul 2>nul && set "OSQ_POWERSHELL=pwsh.exe"\r\n'
-        '"%OSQ_POWERSHELL%" -NoLogo -NoExit -ExecutionPolicy Bypass -File "%~dp0start.ps1"\r\n'
+        '"%OSQ_POWERSHELL%" -NoLogo -NoExit -NoProfile -ExecutionPolicy Bypass '
+        '-File "%~dp0start.ps1"\r\n'
     )
 
 

--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -1247,11 +1247,34 @@ def _artifact_event_payload(event: Any) -> dict[str, Any] | None:
 
 
 def _artifact_delivery_key(artifact: dict[str, Any]) -> str:
-    for field in ("id", "sha256", "path", "download_url", "channel_download_url", "name"):
+    for field in (
+        "sha256",
+        "path",
+        "channel_download_url",
+        "signed_download_url",
+        "download_url",
+        "id",
+        "name",
+    ):
         value = artifact.get(field)
         if value:
             return f"{field}:{value}"
     return ""
+
+
+def _dedupe_artifacts_for_channel_delivery(
+    artifacts: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    unique: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for artifact in artifacts:
+        key = _artifact_delivery_key(artifact)
+        if key:
+            if key in seen:
+                continue
+            seen.add(key)
+        unique.append(artifact)
+    return unique
 
 
 def _channel_safe_artifact_url(artifact: dict[str, Any]) -> str:
@@ -1266,7 +1289,7 @@ def _channel_safe_artifact_url(artifact: dict[str, Any]) -> str:
 
 def _artifact_fallback_lines(artifacts: list[dict[str, Any]]) -> list[str]:
     lines: list[str] = []
-    for artifact in artifacts:
+    for artifact in _dedupe_artifacts_for_channel_delivery(artifacts):
         name = artifact.get("name") if isinstance(artifact.get("name"), str) else "artifact"
         target = _channel_safe_artifact_url(artifact)
         if target:
@@ -1349,7 +1372,7 @@ async def _deliver_artifacts_as_channel_files(
 
     store = ArtifactStore(_artifact_media_root_from_config(config))
     undelivered: list[dict[str, Any]] = []
-    for artifact in artifacts:
+    for artifact in _dedupe_artifacts_for_channel_delivery(artifacts):
         artifact_id = artifact.get("id")
         session_id = artifact.get("session_id")
         if not isinstance(artifact_id, str) or not isinstance(session_id, str):

--- a/src/opensquilla/onboarding/flow.py
+++ b/src/opensquilla/onboarding/flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import re
 import sys
 from dataclasses import dataclass
 from typing import Any, cast
@@ -232,6 +233,8 @@ def _required_value(label: str):
 
 _PASTE_API_KEY_CHOICE = "Paste API key now"
 _DETECTED_ENV_SUFFIX = " (detected)"
+_TERMINAL_ESCAPE_RE = re.compile(r"\x1b")
+_LEADING_TERMINAL_KEY_RE = re.compile(r"^\[[0-9;?]+~")
 
 
 def _api_key_env_choice(env_key: str, *, detected: bool = False) -> str:
@@ -256,6 +259,26 @@ def _api_key_source_choices(env_key: str) -> list[str]:
             _api_key_env_choice(env_key, detected=bool(os.environ.get(env_key)))
         )
     return choices
+
+
+def _secret_value_validator(label: str):
+    required = _required_value(label)
+
+    def _validate(value: str) -> bool | str:
+        result = cast(bool | str, required(value))
+        if result is not True:
+            return result
+        stripped = str(value or "").strip()
+        if _TERMINAL_ESCAPE_RE.search(stripped) or _LEADING_TERMINAL_KEY_RE.search(
+            stripped
+        ):
+            return (
+                "Paste was not read correctly by this terminal. Use right-click, "
+                "Shift+Insert, or the environment variable option."
+            )
+        return True
+
+    return _validate
 
 
 def _search_api_key_prompt(spec) -> str:
@@ -298,7 +321,7 @@ def _ask_provider_fields(
                 answers["api_key"] = (
                     questionary.password(
                         "API key",
-                        validate=_required_value("API key"),
+                        validate=_secret_value_validator("API key"),
                     ).ask()
                     or ""
                 )
@@ -344,7 +367,7 @@ def _ask_search_fields(questionary, spec) -> dict[str, Any]:
             answers["api_key"] = (
                 questionary.password(
                     _search_api_key_prompt(spec),
-                    validate=_required_value("Search API key"),
+                    validate=_secret_value_validator("Search API key"),
                 ).ask()
                 or ""
             )
@@ -464,7 +487,13 @@ def _ask_image_generation_fields(
     ).ask()
     selected_env_key = _api_key_env_from_choice(key_source or "")
     if key_source == _PASTE_API_KEY_CHOICE:
-        answers["api_key"] = questionary.password("Image API key").ask() or ""
+        answers["api_key"] = (
+            questionary.password(
+                "Image API key",
+                validate=_secret_value_validator("Image API key"),
+            ).ask()
+            or ""
+        )
         answers["api_key_env"] = ""
     elif selected_env_key:
         answers["api_key"] = ""
@@ -769,7 +798,13 @@ def _ask_channel_field(questionary, field: ChannelSetupField, default: Any) -> A
     if field.field_type == "bool":
         return questionary.confirm(field.label, default=bool(default)).ask()
     if field.field_type == "password":
-        return questionary.password(field.label).ask() or ""
+        return (
+            questionary.password(
+                field.label,
+                validate=_secret_value_validator(field.label),
+            ).ask()
+            or ""
+        )
     if field.field_type == "int":
         raw = questionary.text(
             field.label, default=str(default if default is not None else 0)

--- a/tests/test_gateway/test_channel_dispatch_realtime.py
+++ b/tests/test_gateway/test_channel_dispatch_realtime.py
@@ -19,6 +19,7 @@ from opensquilla.gateway.attachment_ingest import (
 )
 from opensquilla.gateway.channel_dispatch import (
     _artifact_fallback_lines,
+    _deliver_artifacts_as_channel_files,
     _deliver_runtime_channel_reply,
     _dispatch_combined_message_after_debounce,
     _ingest_channel_message_attachments,
@@ -641,6 +642,50 @@ async def test_runtime_channel_stream_relay_sends_artifact_with_adapter_upload(
     assert channel.chunks == ["done"]
     assert channel.files == [("c1", "report.pptx")]
     assert channel.sent == []
+
+
+@pytest.mark.asyncio
+async def test_channel_file_delivery_dedupes_same_artifact_material(tmp_path) -> None:
+    store = ArtifactStore(tmp_path)
+    payload = b"\x89PNG\r\n\x1a\nimage bytes"
+    first = store.publish_bytes(
+        payload,
+        session_id="session-1",
+        session_key="agent:main:feishu:direct:u1",
+        name="image.png",
+        mime="image/png",
+        source="image_generate",
+    )
+    second = store.publish_bytes(
+        payload,
+        session_id="session-1",
+        session_key="agent:main:feishu:direct:u1",
+        name="image.png",
+        mime="image/png",
+        source="publish_artifact",
+    )
+
+    class FileChannel(_FakeChannel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.files: list[tuple[str, str]] = []
+
+        async def send_file(self, chat_id: str, file_path: str) -> None:
+            assert Path(file_path).is_file()
+            self.files.append((chat_id, Path(file_path).name))
+
+    channel = FileChannel()
+    config = SimpleNamespace(attachments=SimpleNamespace(media_root=str(tmp_path)))
+
+    undelivered = await _deliver_artifacts_as_channel_files(
+        channel,
+        _message(),
+        [first.to_dict(), second.to_dict()],
+        config,
+    )
+
+    assert undelivered == []
+    assert channel.files == [("c1", "image.png")]
 
 
 @pytest.mark.asyncio

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -239,6 +239,44 @@ def test_interactive_provider_fields_requires_pasted_api_key(monkeypatch):
     assert answers["api_key_env"] == ""
 
 
+def test_interactive_provider_fields_rejects_terminal_paste_escape(monkeypatch):
+    from opensquilla.onboarding.flow import OnboardOptions, _ask_provider_fields
+    from opensquilla.onboarding.provider_specs import get_provider_setup_spec
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    class _Answer:
+        def __init__(self, value):
+            self.value = value
+
+        def ask(self):
+            return self.value
+
+    class _Questionary:
+        def select(self, message: str, **kwargs):
+            assert message == "LLM API key source"
+            assert kwargs.get("default") == "Paste API key now"
+            return _Answer("Paste API key now")
+
+        def password(self, message: str, **kwargs):
+            assert message == "API key"
+            validate = kwargs.get("validate")
+            assert validate is not None
+            assert validate("[2;2~") is not True
+            assert validate("\x1b[200~sk-live\x1b[201~") is not True
+            assert validate("sk-live-with-[2;2~-literal-suffix") is True
+            assert validate("sk-live") is True
+            return _Answer("sk-live")
+
+    answers = _ask_provider_fields(
+        _Questionary(),
+        get_provider_setup_spec("openrouter"),
+        OnboardOptions(),
+    )
+
+    assert answers["api_key"] == "sk-live"
+
+
 def test_interactive_onboard_prompts_router_defaults_before_persist(tmp_path, monkeypatch):
     import sys
     import types

--- a/tests/test_scripts/test_build_wheelhouse_zip.py
+++ b/tests/test_scripts/test_build_wheelhouse_zip.py
@@ -427,7 +427,8 @@ def test_start_scripts_use_bundled_python_runtime() -> None:
         'cd /d "%~dp0"\r\n'
         'set "OSQ_POWERSHELL=powershell.exe"\r\n'
         'where pwsh.exe >nul 2>nul && set "OSQ_POWERSHELL=pwsh.exe"\r\n'
-        '"%OSQ_POWERSHELL%" -NoLogo -NoExit -ExecutionPolicy Bypass -File "%~dp0start.ps1"\r\n'
+        '"%OSQ_POWERSHELL%" -NoLogo -NoExit -NoProfile -ExecutionPolicy Bypass '
+        '-File "%~dp0start.ps1"\r\n'
     )
 
 


### PR DESCRIPTION
## Summary
- keep the 0.1.0rc1 release name while replacing the Windows/source release contents with the latest release-edge fixes
- dedupe channel artifact delivery by stable artifact identity so generated images are not sent twice
- harden Windows portable onboarding against polluted pasted API keys and start PowerShell with -NoProfile

## Verification
- uv run pytest tests/test_onboarding/test_flow.py tests/test_scripts/test_build_wheelhouse_zip.py::test_prepare_windows_portable_release_tree_includes_double_click_launcher tests/test_gateway/test_channel_dispatch_realtime.py tests/test_artifacts.py tests/test_engine/test_runtime_artifacts.py -q
- uv run ruff check src/opensquilla/onboarding/flow.py scripts/build_wheelhouse_zip.py tests/test_onboarding/test_flow.py tests/test_scripts/test_build_wheelhouse_zip.py src/opensquilla/gateway/channel_dispatch.py tests/test_gateway/test_channel_dispatch_realtime.py
- git diff --check