### PR TITLE
Refine router panel candidate visuals

### DIFF
--- a/src/opensquilla/engine/steps/squilla_router.py
+++ b/src/opensquilla/engine/steps/squilla_router.py
@@ -918,11 +918,14 @@ async def apply_squilla_router(ctx: TurnContext) -> TurnContext:
 
         image_tiers = {k: v for k, v in tiers.items() if v.get("supports_image", False)}
         if not image_tiers:
-            log.debug(
+            log.warning(
                 "squilla_router.no_image_tier",
                 note="image detected but no supports_image tier",
             )
-            return ctx
+            raise RuntimeError(
+                "No image-capable SquillaRouter tier is configured for this image request. "
+                "Configure squilla_router.tiers.image_model with supports_image=true."
+            )
         tier_name = random.choice(list(image_tiers.keys()))
         decision = RoutingDecision(
             tier=tier_name,

--- a/src/opensquilla/gateway/static/css/views/chat.css
+++ b/src/opensquilla/gateway/static/css/views/chat.css
@@ -2893,17 +2893,16 @@ select.clarify-form-input {
  * Router slider — arcade-brutalist whac-a-mole grid that fires when
  * the squilla router lands a tier.
  *
- * The strip is a 3 × 4 grid of cells: the operator's real configured
- * tiers (deduped by model) sit in the top rows, padded with popular
- * decoy model names so the grid feels populated. A square hammer-
- * selector hops between cells with bouncy easing and locks onto the
- * routed cell — each visited cell does a quick mole-pop, the winner
- * cell additionally fires a particle burst.
+ * The strip is a compact grid of real candidates for the current
+ * request kind. A square hammer-selector hops between cells with
+ * bouncy easing and locks onto the routed cell — each visited cell
+ * does a quick mole-pop, the winner cell additionally fires a
+ * particle burst.
  *
  * Aesthetic: hairline mantis-brutalist. Orange is the only colour
- * that signals; decoys read dim. Live and history-loaded renders
- * share the same component (history skips the hop animation and
- * settles immediately on the winner cell). ─────────────────────── */
+ * that signals. Live and history-loaded renders share the same
+ * component (history skips the hop animation and settles immediately
+ * on the winner cell). ─────────────────────────────────────────── */
 .router-fx {
   display: flex;
   flex-direction: column;
@@ -2967,10 +2966,9 @@ select.clarify-form-input {
 .router-fx-grid {
   position: relative;
   display: grid;
-  /* 5 × 3 cells. JS pulls from _ROUTER_FX_GRID_COLS / _ROUTER_FX_GRID_ROWS;
-     keep these in sync with that constant when changing dimensions. */
-  grid-template-columns: repeat(5, 1fr);
-  grid-template-rows: repeat(3, 30px);
+  grid-template-columns: repeat(var(--router-fx-cols, 2), 1fr);
+  grid-template-rows: none;
+  grid-auto-rows: 34px;
   gap: 4px;
   padding: 8px;
   background:
@@ -3018,11 +3016,8 @@ select.clarify-form-input {
   white-space: nowrap;
 }
 
-/* Equal prominence: every model cell renders identically at rest — no
- * "this one is configured" accent dot and no dimmed/italic "decoy"
- * treatment. The grid reads as one uniform field so an observer cannot
- * tell which names are actually on the operator's router; only the
- * routing RESULT (.win, below) is ever emphasised. */
+/* Equal prominence: every candidate cell renders identically at rest. Only
+ * the routing RESULT (.win, below) is emphasised. */
 
 /* Mole-pop: scale up + tiny lift + accent tint as the hammer arrives. */
 @keyframes router-fx-mole-pop {
@@ -3235,18 +3230,16 @@ select.clarify-form-input {
   background: var(--text-muted);
 }
 
-/* NOTE: the router grid deliberately does NOT honour prefers-reduced-motion
- * either — same rationale as the cloud: the "Router animation" switch is the
- * explicit opt-in, so OS reduce-motion does not suppress the chase. */
+/* NOTE: the router grid deliberately does NOT honour prefers-reduced-motion:
+ * the "Visual effects" switch is the explicit opt-in, so OS reduce-motion
+ * does not suppress the chase. */
 
-/* Mobile: collapse to 3 columns × 5 rows + smaller type. The hammer
- * still hops; the grid just gets denser. JS still renders 15 cells —
- * keep the cell count divisible across the active grid template so no
- * row ends short. */
+/* Mobile: keep the same real-candidate roster, but wrap compactly. */
 @media (max-width: 640px) {
   .router-fx-grid {
-    grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: repeat(5, 28px);
+    grid-template-columns: repeat(var(--router-fx-mobile-cols, var(--router-fx-cols, 2)), 1fr);
+    grid-template-rows: none;
+    grid-auto-rows: 30px;
     padding: 6px;
     gap: 3px;
   }
@@ -3255,161 +3248,11 @@ select.clarify-form-input {
 }
 @media (max-width: 380px) {
   .router-fx-grid {
-    grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: repeat(5, 26px);
+    grid-template-columns: repeat(var(--router-fx-mobile-cols, 2), 1fr);
+    grid-template-rows: none;
+    grid-auto-rows: 28px;
   }
   .router-fx-cell { font-size: 9.5px; padding: 0 4px; }
-}
-
-/* ── Router-fx style variants ────────────────────────────────────────────
- * Groundwork for future frontend experiments. The visible style today is the
- * BASE look above, rendered when no data-variant attribute is present. JS
- * (_buildRouterFxElement) stamps data-variant="<name>" on the .router-fx root
- * only for non-'default' variants, so adding a skin is purely additive here.
- *
- * To add a variant:
- *   .router-fx[data-variant="<name>"] { --accent: …; --danger: …; }
- * Prefer redefining the custom properties the strip already consumes (--accent,
- * --danger, --text*, --bg*, --hairline, --radius-*) — they inherit down the
- * subtree and stay light/dark-correct for free. Add structural/keyframe rules
- * ONLY when a variant changes shape or motion, and if so mirror the
- * prefers-reduced-motion guard and the 640px/380px grid-collapse rules above,
- * and keep the JS grid-cell count in sync.
- *
- * Keep palette-only variants PALETTE-ONLY: the data-source="fallback" and
- * data-observe="true" rules are semantic overlays at depth (0,1,2,0); a
- * token-only variant layers cleanly under them instead of fighting specificity.
- * The "cloud" variant below is a STRUCTURAL one (its own layout + motion). */
-
-/* ── Cloud variant: "model nebula" / rack-focus ──────────────────────────
- * An optical instrument focusing, not a marketing tag-cloud. ~36 model names
- * hang in an organic, edge-dissolved field at seeded focal DEPTHS where blur,
- * scale and opacity move together (near = sharp/large/bright; far =
- * soft/small/dim). Two layers per name keep motion from fighting: the OUTER
- * owns position + a perpetual parallax drift (the field stays alive even once
- * settled) and the winner's glide to focus; the INNER owns the rack-focus
- * (scale/blur/opacity/glow). Routing: idle -> playing (the whole field
- * defocuses, ease-IN) -> settled (the winner glides to the focal point and
- * resolves sharp with an accent bloom; the rest sink to bokeh). */
-.router-fx[data-variant="cloud"] .router-fx-cloud {
-  position: relative;
-  width: 100%;
-  height: 268px;
-  margin-top: 2px;
-  overflow: visible;
-  /* no border, no box — a faint accent core; the radial mask dissolves the
-   * edges so the nebula has no rigid rectangular boundary. */
-  background:
-    radial-gradient(58% 64% at 50% 47%,
-      color-mix(in srgb, var(--accent) 7%, transparent) 0%,
-      transparent 72%);
-  -webkit-mask-image: radial-gradient(74% 76% at 50% 49%, #000 50%, transparent 100%);
-  mask-image: radial-gradient(74% 76% at 50% 49%, #000 50%, transparent 100%);
-}
-
-/* OUTER: position + (winner only) the glide to focus. NO perpetual motion —
- * the panel must be perfectly still once settled / while output renders. */
-.router-fx[data-variant="cloud"] .router-fx-mote {
-  position: absolute;
-  left: var(--x, 50%);
-  top: var(--y, 50%);
-  z-index: var(--z, 1);
-  transform: translate(-50%, -50%);
-  pointer-events: none;
-  transition:
-    left 360ms cubic-bezier(.2,.85,.25,1),
-    top 360ms cubic-bezier(.2,.85,.25,1);
-}
-
-/* INNER: the focal optics (scale / blur / opacity / colour / glow). */
-.router-fx[data-variant="cloud"] .router-fx-mote-i {
-  display: inline-block;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  line-height: 1;
-  letter-spacing: 0.02em;
-  white-space: nowrap;
-  color: var(--text);
-  opacity: var(--op, 0.6);
-  filter: blur(var(--blur, 0));
-  transform: scale(var(--sc, 1));
-  transform-origin: center;
-  transition:
-    transform 360ms cubic-bezier(.2,.85,.25,1),
-    filter 340ms cubic-bezier(.2,.85,.25,1),
-    opacity 300ms ease,
-    color 280ms ease,
-    letter-spacing 360ms cubic-bezier(.2,.85,.25,1),
-    text-shadow 360ms ease;
-}
-
-/* Scanning — the live "search" before the decision arrives. JS toggles
- * .is-scan across motes (~170ms) so a candidate roams into sharp accent
- * focus while the rest sit softly defocused. Discrete class swaps, so the
- * motion shows even where CSS keyframes are suppressed. */
-.router-fx[data-variant="cloud"][data-state="scanning"] .router-fx-mote-i {
-  filter: blur(calc(var(--blur, 0) + 1.6px));
-  opacity: calc(var(--op, 0.6) * 0.7);
-  transition:
-    transform 200ms cubic-bezier(.2,.85,.25,1),
-    filter 200ms ease,
-    opacity 200ms ease,
-    color 200ms ease,
-    text-shadow 200ms ease;
-}
-.router-fx[data-variant="cloud"][data-state="scanning"] .router-fx-mote.is-scan {
-  z-index: 250;
-}
-.router-fx[data-variant="cloud"][data-state="scanning"] .router-fx-mote.is-scan .router-fx-mote-i {
-  filter: blur(0);
-  opacity: 1;
-  transform: scale(1.4);
-  color: var(--accent);
-  text-shadow:
-    0 0 8px color-mix(in srgb, var(--accent) 60%, transparent),
-    0 0 20px color-mix(in srgb, var(--accent) 32%, transparent);
-}
-
-/* Playing — the lens leaves focus: the whole field defocuses (ease-IN).
- * Only the INNER changes; the outer keeps drifting underneath. */
-.router-fx[data-variant="cloud"][data-state="playing"] .router-fx-mote-i {
-  filter: blur(calc(var(--blur, 0) + 3.6px));
-  opacity: calc(var(--op, 0.6) * 0.4);
-  transform: scale(calc(var(--sc, 1) * 0.86));
-  transition:
-    transform 360ms ease-in,
-    filter 340ms ease-in,
-    opacity 340ms ease-in;
-}
-
-/* Settled — the field sinks to soft bokeh (the outer keeps drifting, so it is
- * never frozen). */
-.router-fx[data-variant="cloud"][data-state="settled"] .router-fx-mote-i {
-  filter: blur(calc(var(--blur, 0) + 2.6px));
-  opacity: 0.16;
-  transform: scale(calc(var(--sc, 1) * 0.9));
-}
-
-/* ...except the winner: the OUTER glides to the focal point (left/top eased)
- * while the INNER resolves sharp with a layered accent bloom. STATIC once
- * settled — no breathe — so the panel is still while output renders.
- * The --winner class outranks the generic settled rule above on specificity. */
-.router-fx[data-variant="cloud"][data-state="settled"] .router-fx-mote--winner {
-  left: 50%;
-  top: 47%;
-  z-index: 300;
-}
-.router-fx[data-variant="cloud"][data-state="settled"] .router-fx-mote--winner .router-fx-mote-i {
-  filter: blur(0);
-  opacity: 1;
-  color: var(--accent);
-  font-weight: 600;
-  letter-spacing: 0.09em;
-  transform: scale(1.9);
-  text-shadow:
-    0 0 8px color-mix(in srgb, var(--accent) 70%, transparent),
-    0 0 22px color-mix(in srgb, var(--accent) 46%, transparent),
-    0 0 48px color-mix(in srgb, var(--accent) 24%, transparent);
 }
 
 /* Once settled, the chase hammer is gone — the .win cell is the marker. */
@@ -3426,65 +3269,16 @@ select.clarify-form-input {
   transition: none !important;
 }
 
-/* Focal reticle: two corner ticks that close on the winner as it locks. */
-.router-fx[data-variant="cloud"] .router-fx-reticle {
-  position: absolute;
-  left: 50%;
-  top: 47%;
-  width: 168px;
-  height: 58px;
-  transform: translate(-50%, -50%) scale(0.82);
-  opacity: 0;
-  pointer-events: none;
-  transition:
-    opacity 460ms ease 220ms,
-    transform 600ms cubic-bezier(.2,.85,.25,1) 220ms;
-}
-.router-fx[data-variant="cloud"] .router-fx-reticle::before,
-.router-fx[data-variant="cloud"] .router-fx-reticle::after {
-  content: '';
-  position: absolute;
-  width: 14px;
-  height: 14px;
-  border: 1px solid color-mix(in srgb, var(--accent) 55%, transparent);
-}
-.router-fx[data-variant="cloud"] .router-fx-reticle::before { left: 0; top: 0; border-right: none; border-bottom: none; }
-.router-fx[data-variant="cloud"] .router-fx-reticle::after  { right: 0; bottom: 0; border-left: none; border-top: none; }
-.router-fx[data-variant="cloud"][data-state="settled"] .router-fx-reticle {
-  opacity: 0.9;
-  transform: translate(-50%, -50%) scale(1);
-}
-
-/* Observe mode: routed model did not drive the turn — dim the whole field. */
-.router-fx[data-variant="cloud"][data-observe="true"] .router-fx-cloud { opacity: 0.6; }
-
-/* Fallback: the chosen tier was the safety net — carry the signal in danger
- * (static glow, no breathe). */
-.router-fx[data-variant="cloud"][data-source="fallback"][data-state="settled"] .router-fx-mote--winner .router-fx-mote-i {
-  color: var(--danger);
-  text-shadow:
-    0 0 7px color-mix(in srgb, var(--danger) 68%, transparent),
-    0 0 20px color-mix(in srgb, var(--danger) 45%, transparent),
-    0 0 46px color-mix(in srgb, var(--danger) 24%, transparent);
-  animation: none;
-}
-.router-fx[data-variant="cloud"][data-source="fallback"] .router-fx-reticle::before,
-.router-fx[data-variant="cloud"][data-source="fallback"] .router-fx-reticle::after {
-  border-color: color-mix(in srgb, var(--danger) 55%, transparent);
-}
-
-/* NOTE: the cloud deliberately does NOT honour prefers-reduced-motion — the
- * panel is an explicitly toggled decorative effect (the "Router animation" /
- * "Cloud view" switches are the opt-in), so OS reduce-motion does not
- * blanket-suppress it. Turn the switch off to stop the motion. */
-
-/* Mobile: a shorter field + smaller type so the nebula still breathes. */
-@media (max-width: 640px) {
-  .router-fx[data-variant="cloud"] .router-fx-cloud {
-    height: 200px;
-  }
-  .router-fx[data-variant="cloud"] .router-fx-mote-i { font-size: 10px; }
-  .router-fx[data-variant="cloud"][data-state="settled"] .router-fx-mote--winner .router-fx-mote-i {
-    transform: scale(1.6);
-  }
-}
+/* ── Router-fx style variants ────────────────────────────────────────────
+ * Groundwork for future frontend experiments. The visible style today is the
+ * BASE look above, rendered when no data-variant attribute is present. JS
+ * (_buildRouterFxElement) stamps data-variant="<name>" on the .router-fx root
+ * only for non-'default' variants, so adding a skin is purely additive here.
+ *
+ * To add a variant:
+ *   .router-fx[data-variant="<name>"] { --accent: …; --danger: …; }
+ * Prefer redefining the custom properties the strip already consumes (--accent,
+ * --danger, --text*, --bg*, --hairline, --radius-*). Keep variants
+ * palette-only unless the router contract changes to support a second visual
+ * grammar for real candidates.
+ */

--- a/src/opensquilla/gateway/static/css/views/chat.css
+++ b/src/opensquilla/gateway/static/css/views/chat.css
@@ -591,31 +591,32 @@
   position: relative;
 }
 
-/* Streaming indicator — one spinning shrimp anchored inside the bubble,
-   at the bottom of .msg-body. Applies the whole time the assistant turn is
-   in flight (text streaming OR tool execution), so the affordance does not
-   vanish when control moves between text deltas and tool calls. The
-   :not(.awaiting-model) guard lets the pre-first-token "waiting for model
-   response..." text on .msg.streaming.awaiting-model::after be the only
-   marker during the wait, then the shrimp takes over once tokens start. */
-.msg.streaming:not(.awaiting-model) .msg-body::after {
+/* Streaming active mark — delayed bottom dock. The mark appears only after
+   short turns have had time to finish, then sits inside the bubble footer with
+   a small rightward offset so it does not collide with tool-card status rails. */
+.msg.streaming.streaming-active-mark:not(.awaiting-model) .msg-body {
+  padding-bottom: calc(var(--sp-2) + 24px);
+}
+
+.msg.streaming.streaming-active-mark:not(.awaiting-model) .msg-body::after {
   content: '';
   display: block;
-  width: 1.1em;
-  height: 1.1em;
-  margin-top: 6px;
-  position: relative;
-  left: 0;
+  position: absolute;
+  left: calc(var(--sp-4) + 16px);
+  bottom: calc(var(--sp-2) + 8px);
+  width: 16px;
+  height: 16px;
+  pointer-events: none;
+  border-radius: 50%;
+  background-color: color-mix(in srgb, var(--bg-surface) 90%, var(--bg) 10%);
   background-image: url('../../img/opensquilla-mark.png');
   background-repeat: no-repeat;
   background-position: center;
-  background-size: contain;
-  /* Wheel kinematics: ~1.1em diameter → ~3.46em circumference per spin. The
-     forward traverse covers ~4 rotations (1440°) over 5s, then the return
-     interpolates back to 0° — so the spin direction reverses with the swim
-     direction, matching a real rolling wheel instead of a sliding one. The
-     two are baked into one keyframes so they stay synchronized. */
-  animation: shrimp-roll 10s linear infinite;
+  background-size: 11px 11px;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--accent) 7%, transparent),
+    0 0 6px color-mix(in srgb, var(--accent-secondary) 18%, transparent);
+  animation: squilla-activity-spin 1.6s linear infinite;
 }
 
 .msg.streaming.awaiting-model::after {
@@ -639,9 +640,16 @@
   50%      { opacity: 0.48; }
 }
 
-@keyframes shrimp-roll {
-  0%, 100% { left: 0;                  transform: rotate(0deg); }
-  50%      { left: calc(100% - 1.1em); transform: rotate(1440deg); }
+@keyframes squilla-activity-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .msg.streaming.streaming-active-mark:not(.awaiting-model) .msg-body::after {
+    animation: none;
+    opacity: 0.72;
+    transform: none;
+  }
 }
 
 @keyframes blink {

--- a/src/opensquilla/gateway/static/js/views/chat.js
+++ b/src/opensquilla/gateway/static/js/views/chat.js
@@ -1450,12 +1450,10 @@ const ChatView = (() => {
       _updateElevatedPill();
       _refreshToolbarTriggerGlow();
 
-      // Pre-populate the router slider's tier list and model cache
-      // from the operator's actual configured tiers. We register EVERY
-      // tier (including image-only ones like "image_model") into the
-      // slot list, so image-capable models like kimi-k2.6 show up in
-      // the slider even before the first image route fires for the
-      // current session.
+      // Pre-populate the router visualisation from the operator's actual
+      // configured tiers. We keep every tier in the cache, including
+      // image-only routes, but render-time request-kind filtering decides
+      // which candidates can really be called for this turn.
       //
       // We REPLACE _routerFxSlotList from config (rather than merge)
       // so that tiers the operator has removed drop out of the grid
@@ -1471,14 +1469,21 @@ const ChatView = (() => {
           const lower = tier.toLowerCase();
           configTierKeys.push(lower);
           configTierSet.add(lower);
-          const model = tiers[tier]?.model;
-          if (typeof model === 'string' && model) {
-            _routerFxModels[lower] = model;
-          }
+          const rawTier = tiers[tier];
+          const tierConfig = {
+            model: typeof rawTier?.model === 'string' ? rawTier.model : '',
+            supportsImage: rawTier?.supports_image === true,
+            imageOnly: rawTier?.image_only === true,
+          };
+          _routerFxTierConfigs[lower] = tierConfig;
+          if (tierConfig.model) _routerFxModels[lower] = tierConfig.model;
         });
       }
       Object.keys(_routerFxModels).forEach((tier) => {
         if (!configTierSet.has(tier)) delete _routerFxModels[tier];
+      });
+      Object.keys(_routerFxTierConfigs).forEach((tier) => {
+        if (!configTierSet.has(tier)) delete _routerFxTierConfigs[tier];
       });
       _routerFxConfigTiers = configTierSet;
       if (configTierKeys.length > 0) {
@@ -3243,73 +3248,12 @@ const ChatView = (() => {
   }
 
   /* ── Router slider — arcade-brutalist whac-a-mole grid ─────────────
-   * Fires once per user message when session.event.router_decision
-   * lands. A 3 × 4 cell grid mixes the operator's real configured
-   * tiers (deduped by model) with popular decoy models from the
-   * OpenRouter ecosystem; a hammer-selector hops between cells with
-   * bouncy easing and locks onto the routed cell with a particle
-   * burst. The strip is non-blocking — assistant text streams below
-   * the grid while the chase plays above. */
-
-  // 5 cols × 3 rows = 15 cells. The wider grid gives the hammer more
-  // hops to play and shows the model space as a proper "dial" rather
-  // than a tight 4-cell strip. Mobile breakpoints collapse this down
-  // (see chat.css @media rules).
-  const _ROUTER_FX_GRID_COLS = 5;
-  const _ROUTER_FX_GRID_ROWS = 3;
-  const _ROUTER_FX_GRID_CELLS = _ROUTER_FX_GRID_COLS * _ROUTER_FX_GRID_ROWS;
-  const _ROUTER_FX_REAL_ANCHOR_CELLS = [1, 6, 8, 13, 11, 3, 5, 9, 12, 14, 0, 4, 7, 10, 2];
-
-  // Popular OpenRouter models used as visual decoys, ordered by
-  // approximate openrouter.ai traffic ranking (highest volume first),
-  // refreshed 2026-05 from the OpenRouter usage leaderboard. Anything
-  // already on the operator's router (matched after stripping the
-  // provider prefix) is filtered out at render-time, so the
-  // highest-traffic models that aren't on this user's dial bubble to
-  // the top of the visible field. The actual route is always chosen
-  // from the operator's configured tiers — these only populate the
-  // field. With the real/decoy distinction removed, configured models
-  // are no longer VISUALLY distinguishable from the rest (the roster can
-  // still be inferred by correlating shown names against this public
-  // pool — closing that fully is a separate, deeper change).
-  const _ROUTER_FX_DECOY_POOL = [
-    'deepseek-v4-flash',
-    'claude-sonnet-4.6',
-    'qwen3.6-plus',
-    'minimax-m2.7',
-    'gpt-5.5',
-    'gemini-3.5-flash',
-    'glm-5-turbo',
-    'claude-opus-4.8',
-    'nemotron-3-super',
-    'deepseek-v4-pro',
-    'mimo-v2.5-pro',
-    'gpt-5.4',
-    'kimi-k2.6',
-    'claude-opus-4.7',
-    'gemini-3.1-flash-lite',
-    'glm-5.1',
-    'qwen3.6-max',
-    'claude-haiku-4.5',
-    'grok-4.3',
-    'gpt-5.4-mini',
-    'gemini-2.5-flash',
-    'step-3.5-flash',
-    'mistral-medium-3.5',
-    'ling-2.6-1t',
-    'deepseek-v3.2',
-    'trinity-large-thinking',
-    'gemini-2.5-pro',
-    'seed-2.0-mini',
-    'gpt-5.3-codex',
-    'grok-4.20',
-    'mercury-2',
-    'hunyuan-3',
-    'mimo-v2-omni',
-    'command-r-plus',
-    'llama-4-405b',
-    'sonar-large',
-  ];
+   * Fires once per user message when session.event.router_decision lands.
+   * The grid contains only the effective candidates that could actually be
+   * called for this request kind, deduped by display model name. A
+   * hammer-selector hops between those real cells and locks onto the routed
+   * cell with a particle burst. The strip is non-blocking — assistant text
+   * streams below the grid while the chase plays above. */
 
   // OpenSquilla's tier ids vary by tier_profile. We seed the slot
   // list from config and register any decision tier we haven't seen
@@ -3317,6 +3261,7 @@ const ChatView = (() => {
   const _ROUTER_FX_DEFAULT_TIERS = ['t0', 't1', 't2', 't3'];
   let _routerFxSlotList = _ROUTER_FX_DEFAULT_TIERS.slice();
   const _routerFxModels = {};
+  const _routerFxTierConfigs = {};
   // Authoritative set of tier ids that exist in the *current* config
   // snapshot (populated by _loadFeatureToggles). Used to skip history
   // strips whose routed_tier has been removed from config and to know
@@ -3386,6 +3331,106 @@ const ChatView = (() => {
 
   function _routerFxStripProvider(name) {
     return _modelDisplayName(name);
+  }
+
+  function _routerFxRequestKindFromAttachments(attachments) {
+    const list = Array.isArray(attachments) ? attachments : [];
+    for (const item of list) {
+      const mime = String(item?.mime || item?.type || '').toLowerCase();
+      if (mime.indexOf('image/') === 0) return 'image';
+    }
+    return 'text';
+  }
+
+  function _routerFxNormalizeRequestKind(requestKind) {
+    return requestKind === 'image' ? 'image' : 'text';
+  }
+
+  function _routerFxTierConfig(tier) {
+    const norm = typeof tier === 'string' ? tier.toLowerCase() : '';
+    const known = norm ? _routerFxTierConfigs[norm] : null;
+    if (known) return known;
+    return {
+      model: norm && _routerFxModels[norm] ? _routerFxModels[norm] : '',
+      supportsImage: false,
+      imageOnly: false,
+    };
+  }
+
+  function _routerFxRememberTierDecision(tier, model) {
+    if (typeof tier !== 'string' || !tier) return;
+    const norm = tier.toLowerCase();
+    _routerFxRegisterTier(norm);
+    if (!model) return;
+    const modelName = String(model);
+    _routerFxModels[norm] = modelName;
+    const current = _routerFxTierConfigs[norm] || {};
+    _routerFxTierConfigs[norm] = {
+      model: modelName,
+      supportsImage: current.supportsImage === true,
+      imageOnly: current.imageOnly === true,
+    };
+  }
+
+  function _routerFxTierMatchesRequestKind(tierConfig, requestKind) {
+    const kind = _routerFxNormalizeRequestKind(requestKind);
+    if (kind === 'image') return !!(tierConfig.supportsImage || tierConfig.imageOnly);
+    return !tierConfig.imageOnly;
+  }
+
+  function _routerFxRequestKindFromDecision(decision, fallbackKind) {
+    if (fallbackKind) return _routerFxNormalizeRequestKind(fallbackKind);
+    const source = String(decision?.source || decision?.routing_source || '').toLowerCase();
+    const tier = String(decision?.tier || decision?.routed_tier || '').toLowerCase();
+    if (source === 'image_route' || tier === 'image_model') return 'image';
+    return 'text';
+  }
+
+  function _routerFxVisualEntries(requestKind, decision) {
+    if (_routerFxConfigTiers === null) return [];
+    const kind = _routerFxRequestKindFromDecision(decision, requestKind);
+    const byDisplay = new Map();
+    _routerFxSlotList.forEach((tier) => {
+      if (_routerFxConfigTiers !== null && !_routerFxConfigTiers.has(tier)) return;
+      const tierConfig = _routerFxTierConfig(tier);
+      if (!_routerFxTierMatchesRequestKind(tierConfig, kind)) return;
+      const displayName = tierConfig.model ? _routerFxStripProvider(tierConfig.model) : tier;
+      const key = displayName ? displayName.toLowerCase() : tier;
+      let entry = byDisplay.get(key);
+      if (!entry) {
+        entry = { key, tiers: [], model: tierConfig.model || '', displayName };
+        byDisplay.set(key, entry);
+      }
+      entry.tiers.push(tier);
+      if (!entry.model && tierConfig.model) entry.model = tierConfig.model;
+    });
+    const decisionTier = decision && typeof decision.tier === 'string'
+      ? decision.tier.toLowerCase()
+      : '';
+    const decisionModel = decision && typeof decision.model === 'string' ? decision.model : '';
+    if (decisionTier && decisionModel) {
+      const displayName = _routerFxStripProvider(decisionModel);
+      const key = displayName ? displayName.toLowerCase() : decisionTier;
+      let entry = byDisplay.get(key);
+      if (!entry && _routerFxTierMatchesRequestKind(_routerFxTierConfig(decisionTier), kind)) {
+        entry = { key, tiers: [], model: decisionModel, displayName };
+        byDisplay.set(key, entry);
+      }
+      if (entry) {
+        if (entry.tiers.indexOf(decisionTier) < 0) entry.tiers.push(decisionTier);
+        if (!entry.model) entry.model = decisionModel;
+      }
+    }
+    return Array.from(byDisplay.values()).map((e) => ({
+      key: e.key,
+      tiers: _routerFxSortTiers(e.tiers),
+      model: e.model,
+      displayName: e.displayName || (e.model ? _routerFxStripProvider(e.model) : e.tiers[0]),
+    }));
+  }
+
+  function _routerFxHasMultipleCandidates(requestKind, decision) {
+    return _routerFxVisualEntries(requestKind, decision).length > 1;
   }
 
   // Promise resolved when _loadFeatureToggles has populated tier
@@ -3520,110 +3565,25 @@ const ChatView = (() => {
     }
   }
 
-  // Group tiers by their backing model so two tiers that resolve to
-  // the same model don't get two cells.
-  function _routerFxRealEntries(decision) {
-    const winnerTier = decision && typeof decision.tier === 'string' ? decision.tier.toLowerCase() : '';
-    const winnerModel = decision && typeof decision.model === 'string' ? decision.model : '';
-    const slotKeyOf = (tier) => {
-      const m = _routerFxModels[tier];
-      return m ? m : 'tier:' + tier;
-    };
-    const byKey = new Map();
-    _routerFxSlotList.forEach((tier) => {
-      const key = slotKeyOf(tier);
-      let entry = byKey.get(key);
-      if (!entry) {
-        entry = { key, tiers: [], model: _routerFxModels[tier] || '' };
-        byKey.set(key, entry);
-      }
-      entry.tiers.push(tier);
-    });
-    if (winnerTier && winnerModel) {
-      const target = byKey.get(slotKeyOf(winnerTier));
-      if (target && !target.model) target.model = winnerModel;
-    }
-    return Array.from(byKey.values()).map((e) => ({
-      key: e.key,
-      tiers: e.tiers,
-      model: e.model,
-      displayName: e.model ? _routerFxStripProvider(e.model) : e.tiers[0],
-    }));
+  // Build the visual roster for this turn only. Text requests exclude
+  // image-only routes; image requests include only image-capable routes.
+  // Entries are deduped by display model name so provider/thinking/tier
+  // differences do not create extra visual cells.
+  function _routerFxRealEntries(decision, requestKind) {
+    return _routerFxVisualEntries(requestKind, decision);
   }
 
-  // FNV-1a 32-bit hash of a string — folds the seed key down to a
-  // single integer for mulberry32 to seed off.
-  function _routerFxHashSeed(key) {
-    let h = 0x811c9dc5;
-    const s = String(key == null ? '' : key);
-    for (let i = 0; i < s.length; i++) {
-      h ^= s.charCodeAt(i);
-      h = Math.imul(h, 0x01000193);
-    }
-    return h >>> 0;
-  }
-
-  // mulberry32 PRNG — deterministic, well-distributed, ~10 LoC.
-  function _routerFxMulberry32(seed) {
-    let state = seed >>> 0;
-    return function () {
-      state = (state + 0x6D2B79F5) >>> 0;
-      let t = state;
-      t = Math.imul(t ^ (t >>> 15), t | 1);
-      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-    };
-  }
-
-  // Fisher-Yates in place using the supplied RNG (defaults to
-  // Math.random when no seed key is given — exclusively for code
-  // paths that don't have a stable identifier).
-  function _routerFxShuffle(arr, seedKey) {
-    const rng = seedKey != null
-      ? _routerFxMulberry32(_routerFxHashSeed(seedKey))
-      : Math.random;
-    for (let i = arr.length - 1; i > 0; i--) {
-      const j = Math.floor(rng() * (i + 1));
-      const tmp = arr[i];
-      arr[i] = arr[j];
-      arr[j] = tmp;
-    }
-    return arr;
-  }
-
-  // Assemble the grid (_ROUTER_FX_GRID_CELLS cells): real (deduped) entries + decoys.
-  // Real cells land on distributed anchor slots in a deterministic model order,
-  // so each available model keeps a stable position. The live selector animation
-  // remains random; only the underlying dial layout is fixed.
+  // Assemble the grid from real candidates only. No filler/decoy wall: every
+  // visible model name is a candidate that could actually be called this turn.
   function _routerFxBuildGridCells(realEntries, seedKey) {
-    const cells = Array.from({ length: _ROUTER_FX_GRID_CELLS }, () => null);
-    const realNames = new Set();
     const orderedRealEntries = realEntries.slice().sort((a, b) => (
       (a.displayName || a.key || '').localeCompare(b.displayName || b.key || '')
     ));
-    orderedRealEntries.forEach((entry, i) => {
-      const anchor = _ROUTER_FX_REAL_ANCHOR_CELLS[i];
-      const idx = typeof anchor === 'number' ? anchor : cells.findIndex((cell) => cell == null);
-      if (idx < 0 || idx >= cells.length) return;
-      cells[idx] = { kind: 'real', entry, displayName: entry.displayName };
-      if (entry.displayName) realNames.add(entry.displayName);
-    });
-
-    const decoys = [];
-    for (let i = 0; i < _ROUTER_FX_DECOY_POOL.length && decoys.length < _ROUTER_FX_GRID_CELLS; i++) {
-      const name = _ROUTER_FX_DECOY_POOL[i];
-      if (realNames.has(name)) continue;
-      decoys.push({ kind: 'decoy', displayName: name });
-    }
-    while (decoys.length < _ROUTER_FX_GRID_CELLS) {
-      decoys.push({ kind: 'decoy', displayName: '—' });
-    }
-    const orderedDecoys = _routerFxShuffle(decoys, seedKey ? seedKey + ':decoy' : undefined);
-    let decoyIdx = 0;
-    for (let i = 0; i < cells.length; i++) {
-      if (cells[i] == null) cells[i] = orderedDecoys[decoyIdx++];
-    }
-    return cells;
+    return orderedRealEntries.map((entry) => ({
+      kind: 'real',
+      entry,
+      displayName: entry.displayName,
+    }));
   }
 
   function _buildRouterFxElement(decision, opts) {
@@ -3665,32 +3625,21 @@ const ChatView = (() => {
     const seedKey = opts && opts.seedKey ? String(opts.seedKey) : '';
     if (seedKey) wrap.dataset.seed = seedKey;
 
-    // Cloud variant: a focal-depth nebula of pool models + the routed winner.
-    // No configured roster is rendered. Returns early; the grid build below
-    // is the default look.
-    if (variant === 'cloud') {
-      _routerFxBuildCloud(wrap, decision, seedKey);
-      if (opts.preSettled) {
-        _settleRouterFxCloud(wrap);
-        _routerFxNormalizeSettledStrip(wrap, opts.renderMode || 'history', decision);
-      }
-      return wrap;
-    }
-
-    const realEntries = _routerFxRealEntries(decision);
+    const requestKind = _routerFxRequestKindFromDecision(decision, opts.requestKind);
+    const realEntries = _routerFxRealEntries(decision, requestKind);
+    if (realEntries.length <= 1) return null;
     const gridCells = _routerFxBuildGridCells(realEntries, seedKey || undefined);
 
     const grid = document.createElement('div');
     grid.className = 'router-fx-grid';
+    const cols = Math.min(4, Math.max(2, gridCells.length));
+    const mobileCols = gridCells.length > 2 ? 2 : gridCells.length;
+    grid.style.setProperty('--router-fx-cols', String(cols));
+    grid.style.setProperty('--router-fx-mobile-cols', String(Math.max(1, mobileCols)));
     gridCells.forEach((cellInfo, i) => {
       const cell = document.createElement('div');
       cell.className = 'router-fx-cell';
       cell.dataset.cellIdx = String(i);
-      // Intentionally NOT stamping which cell is real (configured) vs decoy:
-      // every cell renders identically, and the DOM must not leak the
-      // operator's wired-up model roster. Winner detection reads the in-memory
-      // _fxGridCells array (below), not any DOM attribute, so the routing
-      // result still lands on the right cell without exposing the rest.
       // title surfaces the full name on hover when a long one is ellipsized.
       cell.innerHTML = `<span class="nm" title="${_esc(cellInfo.displayName)}">${_esc(cellInfo.displayName)}</span>`;
       grid.appendChild(cell);
@@ -3702,6 +3651,7 @@ const ChatView = (() => {
 
     wrap._fxGridCells = gridCells;
     wrap._fxRealEntries = realEntries;
+    wrap._fxRequestKind = requestKind;
 
     if (opts.preSettled) {
       const winnerIdx = _routerFxWinnerCellIndex(wrap, decision.tier);
@@ -3788,9 +3738,6 @@ const ChatView = (() => {
     if (selector) selector.classList.remove('visible', 'lock', 'lock-impact');
     wrap.querySelectorAll('.router-fx-cell.pinging').forEach((cell) => {
       cell.classList.remove('pinging');
-    });
-    wrap.querySelectorAll('.router-fx-mote.is-scan').forEach((mote) => {
-      mote.classList.remove('is-scan');
     });
     wrap.querySelectorAll('.router-fx-burst').forEach((burst) => burst.remove());
   }
@@ -3947,116 +3894,13 @@ const ChatView = (() => {
     });
   }
 
-  // ── Cloud variant ("model nebula" / rack-focus) ─────────────────────
-  // A focal-depth field of ~36 pool models + the routed winner, scattered
-  // at seeded positions/depths. Routing reads as a camera rack-focus pull:
-  // the whole field defocuses, then the winner snaps sharp and blooms an
-  // accent glow at the focal point while the rest recede to bokeh. The field
-  // is pool + winner ONLY (never the configured roster), so it exposes
-  // nothing beyond the already-public routed model.
+  // Winner label used for settled semantics and assistive text.
   function _routerFxWinnerName(decision) {
     const model = decision && (decision.model || decision.routed_model);
     if (model) return _routerFxStripProvider(String(model));
     const tier = decision && decision.tier ? String(decision.tier).toLowerCase() : '';
     if (tier && _routerFxModels[tier]) return _routerFxStripProvider(_routerFxModels[tier]);
     return tier || '';
-  }
-
-  function _routerFxBuildCloud(wrap, decision, seedKey) {
-    const cloud = document.createElement('div');
-    cloud.className = 'router-fx-cloud';
-    const winnerName = _routerFxWinnerName(decision);
-    // Field = the public decoy pool + the routed winner (deduped). No
-    // configured-roster names beyond the winner are ever rendered.
-    const seen = new Set();
-    const names = [];
-    if (winnerName) { names.push(winnerName); seen.add(winnerName.toLowerCase()); }
-    _ROUTER_FX_DECOY_POOL.forEach((n) => {
-      const k = n.toLowerCase();
-      if (!seen.has(k)) { seen.add(k); names.push(n); }
-    });
-    // Deterministic per seed so a history rebuild reproduces the same nebula.
-    const rng = _routerFxMulberry32(_routerFxHashSeed((seedKey || '') + ':cloud'));
-    const wkey = winnerName ? winnerName.toLowerCase() : '';
-    let winnerEl = null;
-    names.forEach((name) => {
-      // Two layers, so motion never fights: the OUTER mote owns position +
-      // a perpetual parallax drift (transform) + the winner's travel-to-
-      // focus (left/top), while the INNER owns the rack-focus (scale, blur,
-      // opacity, glow). Splitting them means the field keeps breathing even
-      // once settled, and the winner glides to the focal point instead of
-      // teleporting.
-      const mote = document.createElement('span');
-      mote.className = 'router-fx-mote';
-      // Organic elliptical scatter: area-uniform radius (sqrt) at a random
-      // angle clusters names toward the core and thins to the edges — a soft
-      // nebula, no rigid rows. Focal depth d∈[0,1] drives blur, scale and
-      // opacity TOGETHER so it reads as coherent optical depth, not a tag cloud.
-      const d = rng();
-      const ang = rng() * Math.PI * 2;
-      const rad = Math.sqrt(rng());
-      const x = (50 + Math.cos(ang) * rad * 47).toFixed(2);
-      const y = (50 + Math.sin(ang) * rad * 41).toFixed(2);
-      const blur = (d * 3.4).toFixed(2);
-      const scale = (1.22 - d * 0.62).toFixed(3);
-      const op = (0.92 - d * 0.64).toFixed(3);
-      const z = Math.round((1 - d) * 100);
-      const driftDur = (11 + rng() * 9).toFixed(2);
-      const driftDelay = (-(rng() * 20)).toFixed(2);
-      const dx = (rng() * 2 - 1).toFixed(2);
-      const dy = (rng() * 2 - 1).toFixed(2);
-      mote.style.cssText =
-        `--x:${x}%;--y:${y}%;--z:${z};--drift:${driftDur}s;`
-        + `--ddelay:${driftDelay}s;--dx:${dx};--dy:${dy};`;
-      const inner = document.createElement('span');
-      inner.className = 'router-fx-mote-i';
-      inner.style.cssText = `--blur:${blur}px;--sc:${scale};--op:${op};`;
-      inner.textContent = name;
-      mote.appendChild(inner);
-      if (!winnerEl && wkey && name.toLowerCase() === wkey) {
-        mote.classList.add('router-fx-mote--winner');
-        winnerEl = mote;
-      }
-      cloud.appendChild(mote);
-    });
-    const reticle = document.createElement('div');
-    reticle.className = 'router-fx-reticle';
-    reticle.setAttribute('aria-hidden', 'true');
-    cloud.appendChild(reticle);
-    wrap.appendChild(cloud);
-    wrap._fxCloud = true;
-    wrap._fxWinnerEl = winnerEl;
-  }
-
-  // Settle with no animation (history rebuild, observe mode, reduced motion):
-  // winner in focus, the rest already receded — the CSS settled state does it.
-  function _settleRouterFxCloud(wrap) {
-    if (!wrap) return;
-    wrap.dataset.state = 'settled';
-    delete wrap.dataset.live;
-    delete wrap.dataset.scanning;
-    wrap._fxFinished = true;
-    _routerFxClearVisualResidue(wrap);
-    _routerFxApplySettledSemantics(wrap, wrap._fxDecision || null, wrap.dataset.renderMode);
-  }
-
-  // Live rack-focus: brief beat on the full field, defocus the whole field
-  // (ease-in, lens leaving focus), then snap the winner sharp (decelerate).
-  // The optical pull is CSS (mote transitions keyed off data-state); JS only
-  // flips the phase with the right timing.
-  function _animateRouterFxCloud(wrap) {
-    if (!wrap) return;
-    // Opt-in via the toggle, independent of OS reduce-motion (see
-    // _animateRouterFx). Settle directly only if there is no winner to focus.
-    if (!wrap._fxWinnerEl) { _settleRouterFxCloud(wrap); return; }
-    _routerFxClearAnimationTimers(wrap);
-    // Hold the in-focus field a beat so the defocus reads as intentional.
-    wrap._fxAnimTimers.push(setTimeout(() => {
-      if (wrap.isConnected && wrap.dataset.renderMode === 'live') wrap.dataset.state = 'playing';
-    }, 260));
-    wrap._fxAnimTimers.push(setTimeout(() => {
-      if (wrap.isConnected && wrap.dataset.renderMode === 'live') _settleRouterFxCloud(wrap);
-    }, 680));
   }
 
   // ── Scan → lock ─────────────────────────────────────────────────────────
@@ -4102,7 +3946,9 @@ const ChatView = (() => {
       });
       return;
     }
-    const started = _routerFxBeginScan(pending.anchorDiv, pending.seedKey);
+    const started = _routerFxBeginScan(pending.anchorDiv, pending.seedKey, {
+      requestKind: pending.requestKind,
+    });
     if (!started || !pending.decision || !_thread) return;
     const liveStrip = _thread.querySelector('.router-fx[data-live="true"]');
     if (!liveStrip || liveStrip.dataset.turnIndex !== String(pending.turnIndex)) return;
@@ -4117,7 +3963,9 @@ const ChatView = (() => {
     }
   }
 
-  function _scheduleRouterFxBeginScan(anchorDiv, seedKey) {
+  function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts) {
+    opts = opts || {};
+    const requestKind = _routerFxNormalizeRequestKind(opts.requestKind);
     _cancelPendingRouterFxScan('reschedule');
     if (_routerFxIsSuppressedForCompactionTurn(_routerFxCountUserMessages())) {
       _chatDiag('router_scan.schedule.skip.compaction_suppressed', {
@@ -4133,9 +3981,17 @@ const ChatView = (() => {
       });
       return false;
     }
+    if (!_routerFxHasMultipleCandidates(requestKind, null)) {
+      _chatDiag('router_scan.schedule.skip.single_candidate', {
+        requestKind,
+        candidates: _routerFxVisualEntries(requestKind, null).length,
+      });
+      return false;
+    }
     _routerFxScanPending = {
       anchorDiv,
       seedKey,
+      requestKind,
       sessionKey: _sessionKey || '',
       turnIndex: String(_routerFxCountUserMessages()),
       decision: null,
@@ -4143,6 +3999,7 @@ const ChatView = (() => {
     _routerFxScanDelayTimer = setTimeout(_finishPendingRouterFxScan, _ROUTER_FX_START_DELAY_MS);
     _chatDiag('router_scan.scheduled', {
       seedKey,
+      requestKind,
       delayMs: _ROUTER_FX_START_DELAY_MS,
       turnIndex: _routerFxScanPending.turnIndex,
       anchor: _chatDiagDescribeElement(anchorDiv),
@@ -4155,7 +4012,9 @@ const ChatView = (() => {
   // winner. The scan is JS-driven (discrete class/position changes every
   // ~170ms), so it renders regardless of any CSS-animation quirk — and it
   // fills the wait instead of trailing it, replacing the "Watching" placeholder.
-  function _routerFxBeginScan(anchorDiv, seedKey) {
+  function _routerFxBeginScan(anchorDiv, seedKey, opts) {
+    opts = opts || {};
+    const requestKind = _routerFxNormalizeRequestKind(opts.requestKind);
     if (_routerFxIsSuppressedForCompactionTurn(_routerFxCountUserMessages())) {
       _chatDiag('router_scan.skip.compaction_suppressed', {
         turnIndex: String(_routerFxCountUserMessages()),
@@ -4172,10 +4031,28 @@ const ChatView = (() => {
       });
       return false;
     }
+    if (!_routerFxHasMultipleCandidates(requestKind, null)) {
+      _chatDiag('router_scan.skip.single_candidate', {
+        requestKind,
+        candidates: _routerFxVisualEntries(requestKind, null).length,
+      });
+      return false;
+    }
     _thread.querySelectorAll('.router-fx[data-live="true"]').forEach((el) => {
       _routerFxRemoveStrip(el);
     });
-    const wrap = _buildRouterFxElement({ source: 'none' }, { seedKey, renderMode: 'live' });
+    const wrap = _buildRouterFxElement({ source: 'none' }, {
+      seedKey,
+      renderMode: 'live',
+      requestKind,
+    });
+    if (!wrap) {
+      _chatDiag('router_scan.skip.single_candidate', {
+        requestKind,
+        candidates: _routerFxVisualEntries(requestKind, null).length,
+      });
+      return false;
+    }
     wrap.dataset.live = 'true';
     wrap.dataset.scanning = 'true';
     wrap.dataset.state = 'scanning';
@@ -4227,15 +4104,14 @@ const ChatView = (() => {
     }
   }
 
-  // JS-driven roaming "search": every ~170ms a different candidate is brought
-  // into focus (cloud: a mote sharpens via .is-scan; grid: the hammer hops).
+  // JS-driven roaming "search": every ~190ms the selector hops across a real
+  // candidate cell.
   function _routerFxScanRoam(wrap) {
-    const isCloud = !!wrap._fxCloud;
-    const container = wrap.querySelector(isCloud ? '.router-fx-cloud' : '.router-fx-grid');
-    if (!container) return;
-    const targets = container.querySelectorAll(isCloud ? '.router-fx-mote' : '.router-fx-cell');
+    const grid = wrap.querySelector('.router-fx-grid');
+    if (!grid) return;
+    const targets = grid.querySelectorAll('.router-fx-cell');
     if (!targets.length) return;
-    const selector = isCloud ? null : container.querySelector('.router-fx-selector');
+    const selector = grid.querySelector('.router-fx-selector');
     if (selector) selector.classList.add('visible');
     let prev = -1;
     const step = () => {
@@ -4244,13 +4120,11 @@ const ChatView = (() => {
       let g = 0;
       do { i = Math.floor(Math.random() * targets.length); g++; } while (i === prev && g < 8);
       prev = i;
-      if (isCloud) {
-        targets.forEach((m, idx) => m.classList.toggle('is-scan', idx === i));
-      } else if (selector) {
+      if (selector) {
         _routerFxPositionSelector(selector, targets[i], { hopIdx: i });
         _routerFxPing(targets[i]);
       }
-      wrap._fxScanTimer = setTimeout(step, isCloud ? 170 : 190);
+      wrap._fxScanTimer = setTimeout(step, 190);
     };
     step();
   }
@@ -4260,7 +4134,6 @@ const ChatView = (() => {
     if (wrap._fxScanTimer) { clearTimeout(wrap._fxScanTimer); wrap._fxScanTimer = null; }
     if (wrap._fxScanCap) { clearTimeout(wrap._fxScanCap); wrap._fxScanCap = null; }
     delete wrap.dataset.scanning;
-    wrap.querySelectorAll('.router-fx-mote.is-scan').forEach((m) => m.classList.remove('is-scan'));
   }
 
   function _routerFxPauseScanTimers(wrap) {
@@ -4297,7 +4170,7 @@ const ChatView = (() => {
     _thread.querySelectorAll('.router-fx[data-live="true"]').forEach((wrap) => {
       // Output already complete/arriving → finish the scan immediately, locking
       // onto the cached winner (no half-scan left hanging). Do not mark frozen:
-      // _routerFxLockGrid/_routerFxLockCloud own the visible selection motion.
+      // _routerFxLockGrid owns the visible selection motion.
       if (wrap._fxDecision) {
         _routerFxFinishScan(wrap);
       } else {
@@ -4324,36 +4197,13 @@ const ChatView = (() => {
       wrap.dataset.rolloutPhase = typeof decision.rollout_phase === 'string'
         ? decision.rollout_phase : 'observe';
     }
-    if (wrap._fxCloud) _routerFxLockCloud(wrap, decision);
-    else _routerFxLockGrid(wrap, decision);
-  }
-
-  function _routerFxLockCloud(wrap, decision) {
-    const winnerName = _routerFxWinnerName(decision);
-    const wkey = winnerName ? winnerName.toLowerCase() : '';
-    let winnerEl = null;
-    const motes = wrap.querySelectorAll('.router-fx-mote');
-    if (wkey) {
-      motes.forEach((m) => {
-        const inner = m.querySelector('.router-fx-mote-i');
-        if (!winnerEl && inner && (inner.textContent || '').trim().toLowerCase() === wkey) winnerEl = m;
-      });
-      if (!winnerEl && motes.length) {
-        // Routed model isn't in the field — relabel the first mote to it.
-        winnerEl = motes[0];
-        const inner = winnerEl.querySelector('.router-fx-mote-i');
-        if (inner) inner.textContent = winnerName;
-      }
-    }
-    if (winnerEl) { winnerEl.classList.add('router-fx-mote--winner'); wrap._fxWinnerEl = winnerEl; }
-    requestAnimationFrame(() => { if (wrap.isConnected) _settleRouterFxCloud(wrap); });
+    _routerFxLockGrid(wrap, decision);
   }
 
   function _routerFxLockGrid(wrap, decision) {
     const tier = decision.tier ? String(decision.tier) : '';
     if (tier) {
-      _routerFxRegisterTier(tier);
-      if (decision.model) _routerFxModels[tier.toLowerCase()] = String(decision.model);
+      _routerFxRememberTierDecision(tier, decision.model || '');
     }
     const winnerIdx = _routerFxWinnerCellIndex(wrap, tier);
     if (winnerIdx >= 0) {
@@ -4499,10 +4349,7 @@ const ChatView = (() => {
       _chatDiag('router_decision.skip.no_tier', _chatDiagSummarizePayload(payload));
       return;
     }
-    _routerFxRegisterTier(tier);
-    if (payload.model) {
-      _routerFxModels[tier.toLowerCase()] = String(payload.model);
-    }
+    _routerFxRememberTierDecision(tier, payload.model || '');
     const turnIndex = _routerFxCountUserMessages();
     if (_routerFxIsSuppressedForCompactionTurn(turnIndex)) {
       if (_thread) {
@@ -4536,6 +4383,7 @@ const ChatView = (() => {
       _chatDiag('router_decision.cached_on_pending_scan', {
         payload: _chatDiagSummarizePayload(payload),
         turnIndex: _routerFxScanPending.turnIndex || '',
+        requestKind: _routerFxScanPending.requestKind || '',
       });
       return;
     }
@@ -4576,6 +4424,11 @@ const ChatView = (() => {
       _chatDiag('router_decision.skip.disabled_post_config', _chatDiagSummarizePayload(payload));
       return;
     }
+    const replayRequestKind = _routerFxRequestKindFromDecision(payload, null);
+    if (!_routerFxHasMultipleCandidates(replayRequestKind, payload)) {
+      _chatDiag('router_decision.skip.single_candidate', _chatDiagSummarizePayload(payload));
+      return;
+    }
     if (!_historyHasRendered || _historyHydrating) {
       _cachePendingRouterDecision(payload);
       _chatDiag('router_decision.cached_during_history_hydration', {
@@ -4602,14 +4455,16 @@ const ChatView = (() => {
       preSettled: true,
       renderMode: 'history',
       seedKey: replaySeed,
+      requestKind: replayRequestKind,
     });
-    // Cloud flags its winner mote at build time; the grid resolves a winning
-    // cell index. Either way, bail if there is no winner to focus.
-    const winnerIdx = wrap._fxCloud ? -1 : _routerFxWinnerCellIndex(wrap, tier);
-    if (wrap._fxCloud ? !wrap._fxWinnerEl : winnerIdx < 0) {
+    if (!wrap) {
+      _chatDiag('router_decision.skip.single_candidate', _chatDiagSummarizePayload(payload));
+      return;
+    }
+    const winnerIdx = _routerFxWinnerCellIndex(wrap, tier);
+    if (winnerIdx < 0) {
       _chatDiag('router_decision.skip.no_winner', {
         payload: _chatDiagSummarizePayload(payload),
-        cloud: !!wrap._fxCloud,
         winnerIdx,
       });
       return;
@@ -4648,7 +4503,8 @@ const ChatView = (() => {
   // `seedKey` should be a stable per-turn identifier (msg.timestamp
   // or message id) so the cell shuffle reproduces deterministically
   // across page refreshes.
-  function _buildRouterFxFromUsage(usage, seedKey) {
+  function _buildRouterFxFromUsage(usage, seedKey, opts) {
+    opts = opts || {};
     if (!usage) return null;
     // User-pref gate: the viewer has hidden the router-fx visualisation, so
     // no history strip is built. Distinct from the operator routing flag below
@@ -4668,7 +4524,7 @@ const ChatView = (() => {
         && !_routerFxConfigTiers.has(tier.toLowerCase())) {
       return null;
     }
-    _routerFxRegisterTier(tier);
+    _routerFxRememberTierDecision(tier, usage.routed_model || usage.model || '');
     const decision = {
       tier,
       model: usage.routed_model || usage.model || '',
@@ -4678,7 +4534,7 @@ const ChatView = (() => {
       routing_applied: usage.routing_applied !== false,
       rollout_phase: usage.rollout_phase || 'full',
     };
-    if (decision.model) _routerFxModels[tier.toLowerCase()] = decision.model;
+    const requestKind = _routerFxRequestKindFromDecision(decision, opts.requestKind);
     // The cached seed from _routerFxResolveSeed already encodes
     // (stamp, tier, turnIndex) — pass it through verbatim so that
     // live and history paths derive the SAME shuffle for the same
@@ -4688,6 +4544,7 @@ const ChatView = (() => {
     return _buildRouterFxElement(decision, {
       preSettled: true,
       seedKey: seedKey != null ? String(seedKey) : ('history:' + tier),
+      requestKind: requestKind,
     });
   }
 
@@ -5615,9 +5472,13 @@ const ChatView = (() => {
     // keyed by (sessionKey, userMsgIndex, tier); using this counter
     // means live + history rebuilds for the same turn reuse the same layout.
     let _histUserIdx = 0;
+    let _histLastUserRequestKind = 'text';
     const consumedHistoryElements = new Set();
     messages.forEach((msg) => {
-        if (msg.role === 'user') _histUserIdx++;
+        if (msg.role === 'user') {
+          _histUserIdx++;
+          _histLastUserRequestKind = _routerFxRequestKindFromAttachments(msg.attachments || []);
+        }
         const rawText = msg.text || '';
         const displayText = msg.role === 'user' ? _stripTimePrefix(rawText) : rawText;
         const stableIdentity = _historyStableMessageIdentity(msg);
@@ -5743,7 +5604,9 @@ const ChatView = (() => {
                 if (existingStrip) _routerFxRemoveStrip(existingStrip);
                 const hint = msg.timestamp || msg.ts || msg.message_id || '';
                 const cachedSeed = _routerFxResolveLayoutSeed(_sessionKey, hint);
-                const routerStrip = _buildRouterFxFromUsage(savedUsage, cachedSeed);
+                const routerStrip = _buildRouterFxFromUsage(savedUsage, cachedSeed, {
+                  requestKind: _histLastUserRequestKind,
+                });
                 if (routerStrip) {
                   routerStrip.dataset.sessionKey = _sessionKey || '';
                   routerStrip.dataset.turnIndex = String(_histUserIdx);
@@ -6186,6 +6049,7 @@ const ChatView = (() => {
     }
     const normalizationProvenance = _inputNormalizationProvenanceFromAttachments(_pendingAttachments);
     if (normalizationProvenance) params.inputProvenance = normalizationProvenance;
+    const routerFxRequestKind = _routerFxRequestKindFromAttachments(params.attachments || []);
 
     // Clear input and attachments
     _textarea.value = '';
@@ -6196,7 +6060,9 @@ const ChatView = (() => {
     // Start streaming UI. Delay the routing scan briefly so request-time
     // compaction can claim the turn without a competing one-frame router flash.
     _startStreaming();
-    const routerScanStarted = _scheduleRouterFxBeginScan(userDiv, _routerFxResolveLayoutSeed(_sessionKey));
+    const routerScanStarted = _scheduleRouterFxBeginScan(userDiv, _routerFxResolveLayoutSeed(_sessionKey), {
+      requestKind: routerFxRequestKind,
+    });
     _chatDiag('send.start', {
       textLen: providerText.length,
       attachments: params.attachments ? params.attachments.length : 0,

--- a/src/opensquilla/gateway/static/js/views/chat.js
+++ b/src/opensquilla/gateway/static/js/views/chat.js
@@ -3930,7 +3930,7 @@ const ChatView = (() => {
     }
   }
 
-  function _finishPendingRouterFxScan() {
+  async function _finishPendingRouterFxScan() {
     const pending = _routerFxScanPending;
     _routerFxScanDelayTimer = null;
     _routerFxScanPending = null;
@@ -3945,6 +3945,22 @@ const ChatView = (() => {
     if (_isCompactInFlightForCurrentSession()
         || _routerFxIsSuppressedForCompactionTurn(pending.turnIndex)) {
       _chatDiag('router_scan.pending.drop.compaction_suppressed', {
+        sessionKey: pending.sessionKey || '',
+        turnIndex: pending.turnIndex || '',
+      });
+      return;
+    }
+    await _routerFxAwaitConfig();
+    if (pending.sessionKey !== (_sessionKey || '')) {
+      _chatDiag('router_scan.pending.drop.session_changed_after_config', {
+        pendingSessionKey: pending.sessionKey || '',
+        sessionKey: _sessionKey || '',
+      });
+      return;
+    }
+    if (_isCompactInFlightForCurrentSession()
+        || _routerFxIsSuppressedForCompactionTurn(pending.turnIndex)) {
+      _chatDiag('router_scan.pending.drop.compaction_suppressed_after_config', {
         sessionKey: pending.sessionKey || '',
         turnIndex: pending.turnIndex || '',
       });
@@ -3985,7 +4001,7 @@ const ChatView = (() => {
       });
       return false;
     }
-    if (!_routerFxHasMultipleCandidates(requestKind, null)) {
+    if (_routerFxConfigTiers !== null && !_routerFxHasMultipleCandidates(requestKind, null)) {
       _chatDiag('router_scan.schedule.skip.single_candidate', {
         requestKind,
         candidates: _routerFxVisualEntries(requestKind, null).length,
@@ -4000,7 +4016,9 @@ const ChatView = (() => {
       turnIndex: String(_routerFxCountUserMessages()),
       decision: null,
     };
-    _routerFxScanDelayTimer = setTimeout(_finishPendingRouterFxScan, _ROUTER_FX_START_DELAY_MS);
+    _routerFxScanDelayTimer = setTimeout(() => {
+      void _finishPendingRouterFxScan();
+    }, _ROUTER_FX_START_DELAY_MS);
     _chatDiag('router_scan.scheduled', {
       seedKey,
       requestKind,

--- a/src/opensquilla/gateway/static/js/views/chat.js
+++ b/src/opensquilla/gateway/static/js/views/chat.js
@@ -43,6 +43,10 @@ const ChatView = (() => {
   let _currentRunStatus = 'idle';
   let _historySyncTimer = null;
   const _AWAITING_MODEL_CLASS = 'awaiting-model';
+  const _STREAM_ACTIVE_MARK_CLASS = 'streaming-active-mark';
+  const _STREAM_ACTIVE_MARK_DELAY_MS = 3500;
+  let _streamActiveMarkTimer = null;
+  let _streamActiveMarkVisibleStartedAt = 0;
   let _lastVisibleStreamEvent = '';
   const _DEFAULT_STREAM_IDLE_TIMEOUT_MS = 210000; // server should emit terminal first
   let _streamIdleTimeoutMs = _DEFAULT_STREAM_IDLE_TIMEOUT_MS;
@@ -6402,6 +6406,38 @@ const ChatView = (() => {
     return true;
   }
 
+  function _clearStreamActiveMarkReveal() {
+    if (_streamActiveMarkTimer) {
+      clearTimeout(_streamActiveMarkTimer);
+      _streamActiveMarkTimer = null;
+    }
+    _streamActiveMarkVisibleStartedAt = 0;
+    if (_streamBubble) _streamBubble.classList.remove(_STREAM_ACTIVE_MARK_CLASS);
+  }
+
+  function _beginStreamActiveMarkRevealWindow() {
+    _streamActiveMarkVisibleStartedAt = Date.now();
+    _scheduleStreamActiveMarkReveal();
+  }
+
+  function _maybeRevealStreamActiveMark() {
+    if (!_isStreaming || !_streamBubble) return false;
+    const elapsedMs = _streamActiveMarkVisibleStartedAt ? Date.now() - _streamActiveMarkVisibleStartedAt : 0;
+    if (elapsedMs < _STREAM_ACTIVE_MARK_DELAY_MS) return false;
+    _streamBubble.classList.add(_STREAM_ACTIVE_MARK_CLASS);
+    return true;
+  }
+
+  function _scheduleStreamActiveMarkReveal() {
+    if (_streamActiveMarkTimer) clearTimeout(_streamActiveMarkTimer);
+    const generation = _streamGeneration;
+    _streamActiveMarkTimer = setTimeout(() => {
+      _streamActiveMarkTimer = null;
+      if (_streamGeneration !== generation) return;
+      _maybeRevealStreamActiveMark();
+    }, _STREAM_ACTIVE_MARK_DELAY_MS);
+  }
+
   function _startStreaming() {
     _chatDiag('stream.start.before', {
       wasStreaming: _isStreaming,
@@ -6475,6 +6511,7 @@ const ChatView = (() => {
       }
 
       _thread.appendChild(_streamBubble);
+      _beginStreamActiveMarkRevealWindow();
 
       // Create the first text segment
       _newTextSegment();
@@ -6482,6 +6519,7 @@ const ChatView = (() => {
         streamBubble: _chatDiagDescribeElement(_streamBubble),
       });
     }
+    _maybeRevealStreamActiveMark();
     return _streamBubble;
   }
 
@@ -6580,6 +6618,7 @@ const ChatView = (() => {
     if (_renderRafId) { cancelAnimationFrame(_renderRafId); _renderRafId = null; }
     _renderDirty = false;
     _clearStreamIdleTimer();
+    _clearStreamActiveMarkReveal();
     _streamIdlePausedForApproval = false;
     _approvalPendingForCurrentSession = false;
     if (_streamBubble) {
@@ -9155,6 +9194,7 @@ const ChatView = (() => {
     // Clear the root --composer-h so other views' toasts don't keep that offset.
     document.documentElement.style.removeProperty('--composer-h');
     if (_isStreaming) _endStreaming();
+    _clearStreamActiveMarkReveal();
     _hideThinkingIndicator();
     _cancelPendingRouterFxScan('destroy');
     if (_renderRafId) { cancelAnimationFrame(_renderRafId); _renderRafId = null; }

--- a/src/opensquilla/gateway/static/js/views/setup.js
+++ b/src/opensquilla/gateway/static/js/views/setup.js
@@ -524,6 +524,9 @@ const SetupView = (() => {
   }
 
   function _tierRow(name, tier) {
+    const isImageModel = name === 'image_model';
+    const imageCheckedAttr = isImageModel ? ' checked disabled' :
+      (tier.supportsImage || tier.supports_image ? ' checked' : '');
     return `<div class="setup-tier-table__row" role="row" data-tier="${_esc(name)}">
       <span><code>${_esc(name)}</code></span>
       <input ${_tierControlAttrs(name, 'provider', 'provider')} data-tier-field="provider" value="${_esc(tier.provider || '')}">
@@ -531,7 +534,7 @@ const SetupView = (() => {
       <select ${_tierControlAttrs(name, 'thinkingLevel', 'thinking level')} data-tier-field="thinkingLevel">
         ${['', 'off', 'none', 'minimal', 'low', 'medium', 'high', 'xhigh'].map(v => `<option value="${v}"${v === (tier.thinkingLevel || tier.thinking_level || '') ? ' selected' : ''}>${v || '-'}</option>`).join('')}
       </select>
-      <input ${_tierControlAttrs(name, 'supportsImage', 'supports image')} type="checkbox" data-tier-field="supportsImage"${tier.supportsImage || tier.supports_image ? ' checked' : ''}>
+      <input ${_tierControlAttrs(name, 'supportsImage', 'supports image')} type="checkbox" data-tier-field="supportsImage"${imageCheckedAttr}>
     </div>`;
   }
 
@@ -1580,6 +1583,10 @@ const SetupView = (() => {
         const key = input.dataset.tierField;
         tier[key] = input.type === 'checkbox' ? input.checked : input.value;
       });
+      if (row.dataset.tier === 'image_model') {
+        tier.supportsImage = true;
+        tier.image_only = true;
+      }
       tiers[row.dataset.tier] = tier;
     });
     try {

--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -139,6 +139,15 @@ def _normalize_tier_payload(name: str, payload: Any) -> dict[str, Any]:
     return out
 
 
+def _enforce_router_tier_role_invariants(name: str, tier: dict[str, Any]) -> dict[str, Any]:
+    if name != "image_model":
+        return tier
+    out = dict(tier)
+    out["supports_image"] = True
+    out["image_only"] = True
+    return out
+
+
 def _merge_router_tiers(
     base: dict[str, Any],
     overrides: dict[str, Any] | None,
@@ -153,7 +162,7 @@ def _merge_router_tiers(
         override = _normalize_tier_payload(tier_name, raw_override)
         current = dict(merged.get(tier_name, {}))
         current.update(override)
-        merged[tier_name] = current
+        merged[tier_name] = _enforce_router_tier_role_invariants(tier_name, current)
     return merged
 
 

--- a/tests/functional/test_webui_browser_chat_e2e.py
+++ b/tests/functional/test_webui_browser_chat_e2e.py
@@ -1632,6 +1632,8 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                   winners: strips.map(
                     el => el.querySelector(".router-fx-cell.win .nm")?.textContent || ""
                   ),
+                  cellCount: cells.length,
+                  cellLabels: cells.map(el => el.textContent || ""),
                   hasLongLabel: cells.some(el => el.textContent === "gemini-3.1-flash-lite"),
                   overflows,
                   gridWithinViewport: gridRect
@@ -1662,6 +1664,20 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                   sessionKey: "agent:main:webchat:router-fx-panel",
                   historyMessages: [],
                   chatCalls: [],
+                  routerConfig: {
+                    enabled: true,
+                    rollout_phase: "full",
+                    tiers: {
+                      t1: { model: "openrouter/deepseek-v4-flash" },
+                      t2: { model: "openrouter/gemini-3.1-flash-lite" },
+                      t3: { model: "openrouter/qwen3.6-max" },
+                      image_model: {
+                        model: "openrouter/kimi-k2.6",
+                        supports_image: true,
+                        image_only: true,
+                      },
+                    },
+                  },
                 };
                 const rpc = App.getRpc();
                 const originalCall = rpc.call.bind(rpc);
@@ -1672,15 +1688,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                   if (method === "config.get") {
                     return Promise.resolve({
                       permissions: { default_mode: "ask" },
-                      squilla_router: {
-                        enabled: true,
-                        rollout_phase: "full",
-                        tiers: {
-                          t1: { model: "openrouter/deepseek-v4-flash" },
-                          t2: { model: "openrouter/gemini-3.1-flash-lite" },
-                          t3: { model: "openrouter/qwen3.6-max" },
-                        },
-                      },
+                      squilla_router: window.__routerFxTest.routerConfig,
                     });
                   }
                   if (method === "chat.history") {
@@ -1881,8 +1889,8 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                   },
                 ];
                 window.__routerFxTest.deferHistory = true;
-                const stateHandlers = App.getRpc()._listeners.get("_state");
-                if (stateHandlers) stateHandlers.forEach(h => h("connected"));
+                Router.navigate("/overview");
+                Router.navigate("/chat?session=agent:main:webchat:router-fx-panel");
               });
               await emit(page, "session.event.router_decision", {
                 session_key: sessionKey,
@@ -1908,6 +1916,94 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
               await page.waitForTimeout(300);
               const afterHistoryHydrationReplay = await snapshot(page);
 
+              await page.evaluate(() => {
+                window.__routerFxTest.historyMessages = [
+                  {
+                    role: "user",
+                    text: "describe image",
+                    message_id: "router-fx-u-image",
+                    timestamp: "2026-05-30T00:00:04Z",
+                    attachments: [{
+                      mime: "image/png",
+                      type: "image/png",
+                      name: "preview.png",
+                      data: "data:image/png;base64,iVBORw0KGgo=",
+                    }],
+                  },
+                  {
+                    role: "assistant",
+                    text: "image done",
+                    message_id: "router-fx-a-image",
+                    timestamp: "2026-05-30T00:00:05Z",
+                    model: "openrouter/kimi-k2.6",
+                    usage: {
+                      model: "openrouter/kimi-k2.6",
+                      routed_model: "openrouter/kimi-k2.6",
+                      routed_tier: "image_model",
+                      routing_source: "image_route",
+                      routing_applied: true,
+                      input_tokens: 21,
+                      output_tokens: 5,
+                    },
+                  },
+                ];
+                Router.navigate("/overview");
+                Router.navigate("/chat?session=agent:main:webchat:router-fx-panel");
+              });
+              await page.waitForFunction(
+                () =>
+                  document.querySelector(".msg.user .msg-attachments") &&
+                  document.querySelectorAll(".router-fx").length === 0,
+                { timeout: 15000 }
+              );
+              const singleImageCandidate = await snapshot(page);
+
+              await page.evaluate(() => {
+                window.__routerFxTest.routerConfig = {
+                  enabled: true,
+                  rollout_phase: "full",
+                  tiers: {
+                    t1: { model: "openrouter/shared-model" },
+                    t2: { model: "other-provider/shared-model" },
+                  },
+                };
+                window.__routerFxTest.historyMessages = [
+                  {
+                    role: "user",
+                    text: "same model different provider",
+                    message_id: "router-fx-u-same-display",
+                    timestamp: "2026-05-30T00:00:06Z",
+                  },
+                  {
+                    role: "assistant",
+                    text: "same done",
+                    message_id: "router-fx-a-same-display",
+                    timestamp: "2026-05-30T00:00:07Z",
+                    model: "openrouter/shared-model",
+                    usage: {
+                      model: "openrouter/shared-model",
+                      routed_model: "openrouter/shared-model",
+                      routed_tier: "t1",
+                      routing_source: "squilla_router",
+                      routing_applied: true,
+                      input_tokens: 8,
+                      output_tokens: 2,
+                    },
+                  },
+                ];
+                Router.navigate("/overview");
+                Router.navigate("/chat?session=agent:main:webchat:router-fx-panel");
+              });
+              await page.waitForFunction(
+                () =>
+                  document.querySelector(".msg.user")?.textContent.includes(
+                    "same model different provider"
+                  ) &&
+                  document.querySelectorAll(".router-fx").length === 0,
+                { timeout: 15000 }
+              );
+              const sameDisplaySingleCandidate = await snapshot(page);
+
               const result = {
                 liveSettled,
                 reopened,
@@ -1915,6 +2011,8 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                 narrow,
                 duringHistoryHydrationReplay,
                 afterHistoryHydrationReplay,
+                singleImageCandidate,
+                sameDisplaySingleCandidate,
                 pageErrors: errors,
               };
               await browser.close();
@@ -1966,6 +2064,13 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
     assert payload["liveSettled"]["selectorVisible"] == 0
     assert payload["liveSettled"]["winner"] == "deepseek-v4-flash"
     assert "Router selected deepseek-v4-flash" in payload["liveSettled"]["aria"]
+    assert payload["liveSettled"]["cellCount"] == 3
+    assert set(payload["liveSettled"]["cellLabels"]) == {
+        "deepseek-v4-flash",
+        "gemini-3.1-flash-lite",
+        "qwen3.6-max",
+    }
+    assert "kimi-k2.6" not in payload["liveSettled"]["cellLabels"]
 
     for key in ("reopened", "afterReplay", "narrow"):
         snap = payload[key]
@@ -1980,12 +2085,15 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
         assert snap["animations"] == [], snap
         assert snap["winner"] == "deepseek-v4-flash", snap
         assert snap["hasLongLabel"] is True, snap
+        assert snap["cellCount"] == 3, snap
+        assert "kimi-k2.6" not in snap["cellLabels"], snap
         assert snap["overflows"] == [], snap
         assert snap["gridWithinViewport"] is True, snap
 
     during = payload["duringHistoryHydrationReplay"]
-    assert during["count"] == 1, during
-    assert during["winners"] == ["deepseek-v4-flash"], during
+    assert during["count"] in (0, 1), during
+    if during["count"] == 1:
+        assert during["winners"] == ["deepseek-v4-flash"], during
     assert during["liveCount"] == 0, during
     assert during["scanningCount"] == 0, during
     assert during["selectorVisible"] == 0, during
@@ -2005,6 +2113,18 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
         "deepseek-v4-flash",
         "gemini-3.1-flash-lite",
     }, after_hydration
+
+    image_single = payload["singleImageCandidate"]
+    assert image_single["count"] == 0, image_single
+    assert image_single["cellCount"] == 0, image_single
+    assert image_single["liveCount"] == 0, image_single
+    assert image_single["scanningCount"] == 0, image_single
+
+    same_display_single = payload["sameDisplaySingleCandidate"]
+    assert same_display_single["count"] == 0, same_display_single
+    assert same_display_single["cellCount"] == 0, same_display_single
+    assert same_display_single["liveCount"] == 0, same_display_single
+    assert same_display_single["scanningCount"] == 0, same_display_single
 
 
 def test_webchat_large_paste_auto_attaches_text_in_real_browser(tmp_path: Path) -> None:

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -1,4 +1,3 @@
-import re
 from pathlib import Path
 
 CHAT_JS = Path("src/opensquilla/gateway/static/js/views/chat.js")
@@ -1792,199 +1791,119 @@ def test_router_fx_history_reanchors_stranded_strip() -> None:
     assert "if (!anchored) _routerFxRemoveStrip(el);" in history_body
 
 
-def test_router_fx_uses_fixed_model_slots_and_keeps_decoy_seed() -> None:
+def test_router_fx_uses_only_effective_real_candidates() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
     builder_start = source.index("function _routerFxBuildGridCells(realEntries, seedKey) {")
     builder_end = source.index("  function _buildRouterFxElement", builder_start)
     builder_body = source[builder_start:builder_end]
-    live_start = source.index("async function _handleRouterDecision(payload) {")
-    live_end = source.index("  // History-load entry point", live_start)
-    live_body = source[live_start:live_end]
 
-    assert "const _ROUTER_FX_REAL_ANCHOR_CELLS = [1, 6, 8, 13, 11" in source
+    assert "const _ROUTER_FX_DECOY_POOL" not in source
+    assert "_ROUTER_FX_REAL_ANCHOR_CELLS" not in source
+    assert "_ROUTER_FX_GRID_CELLS" not in source
     assert "function _routerFxResolveLayoutSeed(sessionKey, hintTimestamp)" in source
-    assert "const replaySeed = _routerFxResolveLayoutSeed(_sessionKey);" in live_body
+    assert "function _routerFxVisualEntries(requestKind, decision) {" in source
     assert "const cachedSeed = _routerFxResolveLayoutSeed(_sessionKey, hint);" in source
     assert "const orderedRealEntries = realEntries.slice().sort" in builder_body
-    assert "const anchor = _ROUTER_FX_REAL_ANCHOR_CELLS[i];" in builder_body
-    assert "const orderedDecoys = _routerFxShuffle(decoys," in builder_body
+    assert "return orderedRealEntries.map((entry) => ({" in builder_body
+    assert "kind: 'real'," in builder_body
+    assert "kind: 'decoy'" not in builder_body
     assert "return _routerFxShuffle(cells, seedKey);" not in builder_body
 
 
-def test_router_fx_cells_have_equal_prominence_and_hide_roster() -> None:
-    # Every model cell must render identically; the panel must not reveal which
-    # names are the operator's actually-configured (active) models. So the old
-    # real/decoy visual distinction is gone (no breathing accent dot, no
-    # dimmed/italic decoys) AND the DOM no longer carries data-kind/data-tiers.
+def test_router_fx_cells_render_plain_model_names_only() -> None:
+    # The panel intentionally shows the real candidates for this request. Cells
+    # show only the user-facing model name: no S/M/L/XL, no provider labels, no
+    # thinking badges, and no DOM roster metadata beyond the cell index needed
+    # for the selector.
     source = CHAT_JS.read_text(encoding="utf-8")
     css = CHAT_CSS.read_text(encoding="utf-8")
 
-    # No DOM attribute leaks the real/decoy split.
     assert "cell.dataset.kind" not in source
     assert "cell.dataset.tiers" not in source
-    # No CSS differentiates real vs decoy cells; the "on the dial" dot is gone.
     assert '[data-kind="real"]' not in css
     assert '[data-kind="decoy"]' not in css
     assert "router-fx-dot-idle" not in css
-    # Cells share one uniform colour; only the winner is emphasised.
     cell_start = css.index(".router-fx-cell {")
     cell_end = css.index("}", cell_start)
     assert "color: var(--text);" in css[cell_start:cell_end]
     assert ".router-fx-cell.win {" in css
-    # Winner keeps a self-contained lock dot (no longer inherited from a
-    # real-cell dot that no longer exists).
     win_after = css.index(".router-fx-cell.win::after {")
     win_after_end = css.index("}", win_after)
     assert "content: '';" in css[win_after:win_after_end]
-    # Winner detection reads the in-memory grid-cell array, not a DOM attribute,
-    # so it still lands on the routed cell without exposing the rest. Pin the
-    # predicate (reads .kind off the array) and the cell-idx stamping that the
-    # positional DOM lookup relies on — so a refactor that broke landing fails.
     assert "const cells = wrap._fxGridCells || [];" in source
     assert "cells[i].kind === 'real'" in source
     assert "cell.dataset.cellIdx = String(i);" in source
+    assert "cell.dataset.provider" not in source
+    assert "cell.dataset.thinking" not in source
+    for size_label in (">S<", ">M<", ">L<", ">XL<"):
+        assert size_label not in source
 
 
-def test_router_fx_decoy_pool_doubled_with_current_models() -> None:
-    # Roster expanded to >= 2x the previous 16, sourced from OpenRouter's
-    # highest-usage models (ordered by volume, highest first).
+def test_router_fx_config_caches_text_and_image_capability_flags() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    pool_start = source.index("const _ROUTER_FX_DECOY_POOL = [")
-    pool_end = source.index("];", pool_start)
-    pool = source[pool_start:pool_end]
-    names = re.findall(r"'([^']+)'", pool)
-    assert len(names) >= 32, f"expected >= 32 pooled models, found {len(names)}"
-    # Ordered by usage, highest first — the documented #1 leads.
-    assert names[0] == "deepseek-v4-flash"
-    for name in ("claude-sonnet-4.6", "glm-5.1", "qwen3.6-plus"):
-        assert name in names
+    load_start = source.index("async function _loadFeatureToggles() {")
+    load_end = source.index("  /* ── Session Chip", load_start)
+    body = source[load_start:load_end]
+
+    assert "const _routerFxTierConfigs = {};" in source
+    assert "model: typeof rawTier?.model === 'string' ? rawTier.model : ''," in body
+    assert "supportsImage: rawTier?.supports_image === true," in body
+    assert "imageOnly: rawTier?.image_only === true," in body
+    assert "_routerFxTierConfigs[lower] = tierConfig;" in body
+    assert "delete _routerFxTierConfigs[tier];" in body
 
 
-def test_router_fx_cloud_variant_renders_seeded_depth_field() -> None:
-    # The cloud variant builds a focal-depth nebula: each mote gets a seeded
-    # depth driving blur/scale/opacity TOGETHER (coherent optical depth, not a
-    # random tag cloud), deterministic per layout seed for history rebuilds.
-    source = CHAT_JS.read_text(encoding="utf-8")
-
-    assert "function _routerFxBuildCloud(wrap, decision, seedKey) {" in source
-    build_start = source.index("function _routerFxBuildCloud(wrap, decision, seedKey) {")
-    build_end = source.index("function _settleRouterFxCloud(wrap) {", build_start)
-    body = source[build_start:build_end]
-    # Seeded RNG keyed off the layout seed → reproducible nebula.
-    assert "_routerFxMulberry32(_routerFxHashSeed((seedKey || '') + ':cloud'))" in body
-    # blur, scale, opacity all derive from the same depth d.
-    assert "const d = rng();" in body
-    assert "const blur = (d * 3.4).toFixed(2);" in body
-    assert "const scale = (1.22 - d * 0.62).toFixed(3);" in body
-    assert "const op = (0.92 - d * 0.64).toFixed(3);" in body
-    # Organic elliptical scatter (area-uniform radius at a random angle).
-    assert "const rad = Math.sqrt(rng());" in body
-    assert "Math.cos(ang)" in body and "Math.sin(ang)" in body
-    # Two layers so drift (outer) and rack-focus (inner) never fight.
-    assert "inner.className = 'router-fx-mote-i';" in body
-    assert "mote.appendChild(inner);" in body
-    assert "mote.classList.add('router-fx-mote--winner');" in body
-    assert "wrap._fxCloud = true;" in body
-    assert "wrap._fxWinnerEl = winnerEl;" in body
-    # Builder branches to the cloud and returns before the grid build.
-    assert "if (variant === 'cloud') {" in source
-    assert "_routerFxBuildCloud(wrap, decision, seedKey);" in source
-
-
-def test_router_fx_cloud_shows_pool_plus_winner_not_roster() -> None:
-    # Privacy: the cloud field is the public decoy pool + the (already-public)
-    # routed winner only — it must NOT render the operator's configured roster.
-    source = CHAT_JS.read_text(encoding="utf-8")
-    build_start = source.index("function _routerFxBuildCloud(wrap, decision, seedKey) {")
-    build_end = source.index("function _settleRouterFxCloud(wrap) {", build_start)
-    body = source[build_start:build_end]
-
-    assert "_ROUTER_FX_DECOY_POOL.forEach(" in body
-    assert "const winnerName = _routerFxWinnerName(decision);" in body
-    # The roster builder is never consulted inside the cloud build.
-    assert "_routerFxRealEntries" not in body
-    assert "function _routerFxWinnerName(decision) {" in source
-
-
-def test_router_fx_cloud_rack_focus_dispatch_is_motion_opt_in() -> None:
-    # Cloud strips still have a live scan/lock path, but replay/history
-    # decisions must render settled instead of re-running rack-focus motion.
+def test_router_fx_filters_text_and_image_candidates_by_request_kind() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
 
-    assert "function _animateRouterFxCloud(wrap) {" in source
-    assert "function _settleRouterFxCloud(wrap) {" in source
-    anim_start = source.index("function _animateRouterFxCloud(wrap) {")
-    anim_end = source.index("// Anchor invariant", anim_start)
-    anim = source[anim_start:anim_end]
-    assert "if (!wrap._fxWinnerEl) { _settleRouterFxCloud(wrap); return; }" in anim
-    assert "prefers-reduced-motion" not in anim   # decoupled from OS reduce-motion
-    assert "wrap.dataset.state = 'playing';" in anim
-    assert "wrap.dataset.state = 'settled';" in anim
-    assert anim.index("'playing'") < anim.index("'settled'")
-    # Live strips lock through the cloud-specific settle path.
-    assert "wrap._fxCloud" in source
-    assert "if (wrap._fxCloud) _routerFxLockCloud(wrap, decision);" in source
-    lock_start = source.index("function _routerFxLockCloud(wrap, decision) {")
-    lock_end = source.index("function _routerFxLockGrid(wrap, decision) {", lock_start)
-    lock_cloud = source[lock_start:lock_end]
-    assert "_settleRouterFxCloud(wrap)" in lock_cloud
+    assert "function _routerFxRequestKindFromAttachments(attachments) {" in source
+    request_start = source.index("function _routerFxRequestKindFromAttachments(attachments) {")
+    request_end = source.index("function _routerFxTierMatchesRequestKind", request_start)
+    request_body = source[request_start:request_end]
+    assert "return 'image';" in request_body
+    assert "return 'text';" in request_body
 
-    handler_start = source.index("async function _handleRouterDecision(payload) {")
-    handler_end = source.index("// History-load entry point", handler_start)
-    handler = source[handler_start:handler_end]
-    assert "_animateRouterFxCloud(wrap)" not in handler
-    assert "preSettled: true" in handler
-    assert "renderMode: 'history'" in handler
+    match_start = source.index("function _routerFxTierMatchesRequestKind")
+    match_end = source.index("function _routerFxVisualEntries", match_start)
+    match_body = source[match_start:match_end]
+    assert "return !!(tierConfig.supportsImage || tierConfig.imageOnly);" in match_body
+    assert "return !tierConfig.imageOnly;" in match_body
+
+    send_start = source.index("async function _onSend()")
+    send_end = source.index("    // Send", send_start)
+    send_body = source[send_start:send_end]
+    assert (
+        "const routerFxRequestKind = "
+        "_routerFxRequestKindFromAttachments(params.attachments || []);"
+    ) in send_body
+    assert "requestKind: routerFxRequestKind" in send_body
 
 
-def test_router_fx_cloud_css_rack_focus_states() -> None:
-    css = CHAT_CSS.read_text(encoding="utf-8")
-
-    # Borderless/organic: no rigid box — a radial mask dissolves the edges,
-    # and content-visibility keeps off-screen history strips cheap.
-    cloud_start = css.index('.router-fx[data-variant="cloud"] .router-fx-cloud {')
-    cloud_block = css[cloud_start:css.index("}", cloud_start)]
-    assert "border:" not in cloud_block          # no rigid rectangular boundary
-    assert "mask-image: radial-gradient(" in cloud_block
-    # content-visibility was removed — it paused animation on auto-scroll.
-    assert "content-visibility" not in cloud_block
-    # Two layers: OUTER owns position + (winner) glide; INNER owns the optics.
-    # NO perpetual motion — the panel must be still once settled / when output
-    # renders (the absolute red line), so there is no drift/breathe loop.
-    mote_start = css.index('.router-fx[data-variant="cloud"] .router-fx-mote {')
-    mote_block = css[mote_start:css.index("}", mote_start)]
-    assert "animation:" not in mote_block               # no perpetual drift
-    assert "will-change" not in mote_block              # not pinned permanently (perf)
-    assert "@keyframes router-fx-drift" not in css      # drift loop removed
-    assert "router-fx-winner-breathe" not in css        # breathe loop removed
-    assert '.router-fx[data-variant="cloud"] .router-fx-mote-i {' in css
-    # Defocus (ease-IN) and the winner resolve target the INNER; the winner's
-    # glide to focus is on the OUTER (left/top), so it travels, never teleports.
-    assert '.router-fx[data-variant="cloud"][data-state="playing"] .router-fx-mote-i {' in css
-    assert ('.router-fx[data-variant="cloud"][data-state="settled"] '
-            '.router-fx-mote--winner .router-fx-mote-i {') in css
-    assert '.router-fx[data-variant="cloud"] .router-fx-reticle {' in css
-    # Output start no longer freezes the winner-lock animation; once settled,
-    # the grid hides only the chase hammer.
-    assert '.router-fx[data-frozen="true"]' not in css
-    selector_hide = (".router-fx[data-state=\"settled\"] .router-fx-selector"
-                     " { opacity: 0 !important; }")
-    assert selector_hide in css
-    # Motion is opt-in via the toggle, so the cloud does NOT honour OS
-    # reduce-motion (no @media block suppressing the cloud motes).
-    assert "deliberately does NOT honour prefers-reduced-motion" in css
-
-
-def test_router_fx_cloud_view_toggle_is_not_exposed() -> None:
+def test_router_fx_single_visual_candidate_renders_nothing_live_or_history() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    popover_start = source.index('id="chat-toolbar-popover"')
-    popover_end = source.index("chat-input-wrap", popover_start)
-    popover = source[popover_start:popover_end]
 
-    assert 'id="toggle-router-cloud"' not in popover
-    assert "Cloud view" not in popover
-    assert "const routerCloudToggle = _el.querySelector('#toggle-router-cloud');" not in source
-    assert "routerCloudToggle.checked = _routerFx.variant === 'cloud';" not in source
+    builder_start = source.index("function _buildRouterFxElement(decision, opts) {")
+    builder_end = source.index("  function _routerFxWinnerCellIndex", builder_start)
+    builder_body = source[builder_start:builder_end]
+    assert "if (realEntries.length <= 1) return null;" in builder_body
+
+    schedule_start = source.index("function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts) {")
+    schedule_end = source.index("  // Render the routing visualisation", schedule_start)
+    schedule_body = source[schedule_start:schedule_end]
+    assert "if (!_routerFxHasMultipleCandidates(requestKind, null)) {" in schedule_body
+    assert "_chatDiag('router_scan.schedule.skip.single_candidate'" in schedule_body
+
+    begin_start = source.index("function _routerFxBeginScan(anchorDiv, seedKey, opts) {")
+    begin_end = source.index("function _routerFxScanRoam(", begin_start)
+    begin_body = source[begin_start:begin_end]
+    assert "if (!wrap) {" in begin_body
+    assert "_chatDiag('router_scan.skip.single_candidate'" in begin_body
+
+    history_start = source.index("function _buildRouterFxFromUsage(usage, seedKey, opts) {")
+    history_end = source.index("  /* ── RPC Event Subscriptions", history_start)
+    history_body = source[history_start:history_end]
+    assert "requestKind: requestKind" in history_body
+    assert "return _buildRouterFxElement(decision, {" in history_body
 
 
 def test_router_fx_grid_labels_shrink_to_fit() -> None:
@@ -2039,7 +1958,7 @@ def test_router_fx_scan_to_lock_fills_the_wait() -> None:
     css = CHAT_CSS.read_text(encoding="utf-8")
 
     for fn in ("_routerFxBeginScan", "_routerFxScanRoam", "_routerFxStopScan",
-               "_routerFxLock", "_routerFxLockCloud", "_routerFxLockGrid"):
+               "_routerFxLock", "_routerFxLockGrid"):
         assert f"function {fn}(" in source
     # Scan is gated on BOTH the viz pref and routing actually being on.
     begin_start = source.index("function _routerFxBeginScan(")
@@ -2048,10 +1967,11 @@ def test_router_fx_scan_to_lock_fills_the_wait() -> None:
     assert "if (!_thread || !_routerFx.enabled || !_routerFeatureEnabled) {" in begin
     assert "_chatDiag('router_scan.skip'" in begin
     assert "return false;" in begin
+    assert "_routerFxHasMultipleCandidates(requestKind, null)" in begin
     # Scheduled from the send path.
     assert (
         "const routerScanStarted = _scheduleRouterFxBeginScan("
-        "userDiv, _routerFxResolveLayoutSeed(_sessionKey));"
+        "userDiv, _routerFxResolveLayoutSeed(_sessionKey), {"
     ) in source
     # The scan runs for a FIXED, hard-capped window (≤1s), then locks — not
     # "roam until the decision WS event lands".
@@ -2063,16 +1983,14 @@ def test_router_fx_scan_to_lock_fills_the_wait() -> None:
     assert "liveStrip._fxDecision = payload;" in source
     assert "if (liveStrip._fxFinished) {" in source
     assert "_routerFxLock(wrap, wrap._fxDecision);" in source  # finish locks the cached winner
-    # Roam is JS-driven discrete swaps (cloud: .is-scan; grid: hammer hop).
+    # Roam is JS-driven discrete selector hops across the real candidate cells.
     roam_start = source.index("function _routerFxScanRoam(")
     roam_end = source.index("function _routerFxStopScan(", roam_start)
     roam = source[roam_start:roam_end]
-    assert "m.classList.toggle('is-scan', idx === i)" in roam
-    assert "wrap._fxScanTimer = setTimeout(step, isCloud ? 170 : 190);" in roam
-    # CSS gives the roaming focus a sharp accent pop.
-    scan_css = ('.router-fx[data-variant="cloud"][data-state="scanning"] '
-                '.router-fx-mote.is-scan .router-fx-mote-i {')
-    assert scan_css in css
+    assert "const grid = wrap.querySelector('.router-fx-grid');" in roam
+    assert "const targets = grid.querySelectorAll('.router-fx-cell');" in roam
+    assert "wrap._fxScanTimer = setTimeout(step, 190);" in roam
+    assert ".router-fx-mote" not in css
 
 
 def test_chat_compaction_suppresses_current_turn_router_wait_panel() -> None:
@@ -2081,7 +1999,7 @@ def test_chat_compaction_suppresses_current_turn_router_wait_panel() -> None:
     assert "let _compactSuppressedRouterTurnIndex = '';" in source
     assert "function _suppressRouterFxForCompaction(payload = {})" in source
     assert "const _ROUTER_FX_START_DELAY_MS = 280;" in source
-    assert "function _scheduleRouterFxBeginScan(anchorDiv, seedKey)" in source
+    assert "function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts)" in source
     assert "function _cancelPendingRouterFxScan(reason = '')" in source
 
     toast_start = source.index("function _showCompactionToast(payload, meta = {})")
@@ -2104,7 +2022,7 @@ def test_chat_compaction_suppresses_current_turn_router_wait_panel() -> None:
     send_end = source.index("    // Send", send_start)
     send_body = source[send_start:send_end]
     assert (
-        "_scheduleRouterFxBeginScan(userDiv, _routerFxResolveLayoutSeed(_sessionKey))"
+        "_scheduleRouterFxBeginScan(userDiv, _routerFxResolveLayoutSeed(_sessionKey), {"
         in send_body
     )
     assert "_routerFxBeginScan(userDiv, _routerFxResolveLayoutSeed(_sessionKey))" not in send_body
@@ -2249,7 +2167,6 @@ def test_router_fx_settled_cleanup_clears_live_animation_state() -> None:
     clear = source[clear_start:clear_end]
     assert "selector.classList.remove('visible', 'lock', 'lock-impact')" in clear
     assert ".router-fx-cell.pinging" in clear
-    assert ".router-fx-mote.is-scan" in clear
     assert ".router-fx-burst" in clear
 
     settle_start = source.index("function _settleRouterFxImmediate(wrap, winnerIdx, opts) {")
@@ -2257,12 +2174,6 @@ def test_router_fx_settled_cleanup_clears_live_animation_state() -> None:
     settle = source[settle_start:settle_end]
     assert "delete wrap.dataset.live;" in settle
     assert "delete wrap.dataset.scanning;" in settle
-
-    cloud_start = source.index("function _settleRouterFxCloud(wrap) {")
-    cloud_end = source.index("// Live rack-focus", cloud_start)
-    cloud = source[cloud_start:cloud_end]
-    assert "delete wrap.dataset.live;" in cloud
-    assert "delete wrap.dataset.scanning;" in cloud
 
 
 def test_router_fx_config_refresh_prunes_stale_model_cache() -> None:
@@ -2273,6 +2184,7 @@ def test_router_fx_config_refresh_prunes_stale_model_cache() -> None:
 
     assert "Object.keys(_routerFxModels).forEach((tier) => {" in body
     assert "if (!configTierSet.has(tier)) delete _routerFxModels[tier];" in body
+    assert "if (!configTierSet.has(tier)) delete _routerFxTierConfigs[tier];" in body
     assert "_routerFxConfigTiers = configTierSet;" in body
 
 
@@ -2430,7 +2342,7 @@ def test_router_fx_history_mode_has_no_motion_effects() -> None:
 
 def test_router_fx_history_and_turn_meta_preserve_observe_rollout_state() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    history_start = source.index("function _buildRouterFxFromUsage(usage, seedKey) {")
+    history_start = source.index("function _buildRouterFxFromUsage(usage, seedKey, opts) {")
     history_end = source.index("  /* ── RPC Event Subscriptions", history_start)
     history_body = source[history_start:history_end]
     store_start = source.index("_storeTurnMeta(_sessionKey, _metaIdx")
@@ -2444,22 +2356,21 @@ def test_router_fx_history_and_turn_meta_preserve_observe_rollout_state() -> Non
     assert "rollout_phase: u.rollout_phase || 'full'," in store_body
 
 
-def test_router_fx_mobile_grid_matches_explicit_cell_count() -> None:
-    """Mobile router-fx grid rows×cols stays in lockstep with the JS cell count.
-
-    The JS constant ``_ROUTER_FX_GRID_CELLS`` is 15 (5 cols × 3 rows on desktop);
-    mobile and tiny breakpoints collapse to 3×5 so no row ends short.
-    """
+def test_router_fx_mobile_grid_uses_dynamic_candidate_columns() -> None:
+    """Mobile router-fx grid follows actual candidate count, not a fixed wall."""
     css = CHAT_CSS.read_text(encoding="utf-8")
     mobile_start = css.index("@media (max-width: 640px)")
     tiny_start = css.index("@media (max-width: 380px)")
     mobile_body = css[mobile_start:tiny_start]
     tiny_body = css[tiny_start:]
 
-    assert "grid-template-columns: repeat(3, 1fr);" in mobile_body
-    assert "grid-template-rows: repeat(5, 28px);" in mobile_body
-    assert "grid-template-columns: repeat(3, 1fr);" in tiny_body
-    assert "grid-template-rows: repeat(5, 26px);" in tiny_body
+    assert (
+        "grid-template-columns: "
+        "repeat(var(--router-fx-mobile-cols, var(--router-fx-cols, 2)), 1fr);"
+    ) in mobile_body
+    assert "grid-template-rows: none;" in mobile_body
+    assert "grid-template-columns: repeat(var(--router-fx-mobile-cols, 2), 1fr);" in tiny_body
+    assert "grid-template-rows: none;" in tiny_body
 
 
 def test_router_fx_visualisation_pref_is_client_side_localstorage() -> None:
@@ -2555,7 +2466,7 @@ def test_router_fx_render_gated_in_both_live_and_history_paths() -> None:
     )
     assert pre_gate in handler_body
     assert post_gate in handler_body
-    assert handler_body.index("_routerFxModels[tier.toLowerCase()] = String(payload.model);") < \
+    assert handler_body.index("_routerFxRememberTierDecision(tier, payload.model || '');") < \
         handler_body.index(pre_gate)
     assert handler_body.index(pre_gate) < \
         handler_body.index("await _routerFxAwaitConfig();")

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -1953,8 +1953,15 @@ def test_router_fx_single_visual_candidate_renders_nothing_live_or_history() -> 
     schedule_start = source.index("function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts) {")
     schedule_end = source.index("  // Render the routing visualisation", schedule_start)
     schedule_body = source[schedule_start:schedule_end]
-    assert "if (!_routerFxHasMultipleCandidates(requestKind, null)) {" in schedule_body
+    assert "if (_routerFxConfigTiers !== null && !_routerFxHasMultipleCandidates(requestKind, null)) {" in schedule_body
     assert "_chatDiag('router_scan.schedule.skip.single_candidate'" in schedule_body
+
+    pending_start = source.index("async function _finishPendingRouterFxScan() {")
+    pending_end = source.index("function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts) {", pending_start)
+    pending_body = source[pending_start:pending_end]
+    assert pending_body.index("await _routerFxAwaitConfig();") < pending_body.index(
+        "_routerFxBeginScan(pending.anchorDiv, pending.seedKey"
+    )
 
     begin_start = source.index("function _routerFxBeginScan(anchorDiv, seedKey, opts) {")
     begin_end = source.index("function _routerFxScanRoam(", begin_start)

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -340,6 +340,69 @@ def test_chat_shows_awaiting_model_hint_after_tool_result_heartbeat() -> None:
     assert "document.createTextNode('waiting for model response" not in source
 
 
+def test_chat_streaming_indicator_uses_delayed_bottom_dock() -> None:
+    css = CHAT_CSS.read_text(encoding="utf-8")
+
+    assert ".msg.streaming.streaming-active-mark:not(.awaiting-model) .msg-body::after" in css
+    assert "padding-bottom: calc(var(--sp-2) + 24px);" in css
+    assert "left: calc(var(--sp-4) + 16px);" in css
+    assert "bottom: calc(var(--sp-2) + 8px);" in css
+    assert "background-image: url('../../img/opensquilla-mark.png');" in css
+    assert "width: 16px;" in css
+    assert "height: 16px;" in css
+    assert "background-size: 11px 11px;" in css
+    assert "border-radius: 50%;" in css
+    assert "0 0 0 1px color-mix(in srgb, var(--accent) 7%, transparent)" in css
+    assert "0 0 6px color-mix(in srgb, var(--accent-secondary) 18%, transparent)" in css
+    assert "animation: squilla-activity-spin 1.6s linear infinite;" in css
+    assert "@keyframes squilla-activity-spin" in css
+    assert "@media (prefers-reduced-motion: reduce)" in css
+    assert ".chat-tools-collapse--running > .chat-tools-summary .chat-tools-icon" not in css
+    assert ".msg-text-seg:not(:empty):last-of-type > :last-child::after" not in css
+    assert "streaming-harbor" not in css
+    assert "animation: squilla-harbor-peek" not in css
+    assert "@keyframes squilla-harbor-peek" not in css
+    assert "animation: squilla-harbor-spin" not in css
+    assert "@keyframes squilla-harbor-spin" not in css
+    assert "animation: squilla-harbor-wave" not in css
+    assert "@keyframes squilla-harbor-wave" not in css
+    assert "animation: squilla-dock-patrol" not in css
+    assert "@keyframes squilla-dock-patrol" not in css
+    assert "animation: shrimp-roll" not in css
+    assert "@keyframes shrimp-roll" not in css
+
+
+def test_chat_streaming_active_mark_reveals_after_visible_bubble_delay() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+
+    assert "const _STREAM_ACTIVE_MARK_CLASS = 'streaming-active-mark';" in source
+    assert "const _STREAM_ACTIVE_MARK_DELAY_MS = 3500;" in source
+    assert "let _streamActiveMarkVisibleStartedAt = 0;" in source
+    assert "function _beginStreamActiveMarkRevealWindow()" in source
+
+    start_stream_start = source.index("function _startStreaming()")
+    start_stream_end = source.index("  function _ensureStreamBubble", start_stream_start)
+    start_stream_body = source[start_stream_start:start_stream_end]
+    assert "_scheduleStreamActiveMarkReveal();" not in start_stream_body
+    assert "_beginStreamActiveMarkRevealWindow();" not in start_stream_body
+
+    ensure_start = source.index("function _ensureStreamBubble()")
+    ensure_end = source.index("  /** Create a new .msg-text-seg", ensure_start)
+    ensure_body = source[ensure_start:ensure_end]
+    assert "_beginStreamActiveMarkRevealWindow();" in ensure_body
+    assert "_maybeRevealStreamActiveMark();" in ensure_body
+
+    reveal_start = source.index("function _maybeRevealStreamActiveMark()")
+    reveal_end = source.index("  function _scheduleStreamActiveMarkReveal", reveal_start)
+    reveal_body = source[reveal_start:reveal_end]
+    assert "_streamActiveMarkVisibleStartedAt ? Date.now() - _streamActiveMarkVisibleStartedAt : 0" in reveal_body
+
+    end_stream_start = source.index("function _endStreaming(opts)")
+    end_stream_end = source.index("  function _hasViewLocalStreamState", end_stream_start)
+    end_stream_body = source[end_stream_start:end_stream_end]
+    assert "_clearStreamActiveMarkReveal();" in end_stream_body
+
+
 def test_chat_clears_awaiting_model_hint_on_next_visible_event_and_stream_reset() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
     append_delta_start = source.index("function _appendDelta(text)")

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -185,6 +185,45 @@ async def test_router_configure_accepts_tier_overrides_and_syncs_llm_model(
 
 
 @pytest.mark.asyncio
+async def test_router_configure_persists_image_model_as_image_capable(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(tmp_path / "c.toml"))
+    from opensquilla.gateway.config import GatewayConfig
+
+    ctx = _admin_ctx()
+    ctx.config = GatewayConfig(llm={"provider": "openrouter", "model": "z-ai/glm-5.1"})
+    ctx.config.config_path = str(tmp_path / "c.toml")
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.router.configure",
+        {
+            "mode": "openrouter-mix",
+            "defaultTier": "t1",
+            "tiers": {
+                "image_model": {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-opus-4.7",
+                    "supportsImage": False,
+                },
+            },
+        },
+        ctx,
+    )
+
+    assert res.error is None, res.error
+    persisted = tomllib.loads((tmp_path / "c.toml").read_text())
+    image_tier = persisted["squilla_router"]["tiers"]["image_model"]
+    assert image_tier["model"] == "anthropic/claude-opus-4.7"
+    assert image_tier["supports_image"] is True
+    assert image_tier["image_only"] is True
+    assert ctx.config.squilla_router.tiers["image_model"]["supports_image"] is True
+    assert ctx.config.squilla_router.tiers["image_model"]["image_only"] is True
+
+
+@pytest.mark.asyncio
 async def test_router_configure_rejects_image_model_as_default_tier(
     tmp_path,
     monkeypatch,

--- a/tests/test_gateway/test_static_onboarding_views.py
+++ b/tests/test_gateway/test_static_onboarding_views.py
@@ -85,6 +85,15 @@ def test_setup_view_is_available_and_uses_canonical_cli_fallbacks():
     assert "Connected" in txt
 
 
+def test_setup_view_locks_image_model_image_support():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "const isImageModel = name === 'image_model';" in txt
+    assert "isImageModel ? ' checked disabled' :" in txt
+    assert "tier.supportsImage = true;" in txt
+    assert "tier.image_only = true;" in txt
+
+
 def test_setup_finish_cli_commands_target_active_config_path():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
     start = txt.index("function _renderFinishStep()")

--- a/tests/test_model_router_behavior.py
+++ b/tests/test_model_router_behavior.py
@@ -782,6 +782,30 @@ async def test_image_input_routes_directly_to_vision_model_without_prompt_inject
 
 
 @pytest.mark.asyncio
+async def test_image_attachment_without_image_tier_fails_locally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        squilla_router_step,
+        "_get_strategy",
+        lambda _config: pytest.fail(
+            "image routing without image tier should not invoke text strategy"
+        ),
+    )
+    ctx = make_context(
+        "What is in this screenshot?",
+        attachments=[{"type": "image", "mime_type": "image/png"}],
+    )
+    ctx.config.squilla_router.tiers["image_model"]["supports_image"] = False
+
+    with pytest.raises(
+        RuntimeError,
+        match="No image-capable SquillaRouter tier is configured",
+    ):
+        await apply_squilla_router(ctx)
+
+
+@pytest.mark.asyncio
 async def test_non_image_attachment_does_not_force_vision_route(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -360,6 +360,28 @@ def test_upsert_router_recommended_writes_profile_without_expanded_tiers():
     assert res.public_payload["mode"] == "recommended"
 
 
+def test_upsert_router_forces_image_model_role_invariants():
+    cfg = GatewayConfig(llm={"provider": "openrouter", "model": "z-ai/glm-5.1"})
+
+    res = upsert_router(
+        cfg,
+        mode="openrouter-mix",
+        tiers={
+            "image_model": {
+                "provider": "openrouter",
+                "model": "anthropic/claude-opus-4.7",
+                "supportsImage": False,
+                "image_only": False,
+            }
+        },
+    )
+
+    image_tier = res.config.squilla_router.tiers["image_model"]
+    assert image_tier["model"] == "anthropic/claude-opus-4.7"
+    assert image_tier["supports_image"] is True
+    assert image_tier["image_only"] is True
+
+
 def test_upsert_router_can_disable():
     cfg = GatewayConfig(llm={"provider": "openrouter", "model": "deepseek/x"})
 


### PR DESCRIPTION
## Summary

This PR updates the WebUI model router and running-work indicator behavior:

- Show only the effective callable router candidates instead of the full decoy model wall.
- Keep router labels as model names only, without exposing tier size, provider, or thinking metadata.
- Suppress router animation/panel when there is only one effective candidate, including image-only routes.
- Route image request visuals through image-capable/image_model candidates instead of text tiers.
- Enforce image_model setup invariants for image capability fields.
- Delay and shrink the Harbor/Squilla running marker so it appears only after visible work persists.
- Fix the first-send cold-config race so unknown router config is not treated as a single-candidate state, while chat.send remains non-blocking.

## Validation

- `.venv/bin/pytest tests/test_gateway/test_chat_view_static.py -q`
- `.venv/bin/pytest tests/test_model_router_behavior.py -q -k 'image_attachment_without_image_tier or image_input_routes_directly or non_image_attachment'`
- `.venv/bin/pytest tests/test_onboarding/test_mutations.py tests/test_gateway/test_rpc_onboarding.py tests/test_gateway/test_static_onboarding_views.py -q -k 'image_model or router_configure_persists_image_model or setup_view_locks'`
- Earlier browser validation before the latest rebase: `OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E=1 .venv/bin/pytest tests/functional/test_webui_browser_chat_e2e.py -q -k 'router_fx_live_then_reopen_stays_settled_in_real_browser'`

## Notes

CI status is not being handled in this PR-opening step because the CI system itself is currently being updated.
