### PR TITLE
Preserve approval grants for host execution

### DIFF
--- a/src/opensquilla/tools/builtin/code_exec.py
+++ b/src/opensquilla/tools/builtin/code_exec.py
@@ -274,6 +274,8 @@ async def execute_code(
         )
 
         prior_elevation = _approval_elevation_state()
+        approval_response: dict[str, object] | None = None
+        approval_granted = False
         try:
             approval_response = await _check_exec_approval(
                 tool_name="execute_code",
@@ -283,8 +285,10 @@ async def execute_code(
                 approval_id=approval_id,
                 background=False,
             )
+            approval_granted = approval_response is None and _approval_elevation_state()
         finally:
-            _restore_approval_elevation(prior_elevation)
+            if not approval_granted:
+                _restore_approval_elevation(prior_elevation)
         if approval_response is not None:
             return json.dumps(approval_response)
 

--- a/src/opensquilla/tools/builtin/shell.py
+++ b/src/opensquilla/tools/builtin/shell.py
@@ -512,6 +512,8 @@ async def background_process(
         return sensitive_block
     if result.needs_approval:
         prior_elevation = _approval_elevation_state()
+        approval_response: dict[str, object] | None = None
+        approval_granted = False
         try:
             approval_response = await _check_exec_approval(
                 tool_name="background_process",
@@ -521,8 +523,10 @@ async def background_process(
                 approval_id=approval_id,
                 background=True,
             )
+            approval_granted = approval_response is None and _approval_elevation_state()
         finally:
-            _restore_approval_elevation(prior_elevation)
+            if not approval_granted:
+                _restore_approval_elevation(prior_elevation)
         if approval_response is not None:
             status = approval_response.get("status")
             if status == "approval_denied":

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -233,6 +233,94 @@ async def test_unattended_bypass_allows_destructive_code_exec(
 
 
 @pytest.mark.asyncio
+async def test_approved_destructive_code_exec_uses_host_grant_when_sandbox_enabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.workspace_dir = str(tmp_path)
+    target = tmp_path / "target.txt"
+    target.write_text("delete me", encoding="utf-8")
+    configure_runtime(
+        SandboxSettings(
+            sandbox=True,
+            security_grading=True,
+            backend="noop",
+            allow_legacy_mode=True,
+        ),
+        workspace=tmp_path,
+    )
+    monkeypatch.setattr(
+        code_exec,
+        "_resolve_python_bin",
+        lambda *, sandbox_enabled: sys.executable,
+    )
+
+    async def fail_sandbox(*args: object, **kwargs: object) -> object:
+        raise AssertionError("sandbox backend should not run after approval")
+
+    monkeypatch.setattr(code_exec, "run_under_backend", fail_sandbox)
+
+    code = "import os\nos.remove('target.txt')"
+    pending = json.loads(await execute_code(code))
+    assert pending["status"] == "approval_required"
+    approval_id = str(pending["approval_id"])
+    get_approval_queue().resolve(approval_id, approved=True)
+
+    result = await execute_code(code, approval_id=approval_id)
+    payload = json.loads(result)
+
+    assert payload["exit_code"] == 0
+    assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_approved_background_process_uses_host_grant_when_sandbox_enabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.workspace_dir = str(tmp_path)
+    target = tmp_path / "target.txt"
+    target.write_text("delete me", encoding="utf-8")
+    configure_runtime(
+        SandboxSettings(
+            sandbox=True,
+            security_grading=True,
+            backend="noop",
+            allow_legacy_mode=True,
+        ),
+        workspace=tmp_path,
+    )
+
+    async def fail_sandbox(*args: object, **kwargs: object) -> object:
+        raise AssertionError("sandbox background backend should not run after approval")
+
+    monkeypatch.setattr(shell, "_spawn_sandboxed_background_process", fail_sandbox)
+
+    pending = json.loads(await shell.background_process("rm target.txt", workdir=str(tmp_path)))
+    assert pending["status"] == "approval_required"
+    approval_id = str(pending["approval_id"])
+    get_approval_queue().resolve(approval_id, approved=True)
+
+    result = await shell.background_process(
+        "rm target.txt",
+        workdir=str(tmp_path),
+        timeout=5,
+        approval_id=approval_id,
+    )
+
+    assert "status: running" in result
+    session_id = result.splitlines()[0].split("=", 1)[1]
+    session = shell._bg_sessions[session_id]
+    assert session.collector_task is not None
+    await session.collector_task
+    assert not target.exists()
+
+
+@pytest.mark.asyncio
 async def test_unattended_bypass_allows_outside_workspace_write(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()


### PR DESCRIPTION
## Summary
- Preserve approved per-call host execution grants for destructive `execute_code` retries.
- Apply the same grant preservation to approved `background_process` retries.
- Add regressions proving approved destructive code/background calls bypass the sandbox backend and execute in the host workspace.

## Test Plan
- `uv run --extra dev --extra recommended pytest -q tests/test_tools/test_shell_approval_policy.py`
- `uv run --extra dev --extra recommended ruff check .`
- `uv run --extra dev --extra recommended mypy src/opensquilla --show-error-codes`