### PR TITLE
Polish WebUI readability and mobile controls

### DIFF
--- a/src/opensquilla/gateway/static/css/base.css
+++ b/src/opensquilla/gateway/static/css/base.css
@@ -17,8 +17,8 @@
   --fs-xl: 1.5rem;
   --fs-2xl: 2rem;
 
-  /* Display tracking — Inter looks crisper with negative tracking at large sizes. */
-  --track-display: -0.035em;
+  /* Display tracking stays neutral to keep compact WebUI labels readable. */
+  --track-display: 0;
   --track-tabular: 0.01em;
 
   /* Radius */
@@ -63,7 +63,7 @@
   --bg-hover: #232328;
   --text: #ECECEF;
   --text-muted: #A1A1AA;
-  --text-dim: #71717A;
+  --text-dim: #82828A;
   --border: rgba(255,255,255,0.07);
   --border-strong: rgba(255,255,255,0.13);
   --border-focus: rgba(255,255,255,0.18);
@@ -77,8 +77,8 @@
   --accent-foreground: #1a0e02;
   --ok: #22C55E;
   --warn: #EAB308;
-  --danger: #EF4444;
-  --info: #3B82F6;
+  --danger: #F87171;
+  --info: #60A5FA;
   --shadow: rgba(0, 0, 0, 0.5);
   --shadow-color: rgba(0,0,0,0.5);
   --grain-opacity: 0.05;
@@ -101,22 +101,22 @@
   --bg-hover: #E7E4DD;
   --text: #18181B;
   --text-muted: #4B4B53;
-  --text-dim: #8A8A93;
+  --text-dim: #66666E;
   --border: rgba(20,18,15,0.10);
   --border-strong: rgba(20,18,15,0.18);
   --border-focus: rgba(20,18,15,0.24);
   --card: #FFFFFF;
   --hairline: rgba(20,18,15,0.08);
 
-  --accent: #C44B05;
+  --accent: #B84404;
   --accent-hover: #A23C02;
   --accent-deep: #7A2C00;
   --accent-secondary: #DD6224;
   --accent-foreground: #FFFFFF;
-  --ok: #16A34A;
-  --warn: #B47800;
-  --danger: #DC2626;
-  --info: #2563EB;
+  --ok: #166534;
+  --warn: #7A4F00;
+  --danger: #A61B1B;
+  --info: #1D4ED8;
   --shadow: rgba(40,30,20,0.10);
   --shadow-color: rgba(40,30,20,0.10);
   --grain-opacity: 0.03;
@@ -350,6 +350,7 @@ pre {
   display: flex;
   align-items: center;
   gap: 10px;
+  min-height: 40px;
   padding: 7px var(--sp-3);
   color: var(--text-muted);
   cursor: pointer;
@@ -358,7 +359,7 @@ pre {
   font-size: var(--fs-sm);
   position: relative;
   z-index: 1;
-  letter-spacing: -0.005em;
+  letter-spacing: 0;
   transition: background var(--transition), color var(--transition);
 }
 .nav-item:hover { background: var(--bg-hover); color: var(--text); }
@@ -398,6 +399,24 @@ pre {
   outline-offset: 2px;
 }
 
+@media (min-width: 769px) and (max-height: 640px) {
+  .nav-brand {
+    height: 44px;
+    min-height: 44px;
+  }
+
+  .nav-group-label {
+    margin-top: var(--sp-2);
+    padding: 5px var(--sp-4) 2px;
+    font-size: 9.5px;
+    line-height: 1.1;
+  }
+
+  .nav-group-label:first-of-type {
+    margin-top: 4px;
+  }
+}
+
 /* Approval count badge */
 .nav-badge {
   margin-left: auto;
@@ -423,7 +442,7 @@ pre {
 /* Accessibility: improved color contrast (WCAG AA) */
 [data-theme="dark"] {
   --text-muted: #A8A8B0;
-  --text-dim: #76767E;
+  --text-dim: #82828A;
 }
 
 /* View headers — display weight, very tight tracking, baseline accent rule. */

--- a/src/opensquilla/gateway/static/css/components.css
+++ b/src/opensquilla/gateway/static/css/components.css
@@ -16,6 +16,7 @@
   color: var(--text);
   cursor: pointer;
   line-height: 1.4;
+  min-height: 40px;
   white-space: nowrap;
   transition: background var(--transition), border-color var(--transition);
 }
@@ -35,15 +36,15 @@
 }
 .btn svg { width: 14px; height: 14px; }
 
-.btn--sm { padding: 4px var(--sp-2); font-size: var(--fs-xs); }
+.btn--sm { min-height: 40px; padding: 4px var(--sp-2); font-size: var(--fs-xs); }
 .btn--lg { padding: 9px var(--sp-4); font-size: var(--fs-md); }
 .btn--ghost { background: transparent; border-color: transparent; }
 .btn--ghost:hover { background: var(--bg-hover); }
-.btn--icon { padding: var(--sp-1); min-width: 32px; min-height: 32px; }
+.btn--icon { padding: var(--sp-1); min-width: 40px; min-height: 40px; }
 .btn--primary {
   background: var(--accent);
   border-color: var(--accent);
-  color: #1a0e02;
+  color: var(--accent-foreground);
   font-weight: 600;
 }
 .btn--primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
@@ -70,6 +71,40 @@
 .btn-group .btn:last-child { border-top-right-radius: var(--radius-md); border-bottom-right-radius: var(--radius-md); }
 .btn-group .btn:not(:first-child) { margin-left: -1px; }
 .btn-group .btn.btn-primary { z-index: 1; }
+
+/* Mobile action strip — shared header action contract for dense operator views. */
+@media (max-width: 760px) {
+  .mobile-action-strip {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+  .mobile-action-strip.mobile-action-strip { flex-wrap: nowrap; }
+  .mobile-action-strip::-webkit-scrollbar { display: none; }
+  .mobile-action-strip__item,
+  .mobile-action-strip__button {
+    flex: 0 0 auto;
+  }
+  .mobile-action-strip__button {
+    width: var(--mobile-action-button-size, 40px);
+    padding: 0;
+    justify-content: center;
+  }
+  .mobile-action-strip__label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+  }
+}
 
 /* Cards */
 .card {
@@ -310,13 +345,13 @@
 .stat-value {
   font-size: 1.5rem;
   font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
   line-height: 1;
   font-variant-numeric: tabular-nums;
   margin-top: 2px;
   color: var(--text);
 }
-.stat-value.mono { font-family: var(--font-mono); font-size: 1.125rem; }
+.stat-value.mono { font-family: var(--font-mono); font-size: 1.125rem; line-height: 1.3; }
 .stat-hint { font-size: var(--fs-xs); color: var(--text-muted); }
 .stat-hint .delta-up { color: var(--ok); }
 .stat-hint .delta-dn { color: var(--danger); }
@@ -361,7 +396,7 @@
 .modal-title {
   font-size: var(--fs-lg);
   font-weight: 700;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   margin-bottom: var(--sp-3);
   padding-top: 4px;
 }
@@ -444,7 +479,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  letter-spacing: -0.005em;
+  letter-spacing: 0;
   position: relative;
   overflow: hidden;
 }
@@ -575,7 +610,7 @@
 .search-input:focus { border-color: var(--accent); box-shadow: var(--shadow-sm); }
 
 /* Generic input */
-.input { padding: var(--sp-2) var(--sp-3); font-size: var(--fs-sm); background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius-md); color: var(--text); outline: none; transition: border-color var(--transition); }
+.input { min-height: 36px; padding: var(--sp-2) var(--sp-3); font-size: var(--fs-sm); background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius-md); color: var(--text); outline: none; transition: border-color var(--transition); }
 .input:focus { border-color: var(--accent); }
 
 /* View actions */
@@ -629,8 +664,15 @@
 .state-icon.warn { color: var(--warn); border-color: color-mix(in srgb, var(--warn) 35%, var(--border)); background: color-mix(in srgb, var(--warn) 12%, var(--bg-elevated)); }
 .state-icon.err { color: var(--danger); border-color: color-mix(in srgb, var(--danger) 35%, var(--border)); background: color-mix(in srgb, var(--danger) 12%, var(--bg-elevated)); }
 .state-icon.info { color: var(--info); border-color: color-mix(in srgb, var(--info) 35%, var(--border)); background: color-mix(in srgb, var(--info) 12%, var(--bg-elevated)); }
