### PR TITLE
Simplify portable preview install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,35 +38,38 @@ disabled` if you intentionally want to skip the bundled router.
 
 ### Preview release package
 
-Use this path if you want to try OpenSquilla as a local app without cloning the
-repository or installing Git, Git LFS, or `uv`.
+Download the preview package if you want to try OpenSquilla as a local app
+without cloning the repository or installing Git, Git LFS, or `uv`.
+
+Current preview packages:
+
+- `OpenSquilla-<version>-windows-x64-py312-recommended-portable.zip` for
+  Windows.
+
+The recommended portable zip includes Feishu websocket support by default. If a
+package is not available for your platform, use the source install path below.
 
 1. Open the [GitHub Releases](https://github.com/opensquilla/opensquilla/releases)
-   page and download the preview package for your platform.
-
-   Current preview packages:
-
-   - `OpenSquilla-<version>-windows-x64-py312-recommended-portable.zip` for
-     Windows.
-
-   The recommended portable zip includes Feishu websocket support by default.
-   If a package is not available for your platform, use the source install path
-   below.
+   page and download the package.
 
 2. Extract to Downloads, Documents, or another folder you can write to.
 
-3. Install or start from the extracted folder.
+3. Double-click `Start OpenSquilla.cmd` from the extracted folder.
 
-   Windows portable zip:
+   Keep the terminal window open. Closing it stops the gateway.
 
-   - Double-click `Start OpenSquilla.cmd`.
-   - Double-click `OpenSquilla Shell.cmd` if you want a terminal where
-     `opensquilla ...` commands work from the portable package.
-   - Keep the terminal window open. Closing it stops the gateway.
-   - First run opens onboarding when no local config exists.
+4. Complete onboarding and open the Web UI.
 
-   Optional PowerShell start for users who want to set an API key in the same
-   terminal first:
+   The launcher opens onboarding before the gateway starts. On first run, choose
+   a provider and paste the requested keys; later starts let you review or change
+   the config. Then open <http://127.0.0.1:18790/control/>.
+
+<details>
+<summary>Advanced portable usage</summary>
+
+Use these options only when you want scripted setup or portable CLI commands.
+
+- To provide an OpenRouter key before first start:
 
    ```powershell
    $env:OPENROUTER_API_KEY="sk-..."
@@ -79,23 +82,28 @@ repository or installing Git, Git LFS, or `uv`.
    without asking you to paste the key. If the variable is not set, the
    onboarding wizard lets you choose a provider freely.
 
-4. Configure a model provider.
-
-   Portable zip users can normally do this from the onboarding wizard opened by
-   `Start OpenSquilla.cmd`, `start.ps1`, or `start.sh`. The `OPENROUTER_API_KEY`
-   shortcut above is optional. The portable zip does not install a global
-   `opensquilla` command; run commands from the extracted folder through the
-   included start scripts or `.\opensquilla.cmd`, for example:
+- The portable zip does not install a global `opensquilla` command. For a
+  terminal where `opensquilla ...` commands work, double-click
+  `OpenSquilla Shell.cmd`, or run commands from the extracted folder through
+  `.\opensquilla.cmd`:
 
    ```powershell
    .\opensquilla.cmd onboard --provider openrouter --api-key-env OPENROUTER_API_KEY
    ```
 
-5. Start OpenSquilla and open the Web UI.
+</details>
 
-   Portable zip users already start the gateway through `Start OpenSquilla.cmd`,
-   `start.ps1`, or `start.sh`. Then open
-   <http://127.0.0.1:18790/control/>.
+<details>
+<summary>Portable troubleshooting</summary>
+
+- If Windows blocks the launcher, make sure the zip came from the official
+  GitHub Releases page, then use the Windows prompt to allow it.
+- If the Web UI does not open, keep the gateway terminal open and visit
+  <http://127.0.0.1:18790/control/> manually.
+- If `opensquilla` is not recognized, use `OpenSquilla Shell.cmd` or
+  `.\opensquilla.cmd` from the extracted folder.
+
+</details>
 
 Preview packages are the recommended public distribution channel for validating
 installation, onboarding, the local gateway, and the Web UI before the stable

