### PR TITLE
Fix release asset publishing without repository checkout

### DIFF
--- a/.github/workflows/wheelhouse-release.yml
+++ b/.github/workflows/wheelhouse-release.yml
@@ -264,13 +264,12 @@ jobs:
         run: |
           python - <<'PY'
           import hashlib
+          import os
           import re
-          import tomllib
           from pathlib import Path
 
           dist = Path("dist")
-          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
-          version = project["project"]["version"]
+          version = os.environ["RELEASE_TAG"].removeprefix("v")
           is_prerelease = bool(re.search(r"(?:a|b|rc)[0-9]+$", version))
           versioned_zips = sorted(
               path for path in dist.glob("OpenSquilla-*.zip")


### PR DESCRIPTION
## Summary

Fix the release publishing workflow so the publish job verifies downloaded
assets using the explicit release tag instead of reading repository files that
are not checked out in that job.

This was discovered while publishing v0.2.0: the tag build produced valid
assets, but the publish job failed before upload because `pyproject.toml` was
unavailable. The v0.2.0 release was published by dispatching this fixed
workflow from the repair branch against the existing tag.

## Scope

- Derive prerelease status from `RELEASE_TAG` in the publish job.
- Leave the v0.2.0 tag unchanged.
- No runtime/package behavior changes.

## Tested

```text
uv run --no-sync pytest tests/test_public_release_hygiene.py tests/test_release_consistency.py tests/test_scripts/test_build_wheelhouse_zip.py -q
49 passed

GitHub Actions workflow_dispatch for v0.2.0 from this branch:
Build Windows release assets: passed
Publish release assets: passed
```

## Not Tested

- A future tag push after this workflow fix lands on main.