### PR TITLE
Prepare OpenSquilla 0.2.0 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: OpenSquilla version or commit
       description: Use the release version or commit hash where the issue occurs.
-      placeholder: "0.1.0 or commit hash"
+      placeholder: "0.2.0 or commit hash"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-## [0.2.0rc1] - 2026-05-18
+## [0.2.0] - 2026-05-20
 
 ### Added
 
@@ -41,16 +41,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Memory surfaces now separate curated memory from raw transcript search, recall
   prior-session evidence, keep manual Dream runs on configured memory
   workspaces, and let compaction continue when memory flush degrades.
-- Release/install support now includes tag-pinned preview URLs, reproducible
-  wheel/portable release guidance, source install scripts, Windows portable
-  hardening, ONNX/router recovery messaging, and Docker/compose alignment on
-  the gateway port.
+- Release/install support now includes versioned release URLs,
+  latest-download aliases, reproducible wheel/portable release guidance,
+  source install scripts, Windows portable hardening, ONNX/router recovery
+  messaging, and Docker/compose alignment on the gateway port.
 
 ### Changed
 
-- Release installation docs now use version-pinned `0.2.0rc1` asset URLs for
-  preview installs and reserve `/releases/latest/download/` aliases for stable
-  releases.
+- Release installation docs now use 0.2.0 release asset URLs and
+  `/releases/latest/download/` aliases for the current wheel and Windows
+  portable zip.
 - Cron tool calls now require structured schedule input (`{kind, ...}`) instead
   of backend natural-language schedule parsing. CLI cron flags still accept
   standard user-facing forms such as `--cron`, `--every`, `--at`, and
@@ -69,8 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   runtime-backed state for recency ordering, per-turn token metrics, provider
   badges, setup form behavior, and session cancellation/readback.
 - The default gateway/release documentation now centers on port `18791`, and
-  preview release URLs are tag-pinned until a stable release can use latest
-  aliases.
+  release download paths use the current 0.2.0 assets.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,11 @@ Open pull requests against `dev` by default. OpenSquilla uses `dev` as the activ
 
 Use `main` only for maintainer-directed release candidates, release stabilization, documentation-only preview, or urgent hotfix work that starts from the current published line. When in doubt, target `dev`; maintainers will route release-ready changes from `dev` to `main`. If a pull request was opened against `main` by mistake, retarget it to `dev` before review.
 
+After a release, maintainers may start a new development cycle from the
+latest `main` release point. When that requires replacing the active
+`dev` branch, the previous branch will be archived and contributors
+will be asked to rebase or retarget open pull requests.
+
 ## Default Checks
 
 Install development dependencies:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ OpenRouter, OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope,
 and 20+ other LLM providers with no change to your code or config
 schema.
 
-OpenSquilla is in active preview (0.2.0 Preview 1).
+OpenSquilla 0.2.0 is the current release.
 
 ---
 
@@ -47,8 +47,9 @@ Windows portable and Quick terminal install give you a prebuilt
 and Develop from source — build **from a Git checkout** (`git clone` +
 Git LFS).
 
-Preview install commands use version-pinned download URLs. The
-`/releases/latest/download/` aliases are reserved for stable releases.
+Release install commands use published GitHub release assets. The
+`/releases/latest/download/` aliases point to the current release wheel
+and Windows portable zip.
 
 | Path | Audience | When to use |
 | --- | --- | --- |
