### PR TITLE
fix(sandbox): macOS Seatbelt sandbox backend implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,24 +41,14 @@ disabled` if you intentionally want to skip the bundled router.
 Download the preview package if you want to try OpenSquilla as a local app
 without cloning the repository or installing Git, Git LFS, or `uv`.
 
-Current preview packages:
+1. Download the package from the [GitHub Releases](https://github.com/opensquilla/opensquilla/releases)
+   page and extract it to a writable folder.
 
-- `OpenSquilla-<version>-windows-x64-py312-recommended-portable.zip` for
-  Windows.
-
-The recommended portable zip includes Feishu websocket support by default. If a
-package is not available for your platform, use the source install path below.
-
-1. Open the [GitHub Releases](https://github.com/opensquilla/opensquilla/releases)
-   page and download the package.
-
-2. Extract to Downloads, Documents, or another folder you can write to.
-
-3. Double-click `Start OpenSquilla.cmd` from the extracted folder.
+2. Double-click `Start OpenSquilla.cmd` from the extracted folder.
 
    Keep the terminal window open. Closing it stops the gateway.
 
-4. Complete onboarding and open the Web UI.
+3. Complete onboarding and open the Web UI.
 
    The launcher opens onboarding before the gateway starts. On first run, choose
    a provider and paste the requested keys; later starts let you review or change

--- a/src/opensquilla/sandbox/backend/__init__.py
+++ b/src/opensquilla/sandbox/backend/__init__.py
@@ -5,8 +5,7 @@ Three backends ship today:
 * :class:`~opensquilla.sandbox.backend.bubblewrap.BubblewrapBackend` — the Linux
   primary path; uses the ``bwrap`` binary for namespace isolation.
 * :class:`~opensquilla.sandbox.backend.seatbelt.SeatbeltBackend` — macOS
-  profile renderer. Exposes SBPL generation and an honest ``available()``
-  check but does not yet execute commands.
+  primary path; uses ``sandbox-exec`` with a generated SBPL profile.
 * :class:`~opensquilla.sandbox.backend.noop.NoopBackend` — used when the sandbox
   feature switch is off; runs the command through the existing rlimit
   wrapper and emits a warning on every invocation so the bypass is visible

--- a/src/opensquilla/sandbox/backend/seatbelt.py
+++ b/src/opensquilla/sandbox/backend/seatbelt.py
@@ -20,9 +20,6 @@ error message points at this file.
 
 from __future__ import annotations
 
-import shutil
-import sys
-
 from opensquilla.sandbox.backend.base import Backend
 from opensquilla.sandbox.types import (
     NetworkMode,
@@ -66,9 +63,9 @@ class SeatbeltBackend(Backend):
     name = "seatbelt"
 
     def available(self) -> bool:
-        if sys.platform != "darwin":
-            return False
-        return shutil.which(_SANDBOX_EXEC) is not None
+        # Backend.available() means "can execute SandboxRequest", not merely
+        # "can render a profile". Keep this false until run() is implemented.
+        return False
 
     async def run(self, request: SandboxRequest) -> SandboxResult:  # noqa: ARG002
         raise NotImplementedError(

--- a/src/opensquilla/sandbox/backend/seatbelt.py
+++ b/src/opensquilla/sandbox/backend/seatbelt.py
@@ -1,78 +1,539 @@
-"""macOS Seatbelt backend with SBPL profile rendering.
+"""macOS Seatbelt backend.
 
-This module deliberately renders profiles only and does not run commands yet.
-It keeps the backend abstraction, policy translation, and availability probe
-ready for future ``sandbox-exec`` execution support.
-
-The Seatbelt profile language (SBPL) is a TinyScheme-derived DSL. The
-baseline profile for opensquilla maps a :class:`SandboxPolicy` to three rules:
-
-1. ``(deny default)`` — start from a deny-by-default posture.
-2. ``(allow file-read* (subpath "<workspace>"))`` plus ``file-write*`` if
-   the policy has ``workspace_rw``.
-3. ``(deny network*)`` when ``policy.network == NetworkMode.NONE``.
-
-:func:`_render_sbpl_skeleton` returns the profile string so the unit test
-suite can assert shape without invoking ``sandbox-exec``. The runtime entry
-point :meth:`SeatbeltBackend.run` raises :class:`NotImplementedError`; the
-error message points at this file.
+Executes requests through ``sandbox-exec`` with a generated SBPL profile.
+Seatbelt is not a Linux namespace equivalent: paths stay as host paths, there
+is no PID/user namespace, and V1 intentionally supports only host network or
+no network. The profile is still deny-by-default for filesystem and network
+access, with explicit read/write allowances for the workspace, configured
+mounts, system runtime paths, and a backend-owned temporary directory.
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import logging
+import os
+import re
+import shutil
+import signal
+import sys
+import tempfile
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
 from opensquilla.sandbox.backend.base import Backend
 from opensquilla.sandbox.types import (
     NetworkMode,
+    SandboxBackendError,
     SandboxPolicy,
     SandboxRequest,
     SandboxResult,
 )
 
-_SANDBOX_EXEC = "sandbox-exec"
+log = logging.getLogger(__name__)
+
+_SANDBOX_EXEC_NAME = "sandbox-exec"
+_SANDBOX_EXEC_SYSTEM_PATH = Path("/usr/bin/sandbox-exec")
+_OUTPUT_BYTE_CAP = 1_048_576
+_TERMINATE_GRACE_S = 2.0
+
+# Broad but explicit runtime reads needed for ordinary macOS command
+# execution. Every path here widens the sandbox, so keep the list boring.
+_BASE_RO_PATHS: tuple[Path, ...] = (
+    Path("/bin"),
+    Path("/sbin"),
+    Path("/usr/bin"),
+    Path("/usr/lib"),
+    Path("/System/Library"),
+    Path("/Library/Developer/CommandLineTools"),
+)
+_BREW_PREFIXES: tuple[Path, ...] = (Path("/opt/homebrew"), Path("/usr/local"))
 
 
-def _render_sbpl_skeleton(policy: SandboxPolicy) -> str:
-    """Render the three-rule SBPL profile for ``policy``.
+def _sandbox_exec_binary(binary: str | None = None) -> str | None:
+    if binary is not None:
+        return shutil.which(binary)
+    if _SANDBOX_EXEC_SYSTEM_PATH.exists():
+        return str(_SANDBOX_EXEC_SYSTEM_PATH)
+    return shutil.which(_SANDBOX_EXEC_NAME)
 
-    The output is intentionally small and readable: each rule is on its own
-    line so future execution support can extend it with additional allow rules
-    (cache dirs, homebrew prefix, etc.) without reformatting.
-    """
-    lines: list[str] = [
-        "(version 1)",
-        "(deny default)",
-    ]
+
+def _validate_mount_path(path: Path, *, kind: str) -> None:
+    if not path.is_absolute():
+        raise SandboxBackendError(f"{kind} path must be absolute: {path!r}")
+    if any(part == ".." for part in path.parts):
+        raise SandboxBackendError(f"{kind} path contains '..': {path!r}")
+
+
+def _validate_request(request: SandboxRequest) -> None:
+    if not request.argv:
+        raise SandboxBackendError("seatbelt request argv must not be empty")
+    _validate_mount_path(request.cwd, kind="cwd")
+    if not request.cwd.exists():
+        raise SandboxBackendError(f"cwd missing on host: {request.cwd!r}")
+    for spec in request.policy.mounts:
+        _validate_mount_path(spec.host_path, kind="host mount")
+        _validate_mount_path(spec.sandbox_path, kind="sandbox mount")
+        if spec.required and not spec.host_path.exists():
+            raise SandboxBackendError(f"required mount missing on host: {spec.host_path!r}")
+
+
+def _scheme_string(value: str) -> str:
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    return f'"{escaped}"'
+
+
+def _literal(path: Path) -> str:
+    return f"(literal {_scheme_string(str(path))})"
+
+
+def _subpath(path: Path) -> str:
+    return f"(subpath {_scheme_string(str(path))})"
+
+
+def _unique_existing(paths: Iterable[Path]) -> list[Path]:
+    seen: set[str] = set()
+    result: list[Path] = []
+    for path in paths:
+        candidates = [path]
+        try:
+            resolved = path.resolve(strict=False)
+        except OSError:
+            resolved = path
+        if resolved != path:
+            candidates.append(resolved)
+        for candidate in candidates:
+            key = str(candidate)
+            if key in seen or not candidate.exists():
+                continue
+            seen.add(key)
+            result.append(candidate)
+    return result
+
+
+def _parents_for(path: Path) -> list[Path]:
+    parents: list[Path] = []
+    current = path
+    if path.is_file():
+        current = path.parent
+    for parent in (current, *current.parents):
+        if parent == parent.parent:
+            break
+        parents.append(parent)
+    return list(reversed(parents))
+
+
+def _resolve_executable(argv0: str) -> Path | None:
+    candidate = Path(argv0)
+    if candidate.is_absolute():
+        return candidate.resolve(strict=False)
+    resolved = shutil.which(argv0)
+    if resolved is None:
+        return None
+    return Path(resolved).resolve(strict=False)
+
+
+def _is_under(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(parent.resolve(strict=False))
+    except ValueError:
+        return False
+    return True
+
+
+def _extra_runtime_read_paths(request: SandboxRequest) -> list[Path]:
+    paths: list[Path] = [request.cwd]
+    argv0 = Path(request.argv[0])
+    if argv0.is_absolute():
+        paths.append(argv0)
+        paths.extend(_parents_for(argv0))
+    exe = _resolve_executable(request.argv[0])
+    if exe is not None:
+        paths.append(exe)
+        paths.extend(_parents_for(exe))
+        for prefix in _BREW_PREFIXES:
+            if _is_under(exe, prefix):
+                paths.append(prefix)
+    return paths
+
+
+def _env_for_policy(
+    policy: SandboxPolicy,
+    override_env: dict[str, str],
+    *,
+    tmp_dir: Path | None,
+) -> dict[str, str]:
+    allowlist = set(policy.env_allowlist)
+    resolved: dict[str, str] = {}
+    for key in policy.env_allowlist:
+        value = os.environ.get(key)
+        if value is not None:
+            resolved[key] = value
+    for key, value in override_env.items():
+        if key not in allowlist:
+            log.debug("sandbox.seatbelt_env_override_rejected: key=%s", key)
+            continue
+        resolved[key] = value
+    if tmp_dir is not None:
+        resolved["TMPDIR"] = str(tmp_dir)
+    return resolved
+
+
+def _read_rules(paths: Iterable[Path]) -> list[str]:
+    rules: list[str] = []
+    for path in _unique_existing(paths):
+        selector = _literal(path) if path.is_file() else _subpath(path)
+        rules.append(f"(allow file-read* {selector})")
+    return rules
+
+
+def _write_rules(paths: Iterable[Path]) -> list[str]:
+    return [f"(allow file-write* {_subpath(path)})" for path in _unique_existing(paths)]
+
+
+def render_seatbelt_profile(
+    request: SandboxRequest,
+    *,
+    tmp_dir: Path | None = None,
+) -> str:
+    """Render a deny-by-default SBPL profile for ``request``."""
+    policy = request.policy
+    if policy.network == NetworkMode.PROXY_ALLOWLIST:
+        raise SandboxBackendError(
+            "NetworkMode.PROXY_ALLOWLIST is not supported by the seatbelt backend"
+        )
+
+    read_paths: list[Path] = []
+    write_paths: list[Path] = []
     workspace = next(
         (m for m in policy.mounts if m.sandbox_path.as_posix() == "/workspace"),
         None,
     )
     if workspace is not None:
-        lines.append(f'(allow file-read* (subpath "{workspace.host_path}"))')
-        if policy.workspace_rw:
-            lines.append(f'(allow file-write* (subpath "{workspace.host_path}"))')
+        read_paths.append(workspace.host_path)
+        if workspace.mode == "rw" or policy.workspace_rw:
+            write_paths.append(workspace.host_path)
+
+    for spec in policy.mounts:
+        if spec is workspace:
+            continue
+        if not spec.host_path.exists():
+            if spec.required:
+                raise SandboxBackendError(f"required mount missing on host: {spec.host_path!r}")
+            log.debug("sandbox.seatbelt_mount_skipped: %s (not present)", spec.host_path)
+            continue
+        read_paths.append(spec.host_path)
+        if spec.mode == "rw":
+            write_paths.append(spec.host_path)
+
+    if tmp_dir is not None:
+        read_paths.append(tmp_dir)
+        write_paths.append(tmp_dir)
+
+    read_paths.extend(path for path in _BASE_RO_PATHS if path.exists())
+    read_paths.extend(_extra_runtime_read_paths(request))
+
+    lines: list[str] = [
+        "(version 1)",
+        "(deny default)",
+        "(allow process*)",
+        "(allow sysctl-read)",
+        f"(allow file-read* {_literal(Path('/'))})",
+    ]
     if policy.network == NetworkMode.NONE:
         lines.append("(deny network*)")
-    else:
+    elif policy.network == NetworkMode.HOST:
         lines.append("(allow network*)")
+    else:  # pragma: no cover - exhaustive guard for future enum values
+        raise SandboxBackendError(f"unsupported seatbelt network mode: {policy.network!r}")
+
+    lines.extend(_read_rules(read_paths))
+    lines.extend(_write_rules(write_paths))
     return "\n".join(lines) + "\n"
 
 
+def _render_sbpl_skeleton(policy: SandboxPolicy) -> str:
+    """Compatibility helper for existing tests.
+
+    New code should call :func:`render_seatbelt_profile` with a full request so
+    the renderer can include cwd, executable, and temporary-directory rules.
+    """
+    cwd = Path.cwd()
+    return render_seatbelt_profile(
+        SandboxRequest(
+            argv=("sh", "-c", "true"),
+            cwd=cwd,
+            action_kind="seatbelt.profile",
+            policy=policy,
+        )
+    )
+
+
+def build_seatbelt_argv(
+    request: SandboxRequest,
+    profile_path: Path,
+    *,
+    binary: str | None = None,
+) -> list[str]:
+    resolved = _sandbox_exec_binary(binary)
+    if resolved is None:
+        label = binary or _SANDBOX_EXEC_NAME
+        raise SandboxBackendError(f"seatbelt backend unavailable: missing {label!r} binary")
+    _validate_mount_path(profile_path, kind="profile")
+    return [resolved, "-f", str(profile_path), *request.argv]
+
+
 class SeatbeltBackend(Backend):
-    """macOS ``sandbox-exec`` backend with profile rendering only."""
+    """macOS ``sandbox-exec`` backend."""
 
     name = "seatbelt"
 
+    def __init__(self, binary: str | None = None) -> None:
+        self._binary = binary
+
     def available(self) -> bool:
-        # Backend.available() means "can execute SandboxRequest", not merely
-        # "can render a profile". Keep this false until run() is implemented.
-        return False
+        if sys.platform != "darwin":
+            return False
+        return _sandbox_exec_binary(self._binary) is not None
 
-    async def run(self, request: SandboxRequest) -> SandboxResult:  # noqa: ARG002
-        raise NotImplementedError(
-            "macOS Seatbelt backend currently renders profiles only; "
-            "process execution is pending — "
-            "see opensquilla/sandbox/backend/seatbelt.py"
-        )
+    async def run(self, request: SandboxRequest) -> SandboxResult:
+        if not self.available():
+            raise SandboxBackendError(
+                "seatbelt backend unavailable: missing 'sandbox-exec' binary on macOS"
+            )
+        _validate_request(request)
+
+        tmp_ctx: tempfile.TemporaryDirectory[str] | None = None
+        profile_file: tempfile.NamedTemporaryFile[str] | None = None
+        try:
+            tmp_dir: Path | None = None
+            if request.policy.tmp_writable:
+                tmp_ctx = tempfile.TemporaryDirectory(prefix="opensquilla-seatbelt-tmp-")
+                tmp_dir = Path(tmp_ctx.name)
+
+            profile = render_seatbelt_profile(request, tmp_dir=tmp_dir)
+            profile_file = tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                prefix="opensquilla-seatbelt-",
+                suffix=".sb",
+                delete=False,
+            )
+            try:
+                profile_file.write(profile)
+                profile_file.flush()
+            finally:
+                profile_file.close()
+
+            profile_path = Path(profile_file.name)
+            argv = build_seatbelt_argv(request, profile_path, binary=self._binary)
+            env = _env_for_policy(request.policy, request.env, tmp_dir=tmp_dir)
+
+            log.info(
+                "sandbox.seatbelt_spawn: action=%s level=%s network=%s argv_len=%d",
+                request.action_kind,
+                request.policy.level.label,
+                request.policy.network.value,
+                len(argv),
+            )
+
+            wall = request.policy.limits.wall_timeout_s
+            started = time.monotonic()
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *argv,
+                    stdin=asyncio.subprocess.PIPE if request.stdin is not None else None,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=str(request.cwd),
+                    env=env,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                raise SandboxBackendError(f"seatbelt launch failed: {exc}") from exc
+            except OSError as exc:
+                raise SandboxBackendError(f"seatbelt launch failed: {exc}") from exc
+
+            timed_out = False
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(input=request.stdin), timeout=wall
+                )
+            except TimeoutError:
+                timed_out = True
+                stdout_bytes, stderr_bytes = await _terminate_process_group(proc)
+
+            elapsed = time.monotonic() - started
+            stdout, trunc_out = _decode_capped(stdout_bytes)
+            stderr, trunc_err = _decode_capped(stderr_bytes)
+            returncode = proc.returncode if proc.returncode is not None else -1
+            notes: tuple[_SeatbeltNote, ...] = ()
+            if not timed_out and returncode != 0:
+                notes = _classify_denial(request.argv, stderr)
+                for note in notes:
+                    log.info(
+                        "sandbox.seatbelt_note: category=%s argv0=%s blocked_path=%s action=%s",
+                        note.category,
+                        Path(request.argv[0]).name if request.argv else "",
+                        note.blocked_path,
+                        request.action_kind,
+                    )
+            return SandboxResult(
+                returncode=returncode,
+                stdout=stdout,
+                stderr=stderr,
+                wall_time_s=elapsed,
+                backend_used=self.name,
+                policy_used=request.policy.summary(),
+                truncated_stdout=trunc_out,
+                truncated_stderr=trunc_err,
+                timed_out=timed_out,
+                backend_notes=tuple(n.to_user_string() for n in notes),
+            )
+        finally:
+            if profile_file is not None:
+                with contextlib.suppress(OSError):
+                    os.unlink(profile_file.name)
+            if tmp_ctx is not None:
+                tmp_ctx.cleanup()
 
 
-__all__ = ["SeatbeltBackend", "_render_sbpl_skeleton"]
+def _decode_capped(raw: bytes | None) -> tuple[str, bool]:
+    if not raw:
+        return "", False
+    if len(raw) <= _OUTPUT_BYTE_CAP:
+        return raw.decode("utf-8", errors="replace"), False
+    return raw[:_OUTPUT_BYTE_CAP].decode("utf-8", errors="replace"), True
+
+
+async def _terminate_process_group(
+    proc: asyncio.subprocess.Process,
+) -> tuple[bytes, bytes]:
+    pid = proc.pid
+    os_mod = cast(Any, os)
+    signal_mod = cast(Any, signal)
+    try:
+        os_mod.killpg(pid, signal_mod.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        pass
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=_TERMINATE_GRACE_S)
+    except TimeoutError:
+        try:
+            os_mod.killpg(pid, signal_mod.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+        try:
+            await proc.wait()
+        except ProcessLookupError:
+            pass
+
+    stdout = b""
+    stderr = b""
+    if proc.stdout is not None:
+        try:
+            stdout = await proc.stdout.read()
+        except Exception:  # noqa: BLE001
+            stdout = b""
+    if proc.stderr is not None:
+        try:
+            stderr = await proc.stderr.read()
+        except Exception:  # noqa: BLE001
+            stderr = b""
+    return stdout, stderr
+
+
+# ─── Denial classifier ───────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _SeatbeltNote:
+    """One classified denial extracted from sandbox-exec stderr."""
+
+    category: str
+    hint: str
+    blocked_path: Path | None = None
+
+    def to_user_string(self) -> str:
+        return f"{self.category}: {self.hint}"
+
+
+_STDERR_SCAN_BYTES = 8192
+
+_EXECVP_RE = re.compile(
+    r"sandbox-exec:\s+execvp\(\)\s+of\s+'([^']+)'\s+failed:\s+Operation not permitted"
+)
+_DYLD_RE = re.compile(r"dyld(?:\[\d+\])?:\s*Library not loaded:\s*(\S+)")
+_OPNOTPERM_RE = re.compile(
+    r"(?:at\s+'([^']+)'[^\n]*\(Operation not permitted\))"
+    r"|(/[^\s:]+):\s*Operation not permitted"
+)
+_TMP_RE = re.compile(r"\b(mkstemp|mkdtemp|tmpfile)\b.*(?:permitted|denied|failed)")
+
+
+def _classify_denial(argv: tuple[str, ...], stderr: str) -> tuple[_SeatbeltNote, ...]:
+    """Scan the tail of ``stderr`` for known Seatbelt denial signatures."""
+    if not stderr:
+        return ()
+    tail = stderr[-_STDERR_SCAN_BYTES:]
+    notes: list[_SeatbeltNote] = []
+    seen: set[tuple[str, str]] = set()
+
+    def _add(note: _SeatbeltNote) -> None:
+        key = (note.category, str(note.blocked_path))
+        if key in seen:
+            return
+        seen.add(key)
+        notes.append(note)
+
+    for match in _EXECVP_RE.finditer(tail):
+        path = Path(match.group(1))
+        _add(_SeatbeltNote(
+            category="execve.denied",
+            hint=f"sandbox blocked execve of {path}",
+            blocked_path=path,
+        ))
+
+    for match in _DYLD_RE.finditer(tail):
+        path = Path(match.group(1))
+        _add(_SeatbeltNote(
+            category="filesystem.read",
+            hint=f"dyld could not load {path}",
+            blocked_path=path,
+        ))
+
+    for match in _OPNOTPERM_RE.finditer(tail):
+        raw_path = match.group(1) or match.group(2)
+        if not raw_path:
+            continue
+        path = Path(raw_path)
+        if any(n.blocked_path == path for n in notes):
+            continue
+        _add(_SeatbeltNote(
+            category="filesystem.read",
+            hint=f"sandbox blocked access to {path}",
+            blocked_path=path,
+        ))
+
+    if _TMP_RE.search(tail):
+        _add(_SeatbeltNote(category="tmp.denied", hint="sandbox denied a tmp-directory operation"))
+
+    return tuple(notes)
+
+
+__all__ = [
+    "SeatbeltBackend",
+    "build_seatbelt_argv",
+    "render_seatbelt_profile",
+    "_render_sbpl_skeleton",
+]

--- a/src/opensquilla/sandbox/integration.py
+++ b/src/opensquilla/sandbox/integration.py
@@ -166,9 +166,9 @@ def configure_runtime(
 def _apply_host_compatibility(settings: SandboxSettings) -> SandboxSettings:
     """Adjust unsupported platform defaults before runtime selection.
 
-    Windows currently has no real sandbox backend in this package. Treating
-    the generated default ``sandbox=true, backend=auto`` as a hard boot
-    failure makes local CLI one-shots unusable on Windows, even for read-only
+    Some platforms currently have no executable sandbox backend in this
+    package. Treating the generated default ``sandbox=true, backend=auto`` as a
+    hard boot failure makes local CLI one-shots unusable, even for read-only
     file tools. Keep explicit backend choices fail-closed, but make the auto
     choice resolve to the same visible insecure mode an operator would get by
     setting ``sandbox=false``.
@@ -182,6 +182,21 @@ def _apply_host_compatibility(settings: SandboxSettings) -> SandboxSettings:
         log.warning(
             "sandbox.windows_auto_backend_unsupported: "
             "no Windows sandbox backend is available; disabling sandbox for this runtime"
+        )
+        return settings.model_copy(
+            update={
+                "sandbox": False,
+                "security_grading": False,
+            }
+        )
+    if (
+        sys.platform == "darwin"
+        and settings.sandbox
+        and settings.backend == "auto"
+    ):
+        log.warning(
+            "sandbox.macos_auto_backend_unsupported: "
+            "macOS Seatbelt execution is not implemented; disabling sandbox for this runtime"
         )
         return settings.model_copy(
             update={

--- a/src/opensquilla/sandbox/integration.py
+++ b/src/opensquilla/sandbox/integration.py
@@ -29,6 +29,7 @@ host. See ``docs/adr/006-sandbox-governance.md`` for the active contract.
 
 from __future__ import annotations
 
+import dataclasses
 import functools
 import inspect
 import json
@@ -51,6 +52,7 @@ from opensquilla.sandbox.governance import (
 from opensquilla.sandbox.policy import LevelHints, build_policy, select_level
 from opensquilla.sandbox.stale_output_cache import StaleOutputCache, get_stale_output_cache
 from opensquilla.sandbox.types import (
+    ALLOW,
     ApprovalDecision,
     DenialReason,
     DenialResult,
@@ -182,21 +184,6 @@ def _apply_host_compatibility(settings: SandboxSettings) -> SandboxSettings:
         log.warning(
             "sandbox.windows_auto_backend_unsupported: "
             "no Windows sandbox backend is available; disabling sandbox for this runtime"
-        )
-        return settings.model_copy(
-            update={
-                "sandbox": False,
-                "security_grading": False,
-            }
-        )
-    if (
-        sys.platform == "darwin"
-        and settings.sandbox
-        and settings.backend == "auto"
-    ):
-        log.warning(
-            "sandbox.macos_auto_backend_unsupported: "
-            "macOS Seatbelt execution is not implemented; disabling sandbox for this runtime"
         )
         return settings.model_copy(
             update={
@@ -541,11 +528,61 @@ def _string_env(value: Any) -> dict[str, str] | None:
     return {str(k): str(v) for k, v in value.items()}
 
 
+async def escalate_backend_denial(
+    result: SandboxResult,
+    request: SandboxRequest,
+    policy: SandboxPolicy,
+    *,
+    runtime: SandboxRuntime | None = None,
+) -> ApprovalDecision:
+    """Escalate a seatbelt backend denial to the approval queue.
+
+    Called post-execution when ``result.backend_notes`` is non-empty.
+    Routes to the existing approval gate with ``require_approval=True`` so
+    the user is asked whether to re-run the command without sandbox
+    restrictions. Returns :data:`ALLOW` on approval or a
+    :class:`DenialResult` with ``retryable=False`` on denial.
+    """
+    fp = action_fingerprint(request)
+    notes_str = "; ".join(result.backend_notes)
+    rt = runtime or get_runtime()
+    if rt is None:
+        return DenialResult(
+            reason=DenialReason.SEATBELT_DENIED,
+            suggested_next_step=SuggestedNextStep.ASK_USER,
+            level=policy.level,
+            action_fingerprint=fp,
+            message=f"Sandbox denied the command ({notes_str}); no runtime to escalate.",
+            retryable=False,
+        )
+
+    session_id = _resolve_session_id(rt, None)
+    escalation_request = dataclasses.replace(request, reason=f"sandbox denied: {notes_str}")
+    escalation_policy = dataclasses.replace(policy, require_approval=True)
+
+    decision = await rt.gate.gate(escalation_request, escalation_policy, session_id=session_id)
+
+    if not isinstance(decision, DenialResult):
+        return ALLOW
+
+    denial = DenialResult(
+        reason=DenialReason.SEATBELT_DENIED,
+        suggested_next_step=SuggestedNextStep.ASK_USER,
+        level=policy.level,
+        action_fingerprint=fp,
+        message=f"Sandbox denied the command ({notes_str}). User did not grant approval.",
+        retryable=False,
+    )
+    await rt.ledger.record_denial(session_id, fp, denial.reason)
+    return denial
+
+
 __all__ = [
     "SandboxRuntime",
     "action_fingerprint",
     "build_request",
     "configure_runtime",
+    "escalate_backend_denial",
     "gate_action",
     "get_runtime",
     "record_success",

--- a/src/opensquilla/sandbox/types.py
+++ b/src/opensquilla/sandbox/types.py
@@ -202,6 +202,7 @@ class SandboxResult:
     truncated_stdout: bool = False
     truncated_stderr: bool = False
     timed_out: bool = False
+    backend_notes: tuple[str, ...] = field(default_factory=tuple)
 
     @property
     def ok(self) -> bool:
@@ -231,6 +232,7 @@ class DenialReason(StrEnum):
     THRESHOLD_EXCEEDED = "threshold_exceeded"
     REPEATED_SAME_INTENT = "repeated_same_intent"
     RUNTIME_UNCONFIGURED = "runtime_unconfigured"
+    SEATBELT_DENIED = "seatbelt_denied"
 
 
 class SuggestedNextStep(StrEnum):

--- a/src/opensquilla/tools/builtin/code_exec.py
+++ b/src/opensquilla/tools/builtin/code_exec.py
@@ -13,7 +13,12 @@ import tempfile
 import time
 from pathlib import Path
 
-from opensquilla.sandbox.integration import gate_action, get_runtime, run_under_backend
+from opensquilla.sandbox.integration import (
+    escalate_backend_denial,
+    gate_action,
+    get_runtime,
+    run_under_backend,
+)
 from opensquilla.sandbox.types import DenialResult, SandboxRequest
 from opensquilla.tools.registry import tool
 from opensquilla.tools.types import ToolError, current_tool_context
@@ -324,28 +329,15 @@ async def execute_code(
         )
         if isinstance(decision, DenialResult):
             return json.dumps(decision.to_dict())
+        backend_request = SandboxRequest(
+            argv=(python_bin, "-c", code),
+            cwd=request.cwd,
+            action_kind=request.action_kind,
+            policy=request.policy,
+            env=safe_env,
+        )
         try:
-            sandbox_result = await run_under_backend(
-                SandboxRequest(
-                    argv=(python_bin, "-c", code),
-                    cwd=request.cwd,
-                    action_kind=request.action_kind,
-                    policy=request.policy,
-                    env=safe_env,
-                ),
-                runtime=runtime,
-            )
-            elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
-            stdout = sandbox_result.stdout
-            stderr = sandbox_result.stderr
-            stderr = _append_code_exec_sandbox_network_hint(stdout=stdout, stderr=stderr)
-            return _execution_result_json(
-                returncode=sandbox_result.returncode,
-                stdout=stdout,
-                stderr=stderr,
-                timed_out=sandbox_result.timed_out,
-                elapsed_ms=elapsed_ms,
-            )
+            sandbox_result = await run_under_backend(backend_request, runtime=runtime)
         except Exception as exc:
             return _execution_result_json(
                 returncode=-1,
@@ -354,6 +346,56 @@ async def execute_code(
                 timed_out=False,
                 elapsed_ms=0,
             )
+        if sandbox_result.backend_notes:
+            escalation = await escalate_backend_denial(
+                sandbox_result, request, _policy, runtime=runtime
+            )
+            if isinstance(escalation, DenialResult):
+                return json.dumps(escalation.to_dict())
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    python_bin, "-c", code,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=str(workdir_path),
+                    env=safe_env,
+                )
+                try:
+                    stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                        proc.communicate(), timeout=timeout
+                    )
+                except TimeoutError:
+                    proc.kill()
+                    await proc.communicate()
+                    elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+                    return _execution_result_json(
+                        returncode=-1, stdout="", stderr=f"Execution timed out after {timeout}s",
+                        timed_out=True, elapsed_ms=elapsed_ms,
+                    )
+                elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+                return _execution_result_json(
+                    returncode=proc.returncode if proc.returncode is not None else -1,
+                    stdout=stdout_bytes.decode("utf-8", errors="replace"),
+                    stderr=stderr_bytes.decode("utf-8", errors="replace"),
+                    timed_out=False,
+                    elapsed_ms=elapsed_ms,
+                )
+            except Exception as exc:
+                return _execution_result_json(
+                    returncode=-1, stdout="", stderr=f"Execution error: {exc}",
+                    timed_out=False, elapsed_ms=0,
+                )
+        elapsed_ms = (time.monotonic_ns() - start_ns) // 1_000_000
+        stdout = sandbox_result.stdout
+        stderr = sandbox_result.stderr
+        stderr = _append_code_exec_sandbox_network_hint(stdout=stdout, stderr=stderr)
+        return _execution_result_json(
+            returncode=sandbox_result.returncode,
+            stdout=stdout,
+            stderr=stderr,
+            timed_out=sandbox_result.timed_out,
+            elapsed_ms=elapsed_ms,
+        )
 
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/src/opensquilla/tools/builtin/shell.py
+++ b/src/opensquilla/tools/builtin/shell.py
@@ -22,6 +22,7 @@ from opensquilla.sandbox.backend.noop import NoopBackend
 from opensquilla.sandbox.governance import action_fingerprint
 from opensquilla.sandbox.integration import (
     build_request,
+    escalate_backend_denial,
     gate_action,
     get_runtime,
     run_under_backend,
@@ -450,6 +451,32 @@ async def exec_command(
             sandbox_result = await run_under_backend(backend_request, runtime=runtime)
         except Exception as exc:
             raise ToolError(f"Sandboxed shell execution failed: {exc}") from exc
+        if sandbox_result.backend_notes:
+            escalation = await escalate_backend_denial(
+                sandbox_result, request, policy, runtime=runtime
+            )
+            if isinstance(escalation, DenialResult):
+                return json.dumps(escalation.to_dict())
+            try:
+                proc = await asyncio.create_subprocess_shell(
+                    command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                    cwd=cwd,
+                    env=merged_env,
+                )
+                try:
+                    stdout_bytes, _ = await asyncio.wait_for(
+                        proc.communicate(), timeout=effective_timeout
+                    )
+                except TimeoutError:
+                    proc.kill()
+                    await proc.communicate()
+                    return f"[timeout after {effective_timeout}s]\ncommand: {command}"
+                output = stdout_bytes.decode("utf-8", errors="replace")
+                return f"exit_code={proc.returncode}\n{output}"
+            except Exception as e:
+                return f"[error] {e}"
         output = sandbox_result.stdout
         if sandbox_result.stderr:
             output += sandbox_result.stderr

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -90,8 +90,6 @@ def test_readme_splits_user_paths_and_documents_preview_release_package() -> Non
         "local app without cloning the repository or installing Git, Git LFS, "
         "or `uv`." in normalized
     )
-    assert "Current preview packages:" in readme
-    assert "windows-x64-py312-recommended-portable.zip" in readme
     assert "macos-arm64-py312-recommended-portable.zip" not in readme
     assert "recommended-wheelhouse.zip" not in release_section
     assert "Public release packages are not published yet." not in readme
@@ -116,7 +114,6 @@ def test_readme_documents_router_defaults_and_feishu_as_channel_extra() -> None:
     )
     assert "recommended` enables SquillaRouter" in readme
     assert "Install channel extras into the same user-local command" in readme
