### PR TITLE
Trim preview package list and merge download steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,24 +41,14 @@ disabled` if you intentionally want to skip the bundled router.
 Download the preview package if you want to try OpenSquilla as a local app
 without cloning the repository or installing Git, Git LFS, or `uv`.
 
-Current preview packages:
+1. Download the package from the [GitHub Releases](https://github.com/opensquilla/opensquilla/releases)
+   page and extract it to Downloads, Documents, or another folder you can write to.
 
-- `OpenSquilla-<version>-windows-x64-py312-recommended-portable.zip` for
-  Windows.
-
-The recommended portable zip includes Feishu websocket support by default. If a
-package is not available for your platform, use the source install path below.
-
-1. Open the [GitHub Releases](https://github.com/opensquilla/opensquilla/releases)
-   page and download the package.
-
-2. Extract to Downloads, Documents, or another folder you can write to.
-
-3. Double-click `Start OpenSquilla.cmd` from the extracted folder.
+2. Double-click `Start OpenSquilla.cmd` from the extracted folder.
 
    Keep the terminal window open. Closing it stops the gateway.
 
-4. Complete onboarding and open the Web UI.
+3. Complete onboarding and open the Web UI.
 
    The launcher opens onboarding before the gateway starts. On first run, choose
    a provider and paste the requested keys; later starts let you review or change

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Download the preview package if you want to try OpenSquilla as a local app
 without cloning the repository or installing Git, Git LFS, or `uv`.
 
 1. Download the package from the [GitHub Releases](https://github.com/opensquilla/opensquilla/releases)
-   page and extract it to Downloads, Documents, or another folder you can write to.
+   page and extract it to a writable folder.
 
 2. Double-click `Start OpenSquilla.cmd` from the extracted folder.
 

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -90,8 +90,6 @@ def test_readme_splits_user_paths_and_documents_preview_release_package() -> Non
         "local app without cloning the repository or installing Git, Git LFS, "
         "or `uv`." in normalized
     )
-    assert "Current preview packages:" in readme
-    assert "windows-x64-py312-recommended-portable.zip" in readme
     assert "macos-arm64-py312-recommended-portable.zip" not in readme
     assert "recommended-wheelhouse.zip" not in release_section
     assert "Public release packages are not published yet." not in readme
@@ -116,7 +114,6 @@ def test_readme_documents_router_defaults_and_feishu_as_channel_extra() -> None:
     )
     assert "recommended` enables SquillaRouter" in readme
     assert "Install channel extras into the same user-local command" in readme
-    assert "The recommended portable zip includes Feishu websocket support by default." in readme
     assert "Feishu websocket channel support" in readme
     assert "Optional: add a channel adapter only if you need one." in readme
     assert "powershell -ExecutionPolicy Bypass -File .\\install.ps1 -Extras feishu" in readme

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -639,7 +639,6 @@ def test_readme_distinguishes_recommended_profile_from_channel_extras() -> None:
     ) in readme
     assert "| Developer | [Develop from source](#develop-from-source) | Available now |" in readme
     assert "Download the preview package if you want to try OpenSquilla as a local app" in readme
-    assert "The recommended portable zip includes Feishu websocket support by default." in readme
     assert "`recommended` is the\nnormal runtime profile" in readme
     assert "Messaging channel adapters are opt-in extras." in readme
     assert "Feishu is shown only\nas an example channel adapter" in readme


### PR DESCRIPTION
## Summary
- Drop the Windows-only "Current preview packages" list from the Preview release package section
- Merge the "download" and "extract" instructions into a single step

## Test plan
- [ ] Render README on GitHub and confirm the Preview release package section reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)