### PR TITLE
Implement macOS Seatbelt sandbox execution

### DIFF
--- a/src/opensquilla/sandbox/backend/__init__.py
+++ b/src/opensquilla/sandbox/backend/__init__.py
@@ -5,8 +5,7 @@ Three backends ship today:
 * :class:`~opensquilla.sandbox.backend.bubblewrap.BubblewrapBackend` — the Linux
   primary path; uses the ``bwrap`` binary for namespace isolation.
 * :class:`~opensquilla.sandbox.backend.seatbelt.SeatbeltBackend` — macOS
-  profile renderer. Exposes SBPL generation and an honest ``available()``
-  check but does not yet execute commands.
+  primary path; uses ``sandbox-exec`` with a generated SBPL profile.
 * :class:`~opensquilla.sandbox.backend.noop.NoopBackend` — used when the sandbox
   feature switch is off; runs the command through the existing rlimit
   wrapper and emits a warning on every invocation so the bypass is visible

--- a/src/opensquilla/sandbox/backend/seatbelt.py
+++ b/src/opensquilla/sandbox/backend/seatbelt.py
@@ -1,81 +1,447 @@
-"""macOS Seatbelt backend with SBPL profile rendering.
+"""macOS Seatbelt backend.
 
-This module deliberately renders profiles only and does not run commands yet.
-It keeps the backend abstraction, policy translation, and availability probe
-ready for future ``sandbox-exec`` execution support.
-
-The Seatbelt profile language (SBPL) is a TinyScheme-derived DSL. The
-baseline profile for opensquilla maps a :class:`SandboxPolicy` to three rules:
-
-1. ``(deny default)`` — start from a deny-by-default posture.
-2. ``(allow file-read* (subpath "<workspace>"))`` plus ``file-write*`` if
-   the policy has ``workspace_rw``.
-3. ``(deny network*)`` when ``policy.network == NetworkMode.NONE``.
-
-:func:`_render_sbpl_skeleton` returns the profile string so the unit test
-suite can assert shape without invoking ``sandbox-exec``. The runtime entry
-point :meth:`SeatbeltBackend.run` raises :class:`NotImplementedError`; the
-error message points at this file.
+Executes requests through ``sandbox-exec`` with a generated SBPL profile.
+Seatbelt is not a Linux namespace equivalent: paths stay as host paths, there
+is no PID/user namespace, and V1 intentionally supports only host network or
+no network. The profile is still deny-by-default for filesystem and network
+access, with explicit read/write allowances for the workspace, configured
+mounts, system runtime paths, and a backend-owned temporary directory.
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import logging
+import os
 import shutil
+import signal
 import sys
+import tempfile
+import time
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, cast
 
 from opensquilla.sandbox.backend.base import Backend
 from opensquilla.sandbox.types import (
     NetworkMode,
+    SandboxBackendError,
     SandboxPolicy,
     SandboxRequest,
     SandboxResult,
 )
 
