### PR TITLE
Preserve user message newlines in chat on main

### DIFF
--- a/src/opensquilla/gateway/static/css/views/chat.css
+++ b/src/opensquilla/gateway/static/css/views/chat.css
@@ -472,6 +472,8 @@
   box-shadow: var(--shadow-sm);
   font-size: var(--fs-sm);
   line-height: 1.6;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   word-break: break-word;
   max-width: 78%;
   min-width: 56px;
@@ -1387,6 +1389,8 @@
   min-height: 32px;
   min-width: 56px;
   padding: var(--sp-2) var(--sp-4);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   word-break: break-word;
 }
 

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -117,6 +117,21 @@ def test_chat_sent_attachment_images_render_as_separate_thumbnail_attachments() 
     assert "var(--accent)" not in thumb_block
 
 
+def test_chat_user_message_bubbles_preserve_multiline_text() -> None:
+    css = CHAT_CSS.read_text(encoding="utf-8")
+    user_start = css.index(".chat-msg--user .chat-msg-text,")
+    user_end = css.index("/* Assistant", user_start)
+    user_block = css[user_start:user_end]
+    text_start = css.index(".msg.user .msg-body--has-attachments .msg-attachment-text {")
+    text_end = css.index(".msg.user .msg-body--has-attachments .msg-attachments", text_start)
+    attachment_text_block = css[text_start:text_end]
+
+    assert "white-space: pre-wrap;" in user_block
+    assert "overflow-wrap: anywhere;" in user_block
+    assert "white-space: pre-wrap;" in attachment_text_block
+    assert "overflow-wrap: anywhere;" in attachment_text_block
+
+
 def test_chat_non_image_message_attachments_render_download_links_when_data_exists() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
     render_start = source.index("function _renderMessageAttachmentHtml(att)")


### PR DESCRIPTION
## Summary

- Sync #124 to main after it was merged into dev.
- Preserve multiline rendering for user chat bubbles and user text shown alongside attachments.
- Keep this as a one-commit hotfix sync instead of merging dev into main.

## Tests

- git diff --check origin/main..HEAD
- UV_PYTHON=3.12 UV_CACHE_DIR=/tmp/uv-cache TMPDIR=/tmp uv run pytest tests/test_gateway/test_chat_view_static.py -q
- UV_PYTHON=3.12 UV_CACHE_DIR=/tmp/uv-cache TMPDIR=/tmp uv run --extra dev ruff check src tests

## Notes

Original dev PR: #124