### PR TITLE
Fix flush overflow accounting

### DIFF
--- a/src/opensquilla/cli/memory_flush_cmd.py
+++ b/src/opensquilla/cli/memory_flush_cmd.py
@@ -245,8 +245,8 @@ async def run_memory_flush_session(
         flush_service = getattr(svc, "flush_service", None)
         if flush_service is None:
             raise RuntimeError(
-                "session flush service is disabled; unset OPENSQUILLA_SESSION_FLUSH=0 "
-                "or enable session flush before running memory flush-session"
+                "session flush service is disabled; set memory.flush_enabled=true "
+                "and leave OPENSQUILLA_SESSION_FLUSH unset before running memory flush-session"
             )
         session_manager = svc.session_manager
         if session_manager is None:

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -1867,8 +1867,6 @@ class Agent:
         turn_tool_errors = 0
         last_actual_model = ""
         terminal_error: ErrorEvent | None = None
-        window_input_tokens = 0
-        window_output_tokens = 0
         final_text_parts: list[str] = []
         final_reasoning_parts: list[str] = []
         artifact_delivery_final_response_pending = False
@@ -2625,8 +2623,6 @@ class Agent:
                             )
                             if visible_text:
                                 final_text_parts.append(visible_text)
-                            window_input_tokens += iter_input_tokens
-                            window_output_tokens += iter_output_tokens
                             logger.warning(
                                 "provider.output_truncated_continue",
                                 session_key=self._session_key,
@@ -2943,8 +2939,6 @@ class Agent:
                                 kept_count=len(overflow_outcome.messages),
                                 removed_count=overflow_outcome.removed_count,
                             )
-                            window_input_tokens = 0
-                            window_output_tokens = 0
                             _call_attempt += 1
                             continue
                         if not _fallback.should_retry(kind, _retry_attempt):
@@ -3040,14 +3034,16 @@ class Agent:
                 if iter_reasoning_content:
                     final_reasoning_parts.append(iter_reasoning_content)
 
-                window_input_tokens += iter_input_tokens
-                window_output_tokens += iter_output_tokens
-
-                # Check overflow against the current post-compaction window,
-                # not lifetime usage for the whole turn.
+                # Check overflow against the live provider request, not
+                # cumulative billable usage for the whole turn.
+                estimated_context_tokens = self._estimate_live_request_tokens(
+                    request_messages,
+                    tools=provider_tools_for_call,
+                    config=call_chat_cfg,
+                )
                 overflow_outcome = await self._check_context_overflow(
                     turn_messages,
-                    window_input_tokens + window_output_tokens,
+                    estimated_context_tokens,
                     request_context_insert_index=request_context_insert_index,
                     runtime_context_insert_index=runtime_context_insert_index,
                 )
@@ -3065,9 +3061,9 @@ class Agent:
                     )
                     continue  # retry the tool loop iteration
                 if overflow_outcome.compacted:
-                    # Compaction happened — replace message list and reset only
-                    # the live-window gauge. Lifetime counters keep feeding
-                    # DoneEvent usage/cost accounting for this turn.
+                    # Compaction happened — replace message list. Lifetime
+                    # counters keep feeding DoneEvent usage/cost accounting for
+                    # this turn.
                     turn_messages = overflow_outcome.messages
                     if overflow_outcome.request_context_insert_index is not None:
                         request_context_insert_index = overflow_outcome.request_context_insert_index
@@ -3080,8 +3076,6 @@ class Agent:
                         kept_count=len(overflow_outcome.messages),
                         removed_count=overflow_outcome.removed_count,
                     )
-                    window_input_tokens = 0
-                    window_output_tokens = 0
                     overflow_retries = 0  # reset on success
                     # Rebuild chat_cfg so next LLM call uses refreshed system
                     # prompt. Read cache_breakpoints from the
@@ -4011,16 +4005,69 @@ class Agent:
             default_model=self.config.model_id,
         )
 
