### PR TITLE
Parse quoted file and image command paths

### DIFF
--- a/src/opensquilla/cli/attachments.py
+++ b/src/opensquilla/cli/attachments.py
@@ -154,6 +154,28 @@ def _check_size_policy(path: Path, mime: str) -> int:
     return size
 
 
+def _parse_path_prompt(command: str, prefix: str, usage: str) -> tuple[Path, str]:
+    rest = command[len(prefix) :].strip()
+    if not rest:
+        raise ValueError(usage)
+
+    if rest[0] in {'"', "'"}:
+        quote = rest[0]
+        end = rest.find(quote, 1)
+        if end == -1:
+            raise ValueError(f"{usage} (unclosed quote)")
+        token = rest[1:end]
+        prompt = rest[end + 1 :].strip()
+    else:
+        parts = rest.split(None, 1)
+        token = parts[0]
+        prompt = parts[1] if len(parts) > 1 else ""
+
+    if not token:
+        raise ValueError(usage)
+    return Path(token).expanduser(), prompt
+
+
 def build_file_attachment(
     path: str | Path,
     *,
@@ -221,11 +243,8 @@ def file_prompt_and_attachments(
     *,
     upload_callable: UploadCallable | None = None,
 ) -> tuple[str, list[dict[str, Any]]]:
-    parts = command[len("/file ") :].strip().split(None, 1)
-    if not parts:
-        raise ValueError("Usage: /file <path> [prompt]")
-    path = Path(parts[0]).expanduser()
-    prompt = parts[1] if len(parts) > 1 else "Read this file"
+    path, prompt = _parse_path_prompt(command, "/file ", "Usage: /file <path> [prompt]")
+    prompt = prompt or "Read this file"
     return prompt, [build_file_attachment(path, upload_callable=upload_callable)]
 
 
@@ -234,11 +253,8 @@ async def async_file_prompt_and_attachments(
     *,
     upload_callable: AsyncUploadCallable | None = None,
 ) -> tuple[str, list[dict[str, Any]]]:
-    parts = command[len("/file ") :].strip().split(None, 1)
-    if not parts:
-        raise ValueError("Usage: /file <path> [prompt]")
-    path = Path(parts[0]).expanduser()
-    prompt = parts[1] if len(parts) > 1 else "Read this file"
+    path, prompt = _parse_path_prompt(command, "/file ", "Usage: /file <path> [prompt]")
+    prompt = prompt or "Read this file"
     return prompt, [await build_file_attachment_async(path, upload_callable=upload_callable)]
 
 
@@ -247,17 +263,13 @@ def attachments_from_paths(paths: list[str] | tuple[str, ...]) -> list[dict[str,
 
 
 def image_prompt_from_command(command: str) -> str:
-    parts = command[len("/image ") :].strip().split(None, 1)
-    return parts[1] if len(parts) > 1 else "Describe this image"
+    _path, prompt = _parse_path_prompt(command, "/image ", "Usage: /image <path> [prompt]")
+    return prompt or "Describe this image"
 
 
 def image_prompt_and_attachments(command: str) -> tuple[str, list[dict[str, str]]]:
-    parts = command[len("/image ") :].strip().split(None, 1)
-    if not parts:
-        raise ValueError("Usage: /image <path> [prompt]")
-
-    path = Path(parts[0]).expanduser()
-    prompt = parts[1] if len(parts) > 1 else "Describe this image"
+    path, prompt = _parse_path_prompt(command, "/image ", "Usage: /image <path> [prompt]")
+    prompt = prompt or "Describe this image"
     _ensure_existing_file(path)
 
     ext = path.suffix.lower().lstrip(".")

--- a/tests/test_cli/test_chat_file_command.py
+++ b/tests/test_cli/test_chat_file_command.py
@@ -29,7 +29,11 @@ from opensquilla.cli.attachments import (
     CLI_STAGED_PDF_BYTES,
     CLI_TEXT_ATTACHMENT_BYTES,
 )
-from opensquilla.cli.chat_cmd import _file_prompt_and_attachments
+from opensquilla.cli.chat_cmd import (
+    _file_prompt_and_attachments,
+    _image_prompt_and_attachments,
+    _image_prompt_from_command,
+)
 
 
 def _write(tmp_path: Path, name: str, payload: bytes) -> Path:
@@ -56,6 +60,38 @@ def test_file_command_inline_for_small_csv(tmp_path: Path) -> None:
     assert att["name"] == "data.csv"
     assert "data" in att and "file_uuid" not in att
     assert base64.b64decode(att["data"]) == csv_bytes
+
+
+def test_file_command_parses_quoted_path_with_spaces(tmp_path: Path) -> None:
+    csv_bytes = b"col_a,col_b\n1,2\n"
+    path = _write(tmp_path, "data set.csv", csv_bytes)
+
+    prompt, attachments = _file_prompt_and_attachments(
+        f'/file "{path}" summarise this', upload_callable=None
+    )
+
+    assert prompt == "summarise this"
+    assert attachments[0]["name"] == "data set.csv"
+    assert attachments[0]["type"] == "text/csv"
+    assert base64.b64decode(attachments[0]["data"]) == csv_bytes
+
+
+def test_file_command_rejects_unclosed_quoted_path() -> None:
+    with pytest.raises(ValueError, match=r"Usage: /file"):
+        _file_prompt_and_attachments('/file "unterminated', upload_callable=None)
+
+
+def test_image_command_parses_quoted_path_with_spaces(tmp_path: Path) -> None:
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"payload"
+    path = _write(tmp_path, "screen shot.png", png_bytes)
+
+    prompt, attachments = _image_prompt_and_attachments(f'/image "{path}" describe it')
+
+    assert _image_prompt_from_command(f'/image "{path}" describe it') == "describe it"
+    assert prompt == "describe it"
+    assert attachments[0]["name"] == "screen shot.png"
+    assert attachments[0]["type"] == "image/png"
+    assert base64.b64decode(attachments[0]["data"]) == png_bytes
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add shared parsing for `/file` and `/image` path-plus-prompt commands.
- Support quoted local paths so filenames containing spaces are not truncated before attachment handling.
- Add regressions for quoted file paths, quoted image paths, and unclosed quotes.

## Test Plan
- `uv run --extra dev --extra recommended pytest -q tests/test_cli/test_chat_file_command.py`
- `uv run --extra dev --extra recommended ruff check .`
- `uv run --extra dev --extra recommended mypy src/opensquilla --show-error-codes`