### PR TITLE
Keep long cron names out of edit drawer titles

### DIFF
--- a/src/opensquilla/gateway/static/js/views/cron.js
+++ b/src/opensquilla/gateway/static/js/views/cron.js
@@ -929,7 +929,7 @@ const CronView = (() => {
     const eyebrow = _el.querySelector('#cron-panel-eyebrow');
     const title = _el.querySelector('#cron-panel-title');
     eyebrow.textContent = job ? 'Edit schedule' : 'New schedule';
-    title.textContent = job ? (job.name || job.id) : 'Create a job';
+    title.textContent = job ? 'Edit Schedule' : 'Create a job';
 
     const tpl = template || {};
     const name = job ? (job.name || '') : (tpl.name || '');

--- a/tests/test_gateway/test_cron_view_static.py
+++ b/tests/test_gateway/test_cron_view_static.py
@@ -30,6 +30,14 @@ def test_editing_cron_jobs_prefers_origin_before_target_session_key() -> None:
     assert origin_idx < target_idx < session_idx
 
 
+def test_editing_cron_jobs_uses_stable_panel_title_for_long_names() -> None:
+    source = CRON_JS.read_text(encoding="utf-8")
+
+    assert "title.textContent = job ? 'Edit Schedule' : 'Create a job';" in source
+    assert "title.textContent = job ? (job.name || job.id) : 'Create a job';" not in source
+    assert "_el.querySelector('#cp-name').value = name;" in source
+
+
 def test_agent_turn_session_target_does_not_remain_main_after_mode_switch() -> None:
     source = CRON_JS.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Use a stable `Edit Schedule` heading when editing cron jobs so long schedule names do not expand the drawer header.
- Keep the full schedule name in the editable Name field.
- Add a static regression test for the edit-panel title behavior.

## Test Plan
- [x] `.venv/bin/pytest -q tests/test_gateway/test_cron_view_static.py`
- [x] `node --check src/opensquilla/gateway/static/js/views/cron.js`
- [x] `git diff --check`
- [x] Playwright browser verification: long 252-character cron name opens with `titleText=Edit Schedule`, `nameLength=252`, `titleEqualsName=false`, `headHeight=75`

## Dev Sync Note
After this hotfix lands on `main`, propagate commit `6c49411` back to `dev` with `git cherry-pick -x 6c49411` unless `git cherry -v origin/dev origin/main` shows it as already patch-equivalent.