### PR TITLE
Require Slack webhook signing secret in onboarding

### DIFF
--- a/src/opensquilla/gateway/static/js/views/setup.js
+++ b/src/opensquilla/gateway/static/js/views/setup.js
@@ -1063,7 +1063,7 @@ const SetupView = (() => {
     const rawName = String(field.name || 'field');
     const fieldName = `setup_${scope}_${rawName}`;
     const fieldId = `setup-${scope}-${rawName.replace(/[^a-zA-Z0-9_-]+/g, '-')}`;
-    const attrs = `data-name="${_esc(rawName)}" data-scope="${scope}" data-show-when="${showWhen}"`;
+    const attrs = `data-name="${_esc(rawName)}" data-scope="${scope}" data-show-when="${showWhen}" data-required="${field.required ? 'true' : 'false'}"`;
     if (field.type === 'bool') {
       return `<label class="setup-check" ${attrs} for="${_esc(fieldId)}"><input id="${_esc(fieldId)}" name="${_esc(fieldName)}" type="checkbox" ${field.default ? ' checked' : ''}><span>${_esc(field.label)}${required}${desc}</span></label>`;
     }
@@ -1420,6 +1420,19 @@ const SetupView = (() => {
     return out;
   }
 
+  function _validateScopedRequiredFields(scope) {
+    let missing = '';
+    _el.querySelectorAll(`[data-scope="${scope}"][data-name][data-required="true"]`).forEach(label => {
+      if (missing || label.hidden) return;
+      const input = label.querySelector('input, select');
+      if (!input || input.type === 'checkbox') return;
+      if (String(input.value || '').trim()) return;
+      const labelText = label.querySelector('span')?.textContent || label.dataset.name || 'required field';
+      missing = labelText.replace(/\s*\*\s*$/, '').trim();
+    });
+    return missing;
+  }
+
   async function _saveProvider() {
     const providerId = _el.querySelector('[data-provider-select]')?.value;
     if (!providerId) {
@@ -1481,6 +1494,11 @@ const SetupView = (() => {
   }
 
   async function _saveChannel() {
+    const missing = _validateScopedRequiredFields('channel');
+    if (missing) {
+      UI.toast(`${missing} is required.`, 'err');
+      return;
+    }
     const entry = Object.assign({ type: _el.querySelector('[data-channel-type]')?.value }, _readScopedFields('channel'));
     try {
       await _rpc.call('onboarding.channel.probe', { entry });

--- a/src/opensquilla/gateway/static/js/views/setup.js
+++ b/src/opensquilla/gateway/static/js/views/setup.js
@@ -1427,10 +1427,22 @@ const SetupView = (() => {
       const input = label.querySelector('input, select');
       if (!input || input.type === 'checkbox') return;
       if (String(input.value || '').trim()) return;
+      if (input.dataset.secret === 'true' && _canKeepExistingSecret(scope)) return;
       const labelText = label.querySelector('span')?.textContent || label.dataset.name || 'required field';
       missing = labelText.replace(/\s*\*\s*$/, '').trim();
     });
     return missing;
+  }
+
+  function _canKeepExistingSecret(scope) {
+    if (scope !== 'channel') return false;
+    const type = _el.querySelector('[data-channel-type]')?.value || _channelType || '';
+    const name = _el.querySelector('[data-scope="channel"][data-name="name"] input')?.value || '';
+    return (_channelStatus.channels || []).some(row => (
+      row.configured !== false
+      && String(row.type || '') === String(type)
+      && String(row.name || '') === String(name).trim()
+    ));
   }
 
   async function _saveProvider() {

--- a/src/opensquilla/onboarding/channel_specs.py
+++ b/src/opensquilla/onboarding/channel_specs.py
@@ -87,7 +87,7 @@ def _slack_spec() -> ChannelSetupSpec:
                               description="Optional; replies auto-target the incoming "
                               "conversation when unset."),
             ChannelSetupField("signing_secret", "Signing secret", "password",
-                              required=False, secret=True, group="credentials",
+                              required=True, secret=True, group="credentials",
                               advanced=True,
                               show_when={"connection_mode": "webhook"}),
             ChannelSetupField("reply_in_thread", "Reply in thread", "bool",

--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -676,6 +676,12 @@ def validate_channel_entry(payload: dict[str, Any]) -> dict[str, Any]:
         entry = parse_channel_entry(full)
     except ValidationError as exc:
         raise ValueError(str(exc)) from exc
+    if (
+        type_name == "slack"
+        and getattr(entry, "connection_mode", "webhook") == "webhook"
+        and not str(getattr(entry, "signing_secret", "") or "").strip()
+    ):
+        raise ValueError("slack webhook channels require signing_secret")
     return entry.model_dump(mode="python")
 
 

--- a/tests/test_cli/test_channels_cmd.py
+++ b/tests/test_cli/test_channels_cmd.py
@@ -53,6 +53,7 @@ def test_channels_add_slack_succeeds_with_token(tmp_path, monkeypatch):
         [
             "channels", "add", "slack",
             "--name", "w", "--token", "xoxb-x",
+            "--field", "signing_secret=ss",
             "--field", "slack_channel_id=C123",
         ],
     )
@@ -65,7 +66,8 @@ def test_channels_add_slack_succeeds_with_token(tmp_path, monkeypatch):
 def test_channels_remove(tmp_path, monkeypatch):
     target = _setenv(monkeypatch, tmp_path)
     runner.invoke(app, ["channels", "add", "slack",
-                        "--name", "w", "--token", "x"])
+                        "--name", "w", "--token", "x",
+                        "--field", "signing_secret=ss"])
     result = runner.invoke(app, ["channels", "remove", "w"])
     assert result.exit_code == 0
     # Either the channel is gone, or the [[channels.channels]] table is empty.
@@ -76,7 +78,8 @@ def test_channels_remove(tmp_path, monkeypatch):
 def test_channels_disable_then_enable(tmp_path, monkeypatch):
     target = _setenv(monkeypatch, tmp_path)
     runner.invoke(app, ["channels", "add", "slack",
-                        "--name", "w", "--token", "x"])
+                        "--name", "w", "--token", "x",
+                        "--field", "signing_secret=ss"])
     r1 = runner.invoke(app, ["channels", "disable", "w"])
     assert r1.exit_code == 0
     assert "enabled = false" in target.read_text()
@@ -88,7 +91,8 @@ def test_channels_disable_then_enable(tmp_path, monkeypatch):
 def test_channels_list_redacts_secrets(tmp_path, monkeypatch):
     _setenv(monkeypatch, tmp_path)
     runner.invoke(app, ["channels", "add", "slack",
-                        "--name", "w", "--token", "supersecret"])
+                        "--name", "w", "--token", "supersecret",
+                        "--field", "signing_secret=ss"])
     result = runner.invoke(app, ["channels", "list"])
     assert "supersecret" not in result.stdout
     assert "***" in result.stdout
@@ -100,6 +104,7 @@ def test_channels_edit_updates_only_provided_fields(tmp_path, monkeypatch):
         app,
         ["channels", "add", "slack", "--name", "w",
          "--token", "xoxb-original",
+         "--field", "signing_secret=ss",
          "--field", "slack_channel_id=C111"],
     )
     result = runner.invoke(
@@ -124,7 +129,7 @@ def test_channels_edit_preserves_enabled_when_unchanged(tmp_path, monkeypatch):
     runner.invoke(
         app,
         ["channels", "add", "slack", "--name", "w",
-         "--token", "xoxb-x", "--disabled"],
+         "--token", "xoxb-x", "--field", "signing_secret=ss", "--disabled"],
     )
     assert "enabled = false" in target.read_text()
     r = runner.invoke(
@@ -141,7 +146,7 @@ def test_channels_edit_preserves_agent_id_when_unchanged(tmp_path, monkeypatch):
     runner.invoke(
         app,
         ["channels", "add", "slack", "--name", "w",
-         "--token", "xoxb-x", "--agent-id", "ops"],
+         "--token", "xoxb-x", "--field", "signing_secret=ss", "--agent-id", "ops"],
     )
     assert 'agent_id = "ops"' in target.read_text()
     r = runner.invoke(
@@ -158,7 +163,9 @@ def test_channels_edit_preserves_non_secret_bool_when_unchanged(
     runner.invoke(
         app,
         ["channels", "add", "slack", "--name", "w",
-         "--token", "xoxb-x", "--field", "reply_in_thread=true"],
+         "--token", "xoxb-x",
+         "--field", "signing_secret=ss",
+         "--field", "reply_in_thread=true"],
     )
     assert "reply_in_thread = true" in target.read_text()
     r = runner.invoke(
@@ -208,7 +215,12 @@ def test_channels_add_token_flag_echoes_resolved_field(tmp_path, monkeypatch):
 def test_channels_add_token_flag_for_slack_resolves_to_token(tmp_path, monkeypatch):
     _setenv(monkeypatch, tmp_path)
     result = runner.invoke(
-        app, ["channels", "add", "slack", "--name", "w", "--token", "xoxb-x"]
+        app,
+        [
+            "channels", "add", "slack",
+            "--name", "w", "--token", "xoxb-x",
+            "--field", "signing_secret=ss",
+        ],
     )
     assert result.exit_code == 0, result.stdout
     assert "slack.token" in result.stdout
@@ -248,7 +260,12 @@ def test_channels_types_lists_all_supported(tmp_path, monkeypatch):
 def test_channels_add_restart_notice_disambiguates(tmp_path, monkeypatch):
     _setenv(monkeypatch, tmp_path)
     result = runner.invoke(
-        app, ["channels", "add", "slack", "--name", "w", "--token", "x"]
+        app,
+        [
+            "channels", "add", "slack",
+            "--name", "w", "--token", "x",
+            "--field", "signing_secret=ss",
+        ],
     )
     assert result.exit_code == 0
     out = result.stdout.lower()
@@ -260,7 +277,12 @@ def test_channels_add_restart_notice_disambiguates(tmp_path, monkeypatch):
 def test_channels_add_prints_status_verification_next_step(tmp_path, monkeypatch):
     _setenv(monkeypatch, tmp_path)
     result = runner.invoke(
-        app, ["channels", "add", "slack", "--name", "w", "--token", "x"]
+        app,
+        [
+            "channels", "add", "slack",
+            "--name", "w", "--token", "x",
+            "--field", "signing_secret=ss",
+        ],
     )
     assert result.exit_code == 0
     out = result.stdout.lower()
@@ -276,7 +298,12 @@ def test_channels_add_echoes_resolved_path_and_source(tmp_path, monkeypatch):
     (project / "opensquilla.toml").write_text("")
     monkeypatch.chdir(project)
     result = runner.invoke(
-        app, ["channels", "add", "slack", "--name", "w", "--token", "x"]
+        app,
+        [
+            "channels", "add", "slack",
+            "--name", "w", "--token", "x",
+            "--field", "signing_secret=ss",
+        ],
     )
     assert result.exit_code == 0, result.stdout
     assert str(project / "opensquilla.toml") in result.stdout

--- a/tests/test_cli/test_cli_product_completeness.py
+++ b/tests/test_cli/test_cli_product_completeness.py
@@ -94,7 +94,14 @@ def _install_fake_gateway(monkeypatch, cls=FakeGatewayClient) -> type[FakeGatewa
 def test_catalog_list_json_surfaces(tmp_path: Path, monkeypatch):
     target = tmp_path / "c.toml"
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
-    runner.invoke(app, ["channels", "add", "slack", "--name", "w", "--token", "supersecret"])
+    runner.invoke(
+        app,
+        [
+            "channels", "add", "slack",
+            "--name", "w", "--token", "supersecret",
+            "--field", "signing_secret=ss",
+        ],
+    )
 
     providers = runner.invoke(app, ["providers", "list", "--json"])
     search = runner.invoke(app, ["search", "list", "--json"])

--- a/tests/test_cli/test_onboard_cmd.py
+++ b/tests/test_cli/test_onboard_cmd.py
@@ -1954,6 +1954,8 @@ def test_configure_channel_noninteractive_adds_slack(tmp_path, monkeypatch):
             "work",
             "--token",
             "xoxb-secret",
+            "--field",
+            "signing_secret=ss",
         ],
     )
 

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -1235,7 +1235,13 @@ def test_configured_agent_ids_include_enabled_registry_agents_and_channels() -> 
                 AgentEntryConfig(id="disabled", enabled=False),
             ]
         ),
