### PR TITLE
Prevent malformed tool-call replay from reaching providers

### DIFF
--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -3805,6 +3805,7 @@ class Agent:
         source_messages = self._strip_provider_context_marker_replay_for_provider(source_messages)
         source_messages = self._compact_aggregate_tool_results_for_provider(source_messages)
         source_messages = self._sanitize_projected_tool_use_arguments_for_provider(source_messages)
+        source_messages = repair_tool_pairing(source_messages)
         return sanitize_session_messages(source_messages)
 
     def _apply_provider_tool_result_overrides(self, messages: list[Message]) -> list[Message]:

--- a/src/opensquilla/engine/history.py
+++ b/src/opensquilla/engine/history.py
@@ -93,42 +93,59 @@ def _extract_tool_result_ids(content: Any) -> set[str]:
 
 
 def repair_tool_pairing(messages: list[Message]) -> list[Message]:
-    """Remove messages with orphaned tool_use or tool_result blocks.
+    """Remove messages with malformed tool_use/tool_result adjacency.
 
-    A tool_use is orphaned if no subsequent message has a matching tool_result.
-    A tool_result is orphaned if no prior message has a matching tool_use.
+    OpenAI-compatible providers require an assistant message with tool calls to
+    be followed immediately by tool result messages for every requested
+    ``tool_call_id``. A matching ID elsewhere in the transcript is not enough:
+    ordinary user/context messages between the call and result still make the
+    provider request invalid.
+
     Returns original list reference if no repairs needed.
     """
-    # Collect all tool_use IDs and tool_result IDs
-    all_use_ids: set[str] = set()
-    all_result_ids: set[str] = set()
-
-    for msg in messages:
-        all_use_ids.update(_extract_tool_use_ids(msg.content))
-        all_result_ids.update(_extract_tool_result_ids(msg.content))
-
-    # Find orphans
-    orphan_uses = all_use_ids - all_result_ids
-    orphan_results = all_result_ids - all_use_ids
-
-    if not orphan_uses and not orphan_results:
+    if not messages:
         return messages
 
-    # Filter out messages that ONLY contain orphan blocks
+    valid_tool_call_indices: set[int] = set()
+    valid_tool_result_indices: set[int] = set()
+
+    for index, message in enumerate(messages[:-1]):
+        use_ids = _extract_tool_use_ids(message.content)
+        if not use_ids:
+            continue
+        if message.role != "assistant":
+            continue
+
+        result_indices: set[int] = set()
+        result_ids: set[str] = set()
+        for result_index in range(index + 1, len(messages)):
+            next_result_ids = _extract_tool_result_ids(messages[result_index].content)
+            if not next_result_ids:
+                break
+            result_ids.update(next_result_ids)
+            if not result_ids.issubset(use_ids):
+                break
+            result_indices.add(result_index)
+            if result_ids == use_ids:
+                break
+
+        if result_ids == use_ids:
+            valid_tool_call_indices.add(index)
+            valid_tool_result_indices.update(result_indices)
+
     repaired: list[Message] = []
-    for msg in messages:
-        use_ids = _extract_tool_use_ids(msg.content)
-        result_ids = _extract_tool_result_ids(msg.content)
+    for index, message in enumerate(messages):
+        use_ids = _extract_tool_use_ids(message.content)
+        result_ids = _extract_tool_result_ids(message.content)
 
-        # If message has tool blocks and ALL are orphaned, skip it
-        if use_ids and use_ids.issubset(orphan_uses) and not isinstance(msg.content, str):
+        if use_ids and index not in valid_tool_call_indices:
             continue
-        if result_ids and result_ids.issubset(orphan_results) and not isinstance(msg.content, str):
+        if result_ids and index not in valid_tool_result_indices:
             continue
 
-        repaired.append(msg)
+        repaired.append(message)
 
-    return repaired
+    return messages if len(repaired) == len(messages) else repaired
 
 
 def _coerce_tool_input(raw: Any) -> dict[str, Any]:

--- a/tests/test_engine/test_session_sanitize.py
+++ b/tests/test_engine/test_session_sanitize.py
@@ -1473,6 +1473,106 @@ async def test_agent_request_context_is_request_only_after_history() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agent_provider_view_prunes_non_adjacent_tool_results() -> None:
+    provider = CapturingProvider()
+    agent = Agent(provider=provider, config=AgentConfig(max_iterations=1))
+    agent.set_history(
+        [
+            Message(role="user", content="old task"),
+            Message(
+                role="assistant",
+                content=[
+                    ContentBlockToolUse(
+                        id="call_lookup",
+                        name="lookup",
+                        input={"q": "old"},
+                    )
+                ],
+            ),
+            Message(role="user", content="ordinary user message before the tool result"),
+            Message(
+                role="user",
+                content=[
+                    ContentBlockToolResult(
+                        tool_use_id="call_lookup",
+                        content="lookup result",
+                        is_error=False,
+                    )
+                ],
+            ),
+        ]
+    )
+
+    events = [event async for event in agent.run_turn("continue")]
+
+    assert any(event.kind == "done" for event in events)
+    replay_payload = json.dumps(
+        [message.model_dump(mode="json") for message in provider.calls[0]["messages"]],
+        ensure_ascii=False,
+    )
+    assert "call_lookup" not in replay_payload
+    assert "ordinary user message before the tool result" in replay_payload
+
+
+@pytest.mark.asyncio
+async def test_agent_provider_view_preserves_split_adjacent_tool_results() -> None:
+    provider = CapturingProvider()
+    agent = Agent(provider=provider, config=AgentConfig(max_iterations=1))
+    agent.set_history(
+        [
+            Message(role="user", content="old task"),
+            Message(
+                role="assistant",
+                content=[
+                    ContentBlockToolUse(
+                        id="call_alpha",
+                        name="lookup",
+                        input={"q": "alpha"},
+                    ),
+                    ContentBlockToolUse(
+                        id="call_beta",
+                        name="lookup",
+                        input={"q": "beta"},
+                    ),
+                ],
+            ),
+            Message(
+                role="user",
+                content=[
+                    ContentBlockToolResult(
+                        tool_use_id="call_alpha",
+                        content="alpha result",
+                        is_error=False,
+                    )
+                ],
+            ),
+            Message(
+                role="user",
+                content=[
+                    ContentBlockToolResult(
+                        tool_use_id="call_beta",
+                        content="beta result",
+                        is_error=False,
+                    )
+                ],
+            ),
+        ]
+    )
+
+    events = [event async for event in agent.run_turn("continue")]
+
+    assert any(event.kind == "done" for event in events)
+    replay_payload = json.dumps(
+        [message.model_dump(mode="json") for message in provider.calls[0]["messages"]],
+        ensure_ascii=False,
+    )
+    assert "call_alpha" in replay_payload
+    assert "alpha result" in replay_payload
+    assert "call_beta" in replay_payload
+    assert "beta result" in replay_payload
+
+
+@pytest.mark.asyncio
 async def test_agent_request_context_repeats_across_tool_loop_without_persisting() -> None:
     provider = ToolLoopCapturingProvider()
 


### PR DESCRIPTION
## Summary
- enforce adjacent assistant tool_use -> tool_result pairing before provider requests
- run tool pairing repair after provider-view history transformations
- add regression coverage for non-adjacent stale tool results

## Tests
- /home/weihe/work/code/rhythm/opensquilla/.venv/bin/pytest tests/test_engine/test_session_sanitize.py::test_agent_provider_view_prunes_non_adjacent_tool_results
- /home/weihe/work/code/rhythm/opensquilla/.venv/bin/pytest tests/test_provider_openai_compat_payloads.py::test_deepseek_tool_replay_preserves_reasoning_content_in_payload tests/test_provider_openai_compat_payloads.py::test_deepseek_v4_tool_replay_adds_empty_reasoning_content_when_missing tests/test_engine/test_execution_status_carrier_chain.py
- /home/weihe/work/code/rhythm/opensquilla/.venv/bin/python -m ruff check src/opensquilla/engine/history.py src/opensquilla/engine/agent.py tests/test_engine/test_session_sanitize.py

## Note
Full tests/test_engine/test_session_sanitize.py on origin/main currently has an unrelated _check_context_overflow signature mismatch.