--- a/scripts/build_wheelhouse_zip.py
+++ b/scripts/build_wheelhouse_zip.py
@@ -1093,16 +1093,8 @@ def render_readme(
         python_note = "Python is bundled in this zip."
         setup_note = (
             "The recommended portable package includes Feishu websocket support. "
-            "First run opens the configuration wizard when no local config exists. "
-            "If `OPENROUTER_API_KEY` is present and no local config exists, "
-            "the launcher writes an OpenRouter env-reference config and starts "
-            "the gateway without asking you to paste the key. Later runs open "
-            "the wizard again so you can review or change configuration before "
-            "the gateway starts. Config, workspace, logs, memory, and runtime "
-            "state use the normal user-level OpenSquilla directory. "
-            "Portable packages do not install a global `opensquilla` command; "
-            "run commands from this extracted folder with `./opensquilla` or "
-            "`opensquilla.cmd`."
+            "Config, workspace, logs, memory, and runtime state use the normal "
+            "user-level OpenSquilla directory."
         )
     else:
         release_kind = "Wheelhouse Release"
@@ -1118,24 +1110,37 @@ def render_readme(
         if portable:
             command_section = f"""## Windows
 
-Double-click `Start OpenSquilla.cmd`.
-Double-click `OpenSquilla Shell.cmd` for a terminal where `opensquilla ...`
-commands work from this portable package.
+1. Double-click `Start OpenSquilla.cmd`.
+2. Keep the terminal open. Closing the terminal stops the gateway.
+3. Complete onboarding. On first run, choose a provider and paste the requested
+   keys; later starts let you review or change the config.
+4. Open `http://127.0.0.1:18790/control/`.
 
-Or run from PowerShell:
+<details>
+<summary>Advanced portable usage</summary>
+
+Use these options only when you want scripted setup or portable CLI commands.
+
+To start from PowerShell:
 
 ```powershell
 Set-ExecutionPolicy -Scope Process Bypass
 {windows_command}
 ```
 
-Portable CLI commands can also be run from this folder:
+If `OPENROUTER_API_KEY` is present and no local config exists, the launcher
+writes an OpenRouter env-reference config and starts the gateway without asking
+you to paste the key.
+
+The portable package does not install a global `opensquilla` command. For a
+terminal where `opensquilla ...` commands work, double-click
+`OpenSquilla Shell.cmd`, or run commands from this folder:
 
 ```powershell
 .\\opensquilla.cmd onboard
 ```
 
-Keep the terminal open. Closing the terminal stops the gateway.
+</details>
 """
         else:
             command_section = f"""## Windows PowerShell
@@ -1146,12 +1151,33 @@ Set-ExecutionPolicy -Scope Process Bypass
 ```
 """
     else:
-        command_section = f"""## macOS / Linux
+        if portable:
+            command_section = f"""## macOS / Linux
+
+1. Run the launcher from the extracted folder:
+
+```sh
+{unix_commands}
+```
+
+2. Keep the terminal open. Closing the terminal stops the gateway.
+3. Complete onboarding. On first run, choose a provider and paste the requested
+   keys; later starts let you review or change the config.
+4. Open `http://127.0.0.1:18790/control/`.
+"""
+        else:
+            command_section = f"""## macOS / Linux
 
 ```sh
 {unix_commands}
 ```
 """
+
+    web_ui_note = (
+        ""
+        if portable
+        else "Open `http://127.0.0.1:18790/control/`.\n\n"
+    )
 
     return f"""# OpenSquilla {app_version} {release_kind}
 
@@ -1161,11 +1187,9 @@ Build target:
 - Python: `{python_major}.{python_minor}`
 - profile: `{profile}`
 
-{command_section}
+{command_section.rstrip()}
 
-Open `http://127.0.0.1:18790/control/`.
-
-{python_note}
+{web_ui_note}{python_note}
 
 {setup_note}
 """

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -86,9 +86,9 @@ def test_readme_splits_user_paths_and_documents_preview_release_package() -> Non
     )
     assert "| Developer | [Develop from source](#develop-from-source) | Available now |" in readme
     assert (
-        "Use this path if you want to try OpenSquilla as a local app without "
-        "cloning the repository or installing Git, Git LFS, or `uv`."
-        in normalized
+        "Download the preview package if you want to try OpenSquilla as a "
+        "local app without cloning the repository or installing Git, Git LFS, "
+        "or `uv`." in normalized
     )
     assert "Current preview packages:" in readme
     assert "windows-x64-py312-recommended-portable.zip" in readme

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -638,7 +638,7 @@ def test_readme_distinguishes_recommended_profile_from_channel_extras() -> None:
         "| Command-line user | [Install from source](#install-from-source) | Available now |"
     ) in readme
     assert "| Developer | [Develop from source](#develop-from-source) | Available now |" in readme
-    assert "Use this path if you want to try OpenSquilla as a local app" in readme
+    assert "Download the preview package if you want to try OpenSquilla as a local app" in readme
     assert "The recommended portable zip includes Feishu websocket support by default." in readme
     assert "`recommended` is the\nnormal runtime profile" in readme
     assert "Messaging channel adapters are opt-in extras." in readme

--- a/tests/test_scripts/test_build_wheelhouse_zip.py
+++ b/tests/test_scripts/test_build_wheelhouse_zip.py
@@ -469,13 +469,14 @@ def test_render_readme_is_platform_specific_for_windows_portable() -> None:
     assert "## macOS / Linux" not in readme
     assert "bash start.sh" not in readme
     assert "Python is bundled in this zip." in readme
-    assert "First run opens the configuration wizard" in readme
+    assert "Complete onboarding." in readme
     assert "The recommended portable package includes Feishu websocket support." in readme
+    assert "Advanced portable usage" in readme
     assert "OPENROUTER_API_KEY" in readme
-    assert "the launcher writes an OpenRouter env-reference config" in readme
-    assert "Later runs open the wizard again" in readme
+    assert "writes an OpenRouter env-reference config" in readme
+    assert "later starts let you review or change the config" in readme
     assert "skip setup when it is complete" not in readme
-    assert "do not install a global `opensquilla` command" in readme
+    assert "does not install a global `opensquilla` command" in readme
     assert (
         "Config, workspace, logs, memory, and runtime state use the normal "
         "user-level OpenSquilla directory." in readme
@@ -501,11 +502,11 @@ def test_render_readme_is_platform_specific_for_macos_portable() -> None:
     assert "## Windows PowerShell" not in readme
     assert ".\\start.ps1" not in readme
     assert "Python is bundled in this zip." in readme
-    assert "First run opens the configuration wizard" in readme
+    assert "Complete onboarding." in readme
     assert "The recommended portable package includes Feishu websocket support." in readme
-    assert "Later runs open the wizard again" in readme
+    assert "later starts let you review or change the config" in readme
     assert "skip setup when it is complete" not in readme
-    assert "do not install a global `opensquilla` command" in readme
+    assert "does not install a global `opensquilla` command" not in readme
     assert (
         "Config, workspace, logs, memory, and runtime state use the normal "
         "user-level OpenSquilla directory." in readme
@@ -646,9 +647,10 @@ def test_prepare_windows_portable_release_tree_includes_double_click_launcher(
     assert "opensquilla.cmd" in shell_text
     readme = (release_root / "README.md").read_text(encoding="utf-8")
     assert "Double-click `Start OpenSquilla.cmd`" in readme
-    assert "Double-click `OpenSquilla Shell.cmd`" in readme
+    assert "double-click\n`OpenSquilla Shell.cmd`" in readme
     assert ".\\opensquilla.cmd onboard" in readme
     assert "Closing the terminal stops the gateway." in readme
+    assert "Advanced portable usage" in readme
 
 
 def test_install_portable_wheelhouse_preinstalls_into_bundled_python(


### PR DESCRIPTION
## Summary
- Simplifies the Windows portable preview quick start.
- Keeps provider shortcut and portable command details in an advanced section.
- Aligns package README output and tests with the public README.

## Validation
- uv run pytest tests/test_scripts/test_build_wheelhouse_zip.py tests/test_install_scripts.py -q
- uv run ruff check scripts/build_wheelhouse_zip.py tests/test_scripts/test_build_wheelhouse_zip.py tests/test_install_scripts.py
- git diff --check origin/main..HEAD

## Release
No release package is published by this change.