-        entry_payload={"type": "slack", "name": "work", "token": "x", "agent_id": "channel"},
+        entry_payload={
+            "type": "slack",
+            "name": "work",
+            "token": "x",
+            "signing_secret": "ss",
+            "agent_id": "channel",
+        },
     )
 
     assert _configured_agent_ids(result.config) == ["channel", "main", "ops"]

--- a/tests/test_gateway/test_rpc_channels.py
+++ b/tests/test_gateway/test_rpc_channels.py
@@ -34,7 +34,12 @@ async def test_channels_status_includes_configured_channels_without_manager():
     ctx = _read_ctx()
     res = upsert_channel(
         GatewayConfig(),
-        entry_payload={"type": "slack", "name": "work", "token": "xoxb-secret"},
+        entry_payload={
+            "type": "slack",
+            "name": "work",
+            "token": "xoxb-secret",
+            "signing_secret": "ss",
+        },
     )
     ctx.config = res.config
 

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -285,13 +285,34 @@ async def test_channel_upsert_redacts_secrets(tmp_path, monkeypatch):
     res = await get_dispatcher().dispatch(
         "r1",
         "onboarding.channel.upsert",
-        {"entry": {"type": "slack", "name": "w", "token": "supersecret"}},
+        {
+            "entry": {
+                "type": "slack",
+                "name": "w",
+                "token": "supersecret",
+                "signing_secret": "signing-secret",
+            }
+        },
         _admin_ctx(),
     )
     assert res.error is None, res.error
     assert res.payload["changed"] is True
     assert res.payload["restartRequired"] is True
     assert res.payload["entry"]["token"] == "***"
