### PR TITLE
Preserve user message newlines in chat

### DIFF
--- a/src/opensquilla/gateway/static/css/views/chat.css
+++ b/src/opensquilla/gateway/static/css/views/chat.css
@@ -472,6 +472,8 @@
   box-shadow: var(--shadow-sm);
   font-size: var(--fs-sm);
   line-height: 1.6;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   word-break: break-word;
   max-width: 78%;
   min-width: 56px;
@@ -1387,6 +1389,8 @@
   min-height: 32px;
   min-width: 56px;
   padding: var(--sp-2) var(--sp-4);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   word-break: break-word;
 }
 

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -117,6 +117,21 @@ def test_chat_sent_attachment_images_render_as_separate_thumbnail_attachments() 
     assert "var(--accent)" not in thumb_block
 
 
+def test_chat_user_message_bubbles_preserve_multiline_text() -> None:
+    css = CHAT_CSS.read_text(encoding="utf-8")
+    user_start = css.index(".chat-msg--user .chat-msg-text,")
+    user_end = css.index("/* Assistant", user_start)
+    user_block = css[user_start:user_end]
+    text_start = css.index(".msg.user .msg-body--has-attachments .msg-attachment-text {")
+    text_end = css.index(".msg.user .msg-body--has-attachments .msg-attachments", text_start)
+    attachment_text_block = css[text_start:text_end]
+
+    assert "white-space: pre-wrap;" in user_block
+    assert "overflow-wrap: anywhere;" in user_block
+    assert "white-space: pre-wrap;" in attachment_text_block
+    assert "overflow-wrap: anywhere;" in attachment_text_block
+
+
 def test_chat_non_image_message_attachments_render_download_links_when_data_exists() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
     render_start = source.index("function _renderMessageAttachmentHtml(att)")


### PR DESCRIPTION
## Summary

- Preserve line breaks in user message bubbles with `white-space: pre-wrap`.
- Apply the same multiline rendering to user text shown alongside attachments.
- Add a static regression test for multiline user message bubble rendering.

## Tests

- `uv run python -m pytest tests/test_gateway/test_chat_view_static.py -q` - passed, 165 tests
- `uv run ruff check src tests` - passed
- `uv build --wheel` - passed
- `uv run pytest -q` - not completed in this local environment; collection fails because `numpy` is missing for `tests/test_inference_postprocess_rules.py`

## Checklist

- [x] This pull request targets `dev`, unless a maintainer asked for a `main` release/hotfix/documentation PR.
- [x] I ran `uv run ruff check src tests`.
- [ ] I ran `uv run pytest -q`.
- [x] I ran `uv build --wheel`.
- [x] Behavior changes include public regression tests.
- [x] The default test path remains offline, deterministic, credential-free, and safe for forks.
- [x] I did not commit secrets, local paths, private prompts, real provider transcripts, channel identifiers, or AI session artifacts.
- [x] I did not commit maintainer-only files from `tests/_private/` or `.omx/private-golden/`.
- [x] Third-party origin is declared: `none`.
- [x] For non-`none` third-party origin, I listed the upstream URL, license, whether code/rules/fixtures/text were copied or adapted, and updated notices/provenance where required.

## Live Checks

This changes browser UI rendering only. I do not think a maintainer needs to run the `Live Release E2E` workflow for this PR; the targeted offline WebChat static test passed.

## Documentation Changes

No documentation changes.