### PR TITLE
Harden Slack Socket Mode routing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ module = [
     "src.router.*",
     "tiktoken.*",
     "tokenizers.*",
+    "websockets.*",
     "yaml.*",
     "yoyo.*",
 ]

--- a/src/opensquilla/channels/slack.py
+++ b/src/opensquilla/channels/slack.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import hmac
 import json
@@ -81,6 +82,11 @@ class SlackChannel:
     reply_in_thread: bool = False
     signing_secret: str | None = None
     status_reactions_enabled: bool = False
+    # Transport selection. ``socket`` uses Slack Socket Mode (an outbound
+    # websocket long-connection) and needs no public Request URL; it requires
+    # ``app_token`` (an ``xapp-`` App-Level Token with ``connections:write``).
+    connection_mode: str = "webhook"
+    app_token: str = ""
     # ``policy`` declares the admit/deny semantics consumed by
     # ``opensquilla.channels._util.evaluate_policy``. Slack admits DMs, admits
     # group messages only when the bot is mentioned, and applies no
@@ -105,7 +111,14 @@ class SlackChannel:
         init=False,
         repr=False,
     )
+    _socket_task: asyncio.Task | None = field(default=None, init=False, repr=False)
+    _socket_stop: asyncio.Event | None = field(default=None, init=False, repr=False)
     supports_slash_commands: bool = True
+
+    @property
+    def transport_name(self) -> str:
+        """``websocket`` in Socket Mode so the gateway skips webhook routing."""
+        return "websocket" if self.connection_mode == "socket" else "webhook"
 
     @property
     def capability_profile(self) -> ChannelCapabilityProfile:
@@ -121,7 +134,7 @@ class SlackChannel:
             thread_reply=True,
             edit=True,
             delete=True,
-            transports=("webhook",),
+            transports=(self.transport_name,),
         )
 
     @property
@@ -234,35 +247,62 @@ class SlackChannel:
             metadata=metadata,
         )
 
+    def build_reply_message(self, content: str, inbound: IncomingMessage) -> OutgoingMessage:
+        """Target the inbound conversation so batch replies need no static channel id."""
+        return OutgoingMessage(content=content, reply_to=inbound.channel_id)
+
+    def streaming_reply_kwargs(self, inbound: IncomingMessage) -> dict[str, Any]:
+        """Stream the reply into the inbound conversation."""
+        return {"channel": inbound.channel_id}
+
     # ------------------------------------------------------------------
     # Outbound
     # ------------------------------------------------------------------
 
     async def send(self, message: OutgoingMessage) -> None:
-        """Post a message to the Slack channel via chat.postMessage."""
-        payload: dict[str, Any] = {
-            "channel": self.slack_channel_id,
-            "text": message.content,
-        }
-        if message.reply_to:
-            payload["thread_ts"] = message.reply_to
-        elif self.reply_in_thread and self._last_thread_ts:
-            payload["thread_ts"] = self._last_thread_ts
-        if message.metadata:
-            if "thread_ts" in message.metadata and message.metadata["thread_ts"] is None:
-                payload.pop("thread_ts", None)
-            payload.update(
-                {key: value for key, value in message.metadata.items() if value is not None}
-            )
+        """Post a message to the originating Slack conversation.
+
+        The destination is resolved from ``reply_to`` — the gateway routes the
+        source conversation there — so the bot answers wherever it was
+        addressed without a statically configured ``slack_channel_id``. Slack
+        conversation ids are prefixed ``C``/``G``/``D``; a bare message
+        timestamp is treated as a thread anchor instead. An explicit
+        ``metadata['channel']`` / ``metadata['thread_ts']`` still wins.
+        """
+        meta = message.metadata or {}
+        channel = self.slack_channel_id
+        thread_ts: str | None = None
+        rt = (message.reply_to or "").strip()
+        if rt[:1] in ("C", "G", "D"):
+            channel = rt
+        elif rt:
+            thread_ts = rt
+        if meta.get("channel"):
+            channel = str(meta["channel"])
+        if "thread_ts" in meta:
+            thread_ts = meta["thread_ts"]
+        elif thread_ts is None and self.reply_in_thread and self._last_thread_ts:
+            thread_ts = self._last_thread_ts
+        if not channel:
+            log.error("slack.send_failed", channel="", error="no_target_channel")
+            raise RuntimeError("Slack send has no target channel")
+
+        payload: dict[str, Any] = {"channel": channel, "text": message.content}
+        if thread_ts:
+            payload["thread_ts"] = thread_ts
+        for key, value in meta.items():
+            if key in ("channel", "thread_ts") or value is None:
+                continue
+            payload[key] = value
 
         client = self._get_client()
         resp = await client.post("/chat.postMessage", json=payload)
         resp.raise_for_status()
         data = resp.json()
         if not data.get("ok"):
-            log.error("slack.send_failed", error=data.get("error"), channel=self.slack_channel_id)
+            log.error("slack.send_failed", channel=channel, error=data.get("error"))
             raise RuntimeError(f"Slack API error: {data.get('error')}")
-        log.debug("slack.send", channel=self.slack_channel_id, ts=data.get("ts"))
+        log.debug("slack.send", channel=channel, ts=data.get("ts"))
 
     async def send_file(
         self,
@@ -349,25 +389,30 @@ class SlackChannel:
         self,
         chunks: AsyncIterator[str],
         *,
+        channel: str | None = None,
         thread_ts: str | None = None,
         update_interval_ms: int = 500,
     ) -> str | None:
         """Send a streaming message: post first chunk, update with subsequent chunks.
 
         Returns the message ``ts`` or ``None`` if the iterator was empty.
+        ``channel`` targets the originating conversation (defaulting to
+        ``slack_channel_id``) so a streamed reply lands where the bot was
+        addressed without a statically configured channel.
 
         Uses ``StreamThrottle`` so a fast producer cannot fire two
         concurrent ``chat.update`` calls and a single network failure
         does not lose accumulated text.
         """
         client = self._get_client()
+        target = channel or self.slack_channel_id
         throttle = StreamThrottle(interval_s=update_interval_ms / 1000.0)
         message_ts: str | None = None
 
         async def _post(text: str) -> None:
             nonlocal message_ts
             payload: dict[str, Any] = {
-                "channel": self.slack_channel_id,
+                "channel": target,
                 "text": text,
             }
             if thread_ts:
@@ -384,7 +429,7 @@ class SlackChannel:
             resp = await client.post(
                 "/chat.update",
                 json={
-                    "channel": self.slack_channel_id,
+                    "channel": target,
                     "ts": message_ts,
                     "text": text,
                 },
@@ -433,7 +478,8 @@ class SlackChannel:
     # ------------------------------------------------------------------
 
     async def start(self) -> None:
-        """Validate token via auth.test and store bot_user_id."""
+        """Validate the bot token, store ``bot_user_id``, and — in Socket Mode —
+        open the Slack Socket Mode long-connection."""
         client = self._get_client()
         resp = await client.post("/auth.test")
         resp.raise_for_status()
@@ -441,16 +487,104 @@ class SlackChannel:
         if not data.get("ok"):
             raise SlackAuthError(data.get("error", "unknown auth error"))
         self.bot_user_id = data["user_id"]
+        if self.connection_mode == "socket":
+            if not self.app_token:
+                raise SlackAuthError(
+                    "connection_mode='socket' requires app_token (an xapp- App-Level Token)"
+                )
+            self._socket_stop = asyncio.Event()
+            self._socket_task = asyncio.create_task(
+                self._run_socket_loop(), name="slack-socket-mode"
+            )
         self._connected = True
-        log.info("slack.started", bot_user_id=self.bot_user_id)
+        log.info("slack.started", bot_user_id=self.bot_user_id, mode=self.connection_mode)
 
     async def stop(self) -> None:
         """Gracefully shut down the channel adapter."""
+        if self._socket_stop is not None:
+            self._socket_stop.set()
+        if self._socket_task is not None:
+            self._socket_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._socket_task
+            self._socket_task = None
         if self._client is not None:
             await self._client.aclose()
             self._client = None
         self._connected = False
         log.info("slack.stopped")
+
+    # ------------------------------------------------------------------
+    # Socket Mode transport (no public Request URL required)
+    # ------------------------------------------------------------------
+
+    async def _open_socket_connection(self) -> str:
+        """Open a Socket Mode session and return the issued ``wss://`` url."""
+        client = self._get_client()
+        resp = await client.post(
+            "/apps.connections.open",
+            headers={"Authorization": f"Bearer {self.app_token}"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if not data.get("ok"):
+            raise SlackAuthError(f"apps.connections.open failed: {data.get('error')}")
+        return str(data["url"])
+
+    async def _run_socket_loop(self) -> None:
+        """Maintain the Socket Mode websocket, reconnecting with backoff."""
+        import websockets
+
+        backoff = 1.0
+        stop = self._socket_stop
+        while stop is None or not stop.is_set():
+            try:
+                ws_url = await self._open_socket_connection()
+                async with websockets.connect(
+                    ws_url, ping_interval=30, ping_timeout=20, max_size=None
+                ) as ws:
+                    self._connected = True
+                    backoff = 1.0
+                    log.info("slack.socket_mode.connected")
+                    async for raw in ws:
+                        if stop is not None and stop.is_set():
+                            break
+                        await self._handle_socket_frame(ws, raw)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._connected = False
+                log.warning("slack.socket_mode.reconnect", error=str(exc), backoff=backoff)
+                if stop is None:
+                    break
+                with contextlib.suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(stop.wait(), timeout=backoff)
+                if stop.is_set():
+                    break
+                backoff = min(backoff * 2, 30.0)
+
+    async def _handle_socket_frame(self, ws: Any, raw: str | bytes) -> None:
+        """Ack and dispatch a single Socket Mode frame."""
+        try:
+            msg = json.loads(raw)
+        except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
+            return
+        # Slack requires an ack (echo the envelope id) within 3 seconds.
+        envelope_id = msg.get("envelope_id")
+        if envelope_id:
+            with contextlib.suppress(Exception):
+                await ws.send(json.dumps({"envelope_id": envelope_id}))
+        mtype = msg.get("type")
+        if mtype == "disconnect":
+            # Slack rotates connections periodically; close so the loop reconnects.
+            with contextlib.suppress(Exception):
+                await ws.close()
+            return
+        if mtype != "events_api":
+            return
+        payload = msg.get("payload")
+        if isinstance(payload, dict) and payload.get("type") == "event_callback":
+            self._ingest_event_callback(payload)
 
     def is_connected(self) -> bool:
         """Return whether the adapter has been started and is connected."""
@@ -497,19 +631,36 @@ class SlackChannel:
             return JSONResponse({"challenge": challenge})
 
         if event_type == "event_callback":
-            event = data.get("event", {})
-            if event.get("type") == "message":
-                dedupe_key = str(
-                    data.get("event_id")
-                    or event.get("client_msg_id")
-                    or f"{event.get('channel', '')}:{event.get('ts', '')}"
-                ).strip(":")
-                if dedupe_key and not self._dedupe.check_and_add(dedupe_key):
-                    return Response(status_code=200)
-                msg = self.parse_event(event)
-                self.enqueue(msg)
+            self._ingest_event_callback(data)
 
         return Response(status_code=200)
+
+    def _ingest_event_callback(self, data: dict[str, Any]) -> None:
+        """Shared inbound path for an Events API ``event_callback`` payload,
+        used by both the webhook handler and the Socket Mode loop."""
+        event = data.get("event", {})
+        if not isinstance(event, dict) or event.get("type") != "message":
+            return
+        # Only plain user messages are input; drop edits/deletes/joins and the
+        # bot's own streaming-edit echoes (``message_changed`` etc.).
+        if event.get("subtype") not in (None, "file_share", "me_message", "thread_broadcast"):
+            return
+        if self._is_own_message(event):
+            return
+        dedupe_key = str(
+            data.get("event_id")
+            or event.get("client_msg_id")
+            or f"{event.get('channel', '')}:{event.get('ts', '')}"
+        ).strip(":")
+        if dedupe_key and not self._dedupe.check_and_add(dedupe_key):
+            return
+        self.enqueue(self.parse_event(event))
+
+    def _is_own_message(self, event: dict[str, Any]) -> bool:
+        """Drop the bot's own messages so replies never loop back as input."""
+        if event.get("subtype") == "bot_message" or event.get("bot_id"):
+            return True
+        return bool(self.bot_user_id and event.get("user") == self.bot_user_id)
 
     def _verify_signature(self, body: bytes, timestamp: str, signature: str) -> bool:
         """Verify Slack request signature using HMAC-SHA256."""

--- a/src/opensquilla/channels/slack.py
+++ b/src/opensquilla/channels/slack.py
@@ -249,11 +249,25 @@ class SlackChannel:
 
     def build_reply_message(self, content: str, inbound: IncomingMessage) -> OutgoingMessage:
         """Target the inbound conversation so batch replies need no static channel id."""
-        return OutgoingMessage(content=content, reply_to=inbound.channel_id)
+        metadata: dict[str, Any] = {}
+        if thread_ts := self._reply_thread_ts(inbound):
+            metadata["thread_ts"] = thread_ts
+        return OutgoingMessage(content=content, reply_to=inbound.channel_id, metadata=metadata)
 
     def streaming_reply_kwargs(self, inbound: IncomingMessage) -> dict[str, Any]:
         """Stream the reply into the inbound conversation."""
-        return {"channel": inbound.channel_id}
+        kwargs = {"channel": inbound.channel_id}
+        if thread_ts := self._reply_thread_ts(inbound):
+            kwargs["thread_ts"] = thread_ts
+        return kwargs
+
+    def _reply_thread_ts(self, inbound: IncomingMessage) -> str | None:
+        """Resolve the Slack thread target for a reply to ``inbound``."""
+        if not self.reply_in_thread:
+            return None
+        metadata = inbound.metadata or {}
+        raw = metadata.get("thread_ts") or metadata.get("ts")
+        return str(raw) if raw else None
 
     # ------------------------------------------------------------------
     # Outbound
@@ -262,8 +276,8 @@ class SlackChannel:
     async def send(self, message: OutgoingMessage) -> None:
         """Post a message to the originating Slack conversation.
 
-        The destination is resolved from ``reply_to`` — the gateway routes the
-        source conversation there — so the bot answers wherever it was
+        The destination is resolved from ``reply_to``: the gateway routes the
+        source conversation there, so the bot answers wherever it was
         addressed without a statically configured ``slack_channel_id``. Slack
         conversation ids are prefixed ``C``/``G``/``D``; a bare message
         timestamp is treated as a thread anchor instead. An explicit
@@ -406,6 +420,9 @@ class SlackChannel:
         """
         client = self._get_client()
         target = channel or self.slack_channel_id
+        if not target:
+            log.error("slack.stream_failed", channel="", error="no_target_channel")
+            raise RuntimeError("Slack stream has no target channel")
         throttle = StreamThrottle(interval_s=update_interval_ms / 1000.0)
         message_ts: str | None = None
 
@@ -478,7 +495,7 @@ class SlackChannel:
     # ------------------------------------------------------------------
 
     async def start(self) -> None:
-        """Validate the bot token, store ``bot_user_id``, and — in Socket Mode —
+        """Validate the bot token, store ``bot_user_id``, and - in Socket Mode -
         open the Slack Socket Mode long-connection."""
         client = self._get_client()
         resp = await client.post("/auth.test")
@@ -492,9 +509,10 @@ class SlackChannel:
                 raise SlackAuthError(
                     "connection_mode='socket' requires app_token (an xapp- App-Level Token)"
                 )
+            initial_socket_url = await self._open_socket_connection()
             self._socket_stop = asyncio.Event()
             self._socket_task = asyncio.create_task(
-                self._run_socket_loop(), name="slack-socket-mode"
+                self._run_socket_loop(initial_socket_url), name="slack-socket-mode"
             )
         self._connected = True
         log.info("slack.started", bot_user_id=self.bot_user_id, mode=self.connection_mode)
@@ -531,15 +549,17 @@ class SlackChannel:
             raise SlackAuthError(f"apps.connections.open failed: {data.get('error')}")
         return str(data["url"])
 
-    async def _run_socket_loop(self) -> None:
+    async def _run_socket_loop(self, initial_socket_url: str | None = None) -> None:
         """Maintain the Socket Mode websocket, reconnecting with backoff."""
         import websockets
 
         backoff = 1.0
         stop = self._socket_stop
+        next_socket_url = initial_socket_url
         while stop is None or not stop.is_set():
             try:
-                ws_url = await self._open_socket_connection()
+                ws_url = next_socket_url or await self._open_socket_connection()
+                next_socket_url = None
                 async with websockets.connect(
                     ws_url, ping_interval=30, ping_timeout=20, max_size=None
                 ) as ws:
@@ -553,6 +573,7 @@ class SlackChannel:
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
+                next_socket_url = None
                 self._connected = False
                 log.warning("slack.socket_mode.reconnect", error=str(exc), backoff=backoff)
                 if stop is None:

--- a/src/opensquilla/channels/slack.py
+++ b/src/opensquilla/channels/slack.py
@@ -249,7 +249,7 @@ class SlackChannel:
 
     def build_reply_message(self, content: str, inbound: IncomingMessage) -> OutgoingMessage:
         """Target the inbound conversation so batch replies need no static channel id."""
-        metadata: dict[str, Any] = {}
+        metadata: dict[str, Any] = {"channel": inbound.channel_id}
         if thread_ts := self._reply_thread_ts(inbound):
             metadata["thread_ts"] = thread_ts
         return OutgoingMessage(content=content, reply_to=inbound.channel_id, metadata=metadata)

--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -660,12 +660,15 @@ async def _dispatch_channel_slash_command(
             context_factory=context_factory,
         )
 
-    return await DEFAULT_COMMAND_REGISTRY.dispatch(
+    reply = await DEFAULT_COMMAND_REGISTRY.dispatch(
         envelope=route_envelope,
         message_content=msg.content,
         rpc_dispatcher=rpc_dispatcher,
         context_factory=context_factory,
     )
+    if reply is None:
+        return None
+    return _preserve_route_channel_metadata(reply, route_envelope)
 
 
 async def _dispatch_channel_new_command(
@@ -719,7 +722,7 @@ async def _dispatch_channel_new_command(
             route_envelope,
             metadata={"command": "new", "method": "sessions.reset", "denied": False},
         )
-    return reply
+    return _preserve_route_channel_metadata(reply, route_envelope)
 
 
 # fmt: off
@@ -1205,6 +1208,27 @@ def _route_envelope_reply_message(
             content=content,
             reply_to=thread_id or channel_id,
             metadata=merged_metadata,
+        )
+    )
+
+
+def _preserve_route_channel_metadata(
+    reply: OutgoingMessage,
+    route_envelope: Any,
+) -> OutgoingMessage:
+    """Add route channel metadata to thread-targeted replies when needed."""
+    channel_id = getattr(route_envelope, "channel_id", None)
+    thread_id = getattr(route_envelope, "thread_id", None)
+    if not channel_id or not thread_id or reply.reply_to != thread_id:
+        return _sanitize_outgoing_message(reply)
+    metadata = dict(reply.metadata or {})
+    metadata.setdefault("channel", channel_id)
+    return _sanitize_outgoing_message(
+        OutgoingMessage(
+            content=reply.content,
+            attachments=list(reply.attachments),
+            metadata=metadata,
+            reply_to=reply.reply_to,
         )
     )
 

--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -451,9 +451,9 @@ async def run_channel_dispatch(
                     cap=_in_flight.cap,
                 )
                 await channel.send(
-                    OutgoingMessage(
-                        content="Server busy, please retry",
-                        reply_to=route_envelope.thread_id or route_envelope.channel_id,
+                    _route_envelope_reply_message(
+                        "Server busy, please retry",
+                        route_envelope,
                     )
                 )
                 await status_reactor.completed(msg)
@@ -510,12 +510,12 @@ async def run_channel_dispatch(
                     raise
                 await status_reactor.failed(msg)
                 await channel.send(
-                    OutgoingMessage(
-                        content=(
+                    _route_envelope_reply_message(
+                        (
                             "The session task queue is full. "
                             f"Try again after queued work completes. ({exc})"
                         ),
-                        reply_to=route_envelope.thread_id or route_envelope.channel_id,
+                        route_envelope,
                     )
                 )
             else:
@@ -642,9 +642,9 @@ async def _dispatch_channel_slash_command(
         head = _slash_command_head(msg.content)
         if head is None:
             return None
-        return OutgoingMessage(
-            content=f"Unsupported command: {head}. Try /help.",
-            reply_to=route_envelope.thread_id or route_envelope.channel_id,
+        return _route_envelope_reply_message(
+            f"Unsupported command: {head}. Try /help.",
+            route_envelope,
             metadata={"command": head[1:].lower(), "method": None, "unsupported": True},
         )
 
@@ -691,12 +691,12 @@ async def _dispatch_channel_new_command(
     )
     if not allowed:
         detail = f": missing {missing}" if missing else ""
-        return OutgoingMessage(
-            content=(
+        return _route_envelope_reply_message(
+            (
                 "/new denied: Insufficient scope for method: "
                 f"sessions.reset{detail}"
             ),
-            reply_to=route_envelope.thread_id or route_envelope.channel_id,
+            route_envelope,
             metadata={"command": "new", "method": "sessions.reset", "denied": True},
         )
 
@@ -714,9 +714,9 @@ async def _dispatch_channel_new_command(
         context_factory=lambda _envelope: ctx,
     )
     if reply is None:
-        return OutgoingMessage(
-            content="/new failed: command unavailable",
-            reply_to=route_envelope.thread_id or route_envelope.channel_id,
+        return _route_envelope_reply_message(
+            "/new failed: command unavailable",
+            route_envelope,
             metadata={"command": "new", "method": "sessions.reset", "denied": False},
         )
     return reply
@@ -764,9 +764,9 @@ async def _dispatch_combined_message_after_debounce(channel: Any, combined: Any,
                 cap=_in_flight.cap,
             )
             await channel.send(
-                OutgoingMessage(
-                    content="Server busy, please retry",
-                    reply_to=route_envelope.thread_id or route_envelope.channel_id,
+                _route_envelope_reply_message(
+                    "Server busy, please retry",
+                    route_envelope,
                 )
             )
             await status_reactor.completed(msg)
@@ -804,7 +804,7 @@ async def _dispatch_combined_message_after_debounce(channel: Any, combined: Any,
         if isinstance(exc, TaskQueueFullError):
             await status_reactor.failed(msg)
             log.warning("channel_dispatch.debounce_enqueue_failed", session_key=session_key, reason="queue_full", coalesced_count=combined.coalesced_count)  # noqa: E501
-            await channel.send(OutgoingMessage(content="Your messages couldn't be processed because the queue is full. Please retry.", reply_to=route_envelope.thread_id or route_envelope.channel_id))  # noqa: E501
+            await channel.send(_route_envelope_reply_message("Your messages couldn't be processed because the queue is full. Please retry.", route_envelope))  # noqa: E501
             return
         log.exception("channel_dispatch.debounce_enqueue_failed", session_key=session_key, reason="unexpected")  # noqa: E501
         await status_reactor.failed(msg)
@@ -1186,6 +1186,27 @@ def _build_reply_message(channel: Any, content: str, msg: IncomingMessage) -> Ou
         if isinstance(reply, OutgoingMessage):
             return _sanitize_outgoing_message(reply)
     return _sanitize_outgoing_message(OutgoingMessage(content=content))
+
+
+def _route_envelope_reply_message(
+    content: str,
+    route_envelope: Any,
+    *,
+    metadata: dict[str, Any] | None = None,
+) -> OutgoingMessage:
+    """Build a reply that preserves channel id when targeting a thread id."""
+    channel_id = getattr(route_envelope, "channel_id", None)
+    thread_id = getattr(route_envelope, "thread_id", None)
+    merged_metadata = dict(metadata or {})
+    if thread_id and channel_id:
+        merged_metadata.setdefault("channel", channel_id)
+    return _sanitize_outgoing_message(
+        OutgoingMessage(
+            content=content,
+            reply_to=thread_id or channel_id,
+            metadata=merged_metadata,
+        )
+    )
 
 
 def _status_reactor(channel: Any) -> Any:

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -1095,6 +1095,11 @@ class SlackChannelEntry(ConfiguredChannelEntry):
     slack_channel_id: str = ""
     signing_secret: str | None = None
     reply_in_thread: bool = False
+    # ``socket`` uses Slack Socket Mode (an outbound websocket long-connection,
+    # like Feishu) and needs no public Request URL; ``webhook`` keeps the
+    # Events API webhook. Socket Mode additionally requires ``app_token``.
+    connection_mode: Literal["webhook", "socket"] = "webhook"
+    app_token: str = ""
 
 
 class FeishuChannelEntry(ConfiguredChannelEntry):

--- a/src/opensquilla/onboarding/channel_specs.py
+++ b/src/opensquilla/onboarding/channel_specs.py
@@ -94,8 +94,7 @@ def _slack_spec() -> ChannelSetupSpec:
                               required=False, default=False),
             ChannelSetupField("connection_mode", "Connection mode", "select",
                               required=False, default="webhook",
-                              choices=("webhook", "socket"),
-                              advanced=True),
+                              choices=("webhook", "socket")),
         ),
     )
 

--- a/src/opensquilla/onboarding/channel_specs.py
+++ b/src/opensquilla/onboarding/channel_specs.py
@@ -62,25 +62,39 @@ def _slack_spec() -> ChannelSetupSpec:
     return ChannelSetupSpec(
         type="slack",
         label="Slack",
-        description="Slack workspace bot using bot token + signing secret.",
-        transport="webhook",
-        requires_public_url=True,
+        description="Slack workspace bot — Socket Mode (websocket) or Events API webhook.",
+        transport="mixed",
+        requires_public_url=False,
         dependency_extra=None,
         restart_required=True,
         docs_hint="https://api.slack.com/apps",
-        help="Slack webhooks require a public URL reachable by Slack.",
+        help=(
+            "connection_mode=socket uses Slack Socket Mode (an outbound websocket) and "
+            "needs no public URL — set app_token (xapp-...). connection_mode=webhook uses "
+            "the Events API and needs a public Request URL reachable by Slack."
+        ),
         fields=(
             *_common_fields(),
             ChannelSetupField("token", "Bot token (xoxb-...)", "password",
                               required=True, secret=True, group="credentials",
                               placeholder="xoxb-..."),
+            ChannelSetupField("app_token", "App-level token (xapp-...)", "password",
+                              required=False, secret=True, group="credentials",
+                              placeholder="xapp-...",
+                              show_when={"connection_mode": "socket"}),
             ChannelSetupField("slack_channel_id", "Default channel id", "text",
-                              required=False, default=""),
+                              required=False, default="",
+                              description="Optional; replies auto-target the incoming "
+                              "conversation when unset."),
             ChannelSetupField("signing_secret", "Signing secret", "password",
                               required=False, secret=True, group="credentials",
-                              advanced=True),
+                              advanced=True,
+                              show_when={"connection_mode": "webhook"}),
             ChannelSetupField("reply_in_thread", "Reply in thread", "bool",
                               required=False, default=False),
+            ChannelSetupField("connection_mode", "Connection mode", "select",
+                              required=False, default="webhook",
+                              choices=("webhook", "socket")),
         ),
     )
 

--- a/src/opensquilla/onboarding/channel_specs.py
+++ b/src/opensquilla/onboarding/channel_specs.py
@@ -62,7 +62,7 @@ def _slack_spec() -> ChannelSetupSpec:
     return ChannelSetupSpec(
         type="slack",
         label="Slack",
-        description="Slack workspace bot — Socket Mode (websocket) or Events API webhook.",
+        description="Slack workspace bot - Socket Mode (websocket) or Events API webhook.",
         transport="mixed",
         requires_public_url=False,
         dependency_extra=None,
@@ -70,7 +70,7 @@ def _slack_spec() -> ChannelSetupSpec:
         docs_hint="https://api.slack.com/apps",
         help=(
             "connection_mode=socket uses Slack Socket Mode (an outbound websocket) and "
-            "needs no public URL — set app_token (xapp-...). connection_mode=webhook uses "
+            "needs no public URL - set app_token (xapp-...). connection_mode=webhook uses "
             "the Events API and needs a public Request URL reachable by Slack."
         ),
         fields=(
@@ -94,7 +94,8 @@ def _slack_spec() -> ChannelSetupSpec:
                               required=False, default=False),
             ChannelSetupField("connection_mode", "Connection mode", "select",
                               required=False, default="webhook",
-                              choices=("webhook", "socket")),
+                              choices=("webhook", "socket"),
+                              advanced=True),
         ),
     )
 

--- a/src/opensquilla/onboarding/flow.py
+++ b/src/opensquilla/onboarding/flow.py
@@ -1093,7 +1093,7 @@ def _should_prompt_channel_field(
     if field.required:
         return True
     if field.name in controls:
-        return not field.advanced
+        return True
     if field.show_when and field.default in (None, ""):
         return True
     return False

--- a/src/opensquilla/onboarding/flow.py
+++ b/src/opensquilla/onboarding/flow.py
@@ -1095,7 +1095,7 @@ def _should_prompt_channel_field(
     if field.name in controls:
         return True
     if field.show_when and field.default in (None, ""):
-        return True
+        return not field.advanced
     return False
 
 

--- a/src/opensquilla/onboarding/flow.py
+++ b/src/opensquilla/onboarding/flow.py
@@ -1093,7 +1093,7 @@ def _should_prompt_channel_field(
     if field.required:
         return True
     if field.name in controls:
-        return True
+        return not field.advanced
     if field.show_when and field.default in (None, ""):
         return True
     return False

--- a/tests/test_channels/test_slack_socket_mode.py
+++ b/tests/test_channels/test_slack_socket_mode.py
@@ -1,0 +1,139 @@
+"""Slack Socket Mode transport, auto-target replies, and self-echo filtering."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from opensquilla.channels.slack import SlackAuthError, SlackChannel
+from opensquilla.channels.types import IncomingMessage, OutgoingMessage
+
+
+def _mk(**kwargs: Any) -> SlackChannel:
+    kwargs.setdefault("slack_channel_id", "")
+    ch = SlackChannel(token="xoxb-test", **kwargs)
+    ch.bot_user_id = "UBOT"
+    return ch
+
+
+class _FakeResp:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def post(
+        self, path: str, json: dict[str, Any] | None = None, headers: Any = None
+    ) -> _FakeResp:
+        self.calls.append((path, json))
+        if path == "/auth.test":
+            return _FakeResp({"ok": True, "user_id": "UBOT"})
+        return _FakeResp({"ok": True, "ts": "1700000000.000100"})
+
+
+# ── transport selection ───────────────────────────────────────────────────
+
+
+def test_transport_name_follows_connection_mode() -> None:
+    assert _mk().transport_name == "webhook"
+    assert _mk(connection_mode="socket").transport_name == "websocket"
+
+
+async def test_socket_mode_requires_app_token() -> None:
+    ch = _mk(connection_mode="socket")  # no app_token
+    ch._get_client = lambda: _FakeClient()  # type: ignore[method-assign]
+    with pytest.raises(SlackAuthError):
+        await ch.start()
+
+
+# ── inbound filtering (the self-echo / loop guard) ─────────────────────────
+
+
+def test_ingest_accepts_plain_user_message() -> None:
+    ch = _mk()
+    ch._ingest_event_callback(
+        {
+            "event_id": "Ev1",
+            "event": {
+                "type": "message",
+                "user": "UUSER",
+                "channel": "D123",
+                "text": "hi",
+                "ts": "1.1",
+            },
+        }
+    )
+    assert ch._queue.qsize() == 1
+    msg = ch._queue.get_nowait()
+    assert msg.channel_id == "D123"
+    assert msg.content == "hi"
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"type": "message", "bot_id": "B1", "channel": "D1", "text": "x", "ts": "2"},
+        {"type": "message", "user": "UBOT", "channel": "D1", "text": "x", "ts": "3"},
+        {"type": "message", "subtype": "bot_message", "channel": "D1", "text": "x", "ts": "4"},
+        {"type": "message", "subtype": "message_changed", "channel": "D1", "ts": "5"},
+        {"type": "message", "subtype": "message_deleted", "channel": "D1", "ts": "6"},
+    ],
+)
+def test_ingest_drops_self_echoes_and_non_user_subtypes(event: dict[str, Any]) -> None:
+    ch = _mk()
+    ch._ingest_event_callback({"event_id": f"e-{event.get('ts')}", "event": event})
+    assert ch._queue.qsize() == 0
+
+
+def test_ingest_dedupes_replayed_event() -> None:
+    ch = _mk()
+    payload = {
+        "event_id": "Dup1",
+        "event": {"type": "message", "user": "U", "channel": "D1", "text": "hi", "ts": "9"},
+    }
+    ch._ingest_event_callback(payload)
+    ch._ingest_event_callback(payload)
+    assert ch._queue.qsize() == 1
+
+
+# ── outbound: auto-target the originating conversation ─────────────────────
+
+
+async def test_send_auto_targets_reply_conversation() -> None:
+    ch = _mk()  # slack_channel_id empty on purpose
+    fake = _FakeClient()
+    ch._get_client = lambda: fake  # type: ignore[method-assign]
+    await ch.send(OutgoingMessage(content="hello", reply_to="D999"))
+    post = next(c for c in fake.calls if c[0] == "/chat.postMessage")
+    assert post[1] is not None
+    assert post[1]["channel"] == "D999"
+    # A conversation id must NOT be misused as a thread anchor.
+    assert "thread_ts" not in post[1]
+
+
+async def test_send_threads_only_on_message_ts() -> None:
+    ch = _mk(slack_channel_id="C1")
+    fake = _FakeClient()
+    ch._get_client = lambda: fake  # type: ignore[method-assign]
+    await ch.send(OutgoingMessage(content="hi", reply_to="1700000000.000200"))
+    post = next(c for c in fake.calls if c[0] == "/chat.postMessage")
+    assert post[1] is not None
+    assert post[1]["channel"] == "C1"
+    assert post[1]["thread_ts"] == "1700000000.000200"
+
+
+def test_reply_helpers_target_inbound_conversation() -> None:
+    ch = _mk()
+    inbound = IncomingMessage(sender_id="U", channel_id="D42", content="hi")
+    assert ch.build_reply_message("r", inbound).reply_to == "D42"
+    assert ch.streaming_reply_kwargs(inbound) == {"channel": "D42"}