-.state-title { font-size: var(--fs-lg); font-weight: 600; letter-spacing: -0.01em; }
-.state-text { font-size: var(--fs-sm); color: var(--text-muted); max-width: 52ch; }
+.state-title { font-size: var(--fs-lg); font-weight: 600; letter-spacing: 0; }
+.state-text {
+  width: 100%;
+  max-width: 52ch;
+  box-sizing: border-box;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  overflow-wrap: anywhere;
+}
 .state-actions { display: flex; gap: 8px; margin-top: var(--sp-2); }
 .state-meta {
   margin-top: var(--sp-3);
@@ -743,7 +785,7 @@
 .drawer__title {
   font-size: var(--fs-lg);
   font-weight: 700;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   margin: 0;
   display: flex;
   align-items: center;

--- a/src/opensquilla/gateway/static/css/mobile.css
+++ b/src/opensquilla/gateway/static/css/mobile.css
@@ -7,7 +7,7 @@
 
   /* Touch-friendly tap targets */
   .btn { min-height: 44px; min-width: 44px; }
-  .btn--sm { min-height: 36px; }
+  .btn--sm { min-height: 40px; }
   .btn--icon { min-width: 44px; min-height: 44px; }
 
   /* Safe area insets for notched phones */

--- a/src/opensquilla/gateway/static/css/views/agents.css
+++ b/src/opensquilla/gateway/static/css/views/agents.css
@@ -24,7 +24,7 @@
 }
 .ag-stage__title {
   font-size: clamp(1.625rem, 1.2rem + 1vw, 2.25rem);
-  font-weight: 700; letter-spacing: -0.025em; line-height: 1.05;
+  font-weight: 700; letter-spacing: 0; line-height: 1.05;
   position: relative;
 }
 .ag-stage__title::after {
@@ -41,7 +41,8 @@
 
 .ag-iconbtn {
   display: inline-flex; align-items: center; gap: 4px;
-  padding: 5px 10px;
+  min-height: 40px;
+  padding: 7px 10px;
   font-size: var(--fs-xs); font-weight: 500;
   background: transparent; border: 1px solid var(--border);
   border-radius: var(--radius-sm); color: var(--text-muted);
@@ -134,7 +135,7 @@
   font: inherit;
   font-size: var(--fs-sm);
 }
-.ag-input:not(textarea) { height: 34px; }
+.ag-input:not(textarea) { height: 40px; }
 .ag-input:focus {
   outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent);
   border-color: var(--accent);
@@ -221,7 +222,7 @@
 
 .ag-list__head { display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--sp-3); }
 .ag-list__title {
-  font-size: var(--fs-lg); font-weight: 600; letter-spacing: -0.01em;
+  font-size: var(--fs-lg); font-weight: 600; letter-spacing: 0;
   display: flex; align-items: center; gap: 8px;
 }
 .ag-list__count {
@@ -278,6 +279,9 @@
 .ag-card__id-block { display: flex; align-items: center; gap: 8px; min-width: 0; }
 .ag-card__actions { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; justify-content: flex-end; }
 .ag-card__id {
+  display: inline-block;
+  max-width: 100%;
+  min-width: 0;
   font-family: var(--font-mono);
   font-size: 12.5px;
   font-weight: 600;
@@ -287,19 +291,26 @@
   padding: 2px 8px;
   border-radius: var(--radius-sm);
   letter-spacing: 0.02em;
+  overflow-wrap: anywhere;
 }
 
 .ag-card__name {
+  max-width: 100%;
+  min-width: 0;
   font-size: var(--fs-md);
   font-weight: 700;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   color: var(--text);
+  overflow-wrap: anywhere;
 }
 .ag-card__desc {
   margin: 0;
+  max-width: 100%;
+  min-width: 0;
   color: var(--text-muted);
   font-size: var(--fs-sm);
   line-height: 1.5;
+  overflow-wrap: anywhere;
 }
 .ag-card__meta {
   display: grid;
@@ -317,10 +328,13 @@
 }
 .ag-card__meta dd {
   margin: 0; font-size: var(--fs-sm);
+  max-width: 100%;
+  min-width: 0;
   color: var(--text);
-  white-space: nowrap;
+  white-space: normal;
   overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
 }
 .ag-mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 
@@ -365,4 +379,25 @@
   .ag-stage__header { flex-direction: column; align-items: stretch; }
   .ag-create__form { grid-template-columns: 1fr; }
   .ag-cards { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 420px) {
+  .ag-card__head {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .ag-card__id-block {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .ag-card__actions {
+    justify-content: stretch;
+  }
+
+  .ag-card__actions .ag-iconbtn {
+    flex: 1 1 96px;
+    justify-content: center;
+  }
 }

--- a/src/opensquilla/gateway/static/css/views/approvals.css
+++ b/src/opensquilla/gateway/static/css/views/approvals.css
@@ -24,7 +24,7 @@
 }
 .ap-stage__title {
   font-size: clamp(1.625rem, 1.2rem + 1vw, 2.25rem);
-  font-weight: 700; letter-spacing: -0.025em; line-height: 1.05;
+  font-weight: 700; letter-spacing: 0; line-height: 1.05;
   position: relative;
 }
 .ap-stage__title::after {
@@ -61,7 +61,7 @@
   color: var(--text-dim);
 }
 .ap-panel__title {
-  font-size: var(--fs-md); font-weight: 600; letter-spacing: -0.01em;
+  font-size: var(--fs-md); font-weight: 600; letter-spacing: 0;
 }
 .ap-strategy__options {
   display: grid;
@@ -94,7 +94,11 @@
   border: 1.5px solid var(--text-dim);
   border-radius: 50%;
   position: relative;
-  transition: border-color var(--transition);
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+.ap-radio input:focus-visible + .ap-radio__indicator {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
 }
 .ap-radio.is-active .ap-radio__indicator {
   border-color: var(--accent);
@@ -111,7 +115,7 @@
   font-size: var(--fs-sm); font-weight: 600;
   color: var(--text);
 }
-.ap-radio.is-active .ap-radio__label { color: var(--accent); }
+.ap-radio.is-active .ap-radio__label { color: var(--accent-hover); }
 .ap-radio__desc {
   font-size: var(--fs-xs);
   color: var(--text-muted);
@@ -122,7 +126,7 @@
 
 .ap-list-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--sp-3); }
 .ap-list__title {
-  font-size: var(--fs-lg); font-weight: 600; letter-spacing: -0.01em;
+  font-size: var(--fs-lg); font-weight: 600; letter-spacing: 0;
   display: flex; align-items: center; gap: 8px;
 }
 .ap-list__count {
@@ -165,7 +169,7 @@
 .ap-card__name {
   font-weight: 700;
   font-size: var(--fs-md);
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
 }
 .ap-card__time {
   font-size: 10.5px;
@@ -193,6 +197,13 @@
   gap: 16px;
   font-size: var(--fs-xs);
   color: var(--text-muted);
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.ap-card__meta span {
+  max-width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 .ap-card__meta em {
   font-style: normal;
@@ -210,6 +221,10 @@
   border-radius: var(--radius-sm);
   color: var(--text);
   font-size: 11px;
+  max-width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .ap-card__block { display: flex; flex-direction: column; gap: 4px; }

--- a/src/opensquilla/gateway/static/css/views/channels.css
+++ b/src/opensquilla/gateway/static/css/views/channels.css
@@ -41,27 +41,19 @@
   opacity: 0.85;
 }
 .ch-stage__eyebrow {
-  font-family: var(--font-mono);
-  font-size: 10.5px; font-weight: 600;
-  letter-spacing: 0.22em;
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--accent);
+  color: var(--text-dim);
   display: inline-flex;
   align-items: center;
   gap: 8px;
-}
-.ch-stage__eyebrow::before {
-  content: "";
-  width: 16px; height: 1px;
-  background: currentColor;
-  display: inline-block;
-  opacity: 0.7;
 }
 .ch-stage__title {
   font-family: var(--font-display);
   font-size: clamp(1.875rem, 1.2rem + 1.4vw, 2.625rem);
   font-weight: 800;
-  letter-spacing: -0.045em;
+  letter-spacing: 0;
   line-height: 1.0;
   position: relative;
   font-feature-settings: "ss01", "cv11";
@@ -96,7 +88,7 @@
 }
 .ch-list__title {
   font-size: var(--fs-lg); font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
   display: flex; align-items: center; gap: 10px;
   font-family: var(--font-display);
 }
@@ -176,7 +168,7 @@
 }
 .ch-card__name {
   font-weight: 700; font-size: var(--fs-md); flex: 1;
-  letter-spacing: -0.015em;
+  letter-spacing: 0;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   min-width: 0;
   font-family: var(--font-display);
@@ -190,7 +182,7 @@
 
 .ch-card__meta {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 8px 18px; margin: 0;
   padding-top: var(--sp-3);
   border-top: 1px dashed var(--border);
@@ -213,10 +205,13 @@
 .ch-card__meta dd {
   margin: 0;
   font-size: var(--fs-sm);
+  max-width: 100%;
+  min-width: 0;
   color: var(--text);
-  white-space: nowrap;
+  white-space: normal;
   overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
   font-weight: 500;
 }
 .ch-mono {
@@ -230,6 +225,7 @@
   cursor: pointer;
   color: var(--text-muted);
   user-select: none;
+  min-height: 38px;
   font-size: 10.5px;
   font-weight: 700;
   letter-spacing: 0.16em;
@@ -320,22 +316,27 @@
 .ch-empty__art {
   width: 120px; height: 120px;
   color: var(--text-muted);
+  line-height: 1;
   margin-bottom: var(--sp-4);
   filter: drop-shadow(0 0 24px color-mix(in srgb, var(--accent) 18%, transparent));
 }
+.ch-empty__art svg { display: block; width: 100%; height: 100%; }
 .ch-empty__title {
   font-family: var(--font-display);
   font-size: 1.625rem; font-weight: 800;
-  letter-spacing: -0.035em;
+  letter-spacing: 0;
   color: var(--text);
   margin-bottom: 10px;
 }
 .ch-empty__msg {
+  width: 100%;
+  max-width: 56ch;
+  box-sizing: border-box;
   color: var(--text-muted);
   font-size: var(--fs-sm);
-  max-width: 56ch;
   line-height: 1.6;
   margin-bottom: var(--sp-4);
+  overflow-wrap: anywhere;
 }
 .ch-empty__actions {
   display: flex;
@@ -381,5 +382,23 @@
   .ch-stage__header { flex-direction: column; align-items: stretch; }
   .ch-stage__actions { width: 100%; }
   .ch-cards { grid-template-columns: 1fr; }
+  .ch-card__head { align-items: flex-start; flex-wrap: wrap; }
+  .ch-card__name {
+    flex: 1 1 180px;
+    max-width: 100%;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+  }
+  .ch-card__head .chip {
+    max-width: 100%;
+    min-width: 0;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
   .ch-stage__title-block { padding-left: 14px; }
+  .ch-stage__title-block::before {
+    bottom: auto;
+    height: 16px;
+  }
 }

--- a/src/opensquilla/gateway/static/css/views/chat.css
+++ b/src/opensquilla/gateway/static/css/views/chat.css
@@ -48,6 +48,16 @@
   flex-shrink: 0;
 }
 
+#chat-run-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding-inline: 10px;
+  line-height: 1;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
 .chat-label {
   font-size: var(--fs-sm);
   color: var(--text-muted);
@@ -63,6 +73,7 @@
   align-items: center;
   gap: var(--sp-2);
   padding: var(--sp-1) var(--sp-3);
+  min-height: 40px;
   font-size: var(--fs-sm);
   font-family: var(--font-mono);
   background: var(--bg);
@@ -122,12 +133,12 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: 22px;
-  height: 22px;
+  width: 40px;
+  height: 40px;
   padding: 0;
   color: var(--text-muted);
-  background: none;
-  border: none;
+  background: var(--bg);
+  border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   cursor: pointer;
 }
@@ -1564,6 +1575,21 @@
 }
 .chat-toolbar-trigger:hover { color: var(--accent); }
 .chat-toolbar-trigger.is-active { color: var(--accent); }
+.chat-toolbar-trigger.has-bypass-signal {
+  min-width: 76px;
+  padding-inline: 8px 10px;
+  border-color: color-mix(in srgb, var(--danger) 55%, var(--border));
+  background: color-mix(in srgb, var(--danger) 12%, var(--bg-surface));
+  color: var(--danger);
+}
+.chat-toolbar-trigger-label {
+  display: none;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+.chat-toolbar-trigger.has-bypass-signal .chat-toolbar-trigger-label { display: inline; }
 
 /* Per-toggle status dots reveal which runtime mode is non-default. */
 .chat-toolbar-trigger-dots {
@@ -1597,60 +1623,6 @@
 /* Open state highlights the trigger itself. */
 .chat-toolbar-trigger.is-active .chat-toolbar-trigger-dots i {
   background: color-mix(in srgb, currentColor 30%, transparent);
-}
-
-/* ─── Bypass warning chip ──────────────────────────────────────────────
-   Surfaces ONLY when Approvals = bypassed. Sits inside the composer above
-   the input bar so it can't be missed before Send. Costs zero rows in the
-   default (non-bypassed) case. */
-.chat-bypass-warn {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 0 var(--sp-3) var(--sp-2);
-  padding: 6px 10px;
-  border: 1px solid color-mix(in srgb, var(--danger) 55%, var(--border));
-  border-left: 3px solid var(--danger);
-  border-radius: var(--radius-sm);
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--danger) 14%, transparent), transparent 60%),
-    var(--bg-surface);
-  color: var(--danger);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  animation: chat-bypass-warn-in 220ms cubic-bezier(.2,.7,.2,1);
-}
-.chat-bypass-warn.hidden { display: none !important; }
-.chat-bypass-warn__glyph {
-  display: inline-grid;
-  place-items: center;
-  width: 16px; height: 16px;
-  border-radius: 50%;
-  background: var(--danger);
-  color: #fff;
-  font-family: var(--font-display, var(--font-sans));
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0;
-  flex-shrink: 0;
-}
-.chat-bypass-warn__text {
-  letter-spacing: 0.08em;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-@keyframes chat-bypass-warn-in {
-  from { opacity: 0; transform: translateY(-4px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .chat-bypass-warn { animation: none; }
 }
 
 .chat-toolbar-popover {
@@ -1750,6 +1722,35 @@
 @media (max-width: 480px) {
   #chat-btn-export { display: none !important; }
 
+  .chat-header {
+    gap: var(--sp-2);
+  }
+
+  .chat-label {
+    display: none;
+  }
+
+  .chat-session-chip {
+    flex: 1 1 auto;
+    max-width: none;
+    min-height: 40px;
+    padding-inline: var(--sp-2);
+  }
+
+  .chat-session-copy-btn {
+    width: 40px;
+    height: 40px;
+    border: 1px solid var(--border);
+    background: var(--bg);
+  }
+
+  .chat-session-popover {
+    left: 12px !important;
+    right: 12px;
+    width: auto;
+    max-width: none;
+  }
+
   /* On narrow phones the input was getting squeezed to ~80px. Tighten icon
      targets to the touch minimum (40px instead of 44px) so the input gets
      back enough width to read its own placeholder. */
@@ -1781,29 +1782,54 @@
     max-width: none;
     z-index: 2500;
   }
-  /* When the run-modes popover is open, mute the toast stack so transient
-     "Squilla Router: ON/OFF" confirmations don't cover the popover content
-     the user is still interacting with. The toggle's own visible state is
-     the canonical feedback in this moment. */
+  /* When the run-modes popover is open, mute non-critical toasts so transient
+     "Squilla Router: ON/OFF" confirmations don't cover the popover content.
+     Error toasts stay visible because they may be the only failure feedback. */
   body:has(.chat-toolbar-popover.is-open) .toast-stack {
+    pointer-events: none;
+  }
+  body:has(.chat-toolbar-popover.is-open) .toast:not(.err) {
     opacity: 0;
     pointer-events: none;
     transition: opacity 120ms ease;
+  }
+  body:has(.chat-toolbar-popover.is-open) .toast.err {
+    opacity: 1;
+    pointer-events: auto;
   }
   /* Hide the desktop arrow notch — it can't reliably point at the trigger
      once we're using viewport-anchored positioning on phone. */
   .chat-toolbar-popover-arrow { display: none; }
 }
 
-/* Tiny phones only (iPhone SE 1st-gen, etc) — hide the "+" new-chat button.
-   Most modern iPhones are 375–393px so they keep it. New chat is reachable
-   from the session chip dropdown either way. */
+/* Tiny phones only (iPhone SE 1st-gen, etc). Most modern iPhones are
+   375-393px, so they keep the standard compact header. */
 @media (max-width: 360px) {
-  #chat-btn-new { display: none !important; }
+  .chat-header {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .chat-header-left {
+    flex: 1 1 100%;
+  }
+
+  .chat-session-chip {
+    gap: var(--sp-1);
+    padding-inline: 4px;
+  }
+
+  .chat-header-right {
+    margin-left: 0;
+  }
 }
 
 .chat-pill {
-  padding: 2px 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 6px 12px;
   border-radius: 12px;
   border: 1px solid var(--border);
   background: transparent;
@@ -1870,6 +1896,7 @@
   font-size: var(--fs-xs);
   color: var(--text-muted);
   cursor: pointer;
+  min-height: 40px;
   user-select: none;
 }
 
@@ -1881,8 +1908,8 @@
 .toggle-switch {
   position: relative;
   display: inline-block;
-  width: 32px;
-  height: 18px;
+  width: 40px;
+  height: 22px;
   flex-shrink: 0;
 }
 
@@ -1907,10 +1934,10 @@
 
 .toggle-thumb {
   position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 12px;
-  height: 12px;
+  top: 1px;
+  left: 1px;
+  width: 18px;
+  height: 18px;
   background: var(--text-dim);
   border-radius: 50%;
   transition: transform 0.2s, background 0.2s;
@@ -1923,7 +1950,7 @@
 }
 
 .toggle-switch input:checked + .toggle-track .toggle-thumb {
-  transform: translateX(14px);
+  transform: translateX(18px);
   background: #fff;
 }
 
@@ -1970,7 +1997,7 @@
   font-family: inherit;
   font-size: var(--fs-sm);
   line-height: 1.4;
-  min-height: 0;
+  min-height: 40px;
   max-height: 150px;
   overflow-y: auto;
   outline: none;
@@ -1991,6 +2018,30 @@
 }
 #chat-btn-send:active {
   transform: scale(0.92);
+}
+
+@media (max-width: 480px) {
+  .chat-input-bar {
+    flex-wrap: wrap;
+    align-items: center;
+    row-gap: 6px;
+  }
+
+  #chat-btn-attach,
+  .chat-toolbar-wrap,
+  #chat-btn-new {
+    order: 0;
+  }
+
+  .chat-input-wrap {
+    order: 1;
+    flex: 1 1 calc(100% - 44px);
+  }
+
+  #chat-btn-send,
+  #chat-btn-stop {
+    order: 2;
+  }
 }
 
 /* Stop button pulse animation during streaming */

--- a/src/opensquilla/gateway/static/css/views/config.css
+++ b/src/opensquilla/gateway/static/css/views/config.css
@@ -22,7 +22,7 @@
 }
 .cfg-stage__title {
   font-size: clamp(1.625rem, 1.2rem + 1vw, 2.25rem);
-  font-weight: 700; letter-spacing: -0.025em; line-height: 1.05;
+  font-weight: 700; letter-spacing: 0; line-height: 1.05;
   position: relative;
 }
 .cfg-stage__title::after {
@@ -40,7 +40,7 @@
 /* Control-center buttons */
 .cfg-btn {
   display: inline-flex; align-items: center; gap: 6px;
-  height: 34px; padding: 0 14px;
+  min-height: 40px; padding: 0 14px;
   font-size: var(--fs-sm); font-weight: 500;
   border-radius: 999px;
   border: 1px solid var(--border);
@@ -56,7 +56,7 @@
 .cfg-btn--primary {
   background: var(--accent);
   border-color: var(--accent);
-  color: #1a0e02;
+  color: var(--accent-foreground);
   font-weight: 600;
   box-shadow: 0 1px 0 0 rgba(255,255,255,0.06) inset, 0 6px 16px -8px color-mix(in srgb, var(--accent) 60%, transparent);
 }
@@ -72,6 +72,7 @@
   gap: 2px;
 }
 .cfg-mode-btn {
+  min-height: 40px;
   padding: 4px 14px;
   font-size: var(--fs-xs); font-weight: 600;
   letter-spacing: 0.04em;
@@ -84,7 +85,7 @@
 .cfg-mode-btn:hover { color: var(--text); }
 .cfg-mode-btn.is-active {
   background: var(--accent);
-  color: #1a0e02;
+  color: var(--accent-foreground);
 }
 .cfg-mode-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
@@ -99,11 +100,11 @@
   overflow-x: auto;
 }
 .cfg-tab {
-  min-height: 36px;
+  min-height: 40px;
   padding: 8px 16px;
   font-size: var(--fs-sm);
   font-weight: 500;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   color: var(--text-muted);
   background: transparent;
   border: none;
@@ -114,7 +115,7 @@
 }
 .cfg-tab:hover { color: var(--text); }
 .cfg-tab.is-active {
-  color: var(--accent);
+  color: var(--accent-hover);
   font-weight: 600;
   border-bottom-color: var(--accent);
 }
@@ -123,6 +124,7 @@
 /* Search input within toolbar */
 .cfg-search-input {
   width: 100%;
+  min-height: 40px;
   padding: 7px 12px 7px 32px;
   font-size: var(--fs-sm);
   background: var(--bg);
@@ -176,16 +178,21 @@
 
 .cfg-search-icon {
   position: absolute;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   left: var(--sp-3);
   top: 50%;
   width: 16px;
   height: 16px;
   color: var(--text-dim);
+  line-height: 1;
   pointer-events: none;
   transform: translateY(-50%);
 }
 
 .cfg-search-icon svg {
+  display: block;
   width: 16px;
   height: 16px;
 }
@@ -280,10 +287,14 @@
 
 .cfg-input-text {
   flex: 1;
+  min-height: 40px;
   min-width: 0;
 }
 
-.cfg-input-number { width: 140px; }
+.cfg-input-number {
+  min-height: 40px;
+  width: 140px;
+}
 
 .cfg-input-json {
   width: 100%;
@@ -302,7 +313,7 @@
   align-items: center;
   gap: var(--sp-2);
   width: fit-content;
-  min-height: 30px;
+  min-height: 40px;
   color: var(--text-muted);
   cursor: pointer;
   font-size: var(--fs-sm);
@@ -317,8 +328,8 @@
 
 .cfg-switch-track {
   position: relative;
-  width: 36px;
-  height: 20px;
+  width: 40px;
+  height: 22px;
   flex-shrink: 0;
   border: 1px solid var(--border-focus);
   border-radius: 999px;
@@ -328,10 +339,10 @@
 
 .cfg-switch-thumb {
   position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 14px;
-  height: 14px;
+  top: 1px;
+  left: 1px;
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
   background: var(--text-muted);
   transition: transform var(--transition), background var(--transition);
@@ -344,7 +355,7 @@
 
 .cfg-switch input:checked + .cfg-switch-track .cfg-switch-thumb {
   background: var(--accent);
-  transform: translateX(16px);
+  transform: translateX(18px);
 }
 
 .cfg-switch input:focus-visible + .cfg-switch-track {
@@ -391,7 +402,7 @@
 
 .cfg-object-action {
   flex-shrink: 0;
-  color: var(--accent);
+  color: var(--accent-hover);
   font-size: var(--fs-xs);
   font-weight: 700;
 }
@@ -455,10 +466,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 32px;
-  min-height: 32px;
-  width: 32px;
-  height: 32px;
+  min-width: 40px;
+  min-height: 40px;
+  width: 40px;
+  height: 40px;
   padding: 0;
   margin: 0;
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
@@ -719,6 +730,19 @@
 }
 
 /* Responsive */
+@media (max-width: 900px) {
+  .cfg-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .cfg-search-wrap {
+    flex-basis: auto;
+    width: 100%;
+    min-width: 0;
+  }
+}
+
 @media (max-width: 760px) {
   .cfg-toolbar {
     align-items: stretch;
@@ -726,12 +750,34 @@
   }
 
   .cfg-tabs {
-    flex-wrap: wrap;
-    overflow-x: visible;
+    flex-wrap: nowrap;
+    mask-image: linear-gradient(
+      90deg,
+      transparent,
+      #000 14px,
+      #000 calc(100% - 44px),
+      transparent
+    );
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-inline: var(--sp-2) var(--sp-8);
+    scroll-snap-type: x proximity;
+    scroll-padding-inline: var(--sp-2);
+    -webkit-mask-image: linear-gradient(
+      90deg,
+      transparent,
+      #000 14px,
+      #000 calc(100% - 44px),
+      transparent
+    );
+    -webkit-overflow-scrolling: touch;
   }
 
   .cfg-tab {
-    min-height: 36px;
+    flex: 0 0 auto;
+    min-height: 40px;
+    scroll-snap-align: start;
   }
 
   .cfg-search-wrap {
@@ -767,9 +813,28 @@
     padding-top: 0;
   }
 
+  .config-field > .form-label,
+  .config-field__label-row > .form-label {
+    max-width: 100%;
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+    white-space: normal;
+  }
+
   .cfg-input-row,
   .cfg-object-field {
     max-width: 100%;
+  }
+
+  .cfg-object-field summary {
+    align-items: flex-start;
+  }
+
+  .cfg-object-summary {
+    overflow: visible;
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+    white-space: normal;
   }
 
   .cfg-input-number {

--- a/src/opensquilla/gateway/static/css/views/cron.css
+++ b/src/opensquilla/gateway/static/css/views/cron.css
@@ -61,7 +61,7 @@
 .cron-stage__title {
   font-size: clamp(1.625rem, 1.2rem + 1vw, 2.25rem);
   font-weight: 700;
-  letter-spacing: -0.025em;
+  letter-spacing: 0;
   line-height: 1.05;
   color: var(--text);
   /* tiny accent underline-rhythm tying into the stripe motif */
@@ -111,6 +111,7 @@
 .cron-search-icon svg { width: 14px; height: 14px; }
 .cron-search-input {
   width: 240px;
+  min-height: 40px;
   padding: 8px 12px 8px 32px;
   font-size: var(--fs-sm);
   background: var(--bg);
@@ -281,7 +282,7 @@
 .cron-jobs__title {
   font-size: var(--fs-lg);
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -309,6 +310,7 @@
   gap: 2px;
 }
 .cron-view-toggle__btn {
+  min-height: 40px;
   padding: 4px 12px;
   font-size: var(--fs-xs);
   font-weight: 600;
@@ -324,7 +326,7 @@
 .cron-view-toggle__btn:hover { color: var(--text); }
 .cron-view-toggle__btn.is-active {
   background: var(--accent);
-  color: #1a0e02;
+  color: var(--accent-foreground);
 }
 
 /* ─── Card grid ──────────────────────────────────────────────────────── */
@@ -427,10 +429,11 @@
   text-align: left;
   flex: 1;
   min-width: 0;
-  white-space: nowrap;
+  white-space: normal;
   overflow: hidden;
-  text-overflow: ellipsis;
-  letter-spacing: -0.01em;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  letter-spacing: 0;
 }
 .cron-card__name:hover { color: var(--accent); }
 
@@ -488,7 +491,7 @@
 
 .cron-card__meta {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 6px 16px;
   margin: 0;
   padding: var(--sp-3) 0 0;
@@ -504,11 +507,14 @@
 }
 .cron-card__meta dd {
   font-size: var(--fs-sm);
+  max-width: 100%;
+  min-width: 0;
   color: var(--text);
   margin: 0;
-  white-space: nowrap;
+  white-space: normal;
   overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
 }
 .cron-card__message {
   grid-column: 1 / -1;
@@ -649,7 +655,7 @@
 .cron-detail__name {
   font-size: var(--fs-lg);
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
 }
 .cron-detail__runs { font-size: var(--fs-sm); }
 .cron-runs {
@@ -700,8 +706,10 @@
   width: 120px;
   height: 120px;
   color: var(--text-muted);
+  line-height: 1;
   margin-bottom: var(--sp-4);
 }
+.cron-empty__clock svg { display: block; width: 100%; height: 100%; }
 .cron-empty__hand {
   transform-origin: 60px 60px;
   animation: cron-hand 9s linear infinite;
@@ -713,16 +721,19 @@
 .cron-empty__title {
   font-size: 1.5rem;
   font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
   color: var(--text);
   margin-bottom: 8px;
 }
 .cron-empty__msg {
+  width: 100%;
+  max-width: 56ch;
+  box-sizing: border-box;
   color: var(--text-muted);
   font-size: var(--fs-sm);
-  max-width: 56ch;
   line-height: 1.55;
   margin-bottom: var(--sp-5);
+  overflow-wrap: anywhere;
 }
 .cron-empty__cta {
   margin-bottom: var(--sp-6);
@@ -736,7 +747,9 @@
   gap: var(--sp-2);
   justify-content: center;
   align-items: center;
+  width: 100%;
   max-width: 720px;
+  box-sizing: border-box;
   position: relative;
   z-index: 1;
 }
@@ -750,8 +763,12 @@
 }
 .cron-empty-hint {
   display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 40px;
   padding: 8px 14px;
   background: var(--bg);
   border: 1px solid var(--border);
@@ -770,6 +787,11 @@
   padding: 1px 6px;
   border-radius: var(--radius-sm);
   letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.cron-empty-hint span {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 /* ─── Side panel (create / edit) ─────────────────────────────────────── */
@@ -822,7 +844,7 @@
 .cron-panel__title {
   font-size: 1.125rem;
   font-weight: 700;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
 }
 .cron-panel__body {
   flex: 1;
@@ -836,6 +858,15 @@
   margin-top: var(--sp-3);
   display: flex;
   gap: var(--sp-2);
+  position: sticky;
+  bottom: calc(-1 * var(--sp-5));
+  margin-inline: calc(-1 * var(--sp-5));
+  margin-bottom: calc(-1 * var(--sp-5));
+  padding: var(--sp-3) var(--sp-5) var(--sp-5);
+  background:
+    linear-gradient(180deg, transparent, var(--bg-surface) 18%),
+    var(--bg-surface);
+  border-top: 1px solid var(--border);
 }
 
 /* ─── Form field ─────────────────────────────────────────────────────── */
@@ -1029,4 +1060,46 @@
   .cron-summary { grid-template-columns: 1fr 1fr; }
   .cron-card-grid { grid-template-columns: 1fr; }
   .cron-table-wrap { overflow-x: auto; }
+}
+
+@media (max-width: 480px) {
+  .cron-stage__actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .cron-search-wrap {
+    grid-column: 1 / -1;
+  }
+
+  .cron-stage__actions .btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .cron-empty-hint {
+    min-height: 40px;
+    padding: 9px 14px;
+  }
+
+  .cron-panel {
+    width: 100vw;
+    max-width: 100vw;
+  }
+
+  .cron-panel__body {
+    padding: var(--sp-4);
+  }
+
+  .cron-panel__actions {
+    bottom: calc(-1 * var(--sp-4));
+    margin-inline: calc(-1 * var(--sp-4));
+    margin-bottom: calc(-1 * var(--sp-4));
+    padding: var(--sp-3) var(--sp-4) var(--sp-4);
+  }
+
+  .cron-panel__actions .btn {
+    flex: 1 1 0;
+    justify-content: center;
+  }
 }

--- a/src/opensquilla/gateway/static/css/views/health.css
+++ b/src/opensquilla/gateway/static/css/views/health.css
@@ -140,7 +140,7 @@
   display: block;
   font-size: clamp(1.6rem, 1.2rem + 1vw, 2.35rem);
   letter-spacing: 0;
-  line-height: 1;
+  line-height: 1.12;
   margin-top: var(--sp-2);
 }
 
@@ -149,6 +149,8 @@
   display: block;
   font-size: var(--fs-sm);
   margin-top: var(--sp-2);
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .health-report-context {
@@ -159,27 +161,32 @@
   min-width: 0;
 }
 
-.health-report-context span {
+.health-report-context__item {
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
-  display: inline-flex;
+  display: inline-grid;
   font-family: var(--font-mono);
   font-size: 11px;
+  grid-template-columns: auto minmax(0, 1fr);
   gap: 6px;
   line-height: 1.5;
   max-width: 100%;
   min-width: 0;
-  overflow-wrap: anywhere;
   padding: 3px 7px;
-  word-break: break-word;
 }
 
 .health-report-context b {
   color: var(--text-dim);
   font-family: inherit;
   font-weight: 700;
+}
+
+.health-report-context__value {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .health-count-grid {
@@ -209,7 +216,7 @@
   font-size: 2rem;
   font-variant-numeric: tabular-nums;
   letter-spacing: 0;
-  line-height: 1;
+  line-height: 1.12;
   margin-top: var(--sp-4);
 }
 
@@ -296,6 +303,8 @@
   font-weight: 700;
   gap: 6px;
   letter-spacing: 0.12em;
+  min-width: 0;
+  overflow-wrap: anywhere;
   text-transform: uppercase;
 }
 
@@ -337,12 +346,16 @@
   font-weight: 700;
   letter-spacing: 0;
   margin-top: var(--sp-2);
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .health-finding__detail {
   color: var(--text-muted);
   line-height: 1.5;
   margin-top: 4px;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .health-evidence {
@@ -350,6 +363,8 @@
   flex-wrap: wrap;
   gap: 6px;
   margin-top: var(--sp-3);
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .health-evidence span {
@@ -363,6 +378,7 @@
   gap: 6px;
   line-height: 1.5;
   max-width: 100%;
+  min-width: 0;
   overflow-wrap: anywhere;
   padding: 3px 7px;
 }
@@ -444,6 +460,8 @@
   display: inline-flex;
   gap: 6px;
   max-width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
   vertical-align: middle;
 }
 
@@ -456,11 +474,11 @@
   cursor: pointer;
   display: inline-flex;
   flex: 0 0 auto;
-  height: 26px;
+  height: 40px;
   justify-content: center;
   padding: 0;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
-  width: 26px;
+  width: 40px;
 }
 
 .health-step__copy:hover {
@@ -513,7 +531,8 @@
   }
 
   .health-stage__header .btn {
-    width: 100%;
+    align-self: flex-start;
+    width: auto;
   }
 
   .health-count-grid {
@@ -523,5 +542,27 @@
   .health-finding {
     grid-template-columns: 16px minmax(0, 1fr);
     padding: var(--sp-3);
+  }
+}
+
+@media (max-width: 480px) {
+  .health-report-context {
+    display: grid;
+  }
+
+  .health-report-context__item {
+    gap: 2px;
+    grid-template-columns: minmax(0, 1fr);
+    width: 100%;
+  }
+
+  .health-step__command {
+    display: flex;
+    width: 100%;
+  }
+
+  .health-step__command code {
+    flex: 1 1 auto;
+    min-width: 0;
   }
 }

--- a/src/opensquilla/gateway/static/css/views/logs.css
+++ b/src/opensquilla/gateway/static/css/views/logs.css
@@ -24,7 +24,7 @@
 }
 .lg-stage__title {
   font-size: clamp(1.625rem, 1.2rem + 1vw, 2.25rem);
-  font-weight: 700; letter-spacing: -0.025em; line-height: 1.05;
+  font-weight: 700; letter-spacing: 0; line-height: 1.05;
   position: relative;
 }
 .lg-stage__title::after {
@@ -38,6 +38,7 @@
   margin-top: var(--sp-3); max-width: 60ch;
 }
 .lg-stage__actions { display: flex; gap: var(--sp-2); flex-wrap: wrap; align-items: center; }
+.lg-stage__actions .btn { min-height: 40px; }
 .lg-status-pills { display: flex; gap: var(--sp-2); flex-wrap: wrap; align-items: center; }
 
 /* ─── Buttons & pills ────────────────────────────────────────────────── */
@@ -82,8 +83,8 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  min-height: 32px;
-  padding: 4px 10px;
+  min-height: 40px;
+  padding: 7px 10px;
   border: 1px solid var(--border);
   border-radius: 999px;
   background: var(--bg-elevated);
@@ -120,6 +121,7 @@
 .lg-search-icon svg { width: 14px; height: 14px; }
 .lg-search-input {
   width: 100%;
+  min-height: 40px;
   padding: 8px 12px 8px 32px;
   font-size: var(--fs-sm);
   background: var(--bg);
@@ -137,7 +139,9 @@
 .lg-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
+  min-height: 40px;
+  padding: 0 2px;
   cursor: pointer;
   user-select: none;
   font-size: var(--fs-sm);
@@ -145,16 +149,17 @@
 .lg-toggle input { position: absolute; opacity: 0; pointer-events: none; }
 .lg-toggle__track {
   position: relative;
-  width: 32px; height: 18px;
+  flex: 0 0 auto;
+  width: 40px; height: 22px;
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: 999px;
-  transition: background var(--transition), border-color var(--transition);
+  transition: background var(--transition), border-color var(--transition), box-shadow var(--transition);
 }
 .lg-toggle__thumb {
   position: absolute;
   top: 1px; left: 1px;
-  width: 14px; height: 14px;
+  width: 18px; height: 18px;
   background: var(--text-muted);
   border-radius: 50%;
   transition: transform var(--transition), background var(--transition);
@@ -164,8 +169,11 @@
   border-color: var(--accent);
 }
 .lg-toggle input:checked + .lg-toggle__track .lg-toggle__thumb {
-  transform: translateX(14px);
+  transform: translateX(18px);
   background: var(--accent);
+}
+.lg-toggle input:focus-visible + .lg-toggle__track {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
 }
 .lg-toggle__label {
   font-size: var(--fs-xs);
@@ -222,9 +230,9 @@
   display: grid;
   grid-template-columns: 180px 70px 1fr;
   gap: 8px;
+  min-width: 0;
   padding: 2px var(--sp-4);
   white-space: pre-wrap;
-  word-break: break-all;
   border-left: 2px solid transparent;
   transition: background 60ms ease;
 }
@@ -258,7 +266,11 @@
 .lg-line--info  {}
 .lg-line--debug, .lg-line--trace { color: var(--text-muted); }
 
-.lg-line__msg { word-break: break-all; }
+.lg-line__msg {
+  min-width: 0;
+  word-break: normal;
+  overflow-wrap: break-word;
+}
 .lg-line__match {
   background: color-mix(in srgb, var(--accent) 30%, transparent);
   color: var(--accent);
@@ -276,10 +288,26 @@
 
 @media (max-width: 720px) {
   .lg-stage__header { flex-direction: column; align-items: stretch; }
-  .lg-toolbar { flex-direction: column; align-items: stretch; }
-  .lg-levels { flex-direction: column; align-items: stretch; }
-  .lg-levels__row { width: 100%; }
+  .lg-toolbar { flex-direction: column; align-items: stretch; gap: var(--sp-3); }
+  .lg-levels {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+    width: 100%;
+    min-width: 0;
+    overflow: hidden;
+  }
+  .lg-levels__row {
+    width: 100%;
+    flex: 0 0 auto;
+    min-width: 0;
+    flex-wrap: wrap;
+    overflow: visible;
+  }
+  .lg-level-btn { flex: 0 0 auto; }
   .lg-search-wrap { width: 100%; min-width: 0; }
+  .lg-toggle { width: 100%; min-height: 40px; }
   .lg-line { grid-template-columns: 70px 1fr; }
+  .lg-line__msg { grid-column: 1 / -1; }
   .lg-line__ts { display: none; }
 }

--- a/src/opensquilla/gateway/static/css/views/overview.css
+++ b/src/opensquilla/gateway/static/css/views/overview.css
@@ -33,7 +33,7 @@
 .ov-stage__title {
   font-size: clamp(1.625rem, 1.2rem + 1vw, 2.25rem);
   font-weight: 700;
-  letter-spacing: -0.025em;
+  letter-spacing: 0;
   line-height: 1.05;
   position: relative;
 }
@@ -128,12 +128,17 @@
 .ov-stat__value {
   font-size: 1.75rem;
   font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
   color: var(--text);
-  line-height: 1;
+  line-height: 1.18;
   font-variant-numeric: tabular-nums;
 }
-.ov-stat__value--mono { font-family: var(--font-mono); font-size: 1.375rem; }
+.ov-stat__value--mono { font-family: var(--font-mono); font-size: 1.375rem; line-height: 1.3; }
+.ov-stat__value--status {
+  font-size: clamp(1.35rem, 1.35vw, 1.55rem);
+  line-height: 1.2;
+  white-space: nowrap;
+}
 .ov-stat__hint {
   margin-top: 6px;
   font-size: var(--fs-xs);
@@ -179,7 +184,7 @@
 .ov-panel__title {
   font-size: var(--fs-lg);
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
 }
 .ov-panel__meta {
   font-size: var(--fs-xs);
@@ -190,9 +195,13 @@
 }
 
 .ov-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: transparent;
   border: 0;
-  padding: 0;
+  min-height: 40px;
+  padding: 0 var(--sp-1);
   cursor: pointer;
   color: var(--accent);
   font-size: var(--fs-xs);
@@ -296,8 +305,9 @@
   width: 36px;
   height: 36px;
   color: var(--text-dim);
+  line-height: 1;
 }
-.ov-recent__empty-icon svg { width: 36px; height: 36px; }
+.ov-recent__empty-icon svg { display: block; width: 36px; height: 36px; }
 
 /* ─── Form fields (connection panel) ─────────────────────────────────── */
 
@@ -313,6 +323,7 @@
 .ov-field__optional { color: var(--text-dim); text-transform: none; letter-spacing: 0; font-weight: 500; margin-left: 4px; }
 .ov-field__input {
   width: 100%;
+  min-height: 40px;
   padding: 8px 12px;
   font-size: var(--fs-sm);
   background: var(--bg);
@@ -426,6 +437,13 @@
   .ov-stage__actions { width: 100%; }
   .ov-stat__icon { top: 8px; right: 8px; }
   .ov-recent__row { grid-template-columns: auto 1fr auto; gap: 8px; }
+  .ov-recent__key {
+    max-width: 100%;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+  }
+  .ov-recent__arrow { display: none; }
   .ov-recent__model, .ov-recent__msgs { display: none; }
   .ov-event-log__row { grid-template-columns: 70px 1fr; }
   .ov-event-log__payload { grid-column: 1 / -1; padding-left: 82px; color: var(--text-dim); }

--- a/src/opensquilla/gateway/static/css/views/sessions.css
+++ b/src/opensquilla/gateway/static/css/views/sessions.css
@@ -40,7 +40,7 @@
 .sess-stage__title {
   font-size: clamp(1.625rem, 1.2rem + 1vw, 2.25rem);
   font-weight: 700;
-  letter-spacing: -0.025em;
+  letter-spacing: 0;
   line-height: 1.05;
   position: relative;
 }
@@ -82,6 +82,7 @@
 .sess-search-icon svg { width: 14px; height: 14px; }
 .sess-search-input {
   width: 260px;
+  min-height: 40px;
   padding: 8px 12px 8px 32px;
   font-size: var(--fs-sm);
   background: var(--bg);
@@ -134,7 +135,7 @@
 .sess-list__title {
   font-size: var(--fs-lg);
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -169,6 +170,7 @@
 }
 .sess-page-size select {
   padding: 4px 8px;
+  min-height: 40px;
   font-size: var(--fs-xs);
   background: var(--bg-surface);
   border: 1px solid var(--border);
@@ -409,8 +411,10 @@
   width: 130px;
   height: 130px;
   color: var(--text-muted);
+  line-height: 1;
   margin-bottom: var(--sp-4);
 }
+.sess-empty__art svg { display: block; width: 100%; height: 100%; }
 .sess-empty__pulse {
   animation: sess-empty-blink 2.4s ease-in-out infinite;
   transform-origin: center;
@@ -422,16 +426,19 @@
 .sess-empty__title {
   font-size: 1.5rem;
   font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
   color: var(--text);
   margin-bottom: 8px;
 }
 .sess-empty__msg {
+  width: 100%;
+  max-width: 56ch;
+  box-sizing: border-box;
   color: var(--text-muted);
   font-size: var(--fs-sm);
-  max-width: 56ch;
   line-height: 1.55;
   margin-bottom: var(--sp-5);
+  overflow-wrap: anywhere;
 }
 .sess-empty__cta { height: 40px; padding: 0 20px; font-size: var(--fs-sm); }
 
@@ -498,8 +505,17 @@
   margin-top: 2px;
   font-size: var(--fs-xs);
   color: var(--text-muted);
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
-.sess-key__agent { display: inline-flex; align-items: center; gap: 4px; }
+.sess-key__agent {
+  align-items: center;
+  display: inline-flex;
+  gap: 4px;
+  max-width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
 .sess-key__agent--orphan { color: var(--text); }
 .chip-warn {
   background: color-mix(in srgb, #f0a030 18%, transparent);
@@ -519,4 +535,22 @@
     -webkit-overflow-scrolling: touch;
   }
   .sess-table { min-width: 720px; }
+}
+
+@media (max-width: 480px) {
+  .sess-search-wrap {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+
+  .sess-stage__actions > .btn {
+    flex: 1 1 0;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 360px) {
+  .sess-stage .stat-row {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/opensquilla/gateway/static/css/views/skills.css
+++ b/src/opensquilla/gateway/static/css/views/skills.css
@@ -25,7 +25,7 @@
 }
 .sk-stage__title {
   font-size: clamp(1.625rem, 1.2rem + 1vw, 2.25rem);
-  font-weight: 700; letter-spacing: -0.025em; line-height: 1.05;
+  font-weight: 700; letter-spacing: 0; line-height: 1.05;
   position: relative;
 }
 .sk-stage__title::after {
@@ -50,6 +50,7 @@
 .sk-search-icon svg { width: 14px; height: 14px; }
 .sk-search-input {
   width: 240px; padding: 8px 12px 8px 32px;
+  min-height: 40px;
   font-size: var(--fs-sm);
   background: var(--bg);
   border: 1px solid var(--border);
@@ -62,12 +63,14 @@
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
 }
 .sk-search-wrap--lg { flex: 1; }
-.sk-search-input--lg { width: 100%; height: 38px; font-size: var(--fs-md); padding-left: 36px; }
+.sk-search-input--lg { width: 100%; height: 40px; font-size: var(--fs-md); padding-left: 36px; }
 .sk-search-wrap--lg .sk-search-icon svg { width: 16px; height: 16px; }
 
 .sk-iconbtn {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 28px; height: 28px;
+  width: 40px; height: 40px;
+  min-width: 40px;
+  flex: 0 0 40px;
   border: 1px solid var(--border); border-radius: var(--radius-md);
   background: var(--bg-surface);
   color: var(--text-muted);
@@ -130,7 +133,7 @@
 }
 .sk-stat__value {
   font-size: 1.75rem; font-weight: 700;
-  letter-spacing: -0.02em; line-height: 1;
+  letter-spacing: 0; line-height: 1;
   font-variant-numeric: tabular-nums;
 }
 .sk-stat__hint { margin-top: 6px; font-size: var(--fs-xs); color: var(--text-muted); }
@@ -150,6 +153,7 @@
 }
 .sk-tab {
   display: inline-flex; align-items: center; gap: 6px;
+  min-height: 40px;
   padding: 5px 16px;
   font-size: var(--fs-sm); font-weight: 600;
   letter-spacing: 0.02em;
@@ -161,8 +165,10 @@
 }
 .sk-tab svg { width: 14px; height: 14px; }
 .sk-tab:hover { color: var(--text); }
-.sk-tab.is-active { background: var(--accent); color: #1a0e02; }
+.sk-tab.is-active { background: var(--accent); color: var(--accent-foreground); }
 .sk-tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+#skills-refresh { min-height: 40px; }
+#skills-github-install { min-height: 40px; }
 
 /* ─── Layer groups ───────────────────────────────────────────────────── */
 
@@ -246,7 +252,7 @@
 }
 .sk-card:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .sk-card__head {
-  display: flex; align-items: center; gap: 8px; min-width: 0;
+  display: flex; align-items: flex-start; gap: 8px; min-width: 0;
 }
 .sk-card__dot {
   width: 8px; height: 8px; border-radius: 50%;
@@ -275,22 +281,28 @@
 .sk-card__name {
   font-weight: 600;
   font-size: var(--fs-sm);
+  line-height: 1.25;
   flex: 1;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 .sk-card:hover .sk-card__name { color: var(--accent); }
 .sk-card__desc {
   margin: 0;
+  max-width: 100%;
+  min-width: 0;
   color: var(--text-muted);
   font-size: 12.5px;
   line-height: 1.45;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  min-height: calc(12.5px * 1.45 * 3);
+  line-clamp: 3;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  overflow-wrap: anywhere;
+  mask-image: linear-gradient(180deg, #000 0%, #000 68%, transparent 100%);
 }
 
 .sk-error {
@@ -452,7 +464,7 @@
 }
 .sk-dialog__head-left { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .sk-dialog__emoji { font-size: 1.4em; }
-.sk-dialog__name { font-size: var(--fs-md); font-weight: 700; letter-spacing: -0.01em; }
+.sk-dialog__name { font-size: var(--fs-md); font-weight: 700; letter-spacing: 0; }
 .sk-dialog__chips { display: flex; align-items: center; gap: 6px; }
 .sk-dialog__body {
   padding: var(--sp-4);
@@ -528,6 +540,10 @@
   .sk-stage__actions { width: 100%; }
   .sk-search-input { flex: 1; width: 100%; }
   .sk-search-wrap { flex: 1; }
+  .sk-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--sp-2); }
+  .sk-stat { min-height: 86px; padding: var(--sp-3) var(--sp-3) var(--sp-3) var(--sp-4); }
+  .sk-stat__value { font-size: 1.35rem; }
+  .sk-stat__hint { margin-top: 4px; line-height: 1.2; }
   .sk-registry__head,
   .sk-github-install { flex-direction: column; align-items: stretch; }
   .sk-grid { grid-template-columns: 1fr; }
@@ -583,12 +599,15 @@
 }
 .sk-card__sub-chip {
   padding: 1px 6px;
+  max-width: 100%;
+  min-width: 0;
   border-radius: 3px;
   background: color-mix(in oklab, var(--text) 8%, transparent);
   color: var(--text-dim);
   font-size: 11px;
   font-family: var(--font-mono);
   line-height: 1.5;
+  overflow-wrap: anywhere;
 }
 .sk-card__sub-chip--more {
   background: transparent;

--- a/src/opensquilla/gateway/static/css/views/usage.css
+++ b/src/opensquilla/gateway/static/css/views/usage.css
@@ -43,7 +43,7 @@
 .usage-stage__title {
   font-size: clamp(1.625rem, 1.2rem + 1vw, 2.25rem);
   font-weight: 700;
-  letter-spacing: -0.025em;
+  letter-spacing: 0;
   line-height: 1.05;
   position: relative;
 }
@@ -68,6 +68,7 @@
   align-items: center;
   gap: var(--sp-2);
   flex-wrap: wrap;
+  --mobile-action-button-size: 44px;
 }
 
 /* ─── Currency switch ────────────────────────────────────────────────── */
@@ -81,6 +82,7 @@
   gap: 2px;
 }
 .usage-currency__btn {
+  min-height: 40px;
   padding: 4px 12px;
   font-size: var(--fs-xs);
   font-weight: 600;
@@ -96,7 +98,7 @@
 .usage-currency__btn:hover { color: var(--text); }
 .usage-currency__btn.is-active {
   background: var(--accent);
-  color: #1a0e02;
+  color: var(--accent-foreground);
 }
 .usage-currency__btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
@@ -127,6 +129,7 @@
   gap: 2px;
 }
 .usage-seg, .usage-range__btn {
+  min-height: 40px;
   padding: 4px 14px;
   font-size: var(--fs-xs);
   font-weight: 600;
@@ -141,7 +144,7 @@
 .usage-seg:hover, .usage-range__btn:hover { color: var(--text); }
 .usage-seg.is-active {
   background: var(--accent);
-  color: #1a0e02;
+  color: var(--accent-foreground);
 }
 .usage-range__btn.is-active {
   background: var(--bg-surface);
@@ -280,7 +283,7 @@
 .usage-section-title {
   font-size: var(--fs-lg);
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
 }
 .usage-section-meta {
   font-size: var(--fs-xs);
@@ -326,21 +329,26 @@
 }
 .usage-model-card__id { display: flex; align-items: baseline; gap: 6px; min-width: 0; flex-wrap: wrap; }
 .usage-model-card__provider {
+  max-width: 100%;
+  min-width: 0;
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-dim);
+  overflow-wrap: anywhere;
 }
 .usage-model-card__name {
+  max-width: 100%;
+  min-width: 0;
   font-size: var(--fs-md);
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   font-family: var(--font-mono);
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 100%;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
 }
 .usage-model-card__share {
   flex-shrink: 0;
@@ -411,6 +419,7 @@
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
+  position: relative;
   /* The 8-column session table is wider than the content area at standard
      desktop widths (right-most MODEL column was clipped). Allow horizontal
      scroll while still clipping any vertical overflow at the rounded edge. */
@@ -445,6 +454,10 @@
 }
 .usage-table tbody tr:last-child td { border-bottom: 0; }
 .usage-table tbody tr:hover td { background: var(--bg-elevated); }
+.usage-empty-row .state {
+  width: min(100%, 520px);
+  margin-inline: auto;
+}
 
 .usage-mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 .usage-dim { color: var(--text-muted); }
@@ -738,10 +751,109 @@
 
 /* ─── Responsive ─────────────────────────────────────────────────────── */
 
+@media (max-width: 900px) {
+  .usage-table-wrap::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 28px;
+    pointer-events: none;
+    background:
+      linear-gradient(
+        90deg,
+        transparent,
+        color-mix(in srgb, var(--bg-surface) 88%, transparent)
+      );
+    box-shadow: inset -10px 0 12px -14px rgba(0, 0, 0, 0.55);
+  }
+}
+
 @media (max-width: 720px) {
   .usage-stage__header { flex-direction: column; align-items: stretch; }
-  .usage-stage__actions { width: 100%; }
-  .usage-bar-row { grid-template-columns: 100px 1fr 60px; gap: 8px; }
-  .usage-bar-row__label { font-size: 10.5px; }
-  .usage-table-wrap { overflow-x: auto; }
+  .usage-stage__actions .btn {
+    background: var(--bg-surface);
+    border-color: var(--border);
+  }
+  .usage-bar-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    row-gap: 6px;
+    gap: 8px;
+  }
+  .usage-bar-row__label {
+    grid-column: 1 / -1;
+    max-width: 100%;
+    font-size: 10.5px;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+  }
+  .usage-table-wrap { overflow-x: hidden; }
+  .usage-table-wrap::after { content: none; }
+  .usage-table {
+    display: block;
+    width: 100%;
+  }
+  .usage-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+  .usage-table thead tr,
+  .usage-table thead th {
+    display: block;
+  }
+  .usage-table tbody {
+    display: grid;
+    gap: var(--sp-3);
+    padding: var(--sp-3);
+  }
+  .usage-table tbody tr {
+    display: block;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+    overflow: hidden;
+  }
+  .usage-table tbody td {
+    display: grid;
+    grid-template-columns: minmax(72px, 0.34fr) minmax(0, 1fr);
+    gap: var(--sp-3);
+    align-items: start;
+    padding: 8px var(--sp-3);
+    border-bottom: 1px solid var(--border);
+    overflow-wrap: anywhere;
+  }
+  .usage-table tbody td::before {
+    content: attr(data-label);
+    color: var(--text-dim);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .usage-table tbody td:last-child { border-bottom: 0; }
+  .usage-table tbody tr:hover td { background: transparent; }
+  .usage-empty-row,
+  .usage-expand-cell {
+    display: block !important;
+    padding: var(--sp-3) !important;
+  }
+  .usage-empty-row::before,
+  .usage-expand-cell::before {
+    content: none !important;
+  }
+  .usage-empty-row .state {
+    width: min(100%, calc(100vw - 64px));
+    margin-inline: 0;
+  }
 }

--- a/src/opensquilla/gateway/static/js/app.js
+++ b/src/opensquilla/gateway/static/js/app.js
@@ -44,10 +44,6 @@ const App = (() => {
 
     Router.init(_basePath(), document.getElementById('content'));
 
-    if (window.matchMedia('(max-width: 768px)').matches && Router.currentPath() === '/overview') {
-      Router.navigate('/chat');
-    }
-
     _autoConnect();
   }
 
@@ -55,7 +51,7 @@ const App = (() => {
     const app = document.getElementById('app');
     const basePath = _basePath();
     app.innerHTML = `
-      <nav class="sidebar">
+      <nav class="sidebar" id="sidebar-nav" aria-label="Primary">
         <div class="nav-brand"><img class="brand-mark" src="${basePath}/static/img/opensquilla-mark.png" alt="" aria-hidden="true"> OpenSquilla</div>
         <div class="nav-group-label">Chat</div>
         <a class="nav-item" href="#" data-path="/chat">${icons.chat()} Chat</a>
@@ -76,7 +72,7 @@ const App = (() => {
       <div class="main">
         <header class="topbar">
           <div class="topbar-left">
-            <button class="btn btn--icon btn--ghost sidebar-toggle" id="sidebar-toggle" title="Toggle menu">${icons.menu()}</button>
+            <button class="btn btn--icon btn--ghost sidebar-toggle" id="sidebar-toggle" title="Toggle menu" aria-controls="sidebar-nav" aria-expanded="false">${icons.menu()}</button>
             <span class="conn-pill err" id="conn-pill">Disconnected</span>
           </div>
           <div class="topbar-right">
@@ -105,12 +101,26 @@ const App = (() => {
     const toggle = document.getElementById('sidebar-toggle');
     const sidebar = document.querySelector('.sidebar');
     if (!toggle || !sidebar) return;
+    const mobileQuery = window.matchMedia('(max-width: 768px)');
+
+    const setSidebarOpen = (open) => {
+      sidebar.classList.toggle('open', open);
+      _syncSidebarAccessibility(sidebar, toggle, mobileQuery);
+    };
+
+    _syncSidebarAccessibility(sidebar, toggle, mobileQuery);
+    if (mobileQuery.addEventListener) {
+      mobileQuery.addEventListener('change', () => _syncSidebarAccessibility(sidebar, toggle, mobileQuery));
+    } else if (mobileQuery.addListener) {
+      mobileQuery.addListener(() => _syncSidebarAccessibility(sidebar, toggle, mobileQuery));
+    }
+
     toggle.addEventListener('click', (e) => {
       e.stopPropagation();
-      sidebar.classList.toggle('open');
+      setSidebarOpen(!sidebar.classList.contains('open'));
     });
     sidebar.addEventListener('click', (e) => {
-      if (e.target.closest('.nav-item')) sidebar.classList.remove('open');
+      if (e.target.closest('.nav-item')) setSidebarOpen(false);
     });
     // Click outside the sidebar (and not on the toggle) closes the drawer.
     // The CSS backdrop is a pseudo-element that can't receive pointer events,
@@ -118,14 +128,27 @@ const App = (() => {
     document.addEventListener('click', (e) => {
       if (!sidebar.classList.contains('open')) return;
       if (sidebar.contains(e.target) || toggle.contains(e.target)) return;
-      sidebar.classList.remove('open');
+      setSidebarOpen(false);
     });
     // Esc closes the drawer for keyboard users.
     document.addEventListener('keydown', (e) => {
       if (e.key === 'Escape' && sidebar.classList.contains('open')) {
-        sidebar.classList.remove('open');
+        setSidebarOpen(false);
       }
     });
+  }
+
+  function _syncSidebarAccessibility(sidebar, toggle, mobileQuery) {
+    const isOpen = sidebar.classList.contains('open');
+    const isHiddenDrawer = mobileQuery.matches && !isOpen;
+    toggle.setAttribute('aria-expanded', String(isOpen));
+    if (isHiddenDrawer) {
+      sidebar.setAttribute('aria-hidden', 'true');
+      sidebar.setAttribute('inert', '');
+      return;
+    }
+    sidebar.removeAttribute('aria-hidden');
+    sidebar.removeAttribute('inert');
   }
 
   function _bindConnectionState() {

--- a/src/opensquilla/gateway/static/js/views/chat.js
+++ b/src/opensquilla/gateway/static/js/views/chat.js
@@ -939,7 +939,7 @@ const ChatView = (() => {
           <div class="chat-header-left">
             <label class="chat-label">Chat session</label>
             <button type="button" class="chat-session-chip" id="chat-session-chip"
-                    aria-label="Switch chat session" aria-haspopup="dialog" aria-expanded="false">
+                    aria-label="Switch chat session: ${_esc(_sessionKey)}" aria-haspopup="dialog" aria-expanded="false">
               <span class="chat-session-chip-key" id="chat-session-chip-key" title="${_esc(_sessionKey)}">${_esc(_sessionKey)}</span>
               <span class="chat-session-chip-caret" aria-hidden="true">${_iconChevronDown()}</span>
             </button>
@@ -963,10 +963,6 @@ const ChatView = (() => {
         <div class="chat-slash hidden" id="chat-slash"></div>
         <div class="chat-composer" id="chat-composer">
           <div class="chat-attachments hidden" id="chat-attach-preview"></div>
-          <div class="chat-bypass-warn hidden" id="chat-bypass-warn" role="status" aria-live="polite">
-            <span class="chat-bypass-warn__glyph" aria-hidden="true">!</span>
-            <span class="chat-bypass-warn__text">Approvals bypassed for this session</span>
-          </div>
           <div class="chat-input-bar">
             <button class="btn btn--icon btn--ghost" id="chat-btn-attach" title="Attach files: PNG, JPEG, GIF, WEBP, PDF, TXT, MD, HTML, CSV, JSON">${icons.paperclip()}</button>
             <div class="chat-toolbar-wrap">
@@ -974,7 +970,7 @@ const ChatView = (() => {
                       title="Run modes — approvals, router"
                       aria-label="Run modes"
                       aria-haspopup="dialog"
-                      aria-expanded="false">${_iconGear()}<span class="chat-toolbar-trigger-dots" aria-hidden="true"><i data-dot="bypass"></i><i data-dot="router"></i></span></button>
+                      aria-expanded="false">${_iconGear()}<span class="chat-toolbar-trigger-label" id="chat-toolbar-trigger-label"></span><span class="chat-toolbar-trigger-dots" aria-hidden="true"><i data-dot="bypass"></i><i data-dot="router"></i></span></button>
               <div class="chat-toolbar-popover hidden" id="chat-toolbar-popover" role="dialog" aria-label="Composer settings">
                 <div class="chat-toolbar-popover-arrow" aria-hidden="true"></div>
                 <div class="chat-toolbar-popover-inner" id="chat-toolbar">
@@ -1047,11 +1043,20 @@ const ChatView = (() => {
     _loadFeatureToggles();
     _loadSlashCommands();
 
-    // Autofocus chat input
-    if (_textarea) _textarea.focus();
+    // Keep desktop keyboard flow quick, but avoid opening the soft keyboard on
+    // mobile/touch devices before the user asks to type.
+    if (_textarea && _shouldAutofocusComposer()) _textarea.focus();
   }
 
   /* ── Toolbar Pills (feature toggles) ────────────────────────────────── */
+
+  function _shouldAutofocusComposer() {
+    try {
+      if (window.matchMedia('(max-width: 768px)').matches) return false;
+      if (window.matchMedia('(pointer: coarse)').matches) return false;
+    } catch {}
+    return true;
+  }
 
   function _bindToolbarPills() {
     if (_elevatedPill) {
@@ -1128,11 +1133,13 @@ const ChatView = (() => {
   function _updateSessionChip(key) {
     _sessionKey = key;
     const chipKey = _el && _el.querySelector('#chat-session-chip-key');
+    const chip = _el && _el.querySelector('#chat-session-chip');
     const copyBtn = _el && _el.querySelector('#chat-session-copy');
     if (chipKey) {
       chipKey.textContent = key;
       chipKey.title = key;
     }
+    if (chip) chip.setAttribute('aria-label', 'Switch chat session: ' + key);
     if (copyBtn) copyBtn.title = 'Copy session key: ' + key;
   }
 
@@ -1573,25 +1580,31 @@ const ChatView = (() => {
   function _refreshToolbarTriggerGlow() {
     const trigger = _el && _el.querySelector('#chat-toolbar-trigger');
     if (!trigger) return;
+    const triggerLabel = trigger.querySelector('#chat-toolbar-trigger-label');
     trigger.classList.toggle('is-glowing', _toolbarTriggerActive());
     // Per-toggle status dots — each lights independently so a glance at the
     // composer reveals which mode is non-default, not just that something is.
-    const bypass = !!_toolbarState.bypass;
+    const effectiveMode = _effectiveElevatedMode();
+    const bypass = _isApprovalBypassMode(effectiveMode);
     const routerOff = _toolbarState.router === false;
     trigger.classList.toggle('has-dot-bypass', bypass);
     trigger.classList.toggle('has-dot-router', routerOff);
-    // Bypass warning chip — only "Approvals bypassed" rises to a visible chip.
-    // Router-off is non-default but not safety-critical.
-    const warn = _el && _el.querySelector('#chat-bypass-warn');
-    if (warn) {
-      const text = warn.querySelector('.chat-bypass-warn__text');
-      if (text) {
-        text.textContent = _elevatedMode
-          ? 'Approvals bypassed for this session'
-          : 'Approvals bypassed by global default';
-      }
-      warn.classList.toggle('hidden', !bypass);
+    trigger.classList.toggle('has-bypass-signal', bypass);
+    const bypassLabel = effectiveMode === 'full' ? 'FULL' : 'BYPASS';
+    if (triggerLabel) {
+      triggerLabel.textContent = '';
+      if (bypass) triggerLabel.textContent = bypassLabel;
     }
+    const signalParts = [];
+    if (effectiveMode === 'full') {
+      signalParts.push(`${bypassLabel}: Full permission mode active`);
+    } else if (bypass) {
+      signalParts.push(`${bypassLabel}: Approvals bypassed`);
+    }
+    if (routerOff) signalParts.push('router off');
+    const statusLabel = signalParts.length ? `Run modes: ${signalParts.join(', ')}` : 'Run modes';
+    trigger.setAttribute('aria-label', statusLabel);
+    trigger.title = statusLabel;
   }
 
   function _bindToolbarTrigger() {

--- a/src/opensquilla/gateway/static/js/views/config.js
+++ b/src/opensquilla/gateway/static/js/views/config.js
@@ -118,14 +118,14 @@ const ConfigView = (() => {
             <h2 class="cfg-stage__title">Config</h2>
             <p class="cfg-stage__subtitle">Advanced gateway configuration. Use guided setup for provider, router, channels, and extras.</p>
           </div>
-          <div class="cfg-stage__actions">
-            <div class="cfg-mode-toggle" role="group" aria-label="Editor mode">
+          <div class="cfg-stage__actions mobile-action-strip">
+            <div class="cfg-mode-toggle mobile-action-strip__item" role="group" aria-label="Editor mode">
               <button class="cfg-mode-btn ${_mode === 'form' ? 'is-active' : ''}" type="button" data-cfg-mode="form">Form</button>
               <button class="cfg-mode-btn ${_mode === 'yaml' ? 'is-active' : ''}" type="button" data-cfg-mode="yaml">YAML</button>
             </div>
-            <button class="cfg-btn cfg-btn--ghost" id="cfg-guided-setup" type="button" title="Open guided setup">${icons.config()}<span>Guided setup</span></button>
-            <button class="cfg-btn cfg-btn--ghost" id="cfg-reload" type="button" title="Reload config">${icons.refresh()}<span>Reload</span></button>
-            <button class="cfg-btn cfg-btn--ghost" id="cfg-save" type="button" title="Save config">${icons.check()}<span>Save</span></button>
+            <button class="cfg-btn cfg-btn--ghost mobile-action-strip__button" id="cfg-guided-setup" type="button" title="Open guided setup">${icons.config()}<span class="mobile-action-strip__label">Guided setup</span></button>
+            <button class="cfg-btn cfg-btn--ghost mobile-action-strip__button" id="cfg-reload" type="button" title="Reload config">${icons.refresh()}<span class="mobile-action-strip__label">Reload</span></button>
+            <button class="cfg-btn cfg-btn--ghost mobile-action-strip__button" id="cfg-save" type="button" title="Save config">${icons.check()}<span class="mobile-action-strip__label">Save</span></button>
           </div>
         </header>
 

--- a/src/opensquilla/gateway/static/js/views/health.js
+++ b/src/opensquilla/gateway/static/js/views/health.js
@@ -159,8 +159,13 @@ const HealthView = (() => {
     }
     if (report.agentId) items.push(['Agent', report.agentId]);
     if (!items.length) return '';
+    const contextItems = items.map(([label, value]) => `
+        <span class="health-report-context__item">
+          <b>${_esc(label)}</b>
+          <span class="health-report-context__value">${_esc(value)}</span>
+        </span>`).join('');
     return `<div class="health-report-context" aria-label="Health report context">
-      ${items.map(([label, value]) => `<span><b>${_esc(label)}</b>${_esc(value)}</span>`).join('')}
+      ${contextItems}
     </div>`;
   }
 

--- a/src/opensquilla/gateway/static/js/views/overview.js
+++ b/src/opensquilla/gateway/static/js/views/overview.js
@@ -6,6 +6,7 @@ const OverviewView = (() => {
   let _unsubs = [];
   let _intervals = [];
   let _eventLog = [];
+  let _viewGeneration = 0;
 
   function _ensureCss() {
     if (document.querySelector('link[data-view-css="overview"]')) return;
@@ -20,6 +21,7 @@ const OverviewView = (() => {
   }
 
   function render(el) {
+    _viewGeneration += 1;
     _el = el;
     _rpc = App.getRpc();
     _ensureCss();
@@ -66,7 +68,7 @@ const OverviewView = (() => {
           <button class="ov-stat" data-nav="/health" type="button" id="ov-health">
             <div class="ov-stat__icon">${icons.logs()}</div>
             <div class="ov-stat__label">Health</div>
-            <div class="ov-stat__value ov-stat__value--mono" id="ov-health-status">${UI.skeleton('90px', '1.4rem')}</div>
+            <div class="ov-stat__value ov-stat__value--status" id="ov-health-status">${UI.skeleton('90px', '1.4rem')}</div>
             <div class="ov-stat__hint" id="ov-health-summary">doctor.status</div>
           </button>
           <div class="ov-stat ov-stat--static">
@@ -177,6 +179,7 @@ const OverviewView = (() => {
   }
 
   function destroy() {
+    _viewGeneration += 1;
     _unsubs.forEach(fn => fn());
     _unsubs = [];
     _intervals.forEach(id => clearInterval(id));
@@ -207,20 +210,27 @@ const OverviewView = (() => {
   }
 
   async function _loadData() {
-    if (!_el) return;
-    await _rpc.waitForConnection();
+    const root = _el;
+    const generation = _viewGeneration;
+    if (!root) return;
+    const rpc = _rpc;
+    if (!rpc) return;
+    await rpc.waitForConnection();
+    if (!_isCurrentView(root, rpc, generation)) return;
 
     const set = (id, val) => {
-      const el = _el && _el.querySelector('#' + id);
+      if (!_isCurrentView(root, rpc, generation)) return;
+      const el = root.querySelector('#' + id);
       if (el) el.innerHTML = val != null ? String(val) : '—';
     };
     const setText = (id, val) => {
-      const el = _el && _el.querySelector('#' + id);
+      if (!_isCurrentView(root, rpc, generation)) return;
+      const el = root.querySelector('#' + id);
       if (el) el.textContent = val != null ? String(val) : '—';
     };
 
-    _rpc.call('status').then(data => {
-      if (!_el) return;
+    rpc.call('status').then(data => {
+      if (!_isCurrentView(root, rpc, generation)) return;
       const ms = data.uptime_ms;
       if (ms != null) {
         const s = Math.floor(ms / 1000);
@@ -232,24 +242,27 @@ const OverviewView = (() => {
       }
       setText('ov-version-line', data.version ? `v${data.version}` : '—');
       set('ov-provider', _esc(data.provider ?? '—'));
-    }).catch(err => UI.toast('Failed to load status: ' + err.message, 'err'));
+    }).catch(err => {
+      if (!_isCurrentView(root, rpc, generation)) return;
+      UI.toast('Failed to load status: ' + err.message, 'err');
+    });
 
-    _rpc.call('doctor.status', { agentId: 'main', deep: false }).then(report => {
-      if (!_el) return;
-      set('ov-health-status', _esc(report.status ?? 'unknown'));
+    rpc.call('doctor.status', { agentId: 'main', deep: false }).then(report => {
+      if (!_isCurrentView(root, rpc, generation)) return;
+      set('ov-health-status', _esc(_readinessStatusLabel(report.status ?? 'unknown')));
       setText('ov-health-summary', report.summary ?? 'view details');
     }).catch(() => {
-      if (!_el) return;
+      if (!_isCurrentView(root, rpc, generation)) return;
       set('ov-health-status', 'unavailable');
       setText('ov-health-summary', 'open health');
     });
 
-    _rpc.call('usage.status').then(data => {
-      if (!_el) return;
+    rpc.call('usage.status').then(data => {
+      if (!_isCurrentView(root, rpc, generation)) return;
       const cur = localStorage.getItem('opensquilla-currency') || 'USD';
       set('ov-sessions', data.totalSessions ?? '—');
       set('ov-tokens', data.totalTokens != null ? data.totalTokens.toLocaleString() : '—');
-      const costLine = _el.querySelector('#ov-cost-line');
+      const costLine = root.querySelector('#ov-cost-line');
       if (costLine) {
         if (data.totalCostUsd != null) {
           // CNY rate sourced from SquillaConstants — kept in sync across
@@ -265,8 +278,8 @@ const OverviewView = (() => {
       }
     }).catch(() => {});
 
-    _rpc.call('sessions.list', { limit: 5 }).then(data => {
-      if (!_el) return;
+    rpc.call('sessions.list', { limit: 5 }).then(data => {
+      if (!_isCurrentView(root, rpc, generation)) return;
       const sessions = (data.sessions || [])
         .slice()
         .sort((a, b) => {
@@ -275,7 +288,7 @@ const OverviewView = (() => {
           return tb - ta;
         })
         .slice(0, 6);
-      const container = _el.querySelector('#ov-recent-sessions');
+      const container = root.querySelector('#ov-recent-sessions');
       if (!container) return;
       if (sessions.length === 0) {
         container.innerHTML = `<div class="ov-recent__empty">
@@ -304,6 +317,10 @@ const OverviewView = (() => {
         b.addEventListener('click', () => Router.navigate('/chat?session=' + encodeURIComponent(b.dataset.key)));
       });
     }).catch(() => {});
+  }
+
+  function _isCurrentView(root, rpc, generation) {
+    return _el === root && _rpc === rpc && _viewGeneration === generation;
   }
 
   function _pushEvent(eventName, payload) {
@@ -339,6 +356,21 @@ const OverviewView = (() => {
         <span class="ov-event-log__name">${_esc(e.eventName)}</span>
         <span class="ov-event-log__payload">${_esc(e.payloadStr)}</span>
       </div>`).join('');
+  }
+
+  function _readinessStatusLabel(status) {
+    const labels = {
+      ready: 'Ready',
+      degraded: 'Degraded',
+      action_required: 'Action required',
+      unavailable: 'Unavailable',
+      unknown: 'Unknown',
+    };
+    const key = String(status || 'unknown').toLowerCase();
+    if (labels[key]) return labels[key];
+    return key
+      .replace(/[_-]+/g, ' ')
+      .replace(/\b\w/g, c => c.toUpperCase());
   }
 
   function _esc(s) {

--- a/src/opensquilla/gateway/static/js/views/skills.js
+++ b/src/opensquilla/gateway/static/js/views/skills.js
@@ -718,9 +718,7 @@ const SkillsView = (() => {
 
     const dotTitle = skill.status_detail || (skill.eligible ? 'Ready' : 'Needs setup');
     const emoji = skill.emoji ? `<span class="sk-card__emoji">${_esc(skill.emoji)}</span>` : '';
-    const desc = skill.description
-      ? (skill.description.length > 100 ? skill.description.slice(0, 100) + '…' : skill.description)
-      : '';
+    const desc = skill.description || '';
     // Meta-skill card adds a "uses:" chip strip showing the sub-skills its
     // composition references. Limit to 6 visible chips + "+N" overflow so
     // the card height stays bounded for large DAGs.
@@ -744,14 +742,14 @@ const SkillsView = (() => {
     const kindBadge = isMeta
       ? `<span class="sk-card__kind-badge" title="${_esc(skill.kind)}">${skill.kind === 'meta_sop' ? 'SOP' : 'META'}</span>`
       : '';
-    return `<button type="button" class="sk-card${isMeta ? ' sk-card--meta' : ''}" data-skill-card="${_esc(skill.name)}">
+    return `<button type="button" class="sk-card${isMeta ? ' sk-card--meta' : ''}" data-skill-card="${_esc(skill.name)}" title="${_esc(skill.name + (desc ? ': ' + desc : ''))}">
       <div class="sk-card__head">
         <span class="sk-card__dot ${dotCls}" title="${_esc(dotTitle)}"></span>
         ${emoji}
-        <span class="sk-card__name">${_esc(skill.name)}</span>
+        <span class="sk-card__name" title="${_esc(skill.name)}">${_esc(skill.name)}</span>
         ${kindBadge}
       </div>
-      <p class="sk-card__desc">${_esc(desc)}</p>
+      <p class="sk-card__desc" title="${_esc(desc)}">${_esc(desc)}</p>
       ${subSkillsHtml}
     </button>`;
   }
@@ -853,7 +851,7 @@ const SkillsView = (() => {
         <button type="button" class="sk-iconbtn" id="skill-dialog-close" aria-label="Close">${icons.x()}</button>
       </header>
       <section class="sk-dialog__body">
-        <p class="sk-dialog__desc">${_esc(_truncDesc(skill.description))}</p>
+        <p class="sk-dialog__desc">${_esc(skill.description || '')}</p>
         ${triggersHtml}
         ${compositionHtml}
         ${missingHtml}
@@ -974,13 +972,6 @@ const SkillsView = (() => {
 
   function _esc(s) {
     return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-  }
-
-  function _truncDesc(s, n = 220) {
-    if (!s) return '';
-    const firstSent = s.split(/(?<=\.)\s+(?=[A-Z])/)[0] || s;
-    const base = firstSent.length <= n ? firstSent : firstSent.slice(0, n).replace(/\s+\S*$/, '') + '…';
-    return base;
   }
 
   function _layerLabel(layer) {

--- a/src/opensquilla/gateway/static/js/views/usage.js
+++ b/src/opensquilla/gateway/static/js/views/usage.js
@@ -44,16 +44,16 @@ const UsageView = (() => {
                  burying it in the chart legend — it applies to the whole view's filtered set. -->
             <small class="usage-range-notice" id="usage-range-hint" aria-live="polite"></small>
           </div>
-          <div class="usage-stage__actions">
-            <div class="usage-currency" role="group" aria-label="Currency">
+          <div class="usage-stage__actions mobile-action-strip">
+            <div class="usage-currency mobile-action-strip__item" role="group" aria-label="Currency">
               <button class="usage-currency__btn" data-cur="USD" title="US Dollar">$ USD</button>
               <button class="usage-currency__btn" data-cur="CNY" title="Chinese Yuan">¥ CNY</button>
             </div>
-            <button class="btn btn--ghost" id="usage-export" title="Download CSV">
-              ${icons.download()}<span>Export</span>
+            <button class="btn btn--ghost mobile-action-strip__button" id="usage-export" title="Download CSV">
+              ${icons.download()}<span class="mobile-action-strip__label">Export</span>
             </button>
-            <button class="btn btn--ghost" id="usage-refresh" title="Refresh">
-              ${icons.refresh()}<span>Refresh</span>
+            <button class="btn btn--ghost mobile-action-strip__button" id="usage-refresh" title="Refresh">
+              ${icons.refresh()}<span class="mobile-action-strip__label">Refresh</span>
             </button>
           </div>
         </header>
@@ -512,15 +512,15 @@ const UsageView = (() => {
         const timestamp = _sessionTimestamp(row);
         const modified = timestamp != null ? UI.relTime(timestamp) : '—';
         html += `<tr>
-          <td>${sessionLink}</td>
-          <td class="usage-mono usage-dim">${_esc(modified)}</td>
-          <td class="usage-mono">${_rowVal(row, 'input_tokens', 'inputTokens') != null ? Number(_rowVal(row, 'input_tokens', 'inputTokens')).toLocaleString() : '—'}</td>
-          <td class="usage-mono">${_rowVal(row, 'output_tokens', 'outputTokens') != null ? Number(_rowVal(row, 'output_tokens', 'outputTokens')).toLocaleString() : '—'}</td>
-          <td class="usage-mono usage-dim">${_rowVal(row, 'cache_read_tokens', 'cacheReadTokens') != null ? Number(_rowVal(row, 'cache_read_tokens', 'cacheReadTokens')).toLocaleString() : '—'}</td>
-          <td class="usage-mono usage-dim">${_rowVal(row, 'cache_write_tokens', 'cacheWriteTokens') != null ? Number(_rowVal(row, 'cache_write_tokens', 'cacheWriteTokens')).toLocaleString() : '—'}</td>
-          <td class="usage-mono usage-cost">${_fmtCost(cost)}</td>
-          <td>${_renderCostSourceBadge(row)}</td>
-          <td>${_renderModelCell(row)}</td>
+          <td data-label="Session">${sessionLink}</td>
+          <td data-label="Modified" class="usage-mono usage-dim">${_esc(modified)}</td>
+          <td data-label="Input" class="usage-mono">${_rowVal(row, 'input_tokens', 'inputTokens') != null ? Number(_rowVal(row, 'input_tokens', 'inputTokens')).toLocaleString() : '—'}</td>
+          <td data-label="Output" class="usage-mono">${_rowVal(row, 'output_tokens', 'outputTokens') != null ? Number(_rowVal(row, 'output_tokens', 'outputTokens')).toLocaleString() : '—'}</td>
+          <td data-label="Cache R" class="usage-mono usage-dim">${_rowVal(row, 'cache_read_tokens', 'cacheReadTokens') != null ? Number(_rowVal(row, 'cache_read_tokens', 'cacheReadTokens')).toLocaleString() : '—'}</td>
+          <td data-label="Cache W" class="usage-mono usage-dim">${_rowVal(row, 'cache_write_tokens', 'cacheWriteTokens') != null ? Number(_rowVal(row, 'cache_write_tokens', 'cacheWriteTokens')).toLocaleString() : '—'}</td>
+          <td data-label="Cost" class="usage-mono usage-cost">${_fmtCost(cost)}</td>
+          <td data-label="Source">${_renderCostSourceBadge(row)}</td>
+          <td data-label="Model">${_renderModelCell(row)}</td>
         </tr>`;
       });
     }
@@ -777,6 +777,7 @@ const UsageView = (() => {
         const expandTr = document.createElement('tr');
         expandTr.className = 'usage-expand-row';
         const td = document.createElement('td');
+        td.className = 'usage-expand-cell';
         td.colSpan = USAGE_SESSION_TABLE_COLUMNS.length;
         td.appendChild(_buildExpandedContent(row));
         expandTr.appendChild(td);

--- a/tests/test_gateway/test_agents_view_static.py
+++ b/tests/test_gateway/test_agents_view_static.py
@@ -8,6 +8,7 @@ SESSIONS_JS = Path("src/opensquilla/gateway/static/js/views/sessions.js")
 SESSIONS_CSS = Path("src/opensquilla/gateway/static/css/views/sessions.css")
 COMPONENTS_JS = Path("src/opensquilla/gateway/static/js/components.js")
 COMPONENTS_CSS = Path("src/opensquilla/gateway/static/css/components.css")
+MOBILE_CSS = Path("src/opensquilla/gateway/static/css/mobile.css")
 
 
 def test_agents_view_keeps_inline_create_form_and_drawer_for_view_edit() -> None:
@@ -53,6 +54,78 @@ def test_agents_view_css_has_inline_form_and_drawer_styles() -> None:
     # Dead "live preview" rules were pruned.
     assert ".ag-drawer__preview" not in css
     assert ".ag-drawer__layout" not in css
+
+
+def test_agents_inline_actions_keep_touch_friendly_hit_areas() -> None:
+    css = AGENTS_CSS.read_text(encoding="utf-8")
+    rule = css[css.index(".ag-iconbtn {") : css.index("}", css.index(".ag-iconbtn {"))]
+    input_start = css.index(".ag-input:not(textarea) {")
+    input_rule = css[input_start : css.index("}", input_start)]
+
+    assert "min-height: 40px" in rule
+    assert "height: 40px" in input_rule
+
+
+def test_agents_card_header_stacks_actions_on_narrow_mobile() -> None:
+    css = AGENTS_CSS.read_text(encoding="utf-8")
+    mobile = css.split("@media (max-width: 420px)", 1)[1]
+    head_rule = mobile.split(".ag-card__head", 1)[1].split("}", 1)[0]
+    id_rule = mobile.split(".ag-card__id-block", 1)[1].split("}", 1)[0]
+    actions_rule = mobile.split(".ag-card__actions {", 1)[1].split("}", 1)[0]
+    action_button_rule = mobile.split(".ag-card__actions .ag-iconbtn", 1)[1].split(
+        "}", 1
+    )[0]
+
+    assert "flex-direction: column" in head_rule
+    assert "align-items: stretch" in head_rule
+    assert "flex-wrap: wrap" in id_rule
+    assert "width: 100%" in id_rule
+    assert "justify-content: stretch" in actions_rule
+    assert "flex: 1 1 96px" in action_button_rule
+    assert "justify-content: center" in action_button_rule
+
+
+def test_agents_card_variable_copy_wraps_inside_mobile_cards() -> None:
+    css = AGENTS_CSS.read_text(encoding="utf-8")
+
+    for selector in (".ag-card__id {", ".ag-card__name {", ".ag-card__desc {"):
+        rule = css[css.index(selector) : css.index("}", css.index(selector))]
+
+        assert "max-width: 100%" in rule, selector
+        assert "min-width: 0" in rule, selector
+        assert "overflow-wrap: anywhere" in rule, selector
+
+
+def test_agents_card_metadata_wraps_long_runtime_values() -> None:
+    css = AGENTS_CSS.read_text(encoding="utf-8")
+    rule = css[
+        css.index(".ag-card__meta dd {") : css.index(
+            "}", css.index(".ag-card__meta dd {")
+        )
+    ]
+
+    assert "max-width: 100%" in rule
+    assert "min-width: 0" in rule
+    assert "white-space: normal" in rule
+    assert "overflow-wrap: anywhere" in rule
+    assert "text-overflow: clip" in rule
+
+
+def test_global_buttons_keep_stable_hit_area() -> None:
+    css = COMPONENTS_CSS.read_text(encoding="utf-8")
+    btn_rule = css[css.index(".btn {") : css.index("}", css.index(".btn {"))]
+    sm_rule = css[css.index(".btn--sm {") : css.index("}", css.index(".btn--sm {"))]
+    icon_rule = css[css.index(".btn--icon {") : css.index("}", css.index(".btn--icon {"))]
+    mobile_css = MOBILE_CSS.read_text(encoding="utf-8")
+    mobile_sm_rule = mobile_css[
+        mobile_css.index(".btn--sm {") : mobile_css.index("}", mobile_css.index(".btn--sm {"))
+    ]
+
+    assert "min-height: 40px" in btn_rule
+    assert "min-height: 40px" in sm_rule
+    assert "min-width: 40px" in icon_rule
+    assert "min-height: 40px" in icon_rule
+    assert "min-height: 40px" in mobile_sm_rule
 
 
 def test_sessions_view_uses_combobox_and_admin_agent_create_rpc() -> None:

--- a/tests/test_gateway/test_approvals_view_static.py
+++ b/tests/test_gateway/test_approvals_view_static.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+APPROVALS_CSS = Path("src/opensquilla/gateway/static/css/views/approvals.css")
+APPROVALS_JS = Path("src/opensquilla/gateway/static/js/views/approvals.js")
+
+
+def test_approvals_radio_indicator_keeps_visible_keyboard_focus() -> None:
+    css = APPROVALS_CSS.read_text(encoding="utf-8")
+    indicator_start = css.index(".ap-radio__indicator {")
+    indicator_rule = css[indicator_start : css.index("}", indicator_start)]
+    focus_start = css.index(".ap-radio input:focus-visible + .ap-radio__indicator {")
+    focus_rule = css[focus_start : css.index("}", focus_start)]
+
+    assert "transition: border-color var(--transition), box-shadow var(--transition)" in (
+        indicator_rule
+    )
+    assert "border-color: var(--accent)" in focus_rule
+    assert "box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent)" in (
+        focus_rule
+    )
+
+
+def test_approvals_radio_markup_keeps_indicator_after_input() -> None:
+    js = APPROVALS_JS.read_text(encoding="utf-8")
+    input_start = js.index('<input type="radio" name="ap-mode"')
+    indicator_start = js.index('<span class="ap-radio__indicator"></span>')
+    between_input_and_indicator = js[js.index("/>", input_start) + 2 : indicator_start]
+
+    assert input_start < indicator_start
+    assert between_input_and_indicator.strip() == ""
+
+
+def test_approvals_active_radio_label_uses_accessible_accent_text() -> None:
+    css = APPROVALS_CSS.read_text(encoding="utf-8")
+    start = css.index(".ap-radio.is-active .ap-radio__label {")
+    rule = css[start : css.index("}", start)]
+
+    assert "color: var(--accent-hover)" in rule
+
+
+def test_approval_card_metadata_wraps_long_runtime_identifiers() -> None:
+    css = APPROVALS_CSS.read_text(encoding="utf-8")
+
+    assert ".ap-card__meta span {" in css
+    meta_start = css.index(".ap-card__meta {")
+    meta_rule = css[meta_start : css.index("}", meta_start)]
+    meta_item_start = css.index(".ap-card__meta span {")
+    meta_item_rule = css[meta_item_start : css.index("}", meta_item_start)]
+    code_start = css.index(".ap-card__meta code {")
+    code_rule = css[code_start : css.index("}", code_start)]
+
+    assert "min-width: 0" in meta_rule
+    assert "overflow-wrap: anywhere" in meta_rule
+    assert "max-width: 100%" in meta_item_rule
+    assert "min-width: 0" in meta_item_rule
+    assert "overflow-wrap: anywhere" in meta_item_rule
+    assert "white-space: normal" in code_rule
+    assert "overflow-wrap: anywhere" in code_rule

--- a/tests/test_gateway/test_channels_view_static.py
+++ b/tests/test_gateway/test_channels_view_static.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+CHANNELS_CSS = Path("src/opensquilla/gateway/static/css/views/channels.css")
+
+
+def test_channels_config_summary_keeps_touch_friendly_hit_area() -> None:
+    css = CHANNELS_CSS.read_text(encoding="utf-8")
+    rule = css[
+        css.index(".ch-card__config summary {") : css.index(
+            "}", css.index(".ch-card__config summary {")
+        )
+    ]
+
+    assert "min-height: 38px" in rule
+
+
+def test_channels_header_eyebrow_uses_shared_clean_label_style() -> None:
+    css = CHANNELS_CSS.read_text(encoding="utf-8")
+    rule = css[
+        css.index(".ch-stage__eyebrow {") : css.index(
+            "}", css.index(".ch-stage__eyebrow {")
+        )
+    ]
+
+    assert ".ch-stage__eyebrow::before" not in css
+    assert "font-size: 11px" in rule
+    assert "font-weight: 700" in rule
+    assert "letter-spacing: 0.16em" in rule
+    assert "color: var(--text-dim)" in rule
+    assert "color: var(--accent)" not in rule
+
+
+def test_channels_card_metadata_wraps_long_runtime_values() -> None:
+    css = CHANNELS_CSS.read_text(encoding="utf-8")
+    meta_rule = css[
+        css.index(".ch-card__meta {") : css.index(
+            "}", css.index(".ch-card__meta {")
+        )
+    ]
+    rule = css[
+        css.index(".ch-card__meta dd {") : css.index(
+            "}", css.index(".ch-card__meta dd {")
+        )
+    ]
+
+    assert "repeat(auto-fit, minmax(140px, 1fr))" in meta_rule
+    assert "max-width: 100%" in rule
+    assert "min-width: 0" in rule
+    assert "white-space: normal" in rule
+    assert "overflow-wrap: anywhere" in rule
+    assert "text-overflow: clip" in rule
+
+
+def test_channels_mobile_header_bracket_stays_compact() -> None:
+    css = CHANNELS_CSS.read_text(encoding="utf-8")
+    mobile_css = css[css.index("@media (max-width: 720px)") :]
+
+    assert ".ch-stage__title-block::before" in mobile_css
+    assert "bottom: auto" in mobile_css
+    assert "height: 16px" in mobile_css
+
+
+def test_channels_mobile_card_header_keeps_names_readable() -> None:
+    css = CHANNELS_CSS.read_text(encoding="utf-8")
+    mobile_css = css[css.index("@media (max-width: 720px)") :]
+    head_rule = mobile_css[
+        mobile_css.index(".ch-card__head {") : mobile_css.index(
+            "}", mobile_css.index(".ch-card__head {")
+        )
+    ]
+    name_rule = mobile_css[
+        mobile_css.index(".ch-card__name {") : mobile_css.index(
+            "}", mobile_css.index(".ch-card__name {")
+        )
+    ]
+    chip_rule = mobile_css[
+        mobile_css.index(".ch-card__head .chip {") : mobile_css.index(
+            "}", mobile_css.index(".ch-card__head .chip {")
+        )
+    ]
+
+    assert "flex-wrap: wrap" in head_rule
+    assert "align-items: flex-start" in head_rule
+    assert "flex: 1 1 180px" in name_rule
+    assert "max-width: 100%" in name_rule
+    assert "white-space: normal" in name_rule
+    assert "overflow-wrap: anywhere" in name_rule
+    assert "text-overflow: clip" in name_rule
+    assert "max-width: 100%" in chip_rule
+    assert "white-space: normal" in chip_rule
+    assert "overflow-wrap: anywhere" in chip_rule

--- a/tests/test_gateway/test_chat_static_assets.py
+++ b/tests/test_gateway/test_chat_static_assets.py
@@ -76,11 +76,19 @@ def test_chat_permission_pill_distinguishes_global_and_session_modes() -> None:
     assert "cfg?.permissions?.default_mode" in source
     assert "Global ${_globalElevatedMode.toUpperCase()}" in source
     assert "Session ${_elevatedMode.toUpperCase()}" in source
-    assert "Approvals bypassed by global default" in source
     assert "opensquilla sandbox on|bypass|full|reset" in source
 
     # The legacy image-only `accept="image/*" multiple` literal must be gone:
     assert 'accept="image/*" multiple' not in source
+
+
+def test_chat_does_not_render_persistent_bypass_warning_chip() -> None:
+    chat_source = _read_chat_js()
+    chat_css = _read_chat_css()
+
+    assert "chat-bypass-warn" not in chat_source
+    assert "chat-bypass-warn" not in chat_css
+    assert "Approvals bypassed by global default" not in chat_source
 
 
 def test_webui_bypass_shortcuts_do_not_enable_full_mode() -> None:
@@ -106,6 +114,63 @@ def test_app_uses_dynamic_viewport_height_after_100vh_fallback_for_mobile_compos
     assert "height: 100vh;" in css
     assert "height: 100dvh;" in css
     assert css.index("height: 100vh;") < css.index("height: 100dvh;")
+
+
+def test_app_preserves_explicit_mobile_routes_instead_of_forcing_chat() -> None:
+    app = _read_app_js()
+    router = Path("src/opensquilla/gateway/static/js/router.js").read_text(encoding="utf-8")
+
+    assert "Router.currentPath() === '/overview'" not in app
+    assert "Router.navigate('/chat');" not in app
+    assert "window.matchMedia('(max-width: 768px)').matches ? '/chat' : '/overview'" in router
+
+
+def test_chat_composer_autofocus_is_desktop_only() -> None:
+    source = _read_chat_js()
+
+    assert "function _shouldAutofocusComposer()" in source
+    assert "window.matchMedia('(max-width: 768px)')" in source
+    assert "window.matchMedia('(pointer: coarse)')" in source
+    assert "if (_textarea && _shouldAutofocusComposer()) _textarea.focus();" in source
+    assert "// Autofocus chat input\n    if (_textarea) _textarea.focus();" not in source
+
+
+def test_mobile_sidebar_closed_state_leaves_focus_order() -> None:
+    app = _read_app_js()
+
+    assert 'id="sidebar-nav"' in app
+    assert 'aria-controls="sidebar-nav"' in app
+    assert "_syncSidebarAccessibility(sidebar, toggle, mobileQuery)" in app
+    assert "window.matchMedia('(max-width: 768px)')" in app
+    assert "sidebar.setAttribute('aria-hidden', 'true')" in app
+    assert "sidebar.setAttribute('inert', '')" in app
+    assert "sidebar.removeAttribute('aria-hidden')" in app
+    assert "sidebar.removeAttribute('inert')" in app
+    assert "toggle.setAttribute('aria-expanded', String(isOpen));" in app
+
+
+def test_desktop_sidebar_nav_items_keep_polished_hit_areas() -> None:
+    css = _read_base_css()
+
+    nav_start = css.index(".nav-item {")
+    nav_rule = css[nav_start : css.index("}", nav_start)]
+
+    assert "min-height: 40px" in nav_rule
+
+
+def test_short_desktop_sidebar_keeps_primary_nav_visible() -> None:
+    css = _read_base_css()
+
+    assert "@media (min-width: 769px) and (max-height: 640px)" in css
+    compact_start = css.index("@media (min-width: 769px) and (max-height: 640px)")
+    compact_rule = css[compact_start:]
+
+    assert ".nav-brand {" in compact_rule
+    assert "min-height: 44px" in compact_rule
+    assert ".nav-group-label {" in compact_rule
+    assert "padding: 5px var(--sp-4) 2px" in compact_rule
+    assert ".nav-group-label:first-of-type" in compact_rule
+    assert "margin-top: 4px" in compact_rule
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -22,6 +22,38 @@ def test_chat_toolbar_has_no_tool_compress_selector() -> None:
     assert "tool-compress" not in source
 
 
+def test_chat_run_modes_keep_bypass_visible_and_accessible() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+    css = CHAT_CSS.read_text(encoding="utf-8")
+
+    assert 'id="chat-toolbar-trigger-label"' in source
+    assert "triggerLabel.textContent = bypassLabel;" in source
+    assert "has-bypass-signal" in source
+    assert "`${bypassLabel}: Approvals bypassed`" in source
+    assert "`${bypassLabel}: Full permission mode active`" in source
+    assert ".chat-toolbar-trigger.has-bypass-signal" in css
+    assert ".chat-toolbar-trigger-label" in css
+
+
+def test_chat_session_chip_accessible_name_includes_visible_key() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+
+    assert 'aria-label="Switch chat session: ${_esc(_sessionKey)}"' in source
+    assert "chip.setAttribute('aria-label', 'Switch chat session: ' + key)" in source
+
+
+def test_chat_mobile_run_modes_keep_error_toasts_visible() -> None:
+    css = CHAT_CSS.read_text(encoding="utf-8")
+    mobile_start = css.index("@media (max-width: 480px)")
+    mobile_block = css[mobile_start : css.index("@media (max-width: 360px)", mobile_start)]
+
+    assert "body:has(.chat-toolbar-popover.is-open) .toast-stack {" in mobile_block
+    assert "body:has(.chat-toolbar-popover.is-open) .toast:not(.err)" in mobile_block
+    assert "body:has(.chat-toolbar-popover.is-open) .toast.err" in mobile_block
+    hidden_stack_rule = "body:has(.chat-toolbar-popover.is-open) .toast-stack {\n    opacity: 0;"
+    assert hidden_stack_rule not in mobile_block
+
+
 def test_chat_tool_display_map_does_not_reference_removed_wrapper_tools() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
     start = source.index("const _TOOL_EMOJI = {")
@@ -207,6 +239,125 @@ def test_chat_url_agent_query_resolves_default_webchat_session() -> None:
     assert "const urlAgent = _readAgentFromUrl();" in source
     assert "urlSession || (urlAgent ? _webchatSessionKey(urlAgent) : storedSession)" in source
     assert "url.searchParams.delete('agent');" in source
+
+
+def test_chat_mobile_session_controls_keep_touch_targets() -> None:
+    css = CHAT_CSS.read_text(encoding="utf-8")
+    mobile_start = css.index("@media (max-width: 480px)")
+    mobile_block = css[mobile_start : css.index("@media (max-width: 360px)", mobile_start)]
+    label_start = mobile_block.index(".chat-label {")
+    label_rule = mobile_block[label_start : mobile_block.index("}", label_start)]
+    popover_start = mobile_block.index(".chat-session-popover {")
+    popover_rule = mobile_block[popover_start : mobile_block.index("}", popover_start)]
+    chip_start = mobile_block.index(".chat-session-chip {")
+    chip_rule = mobile_block[chip_start : mobile_block.index("}", chip_start)]
+    copy_start = mobile_block.index(".chat-session-copy-btn {")
+    copy_rule = mobile_block[copy_start : mobile_block.index("}", copy_start)]
+
+    assert ".chat-session-chip" in mobile_block
+    assert "display: none" in label_rule
+    assert "left: 12px !important" in popover_rule
+    assert "right: 12px" in popover_rule
+    assert "width: auto" in popover_rule
+    assert "min-height: 40px" in chip_rule
+    assert ".chat-session-copy-btn" in mobile_block
+    assert "width: 40px" in copy_rule
+    assert "height: 40px" in copy_rule
+
+
+def test_chat_tiny_phone_header_gives_session_key_full_row() -> None:
+    css = CHAT_CSS.read_text(encoding="utf-8")
+    tiny_start = css.index("@media (max-width: 360px)")
+    tiny_block = css[tiny_start : css.index(".chat-pill {", tiny_start)]
+    header_start = tiny_block.index(".chat-header {")
+    header_rule = tiny_block[header_start : tiny_block.index("}", header_start)]
+    left_start = tiny_block.index(".chat-header-left {")
+    left_rule = tiny_block[left_start : tiny_block.index("}", left_start)]
+    chip_start = tiny_block.index(".chat-session-chip {")
+    chip_rule = tiny_block[chip_start : tiny_block.index("}", chip_start)]
+
+    assert "flex-wrap: wrap" in header_rule
+    assert "align-items: flex-start" in header_rule
+    assert "flex: 1 1 100%" in left_rule
+    assert "gap: var(--sp-1)" in chip_rule
+    assert "padding-inline: 4px" in chip_rule
+
+
+def test_chat_mobile_composer_gives_message_input_a_full_row() -> None:
+    css = CHAT_CSS.read_text(encoding="utf-8")
+    base_wrap_start = css.index(".chat-input-wrap {")
+    mobile_start = css.index("@media (max-width: 480px)", base_wrap_start)
+    mobile_block = css[mobile_start : css.index("/* Stop button pulse animation", mobile_start)]
+    input_start = mobile_block.index(".chat-input-bar {")
+    input_rule = mobile_block[input_start : mobile_block.index("}", input_start)]
+    wrap_start = mobile_block.index(".chat-input-wrap {")
+    wrap_rule = mobile_block[wrap_start : mobile_block.index("}", wrap_start)]
+    send_start = mobile_block.index("#chat-btn-send,")
+    send_rule = mobile_block[send_start : mobile_block.index("}", send_start)]
+
+    assert "#chat-btn-new { display: none" not in css
+    assert mobile_start > base_wrap_start
+    assert "flex-wrap: wrap" in input_rule
+    assert "row-gap: 6px" in input_rule
+    assert "flex: 1 1 calc(100% - 44px)" in wrap_rule
+    assert "order: 2" in send_rule
+
+
+def test_chat_desktop_session_controls_keep_polished_hit_areas() -> None:
+    css = CHAT_CSS.read_text(encoding="utf-8")
+    chip_start = css.index(".chat-session-chip {")
+    copy_start = css.index(".chat-session-copy-btn {")
+    chip_rule = css[chip_start : css.index("}", chip_start)]
+    copy_rule = css[copy_start : css.index("}", copy_start)]
+
+    assert "min-height: 40px" in chip_rule
+    assert "width: 40px" in copy_rule
+    assert "height: 40px" in copy_rule
+    assert "border: 1px solid var(--border)" in copy_rule
+
+
+def test_chat_run_status_chip_aligns_with_header_controls() -> None:
+    css = CHAT_CSS.read_text(encoding="utf-8")
+    status_start = css.index("#chat-run-status {")
+    status_rule = css[status_start : css.index("}", status_start)]
+
+    assert "display: inline-flex" in status_rule
+    assert "align-items: center" in status_rule
+    assert "min-height: 28px" in status_rule
+    assert "padding-inline: 10px" in status_rule
+    assert "line-height: 1" in status_rule
+    assert "white-space: nowrap" in status_rule
+    assert "flex-shrink: 0" in status_rule
+
+
+def test_chat_run_mode_pills_keep_touch_friendly_hit_areas() -> None:
+    css = CHAT_CSS.read_text(encoding="utf-8")
+    pill_start = css.index(".chat-pill {")
+    pill_rule = css[pill_start : css.index("}", pill_start)]
+
+    assert "display: inline-flex" in pill_rule
+    assert "align-items: center" in pill_rule
+    assert "justify-content: center" in pill_rule
+    assert "min-height: 40px" in pill_rule
+
+
+def test_chat_router_toggle_keeps_touch_friendly_hit_area() -> None:
+    css = CHAT_CSS.read_text(encoding="utf-8")
+    wrap_start = css.index(".toggle-switch-wrap {")
+    switch_start = css.index(".toggle-switch {")
+    thumb_start = css.index(".toggle-thumb {")
+    checked_start = css.index(".toggle-switch input:checked + .toggle-track .toggle-thumb {")
+    wrap_rule = css[wrap_start : css.index("}", wrap_start)]
+    switch_rule = css[switch_start : css.index("}", switch_start)]
+    thumb_rule = css[thumb_start : css.index("}", thumb_start)]
+    checked_rule = css[checked_start : css.index("}", checked_start)]
+
+    assert "min-height: 40px" in wrap_rule
+    assert "width: 40px" in switch_rule
+    assert "height: 22px" in switch_rule
+    assert "width: 18px" in thumb_rule
+    assert "height: 18px" in thumb_rule
+    assert "transform: translateX(18px)" in checked_rule
 
 
 def test_chat_new_session_uses_current_agent_namespace() -> None:

--- a/tests/test_gateway/test_config_view_static.py
+++ b/tests/test_gateway/test_config_view_static.py
@@ -1,0 +1,236 @@
+import re
+from pathlib import Path
+
+BASE_CSS = Path("src/opensquilla/gateway/static/css/base.css")
+COMPONENTS_CSS = Path("src/opensquilla/gateway/static/css/components.css")
+CONFIG_JS = Path("src/opensquilla/gateway/static/js/views/config.js")
+CONFIG_CSS = Path("src/opensquilla/gateway/static/css/views/config.css")
+
+
+def _relative_luminance(hex_color: str) -> float:
+    channels = [int(hex_color[index : index + 2], 16) / 255 for index in (1, 3, 5)]
+    linear = [
+        channel / 12.92
+        if channel <= 0.03928
+        else ((channel + 0.055) / 1.055) ** 2.4
+        for channel in channels
+    ]
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+
+def _contrast_ratio(foreground: str, background: str) -> float:
+    lighter, darker = sorted(
+        (_relative_luminance(foreground), _relative_luminance(background)),
+        reverse=True,
+    )
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _light_theme_token(name: str) -> str:
+    css = BASE_CSS.read_text(encoding="utf-8")
+    light_start = css.index('[data-theme="light"] {')
+    light_rule = css[light_start : css.index("}", light_start)]
+    match = re.search(rf"--{name}:\s*(#[0-9A-Fa-f]{{6}});", light_rule)
+    assert match is not None
+    return match.group(1)
+
+
+def test_config_mode_toggle_keeps_touch_friendly_hit_area() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+    rule = css[css.index(".cfg-mode-btn {") : css.index("}", css.index(".cfg-mode-btn {"))]
+
+    assert "min-height: 40px" in rule
+
+
+def test_config_header_actions_keep_touch_friendly_hit_area() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+    rule = css[css.index(".cfg-btn {") : css.index("}", css.index(".cfg-btn {"))]
+
+    assert "min-height: 40px" in rule
+
+
+def test_config_primary_buttons_use_theme_contrast_token() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+    rule = css[
+        css.index(".cfg-btn--primary {") : css.index(
+            "}",
+            css.index(".cfg-btn--primary {"),
+        )
+    ]
+
+    assert "color: var(--accent-foreground)" in rule
+
+
+def test_config_header_actions_stay_single_row_scrollable_on_mobile() -> None:
+    components = COMPONENTS_CSS.read_text(encoding="utf-8")
+    source = CONFIG_JS.read_text(encoding="utf-8")
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+
+    assert ".mobile-action-strip {" in components
+    assert ".mobile-action-strip.mobile-action-strip { flex-wrap: nowrap; }" in components
+    assert "overflow-x: auto" in components
+    assert "scrollbar-width: none" in components
+    assert "-webkit-overflow-scrolling: touch" in components
+    assert ".mobile-action-strip__button {" in components
+    assert "width: var(--mobile-action-button-size, 40px)" in components
+    assert ".mobile-action-strip__label {" in components
+    assert "clip: rect(0 0 0 0)" in components
+
+    assert 'cfg-stage__actions mobile-action-strip' in source
+    assert 'cfg-mode-toggle mobile-action-strip__item' in source
+    assert 'mobile-action-strip__button' in source
+    assert 'mobile-action-strip__label' in source
+    assert ".cfg-stage__actions .cfg-btn span" not in css
+
+
+def test_config_help_buttons_keep_touch_friendly_hit_area() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+    rule = css[css.index(".cfg-help-btn {") : css.index("}", css.index(".cfg-help-btn {"))]
+
+    assert "min-width: 40px" in rule
+    assert "min-height: 40px" in rule
+    assert "width: 40px" in rule
+    assert "height: 40px" in rule
+
+
+def test_config_search_input_keeps_touch_friendly_hit_area() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+    rule = css[css.index(".cfg-search-input {") : css.index("}", css.index(".cfg-search-input {"))]
+
+    assert "min-height: 40px" in rule
+
+
+def test_config_scalar_inputs_keep_touch_friendly_hit_area() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+    text_rule = css[css.index(".cfg-input-text {") : css.index("}", css.index(".cfg-input-text {"))]
+    number_rule = css[
+        css.index(".cfg-input-number {") : css.index("}", css.index(".cfg-input-number {"))
+    ]
+
+    assert "min-height: 40px" in text_rule
+    assert "min-height: 40px" in number_rule
+
+
+def test_config_switches_keep_touch_friendly_hit_area() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+    switch_rule = css[css.index(".cfg-switch {") : css.index("}", css.index(".cfg-switch {"))]
+    track_rule = css[
+        css.index(".cfg-switch-track {") : css.index("}", css.index(".cfg-switch-track {"))
+    ]
+    thumb_rule = css[
+        css.index(".cfg-switch-thumb {") : css.index("}", css.index(".cfg-switch-thumb {"))
+    ]
+    checked_rule = css[
+        css.index(".cfg-switch input:checked + .cfg-switch-track .cfg-switch-thumb {") : css.index(
+            "}",
+            css.index(".cfg-switch input:checked + .cfg-switch-track .cfg-switch-thumb {"),
+        )
+    ]
+
+    assert "min-height: 40px" in switch_rule
+    assert "width: 40px" in track_rule
+    assert "height: 22px" in track_rule
+    assert "width: 18px" in thumb_rule
+    assert "height: 18px" in thumb_rule
+    assert "transform: translateX(18px)" in checked_rule
+
+
+def test_config_tabs_keep_touch_friendly_hit_area() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+    rule = css[css.index(".cfg-tab {") : css.index("}", css.index(".cfg-tab {"))]
+
+    assert "min-height: 40px" in rule
+
+
+def test_config_active_controls_use_accessible_light_theme_contrast() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+    mode_rule = css[
+        css.index(".cfg-mode-btn.is-active {") : css.index(
+            "}",
+            css.index(".cfg-mode-btn.is-active {"),
+        )
+    ]
+    tab_rule = css[
+        css.index(".cfg-tab.is-active {") : css.index(
+            "}",
+            css.index(".cfg-tab.is-active {"),
+        )
+    ]
+    action_rule = css[
+        css.index(".cfg-object-action {") : css.index(
+            "}",
+            css.index(".cfg-object-action {"),
+        )
+    ]
+
+    assert "color: var(--accent-foreground)" in mode_rule
+    assert "color: var(--accent-hover)" in tab_rule
+    assert "color: var(--accent-hover)" in action_rule
+    assert (
+        _contrast_ratio(_light_theme_token("accent-foreground"), _light_theme_token("accent"))
+        >= 4.5
+    )
+    assert (
+        _contrast_ratio(_light_theme_token("accent-hover"), _light_theme_token("bg-surface"))
+        >= 4.5
+    )
+
+
+def test_config_toolbar_stacks_tabs_and_search_on_tablet_widths() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+    tablet = css.split("@media (max-width: 900px)", 1)[1]
+    toolbar_rule = tablet.split(".cfg-toolbar {", 1)[1].split("}", 1)[0]
+    search_rule = tablet.split(".cfg-search-wrap {", 1)[1].split("}", 1)[0]
+
+    assert "align-items: stretch" in toolbar_rule
+    assert "flex-direction: column" in toolbar_rule
+    assert "flex-basis: auto" in search_rule
+    assert "width: 100%" in search_rule
+    assert "min-width: 0" in search_rule
+
+
+def test_config_tabs_stay_single_row_scrollable_on_mobile() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+    mobile = css.split("@media (max-width: 760px)", 1)[1]
+    tabs_rule = mobile.split(".cfg-tabs {", 1)[1].split("}", 1)[0]
+    tab_rule = mobile.split(".cfg-tab {", 1)[1].split("}", 1)[0]
+
+    assert "flex-wrap: nowrap" in tabs_rule
+    assert "mask-image: linear-gradient(" in tabs_rule
+    assert "transparent" in tabs_rule
+    assert "#000 14px" in tabs_rule
+    assert "#000 calc(100% - 44px)" in tabs_rule
+    assert "overflow-x: auto" in tabs_rule
+    assert "overflow-y: hidden" in tabs_rule
+    assert "padding-inline: var(--sp-2) var(--sp-8)" in tabs_rule
+    assert "scroll-snap-type: x proximity" in tabs_rule
+    assert "scroll-padding-inline: var(--sp-2)" in tabs_rule
+    assert "-webkit-mask-image: linear-gradient(" in tabs_rule
+    assert "-webkit-overflow-scrolling: touch" in tabs_rule
+    assert "flex: 0 0 auto" in tab_rule
+    assert "min-height: 40px" in tab_rule
+    assert "scroll-snap-align: start" in tab_rule
+
+
+def test_config_object_summaries_wrap_on_phone_widths() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+    mobile = css.split("@media (max-width: 640px)", 1)[1]
+    summary_rule = mobile.split(".cfg-object-summary {", 1)[1].split("}", 1)[0]
+
+    assert "white-space: normal" in summary_rule
+    assert "overflow-wrap: anywhere" in summary_rule
+    assert "text-overflow: clip" in summary_rule
+
+
+def test_config_field_labels_wrap_long_keys_on_phone_widths() -> None:
+    css = CONFIG_CSS.read_text(encoding="utf-8")
+    mobile = css.split("@media (max-width: 640px)", 1)[1]
+    label_rule = mobile.split(
+        ".config-field > .form-label,\n  .config-field__label-row > .form-label {",
+        1,
+    )[1].split("}", 1)[0]
+
+    assert "max-width: 100%" in label_rule
+    assert "overflow-wrap: anywhere" in label_rule
+    assert "text-overflow: clip" in label_rule
+    assert "white-space: normal" in label_rule

--- a/tests/test_gateway/test_cron_view_static.py
+++ b/tests/test_gateway/test_cron_view_static.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 CRON_JS = Path("src/opensquilla/gateway/static/js/views/cron.js")
+CRON_CSS = Path("src/opensquilla/gateway/static/css/views/cron.css")
 
 
 def test_new_cron_jobs_default_to_static_reminders() -> None:
@@ -105,3 +106,126 @@ def test_cron_finished_event_refreshes_after_scheduler_state_persists() -> None:
 
     assert "_scheduleCronReload()" in source
     assert "setTimeout(_loadData, 750)" in source
+
+
+def test_cron_view_toggle_keeps_touch_friendly_hit_area() -> None:
+    css = CRON_CSS.read_text(encoding="utf-8")
+    start = css.index(".cron-view-toggle__btn {")
+    rule = css[start : css.index("}", start)]
+
+    assert "min-height: 40px" in rule
+
+
+def test_cron_active_view_toggle_uses_theme_contrast_token() -> None:
+    css = CRON_CSS.read_text(encoding="utf-8")
+    start = css.index(".cron-view-toggle__btn.is-active {")
+    rule = css[start : css.index("}", start)]
+
+    assert "color: var(--accent-foreground)" in rule
+
+
+def test_cron_search_keeps_touch_friendly_hit_area() -> None:
+    css = CRON_CSS.read_text(encoding="utf-8")
+    start = css.index(".cron-search-input {")
+    rule = css[start : css.index("}", start)]
+
+    assert "min-height: 40px" in rule
+
+
+def test_cron_cards_wrap_long_names_and_runtime_metadata() -> None:
+    css = CRON_CSS.read_text(encoding="utf-8")
+    name_start = css.index(".cron-card__name {")
+    name_rule = css[name_start : css.index("}", name_start)]
+    meta_start = css.index(".cron-card__meta {")
+    meta_rule = css[meta_start : css.index("}", meta_start)]
+    value_start = css.index(".cron-card__meta dd {")
+    value_rule = css[value_start : css.index("}", value_start)]
+
+    assert "white-space: normal" in name_rule
+    assert "overflow-wrap: anywhere" in name_rule
+    assert "text-overflow: clip" in name_rule
+    assert "repeat(auto-fit, minmax(140px, 1fr))" in meta_rule
+    assert "max-width: 100%" in value_rule
+    assert "min-width: 0" in value_rule
+    assert "white-space: normal" in value_rule
+    assert "overflow-wrap: anywhere" in value_rule
+    assert "text-overflow: clip" in value_rule
+
+
+def test_cron_mobile_actions_keep_search_usable() -> None:
+    css = CRON_CSS.read_text(encoding="utf-8")
+    mobile_start = css.index("@media (max-width: 480px)")
+    mobile_rule = css[mobile_start:]
+
+    assert ".cron-stage__actions" in mobile_rule
+    assert "display: grid" in mobile_rule
+    assert "grid-template-columns: repeat(2, minmax(0, 1fr))" in mobile_rule
+    assert ".cron-search-wrap" in mobile_rule
+    assert "grid-column: 1 / -1" in mobile_rule
+    assert ".cron-stage__actions .btn" in mobile_rule
+    assert "width: 100%" in mobile_rule
+    assert "justify-content: center" in mobile_rule
+
+
+def test_cron_empty_hints_keep_mobile_touch_targets() -> None:
+    css = CRON_CSS.read_text(encoding="utf-8")
+    mobile_start = css.index("@media (max-width: 480px)")
+    mobile_rule = css[mobile_start:]
+    code_start = css.index(".cron-empty-hint code {")
+    code_rule = css[code_start : css.index("}", code_start)]
+    assert ".cron-empty-hint {" in mobile_rule
+    hint_rule = mobile_rule[
+        mobile_rule.index(".cron-empty-hint {") : mobile_rule.index(
+            "}", mobile_rule.index(".cron-empty-hint {")
+        )
+    ]
+
+    assert "min-height: 40px" in hint_rule
+    assert "padding: 9px 14px" in hint_rule
+    assert "white-space: nowrap" in code_rule
+
+
+def test_cron_empty_hints_keep_desktop_hit_area() -> None:
+    css = CRON_CSS.read_text(encoding="utf-8")
+    start = css.index(".cron-empty-hint {")
+    rule = css[start : css.index("}", start)]
+
+    assert "min-height: 40px" in rule
+
+
+def test_cron_empty_hints_wrap_long_labels_inside_mobile_viewport() -> None:
+    css = CRON_CSS.read_text(encoding="utf-8")
+    hints_start = css.index(".cron-empty__hints {")
+    hints_rule = css[hints_start : css.index("}", hints_start)]
+    hint_start = css.index(".cron-empty-hint {")
+    hint_rule = css[hint_start : css.index("}", hint_start)]
+    assert ".cron-empty-hint span {" in css
+    label_start = css.index(".cron-empty-hint span {")
+    label_rule = css[label_start : css.index("}", label_start)]
+
+    assert "width: 100%" in hints_rule
+    assert "max-width: 720px" in hints_rule
+    assert "box-sizing: border-box" in hints_rule
+    assert "max-width: 100%" in hint_rule
+    assert "min-width: 0" in hint_rule
+    assert "flex-wrap: wrap" in hint_rule
+    assert "min-width: 0" in label_rule
+    assert "overflow-wrap: anywhere" in label_rule
+
+
+def test_cron_panel_actions_stay_reachable_on_mobile() -> None:
+    css = CRON_CSS.read_text(encoding="utf-8")
+
+    actions_start = css.index(".cron-panel__actions {")
+    actions_rule = css[actions_start : css.index("}", actions_start)]
+    assert "position: sticky" in actions_rule
+    assert "bottom: calc(-1 * var(--sp-5))" in actions_rule
+    assert "border-top: 1px solid var(--border)" in actions_rule
+
+    mobile_start = css.index("@media (max-width: 480px)")
+    mobile_rule = css[mobile_start:]
+    assert ".cron-panel" in mobile_rule
+    assert "width: 100vw" in mobile_rule
+    assert "max-width: 100vw" in mobile_rule
+    assert ".cron-panel__actions .btn" in mobile_rule
+    assert "flex: 1 1 0" in mobile_rule

--- a/tests/test_gateway/test_health_view_static.py
+++ b/tests/test_gateway/test_health_view_static.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 APP_JS = Path("src/opensquilla/gateway/static/js/app.js")
 OVERVIEW_JS = Path("src/opensquilla/gateway/static/js/views/overview.js")
+OVERVIEW_CSS = Path("src/opensquilla/gateway/static/css/views/overview.css")
 HEALTH_JS = Path("src/opensquilla/gateway/static/js/views/health.js")
 HEALTH_CSS = Path("src/opensquilla/gateway/static/css/views/health.css")
 INDEX_HTML = Path("src/opensquilla/gateway/templates/index.html")
@@ -36,12 +37,51 @@ def test_overview_surfaces_readiness_summary() -> None:
     assert 'data-nav="/health"' in source
 
 
+def test_overview_humanizes_readiness_status() -> None:
+    source = OVERVIEW_JS.read_text(encoding="utf-8")
+    css = OVERVIEW_CSS.read_text(encoding="utf-8")
+    health_tile_start = source.index('id="ov-health-status"')
+    health_tile = source[health_tile_start - 120 : health_tile_start + 180]
+
+    assert "function _readinessStatusLabel(status)" in source
+    assert "action_required: 'Action required'" in source
+    assert "_readinessStatusLabel(report.status ?? 'unknown')" in source
+    assert "ov-stat__value--mono" not in health_tile
+    assert "ov-stat__value--status" in health_tile
+    value_rule = css.split(".ov-stat__value {", 1)[1].split("}", 1)[0]
+    mono_rule = css.split(".ov-stat__value--mono", 1)[1].split("}", 1)[0]
+    status_rule = css.split(".ov-stat__value--status", 1)[1].split("}", 1)[0]
+    assert "line-height: 1.18" in value_rule
+    assert "line-height: 1.3" in mono_rule
+    assert "line-height: 1.2" in status_rule
+    assert "white-space: nowrap" in status_rule
+
+
 def test_health_css_defines_responsive_finding_rows() -> None:
     css = HEALTH_CSS.read_text(encoding="utf-8")
 
     assert ".health-layout" in css
     assert ".health-finding" in css
     assert "@media (max-width: 760px)" in css
+
+
+def test_health_mobile_refresh_button_keeps_visible_width() -> None:
+    css = HEALTH_CSS.read_text(encoding="utf-8")
+    mobile = css.split("@media (max-width: 760px)", 1)[1]
+    refresh_rule = mobile.split(".health-stage__header .btn", 1)[1].split("}", 1)[0]
+
+    assert "align-self: flex-start" in refresh_rule
+    assert "width: auto" in refresh_rule
+    assert "width: 100%" not in refresh_rule
+
+
+def test_health_status_numerals_have_breathing_room() -> None:
+    css = HEALTH_CSS.read_text(encoding="utf-8")
+    score_rule = css.split(".health-score strong {", 1)[1].split("}", 1)[0]
+    count_rule = css.split(".health-count strong {", 1)[1].split("}", 1)[0]
+
+    assert "line-height: 1.12" in score_rule
+    assert "line-height: 1.12" in count_rule
 
 
 def test_health_view_uses_status_visual_system() -> None:
@@ -160,15 +200,50 @@ def test_health_view_surfaces_report_context_for_config_and_agent() -> None:
     assert "Requested config" in source
     assert "report.agentId" in source
     assert "health-report-context" in source
+    assert "health-report-context__item" in source
+    assert "health-report-context__value" in source
     assert ".health-report-context" in css
 
 
 def test_health_report_context_wraps_long_paths_on_mobile() -> None:
     css = HEALTH_CSS.read_text(encoding="utf-8")
+    source = HEALTH_JS.read_text(encoding="utf-8")
 
-    context_span = css.split(".health-report-context span", 1)[1].split("}", 1)[0]
-    assert "min-width: 0" in context_span
-    assert "word-break: break-word" in context_span
+    assert "class=\"health-report-context__item\"" in source
+    assert "class=\"health-report-context__value\"" in source
+    context_item = css.split(".health-report-context__item", 1)[1].split("}", 1)[0]
+    context_value = css.split(".health-report-context__value", 1)[1].split("}", 1)[0]
+    mobile_context = css.split("@media (max-width: 480px)", 1)[1]
+    mobile_context_item = mobile_context.split(".health-report-context__item", 1)[1].split(
+        "}", 1
+    )[0]
+
+    assert "display: inline-grid" in context_item
+    assert "grid-template-columns: auto minmax(0, 1fr)" in context_item
+    assert "min-width: 0" in context_value
+    assert "overflow-wrap: anywhere" in context_value
+    assert "word-break: break-word" in context_value
+    assert "grid-template-columns: minmax(0, 1fr)" in mobile_context_item
+    assert "width: 100%" in mobile_context_item
+
+
+def test_health_runtime_diagnostics_wrap_inside_cards() -> None:
+    css = HEALTH_CSS.read_text(encoding="utf-8")
+
+    wrapping_selectors = (
+        ".health-score__summary",
+        ".health-finding__meta",
+        ".health-finding__title",
+        ".health-finding__detail",
+        ".health-evidence",
+        ".health-evidence span",
+        ".health-step__command",
+    )
+
+    for selector in wrapping_selectors:
+        rule = css.split(f"{selector} {{", 1)[1].split("}", 1)[0]
+        assert "min-width: 0" in rule
+        assert "overflow-wrap: anywhere" in rule
 
 
 def test_health_view_scopes_local_fallback_commands_to_bootstrap_config() -> None:
@@ -259,3 +334,19 @@ def test_health_view_makes_recovery_commands_copyable() -> None:
     assert "Copied command" in source
     assert "health-step__copy" in source
     assert ".health-step__copy" in css
+    copy_start = css.index(".health-step__copy {")
+    copy_rule = css[copy_start : css.index("}", copy_start)]
+    assert "height: 40px" in copy_rule
+    assert "width: 40px" in copy_rule
+
+    mobile_start = css.index("@media (max-width: 480px)")
+    mobile_css = css[mobile_start:]
+    command_start = mobile_css.index(".health-step__command {")
+    command_rule = mobile_css[command_start : mobile_css.index("}", command_start)]
+    command_code_start = mobile_css.index(".health-step__command code {")
+    command_code_rule = mobile_css[
+        command_code_start : mobile_css.index("}", command_code_start)
+    ]
+    assert "width: 100%" in command_rule
+    assert "flex: 1 1 auto" in command_code_rule
+    assert "min-width: 0" in command_code_rule

--- a/tests/test_gateway/test_logs_view_static.py
+++ b/tests/test_gateway/test_logs_view_static.py
@@ -33,7 +33,7 @@ def test_config_view_explains_debug_file_logging_fields() -> None:
     assert "'log_file_backup_count'" in source
 
 
-def test_logs_mobile_toolbar_wraps_controls() -> None:
+def test_logs_mobile_toolbar_keeps_level_filters_compact() -> None:
     css = LOGS_CSS.read_text(encoding="utf-8")
 
     levels_start = css.index(".lg-levels__row {")
@@ -44,29 +44,113 @@ def test_logs_mobile_toolbar_wraps_controls() -> None:
     level_button_rule = css[
         level_button_start : css.index("}", level_button_start)
     ]
-    assert "min-height: 32px" in level_button_rule
+    assert "min-height: 40px" in level_button_rule
 
     mobile_start = css.index("@media (max-width: 720px)")
     mobile_block = css[mobile_start:]
+    mobile_levels_wrap_start = mobile_block.index(".lg-levels {")
+    mobile_levels_wrap_rule = mobile_block[
+        mobile_levels_wrap_start : mobile_block.index("}", mobile_levels_wrap_start)
+    ]
+    mobile_levels_start = mobile_block.index(".lg-levels__row {")
+    mobile_levels_rule = mobile_block[
+        mobile_levels_start : mobile_block.index("}", mobile_levels_start)
+    ]
+    mobile_button_start = mobile_block.index(".lg-level-btn {")
+    mobile_button_rule = mobile_block[
+        mobile_button_start : mobile_block.index("}", mobile_button_start)
+    ]
+
+    assert "width: 100%" in mobile_levels_wrap_rule
+    assert "flex-direction: column" in mobile_levels_wrap_rule
+    assert "align-items: stretch" in mobile_levels_wrap_rule
+    assert "gap: 6px" in mobile_levels_wrap_rule
+    assert "width: 100%" in mobile_levels_rule
+    assert "flex-wrap: wrap" in mobile_levels_rule
+    assert "min-width: 0" in mobile_levels_rule
+    assert "overflow: visible" in mobile_levels_rule
+    assert "overflow-x: auto" not in mobile_levels_rule
+    assert "mask-image: linear-gradient" not in mobile_levels_rule
+    assert "padding-inline-end" not in mobile_levels_rule
+    assert "flex: 0 0 auto" in mobile_button_rule
     assert ".lg-search-wrap" in mobile_block
     assert "width: 100%" in mobile_block
     assert "min-width: 0" in mobile_block
+    assert ".lg-toggle { width: 100%; min-height: 40px; }" in mobile_block
 
 
-def test_config_mobile_tabs_wrap_instead_of_clipping() -> None:
+def test_logs_auto_follow_toggle_keeps_touch_friendly_hit_area() -> None:
+    css = LOGS_CSS.read_text(encoding="utf-8")
+
+    toggle_rule = css[css.index(".lg-toggle {") : css.index("}", css.index(".lg-toggle {"))]
+    track_start = css.index(".lg-toggle__track {")
+    track_rule = css[track_start : css.index("}", track_start)]
+    thumb_start = css.index(".lg-toggle__thumb {")
+    thumb_rule = css[thumb_start : css.index("}", thumb_start)]
+
+    assert "min-height: 40px" in toggle_rule
+    assert "width: 40px; height: 22px" in track_rule
+    assert "width: 18px; height: 18px" in thumb_rule
+    assert "input:focus-visible + .lg-toggle__track" in css
+
+
+def test_logs_search_keeps_touch_friendly_hit_area() -> None:
+    css = LOGS_CSS.read_text(encoding="utf-8")
+    start = css.index(".lg-search-input {")
+    rule = css[start : css.index("}", start)]
+
+    assert "min-height: 40px" in rule
+
+
+def test_logs_header_actions_keep_touch_friendly_hit_area() -> None:
+    css = LOGS_CSS.read_text(encoding="utf-8")
+    start = css.index(".lg-stage__actions .btn {")
+    rule = css[start : css.index("}", start)]
+
+    assert "min-height: 40px" in rule
+
+
+def test_logs_lines_wrap_at_words_before_breaking_long_tokens() -> None:
+    css = LOGS_CSS.read_text(encoding="utf-8")
+
+    line_start = css.index(".lg-line {")
+    line_rule = css[line_start : css.index("}", line_start)]
+    msg_start = css.index(".lg-line__msg {")
+    msg_rule = css[msg_start : css.index("}", msg_start)]
+
+    assert "white-space: pre-wrap" in line_rule
+    assert "min-width: 0" in line_rule
+    assert "word-break: break-all" not in line_rule
+    assert "min-width: 0" in msg_rule
+    assert "word-break: normal" in msg_rule
+    assert "overflow-wrap: break-word" in msg_rule
+
+    mobile_start = css.index("@media (max-width: 720px)")
+    mobile_block = css[mobile_start:]
+    mobile_msg_start = mobile_block.index(".lg-line__msg {")
+    mobile_msg_rule = mobile_block[
+        mobile_msg_start : mobile_block.index("}", mobile_msg_start)
+    ]
+    assert "grid-column: 1 / -1" in mobile_msg_rule
+
+
+def test_config_mobile_tabs_scroll_instead_of_wrapping() -> None:
     css = CONFIG_CSS.read_text(encoding="utf-8")
 
     mobile_start = css.index("@media (max-width: 760px)")
     mobile_block = css[mobile_start:]
     assert ".cfg-tabs" in mobile_block
-    assert "flex-wrap: wrap" in mobile_block
-    assert "overflow-x: visible" in mobile_block
+    assert "flex-wrap: nowrap" in mobile_block
+    assert "overflow-x: auto" in mobile_block
+    assert "overflow-y: hidden" in mobile_block
+    assert "scroll-snap-type: x proximity" in mobile_block
     assert ".cfg-tab" in mobile_block
-    assert "min-height: 36px" in mobile_block
+    assert "flex: 0 0 auto" in mobile_block
+    assert "min-height: 40px" in mobile_block
 
     help_rule = css[css.index(".cfg-help-btn {") : css.index("}", css.index(".cfg-help-btn {"))]
-    assert "min-width: 32px" in help_rule
-    assert "min-height: 32px" in help_rule
+    assert "min-width: 40px" in help_rule
+    assert "min-height: 40px" in help_rule
 
 
 def test_example_config_lists_debug_file_logging_controls() -> None:

--- a/tests/test_gateway/test_sessions_view_static.py
+++ b/tests/test_gateway/test_sessions_view_static.py
@@ -1,6 +1,59 @@
 from pathlib import Path
 
 SESSIONS_JS = Path("src/opensquilla/gateway/static/js/views/sessions.js")
+SESSIONS_CSS = Path("src/opensquilla/gateway/static/css/views/sessions.css")
+
+
+def test_sessions_page_size_select_keeps_touch_friendly_hit_area() -> None:
+    css = SESSIONS_CSS.read_text(encoding="utf-8")
+    start = css.index(".sess-page-size select {")
+    rule = css[start : css.index("}", start)]
+
+    assert "min-height: 40px" in rule
+
+
+def test_sessions_search_keeps_touch_friendly_hit_area() -> None:
+    css = SESSIONS_CSS.read_text(encoding="utf-8")
+    start = css.index(".sess-search-input {")
+    rule = css[start : css.index("}", start)]
+
+    assert "min-height: 40px" in rule
+
+
+def test_sessions_mobile_header_keeps_search_readable() -> None:
+    css = SESSIONS_CSS.read_text(encoding="utf-8")
+    mobile_start = css.index("@media (max-width: 480px)")
+    mobile_block = css[mobile_start:]
+
+    assert ".sess-search-wrap" in mobile_block
+    assert "flex: 1 1 100%" in mobile_block
+    assert ".sess-stage__actions > .btn" in mobile_block
+    assert "flex: 1 1 0" in mobile_block
+    assert "justify-content: center" in mobile_block
+
+
+def test_sessions_extra_narrow_stats_use_single_column() -> None:
+    css = SESSIONS_CSS.read_text(encoding="utf-8")
+    mobile_start = css.index("@media (max-width: 360px)")
+    mobile_block = css[mobile_start:]
+    stat_start = mobile_block.index(".sess-stage .stat-row {")
+    stat_rule = mobile_block[stat_start : mobile_block.index("}", stat_start)]
+
+    assert "grid-template-columns: 1fr" in stat_rule
+
+
+def test_sessions_agent_subline_wraps_long_runtime_identifiers() -> None:
+    css = SESSIONS_CSS.read_text(encoding="utf-8")
+    subline_start = css.index(".sess-key__sub {")
+    subline_rule = css[subline_start : css.index("}", subline_start)]
+    agent_start = css.index(".sess-key__agent {")
+    agent_rule = css[agent_start : css.index("}", agent_start)]
+
+    assert "min-width: 0" in subline_rule
+    assert "overflow-wrap: anywhere" in subline_rule
+    assert "max-width: 100%" in agent_rule
+    assert "min-width: 0" in agent_rule
+    assert "overflow-wrap: anywhere" in agent_rule
 
 
 def test_single_session_delete_checks_backend_partial_failure_response() -> None:

--- a/tests/test_gateway/test_skills_view_static.py
+++ b/tests/test_gateway/test_skills_view_static.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+SKILLS_JS = Path("src/opensquilla/gateway/static/js/views/skills.js")
+SKILLS_CSS = Path("src/opensquilla/gateway/static/css/views/skills.css")
+
+
+def test_skills_cards_keep_full_description_available_while_clamping_visually() -> None:
+    source = SKILLS_JS.read_text(encoding="utf-8")
+    css = SKILLS_CSS.read_text(encoding="utf-8")
+
+    render_start = source.index("function _renderCard(skill)")
+    render_end = source.index("  function _openSkillDialog", render_start)
+    render_body = source[render_start:render_end]
+
+    assert "const desc = skill.description || '';" in render_body
+    assert "skill.description.length > 100" not in render_body
+    assert 'title="${_esc(skill.name + (desc ? \': \' + desc : \'\'))}"' in render_body
+    assert '<p class="sk-card__desc" title="${_esc(desc)}">${_esc(desc)}</p>' in render_body
+
+    desc_start = css.index(".sk-card__desc {")
+    desc_rule = css[desc_start : css.index("}", desc_start)]
+    assert "-webkit-line-clamp: 3" in desc_rule
+    assert "line-clamp: 3" in desc_rule
+    assert "mask-image: linear-gradient" in desc_rule
+    assert "min-height:" in desc_rule
+
+
+def test_skill_detail_dialog_shows_full_description_for_touch_users() -> None:
+    source = SKILLS_JS.read_text(encoding="utf-8")
+    dialog_start = source.index("function _openSkillDialog(skill)")
+    dialog_end = source.index("  async function _installDeps", dialog_start)
+    dialog_body = source[dialog_start:dialog_end]
+
+    assert '<p class="sk-dialog__desc">${_esc(skill.description || \'\')}</p>' in dialog_body
+    assert "_truncDesc" not in source
+
+
+def test_skills_primary_controls_keep_touch_friendly_hit_areas() -> None:
+    css = SKILLS_CSS.read_text(encoding="utf-8")
+
+    search_rule = css[
+        css.index(".sk-search-input {") : css.index("}", css.index(".sk-search-input {"))
+    ]
+    icon_rule = css[css.index(".sk-iconbtn {") : css.index("}", css.index(".sk-iconbtn {"))]
+    tab_rule = css[css.index(".sk-tab {") : css.index("}", css.index(".sk-tab {"))]
+
+    assert "min-height: 40px" in search_rule
+    assert "width: 40px; height: 40px" in icon_rule
+    assert "min-width: 40px" in icon_rule
+    assert "flex: 0 0 40px" in icon_rule
+    assert "min-height: 40px" in tab_rule
+    assert "#skills-refresh { min-height: 40px; }" in css
+    assert "#skills-github-install { min-height: 40px; }" in css
+
+
+def test_skills_active_tabs_use_theme_contrast_token() -> None:
+    css = SKILLS_CSS.read_text(encoding="utf-8")
+    start = css.index(".sk-tab.is-active {")
+    rule = css[start : css.index("}", start)]
+
+    assert "color: var(--accent-foreground)" in rule
+
+
+def test_skill_card_names_wrap_instead_of_truncating_identifiers() -> None:
+    css = SKILLS_CSS.read_text(encoding="utf-8")
+    head_rule = css[css.index(".sk-card__head {") : css.index("}", css.index(".sk-card__head {"))]
+    name_rule = css[css.index(".sk-card__name {") : css.index("}", css.index(".sk-card__name {"))]
+
+    assert "align-items: flex-start" in head_rule
+    assert "overflow-wrap: anywhere" in name_rule
+    assert "white-space: normal" in name_rule
+    assert "text-overflow: ellipsis" not in name_rule
+
+
+def test_skill_card_variable_copy_wraps_inside_mobile_cards() -> None:
+    css = SKILLS_CSS.read_text(encoding="utf-8")
+
+    for selector in (".sk-card__desc {", ".sk-card__sub-chip {"):
+        rule = css[css.index(selector) : css.index("}", css.index(selector))]
+
+        assert "max-width: 100%" in rule, selector
+        assert "min-width: 0" in rule, selector
+        assert "overflow-wrap: anywhere" in rule, selector
+
+
+def test_skills_mobile_stats_keep_list_visible_in_first_viewport() -> None:
+    css = SKILLS_CSS.read_text(encoding="utf-8")
+    mobile_start = css.index("@media (max-width: 720px)")
+    mobile_rule = css[mobile_start : css.index("/* ─── Meta-Skill", mobile_start)]
+
+    assert (
+        ".sk-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); "
+        "gap: var(--sp-2); }"
+        in mobile_rule
+    )
+    assert (
+        ".sk-stat { min-height: 86px; "
+        "padding: var(--sp-3) var(--sp-3) var(--sp-3) var(--sp-4); }"
+        in mobile_rule
+    )
+    assert ".sk-stat__value { font-size: 1.35rem; }" in mobile_rule

--- a/tests/test_gateway/test_status_helper_static.py
+++ b/tests/test_gateway/test_status_helper_static.py
@@ -3,6 +3,7 @@ from pathlib import Path
 COMPONENTS_JS = Path("src/opensquilla/gateway/static/js/components.js")
 SESSIONS_JS = Path("src/opensquilla/gateway/static/js/views/sessions.js")
 OVERVIEW_JS = Path("src/opensquilla/gateway/static/js/views/overview.js")
+OVERVIEW_CSS = Path("src/opensquilla/gateway/static/css/views/overview.css")
 SESSIONS_CSS = Path("src/opensquilla/gateway/static/css/views/sessions.css")
 
 
@@ -136,3 +137,61 @@ def test_overview_view_uses_status_helper() -> None:
 
     # Legacy 3-bucket ternary fragment must be gone.
     assert "? 'is-on'" not in source
+
+
+def test_overview_ignores_stale_load_after_view_destroy() -> None:
+    source = OVERVIEW_JS.read_text(encoding="utf-8")
+    render_start = source.index("function render(el)")
+    render_end = source.index("  function destroy()", render_start)
+    render_body = source[render_start:render_end]
+    destroy_start = source.index("function destroy()")
+    destroy_end = source.index("  function _updateConnectionPill", destroy_start)
+    destroy_body = source[destroy_start:destroy_end]
+    start = source.index("async function _loadData()")
+    end = source.index("  function _pushEvent", start)
+    body = source[start:end]
+
+    assert "let _viewGeneration = 0;" in source
+    assert "_viewGeneration += 1;" in render_body
+    assert "_viewGeneration += 1;" in destroy_body
+    assert "const root = _el;" in body
+    assert "const generation = _viewGeneration;" in body
+    assert "const rpc = _rpc;" in body
+    assert "if (!rpc) return;" in body
+    assert "function _isCurrentView(root, rpc, generation)" in body
+    assert "return _el === root && _rpc === rpc && _viewGeneration === generation;" in body
+    assert body.count("if (!_isCurrentView(root, rpc, generation)) return;") >= 8
+    assert "root.querySelector('#' + id)" in body
+    assert "root.querySelector('#ov-cost-line')" in body
+    assert "root.querySelector('#ov-recent-sessions')" in body
+    assert "rpc.call('status')" in body
+    assert "rpc.call('doctor.status'" in body
+
+
+def test_overview_text_links_have_touch_friendly_hit_area() -> None:
+    css = OVERVIEW_CSS.read_text(encoding="utf-8")
+    start = css.index(".ov-link {")
+    rule = css[start : css.index("}", start)]
+
+    assert "display: inline-flex" in rule
+    assert "min-height: 40px" in rule
+    assert "padding: 0 var(--sp-1)" in rule
+
+
+def test_overview_mobile_recent_session_keys_wrap_inside_rows() -> None:
+    css = OVERVIEW_CSS.read_text(encoding="utf-8")
+    mobile = css.split("@media (max-width: 720px)", 1)[1]
+    key_rule = mobile.split(".ov-recent__key {", 1)[1].split("}", 1)[0]
+
+    assert "max-width: 100%" in key_rule
+    assert "white-space: normal" in key_rule
+    assert "overflow-wrap: anywhere" in key_rule
+    assert "text-overflow: clip" in key_rule
+
+
+def test_overview_mobile_recent_session_arrow_does_not_create_ghost_row() -> None:
+    css = OVERVIEW_CSS.read_text(encoding="utf-8")
+    mobile = css.split("@media (max-width: 720px)", 1)[1]
+    arrow_rule = mobile.split(".ov-recent__arrow {", 1)[1].split("}", 1)[0]
+
+    assert "display: none" in arrow_rule

--- a/tests/test_gateway/test_usage_view_static.py
+++ b/tests/test_gateway/test_usage_view_static.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 USAGE_JS = Path("src/opensquilla/gateway/static/js/views/usage.js")
 USAGE_CSS = Path("src/opensquilla/gateway/static/css/views/usage.css")
+COMPONENTS_CSS = Path("src/opensquilla/gateway/static/css/components.css")
 
 
 def test_usage_view_renders_cost_source_badges_and_exports_fields() -> None:
@@ -41,6 +42,22 @@ def test_usage_collapsed_model_display_uses_model_breakdown() -> None:
     assert "const label = bd.length > 1 ? `auto · ${bd.length} models` : _esc(model);" not in body
 
 
+def test_usage_model_card_identifiers_wrap_inside_mobile_cards() -> None:
+    source = USAGE_CSS.read_text(encoding="utf-8")
+    provider_start = source.index(".usage-model-card__provider {")
+    provider_rule = source[provider_start : source.index("}", provider_start)]
+    name_start = source.index(".usage-model-card__name {")
+    name_rule = source[name_start : source.index("}", name_start)]
+
+    for rule in (provider_rule, name_rule):
+        assert "max-width: 100%" in rule
+        assert "min-width: 0" in rule
+        assert "overflow-wrap: anywhere" in rule
+
+    assert "white-space: normal" in name_rule
+    assert "text-overflow: clip" in name_rule
+
+
 def test_usage_view_has_cost_source_styles() -> None:
     source = USAGE_CSS.read_text(encoding="utf-8")
 
@@ -51,6 +68,149 @@ def test_usage_view_has_cost_source_styles() -> None:
     assert ".usage-source--mixed" in source
     assert ".usage-source--unavailable" in source
     assert ".usage-source--ephemeral" in source
+
+
+def test_usage_segmented_controls_keep_touch_friendly_hit_areas() -> None:
+    source = USAGE_CSS.read_text(encoding="utf-8")
+    currency_start = source.index(".usage-currency__btn {")
+    seg_start = source.index(".usage-seg, .usage-range__btn {")
+    currency_rule = source[
+        currency_start : source.index("}", currency_start)
+    ]
+    seg_rule = source[seg_start : source.index("}", seg_start)]
+
+    assert "min-height: 40px" in currency_rule
+    assert "min-height: 40px" in seg_rule
+
+
+def test_usage_active_segmented_controls_use_theme_contrast_token() -> None:
+    source = USAGE_CSS.read_text(encoding="utf-8")
+    currency_start = source.index(".usage-currency__btn.is-active {")
+    seg_start = source.index(".usage-seg.is-active {")
+    currency_rule = source[currency_start : source.index("}", currency_start)]
+    seg_rule = source[seg_start : source.index("}", seg_start)]
+
+    assert "color: var(--accent-foreground)" in currency_rule
+    assert "color: var(--accent-foreground)" in seg_rule
+
+
+def test_usage_header_actions_stay_single_row_scrollable_on_mobile() -> None:
+    components = COMPONENTS_CSS.read_text(encoding="utf-8")
+    js = USAGE_JS.read_text(encoding="utf-8")
+    source = USAGE_CSS.read_text(encoding="utf-8")
+
+    mobile_start = source.rindex("@media (max-width: 720px)")
+    mobile_block = source[mobile_start:]
+
+    assert ".mobile-action-strip {" in components
+    assert ".mobile-action-strip.mobile-action-strip { flex-wrap: nowrap; }" in components
+    assert ".mobile-action-strip__button {" in components
+    assert ".mobile-action-strip__label {" in components
+    assert 'usage-stage__actions mobile-action-strip' in js
+    assert 'usage-currency mobile-action-strip__item' in js
+    assert 'mobile-action-strip__button' in js
+    assert 'mobile-action-strip__label' in js
+    assert "--mobile-action-button-size: 44px" in source
+    assert ".usage-stage__actions .btn span" not in source
+
+    button_start = mobile_block.rindex(".usage-stage__actions .btn {")
+    button_rule = mobile_block[button_start : mobile_block.index("}", button_start)]
+    assert "background: var(--bg-surface)" in button_rule
+    assert "border-color: var(--border)" in button_rule
+
+
+def test_usage_chart_labels_wrap_on_mobile() -> None:
+    source = USAGE_CSS.read_text(encoding="utf-8")
+
+    mobile_start = source.rindex("@media (max-width: 720px)")
+    mobile_block = source[mobile_start:]
+    row_start = mobile_block.index(".usage-bar-row {")
+    row_rule = mobile_block[row_start : mobile_block.index("}", row_start)]
+    label_start = mobile_block.index(".usage-bar-row__label {")
+    label_rule = mobile_block[label_start : mobile_block.index("}", label_start)]
+
+    assert "grid-template-columns: minmax(0, 1fr) auto" in row_rule
+    assert "align-items: start" in row_rule
+    assert "row-gap: 6px" in row_rule
+    assert "grid-column: 1 / -1" in label_rule
+    assert "max-width: 100%" in label_rule
+    assert "white-space: normal" in label_rule
+    assert "overflow-wrap: anywhere" in label_rule
+    assert "text-overflow: clip" in label_rule
+
+
+def test_usage_empty_table_state_stays_visible_on_mobile() -> None:
+    source = USAGE_CSS.read_text(encoding="utf-8")
+
+    empty_start = source.index(".usage-empty-row .state {")
+    empty_rule = source[empty_start : source.index("}", empty_start)]
+    mobile_start = source.index("@media (max-width: 720px)")
+    mobile_block = source[mobile_start:]
+    mobile_empty_start = mobile_block.index(".usage-empty-row .state {")
+    mobile_empty_rule = mobile_block[
+        mobile_empty_start : mobile_block.index("}", mobile_empty_start)
+    ]
+
+    assert "width: min(100%, 520px)" in empty_rule
+    assert "margin-inline: auto" in empty_rule
+    assert "width: min(100%, calc(100vw - 64px))" in mobile_empty_rule
+    assert "margin-inline: 0" in mobile_empty_rule
+
+
+def test_usage_table_scroll_edge_has_visual_affordance() -> None:
+    source = USAGE_CSS.read_text(encoding="utf-8")
+
+    wrap_start = source.index(".usage-table-wrap {")
+    wrap_rule = source[wrap_start : source.index("}", wrap_start)]
+    tablet_start = source.index("@media (max-width: 900px)")
+    next_mobile_start = source.index("@media (max-width: 720px)", tablet_start)
+    tablet_block = source[tablet_start:next_mobile_start]
+    fade_start = tablet_block.index(".usage-table-wrap::after {")
+    fade_rule = tablet_block[fade_start : tablet_block.index("}", fade_start)]
+
+    assert "position: relative" in wrap_rule
+    assert "overflow-x: auto" in wrap_rule
+    assert 'content: ""' in fade_rule
+    assert "position: absolute" in fade_rule
+    assert "right: 0" in fade_rule
+    assert "pointer-events: none" in fade_rule
+    assert "linear-gradient" in fade_rule
+    assert "box-shadow" in fade_rule
+
+
+def test_usage_session_table_becomes_labeled_cards_on_mobile() -> None:
+    js = USAGE_JS.read_text(encoding="utf-8")
+    source = USAGE_CSS.read_text(encoding="utf-8")
+
+    mobile_start = source.rindex("@media (max-width: 720px)")
+    mobile_block = source[mobile_start:]
+
+    for label in [
+        "Session",
+        "Modified",
+        "Input",
+        "Output",
+        "Cache R",
+        "Cache W",
+        "Cost",
+        "Source",
+        "Model",
+    ]:
+        assert f'data-label="{label}"' in js
+
+    assert ".usage-table-wrap { overflow-x: hidden; }" in mobile_block
+    assert ".usage-table-wrap::after { content: none; }" in mobile_block
+    assert ".usage-table thead {" in mobile_block
+    assert "clip: rect(0 0 0 0)" in mobile_block
+    assert "clip-path: inset(50%)" in mobile_block
+    assert ".usage-table thead tr," in mobile_block
+    assert ".usage-table tbody {" in mobile_block
+    assert "display: grid" in mobile_block
+    assert ".usage-table tbody td {" in mobile_block
+    assert "grid-template-columns: minmax(72px, 0.34fr) minmax(0, 1fr)" in mobile_block
+    assert "content: attr(data-label)" in mobile_block
+    assert "usage-expand-cell" in js
+    assert ".usage-expand-cell::before" in mobile_block
 
 
 def test_usage_view_recognises_prorated_source() -> None:

--- a/tests/test_gateway/test_webui_typography_static.py
+++ b/tests/test_gateway/test_webui_typography_static.py
@@ -1,0 +1,236 @@
+import re
+from pathlib import Path
+
+CSS_DIR = Path("src/opensquilla/gateway/static/css")
+COMPONENTS_CSS = Path("src/opensquilla/gateway/static/css/components.css")
+VIEW_CSS_DIR = Path("src/opensquilla/gateway/static/css/views")
+
+
+def _relative_luminance(hex_color: str) -> float:
+    channels = [int(hex_color[index : index + 2], 16) / 255 for index in (1, 3, 5)]
+    linear = [
+        channel / 12.92
+        if channel <= 0.03928
+        else ((channel + 0.055) / 1.055) ** 2.4
+        for channel in channels
+    ]
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+
+def _contrast_ratio(foreground: str, background: str) -> float:
+    lighter, darker = sorted(
+        (_relative_luminance(foreground), _relative_luminance(background)),
+        reverse=True,
+    )
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _mix_srgb(foreground: str, foreground_percent: int, background: str) -> str:
+    ratio = foreground_percent / 100
+    foreground_channels = [int(foreground[index : index + 2], 16) for index in (1, 3, 5)]
+    background_channels = [int(background[index : index + 2], 16) for index in (1, 3, 5)]
+    mixed = [
+        round(foreground_channel * ratio + background_channel * (1 - ratio))
+        for foreground_channel, background_channel in zip(
+            foreground_channels,
+            background_channels,
+            strict=True,
+        )
+    ]
+    return "#" + "".join(f"{channel:02X}" for channel in mixed)
+
+
+def test_non_onboarding_webui_css_does_not_use_negative_letter_spacing() -> None:
+    offenders: list[str] = []
+    for css_path in sorted(CSS_DIR.rglob("*.css")):
+        if css_path.name == "setup.css":
+            continue
+        for line_no, line in enumerate(css_path.read_text(encoding="utf-8").splitlines(), 1):
+            if (
+                ("letter-spacing:" in line and "letter-spacing: -" in line)
+                or ("--track" in line and ": -" in line)
+            ):
+                offenders.append(f"{css_path}:{line_no}:{line.strip()}")
+
+    assert offenders == []
+
+
+def test_shared_mono_stat_values_have_room_for_glyphs() -> None:
+    css = COMPONENTS_CSS.read_text(encoding="utf-8")
+    rule = css[css.index(".stat-value.mono {") : css.index("}", css.index(".stat-value.mono {"))]
+
+    assert "line-height: 1.3" in rule
+
+
+def test_header_search_inputs_keep_polished_hit_areas() -> None:
+    search_rules = {
+        "skills.css": ".sk-search-input {",
+        "sessions.css": ".sess-search-input {",
+        "cron.css": ".cron-search-input {",
+        "logs.css": ".lg-search-input {",
+        "config.css": ".cfg-search-input {",
+    }
+
+    for filename, selector in search_rules.items():
+        css = (VIEW_CSS_DIR / filename).read_text(encoding="utf-8")
+        rule = css[css.index(selector) : css.index("}", css.index(selector))]
+        match = re.search(r"min-height:\s*(\d+)px", rule)
+        assert match is not None, filename
+        assert int(match.group(1)) >= 36, filename
+
+
+def test_text_entry_inputs_keep_polished_hit_areas() -> None:
+    component_css = COMPONENTS_CSS.read_text(encoding="utf-8")
+    component_rule = component_css[
+        component_css.index(".input {") : component_css.index("}", component_css.index(".input {"))
+    ]
+    overview_css = (VIEW_CSS_DIR / "overview.css").read_text(encoding="utf-8")
+    overview_rule = overview_css[
+        overview_css.index(".ov-field__input {") : overview_css.index(
+            "}", overview_css.index(".ov-field__input {")
+        )
+    ]
+    chat_css = (VIEW_CSS_DIR / "chat.css").read_text(encoding="utf-8")
+    chat_rule_start = chat_css.rindex(".chat-textarea {")
+    chat_rule = chat_css[chat_rule_start : chat_css.index("}", chat_rule_start)]
+
+    assert "min-height: 36px" in component_rule
+    assert "min-height: 40px" in overview_rule
+    assert "min-height: 40px" in chat_rule
+
+
+def test_empty_state_copy_stays_inside_mobile_cards() -> None:
+    copy_rules = {
+        "components.css": ".state-text {",
+        "channels.css": ".ch-empty__msg {",
+        "sessions.css": ".sess-empty__msg {",
+        "cron.css": ".cron-empty__msg {",
+    }
+
+    for filename, selector in copy_rules.items():
+        css_path = COMPONENTS_CSS if filename == "components.css" else VIEW_CSS_DIR / filename
+        css = css_path.read_text(encoding="utf-8")
+        rule = css[css.index(selector) : css.index("}", css.index(selector))]
+
+        assert "width: 100%" in rule, filename
+        assert "max-width:" in rule, filename
+        assert "box-sizing: border-box" in rule, filename
+        assert "overflow-wrap: anywhere" in rule, filename
+
+
+def test_empty_state_svg_art_boxes_drop_inline_baseline() -> None:
+    art_rules = {
+        "overview.css": (".ov-recent__empty-icon {", ".ov-recent__empty-icon svg {"),
+        "channels.css": (".ch-empty__art {", ".ch-empty__art svg {"),
+        "sessions.css": (".sess-empty__art {", ".sess-empty__art svg {"),
+        "cron.css": (".cron-empty__clock {", ".cron-empty__clock svg {"),
+    }
+
+    for filename, (box_selector, svg_selector) in art_rules.items():
+        css = (VIEW_CSS_DIR / filename).read_text(encoding="utf-8")
+        box_rule = css[css.index(box_selector) : css.index("}", css.index(box_selector))]
+        svg_rule = css[css.index(svg_selector) : css.index("}", css.index(svg_selector))]
+
+        assert "line-height: 1" in box_rule, filename
+        assert "display: block" in svg_rule, filename
+
+
+def test_header_search_icons_drop_inline_svg_baseline() -> None:
+    css = (VIEW_CSS_DIR / "config.css").read_text(encoding="utf-8")
+    box_selector = ".cfg-search-icon {"
+    svg_selector = ".cfg-search-icon svg {"
+    box_rule = css[css.index(box_selector) : css.index("}", css.index(box_selector))]
+    svg_rule = css[css.index(svg_selector) : css.index("}", css.index(svg_selector))]
+
+    assert "line-height: 1" in box_rule
+    assert "display: block" in svg_rule
+
+
+def test_light_theme_dim_text_meets_accessible_contrast() -> None:
+    css = (CSS_DIR / "base.css").read_text(encoding="utf-8")
+    light_start = css.index('[data-theme="light"] {')
+    light_rule = css[light_start : css.index("}", light_start)]
+
+    bg = re.search(r"--bg:\s*(#[0-9A-Fa-f]{6});", light_rule)
+    surface = re.search(r"--bg-surface:\s*(#[0-9A-Fa-f]{6});", light_rule)
+    dim = re.search(r"--text-dim:\s*(#[0-9A-Fa-f]{6});", light_rule)
+    accent = re.search(r"--accent:\s*(#[0-9A-Fa-f]{6});", light_rule)
+    accent_foreground = re.search(r"--accent-foreground:\s*(#[0-9A-Fa-f]{6});", light_rule)
+    assert bg is not None
+    assert surface is not None
+    assert dim is not None
+    assert accent is not None
+    assert accent_foreground is not None
+
+    assert _contrast_ratio(dim.group(1), bg.group(1)) >= 4.5
+    assert _contrast_ratio(dim.group(1), surface.group(1)) >= 4.5
+    assert _contrast_ratio(accent.group(1), bg.group(1)) >= 4.5
+    assert _contrast_ratio(accent_foreground.group(1), accent.group(1)) >= 4.5
+
+
+def test_light_theme_status_tokens_meet_accessible_tinted_contrast() -> None:
+    css = (CSS_DIR / "base.css").read_text(encoding="utf-8")
+    light_start = css.index('[data-theme="light"] {')
+    light_rule = css[light_start : css.index("}", light_start)]
+
+    status_tokens = {
+        "ok": 10,
+        "warn": 14,
+        "danger": 14,
+        "info": 14,
+    }
+    elevated = re.search(r"--bg-elevated:\s*(#[0-9A-Fa-f]{6});", light_rule)
+    assert elevated is not None
+
+    for token, tint in status_tokens.items():
+        color = re.search(rf"--{token}:\s*(#[0-9A-Fa-f]{{6}});", light_rule)
+        assert color is not None
+        pill_background = _mix_srgb(color.group(1), tint, elevated.group(1))
+        bg = re.search(r"--bg:\s*(#[0-9A-Fa-f]{6});", light_rule)
+        assert bg is not None
+        body_background = _mix_srgb(color.group(1), tint, bg.group(1))
+
+        assert _contrast_ratio(color.group(1), pill_background) >= 4.5, token
+        assert _contrast_ratio(color.group(1), body_background) >= 4.5, token
+
+    danger = re.search(r"--danger:\s*(#[0-9A-Fa-f]{6});", light_rule)
+    bg = re.search(r"--bg:\s*(#[0-9A-Fa-f]{6});", light_rule)
+    assert danger is not None
+    assert bg is not None
+    log_line_background = _mix_srgb(danger.group(1), 4, bg.group(1))
+    error_label_background = _mix_srgb(danger.group(1), 14, log_line_background)
+
+    assert _contrast_ratio(danger.group(1), error_label_background) >= 4.5
+
+
+def test_dark_theme_dim_and_status_tokens_meet_accessible_contrast() -> None:
+    css = (CSS_DIR / "base.css").read_text(encoding="utf-8")
+    dark_start = css.index('[data-theme="dark"], :root {')
+    dark_rule = css[dark_start : css.index("}", dark_start)]
+
+    bg = re.search(r"--bg:\s*(#[0-9A-Fa-f]{6});", dark_rule)
+    surface = re.search(r"--bg-surface:\s*(#[0-9A-Fa-f]{6});", dark_rule)
+    elevated = re.search(r"--bg-elevated:\s*(#[0-9A-Fa-f]{6});", dark_rule)
+    dim = re.search(r"--text-dim:\s*(#[0-9A-Fa-f]{6});", dark_rule)
+    assert bg is not None
+    assert surface is not None
+    assert elevated is not None
+    assert dim is not None
+
+    assert _contrast_ratio(dim.group(1), bg.group(1)) >= 4.5
+    assert _contrast_ratio(dim.group(1), surface.group(1)) >= 4.5
+    assert _contrast_ratio(dim.group(1), elevated.group(1)) >= 4.5
+
+    for token in ("danger", "info"):
+        color = re.search(rf"--{token}:\s*(#[0-9A-Fa-f]{{6}});", dark_rule)
+        assert color is not None
+        tinted_background = _mix_srgb(color.group(1), 14, elevated.group(1))
+
+        assert _contrast_ratio(color.group(1), tinted_background) >= 4.5, token
+
+
+def test_primary_buttons_use_theme_contrast_token() -> None:
+    css = COMPONENTS_CSS.read_text(encoding="utf-8")
+    rule = css[css.index(".btn--primary {") : css.index("}", css.index(".btn--primary {"))]
+
+    assert "color: var(--accent-foreground)" in rule


### PR DESCRIPTION
## Summary

- Frontend-only WebUI polish for the non-onboarding control UI.
- Improves mobile readability, touch targets, responsive overflow cues, sidebar accessibility, theme contrast, compact header actions, and static regression coverage.
- Keeps backend behavior and gateway semantics unchanged.

## Validation

- `.venv/bin/pytest -q tests/test_gateway/test_*_view_static.py tests/test_gateway/test_chat_static_assets.py tests/test_gateway/test_status_helper_static.py tests/test_gateway/test_webui_typography_static.py` — 262 passed, 1 warning (`asyncio_mode` config warning).
- `node --check` over `src/opensquilla/gateway/static/js/app.js` and `src/opensquilla/gateway/static/js/views/*.js` — passed.
- `git diff --check origin/dev..HEAD` — passed.

## Notes

- Local branch was rebased onto latest `origin/dev` and squashed into one commit before publication.
- Recommended merge method: Squash and merge into `dev`.
- `ruff` was not available locally (`No module named ruff`).