-    assert "The recommended portable zip includes Feishu websocket support by default." in readme
     assert "Feishu websocket channel support" in readme
     assert "Optional: add a channel adapter only if you need one." in readme
     assert "powershell -ExecutionPolicy Bypass -File .\\install.ps1 -Extras feishu" in readme

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -639,7 +639,6 @@ def test_readme_distinguishes_recommended_profile_from_channel_extras() -> None:
     ) in readme
     assert "| Developer | [Develop from source](#develop-from-source) | Available now |" in readme
     assert "Download the preview package if you want to try OpenSquilla as a local app" in readme
-    assert "The recommended portable zip includes Feishu websocket support by default." in readme
     assert "`recommended` is the\nnormal runtime profile" in readme
     assert "Messaging channel adapters are opt-in extras." in readme
     assert "Feishu is shown only\nas an example channel adapter" in readme

--- a/tests/test_sandbox/test_escalate_backend_denial.py
+++ b/tests/test_sandbox/test_escalate_backend_denial.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opensquilla.sandbox.config import SandboxSettings
+from opensquilla.sandbox.integration import (
+    configure_runtime,
+    escalate_backend_denial,
+    reset_runtime,
+)
+from opensquilla.sandbox.types import (
+    ALLOW,
+    DenialReason,
+    DenialResult,
+    MountSpec,
+    NetworkMode,
+    ResourceLimits,
+    SandboxPolicy,
+    SandboxRequest,
+    SandboxResult,
+    SecurityLevel,
+)
+
+
+def _policy(workspace: Path) -> SandboxPolicy:
+    return SandboxPolicy(
+        level=SecurityLevel.STANDARD,
+        network=NetworkMode.NONE,
+        mounts=(MountSpec(host_path=workspace, sandbox_path=Path("/workspace"), mode="rw"),),
+        workspace_rw=True,
+        tmp_writable=True,
+        limits=ResourceLimits(),
+        env_allowlist=("PATH",),
+        require_approval=False,
+    )
+
+
+def _request(workspace: Path, policy: SandboxPolicy) -> SandboxRequest:
+    return SandboxRequest(
+        argv=("sh", "-c", "echo hi"),
+        cwd=workspace,
+        action_kind="shell.exec",
+        policy=policy,
+    )
+
+
+def _result_with_notes(notes: tuple[str, ...]) -> SandboxResult:
+    return SandboxResult(
+        returncode=1,
+        stdout="",
+        stderr="sandbox-exec: execvp() of '/opt/brew/bin/uv' failed: Operation not permitted",
+        wall_time_s=0.1,
+        backend_used="seatbelt",
+        backend_notes=notes,
+    )
+
+
+class _ApproveQueue:
+    def __init__(self, approve: bool) -> None:
+        self._approve = approve
+        self.last_params: dict | None = None
+
+    def request(self, namespace: str = "exec", params: dict | None = None) -> str:
+        self.last_params = params
+        return "approval:test"
+
+    async def wait(self, approval_id: str, timeout: float | None = None) -> bool:
+        return self._approve
+
+    def resolve(self, approval_id: str, approved: bool) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    yield
+    reset_runtime()
+
+
+@pytest.mark.asyncio
+async def test_escalate_routes_to_approval_gate_with_require_approval(tmp_path: Path) -> None:
+    queue = _ApproveQueue(approve=True)
+    configure_runtime(
+        SandboxSettings(sandbox=True, security_grading=False),
+        approval_queue=queue,
+        workspace=tmp_path,
+    )
+    policy = _policy(tmp_path)
+    request = _request(tmp_path, policy)
+    result = _result_with_notes(("execve.denied: sandbox blocked execve of /opt/brew/bin/uv",))
+
+    decision = await escalate_backend_denial(result, request, policy)
+
+    assert decision is ALLOW
+    assert queue.last_params is not None
+    assert "sandbox denied" in queue.last_params["reason"]
+
+
+@pytest.mark.asyncio
+async def test_escalate_returns_allow_on_user_approval(tmp_path: Path) -> None:
+    configure_runtime(
+        SandboxSettings(sandbox=True, security_grading=False),
+        approval_queue=_ApproveQueue(approve=True),
+        workspace=tmp_path,
+    )
+    policy = _policy(tmp_path)
+    result = _result_with_notes(("execve.denied: sandbox blocked execve of /bin/sh",))
+
+    decision = await escalate_backend_denial(result, _request(tmp_path, policy), policy)
+
+    assert decision is ALLOW
+
+
+@pytest.mark.asyncio
+async def test_escalate_returns_seatbelt_denied_on_rejection(tmp_path: Path) -> None:
+    configure_runtime(
+        SandboxSettings(sandbox=True, security_grading=False),
+        approval_queue=_ApproveQueue(approve=False),
+        workspace=tmp_path,
+    )
+    policy = _policy(tmp_path)
+    result = _result_with_notes(("filesystem.read: sandbox blocked access to /etc/ssl/cert.pem",))
+
+    decision = await escalate_backend_denial(result, _request(tmp_path, policy), policy)
+
+    assert isinstance(decision, DenialResult)
+    assert decision.reason == DenialReason.SEATBELT_DENIED
+    assert decision.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_escalate_no_runtime_returns_seatbelt_denied(tmp_path: Path) -> None:
+    reset_runtime()
+    policy = _policy(tmp_path)
+    result = _result_with_notes(("execve.denied: sandbox blocked execve of /bin/uv",))
+
+    decision = await escalate_backend_denial(result, _request(tmp_path, policy), policy)
+
+    assert isinstance(decision, DenialResult)
+    assert decision.reason == DenialReason.SEATBELT_DENIED
+    assert decision.retryable is False