--- a/tests/test_channels/test_slack_socket_mode.py
+++ b/tests/test_channels/test_slack_socket_mode.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
 
+from opensquilla.channels.manager import ChannelManager
 from opensquilla.channels.slack import SlackAuthError, SlackChannel
 from opensquilla.channels.types import IncomingMessage, OutgoingMessage
 
@@ -30,18 +32,21 @@ class _FakeResp:
 
 class _FakeClient:
     def __init__(self) -> None:
-        self.calls: list[tuple[str, dict[str, Any] | None]] = []
+        self.calls: list[tuple[str, dict[str, Any] | None, Any]] = []
+        self.socket_open_payload: dict[str, Any] = {
+            "ok": True,
+            "url": "wss://socket.slack.test/session",
+        }
 
     async def post(
         self, path: str, json: dict[str, Any] | None = None, headers: Any = None
     ) -> _FakeResp:
-        self.calls.append((path, json))
+        self.calls.append((path, json, headers))
         if path == "/auth.test":
             return _FakeResp({"ok": True, "user_id": "UBOT"})
+        if path == "/apps.connections.open":
+            return _FakeResp(self.socket_open_payload)
         return _FakeResp({"ok": True, "ts": "1700000000.000100"})
-
-
-# ── transport selection ───────────────────────────────────────────────────
 
 
 def test_transport_name_follows_connection_mode() -> None:
@@ -56,7 +61,35 @@ async def test_socket_mode_requires_app_token() -> None:
         await ch.start()
 
 
-# ── inbound filtering (the self-echo / loop guard) ─────────────────────────
+async def test_socket_mode_validates_app_token_before_reporting_started() -> None:
+    ch = _mk(connection_mode="socket", app_token="xapp-valid")
+    fake = _FakeClient()
+    fake.socket_open_payload = {"ok": False, "error": "invalid_auth"}
+    ch._get_client = lambda: fake  # type: ignore[method-assign]
+    with pytest.raises(SlackAuthError, match="apps.connections.open failed"):
+        await ch.start()
+    assert ch.is_connected() is False
+
+
+async def test_socket_mode_start_passes_opened_url_to_background_loop() -> None:
+    ch = _mk(connection_mode="socket", app_token="xapp-valid")
+    fake = _FakeClient()
+    seen: list[str | None] = []
+
+    async def _fake_socket_loop(initial_socket_url: str | None = None) -> None:
+        seen.append(initial_socket_url)
+        await ch._socket_stop.wait()  # type: ignore[union-attr]
+
+    ch._get_client = lambda: fake  # type: ignore[method-assign]
+    ch._run_socket_loop = _fake_socket_loop  # type: ignore[method-assign]
+
+    await ch.start()
+    await asyncio.sleep(0)
+    await ch.stop()
+
+    assert seen == ["wss://socket.slack.test/session"]
+    open_call = next(c for c in fake.calls if c[0] == "/apps.connections.open")
+    assert open_call[2] == {"Authorization": "Bearer xapp-valid"}
 
 
 def test_ingest_accepts_plain_user_message() -> None:
