### PR TITLE
Productize section-aware onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ variables when you pass `--api-key-env`. The router defaults to
 opensquilla onboard                # full interactive wizard
 opensquilla onboard --if-needed    # idempotent: safe for scripts and re-installs
 opensquilla onboard --minimal      # provider only; skip channels and search
+opensquilla onboard status         # inspect every setup section without writing
 ```
 
 In SSH, CI, or any environment without a TTY, use the non-interactive
@@ -366,7 +367,10 @@ opensquilla configure channels
 
 Sections: `provider`, `router`, `channels`, `search`,
 `image-generation`, `memory-embedding`. The Web UI exposes the same
-flow at `/control/setup`.
+catalog and status model at `/control/setup`: Provider and Router are
+the fast path, while Channels, Search, Image generation, and Memory
+embedding sit in the Capability Center and can be configured later.
+Empty channels are treated as an opt-out, not a failed setup.
 
 **Config load order:** `OPENSQUILLA_GATEWAY_CONFIG_PATH` →
 `./opensquilla.toml` → `~/.opensquilla/config.toml` → built-in

--- a/src/opensquilla/cli/gateway_cmd.py
+++ b/src/opensquilla/cli/gateway_cmd.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import shlex
 
 import typer
 
@@ -59,9 +60,8 @@ def run_gateway(
     honoured as the fallback when no CLI flag or env var is supplied,
     matching what the field name promises.
     """
-    config = GatewayConfig.load(
-        config_path or os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH")
-    )
+    effective_config_path = config_path or os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH")
+    config = GatewayConfig.load(effective_config_path)
     host = _resolve_lifecycle_host(
         bind=bind,
         listen=listen,
@@ -78,8 +78,6 @@ def run_gateway(
         f"on {banner_host}:{effective_port}"
     )
     scheme = "https" if (config.tls.keyfile and config.tls.certfile) else "http"
-    for line in gateway_startup_guidance(host, effective_port, scheme=scheme):
-        console.print(line)
     if is_public_bind(host):
         # Use ASCII-only glyphs here so the warning still prints on Windows
         # consoles configured for legacy GBK code pages (where U+26A0 / em-dash
@@ -114,6 +112,8 @@ def run_gateway(
             subscription_manager=subscription_mgr,
             run=True,
         )
+        for line in gateway_startup_guidance(host, effective_port, scheme=scheme):
+            console.print(line)
         assert server._task is not None
         try:
             await server._task
@@ -124,6 +124,51 @@ def run_gateway(
         asyncio.run(_run())
     except KeyboardInterrupt:
         console.print("\n[yellow]Gateway stopped.[/yellow]")
+    except ValueError as exc:
+        _print_gateway_startup_recovery(
+            exc,
+            config=config,
+            config_path=effective_config_path,
+        )
+        raise typer.Exit(1) from exc
+
+
+def _print_gateway_startup_recovery(
+    exc: ValueError,
+    *,
+    config: GatewayConfig,
+    config_path: str | None,
+) -> None:
+    console.print(f"[bold red]Gateway could not start:[/bold red] {exc}")
+    try:
+        from opensquilla.onboarding.next_steps import env_recovery_commands
+        from opensquilla.onboarding.status import get_onboarding_status
+
+        commands = env_recovery_commands(get_onboarding_status(config))
+    except Exception as recovery_exc:
+        console.print(
+            "[dim]Onboarding recovery details unavailable: "
+            f"{recovery_exc}[/dim]"
+        )
+        return
+    if not commands:
+        return
+    config_arg = _gateway_config_cli_arg(config_path)
+    console.print("[bold yellow]Fix onboarding environment first:[/bold yellow]")
+    for entry in commands:
+        label = str(entry.get("label") or "Set key")
+        command = str(entry.get("command") or "").strip()
+        if command:
+            console.print(f"  {label}: {command}")
+    console.print(f"  Check status: opensquilla onboard status{config_arg}")
+    console.print(f"  Guided CLI: opensquilla onboard --if-needed{config_arg}")
+    console.print(f"  Then rerun: opensquilla gateway run{config_arg}")
+
+
+def _gateway_config_cli_arg(config_path: str | None) -> str:
+    if not config_path:
+        return ""
+    return f" --config {shlex.quote(str(config_path))}"
 
 
 def _resolve_lifecycle_host(

--- a/src/opensquilla/cli/onboard_cmd.py
+++ b/src/opensquilla/cli/onboard_cmd.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import json as _json
 import shlex
+import tomllib
 from pathlib import Path
 
 import typer
+from pydantic import ValidationError
 from rich.table import Table
 
+from opensquilla.cli.output import print_json
 from opensquilla.cli.ui import (
     ACCENT,
     ACCENT_SOFT,
@@ -18,18 +21,107 @@ from opensquilla.cli.ui import (
     markup_escape,
     warning_panel,
 )
-from opensquilla.onboarding.config_store import load_config
+from opensquilla.onboarding.config_store import load_config, resolve_config_path
 from opensquilla.onboarding.flow import (
     OnboardOptions,
     run_interactive_configure,
     run_interactive_onboard,
     run_noninteractive_provider_configure,
 )
-from opensquilla.onboarding.next_steps import env_reference_warnings, format_next_steps
+from opensquilla.onboarding.next_steps import (
+    env_recovery_commands,
+    env_reference_warnings,
+    format_next_steps,
+    headless_setup_commands,
+    setup_catalog_command,
+)
 from opensquilla.onboarding.section_status import SectionStatus
+from opensquilla.onboarding.setup_engine import (
+    IMAGE_GENERATION_SECTION_ALIASES,
+    MEMORY_EMBEDDING_SECTION_ALIASES,
+    setup_catalog_payload,
+)
+from opensquilla.onboarding.setup_paths import web_setup_url
 from opensquilla.onboarding.status import OnboardingStatus, get_onboarding_status
 
 _STATUS_BLOCKING = {SectionStatus.MISSING, SectionStatus.DEGRADED, SectionStatus.UNKNOWN}
+_STATUS_DISPLAY: dict[SectionStatus, str] = {
+    SectionStatus.OK: "Ready",
+    SectionStatus.OPTIONAL: "Later",
+    SectionStatus.MISSING: "Missing",
+    SectionStatus.DEGRADED: "Needs action",
+    SectionStatus.UNKNOWN: "Check",
+}
+_LLM_SOURCE_DISPLAY = {
+    "explicit": "explicit key",
+    "env": "env key visible",
+    "missing_env": "env key not visible",
+    "none": "not configured",
+}
+_IMAGE_SOURCE_DISPLAY = {
+    "explicit": "explicit key",
+    "env": "env key visible",
+    "llm_fallback": "same provider key",
+    "none": "not configured",
+}
+
+
+def _section_label(status: OnboardingStatus, name: str) -> str:
+    detail = status.section_details.get(name, {})
+    label = detail.get("label")
+    return str(label) if label else name.replace("_", " ").title()
+
+
+def _section_scope(status: OnboardingStatus, name: str) -> str:
+    detail = status.section_details.get(name, {})
+    return "Required" if detail.get("required") else "Optional"
+
+
+def _status_display(state: SectionStatus) -> str:
+    return _STATUS_DISPLAY.get(state, state.value)
+
+
+def _section_status_display(status: OnboardingStatus, name: str) -> str:
+    state = status.sections[name]
+    if (
+        name == "router"
+        and state is SectionStatus.OK
+        and _section_detail(status, name) == "uses SquillaRouter after provider setup"
+    ):
+        return "Provider first"
+    return _status_display(state)
+
+
+def _section_status_style(state: SectionStatus, display: str) -> str:
+    if display == "Provider first":
+        return "yellow"
+    return _STATUS_STYLE.get(state, "")
+
+
+def _section_detail(status: OnboardingStatus, name: str) -> str:
+    detail = str(status.section_details.get(name, {}).get("detail") or "")
+    if detail:
+        return detail
+    if name == "llm":
+        return _LLM_SOURCE_DISPLAY.get(status.llm_source, status.llm_source)
+    if name == "search":
+        return "configured" if status.search_configured else "not configured"
+    if name == "image_generation" and status.image_generation_provider:
+        source = _IMAGE_SOURCE_DISPLAY.get(
+            status.image_generation_source,
+            status.image_generation_source,
+        )
+        return (
+            f"{status.image_generation_provider} "
+            f"({source})"
+        ).strip()
+    if name == "image_generation":
+        return "disabled" if not status.image_generation_enabled else "not configured"
+    if name == "channels":
+        return f"{status.channel_count} configured"
+    if name == "memory_embedding":
+        return status.memory_embedding_provider
+    return ""
 
 
 def _print_env_reference_warnings(config) -> None:
@@ -47,11 +139,90 @@ def _print_saved_path(path: object) -> None:
 
 def _format_missing_sections(status: OnboardingStatus) -> str:
     parts = [
-        f"{name} ({state.value})"
+        f"{_section_label(status, name)} ({_status_display(state)})"
         for name, state in status.sections.items()
         if state in _STATUS_BLOCKING
     ]
     return ", ".join(parts) if parts else "none"
+
+
+def _optional_action_sections(status: OnboardingStatus) -> list[str]:
+    return [
+        name
+        for name, state in status.sections.items()
+        if not status.section_details.get(name, {}).get("required")
+        and not status.section_details.get(name, {}).get("blocking")
+        and (
+            status.section_details.get(name, {}).get("actionRequired")
+            or state is not SectionStatus.OK
+        )
+    ]
+
+
+def _format_action_sections(status: OnboardingStatus, names: list[str]) -> str:
+    parts = [
+        f"{_section_label(status, name)} ({_status_display(status.sections[name])})"
+        for name in names
+    ]
+    return ", ".join(parts) if parts else "none"
+
+
+def _format_config_load_error(exc: Exception) -> str:
+    if isinstance(exc, ValidationError):
+        errors = exc.errors()
+        if errors:
+            first = errors[0]
+            loc = ".".join(str(part) for part in first.get("loc", ()))
+            msg = str(first.get("msg") or "invalid value")
+            return f"{loc}: {msg}" if loc else msg
+    return str(exc).splitlines()[0]
+
+
+def _exit_config_load_error(exc: Exception, path: str | Path | None = None) -> None:
+    target, _ = resolve_config_path(path)
+    config_arg = _config_cli_arg(target)
+    error_console.print(
+        f"[red]OpenSquilla config error:[/red] {markup_escape(str(target))}"
+    )
+    error_console.print(
+        f"[dim]Reason: {markup_escape(_format_config_load_error(exc))}[/dim]"
+    )
+    error_console.print("[dim]Fix: edit or move this config, then rerun onboarding:[/dim]")
+    error_console.print(
+        f"  [{ACCENT_SOFT}]opensquilla onboard --if-needed"
+        f"{markup_escape(config_arg)}[/]"
+    )
+    raise typer.Exit(code=2) from exc
+
+
+def _load_config_for_cli(path: str | Path | None = None):
+    try:
+        return load_config(path)
+    except (OSError, tomllib.TOMLDecodeError, ValidationError) as exc:
+        _exit_config_load_error(exc, path)
+
+
+def _format_section_names(status: OnboardingStatus, names: list[str]) -> str:
+    return ", ".join(_section_label(status, name) for name in names) if names else "none"
+
+
+def _status_cockpit_summary(status: OnboardingStatus) -> str:
+    blocking = [
+        name
+        for name in status.sections
+        if status.section_details.get(name, {}).get("blocking")
+    ]
+    optional_later = [
+        name
+        for name, state in status.sections.items()
+        if not status.section_details.get(name, {}).get("required")
+        and not status.section_details.get(name, {}).get("blocking")
+        and state is not SectionStatus.OK
+    ]
+    return (
+        f"Blocking setup: {_format_section_names(status, blocking)}"
+        f" · Optional later: {_format_section_names(status, optional_later)}"
+    )
 
 
 def _config_cli_arg(config_path: Path | None) -> str:
@@ -60,8 +231,150 @@ def _config_cli_arg(config_path: Path | None) -> str:
     return f" --config {shlex.quote(str(config_path))}"
 
 
+def _headless_section_paths(
+    names: list[str],
+    config_arg: str,
+) -> list[tuple[str, str, str]]:
+    paths: list[tuple[str, str, str]] = []
+    seen_commands: set[str] = set()
+    for name in names:
+        entries = headless_setup_commands(name)
+        if not entries:
+            continue
+        for label, command in entries:
+            if command in seen_commands:
+                continue
+            seen_commands.add(command)
+            paths.append((label, f"{command}{config_arg}", ""))
+    return paths
+
+
+def _missing_env_paths(status: OnboardingStatus) -> list[tuple[str, str, str]]:
+    return [
+        (str(entry["label"]), str(entry["command"]), "")
+        for entry in env_recovery_commands(status)
+    ]
+
+
+def _has_blocking_env_recovery(status: OnboardingStatus) -> bool:
+    for entry in env_recovery_commands(status):
+        section = str(entry.get("section") or "")
+        if status.section_details.get(section, {}).get("blocking"):
+            return True
+    return False
+
+
+def _status_setup_paths(
+    status: OnboardingStatus,
+    cfg,
+    config_path: Path | None,
+) -> list[tuple[str, str, str]]:
+    config_arg = _config_cli_arg(config_path)
+    paths = _missing_env_paths(status)
+    paths.append(
+        (
+            "Guided CLI",
+            f"opensquilla onboard --if-needed{config_arg}",
+            "",
+        ),
+    )
+    setup_url = web_setup_url(cfg)
+    if setup_url:
+        web_label = (
+            "Web UI after env fix" if _has_blocking_env_recovery(status) else "Web UI"
+        )
+        paths.append(
+            (
+                web_label,
+                f"opensquilla gateway run{config_arg}",
+                f" -> {setup_url}",
+            )
+        )
+    catalog_label, catalog_command = setup_catalog_command(config_arg)
+    paths.append((catalog_label, catalog_command, ""))
+    blocking = [
+        name
+        for name, state in status.sections.items()
+        if state in _STATUS_BLOCKING
+        or status.section_details.get(name, {}).get("blocking")
+    ]
+    paths.extend(_headless_section_paths(blocking, config_arg))
+    return paths
+
+
+def _optional_setup_paths(
+    status: OnboardingStatus,
+    cfg,
+    config_path: Path | None,
+) -> list[tuple[str, str, str]]:
+    config_arg = _config_cli_arg(config_path)
+    paths: list[tuple[str, str, str]] = []
+    setup_url = web_setup_url(cfg)
+    if setup_url:
+        paths.append(
+            (
+                "Web UI",
+                f"opensquilla gateway run{config_arg}",
+                f" -> {setup_url}",
+            )
+        )
+    catalog_label, catalog_command = setup_catalog_command(config_arg)
+    paths.append((catalog_label, catalog_command, ""))
+    paths.extend(_headless_section_paths(_optional_action_sections(status), config_arg))
+    return paths
+
+
+def _ready_setup_paths(
+    cfg,
+    config_path: Path | None,
+) -> list[tuple[str, str, str]]:
+    config_arg = _config_cli_arg(config_path)
+    setup_url = web_setup_url(cfg)
+    return [
+        (
+            "Start gateway",
+            f"opensquilla gateway run{config_arg}",
+            f" -> {setup_url}" if setup_url else "",
+        ),
+        (
+            "Reconfigure later",
+            f"opensquilla onboard configure <section>{config_arg}",
+            "",
+        ),
+    ]
+
+
+def _print_status_path(label: str, command: str, suffix: str = "") -> None:
+    console.print(
+        f"  [dim]{label}:[/] "
+        f"[{ACCENT_SOFT}]{markup_escape(command)}[/]"
+        f"[dim]{markup_escape(suffix)}[/]",
+        soft_wrap=True,
+    )
+
+
+def _print_optional_action_handoff(
+    status: OnboardingStatus,
+    cfg,
+    config_path: Path | None,
+) -> None:
+    actions = _optional_action_sections(status)
+    console.print(
+        f"[{ACCENT_SOFT}]◆[/] [bold]core setup is ready[/]; "
+        "[bold]optional capabilities need action:[/] "
+        f"{markup_escape(_format_action_sections(status, actions))}",
+        soft_wrap=True,
+    )
+    console.print("[bold]Optional next moves:[/]")
+    for label, command, suffix in _optional_setup_paths(status, cfg, config_path):
+        _print_status_path(label, command, suffix)
+
+
 onboard_app = typer.Typer(
-    help="Run or inspect OpenSquilla onboarding.",
+    help=(
+        "OpenSquilla setup cockpit for providers, SquillaRouter, "
+        "channels, search, images, and memory."
+    ),
     invoke_without_command=True,
     no_args_is_help=False,
 )
@@ -70,23 +383,48 @@ onboard_app = typer.Typer(
 @onboard_app.callback(invoke_without_command=True)
 def onboard_command(
     ctx: typer.Context,
-    provider: str = typer.Option("", "--provider"),
-    model: str = typer.Option("", "--model"),
-    api_key: str = typer.Option("", "--api-key"),
-    api_key_env: str = typer.Option("", "--api-key-env"),
-    base_url: str = typer.Option("", "--base-url"),
+    provider: str = typer.Option("", "--provider", help="Provider id to configure."),
+    model: str = typer.Option("", "--model", help="Model id for the provider."),
+    api_key: str = typer.Option("", "--api-key", help="Provider key to store in config."),
+    api_key_env: str = typer.Option(
+        "",
+        "--api-key-env",
+        help="Read the provider key from this environment variable.",
+    ),
+    base_url: str = typer.Option("", "--base-url", help="Custom provider base URL."),
+    proxy: str = typer.Option("", "--proxy", help="Explicit HTTP proxy URL for upstream calls."),
     router: str = typer.Option(
         "recommended",
         "--router",
         metavar="MODE",
         help="Router profile: recommended, openrouter-mix, or disabled.",
     ),
-    minimal: bool = typer.Option(False, "--minimal"),
-    skip_channels: bool = typer.Option(False, "--skip-channels"),
-    skip_search: bool = typer.Option(False, "--skip-search"),
-    skip_image_generation: bool = typer.Option(False, "--skip-image-generation"),
-    skip_migration: bool = typer.Option(False, "--skip-migration"),
-    if_needed: bool = typer.Option(False, "--if-needed"),
+    minimal: bool = typer.Option(False, "--minimal", help="Keep interactive setup to core fields."),
+    skip_channels: bool = typer.Option(
+        False,
+        "--skip-channels",
+        help="Leave channel setup for later.",
+    ),
+    skip_search: bool = typer.Option(
+        False,
+        "--skip-search",
+        help="Leave optional Web search setup for later.",
+    ),
+    skip_image_generation: bool = typer.Option(
+        False,
+        "--skip-image-generation",
+        help="Leave optional image generation setup for later.",
+    ),
+    skip_migration: bool = typer.Option(
+        False,
+        "--skip-migration",
+        help="Skip legacy OpenClaw/Hermes import prompts.",
+    ),
+    if_needed: bool = typer.Option(
+        False,
+        "--if-needed",
+        help="Only run the wizard when required setup is incomplete.",
+    ),
     config_path: Path | None = typer.Option(None, "--config", help="Override config path."),
 ) -> None:
     """Run first-run onboarding (interactive or non-interactive)."""
@@ -95,9 +433,12 @@ def onboard_command(
         # handler take over instead of running the interactive flow.
         return
     if if_needed:
-        cfg = load_config(config_path)
+        cfg = _load_config_for_cli(config_path)
         status = get_onboarding_status(cfg)
         if status.has_config and not status.needs_onboarding:
+            if _optional_action_sections(status):
+                _print_optional_action_handoff(status, cfg, config_path)
+                raise typer.Exit(code=0)
             console.print(
                 f"[{ACCENT_SOFT}]◆[/] [bold]onboarding already complete[/]"
                 " [dim]— nothing to do[/dim]"
@@ -112,29 +453,41 @@ def onboard_command(
             )
 
     if provider:
-        result = run_noninteractive_provider_configure(
-            provider,
-            {
-                "model": model,
-                "api_key": api_key,
-                "api_key_env": api_key_env,
-                "base_url": base_url,
-                "router": router,
-            },
-            path=config_path,
-        )
+        try:
+            result = run_noninteractive_provider_configure(
+                provider,
+                {
+                    "model": model,
+                    "api_key": api_key,
+                    "api_key_env": api_key_env,
+                    "base_url": base_url,
+                    "proxy": proxy,
+                    "router": router,
+                },
+                path=config_path,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            error_console.print(f"[red]Error:[/red] {markup_escape(str(exc))}")
+            if "model is required" in str(exc):
+                error_console.print(
+                    "[dim]Hint: pass --model <model-id> for providers without "
+                    "a router default, or run `opensquilla onboard` for guided "
+                    "prompts.[/dim]"
+                )
+            raise typer.Exit(code=2) from exc
         console.print(
             banner_panel(
-                "Provider Configured",
-                f"{provider} · {result.path}",
+                "OpenSquilla Setup Handoff",
+                provider,
             )
         )
-        cfg = load_config(result.path)
+        cfg = _load_config_for_cli(result.path)
         _print_env_reference_warnings(cfg)
         console.print(
             format_next_steps(cfg, config_path=result.path),
             markup=False,
             highlight=False,
+            soft_wrap=True,
         )
         return
 
@@ -148,6 +501,7 @@ def onboard_command(
         api_key=api_key or None,
         api_key_env=api_key_env or None,
         base_url=base_url or None,
+        proxy=proxy or None,
         router_mode=router,
         minimal=minimal,
         skip_migration=skip_migration,
@@ -158,16 +512,17 @@ def onboard_command(
         raise typer.Exit(code=2)
     console.print(
         banner_panel(
-            "Onboarding Complete",
+            "OpenSquilla Setup Handoff",
             str(result.path),
         )
     )
-    cfg = load_config(result.path)
+    cfg = _load_config_for_cli(result.path)
     _print_env_reference_warnings(cfg)
     console.print(
         format_next_steps(cfg, config_path=result.path),
         markup=False,
         highlight=False,
+        soft_wrap=True,
     )
 
 
@@ -181,17 +536,411 @@ _STATUS_STYLE: dict[SectionStatus, str] = {
 
 
 def _status_payload(status: OnboardingStatus) -> dict:
+    sections = {name: state.value for name, state in status.sections.items()}
+    section_details = {name: dict(detail) for name, detail in status.section_details.items()}
+    if "llm" in sections:
+        sections["provider"] = sections["llm"]
+    if "llm" in section_details:
+        section_details["provider"] = dict(section_details["llm"])
+
     return {
         "configPath": status.config_path,
         "hasConfig": status.has_config,
         "needsOnboarding": status.needs_onboarding,
-        "sections": {name: state.value for name, state in status.sections.items()},
+        "sections": sections,
+        "sectionDetails": section_details,
+        "sectionAliases": {"llm": "provider"},
         "llmSource": status.llm_source,
+        "llmEnvKey": status.llm_env_key,
+        "searchProvider": status.search_provider,
+        "searchSource": status.search_source,
+        "searchEnvKey": status.search_env_key,
         "imageGenerationEnabled": status.image_generation_enabled,
+        "imageGenerationSource": status.image_generation_source,
         "imageGenerationProvider": status.image_generation_provider,
         "imageGenerationPrimary": status.image_generation_primary,
+        "imageGenerationEnvKey": status.image_generation_env_key,
+        "memoryEmbeddingConfigured": status.memory_embedding_configured,
+        "memoryEmbeddingProvider": status.memory_embedding_provider,
+        "memoryEmbeddingSource": status.memory_embedding_source,
+        "memoryEmbeddingEnvKey": status.memory_embedding_env_key,
+        "envRecoveryCommands": env_recovery_commands(status),
         "channelCount": status.channel_count,
     }
+
+
+def _catalog_count(value: object) -> int:
+    if isinstance(value, list):
+        return len(value)
+    if isinstance(value, dict) and isinstance(value.get("profiles"), list):
+        return len(value["profiles"])
+    return 1
+
+
+_CATALOG_COMMANDS = {
+    "providers": (
+        "opensquilla onboard configure provider --provider <id> --model <model> "
+        "--api-key-env <ENV_NAME>"
+    ),
+    "routerProfiles": (
+        "opensquilla onboard configure router --router recommended --default-tier t1"
+    ),
+    "searchProviders": (
+        "opensquilla onboard configure search --search-provider <provider> "
+        "--api-key-env <ENV_NAME>"
+    ),
+    "channels": (
+        "opensquilla onboard configure channels --channel-type <type> --name <name> "
+        "--field key=value"
+    ),
+    "imageGenerationProviders": (
+        "opensquilla onboard configure image --image-provider <provider> "
+        "--primary <model> --api-key-env <ENV_NAME>"
+    ),
+    "memoryEmbeddingProviders": (
+        "opensquilla onboard configure memory --memory-provider <provider> "
+        "--model <model> --api-key-env <ENV_NAME>"
+    ),
+}
+
+_CATALOG_SECTION_COMMANDS = {
+    "providers": "opensquilla onboard catalog providers",
+    "routerProfiles": "opensquilla onboard catalog router",
+    "searchProviders": "opensquilla onboard catalog search",
+    "channels": "opensquilla onboard catalog channels",
+    "imageGenerationProviders": "opensquilla onboard catalog image",
+    "memoryEmbeddingProviders": "opensquilla onboard catalog memory",
+}
+
+_CATALOG_TITLES = {
+    "providers": "Text providers",
+    "routerProfiles": "SquillaRouter profiles",
+    "searchProviders": "Web search providers",
+    "channels": "Channel types",
+    "imageGenerationProviders": "Image generation providers",
+    "memoryEmbeddingProviders": "Memory embedding providers",
+}
+
+
+def _catalog_value(row: dict[str, object], key: str, fallback: str = "") -> str:
+    value = row.get(key)
+    if value is None or value == "":
+        return fallback
+    return str(value)
+
+
+def _catalog_key_requirement(row: dict[str, object]) -> str:
+    if row.get("requiresApiKey"):
+        return _catalog_value(row, "envKey", "API key")
+    return "No key"
+
+
+def _catalog_runtime(row: dict[str, object]) -> str:
+    if row.get("runtimeSupported") is False:
+        return "metadata only"
+    return "ready"
+
+
+def _catalog_field_summary(row: dict[str, object]) -> str:
+    fields = row.get("fields")
+    if not isinstance(fields, list):
+        return ""
+    required: list[str] = []
+    for field in fields:
+        if not isinstance(field, dict) or not field.get("required"):
+            continue
+        label = str(field.get("label") or field.get("name") or "")
+        name = str(field.get("name") or "")
+        required.append(f"{label} ({name})" if name else label)
+    return ", ".join(required) if required else "No required fields"
+
+
+def _print_catalog_line(text: str) -> None:
+    console.print(text, soft_wrap=True)
+
+
+def _catalog_command(name: str, config_arg: str = "") -> str:
+    command = _CATALOG_COMMANDS.get(name, "")
+    return f"{command}{config_arg}" if command else ""
+
+
+def _catalog_section_command(name: str, config_arg: str = "") -> str:
+    command = _CATALOG_SECTION_COMMANDS.get(name, "")
+    return f"{command}{config_arg}" if command else ""
+
+
+def _catalog_try_command(
+    name: str,
+    row: dict[str, object],
+    config_arg: str = "",
+) -> str:
+    if name == "providers":
+        provider_id = _catalog_value(row, "providerId", "<id>")
+        model = _catalog_value(row, "defaultDirectModel", "<model>")
+        command = (
+            "opensquilla onboard configure provider "
+            f"--provider {provider_id} --model {model}"
+        )
+        if row.get("requiresApiKey"):
+            command += f" --api-key-env {_catalog_value(row, 'envKey', '<ENV_NAME>')}"
+        if row.get("requiresBaseUrl"):
+            command += f" --base-url {_catalog_value(row, 'defaultBaseUrl', '<base-url>')}"
+        return f"{command}{config_arg}"
+
+    if name == "searchProviders":
+        if row.get("runtimeSupported") is False:
+            return ""
+        provider_id = _catalog_value(row, "providerId", "<provider>")
+        command = f"opensquilla onboard configure search --search-provider {provider_id}"
+        if row.get("requiresApiKey"):
+            command += f" --api-key-env {_catalog_value(row, 'envKey', '<ENV_NAME>')}"
+        return f"{command}{config_arg}"
+
+    if name == "channels":
+        channel_type = _catalog_value(row, "type", "<type>")
+        command = (
+            "opensquilla onboard configure channels "
+            f"--channel-type {channel_type} --name <name>"
+        )
+        fields = row.get("fields")
+        if isinstance(fields, list):
+            for field in fields:
+                if not isinstance(field, dict) or not field.get("required"):
+                    continue
+                field_name = str(field.get("name") or "")
+                if not field_name or field_name == "name":
+                    continue
+                if field_name == "token":
+                    command += " --token <token>"
+                else:
+                    command += f" --field {field_name}=<value>"
+        return f"{command}{config_arg}"
+
+    if name == "imageGenerationProviders":
+        provider_id = _catalog_value(row, "providerId", "<provider>")
+        model = _catalog_value(row, "defaultModel", "<model>")
+        command = (
+            "opensquilla onboard configure image "
+            f"--image-provider {provider_id} --primary {model}"
+        )
+        if row.get("requiresApiKey"):
+            command += f" --api-key-env {_catalog_value(row, 'envKey', '<ENV_NAME>')}"
+        if row.get("requiresBaseUrl"):
+            command += f" --base-url {_catalog_value(row, 'defaultBaseUrl', '<base-url>')}"
+        return f"{command}{config_arg}"
+
+    if name == "memoryEmbeddingProviders":
+        provider_id = _catalog_value(row, "providerId", "<provider>")
+        command = (
+            "opensquilla onboard configure memory "
+            f"--memory-provider {provider_id}"
+        )
+        if row.get("requiresApiKey"):
+            command += f" --api-key-env {_catalog_value(row, 'envKey', '<ENV_NAME>')}"
+        if provider_id == "openai-compatible":
+            command += " --base-url <base-url> --model <model>"
+        elif provider_id == "ollama":
+            command += " --model <model>"
+        return f"{command}{config_arg}"
+
+    return _catalog_command(name, config_arg)
+
+
+def _print_catalog_try_command(
+    name: str,
+    row: dict[str, object],
+    config_arg: str = "",
+) -> None:
+    command = _catalog_try_command(name, row, config_arg)
+    if command:
+        _print_catalog_line(f"  Try: {command}")
+    else:
+        _print_catalog_line("  Try: not configurable in this build")
+
+
+def _print_catalog_recipe_hint() -> None:
+    console.print("Copy a Try line; key flags appear only when that option needs them.")
+
+
+def _catalog_provider_route(row: dict[str, object]) -> str:
+    return "SquillaRouter ready" if row.get("routerSupported") else "Direct only"
+
+
+def _print_list_catalog(
+    name: str,
+    rows: list[dict[str, object]],
+    config_arg: str = "",
+) -> None:
+    if name == "providers":
+        console.print("[bold]OpenSquilla text provider options[/bold]")
+        _print_catalog_recipe_hint()
+        for row in rows:
+            _print_catalog_line(
+                f"- {_catalog_value(row, 'providerId')}: {_catalog_value(row, 'label')}"
+                f" | route {_catalog_provider_route(row)}"
+                f" | key {_catalog_key_requirement(row)}"
+                f" | default {_catalog_value(row, 'defaultDirectModel', 'custom')}"
+            )
+            _print_catalog_try_command(name, row, config_arg)
+        return
+
+    if name == "searchProviders":
+        console.print("[bold]OpenSquilla Web search provider options[/bold]")
+        _print_catalog_recipe_hint()
+        for row in rows:
+            _print_catalog_line(
+                f"- {_catalog_value(row, 'providerId')}: {_catalog_value(row, 'label')}"
+                f" | {_catalog_runtime(row)}"
+                f" | key {_catalog_key_requirement(row)}"
+                f" | {_catalog_value(row, 'deployment')}"
+            )
+            _print_catalog_try_command(name, row, config_arg)
+        return
+
+    if name == "channels":
+        console.print("[bold]OpenSquilla channel type options[/bold]")
+        _print_catalog_recipe_hint()
+        for row in rows:
+            channel_type = _catalog_value(row, "type")
+            _print_catalog_line(
+                f"- {channel_type}: {_catalog_value(row, 'label')}"
+                f" | {_catalog_value(row, 'transport')}"
+                f" | fields {_catalog_field_summary(row)}"
+                f" | guide opensquilla channels describe {channel_type} --json"
+            )
+            _print_catalog_try_command(name, row, config_arg)
+        return
+
+    if name == "imageGenerationProviders":
+        console.print("[bold]OpenSquilla image generation provider options[/bold]")
+        _print_catalog_recipe_hint()
+        for row in rows:
+            _print_catalog_line(
+                f"- {_catalog_value(row, 'providerId')}: {_catalog_value(row, 'label')}"
+                f" | key {_catalog_key_requirement(row)}"
+                f" | default {_catalog_value(row, 'defaultModel', 'custom')}"
+            )
+            _print_catalog_try_command(name, row, config_arg)
+        return
+
+    if name == "memoryEmbeddingProviders":
+        console.print("[bold]OpenSquilla memory embedding provider options[/bold]")
+        _print_catalog_recipe_hint()
+        for row in rows:
+            _print_catalog_line(
+                f"- {_catalog_value(row, 'providerId')}: {_catalog_value(row, 'label')}"
+                f" | {_catalog_value(row, 'deployment')}"
+                f" | key {_catalog_key_requirement(row)}"
+            )
+            _print_catalog_try_command(name, row, config_arg)
+        return
+
+
+def _router_tier_summary(profile: dict[str, object]) -> str:
+    tiers = profile.get("tiers")
+    if not isinstance(tiers, dict):
+        return ""
+    summary: list[str] = []
+    for tier in ("t0", "t1", "t2", "t3"):
+        tier_spec = tiers.get(tier)
+        if isinstance(tier_spec, dict):
+            summary.append(f"{tier}: {tier_spec.get('model', '')}")
+    return "; ".join(summary)
+
+
+def _print_router_catalog(catalog: dict[str, object], config_arg: str = "") -> None:
+    modes = catalog.get("modes")
+    if isinstance(modes, list):
+        console.print("[bold]OpenSquilla router modes[/bold]")
+        for row in modes:
+            if not isinstance(row, dict):
+                continue
+            _print_catalog_line(
+                f"- {_catalog_value(row, 'mode')}: {_catalog_value(row, 'label')}"
+                f" | {_catalog_value(row, 'description')}"
+            )
+
+    profiles = catalog.get("profiles")
+    if isinstance(profiles, list):
+        console.print("[bold]OpenSquilla provider tier profiles[/bold]")
+        for row in profiles:
+            if not isinstance(row, dict):
+                continue
+            _print_catalog_line(
+                f"- {_catalog_value(row, 'profileId')}: {_catalog_value(row, 'label')}"
+                f" | {_router_tier_summary(row)}"
+            )
+    console.print("Copy a Try line to keep the default OpenSquilla router profile.")
+    _print_catalog_line(f"  Try: {_catalog_command('routerProfiles', config_arg)}")
+
+
+def _print_focused_catalog(name: str, value: object, config_arg: str = "") -> None:
+    if name == "routerProfiles" and isinstance(value, dict):
+        _print_router_catalog(value, config_arg)
+        return
+    if isinstance(value, list):
+        rows = [row for row in value if isinstance(row, dict)]
+        _print_list_catalog(name, rows, config_arg)
+        return
+
+
+@onboard_app.command("catalog")
+def onboard_catalog_command(
+    section: str = typer.Argument(
+        "",
+        metavar="SECTION",
+        help=(
+            "Optional section: providers, router, search, channels, "
+            "image (alias for image-generation), or memory "
+            "(alias for memory-embedding)."
+        ),
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    config_path: Path | None = typer.Option(
+        None,
+        "--config",
+        help="Accepted for copyable setup paths.",
+    ),
+) -> None:
+    """List onboarding setup options for every configurable section.
+
+    Aliases: image (alias for image-generation), memory (alias for memory-embedding).
+    """
+    config_arg = _config_cli_arg(config_path)
+    try:
+        payload = setup_catalog_payload(section or None)
+    except ValueError as exc:
+        error_console.print(f"[red]Error:[/red] {markup_escape(str(exc))}")
+        raise typer.Exit(code=2) from exc
+
+    if json_output:
+        print_json(payload)
+        return
+
+    if section and len(payload) == 1:
+        name, value = next(iter(payload.items()))
+        _print_focused_catalog(name, value, config_arg)
+        return
+
+    table = Table(title="OpenSquilla setup catalog")
+    table.add_column("Section")
+    table.add_column("Options", justify="right")
+    table.add_column("Open section", overflow="fold")
+    for name, value in payload.items():
+        table.add_row(
+            _CATALOG_TITLES.get(name, name),
+            str(_catalog_count(value)),
+            _catalog_section_command(name, config_arg),
+        )
+    console.print(table)
+    console.print("Open a section for option-specific Try commands:")
+    for name in payload:
+        title = _CATALOG_TITLES.get(name, name)
+        _print_catalog_line(f"  {title}: {_catalog_section_command(name, config_arg)}")
+    console.print(
+        "Tip: start with `opensquilla onboard catalog providers` for the required "
+        "text provider."
+    )
 
 
 @onboard_app.command("status")
@@ -200,78 +949,238 @@ def onboard_status_command(
     config_path: Path | None = typer.Option(None, "--config", help="Override config path."),
 ) -> None:
     """Print readiness of every onboarding section without mutating state."""
-    cfg = load_config(config_path)
+    cfg = _load_config_for_cli(config_path)
     status = get_onboarding_status(cfg)
 
     if json_output:
         typer.echo(_json.dumps(_status_payload(status), ensure_ascii=False))
         return
 
-    table = Table(title="Onboarding readiness", show_header=True)
+    console.print(banner_panel("OpenSquilla Setup Cockpit", _status_cockpit_summary(status)))
+    table = Table(title="OpenSquilla setup readiness", show_header=True)
     table.add_column("Section")
+    table.add_column("Scope")
     table.add_column("Status")
     table.add_column("Detail")
     for name, state in status.sections.items():
-        style = _STATUS_STYLE.get(state, "")
-        detail = ""
-        if name == "llm":
-            detail = status.llm_source
-        elif name == "image_generation" and status.image_generation_provider:
-            detail = (
-                f"{status.image_generation_provider} "
-                f"({status.image_generation_source})"
-            ).strip()
-        elif name == "channels":
-            detail = f"{status.channel_count} configured"
+        display = _section_status_display(status, name)
+        style = _section_status_style(state, display)
         table.add_row(
-            name,
-            f"[{style}]{state.value}[/]" if style else state.value,
-            detail,
+            _section_label(status, name),
+            _section_scope(status, name),
+            f"[{style}]{display}[/]" if style else display,
+            _section_detail(status, name),
         )
     console.print(table)
+    console.print("[dim]Action guide:[/]")
+    console.print("[dim]  Fix: blocked or action-required[/]")
+    console.print("[dim]  Review: ready[/]")
+    console.print("[dim]  Configure: optional later[/]")
     console.print(
-        f"[bold]Needs onboarding:[/] "
-        f"{'yes' if status.needs_onboarding else 'no'}"
+        f"[bold]OpenSquilla ready:[/] "
+        f"{'no' if status.needs_onboarding else 'yes'}"
     )
     if status.needs_onboarding:
-        command = f"opensquilla onboard --if-needed{_config_cli_arg(config_path)}"
+        paths = _status_setup_paths(status, cfg, config_path)
+        fix_paths = _missing_env_paths(status)
+        if fix_paths:
+            console.print("[bold]Fix now:[/]")
+            for label, command, suffix in fix_paths:
+                _print_status_path(label, command, suffix)
+            setup_paths = paths[len(fix_paths) :]
+            if setup_paths:
+                console.print("[bold]Setup paths:[/]")
+                for label, command, suffix in setup_paths:
+                    _print_status_path(label, command, suffix)
+        else:
+            recommended_label, recommended_command, recommended_suffix = paths[0]
+            console.print("[bold]Recommended next move:[/]")
+            _print_status_path(
+                recommended_label,
+                recommended_command,
+                recommended_suffix,
+            )
+            alternatives = paths[1:]
+            if alternatives:
+                console.print("[bold]Setup paths:[/]")
+                for label, command, suffix in alternatives:
+                    _print_status_path(label, command, suffix)
         console.print(
-            f"  [dim]Run[/] [{ACCENT_SOFT}]{markup_escape(command)}[/] "
-            f"[dim]to address:[/] "
+            f"  [dim]Addressing:[/] "
             f"{markup_escape(_format_missing_sections(status))}"
         )
+    elif _optional_action_sections(status):
+        console.print("[bold]Optional next moves:[/]")
+        for label, command, suffix in _optional_setup_paths(status, cfg, config_path):
+            _print_status_path(label, command, suffix)
+    else:
+        console.print("[bold]Ready next moves:[/]")
+        for label, command, suffix in _ready_setup_paths(cfg, config_path):
+            _print_status_path(label, command, suffix)
 
 
+@onboard_app.command("configure")
 def configure_command(
     section_arg: str = typer.Argument(
         "",
-        help="provider | router | channels | search | image-generation | memory-embedding",
+        metavar="SECTION",
+        help=(
+            "Section to configure: provider, router, channels, search, "
+            "image (alias for image-generation), or memory "
+            "(alias for memory-embedding)."
+        ),
     ),
     section: str = typer.Option(
-        "", "--section",
-        help="provider | router | channels | search | image-generation | memory-embedding",
+        "",
+        "--section",
+        help=(
+            "Section to configure: provider, router, channels, search, "
+            "image (alias for image-generation), or memory "
+            "(alias for memory-embedding)."
+        ),
+        rich_help_panel="Target section",
     ),
-    provider: str = typer.Option("", "--provider"),
-    model: str = typer.Option("", "--model"),
-    api_key: str = typer.Option("", "--api-key"),
-    api_key_env: str = typer.Option("", "--api-key-env"),
-    base_url: str = typer.Option("", "--base-url"),
-    router: str = typer.Option("", "--router", help="recommended | openrouter-mix | disabled"),
-    search_provider: str = typer.Option("", "--search-provider"),
-    max_results: int = typer.Option(5, "--max-results"),
-    channel_type: str = typer.Option("", "--channel-type"),
-    name: str = typer.Option("", "--name"),
-    token: str = typer.Option("", "--token"),
+    provider: str = typer.Option(
+        "",
+        "--provider",
+        help="Text provider id for provider setup.",
+        rich_help_panel="Text provider",
+    ),
+    model: str = typer.Option(
+        "",
+        "--model",
+        help="Model id for provider or remote memory embedding.",
+        rich_help_panel="Shared keys and endpoints",
+    ),
+    api_key: str = typer.Option(
+        "",
+        "--api-key",
+        help="API key for provider, search, image generation, or memory embedding.",
+        rich_help_panel="Shared keys and endpoints",
+    ),
+    api_key_env: str = typer.Option(
+        "",
+        "--api-key-env",
+        help="Read that capability key from this environment variable.",
+        rich_help_panel="Shared keys and endpoints",
+    ),
+    base_url: str = typer.Option(
+        "",
+        "--base-url",
+        help="Custom upstream base URL for provider, image, or remote memory.",
+        rich_help_panel="Shared keys and endpoints",
+    ),
+    proxy: str = typer.Option(
+        "",
+        "--proxy",
+        help="Explicit HTTP proxy URL for provider or search upstream calls.",
+        rich_help_panel="Shared keys and endpoints",
+    ),
+    router: str = typer.Option(
+        "",
+        "--router",
+        help="recommended | openrouter-mix | disabled",
+        rich_help_panel="Router",
+    ),
+    default_tier: str = typer.Option(
+        "",
+        "--default-tier",
+        help="Default router text tier: t0, t1, t2, or t3.",
+        rich_help_panel="Router",
+    ),
+    search_provider: str = typer.Option(
+        "",
+        "--search-provider",
+        help="Search provider id.",
+        rich_help_panel="Search",
+    ),
+    max_results: int = typer.Option(
+        5,
+        "--max-results",
+        help="Default Web search result limit.",
+        rich_help_panel="Search",
+    ),
+    use_env_proxy: bool = typer.Option(
+        False,
+        "--use-env-proxy/--no-use-env-proxy",
+        help="Let Web search use HTTP(S)_PROXY from the gateway environment.",
+        rich_help_panel="Search",
+    ),
+    fallback_policy: str = typer.Option(
+        "off",
+        "--fallback-policy",
+        help="Search fallback policy: off or network.",
+        rich_help_panel="Search",
+    ),
+    diagnostics: bool = typer.Option(
+        False,
+        "--diagnostics/--no-diagnostics",
+        help="Include search provider attempt/error details for troubleshooting.",
+        rich_help_panel="Search",
+    ),
+    channel_type: str = typer.Option(
+        "",
+        "--channel-type",
+        help="Channel type such as slack, discord, feishu.",
+        rich_help_panel="Channels",
+    ),
+    name: str = typer.Option(
+        "",
+        "--name",
+        help="Channel instance name.",
+        rich_help_panel="Channels",
+    ),
+    token: str = typer.Option(
+        "",
+        "--token",
+        help="Channel token or bot secret.",
+        rich_help_panel="Channels",
+    ),
     fields: list[str] = typer.Option(
-        [], "--field", "-f", help="Repeatable key=value channel field."
+        [],
+        "--field",
+        "-f",
+        help="Repeatable key=value channel field.",
+        rich_help_panel="Channels",
     ),
-    image_provider: str = typer.Option("", "--image-provider"),
-    primary: str = typer.Option("", "--primary"),
-    memory_provider: str = typer.Option("", "--memory-provider"),
-    onnx_dir: str = typer.Option("", "--onnx-dir"),
-    config_path: Path | None = typer.Option(None, "--config", help="Override config path."),
+    image_provider: str = typer.Option(
+        "",
+        "--image-provider",
+        help="Image provider id.",
+        rich_help_panel="Image generation",
+    ),
+    image_enabled: bool = typer.Option(
+        True,
+        "--image-enabled/--no-image-enabled",
+        help="Enable or disable image generation.",
+        rich_help_panel="Image generation",
+    ),
+    primary: str = typer.Option(
+        "",
+        "--primary",
+        help="Image model id.",
+        rich_help_panel="Image generation",
+    ),
+    memory_provider: str = typer.Option(
+        "",
+        "--memory-provider",
+        help="Memory embedding provider.",
+        rich_help_panel="Memory embedding",
+    ),
+    onnx_dir: str = typer.Option(
+        "",
+        "--onnx-dir",
+        help="Local embedding ONNX model directory.",
+        rich_help_panel="Memory embedding",
+    ),
+    config_path: Path | None = typer.Option(
+        None,
+        "--config",
+        help="Override config path.",
+        rich_help_panel="Global",
+    ),
 ) -> None:
-    """Reconfigure a section (providers/channels/search/image-generation)."""
+    """Reconfigure provider, router, channels, search, image generation, or memory."""
     selected = section or section_arg
     if selected:
         from opensquilla.onboarding.setup_engine import SetupEngine
@@ -288,18 +1197,19 @@ def configure_command(
                         "apiKey": api_key,
                         "apiKeyEnv": api_key_env,
                         "baseUrl": base_url,
+                        "proxy": proxy,
                     },
                 )
                 result = engine.persist()
                 _print_saved_path(result.path)
-                _print_env_reference_warnings(load_config(result.path))
+                _print_env_reference_warnings(_load_config_for_cli(result.path))
                 return
             if normalized == "router" and router:
                 engine = SetupEngine(path=config_path)
-                engine.apply("router", {"mode": router})
+                engine.apply("router", {"mode": router, "defaultTier": default_tier})
                 result = engine.persist()
                 _print_saved_path(result.path)
-                _print_env_reference_warnings(load_config(result.path))
+                _print_env_reference_warnings(_load_config_for_cli(result.path))
                 return
             if normalized == "search" and search_provider:
                 engine = SetupEngine(path=config_path)
@@ -310,11 +1220,15 @@ def configure_command(
                         "apiKey": api_key,
                         "apiKeyEnv": api_key_env,
                         "maxResults": max_results,
+                        "proxy": proxy,
+                        "useEnvProxy": use_env_proxy,
+                        "fallbackPolicy": fallback_policy,
+                        "diagnostics": diagnostics,
                     },
                 )
                 result = engine.persist()
                 _print_saved_path(result.path)
-                _print_env_reference_warnings(load_config(result.path))
+                _print_env_reference_warnings(_load_config_for_cli(result.path))
                 return
             if normalized in {"channel", "channels"} and channel_type and name:
                 from opensquilla.cli.channel_fields import (
@@ -330,7 +1244,9 @@ def configure_command(
                 result = engine.persist()
                 _print_saved_path(result.path)
                 return
-            if normalized in {"image-generation", "image_generation"} and image_provider:
+            if normalized in IMAGE_GENERATION_SECTION_ALIASES and (
+                image_provider or not image_enabled
+            ):
                 engine = SetupEngine(path=config_path)
                 engine.apply(
                     "image-generation",
@@ -340,13 +1256,14 @@ def configure_command(
                         "apiKey": api_key,
                         "apiKeyEnv": api_key_env,
                         "baseUrl": base_url,
-                        "enabled": True,
+                        "enabled": image_enabled,
                     },
                 )
                 result = engine.persist()
                 _print_saved_path(result.path)
+                _print_env_reference_warnings(_load_config_for_cli(result.path))
                 return
-            if normalized in {"memory-embedding", "memory_embedding"} and memory_provider:
+            if normalized in MEMORY_EMBEDDING_SECTION_ALIASES and memory_provider:
                 engine = SetupEngine(path=config_path)
                 engine.apply(
                     "memory-embedding",
@@ -354,13 +1271,17 @@ def configure_command(
                         "providerId": memory_provider,
                         "model": model,
                         "apiKey": api_key,
+                        "apiKeyEnv": api_key_env,
                         "baseUrl": base_url,
                         "onnxDir": onnx_dir,
                     },
                 )
                 result = engine.persist()
                 _print_saved_path(result.path)
+                _print_env_reference_warnings(_load_config_for_cli(result.path))
                 return
+        except (OSError, tomllib.TOMLDecodeError, ValidationError) as exc:
+            _exit_config_load_error(exc, config_path)
         except (KeyError, TypeError, ValueError) as exc:
             error_console.print(f"[red]Error:[/red] {markup_escape(exc)}")
             raise typer.Exit(code=2) from exc

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -409,6 +409,7 @@ class MemoryEmbeddingRemoteConfig(BaseModel):
     """OpenAI-compatible remote memory embedding settings."""
 
     api_key: str | None = None
+    api_key_env: str | None = None
     base_url: str | None = None
     headers: dict[str, str] = Field(default_factory=dict)
     model: str | None = None
@@ -1768,7 +1769,10 @@ class GatewayConfig(BaseSettings):
                 cfg.config_path = str(path)
                 return cfg
 
-        return cls()
+        cfg = cls()
+        if config_path:
+            cfg.config_path = str(Path(config_path))
+        return cfg
 
 
 # --- bind-address resolution ----------------------------------------------

--- a/src/opensquilla/gateway/rpc_onboarding.py
+++ b/src/opensquilla/gateway/rpc_onboarding.py
@@ -134,6 +134,7 @@ def _persist(ctx: RpcContext, new_cfg: Any, *, restart_required: bool) -> str:
 
 
 def _status_payload(ctx: RpcContext) -> dict[str, Any]:
+    from opensquilla.onboarding.next_steps import env_recovery_commands
     from opensquilla.onboarding.status import get_onboarding_status
 
     cfg = _active_config(ctx)
@@ -143,15 +144,27 @@ def _status_payload(ctx: RpcContext) -> dict[str, Any]:
         "hasConfig": s.has_config,
         "llmConfigured": s.llm_configured,
         "llmSource": s.llm_source,
+        "llmEnvKey": s.llm_env_key,
         "imageGenerationConfigured": s.image_generation_configured,
         "imageGenerationEnabled": s.image_generation_enabled,
         "imageGenerationSource": s.image_generation_source,
         "imageGenerationProvider": s.image_generation_provider,
         "imageGenerationPrimary": s.image_generation_primary,
+        "imageGenerationEnvKey": s.image_generation_env_key,
         "searchConfigured": s.search_configured,
+        "searchProvider": s.search_provider,
+        "searchSource": s.search_source,
+        "searchEnvKey": s.search_env_key,
+        "memoryEmbeddingConfigured": s.memory_embedding_configured,
+        "memoryEmbeddingProvider": s.memory_embedding_provider,
+        "memoryEmbeddingSource": s.memory_embedding_source,
+        "memoryEmbeddingEnvKey": s.memory_embedding_env_key,
         "channelCount": s.channel_count,
         "channelsConfigured": s.channels_configured,
         "needsOnboarding": s.needs_onboarding,
+        "sections": {name: state.value for name, state in s.sections.items()},
+        "sectionDetails": s.section_details,
+        "envRecoveryCommands": env_recovery_commands(s),
         "warnings": list(s.warnings),
     }
 
@@ -167,6 +180,9 @@ async def _onboarding_catalog(params: Any, ctx: RpcContext) -> dict[str, Any]:
     from opensquilla.onboarding.image_generation_specs import (
         image_generation_provider_catalog_payload,
     )
+    from opensquilla.onboarding.memory_embedding_specs import (
+        memory_embedding_provider_catalog_payload,
+    )
     from opensquilla.onboarding.provider_specs import provider_catalog_payload
     from opensquilla.onboarding.router_specs import router_catalog_payload
     from opensquilla.onboarding.search_specs import search_provider_catalog_payload
@@ -176,44 +192,7 @@ async def _onboarding_catalog(params: Any, ctx: RpcContext) -> dict[str, Any]:
         "channels": channel_catalog_payload(),
         "searchProviders": search_provider_catalog_payload(),
         "routerProfiles": router_catalog_payload(),
-        "memoryEmbeddingProviders": [
-            {
-                "providerId": "auto",
-                "label": "Auto (local BGE first)",
-                "requiresApiKey": False,
-                "requiresBaseUrl": False,
-            },
-            {
-                "providerId": "local",
-                "label": "Bundled BGE-small",
-                "requiresApiKey": False,
-                "requiresBaseUrl": False,
-            },
-            {
-                "providerId": "openai",
-                "label": "OpenAI",
-                "requiresApiKey": True,
-                "requiresBaseUrl": False,
-            },
-            {
-                "providerId": "openai-compatible",
-                "label": "OpenAI-compatible remote",
-                "requiresApiKey": True,
-                "requiresBaseUrl": False,
-            },
-            {
-                "providerId": "ollama",
-                "label": "Ollama",
-                "requiresApiKey": False,
-                "requiresBaseUrl": False,
-            },
-            {
-                "providerId": "none",
-                "label": "FTS-only",
-                "requiresApiKey": False,
-                "requiresBaseUrl": False,
-            },
-        ],
+        "memoryEmbeddingProviders": memory_embedding_provider_catalog_payload(),
         "imageGenerationProviders": image_generation_provider_catalog_payload(),
     }
 
@@ -369,6 +348,7 @@ async def _memory_embedding_configure(params: Any, ctx: RpcContext) -> dict[str,
         provider=provider,
         model=params.get("model", "") if isinstance(params, dict) else "",
         api_key=params.get("apiKey", "") if isinstance(params, dict) else "",
+        api_key_env=params.get("apiKeyEnv", "") if isinstance(params, dict) else "",
         base_url=params.get("baseUrl", "") if isinstance(params, dict) else "",
         onnx_dir=params.get("onnxDir", "") if isinstance(params, dict) else "",
     )

--- a/src/opensquilla/gateway/static/css/views/setup.css
+++ b/src/opensquilla/gateway/static/css/views/setup.css
@@ -14,6 +14,10 @@
   margin: 0 auto;
 }
 
+.setup [hidden] {
+  display: none !important;
+}
+
 /* Top hairline rail — a tuned scan line introducing the surface. */
 .setup::before {
   content: "";
@@ -223,6 +227,32 @@
   line-height: 1.45;
 }
 
+.setup-warning__command {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 34px;
+  gap: var(--sp-2);
+  align-items: stretch;
+  margin-top: var(--sp-3);
+}
+
+.setup-warning__command code {
+  min-width: 0;
+  overflow-x: auto;
+  border: 1px solid color-mix(in srgb, var(--warn) 35%, var(--border));
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text);
+  padding: 9px 10px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.setup-mini__env-command {
+  margin-top: 0;
+}
+
 /* ─── Stepper — connected rail with calibrated marks ─────────────────── */
 
 .setup-stepper {
@@ -245,12 +275,14 @@
 }
 
 .setup-stepper__item {
-  display: flex;
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr);
+  grid-template-rows: auto auto;
   align-items: center;
   justify-content: center;
   gap: 10px;
   min-height: 52px;
-  padding: 0 12px;
+  padding: 8px 12px;
   border: 0;
   background: var(--bg-surface);
   color: var(--text-muted);
@@ -265,9 +297,8 @@
     color var(--transition),
     background var(--transition);
   position: relative;
-  white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
+  text-align: left;
 }
 /* Each step gets a ground-tick at the rail — quiet, until active. */
 .setup-stepper__item::after {
@@ -290,7 +321,7 @@
   background: var(--border);
 }
 
-.setup-stepper__item span {
+.setup-stepper__num {
   display: inline-grid;
   place-items: center;
   width: 22px;
@@ -305,11 +336,36 @@
   transition: border-color var(--transition), color var(--transition), background var(--transition);
 }
 
+.setup-stepper__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.setup-stepper__state {
+  grid-column: 2;
+  min-width: 0;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1.1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.setup-stepper__state.is-ok { color: var(--ok); }
+.setup-stepper__state.is-warn { color: var(--warn); }
+
 .setup-stepper__item:hover {
   background: color-mix(in srgb, var(--accent) 4%, var(--bg-surface));
   color: var(--text);
 }
-.setup-stepper__item:hover span {
+.setup-stepper__item:hover .setup-stepper__num {
   border-color: var(--border-strong);
 }
 
@@ -322,7 +378,7 @@
   width: 56px;
   box-shadow: 0 0 14px color-mix(in srgb, var(--accent) 70%, transparent);
 }
-.setup-stepper__item.is-active span {
+.setup-stepper__item.is-active .setup-stepper__num {
   border-color: var(--accent);
   color: var(--accent-foreground);
   background: var(--accent);
@@ -395,8 +451,73 @@
 .setup-channel-fields,
 .setup-mini {
   display: grid;
+  align-content: start;
   gap: var(--sp-3);
   min-width: 0;
+}
+
+.setup-provider-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  min-width: 0;
+  min-height: 34px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-surface) 84%, var(--bg));
+  color: var(--text);
+}
+
+.setup-provider-meta span,
+.setup-provider-meta strong {
+  min-width: 0;
+  font-size: var(--fs-xs);
+  line-height: 1.35;
+}
+
+.setup-provider-meta span {
+  color: var(--text-dim);
+}
+
+.setup-provider-meta strong {
+  font-weight: 750;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.setup-provider-meta__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 22px;
+  padding: 2px 8px;
+  border: 1px solid color-mix(in srgb, var(--text-muted) 24%, var(--border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bg-surface) 70%, var(--bg));
+  color: var(--text-muted);
+  font-weight: 800;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.setup-provider-meta__badge.is-ready {
+  border-color: color-mix(in srgb, var(--ok) 48%, var(--border));
+  background: color-mix(in srgb, var(--ok) 10%, var(--bg-surface));
+  color: var(--ok);
+}
+
+.setup-provider-meta__badge.is-direct {
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg-surface));
+  color: var(--accent);
+}
+
+.setup-provider-meta__badge.is-neutral {
+  border-color: color-mix(in srgb, var(--text-muted) 24%, var(--border));
+  background: color-mix(in srgb, var(--bg-surface) 70%, var(--bg));
+  color: var(--text-muted);
 }
 
 .setup-mini h4 {
@@ -404,6 +525,149 @@
   font-weight: 700;
   letter-spacing: -0.015em;
   margin-bottom: 2px;
+}
+
+.setup-mini__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.setup-mini__advanced {
+  display: block;
+  min-width: 0;
+  padding-top: var(--sp-2);
+  border-top: 1px dashed var(--border);
+}
+
+.setup-mini__advanced > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  min-height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-surface) 82%, var(--bg));
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  list-style: none;
+  text-transform: uppercase;
+  transition:
+    border-color var(--transition),
+    background var(--transition),
+    color var(--transition);
+}
+
+.setup-mini__advanced > summary::-webkit-details-marker { display: none; }
+.setup-mini__advanced > summary::after {
+  content: "+";
+  color: var(--accent);
+  font-size: 13px;
+  letter-spacing: 0;
+}
+details.setup-mini__advanced[open] > summary {
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
+  color: var(--text);
+}
+details.setup-mini__advanced[open] > summary::after { content: "-"; }
+.setup-mini__advanced > summary:hover {
+  border-color: var(--border-strong);
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg-surface));
+  color: var(--text);
+}
+.setup-mini__advanced > summary:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.setup-mini__advanced-body {
+  display: grid;
+  gap: var(--sp-3);
+  min-width: 0;
+  padding-top: var(--sp-3);
+}
+
+.setup-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 24px;
+  padding: 0 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.setup-badge.is-ok {
+  border-color: color-mix(in srgb, var(--ok) 45%, var(--border));
+  color: var(--ok);
+}
+.setup-badge.is-warn {
+  border-color: color-mix(in srgb, var(--warn) 55%, var(--border));
+  color: var(--warn);
+}
+.setup-badge.is-muted {
+  color: var(--text-dim);
+}
+
+.setup-need-list {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  padding: 2px 0;
+}
+
+.setup-need-list > span {
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.setup-need-list ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.setup-need-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  line-height: 1.45;
+}
+
+.setup-need-list li::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  margin-top: 0.45em;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
 }
 
 .setup-form label,
@@ -419,6 +683,16 @@
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
+}
+
+.setup-form label.is-disabled,
+.setup-mini label.is-disabled {
+  color: var(--text-dim);
+}
+
+.setup-form label.is-disabled input,
+.setup-mini label.is-disabled input {
+  opacity: 0.72;
 }
 
 .setup-form input,
@@ -508,7 +782,7 @@
 .setup-extras,
 .setup-channel-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   gap: var(--sp-4);
 }
 
@@ -642,9 +916,155 @@
   letter-spacing: 0;
 }
 
+.setup-readiness {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+  gap: var(--sp-2);
+}
+
+.setup-readiness__group {
+  display: grid;
+  align-content: start;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.setup-readiness__group h4 {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.setup-readiness__row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto auto;
+  gap: 10px;
+  align-items: center;
+  min-height: 38px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  font-size: var(--fs-xs);
+}
+
+.setup-readiness__row strong,
+.setup-readiness__row small {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.setup-readiness__row small { color: var(--text-muted); }
+.setup-readiness__row.is-ok strong { color: var(--ok); }
+.setup-readiness__row.is-warn strong { color: var(--warn); }
+.setup-readiness__row.is-muted strong { color: var(--text-muted); }
+
+.setup-readiness__action {
+  min-height: 28px;
+  padding: 0 10px;
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border));
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg));
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    border-color var(--transition),
+    background var(--transition),
+    transform 160ms var(--ease-press);
+}
+
+.setup-readiness__action:hover {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg));
+}
+
+.setup-readiness__action:active {
+  transform: translateY(1px);
+}
+
+.setup-readiness__action:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.setup-readiness__detail {
+  grid-column: 1 / -1;
+  min-width: 0;
+  color: var(--text-muted);
+  font-style: normal;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
 .setup-cli {
   display: grid;
+  gap: 12px;
+}
+
+.setup-cli__group {
+  display: grid;
   gap: 8px;
+  min-width: 0;
+}
+
+.setup-cli__group + .setup-cli__group {
+  padding-top: 12px;
+  border-top: 1px dashed var(--border);
+}
+
+.setup-cli__group-head {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.setup-cli__group-head h4 {
+  margin: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 750;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.setup-cli__row {
+  align-items: stretch;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(116px, 0.34fr) minmax(0, 1fr) 34px;
+}
+
+.setup-cli__label {
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  display: inline-flex;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  justify-content: center;
+  letter-spacing: 0;
+  min-height: 38px;
+  padding: 0 10px;
+  text-align: center;
+  text-transform: uppercase;
 }
 
 .setup-cli code {
@@ -667,6 +1087,33 @@
   content: "$ ";
   color: var(--accent);
   font-weight: 700;
+}
+
+.setup-cli__copy {
+  align-items: center;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  height: 100%;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  width: 34px;
+}
+
+.setup-cli__copy:hover {
+  background: var(--bg-panel);
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.setup-cli__copy svg {
+  height: 14px;
+  width: 14px;
 }
 
 .setup-actions {
@@ -734,6 +1181,26 @@
     0 2px 8px -4px color-mix(in srgb, var(--accent) 40%, transparent);
 }
 
+.setup-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+  transform: none;
+  box-shadow: none;
+}
+
+.setup-btn:disabled:hover,
+.setup-btn:disabled:active {
+  border-color: var(--border);
+  background: var(--bg);
+  transform: none;
+}
+
+.setup-btn--primary:disabled:hover,
+.setup-btn--primary:disabled:active {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .setup-btn,
   .setup-stepper__item,
@@ -771,7 +1238,8 @@
   .setup-router-toolbar,
   .setup-extras,
   .setup-channel-grid,
-  .setup-summary {
+  .setup-summary,
+  .setup-readiness {
     grid-template-columns: 1fr;
   }
 
@@ -782,6 +1250,28 @@
     display: none;
   }
   .setup-stepper::after { display: none; }
+
+  .setup-readiness__row {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .setup-readiness__row strong {
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: end;
+  }
+
+  .setup-readiness__row small {
+    grid-column: 2;
+    grid-row: 2;
+    justify-self: end;
+  }
+
+  .setup-readiness__action {
+    grid-column: 1;
+    grid-row: 2;
+    justify-self: start;
+  }
 }
 
 @media (max-width: 560px) {
@@ -799,5 +1289,14 @@
 
   .setup-btn {
     flex: 1 1 150px;
+  }
+
+  .setup-cli__row {
+    grid-template-columns: minmax(0, 1fr) 34px;
+  }
+
+  .setup-cli__label {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
   }
 }

--- a/src/opensquilla/gateway/static/js/views/channels.js
+++ b/src/opensquilla/gateway/static/js/views/channels.js
@@ -174,7 +174,7 @@ const ChannelsView = (() => {
         <div class="ch-empty__actions">
           <button class="btn btn--primary" id="ch-guided-setup" type="button">${icons.config()}<span>Guided setup</span></button>
         </div>
-        <code class="ch-empty__code">opensquilla configure --section channels · opensquilla channels list</code>
+        <code class="ch-empty__code">opensquilla onboard configure channels · opensquilla channels list</code>
       </div>`;
       _el.querySelector('#ch-guided-setup')?.addEventListener('click', () => Router.navigate('/setup'));
       return;
@@ -223,7 +223,7 @@ const ChannelsView = (() => {
 
   function _statusHint({ status, isRunning, isDead, enabled, name }) {
     const safeName = name || '<name>';
-    if (!enabled) return `Disabled in config — gateway restart required after re-enabling. Run \`opensquilla configure --section channels\` to change.`;
+    if (!enabled) return `Disabled in config — gateway restart required after re-enabling. Run \`opensquilla onboard configure channels\` to change.`;
     if (isDead) return `Adapter is dead. Inspect gateway logs, then \`opensquilla channels restart ${safeName}\`.`;
     if (isRunning) return 'Adapter is live in the current gateway process.';
     if (status === 'restarting') return 'Adapter is restarting after dispatch errors.';

--- a/src/opensquilla/gateway/static/js/views/setup.js
+++ b/src/opensquilla/gateway/static/js/views/setup.js
@@ -5,7 +5,7 @@ const SetupView = (() => {
     { id: 'provider', label: 'Provider' },
     { id: 'router', label: 'Router Tiers' },
     { id: 'channels', label: 'Channels' },
-    { id: 'extras', label: 'Extras' },
+    { id: 'extras', label: 'Capabilities' },
     { id: 'finish', label: 'Finish' },
   ];
   const TEXT_TIERS = ['t0', 't1', 't2', 't3'];
@@ -14,6 +14,13 @@ const SetupView = (() => {
     t1: 'Balanced default (t1)',
     t2: 'Stronger reasoning (t2)',
     t3: 'Max quality (t3)',
+  };
+  const READINESS_LABELS = {
+    ok: 'Ready',
+    optional: 'Optional',
+    missing: 'Missing',
+    degraded: 'Needs action',
+    unknown: 'Check',
   };
 
   let _el = null;
@@ -25,6 +32,7 @@ const SetupView = (() => {
   let _step = 'provider';
   let _channelType = '';
   let _pollTimer = null;
+  let _hasAutoSelectedStep = false;
   const _drafts = new Map();
   let _channelDirty = false;
 
@@ -33,6 +41,7 @@ const SetupView = (() => {
     _rpc = App.getRpc();
     await _rpc.waitForConnection();
     await _load();
+    _selectInitialStep();
     _draw();
     _startChannelPolling();
   }
@@ -56,27 +65,26 @@ const SetupView = (() => {
 
   function _draw() {
     if (!_el) return;
+    const setupAction = _hasSetupAction();
     _el.innerHTML = `
       <section class="setup">
         <header class="setup__head">
           <div>
             <p class="setup__kicker">OpenSquilla setup</p>
-            <h2>Core runtime configuration</h2>
+            <h2>${setupAction ? 'Action needed' : 'Ready to run'}</h2>
           </div>
           <div class="setup__head-aside">
             <button type="button" class="setup__exit" data-exit-setup aria-label="Exit setup and return to Overview">
               <span aria-hidden="true">←</span><span>Exit setup</span>
             </button>
-            <div class="setup__status ${_status.needsOnboarding ? 'is-warn' : 'is-ok'}">
-              ${_status.needsOnboarding ? 'Action needed' : 'Configured'}
+            <div class="setup__status ${setupAction ? 'is-warn' : 'is-ok'}">
+              ${setupAction ? 'Action needed' : 'Ready'}
             </div>
             ${_renderOnboardingReasons()}
           </div>
         </header>
         <nav class="setup-stepper" aria-label="Setup steps">
-          ${STEPS.map((s, idx) => `<button class="setup-stepper__item ${s.id === _step ? 'is-active' : ''}" data-step="${s.id}">
-            <span>${idx + 1}</span>${_esc(s.label)}
-          </button>`).join('')}
+          ${STEPS.map(_renderStepButton).join('')}
         </nav>
         <div class="setup__body">${_renderCurrentStep()}</div>
       </section>`;
@@ -89,6 +97,67 @@ const SetupView = (() => {
     _bindStep();
   }
 
+  function _renderStepButton(s, idx) {
+    const status = _stepStatus(s.id);
+    return `<button class="setup-stepper__item ${s.id === _step ? 'is-active' : ''}" data-step="${_esc(s.id)}" aria-label="${_esc(`${s.label}: ${status.label}`)}">
+      <span class="setup-stepper__num">${idx + 1}</span>
+      <span class="setup-stepper__label">${_esc(s.label)}</span>
+      <small class="setup-stepper__state ${_esc(status.tone)}">${_esc(status.label)}</small>
+    </button>`;
+  }
+
+  function _stepStatus(stepId) {
+    const currentProvider = (_config.llm || {}).provider || '';
+    const hasSavedProvider = Boolean(currentProvider) && _status.hasConfig !== false;
+    if (stepId === 'provider') {
+      if (_providerEnvMissing()) return { label: 'Needs action', tone: 'is-warn' };
+      return _detailStepStatus((_status.sectionDetails || {}).llm || (_status.sectionDetails || {}).provider);
+    }
+    if (stepId === 'router' && !hasSavedProvider) {
+      return { label: 'Provider first', tone: 'is-muted' };
+    }
+    if (stepId === 'router') return _detailStepStatus((_status.sectionDetails || {}).router);
+    if (stepId === 'channels') return _detailStepStatus((_status.sectionDetails || {}).channels);
+    if (stepId === 'extras') {
+      return _aggregateStepStatus(['search', 'image_generation', 'memory_embedding']);
+    }
+    if (stepId === 'finish') {
+      return _hasSetupAction()
+        ? { label: 'Review', tone: 'is-warn' }
+        : { label: 'Ready', tone: 'is-ok' };
+    }
+    return { label: 'Review', tone: 'is-muted' };
+  }
+
+  function _aggregateStepStatus(sectionNames) {
+    const details = _status.sectionDetails || {};
+    const entries = sectionNames.map(name => details[name]).filter(Boolean);
+    if (entries.some(detail => _stepDetailNeedsAction(detail))) {
+      return { label: 'Needs action', tone: 'is-warn' };
+    }
+    if (entries.length && entries.every(detail => detail.status === 'ok')) {
+      return { label: 'Ready', tone: 'is-ok' };
+    }
+    return { label: 'Optional', tone: 'is-muted' };
+  }
+
+  function _detailStepStatus(detail) {
+    if (!detail) return { label: 'Review', tone: 'is-muted' };
+    if (_stepDetailNeedsAction(detail)) return { label: 'Needs action', tone: 'is-warn' };
+    if (detail.status === 'ok') return { label: 'Ready', tone: 'is-ok' };
+    return { label: READINESS_LABELS[detail.status] || 'Optional', tone: 'is-muted' };
+  }
+
+  function _stepDetailNeedsAction(detail) {
+    return Boolean(
+      detail
+      && (
+        detail.blocking || detail.actionRequired
+        || detail.status === 'missing' || detail.status === 'degraded'
+      )
+    );
+  }
+
   function _renderOnboardingReasons() {
     const reasons = _onboardingReasons();
     if (!reasons.length) return '';
@@ -98,21 +167,47 @@ const SetupView = (() => {
   }
 
   function _onboardingReasons() {
-    if (!_status.needsOnboarding) return [];
+    if (!_hasSetupAction()) return [];
     const reasons = [];
     const llm = _config.llm || {};
     if (_providerEnvMissing()) {
       reasons.push(`${_providerEnvKey()} is not visible`);
     } else if (!llm.provider || !llm.model) {
-      reasons.push('Provider action required');
+      reasons.push('Connect a model provider');
     }
-    if ((_status.channelCount || 0) === 0) {
-      reasons.push('No channels configured');
-    }
-    if (_status.imageGenerationEnabled !== false && _status.imageGenerationConfigured === false) {
-      reasons.push('Image generation needs a visible key');
-    }
+    const details = _status.sectionDetails || {};
+    Object.entries(details).forEach(([name, detail]) => {
+      if (!detail.blocking && !detail.actionRequired) return;
+      if ((name === 'llm' || name === 'provider') && detail.status === 'missing') {
+        if (!reasons.includes('Connect a model provider')) reasons.push('Connect a model provider');
+        return;
+      }
+      if ((name === 'llm' || name === 'provider') && reasons.length) return;
+      const reason = _setupActionReason(name, detail);
+      if (!reasons.includes(reason)) reasons.push(reason);
+    });
     return reasons.length ? reasons : ['Review setup sections for pending actions'];
+  }
+
+  function _setupActionReason(name, detail) {
+    const missingEnvPrefix = 'env key not visible: ';
+    const detailText = String(detail.detail || '');
+    if (detailText.startsWith(missingEnvPrefix)) {
+      const envKey = detailText.slice(missingEnvPrefix.length).trim();
+      if (envKey) return `${envKey} is not visible`;
+    }
+    return `${detail.label || name} setup needed`;
+  }
+
+  function _hasSetupAction() {
+    if (_status.needsOnboarding) return true;
+    const details = _status.sectionDetails || {};
+    return Object.values(details).some(detail => (
+      detail.blocking
+      || detail.actionRequired
+      || detail.status === 'missing'
+      || detail.status === 'degraded'
+    ));
   }
 
   function _renderCurrentStep() {
@@ -123,45 +218,181 @@ const SetupView = (() => {
     return _renderProviderStep();
   }
 
+  function _selectInitialStep() {
+    if (_hasAutoSelectedStep) return;
+    _step = _initialStepFromStatus();
+    _hasAutoSelectedStep = true;
+  }
+
+  function _initialStepFromStatus() {
+    const details = _status.sectionDetails || {};
+    const sectionSteps = [
+      ['llm', 'provider'],
+      ['router', 'router'],
+      ['channels', 'channels'],
+      ['search', 'extras'],
+      ['image_generation', 'extras'],
+      ['memory_embedding', 'extras'],
+    ];
+    const entry = sectionSteps.find(([section]) => {
+      const detail = details[section] || {};
+      return (
+        detail.blocking
+        || detail.actionRequired
+        || detail.status === 'missing'
+        || detail.status === 'degraded'
+      );
+    });
+    if (entry) return entry[1];
+    if (_status.needsOnboarding === false) return 'finish';
+    return 'provider';
+  }
+
+  function _renderNeedList(items, label, dataAttr = '') {
+    const needs = (items || []).filter(Boolean);
+    const attr = dataAttr ? ` ${dataAttr}` : '';
+    if (!needs.length) return `<div class="setup-need-list is-empty"${attr} hidden></div>`;
+    return `<div class="setup-need-list"${attr} aria-label="${_esc(label)}">
+      <span>${_esc(label)}</span>
+      <ul>${needs.map(item => `<li>${_esc(item)}</li>`).join('')}</ul>
+    </div>`;
+  }
+
+  function _credentialNeedList(items, envKey) {
+    const key = String(envKey || '').trim();
+    if (!key) return items || [];
+    return (items || []).map(item => {
+      if (/API key via [A-Z0-9_]+ or a one-time paste\./.test(item)) {
+        return `API key via ${key} or a one-time paste.`;
+      }
+      if (/Remote embedding API key or [A-Z0-9_]+ reference\./.test(item)) {
+        return `Remote embedding API key or ${key} reference.`;
+      }
+      return item;
+    });
+  }
+
+  function _memoryNeedList(spec, providerId, envKey) {
+    const items = (spec?.whatYouNeed || []).filter(Boolean);
+    if (providerId === 'auto' && !String(envKey || '').trim()) {
+      return items.filter(item => !/remote fallback credentials/i.test(item));
+    }
+    return spec?.requiresApiKey ? _credentialNeedList(items, envKey || spec.envKey) : items;
+  }
+
+  function _replaceNeedList(selector, items, label, dataAttr) {
+    const box = _el?.querySelector(selector);
+    if (box) box.outerHTML = _renderNeedList(items, label, dataAttr);
+  }
+
   function _renderProviderStep() {
     const providers = (_catalog.providers || []).filter(p => p.runtimeSupported);
     const current = (_config.llm || {});
-    const selected = current.provider || providers[0]?.providerId || 'openrouter';
-    const spec = providers.find(p => p.providerId === selected) || providers[0] || {};
+    const hasSavedProvider = (
+      Boolean(current.provider)
+      && _status.hasConfig !== false
+    );
+    const selected = hasSavedProvider ? current.provider : '';
+    const spec = selected ? providers.find(p => p.providerId === selected) || {} : {};
+    const providerSummary = hasSavedProvider
+      ? (spec.label || selected)
+      : `Choose from ${providers.length} supported providers`;
+    const values = selected ? _providerConfigFor(selected) : {};
+    const providerFields = spec.fields || [];
+    const providerCoreFields = providerFields.filter(field => !_isProviderAdvancedField(field, spec));
+    const providerAdvancedFields = providerFields.filter(field => _isProviderAdvancedField(field, spec));
+    const providerAdvancedOpen = _providerAdvancedOpen(providerAdvancedFields, values) ? ' open' : '';
+    const routerSupportTone = _providerRouterSupportTone(selected ? spec : null);
     return `
       <section class="setup-panel">
         <header class="setup-panel__head">
           <h3>Provider</h3>
-          <p>${_esc(current.provider || 'not configured')}</p>
+          <p data-provider-summary>${_esc(providerSummary)}</p>
         </header>
         <div class="setup-form">
           <label><span>Provider</span>
-            <select data-provider-select>
+            <select data-provider-select name="setup_provider">
+              <option value="" disabled${selected ? '' : ' selected'}>Choose a provider</option>
               ${providers.map(p => `<option value="${_esc(p.providerId)}"${p.providerId === selected ? ' selected' : ''}>${_esc(p.label)}</option>`).join('')}
             </select>
           </label>
+          <div class="setup-provider-meta" data-provider-router-support>
+            <span>SquillaRouter tiers</span>
+            <strong class="setup-provider-meta__badge ${_esc(routerSupportTone)}" data-provider-router-support-label>${_esc(_providerRouterSupportText(selected ? spec : null))}</strong>
+          </div>
+          ${_renderNeedList(selected ? spec.whatYouNeed : ['Choose a provider to see required fields.'], 'Provider needs', 'data-provider-needs')}
           <div class="setup-provider-fields">
-            ${_renderProviderFields(spec, current)}
+            ${_renderProviderFields(providerCoreFields, values)}
+          </div>
+          <div data-provider-advanced-wrap>
+            ${_renderProviderAdvancedFields(providerAdvancedFields, values, providerAdvancedOpen)}
           </div>
           ${_providerEnvWarning()}
           <div class="setup-actions">
-            <button class="setup-btn setup-btn--primary" data-save-provider>Save Provider</button>
-            <button class="setup-btn" data-next="router">Next</button>
+            <button class="setup-btn setup-btn--primary" data-save-provider${selected ? '' : ' disabled'}>Save Provider</button>
+            <button class="setup-btn" data-next="router"${selected ? '' : ' disabled'}>Next</button>
           </div>
         </div>
       </section>`;
   }
 
-  function _renderProviderFields(spec, current) {
-    return (spec.fields || []).map(field => {
-      const name = field.name;
-      let value = '';
-      if (name === 'model') value = current.model || field.default || '';
-      else if (name === 'base_url') value = current.base_url || field.default || '';
-      else if (name === 'proxy') value = current.proxy || '';
-      else if (name === 'api_key_env') value = current.api_key_env || (current.api_key ? '' : field.default || '');
+  function _providerRouterSupportText(spec) {
+    if (!spec || !spec.providerId) return 'choose provider';
+    return spec.routerSupported === true ? 'SquillaRouter ready' : 'Direct only';
+  }
+
+  function _providerRouterSupportTone(spec) {
+    if (!spec || !spec.providerId) return 'is-neutral';
+    return spec.routerSupported === true ? 'is-ready' : 'is-direct';
+  }
+
+  function _providerConfigFor(providerId) {
+    const current = _config.llm || {};
+    return current.provider === providerId ? current : {};
+  }
+
+  function _isProviderAdvancedField(field, spec) {
+    if (['base_url', 'proxy'].includes(field.name)) return true;
+    if (field.name === 'model') {
+      return spec.routerSupported === true && field.required !== true;
+    }
+    return false;
+  }
+
+  function _providerFieldValue(field, current) {
+    const name = field.name;
+    if (name === 'model') return current.model || field.default || '';
+    if (name === 'base_url') return current.base_url || field.default || '';
+    if (name === 'proxy') return current.proxy || '';
+    if (name === 'api_key_env') return current.api_key_env || (current.api_key ? '' : field.default || '');
+    return '';
+  }
+
+  function _providerAdvancedOpen(fields, current) {
+    return fields.some(field => {
+      if (field.required) return true;
+      const value = String(_providerFieldValue(field, current) || '').trim();
+      const defaultValue = String(field.default || '').trim();
+      if (defaultValue) return value !== defaultValue;
+      return value.length > 0;
+    });
+  }
+
+  function _renderProviderFields(fields, current) {
+    return (fields || []).map(field => {
+      const value = _providerFieldValue(field, current);
       return _fieldHtml(field, value, 'provider');
     }).join('');
+  }
+
+  function _renderProviderAdvancedFields(fields, current, openAttr = '') {
+    if (!fields.length) return '';
+    return `<details class="setup-mini__advanced" data-provider-advanced${openAttr}>
+      <summary>Advanced provider connection</summary>
+      <div class="setup-mini__advanced-body" aria-label="Provider connection">
+        ${_renderProviderFields(fields, current)}
+      </div>
+    </details>`;
   }
 
   function _providerEnvMissing() {
@@ -172,49 +403,105 @@ const SetupView = (() => {
     return ((_config.llm || {}).api_key_env || 'the selected API key environment variable');
   }
 
+  function _providerEnvRecoveryCommand() {
+    return _envRecoveryCommand('llm');
+  }
+
+  function _capabilityEnvRecoveryCommand(section) {
+    return _envRecoveryCommand(section);
+  }
+
+  function _envRecoveryCommand(section) {
+    const commands = Array.isArray(_status.envRecoveryCommands)
+      ? _status.envRecoveryCommands
+      : [];
+    const entry = commands.find(entry => entry && entry.section === section && entry.command);
+    return entry ? entry.command : '';
+  }
+
   function _providerEnvWarning() {
     if (!_providerEnvMissing()) return '';
     const envKey = _providerEnvKey();
-    return `<div class="setup-warning">${_esc(envKey)} is not visible to this gateway process. Set it before starting or restarting the gateway, or paste an API key instead.</div>`;
+    const command = _providerEnvRecoveryCommand();
+    const commandRow = command ? _renderProviderEnvCommand(command) : '';
+    return `<div class="setup-warning">
+      <div>${_esc(envKey)} is not visible to this gateway process. Set it before starting or restarting the gateway, or paste an API key instead.</div>
+      ${commandRow}
+    </div>`;
+  }
+
+  function _renderProviderEnvCommand(command) {
+    return _renderEnvRecoveryCommand(command, 'Copy set provider key command');
+  }
+
+  function _renderCapabilityEnvRecoveryCommand(section) {
+    const command = _capabilityEnvRecoveryCommand(section);
+    if (!command) return '';
+    const labels = {
+      search: 'Copy set search key command',
+      image_generation: 'Copy set image key command',
+      memory_embedding: 'Copy set memory key command',
+    };
+    return _renderEnvRecoveryCommand(
+      command,
+      labels[section] || 'Copy set environment key command',
+      'setup-warning__command setup-mini__env-command',
+    );
+  }
+
+  function _renderEnvRecoveryCommand(command, copyLabel, className = 'setup-warning__command') {
+    const safeCommand = _esc(command);
+    return `<div class="${_esc(className)}">
+      <code>${safeCommand}</code>
+      <button class="setup-cli__copy" type="button" data-setup-copy-command="${safeCommand}" title="${_esc(copyLabel)}" aria-label="${_esc(copyLabel)}">
+        ${icons.copy()}
+      </button>
+    </div>`;
   }
 
   function _renderRouterStep() {
     const router = (_config.squilla_router || {});
-    const provider = (_config.llm || {}).provider || 'openrouter';
+    const currentProvider = (_config.llm || {}).provider || '';
+    const hasSavedProvider = Boolean(currentProvider) && _status.hasConfig !== false;
+    const provider = hasSavedProvider ? currentProvider : '';
     const catalog = _catalog.routerProfiles || {};
     const profiles = catalog.profiles || [];
-    const profile = profiles.find(p => p.providerId === provider) || profiles.find(p => p.profileId === 'openrouter') || {};
-    const tiers = Object.assign({}, profile.tiers || {}, router.tiers || {});
+    const profile = provider ? profiles.find(p => p.providerId === provider) || {} : {};
+    const tiers = provider ? Object.assign({}, profile.tiers || {}, router.tiers || {}) : {};
     const defaultTier = router.default_tier || catalog.defaultTier || 't1';
     const mode = router.enabled === false ? 'disabled' : 'recommended';
+    const routerSummary = provider
+      ? `${provider} / ${_tierLabel(defaultTier)}`
+      : 'Choose a provider first';
+    const routerDisabled = provider ? '' : ' disabled';
     return `
       <section class="setup-panel">
         <header class="setup-panel__head">
           <h3>Router Tiers</h3>
-          <p>${_esc(provider)} / ${_esc(_tierLabel(defaultTier))}</p>
+          <p>${_esc(routerSummary)}</p>
         </header>
         <div class="setup-router-toolbar">
           <label><span>Mode</span>
-            <select data-router-mode>
+            <select id="setup-router-mode" name="setup_router_mode" data-router-mode${routerDisabled}>
               <option value="recommended"${mode === 'recommended' ? ' selected' : ''}>SquillaRouter</option>
               <option value="disabled"${mode === 'disabled' ? ' selected' : ''}>Disabled</option>
             </select>
           </label>
           <label><span>Default text model</span>
-            <select data-default-tier>
+            <select id="setup-router-default-tier" name="setup_router_default_tier" data-default-tier${routerDisabled}>
               ${TEXT_TIERS.map(t => `<option value="${t}"${t === defaultTier ? ' selected' : ''}>${_esc(_tierLabel(t))}</option>`).join('')}
             </select>
           </label>
         </div>
-        <div class="setup-tier-table" role="table">
+        ${provider ? `<div class="setup-tier-table" role="table">
           <div class="setup-tier-table__row is-head" role="row">
             <span>Tier</span><span>Provider</span><span>Model</span><span>Thinking</span><span>Image</span>
           </div>
           ${Object.entries(tiers).filter(([name]) => TEXT_TIERS.includes(name) || name === 'image_model').map(([name, tier]) => _tierRow(name, tier)).join('')}
-        </div>
+        </div>` : `<div class="setup-warning" data-router-provider-needed>Choose a provider first to preview and save SquillaRouter tiers.</div>`}
         <div class="setup-actions">
           <button class="setup-btn" data-prev="provider">Back</button>
-          <button class="setup-btn setup-btn--primary" data-save-router>Save Router</button>
+          <button class="setup-btn setup-btn--primary" data-save-router${provider ? '' : ' disabled'}>Save Router</button>
           <button class="setup-btn" data-next="channels">Next</button>
         </div>
       </section>`;
@@ -223,13 +510,21 @@ const SetupView = (() => {
   function _tierRow(name, tier) {
     return `<div class="setup-tier-table__row" role="row" data-tier="${_esc(name)}">
       <span><code>${_esc(name)}</code></span>
-      <input data-tier-field="provider" value="${_esc(tier.provider || '')}">
-      <input data-tier-field="model" value="${_esc(tier.model || '')}">
-      <select data-tier-field="thinkingLevel">
+      <input ${_tierControlAttrs(name, 'provider', 'provider')} data-tier-field="provider" value="${_esc(tier.provider || '')}">
+      <input ${_tierControlAttrs(name, 'model', 'model')} data-tier-field="model" value="${_esc(tier.model || '')}">
+      <select ${_tierControlAttrs(name, 'thinkingLevel', 'thinking level')} data-tier-field="thinkingLevel">
         ${['', 'off', 'none', 'minimal', 'low', 'medium', 'high', 'xhigh'].map(v => `<option value="${v}"${v === (tier.thinkingLevel || tier.thinking_level || '') ? ' selected' : ''}>${v || '-'}</option>`).join('')}
       </select>
-      <input type="checkbox" data-tier-field="supportsImage"${tier.supportsImage || tier.supports_image ? ' checked' : ''}>
+      <input ${_tierControlAttrs(name, 'supportsImage', 'supports image')} type="checkbox" data-tier-field="supportsImage"${tier.supportsImage || tier.supports_image ? ' checked' : ''}>
     </div>`;
+  }
+
+  function _tierControlAttrs(name, field, label) {
+    const safeTier = String(name || 'tier').replace(/[^a-zA-Z0-9_-]+/g, '-');
+    const tierFieldName = `setup_router_${name}_${field}`;
+    const tierFieldId = `setup-router-${safeTier}-${field}`;
+    const tierLabel = `${name} ${label}`;
+    return `id="${_esc(tierFieldId)}" name="${_esc(tierFieldName)}" aria-label="${_esc(tierLabel)}"`;
   }
 
   function _tierLabel(tier) {
@@ -240,6 +535,7 @@ const SetupView = (() => {
     const channels = (_catalog.channels || []);
     const selected = channels.some(c => c.type === _channelType) ? _channelType : (channels[0]?.type || 'telegram');
     _channelType = selected;
+    const channelSpec = channels.find(c => c.type === selected);
     const runtimeRows = (_channelStatus.channels || []).filter(row => row.configured !== false);
     return `
       <section class="setup-panel">
@@ -250,11 +546,12 @@ const SetupView = (() => {
         <div class="setup-channel-grid">
           <div class="setup-form" data-channel-dirty-root>
             <label><span>Channel type</span>
-              <select data-channel-type>
+              <select id="setup-channel-type" name="setup_channel_type" data-channel-type>
                 ${channels.map(c => `<option value="${_esc(c.type)}"${c.type === selected ? ' selected' : ''}>${_esc(c.label)}</option>`).join('')}
               </select>
             </label>
-            <div class="setup-channel-fields">${_renderChannelFields(channels.find(c => c.type === selected))}</div>
+            ${_renderNeedList(channelSpec ? channelSpec.whatYouNeed : [], 'Channel needs', 'data-channel-needs')}
+            <div class="setup-channel-fields">${_renderChannelFields(channelSpec)}</div>
             <div class="setup-actions">
               <button class="setup-btn setup-btn--primary" data-save-channel>Save Channel</button>
             </div>
@@ -287,47 +584,157 @@ const SetupView = (() => {
   }
 
   function _renderExtrasStep() {
+    const searchProviders = (_catalog.searchProviders || []).filter(p => p.runtimeSupported);
+    const searchSelected = _config.search_provider || searchProviders.find(p => p.providerId === 'duckduckgo')?.providerId || searchProviders[0]?.providerId || 'duckduckgo';
+    const searchSpec = searchProviders.find(p => p.providerId === searchSelected) || searchProviders[0] || {};
+    const searchEnv = _config.search_api_key_env || (searchSpec.requiresApiKey ? searchSpec.envKey : '') || '';
+    const searchRequiresKey = searchSpec.requiresApiKey === true;
+    const searchKeyDisabled = searchRequiresKey ? '' : ' disabled';
+    const searchKeyClass = searchRequiresKey ? '' : ' is-disabled';
+    const searchKeyHidden = searchRequiresKey ? '' : ' hidden';
+    const searchKeyPlaceholder = searchRequiresKey ? 'leave blank to keep current' : 'not required for this provider';
+    const searchEnvPlaceholder = searchRequiresKey ? (searchSpec.envKey || 'SEARCH_API_KEY') : 'not required for this provider';
+    const searchProxy = _config.search_proxy || '';
+    const searchUseEnvProxy = _config.search_use_env_proxy === true;
+    const searchFallbackPolicy = _config.search_fallback_policy || 'off';
+    const searchDiagnostics = _config.search_diagnostics === true;
+    const searchAdvancedOpen = searchProxy || searchUseEnvProxy || searchFallbackPolicy !== 'off' || searchDiagnostics ? ' open' : '';
     const imageProviders = (_catalog.imageGenerationProviders || []).filter(p => p.runtimeSupported);
     const memoryProviders = _catalog.memoryEmbeddingProviders || [];
     const current = ((_config || {}).memory || {}).embedding || {};
     const effectiveProvider = current.provider || current.mode || 'auto';
     const currentMode = current.mode; // current.mode is kept explicit for static coverage.
-    const imageSpec = imageProviders[0] || {};
+    const memorySpec = memoryProviders.find(p => p.providerId === effectiveProvider) || memoryProviders[0] || {};
+    const memoryRemote = current.remote || {};
+    const memoryLocal = current.local || {};
+    const memoryOllama = current.ollama || {};
+    const memoryRemoteControlEnabled = ['auto', 'openai', 'openai-compatible', 'ollama'].includes(effectiveProvider);
+    const memoryApiKeyEnabled = effectiveProvider === 'auto' || memorySpec.requiresApiKey === true;
+    const memoryLocalControlEnabled = effectiveProvider === 'local';
+    const memoryRemoteDisabled = memoryRemoteControlEnabled ? '' : ' disabled';
+    const memoryApiKeyDisabled = memoryApiKeyEnabled ? '' : ' disabled';
+    const memoryLocalDisabled = memoryLocalControlEnabled ? '' : ' disabled';
+    const memoryRemoteClass = memoryRemoteControlEnabled ? '' : ' is-disabled';
+    const memoryApiKeyClass = memoryApiKeyEnabled ? '' : ' is-disabled';
+    const memoryLocalClass = memoryLocalControlEnabled ? '' : ' is-disabled';
+    const memoryApiKeyLabel = effectiveProvider === 'auto' ? 'Fallback API key' : 'API key';
+    const memoryApiKeyPlaceholder = memoryApiKeyEnabled ? 'leave blank to keep current' : 'not required for this provider';
+    const memoryEnv = memoryRemote.api_key_env || (memoryApiKeyEnabled ? memorySpec.envKey || '' : '') || '';
+    const memoryEnvPlaceholder = memorySpec.envKey || 'OPENAI_API_KEY';
+    const memoryModelPlaceholder = effectiveProvider === 'ollama' ? 'nomic-embed-text' : (memoryRemoteControlEnabled ? 'text-embedding-3-small' : 'not used by this provider');
+    const memoryBasePlaceholder = effectiveProvider === 'ollama' ? 'http://localhost:11434' : (memoryRemoteControlEnabled ? 'https://api.openai.com/v1' : 'not used by this provider');
+    const memoryOnnxPlaceholder = memoryLocalControlEnabled ? 'models/bge-onnx' : 'only for bundled local provider';
+    const memoryRemoteOptionsHasSaved = Boolean(String(
+      memoryRemote.model || memoryRemote.api_key || memoryRemote.api_key_env || memoryRemote.base_url
+      || memoryOllama.model || memoryOllama.base_url || '',
+    ).trim());
+    const memoryRemoteOptionsOpen = effectiveProvider !== 'auto' || memoryRemoteOptionsHasSaved ? ' open' : '';
+    const memoryRemoteOptionsHidden = memoryRemoteControlEnabled || memoryApiKeyEnabled ? '' : ' hidden';
+    const memoryRemoteOptionsSummary = effectiveProvider === 'auto' ? 'Remote fallback options' : 'Connection options';
+    const memoryLocalHidden = memoryLocalControlEnabled ? '' : ' hidden';
+    const memoryStatusText = _memoryEmbeddingStatusText(effectiveProvider);
+    const memoryNeeds = _memoryNeedList(memorySpec, effectiveProvider, memoryEnv);
+    const imageProviderSelected = _status.imageGenerationProvider || (_status.imageGenerationPrimary || '').split('/')[0] || imageProviders[0]?.providerId || 'openrouter';
+    const imageSpec = imageProviders.find(p => p.providerId === imageProviderSelected) || imageProviders[0] || {};
+    const imageConfig = ((_config || {}).image_generation || {});
+    const imageProviderConfig = ((imageConfig.providers || {})[imageProviderSelected] || {});
+    const imageEnv = imageProviderConfig.api_key_env || (imageSpec.requiresApiKey ? imageSpec.envKey : '') || '';
+    const imageBaseUrl = imageProviderConfig.base_url || imageSpec.defaultBaseUrl || '';
+    const imagePrimary = _status.imageGenerationPrimary || imageSpec.defaultModel || '';
     const field = (imageSpec.fields || []).find(candidate => candidate.name === 'enabled') || { default: true };
     const imageEnabledDefault = _status.imageGenerationEnabled === false ? false : field.default !== false;
-    const imageProviderSelected = _status.imageGenerationProvider || (_status.imageGenerationPrimary || '').split('/')[0] || imageProviders[0]?.providerId || 'openrouter';
+    const imageConfigHidden = imageEnabledDefault ? '' : ' hidden';
+    const imageNeeds = imageEnabledDefault
+      ? _credentialNeedList(imageSpec.whatYouNeed, imageEnv || imageSpec.envKey)
+      : ['No key required while image generation is disabled.'];
     const imageStatusText = _imageGenerationStatusText();
     return `
       <section class="setup-panel">
         <header class="setup-panel__head">
-          <h3>Extras</h3>
-          <p>${_esc(effectiveProvider || currentMode || 'auto')}</p>
+          <h3>Capability Center</h3>
+          <p>Web search · Memory recall · Image generation</p>
         </header>
         <div class="setup-extras">
           <div class="setup-mini">
-            <h4>Memory embedding</h4>
+            <div class="setup-mini__head">
+              <h4>Web search</h4>
+              ${_renderCapabilityBadge('search')}
+            </div>
+            <p class="setup-muted">${_esc(_searchStatusText())}</p>
+            ${_renderCapabilityEnvRecoveryCommand('search')}
+            ${_renderNeedList(_credentialNeedList(searchSpec.whatYouNeed, searchEnv || searchSpec.envKey), 'Search needs', 'data-search-needs')}
             <label><span>Provider</span>
-              <select data-memory-provider>
+              <select id="setup-search-provider" name="setup_search_provider" data-search-provider>
+                ${searchProviders.map(p => `<option value="${_esc(p.providerId)}"${p.providerId === searchSelected ? ' selected' : ''}>${_esc(p.label)}</option>`).join('')}
+              </select>
+            </label>
+            <label><span>Max results</span><input id="setup-search-max-results" name="setup_search_max_results" type="number" min="1" step="1" inputmode="numeric" data-search-field="max_results" value="${_esc(String(_config.search_max_results || 5))}"></label>
+            <div class="setup-mini__advanced-body" data-search-key-fields${searchKeyHidden}>
+              <label class="${searchKeyClass}"><span>API key</span><input id="setup-search-api-key" name="setup_search_api_key" type="password" data-search-field="api_key" data-secret="true" placeholder="${_esc(searchKeyPlaceholder)}"${searchKeyDisabled}></label>
+              <label class="${searchKeyClass}"><span>API key env</span><input id="setup-search-api-key-env" name="setup_search_api_key_env" data-search-field="api_key_env" value="${_esc(searchEnv)}" placeholder="${_esc(searchEnvPlaceholder)}"${searchKeyDisabled}></label>
+            </div>
+            <details class="setup-mini__advanced" data-search-advanced${searchAdvancedOpen}>
+              <summary>Advanced search options</summary>
+              <div class="setup-mini__advanced-body" aria-label="Search behavior">
+                <label><span>HTTP proxy</span><input id="setup-search-proxy" name="setup_search_proxy" data-search-field="proxy" value="${_esc(searchProxy)}" placeholder="http://127.0.0.1:7890"></label>
+                <label class="setup-check"><input id="setup-search-use-env-proxy" name="setup_search_use_env_proxy" type="checkbox" data-search-field="use_env_proxy"${searchUseEnvProxy ? ' checked' : ''}><span>Use environment proxy</span></label>
+                <label><span>Fallback policy</span>
+                  <select id="setup-search-fallback-policy" name="setup_search_fallback_policy" data-search-field="fallback_policy">
+                    <option value="off"${searchFallbackPolicy === 'off' ? ' selected' : ''}>Off</option>
+                    <option value="network"${searchFallbackPolicy === 'network' ? ' selected' : ''}>Network retry</option>
+                  </select>
+                </label>
+                <label class="setup-check"><input id="setup-search-diagnostics" name="setup_search_diagnostics" type="checkbox" data-search-field="diagnostics"${searchDiagnostics ? ' checked' : ''}><span>Diagnostics</span></label>
+              </div>
+            </details>
+            <button class="${_capabilitySaveButtonClass('search')}" data-save-search>Save web search</button>
+          </div>
+          <div class="setup-mini">
+            <div class="setup-mini__head">
+              <h4>Memory embedding</h4>
+              ${_renderCapabilityBadge('memory_embedding')}
+            </div>
+            <p class="setup-muted" data-memory-status-text>${_esc(memoryStatusText)}</p>
+            ${_renderCapabilityEnvRecoveryCommand('memory_embedding')}
+            ${_renderNeedList(memoryNeeds, 'Memory needs', 'data-memory-needs')}
+            <label><span>Provider</span>
+              <select id="setup-memory-provider" name="setup_memory_provider" data-memory-provider>
                 ${memoryProviders.map(p => `<option value="${_esc(p.providerId)}"${p.providerId === effectiveProvider ? ' selected' : ''}>${_esc(p.label)}</option>`).join('')}
               </select>
             </label>
-            <label><span>Model</span><input data-memory-field="model" value="${_esc((current.remote || {}).model || '')}" placeholder="text-embedding-3-small"></label>
-            <label><span>Remote fallback API key</span><input type="password" data-memory-field="api_key" data-secret="true" placeholder="leave blank to keep current"></label>
-            <label><span>Base URL</span><input data-memory-field="base_url" value="${_esc((current.remote || {}).base_url || '')}" placeholder="https://api.openai.com/v1"></label>
-            <button class="setup-btn setup-btn--primary" data-save-memory>Save Memory</button>
+            <label class="${memoryLocalClass}" data-memory-local-field${memoryLocalHidden}><span>ONNX directory</span><input id="setup-memory-onnx-dir" name="setup_memory_onnx_dir" data-memory-field="onnx_dir" value="${_esc(memoryLocal.onnx_dir || '')}" placeholder="${_esc(memoryOnnxPlaceholder)}"${memoryLocalDisabled}></label>
+            <details class="setup-mini__advanced" data-memory-remote-options${memoryRemoteOptionsOpen}${memoryRemoteOptionsHidden}>
+              <summary>${_esc(memoryRemoteOptionsSummary)}</summary>
+              <div class="setup-mini__advanced-body" aria-label="Memory embedding connection">
+                <label class="${memoryRemoteClass}"><span>Model</span><input id="setup-memory-model" name="setup_memory_model" data-memory-field="model" value="${_esc(memoryRemote.model || memoryOllama.model || '')}" placeholder="${_esc(memoryModelPlaceholder)}"${memoryRemoteDisabled}></label>
+                <label class="${memoryApiKeyClass}"><span data-memory-api-key-label>${_esc(memoryApiKeyLabel)}</span><input id="setup-memory-api-key" name="setup_memory_api_key" type="password" data-memory-field="api_key" data-secret="true" placeholder="${_esc(memoryApiKeyPlaceholder)}"${memoryApiKeyDisabled}></label>
+                <label class="${memoryApiKeyClass}"><span>API key env</span><input id="setup-memory-api-key-env" name="setup_memory_api_key_env" data-memory-field="api_key_env" value="${_esc(memoryEnv)}" placeholder="${_esc(memoryEnvPlaceholder)}"${memoryApiKeyDisabled}></label>
+                <label class="${memoryRemoteClass}"><span>Base URL</span><input id="setup-memory-base-url" name="setup_memory_base_url" data-memory-field="base_url" value="${_esc(memoryRemote.base_url || memoryOllama.base_url || '')}" placeholder="${_esc(memoryBasePlaceholder)}"${memoryRemoteDisabled}></label>
+              </div>
+            </details>
+            <button class="${_capabilitySaveButtonClass('memory_embedding')}" data-save-memory>Save memory embedding</button>
           </div>
           <div class="setup-mini">
-            <h4>Image generation</h4>
+            <div class="setup-mini__head">
+              <h4>Image generation</h4>
+              ${_renderCapabilityBadge('image_generation')}
+            </div>
             <p class="setup-muted">${_esc(imageStatusText)}</p>
-            <label><span>Provider</span>
-              <select data-image-provider>
-                ${imageProviders.map(p => `<option value="${_esc(p.providerId)}"${p.providerId === imageProviderSelected ? ' selected' : ''}>${_esc(p.label)}</option>`).join('')}
-              </select>
-            </label>
-            <label><span>Primary model</span><input data-image-field="primary" value="${_esc(_status.imageGenerationPrimary || '')}"></label>
-            <label><span>API key</span><input type="password" data-image-field="api_key" data-secret="true" placeholder="leave blank to keep current"></label>
-            <label class="setup-check"><input type="checkbox" data-image-enabled${imageEnabledDefault ? ' checked' : ''}><span>Enabled</span></label>
-            <button class="setup-btn setup-btn--primary" data-save-image>Save Image</button>
+            ${_renderCapabilityEnvRecoveryCommand('image_generation')}
+            ${_renderNeedList(imageNeeds, 'Image needs', 'data-image-needs')}
+            <div class="setup-mini__advanced-body" data-image-config-fields${imageConfigHidden}>
+              <label><span>Provider</span>
+                <select id="setup-image-provider" name="setup_image_provider" data-image-provider>
+                  ${imageProviders.map(p => `<option value="${_esc(p.providerId)}"${p.providerId === imageProviderSelected ? ' selected' : ''}>${_esc(p.label)}</option>`).join('')}
+                </select>
+              </label>
+              <label><span>Primary model</span><input id="setup-image-primary" name="setup_image_primary" data-image-field="primary" value="${_esc(imagePrimary)}"></label>
+              <label><span>API key</span><input id="setup-image-api-key" name="setup_image_api_key" type="password" data-image-field="api_key" data-secret="true" placeholder="leave blank to keep current"></label>
+              <label><span>API key env</span><input id="setup-image-api-key-env" name="setup_image_api_key_env" data-image-field="api_key_env" value="${_esc(imageEnv)}" placeholder="${_esc(imageSpec.envKey || 'OPENROUTER_API_KEY')}"></label>
+              <label><span>Base URL</span><input id="setup-image-base-url" name="setup_image_base_url" data-image-field="base_url" value="${_esc(imageBaseUrl)}" placeholder="${_esc(imageSpec.defaultBaseUrl || 'https://api.openai.com/v1')}"></label>
+            </div>
+            <label class="setup-check"><input id="setup-image-enabled" name="setup_image_enabled" type="checkbox" data-image-enabled${imageEnabledDefault ? ' checked' : ''}><span>Enabled</span></label>
+            <button class="${_capabilitySaveButtonClass('image_generation')}" data-save-image>Save image generation</button>
           </div>
         </div>
         <div class="setup-actions">
@@ -337,35 +744,184 @@ const SetupView = (() => {
       </section>`;
   }
 
+  function _capabilitySaveButtonClass(name) {
+    const detail = (_status.sectionDetails || {})[name] || {};
+    return detail.blocking || detail.actionRequired
+      ? 'setup-btn setup-btn--primary'
+      : 'setup-btn';
+  }
+
+  function _renderCapabilityBadge(name) {
+    const detail = (_status.sectionDetails || {})[name] || {};
+    return `<span class="setup-badge ${_readinessTone(detail)}">${_esc(_readinessStatusLabel(detail))}</span>`;
+  }
+
+  function _missingEnvStatusText(capability, envKey, fallback) {
+    const key = String(envKey || '').trim();
+    if (!key) return fallback;
+    return `${capability} is selected, but $${key} is not visible to the gateway.`;
+  }
+
+  function _searchStatusText() {
+    if (!_config.search_provider) {
+      return 'Web search is off until a provider is selected.';
+    }
+    if (_status.searchConfigured === true) {
+      return 'Web search is ready for new turns.';
+    }
+    if (_status.searchSource === 'missing_env') {
+      return _missingEnvStatusText(
+        'Web search',
+        _status.searchEnvKey,
+        'Web search is selected but still needs a visible provider key.',
+      );
+    }
+    return 'Web search is selected but still needs a visible provider key.';
+  }
+
   function _imageGenerationStatusText() {
     if (_status.imageGenerationEnabled === false) {
-      return 'image_generate is hidden from agents until this capability is enabled.';
+      return 'Image generation is hidden from agents until this capability is enabled.';
     }
     if (_status.imageGenerationConfigured === true) {
-      return 'image_generate will be available in new turns once the gateway has the visible key.';
+      if (_status.imageGenerationSource === 'llm_fallback') {
+        return 'Image generation will be available in new turns using the same provider key.';
+      }
+      return 'Image generation will be available in new turns once the gateway has the visible key.';
     }
-    return 'image_generate is enabled but still needs a visible provider key before agents can use it.';
+    if (_status.imageGenerationSource === 'missing_env') {
+      return _missingEnvStatusText(
+        'Image generation',
+        _status.imageGenerationEnvKey,
+        'Image generation is enabled but still needs a visible provider key before agents can use it.',
+      );
+    }
+    return 'Image generation is enabled but still needs a visible provider key before agents can use it.';
+  }
+
+  function _memoryEmbeddingStatusText(providerId = '') {
+    const current = ((_config || {}).memory || {}).embedding || {};
+    const savedProvider = current.provider || current.mode || _status.memoryEmbeddingProvider || 'auto';
+    const provider = providerId || savedProvider;
+    if (provider === 'none') {
+      return 'Keyword search stays available; embeddings are disabled.';
+    }
+    if (provider === 'local') {
+      return 'Uses local BGE embeddings; no remote key is needed.';
+    }
+    if (provider === 'ollama') {
+      return 'Uses your Ollama server; no API key is needed.';
+    }
+    if (provider === 'auto') {
+      return 'Local-first memory search; optional remote fallback can be configured.';
+    }
+    if (provider === savedProvider && _status.memoryEmbeddingConfigured === true) {
+      return 'Remote memory embeddings are configured for new turns.';
+    }
+    if (provider === savedProvider && _status.memoryEmbeddingSource === 'missing_env') {
+      return _missingEnvStatusText(
+        'Remote memory embeddings',
+        _status.memoryEmbeddingEnvKey,
+        'Remote memory embeddings need a visible provider key before they can run.',
+      );
+    }
+    return 'Remote memory embeddings need a visible provider key before they can run.';
+  }
+
+  function _toastEnvReferenceSave(
+    surface,
+    envKey,
+    keySource = '',
+    hasInlineKey = '',
+    restartRequired = false,
+  ) {
+    const key = String(envKey || '').trim();
+    if (!key || hasInlineKey) return false;
+    if (keySource === 'missing_env' || restartRequired) {
+      UI.toast(`${surface} saved $${key}. Start or restart the gateway with that variable set.`, 'warn', 5200);
+      return true;
+    }
+    UI.toast(`${surface} saved $${key} reference. Keep it set for gateway restarts.`, 'info', 4200);
+    return true;
   }
 
   function _renderFinishStep() {
     const router = (_config.squilla_router || {});
+    const currentProvider = (_config.llm || {}).provider || '';
+    const hasSavedProvider = Boolean(currentProvider) && _status.hasConfig !== false;
+    const providerSummary = hasSavedProvider ? currentProvider : 'not configured';
+    const modelSummary = hasSavedProvider
+      ? ((_config.llm || {}).model || 'SquillaRouter defaults')
+      : 'not configured';
+    const routerSummary = hasSavedProvider
+      ? (router.enabled === false ? 'disabled' : 'SquillaRouter')
+      : 'choose a provider first';
+    const providerProxy = hasSavedProvider ? ((_config.llm || {}).proxy || '').trim() : '';
+    const configArg = _configCliArg(_status.configPath);
+    const envRecoveryCommands = Array.isArray(_status.envRecoveryCommands)
+      ? _status.envRecoveryCommands
+        .map(entry => ({
+          label: entry.label || 'Set environment key',
+          command: entry.command || '',
+        }))
+        .filter(entry => entry.command)
+      : [];
+    const fixCommands = _envFixCommands(envRecoveryCommands, configArg);
+    const handoffCommands = [
+      {
+        label: 'Guided CLI',
+        command: `opensquilla onboard --if-needed${configArg}`,
+      },
+      {
+        label: 'Check status',
+        command: `opensquilla onboard status${configArg}`,
+      },
+    ];
+    const recipeCommands = [
+      {
+        label: 'Provider options',
+        command: `opensquilla onboard catalog providers${configArg}`,
+      },
+      {
+        label: 'Router tiers',
+        command: `opensquilla onboard catalog router${configArg}`,
+      },
+      {
+        label: 'Search options',
+        command: `opensquilla onboard catalog search${configArg}`,
+      },
+      {
+        label: 'Channel options',
+        command: `opensquilla onboard catalog channels${configArg}`,
+      },
+      {
+        label: 'Image options',
+        command: `opensquilla onboard catalog image${configArg}`,
+      },
+      {
+        label: 'Memory options',
+        command: `opensquilla onboard catalog memory${configArg}`,
+      },
+    ];
     return `
       <section class="setup-panel">
         <header class="setup-panel__head">
           <h3>Finish</h3>
           <p>${_esc(_status.configPath || '')}</p>
         </header>
+        <div class="setup-cli">
+          ${_renderCliCommandGroup('Fix now', fixCommands)}
+          ${_renderCliCommandGroup('CLI handoff', handoffCommands)}
+          ${_renderCliCommandGroup('CLI recipes', recipeCommands)}
+        </div>
         <div class="setup-summary">
-          <div><span>Provider</span><strong>${_esc((_config.llm || {}).provider || '')}</strong></div>
-          <div><span>Model</span><strong>${_esc((_config.llm || {}).model || '')}</strong></div>
-          <div><span>Router</span><strong>${router.enabled === false ? 'disabled' : _esc(router.tier_profile || 'openrouter-mix')}</strong></div>
+          <div><span>Provider</span><strong>${_esc(providerSummary)}</strong></div>
+          <div><span>Model</span><strong>${_esc(modelSummary)}</strong></div>
+          ${providerProxy ? `<div><span>Proxy</span><strong>${_esc(providerProxy)}</strong></div>` : ''}
+          <div><span>Router</span><strong>${_esc(routerSummary)}</strong></div>
           <div><span>Channels</span><strong>${_esc(String(_status.channelCount || 0))}</strong></div>
         </div>
-        <div class="setup-cli">
-          <code>opensquilla onboard --if-needed</code>
-          <code>opensquilla configure provider</code>
-          <code>opensquilla channels status &lt;name&gt; --json</code>
-        </div>
+        ${_renderReadinessSummary()}
         <div class="setup-actions">
           <button class="setup-btn" data-prev="extras">Back</button>
           <button class="setup-btn" data-reload>Refresh</button>
@@ -374,23 +930,139 @@ const SetupView = (() => {
       </section>`;
   }
 
+  function _renderCliCommandGroup(title, commands) {
+    if (!commands.length) return '';
+    return `<section class="setup-cli__group" aria-label="${_esc(title)}">
+      <div class="setup-cli__group-head">
+        <h4>${_esc(title)}</h4>
+      </div>
+      ${commands.map(_renderCliCommand).join('')}
+    </section>`;
+  }
+
+  function _envFixCommands(envRecoveryCommands, configArg) {
+    if (!envRecoveryCommands.length) return [];
+    return [
+      ...envRecoveryCommands,
+      {
+        label: 'Restart gateway after env fix',
+        command: `opensquilla gateway restart${configArg}`,
+      },
+    ];
+  }
+
+  function _renderCliCommand({ label, command }) {
+    const safeCommand = _esc(command);
+    const copyLabel = `Copy ${label} command`;
+    return `<div class="setup-cli__row">
+      <span class="setup-cli__label">${_esc(label)}</span>
+      <code>${safeCommand}</code>
+      <button class="setup-cli__copy" type="button" data-setup-copy-command="${safeCommand}" title="${_esc(copyLabel)}" aria-label="${_esc(copyLabel)}">
+        ${icons.copy()}
+      </button>
+    </div>`;
+  }
+
+  function _renderReadinessSummary() {
+    const details = _status.sectionDetails || {};
+    const entries = Object.entries(details);
+    if (!entries.length) return '';
+    const required = entries.filter(([, detail]) => detail.required);
+    const optional = entries.filter(([, detail]) => !detail.required);
+    return `<div class="setup-readiness" aria-label="Onboarding readiness">
+      ${_renderReadinessGroup('Required setup', required)}
+      ${_renderReadinessGroup('Optional capabilities', optional)}
+    </div>`;
+  }
+
+  function _renderReadinessGroup(title, entries) {
+    if (!entries.length) return '';
+    return `<div class="setup-readiness__group">
+      <h4>${_esc(title)}</h4>
+      ${entries.map(([name, detail]) => {
+        const note = detail.detail ? `<em class="setup-readiness__detail">${_esc(detail.detail)}</em>` : '';
+        const step = _setupStepForSection(name, detail);
+        const action = _renderReadinessAction(step, detail, name);
+        return `<div class="setup-readiness__row ${_readinessTone(detail, name)}">
+          <span>${_esc(detail.label || name)}</span>
+          <strong>${_esc(_readinessStatusLabel(detail, name))}</strong>
+          <small>${detail.required ? 'Required' : 'Optional'}</small>
+          ${action}
+          ${note}
+        </div>`;
+      }).join('')}
+    </div>`;
+  }
+
+  function _setupStepForSection(name, detail = {}) {
+    if (_routerNeedsProvider(detail, name)) return 'provider';
+    if (name === 'llm' || name === 'provider') return 'provider';
+    if (name === 'router') return 'router';
+    if (name === 'channels') return 'channels';
+    if (name === 'search' || name === 'image_generation' || name === 'memory_embedding') return 'extras';
+    return '';
+  }
+
+  function _routerNeedsProvider(detail, name) {
+    return name === 'router'
+      && detail.status === 'ok'
+      && detail.detail === 'uses SquillaRouter after provider setup';
+  }
+
+  function _readinessActionLabel(detail, name) {
+    if (_routerNeedsProvider(detail, name)) return 'Choose provider';
+    if (detail.blocking || detail.actionRequired) return 'Fix';
+    if (detail.status === 'ok') return 'Review';
+    return 'Configure';
+  }
+
+  function _renderReadinessAction(step, detail, name) {
+    if (!step) return '';
+    const actionAriaLabel = _readinessActionAriaLabel(detail, name);
+    return `<button type="button" class="setup-readiness__action" ` +
+      `aria-label="${_esc(actionAriaLabel)}" title="${_esc(actionAriaLabel)}" ` +
+      `data-step="${_esc(step)}">${_esc(_readinessActionLabel(detail, name))}</button>`;
+  }
+
+  function _readinessActionAriaLabel(detail, name) {
+    const label = detail.label || name.replace(/_/g, ' ');
+    if (_routerNeedsProvider(detail, name)) return `Choose provider for ${label}`;
+    return `${_readinessActionLabel(detail, name)} ${label}`;
+  }
+
+  function _readinessTone(detail, name) {
+    if (_routerNeedsProvider(detail, name)) return 'is-warn';
+    if (detail.blocking || detail.actionRequired) return 'is-warn';
+    if (detail.status === 'ok') return 'is-ok';
+    return 'is-muted';
+  }
+
+  function _readinessStatusLabel(detail, name) {
+    if (_routerNeedsProvider(detail, name)) return 'Provider first';
+    if (detail.blocking || detail.actionRequired) return 'Needs action';
+    return READINESS_LABELS[detail.status] || 'Optional';
+  }
+
   function _fieldHtml(field, value, scope) {
     const required = field.required ? ' *' : '';
     const desc = field.description ? `<small class="setup-field-desc">${_esc(field.description)}</small>` : '';
     const showWhen = field.showWhen && Object.keys(field.showWhen).length ? _esc(JSON.stringify(field.showWhen)) : '';
-    const attrs = `data-name="${_esc(field.name)}" data-scope="${scope}" data-show-when="${showWhen}"`;
+    const rawName = String(field.name || 'field');
+    const fieldName = `setup_${scope}_${rawName}`;
+    const fieldId = `setup-${scope}-${rawName.replace(/[^a-zA-Z0-9_-]+/g, '-')}`;
+    const attrs = `data-name="${_esc(rawName)}" data-scope="${scope}" data-show-when="${showWhen}"`;
     if (field.type === 'bool') {
-      return `<label class="setup-check" ${attrs}><input type="checkbox" ${field.default ? ' checked' : ''}><span>${_esc(field.label)}${required}${desc}</span></label>`;
+      return `<label class="setup-check" ${attrs} for="${_esc(fieldId)}"><input id="${_esc(fieldId)}" name="${_esc(fieldName)}" type="checkbox" ${field.default ? ' checked' : ''}><span>${_esc(field.label)}${required}${desc}</span></label>`;
     }
     if (field.type === 'select') {
-      return `<label ${attrs}><span>${_esc(field.label)}${required}</span>${desc}<select>
+      return `<label ${attrs} for="${_esc(fieldId)}"><span>${_esc(field.label)}${required}</span>${desc}<select id="${_esc(fieldId)}" name="${_esc(fieldName)}">
         ${(field.choices || []).map(choice => `<option value="${_esc(choice)}"${choice === value ? ' selected' : ''}>${_esc(choice)}</option>`).join('')}
       </select></label>`;
     }
     const isSecret = field.secret || field.type === 'password';
     const inputType = isSecret ? 'password' : (field.type === 'int' || field.type === 'float' ? 'number' : 'text');
     const placeholder = field.placeholder || (isSecret ? 'leave blank to keep current' : '');
-    return `<label ${attrs}><span>${_esc(field.label)}${required}</span>${desc}<input type="${inputType}" data-secret="${isSecret}" value="${isSecret ? '' : _esc(String(value || ''))}" placeholder="${_esc(placeholder)}"></label>`;
+    return `<label ${attrs} for="${_esc(fieldId)}"><span>${_esc(field.label)}${required}</span>${desc}<input id="${_esc(fieldId)}" name="${_esc(fieldName)}" type="${inputType}" data-secret="${isSecret}" value="${isSecret ? '' : _esc(String(value || ''))}" placeholder="${_esc(placeholder)}"></label>`;
   }
 
   function _bindStep() {
@@ -399,8 +1071,7 @@ const SetupView = (() => {
     _el.querySelectorAll('[data-exit-setup]').forEach(btn => btn.addEventListener('click', () => Router.navigate('/overview')));
     _el.querySelector('[data-reload]')?.addEventListener('click', async () => { await _load(); _draw(); });
     _el.querySelector('[data-provider-select]')?.addEventListener('change', () => {
-      _rememberDraft('provider');
-      _drawProviderFields();
+      _drawProviderFields({ rememberDraft: true });
     });
     _el.querySelector('[data-channel-type]')?.addEventListener('change', () => {
       _channelDirty = true;
@@ -408,14 +1079,48 @@ const SetupView = (() => {
       _drawChannelFields();
       _bindChannelDirtyTracking();
     });
+    _el.querySelector('[data-search-provider]')?.addEventListener('change', _syncSearchProviderEnvHint);
+    _el.querySelector('[data-memory-provider]')?.addEventListener('change', _syncMemoryProviderControls);
+    _el.querySelector('[data-image-provider]')?.addEventListener('change', _syncImageProviderDefaults);
+    _el.querySelector('[data-image-enabled]')?.addEventListener('change', _syncImageProviderDefaults);
+    _el.querySelectorAll('[data-setup-copy-command]').forEach(btn => btn.addEventListener('click', _onSetupCommandCopy));
     _bindChannelDirtyTracking();
     _bindConditionalSelects(_el);
     _applyConditionalFields();
     _el.querySelector('[data-save-provider]')?.addEventListener('click', _saveProvider);
     _el.querySelector('[data-save-router]')?.addEventListener('click', _saveRouter);
     _el.querySelector('[data-save-channel]')?.addEventListener('click', _saveChannel);
+    _el.querySelector('[data-save-search]')?.addEventListener('click', _saveSearch);
     _el.querySelector('[data-save-memory]')?.addEventListener('click', _saveMemory);
     _el.querySelector('[data-save-image]')?.addEventListener('click', _saveImage);
+  }
+
+  async function _onSetupCommandCopy(event) {
+    const btn = event.currentTarget;
+    const command = btn.dataset.setupCopyCommand || '';
+    if (!command) return;
+    try {
+      await _copyText(command);
+      UI.toast('Copied command', 'ok', 1600);
+    } catch (err) {
+      UI.toast('Copy failed: ' + (err.message || String(err)), 'err', 2500);
+    }
+  }
+
+  function _copyText(text) {
+    if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+      return navigator.clipboard.writeText(text);
+    }
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return ok ? Promise.resolve() : Promise.reject(new Error('Copy command failed'));
   }
 
   function _setStep(step) {
@@ -454,6 +1159,10 @@ const SetupView = (() => {
       _drawChannelFields();
       _restoreDraft('channels');
     }
+    if (_step === 'extras' && _drafts.has('extras')) {
+      _syncSearchProviderKeyControls({ refreshEnv: false });
+      _syncMemoryProviderControls();
+    }
   }
 
   function _fieldKey(input, idx) {
@@ -465,6 +1174,8 @@ const SetupView = (() => {
     if (input.dataset.defaultTier !== undefined) return 'router:defaultTier';
     if (input.dataset.providerSelect !== undefined) return 'provider:selected';
     if (input.dataset.channelType !== undefined) return 'channel:type';
+    if (input.dataset.searchProvider !== undefined) return 'extras:search:provider';
+    if (input.dataset.searchField) return `extras:search:${input.dataset.searchField}`;
     if (input.dataset.memoryProvider !== undefined) return 'extras:memory:provider';
     if (input.dataset.memoryField) return `extras:memory:${input.dataset.memoryField}`;
     if (input.dataset.imageProvider !== undefined) return 'extras:image:provider';
@@ -486,13 +1197,40 @@ const SetupView = (() => {
     });
   }
 
-  function _drawProviderFields() {
+  function _drawProviderFields({ rememberDraft = false } = {}) {
     const providerId = _el.querySelector('[data-provider-select]')?.value;
+    const saveButton = _el.querySelector('[data-save-provider]');
+    if (saveButton) saveButton.disabled = !providerId;
+    const nextButton = _el.querySelector('[data-next="router"]');
+    if (nextButton) nextButton.disabled = !providerId;
     const spec = (_catalog.providers || []).find(p => p.providerId === providerId);
+    const routerSupport = _el.querySelector('[data-provider-router-support-label]');
+    if (routerSupport) {
+      routerSupport.textContent = _providerRouterSupportText(spec);
+      routerSupport.className = `setup-provider-meta__badge ${_providerRouterSupportTone(spec)}`;
+    }
+    if (!spec) return;
+    const providerFields = spec.fields || [];
+    const providerCoreFields = providerFields.filter(field => !_isProviderAdvancedField(field, spec));
+    const providerAdvancedFields = providerFields.filter(field => _isProviderAdvancedField(field, spec));
+    const values = _providerConfigFor(providerId);
     const box = _el.querySelector('.setup-provider-fields');
-    if (box && spec) box.innerHTML = _renderProviderFields(spec, _config.llm || {});
-    _bindConditionalSelects(box || _el);
+    if (box) box.innerHTML = _renderProviderFields(providerCoreFields, values);
+    const advanced = _el.querySelector('[data-provider-advanced-wrap]');
+    if (advanced) {
+      const providerAdvancedOpen = _providerAdvancedOpen(providerAdvancedFields, values) ? ' open' : '';
+      advanced.innerHTML = _renderProviderAdvancedFields(
+        providerAdvancedFields,
+        values,
+        providerAdvancedOpen,
+      );
+    }
+    _replaceNeedList('[data-provider-needs]', spec?.whatYouNeed, 'Provider needs', 'data-provider-needs');
+    const summary = _el.querySelector('[data-provider-summary]');
+    if (summary) summary.textContent = spec.label || providerId || 'not configured';
+    _bindConditionalSelects(_el);
     _applyConditionalFields();
+    if (rememberDraft) _rememberDraft('provider');
   }
 
   function _drawChannelFields() {
@@ -501,8 +1239,133 @@ const SetupView = (() => {
     const spec = (_catalog.channels || []).find(c => c.type === type);
     const box = _el.querySelector('.setup-channel-fields');
     if (box && spec) box.innerHTML = _renderChannelFields(spec);
+    _replaceNeedList('[data-channel-needs]', spec?.whatYouNeed, 'Channel needs', 'data-channel-needs');
     _bindConditionalSelects(box || _el);
     _applyConditionalFields();
+  }
+
+  function _syncSearchProviderEnvHint() {
+    _syncSearchProviderKeyControls();
+    _rememberDraft('extras');
+  }
+
+  function _syncSearchProviderKeyControls({ refreshEnv = true } = {}) {
+    const providerId = _el.querySelector('[data-search-provider]')?.value;
+    const spec = (_catalog.searchProviders || []).find(p => p.providerId === providerId) || {};
+    const requiresKey = spec.requiresApiKey === true;
+    const keyInput = _el.querySelector('[data-search-field="api_key"]');
+    const envInput = _el.querySelector('[data-search-field="api_key_env"]');
+    const keyFields = _el.querySelector('[data-search-key-fields]');
+    _replaceNeedList('[data-search-needs]', _credentialNeedList(spec.whatYouNeed, envInput?.value || spec.envKey), 'Search needs', 'data-search-needs');
+    if (keyFields) {
+      keyFields.hidden = !requiresKey;
+    }
+    if (keyInput) {
+      keyInput.disabled = !requiresKey;
+      keyInput.placeholder = requiresKey ? 'leave blank to keep current' : 'not required for this provider';
+      if (!requiresKey) keyInput.value = '';
+      keyInput.closest('label')?.classList.toggle('is-disabled', !requiresKey);
+    }
+    if (envInput) {
+      envInput.disabled = !requiresKey;
+      envInput.placeholder = requiresKey ? (spec.envKey || 'SEARCH_API_KEY') : 'not required for this provider';
+      if (!requiresKey) envInput.value = '';
+      else if (refreshEnv) envInput.value = spec.envKey || '';
+      envInput.closest('label')?.classList.toggle('is-disabled', !requiresKey);
+    }
+  }
+
+  function _syncMemoryProviderControls() {
+    const providerId = _el.querySelector('[data-memory-provider]')?.value || 'auto';
+    const memorySpec = (_catalog.memoryEmbeddingProviders || []).find(p => p.providerId === providerId) || {};
+    const remoteControlEnabled = ['auto', 'openai', 'openai-compatible', 'ollama'].includes(providerId);
+    const apiKeyEnabled = providerId === 'auto' || memorySpec.requiresApiKey === true;
+    const modelInput = _el.querySelector('[data-memory-field="model"]');
+    const apiKeyInput = _el.querySelector('[data-memory-field="api_key"]');
+    const envInput = _el.querySelector('[data-memory-field="api_key_env"]');
+    const baseInput = _el.querySelector('[data-memory-field="base_url"]');
+    const onnxInput = _el.querySelector('[data-memory-field="onnx_dir"]');
+    const apiKeyLabel = _el.querySelector('[data-memory-api-key-label]');
+    const localField = _el.querySelector('[data-memory-local-field]');
+    const remoteOptions = _el.querySelector('[data-memory-remote-options]');
+    const statusText = _el.querySelector('[data-memory-status-text]');
+    const localControlEnabled = providerId === 'local';
+    const hasRemoteOptions = remoteControlEnabled || apiKeyEnabled;
+    _replaceNeedList('[data-memory-needs]', _memoryNeedList(memorySpec, providerId, envInput?.value || memorySpec.envKey), 'Memory needs', 'data-memory-needs');
+    if (remoteOptions) {
+      remoteOptions.hidden = !hasRemoteOptions;
+      remoteOptions.open = providerId !== 'auto' && hasRemoteOptions;
+      const summary = remoteOptions.querySelector('summary');
+      if (summary) summary.textContent = providerId === 'auto' ? 'Remote fallback options' : 'Connection options';
+    }
+    if (modelInput) {
+      modelInput.disabled = !remoteControlEnabled;
+      modelInput.placeholder = providerId === 'ollama' ? 'nomic-embed-text' : (remoteControlEnabled ? 'text-embedding-3-small' : 'not used by this provider');
+      if (!remoteControlEnabled) modelInput.value = '';
+      modelInput.closest('label')?.classList.toggle('is-disabled', !remoteControlEnabled);
+    }
+    if (apiKeyInput) {
+      apiKeyInput.disabled = !apiKeyEnabled;
+      apiKeyInput.placeholder = apiKeyEnabled ? 'leave blank to keep current' : 'not required for this provider';
+      if (!apiKeyEnabled) apiKeyInput.value = '';
+      apiKeyInput.closest('label')?.classList.toggle('is-disabled', !apiKeyEnabled);
+    }
+    if (envInput) {
+      envInput.disabled = !apiKeyEnabled;
+      envInput.placeholder = memorySpec.envKey || 'OPENAI_API_KEY';
+      if (!apiKeyEnabled) envInput.value = '';
+      else if (!envInput.value) envInput.value = memorySpec.envKey || '';
+      envInput.closest('label')?.classList.toggle('is-disabled', !apiKeyEnabled);
+    }
+    if (apiKeyLabel) {
+      apiKeyLabel.textContent = providerId === 'auto' ? 'Fallback API key' : 'API key';
+    }
+    if (baseInput) {
+      baseInput.disabled = !remoteControlEnabled;
+      baseInput.placeholder = providerId === 'ollama' ? 'http://localhost:11434' : (remoteControlEnabled ? 'https://api.openai.com/v1' : 'not used by this provider');
+      if (!remoteControlEnabled) baseInput.value = '';
+      baseInput.closest('label')?.classList.toggle('is-disabled', !remoteControlEnabled);
+    }
+    if (onnxInput) {
+      onnxInput.disabled = !localControlEnabled;
+      onnxInput.placeholder = localControlEnabled ? 'models/bge-onnx' : 'only for bundled local provider';
+      if (!localControlEnabled) onnxInput.value = '';
+      onnxInput.closest('label')?.classList.toggle('is-disabled', !localControlEnabled);
+    }
+    if (localField) {
+      localField.hidden = !localControlEnabled;
+    }
+    if (statusText) {
+      statusText.textContent = _memoryEmbeddingStatusText(providerId);
+    }
+    _rememberDraft('extras');
+  }
+
+  function _syncImageProviderDefaults() {
+    const enabledInput = _el.querySelector('[data-image-enabled]');
+    const imageEnabled = enabledInput?.checked !== false;
+    const imageConfigFields = _el.querySelector('[data-image-config-fields]');
+    if (imageConfigFields) imageConfigFields.hidden = !imageEnabled;
+    const providerId = _el.querySelector('[data-image-provider]')?.value;
+    const spec = (_catalog.imageGenerationProviders || []).find(p => p.providerId === providerId) || {};
+    const envInput = _el.querySelector('[data-image-field="api_key_env"]');
+    if (envInput) {
+      envInput.value = spec.requiresApiKey ? (spec.envKey || '') : '';
+    }
+    const imageNeeds = imageEnabled
+      ? _credentialNeedList(spec.whatYouNeed, envInput?.value || spec.envKey)
+      : ['No key required while image generation is disabled.'];
+    _replaceNeedList('[data-image-needs]', imageNeeds, 'Image needs', 'data-image-needs');
+    const primaryInput = _el.querySelector('[data-image-field="primary"]');
+    const currentProvider = (primaryInput?.value || '').split('/')[0];
+    if (primaryInput && currentProvider !== providerId) {
+      primaryInput.value = spec.defaultModel || primaryInput.value;
+    }
+    const baseInput = _el.querySelector('[data-image-field="base_url"]');
+    if (baseInput) {
+      baseInput.value = spec.defaultBaseUrl || baseInput.value;
+    }
+    _rememberDraft('extras');
   }
 
   function _bindConditionalSelects(root) {
@@ -546,6 +1409,10 @@ const SetupView = (() => {
 
   async function _saveProvider() {
     const providerId = _el.querySelector('[data-provider-select]')?.value;
+    if (!providerId) {
+      UI.toast('Choose a provider before saving.', 'err');
+      return;
+    }
     try {
       await _rpc.call('onboarding.provider.configure', Object.assign({ providerId }, _readScopedFields('provider')));
       await _load();
@@ -565,6 +1432,11 @@ const SetupView = (() => {
   }
 
   async function _saveRouter() {
+    const currentProvider = (_config.llm || {}).provider || '';
+    if (!(Boolean(currentProvider) && _status.hasConfig !== false)) {
+      UI.toast('Choose a provider before saving router tiers.', 'err');
+      return;
+    }
     const tiers = {};
     _el.querySelectorAll('[data-tier]').forEach(row => {
       const tier = {};
@@ -608,11 +1480,39 @@ const SetupView = (() => {
   async function _saveMemory() {
     const params = { providerId: _el.querySelector('[data-memory-provider]')?.value || 'auto' };
     _el.querySelectorAll('[data-memory-field]').forEach(input => {
+      if (input.disabled) return;
       if (input.value !== '' || input.dataset.secret !== 'true') params[_camel(input.dataset.memoryField)] = input.value;
     });
     try {
-      await _rpc.call('onboarding.memory_embedding.configure', params);
-      UI.toast('Memory embedding saved. Restart required.', 'info');
+      const res = await _rpc.call('onboarding.memory_embedding.configure', params);
+      const remote = ((res || {}).entry || {}).remote || {};
+      if (!_toastEnvReferenceSave(
+        'Memory embedding',
+        remote.api_key_env,
+        '',
+        remote.api_key,
+        (res || {}).restartRequired,
+      )) {
+        UI.toast('Memory embedding saved. Restart required.', 'info');
+      }
+      await _load();
+      _draw();
+    } catch (err) {
+      UI.toast('Save failed: ' + err.message, 'err');
+    }
+  }
+
+  async function _saveSearch() {
+    const params = { providerId: _el.querySelector('[data-search-provider]')?.value || 'duckduckgo' };
+    _el.querySelectorAll('[data-search-field]').forEach(input => {
+      if (input.value === '' && input.dataset.secret === 'true') return;
+      const key = _camel(input.dataset.searchField);
+      if (input.type === 'checkbox') params[key] = input.checked;
+      else params[key] = input.type === 'number' ? Number.parseInt(input.value || '0', 10) : input.value;
+    });
+    try {
+      await _rpc.call('onboarding.search.configure', params);
+      UI.toast('Search saved.', 'info');
       await _load();
       _draw();
     } catch (err) {
@@ -627,8 +1527,17 @@ const SetupView = (() => {
       if (input.value !== '' || input.dataset.secret !== 'true') params[_camel(input.dataset.imageField)] = input.value;
     });
     try {
-      await _rpc.call('onboarding.imageGeneration.configure', params);
-      UI.toast('Image generation saved.', 'info');
+      const res = await _rpc.call('onboarding.imageGeneration.configure', params);
+      const entry = (res || {}).entry || {};
+      if (!_toastEnvReferenceSave(
+        'Image generation',
+        entry.api_key_env,
+        entry.api_key_source,
+        entry.api_key,
+        (res || {}).restartRequired,
+      )) {
+        UI.toast('Image generation saved.', 'info');
+      }
       await _load();
       _draw();
     } catch (err) {
@@ -654,6 +1563,16 @@ const SetupView = (() => {
     return String(name || '').replace(/_([a-z])/g, (_, c) => c.toUpperCase());
   }
 
+  function _configCliArg(configPath) {
+    return configPath ? ` --config ${_shellArg(configPath)}` : '';
+  }
+
+  function _shellArg(value) {
+    const text = String(value || '');
+    if (/^[A-Za-z0-9_@%+=:,./~-]+$/.test(text)) return text;
+    return `'${text.replace(/'/g, `'\\''`)}'`;
+  }
+
   function _esc(s) {
     return String(s == null ? '' : s)
       .replace(/&/g, '&amp;').replace(/</g, '&lt;')
@@ -669,6 +1588,8 @@ const SetupView = (() => {
     _status = {};
     _config = {};
     _channelStatus = { channels: [] };
+    _step = 'provider';
+    _hasAutoSelectedStep = false;
   }
 
   return { render, destroy };

--- a/src/opensquilla/memory/embedding_resolver.py
+++ b/src/opensquilla/memory/embedding_resolver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -113,8 +114,11 @@ def resolve_memory_embedding(
         or top_model
         or OpenAIEmbeddingProvider.DEFAULT_MODEL
     )
-    remote_api_key = _clean_str(getattr(remote_cfg, "api_key", None)) or _clean_str(
-        getattr(embed_cfg, "api_key", None)
+    remote_api_key_env = _clean_str(getattr(remote_cfg, "api_key_env", None))
+    remote_api_key = (
+        _clean_str(getattr(remote_cfg, "api_key", None))
+        or _clean_str(getattr(embed_cfg, "api_key", None))
+        or (os.environ.get(remote_api_key_env) if remote_api_key_env else None)
     )
     remote_base_url = (
         _clean_str(getattr(remote_cfg, "base_url", None))

--- a/src/opensquilla/onboarding/__init__.py
+++ b/src/opensquilla/onboarding/__init__.py
@@ -14,6 +14,12 @@ from opensquilla.onboarding.image_generation_specs import (
     image_generation_provider_catalog_payload,
     list_image_generation_provider_setup_specs,
 )
+from opensquilla.onboarding.memory_embedding_specs import (
+    MemoryEmbeddingProviderSetupSpec,
+    get_memory_embedding_provider_setup_spec,
+    list_memory_embedding_provider_setup_specs,
+    memory_embedding_provider_catalog_payload,
+)
 from opensquilla.onboarding.provider_specs import (
     ProviderSetupField,
     ProviderSetupSpec,
@@ -40,6 +46,7 @@ __all__ = [
     "ChannelSetupSpec",
     "ImageGenerationProviderSetupField",
     "ImageGenerationProviderSetupSpec",
+    "MemoryEmbeddingProviderSetupSpec",
     "ProviderSetupField",
     "ProviderSetupSpec",
     "RouterSetupProfile",
@@ -48,12 +55,15 @@ __all__ = [
     "channel_catalog_payload",
     "get_channel_setup_spec",
     "get_image_generation_provider_setup_spec",
+    "get_memory_embedding_provider_setup_spec",
     "get_provider_setup_spec",
     "get_router_setup_profile",
     "get_search_provider_setup_spec",
     "image_generation_provider_catalog_payload",
+    "memory_embedding_provider_catalog_payload",
     "list_channel_setup_specs",
     "list_image_generation_provider_setup_specs",
+    "list_memory_embedding_provider_setup_specs",
     "list_provider_setup_specs",
     "list_router_setup_profiles",
     "list_search_provider_setup_specs",

--- a/src/opensquilla/onboarding/channel_specs.py
+++ b/src/opensquilla/onboarding/channel_specs.py
@@ -38,6 +38,9 @@ class ChannelSetupSpec:
     docs_hint: str
     fields: tuple[ChannelSetupField, ...]
     help: str = ""
+    blocking: bool = False
+    can_probe: bool = True
+    readme_scenarios: tuple[str, ...] = ("chat channels", "first-run setup")
 
 
 def _common_fields() -> tuple[ChannelSetupField, ...]:
@@ -373,6 +376,10 @@ def channel_catalog_payload() -> list[dict[str, Any]]:
             "restartRequired": s.restart_required,
             "docsHint": s.docs_hint,
             "help": s.help,
+            "blocking": s.blocking,
+            "canProbe": s.can_probe,
+            "readmeScenarios": list(s.readme_scenarios),
+            "whatYouNeed": _what_you_need(s),
             "fields": [
                 {
                     "name": f.name,
@@ -394,3 +401,18 @@ def channel_catalog_payload() -> list[dict[str, Any]]:
         }
         for s in list_channel_setup_specs()
     ]
+
+
+def _what_you_need(spec: ChannelSetupSpec) -> list[str]:
+    needs = [
+        f"{field.label}."
+        for field in spec.fields
+        if field.required and field.name not in {"name", "enabled", "agent_id"}
+    ]
+    if spec.requires_public_url:
+        needs.append("A public URL reachable by the channel provider.")
+    if spec.dependency_extra:
+        needs.append(f"Install the `{spec.dependency_extra}` optional extra.")
+    if not needs:
+        needs.append("A channel entry name and provider-side bot/app setup.")
+    return needs

--- a/src/opensquilla/onboarding/config_store.py
+++ b/src/opensquilla/onboarding/config_store.py
@@ -149,10 +149,10 @@ def persist_config(
     os.chmod(target, 0o600)
 
     log.debug(
-        "onboarding.config_persisted",
-        path=str(target),
-        backup=str(backup_path) if backup_path else None,
-        restart_required=restart_required,
+        "onboarding.config_persisted path=%s backup=%s restart_required=%s",
+        str(target),
+        str(backup_path) if backup_path else None,
+        restart_required,
     )
 
     return PersistResult(

--- a/src/opensquilla/onboarding/config_store.py
+++ b/src/opensquilla/onboarding/config_store.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import structlog
 import tomli_w
 
 try:
@@ -24,7 +24,7 @@ from opensquilla.gateway.config_migration import (
 )
 from opensquilla.paths import default_opensquilla_home
 
-log = structlog.get_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -148,7 +148,7 @@ def persist_config(
 
     os.chmod(target, 0o600)
 
-    log.info(
+    log.debug(
         "onboarding.config_persisted",
         path=str(target),
         backup=str(backup_path) if backup_path else None,

--- a/src/opensquilla/onboarding/flow.py
+++ b/src/opensquilla/onboarding/flow.py
@@ -1925,7 +1925,7 @@ def _run_optional_section(
     section: str,
     label: str,
     runner,
-    args: tuple = (),
+    args: tuple[Any, ...] = (),
     kwargs: dict | None = None,
     config_path: str | Path | None = None,
 ) -> None:
@@ -2023,7 +2023,7 @@ def _run_action_required_optional_sections(
             section=str(action["section"]),
             label=str(action["label"]),
             runner=action["runner"],
-            args=action.get("args", ()),
+            args=cast(tuple[Any, ...], action.get("args", ())),
             config_path=options.config_path,
         )
 

--- a/src/opensquilla/onboarding/flow.py
+++ b/src/opensquilla/onboarding/flow.py
@@ -30,12 +30,23 @@ from opensquilla.onboarding.image_generation_specs import (
     get_image_generation_provider_setup_spec,
     list_image_generation_provider_setup_specs,
 )
+from opensquilla.onboarding.memory_embedding_specs import (
+    MemoryEmbeddingProviderSetupSpec,
+    get_memory_embedding_provider_setup_spec,
+    list_memory_embedding_provider_setup_specs,
+)
 from opensquilla.onboarding.mutations import (
     upsert_channel,
     upsert_image_generation_provider,
     upsert_llm_provider,
+    upsert_memory_embedding,
     upsert_router,
     upsert_search_provider,
+)
+from opensquilla.onboarding.next_steps import (
+    headless_setup_command,
+    headless_setup_commands,
+    setup_catalog_command,
 )
 from opensquilla.onboarding.provider_specs import (
     get_provider_setup_spec,
@@ -45,6 +56,7 @@ from opensquilla.onboarding.search_specs import (
     get_search_provider_setup_spec,
     list_search_provider_setup_specs,
 )
+from opensquilla.onboarding.setup_paths import web_setup_url
 from opensquilla.onboarding.status import get_onboarding_status
 from opensquilla.ui import (
     ACCENT,
@@ -114,6 +126,7 @@ class OnboardOptions:
     api_key: str | None = None
     api_key_env: str | None = None
     base_url: str | None = None
+    proxy: str | None = None
     router_mode: str = "recommended"
     minimal: bool = False
     skip_migration: bool = False
@@ -220,19 +233,57 @@ def _config_cli_arg(config_path: str | Path | None) -> str:
     return f" --config {shlex.quote(str(config_path))}"
 
 
+def _first_blocking_setup_section(cfg: Any) -> str:
+    status = get_onboarding_status(cfg)
+    for name in status.sections:
+        if status.section_details.get(name, {}).get("blocking"):
+            return name
+    return "provider"
+
+
 def _print_noninteractive_hint(
+    cfg: Any,
     config_path: str | Path | None = None,
+    *,
+    section: str | None = None,
 ) -> PersistResult:
+    if config_path is None and isinstance(cfg, (str, Path)):
+        config_path = cfg
+        cfg = load_config(config_path)
     config_arg = _config_cli_arg(config_path)
-    print(
-        "Onboarding requires a TTY. Run a non-interactive equivalent, e.g.:\n"
-        "  opensquilla onboard --provider openrouter "
-        f"--api-key-env OPENROUTER_API_KEY --router recommended --minimal{config_arg}\n"
-        "  opensquilla search configure brave "
-        f"--api-key $BRAVE_SEARCH_API_KEY{config_arg}\n"
-        "  opensquilla channels add slack "
-        f"--name work --token $SLACK_TOKEN{config_arg}"
+    normalized = (section or _first_blocking_setup_section(cfg)).replace("_", "-")
+    headless_commands = headless_setup_commands(normalized)
+    if not headless_commands:
+        headless_commands = [
+            headless_setup_command("provider")
+            or (
+                "Provider recipes",
+                "opensquilla onboard catalog providers",
+            )
+        ]
+    guided_command = (
+        f"opensquilla onboard configure {normalized}{config_arg}"
+        if section
+        else f"opensquilla onboard --if-needed{config_arg}"
     )
+    lines = [
+        "Onboarding requires a TTY-compatible interactive terminal for the guided wizard.",
+        "Use a runnable setup path from this shell:",
+    ]
+    setup_url = web_setup_url(cfg)
+    if setup_url:
+        lines.append(f"  Web UI: opensquilla gateway run{config_arg} -> {setup_url}")
+    catalog_label, catalog_command = setup_catalog_command(config_arg)
+    lines.append(f"  {catalog_label}: {catalog_command}")
+    for label, command in headless_commands:
+        lines.append(f"  {label}: {command}{config_arg}")
+    lines.extend(
+        [
+            f"  Guided CLI: {guided_command} (interactive terminal only)",
+            f"  Check status: opensquilla onboard status{config_arg}",
+        ]
+    )
+    print("\n".join(lines))
     return PersistResult(
         path=default_config_path(),
         backup_path=None,
@@ -309,6 +360,12 @@ def _api_key_source_choices(env_key: str) -> list[str]:
     return choices
 
 
+def _api_key_source_default(env_key: str) -> str:
+    if env_key and os.environ.get(env_key):
+        return _api_key_env_choice(env_key, detected=True)
+    return _PASTE_API_KEY_CHOICE
+
+
 def _secret_value_validator(label: str):
     required = _required_value(label)
 
@@ -360,7 +417,7 @@ def _ask_provider_fields(
             key_source = questionary.select(
                 "LLM API key source",
                 choices=_api_key_source_choices(env_key or ""),
-                default=_PASTE_API_KEY_CHOICE,
+                default=_api_key_source_default(env_key or ""),
             ).ask()
             selected_env_key = _api_key_env_from_choice(key_source or "")
             answers["api_key_env"] = selected_env_key
@@ -383,6 +440,7 @@ def _ask_provider_fields(
         )
     else:
         answers["base_url"] = options.base_url or spec.default_base_url
+    answers["proxy"] = options.proxy or ""
     return answers
 
 
@@ -409,7 +467,7 @@ def _ask_search_fields(questionary, spec) -> dict[str, Any]:
                 _ask_or_cancel(
                     questionary.confirm(
                         f"Use {env_key} from environment?",
-                        default=False,
+                        default=True,
                     ),
                     section="search",
                 )
@@ -464,7 +522,7 @@ def run_interactive_search_configure(
     config_path: str | Path | None = None,
 ) -> PersistResult:
     if not _is_tty():
-        return _print_noninteractive_hint(config_path)
+        return _print_noninteractive_hint(config_path, section="search")
 
     import questionary as _qmod
     questionary = _styled(_qmod)
@@ -540,13 +598,15 @@ def _ask_image_generation_fields(
     llm_choice = "Reuse matching LLM provider key"
     if config.llm.provider == spec.provider_id and config.llm.api_key:
         key_choices.append(llm_choice)
-    key_choices.append(_PASTE_API_KEY_CHOICE)
     env_choice = (
         _api_key_env_choice(spec.env_key)
         if spec.env_key
         else ""
     )
-    if env_choice:
+    if env_choice and os.environ.get(spec.env_key):
+        key_choices.append(env_choice)
+    key_choices.append(_PASTE_API_KEY_CHOICE)
+    if env_choice and not os.environ.get(spec.env_key):
         key_choices.append(env_choice)
 
     key_source = questionary.select(
@@ -606,7 +666,7 @@ def run_interactive_image_generation_configure(
     config_path: str | Path | None = None,
 ) -> PersistResult:
     if not _is_tty():
-        return _print_noninteractive_hint(config_path)
+        return _print_noninteractive_hint(config_path, section="image-generation")
 
     import questionary as _qmod
     questionary = _styled(_qmod)
@@ -626,6 +686,179 @@ def run_interactive_image_generation_configure(
     )
     persisted = persist_config(result.config, path=config_path, restart_required=False)
     _print_image_generation_saved(provider_id)
+    return persisted
+
+
+def _memory_embedding_choice_label(spec: MemoryEmbeddingProviderSetupSpec) -> str:
+    return f"{spec.provider_id} ({spec.label})"
+
+
+def _memory_embedding_choice_to_provider_id(choice: str | None) -> str:
+    return (choice or "").split(" ", 1)[0]
+
+
+def _ask_memory_embedding_choice(
+    questionary,
+    config,
+) -> tuple[MemoryEmbeddingProviderSetupSpec, str]:
+    providers = [
+        s
+        for s in list_memory_embedding_provider_setup_specs()
+        if s.runtime_supported
+    ]
+    current_provider = getattr(config.memory.embedding, "requested_provider", "auto")
+    default_spec = next(
+        (s for s in providers if s.provider_id == current_provider),
+        providers[0],
+    )
+    choice = _ask_or_cancel(
+        questionary.select(
+            "Memory embedding provider",
+            choices=[_memory_embedding_choice_label(s) for s in providers],
+            default=_memory_embedding_choice_label(default_spec),
+        ),
+        section="memory embedding",
+    )
+    provider_id = _memory_embedding_choice_to_provider_id(choice)
+    return get_memory_embedding_provider_setup_spec(provider_id), provider_id
+
+
+def _memory_embedding_key_choices(
+    spec: MemoryEmbeddingProviderSetupSpec,
+    config,
+) -> list[str]:
+    embedding = config.memory.embedding
+    current_env = str(getattr(embedding.remote, "api_key_env", "") or "").strip()
+    current_key = str(
+        getattr(embedding.remote, "api_key", "")
+        or getattr(embedding, "api_key", "")
+        or ""
+    ).strip()
+    choices: list[str] = []
+    if current_key:
+        choices.append("Keep stored memory API key")
+    env_key = current_env or spec.env_key
+    if env_key:
+        choices.append(
+            _api_key_env_choice(env_key, detected=bool(os.environ.get(env_key)))
+        )
+    choices.append(_PASTE_API_KEY_CHOICE)
+    return choices
+
+
+def _ask_memory_embedding_fields(
+    questionary,
+    spec: MemoryEmbeddingProviderSetupSpec,
+    config,
+) -> dict[str, Any]:
+    embedding = config.memory.embedding
+    answers: dict[str, Any] = {}
+    if spec.provider_id == "none":
+        return answers
+    if spec.provider_id == "local":
+        answers["onnx_dir"] = _ask_or_cancel(
+            questionary.text(
+                "Local ONNX directory",
+                default=(
+                    embedding.local.onnx_dir
+                    if embedding.requested_provider == "local"
+                    else ""
+                ),
+            ),
+            section="memory embedding",
+        )
+        return answers
+    if spec.provider_id in {"openai", "openai-compatible"}:
+        answers["model"] = _ask_or_cancel(
+            questionary.text(
+                "Memory embedding model",
+                default=embedding.remote.model
+                or embedding.model
+                or "text-embedding-3-small",
+            ),
+            section="memory embedding",
+        )
+        key_source = _ask_or_cancel(
+            questionary.select(
+                "Memory API key source",
+                choices=_memory_embedding_key_choices(spec, config),
+            ),
+            section="memory embedding",
+        )
+        selected_env_key = _api_key_env_from_choice(key_source or "")
+        if key_source == _PASTE_API_KEY_CHOICE:
+            answers["api_key"] = _ask_or_cancel(
+                questionary.password(
+                    "Memory embedding API key",
+                    validate=_secret_value_validator("Memory embedding API key"),
+                ),
+                section="memory embedding",
+            )
+            answers["api_key_env"] = ""
+        elif selected_env_key:
+            answers["api_key"] = ""
+            answers["api_key_env"] = selected_env_key
+        else:
+            answers["api_key"] = ""
+            answers["api_key_env"] = ""
+        answers["base_url"] = _ask_or_cancel(
+            questionary.text(
+                "Memory embedding base URL",
+                default=embedding.remote.base_url
+                or embedding.base_url
+                or "https://api.openai.com/v1",
+            ),
+            section="memory embedding",
+        )
+        return answers
+    if spec.provider_id == "ollama":
+        answers["model"] = _ask_or_cancel(
+            questionary.text(
+                "Memory embedding model",
+                default=embedding.ollama.model or "nomic-embed-text",
+            ),
+            section="memory embedding",
+        )
+        answers["base_url"] = _ask_or_cancel(
+            questionary.text(
+                "Memory embedding base URL",
+                default=embedding.ollama.base_url or "http://localhost:11434",
+            ),
+            section="memory embedding",
+        )
+    return answers
+
+
+def run_interactive_memory_embedding_configure(
+    config_path: str | Path | None = None,
+) -> PersistResult:
+    if not _is_tty():
+        cfg = load_config(config_path)
+        return _print_noninteractive_hint(cfg, config_path, section="memory-embedding")
+
+    import questionary as _qmod
+    questionary = _styled(_qmod)
+
+    cfg = load_config(config_path)
+    spec, provider_id = _ask_memory_embedding_choice(questionary, cfg)
+    answers = _ask_memory_embedding_fields(questionary, spec, cfg)
+    result = upsert_memory_embedding(
+        cfg,
+        provider=provider_id,
+        model=answers.get("model"),
+        api_key=answers.get("api_key"),
+        api_key_env=answers.get("api_key_env"),
+        base_url=answers.get("base_url"),
+        onnx_dir=answers.get("onnx_dir"),
+    )
+    persisted = persist_config(result.config, path=config_path, restart_required=False)
+    console.print(
+        f"[bold {ACCENT}]◆[/] [bold]Memory embedding configured.[/]"
+    )
+    console.print(
+        f"  [dim]Provider:[/dim] [{ACCENT_SOFT}]{markup_escape(provider_id)}[/]"
+        " [dim]· new memory indexing will use this setting[/dim]"
+    )
     return persisted
 
 
@@ -804,6 +1037,33 @@ def _ask_router_fields(
     if questionary.confirm("Edit router tier models now?", default=False).ask():
         payload["tiers"] = _router_tier_overrides(questionary, preview)
     return payload
+
+
+def run_interactive_router_configure(
+    *, config_path: str | Path | None = None
+) -> PersistResult:
+    cfg = load_config(config_path)
+    if not _is_tty():
+        return _print_noninteractive_hint(cfg, config_path, section="router")
+
+    import questionary as _qmod
+
+    questionary = _styled(_qmod)
+    provider_id = _provider_id_from_config(cfg)
+    requested_mode = "recommended" if cfg.squilla_router.enabled else "disabled"
+    payload = _ask_router_fields(
+        questionary,
+        cfg,
+        provider_id=provider_id,
+        requested_mode=requested_mode,
+    )
+    result = upsert_router(
+        cfg,
+        mode=payload["mode"],
+        default_tier=payload.get("defaultTier"),
+        tiers=payload.get("tiers"),
+    )
+    return persist_config(result.config, path=config_path, restart_required=False)
 
 
 def _channel_control_fields(spec: ChannelSetupSpec) -> set[str]:
@@ -1487,7 +1747,7 @@ def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
         )
 
     if not _is_tty():
-        return _print_noninteractive_hint(options.config_path)
+        return _print_noninteractive_hint(cfg, options.config_path)
 
     import questionary as _qmod
     questionary = _styled(_qmod)
@@ -1495,10 +1755,23 @@ def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
     console.print(
         banner_panel(
             "OpenSquilla Onboarding",
-            "Migration · Provider · Router · Channel · Search",
+            "Migration · Provider · SquillaRouter · Channels · Capabilities",
         )
     )
     _wait_for_setup_start()
+    if options.if_needed and status.has_config and status.llm_configured:
+        _run_action_required_optional_sections(
+            questionary,
+            status,
+            options=options,
+        )
+        return persist_config(
+            load_config(options.config_path),
+            path=options.config_path,
+            restart_required=False,
+            backup=False,
+        )
+
     config_path = _config_path_from_loaded_config(cfg)
     migration_result: Any | None = None
     if not options.skip_migration:
@@ -1579,6 +1852,7 @@ def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
                 api_key=answers.get("api_key", ""),
                 api_key_env=answers.get("api_key_env", ""),
                 base_url=answers.get("base_url", ""),
+                proxy=answers.get("proxy", ""),
             )
             cfg_after_provider = res.config
             if options.router_mode:
@@ -1635,6 +1909,14 @@ def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
             config_path=options.config_path,
         )
 
+    refreshed_status = get_onboarding_status(load_config(options.config_path))
+    _run_action_required_optional_sections(
+        questionary,
+        refreshed_status,
+        options=options,
+        sections=("memory_embedding",),
+    )
+
     return persist
 
 
@@ -1649,7 +1931,7 @@ def _run_optional_section(
 ) -> None:
     """Run an optional onboarding step, isolating cancellation from siblings.
 
-    ``section`` is the slug consumed by ``opensquilla configure <section>``;
+    ``section`` is the slug consumed by ``opensquilla onboard configure <section>``;
     ``label`` is the user-facing wording (which can contain spaces). Only
     cancellation-shaped exceptions are caught here — real validation or
     programming errors propagate so they surface in the operator's terminal
@@ -1667,11 +1949,82 @@ def _run_optional_section(
         )
         console.print(
             f"  [dim]Resume later with[/dim] "
-            f"[{ACCENT_SOFT}]opensquilla configure {section}{config_arg}[/]"
+            f"[{ACCENT_SOFT}]opensquilla onboard configure {section}{config_arg}[/]"
         )
     except KeyboardInterrupt:
         console.print(
             f"[yellow]{label} setup interrupted — skipping.[/yellow]"
+        )
+
+
+def _section_needs_action(status, section: str) -> bool:
+    detail = status.section_details.get(section, {})
+    return bool(detail.get("blocking") or detail.get("actionRequired"))
+
+
+def _run_action_required_optional_sections(
+    questionary,
+    status,
+    *,
+    options: OnboardOptions,
+    sections: tuple[str, ...] = (
+        "router",
+        "channels",
+        "search",
+        "image_generation",
+        "memory_embedding",
+    ),
+) -> None:
+    actions = {
+        "router": {
+            "prompt": "Configure SquillaRouter now?",
+            "section": "router",
+            "label": "router",
+            "runner": run_interactive_router_configure,
+            "skip": False,
+        },
+        "channels": {
+            "prompt": "Configure messaging channels now?",
+            "section": "channels",
+            "label": "channel",
+            "runner": run_interactive_channel_add,
+            "args": (None,),
+            "skip": options.skip_channels,
+        },
+        "search": {
+            "prompt": "Configure web search now?",
+            "section": "search",
+            "label": "search",
+            "runner": run_interactive_search_configure,
+            "skip": options.skip_search,
+        },
+        "image_generation": {
+            "prompt": "Fix image generation now?",
+            "section": "image-generation",
+            "label": "image generation",
+            "runner": run_interactive_image_generation_configure,
+            "skip": options.skip_image_generation,
+        },
+        "memory_embedding": {
+            "prompt": "Configure memory embeddings now?",
+            "section": "memory-embedding",
+            "label": "memory embedding",
+            "runner": run_interactive_memory_embedding_configure,
+            "skip": False,
+        },
+    }
+    for name in sections:
+        action = actions.get(name)
+        if not action or action.get("skip") or not _section_needs_action(status, name):
+            continue
+        if not questionary.confirm(str(action["prompt"]), default=True).ask():
+            continue
+        _run_optional_section(
+            section=str(action["section"]),
+            label=str(action["label"]),
+            runner=action["runner"],
+            args=action.get("args", ()),
+            config_path=options.config_path,
         )
 
 
@@ -1681,7 +2034,7 @@ def run_interactive_channel_add(
     config_path: str | Path | None = None,
 ) -> PersistResult:
     if not _is_tty():
-        return _print_noninteractive_hint(config_path)
+        return _print_noninteractive_hint(config_path, section="channels")
 
     import questionary as _qmod
     questionary = _styled(_qmod)
@@ -1709,7 +2062,7 @@ def run_interactive_channel_edit(
     config_path: str | Path | None = None,
 ) -> PersistResult:
     if not _is_tty():
-        return _print_noninteractive_hint(config_path)
+        return _print_noninteractive_hint(config_path, section="channels")
 
     import questionary as _qmod
     questionary = _styled(_qmod)
@@ -1719,7 +2072,7 @@ def run_interactive_channel_edit(
     if not existing_entries:
         console.print(
             f"[{ACCENT_DIM}]no channels to edit[/]"
-            " [dim]· run `configure --section channels` to add one[/dim]"
+            " [dim]· run `opensquilla onboard configure channels` to add one[/dim]"
         )
         return persist_config(
             cfg,
@@ -1758,7 +2111,8 @@ def run_interactive_configure(
     config_path: str | Path | None = None,
 ) -> PersistResult | None:
     if not _is_tty():
-        _print_noninteractive_hint(config_path)
+        cfg = load_config(config_path)
+        _print_noninteractive_hint(cfg, config_path, section=section)
         return None
 
     import questionary as _qmod
@@ -1766,9 +2120,16 @@ def run_interactive_configure(
 
     section = section or questionary.select(
         "Section",
-        choices=["providers", "channels", "search", "image-generation"],
+        choices=[
+            "provider",
+            "router",
+            "channels",
+            "search",
+            "image-generation",
+            "memory-embedding",
+        ],
     ).ask()
-    if section == "providers":
+    if section in {"provider", "providers"}:
         return run_interactive_onboard(
             OnboardOptions(
                 skip_channels=True,
@@ -1776,7 +2137,9 @@ def run_interactive_configure(
                 config_path=config_path,
             )
         )
-    if section == "channels":
+    if section == "router":
+        return run_interactive_router_configure(config_path=config_path)
+    if section in {"channel", "channels"}:
         existing = load_config(config_path).channels.channels
         if existing:
             mode = questionary.select(
@@ -1791,6 +2154,8 @@ def run_interactive_configure(
         return run_interactive_search_configure(config_path=config_path)
     if section in {"image-generation", "image_generation"}:
         return run_interactive_image_generation_configure(config_path=config_path)
+    if section in {"memory-embedding", "memory_embedding"}:
+        return run_interactive_memory_embedding_configure(config_path=config_path)
     console.print(
         f"[{ACCENT_DIM}]section[/] [{ACCENT_SOFT}]{markup_escape(repr(section))}[/]"
         " [dim]not yet supported in the wizard · edit "

--- a/src/opensquilla/onboarding/image_generation_specs.py
+++ b/src/opensquilla/onboarding/image_generation_specs.py
@@ -30,6 +30,11 @@ class ImageGenerationProviderSetupSpec:
     default_base_url: str
     default_model: str
     suggested_models: tuple[str, ...]
+    deployment: str
+    blocking: bool
+    can_probe: bool
+    readme_scenarios: tuple[str, ...]
+    what_you_need: tuple[str, ...]
     fields: tuple[ImageGenerationProviderSetupField, ...]
 
 
@@ -99,6 +104,14 @@ def list_image_generation_provider_setup_specs() -> list[ImageGenerationProvider
             default_base_url=str(data["default_base_url"]),
             default_model=str(data["default_model"]),
             suggested_models=tuple(data["suggested_models"]),
+            deployment="cloud",
+            blocking=False,
+            can_probe=False,
+            readme_scenarios=("image generation", "first-run setup"),
+            what_you_need=(
+                f"API key via {data['env_key']} or a one-time paste.",
+                "A provider/model id that supports image generation.",
+            ),
             fields=_fields_for(data),
         )
         for provider_id, data in _IMAGE_PROVIDER_DATA.items()
@@ -125,6 +138,11 @@ def image_generation_provider_catalog_payload() -> list[dict[str, Any]]:
             "defaultBaseUrl": s.default_base_url,
             "defaultModel": s.default_model,
             "suggestedModels": list(s.suggested_models),
+            "deployment": s.deployment,
+            "blocking": s.blocking,
+            "canProbe": s.can_probe,
+            "readmeScenarios": list(s.readme_scenarios),
+            "whatYouNeed": list(s.what_you_need),
             "fields": [
                 {
                     "name": f.name,

--- a/src/opensquilla/onboarding/memory_embedding_specs.py
+++ b/src/opensquilla/onboarding/memory_embedding_specs.py
@@ -1,0 +1,133 @@
+"""Onboarding-friendly memory embedding provider catalog."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+Deployment = Literal["auto", "local", "cloud", "custom", "disabled"]
+
+
+@dataclass(frozen=True)
+class MemoryEmbeddingProviderSetupSpec:
+    provider_id: str
+    label: str
+    deployment: Deployment
+    runtime_supported: bool
+    requires_api_key: bool
+    env_key: str
+    requires_base_url: bool
+    blocking: bool
+    can_probe: bool
+    readme_scenarios: tuple[str, ...]
+    what_you_need: tuple[str, ...]
+
+
+_MEMORY_EMBEDDING_PROVIDER_DATA: dict[str, dict[str, Any]] = {
+    "auto": {
+        "label": "Auto (local BGE first)",
+        "deployment": "auto",
+        "requires_api_key": False,
+        "requires_base_url": False,
+        "what_you_need": (
+            "Bundled local embeddings for the default path.",
+            "Optional remote fallback credentials if configured.",
+        ),
+    },
+    "local": {
+        "label": "Bundled BGE-small",
+        "deployment": "local",
+        "requires_api_key": False,
+        "requires_base_url": False,
+        "what_you_need": (
+            "Local ONNX embedding assets from the recommended install.",
+            "Optional ONNX directory override for custom local assets.",
+        ),
+    },
+    "openai": {
+        "label": "OpenAI",
+        "deployment": "cloud",
+        "requires_api_key": True,
+        "env_key": "OPENAI_API_KEY",
+        "requires_base_url": False,
+        "what_you_need": (
+            "Remote embedding API key or OPENAI_API_KEY reference.",
+            "Optional embedding model override.",
+        ),
+    },
+    "openai-compatible": {
+        "label": "OpenAI-compatible remote",
+        "deployment": "custom",
+        "requires_api_key": True,
+        "env_key": "",
+        "requires_base_url": False,
+        "what_you_need": (
+            "Remote embedding API key or env reference.",
+            "Optional base URL and model for the compatible endpoint.",
+        ),
+    },
+    "ollama": {
+        "label": "Ollama",
+        "deployment": "local",
+        "requires_api_key": False,
+        "requires_base_url": False,
+        "what_you_need": (
+            "A reachable Ollama server.",
+            "Optional embedding model override.",
+        ),
+    },
+    "none": {
+        "label": "FTS-only",
+        "deployment": "disabled",
+        "requires_api_key": False,
+        "requires_base_url": False,
+        "what_you_need": ("No embedding service; keyword search remains available.",),
+    },
+}
+
+
+def list_memory_embedding_provider_setup_specs() -> list[MemoryEmbeddingProviderSetupSpec]:
+    return [
+        MemoryEmbeddingProviderSetupSpec(
+            provider_id=provider_id,
+            label=str(data["label"]),
+            deployment=data["deployment"],
+            runtime_supported=True,
+            requires_api_key=bool(data["requires_api_key"]),
+            env_key=str(data.get("env_key", "")),
+            requires_base_url=bool(data["requires_base_url"]),
+            blocking=False,
+            can_probe=False,
+            readme_scenarios=("memory", "first-run setup"),
+            what_you_need=tuple(data["what_you_need"]),
+        )
+        for provider_id, data in _MEMORY_EMBEDDING_PROVIDER_DATA.items()
+    ]
+
+
+def get_memory_embedding_provider_setup_spec(
+    provider_id: str,
+) -> MemoryEmbeddingProviderSetupSpec:
+    for spec in list_memory_embedding_provider_setup_specs():
+        if spec.provider_id == provider_id:
+            return spec
+    raise KeyError(f"unknown memory embedding provider: {provider_id!r}")
+
+
+def memory_embedding_provider_catalog_payload() -> list[dict[str, Any]]:
+    return [
+        {
+            "providerId": s.provider_id,
+            "label": s.label,
+            "deployment": s.deployment,
+            "runtimeSupported": s.runtime_supported,
+            "requiresApiKey": s.requires_api_key,
+            "envKey": s.env_key,
+            "requiresBaseUrl": s.requires_base_url,
+            "blocking": s.blocking,
+            "canProbe": s.can_probe,
+            "readmeScenarios": list(s.readme_scenarios),
+            "whatYouNeed": list(s.what_you_need),
+        }
+        for s in list_memory_embedding_provider_setup_specs()
+    ]

--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -67,6 +67,16 @@ def _clean_optional_str(value: str | None) -> str:
     return value.strip()
 
 
+def _positive_int(value: int | str, *, label: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{label} must be an integer >= 1") from None
+    if parsed < 1:
+        raise ValueError(f"{label} must be >= 1")
+    return parsed
+
+
 def _reconcile_router_profile_for_provider(
     cfg: GatewayConfig,
     provider_id: str,
@@ -95,6 +105,17 @@ def _reconcile_router_profile_for_provider(
 def _default_text_tier(default_tier: str | None) -> str:
     tier = (default_tier or "t1").strip()
     return tier if tier in _TEXT_ROUTER_TIERS else "t1"
+
+
+def _normalize_explicit_text_tier(default_tier: str | None) -> str | None:
+    if default_tier is None:
+        return None
+    tier = str(default_tier).strip()
+    if not tier:
+        return None
+    if tier not in _TEXT_ROUTER_TIERS:
+        raise ValueError("defaultTier must reference a text tier")
+    return tier
 
 
 def _router_default_model_for_provider(provider_id: str, default_tier: str | None) -> str:
@@ -256,8 +277,11 @@ def upsert_router(
     router_payload = config.squilla_router.model_dump(mode="python")
     router_payload.pop("tiers", None)
 
-    default_tier_clean = str(default_tier or router_payload.get("default_tier") or "t1")
-    if default_tier is not None:
+    default_tier_override = _normalize_explicit_text_tier(default_tier)
+    default_tier_clean = default_tier_override or str(
+        router_payload.get("default_tier") or "t1"
+    )
+    if default_tier_override is not None:
         router_payload["default_tier"] = default_tier_clean
 
     public_payload: dict[str, Any] = {"mode": router_mode}
@@ -314,7 +338,7 @@ def upsert_search_provider(
     provider_id: str,
     api_key: str = "",
     api_key_env: str = "",
-    max_results: int = 5,
+    max_results: int | str = 5,
     proxy: str = "",
     use_env_proxy: bool = False,
     fallback_policy: str = "off",
@@ -325,14 +349,21 @@ def upsert_search_provider(
         raise ValueError(
             f"search provider {provider_id!r} is not runtime-supported and cannot be configured"
         )
-    if max_results < 1:
-        raise ValueError("max_results must be >= 1")
+    effective_max_results = _positive_int(max_results, label="max_results")
     if fallback_policy not in {"off", "network"}:
         raise ValueError("fallback_policy must be 'off' or 'network'")
     fallback_policy_value = cast(SearchFallbackPolicy, fallback_policy)
 
-    effective_api_key = clean_header_secret(api_key, label="Search API key")
-    effective_api_key_env = "" if api_key else api_key_env.strip()
+    effective_api_key = (
+        clean_header_secret(api_key, label="Search API key")
+        if spec.requires_api_key
+        else ""
+    )
+    effective_api_key_env = (
+        ""
+        if api_key or not spec.requires_api_key
+        else api_key_env.strip()
+    )
     if (
         not effective_api_key
         and not effective_api_key_env
@@ -348,7 +379,7 @@ def upsert_search_provider(
     new_cfg.search_provider = provider_id
     new_cfg.search_api_key = effective_api_key
     new_cfg.search_api_key_env = effective_api_key_env
-    new_cfg.search_max_results = max_results
+    new_cfg.search_max_results = effective_max_results
     new_cfg.search_proxy = proxy
     new_cfg.search_use_env_proxy = bool(use_env_proxy)
     new_cfg.search_fallback_policy = fallback_policy_value
@@ -364,7 +395,7 @@ def upsert_search_provider(
         "api_key": effective_api_key,
         "api_key_env": effective_api_key_env,
         "api_key_source": api_key_source,
-        "max_results": max_results,
+        "max_results": effective_max_results,
         "proxy": proxy,
         "use_env_proxy": bool(use_env_proxy),
         "fallback_policy": fallback_policy_value,
@@ -425,21 +456,23 @@ def upsert_image_generation_provider(
         raise ValueError(
             "primary must be a provider/model reference for "
             f"image generation provider {provider_id!r}"
-        )
+    )
 
     current_provider_cfg = _image_generation_provider_config(config, provider_id)
-    if api_key and api_key_env.strip():
+    explicit_env_key = _clean_optional_str(api_key_env)
+    if api_key and explicit_env_key:
         raise ValueError("configure either api_key or api_key_env, not both")
     effective_api_key = clean_header_secret(
         api_key or getattr(current_provider_cfg, "api_key", ""),
         label="Image API key",
     )
-    env_key = (
-        ""
-        if api_key
-        else api_key_env.strip()
-        or getattr(current_provider_cfg, "api_key_env", spec.env_key)
-        or spec.env_key
+    current_env_key = getattr(current_provider_cfg, "api_key_env", spec.env_key) or ""
+    if api_key:
+        env_key = ""
+    else:
+        env_key = explicit_env_key or current_env_key or spec.env_key
+    has_saved_env_reference = bool(
+        explicit_env_key or (current_env_key and current_env_key != spec.env_key)
     )
     api_key_source = _image_generation_api_key_source(
         config,
@@ -447,11 +480,18 @@ def upsert_image_generation_provider(
         api_key=effective_api_key,
         env_key=env_key,
     )
-    if spec.requires_api_key and api_key_source == "none":
+    if (
+        enabled
+        and spec.requires_api_key
+        and api_key_source == "none"
+        and not has_saved_env_reference
+    ):
         raise ValueError(
             f"image generation provider {provider_id!r} requires an api_key, "
             f"{spec.env_key}, or a matching configured LLM provider"
         )
+    if api_key_source == "none" and has_saved_env_reference:
+        api_key_source = "missing_env"
 
     effective_base_url = (
         base_url or getattr(current_provider_cfg, "base_url", "") or spec.default_base_url
@@ -485,12 +525,28 @@ def upsert_image_generation_provider(
     )
 
 
+def disable_image_generation(config: GatewayConfig) -> MutationResult:
+    new_cfg = _clone(config)
+    new_cfg.image_generation.enabled = False
+    return MutationResult(
+        config=new_cfg,
+        changed=True,
+        restart_required=False,
+        warnings=[],
+        public_payload={
+            "enabled": False,
+            "primary": new_cfg.image_generation.primary,
+        },
+    )
+
+
 def upsert_memory_embedding(
     config: GatewayConfig,
     *,
     provider: str,
     model: str | None = None,
     api_key: str | None = None,
+    api_key_env: str | None = None,
     base_url: str | None = None,
     onnx_dir: str | None = None,
 ) -> MutationResult:
@@ -502,16 +558,29 @@ def upsert_memory_embedding(
     current = config.memory.embedding
     model_value = _clean_optional_str(model)
     api_key_value = _clean_optional_str(api_key)
+    api_key_env_value = _clean_optional_str(api_key_env)
+    if api_key_value and api_key_env_value:
+        raise ValueError("configure either api_key or api_key_env, not both")
     base_url_value = _clean_optional_str(base_url)
     onnx_dir_value = _clean_optional_str(onnx_dir)
     payload: dict[str, Any] = {"provider": provider}
 
     if provider in _REMOTE_MEMORY_EMBEDDING_PROVIDERS:
-        effective_api_key = api_key_value or current.remote.api_key or current.api_key or ""
-        if not effective_api_key:
-            raise ValueError("remote memory embedding provider requires an api_key")
+        current_api_key_env = _clean_optional_str(
+            getattr(current.remote, "api_key_env", None)
+        )
+        effective_api_key_env = "" if api_key_value else (
+            api_key_env_value or current_api_key_env or ""
+        )
+        effective_api_key = (
+            api_key_value
+            or ("" if effective_api_key_env else current.remote.api_key or current.api_key or "")
+        )
+        if not effective_api_key and not effective_api_key_env:
+            raise ValueError(
+                "remote memory embedding provider requires an api_key or api_key_env"
+            )
         payload["remote"] = {
-            "api_key": effective_api_key,
             "base_url": (
                 base_url_value
                 or current.remote.base_url
@@ -519,19 +588,34 @@ def upsert_memory_embedding(
                 or _DEFAULT_REMOTE_EMBEDDING_BASE_URL
             ),
         }
+        if effective_api_key:
+            payload["remote"]["api_key"] = effective_api_key
+        if effective_api_key_env:
+            payload["remote"]["api_key_env"] = effective_api_key_env
         remote_model = model_value or current.remote.model or current.model
         if remote_model:
             payload["remote"]["model"] = remote_model
     elif provider == "auto":
         remote_payload: dict[str, str] = {}
-        effective_api_key = api_key_value or current.remote.api_key or current.api_key or ""
+        current_api_key_env = _clean_optional_str(
+            getattr(current.remote, "api_key_env", None)
+        )
+        effective_api_key_env = "" if api_key_value else (
+            api_key_env_value or current_api_key_env or ""
+        )
+        effective_api_key = (
+            api_key_value
+            or ("" if effective_api_key_env else current.remote.api_key or current.api_key or "")
+        )
         if effective_api_key:
             remote_payload["api_key"] = effective_api_key
+        if effective_api_key_env:
+            remote_payload["api_key_env"] = effective_api_key_env
         remote_base_url = base_url_value or current.remote.base_url or current.base_url
         if remote_base_url:
             remote_payload["base_url"] = remote_base_url
         remote_model = model_value or current.remote.model or (
-            current.model if effective_api_key else None
+            current.model if (effective_api_key or effective_api_key_env) else None
         )
         if remote_model:
             remote_payload["model"] = remote_model
@@ -558,7 +642,7 @@ def upsert_memory_embedding(
 
     new_cfg.memory.embedding = MemoryEmbeddingConfig.model_validate(payload)
     changed = old_memory != new_cfg.memory.model_dump(mode="python")
-    if api_key_value:
+    if api_key_value or api_key_env_value:
         new_cfg.clear_runtime_secret("memory.embedding.remote.api_key")
         new_cfg.clear_runtime_secret("memory.embedding.api_key")
 

--- a/src/opensquilla/onboarding/next_steps.py
+++ b/src/opensquilla/onboarding/next_steps.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import platform
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,7 @@ from opensquilla.onboarding.image_generation_specs import (
     get_image_generation_provider_setup_spec,
 )
 from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
+from opensquilla.onboarding.setup_paths import web_setup_url
 from opensquilla.onboarding.status import get_onboarding_status
 
 _KEY_URLS = {
@@ -19,12 +21,124 @@ _KEY_URLS = {
     "anthropic": "https://console.anthropic.com/settings/keys",
     "deepseek": "https://platform.deepseek.com/api_keys",
 }
+_CAPABILITY_SECTIONS = ("search", "channels", "image_generation", "memory_embedding")
+_CAPABILITY_STATUS_DISPLAY = {
+    "ok": "Ready",
+    "optional": "Later",
+    "missing": "Missing",
+    "degraded": "Needs action",
+    "unknown": "Check",
+}
+_HEADLESS_SECTION_ALIASES = {
+    "llm": "provider",
+    "providers": "provider",
+    "channel": "channels",
+    "image_generation": "image-generation",
+    "memory_embedding": "memory-embedding",
+}
+_HEADLESS_SETUP_COMMANDS = {
+    "provider": (
+        "Provider recipes",
+        "opensquilla onboard catalog providers",
+    ),
+    "router": (
+        "Headless router",
+        "opensquilla onboard configure router --router recommended --default-tier t1",
+    ),
+    "channels": (
+        "Channel recipes",
+        "opensquilla onboard catalog channels",
+    ),
+    "search": (
+        "Headless search",
+        "opensquilla onboard configure search --search-provider duckduckgo",
+    ),
+    "image-generation": (
+        "Image recipes",
+        "opensquilla onboard catalog image",
+    ),
+    "memory-embedding": (
+        "Headless memory embedding",
+        "opensquilla onboard configure memory --memory-provider auto",
+    ),
+}
 
 
-def _set_env_hint(env_key: str) -> str:
+def _normalize_headless_section(section: str) -> str:
+    normalized = section.strip().lower().replace("_", "-")
+    return _HEADLESS_SECTION_ALIASES.get(normalized, normalized)
+
+
+def headless_setup_commands(section: str) -> list[tuple[str, str]]:
+    normalized = _normalize_headless_section(section)
+    commands: list[tuple[str, str]] = []
+    entry = _HEADLESS_SETUP_COMMANDS.get(normalized)
+    if entry:
+        commands.append(entry)
+    return commands
+
+
+def headless_setup_command(section: str) -> tuple[str, str] | None:
+    commands = headless_setup_commands(section)
+    return commands[-1] if commands else None
+
+
+def setup_catalog_command(config_arg: str = "") -> tuple[str, str]:
+    return "Explore options", f"opensquilla onboard catalog{config_arg}"
+
+
+def set_env_hint(env_key: str) -> str:
     if platform.system().lower().startswith("win"):
         return f'PowerShell: $env:{env_key} = "<your-key>"'
     return f'export {env_key}="<your-key>"'
+
+
+def _set_env_hint(env_key: str) -> str:
+    return set_env_hint(env_key)
+
+
+def env_recovery_commands(status: Any) -> list[dict[str, str]]:
+    candidates = [
+        ("llm", "Set provider key", status.llm_source, status.llm_env_key),
+        ("search", "Set search key", status.search_source, status.search_env_key),
+        (
+            "image_generation",
+            "Set image key",
+            status.image_generation_source,
+            status.image_generation_env_key,
+        ),
+        (
+            "memory_embedding",
+            "Set memory key",
+            status.memory_embedding_source,
+            status.memory_embedding_env_key,
+        ),
+    ]
+    seen_env_keys: set[str] = set()
+
+    def priority(
+        item: tuple[int, tuple[str, str, str, str]],
+    ) -> tuple[int, int]:
+        index, (section, _label, _source, _env_key) = item
+        detail = status.section_details.get(section, {})
+        return (0 if detail.get("blocking") else 1, index)
+
+    commands: list[dict[str, str]] = []
+    for _index, (section, label, source, env_key) in sorted(
+        enumerate(candidates),
+        key=priority,
+    ):
+        if source != "missing_env" or not env_key or env_key in seen_env_keys:
+            continue
+        seen_env_keys.add(env_key)
+        commands.append(
+            {
+                "section": section,
+                "label": label,
+                "command": set_env_hint(env_key),
+            }
+        )
+    return commands
 
 
 def _missing_env_warning(surface: str, env_key: str) -> str:
@@ -35,12 +149,33 @@ def _missing_env_warning(surface: str, env_key: str) -> str:
     )
 
 
+def _config_cli_arg(config_path: str | Path | None) -> str:
+    if not config_path:
+        return ""
+    return f" --config {shlex.quote(str(config_path))}"
+
+
 def _image_generation_provider_id(config: Any) -> str:
     primary = str(getattr(config.image_generation, "primary", "") or "")
     provider_id, sep, _model = primary.partition("/")
     if sep and provider_id:
         return provider_id
     return "openai"
+
+
+def _capabilities_summary(status: Any) -> str:
+    parts: list[str] = []
+    for name in _CAPABILITY_SECTIONS:
+        detail = status.section_details.get(name, {})
+        label = str(detail.get("label") or name.replace("_", " ").title())
+        if detail.get("blocking") or detail.get("actionRequired"):
+            display = "Needs action"
+        else:
+            state = status.sections.get(name)
+            value = str(getattr(state, "value", detail.get("status") or "optional"))
+            display = _CAPABILITY_STATUS_DISPLAY.get(value, value.replace("_", " ").title())
+        parts.append(f"{label}={display}")
+    return " | ".join(parts)
 
 
 def env_reference_warnings(config: Any) -> list[str]:
@@ -73,8 +208,24 @@ def env_reference_warnings(config: Any) -> list[str]:
             image_spec = get_image_generation_provider_setup_spec(provider_id)
         except KeyError:
             image_spec = None
-        if image_spec is not None and image_spec.env_key and not os.environ.get(image_spec.env_key):
-            warnings.append(_missing_env_warning("Image generation provider", image_spec.env_key))
+        providers = getattr(getattr(config, "image_generation", None), "providers", None)
+        provider_cfg = getattr(providers, provider_id, None) if providers is not None else None
+        image_env_key = str(getattr(provider_cfg, "api_key_env", "") or "").strip()
+        if not image_env_key and image_spec is not None:
+            image_env_key = str(getattr(image_spec, "env_key", "") or "").strip()
+        if image_env_key and not os.environ.get(image_env_key):
+            warnings.append(_missing_env_warning("Image generation provider", image_env_key))
+
+    embedding = getattr(getattr(config, "memory", None), "embedding", None)
+    embedding_provider = str(getattr(embedding, "requested_provider", "") or "")
+    if embedding_provider in {"openai", "openai-compatible"}:
+        remote = getattr(embedding, "remote", None)
+        memory_env_key = str(getattr(remote, "api_key_env", "") or "").strip()
+        memory_key = str(getattr(remote, "api_key", "") or "") or str(
+            getattr(embedding, "api_key", "") or ""
+        )
+        if memory_env_key and not memory_key and not os.environ.get(memory_env_key):
+            warnings.append(_missing_env_warning("Memory embedding", memory_env_key))
 
     return warnings
 
@@ -87,6 +238,13 @@ def format_next_steps(config: Any, *, config_path: str | Path | None = None) -> 
     provider = str(getattr(llm, "provider", "") or "")
     model = str(getattr(llm, "model", "") or "")
     env_key = str(getattr(llm, "api_key_env", "") or "")
+    router_default = str(getattr(router, "default_tier", "") or "t1")
+    router_line = (
+        "  Router: disabled"
+        if not router.enabled
+        else f"  Router: SquillaRouter, default={router_default}"
+    )
+    config_arg = _config_cli_arg(config_path)
     key_source = status.llm_source
     if key_source == "env" and env_key:
         key_line = f"Key: ${env_key}"
@@ -102,29 +260,20 @@ def format_next_steps(config: Any, *, config_path: str | Path | None = None) -> 
         f"  Config: {path}",
         f"  LLM: {provider} / {model}",
         f"  {key_line}",
-        (
-            "  Router: disabled"
-            if not router.enabled
-            else (
-                f"  Router: profile={router.tier_profile or 'openrouter-mix'}, "
-                f"default={router.default_tier}"
-            )
-        ),
+        router_line,
+        f"  Capabilities: {_capabilities_summary(status)}",
         "",
         "Commands:",
-        "  Run gateway now: opensquilla gateway run",
-        "  Start gateway in background: opensquilla gateway start --json",
-        "  Restart running gateway: opensquilla gateway restart --json",
+        f"  Run gateway now: opensquilla gateway run{config_arg}",
+        f"  Start gateway in background: opensquilla gateway start --json{config_arg}",
+        f"  Restart running gateway: opensquilla gateway restart --json{config_arg}",
     ]
     if key_source == "missing_env" and env_key:
-        lines.append(f"  Set key before starting gateway: {_set_env_hint(env_key)}")
-    lines.extend(
-        [
-            "",
-            "Reference:",
-            "  Web UI: http://127.0.0.1:18791/control/",
-        ]
-    )
+        lines.append(f"  Set key before starting gateway: {set_env_hint(env_key)}")
+    lines.extend(["", "Reference:"])
+    setup_url = web_setup_url(config)
+    if setup_url:
+        lines.append(f"  Web UI: {setup_url}")
     key_url = _KEY_URLS.get(provider)
     if key_url:
         lines.append(f"  Provider keys: {key_url}")

--- a/src/opensquilla/onboarding/provider_specs.py
+++ b/src/opensquilla/onboarding/provider_specs.py
@@ -9,6 +9,7 @@ from opensquilla.gateway.config import ROUTER_TIER_PROFILE_IDS, _router_tier_pro
 from opensquilla.provider.registry import ProviderSpec, list_provider_specs
 
 FieldType = Literal["text", "password", "select", "bool"]
+Deployment = Literal["cloud", "local", "custom", "oauth"]
 
 
 @dataclass(frozen=True)
@@ -34,6 +35,11 @@ class ProviderSetupSpec:
     requires_api_key: bool
     requires_base_url: bool
     router_supported: bool
+    deployment: Deployment
+    blocking: bool
+    can_probe: bool
+    readme_scenarios: tuple[str, ...]
+    what_you_need: tuple[str, ...]
     default_direct_model: str
     capabilities: tuple[str, ...]
     fields: tuple[ProviderSetupField, ...]
@@ -87,6 +93,42 @@ _ONBOARDING_VERIFIED_PROVIDER_IDS = frozenset(
     }
 )
 
+_LOCAL_PROVIDER_IDS = frozenset({"ollama", "vllm", "lm_studio", "ovms"})
+_OAUTH_PROVIDER_IDS = frozenset({"openai_codex", "github_copilot"})
+
+
+def _deployment_for(spec: ProviderSpec) -> Deployment:
+    if spec.provider_id in _LOCAL_PROVIDER_IDS:
+        return "local"
+    if spec.provider_id in _OAUTH_PROVIDER_IDS:
+        return "oauth"
+    if spec.requires_base_url():
+        return "custom"
+    return "cloud"
+
+
+def _what_you_need(spec: ProviderSpec) -> tuple[str, ...]:
+    needs: list[str] = []
+    if spec.provider_id not in ROUTER_TIER_PROFILE_IDS:
+        needs.append(
+            "A local model name available from your model server."
+            if spec.provider_id in _LOCAL_PROVIDER_IDS
+            else "A provider model id."
+        )
+    if spec.requires_api_key():
+        needs.append(
+            f"API key via {spec.env_key} or a one-time paste."
+            if spec.env_key
+            else "Provider API key."
+        )
+    if spec.requires_base_url():
+        needs.append("Provider base URL.")
+    if spec.provider_id in _LOCAL_PROVIDER_IDS:
+        needs.append("A reachable local model server.")
+    if not needs:
+        needs.append("No API key required for the default local path.")
+    return tuple(needs)
+
 
 def _default_direct_model(provider_id: str) -> str:
     if provider_id in ROUTER_TIER_PROFILE_IDS:
@@ -94,6 +136,17 @@ def _default_direct_model(provider_id: str) -> str:
         tier = tiers.get("t1") or tiers.get("t0") or {}
         return str(tier.get("model") or "")
     return ""
+
+
+def _model_description(spec: ProviderSpec, *, router_supported: bool) -> str:
+    if router_supported:
+        return (
+            "Optional direct fallback model. Leave blank to use the selected "
+            "SquillaRouter default tier."
+        )
+    if spec.provider_id in _LOCAL_PROVIDER_IDS:
+        return "Required local model id. Use a model available from your local model server."
+    return "Required model id for this provider."
 
 
 def _fields_for(spec: ProviderSpec) -> tuple[ProviderSetupField, ...]:
@@ -105,10 +158,7 @@ def _fields_for(spec: ProviderSpec) -> tuple[ProviderSetupField, ...]:
             field_type="text",
             required=not router_supported,
             default=_default_direct_model(spec.provider_id),
-            description=(
-                "Direct fallback model. Router-supported providers can leave this "
-                "blank to use the selected router default tier."
-            ),
+            description=_model_description(spec, router_supported=router_supported),
         ),
         ProviderSetupField(
             name="api_key",
@@ -120,6 +170,20 @@ def _fields_for(spec: ProviderSpec) -> tuple[ProviderSetupField, ...]:
                 f"Stored under env key {spec.env_key}." if spec.env_key else ""
             ),
             secret=True,
+        ),
+        *(
+            (
+                ProviderSetupField(
+                    name="api_key_env",
+                    label="API key env",
+                    field_type="text",
+                    required=False,
+                    default=spec.env_key,
+                    description="Environment variable name the gateway reads for this key.",
+                ),
+            )
+            if spec.requires_api_key()
+            else ()
         ),
         ProviderSetupField(
             name="base_url",
@@ -159,6 +223,11 @@ def _to_setup_spec(spec: ProviderSpec) -> ProviderSetupSpec:
         requires_api_key=spec.requires_api_key(),
         requires_base_url=spec.requires_base_url(),
         router_supported=spec.provider_id in ROUTER_TIER_PROFILE_IDS,
+        deployment=_deployment_for(spec),
+        blocking=True,
+        can_probe=False,
+        readme_scenarios=("first-run setup", "quick terminal install"),
+        what_you_need=_what_you_need(spec),
         default_direct_model=_default_direct_model(spec.provider_id),
         capabilities=tuple(sorted(spec.capabilities)),
         fields=_fields_for(spec),
@@ -197,6 +266,11 @@ def provider_catalog_payload() -> list[dict[str, Any]]:
             "requiresApiKey": s.requires_api_key,
             "requiresBaseUrl": s.requires_base_url,
             "routerSupported": s.router_supported,
+            "deployment": s.deployment,
+            "blocking": s.blocking,
+            "canProbe": s.can_probe,
+            "readmeScenarios": list(s.readme_scenarios),
+            "whatYouNeed": list(s.what_you_need),
             "defaultDirectModel": s.default_direct_model,
             "capabilities": list(s.capabilities),
             "fields": [

--- a/src/opensquilla/onboarding/search_specs.py
+++ b/src/opensquilla/onboarding/search_specs.py
@@ -31,6 +31,11 @@ class SearchProviderSetupSpec:
     metadata_supported: bool
     requires_api_key: bool
     env_key: str
+    deployment: Literal["cloud", "local"]
+    blocking: bool
+    can_probe: bool
+    readme_scenarios: tuple[str, ...]
+    what_you_need: tuple[str, ...]
     capabilities: tuple[str, ...]
     fields: tuple[SearchProviderSetupField, ...]
 
@@ -102,6 +107,11 @@ def _fields_for(spec: SearchProviderSpec) -> tuple[SearchProviderSetupField, ...
 
 
 def _to_setup_spec(spec: SearchProviderSpec) -> SearchProviderSetupSpec:
+    what_you_need = (
+        (f"API key via {spec.env_key} or a one-time paste.",)
+        if spec.requires_api_key
+        else ("No API key required.",)
+    )
     return SearchProviderSetupSpec(
         provider_id=spec.provider_id,
         label=_SEARCH_PROVIDER_LABELS.get(spec.provider_id, spec.provider_id),
@@ -109,6 +119,11 @@ def _to_setup_spec(spec: SearchProviderSpec) -> SearchProviderSetupSpec:
         metadata_supported=spec.metadata_supported,
         requires_api_key=spec.requires_api_key,
         env_key=spec.env_key,
+        deployment="cloud" if spec.requires_api_key else "local",
+        blocking=False,
+        can_probe=False,
+        readme_scenarios=("built-in web search", "first-run setup"),
+        what_you_need=what_you_need,
         capabilities=tuple(sorted(spec.capabilities)),
         fields=_fields_for(spec),
     )
@@ -134,6 +149,11 @@ def search_provider_catalog_payload() -> list[dict[str, Any]]:
             "metadataSupported": s.metadata_supported,
             "requiresApiKey": s.requires_api_key,
             "envKey": s.env_key,
+            "deployment": s.deployment,
+            "blocking": s.blocking,
+            "canProbe": s.can_probe,
+            "readmeScenarios": list(s.readme_scenarios),
+            "whatYouNeed": list(s.what_you_need),
             "capabilities": list(s.capabilities),
             "fields": [
                 {

--- a/src/opensquilla/onboarding/section_status.py
+++ b/src/opensquilla/onboarding/section_status.py
@@ -20,7 +20,7 @@ Adding a new section means writing one verifier here and registering it in
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from enum import StrEnum
 from typing import Any, cast
 
@@ -31,6 +31,8 @@ from opensquilla.onboarding.image_generation_specs import (
 )
 from opensquilla.onboarding.provider_specs import get_provider_setup_spec
 from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
+
+FIRST_RUN_REQUIRED_SECTIONS = frozenset({"llm"})
 
 
 class SectionStatus(StrEnum):
@@ -140,6 +142,39 @@ def image_generation_section_status(cfg: GatewayConfig) -> SectionStatus:
     return aggregate
 
 
+def memory_embedding_section_status(cfg: GatewayConfig) -> SectionStatus:
+    """Memory embedding is optional unless the operator selected remote mode.
+
+    The default ``auto`` path is considered locally usable because it falls
+    back to the bundled/on-device embedding stack. ``none`` is an explicit
+    opt-out. Remote embedding providers can use either a stored key or an
+    env-key reference. A configured but currently missing env var is degraded
+    rather than missing, matching the other onboarding key surfaces.
+    """
+    memory = getattr(cfg, "memory", None)
+    embedding = getattr(memory, "embedding", None)
+    if embedding is None:
+        return SectionStatus.OPTIONAL
+    provider = str(getattr(embedding, "requested_provider", "") or "auto")
+    if provider == "none":
+        return SectionStatus.OPTIONAL
+    if provider in {"auto", "local", "ollama"}:
+        return SectionStatus.OK
+    if provider in {"openai", "openai-compatible"}:
+        remote = getattr(embedding, "remote", None)
+        key = (
+            str(getattr(remote, "api_key", "") or "")
+            or str(getattr(embedding, "api_key", "") or "")
+        )
+        if key:
+            return SectionStatus.OK
+        env_key = str(getattr(remote, "api_key_env", "") or "").strip()
+        if env_key:
+            return SectionStatus.OK if os.environ.get(env_key) else SectionStatus.DEGRADED
+        return SectionStatus.MISSING
+    return SectionStatus.UNKNOWN
+
+
 def _image_generation_credential_state(
     cfg: GatewayConfig,
     provider_id: str,
@@ -152,9 +187,9 @@ def _image_generation_credential_state(
     Resolution order (each branch wins if it produces ``OK``):
       1. explicit ``provider_cfg.api_key`` (paste) -> ``OK``
       2. operator-explicit env_key resolved in ``os.environ`` -> ``OK``
-      3. spec default env_key resolved in ``os.environ`` -> ``OK``
-      4. matching LLM provider with an explicit ``api_key`` (image-gen reuses it) -> ``OK``
-      5. operator-explicit env_key declared but absent -> ``DEGRADED``
+      3. operator-explicit env_key declared but absent -> ``DEGRADED``
+      4. spec default env_key resolved in ``os.environ`` -> ``OK``
+      5. matching LLM provider with an explicit ``api_key`` (image-gen reuses it) -> ``OK``
       6. otherwise -> ``MISSING``
 
     Known tradeoff: the config schema does not record whether the operator
@@ -191,8 +226,12 @@ def _image_generation_credential_state(
         cfg_env_key = (getattr(provider_cfg, "api_key_env", "") or "").strip()
     explicit_env_key = cfg_env_key if cfg_env_key and cfg_env_key != spec_env_key else ""
 
-    if explicit_env_key and os.environ.get(explicit_env_key):
-        return SectionStatus.OK
+    if explicit_env_key:
+        return (
+            SectionStatus.OK
+            if os.environ.get(explicit_env_key)
+            else SectionStatus.DEGRADED
+        )
     if spec_env_key and os.environ.get(spec_env_key):
         return SectionStatus.OK
 
@@ -204,9 +243,23 @@ def _image_generation_credential_state(
         return SectionStatus.OK
 
     # Nothing produced an OK; classify how the operator left the provider.
-    if explicit_env_key:
-        return SectionStatus.DEGRADED
     return SectionStatus.MISSING
+
+
+def _image_generation_provider_has_operator_credential(
+    cfg: GatewayConfig,
+    provider_id: str,
+    spec: Any,
+) -> bool:
+    providers = getattr(getattr(cfg, "image_generation", None), "providers", None)
+    provider_cfg = getattr(providers, provider_id, None) if providers is not None else None
+    if provider_cfg is None:
+        return False
+    if getattr(provider_cfg, "api_key", ""):
+        return True
+    spec_env_key = (getattr(spec, "env_key", "") or "").strip()
+    cfg_env_key = (getattr(provider_cfg, "api_key_env", "") or "").strip()
+    return bool(cfg_env_key and cfg_env_key != spec_env_key)
 
 
 def section_verifiers() -> dict[str, Callable[[GatewayConfig], SectionStatus]]:
@@ -217,18 +270,25 @@ def section_verifiers() -> dict[str, Callable[[GatewayConfig], SectionStatus]]:
         "search": search_section_status,
         "channels": channels_section_status,
         "image_generation": image_generation_section_status,
+        "memory_embedding": memory_embedding_section_status,
     }
 
 
-def needs_onboarding(sections: dict[str, SectionStatus]) -> bool:
-    """Any non-OK, non-OPTIONAL section means onboarding has unfinished work.
+def needs_onboarding(
+    sections: dict[str, SectionStatus],
+    *,
+    required_sections: Collection[str] = FIRST_RUN_REQUIRED_SECTIONS,
+) -> bool:
+    """Required non-OK, non-OPTIONAL sections mean onboarding is still blocking.
 
-    DEGRADED is included so a missing env var surfaces on the next
-    ``--if-needed`` run rather than being silently treated as resolved.
+    Optional sections still surface their own action-required status through
+    ``OnboardingStatus.section_details`` but do not keep ``--if-needed`` in the
+    first-run wizard.
     """
     return any(
-        status not in (SectionStatus.OK, SectionStatus.OPTIONAL)
-        for status in sections.values()
+        sections.get(name, SectionStatus.UNKNOWN)
+        not in (SectionStatus.OK, SectionStatus.OPTIONAL)
+        for name in required_sections
     )
 
 
@@ -238,14 +298,26 @@ def _configured_image_generation_provider_ids(cfg: GatewayConfig) -> list[str]:
     fallbacks = list(getattr(image_cfg, "fallbacks", []) or [])
     default_primary = "openai/gpt-image-1"
     explicit_routing = bool(fallbacks) or bool(primary and primary != default_primary)
+    specs = [
+        spec
+        for spec in list_image_generation_provider_setup_specs()
+        if spec.runtime_supported
+    ]
+    explicit_provider_ids = [
+        spec.provider_id
+        for spec in specs
+        if _image_generation_provider_has_operator_credential(
+            cfg,
+            spec.provider_id,
+            spec,
+        )
+    ]
+    if not explicit_routing and explicit_provider_ids:
+        return explicit_provider_ids
     refs = (
         [primary, *fallbacks]
         if explicit_routing
-        else [
-            spec.default_model
-            for spec in list_image_generation_provider_setup_specs()
-            if spec.runtime_supported
-        ]
+        else [spec.default_model for spec in specs]
     )
     seen: set[str] = set()
     result: list[str] = []

--- a/src/opensquilla/onboarding/setup_engine.py
+++ b/src/opensquilla/onboarding/setup_engine.py
@@ -11,8 +11,12 @@ from opensquilla.onboarding.config_store import PersistResult, load_config, pers
 from opensquilla.onboarding.image_generation_specs import (
     image_generation_provider_catalog_payload,
 )
+from opensquilla.onboarding.memory_embedding_specs import (
+    memory_embedding_provider_catalog_payload,
+)
 from opensquilla.onboarding.mutations import (
     MutationResult,
+    disable_image_generation,
     upsert_channel,
     upsert_image_generation_provider,
     upsert_llm_provider,
@@ -26,46 +30,41 @@ from opensquilla.onboarding.router_specs import router_catalog_payload
 from opensquilla.onboarding.search_specs import search_provider_catalog_payload
 from opensquilla.onboarding.status import OnboardingStatus, get_onboarding_status
 
+IMAGE_GENERATION_SECTION_ALIASES = frozenset(
+    {"image", "image-generation", "image_generation"}
+)
+MEMORY_EMBEDDING_SECTION_ALIASES = frozenset(
+    {"memory", "memory-embedding", "memory_embedding"}
+)
 
-def _memory_embedding_catalog_payload() -> list[dict[str, Any]]:
-    return [
-        {
-            "providerId": "auto",
-            "label": "Auto (local BGE first)",
-            "requiresApiKey": False,
-            "requiresBaseUrl": False,
-        },
-        {
-            "providerId": "local",
-            "label": "Bundled BGE-small",
-            "requiresApiKey": False,
-            "requiresBaseUrl": False,
-        },
-        {
-            "providerId": "openai",
-            "label": "OpenAI",
-            "requiresApiKey": True,
-            "requiresBaseUrl": False,
-        },
-        {
-            "providerId": "openai-compatible",
-            "label": "OpenAI-compatible remote",
-            "requiresApiKey": True,
-            "requiresBaseUrl": False,
-        },
-        {
-            "providerId": "ollama",
-            "label": "Ollama",
-            "requiresApiKey": False,
-            "requiresBaseUrl": False,
-        },
-        {
-            "providerId": "none",
-            "label": "FTS-only",
-            "requiresApiKey": False,
-            "requiresBaseUrl": False,
-        },
-    ]
+_CATALOG_SECTION_ALIASES = {
+    "provider": "providers",
+    "providers": "providers",
+    "router": "routerProfiles",
+    "search": "searchProviders",
+    "channels": "channels",
+    "channel": "channels",
+    **{alias: "imageGenerationProviders" for alias in IMAGE_GENERATION_SECTION_ALIASES},
+    **{alias: "memoryEmbeddingProviders" for alias in MEMORY_EMBEDDING_SECTION_ALIASES},
+}
+
+
+def setup_catalog_payload(section: str | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "providers": provider_catalog_payload(),
+        "routerProfiles": router_catalog_payload(),
+        "searchProviders": search_provider_catalog_payload(),
+        "channels": channel_catalog_payload(),
+        "imageGenerationProviders": image_generation_provider_catalog_payload(),
+        "memoryEmbeddingProviders": memory_embedding_provider_catalog_payload(),
+    }
+    if section is None:
+        return payload
+    normalized = section.strip().lower()
+    key = _CATALOG_SECTION_ALIASES.get(normalized)
+    if key is None:
+        raise ValueError(f"unknown setup section: {section!r}")
+    return {key: payload[key]}
 
 
 class SetupEngine:
@@ -86,33 +85,7 @@ class SetupEngine:
         return get_onboarding_status(self.config)
 
     def catalog(self, section: str | None = None) -> dict[str, Any]:
-        payload: dict[str, Any] = {
-            "providers": provider_catalog_payload(),
-            "routerProfiles": router_catalog_payload(),
-            "searchProviders": search_provider_catalog_payload(),
-            "channels": channel_catalog_payload(),
-            "imageGenerationProviders": image_generation_provider_catalog_payload(),
-            "memoryEmbeddingProviders": _memory_embedding_catalog_payload(),
-        }
-        if section is None:
-            return payload
-        normalized = section.strip().lower()
-        aliases = {
-            "provider": "providers",
-            "providers": "providers",
-            "router": "routerProfiles",
-            "search": "searchProviders",
-            "channels": "channels",
-            "channel": "channels",
-            "image-generation": "imageGenerationProviders",
-            "image_generation": "imageGenerationProviders",
-            "memory-embedding": "memoryEmbeddingProviders",
-            "memory_embedding": "memoryEmbeddingProviders",
-        }
-        key = aliases.get(normalized)
-        if key is None:
-            raise ValueError(f"unknown setup section: {section!r}")
-        return {key: payload[key]}
+        return setup_catalog_payload(section)
 
     def apply(self, section: str, payload: dict[str, Any]) -> MutationResult:
         normalized = section.strip().lower()
@@ -150,22 +123,28 @@ class SetupEngine:
             if not isinstance(entry, dict):
                 raise ValueError("channel payload must contain an entry object")
             res = upsert_channel(self.config, entry_payload=entry)
-        elif normalized in {"image-generation", "image_generation"}:
-            res = upsert_image_generation_provider(
-                self.config,
-                provider_id=str(payload["providerId"]),
-                primary=str(payload.get("primary", "")),
-                api_key=str(payload.get("apiKey", "")),
-                api_key_env=str(payload.get("apiKeyEnv", "")),
-                base_url=str(payload.get("baseUrl", "")),
-                enabled=bool(payload.get("enabled", True)),
-            )
-        elif normalized in {"memory-embedding", "memory_embedding"}:
+        elif normalized in IMAGE_GENERATION_SECTION_ALIASES:
+            enabled = bool(payload.get("enabled", True))
+            provider_id = str(payload.get("providerId", ""))
+            if not enabled and not provider_id:
+                res = disable_image_generation(self.config)
+            else:
+                res = upsert_image_generation_provider(
+                    self.config,
+                    provider_id=provider_id,
+                    primary=str(payload.get("primary", "")),
+                    api_key=str(payload.get("apiKey", "")),
+                    api_key_env=str(payload.get("apiKeyEnv", "")),
+                    base_url=str(payload.get("baseUrl", "")),
+                    enabled=enabled,
+                )
+        elif normalized in MEMORY_EMBEDDING_SECTION_ALIASES:
             res = upsert_memory_embedding(
                 self.config,
                 provider=str(payload["providerId"]),
                 model=payload.get("model"),
                 api_key=payload.get("apiKey"),
+                api_key_env=payload.get("apiKeyEnv"),
                 base_url=payload.get("baseUrl"),
                 onnx_dir=payload.get("onnxDir"),
             )

--- a/src/opensquilla/onboarding/setup_paths.py
+++ b/src/opensquilla/onboarding/setup_paths.py
@@ -1,0 +1,29 @@
+"""Shared onboarding setup path helpers."""
+
+from __future__ import annotations
+
+from opensquilla.gateway.config import GatewayConfig
+
+
+def _format_url_host(host: str) -> str:
+    if ":" in host and not (host.startswith("[") and host.endswith("]")):
+        return f"[{host}]"
+    return host
+
+
+def _local_web_host(host: str) -> str:
+    if host == "0.0.0.0":
+        return "127.0.0.1"
+    if host == "::":
+        return "::1"
+    return host
+
+
+def web_setup_url(cfg: GatewayConfig) -> str | None:
+    if not cfg.control_ui.enabled:
+        return None
+    scheme = "https" if cfg.tls.keyfile and cfg.tls.certfile else "http"
+    host = _format_url_host(_local_web_host(str(cfg.host)))
+    base_path = cfg.control_ui.base_path.rstrip("/")
+    setup_path = f"{base_path}/setup" if base_path else "/setup"
+    return f"{scheme}://{host}:{cfg.port}{setup_path}"

--- a/src/opensquilla/onboarding/status.py
+++ b/src/opensquilla/onboarding/status.py
@@ -19,11 +19,14 @@ from opensquilla.onboarding.image_generation_specs import (
     list_image_generation_provider_setup_specs,
 )
 from opensquilla.onboarding.provider_specs import get_provider_setup_spec
+from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
 from opensquilla.onboarding.section_status import (
+    FIRST_RUN_REQUIRED_SECTIONS,
     SectionStatus,
     channels_section_status,
     image_generation_section_status,
     llm_section_status,
+    memory_embedding_section_status,
     router_section_status,
     search_section_status,
     section_verifiers,
@@ -39,20 +42,97 @@ class OnboardingStatus:
     has_config: bool
     llm_configured: bool
     llm_source: str
+    llm_env_key: str
+    search_configured: bool
+    search_provider: str
+    search_source: str
+    search_env_key: str
     image_generation_configured: bool
     image_generation_enabled: bool
     image_generation_source: str
     image_generation_provider: str
     image_generation_primary: str
-    search_configured: bool
+    image_generation_env_key: str
+    memory_embedding_configured: bool
+    memory_embedding_provider: str
+    memory_embedding_source: str
+    memory_embedding_env_key: str
     channel_count: int
     channels_configured: bool
     needs_onboarding: bool
     sections: dict[str, SectionStatus] = field(default_factory=dict)
+    section_details: dict[str, dict[str, object]] = field(default_factory=dict)
     warnings: tuple[str, ...] = ()
 
 
-def _llm_source(cfg: GatewayConfig, status: SectionStatus) -> str:
+_SECTION_LABELS: dict[str, str] = {
+    "llm": "Provider",
+    "router": "Router",
+    "search": "Web search",
+    "channels": "Channels",
+    "image_generation": "Image generation",
+    "memory_embedding": "Memory embedding",
+}
+
+
+def _section_details(
+    sections: dict[str, SectionStatus],
+    detail_text: dict[str, str] | None = None,
+    runtime_blocking: set[str] | None = None,
+) -> dict[str, dict[str, object]]:
+    details: dict[str, dict[str, object]] = {}
+    for name, state in sections.items():
+        required = name in FIRST_RUN_REQUIRED_SECTIONS
+        action_required = state not in (SectionStatus.OK, SectionStatus.OPTIONAL)
+        blocking = (required and action_required) or (
+            action_required and name in (runtime_blocking or set())
+        )
+        details[name] = {
+            "label": _SECTION_LABELS.get(name, name.replace("_", " ").title()),
+            "status": state.value,
+            "required": required,
+            "optional": not required,
+            "blocking": blocking,
+            "actionRequired": action_required,
+        }
+        if detail_text and detail_text.get(name):
+            details[name]["detail"] = detail_text[name]
+    return details
+
+
+def _source_detail(source: str, env_key: str = "") -> str:
+    if source == "explicit":
+        return "stored key"
+    if source == "env":
+        return f"env key visible: {env_key}" if env_key else "env key visible"
+    if source == "missing_env":
+        return f"env key not visible: {env_key}" if env_key else "env key not visible"
+    if source == "not_required":
+        return "no key required"
+    return ""
+
+
+def _with_provider(provider: str, detail: str) -> str:
+    if provider and detail:
+        return f"{provider} ({detail})"
+    return provider or detail
+
+
+def _router_detail(cfg: GatewayConfig, llm_source: str) -> str:
+    router = getattr(cfg, "squilla_router", None)
+    if router is None or not bool(getattr(router, "enabled", False)):
+        return "disabled"
+    llm = getattr(cfg, "llm", None)
+    if llm_source == "none" or not getattr(llm, "provider", ""):
+        return "uses SquillaRouter after provider setup"
+    profile = str(getattr(router, "tier_profile", "") or "").strip()
+    if profile:
+        return f"SquillaRouter profile: {profile}"
+    default_tier = str(getattr(router, "default_tier", "") or "t1").strip()
+    return f"SquillaRouter default tier: {default_tier}"
+
+
+def _llm_source(cfg: GatewayConfig, status: SectionStatus) -> tuple[str, str]:
     """Re-derive the legacy ``llm_source`` annotation alongside the verifier.
 
     The verifier collapses the source detail into a single enum so it stays
@@ -62,23 +142,48 @@ def _llm_source(cfg: GatewayConfig, status: SectionStatus) -> str:
     """
     llm = cfg.llm
     if not llm.provider or not llm.model:
-        return "none"
+        return "none", ""
     try:
         spec = get_provider_setup_spec(llm.provider)
     except KeyError:
-        return "none"
+        return "none", ""
     if not spec.runtime_supported or not spec.requires_api_key:
-        return "none"
+        return "not_required", ""
     if status is SectionStatus.OK and llm.api_key and (
         "llm.api_key" not in getattr(cfg, "_runtime_secret_paths", set())
     ):
-        return "explicit"
+        return "explicit", ""
     env_key = (getattr(llm, "api_key_env", "") or "").strip()
     if env_key and os.environ.get(env_key):
-        return "env"
+        return "env", env_key
     if env_key:
-        return "missing_env"
-    return "none"
+        return "missing_env", env_key
+    return "none", ""
+
+
+def _search_annotations(
+    cfg: GatewayConfig,
+    status: SectionStatus,
+) -> tuple[str, str, str]:
+    provider = str(getattr(cfg, "search_provider", "") or "").strip()
+    if not provider:
+        return "", "none", ""
+    try:
+        spec = get_search_provider_setup_spec(provider)
+    except KeyError:
+        return provider, "none", ""
+    if not spec.requires_api_key:
+        return provider, "not_required", ""
+    if getattr(cfg, "search_api_key", ""):
+        return provider, "explicit", ""
+    env_key = str(getattr(cfg, "search_api_key_env", "") or "").strip()
+    if env_key and os.environ.get(env_key):
+        return provider, "env", env_key
+    if env_key:
+        return provider, "missing_env", env_key
+    if status is SectionStatus.OK:
+        return provider, "env", spec.env_key
+    return provider, "none", spec.env_key
 
 
 def _image_generation_provider_config(cfg: GatewayConfig, provider_id: str) -> object | None:
@@ -100,14 +205,41 @@ def _image_generation_provider_source(
     if explicit_key:
         return "explicit", spec.env_key
 
-    env_key = getattr(provider_cfg, "api_key_env", spec.env_key) if provider_cfg else spec.env_key
-    if env_key and os.environ.get(env_key):
-        return "env", env_key
+    spec_env_key = (getattr(spec, "env_key", "") or "").strip()
+    cfg_env_key = (
+        (getattr(provider_cfg, "api_key_env", "") or "").strip()
+        if provider_cfg
+        else ""
+    )
+    explicit_env_key = cfg_env_key if cfg_env_key and cfg_env_key != spec_env_key else ""
+    if explicit_env_key:
+        return (
+            ("env", explicit_env_key)
+            if os.environ.get(explicit_env_key)
+            else ("missing_env", explicit_env_key)
+        )
+    if spec_env_key and os.environ.get(spec_env_key):
+        return "env", spec_env_key
 
     llm = getattr(cfg, "llm", None)
     if getattr(llm, "provider", "").strip().lower() == provider_id and getattr(llm, "api_key", ""):
         return "llm_fallback", spec.env_key
-    return "", spec.env_key
+    return "", spec_env_key
+
+
+def _image_generation_provider_has_operator_credential(
+    cfg: GatewayConfig,
+    provider_id: str,
+    spec: object,
+) -> bool:
+    provider_cfg = _image_generation_provider_config(cfg, provider_id)
+    if provider_cfg is None:
+        return False
+    if getattr(provider_cfg, "api_key", ""):
+        return True
+    spec_env_key = (getattr(spec, "env_key", "") or "").strip()
+    cfg_env_key = (getattr(provider_cfg, "api_key_env", "") or "").strip()
+    return bool(cfg_env_key and cfg_env_key != spec_env_key)
 
 
 def _configured_image_generation_provider_ids(cfg: GatewayConfig) -> list[str]:
@@ -117,14 +249,26 @@ def _configured_image_generation_provider_ids(cfg: GatewayConfig) -> list[str]:
     fallbacks = list(getattr(image_cfg, "fallbacks", []) or [])
     default_primary = "openai/gpt-image-1"
     explicit_model_routing = bool(fallbacks) or bool(primary and primary != default_primary)
+    specs = [
+        spec
+        for spec in list_image_generation_provider_setup_specs()
+        if spec.runtime_supported
+    ]
+    explicit_provider_ids = [
+        spec.provider_id
+        for spec in specs
+        if _image_generation_provider_has_operator_credential(
+            cfg,
+            spec.provider_id,
+            spec,
+        )
+    ]
+    if not explicit_model_routing and explicit_provider_ids:
+        return explicit_provider_ids
     if explicit_model_routing:
         refs = [primary, *fallbacks]
     else:
-        refs = [
-            spec.default_model
-            for spec in list_image_generation_provider_setup_specs()
-            if spec.runtime_supported
-        ]
+        refs = [spec.default_model for spec in specs]
 
     provider_ids: list[str] = []
     seen: set[str] = set()
@@ -140,16 +284,58 @@ def _configured_image_generation_provider_ids(cfg: GatewayConfig) -> list[str]:
 def _image_generation_annotations(
     cfg: GatewayConfig,
     status: SectionStatus,
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, str]:
     image_cfg = cfg.image_generation
     primary = getattr(image_cfg, "primary", "")
     if status is SectionStatus.OPTIONAL:
-        return "none", "", primary
+        return "none", "", primary, ""
     for provider_id in _configured_image_generation_provider_ids(cfg):
-        source, _env_key = _image_generation_provider_source(cfg, provider_id)
+        source, env_key = _image_generation_provider_source(cfg, provider_id)
         if source:
-            return source, provider_id, primary
-    return "none", "", primary
+            return source, provider_id, primary, env_key
+    return "none", "", primary, ""
+
+
+def _memory_embedding_annotations(
+    cfg: GatewayConfig,
+    status: SectionStatus,
+) -> tuple[str, str]:
+    memory = getattr(cfg, "memory", None)
+    embedding = getattr(memory, "embedding", None)
+    if embedding is None:
+        return "none", ""
+    provider = str(getattr(embedding, "requested_provider", "") or "auto")
+    if provider in {"none", "auto", "local", "ollama"}:
+        return "not_required", ""
+    remote = getattr(embedding, "remote", None)
+    key = (
+        str(getattr(remote, "api_key", "") or "")
+        or str(getattr(embedding, "api_key", "") or "")
+    )
+    if key:
+        return "explicit", ""
+    env_key = str(getattr(remote, "api_key_env", "") or "").strip()
+    if env_key and os.environ.get(env_key):
+        return "env", env_key
+    if env_key:
+        return "missing_env", env_key
+    if status is SectionStatus.OK:
+        return "env", env_key
+    return "none", env_key
+
+
+def _runtime_blocking_sections(
+    *,
+    memory_provider: str,
+    memory_status: SectionStatus,
+) -> set[str]:
+    blocking: set[str] = set()
+    if (
+        memory_provider in {"openai", "openai-compatible"}
+        and memory_status not in (SectionStatus.OK, SectionStatus.OPTIONAL)
+    ):
+        blocking.add("memory_embedding")
+    return blocking
 
 
 def get_onboarding_status(config: GatewayConfig) -> OnboardingStatus:
@@ -159,10 +345,44 @@ def get_onboarding_status(config: GatewayConfig) -> OnboardingStatus:
     sections = {name: verifier(config) for name, verifier in section_verifiers().items()}
 
     llm_status = sections["llm"]
+    search_status = sections["search"]
     image_status = sections["image_generation"]
-    image_source, image_provider, image_primary = _image_generation_annotations(
+    memory_status = sections["memory_embedding"]
+    llm_source, llm_env_key = _llm_source(config, llm_status)
+    search_provider, search_source, search_env_key = _search_annotations(
+        config, search_status
+    )
+    image_source, image_provider, image_primary, image_env_key = _image_generation_annotations(
         config, image_status
     )
+    memory_embedding = getattr(getattr(config, "memory", None), "embedding", None)
+    memory_provider = str(
+        getattr(memory_embedding, "requested_provider", "")
+        or getattr(memory_embedding, "provider", "")
+        or ""
+    )
+    memory_source, memory_env_key = _memory_embedding_annotations(config, memory_status)
+    runtime_blocking = _runtime_blocking_sections(
+        memory_provider=memory_provider,
+        memory_status=memory_status,
+    )
+    detail_text = {
+        "llm": _source_detail(llm_source, llm_env_key),
+        "router": _router_detail(config, llm_source),
+        "search": _source_detail(search_source, search_env_key),
+        "image_generation": _with_provider(
+            image_provider,
+            (
+                "same provider key"
+                if image_source == "llm_fallback"
+                else _source_detail(image_source, image_env_key)
+            ),
+        ),
+        "memory_embedding": _with_provider(
+            memory_provider,
+            _source_detail(memory_source, memory_env_key),
+        ),
+    }
 
     enabled_channels = [c for c in config.channels.channels if c.enabled]
 
@@ -170,17 +390,27 @@ def get_onboarding_status(config: GatewayConfig) -> OnboardingStatus:
         config_path=str(path),
         has_config=has_config,
         llm_configured=llm_status is SectionStatus.OK,
-        llm_source=_llm_source(config, llm_status),
+        llm_source=llm_source,
+        llm_env_key=llm_env_key,
+        search_configured=search_status is SectionStatus.OK,
+        search_provider=search_provider,
+        search_source=search_source,
+        search_env_key=search_env_key,
         image_generation_configured=image_status is SectionStatus.OK,
         image_generation_enabled=bool(getattr(config.image_generation, "enabled", False)),
         image_generation_source=image_source,
         image_generation_provider=image_provider,
         image_generation_primary=image_primary,
-        search_configured=sections["search"] is SectionStatus.OK,
+        image_generation_env_key=image_env_key,
+        memory_embedding_configured=memory_status is SectionStatus.OK,
+        memory_embedding_provider=memory_provider,
+        memory_embedding_source=memory_source,
+        memory_embedding_env_key=memory_env_key,
         channel_count=len(config.channels.channels),
         channels_configured=bool(enabled_channels),
-        needs_onboarding=_needs_onboarding(sections),
+        needs_onboarding=_needs_onboarding(sections) or bool(runtime_blocking),
         sections=sections,
+        section_details=_section_details(sections, detail_text, runtime_blocking),
     )
 
 
@@ -191,6 +421,7 @@ __all__ = [
     "channels_section_status",
     "image_generation_section_status",
     "llm_section_status",
+    "memory_embedding_section_status",
     "router_section_status",
     "search_section_status",
 ]

--- a/src/opensquilla/skills/meta/orchestrator.py
+++ b/src/opensquilla/skills/meta/orchestrator.py
@@ -297,8 +297,11 @@ class MetaOrchestrator:
             if run_id is not None and self._run_writer is not None:
                 try:
                     if cancelled:
-                        await _to_thread(
-                            self._run_writer.finish_run_sync,
+                        # A cancelled task may interrupt an awaited executor
+                        # future before the sqlite update is visible. The
+                        # cancel marker is a single local UPDATE, so keep it
+                        # in this task's finalizer.
+                        self._run_writer.finish_run_sync(
                             run_id=run_id,
                             status="cancelled",
                             result=None,

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -127,9 +127,11 @@ def test_gateway_run_turns_missing_onboarding_env_into_recovery_hint(
         in compact
     )
     expected_config = str(target).replace("\\", "/")
-    assert (
-        f"opensquillaonboardstatus--config{expected_config}"
-        in compact.replace("\\", "/")
+    normalized = compact.replace("\\", "/")
+    assert "opensquillaonboardstatus--config" in normalized
+    assert expected_config in normalized
+    assert normalized.index("opensquillaonboardstatus--config") < normalized.index(
+        expected_config
     )
     assert "Traceback" not in output
 

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -80,6 +80,46 @@ def test_gateway_startup_guidance_shows_operator_next_steps() -> None:
     assert "[dim]Keep this terminal open. Press Ctrl+C to stop.[/dim]" in guidance
 
 
+def test_gateway_run_turns_missing_onboarding_env_into_recovery_hint(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "custom.toml"
+    target.write_text(
+        '[llm]\n'
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key = "sk-or"\n'
+        '\n'
+        '[memory.embedding]\n'
+        'provider = "openai"\n'
+        '\n'
+        '[memory.embedding.remote]\n'
+        'api_key_env = "OPENAI_EMBEDDINGS_API_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "home"))
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
+
+    async def fail_start_gateway_server(**_kwargs):
+        raise ValueError(
+            "memory.embedding.provider='openai' requires "
+            "memory.embedding.remote.api_key"
+        )
+
+    monkeypatch.setattr(gateway_cmd, "start_gateway_server", fail_start_gateway_server)
+
+    result = runner.invoke(app, ["gateway", "run", "--config", str(target)])
+
+    assert result.exit_code == 1
+    output = result.stdout + (result.stderr or "")
+    compact = "".join(output.split())
+    assert "Gateway could not start" in output
+    assert 'Set memory key: export OPENAI_EMBEDDINGS_API_KEY="<your-key>"' in output
+    assert f"opensquillaonboardstatus--config{target}" in compact
+    assert "Traceback" not in output
+
+
 def test_gateway_lifecycle_paths_use_state_root(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "home"))
 
@@ -357,6 +397,44 @@ def test_gateway_run_uses_config_host_port_when_flags_are_omitted(
 
     assert captured["config"].host == "127.0.0.2"
     assert captured["config"].port == 19999
+
+
+def test_gateway_run_keeps_missing_explicit_config_path_for_setup(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    custom_config = tmp_path / "first-run.toml"
+    captured = {}
+
+    class FakeServer:
+        def __init__(self, task):
+            self._task = task
+
+        async def close(self, _reason):
+            return None
+
+    async def fake_start_gateway_server(*, config, subscription_manager, run):
+        captured["config"] = config
+
+        async def done():
+            return None
+
+        import asyncio
+
+        return FakeServer(asyncio.create_task(done()))
+
+    monkeypatch.setattr(gateway_cmd, "start_gateway_server", fake_start_gateway_server)
+
+    gateway_cmd.run_gateway(
+        port=19876,
+        bind=None,
+        listen="",
+        debug=False,
+        config_path=str(custom_config),
+    )
+
+    assert captured["config"].config_path == str(custom_config)
+    assert not custom_config.exists()
 
 
 def test_gateway_start_waits_for_readiness_after_liveness(tmp_path, monkeypatch) -> None:

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import platform
 import sys
 from types import SimpleNamespace
 
@@ -13,6 +14,12 @@ from opensquilla.paths import default_opensquilla_home
 
 runner = CliRunner()
 Manager = gateway_lifecycle.GatewayLifecycleManager
+
+
+def _env_hint(env_key: str) -> str:
+    if platform.system().lower().startswith("win"):
+        return f'PowerShell: $env:{env_key} = "<your-key>"'
+    return f'export {env_key}="<your-key>"'
 
 
 def _payload(result):
@@ -115,7 +122,10 @@ def test_gateway_run_turns_missing_onboarding_env_into_recovery_hint(
     output = result.stdout + (result.stderr or "")
     compact = "".join(output.split())
     assert "Gateway could not start" in output
-    assert 'Set memory key: export OPENAI_EMBEDDINGS_API_KEY="<your-key>"' in output
+    assert (
+        f"Set memory key: {_env_hint('OPENAI_EMBEDDINGS_API_KEY')}".replace(" ", "")
+        in compact
+    )
     assert f"opensquillaonboardstatus--config{target}" in compact
     assert "Traceback" not in output
 

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -126,7 +126,11 @@ def test_gateway_run_turns_missing_onboarding_env_into_recovery_hint(
         f"Set memory key: {_env_hint('OPENAI_EMBEDDINGS_API_KEY')}".replace(" ", "")
         in compact
     )
-    assert f"opensquillaonboardstatus--config{target}" in compact
+    expected_config = str(target).replace("\\", "/")
+    assert (
+        f"opensquillaonboardstatus--config{expected_config}"
+        in compact.replace("\\", "/")
+    )
     assert "Traceback" not in output
 
 

--- a/tests/test_cli/test_help_theme.py
+++ b/tests/test_cli/test_help_theme.py
@@ -55,6 +55,44 @@ def test_onboard_help_uses_compact_option_columns() -> None:
     assert not re.search(r"--provider\s{12,}TEXT", output)
 
 
+def test_onboard_help_explains_first_run_inputs() -> None:
+    result = runner.invoke(app, ["onboard", "--help"], terminal_width=110)
+
+    assert result.exit_code == 0, result.output
+    output = click.unstyle(result.output)
+    assert "OpenSquilla setup cockpit" in output
+    assert "SquillaRouter" in output
+    assert "Provider id to configure" in output
+    assert "Model id for the provider" in output
+    assert "Read the provider key from this environment" in output
+    assert "variable." in output
+    assert "Only run the wizard when required setup is" in output
+    assert "incomplete." in output
+    assert "Leave channel setup for later" in output
+    assert "Leave optional Web search setup for later" in output
+    assert "Leave optional image generation setup for later" in output
+
+
+def test_configure_help_explains_section_specific_inputs() -> None:
+    result = runner.invoke(app, ["configure", "--help"], terminal_width=110)
+
+    assert result.exit_code == 0, result.output
+    output = click.unstyle(result.output)
+    normalized = " ".join(output.replace("│", " ").split())
+    assert "Reconfigure provider, router, channels, search, image generation, or memory" in output
+    assert "Usage:" in output
+    assert "[SECTION]" in output
+    assert "SECTION_ARG" not in output
+    assert "Section to configure" in output
+    assert "Text provider id for provider setup" in normalized
+    assert "Search provider id" in normalized
+    assert "Image provider id" in normalized
+    assert "Model id for provider or remote memory embedding" in normalized
+    assert "Channel type such as slack, discord, feishu" in normalized
+    assert "Image model id" in normalized
+    assert "Memory embedding provider" in output
+
+
 def test_help_theme_supports_click_make_metavar_without_context(monkeypatch) -> None:
     def legacy_make_metavar(self: click.Option) -> str:
         if self.is_bool_flag:

--- a/tests/test_cli/test_onboard_cmd.py
+++ b/tests/test_cli/test_onboard_cmd.py
@@ -6,6 +6,7 @@ import json as _json
 import shlex
 import tomllib
 
+import pytest
 from typer.testing import CliRunner
 
 from opensquilla.cli.main import app
@@ -33,6 +34,71 @@ def test_onboard_noninteractive_provider(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.stdout
     assert "openrouter" in target.read_text()
     assert "sk" not in result.stdout
+    assert "onboarding.config_persisted" not in result.stdout
+    assert "openrouter ·" not in result.stdout
+    assert "OpenSquilla Setup Handoff" in result.stdout
+    assert "Provider Configured" not in result.stdout
+    assert "LLM: openrouter / deepseek/deepseek-v4-flash" in result.stdout
+
+
+def test_onboard_finish_commands_remain_copyable_with_long_config_path(
+    tmp_path,
+    monkeypatch,
+):
+    from opensquilla.cli import onboard_cmd
+
+    target = tmp_path / "very-long-config-name-for-onboard-output.toml"
+    monkeypatch.setattr(onboard_cmd.console, "width", 48)
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "--provider",
+            "openrouter",
+            "--model",
+            "deepseek/deepseek-v4-flash",
+            "--api-key",
+            "sk",
+            "--router",
+            "disabled",
+            "--minimal",
+            "--config",
+            str(target),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert f"opensquilla gateway run --config {_config_arg(target)}" in result.stdout
+    assert f"opensquilla gateway start --json --config {_config_arg(target)}" in result.stdout
+    assert (
+        f"opensquilla gateway restart --json --config {_config_arg(target)}"
+        in result.stdout
+    )
+
+
+def test_onboard_status_paths_remain_copyable_with_long_config_path(
+    tmp_path,
+    monkeypatch,
+):
+    from opensquilla.cli import onboard_cmd
+
+    target = tmp_path / "very-long-config-name-for-onboard-status-output.toml"
+    monkeypatch.setattr(onboard_cmd.console, "width", 48)
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert (
+        f"Guided CLI: opensquilla onboard --if-needed --config {_config_arg(target)}"
+        in result.stdout
+    )
+    assert f"Web UI: opensquilla gateway run --config {_config_arg(target)}" in result.stdout
+    assert (
+        "Provider recipes: "
+        f"opensquilla onboard catalog providers --config {_config_arg(target)}"
+        in result.stdout
+    )
 
 
 def test_onboard_accepts_skip_image_generation_option(tmp_path, monkeypatch):
@@ -102,6 +168,8 @@ def test_onboard_noninteractive_provider_can_use_env_key_and_router(tmp_path, mo
             "deepseek-chat",
             "--api-key-env",
             "DEEPSEEK_API_KEY",
+            "--proxy",
+            "http://127.0.0.1:7890",
             "--router",
             "recommended",
             "--minimal",
@@ -112,6 +180,7 @@ def test_onboard_noninteractive_provider_can_use_env_key_and_router(tmp_path, mo
     data = tomllib.loads(target.read_text())
     assert data["llm"]["provider"] == "deepseek"
     assert data["llm"]["api_key_env"] == "DEEPSEEK_API_KEY"
+    assert data["llm"]["proxy"] == "http://127.0.0.1:7890"
     assert "api_key" not in data["llm"]
     assert data["squilla_router"]["tier_profile"] == "deepseek"
     assert "tiers" not in data["squilla_router"]
@@ -173,6 +242,27 @@ def test_onboard_noninteractive_provider_without_router_profile_disables_router(
     assert data["squilla_router"]["enabled"] is False
 
 
+def test_onboard_noninteractive_provider_error_is_productized(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "--provider",
+            "ollama",
+            "--minimal",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "model is required" in result.stderr
+    assert "--model <model-id>" in result.stderr
+    assert "Traceback" not in result.stdout + result.stderr
+    assert not target.exists()
+
+
 def test_onboard_if_needed_skips_when_configured(tmp_path, monkeypatch):
     target = tmp_path / "c.toml"
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
@@ -188,7 +278,10 @@ def test_onboard_if_needed_skips_when_configured(tmp_path, monkeypatch):
     mtime_before = target.stat().st_mtime
     result = runner.invoke(app, ["onboard", "--if-needed"])
     assert result.exit_code == 0
-    assert "already complete" in result.stdout.lower()
+    assert "core setup is ready" in result.stdout.lower()
+    assert "Optional next moves:" in result.stdout
+    assert "Channel recipes:" in result.stdout
+    assert "Image recipes:" in result.stdout
     assert target.stat().st_mtime == mtime_before
 
 
@@ -208,7 +301,9 @@ def test_onboard_if_needed_uses_explicit_config_path(tmp_path, monkeypatch):
     result = runner.invoke(app, ["onboard", "--if-needed", "--config", str(target)])
 
     assert result.exit_code == 0
-    assert "already complete" in result.stdout.lower()
+    assert "core setup is ready" in result.stdout.lower()
+    assert "Optional next moves:" in result.stdout
+    assert f"--config{_config_arg(target)}" in "".join(result.stdout.split())
     assert not default_target.exists()
 
 
@@ -227,7 +322,8 @@ def test_onboard_if_needed_skips_when_key_comes_from_env(tmp_path, monkeypatch):
     result = runner.invoke(app, ["onboard", "--if-needed"])
 
     assert result.exit_code == 0
-    assert "already complete" in result.stdout.lower()
+    assert "core setup is ready" in result.stdout.lower()
+    assert "Optional next moves:" in result.stdout
 
 
 def test_onboard_if_needed_does_not_treat_env_as_config_without_config_file(
@@ -346,6 +442,53 @@ def test_onboard_status_uses_explicit_config_path(tmp_path, monkeypatch):
     assert not default_target.exists()
 
 
+def test_onboard_status_json_exposes_provider_section_alias(tmp_path, monkeypatch):
+    target = tmp_path / "custom.toml"
+    target.write_text(
+        '[llm]\n'
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key_env = "CUSTOM_LLM_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("CUSTOM_LLM_KEY", raising=False)
+
+    result = runner.invoke(app, ["onboard", "status", "--json", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    payload = _json.loads(result.stdout)
+    assert payload["sections"]["provider"] == payload["sections"]["llm"]
+    assert payload["sectionDetails"]["provider"] == payload["sectionDetails"]["llm"]
+    assert payload["sectionDetails"]["provider"]["label"] == "Provider"
+    assert payload["sectionAliases"] == {"llm": "provider"}
+    assert payload["envRecoveryCommands"] == [
+        {
+            "section": "llm",
+            "label": "Set provider key",
+            "command": 'export CUSTOM_LLM_KEY="<your-key>"',
+        }
+    ]
+
+
+def test_onboard_status_reports_invalid_config_without_traceback(tmp_path):
+    target = tmp_path / "bad.toml"
+    target.write_text("[search]\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 2
+    assert "OpenSquilla config error" in result.stderr
+    assert str(target) in result.stderr
+    assert "search" in result.stderr
+    assert "Fix:" in result.stderr
+    assert (
+        f"opensquillaonboard--if-needed--config{_config_arg(target)}"
+        in "".join(result.stderr.split())
+    )
+    assert "Traceback" not in result.stderr
+    assert "pydantic_core" not in result.stderr
+
+
 def test_onboard_status_table_keeps_explicit_config_path_in_next_step(
     tmp_path,
     monkeypatch,
@@ -372,6 +515,883 @@ def test_onboard_status_table_keeps_explicit_config_path_in_next_step(
     assert not default_target.exists()
 
 
+def test_onboard_status_table_offers_cli_web_and_recipe_setup_paths(
+    tmp_path,
+    monkeypatch,
+):
+    default_target = tmp_path / "default.toml"
+    target = tmp_path / "custom.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(default_target))
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    collapsed = "".join(result.stdout.split())
+    assert "Setup paths:" in result.stdout
+    assert "Guided CLI:" in result.stdout
+    assert (
+        f"opensquillaonboard--if-needed--config{_config_arg(target)}"
+        in collapsed
+    )
+    assert "Web UI:" in result.stdout
+    assert (
+        f"opensquillagatewayrun--config{_config_arg(target)}"
+        in collapsed
+    )
+    assert "http://127.0.0.1:18791/control/setup" in result.stdout
+    assert "Explore options:" in result.stdout
+    assert (
+        f"opensquillaonboardcatalog--config{_config_arg(target)}"
+        in collapsed
+    )
+    assert "opensquilla onboard catalog --json" not in result.stdout
+    assert "Provider recipes:" in result.stdout
+    assert (
+        "opensquillaonboardcatalogproviders"
+        f"--config{_config_arg(target)}"
+        in collapsed
+    )
+    assert "--provider<id>" not in collapsed
+    assert "--model<model>" not in collapsed
+    assert "--api-key-env<ENV_NAME>" not in collapsed
+    assert not default_target.exists()
+
+
+def test_onboard_status_points_missing_provider_to_provider_recipes(
+    tmp_path,
+    monkeypatch,
+):
+    default_target = tmp_path / "default.toml"
+    target = tmp_path / "custom.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(default_target))
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    collapsed = "".join(result.stdout.split())
+    assert "Provider recipes:" in result.stdout
+    assert (
+        f"opensquillaonboardcatalogproviders--config{_config_arg(target)}"
+        in collapsed
+    )
+    assert "Headless provider:" not in result.stdout
+    assert "--provider <id>" not in result.stdout
+    assert "--model <model>" not in result.stdout
+    assert "--api-key-env <ENV_NAME>" not in result.stdout
+    assert not default_target.exists()
+
+
+def test_onboard_status_leads_with_recommended_next_move(tmp_path, monkeypatch):
+    default_target = tmp_path / "default.toml"
+    target = tmp_path / "custom.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(default_target))
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    collapsed = "".join(result.stdout.split())
+    assert "Recommended next move:" in result.stdout
+    assert "Guided CLI:" in result.stdout
+    assert (
+        f"GuidedCLI:opensquillaonboard--if-needed--config{_config_arg(target)}"
+        in collapsed
+    )
+    assert result.stdout.count("Guided CLI:") == 1
+    assert result.stdout.index("Recommended next move:") < result.stdout.index(
+        "Setup paths:"
+    )
+    assert not default_target.exists()
+
+
+def test_onboard_status_web_path_uses_gateway_and_control_ui_config(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "custom.toml"
+    target.write_text(
+        'host = "0.0.0.0"\n'
+        "port = 19999\n"
+        "\n"
+        "[control_ui]\n"
+        'base_path = "/ops"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(tmp_path / "default.toml"))
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Web UI:" in result.stdout
+    assert "http://127.0.0.1:19999/ops/setup" in result.stdout
+    assert "http://0.0.0.0:19999" not in result.stdout
+
+
+def test_onboard_status_does_not_offer_disabled_web_ui_path(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "custom.toml"
+    target.write_text(
+        "[control_ui]\n"
+        "enabled = false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(tmp_path / "default.toml"))
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Guided CLI:" in result.stdout
+    assert "Provider recipes:" in result.stdout
+    assert "Web UI:" not in result.stdout
+    assert "/control/setup" not in result.stdout
+
+
+def test_onboard_status_table_uses_product_labels_and_scope_column(
+    tmp_path,
+    monkeypatch,
+):
+    default_target = tmp_path / "default.toml"
+    target = tmp_path / "custom.toml"
+    target.write_text(
+        '[llm]\n'
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key_env = "CUSTOM_LLM_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(default_target))
+    monkeypatch.delenv("CUSTOM_LLM_KEY", raising=False)
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "OpenSquilla setup readiness" in result.stdout
+    assert "OpenSquilla ready:" in result.stdout
+    assert "Needs onboarding:" not in result.stdout
+    assert "Provider" in result.stdout
+    assert "Web search" in result.stdout
+    assert "Image generation" in result.stdout
+    assert "Memory embedding" in result.stdout
+    assert "Required" in result.stdout
+    assert "Optional" in result.stdout
+    assert "Later" in result.stdout
+    assert "env key not visible" in result.stdout
+    assert "llm" not in result.stdout
+    assert "missing_env" not in result.stdout
+    assert "image_generation" not in result.stdout
+    assert not default_target.exists()
+
+
+def test_onboard_status_prioritizes_missing_env_recovery(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "custom.toml"
+    target.write_text(
+        '[llm]\n'
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key_env = "CUSTOM_LLM_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("CUSTOM_LLM_KEY", raising=False)
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert 'Set provider key: export CUSTOM_LLM_KEY="<your-key>"' in result.stdout
+    assert result.stdout.index("Set provider key:") < result.stdout.index("Guided CLI:")
+
+
+def test_onboard_status_prints_action_guide_without_squeezing_detail(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "custom.toml"
+    target.write_text(
+        '[llm]\n'
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key_env = "CUSTOM_LLM_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("CUSTOM_LLM_KEY", raising=False)
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Action guide:" in result.stdout
+    assert "Fix: blocked or action-required" in result.stdout
+    assert "Review: ready" in result.stdout
+    assert "Configure: optional later" in result.stdout
+    assert "┃ Action" not in result.stdout.split("Action guide:", 1)[0]
+    assert "env key not visible" in result.stdout
+
+
+def test_onboard_help_exposes_configure_command():
+    result = runner.invoke(app, ["onboard", "--help"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "status" in result.stdout
+    assert "catalog" in result.stdout
+    assert "List onboarding setup options for every configurable section." in result.stdout
+    assert "configure" in result.stdout
+    assert "Reconfigure provider, router, channels, search, image generation" in result.stdout
+    assert "or memory." in result.stdout
+
+
+def test_onboard_catalog_json_exposes_all_setup_options(tmp_path, monkeypatch):
+    target = tmp_path / "custom.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "catalog", "--json", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    payload = _json.loads(result.stdout)
+    assert {
+        "providers",
+        "routerProfiles",
+        "searchProviders",
+        "channels",
+        "imageGenerationProviders",
+        "memoryEmbeddingProviders",
+    } <= payload.keys()
+    assert any(row["providerId"] == "openrouter" for row in payload["providers"])
+    assert any(row["providerId"] == "duckduckgo" for row in payload["searchProviders"])
+    assert any(row["providerId"] == "openrouter" for row in payload["imageGenerationProviders"])
+    assert any(row["providerId"] == "auto" for row in payload["memoryEmbeddingProviders"])
+    assert any(row["type"] == "discord" for row in payload["channels"])
+    assert not target.exists()
+
+
+def test_onboard_catalog_help_names_short_capability_section_aliases():
+    result = runner.invoke(app, ["onboard", "catalog", "--help"])
+
+    assert result.exit_code == 0, result.stdout
+    plain = " ".join(result.stdout.replace("│", " ").split())
+    assert "image (alias for image-generation)" in plain
+    assert "memory (alias for memory-embedding)" in plain
+
+
+def test_onboard_catalog_can_focus_one_setup_section():
+    result = runner.invoke(app, ["onboard", "catalog", "search", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = _json.loads(result.stdout)
+    assert list(payload) == ["searchProviders"]
+    assert any(row["providerId"] == "duckduckgo" for row in payload["searchProviders"])
+    assert all("requiresApiKey" in row for row in payload["searchProviders"])
+
+
+@pytest.mark.parametrize(
+    ("alias", "section_key", "expected"),
+    [
+        ("image", "imageGenerationProviders", "openrouter/google/gemini"),
+        ("memory", "memoryEmbeddingProviders", "openai-compatible"),
+    ],
+)
+def test_onboard_catalog_accepts_short_capability_section_aliases(
+    alias,
+    section_key,
+    expected,
+):
+    result = runner.invoke(app, ["onboard", "catalog", alias, "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = _json.loads(result.stdout)
+    assert list(payload) == [section_key]
+    assert expected in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("section", "expected"),
+    [
+        ("providers", ["openrouter", "OPENROUTER_API_KEY", "deepseek/deepseek-v4-flash"]),
+        ("router", ["recommended", "openrouter-mix", "t0", "t3"]),
+        ("search", ["duckduckgo", "brave", "BRAVE_SEARCH_API_KEY"]),
+        ("channels", ["discord", "Bot token", "opensquilla channels describe discord --json"]),
+        ("image-generation", ["openrouter", "openrouter/google/gemini", "OPENROUTER_API_KEY"]),
+        ("memory-embedding", ["auto", "local", "openai-compatible", "FTS-only"]),
+    ],
+)
+def test_onboard_catalog_focused_human_output_lists_usable_options(section, expected):
+    result = runner.invoke(app, ["onboard", "catalog", section])
+
+    assert result.exit_code == 0, result.stdout
+    for text in expected:
+        assert text in result.stdout
+
+
+def test_onboard_catalog_provider_rows_name_squillarouter_tier_support():
+    result = runner.invoke(app, ["onboard", "catalog", "providers"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "route SquillaRouter ready" in result.stdout
+    assert "route Direct only" in result.stdout
+    openrouter_row = next(
+        line for line in result.stdout.splitlines() if line.startswith("- openrouter:")
+    )
+    anthropic_row = next(
+        line for line in result.stdout.splitlines() if line.startswith("- anthropic:")
+    )
+    assert openrouter_row.index("route SquillaRouter ready") < openrouter_row.index(
+        "key OPENROUTER_API_KEY"
+    )
+    assert anthropic_row.index("route Direct only") < anthropic_row.index(
+        "key ANTHROPIC_API_KEY"
+    )
+    assert "SquillaRouter tiers yes" not in result.stdout
+    assert "SquillaRouter tiers no" not in result.stdout
+    assert "router yes" not in result.stdout
+    assert "router no" not in result.stdout
+
+
+def test_onboard_catalog_focused_commands_are_actionable_with_config_path(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "catalog-target.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "catalog", "channels", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert (
+        "Try: opensquilla onboard configure channels --channel-type discord "
+        "--name <name> --token <token>"
+    ) in result.stdout
+    assert f"--config {_config_arg(target)}" in result.stdout
+    assert "opensquilla onboard configure channels --channel-type <type>\n" not in result.stdout
+    assert "Configure with:" not in result.stdout
+    assert not target.exists()
+
+
+@pytest.mark.parametrize(
+    "section, forbidden",
+    [
+        ("providers", "opensquilla onboard configure provider --provider <id>"),
+        ("search", "--search-provider <provider>"),
+        ("channels", "opensquilla onboard configure channels --channel-type <type>"),
+        ("image-generation", "--image-provider <provider>"),
+        ("memory-embedding", "--memory-provider <provider>"),
+    ],
+)
+def test_onboard_catalog_focused_output_uses_recipes_not_generic_templates(
+    section,
+    forbidden,
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "focused-catalog.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "catalog", section, "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Copy a Try line" in result.stdout
+    assert "Configure with:" not in result.stdout
+    assert forbidden not in result.stdout
+    assert f"--config {_config_arg(target)}" in result.stdout
+    assert not target.exists()
+
+
+def test_onboard_catalog_router_focus_offers_a_real_recipe(tmp_path, monkeypatch):
+    target = tmp_path / "router-catalog.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "catalog", "router", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Try: opensquilla onboard configure router --router recommended --default-tier t1" in (
+        result.stdout
+    )
+    assert "Configure with:" not in result.stdout
+    assert f"--config {_config_arg(target)}" in result.stdout
+    assert not target.exists()
+
+
+def test_onboard_catalog_focused_provider_examples_match_key_requirements(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "provider-catalog.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        ["onboard", "catalog", "providers", "--config", str(target)],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert (
+        "Try: opensquilla onboard configure provider --provider openrouter "
+        "--model deepseek/deepseek-v4-flash --api-key-env OPENROUTER_API_KEY "
+        f"--config {_config_arg(target)}"
+    ) in result.stdout
+    assert (
+        "Try: opensquilla onboard configure provider --provider anthropic "
+        "--model <model> --api-key-env ANTHROPIC_API_KEY "
+        f"--config {_config_arg(target)}"
+    ) in result.stdout
+    assert (
+        "Try: opensquilla onboard configure provider --provider ollama "
+        "--model <model> "
+        f"--config {_config_arg(target)}"
+    ) in result.stdout
+    ollama_line = next(
+        line
+        for line in result.stdout.splitlines()
+        if line.startswith("  Try: opensquilla onboard configure provider --provider ollama")
+    )
+    assert "--api-key-env" not in ollama_line
+    assert not target.exists()
+
+
+def test_onboard_catalog_focused_capability_examples_match_key_requirements(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "capability-catalog.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    search = runner.invoke(
+        app,
+        ["onboard", "catalog", "search", "--config", str(target)],
+    )
+    memory = runner.invoke(
+        app,
+        ["onboard", "catalog", "memory-embedding", "--config", str(target)],
+    )
+
+    assert search.exit_code == 0, search.stdout
+    assert (
+        "Try: opensquilla onboard configure search --search-provider brave "
+        "--api-key-env BRAVE_SEARCH_API_KEY "
+        f"--config {_config_arg(target)}"
+    ) in search.stdout
+    assert (
+        "Try: opensquilla onboard configure search --search-provider duckduckgo "
+        f"--config {_config_arg(target)}"
+    ) in search.stdout
+    duckduckgo_line = next(
+        line
+        for line in search.stdout.splitlines()
+        if line.startswith(
+            "  Try: opensquilla onboard configure search --search-provider duckduckgo"
+        )
+    )
+    assert "--api-key-env" not in duckduckgo_line
+
+    assert memory.exit_code == 0, memory.stdout
+    assert (
+        "Try: opensquilla onboard configure memory --memory-provider auto "
+        f"--config {_config_arg(target)}"
+    ) in memory.stdout
+    assert (
+        "Try: opensquilla onboard configure memory --memory-provider openai "
+        "--api-key-env OPENAI_API_KEY "
+        f"--config {_config_arg(target)}"
+    ) in memory.stdout
+    auto_line = next(
+        line
+        for line in memory.stdout.splitlines()
+        if line.startswith(
+            "  Try: opensquilla onboard configure memory --memory-provider auto"
+        )
+    )
+    assert "--api-key-env" not in auto_line
+    assert "--model" not in auto_line
+    assert not target.exists()
+
+
+def test_onboard_catalog_focused_channel_examples_include_required_fields(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "channel-catalog.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        ["onboard", "catalog", "channels", "--config", str(target)],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert (
+        "Try: opensquilla onboard configure channels --channel-type discord "
+        "--name <name> --token <token> "
+        f"--config {_config_arg(target)}"
+    ) in result.stdout
+    assert (
+        "Try: opensquilla onboard configure channels --channel-type feishu "
+        "--name <name> --field app_id=<value> --field app_secret=<value> "
+        f"--config {_config_arg(target)}"
+    ) in result.stdout
+    assert "opensquilla channels describe feishu --json" in result.stdout
+    assert not target.exists()
+
+
+def test_onboard_catalog_focused_image_and_metadata_search_examples_are_specific(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "image-catalog.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    image = runner.invoke(
+        app,
+        ["onboard", "catalog", "image-generation", "--config", str(target)],
+    )
+    search = runner.invoke(
+        app,
+        ["onboard", "catalog", "search", "--config", str(target)],
+    )
+
+    assert image.exit_code == 0, image.stdout
+    assert (
+        "Try: opensquilla onboard configure image "
+        "--image-provider openrouter "
+        "--primary openrouter/google/gemini-3.1-flash-image-preview "
+        "--api-key-env OPENROUTER_API_KEY "
+        f"--config {_config_arg(target)}"
+    ) in image.stdout
+
+    assert search.exit_code == 0, search.stdout
+    assert "- exa: Exa | metadata only" in search.stdout
+    assert "Try: opensquilla onboard configure search --search-provider exa" not in (
+        search.stdout
+    )
+    assert "Try: not configurable in this build" in search.stdout
+    assert not target.exists()
+
+
+def test_onboard_catalog_overview_commands_keep_active_config_path(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "catalog-overview.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "catalog", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    compact = result.stdout.replace(" ", "").replace("\n", "")
+    assert (
+        f"opensquillaonboardcatalogproviders--config{_config_arg(target)}".replace(
+            " ", ""
+        )
+        in compact
+    )
+    assert (
+        f"opensquillaonboardcatalogchannels--config{_config_arg(target)}".replace(
+            " ", ""
+        )
+        in compact
+    )
+    assert (
+        f"opensquillaonboardcatalogrouter--config{_config_arg(target)}".replace(" ", "")
+        in compact
+    )
+    assert (
+        f"opensquillaonboardcatalogsearch--config{_config_arg(target)}".replace(" ", "")
+        in compact
+    )
+    assert (
+        f"opensquillaonboardcatalogimage--config{_config_arg(target)}".replace(
+            " ", ""
+        )
+        in compact
+    )
+    assert (
+        f"opensquillaonboardcatalogmemory--config{_config_arg(target)}".replace(
+            " ", ""
+        )
+        in compact
+    )
+    assert "Open section" in result.stdout
+    assert "option-specific Try commands" in result.stdout
+    assert not target.exists()
+
+
+def test_onboard_catalog_overview_hides_generic_configure_templates(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "catalog-overview.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "catalog", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Configure templates:" not in result.stdout
+    assert "opensquilla onboard configure provider --provider <id>" not in result.stdout
+    assert "--api-key-env <ENV_NAME>" not in result.stdout
+    assert "--search-provider <provider>" not in result.stdout
+    assert "--memory-provider <provider>" not in result.stdout
+    assert not target.exists()
+
+
+def test_onboard_configure_help_groups_options_by_setup_area():
+    result = runner.invoke(app, ["onboard", "configure", "--help"])
+
+    assert result.exit_code == 0, result.stdout
+    expected_panels = [
+        "Target section",
+        "Text provider",
+        "Shared keys and endpoints",
+        "Router",
+        "Search",
+        "Channels",
+        "Image generation",
+        "Memory embedding",
+        "Global",
+    ]
+    for panel in expected_panels:
+        assert panel in result.stdout
+
+    expected_option_locations = [
+        ("Text provider", "--provider"),
+        ("Shared keys and endpoints", "--model"),
+        ("Shared keys and endpoints", "--api-key-env"),
+        ("Shared keys and endpoints", "--base-url"),
+        ("Shared keys and endpoints", "--proxy"),
+        ("Router", "--router"),
+        ("Search", "--search-provider"),
+        ("Channels", "--channel-type"),
+        ("Image generation", "--image-provider"),
+        ("Memory embedding", "--memory-provider"),
+        ("Global", "--config"),
+    ]
+    for panel, option in expected_option_locations:
+        assert result.stdout.index(panel) < result.stdout.index(option)
+
+    plain = " ".join(result.stdout.replace("│", " ").split())
+    assert "API key for provider, search, image generation, or memory embedding." in plain
+    assert "image (alias for image-generation)" in plain
+    assert "memory (alias for memory-embedding)" in plain
+
+
+def test_onboard_status_summarizes_blocking_and_optional_sections(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "custom.toml"
+    target.write_text(
+        '[llm]\n'
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key_env = "CUSTOM_LLM_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("CUSTOM_LLM_KEY", raising=False)
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "OpenSquilla Setup Cockpit" in result.stdout
+    assert "Blocking setup: Provider" in result.stdout
+    assert "Optional later: Channels, Image generation" in result.stdout
+    assert "llm" not in result.stdout
+    assert "image_generation" not in result.stdout
+
+
+def test_onboard_status_explains_router_ready_before_provider_setup(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "custom.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(tmp_path / "default.toml"))
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Router" in result.stdout
+    collapsed = "".join(result.stdout.split())
+    assert "Provider first" in result.stdout
+    assert "usesSquillaRouterafter" in collapsed
+    assert "providersetup" in collapsed
+
+    json_result = runner.invoke(
+        app,
+        ["onboard", "status", "--json", "--config", str(target)],
+    )
+    assert json_result.exit_code == 0, json_result.stdout
+    payload = _json.loads(json_result.stdout)
+    assert (
+        payload["sectionDetails"]["router"]["detail"]
+        == "uses SquillaRouter after provider setup"
+    )
+
+
+def test_onboard_status_table_hides_image_generation_internal_source(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "custom.toml"
+    target.write_text(
+        '[llm]\n'
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key = "sk-or"\n'
+        '\n'
+        '[image_generation]\n'
+        'enabled = true\n'
+        'primary = "openrouter/google/gemini-3.1-flash-image-preview"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Image generation" in result.stdout
+    assert "openrouter (same provider key)" in result.stdout
+    assert "llm_fallback" not in result.stdout
+
+
+def test_onboard_status_table_names_missing_env_keys_for_optional_capabilities(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "custom.toml"
+    target.write_text(
+        'search_provider = "brave"\n'
+        'search_api_key_env = "BRAVE_SEARCH_API_KEY"\n'
+        "\n"
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key = "sk-or"\n'
+        "\n"
+        "[image_generation]\n"
+        "enabled = true\n"
+        'primary = "openai/gpt-image-1"\n'
+        "\n"
+        "[image_generation.providers.openai]\n"
+        'api_key_env = "OPENAI_IMAGE_KEY"\n'
+        "\n"
+        "[memory.embedding]\n"
+        'provider = "openai"\n'
+        "\n"
+        "[memory.embedding.remote]\n"
+        'api_key_env = "OPENAI_EMBEDDINGS_API_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_IMAGE_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Blocking setup: Memory embedding" in result.stdout
+    assert "Web search" in result.stdout
+    assert "env key not visible" in result.stdout
+    assert "BRAVE_SEARCH_API_KEY" in result.stdout
+    assert "Image generation" in result.stdout
+    assert "openai" in result.stdout
+    assert "OPENAI_IMAGE_KEY" in result.stdout
+    assert "Memory embedding" in result.stdout
+    assert "OPENAI_EMBEDDINGS_API_KEY" in result.stdout
+    assert 'Set search key: export BRAVE_SEARCH_API_KEY="<your-key>"' in result.stdout
+    assert 'Set image key: export OPENAI_IMAGE_KEY="<your-key>"' in result.stdout
+    assert (
+        'Set memory key: export OPENAI_EMBEDDINGS_API_KEY="<your-key>"'
+        in result.stdout
+    )
+    assert "Fix now:" in result.stdout
+    assert result.stdout.index("Fix now:") < result.stdout.index("Set memory key:")
+    assert result.stdout.index("Set image key:") < result.stdout.index("Setup paths:")
+    assert "Set search key:" not in result.stdout.split("Setup paths:", 1)[1]
+    assert "Web UI after env fix:" in result.stdout
+    assert result.stdout.index("Set memory key:") < result.stdout.index("Set search key:")
+    assert "not configured" not in result.stdout
+
+    from opensquilla.cli.onboard_cmd import _status_cockpit_summary
+    from opensquilla.onboarding.config_store import load_config
+    from opensquilla.onboarding.status import get_onboarding_status
+
+    summary = _status_cockpit_summary(get_onboarding_status(load_config(target)))
+    assert summary == (
+        "Blocking setup: Memory embedding"
+        " · Optional later: Web search, Channels, Image generation"
+    )
+
+
+def test_onboard_status_offers_optional_capability_paths_when_core_ready(
+    tmp_path,
+):
+    target = tmp_path / "custom.toml"
+    target.write_text(
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key = "sk-or"\n',
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "OpenSquilla ready: yes" in result.stdout
+    assert "Optional next moves:" in result.stdout
+    assert "Web UI:" in result.stdout
+    assert "Explore options:" in result.stdout
+    assert "Setup catalog:" not in result.stdout
+    assert "opensquilla onboard catalog --json" not in result.stdout
+    assert "Channel recipes:" in result.stdout
+    compact = "".join(result.stdout.split())
+    assert f"opensquillaonboardcatalog--config{_config_arg(target)}" in compact
+    assert f"opensquillaonboardcatalogchannels--config{_config_arg(target)}" in compact
+    assert "opensquillachannelsdescribe<type>--json" not in compact
+    assert "opensquillaonboardconfigurechannels--channel-type<type>" not in compact
+    assert "Image recipes:" in result.stdout
+    assert (
+        f"opensquillaonboardcatalogimage--config{_config_arg(target)}"
+        in compact
+    )
+    assert "opensquillaonboardconfigureimage--image-provider<provider>" not in compact
+    assert f"--config{_config_arg(target)}" in compact
+    assert "Provider recipes:" not in result.stdout
+
+
+def test_onboard_status_offers_ready_next_moves_when_all_sections_ready(
+    tmp_path,
+):
+    target = tmp_path / "custom.toml"
+    target.write_text(
+        'search_provider = "duckduckgo"\n'
+        "\n"
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key = "sk-or"\n'
+        "\n"
+        "[image_generation]\n"
+        "enabled = true\n"
+        'primary = "openrouter/google/gemini-3.1-flash-image-preview"\n'
+        "\n"
+        "[[channels.channels]]\n"
+        'type = "slack"\n'
+        'name = "w"\n'
+        'token = "xoxb-test"\n',
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "OpenSquilla ready: yes" in result.stdout
+    assert "Ready next moves:" in result.stdout
+    assert "Start gateway:" in result.stdout
+    assert "opensquilla gateway run" in result.stdout
+    assert "Reconfigure later:" in result.stdout
+    assert "opensquilla onboard configure <section>" in result.stdout
+    assert "Optional next moves:" not in result.stdout
+    assert "Recommended next move:" not in result.stdout
+
+
 def test_onboard_if_needed_non_tty_hint_keeps_explicit_config_path(
     tmp_path,
     monkeypatch,
@@ -384,7 +1404,188 @@ def test_onboard_if_needed_non_tty_hint_keeps_explicit_config_path(
 
     assert result.exit_code == 2
     assert f"--config {_config_arg(target)}" in result.stdout
+    assert "Guided CLI:" in result.stdout
+    assert "Web UI:" in result.stdout
+    assert "http://127.0.0.1:18791/control/setup" in result.stdout
+    assert "Provider recipes:" in result.stdout
+    assert "Check status:" in result.stdout
     assert not default_target.exists()
+
+
+def test_onboard_if_needed_non_tty_hint_prioritizes_runnable_paths(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "custom.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "--if-needed"])
+
+    assert result.exit_code == 2
+    assert "Use a runnable setup path from this shell:" in result.stdout
+    assert result.stdout.index("Web UI:") < result.stdout.index("Provider recipes:")
+    assert result.stdout.index("Provider recipes:") < result.stdout.index("Guided CLI:")
+    assert "Guided CLI: opensquilla onboard --if-needed" in result.stdout
+    assert "(interactive terminal only)" in result.stdout
+    assert not target.exists()
+
+
+def test_onboard_if_needed_non_tty_hint_stays_provider_neutral(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "custom.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "--if-needed"])
+
+    assert result.exit_code == 2
+    assert "Provider recipes:" in result.stdout
+    assert "opensquilla onboard catalog providers" in result.stdout
+    assert "opensquilla onboard configure provider --provider <id>" not in result.stdout
+    assert "--model <model>" not in result.stdout
+    assert "--api-key-env <ENV_NAME>" not in result.stdout
+    assert "openrouter" not in result.stdout.lower()
+    assert "brave" not in result.stdout.lower()
+    assert "slack" not in result.stdout.lower()
+    assert "configure search" not in result.stdout
+    assert "channels add" not in result.stdout
+    assert not target.exists()
+
+
+def test_onboard_if_needed_non_tty_hint_hides_disabled_web_ui_path(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "custom.toml"
+    target.write_text("[control_ui]\nenabled = false\n", encoding="utf-8")
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "--if-needed"])
+
+    assert result.exit_code == 2
+    assert "Guided CLI:" in result.stdout
+    assert "Provider recipes:" in result.stdout
+    assert "Check status:" in result.stdout
+    assert result.stdout.index("Provider recipes:") < result.stdout.index("Guided CLI:")
+    assert "Web UI:" not in result.stdout
+    assert "/control/setup" not in result.stdout
+
+
+def test_onboard_if_needed_non_tty_hint_targets_blocking_memory_section(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "custom.toml"
+    target.write_text(
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key = "sk-or"\n'
+        "\n"
+        "[memory.embedding]\n"
+        'provider = "openai"\n'
+        "\n"
+        "[memory.embedding.remote]\n"
+        'api_key_env = "OPENAI_EMBEDDINGS_API_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
+
+    result = runner.invoke(app, ["onboard", "--if-needed", "--config", str(target)])
+
+    assert result.exit_code == 2
+    assert "Use a runnable setup path from this shell:" in result.stdout
+    assert "Headless memory embedding:" in result.stdout
+    assert (
+        "opensquilla onboard configure memory --memory-provider auto"
+        in result.stdout
+    )
+    assert f"--config {_config_arg(target)}" in result.stdout
+    assert "Provider recipes:" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("section", "label", "command"),
+    [
+        (
+            "provider",
+            "Provider recipes:",
+            "opensquilla onboard catalog providers",
+        ),
+        (
+            "router",
+            "Headless router:",
+            "opensquilla onboard configure router --router recommended --default-tier t1",
+        ),
+        (
+            "channels",
+            "Channel recipes:",
+            "opensquilla onboard catalog channels",
+        ),
+        (
+            "search",
+            "Headless search:",
+            "opensquilla onboard configure search --search-provider duckduckgo",
+        ),
+        (
+            "image-generation",
+            "Image recipes:",
+            "opensquilla onboard catalog image",
+        ),
+        (
+            "memory-embedding",
+            "Headless memory embedding:",
+            "opensquilla onboard configure memory --memory-provider auto",
+        ),
+    ],
+)
+def test_configure_without_tty_hint_targets_selected_section(
+    tmp_path,
+    monkeypatch,
+    section,
+    label,
+    command,
+):
+    target = tmp_path / "custom.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["configure", section, "--config", str(target)])
+
+    assert result.exit_code == 0
+    assert label in result.stdout
+    assert command in result.stdout
+    assert f"--config {_config_arg(target)}" in result.stdout
+    assert "opensquilla onboard configure provider --provider <id>" not in result.stdout
+    assert "opensquilla channels describe <type>" not in result.stdout
+    assert "--image-provider <provider>" not in result.stdout
+    assert not target.exists()
+
+
+def test_onboard_configure_provider_alias_uses_setup_engine(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "provider",
+            "--provider",
+            "openrouter",
+            "--model",
+            "deepseek/deepseek-v4-flash",
+            "--api-key-env",
+            "OPENROUTER_API_KEY",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    data = tomllib.loads(target.read_text())
+    assert data["llm"]["provider"] == "openrouter"
+    assert data["llm"]["api_key_env"] == "OPENROUTER_API_KEY"
+    assert "api_key" not in data["llm"]
 
 
 def test_configure_provider_noninteractive_uses_setup_engine(tmp_path, monkeypatch):
@@ -402,6 +1603,8 @@ def test_configure_provider_noninteractive_uses_setup_engine(tmp_path, monkeypat
             "deepseek/deepseek-v4-flash",
             "--api-key-env",
             "OPENROUTER_API_KEY",
+            "--proxy",
+            "http://127.0.0.1:7890",
         ],
     )
 
@@ -409,6 +1612,7 @@ def test_configure_provider_noninteractive_uses_setup_engine(tmp_path, monkeypat
     data = tomllib.loads(target.read_text())
     assert data["llm"]["provider"] == "openrouter"
     assert data["llm"]["api_key_env"] == "OPENROUTER_API_KEY"
+    assert data["llm"]["proxy"] == "http://127.0.0.1:7890"
     assert "api_key" not in data["llm"]
 
 
@@ -527,6 +1731,38 @@ def test_configure_provider_errors_go_to_stderr(tmp_path, monkeypatch):
     assert "unknown provider" not in result.stdout
 
 
+def test_configure_provider_reports_invalid_config_without_schema_traceback(tmp_path):
+    target = tmp_path / "bad.toml"
+    target.write_text("[search]\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "configure",
+            "provider",
+            "--provider",
+            "deepseek",
+            "--model",
+            "deepseek-chat",
+            "--api-key-env",
+            "DEEPSEEK_API_KEY",
+            "--config",
+            str(target),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "OpenSquilla config error" in result.stderr
+    assert str(target) in result.stderr
+    assert "search" in result.stderr
+    assert (
+        f"opensquillaonboard--if-needed--config{_config_arg(target)}"
+        in "".join(result.stderr.split())
+    )
+    assert "pydantic.dev" not in result.stderr
+    assert "Traceback" not in result.stderr
+
+
 def test_configure_router_noninteractive_can_disable(tmp_path, monkeypatch):
     target = tmp_path / "c.toml"
     target.write_text(
@@ -540,6 +1776,48 @@ def test_configure_router_noninteractive_can_disable(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.stdout
     data = tomllib.loads(target.read_text())
     assert data["squilla_router"]["enabled"] is False
+
+
+def test_configure_router_noninteractive_can_set_default_tier(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    target.write_text(
+        '[llm]\nprovider = "deepseek"\nmodel = "deepseek-chat"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        ["configure", "router", "--router", "recommended", "--default-tier", "t2"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    data = tomllib.loads(target.read_text())
+    assert data["squilla_router"]["enabled"] is True
+    assert data["squilla_router"]["tier_profile"] == "deepseek"
+    assert data["squilla_router"]["default_tier"] == "t2"
+
+
+def test_configure_router_rejects_invalid_default_tier_without_writing(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "c.toml"
+    target.write_text(
+        '[llm]\nprovider = "ollama"\nmodel = "llama3"\n',
+        encoding="utf-8",
+    )
+    before = target.read_text(encoding="utf-8")
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        ["configure", "router", "--router", "recommended", "--default-tier", "bad"],
+    )
+
+    assert result.exit_code == 2
+    assert "defaultTier must reference a text tier" in result.output
+    assert "Traceback" not in result.output
+    assert target.read_text(encoding="utf-8") == before
 
 
 def test_configure_router_invalid_mode_reports_clean_error(tmp_path, monkeypatch):
@@ -566,13 +1844,30 @@ def test_configure_search_noninteractive(tmp_path, monkeypatch):
 
     result = runner.invoke(
         app,
-        ["configure", "search", "--search-provider", "duckduckgo", "--max-results", "7"],
+        [
+            "configure",
+            "search",
+            "--search-provider",
+            "duckduckgo",
+            "--max-results",
+            "7",
+            "--proxy",
+            "http://127.0.0.1:7890",
+            "--use-env-proxy",
+            "--fallback-policy",
+            "network",
+            "--diagnostics",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout
     data = tomllib.loads(target.read_text())
     assert data["search_provider"] == "duckduckgo"
     assert data["search_max_results"] == 7
+    assert data["search_proxy"] == "http://127.0.0.1:7890"
+    assert data["search_use_env_proxy"] is True
+    assert data["search_fallback_policy"] == "network"
+    assert data["search_diagnostics"] is True
 
 
 def test_configure_search_can_use_env_key_reference(tmp_path, monkeypatch):
@@ -781,6 +2076,145 @@ def test_configure_image_generation_can_use_nondefault_env_reference(
     assert provider["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
 
 
+def test_configure_image_generation_can_save_missing_env_reference(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("OPENSQUILLA_TEST_IMAGE_KEY", raising=False)
+
+    result = runner.invoke(
+        app,
+        [
+            "configure",
+            "image-generation",
+            "--image-provider",
+            "openrouter",
+            "--primary",
+            "openrouter/google/gemini-3.1-flash-image-preview",
+            "--api-key-env",
+            "OPENSQUILLA_TEST_IMAGE_KEY",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    data = tomllib.loads(target.read_text())
+    provider = data["image_generation"]["providers"]["openrouter"]
+    assert provider["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
+    assert "warning" in result.stdout.lower()
+    assert "OPENSQUILLA_TEST_IMAGE_KEY" in result.stdout
+
+
+def test_configure_image_generation_can_disable_from_cli(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.setenv("OPENSQUILLA_TEST_IMAGE_KEY", "sk-image-env")
+
+    result = runner.invoke(
+        app,
+        [
+            "configure",
+            "image-generation",
+            "--image-provider",
+            "openrouter",
+            "--primary",
+            "openrouter/google/gemini-3.1-flash-image-preview",
+            "--api-key-env",
+            "OPENSQUILLA_TEST_IMAGE_KEY",
+            "--no-image-enabled",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    data = tomllib.loads(target.read_text())
+    provider = data["image_generation"]["providers"]["openrouter"]
+    assert data["image_generation"]["enabled"] is False
+    assert data["image_generation"]["primary"] == (
+        "openrouter/google/gemini-3.1-flash-image-preview"
+    )
+    assert provider["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
+
+
+def test_configure_image_generation_can_disable_without_provider_from_cli(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    result = runner.invoke(
+        app,
+        [
+            "configure",
+            "image-generation",
+            "--no-image-enabled",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    data = tomllib.loads(target.read_text())
+    assert data["image_generation"]["enabled"] is False
+    assert "requires an api_key" not in result.output
+
+
+def test_configure_accepts_short_capability_section_aliases(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    image = runner.invoke(app, ["configure", "image", "--no-image-enabled"])
+    memory = runner.invoke(
+        app,
+        [
+            "configure",
+            "memory",
+            "--memory-provider",
+            "local",
+            "--onnx-dir",
+            "models/bge",
+        ],
+    )
+
+    assert image.exit_code == 0, image.output
+    assert memory.exit_code == 0, memory.output
+    data = tomllib.loads(target.read_text())
+    assert data["image_generation"]["enabled"] is False
+    assert data["memory"]["embedding"]["provider"] == "local"
+    assert data["memory"]["embedding"]["local"]["onnx_dir"] == "models/bge"
+
+
+def test_configure_image_generation_can_disable_provider_without_key_from_cli(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    result = runner.invoke(
+        app,
+        [
+            "configure",
+            "image-generation",
+            "--image-provider",
+            "openrouter",
+            "--primary",
+            "openrouter/google/gemini-3.1-flash-image-preview",
+            "--no-image-enabled",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = tomllib.loads(target.read_text())
+    assert data["image_generation"]["enabled"] is False
+    assert data["image_generation"]["primary"] == (
+        "openrouter/google/gemini-3.1-flash-image-preview"
+    )
+    assert "requires an api_key" not in result.output
+
+
 def test_configure_memory_embedding_noninteractive(tmp_path, monkeypatch):
     target = tmp_path / "c.toml"
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
@@ -803,6 +2237,36 @@ def test_configure_memory_embedding_noninteractive(tmp_path, monkeypatch):
     assert data["memory"]["embedding"]["local"]["onnx_dir"] == "models/bge"
 
 
+def test_configure_memory_embedding_can_use_env_key_reference(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
+
+    result = runner.invoke(
+        app,
+        [
+            "configure",
+            "memory-embedding",
+            "--memory-provider",
+            "openai",
+            "--model",
+            "text-embedding-3-small",
+            "--api-key-env",
+            "OPENAI_EMBEDDINGS_API_KEY",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    data = tomllib.loads(target.read_text())
+    remote = data["memory"]["embedding"]["remote"]
+    assert data["memory"]["embedding"]["provider"] == "openai"
+    assert remote["model"] == "text-embedding-3-small"
+    assert remote["api_key_env"] == "OPENAI_EMBEDDINGS_API_KEY"
+    assert "api_key" not in remote
+    assert "warning" in result.stdout.lower()
+    assert "OPENAI_EMBEDDINGS_API_KEY" in result.stdout
+
+
 def test_onboard_without_tty_prints_hint_without_writing_config(tmp_path, monkeypatch):
     target = tmp_path / "c.toml"
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
@@ -811,8 +2275,11 @@ def test_onboard_without_tty_prints_hint_without_writing_config(tmp_path, monkey
 
     assert result.exit_code == 2
     assert "requires a TTY" in result.stdout
-    assert "--api-key-env" in result.stdout
-    assert "--router" in result.stdout
+    assert "Provider recipes:" in result.stdout
+    assert "opensquilla onboard catalog providers" in result.stdout
+    assert "--api-key-env" not in result.stdout
+    assert "--api-key $" not in result.stdout
+    assert "Check status:" in result.stdout
     assert not target.exists()
 
 

--- a/tests/test_cli/test_onboard_cmd.py
+++ b/tests/test_cli/test_onboard_cmd.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json as _json
+import platform
+import re
 import shlex
 import tomllib
 
@@ -12,6 +14,21 @@ from typer.testing import CliRunner
 from opensquilla.cli.main import app
 
 runner = CliRunner()
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _plain_text(value: str) -> str:
+    return " ".join(_ANSI_RE.sub("", value).replace("│", " ").split())
+
+
+def _compact_text(value: str) -> str:
+    return "".join(_ANSI_RE.sub("", value).replace("│", " ").split())
+
+
+def _env_hint(env_key: str) -> str:
+    if platform.system().lower().startswith("win"):
+        return f'PowerShell: $env:{env_key} = "<your-key>"'
+    return f'export {env_key}="<your-key>"'
 
 
 def _config_arg(path) -> str:
@@ -465,7 +482,7 @@ def test_onboard_status_json_exposes_provider_section_alias(tmp_path, monkeypatc
         {
             "section": "llm",
             "label": "Set provider key",
-            "command": 'export CUSTOM_LLM_KEY="<your-key>"',
+            "command": _env_hint("CUSTOM_LLM_KEY"),
         }
     ]
 
@@ -478,7 +495,7 @@ def test_onboard_status_reports_invalid_config_without_traceback(tmp_path):
 
     assert result.exit_code == 2
     assert "OpenSquilla config error" in result.stderr
-    assert str(target) in result.stderr
+    assert _compact_text(str(target)) in _compact_text(result.stderr)
     assert "search" in result.stderr
     assert "Fix:" in result.stderr
     assert (
@@ -700,7 +717,9 @@ def test_onboard_status_prioritizes_missing_env_recovery(
     result = runner.invoke(app, ["onboard", "status", "--config", str(target)])
 
     assert result.exit_code == 0, result.stdout
-    assert 'Set provider key: export CUSTOM_LLM_KEY="<your-key>"' in result.stdout
+    assert f"Set provider key: {_env_hint('CUSTOM_LLM_KEY')}" in _plain_text(
+        result.stdout
+    )
     assert result.stdout.index("Set provider key:") < result.stdout.index("Guided CLI:")
 
 
@@ -735,10 +754,13 @@ def test_onboard_help_exposes_configure_command():
     assert result.exit_code == 0, result.stdout
     assert "status" in result.stdout
     assert "catalog" in result.stdout
-    assert "List onboarding setup options for every configurable section." in result.stdout
+    compact = _compact_text(result.stdout)
+    assert "Listonboardingsetupoptionsforeveryconfigurablesection." in compact
     assert "configure" in result.stdout
-    assert "Reconfigure provider, router, channels, search, image generation" in result.stdout
-    assert "or memory." in result.stdout
+    assert (
+        "Reconfigureprovider,router,channels,search,imagegeneration,ormemory."
+        in compact
+    )
 
 
 def test_onboard_catalog_json_exposes_all_setup_options(tmp_path, monkeypatch):
@@ -769,9 +791,9 @@ def test_onboard_catalog_help_names_short_capability_section_aliases():
     result = runner.invoke(app, ["onboard", "catalog", "--help"])
 
     assert result.exit_code == 0, result.stdout
-    plain = " ".join(result.stdout.replace("│", " ").split())
-    assert "image (alias for image-generation)" in plain
-    assert "memory (alias for memory-embedding)" in plain
+    compact = _compact_text(result.stdout)
+    assert "image(aliasforimage-generation)" in compact
+    assert "memory(aliasformemory-embedding)" in compact
 
 
 def test_onboard_catalog_can_focus_one_setup_section():
@@ -1166,10 +1188,10 @@ def test_onboard_configure_help_groups_options_by_setup_area():
     for panel, option in expected_option_locations:
         assert result.stdout.index(panel) < result.stdout.index(option)
 
-    plain = " ".join(result.stdout.replace("│", " ").split())
-    assert "API key for provider, search, image generation, or memory embedding." in plain
-    assert "image (alias for image-generation)" in plain
-    assert "memory (alias for memory-embedding)" in plain
+    compact = _compact_text(result.stdout)
+    assert "APIkeyforprovider,search,imagegeneration,ormemoryembedding." in compact
+    assert "image(aliasforimage-generation)" in compact
+    assert "memory(aliasformemory-embedding)" in compact
 
 
 def test_onboard_status_summarizes_blocking_and_optional_sections(
@@ -1294,11 +1316,11 @@ def test_onboard_status_table_names_missing_env_keys_for_optional_capabilities(
     assert "OPENAI_IMAGE_KEY" in result.stdout
     assert "Memory embedding" in result.stdout
     assert "OPENAI_EMBEDDINGS_API_KEY" in result.stdout
-    assert 'Set search key: export BRAVE_SEARCH_API_KEY="<your-key>"' in result.stdout
-    assert 'Set image key: export OPENAI_IMAGE_KEY="<your-key>"' in result.stdout
+    stdout_plain = _plain_text(result.stdout)
+    assert f"Set search key: {_env_hint('BRAVE_SEARCH_API_KEY')}" in stdout_plain
+    assert f"Set image key: {_env_hint('OPENAI_IMAGE_KEY')}" in stdout_plain
     assert (
-        'Set memory key: export OPENAI_EMBEDDINGS_API_KEY="<your-key>"'
-        in result.stdout
+        f"Set memory key: {_env_hint('OPENAI_EMBEDDINGS_API_KEY')}" in stdout_plain
     )
     assert "Fix now:" in result.stdout
     assert result.stdout.index("Fix now:") < result.stdout.index("Set memory key:")
@@ -1753,7 +1775,7 @@ def test_configure_provider_reports_invalid_config_without_schema_traceback(tmp_
 
     assert result.exit_code == 2
     assert "OpenSquilla config error" in result.stderr
-    assert str(target) in result.stderr
+    assert _compact_text(str(target)) in _compact_text(result.stderr)
     assert "search" in result.stderr
     assert (
         f"opensquillaonboard--if-needed--config{_config_arg(target)}"

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import platform
 import tomllib
 
 import pytest
@@ -9,6 +10,12 @@ import pytest
 import opensquilla.gateway.rpc_onboarding  # noqa: F401  ensures registration
 from opensquilla.gateway.auth import Principal
 from opensquilla.gateway.rpc import RpcContext, get_dispatcher
+
+
+def _env_hint(env_key: str) -> str:
+    if platform.system().lower().startswith("win"):
+        return f'PowerShell: $env:{env_key} = "<your-key>"'
+    return f'export {env_key}="<your-key>"'
 
 
 def _admin_ctx() -> RpcContext:
@@ -519,17 +526,17 @@ async def test_onboarding_status_exposes_missing_env_keys_for_optional_capabilit
         {
             "section": "memory_embedding",
             "label": "Set memory key",
-            "command": 'export OPENAI_EMBEDDINGS_API_KEY="<your-key>"',
+            "command": _env_hint("OPENAI_EMBEDDINGS_API_KEY"),
         },
         {
             "section": "search",
             "label": "Set search key",
-            "command": 'export BRAVE_SEARCH_API_KEY="<your-key>"',
+            "command": _env_hint("BRAVE_SEARCH_API_KEY"),
         },
         {
             "section": "image_generation",
             "label": "Set image key",
-            "command": 'export OPENAI_IMAGE_KEY="<your-key>"',
+            "command": _env_hint("OPENAI_IMAGE_KEY"),
         },
     ]
 

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -42,6 +42,9 @@ async def test_onboarding_status_works_with_read_scope(tmp_path, monkeypatch):
     assert res.error is None, res.error
     assert "needsOnboarding" in res.payload
     assert "configPath" in res.payload
+    assert "sections" in res.payload
+    assert "sectionDetails" in res.payload
+    assert "memory_embedding" in res.payload["sections"]
 
 
 @pytest.mark.asyncio
@@ -71,6 +74,7 @@ async def test_onboarding_catalog_returns_providers_and_channels(tmp_path, monke
         "ollama",
         "none",
     } <= memory_provider_ids
+    assert all("whatYouNeed" in p for p in payload["memoryEmbeddingProviders"])
     router_profile_ids = {p["profileId"] for p in payload["routerProfiles"]["profiles"]}
     assert {"openrouter", "deepseek", "openai"} <= router_profile_ids
 
@@ -322,6 +326,21 @@ async def test_search_configure_redacts_api_key(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_search_configure_accepts_webui_string_max_results(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(tmp_path / "c.toml"))
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.search.configure",
+        {"providerId": "duckduckgo", "maxResults": "5"},
+        _admin_ctx(),
+    )
+
+    assert res.error is None, res.error
+    assert res.payload["entry"]["max_results"] == 5
+
+
+@pytest.mark.asyncio
 async def test_image_generation_configure_redacts_api_key(tmp_path, monkeypatch):
     target = tmp_path / "c.toml"
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
@@ -380,6 +399,64 @@ async def test_image_generation_configure_can_use_custom_env_reference(
 
 
 @pytest.mark.asyncio
+async def test_image_generation_configure_can_save_missing_custom_env_reference(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_TEST_IMAGE_KEY", raising=False)
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.imageGeneration.configure",
+        {
+            "providerId": "openrouter",
+            "primary": "openrouter/google/gemini-3.1-flash-image-preview",
+            "apiKeyEnv": "OPENSQUILLA_TEST_IMAGE_KEY",
+        },
+        _admin_ctx(),
+    )
+
+    assert res.error is None, res.error
+    assert res.payload["entry"]["api_key_source"] == "missing_env"
+    assert res.payload["entry"]["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
+    data = tomllib.loads(target.read_text())
+    provider = data["image_generation"]["providers"]["openrouter"]
+    assert provider["api_key"] == ""
+    assert provider["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
+
+
+@pytest.mark.asyncio
+async def test_image_generation_configure_can_disable_without_visible_key(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.imageGeneration.configure",
+        {
+            "providerId": "openrouter",
+            "primary": "openrouter/google/gemini-3.1-flash-image-preview",
+            "enabled": False,
+        },
+        _admin_ctx(),
+    )
+
+    assert res.error is None, res.error
+    assert res.payload["entry"]["enabled"] is False
+    assert res.payload["entry"]["api_key_source"] == "none"
+
+    data = tomllib.loads(target.read_text())
+    assert data["image_generation"]["enabled"] is False
+
+
+@pytest.mark.asyncio
 async def test_onboarding_status_requires_image_generation_enable_for_llm_fallback(
     tmp_path,
     monkeypatch,
@@ -399,6 +476,62 @@ async def test_onboarding_status_requires_image_generation_enable_for_llm_fallba
     assert res.payload["imageGenerationEnabled"] is False
     assert res.payload["imageGenerationSource"] == "none"
     assert res.payload["imageGenerationProvider"] == ""
+
+
+@pytest.mark.asyncio
+async def test_onboarding_status_exposes_missing_env_keys_for_optional_capabilities(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(tmp_path / "c.toml"))
+    from opensquilla.gateway.config import GatewayConfig
+
+    ctx = _read_ctx()
+    ctx.config = GatewayConfig()
+    ctx.config.llm.provider = "openrouter"
+    ctx.config.llm.model = "deepseek/deepseek-v4-flash"
+    ctx.config.llm.api_key = "sk-or"
+    ctx.config.search_provider = "brave"
+    ctx.config.search_api_key_env = "BRAVE_SEARCH_API_KEY"
+    ctx.config.image_generation.enabled = True
+    ctx.config.image_generation.primary = "openai/gpt-image-1"
+    ctx.config.image_generation.providers.openai.api_key_env = "OPENAI_IMAGE_KEY"
+    ctx.config.memory.embedding.provider = "openai"
+    ctx.config.memory.embedding.remote.api_key_env = "OPENAI_EMBEDDINGS_API_KEY"
+    monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_IMAGE_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
+
+    res = await get_dispatcher().dispatch("r1", "onboarding.status", {}, ctx)
+
+    assert res.error is None, res.error
+    assert res.payload["searchProvider"] == "brave"
+    assert res.payload["searchSource"] == "missing_env"
+    assert res.payload["searchEnvKey"] == "BRAVE_SEARCH_API_KEY"
+    assert res.payload["sections"]["image_generation"] == "degraded"
+    assert res.payload["sectionDetails"]["image_generation"]["actionRequired"] is True
+    assert res.payload["imageGenerationSource"] == "missing_env"
+    assert res.payload["imageGenerationProvider"] == "openai"
+    assert res.payload["imageGenerationEnvKey"] == "OPENAI_IMAGE_KEY"
+    assert res.payload["memoryEmbeddingSource"] == "missing_env"
+    assert res.payload["memoryEmbeddingEnvKey"] == "OPENAI_EMBEDDINGS_API_KEY"
+    assert res.payload["envRecoveryCommands"] == [
+        {
+            "section": "memory_embedding",
+            "label": "Set memory key",
+            "command": 'export OPENAI_EMBEDDINGS_API_KEY="<your-key>"',
+        },
+        {
+            "section": "search",
+            "label": "Set search key",
+            "command": 'export BRAVE_SEARCH_API_KEY="<your-key>"',
+        },
+        {
+            "section": "image_generation",
+            "label": "Set image key",
+            "command": 'export OPENAI_IMAGE_KEY="<your-key>"',
+        },
+    ]
 
 
 @pytest.mark.asyncio
@@ -446,6 +579,33 @@ async def test_memory_embedding_configure_redacts_remote_api_key(tmp_path, monke
     assert res.payload["changed"] is True
     assert res.payload["restartRequired"] is True
     assert res.payload["entry"]["remote"]["api_key"] == "***"
+
+
+@pytest.mark.asyncio
+async def test_memory_embedding_configure_can_use_env_key_reference(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.memory_embedding.configure",
+        {
+            "providerId": "openai",
+            "model": "text-embedding-3-small",
+            "apiKeyEnv": "OPENAI_EMBEDDINGS_API_KEY",
+        },
+        _admin_ctx(),
+    )
+
+    assert res.error is None, res.error
+    assert res.payload["entry"]["remote"]["api_key_env"] == "OPENAI_EMBEDDINGS_API_KEY"
+    data = tomllib.loads(target.read_text())
+    remote = data["memory"]["embedding"]["remote"]
+    assert remote["api_key_env"] == "OPENAI_EMBEDDINGS_API_KEY"
+    assert "api_key" not in remote
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_static_onboarding_views.py
+++ b/tests/test_gateway/test_static_onboarding_views.py
@@ -28,7 +28,7 @@ def test_channels_view_is_read_only_status_surface():
 def test_channels_view_points_configuration_to_cli_onboarding():
     txt = (VIEWS / "channels.js").read_text(encoding="utf-8")
     assert "opensquilla channels list" in txt
-    assert "opensquilla configure --section channels" in txt
+    assert "opensquilla onboard configure channels" in txt
 
 
 def test_channels_stats_do_not_report_attention_states_as_healthy():
@@ -61,10 +61,12 @@ def test_setup_view_loads_catalog_and_status():
     assert "onboarding.status" in txt
     assert "config.get" in txt
     assert "onboarding.provider.configure" in txt
+    assert "onboarding.search.configure" in txt
     assert "onboarding.imageGeneration.configure" in txt
     assert "imageGenerationProviders" in txt
     assert "onboarding.memory_embedding.configure" in txt
-    assert "Remote fallback API key" in txt
+    assert "Fallback API key" in txt
+    assert "data-memory-api-key-label" in txt
     assert "effectiveProvider" in txt
     assert "current.mode" in txt
 
@@ -73,12 +75,223 @@ def test_setup_view_is_available_and_uses_canonical_cli_fallbacks():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
     assert "SETUP_UI_AVAILABLE" not in txt
     assert "opensquilla onboard" in txt
-    assert "opensquilla configure provider" in txt
+    assert "opensquilla onboard catalog providers" in txt
     assert "opensquilla providers configure" not in txt
     assert "onboarding.router.configure" in txt
     assert "onboarding.channel.probe" in txt
     assert "channels.status" in txt
     assert "Connected" in txt
+
+
+def test_setup_finish_cli_commands_target_active_config_path():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderFinishStep()")
+    end = txt.index("  function _renderReadinessSummary", start)
+    body = txt[start:end]
+
+    assert "const configArg = _configCliArg(_status.configPath)" in body
+    assert "function _configCliArg" in txt
+    assert "function _shellArg" in txt
+    assert "Guided CLI" in body
+    assert "`opensquilla onboard --if-needed${configArg}`" in body
+    assert "Check status" in body
+    assert "`opensquilla onboard status${configArg}`" in body
+    assert "Provider options" in body
+    assert "`opensquilla onboard catalog providers${configArg}`" in body
+    assert "Router tiers" in body
+    assert "`opensquilla onboard catalog router${configArg}`" in body
+    assert "Search options" in body
+    assert "`opensquilla onboard catalog search${configArg}`" in body
+    assert "Channel options" in body
+    assert "`opensquilla onboard catalog channels${configArg}`" in body
+    assert "Image options" in body
+    assert "`opensquilla onboard catalog image${configArg}`" in body
+    assert "Memory options" in body
+    assert "`opensquilla onboard catalog memory${configArg}`" in body
+    assert "Catalog overview" not in body
+    assert "`opensquilla onboard catalog${configArg}`" not in body
+    assert "Channel field guide" not in body
+    assert "opensquilla channels describe <type>" not in body
+    assert "<type>" not in body
+    assert "const envRecoveryCommands = Array.isArray(_status.envRecoveryCommands)" in body
+    assert "const fixCommands = _envFixCommands(envRecoveryCommands, configArg)" in body
+    assert "const handoffCommands = [" in body
+    assert "const recipeCommands = [" in body
+    assert "_renderCliCommandGroup('Fix now', fixCommands)" in body
+    assert "_renderCliCommandGroup('CLI handoff', handoffCommands)" in body
+    assert "_renderCliCommandGroup('CLI recipes', recipeCommands)" in body
+
+
+def test_setup_finish_groups_recovery_commands_before_cli_reference():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    css = (ROOT / "static/css/views/setup.css").read_text(encoding="utf-8")
+    start = txt.index("function _renderFinishStep()")
+    end = txt.index("  function _renderCliCommand", start)
+    body = txt[start:end]
+
+    assert "const fixCommands = _envFixCommands(envRecoveryCommands, configArg)" in body
+    assert "const handoffCommands = [" in body
+    assert "const recipeCommands = [" in body
+    assert "Fix now" in body
+    assert "CLI handoff" in body
+    assert "CLI recipes" in body
+    assert (
+        "_renderCliCommandGroup('Fix now', fixCommands)"
+        in body
+    )
+    assert (
+        "_renderCliCommandGroup('CLI handoff', handoffCommands)"
+        in body
+    )
+    assert (
+        "_renderCliCommandGroup('CLI recipes', recipeCommands)"
+        in body
+    )
+    assert body.index("_renderCliCommandGroup('Fix now'") < body.index(
+        "_renderCliCommandGroup('CLI handoff'"
+    )
+    assert body.index("_renderCliCommandGroup('CLI handoff'") < body.index(
+        "_renderCliCommandGroup('CLI recipes'"
+    )
+    assert "function _renderCliCommandGroup" in txt
+    assert "setup-cli__group" in txt
+    assert ".setup-cli__group" in css
+    assert ".setup-cli__group-head" in css
+
+
+def test_setup_finish_prioritizes_cli_actions_before_configuration_details():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderFinishStep()")
+    end = txt.index("  function _renderCliCommand", start)
+    body = txt[start:end]
+
+    assert body.index('<div class="setup-cli">') < body.index('<div class="setup-summary">')
+    assert body.index('<div class="setup-cli">') < body.index("_renderReadinessSummary()")
+
+
+def test_setup_finish_pairs_env_recovery_with_gateway_restart_command():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderFinishStep()")
+    end = txt.index("  function _renderReadinessSummary", start)
+    body = txt[start:end]
+
+    assert "const fixCommands = _envFixCommands(envRecoveryCommands, configArg)" in body
+    assert "function _envFixCommands" in txt
+    assert "if (!envRecoveryCommands.length) return [];" in txt
+    assert "label: 'Restart gateway after env fix'" in txt
+    assert "command: `opensquilla gateway restart${configArg}`" in txt
+    assert body.index("const envRecoveryCommands = Array.isArray") < body.index(
+        "const fixCommands = _envFixCommands(envRecoveryCommands, configArg)"
+    )
+
+
+def test_setup_finish_cli_commands_are_provider_neutral():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderFinishStep()")
+    end = txt.index("  function _renderReadinessSummary", start)
+    body = txt[start:end]
+
+    assert "opensquilla onboard catalog providers" in body
+    assert "opensquilla onboard catalog search" in body
+    assert "opensquilla onboard catalog image" in body
+    assert "opensquilla onboard catalog memory" in body
+    assert "--search-provider <provider>" not in body
+    assert "--image-provider <provider>" not in body
+    assert "--memory-provider <provider>" not in body
+    assert "--api-key-env <ENV_NAME>" not in body
+    assert "--search-provider brave" not in body
+    assert "--image-provider openrouter" not in body
+    assert "--memory-provider openai" not in body
+    assert "OPENAI_API_KEY" not in body
+    assert "BRAVE_SEARCH_API_KEY" not in body
+
+
+def test_setup_view_starts_on_most_relevant_step():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    render_start = txt.index("async function render(el)")
+    render_end = txt.index("  async function _load()", render_start)
+    render_body = txt[render_start:render_end]
+    destroy_start = txt.index("function destroy()")
+    destroy_body = txt[destroy_start:]
+
+    assert "let _hasAutoSelectedStep = false" in txt
+    assert "function _selectInitialStep()" in txt
+    assert "function _initialStepFromStatus()" in txt
+    assert "await _load();\n    _selectInitialStep();" in render_body
+    assert render_body.index("await _load();") < render_body.index("_selectInitialStep();")
+    assert txt.index("const entry = sectionSteps.find") < txt.index(
+        "if (_status.needsOnboarding === false) return 'finish';"
+    )
+    assert "if (_status.needsOnboarding === false) return 'finish';" in txt
+    assert "detail.actionRequired" in txt
+    assert "['llm', 'provider']" in txt
+    assert "['router', 'router']" in txt
+    assert "['search', 'extras']" in txt
+    assert "['image_generation', 'extras']" in txt
+    assert "['memory_embedding', 'extras']" in txt
+    assert "_step = 'provider';" in destroy_body
+    assert "_hasAutoSelectedStep = false;" in destroy_body
+
+
+def test_setup_header_tracks_optional_action_required_sections():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    draw_start = txt.index("function _draw()")
+    draw_end = txt.index("  function _renderOnboardingReasons()", draw_start)
+    draw_body = txt[draw_start:draw_end]
+    reasons_start = txt.index("function _onboardingReasons()")
+    reasons_end = txt.index("  function _renderCurrentStep()", reasons_start)
+    reasons_body = txt[reasons_start:reasons_end]
+
+    assert "function _hasSetupAction()" in txt
+    assert "const setupAction = _hasSetupAction();" in draw_body
+    assert "${setupAction ? 'Action needed' : 'Ready to run'}" in draw_body
+    assert "setup__status ${setupAction ? 'is-warn' : 'is-ok'}" in draw_body
+    assert "${setupAction ? 'Action needed' : 'Ready'}" in draw_body
+    assert "if (!_hasSetupAction()) return [];" in reasons_body
+    assert "if (!detail.blocking && !detail.actionRequired)" in reasons_body
+
+
+def test_setup_finish_summarizes_provider_proxy_only_when_present():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderFinishStep()")
+    end = txt.index("  function _renderReadinessSummary", start)
+    body = txt[start:end]
+
+    assert (
+        "const providerProxy = hasSavedProvider ? ((_config.llm || {}).proxy || '').trim() : ''"
+    ) in body
+    assert "providerProxy ?" in body
+    assert "<span>Proxy</span>" in body
+
+
+def test_setup_finish_cli_commands_are_copyable():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    css = (ROOT / "static/css/views/setup.css").read_text(encoding="utf-8")
+
+    assert "function _renderCliCommand" in txt
+    assert "const copyLabel = `Copy ${label} command`" in txt
+    assert "data-setup-copy-command" in txt
+    assert 'title="${_esc(copyLabel)}"' in txt
+    assert 'aria-label="${_esc(copyLabel)}"' in txt
+    assert 'title="Copy command"' not in txt
+    assert 'aria-label="Copy command"' not in txt
+    assert "navigator.clipboard.writeText" in txt
+    assert "Copied command" in txt
+    assert "setup-cli__copy" in txt
+    assert "setup-cli__label" in txt
+    assert "${icons.copy()}" in txt
+    assert ".setup-cli__copy" in css
+    assert ".setup-cli__label" in css
+
+
+def test_setup_finish_cli_commands_stack_labels_on_mobile():
+    css = (ROOT / "static/css/views/setup.css").read_text(encoding="utf-8")
+    mobile = css.split("@media (max-width: 560px)", 1)[1]
+
+    assert ".setup-cli__row" in mobile
+    assert "grid-template-columns: minmax(0, 1fr) 34px" in mobile
+    assert ".setup-cli__label" in mobile
+    assert "grid-column: 1 / -1" in mobile
 
 
 def test_setup_view_keeps_channel_fields_in_config_shape():
@@ -92,17 +305,240 @@ def test_setup_view_renders_catalog_field_descriptions():
     assert "setup-field-desc" in txt
 
 
+def test_setup_view_surfaces_catalog_requirements_before_fields():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "function _renderNeedList" in txt
+    assert "setup-need-list" in txt
+    assert "spec.whatYouNeed" in txt
+    assert "searchSpec.whatYouNeed" in txt
+    assert "_memoryNeedList(memorySpec" in txt
+    assert "imageSpec.whatYouNeed" in txt
+    assert "channelSpec.whatYouNeed" in txt
+
+
+def test_setup_view_ties_need_lists_to_selected_env_keys():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "function _credentialNeedList" in txt
+    assert "_credentialNeedList(searchSpec.whatYouNeed, searchEnv || searchSpec.envKey)" in txt
+    assert "_credentialNeedList(imageSpec.whatYouNeed, imageEnv || imageSpec.envKey)" in txt
+    assert "envInput.value = spec.requiresApiKey ? (spec.envKey || '') : ''" in txt
+    assert "_credentialNeedList(spec.whatYouNeed, envInput?.value || spec.envKey)" in txt
+
+
+def test_setup_provider_step_is_neutral_before_provider_choice():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    css = (ROOT / "static/css/views/setup.css").read_text(encoding="utf-8")
+    start = txt.index("function _renderProviderStep()")
+    end = txt.index("  function _providerConfigFor", start)
+    body = txt[start:end]
+    sync_start = txt.index("function _drawProviderFields")
+    sync_end = txt.index("  function _drawChannelFields", sync_start)
+    sync_body = txt[sync_start:sync_end]
+    save_start = txt.index("async function _saveProvider()")
+    save_end = txt.index("  async function _saveRouter()", save_start)
+    save_body = txt[save_start:save_end]
+
+    assert "const selected = hasSavedProvider ? current.provider : ''" in body
+    assert "Choose from ${providers.length} supported providers" in body
+    assert (
+        '<option value="" disabled${selected ? \'\' : \' selected\'}>'
+        "Choose a provider</option>"
+    ) in body
+    assert "const spec = selected ? providers.find" in body
+    assert "selected ? spec.whatYouNeed : ['Choose a provider to see required fields.']" in body
+    assert "data-save-provider${selected ? '' : ' disabled'}" in body
+    assert 'data-next="router"${selected ? \'\' : \' disabled\'}' in body
+    assert "saveButton.disabled = !providerId" in sync_body
+    assert 'const nextButton = _el.querySelector(\'[data-next="router"]\')' in sync_body
+    assert "if (nextButton) nextButton.disabled = !providerId" in sync_body
+    assert "if (!providerId)" in save_body
+    assert "Choose a provider before saving." in save_body
+    assert ".setup-btn:disabled" in css
+    assert "cursor: not-allowed" in css
+
+
+def test_setup_view_declutters_memory_auto_requirements():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "function _memoryNeedList" in txt
+    assert "_memoryNeedList(memorySpec, effectiveProvider, memoryEnv)" in txt
+    assert "!/remote fallback credentials/i.test(item)" in txt
+
+
+def test_setup_view_collapses_search_advanced_options_by_default():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "const searchAdvancedOpen" in txt
+    assert 'details class="setup-mini__advanced" data-search-advanced${searchAdvancedOpen}' in txt
+    assert "<summary>Advanced search options</summary>" in txt
+    assert "setup-mini__advanced-body" in txt
+    assert "searchFallbackPolicy !== 'off'" in txt
+    assert "setup_search_proxy" in txt
+
+
+def test_setup_view_collapses_provider_connection_options_by_default():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "const providerCoreFields" in txt
+    assert "const providerAdvancedFields" in txt
+    assert "const providerAdvancedOpen" in txt
+    assert "_isProviderAdvancedField(field, spec)" in txt
+    assert (
+        "_renderProviderAdvancedFields(providerAdvancedFields, values, providerAdvancedOpen)"
+        in txt
+    )
+    assert 'details class="setup-mini__advanced" data-provider-advanced${openAttr}' in txt
+    assert "<summary>Advanced provider connection</summary>" in txt
+    assert "setup-provider-fields" in txt
+    assert "Provider connection" in txt
+    assert "base_url" in txt
+    assert "proxy" in txt
+
+
+def test_setup_provider_advanced_opens_for_required_or_custom_connection():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "function _providerAdvancedOpen" in txt
+    assert "if (field.required) return true;" in txt
+    assert "value !== defaultValue" in txt
+    assert "return value.length > 0;" in txt
+
+
+def test_setup_view_moves_optional_router_model_into_provider_advanced_connection():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "_isProviderAdvancedField(field, spec)" in txt
+    assert "field.name === 'model'" in txt
+    assert "spec.routerSupported === true" in txt
+    assert "field.required !== true" in txt
+    assert (
+        "providerCoreFields = providerFields.filter(field => "
+        "!_isProviderAdvancedField(field, spec))"
+    ) in txt
+    assert (
+        "providerAdvancedFields = providerFields.filter(field => "
+        "_isProviderAdvancedField(field, spec))"
+    ) in txt
+    assert "if (defaultValue) return value !== defaultValue;" in txt
+
+
+def test_setup_view_keeps_required_provider_model_in_core_fields():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    model_start = txt.index("if (field.name === 'model')")
+    model_clause = txt[model_start : txt.index("return false;", model_start)]
+    assert "field.required !== true" in model_clause
+    assert "spec.routerSupported === true" in model_clause
+
+
+def test_setup_provider_switch_redraws_core_and_advanced_fields_together():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    start = txt.index("function _drawProviderFields")
+    body = txt[start : txt.index("  function _drawChannelFields", start)]
+    assert "const providerFields = spec.fields || []" in body
+    assert "const providerCoreFields" in body
+    assert "const providerAdvancedFields" in body
+    assert "box.innerHTML = _renderProviderFields(providerCoreFields" in body
+    assert "advanced.innerHTML = _renderProviderAdvancedFields(" in body
+    assert "_renderProviderFields(spec," not in body
+
+
 def test_setup_view_warns_when_env_key_is_not_visible_to_gateway():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    css = (ROOT / "static/css/views/setup.css").read_text(encoding="utf-8")
+
     assert "missing_env" in txt
     assert "not visible to this gateway process" in txt
     assert "Set it before starting or restarting the gateway" in txt
     assert "if (_providerEnvMissing())" in txt
+    assert "function _providerEnvRecoveryCommand()" in txt
+    assert "Array.isArray(_status.envRecoveryCommands)" in txt
+    assert "return _envRecoveryCommand('llm')" in txt
+    assert "_providerEnvRecoveryCommand()" in txt
+    assert "setup-warning__command" in txt
+    assert 'data-setup-copy-command="${safeCommand}"' in txt
+    assert "Copy set provider key command" in txt
+    assert ".setup-warning__command" in css
+    assert ".setup-warning__command code" in css
 
 
 def test_setup_view_does_not_default_env_key_over_stored_provider_key():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
     assert "current.api_key ? '' : field.default" in txt
+
+
+def test_setup_provider_form_can_submit_api_key_env():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    assert "api_key_env" in txt
+    assert "_camel(label.dataset.name)" in txt
+    assert "onboarding.provider.configure" in txt
+
+
+def test_setup_provider_controls_have_browser_field_names():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    assert 'name="setup_provider"' in txt
+    assert "const fieldName = `setup_${scope}_${rawName}`" in txt
+    assert 'for="${_esc(fieldId)}"' in txt
+    assert 'id="${_esc(fieldId)}"' in txt
+    assert 'name="${_esc(fieldName)}"' in txt
+
+
+def test_setup_provider_switch_refreshes_provider_defaults():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    assert "function _providerConfigFor(providerId)" in txt
+    assert "current.provider === providerId ? current : {}" in txt
+    assert 'data-provider-summary' in txt
+    assert "_drawProviderFields({ rememberDraft: true })" in txt
+
+
+def test_setup_all_wizard_controls_have_browser_field_names():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    for name in (
+        "setup_router_mode",
+        "setup_router_default_tier",
+        "setup_channel_type",
+        "setup_search_provider",
+        "setup_search_max_results",
+        "setup_search_api_key",
+        "setup_search_api_key_env",
+        "setup_search_proxy",
+        "setup_search_use_env_proxy",
+        "setup_search_fallback_policy",
+        "setup_search_diagnostics",
+        "setup_memory_provider",
+        "setup_memory_model",
+        "setup_memory_api_key",
+        "setup_memory_api_key_env",
+        "setup_memory_base_url",
+        "setup_memory_onnx_dir",
+        "setup_image_provider",
+        "setup_image_primary",
+        "setup_image_api_key",
+        "setup_image_api_key_env",
+        "setup_image_base_url",
+        "setup_image_enabled",
+    ):
+        assert f'name="{name}"' in txt
+
+    assert "const tierFieldName = `setup_router_${name}_${field}`" in txt
+    assert 'name="${_esc(tierFieldName)}"' in txt
+    assert 'aria-label="${_esc(tierLabel)}' in txt
+
+
+def test_setup_view_bounds_search_max_results_control():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index('id="setup-search-max-results"')
+    end = txt.index('data-search-field="max_results"', start)
+    control = txt[start:end]
+
+    assert 'type="number"' in control
+    assert 'min="1"' in control
+    assert 'step="1"' in control
+    assert 'inputmode="numeric"' in control
 
 
 def test_setup_view_preserves_selected_channel_type_while_redrawing_fields():
@@ -141,8 +577,101 @@ def test_setup_view_treats_image_configure_as_capability_enable_action():
 
 def test_setup_view_explains_image_generation_tool_visibility():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
-    assert "image_generate is hidden from agents" in txt
-    assert "image_generate will be available in new turns" in txt
+    start = txt.index("function _imageGenerationStatusText")
+    end = txt.index("  function _memoryEmbeddingStatusText", start)
+    body = txt[start:end]
+
+    assert "Image generation is hidden from agents" in body
+    assert "Image generation will be available in new turns" in body
+    assert "_status.imageGenerationSource === 'missing_env'" in body
+    assert "_status.imageGenerationEnvKey" in body
+    assert "image_generate" not in body
+    assert "imageGenerationSource === 'llm_fallback'" in txt
+    assert "same provider key" in txt
+
+
+def test_setup_view_uses_product_language_for_search_status_text():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _searchStatusText")
+    end = txt.index("  function _imageGenerationStatusText", start)
+    body = txt[start:end]
+
+    assert "Web search is off until a provider is selected." in body
+    assert "Web search is ready for new turns." in body
+    assert "_status.searchSource === 'missing_env'" in body
+    assert "_status.searchEnvKey" in body
+    assert "Web search is selected but still needs a visible provider key." in body
+    assert "web_search" not in body
+
+
+def test_setup_view_names_missing_env_key_for_memory_embedding_status_text():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _memoryEmbeddingStatusText")
+    end = txt.index("  function _toastEnvReferenceSave", start)
+    body = txt[start:end]
+
+    assert "_status.memoryEmbeddingSource === 'missing_env'" in body
+    assert "_status.memoryEmbeddingEnvKey" in body
+    assert "Remote memory embeddings need a visible provider key before they can run." in body
+
+
+def test_setup_capability_cards_offer_copyable_env_recovery_commands():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderExtrasStep()")
+    end = txt.index("  function _capabilitySaveButtonClass", start)
+    body = txt[start:end]
+
+    assert "function _capabilityEnvRecoveryCommand(section)" in txt
+    assert "function _renderCapabilityEnvRecoveryCommand(section)" in txt
+    assert "Array.isArray(_status.envRecoveryCommands)" in txt
+    assert "entry.section === section" in txt
+    assert "_renderCapabilityEnvRecoveryCommand('search')" in body
+    assert "_renderCapabilityEnvRecoveryCommand('memory_embedding')" in body
+    assert "_renderCapabilityEnvRecoveryCommand('image_generation')" in body
+    assert "Copy set search key command" in txt
+    assert "Copy set memory key command" in txt
+    assert "Copy set image key command" in txt
+    assert 'data-setup-copy-command="${safeCommand}"' in txt
+
+
+def test_setup_view_exposes_image_generation_env_key_config():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    assert "imageProviders.find(p => p.providerId === imageProviderSelected)" in txt
+    assert "imageProviderConfig.api_key_env" in txt
+    assert 'data-image-field="api_key_env"' in txt
+    assert "setup_image_api_key_env" in txt
+    assert "imageSpec.envKey" in txt
+    assert "_syncImageProviderDefaults" in txt
+    assert "[data-image-provider]')?.addEventListener('change', _syncImageProviderDefaults)" in txt
+    assert "primaryInput.value = spec.defaultModel || primaryInput.value" in txt
+
+
+def test_setup_image_generation_hides_provider_fields_until_enabled():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderExtrasStep()")
+    end = txt.index("  function _capabilitySaveButtonClass", start)
+    body = txt[start:end]
+
+    assert "const imageConfigHidden = imageEnabledDefault ? '' : ' hidden'" in body
+    assert 'data-image-config-fields${imageConfigHidden}' in body
+    assert "[data-image-enabled]')?.addEventListener('change', _syncImageProviderDefaults)" in txt
+
+    sync_start = txt.index("function _syncImageProviderDefaults()")
+    sync_end = txt.index("  function _bindConditionalSelects", sync_start)
+    sync_body = txt[sync_start:sync_end]
+    assert "const enabledInput = _el.querySelector('[data-image-enabled]')" in sync_body
+    assert "const imageConfigFields = _el.querySelector('[data-image-config-fields]')" in sync_body
+    assert "imageConfigFields.hidden = !imageEnabled" in sync_body
+
+
+def test_setup_view_exposes_image_generation_base_url_config():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "imageProviderConfig.base_url" in txt
+    assert "imageSpec.defaultBaseUrl" in txt
+    assert 'data-image-field="base_url"' in txt
+    assert "setup_image_base_url" in txt
+    assert "baseInput.value = spec.defaultBaseUrl || baseInput.value" in txt
 
 
 def test_setup_view_preserves_selected_image_generation_provider():
@@ -170,6 +699,17 @@ def test_setup_view_preserves_unsaved_form_values_across_step_navigation():
     assert "_setStep(btn.dataset.next)" in txt
 
 
+def test_setup_view_reconciles_search_key_state_after_restoring_draft_provider():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _restoreDynamicDraftFields()")
+    end = txt.index("  function _fieldKey", start)
+    body = txt[start:end]
+
+    assert "function _syncSearchProviderKeyControls" in txt
+    assert "if (_step === 'extras' && _drafts.has('extras'))" in body
+    assert "_syncSearchProviderKeyControls({ refreshEnv: false })" in body
+
+
 def test_setup_view_does_not_redraw_dirty_channel_form_during_status_poll():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
     assert "let _channelDirty" in txt
@@ -181,14 +721,454 @@ def test_setup_view_surfaces_action_needed_reasons():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
     assert "function _onboardingReasons" in txt
     assert "setup-reasons" in txt
-    assert "Provider action required" in txt
-    assert "No channels configured" in txt
+    assert "Connect a model provider" in txt
+    assert "detail.status === 'missing'" in txt
+    assert "Provider action required" not in txt
+    assert "sectionDetails" in txt
+    assert "detail.blocking" in txt
+    assert "(_status.channelCount || 0) === 0" not in txt
+
+
+def test_setup_stepper_surfaces_readiness_for_each_setup_area():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    css = (ROOT / "static/css/views/setup.css").read_text(encoding="utf-8")
+    draw_start = txt.index("function _draw()")
+    draw_end = txt.index("  function _renderOnboardingReasons()", draw_start)
+    draw_body = txt[draw_start:draw_end]
+
+    assert "STEPS.map(_renderStepButton).join('')" in draw_body
+    assert "function _renderStepButton" in txt
+    assert "function _stepStatus" in txt
+    assert "function _aggregateStepStatus" in txt
+    assert "setup-stepper__state" in txt
+    assert "setup-stepper__label" in txt
+    assert "setup-stepper__num" in txt
+    assert "_aggregateStepStatus(['search', 'image_generation', 'memory_embedding'])" in txt
+    assert "detail.blocking || detail.actionRequired" in txt
+    assert "detail.status === 'missing' || detail.status === 'degraded'" in txt
+    assert "aria-label=\"${_esc(`${s.label}: ${status.label}`)}\"" in txt
+    assert ".setup-stepper__state" in css
+    assert ".setup-stepper__state.is-ok" in css
+    assert ".setup-stepper__state.is-warn" in css
+    assert ".setup-stepper__label" in css
+
+
+def test_setup_stepper_names_router_provider_prerequisite():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _stepStatus")
+    body = txt[start : txt.index("  function _aggregateStepStatus", start)]
+
+    assert "const currentProvider = (_config.llm || {}).provider || ''" in body
+    assert (
+        "const hasSavedProvider = Boolean(currentProvider) "
+        "&& _status.hasConfig !== false"
+    ) in body
+    assert "if (stepId === 'router' && !hasSavedProvider)" in body
+    assert "Provider first" in body
+
+
+def test_setup_header_reasons_name_missing_env_keys_for_capabilities():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _onboardingReasons()")
+    end = txt.index("  function _hasSetupAction()", start)
+    body = txt[start:end]
+
+    assert "function _setupActionReason" in txt
+    assert "const missingEnvPrefix = 'env key not visible: '" in txt
+    assert "return `${envKey} is not visible`" in txt
+    assert "_setupActionReason(name, detail)" in body
+    assert "Memory embedding setup needed" not in body
+
+
+def test_setup_provider_first_run_summary_does_not_headline_default_provider():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderProviderStep()")
+    end = txt.index("  function _providerConfigFor", start)
+    body = txt[start:end]
+
+    assert (
+        "const hasSavedProvider = (\n"
+        "      Boolean(current.provider)\n"
+        "      && _status.hasConfig !== false\n"
+        "    )"
+    ) in body
+    assert (
+        "const providerSummary = hasSavedProvider\n"
+        "      ? (spec.label || selected)\n"
+        "      : `Choose from ${providers.length} supported providers`"
+    ) in body
+    assert '<p data-provider-summary>${_esc(providerSummary)}</p>' in body
+    assert '<p data-provider-summary>${_esc(selected || \'not configured\')}</p>' not in body
+
+
+def test_setup_provider_step_surfaces_squillarouter_tier_support():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderProviderStep()")
+    end = txt.index("  function _providerConfigFor", start)
+    body = txt[start:end]
+    sync_start = txt.index("function _drawProviderFields")
+    sync_end = txt.index("  function _drawChannelFields", sync_start)
+    sync_body = txt[sync_start:sync_end]
+
+    assert "function _providerRouterSupportText" in txt
+    assert "function _providerRouterSupportTone" in txt
+    assert "spec.routerSupported === true" in txt
+    assert "'SquillaRouter ready'" in txt
+    assert "'Direct only'" in txt
+    assert "'available'" not in body
+    assert "'direct model only'" not in body
+    assert "data-provider-router-support" in body
+    assert "data-provider-router-support-label" in body
+    assert "setup-provider-meta__badge" in body
+    assert "SquillaRouter tiers" in body
+    assert "_providerRouterSupportText(selected ? spec : null)" in body
+    assert "_providerRouterSupportTone(selected ? spec : null)" in body
+    assert "routerSupport.textContent = _providerRouterSupportText(spec);" in sync_body
+    assert "routerSupport.className = `setup-provider-meta__badge" in sync_body
+    assert "_providerRouterSupportTone(spec)" in sync_body
+
+
+def test_setup_provider_router_support_badge_has_distinct_tones():
+    css = (ROOT / "static/css/views/setup.css").read_text(encoding="utf-8")
+
+    assert ".setup-provider-meta__badge" in css
+    assert ".setup-provider-meta__badge.is-ready" in css
+    assert ".setup-provider-meta__badge.is-direct" in css
+    assert ".setup-provider-meta__badge.is-neutral" in css
+
+
+def test_setup_provider_switch_summary_uses_provider_label():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _drawProviderFields")
+    end = txt.index("  function _drawChannelFields", start)
+    body = txt[start:end]
+
+    assert "summary.textContent = spec.label || providerId || 'not configured';" in body
+
+
+def test_setup_router_step_stays_neutral_before_provider_is_configured():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderRouterStep()")
+    end = txt.index("  function _tierRow", start)
+    body = txt[start:end]
+
+    assert "const currentProvider = (_config.llm || {}).provider || ''" in body
+    assert (
+        "const hasSavedProvider = Boolean(currentProvider) && _status.hasConfig !== false"
+    ) in body
+    assert "const provider = hasSavedProvider ? currentProvider : ''" in body
+    assert "const routerSummary = provider" in body
+    assert "'Choose a provider first'" in body
+    assert "profiles.find(p => p.profileId === 'openrouter')" not in body
+    assert "const tiers = provider ?" in body
+    assert "data-router-provider-needed" in body
+    assert "data-save-router${provider ? '' : ' disabled'}" in body
+
+    save_start = txt.index("async function _saveRouter()")
+    save_end = txt.index("  async function _saveChannel()", save_start)
+    save_body = txt[save_start:save_end]
+    assert "Boolean(currentProvider) && _status.hasConfig !== false" in save_body
+    assert "Choose a provider before saving router tiers." in save_body
+
+
+def test_setup_view_exposes_search_in_capability_center():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    assert "Capability Center" in txt
+    assert "label: 'Capabilities'" in txt
+    assert "label: 'Extras'" not in txt
+    assert "function _renderCapabilityBadge" in txt
+    assert "setup-badge" in txt
+    assert "data-search-provider" in txt
+    assert "data-save-search" in txt
+    assert "_syncSearchProviderEnvHint" in txt
+
+
+def test_setup_capability_center_names_each_capability_action():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderExtrasStep()")
+    end = txt.index("  function _capabilitySaveButtonClass", start)
+    body = txt[start:end]
+
+    assert "Web search · Memory recall · Image generation" in body
+    assert "search / memory / image" not in body
+    assert "Save web search" in body
+    assert "Save memory embedding" in body
+    assert "Save image generation" in body
+    assert "Save Memory" not in body
+    assert "Save Image" not in body
+
+
+def test_setup_capability_save_buttons_prioritize_action_required_card():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "function _capabilitySaveButtonClass" in txt
+    start = txt.index("function _capabilitySaveButtonClass")
+    end = txt.index("  function _renderCapabilityBadge", start)
+    body = txt[start:end]
+
+    assert "detail.blocking || detail.actionRequired" in body
+    assert "'setup-btn setup-btn--primary'" in body
+    assert "'setup-btn'" in body
+    assert 'class="${_capabilitySaveButtonClass(\'search\')}"' in txt
+    assert 'class="${_capabilitySaveButtonClass(\'memory_embedding\')}"' in txt
+    assert 'class="${_capabilitySaveButtonClass(\'image_generation\')}"' in txt
+
+
+def test_setup_view_exposes_all_search_configuration_controls():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    for name in (
+        "setup_search_proxy",
+        "setup_search_use_env_proxy",
+        "setup_search_fallback_policy",
+        "setup_search_diagnostics",
+    ):
+        assert f'name="{name}"' in txt
+
+    assert "_config.search_proxy" in txt
+    assert "_config.search_use_env_proxy" in txt
+    assert "_config.search_fallback_policy" in txt
+    assert "_config.search_diagnostics" in txt
+    assert 'data-search-field="proxy"' in txt
+    assert 'data-search-field="use_env_proxy"' in txt
+    assert 'data-search-field="fallback_policy"' in txt
+    assert 'data-search-field="diagnostics"' in txt
+
+
+def test_setup_view_treats_search_provider_keys_as_conditional():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "searchSpec.requiresApiKey === true" in txt
+    assert "searchRequiresKey ? '' : ' disabled'" in txt
+    assert "not required for this provider" in txt
+    assert "const searchKeyHidden = searchRequiresKey ? '' : ' hidden'" in txt
+    assert 'data-search-key-fields${searchKeyHidden}' in txt
+    assert "keyInput.disabled = !requiresKey" in txt
+    assert "envInput.disabled = !requiresKey" in txt
+    assert "keyFields.hidden = !requiresKey" in txt
+
+
+def test_setup_view_treats_memory_remote_fields_as_provider_conditional():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "memorySpec.requiresApiKey === true" in txt
+    assert "memoryApiKeyEnabled" in txt
+    assert "memoryRemoteControlEnabled" in txt
+    assert "function _syncMemoryProviderControls" in txt
+    assert (
+        "[data-memory-provider]')?.addEventListener('change', "
+        "_syncMemoryProviderControls)"
+    ) in txt
+    assert "apiKeyInput.disabled = !apiKeyEnabled" in txt
+    assert "envInput.disabled = !apiKeyEnabled" in txt
+    assert "baseInput.disabled = !remoteControlEnabled" in txt
+    assert "modelInput.disabled = !remoteControlEnabled" in txt
+    assert "remoteOptions.hidden = !hasRemoteOptions" in txt
+    assert "remoteOptions.open = providerId !== 'auto' && hasRemoteOptions" in txt
+    assert 'data-memory-field="api_key_env"' in txt
+
+
+def test_setup_memory_embedding_exposes_local_onnx_dir_without_cluttering_auto():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderExtrasStep()")
+    end = txt.index("  function _capabilitySaveButtonClass", start)
+    body = txt[start:end]
+
+    assert "const memoryLocal = current.local || {}" in body
+    assert "const memoryLocalControlEnabled = effectiveProvider === 'local'" in body
+    assert "const memoryRemoteOptionsSummary" in body
+    assert "Remote fallback options" in body
+    assert "Connection options" in body
+    assert (
+        "data-memory-remote-options"
+        "${memoryRemoteOptionsOpen}${memoryRemoteOptionsHidden}"
+    ) in body
+    assert 'data-memory-local-field${memoryLocalHidden}' in body
+    assert 'name="setup_memory_onnx_dir"' in body
+    assert 'data-memory-field="onnx_dir"' in body
+    assert "memoryLocal.onnx_dir || ''" in body
+
+
+def test_setup_view_surfaces_env_reference_save_feedback():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    memory_start = txt.index("async function _saveMemory()")
+    memory_end = txt.index("  async function _saveSearch()", memory_start)
+    memory_body = txt[memory_start:memory_end]
+    image_start = txt.index("async function _saveImage()")
+    image_end = txt.index("  async function _loadChannelStatus()", image_start)
+    image_body = txt[image_start:image_end]
+
+    assert "function _toastEnvReferenceSave" in txt
+    assert (
+        "const res = await _rpc.call('onboarding.memory_embedding.configure', params)"
+        in memory_body
+    )
+    assert "_toastEnvReferenceSave(" in memory_body
+    assert "'Memory embedding'" in memory_body
+    assert "remote.api_key_env" in memory_body
+    assert "restartRequired" in memory_body
+    assert (
+        "const res = await _rpc.call('onboarding.imageGeneration.configure', params)"
+        in image_body
+    )
+    assert "_toastEnvReferenceSave(" in image_body
+    assert "'Image generation'" in image_body
+    assert "entry.api_key_source" in image_body
+
+
+def test_setup_view_explains_memory_embedding_provider_modes():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "function _memoryEmbeddingStatusText" in txt
+    assert 'data-memory-status-text' in txt
+    assert "Local-first memory search" in txt
+    assert "Uses local BGE embeddings" in txt
+    assert "Uses your Ollama server" in txt
+    assert "Keyword search stays available; embeddings are disabled." in txt
+    assert "savedProvider" in txt
+    assert "provider === savedProvider" in txt
+    assert "statusText.textContent = _memoryEmbeddingStatusText(providerId)" in txt
+
+
+def test_setup_view_does_not_submit_disabled_memory_fields():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("async function _saveMemory()")
+    end = txt.index("  async function _saveSearch()", start)
+    body = txt[start:end]
+
+    assert "if (input.disabled) return;" in body
+
+
+def test_setup_view_saves_search_checkboxes_as_booleans():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("async function _saveSearch()")
+    end = txt.index("  async function _saveImage()", start)
+    body = txt[start:end]
+
+    assert "input.type === 'checkbox'" in body
+    assert "params[key] = input.checked" in body
+
+
+def test_setup_finish_groups_required_and_optional_readiness():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    assert "function _renderReadinessGroup" in txt
+    assert "Required setup" in txt
+    assert "Optional capabilities" in txt
+    assert "setup-readiness__group" in txt
+
+
+def test_setup_finish_readiness_rows_render_detail_text():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderReadinessGroup")
+    end = txt.index("  function _readinessTone", start)
+    body = txt[start:end]
+
+    assert "detail.detail" in body
+    assert "setup-readiness__detail" in body
+
+
+def test_setup_finish_readiness_rows_offer_direct_config_actions():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    css = (ROOT / "static/css/views/setup.css").read_text(encoding="utf-8")
+    start = txt.index("function _renderReadinessGroup")
+    end = txt.index("  function _readinessTone", start)
+    body = txt[start:end]
+
+    assert "function _setupStepForSection" in txt
+    assert "function _readinessActionLabel" in txt
+    assert "const step = _setupStepForSection(name, detail)" in body
+    assert "const action = _renderReadinessAction(step, detail, name)" in body
+    assert "function _renderReadinessAction" in txt
+    assert "const actionAriaLabel = _readinessActionAriaLabel(detail, name)" in body
+    assert 'class="setup-readiness__action"' in body
+    assert "aria-label=\"${_esc(actionAriaLabel)}\"" in body
+    assert "title=\"${_esc(actionAriaLabel)}\"" in body
+    assert "data-step=\"${_esc(step)}\"" in body
+    assert "_readinessActionLabel(detail, name)" in body
+    assert "function _readinessActionAriaLabel" in txt
+    assert ".setup-readiness__action" in css
+    assert "grid-template-columns: minmax(0, 1fr) auto auto auto" in css
+
+
+def test_setup_finish_readiness_names_router_provider_prerequisite():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "function _routerNeedsProvider" in txt
+    assert "uses SquillaRouter after provider setup" in txt
+
+    start = txt.index("function _setupStepForSection")
+    end = txt.index("  function _readinessActionLabel", start)
+    setup_body = txt[start:end]
+    assert "if (_routerNeedsProvider(detail, name)) return 'provider'" in setup_body
+
+    start = txt.index("function _readinessActionLabel")
+    end = txt.index("  function _renderReadinessAction", start)
+    action_body = txt[start:end]
+    assert "if (_routerNeedsProvider(detail, name)) return 'Choose provider'" in action_body
+
+    start = txt.index("function _readinessActionAriaLabel")
+    aria_body = txt[start : txt.index("  function _readinessTone", start)]
+    assert "return `Choose provider for ${label}`" in aria_body
+
+    start = txt.index("function _readinessStatusLabel")
+    status_body = txt[start : txt.index("  function _fieldHtml", start)]
+    assert "if (_routerNeedsProvider(detail, name)) return 'Provider first'" in status_body
+
+
+def test_setup_finish_summary_stays_neutral_before_provider_is_configured():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _renderFinishStep()")
+    end = txt.index("  function _renderCliCommand", start)
+    body = txt[start:end]
+
+    assert "const currentProvider = (_config.llm || {}).provider || ''" in body
+    assert (
+        "const hasSavedProvider = Boolean(currentProvider) && _status.hasConfig !== false"
+    ) in body
+    assert "const providerSummary = hasSavedProvider ? currentProvider : 'not configured'" in body
+    assert (
+        "const modelSummary = hasSavedProvider"
+        "\n      ? ((_config.llm || {}).model || 'SquillaRouter defaults')"
+        "\n      : 'not configured'"
+    ) in body
+    assert (
+        "const routerSummary = hasSavedProvider"
+        "\n      ? (router.enabled === false ? 'disabled' : 'SquillaRouter')"
+        "\n      : 'choose a provider first'"
+    ) in body
+    assert "router.tier_profile || 'openrouter-mix'" not in body
+    assert "<strong>${_esc(providerSummary)}</strong>" in body
+    assert "<strong>${_esc(modelSummary)}</strong>" in body
+    assert "<strong>${_esc(routerSummary)}</strong>" in body
 
 
 def test_setup_panel_avoids_dense_background_rule_lines():
     css = (ROOT / "static/css/views/setup.css").read_text(encoding="utf-8")
     panel_block = css.split(".setup-panel {", 1)[1].split("}", 1)[0]
     assert "repeating-linear-gradient" not in panel_block
+
+
+def test_setup_capability_cards_keep_controls_top_aligned():
+    css = (ROOT / "static/css/views/setup.css").read_text(encoding="utf-8")
+    mini_block = css.split(".setup-mini {", 1)[1].split("}", 1)[0]
+
+    assert "align-content: start" in mini_block
+
+
+def test_setup_hidden_controls_remain_hidden_after_label_layout_rules():
+    css = (ROOT / "static/css/views/setup.css").read_text(encoding="utf-8")
+
+    assert ".setup [hidden]" in css
+    hidden_block = css.split(".setup [hidden]", 1)[1].split("}", 1)[0]
+    assert "display: none !important" in hidden_block
+
+
+def test_setup_search_advanced_details_are_styled_as_secondary_controls():
+    css = (ROOT / "static/css/views/setup.css").read_text(encoding="utf-8")
+
+    assert ".setup-mini__advanced > summary" in css
+    assert ".setup-mini__advanced-body" in css
+    assert "details.setup-mini__advanced[open] > summary::after" in css
 
 
 def test_config_view_exposes_memory_tab_and_restart_notice():

--- a/tests/test_gateway_config_legacy.py
+++ b/tests/test_gateway_config_legacy.py
@@ -46,6 +46,15 @@ _ALL_DEPRECATED_MEMORY_FIELDS = {
 }
 
 
+def test_explicit_missing_config_path_stays_attached_to_defaults(tmp_path: Path) -> None:
+    target = tmp_path / "new-user-config.toml"
+
+    cfg = GatewayConfig.load(target)
+
+    assert cfg.config_path == str(target)
+    assert not target.exists()
+
+
 def _build_toml_with_deprecated(tmp_path: Path) -> Path:
     """Write a minimal config.toml that contains all deprecated fields."""
     lines = ["[memory]\n"]

--- a/tests/test_memory_manager_embedding_config.py
+++ b/tests/test_memory_manager_embedding_config.py
@@ -334,6 +334,23 @@ def test_resolver_auto_uses_memory_remote_when_local_unavailable() -> None:
     assert decision.remote_api_key == "mem-key"
 
 
+def test_resolver_explicit_remote_uses_memory_env_key(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_EMBEDDINGS_API_KEY", "mem-env-key")
+    cfg = GatewayConfig(
+        memory={
+            "embedding": {
+                "provider": "openai",
+                "remote": {"api_key_env": "OPENAI_EMBEDDINGS_API_KEY"},
+            }
+        }
+    )
+
+    decision = resolve_memory_embedding(cfg.memory, local_available=lambda *_: False)
+
+    assert decision.effective_provider == "openai"
+    assert decision.remote_api_key == "mem-env-key"
+
+
 def test_resolver_explicit_remote_requires_memory_api_key() -> None:
     cfg = GatewayConfig(memory={"embedding": {"provider": "openai"}})
     with pytest.raises(ValueError, match="memory.embedding.remote.api_key"):

--- a/tests/test_onboarding/test_channel_specs.py
+++ b/tests/test_onboarding/test_channel_specs.py
@@ -145,8 +145,11 @@ def test_channel_catalog_payload_exposes_ui_metadata():
     assert fields["app_secret"]["placeholder"]
     assert fields["webhook_path"]["showWhen"] == {"connection_mode": "webhook"}
     assert fields["encrypt_key"]["advanced"] is True
+    assert feishu["blocking"] is False
+    assert feishu["whatYouNeed"]
     slack = next(c for c in payload if c["type"] == "slack")
     assert "public URL" in slack["help"]
+    assert any("public URL" in item for item in slack["whatYouNeed"])
 
 
 def test_matrix_encryption_choices():

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -157,6 +157,9 @@ def test_interactive_provider_fields_default_to_pasted_api_key(monkeypatch):
         def confirm(self, message: str, **_kwargs):
             raise AssertionError(f"unexpected confirm prompt: {message}")
 
+        def checkbox(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected checkbox prompt: {message}")
+
     answers = _ask_provider_fields(
         _Questionary(),
         get_provider_setup_spec("openrouter"),
@@ -188,7 +191,9 @@ def test_interactive_provider_fields_explains_detected_env_key(monkeypatch):
                 "Paste API key now",
                 "Use environment variable OPENROUTER_API_KEY (detected)",
             ]
-            assert kwargs.get("default") == "Paste API key now"
+            assert kwargs.get("default") == (
+                "Use environment variable OPENROUTER_API_KEY (detected)"
+            )
             return _Answer("Use environment variable OPENROUTER_API_KEY (detected)")
 
         def password(self, message: str, **_kwargs):
@@ -1062,8 +1067,10 @@ def test_interactive_onboard_can_enable_image_generation(tmp_path, monkeypatch):
             if message == "LLM provider":
                 return _Answer("openrouter (OpenRouter)")
             if message == "LLM API key source":
-                assert kwargs.get("default") == "Paste API key now"
-                return _Answer("Paste API key now")
+                assert kwargs.get("default") == (
+                    "Use environment variable OPENROUTER_API_KEY (detected)"
+                )
+                return _Answer("Use environment variable OPENROUTER_API_KEY (detected)")
             if message == "Router mode":
                 return _Answer("SquillaRouter")
             if message == "Default text model":
@@ -1072,10 +1079,13 @@ def test_interactive_onboard_can_enable_image_generation(tmp_path, monkeypatch):
                 assert kwargs.get("default") == "openrouter (OpenRouter Images)"
                 return _Answer("openrouter (OpenRouter Images)")
             if message == "Image API key source":
-                assert "Use environment variable OPENROUTER_API_KEY" in kwargs.get("choices", [])
-                assert "Reuse matching LLM provider key" in kwargs.get("choices", [])
-                assert kwargs.get("default") == "Reuse matching LLM provider key"
-                return _Answer("Reuse matching LLM provider key")
+                assert (
+                    "Use environment variable OPENROUTER_API_KEY"
+                    in kwargs.get("choices", [])
+                )
+                assert "Reuse matching LLM provider key" not in kwargs.get("choices", [])
+                assert kwargs.get("default") == "Use environment variable OPENROUTER_API_KEY"
+                return _Answer("Use environment variable OPENROUTER_API_KEY")
             raise AssertionError(f"unexpected select prompt: {message}")
 
         def text(self, message: str, **kwargs):
@@ -1117,6 +1127,103 @@ def test_interactive_onboard_can_enable_image_generation(tmp_path, monkeypatch):
         data["image_generation"]["primary"]
         == "openrouter/google/gemini-3.1-flash-image-preview"
     )
+
+
+def test_onboard_if_needed_core_ready_repairs_memory_embedding_without_provider_setup(
+    tmp_path,
+    monkeypatch,
+):
+    import sys
+    import tomllib
+    import types
+
+    from opensquilla.gateway.config import (
+        GatewayConfig,
+        LlmProviderConfig,
+        MemoryEmbeddingConfig,
+    )
+    from opensquilla.onboarding import flow
+    from opensquilla.onboarding.config_store import persist_config
+
+    target = tmp_path / "c.toml"
+    cfg = GatewayConfig(config_path=str(target))
+    cfg.llm = LlmProviderConfig(
+        provider="openrouter",
+        model="deepseek/deepseek-v4-flash",
+        api_key="sk-core",
+    )
+    cfg.memory.embedding = MemoryEmbeddingConfig(provider="openai")
+    persist_config(cfg, path=target, backup=False)
+
+    calls: list[str] = []
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-memory-env")
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    monkeypatch.setattr(flow, "_wait_for_setup_start", lambda: calls.append("start gate"))
+    monkeypatch.setattr(flow, "detect_default_sources", lambda: [])
+
+    banner_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        flow,
+        "banner_panel",
+        lambda title, subtitle: banner_calls.append((title, subtitle)) or title,
+    )
+
+    class _Answer:
+        def __init__(self, value):
+            self.value = value
+
+        def ask(self):
+            return self.value
+
+    class _Questionary(types.SimpleNamespace):
+        def confirm(self, message: str, **kwargs):
+            calls.append(message)
+            if message == "Configure memory embeddings now?":
+                assert kwargs.get("default") is True
+                return _Answer(True)
+            raise AssertionError(f"unexpected confirm prompt: {message}")
+
+        def select(self, message: str, **kwargs):
+            calls.append(message)
+            if message == "Memory embedding provider":
+                return _Answer("openai (OpenAI)")
+            if message == "Memory API key source":
+                assert "Use environment variable OPENAI_API_KEY (detected)" in kwargs.get(
+                    "choices", []
+                )
+                return _Answer("Use environment variable OPENAI_API_KEY (detected)")
+            raise AssertionError(f"unexpected select prompt: {message}")
+
+        def text(self, message: str, **kwargs):
+            calls.append(message)
+            if message == "Memory embedding model":
+                return _Answer(kwargs.get("default"))
+            if message == "Memory embedding base URL":
+                return _Answer(kwargs.get("default"))
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+        def password(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected password prompt: {message}")
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    flow.run_interactive_onboard(flow.OnboardOptions(if_needed=True))
+
+    assert "LLM provider" not in calls
+    assert calls.index("Configure memory embeddings now?") < calls.index(
+        "Memory embedding provider"
+    )
+    assert banner_calls == [
+        (
+            "OpenSquilla Onboarding",
+            "Migration · Provider · SquillaRouter · Channels · Capabilities",
+        )
+    ]
+    data = tomllib.loads(target.read_text())
+    assert data["memory"]["embedding"]["provider"] == "openai"
+    assert data["memory"]["embedding"]["remote"]["api_key_env"] == "OPENAI_API_KEY"
+    assert "api_key" not in data["memory"]["embedding"]["remote"]
 
 
 def test_interactive_configure_image_generation_persists(tmp_path, monkeypatch):
@@ -1400,6 +1507,9 @@ def test_interactive_channel_add_uses_explicit_config_path(tmp_path, monkeypatch
         def confirm(self, message: str, **_kwargs):
             raise AssertionError(f"unexpected confirm prompt: {message}")
 
+        def checkbox(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected checkbox prompt: {message}")
+
     monkeypatch.setitem(sys.modules, "questionary", _Questionary())
 
     flow.run_interactive_channel_add(None, config_path=target)
@@ -1498,7 +1608,7 @@ def test_search_provider_key_defaults_to_pasted_key_with_brave_hint(monkeypatch)
     assert answers["api_key_env"] == ""
 
 
-def test_search_provider_detected_env_still_defaults_to_manual_key(monkeypatch):
+def test_search_provider_detected_env_prefers_env_but_can_use_manual_key(monkeypatch):
     from opensquilla.onboarding.flow import _ask_search_fields
     from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
 
@@ -1519,7 +1629,7 @@ def test_search_provider_detected_env_still_defaults_to_manual_key(monkeypatch):
 
         def confirm(self, message: str, **kwargs):
             if message == "Use BRAVE_SEARCH_API_KEY from environment?":
-                assert kwargs.get("default") is False
+                assert kwargs.get("default") is True
                 return _Answer(False)
             if message == "Use environment proxy for search?":
                 return _Answer(False)
@@ -1574,7 +1684,7 @@ def test_search_provider_can_use_detected_env_when_requested(monkeypatch):
 
         def confirm(self, message: str, **kwargs):
             if message == "Use BRAVE_SEARCH_API_KEY from environment?":
-                assert kwargs.get("default") is False
+                assert kwargs.get("default") is True
                 return _Answer(True)
             if message == "Use environment proxy for search?":
                 return _Answer(False)
@@ -1787,6 +1897,154 @@ def test_interactive_configure_search_uses_explicit_config_path(tmp_path, monkey
     assert not default_target.exists()
 
 
+def test_interactive_configure_memory_embedding_is_in_section_menu(
+    tmp_path,
+    monkeypatch,
+):
+    import sys
+    import tomllib
+    import types
+
+    from opensquilla.onboarding import flow
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-memory-env")
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    class _Answer:
+        def __init__(self, value):
+            self.value = value
+
+        def ask(self):
+            return self.value
+
+    class _Questionary(types.SimpleNamespace):
+        def select(self, message: str, **kwargs):
+            if message == "Section":
+                assert "memory-embedding" in kwargs["choices"]
+                return _Answer("memory-embedding")
+            if message == "Memory embedding provider":
+                return _Answer("openai (OpenAI)")
+            if message == "Memory API key source":
+                return _Answer("Use environment variable OPENAI_API_KEY")
+            raise AssertionError(f"unexpected select prompt: {message}")
+
+        def text(self, message: str, **kwargs):
+            if message == "Memory embedding model":
+                return _Answer("text-embedding-3-small")
+            if message == "Memory embedding base URL":
+                return _Answer(kwargs.get("default"))
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+        def password(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected password prompt: {message}")
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    flow.run_interactive_configure(config_path=target)
+
+    data = tomllib.loads(target.read_text())
+    remote = data["memory"]["embedding"]["remote"]
+    assert data["memory"]["embedding"]["provider"] == "openai"
+    assert remote["api_key_env"] == "OPENAI_API_KEY"
+    assert "api_key" not in remote
+
+
+def test_interactive_memory_embedding_configure_without_tty_prints_hint(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    from opensquilla.onboarding import flow
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setattr(flow, "_is_tty", lambda: False)
+
+    result = flow.run_interactive_memory_embedding_configure(config_path=target)
+
+    assert result.warnings == ["tty_required"]
+    assert not target.exists()
+    out = capsys.readouterr().out
+    assert "Headless memory embedding:" in out
+    assert "opensquilla onboard configure memory-embedding --config" in out
+
+
+def test_interactive_configure_provider_accepts_singular_section_alias(
+    tmp_path,
+    monkeypatch,
+):
+    from opensquilla.onboarding import flow
+    from opensquilla.onboarding.config_store import PersistResult
+
+    target = tmp_path / "custom.toml"
+    seen = {}
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    def fake_run_interactive_onboard(options):
+        seen["config_path"] = options.config_path
+        return PersistResult(
+            path=target,
+            backup_path=None,
+            restart_required=False,
+            warnings=[],
+        )
+
+    monkeypatch.setattr(flow, "run_interactive_onboard", fake_run_interactive_onboard)
+
+    result = flow.run_interactive_configure("provider", config_path=target)
+
+    assert result is not None
+    assert seen["config_path"] == target
+
+
+def test_interactive_configure_router_persists(tmp_path, monkeypatch):
+    import sys
+    import tomllib
+    import types
+
+    from opensquilla.onboarding import flow
+
+    target = tmp_path / "c.toml"
+    target.write_text(
+        '[llm]\nprovider = "openrouter"\nmodel = "deepseek/deepseek-v4-flash"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    class _Answer:
+        def __init__(self, value):
+            self.value = value
+
+        def ask(self):
+            return self.value
+
+    class _Questionary(types.SimpleNamespace):
+        def select(self, message: str, **kwargs):
+            if message == "Router mode":
+                return _Answer("Disabled")
+            raise AssertionError(f"unexpected select prompt: {message}")
+
+        def text(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+        def password(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected password prompt: {message}")
+
+        def confirm(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected confirm prompt: {message}")
+
+        def checkbox(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected checkbox prompt: {message}")
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    flow.run_interactive_configure("router", config_path=target)
+
+    data = tomllib.loads(target.read_text())
+    assert data["squilla_router"]["enabled"] is False
+
+
 def test_interactive_configure_provider_receives_explicit_config_path(
     tmp_path,
     monkeypatch,
@@ -1816,7 +2074,7 @@ def test_interactive_configure_provider_receives_explicit_config_path(
 
 
 def test_interactive_configure_without_tty_does_not_create_config(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, capsys
 ):
     target = tmp_path / "c.toml"
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
@@ -1826,4 +2084,9 @@ def test_interactive_configure_without_tty_does_not_create_config(
     result = flow.run_interactive_configure("providers")
 
     assert result is None
+    out = capsys.readouterr().out
+    assert "Guided CLI:" in out
+    assert "Provider recipes:" in out
+    assert "Headless provider:" not in out
+    assert "Check status:" in out
     assert not target.exists()

--- a/tests/test_onboarding/test_flow_cancel.py
+++ b/tests/test_onboarding/test_flow_cancel.py
@@ -186,7 +186,7 @@ def test_optional_section_runner_swallows_user_cancelled(monkeypatch):
 
     text = recorder.joined().lower()
     assert "search setup cancelled" in text
-    assert "opensquilla configure search" in recorder.joined()
+    assert "opensquilla onboard configure search" in recorder.joined()
 
 
 def test_optional_section_runner_resume_hint_uses_section_slug_not_label(monkeypatch):
@@ -205,7 +205,7 @@ def test_optional_section_runner_resume_hint_uses_section_slug_not_label(monkeyp
         runner=_runner,
     )
 
-    assert "opensquilla configure image-generation" in recorder.joined()
+    assert "opensquilla onboard configure image-generation" in recorder.joined()
 
 
 def test_optional_section_runner_swallows_keyboard_interrupt(monkeypatch):

--- a/tests/test_onboarding/test_if_needed_gate.py
+++ b/tests/test_onboarding/test_if_needed_gate.py
@@ -1,10 +1,8 @@
 """End-to-end coverage for the ``onboard --if-needed`` gate.
 
-The user-reported regression was: after cancelling the search section
-mid-flow, ``onboard --if-needed`` falsely reported "complete" because the
-gate only consulted ``llm_configured``. With section-verifier semantics
-the gate must escalate to every section so a stuck search step keeps the
-operator in the flow.
+The gate represents first-run readiness. Optional capability sections still
+surface action-required metadata, but they must not keep provider-complete
+installs inside the interactive wizard forever.
 
 Console output is captured by monkeypatching ``opensquilla.cli.onboard_cmd.console``
 rather than ``capsys``. Rich consoles bind to a stdout reference at import
@@ -68,40 +66,53 @@ def test_if_needed_skips_when_all_sections_ok_or_optional(
 
     result = runner.invoke(app, ["onboard", "--if-needed"])
     assert result.exit_code == 0, result.output
-    assert "already complete" in recorder.joined()
+    assert "core setup is ready" in recorder.joined()
+    assert "optional capabilities need action" in recorder.joined()
+    assert "Optional next moves" in recorder.joined()
+    assert "Headless channel" in recorder.joined()
 
 
-def test_if_needed_does_not_skip_when_search_was_cancelled(
+def test_if_needed_surfaces_optional_actions_without_running_wizard(
     monkeypatch, tmp_path, recorder, runner
 ):
-    """Reproduces the user's original report:
-
-    Provider was configured, then the search step crashed at the api-key
-    prompt. ``onboard --if-needed`` used to print "already complete" and
-    exit. With section verifiers it must keep the operator in the flow.
-    """
     cfg = _llm_ok_cfg()
+    cfg.llm = LlmProviderConfig(
+        provider="deepseek",
+        model="m",
+        api_key="sk-x",
+        base_url="https://api.deepseek.com/v1",
+    )
     cfg.search_provider = "brave"
     cfg.search_api_key = ""
     cfg.search_api_key_env = ""
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openai/gpt-image-1"
+    cfg.memory.embedding.provider = "auto"
 
     config_path = tmp_path / "config.toml"
     config_path.write_text("")
     cfg.config_path = str(config_path)
     monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setattr("opensquilla.cli.onboard_cmd.load_config", lambda _path=None: cfg)
 
     status = get_onboarding_status(cfg)
-    assert status.needs_onboarding is True
-    assert status.sections["search"].value == "missing"
+    assert status.needs_onboarding is False
+    action_sections = ("search", "image_generation")
+    for section in action_sections:
+        assert status.section_details[section]["actionRequired"] is True
 
-    # Force non-TTY exit path so the interactive flow does not actually run.
+    # Guard the assertion: this path should exit before the wizard is reached.
     monkeypatch.setattr("opensquilla.onboarding.flow._is_tty", lambda: False)
 
-    runner.invoke(app, ["onboard", "--if-needed"])
+    result = runner.invoke(app, ["onboard", "--if-needed"])
+    assert result.exit_code == 0, result.output
+    assert "core setup is ready" in recorder.joined()
+    assert "optional capabilities need action" in recorder.joined()
+    for section in action_sections:
+        assert status.section_details[section]["label"] in recorder.joined()
     assert "already complete" not in recorder.joined()
-    assert "unfinished sections" in recorder.joined()
-    assert "search" in recorder.joined()
+    assert "unfinished sections" not in recorder.joined()
 
 
 def test_onboard_status_subcommand_emits_json(monkeypatch, tmp_path, runner):

--- a/tests/test_onboarding/test_if_needed_gate.py
+++ b/tests/test_onboarding/test_if_needed_gate.py
@@ -69,7 +69,8 @@ def test_if_needed_skips_when_all_sections_ok_or_optional(
     assert "core setup is ready" in recorder.joined()
     assert "optional capabilities need action" in recorder.joined()
     assert "Optional next moves" in recorder.joined()
-    assert "Headless channel" in recorder.joined()
+    assert "Channel recipes:" in recorder.joined()
+    assert "Image recipes:" in recorder.joined()
 
 
 def test_if_needed_surfaces_optional_actions_without_running_wizard(

--- a/tests/test_onboarding/test_image_generation_specs.py
+++ b/tests/test_onboarding/test_image_generation_specs.py
@@ -1,0 +1,19 @@
+"""Tests for onboarding image generation provider catalog."""
+
+from __future__ import annotations
+
+from opensquilla.onboarding.image_generation_specs import (
+    image_generation_provider_catalog_payload,
+)
+
+
+def test_image_generation_payload_exposes_optional_capability_metadata():
+    payload = image_generation_provider_catalog_payload()
+
+    assert {row["providerId"] for row in payload} == {"openai", "openrouter"}
+    for row in payload:
+        assert row["blocking"] is False
+        assert row["canProbe"] is False
+        assert row["deployment"] == "cloud"
+        assert row["whatYouNeed"]
+        assert row["readmeScenarios"]

--- a/tests/test_onboarding/test_memory_embedding_specs.py
+++ b/tests/test_onboarding/test_memory_embedding_specs.py
@@ -1,0 +1,48 @@
+"""Tests for onboarding memory embedding provider catalog."""
+
+from __future__ import annotations
+
+import pytest
+
+from opensquilla.onboarding.memory_embedding_specs import (
+    get_memory_embedding_provider_setup_spec,
+    memory_embedding_provider_catalog_payload,
+)
+
+
+def test_memory_embedding_catalog_covers_all_setup_providers():
+    payload = memory_embedding_provider_catalog_payload()
+    provider_ids = {row["providerId"] for row in payload}
+
+    assert {
+        "auto",
+        "local",
+        "openai",
+        "openai-compatible",
+        "ollama",
+        "none",
+    } <= provider_ids
+
+
+def test_memory_embedding_payload_exposes_readiness_metadata():
+    payload = memory_embedding_provider_catalog_payload()
+
+    for row in payload:
+        assert row["blocking"] is False
+        assert row["canProbe"] is False
+        assert row["deployment"] in {"auto", "local", "cloud", "custom", "disabled"}
+        assert row["whatYouNeed"]
+        assert row["readmeScenarios"]
+
+
+def test_memory_embedding_remote_requires_key():
+    spec = get_memory_embedding_provider_setup_spec("openai")
+
+    assert spec.requires_api_key is True
+    assert spec.deployment == "cloud"
+    assert spec.env_key == "OPENAI_API_KEY"
+
+
+def test_unknown_memory_embedding_provider_raises():
+    with pytest.raises(KeyError):
+        get_memory_embedding_provider_setup_spec("does-not-exist")

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -82,6 +82,22 @@ def test_upsert_memory_embedding_remote_redacts_key():
     assert res.public_payload["remote"]["api_key"] == REDACTED_PLACEHOLDER
 
 
+def test_upsert_memory_embedding_remote_can_use_env_key_reference():
+    cfg = GatewayConfig()
+    res = upsert_memory_embedding(
+        cfg,
+        provider="openai",
+        model="text-embedding-3-small",
+        api_key_env="OPENAI_EMBEDDINGS_API_KEY",
+        base_url="https://api.openai.com/v1",
+    )
+
+    remote = res.config.memory.embedding.remote
+    assert remote.api_key in {"", None}
+    assert remote.api_key_env == "OPENAI_EMBEDDINGS_API_KEY"
+    assert res.public_payload["remote"]["api_key_env"] == "OPENAI_EMBEDDINGS_API_KEY"
+
+
 def test_upsert_memory_embedding_auto_can_store_remote_fallback():
     cfg = GatewayConfig()
     res = upsert_memory_embedding(
@@ -451,6 +467,32 @@ def test_upsert_search_provider_can_use_env_key_reference():
     assert res.public_payload["api_key_source"] == "env"
 
 
+def test_upsert_search_provider_accepts_webui_string_max_results():
+    cfg = GatewayConfig()
+    res = upsert_search_provider(
+        cfg,
+        provider_id="duckduckgo",
+        max_results="5",
+    )
+
+    assert res.config.search_provider == "duckduckgo"
+    assert res.config.search_max_results == 5
+
+
+def test_upsert_search_provider_clears_env_key_for_no_key_provider():
+    cfg = GatewayConfig(search_provider="brave", search_api_key_env="BRAVE_SEARCH_API_KEY")
+
+    res = upsert_search_provider(
+        cfg,
+        provider_id="duckduckgo",
+        api_key_env="BRAVE_SEARCH_API_KEY",
+    )
+
+    assert res.config.search_provider == "duckduckgo"
+    assert res.config.search_api_key_env == ""
+    assert res.public_payload["api_key_source"] == "none"
+
+
 def test_upsert_image_generation_provider_configures_openrouter(monkeypatch):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     cfg = GatewayConfig()
@@ -476,6 +518,22 @@ def test_upsert_image_generation_provider_can_use_matching_llm_key(monkeypatch):
     assert res.config.image_generation.enabled is True
     assert res.config.image_generation.providers.openrouter.api_key == ""
     assert res.public_payload["api_key_source"] == "llm_fallback"
+
+
+def test_upsert_image_generation_provider_can_disable_without_key(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    cfg = GatewayConfig()
+
+    res = upsert_image_generation_provider(
+        cfg,
+        provider_id="openrouter",
+        primary="openrouter/google/gemini-3.1-flash-image-preview",
+        enabled=False,
+    )
+
+    assert res.config.image_generation.enabled is False
+    assert res.config.image_generation.primary == "openrouter/google/gemini-3.1-flash-image-preview"
+    assert res.public_payload["api_key_source"] == "none"
 
 
 def test_upsert_image_generation_provider_rejects_wrong_primary_provider():

--- a/tests/test_onboarding/test_next_steps.py
+++ b/tests/test_onboarding/test_next_steps.py
@@ -32,8 +32,77 @@ def test_onboarding_finish_output_separates_summary_from_commands():
     assert "  Start gateway in background: opensquilla gateway start --json" in text
     assert "  Restart running gateway: opensquilla gateway restart --json" in text
     assert "Reference:" in text
-    assert "  Web UI: http://127.0.0.1:18791/control/" in text
+    assert "  Web UI: http://127.0.0.1:18791/control/setup" in text
     assert "uv run" not in text
+
+
+def test_onboarding_finish_output_summarizes_all_capability_sections():
+    from opensquilla.gateway.config import GatewayConfig, LlmProviderConfig
+    from opensquilla.onboarding.next_steps import format_next_steps
+
+    cfg = GatewayConfig()
+    cfg.llm = LlmProviderConfig(
+        provider="deepseek",
+        model="deepseek-chat",
+        api_key="sk-test",
+        base_url="https://api.deepseek.com/v1",
+    )
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openai/gpt-image-1"
+    cfg.image_generation.providers.openai.api_key = ""
+    cfg.memory.embedding.provider = "openai"
+    cfg.memory.embedding.remote.api_key = ""
+
+    text = format_next_steps(cfg, config_path="/tmp/opensquilla/custom.toml")
+
+    assert (
+        "  Capabilities: Web search=Ready | Channels=Later | "
+        "Image generation=Needs action | Memory embedding=Needs action"
+    ) in text
+    assert text.index("  Capabilities:") < text.index("Commands:")
+
+
+def test_onboarding_finish_output_uses_product_router_label():
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.onboarding.next_steps import format_next_steps
+
+    text = format_next_steps(GatewayConfig(), config_path="/tmp/opensquilla/custom.toml")
+
+    assert "  Router: SquillaRouter, default=t1" in text
+    assert "profile=openrouter-mix" not in text
+
+
+def test_onboarding_finish_output_keeps_explicit_config_in_gateway_commands():
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.onboarding.next_steps import format_next_steps
+
+    text = format_next_steps(GatewayConfig(), config_path="/tmp/opensquilla/custom.toml")
+
+    assert (
+        "  Run gateway now: opensquilla gateway run --config /tmp/opensquilla/custom.toml"
+        in text
+    )
+    assert (
+        "  Start gateway in background: "
+        "opensquilla gateway start --json --config /tmp/opensquilla/custom.toml"
+    ) in text
+    assert (
+        "  Restart running gateway: "
+        "opensquilla gateway restart --json --config /tmp/opensquilla/custom.toml"
+    ) in text
+
+
+def test_onboarding_finish_output_uses_configured_web_setup_url():
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.onboarding.next_steps import format_next_steps
+
+    cfg = GatewayConfig(port=19999)
+    cfg.control_ui.base_path = "/ops"
+
+    text = format_next_steps(cfg)
+
+    assert "  Web UI: http://127.0.0.1:19999/ops/setup" in text
+    assert "  Web UI: http://127.0.0.1:18791/control/" not in text
 
 
 def test_onboarding_finish_output_puts_missing_env_hint_in_commands(monkeypatch):
@@ -88,6 +157,33 @@ def test_env_reference_warnings_cover_llm_and_search_missing_env(monkeypatch):
     )
     assert any(
         "Search provider" in warning and "BRAVE_SEARCH_API_KEY" in warning
+        for warning in warnings
+    )
+
+
+def test_env_reference_warnings_cover_image_and_memory_missing_env(monkeypatch):
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.onboarding.next_steps import env_reference_warnings
+
+    cfg = GatewayConfig()
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openrouter/google/gemini-3.1-flash-image-preview"
+    cfg.image_generation.providers.openrouter.api_key = ""
+    cfg.image_generation.providers.openrouter.api_key_env = "OPENSQUILLA_IMAGE_KEY"
+    cfg.memory.embedding.provider = "openai"
+    cfg.memory.embedding.remote.api_key = ""
+    cfg.memory.embedding.remote.api_key_env = "OPENAI_EMBEDDINGS_API_KEY"
+    monkeypatch.delenv("OPENSQUILLA_IMAGE_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
+
+    warnings = env_reference_warnings(cfg)
+
+    assert any(
+        "Image generation provider" in warning and "OPENSQUILLA_IMAGE_KEY" in warning
+        for warning in warnings
+    )
+    assert any(
+        "Memory embedding" in warning and "OPENAI_EMBEDDINGS_API_KEY" in warning
         for warning in warnings
     )
 

--- a/tests/test_onboarding/test_provider_specs.py
+++ b/tests/test_onboarding/test_provider_specs.py
@@ -109,6 +109,29 @@ def test_ollama_does_not_require_api_key_in_setup_spec():
     assert spec.requires_api_key is False
     api_field = next(f for f in spec.fields if f.name == "api_key")
     assert api_field.required is False
+    assert all(f.name != "api_key_env" for f in spec.fields)
+
+
+def test_api_key_providers_expose_env_key_field_in_setup_spec():
+    spec = get_provider_setup_spec("openrouter")
+    env_field = next(f for f in spec.fields if f.name == "api_key_env")
+
+    assert env_field.label == "API key env"
+    assert env_field.default == "OPENROUTER_API_KEY"
+    assert env_field.required is False
+    assert env_field.secret is False
+
+
+def test_non_router_providers_explain_required_model_in_setup_spec():
+    for provider_id in ("anthropic", "ollama", "qianfan"):
+        spec = get_provider_setup_spec(provider_id)
+        model_field = next(f for f in spec.fields if f.name == "model")
+
+        assert spec.router_supported is False
+        assert model_field.required is True
+        assert "Required" in model_field.description
+        assert "router" not in model_field.description.lower()
+        assert any("model" in item.lower() for item in spec.what_you_need)
 
 
 def test_azure_requires_base_url_in_setup_spec():
@@ -146,3 +169,14 @@ def test_payload_exposes_only_verified_runtime_supported_providers():
 
     assert {row["providerId"] for row in payload} == EXPECTED_SUPPORTED
     assert all(row["runtimeSupported"] is True for row in payload)
+
+
+def test_provider_payload_exposes_readiness_metadata_for_every_provider():
+    payload = provider_catalog_payload()
+
+    for row in payload:
+        assert row["blocking"] is True
+        assert row["deployment"] in {"cloud", "local", "custom", "oauth"}
+        assert row["canProbe"] is False
+        assert row["readmeScenarios"]
+        assert row["whatYouNeed"]

--- a/tests/test_onboarding/test_search_specs.py
+++ b/tests/test_onboarding/test_search_specs.py
@@ -40,6 +40,8 @@ def test_search_catalog_payload_is_web_safe_shape():
     assert "providerId" in first
     assert "runtimeSupported" in first
     assert "fields" in first
+    assert "blocking" in first
+    assert "whatYouNeed" in first
 
 
 def test_search_catalog_explains_fallback_and_diagnostics_fields():
@@ -48,3 +50,11 @@ def test_search_catalog_explains_fallback_and_diagnostics_fields():
 
     assert "DuckDuckGo" in fields["fallback_policy"].description
     assert "attempt/error details" in fields["diagnostics"].description
+
+
+def test_search_payload_marks_search_as_optional_capability():
+    payload = search_provider_catalog_payload()
+
+    assert all(row["blocking"] is False for row in payload)
+    assert all(row["canProbe"] is False for row in payload)
+    assert all(row["readmeScenarios"] for row in payload)

--- a/tests/test_onboarding/test_section_status.py
+++ b/tests/test_onboarding/test_section_status.py
@@ -7,6 +7,7 @@ import pytest
 from opensquilla.gateway.config import (
     GatewayConfig,
     LlmProviderConfig,
+    MemoryEmbeddingConfig,
     SlackChannelEntry,
 )
 from opensquilla.onboarding.section_status import (
@@ -14,6 +15,7 @@ from opensquilla.onboarding.section_status import (
     channels_section_status,
     image_generation_section_status,
     llm_section_status,
+    memory_embedding_section_status,
     needs_onboarding,
     router_section_status,
     search_section_status,
@@ -183,6 +185,83 @@ def test_image_generation_env_key_reference_missing_is_degraded(cfg, monkeypatch
     assert image_generation_section_status(cfg) is SectionStatus.DEGRADED
 
 
+def test_image_generation_missing_custom_env_is_not_masked_by_default_env(
+    cfg,
+    monkeypatch,
+):
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openai/gpt-image-1"
+    cfg.llm = LlmProviderConfig(provider="openrouter", model="m", api_key="")
+    openai_provider = cfg.image_generation.providers.openai
+    openai_provider.api_key = ""
+    openai_provider.api_key_env = "CUSTOM_IMAGE_KEY"
+    monkeypatch.delenv("CUSTOM_IMAGE_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "default-env-key")
+
+    assert image_generation_section_status(cfg) is SectionStatus.DEGRADED
+
+
+def test_image_generation_custom_default_primary_is_not_masked_by_other_provider(
+    cfg,
+    monkeypatch,
+):
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openai/gpt-image-1"
+    cfg.llm = LlmProviderConfig(provider="openrouter", model="m", api_key="sk-or")
+    openai_provider = cfg.image_generation.providers.openai
+    openai_provider.api_key = ""
+    openai_provider.api_key_env = "CUSTOM_IMAGE_KEY"
+    monkeypatch.delenv("CUSTOM_IMAGE_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    assert image_generation_section_status(cfg) is SectionStatus.DEGRADED
+
+
+# ── memory embedding ────────────────────────────────────────────────────────
+
+def test_memory_embedding_auto_is_ok(cfg):
+    cfg.memory.embedding = MemoryEmbeddingConfig(provider="auto")
+    assert memory_embedding_section_status(cfg) is SectionStatus.OK
+
+
+def test_memory_embedding_none_is_optional(cfg):
+    cfg.memory.embedding = MemoryEmbeddingConfig(provider="none")
+    assert memory_embedding_section_status(cfg) is SectionStatus.OPTIONAL
+
+
+def test_memory_embedding_remote_without_key_is_missing(cfg):
+    cfg.memory.embedding = MemoryEmbeddingConfig(provider="openai")
+    assert memory_embedding_section_status(cfg) is SectionStatus.MISSING
+
+
+def test_memory_embedding_remote_with_missing_env_key_is_degraded(cfg, monkeypatch):
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_KEY", raising=False)
+    cfg.memory.embedding = MemoryEmbeddingConfig(
+        provider="openai",
+        remote={"api_key_env": "OPENAI_EMBEDDINGS_API_KEY"},
+    )
+
+    assert memory_embedding_section_status(cfg) is SectionStatus.DEGRADED
+
+
+def test_memory_embedding_remote_with_env_key_is_ok(cfg, monkeypatch):
+    monkeypatch.setenv("OPENAI_EMBEDDINGS_API_KEY", "mem-env-key")
+    cfg.memory.embedding = MemoryEmbeddingConfig(
+        provider="openai",
+        remote={"api_key_env": "OPENAI_EMBEDDINGS_API_KEY"},
+    )
+
+    assert memory_embedding_section_status(cfg) is SectionStatus.OK
+
+
+def test_memory_embedding_remote_with_key_is_ok(cfg):
+    cfg.memory.embedding = MemoryEmbeddingConfig(
+        provider="openai",
+        remote={"api_key": "sk-embedding"},
+    )
+    assert memory_embedding_section_status(cfg) is SectionStatus.OK
+
+
 # ── needs_onboarding reduction ───────────────────────────────────────────────
 
 def test_needs_onboarding_false_when_all_ok_or_optional():
@@ -192,38 +271,42 @@ def test_needs_onboarding_false_when_all_ok_or_optional():
         "search": SectionStatus.OK,
         "channels": SectionStatus.OPTIONAL,
         "image_generation": SectionStatus.OPTIONAL,
+        "memory_embedding": SectionStatus.OK,
     }
     assert needs_onboarding(sections) is False
 
 
-def test_needs_onboarding_true_when_any_missing():
+def test_needs_onboarding_false_when_optional_section_missing():
     sections = {
         "llm": SectionStatus.OK,
         "router": SectionStatus.OPTIONAL,
         "search": SectionStatus.MISSING,
         "channels": SectionStatus.OPTIONAL,
         "image_generation": SectionStatus.OPTIONAL,
+        "memory_embedding": SectionStatus.OK,
     }
-    assert needs_onboarding(sections) is True
+    assert needs_onboarding(sections) is False
 
 
-def test_needs_onboarding_true_when_any_degraded():
+def test_needs_onboarding_true_when_required_section_degraded():
     sections = {
         "llm": SectionStatus.DEGRADED,
         "router": SectionStatus.OK,
         "search": SectionStatus.OK,
         "channels": SectionStatus.OPTIONAL,
         "image_generation": SectionStatus.OPTIONAL,
+        "memory_embedding": SectionStatus.OK,
     }
     assert needs_onboarding(sections) is True
 
 
-def test_needs_onboarding_true_when_any_unknown():
+def test_needs_onboarding_false_when_optional_section_unknown():
     sections = {
         "llm": SectionStatus.OK,
         "router": SectionStatus.UNKNOWN,
         "search": SectionStatus.OK,
         "channels": SectionStatus.OPTIONAL,
         "image_generation": SectionStatus.OPTIONAL,
+        "memory_embedding": SectionStatus.OK,
     }
-    assert needs_onboarding(sections) is True
+    assert needs_onboarding(sections) is False

--- a/tests/test_onboarding/test_setup_engine.py
+++ b/tests/test_onboarding/test_setup_engine.py
@@ -128,6 +128,27 @@ def test_setup_engine_image_generation_can_use_custom_env_reference(
     assert provider["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
 
 
+def test_setup_engine_accepts_short_capability_section_aliases(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    target = tmp_path / "config.toml"
+    engine = SetupEngine(path=target)
+
+    engine.apply("image", {"enabled": False})
+    engine.apply(
+        "memory",
+        {
+            "providerId": "local",
+            "onnxDir": "models/bge",
+        },
+    )
+    engine.persist()
+
+    data = tomllib.loads(target.read_text())
+    assert data["image_generation"]["enabled"] is False
+    assert data["memory"]["embedding"]["provider"] == "local"
+    assert data["memory"]["embedding"]["local"]["onnx_dir"] == "models/bge"
+
+
 def test_setup_engine_catalog_includes_memory_embedding():
     engine = SetupEngine()
 
@@ -135,3 +156,4 @@ def test_setup_engine_catalog_includes_memory_embedding():
 
     provider_ids = {p["providerId"] for p in payload["memoryEmbeddingProviders"]}
     assert {"auto", "local", "openai", "ollama", "none"} <= provider_ids
+    assert all("whatYouNeed" in p for p in payload["memoryEmbeddingProviders"])

--- a/tests/test_onboarding/test_status.py
+++ b/tests/test_onboarding/test_status.py
@@ -143,6 +143,11 @@ def test_ollama_without_key_is_configured():
     )
     s = get_onboarding_status(cfg)
     assert s.llm_configured is True
+    assert s.memory_embedding_configured is True
+    assert s.memory_embedding_provider == "auto"
+    assert s.sections["memory_embedding"].value == "ok"
+    assert s.section_details["llm"]["required"] is True
+    assert s.section_details["channels"]["optional"] is True
 
 
 def test_zero_channels_means_not_messaging_configured():
@@ -158,3 +163,86 @@ def test_channel_present_marks_configured():
     s = get_onboarding_status(res.config)
     assert s.channel_count == 1
     assert s.channels_configured is True
+
+
+def test_section_details_mark_only_provider_as_first_run_blocking():
+    cfg = GatewayConfig()
+    cfg.llm = LlmProviderConfig(provider="", model="", api_key="")
+    cfg.search_provider = "brave"
+    cfg.search_api_key = ""
+    cfg.search_api_key_env = ""
+
+    s = get_onboarding_status(cfg)
+
+    assert s.section_details["llm"]["blocking"] is True
+    assert s.section_details["search"]["actionRequired"] is True
+    assert s.section_details["search"]["blocking"] is False
+
+
+def test_router_detail_explains_provider_dependency_before_provider_setup():
+    cfg = GatewayConfig()
+    cfg.llm = LlmProviderConfig(provider="", model="", api_key="")
+
+    s = get_onboarding_status(cfg)
+
+    assert (
+        s.section_details["router"]["detail"]
+        == "uses SquillaRouter after provider setup"
+    )
+    assert s.section_details["router"]["actionRequired"] is False
+
+
+def test_optional_search_action_does_not_block_first_run():
+    cfg = GatewayConfig()
+    cfg.llm = LlmProviderConfig(
+        provider="openrouter",
+        model="m",
+        api_key="sk-x",
+        base_url="https://openrouter.ai/api/v1",
+    )
+    cfg.search_provider = "brave"
+    cfg.search_api_key = ""
+    cfg.search_api_key_env = ""
+
+    s = get_onboarding_status(cfg)
+
+    assert s.section_details["search"]["actionRequired"] is True
+    assert s.section_details["search"]["blocking"] is False
+    assert s.needs_onboarding is False
+
+
+def test_optional_image_generation_action_does_not_block_first_run(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    cfg = GatewayConfig()
+    cfg.llm = LlmProviderConfig(
+        provider="deepseek",
+        model="m",
+        api_key="sk-x",
+        base_url="https://api.deepseek.com/v1",
+    )
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openai/gpt-image-1"
+
+    s = get_onboarding_status(cfg)
+
+    assert s.section_details["image_generation"]["actionRequired"] is True
+    assert s.section_details["image_generation"]["blocking"] is False
+    assert s.needs_onboarding is False
+
+
+def test_explicit_remote_memory_embedding_action_blocks_gateway_start():
+    cfg = GatewayConfig()
+    cfg.llm = LlmProviderConfig(
+        provider="openrouter",
+        model="m",
+        api_key="sk-x",
+        base_url="https://openrouter.ai/api/v1",
+    )
+    cfg.memory.embedding.provider = "openai"
+    cfg.memory.embedding.remote.api_key = ""
+
+    s = get_onboarding_status(cfg)
+
+    assert s.section_details["memory_embedding"]["actionRequired"] is True
+    assert s.section_details["memory_embedding"]["blocking"] is True
+    assert s.needs_onboarding is True


### PR DESCRIPTION
## Summary

- Productizes onboarding as a section-aware setup flow across provider, SquillaRouter, web search, channels, image generation, and memory embedding.
- Makes CLI onboarding actionable with status/catalog/configure flows, copyable recovery commands, provider-neutral recipes, and non-TTY/headless paths.
- Aligns the Web setup page with the same onboarding status/catalog/RPC contract, including readiness rows, command handoffs, env recovery, provider route badges, and optional capability controls.

## Checklist

- [x] This pull request targets `dev`, unless a maintainer asked for a `main` release/hotfix/documentation PR.
- [x] I ran `uv run ruff check src tests`.
- [ ] I ran `uv run pytest -q`.
- [x] I ran `uv build --wheel`.
- [x] Behavior changes include public regression tests.
- [x] The default test path remains offline, deterministic, credential-free, and safe for forks.
- [x] I did not commit secrets, local paths, private prompts, real provider transcripts, channel identifiers, or AI session artifacts.
- [x] I did not commit maintainer-only files from `tests/_private/` or `.omx/private-golden/`.
- [x] Third-party origin is declared: `none`.

## Live Checks

This PR changes onboarding, gateway setup RPC, and browser UI behavior. A maintainer should run the `Live Release E2E` workflow before treating this as release-ready. Local validation stayed credential-free and did not call live providers.

## Verification

- `uv run --extra dev ruff check src tests`
- `uv run --extra dev --extra recommended --extra mcp mypy src/opensquilla --show-error-codes`
- `uv run --extra dev python -m pytest -q tests/test_cli/test_gateway_cmd.py tests/test_skills/test_meta_run_persistence_e2e.py tests/test_cli/test_onboard_cmd.py tests/test_gateway/test_rpc_onboarding.py tests/test_onboarding/test_if_needed_gate.py` — 170 passed
- `uv run --extra dev python -m pytest -q tests/test_cli/test_onboard_cmd.py tests/test_gateway/test_static_onboarding_views.py tests/test_gateway/test_rpc_onboarding.py tests/test_onboarding/test_flow.py tests/test_onboarding/test_status.py tests/test_onboarding/test_mutations.py tests/test_onboarding/test_next_steps.py tests/test_onboarding/test_setup_engine.py tests/test_onboarding/test_section_status.py tests/test_cli/test_gateway_cmd.py tests/test_cli/test_help_theme.py tests/test_onboarding/test_if_needed_gate.py tests/test_skills/test_meta_run_persistence_e2e.py` — 417 passed
- `node --check src/opensquilla/gateway/static/js/views/setup.js`
- `git diff --check`
- `uv run --extra dev opensquilla onboard --config /tmp/.../config.toml --provider openrouter --model openai/gpt-4o-mini --api-key-env OPENROUTER_API_KEY --minimal --skip-channels --skip-search --skip-image-generation --skip-migration`
- `uv run --extra dev opensquilla onboard status --config /tmp/.../config.toml --json`
- `uv build --wheel`

Local full-suite note:

- `TMPDIR=/dev/shm uv run --extra dev --extra recommended pytest -q` was interrupted after 230 passed / 17 skipped because it entered the repository-level Docker packaging test and stayed in `docker build -t opensquilla-test:meta-runs-persistence .` for several minutes without completing.
- The isolated Docker packaging test also stayed in local `docker build` for 5m19s and was interrupted. Remote CI runs the full matrix in its normal environment.

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
- [x] User-facing feature pages explain when to use the feature, how to start, and where to troubleshoot next.
