### PR TITLE
Polish WebUI: chat refinement, Model Router, brand identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ tests/functional/reports/
 # Generated local outputs from document/meta-skill smoke runs.
 /texput.log
 /src/opensquilla/skills/bundled/multi-search-engine/Tokyo_5日出差行程.docx
+.design-state/
+audit/

--- a/src/opensquilla/gateway/static/css/base.css
+++ b/src/opensquilla/gateway/static/css/base.css
@@ -419,6 +419,45 @@ pre {
   }
 }
 
+/* Sidebar brand footer — small identity anchor at the bottom of the rail.
+   margin-top: auto pushes it to the bottom whether the nav list is long or
+   short; the small accent dot doubles as a discreet liveness cue so the
+   brand reads alive without competing with the nav-active accent rail. */
+.nav-foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: auto;
+  padding: var(--sp-3) var(--sp-4) calc(var(--sp-3) + env(safe-area-inset-bottom, 0px));
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+  border-top: 1px solid var(--border);
+  background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--accent) 4%, transparent) 100%);
+  user-select: none;
+}
+.nav-foot__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 50%, transparent);
+  flex-shrink: 0;
+  animation: nav-foot-pulse 2.4s ease-in-out infinite;
+}
+.nav-foot__ver {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+}
+@keyframes nav-foot-pulse {
+  0%, 100% { box-shadow: 0 0 4px color-mix(in srgb, var(--accent) 35%, transparent); }
+  50%      { box-shadow: 0 0 10px color-mix(in srgb, var(--accent) 65%, transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-foot__dot { animation: none; }
+}
+
 /* Approval count badge */
 .nav-badge {
   margin-left: auto;

--- a/src/opensquilla/gateway/static/css/components.css
+++ b/src/opensquilla/gateway/static/css/components.css
@@ -221,21 +221,41 @@
   height: 6px;
   border-radius: 50%;
   background: currentColor;
+  box-shadow: 0 0 0 2px color-mix(in srgb, currentColor 22%, transparent);
 }
 .conn-pill.ok {
   color: var(--ok);
   border-color: color-mix(in srgb, var(--ok) 35%, var(--border));
   background: color-mix(in srgb, var(--ok) 10%, var(--bg-elevated));
 }
+/* Heartbeat halo on connected — barely there, just enough to read "alive".  */
+.conn-pill.ok::before {
+  animation: conn-pill-heartbeat 2.4s ease-in-out infinite;
+}
+@keyframes conn-pill-heartbeat {
+  0%, 100% { box-shadow: 0 0 0 2px color-mix(in srgb, currentColor 22%, transparent); }
+  50%      { box-shadow: 0 0 0 5px color-mix(in srgb, currentColor 6%, transparent); }
+}
 .conn-pill.warn {
   color: var(--warn);
   border-color: color-mix(in srgb, var(--warn) 35%, var(--border));
   background: color-mix(in srgb, var(--warn) 10%, var(--bg-elevated));
 }
+/* Reconnecting (warn) pulses faster — signals "actively trying". */
+.conn-pill.warn::before {
+  animation: conn-pill-reconnect 0.9s ease-in-out infinite;
+}
+@keyframes conn-pill-reconnect {
+  0%, 100% { transform: scale(1);   opacity: 1; }
+  50%      { transform: scale(1.4); opacity: 0.55; }
+}
 .conn-pill.err {
   color: var(--danger);
   border-color: color-mix(in srgb, var(--danger) 35%, var(--border));
   background: color-mix(in srgb, var(--danger) 10%, var(--bg-elevated));
+}
+@media (prefers-reduced-motion: reduce) {
+  .conn-pill::before { animation: none !important; }
 }
 
 /* Tier badge — compact monospaced t0/t1/t2/t3 indicator for router decisions. */

--- a/src/opensquilla/gateway/static/css/views/chat.css
+++ b/src/opensquilla/gateway/static/css/views/chat.css
@@ -48,19 +48,58 @@
   flex-shrink: 0;
 }
 
+/* Chat run-status pill — leading dot picks up the chip color via currentColor
+   so each lifecycle state (idle/queued/running/failed/interrupted) reads at
+   a glance without relying on text alone. Running/queued get a soft pulse. */
 #chat-run-status {
   display: inline-flex;
   align-items: center;
+  gap: 6px;
   min-height: 28px;
-  padding-inline: 10px;
+  padding-inline: 10px 12px;
   line-height: 1;
   white-space: nowrap;
   flex-shrink: 0;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 10.5px;
+}
+#chat-run-status::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.75;
+  box-shadow: 0 0 0 2px color-mix(in srgb, currentColor 25%, transparent);
+  flex-shrink: 0;
+}
+#chat-run-status.chip-ok::before,
+#chat-run-status.chip-running::before,
+#chat-run-status.chip-warn::before,
+#chat-run-status.chip-queued::before {
+  animation: chat-status-pulse 1.6s ease-in-out infinite;
+}
+@keyframes chat-status-pulse {
+  0%, 100% { box-shadow: 0 0 0 2px color-mix(in srgb, currentColor 25%, transparent); }
+  50%      { box-shadow: 0 0 0 5px color-mix(in srgb, currentColor 6%, transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  #chat-run-status::before { animation: none !important; }
 }
 
+/* Chat header label — promoted to the same small-caps mono treatment used
+   by every other page's "CONTROL · PAGENAME" breadcrumb, so the chat
+   surface reads as part of the same design language even without the
+   full breadcrumb + bold view-title row above the conversation. */
 .chat-label {
-  font-size: var(--fs-sm);
-  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-dim);
   flex-shrink: 0;
 }
 
@@ -342,11 +381,75 @@
   background: rgba(255, 92, 92, 0.04);
 }
 
