### PR TITLE
Record tokenjuice provenance before wider use

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,8 @@
 - [ ] The default test path remains offline, deterministic, credential-free, and safe for forks.
 - [ ] I did not commit secrets, local paths, private prompts, real provider transcripts, channel identifiers, or AI session artifacts.
 - [ ] I did not commit maintainer-only files from `tests/_private/` or `.omx/private-golden/`.
+- [ ] Third-party origin is declared: `none`, `inspired-by`, `adapted/ported`, `vendored`, `direct dependency`, or `modified upstream`.
+- [ ] For non-`none` third-party origin, I listed the upstream URL, license, whether code/rules/fixtures/text were copied or adapted, and updated notices/provenance where required.
 
 ## Live Checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,35 @@ Private test suites, release red-team prompts, real provider transcripts, real c
 
 Local maintainer-only files may live under `tests/_private/` or `.omx/private-golden/`; both are excluded from the public tree and default pytest collection.
 
+## Third-Party Origins
+
+Declare any third-party origin in the pull request. If no third-party material is
+involved, say `none`. If there is any uncertainty, use the more conservative
+category and let maintainers narrow it during review.
+
+- `inspired-by`: only the idea influenced the change; no code, rules, fixtures,
+  structure, or copied text is reused.
+- `adapted/ported`: OpenSquilla re-expresses upstream behavior, rules, or
+  structure in OpenSquilla code.
+- `vendored`: upstream source is copied into the repository with minimal or no
+  changes.
+- `direct dependency`: OpenSquilla depends on an external package through
+  `pyproject.toml` or another package manager.
+- `modified upstream`: vendored upstream source is patched or otherwise changed
+  in the OpenSquilla tree.
+
+For `adapted/ported`, `vendored`, and `modified upstream` material, include the
+upstream URL, license, copyright notice, and any required changes to
+`THIRD_PARTY_NOTICES.md` or a local provenance file in the same pull request.
+For direct dependencies, note the package name and license so maintainers can
+audit redistribution and release-bundle obligations.
+
+Permissive licenses such as Apache-2.0, MIT, MIT-0, BSD, ISC, and compatible
+public-domain-equivalent grants are usually acceptable. GPL, AGPL, LGPL, SSPL,
+source-available, custom commercial, or unclear licenses require explicit
+maintainer approval before code, rules, fixtures, or adapted implementations are
+merged.
+
 ## Security Reports
 
 Do not include vulnerability details, exploit steps, credentials, or provider tokens in public issues. Use the process in `SECURITY.md` for suspected vulnerabilities.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,6 +10,8 @@ It covers:
   agent runtime to invoke them and is documented here for transparency.
 - The local SquillaRouter V4 Phase 3 model bundle under
   `src/opensquilla/squilla_router/models/v4.2_phase3_inference/`.
+- The built-in tokenjuice tool-result compression backend and bundled
+  reduction rules under `src/opensquilla/plugins/tokenjuice/`.
 - The cron prompt-injection scanner was reviewed against Hermes Agent
   reference material; the MIT notice is reproduced below for conservative
   attribution.
@@ -65,6 +67,45 @@ These bundled skill descriptors are authored and maintained by OpenSquilla and
 are released under OpenSquilla's repository license (Apache-2.0; see `LICENSE`):
 
 - `memory`
