### PR TITLE
Add tokenjuice tool compression mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 /dist/
-build/
+/build/
 .venv/
 .env
 .env.test
@@ -47,7 +47,7 @@ GEMINI.md
 !/assets/*.png
 !/src/opensquilla/gateway/static/img/*.png
 site/
-plugins/
+/plugins/
 crontab-*
 ~/
 /docs/

--- a/src/opensquilla/cli/chat_cmd.py
+++ b/src/opensquilla/cli/chat_cmd.py
@@ -1639,8 +1639,9 @@ async def _handle_tool_compress_command(
     arg = parts[1].lower() if len(parts) > 1 else "status"
     aliases = {"on": "truncate", "trim": "truncate", "summary": "summarize"}
     mode_arg = aliases.get(arg, arg)
-    if len(parts) > 2 or mode_arg not in {"off", "truncate", "summarize", "status"}:
-        console.print("[red]Usage: /tool-compress [off|truncate|summarize|status][/red]")
+    modes = {"off", "truncate", "summarize", "tokenjuice", "status"}
+    if len(parts) > 2 or mode_arg not in modes:
+        console.print("[red]Usage: /tool-compress [off|truncate|summarize|tokenjuice|status][/red]")
         return
 
     enabled_path = "agent_token_saving.tool_result_compression_enabled"
@@ -1654,7 +1655,7 @@ async def _handle_tool_compress_command(
             mode = await client.get_config(mode_path)
             enabled = bool(await client.get_config(enabled_path))
             model = await client.get_config(model_path)
-            mode = mode if mode in {"off", "truncate", "summarize"} else None
+            mode = mode if mode in {"off", "truncate", "summarize", "tokenjuice"} else None
             resolved_mode = str(mode or ("truncate" if enabled else "off"))
         else:
             resolved_mode = mode_arg
@@ -1674,7 +1675,7 @@ async def _handle_tool_compress_command(
             mode = getattr(cfg, "tool_result_compression_mode", None)
             enabled = bool(getattr(cfg, "tool_result_compression_enabled", True))
             model = getattr(cfg, "tool_result_compression_summary_model", None)
-            if mode in {"off", "truncate", "summarize"}:
+            if mode in {"off", "truncate", "summarize", "tokenjuice"}:
                 resolved_mode = str(mode)
             else:
                 resolved_mode = "truncate" if enabled else "off"

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -35,6 +35,7 @@ from opensquilla.engine.session_sanitize import (
     session_payload_chars,
 )
 from opensquilla.engine.thinking import drop_reasoning
+from opensquilla.engine.tokenjuice_adapter import reduce_tool_result_with_tokenjuice
 from opensquilla.engine.tool_result_store import (
     ToolResultRecord,
     ToolResultStore,
@@ -576,6 +577,7 @@ class Agent:
         self._session_flush_service = session_flush_service
         self._last_compaction_refusal_reason: str | None = None
         self._tool_failure_loop_counts: dict[tuple[str, str], int] = {}
+        self._provider_tool_result_overrides: dict[str, ContentBlockToolResult] = {}
 
     def _context_overflow_error(self) -> ErrorEvent:
         reason = self._last_compaction_refusal_reason
@@ -826,6 +828,64 @@ class Agent:
             return False
 
     @staticmethod
+    def _tool_call_string_arg(
+        tool_call: ToolCall | None,
+        *names: str,
+    ) -> str | None:
+        if tool_call is None:
+            return None
+        for name in names:
+            value = tool_call.arguments.get(name)
+            if isinstance(value, str) and value.strip():
+                return value
+        return None
+
+    def _tokenjuice_max_inline_chars(self, fallback: int | None = None) -> int:
+        if fallback is not None and fallback > 0:
+            return max(1, int(fallback))
+        budget_chars = int(
+            self.config.context_window_tokens
+            * self.config.tool_result_compression_max_share
+            * 4
+        )
+        return max(
+            1,
+            min(
+                budget_chars,
+                self.config.tool_result_compression_summary_input_max_chars,
+            ),
+        )
+
+    def _tokenjuice_tool_reduction(
+        self,
+        *,
+        tool_name: str,
+        content: str,
+        is_error: bool,
+        tool_use_id: str,
+        arguments: dict[str, Any] | None = None,
+        command: str | None = None,
+        cwd: str | None = None,
+        max_inline_chars: int | None = None,
+    ) -> str | None:
+        reduction = reduce_tool_result_with_tokenjuice(
+            tool_name=tool_name,
+            content=content,
+            is_error=is_error,
+            tool_use_id=tool_use_id,
+            arguments=arguments,
+            command=command,
+            cwd=cwd,
+            max_inline_chars=self._tokenjuice_max_inline_chars(max_inline_chars),
+        )
+        if reduction is None:
+            return None
+        self.config.metadata["tool_compression_backend"] = "tokenjuice"
+        if reduction.reducer:
+            self.config.metadata["tool_compression_tokenjuice_reducer"] = reduction.reducer
+        return reduction.inline_text
+
+    @staticmethod
     def _count_image_blocks(messages: list[Message]) -> int:
         count = 0
         for message in messages:
@@ -836,7 +896,7 @@ class Agent:
 
     def _tool_result_compression_mode(self) -> str:
         mode = self.config.tool_result_compression_mode
-        if mode in {"off", "truncate", "summarize"}:
+        if mode in {"off", "truncate", "summarize", "tokenjuice"}:
             return mode
         return "truncate" if self.config.tool_result_compression_enabled else "off"
 
@@ -1450,7 +1510,12 @@ class Agent:
             max_share=self.config.tool_result_compression_max_share,
         )
 
-    async def _compress_tool_result(self, result: ToolResult) -> ToolResult:
+    async def _compress_tool_result(
+        self,
+        result: ToolResult,
+        *,
+        tool_call: ToolCall | None = None,
+    ) -> ToolResult:
         guarded_content, guarded = _omit_large_json_tool_fields(result.content)
         if guarded:
             result = ToolResult(
@@ -1477,7 +1542,19 @@ class Agent:
         compressed_content: str | None = None
         applied_mode = mode
         budget_class = resolve_budget_class(result.tool_name)
-        if budget_class is ToolResultBudgetClass.CONTROL:
+        if mode == "tokenjuice":
+            compressed_content = self._tokenjuice_tool_reduction(
+                tool_name=result.tool_name,
+                content=result.content,
+                is_error=result.is_error,
+                tool_use_id=result.tool_use_id,
+                arguments=tool_call.arguments if tool_call is not None else None,
+                command=self._tool_call_string_arg(tool_call, "command"),
+                cwd=self._tool_call_string_arg(tool_call, "workdir", "cwd"),
+            )
+            if compressed_content is None:
+                return result
+        elif budget_class is ToolResultBudgetClass.CONTROL:
             compressed_content = compact_tool_result_content(
                 tool_name=result.tool_name,
                 content=result.content,
@@ -1609,6 +1686,8 @@ class Agent:
         semantic_message: str | None = None,
     ) -> AsyncIterator[AgentEvent]:
         """Async generator that drives the state machine."""
+        self._provider_tool_result_overrides = {}
+
         # ------ IDLE → THINKING ------
         yield self._transition(AgentState.THINKING)
 
@@ -3165,6 +3244,7 @@ class Agent:
                 # Emit results in original tool_calls order.
                 for tc in tool_calls:
                     result = results_by_id[tc.tool_use_id]
+                    result_tool_call = tc
                     for artifact in result.artifacts:
                         yield ArtifactEvent(**_artifact_event_kwargs(artifact))
                     yield ToolResultEvent(
@@ -3194,6 +3274,7 @@ class Agent:
                             origin_trace=tc.origin_trace,
                         )
                         result = await _run_one(retry_call)
+                        result_tool_call = retry_call
                         for artifact in result.artifacts:
                             yield ArtifactEvent(**_artifact_event_kwargs(artifact))
                         yield ToolResultEvent(
@@ -3205,6 +3286,19 @@ class Agent:
                             execution_status=result.execution_status,
                         )
                     executed_results.append(result)
+                    compressed_result = await self._compress_tool_result(
+                        result,
+                        tool_call=result_tool_call,
+                    )
+                    if compressed_result.content != result.content:
+                        self._provider_tool_result_overrides[result.tool_use_id] = (
+                            ContentBlockToolResult(
+                                tool_use_id=compressed_result.tool_use_id,
+                                content=compressed_result.content,
+                                is_error=compressed_result.is_error,
+                                execution_status=compressed_result.execution_status,
+                            )
+                        )
                     while self._pending_warnings:
                         yield self._pending_warnings.pop(0)
                     if self._is_turn_yield_result(result):
@@ -3447,6 +3541,7 @@ class Agent:
             runtime_context_message,
             runtime_context_insert_index,
         )
+        source_messages = self._apply_provider_tool_result_overrides(source_messages)
         source_messages = self._strip_provider_context_marker_replay_for_provider(
             source_messages
         )
@@ -3457,6 +3552,39 @@ class Agent:
             source_messages
         )
         return sanitize_session_messages(source_messages)
+
+    def _apply_provider_tool_result_overrides(self, messages: list[Message]) -> list[Message]:
+        if not self._provider_tool_result_overrides:
+            return messages
+
+        projected: list[Message] = []
+        changed = False
+        for message in messages:
+            if not isinstance(message.content, list):
+                projected.append(message)
+                continue
+            blocks: list[Any] = []
+            message_changed = False
+            for block in message.content:
+                if isinstance(block, ContentBlockToolResult):
+                    override = self._provider_tool_result_overrides.get(block.tool_use_id)
+                    if override is not None:
+                        blocks.append(override)
+                        message_changed = True
+                        continue
+                blocks.append(block)
+            if message_changed:
+                projected.append(
+                    Message(
+                        role=message.role,
+                        content=blocks,
+                        reasoning_content=message.reasoning_content,
+                    )
+                )
+                changed = True
+            else:
+                projected.append(message)
+        return projected if changed else messages
 
     @staticmethod
     def _provider_request_is_smaller(before: list[Message], after: list[Message]) -> bool:

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -1553,7 +1553,23 @@ class Agent:
                 cwd=self._tool_call_string_arg(tool_call, "workdir", "cwd"),
             )
             if compressed_content is None:
-                return result
+                applied_mode = "tokenjuice_fallback_truncate"
+                self.config.metadata["tool_compression_tokenjuice_fallbacks"] = (
+                    self.config.metadata.get("tool_compression_tokenjuice_fallbacks", 0) + 1
+                )
+            elif self._tool_result_over_budget(compressed_content):
+                compressed_content = truncate_result(
+                    compressed_content,
+                    self.config.context_window_tokens,
+                    max_share=self.config.tool_result_compression_max_share,
+                )
+                applied_mode = "tokenjuice_truncate"
+                self.config.metadata["tool_compression_tokenjuice_over_budget_fallbacks"] = (
+                    self.config.metadata.get(
+                        "tool_compression_tokenjuice_over_budget_fallbacks", 0
+                    )
+                    + 1
+                )
         elif budget_class is ToolResultBudgetClass.CONTROL:
             compressed_content = compact_tool_result_content(
                 tool_name=result.tool_name,

--- a/src/opensquilla/engine/commands.py
+++ b/src/opensquilla/engine/commands.py
@@ -304,11 +304,12 @@ _COMMANDS: tuple[CommandDef, ...] = (
     ),
     CommandDef(
         name="/tool-compress",
-        usage="/tool-compress [off|truncate|summarize|status]",
+        usage="/tool-compress [off|truncate|summarize|tokenjuice|status]",
         description="Show or set tool result compression mode.",
         execution={_T: _local("tool-compress.status"), _S: _local("tool-compress.status")},
         argument_choices=(
             ArgumentChoice("off", "Disable tool result compression."),
+            ArgumentChoice("tokenjuice", "Reduce structured tool results with tokenjuice rules."),
             ArgumentChoice("truncate", "Truncate long tool results."),
             ArgumentChoice("status", "Show current compression mode."),
             ArgumentChoice("summarize", "Summarize long tool results."),

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -2445,7 +2445,7 @@ class TurnRunner:
         if agent_token_cfg is None:
             return "truncate"
         mode = getattr(agent_token_cfg, "tool_result_compression_mode", None)
-        if mode in {"off", "truncate", "summarize"}:
+        if mode in {"off", "truncate", "summarize", "tokenjuice"}:
             return str(mode)
         return (
             "truncate"

--- a/src/opensquilla/engine/tokenjuice_adapter.py
+++ b/src/opensquilla/engine/tokenjuice_adapter.py
@@ -1,0 +1,74 @@
+"""Tokenjuice bridge for OpenSquilla tool-result compression."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from opensquilla.plugins.tokenjuice import reduce_tool_result as _reduce_tool_result_plugin
+
+
+@dataclass(frozen=True)
+class TokenjuiceReduction:
+    inline_text: str
+    raw_chars: int
+    reduced_chars: int
+    ratio: float
+    reducer: str | None = None
+
+
+def _string_arg(args: dict[str, Any] | None, *names: str) -> str | None:
+    if not args:
+        return None
+    for name in names:
+        value = args.get(name)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def reduce_tool_result_with_tokenjuice(
+    *,
+    tool_name: str,
+    content: str,
+    is_error: bool,
+    tool_use_id: str,
+    arguments: dict[str, Any] | None = None,
+    command: str | None = None,
+    cwd: str | None = None,
+    max_inline_chars: int | None = None,
+    timeout_seconds: float = 5.0,
+) -> TokenjuiceReduction | None:
+    """Run the built-in tokenjuice plugin for a tool result.
+
+    Returns ``None`` when tokenjuice fails or does not reduce the result.
+    Compression is best-effort because tool output must never fail an agent turn.
+    """
+
+    del timeout_seconds
+    command = command or _string_arg(arguments, "command")
+    cwd = cwd or _string_arg(arguments, "workdir", "cwd")
+    try:
+        reduction = _reduce_tool_result_plugin(
+            tool_name=tool_name,
+            content=content,
+            is_error=is_error,
+            tool_use_id=tool_use_id,
+            arguments=arguments,
+            command=command,
+            cwd=cwd,
+            max_inline_chars=max_inline_chars,
+        )
+    except Exception:
+        return None
+    if reduction is None:
+        return None
+    if len(reduction.inline_text) >= len(content):
+        return None
+    return TokenjuiceReduction(
+        inline_text=reduction.inline_text,
+        raw_chars=reduction.raw_chars,
+        reduced_chars=reduction.reduced_chars,
+        ratio=reduction.ratio,
+        reducer=reduction.reducer,
+    )

--- a/src/opensquilla/engine/tool_truncation.py
+++ b/src/opensquilla/engine/tool_truncation.py
@@ -19,19 +19,26 @@ def truncate_result(
     Returns original text if within budget.
     """
     budget_tokens = int(context_window_tokens * max_share)
-    text_tokens = estimate_tokens(text)
+    budget_chars = max(0, budget_tokens * 4)
 
-    if text_tokens <= budget_tokens:
+    if budget_chars <= 0:
+        return ""
+
+    if budget_chars >= len(text):
         return text
 
-    # Convert token budget to char budget (4 chars per token)
-    budget_chars = budget_tokens * 4
-    head_chars = int(budget_chars * 0.70)
-    tail_chars = int(budget_chars * 0.20)
+    keep_chars = max(0, int(budget_chars * 0.90))
+    while keep_chars >= 0:
+        head_chars = int(keep_chars * 0.70)
+        tail_chars = keep_chars - head_chars
+        omitted = len(text) - head_chars - tail_chars
+        marker = f"\n[...truncated {omitted} chars...]\n"
+        if len(marker) > budget_chars:
+            break
+        tail = text[-tail_chars:] if tail_chars > 0 else ""
+        truncated = text[:head_chars] + marker + tail
+        if len(truncated) <= budget_chars:
+            return truncated
+        keep_chars -= 1
 
-    if head_chars + tail_chars >= len(text):
-        return text
-
-    omitted = len(text) - head_chars - tail_chars
-    marker = f"\n[...truncated {omitted} chars...]\n"
-    return text[:head_chars] + marker + text[-tail_chars:]
+    return text[:budget_chars]

--- a/src/opensquilla/engine/turn_runner/agent_bootstrap_stage.py
+++ b/src/opensquilla/engine/turn_runner/agent_bootstrap_stage.py
@@ -464,13 +464,15 @@ class AgentBootstrapStage:
             metadata=inp.turn.metadata,
         )
 
-        # 5. Resolve tool-result summarizer provider (may wrap fallback)
-        summarizer = self._summarizer_provider.resolve(
-            mode=aux.tool_result_compression_mode,
-            cloned_selector=inp.cloned_selector,
-            current_provider=inp.provider,
-            summary_model=aux.tool_result_compression_summary_model,
-        )
+        # 5. Resolve tool-result summarizer provider only for summarize mode.
+        summarizer = None
+        if aux.tool_result_compression_mode == "summarize":
+            summarizer = self._summarizer_provider.resolve(
+                mode=aux.tool_result_compression_mode,
+                cloned_selector=inp.cloned_selector,
+                current_provider=inp.provider,
+                summary_model=aux.tool_result_compression_summary_model,
+            )
 
         # 6. Warm session and capture memory snapshot (async, dict-mutating)
         memory = await self._memory_snapshot.warm_and_capture(

--- a/src/opensquilla/engine/types.py
+++ b/src/opensquilla/engine/types.py
@@ -284,7 +284,9 @@ class AgentConfig:
     model_capabilities: Any | None = None  # ModelCapabilities from provider.types
     # Agent token saving: compress tool results before feeding them back to the LLM.
     tool_result_compression_enabled: bool = True
-    tool_result_compression_mode: Literal["off", "truncate", "summarize"] | None = None
+    tool_result_compression_mode: (
+        Literal["off", "truncate", "summarize", "tokenjuice"] | None
+    ) = None
     tool_result_compression_max_share: float = 0.25
     tool_result_compression_summary_model: str | None = None
     tool_result_compression_summary_max_tokens: int = 1024

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -935,7 +935,9 @@ class AgentTokenSavingConfig(BaseSettings):
     # Keep enabled by default to preserve the existing agent behavior: large
     # tool outputs are head+tail truncated before they re-enter LLM context.
     tool_result_compression_enabled: bool = True
-    tool_result_compression_mode: Literal["off", "truncate", "summarize"] | None = None
+    tool_result_compression_mode: (
+        Literal["off", "truncate", "summarize", "tokenjuice"] | None
+    ) = None
     tool_result_compression_max_share: float = Field(default=0.25, gt=0.0, le=1.0)
     tool_result_compression_summary_model: str | None = None
     tool_result_compression_summary_max_tokens: int = Field(default=1024, ge=64)
@@ -946,7 +948,9 @@ class AgentTokenSavingConfig(BaseSettings):
     tool_result_store_retention_seconds: int = Field(default=7 * 24 * 60 * 60, ge=0)
 
     @property
-    def effective_tool_result_compression_mode(self) -> Literal["off", "truncate", "summarize"]:
+    def effective_tool_result_compression_mode(
+        self,
+    ) -> Literal["off", "truncate", "summarize", "tokenjuice"]:
         if self.tool_result_compression_mode is not None:
             return self.tool_result_compression_mode
         return "truncate" if self.tool_result_compression_enabled else "off"

--- a/src/opensquilla/gateway/static/js/views/chat.js
+++ b/src/opensquilla/gateway/static/js/views/chat.js
@@ -946,7 +946,7 @@ const ChatView = (() => {
                   <div class="chat-toolbar-row">
                     <span class="chat-toolbar-row-label">Tool Compress</span>
                     <button class="chat-pill" id="pill-tool-compress"
-                            title="Cycle tool result handling: off, truncate, or summarize with the configured cheap model">Tool Compress</button>
+                            title="Cycle tool result handling: off, truncate, summarize, or tokenjuice">Tool Compress</button>
                   </div>
                   <div class="chat-toolbar-row">
                     <span class="chat-toolbar-row-label">Approvals</span>
@@ -1120,18 +1120,19 @@ const ChatView = (() => {
 
   function _resolveToolCompressMode(cfg) {
     const mode = cfg?.tool_result_compression_mode;
-    if (mode === 'off' || mode === 'truncate' || mode === 'summarize') return mode;
+    if (mode === 'off' || mode === 'truncate' || mode === 'summarize' || mode === 'tokenjuice') return mode;
     return (cfg?.tool_result_compression_enabled ?? true) ? 'truncate' : 'off';
   }
 
   function _nextToolCompressMode(mode) {
     if (mode === 'off') return 'truncate';
     if (mode === 'truncate') return 'summarize';
+    if (mode === 'summarize') return 'tokenjuice';
     return 'off';
   }
 
   function _setToolCompressButton(btn, mode) {
-    const labels = { off: 'OFF', truncate: 'TRIM', summarize: 'SUMMARY' };
+    const labels = { off: 'OFF', truncate: 'TRIM', summarize: 'SUMMARY', tokenjuice: 'TOKENJUICE' };
     btn.textContent = labels[mode] || 'TRIM';
     btn.classList.toggle('is-active', mode !== 'off');
     btn.classList.toggle('chat-pill--summary', mode === 'summarize');
@@ -1569,7 +1570,7 @@ const ChatView = (() => {
   // != truncate, OR router off.
   let _toolbarState = {
     bypass: false,        // true when elevated mode is on
-    toolCompress: 'truncate', // 'off' | 'truncate' | 'summarize'
+    toolCompress: 'truncate', // 'off' | 'truncate' | 'summarize' | 'tokenjuice'
     router: true,         // false when router toggle is off
   };
 

--- a/src/opensquilla/plugins/__init__.py
+++ b/src/opensquilla/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in OpenSquilla plugins."""

--- a/src/opensquilla/plugins/tokenjuice/__init__.py
+++ b/src/opensquilla/plugins/tokenjuice/__init__.py
@@ -1,0 +1,6 @@
+"""OpenSquilla-native tokenjuice reducer plugin."""
+
+from .plugin import reduce_tool_result
+from .types import Reduction
+
+__all__ = ["Reduction", "reduce_tool_result"]

--- a/src/opensquilla/plugins/tokenjuice/formatters.py
+++ b/src/opensquilla/plugins/tokenjuice/formatters.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import re
+
+ANSI_RE = re.compile(
+    r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))"
+)
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI_RE.sub("", text)
+
+
+def trim_empty_edges(lines: list[str]) -> list[str]:
+    start = 0
+    end = len(lines)
+    while start < end and not lines[start].strip():
+        start += 1
+    while end > start and not lines[end - 1].strip():
+        end -= 1
+    return lines[start:end]
+
+
+def dedupe_adjacent(lines: list[str]) -> list[str]:
+    deduped: list[str] = []
+    last: str | None = None
+    for line in lines:
+        if line != last:
+            deduped.append(line)
+        last = line
+    return deduped
+
+
+def head_tail(lines: list[str], head: int, tail: int) -> list[str]:
+    if len(lines) <= head + tail:
+        return lines
+    omitted = len(lines) - head - tail
+    return [*lines[:head], f"... omitted {omitted} lines ...", *lines[-tail:]]
+
+
+def count_pattern(lines: list[str], pattern: str, flags: str = "") -> int:
+    re_flags = 0
+    if "i" in flags:
+        re_flags |= re.IGNORECASE
+    if "m" in flags:
+        re_flags |= re.MULTILINE
+    compiled = re.compile(pattern, re_flags)
+    return sum(1 for line in lines if compiled.search(line))

--- a/src/opensquilla/plugins/tokenjuice/matcher.py
+++ b/src/opensquilla/plugins/tokenjuice/matcher.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import re
+import shlex
+from typing import Any
+
+from .types import Rule
+
+
+def command_argv(command: str | None, argv: list[str] | None = None) -> list[str]:
+    if argv:
+        return argv
+    if not command:
+        return []
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def _list_of_strings(value: Any) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        return []
+    return [item for item in value]
+
+
+def _list_of_string_lists(value: Any) -> list[list[str]]:
+    if not isinstance(value, list):
+        return []
+    return [
+        [item for item in entry if isinstance(item, str)]
+        for entry in value
+        if isinstance(entry, list)
+    ]
+
+
+def _contains_all(argv: list[str], needles: list[str]) -> bool:
+    return all(needle in argv for needle in needles)
+
+
+def _contains_command_text(command: str, needles: list[str]) -> bool:
+    lowered = command.lower()
+    return all(needle.lower() in lowered for needle in needles)
+
+
+def rule_matches(
+    rule: Rule,
+    *,
+    tool_name: str,
+    command: str | None,
+    argv: list[str] | None,
+    content: str,
+    exit_code: int,
+) -> bool:
+    match = rule.match
+    if not match:
+        return True
+
+    normalized_tool = "exec" if command else tool_name
+    tool_names = _list_of_strings(match.get("toolNames"))
+    if tool_names and normalized_tool not in tool_names and tool_name not in tool_names:
+        return False
+
+    tokens = command_argv(command, argv)
+    argv0 = _list_of_strings(match.get("argv0"))
+    if argv0 and (not tokens or tokens[0] not in argv0):
+        return False
+
+    argv_includes = _list_of_string_lists(match.get("argvIncludes"))
+    if argv_includes and not any(_contains_all(tokens, entry) for entry in argv_includes):
+        return False
+
+    command_text = command or " ".join(tokens)
+    command_includes = _list_of_strings(match.get("commandIncludes"))
+    if command_includes and not _contains_command_text(command_text, command_includes):
+        return False
+
+    command_includes_any = _list_of_strings(match.get("commandIncludesAny"))
+    if command_includes_any and not any(
+        needle.lower() in command_text.lower() for needle in command_includes_any
+    ):
+        return False
+
+    command_regex = match.get("commandRegex")
+    if isinstance(command_regex, str) and not re.search(command_regex, command_text):
+        return False
+
+    exit_codes = match.get("exitCodes")
+    if isinstance(exit_codes, list) and exit_codes and exit_code not in exit_codes:
+        return False
+
+    output_regex = match.get("outputRegex")
+    if isinstance(output_regex, str) and not re.search(output_regex, content, re.MULTILINE):
+        return False
+
+    return True
+
+
+def select_rule(
+    rules: tuple[Rule, ...],
+    *,
+    tool_name: str,
+    command: str | None,
+    argv: list[str] | None,
+    content: str,
+    exit_code: int,
+) -> Rule | None:
+    for rule in rules:
+        if rule_matches(
+            rule,
+            tool_name=tool_name,
+            command=command,
+            argv=argv,
+            content=content,
+            exit_code=exit_code,
+        ):
+            return rule
+    return None

--- a/src/opensquilla/plugins/tokenjuice/plugin.py
+++ b/src/opensquilla/plugins/tokenjuice/plugin.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .matcher import command_argv, select_rule
+from .reducer import reduce_with_rule
+from .rules import load_rules
+from .types import Reduction
+
+
+def _string_arg(args: dict[str, Any] | None, *names: str) -> str | None:
+    if not args:
+        return None
+    for name in names:
+        value = args.get(name)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _format_inline(summary: str, facts: dict[str, int], *, exit_code: int) -> str:
+    parts: list[str] = []
+    if exit_code != 0:
+        parts.append(f"exit {exit_code}")
+    non_zero_facts = [f"{name}: {count}" for name, count in facts.items() if count]
+    if non_zero_facts:
+        parts.append("; ".join(non_zero_facts))
+    parts.append(summary)
+    return "\n".join(part for part in parts if part).strip()
+
+
+def reduce_tool_result(
+    *,
+    tool_name: str,
+    content: str,
+    is_error: bool,
+    tool_use_id: str,
+    arguments: dict[str, Any] | None = None,
+    command: str | None = None,
+    cwd: str | None = None,
+    max_inline_chars: int | None = None,
+) -> Reduction | None:
+    del cwd, tool_use_id
+    command = command or _string_arg(arguments, "command")
+    argv = arguments.get("argv") if isinstance(arguments, dict) else None
+    argv = argv if isinstance(argv, list) and all(isinstance(item, str) for item in argv) else None
+    exit_code = 1 if is_error else 0
+    rule = select_rule(
+        load_rules(),
+        tool_name=tool_name,
+        command=command,
+        argv=command_argv(command, argv),
+        content=content,
+        exit_code=exit_code,
+    )
+    if rule is None:
+        return None
+
+    summary, facts = reduce_with_rule(rule, content, exit_code=exit_code)
+    if not summary:
+        return None
+    inline_text = _format_inline(summary, facts, exit_code=exit_code)
+    if (
+        max_inline_chars is not None
+        and max_inline_chars > 0
+        and len(inline_text) > max_inline_chars
+    ):
+        half = max(1, (max_inline_chars - 32) // 2)
+        inline_text = f"{inline_text[:half]}\n... omitted chars ...\n{inline_text[-half:]}"
+    if len(inline_text) >= len(content):
+        return None
+    return Reduction(
+        inline_text=inline_text,
+        raw_chars=len(content),
+        reduced_chars=len(inline_text),
+        ratio=len(inline_text) / max(1, len(content)),
+        reducer=rule.id,
+    )

--- a/src/opensquilla/plugins/tokenjuice/reducer.py
+++ b/src/opensquilla/plugins/tokenjuice/reducer.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .formatters import count_pattern, dedupe_adjacent, head_tail, strip_ansi, trim_empty_edges
+from .types import Rule
+
+
+def _compile_flags(flags: str = "") -> int:
+    compiled = 0
+    if "i" in flags:
+        compiled |= re.IGNORECASE
+    if "m" in flags:
+        compiled |= re.MULTILINE
+    return compiled
+
+
+def _patterns(values: Any) -> list[re.Pattern[str]]:
+    if not isinstance(values, list):
+        return []
+    patterns: list[re.Pattern[str]] = []
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        try:
+            patterns.append(re.compile(value))
+        except re.error:
+            continue
+    return patterns
+
+
+def _apply_output_matches(rule: Rule, text: str) -> str | None:
+    for entry in rule.output_matches:
+        pattern = entry.get("pattern")
+        message = entry.get("message")
+        if not isinstance(pattern, str) or not isinstance(message, str):
+            continue
+        try:
+            if re.search(pattern, text, re.MULTILINE):
+                return message
+        except re.error:
+            continue
+    return None
+
+
+def _summarize_window(rule: Rule, *, exit_code: int) -> tuple[int, int]:
+    if exit_code != 0 and rule.failure.get("preserveOnFailure"):
+        return int(rule.failure.get("head") or 12), int(rule.failure.get("tail") or 12)
+    return int(rule.summarize.get("head") or 8), int(rule.summarize.get("tail") or 8)
+
+
+def reduce_with_rule(rule: Rule, raw_text: str, *, exit_code: int) -> tuple[str, dict[str, int]]:
+    text = strip_ansi(raw_text) if rule.transforms.get("stripAnsi") else raw_text
+    output_match = _apply_output_matches(rule, text)
+    if output_match is not None:
+        return output_match, {}
+
+    lines = text.splitlines()
+    if rule.transforms.get("trimEmptyEdges"):
+        lines = trim_empty_edges(lines)
+    if rule.transforms.get("dedupeAdjacent"):
+        lines = dedupe_adjacent(lines)
+
+    counter_lines = list(lines)
+    skip_patterns = _patterns(rule.filters.get("skipPatterns"))
+    if skip_patterns:
+        lines = [
+            line
+            for line in lines
+            if not any(pattern.search(line) for pattern in skip_patterns)
+        ]
+
+    keep_patterns = _patterns(rule.filters.get("keepPatterns"))
+    if keep_patterns:
+        kept = [line for line in lines if any(pattern.search(line) for pattern in keep_patterns)]
+        if kept:
+            lines = kept
+
+    if not lines and rule.on_empty:
+        return rule.on_empty, {}
+
+    fact_source = counter_lines if rule.counter_source == "preKeep" else lines
+    facts: dict[str, int] = {}
+    for counter in rule.counters:
+        name = counter.get("name")
+        pattern = counter.get("pattern")
+        if not isinstance(name, str) or not isinstance(pattern, str):
+            continue
+        facts[name] = count_pattern(fact_source, pattern, str(counter.get("flags") or ""))
+
+    head, tail = _summarize_window(rule, exit_code=exit_code)
+    compacted = head_tail(lines, head, tail)
+    return "\n".join(compacted).strip(), facts

--- a/src/opensquilla/plugins/tokenjuice/rules.py
+++ b/src/opensquilla/plugins/tokenjuice/rules.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from importlib import resources
+from typing import Any
+
+from .types import Rule
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_tuple_of_dicts(value: Any) -> tuple[dict[str, Any], ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, dict))
+
+
+def _load_rule(path: resources.abc.Traversable) -> Rule | None:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    rule_id = raw.get("id")
+    if not isinstance(rule_id, str) or not rule_id:
+        return None
+    family = raw.get("family")
+    on_empty = raw.get("onEmpty")
+    counter_source = raw.get("counterSource")
+    return Rule(
+        id=rule_id,
+        family=family if isinstance(family, str) else "generic",
+        match=_as_dict(raw.get("match")),
+        transforms=_as_dict(raw.get("transforms")),
+        filters=_as_dict(raw.get("filters")),
+        summarize=_as_dict(raw.get("summarize")),
+        failure=_as_dict(raw.get("failure")),
+        counters=_as_tuple_of_dicts(raw.get("counters")),
+        output_matches=_as_tuple_of_dicts(raw.get("outputMatches")),
+        on_empty=on_empty if isinstance(on_empty, str) else None,
+        counter_source=counter_source if isinstance(counter_source, str) else "postKeep",
+        priority=int(raw.get("priority") or 0),
+    )
+
+
+def _iter_json_files(root: resources.abc.Traversable):
+    for child in root.iterdir():
+        if child.name == "fixtures":
+            continue
+        if child.is_dir():
+            yield from _iter_json_files(child)
+        elif child.name.endswith(".json"):
+            yield child
+
+
+@lru_cache(maxsize=1)
+def load_rules() -> tuple[Rule, ...]:
+    root = resources.files("opensquilla.plugins.tokenjuice").joinpath("rules")
+    rules = [rule for path in _iter_json_files(root) if (rule := _load_rule(path)) is not None]
+    return tuple(
+        sorted(
+            rules,
+            key=lambda rule: (
+                rule.id == "generic/fallback",
+                -rule.priority,
+                rule.id,
+            ),
+        )
+    )

--- a/src/opensquilla/plugins/tokenjuice/rules/archive/tar.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/archive/tar.json
@@ -1,0 +1,30 @@
+{
+  "id": "archive/tar",
+  "family": "archive-cli",
+  "description": "Compact tar output while preserving archive paths and error lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["tar"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|cannot",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/archive/unzip.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/archive/unzip.json
@@ -1,0 +1,30 @@
+{
+  "id": "archive/unzip",
+  "family": "archive-cli",
+  "description": "Compact unzip output while preserving extracted paths and conflict lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["unzip"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "inflating|extracting|replace|error",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/archive/zip.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/archive/zip.json
@@ -1,0 +1,30 @@
+{
+  "id": "archive/zip",
+  "family": "archive-cli",
+  "description": "Compact zip output while preserving archived paths and warnings.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["zip"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "adding|updating|warning|error",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/cmake.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/cmake.json
@@ -1,0 +1,35 @@
+{
+  "id": "build/cmake",
+  "family": "build-native",
+  "description": "Compact cmake output while preserving configure errors, build failures, and final status.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["cmake"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "CMake Error|error:|failed|FAILED",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "CMake Warning|warning:",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/dotnet.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/dotnet.json
@@ -1,0 +1,36 @@
+{
+  "id": "build/dotnet",
+  "family": "build-dotnet",
+  "description": "Compact dotnet build and restore output while preserving diagnostics and final summaries.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["dotnet"],
+    "argvIncludesAny": [["build"], ["restore"], ["publish"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error [A-Z]+\\d+|Build FAILED|failed",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning [A-Z]+\\d+|warning",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/esbuild.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/esbuild.json
@@ -1,0 +1,35 @@
+{
+  "id": "build/esbuild",
+  "family": "build-bundler",
+  "description": "Compact esbuild and tsdown-like output while preserving actual errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludes": ["esbuild"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/go-build.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/go-build.json
@@ -1,0 +1,31 @@
+{
+  "id": "build/go-build",
+  "family": "build-go",
+  "description": "Compact go build output while preserving compiler diagnostics and package failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["go"],
+    "argvIncludes": [["build"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "^# |\\.go:\\d+:\\d+:|cannot|undefined|failed",
+      "flags": "im"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/gradle.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/gradle.json
@@ -1,0 +1,35 @@
+{
+  "id": "build/gradle",
+  "family": "build-jvm",
+  "description": "Compact Gradle output while preserving task failures, test failures, and build status.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["gradle", "gradlew", "./gradlew"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "failed task",
+      "pattern": "FAILURE: Build failed|Execution failed for task|FAILED",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "Deprecated Gradle features|warning",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/maven.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/maven.json
@@ -1,0 +1,35 @@
+{
+  "id": "build/maven",
+  "family": "build-jvm",
+  "description": "Compact Maven output while preserving errors, failed goals, and reactor summaries.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["mvn", "mvnw", "./mvnw"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "\\[ERROR\\]|BUILD FAILURE|Failed to execute goal",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "\\[WARNING\\]",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/msbuild.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/msbuild.json
@@ -1,0 +1,35 @@
+{
+  "id": "build/msbuild",
+  "family": "build-dotnet",
+  "description": "Compact MSBuild output while preserving project errors, warnings, and build status.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["msbuild"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error [A-Z]+\\d+|Build FAILED|failed",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning [A-Z]+\\d+|warning",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/pnpm-build.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/pnpm-build.json
@@ -1,0 +1,44 @@
+{
+  "id": "build/pnpm-build",
+  "family": "build-script",
+  "description": "Compact pnpm build script output while preserving downstream warnings and failures.",
+  "onEmpty": "pnpm build: ok",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["pnpm"],
+    "argvIncludes": [["build"]],
+    "commandIncludes": ["pnpm build"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^> .+$",
+      "^\\s*Done in .+$"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning|warn",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/swift-build.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/swift-build.json
@@ -1,0 +1,56 @@
+{
+  "id": "build/swift-build",
+  "family": "build",
+  "description": "Compact swift build output while preserving compile diagnostics, contention messages, and final build status.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["swift"],
+    "argvIncludes": [["build"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^\\[\\d+/\\d+\\]\\s+.+$",
+      "^Building for .+\\.\\.\\.$",
+      "^Planning build$"
+    ],
+    "keepPatterns": [
+      "^.+:\\d+:\\d+: error: .+",
+      "^.+:\\d+:\\d+: warning: .+",
+      "^.+:\\d+: error: .+",
+      "^.+:\\d+: warning: .+",
+      "^error: .+",
+      "^warning: .+",
+      "^note: .+",
+      "^Another instance of SwiftPM.+$",
+      "^Build complete!.+$",
+      "^Build complete!$",
+      "^Build failed.+$"
+    ]
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/tsc.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/tsc.json
@@ -1,0 +1,74 @@
+{
+  "id": "build/tsc",
+  "family": "build-typescript",
+  "description": "Compact TypeScript compiler output while preserving real diagnostics.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludes": ["tsc"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^Files:\\s+\\d+",
+      "^Lines of Library:\\s+\\d+",
+      "^Lines of Definitions:\\s+\\d+",
+      "^Lines of TypeScript:\\s+\\d+",
+      "^Lines of JavaScript:\\s+\\d+",
+      "^Lines of JSON:\\s+\\d+",
+      "^Lines of Other:\\s+\\d+",
+      "^Identifiers:\\s+\\d+",
+      "^Symbols:\\s+\\d+",
+      "^Types:\\s+\\d+",
+      "^Instantiations:\\s+\\d+",
+      "^Memory used:\\s+.+",
+      "^Assignability cache size:\\s+\\d+",
+      "^Identity cache size:\\s+\\d+",
+      "^Subtype cache size:\\s+\\d+",
+      "^Strict subtype cache size:\\s+\\d+",
+      "^I/O Read time:\\s+.+",
+      "^Parse time:\\s+.+",
+      "^ResolveModule time:\\s+.+",
+      "^ResolveLibrary time:\\s+.+",
+      "^Program time:\\s+.+",
+      "^Bind time:\\s+.+",
+      "^Check time:\\s+.+",
+      "^transformTime time:\\s+.+",
+      "^commentTime time:\\s+.+",
+      "^I/O Write time:\\s+.+",
+      "^printTime time:\\s+.+",
+      "^Emit time:\\s+.+",
+      "^Total time:\\s+.+",
+      "^Watching for file changes\\."
+    ],
+    "keepPatterns": [
+      "^.+\\(\\d+,\\d+\\):\\s+error TS\\d+: .+",
+      "^.+\\(\\d+,\\d+\\):\\s+warning TS\\d+: .+",
+      "^Found \\d+ errors?.+",
+      "^error TS\\d+: .+"
+    ]
+  },
+  "summarize": {
+    "head": 4,
+    "tail": 4
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 4,
+    "tail": 6
+  },
+  "counters": [
+    {
+      "name": "typescript error",
+      "pattern": "TS\\d+"
+    },
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/tsdown.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/tsdown.json
@@ -1,0 +1,35 @@
+{
+  "id": "build/tsdown",
+  "family": "build-bundler",
+  "description": "Compact tsdown build output while preserving warnings and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludes": ["tsdown"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/vite.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/vite.json
@@ -1,0 +1,42 @@
+{
+  "id": "build/vite",
+  "family": "build-bundler",
+  "description": "Compact vite build output while preserving warnings and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludes": ["vite", "build"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^transforming \\(.+\\) .+",
+      "^rendering chunks \\(.+\\) .+",
+      "^computing gzip size \\(.+\\) .+"
+    ]
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/webpack.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/webpack.json
@@ -1,0 +1,51 @@
+{
+  "id": "build/webpack",
+  "family": "build-bundler",
+  "description": "Compact webpack output while preserving module errors and warnings.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludes": ["webpack"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "^Entrypoint\\s+.+",
+      "^ERROR in .+",
+      "^WARNING in .+",
+      "^Module .+",
+      "^\\s*ERROR\\s+in\\s+.+",
+      "^\\s*webpack\\s+\\d+\\.\\d+\\.\\d+ compiled .+",
+      "^\\s*\\d+ errors? have detailed information.+"
+    ]
+  },
+  "summarize": {
+    "head": 4,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 4,
+    "tail": 8
+  },
+  "counters": [
+    {
+      "name": "asset",
+      "pattern": "^asset\\s+.+",
+      "flags": "m"
+    },
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/build/xcodebuild.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/build/xcodebuild.json
@@ -1,0 +1,80 @@
+{
+  "id": "build/xcodebuild",
+  "family": "build-xcode",
+  "description": "Compact xcodebuild output while preserving real diagnostics, failed commands, and final status.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludesAny": ["xcodebuild ", "&& xcodebuild ", "; xcodebuild ", "\nxcodebuild "]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^Fetching from https?://.+",
+      "^Resolve Package Graph$",
+      "^Resolved source packages:$",
+      "^Command line invocation:$",
+      "^\\s+/Applications/Xcode\\.app/.+/xcodebuild .+$",
+      "^Prepare packages$",
+      "^CreateBuildRequest$",
+      "^SendProjectDescription$",
+      "^CreateBuildOperation$",
+      "^Build description signature: .+$",
+      "^Build description path: .+$",
+      "^note: Building targets in dependency order$",
+      "^note: Target dependency graph \\(.+ targets\\)$",
+      "^\\s*Target '.+' in project '.+'.*$",
+      "^\\s*➜ .+$",
+      "^SwiftDriver(?:JobDiscovery| Compilation)? normal .+$",
+      "^SwiftCompile normal .+$",
+      "^CompileSwift(?:Sources)? normal .+$",
+      "^Ld .+$",
+      "^CodeSign .+$",
+      "^ProcessProductPackaging .+$",
+      "^CompileAssetCatalog .+$"
+    ],
+    "keepPatterns": [
+      "^.+:\\d+:\\d+: error: .+",
+      "^.+:\\d+:\\d+: warning: .+",
+      "^.+:\\d+: error: .+",
+      "^.+:\\d+: warning: .+",
+      "^error: .+",
+      "^warning: .+",
+      "^note: .+",
+      "^The following build commands failed:$",
+      "^\\t.+$",
+      "^\\*\\* BUILD (?:SUCCEEDED|FAILED) \\*\\*$",
+      "^\\*\\* TEST (?:SUCCEEDED|FAILED) \\*\\*$",
+      "^Testing failed:$"
+    ]
+  },
+  "summarize": {
+    "head": 18,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 24,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning",
+      "flags": "i"
+    },
+    {
+      "name": "failed command",
+      "pattern": "^\\t.+$",
+      "flags": "m"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/cloud/aws.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/cloud/aws.json
@@ -1,0 +1,30 @@
+{
+  "id": "cloud/aws",
+  "family": "cloud-cli",
+  "description": "Compact AWS CLI output while preserving result rows and service errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["aws"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|exception|denied|not found",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/cloud/az.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/cloud/az.json
@@ -1,0 +1,30 @@
+{
+  "id": "cloud/az",
+  "family": "cloud-cli",
+  "description": "Compact Azure CLI output while preserving key resource rows and deployment failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["az"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|forbidden|not found",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/cloud/flyctl.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/cloud/flyctl.json
@@ -1,0 +1,30 @@
+{
+  "id": "cloud/flyctl",
+  "family": "deploy-cli",
+  "description": "Compact Fly output while preserving machine, app, and rollout status lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["fly", "flyctl"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|unhealthy|warning",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/cloud/gcloud.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/cloud/gcloud.json
@@ -1,0 +1,30 @@
+{
+  "id": "cloud/gcloud",
+  "family": "cloud-cli",
+  "description": "Compact gcloud output while preserving resource tables and API failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["gcloud"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|permission|denied",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/cloud/gh.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/cloud/gh.json
@@ -1,0 +1,30 @@
+{
+  "id": "cloud/gh",
+  "family": "developer-cli",
+  "description": "Compact GitHub CLI output while preserving issue, PR, and workflow result lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["gh", "ghx"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|not found|forbidden",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/cloud/vercel.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/cloud/vercel.json
@@ -1,0 +1,30 @@
+{
+  "id": "cloud/vercel",
+  "family": "deploy-cli",
+  "description": "Compact Vercel CLI output while preserving deployment URLs and error details.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["vercel"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|canceled|timed out",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/database/mongosh.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/database/mongosh.json
@@ -1,0 +1,30 @@
+{
+  "id": "database/mongosh",
+  "family": "database-cli",
+  "description": "Compact mongosh output while preserving collection results and query errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["mongosh"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|exception",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/database/mysql.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/database/mysql.json
@@ -1,0 +1,30 @@
+{
+  "id": "database/mysql",
+  "family": "database-cli",
+  "description": "Compact mysql output while preserving query rows and SQL errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["mysql"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|denied|unknown",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/database/psql.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/database/psql.json
@@ -1,0 +1,30 @@
+{
+  "id": "database/psql",
+  "family": "database-cli",
+  "description": "Compact psql output while preserving result tables and query errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["psql"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|permission denied",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/database/redis-cli.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/database/redis-cli.json
@@ -1,0 +1,30 @@
+{
+  "id": "database/redis-cli",
+  "family": "database-cli",
+  "description": "Compact redis-cli output while preserving command replies and connection failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["redis-cli"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|denied|could not connect",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/database/sqlite3.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/database/sqlite3.json
@@ -1,0 +1,30 @@
+{
+  "id": "database/sqlite3",
+  "family": "database-cli",
+  "description": "Compact sqlite3 output while preserving query rows and parse errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["sqlite3"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|no such table",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/devops/docker-build.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/devops/docker-build.json
@@ -1,0 +1,53 @@
+{
+  "id": "devops/docker-build",
+  "family": "container-build",
+  "description": "Compact docker build output while preserving real failures and final stages.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["docker"],
+    "argvIncludes": [["build"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^#\\d+\\s+[0-9.]+\\s",
+      "^#\\d+\\s+extracting\\s",
+      "^#\\d+\\s+sha256:"
+    ],
+    "keepPatterns": [
+      "^#\\d+\\s+\\[",
+      "^#\\d+\\s+DONE\\s",
+      "^#\\d+\\s+ERROR:",
+      "^ERROR:",
+      "^ => ",
+      "^exporting to image$",
+      "^writing image",
+      "^naming to "
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "step",
+      "pattern": "^#\\d+\\s+\\[",
+      "flags": "m"
+    },
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/devops/docker-compose.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/devops/docker-compose.json
@@ -1,0 +1,44 @@
+{
+  "id": "devops/docker-compose",
+  "family": "container-compose",
+  "description": "Compact docker compose output while preserving service rows, status, and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["docker"],
+    "argvIncludes": [["compose"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "error|warn|failed|unhealthy|exited|orphan",
+      "^(NAME|SERVICE|CONTAINER ID)\\s+",
+      "^[-a-zA-Z0-9_.]+\\s+.+",
+      "^\\s*\\d+ services?\\s+",
+      "^\\s*\\d+ containers?\\s+"
+    ]
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "service",
+      "pattern": "^(?!NAME\\s|SERVICE\\s|CONTAINER ID\\s).+\\S.*$"
+    },
+    {
+      "name": "error",
+      "pattern": "error|failed|unhealthy|exited",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/devops/docker-images.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/devops/docker-images.json
@@ -1,0 +1,30 @@
+{
+  "id": "devops/docker-images",
+  "family": "container-images",
+  "description": "Compact docker images output while preserving image rows.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["docker"],
+    "argvIncludes": [["images"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "image",
+      "pattern": "^(?!REPOSITORY\\s).+\\S.*$"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/devops/docker-logs.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/devops/docker-logs.json
@@ -1,0 +1,43 @@
+{
+  "id": "devops/docker-logs",
+  "family": "container-logs",
+  "description": "Compact docker logs output while preserving early and late log lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["docker"],
+    "argvIncludes": [["logs"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "error|warn|fatal|panic|exception|traceback|timeout|refused|fail",
+      "^Caused by:",
+      "^Traceback"
+    ]
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warn",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/devops/docker-ps.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/devops/docker-ps.json
@@ -1,0 +1,30 @@
+{
+  "id": "devops/docker-ps",
+  "family": "container-list",
+  "description": "Compact docker ps output while preserving container rows.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["docker"],
+    "argvIncludes": [["ps"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "container",
+      "pattern": "^(?!CONTAINER ID\\s).+\\S.*$"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/devops/helm.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/devops/helm.json
@@ -1,0 +1,35 @@
+{
+  "id": "devops/helm",
+  "family": "devops-cli",
+  "description": "Compact Helm output while preserving rendered-resource errors, release status, and upgrade failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["helm"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 14,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 20,
+    "tail": 20
+  },
+  "counters": [
+    {
+      "name": "resource",
+      "pattern": "^kind: |^# Source:",
+      "flags": "m"
+    },
+    {
+      "name": "error",
+      "pattern": "Error:|failed|UPGRADE FAILED|INSTALLATION FAILED",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/devops/kubectl-describe.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/devops/kubectl-describe.json
@@ -1,0 +1,45 @@
+{
+  "id": "devops/kubectl-describe",
+  "family": "kubernetes-describe",
+  "description": "Compact kubectl describe output while preserving metadata, status, events, and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["kubectl"],
+    "argvIncludes": [["describe"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "^(Name|Namespace|Priority|Node|Status|IP|Controlled By|Containers|Conditions|Events):",
+      "^\\s*(Type|Reason|Age|From|Message)\\s+",
+      "error|warn|failed|back-off|crashloop|unhealthy|timeout",
+      "^\\s*Warning\\s+",
+      "^\\s*Normal\\s+"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "warning|back-off|failed|unhealthy",
+      "flags": "i"
+    },
+    {
+      "name": "event",
+      "pattern": "^\\s*(Warning|Normal)\\s+",
+      "flags": "m"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/devops/kubectl-get.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/devops/kubectl-get.json
@@ -1,0 +1,35 @@
+{
+  "id": "devops/kubectl-get",
+  "family": "kubernetes-list",
+  "description": "Compact kubectl get output while preserving resource rows.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["kubectl"],
+    "argvIncludes": [["get"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^No resources found"
+    ]
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "resource",
+      "pattern": "^(?!NAME\\s).+\\S.*$"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/devops/kubectl-logs.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/devops/kubectl-logs.json
@@ -1,0 +1,43 @@
+{
+  "id": "devops/kubectl-logs",
+  "family": "kubernetes-logs",
+  "description": "Compact kubectl logs output while preserving key log lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["kubectl"],
+    "argvIncludes": [["logs"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "error|warn|fatal|panic|exception|traceback|timeout|refused|fail",
+      "^Caused by:",
+      "^Traceback"
+    ]
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warn",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/devops/pulumi.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/devops/pulumi.json
@@ -1,0 +1,35 @@
+{
+  "id": "devops/pulumi",
+  "family": "iac-cli",
+  "description": "Compact Pulumi output while preserving resource changes, diagnostics, and deployment failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["pulumi"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "change",
+      "pattern": "\\+|~|-|Resources:",
+      "flags": "i"
+    },
+    {
+      "name": "error",
+      "pattern": "error:|failed|Diagnostics:",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/devops/terraform.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/devops/terraform.json
@@ -1,0 +1,35 @@
+{
+  "id": "devops/terraform",
+  "family": "iac-cli",
+  "description": "Compact Terraform output while preserving plan changes, diagnostics, and apply failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["terraform"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "change",
+      "pattern": "Plan:|Apply complete|No changes|will be created|will be updated|will be destroyed",
+      "flags": "i"
+    },
+    {
+      "name": "error",
+      "pattern": "Error:|failed|Invalid|denied",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/devops/terragrunt.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/devops/terragrunt.json
@@ -1,0 +1,35 @@
+{
+  "id": "devops/terragrunt",
+  "family": "iac-cli",
+  "description": "Compact Terragrunt output while preserving Terraform diagnostics, module paths, and failed runs.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["terragrunt"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "module",
+      "pattern": "Working dir|Downloading Terraform configurations|Plan:",
+      "flags": "i"
+    },
+    {
+      "name": "error",
+      "pattern": "ERRO|Error:|failed|Invalid",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/filesystem/fd.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/filesystem/fd.json
@@ -1,0 +1,33 @@
+{
+  "id": "filesystem/fd",
+  "family": "filesystem-inventory",
+  "description": "Compact fd output while preserving matching paths and errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["fd", "fdfind"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "path",
+      "pattern": "^(?!(fd: |\\[fd error\\]: )).+\\S.*$"
+    },
+    {
+      "name": "error",
+      "pattern": "^(fd: |\\[fd error\\]: )"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/filesystem/find.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/filesystem/find.json
@@ -1,0 +1,42 @@
+{
+  "id": "filesystem/find",
+  "family": "filesystem-find",
+  "description": "Compact find output while preserving matches and failure context.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["find"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "^\\./.+",
+      "^/.+",
+      "Permission denied",
+      "No such file"
+    ]
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "match",
+      "pattern": "^(?!find: ).+\\S.*$"
+    },
+    {
+      "name": "permission denied",
+      "pattern": "Permission denied",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/filesystem/git-ls-files.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/filesystem/git-ls-files.json
@@ -1,0 +1,35 @@
+{
+  "id": "filesystem/git-ls-files",
+  "family": "filesystem-inventory",
+  "description": "Compact git ls-files output while preserving tracked path samples.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["git"],
+    "gitSubcommands": ["ls-files"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "path",
+      "pattern": "^(?!fatal: ).+\\S.*$"
+    },
+    {
+      "name": "error",
+      "pattern": "fatal:|error:",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/filesystem/ls.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/filesystem/ls.json
@@ -1,0 +1,29 @@
+{
+  "id": "filesystem/ls",
+  "family": "filesystem-listing",
+  "description": "Compact ls output for directory listings.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["ls"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "item",
+      "pattern": "^(?!total\\s+\\d+).+\\S.*$"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/filesystem/rg-files.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/filesystem/rg-files.json
@@ -1,0 +1,34 @@
+{
+  "id": "filesystem/rg-files",
+  "family": "filesystem-inventory",
+  "description": "Compact rg --files output while preserving path samples and errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["rg"],
+    "argvIncludes": [["--files"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "path",
+      "pattern": "^(?!rg: ).+\\S.*$"
+    },
+    {
+      "name": "error",
+      "pattern": "^rg: "
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/generic/fallback.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/generic/fallback.json
@@ -1,0 +1,32 @@
+{
+  "id": "generic/fallback",
+  "family": "generic",
+  "description": "Generic fallback reducer for line-oriented output.",
+  "match": {},
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 20
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/generic/help.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/generic/help.json
@@ -1,0 +1,25 @@
+{
+  "id": "generic/help",
+  "family": "help",
+  "description": "Preserve command help output so agents can inspect available commands and flags.",
+  "priority": 25,
+  "match": {
+    "toolNames": ["exec"],
+    "argvIncludesAny": [["--help"], ["help"]],
+    "commandIncludesAny": [" --help", " help"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 80,
+    "tail": 40
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 80,
+    "tail": 40
+  }
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/git/branch.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/git/branch.json
@@ -1,0 +1,29 @@
+{
+  "id": "git/branch",
+  "family": "git-branches",
+  "description": "Compact git branch output while preserving branch names and current branch context.",
+  "match": {
+    "argv0": ["git"],
+    "argvIncludes": [["branch"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 14,
+    "tail": 4
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "branch",
+      "pattern": ".+"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/git/diff-name-only.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/git/diff-name-only.json
@@ -1,0 +1,29 @@
+{
+  "id": "git/diff-name-only",
+  "family": "git-diff",
+  "description": "Compact git diff --name-only output.",
+  "match": {
+    "argv0": ["git"],
+    "argvIncludes": [["diff"], ["--name-only"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 16,
+    "tail": 4
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "file",
+      "pattern": ".+"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/git/diff-stat.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/git/diff-stat.json
@@ -1,0 +1,37 @@
+{
+  "id": "git/diff-stat",
+  "family": "git-diff",
+  "description": "Compact git diff --stat output.",
+  "match": {
+    "argv0": ["git"],
+    "argvIncludes": [["diff"], ["--stat"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "file",
+      "pattern": "\\|"
+    },
+    {
+      "name": "insertion",
+      "pattern": "insertions?\\(\\+\\)"
+    },
+    {
+      "name": "deletion",
+      "pattern": "deletions?\\(-\\)"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/git/diff.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/git/diff.json
@@ -1,0 +1,65 @@
+{
+  "id": "git/diff",
+  "family": "git-diff",
+  "description": "Compact full git diff patch output while preserving file and hunk headers plus changed lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludesAny": ["git diff ", "&& git diff ", "; git diff ", "\ngit diff "]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "^diff --git\\s+.+",
+      "^new file mode\\s+.+",
+      "^deleted file mode\\s+.+",
+      "^similarity index\\s+.+",
+      "^rename from\\s+.+",
+      "^rename to\\s+.+",
+      "^Binary files .+ differ$",
+      "^---\\s+.+",
+      "^\\+\\+\\+\\s+.+",
+      "^@@\\s+.+",
+      "^\\+(?!\\+\\+\\+).+",
+      "^-(?!---).+",
+      "^\\\\ No newline at end of file$",
+      "^\\s*\\d+ files? changed.+",
+      "^\\s*create mode .+",
+      "^\\s*delete mode .+"
+    ]
+  },
+  "summarize": {
+    "head": 20,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 24,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "changed file",
+      "pattern": "^diff --git\\s",
+      "flags": "m"
+    },
+    {
+      "name": "hunk",
+      "pattern": "^@@\\s",
+      "flags": "m"
+    },
+    {
+      "name": "added line",
+      "pattern": "^\\+(?!\\+\\+\\+).+",
+      "flags": "m"
+    },
+    {
+      "name": "removed line",
+      "pattern": "^-(?!---).+",
+      "flags": "m"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/git/log-oneline.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/git/log-oneline.json
@@ -1,0 +1,30 @@
+{
+  "id": "git/log-oneline",
+  "family": "git-history",
+  "description": "Compact git log --oneline output while preserving commits.",
+  "match": {
+    "argv0": ["git"],
+    "argvIncludes": [["log"], ["--oneline"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "commit",
+      "pattern": "^[a-f0-9]{7,}\\s",
+      "flags": "m"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/git/remote-v.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/git/remote-v.json
@@ -1,0 +1,29 @@
+{
+  "id": "git/remote-v",
+  "family": "git-remote",
+  "description": "Compact git remote -v output while preserving fetch/push remotes.",
+  "match": {
+    "argv0": ["git"],
+    "argvIncludes": [["remote"], ["-v"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 4
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "remote",
+      "pattern": "\\((fetch|push)\\)"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/git/show.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/git/show.json
@@ -1,0 +1,50 @@
+{
+  "id": "git/show",
+  "family": "git-show",
+  "description": "Compact git show output while preserving commit summary and diff stat.",
+  "match": {
+    "argv0": ["git"],
+    "argvIncludes": [["show"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "^commit\\s+.+",
+      "^Author:\\s+.+",
+      "^Date:\\s+.+",
+      "^\\s{4}.+",
+      "^diff --git\\s+.+",
+      "^index\\s+[a-f0-9]+\\.[a-f0-9]+",
+      "^---\\s+.+",
+      "^\\+\\+\\+\\s+.+",
+      "^@@\\s+.+",
+      "^\\s*\\d+ files? changed.+",
+      "^\\s*create mode .+",
+      "^\\s*delete mode .+"
+    ]
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "file",
+      "pattern": "\\|"
+    },
+    {
+      "name": "commit",
+      "pattern": "^commit\\s",
+      "flags": "m"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/git/stash-list.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/git/stash-list.json
@@ -1,0 +1,30 @@
+{
+  "id": "git/stash-list",
+  "family": "git-stash",
+  "description": "Compact git stash list output while preserving stash entries.",
+  "match": {
+    "argv0": ["git"],
+    "argvIncludes": [["stash"], ["list"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 4
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "stash",
+      "pattern": "^stash@\\{\\d+\\}:",
+      "flags": "m"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/git/status.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/git/status.json
@@ -1,0 +1,54 @@
+{
+  "id": "git/status",
+  "family": "git-status",
+  "description": "Compact human-readable git status output.",
+  "onEmpty": "working tree clean",
+  "match": {
+    "argv0": ["git"],
+    "argvIncludes": [["status"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^On branch ",
+      "^Your branch is ",
+      "^and have \\d+ and \\d+ different commits each.*$",
+      "^\\(use \"git .+\" to .+\\)$",
+      "^no changes added to commit.*$",
+      "^nothing added to commit but untracked files present.*$",
+      "^nothing to commit, working tree clean$",
+      "^use \"git .+\" to .+"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 4
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "modified file",
+      "pattern": "^(?:M:|\\s*modified:|[ MTRU][MTRU]\\s+|[MTRU][ MTRU]\\s+)"
+    },
+    {
+      "name": "new file",
+      "pattern": "^(?:A:|\\s*new file:|A.\\s+|.A\\s+)"
+    },
+    {
+      "name": "deleted file",
+      "pattern": "^(?:D:|\\s*deleted:|D.\\s+|.D\\s+)"
+    },
+    {
+      "name": "untracked file",
+      "pattern": "^(?:\\?\\?:|\\?\\?\\s+|\\s*untracked files:)"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/git/worktree-list.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/git/worktree-list.json
@@ -1,0 +1,31 @@
+{
+  "id": "git/worktree-list",
+  "family": "git-worktree",
+  "description": "Compact git worktree list output while preserving worktree entries.",
+  "match": {
+    "argv0": ["git"],
+    "gitSubcommands": ["worktree"],
+    "argvIncludes": [["list"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 4
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "worktree",
+      "pattern": "^/\\S",
+      "flags": "m"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/install/bun-install.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/install/bun-install.json
@@ -1,0 +1,43 @@
+{
+  "id": "install/bun-install",
+  "family": "dependency-install",
+  "description": "Compact bun install output while preserving warnings and package counts.",
+  "matchOutput": [
+    {
+      "pattern": "Checked \\d+ installs? across \\d+ packages? \\(no changes\\)",
+      "message": "bun install: up to date",
+      "flags": "i"
+    }
+  ],
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["bun"],
+    "argvIncludes": [["install"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "warning",
+      "flags": "i"
+    },
+    {
+      "name": "package",
+      "pattern": "\\bpackage(s)?\\b",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/install/npm-ci.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/install/npm-ci.json
@@ -1,0 +1,49 @@
+{
+  "id": "install/npm-ci",
+  "family": "dependency-install",
+  "description": "Compact npm ci output while preserving warnings and audit summaries.",
+  "onEmpty": "npm ci: ok",
+  "matchOutput": [
+    {
+      "pattern": "up to date, audited \\d+ package",
+      "message": "npm ci: up to date",
+      "flags": "i"
+    }
+  ],
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["npm"],
+    "argvIncludes": [["ci"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^npm notice .+"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "warn",
+      "flags": "i"
+    },
+    {
+      "name": "vulnerability",
+      "pattern": "vulnerabilit",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/install/npm-install.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/install/npm-install.json
@@ -1,0 +1,49 @@
+{
+  "id": "install/npm-install",
+  "family": "dependency-install",
+  "description": "Compact npm install output while preserving warnings and audit summaries.",
+  "onEmpty": "npm install: ok",
+  "matchOutput": [
+    {
+      "pattern": "up to date, audited \\d+ package",
+      "message": "npm install: up to date",
+      "flags": "i"
+    }
+  ],
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["npm"],
+    "argvIncludes": [["install"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^npm notice .+"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "warn",
+      "flags": "i"
+    },
+    {
+      "name": "vulnerability",
+      "pattern": "vulnerabilit",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/install/pnpm-install.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/install/pnpm-install.json
@@ -1,0 +1,43 @@
+{
+  "id": "install/pnpm-install",
+  "family": "dependency-install",
+  "description": "Compact pnpm install output while preserving warnings and summary lines.",
+  "matchOutput": [
+    {
+      "pattern": "Already up to date",
+      "message": "pnpm install: up to date",
+      "flags": "i"
+    }
+  ],
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["pnpm"],
+    "argvIncludes": [["install"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "warn",
+      "flags": "i"
+    },
+    {
+      "name": "package",
+      "pattern": "\\bpackages?\\b",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/install/yarn-install.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/install/yarn-install.json
@@ -1,0 +1,42 @@
+{
+  "id": "install/yarn-install",
+  "family": "dependency-install",
+  "description": "Compact yarn install output while preserving warnings and summary lines.",
+  "matchOutput": [
+    {
+      "pattern": "Already up-to-date\\.",
+      "message": "yarn install: up to date"
+    }
+  ],
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["yarn"],
+    "argvIncludes": [["install"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "warning",
+      "flags": "i"
+    },
+    {
+      "name": "package",
+      "pattern": "\\bpackages?\\b",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/lint/biome.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/lint/biome.json
@@ -1,0 +1,35 @@
+{
+  "id": "lint/biome",
+  "family": "lint-results",
+  "description": "Compact Biome output while preserving diagnostics.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludes": ["biome"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 14,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "\\berror\\b",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "\\bwarning\\b",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/lint/eslint.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/lint/eslint.json
@@ -1,0 +1,45 @@
+{
+  "id": "lint/eslint",
+  "family": "lint-results",
+  "description": "Compact ESLint output while preserving file diagnostics and summary counts.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludes": ["eslint"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "^.+\\.(ts|tsx|js|jsx|mjs|cjs)$",
+      "^\\s*\\d+:\\d+\\s+(error|warning)\\s+.+",
+      "^✖\\s+.+",
+      "^\\d+ problems?\\s+\\(.+\\)$",
+      "^\\s*error\\s+.+",
+      "^\\s*warning\\s+.+"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "\\berror\\b",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "\\bwarning\\b",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/lint/oxlint.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/lint/oxlint.json
@@ -1,0 +1,35 @@
+{
+  "id": "lint/oxlint",
+  "family": "lint-results",
+  "description": "Compact Oxlint output while preserving diagnostics.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludes": ["oxlint"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 14,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "\\berror\\b",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "\\bwarning\\b",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/lint/prettier-check.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/lint/prettier-check.json
@@ -1,0 +1,34 @@
+{
+  "id": "lint/prettier-check",
+  "family": "lint-results",
+  "description": "Compact Prettier check output while preserving unformatted files.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludes": ["prettier", "--check"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "warn",
+      "flags": "i"
+    },
+    {
+      "name": "file",
+      "pattern": "\\[[^\\]]+\\]"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/media/ffmpeg.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/media/ffmpeg.json
@@ -1,0 +1,30 @@
+{
+  "id": "media/ffmpeg",
+  "family": "media-cli",
+  "description": "Compact ffmpeg output while preserving stream mapping, progress, and terminal errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["ffmpeg"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|invalid|failed|frame=",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/media/mediainfo.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/media/mediainfo.json
@@ -1,0 +1,30 @@
+{
+  "id": "media/mediainfo",
+  "family": "media-cli",
+  "description": "Compact mediainfo output while preserving format, duration, and stream details.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["mediainfo"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "error|failed|duration|format",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/network/curl.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/network/curl.json
@@ -1,0 +1,30 @@
+{
+  "id": "network/curl",
+  "family": "network-http",
+  "description": "Compact curl output while preserving response or failure details.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["curl"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|timed out",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/network/dig.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/network/dig.json
@@ -1,0 +1,30 @@
+{
+  "id": "network/dig",
+  "family": "network-dns",
+  "description": "Compact dig output while preserving answer sections and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["dig"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "answer",
+      "pattern": "ANSWER SECTION|\\sIN\\sA\\s|\\sIN\\sAAAA\\s",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/network/nslookup.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/network/nslookup.json
@@ -1,0 +1,30 @@
+{
+  "id": "network/nslookup",
+  "family": "network-dns",
+  "description": "Compact nslookup output while preserving server and answer rows.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["nslookup"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "server",
+      "pattern": "^Server:",
+      "flags": "m"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/network/ping.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/network/ping.json
@@ -1,0 +1,35 @@
+{
+  "id": "network/ping",
+  "family": "network-probe",
+  "description": "Compact ping output while preserving packet loss and latency summary.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["ping"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "reply",
+      "pattern": "bytes from",
+      "flags": "i"
+    },
+    {
+      "name": "packet loss",
+      "pattern": "packet loss",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/network/ssh.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/network/ssh.json
@@ -1,0 +1,30 @@
+{
+  "id": "network/ssh",
+  "family": "network-remote-shell",
+  "description": "Compact ssh output while preserving authentication and connection errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["ssh"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "permission denied|connection refused|timed out|host key verification failed",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/network/traceroute.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/network/traceroute.json
@@ -1,0 +1,30 @@
+{
+  "id": "network/traceroute",
+  "family": "network-route",
+  "description": "Compact traceroute output while preserving hop rows and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["traceroute"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "hop",
+      "pattern": "^\\s*\\d+\\s",
+      "flags": "m"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/network/wget.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/network/wget.json
@@ -1,0 +1,30 @@
+{
+  "id": "network/wget",
+  "family": "network-http",
+  "description": "Compact wget output while preserving transfer summary and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["wget"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/observability/free.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/observability/free.json
@@ -1,0 +1,30 @@
+{
+  "id": "observability/free",
+  "family": "resource-memory",
+  "description": "Compact free output while preserving memory and swap totals.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["free"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "error|failed",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/observability/htop.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/observability/htop.json
@@ -1,0 +1,30 @@
+{
+  "id": "observability/htop",
+  "family": "resource-processes",
+  "description": "Compact htop output while preserving load, tasks, and top process lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["htop"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "load average|tasks|zombie",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/observability/iostat.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/observability/iostat.json
@@ -1,0 +1,30 @@
+{
+  "id": "observability/iostat",
+  "family": "resource-io",
+  "description": "Compact iostat output while preserving CPU averages and busy devices.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["iostat"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "busy",
+      "pattern": "%util|Device",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/observability/top.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/observability/top.json
@@ -1,0 +1,30 @@
+{
+  "id": "observability/top",
+  "family": "resource-processes",
+  "description": "Compact top output while preserving load, task counts, and leading process rows.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["top"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "load average|zombie|stopped",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/observability/vmstat.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/observability/vmstat.json
@@ -1,0 +1,30 @@
+{
+  "id": "observability/vmstat",
+  "family": "resource-vm",
+  "description": "Compact vmstat output while preserving run queue, memory, swap, and io columns.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["vmstat"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "swpd|cache|wa|st",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/package/apt-install.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/package/apt-install.json
@@ -1,0 +1,36 @@
+{
+  "id": "package/apt-install",
+  "family": "system-package-install",
+  "description": "Compact apt install output while preserving package counts, fetch summaries, and errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["apt", "apt-get"],
+    "argvIncludes": [["install"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^Reading database \\.{3}.+$"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|unable to",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/package/apt-upgrade.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/package/apt-upgrade.json
@@ -1,0 +1,36 @@
+{
+  "id": "package/apt-upgrade",
+  "family": "system-package-upgrade",
+  "description": "Compact apt upgrade output while preserving upgraded package counts and blocking errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["apt", "apt-get"],
+    "argvIncludes": [["upgrade"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^Reading database \\.{3}.+$"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|kept back",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/package/brew-install.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/package/brew-install.json
@@ -1,0 +1,31 @@
+{
+  "id": "package/brew-install",
+  "family": "system-package-install",
+  "description": "Compact brew install output while preserving taps, installs, and failure details.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["brew"],
+    "argvIncludes": [["install"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "warning|error|failed",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/package/brew-upgrade.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/package/brew-upgrade.json
@@ -1,0 +1,31 @@
+{
+  "id": "package/brew-upgrade",
+  "family": "system-package-upgrade",
+  "description": "Compact brew upgrade output while preserving upgraded formulae and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["brew"],
+    "argvIncludes": [["upgrade"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "warning|error|failed",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/package/composer.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/package/composer.json
@@ -1,0 +1,35 @@
+{
+  "id": "package/composer",
+  "family": "package-manager",
+  "description": "Compact Composer output while preserving package operations, solver failures, and script errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["composer"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "package",
+      "pattern": "Installing|Updating|Locking|Removing|Generating autoload",
+      "flags": "i"
+    },
+    {
+      "name": "error",
+      "pattern": "Your requirements could not be resolved|Script .* returned with error|failed|error",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/package/dnf-install.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/package/dnf-install.json
@@ -1,0 +1,31 @@
+{
+  "id": "package/dnf-install",
+  "family": "system-package-install",
+  "description": "Compact dnf install output while preserving transaction summaries and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["dnf"],
+    "argvIncludes": [["install"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|nothing to do",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/package/fnm.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/package/fnm.json
@@ -1,0 +1,35 @@
+{
+  "id": "package/fnm",
+  "family": "runtime-manager",
+  "description": "Compact fnm output while preserving installs, selected versions, and lookup failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["fnm"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "version",
+      "pattern": "Installing|Using|Downloading|v\\d+\\.\\d+\\.\\d+",
+      "flags": "i"
+    },
+    {
+      "name": "error",
+      "pattern": "error|failed|not found",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/package/npm-ls.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/package/npm-ls.json
@@ -1,0 +1,31 @@
+{
+  "id": "package/npm-ls",
+  "family": "package-manager",
+  "description": "Compact npm ls output while preserving dependency tree roots, invalid packages, and missing peers.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["npm"],
+    "argvIncludesAny": [["ls"], ["list"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "problem",
+      "pattern": "UNMET|invalid|extraneous|missing|npm ERR!",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/package/yum-install.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/package/yum-install.json
@@ -1,0 +1,31 @@
+{
+  "id": "package/yum-install",
+  "family": "system-package-install",
+  "description": "Compact yum install output while preserving dependency summaries and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["yum"],
+    "argvIncludes": [["install"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|nothing to do",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/search/git-grep.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/search/git-grep.json
@@ -1,0 +1,30 @@
+{
+  "id": "search/git-grep",
+  "family": "search",
+  "description": "Compact git grep output while preserving matches.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["git"],
+    "argvIncludes": [["grep"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 4
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "match",
+      "pattern": ".+:.+"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/search/grep.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/search/grep.json
@@ -1,0 +1,38 @@
+{
+  "id": "search/grep",
+  "family": "search",
+  "description": "Compact grep output while preserving matching lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["grep"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "^.+:\\d+[: -].+",
+      "^.+:.+",
+      "error|warn|binary file|permission denied|no such file",
+      "^\\d+ matches?$",
+      "^\\d+ files? matched$"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "match",
+      "pattern": ".+:.+"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/search/rg.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/search/rg.json
@@ -1,0 +1,38 @@
+{
+  "id": "search/rg",
+  "family": "search",
+  "description": "Compact ripgrep output while preserving match lines.",
+  "match": {
+    "argv0": ["rg"],
+    "toolNames": ["exec"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "^.+:\\d+[: -].+",
+      "^.+:.+",
+      "error|warn|binary file|permission denied|no such file",
+      "^\\d+ matches?$",
+      "^\\d+ files? matched$"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "match",
+      "pattern": ".+:.+"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/service/journalctl.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/service/journalctl.json
@@ -1,0 +1,42 @@
+{
+  "id": "service/journalctl",
+  "family": "service-logs",
+  "description": "Compact journalctl output while preserving key log lines and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["journalctl"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "error|warn|fatal|panic|exception|traceback|timeout|refused|fail",
+      "^Caused by:",
+      "^Traceback"
+    ]
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "warn",
+      "flags": "i"
+    },
+    {
+      "name": "error",
+      "pattern": "error|failed",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/service/launchctl.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/service/launchctl.json
@@ -1,0 +1,41 @@
+{
+  "id": "service/launchctl",
+  "family": "service-state",
+  "description": "Compact launchctl output while preserving labels and status rows.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["launchctl"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "^-?\\d+\\s+\\S+\\s+.+",
+      "^PID\\s+Status\\s+Label$",
+      "error|failed|stopped|disabled"
+    ]
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "service",
+      "pattern": "^(?!PID\\s+Status\\s+Label$).+\\S.*$"
+    },
+    {
+      "name": "error",
+      "pattern": "error|failed|stopped|disabled",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/service/lsof.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/service/lsof.json
@@ -1,0 +1,29 @@
+{
+  "id": "service/lsof",
+  "family": "service-open-files",
+  "description": "Compact lsof output while preserving open-file rows.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["lsof"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "entry",
+      "pattern": "^(?!COMMAND\\s+PID\\s+USER\\s).+\\S.*$"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/service/netstat.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/service/netstat.json
@@ -1,0 +1,29 @@
+{
+  "id": "service/netstat",
+  "family": "service-network-state",
+  "description": "Compact netstat output while preserving socket rows.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["netstat"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "socket",
+      "pattern": "^(?!Proto\\s|Active\\s).+\\S.*$"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/service/pm2.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/service/pm2.json
@@ -1,0 +1,35 @@
+{
+  "id": "service/pm2",
+  "family": "service-process-manager",
+  "description": "Compact pm2 output while preserving process state, log errors, and restart failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["pm2"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "process",
+      "pattern": "online|stopped|errored|restarting|launching",
+      "flags": "i"
+    },
+    {
+      "name": "error",
+      "pattern": "error|failed|exception|EADDRINUSE",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/service/service.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/service/service.json
@@ -1,0 +1,46 @@
+{
+  "id": "service/service",
+  "family": "service-state",
+  "description": "Compact service command output while preserving status and failure lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["service"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "error|failed|inactive|stopped|warning|refused|timeout",
+      "is running",
+      "is stopped",
+      "start/running",
+      "stop/waiting",
+      "^\\s*Active:\\s+.+",
+      "^\\s*Status:\\s+.+"
+    ]
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "warning|refused|timeout",
+      "flags": "i"
+    },
+    {
+      "name": "error",
+      "pattern": "error|failed|inactive|stopped",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/service/ss.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/service/ss.json
@@ -1,0 +1,29 @@
+{
+  "id": "service/ss",
+  "family": "service-network-state",
+  "description": "Compact ss output while preserving socket rows.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["ss"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "socket",
+      "pattern": "^(?!Netid\\s|State\\s).+\\S.*$"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/service/systemctl-status.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/service/systemctl-status.json
@@ -1,0 +1,45 @@
+{
+  "id": "service/systemctl-status",
+  "family": "service-state",
+  "description": "Compact systemctl status output while preserving active state and failure lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["systemctl"],
+    "argvIncludes": [["status"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "^●\\s+.+",
+      "^\\s*(Loaded|Active|Main PID|Tasks|Memory|CPU):",
+      "error|failed|inactive|dead|back-off|timeout|refused|warning",
+      "^\\s*Process:\\s+.+",
+      "^\\s*Docs:\\s+.+"
+    ]
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "warning|back-off|timeout|refused",
+      "flags": "i"
+    },
+    {
+      "name": "error",
+      "pattern": "failed|inactive|dead|error",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/system/df.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/system/df.json
@@ -1,0 +1,29 @@
+{
+  "id": "system/df",
+  "family": "system-disk",
+  "description": "Compact df output while preserving filesystem rows.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["df"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 4
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 12
+  },
+  "counters": [
+    {
+      "name": "filesystem",
+      "pattern": ".+"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/system/du.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/system/du.json
@@ -1,0 +1,29 @@
+{
+  "id": "system/du",
+  "family": "system-disk",
+  "description": "Compact du output while preserving size rows.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["du"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "entry",
+      "pattern": "^\\S+\\s+.+"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/system/file.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/system/file.json
@@ -1,0 +1,30 @@
+{
+  "id": "system/file",
+  "family": "file-inspection",
+  "description": "Compact file output while preserving the detected file type.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["file"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "cannot open|error",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/system/ps.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/system/ps.json
@@ -1,0 +1,29 @@
+{
+  "id": "system/ps",
+  "family": "system-processes",
+  "description": "Compact ps output while preserving process rows.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["ps"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 12,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "process",
+      "pattern": "^(?!USER\\s|PID\\s).+\\S.*$"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/task/env.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/task/env.json
@@ -1,0 +1,31 @@
+{
+  "id": "task/env",
+  "family": "shell-runner",
+  "description": "Compact env-prefixed command output while preserving wrapped command failures.",
+  "priority": 1,
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["env"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "env:|error|failed|not found|permission denied",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/task/just.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/task/just.json
@@ -1,0 +1,30 @@
+{
+  "id": "task/just",
+  "family": "task-runner",
+  "description": "Compact just output while preserving task results and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["just"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/task/make.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/task/make.json
@@ -1,0 +1,30 @@
+{
+  "id": "task/make",
+  "family": "task-runner",
+  "description": "Compact make output while preserving target failures and summaries.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["make"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/task/mise.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/task/mise.json
@@ -1,0 +1,35 @@
+{
+  "id": "task/mise",
+  "family": "task-runner",
+  "description": "Compact mise output while preserving task results, tool installs, and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["mise"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "install",
+      "pattern": "Downloading|Extracting|Installing|Installed",
+      "flags": "i"
+    },
+    {
+      "name": "error",
+      "pattern": "error|failed|not found|exit status",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/task/node.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/task/node.json
@@ -1,0 +1,30 @@
+{
+  "id": "task/node",
+  "family": "runtime-cli",
+  "description": "Compact node output while preserving stack traces, uncaught errors, and process failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["node"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 20,
+    "tail": 20
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "Error:|TypeError:|ReferenceError:|SyntaxError:|UnhandledPromiseRejection|ERR_",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/task/php.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/task/php.json
@@ -1,0 +1,30 @@
+{
+  "id": "task/php",
+  "family": "runtime-cli",
+  "description": "Compact php output while preserving fatal errors, warnings, and failed scripts.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["php"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 20,
+    "tail": 20
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "PHP Fatal error|PHP Warning|Parse error|Exception|failed",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/task/python.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/task/python.json
@@ -1,0 +1,30 @@
+{
+  "id": "task/python",
+  "family": "runtime-cli",
+  "description": "Compact Python output while preserving tracebacks, exceptions, and failed scripts.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["python", "python3"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 20,
+    "tail": 20
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "Traceback|Error:|Exception|SyntaxError|ModuleNotFoundError|FAILED",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/task/ruby.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/task/ruby.json
@@ -1,0 +1,30 @@
+{
+  "id": "task/ruby",
+  "family": "runtime-cli",
+  "description": "Compact ruby output while preserving exceptions, load errors, and failed scripts.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["ruby"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 20,
+    "tail": 20
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "Traceback|Error|Exception|LoadError|NoMethodError|failed",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/task/uv.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/task/uv.json
@@ -1,0 +1,35 @@
+{
+  "id": "task/uv",
+  "family": "python-task-runner",
+  "description": "Compact uv output while preserving environment setup, package changes, and command failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["uv"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "package",
+      "pattern": "Resolved|Prepared|Installed|Uninstalled|Audited",
+      "flags": "i"
+    },
+    {
+      "name": "error",
+      "pattern": "error|failed|Traceback|FAILED|exit code",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/tests/bun-test.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/tests/bun-test.json
@@ -1,0 +1,56 @@
+{
+  "id": "tests/bun-test",
+  "family": "test-results",
+  "description": "Compact bun test output while preserving failures and summary lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["bun"],
+    "argvIncludes": [["test"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^> .+$",
+      "^\\s*RUN\\s+.+$",
+      "^\\s*Start at\\s+.+$"
+    ],
+    "keepPatterns": [
+      "^\\s*❯\\s+.+",
+      "^\\s*✓\\s+.+",
+      "^\\s*FAIL\\s+.+",
+      "^\\s*PASS\\s+.+",
+      "^AssertionError: .+",
+      "^Error: .+",
+      "^Caused by: .+",
+      "^\\s*Test Files\\s+.+",
+      "^\\s*Tests\\s+.+",
+      "^\\s*Duration\\s+.+",
+      "^⎯⎯⎯.+"
+    ]
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "failed",
+      "pattern": "fail",
+      "flags": "i"
+    },
+    {
+      "name": "passed",
+      "pattern": "pass",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/tests/cargo-test.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/tests/cargo-test.json
@@ -1,0 +1,41 @@
+{
+  "id": "tests/cargo-test",
+  "family": "test-results",
+  "description": "Compact cargo test output while preserving failures and final summary.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["cargo"],
+    "argvIncludes": [["test"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^\\s*Compiling .+",
+      "^\\s*Finished .+",
+      "^\\s*Running .+"
+    ]
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "failed test",
+      "pattern": "FAILED"
+    },
+    {
+      "name": "passed test",
+      "pattern": "ok"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/tests/go-test.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/tests/go-test.json
@@ -1,0 +1,49 @@
+{
+  "id": "tests/go-test",
+  "family": "test-results",
+  "description": "Compact go test output while preserving failing packages and summaries.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["go"],
+    "argvIncludes": [["test"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^ok\\s.+"
+    ],
+    "keepPatterns": [
+      "^FAIL\\s.+",
+      "^--- FAIL: .+",
+      "^panic: .+",
+      "^\\s+.+_test\\.go:\\d+: .+",
+      "^\\s+Error Trace: .+",
+      "^\\s+Error: .+"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "failed package",
+      "pattern": "^FAIL\\s",
+      "flags": "m"
+    },
+    {
+      "name": "passed package",
+      "pattern": "^ok\\s",
+      "flags": "m"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/tests/jest.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/tests/jest.json
@@ -1,0 +1,41 @@
+{
+  "id": "tests/jest",
+  "family": "test-results",
+  "description": "Compact Jest output while preserving failures and summary counts.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludes": ["jest"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^\\s*at .+",
+      "^Ran all test suites.*$"
+    ]
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "failed test",
+      "pattern": "^FAIL\\s",
+      "flags": "m"
+    },
+    {
+      "name": "passed suite",
+      "pattern": "^PASS\\s",
+      "flags": "m"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/tests/mocha.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/tests/mocha.json
@@ -1,0 +1,35 @@
+{
+  "id": "tests/mocha",
+  "family": "test-results",
+  "description": "Compact Mocha output while preserving failing tests and summary counts.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludes": ["mocha"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "failing",
+      "pattern": "\\bfailing\\b",
+      "flags": "i"
+    },
+    {
+      "name": "passing",
+      "pattern": "\\bpassing\\b",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/tests/npm-test.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/tests/npm-test.json
@@ -1,0 +1,56 @@
+{
+  "id": "tests/npm-test",
+  "family": "test-results",
+  "description": "Catch common npm test runs when the underlying runner is not explicit.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["npm"],
+    "argvIncludes": [["test"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^> .+$",
+      "^\\s*RUN\\s+.+$",
+      "^\\s*Start at\\s+.+$"
+    ],
+    "keepPatterns": [
+      "^\\s*❯\\s+.+",
+      "^\\s*✓\\s+.+",
+      "^\\s*FAIL\\s+.+",
+      "^\\s*PASS\\s+.+",
+      "^AssertionError: .+",
+      "^Error: .+",
+      "^Caused by: .+",
+      "^\\s*Test Files\\s+.+",
+      "^\\s*Tests\\s+.+",
+      "^\\s*Duration\\s+.+",
+      "^⎯⎯⎯.+"
+    ]
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "failed",
+      "pattern": "fail",
+      "flags": "i"
+    },
+    {
+      "name": "passed",
+      "pattern": "pass",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/tests/playwright.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/tests/playwright.json
@@ -1,0 +1,37 @@
+{
+  "id": "tests/playwright",
+  "family": "test-results",
+  "description": "Compact Playwright test output while preserving failing specs and summary lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["playwright", "pnpm", "npx", "bunx", "yarn", "npm"],
+    "argvIncludes": [["playwright"], ["test"]],
+    "commandIncludes": ["playwright", "test"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "failed",
+      "pattern": "\\bfailed\\b",
+      "flags": "i"
+    },
+    {
+      "name": "passed",
+      "pattern": "\\bpassed\\b",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/tests/pnpm-test.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/tests/pnpm-test.json
@@ -1,0 +1,56 @@
+{
+  "id": "tests/pnpm-test",
+  "family": "test-results",
+  "description": "Catch common pnpm test runs when the underlying runner is not explicit.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["pnpm"],
+    "argvIncludes": [["test"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^> .+$",
+      "^\\s*RUN\\s+.+$",
+      "^\\s*Start at\\s+.+$"
+    ],
+    "keepPatterns": [
+      "^\\s*❯\\s+.+",
+      "^\\s*✓\\s+.+",
+      "^\\s*FAIL\\s+.+",
+      "^\\s*PASS\\s+.+",
+      "^AssertionError: .+",
+      "^Error: .+",
+      "^Caused by: .+",
+      "^\\s*Test Files\\s+.+",
+      "^\\s*Tests\\s+.+",
+      "^\\s*Duration\\s+.+",
+      "^⎯⎯⎯.+"
+    ]
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "failed",
+      "pattern": "fail",
+      "flags": "i"
+    },
+    {
+      "name": "passed",
+      "pattern": "pass",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/tests/pytest.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/tests/pytest.json
@@ -1,0 +1,54 @@
+{
+  "id": "tests/pytest",
+  "family": "test-results",
+  "description": "Compact pytest output while preserving failures and final summary.",
+  "counterSource": "preKeep",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludes": ["pytest"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^platform .+",
+      "^rootdir: .+",
+      "^plugins: .+",
+      "^collected \\d+ items$"
+    ],
+    "keepPatterns": [
+      "^=+.+(failed|passed|error).+=+$",
+      "^_{2,}.+_{2,}$",
+      "^FAILED .+",
+      "^ERROR .+",
+      "^E\\s+.+",
+      "AssertionError",
+      "^.+::.+ (FAILED|ERROR)$",
+      "^>\\s+.+"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "failed test",
+      "pattern": "^.+::.+ (FAILED|ERROR)$",
+      "flags": "i"
+    },
+    {
+      "name": "passed test",
+      "pattern": "^.+::.+ PASSED$",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/tests/rspec.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/tests/rspec.json
@@ -1,0 +1,31 @@
+{
+  "id": "tests/rspec",
+  "family": "test-results",
+  "description": "Compact RSpec output while preserving examples, failures, and summary counts.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["rspec", "bundle"],
+    "commandIncludesAny": ["rspec"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 20,
+    "tail": 20
+  },
+  "counters": [
+    {
+      "name": "failing",
+      "pattern": "Failures:|\\d+\\) |failed|examples?, \\d+ failures?",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/tests/swift-test.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/tests/swift-test.json
@@ -1,0 +1,66 @@
+{
+  "id": "tests/swift-test",
+  "family": "test-results",
+  "description": "Compact swift test output while preserving compile diagnostics, failing tests, and final summaries.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["swift"],
+    "argvIncludes": [["test"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^\\[\\d+/\\d+\\]\\s+.+$",
+      "^Building for .+\\.\\.\\.$",
+      "^Planning build$",
+      "^Test Case '.+' started\\.$",
+      "^Test Case '.+' passed .+$",
+      "^Test Suite '.+' started at .+$"
+    ],
+    "keepPatterns": [
+      "^.+:\\d+:\\d+: error: .+",
+      "^.+:\\d+:\\d+: warning: .+",
+      "^.+:\\d+: error: .+",
+      "^.+:\\d+: warning: .+",
+      "^error: .+",
+      "^warning: .+",
+      "^note: .+",
+      "^Test Case '.+' failed .+$",
+      "^Test Suite '.+' failed at .+$",
+      "^\\s*Executed \\d+ tests?, with \\d+ failures?.+$",
+      "^Test run with .+ failed.+$",
+      "^[✘✖✗] .+$",
+      "^.+(?:Assertion|Expectation) failed:.+$"
+    ]
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning",
+      "flags": "i"
+    },
+    {
+      "name": "failed test",
+      "pattern": "(?:^Test Case '.+' failed .+$|^[✘✖✗] .+$)",
+      "flags": "m"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/tests/vitest.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/tests/vitest.json
@@ -1,0 +1,56 @@
+{
+  "id": "tests/vitest",
+  "family": "test-results",
+  "description": "Compact Vitest output while preserving failures and summary lines.",
+  "priority": 1,
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludesAny": ["vitest", "run-vitest.mjs"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^\\s*at .+",
+      "^\\s*❯ .+node_modules.+",
+      "^\\s*✓ .+"
+    ],
+    "keepPatterns": [
+      "^\\s*RUN\\s+",
+      "^\\s*❯\\s+.+",
+      "^\\s*FAIL\\s+.+",
+      "^AssertionError: .+",
+      "^Error: .+",
+      "^Caused by: .+",
+      "^\\s*Test Files\\s+.+",
+      "^\\s*Tests\\s+.+",
+      "^   Start at\\s+.+",
+      "^   Duration\\s+.+",
+      "^⎯⎯⎯.+"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "failed suite",
+      "pattern": "^\\s*❯\\s.+",
+      "flags": "m"
+    },
+    {
+      "name": "failure",
+      "pattern": "failed",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/tests/yarn-test.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/tests/yarn-test.json
@@ -1,0 +1,56 @@
+{
+  "id": "tests/yarn-test",
+  "family": "test-results",
+  "description": "Catch common yarn test runs when the underlying runner is not explicit.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["yarn"],
+    "argvIncludes": [["test"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^> .+$",
+      "^\\s*RUN\\s+.+$",
+      "^\\s*Start at\\s+.+$"
+    ],
+    "keepPatterns": [
+      "^\\s*❯\\s+.+",
+      "^\\s*✓\\s+.+",
+      "^\\s*FAIL\\s+.+",
+      "^\\s*PASS\\s+.+",
+      "^AssertionError: .+",
+      "^Error: .+",
+      "^Caused by: .+",
+      "^\\s*Test Files\\s+.+",
+      "^\\s*Tests\\s+.+",
+      "^\\s*Duration\\s+.+",
+      "^⎯⎯⎯.+"
+    ]
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 16,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "failed",
+      "pattern": "fail",
+      "flags": "i"
+    },
+    {
+      "name": "passed",
+      "pattern": "pass",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/text/wc.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/text/wc.json
@@ -1,0 +1,35 @@
+{
+  "id": "text/wc",
+  "family": "text-processing",
+  "description": "Compact wc output while preserving counts and read errors.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["wc"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "count",
+      "pattern": "^\\s*\\d+",
+      "flags": "m"
+    },
+    {
+      "name": "error",
+      "pattern": "No such file|Permission denied|cannot open",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/transfer/rsync.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/transfer/rsync.json
@@ -1,0 +1,30 @@
+{
+  "id": "transfer/rsync",
+  "family": "file-transfer",
+  "description": "Compact rsync output while preserving changed paths, stats, and sync failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["rsync"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|connection|sent ",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/rules/transfer/scp.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/transfer/scp.json
@@ -1,0 +1,30 @@
+{
+  "id": "transfer/scp",
+  "family": "file-transfer",
+  "description": "Compact scp output while preserving transferred paths, throughput, and ssh failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["scp"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 8,
+    "tail": 6
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 10,
+    "tail": 10
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error|failed|permission denied|lost connection",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/opensquilla/plugins/tokenjuice/types.py
+++ b/src/opensquilla/plugins/tokenjuice/types.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Rule:
+    id: str
+    family: str
+    match: dict[str, Any]
+    transforms: dict[str, Any]
+    filters: dict[str, Any]
+    summarize: dict[str, Any]
+    failure: dict[str, Any]
+    counters: tuple[dict[str, Any], ...]
+    output_matches: tuple[dict[str, Any], ...]
+    on_empty: str | None
+    counter_source: str
+    priority: int
+
+
+@dataclass(frozen=True)
+class Reduction:
+    inline_text: str
+    raw_chars: int
+    reduced_chars: int
+    ratio: float
+    reducer: str | None = None

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -35,6 +35,7 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     ("engine", "identity"),
     ("engine", "memory"),
     ("engine", "observability"),
+    ("engine", "plugins"),
     ("engine", "provider"),
     ("engine", "safety"),
     ("engine", "session"),

--- a/tests/test_cli/test_chat_cmd.py
+++ b/tests/test_cli/test_chat_cmd.py
@@ -1717,6 +1717,27 @@ async def test_gateway_slash_tool_compress_can_switch_to_summarize(monkeypatch) 
 
 
 @pytest.mark.asyncio
+async def test_gateway_slash_tool_compress_can_switch_to_tokenjuice(monkeypatch) -> None:
+    _FakeGatewayClient.instances.clear()
+    monkeypatch.setattr("opensquilla.cli.gateway_client.GatewayClient", _FakeGatewayClient)
+    fake = _FakeGatewayClient()
+    state = ChatSessionState(session_key="agent:main:abc123", model="openai/test")
+
+    handled = await chat_cmd._handle_gateway_slash_command(
+        "/tool-compress tokenjuice", state, fake, {"mode": None}
+    )
+
+    assert handled is True
+    assert fake.config_patch_safe_calls == [
+        {
+            "agent_token_saving.tool_result_compression_mode": "tokenjuice",
+            "agent_token_saving.tool_result_compression_enabled": True,
+        }
+    ]
+    assert fake.config_values["agent_token_saving.tool_result_compression_mode"] == "tokenjuice"
+
+
+@pytest.mark.asyncio
 async def test_gateway_slash_tool_compress_status_reads_config(monkeypatch) -> None:
     _FakeGatewayClient.instances.clear()
     monkeypatch.setattr("opensquilla.cli.gateway_client.GatewayClient", _FakeGatewayClient)
@@ -1756,6 +1777,10 @@ async def test_standalone_tool_compress_toggles_config() -> None:
     await chat_cmd._handle_tool_compress_command("/tool-compress summarize", config=config)
     assert config.agent_token_saving.tool_result_compression_enabled is True
     assert config.agent_token_saving.tool_result_compression_mode == "summarize"
+
+    await chat_cmd._handle_tool_compress_command("/tool-compress tokenjuice", config=config)
+    assert config.agent_token_saving.tool_result_compression_enabled is True
+    assert config.agent_token_saving.tool_result_compression_mode == "tokenjuice"
 
     await chat_cmd._handle_tool_compress_command("/tool-compress on", config=config)
     assert config.agent_token_saving.tool_result_compression_mode == "truncate"

--- a/tests/test_cli/test_slash_completer.py
+++ b/tests/test_cli/test_slash_completer.py
@@ -99,6 +99,12 @@ def test_tool_compress_argument_completions_show_modes_not_commands() -> None:
     assert results == ["status", "summarize"]
 
 
+def test_tool_compress_argument_completions_include_tokenjuice() -> None:
+    results = _completions_for("/tool-compress t")
+
+    assert results == ["tokenjuice", "truncate"]
+
+
 def test_commands_without_argument_completions_do_not_fall_back_to_slash_words() -> None:
     results = _completions_for("/help ")
 

--- a/tests/test_engine/test_tokenjuice_tool_result_compression.py
+++ b/tests/test_engine/test_tokenjuice_tool_result_compression.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import opensquilla.engine.agent as agent_mod
+import opensquilla.engine.tokenjuice_adapter as tokenjuice_adapter_mod
+from opensquilla.engine import Agent, AgentConfig, ToolCall, ToolResult
+from opensquilla.engine.runtime import TurnRunner
+from opensquilla.engine.types import ToolResultEvent
+from opensquilla.gateway.config import AgentTokenSavingConfig
+from opensquilla.plugins.tokenjuice import reduce_tool_result as plugin_reduce_tool_result
+from opensquilla.provider import DoneEvent, TextDeltaEvent, ToolDefinition, ToolInputSchema
+from opensquilla.provider import DoneEvent as ProviderDoneEvent
+from opensquilla.provider import ToolUseEndEvent as ProviderToolUseEndEvent
+from opensquilla.provider import ToolUseStartEvent as ProviderToolUseStartEvent
+
+
+class _Provider:
+    provider_name = "fake"
+
+    def __init__(self, return_text: str | None = None) -> None:
+        self.return_text = return_text
+        self.chat_calls = 0
+
+    def chat(self, messages, tools=None, config=None):
+        self.chat_calls += 1
+        if self.return_text is None:  # pragma: no cover - must not run
+            raise AssertionError("summary provider should not be used")
+        return self._stream()
+
+    async def _stream(self):
+        yield TextDeltaEvent(text=self.return_text or "")
+        yield DoneEvent(stop_reason="stop", model="summary-model")
+
+    async def list_models(self) -> list[Any]:
+        return []
+
+
+class _ToolCallingProvider:
+    provider_name = "fake"
+
+    def __init__(self) -> None:
+        self.calls: list[list[Any]] = []
+
+    def chat(self, messages, tools=None, config=None):
+        self.calls.append(messages)
+        return self._stream(len(self.calls))
+
+    async def _stream(self, call_number: int):
+        if call_number == 1:
+            yield ProviderToolUseStartEvent(tool_use_id="tool-1", tool_name="exec_command")
+            yield ProviderToolUseEndEvent(
+                tool_use_id="tool-1",
+                tool_name="exec_command",
+                arguments={"command": "pytest -q", "workdir": "/repo"},
+            )
+            yield ProviderDoneEvent(stop_reason="tool_use", input_tokens=1, output_tokens=1)
+            return
+        yield TextDeltaEvent(text="done")
+        yield ProviderDoneEvent(stop_reason="stop", input_tokens=1, output_tokens=1)
+
+    async def list_models(self) -> list[Any]:
+        return []
+
+
+def _tool_def(name: str) -> ToolDefinition:
+    return ToolDefinition(
+        name=name,
+        description=f"Mock tool {name}",
+        input_schema=ToolInputSchema(properties={}, required=[]),
+    )
+
+
+def test_agent_resolves_tokenjuice_compression_mode() -> None:
+    agent = Agent(
+        provider=_Provider(),
+        config=AgentConfig(tool_result_compression_mode="tokenjuice"),
+    )
+
+    assert agent._tool_result_compression_mode() == "tokenjuice"
+
+
+def test_runtime_resolves_tokenjuice_compression_mode() -> None:
+    cfg = SimpleNamespace(
+        tool_result_compression_mode="tokenjuice",
+        tool_result_compression_enabled=True,
+    )
+
+    assert TurnRunner._resolve_tool_result_compression_mode(cfg) == "tokenjuice"
+
+
+def test_gateway_config_accepts_tokenjuice_compression_mode() -> None:
+    cfg = AgentTokenSavingConfig(tool_result_compression_mode="tokenjuice")
+
+    assert cfg.effective_tool_result_compression_mode == "tokenjuice"
+
+
+@pytest.mark.asyncio
+async def test_truncate_mode_does_not_call_tokenjuice(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_reduce(**kwargs: Any) -> Any:  # pragma: no cover - must not run
+        raise AssertionError("truncate mode must not call tokenjuice")
+
+    monkeypatch.setattr(agent_mod, "reduce_tool_result_with_tokenjuice", fail_reduce, raising=False)
+    agent = Agent(
+        provider=_Provider(),
+        config=AgentConfig(
+            context_window_tokens=100,
+            tool_result_compression_mode="truncate",
+            tool_result_compression_max_share=0.25,
+        ),
+    )
+    result = ToolResult(
+        tool_use_id="tool-1",
+        tool_name="exec_command",
+        content="pytest output\n" + ("x" * 1000),
+    )
+
+    compressed = await agent._compress_tool_result(
+        result,
+        tool_call=ToolCall(
+            tool_use_id="tool-1",
+            tool_name="exec_command",
+            arguments={"command": "pytest -q", "workdir": "/repo"},
+        ),
+    )
+
+    assert compressed.content != result.content
+    assert "pytest output" in compressed.content
+    assert "[...truncated" in compressed.content
+    assert agent.config.metadata.get("tool_compression_backend") is None
+
+
+@pytest.mark.asyncio
+async def test_summarize_mode_does_not_call_tokenjuice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _Provider(return_text="summary result")
+
+    def fail_reduce(**kwargs: Any) -> Any:  # pragma: no cover - must not run
+        raise AssertionError("summarize mode must not call tokenjuice")
+
+    monkeypatch.setattr(agent_mod, "reduce_tool_result_with_tokenjuice", fail_reduce, raising=False)
+    agent = Agent(
+        provider=_Provider(),
+        config=AgentConfig(
+            context_window_tokens=100,
+            tool_result_compression_mode="summarize",
+            tool_result_compression_max_share=0.25,
+        ),
+        tool_result_summarizer_provider=provider,
+    )
+    result = ToolResult(
+        tool_use_id="tool-1",
+        tool_name="exec_command",
+        content="long output\n" + ("x" * 1000),
+    )
+
+    compressed = await agent._compress_tool_result(result)
+
+    assert "summary result" in compressed.content
+    assert provider.chat_calls == 1
+    assert agent.config.metadata.get("tool_compression_backend") is None
+
+
+@pytest.mark.asyncio
+async def test_tokenjuice_mode_uses_tokenjuice_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_reduce(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return SimpleNamespace(
+            inline_text="[tokenjuice]\n1 failed, 2 passed",
+            raw_chars=len(kwargs["content"]),
+            reduced_chars=30,
+            ratio=0.1,
+            reducer="tests/pytest",
+        )
+
+    monkeypatch.setattr(agent_mod, "reduce_tool_result_with_tokenjuice", fake_reduce, raising=False)
+    agent = Agent(
+        provider=_Provider(),
+        config=AgentConfig(
+            context_window_tokens=100,
+            tool_result_compression_mode="tokenjuice",
+            tool_result_compression_max_share=0.25,
+        ),
+    )
+    result = ToolResult(
+        tool_use_id="tool-1",
+        tool_name="exec_command",
+        content="pytest output\n" + ("x" * 1000),
+    )
+
+    compressed = await agent._compress_tool_result(
+        result,
+        tool_call=ToolCall(
+            tool_use_id="tool-1",
+            tool_name="exec_command",
+            arguments={"command": "pytest -q", "workdir": "/repo"},
+        ),
+    )
+
+    assert compressed.content == "[tokenjuice]\n1 failed, 2 passed"
+    assert calls[0]["tool_name"] == "exec_command"
+    assert calls[0]["command"] == "pytest -q"
+    assert calls[0]["cwd"] == "/repo"
+    assert agent.config.metadata["tool_compression_backend"] == "tokenjuice"
+
+
+@pytest.mark.asyncio
+async def test_tokenjuice_mode_keeps_raw_result_when_tokenjuice_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        agent_mod,
+        "reduce_tool_result_with_tokenjuice",
+        lambda **kwargs: None,
+        raising=False,
+    )
+    agent = Agent(
+        provider=_Provider(),
+        config=AgentConfig(
+            context_window_tokens=100,
+            tool_result_compression_mode="tokenjuice",
+            tool_result_compression_max_share=0.25,
+        ),
+    )
+    result = ToolResult(
+        tool_use_id="tool-1",
+        tool_name="exec_command",
+        content="long output\n" + ("x" * 1000),
+    )
+
+    compressed = await agent._compress_tool_result(result)
+
+    assert compressed is result
+    assert agent.config.metadata.get("tool_compression_backend") is None
+
+
+@pytest.mark.asyncio
+async def test_summarize_mode_falls_back_to_summary_provider_when_tokenjuice_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        agent_mod,
+        "reduce_tool_result_with_tokenjuice",
+        lambda **kwargs: None,
+        raising=False,
+    )
+    provider = _Provider(return_text="summary result")
+    agent = Agent(
+        provider=_Provider(),
+        config=AgentConfig(
+            context_window_tokens=100,
+            tool_result_compression_mode="summarize",
+            tool_result_compression_max_share=0.25,
+        ),
+        tool_result_summarizer_provider=provider,
+    )
+    result = ToolResult(
+        tool_use_id="tool-1",
+        tool_name="exec_command",
+        content="long output\n" + ("x" * 1000),
+    )
+
+    compressed = await agent._compress_tool_result(result)
+
+    assert "summary result" in compressed.content
+    assert provider.chat_calls == 1
+
+
+def test_tokenjuice_adapter_calls_python_plugin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_reduce(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return SimpleNamespace(
+            inline_text="reduced output",
+            raw_chars=23,
+            reduced_chars=14,
+            ratio=14 / 23,
+            reducer="tests/pytest",
+        )
+
+    monkeypatch.setattr(
+        tokenjuice_adapter_mod,
+        "_reduce_tool_result_plugin",
+        fake_reduce,
+    )
+
+    result = tokenjuice_adapter_mod.reduce_tool_result_with_tokenjuice(
+        tool_name="exec_command",
+        content="raw output with details",
+        is_error=False,
+        tool_use_id="tool-1",
+        arguments={"command": "pytest -q", "workdir": "/repo"},
+        max_inline_chars=600,
+    )
+
+    assert result is not None
+    assert result.inline_text == "reduced output"
+    assert result.reducer == "tests/pytest"
+    assert captured["tool_name"] == "exec_command"
+    assert captured["content"] == "raw output with details"
+    assert captured["is_error"] is False
+    assert captured["tool_use_id"] == "tool-1"
+    assert captured["arguments"] == {"command": "pytest -q", "workdir": "/repo"}
+    assert captured["command"] == "pytest -q"
+    assert captured["cwd"] == "/repo"
+    assert captured["max_inline_chars"] == 600
+
+
+def test_tokenjuice_adapter_returns_none_when_plugin_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        tokenjuice_adapter_mod,
+        "_reduce_tool_result_plugin",
+        lambda **kwargs: None,
+    )
+
+    assert (
+        tokenjuice_adapter_mod.reduce_tool_result_with_tokenjuice(
+            tool_name="exec_command",
+            content="raw output",
+            is_error=False,
+            tool_use_id="tool-1",
+        )
+        is None
+    )
+
+
+def test_tokenjuice_adapter_ignores_non_shrinking_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_reduce(**kwargs: Any) -> Any:
+        return SimpleNamespace(
+            inline_text="this output is longer than raw output",
+            raw_chars=10,
+            reduced_chars=35,
+            ratio=3.5,
+            reducer="generic/fallback",
+        )
+
+    monkeypatch.setattr(
+        tokenjuice_adapter_mod,
+        "_reduce_tool_result_plugin",
+        fake_reduce,
+    )
+
+    assert (
+        tokenjuice_adapter_mod.reduce_tool_result_with_tokenjuice(
+            tool_name="exec_command",
+            content="raw output",
+            is_error=False,
+            tool_use_id="tool-1",
+        )
+        is None
+    )
+
+
+def test_python_plugin_reduces_pytest_output() -> None:
+    output = "\n".join(
+        [
+            "platform darwin -- Python 3.13",
+            "rootdir: /repo",
+            "collected 3 items",
+            "tests/test_api.py::test_ok PASSED",
+            "tests/test_api.py::test_bad FAILED",
+            "E   AssertionError: expected 1 == 2",
+            "FAILED tests/test_api.py::test_bad - AssertionError",
+            "=========================== 1 failed, 1 passed in 0.12s ===========================",
+        ]
+    )
+
+    result = plugin_reduce_tool_result(
+        tool_name="exec_command",
+        tool_use_id="tool-1",
+        command="pytest -q",
+        content=output,
+        is_error=True,
+        max_inline_chars=600,
+    )
+
+    assert result is not None
+    assert result.reducer == "tests/pytest"
+    assert "FAILED tests/test_api.py::test_bad" in result.inline_text
+    assert "AssertionError" in result.inline_text
+    assert "rootdir:" not in result.inline_text
+
+
+@pytest.mark.asyncio
+async def test_run_turn_feeds_tokenjuice_reduced_tool_result_to_next_provider_call() -> None:
+    output = "\n".join(
+        [
+            "platform darwin -- Python 3.13",
+            "rootdir: /repo",
+            "collected 3 items",
+            *(f"tests/test_api.py::test_extra_{index} PASSED" for index in range(40)),
+            "tests/test_api.py::test_ok PASSED",
+            "tests/test_api.py::test_bad FAILED",
+            "E   AssertionError: expected 1 == 2",
+            "FAILED tests/test_api.py::test_bad - AssertionError",
+            "=========================== 1 failed, 1 passed in 0.12s ===========================",
+        ]
+    )
+
+    async def handler(tool_call: ToolCall) -> ToolResult:
+        return ToolResult(
+            tool_use_id=tool_call.tool_use_id,
+            tool_name=tool_call.tool_name,
+            content=output,
+            is_error=True,
+        )
+
+    provider = _ToolCallingProvider()
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            context_window_tokens=500,
+            max_iterations=2,
+            tool_result_compression_mode="tokenjuice",
+            tool_result_compression_max_share=0.25,
+        ),
+        tool_definitions=[_tool_def("exec_command")],
+        tool_handler=handler,
+    )
+
+    events = [event async for event in agent.run_turn("run tests")]
+
+    assert len(provider.calls) == 2
+    second_call_tool_result = provider.calls[1][-1].content[0].content
+    assert "FAILED tests/test_api.py::test_bad" in second_call_tool_result
+    assert "AssertionError" in second_call_tool_result
+    assert "rootdir:" not in second_call_tool_result
+    assert agent.config.metadata["tool_compression_backend"] == "tokenjuice"
+    raw_event = next(event for event in events if isinstance(event, ToolResultEvent))
+    assert raw_event.result == output
+
+
+def test_python_plugin_reduces_docker_build_output() -> None:
+    output = "\n".join(
+        [
+            "#1 [internal] load build definition from Dockerfile",
+            "#1 sha256:1234",
+            "#1 DONE 0.1s",
+            "#2 [2/3] RUN pnpm install",
+            "#2 1.234 lots of progress",
+            "#2 ERROR: process exited with code 1",
+            "ERROR: failed to solve: process exited with code 1",
+        ]
+    )
+
+    result = plugin_reduce_tool_result(
+        tool_name="exec_command",
+        tool_use_id="tool-1",
+        command="docker build .",
+        content=output,
+        is_error=True,
+        max_inline_chars=600,
+    )
+
+    assert result is not None
+    assert result.reducer == "devops/docker-build"
+    assert "ERROR: failed to solve" in result.inline_text
+    assert "sha256:1234" not in result.inline_text
+
+
+def test_python_plugin_generic_fallback_head_tail() -> None:
+    output = "\n".join(f"line {index}" for index in range(60))
+
+    result = plugin_reduce_tool_result(
+        tool_name="exec_command",
+        tool_use_id="tool-1",
+        command="custom-tool --verbose",
+        content=output,
+        is_error=False,
+        max_inline_chars=400,
+    )
+
+    assert result is not None
+    assert result.reducer == "generic/fallback"
+    assert "line 0" in result.inline_text
+    assert "line 59" in result.inline_text
+    assert "omitted" in result.inline_text
+
+
+def test_typescript_runtime_directory_is_not_present() -> None:
+    from pathlib import Path
+
+    assert not (Path(__file__).resolve().parents[2] / "src/opensquilla/tokenjuice_runtime").exists()

--- a/tests/test_engine/test_tokenjuice_tool_result_compression.py
+++ b/tests/test_engine/test_tokenjuice_tool_result_compression.py
@@ -39,6 +39,21 @@ class _Provider:
         return []
 
 
+class _FailingSummaryProvider:
+    provider_name = "fake"
+    model = "failing-summary-model"
+
+    def __init__(self) -> None:
+        self.chat_calls = 0
+
+    def chat(self, messages, tools=None, config=None):
+        self.chat_calls += 1
+        raise RuntimeError("summary unavailable")
+
+    async def list_models(self) -> list[Any]:
+        return []
+
+
 class _ToolCallingProvider:
     provider_name = "fake"
 
@@ -211,7 +226,7 @@ async def test_tokenjuice_mode_uses_tokenjuice_adapter(monkeypatch: pytest.Monke
 
 
 @pytest.mark.asyncio
-async def test_tokenjuice_mode_keeps_raw_result_when_tokenjuice_returns_none(
+async def test_tokenjuice_mode_falls_back_to_truncate_when_tokenjuice_returns_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -236,8 +251,75 @@ async def test_tokenjuice_mode_keeps_raw_result_when_tokenjuice_returns_none(
 
     compressed = await agent._compress_tool_result(result)
 
-    assert compressed is result
+    assert compressed is not result
+    assert compressed.content != result.content
+    assert "[...truncated" in compressed.content
     assert agent.config.metadata.get("tool_compression_backend") is None
+    assert agent.config.metadata["tool_compression_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_tokenjuice_mode_truncates_reduction_that_still_exceeds_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_reduce(**kwargs: Any) -> Any:
+        return SimpleNamespace(
+            inline_text="[tokenjuice]\n" + ("important detail " * 40),
+            raw_chars=len(kwargs["content"]),
+            reduced_chars=700,
+            ratio=0.7,
+            reducer="generic/fallback",
+        )
+
+    monkeypatch.setattr(agent_mod, "reduce_tool_result_with_tokenjuice", fake_reduce, raising=False)
+    agent = Agent(
+        provider=_Provider(),
+        config=AgentConfig(
+            context_window_tokens=100,
+            tool_result_compression_mode="tokenjuice",
+            tool_result_compression_max_share=0.25,
+        ),
+    )
+    result = ToolResult(
+        tool_use_id="tool-1",
+        tool_name="exec_command",
+        content="raw output\n" + ("x" * 1000),
+    )
+
+    compressed = await agent._compress_tool_result(result)
+
+    assert compressed.content != result.content
+    assert "[...truncated" in compressed.content
+    assert len(compressed.content) <= 100
+    assert agent.config.metadata["tool_compression_backend"] == "tokenjuice"
+    assert agent.config.metadata["tool_compression_tokenjuice_over_budget_fallbacks"] == 1
+
+
+@pytest.mark.asyncio
+async def test_summarize_mode_falls_back_to_budgeted_truncate_when_summary_fails() -> None:
+    provider = _FailingSummaryProvider()
+    agent = Agent(
+        provider=_Provider(),
+        config=AgentConfig(
+            context_window_tokens=100,
+            tool_result_compression_mode="summarize",
+            tool_result_compression_max_share=0.25,
+        ),
+        tool_result_summarizer_provider=provider,
+    )
+    result = ToolResult(
+        tool_use_id="tool-1",
+        tool_name="exec_command",
+        content="long output\n" + ("x" * 1000),
+    )
+
+    compressed = await agent._compress_tool_result(result)
+
+    assert provider.chat_calls == 1
+    assert compressed is not result
+    assert compressed.content != result.content
+    assert "[...truncated" in compressed.content
+    assert agent.config.metadata["tool_compression_calls"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_tool_truncation.py
+++ b/tests/test_engine/test_tool_truncation.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from opensquilla.engine.tool_truncation import truncate_result
+
+
+def test_truncate_result_respects_final_character_budget_with_marker() -> None:
+    text = "0123456789" * 40
+
+    truncated = truncate_result(text, context_window_tokens=80, max_share=0.25)
+
+    assert truncated != text
+    assert "[...truncated" in truncated
+    assert len(truncated) <= 80
+
+
+def test_truncate_result_handles_marker_larger_than_tiny_budget() -> None:
+    text = "abcdefghijklmnopqrstuvwxyz" * 4
+
+    truncated = truncate_result(text, context_window_tokens=4, max_share=0.25)
+
+    assert truncated != text
+    assert len(truncated) <= 4
+
+
+def test_truncate_result_uses_character_budget_as_hard_ceiling() -> None:
+    text = "abcdefg"
+
+    truncated = truncate_result(text, context_window_tokens=4, max_share=0.25)
+
+    assert truncated == "abcd"

--- a/tests/test_engine/turn_runner/test_agent_bootstrap_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_agent_bootstrap_stage_unit.py
@@ -368,6 +368,23 @@ async def test_case07_summarize_without_summary_model() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tokenjuice_mode_does_not_resolve_summary_provider() -> None:
+    aux_builder = _RecordingAgentConfigBuilder(
+        aux=_default_aux(mode="tokenjuice", summary_model="cheap/model")
+    )
+    summarizer = _RecordingSummarizerProvider(
+        summarizer=SimpleNamespace(name="summary_wrapped")
+    )
+    factory = _RecordingAgentFactory()
+    stage = _make_stage(aux=aux_builder, summarizer=summarizer, factory=factory)
+
+    await stage.run(_make_input())
+
+    assert summarizer.calls == 0
+    assert factory.last_kwargs["tool_result_summarizer_provider"] is None
+
+
+@pytest.mark.asyncio
 async def test_case08_sync_manager_warm() -> None:
     sync_manager = SimpleNamespace(label="memsync")
     snap = _RecordingMemorySnapshot(

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -13,6 +13,15 @@ def test_chat_history_passes_subagent_completion_provenance_to_renderer() -> Non
     assert "provenanceSourceSessionKey: msg.provenance_source_session_key || ''" in source
 
 
+def test_chat_toolbar_supports_tokenjuice_tool_compression_mode() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+
+    assert "mode === 'tokenjuice'" in source
+    assert "if (mode === 'summarize') return 'tokenjuice';" in source
+    assert "tokenjuice: 'TOKENJUICE'" in source
+    assert "off, truncate, summarize, or tokenjuice" in source
+
+
 def test_chat_tool_display_map_does_not_reference_removed_wrapper_tools() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
     start = source.index("const _TOOL_EMOJI = {")


### PR DESCRIPTION
## Summary
  - Add `tokenjuice` as a standalone tool result compression mode alongside `off`, `truncate`, and
  `summarize`.
  - Bundle a Python tokenjuice plugin with rule-based reducers for common command/tool outputs.
  - Preserve raw tool results in history/events while sending tokenjuice-reduced results only in
  provider request projection.

## Test Plan
  - [x] `uv run --extra dev pytest tests/test_engine/test_tokenjuice_tool_result_compression.py tests/
  test_engine/test_tool_concurrency.py tests/test_engine/test_runtime_artifacts.py tests/test_engine/
  turn_runner/test_agent_bootstrap_stage_unit.py tests/test_engine/test_session_sanitize.py tests/
  test_cli/test_chat_cmd.py tests/test_cli/test_slash_completer.py tests/test_gateway/
  test_chat_view_static.py -q`
  - [x] `uv run --extra dev ruff check ...`
  - [x] `git diff --check`
  - [x] `uv build --wheel`
  - [x] Verified the wheel includes 129 tokenjuice JSON rules, including `rules/build/*.json`