@@ -106,7 +139,41 @@ def test_ingest_dedupes_replayed_event() -> None:
     assert ch._queue.qsize() == 1
 
 
-# ── outbound: auto-target the originating conversation ─────────────────────
+class _FakeSocket:
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.closed = False
+
+    async def send(self, payload: str) -> None:
+        self.sent.append(payload)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+async def test_socket_frame_acks_and_dispatches_events_api_payload() -> None:
+    ch = _mk()
+    ws = _FakeSocket()
+    await ch._handle_socket_frame(
+        ws,
+        (
+            '{"envelope_id":"env-1","type":"events_api","payload":'
+            '{"type":"event_callback","event_id":"Ev1","event":'
+            '{"type":"message","user":"UUSER","channel":"D123","text":"hi","ts":"1.1"}}}'
+        ),
+    )
+
+    assert ws.sent == ['{"envelope_id": "env-1"}']
+    assert ch._queue.qsize() == 1
+
+
+async def test_socket_frame_disconnect_closes_socket_after_ack() -> None:
+    ch = _mk()
+    ws = _FakeSocket()
+    await ch._handle_socket_frame(ws, '{"envelope_id":"env-2","type":"disconnect"}')
+
+    assert ws.sent == ['{"envelope_id": "env-2"}']
+    assert ws.closed is True
 
 
 async def test_send_auto_targets_reply_conversation() -> None:
@@ -137,3 +204,51 @@ def test_reply_helpers_target_inbound_conversation() -> None:
     inbound = IncomingMessage(sender_id="U", channel_id="D42", content="hi")
     assert ch.build_reply_message("r", inbound).reply_to == "D42"
     assert ch.streaming_reply_kwargs(inbound) == {"channel": "D42"}
+
+
+def test_reply_helpers_preserve_thread_target_when_enabled() -> None:
+    ch = _mk(reply_in_thread=True)
+    inbound = IncomingMessage(
+        sender_id="U",
+        channel_id="C42",
+        content="hi",
+        metadata={"ts": "1700000000.000200", "thread_ts": "1700000000.000100"},
+    )
+
+    reply = ch.build_reply_message("r", inbound)
+
+    assert reply.reply_to == "C42"
+    assert reply.metadata == {"thread_ts": "1700000000.000100"}
+    assert ch.streaming_reply_kwargs(inbound) == {
+        "channel": "C42",
+        "thread_ts": "1700000000.000100",
+    }
+
+
+def test_reply_helpers_thread_root_when_enabled() -> None:
+    ch = _mk(reply_in_thread=True)
+    inbound = IncomingMessage(
+        sender_id="U",
+        channel_id="C42",
+        content="hi",
+        metadata={"ts": "1700000000.000200"},
+    )
+
+    assert ch.build_reply_message("r", inbound).metadata == {
+        "thread_ts": "1700000000.000200"
+    }
+
+
+def test_channel_manager_skips_webhook_route_for_slack_socket_mode() -> None:
+    manager = ChannelManager(
+        _channels={
+            "webhook": _mk(connection_mode="webhook"),
+            "socket": _mk(connection_mode="socket", app_token="xapp-valid"),
+        },
+        _turn_runner=None,
+        _session_manager=None,
+    )
+
+    routes = manager.collect_webhook_routes()
+
+    assert [route.path for route in routes] == ["/slack/events"]

--- a/tests/test_channels/test_slack_socket_mode.py
+++ b/tests/test_channels/test_slack_socket_mode.py
@@ -199,10 +199,28 @@ async def test_send_threads_only_on_message_ts() -> None:
     assert post[1]["thread_ts"] == "1700000000.000200"
 
 