+/* Empty state — quiet but structured. The signal-bar mark uses three
+   accent bars climbing left-to-right (loose CRT/loading-bar reference);
+   title is light-weight so the composer below stays the primary CTA. */
 .chat-empty {
-  color: var(--text-dim);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--sp-3);
+  color: var(--text-muted);
   text-align: center;
-  padding: var(--sp-8) 0;
+  padding: clamp(var(--sp-6), 8vh, var(--sp-8) * 2) var(--sp-4);
   font-size: var(--fs-sm);
+  margin: auto;
+  max-width: 520px;
+}
+.chat-empty__mark {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 5px;
+  height: 28px;
+  margin-bottom: var(--sp-2);
+}
+.chat-empty__bar {
+  display: block;
+  width: 6px;
+  background: color-mix(in srgb, var(--accent) 75%, transparent);
+  border-radius: 1px;
+  box-shadow: 0 0 8px color-mix(in srgb, var(--accent) 35%, transparent);
+  animation: chat-empty-bar 1.8s cubic-bezier(.6,.05,.4,1) infinite;
+}
+.chat-empty__bar:nth-child(1) { height: 30%; animation-delay: 0s; }
+.chat-empty__bar:nth-child(2) { height: 65%; animation-delay: 0.15s; }
+.chat-empty__bar:nth-child(3) { height: 100%; animation-delay: 0.30s; }
+@keyframes chat-empty-bar {
+  0%, 100% { transform: scaleY(0.55); opacity: 0.45; }
+  50%      { transform: scaleY(1);    opacity: 1; }
+}
+.chat-empty__bar { transform-origin: 50% 100%; }
+.chat-empty__title {
+  font-family: var(--font-display, var(--font-sans));
+  font-size: var(--fs-lg);
+  font-weight: 700;
+  letter-spacing: var(--track-display);
+  color: var(--text);
+  margin: 0;
+}
+.chat-empty__hint {
+  font-size: var(--fs-xs);
+  line-height: 1.6;
+  color: var(--text-dim);
+  margin: 0;
+  max-width: 38em;
+}
+.chat-empty__hint kbd {
+  display: inline-block;
+  padding: 1px 6px;
+  margin: 0 2px;
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  line-height: 1.2;
+  vertical-align: 1px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-empty__bar { animation: none; transform: scaleY(0.7); opacity: 0.7; }
 }
 
 /* ─── Day separator ────────────────────────────────────────────────────── */
@@ -357,9 +460,10 @@
   gap: var(--sp-3);
   color: var(--text-dim);
   font-size: var(--fs-xs);
-  letter-spacing: 0.04em;
+  font-weight: 600;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  margin: var(--sp-2) 0;
+  margin: var(--sp-4) 0 var(--sp-3);
   user-select: none;
 }
 .chat-day-sep::before,
@@ -444,7 +548,10 @@
   font-size: var(--fs-sm);
   line-height: 1.6;
   word-break: break-word;
-  max-width: 70%;
+  /* Reading-column cap: on ultra-wide screens 70% becomes ~1000px which
+     reads as a banner, not a message. The 56ch ceiling holds the bubble
+     to a comfortable line length without changing mobile (where 70% wins). */
+  max-width: min(70%, 56ch);
   min-width: 56px;
   min-height: 32px;
   margin-left: auto;
@@ -465,7 +572,10 @@
   font-size: var(--fs-sm);
   line-height: 1.7;
   word-break: break-word;
-  max-width: 85%;
+  /* Reading-column cap (see user bubble); assistant bubbles get a bit more
+     room — 72ch — to fit longer prose, code, and lists without wrapping
+     awkwardly while still preventing edge-to-edge sprawl on wide screens. */
+  max-width: min(85%, 72ch);
   min-width: 56px;
   min-height: 32px;
 }
@@ -560,19 +670,28 @@
   position: relative;
 }
 
