### PR TITLE
Keep CLI help compatible with Typer parameter wrappers

### DIFF
--- a/src/opensquilla/ui.py
+++ b/src/opensquilla/ui.py
@@ -60,46 +60,62 @@ def _apply_typer_help_theme() -> None:
     rich_utils.STYLE_USAGE = ACCENT_SOFT
     rich_utils.STYLE_METAVAR = f"bold {ACCENT_SOFT}"
 
+    def _is_argument(param: object) -> bool:
+        return (
+            isinstance(param, click.Argument)
+            or getattr(param, "param_type_name", "") == "argument"
+        )
+
+    def _is_option(param: object) -> bool:
+        return isinstance(param, click.Option) or getattr(param, "param_type_name", "") == "option"
+
     def _make_metavar(param: click.Parameter) -> str:
-        if param.metavar:
-            return param.metavar
-        if isinstance(param, click.Argument) and param.name:
-            return param.name.upper()
-        return param.type.name.upper()
+        metavar = getattr(param, "metavar", None)
+        if metavar:
+            return str(metavar)
+        name = getattr(param, "name", None)
+        if _is_argument(param) and name:
+            return str(name).upper()
+        param_type = getattr(param, "type", None)
+        type_name = getattr(param_type, "name", "text")
+        return str(type_name).upper()
 
     def _parameter_label(param: click.Parameter, ctx: click.Context) -> Text:
-        if isinstance(param, click.Argument):
+        if _is_argument(param):
             metavar = _make_metavar(param)
             return Text(metavar, style=rich_utils.STYLE_METAVAR)
 
-        assert isinstance(param, click.Option)
-        opt_parts = [*param.opts]
-        if param.secondary_opts:
-            opt_parts.append("/".join(param.secondary_opts))
+        if not _is_option(param):
+            return Text(str(getattr(param, "name", "") or ""), style=rich_utils.STYLE_OPTION)
+        opt_parts = [*getattr(param, "opts", ())]
+        secondary_opts = getattr(param, "secondary_opts", ())
+        if secondary_opts:
+            opt_parts.append("/".join(secondary_opts))
         label = Text(", ".join(opt_parts), style=rich_utils.STYLE_OPTION)
 
         metavar = _make_metavar(param)
         if metavar != "BOOLEAN":
             label.append(" ")
             label.append(metavar, style=rich_utils.STYLE_METAVAR)
-        if param.required:
+        if getattr(param, "required", False):
             label.append(" ")
             label.append(rich_utils.REQUIRED_SHORT_STRING, style=rich_utils.STYLE_REQUIRED_SHORT)
         return label
 
     def _parameter_help(param: click.Parameter, ctx: click.Context) -> Text:
-        if isinstance(param, click.Option):
+        if _is_option(param):
             try:
                 help_record = param.get_help_record(ctx)
-            except TypeError:
-                help_text = param.help or ""
-                if param.show_default and param.default not in (None, "", False):
-                    help_text = f"{help_text}  [default: {param.default}]".strip()
+            except (AttributeError, TypeError):
+                help_text = str(getattr(param, "help", "") or "")
+                default = getattr(param, "default", None)
+                if getattr(param, "show_default", False) and default not in (None, "", False):
+                    help_text = f"{help_text}  [default: {default}]".strip()
                 return Text(help_text, style=rich_utils.STYLE_OPTION_HELP)
             else:
                 if help_record is not None:
                     return Text(help_record[1] or "", style=rich_utils.STYLE_OPTION_HELP)
-        return Text("")
+        return Text(str(getattr(param, "help", "") or ""), style=rich_utils.STYLE_OPTION_HELP)
 
     def _print_compact_options_panel(
         *,

--- a/tests/test_cli/test_help_theme.py
+++ b/tests/test_cli/test_help_theme.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import re
+from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 
 import click
+from rich.console import Console
 from typer import rich_utils
 from typer.testing import CliRunner
 
@@ -107,6 +110,42 @@ def test_help_theme_supports_click_make_metavar_without_context(monkeypatch) -> 
     output = click.unstyle(result.output)
     assert "--provider TEXT" in output
     assert "--router MODE" in output
+
+
+def test_help_theme_accepts_typer_vendored_click_parameters() -> None:
+    option = SimpleNamespace(
+        param_type_name="option",
+        name="provider",
+        opts=["--provider"],
+        secondary_opts=[],
+        metavar=None,
+        type=SimpleNamespace(name="text"),
+        required=False,
+        help="Provider id to configure.",
+    )
+    argument = SimpleNamespace(
+        param_type_name="argument",
+        name="section_arg",
+        opts=["section_arg"],
+        secondary_opts=[],
+        metavar="SECTION",
+        type=SimpleNamespace(name="text"),
+        required=False,
+        help="Section to configure.",
+    )
+    console = Console(file=StringIO(), force_terminal=False, color_system=None)
+
+    rich_utils._print_options_panel(
+        name="Options",
+        params=[option, argument],
+        ctx=click.Context(click.Command("demo")),
+        markup_mode="rich",
+        console=console,
+    )
+
+    output = click.unstyle(console.file.getvalue())
+    assert "--provider TEXT" in output
+    assert "SECTION" in output
 
 
 def test_cli_brand_surfaces_do_not_use_cyan() -> None:


### PR DESCRIPTION
## Summary

Cherry-picks the local `b3481323` fix onto current `origin/dev` so OpenSquilla's Rich/Typer help theme remains compatible with Typer 0.26.x parameter wrapper objects.

## Why

Typer 0.26.x can pass vendored `TyperOption` / `TyperArgument`-shaped objects into the patched Rich help panel. The existing theme assumed local Click class identity and could crash before rendering `--help`.

## Validation

- `uv run pytest tests/test_cli/test_help_theme.py -q`
- `uv run --with typer==0.26.4 python` help smoke for `--help`, `onboard --help`, `configure --help`, and `onboard configure --help`
- `uv sync --extra dev --frozen`
- `uv run ruff check src/opensquilla/ui.py tests/test_cli/test_help_theme.py`
