### PR TITLE
Integrate automation controls and MCP bridge into dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: uv sync --extra dev --extra recommended --frozen
+        run: uv sync --extra dev --extra recommended --extra mcp --frozen
 
       - name: Lint
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "mypy>=1.10",
     "ruff>=0.5",
 ]
-mcp = ["mcp>=1.0"]
+mcp = ["mcp>=1.2.0"]
 memory = [
     "tiktoken>=0.5",
     "jieba>=0.42",

--- a/src/opensquilla/cli/agent_cmd.py
+++ b/src/opensquilla/cli/agent_cmd.py
@@ -123,6 +123,8 @@ async def run_agent_once(
     effective_model = model or _agent_model_from_config(cfg, agent_id)
     active_workspace = workspace or getattr(cfg, "workspace_dir", None)
     service_cfg = _with_agent_workspace_config(cfg, active_workspace) if active_workspace else cfg
+    if stateless or stateless_keep_project_rules:
+        service_cfg = _with_memory_source_config(service_cfg, "state")
     if effective_model:
         service_cfg = _with_agent_model_config(service_cfg, effective_model)
     if thinking:
@@ -161,10 +163,12 @@ async def run_agent_once(
     # ids), so non-main CLI invocations would write to the per-agent workspace
     # but the index would never see those writes.
     extra_agents = [agent_id] if agent_id and agent_id != "main" else None
+    seed_agent_workspaces = not (stateless or stateless_keep_project_rules)
     svc = await build_services(
         config=service_cfg,
         session_db_path=session_db_path,
         extra_agent_ids=extra_agents,
+        seed_agent_workspaces=seed_agent_workspaces,
     )
     assert svc.session_manager is not None
     session_key = canonicalize_session_key(session_id or f"agent:{agent_id}:main")
@@ -344,6 +348,23 @@ def _with_agent_workspace_config(config: Any, workspace: str) -> Any:
     setattr(copied, "workspace_dir", workspace)
     if memory is not None:
         setattr(copied, "memory", memory)
+    return copied
+
+
+def _with_memory_source_config(config: Any, source: str) -> Any:
+    memory = getattr(config, "memory", None)
+    if memory is None:
+        return config
+    if hasattr(memory, "model_copy"):
+        memory = memory.model_copy(update={"source": source})
+    else:
+        memory = copy.copy(memory)
+        setattr(memory, "source", source)
+
+    if hasattr(config, "model_copy"):
+        return config.model_copy(update={"memory": memory})
+    copied = copy.copy(config)
+    setattr(copied, "memory", memory)
     return copied
 
 

--- a/src/opensquilla/cli/agent_cmd.py
+++ b/src/opensquilla/cli/agent_cmd.py
@@ -15,6 +15,7 @@ from typing import Any
 import typer
 from rich.panel import Panel
 from rich.text import Text
+from typer.models import OptionInfo
 
 from opensquilla.cli.attachments import attachments_from_paths
 from opensquilla.cli.ui import console
@@ -30,10 +31,13 @@ class AgentRunResult:
     errors: list[dict[str, str]]
     workspace: str | None = None
     workspace_strict: bool = False
+    workspace_lockdown: bool = False
+    scratch_dir: str | None = None
     thinking: str | None = None
     transcript_path: str | None = None
     usage_path: str | None = None
     artifacts: list[dict[str, Any]] | None = None
+    routing: dict[str, Any] | None = None
 
 
 def _cli_sender_id() -> str:
@@ -64,6 +68,12 @@ def _public_artifacts(artifacts: list[dict[str, Any]] | None) -> list[dict[str, 
     return [artifact_payload(artifact) for artifact in artifacts or []]
 
 
+def _unwrap_typer_default(value: Any) -> Any:
+    if isinstance(value, OptionInfo):
+        return value.default
+    return value
+
+
 async def run_agent_once(
     *,
     message: str,
@@ -83,6 +93,10 @@ async def run_agent_once(
     attachments: list[dict[str, Any]] | None = None,
     attachment_paths: list[str] | tuple[str, ...] | None = None,
     unattended: bool = True,
+    stateless: bool = False,
+    stateless_keep_project_rules: bool = False,
+    scratch_dir: str | None = None,
+    workspace_lockdown: bool = False,
     permissions: str | None = None,
 ) -> AgentRunResult:
     """Run a single agent turn through build_services() and TurnRunner.run()."""
@@ -131,6 +145,15 @@ async def run_agent_once(
         tool_workspace_dir = str(resolved_path)
     else:
         tool_workspace_dir = active_workspace
+    effective_scratch_dir: str | None = None
+    if scratch_dir:
+        scratch_path = Path(scratch_dir).expanduser().resolve(strict=False)
+        scratch_path.mkdir(parents=True, exist_ok=True)
+        effective_scratch_dir = str(scratch_path)
+    if workspace_lockdown and not tool_workspace_dir and not effective_scratch_dir:
+        raise ValueError(
+            "workspace_lockdown requires --workspace, configured workspace_dir, or --scratch-dir"
+        )
 
     # Hand the runtime agent_id to build_services so its memory store /
     # retriever / sync manager / turn capture are pre-built for that agent.
@@ -207,8 +230,15 @@ async def run_agent_once(
             workspace_dir=tool_workspace_dir,
             workspace_strict=effective_workspace_strict,
         )
+        tool_ctx.scratch_dir = effective_scratch_dir
+        tool_ctx.workspace_lockdown = workspace_lockdown
 
         runner = build_turn_runner_from_services(svc)
+        bootstrap_context_mode = _bootstrap_context_mode(
+            unattended=unattended,
+            stateless=stateless,
+            stateless_keep_project_rules=stateless_keep_project_rules,
+        )
 
         async for event in runner.run(
             message,
@@ -221,7 +251,7 @@ async def run_agent_once(
             history_has_persisted_user=True,
             no_memory_capture=no_memory_capture,
             attachments=run_attachments,
-            bootstrap_context_mode="unattended" if unattended else None,
+            bootstrap_context_mode=bootstrap_context_mode,
         ):
             if isinstance(event, TextDeltaEvent):
                 text_parts.append(event.text)
@@ -251,11 +281,50 @@ async def run_agent_once(
         errors=errors,
         workspace=tool_workspace_dir,
         workspace_strict=effective_workspace_strict,
+        workspace_lockdown=workspace_lockdown,
+        scratch_dir=effective_scratch_dir,
         thinking=thinking or getattr(getattr(service_cfg, "llm", None), "thinking", None),
         transcript_path=transcript_path,
         usage_path=usage_path,
         artifacts=artifacts,
+        routing=_routing_from_done(done),
     )
+
+
+def _bootstrap_context_mode(
+    *,
+    unattended: bool,
+    stateless: bool,
+    stateless_keep_project_rules: bool,
+) -> str | None:
+    if stateless_keep_project_rules:
+        return "stateless_keep_project_rules"
+    if stateless:
+        return "stateless"
+    if unattended:
+        return "unattended"
+    return None
+
+
+def _routing_from_done(done: Any | None) -> dict[str, Any] | None:
+    if done is None:
+        return None
+    routing = {
+        "routed_tier": getattr(done, "routed_tier", None),
+        "routing_source": getattr(done, "routing_source", "none"),
+        "routing_confidence": getattr(done, "routing_confidence", 0.0),
+        "baseline_model": getattr(done, "baseline_model", ""),
+        "routed_model": getattr(done, "routed_model", ""),
+    }
+    if (
+        routing["routed_tier"] is None
+        and routing["routing_source"] == "none"
+        and not routing["routing_confidence"]
+        and not routing["baseline_model"]
+        and not routing["routed_model"]
+    ):
+        return None
+    return routing
 
 
 def _with_agent_workspace_config(config: Any, workspace: str) -> Any:
@@ -528,6 +597,19 @@ def run_agent_command(
         "--workspace-strict/--no-workspace-strict",
         help="Restrict read-side file tools to --workspace",
     ),
+    workspace_lockdown: bool = typer.Option(
+        False,
+        "--workspace-lockdown",
+        help=(
+            "Opt in to automation write containment: writes must stay under "
+            "--workspace or --scratch-dir."
+        ),
+    ),
+    scratch_dir: str = typer.Option(
+        "",
+        "--scratch-dir",
+        help="Directory for temporary scripts, logs, debug output, and candidate patches.",
+    ),
     timeout: float | None = typer.Option(
         None, "--timeout", "-T", help="Total agent timeout in seconds (0=unlimited)"
     ),
@@ -570,6 +652,21 @@ def run_agent_command(
             "single-shot automation."
         ),
     ),
+    stateless: bool = typer.Option(
+        False,
+        "--stateless/--no-stateless",
+        help="Use clean-room prompt bootstrap; does not change --unattended semantics.",
+    ),
+    clean_room: bool = typer.Option(
+        False,
+        "--clean-room",
+        help="Alias for --stateless.",
+    ),
+    stateless_keep_project_rules: bool = typer.Option(
+        False,
+        "--stateless-keep-project-rules",
+        help="With clean-room bootstrap, keep AGENTS.md project rules only.",
+    ),
     permissions: str | None = typer.Option(
         None,
         "--permissions",
@@ -581,6 +678,29 @@ def run_agent_command(
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """Run a single agent turn for automation."""
+    message = _unwrap_typer_default(message)
+    agent_id = _unwrap_typer_default(agent_id)
+    session_id = _unwrap_typer_default(session_id)
+    model = _unwrap_typer_default(model)
+    workspace = _unwrap_typer_default(workspace)
+    workspace_strict = _unwrap_typer_default(workspace_strict)
+    workspace_lockdown = _unwrap_typer_default(workspace_lockdown)
+    scratch_dir = _unwrap_typer_default(scratch_dir)
+    timeout = _unwrap_typer_default(timeout)
+    max_iterations = _unwrap_typer_default(max_iterations)
+    thinking = _unwrap_typer_default(thinking)
+    transcript_path = _unwrap_typer_default(transcript_path)
+    usage_path = _unwrap_typer_default(usage_path)
+    session_db_path = _unwrap_typer_default(session_db_path)
+    no_memory_capture = _unwrap_typer_default(no_memory_capture)
+    file_paths = _unwrap_typer_default(file_paths)
+    unattended = _unwrap_typer_default(unattended)
+    stateless = _unwrap_typer_default(stateless)
+    clean_room = _unwrap_typer_default(clean_room)
+    stateless_keep_project_rules = _unwrap_typer_default(stateless_keep_project_rules)
+    permissions = _unwrap_typer_default(permissions)
+    json_output = _unwrap_typer_default(json_output)
+
     result = asyncio.run(
         run_agent_once(
             message=message,
@@ -589,6 +709,8 @@ def run_agent_command(
             model=model or None,
             workspace=workspace or None,
             workspace_strict=workspace_strict,
+            workspace_lockdown=workspace_lockdown,
+            scratch_dir=scratch_dir or None,
             thinking=thinking or None,
             timeout=timeout,
             max_iterations=max_iterations,
@@ -596,8 +718,10 @@ def run_agent_command(
             usage_path=usage_path or None,
             session_db_path=session_db_path,
             no_memory_capture=no_memory_capture,
-            attachment_paths=file_paths,
+            attachment_paths=list(file_paths or []),
             unattended=unattended,
+            stateless=stateless or clean_room,
+            stateless_keep_project_rules=stateless_keep_project_rules,
             permissions=permissions,
         )
     )
@@ -611,6 +735,9 @@ def run_agent_command(
         "errors": result.errors,
         "workspace": result.workspace,
         "workspace_strict": result.workspace_strict,
+        "workspace_lockdown": result.workspace_lockdown,
+        "scratch_dir": result.scratch_dir,
+        "routing": result.routing,
         "thinking": result.thinking,
         "transcript_path": result.transcript_path,
         "usage_path": result.usage_path,

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -20,8 +20,8 @@ from opensquilla.cli.cron_cmd import cron_app  # noqa: E402
 from opensquilla.cli.diagnostics_cmd import diagnostics_app  # noqa: E402
 from opensquilla.cli.dist_cmd import app as dist_app  # noqa: E402
 from opensquilla.cli.init_cmd import init_command  # noqa: E402
-from opensquilla.cli.memory_flush_cmd import memory_flush_session_cmd  # noqa: E402
 from opensquilla.cli.mcp_server_cmd import app as mcp_server_app  # noqa: E402
+from opensquilla.cli.memory_flush_cmd import memory_flush_session_cmd  # noqa: E402
 from opensquilla.cli.models_cmd import app as models_app  # noqa: E402
 from opensquilla.cli.onboard_cmd import configure_command, onboard_command  # noqa: E402
 from opensquilla.cli.providers_cmd import providers_app  # noqa: E402

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -21,6 +21,7 @@ from opensquilla.cli.diagnostics_cmd import diagnostics_app  # noqa: E402
 from opensquilla.cli.dist_cmd import app as dist_app  # noqa: E402
 from opensquilla.cli.init_cmd import init_command  # noqa: E402
 from opensquilla.cli.memory_flush_cmd import memory_flush_session_cmd  # noqa: E402
+from opensquilla.cli.mcp_server_cmd import app as mcp_server_app  # noqa: E402
 from opensquilla.cli.models_cmd import app as models_app  # noqa: E402
 from opensquilla.cli.onboard_cmd import configure_command, onboard_command  # noqa: E402
 from opensquilla.cli.providers_cmd import providers_app  # noqa: E402
@@ -45,6 +46,7 @@ app.add_typer(cost_app, name="cost")
 app.add_typer(diagnostics_app, name="diagnostics")
 app.add_typer(cron_app, name="cron")
 app.add_typer(dist_app, name="dist")
+app.add_typer(mcp_server_app, name="mcp-server")
 app.add_typer(models_app, name="models")
 app.add_typer(providers_app, name="providers")
 app.add_typer(search_app, name="search")

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -16,8 +16,8 @@ from opensquilla.cli.agents_cmd import agents_app  # noqa: E402
 from opensquilla.cli.channels_cmd import channels_app  # noqa: E402
 from opensquilla.cli.config_cmd import app as config_app  # noqa: E402
 from opensquilla.cli.cost_cmd import app as cost_app  # noqa: E402
-from opensquilla.cli.diagnostics_cmd import diagnostics_app  # noqa: E402
 from opensquilla.cli.cron_cmd import cron_app  # noqa: E402
+from opensquilla.cli.diagnostics_cmd import diagnostics_app  # noqa: E402
 from opensquilla.cli.dist_cmd import app as dist_app  # noqa: E402
 from opensquilla.cli.init_cmd import init_command  # noqa: E402
 from opensquilla.cli.memory_flush_cmd import memory_flush_session_cmd  # noqa: E402
@@ -406,6 +406,19 @@ def agent(
         "--workspace-strict/--no-workspace-strict",
         help="Restrict read-side file tools to --workspace",
     ),
+    workspace_lockdown: bool = typer.Option(
+        False,
+        "--workspace-lockdown",
+        help=(
+            "Opt in to automation write containment: writes must stay under "
+            "--workspace or --scratch-dir."
+        ),
+    ),
+    scratch_dir: str = typer.Option(
+        "",
+        "--scratch-dir",
+        help="Directory for temporary scripts, logs, debug output, and candidate patches.",
+    ),
     timeout: float | None = typer.Option(
         None, "--timeout", "-T", help="Total agent timeout in seconds (0=unlimited)"
     ),
@@ -448,6 +461,21 @@ def agent(
             "single-shot automation."
         ),
     ),
+    stateless: bool = typer.Option(
+        False,
+        "--stateless/--no-stateless",
+        help="Use clean-room prompt bootstrap; does not change --unattended semantics.",
+    ),
+    clean_room: bool = typer.Option(
+        False,
+        "--clean-room",
+        help="Alias for --stateless.",
+    ),
+    stateless_keep_project_rules: bool = typer.Option(
+        False,
+        "--stateless-keep-project-rules",
+        help="With clean-room bootstrap, keep AGENTS.md project rules only.",
+    ),
     permissions: str | None = typer.Option(
         None,
         "--permissions",
@@ -466,6 +494,8 @@ def agent(
         model=model,
         workspace=workspace,
         workspace_strict=workspace_strict,
+        workspace_lockdown=workspace_lockdown,
+        scratch_dir=scratch_dir,
         thinking=thinking,
         timeout=timeout,
         max_iterations=max_iterations,
@@ -475,6 +505,9 @@ def agent(
         no_memory_capture=no_memory_capture,
         file_paths=file_paths,
         unattended=unattended,
+        stateless=stateless,
+        clean_room=clean_room,
+        stateless_keep_project_rules=stateless_keep_project_rules,
         permissions=permissions,
         json_output=json_output,
     )

--- a/src/opensquilla/cli/mcp_server_cmd.py
+++ b/src/opensquilla/cli/mcp_server_cmd.py
@@ -1,0 +1,33 @@
+"""CLI commands for running OpenSquilla as an inbound MCP server."""
+
+from __future__ import annotations
+
+import typer
+
+from opensquilla.cli.url_utils import normalize_gateway_url
+
+app = typer.Typer(help="Run the OpenSquilla MCP server bridge.")
+
+
+@app.command("run")
+def run_mcp_server(
+    gateway_url: str = typer.Option(
+        "ws://localhost:18790/ws",
+        "--gateway",
+        envvar="OPENSQUILLA_GATEWAY_URL",
+        help="OpenSquilla gateway URL to bridge to.",
+    ),
+) -> None:
+    """Run a stdio MCP server exposing OpenSquilla session workflows."""
+
+    from opensquilla.mcp_server.bridge import OpenSquillaMCPBridge
+    from opensquilla.mcp_server.server import create_mcp_server
+
+    bridge = OpenSquillaMCPBridge(gateway_url=normalize_gateway_url(gateway_url))
+    try:
+        mcp = create_mcp_server(bridge)
+    except RuntimeError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED, err=True)
+        raise typer.Exit(1) from exc
+
+    mcp.run(transport="stdio")

--- a/src/opensquilla/engine/fallback.py
+++ b/src/opensquilla/engine/fallback.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import random
+import re
 from dataclasses import dataclass, field
 from enum import StrEnum
 
@@ -14,6 +15,12 @@ class ProviderErrorKind(StrEnum):
     CONTEXT_OVERFLOW = "context_overflow"
     TRANSPORT_TRANSIENT = "transport_transient"
     UNKNOWN = "unknown"
+
+
+_TRANSIENT_HTTP_STATUS_RE = re.compile(
+    r"\b(?:http(?: status)?|status(?:[_ -]?code)?|error code|code)\s*[:=]?\s*"
+    r"(?:504|520|522|524)\b"
+)
 
 
 @dataclass
@@ -48,6 +55,8 @@ class FallbackPolicy:
             or "timeout" in msg
         )
         if transport_match:
+            return ProviderErrorKind.TRANSPORT_TRANSIENT
+        if _TRANSIENT_HTTP_STATUS_RE.search(msg):
             return ProviderErrorKind.TRANSPORT_TRANSIENT
         ctx_match = "context" in msg and (
             "exceed" in msg or "length" in msg or "too long" in msg or "overflow" in msg

--- a/src/opensquilla/engine/fallback.py
+++ b/src/opensquilla/engine/fallback.py
@@ -17,9 +17,20 @@ class ProviderErrorKind(StrEnum):
     UNKNOWN = "unknown"
 
 
+_GATEWAY_CODES = r"(?:504|520|522|523|524)"
+_GATEWAY_CONTEXT = r"(?:cloudflare|openrouter|upstream|gateway|backend)"
+_GATEWAY_ERROR_TERMS = (
+    r"(?:error|returned|returning|failed|failure|unreachable|timeout|timed out|"
+    r"overload(?:ed)?|bad gateway|origin)"
+)
 _TRANSIENT_HTTP_STATUS_RE = re.compile(
     r"\b(?:http(?: status)?|status(?:[_ -]?code)?|error code|code)\s*[:=]?\s*"
-    r"(?:504|520|522|524)\b"
+    rf"{_GATEWAY_CODES}\b"
+)
+_TRANSIENT_GATEWAY_CONTEXT_RE = re.compile(
+    rf"\b{_GATEWAY_CONTEXT}\b[^\n]{{0,80}}\b{_GATEWAY_ERROR_TERMS}\b[^\n]{{0,80}}\b{_GATEWAY_CODES}\b"
+    rf"|\b{_GATEWAY_CONTEXT}\b[^\n]{{0,80}}\b{_GATEWAY_CODES}\b[^\n]{{0,80}}\b{_GATEWAY_ERROR_TERMS}\b"
+    rf"|\b{_GATEWAY_CODES}\b[^\n]{{0,80}}\b{_GATEWAY_CONTEXT}\b[^\n]{{0,80}}\b{_GATEWAY_ERROR_TERMS}\b"
 )
 
 
@@ -56,7 +67,7 @@ class FallbackPolicy:
         )
         if transport_match:
             return ProviderErrorKind.TRANSPORT_TRANSIENT
-        if _TRANSIENT_HTTP_STATUS_RE.search(msg):
+        if _TRANSIENT_HTTP_STATUS_RE.search(msg) or _TRANSIENT_GATEWAY_CONTEXT_RE.search(msg):
             return ProviderErrorKind.TRANSPORT_TRANSIENT
         ctx_match = "context" in msg and (
             "exceed" in msg or "length" in msg or "too long" in msg or "overflow" in msg

--- a/src/opensquilla/engine/fallback.py
+++ b/src/opensquilla/engine/fallback.py
@@ -12,6 +12,7 @@ class ProviderErrorKind(StrEnum):
     AUTH_FAILURE = "auth_failure"
     OVERLOADED = "overloaded"
     CONTEXT_OVERFLOW = "context_overflow"
+    TRANSPORT_TRANSIENT = "transport_transient"
     UNKNOWN = "unknown"
 
 
@@ -34,6 +35,20 @@ class FallbackPolicy:
             return ProviderErrorKind.AUTH_FAILURE
         if "overload" in msg or "503" in msg or "502" in msg or "capacity" in msg:
             return ProviderErrorKind.OVERLOADED
+        transport_match = (
+            "request error" in msg
+            or "readtimeout" in msg
+            or "connecttimeout" in msg
+            or "connection reset" in msg
+            or "connection refused" in msg
+            or "connection attempts failed" in msg
+            or "network is unreachable" in msg
+            or "temporary failure" in msg
+            or "timed out" in msg
+            or "timeout" in msg
+        )
+        if transport_match:
+            return ProviderErrorKind.TRANSPORT_TRANSIENT
         ctx_match = "context" in msg and (
             "exceed" in msg or "length" in msg or "too long" in msg or "overflow" in msg
         )
@@ -51,6 +66,7 @@ class FallbackPolicy:
             ProviderErrorKind.RATE_LIMIT,
             ProviderErrorKind.OVERLOADED,
             ProviderErrorKind.CONTEXT_OVERFLOW,
+            ProviderErrorKind.TRANSPORT_TRANSIENT,
         )
         if kind in retryable:
             return True

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -2897,6 +2897,14 @@ class TurnRunner:
                 bootstrap_filenames = tuple(
                     name for name in bootstrap_filenames if name != "BOOTSTRAP.md"
                 )
+            elif bootstrap_context_mode == "stateless":
+                bootstrap_filenames = tuple(
+                    name for name in bootstrap_filenames if name == "TOOLS.md"
+                )
+            elif bootstrap_context_mode == "stateless_keep_project_rules":
+                bootstrap_filenames = tuple(
+                    name for name in bootstrap_filenames if name in {"AGENTS.md", "TOOLS.md"}
+                )
             loaded_workspace_files, bootstrap_report = load_workspace_files_budgeted_with_report(
                 str(bootstrap_workspace_dir),
                 per_file_max_chars=self._resolve_bootstrap_max_chars(),
@@ -2928,7 +2936,13 @@ class TurnRunner:
                     report=list(visible_bootstrap_report),
                 )
         memory_source_dir = self._resolve_memory_source_dir(agent_id)
-        private_memory_allowed = allows_private_memory_prompt_injection(session_key)
+        stateless_prompt = bootstrap_context_mode in {
+            "stateless",
+            "stateless_keep_project_rules",
+        }
+        private_memory_allowed = (
+            False if stateless_prompt else allows_private_memory_prompt_injection(session_key)
+        )
 
         # Use frozen snapshot if available, otherwise read from disk
         snap_key = (agent_id, session_key) if session_key else None
@@ -2947,7 +2961,9 @@ class TurnRunner:
             prompt_metadata["injected_workspace_files_count"] = len(workspace_files)
             prompt_metadata["bootstrap_files"] = visible_bootstrap_report
             if not private_memory_allowed:
-                prompt_metadata["memory_prompt_injection_skipped"] = "session-scope"
+                prompt_metadata["memory_prompt_injection_skipped"] = (
+                    "stateless" if stateless_prompt else "session-scope"
+                )
             prompt_metadata["retrieval_mode"] = "fts_only"
 
         soul_doc = parse_soul(workspace_files["SOUL.md"]) if "SOUL.md" in workspace_files else None

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -1003,6 +1003,7 @@ async def build_services(
     usage_tracker: Any = None,
     session_db_path: str = ":memory:",
     extra_agent_ids: list[str] | None = None,
+    seed_agent_workspaces: bool = True,
 ) -> ServiceContainer:
     """Initialize reusable services without any gateway-specific side effects.
 
@@ -1032,7 +1033,8 @@ async def build_services(
     from opensquilla.memory.embedding_resolver import resolve_memory_embedding
 
     resolve_memory_embedding(config.memory, local_available=lambda *_: False)
-    _ensure_configured_agent_workspaces(config, extra_agent_ids=extra_agent_ids)
+    if seed_agent_workspaces:
+        _ensure_configured_agent_workspaces(config, extra_agent_ids=extra_agent_ids)
 
     # Inject config into admin tool (needed by both gateway and standalone)
     from opensquilla.tools.builtin.admin import set_gateway_config

--- a/src/opensquilla/gateway_client.py
+++ b/src/opensquilla/gateway_client.py
@@ -1,0 +1,264 @@
+"""Reusable WebSocket RPC client for OpenSquilla gateway integrations."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from typing import Any, cast
+from urllib.parse import urlparse, urlunparse
+
+
+class GatewayRPCError(Exception):
+    """RPC failure returned by the OpenSquilla gateway."""
+
+    def __init__(
+        self,
+        method: str,
+        *,
+        code: str | None = None,
+        message: str = "RPC failed",
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        self.method = method
+        self.code = code
+        self.message = message
+        self.data = data
+        super().__init__(self.__str__())
+
+    def __str__(self) -> str:
+        code = f"{self.code}: " if self.code else ""
+        return f"{self.method} failed: {code}{self.message}"
+
+
+def normalize_gateway_url(url: str) -> str:
+    """Normalize user-supplied gateway URLs to websocket endpoints."""
+
+    stripped = url.strip()
+    if "://" in stripped:
+        parsed = urlparse(stripped)
+        scheme = parsed.scheme
+        netloc = parsed.netloc
+        path = parsed.path
+    else:
+        parsed = urlparse(f"//{stripped}")
+        scheme = "ws"
+        netloc = parsed.netloc
+        path = parsed.path
+
+    if scheme not in {"http", "https", "ws", "wss"}:
+        raise ValueError(f"Unsupported gateway URL scheme: {scheme!r}")
+
+    websocket_scheme = "wss" if scheme in {"https", "wss"} else "ws"
+    websocket_path = "/ws" if path in ("", "/") else path
+    return urlunparse((websocket_scheme, netloc, websocket_path, "", "", ""))
+
+
+class GatewayRPCClient:
+    """Small async gateway client for non-CLI adapters."""
+
+    def __init__(
+        self,
+        *,
+        scopes: list[str] | None = None,
+        request_timeout_s: float | None = 30.0,
+    ) -> None:
+        self.scopes = scopes or ["operator.read", "operator.write"]
+        self.request_timeout_s = request_timeout_s
+        self._ws: Any = None
+        self._recv_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self._pending: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self._listener_task: asyncio.Task[None] | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._heartbeat_interval = 48.0
+        self._connection_error: ConnectionError | None = None
+        self._closing = False
+
+    async def connect(self, url: str = "ws://localhost:18790/ws") -> None:
+        if self._ws is not None:
+            await self.close()
+        self._closing = False
+        self._connection_error = None
+        try:
+            import websockets
+        except ImportError as exc:  # pragma: no cover - dependency is part of base install.
+            raise RuntimeError("websockets package is required") from exc
+
+        self._ws = await websockets.connect(normalize_gateway_url(url))
+
+        try:
+            raw = await self._ws.recv()
+            challenge = json.loads(raw)
+            if challenge.get("type") != "event" or challenge.get("event") != "connect.challenge":
+                raise RuntimeError(f"Unexpected gateway handshake frame: {challenge}")
+
+            req_id = str(uuid.uuid4())
+            await self._ws.send(
+                json.dumps(
+                    {
+                        "type": "req",
+                        "id": req_id,
+                        "method": "connect",
+                        "params": {
+                            "minProtocol": 1,
+                            "maxProtocol": 3,
+                            "role": "operator",
+                            "scopes": self.scopes,
+                        },
+                    }
+                )
+            )
+
+            raw = await self._ws.recv()
+            hello = json.loads(raw)
+            if hello.get("type") != "hello-ok":
+                raise RuntimeError(f"Gateway handshake failed: {hello}")
+        except Exception:
+            await self._close_failed_connect()
+            raise
+
+        policy = hello.get("policy") if isinstance(hello.get("policy"), dict) else {}
+        self._heartbeat_interval = _heartbeat_interval_from_policy(policy)
+        self._listener_task = asyncio.create_task(self._listen())
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop(self._ws))
+
+    async def call(self, method: str, params: dict[str, Any] | None = None) -> Any:
+        if self._connection_error is not None:
+            raise self._connection_error
+        if self._ws is None:
+            raise ConnectionError("Gateway connection is not open")
+
+        req_id = str(uuid.uuid4())
+        loop = asyncio.get_event_loop()
+        fut: asyncio.Future[dict[str, Any]] = loop.create_future()
+        self._pending[req_id] = fut
+        try:
+            await self._ws.send(
+                json.dumps({"type": "req", "id": req_id, "method": method, "params": params})
+            )
+        except Exception as exc:
+            self._pending.pop(req_id, None)
+            err = self._mark_connection_failed(exc)
+            raise err from exc
+
+        try:
+            if self.request_timeout_s is None:
+                res = await fut
+            else:
+                res = await asyncio.wait_for(fut, timeout=self.request_timeout_s)
+        except TimeoutError as exc:
+            self._pending.pop(req_id, None)
+            raise TimeoutError(f"{method} timed out after {self.request_timeout_s:g}s") from exc
+        if not res.get("ok"):
+            err = res.get("error", {})
+            raise GatewayRPCError(
+                method,
+                code=err.get("code"),
+                message=err.get("message") or "RPC failed",
+                data=err.get("data") if isinstance(err.get("data"), dict) else None,
+            )
+        payload = res.get("payload")
+        return {} if payload is None else payload
+
+    async def list_sessions(self, limit: int = 50) -> dict[str, Any]:
+        return cast(dict[str, Any], await self.call("sessions.list", {"limit": limit}))
+
+    async def resolve_session(self, key: str) -> dict[str, Any]:
+        return cast(dict[str, Any], await self.call("sessions.resolve", {"key": key}))
+
+    async def session_history(self, session_key: str, limit: int = 1000) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            await self.call("chat.history", {"sessionKey": session_key, "limit": limit}),
+        )
+
+    async def recv_event(self, timeout: float | None = None) -> dict[str, Any]:
+        if timeout is None:
+            return await self._recv_queue.get()
+        return await asyncio.wait_for(self._recv_queue.get(), timeout=timeout)
+
+    async def close(self) -> None:
+        self._closing = True
+        for task in (self._heartbeat_task, self._listener_task):
+            if task is None:
+                continue
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        if self._ws is not None:
+            await self._ws.close()
+        self._ws = None
+        self._heartbeat_task = None
+        self._listener_task = None
+
+    async def _close_failed_connect(self) -> None:
+        ws = self._ws
+        self._ws = None
+        if ws is not None:
+            await ws.close()
+
+    async def _listen(self) -> None:
+        try:
+            async for raw in self._ws:
+                frame = json.loads(raw)
+                frame_type = frame.get("type")
+                if frame_type == "res":
+                    fut = self._pending.pop(frame["id"], None)
+                    if fut is not None and not fut.done():
+                        fut.set_result(frame)
+                elif frame_type == "event":
+                    await self._recv_queue.put(frame)
+                elif frame_type == "pong":
+                    continue
+            if not self._closing:
+                self._mark_connection_failed(ConnectionError("WebSocket connection closed"))
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._mark_connection_failed(exc)
+
+    async def _heartbeat_loop(self, ws: Any) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._heartbeat_interval)
+                if self._closing or ws is not self._ws:
+                    return
+                await ws.send('{"type":"ping"}')
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._mark_connection_failed(exc)
+
+    def _mark_connection_failed(self, exc: BaseException) -> ConnectionError:
+        if isinstance(exc, ConnectionError):
+            err = exc
+        else:
+            err = ConnectionError(f"Gateway connection lost: {exc}")
+        if self._connection_error is None:
+            self._connection_error = err
+        else:
+            err = self._connection_error
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.set_exception(err)
+        self._pending.clear()
+        current_task = asyncio.current_task()
+        for task in (self._heartbeat_task, self._listener_task):
+            if task is not None and task is not current_task and not task.done():
+                task.cancel()
+        return err
+
+
+def _heartbeat_interval_from_policy(policy: dict[str, Any]) -> float:
+    raw = policy.get("client_ws_keepalive_timeout_ms", 120_000)
+    try:
+        keepalive_ms = int(raw)
+    except (TypeError, ValueError):
+        keepalive_ms = 120_000
+    keepalive_s = max(0, keepalive_ms) / 1000.0
+    if keepalive_s <= 0.0:
+        keepalive_s = 120.0
+    minimum = 15.0 if keepalive_s > 15.0 else 0.05
+    return max(minimum, keepalive_s * 0.4)

--- a/src/opensquilla/mcp_server/__init__.py
+++ b/src/opensquilla/mcp_server/__init__.py
@@ -1,0 +1,11 @@
+"""Inbound MCP server bridge for OpenSquilla.
+
+This package exposes OpenSquilla sessions to external MCP clients. It is
+intentionally separate from :mod:`opensquilla.mcp`, which is the outbound MCP
+client integration used to import tools from external MCP servers.
+"""
+
+from opensquilla.mcp_server.bridge import OpenSquillaMCPBridge
+from opensquilla.mcp_server.server import create_mcp_server
+
+__all__ = ["OpenSquillaMCPBridge", "create_mcp_server"]

--- a/src/opensquilla/mcp_server/bridge.py
+++ b/src/opensquilla/mcp_server/bridge.py
@@ -1,0 +1,286 @@
+"""Gateway-backed implementation for the inbound OpenSquilla MCP bridge."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Callable
+from typing import Any, Protocol
+
+from opensquilla.gateway_client import normalize_gateway_url
+
+
+class GatewayClientLike(Protocol):
+    async def connect(self, url: str) -> None: ...
+
+    async def close(self) -> None: ...
+
+    async def list_sessions(self, limit: int = 50) -> dict[str, Any]: ...
+
+    async def resolve_session(self, key: str) -> dict[str, Any]: ...
+
+    async def session_history(self, session_key: str, limit: int = 1000) -> dict[str, Any]: ...
+
+    async def call(self, method: str, params: dict[str, Any] | None = None) -> Any: ...
+
+    async def recv_event(self, timeout: float | None = None) -> dict[str, Any]: ...
+
+
+def _default_gateway_client() -> GatewayClientLike:
+    from opensquilla.gateway_client import GatewayRPCClient
+
+    return GatewayRPCClient()
+
+
+class OpenSquillaMCPBridge:
+    """Small product bridge from MCP tools/resources to existing gateway RPCs."""
+
+    def __init__(
+        self,
+        *,
+        gateway_url: str | None = None,
+        gateway_client_factory: Callable[[], GatewayClientLike] = _default_gateway_client,
+    ) -> None:
+        raw_url = (
+            gateway_url
+            or os.environ.get("OPENSQUILLA_GATEWAY_URL")
+            or "ws://localhost:18790/ws"
+        )
+        self.gateway_url = normalize_gateway_url(raw_url)
+        self._gateway_client_factory = gateway_client_factory
+        self._client: GatewayClientLike | None = None
+
+    async def close(self) -> None:
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+
+    async def _ensure_client(self) -> GatewayClientLike:
+        if self._client is None:
+            client = self._gateway_client_factory()
+            await client.connect(self.gateway_url)
+            self._client = client
+        return self._client
+
+    async def conversations_list(self, limit: int = 50) -> dict[str, Any]:
+        client = await self._ensure_client()
+        return await client.list_sessions(limit=limit)
+
+    async def session_resolve(self, key: str) -> dict[str, Any]:
+        client = await self._ensure_client()
+        return await client.resolve_session(key)
+
+    async def messages_read(self, key: str, limit: int = 1000) -> dict[str, Any]:
+        client = await self._ensure_client()
+        return await client.session_history(key, limit=limit)
+
+    async def messages_send(
+        self,
+        key: str,
+        message: str,
+        *,
+        intent: str = "continue",
+        attachments: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        client = self._gateway_client_factory()
+        await client.connect(self.gateway_url)
+        try:
+            subscription = await self._subscribe_messages(client, key, since_stream_seq=None)
+            result = await client.call(
+                "sessions.send",
+                {
+                    "key": key,
+                    "message": message,
+                    "attachments": attachments or [],
+                    "intent": intent,
+                    "_source": {
+                        "caller_kind": "cli",
+                        "channel_kind": "cli",
+                        "channel_id": "mcp:bridge",
+                        "source_kind": "mcp",
+                        "source_name": "mcp_server",
+                    },
+                },
+            )
+            response = result if isinstance(result, dict) else {"result": result}
+            response["current_stream_seq"] = subscription.get("current_stream_seq")
+            response["replay_complete"] = subscription.get("replay_complete")
+            response["replay_gap_reason"] = subscription.get("replay_gap_reason")
+            return response
+        finally:
+            await client.close()
+
+    async def events_wait(
+        self,
+        key: str,
+        *,
+        since_stream_seq: int | None = None,
+        timeout_ms: int = 30_000,
+        max_events: int = 100,
+        terminal_only: bool = False,
+    ) -> dict[str, Any]:
+        client = self._gateway_client_factory()
+        await client.connect(self.gateway_url)
+        try:
+            subscription = await self._subscribe_messages(
+                client, key, since_stream_seq=since_stream_seq
+            )
+
+            events: list[dict[str, Any]] = []
+            current_stream_seq = int(
+                subscription.get("current_stream_seq") or since_stream_seq or 0
+            )
+            deadline = time.monotonic() + max(0, timeout_ms) / 1000
+            max_events = max(1, max_events)
+
+            while len(events) < max_events:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                try:
+                    frame = await client.recv_event(timeout=remaining)
+                except TimeoutError:
+                    break
+                normalized = _normalize_event_frame(frame)
+                payload = normalized.get("payload")
+                if not isinstance(payload, dict) or payload.get("session_key") != key:
+                    continue
+                event_name = str(normalized.get("event") or "")
+                stream_seq = payload.get("stream_seq")
+                if isinstance(stream_seq, int):
+                    current_stream_seq = max(current_stream_seq, stream_seq)
+                is_terminal = event_name in _TERMINAL_EVENTS
+                if not terminal_only or is_terminal:
+                    events.append({"event": event_name, "payload": payload})
+                if is_terminal:
+                    break
+
+            return {
+                "key": key,
+                "events": events,
+                "current_stream_seq": current_stream_seq,
+                "replay_complete": subscription.get("replay_complete"),
+                "replay_gap_reason": subscription.get("replay_gap_reason"),
+                "timed_out": not events or (events[-1]["event"] not in _TERMINAL_EVENTS),
+            }
+        finally:
+            await client.close()
+
+    async def transcript_jsonl(self, key: str, limit: int = 1000) -> str:
+        history = await self.messages_read(key, limit=limit)
+        messages = history.get("messages", []) if isinstance(history, dict) else []
+        rows = [_message_to_event(row) for row in messages if isinstance(row, dict)]
+        flattened: list[dict[str, Any]] = []
+        for row in rows:
+            if isinstance(row, list):
+                flattened.extend(row)
+            else:
+                flattened.append(row)
+        return "\n".join(json.dumps(row, ensure_ascii=False, default=str) for row in flattened)
+
+    async def _subscribe_messages(
+        self,
+        client: GatewayClientLike,
+        key: str,
+        *,
+        since_stream_seq: int | None,
+    ) -> dict[str, Any]:
+        result = await client.call(
+            "sessions.messages.subscribe",
+            {"key": key, "since_stream_seq": since_stream_seq},
+        )
+        return result if isinstance(result, dict) else {}
+
+
+_TERMINAL_EVENTS = {
+    "session.event.done",
+    "session.event.error",
+    "task.cancelled",
+    "task.failed",
+    "task.timeout",
+    "task.abandoned",
+}
+
+
+def _normalize_event_frame(frame: dict[str, Any]) -> dict[str, Any]:
+    if "event" in frame and "payload" in frame:
+        return frame
+    return {"event": frame.get("event"), "payload": frame.get("payload") or frame}
+
+
+def _message_to_event(message: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]]:
+    role = str(message.get("role") or "unknown")
+    timestamp = message.get("timestamp")
+    tool_calls = message.get("tool_calls") or []
+    if role == "assistant" and isinstance(tool_calls, list) and tool_calls:
+        return _assistant_tool_events(tool_calls, timestamp=timestamp)
+    return _message_event(
+        role,
+        [{"type": "text", "text": str(message.get("text") or "")}] if message.get("text") else [],
+        timestamp=timestamp,
+    )
+
+
+def _assistant_tool_events(
+    tool_calls: list[Any],
+    *,
+    timestamp: Any,
+) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    assistant_blocks: list[dict[str, Any]] = []
+    for segment in tool_calls:
+        if not isinstance(segment, dict):
+            continue
+        segment_type = segment.get("type")
+        if segment_type == "text":
+            text = segment.get("text")
+            if text:
+                assistant_blocks.append({"type": "text", "text": str(text)})
+        elif segment_type == "tool_use":
+            assistant_blocks.append(
+                {
+                    "type": "toolCall",
+                    "name": str(segment.get("name") or ""),
+                    "id": str(segment.get("tool_use_id") or ""),
+                    "arguments": segment.get("input") or {},
+                }
+            )
+        elif segment_type == "tool_result":
+            if assistant_blocks:
+                output.append(_message_event("assistant", assistant_blocks, timestamp=timestamp))
+                assistant_blocks = []
+            output.append(
+                _message_event(
+                    "toolResult",
+                    [{"type": "text", "text": str(segment.get("result") or "")}],
+                    timestamp=timestamp,
+                    tool_call_id=str(segment.get("tool_use_id") or ""),
+                    tool_name=str(segment.get("name") or ""),
+                    is_error=bool(segment.get("is_error", False)),
+                )
+            )
+    if assistant_blocks:
+        output.append(_message_event("assistant", assistant_blocks, timestamp=timestamp))
+    return output
+
+
+def _message_event(
+    role: str,
+    content: list[dict[str, Any]],
+    *,
+    timestamp: Any = None,
+    tool_call_id: str | None = None,
+    tool_name: str | None = None,
+    is_error: bool | None = None,
+) -> dict[str, Any]:
+    event: dict[str, Any] = {"type": "message", "message": {"role": role, "content": content}}
+    if timestamp is not None:
+        event["timestamp"] = timestamp
+    if tool_call_id is not None:
+        event["message"]["toolCallId"] = tool_call_id
+    if tool_name is not None:
+        event["message"]["toolName"] = tool_name
+    if is_error is not None:
+        event["message"]["isError"] = is_error
+    return event

--- a/src/opensquilla/mcp_server/server.py
+++ b/src/opensquilla/mcp_server/server.py
@@ -1,0 +1,94 @@
+"""FastMCP server factory for exposing OpenSquilla session workflows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from opensquilla.mcp_server.bridge import OpenSquillaMCPBridge
+
+
+def create_mcp_server(
+    bridge: OpenSquillaMCPBridge | None = None,
+    *,
+    name: str = "OpenSquilla",
+    fastmcp_cls: type[Any] | None = None,
+) -> Any:
+    """Create a FastMCP app with product-oriented OpenSquilla tools/resources."""
+
+    if fastmcp_cls is None:
+        try:
+            from mcp.server.fastmcp import FastMCP
+        except ImportError as exc:  # pragma: no cover - exercised through CLI behavior.
+            raise RuntimeError(
+                "The MCP server requires the optional dependency: install opensquilla[mcp]."
+            ) from exc
+        fastmcp_cls = FastMCP
+
+    bridge = bridge or OpenSquillaMCPBridge()
+    mcp = fastmcp_cls(name, json_response=True)
+
+    @mcp.tool(name="conversations_list")
+    async def conversations_list(limit: int = 50) -> dict[str, Any]:
+        """List OpenSquilla sessions visible to the connected gateway principal."""
+
+        return await bridge.conversations_list(limit=limit)
+
+    @mcp.tool(name="session_resolve")
+    async def session_resolve(key: str) -> dict[str, Any]:
+        """Resolve a session key or identifier to OpenSquilla session metadata."""
+
+        return await bridge.session_resolve(key)
+
+    @mcp.tool(name="messages_read")
+    async def messages_read(key: str, limit: int = 1000) -> dict[str, Any]:
+        """Read persisted messages for an OpenSquilla session."""
+
+        return await bridge.messages_read(key, limit=limit)
+
+    @mcp.tool(name="messages_send")
+    async def messages_send(key: str, message: str, intent: str = "continue") -> dict[str, Any]:
+        """Send a user message to an existing OpenSquilla session."""
+
+        return await bridge.messages_send(key, message, intent=intent)
+
+    @mcp.tool(name="events_wait")
+    async def events_wait(
+        key: str,
+        since_stream_seq: int | None = None,
+        timeout_ms: int = 30_000,
+        max_events: int = 100,
+        terminal_only: bool = False,
+    ) -> dict[str, Any]:
+        """Wait for live or replayed gateway events for an OpenSquilla session."""
+
+        return await bridge.events_wait(
+            key,
+            since_stream_seq=since_stream_seq,
+            timeout_ms=timeout_ms,
+            max_events=max_events,
+            terminal_only=terminal_only,
+        )
+
+    @mcp.tool(name="transcript_export")
+    async def transcript_export(key: str, limit: int = 1000) -> str:
+        """Export a session transcript as JSONL with standard tool evidence events."""
+
+        return await bridge.transcript_jsonl(key, limit=limit)
+
+    @mcp.resource("opensquilla://sessions")
+    async def sessions_resource() -> dict[str, Any]:
+        return await bridge.conversations_list()
+
+    @mcp.resource("opensquilla://sessions/{key}")
+    async def session_resource(key: str) -> dict[str, Any]:
+        return await bridge.session_resolve(key)
+
+    @mcp.resource("opensquilla://sessions/{key}/messages")
+    async def session_messages_resource(key: str) -> dict[str, Any]:
+        return await bridge.messages_read(key)
+
+    @mcp.resource("opensquilla://sessions/{key}/transcript.jsonl")
+    async def session_transcript_resource(key: str) -> str:
+        return await bridge.transcript_jsonl(key)
+
+    return mcp

--- a/src/opensquilla/provider/failures.py
+++ b/src/opensquilla/provider/failures.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from enum import StrEnum
 
 
@@ -52,6 +53,21 @@ _OPENAI_COMPAT_PROVIDERS = {
     "ovms",
 }
 
+_GATEWAY_TRANSIENT_STATUS_CODES = {502, 503, 504, 520, 522, 523, 524}
+_GATEWAY_CODES = r"(?:504|520|522|523|524)"
+_GATEWAY_CONTEXT = r"(?:cloudflare|openrouter|upstream|gateway|backend)"
+_GATEWAY_ERROR_TERMS = (
+    r"(?:error|returned|returning|failed|failure|unreachable|timeout|timed out|"
+    r"overload(?:ed)?|bad gateway|origin)"
+)
+_GATEWAY_TRANSIENT_RE = re.compile(
+    r"\b(?:http(?: status)?|status(?:[_ -]?code)?|error code|code)\s*[:=]?\s*"
+    rf"{_GATEWAY_CODES}\b"
+    rf"|\b{_GATEWAY_CONTEXT}\b[^\n]{{0,80}}\b{_GATEWAY_ERROR_TERMS}\b[^\n]{{0,80}}\b{_GATEWAY_CODES}\b"
+    rf"|\b{_GATEWAY_CONTEXT}\b[^\n]{{0,80}}\b{_GATEWAY_CODES}\b[^\n]{{0,80}}\b{_GATEWAY_ERROR_TERMS}\b"
+    rf"|\b{_GATEWAY_CODES}\b[^\n]{{0,80}}\b{_GATEWAY_CONTEXT}\b[^\n]{{0,80}}\b{_GATEWAY_ERROR_TERMS}\b"
+)
+
 
 def _joined(status_code: int | None, raw_code: str, message: str) -> str:
     return f"{status_code or ''} {raw_code or ''} {message or ''}".lower()
@@ -86,6 +102,10 @@ def _is_policy_refusal(text: str) -> bool:
     )
 
 
+def _is_gateway_transient(text: str) -> bool:
+    return bool(_GATEWAY_TRANSIENT_RE.search(text))
+
+
 def classify_provider_error(
     provider_name: str,
     status_code: int | None,
@@ -113,7 +133,11 @@ def classify_provider_error(
             return ProviderFailureKind.MODEL_NOT_FOUND
         if "does not support" in text or "unsupported" in text:
             return ProviderFailureKind.UNSUPPORTED_FEATURE
-        if status_code in {502, 503, 504} or "overloaded" in text or "upstream" in text:
+        if (
+            status_code in _GATEWAY_TRANSIENT_STATUS_CODES
+            or "overloaded" in text
+            or _is_gateway_transient(text)
+        ):
             return ProviderFailureKind.PROVIDER_OVERLOADED
         if status_code == 400 or "invalid_request" in text:
             return ProviderFailureKind.BAD_REQUEST
@@ -141,7 +165,7 @@ def classify_provider_error(
 
     if status_code == 429 or "rate limit" in text:
         return ProviderFailureKind.RATE_LIMITED
-    if status_code in {502, 503, 504}:
+    if status_code in _GATEWAY_TRANSIENT_STATUS_CODES or _is_gateway_transient(text):
         return ProviderFailureKind.PROVIDER_OVERLOADED
     if "malformed" in text or "invalid json" in text:
         return ProviderFailureKind.MALFORMED_RESPONSE

--- a/src/opensquilla/tools/builtin/filesystem.py
+++ b/src/opensquilla/tools/builtin/filesystem.py
@@ -331,6 +331,40 @@ def _is_sensitive_access_path(resolved: Path) -> bool:
     return _context_elevated_mode() != "full" and is_sensitive_path(str(resolved)) is not None
 
 
+def _workspace_lockdown_roots() -> list[Path]:
+    ctx = current_tool_context.get()
+    if ctx is None or not ctx.workspace_lockdown:
+        return []
+    roots: list[Path] = []
+    if ctx.workspace_dir:
+        roots.append(Path(ctx.workspace_dir).expanduser().resolve(strict=False))
+    if ctx.scratch_dir:
+        roots.append(Path(ctx.scratch_dir).expanduser().resolve(strict=False))
+    return roots
+
+
+def _inside_any_root(candidate: Path, roots: list[Path]) -> bool:
+    resolved = candidate.expanduser().resolve(strict=False)
+    for root in roots:
+        try:
+            resolved.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _gate_workspace_lockdown_write(tool_name: str, resolved: Path, original_path: str) -> None:
+    roots = _workspace_lockdown_roots()
+    if not roots or _inside_any_root(resolved, roots):
+        return
+    allowed = ", ".join(str(root) for root in roots)
+    raise ToolError(
+        f"{tool_name} blocked by workspace lockdown: {original_path} resolves to "
+        f"{resolved}, outside allowed roots: {allowed}."
+    )
+
+
 async def _gate_out_of_workspace_write(
     tool_name: str,
     resolved: Path,
@@ -356,6 +390,8 @@ async def _gate_out_of_workspace_write(
             return build_block_envelope(
                 f"{tool_name} {original_path}", sensitive, tool_name=tool_name
             )
+
+    _gate_workspace_lockdown_write(tool_name, resolved, original_path)
 
     if not _is_outside_workspace(resolved):
         return None

--- a/src/opensquilla/tools/builtin/shell.py
+++ b/src/opensquilla/tools/builtin/shell.py
@@ -7,6 +7,7 @@ import contextlib
 import contextvars
 import json
 import os
+import re
 import signal
 import time
 import uuid
@@ -188,6 +189,72 @@ def _sensitive_shell_block(
     marker = _sensitive_body_marker(checked_text)
     if marker is not None:
         return _sensitive_body_block(tool_name, marker)
+    return None
+
+
+def _workspace_lockdown_roots() -> list[Path]:
+    ctx = current_tool_context.get()
+    if ctx is None or not ctx.workspace_lockdown:
+        return []
+    roots: list[Path] = []
+    if ctx.workspace_dir:
+        roots.append(Path(ctx.workspace_dir).expanduser().resolve(strict=False))
+    if ctx.scratch_dir:
+        roots.append(Path(ctx.scratch_dir).expanduser().resolve(strict=False))
+    return roots
+
+
+def _path_inside_any_root(path: Path, roots: list[Path]) -> bool:
+    candidate = path.expanduser().resolve(strict=False)
+    for root in roots:
+        try:
+            candidate.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _resolve_shell_write_target(raw_target: str, workdir: str | None) -> Path:
+    cleaned = raw_target.strip().strip("'\"")
+    path = Path(cleaned).expanduser()
+    if not path.is_absolute():
+        base = Path(workdir).expanduser() if workdir else Path.cwd()
+        path = base / path
+    return path.resolve(strict=False)
+
+
+def _workspace_lockdown_shell_block(
+    tool_name: str,
+    command: str,
+    workdir: str | None,
+) -> dict[str, object] | None:
+    roots = _workspace_lockdown_roots()
+    if not roots:
+        return None
+    targets: list[str] = []
+    redirection_pattern = r"(?:^|\s)(?:\d?>{1,2}|&>{1,2})\s*(['\"]?)([^'\"\s|&;]+)\1"
+    targets.extend(match.group(2) for match in re.finditer(redirection_pattern, command))
+    tee_pattern = r"(?:^|\s)tee(?:\s+-[A-Za-z]+)*\s+(['\"]?)([^'\"\s|&;]+)\1"
+    targets.extend(match.group(2) for match in re.finditer(tee_pattern, command))
+    for target in targets:
+        resolved = _resolve_shell_write_target(target, workdir)
+        if _path_inside_any_root(resolved, roots):
+            continue
+        return {
+            "status": "blocked",
+            "reason": "workspace_lockdown",
+            "tool": tool_name,
+            "command": command,
+            "target": target,
+            "resolved_path": str(resolved),
+            "allowed_roots": [str(root) for root in roots],
+            "message": (
+                f"{tool_name} blocked by workspace lockdown: shell write target "
+                f"{resolved} is outside allowed roots."
+            ),
+            "retryable": False,
+        }
     return None
 
 
@@ -397,6 +464,9 @@ async def exec_command(
     sensitive_block = _sensitive_shell_block("exec_command", command, workdir=cwd)
     if sensitive_block is not None:
         return sensitive_block
+    lockdown_block = _workspace_lockdown_shell_block("exec_command", command, cwd)
+    if lockdown_block is not None:
+        return json.dumps(lockdown_block, ensure_ascii=False)
 
     # Warnlist: two-step approval flow
     if result.needs_approval:
@@ -510,6 +580,9 @@ async def background_process(
     sensitive_block = _sensitive_shell_block("background_process", command, workdir=cwd)
     if sensitive_block is not None:
         return sensitive_block
+    lockdown_block = _workspace_lockdown_shell_block("background_process", command, cwd)
+    if lockdown_block is not None:
+        return json.dumps(lockdown_block, ensure_ascii=False)
     if result.needs_approval:
         prior_elevation = _approval_elevation_state()
         try:
@@ -965,6 +1038,16 @@ async def _check_exec_approval(
                 sensitive=sensitive,
             )
             return build_block_envelope(command, sensitive, tool_name=tool_name)
+
+    lockdown_block = _workspace_lockdown_shell_block(tool_name, command, workdir)
+    if lockdown_block is not None:
+        log.warning(
+            "shell_workspace_lockdown_blocked",
+            command=_audit_command(command),
+            tool=tool_name,
+            resolved_path=lockdown_block.get("resolved_path"),
+        )
+        return lockdown_block
 
     # /elevated full — trusted operator has taken explicit responsibility.
     # Approvals are skipped entirely.

--- a/src/opensquilla/tools/registry.py
+++ b/src/opensquilla/tools/registry.py
@@ -225,6 +225,23 @@ class ToolRegistry:
             "required": rt.spec.required,
         }
 
+    @staticmethod
+    def _description_for(rt: RegisteredTool, ctx: ToolContext) -> str:
+        description = rt.spec.description
+        scratch_dir = getattr(ctx, "scratch_dir", None)
+        if scratch_dir and rt.spec.name in {
+            "exec_command",
+            "write_file",
+            "edit_file",
+            "apply_patch",
+            "execute_code",
+        }:
+            description = (
+                f"{description} For temporary scripts, logs, debug output, and "
+                f"candidate patches, use the configured scratch directory: {scratch_dir}."
+            )
+        return description
+
     def to_tool_definitions(self, ctx: ToolContext | None = None) -> list[ToolDefinition]:
         """Export tools as MCP-compatible ToolDefinition list.
 
@@ -238,7 +255,7 @@ class ToolRegistry:
         return [
             ToolDefinition(
                 name=rt.spec.name,
-                description=rt.spec.description,
+                description=self._description_for(rt, active_ctx),
                 input_schema=ToolInputSchema(
                     type="object",
                     properties=rt.spec.parameters,
@@ -282,7 +299,7 @@ class ToolRegistry:
         return [
             {
                 "name": rt.spec.name,
-                "description": rt.spec.description,
+                "description": self._description_for(rt, ctx),
                 "schema": self._schema_for(rt),
                 "source": "plugin" if "." in rt.spec.name else "builtin",
                 "enabled": True,
@@ -310,7 +327,7 @@ class ToolRegistry:
         return [
             {
                 "name": rt.spec.name,
-                "description": rt.spec.description,
+                "description": self._description_for(rt, ctx),
                 "schema": self._schema_for(rt),
             }
             for rt in self._iter_visible_tools(ctx, sort=True)

--- a/src/opensquilla/tools/types.py
+++ b/src/opensquilla/tools/types.py
@@ -43,6 +43,8 @@ class ToolContext:
     workspace_dir: str | None = None
     memory_source_dir: str | None = None
     workspace_strict: bool = False
+    scratch_dir: str | None = None
+    workspace_lockdown: bool = False
     session_key: str | None = None
     channel_kind: str | None = None
     channel_id: str | None = None

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -20,6 +20,7 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     ("cli", "engine"),
     ("cli", "gateway"),
     ("cli", "memory"),
+    ("cli", "mcp_server"),
     ("cli", "observability"),
     ("cli", "onboarding"),
     ("cli", "sandbox"),

--- a/tests/test_cli/test_agent_cmd.py
+++ b/tests/test_cli/test_agent_cmd.py
@@ -604,6 +604,82 @@ async def test_run_agent_once_can_keep_project_rules_in_stateless_bootstrap(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stateless", "stateless_keep_project_rules"),
+    [
+        (True, False),
+        (False, True),
+    ],
+)
+async def test_run_agent_once_disables_workspace_template_seeding_for_stateless(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    stateless: bool,
+    stateless_keep_project_rules: bool,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeTurnRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def run(self, message: str, session_key: str, **kwargs: Any):
+            yield DoneEvent(text="ok", model=kwargs.get("model") or "")
+
+    async def fake_build_services(*, config: GatewayConfig, **kwargs: Any) -> _FakeServices:
+        captured.update(kwargs)
+        captured["config"] = config
+        return _FakeServices(config)
+
+    monkeypatch.setattr("opensquilla.engine.runtime.TurnRunner", FakeTurnRunner)
+    monkeypatch.setattr("opensquilla.gateway.build_services", fake_build_services)
+
+    await run_agent_once(
+        message="hello",
+        config=GatewayConfig(),
+        workspace=str(tmp_path),
+        stateless=stateless,
+        stateless_keep_project_rules=stateless_keep_project_rules,
+        no_memory_capture=True,
+    )
+
+    assert captured["seed_agent_workspaces"] is False
+    assert captured["config"].memory.source == "state"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_once_keeps_workspace_template_seeding_for_normal_runs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeTurnRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def run(self, message: str, session_key: str, **kwargs: Any):
+            yield DoneEvent(text="ok", model=kwargs.get("model") or "")
+
+    async def fake_build_services(*, config: GatewayConfig, **kwargs: Any) -> _FakeServices:
+        captured.update(kwargs)
+        captured["config"] = config
+        return _FakeServices(config)
+
+    monkeypatch.setattr("opensquilla.engine.runtime.TurnRunner", FakeTurnRunner)
+    monkeypatch.setattr("opensquilla.gateway.build_services", fake_build_services)
+
+    await run_agent_once(
+        message="hello",
+        config=GatewayConfig(),
+        workspace=str(tmp_path),
+    )
+
+    assert captured["seed_agent_workspaces"] is True
+    assert captured["config"].memory.source == "workspace"
+
+
+@pytest.mark.asyncio
 async def test_run_agent_once_passes_scratch_and_lockdown_to_tool_context(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,

--- a/tests/test_cli/test_agent_cmd.py
+++ b/tests/test_cli/test_agent_cmd.py
@@ -172,6 +172,118 @@ def test_run_agent_command_json_includes_artifacts(
     assert output_artifact["download_url"] == "/api/v1/artifacts/art-cli"
 
 
+def test_run_agent_command_direct_call_normalizes_typer_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_run_agent_once(**kwargs: Any) -> AgentRunResult:
+        captured.update(kwargs)
+        return AgentRunResult(
+            status="ok",
+            agent_id="main",
+            session_key="agent:main:main",
+            text="ok",
+            usage={},
+            errors=[],
+        )
+
+    monkeypatch.setattr("opensquilla.cli.agent_cmd.run_agent_once", fake_run_agent_once)
+
+    run_agent_command(message="hello")
+
+    assert captured["agent_id"] == "main"
+    assert captured["session_id"] == ""
+    assert captured["model"] is None
+    assert captured["workspace"] is None
+    assert captured["workspace_strict"] is None
+    assert captured["workspace_lockdown"] is False
+    assert captured["scratch_dir"] is None
+    assert captured["timeout"] is None
+    assert captured["max_iterations"] is None
+    assert captured["thinking"] is None
+    assert captured["transcript_path"] is None
+    assert captured["usage_path"] is None
+    assert captured["session_db_path"] == ":memory:"
+    assert captured["no_memory_capture"] is False
+    assert captured["attachment_paths"] == []
+    assert captured["unattended"] is True
+    assert captured["stateless"] is False
+    assert captured["stateless_keep_project_rules"] is False
+    assert captured["permissions"] is None
+
+
+def test_run_agent_command_json_includes_routing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_run_agent_once(**kwargs: Any) -> AgentRunResult:
+        result = AgentRunResult(
+            status="ok",
+            agent_id="main",
+            session_key="agent:main:main",
+            text="ok",
+            usage={},
+            errors=[],
+        )
+        result.routing = {  # type: ignore[attr-defined]
+            "routed_tier": "t2",
+            "routing_source": "v4_phase3",
+            "routing_confidence": 0.91,
+            "baseline_model": "openrouter/heavy",
+            "routed_model": "openrouter/light",
+        }
+        return result
+
+    monkeypatch.setattr("opensquilla.cli.agent_cmd.run_agent_once", fake_run_agent_once)
+
+    run_agent_command(message="hello", json_output=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["routing"] == {
+        "routed_tier": "t2",
+        "routing_source": "v4_phase3",
+        "routing_confidence": 0.91,
+        "baseline_model": "openrouter/heavy",
+        "routed_model": "openrouter/light",
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_agent_once_collects_done_routing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeTurnRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            return None
+
+        async def run(self, message: str, session_key: str, **kwargs: Any):
+            yield DoneEvent(
+                text="ok",
+                routed_tier="t2",
+                routing_source="v4_phase3",
+                routing_confidence=0.91,
+                baseline_model="openrouter/heavy",
+                routed_model="openrouter/light",
+            )
+
+    async def fake_build_services(*, config: GatewayConfig, **kwargs: Any) -> _FakeServices:
+        return _FakeServices(config)
+
+    monkeypatch.setattr("opensquilla.engine.runtime.TurnRunner", FakeTurnRunner)
+    monkeypatch.setattr("opensquilla.gateway.build_services", fake_build_services)
+
+    result = await run_agent_once(message="hello", config=GatewayConfig())
+
+    assert result.routing == {  # type: ignore[attr-defined]
+        "routed_tier": "t2",
+        "routing_source": "v4_phase3",
+        "routing_confidence": 0.91,
+        "baseline_model": "openrouter/heavy",
+        "routed_model": "openrouter/light",
+    }
+
+
 @pytest.mark.asyncio
 async def test_run_agent_once_explicit_model_overrides_agent_registry_model(
     monkeypatch: pytest.MonkeyPatch,
@@ -437,6 +549,105 @@ async def test_run_agent_once_can_opt_into_interactive_single_shot(
 
 
 @pytest.mark.asyncio
+async def test_run_agent_once_can_opt_into_stateless_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeTurnRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def run(self, message: str, session_key: str, **kwargs: Any):
+            captured["bootstrap_context_mode"] = kwargs.get("bootstrap_context_mode")
+            yield DoneEvent(text="ok", model=kwargs.get("model") or "")
+
+    async def fake_build_services(*, config: GatewayConfig, **kwargs: Any) -> _FakeServices:
+        return _FakeServices(config)
+
+    monkeypatch.setattr("opensquilla.engine.runtime.TurnRunner", FakeTurnRunner)
+    monkeypatch.setattr("opensquilla.gateway.build_services", fake_build_services)
+
+    await run_agent_once(message="hello", config=GatewayConfig(), stateless=True)
+
+    assert captured["bootstrap_context_mode"] == "stateless"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_once_can_keep_project_rules_in_stateless_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeTurnRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def run(self, message: str, session_key: str, **kwargs: Any):
+            captured["bootstrap_context_mode"] = kwargs.get("bootstrap_context_mode")
+            yield DoneEvent(text="ok", model=kwargs.get("model") or "")
+
+    async def fake_build_services(*, config: GatewayConfig, **kwargs: Any) -> _FakeServices:
+        return _FakeServices(config)
+
+    monkeypatch.setattr("opensquilla.engine.runtime.TurnRunner", FakeTurnRunner)
+    monkeypatch.setattr("opensquilla.gateway.build_services", fake_build_services)
+
+    await run_agent_once(
+        message="hello",
+        config=GatewayConfig(),
+        stateless=True,
+        stateless_keep_project_rules=True,
+    )
+
+    assert captured["bootstrap_context_mode"] == "stateless_keep_project_rules"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_once_passes_scratch_and_lockdown_to_tool_context(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeTurnRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def run(self, message: str, session_key: str, **kwargs: Any):
+            captured["tool_context"] = kwargs.get("tool_context")
+            yield DoneEvent(text="ok", model=kwargs.get("model") or "")
+
+    async def fake_build_services(*, config: GatewayConfig, **kwargs: Any) -> _FakeServices:
+        return _FakeServices(config)
+
+    monkeypatch.setattr("opensquilla.engine.runtime.TurnRunner", FakeTurnRunner)
+    monkeypatch.setattr("opensquilla.gateway.build_services", fake_build_services)
+
+    scratch_dir = tmp_path / "scratch"
+    await run_agent_once(
+        message="hello",
+        config=GatewayConfig(),
+        scratch_dir=str(scratch_dir),
+        workspace_lockdown=True,
+    )
+
+    ctx = captured["tool_context"]
+    assert ctx.scratch_dir == str(scratch_dir)
+    assert ctx.workspace_lockdown is True
+
+
+@pytest.mark.asyncio
+async def test_run_agent_once_rejects_workspace_lockdown_without_allowed_roots() -> None:
+    with pytest.raises(ValueError, match="workspace_lockdown requires"):
+        await run_agent_once(
+            message="hello",
+            config=GatewayConfig(workspace_dir=None),
+            workspace_lockdown=True,
+        )
+
+
+@pytest.mark.asyncio
 async def test_run_agent_once_rejects_invalid_max_iterations() -> None:
     with pytest.raises(ValueError, match="max_iterations"):
         await run_agent_once(
@@ -633,3 +844,36 @@ def test_top_level_agent_command_accepts_permissions_option(
 
     assert result.exit_code == 0, result.output
     assert captured["permissions"] == "bypass"
+
+
+def test_top_level_agent_command_accepts_automation_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.cli.main import app
+
+    captured: dict[str, Any] = {}
+
+    def fake_run_agent_command(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("opensquilla.cli.main.run_agent_command", fake_run_agent_command)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "agent",
+            "--message",
+            "hello",
+            "--clean-room",
+            "--stateless-keep-project-rules",
+            "--scratch-dir",
+            "scratch",
+            "--workspace-lockdown",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["clean_room"] is True
+    assert captured["stateless_keep_project_rules"] is True
+    assert captured["scratch_dir"] == "scratch"
+    assert captured["workspace_lockdown"] is True

--- a/tests/test_engine/test_bootstrap_snapshot_invalidation.py
+++ b/tests/test_engine/test_bootstrap_snapshot_invalidation.py
@@ -95,6 +95,78 @@ def test_unattended_bootstrap_context_skips_only_bootstrap_md(tmp_path) -> None:
     assert {"AGENTS.md", "SOUL.md", "IDENTITY.md", "TOOLS.md", "USER.md"} <= filenames
 
 
+def test_stateless_bootstrap_context_skips_persona_memory_and_bootstrap(tmp_path) -> None:
+    for filename in (
+        "AGENTS.md",
+        "SOUL.md",
+        "IDENTITY.md",
+        "TOOLS.md",
+        "USER.md",
+        "MEMORY.md",
+        "HEARTBEAT.md",
+        "BOOTSTRAP.md",
+    ):
+        (tmp_path / filename).write_text(f"{filename} body\n", encoding="utf-8")
+    runner = TurnRunner(
+        provider_selector=None,
+        config=SimpleNamespace(
+            workspace_dir=str(tmp_path),
+            memory=SimpleNamespace(source="workspace"),
+            tools=SimpleNamespace(profile=None),
+        ),
+    )
+    metadata: dict[str, object] = {}
+
+    runner._assemble_prompt(
+        "main",
+        [],
+        session_key="agent:main:auto",
+        prompt_metadata=metadata,
+        bootstrap_context_mode="stateless",
+    )
+
+    report = metadata["bootstrap_files"]
+    filenames = {item.filename for item in report}  # type: ignore[attr-defined]
+    assert filenames == {"TOOLS.md"}
+    assert metadata["memory_md_present"] is False
+
+
+def test_stateless_keep_project_rules_preserves_only_agents_md(tmp_path) -> None:
+    for filename in (
+        "AGENTS.md",
+        "SOUL.md",
+        "IDENTITY.md",
+        "TOOLS.md",
+        "USER.md",
+        "MEMORY.md",
+        "HEARTBEAT.md",
+        "BOOTSTRAP.md",
+    ):
+        (tmp_path / filename).write_text(f"{filename} body\n", encoding="utf-8")
+    runner = TurnRunner(
+        provider_selector=None,
+        config=SimpleNamespace(
+            workspace_dir=str(tmp_path),
+            memory=SimpleNamespace(source="workspace"),
+            tools=SimpleNamespace(profile=None),
+        ),
+    )
+    metadata: dict[str, object] = {}
+
+    runner._assemble_prompt(
+        "main",
+        [],
+        session_key="agent:main:auto",
+        prompt_metadata=metadata,
+        bootstrap_context_mode="stateless_keep_project_rules",
+    )
+
+    report = metadata["bootstrap_files"]
+    filenames = {item.filename for item in report}  # type: ignore[attr-defined]
+    assert filenames == {"AGENTS.md", "TOOLS.md"}
+    assert metadata["memory_md_present"] is False
+
+
 def test_full_and_unattended_bootstrap_snapshots_use_distinct_keys(tmp_path) -> None:
     (tmp_path / "AGENTS.md").write_text("agents\n", encoding="utf-8")
     (tmp_path / "BOOTSTRAP.md").write_text("bootstrap\n", encoding="utf-8")

--- a/tests/test_mcp_server/test_bridge.py
+++ b/tests/test_mcp_server/test_bridge.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from opensquilla.mcp_server.bridge import OpenSquillaMCPBridge
+
+
+class FakeGatewayClient:
+    def __init__(self) -> None:
+        self.connected_url: str | None = None
+        self.closed = False
+        self.calls: list[tuple[str, dict[str, Any] | None]] = []
+        self.events: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def connect(self, url: str) -> None:
+        self.connected_url = url
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def list_sessions(self, limit: int = 50) -> dict[str, Any]:
+        self.calls.append(("sessions.list", {"limit": limit}))
+        return {"sessions": [{"key": "agent:main:main", "entry_count": 2}], "count": 1}
+
+    async def resolve_session(self, key: str) -> dict[str, Any]:
+        self.calls.append(("sessions.resolve", {"key": key}))
+        return {"key": key, "session_id": "sid-1", "agent_id": "main"}
+
+    async def session_history(self, session_key: str, limit: int = 1000) -> dict[str, Any]:
+        self.calls.append(("chat.history", {"sessionKey": session_key, "limit": limit}))
+        return {
+            "messages": [
+                {
+                    "id": "m1",
+                    "role": "user",
+                    "text": "hello",
+                    "timestamp": 1,
+                },
+                {
+                    "id": "m2",
+                    "role": "assistant",
+                    "text": "looked it up",
+                    "timestamp": 2,
+                    "tool_calls": [
+                        {
+                            "type": "tool_use",
+                            "tool_use_id": "tool-1",
+                            "name": "lookup",
+                            "input": {"q": "hello"},
+                        },
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool-1",
+                            "name": "lookup",
+                            "result": "world",
+                            "is_error": False,
+                        },
+                    ],
+                },
+            ]
+        }
+
+    async def call(self, method: str, params: dict[str, Any] | None = None) -> Any:
+        self.calls.append((method, params))
+        if method == "sessions.messages.subscribe":
+            return {
+                "subscribed": True,
+                "key": params["key"],
+                "current_stream_seq": 7,
+                "replay_complete": True,
+            }
+        if method == "sessions.send":
+            return {"status": "accepted", "key": params["key"], "task_id": "task-1"}
+        raise AssertionError(f"unexpected method: {method}")
+
+    async def recv_event(self, timeout: float | None = None) -> dict[str, Any]:
+        if timeout is None:
+            return await self.events.get()
+        return await asyncio.wait_for(self.events.get(), timeout=timeout)
+
+
+@pytest.mark.asyncio
+async def test_bridge_reuses_gateway_read_rpcs() -> None:
+    client = FakeGatewayClient()
+    bridge = OpenSquillaMCPBridge(
+        gateway_url="ws://127.0.0.1:18790/ws",
+        gateway_client_factory=lambda: client,
+    )
+
+    sessions = await bridge.conversations_list(limit=10)
+    resolved = await bridge.session_resolve("agent:main:main")
+    messages = await bridge.messages_read("agent:main:main", limit=5)
+
+    assert client.connected_url == "ws://127.0.0.1:18790/ws"
+    assert sessions["sessions"][0]["key"] == "agent:main:main"
+    assert resolved["session_id"] == "sid-1"
+    assert messages["messages"][0]["text"] == "hello"
+    assert client.calls[:3] == [
+        ("sessions.list", {"limit": 10}),
+        ("sessions.resolve", {"key": "agent:main:main"}),
+        ("chat.history", {"sessionKey": "agent:main:main", "limit": 5}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_messages_send_subscribes_before_accepting_turn() -> None:
+    client = FakeGatewayClient()
+    bridge = OpenSquillaMCPBridge(gateway_client_factory=lambda: client)
+
+    result = await bridge.messages_send("agent:main:main", "continue", intent="continue")
+
+    assert result == {
+        "status": "accepted",
+        "key": "agent:main:main",
+        "task_id": "task-1",
+        "current_stream_seq": 7,
+        "replay_complete": True,
+        "replay_gap_reason": None,
+    }
+    assert client.closed is True
+    assert client.calls == [
+        ("sessions.messages.subscribe", {"key": "agent:main:main", "since_stream_seq": None}),
+        (
+            "sessions.send",
+            {
+                "key": "agent:main:main",
+                "message": "continue",
+                "attachments": [],
+                "intent": "continue",
+                "_source": {
+                    "caller_kind": "cli",
+                    "channel_kind": "cli",
+                    "channel_id": "mcp:bridge",
+                    "source_kind": "mcp",
+                    "source_name": "mcp_server",
+                },
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_events_wait_returns_session_events_until_terminal() -> None:
+    client = FakeGatewayClient()
+    await client.events.put(
+        {
+            "event": "session.event.text_delta",
+            "payload": {"session_key": "agent:main:main", "stream_seq": 8, "text": "hi"},
+        }
+    )
+    await client.events.put(
+        {
+            "event": "session.event.done",
+            "payload": {"session_key": "agent:main:main", "stream_seq": 9, "reason": "stop"},
+        }
+    )
+    bridge = OpenSquillaMCPBridge(gateway_client_factory=lambda: client)
+
+    result = await bridge.events_wait("agent:main:main", since_stream_seq=7, timeout_ms=1000)
+
+    assert result["current_stream_seq"] == 9
+    assert [event["event"] for event in result["events"]] == [
+        "session.event.text_delta",
+        "session.event.done",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transcript_jsonl_exports_standard_tool_evidence() -> None:
+    bridge = OpenSquillaMCPBridge(gateway_client_factory=FakeGatewayClient)
+
+    text = await bridge.transcript_jsonl("agent:main:main")
+    rows = [json.loads(line) for line in text.splitlines()]
+
+    assert rows[0]["message"]["role"] == "user"
+    assert rows[1]["message"]["role"] == "assistant"
+    assert rows[1]["message"]["content"][0]["type"] == "toolCall"
+    assert rows[1]["message"]["content"][0]["name"] == "lookup"
+    assert rows[2]["message"]["role"] == "toolResult"
+    assert rows[2]["message"]["toolCallId"] == "tool-1"
+
+
+def test_mcp_server_package_does_not_import_cli_layer() -> None:
+    package_root = Path("src/opensquilla/mcp_server")
+    imported_modules: set[str] = set()
+    for path in package_root.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported_modules.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported_modules.add(node.module)
+
+    assert not any(module.startswith("opensquilla.cli") for module in imported_modules)
+    assert not any(
+        module == "opensquilla.gateway" or module.startswith("opensquilla.gateway.")
+        for module in imported_modules
+    )
+
+
+@pytest.mark.asyncio
+async def test_events_wait_uses_dedicated_connection_and_closes_it() -> None:
+    clients: list[FakeGatewayClient] = []
+    event_client = FakeGatewayClient()
+
+    def factory() -> FakeGatewayClient:
+        if len(clients) == 1:
+            clients.append(event_client)
+            return event_client
+        client = FakeGatewayClient()
+        clients.append(client)
+        return client
+
+    bridge = OpenSquillaMCPBridge(gateway_client_factory=factory)
+    await bridge.conversations_list()
+    await clients[0].events.put(
+        {
+            "event": "session.event.done",
+            "payload": {"session_key": "agent:main:main", "stream_seq": 3},
+        }
+    )
+    await event_client.events.put(
+        {
+            "event": "session.event.done",
+            "payload": {"session_key": "agent:main:main", "stream_seq": 8},
+        }
+    )
+
+    result = await bridge.events_wait("agent:main:main", timeout_ms=1000)
+
+    assert len(clients) == 2
+    assert result["current_stream_seq"] == 8
+    assert clients[0].closed is False
+    assert event_client.closed is True

--- a/tests/test_mcp_server/test_cli.py
+++ b/tests/test_mcp_server/test_cli.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from opensquilla.cli.main import app
+
+
+def test_mcp_server_cli_help_exposes_real_bridge_without_benchmark_mode() -> None:
+    result = CliRunner().invoke(app, ["mcp-server", "run", "--help"])
+
+    assert result.exit_code == 0
+    assert "--gateway" in result.output
+    assert "stdio" in result.output.lower()
+    assert "--transport" not in result.output
+    assert "--host" not in result.output
+    assert "--port" not in result.output
+    assert "--allow-nonlocal" not in result.output
+    assert "benchmark" not in result.output.lower()
+    assert "mock" not in result.output.lower()

--- a/tests/test_mcp_server/test_cli.py
+++ b/tests/test_mcp_server/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import click
 from typer.testing import CliRunner
 
 from opensquilla.cli.main import app
@@ -7,13 +8,14 @@ from opensquilla.cli.main import app
 
 def test_mcp_server_cli_help_exposes_real_bridge_without_benchmark_mode() -> None:
     result = CliRunner().invoke(app, ["mcp-server", "run", "--help"])
+    output = click.unstyle(result.output)
 
     assert result.exit_code == 0
-    assert "--gateway" in result.output
-    assert "stdio" in result.output.lower()
-    assert "--transport" not in result.output
-    assert "--host" not in result.output
-    assert "--port" not in result.output
-    assert "--allow-nonlocal" not in result.output
-    assert "benchmark" not in result.output.lower()
-    assert "mock" not in result.output.lower()
+    assert "--gateway" in output
+    assert "stdio" in output.lower()
+    assert "--transport" not in output
+    assert "--host" not in output
+    assert "--port" not in output
+    assert "--allow-nonlocal" not in output
+    assert "benchmark" not in output.lower()
+    assert "mock" not in output.lower()

--- a/tests/test_mcp_server/test_fastmcp_app.py
+++ b/tests/test_mcp_server/test_fastmcp_app.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import tomllib
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from opensquilla.mcp_server.server import create_mcp_server
+
+
+class FakeFastMCP:
+    def __init__(self, name: str, **kwargs: Any) -> None:
+        self.name = name
+        self.kwargs = kwargs
+        self.tools: dict[str, Callable[..., Any]] = {}
+        self.resources: dict[str, Callable[..., Any]] = {}
+        self.run_calls: list[dict[str, Any]] = []
+
+    def tool(self, name: str | None = None):
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            self.tools[name or func.__name__] = func
+            return func
+
+        return decorator
+
+    def resource(self, uri: str):
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            self.resources[uri] = func
+            return func
+
+        return decorator
+
+    def run(self, **kwargs: Any) -> None:
+        self.run_calls.append(kwargs)
+
+
+class FakeBridge:
+    async def conversations_list(self, limit: int = 50) -> dict[str, Any]:
+        return {"sessions": [{"key": "agent:main:main"}], "limit": limit}
+
+    async def session_resolve(self, key: str) -> dict[str, Any]:
+        return {"key": key, "session_id": "sid-1"}
+
+    async def messages_read(self, key: str, limit: int = 1000) -> dict[str, Any]:
+        return {"messages": [{"role": "user", "text": key}], "limit": limit}
+
+    async def messages_send(
+        self, key: str, message: str, intent: str = "continue"
+    ) -> dict[str, Any]:
+        return {"status": "accepted", "key": key, "message": message, "intent": intent}
+
+    async def events_wait(
+        self,
+        key: str,
+        since_stream_seq: int | None = None,
+        timeout_ms: int = 30000,
+        max_events: int = 100,
+        terminal_only: bool = False,
+    ) -> dict[str, Any]:
+        return {
+            "key": key,
+            "since_stream_seq": since_stream_seq,
+            "timeout_ms": timeout_ms,
+            "max_events": max_events,
+            "terminal_only": terminal_only,
+            "events": [],
+        }
+
+    async def transcript_jsonl(self, key: str, limit: int = 1000) -> str:
+        return '{"type":"message","message":{"role":"user","content":[]}}'
+
+
+def test_create_mcp_server_registers_product_tools_and_resources() -> None:
+    app = create_mcp_server(FakeBridge(), fastmcp_cls=FakeFastMCP)
+
+    assert app.kwargs == {"json_response": True}
+    assert set(app.tools) == {
+        "conversations_list",
+        "session_resolve",
+        "messages_read",
+        "messages_send",
+        "events_wait",
+        "transcript_export",
+    }
+    assert set(app.resources) == {
+        "opensquilla://sessions",
+        "opensquilla://sessions/{key}",
+        "opensquilla://sessions/{key}/messages",
+        "opensquilla://sessions/{key}/transcript.jsonl",
+    }
+
+
+def test_create_mcp_server_has_no_benchmark_or_mock_public_tools() -> None:
+    app = create_mcp_server(FakeBridge(), fastmcp_cls=FakeFastMCP)
+
+    names = " ".join([*app.tools, *app.resources])
+    assert "benchmark" not in names
+    assert "mock" not in names
+
+
+def test_optional_mcp_dependency_minimum_supports_fastmcp() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    mcp_specs = pyproject["project"]["optional-dependencies"]["mcp"]
+
+    assert "mcp>=1.2.0" in mcp_specs

--- a/tests/test_mcp_server/test_gateway_client.py
+++ b/tests/test_mcp_server/test_gateway_client.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from opensquilla.gateway_client import GatewayRPCClient
+
+
+class _SilentWebSocket:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.closed = False
+
+    async def send(self, payload: str) -> None:
+        self.sent.append(json.loads(payload))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_gateway_rpc_call_times_out_and_clears_pending_request() -> None:
+    client = GatewayRPCClient(request_timeout_s=0.01)
+    client._ws = _SilentWebSocket()
+
+    with pytest.raises(TimeoutError, match="sessions.list timed out"):
+        await client.call("sessions.list", {"limit": 1})
+
+    assert client._pending == {}
+
+
+@pytest.mark.asyncio
+async def test_gateway_connect_closes_socket_after_bad_handshake(monkeypatch) -> None:
+    class BadHandshakeWebSocket(_SilentWebSocket):
+        async def recv(self) -> str:
+            return json.dumps({"type": "event", "event": "unexpected"})
+
+    ws = BadHandshakeWebSocket()
+
+    async def connect(_url: str):
+        return ws
+
+    monkeypatch.setitem(sys.modules, "websockets", SimpleNamespace(connect=connect))
+    client = GatewayRPCClient()
+
+    with pytest.raises(RuntimeError, match="Unexpected gateway handshake frame"):
+        await client.connect("ws://127.0.0.1:18790/ws")
+
+    assert ws.closed is True
+    assert client._ws is None

--- a/tests/test_mcp_server/test_protocol_smoke.py
+++ b/tests/test_mcp_server/test_protocol_smoke.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import textwrap
+import time
+import urllib.request
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import AnyUrl
+
+from opensquilla.mcp_server.bridge import OpenSquillaMCPBridge
+
+
+def _src_env(tmp_path: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    src_path = str(Path.cwd() / "src")
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = src_path if not existing else f"{src_path}{os.pathsep}{existing}"
+    env["OPENSQUILLA_STATE_DIR"] = str(tmp_path / "state")
+    env["OPENSQUILLA_LOG_DIR"] = str(tmp_path / "logs")
+    env["OPENSQUILLA_TURN_CALL_LOG"] = "0"
+    return env
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_health(port: int, process: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + 20.0
+    last_error = ""
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            stdout = process.stdout.read() if process.stdout else ""
+            stderr = process.stderr.read() if process.stderr else ""
+            raise AssertionError(
+                f"gateway exited early code={process.returncode}\nstdout={stdout}\nstderr={stderr}"
+            )
+        try:
+            with urllib.request.urlopen(  # noqa: S310 - localhost test probe.
+                f"http://127.0.0.1:{port}/health",
+                timeout=1.0,
+            ) as response:
+                if response.status == 200 and json.loads(response.read()).get("ok") is True:
+                    return
+        except Exception as exc:  # noqa: BLE001 - surfaced on timeout.
+            last_error = str(exc)
+        time.sleep(0.1)
+    raise AssertionError(f"gateway did not become healthy: {last_error}")
+
+
+def _stop_process(process: subprocess.Popen[str]) -> None:
+    process.terminate()
+    try:
+        process.wait(timeout=8)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=8)
+
+
+def _payload_from_tool_result(result: Any) -> dict[str, Any]:
+    structured = getattr(result, "structuredContent", None)
+    if isinstance(structured, dict):
+        return structured
+    content = getattr(result, "content", [])
+    text = getattr(content[0], "text", "") if content else ""
+    return json.loads(text)
+
+
+def _payload_from_resource_result(result: Any) -> dict[str, Any]:
+    contents = getattr(result, "contents", [])
+    text = getattr(contents[0], "text", "") if contents else ""
+    return json.loads(text)
+
+
+@pytest.mark.asyncio
+async def test_stdio_mcp_protocol_lists_calls_tools_and_reads_resources(tmp_path: Path) -> None:
+    session_mod = pytest.importorskip("mcp.client.session")
+    stdio_mod = pytest.importorskip("mcp.client.stdio")
+
+    server_script = tmp_path / "mcp_stdio_smoke_server.py"
+    server_script.write_text(
+        textwrap.dedent(
+            """
+            import anyio
+
+            from opensquilla.mcp_server.server import create_mcp_server
+
+
+            class FakeBridge:
+                async def conversations_list(self, limit=50):
+                    return {"sessions": [{"key": "demo", "displayName": "Demo"}], "limit": limit}
+
+                async def session_resolve(self, key):
+                    return {"key": key, "session_id": "demo"}
+
+                async def messages_read(self, key, limit=1000):
+                    return {"messages": [{"role": "user", "text": f"hello {key}"}], "limit": limit}
+
+                async def messages_send(self, key, message, intent="continue"):
+                    return {
+                        "status": "accepted",
+                        "key": key,
+                        "message": message,
+                        "intent": intent,
+                        "current_stream_seq": 1,
+                    }
+
+                async def events_wait(
+                    self,
+                    key,
+                    since_stream_seq=None,
+                    timeout_ms=30000,
+                    max_events=100,
+                    terminal_only=False,
+                ):
+                    return {
+                        "key": key,
+                        "events": [{"event": "session.event.done", "payload": {"stream_seq": 2}}],
+                        "current_stream_seq": 2,
+                        "timed_out": False,
+                    }
+
+                async def transcript_jsonl(self, key, limit=1000):
+                    return (
+                        '{"type":"message","message":{"role":"user",'
+                        '"content":[{"type":"text","text":"hello"}]}}'
+                    )
+
+
+            async def main():
+                await create_mcp_server(FakeBridge()).run_stdio_async()
+
+
+            anyio.run(main)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    params = stdio_mod.StdioServerParameters(
+        command=sys.executable,
+        args=[str(server_script)],
+        env=_src_env(tmp_path),
+        cwd=str(Path.cwd()),
+    )
+    with (tmp_path / "mcp-stderr.log").open("w", encoding="utf-8") as errlog:
+        async with stdio_mod.stdio_client(params, errlog=errlog) as (
+            read_stream,
+            write_stream,
+        ):
+            async with session_mod.ClientSession(
+                read_stream,
+                write_stream,
+                read_timeout_seconds=timedelta(seconds=10),
+            ) as session:
+                init = await session.initialize()
+                assert init.capabilities.tools is not None
+                assert init.capabilities.resources is not None
+
+                tools = await session.list_tools()
+                assert {
+                    "conversations_list",
+                    "session_resolve",
+                    "messages_read",
+                    "messages_send",
+                    "events_wait",
+                    "transcript_export",
+                }.issubset({tool.name for tool in tools.tools})
+
+                list_result = await session.call_tool("conversations_list", {"limit": 3})
+                assert list_result.isError is False
+                assert _payload_from_tool_result(list_result)["sessions"][0]["key"] == "demo"
+
+                send_result = await session.call_tool(
+                    "messages_send",
+                    {"key": "demo", "message": "from mcp smoke"},
+                )
+                assert send_result.isError is False
+                assert _payload_from_tool_result(send_result)["current_stream_seq"] == 1
+
+                resources = await session.list_resources()
+                assert "opensquilla://sessions" in {
+                    str(resource.uri) for resource in resources.resources
+                }
+
+                templates = await session.list_resource_templates()
+                assert "opensquilla://sessions/{key}/messages" in {
+                    str(template.uriTemplate) for template in templates.resourceTemplates
+                }
+
+                read_result = await session.read_resource(
+                    AnyUrl("opensquilla://sessions/demo/messages")
+                )
+                assert (
+                    _payload_from_resource_result(read_result)["messages"][0]["text"]
+                    == "hello demo"
+                )
+
+
+@pytest.mark.asyncio
+async def test_bridge_runs_against_real_gateway_websocket_session_flow(tmp_path: Path) -> None:
+    pytest.importorskip("uvicorn")
+    pytest.importorskip("websockets")
+
+    port = _free_port()
+    server_script = tmp_path / "gateway_mcp_smoke_server.py"
+    server_script.write_text(
+        textwrap.dedent(
+            f"""
+            import asyncio
+            import time
+            from dataclasses import dataclass
+            from types import SimpleNamespace
+
+            import uvicorn
+
+            from opensquilla.engine.types import DoneEvent, TextDeltaEvent
+            from opensquilla.gateway.app import create_gateway_app
+            from opensquilla.gateway.config import AuthConfig, GatewayConfig
+            from opensquilla.gateway.websocket import SubscriptionManager
+
+
+            @dataclass
+            class Session:
+                session_key: str = "agent:main:mcp-smoke"
+                session_id: str = "mcp-smoke"
+                status: str = "running"
+                agent_id: str = "main"
+                created_at: int = 1000
+                updated_at: int = 1000
+                display_name: str | None = "MCP smoke"
+                model: str | None = None
+                channel: str | None = None
+                chat_type: str = "unknown"
+                group_id: str | None = None
+                subject: str | None = None
+                last_channel: str | None = None
+                last_to: str | None = None
+                last_account_id: str | None = None
+                last_thread_id: str | None = None
+                delivery_context: dict | None = None
+                parent_session_key: str | None = None
+                spawned_by: str | None = None
+                origin: dict | None = None
+
+
+            class Storage:
+                def __init__(self):
+                    self.sessions = {{"agent:main:mcp-smoke": Session()}}
+                    self.transcripts = {{"mcp-smoke": []}}
+
+                async def list_sessions(self, limit=None):
+                    rows = list(self.sessions.values())
+                    return rows[:limit] if limit else rows
+
+                async def get_session(self, key):
+                    return self.sessions.get(key)
+
+                async def count_transcript_entries(self, session_id):
+                    return len(self.transcripts.get(session_id, []))
+
+                async def list_agent_tasks_for_sessions(self, session_keys, limit_per_session=100):
+                    return {{key: [] for key in session_keys}}
+
+                async def list_agent_tasks(
+                    self,
+                    session_key=None,
+                    status=None,
+                    limit=100,
+                    offset=0,
+                ):
+                    return []
+
+
+            class SessionManager:
+                def __init__(self):
+                    self._storage = Storage()
+                    self._epoch_cache = {{}}
+
+                async def create(self, session_key, agent_id="main", display_name=None, model=None):
+                    session = Session(
+                        session_key=session_key,
+                        session_id=session_key.rsplit(":", 1)[-1],
+                        agent_id=agent_id,
+                        display_name=display_name,
+                        model=model,
+                    )
+                    self._storage.sessions[session_key] = session
+                    self._storage.transcripts.setdefault(session.session_id, [])
+                    return session
+
+                async def append_message(self, key, role="user", content=""):
+                    session = self._storage.sessions[key]
+                    message_id = (
+                        f"msg-{{len(self._storage.transcripts[session.session_id]) + 1}}"
+                    )
+                    entry = SimpleNamespace(
+                        role=role,
+                        content=content,
+                        message_id=message_id,
+                        created_at=int(time.time() * 1000),
+                    )
+                    self._storage.transcripts.setdefault(session.session_id, []).append(entry)
+                    session.updated_at = entry.created_at
+                    return entry
+
+                async def get_transcript(self, key):
+                    session = self._storage.sessions.get(key)
+                    if session is None:
+                        return []
+                    return list(self._storage.transcripts.get(session.session_id, []))
+
+                async def apply_intent(self, key, intent, **kwargs):
+                    return self._storage.sessions[key], False
+
+
+            class TurnRunner:
+                def __init__(self):
+                    self._locks = {{}}
+
+                def get_session_lock(self, key):
+                    self._locks.setdefault(key, asyncio.Lock())
+                    return self._locks[key]
+
+                def run(self, message, key, **kwargs):
+                    async def events():
+                        yield TextDeltaEvent(text="gateway smoke delta")
+                        yield DoneEvent(text="gateway smoke done")
+
+                    return events()
+
+
+            config = GatewayConfig(
+                host="127.0.0.1",
+                port={port},
+                auth=AuthConfig(mode="none"),
+                state_dir=r"{str(tmp_path / "state")}",
+            )
+            app = create_gateway_app(
+                config,
+                session_manager=SessionManager(),
+                subscription_manager=SubscriptionManager(),
+                turn_runner=TurnRunner(),
+            )
+
+            uvicorn.run(app, host="127.0.0.1", port={port}, log_level="warning")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    process = subprocess.Popen(
+        [sys.executable, str(server_script)],
+        cwd=Path.cwd(),
+        env=_src_env(tmp_path),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    try:
+        _wait_for_health(port, process)
+        bridge = OpenSquillaMCPBridge(gateway_url=f"ws://127.0.0.1:{port}/ws")
+        try:
+            listed = await bridge.conversations_list(limit=5)
+            assert listed["sessions"][0]["key"] == "agent:main:mcp-smoke"
+
+            history_before = await bridge.messages_read("agent:main:mcp-smoke")
+            assert history_before["messages"] == []
+
+            send_result = await bridge.messages_send(
+                "agent:main:mcp-smoke",
+                "hello through real gateway",
+            )
+            assert send_result["status"] == "accepted"
+            assert isinstance(send_result["current_stream_seq"], int)
+
+            events = await bridge.events_wait(
+                "agent:main:mcp-smoke",
+                since_stream_seq=send_result["current_stream_seq"],
+                timeout_ms=5000,
+                terminal_only=True,
+            )
+            assert events["timed_out"] is False
+            assert events["events"][0]["event"] == "session.event.done"
+
+            history_after = await bridge.messages_read("agent:main:mcp-smoke")
+            assert history_after["messages"][0]["role"] == "user"
+            assert history_after["messages"][0]["text"] == "hello through real gateway"
+        finally:
+            await bridge.close()
+    finally:
+        _stop_process(process)

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -73,6 +73,24 @@ def test_agent_fallback_retries_transport_transient_errors(message: str) -> None
     assert policy.should_retry(kind, attempt=0) is True
 
 
+@pytest.mark.parametrize(
+    "message",
+    [
+        "HTTP 520: upstream provider returned an unknown error",
+        "HTTP 522",
+        "HTTP 524",
+        "HTTP 504",
+    ],
+)
+def test_agent_fallback_retries_gateway_transient_http_errors(message: str) -> None:
+    policy = FallbackPolicy(max_retries=2)
+
+    kind = policy.classify_error(message)
+
+    assert kind is ProviderErrorKind.TRANSPORT_TRANSIENT
+    assert policy.should_retry(kind, attempt=0) is True
+
+
 def test_agent_fallback_still_does_not_retry_auth_failures() -> None:
     policy = FallbackPolicy(max_retries=2)
 

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -78,8 +78,10 @@ def test_agent_fallback_retries_transport_transient_errors(message: str) -> None
     [
         "HTTP 520: upstream provider returned an unknown error",
         "HTTP 522",
+        "HTTP 523",
         "HTTP 524",
         "HTTP 504",
+        "status_code: 523",
     ],
 )
 def test_agent_fallback_retries_gateway_transient_http_errors(message: str) -> None:
@@ -89,6 +91,92 @@ def test_agent_fallback_retries_gateway_transient_http_errors(message: str) -> N
 
     assert kind is ProviderErrorKind.TRANSPORT_TRANSIENT
     assert policy.should_retry(kind, attempt=0) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Cloudflare returned 520",
+        "upstream returned 522",
+        "OpenRouter upstream error 520",
+        "provider backend returned 524",
+        "524 from backend failure",
+    ],
+)
+def test_agent_fallback_retries_gateway_context_transient_codes(message: str) -> None:
+    policy = FallbackPolicy(max_retries=2)
+
+    kind = policy.classify_error(message)
+
+    assert kind is ProviderErrorKind.TRANSPORT_TRANSIENT
+    assert policy.should_retry(kind, attempt=0) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "random value 520",
+        "line 520",
+        "520 tokens",
+        "issue 520",
+        "the provider sent 520 tokens",
+        "edge case 520",
+        "proxy line 520",
+        "gateway request id 520",
+        "openrouter model id 520",
+        "upstream metadata 520",
+        "Cloudflare is configured. " + ("x" * 120) + " value 520",
+    ],
+)
+def test_agent_fallback_does_not_retry_unscoped_gateway_numbers(message: str) -> None:
+    policy = FallbackPolicy(max_retries=2)
+
+    kind = policy.classify_error(message)
+
+    assert kind is ProviderErrorKind.UNKNOWN
+    assert policy.should_retry(kind, attempt=0) is False
+
+
+@pytest.mark.parametrize("provider", ["openrouter", "deepseek"])
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Cloudflare returned 520",
+        "upstream returned 522",
+        "OpenRouter upstream error 520",
+        "provider backend returned 524",
+        "HTTP 523",
+    ],
+)
+def test_provider_failure_classifies_gateway_transient_errors(
+    provider: str, message: str
+) -> None:
+    assert (
+        classify_provider_error(provider, None, message=message)
+        is ProviderFailureKind.PROVIDER_OVERLOADED
+    )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "random value 520",
+        "line 520",
+        "520 tokens",
+        "the provider sent 520 tokens",
+        "edge case 520",
+        "proxy line 520",
+        "gateway request id 520",
+        "openrouter model id 520",
+        "upstream metadata 520",
+        "Cloudflare is configured. " + ("x" * 120) + " value 520",
+    ],
+)
+def test_provider_failure_does_not_classify_unscoped_gateway_numbers(message: str) -> None:
+    assert (
+        classify_provider_error("openrouter", None, message=message)
+        is ProviderFailureKind.UNKNOWN
+    )
 
 
 def test_agent_fallback_still_does_not_retry_auth_failures() -> None:

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from opensquilla.engine.fallback import FallbackPolicy, ProviderErrorKind
 from opensquilla.provider.failures import ProviderFailureKind, classify_provider_error
 
 
@@ -52,3 +53,30 @@ def test_minimax_region_profiles_use_anthropic_failure_classification(provider: 
         classify_provider_error(provider, 401, raw_code="authentication_error")
         is ProviderFailureKind.AUTH_INVALID
     )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Request error: connection reset by peer",
+        "Request error: All connection attempts failed",
+        "ReadTimeout while contacting provider",
+        "ConnectTimeout while contacting provider",
+    ],
+)
+def test_agent_fallback_retries_transport_transient_errors(message: str) -> None:
+    policy = FallbackPolicy(max_retries=2)
+
+    kind = policy.classify_error(message)
+
+    assert kind is ProviderErrorKind.TRANSPORT_TRANSIENT
+    assert policy.should_retry(kind, attempt=0) is True
+
+
+def test_agent_fallback_still_does_not_retry_auth_failures() -> None:
+    policy = FallbackPolicy(max_retries=2)
+
+    kind = policy.classify_error("invalid api key")
+
+    assert kind is ProviderErrorKind.AUTH_FAILURE
+    assert policy.should_retry(kind, attempt=0) is False

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -252,6 +252,91 @@ async def test_unattended_bypass_allows_outside_workspace_write(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
+async def test_workspace_lockdown_blocks_outside_workspace_write_even_with_bypass(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    write_file = filesystem.write_file.__wrapped__.__wrapped__  # type: ignore[attr-defined]
+    with pytest.raises(ToolError, match="workspace lockdown"):
+        await write_file(str(outside), "ok")
+
+    assert not outside.exists()
+    assert len(get_approval_queue().list_pending("exec")) == 0
+
+
+@pytest.mark.asyncio
+async def test_workspace_lockdown_allows_configured_scratch_dir(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    scratch = tmp_path / "scratch"
+    workspace.mkdir()
+    scratch.mkdir()
+    target = scratch / "debug.py"
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.scratch_dir = str(scratch)  # type: ignore[attr-defined]
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    write_file = filesystem.write_file.__wrapped__.__wrapped__  # type: ignore[attr-defined]
+    result = await write_file(str(target), "print('ok')")
+
+    assert result.startswith("Written 11 bytes to ")
+    assert target.read_text(encoding="utf-8") == "print('ok')"
+
+
+def test_tool_definitions_include_scratch_guidance_when_configured(tmp_path: Path) -> None:
+    from opensquilla.tools.registry import get_default_registry
+
+    scratch = tmp_path / "scratch"
+    ctx = ToolContext(is_owner=True, scratch_dir=str(scratch))
+
+    tools = get_default_registry().to_tool_definitions(ctx)
+    descriptions = {tool.name: tool.description for tool in tools}
+
+    assert str(scratch) in descriptions["exec_command"]
+    assert str(scratch) in descriptions["write_file"]
+
+
+@pytest.mark.asyncio
+async def test_workspace_lockdown_blocks_obvious_outside_shell_redirection(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_lockdown = True  # type: ignore[attr-defined]
+
+    result = await shell._check_exec_approval(
+        "exec_command",
+        f"echo ok > {outside}",
+        str(workspace),
+        "command requires approval",
+        None,
+        False,
+    )
+
+    assert result is not None
+    assert result["status"] == "blocked"
+    assert result["reason"] == "workspace_lockdown"
+
+
+@pytest.mark.asyncio
 async def test_bypass_still_blocks_sensitive_shell_targets() -> None:
     ctx = current_tool_context.get()
     assert ctx is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1887,7 +1887,7 @@ requires-dist = [
     { name = "markdown", marker = "extra == 'matrix-e2e'", specifier = ">=3.0" },
     { name = "matrix-nio", marker = "extra == 'matrix'", specifier = ">=0.25,<0.26" },
     { name = "matrix-nio", extras = ["e2e"], marker = "extra == 'matrix-e2e'", specifier = ">=0.25,<0.26" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "numpy", marker = "extra == 'model-router'", specifier = ">=1.26" },
     { name = "numpy", marker = "extra == 'recommended'", specifier = ">=1.26" },


### PR DESCRIPTION
## Summary
- Merge `origin/feature/agent-automation-controls` into current `dev` to add explicit single-shot automation controls, workspace/scratch containment, benchmark transcript/usage output, shell/filesystem approval policy support, and provider failure classification.
- Merge `origin/feature/mcp-server-bridge` into current `dev` to add the optional FastMCP stdio bridge, reusable gateway RPC client, MCP CLI surface, and MCP protocol/resource tests.
- Add a narrow integration cleanup commit for `src/opensquilla/cli/main.py` import ordering after both CLI surfaces are present.

## Source branches
- `origin/feature/agent-automation-controls` at `61a17c2`
- `origin/feature/mcp-server-bridge` at `f72280d`
- Base: `origin/dev` at `668df3e`

## Verification
- `uv sync --extra dev --extra mcp --extra recommended`
- `uv run --no-sync python -m ruff check <changed-files>`: passed
- `uv run --no-sync python -m pytest tests/test_cli/test_agent_cmd.py tests/test_engine/test_bootstrap_snapshot_invalidation.py tests/test_provider_failure_classification.py tests/test_tools/test_shell_approval_policy.py tests/test_mcp_server tests/test_ci/test_architecture_import_contracts.py -q`: 138 passed
- `uv run --no-sync opensquilla --help`: shows `agent` and `mcp-server`
- `uv run --no-sync opensquilla mcp-server --help`: shows `run`
- `uv run --no-sync opensquilla agent --help`: shows automation flags including `--permissions`, `--scratch-dir`, `--usage-path`, and `--stateless`
- `uv run --no-sync python -m ruff check .`: passed
- `uv run --no-sync python -m pytest -q`: 2049 passed, 9 skipped, 2 warnings

## Notes
- `uv sync --all-extras` is not used on Windows here because `matrix-e2e` pulls `python-olm`, which requires native build tools (`cmake`/`make`). The full pytest run was done with `dev+mcp+recommended`, which covers the current full suite requirements without Matrix E2EE build tooling.
- After this PR is merged, `feature/agent-automation-controls` and `feature/mcp-server-bridge` can be treated as superseded once ancestor checks confirm their tips are contained in `dev`.