+/* Streaming caret — thin terminal-style block bar in mantis orange.
+   Replaces the U+25CD "broken circle" glyph that didn't read as a cursor
+   at typographic size. The bar is a CSS box so it inherits theme accent
+   on the fly instead of relying on font fallback. */
 .chat-msg--streaming .chat-msg-text::after,
 .msg.streaming .msg-body:not(:has(.msg-text-seg:not(:empty)))::after,
 .msg.streaming .msg-text-seg:not(:empty):last-of-type::after {
-  content: '\25CD';
+  content: '';
   display: inline-block;
-  color: var(--accent);
-  animation: blink 1.2s ease-in-out infinite;
-  margin-left: 2px;
+  width: 0.5em;
+  height: 1em;
+  vertical-align: -0.14em;
+  background: var(--accent);
+  border-radius: 1px;
+  margin-left: 3px;
+  animation: blink 1.0s steps(2, end) infinite;
+  box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 55%, transparent);
 }
 
 @keyframes blink {
-  0%, 100% { opacity: 1; }
-  50%      { opacity: 0.2; }
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0.15; }
 }
 
 /* Interrupted-turn marker. Appended to the .msg-body when a streaming
@@ -660,7 +779,7 @@
   gap: 4px 8px;
   font-size: var(--fs-xs);
   color: var(--text-muted);
-  opacity: 0.75;
+  opacity: 0.85;
   padding: 0 2px;
   user-select: none;
   /* Cap the row width to the bubble so long model names break cleanly
@@ -723,9 +842,17 @@
   color: var(--text-muted);
 }
 
+/* Headings inside assistant responses: tinted toward the accent but mostly
+   text-colored so long answers with many h2/h3 don't read as a citrus
+   warning bar. h2 keeps a thin accent underline to retain a visual anchor. */
 .msg.assistant .msg-body h2,
 .msg.assistant .msg-body h3 {
-  color: var(--accent);
+  color: color-mix(in srgb, var(--accent) 35%, var(--text));
+  font-weight: 700;
+}
+.msg.assistant .msg-body h2 {
+  padding-bottom: 0.18em;
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 32%, transparent);
 }
 
 /* ─── Thinking / Typing indicator ──────────────────────────────────────── */
@@ -1804,6 +1931,12 @@
     padding-inline: 4px;
   }
 
+  /* Sub-360 widths drop the new-chat (+) button so the composer rail
+     can breathe — paperclip + run-modes + textarea + send is enough on
+     tiny phones; new chat stays reachable via session chip popover. */
+  #chat-btn-new { display: none !important; }
+  .chat-input-bar { gap: 3px; }
+
   .chat-header-right {
     margin-left: 0;
   }
@@ -1992,6 +2125,11 @@
 
 .chat-textarea:focus {
   border-color: var(--accent);
+  /* Match the 3px accent ring used by base.css inputs so the composer focus
+     state is consistent with the rest of the WebUI. Layer over the existing
+     drop shadow so the textarea keeps its lift off the input bar. */
+  box-shadow: var(--shadow-md),
+              0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 .chat-textarea::placeholder {
@@ -2006,28 +2144,32 @@
 }
 
 @media (max-width: 480px) {
+  /* Single-row composer on phones: paperclip · run-modes · + · textarea · send.
+     The textarea shrinks aggressively (flex:1 1 0; min-width:0) so all controls
+     stay reachable in one row without wrapping. New-chat (+) keeps its order=2
+     between settings and the input — only hidden on the tiniest screens. */
   .chat-input-bar {
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: center;
-    row-gap: 6px;
+    gap: 4px;
   }
 
-  #chat-btn-attach,
-  .chat-toolbar-wrap,
-  #chat-btn-new {
-    order: 0;
-  }
+  #chat-btn-attach { order: 0; }
+  .chat-toolbar-wrap { order: 1; }
+  #chat-btn-new { order: 2; }
 
   .chat-input-wrap {
-    order: 1;
-    flex: 1 1 calc(100% - 44px);
+    order: 3;
+    flex: 1 1 0;
+    min-width: 0;
   }
 
   #chat-btn-send,
   #chat-btn-stop {
-    order: 2;
+    order: 4;
   }
 }
+
 
 /* Stop button pulse animation during streaming */
 #chat-btn-send.danger {
@@ -2197,7 +2339,7 @@
   cursor: default;
   user-select: none;
   /* Lift past the parent's opacity so the savings figure reads */
-  opacity: calc(1 / 0.75);
+  opacity: calc(1 / 0.85);
   transition: border-color 200ms ease, background 200ms ease, color 200ms ease;
 }
 [data-theme="dark"] .msg-meta__saved {
@@ -2289,9 +2431,10 @@
   white-space: nowrap;
   cursor: default;
   user-select: none;
-  /* The parent .msg-meta uses opacity:0.75; lift the combo back to full
-     so the celebration reads against the muted model/tokens text. */
-  opacity: calc(1 / 0.75);
+  /* The parent .msg-meta is dimmed (see .msg-meta opacity); lift the combo
+     back to full so the celebration reads against the muted model/tokens
+     text. The reciprocal is computed from the parent value above. */
+  opacity: calc(1 / 0.85);
   animation: msg-combo-in 320ms cubic-bezier(0.34, 1.56, 0.64, 1);
   transition: border-color 200ms ease, background 200ms ease, color 200ms ease, box-shadow 200ms ease;
 }
@@ -2366,8 +2509,8 @@
 
 @keyframes msg-combo-in {
   0%   { opacity: 0;              transform: scale(0.6); }
-  60%  { opacity: calc(1 / 0.75); transform: scale(1.15); }
-  100% { opacity: calc(1 / 0.75); transform: scale(1); }
+  60%  { opacity: calc(1 / 0.85); transform: scale(1.15); }
+  100% { opacity: calc(1 / 0.85); transform: scale(1); }
 }
 
 @keyframes msg-combo-flicker {
@@ -2431,7 +2574,9 @@
   user-select: none;
   align-self: center;
   width: 100%;
-  max-width: 560px;
+  /* Wider envelope so the 5-col grid keeps cells readable without
+     forcing model names to ellipsis at common breakpoints. */
+  max-width: 680px;
 }
 
 .router-fx-header {
@@ -2466,8 +2611,14 @@
   0%, 100% { transform: translateX(0); }
   50%      { transform: translateX(3px); }
 }
