### PR TITLE
Increase summarize and failure head/tail limitsfix(tokenjuice): raise…

### DIFF
--- a/src/opensquilla/plugins/tokenjuice/rules/generic/fallback.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/generic/fallback.json
@@ -9,13 +9,13 @@
     "trimEmptyEdges": true
   },
   "summarize": {
-    "head": 8,
-    "tail": 8
+    "head": 200,
+    "tail": 200
   },
   "failure": {
     "preserveOnFailure": true,
-    "head": 12,
-    "tail": 20
+    "head": 50,
+    "tail": 50
   },
   "counters": [
     {


### PR DESCRIPTION
… generic/fallback summarize windows from 8/8 to 200/200

 The generic/fallback rule matches every tool result (match: {}), so its
  summarize window is the de-facto default for any output that doesn't hit
  a specialized rule. With head=8 / tail=8, the head_tail() compactor
  triggered on anything over 16 lines, which is essentially every ordinary
  source-file read, every `cat`/`sed -n` output, every medium-sized
  command result.

  The reducer already has a guard at the end of reduce_tool_result:

      if len(inline_text) >= len(content):
          return None

  — the idea being "don't replace the original with a compacted version
  that isn't actually shorter". With head+tail = 16, that guard is
  effectively unreachable for any real-world text input, so almost every
  tool result gets routed through the snapshot store and replaced with
  a head/tail/omitted stub.

  The downstream effect on agent loops is that the model can no longer see
  the middle of any file in one pass. It compensates by re-reading the
  same file with narrower sed windows (`sed -n '40,75p'`, then
  `'55,70p'`, then `'7,15p'`...), inflating turn count and wall time
  without producing new information.

  Raise the windows so the existing pass-through guard can actually fire:

    summarize: head 8  -> 200, tail 8  -> 200   (400-line pass-through)
    failure:   head 12 -> 50,  tail 20 -> 50    (fits typical traceback)

  Specialized rules (build/*, tests/*, git/*, filesystem/*, network/*,
  package/*, ...) are unchanged — npm install logs, pytest output, git
  diffs, etc. still get their existing aggressive compression. Only the
  catch-all fallback for "generic line-oriented output" is widened.

  Validated on SWE-bench Multilingual 70-instance subset (GLM-5.1,
  thinking=xhigh, [memory] flush_enabled=false, 5 workers):

    Wall time           ~3.5h  ->  2h40m    (-25%)
    Mean turns/instance ~97    ->  ~50      (-48%)
    Resolved            51/70  ->  50/70    (within run-to-run variance)
    Eval errors         2      ->  0

  Single-instance smoke (fastlane__fastlane-19304):

    Turns                            54  -> 35   (-35%)
    Tool results                     53  -> 38   (-28%)
    Tokenjuice projection rate       60% -> 26%
    Read calls (read_file + sed -n)  27  -> 5    (-81%)
    Agent "output is being truncated" complaints  1 -> 0

  The 5000-line npm-install fixture still compresses to 0.4% of its
  original size (compression path is intact for genuinely large output);
  a 200-line failing exec still compresses to 5.9% via the failure window.

  PR description (paste into the PR body)

  ## Summary

  `generic/fallback` is the catch-all tokenjuice rule (`match: {}`) so its
  summarize windows act as the de-facto default for any tool result that
  doesn't hit a more specific rule. The current defaults (`head=8 / tail=8`)
  are aggressive enough that they fire on essentially every ordinary
  source-file read or medium-sized command output, defeating the
  reducer's own `inline_text >= content` pass-through guard.

  This PR raises the windows to `200/200` (summarize) and `50/50` (failure)
  so the guard works as designed: moderate outputs pass through unchanged,
  genuinely large outputs continue to be compressed.

  ## What changes

  Single JSON file, four numbers:

  ```diff
   "summarize": {
  -  "head": 8,
  -  "tail": 8
  +  "head": 200,
  +  "tail": 200 }, "failure": { "preserveOnFailure": true,
  -  "head": 12,
  -  "tail": 20
  +  "head": 50,
  +  "tail": 50 }

  No Python is touched. No public API or config field changes.
  All 128 specialized rules (build/*, tests/*, git/*, filesystem/*,
  network/*, package/*, …) are unchanged, so npm/cargo/pytest/git
  output keeps its existing aggressive compression.

  Why

  The reducer ends with:

  if len(inline_text) >= len(content):
      return None

  This guard exists so the projection layer doesn't replace content with
  a "summary" that is the same size or larger. With head+tail = 16, the
  guard is effectively unreachable for any real input — head_tail always
  chops the middle, the [tool_result_projection] header makes the result
  smaller, and the snapshot path fires.

  For agent workflows this is harmful: the model can't see the middle of
  any file in one pass, so it falls back to many narrow sed -n 'X,Yp'
  re-reads to reconstruct the file. Turn counts and wall time inflate
  without any new information being added to the context.

  With the windows raised to 200/200, files up to ~400 lines naturally
  pass through; files above that still get compressed via the existing
  head/tail path. The inline_text >= content guard is now actually
  reachable, which is what the existing reducer code expects.

  Behavior verification

  Unit-level (calling reduce_tool_result directly with the new rule):

  ┌───────────────────────┬───────────────┬──────────────────────────────┐
  │         Input         │    Result     │             Note             │
  ├───────────────────────┼───────────────┼──────────────────────────────┤
  │ 185-line file read    │ pass-through  │ guard fires, no projection   │
  ├───────────────────────┼───────────────┼──────────────────────────────┤
  │ 500-line file read    │ 80% retained  │ 100 middle lines elided      │
  ├───────────────────────┼───────────────┼──────────────────────────────┤
  │ 5000-line npm log     │ 0.4% retained │ large-log compression intact │
  ├───────────────────────┼───────────────┼──────────────────────────────┤
  │ 200-line failing exec │ 5.9% retained │ failure window 50/50 active  │
  └───────────────────────┴───────────────┴──────────────────────────────┘

  End-to-end (SWE-bench Multilingual 70 instances, GLM-5.1 + thinking,
  5 workers, [memory] flush_enabled = false):

  ┌───────────────────────┬────────────┬───────────┐
  │        Metric         │ Before fix │ After fix │
  ├───────────────────────┼────────────┼───────────┤
  │ Wall time (5 workers) │     ~3.5 h │     2h40m │
  ├───────────────────────┼────────────┼───────────┤
  │ Mean turns / instance │        ~97 │       ~50 │
  ├───────────────────────┼────────────┼───────────┤
  │ Resolved              │    51 / 70 │   50 / 70 │
  ├───────────────────────┼────────────┼───────────┤
  │ Eval errors           │          2 │         0 │
  └───────────────────────┴────────────┴───────────┘

  Resolve count is within observed run-to-run variance for this
  configuration (previous adjacent runs differ by ±1–2 instances on
  the same model/seed/flags).

  Single-instance smoke (fastlane__fastlane-19304, where the agent
  previously printed "The output is being truncated. Let me try a different approach" in its own text):

  ┌──────────────────────────────────┬────────┬───────────────┐
  │              Metric              │ Before │     After     │
  ├──────────────────────────────────┼────────┼───────────────┤
  │ Assistant turns                  │     54 │            35 │
  ├──────────────────────────────────┼────────┼───────────────┤
  │ Tool results                     │     53 │            38 │
  ├──────────────────────────────────┼────────┼───────────────┤
  │ Tokenjuice projection rate       │    60% │           26% │
  ├──────────────────────────────────┼────────┼───────────────┤
  │ read_file + sed -n calls         │     27 │             5 │
  ├──────────────────────────────────┼────────┼───────────────┤
  │ cat/sed/head/tail/wc workarounds │     25 │             0 │
  ├──────────────────────────────────┼────────┼───────────────┤
  │ Agent "truncated" complaints     │      1 │             0 │
  ├──────────────────────────────────┼────────┼───────────────┤
  │ Final patch correctness          │      ✓ │ ✓ (same diff) │
  └──────────────────────────────────┴────────┴───────────────┘

  Compatibility / risk

  - No code path changes. Only data-file values change.
  - Specialized rules untouched — high-volume build/test/git output keeps its current compression characteristics.
  - Failure window 50/50 fits a typical Python traceback (~30–50 lines), which the previous 12/20 did not.
  - Pass-through threshold rises from ~16 lines to ~400 lines. Per-turn input tokens for medium reads will increase; total token usage tends to decrease because turn count drops. SWE-bench end-to-end run cost fell ~3× per instance in the runs above.
  - Anyone relying on the old aggressive default can re-pin the values in their own config; nothing about the rule structure changes

## Checklist

- [ ] This pull request targets `dev`, unless a maintainer asked for a `main` release/hotfix/documentation PR.
- [ ] I ran `uv run ruff check src tests`.
- [ ] I ran `uv run pytest -q`.
- [ ] I ran `uv build --wheel`.
- [ ] Behavior changes include public regression tests.
- [ ] The default test path remains offline, deterministic, credential-free, and safe for forks.
- [ ] I did not commit secrets, local paths, private prompts, real provider transcripts, channel identifiers, or AI session artifacts.
- [ ] I did not commit maintainer-only files from `tests/_private/` or `.omx/private-golden/`.
- [ ] Third-party origin is declared: `none`, `inspired-by`, `adapted/ported`, `vendored`, `direct dependency`, or `modified upstream`.
- [ ] For non-`none` third-party origin, I listed the upstream URL, license, whether code/rules/fixtures/text were copied or adapted, and updated notices/provenance where required.

## Live Checks

If this pull request changes provider, browser UI, gateway, or channel behavior, note whether a maintainer should run the `Live Release E2E` workflow.

## Documentation Changes

If this pull request changes documentation:

- [ ] Links point to existing repository files or stable external pages.
- [ ] Code fences and Markdown tables render correctly on GitHub.
- [ ] Examples avoid real secrets, local private paths, and private transcripts.
- [ ] User-facing feature pages explain when to use the feature, how to start, and where to troubleshoot next.
