### PR TITLE
Document OpenSquilla product workflows for users

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_report.yml
@@ -1,0 +1,45 @@
+name: Documentation issue
+description: Report missing, confusing, or outdated OpenSquilla documentation
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for improving OpenSquilla's docs. Do not include credentials, provider tokens, private transcripts, account identifiers, or sensitive local paths.
+  - type: input
+    id: page
+    attributes:
+      label: Page or section
+      description: Link the page, heading, or command example that needs work.
+      placeholder: "docs/quickstart.md, docs/features/memory.md, or a GitHub URL"
+    validations:
+      required: true
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Issue type
+      options:
+        - Incorrect command or option
+        - Missing setup step
+        - Confusing explanation
+        - Missing feature guide
+        - Broken link
+        - Screenshot or UI mismatch
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong or missing?
+      description: Describe what you expected to learn and where the documentation fell short.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: If you know the correction, include the command, wording, or link that would help.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,12 @@
 ## Live Checks
 
 If this pull request changes provider, browser UI, gateway, or channel behavior, note whether a maintainer should run the `Live Release E2E` workflow.
+
+## Documentation Changes
+
+If this pull request changes documentation:
+
+- [ ] Links point to existing repository files or stable external pages.
+- [ ] Code fences and Markdown tables render correctly on GitHub.
+- [ ] Examples avoid real secrets, local private paths, and private transcripts.
+- [ ] User-facing feature pages explain when to use the feature, how to start, and where to troubleshoot next.

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ benchmarks/
 specs/
 # Local agent/editor instructions and runtime state.
 AGENTS.md
+!docs/agents.md
 !src/opensquilla/identity/templates/bootstrap/AGENTS.md
 CLAUDE.md
 GEMINI.md

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ site/
 /plugins/
 crontab-*
 ~/
-/docs/
 /reference-*
 /reference-mem
 /bench-mem

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ schema.
 
 OpenSquilla 0.2.1 is the current release.
 
+For task-oriented product documentation, start with the
+[OpenSquilla Product Guide](README.product.md) or the
+[documentation index](docs/README.md).
+
 ---
 
 ## Installation

