### PR TITLE
Harden agent runtime cache, flush, and compaction observability

### DIFF
--- a/scripts/live_openrouter_prompt_cache_smoke.py
+++ b/scripts/live_openrouter_prompt_cache_smoke.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Opt-in OpenRouter explicit prompt-cache smoke for one model.
+
+The smoke sends the same large system prompt twice and reports whether the
+second response exposes non-zero cached prompt tokens. It is intentionally not
+part of default CI; run it only with live OpenRouter credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+
+import httpx
+
+DEFAULT_MODEL = "z-ai/glm-5.1"
+DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def _cached_prompt_tokens(payload: dict[str, Any]) -> int:
+    usage = payload.get("usage")
+    if not isinstance(usage, dict):
+        return 0
+
+    prompt_details = usage.get("prompt_tokens_details")
+    if isinstance(prompt_details, dict):
+        value = prompt_details.get("cached_tokens")
+        if isinstance(value, int):
+            return max(0, value)
+
+    for key in (
+        "cached_tokens",
+        "prompt_cache_hit_tokens",
+        "cache_read_input_tokens",
+        "cached_input_tokens",
+    ):
+        value = usage.get(key)
+        if isinstance(value, int):
+            return max(0, value)
+    return 0
+
+
+def _cache_request_payload(model: str, system_text: str) -> dict[str, Any]:
+    return {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": system_text,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
+            {"role": "user", "content": "Reply with exactly: cache-smoke-ok"},
+        ],
+        "max_tokens": 16,
+        "temperature": 0,
+    }
+
+
+def _large_system_prompt() -> str:
+    stable_line = (
+        "OpenSquilla explicit cache smoke stable prefix. "
+        "This text is synthetic public test material. "
+    )
+    return stable_line * 260
+
+
+def _post_once(
+    client: httpx.Client,
+    *,
+    url: str,
+    api_key: str,
+    model: str,
+    system_text: str,
+) -> dict[str, Any]:
+    response = client.post(
+        url,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://opensquilla.ai",
+            "X-OpenRouter-Title": "OpenSquilla cache smoke",
+        },
+        json=_cache_request_payload(model, system_text),
+    )
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        raise RuntimeError("OpenRouter returned a non-object JSON payload")
+    return data
+
+
+def run_smoke(*, api_key: str, model: str, base_url: str, timeout: float) -> dict[str, Any]:
+    system_text = _large_system_prompt()
+    url = base_url.rstrip("/") + "/chat/completions"
+    with httpx.Client(timeout=timeout, trust_env=True) as client:
+        first = _post_once(client, url=url, api_key=api_key, model=model, system_text=system_text)
+        second = _post_once(client, url=url, api_key=api_key, model=model, system_text=system_text)
+
+    first_cached = _cached_prompt_tokens(first)
+    second_cached = _cached_prompt_tokens(second)
+    return {
+        "model": model,
+        "base_url": base_url,
+        "explicit_cache_supported": second_cached > 0,
+        "first_cached_tokens": first_cached,
+        "second_cached_tokens": second_cached,
+        "usage_fields_present": {
+            "first": sorted((first.get("usage") or {}).keys())
+            if isinstance(first.get("usage"), dict)
+            else [],
+            "second": sorted((second.get("usage") or {}).keys())
+            if isinstance(second.get("usage"), dict)
+            else [],
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model", default=os.environ.get("OPENROUTER_CACHE_SMOKE_MODEL", DEFAULT_MODEL)
+    )
+    parser.add_argument(
+        "--base-url", default=os.environ.get("OPENROUTER_BASE_URL", DEFAULT_BASE_URL)
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=float(os.environ.get("OPENROUTER_CACHE_SMOKE_TIMEOUT", "90")),
+    )
+    args = parser.parse_args(argv)
+
+    api_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
+    if not api_key:
+        print(
+            json.dumps({"ok": False, "error": "OPENROUTER_API_KEY is required"}, ensure_ascii=False)
+        )
+        return 2
+
+    try:
+        result = run_smoke(
+            api_key=api_key,
+            model=args.model,
+            base_url=args.base_url,
+            timeout=args.timeout,
+        )
+    except Exception as exc:  # pragma: no cover - live diagnostic path
+        print(json.dumps({"ok": False, "error": str(exc), "model": args.model}, ensure_ascii=False))
+        return 1
+
+    print(json.dumps({"ok": True, **result}, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -223,9 +223,7 @@ def _is_threshold_denial(result: ToolResult) -> bool:
     )
 
 
-_PENDING_APPROVAL_STATUSES: frozenset[str] = frozenset(
-    {"approval_required", "approval_pending"}
-)
+_PENDING_APPROVAL_STATUSES: frozenset[str] = frozenset({"approval_required", "approval_pending"})
 
 
 def _pending_approval_payload(content: str) -> dict[str, Any] | None:
@@ -385,9 +383,8 @@ class _ProviderRetryPolicy:
         kind: _ProviderAttemptKind,
         used: dict[_ProviderAttemptKind, int],
     ) -> bool:
-        return (
-            self.max_provider_retries > 0
-            and used.get(kind, 0) < self.attempt_budgets.get(kind, 0)
+        return self.max_provider_retries > 0 and used.get(kind, 0) < self.attempt_budgets.get(
+            kind, 0
         )
 
     def can_retry_provider_failure(
@@ -889,10 +886,7 @@ class Agent:
         if len(tool_result_refs) <= 2:
             return messages
 
-        recent_ids = {
-            id(block)
-            for _message_index, _block_index, block in tool_result_refs[-2:]
-        }
+        recent_ids = {id(block) for _message_index, _block_index, block in tool_result_refs[-2:]}
         budget_tokens = int(
             self.config.context_window_tokens * self.config.tool_result_compression_max_share
         )
@@ -930,9 +924,7 @@ class Agent:
             head = content[:240]
             tail = content[-240:] if len(content) > 240 else ""
             omitted = max(0, len(content) - len(head) - len(tail))
-            handle_line = (
-                f"tool_result_handle: {stored.handle}\n" if stored is not None else ""
-            )
+            handle_line = f"tool_result_handle: {stored.handle}\n" if stored is not None else ""
             compacted = (
                 "[aggregate_tool_result_compacted]\n"
                 f"tool_use_id: {block.tool_use_id}\n"
@@ -1010,9 +1002,9 @@ class Agent:
         self.config.metadata["tool_aggregate_compression_tokens_after"] = after_tokens
         self.config.metadata["tool_aggregate_compression_tokens_saved"] = saved_tokens
         self.config.metadata["tool_compression_applied"] = True
-        self.config.metadata["tool_compression_calls"] = (
-            self.config.metadata.get("tool_compression_calls", 0) + len(replacements)
-        )
+        self.config.metadata["tool_compression_calls"] = self.config.metadata.get(
+            "tool_compression_calls", 0
+        ) + len(replacements)
         self.config.metadata["tool_compression_tokens_before"] = (
             self.config.metadata.get("tool_compression_tokens_before", 0) + before_tokens
         )
@@ -1020,8 +1012,7 @@ class Agent:
             self.config.metadata.get("tool_compression_tokens_after", 0) + after_tokens
         )
         self.config.metadata["tool_compression_tokens_saved"] = (
-            self.config.metadata.get("tool_compression_tokens_saved", 0)
-            + saved_tokens
+            self.config.metadata.get("tool_compression_tokens_saved", 0) + saved_tokens
         )
         self._write_turn_call_log(
             "tool_aggregate_compression",
@@ -1047,9 +1038,7 @@ class Agent:
             return block.content if isinstance(block.content, str) else str(block.content)
 
         total_chars = sum(len(_content(block)) for _m, _b, block in tool_result_refs)
-        external_cap = self._tool_result_provider_request_max_chars(
-            ToolResultBudgetClass.EXTERNAL
-        )
+        external_cap = self._tool_result_provider_request_max_chars(ToolResultBudgetClass.EXTERNAL)
         external_chars = sum(
             len(_content(block))
             for _m, _b, block in tool_result_refs
@@ -1110,10 +1099,7 @@ class Agent:
                 and not _tool_result_content_has_artifact(content)
                 and (
                     single_over_budget
-                    or (
-                        self.config.context_window_tokens >= 64_000
-                        and id(block) not in recent_ids
-                    )
+                    or (self.config.context_window_tokens >= 64_000 and id(block) not in recent_ids)
                 )
             ):
                 replacement_content = self._tool_result_projection_for_provider(
@@ -1169,9 +1155,9 @@ class Agent:
             self.config.metadata.get("tool_absolute_compression_calls", 0) + 1
         )
         self.config.metadata["tool_compression_applied"] = True
-        self.config.metadata["tool_compression_calls"] = (
-            self.config.metadata.get("tool_compression_calls", 0) + len(replacements)
-        )
+        self.config.metadata["tool_compression_calls"] = self.config.metadata.get(
+            "tool_compression_calls", 0
+        ) + len(replacements)
         return compacted_messages
 
     def _tool_result_projection_for_provider(
@@ -1192,9 +1178,7 @@ class Agent:
             tool_use_id=tool_use_id,
             tool_name=tool_name,
         )
-        handle_line = (
-            f"tool_result_handle: {stored.handle}\n" if stored is not None else ""
-        )
+        handle_line = f"tool_result_handle: {stored.handle}\n" if stored is not None else ""
         if max_preview_chars <= 0:
             head = ""
             tail = ""
@@ -1301,8 +1285,8 @@ class Agent:
 
         self.config.metadata["tool_argument_provider_view_summaries_applied"] = True
         metadata_key = "tool_argument_provider_view_summaries"
-        self.config.metadata[metadata_key] = (
-            self.config.metadata.get(metadata_key, 0) + len(replacements)
+        self.config.metadata[metadata_key] = self.config.metadata.get(metadata_key, 0) + len(
+            replacements
         )
         self._write_turn_call_log(
             "tool_argument_provider_view_summary",
@@ -1524,10 +1508,9 @@ class Agent:
         self.config.metadata["tool_compression_tokens_after"] = (
             self.config.metadata.get("tool_compression_tokens_after", 0) + tokens_after
         )
-        self.config.metadata["tool_compression_tokens_saved"] = (
-            self.config.metadata.get("tool_compression_tokens_saved", 0)
-            + max(0, tokens_before - tokens_after)
-        )
+        self.config.metadata["tool_compression_tokens_saved"] = self.config.metadata.get(
+            "tool_compression_tokens_saved", 0
+        ) + max(0, tokens_before - tokens_after)
 
         self._write_turn_call_log(
             "tool_response_compression",
@@ -1702,9 +1685,7 @@ class Agent:
         )
         runtime_context = self._runtime_context_block()
         runtime_context_message = self._runtime_context_message(runtime_context)
-        request_context_message = self._request_context_message(
-            self.config.request_context_prompt
-        )
+        request_context_message = self._request_context_message(self.config.request_context_prompt)
         runtime_context_hash = hashlib.sha256(runtime_context.encode("utf-8")).hexdigest()[:16]
 
         chat_cfg = ChatConfig(
@@ -1775,9 +1756,7 @@ class Agent:
             return parsed if parsed > 0 else None
 
         def _turn_budget_error() -> ErrorEvent | None:
-            max_llm_calls = self._positive_int(
-                getattr(self.config, "max_turn_llm_calls", 0)
-            )
+            max_llm_calls = self._positive_int(getattr(self.config, "max_turn_llm_calls", 0))
             if max_llm_calls is not None and turn_llm_calls > max_llm_calls:
                 return ErrorEvent(
                     message=(
@@ -1786,9 +1765,7 @@ class Agent:
                     ),
                     code="turn_llm_call_budget_exceeded",
                 )
-            max_input = self._positive_int(
-                getattr(self.config, "max_turn_input_tokens", 0)
-            )
+            max_input = self._positive_int(getattr(self.config, "max_turn_input_tokens", 0))
             if max_input is not None and total_input_tokens > max_input:
                 return ErrorEvent(
                     message=(
@@ -1797,9 +1774,7 @@ class Agent:
                     ),
                     code="turn_input_token_budget_exceeded",
                 )
-            max_output = self._positive_int(
-                getattr(self.config, "max_turn_output_tokens", 0)
-            )
+            max_output = self._positive_int(getattr(self.config, "max_turn_output_tokens", 0))
             if max_output is not None and total_output_tokens > max_output:
                 return ErrorEvent(
                     message=(
@@ -1808,9 +1783,7 @@ class Agent:
                     ),
                     code="turn_output_token_budget_exceeded",
                 )
-            max_cost = _positive_float(
-                getattr(self.config, "max_turn_billed_cost_usd", 0.0)
-            )
+            max_cost = _positive_float(getattr(self.config, "max_turn_billed_cost_usd", 0.0))
             if max_cost is not None and total_billed_cost > max_cost:
                 return ErrorEvent(
                     message=(
@@ -1819,9 +1792,7 @@ class Agent:
                     ),
                     code="turn_billed_cost_budget_exceeded",
                 )
-            max_tool_errors = self._positive_int(
-                getattr(self.config, "max_turn_tool_errors", 0)
-            )
+            max_tool_errors = self._positive_int(getattr(self.config, "max_turn_tool_errors", 0))
             if max_tool_errors is not None and turn_tool_errors >= max_tool_errors:
                 return ErrorEvent(
                     message=(
@@ -1833,9 +1804,7 @@ class Agent:
             return None
 
         def _turn_llm_call_budget_error(next_call_number: int) -> ErrorEvent | None:
-            max_llm_calls = self._positive_int(
-                getattr(self.config, "max_turn_llm_calls", 0)
-            )
+            max_llm_calls = self._positive_int(getattr(self.config, "max_turn_llm_calls", 0))
             if max_llm_calls is None or next_call_number <= max_llm_calls:
                 return None
             return ErrorEvent(
@@ -1928,9 +1897,7 @@ class Agent:
 
                 _retry_attempt = 0
                 _call_attempt = 0
-                _retry_policy = _ProviderRetryPolicy.from_provider_budget(
-                    _fallback.max_retries
-                )
+                _retry_policy = _ProviderRetryPolicy.from_provider_budget(_fallback.max_retries)
                 _attempt_retries_used = _retry_policy.used_attempts()
                 _invalid_response_fallback_done = False
                 while _retry_attempt <= _fallback.max_retries:
@@ -2075,18 +2042,16 @@ class Agent:
                                         acc.json_chars - last_heartbeat_chars
                                         >= _TOOL_ARGUMENT_HEARTBEAT_CHARS
                                     ):
-                                        tool_argument_heartbeat_chars[
-                                            raw_ev.tool_use_id
-                                        ] = acc.json_chars
+                                        tool_argument_heartbeat_chars[raw_ev.tool_use_id] = (
+                                            acc.json_chars
+                                        )
                                         yield RunHeartbeatEvent(
                                             phase="llm_tool_arguments",
                                             elapsed_ms=int(
                                                 (time.monotonic() - call_started_at) * 1000
                                             ),
                                             idle_ms=0,
-                                            message=(
-                                                f"Receiving {acc.tool_name} arguments"
-                                            ),
+                                            message=(f"Receiving {acc.tool_name} arguments"),
                                         )
 
                             elif isinstance(raw_ev, ToolUseEndEvent):
@@ -2095,9 +2060,7 @@ class Agent:
                                         ignored_post_delivery_tool_use = True
                                     continue
                                 acc = pending_tools.pop(raw_ev.tool_use_id, None)
-                                tool_argument_heartbeat_chars.pop(
-                                    raw_ev.tool_use_id, None
-                                )
+                                tool_argument_heartbeat_chars.pop(raw_ev.tool_use_id, None)
                                 if acc and acc.json_buf:
                                     arguments = acc.finish()
                                 else:
@@ -2346,8 +2309,7 @@ class Agent:
                             continue
 
                         if (
-                            attempt_classification.kind
-                            == _ProviderAttemptKind.STREAM_INCOMPLETE
+                            attempt_classification.kind == _ProviderAttemptKind.STREAM_INCOMPLETE
                             and not attempt_classification.user_visible_emitted
                             and _retry_policy.can_retry_attempt(
                                 _ProviderAttemptKind.STREAM_INCOMPLETE,
@@ -2571,8 +2533,8 @@ class Agent:
                             provider_compaction_window_tokens = (
                                 self._provider_budget_compaction_window_tokens(provider_error)
                             )
-                            provider_estimated_tokens = (
-                                self._provider_budget_estimated_tokens(provider_error)
+                            provider_estimated_tokens = self._provider_budget_estimated_tokens(
+                                provider_error
                             )
                             provider_compaction_refusal_reason = (
                                 self._last_compaction_refusal_reason
@@ -2641,9 +2603,7 @@ class Agent:
                                     self._last_compaction_refusal_reason
                                     != "provider_recent_tail_too_large"
                                 ):
-                                    self._last_compaction_refusal_reason = (
-                                        "compaction_not_smaller"
-                                    )
+                                    self._last_compaction_refusal_reason = "compaction_not_smaller"
                                 terminal_error = self._context_overflow_error()
                                 yield terminal_error
                                 break
@@ -2787,9 +2747,7 @@ class Agent:
                     # DoneEvent usage/cost accounting for this turn.
                     turn_messages = overflow_outcome.messages
                     if overflow_outcome.request_context_insert_index is not None:
-                        request_context_insert_index = (
-                            overflow_outcome.request_context_insert_index
-                        )
+                        request_context_insert_index = overflow_outcome.request_context_insert_index
                     if overflow_outcome.runtime_context_insert_index is not None:
                         runtime_context_insert_index = overflow_outcome.runtime_context_insert_index
                     yield CompactionEvent(
@@ -2825,9 +2783,7 @@ class Agent:
                             if isinstance(self.config.thinking, ThinkingLevel)
                             else None
                         ),
-                        provider_request_max_chars=(
-                            self._provider_request_proof_max_chars()
-                        ),
+                        provider_request_max_chars=(self._provider_request_proof_max_chars()),
                     )
 
                 assembled_text = "".join(assistant_text_parts)
@@ -2847,9 +2803,7 @@ class Agent:
                         preflight_tool_results[tc.tool_use_id] = resolved
                         if self._is_provider_context_projection_reuse_result(resolved):
                             terminal_projection_preflight_error = True
-                        resolved_tool_calls.append(
-                            self._sanitize_projected_tool_call_arguments(tc)
-                        )
+                        resolved_tool_calls.append(self._sanitize_projected_tool_call_arguments(tc))
                         continue
                     resolved_tool_calls.append(resolved)
                 tool_calls = resolved_tool_calls
@@ -2954,9 +2908,7 @@ class Agent:
                             res = ToolResult(
                                 tool_use_id=tc.tool_use_id,
                                 tool_name=tc.tool_name,
-                                content=(
-                                    f"Tool '{tc.tool_name}' timed out after {tool_timeout}s"
-                                ),
+                                content=(f"Tool '{tc.tool_name}' timed out after {tool_timeout}s"),
                                 is_error=True,
                                 execution_status=runtime_execution_status(
                                     "timeout",
@@ -3021,8 +2973,7 @@ class Agent:
                             )
                             if not done:
                                 if _loop.time() >= tool_deadline or (
-                                    _total_deadline is not None
-                                    and _loop.time() >= _total_deadline
+                                    _total_deadline is not None and _loop.time() >= _total_deadline
                                 ):
                                     for task, tc in list(task_to_tool_call.items()):
                                         if task in pending:
@@ -3137,9 +3088,7 @@ class Agent:
                         async with key_lock:
                             return await _run_after_key_lock()
 
-                    task_to_tool_call = {
-                        asyncio.create_task(_run_limited(tc)): tc for tc in batch
-                    }
+                    task_to_tool_call = {asyncio.create_task(_run_limited(tc)): tc for tc in batch}
                     async for event in _collect_tool_tasks(task_to_tool_call):
                         yield event
 
@@ -3177,10 +3126,7 @@ class Agent:
                         execution_status=result.execution_status,
                     )
                     pending_approval = _pending_approval_payload(result.content)
-                    if (
-                        pending_approval is not None
-                        and not tc.arguments.get("approval_id")
-                    ):
+                    if pending_approval is not None and not tc.arguments.get("approval_id"):
                         await _wait_for_pending_approval_resolution(
                             pending_approval,
                             timeout=_cap_timeout_by_deadlines(self._approval_wait_timeout()),
@@ -3219,9 +3165,7 @@ class Agent:
                         )
                     )
 
-                terminal_artifacts = self._terminal_artifact_delivery_artifacts(
-                    executed_results
-                )
+                terminal_artifacts = self._terminal_artifact_delivery_artifacts(executed_results)
                 if terminal_artifacts:
                     artifact_delivery_final_response_artifacts = terminal_artifacts
 
@@ -3448,15 +3392,9 @@ class Agent:
             runtime_context_message,
             runtime_context_insert_index,
         )
-        source_messages = self._strip_provider_context_marker_replay_for_provider(
-            source_messages
-        )
-        source_messages = self._compact_aggregate_tool_results_for_provider(
-            source_messages
-        )
-        source_messages = self._sanitize_projected_tool_use_arguments_for_provider(
-            source_messages
-        )
+        source_messages = self._strip_provider_context_marker_replay_for_provider(source_messages)
+        source_messages = self._compact_aggregate_tool_results_for_provider(source_messages)
+        source_messages = self._sanitize_projected_tool_use_arguments_for_provider(source_messages)
         return sanitize_session_messages(source_messages)
 
     @staticmethod
@@ -3763,6 +3701,19 @@ class Agent:
                     indexed_chunk_count=getattr(receipt, "indexed_chunk_count", None),
                 )
                 self._flush_done_this_cycle = False
+                if self.config.flush_compaction_requires_safe_receipt:
+                    self._last_compaction_refusal_reason = reason
+                    if self._session_key:
+                        notify_compaction(
+                            self._session_key,
+                            source="automatic",
+                            phase="agent_inline_overflow",
+                            status="skipped",
+                            reason=reason,
+                            tokens_before=total_tokens,
+                            context_window_tokens=window_tokens,
+                        )
+                    return None
 
         # --- Compaction ---
         entries = [
@@ -3919,9 +3870,7 @@ class Agent:
                     "memory_flush.degraded",
                     mode=mode,
                     integrity_status=getattr(receipt, "integrity_status", None),
-                    output_coverage_status=getattr(
-                        receipt, "output_coverage_status", None
-                    ),
+                    output_coverage_status=getattr(receipt, "output_coverage_status", None),
                     obligation_status=getattr(receipt, "obligation_status", None),
                     raw_reason=getattr(receipt, "raw_reason", None),
                     next_retry_seconds=next_retry_seconds,
@@ -4040,8 +3989,7 @@ class Agent:
         if Agent._has_provider_context_argument_marker(arguments):
             return True
         return any(
-            isinstance(value, str)
-            and value.startswith(_INVALID_PROVIDER_CONTEXT_PROJECTION_PREFIX)
+            isinstance(value, str) and value.startswith(_INVALID_PROVIDER_CONTEXT_PROJECTION_PREFIX)
             for value in arguments.values()
         )
 
@@ -4082,10 +4030,7 @@ class Agent:
             next_content: list[Any] = []
             changed = False
             for block in message.content:
-                if (
-                    isinstance(block, ContentBlockToolUse)
-                    and block.id in blocked_tool_ids
-                ):
+                if isinstance(block, ContentBlockToolUse) and block.id in blocked_tool_ids:
                     stripped_blocks += 1
                     changed = True
                     continue
@@ -4145,9 +4090,8 @@ class Agent:
 
     @staticmethod
     def _has_provider_context_argument_marker(arguments: dict[str, Any]) -> bool:
-        return (
-            arguments.get(_INVALID_PROVIDER_CONTEXT_ARGUMENTS_KEY) is True
-            or any(arguments.get(marker) is True for marker in _COMPACTED_TOOL_ARGUMENT_MARKERS)
+        return arguments.get(_INVALID_PROVIDER_CONTEXT_ARGUMENTS_KEY) is True or any(
+            arguments.get(marker) is True for marker in _COMPACTED_TOOL_ARGUMENT_MARKERS
         )
 
     @staticmethod
@@ -4308,8 +4252,7 @@ class Agent:
         )
         if (
             block_threshold > 0
-            and self._tool_failure_loop_counts.get(failure_signature, 0)
-            >= block_threshold - 1
+            and self._tool_failure_loop_counts.get(failure_signature, 0) >= block_threshold - 1
         ):
             return ToolResult(
                 tool_use_id=tc.tool_use_id,
@@ -4470,12 +4413,8 @@ class Agent:
             tool_use_argument_provider_request_max_chars=(
                 self.config.tool_use_argument_provider_request_max_chars
             ),
-            tool_use_argument_projection_enabled=(
-                self.config.tool_use_argument_projection_enabled
-            ),
-            tool_failure_loop_block_threshold=(
-                self.config.tool_failure_loop_block_threshold
-            ),
+            tool_use_argument_projection_enabled=(self.config.tool_use_argument_projection_enabled),
+            tool_failure_loop_block_threshold=(self.config.tool_failure_loop_block_threshold),
             max_safe_tool_concurrency=self.config.max_safe_tool_concurrency,
             tool_result_external_keep_recent=self.config.tool_result_external_keep_recent,
             tool_result_store_dir=self.config.tool_result_store_dir,
@@ -4483,12 +4422,8 @@ class Agent:
             tool_result_store_session_key=self.config.tool_result_store_session_key,
             tool_result_store_agent_id=self.config.tool_result_store_agent_id,
             tool_result_store_max_bytes=self.config.tool_result_store_max_bytes,
-            tool_result_store_disk_budget_bytes=(
-                self.config.tool_result_store_disk_budget_bytes
-            ),
-            tool_result_store_retention_seconds=(
-                self.config.tool_result_store_retention_seconds
-            ),
+            tool_result_store_disk_budget_bytes=(self.config.tool_result_store_disk_budget_bytes),
+            tool_result_store_retention_seconds=(self.config.tool_result_store_retention_seconds),
         )
         return Agent(
             provider=self.provider,

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -1670,10 +1670,6 @@ class Agent:
 
         # Build initial message list
         turn_messages: list[Message] = list(history)
-        # Keep large request-scoped context at a stable provider prefix. If
-        # history is allowed to move ahead of it after the first turn,
-        # prefix-based provider caches can no longer reuse that block.
-        request_context_insert_index = 0
         # Insert this turn's skills context BEFORE the user content so it
         # joins turn_messages permanently (persists into self._history at
         # turn end). Re-inserting a fresh skills_ctx into request_messages
@@ -1685,6 +1681,11 @@ class Agent:
         skills_context_message = self._skills_context_message()
         if skills_context_message is not None:
             turn_messages.append(skills_context_message)
+        # Keep persisted history and persisted skills as the provider-visible
+        # prefix. Request-scoped context can change every turn, so keep it near
+        # the current turn instead of letting it invalidate implicit prefix
+        # caches from messages[0].
+        request_context_insert_index = len(turn_messages)
         runtime_context_insert_index = len(turn_messages)
         if extra_messages:
             turn_messages.extend(extra_messages)

--- a/src/opensquilla/engine/cache_break_monitor.py
+++ b/src/opensquilla/engine/cache_break_monitor.py
@@ -29,10 +29,28 @@ def _stable_hash(value: Any) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
-def _message_prefix_payload(messages: list[Message], *, tail_count: int = 2) -> list[Any]:
+def _message_prefix_messages(messages: list[Message], *, tail_count: int = 2) -> list[Message]:
     if tail_count <= 0:
-        return [_jsonable(message) for message in messages]
-    return [_jsonable(message) for message in messages[:-tail_count]]
+        return list(messages)
+    return list(messages[:-tail_count])
+
+
+def _message_prefix_payload(messages: list[Message], *, tail_count: int = 2) -> list[Any]:
+    return [
+        _jsonable(message) for message in _message_prefix_messages(messages, tail_count=tail_count)
+    ]
+
+
+def _message_prefix_item_kind(message: Message) -> str:
+    content = message.content
+    if isinstance(content, str):
+        if content.startswith("[Request context for this turn]"):
+            return "request_context"
+        if content.startswith("[Runtime context for this turn]"):
+            return "runtime_context"
+        if content.startswith("[Available skills for this turn]"):
+            return "skills_context"
+    return "history"
 
 
 def _cache_control_payload(config: ChatConfig) -> dict[str, Any]:
@@ -60,6 +78,7 @@ class PromptStateSnapshot:
     message_count: int
     tool_count: int
     messages_prefix_item_hashes: tuple[str, ...] = ()
+    messages_prefix_item_kinds: tuple[str, ...] = ()
     cache_control_field_hashes: tuple[tuple[str, str], ...] = ()
 
     def changed_fields(self, previous: PromptStateSnapshot) -> tuple[str, ...]:
@@ -81,6 +100,7 @@ class PromptStateSnapshot:
             "tools_hash": self.tools_hash,
             "messages_prefix_hash": self.messages_prefix_hash,
             "messages_prefix_item_hashes": list(self.messages_prefix_item_hashes),
+            "messages_prefix_item_kinds": list(self.messages_prefix_item_kinds),
             "cache_control_hash": self.cache_control_hash,
             "cache_control_field_hashes": dict(self.cache_control_field_hashes),
             "model": self.model,
@@ -145,7 +165,8 @@ class CacheBreakMonitor:
         config: ChatConfig,
         model: str,
     ) -> PromptStateSnapshot:
-        messages_prefix_payload = _message_prefix_payload(messages)
+        messages_prefix_messages = _message_prefix_messages(messages)
+        messages_prefix_payload = [_jsonable(message) for message in messages_prefix_messages]
         cache_control_payload = _cache_control_payload(config)
         return PromptStateSnapshot(
             system_hash=_stable_hash(config.system or ""),
@@ -157,6 +178,9 @@ class CacheBreakMonitor:
             tool_count=len(tools or []),
             messages_prefix_item_hashes=tuple(
                 _stable_hash(message) for message in messages_prefix_payload
+            ),
+            messages_prefix_item_kinds=tuple(
+                _message_prefix_item_kind(message) for message in messages_prefix_messages
             ),
             cache_control_field_hashes=tuple(
                 (key, _stable_hash(value)) for key, value in sorted(cache_control_payload.items())

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -126,7 +126,13 @@ from opensquilla.provider import (
 )
 from opensquilla.safety import injection_guard, permission_matrix, sandbox, tool_tiers
 from opensquilla.session.compaction_lifecycle import (
+    COMPACTION_PERSISTED_EVENT,
+    COMPACTION_TRIGGERED_EVENT,
+    compaction_lifecycle_payload,
+    compaction_result_payload,
     flush_receipt_allows_destructive_compaction,
+    new_compaction_id,
+    pre_compaction_flush_requires_safe_receipt,
 )
 from opensquilla.session.cost_rollup import (
     normalize_event_cost_source,
@@ -163,15 +169,11 @@ _T3_NOT_APPLICABLE: Final[str] = "not_applicable"
 _T3_HANDLED: Final[str] = "handled"
 _T3_FLUSH_FAILED: Final[str] = "flush_failed"
 _T3_COMPACT_FAILED: Final[str] = "compact_failed"
-_SAFE_FLUSH_OUTPUT_COVERAGE_STATUSES: Final[frozenset[str]] = frozenset(
-    {"ok", "unverifiable"}
-)
+_SAFE_FLUSH_OUTPUT_COVERAGE_STATUSES: Final[frozenset[str]] = frozenset({"ok", "unverifiable"})
 _SAFE_FLUSH_OBLIGATION_STATUSES: Final[frozenset[str]] = frozenset(
     {"ok", "backfilled", "unverifiable"}
 )
-_IMAGE_GENERATION_TOOL_NAMES: Final[frozenset[str]] = frozenset(
-    {"image_generate"}
-)
+_IMAGE_GENERATION_TOOL_NAMES: Final[frozenset[str]] = frozenset({"image_generate"})
 _ARTIFACT_DELIVERY_FAILURE_MARKER: Final[str] = "File delivery failed:"
 _ARTIFACT_DELIVERY_TOOL_NAME: Final[str] = "publish_artifact"
 _ARTIFACT_DELIVERY_FAILURE_MAX_CHARS: Final[int] = 360
@@ -202,30 +204,32 @@ def _is_deepseek_model_id(model: str) -> bool:
 
 # Tools that are safe to run concurrently within a single LLM turn.
 # Any tool name absent from this set is treated as mutex (serial dispatch).
-_SAFE_TOOL_NAMES: frozenset[str] = frozenset({
-    "agents_list",
-    "git_diff",
-    "git_log",
-    "git_status",
-    "glob_search",
-    "grep_search",
-    "image",
-    "list_dir",
-    "memory_get",
-    "memory_search",
-    "pdf",
-    "read_file",
-    "read_spreadsheet",
-    "session_search",
-    "session_status",
-    "sessions_history",
-    "sessions_list",
-    "skill_list",
-    "skill_view",
-    "tts",
-    "web_fetch",
-    "web_search",
-})
+_SAFE_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "agents_list",
+        "git_diff",
+        "git_log",
+        "git_status",
+        "glob_search",
+        "grep_search",
+        "image",
+        "list_dir",
+        "memory_get",
+        "memory_search",
+        "pdf",
+        "read_file",
+        "read_spreadsheet",
+        "session_search",
+        "session_status",
+        "sessions_history",
+        "sessions_list",
+        "skill_list",
+        "skill_view",
+        "tts",
+        "web_fetch",
+        "web_search",
+    }
+)
 
 _ToolConcurrencyMode = Literal["mutex", "concurrent", "keyed", "predicate"]
 
@@ -238,17 +242,19 @@ class _ToolConcurrencyPolicy:
     limit_key: Hashable | None = None
 
 
-_FEISHU_READ_ONLY_TOOL_NAMES: frozenset[str] = frozenset({
-    "feishu_chat_read",
-    "feishu_doc_list_blocks",
-    "feishu_doc_read_raw",
-    "feishu_drive_meta",
-    "feishu_drive_search",
-    "feishu_scopes_status",
-    "feishu_wiki_get_node",
-    "feishu_wiki_list_nodes",
-    "feishu_wiki_list_spaces",
-})
+_FEISHU_READ_ONLY_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "feishu_chat_read",
+        "feishu_doc_list_blocks",
+        "feishu_doc_read_raw",
+        "feishu_drive_meta",
+        "feishu_drive_search",
+        "feishu_scopes_status",
+        "feishu_wiki_get_node",
+        "feishu_wiki_list_nodes",
+        "feishu_wiki_list_spaces",
+    }
+)
 
 _MUTEX_TOOL_POLICY = _ToolConcurrencyPolicy(mode="mutex")
 _CONCURRENT_TOOL_POLICY = _ToolConcurrencyPolicy(mode="concurrent")
@@ -296,8 +302,8 @@ def _get_tool_concurrency_policy(
 # running, which matters for stream wrappers such as heartbeat_stream. Treating
 # the lock id as the ownership token lets those child tasks enter without
 # self-deadlocking while unrelated tasks still see their own context values.
-_SESSION_LOCK_OWNER: contextvars.ContextVar[dict[int, asyncio.Task[Any]]] = (
-    contextvars.ContextVar("_session_lock_owner")
+_SESSION_LOCK_OWNER: contextvars.ContextVar[dict[int, asyncio.Task[Any]]] = contextvars.ContextVar(
+    "_session_lock_owner"
 )
 
 
@@ -518,9 +524,9 @@ def _format_compaction_summary_context(summary_texts: list[str]) -> str | None:
     rendered = f"{_COMPACTION_SUMMARY_CONTEXT_HEADER}\n" + "\n\n".join(blocks)
     if len(rendered) <= _COMPACTION_SUMMARY_CONTEXT_MAX_CHARS:
         return rendered
-    tail_budget = _COMPACTION_SUMMARY_CONTEXT_MAX_CHARS - len(
-        _COMPACTION_SUMMARY_CONTEXT_HEADER
-    ) - 80
+    tail_budget = (
+        _COMPACTION_SUMMARY_CONTEXT_MAX_CHARS - len(_COMPACTION_SUMMARY_CONTEXT_HEADER) - 80
+    )
     tail_budget = max(1000, tail_budget)
     return (
         f"{_COMPACTION_SUMMARY_CONTEXT_HEADER}\n"
@@ -768,9 +774,7 @@ def _persisted_tool_result_segment(
     segment["result_truncated"] = True
     segment["result_original_chars"] = len(result)
     if "execution_status" in segment:
-        segment["execution_status"] = mark_execution_status_truncated(
-            segment["execution_status"]
-        )
+        segment["execution_status"] = mark_execution_status_truncated(segment["execution_status"])
     try:
         parsed = json.loads(result)
     except (json.JSONDecodeError, TypeError):
@@ -971,9 +975,8 @@ class _SelectorFallbackProvider:
                 yield event
                 continue
 
-            if (
-                isinstance(event, ProviderErrorEvent)
-                and _should_use_selector_fallback(self.provider_name, event)
+            if isinstance(event, ProviderErrorEvent) and _should_use_selector_fallback(
+                self.provider_name, event
             ):
                 try:
                     self._provider = self._selector.next_fallback_after_failure(
@@ -1166,6 +1169,7 @@ def _extract_pdf_attachment_text(raw_bytes: bytes, filename: str) -> str:
     if not extracted:
         raise ValueError(f"PDF attachment {filename!r} has no extractable text")
     return _truncate_attachment_text(extracted)
+
 
 # Strong past-tense / perfect-aspect phrases that signal the model is claiming
 # to have produced an image. Only checked when ``image_generate`` is available
@@ -1840,9 +1844,7 @@ class TurnRunner:
                 # Harness performs the legacy observability + persist +
                 # yield sequence in the legacy ORDER (trace-emit, persist,
                 # yield, return).
-                provider_error_event = cast(
-                    ErrorEvent, pt_outcome.require_early_yield()
-                )
+                provider_error_event = cast(ErrorEvent, pt_outcome.require_early_yield())
                 log.error("turn_runner.no_provider", session_key=session_key)
                 self._emit_turn_event(
                     "turn_error",
@@ -1937,9 +1939,7 @@ class TurnRunner:
                         "input_mode": input_mode,
                         "message": effective_runtime_message,
                         "attachment_count": len(attachments),
-                        "tool_names": [
-                            getattr(td, "name", "") for td in turn.tool_defs
-                        ],
+                        "tool_names": [getattr(td, "name", "") for td in turn.tool_defs],
                     },
                 )
             log.debug(
@@ -2003,9 +2003,7 @@ class TurnRunner:
                 )
             )
             ch_out = ch_outcome.require_output()
-            agent.config.request_context_prompt = (
-                ch_out.final_request_context_prompt
-            )
+            agent.config.request_context_prompt = ch_out.final_request_context_prompt
 
             # 8. Build extra messages for attachments + turn_input rebind.
             # AttachmentStage owns the slice.
@@ -2074,9 +2072,7 @@ class TurnRunner:
             # text segment. The stage's post-stream notify already
             # fired (it is the last action of the stage body).
             if current_text_parts:
-                turn_segments.append(
-                    {"type": "text", "text": "".join(current_text_parts)}
-                )
+                turn_segments.append({"type": "text", "text": "".join(current_text_parts)})
 
             # 10. Persist assistant response (filter sentinel tokens).
             # TurnFinalizerStage owns the slice. The four side effects
@@ -2254,8 +2250,7 @@ class TurnRunner:
             )
             event_code = (
                 error_code
-                if error_code
-                in {"provider_request_too_large", "provider_output_truncated"}
+                if error_code in {"provider_request_too_large", "provider_output_truncated"}
                 else "agent_error"
             )
             log.error(
@@ -2478,8 +2473,7 @@ class TurnRunner:
         )
         event_code = (
             error_code
-            if error_code
-            in {"provider_request_too_large", "provider_output_truncated"}
+            if error_code in {"provider_request_too_large", "provider_output_truncated"}
             else event.code
         )
         if event_code == "provider_output_truncated":
@@ -2563,8 +2557,10 @@ class TurnRunner:
                     error=str(exc),
                 )
 
-        base_message = event.message.strip() if event.message else (
-            f"Tool result summarization failed for model {model_label!r}."
+        base_message = (
+            event.message.strip()
+            if event.message
+            else (f"Tool result summarization failed for model {model_label!r}.")
         )
         suffix = " Tool Compress has been turned OFF." if disabled else ""
         return WarningEvent(
@@ -2736,9 +2732,7 @@ class TurnRunner:
             try:
                 value = float(raw)
             except ValueError:
-                log.warning(
-                    "turn_runner.invalid_agent_iteration_timeout", source="env", raw=raw
-                )
+                log.warning("turn_runner.invalid_agent_iteration_timeout", source="env", raw=raw)
             else:
                 if value >= 0:
                     return value
@@ -2846,15 +2840,11 @@ class TurnRunner:
             try:
                 value = float(raw)
             except ValueError:
-                log.warning(
-                    "turn_runner.invalid_agent_request_timeout", source="env", raw=raw
-                )
+                log.warning("turn_runner.invalid_agent_request_timeout", source="env", raw=raw)
             else:
                 if value > 0:
                     return value
-                log.warning(
-                    "turn_runner.invalid_agent_request_timeout", source="env", value=value
-                )
+                log.warning("turn_runner.invalid_agent_request_timeout", source="env", value=value)
 
         value = getattr(self._config, "agent_request_timeout_seconds", None)
         if self._non_bool_number(value) and value > 0:
@@ -2903,9 +2893,7 @@ class TurnRunner:
             try:
                 value = int(raw)
             except ValueError:
-                log.warning(
-                    "turn_runner.invalid_agent_max_provider_retries", source="env", raw=raw
-                )
+                log.warning("turn_runner.invalid_agent_max_provider_retries", source="env", raw=raw)
             else:
                 if value >= 0:
                     return value
@@ -3068,8 +3056,7 @@ class TurnRunner:
 
         detected = detect_runtime_tool_surface_capabilities(
             channel_backing=(
-                ctx.caller_kind in {CallerKind.CHANNEL, CallerKind.WEB}
-                and bool(ctx.channel_id)
+                ctx.caller_kind in {CallerKind.CHANNEL, CallerKind.WEB} and bool(ctx.channel_id)
             )
         )
         capabilities = ToolSurfaceCapabilities(
@@ -3318,9 +3305,7 @@ class TurnRunner:
             prompt_metadata["memory_retrieval_vector_weight"] = retrieval_metadata.get(
                 "vector_weight"
             )
-            prompt_metadata["memory_retrieval_text_weight"] = retrieval_metadata.get(
-                "text_weight"
-            )
+            prompt_metadata["memory_retrieval_text_weight"] = retrieval_metadata.get("text_weight")
             prompt_metadata["memory_mode_fingerprint"] = retrieval_metadata
 
         soul_doc = parse_soul(workspace_files["SOUL.md"]) if "SOUL.md" in workspace_files else None
@@ -3550,9 +3535,7 @@ class TurnRunner:
                 )
                 return commit_deferred_router_history(routed)
             except TimeoutError as exc:
-                raise TimeoutError(
-                    f"squilla router timed out after {router_timeout:g}s"
-                ) from exc
+                raise TimeoutError(f"squilla router timed out after {router_timeout:g}s") from exc
 
         _bounded_apply_squilla_router.__name__ = "apply_squilla_router"
 
@@ -3853,10 +3836,7 @@ class TurnRunner:
                     )
                     if baseline.price.output_per_m > 0:
                         savings_telemetry.short_reply_savings_usd_estimated_vs_baseline = round(
-                            (
-                                savings_telemetry.short_reply_savings_tokens_estimated
-                                / 1_000_000
-                            )
+                            (savings_telemetry.short_reply_savings_tokens_estimated / 1_000_000)
                             * baseline.price.output_per_m,
                             6,
                         )
@@ -3882,9 +3862,7 @@ class TurnRunner:
                 savings_telemetry.billed_cost_usd = (
                     done_event.billed_cost if done_event is not None else None
                 )
-                savings_telemetry.cost_usd = (
-                    done_event.cost_usd if done_event is not None else None
-                )
+                savings_telemetry.cost_usd = done_event.cost_usd if done_event is not None else None
                 savings_telemetry.cost_source = (
                     normalize_event_cost_source(
                         done_event.cost_source,
@@ -3941,18 +3919,14 @@ class TurnRunner:
                 retrieval_mode=prompt_report.retrieval_mode if prompt_report else None,
                 cache_mode=prompt_report.cache_mode if prompt_report else None,
                 cache_base_hash=prompt_report.cache_base_hash if prompt_report else None,
-                cache_dynamic_hash=(
-                    prompt_report.cache_dynamic_hash if prompt_report else None
-                ),
+                cache_dynamic_hash=(prompt_report.cache_dynamic_hash if prompt_report else None),
                 cache_read_input_tokens=(
                     int(done_event.cached_tokens or 0) if done_event is not None else 0
                 ),
                 cache_creation_input_tokens=(
                     int(done_event.cache_write_tokens or 0) if done_event is not None else 0
                 ),
-                resolved_model=(
-                    prompt_report.resolved_model if prompt_report else None
-                )
+                resolved_model=(prompt_report.resolved_model if prompt_report else None)
                 or resolved_model,
                 alias_resolution_chain=(
                     prompt_report.alias_resolution_chain
@@ -3967,9 +3941,7 @@ class TurnRunner:
                 cache_shadow_final_hash=(
                     prompt_report.cache_shadow_final_hash if prompt_report else None
                 ),
-                cache_key_collision=(
-                    prompt_report.cache_key_collision if prompt_report else False
-                ),
+                cache_key_collision=(prompt_report.cache_key_collision if prompt_report else False),
                 reasoning_hint_resolved=(
                     prompt_report.reasoning_hint_resolved if prompt_report else None
                 ),
@@ -4064,6 +4036,7 @@ class TurnRunner:
             final_tier="t3",
             context_window_tokens=context_window_tokens,
         )
+        compaction_id = new_compaction_id()
         notify_compaction(
             session_key,
             source="automatic",
@@ -4071,14 +4044,35 @@ class TurnRunner:
             status="started",
             previous_tier=previous,
             context_window_tokens=context_window_tokens,
+            **compaction_lifecycle_payload(compaction_id, COMPACTION_TRIGGERED_EVENT),
         )
 
         if self._pre_compaction_flush_enabled():
-            await self._await_pre_compaction_flush_grace(
+            flush_safe = await self._await_pre_compaction_flush_grace(
                 transcript,
                 session_key,
                 event_prefix="t3_upgrade_compaction",
             )
+            if self._pre_compaction_flush_requires_safe_receipt() and not flush_safe:
+                log.warning(
+                    "t3_upgrade_compaction.skipped",
+                    session_key=session_key,
+                    reason="unsafe_flush_receipt",
+                )
+                notify_compaction(
+                    session_key,
+                    source="automatic",
+                    phase="t3_upgrade",
+                    status="skipped",
+                    reason="unsafe_flush_receipt",
+                    context_window_tokens=context_window_tokens,
+                    flush_receipt_status="unsafe",
+                    **compaction_lifecycle_payload(
+                        compaction_id,
+                        COMPACTION_TRIGGERED_EVENT,
+                    ),
+                )
+                return _T3_HANDLED
 
         try:
             compaction_config = None
@@ -4092,22 +4086,36 @@ class TurnRunner:
                 )
             from opensquilla.session.compaction import call_compact_with_optional_config
 
-            result = await call_compact_with_optional_config(
-                self._session_manager.compact,
-                session_key,
-                context_window_tokens,
-                compaction_config,
-            )
+            compaction_result = None
+            compact_with_result = getattr(type(self._session_manager), "compact_with_result", None)
+            if callable(compact_with_result):
+                compaction_result = await self._session_manager.compact_with_result(
+                    session_key,
+                    context_window_tokens,
+                    compaction_config,
+                )
+                result = getattr(compaction_result, "summary", "") or ""
+            else:
+                result = await call_compact_with_optional_config(
+                    self._session_manager.compact,
+                    session_key,
+                    context_window_tokens,
+                    compaction_config,
+                )
             self.mark_compacted_this_turn(session_key)
             self._record_compaction_success(session_key)
             if result:
+                completed_payload = {"summary_len": len(result)}
+                if compaction_result is not None:
+                    completed_payload.update(compaction_result_payload(compaction_result))
                 notify_compaction(
                     session_key,
                     source="automatic",
                     phase="t3_upgrade",
                     status="completed",
                     context_window_tokens=context_window_tokens,
-                    summary_len=len(result),
+                    **completed_payload,
+                    **compaction_lifecycle_payload(compaction_id, COMPACTION_PERSISTED_EVENT),
                 )
             else:
                 notify_compaction(
@@ -4117,6 +4125,10 @@ class TurnRunner:
                     status="skipped",
                     reason="empty_summary",
                     context_window_tokens=context_window_tokens,
+                    **compaction_lifecycle_payload(
+                        compaction_id,
+                        COMPACTION_TRIGGERED_EVENT,
+                    ),
                 )
             log.info(
                 "t3_upgrade_compaction.compact_done",
@@ -4140,6 +4152,10 @@ class TurnRunner:
                 status="failed",
                 message=str(exc),
                 context_window_tokens=context_window_tokens,
+                **compaction_lifecycle_payload(
+                    compaction_id,
+                    COMPACTION_TRIGGERED_EVENT,
+                ),
             )
             return _T3_COMPACT_FAILED
 
@@ -4195,6 +4211,7 @@ class TurnRunner:
             threshold=threshold,
             ratio=ratio,
         )
+        compaction_id = new_compaction_id()
         notify_compaction(
             session_key,
             source="automatic",
@@ -4202,13 +4219,35 @@ class TurnRunner:
             status="started",
             tokens_before=total_tokens,
             context_window_tokens=context_window_tokens,
+            **compaction_lifecycle_payload(compaction_id, COMPACTION_TRIGGERED_EVENT),
         )
         if self._pre_compaction_flush_enabled():
-            await self._await_pre_compaction_flush_grace(
+            flush_safe = await self._await_pre_compaction_flush_grace(
                 transcript,
                 session_key,
                 event_prefix="preflight_compaction",
             )
+            if self._pre_compaction_flush_requires_safe_receipt() and not flush_safe:
+                log.warning(
+                    "preflight_compaction.skipped",
+                    session_key=session_key,
+                    reason="unsafe_flush_receipt",
+                )
+                notify_compaction(
+                    session_key,
+                    source="automatic",
+                    phase="preflight",
+                    status="skipped",
+                    reason="unsafe_flush_receipt",
+                    tokens_before=total_tokens,
+                    context_window_tokens=context_window_tokens,
+                    flush_receipt_status="unsafe",
+                    **compaction_lifecycle_payload(
+                        compaction_id,
+                        COMPACTION_TRIGGERED_EVENT,
+                    ),
+                )
+                return
         compaction_config = None
         if compaction_provider is not None or compaction_model:
             from opensquilla.session.compaction import build_compaction_config_from_provider
@@ -4221,12 +4260,22 @@ class TurnRunner:
         from opensquilla.session.compaction import call_compact_with_optional_config
 
         try:
-            result = await call_compact_with_optional_config(
-                self._session_manager.compact,
-                session_key,
-                context_window_tokens,
-                compaction_config,
-            )
+            compaction_result = None
+            compact_with_result = getattr(type(self._session_manager), "compact_with_result", None)
+            if callable(compact_with_result):
+                compaction_result = await self._session_manager.compact_with_result(
+                    session_key,
+                    context_window_tokens,
+                    compaction_config,
+                )
+                result = getattr(compaction_result, "summary", "") or ""
+            else:
+                result = await call_compact_with_optional_config(
+                    self._session_manager.compact,
+                    session_key,
+                    context_window_tokens,
+                    compaction_config,
+                )
             self.mark_compacted_this_turn(session_key)
         except asyncio.CancelledError:
             raise
@@ -4245,17 +4294,30 @@ class TurnRunner:
                 message=str(exc),
                 tokens_before=total_tokens,
                 context_window_tokens=context_window_tokens,
+                **compaction_lifecycle_payload(
+                    compaction_id,
+                    COMPACTION_TRIGGERED_EVENT,
+                ),
             )
             return
         self._record_compaction_success(session_key)
         if result:
+            completed_payload = {"tokens_before": total_tokens}
+            if compaction_result is not None:
+                completed_payload.update(
+                    compaction_result_payload(
+                        compaction_result,
+                        tokens_before=total_tokens,
+                    )
+                )
             notify_compaction(
                 session_key,
                 source="automatic",
                 phase="preflight",
                 status="completed",
-                tokens_before=total_tokens,
                 context_window_tokens=context_window_tokens,
+                **completed_payload,
+                **compaction_lifecycle_payload(compaction_id, COMPACTION_PERSISTED_EVENT),
             )
         else:
             notify_compaction(
@@ -4266,6 +4328,10 @@ class TurnRunner:
                 reason="empty_summary",
                 tokens_before=total_tokens,
                 context_window_tokens=context_window_tokens,
+                **compaction_lifecycle_payload(
+                    compaction_id,
+                    COMPACTION_TRIGGERED_EVENT,
+                ),
             )
 
     def _pre_compaction_flush_enabled(self) -> bool:
@@ -4282,6 +4348,9 @@ class TurnRunner:
         if isinstance(raw_enabled, str):
             return raw_enabled.strip().lower() not in {"0", "false", "no", "off"}
         return bool(raw_enabled)
+
+    def _pre_compaction_flush_requires_safe_receipt(self) -> bool:
+        return pre_compaction_flush_requires_safe_receipt(self._config)
 
     def _pre_compaction_flush_timeout_seconds(self) -> float:
         memory_cfg = getattr(self._config, "memory", None)
@@ -4652,9 +4721,7 @@ class TurnRunner:
             if not isinstance(att, dict):
                 continue
             media_type = att.get("type") or att.get("mime") or att.get("media_type")
-            if not (
-                isinstance(media_type, str) and media_type in _ALLOWED_ENGINE_MEDIA_TYPES
-            ):
+            if not (isinstance(media_type, str) and media_type in _ALLOWED_ENGINE_MEDIA_TYPES):
                 continue
             # Persisted attachment envelope: ``sha256_ref`` indicates the bytes live on
             # disk under media/transcripts/<session>/<sha>; for replay we
@@ -4663,7 +4730,8 @@ class TurnRunner:
             sha_ref = att.get("sha256_ref")
             missing_reason = att.get("missing_reason")
             if not (
-                (isinstance(data, str) and data) or (isinstance(sha_ref, str) and sha_ref)
+                (isinstance(data, str) and data)
+                or (isinstance(sha_ref, str) and sha_ref)
                 or (isinstance(missing_reason, str) and missing_reason)
             ):
                 continue
@@ -4690,9 +4758,7 @@ class TurnRunner:
         if not isinstance(text, str) or not isinstance(artifacts, list):
             return content
         markers = [
-            artifact_marker(artifact)
-            for artifact in artifacts
-            if isinstance(artifact, dict)
+            artifact_marker(artifact) for artifact in artifacts if isinstance(artifact, dict)
         ]
         if not markers:
             return text
@@ -4746,9 +4812,7 @@ class TurnRunner:
                 if isinstance(mime, str) and mime in _ALLOWED_ENGINE_MEDIA_TYPES:
                     media_type = mime
             if media_type is None or media_type not in _ALLOWED_ENGINE_MEDIA_TYPES:
-                raise ValueError(
-                    f"attachments[{index}] media type {att_type!r} is not allowed"
-                )
+                raise ValueError(f"attachments[{index}] media type {att_type!r} is not allowed")
             if is_attachment_ref(att):
                 missing_ref_marker = ""
                 if media_root is None:
@@ -4779,9 +4843,7 @@ class TurnRunner:
             else:
                 max_bytes = _MAX_ATTACHMENT_BYTES
             if len(raw_bytes) > max_bytes:
-                raise ValueError(
-                    f"attachments[{index}] exceeds the {max_bytes} byte limit"
-                )
+                raise ValueError(f"attachments[{index}] exceeds the {max_bytes} byte limit")
 
             name_raw = att.get("name")
             filename = _sanitize_attachment_filename(name_raw)
@@ -4791,16 +4853,13 @@ class TurnRunner:
                 continue
 
             if media_type.startswith("image/"):
-                attachment_blocks.append(
-                    ContentBlockImage(media_type=media_type, data=data)
-                )
+                attachment_blocks.append(ContentBlockImage(media_type=media_type, data=data))
             elif media_type == "application/pdf":
                 try:
                     extracted_pdf_text = _extract_pdf_attachment_text(raw_bytes, filename)
                 except ValueError as exc:
                     extracted_pdf_text = (
-                        "[attachment unavailable: PDF text could not be extracted: "
-                        f"{exc}]"
+                        f"[attachment unavailable: PDF text could not be extracted: {exc}]"
                     )
                 wrapped = _render_file_context_block(filename, media_type, extracted_pdf_text)
                 attachment_blocks.append(ContentBlockText(text=wrapped))
@@ -4817,9 +4876,7 @@ class TurnRunner:
                 wrapped = _render_file_context_block(filename, media_type, decoded_text)
                 attachment_blocks.append(ContentBlockText(text=wrapped))
             else:  # pragma: no cover - guarded by allow-list above
-                raise ValueError(
-                    f"attachments[{index}] media type {media_type!r} is not handled"
-                )
+                raise ValueError(f"attachments[{index}] media type {media_type!r} is not handled")
 
         return [
             Message(

--- a/src/opensquilla/gateway/context_overflow.py
+++ b/src/opensquilla/gateway/context_overflow.py
@@ -36,9 +36,17 @@ from opensquilla.session.compaction import (
     estimate_entry_model_replay_tokens,
 )
 from opensquilla.session.compaction_lifecycle import (
+    COMPACTION_PERSISTED_EVENT,
+    COMPACTION_REPLAYED_EVENT,
+    COMPACTION_TRIGGERED_EVENT,
     CompactionLifecycleResult,
+    compaction_lifecycle_payload,
+    compaction_result_payload,
     flush_receipt_allows_destructive_compaction,
+    flush_receipt_status,
+    new_compaction_id,
     pre_compaction_flush_enabled,
+    pre_compaction_flush_requires_safe_receipt,
 )
 from opensquilla.session.keys import parse_agent_id
 from opensquilla.session.tokenizer import estimate_tokens
@@ -381,11 +389,10 @@ async def apply_context_overflow_policy(
                     outcome.retried = True
                     return outcome
                 outcome.reason = "compaction_insufficient"
-                outcome.refusal = _build_refusal_envelope(
-                    post_estimate, budget, outcome.reason
-                )
+                outcome.refusal = _build_refusal_envelope(post_estimate, budget, outcome.reason)
                 return outcome
 
+            compaction_id = new_compaction_id()
             notify_compaction(
                 session_key,
                 source="automatic",
@@ -393,6 +400,10 @@ async def apply_context_overflow_policy(
                 status="started",
                 tokens_before=estimated,
                 context_window_tokens=budget,
+                **compaction_lifecycle_payload(
+                    compaction_id,
+                    COMPACTION_TRIGGERED_EVENT,
+                ),
             )
             outcome.flush_receipt = await _await_auto_summarize_flush_grace(
                 config=config,
@@ -400,15 +411,64 @@ async def apply_context_overflow_policy(
                 session_key=session_key,
                 flush_service=flush_service,
             )
+            if (
+                pre_compaction_flush_enabled(config)
+                and pre_compaction_flush_requires_safe_receipt(config)
+                and not flush_receipt_allows_destructive_compaction(outcome.flush_receipt)
+            ):
+                outcome.reason = "compaction_flush_failed"
+                outcome.tokens_after = estimated
+                outcome.remaining_budget_tokens = max(budget - estimated, 0)
+                outcome.refusal = _build_refusal_envelope(
+                    estimated,
+                    budget,
+                    outcome.reason,
+                )
+                outcome.lifecycle = CompactionLifecycleResult(
+                    compacted=False,
+                    refused=True,
+                    reason=outcome.reason,
+                    tokens_before=estimated,
+                    tokens_after=estimated,
+                    remaining_budget_tokens=outcome.remaining_budget_tokens,
+                    flush_receipt=outcome.flush_receipt,
+                )
+                log.warning(
+                    "context_overflow.auto_summarize_refused",
+                    session_key=session_key,
+                    reason=outcome.reason,
+                )
+                notify_compaction(
+                    session_key,
+                    source="automatic",
+                    phase="gateway_auto_summarize",
+                    status="failed",
+                    reason=outcome.reason,
+                    tokens_before=estimated,
+                    tokens_after=estimated,
+                    remaining_budget_tokens=outcome.remaining_budget_tokens,
+                    context_window_tokens=budget,
+                    flush_receipt_status=flush_receipt_status(outcome.flush_receipt),
+                    **compaction_lifecycle_payload(
+                        compaction_id,
+                        COMPACTION_TRIGGERED_EVENT,
+                    ),
+                )
+                return outcome
 
+            compaction_result = None
             compact_with_result = getattr(session_manager, "compact_with_result", None)
             if callable(compact_with_result):
-                result = await compact_with_result(session_key, budget, compaction_config)
-                summary = getattr(result, "summary", "") or ""
-                outcome.removed_count = int(getattr(result, "removed_count", 0) or 0)
-                outcome.kept_count = len(getattr(result, "kept_entries", []) or [])
+                compaction_result = await compact_with_result(
+                    session_key,
+                    budget,
+                    compaction_config,
+                )
+                summary = getattr(compaction_result, "summary", "") or ""
+                outcome.removed_count = int(getattr(compaction_result, "removed_count", 0) or 0)
+                outcome.kept_count = len(getattr(compaction_result, "kept_entries", []) or [])
                 outcome.summary_source = str(
-                    getattr(result, "summary_source", "unknown") or "unknown"
+                    getattr(compaction_result, "summary_source", "unknown") or "unknown"
                 )
             else:
                 summary = await call_compact_with_optional_config(
@@ -432,9 +492,7 @@ async def apply_context_overflow_policy(
 
             if post_estimate > budget or post_estimate >= estimated:
                 outcome.reason = "compaction_insufficient"
-                outcome.refusal = _build_refusal_envelope(
-                    post_estimate, budget, outcome.reason
-                )
+                outcome.refusal = _build_refusal_envelope(post_estimate, budget, outcome.reason)
                 outcome.lifecycle = CompactionLifecycleResult(
                     compacted=False,
                     refused=True,
@@ -454,20 +512,37 @@ async def apply_context_overflow_policy(
                     reason=outcome.reason,
                     tokens_after=post_estimate,
                 )
+                failed_payload = {
+                    "tokens_before": estimated,
+                    "tokens_after": post_estimate,
+                    "remaining_budget_tokens": outcome.remaining_budget_tokens,
+                    "removed_count": outcome.removed_count,
+                    "kept_count": outcome.kept_count,
+                    "summary_len": outcome.summary_len,
+                    "summary_source": outcome.summary_source,
+                }
+                if compaction_result is not None:
+                    failed_payload.update(
+                        compaction_result_payload(
+                            compaction_result,
+                            tokens_before=estimated,
+                            tokens_after=post_estimate,
+                            remaining_budget_tokens=outcome.remaining_budget_tokens,
+                        )
+                    )
                 notify_compaction(
                     session_key,
                     source="automatic",
                     phase="gateway_auto_summarize",
                     status="failed",
                     reason=outcome.reason,
-                    tokens_before=estimated,
-                    tokens_after=post_estimate,
-                    remaining_budget_tokens=outcome.remaining_budget_tokens,
-                    removed_count=outcome.removed_count,
-                    kept_count=outcome.kept_count,
-                    summary_len=outcome.summary_len,
-                    summary_source=outcome.summary_source,
                     context_window_tokens=budget,
+                    flush_receipt_status=flush_receipt_status(outcome.flush_receipt),
+                    **failed_payload,
+                    **compaction_lifecycle_payload(
+                        compaction_id,
+                        COMPACTION_PERSISTED_EVENT,
+                    ),
                 )
                 return outcome
 
@@ -494,18 +569,33 @@ async def apply_context_overflow_policy(
                 remaining_budget_tokens=outcome.remaining_budget_tokens,
                 summary_source=outcome.summary_source,
             )
+            completed_payload = {
+                "tokens_before": estimated,
+                "tokens_after": post_estimate,
+                "remaining_budget_tokens": outcome.remaining_budget_tokens,
+                "removed_count": outcome.removed_count,
+                "kept_count": outcome.kept_count,
+                "summary_len": outcome.summary_len,
+                "summary_source": outcome.summary_source,
+            }
+            if compaction_result is not None:
+                completed_payload.update(
+                    compaction_result_payload(
+                        compaction_result,
+                        tokens_before=estimated,
+                        tokens_after=post_estimate,
+                        remaining_budget_tokens=outcome.remaining_budget_tokens,
+                    )
+                )
             notify_compaction(
                 session_key,
                 source="automatic",
                 phase="gateway_auto_summarize",
                 status="completed",
-                tokens_before=estimated,
-                tokens_after=post_estimate,
-                remaining_budget_tokens=outcome.remaining_budget_tokens,
-                removed_count=outcome.removed_count,
-                kept_count=outcome.kept_count,
-                summary_len=outcome.summary_len,
-                summary_source=outcome.summary_source,
+                context_window_tokens=budget,
+                flush_receipt_status=flush_receipt_status(outcome.flush_receipt),
+                **completed_payload,
+                **compaction_lifecycle_payload(compaction_id, COMPACTION_REPLAYED_EVENT),
             )
         except Exception as exc:  # noqa: BLE001 — best-effort
             outcome.reason = "compaction_failed"

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -489,6 +489,19 @@ def _stable_json_hash(value: Any) -> str:
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
 
 
+def _openrouter_non_system_prefix_item_hashes(
+    messages: list[dict[str, Any]], *, max_items: int = 3
+) -> list[str]:
+    hashes: list[str] = []
+    for message in messages:
+        if message.get("role") == "system":
+            continue
+        hashes.append(_stable_json_hash(message))
+        if len(hashes) >= max_items:
+            break
+    return hashes
+
+
 def _attach_reasoning_content(
     msg: Message,
     payload: dict[str, Any],
@@ -916,6 +929,9 @@ class OpenAIProvider:
                 if openai_messages and openai_messages[0].get("role") == "system"
                 else None
             )
+            non_system_prefix_item_hashes = _openrouter_non_system_prefix_item_hashes(
+                openai_messages
+            )
             log.debug(
                 "openrouter.payload_cache_shape",
                 model=self._model,
@@ -923,6 +939,10 @@ class OpenAIProvider:
                 system_hash=_stable_json_hash(system_payload) if system_payload else "",
                 tools_hash=_stable_json_hash(payload.get("tools", [])) if tools else "",
                 messages_prefix_hash=_stable_json_hash(openai_messages[:-1]),
+                first_non_system_hash=(
+                    non_system_prefix_item_hashes[0] if non_system_prefix_item_hashes else ""
+                ),
+                non_system_prefix_item_hashes=non_system_prefix_item_hashes,
                 message_count=len(openai_messages),
             )
 

--- a/src/opensquilla/result_budget.py
+++ b/src/opensquilla/result_budget.py
@@ -70,6 +70,29 @@ class ToolRunBudgetPolicy:
 DEFAULT_TOOL_RUN_BUDGET_POLICY = ToolRunBudgetPolicy()
 
 
+def build_webresearch_tool_run_budget_policy(
+    *,
+    max_web_search_calls_per_turn: int | None = None,
+    max_web_fetch_calls_per_turn: int | None = None,
+    max_external_text_chars_per_turn: int | None = None,
+    max_single_fetch_chars: int | None = 50_000,
+    max_web_search_results: int | None = 10,
+) -> ToolRunBudgetPolicy:
+    """Build an explicit webresearch budget policy for benchmark/profile use.
+
+    The defaults intentionally match the normal runtime: no per-turn call-count
+    caps and no aggregate external-text cap. Callers must opt in to tighter
+    limits by passing concrete values.
+    """
+    return ToolRunBudgetPolicy(
+        max_web_search_calls_per_turn=max_web_search_calls_per_turn,
+        max_web_fetch_calls_per_turn=max_web_fetch_calls_per_turn,
+        max_external_text_chars_per_turn=max_external_text_chars_per_turn,
+        max_single_fetch_chars=max_single_fetch_chars,
+        max_web_search_results=max_web_search_results,
+    )
+
+
 class ToolRunBudgetExceededError(RuntimeError):
     """Raised when a tool call would exceed the per-turn run budget."""
 
@@ -166,6 +189,15 @@ class ToolRunBudgetTracker:
                 self._web_fetch_calls_used = max(0, self._web_fetch_calls_used - 1)
             if reservation.counted_as_search:
                 self._web_search_calls_used = max(0, self._web_search_calls_used - 1)
+
+    async def snapshot(self) -> dict[str, int]:
+        async with self._lock:
+            return {
+                "web_search_calls_used": self._web_search_calls_used,
+                "web_fetch_calls_used": self._web_fetch_calls_used,
+                "external_text_chars_used": self._external_text_chars_used,
+                "external_text_chars_reserved": self._external_text_chars_reserved,
+            }
 
     def _reserve_external_text_budget(
         self,

--- a/src/opensquilla/session/compaction_lifecycle.py
+++ b/src/opensquilla/session/compaction_lifecycle.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Final
+from uuid import uuid4
 
-SAFE_FLUSH_OUTPUT_COVERAGE_STATUSES: Final[frozenset[str]] = frozenset(
-    {"ok", "unverifiable"}
-)
+SAFE_FLUSH_OUTPUT_COVERAGE_STATUSES: Final[frozenset[str]] = frozenset({"ok", "unverifiable"})
 SAFE_FLUSH_OBLIGATION_STATUSES: Final[frozenset[str]] = frozenset(
     {"ok", "backfilled", "unverifiable"}
 )
+COMPACTION_TRIGGERED_EVENT: Final[str] = "compaction.triggered"
+COMPACTION_CHUNK_SUMMARIZED_EVENT: Final[str] = "compaction.chunk_summarized"
+COMPACTION_SUMMARY_VERIFIED_EVENT: Final[str] = "compaction.summary_verified"
+COMPACTION_PERSISTED_EVENT: Final[str] = "compaction.persisted"
+COMPACTION_REPLAYED_EVENT: Final[str] = "compaction.replayed"
+COMPACTION_COVERAGE_UNKNOWN: Final[str] = "unknown"
 
 
 @dataclass(frozen=True)
@@ -27,6 +32,86 @@ class CompactionLifecycleResult:
     summary_len: int = 0
     summary_source: str = "unknown"
     flush_receipt: Any = None
+
+
+def new_compaction_id() -> str:
+    """Return an opaque id used to correlate one compaction attempt's events."""
+
+    return f"cmp_{uuid4().hex}"
+
+
+def compaction_event_chain(event: str) -> list[str]:
+    """Return the lifecycle events completed by the given telemetry event."""
+
+    if event == COMPACTION_REPLAYED_EVENT:
+        return [
+            COMPACTION_TRIGGERED_EVENT,
+            COMPACTION_CHUNK_SUMMARIZED_EVENT,
+            COMPACTION_SUMMARY_VERIFIED_EVENT,
+            COMPACTION_PERSISTED_EVENT,
+            COMPACTION_REPLAYED_EVENT,
+        ]
+    if event == COMPACTION_PERSISTED_EVENT:
+        return [
+            COMPACTION_TRIGGERED_EVENT,
+            COMPACTION_CHUNK_SUMMARIZED_EVENT,
+            COMPACTION_SUMMARY_VERIFIED_EVENT,
+            COMPACTION_PERSISTED_EVENT,
+        ]
+    if event == COMPACTION_SUMMARY_VERIFIED_EVENT:
+        return [
+            COMPACTION_TRIGGERED_EVENT,
+            COMPACTION_CHUNK_SUMMARIZED_EVENT,
+            COMPACTION_SUMMARY_VERIFIED_EVENT,
+        ]
+    if event == COMPACTION_CHUNK_SUMMARIZED_EVENT:
+        return [COMPACTION_TRIGGERED_EVENT, COMPACTION_CHUNK_SUMMARIZED_EVENT]
+    return [COMPACTION_TRIGGERED_EVENT]
+
+
+def compaction_lifecycle_payload(compaction_id: str, event: str) -> dict[str, Any]:
+    return {
+        "compaction_id": compaction_id,
+        "event": event,
+        "event_chain": compaction_event_chain(event),
+        "coverage_status": COMPACTION_COVERAGE_UNKNOWN,
+    }
+
+
+def compaction_result_payload(
+    result: Any,
+    *,
+    tokens_before: int | None = None,
+    tokens_after: int | None = None,
+    remaining_budget_tokens: int | None = None,
+) -> dict[str, Any]:
+    kept_entries = getattr(result, "kept_entries", None) or []
+    payload: dict[str, Any] = {
+        "removed_count": int(getattr(result, "removed_count", 0) or 0),
+        "kept_count": len(kept_entries),
+        "chunk_count": int(getattr(result, "chunks_processed", 0) or 0),
+        "summary_len": len(str(getattr(result, "summary", "") or "")),
+        "summary_source": str(getattr(result, "summary_source", "unknown") or "unknown"),
+    }
+    if tokens_before is None:
+        tokens_before = getattr(result, "tokens_before", None)
+    if tokens_after is None:
+        tokens_after = getattr(result, "tokens_after", None)
+    if remaining_budget_tokens is None:
+        remaining_budget_tokens = getattr(result, "remaining_budget_tokens", None)
+    if tokens_before is not None:
+        payload["tokens_before"] = int(tokens_before)
+    if tokens_after is not None:
+        payload["tokens_after"] = int(tokens_after)
+    if remaining_budget_tokens is not None:
+        payload["remaining_budget_tokens"] = int(remaining_budget_tokens)
+    return payload
+
+
+def flush_receipt_status(receipt: Any) -> str:
+    if receipt is None:
+        return "not_requested"
+    return "safe" if flush_receipt_allows_destructive_compaction(receipt) else "unsafe"
 
 
 def _receipt_value(receipt: Any, name: str, default: Any) -> Any:
@@ -53,8 +138,7 @@ def flush_receipt_allows_destructive_compaction(receipt: Any) -> bool:
     if integrity_status != "ok":
         return False
     output_coverage_status = str(
-        _receipt_value(receipt, "output_coverage_status", "unverified")
-        or "unverified"
+        _receipt_value(receipt, "output_coverage_status", "unverified") or "unverified"
     )
     if output_coverage_status not in SAFE_FLUSH_OUTPUT_COVERAGE_STATUSES:
         return False

--- a/src/opensquilla/tools/dispatch.py
+++ b/src/opensquilla/tools/dispatch.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 import weakref
 from collections.abc import Sequence
 from typing import Any
@@ -33,6 +34,7 @@ from opensquilla.result_budget import (
     ToolResultBudgetTracker,
     ToolRunBudgetExceededError,
     ToolRunBudgetPolicy,
+    ToolRunBudgetReservation,
     ToolRunBudgetTracker,
     clamp_tool_arguments,
 )
@@ -137,6 +139,44 @@ def _build_envelope_result(
         ),
         is_error=True,
         execution_status=normalize_execution_status(status),
+    )
+
+
+async def _emit_webresearch_tool_run_diagnostics(
+    *,
+    tool_call: ToolCall,
+    effective_ctx: ToolContext | None,
+    reservation: ToolRunBudgetReservation,
+    run_budget_tracker: ToolRunBudgetTracker,
+    started_at: float,
+    raw_result: Any,
+    exception: BaseException | None,
+) -> None:
+    if not reservation.counted_as_external_text:
+        return
+    snapshot = await run_budget_tracker.snapshot()
+    if exception is None:
+        status = "ok"
+    elif isinstance(exception, ToolRunBudgetExceededError):
+        status = "budget_exhausted"
+    else:
+        status = "error"
+    result_chars = 0
+    if raw_result is not None:
+        result_chars = len(raw_result if isinstance(raw_result, str) else str(raw_result))
+    log.debug(
+        "dispatch.webresearch_tool_run_diagnostics",
+        tool=tool_call.tool_name,
+        tool_use_id=tool_call.tool_use_id,
+        agent_id=effective_ctx.agent_id if effective_ctx else None,
+        session_key=effective_ctx.session_key if effective_ctx else None,
+        status=status,
+        tool_wall_time_ms=round((time.monotonic() - started_at) * 1000, 3),
+        result_chars=result_chars,
+        reserved_external_text_chars=reservation.reserved_external_text_chars,
+        counted_as_search=reservation.counted_as_search,
+        counted_as_fetch=reservation.counted_as_fetch,
+        **snapshot,
     )
 
 
@@ -510,6 +550,7 @@ def build_tool_handler(
             return envelope
 
         token = current_tool_context.set(effective_ctx)
+        tool_started_at = time.monotonic()
         raw_result: Any = None
         exception: BaseException | None = None
         artifact_start = (
@@ -545,6 +586,15 @@ def build_tool_handler(
                                 error=str(hook_exc),
                             )
                 if not isinstance(exception, asyncio.CancelledError):
+                    await _emit_webresearch_tool_run_diagnostics(
+                        tool_call=tool_call,
+                        effective_ctx=effective_ctx,
+                        reservation=reservation,
+                        run_budget_tracker=run_budget_tracker,
+                        started_at=tool_started_at,
+                        raw_result=raw_result,
+                        exception=exception,
+                    )
                     # 7. Single finalisation point.
                     return await finalize(
                         tool_call,

--- a/tests/functional/test_live_openrouter_compaction.py
+++ b/tests/functional/test_live_openrouter_compaction.py
@@ -1,0 +1,75 @@
+"""Opt-in live OpenRouter compaction smoke.
+
+Uses only public synthetic text and skips unless explicitly enabled with local
+credentials. The goal is to prove the compaction path can complete with a real
+LLM call without making normal test runs credentialed or costful.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from opensquilla.session.compaction import CompactionConfig
+from opensquilla.session.manager import SessionManager
+from opensquilla.session.storage import SessionStorage
+
+pytestmark = [pytest.mark.llm, pytest.mark.llm_smoke, pytest.mark.agent_context_boundary]
+
+
+@pytest.mark.asyncio
+async def test_live_openrouter_session_compaction_succeeds(tmp_path: Path) -> None:
+    if os.environ.get("OPENSQUILLA_LIVE_COMPACTION_E2E") != "1":
+        pytest.skip("set OPENSQUILLA_LIVE_COMPACTION_E2E=1 to run live compaction smoke")
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        pytest.skip("OPENROUTER_API_KEY not set")
+
+    storage = SessionStorage(str(tmp_path / "sessions.db"))
+    await storage.connect()
+    manager = SessionManager(storage)
+    session_key = "agent:main:live-compaction"
+    try:
+        await manager.create(session_key)
+        for index in range(12):
+            await manager.append_message(
+                session_key,
+                "user" if index % 2 == 0 else "assistant",
+                (
+                    f"Synthetic compaction fact {index}: "
+                    "the public dummy project uses alpha, beta, and gamma markers. "
+                    "Keep the current goal, completed steps, failures, and next action. " * 20
+                ),
+                token_count=450,
+            )
+
+        result = await manager.compact_with_result(
+            session_key,
+            context_window_tokens=2_000,
+            config=CompactionConfig(
+                model=os.environ.get("LLM_TEST_MODEL", "openai/gpt-4o-mini"),
+                api_key=api_key,
+                base_url=os.environ.get(
+                    "OPENROUTER_BASE_URL",
+                    "https://openrouter.ai/api/v1",
+                ),
+                timeout_seconds=90,
+            ),
+        )
+
+        assert result.summary
+        assert result.summary_source == "llm"
+        assert result.removed_count > 0
+        assert result.chunks_processed >= 1
+        assert result.tokens_after < result.tokens_before
+
+        node = await manager._storage.get_session(session_key)
+        assert node is not None
+        assert node.compaction_count == 1
+        assert await manager.get_transcript(session_key)
+        summaries = await manager.get_summaries(session_key)
+        assert [summary.summary_text for summary in summaries] == [result.summary]
+    finally:
+        await storage.close()

--- a/tests/test_engine/test_cache_break_monitor.py
+++ b/tests/test_engine/test_cache_break_monitor.py
@@ -60,7 +60,43 @@ def test_cache_break_monitor_initializes_then_detects_attributed_drop() -> None:
     log_payload = report.to_log_dict()
     assert "forensics" in log_payload
     assert log_payload["forensics"]["previous"]["messages_prefix_item_hashes"]
+    assert log_payload["forensics"]["previous"]["messages_prefix_item_kinds"] == ["history"]
     assert log_payload["forensics"]["current"]["cache_control_field_hashes"]
+
+
+def test_cache_break_monitor_forensics_labels_request_context_prefix_items() -> None:
+    monitor = CacheBreakMonitor(min_drop_tokens=10, min_drop_ratio=0.05)
+    first = monitor.record_prompt_state(
+        messages=[
+            Message(role="user", content="[Request context for this turn]\nvolatile one"),
+            Message(role="user", content="old question"),
+            Message(role="assistant", content="old answer"),
+            Message(role="user", content="current question"),
+        ],
+        tools=None,
+        config=ChatConfig(system="stable system"),
+        model="model-a",
+    )
+    monitor.check_response_for_cache_break("agent:main:s1", first, 5000)
+
+    second = monitor.record_prompt_state(
+        messages=[
+            Message(role="user", content="[Request context for this turn]\nvolatile two"),
+            Message(role="user", content="old question"),
+            Message(role="assistant", content="old answer"),
+            Message(role="user", content="current question"),
+        ],
+        tools=None,
+        config=ChatConfig(system="stable system"),
+        model="model-a",
+    )
+
+    report = monitor.check_response_for_cache_break("agent:main:s1", second, 100)
+
+    assert report.break_detected is True
+    payload = report.to_log_dict()
+    assert payload["forensics"]["previous"]["messages_prefix_item_kinds"][0] == "request_context"
+    assert payload["forensics"]["current"]["messages_prefix_item_kinds"][0] == "request_context"
 
 
 def test_cache_break_monitor_resets_baseline_after_compaction() -> None:

--- a/tests/test_engine/test_preflight_compaction.py
+++ b/tests/test_engine/test_preflight_compaction.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from opensquilla.engine import runtime as runtime_module
 from opensquilla.engine.runtime import TurnRunner
 from opensquilla.gateway.config import GatewayConfig
 from opensquilla.provider import DoneEvent as ProviderDone
@@ -134,6 +135,33 @@ class _FakeProviderSelector:
 
     def resolve(self) -> _FakeCompactionProvider:
         return self.provider
+
+
+class _ResultCompactionSessionManager:
+    def __init__(self, transcript: list[TranscriptEntry]) -> None:
+        self._transcript = transcript
+        self.compact_with_result_calls: list[tuple[str, int, object | None]] = []
+
+    async def get_transcript(self, session_key: str) -> list[TranscriptEntry]:
+        return list(self._transcript)
+
+    async def compact_with_result(
+        self,
+        session_key: str,
+        context_window_tokens: int,
+        config: object | None = None,
+    ) -> SimpleNamespace:
+        self.compact_with_result_calls.append((session_key, context_window_tokens, config))
+        return SimpleNamespace(
+            summary="summary text",
+            kept_entries=[{"role": "assistant", "content": "tail"}],
+            removed_count=4,
+            chunks_processed=3,
+            summary_source="llm",
+            tokens_before=1000,
+            tokens_after=200,
+            remaining_budget_tokens=800,
+        )
 
 
 @pytest.fixture
@@ -274,6 +302,50 @@ async def test_preflight_above_threshold_triggers_compact() -> None:
 
 
 @pytest.mark.asyncio
+async def test_preflight_completed_event_reports_compaction_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context_window = 1000
+    entries = [_make_entry("a" * 4000)]
+    sm = _ResultCompactionSessionManager(entries)
+    events: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        runtime_module,
+        "notify_compaction",
+        lambda session_key, **payload: events.append((session_key, payload)),
+    )
+    runner = TurnRunner(provider_selector=MagicMock(), session_manager=sm)
+
+    with patch("opensquilla.session.tokenizer.estimate_tokens", return_value=1000):
+        await runner._maybe_preflight_compact("user:session", context_window)
+
+    assert sm.compact_with_result_calls == [("user:session", context_window, None)]
+    assert [(key, payload["status"]) for key, payload in events] == [
+        ("user:session", "started"),
+        ("user:session", "completed"),
+    ]
+    compaction_ids = {payload.get("compaction_id") for _, payload in events}
+    assert len(compaction_ids) == 1
+    assert None not in compaction_ids
+    assert events[0][1]["event"] == "compaction.triggered"
+    completed = events[-1][1]
+    assert completed["event"] == "compaction.persisted"
+    assert completed["event_chain"] == [
+        "compaction.triggered",
+        "compaction.chunk_summarized",
+        "compaction.summary_verified",
+        "compaction.persisted",
+    ]
+    assert completed["coverage_status"] == "unknown"
+    assert completed["chunk_count"] == 3
+    assert completed["summary_source"] == "llm"
+    assert completed["removed_count"] == 4
+    assert completed["kept_count"] == 1
+    assert completed["tokens_after"] == 200
+    assert completed["remaining_budget_tokens"] == 800
+
+
+@pytest.mark.asyncio
 async def test_preflight_counts_tool_call_arguments_when_deciding_to_compact() -> None:
     context_window = 1000
     entries = [
@@ -409,6 +481,39 @@ async def test_preflight_degraded_flush_receipts_do_not_block_compaction(
 
     flush_service.execute.assert_awaited_once()
     mock_sm.compact.assert_awaited_once_with("agent:ops:long-session", context_window)
+
+
+@pytest.mark.asyncio
+async def test_preflight_strict_flush_receipt_skips_destructive_compaction() -> None:
+    context_window = 1000
+    entries = [_make_entry("early durable fact " + ("a" * 4000))]
+    mock_sm = MagicMock()
+    mock_sm.get_transcript = AsyncMock(return_value=entries)
+    mock_sm.compact = AsyncMock(return_value="summary text")
+
+    flush_service = MagicMock()
+    flush_service.execute = AsyncMock(
+        return_value=_flush_receipt(integrity_status="missing_chunks")
+    )
+    runner = TurnRunner(
+        provider_selector=MagicMock(),
+        session_manager=mock_sm,
+        session_flush_service=flush_service,
+        config=SimpleNamespace(
+            memory=SimpleNamespace(
+                flush_enabled=True,
+                flush_timeout_seconds=0.25,
+                flush_background_timeout_seconds=42.0,
+                flush_compaction_requires_safe_receipt=True,
+            )
+        ),
+    )
+
+    with patch("opensquilla.session.tokenizer.estimate_tokens", return_value=1000):
+        await runner._maybe_preflight_compact("agent:ops:long-session", context_window)
+
+    flush_service.execute.assert_awaited_once()
+    mock_sm.compact.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -759,7 +864,7 @@ async def test_preflight_exactly_at_threshold_does_not_compact() -> None:
 
 @pytest.mark.asyncio
 async def test_preflight_integration_with_real_session_manager(session_mgr) -> None:
-    """Integration: pre-flight with real SessionManager calls compact() when over threshold."""
+    """Integration: pre-flight with real SessionManager compacts when over threshold."""
     mgr = session_mgr
     key = "user:preflight-test"
     await mgr.create(key)
@@ -771,21 +876,21 @@ async def test_preflight_integration_with_real_session_manager(session_mgr) -> N
 
     runner = TurnRunner(provider_selector=MagicMock(), session_manager=mgr)
 
-    # Patch compact() on the real manager to verify it gets called
-    original_compact = mgr.compact
+    # Patch compact_with_result() to verify the metadata-preserving path is used.
+    original_compact_with_result = mgr.compact_with_result
     compact_calls: list[tuple] = []
 
-    async def _spy_compact(session_key, context_window_tokens, config=None):
+    async def _spy_compact_with_result(session_key, context_window_tokens, config=None):
         compact_calls.append((session_key, context_window_tokens))
-        return await original_compact(session_key, context_window_tokens, config)
+        return await original_compact_with_result(session_key, context_window_tokens, config)
 
-    mgr.compact = _spy_compact  # type: ignore[method-assign]
+    mgr.compact_with_result = _spy_compact_with_result  # type: ignore[method-assign]
 
     # Force all tokens to exceed the default threshold (100 * 0.85 = 85)
     with patch("opensquilla.session.tokenizer.estimate_tokens", return_value=1000):
         await runner._maybe_preflight_compact(key, 100)
 
-    # compact() was invoked with the correct args
+    # compact_with_result() was invoked with the correct args.
     assert len(compact_calls) == 1
     assert compact_calls[0] == (key, 100)
 

--- a/tests/test_engine/test_prompt_cache_stability.py
+++ b/tests/test_engine/test_prompt_cache_stability.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import MagicMock
@@ -35,6 +37,16 @@ class _CapturingProvider:
 
     async def list_models(self) -> list[Any]:
         return []
+
+
+def _message_item_hash(message: Message) -> str:
+    payload = json.dumps(
+        message.model_dump(mode="json", exclude_none=True),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
 @pytest.fixture
@@ -116,12 +128,12 @@ async def test_summary_context_is_request_only_and_keeps_system_cache_anchor(
     call = provider.calls[0]
     assert call["config"].system == "stable base"
     assert call["config"].cache_breakpoints == [{"text": "stable base", "cache": "true"}]
-    request_context = call["messages"][0].content
-    assert "[Request context for this turn]" in request_context
-    assert [message.content for message in call["messages"][1:3]] == [
+    assert [message.content for message in call["messages"][0:2]] == [
         "old question",
         "old answer",
     ]
+    request_context = call["messages"][2].content
+    assert "[Request context for this turn]" in request_context
     assert "[Compacted Session Summaries]" in request_context
     assert "summary outside transcript" in request_context
     assert "<memory_context>volatile recall</memory_context>" in request_context
@@ -133,3 +145,45 @@ async def test_summary_context_is_request_only_and_keeps_system_cache_anchor(
         for message in agent._history
         if isinstance(message.content, str)
     )
+
+
+@pytest.mark.asyncio
+async def test_changing_request_context_does_not_pollute_persisted_history_prefix() -> None:
+    provider = _CapturingProvider()
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            system_prompt="stable base",
+            request_context_prompt="<memory_context>volatile one</memory_context>",
+            cache_breakpoints=[{"text": "stable base", "cache": "true"}],
+            cache_mode="auto",
+            max_iterations=1,
+        ),
+    )
+    agent.set_history(
+        [
+            Message(role="user", content="old question"),
+            Message(role="assistant", content="old answer"),
+        ]
+    )
+
+    first_events = [event async for event in agent.run_turn("first question")]
+    agent.config.request_context_prompt = "<memory_context>volatile two</memory_context>"
+    second_events = [event async for event in agent.run_turn("second question")]
+
+    assert any(event.kind == "done" for event in first_events)
+    assert any(event.kind == "done" for event in second_events)
+    first_messages = provider.calls[0]["messages"]
+    second_messages = provider.calls[1]["messages"]
+    assert first_messages[0] == Message(role="user", content="old question")
+    assert first_messages[1] == Message(role="assistant", content="old answer")
+    assert second_messages[0] == Message(role="user", content="old question")
+    assert second_messages[1] == Message(role="assistant", content="old answer")
+    assert [_message_item_hash(message) for message in first_messages[0:2]] == [
+        _message_item_hash(message) for message in second_messages[0:2]
+    ]
+    old_prefix_payload = json.dumps(
+        [message.model_dump(mode="json", exclude_none=True) for message in second_messages[0:2]],
+        ensure_ascii=False,
+    )
+    assert "<memory_context>volatile two</memory_context>" not in old_prefix_payload

--- a/tests/test_engine/test_session_sanitize.py
+++ b/tests/test_engine/test_session_sanitize.py
@@ -168,9 +168,7 @@ class CopiedProjectionToolLoopCapturingProvider(LargeArgumentToolLoopCapturingPr
             "field: code\n"
             f"original_chars: {len(self.code)}\n"
             f"original_input_chars: {len(self.code)}\n"
-            "sha256: "
-            + hashlib.sha256(self.code.encode("utf-8")).hexdigest()
-            + "\n"
+            "sha256: " + hashlib.sha256(self.code.encode("utf-8")).hexdigest() + "\n"
             "tool_argument_handle: tr-1234567890abcdef1234567890abcdef\n"
             "omitted_chars: 123\n"
             "reason: legacy test marker\n"
@@ -880,6 +878,7 @@ def test_agent_provider_view_scrubs_legacy_projected_tool_argument(tmp_path) -> 
     ]
     assert all("tool_use_argument_projection" not in content for content in stored_contents)
 
+
 def test_agent_provider_view_does_not_project_aggregate_tool_use_arguments(tmp_path) -> None:
     agent = Agent(
         provider=CapturingProvider(),
@@ -912,9 +911,7 @@ def test_agent_provider_view_does_not_project_aggregate_tool_use_arguments(tmp_p
     projected = agent._sanitize_projected_tool_use_arguments_for_provider(messages)
 
     projected_blocks = [
-        block
-        for block in projected[0].content
-        if isinstance(block, ContentBlockToolUse)
+        block for block in projected[0].content if isinstance(block, ContentBlockToolUse)
     ]
     assert all(block.input["content"] == "x" * 700 for block in projected_blocks)
     assert all(
@@ -976,6 +973,7 @@ def test_agent_provider_view_derives_tool_result_budget_above_legacy_default(
     assert first_result.content.startswith("FETCH_DERIVED_0")
     assert "external_tool_result_compacted" not in first_result.content
 
+
 def test_agent_provider_view_does_not_project_small_aggregate_tool_use_arguments(tmp_path) -> None:
     agent = Agent(
         provider=CapturingProvider(),
@@ -1008,9 +1006,7 @@ def test_agent_provider_view_does_not_project_small_aggregate_tool_use_arguments
     projected = agent._sanitize_projected_tool_use_arguments_for_provider(messages)
 
     projected_blocks = [
-        block
-        for block in projected[0].content
-        if isinstance(block, ContentBlockToolUse)
+        block for block in projected[0].content if isinstance(block, ContentBlockToolUse)
     ]
     assert all(block.input["content"] == "x" * 200 for block in projected_blocks)
     assert all(block.input["path"].startswith("generated/") for block in projected_blocks)
@@ -1056,9 +1052,7 @@ def test_agent_provider_view_keeps_successful_file_write_argument_executable(tmp
     projected = agent._sanitize_projected_tool_use_arguments_for_provider(messages)
 
     projected_tool_use = next(
-        block
-        for block in projected[0].content
-        if isinstance(block, ContentBlockToolUse)
+        block for block in projected[0].content if isinstance(block, ContentBlockToolUse)
     )
     projected_content = projected_tool_use.input["content"]
     assert projected_tool_use.id == "write-1"
@@ -1069,16 +1063,12 @@ def test_agent_provider_view_keeps_successful_file_write_argument_executable(tmp
     assert "successful_file_write_projection" not in projected_content
     assert "<p>word</p>" in projected_content
     projected_result = next(
-        block
-        for block in projected[1].content
-        if isinstance(block, ContentBlockToolResult)
+        block for block in projected[1].content if isinstance(block, ContentBlockToolResult)
     )
     assert projected_result.tool_use_id == "write-1"
     assert projected[-1].role == "user"
     history_block = next(
-        block
-        for block in messages[0].content
-        if isinstance(block, ContentBlockToolUse)
+        block for block in messages[0].content if isinstance(block, ContentBlockToolUse)
     )
     assert history_block.input["content"] == large_html
     assert "tool_argument_projection_applied" not in agent.config.metadata
@@ -1706,6 +1696,62 @@ def test_agent_provider_request_messages_project_overflow_retry_tool_results(
 
 
 @pytest.mark.asyncio
+async def test_agent_inline_strict_flush_receipt_refuses_destructive_compaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = Agent(
+        provider=CapturingProvider(),
+        config=AgentConfig(
+            context_window_tokens=10,
+            context_overflow_threshold=0.1,
+            flush_enabled=True,
+            flush_timeout_seconds=0.1,
+            flush_compaction_requires_safe_receipt=True,
+        ),
+    )
+    messages = [Message(role="user", content="important history")]
+    compact_called = False
+
+    monkeypatch.setattr(
+        "opensquilla.memory.flush.should_flush",
+        lambda **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        "opensquilla.memory.flush.resolve_flush_plan",
+        lambda **_kwargs: SimpleNamespace(relative_path="flush.md"),
+    )
+
+    async def degraded_flush(_plan: Any, _messages: list[Message]) -> Any:
+        return SimpleNamespace(
+            mode="llm",
+            indexed_chunk_count=1,
+            integrity_status="missing_chunks",
+            output_coverage_status="ok",
+            invalid_candidate_count=0,
+            candidate_missing_ids=[],
+            obligation_status="ok",
+            obligation_missing_ids=[],
+        )
+
+    async def compact_context_should_not_run(_request: Any) -> Any:
+        nonlocal compact_called
+        compact_called = True
+        return SimpleNamespace(summary="", kept_entries=[], removed_count=0)
+
+    monkeypatch.setattr(agent, "_run_flush", degraded_flush)
+    monkeypatch.setattr(
+        "opensquilla.engine.agent.compact_context",
+        compact_context_should_not_run,
+    )
+
+    outcome = await agent._check_context_overflow(messages, total_tokens=100)
+
+    assert outcome is None
+    assert compact_called is False
+    assert agent._last_compaction_refusal_reason == "memory_flush_degraded_before_compaction"
+
+
+@pytest.mark.asyncio
 async def test_agent_keeps_large_tool_arguments_during_tool_replay(tmp_path) -> None:
     large_code = "print('start')\n" + ("x = 1\n" * 500) + "print('end')\n"
     provider = LargeArgumentToolLoopCapturingProvider(large_code)
@@ -1743,9 +1789,7 @@ async def test_agent_keeps_large_tool_arguments_during_tool_replay(tmp_path) -> 
         and any(getattr(block, "type", None) == "tool_use" for block in message.content)
     )
     replay_block = next(
-        block
-        for block in assistant_replay.content
-        if isinstance(block, ContentBlockToolUse)
+        block for block in assistant_replay.content if isinstance(block, ContentBlockToolUse)
     )
     assert replay_block.input["code"] == large_code
     assert "tool_use_argument_projection" not in replay_block.input["code"]

--- a/tests/test_engine/test_session_sanitize.py
+++ b/tests/test_engine/test_session_sanitize.py
@@ -1527,16 +1527,16 @@ async def test_agent_request_context_is_request_only_after_history() -> None:
     assert "<memory_context>volatile recall</memory_context>" not in call["config"].system
     assert [message.role for message in call["messages"]] == [
         "user",
-        "user",
         "assistant",
         "user",
         "user",
+        "user",
     ]
-    assert "[Request context for this turn]" in call["messages"][0].content
-    assert "<memory_context>volatile recall</memory_context>" in call["messages"][0].content
-    assert call["messages"][1] == Message(role="user", content="old question")
-    assert call["messages"][2] == Message(role="assistant", content="old answer")
-    assert "[Available skills for this turn]" in call["messages"][3].content
+    assert call["messages"][0] == Message(role="user", content="old question")
+    assert call["messages"][1] == Message(role="assistant", content="old answer")
+    assert "[Available skills for this turn]" in call["messages"][2].content
+    assert "[Request context for this turn]" in call["messages"][3].content
+    assert "<memory_context>volatile recall</memory_context>" in call["messages"][3].content
     assert call["messages"][4].content.startswith("hello")
     assert "[Runtime context for this turn]" in call["messages"][4].content
     assert all(

--- a/tests/test_engine/test_t3_upgrade_compaction.py
+++ b/tests/test_engine/test_t3_upgrade_compaction.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from opensquilla.engine import runtime as runtime_module
 from opensquilla.engine.pipeline import TurnContext
 from opensquilla.engine.runtime import TurnRunner
 from opensquilla.session.models import TranscriptEntry
@@ -28,6 +29,26 @@ class _FakeSessionManager:
     async def compact(self, session_key: str, context_window_tokens: int, **kwargs: Any) -> str:
         self.compact_calls.append((session_key, context_window_tokens))
         return "summary"
+
+
+class _ResultCompactionSessionManager(_FakeSessionManager):
+    async def compact_with_result(
+        self,
+        session_key: str,
+        context_window_tokens: int,
+        config: object | None = None,
+    ) -> SimpleNamespace:
+        self.compact_calls.append((session_key, context_window_tokens))
+        return SimpleNamespace(
+            summary="summary",
+            kept_entries=[{"role": "assistant", "content": "tail"}],
+            removed_count=2,
+            chunks_processed=1,
+            summary_source="llm",
+            tokens_before=300,
+            tokens_after=100,
+            remaining_budget_tokens=context_window_tokens - 100,
+        )
 
 
 @dataclass(frozen=True)
@@ -74,6 +95,7 @@ class _FakeFlushService:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _sample_transcript() -> list[TranscriptEntry]:
     return [
@@ -131,6 +153,7 @@ def _make_runner(
     flush_enabled: bool = True,
     flush_timeout_seconds: float = 15.0,
     flush_background_timeout_seconds: float = 120.0,
+    flush_compaction_requires_safe_receipt: bool = False,
 ) -> TurnRunner:
     config = SimpleNamespace(
         squilla_router=SimpleNamespace(upgrade_to_t3_compaction_enabled=enabled),
@@ -138,6 +161,7 @@ def _make_runner(
             flush_enabled=flush_enabled,
             flush_timeout_seconds=flush_timeout_seconds,
             flush_background_timeout_seconds=flush_background_timeout_seconds,
+            flush_compaction_requires_safe_receipt=flush_compaction_requires_safe_receipt,
         ),
     )
     return TurnRunner(
@@ -160,14 +184,55 @@ async def test_t2_to_t3_triggers_flush_then_compact() -> None:
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
     turn = _make_turn(routed_tier="t3", previous_tier="t2")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
     assert len(fs.execute_calls) == 1
     assert len(sm.compact_calls) == 1
     assert sm.compact_calls[0] == ("agent:main:webchat:default", 100_000)
+
+
+@pytest.mark.asyncio
+async def test_t3_completed_event_reports_compaction_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sm = _ResultCompactionSessionManager(_sample_transcript())
+    fs = _FakeFlushService()
+    events: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        runtime_module,
+        "notify_compaction",
+        lambda session_key, **payload: events.append((session_key, payload)),
+    )
+    runner = _make_runner(session_manager=sm, flush_service=fs)
+
+    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
+
+    assert result == "handled"
+    assert [(key, payload["status"]) for key, payload in events] == [
+        ("agent:main:webchat:default", "started"),
+        ("agent:main:webchat:default", "completed"),
+    ]
+    compaction_ids = {payload.get("compaction_id") for _, payload in events}
+    assert len(compaction_ids) == 1
+    assert None not in compaction_ids
+    assert events[0][1]["event"] == "compaction.triggered"
+    completed = events[-1][1]
+    assert completed["event"] == "compaction.persisted"
+    assert completed["event_chain"] == [
+        "compaction.triggered",
+        "compaction.chunk_summarized",
+        "compaction.summary_verified",
+        "compaction.persisted",
+    ]
+    assert completed["coverage_status"] == "unknown"
+    assert completed["chunk_count"] == 1
+    assert completed["summary_source"] == "llm"
+    assert completed["removed_count"] == 2
+    assert completed["kept_count"] == 1
+    assert completed["tokens_after"] == 100
+    assert completed["remaining_budget_tokens"] == 99_900
 
 
 @pytest.mark.asyncio
@@ -194,9 +259,7 @@ async def test_t3_to_t3_skips() -> None:
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
     turn = _make_turn(routed_tier="t3", previous_tier="t3")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "not_applicable"
     assert len(fs.execute_calls) == 0
@@ -210,9 +273,7 @@ async def test_non_t3_route_skips() -> None:
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
     turn = _make_turn(routed_tier="t1", previous_tier="t0")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "not_applicable"
     assert len(fs.execute_calls) == 0
@@ -226,9 +287,7 @@ async def test_config_disabled_skips() -> None:
     runner = _make_runner(session_manager=sm, flush_service=fs, enabled=False)
 
     turn = _make_turn(routed_tier="t3", previous_tier="t2")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "not_applicable"
     assert len(fs.execute_calls) == 0
@@ -242,9 +301,7 @@ async def test_observe_mode_skips() -> None:
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
     turn = _make_turn(routed_tier="t3", previous_tier="t2", routing_applied=False)
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "not_applicable"
     assert len(fs.execute_calls) == 0
@@ -258,9 +315,7 @@ async def test_flush_raises_does_not_block_compaction() -> None:
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
     turn = _make_turn(routed_tier="t3", previous_tier="t2")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
     assert len(fs.execute_calls) == 1
@@ -274,9 +329,7 @@ async def test_flush_error_receipt_does_not_block_compaction() -> None:
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
     turn = _make_turn(routed_tier="t3", previous_tier="t2")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
     assert len(fs.execute_calls) == 1
@@ -303,13 +356,29 @@ async def test_degraded_flush_receipts_do_not_block_compaction(
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
     turn = _make_turn(routed_tier="t3", previous_tier="t2")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
     assert len(fs.execute_calls) == 1
     assert len(sm.compact_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_t3_strict_flush_receipt_skips_destructive_compaction() -> None:
+    sm = _FakeSessionManager(_sample_transcript())
+    fs = _FakeFlushService(receipt=_FakeFlushReceipt(integrity_status="missing_chunks"))
+    runner = _make_runner(
+        session_manager=sm,
+        flush_service=fs,
+        flush_compaction_requires_safe_receipt=True,
+    )
+
+    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
+
+    assert result == "handled"
+    assert len(fs.execute_calls) == 1
+    assert sm.compact_calls == []
 
 
 @pytest.mark.asyncio
@@ -319,9 +388,7 @@ async def test_backfilled_flush_receipt_allows_compact() -> None:
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
     turn = _make_turn(routed_tier="t3", previous_tier="t2")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
     assert len(fs.execute_calls) == 1
@@ -340,9 +407,7 @@ async def test_t3_flush_uses_background_timeout_for_service_call() -> None:
     )
 
     turn = _make_turn(routed_tier="t3", previous_tier="t2")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
     assert fs.execute_calls[0]["timeout"] == 42.0
@@ -355,9 +420,7 @@ async def test_t3_flush_uses_longer_default_background_timeout() -> None:
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
     turn = _make_turn(routed_tier="t3", previous_tier="t2")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
     assert fs.execute_calls[0]["timeout"] == 120.0
@@ -375,9 +438,7 @@ async def test_t3_flush_grace_timeout_does_not_block_compaction() -> None:
     )
 
     turn = _make_turn(routed_tier="t3", previous_tier="t2")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
     assert fs.execute_calls[0]["timeout"] == 42.0
@@ -394,9 +455,7 @@ async def test_memory_flush_disabled_compacts_without_flush_service() -> None:
     )
 
     turn = _make_turn(routed_tier="t3", previous_tier="t2")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
     assert len(sm.compact_calls) == 1
@@ -413,9 +472,7 @@ async def test_env_flush_disabled_compacts_without_flush_service(
     runner = _make_runner(session_manager=sm, flush_service=None)
 
     turn = _make_turn(routed_tier="t3", previous_tier="t2")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
     assert len(sm.compact_calls) == 1
@@ -433,9 +490,7 @@ async def test_compact_raises_continues() -> None:
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
     turn = _make_turn(routed_tier="t3", previous_tier="t2")
-    result = await runner._maybe_compact_on_t3_upgrade(
-        "agent:main:webchat:default", turn, 100_000
-    )
+    result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "compact_failed"
     assert len(fs.execute_calls) == 1

--- a/tests/test_gateway/test_context_overflow.py
+++ b/tests/test_gateway/test_context_overflow.py
@@ -46,6 +46,22 @@ class _FakeSessionManager:
         return "[summary]"
 
 
+class _ResultCompactionSessionManager(_FakeSessionManager):
+    async def compact_with_result(self, session_key: str, budget: int, config=None):
+        self.compact_calls.append((session_key, budget, config))
+        self._transcript = [_FakeEntry(content="[summary]")]
+        return SimpleNamespace(
+            summary="[summary]",
+            kept_entries=[{"role": "assistant", "content": "[tail]"}],
+            removed_count=5,
+            chunks_processed=2,
+            summary_source="llm",
+            tokens_before=900,
+            tokens_after=90,
+            remaining_budget_tokens=max(budget - 90, 0),
+        )
+
+
 class _InsufficientCompactionSessionManager(_FakeSessionManager):
     async def compact(self, session_key: str, budget: int, config=None) -> str:
         self.compact_calls.append((session_key, budget, config))
@@ -146,9 +162,7 @@ def _cfg(
             "flush_enabled": flush_enabled,
             "flush_timeout_seconds": flush_timeout_seconds,
             "flush_background_timeout_seconds": flush_background_timeout_seconds,
-            "flush_compaction_requires_safe_receipt": (
-                flush_compaction_requires_safe_receipt
-            ),
+            "flush_compaction_requires_safe_receipt": (flush_compaction_requires_safe_receipt),
         },
     )
 
@@ -307,7 +321,7 @@ async def test_auto_summarize_emits_started_and_completed_events(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cfg = _cfg(ContextOverflowPolicy.AUTO_SUMMARIZE, budget=10)
-    sm = _FakeSessionManager(_history(6, 40))
+    sm = _ResultCompactionSessionManager(_history(6, 40))
     events: list[tuple[str, dict[str, Any]]] = []
     monkeypatch.setattr(
         context_overflow,
@@ -330,6 +344,25 @@ async def test_auto_summarize_emits_started_and_completed_events(
     ]
     assert all(payload["source"] == "automatic" for _, payload in events)
     assert all(payload["phase"] == "gateway_auto_summarize" for _, payload in events)
+    compaction_ids = {payload.get("compaction_id") for _, payload in events}
+    assert len(compaction_ids) == 1
+    assert None not in compaction_ids
+    assert events[0][1]["event"] == "compaction.triggered"
+    completed = events[-1][1]
+    assert completed["event"] == "compaction.replayed"
+    assert completed["event_chain"] == [
+        "compaction.triggered",
+        "compaction.chunk_summarized",
+        "compaction.summary_verified",
+        "compaction.persisted",
+        "compaction.replayed",
+    ]
+    assert completed["coverage_status"] == "unknown"
+    assert completed["chunk_count"] == 2
+    assert completed["summary_source"] == "llm"
+    assert completed["removed_count"] == 5
+    assert completed["kept_count"] == 1
+    assert completed["tokens_after"] < completed["tokens_before"]
 
 
 @pytest.mark.asyncio
@@ -439,6 +472,52 @@ async def test_auto_summarize_compacts_after_degraded_flush_receipt() -> None:
     assert outcome.lifecycle.flush_receipt is outcome.flush_receipt
     assert outcome.lifecycle.refused is False
     assert sm.compact_calls == [("agent:main:s-flush", 10, None)]
+
+
+@pytest.mark.asyncio
+async def test_auto_summarize_strict_flush_receipt_refuses_before_compaction() -> None:
+    cfg = _cfg(
+        ContextOverflowPolicy.AUTO_SUMMARIZE,
+        budget=10,
+        flush_enabled=True,
+        flush_compaction_requires_safe_receipt=True,
+    )
+    sm = _FakeSessionManager(_history(6, 40))
+    flush_service = SimpleNamespace(
+        execute=AsyncMock(
+            return_value=SimpleNamespace(
+                mode="llm",
+                integrity_status="missing_chunks",
+                indexed_chunk_count=1,
+                output_coverage_status="ok",
+                invalid_candidate_count=0,
+                candidate_missing_ids=[],
+                obligation_status="ok",
+                obligation_missing_ids=[],
+            )
+        )
+    )
+
+    outcome = await apply_context_overflow_policy(
+        config=cfg,
+        message="m",
+        transcript=sm._transcript,
+        session_key="agent:main:s-strict-flush",
+        session_manager=sm,
+        flush_service=flush_service,
+    )
+
+    assert outcome.over_budget is True
+    assert outcome.summarized is False
+    assert outcome.retried is False
+    assert outcome.reason == "compaction_flush_failed"
+    assert outcome.refusal is not None
+    assert outcome.refusal["error"]["reason"] == "compaction_flush_failed"
+    assert outcome.flush_receipt is not None
+    assert outcome.lifecycle is not None
+    assert outcome.lifecycle.refused is True
+    assert outcome.lifecycle.reason == "compaction_flush_failed"
+    assert sm.compact_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_openrouter_prompt_cache_smoke.py
+++ b/tests/test_openrouter_prompt_cache_smoke.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_smoke_module():
+    script_path = (
+        Path(__file__).resolve().parents[1] / "scripts" / "live_openrouter_prompt_cache_smoke.py"
+    )
+    spec = importlib.util.spec_from_file_location("live_openrouter_prompt_cache_smoke", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+smoke = _load_smoke_module()
+
+
+def test_cache_smoke_defaults_to_zai_glm_5_1() -> None:
+    assert smoke.DEFAULT_MODEL == "z-ai/glm-5.1"
+
+
+def test_cached_prompt_tokens_reads_openai_prompt_details() -> None:
+    payload = {"usage": {"prompt_tokens_details": {"cached_tokens": 42}}}
+
+    assert smoke._cached_prompt_tokens(payload) == 42
+
+
+def test_cached_prompt_tokens_reads_openrouter_cache_fields() -> None:
+    payload = {"usage": {"prompt_cache_hit_tokens": 13}}
+
+    assert smoke._cached_prompt_tokens(payload) == 13
+
+
+def test_cache_request_payload_marks_only_system_text_as_ephemeral() -> None:
+    payload = smoke._cache_request_payload("z-ai/glm-5.1", "stable text")
+
+    assert payload["model"] == "z-ai/glm-5.1"
+    system = payload["messages"][0]
+    assert system["role"] == "system"
+    assert system["content"] == [
+        {
+            "type": "text",
+            "text": "stable text",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+    assert payload["messages"][1]["role"] == "user"

--- a/tests/test_provider_openai_prompt_cache.py
+++ b/tests/test_provider_openai_prompt_cache.py
@@ -5,6 +5,7 @@ import json
 from typing import Any
 
 import httpx
+import structlog.testing
 
 from opensquilla.provider.openai import OpenAIProvider
 from opensquilla.provider.types import ChatConfig, DoneEvent, Message
@@ -127,6 +128,49 @@ def test_openrouter_deepseek_auto_cache_does_not_add_top_level_cache_control(mon
     assert "cache_control" not in payload
     assert len(payload["messages"][0]["content"]) == 1
     assert payload["messages"][0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_openrouter_zai_auto_cache_requires_live_capability_proof(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+    _patch_openai_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="z-ai/glm-5.1",
+        base_url="https://openrouter.ai/api/v1",
+    )
+    cfg = ChatConfig(
+        system="stable base",
+        cache_breakpoints=[{"text": "stable base", "cache": "true"}],
+        cache_mode="auto",
+    )
+
+    _collect_done(provider, cfg)
+
+    payload = captured["payload"]
+    assert "cache_control" not in payload
+    assert payload["messages"][0] == {"role": "system", "content": "stable base"}
+
+
+def test_openrouter_payload_cache_shape_logs_fixed_prefix_item_hashes(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+    _patch_openai_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek/deepseek-v4-pro",
+        base_url="https://openrouter.ai/api/v1",
+    )
+    cfg = ChatConfig(
+        system="stable base",
+        cache_breakpoints=[{"text": "stable base", "cache": "true"}],
+        cache_mode="auto",
+    )
+
+    with structlog.testing.capture_logs() as logs:
+        _collect_done(provider, cfg)
+
+    event = next(row for row in logs if row.get("event") == "openrouter.payload_cache_shape")
+    assert event["first_non_system_hash"]
+    assert event["non_system_prefix_item_hashes"] == [event["first_non_system_hash"]]
 
 
 def test_openrouter_anthropic_cache_off_does_not_add_cache_control(monkeypatch) -> None:

--- a/tests/test_provider_openai_prompt_cache.py
+++ b/tests/test_provider_openai_prompt_cache.py
@@ -5,8 +5,8 @@ import json
 from typing import Any
 
 import httpx
-import structlog.testing
 
+from opensquilla.provider import openai as openai_module
 from opensquilla.provider.openai import OpenAIProvider
 from opensquilla.provider.types import ChatConfig, DoneEvent, Message
 
@@ -165,10 +165,20 @@ def test_openrouter_payload_cache_shape_logs_fixed_prefix_item_hashes(monkeypatc
         cache_mode="auto",
     )
 
-    with structlog.testing.capture_logs() as logs:
-        _collect_done(provider, cfg)
+    log_events: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        openai_module.log,
+        "debug",
+        lambda event, **payload: log_events.append((event, payload)),
+    )
 
-    event = next(row for row in logs if row.get("event") == "openrouter.payload_cache_shape")
+    _collect_done(provider, cfg)
+
+    event = next(
+        payload
+        for name, payload in log_events
+        if name == "openrouter.payload_cache_shape"
+    )
     assert event["first_non_system_hash"]
     assert event["non_system_prefix_item_hashes"] == [event["first_non_system_hash"]]
 

--- a/tests/test_tools/test_dispatch_envelope.py
+++ b/tests/test_tools/test_dispatch_envelope.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 
 import pytest
+import structlog.testing
 
 from opensquilla.engine.types import ToolCall
 from opensquilla.result_budget import (
@@ -11,6 +12,7 @@ from opensquilla.result_budget import (
     ToolResultBudgetPolicy,
     ToolRunBudgetExceededError,
     ToolRunBudgetPolicy,
+    build_webresearch_tool_run_budget_policy,
 )
 from opensquilla.tools.dispatch import build_tool_handler
 from opensquilla.tools.registry import ToolRegistry
@@ -65,6 +67,16 @@ def _strict_preview_chars(content: str) -> int:
     preview = payload.get("preview", "")
     assert isinstance(preview, str)
     return len(preview)
+
+
+def test_webresearch_budget_profile_builder_preserves_unlimited_call_defaults() -> None:
+    policy = build_webresearch_tool_run_budget_policy()
+
+    assert policy.max_web_search_calls_per_turn is None
+    assert policy.max_web_fetch_calls_per_turn is None
+    assert policy.max_external_text_chars_per_turn is None
+    assert policy.max_single_fetch_chars == 50_000
+    assert policy.max_web_search_results == 10
 
 
 def test_default_tool_run_budget_leaves_room_for_complex_turns() -> None:
@@ -684,7 +696,7 @@ async def test_dispatch_run_budget_blocks_exhausted_external_call_before_handler
                 max_web_fetch_calls_per_turn=1,
                 max_single_fetch_chars=500,
                 max_external_text_chars_per_turn=1_000,
-            )
+            ),
         ),
     )
 
@@ -748,7 +760,7 @@ async def test_dispatch_run_budget_abort_releases_failed_external_reservation() 
                 max_web_fetch_calls_per_turn=1,
                 max_single_fetch_chars=400,
                 max_external_text_chars_per_turn=400,
-            )
+            ),
         ),
     )
 
@@ -856,7 +868,7 @@ async def test_dispatch_run_budget_limits_concurrent_external_calls_atomically()
                 max_web_fetch_calls_per_turn=1,
                 max_single_fetch_chars=400,
                 max_external_text_chars_per_turn=1_000,
-            )
+            ),
         ),
     )
 
@@ -919,7 +931,7 @@ async def test_dispatch_run_budget_allows_oversized_result_then_controls_retry()
                 max_web_fetch_calls_per_turn=2,
                 max_single_fetch_chars=200,
                 max_external_text_chars_per_turn=200,
-            )
+            ),
         ),
     )
 
@@ -952,6 +964,49 @@ async def test_dispatch_run_budget_allows_oversized_result_then_controls_retry()
 
 
 @pytest.mark.asyncio
+async def test_dispatch_logs_webresearch_run_diagnostics_without_default_call_caps() -> None:
+    registry = ToolRegistry()
+
+    async def web_search(query: str, max_results: int | None = None) -> str:
+        return json.dumps({"query": query, "results": ["one", "two"]})
+
+    registry.register(
+        ToolSpec(
+            name="web_search",
+            description="search",
+            parameters={"query": {"type": "string"}, "max_results": {"type": "integer"}},
+            result_budget_class="external",
+        ),
+        web_search,
+    )
+    handler = build_tool_handler(
+        registry,
+        ToolContext(tool_run_budget_key="dispatch-test-search-diagnostics"),
+    )
+
+    with structlog.testing.capture_logs() as logs:
+        result = await handler(
+            ToolCall(
+                tool_use_id="tc-search-diagnostics",
+                tool_name="web_search",
+                arguments={"query": "test", "max_results": 3},
+            )
+        )
+
+    assert result.is_error is False
+    assert json.loads(result.content)["results"] == ["one", "two"]
+    event = next(
+        row for row in logs if row.get("event") == "dispatch.webresearch_tool_run_diagnostics"
+    )
+    assert event["tool"] == "web_search"
+    assert event["tool_use_id"] == "tc-search-diagnostics"
+    assert event["web_search_calls_used"] == 1
+    assert event["web_fetch_calls_used"] == 0
+    assert event["external_text_chars_used"] >= len(result.content)
+    assert event["tool_wall_time_ms"] >= 0
+
+
+@pytest.mark.asyncio
 async def test_dispatch_run_budget_charges_web_search_external_text() -> None:
     registry = ToolRegistry()
 
@@ -974,7 +1029,7 @@ async def test_dispatch_run_budget_charges_web_search_external_text() -> None:
             tool_run_budget_policy=ToolRunBudgetPolicy(
                 max_web_search_calls_per_turn=2,
                 max_external_text_chars_per_turn=200,
-            )
+            ),
         ),
     )
 
@@ -1198,9 +1253,7 @@ async def test_dispatch_preserves_sessions_yield_control_json_when_bounding() ->
     handler = build_tool_handler(
         registry,
         ToolContext(
-            tool_result_budget_policy=ToolResultBudgetPolicy(
-                max_single_tool_result_chars=160
-            )
+            tool_result_budget_policy=ToolResultBudgetPolicy(max_single_tool_result_chars=160)
         ),
     )
 

--- a/tests/test_tools/test_dispatch_envelope.py
+++ b/tests/test_tools/test_dispatch_envelope.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 
 import pytest
-import structlog.testing
 
 from opensquilla.engine.types import ToolCall
 from opensquilla.result_budget import (
@@ -14,6 +13,7 @@ from opensquilla.result_budget import (
     ToolRunBudgetPolicy,
     build_webresearch_tool_run_budget_policy,
 )
+from opensquilla.tools import dispatch as dispatch_module
 from opensquilla.tools.dispatch import build_tool_handler
 from opensquilla.tools.registry import ToolRegistry
 from opensquilla.tools.types import (
@@ -964,7 +964,9 @@ async def test_dispatch_run_budget_allows_oversized_result_then_controls_retry()
 
 
 @pytest.mark.asyncio
-async def test_dispatch_logs_webresearch_run_diagnostics_without_default_call_caps() -> None:
+async def test_dispatch_logs_webresearch_run_diagnostics_without_default_call_caps(
+    monkeypatch,
+) -> None:
     registry = ToolRegistry()
 
     async def web_search(query: str, max_results: int | None = None) -> str:
@@ -984,19 +986,27 @@ async def test_dispatch_logs_webresearch_run_diagnostics_without_default_call_ca
         ToolContext(tool_run_budget_key="dispatch-test-search-diagnostics"),
     )
 
-    with structlog.testing.capture_logs() as logs:
-        result = await handler(
-            ToolCall(
-                tool_use_id="tc-search-diagnostics",
-                tool_name="web_search",
-                arguments={"query": "test", "max_results": 3},
-            )
+    log_events: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        dispatch_module.log,
+        "debug",
+        lambda event, **payload: log_events.append((event, payload)),
+    )
+
+    result = await handler(
+        ToolCall(
+            tool_use_id="tc-search-diagnostics",
+            tool_name="web_search",
+            arguments={"query": "test", "max_results": 3},
         )
+    )
 
     assert result.is_error is False
     assert json.loads(result.content)["results"] == ["one", "two"]
     event = next(
-        row for row in logs if row.get("event") == "dispatch.webresearch_tool_run_diagnostics"
+        payload
+        for name, payload in log_events
+        if name == "dispatch.webresearch_tool_run_diagnostics"
     )
     assert event["tool"] == "web_search"
     assert event["tool_use_id"] == "tc-search-diagnostics"


### PR DESCRIPTION
## Summary

This PR contains agent runtime cache/flush/compaction-observability hardening.

- Stabilizes provider-visible prompt/cache inputs by keeping dynamic request context out of the early persisted history prefix.
- Adds strict flush receipt gating for destructive compaction when explicitly enabled.
- Adds compaction lifecycle diagnostics for cache/runtime investigation, including correlated compaction IDs and metadata.
- Adds opt-in OpenRouter live smoke coverage for prompt cache and compaction behavior.

## Scope

This does not change the default webresearch/tool-call budget behavior, does not whitelist z-ai/glm explicit cache without live proof, and does not implement structured summary or provider-native compaction.

## Verification

- Targeted pytest suite: 367 passed, 1 skipped.
- Ruff check on touched runtime/test surfaces: passed.
- git diff --check: passed.