+/* Settled header — keeps a faint accent tint so the strip reads "dial
+   locked on a tier" rather than "abandoned." Glyph arrows go translucent
+   accent so the "← MODEL ROUTER →" line continues to point at the pick. */
 .router-fx[data-state="settled"] .router-fx-header {
-  color: var(--text-dim);
+  color: color-mix(in srgb, var(--accent) 38%, var(--text-dim));
+}
+.router-fx[data-state="settled"] .router-fx-header .glyph {
+  color: color-mix(in srgb, var(--accent) 70%, transparent);
 }
 
 /* The grid surface — circuit-board hairlines with a faint dot field
@@ -2476,7 +2627,9 @@
 .router-fx-grid {
   position: relative;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  /* 5 × 3 cells. JS pulls from _ROUTER_FX_GRID_COLS / _ROUTER_FX_GRID_ROWS;
+     keep these in sync with that constant when changing dimensions. */
+  grid-template-columns: repeat(5, 1fr);
   grid-template-rows: repeat(3, 30px);
   gap: 4px;
   padding: 8px;
@@ -2514,7 +2667,8 @@
 /* Real (operator-configured) cells: brighter type only — the accent
  * dot in the top-right corner is the sole "this is on the dial"
  * marker; the cell border stays neutral hairline so the grid reads
- * as one field, not as two segregated zones. */
+ * as one field, not as two segregated zones. The dot breathes slowly
+ * so the dial reads alive while idle. */
 .router-fx-cell[data-kind="real"] {
   color: var(--text);
 }
@@ -2528,6 +2682,15 @@
   border-radius: 50%;
   background: var(--accent);
   opacity: 0.7;
+  box-shadow: 0 0 4px color-mix(in srgb, var(--accent) 45%, transparent);
+  animation: router-fx-dot-idle 3.2s ease-in-out infinite;
+}
+@keyframes router-fx-dot-idle {
+  0%, 100% { opacity: 0.55; box-shadow: 0 0 2px color-mix(in srgb, var(--accent) 25%, transparent); }
+  50%      { opacity: 0.95; box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 60%, transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .router-fx-cell[data-kind="real"]::after { animation: none; }
 }
 
 /* Decoy cells: dim, italic, no dot — clearly "not on the dial" but
@@ -2553,29 +2716,89 @@
   animation-duration: 170ms;
 }
 
-/* Winner: solid orange border, accent text, gentle lift. */
+/* Winner: solid orange border, accent text, with a soft outer halo +
+ * inner top-edge highlight + a one-shot scan-line that sweeps top-to-
+ * bottom on landing. Reads as the locked pick, not just "selected".
+ * The dot in the corner accelerates its pulse to confirm the lock. */
 .router-fx-cell.win {
   color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 9%, var(--bg));
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--accent) 14%, var(--bg)) 0%,
+      color-mix(in srgb, var(--accent) 7%, var(--bg)) 100%);
   border-color: var(--accent);
-  font-weight: 600;
+  font-weight: 700;
   font-style: normal;
-  transform: translateY(-1px);
-  box-shadow: 0 1px 0 color-mix(in srgb, var(--accent) 35%, transparent);
+  transform: translateY(-2px);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent),
+    0 8px 22px -8px color-mix(in srgb, var(--accent) 55%, transparent),
+    inset 0 1px 0 color-mix(in srgb, var(--accent) 40%, transparent);
+  z-index: 4;
 }
 .router-fx-cell.win::after {
   opacity: 1;
+  box-shadow: 0 0 8px color-mix(in srgb, var(--accent) 75%, transparent);
+  animation: router-fx-dot-locked 1.4s ease-in-out infinite;
+}
+/* Scan-line sweep — fires once when .win lands. Sits above the cell
+   surface but below text via z-index management. Pointer-events stay
+   off so it never interferes with click/copy on the model name. */
+.router-fx-cell.win::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 1px;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--accent) 90%, transparent) 50%,
+    transparent 100%);
+  pointer-events: none;
+  opacity: 0;
+  animation: router-fx-scan 720ms cubic-bezier(.4,0,.2,1) 1 forwards;
+  z-index: 1;
+}
+@keyframes router-fx-scan {
+  0%   { opacity: 0;    top: 0;    }
+  20%  { opacity: 1;    top: 10%;  }
+  80%  { opacity: 0.85; top: 90%;  }
+  100% { opacity: 0;    top: 100%; }
+}
+@keyframes router-fx-dot-locked {
+  0%, 100% { opacity: 0.9; box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 50%, transparent); }
+  50%      { opacity: 1;   box-shadow: 0 0 10px color-mix(in srgb, var(--accent) 85%, transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .router-fx-cell.win::before { animation: none; opacity: 0; }
+  .router-fx-cell.win::after { animation: none; }
 }
 
-/* Fallback variant — chosen tier was the safe net, not the routed pick. */
+/* Fallback variant — chosen tier was the safe net, not the routed pick.
+   Mirrors the locked-winner treatment but in the danger palette so the
+   shape is the same and the colour change carries the signal. */
 .router-fx[data-source="fallback"] .router-fx-cell.win {
   color: var(--danger);
   border-color: var(--danger);
-  background: color-mix(in srgb, var(--danger) 9%, var(--bg));
-  box-shadow: 0 1px 0 color-mix(in srgb, var(--danger) 35%, transparent);
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--danger) 14%, var(--bg)) 0%,
+      color-mix(in srgb, var(--danger) 7%, var(--bg)) 100%);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--danger) 35%, transparent),
+    0 8px 22px -8px color-mix(in srgb, var(--danger) 55%, transparent),
+    inset 0 1px 0 color-mix(in srgb, var(--danger) 40%, transparent);
 }
 .router-fx[data-source="fallback"] .router-fx-cell.win::after {
   background: var(--danger);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--danger) 75%, transparent);
