### PR TITLE
Keep legacy token-saving configs loadable

### DIFF
--- a/src/opensquilla/gateway/config_migration.py
+++ b/src/opensquilla/gateway/config_migration.py
@@ -55,9 +55,28 @@ DEPRECATED_MEMORY_LEAVES: frozenset[str] = frozenset(
     if k.startswith("memory.") and not k.startswith("memory.cost.")
 )
 
+DEPRECATED_AGENT_TOKEN_SAVING_FIELDS: frozenset[str] = frozenset(
+    {
+        "agent_token_saving.tool_result_compression_enabled",
+        "agent_token_saving.tool_result_compression_mode",
+        "agent_token_saving.tool_result_compression_max_share",
+        "agent_token_saving.tool_result_compression_summary_model",
+        "agent_token_saving.tool_result_compression_summary_max_tokens",
+        "agent_token_saving.tool_result_compression_summary_timeout_seconds",
+        "agent_token_saving.tool_result_compression_summary_input_max_chars",
+    }
+)
+DEPRECATED_AGENT_TOKEN_SAVING_LEAVES: frozenset[str] = frozenset(
+    k.removeprefix("agent_token_saving.")
+    for k in DEPRECATED_AGENT_TOKEN_SAVING_FIELDS
+)
+
 _LEGACY_MEMORY_FIELDS_WARN_LOCK = threading.Lock()
 _LEGACY_MEMORY_FIELDS_WARNED = False
 _LEGACY_MEMORY_FIELDS_SEEN: set[str] = set()
+_LEGACY_AGENT_TOKEN_SAVING_FIELDS_WARN_LOCK = threading.Lock()
+_LEGACY_AGENT_TOKEN_SAVING_FIELDS_WARNED = False
+_LEGACY_AGENT_TOKEN_SAVING_FIELDS_SEEN: set[str] = set()
 
 
 @dataclass(frozen=True)
@@ -132,6 +151,53 @@ def handle_deprecated_memory_fields(
         )
 
 
+def handle_deprecated_agent_token_saving_fields(
+    found: dict[str, object],
+    source: str,
+) -> None:
+    """Record and warn once for deprecated token-saving fields removed from config data."""
+    global _LEGACY_AGENT_TOKEN_SAVING_FIELDS_WARNED
+
+    if not found:
+        return
+
+    with _LEGACY_AGENT_TOKEN_SAVING_FIELDS_WARN_LOCK:
+        _LEGACY_AGENT_TOKEN_SAVING_FIELDS_SEEN.update(found.keys())
+        should_warn = not _LEGACY_AGENT_TOKEN_SAVING_FIELDS_WARNED
+        if should_warn:
+            _LEGACY_AGENT_TOKEN_SAVING_FIELDS_WARNED = True
+            warning_fields = sorted(_LEGACY_AGENT_TOKEN_SAVING_FIELDS_SEEN)
+        else:
+            warning_fields = []
+
+    _write_legacy_field_log(found, source)
+
+    if should_warn:
+        n = len(warning_fields)
+        first_three = ", ".join(warning_fields[:3])
+        try:
+            logs_dir = default_opensquilla_home() / "logs"
+            log_ref = str(logs_dir)
+        except Exception:
+            log_ref = "~/.opensquilla/logs"
+        warnings.warn(
+            f"OpenSquilla: {n} legacy agent_token_saving.tool_result_compression_* "
+            f"config field(s) migrated or ignored (e.g. {first_three}); see "
+            f"{log_ref} for details. Tokenjuice projection is now the built-in "
+            "tool-result path.",
+            DeprecationWarning,
+            stacklevel=6,
+        )
+        logging.getLogger(__name__).warning(
+            "OpenSquilla: %d legacy agent_token_saving.tool_result_compression_* "
+            "config field(s) migrated or ignored (e.g. %s); see %s for details. "
+            "Tokenjuice projection is now the built-in tool-result path.",
+            n,
+            first_three,
+            log_ref,
+        )
+
+
 def _write_legacy_field_log(found: dict[str, object], source: str) -> None:
     try:
         logs_dir = default_opensquilla_home() / "logs"
