### PR TITLE
Improve English lifestyle meta-skill outputs

### DIFF
--- a/src/opensquilla/engine/tool_text_compat.py
+++ b/src/opensquilla/engine/tool_text_compat.py
@@ -15,16 +15,23 @@ _PLAIN_JSON_TOOL_PREFIX_RE = re.compile(
 _TEXT_PROTOCOL_MARKER_RE = re.compile(
     (
         r"<\s*(?:minimax:tool_call|tool_calls?|tvoe_calls|invoke\b|"
-        r"parameter\b|effect_calls\b|details\b|angle\s+brackets\b)"
+        r"parameter\b|effect_calls\b|details\b|angle\s+brackets\b|"
+        r"[|｜]\s*DSML\s*[|｜]\s*(?:tool_calls?|invoke\b|parameter\b))"
     ),
     re.IGNORECASE,
 )
 _TEXT_PROTOCOL_PARAMETER_RE = re.compile(
-    r"<\s*parameter\s+name\s*=\s*[\"'](?:path|content|command|code|patch)[\"']",
+    (
+        r"<\s*(?:parameter|[|｜]\s*DSML\s*[|｜]\s*parameter)\s+"
+        r"name\s*=\s*[\"'](?:path|content|command|code|patch|sheets)[\"']"
+    ),
     re.IGNORECASE,
 )
 _TEXT_PROTOCOL_INVOKE_RE = re.compile(
-    r"<\s*invoke\s+name\s*=\s*[\"'][A-Za-z_][A-Za-z0-9_.:-]*[\"']",
+    (
+        r"<\s*(?:invoke|[|｜]\s*DSML\s*[|｜]\s*invoke)\s+"
+        r"name\s*=\s*[\"'][A-Za-z_][A-Za-z0-9_.:-]*[\"']"
+    ),
     re.IGNORECASE,
 )
 _TEXT_PROTOCOL_HTML_RE = re.compile(
@@ -32,11 +39,17 @@ _TEXT_PROTOCOL_HTML_RE = re.compile(
     re.IGNORECASE,
 )
 _TEXT_PROTOCOL_CLOSE_RE = re.compile(
-    r"</\s*invoke\s*>|</\s*(?:tool_calls?|tvoe_calls)\s*>",
+    (
+        r"</\s*(?:invoke|[|｜]\s*DSML\s*[|｜]\s*invoke)\s*>|"
+        r"</\s*(?:tool_calls?|tvoe_calls|[|｜]\s*DSML\s*[|｜]\s*tool_calls?)\s*>"
+    ),
     re.IGNORECASE,
 )
 _TEXT_PROTOCOL_STANDALONE_MARKER_RE = re.compile(
-    r"<\s*(?:parameter|effect_calls|tool_calls?|tvoe_calls|angle\s+brackets)\s*>",
+    (
+        r"<\s*(?:parameter|effect_calls|tool_calls?|tvoe_calls|angle\s+brackets|"
+        r"[|｜]\s*DSML\s*[|｜]\s*(?:tool_calls?|invoke|parameter))\b"
+    ),
     re.IGNORECASE,
 )
 _TEXT_PROTOCOL_DETAILS_SUMMARY_RE = re.compile(
@@ -48,6 +61,14 @@ _TEXT_PROTOCOL_PREFIXES = (
     "<tool_call",
     "<tool_calls",
     "<tvoe_calls",
+    "<|dsml|tool_call",
+    "<|dsml|tool_calls",
+    "<|dsml|invoke",
+    "<|dsml|parameter",
+    "<｜dsml｜tool_call",
+    "<｜dsml｜tool_calls",
+    "<｜dsml｜invoke",
+    "<｜dsml｜parameter",
     "<invoke",
     "<parameter",
     "<effect_calls",

--- a/src/opensquilla/skills/bundled/meta-document-to-decision/SKILL.md
+++ b/src/opensquilla/skills/bundled/meta-document-to-decision/SKILL.md
@@ -7,6 +7,15 @@ always: false
 final_text_mode: "step:decision_brief_audit"
 triggers:
   - "document decision"
+  - "vendor renewal"
+  - "renewal materials"
+  - "contract excerpt"
+  - "sales email"
+  - "whether to sign"
+  - "decide tomorrow whether to sign"
+  - "sign, reject, or negotiate"
+  - "evidence table"
+  - "questions for the vendor"
   - "看下这个文件"
   - "帮我判断这个文档"
   - "合同风险"
@@ -239,6 +248,11 @@ composition:
           payment due date. Do not cite statutes or legal article numbers unless
           they appear in the provided materials. Prefer practical negotiation
           language over categorical legal conclusions.
+          Preserve the user's language. If the original request is in English,
+          write the final brief in English with English section headings only;
+          do not default to Chinese or bilingual headings. If the original
+          request is in Chinese, write Simplified Chinese and do not default to
+          English headings.
 
           Risk review:
           {{ outputs.risk_review | truncate(7000) }}
@@ -280,13 +294,24 @@ composition:
           - Preserve the user's requested structure: recommendation, evidence
             table, high/medium/low risks, supplier questions, next 24 hours,
             and professional-review caveat.
-          - Use these exact section titles so the brief is easy to scan:
+          - Preserve the original request language. For an English request,
+            return an English-only brief with English headings; remove Chinese
+            headings such as 底线推荐, 证据表, 高中低风险, 要问供应商的问题, 接下来
+            24 小时, and 专业复核提醒 unless they are quoted source text. For a
+            Chinese request, return Simplified Chinese and do not switch to
+            English section headings.
+          - Use these exact section titles for Chinese or bilingual requests
+            so the brief is easy to scan:
             "Bottom-line recommendation / 底线推荐",
             "Evidence table / 证据表",
             "Risks ranked high/medium/low / 高中低风险",
             "Questions to ask the supplier / 要问供应商的问题",
             "What to do next in 24 hours / 接下来 24 小时",
             and "Professional-review caveat / 专业复核提醒".
+            For English-only requests, use the English portion of each heading
+            only: Bottom-line recommendation, Evidence table, Risks ranked
+            high/medium/low, Questions to ask the supplier, What to do next in
+            24 hours, Professional-review caveat.
           - Preserve date status accurately: payment due 2026-06-03 is an
             upcoming payment deadline, not overdue. Do not infer any
             cancellation deadline from that payment due date.

--- a/src/opensquilla/skills/bundled/meta-job-search-pipeline/SKILL.md
+++ b/src/opensquilla/skills/bundled/meta-job-search-pipeline/SKILL.md
@@ -4,7 +4,7 @@ description: "Use this meta-skill instead of answering directly when a job seeke
 kind: meta
 meta_priority: 65
 always: false
-final_text_mode: "step:deliver_jobpack"
+final_text_mode: "step:deliver_jobpack_audit"
 triggers:
   - "tailor my resume"
   - "改简历"
@@ -606,17 +606,59 @@ composition:
 
           End with a single line:
           PACK_MODE: {{ outputs.mode }}
+    - id: deliver_jobpack_audit
+      kind: llm_chat
+      depends_on: [deliver_jobpack, source_fact_ledger, mode, preferences]
+      with:
+        system: "You are the final quality gate for a job-search deliverable. Return only the cleaned final answer that the user should read. Do not explain the audit. Do not mention workflow, meta-skill, tool names, connector failures, workspace paths, or runtime details."
+        task: |
+          Rewrite the draft below into the final user-facing application pack.
+          Preserve useful content, but enforce the source fact ledger strictly.
+
+          Mode label:
+          {{ outputs.mode }}
+
+          Preferences:
+          {{ outputs.get('preferences', '') | truncate(500) }}
+
+          Strict source fact ledger:
+          {{ outputs.get('source_fact_ledger', '') | truncate(3000) }}
+
+          Draft deliverable:
+          {{ outputs.get('deliver_jobpack', '') | truncate(9000) }}
+
+          Hard requirements:
+          - Return markdown only. Never return JSON, a {"text": ...} wrapper,
+            artifact metadata, file paths, download links, or attachment notes.
+          - Remove leading process commentary such as "perfect for the
+            meta-skill pipeline", "running it now", "I will run", "workflow",
+            or any similar explanation of how the answer was produced.
+          - Preserve the user's language. If the request is English, write
+            English-only prose and English headings. If the request is Chinese,
+            write Simplified Chinese and keep the Chinese structure.
+          - For TAILOR_NEW, include resume rewrite points, paste-ready resume
+            content, a cover letter or outreach email, JD requirement /
+            evidence / gap table, 48-hour interview prep, and a no-fabrication
+            note.
+          - Audit every concrete claim against the strict source fact ledger.
+            Remove or mark as [to fill] / [待补充] any company fact, tool,
+            ownership claim, metric, method, or outcome not present in the
+            user's request.
+          - Do not upgrade participation into ownership. Keep "participated in
+            an AI customer-service pilot, not the owner" when that is the
+            available fact.
+          - Remove internal sentinels such as PACK_MODE.
     - id: store_pack
       kind: agent
       skill: memory
-      depends_on: [deliver_jobpack, mode, job_clarify]
+      depends_on: [deliver_jobpack_audit, mode, job_clarify]
     - id: export_docx
       kind: skill_exec
       skill: docx
-      depends_on: [deliver_jobpack, job_clarify]
+      depends_on: [deliver_jobpack_audit, job_clarify]
       when: "(inputs.get('collected', {}).get('job_clarify', {}).get('export_docx', 'NO') == 'YES') or ('EXPORT_DOCX_REQUESTED: yes' in outputs.get('preferences', ''))"
       with:
-        markdown: "{{ outputs.deliver_jobpack }}"
+        markdown: "{{ outputs.deliver_jobpack_audit }}"
         output_path: "/tmp/jobpack_{{ inputs.get('collected', {}).get('job_clarify', {}).get('target_company', 'untitled') | slugify }}.docx"
 ---
 

--- a/src/opensquilla/skills/bundled/meta-kid-project-planner/SKILL.md
+++ b/src/opensquilla/skills/bundled/meta-kid-project-planner/SKILL.md
@@ -243,13 +243,17 @@ composition:
           {{ inputs.user_message | xml_escape | truncate(2000) }}
     - id: project_fact_ledger
       kind: llm_chat
-      depends_on: [preferences, project_clarify, weather_check]
+      depends_on: [preferences, project_clarify, recall_past_projects, weather_check]
       when: "outputs.feasibility != 'INAPPROPRIATE' and 'PROJECT_SAFE: yes' in outputs.preferences"
       with:
-        system: "You extract a strict source-fact ledger for a child project plan. You do not write the plan. You separate user-provided facts from unknowns and unsafe or unsupported inferences."
+        system: "You extract a strict source-fact ledger for a child project plan. You do not write the plan. You separate user-provided facts, durable memory facts, unknowns, and unsafe or unsupported inferences."
         task: |
           Build a strict project fact ledger from the user's request and any
-          clarification payload.
+          clarification payload. Durable memory is also a source of facts when
+          the memory output clearly states child profile, prior projects,
+          preferences, or parent availability. Ignore memory status prose,
+          file inventory, workspace paths, and runtime/tool wording; extract
+          only the actual remembered facts.
 
           User request:
           {{ inputs.user_message | xml_escape | truncate(3500) }}
@@ -257,13 +261,18 @@ composition:
           Clarification:
           {{ inputs.get('collected', {}).get('project_clarify', {}) | tojson | truncate(1200) }}
 
+          Durable memory / past-project recall:
+          {{ outputs.get('recall_past_projects', '') | truncate(1800) }}
+
           Weather result or fallback:
           {{ outputs.get('weather_check', '') | truncate(800) }}
 
           Return exactly:
           OUTPUT_LANGUAGE: <zh|en|mixed>
           PROVIDED_CHILD_CONTEXT:
-            - <age, ability, guardian availability, or UNKNOWN>
+            - <age, ability, child preferences, guardian availability, or UNKNOWN>
+          PROVIDED_MEMORY_CONTEXT:
+            - <remembered child profile, prior projects, parent constraints, lessons learned, or none>
           PROVIDED_PROJECT_CONTEXT:
             - <topic, school deadline/time window, school output, or UNKNOWN>
           PROVIDED_MATERIALS_BUDGET:
@@ -280,6 +289,13 @@ composition:
               school rule, allergy, fake measurements, tasting/eating>
 
           Rules:
+          - If durable memory says the child is a specific age, likes/dislikes
+            an activity style, has prior projects, or has parent time limits,
+            put those in PROVIDED_CHILD_CONTEXT and PROVIDED_MEMORY_CONTEXT.
+            Do not mark them UNKNOWN.
+          - If the current request asks not to repeat previous projects, list
+            remembered prior projects in PROVIDED_MEMORY_CONTEXT so downstream
+            steps can avoid them explicitly.
           - If the source says only "two weeks later", mark exact date UNKNOWN.
           - If the source says only "half-day sun", mark orientation and hours
             UNKNOWN. Preserve "half-day sun" exactly.
@@ -474,7 +490,7 @@ composition:
         - project_fact_ledger
         - project_clarify
       with:
-        system: "You assemble the final project pack the user will read. Return the complete deliverable inline in chat. Do not create, save, export, attach, or point primarily to an artifact unless the user explicitly asked for a file export. Never mention workflow, meta-skill, tool names, connector failures, workspace paths, or runtime details."
+        system: "You assemble the final project pack the user will read. Return the complete deliverable inline in chat. Do not create, save, export, attach, or point primarily to an artifact unless the user explicitly asked for a file export with words like PDF, file, export, attachment, or download. Treat requests for a printable worksheet, printable record sheet, or poster layout as print-ready markdown included inline. Never mention workflow, meta-skill, tool names, connector failures, workspace paths, or runtime details."
         task: |
           Assemble the final project pack.
 
@@ -494,9 +510,16 @@ composition:
           Project fact ledger:
           {{ outputs.get('project_fact_ledger', '') | truncate(2500) }}
 
+          Durable memory / past-project recall:
+          {{ outputs.get('recall_past_projects', '') | truncate(1600) }}
+
           Source-constraint audit:
           - Treat the Project fact ledger as the source of truth. If an
             intermediate step conflicts with it, ignore the intermediate step.
+          - Treat PROVIDED_MEMORY_CONTEXT in the fact ledger as user-relevant
+            durable context. Preserve remembered age, child preferences, parent
+            time limits, prior projects, and lessons learned unless the current
+            request explicitly contradicts them.
           - If the fact ledger marks a detail UNKNOWN, leave it unknown or mark
             it as an assumption; do not fill it with common sense or current
             date/time.
@@ -535,6 +558,19 @@ composition:
             changed variable such as light exposure. If materials allow, use
             2-3 labelled groups; if not, make the single-group observation
             plan still presentation-ready.
+          - "Printable" means a clean markdown table, worksheet block, or
+            poster-board layout that the user can print from chat. Do not
+            create or refer to PDFs, HTML files, downloads, attachments,
+            local paths, generated artifacts, or workspace files unless the
+            user explicitly asked for a file/PDF/export/download.
+          - If the user asks for a beautiful or visually polished plan, make
+            the inline markdown itself polished: a memorable title, a concise
+            visual theme, color/palette suggestions, kid-facing labels,
+            a drawing-heavy record sheet, and a parent-ready poster layout.
+          - If the user asks to start with remembered constraints, include a
+            section titled exactly "## Remembered constraints I used" near the
+            top and list only facts found in PROVIDED_MEMORY_CONTEXT or the
+            current request. Do not invent memory.
 
           Language and length:
           - Match the user's language. For Chinese requests, write Simplified
@@ -594,28 +630,79 @@ composition:
           without asking the user to confirm before using the current answer.
 
           For English safe projects, use equivalent English headings:
-          assumptions, project design, schedule, materials/substitutes,
-          safety/failure modes, Record and chart, Weather / light adjustment,
-          Final presentation, adult 20-minute check, and missing live info.
+          remembered constraints used when requested, known facts and
+          assumptions, project design, 14-day schedule,
+          materials/substitutes, safety/failure modes, printable record
+          sheet, poster-board layout, simple science explanation,
+          Weather / light adjustment, adult 20-minute check, and missing live
+          info. If the user asked for a visually polished plan, include a
+          short "visual theme" subsection.
 
           End with a single line:
           PACK_DELIVERED: {{ outputs.feasibility }}
     - id: project_pack_audit
       kind: llm_chat
-      depends_on: [deliver_project_pack, project_fact_ledger, feasibility, preferences]
+      depends_on:
+        - deliver_project_pack
+        - project_fact_ledger
+        - recall_past_projects
+        - outline_steps
+        - material_list
+        - safety_notes
+        - learning_objectives
+        - weather_check
+        - feasibility
+        - preferences
       with:
         system: "You are the final quality gate for a child project plan. Return only the cleaned final answer that the user should read. Do not explain the audit. Do not mention workflow, meta-skill, tool names, connector failures, workspace paths, or runtime details."
         task: |
           Rewrite the draft below into the final user-facing project pack.
-          Preserve useful content, but enforce the fact ledger strictly.
+          Preserve useful content, but enforce the fact ledger strictly. If
+          the draft is only JSON, artifact metadata, download references,
+          process commentary, or otherwise not a complete user-facing answer,
+          rebuild the final project pack from the fact ledger and intermediate
+          source sections below.
 
           Project fact ledger:
           {{ outputs.get('project_fact_ledger', '') | truncate(2500) }}
+
+          Durable memory / past-project recall:
+          {{ outputs.get('recall_past_projects', '') | truncate(1600) }}
+
+          Step plan source:
+          {{ outputs.get('outline_steps', '') | truncate(2600) }}
+
+          Materials source:
+          {{ outputs.get('material_list', '') | truncate(1600) }}
+
+          Safety source:
+          {{ outputs.get('safety_notes', '') | truncate(1600) }}
+
+          Learning source:
+          {{ outputs.get('learning_objectives', '') | truncate(1600) }}
+
+          Weather/light source:
+          {{ outputs.get('weather_check', '') | truncate(900) }}
 
           Draft project pack:
           {{ outputs.get('deliver_project_pack', '') | truncate(8000) }}
 
           Required audit rules:
+          - Return markdown only. Never return JSON, artifact metadata, file
+            paths, download links, or attachment notes.
+          - If the draft contains JSON keys such as "text", "artifacts",
+            "artifact_ref", "download_url", "mime", "sha256", "session_id",
+            "created_at", or "store", discard those metadata fields and write
+            a normal markdown answer instead.
+          - Remove leading process commentary such as "perfect match", "let me
+            run it", "I will run", "workflow", "meta-skill", or any similar
+            explanation of how the answer was produced. The first non-empty
+            line must be the user-facing project title, unless the user
+            explicitly requested a different first heading such as
+            "Remembered constraints I used".
+          - Preserve the user's language. If the request is English, write
+            English-only prose and English headings. If the request is Chinese,
+            write Simplified Chinese throughout.
           - Remove exact calendar dates, weekdays, months, or current-year references
             unless the user explicitly provided those exact dates. If the user
             gave only a relative deadline, use Day 1...Day 14 and say exact
@@ -632,8 +719,30 @@ composition:
           - Keep every explicit user constraint from the fact ledger: child age,
             relative deadline, location, available materials, budget, parent
             time, light constraint, and requested sections.
+          - Keep every clear durable-memory constraint from the fact ledger:
+            remembered age, child preferences, writing tolerance, parent
+            availability, prior projects, and lessons learned. Do not rewrite
+            those fields as UNKNOWN when they appear in PROVIDED_MEMORY_CONTEXT.
+          - If the request asks not to repeat previous projects, explicitly
+            avoid or name the prior projects as non-options in one concise
+            sentence.
+          - If the user asks to use remembered facts, include a
+            "## Remembered constraints I used" section with the remembered
+            age, preferences, writing tolerance, parent time limit, prior
+            projects, and lessons learned when those facts appear in
+            PROVIDED_MEMORY_CONTEXT. Do not say no memory exists when
+            PROVIDED_MEMORY_CONTEXT contains facts.
           - Prefer a clear comparison design when it fits: same seed, cup,
             water, and paper-towel conditions, with only light exposure changed.
+          - Treat "printable record sheet" and "poster board layout" as inline
+            deliverables unless the user explicitly asked for PDF/file/export.
+            Include a clean markdown worksheet/table with blank boxes,
+            checkboxes, or placeholders; do not claim that a PDF, HTML file,
+            local file, download, or artifact was generated.
+          - For visually polished project packs, make the markdown itself
+            beautiful and school-ready: memorable title, visual theme or
+            palette, kid-facing labels, drawing-heavy worksheet, and a poster
+            layout the parent can recreate.
           - Keep the answer compact and immediately usable: target 2500-3600 Chinese characters
             for Chinese requests. Avoid long daily tables when grouped phases
             are clearer.
@@ -650,6 +759,21 @@ composition:
           ## 最后展示怎么讲
           ## 家长每晚 20 分钟
           ## 还缺哪些实时信息
+
+          For English requests, use equivalent English headings only:
+          # <Project title>
+          ## Remembered constraints I used
+          ## Known facts and assumptions
+          ## Project design
+          ## 14-day plan
+          ## Materials and substitutes
+          ## Safety and failure modes
+          ## Printable record sheet
+          ## Poster-board layout
+          ## Simple science explanation
+          ## Weather / light adjustment
+          ## Adult 20-minute check
+          ## Missing live information
 
           End with:
           PACK_DELIVERED: {{ outputs.feasibility }}

--- a/src/opensquilla/skills/bundled/meta-safe-skill-installer/SKILL.md
+++ b/src/opensquilla/skills/bundled/meta-safe-skill-installer/SKILL.md
@@ -305,8 +305,9 @@ composition:
         system: "You audit and repair the final installer-safety answer against the evidence ledger."
         task: |
           Rewrite the final answer only as needed so it is faithful to the
-          user's pasted installer evidence. Preserve the user's language where
-          practical.
+          user's pasted installer evidence. Preserve the user's language: for
+          English requests, write English-only prose and headings; for Chinese
+          requests, write Simplified Chinese prose and headings.
 
           Pasted evidence ledger:
           {{ outputs.pasted_evidence | truncate(4000) }}
@@ -339,6 +340,9 @@ composition:
           - Include practical safer alternatives for the user's actual goal,
             such as a local read-only daily-report script/template that does
             not read ~/.ssh, run postinstall hooks, or need broad shell access.
+          - Remove leading process commentary, JSON wrappers, artifact
+            metadata, workflow references, or any explanation of how the answer
+            was produced.
 ---
 
 # Safe Skill Installer

--- a/src/opensquilla/skills/bundled/meta-web-research-to-report/SKILL.md
+++ b/src/opensquilla/skills/bundled/meta-web-research-to-report/SKILL.md
@@ -8,6 +8,16 @@ final_text_mode: "step:final_report_audit"
 triggers:
   - "调研报告"
   - "research report"
+  - "decision memo"
+  - "decision memo with sources"
+  - "short decision memo"
+  - "key findings"
+  - "tradeoffs and risks"
+  - "travel esim"
+  - "carrier roaming"
+  - "local sim"
+  - "mobile data plan"
+  - "what i should order"
   - "写一份报告"
   - "write up the findings"
   - "source-backed writeup"
@@ -291,6 +301,7 @@ composition:
     - id: source_to_claim
       kind: llm_chat
       depends_on: [report_draft, source_quality]
+      when: "outputs.report_mode != 'QUICK_DECISION_MEMO'"
       with:
         system: "You audit report claims against source packs."
         task: |
@@ -312,6 +323,7 @@ composition:
     - id: quality_gate
       kind: llm_chat
       depends_on: [report_draft, source_quality, source_to_claim]
+      when: "outputs.report_mode != 'QUICK_DECISION_MEMO'"
       with:
         system: "You polish final reports and remove process commentary."
         task: |
@@ -358,19 +370,21 @@ composition:
           Source pack:
           {{ outputs.source_quality | truncate(5000) }}
 
-          Source-to-claim map:
-          {{ outputs.source_to_claim | truncate(4000) }}
+          Source-to-claim map (may be empty for quick decision memos):
+          {{ outputs.get('source_to_claim', '') | truncate(4000) }}
 
-          Polished report:
-          {{ outputs.quality_gate | truncate(10000) }}
+          Polished report or quick memo draft:
+          {{ (outputs.get('quality_gate') or outputs.get('report_draft') or '') | truncate(10000) }}
 
           Final output contract:
           - Never return JSON, artifact references, attachment metadata,
             download URLs, or a wrapper like {"text": ..., "artifacts": ...}.
           - Never mention workflow, meta-skill, tool names, connector failures,
             workspace paths, working directory problems, or runtime details.
-          - Never mention workflow, meta-skill, tool names, connector failures, workspace paths, or runtime details.
-          - Never mention workflow, meta-skill, tool names, connector failures, workspace paths, or runtime details.
+          - Preserve the user's language. If the request is in English, write
+            the memo/report in English with English section headings only; do
+            not default to Chinese or bilingual headings. If the request is in
+            Chinese, write Simplified Chinese and do not default to English.
           - Never say the memo was saved, exported, attached, generated as a
             file, or available via artifact unless the user explicitly asked
             for DOCX/file export and the export step ran.
@@ -400,8 +414,8 @@ composition:
             appears in the Source list.
           - Every non-obvious quantitative claim must be cited or explicitly
             marked as an assumption/inference. Remove invented cost, latency,
-            benchmark, or model-quality numbers that are not supported by the
-            source pack.
+            benchmark, plan-price, availability, or quality numbers that are
+            not supported by the source pack.
           - Key findings must cite only source IDs that appear in the Source
             list. When evidence is indirect, say "inference" or "not directly
             proven by the source pack" in the finding or limitations.
@@ -437,16 +451,21 @@ composition:
           {{ outputs.report_mode }}
 
           Source pack:
-          {{ outputs.source_quality | truncate(5000) }}
+          {{ outputs.source_quality | truncate(3000) }}
 
           Draft final:
-          {{ outputs.final_report | truncate(10000) }}
+          {{ outputs.final_report | truncate(7000) }}
 
           Hard requirements:
           - Return the complete final user-facing memo/report body inline in chat, not JSON.
           - If the draft contains artifact references, download URLs, file
             names, or a JSON wrapper, discard the wrapper and reconstruct the
             complete memo inline from the source pack and user request.
+          - Preserve the user's language. For English requests, return
+            English-only prose and English headings; remove Chinese headings
+            and bilingual labels unless they are quoted source text. For
+            Chinese requests, write Simplified Chinese and do not switch to
+            English headings.
           - Remove phrases such as "元技能", "meta-skill", "workflow",
             "工作流", "工作目录", "workspace", "connector", "tool failure",
             "手动做研究", "信息收集充分", and any runtime apology.

--- a/tests/test_core_lightweight_contracts.py
+++ b/tests/test_core_lightweight_contracts.py
@@ -73,6 +73,23 @@ def test_malformed_text_tool_protocol_is_removed_before_user_display() -> None:
     assert strip_protocol_text_leak(text) == "Let me write the dashboard now."
 
 
+def test_dsml_text_tool_protocol_is_removed_before_user_display() -> None:
+    text = (
+        "Let me create the printable daily record sheet as well:\n\n"
+        '<｜DSML｜tool_calls><｜DSML｜invoke name="create_xlsx">'
+        '<｜DSML｜parameter name="name" string="true">'
+        "bean-sprout-daily-record-sheet.xlsx"
+        "</｜DSML｜parameter>"
+        '<｜DSML｜parameter name="sheets" string="false">'
+        '[{"name":"Record Sheet","rows":[["Day","Height"]]}]'
+        "</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>"
+    )
+
+    assert strip_protocol_text_leak(text) == (
+        "Let me create the printable daily record sheet as well:"
+    )
+
+
 def test_tool_scaffold_details_summary_is_removed_before_user_display() -> None:
     text = (
         "Let me read the specific problematic areas to fix them.\n\n"
@@ -97,6 +114,20 @@ def test_streaming_protocol_guard_holds_split_tool_protocol() -> None:
         guard.push(
             '_calls><invoke name="write_file">'
             '<parameter name="content"><!DOCTYPE html><html></html>'
+        )
+        == ""
+    )
+    assert guard.flush() == ""
+
+
+def test_streaming_protocol_guard_holds_split_dsml_tool_protocol() -> None:
+    guard = ProtocolTextLeakGuard()
+
+    assert guard.push("Let me make the sheet.\n\n<｜DS") == "Let me make the sheet."
+    assert (
+        guard.push(
+            'ML｜tool_calls><｜DSML｜invoke name="create_xlsx">'
+            '<｜DSML｜parameter name="sheets">[]</｜DSML｜parameter>'
         )
         == ""
     )

--- a/tests/test_meta_skill_openclaw_lifestyle_comparison.py
+++ b/tests/test_meta_skill_openclaw_lifestyle_comparison.py
@@ -7,6 +7,7 @@ from opensquilla.skills.meta.parser import parse_meta_plan
 from opensquilla.skills.meta.templating import evaluate_when
 from scripts.compare_meta_skill_openclaw import EndpointResult, JudgeResult, OpenSquillaRunner
 from scripts.compare_meta_skill_openclaw_lifestyle import (
+    ENGLISH_LIFESTYLE_PROMPTS,
     LIFESTYLE_COMPARISON_CASES,
     OPENCLAW_T3_MODEL,
     _apply_lifestyle_judge_result,
@@ -220,7 +221,11 @@ def test_new_lifestyle_meta_skills_hide_runtime_failures_and_reply_inline(
                 "web_research": "web_research_fallback",
                 "weather_check": "weather_check_fallback",
             },
-            "required": ["Record and chart", "Weather / light adjustment", "Final presentation"],
+            "required": [
+                "printable record sheet",
+                "poster-board layout",
+                "Weather / light adjustment",
+            ],
         },
         "meta-web-research-to-report": {
             "final": "final_report_audit",
@@ -281,7 +286,13 @@ def test_job_search_pipeline_preserves_language_and_source_truth() -> None:
         "src/opensquilla/skills/bundled/meta-job-search-pipeline/SKILL.md"
     ).read_text(encoding="utf-8")
 
+    assert 'final_text_mode: "step:deliver_jobpack_audit"' in raw
+    assert "deliver_jobpack_audit" in raw
+    assert "Never return JSON" in raw
+    assert "Remove leading process commentary" in raw
+    assert "Remove internal sentinels such as PACK_MODE" in raw
     assert "Do not default Chinese user requests to English" in raw
+    assert "If the request is English, write\n            English-only prose and English headings" in raw
     assert "write Simplified Chinese, including headings" in raw
     assert "Do not add unprovided tools, methods, outcomes, or metrics" in raw
     assert "A/B testing, NPS, customer interviews, Jira" in raw
@@ -606,7 +617,21 @@ def test_safe_skill_installer_keeps_source_evidence_boundaries_upstream() -> Non
 
 def test_lifestyle_meta_skills_have_natural_language_activation_cues() -> None:
     expectations = {
-        "meta-document-to-decision": ["供应商续费", "要不要签"],
+        "meta-document-to-decision": [
+            "供应商续费",
+            "要不要签",
+            "vendor renewal",
+            "contract excerpt",
+            "decide tomorrow whether to sign",
+            "sign, reject, or negotiate",
+        ],
+        "meta-web-research-to-report": [
+            "decision memo",
+            "travel esim",
+            "carrier roaming",
+            "mobile data plan",
+            "what i should order",
+        ],
         "meta-daily-operator-brief": ["今天先帮我排一下", "前三优先级"],
         "meta-safe-skill-installer": ["这个插件能不能装", "curl -fsSL"],
         "meta-account-watch": ["盯一下这两个对手", "销售群里的简报", "和基线相比"],
@@ -618,6 +643,30 @@ def test_lifestyle_meta_skills_have_natural_language_activation_cues() -> None:
         )
         for cue in cues:
             assert cue in raw
+
+
+def test_english_lifestyle_prompts_trigger_target_meta_skills(tmp_path: Path) -> None:
+    from opensquilla.engine.steps.meta_resolution import _trigger_matches
+
+    target_cases = {
+        "document_vendor_decision": "meta-document-to-decision",
+        "web_research_parent_esim": "meta-web-research-to-report",
+    }
+    loader = SkillLoader(
+        bundled_dir=Path("src/opensquilla/skills/bundled"),
+        snapshot_path=tmp_path / "snapshot.json",
+    )
+
+    for case_id, skill_name in target_cases.items():
+        case = next(case for case in LIFESTYLE_COMPARISON_CASES if case.case_id == case_id)
+        english_prompt = ENGLISH_LIFESTYLE_PROMPTS[case_id].lower()
+        target = loader.get_by_name(skill_name)
+        assert target is not None
+        assert any(
+            _trigger_matches(trigger, english_prompt)
+            for trigger in (target.triggers or [])
+        ), f"{case_id} should trigger {skill_name}"
+        assert case.prompt
 
 
 def test_account_watch_outranks_daily_brief_for_competitor_followup_prompts(
@@ -733,12 +782,31 @@ def test_kid_project_planner_final_audits_original_user_constraints(
     audit_text = json.dumps(step_by_id["project_pack_audit"].with_args, ensure_ascii=False)
 
     assert "project_fact_ledger" in step_by_id
+    assert "recall_past_projects" in step_by_id["project_fact_ledger"].depends_on
     assert "project_fact_ledger" in step_by_id["deliver_project_pack"].depends_on
     assert "deliver_project_pack" in step_by_id["project_pack_audit"].depends_on
     assert "project_fact_ledger" in step_by_id["project_pack_audit"].depends_on
+    assert "recall_past_projects" in step_by_id["project_pack_audit"].depends_on
+    assert "outline_steps" in step_by_id["project_pack_audit"].depends_on
+    assert "material_list" in step_by_id["project_pack_audit"].depends_on
+    assert "safety_notes" in step_by_id["project_pack_audit"].depends_on
+    assert "learning_objectives" in step_by_id["project_pack_audit"].depends_on
     assert "{{ inputs.user_message" in final_text
     assert "Project fact ledger" in final_text
+    assert "Durable memory / past-project recall" in final_text
     assert "Project fact ledger" in audit_text
+    assert "PROVIDED_MEMORY_CONTEXT" in audit_text
+    assert "Do not rewrite" in audit_text
+    assert "fields as UNKNOWN" in audit_text
+    assert "intermediate" in audit_text
+    assert "source sections" in audit_text
+    assert "artifact_ref" in audit_text
+    assert "download_url" in audit_text
+    assert "discard those metadata fields" in audit_text
+    assert "printable record sheet" in audit_text
+    assert "poster board layout" in audit_text
+    assert "inline" in audit_text
+    assert "deliverables" in audit_text
     assert "Preserve every explicit user constraint" in final_text
     assert "age, deadline, location, available materials, budget" in final_text
     assert "parent time, light/weather constraints" in final_text
@@ -768,6 +836,28 @@ def test_kid_project_planner_final_avoids_fake_dates_weather_and_data(
     assert "Remove fake sample measurements" in audit_text
     assert "Remove invented balcony direction, temperature ranges, rain forecasts" in audit_text
     assert "2500-3600 Chinese characters" in audit_text
+    assert "Remove leading process commentary" in audit_text
+    assert "first non-empty" in audit_text
+    assert "user-facing project title" in audit_text
+    assert "English-only prose and English headings" in audit_text
+    assert "Return markdown only" in audit_text
+    assert "Never return JSON, artifact metadata" in audit_text
+
+
+def test_kid_project_planner_printable_defaults_to_inline_markdown() -> None:
+    raw = Path(
+        "src/opensquilla/skills/bundled/meta-kid-project-planner/SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Treat requests for a printable worksheet" in raw
+    assert "print-ready markdown included inline" in raw
+    assert "Printable\" means a clean markdown table" in raw
+    assert "Do not\n            create or refer to PDFs, HTML files, downloads" in raw
+    assert "unless the\n            user explicitly asked for a file/PDF/export/download" in raw
+    assert "memorable title" in raw
+    assert "visual theme" in raw
+    assert "drawing-heavy record sheet" in raw
+    assert "parent-ready poster layout" in raw
 
 
 def test_safe_skill_installer_avoids_unverified_external_lookup_claims() -> None:
@@ -785,6 +875,8 @@ def test_safe_skill_installer_avoids_unverified_external_lookup_claims() -> None
     assert "one-line threat model" in raw
     assert "immediate action plan" in raw
     assert "isolated audit recipe" in raw
+    assert "English-only prose and headings" in raw
+    assert "Remove leading process commentary" in raw
     assert "what evidence would change the verdict" in raw
     assert "short message the user can send back" in raw
     assert "credential/key rotation" in raw


### PR DESCRIPTION
## Summary

Replacement for #111 with a clean PR surface on top of the current integration/dev-rollup-20260528 baseline.

This keeps only the remaining English lifestyle meta-skill output improvements that were not already equivalent in the base branch:

- improves English activation/output behavior for lifestyle meta-skills
- strengthens final-answer cleanup against process notes, JSON wrappers, artifact metadata, and runtime details
- adds focused coverage for English lifestyle prompt routing and cleanup contracts

## Conflict handling

#111 was left conflicting because its branch still contained earlier meta-skill integration commits that are already equivalent in integration/dev-rollup-20260528. This replacement branch cherry-picks only the remaining commit onto the current base and resolves the single test import conflict.

## Verification

- git merge-tree --write-tree origin/integration/dev-rollup-20260528 HEAD
- timeout 300 env UV_CACHE_DIR=/tmp/uv-cache-pr111 PYTHONPATH=. uv run --with pytest-asyncio pytest tests/test_core_lightweight_contracts.py tests/test_meta_skill_openclaw_lifestyle_comparison.py
- Result: 63 passed
