### PR TITLE
[codex] Keep PR CI fast with impact gates

### DIFF
--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+changed_files="${1:?usage: classify-ci-changes.sh <changed-files-list>}"
+output_file="${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
+
+docs_only=true
+runtime_changed=false
+test_changed=false
+ci_changed=false
+dependency_changed=false
+release_changed=false
+seen_file=false
+
+mark_runtime_changed() {
+  docs_only=false
+  runtime_changed=true
+}
+
+mark_test_changed() {
+  docs_only=false
+  test_changed=true
+}
+
+mark_ci_changed() {
+  docs_only=false
+  ci_changed=true
+}
+
+mark_dependency_changed() {
+  mark_runtime_changed
+  dependency_changed=true
+  release_changed=true
+}
+
+mark_release_changed() {
+  docs_only=false
+  release_changed=true
+}
+
+while IFS= read -r path || [[ -n "${path}" ]]; do
+  path="${path%$'\r'}"
+  [[ -z "${path}" ]] && continue
+  seen_file=true
+
+  case "${path}" in
+    .ci/run-all)
+      docs_only=false
+      runtime_changed=true
+      test_changed=true
+      ci_changed=true
+      dependency_changed=true
+      release_changed=true
+      ;;
+    pyproject.toml | uv.lock)
+      mark_dependency_changed
+      ;;
+    .github/workflows/wheelhouse-release.yml)
+      mark_ci_changed
+      mark_release_changed
+      ;;
+    .github/workflows/*)
+      mark_ci_changed
+      ;;
+    .github/scripts/*)
+      mark_ci_changed
+      ;;
+    tests/test_scripts/test_build_wheelhouse_zip.py | tests/test_install_scripts.py | tests/test_root_start_scripts.py | tests/test_release_consistency.py | tests/test_public_release_hygiene.py)
+      mark_test_changed
+      mark_release_changed
+      ;;
+    tests/*)
+      mark_test_changed
+      ;;
+    scripts/build_wheelhouse_zip.py | scripts/install_source.sh | scripts/install_source.ps1)
+      mark_runtime_changed
+      mark_release_changed
+      ;;
+    install.sh | install.ps1 | start.sh | start.ps1 | README.release.md | RELEASES.md)
+      mark_release_changed
+      ;;
+    src/* | scripts/* | migrations/*)
+      mark_runtime_changed
+      ;;
+    docs/* | README.md | README.*.md | CHANGELOG.md | CODE_OF_CONDUCT.md | CONTRIBUTING.md | MIGRATION.md | SECURITY.md | SUPPORT.md | THIRD_PARTY_NOTICES.md | META_SKILL_GUIDE.md | RELEASES.md | .github/pull_request_template.md | .github/ISSUE_TEMPLATE/*)
+      ;;
+    *)
+      mark_runtime_changed
+      ;;
+  esac
+done < "${changed_files}"
+
+if [[ "${seen_file}" == "false" ]]; then
+  docs_only=false
+  runtime_changed=true
+  test_changed=true
+  ci_changed=true
+  dependency_changed=true
+  release_changed=true
+fi
+
+{
+  printf 'docs_only=%s\n' "${docs_only}"
+  printf 'runtime_changed=%s\n' "${runtime_changed}"
+  printf 'test_changed=%s\n' "${test_changed}"
+  printf 'ci_changed=%s\n' "${ci_changed}"
+  printf 'dependency_changed=%s\n' "${dependency_changed}"
+  printf 'release_changed=%s\n' "${release_changed}"
+} >> "${output_file}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  classify-changes:
+    name: Classify changed files
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+      runtime_changed: ${{ steps.classify.outputs.runtime_changed }}
+      test_changed: ${{ steps.classify.outputs.test_changed }}
+      ci_changed: ${{ steps.classify.outputs.ci_changed }}
+      dependency_changed: ${{ steps.classify.outputs.dependency_changed }}
+      release_changed: ${{ steps.classify.outputs.release_changed }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: List changed files
+        shell: bash
+        run: |
+          set -euo pipefail
+          changed_files="${RUNNER_TEMP}/changed-files.txt"
+
+          case "${{ github.event_name }}" in
+            pull_request)
+              git diff --name-only \
+                "${{ github.event.pull_request.base.sha }}" \
+                "${{ github.event.pull_request.head.sha }}" > "${changed_files}"
+              ;;
+            push)
+              printf '.ci/run-all\n' > "${changed_files}"
+              ;;
+            *)
+              printf '.ci/run-all\n' > "${changed_files}"
+              ;;
+          esac
+
+          echo "Changed files:"
+          sed 's/^/  /' "${changed_files}"
+          printf 'CHANGED_FILES=%s\n' "${changed_files}" >> "${GITHUB_ENV}"
+
+      - name: Classify changed files
+        id: classify
+        shell: bash
+        run: bash .github/scripts/classify-ci-changes.sh "${CHANGED_FILES}"
+
   workflow-lint:
     name: Validate GitHub Actions workflows
     runs-on: ubuntu-latest
@@ -25,19 +71,15 @@ jobs:
       - name: Run actionlint
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color=false
 
-  checks:
-    name: Lint, test, and build
-    runs-on: ${{ matrix.os }}
+  ubuntu-quality:
+    name: Ubuntu quality gate
+    needs: classify-changes
+    if: needs.classify-changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: ['3.12']
-
     env:
-      UV_PYTHON: ${{ matrix.python-version }}
+      UV_PYTHON: "3.12"
       PYTHONPATH: ${{ github.workspace }}
       OPENSQUILLA_TURN_CALL_LOG: "0"
 
@@ -56,7 +98,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
@@ -99,3 +141,150 @@ jobs:
       - name: Build wheel
         shell: bash
         run: uv build --wheel
+
+  windows-compat:
+    name: Windows compatibility tests
+    needs: classify-changes
+    if: needs.classify-changes.outputs.docs_only != 'true'
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    env:
+      UV_PYTHON: "3.12"
+      PYTHONPATH: ${{ github.workspace }}
+      OPENSQUILLA_TURN_CALL_LOG: "0"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Configure runtime directories
+        shell: bash
+        run: |
+          printf 'OPENSQUILLA_STATE_DIR=%s/opensquilla-state\n' "$RUNNER_TEMP" >> "$GITHUB_ENV"
+          printf 'OPENSQUILLA_LOG_DIR=%s/opensquilla-logs\n' "$RUNNER_TEMP" >> "$GITHUB_ENV"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        shell: bash
+        run: uv sync --extra dev --extra recommended --extra mcp --frozen
+
+      - name: Test
+        shell: bash
+        run: uv run pytest tests -q
+
+  release-packaging:
+    name: Release packaging contracts
+    needs: classify-changes
+    if: needs.classify-changes.outputs.release_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      UV_PYTHON: "3.12"
+      PYTHONPATH: ${{ github.workspace }}
+      OPENSQUILLA_TURN_CALL_LOG: "0"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        shell: bash
+        run: uv sync --extra dev --extra recommended --extra mcp --frozen
+
+      - name: Run release packaging contract tests
+        shell: bash
+        run: |
+          uv run pytest \
+            tests/test_scripts/test_build_wheelhouse_zip.py \
+            tests/test_install_scripts.py \
+            tests/test_root_start_scripts.py \
+            tests/test_release_consistency.py \
+            tests/test_public_release_hygiene.py \
+            -q
+
+  ci-result:
+    name: CI result
+    needs:
+      - classify-changes
+      - workflow-lint
+      - ubuntu-quality
+      - windows-compat
+      - release-packaging
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check required CI results
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          classify_result="${{ needs.classify-changes.result }}"
+          workflow_lint_result="${{ needs.workflow-lint.result }}"
+          ubuntu_result="${{ needs.ubuntu-quality.result }}"
+          windows_result="${{ needs.windows-compat.result }}"
+          release_result="${{ needs.release-packaging.result }}"
+          docs_only="${{ needs.classify-changes.outputs.docs_only }}"
+          runtime_changed="${{ needs.classify-changes.outputs.runtime_changed }}"
+          test_changed="${{ needs.classify-changes.outputs.test_changed }}"
+          ci_changed="${{ needs.classify-changes.outputs.ci_changed }}"
+          dependency_changed="${{ needs.classify-changes.outputs.dependency_changed }}"
+          release_changed="${{ needs.classify-changes.outputs.release_changed }}"
+
+          printf 'classify-changes: %s\n' "${classify_result}"
+          printf 'workflow-lint: %s\n' "${workflow_lint_result}"
+          printf 'ubuntu-quality: %s\n' "${ubuntu_result}"
+          printf 'windows-compat: %s\n' "${windows_result}"
+          printf 'release-packaging: %s\n' "${release_result}"
+          printf 'docs_only=%s runtime_changed=%s test_changed=%s ci_changed=%s dependency_changed=%s release_changed=%s\n' \
+            "${docs_only}" "${runtime_changed}" "${test_changed}" "${ci_changed}" "${dependency_changed}" "${release_changed}"
+
+          if [[ "${classify_result}" != "success" ]]; then
+            echo "Classify changed files must succeed."
+            exit 1
+          fi
+
+          if [[ "${workflow_lint_result}" != "success" ]]; then
+            echo "Workflow lint must succeed."
+            exit 1
+          fi
+
+          if [[ "${docs_only}" != "true" && "${ubuntu_result}" != "success" ]]; then
+            echo "Ubuntu quality gate must succeed for non-documentation changes."
+            exit 1
+          fi
+
+          if [[ "${docs_only}" != "true" && "${windows_result}" != "success" ]]; then
+            echo "Windows compatibility tests must succeed for non-documentation changes."
+            exit 1
+          fi
+
+          if [[ "${release_changed}" == "true" && "${release_result}" != "success" ]]; then
+            echo "Release packaging contracts must succeed for release-surface changes."
+            exit 1
+          fi

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import os
 import re
+import shutil
+import subprocess
+from collections.abc import Callable
 from pathlib import Path
 
 import yaml
 
 WORKFLOW_DIR = Path(".github/workflows")
+CLASSIFIER = Path(".github/scripts/classify-ci-changes.sh")
 TEST_PATH_RE = re.compile(r"tests/[A-Za-z0-9_./-]+\.py")
 
 
@@ -28,6 +33,72 @@ def _workflow_texts() -> list[str]:
     return [path.read_text(encoding="utf-8") for path in WORKFLOW_DIR.glob("*.yml")]
 
 
+def _is_windows_wsl_bash(path: str) -> bool:
+    normalized = path.replace("\\", "/").lower()
+    return normalized.endswith("/windows/system32/bash.exe")
+
+
+def _bash_executable(
+    *,
+    os_name: str = os.name,
+    path_lookup: Callable[[str], str | None] = shutil.which,
+    exists: Callable[[Path], bool] = Path.is_file,
+    program_files: str | None = None,
+) -> str:
+    found = path_lookup("bash")
+    if os_name != "nt":
+        return found or "bash"
+
+    candidates: list[Path] = []
+    if found and not _is_windows_wsl_bash(found):
+        candidates.append(Path(found))
+
+    git_root = Path(program_files or os.environ.get("ProgramFiles", r"C:\Program Files")) / "Git"
+    candidates.extend(
+        [
+            git_root / "bin" / "bash.exe",
+            git_root / "usr" / "bin" / "bash.exe",
+        ]
+    )
+
+    for candidate in candidates:
+        if exists(candidate):
+            return str(candidate)
+
+    raise AssertionError("Git Bash is required to run the CI change classifier on Windows")
+
+
+def _classify_changed_files(
+    tmp_path: Path,
+    paths: list[str],
+    *,
+    line_ending: str = "\n",
+) -> dict[str, str]:
+    changed_file = tmp_path / "changed-files.txt"
+    output_file = tmp_path / "github-output.txt"
+    changed_file.write_text(
+        line_ending.join(paths) + line_ending,
+        encoding="utf-8",
+        newline="",
+    )
+
+    env = os.environ.copy()
+    env["GITHUB_OUTPUT"] = output_file.as_posix()
+    subprocess.run(
+        [_bash_executable(), CLASSIFIER.as_posix(), changed_file.as_posix()],
+        check=True,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    outputs: dict[str, str] = {}
+    for line in output_file.read_text(encoding="utf-8").splitlines():
+        key, value = line.split("=", 1)
+        outputs[key] = value
+    return outputs
+
+
 def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     ci_path = WORKFLOW_DIR / "ci.yml"
     if not ci_path.exists():
@@ -44,6 +115,125 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert 'OPENSQUILLA_LOG_DIR=%s/opensquilla-logs\\n' in text
     assert "OPENSQUILLA_TURN_CALL_LOG: \"0\"" in text
     assert "actionlint@v1.7.12" in text
+    assert "Classify changed files" in text
+    assert "Ubuntu quality gate" in text
+    assert "Windows compatibility tests" in text
+    assert "Release packaging contracts" in text
+    assert "CI result" in text
+    assert 'push)\n              printf \'.ci/run-all\\n\' > "${changed_files}"' in text
+    assert "runtime_changed" in text
+    assert "test_changed" in text
+    assert "ci_changed" in text
+    assert "dependency_changed" in text
+    assert "release_changed" in text
+    assert "code_changed" not in text
+    assert "workflow_changed" not in text
+
+
+def test_ci_change_classifier_allows_root_and_docs_markdown_only(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [
+            "README.md",
+            "CHANGELOG.md",
+            "docs/features/skills.md",
+            ".github/pull_request_template.md",
+        ],
+    )
+
+    assert outputs == {
+        "docs_only": "true",
+        "runtime_changed": "false",
+        "test_changed": "false",
+        "ci_changed": "false",
+        "dependency_changed": "false",
+        "release_changed": "false",
+    }
+
+
+def test_classifier_helper_prefers_git_bash_over_windows_wsl_bash(tmp_path: Path) -> None:
+    git_bash = tmp_path / "Git" / "bin" / "bash.exe"
+
+    result = _bash_executable(
+        os_name="nt",
+        path_lookup=lambda _name: r"C:\Windows\System32\bash.exe",
+        exists=lambda path: path == git_bash,
+        program_files=str(tmp_path),
+    )
+
+    assert result == str(git_bash)
+
+
+def test_ci_change_classifier_accepts_crlf_changed_files(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        ["README.md", "docs/features/skills.md"],
+        line_ending="\r\n",
+    )
+
+    assert outputs["docs_only"] == "true"
+    assert outputs["runtime_changed"] == "false"
+
+
+def test_ci_change_classifier_treats_runtime_markdown_as_runtime(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        ["src/opensquilla/identity/templates/bootstrap/AGENTS.md"],
+    )
+
+    assert outputs["docs_only"] == "false"
+    assert outputs["runtime_changed"] == "true"
+    assert outputs["test_changed"] == "false"
+    assert outputs["ci_changed"] == "false"
+    assert outputs["dependency_changed"] == "false"
+    assert outputs["release_changed"] == "false"
+
+
+def test_ci_change_classifier_tracks_test_changes_separately(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        ["tests/test_ci/test_workflows.py"],
+    )
+
+    assert outputs["docs_only"] == "false"
+    assert outputs["runtime_changed"] == "false"
+    assert outputs["test_changed"] == "true"
+    assert outputs["ci_changed"] == "false"
+    assert outputs["dependency_changed"] == "false"
+    assert outputs["release_changed"] == "false"
+
+
+def test_ci_change_classifier_tracks_ci_dependency_and_release_changes(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [".github/workflows/ci.yml", ".github/scripts/classify-ci-changes.sh", "uv.lock"],
+    )
+
+    assert outputs["docs_only"] == "false"
+    assert outputs["runtime_changed"] == "true"
+    assert outputs["test_changed"] == "false"
+    assert outputs["ci_changed"] == "true"
+    assert outputs["dependency_changed"] == "true"
+    assert outputs["release_changed"] == "true"
+
+
+def test_ci_change_classifier_tracks_release_surface_changes(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [
+            ".github/workflows/wheelhouse-release.yml",
+            "scripts/build_wheelhouse_zip.py",
+            "README.release.md",
+            "tests/test_scripts/test_build_wheelhouse_zip.py",
+        ],
+    )
+
+    assert outputs["docs_only"] == "false"
+    assert outputs["runtime_changed"] == "true"
+    assert outputs["test_changed"] == "true"
+    assert outputs["ci_changed"] == "true"
+    assert outputs["dependency_changed"] == "false"
+    assert outputs["release_changed"] == "true"
 
 
 def test_manual_workflows_reference_existing_test_files() -> None:


### PR DESCRIPTION
## Summary

This changes CI from a single heavy PR gate into impact-based gates driven by changed files.

- Adds `.github/scripts/classify-ci-changes.sh` to classify PR diffs into stable CI impact flags.
- Keeps docs-only PRs on lightweight workflow validation and result aggregation.
- Runs Ubuntu and Windows gates for non-docs PRs.
- Adds an explicit `Release packaging contracts` job for release, installer, wheelhouse, dependency, and release-workflow surfaces.
- Keeps `push` to `main` and manual `workflow_dispatch` on full-run behavior through the `.ci/run-all` path.
- Makes classifier tests portable on Windows by preferring Git Bash over WSL `bash.exe` and by accepting CRLF changed-file lists.

## CI Rules

Classifier outputs:

- `docs_only`
- `runtime_changed`
- `test_changed`
- `ci_changed`
- `dependency_changed`
- `release_changed`

Docs-only PRs skip the expensive Ubuntu and Windows gates. Non-docs PRs run both platform gates. Release-impacting changes also run focused packaging and release contract tests.

## Validation

Run from a clean worktree based on `origin/dev`:

```bash
uv sync --extra dev --extra recommended --extra mcp --frozen
uv run pytest tests/test_ci/test_workflows.py -q
uv run ruff check tests/test_ci/test_workflows.py
bash -n .github/scripts/classify-ci-changes.sh
git diff --check -- .github/workflows/ci.yml .github/scripts/classify-ci-changes.sh tests/test_ci/test_workflows.py
git diff --no-index --check /dev/null .github/scripts/classify-ci-changes.sh
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color=false
```

Results:

- `16 passed`
- Ruff passed
- Shell syntax passed
- Diff whitespace checks passed
- Actionlint passed

## Notes

Opened as draft so the GitHub-hosted matrix can prove the new workflow behavior before this is marked ready.