--- a/README.product.md
+++ b/README.product.md
@@ -1,0 +1,220 @@
+# OpenSquilla Product Guide
+
+OpenSquilla is a token-efficient personal agent runtime for the terminal, a
+local Web UI, and messaging channels. It is designed for users who want one
+agent surface that can chat, use tools, remember useful context, run scheduled
+work, publish artifacts, and route work across multiple LLM providers without
+rewriting their workflow for each provider.
+
+This guide is the product and usage entry point. The existing
+[`README.md`](README.md) remains the package/release README.
+
+## Start Here
+
+1. Install OpenSquilla:
+
+   ```sh
+   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.2.1/opensquilla-0.2.1-py3-none-any.whl"
+   ```
+
+2. Configure your provider:
+
+   ```sh
+   opensquilla onboard
+   ```
+
+3. Start the gateway:
+
+   ```sh
+   opensquilla gateway run
+   ```
+
+4. Open the control UI:
+
+   <http://127.0.0.1:18791/control/>
+
+For platform-specific install paths and recovery steps, see
+[`docs/quickstart.md`](docs/quickstart.md).
+
+## Why OpenSquilla
+
+OpenSquilla focuses on cost-per-success and long-running usefulness rather than
+single-turn chat alone.
+
+| Product capability | What users get |
+| --- | --- |
+| SquillaRouter | Local, on-device routing that chooses an appropriate model tier per turn so simple tasks avoid premium-model cost. |
+| Tool compression | Large tool outputs stay useful without flooding the model context; raw results can be preserved while compact previews are sent to the model. |
+| Meta-skills | Repeatable workflows can be packaged as composable skills, so users can turn recurring multi-step work into reusable agent routines. |
+| Unified surfaces | CLI, Web UI, gateway RPC, and channels share the same runtime path, tools, memory, approvals, and usage accounting. |
+| Durable sessions | Conversations, transcripts, compaction summaries, artifacts, cost, and replay data are persisted for later inspection. |
+| Personal memory | User facts, notes, and task traces can be saved and recalled through local keyword and semantic search. |
+| Multi-provider runtime | OpenRouter, OpenAI, Anthropic, Gemini, DeepSeek, DashScope, Ollama, and other provider-compatible backends can be configured through one schema. |
+| Safe tool use | File, shell, web, memory, git, artifact, media, channel, and agent tools run behind policy layers and approval surfaces. |
+
+## Documentation Map
+
+| Need | Read |
+| --- | --- |
+| Install and run OpenSquilla | [`docs/quickstart.md`](docs/quickstart.md) |
+| Choose the right workflow for a goal | [`docs/use-cases.md`](docs/use-cases.md) |
+| Start, stop, expose, or troubleshoot the gateway | [`docs/gateway.md`](docs/gateway.md) |
+| Configure providers, router, search, channels, memory, and permissions | [`docs/configuration.md`](docs/configuration.md) |
+| Learn the CLI command groups | [`docs/cli.md`](docs/cli.md) |
+| Use the local control console | [`docs/web-ui.md`](docs/web-ui.md) |
+| Resume, export, abort, or delete sessions | [`docs/sessions.md`](docs/sessions.md) |
+| Choose and inspect LLM providers/models | [`docs/providers-and-models.md`](docs/providers-and-models.md) |
+| Configure web search | [`docs/search.md`](docs/search.md) |
+| Understand the main product capabilities | [`docs/features.md`](docs/features.md) |
+| Use SquillaRouter | [`docs/features/squilla-router.md`](docs/features/squilla-router.md) |
+| Understand tool compression and tool-result handles | [`docs/features/tool-compression.md`](docs/features/tool-compression.md) |
+| Use and author meta-skills | [`docs/features/meta-skills.md`](docs/features/meta-skills.md) |
+| Work with memory | [`docs/features/memory.md`](docs/features/memory.md) |
+| Work with skills | [`docs/features/skills.md`](docs/features/skills.md) |
+| Understand compaction, cache, and long-session continuity | [`docs/features/compaction-and-cache.md`](docs/features/compaction-and-cache.md) |
+| Publish artifacts and use media features | [`docs/artifacts-and-media.md`](docs/artifacts-and-media.md) |
+| Connect chat channels | [`docs/channels.md`](docs/channels.md) |
+| Create durable named agents | [`docs/agents.md`](docs/agents.md) |
+| Schedule recurring or one-time work | [`docs/scheduling.md`](docs/scheduling.md) |
+| Understand tools, sandboxing, and approvals | [`docs/tools-and-sandbox.md`](docs/tools-and-sandbox.md) |
+| Choose permissions and approval posture | [`docs/approvals-and-permissions.md`](docs/approvals-and-permissions.md) |
+| Inspect usage and model cost | [`docs/usage-and-cost.md`](docs/usage-and-cost.md) |
+| Diagnose and replay a turn | [`docs/diagnostics-and-replay.md`](docs/diagnostics-and-replay.md) |
+| Connect MCP-capable clients | [`docs/mcp-server.md`](docs/mcp-server.md) |
+| Run sessions, cron, diagnostics, migration, and MCP operations | [`docs/operations.md`](docs/operations.md) |
+| Fix common install/runtime problems | [`docs/troubleshooting.md`](docs/troubleshooting.md) |
+| Understand OpenSquilla terminology | [`docs/glossary.md`](docs/glossary.md) |
+
+## The Fastest Useful Workflow
+
+After the gateway is running, use the surface that fits the job:
+
+```sh
+opensquilla chat
+```
+
+Use this for interactive terminal work.
+
+```sh
+opensquilla agent -m "Summarize this repo and tell me what to test"
+```
+
+Use this for one-shot automation.
+
+```sh
+opensquilla gateway start --json
+```
+
+Use this for background Web UI, channels, and RPC clients.
+
+```sh
+opensquilla sessions list
+opensquilla cost
+opensquilla doctor
+```
+
+Use these to inspect history, cost, and readiness.
+
+## Configuration Essentials
+
+OpenSquilla loads configuration in this order:
+
+1. `OPENSQUILLA_GATEWAY_CONFIG_PATH`
+2. `./opensquilla.toml`
+3. `~/.opensquilla/config.toml`
+4. built-in defaults
+
+Use the CLI for routine changes:
+
+```sh
+opensquilla onboard --if-needed
+opensquilla configure provider --provider openrouter --api-key-env OPENROUTER_API_KEY
+opensquilla configure router --router recommended
+opensquilla configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
+opensquilla configure channels
+opensquilla config get llm.provider
+opensquilla config set gateway.port 18791
+```
+
+See [`docs/configuration.md`](docs/configuration.md) for details.
+
+## Feature Highlights
+
+### SquillaRouter
+
+SquillaRouter is OpenSquilla's local routing layer. It keeps lightweight tasks
+on cheaper models and reserves stronger tiers for harder turns. Router
+decisions stay local; the user's prompt is not sent to a separate external
+classifier just to decide the model.
+
+Read: [`docs/features/squilla-router.md`](docs/features/squilla-router.md)
+
+### Tool Compression
+
+Agent work often creates huge tool results: logs, web pages, search results,
+spreadsheets, diffs, and JSON. OpenSquilla can keep the raw result available
+while projecting a compact model-visible preview, reducing context pressure
+without throwing away the user's working state.
+
+Read: [`docs/features/tool-compression.md`](docs/features/tool-compression.md)
+
+### Meta-Skills
+
+Meta-skills let OpenSquilla present higher-level workflows instead of making the
+user re-describe the same multi-step process. They are useful for repeatable
+research, reporting, audits, PDF/deck generation, PR review, and other composed
+tasks.
+
+Read: [`docs/features/meta-skills.md`](docs/features/meta-skills.md) and
+[`META_SKILL_GUIDE.md`](META_SKILL_GUIDE.md)
+
+## What OpenSquilla Can Do
+
+- Run chat from Web UI, CLI, gateway RPC, terminal channels, and supported
+  messaging platforms.
+- Use tools for files, shell commands, code execution, git, web search/fetch,
+  memory, sessions, artifacts, media, Feishu, scheduled jobs, and subagents.
+- Install, inspect, publish, and compose skills.
+- Schedule recurring runs with `opensquilla cron`.
+- Save durable memory and search previous sessions.
+- Track usage and estimated cost with `opensquilla cost`.
+- Diagnose readiness with `opensquilla doctor` and `/control/` health views.
+- Export reproducible install state with `opensquilla dist`.
+- Bridge OpenSquilla into MCP-capable clients with `opensquilla mcp-server run`
+  when the `mcp` extra is installed.
+- Create and deliver artifacts such as HTML files, PDF reports, slides,
+  spreadsheets, generated images, and channel-delivered files.
+
+## Safety Defaults
+
+The gateway binds to `127.0.0.1` by default. Binding to public interfaces is
+opt-in:
+
+```sh
+opensquilla gateway run --listen 0.0.0.0 --port 18791
+```
+
+Do not expose a public gateway without token auth and a network boundary you
+trust. For tool behavior, approval flow, and workspace containment, see
+[`docs/tools-and-sandbox.md`](docs/tools-and-sandbox.md).
+
+## Existing Reference Docs
+
+- [`README.md`](README.md) - release/package README
+- [`MIGRATION.md`](MIGRATION.md) - migration from OpenClaw and Hermes Agent
+- [`META_SKILL_GUIDE.md`](META_SKILL_GUIDE.md) - meta-skill authoring guide
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) - contributor workflow
+- [`CHANGELOG.md`](CHANGELOG.md) - release history
+
+## Improve the Documentation
+
+OpenSquilla documentation is part of the product. If a setup step is confusing,
+a command is stale, or a feature guide needs a clearer example, open a small
+pull request against `dev`.
+
+Read [`docs/contributing-docs.md`](docs/contributing-docs.md) for docs-specific
+guidance.
+
+---
+
+[Docs index](docs/README.md) · [Improve these docs](docs/contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml) · [Contributing](CONTRIBUTING.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,79 @@
+# OpenSquilla Documentation
+
+This directory is the user-facing product documentation set. It complements the
+root release README with task-oriented guides.
+
+## Read First
+
+1. [`quickstart.md`](quickstart.md) - install, configure, run, and open the Web UI.
+2. [`use-cases.md`](use-cases.md) - task-oriented recipes for common goals.
+3. [`gateway.md`](gateway.md) - gateway lifecycle, host/port, safety, and status.
+4. [`configuration.md`](configuration.md) - provider, router, search, channel,
+   memory, and permission configuration.
+5. [`cli.md`](cli.md) - command groups and common CLI workflows.
+6. [`web-ui.md`](web-ui.md) - local control console and chat UI.
+7. [`sessions.md`](sessions.md) - session continuity, export, resume, abort,
+   and cleanup.
+8. [`glossary.md`](glossary.md) - user-facing terminology.
+
+## Feature Guides
+
+- [`features.md`](features.md) - capability catalog.
+- [`features/squilla-router.md`](features/squilla-router.md) - model routing.
+- [`features/tool-compression.md`](features/tool-compression.md) - compact tool
+  results and handles.
+- [`features/meta-skills.md`](features/meta-skills.md) - reusable workflow skills.
+- [`features/memory.md`](features/memory.md) - durable memory and recall.
+- [`features/skills.md`](features/skills.md) - skill discovery, install, and
+  authoring.
+- [`features/compaction-and-cache.md`](features/compaction-and-cache.md) -
+  long-session compaction and prompt-cache continuity.
+
+## Surfaces and Operations
+
+- [`channels.md`](channels.md) - supported messaging channels and setup flow.
+- [`providers-and-models.md`](providers-and-models.md) - LLM provider catalog,
+  model selection, and runtime-backed model inspection.
+- [`search.md`](search.md) - web search providers and query workflow.
+- [`artifacts-and-media.md`](artifacts-and-media.md) - artifacts, generated
+  files, images, PDF, and TTS.
+- [`tools-and-sandbox.md`](tools-and-sandbox.md) - built-in tools, approvals,
+  sandbox posture, and write policy.
+- [`approvals-and-permissions.md`](approvals-and-permissions.md) - permission
+  profiles, approval commands, workspace containment, and sandbox posture.
+- [`agents.md`](agents.md) - durable named agents and workspace defaults.
+- [`scheduling.md`](scheduling.md) - recurring and one-time scheduled work.
+- [`mcp-server.md`](mcp-server.md) - MCP server bridge for MCP-capable clients.
+- [`usage-and-cost.md`](usage-and-cost.md) - token usage, estimated cost, and
+  cost investigation workflow.
+- [`diagnostics-and-replay.md`](diagnostics-and-replay.md) - diagnostics,
+  raw capture guidance, and read-only turn replay.
+- [`operations.md`](operations.md) - sessions, cron, usage, diagnostics,
+  migration, MCP server, and install inventory commands.
+- [`troubleshooting.md`](troubleshooting.md) - common install/runtime issues.
+- [`glossary.md`](glossary.md) - short definitions for product terms.
+
+## Improve These Docs
+
+Documentation improvements are welcome. Start with
+[`contributing-docs.md`](contributing-docs.md) for docs-specific guidance, then
+open a small pull request against `dev`.
+
+Fast paths:
+
+- Report a stale command, broken link, or confusing page with the
+  [documentation issue template](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml).
+- Edit the affected Markdown page on GitHub and open a focused pull request
+  against `dev`.
+- For new feature documentation, keep independent features on independent pages
+  under `docs/features/`.
+
+## Design Principle
+
+OpenSquilla documentation should help users run the product first, then
+understand its special advantages. Mechanism-heavy runtime detail belongs in
+developer design notes or source comments, not in the first-run path.
+
+---
+
+[Product guide](../README.product.md) · [Improve these docs](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml) · [Contributing](../CONTRIBUTING.md)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,96 @@
+# Durable Agents
+
+OpenSquilla agents are named runtime profiles. Use them when different work
+streams need different defaults, such as a research workspace, a writing
+workspace, or a channel-facing assistant.
+
+The built-in `main` agent is always available. Additional agents are configured
+with `opensquilla agents`.
+
+## When to Create an Agent
+
+Create a durable agent when you want a stable identity for:
+
+- a dedicated workspace;
+- a default model choice;
+- a separate channel or automation target;
+- a recurring task profile;
+- a specialized assistant name and description.
+
+Do not create a new agent for every conversation. Use sessions for ordinary
+conversation continuity.
+
+## List Agents
+
+```sh
+opensquilla agents list
+opensquilla agents list --json
+```
+
+## Add an Agent
+
+```sh
+opensquilla agents add research \
+  --name Research \
+  --description "Research and synthesis workspace" \
+  --workspace /path/to/research \
+  --model gpt-5.4-mini
+```
+
+Agent changes are written to configuration. Restart the gateway before relying
+on the updated agent list:
+
+```sh
+opensquilla gateway restart
+```
+
+## Use an Agent With Sessions
+
+Filter sessions by agent:
+
+```sh
+opensquilla sessions list --agent research
+```
+
+Create scheduled work for an agent:
+
+```sh
+opensquilla cron add \
+  --agent research \
+  --every 1h \
+  --text "Summarize new research notes" \
+  --name research-hourly-summary
+```
+
+Channel configuration can also route incoming messages to configured agents
+depending on the channel setup.
+
+## Delete an Agent
+
+```sh
+opensquilla agents delete research
+opensquilla agents delete research --force
+```
+
+Deleting an agent entry leaves workspace files and state untouched. Clean those
+up separately only when you are sure they are no longer needed.
+
+## Agents vs Sessions vs Skills
+
+| Concept | Use for |
+| --- | --- |
+| Agent | Durable identity and defaults for a work stream. |
+| Session | Conversation history and active task continuity. |
+| Skill | Reusable workflow instructions or tool routines. |
+| Meta-skill | A composed workflow made from multiple skill steps. |
+
+Read next:
+
+- [`sessions.md`](sessions.md)
+- [`features/skills.md`](features/skills.md)
+- [`features/meta-skills.md`](features/meta-skills.md)
+- [`channels.md`](channels.md)
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/approvals-and-permissions.md
+++ b/docs/approvals-and-permissions.md
@@ -1,0 +1,137 @@
+# Approvals and Permissions
+
+Approvals and permissions control how OpenSquilla tools are allowed to act.
+They matter most when an agent can write files, run shell commands, publish
+artifacts, post into channels, or call external services.
+
+Use this page before running unattended automation or giving a channel-connected
+agent broad tool access.
+
+## Permission Profiles
+
+Single-shot automation accepts an explicit permission profile:
+
+```sh
+opensquilla agent --permissions restricted -m "Inspect this repo"
+opensquilla agent --permissions on -m "Run with host execution and approvals"
+opensquilla agent --permissions bypass -m "Trusted local automation"
+opensquilla agent --permissions full -m "Fully trusted local automation"
+```
+
+Practical meaning:
+
+| Profile | Use when |
+| --- | --- |
+| `restricted` / `off` | The task should stay conservative and avoid elevated execution. |
+| `on` | Host execution is allowed, but approval checks still matter. |
+| `bypass` | You trust the task enough to auto-grant approvals while keeping sensitive-path checks. |
+| `full` | You fully trust the task and environment. Use sparingly. |
+
+For automation, prefer the narrowest profile that can complete the task.
+
+## Workspace Containment
+
+Set a workspace for file and shell work:
+
+```sh
+opensquilla agent \
+  --workspace /path/to/project \
+  --workspace-strict \
+  -m "Summarize this repo"
+```
+
+Contain writes to the workspace or scratch directory:
+
+```sh
+opensquilla agent \
+  --workspace /path/to/project \
+  --workspace-lockdown \
+  --scratch-dir /path/to/project/.scratch \
+  -m "Investigate and prepare a minimal patch"
+```
+
+Use `--workspace-lockdown` for unattended runs where accidental writes outside
+the project would be unacceptable.
+
+## Interactive Approvals
+
+Interactive chat surfaces can pause sensitive tool calls for a human decision.
+The terminal chat supports:
+
+```text
+/approvals
+/approvals reset
+/permissions status
+/permissions on
+/permissions off
+/permissions bypass
+/permissions full
+/forget
+```
+
+Use these commands when you need to inspect or reset cached approval decisions
+during a chat.
+
+The Web UI also provides an approvals surface for reviewing pending actions
+outside the message scrollback.
+
+## Sandbox Posture
+
+Inspect sandbox posture:
+
+```sh
+opensquilla sandbox status
+opensquilla sandbox status --json
+```
+
+Set posture:
+
+```sh
+opensquilla sandbox on
+opensquilla sandbox bypass
+opensquilla sandbox full
+opensquilla sandbox reset
+```
+
+Restart the gateway after changing global sandbox posture:
+
+```sh
+opensquilla gateway restart
+```
+
+## Recommended Defaults
+
+| Situation | Recommended approach |
+| --- | --- |
+| First run in a repo | `--workspace` plus `--workspace-strict` |
+| Read-only investigation | `--permissions restricted` |
+| Local patch with tests | `--workspace-lockdown` plus a scratch directory |
+| Web UI task with writes | Keep approvals visible and review sensitive actions |
+| Channel-connected agent | Conservative permissions and explicit channel setup |
+| Unattended automation | Bound timeout/iterations and choose the narrowest workable permissions |
+
+## Troubleshooting
+
+If a tool is denied:
+
+```sh
+opensquilla sandbox status
+opensquilla doctor
+```
+
+Then check:
+
+- whether the surface supports live approvals;
+- whether the workspace path is correct;
+- whether cached approvals need to be reset;
+- whether the task should run with a different permission profile.
+
+Read next:
+
+- [`tools-and-sandbox.md`](tools-and-sandbox.md)
+- [`web-ui.md`](web-ui.md)
+- [`channels.md`](channels.md)
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/artifacts-and-media.md
+++ b/docs/artifacts-and-media.md
@@ -1,0 +1,121 @@
+# Artifacts and Media
+
+OpenSquilla can create and deliver files as part of agent work: reports, HTML
+files, PDFs, slide decks, spreadsheets, generated images, and other artifacts.
+Use artifacts when the output is too large, visual, structured, or important to
+leave only in chat text.
+
+## Artifacts
+
+Artifacts are user-visible files created during a session. In Web UI chat they
+appear as artifact cards when the runtime publishes them. In CLI runs, artifact
+events can include file names, ids, and download URLs.
+
+Common use cases:
+
+- generate a report;
+- create a standalone HTML prototype;
+- build a CSV/XLSX workbook;
+- create a PDF briefing;
+- produce a slide deck;
+- package generated output for channel delivery.
+
+Ask directly:
+
+```text
+Create a one-page HTML dashboard from this data and publish it as an artifact.
+```
+
+```text
+Generate a PDF briefing with sources and publish the final file.
+```
+
+## When to Use Artifacts Instead of Chat
+
+Use artifacts for:
+
+- files the user should download or share;
+- tables or reports that need layout;
+- generated apps, dashboards, or prototypes;
+- long output that would be awkward in chat;
+- channel delivery where the platform supports file upload.
+
+Use chat text for short answers, decisions, and next steps.
+
+## Document Skills
+
+OpenSquilla includes skills for common document formats:
+
+- `docx` for Word documents;
+- `pptx` for PowerPoint decks;
+- `xlsx` for Excel workbooks;
+- `pdf-toolkit` for structured PDF work;
+- `html-to-pdf` for styled PDF rendering.
+
+Discover them:
+
+```sh
+opensquilla skills search pdf
+opensquilla skills view pptx
+opensquilla skills view xlsx
+```
+
+Some document features require optional native/system dependencies. Use
+`opensquilla skills list` and `opensquilla doctor` to check readiness.
+
+## Image Input and Generation
+
+In terminal chat, send an image for analysis:
+
+```text
+/image /path/to/screenshot.png Describe what is wrong with this UI.
+```
+
+Configure image generation:
+
+```sh
+opensquilla configure image-generation
+```
+
+Then ask for images in chat:
+
+```text
+Generate a clean product mockup image for this landing page.
+```
+
+Image provider support depends on configured provider credentials, optional
+dependencies, and runtime policy.
+
+## Text to Speech and Media Helpers
+
+The media tool family includes image, PDF, and TTS helpers. Availability can
+depend on provider config, optional dependencies, and runtime policy.
+
+Use media helpers when the requested output is naturally a file or asset rather
+than a plain text answer.
+
+## Channel Delivery
+
+Channels differ in file-size limits, threading behavior, and upload APIs. If a
+channel cannot deliver an artifact directly, use the Web UI artifact card or
+session export as the recovery surface.
+
+For channel setup, see [`channels.md`](channels.md).
+
+## Troubleshooting
+
+If an artifact does not appear:
+
+1. Check the chat or CLI output for artifact events.
+2. Open the Web UI session and inspect artifact cards.
+3. Export the session if you need durable evidence:
+
+   ```sh
+   opensquilla sessions export <session-key>
+   ```
+
+4. Run `opensquilla doctor` if a document or media dependency appears missing.
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,0 +1,142 @@
+# Channels
+
+Channels let OpenSquilla run from messaging platforms while sharing the same
+agent runtime as the CLI and Web UI. Use channels when you want the same agent
+to answer from Slack, Telegram, Feishu/Lark, Discord, DingTalk, WeCom, Matrix,
+QQ, or another supported adapter.
+
+## Supported Channel Types
+
+Inspect your local install:
+
+```sh
+opensquilla channels types
+opensquilla channels types --json
+opensquilla channels describe feishu
+```
+
+This build exposes the following channel families:
+
+| Type | Label | Transport | Public URL needed |
+| --- | --- | --- | :---: |
+| `dingtalk` | DingTalk | websocket | no |
+| `discord` | Discord | websocket | no |
+| `feishu` | Feishu / Lark | mixed | depends on mode |
+| `matrix` | Matrix | websocket | no |
+| `qq` | QQ Bot | websocket | no |
+| `slack` | Slack | webhook | yes |
+| `telegram` | Telegram | mixed | depends on mode |
+| `wecom` | WeCom | webhook | yes |
+
+The local `channels describe <type>` output is the source of truth for required
+fields, secrets, extras, and restart behavior.
+
+## Setup Flow
+
+Interactive setup:
+
+```sh
+opensquilla configure channels
+```
+
+Add a channel explicitly:
+
+```sh
+opensquilla channels add telegram --name personal
+```
+
+Add provider-specific fields as needed:
+
+```sh
+opensquilla channels add slack --name team --field signing_secret=... --token ...
+```
+
+Restart the gateway process after config edits:
+
+```sh
+opensquilla gateway restart
+```
+
+Verify runtime connection:
+
+```sh
+opensquilla channels status
+opensquilla channels status personal --json
+```
+
+Saving a channel proves the config was written. `channels status` proves whether
+the running gateway loaded and connected it.
+
+## Manage Channels
+
+```sh
+opensquilla channels list
+opensquilla channels enable <name>
+opensquilla channels disable <name>
+opensquilla channels edit <name>
+opensquilla channels restart <name>
+opensquilla channels logout <name>
+opensquilla channels remove <name>
+```
+
+Use `gateway restart` after config changes. Use `channels restart <name>` only
+for an already-loaded live adapter.
+
+## Webhook Channels
+
+Slack and WeCom require a public, provider-reachable URL. Feishu and Telegram
+may require one depending on mode.
+
+For public channels:
+
+- bind the gateway to a reachable interface;
+- place it behind a trusted reverse proxy or tunnel;
+- configure auth;
+- check provider callback URLs and secrets carefully.
+
+Example bind for a controlled network:
+
+```sh
+opensquilla gateway run --listen 0.0.0.0 --port 18791
+```
+
+Do not expose an unauthenticated gateway to the public internet.
+
+## Attachments and Artifacts
+
+Channel adapters can differ in attachment and artifact delivery behavior.
+OpenSquilla normalizes agent execution through the same runtime path, but the
+platform transport still controls file size limits, message threading, and
+download/upload capabilities.
+
+When a channel cannot deliver a large artifact directly, use the Web UI artifact
+card or session export as the recovery path.
+
+## Troubleshooting
+
+If a channel does not respond:
+
+1. Check config entries:
+
+   ```sh
+   opensquilla channels list
+   ```
+
+2. Check runtime status:
+
+   ```sh
+   opensquilla channels status <name> --json
+   ```
+
+3. Restart the gateway process after config changes:
+
+   ```sh
+   opensquilla gateway restart
+   ```
+
+4. For webhook channels, confirm the public URL, provider callback secret, and
+   gateway auth/network boundary.
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,241 @@
+# CLI Reference
+
+The `opensquilla` CLI is the fastest way to configure, run, inspect, and
+automate OpenSquilla.
+
+Run:
+
+```sh
+opensquilla --help
+opensquilla <command> --help
+```
+
+## Main Commands
+
+| Command | Purpose |
+| --- | --- |
+| `opensquilla init` | Initialize a workspace. |
+| `opensquilla doctor` | Diagnose readiness and print recovery steps. |
+| `opensquilla onboard` | Run or inspect first-run setup. |
+| `opensquilla configure` | Reconfigure provider, router, channels, search, image generation, or memory embedding. |
+| `opensquilla gateway` | Run and manage the gateway server. |
+| `opensquilla chat` | Start interactive terminal chat. |
+| `opensquilla agent` | Run a single automation-friendly agent turn. |
+| `opensquilla sessions` | List, inspect, resume, abort, delete, or export sessions. |
+| `opensquilla skills` | List, search, view, install, update, publish, and inspect skills. |
+| `opensquilla memory` | Inspect and maintain memory. |
+| `opensquilla channels` | Configure and inspect messaging channels. |
+| `opensquilla providers` | Configure and inspect LLM providers. |
+| `opensquilla search` | Configure and use web search. |
+| `opensquilla sandbox` | Inspect or change default sandbox posture. |
+| `opensquilla cron` | Manage scheduled OpenSquilla runs. |
+| `opensquilla cost` | Inspect usage and estimated cost. |
+| `opensquilla diagnostics` | Enable or disable runtime diagnostics logging. |
+| `opensquilla replay` | Replay a recorded turn from the decision log. |
+| `opensquilla migrate` | Import state from external agent runtimes. |
+| `opensquilla models` | Inspect available models. |
+| `opensquilla agents` | Manage durable agents. |
+| `opensquilla mcp-server` | Run the OpenSquilla MCP server bridge. |
+| `opensquilla dist` | Emit a reproducible workspace-state inventory. |
+| `opensquilla reset` | Reset a session and flush memory synchronously. |
+
+## Run Surfaces
+
+Web UI and gateway:
+
+```sh
+opensquilla gateway run
+opensquilla gateway start --json
+opensquilla gateway status
+opensquilla gateway restart
+opensquilla gateway stop
+```
+
+Terminal chat:
+
+```sh
+opensquilla chat
+opensquilla chat --model gpt-5.4-mini
+opensquilla chat --session <session-key>
+opensquilla chat --standalone --workspace /path/to/project
+```
+
+One-shot automation:
+
+```sh
+opensquilla agent -m "Review the current directory"
+opensquilla agent --json -m "Return a short machine-readable summary"
+opensquilla agent --workspace /path/to/project --workspace-strict -m "Inspect this repo"
+opensquilla agent --timeout 600 --max-iterations 30 -m "Run a bounded investigation"
+```
+
+Useful automation flags:
+
+| Flag | Purpose |
+| --- | --- |
+| `--workspace` | Set the workspace root. |
+| `--workspace-strict` | Restrict read-side file tools to the workspace. |
+| `--workspace-lockdown` | Contain writes to workspace or scratch directory. |
+| `--scratch-dir` | Place temporary scripts/logs/candidate patches in a known directory. |
+| `--timeout` | Set total agent wall-clock timeout. |
+| `--max-iterations` | Bound the model/tool loop. |
+| `--max-provider-retries` | Bound transient provider retries. |
+| `--length-capped-continuations` | Bound automatic continuations after length-limited provider output. |
+| `--thinking` | Override reasoning level. |
+| `--permissions` | Select restricted, bypass, or full permission posture. |
+| `--transcript-path` | Write a JSONL transcript for automation. |
+| `--usage-path` | Write usage JSON. |
+| `--session-db-path` | Persist session replay across invocations. |
+
+## Configuration Commands
+
+Provider and router:
+
+```sh
+opensquilla onboard
+opensquilla onboard status
+opensquilla configure provider --provider openrouter --api-key-env OPENROUTER_API_KEY
+opensquilla configure router --router recommended
+opensquilla providers list
+opensquilla providers configure openrouter
+opensquilla providers status
+```
+
+Search:
+
+```sh
+opensquilla search list
+opensquilla search configure duckduckgo
+opensquilla search query "latest OpenSquilla release"
+opensquilla configure search --search-provider duckduckgo
+```
+
+Channels:
+
+```sh
+opensquilla channels types
+opensquilla channels describe telegram
+opensquilla channels add telegram --name personal
+opensquilla channels list
+opensquilla channels status
+opensquilla channels enable personal
+opensquilla channels disable personal
+opensquilla channels restart personal
+opensquilla channels remove personal
+```
+
+Raw config:
+
+```sh
+opensquilla config get llm.provider
+opensquilla config set gateway.port 18791
+```
+
+More detail:
+
+- [`configuration.md`](configuration.md)
+- [`providers-and-models.md`](providers-and-models.md)
+- [`search.md`](search.md)
+- [`channels.md`](channels.md)
+
+## Skills and Meta-Skills
+
+```sh
+opensquilla skills list
+opensquilla skills search pdf
+opensquilla skills view pdf-toolkit
+opensquilla skills install <skill-name>
+opensquilla skills update --all
+opensquilla skills uninstall <skill-name>
+opensquilla skills inspect meta-web-to-pdf-briefing
+opensquilla skills meta proposals list
+opensquilla skills meta runs list
+opensquilla skills meta runs show <run-id>
+opensquilla skills meta runs steps <run-id>
+opensquilla skills meta runs replay <run-id> --dry-run
+```
+
+Use `skills inspect` when you want to see the compiled step plan for a
+meta-skill before invoking it.
+
+Read:
+
+- [`features/skills.md`](features/skills.md)
+- [`features/meta-skills.md`](features/meta-skills.md)
+
+## Sessions and History
+
+```sh
+opensquilla sessions list
+opensquilla sessions show <session-key>
+opensquilla sessions resume <session-key>
+opensquilla sessions abort <session-key>
+opensquilla sessions export <session-key>
+opensquilla sessions delete <session-key>
+```
+
+Read: [`sessions.md`](sessions.md)
+
+## Memory
+
+```sh
+opensquilla memory status
+opensquilla memory index
+opensquilla memory list
+opensquilla memory search "preference"
+opensquilla memory show <path>
+opensquilla memory dream
+opensquilla memory flush-session <session-key>
+opensquilla memory repair list
+opensquilla memory raw-fallbacks list
+```
+
+Read: [`features/memory.md`](features/memory.md)
+
+## Durable Agents and Scheduling
+
+```sh
+opensquilla agents list
+opensquilla agents add research --name Research --workspace /path/to/research
+opensquilla agents delete research
+opensquilla cron list
+opensquilla cron add --every 1h --text "Summarize important updates" --name hourly-summary
+opensquilla cron status <job-id>
+opensquilla cron runs <job-id>
+```
+
+Read:
+
+- [`agents.md`](agents.md)
+- [`scheduling.md`](scheduling.md)
+
+## Cost, Diagnostics, and Replay
+
+```sh
+opensquilla cost
+opensquilla diagnostics status
+opensquilla diagnostics on
+opensquilla diagnostics off
+opensquilla replay --session <session-key> --turn <turn-id>
+```
+
+Use diagnostics and replay when you need to understand why a turn behaved a
+certain way.
+
+Read:
+
+- [`usage-and-cost.md`](usage-and-cost.md)
+- [`diagnostics-and-replay.md`](diagnostics-and-replay.md)
+
+## MCP Server Bridge
+
+```sh
+opensquilla mcp-server run
+opensquilla mcp-server run --gateway ws://localhost:18792/ws
+```
+
+Read: [`mcp-server.md`](mcp-server.md)
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,281 @@
+# Configuration
+
+OpenSquilla can be configured from the onboarding wizard, the Web UI setup
+flow, CLI commands, environment variables, and TOML files. Use CLI commands for
+routine setup and edit TOML only for advanced or scripted deployments.
+
+## Config Load Order
+
+OpenSquilla reads configuration in this order:
+
+1. `OPENSQUILLA_GATEWAY_CONFIG_PATH`
+2. `./opensquilla.toml`
+3. `~/.opensquilla/config.toml`
+4. built-in defaults
+
+Use `--config ./opensquilla.toml` when you want to write or inspect a
+project-local config file.
+
+## Secret Handling
+
+Prefer environment-variable references for secrets:
+
+```sh
+export OPENROUTER_API_KEY="sk-..."
+opensquilla configure provider --provider openrouter --api-key-env OPENROUTER_API_KEY
+```
+
+Avoid committing raw API keys to TOML files, shell history, examples, or issue
+reports.
+
+## First-Run Wizard
+
+```sh
+opensquilla onboard
+```
+
+Common options:
+
+```sh
+opensquilla onboard --if-needed
+opensquilla onboard --minimal
+opensquilla onboard --provider openrouter --api-key-env OPENROUTER_API_KEY
+opensquilla onboard --provider openai --model gpt-5.4-mini --api-key-env OPENAI_API_KEY
+opensquilla onboard --provider ollama --model llama3.1
+opensquilla onboard status
+```
+
+The router mode defaults to `recommended`. Use `--router disabled` when you want
+direct single-model routing.
+
+## Reconfigure One Section
+
+The `configure` command edits a selected section:
+
+```sh
+opensquilla configure provider --provider openrouter --api-key-env OPENROUTER_API_KEY
+opensquilla configure router --router recommended
+opensquilla configure router --router openrouter-mix
+opensquilla configure router --router disabled
+opensquilla configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
+opensquilla configure channels
+opensquilla configure image-generation
+opensquilla configure memory-embedding
+```
+
+Supported sections:
+
+- `provider`
+- `router`
+- `channels`
+- `search`
+- `image-generation`
+- `memory-embedding`
+
+## Configuration Decision Table
+
+| Need | Preferred command |
+| --- | --- |
+| First setup | `opensquilla onboard` |
+| CI or install scripts | `opensquilla onboard --if-needed` |
+| Change provider | `opensquilla configure provider ...` |
+| Enable or disable routing | `opensquilla configure router ...` |
+| Configure web search | `opensquilla configure search ...` |
+| Configure messaging platforms | `opensquilla configure channels` |
+| Inspect current values | `opensquilla config get` |
+| Persist an advanced key | `opensquilla config set <key> <value> --config <path>` |
+
+## Provider Configuration
+
+Inspect provider support:
+
+```sh
+opensquilla providers list
+opensquilla providers configure openrouter
+opensquilla providers status
+```
+
+Onboarding-verified providers include:
+
+- OpenRouter
+- OpenAI
+- Anthropic
+- Ollama
+- DeepSeek
+- Gemini
+- DashScope / Qwen
+- Moonshot AI
+- Zhipu / Z.AI
+- Baidu Qianfan
+- Volcengine Ark
+
+OpenSquilla also carries provider registry entries for additional
+OpenAI-compatible or self-hosted backends. Use `opensquilla providers list` on
+your install to see the current catalog.
+
+Read: [`providers-and-models.md`](providers-and-models.md)
+
+## Router Configuration
+
+Router modes:
+
+| Mode | Use when |
+| --- | --- |
+| `recommended` | You want the selected provider's default routing profile. |
+| `openrouter-mix` | You want OpenRouter mixed-model defaults. |
+| `disabled` | You want one configured provider/model for every turn. |
+
+Commands:
+
+```sh
+opensquilla configure router --router recommended
+opensquilla configure router --router openrouter-mix
+opensquilla configure router --router disabled
+```
+
+Router-supported provider profiles depend on the installed build and configured
+provider. Read [`features/squilla-router.md`](features/squilla-router.md) before
+using direct model runs for evaluation.
+
+## Search Configuration
+
+Inspect search providers:
+
+```sh
+opensquilla search list
+opensquilla search status
+opensquilla search query "OpenSquilla release notes"
+```
+
+Configure search:
+
+```sh
+opensquilla configure search --search-provider duckduckgo
+opensquilla configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
+```
+
+Runtime-supported search providers in this build include Brave Search and
+DuckDuckGo. Additional provider metadata may be present for future or
+not-yet-runtime-supported integrations.
+
+Read: [`search.md`](search.md)
+
+## Channel Configuration
+
+List supported channel types:
+
+```sh
+opensquilla channels types --json
+opensquilla channels describe feishu
+opensquilla channels add telegram --name personal
+opensquilla channels status
+```
+
+Channel saves update configuration. Restart the gateway after edits:
+
+```sh
+opensquilla gateway restart
+opensquilla channels status <name> --json
+```
+
+See [`channels.md`](channels.md) for details.
+
+## Memory Configuration
+
+Useful commands:
+
+```sh
+opensquilla memory status
+opensquilla memory index
+opensquilla memory list
+opensquilla memory search "project preference"
+opensquilla memory show <path>
+opensquilla memory dream
+opensquilla memory flush-session <session-key>
+```
+
+Configure embedding behavior:
+
+```sh
+opensquilla configure memory-embedding
+```
+
+Memory can combine Markdown-backed sources with SQLite keyword and semantic
+indexes. The exact memory shape depends on the configured provider and local
+embedding support.
+
+Read: [`features/memory.md`](features/memory.md)
+
+## Sandbox and Permissions
+
+Inspect or change posture:
+
+```sh
+opensquilla sandbox status
+opensquilla sandbox on
+opensquilla sandbox full
+opensquilla sandbox bypass
+opensquilla sandbox reset
+```
+
+Single-shot automation permissions:
+
+```sh
+opensquilla agent --permissions restricted -m "Read the repo and summarize it"
+opensquilla agent --permissions full -m "Make a local patch and run tests"
+```
+
+For unattended automation that must stay inside a workspace:
+
+```sh
+opensquilla agent \
+  --workspace /path/to/project \
+  --workspace-lockdown \
+  --scratch-dir /path/to/project/.scratch \
+  -m "Investigate and propose the smallest fix"
+```
+
+Read: [`tools-and-sandbox.md`](tools-and-sandbox.md)
+
+## Gateway Binding
+
+Foreground:
+
+```sh
+opensquilla gateway run --listen 127.0.0.1 --port 18791
+```
+
+Managed:
+
+```sh
+opensquilla gateway start --json
+opensquilla gateway status
+opensquilla gateway stop
+opensquilla gateway restart
+```
+
+Bind precedence:
+
+1. `--listen`
+2. `--bind`
+3. `OPENSQUILLA_LISTEN`
+4. `OPENSQUILLA_GATEWAY_HOST`
+5. config host
+6. `127.0.0.1`
+
+## Raw Config Editing
+
+For advanced settings, inspect `opensquilla.toml.example` and edit the active
+config file directly. Use CLI commands for routine provider, router, search,
+channel, and sandbox changes because they avoid common key-shape mistakes.
+
+After changing files by hand, restart the gateway and run:
+
+```sh
+opensquilla doctor
+opensquilla gateway status
+```
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -1,0 +1,68 @@
+# Contributing to the Documentation
+
+OpenSquilla welcomes documentation improvements from users and contributors.
+Good documentation changes help people install the product, choose the right
+feature, and recover from common problems without needing maintainer context.
+
+## What to Improve
+
+Useful documentation pull requests include:
+
+- clearer install or setup steps;
+- runnable command examples;
+- screenshots or wording that make the Web UI easier to understand;
+- missing provider, channel, memory, skill, or tool workflows;
+- troubleshooting notes for common failures;
+- corrections when a command, option, or behavior has changed.
+
+Keep feature guides focused on user value and usage. Avoid adding deep runtime
+internals unless the detail is needed to help users operate the product.
+
+## How to Edit
+
+1. If the problem is small, open the affected Markdown page on GitHub and use
+   the pencil edit flow.
+2. If you are not sure of the fix, open a
+   [documentation issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)
+   with the affected page and expected outcome.
+3. Open documentation pull requests against `dev`.
+4. Keep docs changes small and topic-focused.
+5. Use relative links for repository pages.
+6. Prefer concrete commands and examples over abstract descriptions.
+7. If a page describes a CLI command, verify the command name against the local
+   CLI or an existing reference page.
+
+For general contribution rules, see [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## Docs-Only Checks
+
+For documentation-only changes, at minimum check:
+
+- links point to existing repository files;
+- Markdown code fences are balanced;
+- examples do not include private paths, secrets, or real provider keys;
+- screenshots or UI wording match the current product surface;
+- product claims stay user-facing and do not expose unnecessary implementation
+  details.
+
+If a documentation change also changes code, tests, packaging, provider
+behavior, gateway behavior, channels, or browser UI behavior, follow the full
+project checklist in [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## Page Structure
+
+Most user-facing pages should answer:
+
+1. What is this feature for?
+2. When should I use it?
+3. How do I configure or run it?
+4. What should I check when it does not work?
+5. Where should I go next?
+
+Independent features should stay on independent pages. For example, memory,
+skills, meta-skills, SquillaRouter, tool compression, compaction, channels, and
+artifacts should not be merged into one broad mechanism page.
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml) · [Contributing](../CONTRIBUTING.md)

--- a/docs/diagnostics-and-replay.md
+++ b/docs/diagnostics-and-replay.md
@@ -1,0 +1,101 @@
+# Diagnostics and Replay
+
+Diagnostics and replay help explain what happened during an OpenSquilla turn.
+Use them when a result was surprising, slow, expensive, interrupted, or hard to
+reproduce from the chat transcript alone.
+
+## Diagnostics
+
+Diagnostics are runtime logging controls exposed through the gateway.
+
+Check status:
+
+```sh
+opensquilla diagnostics status
+opensquilla diagnostics status --json
+```
+
+Enable diagnostics:
+
+```sh
+opensquilla diagnostics on
+```
+
+Enable raw turn-call capture when a maintainer asks for deeper provider request
+evidence:
+
+```sh
+opensquilla diagnostics on --raw
+```
+
+Turn diagnostics off after collecting enough evidence:
+
+```sh
+opensquilla diagnostics off
+```
+
+## When to Use Diagnostics
+
+Use diagnostics for:
+
+- provider retries, timeouts, or empty responses;
+- SquillaRouter model decisions;
+- prompt-cache or cache-break investigation;
+- compaction lifecycle events;
+- large tool-result compression;
+- channel delivery failures;
+- unusually high cost or latency.
+
+Avoid leaving raw diagnostics on longer than needed. Raw captures may contain
+private prompts, tool outputs, local paths, or provider-visible content.
+
+## Replay a Recorded Turn
+
+Replay reads a recorded turn from the decision log and prints a human-readable
+transcript. It is read-only: it does not re-run tools.
+
+```sh
+opensquilla replay --session <session-key> --turn <turn-id>
+```
+
+Use replay when:
+
+- a chat has moved on but you need to inspect an earlier turn;
+- a bug report needs concise reproduction evidence;
+- you want to compare transcript output with diagnostics and cost data.
+
+## Pair Replay With Sessions
+
+Find the session first:
+
+```sh
+opensquilla sessions list
+opensquilla sessions show <session-key>
+```
+
+Export the full session if exact context matters:
+
+```sh
+opensquilla sessions export <session-key> --output session.md
+```
+
+## Safe Sharing
+
+Before sharing diagnostics, replay output, or exported sessions publicly,
+remove:
+
+- provider keys and bearer tokens;
+- private local paths;
+- private channel identifiers;
+- customer, project, or account names that should not be public;
+- raw provider prompts or tool outputs that include confidential content.
+
+Read next:
+
+- [`sessions.md`](sessions.md)
+- [`usage-and-cost.md`](usage-and-cost.md)
+- [`troubleshooting.md`](troubleshooting.md)
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,172 @@
+# Feature Catalog
+
+OpenSquilla combines a personal-agent runtime with model routing, tools, memory,
+channels, scheduling, and reusable skills.
+
+## Product Surfaces
+
+| Surface | What it is for |
+| --- | --- |
+| Web UI | Local control console, setup, chat sessions, approvals, logs, channels, and usage surfaces. |
+| CLI chat | Interactive terminal agent work. |
+| CLI agent | Single-turn automation, CI-like runs, and benchmark-style invocations. |
+| Gateway RPC | Local server surface for Web UI, CLI clients, channels, and external clients. |
+| Channels | Telegram, Slack, Feishu/Lark, Discord, DingTalk, WeCom, Matrix, QQ, terminal, and websocket-style integrations. |
+
+## Distinctive Features
+
+### SquillaRouter
+
+Local routing for model tier selection. It is designed to keep easy turns cheap
+and reserve expensive models for work that needs them.
+
+Read: [`features/squilla-router.md`](features/squilla-router.md)
+
+### Tool Compression
+
+Large tool outputs are projected into compact provider-visible previews while
+the runtime can keep richer raw results out-of-band.
+
+Read: [`features/tool-compression.md`](features/tool-compression.md)
+
+### Meta-Skills
+
+Repeatable multi-step workflows can be represented as skills, inspected,
+proposed, replayed, and reused.
+
+Read: [`features/meta-skills.md`](features/meta-skills.md)
+
+### Memory
+
+Durable memory lets OpenSquilla recall useful user preferences, project notes,
+and previous task traces without forcing every old transcript into the active
+prompt.
+
+Read: [`features/memory.md`](features/memory.md)
+
+### Skills
+
+Skills package task-specific guidance and scripts so the agent can load the
+right operating instructions only when a task needs them.
+
+Read: [`features/skills.md`](features/skills.md)
+
+### Compaction and Cache Continuity
+
+Long sessions can compact old context, preserve recent task state, and report
+compaction lifecycle events.
+
+Read: [`features/compaction-and-cache.md`](features/compaction-and-cache.md)
+
+### Sessions and Durable Agents
+
+Sessions preserve conversation continuity, exports, and running-task control.
+Durable agents provide named identities and defaults for recurring workstreams.
+
+Read: [`sessions.md`](sessions.md) and [`agents.md`](agents.md)
+
+### Usage, Diagnostics, and Permissions
+
+Usage reports explain recent model spend. Diagnostics and replay help inspect a
+turn after it runs. Permission and approval controls keep tool access matched to
+the task.
+
+Read: [`usage-and-cost.md`](usage-and-cost.md),
+[`diagnostics-and-replay.md`](diagnostics-and-replay.md), and
+[`approvals-and-permissions.md`](approvals-and-permissions.md)
+
+## Core Runtime Capabilities
+
+- Unified `TurnRunner` path across Web UI, CLI, and channels.
+- Provider abstraction for OpenAI-compatible APIs, Anthropic, Ollama, and other
+  configured backends.
+- Streaming responses, tool calls, retries, approvals, artifacts, and final
+  usage accounting.
+- Durable session storage with transcript, summaries, context states, and
+  replay support.
+- Per-agent workspaces and durable agent entries.
+- Subagent support for bounded delegation.
+
+## Tools
+
+OpenSquilla includes tools for:
+
+- Filesystem read/write/edit/list/glob/grep.
+- Shell commands, background processes, and code execution.
+- Git status, diff, log, and commit.
+- Web search and web fetch.
+- Memory search/save/get/delete.
+- Session search, session spawn/send/history/status.
+- Artifact publication.
+- Image generation, PDF, TTS, and media workflows.
+- Spreadsheet, PPTX, DOCX, CSV, and PDF authoring through bundled skills.
+- Feishu/Lark docs, chat, drive, wiki, permissions, and media upload.
+- Cron and gateway administration.
+- Skill listing, viewing, creating, editing, installing dependencies, and
+  meta-skill invocation.
+
+Read: [`tools-and-sandbox.md`](tools-and-sandbox.md)
+
+## Skills
+
+Bundled user-facing skills include:
+
+- `deep-research`
+- `summarize`
+- `memory`
+- `cron`
+- `github`
+- `docx`
+- `pptx`
+- `xlsx`
+- `pdf-toolkit`
+- `html-to-pdf`
+- `multi-search-engine`
+- `weather`
+- `tmux`
+- `sub-agent`
+- `skill-creator`
+
+Bundled meta-skills include workflows for PR review, security review, web
+research reports, PDF briefings, travel planning, knowledge-base bootstrap,
+arXiv digest decks, long-running build watch, compliance bundles, and
+meta-skill creation.
+
+Read: [`features/skills.md`](features/skills.md)
+
+## Scheduling
+
+The `cron` command group manages scheduled OpenSquilla runs:
+
+```sh
+opensquilla cron list
+opensquilla cron add \
+  --every 1h \
+  --text "Summarize important project updates" \
+  --name hourly-project-check
+opensquilla cron status <job-id>
+opensquilla cron run <job-id>
+opensquilla cron runs <job-id>
+```
+
+Scheduled jobs can deliver work through configured surfaces such as channels or
+webhooks depending on the configured job.
+
+Read: [`scheduling.md`](scheduling.md)
+
+## Migration
+
+OpenSquilla can import compatible state from OpenClaw and Hermes Agent:
+
+```sh
+opensquilla migrate openclaw --json
+opensquilla migrate openclaw --apply
+opensquilla migrate hermes --json
+opensquilla migrate hermes --apply
+```
+
+Read: [`../MIGRATION.md`](../MIGRATION.md)
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/features/compaction-and-cache.md
+++ b/docs/features/compaction-and-cache.md
@@ -1,0 +1,114 @@
+# Compaction and Cache Continuity
+
+Long agent sessions need context management. OpenSquilla uses compaction,
+bounded history, tool-result projection, and cache-aware prompt placement to
+keep long-running tasks moving.
+
+Compaction is separate from memory. Memory is durable recall. Compaction is an
+active-session continuity tool.
+
+## What Compaction Does
+
+When session history approaches the configured context budget, OpenSquilla can
+compact older transcript entries into a durable summary and keep the recent
+tail active.
+
+The goal is to preserve:
+
+- user goal;
+- current status;
+- open steps;
+- changed files and artifacts;
+- known failures;
+- important tool results;
+- next action.
+
+Compaction is not a guarantee that every old word remains model-visible. Export
+sessions or save files when exact historical text matters.
+
+## User-Visible Lifecycle
+
+Depending on surface and trigger, users may see:
+
+- compaction started;
+- compaction skipped;
+- compaction completed;
+- compaction failed.
+
+When no compaction is needed, OpenSquilla uses this stable message:
+
+```text
+Already within context budget; no compact was applied
+```
+
+That message is a no-op, not a failure.
+
+## When to Compact Manually
+
+Manual compaction is useful when:
+
+- the session is long and you are about to start a new phase;
+- a previous tool-heavy turn produced a lot of context;
+- the UI indicates context pressure;
+- you want the next answer to focus on the current state rather than the whole
+  transcript.
+
+Avoid compact loops when the runtime says the session is already within budget.
+
+## Passive Compaction
+
+Passive compaction can happen when OpenSquilla detects context pressure before
+or during agent work. The exact trigger depends on model context limits,
+configured budgets, current history, and tool output size.
+
+If passive compaction fails, the safest user response is usually:
+
+1. let the current turn finish or fail cleanly;
+2. export the session if exact history matters;
+3. retry with a narrower request or manually save key artifacts;
+4. enable diagnostics if the failure repeats.
+
+## Prompt Cache Continuity
+
+Prompt caching works best when stable prompt parts stay stable. OpenSquilla
+tries to keep:
+
+- stable system prompt and tool definitions early;
+- current request, volatile runtime context, retrieved history, and tool results
+  near the tail;
+- model/provider switches visible through diagnostics when they may affect
+  cache continuity.
+
+Cache continuity is best-effort. Routing, tools, attachments, provider changes,
+or a large new context can reduce cache reuse.
+
+## Related Commands and Surfaces
+
+Manual compaction is primarily surfaced in chat and Web UI flows. For
+inspection and recovery:
+
+```sh
+opensquilla sessions show <session-key>
+opensquilla sessions export <session-key>
+opensquilla diagnostics on
+```
+
+For memory repair surfaces related to degraded compaction records:
+
+```sh
+opensquilla memory repair list
+opensquilla memory repair show --summary-id <id>
+opensquilla memory raw-fallbacks list
+```
+
+## Best Practices
+
+- Keep important final artifacts in files or published artifacts.
+- Use memory for durable preferences and reusable project facts.
+- Use session export for exact old transcripts.
+- Use manual compaction before a new phase in a very long session.
+- Do not repeatedly compact a short or already-within-budget session.
+
+---
+
+[Docs index](../README.md) · [Product guide](../../README.product.md) · [Improve this page](../contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/features/memory.md
+++ b/docs/features/memory.md
@@ -1,0 +1,129 @@
+# Memory
+
+OpenSquilla memory helps the agent recall durable context without replaying
+every old conversation. Use it for stable preferences, reusable project facts,
+previous decisions, and notes that should survive across sessions.
+
+Memory is separate from skills. Skills teach the agent how to do a task; memory
+stores useful facts and context the agent may need later.
+
+## What to Store
+
+Good memory entries are stable and reusable:
+
+- user preferences;
+- project conventions;
+- recurring output formats;
+- names of important repositories, directories, or services;
+- decisions the user wants reused;
+- brief notes from completed tasks.
+
+Avoid memory for:
+
+- API keys or secrets;
+- raw private data that does not need long-term recall;
+- one-off instructions for the current turn;
+- noisy dumps that would pollute future retrieval;
+- exact transcripts that should instead be exported as session records.
+
+## Common Commands
+
+Inspect memory health:
+
+```sh
+opensquilla memory status
+opensquilla memory status --deep
+```
+
+Index and list memory sources:
+
+```sh
+opensquilla memory index
+opensquilla memory list
+```
+
+Search and inspect memory:
+
+```sh
+opensquilla memory search "release note format"
+opensquilla memory show <path>
+```
+
+Search previous sessions as well as memory:
+
+```sh
+opensquilla memory search "deployment decision" --source all
+```
+
+## Natural Chat Usage
+
+Ask naturally when something should be remembered:
+
+```text
+Remember that I prefer concise release notes with a risk section.
+```
+
+Later, refer to the preference:
+
+```text
+Use my usual release-note format for this changelog.
+```
+
+When memory seems stale, ask the agent to search explicitly:
+
+```text
+Search memory for my release-note preferences before drafting this.
+```
+
+## Session-Derived Memory
+
+For long or important sessions, flush session state into memory before
+archiving, compacting, or switching tasks:
+
+```sh
+opensquilla memory flush-session <session-key>
+```
+
+Use session export when exact old wording matters:
+
+```sh
+opensquilla sessions export <session-key>
+```
+
+Memory is for useful recall. Session export is for exact records.
+
+## Maintenance and Repair
+
+Refresh the index after editing memory files or changing memory configuration:
+
+```sh
+opensquilla memory index --force
+```
+
+Inspect fallback and repair surfaces:
+
+```sh
+opensquilla memory raw-fallbacks list
+opensquilla memory repair list
+```
+
+Show or repair a degraded compaction memory record when instructed by
+diagnostics:
+
+```sh
+opensquilla memory repair show --summary-id <id>
+opensquilla memory repair run --summary-id <id>
+```
+
+## Best Practices
+
+- Keep entries short and sourceable.
+- Prefer "Remember X for project Y" over vague "remember this."
+- Search memory before assuming the agent forgot.
+- Remove or revise stale preferences instead of adding contradictory ones.
+- Keep secrets out of memory.
+- Use artifacts or files for large reference material.
+
+---
+
+[Docs index](../README.md) · [Product guide](../../README.product.md) · [Improve this page](../contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/features/meta-skills.md
+++ b/docs/features/meta-skills.md
@@ -1,0 +1,129 @@
+# Meta-Skills
+
+Meta-skills package repeatable multi-step work as reusable workflows. They are
+for tasks that naturally combine skills, tools, routing, checkpoints, and final
+synthesis.
+
+Use this page when a normal skill is too small and a full custom integration is
+too heavy.
+
+## Skills vs Meta-Skills
+
+| Capability | Use it for |
+| --- | --- |
+| Skill | One focused task pattern, instruction set, or tool helper. |
+| Meta-skill | A reusable workflow made of multiple steps, skills, checks, or outputs. |
+
+For example, "summarize a document" is a skill-shaped task. "Search the web,
+collect sources, draft a report, render it as a PDF, and save the artifact" is
+a meta-skill-shaped task.
+
+## Good Fits
+
+Use a meta-skill for:
+
+- web research reports;
+- PDF or slide briefings;
+- current-diff review bundles;
+- pre-commit quality gates;
+- security or compliance review bundles;
+- knowledge-base bootstrap;
+- travel planning;
+- long-running operational checks;
+- repeatable document generation.
+
+Avoid meta-skills for:
+
+- one-off instructions;
+- a single tool call;
+- vague brainstorming with no stable workflow;
+- workflows that need frequent manual redesign.
+
+## Discover Meta-Skills
+
+List and search skills:
+
+```sh
+opensquilla skills list
+opensquilla skills search meta
+```
+
+Inspect a meta-skill composition:
+
+```sh
+opensquilla skills inspect <meta-skill-name>
+```
+
+The inspect command is useful before relying on a workflow because it shows the
+compiled step shape at a product level.
+
+## Run Meta-Skills
+
+Meta-skills are usually invoked by the agent when the user's request matches
+their triggers. You can also ask for one directly:
+
+```text
+Use the web-to-PDF briefing workflow for this topic.
+```
+
+Prefer outcome-first requests:
+
+```text
+Create a sourced PDF briefing on this competitor and include risks.
+```
+
+OpenSquilla can then choose the matching workflow when one is available.
+
+## Inspect Run History
+
+List recent runs:
+
+```sh
+opensquilla skills meta runs list
+```
+
+Inspect one run:
+
+```sh
+opensquilla skills meta runs show <run-id>
+opensquilla skills meta runs steps <run-id>
+opensquilla skills meta runs failures --since 24h
+```
+
+Preview replay shape without executing live work:
+
+```sh
+opensquilla skills meta runs replay <run-id> --dry-run
+```
+
+## Proposals
+
+Meta-skill creation workflows may write proposals before they become managed
+skills. Inspect proposals:
+
+```sh
+opensquilla skills meta proposals list
+opensquilla skills meta proposals show <proposal-id>
+```
+
+Accept a proposal only after review:
+
+```sh
+opensquilla skills meta proposals accept <proposal-id>
+```
+
+## Authoring
+
+For full authoring rules, templates, safety notes, and examples, read:
+
+```text
+META_SKILL_GUIDE.md
+```
+
+Keep meta-skill descriptions user-facing. A good description tells users when to
+use the workflow and what output to expect; it does not advertise scheduler
+mechanics.
+
+---
+
+[Docs index](../README.md) · [Product guide](../../README.product.md) · [Improve this page](../contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -1,0 +1,157 @@
+# Skills
+
+Skills are task-specific instruction packages and scripts. They let OpenSquilla
+load relevant guidance only when a task needs it, instead of putting every
+possible instruction into every prompt.
+
+Skills are separate from memory. Memory stores facts; skills describe repeatable
+ways to work.
+
+## What Skills Are For
+
+Use skills for repeatable work patterns such as:
+
+- deep research;
+- summarization;
+- GitHub and PR workflows;
+- document generation;
+- spreadsheet, slide, PDF, and DOCX work;
+- web search;
+- weather lookup;
+- terminal or tmux monitoring;
+- subagent delegation;
+- skill creation and review.
+
+If the workflow combines multiple skills or a reusable multi-step plan, use a
+meta-skill instead.
+
+## Discover Installed Skills
+
+List skills available in the current install:
+
+```sh
+opensquilla skills list
+```
+
+View one skill:
+
+```sh
+opensquilla skills view <skill-name>
+```
+
+Search community sources:
+
+```sh
+opensquilla skills search pdf
+```
+
+Some skills may be ineligible when optional dependencies are missing or when the
+skill is intentionally demo-only. `skills list` is the source of truth for your
+current install.
+
+## Install, Update, and Remove Skills
+
+Install a managed skill:
+
+```sh
+opensquilla skills install <skill-name>
+```
+
+Update one skill or all managed skills:
+
+```sh
+opensquilla skills update <skill-name>
+opensquilla skills update --all
+```
+
+Remove a managed skill:
+
+```sh
+opensquilla skills uninstall <skill-name>
+```
+
+## Manage Skill Sources
+
+Custom source repositories are called taps:
+
+```sh
+opensquilla skills tap list
+opensquilla skills tap add <owner/repo>
+opensquilla skills tap remove <owner/repo>
+```
+
+Use taps when your team maintains its own skill catalog.
+
+## Publish and Inspect
+
+Publish a skill directory:
+
+```sh
+opensquilla skills publish <path-to-skill>
+```
+
+Inspect the compiled composition for a meta-skill:
+
+```sh
+opensquilla skills inspect <meta-skill-name>
+```
+
+For ordinary skill content, use:
+
+```sh
+opensquilla skills view <skill-name>
+```
+
+## How to Ask for a Skill
+
+Ask for the outcome:
+
+```text
+Create a PowerPoint deck summarizing this report.
+```
+
+Better than:
+
+```text
+Load the pptx skill and run its script.
+```
+
+OpenSquilla can choose eligible skills from the current catalog when the task
+matches their description and triggers.
+
+## Bundled Skill Families
+
+| Family | Examples |
+| --- | --- |
+| Research | deep research, multi-source search, summarization |
+| Documents | DOCX, PPTX, XLSX, PDF, HTML-to-PDF |
+| Operations | cron, GitHub, terminal monitoring, subagents |
+| Memory | memory-oriented helpers and history exploration |
+| Creation | skill creator, skill review, proposal helpers |
+
+## Troubleshooting
+
+If a skill is not selected:
+
+1. Confirm it appears in the installed catalog:
+
+   ```sh
+   opensquilla skills list
+   ```
+
+2. Inspect its description and eligibility:
+
+   ```sh
+   opensquilla skills view <skill-name>
+   ```
+
+3. Ask for the outcome in normal language. Skill names can help, but user
+   intent should still be clear.
+
+4. If optional dependencies are missing, install or update the skill and retry.
+
+For composed workflows, read [`meta-skills.md`](meta-skills.md).
+
+---
+
+[Docs index](../README.md) · [Product guide](../../README.product.md) · [Improve this page](../contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/features/squilla-router.md
+++ b/docs/features/squilla-router.md
@@ -1,0 +1,149 @@
+# SquillaRouter
+
+SquillaRouter is OpenSquilla's local model-routing layer. It helps the agent
+choose an appropriate model tier for each turn so routine work does not always
+run on the most expensive model.
+
+Use this page when you want to enable routing, understand what it changes, or
+decide whether a fixed provider/model is better for a specific run.
+
+## Why Use It
+
+SquillaRouter is useful when you want:
+
+- lower cost for simple chat, edits, summaries, and routine tool work;
+- stronger models reserved for hard reasoning, recovery, and long tasks;
+- one OpenSquilla workflow that can route across provider profiles;
+- local routing decisions without sending prompts to a separate external
+  classifier just to choose the model.
+
+It is not required. OpenSquilla can also run in direct single-model mode.
+
+## Enable Routing
+
+Recommended first-run setup:
+
+```sh
+opensquilla onboard --router recommended
+```
+
+Reconfigure an existing install:
+
+```sh
+opensquilla configure router --router recommended
+```
+
+Use the OpenRouter mixed defaults:
+
+```sh
+opensquilla configure router --router openrouter-mix
+```
+
+Disable routing and use the configured provider/model directly:
+
+```sh
+opensquilla configure router --router disabled
+```
+
+## Inspect Provider Support
+
+Check the provider catalog available in your install:
+
+```sh
+opensquilla providers list
+```
+
+If the gateway is running, inspect runtime provider health:
+
+```sh
+opensquilla providers status
+```
+
+Router-supported profiles depend on the installed OpenSquilla version,
+optional dependencies, and configured provider credentials. Common profiles
+include OpenRouter, OpenAI, DeepSeek, Gemini, DashScope, Moonshot, Volcengine,
+Zhipu, and compatible provider tiers exposed by the local catalog.
+
+## What the Router Can Affect
+
+Depending on configuration, SquillaRouter may influence:
+
+- selected model tier;
+- direct model fallback;
+- reasoning level;
+- response policy;
+- image-capable model selection;
+- cache-continuity safeguards for recent higher-tier turns.
+
+The exact decision is available through runtime metadata and diagnostics
+surfaces. Turn on diagnostics when you need to understand why a turn was routed
+to a particular model:
+
+```sh
+opensquilla diagnostics on
+```
+
+## Recommended Operating Modes
+
+| Goal | Suggested mode |
+| --- | --- |
+| General personal-agent use | `recommended` |
+| Multi-provider cost optimization through OpenRouter | `openrouter-mix` |
+| Provider evaluation, billing audit, or reproducible benchmark run | `disabled` |
+| Debugging one provider-specific behavior | `disabled` |
+
+For routine use, start with `recommended`. Disable routing only when the model
+choice itself is the thing you are testing.
+
+## Example Requests
+
+Good router-friendly requests describe the outcome, not the tier:
+
+```text
+Summarize this long issue thread and list the decision points.
+```
+
+```text
+Review my current diff and point out the highest-risk changes.
+```
+
+Avoid asking the router to behave like a manual model picker unless you are
+debugging:
+
+```text
+Use exactly this one model for every turn.
+```
+
+For exact-model work, configure direct routing instead.
+
+## Troubleshooting
+
+If routing does not appear to work:
+
+1. Confirm the router is enabled:
+
+   ```sh
+   opensquilla config get router.enabled
+   opensquilla config get llm.provider
+   ```
+
+2. Check provider readiness:
+
+   ```sh
+   opensquilla providers status
+   opensquilla doctor
+   ```
+
+3. If SquillaRouter optional dependencies are missing, OpenSquilla can still run
+   with direct single-model routing. On Windows, ONNX Runtime may require the
+   Visual C++ Redistributable.
+
+4. If you need deterministic model behavior for a run, disable routing:
+
+   ```sh
+   opensquilla configure router --router disabled
+   ```
+
+---
+
+[Docs index](../README.md) · [Product guide](../../README.product.md) · [Improve this page](../contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/features/tool-compression.md
+++ b/docs/features/tool-compression.md
@@ -1,0 +1,118 @@
+# Tool Compression
+
+OpenSquilla agents use tools. Tool calls can produce large outputs: command
+logs, JSON, web pages, search results, diffs, file contents, tables, and
+artifacts. Tool compression keeps those outputs useful without letting them
+consume the whole model context.
+
+This is a user-facing context-management feature. It does not change what the
+tool returned; it changes how much of that result is shown to the model for the
+next step.
+
+## Why It Matters
+
+Tool compression helps when:
+
+- a command prints a large log;
+- a web page or search result is too long for a useful prompt;
+- a file read returns more text than the next step needs;
+- a long session is close to the context budget;
+- you want raw results preserved while the model sees a compact preview.
+
+Without compression, one large tool result can crowd out the user's goal,
+recent conversation, and next action.
+
+## What Users May See
+
+In long or tool-heavy turns, the model-visible result may include:
+
+- a compact preview;
+- a note that a result was shortened;
+- a `tool_result_handle` for an out-of-band stored result;
+- estimated token-saving diagnostics when diagnostics are enabled.
+
+This is expected. It means OpenSquilla is protecting the active context window.
+
+## Product-Level Model
+
+OpenSquilla separates two views:
+
+| View | Purpose |
+| --- | --- |
+| Runtime view | The durable result OpenSquilla can preserve, inspect, or export. |
+| Provider view | The bounded text sent back to the model for the next reasoning step. |
+
+The agent can continue from the important facts while large raw material stays
+available through files, session export, diagnostics, or tool-result handles
+when configured.
+
+## Compression Modes
+
+OpenSquilla supports several compression styles depending on configuration and
+tool output shape.
+
+| Mode | Best for | Tradeoff |
+| --- | --- | --- |
+| `truncate` | Fast deterministic previews. | May omit useful middle sections. |
+| `summarize` | Slower/background workflows that benefit from semantic summaries. | Adds another model call and should be opt-in. |
+| Structured projection | Logs, diffs, JSON, tables, and known tool shapes. | Depends on reducer coverage for that output type. |
+
+Most users should keep the default behavior and use diagnostics only when a
+workflow is still too large.
+
+## How to Work With Large Outputs
+
+Ask for focused follow-up reads:
+
+```text
+Look at the failing test names and the last 80 lines of the log.
+```
+
+Prefer handles, paths, and summaries:
+
+```text
+Use the compacted result to identify likely causes, then read the exact file
+sections you need.
+```
+
+Avoid asking the agent to paste every line of a huge result unless exact text is
+the deliverable:
+
+```text
+Paste the entire 50,000-line log into chat.
+```
+
+## Inspect and Debug
+
+Turn on diagnostics when you need to understand context growth:
+
+```sh
+opensquilla diagnostics on
+```
+
+Export the session when you need to inspect durable history outside the chat
+surface:
+
+```sh
+opensquilla sessions export <session-key>
+```
+
+Review cost and usage after a large tool-heavy run:
+
+```sh
+opensquilla cost
+```
+
+## Best Practices
+
+- Keep tool requests specific.
+- Ask for the smallest file ranges, log tail, or JSON fields that answer the
+  question.
+- Use artifacts for large deliverables instead of forcing everything into chat.
+- Use session export for audit and debugging.
+- Treat tool compression as a continuity feature, not as a substitute for
+  storing important files.
+
+---
+
+[Docs index](../README.md) · [Product guide](../../README.product.md) · [Improve this page](../contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -1,0 +1,148 @@
+# Gateway
+
+The OpenSquilla gateway is the local server behind the Web UI, channels, RPC
+clients, sessions, approvals, diagnostics, and usage views. Most day-to-day
+OpenSquilla surfaces work best when the gateway is running.
+
+Use this page when you want to start, stop, inspect, expose, or troubleshoot
+the gateway.
+
+## Foreground Gateway
+
+Run the gateway in the current terminal:
+
+```sh
+opensquilla gateway run
+```
+
+Open the control console:
+
+```text
+http://127.0.0.1:18791/control/
+```
+
+Stop a foreground gateway with `Ctrl+C`.
+
+## Managed Background Gateway
+
+Start a managed background process and wait for readiness:
+
+```sh
+opensquilla gateway start --json
+```
+
+Inspect it:
+
+```sh
+opensquilla gateway status
+opensquilla gateway status --json
+```
+
+Restart or stop it:
+
+```sh
+opensquilla gateway restart
+opensquilla gateway stop
+```
+
+Use the managed gateway for the Web UI, channels, scheduled jobs, and local
+automation that should survive the current terminal tab.
+
+## Host and Port
+
+Use a different port:
+
+```sh
+opensquilla gateway run --port 18792
+opensquilla gateway status --port 18792
+```
+
+Bind to a specific host:
+
+```sh
+opensquilla gateway run --listen 127.0.0.1 --port 18791
+```
+
+`--listen` is an alias for the bind host and wins over `--bind` when both are
+provided.
+
+## Safety Defaults
+
+The gateway defaults to loopback scope, usually `127.0.0.1`, because the local
+gateway controls chat, tools, sessions, channels, approvals, and configuration.
+
+Public binding is opt-in:
+
+```sh
+opensquilla gateway run --listen 0.0.0.0 --port 18791
+```
+
+Do not expose a gateway to an untrusted network without token auth and a network
+boundary you understand.
+
+## Configuration Path
+
+Use a specific config file:
+
+```sh
+opensquilla gateway run --config /path/to/opensquilla.toml
+opensquilla gateway status --config /path/to/opensquilla.toml
+```
+
+OpenSquilla also reads standard configuration locations described in
+[`configuration.md`](configuration.md).
+
+## Remote Status Check
+
+Inspect a gateway URL directly:
+
+```sh
+opensquilla gateway status --gateway ws://localhost:18791/ws
+```
+
+This is useful when a client or MCP bridge is configured with an explicit
+gateway URL.
+
+## When to Restart
+
+Restart the gateway after changing:
+
+- provider or router configuration;
+- channel configuration;
+- durable agent entries;
+- global sandbox posture;
+- search or image-generation setup;
+- environment variables used by configured providers.
+
+```sh
+opensquilla gateway restart
+```
+
+## Troubleshooting
+
+Check status and readiness:
+
+```sh
+opensquilla gateway status
+opensquilla doctor
+```
+
+If the port is busy:
+
+```sh
+opensquilla gateway run --port 18792
+```
+
+If the Web UI cannot connect, confirm that the URL matches the gateway bind
+host and port.
+
+Read next:
+
+- [`web-ui.md`](web-ui.md)
+- [`configuration.md`](configuration.md)
+- [`channels.md`](channels.md)
+- [`troubleshooting.md`](troubleshooting.md)
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,132 @@
+# Glossary
+
+This glossary defines common OpenSquilla terms in user-facing language. It is
+not a runtime design document.
+
+## Agent
+
+A named OpenSquilla identity with defaults such as model, workspace, name, and
+description. The built-in `main` agent is always available.
+
+Read: [`agents.md`](agents.md)
+
+## Artifact
+
+A file or media output produced by a run, such as an HTML page, report, image,
+spreadsheet, PDF, or slide deck.
+
+Read: [`artifacts-and-media.md`](artifacts-and-media.md)
+
+## Approval
+
+A human decision required before a sensitive tool action can continue. Approval
+behavior depends on the surface, permission profile, and tool policy.
+
+Read: [`approvals-and-permissions.md`](approvals-and-permissions.md)
+
+## Channel
+
+A messaging integration such as Telegram, Slack, Feishu/Lark, Discord, DingTalk,
+WeCom, Matrix, terminal, or websocket-style clients.
+
+Read: [`channels.md`](channels.md)
+
+## Compaction
+
+The process of reducing old context in a long session so the agent can continue
+within the model's context budget.
+
+Read: [`features/compaction-and-cache.md`](features/compaction-and-cache.md)
+
+## Diagnostics
+
+Runtime logging controls used to understand routing, provider behavior,
+compaction, tool compression, cache behavior, and delivery failures.
+
+Read: [`diagnostics-and-replay.md`](diagnostics-and-replay.md)
+
+## Gateway
+
+The local server behind the Web UI, channels, sessions, approvals, diagnostics,
+usage, and RPC clients.
+
+Read: [`gateway.md`](gateway.md)
+
+## Memory
+
+Durable user or project context that can be searched and recalled later without
+stuffing every old transcript into the active prompt.
+
+Read: [`features/memory.md`](features/memory.md)
+
+## Meta-Skill
+
+A composed workflow that runs multiple skill steps as a reusable routine.
+
+Read: [`features/meta-skills.md`](features/meta-skills.md)
+
+## Permission Profile
+
+The chosen tool-access posture for a run, such as `restricted`, `on`, `bypass`,
+or `full`.
+
+Read: [`approvals-and-permissions.md`](approvals-and-permissions.md)
+
+## Provider
+
+An LLM backend configured for OpenSquilla, such as OpenRouter, OpenAI,
+Anthropic, Gemini, DeepSeek, DashScope, or Ollama.
+
+Read: [`providers-and-models.md`](providers-and-models.md)
+
+## Replay
+
+A read-only view of a recorded turn from the decision log. Replay does not
+re-run tools.
+
+Read: [`diagnostics-and-replay.md`](diagnostics-and-replay.md)
+
+## Scheduler
+
+The `opensquilla cron` feature for recurring and one-time OpenSquilla runs.
+
+Read: [`scheduling.md`](scheduling.md)
+
+## Session
+
+A durable conversation or task history. Sessions can be listed, resumed,
+exported, aborted, or deleted.
+
+Read: [`sessions.md`](sessions.md)
+
+## Skill
+
+A reusable package of task-specific guidance, scripts, or workflow instructions
+that OpenSquilla can load when needed.
+
+Read: [`features/skills.md`](features/skills.md)
+
+## SquillaRouter
+
+OpenSquilla's local routing layer for choosing an appropriate model tier per
+turn.
+
+Read: [`features/squilla-router.md`](features/squilla-router.md)
+
+## Tool Compression
+
+A context-saving feature that keeps large tool results useful while sending a
+smaller preview to the model.
+
+Read: [`features/tool-compression.md`](features/tool-compression.md)
+
+## Workspace
+
+The local directory a task is allowed or expected to work in. Workspace flags
+help contain file and shell work.
+
+Read: [`tools-and-sandbox.md`](tools-and-sandbox.md)
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,79 @@
+# MCP Server Bridge
+
+OpenSquilla can run as a stdio MCP server bridge for MCP-capable clients. Use
+this when another local AI client should call into OpenSquilla session
+workflows through the Model Context Protocol.
+
+The MCP bridge is an integration surface. It is separate from OpenSquilla's Web
+UI, CLI, channels, and gateway control console.
+
+## Requirements
+
+Install OpenSquilla with the MCP extra when you need this bridge:
+
+```sh
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.2.1/opensquilla-0.2.1-py3-none-any.whl"
+```
+
+Start the OpenSquilla gateway:
+
+```sh
+opensquilla gateway run
+```
+
+Or use the managed gateway:
+
+```sh
+opensquilla gateway start --json
+opensquilla gateway status
+```
+
+## Run the Bridge
+
+```sh
+opensquilla mcp-server run
+```
+
+By default, the bridge connects to:
+
+```text
+ws://localhost:18791/ws
+```
+
+Use a different gateway:
+
+```sh
+opensquilla mcp-server run --gateway ws://localhost:18792/ws
+```
+
+The command runs a stdio MCP server. Configure your MCP-capable client to launch
+that command as the server process.
+
+## Safety Notes
+
+- Keep the gateway bound to `127.0.0.1` unless you intentionally expose it.
+- Do not put provider keys or channel secrets in MCP client config examples.
+- Treat the MCP client as another tool-calling surface. The same OpenSquilla
+  permissions, tools, sessions, and gateway state still matter.
+
+## Troubleshooting
+
+If the bridge cannot start:
+
+```sh
+opensquilla gateway status
+opensquilla doctor
+```
+
+If the command reports that MCP dependencies are missing, reinstall with the
+`mcp` extra.
+
+Read next:
+
+- [`configuration.md`](configuration.md)
+- [`tools-and-sandbox.md`](tools-and-sandbox.md)
+- [`operations.md`](operations.md)
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,237 @@
+# Operations
+
+This guide covers day-two commands: sessions, cron, cost, diagnostics, replay,
+migration, durable agents, MCP, and install inventory. Use it after the first
+successful chat or gateway run.
+
+## Sessions
+
+Sessions are durable chat/task histories. Use them to resume, inspect, export,
+or clean up prior work.
+
+```sh
+opensquilla sessions list
+opensquilla sessions show <session-key>
+opensquilla sessions resume <session-key>
+opensquilla sessions export <session-key>
+opensquilla sessions abort <session-key>
+opensquilla sessions delete <session-key>
+```
+
+Use session export when exact old context matters or when you want to debug a
+long-running task outside the chat UI.
+
+For resume, abort, export, and cleanup workflows, see
+[`sessions.md`](sessions.md).
+
+## Durable Agents
+
+OpenSquilla supports durable agent entries, including the built-in `main`
+agent.
+
+```sh
+opensquilla agents list
+opensquilla agents add research --name Research --workspace /path/to/research
+opensquilla agents delete research
+```
+
+Use durable agents when you want separate workspaces, instructions, or tool
+profiles for recurring roles. Restart the gateway after agent config changes.
+
+Keep each durable agent's instructions focused on that role instead of turning
+every agent into a copy of `main`.
+
+For agent examples and concepts, see [`agents.md`](agents.md).
+
+## Cron and Scheduled Runs
+
+Cron jobs run OpenSquilla tasks on a schedule.
+
+Inspect jobs:
+
+```sh
+opensquilla cron list
+opensquilla cron status <job-id>
+opensquilla cron runs <job-id>
+```
+
+Add a simple recurring reminder:
+
+```sh
+opensquilla cron add \
+  --every 1h \
+  --text "Check for urgent project updates and summarize them" \
+  --name hourly-project-check
+```
+
+Add a daily cron-style task:
+
+```sh
+opensquilla cron add \
+  --cron "0 9 * * 1-5" \
+  --tz "America/Los_Angeles" \
+  --text "Prepare my weekday morning briefing" \
+  --name weekday-briefing
+```
+
+Manage jobs:
+
+```sh
+opensquilla cron update <job-id> --enabled
+opensquilla cron remove <job-id>
+opensquilla cron run <job-id>
+```
+
+Good uses:
+
+- morning briefings;
+- recurring research digests;
+- PR or CI checks;
+- channel-delivered reminders;
+- scheduled memory consolidation or reporting tasks.
+
+Pair cron with channels when the output should be delivered somewhere other
+than the local Web UI.
+
+For scheduling examples, delivery options, and troubleshooting, see
+[`scheduling.md`](scheduling.md).
+
+## Cost and Usage
+
+Inspect usage and estimated cost:
+
+```sh
+opensquilla cost
+opensquilla cost --by-model
+opensquilla cost --json
+```
+
+Use cost inspection after tool-heavy, routed, or long-context tasks to
+understand actual runtime behavior.
+
+For cost investigation workflow, see [`usage-and-cost.md`](usage-and-cost.md).
+
+## Diagnostics
+
+Diagnostics help explain runtime behavior without changing the core task.
+
+```sh
+opensquilla diagnostics status
+opensquilla diagnostics on
+opensquilla diagnostics off
+```
+
+Use diagnostics when investigating:
+
+- provider retry behavior;
+- router decisions;
+- cache breaks;
+- compaction events;
+- tool-result compression;
+- channel delivery failures.
+
+Turn diagnostics off after collecting the needed evidence.
+
+For diagnostics guidance and safe sharing notes, see
+[`diagnostics-and-replay.md`](diagnostics-and-replay.md).
+
+## Replay
+
+Replay a recorded turn from the decision log:
+
+```sh
+opensquilla replay --session <session-key> --turn <turn-id>
+```
+
+Replay is useful for reproducing an agent turn, reviewing decision metadata, or
+debugging behavior after the original chat has moved on.
+
+## Migration
+
+Preview first:
+
+```sh
+opensquilla migrate openclaw --json
+opensquilla migrate hermes --json
+```
+
+Apply after reviewing the report:
+
+```sh
+opensquilla migrate openclaw --apply
+opensquilla migrate hermes --apply
+```
+
+See [`../MIGRATION.md`](../MIGRATION.md) for custom paths and conflict
+handling.
+
+## MCP Server
+
+OpenSquilla can run an MCP server bridge when installed with the `mcp` extra:
+
+```sh
+opensquilla mcp-server run
+```
+
+Install with:
+
+```sh
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.2.1/opensquilla-0.2.1-py3-none-any.whl"
+```
+
+Use this when another MCP-capable client should access OpenSquilla-managed tools
+or runtime surfaces.
+
+For setup details, see [`mcp-server.md`](mcp-server.md).
+
+## Install Inventory
+
+Emit a reproducible workspace-state inventory:
+
+```sh
+opensquilla dist
+```
+
+Use this for support, release QA, or environment comparison.
+
+## Models
+
+Inspect available models:
+
+```sh
+opensquilla models list
+```
+
+In this build, model inspection can be runtime-backed. If it cannot connect,
+start the gateway first:
+
+```sh
+opensquilla gateway run
+```
+
+For provider catalog inspection that does not require a live gateway, use:
+
+```sh
+opensquilla providers list
+```
+
+Read: [`providers-and-models.md`](providers-and-models.md)
+
+## Health Checklist
+
+For a confusing install or runtime:
+
+```sh
+opensquilla doctor
+opensquilla gateway status
+opensquilla providers list
+opensquilla search list
+opensquilla channels types
+opensquilla sandbox status
+```
+
+Then turn on diagnostics only if the basic health surfaces are not enough.
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -1,0 +1,139 @@
+# Providers and Models
+
+OpenSquilla supports multiple LLM providers through one configuration surface.
+You can run direct single-model mode or enable SquillaRouter for tiered routing.
+
+Use this page when you need to configure a provider, inspect model support, or
+choose between direct model mode and router mode.
+
+## Inspect Providers
+
+List provider metadata from the local install:
+
+```sh
+opensquilla providers list
+opensquilla providers list --json
+```
+
+Show runtime provider diagnostics from the running gateway:
+
+```sh
+opensquilla providers status
+opensquilla providers status openrouter --json
+opensquilla providers status --probe-models
+```
+
+`providers list` does not require a running gateway. `providers status` does.
+
+## Configure a Provider
+
+Interactive:
+
+```sh
+opensquilla providers configure openrouter
+```
+
+Non-interactive onboarding-style configuration:
+
+```sh
+export OPENROUTER_API_KEY="sk-..."
+opensquilla configure provider --provider openrouter --api-key-env OPENROUTER_API_KEY
+```
+
+Direct provider examples:
+
+```sh
+opensquilla configure provider --provider openai --model gpt-5.4-mini --api-key-env OPENAI_API_KEY
+opensquilla configure provider --provider anthropic --model claude-sonnet-4-5 --api-key-env ANTHROPIC_API_KEY
+opensquilla configure provider --provider gemini --model gemini-2.5-flash --api-key-env GEMINI_API_KEY
+opensquilla configure provider --provider ollama --model llama3.1
+```
+
+Prefer environment-variable references for API keys so secrets are not written
+directly into configuration files.
+
+## Onboarding-Verified Providers
+
+This build exposes onboarding support for:
+
+- OpenRouter
+- OpenAI
+- Anthropic
+- Ollama
+- DeepSeek
+- Gemini
+- DashScope / Qwen
+- Moonshot AI
+- Zhipu / Z.AI
+- Baidu Qianfan
+- Volcengine Ark
+
+The provider registry may contain additional compatible providers for advanced
+or self-hosted setups. Use `opensquilla providers list` on your install for the
+current catalog.
+
+## Model Inspection
+
+List models:
+
+```sh
+opensquilla models list
+```
+
+If runtime-backed model inspection cannot connect, start the gateway:
+
+```sh
+opensquilla gateway run
+```
+
+For provider metadata that does not require the gateway, use:
+
+```sh
+opensquilla providers list
+```
+
+## Direct Model vs Router
+
+Direct model mode:
+
+```sh
+opensquilla configure router --router disabled
+opensquilla configure provider --provider openai --model gpt-5.4-mini --api-key-env OPENAI_API_KEY
+```
+
+Router mode:
+
+```sh
+opensquilla configure router --router recommended
+```
+
+| Mode | Use when |
+| --- | --- |
+| Direct model | You are testing one exact model, reproducing provider behavior, or auditing provider billing. |
+| Router mode | You want normal personal-agent use where cost and task complexity vary by turn. |
+
+For routing details, see
+[`features/squilla-router.md`](features/squilla-router.md).
+
+## Provider Troubleshooting
+
+Start with:
+
+```sh
+opensquilla doctor
+opensquilla providers status
+opensquilla diagnostics on
+```
+
+Check:
+
+- the API key environment variable is set in the gateway process environment;
+- the model id matches the provider;
+- the base URL is correct for compatible APIs;
+- proxy settings match your network;
+- router is disabled when debugging one exact provider/model;
+- the gateway was restarted after config changes.
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,229 @@
+# Quickstart
+
+This guide gets OpenSquilla installed, configured, and running locally. It
+assumes you want the standard product experience: terminal commands, local Web
+UI, SquillaRouter, memory/search support, and safe local defaults.
+
+## Requirements
+
+- Python 3.12 or newer for terminal installs.
+- `uv` for the recommended terminal install.
+- Git and Git LFS only when installing from source.
+- A provider API key unless you use a local provider such as Ollama.
+
+## Recommended Install
+
+Install the current release wheel with the recommended extras:
+
+```sh
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.2.1/opensquilla-0.2.1-py3-none-any.whl"
+```
+
+The `recommended` extra includes SquillaRouter dependencies and memory/search
+support used by the default product experience.
+
+If `opensquilla` is not found after install, open a new shell or run:
+
+```sh
+uv tool update-shell
+```
+
+## First-Run Setup
+
+Interactive setup:
+
+```sh
+opensquilla onboard
+```
+
+Script-friendly setup:
+
+```sh
+export OPENROUTER_API_KEY="sk-..."
+opensquilla onboard --provider openrouter --api-key-env OPENROUTER_API_KEY
+```
+
+Useful variants:
+
+```sh
+opensquilla onboard --if-needed
+opensquilla onboard --minimal
+opensquilla onboard --provider openai --api-key-env OPENAI_API_KEY
+opensquilla onboard --provider ollama --model llama3.1
+```
+
+`--if-needed` is safe for install scripts because it avoids rewriting an
+already-ready setup. `--minimal` configures the provider path and skips optional
+channels/search/image-generation sections.
+
+Check onboarding state:
+
+```sh
+opensquilla onboard status
+```
+
+## Run the Gateway
+
+Foreground gateway:
+
+```sh
+opensquilla gateway run
+```
+
+Background gateway with readiness wait:
+
+```sh
+opensquilla gateway start --json
+opensquilla gateway status
+```
+
+Default address:
+
+```text
+http://127.0.0.1:18791/control/
+```
+
+The gateway defaults to loopback for safety. To bind elsewhere, opt in:
+
+```sh
+opensquilla gateway run --listen 0.0.0.0 --port 18791
+```
+
+Only expose a non-loopback gateway behind appropriate auth and network controls.
+
+## First Useful Run
+
+Open the Web UI:
+
+```text
+http://127.0.0.1:18791/control/
+```
+
+Start terminal chat:
+
+```sh
+opensquilla chat
+```
+
+Run one automation turn:
+
+```sh
+opensquilla agent -m "Inspect this workspace and suggest a test plan"
+```
+
+Run a one-shot task in a specific workspace:
+
+```sh
+opensquilla agent \
+  --workspace /path/to/project \
+  --workspace-strict \
+  -m "Review the current diff and list the highest-risk changes"
+```
+
+Use the Web UI for browser-based chat, approvals, setup, channels, usage, and
+logs. Use `opensquilla chat` when you want a terminal conversation. Use
+`opensquilla agent` for one-shot automation.
+
+## Resume Work
+
+Resume a terminal chat session:
+
+```sh
+opensquilla chat --session <session-key>
+```
+
+Inspect sessions:
+
+```sh
+opensquilla sessions list
+opensquilla sessions show <session-key>
+opensquilla sessions export <session-key>
+```
+
+Export a session when exact history matters for debugging or handoff.
+
+## Check Readiness
+
+Run these after setup:
+
+```sh
+opensquilla doctor
+opensquilla providers list
+opensquilla search list
+opensquilla channels types --json
+```
+
+If the gateway is running, inspect runtime status:
+
+```sh
+opensquilla gateway status
+opensquilla providers status
+opensquilla channels status
+opensquilla memory status
+```
+
+For provider/model selection details, see
+[`providers-and-models.md`](providers-and-models.md). For search setup, see
+[`search.md`](search.md).
+
+For gateway lifecycle, host/port, and exposure guidance, see
+[`gateway.md`](gateway.md).
+
+## Stop or Restart
+
+Foreground gateway:
+
+```text
+Ctrl+C
+```
+
+Managed background gateway:
+
+```sh
+opensquilla gateway stop
+opensquilla gateway restart
+```
+
+## Next Steps
+
+After the first run:
+
+1. Configure search if you want web research:
+   [`search.md`](search.md).
+2. Enable channels if you want Slack, Telegram, Feishu/Lark, or another
+   messaging surface: [`channels.md`](channels.md).
+3. Review memory behavior if you want durable recall:
+   [`features/memory.md`](features/memory.md).
+4. Review tool permissions before unattended automation:
+   [`tools-and-sandbox.md`](tools-and-sandbox.md).
+5. Learn SquillaRouter if you want cost-aware model routing:
+   [`features/squilla-router.md`](features/squilla-router.md).
+6. Use the glossary if product terms are unfamiliar:
+   [`glossary.md`](glossary.md).
+
+## Install From Source
+
+Use source install when you want a checkout-backed install:
+
+```sh
+git lfs install
+git clone https://github.com/opensquilla/opensquilla.git
+cd opensquilla
+git lfs pull --include="src/opensquilla/squilla_router/models/**"
+bash scripts/install_source.sh
+```
+
+For development, use the repository virtual environment:
+
+```sh
+uv sync --extra recommended --extra dev
+uv run opensquilla --help
+uv run opensquilla gateway run
+```
+
+When developing from source, prefix commands with `uv run` so they use the
+checkout you are editing.
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,0 +1,168 @@
+# Scheduling
+
+OpenSquilla scheduling lets you run recurring or one-time agent work from the
+gateway. Use it for reminders, periodic summaries, status checks, channel
+updates, and webhook-delivered automation.
+
+Scheduling is managed with the `opensquilla cron` command group.
+
+## Requirements
+
+Scheduled jobs run through the gateway:
+
+```sh
+opensquilla gateway run
+```
+
+For long-lived local use, start the managed gateway:
+
+```sh
+opensquilla gateway start --json
+opensquilla gateway status
+```
+
+## List Jobs
+
+```sh
+opensquilla cron list
+opensquilla cron list --agent main
+opensquilla cron list --json
+```
+
+## Add an Interval Job
+
+Run a prompt every hour:
+
+```sh
+opensquilla cron add \
+  --every 1h \
+  --text "Summarize important project updates" \
+  --name hourly-project-check
+```
+
+Intervals accept values such as `30s`, `5m`, and `1h`.
+
+## Add a Cron Expression
+
+Run on weekdays at 09:00 in a named timezone:
+
+```sh
+opensquilla cron add \
+  --cron "0 9 * * 1-5" \
+  --tz "America/Los_Angeles" \
+  --text "Prepare a short morning brief" \
+  --name weekday-morning-brief
+```
+
+Use `--exact` when you do not want the default stagger.
+
+## Add a One-Time Job
+
+```sh
+opensquilla cron add \
+  --at "2026-06-01T09:00:00+00:00" \
+  --text "Remind me to review the launch checklist" \
+  --name launch-checklist-reminder
+```
+
+## Choose the Session Target
+
+The default target is an isolated session. For most scheduled work, that is the
+least surprising option.
+
+Useful targets:
+
+| Target | Use when |
+| --- | --- |
+| `isolated` | Each scheduled run should stand alone. |
+| `session` | You want to deliver into a specific session configured by the runtime surface. |
+| `main` | You want a system event for the main session. |
+
+Example:
+
+```sh
+opensquilla cron add \
+  --every 30m \
+  --session-target isolated \
+  --text "Check for urgent channel updates" \
+  --name urgent-update-check
+```
+
+## Delivery
+
+Disable delivery:
+
+```sh
+opensquilla cron add \
+  --every 1h \
+  --text "Create a private summary" \
+  --no-deliver \
+  --name private-hourly-summary
+```
+
+Deliver through a webhook:
+
+```sh
+opensquilla cron add \
+  --every 1h \
+  --text "Post a compact status summary" \
+  --webhook-url https://example.com/hooks/opensquilla \
+  --webhook-token-env OPENSQUILLA_WEBHOOK_TOKEN \
+  --name webhook-status-summary
+```
+
+Prefer `--webhook-token-env` or `--webhook-token-file` over inline tokens so
+secrets do not land in shell history.
+
+## Inspect and Run Jobs
+
+```sh
+opensquilla cron status <job-id>
+opensquilla cron runs <job-id>
+opensquilla cron runs <job-id> --limit 50
+```
+
+Run a job immediately:
+
+```sh
+opensquilla cron run <job-id> --yes
+```
+
+## Update or Remove Jobs
+
+```sh
+opensquilla cron update <job-id> --enabled
+opensquilla cron update <job-id> --disabled
+opensquilla cron update <job-id> --every 2h
+opensquilla cron remove <job-id> --yes
+```
+
+Primary delivery destinations are not patched in place from the CLI. Remove and
+re-add a job when the primary channel or webhook destination needs to change.
+
+## Troubleshooting
+
+Check the gateway and job state:
+
+```sh
+opensquilla gateway status
+opensquilla cron list
+opensquilla cron status <job-id>
+opensquilla cron runs <job-id>
+```
+
+If a job posts to a channel, also check:
+
+```sh
+opensquilla channels status
+```
+
+Read next:
+
+- [`channels.md`](channels.md)
+- [`operations.md`](operations.md)
+- [`troubleshooting.md`](troubleshooting.md)
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,113 @@
+# Web Search
+
+OpenSquilla can search the web through configured search providers and can fetch
+pages through guarded web tools. Search is useful for current information,
+source-backed reports, market research, release notes, and troubleshooting.
+
+## Inspect Search Providers
+
+```sh
+opensquilla search list
+opensquilla search list --json
+opensquilla search status
+```
+
+Runtime-supported providers in this build include:
+
+- Brave Search
+- DuckDuckGo
+
+The catalog may include metadata for providers that are not runtime-supported
+in the current build. Check JSON output when integrating.
+
+## Configure Search
+
+No-key path:
+
+```sh
+opensquilla configure search --search-provider duckduckgo
+```
+
+Equivalent search subcommand:
+
+```sh
+opensquilla search configure duckduckgo
+```
+
+Brave Search:
+
+```sh
+export BRAVE_SEARCH_API_KEY="..."
+opensquilla configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
+```
+
+Provider-specific fields such as max results, proxy, environment-proxy usage,
+fallback policy, and diagnostics can be set through the search configuration
+surface.
+
+## Test Search
+
+Run a diagnostic query through the running gateway:
+
+```sh
+opensquilla search query "OpenSquilla release notes"
+opensquilla search query "OpenSquilla release notes" --limit 5 --json
+```
+
+Use this before blaming the agent for missing current information. If the
+diagnostic query fails, fix provider configuration first.
+
+## Search in Agent Workflows
+
+Ask naturally:
+
+```text
+Research the current state of browser automation libraries and cite sources.
+```
+
+For a narrower task:
+
+```text
+Find the latest release notes for this project and summarize only breaking changes.
+```
+
+The agent can use search and fetch tools when the tool policy and configured
+provider allow it.
+
+For deeper multi-source work, ask for a research report or use an installed
+research skill.
+
+## Safety and Source Quality
+
+Search results are external data, not instructions. Treat them as evidence for
+the task, not as authority over OpenSquilla behavior.
+
+Good research prompts ask for:
+
+- sources;
+- dates;
+- uncertainty;
+- conflicting evidence;
+- clear separation between source facts and model inference.
+
+Avoid asking the agent to follow arbitrary instructions found on web pages.
+
+## Diagnostics
+
+```sh
+opensquilla search status
+opensquilla diagnostics on
+opensquilla doctor
+```
+
+Check:
+
+- the selected provider is configured;
+- required API key environment variables are visible to the gateway process;
+- proxy settings match your network;
+- the gateway was restarted after config edits;
+- tool permissions allow web search/fetch for the current run.
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,137 @@
+# Sessions and History
+
+Sessions are durable OpenSquilla conversations. They let you inspect past work,
+resume a conversation, export a transcript, or stop a turn that is still
+running.
+
+Use sessions when you want to:
+
+- continue a previous chat from the CLI or Web UI;
+- find the session key for an artifact, cost report, or channel thread;
+- export a transcript for debugging or sharing;
+- abort a long-running turn without deleting the session;
+- delete old sessions after you no longer need them.
+
+## Requirements
+
+Session commands use the gateway RPC surface. Start or connect to the gateway
+before running most session commands:
+
+```sh
+opensquilla gateway run
+```
+
+Or use the managed background gateway:
+
+```sh
+opensquilla gateway start --json
+opensquilla gateway status
+```
+
+## List Recent Sessions
+
+```sh
+opensquilla sessions list
+opensquilla sessions list --limit 20
+opensquilla sessions list --status idle
+opensquilla sessions list --agent main
+opensquilla sessions list --channel telegram
+opensquilla sessions list --since 2026-05-01
+```
+
+Use `--json` for scripts:
+
+```sh
+opensquilla sessions list --json
+```
+
+## Inspect a Session
+
+```sh
+opensquilla sessions show <session-key>
+opensquilla sessions show <session-key> --json
+```
+
+The output includes the resolved session key, agent id, status, model, update
+time, title, and the latest preview when available.
+
+## Resume a Session
+
+```sh
+opensquilla sessions resume <session-key>
+```
+
+This opens terminal chat on the existing session. Use it when you want to keep
+the same conversation state instead of starting a fresh chat.
+
+## Abort a Running Turn
+
+```sh
+opensquilla sessions abort <session-key>
+opensquilla sessions abort <session-key> --json
+```
+
+Abort stops the running turn if one exists. It does not delete the session.
+
+## Export a Transcript
+
+Export Markdown:
+
+```sh
+opensquilla sessions export <session-key>
+opensquilla sessions export <session-key> --output session.md
+```
+
+Export JSON:
+
+```sh
+opensquilla sessions export <session-key> --format json --output session.json
+```
+
+Exported transcripts are useful for bug reports, audits, or moving a task into a
+document. Remove secrets, private local paths, provider tokens, and private
+channel identifiers before sharing an export publicly.
+
+## Delete a Session
+
+```sh
+opensquilla sessions delete <session-key>
+opensquilla sessions delete <session-key> --yes
+```
+
+Deleting a session is for cleanup. Export first if you may need the transcript
+later.
+
+## Web UI Workflow
+
+The Web UI uses the same session system. In the control console, use the chat
+session selector to switch sessions, inspect status, and continue recent work.
+
+Open:
+
+```text
+http://127.0.0.1:18791/control/
+```
+
+## Troubleshooting
+
+If commands cannot reach the gateway:
+
+```sh
+opensquilla gateway status
+opensquilla doctor
+```
+
+If old context appears summarized, the session may have compacted older
+history. This is normal for long sessions under context pressure. Export the
+session when exact text matters.
+
+Read next:
+
+- [`features/compaction-and-cache.md`](features/compaction-and-cache.md)
+- [`web-ui.md`](web-ui.md)
+- [`operations.md`](operations.md)
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/tools-and-sandbox.md
+++ b/docs/tools-and-sandbox.md
@@ -1,0 +1,156 @@
+# Tools, Approvals, and Sandbox
+
+OpenSquilla tools give the agent useful capabilities. Policy layers, approval
+surfaces, workspace constraints, and sandbox posture control how those tools are
+allowed to act.
+
+Use this page before running unattended automation, file edits, shell commands,
+or channel-connected agents.
+
+For a focused permissions guide, see
+[`approvals-and-permissions.md`](approvals-and-permissions.md).
+
+## Built-In Tool Areas
+
+| Area | Examples |
+| --- | --- |
+| Filesystem | `read_file`, `write_file`, `edit_file`, `list_dir`, `glob_search`, `grep_search`, spreadsheet reads. |
+| Shell and code | `exec_command`, `background_process`, `process`, `execute_code`. |
+| Git | `git_status`, `git_diff`, `git_log`, `git_commit`, `apply_patch`. |
+| Web | `web_search`, `web_fetch`, `http_request`. |
+| Memory | `memory_search`, `memory_save`, `memory_get`, `memory_delete`. |
+| Sessions | `sessions_send`, `sessions_spawn`, `sessions_list`, `sessions_history`, `session_status`. |
+| Artifacts | `publish_artifact`. |
+| Media | image generation, PDF, TTS, and media helpers. |
+| Skills | `skill_list`, `skill_view`, `skill_create`, `skill_edit`, `install_skill_deps`, `meta_invoke`. |
+| Admin | cron and gateway administration. |
+| Channels/platforms | messaging and Feishu/Lark docs, chat, drive, wiki, media, and permission helpers. |
+
+## Permission Modes
+
+Use stricter modes when running unattended:
+
+```sh
+opensquilla agent --permissions restricted -m "Inspect this repo"
+```
+
+Use broader modes only when you trust the task and workspace:
+
+```sh
+opensquilla agent --permissions full --workspace /path/to/project -m "Run tests and fix failures"
+```
+
+For interactive work, the Web UI approvals surface can pause sensitive tool
+calls for review. For automation, choose a permission mode and workspace policy
+before the run starts.
+
+Read: [`approvals-and-permissions.md`](approvals-and-permissions.md)
+
+## Approval Flow
+
+Sensitive actions may pause for human approval depending on permission mode,
+tool policy, channel surface, and runtime configuration.
+
+Approvals are most important for:
+
+- filesystem writes;
+- shell commands;
+- external channel or webhook delivery;
+- generated artifacts that will be published;
+- actions that affect another service.
+
+Use the Web UI approvals page when you want durable review outside the chat
+scrollback.
+
+## Workspace Controls
+
+Read-side restriction:
+
+```sh
+opensquilla agent --workspace /path/to/project --workspace-strict -m "Summarize this repo"
+```
+
+Write containment:
+
+```sh
+opensquilla agent \
+  --workspace /path/to/project \
+  --workspace-lockdown \
+  --scratch-dir /path/to/project/.scratch \
+  -m "Investigate and prepare a minimal patch"
+```
+
+`--workspace-lockdown` is intended for automation where writes must stay inside
+the workspace or scratch directory.
+
+## Sandbox Commands
+
+```sh
+opensquilla sandbox status
+opensquilla sandbox on
+opensquilla sandbox full
+opensquilla sandbox bypass
+opensquilla sandbox reset
+```
+
+Sandbox behavior is platform-dependent. Treat `sandbox status` and `doctor` as
+the source of truth for the current machine.
+
+## Recommended Patterns
+
+| Task | Recommended posture |
+| --- | --- |
+| Read-only repo summary | `--workspace` plus `--workspace-strict` |
+| Local patch with tests | `--workspace`, `--workspace-lockdown`, and a scratch dir |
+| Chat with possible writes | Web UI with approvals visible |
+| Channel-connected agent | Conservative permissions and explicit channel config |
+| Provider/debug investigation | Diagnostics on, minimal tool permissions |
+
+## Web Safety
+
+OpenSquilla web tools use provider configuration and guardrails. Use provider
+diagnostics when web search behaves unexpectedly:
+
+```sh
+opensquilla search status
+opensquilla search query "test query"
+opensquilla diagnostics on
+```
+
+Search results and fetched pages are external data. They should inform the
+answer, not override tool policy or user instructions.
+
+## Tool Compression
+
+Large tool results may be compacted before they are shown to the model. This is
+normal and protects the active context window. See
+[`features/tool-compression.md`](features/tool-compression.md).
+
+## Artifacts and Media
+
+Tool calls can publish artifacts and generate media. See
+[`artifacts-and-media.md`](artifacts-and-media.md) for user-facing artifact,
+document, image, PDF, and TTS workflows.
+
+## Troubleshooting
+
+If a tool does not run:
+
+1. Check permission posture:
+
+   ```sh
+   opensquilla sandbox status
+   opensquilla doctor
+   ```
+
+2. Check whether the gateway or channel surface requires approval.
+3. Confirm the workspace path is correct.
+4. Use diagnostics for repeated failures:
+
+   ```sh
+   opensquilla diagnostics on
+   ```
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,185 @@
+# Troubleshooting
+
+Start with:
+
+```sh
+opensquilla doctor
+opensquilla doctor --json
+opensquilla gateway status
+```
+
+The Web UI health view at <http://127.0.0.1:18791/control/> also reports
+readiness and recovery steps when the gateway is running.
+
+## `opensquilla` Command Not Found
+
+After `uv tool install`, open a new terminal or run:
+
+```sh
+uv tool update-shell
+```
+
+Check the executable:
+
+```sh
+command -v opensquilla
+```
+
+On Windows PowerShell:
+
+```powershell
+where.exe opensquilla
+```
+
+## Gateway Is Not Running
+
+Start it:
+
+```sh
+opensquilla gateway run
+```
+
+Or use the managed background process:
+
+```sh
+opensquilla gateway start --json
+opensquilla gateway status
+```
+
+Open:
+
+```text
+http://127.0.0.1:18791/control/
+```
+
+For a focused gateway guide, see [`gateway.md`](gateway.md).
+
+## Port Already In Use
+
+Use another port:
+
+```sh
+opensquilla gateway run --port 18792
+```
+
+Or stop the managed gateway:
+
+```sh
+opensquilla gateway stop
+```
+
+## Provider Not Configured
+
+Run:
+
+```sh
+opensquilla onboard
+opensquilla providers list
+opensquilla providers configure openrouter
+```
+
+Use environment-variable secrets:
+
+```sh
+export OPENAI_API_KEY="sk-..."
+opensquilla configure provider --provider openai --api-key-env OPENAI_API_KEY
+```
+
+## Router Dependency Problems
+
+If SquillaRouter cannot load, OpenSquilla can still run with direct model
+routing. To disable the router:
+
+```sh
+opensquilla configure router --router disabled
+opensquilla gateway restart
+```
+
+On Windows, ONNX Runtime may need the Visual C++ Redistributable for Visual
+Studio 2015-2022 x64. Install it, then restart the shell and gateway.
+
+## Search Does Not Work
+
+Inspect search providers:
+
+```sh
+opensquilla search list
+opensquilla search status
+```
+
+Use DuckDuckGo for a no-key path:
+
+```sh
+opensquilla configure search --search-provider duckduckgo
+```
+
+Use Brave with a key:
+
+```sh
+export BRAVE_SEARCH_API_KEY="..."
+opensquilla configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
+```
+
+## Channel Config Saved but Channel Is Offline
+
+Restart the gateway after editing channel config:
+
+```sh
+opensquilla gateway restart
+opensquilla channels status <name> --json
+```
+
+For webhook channels, confirm the gateway is reachable from the provider and
+that callback secrets match.
+
+## A Tool Was Denied
+
+Check sandbox and permission state:
+
+```sh
+opensquilla sandbox status
+opensquilla doctor
+```
+
+For one-shot runs, choose an explicit permission posture:
+
+```sh
+opensquilla agent --permissions restricted -m "Read only"
+opensquilla agent --permissions full -m "Trusted local automation"
+```
+
+## The Agent Seems to Forget Old Context
+
+Long sessions may compact old history. This is expected under context pressure.
+
+Inspect sessions:
+
+```sh
+opensquilla sessions show <session-key>
+opensquilla sessions export <session-key>
+```
+
+If exact old text matters, keep it in a file, memory note, or exported session.
+
+## A Turn Is Too Expensive or Too Slow
+
+Try:
+
+```sh
+opensquilla configure router --router recommended
+opensquilla diagnostics on
+opensquilla cost
+```
+
+For automation:
+
+```sh
+opensquilla agent --max-iterations 20 --timeout 600 -m "Bounded task"
+```
+
+For large tool outputs, see
+[`features/tool-compression.md`](features/tool-compression.md).
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/usage-and-cost.md
+++ b/docs/usage-and-cost.md
@@ -1,0 +1,96 @@
+# Usage and Cost
+
+OpenSquilla records token usage and estimated cost from the running gateway.
+Use the cost view after routed, tool-heavy, channel, or long-context work to
+understand where model spend is going.
+
+## Requirements
+
+Cost inspection uses the gateway:
+
+```sh
+opensquilla gateway status
+```
+
+If the gateway is not running:
+
+```sh
+opensquilla gateway run
+```
+
+## Show Cost
+
+```sh
+opensquilla cost
+```
+
+The default view lists session/model rows with input tokens, output tokens, and
+estimated cost.
+
+## Group by Model
+
+```sh
+opensquilla cost --by-model
+```
+
+Use this when SquillaRouter is enabled and you want to see which models carried
+the recent workload.
+
+## Use JSON Output
+
+```sh
+opensquilla cost --json
+opensquilla cost --by-model --json
+```
+
+JSON output is useful for local dashboards, regression checks, and automated
+reports.
+
+## What to Check First
+
+| Signal | What it can mean |
+| --- | --- |
+| Many rows for premium models | Router policy or task shape may be escalating more often than expected. |
+| High input tokens | Long history, large tool results, or large prompt/tool schema surfaces may dominate cost. |
+| High output tokens | The task may need tighter instructions or a smaller response format. |
+| Cost concentrated in one session | Inspect that session before changing global configuration. |
+
+## Lower Cost Safely
+
+Start with router and diagnostics:
+
+```sh
+opensquilla configure router --router recommended
+opensquilla diagnostics on
+opensquilla cost --by-model
+```
+
+For large tool results, read:
+
+- [`features/tool-compression.md`](features/tool-compression.md)
+- [`features/compaction-and-cache.md`](features/compaction-and-cache.md)
+
+For simple one-shot automation, bound the run:
+
+```sh
+opensquilla agent --max-iterations 20 --timeout 600 -m "Bounded task"
+```
+
+## Notes and Limits
+
+- Cost is an estimate based on recorded runtime usage and configured pricing.
+- Provider bills remain the source of truth for actual charges.
+- Tool compression and routing can reduce model context cost, but they should
+  be checked against task success, not only token totals.
+- Diagnostics can explain why a turn routed, compacted, retried, or produced
+  unusually large outputs.
+
+Read next:
+
+- [`features/squilla-router.md`](features/squilla-router.md)
+- [`features/tool-compression.md`](features/tool-compression.md)
+- [`diagnostics-and-replay.md`](diagnostics-and-replay.md)
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,222 @@
+# Use Cases and Recipes
+
+Use this page when you know what you want OpenSquilla to do, but you are not
+sure which feature guide to read first.
+
+## First Successful Run
+
+Goal: install OpenSquilla, configure one provider, and send a real message.
+
+```sh
+opensquilla onboard
+opensquilla gateway run
+```
+
+Then open:
+
+```text
+http://127.0.0.1:18791/control/
+```
+
+If you prefer the terminal:
+
+```sh
+opensquilla chat
+```
+
+Read next:
+
+- [`quickstart.md`](quickstart.md)
+- [`web-ui.md`](web-ui.md)
+- [`providers-and-models.md`](providers-and-models.md)
+
+## Reduce Model Cost
+
+Goal: keep simple work on cheaper models and reserve stronger models for hard
+turns.
+
+```sh
+opensquilla configure router --router recommended
+opensquilla cost --by-model
+```
+
+Use diagnostics when you want to inspect routing and runtime behavior:
+
+```sh
+opensquilla diagnostics on
+```
+
+Read next:
+
+- [`features/squilla-router.md`](features/squilla-router.md)
+- [`features/tool-compression.md`](features/tool-compression.md)
+- [`features/compaction-and-cache.md`](features/compaction-and-cache.md)
+
+## Work With Large Tool Results
+
+Goal: let the agent inspect logs, pages, tables, search results, or diffs
+without flooding the model context.
+
+Start with a bounded workspace run:
+
+```sh
+opensquilla agent \
+  --workspace /path/to/project \
+  --workspace-strict \
+  -m "Inspect the latest logs and summarize the actionable failures"
+```
+
+If the turn seems too slow or expensive:
+
+```sh
+opensquilla cost
+opensquilla diagnostics on
+```
+
+Read next:
+
+- [`features/tool-compression.md`](features/tool-compression.md)
+- [`tools-and-sandbox.md`](tools-and-sandbox.md)
+- [`troubleshooting.md`](troubleshooting.md)
+
+## Build a Repeatable Workflow
+
+Goal: turn recurring work into reusable skills or meta-skills.
+
+Find an existing skill:
+
+```sh
+opensquilla skills search report
+opensquilla skills view <skill-name>
+```
+
+Inspect a meta-skill before running it:
+
+```sh
+opensquilla skills inspect <meta-skill-name>
+```
+
+Review historical meta-skill runs:
+
+```sh
+opensquilla skills meta runs list
+opensquilla skills meta runs show <run-id>
+```
+
+Read next:
+
+- [`features/skills.md`](features/skills.md)
+- [`features/meta-skills.md`](features/meta-skills.md)
+- [`artifacts-and-media.md`](artifacts-and-media.md)
+
+## Remember Useful Context
+
+Goal: preserve preferences, project notes, or reusable task context so future
+turns can find them.
+
+```sh
+opensquilla memory status
+opensquilla memory search "project preference"
+opensquilla memory list
+```
+
+Inspect a stored memory file:
+
+```sh
+opensquilla memory show <path>
+```
+
+Read next:
+
+- [`features/memory.md`](features/memory.md)
+- [`features/compaction-and-cache.md`](features/compaction-and-cache.md)
+
+## Connect a Messaging Channel
+
+Goal: use OpenSquilla from a supported messaging surface while keeping the
+gateway as the local control point.
+
+```sh
+opensquilla channels types
+opensquilla channels describe telegram
+opensquilla channels add telegram --name personal
+opensquilla gateway restart
+opensquilla channels status personal --json
+```
+
+Read next:
+
+- [`channels.md`](channels.md)
+- [`configuration.md`](configuration.md)
+- [`tools-and-sandbox.md`](tools-and-sandbox.md)
+
+## Schedule Recurring Work
+
+Goal: ask OpenSquilla to run a recurring task without manually opening a chat.
+
+```sh
+opensquilla cron add \
+  --every 1h \
+  --text "Summarize important project updates" \
+  --name hourly-project-check
+```
+
+Inspect jobs and runs:
+
+```sh
+opensquilla cron list
+opensquilla cron status <job-id>
+opensquilla cron runs <job-id>
+```
+
+Read next:
+
+- [`operations.md`](operations.md)
+- [`channels.md`](channels.md)
+- [`scheduling.md`](scheduling.md)
+
+## Publish a User-Visible Artifact
+
+Goal: ask the agent to produce a file, report, slide deck, HTML page, image, or
+media asset that you can inspect and share.
+
+```sh
+opensquilla agent -m "Create a short HTML report from the current notes"
+opensquilla sessions export <session-key>
+```
+
+Read next:
+
+- [`artifacts-and-media.md`](artifacts-and-media.md)
+- [`features/skills.md`](features/skills.md)
+- [`features/meta-skills.md`](features/meta-skills.md)
+
+## Recover From a Bad Run
+
+Goal: understand what happened, reduce risk, and continue safely.
+
+```sh
+opensquilla doctor
+opensquilla gateway status
+opensquilla sessions show <session-key>
+opensquilla cost
+```
+
+If a tool was denied or the agent had too much access:
+
+```sh
+opensquilla sandbox status
+opensquilla agent --permissions restricted -m "Read only"
+```
+
+Read next:
+
+- [`troubleshooting.md`](troubleshooting.md)
+- [`tools-and-sandbox.md`](tools-and-sandbox.md)
+- [`approvals-and-permissions.md`](approvals-and-permissions.md)
+- [`diagnostics-and-replay.md`](diagnostics-and-replay.md)
+- [`operations.md`](operations.md)
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -1,0 +1,131 @@
+# Web UI
+
+The OpenSquilla Web UI is the local control console for setup, chat sessions,
+approvals, channels, logs, agents, usage, and operational status. It is the
+best surface when you want browser-based chat, visible tool activity, durable
+approvals, and a quick view of runtime health.
+
+## Start the Web UI
+
+Run the gateway in the foreground:
+
+```sh
+opensquilla gateway run
+```
+
+Open:
+
+```text
+http://127.0.0.1:18791/control/
+```
+
+Or start a managed background gateway:
+
+```sh
+opensquilla gateway start --json
+opensquilla gateway status
+```
+
+The default gateway binds to `127.0.0.1` for safety.
+
+For gateway lifecycle, host/port, and exposure details, see
+[`gateway.md`](gateway.md).
+
+## Main Areas
+
+| Area | Use it for |
+| --- | --- |
+| Chat | Run and resume chat sessions, inspect tool activity, publish artifacts, and use manual compact controls. |
+| Overview / Health | See readiness, provider state, memory state, sandbox posture, and recovery hints. |
+| Channels | Add, edit, enable, disable, restart, and inspect channel adapters. |
+| Skills | Browse available skills and meta-skill surfaces. |
+| Sessions | Inspect durable conversations and operational state. |
+| Agents | Manage durable agent entries. |
+| Usage | Inspect token and estimated-cost rollups. |
+| Cron | View and manage scheduled runs. |
+| Config | Edit setup sections from the browser. |
+| Logs | Inspect runtime logs and diagnostics. |
+| Approvals | Respond to sensitive tool-call approval requests. |
+
+## Chat Sessions
+
+The chat UI supports:
+
+- streaming assistant output;
+- tool-call cards;
+- artifact cards;
+- pending message queue behavior while compaction or runtime work is in flight;
+- manual `/compact`;
+- per-turn usage and savings metadata when available;
+- copyable session keys.
+
+Use the session selector to switch between existing sessions. Copy the session
+key when reporting a bug or asking another OpenSquilla surface to inspect the
+same session.
+
+## Manual Compaction
+
+Long sessions can be compacted from chat. If no compaction is needed, the UI
+reports:
+
+```text
+Already within context budget; no compact was applied
+```
+
+If compaction is running, wait for its terminal state before assuming the next
+message has the compacted context. See
+[`features/compaction-and-cache.md`](features/compaction-and-cache.md).
+
+## Artifacts
+
+When the agent publishes a file, the Web UI shows an artifact card. Use artifact
+cards for:
+
+- generated HTML prototypes;
+- reports and briefings;
+- exported data files;
+- PDFs, slide decks, images, and other generated outputs.
+
+For channel delivery limits and artifact recovery, see
+[`artifacts-and-media.md`](artifacts-and-media.md).
+
+## Approvals
+
+Some tools require confirmation. The approvals area gives operators a durable
+place to approve or deny sensitive actions instead of burying the decision in
+chat text.
+
+Use the approvals area when:
+
+- the agent wants to write files;
+- a command requires elevated permissions;
+- a channel or external action needs human confirmation;
+- unattended automation should pause before a risky operation.
+
+## Logs and Diagnostics
+
+For local diagnosis:
+
+```sh
+opensquilla diagnostics on
+opensquilla gateway status
+opensquilla doctor
+```
+
+Use the Web UI logs and health views to correlate provider readiness, channel
+state, session state, and user-visible errors.
+
+## Safety
+
+The Web UI is local by default. If you bind the gateway to a public interface,
+configure token auth and network controls first:
+
+```sh
+opensquilla gateway run --listen 0.0.0.0 --port 18791
+```
+
+Do not expose an unauthenticated gateway to the public internet.
+
+---
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)


### PR DESCRIPTION
## Summary

- keep `README.md` as the lightweight release/package entry point and route users to product docs
- add `README.product.md` as the product guide for open-source users
- add `docs/README.md` plus task-oriented docs for setup, CLI, Web UI, channels, sessions, providers, memory, skills, SquillaRouter, tool compression, compaction/cache, operations, and troubleshooting
- add a documentation issue template and PR checklist items for docs changes

## Scope

Documentation-only. No runtime behavior changes are included in this PR.

## Validation

- Markdown fence balance check
- Relative repository link existence check
- GitHub issue template YAML parse
- Stale command-pattern check
- `git diff --check origin/dev...HEAD`

## Notes

This branch is based on `origin/dev` and contains one docs commit: `edb434e0`.
