### PR TITLE
Reject zero-length scheduler intervals

### DIFF
--- a/src/opensquilla/scheduler/parser.py
+++ b/src/opensquilla/scheduler/parser.py
@@ -216,14 +216,16 @@ def parse_schedule(
     m = _EVERY_RE.match(raw)
     if m:
         amount = int(m.group(1))
+        if amount <= 0:
+            raise CronParseError("Interval amount must be > 0")
         unit = m.group(2).lower()
         if unit in ("m", "min"):
-            if amount > 0 and 60 % amount == 0:
+            if 60 % amount == 0:
                 return ScheduleKind.EVERY, f"*/{amount} * * * *"
             else:
                 return ScheduleKind.EVERY, str(amount * 60)
         elif unit in ("h", "hr"):
-            if amount > 0 and 24 % amount == 0:
+            if 24 % amount == 0:
                 return ScheduleKind.EVERY, f"0 */{amount} * * *"
             else:
                 return ScheduleKind.EVERY, str(amount * 3600)
@@ -234,6 +236,8 @@ def parse_schedule(
     m = _RELATIVE_RE.match(raw)
     if m:
         amount = int(m.group(1))
+        if amount <= 0:
+            raise CronParseError("Relative delay must be > 0")
         unit = m.group(2).lower()
         secs = amount * _UNIT_SECONDS.get(unit, 60)
         target = now.astimezone(UTC) + timedelta(seconds=secs)

--- a/tests/test_scheduler/test_parser.py
+++ b/tests/test_scheduler/test_parser.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from opensquilla.scheduler.parser import CronParseError, parse_schedule
+from opensquilla.scheduler.types import ScheduleKind
+
+
+@pytest.mark.parametrize("raw", ["every 0m", "every 0h", "every 0d"])
+def test_parse_schedule_rejects_zero_every_interval(raw: str) -> None:
+    with pytest.raises(CronParseError, match=r"> 0"):
+        parse_schedule(raw)
+
+
+@pytest.mark.parametrize("raw", ["0m", "0h", "0d"])
+def test_parse_schedule_rejects_zero_relative_delay(raw: str) -> None:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+
+    with pytest.raises(CronParseError, match=r"> 0"):
+        parse_schedule(raw, reference_now=now)
+
+
+def test_parse_schedule_accepts_positive_every_interval() -> None:
+    assert parse_schedule("every 5m") == (ScheduleKind.EVERY, "*/5 * * * *")


### PR DESCRIPTION
## Summary
- Reject English `every 0m` / `every 0h` / `every 0d` schedules instead of normalizing them to zero-second intervals.
- Reject English `0m` / `0h` / `0d` relative delays instead of scheduling them at the current instant.
- Add scheduler parser regressions while preserving positive interval parsing.

## Test Plan
- `uv run --extra dev --extra recommended pytest -q tests/test_scheduler/test_parser.py`
- `uv run --extra dev --extra recommended ruff check .`
- `uv run --extra dev --extra recommended mypy src/opensquilla --show-error-codes`