### PR TITLE
Keep pasted secret cleanup symmetric

### DIFF
--- a/src/opensquilla/secrets.py
+++ b/src/opensquilla/secrets.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-_TRAILING_PASTE_PUNCTUATION = "、，。；;：:,. \t\r\n"
+_PASTE_BOUNDARY_CHARACTERS = "、，。；;：:,. \t\r\n"
 
 
 def clean_header_secret(value: str | None, *, label: str = "API key") -> str:
     """Return a secret safe to place in an HTTP header value.
 
     API keys are often pasted from chat or docs. On Windows terminals it is easy
-    to carry a trailing full-width punctuation mark into the password prompt;
+    to carry a boundary full-width punctuation mark into the password prompt;
     strip those boundary characters while rejecting non-ASCII text that remains.
     """
 
-    cleaned = str(value or "").strip().rstrip(_TRAILING_PASTE_PUNCTUATION)
+    cleaned = str(value or "").strip(_PASTE_BOUNDARY_CHARACTERS)
     try:
         cleaned.encode("ascii")
     except UnicodeEncodeError as exc:

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -9,6 +9,11 @@ def test_clean_header_secret_strips_trailing_paste_punctuation() -> None:
     assert clean_header_secret(" sk-test、\n", label="API key") == "sk-test"
 
 
+def test_clean_header_secret_strips_leading_paste_punctuation() -> None:
+    assert clean_header_secret("：sk-test", label="API key") == "sk-test"
+    assert clean_header_secret("、sk-test", label="API key") == "sk-test"
+
+
 def test_clean_header_secret_rejects_non_ascii_inside_value() -> None:
     with pytest.raises(ValueError, match="non-ASCII"):
         clean_header_secret("sk-测-test", label="API key")


### PR DESCRIPTION
## Summary

Fixes #73.

This hotfix makes API-key boundary cleanup symmetric: copied full-width punctuation is now stripped from either side of a pasted secret, while non-ASCII characters inside the secret remain rejected.

## Root cause

`clean_header_secret()` first stripped ordinary whitespace and then called `rstrip(...)` for known paste punctuation. That handled trailing artifacts such as `sk-test、`, but left leading artifacts such as `：sk-test` in place, so the existing ASCII guard reported a misleading non-ASCII error.

## Validation

- `PYTHONPATH=src /home/weihe/work/code/rhythm/opensquilla/.venv/bin/pytest tests/test_secrets.py -q`
- `/home/weihe/work/code/rhythm/opensquilla/.venv/bin/ruff check src/opensquilla/secrets.py tests/test_secrets.py`
