### PR TITLE
Preserve 0.3.0 community contributor attribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,14 @@ latest `main` release point. When that requires replacing the active
 `dev` branch, the previous branch will be archived and contributors
 will be asked to rebase or retarget open pull requests.
 
+## Attribution On Squash Or Replay
+
+When maintainer cleanup, replay, or squash merging collapses contributor
+commits, keep the final non-empty commit attributable with `Co-authored-by:`
+trailers for every human contributor whose work is included. Preserve pull
+request author attribution and commit author attribution separately when they
+differ.
+
 ## Default Checks
 
 Install development dependencies:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,29 @@
+# OpenSquilla Contributors
+
+OpenSquilla uses GitHub pull requests, commits, release notes, and this
+human-readable ledger together for contributor attribution. This file records
+release-surface community work that can be harder to see when a release is
+squash-merged or replayed onto `main`.
+
+## OpenSquilla 0.3.0
+
+The 0.3.0 release reached `main` through release synchronization after work had
+landed through `dev` and integration branches. That compressed the default
+branch commit history, so the following community contributions are recorded
+explicitly here.
+
+| Contributor | 0.3.0 contribution | Evidence |
+| --- | --- | --- |
+| [@ab2ence](https://github.com/ab2ence) | Tokenjuice tool-result compression and canonical projection, memory dream consolidation, chat streaming restore work, and cross-platform CI hardening. | [#56](https://github.com/opensquilla/opensquilla/pull/56), [#61](https://github.com/opensquilla/opensquilla/pull/61), [#81](https://github.com/opensquilla/opensquilla/pull/81), [#88](https://github.com/opensquilla/opensquilla/pull/88), [#109](https://github.com/opensquilla/opensquilla/pull/109) |
+| [@lose4578](https://github.com/lose4578) | Submitted the TUI backend/runtime foundation pull request. | [#80](https://github.com/opensquilla/opensquilla/pull/80) |
+| cwan0785 (commit author name; GitHub account: [@Anonymous-4427](https://github.com/Anonymous-4427)) | Authored the TUI backend/runtime extraction commits behind the foundation pull request. | [#80](https://github.com/opensquilla/opensquilla/pull/80) |
+| [@nice-code-la](https://github.com/nice-code-la) | MetaSkill orchestration, router-control replay and hold behavior, retained high-value MetaSkill routing, lifestyle MetaSkill cleanup, and live MetaSkill execution hardening. | [#82](https://github.com/opensquilla/opensquilla/pull/82), [#93](https://github.com/opensquilla/opensquilla/pull/93), [#96](https://github.com/opensquilla/opensquilla/pull/96), [#110](https://github.com/opensquilla/opensquilla/pull/110), [#114](https://github.com/opensquilla/opensquilla/pull/114) replayed through [#115](https://github.com/opensquilla/opensquilla/pull/115), [#119](https://github.com/opensquilla/opensquilla/pull/119) |
+| [@openvictory](https://github.com/openvictory) | UTF-8 migration loading fix for yoyo migrations on Windows locales, plus follow-up release-gate alignment. | [#116](https://github.com/opensquilla/opensquilla/pull/116) |
+
+## Attribution Practice
+
+When maintainer cleanup, replay, or squash merging collapses contributor
+commits, the final non-empty commit should preserve each human contributor with
+`Co-authored-by:` trailers that use GitHub-associated email addresses. Preserve
+pull request author attribution and commit author attribution separately when
+they differ.

--- a/README.md
+++ b/README.md
@@ -625,6 +625,10 @@ OpenSquilla is inspired by
 content is attributed in
 [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
 
+Community contributors are acknowledged in
+[`CONTRIBUTORS.md`](CONTRIBUTORS.md), including release-specific attribution
+notes for squash-merged or replayed work.
+
 ---
 
 ## Contributing

--- a/docs/releases/0.3.0.md
+++ b/docs/releases/0.3.0.md
@@ -111,18 +111,22 @@ individual files from the new zip into an old portable tree.
 
 ## Acknowledgements
 
-Thanks @ab2ence for #56, #81, and #88, which helped bring
-Tokenjuice-backed tool compression and canonical tool-result projection into
-OpenSquilla.
+Thanks @ab2ence for #56, #61, #81, #88, and #109, which helped bring
+Tokenjuice-backed tool compression, canonical tool-result projection, memory
+dream consolidation, chat streaming restore work, and cross-platform release
+gate hardening into OpenSquilla.
 
-Thanks @lose4578 for #80, which helped extract the TUI backend/runtime
-foundation.
+Thanks @lose4578 for submitting #80, and thanks cwan0785
+(@Anonymous-4427 on GitHub) for authoring the TUI
+backend/runtime extraction commits behind that pull request.
 
-Thanks @nice-code-la for #93 and #119, which helped preserve router
-model-switch intent and harden router/MetaSkill execution.
+Thanks @nice-code-la for #82, #93, #96, #110, #114 (replayed through #115),
+and #119, which helped preserve router model-switch intent, harden
+router/MetaSkill execution, and mature the retained high-value MetaSkill
+workflows.
 
 Thanks @openvictory for #116, which fixed UTF-8 migration loading for yoyo
-migrations.
+migrations and helped keep the release gates aligned on Windows.
 
 OpenSquilla's Tokenjuice-backed projection includes a Python adaptation of
 rule-driven reduction ideas and bundled rules derived from


### PR DESCRIPTION
## Summary

- Add a root `CONTRIBUTORS.md` ledger for the 0.3.0 community attribution surface.
- Link that ledger from README Credits and document the squash/replay attribution rule in `CONTRIBUTING.md`.
- Align the 0.3.0 release acknowledgements with reconstructed PR and commit provenance.

## Root Cause

The 0.3.0 release was synchronized to `main` through a maintainer-authored squash/replay path. That preserved release content but compressed default-branch authorship, so GitHub's contributor surfaces no longer reflected all human contributors whose work shipped in 0.3.0.

## Contributor Evidence

This PR reconstructs 0.3.0 contributor attribution from `v0.2.1..origin/dev` git authors plus GitHub PR metadata for #56, #61, #80, #81, #82, #88, #93, #96, #109, #110, #114/#115, #116, and #119.

The PR author and commit author are recorded separately where they differ. In particular, #80 was submitted by @lose4578, while the TUI backend/runtime extraction commits were authored as `cwan0785`, which GitHub commit metadata maps to @Anonymous-4427.

## Merge Note

This PR intentionally includes `Co-authored-by` trailers on the commit for:

- ab2ence
- lose4578
- cwan0785 / Anonymous-4427
- nice-code-la
- openvictory

Please merge in a way that preserves the final commit message trailer block. Rebase merge preserves it directly. If squash merging, keep all `Co-authored-by` trailers.

## Supersedes

Supersedes #126, which only patched README and used the earlier, narrower attribution wording.

## Validation

- `git diff --check -- README.md CONTRIBUTORS.md CONTRIBUTING.md docs/releases/0.3.0.md`
- `rg -n "[[:blank:]]$" README.md CONTRIBUTORS.md CONTRIBUTING.md docs/releases/0.3.0.md`

No code tests were run; this is a docs-only attribution and process fix.
