### PR TITLE
Accept Slack app mention events

### DIFF
--- a/src/opensquilla/channels/slack.py
+++ b/src/opensquilla/channels/slack.py
@@ -660,7 +660,7 @@ class SlackChannel:
         """Shared inbound path for an Events API ``event_callback`` payload,
         used by both the webhook handler and the Socket Mode loop."""
         event = data.get("event", {})
-        if not isinstance(event, dict) or event.get("type") != "message":
+        if not isinstance(event, dict) or event.get("type") not in {"message", "app_mention"}:
             return
         # Only plain user messages are input; drop edits/deletes/joins and the
         # bot's own streaming-edit echoes (``message_changed`` etc.).

--- a/src/opensquilla/channels/slack.py
+++ b/src/opensquilla/channels/slack.py
@@ -668,10 +668,13 @@ class SlackChannel:
             return
         if self._is_own_message(event):
             return
+        event_instance_key = (
+            f"{event.get('channel')}:{event.get('ts')}"
+            if event.get("channel") and event.get("ts")
+            else ""
+        )
         dedupe_key = str(
-            data.get("event_id")
-            or event.get("client_msg_id")
-            or f"{event.get('channel', '')}:{event.get('ts', '')}"
+            event.get("client_msg_id") or event_instance_key or data.get("event_id") or ""
         ).strip(":")
         if dedupe_key and not self._dedupe.check_and_add(dedupe_key):
             return

--- a/tests/test_channels/test_slack_socket_mode.py
+++ b/tests/test_channels/test_slack_socket_mode.py
@@ -112,6 +112,27 @@ def test_ingest_accepts_plain_user_message() -> None:
     assert msg.content == "hi"
 
 
+def test_ingest_accepts_app_mention_event() -> None:
+    ch = _mk()
+    ch._ingest_event_callback(
+        {
+            "event_id": "EvMention",
+            "event": {
+                "type": "app_mention",
+                "user": "UUSER",
+                "channel": "C123",
+                "text": "<@UBOT> hi",
+                "ts": "2.1",
+            },
+        }
+    )
+
+    assert ch._queue.qsize() == 1
+    msg = ch._queue.get_nowait()
+    assert msg.channel_id == "C123"
+    assert msg.content == "<@UBOT> hi"
+
+
 @pytest.mark.parametrize(
     "event",
     [

--- a/tests/test_channels/test_slack_socket_mode.py
+++ b/tests/test_channels/test_slack_socket_mode.py
@@ -160,6 +160,36 @@ def test_ingest_dedupes_replayed_event() -> None:
     assert ch._queue.qsize() == 1
 
 
+def test_ingest_dedupes_app_mention_and_message_pair() -> None:
+    ch = _mk()
+    ch._ingest_event_callback(
+        {
+            "event_id": "EvMention",
+            "event": {
+                "type": "app_mention",
+                "user": "UUSER",
+                "channel": "C123",
+                "text": "<@UBOT> hi",
+                "ts": "10.1",
+            },
+        }
+    )
+    ch._ingest_event_callback(
+        {
+            "event_id": "EvMessage",
+            "event": {
+                "type": "message",
+                "user": "UUSER",
+                "channel": "C123",
+                "text": "<@UBOT> hi",
+                "ts": "10.1",
+            },
+        }
+    )
+
+    assert ch._queue.qsize() == 1
+
+
 class _FakeSocket:
     def __init__(self) -> None:
         self.sent: list[str] = []


### PR DESCRIPTION
## Summary
- Treat Slack app_mention callbacks as user-message equivalents in the shared Events API ingestion path.
- Prevent Socket Mode apps subscribed to app_mentions:read from acknowledging channel mentions and then silently dropping the user turn.
- Add a Slack Socket Mode regression test for app_mention ingestion.

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv run --python 3.12 --extra dev --extra recommended pytest -q tests/test_channels/test_slack_socket_mode.py
- UV_CACHE_DIR=/tmp/uv-cache RUFF_CACHE_DIR=/tmp/ruff-cache uv run --python 3.12 --extra dev --extra recommended ruff check src/opensquilla/channels/slack.py tests/test_channels/test_slack_socket_mode.py