### PR TITLE
Preserve gateway URL query and fragment

### DIFF
--- a/src/opensquilla/cli/url_utils.py
+++ b/src/opensquilla/cli/url_utils.py
@@ -27,6 +27,9 @@ def normalize_gateway_url(url: str) -> str:
         scheme = "ws"
         netloc = parsed.netloc
         path = parsed.path
+    params = parsed.params
+    query = parsed.query
+    fragment = parsed.fragment
 
     if scheme not in {"http", "https", "ws", "wss"}:
         raise ValueError(f"Unsupported gateway URL scheme: {scheme!r}")
@@ -34,4 +37,4 @@ def normalize_gateway_url(url: str) -> str:
     websocket_scheme = "wss" if scheme in {"https", "wss"} else "ws"
     websocket_path = "/ws" if path in ("", "/") else path
 
-    return urlunparse((websocket_scheme, netloc, websocket_path, "", "", ""))
+    return urlunparse((websocket_scheme, netloc, websocket_path, params, query, fragment))

--- a/src/opensquilla/gateway_client.py
+++ b/src/opensquilla/gateway_client.py
@@ -45,13 +45,16 @@ def normalize_gateway_url(url: str) -> str:
         scheme = "ws"
         netloc = parsed.netloc
         path = parsed.path
+    params = parsed.params
+    query = parsed.query
+    fragment = parsed.fragment
 
     if scheme not in {"http", "https", "ws", "wss"}:
         raise ValueError(f"Unsupported gateway URL scheme: {scheme!r}")
 
     websocket_scheme = "wss" if scheme in {"https", "wss"} else "ws"
     websocket_path = "/ws" if path in ("", "/") else path
-    return urlunparse((websocket_scheme, netloc, websocket_path, "", "", ""))
+    return urlunparse((websocket_scheme, netloc, websocket_path, params, query, fragment))
 
 
 class GatewayRPCClient:

--- a/tests/test_cli/test_url_utils.py
+++ b/tests/test_cli/test_url_utils.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from opensquilla.cli.url_utils import normalize_gateway_url
+
+
+def test_normalize_gateway_url_preserves_query_and_fragment() -> None:
+    assert (
+        normalize_gateway_url("https://gateway.example.com/ws?token=abc#trace")
+        == "wss://gateway.example.com/ws?token=abc#trace"
+    )
+
+
+def test_normalize_gateway_url_adds_ws_path_without_dropping_query() -> None:
+    assert normalize_gateway_url("gateway.example.com?token=abc") == "ws://gateway.example.com/ws?token=abc"

--- a/tests/test_mcp_server/test_gateway_client.py
+++ b/tests/test_mcp_server/test_gateway_client.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from opensquilla.gateway_client import GatewayRPCClient
+from opensquilla.gateway_client import GatewayRPCClient, normalize_gateway_url
 
 
 class _SilentWebSocket:
@@ -19,6 +19,17 @@ class _SilentWebSocket:
 
     async def close(self) -> None:
         self.closed = True
+
+
+def test_normalize_gateway_url_preserves_query_and_fragment() -> None:
+    assert (
+        normalize_gateway_url("https://gateway.example.com/ws?token=abc#trace")
+        == "wss://gateway.example.com/ws?token=abc#trace"
+    )
+
+
+def test_normalize_gateway_url_adds_ws_path_without_dropping_query() -> None:
+    assert normalize_gateway_url("gateway.example.com?token=abc") == "ws://gateway.example.com/ws?token=abc"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- preserve gateway URL params, query strings, and fragments when normalizing to websocket URLs
- keep CLI and runtime gateway URL normalization aligned
- add regression coverage for tokenized URLs and bare-host URLs with query strings

Fixes #69.

## Validation
- env PYTHONPATH=src TMPDIR=/dev/shm PYTHONDONTWRITEBYTECODE=1 /home/weihe/work/code/rhythm/opensquilla/.venv/bin/python -m pytest tests/test_mcp_server/test_gateway_client.py tests/test_cli/test_url_utils.py -q
- env PYTHONPATH=src TMPDIR=/dev/shm PYTHONDONTWRITEBYTECODE=1 /home/weihe/work/code/rhythm/opensquilla/.venv/bin/ruff check src/opensquilla/gateway_client.py src/opensquilla/cli/url_utils.py tests/test_mcp_server/test_gateway_client.py tests/test_cli/test_url_utils.py
- git diff --check