### PR TITLE
Make node runtime stubs truthful in tool catalog

### DIFF
--- a/src/opensquilla/tools/builtin/__init__.py
+++ b/src/opensquilla/tools/builtin/__init__.py
@@ -18,6 +18,7 @@ _NAMES = [
     "git",
     "media",
     "messaging",
+    "nodes",
     "patch",
     "sessions",
     "session_search",

--- a/src/opensquilla/tools/builtin/nodes.py
+++ b/src/opensquilla/tools/builtin/nodes.py
@@ -2,14 +2,36 @@
 
 from __future__ import annotations
 
-import json
-
+from opensquilla.tools.registry import tool
 from opensquilla.tools.types import ToolError
 
 _CANVAS_ACTIONS = ("present", "hide", "eval", "snapshot")
 _NODES_ACTIONS = ("list", "describe", "invoke")
 
 
+@tool(
+    name="canvas",
+    description=(
+        "Unavailable node runtime canvas stub. Hidden by default; calls require a "
+        "configured node runtime."
+    ),
+    params={
+        "action": {
+            "type": "string",
+            "description": "Action: present, hide, eval, snapshot",
+        },
+        "node_id": {
+            "type": "string",
+            "description": "Target node identifier",
+        },
+        "content": {
+            "type": "string",
+            "description": "Optional canvas content",
+        },
+    },
+    required=["action", "node_id"],
+    exposed_by_default=False,
+)
 async def canvas(
     action: str,
     node_id: str,
@@ -20,6 +42,33 @@ async def canvas(
     raise ToolError("Canvas requires a configured node runtime.")
 
 
+@tool(
+    name="nodes",
+    description=(
+        "Unavailable node runtime management stub. Hidden by default; calls require a "
+        "configured node runtime."
+    ),
+    params={
+        "action": {
+            "type": "string",
+            "description": "Action: list, describe, invoke",
+        },
+        "node_id": {
+            "type": "string",
+            "description": "Target node identifier for describe or invoke",
+        },
+        "tool_name": {
+            "type": "string",
+            "description": "Target node tool name for invoke",
+        },
+        "arguments": {
+            "type": "object",
+            "description": "Optional node tool arguments",
+        },
+    },
+    required=["action"],
+    exposed_by_default=False,
+)
 async def nodes(
     action: str,
     node_id: str | None = None,
@@ -35,7 +84,4 @@ async def nodes(
     if action == "invoke" and not tool_name:
         raise ToolError("'tool_name' required for invoke")
 
-    if action == "list":
-        return json.dumps({"nodes": []})
-
-    raise ToolError("Node actions require a configured node runtime.")
+    raise ToolError("Nodes require a configured node runtime.")

--- a/tests/test_tools/test_node_runtime_stubs.py
+++ b/tests/test_tools/test_node_runtime_stubs.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from opensquilla.tools.builtin.nodes import canvas, nodes
+from opensquilla.tools.types import ToolError
+
+
+@pytest.mark.asyncio
+async def test_nodes_list_stub_reports_runtime_unavailable() -> None:
+    with pytest.raises(ToolError, match="configured node runtime"):
+        await nodes("list")
+
+
+@pytest.mark.asyncio
+async def test_canvas_stub_reports_runtime_unavailable() -> None:
+    with pytest.raises(ToolError, match="configured node runtime"):
+        await canvas("snapshot", "main")

--- a/tests/test_tools/test_registry_visibility.py
+++ b/tests/test_tools/test_registry_visibility.py
@@ -107,6 +107,34 @@ def test_owner_schema_keeps_canonical_tools_and_subagents_stays_explicit_only() 
     assert "create_pptx" in surfaced_names
 
 
+def test_node_runtime_stubs_stay_hidden_until_explicitly_surfaced() -> None:
+    import opensquilla.tools.builtin  # noqa: F401
+    from opensquilla.tools.registry import get_default_registry
+
+    registry = get_default_registry()
+    owner_ctx = ToolContext(is_owner=True, caller_kind=CallerKind.AGENT)
+
+    default_tools = registry.to_tool_definitions(owner_ctx)
+    assert {tool.name for tool in default_tools}.isdisjoint({"nodes", "canvas"})
+
+    surfaced_ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.AGENT,
+        surfaced_tools={"nodes", "canvas"},
+    )
+    surfaced_tools = {
+        tool.name: tool.description.lower()
+        for tool in registry.to_tool_definitions(surfaced_ctx)
+        if tool.name in {"nodes", "canvas"}
+    }
+
+    assert set(surfaced_tools) == {"nodes", "canvas"}
+    assert "node runtime" in surfaced_tools["nodes"]
+    assert "unavailable" in surfaced_tools["nodes"]
+    assert "node runtime" in surfaced_tools["canvas"]
+    assert "unavailable" in surfaced_tools["canvas"]
+
+
 def test_web_owner_schema_hides_basic_pptx_fallback_by_default() -> None:
     import opensquilla.tools.builtin  # noqa: F401
     from opensquilla.tools.registry import get_default_registry


### PR DESCRIPTION
## Summary
- Register `nodes` and `canvas` as hidden-by-default stubs so they can be explicitly surfaced without appearing generally available.
- Make surfaced descriptions state that these are unavailable node runtime stubs.
- Replace the misleading empty `nodes list` response with an explicit configured-node-runtime error.
- Keep the change scoped to catalog and stub truth; this does not implement a real node runtime.

## Tests
- `PYTHONPATH=src /home/weihe/work/code/rhythm/opensquilla/.venv/bin/python -m pytest tests/test_tools/test_registry_visibility.py tests/test_gateway/test_rpc_tools_visibility.py tests/test_tools/test_node_runtime_stubs.py`
- `/home/weihe/work/code/rhythm/opensquilla/.venv/bin/python -m ruff check src/opensquilla/tools/builtin/__init__.py src/opensquilla/tools/builtin/nodes.py tests/test_tools/test_registry_visibility.py tests/test_tools/test_node_runtime_stubs.py`