+
+
+@pytest.mark.asyncio
+async def test_channel_upsert_rejects_slack_webhook_without_signing_secret(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(tmp_path / "c.toml"))
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.channel.upsert",
+        {"entry": {"type": "slack", "name": "w", "token": "supersecret"}},
+        _admin_ctx(),
+    )
+
+    assert res.error is not None
+    assert "signing_secret" in res.error.message
 
 
 @pytest.mark.asyncio
@@ -821,7 +842,7 @@ async def test_channel_disable_then_remove(tmp_path, monkeypatch):
     await d.dispatch(
         "r1",
         "onboarding.channel.upsert",
-        {"entry": {"type": "slack", "name": "w", "token": "t"}},
+        {"entry": {"type": "slack", "name": "w", "token": "t", "signing_secret": "ss"}},
         _admin_ctx(),
     )
     res = await d.dispatch("r2", "onboarding.channel.disable", {"name": "w"}, _admin_ctx())

--- a/tests/test_gateway/test_static_onboarding_views.py
+++ b/tests/test_gateway/test_static_onboarding_views.py
@@ -570,6 +570,20 @@ def test_setup_view_marks_unsupported_providers_disabled():
     assert "runtimeSupported" in txt
 
 
+def test_setup_view_validates_visible_required_channel_fields_before_save():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+    start = txt.index("function _saveChannel()")
+    end = txt.index("  async function _saveMemory()", start)
+    body = txt[start:end]
+
+    assert 'data-required="${field.required ? \'true\' : \'false\'}"' in txt
+    assert "function _validateScopedRequiredFields(scope)" in txt
+    assert "_validateScopedRequiredFields('channel')" in body
+    assert "if (missing)" in body
+    assert "is required." in body
+    assert "return;" in body
+
+
 def test_setup_view_treats_image_configure_as_capability_enable_action():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
     assert "field.default !== false" in txt

