### PR TITLE
Restore main-visible contributor credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,22 @@ opensquilla gateway restart
 
 ## Credits
 
+OpenSquilla's main-line release history is maintained by the OpenSquilla
+maintainers and community contributors whose work reaches users through
+`dev`, release branches, and published `main` updates:
+
+- [@ab2ence](https://github.com/ab2ence) for Tokenjuice tool compression,
+  memory dream consolidation, and canonical tool-result projection work in
+  #56, #61, #81, and #88.
+- [@lose4578](https://github.com/lose4578) and
+  [@cwan0785](https://github.com/cwan0785) for the TUI backend/runtime
+  foundation and shared chat-envelope extraction in #80.
+- [@nice-code-la](https://github.com/nice-code-la) for high-value MetaSkill
+  routing, router model-switch intent, and router/MetaSkill execution work in
+  #82, #93, and #119.
+- [@openvictory](https://github.com/openvictory) for UTF-8 migration loading
+  and early installer/README cleanup in #18, #25, and #116.
+
 OpenSquilla is inspired by
 [OpenClaw](https://github.com/openclaw/openclaw). Bundled third-party
 content is attributed in


### PR DESCRIPTION
## Summary

- Add a visible community contributor roster to the README Credits section on `main`.
- Credit the contributors whose work was present on `dev` but hidden from the default-branch homepage after the 0.3.0 main sync squash.
- Keep a continuous `Co-authored-by` trailer block on the commit for GitHub contributor attribution.

## Root Cause

`d16fb687` synced the 0.3.0 release surface into `main` as a single Open-Squilla-authored commit. That preserved the release content, but it also dropped the individual dev authorship that GitHub uses for default-branch contributor surfaces.

## Merge Note

Please merge this PR in a way that preserves the final commit message trailer block. Rebase merge preserves it directly. If squash merging, keep all `Co-authored-by` trailers for `ab2ence`, `lose4578`, `cwan0785`, `nice-code-la`, and `openvictory`.

## Validation

- Refreshed `origin/main` and `origin/dev` with `git fetch origin --prune`.
- Compared default-branch and dev author surfaces with `git shortlog -sne origin/main` and `git shortlog -sne origin/dev`.
- Verified public PR authors for #56, #61, #80, #81, #82, #88, #93, #116, and #119.
- Ran `git diff --check origin/main..HEAD -- README.md`.

No code tests were run; this is a README-only attribution fix.