+    @staticmethod
+    def _live_request_jsonable(value: Any) -> Any:
+        model_dump = getattr(value, "model_dump", None)
+        if callable(model_dump):
+            try:
+                return model_dump(mode="json", exclude_none=True)
+            except TypeError:
+                return model_dump(mode="json")
+        if isinstance(value, list | tuple):
+            return [Agent._live_request_jsonable(item) for item in value]
+        if isinstance(value, dict):
+            return {
+                str(key): Agent._live_request_jsonable(item) for key, item in value.items()
+            }
+        if hasattr(value, "__dict__"):
+            return {
+                str(key): Agent._live_request_jsonable(item)
+                for key, item in vars(value).items()
+                if not str(key).startswith("_")
+            }
+        try:
+            json.dumps(value)
+        except TypeError:
+            return repr(value)
+        return value
+
+    def _estimate_live_request_tokens(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolDefinition] | None = None,
+        config: ChatConfig | None = None,
+    ) -> int:
+        """Estimate the current provider request size without lifetime usage."""
+
+        payload: dict[str, Any] = {
+            "messages": [self._live_request_jsonable(message) for message in messages],
+        }
+        if tools:
+            payload["tools"] = [self._live_request_jsonable(tool) for tool in tools]
+        if config is not None:
+            if config.system:
+                payload["system"] = config.system
+            config_payload = config.model_dump(
+                mode="json",
+                exclude_none=True,
+                exclude={"system", "model_capabilities"},
+            )
+            payload.update(config_payload)
+
+        estimated_chars = len(json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str))
+        return max(1, estimated_chars // 4)
+
     async def _check_context_overflow(
         self,
         messages: list[Message],
-        total_tokens: int,
+        estimated_context_tokens: int,
         *,
         request_context_insert_index: int | None = None,
         runtime_context_insert_index: int | None = None,
         compaction_window_tokens: int | None = None,
     ) -> CompactionOutcome | None:
-        """Check if total tokens exceed the overflow threshold.
+        """Check if estimated live context tokens exceed the overflow threshold.
 
         Uses sub-agent flush instead of prompt injection.
         The flush is re-entrant: it can trigger on every approach to threshold.
@@ -4028,7 +4075,7 @@ class Agent:
         self._last_compaction_refusal_reason = None
         window_tokens = compaction_window_tokens or self.config.context_window_tokens
         threshold = self.config.context_overflow_threshold * window_tokens
-        if total_tokens <= threshold:
+        if estimated_context_tokens <= threshold:
             return CompactionOutcome(
                 messages=messages,
                 request_context_insert_index=request_context_insert_index,
@@ -4105,7 +4152,7 @@ class Agent:
                     )
 
                     if should_flush(
-                        total_tokens=total_tokens,
+                        total_tokens=estimated_context_tokens,
                         threshold_tokens=int(threshold),
                         transcript_bytes=transcript_bytes,
                     ):
@@ -4116,7 +4163,7 @@ class Agent:
                         logger.info(
                             "memory_flush.triggered",
                             path=plan.relative_path,
-                            total_tokens=total_tokens,
+                            total_tokens=estimated_context_tokens,
                             threshold=int(threshold),
                         )
                         flush_task = asyncio.create_task(self._run_flush(plan, list(messages)))
@@ -4160,7 +4207,7 @@ class Agent:
                             phase="agent_inline_overflow",
                             status="skipped",
                             reason=reason,
-                            tokens_before=total_tokens,
+                            tokens_before=estimated_context_tokens,
                             context_window_tokens=window_tokens,
                             **compaction_effect_payload(
                                 status="skipped",
@@ -4197,7 +4244,7 @@ class Agent:
                 source="automatic",
                 phase="agent_inline_overflow",
                 status="started",
-                tokens_before=total_tokens,
+                tokens_before=estimated_context_tokens,
                 context_window_tokens=window_tokens,
                 **compaction_effect_payload(status="started"),
                 **compaction_lifecycle_payload(
@@ -4218,7 +4265,7 @@ class Agent:
                     status="failed",
                     message=str(exc),
                     reason=self._last_compaction_refusal_reason,
-                    tokens_before=total_tokens,
+                    tokens_before=estimated_context_tokens,
                     context_window_tokens=window_tokens,
                     **compaction_effect_payload(status="failed"),
                     **compaction_lifecycle_payload(
@@ -4237,7 +4284,7 @@ class Agent:
                 observed_payload.update(
                     compaction_result_payload(
                         result,
-                        tokens_before=total_tokens,
+                        tokens_before=estimated_context_tokens,
                     )
                 )
                 notify_compaction(
@@ -4267,7 +4314,7 @@ class Agent:
                     phase="agent_inline_overflow",
                     status="failed",
                     reason=self._last_compaction_refusal_reason,
-                    tokens_before=total_tokens,
+                    tokens_before=estimated_context_tokens,
                     context_window_tokens=window_tokens,
                     removed_count=result.removed_count,
                     kept_count=len(result.kept_entries),
@@ -4291,7 +4338,7 @@ class Agent:
                     phase="agent_inline_overflow",
                     status="skipped",
                     reason=skip_reason,
-                    tokens_before=total_tokens,
+                    tokens_before=estimated_context_tokens,
                     tokens_after=result.tokens_after,
                     remaining_budget_tokens=result.remaining_budget_tokens,
                     context_window_tokens=window_tokens,

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -4949,9 +4949,9 @@ class TurnRunner:
 
         memory_cfg = getattr(self._config, "memory", None)
         if memory_cfg is None:
-            return self._session_flush_service is not None
+            return False
 
-        raw_enabled = getattr(memory_cfg, "flush_enabled", True)
+        raw_enabled = getattr(memory_cfg, "flush_enabled", False)
         if isinstance(raw_enabled, str):
             return raw_enabled.strip().lower() not in {"0", "false", "no", "off"}
         return bool(raw_enabled)

--- a/src/opensquilla/engine/turn_runner/harness.py
+++ b/src/opensquilla/engine/turn_runner/harness.py
@@ -440,7 +440,7 @@ class _TurnRunnerAgentConfigBuilderAdapter(AgentConfigBuilderPort):
                 media_root_from_config(runner._config) / "tool-results"
             ),
             tool_result_store_session_id=session_id_for_log or session_key,
-            flush_enabled=getattr(mem_cfg, "flush_enabled", True),
+            flush_enabled=getattr(mem_cfg, "flush_enabled", False),
             flush_timeout_seconds=getattr(mem_cfg, "flush_timeout_seconds", 15.0),
             flush_background_timeout_seconds=getattr(
                 mem_cfg, "flush_background_timeout_seconds", 120.0

--- a/src/opensquilla/engine/types.py
+++ b/src/opensquilla/engine/types.py
@@ -324,7 +324,7 @@ class AgentConfig:
     # skill context in history so provider KV-cache prefixes stay stable.
     skills_context_prompt: str | None = None
     # Pre-compaction memory flush
-    flush_enabled: bool = True
+    flush_enabled: bool = False
     flush_timeout_seconds: float = 15.0
     flush_background_timeout_seconds: float = 120.0
     flush_backoff_initial_seconds: float = 30.0

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -1210,8 +1210,8 @@ def build_flush_service(
 ) -> Any:
     """Construct a :class:`SessionFlushService` gated by flush config.
 
-    Returns ``None`` when the kill-switch env var or gateway memory config
-    disables flush. Otherwise returns a service wired to the gateway's tool
+    Returns ``None`` when the kill-switch env var is disabled or gateway memory
+    config does not explicitly enable flush. Otherwise returns a service wired to the gateway's tool
     registry and provider selector. ``agent_id`` is threaded through the
     callable signature for future multi-agent support, but today OpenSquilla
     uses a single ModelSelector so we just call its ``resolve()`` and ignore
@@ -1222,7 +1222,7 @@ def build_flush_service(
     if not is_session_flush_enabled():
         return None
     memory_cfg = getattr(config, "memory", None)
-    if memory_cfg is not None and not getattr(memory_cfg, "flush_enabled", True):
+    if memory_cfg is None or not getattr(memory_cfg, "flush_enabled", False):
         return None
 
     from opensquilla.memory.session_flush import SessionFlushService

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -491,7 +491,7 @@ class MemoryConfig(BaseSettings):
     ttl_sweep_interval_minutes: float = Field(default=60.0, ge=0.0)
 
     # Flush (pre-compaction memory save)
-    flush_enabled: bool = True
+    flush_enabled: bool = False
     flush_timeout_seconds: float = 15.0
     flush_background_timeout_seconds: float = 120.0
     flush_backoff_initial_seconds: float = 30.0

--- a/src/opensquilla/memory/flush_config.py
+++ b/src/opensquilla/memory/flush_config.py
@@ -1,7 +1,9 @@
 """Kill switch for session-end flush.
 
-PR2 synchronous flush is opt-out via ``OPENSQUILLA_SESSION_FLUSH``. Setting the
-env var to ``0`` or ``false`` restores full PR2-pre behavior:
+Session flush is disabled by default in memory configuration. When memory
+configuration explicitly enables it, ``OPENSQUILLA_SESSION_FLUSH`` remains a
+global kill switch. Setting the env var to ``0`` or ``false`` restores full
+pre-flush behavior:
 
 * ``sessions.reset`` skips snapshot/lock-drain and returns the original
   response shape without a ``flush_receipt`` field.

--- a/src/opensquilla/session/compaction_lifecycle.py
+++ b/src/opensquilla/session/compaction_lifecycle.py
@@ -471,7 +471,7 @@ def pre_compaction_flush_enabled(config: Any) -> bool:
     if not is_session_flush_enabled():
         return False
     memory_cfg = getattr(config, "memory", None)
-    return bool(getattr(memory_cfg, "flush_enabled", True))
+    return bool(getattr(memory_cfg, "flush_enabled", False))
 
 
 def pre_compaction_flush_requires_safe_receipt(config: Any) -> bool:

--- a/tests/test_engine/test_agent_llm_budget.py
+++ b/tests/test_engine/test_agent_llm_budget.py
@@ -221,6 +221,49 @@ class _RepeatedToolFailureThenDoneProvider:
         return []
 
 
+class _HighUsageToolLoopProvider:
+    provider_name = "fake"
+
+    def __init__(self, *, tool_rounds: int = 3, input_tokens_per_call: int = 4000) -> None:
+        self.tool_rounds = tool_rounds
+        self.input_tokens_per_call = input_tokens_per_call
+        self.calls: list[list[Message]] = []
+
+    def chat(
+        self,
+        messages: list[Message],
+        tools: list[Any] | None = None,
+        config: ChatConfig | None = None,
+    ) -> AsyncIterator[Any]:
+        self.calls.append(messages)
+        return self._stream(len(self.calls))
+
+    async def _stream(self, call_number: int) -> AsyncIterator[Any]:
+        if call_number > self.tool_rounds:
+            yield ProviderText(text="done")
+            yield ProviderDone(
+                stop_reason="stop",
+                input_tokens=self.input_tokens_per_call,
+                output_tokens=0,
+            )
+            return
+        tool_use_id = f"read-{call_number}"
+        yield ProviderToolUseStart(tool_use_id=tool_use_id, tool_name="exec_command")
+        yield ProviderToolUseEnd(
+            tool_use_id=tool_use_id,
+            tool_name="exec_command",
+            arguments={"command": f"printf round-{call_number}"},
+        )
+        yield ProviderDone(
+            stop_reason="tool_calls",
+            input_tokens=self.input_tokens_per_call,
+            output_tokens=0,
+        )
+
+    async def list_models(self) -> list[Any]:
+        return []
+
+
 class _ConfigCapturingProvider:
     provider_name = "fake"
 
@@ -999,6 +1042,128 @@ async def test_context_overflow_effective_compaction_allows_single_retry(
 
 
 @pytest.mark.asyncio
+async def test_inline_overflow_uses_live_context_not_cumulative_provider_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import opensquilla.engine.agent as agent_module
+
+    provider = _HighUsageToolLoopProvider(tool_rounds=3, input_tokens_per_call=4000)
+    flush_calls: list[int] = []
+    compact_requests: list[Any] = []
+
+    async def _tool(call: Any) -> ToolResult:
+        return ToolResult(
+            tool_use_id=call.tool_use_id,
+            tool_name=call.tool_name,
+            content="ok",
+        )
+
+    async def _flush(_plan: Any, flush_messages: list[Message]) -> Any:
+        flush_calls.append(len(flush_messages))
+        return SimpleNamespace(
+            mode="llm",
+            indexed_chunk_count=1,
+            integrity_status="ok",
+            output_coverage_status="ok",
+            invalid_candidate_count=0,
+            candidate_missing_ids=[],
+            obligation_status="ok",
+            obligation_missing_ids=[],
+        )
+
+    async def _compact(request: Any) -> CompactionResult:
+        compact_requests.append(request)
+        return CompactionResult(
+            summary="",
+            kept_entries=request.entries,
+            removed_count=0,
+            chunks_processed=0,
+        )
+
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            context_window_tokens=20_000,
+            context_overflow_threshold=0.5,
+            flush_enabled=True,
+            flush_timeout_seconds=0.01,
+            max_iterations=10,
+        ),
+        tool_handler=_tool,
+    )
+    monkeypatch.setattr(agent, "_run_flush", _flush)
+    monkeypatch.setattr(agent_module, "compact_context", _compact)
+
+    events = [event async for event in agent.run_turn("read the files one by one")]
+
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.text == "done"
+    assert done.input_tokens == 16_000
+    assert len(provider.calls) == 4
+    assert flush_calls == []
+    assert compact_requests == []
+
+
+@pytest.mark.asyncio
+async def test_inline_overflow_still_triggers_for_large_live_provider_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import opensquilla.engine.agent as agent_module
+
+    provider = _HighUsageToolLoopProvider(tool_rounds=0, input_tokens_per_call=1)
+    large_tool = ToolDefinition(
+        name="large_context_tool",
+        description="large live request surface " + ("z" * 6000),
+        input_schema=ToolInputSchema(),
+    )
+    flush_calls: list[int] = []
+    compact_requests: list[Any] = []
+
+    async def _flush(_plan: Any, flush_messages: list[Message]) -> Any:
+        flush_calls.append(len(flush_messages))
+        return SimpleNamespace(
+            mode="llm",
+            indexed_chunk_count=1,
+            integrity_status="ok",
+            output_coverage_status="ok",
+            invalid_candidate_count=0,
+            candidate_missing_ids=[],
+            obligation_status="ok",
+            obligation_missing_ids=[],
+        )
+
+    async def _compact(request: Any) -> CompactionResult:
+        compact_requests.append(request)
+        return CompactionResult(
+            summary="",
+            kept_entries=request.entries,
+            removed_count=0,
+            chunks_processed=0,
+        )
+
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            context_window_tokens=3000,
+            context_overflow_threshold=0.5,
+            flush_enabled=True,
+            flush_timeout_seconds=0.01,
+            system_prompt="live request system context " + ("s" * 2000),
+        ),
+        tool_definitions=[large_tool],
+    )
+    monkeypatch.setattr(agent, "_run_flush", _flush)
+    monkeypatch.setattr(agent_module, "compact_context", _compact)
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert any(isinstance(event, DoneEvent) for event in events)
+    assert len(provider.calls) == 1
+    assert flush_calls == [1]
+    assert len(compact_requests) == 1
+
+
+@pytest.mark.asyncio
 async def test_provider_request_budget_exhausted_compacts_warns_and_retries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1330,6 +1495,7 @@ async def test_context_overflow_flush_timeout_records_backoff_and_retries(
         config=AgentConfig(
             max_provider_retries=0,
             max_overflow_retries=2,
+            flush_enabled=True,
             flush_timeout_seconds=0.01,
             flush_backoff_initial_seconds=10.0,
         ),

--- a/tests/test_engine/test_preflight_compaction.py
+++ b/tests/test_engine/test_preflight_compaction.py
@@ -44,6 +44,17 @@ def _make_entry(content: str, role: str = "user") -> TranscriptEntry:
     )
 
 
+def _flush_enabled_config(**overrides: Any) -> SimpleNamespace:
+    memory = {
+        "flush_enabled": True,
+        "flush_timeout_seconds": 0.25,
+        "flush_background_timeout_seconds": 120.0,
+        "flush_compaction_requires_safe_receipt": False,
+    }
+    memory.update(overrides)
+    return SimpleNamespace(memory=SimpleNamespace(**memory))
+
+
 def _make_assistant_tool_entry(content: str, tool_calls: list[dict[str, Any]]) -> TranscriptEntry:
     return TranscriptEntry(
         session_id="test-session-id",
@@ -589,6 +600,7 @@ async def test_preflight_starts_full_transcript_flush_without_blocking_compact()
         provider_selector=MagicMock(),
         session_manager=mock_sm,
         session_flush_service=flush_service,
+        config=_flush_enabled_config(),
     )
 
     with patch("opensquilla.session.tokenizer.estimate_tokens", return_value=1000):
@@ -638,6 +650,7 @@ async def test_preflight_degraded_flush_receipts_do_not_block_compaction(
         provider_selector=MagicMock(),
         session_manager=mock_sm,
         session_flush_service=flush_service,
+        config=_flush_enabled_config(),
     )
 
     with patch("opensquilla.session.tokenizer.estimate_tokens", return_value=1000):
@@ -972,6 +985,7 @@ async def test_preflight_backfilled_flush_receipt_allows_compact() -> None:
         provider_selector=MagicMock(),
         session_manager=mock_sm,
         session_flush_service=flush_service,
+        config=_flush_enabled_config(),
     )
 
     with patch("opensquilla.session.tokenizer.estimate_tokens", return_value=1000):

--- a/tests/test_engine/test_session_sanitize.py
+++ b/tests/test_engine/test_session_sanitize.py
@@ -1661,7 +1661,7 @@ async def test_agent_inline_strict_flush_receipt_refuses_destructive_compaction(
         compact_context_should_not_run,
     )
 
-    outcome = await agent._check_context_overflow(messages, total_tokens=100)
+    outcome = await agent._check_context_overflow(messages, estimated_context_tokens=100)
 
     assert outcome is None
     assert compact_called is False

--- a/tests/test_engine/turn_runner/test_agent_bootstrap_stage_snapshot.py
+++ b/tests/test_engine/turn_runner/test_agent_bootstrap_stage_snapshot.py
@@ -600,7 +600,7 @@ async def test_agent_bootstrap_stage_snapshot(
         "agent_config_cache_mode": "off",
         "agent_config_thinking": case["thinking"],
         "agent_config_tool_result_projection_max_inline_chars": 60_000,
-        "agent_config_flush_enabled": True,
+        "agent_config_flush_enabled": False,
         "effective_runtime_timeout": expected_runtime_timeout,
         "effective_max_iterations": expected_max_iterations,
         "effective_iteration_timeout": case["iteration_timeout"],

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -792,6 +792,7 @@ def test_build_flush_service_uses_configured_background_memory_timeout() -> None
         provider_selector=SimpleNamespace(resolve=lambda: object()),
         config=GatewayConfig(
             memory={
+                "flush_enabled": True,
                 "flush_timeout_seconds": 0.25,
                 "flush_background_timeout_seconds": 42.0,
             }
@@ -812,7 +813,7 @@ async def test_build_flush_service_archive_workspace_falls_back_to_main_workspac
     service = build_flush_service(
         tool_registry=registry,
         provider_selector=SimpleNamespace(resolve=lambda: None),
-        config=GatewayConfig(),
+        config=GatewayConfig(memory={"flush_enabled": True}),
         memory_managers={
             "side": SimpleNamespace(workspace_dir=None, memory_dir=matching_memory_dir),
             "main": SimpleNamespace(
@@ -862,7 +863,7 @@ async def test_build_flush_service_wires_durable_receipt_writer(tmp_path: Path) 
         service = build_flush_service(
             tool_registry=registry,
             provider_selector=SimpleNamespace(resolve=lambda: None),
-            config=GatewayConfig(),
+            config=GatewayConfig(memory={"flush_enabled": True}),
             session_manager=session_manager,
             memory_managers={"main": SimpleNamespace(workspace_dir=tmp_path)},
         )
@@ -924,7 +925,7 @@ async def test_build_flush_service_receipt_uses_session_id_captured_before_rotat
         service = build_flush_service(
             tool_registry=registry,
             provider_selector=SimpleNamespace(resolve=lambda: None),
-            config=GatewayConfig(),
+            config=GatewayConfig(memory={"flush_enabled": True}),
             session_manager=session_manager,
             memory_managers={"main": SimpleNamespace(workspace_dir=tmp_path)},
         )
@@ -987,7 +988,7 @@ async def test_build_flush_service_receipts_distinguish_same_window_different_co
         service = build_flush_service(
             tool_registry=registry,
             provider_selector=SimpleNamespace(resolve=lambda: None),
-            config=GatewayConfig(),
+            config=GatewayConfig(memory={"flush_enabled": True}),
             session_manager=session_manager,
             memory_managers={"main": SimpleNamespace(workspace_dir=tmp_path)},
         )
@@ -1043,7 +1044,7 @@ async def test_build_flush_service_archive_failed_without_checkpoint_is_checkpoi
         service = build_flush_service(
             tool_registry=registry,
             provider_selector=SimpleNamespace(resolve=lambda: None),
-            config=GatewayConfig(),
+            config=GatewayConfig(memory={"flush_enabled": True}),
             session_manager=session_manager,
         )
 

--- a/tests/test_memory_flush.py
+++ b/tests/test_memory_flush.py
@@ -207,6 +207,7 @@ async def test_agent_memory_flush_timeout_enters_backoff_without_retrigger(
         config=AgentConfig(
             context_window_tokens=100,
             context_overflow_threshold=0.5,
+            flush_enabled=True,
             flush_timeout_seconds=0.01,
             flush_backoff_initial_seconds=10.0,
             flush_backoff_max_seconds=20.0,
@@ -258,6 +259,7 @@ async def test_agent_memory_flush_timeout_records_backoff_and_compacts(
         config=AgentConfig(
             context_window_tokens=100,
             context_overflow_threshold=0.5,
+            flush_enabled=True,
             flush_timeout_seconds=0.01,
             flush_backoff_initial_seconds=10.0,
             flush_backoff_max_seconds=20.0,


### PR DESCRIPTION
## Summary
- Disable session flush by default unless memory flush is explicitly enabled.
- Estimate live provider request context for inline overflow checks instead of cumulative turn usage.
- Keep flush-specific tests explicitly opted in so the disabled default is covered.

## Verification
- uv run --extra dev pytest tests/test_gateway/test_context_overflow.py tests/test_gateway/test_rpc_sessions.py tests/test_engine/test_preflight_compaction.py tests/test_engine/test_t3_upgrade_compaction.py tests/test_gateway/test_router_boot.py tests/test_engine/test_agent_llm_budget.py tests/test_memory_flush.py tests/test_engine/test_session_sanitize.py::test_agent_inline_strict_flush_receipt_refuses_destructive_compaction tests/test_engine/turn_runner/test_agent_bootstrap_stage_snapshot.py -q
- uv run --extra dev ruff check src/opensquilla/engine/agent.py src/opensquilla/engine/types.py src/opensquilla/gateway/config.py src/opensquilla/gateway/boot.py src/opensquilla/engine/runtime.py src/opensquilla/session/compaction_lifecycle.py src/opensquilla/memory/flush_config.py src/opensquilla/cli/memory_flush_cmd.py tests/test_engine/test_agent_llm_budget.py tests/test_memory_flush.py tests/test_gateway/test_router_boot.py tests/test_engine/test_preflight_compaction.py tests/test_engine/test_session_sanitize.py tests/test_engine/turn_runner/test_agent_bootstrap_stage_snapshot.py