+
+## tokenjuice adapted reduction rules
+
+- Component: built-in tokenjuice tool-result compression backend and bundled
+  reduction rules under `src/opensquilla/plugins/tokenjuice/`.
+- Upstream project: https://github.com/vincentkoc/tokenjuice
+- License: MIT
+- Copyright notice: Copyright (c) 2026 Vincent Koc
+
+OpenSquilla includes a Python adaptation of tokenjuice's rule-driven reducer
+and bundles reduction rules derived from the upstream project. OpenSquilla does
+not depend on the upstream tokenjuice npm package at runtime. Additional
+provenance is recorded in
+`src/opensquilla/plugins/tokenjuice/PROVENANCE.md`; the MIT license text is
+also shipped with that package as `LICENSE.tokenjuice`.
+
+```
+MIT License
+
+Copyright (c) 2026 Vincent Koc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
 
 ## Hermes Agent reference material
 

--- a/src/opensquilla/engine/tokenjuice_adapter.py
+++ b/src/opensquilla/engine/tokenjuice_adapter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from opensquilla.plugins.tokenjuice import reduce_tool_result as _reduce_tool_result_plugin
+from opensquilla.plugins.tokenjuice import reduce_tool_result as _reduce_tool_result_backend
 
 
 @dataclass(frozen=True)
@@ -39,7 +39,7 @@ def reduce_tool_result_with_tokenjuice(
     max_inline_chars: int | None = None,
     timeout_seconds: float = 5.0,
 ) -> TokenjuiceReduction | None:
-    """Run the built-in tokenjuice plugin for a tool result.
+    """Run the built-in tokenjuice compression backend for a tool result.
 
     Returns ``None`` when tokenjuice fails or does not reduce the result.
     Compression is best-effort because tool output must never fail an agent turn.
@@ -49,7 +49,7 @@ def reduce_tool_result_with_tokenjuice(
     command = command or _string_arg(arguments, "command")
     cwd = cwd or _string_arg(arguments, "workdir", "cwd")
     try:
-        reduction = _reduce_tool_result_plugin(
+        reduction = _reduce_tool_result_backend(
             tool_name=tool_name,
             content=content,
             is_error=is_error,

--- a/src/opensquilla/gateway/static/js/views/config.js
+++ b/src/opensquilla/gateway/static/js/views/config.js
@@ -47,7 +47,7 @@ const ConfigView = (() => {
     'log_file_backup_count':
       'Number of rotated debug.log backups to retain.',
     'agent_token_saving.tool_result_compression_mode':
-      'How tool outputs are compressed before being fed back to the model: "off", "auto" (heuristic), or "always". "auto" is a sane default.',
+      'How tool outputs are compressed before being fed back to the model: "off", "truncate" (default TRIM), "summarize", or "tokenjuice" (experimental rule-based backend).',
     'agent_token_saving.tool_result_compression_enabled':
       'Master switch for tool-result compression. Disable to send raw tool output verbatim — useful for debugging, costly otherwise.',
     'squilla_router.enabled':

--- a/src/opensquilla/plugins/tokenjuice/LICENSE.tokenjuice
+++ b/src/opensquilla/plugins/tokenjuice/LICENSE.tokenjuice
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vincent Koc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/opensquilla/plugins/tokenjuice/PROVENANCE.md
+++ b/src/opensquilla/plugins/tokenjuice/PROVENANCE.md
@@ -1,0 +1,32 @@
+# tokenjuice Backend Provenance
+
+This package contains OpenSquilla's built-in tokenjuice tool-result compression
+backend.
+
+## Upstream
+
+- Project: https://github.com/vincentkoc/tokenjuice
+- License: MIT
+- Copyright notice: Copyright (c) 2026 Vincent Koc
+
+## Adaptation Notes
+
+OpenSquilla does not depend on the upstream tokenjuice npm package at runtime.
+The Python reducer in this package is maintained by OpenSquilla and adapts the
+rule-driven reduction approach for OpenSquilla's tool-result compression path.
+
+The bundled JSON reduction rules are derived from upstream tokenjuice rules and
+are redistributed under the upstream MIT license. The license text is included
+in `LICENSE.tokenjuice` and recorded in the repository root
+`THIRD_PARTY_NOTICES.md`.
+
+## Update Procedure
+
+When updating this backend or its bundled rules:
+
+1. Review the upstream tokenjuice license and attribution text.
+2. Keep `LICENSE.tokenjuice` and `THIRD_PARTY_NOTICES.md` in sync with any
+   upstream license or copyright change.
+3. Use synthetic fixtures for OpenSquilla tests; do not copy upstream fixtures
+   unless their license/provenance is recorded explicitly.
+4. Run the tokenjuice compression tests and packaging checks before release.

--- a/src/opensquilla/plugins/tokenjuice/__init__.py
+++ b/src/opensquilla/plugins/tokenjuice/__init__.py
@@ -1,4 +1,4 @@
-"""OpenSquilla-native tokenjuice reducer plugin."""
+"""OpenSquilla-native tokenjuice compression backend."""
 
 from .plugin import reduce_tool_result
 from .types import Reduction

--- a/tests/test_engine/test_tokenjuice_tool_result_compression.py
+++ b/tests/test_engine/test_tokenjuice_tool_result_compression.py
@@ -11,7 +11,7 @@ from opensquilla.engine import Agent, AgentConfig, ToolCall, ToolResult
 from opensquilla.engine.runtime import TurnRunner
 from opensquilla.engine.types import ToolResultEvent
 from opensquilla.gateway.config import AgentTokenSavingConfig
-from opensquilla.plugins.tokenjuice import reduce_tool_result as plugin_reduce_tool_result
+from opensquilla.plugins.tokenjuice import reduce_tool_result as backend_reduce_tool_result
 from opensquilla.provider import DoneEvent, TextDeltaEvent, ToolDefinition, ToolInputSchema
 from opensquilla.provider import DoneEvent as ProviderDoneEvent
 from opensquilla.provider import ToolUseEndEvent as ProviderToolUseEndEvent
@@ -354,7 +354,7 @@ async def test_summarize_mode_falls_back_to_summary_provider_when_tokenjuice_ret
     assert provider.chat_calls == 1
 
 
-def test_tokenjuice_adapter_calls_python_plugin(
+def test_tokenjuice_adapter_calls_python_backend(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, Any] = {}
@@ -371,7 +371,7 @@ def test_tokenjuice_adapter_calls_python_plugin(
 
     monkeypatch.setattr(
         tokenjuice_adapter_mod,
-        "_reduce_tool_result_plugin",
+        "_reduce_tool_result_backend",
         fake_reduce,
     )
 
@@ -397,12 +397,12 @@ def test_tokenjuice_adapter_calls_python_plugin(
     assert captured["max_inline_chars"] == 600
 
 
-def test_tokenjuice_adapter_returns_none_when_plugin_returns_none(
+def test_tokenjuice_adapter_returns_none_when_backend_returns_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         tokenjuice_adapter_mod,
-        "_reduce_tool_result_plugin",
+        "_reduce_tool_result_backend",
         lambda **kwargs: None,
     )
 
@@ -431,7 +431,7 @@ def test_tokenjuice_adapter_ignores_non_shrinking_response(
 
     monkeypatch.setattr(
         tokenjuice_adapter_mod,
-        "_reduce_tool_result_plugin",
+        "_reduce_tool_result_backend",
         fake_reduce,
     )
 
@@ -446,7 +446,7 @@ def test_tokenjuice_adapter_ignores_non_shrinking_response(
     )
 
 
-def test_python_plugin_reduces_pytest_output() -> None:
+def test_python_backend_reduces_pytest_output() -> None:
     output = "\n".join(
         [
             "platform darwin -- Python 3.13",
@@ -460,7 +460,7 @@ def test_python_plugin_reduces_pytest_output() -> None:
         ]
     )
 
-    result = plugin_reduce_tool_result(
+    result = backend_reduce_tool_result(
         tool_name="exec_command",
         tool_use_id="tool-1",
         command="pytest -q",
@@ -525,7 +525,7 @@ async def test_run_turn_feeds_tokenjuice_reduced_tool_result_to_next_provider_ca
     assert raw_event.result == output
 
 
-def test_python_plugin_reduces_docker_build_output() -> None:
+def test_python_backend_reduces_docker_build_output() -> None:
     output = "\n".join(
         [
             "#1 [internal] load build definition from Dockerfile",
@@ -538,7 +538,7 @@ def test_python_plugin_reduces_docker_build_output() -> None:
         ]
     )
 
-    result = plugin_reduce_tool_result(
+    result = backend_reduce_tool_result(
         tool_name="exec_command",
         tool_use_id="tool-1",
         command="docker build .",
@@ -553,10 +553,10 @@ def test_python_plugin_reduces_docker_build_output() -> None:
     assert "sha256:1234" not in result.inline_text
 
 
-def test_python_plugin_generic_fallback_head_tail() -> None:
+def test_python_backend_generic_fallback_head_tail() -> None:
     output = "\n".join(f"line {index}" for index in range(60))
 
-    result = plugin_reduce_tool_result(
+    result = backend_reduce_tool_result(
         tool_name="exec_command",
         tool_use_id="tool-1",
         command="custom-tool --verbose",

--- a/tests/test_skills_third_party_notices.py
+++ b/tests/test_skills_third_party_notices.py
@@ -71,3 +71,28 @@ def test_third_party_notices_match_bundled_provenance(tmp_path: Path) -> None:
         if line.strip().startswith("- `") and line.strip().endswith("`")
     }
     assert listed == set(skills)
+
+
+def test_tokenjuice_backend_has_third_party_provenance() -> None:
+    text = NOTICES.read_text(encoding="utf-8")
+    package_dir = ROOT / "src" / "opensquilla" / "plugins" / "tokenjuice"
+    provenance = package_dir / "PROVENANCE.md"
+    license_file = package_dir / "LICENSE.tokenjuice"
+
+    assert provenance.is_file()
+    assert license_file.is_file()
+
+    provenance_text = provenance.read_text(encoding="utf-8")
+    license_text = license_file.read_text(encoding="utf-8")
+
+    assert "## tokenjuice adapted reduction rules" in text
+    assert "https://github.com/vincentkoc/tokenjuice" in text
+    assert "License: MIT" in text
+    assert "Copyright (c) 2026 Vincent Koc" in text
+    assert "adaptation" in text
+    assert "LICENSE.tokenjuice" in text
+
+    assert "https://github.com/vincentkoc/tokenjuice" in provenance_text
+    assert "bundled JSON reduction rules are derived" in provenance_text
+    assert "MIT License" in license_text
+    assert "Copyright (c) 2026 Vincent Koc" in license_text


### PR DESCRIPTION
## Summary
- record tokenjuice as adapted MIT reduction rules in third-party notices
- ship tokenjuice PROVENANCE.md and LICENSE.tokenjuice with the backend
- clarify third-party origin intake expectations in CONTRIBUTING and PR template
- update tokenjuice wording from plugin to built-in compression backend and fix WebUI config copy

## Behavior
- no change to default tool compression mode
- no change to tokenjuice config value, import path, reducer behavior, metadata keys, or fallback behavior
- tokenjuice remains optional and non-default

## Tests
- `uv run pytest tests/test_engine/test_tokenjuice_tool_result_compression.py -q`
- `uv run pytest tests/test_gateway/test_chat_view_static.py tests/test_cli/test_chat_cmd.py::test_gateway_slash_tool_compress_can_switch_to_tokenjuice -q`
- `uv run pytest tests/test_skills_third_party_notices.py -q`
- `uv run ruff check src tests`
- `uv build --wheel`
- wheel inspection confirmed tokenjuice rules, PROVENANCE.md, and LICENSE.tokenjuice are included