@@ -88,8 +89,8 @@ Install links: [Git](https://git-scm.com/downloads) ·
 The fastest path on Windows — the zip ships a bundled CPython runtime,
 so no separate Python install is required.
 
-1. Download the 0.2.0 Preview 1 portable zip:
-   <https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/OpenSquilla-0.2.0rc1-windows-x64-py312-recommended-portable.zip>
+1. Download the 0.2.0 portable zip:
+   <https://github.com/opensquilla/opensquilla/releases/latest/download/OpenSquilla-windows-x64-portable.zip>
 2. Extract it to a writable folder such as Downloads or Documents,
    then right-click `Start OpenSquilla.cmd` and choose **Run as
    administrator**.
@@ -154,7 +155,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Install OpenSquilla** — the same command on every platform.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/opensquilla-0.2.0rc1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/latest/download/opensquilla-latest-py3-none-any.whl"
 ```
 
 This installs the OpenSquilla wheel from the release URL, then lets
@@ -174,8 +175,8 @@ opensquilla gateway run
 > If `opensquilla` is not found right after a fresh `uv` install, open
 > a new terminal, or re-run the PATH line from step 1.
 
-Stable releases can use the version-independent wheel alias
-`https://github.com/opensquilla/opensquilla/releases/latest/download/opensquilla-latest-py3-none-any.whl`.
+For a fully pinned install, use the versioned wheel URL:
+`https://github.com/opensquilla/opensquilla/releases/download/v0.2.0/opensquilla-0.2.0-py3-none-any.whl`.
 
 ### Install from source
 
@@ -283,10 +284,12 @@ local checkout, restart the gateway so it loads the updated package.
 
 ### Develop from source
 
-Use this path only to modify, test, or debug the current checkout.
-Unlike [Install from source](#install-from-source), this path requires
-`uv`: `uv sync` creates a checkout-local `.venv` and `uv run` executes
-against the live source tree.
+Use this path when you are working on OpenSquilla's source code:
+making changes, running tests, or debugging behavior against this
+checkout. It is not the normal install path. Unlike
+[Install from source](#install-from-source), this path requires `uv`:
+`uv sync` creates a repository-local `.venv`, and `uv run` executes
+commands against the files in this checkout.
 
 ```sh
 uv sync --extra recommended --extra dev
@@ -455,9 +458,9 @@ settings live in `opensquilla.toml.example`.
 
 ---
 
-## What's New in 0.2.0 Preview 1
+## What's New in 0.2.0
 
-This preview expands OpenSquilla across migration, CLI chat, channels,
+This release expands OpenSquilla across migration, CLI chat, channels,
 scheduling, and long-running tool work:
 
 - **Migration path from existing agent homes** — `opensquilla migrate` previews
@@ -481,7 +484,7 @@ scheduling, and long-running tool work:
   make large tool-heavy sessions more predictable.
 - **Web UI and release polish** — recency ordering, table layout, mobile
   controls, duplicate notifications, setup forms, release URLs, and install
-  paths are tightened for the preview.
+  paths are tightened for 0.2.0.
 
 Full notes: [`CHANGELOG.md`](CHANGELOG.md) ·
 [release notes](https://opensquilla.ai/news/).

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 0.2.0 | v0.2.0 | 2026-05-20 | 0.2 release |
 | 0.2.0rc1 | v0.2.0rc1 | 2026-05-19 | Second public preview |
 | 0.1.0rc1 | v0.1.0rc1 | 2026-05-12 | First public preview |
 
@@ -11,7 +12,7 @@ Preview releases publish only versioned assets:
 - `opensquilla-<version>-py3-none-any.whl`
 - `SHA256SUMS`
 
-Stable releases additionally publish version-independent aliases for
+Non-preview releases additionally publish version-independent aliases for
 `/releases/latest/download/` URLs:
 
 - `OpenSquilla-windows-x64-portable.zip`
@@ -20,8 +21,8 @@ Stable releases additionally publish version-independent aliases for
 GitHub source archives remain available for code review and developer
 reference; source installs should use `git clone` plus Git LFS. Public
 wheelhouse zips, macOS portable zips, and Linux portable zips are intentionally
-not published for this preview. macOS and Linux users install the same
-versioned wheel through the `uv tool install` command documented in the README.
+not published for 0.2.x. macOS and Linux users install the same wheel through
+the `uv tool install` command documented in the README.
 
 Preview releases are GitHub pre-releases. Their README install commands must
 use tag-pinned URLs such as:
@@ -29,36 +30,39 @@ use tag-pinned URLs such as:
 - `https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/OpenSquilla-0.2.0rc1-windows-x64-py312-recommended-portable.zip`
 - `https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/opensquilla-0.2.0rc1-py3-none-any.whl`
 
-Stable releases may use the `/releases/latest/download/` aliases after a
-non-pre-release GitHub Release exists.
+0.2.0 install commands may use the `/releases/latest/download/` aliases after
+the non-pre-release GitHub Release exists. Fully pinned URLs remain available:
 
-## Preview tag SOP
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.2.0/OpenSquilla-0.2.0-windows-x64-py312-recommended-portable.zip`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.2.0/opensquilla-0.2.0-py3-none-any.whl`
+
+## Release SOP
 
 1. Verify `git status` is clean.
-2. Update `CHANGELOG.md`: move entries from `[Unreleased]` to `[0.2.0rc1] - <date>` section; reopen empty `[Unreleased]`.
-3. Bump `pyproject.toml` to `0.2.0rc1`.
-4. `git tag -a v0.2.0rc1 -m "OpenSquilla 0.2.0 Preview 1"`
-5. `git push origin v0.2.0rc1` (this triggers `.github/workflows/wheelhouse-release.yml`)
+2. Update `CHANGELOG.md`: move entries from `[Unreleased]` to the release section; reopen empty `[Unreleased]`.
+3. Bump `pyproject.toml` and `uv.lock` to the release version.
+4. `git tag -a v0.2.0 -m "OpenSquilla 0.2.0"`
+5. `git push origin v0.2.0` (this triggers `.github/workflows/wheelhouse-release.yml`)
 6. Wait for the Windows release workflow → review the draft GitHub Release.
-   Confirm it contains exactly the three preview assets listed above, plus
-   GitHub's generated source archives, before publishing.
-7. Confirm the draft GitHub Release is marked as a pre-release.
+   For non-preview releases, confirm it contains versioned assets, latest
+   aliases, `SHA256SUMS`, plus GitHub's generated source archives before
+   publishing.
+7. Confirm the draft GitHub Release is not marked as a pre-release.
 8. Publish the GitHub Release, then run the post-publish tag URL checks:
 
    ```sh
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/OpenSquilla-0.2.0rc1-windows-x64-py312-recommended-portable.zip
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/opensquilla-0.2.0rc1-py3-none-any.whl
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.2.0/OpenSquilla-0.2.0-windows-x64-py312-recommended-portable.zip
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.2.0/opensquilla-0.2.0-py3-none-any.whl
    ```
 
-9. For stable `0.2.0`, publish a non-pre-release GitHub Release and run the
-   post-publish latest URL checks:
+9. Run the post-publish latest URL checks:
 
    ```sh
    curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/latest/download/OpenSquilla-windows-x64-portable.zip
    curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/latest/download/opensquilla-latest-py3-none-any.whl
    ```
 
-10. For subsequent previews: bump `pyproject.toml`, `uv.lock`, `CHANGELOG.md`, and the tag to `0.2.0rc2`, `v0.2.0rc2`, etc.
+10. For subsequent previews: bump `pyproject.toml`, `uv.lock`, `CHANGELOG.md`, and the tag to `0.3.0rc1`, `v0.3.0rc1`, etc. Preview GitHub Releases must be marked as pre-releases and should use tag-pinned README URLs until the next non-preview release exists.
 
 ## GitHub-only release checks
 
@@ -68,9 +72,9 @@ These checks cannot be fully proven by local artifact generation:
 - The release workflow can fetch hydrated Git LFS router assets.
 - Preview GitHub Releases contain the versioned assets and `SHA256SUMS` after
   `gh release upload --clobber`.
-- Stable GitHub Releases contain the versioned assets, stable aliases, and
+- Non-preview GitHub Releases contain the versioned assets, latest aliases, and
   `SHA256SUMS` after `gh release upload --clobber`.
-- After a stable GitHub Release is published, the stable release URLs resolve:
+- After a non-preview GitHub Release is published, the latest release URLs resolve:
   `.../releases/latest/download/OpenSquilla-windows-x64-portable.zip` and
   `.../releases/latest/download/opensquilla-latest-py3-none-any.whl`.
 - After a preview GitHub Release is published, the tag-pinned release asset URLs
@@ -79,7 +83,7 @@ These checks cannot be fully proven by local artifact generation:
   Smart App Control, enterprise policy, and unsigned binary reputation must be
   checked on a real Windows machine.
 
-## Why the package version uses rc
+## Why preview package versions use rc
 
 Release zips are distributed as built artifacts, so the package filename,
 manifest, zip name, and tag should describe the same preview build. PEP 440

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v0.2.0rc1'
+$defaultVersion = 'v0.2.0'
 $repoSlug = if ($env:OPENSQUILLA_REPOSITORY) { $env:OPENSQUILLA_REPOSITORY } else { 'opensquilla/opensquilla' }
 $pythonVersion = if ($env:OPENSQUILLA_PYTHON_VERSION) { $env:OPENSQUILLA_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -99,7 +99,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.2.0rc1. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.2.0. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v0.2.0rc1"
+default_version="v0.2.0"
 repo_slug="${OPENSQUILLA_REPOSITORY:-opensquilla/opensquilla}"
 python_version="${OPENSQUILLA_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v0.2.0rc1|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v0.2.0|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  OPENSQUILLA_VERSION=v0.2.0rc1
+  OPENSQUILLA_VERSION=v0.2.0
   OPENSQUILLA_INSTALL_PROFILE=recommended|core
   OPENSQUILLA_INSTALL_EXTRAS=matrix
   OPENSQUILLA_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported OPENSQUILLA_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.2.0rc1." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.2.0." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensquilla"
-version = "0.2.0rc1"
+version = "0.2.0"
 description = "OpenSquilla — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -38,7 +38,7 @@ def test_release_installers_install_version_pinned_wheel_with_uv() -> None:
     sh = RELEASE_SH.read_text(encoding="utf-8")
 
     for script in (ps1, sh):
-        assert "v0.2.0rc1" in script
+        assert "v0.2.0" in script
         assert "opensquilla-$releaseVersion-py3-none-any.whl" in script or (
             "opensquilla-${release_version}-py3-none-any.whl" in script
         )

--- a/tests/test_public_release_hygiene.py
+++ b/tests/test_public_release_hygiene.py
@@ -161,11 +161,11 @@ def test_release_sop_documents_github_only_validation_boundary() -> None:
     required_phrases = [
         "GitHub-only release checks",
         "Preview releases publish only versioned assets",
-        "Stable releases additionally publish version-independent aliases",
+        "Non-preview releases additionally publish version-independent aliases",
         "OpenSquilla-windows-x64-portable.zip",
         "opensquilla-latest-py3-none-any.whl",
         "SHA256SUMS",
-        "stable release URLs resolve",
+        "latest release URLs resolve",
         "post-publish latest URL checks",
         "curl --fail --head --location",
         "wheelhouse zips, macOS portable zips, and Linux portable zips are intentionally",

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -3,23 +3,25 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
+CURRENT_VERSION = "0.2.0"
+CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.2.0rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"
 
 
-def test_pyproject_version_matches_preview_release() -> None:
+def test_pyproject_version_matches_current_release() -> None:
     config = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     version = config["project"]["version"]
-    assert version == PREVIEW_VERSION, (
-        f"pyproject.toml version must match the preview release; got '{version}'"
+    assert version == CURRENT_VERSION, (
+        f"pyproject.toml version must match the current release; got '{version}'"
     )
 
 
-def test_lockfile_version_matches_preview_release() -> None:
+def test_lockfile_version_matches_current_release() -> None:
     lock = tomllib.loads(Path("uv.lock").read_text(encoding="utf-8"))
     package = next(item for item in lock["package"] if item["name"] == "opensquilla")
 
-    assert package["version"] == PREVIEW_VERSION
+    assert package["version"] == CURRENT_VERSION
 
 
 def _dep_names(specs: list[str]) -> set[str]:
@@ -79,41 +81,46 @@ def test_core_dependencies_support_default_pptx_skill() -> None:
     assert any(dep.startswith("python-pptx") for dep in dependencies)
 
 
-def test_releases_md_exists_and_references_preview_tag() -> None:
+def test_releases_md_exists_and_references_current_and_preview_tags() -> None:
     releases = Path("RELEASES.md")
     assert releases.is_file(), "RELEASES.md must exist at the repository root"
     text = releases.read_text(encoding="utf-8")
+    assert CURRENT_TAG in text, f"RELEASES.md must reference the tag '{CURRENT_TAG}'"
     assert PREVIEW_TAG in text, f"RELEASES.md must reference the tag '{PREVIEW_TAG}'"
 
 
-def test_changelog_has_preview_section_and_unreleased() -> None:
+def test_changelog_has_current_release_section_and_unreleased() -> None:
     changelog = Path("CHANGELOG.md")
     assert changelog.is_file(), "CHANGELOG.md must exist at the repository root"
     text = changelog.read_text(encoding="utf-8")
     assert (
-        f"[{PREVIEW_VERSION}]" in text
-    ), f"CHANGELOG.md must contain a [{PREVIEW_VERSION}] section"
+        f"[{CURRENT_VERSION}]" in text
+    ), f"CHANGELOG.md must contain a [{CURRENT_VERSION}] section"
     assert "[Unreleased]" in text, "CHANGELOG.md must retain an [Unreleased] section"
 
 
-def test_readme_preview_install_uses_tag_pinned_assets() -> None:
+def test_readme_release_install_uses_latest_assets_and_pinned_alternative() -> None:
     readme = Path("README.md").read_text(encoding="utf-8")
 
     assert (
-        f"releases/download/{PREVIEW_TAG}/OpenSquilla-{PREVIEW_VERSION}-windows-x64-py312-recommended-portable.zip"
+        "releases/latest/download/OpenSquilla-windows-x64-portable.zip"
         in readme
     )
     assert (
-        f"releases/download/{PREVIEW_TAG}/opensquilla-{PREVIEW_VERSION}-py3-none-any.whl"
+        "releases/latest/download/opensquilla-latest-py3-none-any.whl"
         in readme
     )
-    assert "Preview install commands use version-pinned download URLs" in readme
+    assert (
+        f"releases/download/{CURRENT_TAG}/opensquilla-{CURRENT_VERSION}-py3-none-any.whl"
+        in readme
+    )
+    assert "Release install commands use published GitHub release assets" in readme
 
 
-def test_release_installers_default_to_preview_tag() -> None:
+def test_release_installers_default_to_current_tag() -> None:
     for path in [Path("install.sh"), Path("install.ps1")]:
         text = path.read_text(encoding="utf-8")
-        assert PREVIEW_TAG in text
+        assert CURRENT_TAG in text
         assert "opensquilla-$releaseVersion-py3-none-any.whl" in text or (
             "opensquilla-${release_version}-py3-none-any.whl" in text
         )

--- a/uv.lock
+++ b/uv.lock
@@ -1644,7 +1644,7 @@ wheels = [
 
 [[package]]
 name = "opensquilla"
-version = "0.2.0rc1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Prepare the final 0.2.0 release metadata, install URLs, release docs, and release hygiene tests on a dedicated release branch.

This PR intentionally does not change runtime source code. Keep it as a draft until we are ready to publish `v0.2.0`; merging it early would make `main` advertise final release download aliases before the GitHub Release exists.

## Scope

- Bump package metadata from `0.2.0rc1` to `0.2.0`.
- Update README install links and 0.2.0 wording.
- Update CHANGELOG and RELEASES for the 0.2.0 release path.
- Point release installers at `v0.2.0` by default.
- Update release/install tests for current 0.2.0 metadata while preserving preview-release checks.

## Release Checklist

- [ ] Confirm no open `release-blocker-0.2` issues.
- [ ] Merge this PR to `main` only when ready to tag and publish.
- [ ] Tag `v0.2.0` from `main`.
- [ ] Wait for the release workflow draft.
- [ ] Publish GitHub Release as a non-prerelease.
- [ ] Verify versioned assets and latest-download aliases.

## Tested

```text
uv lock --check
bash -n install.sh
uv run --no-sync pytest tests/test_public_release_hygiene.py tests/test_release_consistency.py tests/test_scripts/test_build_wheelhouse_zip.py tests/test_install_scripts.py -q
57 passed
```

## Not Tested

- GitHub release workflow execution.
- Post-publish asset URL checks.
