### PR TITLE
Keep preview release assets versioned

### DIFF
--- a/.github/workflows/wheelhouse-release.yml
+++ b/.github/workflows/wheelhouse-release.yml
@@ -197,15 +197,20 @@ jobs:
                   )
           PY
 
-      - name: Create stable release assets
+      - name: Create release assets
         shell: bash
         run: |
           python - <<'PY'
           import hashlib
+          import re
           import shutil
+          import tomllib
           from pathlib import Path
 
           dist = Path("dist")
+          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          version = project["project"]["version"]
+          is_prerelease = bool(re.search(r"(?:a|b|rc)[0-9]+$", version))
           zips = sorted(
               path for path in dist.glob("OpenSquilla-*.zip")
               if path.name != "OpenSquilla-windows-x64-portable.zip"
@@ -216,11 +221,13 @@ jobs:
           )
           assert len(zips) == 1, f"expected one versioned portable zip, got {len(zips)}"
           assert len(wheels) == 1, f"expected one versioned wheel, got {len(wheels)}"
-          stable_zip = dist / "OpenSquilla-windows-x64-portable.zip"
-          stable_wheel = dist / "opensquilla-latest-py3-none-any.whl"
-          shutil.copy2(zips[0], stable_zip)
-          shutil.copy2(wheels[0], stable_wheel)
-          assets = [zips[0], stable_zip, wheels[0], stable_wheel]
+          assets = [zips[0], wheels[0]]
+          if not is_prerelease:
+              stable_zip = dist / "OpenSquilla-windows-x64-portable.zip"
+              stable_wheel = dist / "opensquilla-latest-py3-none-any.whl"
+              shutil.copy2(zips[0], stable_zip)
+              shutil.copy2(wheels[0], stable_wheel)
+              assets = [zips[0], stable_zip, wheels[0], stable_wheel]
           lines = [
               f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}"
               for path in assets
@@ -257,9 +264,14 @@ jobs:
         run: |
           python - <<'PY'
           import hashlib
+          import re
+          import tomllib
           from pathlib import Path
 
           dist = Path("dist")