--- a/tests/test_sandbox/test_seatbelt_backend.py
+++ b/tests/test_sandbox/test_seatbelt_backend.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from opensquilla.sandbox.backend import seatbelt as seatbelt_mod
+from opensquilla.sandbox.backend import select_backend
+from opensquilla.sandbox.backend.seatbelt import (
+    SeatbeltBackend,
+    _classify_denial,
+    build_seatbelt_argv,
+    render_seatbelt_profile,
+)
+from opensquilla.sandbox.config import SandboxSettings
+from opensquilla.sandbox.types import (
+    MountSpec,
+    NetworkMode,
+    ResourceLimits,
+    SandboxBackendError,
+    SandboxPolicy,
+    SandboxRequest,
+    SecurityLevel,
+)
+
+
+def _policy(
+    workspace: Path,
+    *,
+    network: NetworkMode = NetworkMode.NONE,
+    workspace_rw: bool = True,
+    tmp_writable: bool = True,
+    mounts: tuple[MountSpec, ...] | None = None,
+) -> SandboxPolicy:
+    base_mounts = (
+        MountSpec(
+            host_path=workspace,
+            sandbox_path=Path("/workspace"),
+            mode="rw" if workspace_rw else "ro",
+            required=True,
+        ),
+    )
+    return SandboxPolicy(
+        level=SecurityLevel.STANDARD,
+        network=network,
+        mounts=mounts or base_mounts,
+        workspace_rw=workspace_rw,
+        tmp_writable=tmp_writable,
+        limits=ResourceLimits(wall_timeout_s=0.1),
+        env_allowlist=("PATH", "LANG"),
+        require_approval=False,
+    )
+
+
+def _request(policy: SandboxPolicy, cwd: Path) -> SandboxRequest:
+    return SandboxRequest(
+        argv=("sh", "-lc", "echo ok"),
+        cwd=cwd,
+        action_kind="shell.exec",
+        policy=policy,
+        env={"PATH": "/bin", "SECRET": "nope"},
+    )
+
+
+def test_available_false_on_non_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(seatbelt_mod.sys, "platform", "linux")
+    assert SeatbeltBackend(binary="sandbox-exec").available() is False
+
+
+def test_available_true_on_macos_when_sandbox_exec_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(seatbelt_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(seatbelt_mod.shutil, "which", lambda name: "/usr/bin/sandbox-exec")
+    assert SeatbeltBackend(binary="sandbox-exec").available() is True
+
+
+def test_available_false_on_macos_when_sandbox_exec_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(seatbelt_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(seatbelt_mod.shutil, "which", lambda name: None)
+    assert SeatbeltBackend(binary="sandbox-exec").available() is False
+
+
+def test_auto_selects_seatbelt_on_macos_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.sandbox import backend as backend_mod
+
+    monkeypatch.setattr(backend_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(backend_mod.SeatbeltBackend, "available", lambda self: True)
+
+    backend = select_backend(SandboxSettings(sandbox=True, backend="auto"))
+
+    assert backend.name == "seatbelt"
+
+
+def test_explicit_seatbelt_fails_closed_when_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.sandbox import backend as backend_mod
+
+    monkeypatch.setattr(backend_mod.SeatbeltBackend, "available", lambda self: False)
+
+    with pytest.raises(SandboxBackendError, match="seatbelt.*unavailable"):
+        select_backend(SandboxSettings(sandbox=True, backend="seatbelt"))
+
+
+def test_profile_denies_default_and_network_none(tmp_path: Path) -> None:
+    profile = render_seatbelt_profile(_request(_policy(tmp_path), tmp_path))
+
+    assert "(deny default)" in profile
+    assert "(deny network*)" in profile
+    assert f'(allow file-read* (subpath "{tmp_path}"))' in profile
+    assert f'(allow file-write* (subpath "{tmp_path}"))' in profile
+
+
+def test_profile_allows_network_host(tmp_path: Path) -> None:
+    profile = render_seatbelt_profile(
+        _request(_policy(tmp_path, network=NetworkMode.HOST), tmp_path)
+    )
+
+    assert "(allow network*)" in profile
+
+
+def test_profile_rejects_proxy_allowlist(tmp_path: Path) -> None:
+    with pytest.raises(SandboxBackendError, match="PROXY_ALLOWLIST"):
+        render_seatbelt_profile(
+            _request(_policy(tmp_path, network=NetworkMode.PROXY_ALLOWLIST), tmp_path)
+        )
+
+
+def test_profile_keeps_workspace_ro_when_policy_ro(tmp_path: Path) -> None:
+    profile = render_seatbelt_profile(
+        _request(_policy(tmp_path, workspace_rw=False), tmp_path)
+    )
+
+    assert f'(allow file-read* (subpath "{tmp_path}"))' in profile
+    assert f'(allow file-write* (subpath "{tmp_path}"))' not in profile
+
+
+def test_profile_escapes_paths(tmp_path: Path) -> None:
+    hostile = tmp_path / 'quote"path'
+    hostile.mkdir()
+    policy = _policy(
+        hostile,
+        mounts=(
+            MountSpec(
+                host_path=hostile,
+                sandbox_path=Path("/workspace"),
+                mode="rw",
+                required=True,
+            ),
+        ),
+    )
+
+    profile = render_seatbelt_profile(_request(policy, hostile))
+
+    assert '\\"' in profile
+    assert '"quote"path"' not in profile
+
+
+def test_missing_required_mount_raises(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"
+    policy = _policy(
+        tmp_path,
+        mounts=(
+            MountSpec(
+                host_path=missing,
+                sandbox_path=Path("/workspace"),
+                mode="ro",
+                required=True,
+            ),
+        ),
+    )
+
+    with pytest.raises(SandboxBackendError, match="required mount missing"):
+        seatbelt_mod._validate_request(_request(policy, tmp_path))
+
+
+def test_missing_optional_mount_is_skipped(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"
+    policy = _policy(
+        tmp_path,
+        mounts=(
+            MountSpec(
+                host_path=tmp_path,
+                sandbox_path=Path("/workspace"),
+                mode="rw",
+                required=True,
+            ),
+            MountSpec(
+                host_path=missing,
+                sandbox_path=missing,
+                mode="rw",
+                required=False,
+            ),
+        ),
+    )
+
+    profile = render_seatbelt_profile(_request(policy, tmp_path))
+
+    assert str(missing) not in profile
+
+
+def test_build_argv_uses_sandbox_exec(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        seatbelt_mod,
+        "_sandbox_exec_binary",
+        lambda binary=None: "/usr/bin/sandbox-exec",
+    )
+
+    argv = build_seatbelt_argv(
+        _request(_policy(tmp_path), tmp_path),
+        tmp_path / "profile.sb",
+    )
+
+    assert argv[:3] == ["/usr/bin/sandbox-exec", "-f", str(tmp_path / "profile.sb")]
+    assert argv[3:] == ["sh", "-lc", "echo ok"]
+
+
+@pytest.mark.asyncio
+async def test_run_filters_env_and_returns_nonzero_without_raise(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeProcess:
+        pid = 12345
+        returncode = 7
+
+        async def communicate(self, input: bytes | None = None) -> tuple[bytes, bytes]:
+            return b"", b"nope"
+
+    async def fake_create_subprocess_exec(*argv: str, **kwargs: object) -> FakeProcess:
+        captured["argv"] = argv
+        captured["env"] = kwargs["env"]
+        captured["cwd"] = kwargs["cwd"]
+        return FakeProcess()
+
+    monkeypatch.setattr(seatbelt_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        seatbelt_mod,
+        "_sandbox_exec_binary",
+        lambda binary=None: "/usr/bin/sandbox-exec",
+    )
+    monkeypatch.setattr(
+        seatbelt_mod.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    result = await SeatbeltBackend().run(_request(_policy(tmp_path), tmp_path))
+
+    assert result.returncode == 7
+    assert result.stderr == "nope"
+    assert result.backend_used == "seatbelt"
+    assert result.timed_out is False
+    assert captured["cwd"] == str(tmp_path)
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["PATH"] == "/bin"
+    assert "SECRET" not in env
+    assert "TMPDIR" in env
+
+
+@pytest.mark.asyncio
+async def test_run_timeout_returns_timed_out_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class FakeProcess:
+        pid = 12345
+        returncode = -15
+        stdout = None
+        stderr = None
+
+        async def communicate(self, input: bytes | None = None) -> tuple[bytes, bytes]:
+            await asyncio.sleep(1)
+            return b"", b""
+
+        async def wait(self) -> None:
+            return None
+
+    async def fake_create_subprocess_exec(*argv: str, **kwargs: object) -> FakeProcess:
+        return FakeProcess()
+
+    monkeypatch.setattr(seatbelt_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        seatbelt_mod,
+        "_sandbox_exec_binary",
+        lambda binary=None: "/usr/bin/sandbox-exec",
+    )
+    monkeypatch.setattr(
+        seatbelt_mod.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(seatbelt_mod.os, "killpg", lambda pid, sig: None)
+
+    result = await SeatbeltBackend().run(_request(_policy(tmp_path), tmp_path))
+
+    assert result.timed_out is True
+    assert result.returncode == -15
+
+
+@pytest.mark.asyncio
+async def test_real_seatbelt_runs_python_when_available(tmp_path: Path) -> None:
+    if not SeatbeltBackend().available():
+        pytest.skip("requires macOS sandbox-exec")
+    policy = _policy(tmp_path)
+    request = SandboxRequest(
+        argv=(sys.executable, "-c", "print('ok')"),
+        cwd=tmp_path,
+        action_kind="code.exec",
+        policy=policy,
+        env={"PATH": "/bin:/usr/bin"},
+    )
+
+    result = await SeatbeltBackend().run(request)
+
+    assert result.returncode == 0
+    assert result.stdout == "ok\n"
+    assert result.stderr == ""
+
+
+@pytest.mark.asyncio
+async def test_real_seatbelt_blocks_write_outside_workspace_when_available(
+    tmp_path: Path,
+) -> None:
+    if not SeatbeltBackend().available():
+        pytest.skip("requires macOS sandbox-exec")
+    outside = tmp_path.parent / "seatbelt-outside.txt"
+    policy = _policy(tmp_path)
+    request = SandboxRequest(
+        argv=(
+            sys.executable,
+            "-c",
+            f"open({str(outside)!r}, 'w').write('blocked')",
+        ),
+        cwd=tmp_path,
+        action_kind="code.exec",
+        policy=policy,
+        env={"PATH": "/bin:/usr/bin"},
+    )
+
+    result = await SeatbeltBackend().run(request)
+
+    assert result.returncode != 0
+    assert "PermissionError" in result.stderr
+    assert not outside.exists()
+
+
+# ─── _classify_denial tests ───────────────────────────────────────────────
+
+
+def test_classify_denial_execvp_blocked() -> None:
+    stderr = "sandbox-exec: execvp() of '/opt/homebrew/bin/uv' failed: Operation not permitted"
+    notes = _classify_denial(("sh",), stderr)
+    assert len(notes) == 1
+    assert notes[0].category == "execve.denied"
+    assert "/opt/homebrew/bin/uv" in notes[0].hint
+
+
+def test_classify_denial_filesystem_read_blocked() -> None:
+    stderr = "/etc/ssl/cert.pem: Operation not permitted"
+    notes = _classify_denial(("python",), stderr)
+    assert len(notes) == 1
+    assert notes[0].category == "filesystem.read"
+    assert "/etc/ssl/cert.pem" in notes[0].hint
+
+
+def test_classify_denial_dyld_library_not_loaded() -> None:
+    stderr = "dyld[123]: Library not loaded: /opt/homebrew/opt/openssl/lib/libssl.dylib"
+    notes = _classify_denial(("python",), stderr)
+    assert len(notes) == 1
+    assert notes[0].category == "filesystem.read"
+    assert "libssl.dylib" in notes[0].hint
+
+
+def test_classify_denial_empty_stderr_returns_empty() -> None:
+    assert _classify_denial(("sh",), "") == ()
+
+
+def test_classify_denial_unrelated_stderr_returns_empty() -> None:
+    assert _classify_denial(("sh",), "syntax error near unexpected token") == ()
+
+
+def test_classify_denial_deduplicates_same_path() -> None:
+    stderr = (
+        "/etc/ssl/cert.pem: Operation not permitted\n"
+        "/etc/ssl/cert.pem: Operation not permitted\n"
+    )
+    notes = _classify_denial(("python",), stderr)
+    assert len(notes) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_populates_backend_notes_on_denial(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    denial_stderr = (
+        "sandbox-exec: execvp() of '/opt/homebrew/bin/uv' failed: Operation not permitted"
+    )
+
+    class FakeProcess:
+        pid = 12345
+        returncode = 1
+
+        async def communicate(self, input: bytes | None = None) -> tuple[bytes, bytes]:
+            return b"", denial_stderr.encode()
+
+    async def fake_create(*args: object, **kwargs: object) -> FakeProcess:
+        return FakeProcess()
+
+    monkeypatch.setattr(seatbelt_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        seatbelt_mod, "_sandbox_exec_binary", lambda binary=None: "/usr/bin/sandbox-exec"
+    )
+    monkeypatch.setattr(seatbelt_mod.asyncio, "create_subprocess_exec", fake_create)
+
+    result = await SeatbeltBackend().run(_request(_policy(tmp_path), tmp_path))
+
+    assert len(result.backend_notes) == 1
+    assert result.backend_notes[0].startswith("execve.denied:")
+
+
+@pytest.mark.asyncio
+async def test_run_backend_notes_empty_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class FakeProcess:
+        pid = 12345
+        returncode = 0
+
+        async def communicate(self, input: bytes | None = None) -> tuple[bytes, bytes]:
+            return b"ok", b""
+
+    async def fake_create(*args: object, **kwargs: object) -> FakeProcess:
+        return FakeProcess()
+
+    monkeypatch.setattr(seatbelt_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        seatbelt_mod, "_sandbox_exec_binary", lambda binary=None: "/usr/bin/sandbox-exec"
+    )
+    monkeypatch.setattr(seatbelt_mod.asyncio, "create_subprocess_exec", fake_create)
+
+    result = await SeatbeltBackend().run(_request(_policy(tmp_path), tmp_path))
+
+    assert result.backend_notes == ()

--- a/tests/test_sandbox/test_windows_auto_backend.py
+++ b/tests/test_sandbox/test_windows_auto_backend.py
@@ -48,6 +48,45 @@ def test_windows_auto_backend_disables_sandbox_runtime(
     assert runtime.backend.name == "noop"
 
 
+def test_macos_auto_backend_disables_sandbox_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from opensquilla.sandbox import integration
+
+    monkeypatch.setattr(integration.sys, "platform", "darwin")
+
+    runtime = configure_runtime(
+        SandboxSettings(sandbox=True, security_grading=True, backend="auto"),
+        approval_queue=_FakeApprovalQueue(),
+        workspace=tmp_path,
+    )
+
+    assert runtime.settings.sandbox is False
+    assert runtime.settings.security_grading is False
+    assert runtime.effective.sandbox_enabled is False
+    assert runtime.effective.grading_enabled is False
+    assert runtime.backend.name == "noop"
+
+
+def test_explicit_macos_seatbelt_backend_still_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from opensquilla.sandbox import backend as backend_mod
+    from opensquilla.sandbox import integration
+
+    monkeypatch.setattr(integration.sys, "platform", "darwin")
+    monkeypatch.setattr(backend_mod.sys, "platform", "darwin")
+
+    with pytest.raises(SandboxBackendError, match="sandbox backend 'seatbelt' is unavailable"):
+        configure_runtime(
+            SandboxSettings(sandbox=True, security_grading=True, backend="seatbelt"),
+            approval_queue=_FakeApprovalQueue(),
+            workspace=tmp_path,
+        )
+
+
 def test_linux_auto_backend_without_real_backend_still_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_sandbox/test_windows_auto_backend.py
+++ b/tests/test_sandbox/test_windows_auto_backend.py
@@ -48,13 +48,20 @@ def test_windows_auto_backend_disables_sandbox_runtime(
     assert runtime.backend.name == "noop"
 
 
-def test_macos_auto_backend_disables_sandbox_runtime(
+def test_macos_auto_backend_selects_seatbelt_when_available(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    from opensquilla.sandbox import backend as backend_mod
     from opensquilla.sandbox import integration
 
     monkeypatch.setattr(integration.sys, "platform", "darwin")
+    monkeypatch.setattr(backend_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        backend_mod.SeatbeltBackend,
+        "available",
+        lambda self: True,
+    )
 
     runtime = configure_runtime(
         SandboxSettings(sandbox=True, security_grading=True, backend="auto"),
@@ -62,11 +69,11 @@ def test_macos_auto_backend_disables_sandbox_runtime(
         workspace=tmp_path,
     )
 
-    assert runtime.settings.sandbox is False
-    assert runtime.settings.security_grading is False
-    assert runtime.effective.sandbox_enabled is False
-    assert runtime.effective.grading_enabled is False
-    assert runtime.backend.name == "noop"
+    assert runtime.settings.sandbox is True
+    assert runtime.settings.security_grading is True
+    assert runtime.effective.sandbox_enabled is True
+    assert runtime.effective.grading_enabled is True
+    assert runtime.backend.name == "seatbelt"
 
 
 def test_explicit_macos_seatbelt_backend_still_fails_closed(
@@ -78,6 +85,11 @@ def test_explicit_macos_seatbelt_backend_still_fails_closed(
 
     monkeypatch.setattr(integration.sys, "platform", "darwin")
     monkeypatch.setattr(backend_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        backend_mod.SeatbeltBackend,
+        "available",
+        lambda self: False,
+    )
 
     with pytest.raises(SandboxBackendError, match="sandbox backend 'seatbelt' is unavailable"):
         configure_runtime(


### PR DESCRIPTION
## Summary

- Adds macOS Seatbelt sandbox execution: deny-default SBPL profile,
  workspace/tmp/mounts boundary, 9 compatibility profiles for common
  runtimes (python, uv, node, git, homebrew, shell), env allowlist
  filter, and wall-clock timeout with SIGTERM→SIGKILL escalation
- Adds denial classifier (`execve.denied` / `filesystem.read` /
  `tmp.denied`) with results surfaced via `SandboxResult.backend_notes`
  to `shell.exec`, `code_exec`, and background session payloads
- Adds background-process parity: spawns background processes under
  `sandbox-exec` with cleanup callbacks and classifier run on merged
  output at session finalization
- Design is intentionally lean: single `_DEFAULT_ENV_ALLOWLIST`,
  two-mode network (NONE / HOST), no operator-facing overrides — the
  default settings are the supported deployment shape

## Test plan

- [x] `uv run --extra dev pytest tests/test_sandbox/` passes on macOS dev host (`104 passed`)
- [x] `uv run --extra dev ruff check src/opensquilla/sandbox src/opensquilla/tools/builtin/shell.py src/opensquilla/tools/builtin/code_exec.py tests/test_sandbox tests/test_tools/test_sandbox_backend_notes_surface.py tests/test_tools/test_shell_background_seatbelt.py` exits clean
- [x] Manual smoke: `shell.exec`-equivalent Seatbelt run with sandbox on passes; deliberate out-of-allowance write returns non-zero and surfaces useful `backend_notes` denial hints