@@ -159,38 +225,73 @@ def migrate_config_payload(data: dict[str, Any]) -> ConfigMigrationResult:
     """
     builder = _MigrationBuilder(payload=copy.deepcopy(data))
     memory = builder.payload.get("memory")
-    if not isinstance(memory, dict):
-        return builder.result()
+    if isinstance(memory, dict):
+        if memory.get("capture_mode") == "archive_turn_pair":
+            memory["capture_mode"] = "turn_pair"
+            builder.changes.append("memory.capture_mode: archive_turn_pair -> turn_pair")
 
-    if memory.get("capture_mode") == "archive_turn_pair":
-        memory["capture_mode"] = "turn_pair"
-        builder.changes.append("memory.capture_mode: archive_turn_pair -> turn_pair")
+        if "index_captured_turns" in memory:
+            value = memory.pop("index_captured_turns")
+            builder.removed_fields.append("memory.index_captured_turns")
+            if bool(value):
+                builder.warnings.append(
+                    "memory.index_captured_turns was removed; captured turns are no "
+                    "longer indexed into normal recall"
+                )
 
-    if "index_captured_turns" in memory:
-        value = memory.pop("index_captured_turns")
-        builder.removed_fields.append("memory.index_captured_turns")
-        if bool(value):
-            builder.warnings.append(
-                "memory.index_captured_turns was removed; captured turns are no "
-                "longer indexed into normal recall"
+        deprecated: dict[str, object] = {}
+        for leaf in list(memory):
+            if leaf in DEPRECATED_MEMORY_LEAVES:
+                deprecated[f"memory.{leaf}"] = memory.pop(leaf)
+
+        cost = memory.get("cost")
+        if isinstance(cost, dict):
+            for leaf in list(cost):
+                if leaf in DEPRECATED_COST_LEAVES:
+                    deprecated[f"memory.cost.{leaf}"] = cost.pop(leaf)
+            if not cost:
+                memory.pop("cost", None)
+
+        if deprecated:
+            builder.removed_fields.extend(sorted(deprecated))
+            handle_deprecated_memory_fields(deprecated, "config_migration")
+
+    token_saving = builder.payload.get("agent_token_saving")
+    if isinstance(token_saving, dict):
+        summary_input_leaf = "tool_result_compression_summary_input_max_chars"
+        projection_leaf = "tool_result_projection_max_inline_chars"
+        if summary_input_leaf in token_saving and projection_leaf not in token_saving:
+            token_saving[projection_leaf] = token_saving[summary_input_leaf]
+            builder.changes.append(
+                "agent_token_saving.tool_result_compression_summary_input_max_chars "
+                "-> agent_token_saving.tool_result_projection_max_inline_chars"
             )
 
-    deprecated: dict[str, object] = {}
-    for leaf in list(memory):
-        if leaf in DEPRECATED_MEMORY_LEAVES:
-            deprecated[f"memory.{leaf}"] = memory.pop(leaf)
+        deprecated_token_saving: dict[str, object] = {}
+        for leaf in list(token_saving):
+            if leaf in DEPRECATED_AGENT_TOKEN_SAVING_LEAVES:
+                deprecated_token_saving[f"agent_token_saving.{leaf}"] = token_saving.pop(leaf)
 
-    cost = memory.get("cost")
-    if isinstance(cost, dict):
-        for leaf in list(cost):
-            if leaf in DEPRECATED_COST_LEAVES:
-                deprecated[f"memory.cost.{leaf}"] = cost.pop(leaf)
-        if not cost:
-            memory.pop("cost", None)
-
-    if deprecated:
-        builder.removed_fields.extend(sorted(deprecated))
-        handle_deprecated_memory_fields(deprecated, "config_migration")
+        if deprecated_token_saving:
+            builder.removed_fields.extend(sorted(deprecated_token_saving))
+            handle_deprecated_agent_token_saving_fields(
+                deprecated_token_saving,
+                "config_migration",
+            )
+            if (
+                deprecated_token_saving.get(
+                    "agent_token_saving.tool_result_compression_enabled"
+                )
+                is False
+                or deprecated_token_saving.get(
+                    "agent_token_saving.tool_result_compression_mode"
+                )
+                == "off"
+            ):
+                builder.warnings.append(
+                    "agent_token_saving.tool_result_compression_* was removed; "
+                    "tokenjuice projection is now the built-in tool-result path"
+                )
 
     return builder.result()
 

--- a/tests/test_gateway_config_legacy.py
+++ b/tests/test_gateway_config_legacy.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 import opensquilla.gateway.config as config_module
 import opensquilla.gateway.config_migration as migration_module
@@ -143,6 +144,92 @@ def test_load_from_toml_migrates_010_turn_capture_fields(tmp_path: Path) -> None
     data = toml_path.read_text(encoding="utf-8")
     assert 'capture_mode = "turn_pair"' in data
     assert "index_captured_turns" not in data
+
+
+def test_load_migrates_legacy_agent_token_saving_fields(tmp_path: Path) -> None:
+    toml_path = tmp_path / "config.toml"
+    toml_path.write_text(
+        "\n".join(
+            [
+                "[agent_token_saving]",
+                "tool_result_compression_enabled = false",
+                'tool_result_compression_mode = "off"',
+                "tool_result_compression_max_share = 0.25",
+                'tool_result_compression_summary_model = "z-ai/glm-4.5-air"',
+                "tool_result_compression_summary_max_tokens = 512",
+                "tool_result_compression_summary_timeout_seconds = 12.5",
+                "tool_result_compression_summary_input_max_chars = 43210",
+                "tool_result_store_max_bytes = 1234",
+                "tool_result_store_disk_budget_bytes = 5678",
+                "tool_result_store_retention_seconds = 90",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = GatewayConfig.load(toml_path)
+
+    assert cfg.agent_token_saving.tool_result_projection_max_inline_chars == 43210
+    assert cfg.agent_token_saving.tool_result_store_max_bytes == 1234
+    assert cfg.agent_token_saving.tool_result_store_disk_budget_bytes == 5678
+    assert cfg.agent_token_saving.tool_result_store_retention_seconds == 90
+    backups = sorted(tmp_path.glob("config.toml.backup.*"))
+    assert backups
+    backup_text = backups[-1].read_text(encoding="utf-8")
+    assert "tool_result_compression_enabled = false" in backup_text
+    migrated = toml_path.read_text(encoding="utf-8")
+    assert "tool_result_compression_" not in migrated
+    assert "tool_result_projection_max_inline_chars = 43210" in migrated
+    assert "tool_result_store_max_bytes = 1234" in migrated
+
+
+def test_legacy_agent_token_saving_migration_preserves_new_projection_setting(
+    tmp_path: Path,
+) -> None:
+    toml_path = tmp_path / "config.toml"
+    toml_path.write_text(
+        "\n".join(
+            [
+                "[agent_token_saving]",
+                "tool_result_projection_max_inline_chars = 22222",
+                "tool_result_compression_summary_input_max_chars = 60000",
+                "tool_result_compression_enabled = true",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = GatewayConfig.load_from_toml(toml_path)
+
+    assert cfg.agent_token_saving.tool_result_projection_max_inline_chars == 22222
+    migrated = toml_path.read_text(encoding="utf-8")
+    assert "tool_result_projection_max_inline_chars = 22222" in migrated
+    assert "tool_result_compression_" not in migrated
+
+
+def test_legacy_agent_token_saving_migration_keeps_runtime_schema_strict(
+    tmp_path: Path,
+) -> None:
+    toml_path = tmp_path / "config.toml"
+    toml_path.write_text(
+        "\n".join(
+            [
+                "[agent_token_saving]",
+                "tool_result_compression_enabled = true",
+                "tool_result_compression_summary_input_max_chars = 60000",
+                "typo_field = true",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        GatewayConfig.load(toml_path)
+
+    assert "agent_token_saving.typo_field" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- migrate legacy `agent_token_saving.tool_result_compression_*` fields at the user config disk-load boundary
- preserve existing `tool_result_projection_max_inline_chars` when it is already configured, otherwise map the old summary input size to it
- keep runtime config validation strict so unknown `agent_token_saving` fields still fail

## Root Cause
`origin/dev` removed the old configurable tool-result compression surface in favor of the tokenjuice projection/store path, but the config migration layer only handled legacy `memory.*` fields. Users upgrading with old `~/.opensquilla/config.toml` files could therefore hit Pydantic `extra_forbidden` errors before the gateway started.

## Validation
- `PYTHONPATH=src /home/weihe/work/code/rhythm/opensquilla/.venv/bin/pytest tests/test_gateway_config_legacy.py -q`
- `PYTHONPATH=src /home/weihe/work/code/rhythm/opensquilla/.venv/bin/pytest tests/test_engine/test_tokenjuice_tool_result_projection.py tests/test_engine/turn_runner/test_agent_bootstrap_stage_unit.py -q`
- `PYTHONPATH=src /home/weihe/work/code/rhythm/opensquilla/.venv/bin/python -m ruff check src/opensquilla/gateway/config_migration.py tests/test_gateway_config_legacy.py`

## Notes
Live gateway startup against the real user config was not run, to avoid mutating `~/.opensquilla/config.toml` during validation.