--- a/tests/test_gateway/test_static_onboarding_views.py
+++ b/tests/test_gateway/test_static_onboarding_views.py
@@ -578,6 +578,11 @@ def test_setup_view_validates_visible_required_channel_fields_before_save():
 
     assert 'data-required="${field.required ? \'true\' : \'false\'}"' in txt
     assert "function _validateScopedRequiredFields(scope)" in txt
+    assert "function _canKeepExistingSecret(scope)" in txt
+    assert "input.dataset.secret === 'true' && _canKeepExistingSecret(scope)" in txt
+    assert "row.configured !== false" in txt
+    assert "String(row.type || '') === String(type)" in txt
+    assert "String(row.name || '') === String(name).trim()" in txt
     assert "_validateScopedRequiredFields('channel')" in body
     assert "if (missing)" in body
     assert "is required." in body

--- a/tests/test_onboarding/test_channel_specs.py
+++ b/tests/test_onboarding/test_channel_specs.py
@@ -114,6 +114,7 @@ def test_slack_mode_specific_fields_are_conditional():
     fields = {f.name: f for f in spec.fields}
     assert fields["app_token"].show_when == {"connection_mode": "socket"}
     assert fields["signing_secret"].show_when == {"connection_mode": "webhook"}
+    assert fields["signing_secret"].required is True
     assert fields["slack_channel_id"].required is False
 
 

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -1502,6 +1502,8 @@ def test_interactive_channel_add_uses_explicit_config_path(tmp_path, monkeypatch
         def password(self, message: str, **_kwargs):
             if message == "Bot token (xoxb-...)":
                 return _Answer("xoxb-test")
+            if message == "Signing secret":
+                return _Answer("signing-secret")
             raise AssertionError(f"unexpected password prompt: {message}")
 
         def confirm(self, message: str, **_kwargs):
@@ -1517,7 +1519,7 @@ def test_interactive_channel_add_uses_explicit_config_path(tmp_path, monkeypatch
     data = target.read_text()
     assert 'type = "slack"' in data
     assert 'connection_mode = "webhook"' in data
-    assert "signing_secret" not in data
+    assert 'signing_secret = "signing-secret"' in data
     assert not default_target.exists()
 
 

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -1895,7 +1895,10 @@ def test_noninteractive_channel_add_writes_config(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
     from opensquilla.onboarding.flow import run_noninteractive_channel_add
 
-    result = run_noninteractive_channel_add("slack", {"name": "w", "token": "x"})
+    result = run_noninteractive_channel_add(
+        "slack",
+        {"name": "w", "token": "x", "signing_secret": "ss"},
+    )
     assert result.path == target
     assert "slack" in target.read_text()
 

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -164,7 +164,12 @@ def test_upsert_channel_appends_new():
     cfg = GatewayConfig()
     res = upsert_channel(
         cfg,
-        entry_payload={"type": "slack", "name": "work", "token": "xoxb-secret"},
+        entry_payload={
+            "type": "slack",
+            "name": "work",
+            "token": "xoxb-secret",
+            "signing_secret": "ss-secret",
+        },
     )
     assert res.restart_required is True
     entries = list_channel_entries(res.config)
@@ -177,7 +182,12 @@ def test_upsert_channel_updates_same_name():
     cfg = GatewayConfig()
     res1 = upsert_channel(
         cfg,
-        entry_payload={"type": "slack", "name": "work", "token": "old"},
+        entry_payload={
+            "type": "slack",
+            "name": "work",
+            "token": "old",
+            "signing_secret": "ss-old",
+        },
     )
     res2 = upsert_channel(
         res1.config,
@@ -197,11 +207,38 @@ def test_upsert_channel_redacts_secrets_in_payload():
     assert res.public_payload["token"] == REDACTED_PLACEHOLDER
 
 
+def test_slack_webhook_channel_requires_signing_secret():
+    cfg = GatewayConfig()
+    with pytest.raises(ValueError, match="signing_secret"):
+        upsert_channel(
+            cfg,
+            entry_payload={"type": "slack", "name": "w", "token": "xoxb-test"},
+        )
+
+
+def test_slack_socket_channel_does_not_require_signing_secret():
+    cfg = GatewayConfig()
+    res = upsert_channel(
+        cfg,
+        entry_payload={
+            "type": "slack",
+            "name": "w",
+            "token": "xoxb-test",
+            "connection_mode": "socket",
+            "app_token": "xapp-test",
+        },
+    )
+
+    entry = list_channel_entries(res.config)[0]
+    assert entry["connection_mode"] == "socket"
+    assert "signing_secret" not in entry or entry["signing_secret"] in (None, "")
+
+
 def test_remove_channel():
     cfg = GatewayConfig()
     res1 = upsert_channel(
         cfg,
-        entry_payload={"type": "slack", "name": "w", "token": "x"},
+        entry_payload={"type": "slack", "name": "w", "token": "x", "signing_secret": "ss"},
     )
     res2 = remove_channel(res1.config, name="w")
     assert list_channel_entries(res2.config) == []
@@ -218,7 +255,7 @@ def test_set_channel_enabled_toggles():
     cfg = GatewayConfig()
     res1 = upsert_channel(
         cfg,
-        entry_payload={"type": "slack", "name": "w", "token": "x"},
+        entry_payload={"type": "slack", "name": "w", "token": "x", "signing_secret": "ss"},
     )
     res2 = set_channel_enabled(res1.config, name="w", enabled=False)
     assert list_channel_entries(res2.config)[0]["enabled"] is False
@@ -418,7 +455,9 @@ def test_upsert_llm_provider_does_not_carry_key_across_providers():
 
 
 def test_validate_channel_entry_returns_normalized_payload():
-    out = validate_channel_entry({"type": "slack", "name": "w", "token": "x"})
+    out = validate_channel_entry(
+        {"type": "slack", "name": "w", "token": "x", "signing_secret": "ss"}
+    )
     assert out["type"] == "slack"
     assert out["enabled"] is True
     assert out["agent_id"] == "main"
@@ -598,7 +637,12 @@ def test_upsert_channel_replaces_secret_when_provided():
     cfg = GatewayConfig()
     first = upsert_channel(
         cfg,
-        entry_payload={"type": "slack", "name": "w", "token": "xoxb-old"},
+        entry_payload={
+            "type": "slack",
+            "name": "w",
+            "token": "xoxb-old",
+            "signing_secret": "ss-old",
+        },
     )
     second = upsert_channel(
         first.config,

--- a/tests/test_onboarding/test_status.py
+++ b/tests/test_onboarding/test_status.py
@@ -159,7 +159,10 @@ def test_zero_channels_means_not_messaging_configured():
 
 def test_channel_present_marks_configured():
     cfg = GatewayConfig()
-    res = upsert_channel(cfg, entry_payload={"type": "slack", "name": "w", "token": "x"})
+    res = upsert_channel(
+        cfg,
+        entry_payload={"type": "slack", "name": "w", "token": "x", "signing_secret": "ss"},
+    )
     s = get_onboarding_status(res.config)
     assert s.channel_count == 1
     assert s.channels_configured is True


### PR DESCRIPTION
## Summary
- Require the Slack webhook signing secret during interactive onboarding when connection_mode is webhook.
- Keep Socket Mode onboarding on app_token only; signing_secret remains hidden for socket mode.
- Add regression coverage for the Slack spec and both webhook/socket onboarding paths.

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv run --python 3.12 --extra dev --extra recommended pytest -q tests/test_onboarding/test_channel_specs.py tests/test_onboarding/test_flow.py::test_interactive_channel_add_uses_explicit_config_path tests/test_onboarding/test_flow.py::test_interactive_slack_channel_add_can_select_socket_mode
- UV_CACHE_DIR=/tmp/uv-cache RUFF_CACHE_DIR=/tmp/ruff-cache uv run --python 3.12 --extra dev --extra recommended ruff check src/opensquilla/onboarding/channel_specs.py tests/test_onboarding/test_channel_specs.py tests/test_onboarding/test_flow.py