+async def test_send_thread_timestamp_uses_metadata_channel_without_default() -> None:
+    ch = _mk()
+    fake = _FakeClient()
+    ch._get_client = lambda: fake  # type: ignore[method-assign]
+    await ch.send(
+        OutgoingMessage(
+            content="hi",
+            reply_to="1700000000.000200",
+            metadata={"channel": "C42"},
+        )
+    )
+    post = next(c for c in fake.calls if c[0] == "/chat.postMessage")
+    assert post[1] is not None
+    assert post[1]["channel"] == "C42"
+    assert post[1]["thread_ts"] == "1700000000.000200"
+
+
 def test_reply_helpers_target_inbound_conversation() -> None:
     ch = _mk()
     inbound = IncomingMessage(sender_id="U", channel_id="D42", content="hi")
     assert ch.build_reply_message("r", inbound).reply_to == "D42"
+    assert ch.build_reply_message("r", inbound).metadata == {"channel": "D42"}
     assert ch.streaming_reply_kwargs(inbound) == {"channel": "D42"}
 
 
@@ -218,7 +236,10 @@ def test_reply_helpers_preserve_thread_target_when_enabled() -> None:
     reply = ch.build_reply_message("r", inbound)
 
     assert reply.reply_to == "C42"
-    assert reply.metadata == {"thread_ts": "1700000000.000100"}
+    assert reply.metadata == {
+        "channel": "C42",
+        "thread_ts": "1700000000.000100",
+    }
     assert ch.streaming_reply_kwargs(inbound) == {
         "channel": "C42",
         "thread_ts": "1700000000.000100",
@@ -235,6 +256,7 @@ def test_reply_helpers_thread_root_when_enabled() -> None:
     )
 
     assert ch.build_reply_message("r", inbound).metadata == {
+        "channel": "C42",
         "thread_ts": "1700000000.000200"
     }
 

--- a/tests/test_gateway/test_channel_dispatch_realtime.py
+++ b/tests/test_gateway/test_channel_dispatch_realtime.py
@@ -28,14 +28,17 @@ from opensquilla.gateway.channel_dispatch import (
     _build_reply_message,
     _deliver_artifacts_as_channel_files,
     _deliver_runtime_channel_reply,
+    _dispatch_channel_slash_command,
     _dispatch_combined_message_after_debounce,
     _ingest_channel_message_attachments,
+    _preserve_route_channel_metadata,
     _route_envelope_reply_message,
     _run_turn_batch_path,
     _run_turn_with_streaming,
     _RuntimeChannelStreamRelay,
 )
 from opensquilla.gateway.config import AgentEntryConfig, GatewayConfig
+from opensquilla.gateway.protocol import make_ok_res
 from opensquilla.gateway.routing import build_channel_route_envelope
 from opensquilla.safety.permission_matrix import Principal, is_tool_allowed
 from opensquilla.tools.types import CallerKind
@@ -89,6 +92,61 @@ def test_route_envelope_reply_preserves_channel_for_thread_target() -> None:
 
     assert reply.reply_to == "1700000000.000100"
     assert reply.metadata == {"channel": "C42"}
+
+
+def test_preserve_route_channel_metadata_for_registry_thread_reply() -> None:
+    route_envelope = SimpleNamespace(channel_id="C42", thread_id="1700000000.000100")
+    reply = OutgoingMessage(
+        content="done",
+        reply_to="1700000000.000100",
+        metadata={"command": "compact"},
+    )
+
+    fixed = _preserve_route_channel_metadata(reply, route_envelope)
+
+    assert fixed.reply_to == "1700000000.000100"
+    assert fixed.metadata == {"command": "compact", "channel": "C42"}
+
+
+@pytest.mark.asyncio
+async def test_registered_slash_command_preserves_channel_for_thread_target() -> None:
+    msg = IncomingMessage(
+        sender_id="U1",
+        channel_id="C42",
+        content="/compact",
+        metadata={"thread_ts": "1700000000.000100"},
+    )
+    route_envelope = build_channel_route_envelope(
+        msg,
+        session_key="agent:main:slack:group:C42:thread:1700000000.000100",
+        session_prefix="slack",
+        agent_id="main",
+    )
+
+    class FakeDispatcher:
+        async def dispatch(self, req_id, method, params, ctx):
+            return make_ok_res(
+                req_id,
+                {
+                    "status": "skipped",
+                    "compacted": False,
+                },
+            )
+
+    reply = await _dispatch_channel_slash_command(
+        route_envelope=route_envelope,
+        msg=msg,
+        session_manager=object(),
+        session_key=route_envelope.session_key,
+        session_prefix="slack",
+        rpc_dispatcher=FakeDispatcher(),
+        context_factory=lambda _envelope: object(),
+    )
+
+    assert reply is not None
+    assert reply.reply_to == "1700000000.000100"
+    assert reply.metadata["channel"] == "C42"
+    assert reply.metadata["command"] == "compact"
 
 
 def test_channel_stream_policy_prefers_adapter_stream_updates() -> None:

