### PR TITLE
Fix WebUI session-scoped hotfix regressions

### DIFF
--- a/src/opensquilla/gateway/static/js/views/channels.js
+++ b/src/opensquilla/gateway/static/js/views/channels.js
@@ -73,9 +73,12 @@ const ChannelsView = (() => {
 
   async function _loadData() {
     if (!_el) return;
-    await _rpc.waitForConnection();
+    const rpc = _rpc;
+    if (!rpc) return;
+    await rpc.waitForConnection();
+    if (!_el || _rpc !== rpc) return;
 
-    _rpc.call('channels.status').then(data => {
+    rpc.call('channels.status').then(data => {
       if (!_el) return;
       const raw = (data.channels || []).filter(c => c && c.configured !== false);
 

--- a/src/opensquilla/gateway/static/js/views/chat.js
+++ b/src/opensquilla/gateway/static/js/views/chat.js
@@ -526,38 +526,65 @@ const ChatView = (() => {
     return ok ? Promise.resolve() : Promise.reject(new Error('Copy failed'));
   }
 
-  // Re-send the most recent user turn. Pops the trailing assistant bubble
-  // from DOM + _messages and re-issues chat.send with the same text.
-  function _regenerateLastTurn() {
+  // Re-send the user turn that produced the clicked assistant bubble.
+  // Pops that assistant bubble and any later turns from DOM + _messages.
+  function _regenerateAssistantBubble(bubble) {
     if (_isStreaming) {
       UI.toast('Wait for the current response to finish', 'warn', 2000);
       return;
     }
-    // Find last user message in _messages.
-    let lastUserIdx = -1;
-    for (let i = _messages.length - 1; i >= 0; i--) {
-      if (_messages[i].role === 'user') { lastUserIdx = i; break; }
+    if (!bubble || !_thread) {
+      UI.toast('No response to regenerate', 'info', 2000);
+      return;
     }
-    if (lastUserIdx < 0) {
+
+    const assistantBubbles = Array.from(_thread.querySelectorAll(':scope > .msg.assistant'));
+    const assistantOrdinal = assistantBubbles.indexOf(bubble);
+    if (assistantOrdinal < 0) {
+      UI.toast('No response to regenerate', 'info', 2000);
+      return;
+    }
+
+    let assistantSeen = -1;
+    let assistantIdx = -1;
+    for (let i = 0; i < _messages.length; i++) {
+      if (_messages[i].role !== 'assistant') continue;
+      assistantSeen++;
+      if (assistantSeen === assistantOrdinal) {
+        assistantIdx = i;
+        break;
+      }
+    }
+    if (assistantIdx < 0) {
+      UI.toast('No response to regenerate', 'info', 2000);
+      return;
+    }
+
+    let userIdx = -1;
+    for (let i = assistantIdx - 1; i >= 0; i--) {
+      if (_messages[i].role === 'user') { userIdx = i; break; }
+    }
+    if (userIdx < 0) {
       UI.toast('No previous message to regenerate', 'info', 2000);
       return;
     }
-    const userText = _messages[lastUserIdx].text || '';
-    // Remove trailing assistant DOM bubbles and message records after that user turn.
-    _messages.splice(lastUserIdx + 1);
-    // Walk DOM: strip everything after the corresponding user .msg in the thread.
-    if (_thread) {
-      const userBubbles = _thread.querySelectorAll(':scope > .msg.user');
-      const target = userBubbles[userBubbles.length - 1];
-      if (target) {
-        let nxt = target.nextElementSibling;
-        while (nxt) {
-          const toRemove = nxt;
-          nxt = nxt.nextElementSibling;
-          toRemove.remove();
-        }
+
+    const userText = _messages[userIdx].text || '';
+    _messages.splice(userIdx + 1);
+
+    let target = bubble.previousElementSibling;
+    while (target && !target.matches('.msg.user')) {
+      target = target.previousElementSibling;
+    }
+    if (target) {
+      let nxt = target.nextElementSibling;
+      while (nxt) {
+        const toRemove = nxt;
+        nxt = nxt.nextElementSibling;
+        toRemove.remove();
       }
     }
+
     _textarea.value = userText;
     _autoResizeTextarea();
     // Trigger send synchronously — _onSend will read _textarea.
@@ -636,7 +663,7 @@ const ChatView = (() => {
           .then(() => UI.toast('Copied', 'info', 1200))
           .catch((err) => UI.toast('Copy failed: ' + err.message, 'err', 2500));
       } else if (action === 'regenerate') {
-        _regenerateLastTurn();
+        _regenerateAssistantBubble(bubble);
       } else if (action === 'edit') {
         _editUserBubble(bubble);
       }
@@ -2493,6 +2520,7 @@ const ChatView = (() => {
     }));
 
     _unsubs.push(_rpc.on('task.queued', (payload) => {
+      if (!_isCurrentSessionPayload(payload)) return;
       _applySessionRunState({
         run_status: 'queued',
         active_task: { ...(payload || {}), status: 'queued' },
@@ -2500,6 +2528,7 @@ const ChatView = (() => {
     }));
 
     _unsubs.push(_rpc.on('task.running', (payload) => {
+      if (!_isCurrentSessionPayload(payload)) return;
       _applySessionRunState({
         run_status: 'running',
         active_task: { ...(payload || {}), status: 'running' },
@@ -2534,6 +2563,7 @@ const ChatView = (() => {
     _unsubs.push(_rpc.on('*', (rawEvent, rawPayload) => {
       const terminalStatus = _taskTerminalStatus(rawEvent);
       if (terminalStatus) {
+        if (!_isCurrentSessionPayload(rawPayload)) return;
         const terminalRunStatus = terminalStatus === 'succeeded' ? 'idle'
           : terminalStatus === 'abandoned' ? 'interrupted'
           : terminalStatus;
@@ -4661,11 +4691,21 @@ const ChatView = (() => {
     const head = _pendingQueue.shift();
     _renderPendingQueue();
     setTimeout(() => {
+      const draftText = _textarea.value;
+      const draftAttachments = _pendingAttachments.map(att => ({ ...att }));
+      const draftIntent = _pendingSessionIntent;
       _textarea.value = head.text || '';
       _pendingAttachments = head.attachments || [];
       _pendingSessionIntent = head.intent || null;
       _renderAttachmentPreview();
       _onSend();
+      if (draftText.trim() || draftAttachments.length || draftIntent) {
+        _textarea.value = draftText;
+        _pendingAttachments = draftAttachments;
+        _pendingSessionIntent = draftIntent;
+        _renderAttachmentPreview();
+        _autoResizeTextarea();
+      }
     }, 0);
   }
 

--- a/src/opensquilla/gateway/static/js/views/config.js
+++ b/src/opensquilla/gateway/static/js/views/config.js
@@ -8,6 +8,8 @@ const ConfigView = (() => {
 
   let _configData = {};   // raw object from config.get
   let _yamlText = '';     // current YAML text in textarea
+  let _yamlDraft = '';
+  let _yamlDirty = false;
   let _dirty = {};        // form mode: { key: { old, new } }
   let _invalidJson = {};  // form mode: { key: true }
   let _jsonDrafts = {};   // form mode JSON textarea text preserved across rerenders
@@ -188,19 +190,32 @@ const ConfigView = (() => {
       });
     });
 
-    _el.querySelector('#cfg-reload').addEventListener('click', () => { _dirty = {}; _invalidJson = {}; _jsonDrafts = {}; _loadData(); });
+    _el.querySelector('#cfg-reload').addEventListener('click', () => {
+      _dirty = {};
+      _invalidJson = {};
+      _jsonDrafts = {};
+      _yamlDraft = '';
+      _yamlDirty = false;
+      _loadData();
+    });
     _el.querySelector('#cfg-guided-setup')?.addEventListener('click', () => Router.navigate('/setup'));
     _el.querySelector('#cfg-save').addEventListener('click', _save);
     _el.querySelector('#cfg-search').addEventListener('input', (e) => {
       _searchText = e.target.value.toLowerCase();
       _renderFormTabs();
     });
+    _bindYamlDraftTracking();
 
     // sticky save bar wiring
     _el.querySelector('#cfg-stickybar-save').addEventListener('click', _save);
     _el.querySelector('#cfg-stickybar-discard').addEventListener('click', () => {
-      if (Object.keys(_dirty).length === 0) return;
-      _dirty = {}; _invalidJson = {}; _jsonDrafts = {}; _diffOpen = false;
+      if (Object.keys(_dirty).length === 0 && !_yamlDirty) return;
+      _dirty = {};
+      _invalidJson = {};
+      _jsonDrafts = {};
+      _yamlDraft = '';
+      _yamlDirty = false;
+      _diffOpen = false;
       _loadData();
     });
     _el.querySelector('#cfg-stickybar-toggle').addEventListener('click', () => {
@@ -214,6 +229,7 @@ const ConfigView = (() => {
     _unsubs.push(() => document.removeEventListener('click', _onDocClickForTooltip, true));
     _unsubs.push(() => document.removeEventListener('keydown', _onDocKeyForTooltip, true));
 
+    _setMode(_mode);
     _loadData();
   }
 
@@ -225,9 +241,15 @@ const ConfigView = (() => {
     _intervals = [];
     _configData = {};
     _yamlText = '';
+    _yamlDraft = '';
+    _yamlDirty = false;
     _dirty = {};
     _invalidJson = {};
     _jsonDrafts = {};
+    _mode = 'form';
+    _activeTab = 'core';
+    _searchText = '';
+    _diffOpen = false;
     _el = null;
     _rpc = null;
   }
@@ -235,10 +257,15 @@ const ConfigView = (() => {
   // ---- data loading ----------------------------------------------------
 
   async function _loadData() {
-    await _rpc.waitForConnection();
-    _rpc.call('config.get').then(data => {
+    const rpc = _rpc;
+    if (!_el || !rpc) return;
+    await rpc.waitForConnection();
+    if (!_el || _rpc !== rpc) return;
+    rpc.call('config.get').then(data => {
+      if (!_el || _rpc !== rpc) return;
       _configData = data || {};
       _yamlText = _objToYaml(_configData);
+      if (!_yamlDirty) _yamlDraft = _yamlText;
       _invalidJson = {};
       _jsonDrafts = {};
       _renderFormTabs();
@@ -254,12 +281,23 @@ const ConfigView = (() => {
     if (!_el) return;
     // sync yaml textarea when switching to yaml
     if (m === 'yaml') {
-      _el.querySelector('#cfg-yaml-area').value = _yamlText;
+      _el.querySelector('#cfg-yaml-area').value = _yamlDirty ? _yamlDraft : _yamlText;
     }
     _el.querySelector('#cfg-form-view').style.display = m === 'form' ? '' : 'none';
     _el.querySelector('#cfg-yaml-view').style.display = m === 'yaml' ? '' : 'none';
     _el.querySelectorAll('[data-cfg-mode]').forEach(btn => {
       btn.classList.toggle('is-active', btn.dataset.cfgMode === m);
+    });
+    _renderStickybar();
+  }
+
+  function _bindYamlDraftTracking() {
+    const area = _el && _el.querySelector('#cfg-yaml-area');
+    if (!area) return;
+    area.addEventListener('input', (e) => {
+      _yamlDraft = e.target.value;
+      _yamlDirty = _yamlDraft !== _yamlText;
+      _renderStickybar();
     });
   }
 
@@ -503,20 +541,27 @@ const ConfigView = (() => {
     const bar = _el.querySelector('#cfg-stickybar');
     if (!bar) return;
     const keys = Object.keys(_dirty);
-    if (keys.length === 0) {
+    const yamlDirtyVisible = _mode === 'yaml' && _yamlDirty;
+    if (keys.length === 0 && !yamlDirtyVisible) {
       bar.hidden = true;
       _diffOpen = false;
       return;
     }
     bar.hidden = false;
-    _el.querySelector('#cfg-stickybar-count').textContent = String(keys.length);
+    _el.querySelector('#cfg-stickybar-count').textContent = String(yamlDirtyVisible ? 1 : keys.length);
     const toggle = _el.querySelector('#cfg-stickybar-toggle');
     toggle.setAttribute('aria-expanded', _diffOpen ? 'true' : 'false');
     toggle.classList.toggle('is-open', _diffOpen);
     const diff = _el.querySelector('#cfg-stickybar-diff');
     if (_diffOpen) {
       diff.hidden = false;
-      diff.innerHTML = keys.map(k => {
+      diff.innerHTML = yamlDirtyVisible ? `
+        <div class="cfg-diff-row">
+          <span class="cfg-diff-key">YAML</span>
+          <span class="cfg-diff-old">loaded config</span>
+          <span class="cfg-diff-arrow">-&gt;</span>
+          <span class="cfg-diff-new">unsaved draft</span>
+        </div>` : keys.map(k => {
         const { old: oldV, new: newV } = _dirty[k];
         return `<div class="cfg-diff-row">
           <span class="cfg-diff-key">${_esc(k)}</span>
@@ -541,7 +586,7 @@ const ConfigView = (() => {
 
   function _renderYaml() {
     const area = _el && _el.querySelector('#cfg-yaml-area');
-    if (area && _mode === 'yaml') area.value = _yamlText;
+    if (area && _mode === 'yaml') area.value = _yamlDirty ? _yamlDraft : _yamlText;
   }
 
   // ---- save -----------------------------------------------------------
@@ -550,7 +595,7 @@ const ConfigView = (() => {
     if (_mode === 'yaml') {
       const text = _el.querySelector('#cfg-yaml-area').value;
       _rpc.call('config.apply', { config_yaml: text })
-        .then(res => { UI.toast(res && res.restartRequired ? 'Config applied. Gateway restart required for the change to take effect.' : 'Config applied', res && res.restartRequired ? 'info' : 'ok'); _dirty = {}; _invalidJson = {}; _jsonDrafts = {}; _loadData(); })
+        .then(res => { UI.toast(res && res.restartRequired ? 'Config applied. Gateway restart required for the change to take effect.' : 'Config applied', res && res.restartRequired ? 'info' : 'ok'); _dirty = {}; _invalidJson = {}; _jsonDrafts = {}; _yamlDirty = false; _yamlDraft = ''; _loadData(); })
         .catch(err => UI.toast('Apply failed: ' + err.message, 'err'));
     } else {
       if (Object.keys(_invalidJson).length > 0) {

--- a/src/opensquilla/gateway/static/js/views/logs.js
+++ b/src/opensquilla/gateway/static/js/views/logs.js
@@ -16,6 +16,8 @@ const LogsView = (() => {
   let _searchText = '';
   let _autoFollow = true;
   let _status = null;
+  let _pollInFlight = false;
+  let _pollErrorShown = false;
 
   function _ensureCss() {
     if (document.querySelector('link[data-view-css="logs"]')) return;
@@ -40,6 +42,8 @@ const LogsView = (() => {
     _searchText = '';
     _autoFollow = true;
     _status = null;
+    _pollInFlight = false;
+    _pollErrorShown = false;
     _activeLevels = new Set(_DEFAULT_LEVELS);
 
     const levelChips = _LEVELS.map(l => {
@@ -137,13 +141,18 @@ const LogsView = (() => {
     _intervals = [];
     _allLines = [];
     _cursor = 0;
+    _pollInFlight = false;
+    _pollErrorShown = false;
     _el = null;
     _rpc = null;
   }
 
   async function _loadData() {
     if (!_el) return;
-    await _rpc.waitForConnection();
+    const rpc = _rpc;
+    if (!rpc) return;
+    await rpc.waitForConnection();
+    if (!_el || _rpc !== rpc) return;
     _cursor = 0;
     _allLines = [];
     await _loadStatus();
@@ -161,9 +170,13 @@ const LogsView = (() => {
   }
 
   async function _poll() {
-    if (!_el) return;
+    if (!_el || _pollInFlight) return;
+    const rpc = _rpc;
+    if (!rpc) return;
+    _pollInFlight = true;
     try {
-      const data = await _rpc.call('logs.tail', { limit: 500, cursor: _cursor, level: null });
+      const data = await rpc.call('logs.tail', { limit: 500, cursor: _cursor, level: null });
+      if (!_el || _rpc !== rpc) return;
       const lines = data.lines || data.entries || [];
       if (lines.length > 0) {
         if (data.cursor != null) {
@@ -190,8 +203,14 @@ const LogsView = (() => {
         // Render an empty placeholder
         _renderLines();
       }
-    } catch {
-      // Silently ignore poll errors — display stays intact
+      _pollErrorShown = false;
+    } catch (err) {
+      if (!_pollErrorShown) {
+        UI.toast('Log refresh failed: ' + (err?.message || 'unknown error'), 'warn');
+        _pollErrorShown = true;
+      }
+    } finally {
+      _pollInFlight = false;
     }
   }
 

--- a/src/opensquilla/gateway/static/js/views/sessions.js
+++ b/src/opensquilla/gateway/static/js/views/sessions.js
@@ -124,14 +124,17 @@ const SessionsView = (() => {
   }
 
   async function _loadData() {
-    await _rpc.waitForConnection();
+    const rpc = _rpc;
+    if (!_el || !rpc) return;
+    await rpc.waitForConnection();
+    if (!_el || _rpc !== rpc) return;
     // Fetch sessions and agents in parallel so the orphan-agent badge is
     // always rendered against fresh registry state.
     // Explicit limit=200 keeps backend default (50) intact for CLI/channel
     // consumers — only this WebUI surface opts into the larger page size.
     const [sessRes, agentsRes] = await Promise.allSettled([
-      _rpc.call('sessions.list', { limit: 200 }),
-      _rpc.call('agents.list'),
+      rpc.call('sessions.list', { limit: 200 }),
+      rpc.call('agents.list'),
     ]);
     if (!_el) return;
     if (agentsRes.status === 'fulfilled') {
@@ -529,10 +532,24 @@ const SessionsView = (() => {
        <p class="sess-modal__warn"><small>The transcript will not be flushed to disk; use <code>/reset</code> first if you want a backup.</small></p>`,
       [
         {
-          label: 'Delete', cls: 'btn-danger', onClick: () => {
-            _rpc.call('sessions.delete', { key })
-              .then(() => { UI.toast('Session deleted', 'info'); _loadData(); })
-              .catch(err => UI.toast('Delete failed: ' + err.message, 'err'));
+          label: 'Delete', cls: 'btn-danger', onClick: async () => {
+            try {
+              const res = await _rpc.call('sessions.delete', { key });
+              const errors = Array.isArray(res?.errors) ? res.errors : [];
+              const deleted = Array.isArray(res?.deleted) ? res.deleted : [];
+              if (errors.length > 0 || !deleted.includes(key)) {
+                const first = errors[0];
+                const reason = typeof first === 'string'
+                  ? first
+                  : (first?.message || first?.error || first?.reason || 'session was not deleted');
+                UI.toast('Delete failed: ' + reason, 'err');
+              } else {
+                UI.toast('Session deleted', 'info');
+              }
+            } catch (err) {
+              UI.toast('Delete failed: ' + (err?.message || 'unknown error'), 'err');
+            }
+            _loadData();
           }
         },
         { label: 'Cancel', cls: '' },

--- a/src/opensquilla/gateway/task_runtime.py
+++ b/src/opensquilla/gateway/task_runtime.py
@@ -447,7 +447,11 @@ class TaskRuntime:
             value=_queue_depth,
             session_key=envelope.session_key,
         )
-        await self._emit(envelope.session_key, "task.queued", {"task_id": record.task_id})
+        await self._emit(
+            envelope.session_key,
+            "task.queued",
+            {"task_id": record.task_id, "session_key": envelope.session_key},
+        )
         return TaskHandle(
             task_id=record.task_id,
             session_key=envelope.session_key,
@@ -1091,7 +1095,11 @@ class TaskRuntime:
             status=AgentTaskStatus.RUNNING,
             started_at=_epoch_time_ms(),
         )
-        await self._emit(task.envelope.session_key, "task.running", {"task_id": task.task_id})
+        await self._emit(
+            task.envelope.session_key,
+            "task.running",
+            {"task_id": task.task_id, "session_key": task.envelope.session_key},
+        )
         await self._notify_task_lifecycle(
             TaskLifecycleEvent(
                 phase="running",
@@ -1183,6 +1191,7 @@ class TaskRuntime:
         )
         payload: dict[str, Any] = {
             "task_id": task.task_id,
+            "session_key": task.envelope.session_key,
             "terminal_reason": terminal_reason,
         }
         if status != AgentTaskStatus.SUCCEEDED:

--- a/tests/functional/test_webui_browser_chat_e2e.py
+++ b/tests/functional/test_webui_browser_chat_e2e.py
@@ -524,3 +524,353 @@ def test_chat_compaction_events_render_recoverable_toasts_in_real_browser(
         "hasReplayedFailureToast": False,
         "pageErrors": [],
     }
+
+
+def test_webui_hotfix_flows_in_real_browser(tmp_path: Path) -> None:
+    if os.environ.get("OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E") != "1":
+        pytest.skip("set OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E=1 to run chat browser e2e")
+
+    port = _free_port()
+    server_script = tmp_path / "webui_hotfix_server.py"
+    browser_script = tmp_path / "webui_hotfix_browser.js"
+    server_script.write_text(
+        textwrap.dedent(
+            f"""
+            import uvicorn
+
+            from opensquilla.gateway.app import create_gateway_app
+            from opensquilla.gateway.config import AuthConfig, GatewayConfig
+
+            config = GatewayConfig(
+                host="127.0.0.1",
+                port={port},
+                auth=AuthConfig(mode="none"),
+            )
+            app = create_gateway_app(config)
+
+            if __name__ == "__main__":
+                uvicorn.run(app, host="127.0.0.1", port={port}, log_level="warning")
+            """
+        ),
+        encoding="utf-8",
+    )
+    browser_script.write_text(
+        textwrap.dedent(
+            r"""
+            const { chromium } = require("playwright");
+
+            async function waitRpc(page) {
+              await page.waitForFunction(
+                () =>
+                  typeof App !== "undefined" &&
+                  App.getRpc &&
+                  App.getRpc()?.state === "connected",
+                { timeout: 15000 }
+              );
+            }
+
+            async function emit(page, event, payload) {
+              await page.evaluate(
+                ({ event, payload }) => {
+                  const rpc = App.getRpc();
+                  const named = rpc._listeners.get(event);
+                  if (named) named.forEach(h => h(payload));
+                  const wild = rpc._listeners.get("*");
+                  if (wild) wild.forEach(h => h(event, payload));
+                },
+                { event, payload }
+              );
+            }
+
+            (async () => {
+              const browser = await chromium.launch({ headless: true });
+              const page = await browser.newPage();
+              const errors = [];
+              page.on("pageerror", err => errors.push(String(err)));
+
+              await page.goto(process.env.TARGET_URL, {
+                waitUntil: "domcontentloaded",
+                timeout: 30000,
+              });
+              await page.waitForSelector("#chat-textarea", { timeout: 15000 });
+              await waitRpc(page);
+
+              await page.evaluate(() => {
+                const rpc = App.getRpc();
+                const originalCall = rpc.call.bind(rpc);
+                window.__hotfix = {
+                  chatCalls: [],
+                  channelStatusCalls: 0,
+                  delayNextWait: false,
+                  logInFlight: 0,
+                  logMaxInFlight: 0,
+                  logTailCalls: 0,
+                };
+                const originalWait = rpc.waitForConnection.bind(rpc);
+                rpc.waitForConnection = () => {
+                  if (!window.__hotfix.delayNextWait) return originalWait();
+                  window.__hotfix.delayNextWait = false;
+                  return new Promise(resolve => setTimeout(resolve, 300));
+                };
+                rpc.call = (method, params = {}) => {
+                  if (method === "chat.send") {
+                    window.__hotfix.chatCalls.push({ method, params });
+                    return Promise.resolve({ task_id: "task-" + window.__hotfix.chatCalls.length });
+                  }
+                  if (method === "sessions.list") {
+                    return Promise.resolve({
+                      sessions: [{
+                        key: "fake-session",
+                        title: "Fake session",
+                        updated_at: new Date().toISOString(),
+                        message_count: 1,
+                      }],
+                    });
+                  }
+                  if (method === "agents.list") {
+                    return Promise.resolve({ agents: [] });
+                  }
+                  if (method === "sessions.delete") {
+                    return Promise.resolve({ deleted: [], errors: ["denied"] });
+                  }
+                  if (method === "channels.status") {
+                    window.__hotfix.channelStatusCalls += 1;
+                    return Promise.resolve({ channels: [] });
+                  }
+                  if (method === "logs.status") {
+                    return Promise.resolve({ enabled: true, path: "debug.log" });
+                  }
+                  if (method === "logs.tail") {
+                    const callNo = ++window.__hotfix.logTailCalls;
+                    window.__hotfix.logInFlight += 1;
+                    window.__hotfix.logMaxInFlight = Math.max(
+                      window.__hotfix.logMaxInFlight,
+                      window.__hotfix.logInFlight
+                    );
+                    return new Promise((resolve, reject) => {
+                      const delay = callNo === 1 ? 200 : 4500;
+                      setTimeout(() => {
+                        window.__hotfix.logInFlight -= 1;
+                        if (callNo === 1) {
+                          reject(new Error("tail down"));
+                          return;
+                        }
+                        resolve({
+                          cursor: callNo,
+                          lines: [{ level: "INFO", message: "log line " + callNo }],
+                        });
+                      }, delay);
+                    });
+                  }
+                  return originalCall(method, params);
+                };
+              });
+
+              const sessionKey = await page.locator("#chat-session-chip-key").innerText();
+              await emit(
+                page,
+                "task.queued",
+                { task_id: "old-task", session_key: "other-session" }
+              );
+              const statusAfterOtherTask = await page.locator("#chat-run-status").innerText();
+              await emit(page, "task.queued", { task_id: "current-task", session_key: sessionKey });
+              const statusAfterCurrentTask = await page.locator("#chat-run-status").innerText();
+              await emit(page, "sessions.changed", {
+                key: sessionKey,
+                run_status: "idle",
+                last_task: { status: "succeeded" },
+                reason: "turn_complete",
+              });
+
+              await page.fill("#chat-textarea", "first prompt");
+              await page.click("#chat-btn-send");
+              await page.waitForFunction(
+                () => window.__hotfix.chatCalls.some(c => c.params.message === "first prompt"),
+                { timeout: 5000 }
+              );
+              await emit(page, "session.event.done", { text: "first answer" });
+              await page.waitForFunction(
+                () => document.querySelectorAll(".msg.assistant").length >= 1,
+                { timeout: 5000 }
+              );
+
+              await page.fill("#chat-textarea", "second prompt");
+              await page.click("#chat-btn-send");
+              await page.waitForFunction(
+                () => window.__hotfix.chatCalls.some(c => c.params.message === "second prompt"),
+                { timeout: 5000 }
+              );
+              await emit(page, "session.event.done", { text: "second answer" });
+              await page.waitForFunction(
+                () => document.querySelectorAll(".msg.assistant").length >= 2,
+                { timeout: 5000 }
+              );
+
+              await page.locator(".msg.assistant").first().hover();
+              await page.locator(".msg.assistant")
+                .first()
+                .locator('[data-action="regenerate"]')
+                .click();
+              await page.waitForFunction(
+                () =>
+                  window.__hotfix.chatCalls
+                    .filter(c => c.params.message === "first prompt")
+                    .length >= 2,
+                { timeout: 5000 }
+              );
+              const regenerateMessages = await page.evaluate(
+                () => window.__hotfix.chatCalls.map(c => c.params.message)
+              );
+              const bubblesAfterRegenerate = await page.locator(".msg").count();
+
+              await page.fill("#chat-textarea", "queued while streaming");
+              await page.click("#chat-btn-send");
+              await page.fill("#chat-textarea", "draft typed during stream");
+              await emit(page, "session.event.done", { text: "regenerated answer" });
+              await page.waitForFunction(
+                () =>
+                  window.__hotfix.chatCalls
+                    .some(c => c.params.message === "queued while streaming"),
+                { timeout: 5000 }
+              );
+              const draftAfterQueueDrain = await page.locator("#chat-textarea").inputValue();
+
+              await page.evaluate(() => Router.navigate("/config"));
+              await page.waitForSelector("#cfg-yaml-area", { state: "attached", timeout: 15000 });
+              await page.click('[data-cfg-mode="yaml"]');
+              const yamlBefore = await page.locator("#cfg-yaml-area").inputValue();
+              const yamlDraft = yamlBefore + "\n# hotfix draft";
+              await page.fill("#cfg-yaml-area", yamlDraft);
+              await page.click('[data-cfg-mode="form"]');
+              await page.click('[data-cfg-mode="yaml"]');
+              const yamlAfterToggle = await page.locator("#cfg-yaml-area").inputValue();
+              await page.evaluate(() => Router.navigate("/chat"));
+              await page.waitForSelector("#chat-textarea", { timeout: 15000 });
+              await page.evaluate(() => Router.navigate("/config"));
+              await page.waitForSelector("#cfg-yaml-area", { state: "attached", timeout: 15000 });
+              const configFormDisplay = await page
+                .locator("#cfg-form-view")
+                .evaluate(el => getComputedStyle(el).display);
+              const configYamlDisplay = await page
+                .locator("#cfg-yaml-view")
+                .evaluate(el => getComputedStyle(el).display);
+              const formButtonActive = await page
+                .locator('[data-cfg-mode="form"]')
+                .evaluate(el => el.classList.contains("is-active"));
+
+              await page.evaluate(() => {
+                window.__hotfix.delayNextWait = true;
+                window.__hotfix.channelGuardStartedAt = Date.now();
+                Router.navigate("/channels");
+                Router.navigate("/chat");
+              });
+              await page.waitForSelector("#chat-textarea", { timeout: 15000 });
+              await page.waitForFunction(
+                () =>
+                  window.__hotfix.channelStatusCalls === 0 &&
+                  Date.now() - window.__hotfix.channelGuardStartedAt >= 600,
+                { timeout: 2000 }
+              );
+              const channelStatusCallsAfterDestroyedWait = await page.evaluate(
+                () => window.__hotfix.channelStatusCalls
+              );
+
+              await page.evaluate(() => Router.navigate("/sessions"));
+              await page.waitForSelector('[data-del-key="fake-session"]', { timeout: 15000 });
+              await page.click('[data-del-key="fake-session"]');
+              await page.locator(".modal .btn-danger").click();
+              await page.waitForFunction(
+                () => document.body.innerText.includes("Delete failed: denied"),
+                { timeout: 5000 }
+              );
+              const sessionDeleteBody = await page.locator("body").innerText();
+
+              await page.evaluate(() => Router.navigate("/logs"));
+              await page.waitForSelector("#logs-display", { timeout: 15000 });
+              await page.waitForFunction(
+                () => document.body.innerText.includes("Log refresh failed"),
+                { timeout: 5000 }
+              );
+              await page.waitForFunction(
+                () => window.__hotfix.logTailCalls >= 2 && window.__hotfix.logInFlight === 0,
+                { timeout: 10000 }
+              );
+              const logState = await page.evaluate(() => ({
+                maxInFlight: window.__hotfix.logMaxInFlight,
+                tailCalls: window.__hotfix.logTailCalls,
+              }));
+
+              const result = {
+                statusAfterOtherTask,
+                statusAfterCurrentTask,
+                regenerateMessages,
+                bubblesAfterRegenerate,
+                draftAfterQueueDrain,
+                yamlDraftPreserved: yamlAfterToggle === yamlDraft,
+                configResetToForm:
+                  configFormDisplay !== "none" &&
+                  configYamlDisplay === "none" &&
+                  formButtonActive,
+                channelStatusCallsAfterDestroyedWait,
+                sessionDeleteFailed: sessionDeleteBody.includes("Delete failed: denied"),
+                sessionDeleteFalseSuccess: sessionDeleteBody.includes("Session deleted"),
+                logState,
+                pageErrors: errors,
+              };
+              await browser.close();
+              console.log(JSON.stringify(result));
+            })().catch(err => {
+              console.error(err && err.stack ? err.stack : String(err));
+              process.exit(1);
+            });
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["OPENSQUILLA_STATE_DIR"] = str(tmp_path / "state")
+    env["OPENSQUILLA_LOG_DIR"] = str(tmp_path / "logs")
+    server = subprocess.Popen(
+        [sys.executable, str(server_script)],
+        cwd=Path.cwd(),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    try:
+        _wait_for_health(port, server)
+        _install_playwright(tmp_path)
+        result = subprocess.run(
+            [_node(), str(browser_script)],
+            cwd=tmp_path,
+            env=dict(env, TARGET_URL=f"http://127.0.0.1:{port}/control/chat"),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, result.stderr or result.stdout
+        payload = json.loads(result.stdout.strip().splitlines()[-1])
+    finally:
+        _stop_process(server)
+
+    assert payload["pageErrors"] == [], payload["pageErrors"]
+    assert payload["statusAfterOtherTask"] == "Idle"
+    assert payload["statusAfterCurrentTask"] == "Queued"
+    assert payload["regenerateMessages"].count("first prompt") >= 2
+    first_regenerate = payload["regenerateMessages"].index("first prompt")
+    second_send = payload["regenerateMessages"].index("second prompt")
+    assert first_regenerate < second_send
+    assert payload["bubblesAfterRegenerate"] <= 3
+    assert payload["draftAfterQueueDrain"] == "draft typed during stream"
+    assert payload["yamlDraftPreserved"] is True
+    assert payload["configResetToForm"] is True
+    assert payload["channelStatusCallsAfterDestroyedWait"] == 0
+    assert payload["sessionDeleteFailed"] is True
+    assert payload["sessionDeleteFalseSuccess"] is False
+    assert payload["logState"]["tailCalls"] >= 2
+    assert payload["logState"]["maxInFlight"] == 1

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -4,6 +4,7 @@ CHAT_JS = Path("src/opensquilla/gateway/static/js/views/chat.js")
 CHAT_CSS = Path("src/opensquilla/gateway/static/css/views/chat.css")
 RPC_JS = Path("src/opensquilla/gateway/static/js/rpc.js")
 SAVINGS_FX_JS = Path("src/opensquilla/gateway/static/js/components/savings-fx.js")
+TASK_RUNTIME_PY = Path("src/opensquilla/gateway/task_runtime.py")
 
 
 def test_chat_history_passes_subagent_completion_provenance_to_renderer() -> None:
@@ -320,6 +321,23 @@ def test_chat_switching_existing_session_does_not_mark_new_chat_intent() -> None
     assert "_pendingSessionIntent = 'new_chat'" not in switch_body
     assert source.count("_pendingSessionIntent = 'new_chat'") == 2
     assert "params.intent = _pendingSessionIntent;" in source
+
+
+def test_chat_regenerate_targets_clicked_assistant_bubble() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+    hover_start = source.index("function _bindHoverActions()")
+    hover_end = source.index("  function _truncate", hover_start)
+    hover_body = source[hover_start:hover_end]
+    regen_start = source.index("function _regenerateAssistantBubble(bubble)")
+    regen_end = source.index("  // Pop the user message back into the textarea", regen_start)
+    regen_body = source[regen_start:regen_end]
+
+    assert "_regenerateAssistantBubble(bubble);" in hover_body
+    assert "_regenerateLastTurn" not in source
+    assert "querySelectorAll(':scope > .msg.assistant')" in regen_body
+    assert "const assistantOrdinal = assistantBubbles.indexOf(bubble);" in regen_body
+    assert "assistantSeen === assistantOrdinal" in regen_body
+    assert "_messages.splice(userIdx + 1);" in regen_body
 
 
 def test_chat_maps_task_terminal_events_during_migration() -> None:
@@ -958,3 +976,54 @@ def test_chat_input_bar_tightens_desktop_bottom_padding_but_keeps_mobile_safe_ar
     assert desktop_padding in css
     assert mobile_safe_area in css
     assert css.rfind(mobile_safe_area) > css.index(desktop_padding)
+
+
+def test_chat_task_lifecycle_events_are_session_scoped() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+    runtime = TASK_RUNTIME_PY.read_text(encoding="utf-8")
+
+    queued_start = source.index("_rpc.on('task.queued'")
+    queued_end = source.index("_rpc.on('task.running'", queued_start)
+    queued_body = source[queued_start:queued_end]
+    running_start = queued_end
+    running_end = source.index("_rpc.on('session.event.task_group.waiting'", running_start)
+    running_body = source[running_start:running_end]
+    terminal_start = source.index("const terminalStatus = _taskTerminalStatus(rawEvent);")
+    terminal_end = source.index("      const normalized =", terminal_start)
+    terminal_body = source[terminal_start:terminal_end]
+
+    assert "if (!_isCurrentSessionPayload(payload)) return;" in queued_body
+    assert "if (!_isCurrentSessionPayload(payload)) return;" in running_body
+    assert "if (!_isCurrentSessionPayload(rawPayload)) return;" in terminal_body
+    queued_emit_start = runtime.index('await self._emit(\n            envelope.session_key,')
+    queued_emit_end = runtime.index("        return TaskHandle", queued_emit_start)
+    queued_emit = runtime[queued_emit_start:queued_emit_end]
+    running_emit_start = runtime.index('await self._emit(\n            task.envelope.session_key,')
+    running_emit_end = runtime.index(
+        "        await self._notify_task_lifecycle",
+        running_emit_start,
+    )
+    running_emit = runtime[running_emit_start:running_emit_end]
+
+    assert '"task.queued"' in queued_emit
+    assert '"session_key": envelope.session_key' in queued_emit
+    assert '"task.running"' in running_emit
+    assert '"session_key": task.envelope.session_key' in running_emit
+    assert '"session_key": task.envelope.session_key' in runtime
+
+
+def test_chat_queue_drain_preserves_draft_typed_during_stream() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+    start = source.index("function _drainQueueHead()")
+    end = source.index("  function _popPendingTail", start)
+    body = source[start:end]
+
+    assert "const draftText = _textarea.value;" in body
+    assert "const draftAttachments = _pendingAttachments.map" in body
+    assert "const draftIntent = _pendingSessionIntent;" in body
+    assert "_onSend();" in body
+    assert "if (draftText.trim() || draftAttachments.length || draftIntent) {" in body
+    assert "_textarea.value = draftText;" in body
+    assert "_pendingAttachments = draftAttachments;" in body
+    assert "_pendingSessionIntent = draftIntent;" in body
+    assert body.index("_onSend();") < body.index("_textarea.value = draftText;")

--- a/tests/test_gateway/test_logs_view_static.py
+++ b/tests/test_gateway/test_logs_view_static.py
@@ -78,3 +78,40 @@ def test_example_config_lists_debug_file_logging_controls() -> None:
     assert "log_file_backup_count" in source
     assert "diagnostics_enabled enables standard diagnostics" in source
     assert "OPENSQUILLA_TURN_CALL_LOG=1" in source
+
+
+def test_logs_poll_does_not_overlap_or_fail_silently() -> None:
+    source = LOGS_JS.read_text(encoding="utf-8")
+
+    assert "let _pollInFlight = false;" in source
+    assert "let _pollErrorShown = false;" in source
+    start = source.index("async function _poll()")
+    end = source.index("  function _guessLevel", start)
+    body = source[start:end]
+
+    assert "if (!_el || _pollInFlight) return;" in body
+    assert "_pollInFlight = true;" in body
+    assert "Log refresh failed" in body
+    assert "_pollErrorShown = true;" in body
+    assert "_pollInFlight = false;" in body
+    assert "finally" in body
+
+
+def test_config_view_resets_mode_and_preserves_unsaved_yaml_draft() -> None:
+    source = CONFIG_JS.read_text(encoding="utf-8")
+
+    render_start = source.index("function render(el)")
+    render_end = source.index("  function destroy()", render_start)
+    render_body = source[render_start:render_end]
+    destroy_start = render_end
+    destroy_end = source.index("  async function _loadData()", destroy_start)
+    destroy_body = source[destroy_start:destroy_end]
+
+    assert "_setMode(_mode);" in render_body
+    assert "_mode = 'form';" in destroy_body
+    assert "let _yamlDraft = '';" in source
+    assert "let _yamlDirty = false;" in source
+    assert "_bindYamlDraftTracking();" in source
+    assert "_yamlDraft = e.target.value;" in source
+    assert "_yamlDirty = _yamlDraft !== _yamlText;" in source
+    assert "_yamlDirty ? _yamlDraft : _yamlText" in source

--- a/tests/test_gateway/test_sessions_view_static.py
+++ b/tests/test_gateway/test_sessions_view_static.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+SESSIONS_JS = Path("src/opensquilla/gateway/static/js/views/sessions.js")
+
+
+def test_single_session_delete_checks_backend_partial_failure_response() -> None:
+    source = SESSIONS_JS.read_text(encoding="utf-8")
+    start = source.index("function _deleteSession(key)")
+    end = source.index("  async function _openNewSessionModal()", start)
+    body = source[start:end]
+
+    assert "const res = await _rpc.call('sessions.delete', { key });" in body
+    assert "res.errors" in body
+    assert "res.deleted" in body
+    assert "deleted.includes(key)" in body
+    assert "typeof first === 'string'" in body
+    assert "Session deleted" in body
+    assert "Delete failed" in body
+    assert body.index("res.errors") < body.index("Session deleted")

--- a/tests/test_gateway/test_static_onboarding_views.py
+++ b/tests/test_gateway/test_static_onboarding_views.py
@@ -44,6 +44,17 @@ def test_channels_view_filters_to_configured_channels():
     assert "configured !== false" in txt
 
 
+def test_channels_load_stops_if_view_is_destroyed_while_waiting_for_rpc():
+    txt = (VIEWS / "channels.js").read_text(encoding="utf-8")
+    start = txt.index("async function _loadData()")
+    end = txt.index("  function _renderStats", start)
+    body = txt[start:end]
+
+    assert "const rpc = _rpc;" in body
+    assert "await rpc.waitForConnection();" in body
+    assert "if (!_el || _rpc !== rpc) return;" in body
+
+
 def test_setup_view_loads_catalog_and_status():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
     assert "onboarding.catalog" in txt

--- a/tests/test_gateway/test_task_session_lifecycle.py
+++ b/tests/test_gateway/test_task_session_lifecycle.py
@@ -156,6 +156,26 @@ async def test_task_timeout_terminalizes_running_session_and_broadcasts_change()
         "task.timeout",
         "sessions.changed",
     ]
+    assert events[0] == (
+        session.session_key,
+        "task.queued",
+        {"task_id": handle.task_id, "session_key": session.session_key},
+    )
+    assert events[1] == (
+        session.session_key,
+        "task.running",
+        {"task_id": handle.task_id, "session_key": session.session_key},
+    )
+    assert events[2] == (
+        session.session_key,
+        "task.timeout",
+        {
+            "task_id": handle.task_id,
+            "session_key": session.session_key,
+            "terminal_reason": "timeout",
+            "terminal_message": "The task timed out before it could finish.",
+        },
+    )
     assert events[-1] == (
         session.session_key,
         "sessions.changed",
@@ -264,6 +284,16 @@ async def test_task_running_reactivates_terminal_session_before_next_turn() -> N
         "task.succeeded",
         "sessions.changed",
     ]
+    assert events[0] == (
+        session.session_key,
+        "task.queued",
+        {"task_id": handle.task_id, "session_key": session.session_key},
+    )
+    assert events[1] == (
+        session.session_key,
+        "task.running",
+        {"task_id": handle.task_id, "session_key": session.session_key},
+    )
     assert events[2] == (
         session.session_key,
         "sessions.changed",
@@ -289,6 +319,15 @@ async def test_task_running_reactivates_terminal_session_before_next_turn() -> N
                 "status": "succeeded",
                 "terminal_reason": "completed",
             },
+        },
+    )
+    assert events[3] == (
+        session.session_key,
+        "task.succeeded",
+        {
+            "task_id": handle.task_id,
+            "session_key": session.session_key,
+            "terminal_reason": "completed",
         },
     )
     assert manager.finish_calls == []


### PR DESCRIPTION
## Summary
- Fix Chat regenerate so it targets the clicked assistant response instead of the latest turn.
- Scope task lifecycle events by session key, including queued/running/terminal task events.
- Preserve drafts typed while queued messages drain after stream completion.
- Harden Config, Channels, Logs, and Sessions WebUI edge cases around route changes, polling, YAML drafts, and partial delete failures.

## Hotfix Scope
This is a released-user WebUI hotfix against `main`. Production changes are limited to gateway/WebUI surfaces plus the task lifecycle payload contract needed for session-scoped UI state.

## Review Notes
- Code review findings were addressed before publish:
  - ruff lint failures fixed.
  - `sessions.delete` now handles the backend's string-shaped `errors` entries.
  - terminal `task.*` payloads now include `session_key` and Chat filters them.
- Remaining architecture watch item: the opt-in browser hotfix test is intentionally broad for this hotfix; follow-up can split it into smaller harness-backed tests.

## Verification
- `uv run ruff check src tests`
- `node --check` changed WebUI scripts
- `uv run --extra dev pytest -q tests/test_gateway`
- `OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E=1 uv run --extra dev pytest -q tests/functional/test_webui_browser_chat_e2e.py`
- `uv run mypy src/opensquilla/gateway/task_runtime.py`
- `git diff --check`

## Not Tested
- Live provider turn with real model spend.