+}
+.router-fx[data-source="fallback"] .router-fx-cell.win::before {
+  background: linear-gradient(90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--danger) 90%, transparent) 50%,
+    transparent 100%);
 }
 
 /* Hammer selector — absolutely positioned, JS sets transform per hop.
@@ -2701,12 +2924,14 @@
   }
 }
 
-/* Mobile: collapse to 3 columns x 4 rows + smaller type. The hammer
- * still hops; the grid just gets denser. */
+/* Mobile: collapse to 3 columns × 5 rows + smaller type. The hammer
+ * still hops; the grid just gets denser. JS still renders 15 cells —
+ * keep the cell count divisible across the active grid template so no
+ * row ends short. */
 @media (max-width: 640px) {
   .router-fx-grid {
     grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: repeat(4, 28px);
+    grid-template-rows: repeat(5, 28px);
     padding: 6px;
     gap: 3px;
   }
@@ -2715,8 +2940,8 @@
 }
 @media (max-width: 380px) {
   .router-fx-grid {
-    grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(6, 26px);
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(5, 26px);
   }
-  .router-fx-cell { font-size: 9.5px; }
+  .router-fx-cell { font-size: 9.5px; padding: 0 4px; }
 }

--- a/src/opensquilla/gateway/static/js/app.js
+++ b/src/opensquilla/gateway/static/js/app.js
@@ -50,6 +50,17 @@ const App = (() => {
   function _buildLayout() {
     const app = document.getElementById('app');
     const basePath = _basePath();
+    // Strip the build-suffix from the cache-buster version ("0.1.0+1779915602")
+    // so the footer shows a stable semver. Whitelist to safe semver chars
+    // before interpolating — defense in depth against a tampered data attr.
+    // When the version attribute is absent or filtered to empty (no usable
+    // characters), the brand-foot block is suppressed entirely so "v" alone
+    // doesn't render as a broken-looking stub.
+    const rawVersion = document.getElementById('opensquilla-data')?.dataset.version || '';
+    const semver = (rawVersion.split('+')[0] || '').replace(/[^0-9A-Za-z.\-]/g, '').slice(0, 32);
+    const navFootHTML = semver
+      ? `<div class="nav-foot"><span class="nav-foot__dot" aria-hidden="true"></span><span class="nav-foot__ver">v${semver}</span></div>`
+      : '';
     app.innerHTML = `
       <nav class="sidebar" id="sidebar-nav" aria-label="Primary">
         <div class="nav-brand"><img class="brand-mark" src="${basePath}/static/img/opensquilla-mark.png" alt="" aria-hidden="true"> OpenSquilla</div>
@@ -68,6 +79,7 @@ const App = (() => {
         <a class="nav-item" href="#" data-path="/config">${icons.config()} Config</a>
         <a class="nav-item" href="#" data-path="/logs">${icons.logs()} Logs</a>
         <a class="nav-item" href="#" data-path="/approvals">${icons.approvals()} Approvals <span class="nav-badge hidden" id="approval-count">0</span></a>
+        ${navFootHTML}
       </nav>
       <div class="main">
         <header class="topbar">

--- a/src/opensquilla/gateway/static/js/views/chat.js
+++ b/src/opensquilla/gateway/static/js/views/chat.js
@@ -439,10 +439,30 @@ const ChatView = (() => {
 
   /* ── Welcome / empty-state card ──────────────────────────────────────── */
 
-  // Empty state — a single muted line, no interactive elements. The textarea
-  // below is the entry point; the empty thread shouldn't compete with it.
+  // Empty state — structured but quiet: a small signal-bar mark + a one-line
+  // title + a hint row of keyboard shortcuts. The textarea below remains the
+  // primary entry point, so this card uses subdued contrast and no actions.
+  // Outer `.chat-empty` class is preserved because chat.js elsewhere selects
+  // and removes it when the first message arrives.
   function _emptyStateHTML() {
-    return '<div class="chat-empty">No messages yet.</div>';
+    // Title is a styled <p>, not <h2>, so it stays out of the page's heading
+    // outline — the chat surface has no <h1> and other views reserve <h2> for
+    // content sections; using <h2> here would imply a structural section that
+    // isn't there. .chat-empty stays as the outer class so existing
+    // remove-on-first-message selectors still find this node.
+    return ''
+      + '<div class="chat-empty" role="status">'
+      +   '<div class="chat-empty__mark" aria-hidden="true">'
+      +     '<span class="chat-empty__bar"></span>'
+      +     '<span class="chat-empty__bar"></span>'
+      +     '<span class="chat-empty__bar"></span>'
+      +   '</div>'
+      +   '<p class="chat-empty__title">Start a conversation</p>'
+      +   '<p class="chat-empty__hint">Type below, or paste an image or file. '
+      +     '<kbd>↑</kbd> recalls history · <kbd>Esc</kbd> aborts a running turn · '
+      +     '<kbd>/</kbd> opens slash commands.'
+      +   '</p>'
+      + '</div>';
   }
 
   /* ── Per-bubble hover action row (Copy / Regenerate / Edit) ───────── */
@@ -2570,7 +2590,11 @@ const ChatView = (() => {
    * burst. The strip is non-blocking — assistant text streams below
    * the grid while the chase plays above. */
 
-  const _ROUTER_FX_GRID_COLS = 4;
+  // 5 cols × 3 rows = 15 cells. The wider grid gives the hammer more
+  // hops to play and shows the model space as a proper "dial" rather
+  // than a tight 4-cell strip. Mobile breakpoints collapse this down
+  // (see chat.css @media rules).
+  const _ROUTER_FX_GRID_COLS = 5;
   const _ROUTER_FX_GRID_ROWS = 3;
   const _ROUTER_FX_GRID_CELLS = _ROUTER_FX_GRID_COLS * _ROUTER_FX_GRID_ROWS;
 
@@ -2789,7 +2813,7 @@ const ChatView = (() => {
     return arr;
   }
 
-  // Assemble the 12-cell grid: real (deduped) entries + decoys
+  // Assemble the grid (_ROUTER_FX_GRID_CELLS cells): real (deduped) entries + decoys
   // filtered to avoid collisions with real model names, then shuffled
   // with a SEEDED RNG so the same turn always produces the same
   // layout across re-renders (live → DoneEvent → history-sync, plus

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 CHAT_JS = Path("src/opensquilla/gateway/static/js/views/chat.js")
 CHAT_CSS = Path("src/opensquilla/gateway/static/css/views/chat.css")
+APP_JS = Path("src/opensquilla/gateway/static/js/app.js")
+BASE_CSS = Path("src/opensquilla/gateway/static/css/base.css")
 RPC_JS = Path("src/opensquilla/gateway/static/js/rpc.js")
 SAVINGS_FX_JS = Path("src/opensquilla/gateway/static/js/components/savings-fx.js")
 TASK_RUNTIME_PY = Path("src/opensquilla/gateway/task_runtime.py")
@@ -284,7 +286,16 @@ def test_chat_tiny_phone_header_gives_session_key_full_row() -> None:
     assert "padding-inline: 4px" in chip_rule
 
 
-def test_chat_mobile_composer_gives_message_input_a_full_row() -> None:
+def test_chat_mobile_composer_inlines_controls_on_a_single_row() -> None:
+    """Mobile composer keeps every control on a single inline row.
+
+    The earlier wrap-to-second-row layout pushed icon buttons above the
+    textarea, leaving dead horizontal space and breaking the messaging-app
+    convention of [controls] [textarea] [send]. The phone composer now
+    runs nowrap; the textarea shrinks (flex: 1 1 0; min-width: 0) so the
+    paperclip, run-modes, and new-chat buttons stay reachable inline,
+    with the send button at the far right.
+    """
     css = CHAT_CSS.read_text(encoding="utf-8")
     base_wrap_start = css.index(".chat-input-wrap {")
     mobile_start = css.index("@media (max-width: 480px)", base_wrap_start)
@@ -296,12 +307,16 @@ def test_chat_mobile_composer_gives_message_input_a_full_row() -> None:
     send_start = mobile_block.index("#chat-btn-send,")
     send_rule = mobile_block[send_start : mobile_block.index("}", send_start)]
 
-    assert "#chat-btn-new { display: none" not in css
     assert mobile_start > base_wrap_start
-    assert "flex-wrap: wrap" in input_rule
-    assert "row-gap: 6px" in input_rule
-    assert "flex: 1 1 calc(100% - 44px)" in wrap_rule
-    assert "order: 2" in send_rule
+    assert "flex-wrap: nowrap" in input_rule
+    assert "flex: 1 1 0" in wrap_rule
+    assert "min-width: 0" in wrap_rule
+    assert "order: 4" in send_rule
+    # Sub-360 widths drop the new-chat (+) button so the composer rail
+    # can breathe; assert the breakpoint is in place but not above 360.
+    tiny_start = css.index("@media (max-width: 360px)")
+    tiny_block = css[tiny_start:]
+    assert "#chat-btn-new { display: none" in tiny_block
 
 
 def test_chat_desktop_session_controls_keep_polished_hit_areas() -> None:
@@ -891,7 +906,12 @@ def test_router_fx_history_and_turn_meta_preserve_observe_rollout_state() -> Non
     assert "rollout_phase: u.rollout_phase || 'full'," in store_body
 
 
-def test_router_fx_mobile_grid_keeps_twelve_explicit_cells() -> None:
+def test_router_fx_mobile_grid_matches_explicit_cell_count() -> None:
+    """Mobile router-fx grid rows×cols stays in lockstep with the JS cell count.
+
+    The JS constant ``_ROUTER_FX_GRID_CELLS`` is 15 (5 cols × 3 rows on desktop);
+    mobile and tiny breakpoints collapse to 3×5 so no row ends short.
+    """
     css = CHAT_CSS.read_text(encoding="utf-8")
     mobile_start = css.index("@media (max-width: 640px)")
     tiny_start = css.index("@media (max-width: 380px)")
@@ -899,9 +919,9 @@ def test_router_fx_mobile_grid_keeps_twelve_explicit_cells() -> None:
     tiny_body = css[tiny_start:]
 
     assert "grid-template-columns: repeat(3, 1fr);" in mobile_body
-    assert "grid-template-rows: repeat(4, 28px);" in mobile_body
-    assert "grid-template-columns: repeat(2, 1fr);" in tiny_body
-    assert "grid-template-rows: repeat(6, 26px);" in tiny_body
+    assert "grid-template-rows: repeat(5, 28px);" in mobile_body
+    assert "grid-template-columns: repeat(3, 1fr);" in tiny_body
+    assert "grid-template-rows: repeat(5, 26px);" in tiny_body
 
 
 def test_chat_history_replays_turn_meta_to_restore_combo_streak() -> None:
@@ -1368,3 +1388,105 @@ def test_chat_queue_drain_preserves_draft_typed_during_stream() -> None:
     assert "_pendingAttachments = draftAttachments;" in body
     assert "_pendingSessionIntent = draftIntent;" in body
     assert body.index("_onSend();") < body.index("_textarea.value = draftText;")
+
+
+# ─── Design refinement contracts (chat-refine-v2 branch) ──────────────────
+
+
+def test_chat_empty_state_carries_signal_mark_title_and_kbd_hints() -> None:
+    """The chat empty state is the user's first impression of the conversation
+    surface. It must keep the three-bar signal mark, the styled-paragraph
+    title (NOT an <h2> — see _emptyStateHTML comment for the outline reason),
+    and the three keyboard-shortcut <kbd> chips, in that order, so the row
+    stays a structured welcome and not a bare placeholder line.
+    """
+    source = CHAT_JS.read_text(encoding="utf-8")
+    css = CHAT_CSS.read_text(encoding="utf-8")
+    fn_start = source.index("function _emptyStateHTML()")
+    fn_end = source.index("\n  }", fn_start)
+    body = source[fn_start:fn_end]
+
+    # Structural markers in JS — title is <p>, not <h2>, to keep the chat
+    # surface out of the page heading outline (no <h1> exists upstream).
+    assert 'class="chat-empty" role="status"' in body
+    assert 'class="chat-empty__mark"' in body
+    assert body.count('class="chat-empty__bar"') == 3
+    assert '<p class="chat-empty__title">Start a conversation</p>' in body
+    assert '<h2 class="chat-empty__title"' not in body, (
+        "Empty-state title must be a styled <p>, not <h2>, to keep chat out "
+        "of the page heading outline."
+    )
+    assert "chat-empty__hint" in body
+    # Three kbd chips, in order: history, abort, slash.
+    kbd_block = body[body.index('class="chat-empty__hint"'):]
+    assert kbd_block.index("<kbd>↑</kbd>") < kbd_block.index("<kbd>Esc</kbd>")
+    assert kbd_block.index("<kbd>Esc</kbd>") < kbd_block.index("<kbd>/</kbd>")
+
+    # Matching CSS contract — class names referenced from JS must have rules.
+    assert ".chat-empty__mark" in css
+    assert ".chat-empty__bar" in css
+    assert ".chat-empty__title" in css
+    assert ".chat-empty__hint" in css
+    assert ".chat-empty__hint kbd" in css
+
+
+def test_sidebar_renders_brand_foot_only_when_version_is_present() -> None:
+    """The sidebar brand foot anchors product identity at the bottom of the
+    rail. The block is only emitted when the cache-buster ``data-version``
+    parses to a non-empty semver — otherwise ``v`` alone would render as a
+    broken-looking stub. The matching CSS rules must exist in base.css.
+    """
+    app = APP_JS.read_text(encoding="utf-8")
+    base = BASE_CSS.read_text(encoding="utf-8")
+
+    # Build-suffix stripping + whitelist sanitization.
+    assert "rawVersion.split('+')[0]" in app
+    assert "replace(/[^0-9A-Za-z.\\-]/g, '')" in app
+    assert ".slice(0, 32)" in app  # length cap
+
+    # Conditional emission — empty semver suppresses the whole block.
+    assert "navFootHTML = semver" in app
+    assert "? `<div class=\"nav-foot\">" in app
+    assert ': \'\'' in app  # else branch returns empty string
+
+    # CSS contract — class names referenced from JS must have rules.
+    assert ".nav-foot {" in base
+    assert ".nav-foot__dot" in base
+    assert ".nav-foot__ver" in base
+    # Footer sits at the bottom of a flex-column sidebar.
+    foot_block = base[base.index(".nav-foot {") : base.index("}", base.index(".nav-foot {"))]
+    assert "margin-top: auto" in foot_block
+    # Pulse animation is gated behind prefers-reduced-motion.
+    dot_start = base.index(".nav-foot__dot")
+    reduced_start = base.index("@media (prefers-reduced-motion: reduce)", dot_start)
+    reduced_block = base[reduced_start : reduced_start + 240]
+    assert ".nav-foot__dot { animation: none" in reduced_block
+
+
+def test_app_displayed_version_strips_build_suffix_and_unsafe_chars() -> None:
+    """Defensive contract on the version string the brand foot renders.
+
+    Three guarantees:
+    1. Cache-buster build-suffix ("0.1.0+1779915602") is split off so users
+       see a stable semver, not a unix timestamp.
+    2. Characters outside ``[0-9A-Za-z.\\-]`` are stripped before any
+       template interpolation — defense in depth against a tampered
+       ``data-version`` attribute.
+    3. Output is capped at 32 characters so a tampered attribute can't
+       blow out the sidebar layout.
+    """
+    source = APP_JS.read_text(encoding="utf-8")
+    fn_start = source.index("function _buildLayout()")
+    fn_end = source.index("\n  }", fn_start)
+    body = source[fn_start:fn_end]
+
+    # The three contracts above must all live inside _buildLayout so they
+    # cannot drift apart through partial edits.
+    assert "rawVersion.split('+')[0]" in body
+    assert "[^0-9A-Za-z.\\-]" in body
+    assert ".slice(0, 32)" in body
+
+    # And the interpolation site uses the sanitized variable, not the raw
+    # data attribute.
+    assert "${semver}" in body
+    assert "${rawVersion}" not in body


### PR DESCRIPTION
## Summary

Frontend-only design pass on the OpenSquilla WebUI. Chat surface is the primary target, with cross-cutting consistency fixes on shared chrome (sidebar, topbar, connection pill). No backend or core-logic changes; gateway behaviour and wire contracts are untouched.

**Chat conversation**
- Reading-column cap on message bubbles (`min(70%, 56ch)` user / `min(85%, 72ch)` assistant) so wide screens stop sprawling.
- Streaming caret rewritten — CSS-drawn terminal block bar in `--accent` replaces the U+25CD glyph that didn't read as a cursor at body size.
- Composer focus ring now matches `base.css` inputs (3px accent-mix layered over the existing drop shadow).
- Day separator gains breathing room and tabular tracking; per-turn meta footer lifts 0.75 → 0.85 opacity with matching saved/combo chip reciprocals.
- Assistant `h2`/`h3` softened from pure accent to a 35% accent/text mix — long answers no longer read as a citrus warning bar.

**Chat header + status**
- Run-status pill promoted to `● IDLE`-style stateful capsule with leading dot via `currentColor`, 2px halo, and 1.6s pulse on ok/warn. Matches the dot+pill language used by Overview's CONNECTED badge.
- "Chat session" label lifted into the breadcrumb voice (small-caps mono, 0.18em tracking).

**Chat empty state**
- Replaced the bare "No messages yet." line with a structured welcome: three-bar animated signal mark, styled title (`<p>`, not `<h2>`, to keep the surface out of the page heading outline), and a kbd-shortcut row (↑ Esc /).

**Model Router (router-fx)**
- Grid expanded from 4 × 3 (12 cells) to 5 × 3 (15 cells); envelope widens to 680px. Mobile collapses to 3 × 5.
- Winner cell rebuilt to read as *locked*: soft halo, inner top highlight, accent gradient, +2px lift, font-weight 700, plus a one-shot 720ms scan-line sweep on landing.
- Real-cell corner dots breathe at idle (3.2s); winner's dot accelerates to a 1.4s locked pulse.
- Settled header keeps a faint accent tint; fallback variant mirrors the new winner treatment in the danger palette.

**Mobile chat composer**
- Phone composer (≤480px) now inlines all controls on a single row via `flex-wrap: nowrap`; textarea shrinks (`flex: 1 1 0; min-width: 0`) so paperclip, run-modes, and new-chat stay reachable with send pinned far-right. Sub-360px hides the new-chat button.

**Shared chrome**
- Sidebar brand foot — pulsing accent dot + stripped semver (cache-buster suffix split, whitelist-sanitized, length-capped). Suppressed entirely when version is empty.
- Topbar CONNECTED pill wears a 2.4s heartbeat halo; reconnecting (warn) pulses faster at 0.9s; err stays static.

All animations gate behind `prefers-reduced-motion`.

## Files
- `src/opensquilla/gateway/static/css/{base,components,views/chat}.css`
- `src/opensquilla/gateway/static/js/{app.js,views/chat.js}`
- `tests/test_gateway/test_chat_view_static.py`

7 files changed, +509 / -66.

## Test plan
- [x] `pytest tests/test_gateway/test_chat_view_static.py test_chat_static_assets.py test_webui_typography_static.py` → 130/130 passing
- [x] Full static suite (`tests/test_gateway -k static`) → 362/362 passing (excluding 3 pre-existing failures in `test_rpc_cron_current_session.py` unrelated to this change)
- [x] `node --check` on both touched JS files
- [x] Visual verification at 1440×900, 768×1024, 375×812 in both light and dark themes via Playwright + an isolated gateway on port 18799 (separate state dir, default 18791 untouched)
- [x] Live verification of the Model Router 5×3 grid + winner animation against a real LLM call (assistant streamed `2+2 = 4 🦞` with `Saved ~97%` chip)
- [x] Reduced-motion path verified for: chat-empty bars, streaming caret, run-status pill, conn-pill heartbeat, nav-foot dot, router-fx scan-line, locked-dot pulse, idle-dot pulse, real-cell dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)