-_SANDBOX_EXEC = "sandbox-exec"
+log = logging.getLogger(__name__)
+
+_SANDBOX_EXEC_NAME = "sandbox-exec"
+_SANDBOX_EXEC_SYSTEM_PATH = Path("/usr/bin/sandbox-exec")
+_OUTPUT_BYTE_CAP = 1_048_576
+_TERMINATE_GRACE_S = 2.0
+
+# Broad but explicit runtime reads needed for ordinary macOS command
+# execution. Every path here widens the sandbox, so keep the list boring.
+_BASE_RO_PATHS: tuple[Path, ...] = (
+    Path("/bin"),
+    Path("/sbin"),
+    Path("/usr/bin"),
+    Path("/usr/lib"),
+    Path("/System/Library"),
+    Path("/Library/Developer/CommandLineTools"),
+)
+_BREW_PREFIXES: tuple[Path, ...] = (Path("/opt/homebrew"), Path("/usr/local"))
 
 
-def _render_sbpl_skeleton(policy: SandboxPolicy) -> str:
-    """Render the three-rule SBPL profile for ``policy``.
+def _sandbox_exec_binary(binary: str | None = None) -> str | None:
+    if binary is not None:
+        return shutil.which(binary)
+    if _SANDBOX_EXEC_SYSTEM_PATH.exists():
+        return str(_SANDBOX_EXEC_SYSTEM_PATH)
+    return shutil.which(_SANDBOX_EXEC_NAME)
 
-    The output is intentionally small and readable: each rule is on its own
-    line so future execution support can extend it with additional allow rules
-    (cache dirs, homebrew prefix, etc.) without reformatting.
-    """
-    lines: list[str] = [
-        "(version 1)",
-        "(deny default)",
-    ]
+
+def _validate_mount_path(path: Path, *, kind: str) -> None:
+    if not path.is_absolute():
+        raise SandboxBackendError(f"{kind} path must be absolute: {path!r}")
+    if any(part == ".." for part in path.parts):
+        raise SandboxBackendError(f"{kind} path contains '..': {path!r}")
+
+
+def _validate_request(request: SandboxRequest) -> None:
+    if not request.argv:
+        raise SandboxBackendError("seatbelt request argv must not be empty")
+    _validate_mount_path(request.cwd, kind="cwd")
+    if not request.cwd.exists():
+        raise SandboxBackendError(f"cwd missing on host: {request.cwd!r}")
+    for spec in request.policy.mounts:
+        _validate_mount_path(spec.host_path, kind="host mount")
+        _validate_mount_path(spec.sandbox_path, kind="sandbox mount")
+        if spec.required and not spec.host_path.exists():
+            raise SandboxBackendError(f"required mount missing on host: {spec.host_path!r}")
+
+
+def _scheme_string(value: str) -> str:
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    return f'"{escaped}"'
+
+
+def _literal(path: Path) -> str:
+    return f"(literal {_scheme_string(str(path))})"
+
+
+def _subpath(path: Path) -> str:
+    return f"(subpath {_scheme_string(str(path))})"
+
+
+def _unique_existing(paths: Iterable[Path]) -> list[Path]:
+    seen: set[str] = set()
+    result: list[Path] = []
+    for path in paths:
+        candidates = [path]
+        try:
+            resolved = path.resolve(strict=False)
+        except OSError:
+            resolved = path
+        if resolved != path:
+            candidates.append(resolved)
+        for candidate in candidates:
+            key = str(candidate)
+            if key in seen or not candidate.exists():
+                continue
+            seen.add(key)
+            result.append(candidate)
+    return result
+
+
+def _parents_for(path: Path) -> list[Path]:
+    parents: list[Path] = []
+    current = path
+    if path.is_file():
+        current = path.parent
+    for parent in (current, *current.parents):
+        if parent == parent.parent:
+            break
+        parents.append(parent)
+    return list(reversed(parents))
+
+
+def _resolve_executable(argv0: str) -> Path | None:
+    candidate = Path(argv0)
+    if candidate.is_absolute():
+        return candidate.resolve(strict=False)
+    resolved = shutil.which(argv0)
+    if resolved is None:
+        return None
+    return Path(resolved).resolve(strict=False)
+
+
+def _is_under(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(parent.resolve(strict=False))
+    except ValueError:
+        return False
+    return True
+
+
+def _extra_runtime_read_paths(request: SandboxRequest) -> list[Path]:
+    paths: list[Path] = [request.cwd]
+    argv0 = Path(request.argv[0])
+    if argv0.is_absolute():
+        paths.append(argv0)
+        paths.extend(_parents_for(argv0))
+    exe = _resolve_executable(request.argv[0])
+    if exe is not None:
+        paths.append(exe)
+        paths.extend(_parents_for(exe))
+        for prefix in _BREW_PREFIXES:
+            if _is_under(exe, prefix):
+                paths.append(prefix)
+    return paths
+
+
+def _env_for_policy(
+    policy: SandboxPolicy,
+    override_env: dict[str, str],
+    *,
+    tmp_dir: Path | None,
+) -> dict[str, str]:
+    allowlist = set(policy.env_allowlist)
+    resolved: dict[str, str] = {}
+    for key in policy.env_allowlist:
+        value = os.environ.get(key)
+        if value is not None:
+            resolved[key] = value
+    for key, value in override_env.items():
+        if key not in allowlist:
+            log.debug("sandbox.seatbelt_env_override_rejected: key=%s", key)
+            continue
+        resolved[key] = value
+    if tmp_dir is not None:
+        resolved["TMPDIR"] = str(tmp_dir)
+    return resolved
+
+
+def _read_rules(paths: Iterable[Path]) -> list[str]:
+    rules: list[str] = []
+    for path in _unique_existing(paths):
+        selector = _literal(path) if path.is_file() else _subpath(path)
+        rules.append(f"(allow file-read* {selector})")
+    return rules
+
+
+def _write_rules(paths: Iterable[Path]) -> list[str]:
+    return [f"(allow file-write* {_subpath(path)})" for path in _unique_existing(paths)]
+
+
+def render_seatbelt_profile(
+    request: SandboxRequest,
+    *,
+    tmp_dir: Path | None = None,
+) -> str:
+    """Render a deny-by-default SBPL profile for ``request``."""
+    policy = request.policy
+    if policy.network == NetworkMode.PROXY_ALLOWLIST:
+        raise SandboxBackendError(
+            "NetworkMode.PROXY_ALLOWLIST is not supported by the seatbelt backend"
+        )
+
+    read_paths: list[Path] = []
+    write_paths: list[Path] = []
     workspace = next(
         (m for m in policy.mounts if m.sandbox_path.as_posix() == "/workspace"),
         None,
     )
     if workspace is not None:
-        lines.append(f'(allow file-read* (subpath "{workspace.host_path}"))')
-        if policy.workspace_rw:
-            lines.append(f'(allow file-write* (subpath "{workspace.host_path}"))')
+        read_paths.append(workspace.host_path)
+        if workspace.mode == "rw" or policy.workspace_rw:
+            write_paths.append(workspace.host_path)
+
+    for spec in policy.mounts:
+        if spec is workspace:
+            continue
+        if not spec.host_path.exists():
+            if spec.required:
+                raise SandboxBackendError(f"required mount missing on host: {spec.host_path!r}")
+            log.debug("sandbox.seatbelt_mount_skipped: %s (not present)", spec.host_path)
+            continue
+        read_paths.append(spec.host_path)
+        if spec.mode == "rw":
+            write_paths.append(spec.host_path)
+
+    if tmp_dir is not None:
+        read_paths.append(tmp_dir)
+        write_paths.append(tmp_dir)
+
+    read_paths.extend(path for path in _BASE_RO_PATHS if path.exists())
+    read_paths.extend(_extra_runtime_read_paths(request))
+
+    lines: list[str] = [
+        "(version 1)",
+        "(deny default)",
+        "(allow process*)",
+        "(allow sysctl-read)",
+        f"(allow file-read* {_literal(Path('/'))})",
+    ]
     if policy.network == NetworkMode.NONE:
         lines.append("(deny network*)")
-    else:
+    elif policy.network == NetworkMode.HOST:
         lines.append("(allow network*)")
+    else:  # pragma: no cover - exhaustive guard for future enum values
+        raise SandboxBackendError(f"unsupported seatbelt network mode: {policy.network!r}")
+
+    lines.extend(_read_rules(read_paths))
+    lines.extend(_write_rules(write_paths))
     return "\n".join(lines) + "\n"
 
 
+def _render_sbpl_skeleton(policy: SandboxPolicy) -> str:
+    """Compatibility helper for existing tests.
+
+    New code should call :func:`render_seatbelt_profile` with a full request so
+    the renderer can include cwd, executable, and temporary-directory rules.
+    """
+    cwd = Path.cwd()
+    return render_seatbelt_profile(
+        SandboxRequest(
+            argv=("sh", "-c", "true"),
+            cwd=cwd,
+            action_kind="seatbelt.profile",
+            policy=policy,
+        )
+    )
+
+
+def build_seatbelt_argv(
+    request: SandboxRequest,
+    profile_path: Path,
+    *,
+    binary: str | None = None,
+) -> list[str]:
+    resolved = _sandbox_exec_binary(binary)
+    if resolved is None:
+        label = binary or _SANDBOX_EXEC_NAME
+        raise SandboxBackendError(f"seatbelt backend unavailable: missing {label!r} binary")
+    _validate_mount_path(profile_path, kind="profile")
+    return [resolved, "-f", str(profile_path), *request.argv]
+
+
 class SeatbeltBackend(Backend):
-    """macOS ``sandbox-exec`` backend with profile rendering only."""
+    """macOS ``sandbox-exec`` backend."""
 
     name = "seatbelt"
+
+    def __init__(self, binary: str | None = None) -> None:
+        self._binary = binary
 
     def available(self) -> bool:
         if sys.platform != "darwin":
             return False
-        return shutil.which(_SANDBOX_EXEC) is not None
+        return _sandbox_exec_binary(self._binary) is not None
 
-    async def run(self, request: SandboxRequest) -> SandboxResult:  # noqa: ARG002
-        raise NotImplementedError(
-            "macOS Seatbelt backend currently renders profiles only; "
-            "process execution is pending — "
-            "see opensquilla/sandbox/backend/seatbelt.py"
-        )
+    async def run(self, request: SandboxRequest) -> SandboxResult:
+        if not self.available():
+            raise SandboxBackendError(
+                "seatbelt backend unavailable: missing 'sandbox-exec' binary on macOS"
+            )
+        _validate_request(request)
+
+        tmp_ctx: tempfile.TemporaryDirectory[str] | None = None
+        profile_file: tempfile.NamedTemporaryFile[str] | None = None
+        try:
+            tmp_dir: Path | None = None
+            if request.policy.tmp_writable:
+                tmp_ctx = tempfile.TemporaryDirectory(prefix="opensquilla-seatbelt-tmp-")
+                tmp_dir = Path(tmp_ctx.name)
+
+            profile = render_seatbelt_profile(request, tmp_dir=tmp_dir)
+            profile_file = tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                prefix="opensquilla-seatbelt-",
+                suffix=".sb",
+                delete=False,
+            )
+            try:
+                profile_file.write(profile)
+                profile_file.flush()
+            finally:
+                profile_file.close()
+
+            profile_path = Path(profile_file.name)
+            argv = build_seatbelt_argv(request, profile_path, binary=self._binary)
+            env = _env_for_policy(request.policy, request.env, tmp_dir=tmp_dir)
+
+            log.info(
+                "sandbox.seatbelt_spawn: action=%s level=%s network=%s argv_len=%d",
+                request.action_kind,
+                request.policy.level.label,
+                request.policy.network.value,
+                len(argv),
+            )
+
+            wall = request.policy.limits.wall_timeout_s
+            started = time.monotonic()
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *argv,
+                    stdin=asyncio.subprocess.PIPE if request.stdin is not None else None,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=str(request.cwd),
+                    env=env,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                raise SandboxBackendError(f"seatbelt launch failed: {exc}") from exc
+            except OSError as exc:
+                raise SandboxBackendError(f"seatbelt launch failed: {exc}") from exc
+
+            timed_out = False
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(input=request.stdin), timeout=wall
+                )
+            except TimeoutError:
+                timed_out = True
+                stdout_bytes, stderr_bytes = await _terminate_process_group(proc)
+
+            elapsed = time.monotonic() - started
+            stdout, trunc_out = _decode_capped(stdout_bytes)
+            stderr, trunc_err = _decode_capped(stderr_bytes)
+            returncode = proc.returncode if proc.returncode is not None else -1
+            return SandboxResult(
+                returncode=returncode,
+                stdout=stdout,
+                stderr=stderr,
+                wall_time_s=elapsed,
+                backend_used=self.name,
+                policy_used=request.policy.summary(),
+                truncated_stdout=trunc_out,
+                truncated_stderr=trunc_err,
+                timed_out=timed_out,
+            )
+        finally:
+            if profile_file is not None:
+                with contextlib.suppress(OSError):
+                    os.unlink(profile_file.name)
+            if tmp_ctx is not None:
+                tmp_ctx.cleanup()
 
 
-__all__ = ["SeatbeltBackend", "_render_sbpl_skeleton"]
+def _decode_capped(raw: bytes | None) -> tuple[str, bool]:
+    if not raw:
+        return "", False
+    if len(raw) <= _OUTPUT_BYTE_CAP:
+        return raw.decode("utf-8", errors="replace"), False
+    return raw[:_OUTPUT_BYTE_CAP].decode("utf-8", errors="replace"), True
+
+
+async def _terminate_process_group(
+    proc: asyncio.subprocess.Process,
+) -> tuple[bytes, bytes]:
+    pid = proc.pid
+    os_mod = cast(Any, os)
+    signal_mod = cast(Any, signal)
+    try:
+        os_mod.killpg(pid, signal_mod.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        pass
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=_TERMINATE_GRACE_S)
+    except TimeoutError:
+        try:
+            os_mod.killpg(pid, signal_mod.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+        try:
+            await proc.wait()
+        except ProcessLookupError:
+            pass
+
+    stdout = b""
+    stderr = b""
+    if proc.stdout is not None:
+        try:
+            stdout = await proc.stdout.read()
+        except Exception:  # noqa: BLE001
+            stdout = b""
+    if proc.stderr is not None:
+        try:
+            stderr = await proc.stderr.read()
+        except Exception:  # noqa: BLE001
+            stderr = b""
+    return stdout, stderr
+
+
+__all__ = [
+    "SeatbeltBackend",
+    "build_seatbelt_argv",
+    "render_seatbelt_profile",
+    "_render_sbpl_skeleton",
+]

--- a/tests/test_sandbox/test_seatbelt_backend.py
+++ b/tests/test_sandbox/test_seatbelt_backend.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from opensquilla.sandbox.backend import seatbelt as seatbelt_mod
+from opensquilla.sandbox.backend import select_backend
+from opensquilla.sandbox.backend.seatbelt import (
+    SeatbeltBackend,
+    build_seatbelt_argv,
+    render_seatbelt_profile,
+)
+from opensquilla.sandbox.config import SandboxSettings
+from opensquilla.sandbox.types import (
+    MountSpec,
+    NetworkMode,
+    ResourceLimits,
+    SandboxBackendError,
+    SandboxPolicy,
+    SandboxRequest,
+    SecurityLevel,
+)
+
+
+def _policy(
+    workspace: Path,
+    *,
+    network: NetworkMode = NetworkMode.NONE,
+    workspace_rw: bool = True,
+    tmp_writable: bool = True,
+    mounts: tuple[MountSpec, ...] | None = None,
+) -> SandboxPolicy:
+    base_mounts = (
+        MountSpec(
+            host_path=workspace,
+            sandbox_path=Path("/workspace"),
+            mode="rw" if workspace_rw else "ro",
+            required=True,
+        ),
+    )
+    return SandboxPolicy(
+        level=SecurityLevel.STANDARD,
+        network=network,
+        mounts=mounts or base_mounts,
+        workspace_rw=workspace_rw,
+        tmp_writable=tmp_writable,
+        limits=ResourceLimits(wall_timeout_s=0.1),
+        env_allowlist=("PATH", "LANG"),
+        require_approval=False,
+    )
+
+
+def _request(policy: SandboxPolicy, cwd: Path) -> SandboxRequest:
+    return SandboxRequest(
+        argv=("sh", "-lc", "echo ok"),
+        cwd=cwd,
+        action_kind="shell.exec",
+        policy=policy,
+        env={"PATH": "/bin", "SECRET": "nope"},
+    )
+
+
+def test_available_false_on_non_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(seatbelt_mod.sys, "platform", "linux")
+    assert SeatbeltBackend(binary="sandbox-exec").available() is False
+
+
+def test_available_true_on_macos_when_sandbox_exec_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(seatbelt_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(seatbelt_mod.shutil, "which", lambda name: "/usr/bin/sandbox-exec")
+    assert SeatbeltBackend(binary="sandbox-exec").available() is True
+
+
+def test_available_false_on_macos_when_sandbox_exec_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(seatbelt_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(seatbelt_mod.shutil, "which", lambda name: None)
+    assert SeatbeltBackend(binary="sandbox-exec").available() is False
+
+
+def test_auto_selects_seatbelt_on_macos_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.sandbox import backend as backend_mod
+
+    monkeypatch.setattr(backend_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(backend_mod.SeatbeltBackend, "available", lambda self: True)
+
+    backend = select_backend(SandboxSettings(sandbox=True, backend="auto"))
+
+    assert backend.name == "seatbelt"
+
+
+def test_explicit_seatbelt_fails_closed_when_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.sandbox import backend as backend_mod
+
+    monkeypatch.setattr(backend_mod.SeatbeltBackend, "available", lambda self: False)
+
+    with pytest.raises(SandboxBackendError, match="seatbelt.*unavailable"):
+        select_backend(SandboxSettings(sandbox=True, backend="seatbelt"))
+
+
+def test_profile_denies_default_and_network_none(tmp_path: Path) -> None:
+    profile = render_seatbelt_profile(_request(_policy(tmp_path), tmp_path))
+
+    assert "(deny default)" in profile
+    assert "(deny network*)" in profile
+    assert f'(allow file-read* (subpath "{tmp_path}"))' in profile
+    assert f'(allow file-write* (subpath "{tmp_path}"))' in profile
+
+
+def test_profile_allows_network_host(tmp_path: Path) -> None:
+    profile = render_seatbelt_profile(
+        _request(_policy(tmp_path, network=NetworkMode.HOST), tmp_path)
+    )
+
+    assert "(allow network*)" in profile
+
+
+def test_profile_rejects_proxy_allowlist(tmp_path: Path) -> None:
+    with pytest.raises(SandboxBackendError, match="PROXY_ALLOWLIST"):
+        render_seatbelt_profile(
+            _request(_policy(tmp_path, network=NetworkMode.PROXY_ALLOWLIST), tmp_path)
+        )
+
+
+def test_profile_keeps_workspace_ro_when_policy_ro(tmp_path: Path) -> None:
+    profile = render_seatbelt_profile(
+        _request(_policy(tmp_path, workspace_rw=False), tmp_path)
+    )
+
+    assert f'(allow file-read* (subpath "{tmp_path}"))' in profile
+    assert f'(allow file-write* (subpath "{tmp_path}"))' not in profile
+
+
+def test_profile_escapes_paths(tmp_path: Path) -> None:
+    hostile = tmp_path / 'quote"path'
+    hostile.mkdir()
+    policy = _policy(
+        hostile,
+        mounts=(
+            MountSpec(
+                host_path=hostile,
+                sandbox_path=Path("/workspace"),
+                mode="rw",
+                required=True,
+            ),
+        ),
+    )
+
+    profile = render_seatbelt_profile(_request(policy, hostile))
+
+    assert '\\"' in profile
+    assert '"quote"path"' not in profile
+
+
+def test_missing_required_mount_raises(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"
+    policy = _policy(
+        tmp_path,
+        mounts=(
+            MountSpec(
+                host_path=missing,
+                sandbox_path=Path("/workspace"),
+                mode="ro",
+                required=True,
+            ),
+        ),
+    )
+
+    with pytest.raises(SandboxBackendError, match="required mount missing"):
+        seatbelt_mod._validate_request(_request(policy, tmp_path))
+
+
+def test_missing_optional_mount_is_skipped(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"
+    policy = _policy(
+        tmp_path,
+        mounts=(
+            MountSpec(
+                host_path=tmp_path,
+                sandbox_path=Path("/workspace"),
+                mode="rw",
+                required=True,
+            ),
+            MountSpec(
+                host_path=missing,
+                sandbox_path=missing,
+                mode="rw",
+                required=False,
+            ),
+        ),
+    )
+
+    profile = render_seatbelt_profile(_request(policy, tmp_path))
+
+    assert str(missing) not in profile
+
+
+def test_build_argv_uses_sandbox_exec(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        seatbelt_mod,
+        "_sandbox_exec_binary",
+        lambda binary=None: "/usr/bin/sandbox-exec",
+    )
+
+    argv = build_seatbelt_argv(
+        _request(_policy(tmp_path), tmp_path),
+        tmp_path / "profile.sb",
+    )
+
+    assert argv[:3] == ["/usr/bin/sandbox-exec", "-f", str(tmp_path / "profile.sb")]
+    assert argv[3:] == ["sh", "-lc", "echo ok"]
+
+
+@pytest.mark.asyncio
+async def test_run_filters_env_and_returns_nonzero_without_raise(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeProcess:
+        pid = 12345
+        returncode = 7
+
+        async def communicate(self, input: bytes | None = None) -> tuple[bytes, bytes]:
+            return b"", b"nope"
+
+    async def fake_create_subprocess_exec(*argv: str, **kwargs: object) -> FakeProcess:
+        captured["argv"] = argv
+        captured["env"] = kwargs["env"]
+        captured["cwd"] = kwargs["cwd"]
+        return FakeProcess()
+
+    monkeypatch.setattr(seatbelt_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        seatbelt_mod,
+        "_sandbox_exec_binary",
+        lambda binary=None: "/usr/bin/sandbox-exec",
+    )
+    monkeypatch.setattr(
+        seatbelt_mod.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    result = await SeatbeltBackend().run(_request(_policy(tmp_path), tmp_path))
+
+    assert result.returncode == 7
+    assert result.stderr == "nope"
+    assert result.backend_used == "seatbelt"
+    assert result.timed_out is False
+    assert captured["cwd"] == str(tmp_path)
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["PATH"] == "/bin"
+    assert "SECRET" not in env
+    assert "TMPDIR" in env
+
+
+@pytest.mark.asyncio
+async def test_run_timeout_returns_timed_out_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class FakeProcess:
+        pid = 12345
+        returncode = -15
+        stdout = None
+        stderr = None
+
+        async def communicate(self, input: bytes | None = None) -> tuple[bytes, bytes]:
+            await asyncio.sleep(1)
+            return b"", b""
+
+        async def wait(self) -> None:
+            return None
+
+    async def fake_create_subprocess_exec(*argv: str, **kwargs: object) -> FakeProcess:
+        return FakeProcess()
+
+    monkeypatch.setattr(seatbelt_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        seatbelt_mod,
+        "_sandbox_exec_binary",
+        lambda binary=None: "/usr/bin/sandbox-exec",
+    )
+    monkeypatch.setattr(
+        seatbelt_mod.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(seatbelt_mod.os, "killpg", lambda pid, sig: None)
+
+    result = await SeatbeltBackend().run(_request(_policy(tmp_path), tmp_path))
+
+    assert result.timed_out is True
+    assert result.returncode == -15
+
+
+@pytest.mark.asyncio
+async def test_real_seatbelt_runs_python_when_available(tmp_path: Path) -> None:
+    if not SeatbeltBackend().available():
+        pytest.skip("requires macOS sandbox-exec")
+    policy = _policy(tmp_path)
+    request = SandboxRequest(
+        argv=(sys.executable, "-c", "print('ok')"),
+        cwd=tmp_path,
+        action_kind="code.exec",
+        policy=policy,
+        env={"PATH": "/bin:/usr/bin"},
+    )
+
+    result = await SeatbeltBackend().run(request)
+
+    assert result.returncode == 0
+    assert result.stdout == "ok\n"
+    assert result.stderr == ""
+
+
+@pytest.mark.asyncio
+async def test_real_seatbelt_blocks_write_outside_workspace_when_available(
+    tmp_path: Path,
+) -> None:
+    if not SeatbeltBackend().available():
+        pytest.skip("requires macOS sandbox-exec")
+    outside = tmp_path.parent / "seatbelt-outside.txt"
+    policy = _policy(tmp_path)
+    request = SandboxRequest(
+        argv=(
+            sys.executable,
+            "-c",
+            f"open({str(outside)!r}, 'w').write('blocked')",
+        ),
+        cwd=tmp_path,
+        action_kind="code.exec",
+        policy=policy,
+        env={"PATH": "/bin:/usr/bin"},
+    )
+
+    result = await SeatbeltBackend().run(request)
+
+    assert result.returncode != 0
+    assert "PermissionError" in result.stderr
+    assert not outside.exists()

--- a/tests/test_sandbox/test_windows_auto_backend.py
+++ b/tests/test_sandbox/test_windows_auto_backend.py
@@ -48,6 +48,57 @@ def test_windows_auto_backend_disables_sandbox_runtime(
     assert runtime.backend.name == "noop"
 
 
+def test_macos_auto_backend_selects_seatbelt_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from opensquilla.sandbox import backend as backend_mod
+    from opensquilla.sandbox import integration
+
+    monkeypatch.setattr(integration.sys, "platform", "darwin")
+    monkeypatch.setattr(backend_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        backend_mod.SeatbeltBackend,
+        "available",
+        lambda self: True,
+    )
+
+    runtime = configure_runtime(
+        SandboxSettings(sandbox=True, security_grading=True, backend="auto"),
+        approval_queue=_FakeApprovalQueue(),
+        workspace=tmp_path,
+    )
+
+    assert runtime.settings.sandbox is True
+    assert runtime.settings.security_grading is True
+    assert runtime.effective.sandbox_enabled is True
+    assert runtime.effective.grading_enabled is True
+    assert runtime.backend.name == "seatbelt"
+
+
+def test_explicit_macos_seatbelt_backend_still_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from opensquilla.sandbox import backend as backend_mod
+    from opensquilla.sandbox import integration
+
+    monkeypatch.setattr(integration.sys, "platform", "darwin")
+    monkeypatch.setattr(backend_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        backend_mod.SeatbeltBackend,
+        "available",
+        lambda self: False,
+    )
+
+    with pytest.raises(SandboxBackendError, match="sandbox backend 'seatbelt' is unavailable"):
+        configure_runtime(
+            SandboxSettings(sandbox=True, security_grading=True, backend="seatbelt"),
+            approval_queue=_FakeApprovalQueue(),
+            workspace=tmp_path,
+        )
+
+
 def test_linux_auto_backend_without_real_backend_still_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- implement macOS Seatbelt execution through sandbox-exec with generated SBPL profiles
- keep macOS auto backend sandboxed when sandbox-exec is available
- add Seatbelt renderer, availability, timeout, env filtering, and real macOS smoke tests

## Tests
- uv run --extra dev ruff check src/opensquilla/sandbox/backend/seatbelt.py tests/test_sandbox/test_seatbelt_backend.py tests/test_sandbox/test_windows_auto_backend.py
- uv run --extra dev pytest tests/test_sandbox