--- a/tests/test_gateway/test_channel_dispatch_realtime.py
+++ b/tests/test_gateway/test_channel_dispatch_realtime.py
@@ -30,6 +30,7 @@ from opensquilla.gateway.channel_dispatch import (
     _deliver_runtime_channel_reply,
     _dispatch_combined_message_after_debounce,
     _ingest_channel_message_attachments,
+    _route_envelope_reply_message,
     _run_turn_batch_path,
     _run_turn_with_streaming,
     _RuntimeChannelStreamRelay,
@@ -79,6 +80,15 @@ def test_channel_reply_sanitizes_provider_compaction_markers() -> None:
     assert "opensquilla_compacted" not in reply.content
     assert "assistant_content" not in reply.content
     assert reply.content == "Reply to user:\n?"
+
+
+def test_route_envelope_reply_preserves_channel_for_thread_target() -> None:
+    route_envelope = SimpleNamespace(channel_id="C42", thread_id="1700000000.000100")
+
+    reply = _route_envelope_reply_message("busy", route_envelope)
+
+    assert reply.reply_to == "1700000000.000100"
+    assert reply.metadata == {"channel": "C42"}
 
 
 def test_channel_stream_policy_prefers_adapter_stream_updates() -> None:

--- a/tests/test_onboarding/test_channel_specs.py
+++ b/tests/test_onboarding/test_channel_specs.py
@@ -106,7 +106,7 @@ def test_slack_connection_mode_choices():
     assert field.field_type == "select"
     assert field.default == "webhook"
     assert field.choices == ("webhook", "socket")
-    assert field.advanced is True
+    assert field.advanced is False
 
 
 def test_slack_mode_specific_fields_are_conditional():

--- a/tests/test_onboarding/test_channel_specs.py
+++ b/tests/test_onboarding/test_channel_specs.py
@@ -39,8 +39,8 @@ ENTRY_MODELS = {
     "telegram": TelegramChannelEntry,
 }
 
-EXPECTED_PUBLIC_URL = {"slack", "wecom"}
-CONDITIONAL_PUBLIC_URL = {"feishu", "telegram"}
+EXPECTED_PUBLIC_URL = {"wecom"}
+CONDITIONAL_PUBLIC_URL = {"feishu", "slack", "telegram"}
 
 
 def test_catalog_includes_all_channels():
@@ -83,7 +83,7 @@ def test_required_pydantic_fields_are_required_in_spec(type_name: str):
 def test_slack_secrets_are_marked_secret():
     spec = get_channel_setup_spec("slack")
     secrets = {f.name for f in spec.fields if f.secret}
-    assert {"token", "signing_secret"} <= secrets
+    assert {"token", "app_token", "signing_secret"} <= secrets
 
 
 def test_telegram_secrets_are_marked_secret():
@@ -98,6 +98,23 @@ def test_feishu_connection_mode_choices():
     assert field.field_type == "select"
     assert field.default == "websocket"
     assert field.choices == ("webhook", "websocket")
+
+
+def test_slack_connection_mode_choices():
+    spec = get_channel_setup_spec("slack")
+    field = next(f for f in spec.fields if f.name == "connection_mode")
+    assert field.field_type == "select"
+    assert field.default == "webhook"
+    assert field.choices == ("webhook", "socket")
+    assert field.advanced is True
+
+
+def test_slack_mode_specific_fields_are_conditional():
+    spec = get_channel_setup_spec("slack")
+    fields = {f.name: f for f in spec.fields}
+    assert fields["app_token"].show_when == {"connection_mode": "socket"}
+    assert fields["signing_secret"].show_when == {"connection_mode": "webhook"}
+    assert fields["slack_channel_id"].required is False
 
 
 def test_feishu_status_reactions_are_enabled_by_default():
@@ -149,7 +166,10 @@ def test_channel_catalog_payload_exposes_ui_metadata():
     assert feishu["whatYouNeed"]
     slack = next(c for c in payload if c["type"] == "slack")
     assert "public URL" in slack["help"]
-    assert any("public URL" in item for item in slack["whatYouNeed"])
+    assert slack["transport"] == "mixed"
+    assert slack["requiresPublicUrl"] is False
+    slack_fields = {f["name"]: f for f in slack["fields"]}
+    assert slack_fields["app_token"]["showWhen"] == {"connection_mode": "socket"}
 
 
 def test_matrix_encryption_choices():

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -1490,6 +1490,8 @@ def test_interactive_channel_add_uses_explicit_config_path(tmp_path, monkeypatch
         def select(self, message: str, **kwargs):
             if message == "Channel type":
                 return _Answer("slack")
+            if message == "Connection mode":
+                return _Answer("webhook")
             raise AssertionError(f"unexpected select prompt: {message}")
 
         def text(self, message: str, **kwargs):
@@ -1516,6 +1518,59 @@ def test_interactive_channel_add_uses_explicit_config_path(tmp_path, monkeypatch
 
     assert 'type = "slack"' in target.read_text()
     assert not default_target.exists()
+
+
+def test_interactive_slack_channel_add_can_select_socket_mode(tmp_path, monkeypatch):
+    import sys
+    import types
+
+    from opensquilla.onboarding import flow
+
+    target = tmp_path / "socket.toml"
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    class _Answer:
+        def __init__(self, value):
+            self.value = value
+
+        def ask(self):
+            return self.value
+
+    class _Questionary(types.SimpleNamespace):
+        def select(self, message: str, **kwargs):
+            if message == "Channel type":
+                return _Answer("slack")
+            if message == "Connection mode":
+                return _Answer("socket")
+            raise AssertionError(f"unexpected select prompt: {message}")
+
+        def text(self, message: str, **kwargs):
+            if message == "Channel name":
+                return _Answer("slack-socket")
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+        def password(self, message: str, **_kwargs):
+            if message == "Bot token (xoxb-...)":
+                return _Answer("xoxb-test")
+            if message == "App-level token (xapp-...)":
+                return _Answer("xapp-test")
+            raise AssertionError(f"unexpected password prompt: {message}")
+
+        def confirm(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected confirm prompt: {message}")
+
+        def checkbox(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected checkbox prompt: {message}")
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    flow.run_interactive_channel_add(None, config_path=target)
+
+    data = target.read_text()
+    assert 'type = "slack"' in data
+    assert 'connection_mode = "socket"' in data
+    assert 'app_token = "xapp-test"' in data
+    assert "signing_secret" not in data
 
 
 def test_optional_onboarding_section_receives_explicit_config_path(tmp_path):

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -1502,8 +1502,6 @@ def test_interactive_channel_add_uses_explicit_config_path(tmp_path, monkeypatch
         def password(self, message: str, **_kwargs):
             if message == "Bot token (xoxb-...)":
                 return _Answer("xoxb-test")
-            if message == "Signing secret":
-                return _Answer("signing-secret")
             raise AssertionError(f"unexpected password prompt: {message}")
 
         def confirm(self, message: str, **_kwargs):
@@ -1516,7 +1514,10 @@ def test_interactive_channel_add_uses_explicit_config_path(tmp_path, monkeypatch
 
     flow.run_interactive_channel_add(None, config_path=target)
 
-    assert 'type = "slack"' in target.read_text()
+    data = target.read_text()
+    assert 'type = "slack"' in data
+    assert 'connection_mode = "webhook"' in data
+    assert "signing_secret" not in data
     assert not default_target.exists()
 
 


### PR DESCRIPTION
## Summary
- bring the Slack Socket Mode contribution up to the latest main branch
- validate Socket Mode app tokens before reporting channel startup
- preserve inbound Slack thread targets for batch and streaming replies
- keep the minimal Slack onboarding wizard on the webhook default while exposing Socket Mode as an advanced option

This branch includes the original #142 contribution plus a maintainer fix commit. Pushing directly to the contributor fork was rejected by GitHub credentials, so this maintainer hotfix branch is the mergeable path to main.

## Verification
- uv run --python 3.12 --extra dev --extra recommended pytest -q tests/test_channels/test_slack_socket_mode.py tests/test_onboarding/test_channel_specs.py tests/test_onboarding/test_flow.py::test_interactive_channel_add_uses_explicit_config_path tests/test_gateway/test_rpc_onboarding.py tests/test_gateway/test_rpc_channels.py tests/test_channels/test_channel_dedupe.py tests/test_channels/test_channel_capabilities.py::test_slack_profile_matches_current_web_api_adapter_surface
- uv run --python 3.12 --extra dev --extra recommended ruff check src tests
- uv run --python 3.12 --extra dev --extra recommended mypy src/opensquilla --show-error-codes
- uv lock --check
- uv build --wheel

## Notes
Filtered non-live pytest with recommended extras reached 6031 passed; remaining failures were environment-specific to this local workspace: Python 3.13 vs a wheelhouse test target of 3.12, and shell policy blocking commands that reference this workspace-local virtualenv path.