+          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          version = project["project"]["version"]
+          is_prerelease = bool(re.search(r"(?:a|b|rc)[0-9]+$", version))
           versioned_zips = sorted(
               path for path in dist.glob("OpenSquilla-*.zip")
               if path.name != "OpenSquilla-windows-x64-portable.zip"
@@ -273,10 +285,12 @@ jobs:
           sha256s = dist / "SHA256SUMS"
           assert len(versioned_zips) == 1, f"expected one versioned portable zip, got {len(versioned_zips)}"
           assert len(versioned_wheels) == 1, f"expected one versioned wheel, got {len(versioned_wheels)}"
-          assert stable_zip.is_file(), "missing stable portable zip"
-          assert stable_wheel.is_file(), "missing stable wheel"
           assert sha256s.is_file(), "missing SHA256SUMS"
-          assets = [versioned_zips[0], stable_zip, versioned_wheels[0], stable_wheel]
+          assets = [versioned_zips[0], versioned_wheels[0]]
+          if not is_prerelease:
+              assert stable_zip.is_file(), "missing stable portable zip"
+              assert stable_wheel.is_file(), "missing stable wheel"
+              assets = [versioned_zips[0], stable_zip, versioned_wheels[0], stable_wheel]
           expected = [
               f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}"
               for path in assets
@@ -367,15 +381,16 @@ jobs:
           python - <<'PY'
           import json
           import os
+          import re
           import subprocess
           import sys
 
-          expected = {
-              "OpenSquilla-windows-x64-portable.zip",
-              "opensquilla-latest-py3-none-any.whl",
-              "SHA256SUMS",
-          }
           tag = os.environ["TAG"]
+          is_prerelease = bool(re.search(r"(?:a|b|rc)[0-9]+$", tag))
+          expected = {"SHA256SUMS"}
+          if not is_prerelease:
+              expected.add("OpenSquilla-windows-x64-portable.zip")
+              expected.add("opensquilla-latest-py3-none-any.whl")
           raw = subprocess.check_output(
               ["gh", "release", "view", tag, "--json", "assets"],
               text=True,

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,17 +2,20 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
-| 0.2.0rc1 | v0.2.0rc1 | 2026-05-17 | Next public preview |
+| 0.2.0rc1 | v0.2.0rc1 | 2026-05-19 | Second public preview |
 | 0.1.0rc1 | v0.1.0rc1 | 2026-05-12 | First public preview |
 
-Each preview or stable release publishes one cross-platform wheel plus
-Windows-only portable runtime assets:
+Preview releases publish only versioned assets:
 
 - `OpenSquilla-<version>-windows-x64-py312-recommended-portable.zip`
-- `OpenSquilla-windows-x64-portable.zip`
 - `opensquilla-<version>-py3-none-any.whl`
-- `opensquilla-latest-py3-none-any.whl`
 - `SHA256SUMS`
+
+Stable releases additionally publish version-independent aliases for
+`/releases/latest/download/` URLs:
+
+- `OpenSquilla-windows-x64-portable.zip`
+- `opensquilla-latest-py3-none-any.whl`
 
 GitHub source archives remain available for code review and developer
 reference; source installs should use `git clone` plus Git LFS. Public
@@ -37,7 +40,7 @@ non-pre-release GitHub Release exists.
 4. `git tag -a v0.2.0rc1 -m "OpenSquilla 0.2.0 Preview 1"`
 5. `git push origin v0.2.0rc1` (this triggers `.github/workflows/wheelhouse-release.yml`)
 6. Wait for the Windows release workflow → review the draft GitHub Release.
-   Confirm it contains exactly the five OpenSquilla assets listed above, plus
+   Confirm it contains exactly the three preview assets listed above, plus
    GitHub's generated source archives, before publishing.
 7. Confirm the draft GitHub Release is marked as a pre-release.
 8. Publish the GitHub Release, then run the post-publish tag URL checks:
@@ -63,7 +66,9 @@ These checks cannot be fully proven by local artifact generation:
 
 - The tag exists on GitHub and matches `pyproject.toml`.
 - The release workflow can fetch hydrated Git LFS router assets.
-- The GitHub Release contains the versioned assets, stable aliases, and
+- Preview GitHub Releases contain the versioned assets and `SHA256SUMS` after
+  `gh release upload --clobber`.
+- Stable GitHub Releases contain the versioned assets, stable aliases, and
   `SHA256SUMS` after `gh release upload --clobber`.
 - After a stable GitHub Release is published, the stable release URLs resolve:
   `.../releases/latest/download/OpenSquilla-windows-x64-portable.zip` and

--- a/tests/test_public_release_hygiene.py
+++ b/tests/test_public_release_hygiene.py
@@ -160,6 +160,8 @@ def test_release_sop_documents_github_only_validation_boundary() -> None:
 
     required_phrases = [
         "GitHub-only release checks",
+        "Preview releases publish only versioned assets",
+        "Stable releases additionally publish version-independent aliases",
         "OpenSquilla-windows-x64-portable.zip",
         "opensquilla-latest-py3-none-any.whl",
         "SHA256SUMS",

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -126,3 +126,7 @@ def test_release_workflow_marks_preview_tags_as_prereleases() -> None:
     assert "IS_PRERELEASE" in workflow
     assert "--prerelease" in workflow
     assert "OpenSquilla {match.group(1)} Preview {match.group(2)}" in workflow
+    assert "is_prerelease = bool(re.search" in workflow
+    assert "if not is_prerelease:" in workflow
+    assert "expected.add(\"OpenSquilla-windows-x64-portable.zip\")" in workflow
+    assert "expected.add(\"opensquilla-latest-py3-none-any.whl\")" in workflow

--- a/tests/test_scripts/test_build_wheelhouse_zip.py
+++ b/tests/test_scripts/test_build_wheelhouse_zip.py
@@ -820,6 +820,8 @@ def test_release_workflow_publishes_windows_portable_zip_and_wheel() -> None:
     assert "SHA256SUMS" in workflow
     assert "manifest.version" in workflow
     assert "GH_REPO: ${{ github.repository }}" in workflow
+    assert "is_prerelease = bool(re.search" in workflow
+    assert "if not is_prerelease:" in workflow
     assert "OpenSquilla-windows-x64-portable.zip" in workflow
     assert "opensquilla-latest-py3-none-any.whl" in workflow
     assert "dist/*.zip dist/*.whl dist/SHA256SUMS" in workflow


### PR DESCRIPTION
## Summary
- publish stable alias assets only for non-prerelease versions
- keep preview release SHA256SUMS limited to versioned wheel and portable zip
- update RELEASES.md and release contract tests for preview vs stable asset sets

## Tests
- uv run --extra dev pytest tests/test_release_consistency.py tests/test_public_release_hygiene.py tests/test_scripts/test_build_wheelhouse_zip.py -q
- git diff --check