### PR TITLE
Migrate router tiers to c0-c3

### DIFF
--- a/docs/plans/2026-06-03-router-tier-c0-c3-plan.md
+++ b/docs/plans/2026-06-03-router-tier-c0-c3-plan.md
@@ -1,0 +1,211 @@
+# Router Tier c0-c3 Migration Plan
+
+Date: 2026-06-03
+
+## Goal
+
+Migrate OpenSquilla's text router tier identifiers from `t0-t3` to `c0-c3`, remove `S/M/L/XL tier` labels from user-facing/operator descriptions, and prevent Router Control prompt context from exposing tier-strength descriptions to the model.
+
+The bundled router's route classes (`R0-R3`) remain internal. Existing configurations and historical metadata using `t0-t3` should be accepted at input boundaries and normalized to canonical `c0-c3`.
+
+## Requirements
+
+- Canonical text router tier ids are `c0`, `c1`, `c2`, and `c3`.
+- Legacy `t0-t3` are read-only aliases at config/RPC/history/tool input boundaries.
+- Product output surfaces emit only `c0-c3`, not `t0-t3`.
+- `description` remains available for configuration, onboarding, diagnostics, and operator UI.
+- Router Control prompt must not include tier descriptions or explicit strength labels.
+- Default descriptions must not include `S tier`, `M tier`, `L tier`, or `XL tier`.
+- Router behavior must remain equivalent: `R0 -> c0`, `R1 -> c1`, `R2 -> c2`, `R3 -> c3`.
+- Existing routing controls, anti-downgrade behavior, large-context floors, savings display, and highest-tier compaction must continue to work.
+
+## Non-Goals
+
+- Do not retrain or regenerate the bundled router model artifacts.
+- Do not remove internal `T0-T3` thinking-mode names in this change.
+- Do not make descriptions private; only keep them out of model prompt context.
+- Do not preserve `t0-t3` as canonical public output.
+
+## Design Decisions
+
+### Canonical Tier Module
+
+Add one shared tier helper module, likely `src/opensquilla/squilla_router/tiers.py`, with:
+
+- `TEXT_TIERS = ("c0", "c1", "c2", "c3")`
+- `LEGACY_TEXT_TIER_ALIASES = {"t0": "c0", "t1": "c1", "t2": "c2", "t3": "c3"}`
+- `ROUTE_CLASS_TO_TIER = {"R0": "c0", "R1": "c1", "R2": "c2", "R3": "c3"}`
+- `TIER_TO_ROUTE_CLASS = {"c0": "R0", "c1": "R1", "c2": "R2", "c3": "R3"}`
+- `normalize_text_tier(value: object) -> str | None`
+- `normalize_tier_mapping(mapping: Mapping[str, Any]) -> dict[str, Any]`
+- `tier_index(value: object) -> int`
+- `highest_text_tier() -> str`
+- `default_text_tier() -> str`
+
+This avoids scattered string rewrites and fixes existing assumptions such as `str(routed_tier).lstrip("t")`.
+
+### Legacy Compatibility
+
+Normalize legacy ids at these boundaries:
+
+- Gateway config load and tier profile merge.
+- `default_tier` values from config files, environment-derived payloads, and RPC payloads.
+- Onboarding router configuration payloads.
+- Router history entries before anti-downgrade and previous-tier comparison.
+- Router Control target resolution for legacy requests like `tier:t3`.
+
+After normalization, runtime metadata and responses should store/emit canonical `c*` values.
+
+### Router Control Prompt
+
+Change `render_router_control_prompt_block()` so the model receives only operational target ids, not descriptions:
+
+```text
+Use `router_control` only when the user explicitly asks to use a configured route or restore automatic routing.
+Choose one target_id exactly from this menu; do not invent aliases or model ids.
+
+router_control_targets=[{"target_id":"tier:c0"},{"target_id":"tier:c1"},{"target_id":"tier:c2"},{"target_id":"tier:c3"}]
+```
+
+If model-specific targets are retained, expose only `target_id`, for example `{"target_id":"model:deepseek/deepseek-v4-pro"}`. Do not include `tier`, `description`, or `thinking_level` in the prompt menu unless a later requirement proves they are necessary.
+
+Router Control success/replay events may keep detailed metadata for observability, but model prompt context should remain minimal.
+
+### Descriptions
+
+Keep descriptions in config/profile data, but remove `S/M/L/XL tier` and similar explicit tier-label phrasing.
+
+Examples:
+
+- `DeepSeek V4 Flash route for trivial chat, short rewrites, extraction, and low-risk simple Q&A.`
+- `Default balanced text model for normal agent work, coding assistance, debugging, and moderate analysis.`
+- `Stronger text model for multi-step coding, structured reasoning, larger context synthesis, and harder analysis.`
+- `Highest-quality text reasoning model for difficult planning, deep review, complex debugging, and high-stakes synthesis.`
+
+Provider profiles should also avoid `fast tier`, `balanced tier`, `strong tier`, and `highest tier` phrasing. Use `route` or direct model description instead.
+
+## Implementation Steps
+
+1. Add shared tier helpers.
+   - Add `src/opensquilla/squilla_router/tiers.py`.
+   - Update `src/opensquilla/squilla_router/controller.py` to import canonical tier order.
+   - Keep internal thinking-mode values unchanged.
+
+2. Convert default router configuration.
+   - Update `src/opensquilla/gateway/config.py` default tiers and provider profiles to `c0-c3`.
+   - Change `SquillaRouterConfig.default_tier` to `c1`.
+   - Add config validators to normalize legacy tier mappings and legacy default tier values.
+   - Ensure config serialization writes canonical `c*`.
+
+3. Convert routing runtime.
+   - Update `src/opensquilla/squilla_router/v4_phase3.py` so `R0-R3` map to `c0-c3`.
+   - Update `src/opensquilla/engine/steps/squilla_router.py` to use shared helper constants.
+   - Change large-context floors from `t2/t3` to canonical `c2/c3`.
+   - Normalize previous routing history tiers before comparisons.
+   - Replace hardcoded fallback default `t1` with shared default tier.
+
+4. Convert special tier-dependent behavior.
+   - Update `src/opensquilla/engine/router_decision.py` to use `tier_index()`.
+   - Update Dream model selection in `src/opensquilla/memory/dream_factory.py` to use the default canonical tier instead of hardcoded `t1`.
+   - Update highest-tier compaction checks in `src/opensquilla/engine/runtime.py` from hardcoded `t3` to canonical highest text tier. Public names can remain `t3_upgrade` temporarily if renaming the feature would broaden the change too much.
+   - Update auto-propose paths in `src/opensquilla/gateway/boot.py` that currently read `tiers["t3"]`.
+
+5. Convert Router Control.
+   - Update `src/opensquilla/router_control.py` target building, tier strength ordering, target resolution, and prompt rendering.
+   - Accept `tier:t0-t3` as legacy input aliases but emit `tier:c0-c3`.
+   - Remove descriptions from prompt menu output.
+   - Remove `upgrade`/`downgrade` wording from prompt instructions where it implies tier strength.
+   - Update `src/opensquilla/tools/builtin/router_control.py` description if needed.
+
+6. Convert onboarding, CLI, and setup surfaces.
+   - Update `src/opensquilla/onboarding/mutations.py`.
+   - Update `src/opensquilla/onboarding/router_specs.py`.
+   - Update `src/opensquilla/onboarding/flow.py`.
+   - Update `src/opensquilla/onboarding/next_steps.py`.
+   - Update `src/opensquilla/cli/onboard_cmd.py`.
+   - Ensure setup payloads accept legacy ids but display canonical ids.
+
+7. Convert WebUI router display.
+   - Update `src/opensquilla/gateway/static/js/views/setup.js` text tiers and labels.
+   - Update `src/opensquilla/gateway/static/js/views/chat.js` router-fx default tiers, sorting, comments, history handling, and placeholder handling.
+   - Update `src/opensquilla/gateway/static/css/components.css` tier badge classes from `.t0/.t2/.t3` to `.c0/.c2/.c3`.
+
+8. Update docs, examples, scripts, and tests.
+   - Update `opensquilla.toml.example`.
+   - Update router behavior tests.
+   - Update Router Control tests.
+   - Update onboarding tests.
+   - Update WebUI functional tests.
+   - Update live/smoke scripts that define tier configs.
+   - Leave unrelated `t0` variables, scheduler anchors, Slack channel ids, and bundled tokenizer vocabulary untouched.
+
+## Acceptance Criteria
+
+- New default config uses `c0-c3` and `default_tier = "c1"`.
+- Old config with `t0-t3` starts successfully and runtime-normalizes to `c0-c3`.
+- Router classifier output maps `R0-R3` to `c0-c3`.
+- `routed_tier`, `final_tier`, `base_tier`, `previous_tier`, and router events emit `c*` values after normalization.
+- `RouterDecisionEvent.tier_index` returns `0-3` for `c0-c3`.
+- Router Control accepts `tier:t3` as a legacy alias but emits `tier:c3`.
+- Router Control prompt output contains no `description`, `S tier`, `M tier`, `L tier`, `XL tier`, or `tier:t0-t3`.
+- WebUI setup and chat surfaces display `c0-c3`.
+- `description` remains visible in config/operator-facing payloads where already supported.
+- Highest-tier compaction still triggers on upgrades into `c3`.
+- Dream/default model selection still resolves a valid default text model.
+
+## Verification Plan
+
+Run targeted tests first:
+
+```bash
+pytest \
+  tests/test_model_router_behavior.py \
+  tests/test_engine/test_router_decision_event.py \
+  tests/test_engine/test_router_control.py \
+  tests/test_tools/test_router_control_tool.py \
+  tests/test_onboarding/test_router_specs.py \
+  tests/test_onboarding/test_mutations.py \
+  tests/test_onboarding/test_flow.py \
+  tests/test_gateway/test_static_onboarding_views.py
+```
+
+Run high-risk behavior tests:
+
+```bash
+pytest \
+  tests/test_engine/test_t3_upgrade_compaction.py \
+  tests/test_memory_dream_factory.py \
+  tests/functional/test_webui_browser_chat_e2e.py
+```
+
+Run static checks for prompt leakage:
+
+```bash
+rg -n "S tier|M tier|L tier|XL tier|tier:t[0-3]|router_control_targets=.*description" \
+  src opensquilla.toml.example tests
+```
+
+Expected remaining matches should be limited to legacy-compat tests or irrelevant fixtures, with each remaining match reviewed.
+
+## Risks And Mitigations
+
+- Risk: old configs fail to route correctly.
+  - Mitigation: normalize legacy `t*` config keys and defaults during config model validation.
+
+- Risk: hidden runtime comparisons still assume `t*`.
+  - Mitigation: replace all tier ordering/index logic with shared helpers and add regression tests for `c*`.
+
+- Risk: model still infers strength from Router Control prompt.
+  - Mitigation: remove descriptions and strength wording from prompt menu; expose only exact target ids.
+
+- Risk: UI loses router history strips for old sessions.
+  - Mitigation: normalize incoming `routed_tier` values in history/event handling or backend history projection.
+
+- Risk: changing public metadata breaks downstream consumers expecting `t*`.
+  - Mitigation: treat `c*` as the new canonical contract, but accept `t*` at input boundaries. Document the change in release notes.
+
+## Implementation Decisions
+
+- Legacy `t*` config is normalized in memory at load time; existing files are not automatically rewritten except through normal config save flows.
+- Public config now uses `upgrade_to_c3_compaction_enabled`; the old `upgrade_to_t3_compaction_enabled` key is accepted as an input alias so explicit false values are preserved.
+- Router Control prompt and dynamic tool schema expose only canonical route target ids (`tier:c0` through `tier:c3`), not model ids or descriptions.

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -182,7 +182,7 @@ strategy = "v4_phase3"
 #   1. install with `uv sync --extra model-router` or `uv sync --extra recommended`
 #   2. hydrate model assets via:
 #      git lfs pull --include="src/opensquilla/squilla_router/models/**"
-default_tier = "t1"
+default_tier = "c1"
 confidence_threshold = 0.5
 v4_use_aux_head = true
 kv_cache_anti_downgrade_enabled = true
@@ -192,33 +192,33 @@ complaint_upgrade_steps = 1
 complaint_upgrade_max_chars = 160
 require_router_runtime = true
 estimated_output_savings_pct = 0.03
-upgrade_to_t3_compaction_enabled = true
+upgrade_to_c3_compaction_enabled = true
 
-[squilla_router.tiers.t0]
+[squilla_router.tiers.c0]
 provider = "openrouter"
 model = "deepseek/deepseek-v4-flash"
-description = "S tier: fast DeepSeek V4 Flash route for trivial chat, short rewrites, extraction, and low-risk simple Q&A"
+description = "Fast DeepSeek V4 Flash route for trivial chat, short rewrites, extraction, and low-risk simple Q&A"
 supports_image = false
 thinking_level = "high"
 
-[squilla_router.tiers.t1]
+[squilla_router.tiers.c1]
 provider = "openrouter"
 model = "deepseek/deepseek-v4-pro"
-description = "M tier: default balanced text model for normal agent work, coding assistance, debugging, and moderate analysis"
+description = "Default balanced text route for normal agent work, coding assistance, debugging, and moderate analysis"
 supports_image = false
 thinking_level = "high"
 
-[squilla_router.tiers.t2]
+[squilla_router.tiers.c2]
 provider = "openrouter"
 model = "z-ai/glm-5.1"
-description = "L tier: stronger text model for multi-step coding, structured reasoning, larger context synthesis, and harder analysis"
+description = "Stronger text route for multi-step coding, structured reasoning, larger context synthesis, and harder analysis"
 supports_image = false
 thinking_level = "high"
 
-[squilla_router.tiers.t3]
+[squilla_router.tiers.c3]
 provider = "openrouter"
 model = "anthropic/claude-opus-4.7"
-description = "XL tier: highest-quality text reasoning model for difficult planning, deep review, complex debugging, and high-stakes synthesis"
+description = "Highest-quality text reasoning route for difficult planning, deep review, complex debugging, and high-stakes synthesis"
 supports_image = false
 thinking_level = "high"
 

--- a/scripts/live_meta_skill_creator_auto_propose_e2e.py
+++ b/scripts/live_meta_skill_creator_auto_propose_e2e.py
@@ -102,11 +102,11 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
     )
     from opensquilla.tools.dispatch import build_tool_handler
 
-    t3_tiers = {
-        "t0": {"provider": args.provider, "model": args.model, "thinking_level": "off"},
-        "t1": {"provider": args.provider, "model": args.model, "thinking_level": "low"},
-        "t2": {"provider": args.provider, "model": args.model, "thinking_level": "medium"},
-        "t3": {"provider": args.provider, "model": args.model, "thinking_level": "high"},
+    text_tiers = {
+        "c0": {"provider": args.provider, "model": args.model, "thinking_level": "off"},
+        "c1": {"provider": args.provider, "model": args.model, "thinking_level": "low"},
+        "c2": {"provider": args.provider, "model": args.model, "thinking_level": "medium"},
+        "c3": {"provider": args.provider, "model": args.model, "thinking_level": "high"},
     }
     actual_cron = args.actual_scheduler and args.trigger == "cron"
     actual_dream = args.actual_scheduler and args.trigger == "dream"
@@ -121,8 +121,8 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
         },
         squilla_router={
             "enabled": True,
-            "tiers": t3_tiers,
-            "default_tier": "t3",
+            "tiers": text_tiers,
+            "default_tier": "c3",
         },
         meta_skill={
             "auto_propose": {
@@ -184,7 +184,7 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
             metadata={
                 "routing_source": "meta_skill_auto_propose",
                 "routing_applied": True,
-                "routed_tier": "t3",
+                "routed_tier": "c3",
                 "routed_model": args.model,
                 "applied_model": args.model,
                 "thinking_requested": True,

--- a/scripts/live_provider_profile_gateway_e2e.py
+++ b/scripts/live_provider_profile_gateway_e2e.py
@@ -59,19 +59,19 @@ BASE_ENV = {
     "moonshot": "MOONSHOT_BASE_URL",
     "zhipu": "ZAI_BASE_URL",
 }
-TEXT_PROFILE_SLOTS = ("t0", "t1", "t2", "t3")
+TEXT_PROFILE_SLOTS = ("c0", "c1", "c2", "c3")
 LIVE_AGENT_MAX_ITERATIONS = 6
 LIVE_AGENT_RUNTIME_TIMEOUT_SECONDS = 75.0
 LIVE_TURN_HARD_DEADLINE_SECONDS = 90.0
 
 TIER_CASES = [
     {
-        "tier": "t0",
+        "tier": "c0",
         "id": "r0_short_ack",
         "message": "谢谢。不要调用工具，请只回复一个短句，包含 {marker}。",
     },
     {
-        "tier": "t1",
+        "tier": "c1",
         "id": "r1_structured_compare",
         "message": (
             "不要调用工具，只输出 Markdown 表格和 marker。用不超过 4 行的表格比较 "
@@ -80,7 +80,7 @@ TIER_CASES = [
         ),
     },
     {
-        "tier": "t2",
+        "tier": "c2",
         "id": "r2_debugging",
         "message": (
             "下面是异步服务偶发超时的日志片段：连接池耗尽、慢查询、重试风暴、队列积压。"
@@ -89,7 +89,7 @@ TIER_CASES = [
         ),
     },
     {
-        "tier": "t3",
+        "tier": "c3",
         "id": "r3_architecture",
         "message": (
             "请设计跨机房分布式任务调度系统，解释一致性、故障恢复和容量评估。"
@@ -222,7 +222,7 @@ def _write_config(
     model: str,
     *,
     max_tokens: int,
-    default_tier: str = "t1",
+    default_tier: str = "c1",
     tier_overrides: dict[str, dict[str, Any]] | None = None,
 ) -> None:
     tier_override_toml = _render_tier_overrides(tier_overrides)
@@ -407,7 +407,7 @@ def _run_gateway_case_batch(
     max_tokens: int,
     timeout_seconds: float,
     case_mode: str,
-    default_tier: str = "t1",
+    default_tier: str = "c1",
     tier_overrides: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     active_tiers = tier_overrides or tiers

--- a/scripts/smoke_v4_phase3_router.py
+++ b/scripts/smoke_v4_phase3_router.py
@@ -32,25 +32,25 @@ from opensquilla.env import load_env  # noqa: E402
 from opensquilla.gateway.config import GatewayConfig  # noqa: E402
 
 TIERS = {
-    "t0": {
+    "c0": {
         "provider": "openrouter",
         "model": "deepseek/deepseek-v4-flash",
         "description": "short text and trivial follow-ups",
         "thinking_level": "high",
     },
-    "t1": {
+    "c1": {
         "provider": "openrouter",
         "model": "deepseek/deepseek-v4-pro",
         "description": "normal coding and agent tasks",
         "thinking_level": "high",
     },
-    "t2": {
+    "c2": {
         "provider": "openrouter",
         "model": "z-ai/glm-5.1",
         "description": "structured multi-step work",
         "thinking_level": "high",
     },
-    "t3": {
+    "c3": {
         "provider": "openrouter",
         "model": "anthropic/claude-opus-4.7",
         "description": "deep reasoning and hard recovery turns",
@@ -316,7 +316,7 @@ DIALOGUE_ROUTER_CASES = [
         "id": "dialogue_r3_then_summarize",
         "category": "continuous_kv_cache",
         "description": (
-            "A hard architecture turn followed by a short compression request should keep t3."
+            "A hard architecture turn followed by a short compression request should keep c3."
         ),
         "turns": [
             {
@@ -330,7 +330,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "好的，把上面的方案压缩成三句话。",
                 "expected_route_class": "R1",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
@@ -352,7 +352,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "收到。",
                 "expected_route_class": "R0",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
@@ -371,14 +371,14 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "谢谢，先按这个方向查。",
                 "expected_route_class": "R1",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
     {
         "id": "dialogue_r2_then_more_detail",
         "category": "continuous_kv_cache",
-        "description": "A reasoning task followed by detail expansion should stay at or above t2.",
+        "description": "A reasoning task followed by detail expansion should stay at or above c2.",
         "turns": [
             {
                 "message": "发布后 P95 延迟从 300ms 涨到 2s，请给出从指标到代码的回归定位流程。",
@@ -388,7 +388,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "继续展开数据库和缓存两个方向。",
                 "expected_route_class": "R2",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
@@ -404,7 +404,7 @@ DIALOGUE_ROUTER_CASES = [
             {
                 "message": "再给一个团队协作中的例子。",
                 "expected_route_class": "R1",
-                "expected_final_tier": "t1",
+                "expected_final_tier": "c1",
             },
         ],
     },
@@ -412,7 +412,7 @@ DIALOGUE_ROUTER_CASES = [
         "id": "dialogue_r1_then_ack",
         "category": "continuous_followup",
         "description": (
-            "A standard task followed by acknowledgement should keep the active t1 model."
+            "A standard task followed by acknowledgement should keep the active c1 model."
         ),
         "turns": [
             {
@@ -423,7 +423,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "好的。",
                 "expected_route_class": "R0",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t1",
+                "expected_final_tier": "c1",
             },
         ],
     },
@@ -440,7 +440,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "不对，你没理解我的意思，重新回答。",
                 "expected_route_class": "R0",
                 "expect_complaint_upgrade": True,
-                "expected_final_tier": "t1",
+                "expected_final_tier": "c1",
             },
         ],
     },
@@ -457,7 +457,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "这不对，太泛了，按客户视角重新写。",
                 "expected_route_class": "R2",
                 "expect_complaint_upgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
@@ -480,7 +480,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "不对，刚才漏掉了 scheduler event 和 admission webhook，重新排查。",
                 "expected_route_class": "R1",
                 "expect_complaint_upgrade": True,
-                "expected_final_tier": "t2",
+                "expected_final_tier": "c2",
             },
         ],
     },
@@ -503,20 +503,20 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "先只保留权限边界。",
                 "expected_route_class": "R0",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
             {
                 "message": "再压缩成三条。",
                 "expected_route_class": "R0",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
     {
         "id": "dialogue_three_turn_r2_sticky",
         "category": "continuous_kv_cache",
-        "description": "A multi-turn debugging flow should keep t2 across brief narrowing turns.",
+        "description": "A multi-turn debugging flow should keep c2 across brief narrowing turns.",
         "turns": [
             {
                 "message": (
@@ -529,13 +529,13 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "只看异步任务这一块。",
                 "expected_route_class": "R0",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t2",
+                "expected_final_tier": "c2",
             },
             {
                 "message": "再压缩成三条。",
                 "expected_route_class": "R0",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t2",
+                "expected_final_tier": "c2",
             },
         ],
     },
@@ -543,7 +543,7 @@ DIALOGUE_ROUTER_CASES = [
         "id": "dialogue_r0_to_r1_no_sticky_jump",
         "category": "continuous_followup",
         "description": (
-            "A trivial first turn should not block a later standard task from choosing t1."
+            "A trivial first turn should not block a later standard task from choosing c1."
         ),
         "turns": [
             {
@@ -553,7 +553,7 @@ DIALOGUE_ROUTER_CASES = [
             {
                 "message": "比较 PostgreSQL 和 MySQL 在事务、索引、复制方面的差异，用表格输出。",
                 "expected_route_class": "R1",
-                "expected_final_tier": "t1",
+                "expected_final_tier": "c1",
             },
         ],
     },
@@ -574,7 +574,7 @@ DIALOGUE_ROUTER_CASES = [
                     "连接池耗尽、慢查询、重试风暴、队列积压同时出现。"
                 ),
                 "expected_route_class": "R2",
-                "expected_final_tier": "t2",
+                "expected_final_tier": "c2",
             },
         ],
     },
@@ -582,7 +582,7 @@ DIALOGUE_ROUTER_CASES = [
         "id": "dialogue_r1_to_r3_upgrade",
         "category": "continuous_followup",
         "description": (
-            "A standard first turn should allow a later architecture request to upgrade to t3."
+            "A standard first turn should allow a later architecture request to upgrade to c3."
         ),
         "turns": [
             {
@@ -592,7 +592,7 @@ DIALOGUE_ROUTER_CASES = [
             {
                 "message": "现在基于这三个组件设计一个跨区域高可用架构，说明故障恢复和容量评估。",
                 "expected_route_class": "R3",
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
@@ -618,7 +618,7 @@ def _router_config() -> GatewayConfig:
             "strategy": "v4_phase3",
             "rollout_phase": "full",
             "tiers": TIERS,
-            "default_tier": "t1",
+            "default_tier": "c1",
             "require_router_runtime": True,
             "confidence_threshold": 0.5,
             "kv_cache_anti_downgrade_enabled": True,
@@ -705,8 +705,8 @@ async def _forced_recent_history_scenario() -> dict[str, Any]:
             "text": "上一轮是一个长上下文的架构设计问题。",
             "route_class": "R3",
             "final_route_class": "R3",
-            "base_tier": "t3",
-            "final_tier": "t3",
+            "base_tier": "c3",
+            "final_tier": "c3",
             "difficulty": 2.0,
             "margin": 0.8,
             "top1_label": "R3",
@@ -716,8 +716,8 @@ async def _forced_recent_history_scenario() -> dict[str, Any]:
     extra = ctx.metadata.get("routing_extra") or {}
     ok = (
         extra.get("anti_downgrade_applied") is True
-        and ctx.metadata.get("routed_tier") == "t3"
-        and extra.get("previous_tier") == "t3"
+        and ctx.metadata.get("routed_tier") == "c3"
+        and extra.get("previous_tier") == "c3"
     )
     scenario = _scenario_from_ctx(
         "forced_recent_history_blocks_downgrade",
@@ -938,14 +938,30 @@ def _post_json(url: str, payload: dict[str, Any], timeout: float = 5.0) -> dict[
 
 
 def _live_tier_model_map(live_model: str) -> dict[str, str]:
+    def _tier_model_env(canonical: str, legacy: str, default: str) -> str:
+        return os.environ.get(canonical, os.environ.get(legacy, default)).strip()
+
     live_tier_models = {
-        "t0": os.environ.get("OPENSQUILLA_LIVE_LLM_T0_MODEL", "deepseek/deepseek-v4-flash").strip(),
-        "t1": os.environ.get("OPENSQUILLA_LIVE_LLM_T1_MODEL", "deepseek/deepseek-v4-pro").strip(),
-        "t2": os.environ.get("OPENSQUILLA_LIVE_LLM_T2_MODEL", "z-ai/glm-5.1").strip(),
-        "t3": os.environ.get(
+        "c0": _tier_model_env(
+            "OPENSQUILLA_LIVE_LLM_C0_MODEL",
+            "OPENSQUILLA_LIVE_LLM_T0_MODEL",
+            "deepseek/deepseek-v4-flash",
+        ),
+        "c1": _tier_model_env(
+            "OPENSQUILLA_LIVE_LLM_C1_MODEL",
+            "OPENSQUILLA_LIVE_LLM_T1_MODEL",
+            "deepseek/deepseek-v4-pro",
+        ),
+        "c2": _tier_model_env(
+            "OPENSQUILLA_LIVE_LLM_C2_MODEL",
+            "OPENSQUILLA_LIVE_LLM_T2_MODEL",
+            "z-ai/glm-5.1",
+        ),
+        "c3": _tier_model_env(
+            "OPENSQUILLA_LIVE_LLM_C3_MODEL",
             "OPENSQUILLA_LIVE_LLM_T3_MODEL",
             "anthropic/claude-opus-4.7",
-        ).strip(),
+        ),
     }
     if live_model:
         return {tier: live_model for tier in live_tier_models}
@@ -956,10 +972,10 @@ def _write_live_gateway_config(path: Path, live_model: str) -> None:
     live_tier_models = _live_tier_model_map(live_model)
     tier_blocks = []
     for tier, description in {
-        "t0": "live smoke fast tier",
-        "t1": "live smoke standard tier",
-        "t2": "live smoke reasoning tier",
-        "t3": "live smoke frontier tier",
+        "c0": "live smoke fast route",
+        "c1": "live smoke standard route",
+        "c2": "live smoke reasoning route",
+        "c3": "live smoke frontier route",
     }.items():
         tier_blocks.append(
             f"""
@@ -990,7 +1006,7 @@ source = "state"
 
 [llm]
 provider = "openrouter"
-model = "{live_model or live_tier_models['t1']}"
+model = "{live_model or live_tier_models['c1']}"
 base_url = "https://openrouter.ai/api/v1"
 max_tokens = 192
 
@@ -999,7 +1015,7 @@ enabled = true
 auto_thinking = true
 rollout_phase = "full"
 strategy = "v4_phase3"
-default_tier = "t1"
+default_tier = "c1"
 confidence_threshold = 0.5
 kv_cache_anti_downgrade_enabled = true
 kv_cache_anti_downgrade_window_seconds = 600

--- a/src/opensquilla/cli/onboard_cmd.py
+++ b/src/opensquilla/cli/onboard_cmd.py
@@ -583,7 +583,7 @@ _CATALOG_COMMANDS = {
         "--api-key-env <ENV_NAME>"
     ),
     "routerProfiles": (
-        "opensquilla onboard configure router --router recommended --default-tier t1"
+        "opensquilla onboard configure router --router recommended --default-tier c1"
     ),
     "searchProviders": (
         "opensquilla onboard configure search --search-provider <provider> "
@@ -841,7 +841,7 @@ def _router_tier_summary(profile: dict[str, object]) -> str:
     if not isinstance(tiers, dict):
         return ""
     summary: list[str] = []
-    for tier in ("t0", "t1", "t2", "t3"):
+    for tier in ("c0", "c1", "c2", "c3"):
         tier_spec = tiers.get(tier)
         if isinstance(tier_spec, dict):
             summary.append(f"{tier}: {tier_spec.get('model', '')}")
@@ -1085,7 +1085,7 @@ def configure_command(
     default_tier: str = typer.Option(
         "",
         "--default-tier",
-        help="Default router text tier: t0, t1, t2, or t3.",
+        help="Default router text tier: c0, c1, c2, or c3.",
         rich_help_panel="Router",
     ),
     search_provider: str = typer.Option(

--- a/src/opensquilla/engine/router_decision.py
+++ b/src/opensquilla/engine/router_decision.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 from opensquilla.engine.pipeline import TurnContext
 from opensquilla.engine.types import RouterDecisionEvent
+from opensquilla.squilla_router.tiers import normalize_text_tier, tier_index
 
 
 def _coerce_probs(value: object) -> list[float]:
@@ -53,11 +54,8 @@ def build_router_decision_event(turn: TurnContext) -> RouterDecisionEvent | None
     if isinstance(tier_savings, dict):
         savings_pct = savings_pct or _coerce_float(tier_savings.get("pct"))
 
-    tier_idx = -1
-    try:
-        tier_idx = int(str(routed_tier).lstrip("t"))
-    except (TypeError, ValueError):
-        tier_idx = -1
+    routed_tier = normalize_text_tier(routed_tier) or routed_tier
+    tier_idx = tier_index(routed_tier)
 
     source = str(turn.metadata.get("routing_source") or "none")
     routing_applied = turn.metadata.get("routing_applied")

--- a/src/opensquilla/engine/router_decision.py
+++ b/src/opensquilla/engine/router_decision.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 from opensquilla.engine.pipeline import TurnContext
 from opensquilla.engine.types import RouterDecisionEvent
-from opensquilla.squilla_router.tiers import normalize_text_tier, tier_index
+from opensquilla.router_tiers import normalize_text_tier, tier_index
 
 
 def _coerce_probs(value: object) -> list[float]:

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -183,6 +183,7 @@ from opensquilla.session.keys import (
     normalize_agent_id,
 )
 from opensquilla.session.terminal_reply import build_terminal_reply, sanitize_agent_error
+from opensquilla.squilla_router.tiers import HIGHEST_TEXT_TIER, normalize_text_tier, tier_index
 from opensquilla.tools.types import CallerKind, ToolContext
 
 if TYPE_CHECKING:
@@ -4316,27 +4317,32 @@ class TurnRunner:
         and compact failures that should trip the circuit without retrying.
         """
         router_cfg = getattr(self._config, "squilla_router", None)
-        if not getattr(router_cfg, "upgrade_to_t3_compaction_enabled", False):
+        upgrade_compaction_enabled = getattr(
+            router_cfg,
+            "upgrade_to_c3_compaction_enabled",
+            getattr(router_cfg, "upgrade_to_t3_compaction_enabled", False),
+        )
+        if not upgrade_compaction_enabled:
             return _T3_NOT_APPLICABLE
 
-        routed_tier = turn.metadata.get("routed_tier")
-        if routed_tier != "t3":
+        routed_tier = normalize_text_tier(turn.metadata.get("routed_tier"))
+        if routed_tier != HIGHEST_TEXT_TIER:
             return _T3_NOT_APPLICABLE
 
         if not turn.metadata.get("routing_applied", False):
             return _T3_NOT_APPLICABLE
 
         routing_extra = turn.metadata.get("routing_extra", {})
-        previous = routing_extra.get("previous_tier")
+        previous = normalize_text_tier(routing_extra.get("previous_tier"))
         if previous is None:
-            final = routing_extra.get("final_tier")
-            base = routing_extra.get("base_tier")
-            if final == "t3" and base in {"t0", "t1", "t2"}:
+            final = normalize_text_tier(routing_extra.get("final_tier"))
+            base = normalize_text_tier(routing_extra.get("base_tier"))
+            if final == HIGHEST_TEXT_TIER and tier_index(base) in {0, 1, 2}:
                 previous = base
             else:
                 return _T3_NOT_APPLICABLE
 
-        if previous not in {"t0", "t1", "t2"}:
+        if tier_index(previous) not in {0, 1, 2}:
             return _T3_NOT_APPLICABLE
 
         if session_key.startswith(("cron:", "subagent:")):
@@ -4409,7 +4415,7 @@ class TurnRunner:
             "t3_upgrade_compaction.triggered",
             session_key=session_key,
             previous_tier=previous,
-            final_tier="t3",
+            final_tier=HIGHEST_TEXT_TIER,
             context_window_tokens=context_window_tokens,
         )
         self.mark_compaction_attempted_this_turn(session_key)

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -150,6 +150,7 @@ from opensquilla.router_control import (
     RouterControlHoldStore,
     render_router_control_prompt_block,
 )
+from opensquilla.router_tiers import HIGHEST_TEXT_TIER, normalize_text_tier, tier_index
 from opensquilla.safety import injection_guard, permission_matrix, sandbox, tool_tiers
 from opensquilla.session.compaction_lifecycle import (
     COMPACTION_CHUNK_SUMMARIZED_EVENT,
@@ -183,7 +184,6 @@ from opensquilla.session.keys import (
     normalize_agent_id,
 )
 from opensquilla.session.terminal_reply import build_terminal_reply, sanitize_agent_error
-from opensquilla.squilla_router.tiers import HIGHEST_TEXT_TIER, normalize_text_tier, tier_index
 from opensquilla.tools.types import CallerKind, ToolContext
 
 if TYPE_CHECKING:

--- a/src/opensquilla/engine/steps/meta_resolution.py
+++ b/src/opensquilla/engine/steps/meta_resolution.py
@@ -456,9 +456,9 @@ def _trigger_match_text(message: str) -> str:
 
 
 def _tier_sort_key(name: str, index: int) -> tuple[int, int]:
-    """Prefer numeric router tiers (t0 < t1 < t2 < t3), then declaration order."""
+    """Prefer canonical router tiers (c0 < c1 < c2 < c3), then declaration order."""
 
-    match = re.fullmatch(r"t(\d+)", name.strip().lower())
+    match = re.fullmatch(r"c(\d+)", name.strip().lower())
     if match:
         return (int(match.group(1)), index)
     return (-1, index)

--- a/src/opensquilla/engine/steps/squilla_router.py
+++ b/src/opensquilla/engine/steps/squilla_router.py
@@ -28,6 +28,13 @@ from opensquilla.squilla_router.controller import (
     synthetic_one_hot,
     thinking_mode_to_level,
 )
+from opensquilla.squilla_router.tiers import (
+    DEFAULT_TEXT_TIER,
+    HIGHEST_TEXT_TIER,
+    ROUTE_CLASS_TO_TIER,
+    TIER_TO_ROUTE_CLASS,
+    normalize_text_tier,
+)
 
 log = structlog.get_logger(__name__)
 _log_std = logging.getLogger(__name__)
@@ -97,8 +104,8 @@ _DEFER_ROUTING_HISTORY_KEY = "_defer_squilla_router_history"
 _PENDING_ROUTING_HISTORY_ENTRY_KEY = "_pending_squilla_router_history_entry"
 _PENDING_ROUTING_HISTORY_SESSION_KEY = "_pending_squilla_router_history_session"
 _THINKING_LEVELS = {"minimal", "low", "medium", "high", "xhigh", "adaptive"}
-_TIER_TO_ROUTE_CLASS = {"t0": "R0", "t1": "R1", "t2": "R2", "t3": "R3"}
-_ROUTE_CLASS_TO_TIER = {v: k for k, v in _TIER_TO_ROUTE_CLASS.items()}
+_TIER_TO_ROUTE_CLASS = dict(TIER_TO_ROUTE_CLASS)
+_ROUTE_CLASS_TO_TIER = dict(ROUTE_CLASS_TO_TIER)
 _THINKING_MODE_ORDER = {"T0": 0, "T1": 1, "T2": 2, "T3": 3}
 _LARGE_CONTEXT_T2_FLOOR_TOKENS = 25_000
 _LARGE_CONTEXT_T3_FLOOR_TOKENS = 80_000
@@ -282,7 +289,11 @@ class _UnavailableV4Strategy:
         routing_history: list[dict] | None = None,
         **kwargs: object,
     ) -> tuple[str, float, str, dict]:
-        tier = "t1" if "t1" in valid_tiers else (valid_tiers[0] if valid_tiers else "t1")
+        tier = (
+            DEFAULT_TEXT_TIER
+            if DEFAULT_TEXT_TIER in valid_tiers
+            else (valid_tiers[0] if valid_tiers else DEFAULT_TEXT_TIER)
+        )
         return (
             tier,
             0.0,
@@ -490,7 +501,8 @@ def _inject_prompt_hint(message: str, hint: str) -> str:
 
 
 def _tier_index(tier: str, valid_tiers: list[str]) -> int:
-    return valid_tiers.index(tier) if tier in valid_tiers else -1
+    normalized = normalize_text_tier(tier) or tier
+    return valid_tiers.index(normalized) if normalized in valid_tiers else -1
 
 
 def _token_estimate(value: object) -> int | None:
@@ -542,9 +554,9 @@ def _large_context_min_tier(
         material_tokens >= _LARGE_CONTEXT_T3_FLOOR_TOKENS
         or material_tokens >= int(context_window * _LARGE_CONTEXT_T3_CONTEXT_RATIO)
     ):
-        return "t3", material_tokens
+        return HIGHEST_TEXT_TIER, material_tokens
     if material_tokens >= _LARGE_CONTEXT_T2_FLOOR_TOKENS:
-        return "t2", material_tokens
+        return "c2", material_tokens
     return None
 
 
@@ -573,7 +585,7 @@ def _confidence_protected_tier(
     default_tier = getattr(router_cfg, "default_tier", None)
     if default_tier is None:
         return tier, False, threshold, None
-    default_tier = str(default_tier)
+    default_tier = normalize_text_tier(default_tier) or str(default_tier)
     selected_cfg = tiers.get(tier, {}) if isinstance(tiers, dict) else {}
     if bool(_tier_config_value(selected_cfg, "image_only", False)):
         return tier, False, threshold, default_tier
@@ -596,7 +608,8 @@ def _detect_complaint(message: str, max_chars: int | None = None) -> list[str]:
 
 
 def _route_class_for_tier(tier: str) -> str | None:
-    return _TIER_TO_ROUTE_CLASS.get(tier)
+    normalized = normalize_text_tier(tier) or tier
+    return _TIER_TO_ROUTE_CLASS.get(normalized)
 
 
 def _apply_large_context_floor(
@@ -655,11 +668,12 @@ def _tier_for_route_class(route_class: object) -> str | None:
 
 
 def _min_thinking_mode_for_tier(tier: str | None) -> str | None:
-    if tier == "t3":
+    tier = normalize_text_tier(tier)
+    if tier == HIGHEST_TEXT_TIER:
         return "T3"
-    if tier == "t2":
+    if tier == "c2":
         return "T2"
-    if tier == "t1":
+    if tier == DEFAULT_TEXT_TIER:
         return "T1"
     return None
 
@@ -680,8 +694,8 @@ def _reconcile_controller_with_final_tier(
     extra: dict,
 ) -> tuple[str | None, str | None]:
     """Keep controller output consistent with OpenSquilla's final tier overrides."""
-    final_tier = extra.get("final_tier")
-    base_tier = extra.get("base_tier")
+    final_tier = normalize_text_tier(extra.get("final_tier")) or extra.get("final_tier")
+    base_tier = normalize_text_tier(extra.get("base_tier")) or extra.get("base_tier")
     if not final_tier or final_tier == base_tier:
         return thinking_mode, prompt_policy
 
@@ -693,7 +707,7 @@ def _reconcile_controller_with_final_tier(
         _min_thinking_mode_for_tier(str(final_tier)),
     )
     if prompt_policy == "P0" and (
-        str(final_tier) in {"t2", "t3"} or extra.get("complaint_detected")
+        str(final_tier) in {"c2", HIGHEST_TEXT_TIER} or extra.get("complaint_detected")
     ):
         prompt_policy = "P1"
     if thinking_mode is not None and prompt_policy is not None:
@@ -729,7 +743,7 @@ def _previous_final_tier(entry: dict | None) -> str | None:
         return None
     tier = entry.get("final_tier")
     if tier:
-        return str(tier)
+        return normalize_text_tier(tier) or str(tier)
     return _tier_for_route_class(entry.get("final_route_class") or entry.get("route_class"))
 
 
@@ -747,7 +761,7 @@ def _finalize_decision(
     if not _is_history_strategy(strategy_name):
         return decision
 
-    base_tier = decision.tier
+    base_tier = normalize_text_tier(decision.tier) or decision.tier
     final_tier = base_tier
     base_route_class = extra.get("route_class") or _route_class_for_tier(base_tier)
     if base_route_class is not None:
@@ -817,7 +831,8 @@ def _finalize_decision(
     extra.update(
         {
             "base_tier": base_tier,
-            "pre_confidence_tier": pre_confidence_tier,
+            "pre_confidence_tier": normalize_text_tier(pre_confidence_tier)
+            or pre_confidence_tier,
             "confidence_threshold": confidence_threshold,
             "confidence_default_tier": confidence_default_tier,
             "confidence_gate_applied": confidence_gate_applied,
@@ -831,7 +846,7 @@ def _finalize_decision(
                 getattr(router_cfg, "complaint_upgrade_max_chars", 160)
             ),
             "anti_downgrade_applied": anti_downgrade_applied,
-            "previous_tier": previous_tier,
+            "previous_tier": normalize_text_tier(previous_tier) or previous_tier,
             "previous_route_class": previous_route_class,
             "kv_cache_window_seconds": window,
         }
@@ -981,8 +996,6 @@ async def apply_squilla_router(ctx: TurnContext) -> TurnContext:
             ctx.metadata["router_control_target_model"] = hold.model
             ctx.metadata["router_control_target_provider"] = hold.provider
             ctx.metadata["router_control_evidence"] = hold.evidence
-            if hold.duplicate_model_resolution:
-                ctx.metadata["router_control_duplicate_model_resolution"] = True
             ctx.metadata.update(_compute_savings(decision.model, tiers))
             _record_thinking_metadata(ctx, router_cfg, tiers[decision.tier])
             log.debug(
@@ -1051,13 +1064,16 @@ async def apply_squilla_router(ctx: TurnContext) -> TurnContext:
         routing_history=routing_history,
         **classify_context,
     )
+    tier_name = normalize_text_tier(tier_name) or tier_name
     if extra:
         ctx.metadata["routing_extra"] = extra
         thinking_mode = extra.get("thinking_mode")
         prompt_policy = extra.get("prompt_policy")
 
     if tier_name is None or tier_name not in tiers:
-        default = getattr(router_cfg, "default_tier", "t1")
+        default = normalize_text_tier(getattr(router_cfg, "default_tier", DEFAULT_TEXT_TIER))
+        if default is None:
+            default = DEFAULT_TEXT_TIER
         tier_name = default if default in tiers else next(iter(tiers), None)
         if tier_name is None:
             return ctx

--- a/src/opensquilla/engine/steps/squilla_router.py
+++ b/src/opensquilla/engine/steps/squilla_router.py
@@ -20,6 +20,13 @@ from opensquilla.engine.pipeline import TurnContext
 from opensquilla.engine.pricing import lookup_price
 from opensquilla.provider.context_capabilities import provider_state_continuity_diagnostic
 from opensquilla.router_control import RouterControlHoldStore
+from opensquilla.router_tiers import (
+    DEFAULT_TEXT_TIER,
+    HIGHEST_TEXT_TIER,
+    ROUTE_CLASS_TO_TIER,
+    TIER_TO_ROUTE_CLASS,
+    normalize_text_tier,
+)
 from opensquilla.squilla_router.controller import (
     derive_prompt_policy,
     derive_thinking_mode,
@@ -27,13 +34,6 @@ from opensquilla.squilla_router.controller import (
     normalize_decisions,
     synthetic_one_hot,
     thinking_mode_to_level,
-)
-from opensquilla.squilla_router.tiers import (
-    DEFAULT_TEXT_TIER,
-    HIGHEST_TEXT_TIER,
-    ROUTE_CLASS_TO_TIER,
-    TIER_TO_ROUTE_CLASS,
-    normalize_text_tier,
 )
 
 log = structlog.get_logger(__name__)

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -2485,7 +2485,9 @@ async def start_gateway_server(
             provider_selector = svc.provider_selector
             router_cfg = getattr(config, "squilla_router", None)
             tiers = getattr(router_cfg, "tiers", {}) if router_cfg is not None else {}
-            t3_tier = tiers.get("t3") if isinstance(tiers, dict) else None
+            from opensquilla.squilla_router.tiers import HIGHEST_TEXT_TIER
+
+            t3_tier = tiers.get(HIGHEST_TEXT_TIER) if isinstance(tiers, dict) else None
             t3_model = ""
             t3_thinking_level = ""
             if isinstance(t3_tier, dict):
@@ -2533,7 +2535,7 @@ async def start_gateway_server(
             }
             if t3_model:
                 auto_metadata.update({
-                    "routed_tier": "t3",
+                    "routed_tier": HIGHEST_TEXT_TIER,
                     "routed_model": t3_model,
                     "applied_model": t3_model,
                 })

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -2485,7 +2485,7 @@ async def start_gateway_server(
             provider_selector = svc.provider_selector
             router_cfg = getattr(config, "squilla_router", None)
             tiers = getattr(router_cfg, "tiers", {}) if router_cfg is not None else {}
-            from opensquilla.squilla_router.tiers import HIGHEST_TEXT_TIER
+            from opensquilla.router_tiers import HIGHEST_TEXT_TIER
 
             t3_tier = tiers.get(HIGHEST_TEXT_TIER) if isinstance(tiers, dict) else None
             t3_model = ""

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -28,6 +28,11 @@ from opensquilla.gateway.config_migration import (
 )
 from opensquilla.paths import default_opensquilla_home
 from opensquilla.sandbox.config import SandboxSettings
+from opensquilla.squilla_router.tiers import (
+    DEFAULT_TEXT_TIER,
+    normalize_text_tier,
+    normalize_tier_mapping,
+)
 
 
 class ContextOverflowPolicy(StrEnum):
@@ -534,41 +539,41 @@ class MemoryConfig(BaseSettings):
 def _default_tiers() -> dict:
     """Default model routing config."""
     return {
-        "t0": {
+        "c0": {
             "provider": "openrouter",
             "model": "deepseek/deepseek-v4-flash",
             "description": (
-                "S tier: fast DeepSeek V4 Flash route for trivial chat, short rewrites, "
+                "fast DeepSeek V4 Flash route for trivial chat, short rewrites, "
                 "extraction, and low-risk simple Q&A"
             ),
             "supports_image": False,
             "thinking_level": "high",
         },
-        "t1": {
+        "c1": {
             "provider": "openrouter",
             "model": "deepseek/deepseek-v4-pro",
             "description": (
-                "M tier: default balanced text model for normal agent work, coding assistance, "
+                "default balanced text model for normal agent work, coding assistance, "
                 "debugging, and moderate analysis"
             ),
             "supports_image": False,
             "thinking_level": "high",
         },
-        "t2": {
+        "c2": {
             "provider": "openrouter",
             "model": "z-ai/glm-5.1",
             "description": (
-                "L tier: stronger text model for multi-step coding, structured reasoning, "
+                "stronger text model for multi-step coding, structured reasoning, "
                 "larger context synthesis, and harder analysis"
             ),
             "supports_image": False,
             "thinking_level": "high",
         },
-        "t3": {
+        "c3": {
             "provider": "openrouter",
             "model": "anthropic/claude-opus-4.7",
             "description": (
-                "XL tier: highest-quality text reasoning model for difficult planning, "
+                "Highest-quality text reasoning model for difficult planning, "
                 "deep review, complex debugging, and high-stakes synthesis"
             ),
             "supports_image": False,
@@ -629,34 +634,34 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
         return _default_tiers()
     profiles = {
         "openai": {
-            "t0": {
+            "c0": {
                 "provider": "openai",
                 "model": "gpt-5.4-nano",
                 "description": (
-                    "OpenAI fast tier: GPT-5.4 Nano for fast, high-throughput simple work."
+                    "OpenAI fast route: GPT-5.4 Nano for fast, high-throughput simple work."
                 ),
                 "supports_image": False,
                 "thinking_level": "none",
             },
-            "t1": {
+            "c1": {
                 "provider": "openai",
                 "model": "gpt-5.4-mini",
-                "description": "OpenAI balanced tier: GPT-5.4 Mini for normal agent work.",
+                "description": "OpenAI balanced route: GPT-5.4 Mini for normal agent work.",
                 "supports_image": False,
                 "thinking_level": "low",
             },
-            "t2": {
+            "c2": {
                 "provider": "openai",
                 "model": "gpt-5.5",
-                "description": "OpenAI strong tier: GPT-5.5 for complex text tasks.",
+                "description": "OpenAI strong route: GPT-5.5 for complex text tasks.",
                 "supports_image": False,
                 "thinking_level": "medium",
             },
-            "t3": {
+            "c3": {
                 "provider": "openai",
                 "model": "gpt-5.5",
                 "description": (
-                    "OpenAI highest tier: GPT-5.5 with high reasoning; GPT-5.5 Pro is "
+                    "OpenAI highest route: GPT-5.5 with high reasoning; GPT-5.5 Pro is "
                     "excluded because it is not streaming-compatible."
                 ),
                 "supports_image": False,
@@ -664,76 +669,76 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
             },
         },
         "dashscope": {
-            "t0": {
+            "c0": {
                 "provider": "dashscope",
                 "model": "qwen3.6-flash",
                 "description": (
-                    "DashScope fast tier: Qwen3.6 Flash for simple text tasks; "
+                    "DashScope fast route: Qwen3.6 Flash for simple text tasks; "
                     "pending live smoke."
                 ),
                 "supports_image": False,
             },
-            "t1": {
+            "c1": {
                 "provider": "dashscope",
                 "model": "qwen3.6-plus",
                 "description": (
-                    "DashScope balanced tier: Qwen3.6 Plus for normal agent and "
+                    "DashScope balanced route: Qwen3.6 Plus for normal agent and "
                     "coding work; pending live smoke."
                 ),
                 "supports_image": False,
             },
-            "t2": {
+            "c2": {
                 "provider": "dashscope",
                 "model": "qwen3-max",
-                "description": "DashScope strong tier: Qwen3 Max for complex text tasks.",
+                "description": "DashScope strong route: Qwen3 Max for complex text tasks.",
                 "supports_image": False,
             },
-            "t3": {
+            "c3": {
                 "provider": "dashscope",
                 "model": "qwen3-max",
                 "description": (
-                    "DashScope highest tier: Qwen3 Max; higher-thinking behavior "
+                    "DashScope highest route: Qwen3 Max; higher-thinking behavior "
                     "requires future payload support."
                 ),
                 "supports_image": False,
             },
         },
         "deepseek": {
-            "t0": {
+            "c0": {
                 "provider": "deepseek",
                 "model": "deepseek-v4-flash",
                 "description": (
-                    "DeepSeek fast tier: V4 Flash with no router-requested thinking; "
+                    "DeepSeek fast route: V4 Flash with no router-requested thinking; "
                     "request ID pending live smoke."
                 ),
                 "supports_image": False,
                 "thinking_level": "off",
             },
-            "t1": {
+            "c1": {
                 "provider": "deepseek",
                 "model": "deepseek-v4-flash",
                 "description": (
-                    "DeepSeek balanced tier: V4 Flash with thinking enabled; request "
+                    "DeepSeek balanced route: V4 Flash with thinking enabled; request "
                     "ID pending live smoke."
                 ),
                 "supports_image": False,
                 "thinking_level": "low",
             },
-            "t2": {
+            "c2": {
                 "provider": "deepseek",
                 "model": "deepseek-v4-pro",
                 "description": (
-                    "DeepSeek strong tier: V4 Pro with thinking enabled; request ID "
+                    "DeepSeek strong route: V4 Pro with thinking enabled; request ID "
                     "pending live smoke."
                 ),
                 "supports_image": False,
                 "thinking_level": "medium",
             },
-            "t3": {
+            "c3": {
                 "provider": "deepseek",
                 "model": "deepseek-v4-pro",
                 "description": (
-                    "DeepSeek highest tier: same V4 Pro wire behavior until "
+                    "DeepSeek highest route: same V4 Pro wire behavior until "
                     "effort-level support is added."
                 ),
                 "supports_image": False,
@@ -741,31 +746,31 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
             },
         },
         "gemini": {
-            "t0": {
+            "c0": {
                 "provider": "gemini",
                 "model": "gemini-2.5-flash-lite",
-                "description": "Gemini fast tier: 2.5 Flash-Lite for low-latency tasks.",
+                "description": "Gemini fast route: 2.5 Flash-Lite for low-latency tasks.",
                 "supports_image": False,
             },
-            "t1": {
+            "c1": {
                 "provider": "gemini",
                 "model": "gemini-2.5-flash",
-                "description": "Gemini balanced tier: 2.5 Flash for normal agent work.",
+                "description": "Gemini balanced route: 2.5 Flash for normal agent work.",
                 "supports_image": False,
                 "thinking_level": "low",
             },
-            "t2": {
+            "c2": {
                 "provider": "gemini",
                 "model": "gemini-2.5-pro",
-                "description": "Gemini strong tier: 2.5 Pro for complex coding and reasoning.",
+                "description": "Gemini strong route: 2.5 Pro for complex coding and reasoning.",
                 "supports_image": False,
                 "thinking_level": "medium",
             },
-            "t3": {
+            "c3": {
                 "provider": "gemini",
                 "model": "gemini-2.5-pro",
                 "description": (
-                    "Gemini highest tier: 2.5 Pro with high thinking; 3.1 preview "
+                    "Gemini highest route: 2.5 Pro with high thinking; 3.1 preview "
                     "remains opt-in."
                 ),
                 "supports_image": False,
@@ -773,73 +778,73 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
             },
         },
         "zhipu": {
-            "t0": {
+            "c0": {
                 "provider": "zhipu",
                 "model": "glm-4.7-flashx",
                 "description": (
-                    "Zhipu fast tier: GLM-4.7 FlashX for simple text tasks; live smoke "
+                    "Zhipu fast route: GLM-4.7 FlashX for simple text tasks; live smoke "
                     "may require fallback."
                 ),
                 "supports_image": False,
             },
-            "t1": {
+            "c1": {
                 "provider": "zhipu",
                 "model": "glm-5",
-                "description": "Zhipu balanced tier: GLM-5 for normal agent work.",
+                "description": "Zhipu balanced route: GLM-5 for normal agent work.",
                 "supports_image": False,
                 "thinking_level": "low",
             },
-            "t2": {
+            "c2": {
                 "provider": "zhipu",
                 "model": "glm-5.1",
-                "description": "Zhipu strong tier: GLM-5.1 for complex text tasks.",
+                "description": "Zhipu strong route: GLM-5.1 for complex text tasks.",
                 "supports_image": False,
                 "thinking_level": "medium",
             },
-            "t3": {
+            "c3": {
                 "provider": "zhipu",
                 "model": "glm-5.1",
-                "description": "Zhipu highest tier: GLM-5.1 with high reasoning effort.",
+                "description": "Zhipu highest route: GLM-5.1 with high reasoning effort.",
                 "supports_image": False,
                 "thinking_level": "high",
             },
         },
         "moonshot": {
-            "t0": {
+            "c0": {
                 "provider": "moonshot",
                 "model": "kimi-k2.5",
                 "description": (
-                    "Moonshot fast tier: Kimi K2.5 for cost-efficient agent work "
+                    "Moonshot fast route: Kimi K2.5 for cost-efficient agent work "
                     "with 256K context."
                 ),
                 "supports_image": True,
                 "thinking_level": "low",
             },
-            "t1": {
+            "c1": {
                 "provider": "moonshot",
                 "model": "kimi-k2.5",
                 "description": (
-                    "Moonshot balanced tier: Kimi K2.5 for normal multimodal "
+                    "Moonshot balanced route: Kimi K2.5 for normal multimodal "
                     "agent work."
                 ),
                 "supports_image": True,
                 "thinking_level": "medium",
             },
-            "t2": {
+            "c2": {
                 "provider": "moonshot",
                 "model": "kimi-k2.6",
                 "description": (
-                    "Moonshot strong tier: Kimi K2.6 for complex coding, reasoning, "
+                    "Moonshot strong route: Kimi K2.6 for complex coding, reasoning, "
                     "and multimodal tasks."
                 ),
                 "supports_image": True,
                 "thinking_level": "medium",
             },
-            "t3": {
+            "c3": {
                 "provider": "moonshot",
                 "model": "kimi-k2.6",
                 "description": (
-                    "Moonshot highest tier: Kimi K2.6 for the hardest long-horizon "
+                    "Moonshot highest route: Kimi K2.6 for the hardest long-horizon "
                     "agent work."
                 ),
                 "supports_image": True,
@@ -847,41 +852,41 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
             },
         },
         "volcengine": {
-            "t0": {
+            "c0": {
                 "provider": "volcengine",
                 "model": "doubao-seed-2-0-mini-260215",
                 "description": (
-                    "Volcengine fast tier: Doubao Seed 2.0 Mini for low-latency, "
+                    "Volcengine fast route: Doubao Seed 2.0 Mini for low-latency, "
                     "low-cost simple text tasks."
                 ),
                 "supports_image": False,
                 "thinking_level": "off",
             },
-            "t1": {
+            "c1": {
                 "provider": "volcengine",
                 "model": "doubao-seed-2-0-lite-260215",
                 "description": (
-                    "Volcengine balanced tier: Doubao Seed 2.0 Lite for daily agent "
+                    "Volcengine balanced route: Doubao Seed 2.0 Lite for daily agent "
                     "work with lower cost than Pro."
                 ),
                 "supports_image": False,
                 "thinking_level": "low",
             },
-            "t2": {
+            "c2": {
                 "provider": "volcengine",
                 "model": "doubao-seed-2-0-pro-260215",
                 "description": (
-                    "Volcengine strong tier: Doubao Seed 2.0 Pro for complex "
+                    "Volcengine strong route: Doubao Seed 2.0 Pro for complex "
                     "reasoning and multimodal-capable text work."
                 ),
                 "supports_image": False,
                 "thinking_level": "medium",
             },
-            "t3": {
+            "c3": {
                 "provider": "volcengine",
                 "model": "doubao-seed-2-0-code-preview-260215",
                 "description": (
-                    "Volcengine highest tier: Doubao Seed 2.0 Code Preview for the "
+                    "Volcengine highest route: Doubao Seed 2.0 Code Preview for the "
                     "hardest coding and code-review routes."
                 ),
                 "supports_image": False,
@@ -904,7 +909,7 @@ class SquillaRouterConfig(BaseSettings):
     strategy: str = "v4_phase3"
     tier_profile: str | None = None
     tiers: dict = Field(default_factory=_default_tiers)
-    default_tier: str = "t1"
+    default_tier: str = DEFAULT_TEXT_TIER
     confidence_threshold: float = 0.5
     v4_bundle_dir: str | None = None  # V4 Phase 3 bundle root; defaults to bundled assets
     v4_use_aux_head: bool | None = True  # override router.runtime.yaml aux head when set
@@ -916,13 +921,27 @@ class SquillaRouterConfig(BaseSettings):
     complaint_upgrade_max_chars: int = 160
     require_router_runtime: bool = True
     estimated_output_savings_pct: float = 0.03
-    upgrade_to_t3_compaction_enabled: bool = True
+    upgrade_to_c3_compaction_enabled: bool = True
 
     @model_validator(mode="before")
     @classmethod
     def _resolve_tier_profile_defaults(cls, values: Any) -> Any:
         if not isinstance(values, dict):
             return values
+        values = dict(values)
+        if (
+            "upgrade_to_c3_compaction_enabled" not in values
+            and "upgrade_to_t3_compaction_enabled" in values
+        ):
+            values["upgrade_to_c3_compaction_enabled"] = values[
+                "upgrade_to_t3_compaction_enabled"
+            ]
+        if "default_tier" in values:
+            values["default_tier"] = normalize_text_tier(values.get("default_tier")) or values.get(
+                "default_tier"
+            )
+        if isinstance(values.get("tiers"), dict):
+            values["tiers"] = normalize_tier_mapping(values["tiers"])
         profile = values.get("tier_profile")
         if profile is None:
             return values

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -27,12 +27,12 @@ from opensquilla.gateway.config_migration import (
     migrate_config_payload,
 )
 from opensquilla.paths import default_opensquilla_home
-from opensquilla.sandbox.config import SandboxSettings
-from opensquilla.squilla_router.tiers import (
+from opensquilla.router_tiers import (
     DEFAULT_TEXT_TIER,
     normalize_text_tier,
     normalize_tier_mapping,
 )
+from opensquilla.sandbox.config import SandboxSettings
 
 
 class ContextOverflowPolicy(StrEnum):

--- a/src/opensquilla/gateway/static/css/components.css
+++ b/src/opensquilla/gateway/static/css/components.css
@@ -290,7 +290,7 @@
   animation: conn-pill-heartbeat 2.4s ease-in-out infinite;
 }
 
-/* Tier badge — compact monospaced t0/t1/t2/t3 indicator for router decisions. */
+/* Tier badge — compact monospaced c0/c1/c2/c3 indicator for router decisions. */
 .tier {
   display: inline-flex;
   align-items: center;
@@ -305,9 +305,9 @@
   color: var(--accent);
   border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border));
 }
-.tier.t0 { background: color-mix(in srgb, var(--text-dim) 18%, transparent); color: var(--text-muted); border-color: var(--border); }
-.tier.t2 { background: color-mix(in srgb, var(--info) 14%, transparent); color: var(--info); border-color: color-mix(in srgb, var(--info) 30%, var(--border)); }
-.tier.t3 { background: color-mix(in srgb, var(--warn) 14%, transparent); color: var(--warn); border-color: color-mix(in srgb, var(--warn) 30%, var(--border)); }
+.tier.c0 { background: color-mix(in srgb, var(--text-dim) 18%, transparent); color: var(--text-muted); border-color: var(--border); }
+.tier.c2 { background: color-mix(in srgb, var(--info) 14%, transparent); color: var(--info); border-color: color-mix(in srgb, var(--info) 30%, var(--border)); }
+.tier.c3 { background: color-mix(in srgb, var(--warn) 14%, transparent); color: var(--warn); border-color: color-mix(in srgb, var(--warn) 30%, var(--border)); }
 
 /* Spinner — generic 18px loading indicator. */
 .spinner {

--- a/src/opensquilla/gateway/static/js/components/savings-fx.js
+++ b/src/opensquilla/gateway/static/js/components/savings-fx.js
@@ -104,7 +104,7 @@ const SavingsFX = (() => {
 
   function _isComboTier(tier) {
     const value = String(tier || '').trim().toLowerCase();
-    const numeric = /^t(\d+)$/.exec(value);
+    const numeric = /^c(\d+)$/.exec(value) || /^t(\d+)$/.exec(value);
     if (numeric) return Number(numeric[1]) < 3;
     return value !== 'highest' && value !== 'top' && value !== 'flagship';
   }

--- a/src/opensquilla/gateway/static/js/views/chat.js
+++ b/src/opensquilla/gateway/static/js/views/chat.js
@@ -1307,7 +1307,7 @@ const ChatView = (() => {
     // Config (which populates _routerFxModels and registers all
     // configured tiers including image_only ones) must finish before
     // the first history render — otherwise non-winner cells fall back
-    // to the tier id ("t1", "t2") instead of the real model name.
+    // to the tier id ("c1", "c2") instead of the real model name.
     _loadFeatureToggles()
       .catch(() => { /* fall through to history anyway */ })
       .finally(() => _loadHistory());
@@ -1470,7 +1470,8 @@ const ChatView = (() => {
       if (tiers && typeof tiers === 'object') {
         Object.keys(tiers).forEach((tier) => {
           if (typeof tier !== 'string' || !tier) return;
-          const lower = tier.toLowerCase();
+          const lower = _routerFxNormalizeTier(tier);
+          if (!lower) return;
           configTierKeys.push(lower);
           configTierSet.add(lower);
           const rawTier = tiers[tier];
@@ -3262,7 +3263,7 @@ const ChatView = (() => {
   // OpenSquilla's tier ids vary by tier_profile. We seed the slot
   // list from config and register any decision tier we haven't seen
   // before, so the grid never silently drops an unfamiliar tier.
-  const _ROUTER_FX_DEFAULT_TIERS = ['t0', 't1', 't2', 't3'];
+  const _ROUTER_FX_DEFAULT_TIERS = ['c0', 'c1', 'c2', 'c3'];
   let _routerFxSlotList = _ROUTER_FX_DEFAULT_TIERS.slice();
   const _routerFxModels = {};
   const _routerFxTierConfigs = {};
@@ -3308,8 +3309,8 @@ const ChatView = (() => {
 
   function _routerFxSortTiers(list) {
     return list.slice().sort((a, b) => {
-      const am = /^t(\d+)$/.exec(a);
-      const bm = /^t(\d+)$/.exec(b);
+      const am = /^c(\d+)$/.exec(a);
+      const bm = /^c(\d+)$/.exec(b);
       if (am && bm) return parseInt(am[1], 10) - parseInt(bm[1], 10);
       if (am) return -1;
       if (bm) return 1;
@@ -3317,9 +3318,14 @@ const ChatView = (() => {
     });
   }
 
+  function _routerFxNormalizeTier(tier) {
+    if (typeof tier !== 'string' || !tier) return '';
+    return tier.toLowerCase().replace(/^t([0-3])$/, 'c$1');
+  }
+
   function _routerFxRegisterTier(tier) {
-    if (typeof tier !== 'string' || !tier) return;
-    const norm = tier.toLowerCase();
+    const norm = _routerFxNormalizeTier(tier);
+    if (!norm) return;
     if (_routerFxSlotList.indexOf(norm) >= 0) return;
     _routerFxSlotList = _routerFxSortTiers(_routerFxSlotList.concat([norm]));
   }
@@ -3440,7 +3446,7 @@ const ChatView = (() => {
   // Promise resolved when _loadFeatureToggles has populated tier
   // models from config. Any _loadHistory call awaits this gate so the
   // first history rebuild never renders strips with empty tier names
-  // ("t1", "t2", …) just because config hadn't returned yet.
+  // ("c1", "c2", …) just because config hadn't returned yet.
   let _routerFxConfigReadyResolve = null;
   const _routerFxConfigReady = new Promise((resolve) => {
     _routerFxConfigReadyResolve = resolve;
@@ -3515,7 +3521,7 @@ const ChatView = (() => {
   }
   function _routerFxIdentity(model, tier) {
     const modelPart = typeof model === 'string' ? model.trim().toLowerCase() : '';
-    const tierPart = typeof tier === 'string' ? tier.trim().toLowerCase() : '';
+    const tierPart = _routerFxNormalizeTier(tier);
     if (!modelPart && !tierPart) return '';
     return modelPart + '|' + tierPart;
   }
@@ -3597,7 +3603,7 @@ const ChatView = (() => {
     wrap.setAttribute('data-history-role', 'router');
     wrap.dataset.renderMode = opts.renderMode || (opts.preSettled ? 'history' : 'live');
     wrap.dataset.state = 'idle';
-    wrap.dataset.tier = decision.tier || '';
+    wrap.dataset.tier = _routerFxNormalizeTier(decision.tier);
     wrap.dataset.source = decision.source || 'none';
     const identity = _routerFxDecisionIdentity(decision);
     if (identity) wrap.dataset.routerIdentity = identity;
@@ -3658,7 +3664,7 @@ const ChatView = (() => {
     wrap._fxRequestKind = requestKind;
 
     if (opts.preSettled) {
-      const winnerIdx = _routerFxWinnerCellIndex(wrap, decision.tier);
+      const winnerIdx = _routerFxWinnerCellIndex(wrap, _routerFxNormalizeTier(decision.tier));
       if (winnerIdx >= 0) {
         _settleRouterFxImmediate(wrap, winnerIdx, { burst: false, decision });
         _routerFxNormalizeSettledStrip(wrap, opts.renderMode || 'history', decision);
@@ -3902,7 +3908,7 @@ const ChatView = (() => {
   function _routerFxWinnerName(decision) {
     const model = decision && (decision.model || decision.routed_model);
     if (model) return _routerFxStripProvider(String(model));
-    const tier = decision && decision.tier ? String(decision.tier).toLowerCase() : '';
+    const tier = _routerFxNormalizeTier(decision && decision.tier);
     if (tier && _routerFxModels[tier]) return _routerFxStripProvider(_routerFxModels[tier]);
     return tier || '';
   }
@@ -4208,7 +4214,7 @@ const ChatView = (() => {
     if (!wrap) return;
     decision = decision || {};
     _routerFxStopScan(wrap);
-    wrap.dataset.tier = decision.tier || '';
+    wrap.dataset.tier = _routerFxNormalizeTier(decision.tier);
     wrap.dataset.source = decision.source || 'none';
     wrap.dataset.renderMode = wrap.dataset.renderMode || 'live';
     wrap._fxDecision = decision;
@@ -4223,7 +4229,7 @@ const ChatView = (() => {
   }
 
   function _routerFxLockGrid(wrap, decision) {
-    const tier = decision.tier ? String(decision.tier) : '';
+    const tier = _routerFxNormalizeTier(decision.tier);
     if (tier) {
       _routerFxRememberTierDecision(tier, decision.model || '');
     }
@@ -4366,7 +4372,7 @@ const ChatView = (() => {
       _chatDiag('router_decision.skip.invalid_payload', {});
       return;
     }
-    const tier = typeof payload.tier === 'string' ? payload.tier : '';
+    const tier = _routerFxNormalizeTier(payload.tier);
     if (!tier) {
       _chatDiag('router_decision.skip.no_tier', _chatDiagSummarizePayload(payload));
       return;
@@ -4537,13 +4543,13 @@ const ChatView = (() => {
     // was recorded, drop the historic strip on the next rebuild —
     // the slider's whole point is conveying live router behaviour.
     if (_routerFxConfigTiers !== null && !_routerFeatureEnabled) return null;
-    const tier = typeof usage.routed_tier === 'string' ? usage.routed_tier : '';
+    const tier = _routerFxNormalizeTier(usage.routed_tier);
     if (!tier) return null;
     // If the operator has REMOVED this tier from config since the
     // turn was recorded, skip — rendering the strip would show a
-    // ghost cell ("t2") with no current meaning.
+    // ghost cell ("c2") with no current meaning.
     if (_routerFxConfigTiers !== null
-        && !_routerFxConfigTiers.has(tier.toLowerCase())) {
+        && !_routerFxConfigTiers.has(tier)) {
       return null;
     }
     _routerFxRememberTierDecision(tier, usage.routed_model || usage.model || '');
@@ -5321,7 +5327,7 @@ const ChatView = (() => {
     try {
       await _rpc.waitForConnection();
       // Wait until router config (tier → model cache) is populated so
-      // historical strips never render with "t1"/"t2"/"t3" placeholders
+      // historical strips never render with "c1"/"c2"/"c3" placeholders
       // just because we raced the config.get response.
       await _routerFxAwaitConfig();
       const data = await _rpc.call('chat.history', {

--- a/src/opensquilla/gateway/static/js/views/setup.js
+++ b/src/opensquilla/gateway/static/js/views/setup.js
@@ -8,12 +8,12 @@ const SetupView = (() => {
     { id: 'extras', label: 'Capabilities' },
     { id: 'finish', label: 'Finish' },
   ];
-  const TEXT_TIERS = ['t0', 't1', 't2', 't3'];
+  const TEXT_TIERS = ['c0', 'c1', 'c2', 'c3'];
   const TIER_LABELS = {
-    t0: 'Fast/simple (t0)',
-    t1: 'Balanced default (t1)',
-    t2: 'Stronger reasoning (t2)',
-    t3: 'Max quality (t3)',
+    c0: 'Route c0',
+    c1: 'Route c1',
+    c2: 'Route c2',
+    c3: 'Route c3',
   };
   const READINESS_LABELS = {
     ok: 'Ready',
@@ -482,7 +482,7 @@ const SetupView = (() => {
     const profiles = catalog.profiles || [];
     const profile = provider ? profiles.find(p => p.providerId === provider) || {} : {};
     const tiers = provider ? Object.assign({}, profile.tiers || {}, router.tiers || {}) : {};
-    const defaultTier = router.default_tier || catalog.defaultTier || 't1';
+    const defaultTier = router.default_tier || catalog.defaultTier || 'c1';
     const mode = router.enabled === false ? 'disabled' : 'recommended';
     const routerSummary = provider
       ? `${provider} / ${_tierLabel(defaultTier)}`
@@ -547,7 +547,7 @@ const SetupView = (() => {
   }
 
   function _tierLabel(tier) {
-    return TIER_LABELS[tier] || tier || 'Balanced default (t1)';
+    return TIER_LABELS[tier] || tier || 'Route c1';
   }
 
   function _renderChannelsStep() {
@@ -1592,7 +1592,7 @@ const SetupView = (() => {
     try {
       await _rpc.call('onboarding.router.configure', {
         mode: _el.querySelector('[data-router-mode]')?.value || 'recommended',
-        defaultTier: _el.querySelector('[data-default-tier]')?.value || 't1',
+        defaultTier: _el.querySelector('[data-default-tier]')?.value || 'c1',
         tiers,
       });
       UI.toast('Router saved.', 'info');

--- a/src/opensquilla/memory/dream_factory.py
+++ b/src/opensquilla/memory/dream_factory.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from opensquilla.agents.scope import resolve_agent_workspace_dir
 from opensquilla.memory.dream import Dream
+from opensquilla.squilla_router.tiers import DEFAULT_TEXT_TIER, normalize_text_tier
 
 
 def _router_model_routing_enabled(router_cfg: Any | None) -> bool:
@@ -25,11 +26,15 @@ def _dream_provider_target(config: Any) -> tuple[str, str]:
     router_cfg = getattr(config, "squilla_router", None)
     if _router_model_routing_enabled(router_cfg):
         tiers = getattr(router_cfg, "tiers", {}) or {}
-        t1 = tiers.get("t1") if isinstance(tiers, dict) else None
-        if not isinstance(t1, dict) or not str(t1.get("model") or "").strip():
-            raise RuntimeError("squilla_router.tiers.t1 model is required for Dream")
-        provider = str(t1.get("provider") or getattr(llm_cfg, "provider", "openrouter"))
-        model = str(t1["model"])
+        default_tier = normalize_text_tier(getattr(router_cfg, "default_tier", None))
+        default_tier = default_tier or DEFAULT_TEXT_TIER
+        tier_cfg = tiers.get(default_tier) if isinstance(tiers, dict) else None
+        if not isinstance(tier_cfg, dict) or not str(tier_cfg.get("model") or "").strip():
+            raise RuntimeError(
+                f"squilla_router.tiers.{default_tier} model is required for Dream"
+            )
+        provider = str(tier_cfg.get("provider") or getattr(llm_cfg, "provider", "openrouter"))
+        model = str(tier_cfg["model"])
         return provider, model
 
     return str(getattr(llm_cfg, "provider", "openrouter")), str(getattr(llm_cfg, "model", ""))

--- a/src/opensquilla/memory/dream_factory.py
+++ b/src/opensquilla/memory/dream_factory.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from opensquilla.agents.scope import resolve_agent_workspace_dir
 from opensquilla.memory.dream import Dream
-from opensquilla.squilla_router.tiers import DEFAULT_TEXT_TIER, normalize_text_tier
+from opensquilla.router_tiers import DEFAULT_TEXT_TIER, normalize_text_tier
 
 
 def _router_model_routing_enabled(router_cfg: Any | None) -> bool:

--- a/src/opensquilla/onboarding/flow.py
+++ b/src/opensquilla/onboarding/flow.py
@@ -58,6 +58,12 @@ from opensquilla.onboarding.search_specs import (
 )
 from opensquilla.onboarding.setup_paths import web_setup_url
 from opensquilla.onboarding.status import get_onboarding_status
+from opensquilla.squilla_router.tiers import (
+    DEFAULT_TEXT_TIER,
+    IMAGE_TIER,
+    TEXT_TIERS,
+    normalize_text_tier,
+)
 from opensquilla.ui import (
     ACCENT,
     ACCENT_DIM,
@@ -862,13 +868,13 @@ def run_interactive_memory_embedding_configure(
     return persisted
 
 
-_TEXT_ROUTER_TIERS = ("t0", "t1", "t2", "t3")
-_EXPOSED_ROUTER_TIERS = ("t0", "t1", "t2", "t3", "image_model")
+_TEXT_ROUTER_TIERS = TEXT_TIERS
+_EXPOSED_ROUTER_TIERS = (*TEXT_TIERS, IMAGE_TIER)
 _TEXT_TIER_LABELS = {
-    "t0": "Fast/simple (t0)",
-    "t1": "Balanced default (t1)",
-    "t2": "Stronger reasoning (t2)",
-    "t3": "Max quality (t3)",
+    "c0": "Route c0",
+    "c1": "Route c1",
+    "c2": "Route c2",
+    "c3": "Route c3",
 }
 _IMAGE_TIER_LABEL = "Image model"
 _DONE_LABEL = "Done"
@@ -910,16 +916,20 @@ def _router_mode_to_internal(selected: str | None) -> str:
 
 
 def _text_tier_label(tier: str | None) -> str:
-    return _TEXT_TIER_LABELS.get(str(tier or "t1"), _TEXT_TIER_LABELS["t1"])
+    normalized = normalize_text_tier(tier) or DEFAULT_TEXT_TIER
+    return _TEXT_TIER_LABELS.get(normalized, _TEXT_TIER_LABELS[DEFAULT_TEXT_TIER])
 
 
 def _text_tier_to_internal(selected: str | None) -> str:
+    normalized = normalize_text_tier(selected)
+    if normalized:
+        return normalized
     if selected in _TEXT_ROUTER_TIERS:
         return str(selected)
     for tier, label in _TEXT_TIER_LABELS.items():
         if selected == label:
             return tier
-    return "t1"
+    return DEFAULT_TEXT_TIER
 
 
 def _tier_choice_label(tier: str) -> str:
@@ -948,7 +958,7 @@ def _print_router_defaults(config) -> None:
             f"[{ACCENT_DIM}]router[/] [dim]disabled — requests bypass tier routing[/dim]"
         )
         return
-    default_tier = str(getattr(router, "default_tier", "t1") or "t1")
+    default_tier = _text_tier_to_internal(getattr(router, "default_tier", None))
     default = router.tiers.get(default_tier, {})
     console.print(
         f"[bold {ACCENT}]◆ router[/] "
@@ -1027,7 +1037,7 @@ def _ask_router_fields(
     default_tier_choice = questionary.select(
         "Default text model",
         choices=[_TEXT_TIER_LABELS[tier] for tier in _TEXT_ROUTER_TIERS],
-        default=_text_tier_label(str(preview.squilla_router.default_tier or "t1")),
+        default=_text_tier_label(str(preview.squilla_router.default_tier or "c1")),
     ).ask()
     default_tier = _text_tier_to_internal(default_tier_choice)
     preview = upsert_router(config, mode=mode, default_tier=default_tier).config

--- a/src/opensquilla/onboarding/flow.py
+++ b/src/opensquilla/onboarding/flow.py
@@ -58,7 +58,7 @@ from opensquilla.onboarding.search_specs import (
 )
 from opensquilla.onboarding.setup_paths import web_setup_url
 from opensquilla.onboarding.status import get_onboarding_status
-from opensquilla.squilla_router.tiers import (
+from opensquilla.router_tiers import (
     DEFAULT_TEXT_TIER,
     IMAGE_TIER,
     TEXT_TIERS,

--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -33,10 +33,15 @@ from opensquilla.onboarding.redaction import (
 )
 from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
 from opensquilla.secrets import clean_header_secret
+from opensquilla.squilla_router.tiers import (
+    DEFAULT_TEXT_TIER,
+    TEXT_TIERS,
+    normalize_text_tier,
+)
 
 SearchFallbackPolicy = Literal["off", "network"]
 RouterMode = Literal["recommended", "openrouter-mix", "disabled"]
-_TEXT_ROUTER_TIERS = ("t0", "t1", "t2", "t3")
+_TEXT_ROUTER_TIERS = TEXT_TIERS
 _ROUTER_TIER_KEYS = set(_TEXT_ROUTER_TIERS) | {"image_model"}
 _TIER_KEY_ALIASES = {
     "thinkingLevel": "thinking_level",
@@ -91,7 +96,7 @@ def _reconcile_router_profile_for_provider(
     if (
         not current_profile
         and provider_id == "openrouter"
-        and cfg.squilla_router.tiers.get("t0", {}).get("provider") == "openrouter"
+        and cfg.squilla_router.tiers.get("c0", {}).get("provider") == "openrouter"
     ):
         return
     router_payload = cfg.squilla_router.model_dump(mode="python")
@@ -105,16 +110,18 @@ def _reconcile_router_profile_for_provider(
 
 
 def _default_text_tier(default_tier: str | None) -> str:
-    tier = (default_tier or "t1").strip()
-    return tier if tier in _TEXT_ROUTER_TIERS else "t1"
+    tier = normalize_text_tier(default_tier or DEFAULT_TEXT_TIER)
+    return tier if tier in _TEXT_ROUTER_TIERS else DEFAULT_TEXT_TIER
 
 
 def _normalize_explicit_text_tier(default_tier: str | None) -> str | None:
     if default_tier is None:
         return None
-    tier = str(default_tier).strip()
-    if not tier:
+    if not str(default_tier).strip():
         return None
+    tier = normalize_text_tier(default_tier)
+    if not tier:
+        raise ValueError("defaultTier must reference a text tier")
     if tier not in _TEXT_ROUTER_TIERS:
         raise ValueError("defaultTier must reference a text tier")
     return tier
@@ -124,7 +131,7 @@ def _router_default_model_for_provider(provider_id: str, default_tier: str | Non
     if provider_id not in ROUTER_TIER_PROFILE_IDS:
         return ""
     tiers = _router_tier_profile_defaults(provider_id)
-    tier = tiers.get(_default_text_tier(default_tier)) or tiers.get("t1") or {}
+    tier = tiers.get(_default_text_tier(default_tier)) or tiers.get("c1") or {}
     return str(tier.get("model") or "").strip()
 
 
@@ -158,7 +165,7 @@ def _merge_router_tiers(
     if not isinstance(overrides, dict):
         raise ValueError("router tiers must be an object")
     for name, raw_override in overrides.items():
-        tier_name = str(name)
+        tier_name = normalize_text_tier(name) or str(name)
         override = _normalize_tier_payload(tier_name, raw_override)
         current = dict(merged.get(tier_name, {}))
         current.update(override)
@@ -183,7 +190,7 @@ def _sync_llm_model_to_router_default(cfg: GatewayConfig) -> None:
     router = cfg.squilla_router
     if not getattr(router, "enabled", True):
         return
-    default_tier = str(getattr(router, "default_tier", "t1") or "t1")
+    default_tier = _default_text_tier(getattr(router, "default_tier", DEFAULT_TEXT_TIER))
     _validate_router_tiers(router.tiers, default_tier)
     tier = router.tiers[default_tier]
     model = str(tier.get("model") or "").strip()
@@ -211,7 +218,7 @@ def upsert_llm_provider(
     if not model_clean:
         model_clean = _router_default_model_for_provider(
             provider_id,
-            getattr(config.squilla_router, "default_tier", "t1"),
+            getattr(config.squilla_router, "default_tier", "c1"),
         )
     if not model_clean:
         raise ValueError("model is required")
@@ -290,7 +297,7 @@ def upsert_router(
 
     default_tier_override = _normalize_explicit_text_tier(default_tier)
     default_tier_clean = default_tier_override or str(
-        router_payload.get("default_tier") or "t1"
+        normalize_text_tier(router_payload.get("default_tier")) or DEFAULT_TEXT_TIER
     )
     if default_tier_override is not None:
         router_payload["default_tier"] = default_tier_clean

--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -32,12 +32,12 @@ from opensquilla.onboarding.redaction import (
     redact_search_payload,
 )
 from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
-from opensquilla.secrets import clean_header_secret
-from opensquilla.squilla_router.tiers import (
+from opensquilla.router_tiers import (
     DEFAULT_TEXT_TIER,
     TEXT_TIERS,
     normalize_text_tier,
 )
+from opensquilla.secrets import clean_header_secret
 
 SearchFallbackPolicy = Literal["off", "network"]
 RouterMode = Literal["recommended", "openrouter-mix", "disabled"]

--- a/src/opensquilla/onboarding/next_steps.py
+++ b/src/opensquilla/onboarding/next_steps.py
@@ -50,7 +50,7 @@ _HEADLESS_SETUP_COMMANDS = {
     ),
     "router": (
         "Headless router",
-        "opensquilla onboard configure router --router recommended --default-tier t1",
+        "opensquilla onboard configure router --router recommended --default-tier c1",
     ),
     "channels": (
         "Channel recipes",
@@ -258,7 +258,7 @@ def format_next_steps(config: Any, *, config_path: str | Path | None = None) -> 
     provider = str(getattr(llm, "provider", "") or "")
     model = str(getattr(llm, "model", "") or "")
     env_key = str(getattr(llm, "api_key_env", "") or "")
-    router_default = str(getattr(router, "default_tier", "") or "t1")
+    router_default = str(getattr(router, "default_tier", "") or "c1")
     router_line = (
         "  Router: disabled"
         if not router.enabled

--- a/src/opensquilla/onboarding/provider_specs.py
+++ b/src/opensquilla/onboarding/provider_specs.py
@@ -133,7 +133,7 @@ def _what_you_need(spec: ProviderSpec) -> tuple[str, ...]:
 def _default_direct_model(provider_id: str) -> str:
     if provider_id in ROUTER_TIER_PROFILE_IDS:
         tiers = _router_tier_profile_defaults(provider_id)
-        tier = tiers.get("t1") or tiers.get("t0") or {}
+        tier = tiers.get("c1") or tiers.get("c0") or {}
         return str(tier.get("model") or "")
     return ""
 

--- a/src/opensquilla/onboarding/router_specs.py
+++ b/src/opensquilla/onboarding/router_specs.py
@@ -9,6 +9,7 @@ from opensquilla.gateway.config import (
     ROUTER_TIER_PROFILE_IDS,
     _router_tier_profile_defaults,
 )
+from opensquilla.squilla_router.tiers import DEFAULT_TEXT_TIER, TEXT_TIERS
 
 
 @dataclass(frozen=True)
@@ -39,7 +40,7 @@ def _profile_to_setup(profile_id: str) -> RouterSetupProfile:
     exposed_tiers = {
         name: dict(value)
         for name, value in raw_tiers.items()
-        if name in {"t0", "t1", "t2", "t3", "image_model"}
+        if name in set(TEXT_TIERS) | {"image_model"}
     }
     return RouterSetupProfile(
         profile_id=normalized,
@@ -69,13 +70,13 @@ def _tier_payload(tier: dict[str, Any]) -> dict[str, Any]:
 
 def router_catalog_payload() -> dict[str, Any]:
     return {
-        "defaultTier": "t1",
-        "textTiers": ["t0", "t1", "t2", "t3"],
+        "defaultTier": DEFAULT_TEXT_TIER,
+        "textTiers": list(TEXT_TIERS),
         "modes": [
             {
                 "mode": "recommended",
                 "label": "Recommended provider profile",
-                "description": "Use the selected provider's default t0-t3 routing profile.",
+                "description": "Use the selected provider's default c0-c3 routing profile.",
             },
             {
                 "mode": "openrouter-mix",

--- a/src/opensquilla/onboarding/router_specs.py
+++ b/src/opensquilla/onboarding/router_specs.py
@@ -9,7 +9,7 @@ from opensquilla.gateway.config import (
     ROUTER_TIER_PROFILE_IDS,
     _router_tier_profile_defaults,
 )
-from opensquilla.squilla_router.tiers import DEFAULT_TEXT_TIER, TEXT_TIERS
+from opensquilla.router_tiers import DEFAULT_TEXT_TIER, TEXT_TIERS
 
 
 @dataclass(frozen=True)

--- a/src/opensquilla/onboarding/status.py
+++ b/src/opensquilla/onboarding/status.py
@@ -136,7 +136,7 @@ def _router_detail(cfg: GatewayConfig, llm_source: str) -> str:
     profile = str(getattr(router, "tier_profile", "") or "").strip()
     if profile:
         return f"SquillaRouter profile: {profile}"
-    default_tier = str(getattr(router, "default_tier", "") or "t1").strip()
+    default_tier = str(getattr(router, "default_tier", "") or "c1").strip()
     return f"SquillaRouter default tier: {default_tier}"
 
 

--- a/src/opensquilla/router_control.py
+++ b/src/opensquilla/router_control.py
@@ -7,6 +7,11 @@ import time
 from dataclasses import dataclass, fields, is_dataclass
 from typing import Any
 
+from opensquilla.squilla_router.tiers import (
+    normalize_target_id,
+    normalize_tier_mapping,
+)
+
 # Zero means no turn-count cap; the hold expires after an idle TTL.
 DEFAULT_HOLD_TURNS = 0
 DEFAULT_HOLD_TTL_SECONDS = 600.0
@@ -25,7 +30,6 @@ class RouterControlTarget:
     provider: str | None = None
     description: str | None = None
     thinking_level: str | None = None
-    duplicate_model_resolution: bool = False
 
 
 @dataclass
@@ -40,7 +44,6 @@ class RouterControlHold:
     turns_remaining: int = DEFAULT_HOLD_TURNS
     ttl_seconds: float = DEFAULT_HOLD_TTL_SECONDS
     source: str = "router_control_tool"
-    duplicate_model_resolution: bool = False
 
     def is_expired(self, now_monotonic: float) -> tuple[bool, str | None]:
         if self.turns_remaining < 0:
@@ -64,19 +67,10 @@ def _router_tiers(router_cfg: object | None) -> dict[str, dict[str, Any]]:
     }
 
 
-def _tier_strength(tier: str) -> tuple[int, str]:
-    lowered = tier.lower()
-    if lowered.startswith("t") and lowered[1:].isdigit():
-        return int(lowered[1:]), lowered
-    if lowered == "image_model":
-        return -1, lowered
-    return 0, lowered
-
-
 def _text_tiers(router_cfg: object | None) -> dict[str, dict[str, Any]]:
     return {
         name: cfg
-        for name, cfg in _router_tiers(router_cfg).items()
+        for name, cfg in normalize_tier_mapping(_router_tiers(router_cfg)).items()
         if not bool(cfg.get("image_only", False))
     }
 
@@ -104,23 +98,6 @@ def build_router_control_targets(router_cfg: object | None) -> list[RouterContro
             )
         )
 
-    by_model: dict[str, list[RouterControlTarget]] = {}
-    for target in targets:
-        by_model.setdefault(target.model, []).append(target)
-    for model, tier_targets in by_model.items():
-        strongest = max(tier_targets, key=lambda target: _tier_strength(target.tier))
-        targets.append(
-            RouterControlTarget(
-                target_id=f"model:{model}",
-                target_type="model",
-                tier=strongest.tier,
-                model=model,
-                provider=strongest.provider,
-                description=strongest.description,
-                thinking_level=strongest.thinking_level,
-                duplicate_model_resolution=len(tier_targets) > 1,
-            )
-        )
     return targets
 
 
@@ -128,7 +105,7 @@ def resolve_router_control_target(
     router_cfg: object | None,
     target_id: str,
 ) -> RouterControlTarget:
-    normalized = str(target_id or "").strip()
+    normalized = normalize_target_id(target_id)
     if not normalized:
         raise RouterControlValidationError("router_control target_id is required")
     targets = {target.target_id: target for target in build_router_control_targets(router_cfg)}
@@ -141,24 +118,23 @@ def resolve_router_control_target(
 
 
 def render_router_control_prompt_block(router_cfg: object | None) -> str:
-    targets = build_router_control_targets(router_cfg)
+    targets = [
+        target
+        for target in build_router_control_targets(router_cfg)
+        if target.target_type == "tier"
+    ]
     if not targets:
         return ""
     rows = [
         {
             "target_id": target.target_id,
-            "tier": target.tier,
-            "model": target.model,
-            "provider": target.provider,
-            "description": target.description,
-            "thinking_level": target.thinking_level,
         }
         for target in targets
     ]
     menu = json.dumps(rows, ensure_ascii=False, separators=(",", ":"))
     return (
-        "Use `router_control` when the user semantically asks to upgrade, "
-        "downgrade, use a configured tier/model, or restore automatic routing. "
+        "Use `router_control` only when the user explicitly asks to use a "
+        "configured route or restore automatic routing. "
         "For set_hold, you must choose one target_id exactly from this menu; "
         "do not invent aliases or model ids. The menu is operational context, "
         "not a user-facing recommendation list.\n\n"
@@ -203,7 +179,6 @@ class RouterControlHoldStore:
             last_activity_at_monotonic=now,
             turns_remaining=turns_remaining,
             ttl_seconds=ttl_seconds,
-            duplicate_model_resolution=target.duplicate_model_resolution,
         )
         self._holds[session_key] = hold
         return hold
@@ -254,8 +229,6 @@ def router_control_success_payload(
         "replay_required": replay_required,
         "evidence": evidence,
     }
-    if target and target.duplicate_model_resolution:
-        payload["duplicate_model_resolution"] = True
     return json.dumps(payload, ensure_ascii=False)
 
 

--- a/src/opensquilla/router_control.py
+++ b/src/opensquilla/router_control.py
@@ -7,7 +7,7 @@ import time
 from dataclasses import dataclass, fields, is_dataclass
 from typing import Any
 
-from opensquilla.squilla_router.tiers import (
+from opensquilla.router_tiers import (
     normalize_target_id,
     normalize_tier_mapping,
 )

--- a/src/opensquilla/router_tiers.py
+++ b/src/opensquilla/router_tiers.py
@@ -1,4 +1,4 @@
-"""Canonical Squilla router tier identifiers and legacy aliases."""
+"""Canonical router tier identifiers and legacy aliases."""
 
 from __future__ import annotations
 
@@ -89,4 +89,3 @@ def tier_index(value: object) -> int:
         return TEXT_TIERS.index(tier)
     except ValueError:
         return -1
-

--- a/src/opensquilla/squilla_router/controller.py
+++ b/src/opensquilla/squilla_router/controller.py
@@ -7,7 +7,9 @@ are retained only for safe fallback/default handling.
 
 from __future__ import annotations
 
-TIER_ORDER: list[str] = ["t0", "t1", "t2", "t3"]
+from opensquilla.squilla_router.tiers import TEXT_TIERS
+
+TIER_ORDER: list[str] = list(TEXT_TIERS)
 
 _SYNTHETIC_PEAK = 0.85
 

--- a/src/opensquilla/squilla_router/controller.py
+++ b/src/opensquilla/squilla_router/controller.py
@@ -7,7 +7,7 @@ are retained only for safe fallback/default handling.
 
 from __future__ import annotations
 
-from opensquilla.squilla_router.tiers import TEXT_TIERS
+from opensquilla.router_tiers import TEXT_TIERS
 
 TIER_ORDER: list[str] = list(TEXT_TIERS)
 

--- a/src/opensquilla/squilla_router/tiers.py
+++ b/src/opensquilla/squilla_router/tiers.py
@@ -1,0 +1,92 @@
+"""Canonical Squilla router tier identifiers and legacy aliases."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+TEXT_TIERS: tuple[str, str, str, str] = ("c0", "c1", "c2", "c3")
+DEFAULT_TEXT_TIER = "c1"
+HIGHEST_TEXT_TIER = "c3"
+IMAGE_TIER = "image_model"
+
+LEGACY_TEXT_TIER_ALIASES: dict[str, str] = {
+    "t0": "c0",
+    "t1": "c1",
+    "t2": "c2",
+    "t3": "c3",
+}
+
+ROUTE_CLASS_TO_TIER: dict[str, str] = {
+    "R0": "c0",
+    "R1": "c1",
+    "R2": "c2",
+    "R3": "c3",
+}
+TIER_TO_ROUTE_CLASS: dict[str, str] = {tier: route for route, tier in ROUTE_CLASS_TO_TIER.items()}
+
+
+def normalize_text_tier(value: object) -> str | None:
+    """Return the canonical text tier id for *value*, accepting legacy t0-t3."""
+
+    if value is None:
+        return None
+    tier = str(value).strip().lower()
+    if not tier:
+        return None
+    if tier in TEXT_TIERS:
+        return tier
+    return LEGACY_TEXT_TIER_ALIASES.get(tier)
+
+
+def normalize_tier_id(value: object) -> str | None:
+    """Normalize any known tier id, preserving the image tier."""
+
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    if raw == IMAGE_TIER:
+        return IMAGE_TIER
+    return normalize_text_tier(raw)
+
+
+def normalize_target_id(value: object) -> str:
+    """Normalize router-control target ids such as tier:t3 -> tier:c3."""
+
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    if raw.startswith("tier:"):
+        tier = normalize_text_tier(raw.removeprefix("tier:"))
+        return f"tier:{tier}" if tier else raw
+    return raw
+
+
+def normalize_tier_mapping(mapping: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return a copy of a tier mapping with legacy text tier keys canonicalized."""
+
+    if not isinstance(mapping, Mapping):
+        return {}
+    normalized: dict[str, Any] = {}
+    for key, value in mapping.items():
+        tier = normalize_tier_id(key)
+        out_key = tier or str(key)
+        if out_key in normalized and str(key).strip().lower() not in TEXT_TIERS:
+            continue
+        normalized[out_key] = value
+    return normalized
+
+
+def tier_index(value: object) -> int:
+    """Return 0-3 for known text tiers; -1 for unknown values."""
+
+    tier = normalize_text_tier(value)
+    if tier is None:
+        return -1
+    try:
+        return TEXT_TIERS.index(tier)
+    except ValueError:
+        return -1
+

--- a/src/opensquilla/squilla_router/v4_phase3.py
+++ b/src/opensquilla/squilla_router/v4_phase3.py
@@ -14,15 +14,14 @@ import structlog
 import yaml
 
 from opensquilla.squilla_router.controller import TIER_ORDER, select_localized_prompt_hint
+from opensquilla.squilla_router.tiers import (
+    DEFAULT_TEXT_TIER,
+    ROUTE_CLASS_TO_TIER,
+)
 
 log = structlog.get_logger(__name__)
 
-_ROUTE_CLASS_TO_TIER: dict[str, str] = {
-    "R0": "t0",
-    "R1": "t1",
-    "R2": "t2",
-    "R3": "t3",
-}
+_ROUTE_CLASS_TO_TIER: dict[str, str] = dict(ROUTE_CLASS_TO_TIER)
 
 
 def default_bundle_dir() -> Path:
@@ -43,7 +42,7 @@ def runtime_src_import_path(bundle_dir: Path) -> Iterator[None]:
 
 def _find_valid_tier(start_tier: str, valid_tiers: list[str]) -> str:
     if not valid_tiers:
-        return "t1"
+        return DEFAULT_TEXT_TIER
     start_idx = TIER_ORDER.index(start_tier) if start_tier in TIER_ORDER else 1
     for idx in range(start_idx, len(TIER_ORDER)):
         if TIER_ORDER[idx] in valid_tiers:
@@ -165,7 +164,7 @@ class V4Phase3Strategy:
         self,
         valid_tiers: list[str],
     ) -> tuple[str, float, str, dict]:
-        tier = _find_valid_tier("t1", valid_tiers)
+        tier = _find_valid_tier(DEFAULT_TEXT_TIER, valid_tiers)
         route_class = next(
             (key for key, value in _ROUTE_CLASS_TO_TIER.items() if value == tier),
             "R1",
@@ -243,7 +242,7 @@ class V4Phase3Strategy:
     ) -> tuple[str, float, str, dict]:
         decision = result.decision
         route_class = str(getattr(decision, "route_class", "R1"))
-        tier = _ROUTE_CLASS_TO_TIER.get(route_class, "t1")
+        tier = _ROUTE_CLASS_TO_TIER.get(route_class, DEFAULT_TEXT_TIER)
         if tier not in valid_tiers:
             tier = _find_valid_tier(tier, valid_tiers)
 

--- a/src/opensquilla/squilla_router/v4_phase3.py
+++ b/src/opensquilla/squilla_router/v4_phase3.py
@@ -13,11 +13,11 @@ from typing import Any
 import structlog
 import yaml
 
-from opensquilla.squilla_router.controller import TIER_ORDER, select_localized_prompt_hint
-from opensquilla.squilla_router.tiers import (
+from opensquilla.router_tiers import (
     DEFAULT_TEXT_TIER,
     ROUTE_CLASS_TO_TIER,
 )
+from opensquilla.squilla_router.controller import TIER_ORDER, select_localized_prompt_hint
 
 log = structlog.get_logger(__name__)
 

--- a/src/opensquilla/tools/builtin/router_control.py
+++ b/src/opensquilla/tools/builtin/router_control.py
@@ -17,8 +17,7 @@ from opensquilla.tools.types import current_tool_context
     name="router_control",
     description=(
         "Control the Squilla router for this session. Use only when the user asks "
-        "to switch, upgrade, downgrade, use a configured tier/model, or restore "
-        "automatic routing."
+        "to switch to a configured route or restore automatic routing."
     ),
     params={
         "action": {

--- a/src/opensquilla/tools/registry.py
+++ b/src/opensquilla/tools/registry.py
@@ -117,7 +117,9 @@ class ToolRegistry:
             from opensquilla.router_control import build_router_control_targets
 
             target_ids = [
-                target.target_id for target in build_router_control_targets(router_cfg)
+                target.target_id
+                for target in build_router_control_targets(router_cfg)
+                if target.target_type == "tier"
             ]
         except Exception:  # noqa: BLE001 - schema enrichment must not hide the tool
             return parameters

--- a/tests/functional/test_webui_browser_chat_e2e.py
+++ b/tests/functional/test_webui_browser_chat_e2e.py
@@ -1668,9 +1668,9 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                     enabled: true,
                     rollout_phase: "full",
                     tiers: {
-                      t1: { model: "openrouter/deepseek-v4-flash" },
-                      t2: { model: "openrouter/gemini-3.1-flash-lite" },
-                      t3: { model: "openrouter/qwen3.6-max" },
+                      c1: { model: "openrouter/deepseek-v4-flash" },
+                      c2: { model: "openrouter/gemini-3.1-flash-lite" },
+                      c3: { model: "openrouter/qwen3.6-max" },
                       image_model: {
                         model: "openrouter/kimi-k2.6",
                         supports_image: true,
@@ -1746,7 +1746,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
               await emit(page, "session.event.router_decision", {
                 session_key: sessionKey,
                 stream_seq: 101,
-                tier: "t1",
+                tier: "c1",
                 model: "openrouter/deepseek-v4-flash",
                 routing_source: "squilla_router",
                 routing_applied: true,
@@ -1773,7 +1773,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                     usage: {
                       model: "openrouter/deepseek-v4-flash",
                       routed_model: "openrouter/deepseek-v4-flash",
-                      routed_tier: "t1",
+                      routed_tier: "c1",
                       routing_source: "squilla_router",
                       routing_applied: true,
                       input_tokens: 11,
@@ -1793,7 +1793,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
               await emit(page, "session.event.router_decision", {
                 session_key: sessionKey,
                 stream_seq: 102,
-                tier: "t1",
+                tier: "c1",
                 model: "openrouter/deepseek-v4-flash",
                 routing_source: "squilla_router",
                 routing_applied: true,
@@ -1823,7 +1823,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                     usage: {
                       model: "openrouter/deepseek-v4-flash",
                       routed_model: "openrouter/deepseek-v4-flash",
-                      routed_tier: "t1",
+                      routed_tier: "c1",
                       routing_source: "squilla_router",
                       routing_applied: true,
                       input_tokens: 11,
@@ -1858,7 +1858,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                     usage: {
                       model: "openrouter/deepseek-v4-flash",
                       routed_model: "openrouter/deepseek-v4-flash",
-                      routed_tier: "t1",
+                      routed_tier: "c1",
                       routing_source: "squilla_router",
                       routing_applied: true,
                       input_tokens: 11,
@@ -1880,7 +1880,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                     usage: {
                       model: "openrouter/gemini-3.1-flash-lite",
                       routed_model: "openrouter/gemini-3.1-flash-lite",
-                      routed_tier: "t2",
+                      routed_tier: "c2",
                       routing_source: "squilla_router",
                       routing_applied: true,
                       input_tokens: 13,
@@ -1895,7 +1895,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
               await emit(page, "session.event.router_decision", {
                 session_key: sessionKey,
                 stream_seq: 103,
-                tier: "t2",
+                tier: "c2",
                 model: "openrouter/gemini-3.1-flash-lite",
                 routing_source: "squilla_router",
                 routing_applied: true,
@@ -2961,7 +2961,7 @@ def test_completed_reconnect_without_replay_refreshes_history_in_real_browser(
                         enabled: true,
                         rollout_phase: "full",
                         tiers: {
-                          t1: { model: "openrouter/deepseek-v4-flash" },
+                          c1: { model: "openrouter/deepseek-v4-flash" },
                         },
                       },
                     });
@@ -2996,7 +2996,7 @@ def test_completed_reconnect_without_replay_refreshes_history_in_real_browser(
                             usage: {
                               model: "openrouter/deepseek-v4-flash",
                               routed_model: "openrouter/deepseek-v4-flash",
-                              routed_tier: "t1",
+                              routed_tier: "c1",
                               routing_source: "squilla_router",
                               routing_applied: true,
                               input_tokens: 0,
@@ -3194,7 +3194,7 @@ def test_replayed_savings_done_restores_reply_without_replaying_popup_in_real_br
                         enabled: true,
                         rollout_phase: "full",
                         tiers: {
-                          t1: { model: "openrouter/deepseek-v4-flash" },
+                          c1: { model: "openrouter/deepseek-v4-flash" },
                         },
                       },
                     });
@@ -3247,7 +3247,7 @@ def test_replayed_savings_done_restores_reply_without_replaying_popup_in_real_br
                     output_tokens: 661,
                     model: "openrouter/deepseek-v4-flash",
                     routed_model: "openrouter/deepseek-v4-flash",
-                    routed_tier: "t1",
+                    routed_tier: "c1",
                     routing_source: "squilla_router",
                     routing_applied: true,
                     total_savings_pct: 97,

--- a/tests/test_cli/test_agent_cmd.py
+++ b/tests/test_cli/test_agent_cmd.py
@@ -277,7 +277,7 @@ def test_run_agent_command_json_includes_routing(
             errors=[],
         )
         result.routing = {  # type: ignore[attr-defined]
-            "routed_tier": "t2",
+            "routed_tier": "c2",
             "routing_source": "v4_phase3",
             "routing_confidence": 0.91,
             "baseline_model": "openrouter/heavy",
@@ -291,7 +291,7 @@ def test_run_agent_command_json_includes_routing(
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["routing"] == {
-        "routed_tier": "t2",
+        "routed_tier": "c2",
         "routing_source": "v4_phase3",
         "routing_confidence": 0.91,
         "baseline_model": "openrouter/heavy",
@@ -310,7 +310,7 @@ async def test_run_agent_once_collects_done_routing(
         async def run(self, message: str, session_key: str, **kwargs: Any):
             yield DoneEvent(
                 text="ok",
-                routed_tier="t2",
+                routed_tier="c2",
                 routing_source="v4_phase3",
                 routing_confidence=0.91,
                 baseline_model="openrouter/heavy",
@@ -326,7 +326,7 @@ async def test_run_agent_once_collects_done_routing(
     result = await run_agent_once(message="hello", config=GatewayConfig())
 
     assert result.routing == {  # type: ignore[attr-defined]
-        "routed_tier": "t2",
+        "routed_tier": "c2",
         "routing_source": "v4_phase3",
         "routing_confidence": 0.91,
         "baseline_model": "openrouter/heavy",

--- a/tests/test_cli/test_onboard_cmd.py
+++ b/tests/test_cli/test_onboard_cmd.py
@@ -830,7 +830,7 @@ def test_onboard_catalog_accepts_short_capability_section_aliases(
     ("section", "expected"),
     [
         ("providers", ["openrouter", "OPENROUTER_API_KEY", "deepseek/deepseek-v4-pro"]),
-        ("router", ["recommended", "openrouter-mix", "t0", "t3"]),
+        ("router", ["recommended", "openrouter-mix", "c0", "c3"]),
         ("search", ["duckduckgo", "brave", "BRAVE_SEARCH_API_KEY"]),
         ("channels", ["discord", "Bot token", "opensquilla channels describe discord --json"]),
         ("image-generation", ["openrouter", "openrouter/google/gemini", "OPENROUTER_API_KEY"]),
@@ -925,7 +925,7 @@ def test_onboard_catalog_router_focus_offers_a_real_recipe(tmp_path, monkeypatch
     result = runner.invoke(app, ["onboard", "catalog", "router", "--config", str(target)])
 
     assert result.exit_code == 0, result.stdout
-    assert "Try: opensquilla onboard configure router --router recommended --default-tier t1" in (
+    assert "Try: opensquilla onboard configure router --router recommended --default-tier c1" in (
         result.stdout
     )
     assert "Configure with:" not in result.stdout
@@ -1544,7 +1544,7 @@ def test_onboard_if_needed_non_tty_hint_targets_blocking_memory_section(
         (
             "router",
             "Headless router:",
-            "opensquilla onboard configure router --router recommended --default-tier t1",
+            "opensquilla onboard configure router --router recommended --default-tier c1",
         ),
         (
             "channels",
@@ -1816,14 +1816,14 @@ def test_configure_router_noninteractive_can_set_default_tier(tmp_path, monkeypa
 
     result = runner.invoke(
         app,
-        ["configure", "router", "--router", "recommended", "--default-tier", "t2"],
+        ["configure", "router", "--router", "recommended", "--default-tier", "c2"],
     )
 
     assert result.exit_code == 0, result.stdout
     data = tomllib.loads(target.read_text())
     assert data["squilla_router"]["enabled"] is True
     assert data["squilla_router"]["tier_profile"] == "deepseek"
-    assert data["squilla_router"]["default_tier"] == "t2"
+    assert data["squilla_router"]["default_tier"] == "c2"
 
 
 def test_configure_router_rejects_invalid_default_tier_without_writing(

--- a/tests/test_engine/test_router_control.py
+++ b/tests/test_engine/test_router_control.py
@@ -28,7 +28,7 @@ def _router_cfg(tiers: dict) -> SquillaRouterConfig:
         require_router_runtime=False,
         auto_thinking=False,
         tiers=tiers,
-        default_tier="t1" if "t1" in tiers else next(iter(tiers)),
+        default_tier="c1" if "c1" in tiers else next(iter(tiers)),
     )
 
 
@@ -41,26 +41,21 @@ def test_router_control_targets_generalize_to_every_profile() -> None:
         for tier_name, tier_cfg in tiers.items():
             if tier_cfg.get("image_only"):
                 assert f"tier:{tier_name}" not in target_ids
-                assert f"model:{tier_cfg['model']}" not in target_ids
                 continue
             assert f"tier:{tier_name}" in target_ids
-            assert f"model:{tier_cfg['model']}" in target_ids
 
 
-def test_duplicate_exact_model_target_resolves_to_strongest_text_tier() -> None:
+def test_model_targets_are_rejected_by_local_validation() -> None:
     cfg = _router_cfg(
         {
-            "t0": {"provider": "openrouter", "model": "same/model", "supports_image": False},
-            "t1": {"provider": "openrouter", "model": "other/model", "supports_image": False},
-            "t3": {"provider": "openrouter", "model": "same/model", "supports_image": False},
+            "c0": {"provider": "openrouter", "model": "same/model", "supports_image": False},
+            "c1": {"provider": "openrouter", "model": "other/model", "supports_image": False},
+            "c3": {"provider": "openrouter", "model": "same/model", "supports_image": False},
         }
     )
 
-    target = resolve_router_control_target(cfg, "model:same/model")
-
-    assert target.tier == "t3"
-    assert target.model == "same/model"
-    assert target.duplicate_model_resolution is True
+    with pytest.raises(RouterControlValidationError):
+        resolve_router_control_target(cfg, "model:same/model")
 
 
 def test_natural_language_aliases_are_rejected_by_local_validation() -> None:
@@ -70,14 +65,23 @@ def test_natural_language_aliases_are_rejected_by_local_validation() -> None:
         resolve_router_control_target(cfg, "Claude Opus 4.7")
 
 
+def test_legacy_tier_target_aliases_resolve_to_canonical_routes() -> None:
+    cfg = _router_cfg(_router_tier_profile_defaults("openrouter"))
+
+    target = resolve_router_control_target(cfg, "tier:t3")
+
+    assert target.target_id == "tier:c3"
+    assert target.tier == "c3"
+
+
 def test_hold_store_expires_by_explicit_turn_count_and_sliding_idle_time() -> None:
     cfg = _router_cfg(_router_tier_profile_defaults("openrouter"))
-    target = resolve_router_control_target(cfg, "tier:t3")
+    target = resolve_router_control_target(cfg, "tier:c3")
     store = RouterControlHoldStore()
     store.set_hold(
         "agent:main:test",
         target,
-        evidence="use t3",
+        evidence="use c3",
         now_monotonic=100.0,
         turns_remaining=1,
         ttl_seconds=10.0,
@@ -85,13 +89,13 @@ def test_hold_store_expires_by_explicit_turn_count_and_sliding_idle_time() -> No
 
     first = store.get_valid("agent:main:test", now_monotonic=101.0, decrement=True)
     assert first is not None
-    assert first.tier == "t3"
+    assert first.tier == "c3"
     assert store.get_valid("agent:main:test", now_monotonic=102.0) is None
 
     store.set_hold(
         "agent:main:test",
         target,
-        evidence="use t3 again",
+        evidence="use c3 again",
         now_monotonic=100.0,
         ttl_seconds=10.0,
     )
@@ -102,12 +106,12 @@ def test_hold_store_expires_by_explicit_turn_count_and_sliding_idle_time() -> No
 
 def test_hold_store_deepcopy_preserves_session_identity_for_ttl_refresh() -> None:
     cfg = _router_cfg(_router_tier_profile_defaults("openrouter"))
-    target = resolve_router_control_target(cfg, "tier:t3")
+    target = resolve_router_control_target(cfg, "tier:c3")
     store = RouterControlHoldStore()
     store.set_hold(
         "agent:main:test",
         target,
-        evidence="use t3",
+        evidence="use c3",
         now_monotonic=100.0,
         ttl_seconds=10.0,
     )
@@ -125,12 +129,12 @@ async def test_squilla_router_refreshes_hold_idle_ttl_through_copied_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cfg = _router_cfg(_router_tier_profile_defaults("openrouter"))
-    target = resolve_router_control_target(cfg, "tier:t3")
+    target = resolve_router_control_target(cfg, "tier:c3")
     store = RouterControlHoldStore()
     store.set_hold(
         "agent:main:test-refresh",
         target,
-        evidence="use t3",
+        evidence="use c3",
         now_monotonic=100.0,
         ttl_seconds=10.0,
     )
@@ -161,9 +165,9 @@ async def test_squilla_router_refreshes_hold_idle_ttl_through_copied_metadata(
 @pytest.mark.asyncio
 async def test_squilla_router_applies_hold_before_normal_classification(monkeypatch) -> None:
     cfg = _router_cfg(_router_tier_profile_defaults("openrouter"))
-    target = resolve_router_control_target(cfg, "tier:t3")
+    target = resolve_router_control_target(cfg, "tier:c3")
     store = RouterControlHoldStore()
-    store.set_hold("agent:main:test", target, evidence="use t3")
+    store.set_hold("agent:main:test", target, evidence="use c3")
 
     def fail_strategy(_cfg: object) -> object:
         raise AssertionError("router classification should not run while hold is valid")
@@ -185,15 +189,15 @@ async def test_squilla_router_applies_hold_before_normal_classification(monkeypa
     assert out.model == "anthropic/claude-opus-4.7"
     assert out.metadata["routing_source"] == "router_control_hold"
     assert out.metadata["router_control_hold_applied"] is True
-    assert out.metadata["router_control_target_tier"] == "t3"
+    assert out.metadata["router_control_target_tier"] == "c3"
 
 
 @pytest.mark.asyncio
 async def test_image_attachments_bypass_text_hold(monkeypatch) -> None:
     cfg = _router_cfg(_router_tier_profile_defaults("openrouter"))
-    target = resolve_router_control_target(cfg, "tier:t3")
+    target = resolve_router_control_target(cfg, "tier:c3")
     store = RouterControlHoldStore()
-    store.set_hold("agent:main:test-image", target, evidence="use t3")
+    store.set_hold("agent:main:test-image", target, evidence="use c3")
 
     def fail_strategy(_cfg: object) -> object:
         raise AssertionError("image route should not classify")
@@ -224,6 +228,8 @@ def test_prompt_block_contains_canonical_targets_not_aliases() -> None:
     block = render_router_control_prompt_block(cfg)
 
     assert "router_control" in block
-    assert "tier:t3" in block
-    assert "model:anthropic/claude-opus-4.7" in block
+    assert "tier:c3" in block
+    assert "tier:t3" not in block
+    assert "model:anthropic/claude-opus-4.7" not in block
+    assert "description" not in block
     assert "must choose one target_id exactly" in block

--- a/tests/test_engine/test_router_decision_event.py
+++ b/tests/test_engine/test_router_decision_event.py
@@ -41,7 +41,7 @@ def test_returns_none_when_routed_tier_empty_string() -> None:
 
 def test_full_router_metadata_populates_all_event_fields() -> None:
     metadata = {
-        "routed_tier": "t2",
+        "routed_tier": "c2",
         "routed_model": "claude-sonnet-4.6",
         "baseline_model": "claude-opus-4.7",
         "routing_source": "router",
@@ -56,7 +56,7 @@ def test_full_router_metadata_populates_all_event_fields() -> None:
     event = build_router_decision_event(_ctx(metadata))
     assert isinstance(event, RouterDecisionEvent)
     assert event.kind == "router_decision"
-    assert event.tier == "t2"
+    assert event.tier == "c2"
     assert event.tier_index == 2
     assert event.model == "claude-sonnet-4.6"
     assert event.baseline_model == "claude-opus-4.7"
@@ -73,7 +73,7 @@ def test_legacy_router_probability_and_savings_keys_still_work() -> None:
     event = build_router_decision_event(
         _ctx(
             {
-                "routed_tier": "t2",
+                "routed_tier": "c2",
                 "routing_extra": {
                     "probs": [0.12, 0.71, 0.14, 0.03],
                     "tier_savings": {"pct": 64.0},
@@ -88,7 +88,7 @@ def test_legacy_router_probability_and_savings_keys_still_work() -> None:
 
 def test_falls_back_to_turn_model_when_routed_model_absent() -> None:
     event = build_router_decision_event(
-        _ctx({"routed_tier": "t1"}, model="deepseek-v4-flash")
+        _ctx({"routed_tier": "c1"}, model="deepseek-v4-flash")
     )
     assert event is not None
     assert event.model == "deepseek-v4-flash"
@@ -99,7 +99,7 @@ def test_falls_back_to_turn_model_when_routed_model_absent() -> None:
 
 def test_fallback_source_sets_fallback_flag() -> None:
     event = build_router_decision_event(
-        _ctx({"routed_tier": "t2", "routed_model": "x", "routing_source": "fallback"})
+        _ctx({"routed_tier": "c2", "routed_model": "x", "routing_source": "fallback"})
     )
     assert event is not None
     assert event.fallback is True
@@ -110,7 +110,7 @@ def test_malformed_probs_do_not_crash() -> None:
     event = build_router_decision_event(
         _ctx(
             {
-                "routed_tier": "t3",
+                "routed_tier": "c3",
                 "routed_model": "claude-opus-4.7",
                 "routing_extra": {"probs": ["bad", None, 0.5, "x"]},
             }
@@ -129,18 +129,18 @@ def test_unknown_tier_string_results_in_negative_tier_index() -> None:
     assert event.tier_index == -1
 
 
-def test_tier_index_maps_naturally_so_t0_and_t1_dont_collide() -> None:
-    # Regression: an earlier max(0, int(...) - 1) collapsed both t0
-    # and t1 onto index 0. The natural mapping puts t0 at 0, t1 at 1,
+def test_tier_index_maps_naturally_so_c0_and_c1_dont_collide() -> None:
+    # Regression: an earlier max(0, int(...) - 1) collapsed both c0
+    # and c1 onto index 0. The natural mapping puts c0 at 0, c1 at 1,
     # and so on.
     t0_event = build_router_decision_event(
-        _ctx({"routed_tier": "t0", "routed_model": "deepseek-v4-flash"})
+        _ctx({"routed_tier": "c0", "routed_model": "deepseek-v4-flash"})
     )
     t1_event = build_router_decision_event(
-        _ctx({"routed_tier": "t1", "routed_model": "claude-sonnet-4.6"})
+        _ctx({"routed_tier": "c1", "routed_model": "claude-sonnet-4.6"})
     )
     t3_event = build_router_decision_event(
-        _ctx({"routed_tier": "t3", "routed_model": "claude-opus-4.7"})
+        _ctx({"routed_tier": "c3", "routed_model": "claude-opus-4.7"})
     )
     assert t0_event is not None and t0_event.tier_index == 0
     assert t1_event is not None and t1_event.tier_index == 1
@@ -153,7 +153,7 @@ def test_routing_applied_and_rollout_phase_round_trip() -> None:
     observe_event = build_router_decision_event(
         _ctx(
             {
-                "routed_tier": "t2",
+                "routed_tier": "c2",
                 "routed_model": "claude-sonnet-4.6",
                 "routing_applied": False,
                 "rollout_phase": "observe",
@@ -168,7 +168,7 @@ def test_routing_applied_and_rollout_phase_round_trip() -> None:
     full_event = build_router_decision_event(
         _ctx(
             {
-                "routed_tier": "t2",
+                "routed_tier": "c2",
                 "routed_model": "claude-sonnet-4.6",
                 "routing_applied": True,
                 "rollout_phase": "full",
@@ -185,7 +185,7 @@ def test_legacy_metadata_without_routing_applied_defaults_to_applied() -> None:
     # metadata fields. The event helper must fall back to applied=True
     # + rollout_phase="full" so historic strips keep rendering normally.
     event = build_router_decision_event(
-        _ctx({"routed_tier": "t2", "routed_model": "claude-sonnet-4.6"})
+        _ctx({"routed_tier": "c2", "routed_model": "claude-sonnet-4.6"})
     )
     assert event is not None
     assert event.routing_applied is True
@@ -245,7 +245,7 @@ async def test_turn_runner_emits_router_decision_event_from_pipeline_metadata(
                 system_prompt=base_prompt,
                 attachments=attachments,
                 metadata={
-                    "routed_tier": "t2",
+                    "routed_tier": "c2",
                     "routed_model": "routed-model",
                     "routing_source": "router",
                     "routing_confidence": 0.8,
@@ -270,5 +270,5 @@ async def test_turn_runner_emits_router_decision_event_from_pipeline_metadata(
 
     router_events = [event for event in events if isinstance(event, RouterDecisionEvent)]
     assert len(router_events) == 1
-    assert router_events[0].tier == "t2"
+    assert router_events[0].tier == "c2"
     assert router_events[0].model == "routed-model"

--- a/tests/test_engine/test_runtime_router_fallback.py
+++ b/tests/test_engine/test_runtime_router_fallback.py
@@ -39,7 +39,7 @@ class _SlowHistoryStrategy:
     ) -> tuple[str, float, str, dict]:
         time.sleep(0.08)
         return (
-            "t2",
+            "c2",
             0.95,
             "v4_phase3",
             {
@@ -62,7 +62,7 @@ class _MutatingHistoryStrategy:
         assert routing_history
         routing_history[0]["final_tier"] = "poisoned"
         return (
-            "t2",
+            "c2",
             0.95,
             "v4_phase3",
             {
@@ -172,7 +172,7 @@ async def test_squilla_router_timeout_does_not_late_mutate_history_entries(
             "turn_index": 0,
             "_ts": time.monotonic(),
             "text": "previous",
-            "final_tier": "t1",
+            "final_tier": "c1",
         }
     ]
     squilla_router_step._history_store.clear()
@@ -206,7 +206,7 @@ async def test_squilla_router_timeout_does_not_late_mutate_history_entries(
     stored_history = squilla_router_step._history_store.get(session_key)
     assert stored_history == original_history
     assert stored_history is not None
-    assert stored_history[0]["final_tier"] == "t1"
+    assert stored_history[0]["final_tier"] == "c1"
     router_record = next(
         record
         for record in turn.metadata["pipeline_steps"]

--- a/tests/test_engine/test_savings_score.py
+++ b/tests/test_engine/test_savings_score.py
@@ -9,9 +9,9 @@ from opensquilla.engine.runtime import _compute_comprehensive_turn_savings
 from opensquilla.engine.types import DoneEvent
 
 TEXT_TIERS = {
-    "t0": {"model": "deepseek/deepseek-v4-flash"},
-    "t2": {"model": "deepseek/deepseek-v4-pro"},
-    "t3": {"model": "anthropic/claude-opus-4.7"},
+    "c0": {"model": "deepseek/deepseek-v4-flash"},
+    "c2": {"model": "deepseek/deepseek-v4-pro"},
+    "c3": {"model": "anthropic/claude-opus-4.7"},
     "image_model": {"model": "moonshotai/kimi-k2.6", "image_only": True},
 }
 

--- a/tests/test_engine/test_t3_upgrade_compaction.py
+++ b/tests/test_engine/test_t3_upgrade_compaction.py
@@ -159,8 +159,8 @@ def _within_budget_transcript() -> list[TranscriptEntry]:
 
 
 def _make_turn(
-    routed_tier: str = "t3",
-    previous_tier: str | None = "t2",
+    routed_tier: str = "c3",
+    previous_tier: str | None = "c2",
     base_tier: str | None = None,
     final_tier: str | None = None,
     routing_applied: bool = True,
@@ -200,7 +200,7 @@ def _make_runner(
     flush_compaction_requires_safe_receipt: bool = False,
 ) -> TurnRunner:
     config = SimpleNamespace(
-        squilla_router=SimpleNamespace(upgrade_to_t3_compaction_enabled=enabled),
+        squilla_router=SimpleNamespace(upgrade_to_c3_compaction_enabled=enabled),
         memory=SimpleNamespace(
             flush_enabled=flush_enabled,
             flush_timeout_seconds=flush_timeout_seconds,
@@ -227,7 +227,7 @@ async def test_t2_to_t3_triggers_flush_then_compact() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -243,7 +243,7 @@ async def test_t3_within_budget_skips_flush_and_compact() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -266,7 +266,7 @@ async def test_t3_completed_event_reports_compaction_metadata(
     )
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -317,7 +317,7 @@ async def test_t3_stale_preimage_skip_does_not_mark_compacted(
     runner = _make_runner(session_manager=sm, flush_service=fs)
     session_key = "agent:main:webchat:default"
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade(session_key, turn, 100_000)
 
     assert result == "handled"
@@ -332,12 +332,12 @@ async def test_t3_stale_preimage_skip_does_not_mark_compacted(
 
 @pytest.mark.asyncio
 async def test_t0_t1_to_t3_triggers() -> None:
-    for prev in ("t0", "t1"):
+    for prev in ("c0", "c1"):
         sm = _FakeSessionManager(_sample_transcript())
         fs = _FakeFlushService()
         runner = _make_runner(session_manager=sm, flush_service=fs)
 
-        turn = _make_turn(routed_tier="t3", previous_tier=prev)
+        turn = _make_turn(routed_tier="c3", previous_tier=prev)
         result = await runner._maybe_compact_on_t3_upgrade(
             "agent:main:webchat:default", turn, 100_000
         )
@@ -354,7 +354,7 @@ async def test_t3_to_t3_skips() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t3")
+    turn = _make_turn(routed_tier="c3", previous_tier="c3")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "not_applicable"
@@ -368,7 +368,7 @@ async def test_non_t3_route_skips() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t1", previous_tier="t0")
+    turn = _make_turn(routed_tier="c1", previous_tier="c0")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "not_applicable"
@@ -382,7 +382,7 @@ async def test_config_disabled_skips() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs, enabled=False)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "not_applicable"
@@ -396,7 +396,7 @@ async def test_observe_mode_skips() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2", routing_applied=False)
+    turn = _make_turn(routed_tier="c3", previous_tier="c2", routing_applied=False)
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "not_applicable"
@@ -410,7 +410,7 @@ async def test_flush_raises_does_not_block_compaction() -> None:
     fs = _FakeFlushService(raise_exc=RuntimeError("flush boom"))
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -425,7 +425,7 @@ async def test_flush_error_receipt_does_not_block_compaction() -> None:
     fs = _FakeFlushService(receipt=_FakeFlushReceipt(mode="error", error="provider down"))
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -453,7 +453,7 @@ async def test_degraded_flush_receipts_do_not_block_compaction(
     fs = _FakeFlushService(receipt=receipt)
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -472,7 +472,7 @@ async def test_t3_strict_flush_receipt_skips_destructive_compaction() -> None:
         flush_compaction_requires_safe_receipt=True,
     )
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -486,7 +486,7 @@ async def test_backfilled_flush_receipt_allows_compact() -> None:
     fs = _FakeFlushService(receipt=_FakeFlushReceipt(obligation_status="backfilled"))
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -506,7 +506,7 @@ async def test_t3_flush_uses_background_timeout_for_service_call() -> None:
         flush_background_timeout_seconds=42.0,
     )
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -520,7 +520,7 @@ async def test_t3_flush_uses_longer_default_background_timeout() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -539,7 +539,7 @@ async def test_t3_flush_grace_timeout_does_not_block_compaction() -> None:
         flush_background_timeout_seconds=42.0,
     )
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -558,7 +558,7 @@ async def test_memory_flush_disabled_compacts_without_flush_service() -> None:
         flush_enabled=False,
     )
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -575,7 +575,7 @@ async def test_env_flush_disabled_compacts_without_flush_service(
     sm = _FakeSessionManager(_sample_transcript())
     runner = _make_runner(session_manager=sm, flush_service=None)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -593,7 +593,7 @@ async def test_compact_raises_continues() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "compact_failed"
@@ -632,7 +632,7 @@ async def test_t3_compact_failure_uses_emergency_ephemeral_history_trim(
 
     result = await runner._maybe_compact_on_t3_upgrade(
         session_key,
-        _make_turn(routed_tier="t3", previous_tier="t2"),
+        _make_turn(routed_tier="c3", previous_tier="c2"),
         1000,
     )
 
@@ -691,7 +691,7 @@ async def test_t3_open_circuit_still_uses_request_scoped_emergency_trim(
 
     result = await runner._maybe_compact_on_t3_upgrade(
         session_key,
-        _make_turn(routed_tier="t3", previous_tier="t2"),
+        _make_turn(routed_tier="c3", previous_tier="c2"),
         1000,
     )
 

--- a/tests/test_engine/turn_runner/test_router_control_replay_event.py
+++ b/tests/test_engine/turn_runner/test_router_control_replay_event.py
@@ -34,7 +34,7 @@ class _Strategy:
         routing_history: list[dict] | None = None,
         **kwargs: object,
     ) -> tuple[str, float, str, dict]:
-        return "t1", 0.9, "v4_phase3", {"route_class": "R1"}
+        return "c1", 0.9, "v4_phase3", {"route_class": "R1"}
 
 
 class _ReplayProvider:
@@ -57,8 +57,8 @@ class _ReplayProvider:
                 tool_name="router_control",
                 arguments={
                     "action": "set_hold",
-                    "target_id": "tier:t3",
-                    "evidence": "use t3",
+                    "target_id": "tier:c3",
+                    "evidence": "use c3",
                 },
             )
             yield ProviderDone(model=self.model)
@@ -112,7 +112,7 @@ async def test_router_control_replay_event_replays_turn_once(monkeypatch) -> Non
     events = [
         event
         async for event in runner.run(
-            "Use t3 for this",
+            "Use c3 for this",
             "agent:main:router-control-replay",
             tool_context=ToolContext(is_owner=True, caller_kind=CallerKind.CLI),
             history_has_persisted_user=False,
@@ -125,7 +125,7 @@ async def test_router_control_replay_event_replays_turn_once(monkeypatch) -> Non
     text = "".join(getattr(event, "text", "") for event in events if event.kind == "text_delta")
 
     assert len(replay_events) == 1
-    assert replay_events[0].target_tier == "t3"
+    assert replay_events[0].target_tier == "c3"
     assert provider.calls == ["deepseek/deepseek-v4-pro", "anthropic/claude-opus-4.7"]
     assert done_events[-1].text == "new final"
     assert text.endswith("new final")

--- a/tests/test_engine/turn_runner/test_turn_finalizer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_turn_finalizer_stage_unit.py
@@ -264,7 +264,7 @@ async def test_simple_text_with_done_event_fires_rollup() -> None:
         input_tokens=5,
         output_tokens=3,
         model="synthetic-turn-model-4.5",
-        routed_tier="t2",
+        routed_tier="c2",
         routing_applied=False,
         rollout_phase="observe",
     )
@@ -280,7 +280,7 @@ async def test_simple_text_with_done_event_fires_rollup() -> None:
     assert recs["transcript_append"].calls[0]["turn_usage"]["input_tokens"] == 5
     assert recs["transcript_append"].calls[0]["turn_usage"]["output_tokens"] == 3
     assert recs["transcript_append"].calls[0]["turn_usage"]["model"] == "synthetic-turn-model-4.5"
-    assert recs["transcript_append"].calls[0]["turn_usage"]["routed_tier"] == "t2"
+    assert recs["transcript_append"].calls[0]["turn_usage"]["routed_tier"] == "c2"
     assert recs["transcript_append"].calls[0]["turn_usage"]["routing_applied"] is False
     assert recs["transcript_append"].calls[0]["turn_usage"]["rollout_phase"] == "observe"
 
@@ -335,7 +335,7 @@ async def test_turn_with_artifacts_persists_json_wrapped_content() -> None:
 @pytest.mark.asyncio
 async def test_tool_use_segments_persist_with_tool_calls() -> None:
     segments: list[dict[str, Any]] = [
-        {"type": "tool_use", "tool_use_id": "t1", "name": "echo", "input": ""},
+        {"type": "tool_use", "tool_use_id": "c1", "name": "echo", "input": ""},
     ]
     stage, recs = _make_stage()
     inp = _make_input(turn_segments=segments)
@@ -350,7 +350,7 @@ async def test_unknown_background_tool_status_adds_confirmation_guard() -> None:
     segments: list[dict[str, Any]] = [
         {
             "type": "tool_result",
-            "tool_use_id": "t1",
+            "tool_use_id": "c1",
             "name": "background_process",
             "result": "session: open-browser\nstatus: running",
             "is_error": False,
@@ -385,7 +385,7 @@ async def test_successful_background_tool_status_does_not_add_confirmation_guard
     segments: list[dict[str, Any]] = [
         {
             "type": "tool_result",
-            "tool_use_id": "t1",
+            "tool_use_id": "c1",
             "name": "background_process",
             "result": "session: open-browser\nstatus: complete",
             "is_error": False,

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -395,7 +395,10 @@ def test_chat_streaming_active_mark_reveals_after_visible_bubble_delay() -> None
     reveal_start = source.index("function _maybeRevealStreamActiveMark()")
     reveal_end = source.index("  function _scheduleStreamActiveMarkReveal", reveal_start)
     reveal_body = source[reveal_start:reveal_end]
-    assert "_streamActiveMarkVisibleStartedAt ? Date.now() - _streamActiveMarkVisibleStartedAt : 0" in reveal_body
+    assert (
+        "_streamActiveMarkVisibleStartedAt ? Date.now() - _streamActiveMarkVisibleStartedAt : 0"
+        in reveal_body
+    )
 
     end_stream_start = source.index("function _endStreaming(opts)")
     end_stream_end = source.index("  function _hasViewLocalStreamState", end_stream_start)
@@ -1953,11 +1956,18 @@ def test_router_fx_single_visual_candidate_renders_nothing_live_or_history() -> 
     schedule_start = source.index("function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts) {")
     schedule_end = source.index("  // Render the routing visualisation", schedule_start)
     schedule_body = source[schedule_start:schedule_end]
-    assert "if (_routerFxConfigTiers !== null && !_routerFxHasMultipleCandidates(requestKind, null)) {" in schedule_body
+    assert (
+        "if (_routerFxConfigTiers !== null "
+        "&& !_routerFxHasMultipleCandidates(requestKind, null)) {"
+        in schedule_body
+    )
     assert "_chatDiag('router_scan.schedule.skip.single_candidate'" in schedule_body
 
     pending_start = source.index("async function _finishPendingRouterFxScan() {")
-    pending_end = source.index("function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts) {", pending_start)
+    pending_end = source.index(
+        "function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts) {",
+        pending_start,
+    )
     pending_body = source[pending_start:pending_end]
     assert pending_body.index("await _routerFxAwaitConfig();") < pending_body.index(
         "_routerFxBeginScan(pending.anchorDiv, pending.seedKey"

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -834,7 +834,7 @@ async def test_start_gateway_server_wires_meta_skill_auto_propose_routes(
         },
         squilla_router={
             "tiers": {
-                "t3": {
+                "c3": {
                     "model": "frontier-t3-model",
                     "thinking_level": "high",
                 },
@@ -855,7 +855,7 @@ async def test_start_gateway_server_wires_meta_skill_auto_propose_routes(
         assert runtime_contexts[-1]["skill_loader"] is server._services.skill_loader
         base_config = runtime_contexts[-1]["base_config"]
         assert base_config.model_id == "frontier-t3-model"
-        assert base_config.metadata["routed_tier"] == "t3"
+        assert base_config.metadata["routed_tier"] == "c3"
         assert base_config.metadata["thinking_level"] == "high"
         assert runtime_contexts[-1]["baseline_model"] == "frontier-t3-model"
         with pytest.raises(RuntimeError):

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -162,9 +162,9 @@ async def test_router_configure_accepts_tier_overrides_and_syncs_llm_model(
         "onboarding.router.configure",
         {
             "mode": "recommended",
-            "defaultTier": "t2",
+            "defaultTier": "c2",
             "tiers": {
-                "t2": {"provider": "openai", "model": "gpt-5.5-custom"},
+                "c2": {"provider": "openai", "model": "gpt-5.5-custom"},
                 "image_model": {
                     "provider": "openai",
                     "model": "gpt-5.4-mini",
@@ -177,10 +177,10 @@ async def test_router_configure_accepts_tier_overrides_and_syncs_llm_model(
 
     assert res.error is None, res.error
     assert ctx.config.llm.model == "gpt-5.5-custom"
-    assert ctx.config.squilla_router.default_tier == "t2"
+    assert ctx.config.squilla_router.default_tier == "c2"
     persisted = tomllib.loads((tmp_path / "c.toml").read_text())
     assert persisted["llm"]["model"] == "gpt-5.5-custom"
-    assert persisted["squilla_router"]["tiers"]["t2"]["model"] == "gpt-5.5-custom"
+    assert persisted["squilla_router"]["tiers"]["c2"]["model"] == "gpt-5.5-custom"
     assert persisted["squilla_router"]["tiers"]["image_model"]["supports_image"] is True
 
 

--- a/tests/test_gateway/test_static_onboarding_views.py
+++ b/tests/test_gateway/test_static_onboarding_views.py
@@ -734,8 +734,8 @@ def test_setup_router_controls_use_user_facing_labels():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
     assert "SquillaRouter" in txt
     assert "OpenRouter mix" not in txt
-    assert "Balanced default (t1)" in txt
-    assert "Stronger reasoning (t2)" in txt
+    assert "Route c1" in txt
+    assert "Route c2" in txt
 
 
 def test_setup_view_preserves_unsaved_form_values_across_step_navigation():

--- a/tests/test_live_provider_profile_gateway_e2e.py
+++ b/tests/test_live_provider_profile_gateway_e2e.py
@@ -55,9 +55,9 @@ def test_debugging_case_is_bounded_to_keep_marker_in_smoke_budget() -> None:
 
 
 def test_case_markers_are_stable_text_not_millisecond_numbers() -> None:
-    marker = e2e._case_marker("openrouter", "t2", "coverage_t2")
+    marker = e2e._case_marker("openrouter", "c2", "coverage_t2")
 
-    assert marker == "E2E_OPENROUTER_T2_COVERAGE_T2"
+    assert marker == "E2E_OPENROUTER_C2_COVERAGE_T2"
     assert not marker.rsplit("_", 1)[-1].isdigit()
 
 
@@ -80,14 +80,14 @@ def test_live_gateway_profile_config_bounds_agent_runtime(tmp_path: Path) -> Non
 
 def test_profile_slot_targets_cover_slots_not_unique_models() -> None:
     tiers = {
-        "t0": {"provider": "deepseek", "model": "deepseek-v4-flash"},
-        "t1": {
+        "c0": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        "c1": {
             "provider": "deepseek",
             "model": "deepseek-v4-flash",
             "thinking_level": "low",
         },
-        "t2": {"provider": "deepseek", "model": "deepseek-v4-pro"},
-        "t3": {
+        "c2": {"provider": "deepseek", "model": "deepseek-v4-pro"},
+        "c3": {
             "provider": "deepseek",
             "model": "deepseek-v4-pro",
             "thinking_level": "high",
@@ -97,53 +97,53 @@ def test_profile_slot_targets_cover_slots_not_unique_models() -> None:
 
     targets = e2e._profile_slot_targets(tiers)
 
-    assert list(targets) == ["t0", "t1", "t2", "t3"]
-    assert targets["t0"]["model"] == targets["t1"]["model"]
-    assert targets["t1"]["thinking_level"] == "low"
+    assert list(targets) == ["c0", "c1", "c2", "c3"]
+    assert targets["c0"]["model"] == targets["c1"]["model"]
+    assert targets["c1"]["thinking_level"] == "low"
 
 
 def test_forced_tier_overrides_make_only_target_slot_text_routable() -> None:
     tiers = {
-        "t0": {"provider": "deepseek", "model": "deepseek-v4-flash"},
-        "t1": {"provider": "deepseek", "model": "deepseek-v4-flash"},
-        "t2": {"provider": "deepseek", "model": "deepseek-v4-pro"},
-        "t3": {"provider": "deepseek", "model": "deepseek-v4-pro"},
+        "c0": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        "c1": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        "c2": {"provider": "deepseek", "model": "deepseek-v4-pro"},
+        "c3": {"provider": "deepseek", "model": "deepseek-v4-pro"},
     }
 
-    overrides = e2e._forced_tier_overrides_for_slot(tiers, "t2")
+    overrides = e2e._forced_tier_overrides_for_slot(tiers, "c2")
 
-    assert overrides["t2"]["image_only"] is False
-    assert overrides["t2"]["model"] == "deepseek-v4-pro"
-    assert overrides["t0"]["image_only"] is True
-    assert overrides["t1"]["image_only"] is True
-    assert overrides["t3"]["image_only"] is True
+    assert overrides["c2"]["image_only"] is False
+    assert overrides["c2"]["model"] == "deepseek-v4-pro"
+    assert overrides["c0"]["image_only"] is True
+    assert overrides["c1"]["image_only"] is True
+    assert overrides["c3"]["image_only"] is True
 
 
 def test_missing_profile_slots_are_computed_by_slot() -> None:
     tiers = {
-        "t0": {"provider": "deepseek", "model": "deepseek-v4-flash"},
-        "t1": {"provider": "deepseek", "model": "deepseek-v4-flash"},
-        "t2": {"provider": "deepseek", "model": "deepseek-v4-pro"},
-        "t3": {"provider": "deepseek", "model": "deepseek-v4-pro"},
+        "c0": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        "c1": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        "c2": {"provider": "deepseek", "model": "deepseek-v4-pro"},
+        "c3": {"provider": "deepseek", "model": "deepseek-v4-pro"},
     }
     rows = [
         {
             "ok": True,
-            "expected_slot": "t0",
-            "actual_slot_covered": "t0",
+            "expected_slot": "c0",
+            "actual_slot_covered": "c0",
             "expected_model": "deepseek-v4-flash",
             "actual_request_model": "deepseek-v4-flash",
         },
         {
             "ok": True,
-            "expected_slot": "t2",
-            "actual_slot_covered": "t2",
+            "expected_slot": "c2",
+            "actual_slot_covered": "c2",
             "expected_model": "deepseek-v4-pro",
             "actual_request_model": "deepseek-v4-pro",
         },
     ]
 
-    assert e2e._missing_profile_slots(tiers, rows) == ["t1", "t3"]
+    assert e2e._missing_profile_slots(tiers, rows) == ["c1", "c3"]
 
 
 def test_cost_summary_never_promotes_gateway_placeholder_to_provider_bill() -> None:
@@ -178,7 +178,7 @@ def test_router_step_is_extracted_from_decision_log() -> None:
             {"step_name": "resolve_model", "routed_tier": None},
             {
                 "step_name": "apply_squilla_router",
-                "routed_tier": "t2",
+                "routed_tier": "c2",
                 "routing_source": "v4_phase3",
                 "confidence": 0.91,
             },
@@ -187,6 +187,6 @@ def test_router_step_is_extracted_from_decision_log() -> None:
 
     step = e2e._router_step_from_decision(decision)
 
-    assert step["routed_tier"] == "t2"
+    assert step["routed_tier"] == "c2"
     assert step["routing_source"] == "v4_phase3"
     assert step["confidence"] == 0.91

--- a/tests/test_memory_dream_factory.py
+++ b/tests/test_memory_dream_factory.py
@@ -37,7 +37,7 @@ def test_dream_provider_follows_llm_model_when_router_disabled() -> None:
     assert primary.model == "user/custom-model"
 
 
-def test_dream_provider_uses_router_t1_model_when_router_active() -> None:
+def test_dream_provider_uses_legacy_router_default_alias_when_router_active() -> None:
     config = GatewayConfig(
         llm={
             "provider": "openrouter",
@@ -61,6 +61,8 @@ def test_dream_provider_uses_router_t1_model_when_router_active() -> None:
     primary = _primary_config(selector)
     assert primary.provider == "openrouter"
     assert primary.model == "router/t1-model"
+    assert config.squilla_router.default_tier == "c1"
+    assert "c1" in config.squilla_router.tiers
 
 
 def test_dream_rejects_dream_specific_model_override() -> None:

--- a/tests/test_model_router_behavior.py
+++ b/tests/test_model_router_behavior.py
@@ -139,7 +139,7 @@ async def test_full_rollout_applies_routed_model_thinking_and_p0_prompt(
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.91,
         {
             "route_class": "R1",
@@ -153,7 +153,7 @@ async def test_full_rollout_applies_routed_model_thinking_and_p0_prompt(
     routed = await apply_squilla_router(ctx)
 
     assert routed.model == "deepseek/deepseek-v4-pro"
-    assert routed.metadata["routed_tier"] == "t1"
+    assert routed.metadata["routed_tier"] == "c1"
     assert routed.metadata["routed_model"] == "deepseek/deepseek-v4-pro"
     assert routed.metadata["routing_applied"] is True
     assert routed.metadata["applied_model"] == "deepseek/deepseek-v4-pro"
@@ -176,7 +176,7 @@ async def test_router_reports_provider_state_loss_without_changing_route(
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.91,
         {
             "route_class": "R1",
@@ -217,7 +217,7 @@ async def test_router_continuity_diagnostic_ignores_expired_provider_state(
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.91,
         {
             "route_class": "R1",
@@ -261,7 +261,7 @@ async def test_p2_prompt_hint_is_recorded_but_not_injected(
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t3",
+        "c3",
         0.97,
         {
             "route_class": "R3",
@@ -275,7 +275,7 @@ async def test_p2_prompt_hint_is_recorded_but_not_injected(
     routed = await apply_squilla_router(ctx)
 
     assert routed.model == "anthropic/claude-opus-4.7"
-    assert routed.metadata["routed_tier"] == "t3"
+    assert routed.metadata["routed_tier"] == "c3"
     assert routed.metadata["thinking_level"] == "high"
     assert routed.metadata["prompt_policy"] == "P2"
     assert routed.metadata["routing_extra"]["prompt_hint"] == "Use a careful plan before answering."
@@ -288,7 +288,7 @@ async def test_v4_thinking_mode_overrides_explicit_tier_thinking_level(
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.92,
         {
             "route_class": "R2",
@@ -300,7 +300,7 @@ async def test_v4_thinking_mode_overrides_explicit_tier_thinking_level(
 
     routed = await apply_squilla_router(ctx)
 
-    assert routed.metadata["routed_tier"] == "t2"
+    assert routed.metadata["routed_tier"] == "c2"
     assert routed.metadata["thinking_mode"] == "T2"
     assert routed.metadata["thinking_requested"] is True
     assert routed.metadata["thinking_level"] == "medium"
@@ -312,7 +312,7 @@ async def test_confidence_gate_promotes_low_confidence_t0_to_default_t1_and_reco
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t0",
+        "c0",
         0.1,
         {
             "route_class": "R0",
@@ -325,11 +325,11 @@ async def test_confidence_gate_promotes_low_confidence_t0_to_default_t1_and_reco
     routed = await apply_squilla_router(ctx)
     extra = routed.metadata["routing_extra"]
 
-    assert routed.metadata["routed_tier"] == "t1"
+    assert routed.metadata["routed_tier"] == "c1"
     assert routed.model == "deepseek/deepseek-v4-pro"
     assert extra["confidence_gate_applied"] is True
-    assert extra["base_tier"] == "t0"
-    assert extra["final_tier"] == "t1"
+    assert extra["base_tier"] == "c0"
+    assert extra["final_tier"] == "c1"
     assert routed.metadata["thinking_mode"] == "T1"
     assert routed.metadata["thinking_level"] == "low"
     assert "[RESPONSE_POLICY: Answer directly" in routed.message
@@ -341,7 +341,7 @@ async def test_confidence_gate_falls_back_low_confidence_non_default_text_tier(
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.1,
         {
             "route_class": "R2",
@@ -354,18 +354,18 @@ async def test_confidence_gate_falls_back_low_confidence_non_default_text_tier(
     routed = await apply_squilla_router(ctx)
     extra = routed.metadata["routing_extra"]
 
-    assert routed.metadata["routed_tier"] == "t1"
+    assert routed.metadata["routed_tier"] == "c1"
     assert routed.model == "deepseek/deepseek-v4-pro"
     assert extra["confidence_gate_applied"] is True
-    assert extra["pre_confidence_tier"] == "t2"
-    assert extra["final_tier"] == "t1"
+    assert extra["pre_confidence_tier"] == "c2"
+    assert extra["final_tier"] == "c1"
 
 
 @pytest.mark.asyncio
 async def test_large_material_estimate_floors_low_router_tier(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    fake_strategy(monkeypatch, "t1", 0.91, {"route_class": "R1"})
+    fake_strategy(monkeypatch, "c1", 0.91, {"route_class": "R1"})
     ctx = make_context("Please process the attached pasted text.")
     ctx.metadata["input_normalization"] = {
         "guard_action": "generated_text_attachment",
@@ -375,18 +375,18 @@ async def test_large_material_estimate_floors_low_router_tier(
 
     routed = await apply_squilla_router(ctx)
 
-    assert routed.metadata["routed_tier"] == "t2"
+    assert routed.metadata["routed_tier"] == "c2"
     assert routed.metadata["routing_source"] == "large_context_floor"
-    assert routed.metadata["large_context_floor_from_tier"] == "t1"
+    assert routed.metadata["large_context_floor_from_tier"] == "c1"
     assert routed.metadata["large_context_material_tokens"] == 45_000
-    assert routed.metadata["routing_extra"]["final_tier"] == "t2"
+    assert routed.metadata["routing_extra"]["final_tier"] == "c2"
 
 
 @pytest.mark.asyncio
 async def test_large_material_ratio_floors_low_router_tier_to_t3(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    fake_strategy(monkeypatch, "t1", 0.91, {"route_class": "R1"})
+    fake_strategy(monkeypatch, "c1", 0.91, {"route_class": "R1"})
     ctx = make_context("Please process the attached pasted text.")
     object.__setattr__(ctx.config.squilla_router, "context_window_tokens", 100_000)
     ctx.metadata["input_normalization"] = {
@@ -396,9 +396,9 @@ async def test_large_material_ratio_floors_low_router_tier_to_t3(
 
     routed = await apply_squilla_router(ctx)
 
-    assert routed.metadata["routed_tier"] == "t3"
+    assert routed.metadata["routed_tier"] == "c3"
     assert routed.metadata["routing_source"] == "large_context_floor"
-    assert routed.metadata["large_context_floor_from_tier"] == "t1"
+    assert routed.metadata["large_context_floor_from_tier"] == "c1"
     assert routed.metadata["large_context_material_tokens"] == 40_000
 
 
@@ -409,7 +409,7 @@ async def test_anti_downgrade_keeps_recent_higher_tier_despite_confidence_gate(
     ctx1 = make_context("Hard first turn.", session_key="test-confidence-history")
     fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.9,
         {
             "route_class": "R2",
@@ -418,11 +418,11 @@ async def test_anti_downgrade_keeps_recent_higher_tier_despite_confidence_gate(
         },
     )
     routed1 = await apply_squilla_router(ctx1)
-    assert routed1.metadata["routed_tier"] == "t2"
+    assert routed1.metadata["routed_tier"] == "c2"
 
     fake_strategy(
         monkeypatch,
-        "t0",
+        "c0",
         0.1,
         {
             "route_class": "R0",
@@ -435,17 +435,17 @@ async def test_anti_downgrade_keeps_recent_higher_tier_despite_confidence_gate(
     routed2 = await apply_squilla_router(ctx2)
     extra = routed2.metadata["routing_extra"]
 
-    assert routed2.metadata["routed_tier"] == "t2"
+    assert routed2.metadata["routed_tier"] == "c2"
     assert routed2.model == "z-ai/glm-5.1"
     assert extra["confidence_gate_applied"] is True
-    assert extra["pre_confidence_tier"] == "t0"
-    assert extra["final_tier"] == "t2"
+    assert extra["pre_confidence_tier"] == "c0"
+    assert extra["final_tier"] == "c2"
     assert extra["anti_downgrade_applied"] is True
-    assert extra["previous_tier"] == "t2"
+    assert extra["previous_tier"] == "c2"
 
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.9,
         {
             "route_class": "R1",
@@ -458,11 +458,11 @@ async def test_anti_downgrade_keeps_recent_higher_tier_despite_confidence_gate(
     routed3 = await apply_squilla_router(ctx3)
     extra3 = routed3.metadata["routing_extra"]
 
-    assert routed3.metadata["routed_tier"] == "t2"
+    assert routed3.metadata["routed_tier"] == "c2"
     assert routed3.model == "z-ai/glm-5.1"
     assert extra3["confidence_gate_applied"] is False
     assert extra3["anti_downgrade_applied"] is True
-    assert extra3["previous_tier"] == "t2"
+    assert extra3["previous_tier"] == "c2"
 
 
 @pytest.mark.asyncio
@@ -472,7 +472,7 @@ async def test_anti_downgrade_uses_previous_turn_not_window_highest(
     session_key = "test-previous-not-highest"
     fake_strategy(
         monkeypatch,
-        "t3",
+        "c3",
         0.9,
         {
             "route_class": "R3",
@@ -481,13 +481,13 @@ async def test_anti_downgrade_uses_previous_turn_not_window_highest(
         },
     )
     routed1 = await apply_squilla_router(make_context("Very hard turn.", session_key=session_key))
-    assert routed1.metadata["routed_tier"] == "t3"
+    assert routed1.metadata["routed_tier"] == "c3"
 
     ctx2 = make_context("Less hard turn.", session_key=session_key)
     ctx2.config.squilla_router.kv_cache_anti_downgrade_enabled = False
     fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.9,
         {
             "route_class": "R2",
@@ -496,12 +496,12 @@ async def test_anti_downgrade_uses_previous_turn_not_window_highest(
         },
     )
     routed2 = await apply_squilla_router(ctx2)
-    assert routed2.metadata["routed_tier"] == "t2"
+    assert routed2.metadata["routed_tier"] == "c2"
 
     ctx3 = make_context("Easy follow-up.", session_key=session_key)
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.9,
         {
             "route_class": "R1",
@@ -512,10 +512,10 @@ async def test_anti_downgrade_uses_previous_turn_not_window_highest(
     routed3 = await apply_squilla_router(ctx3)
     extra3 = routed3.metadata["routing_extra"]
 
-    assert routed3.metadata["routed_tier"] == "t2"
+    assert routed3.metadata["routed_tier"] == "c2"
     assert routed3.model == "z-ai/glm-5.1"
     assert extra3["anti_downgrade_applied"] is True
-    assert extra3["previous_tier"] == "t2"
+    assert extra3["previous_tier"] == "c2"
 
 
 @pytest.mark.asyncio
@@ -525,7 +525,7 @@ async def test_anti_downgrade_keeps_previous_high_tier_without_margin_gate(
     session_key = "test-anti-downgrade-ignore-margin"
     fake_strategy(
         monkeypatch,
-        "t3",
+        "c3",
         0.95,
         {
             "route_class": "R3",
@@ -537,11 +537,11 @@ async def test_anti_downgrade_keeps_previous_high_tier_without_margin_gate(
     routed1 = await apply_squilla_router(
         make_context("Architecture review.", session_key=session_key)
     )
-    assert routed1.metadata["routed_tier"] == "t3"
+    assert routed1.metadata["routed_tier"] == "c3"
 
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.99,
         {
             "route_class": "R1",
@@ -553,10 +553,10 @@ async def test_anti_downgrade_keeps_previous_high_tier_without_margin_gate(
     routed2 = await apply_squilla_router(make_context("Follow-up.", session_key=session_key))
     extra = routed2.metadata["routing_extra"]
 
-    assert routed2.metadata["routed_tier"] == "t3"
+    assert routed2.metadata["routed_tier"] == "c3"
     assert routed2.model == "anthropic/claude-opus-4.7"
     assert extra["anti_downgrade_applied"] is True
-    assert extra["previous_tier"] == "t3"
+    assert extra["previous_tier"] == "c3"
     assert extra["kv_cache_window_seconds"] == 600
 
 
@@ -566,7 +566,7 @@ async def test_complaint_upgrade_promotes_tier_thinking_and_blocks_compressed_pr
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.9,
         {
             "route_class": "R1",
@@ -579,7 +579,7 @@ async def test_complaint_upgrade_promotes_tier_thinking_and_blocks_compressed_pr
     routed = await apply_squilla_router(ctx)
     extra = routed.metadata["routing_extra"]
 
-    assert routed.metadata["routed_tier"] == "t2"
+    assert routed.metadata["routed_tier"] == "c2"
     assert routed.model == "z-ai/glm-5.1"
     assert extra["complaint_detected"] is True
     assert extra["complaint_upgrade_applied"] is True
@@ -596,7 +596,7 @@ async def test_complaint_upgrade_starts_from_previous_experienced_tier(
     session_key = "test-complaint-upgrade-previous-tier"
     fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.9,
         {
             "route_class": "R2",
@@ -607,11 +607,11 @@ async def test_complaint_upgrade_starts_from_previous_experienced_tier(
     routed1 = await apply_squilla_router(
         make_context("Analyze this tricky failure.", session_key=session_key)
     )
-    assert routed1.metadata["routed_tier"] == "t2"
+    assert routed1.metadata["routed_tier"] == "c2"
 
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.9,
         {
             "route_class": "R1",
@@ -622,9 +622,9 @@ async def test_complaint_upgrade_starts_from_previous_experienced_tier(
     routed2 = await apply_squilla_router(make_context("答非所问", session_key=session_key))
     extra = routed2.metadata["routing_extra"]
 
-    assert routed2.metadata["routed_tier"] == "t3"
+    assert routed2.metadata["routed_tier"] == "c3"
     assert routed2.model == "anthropic/claude-opus-4.7"
-    assert extra["previous_tier"] == "t2"
+    assert extra["previous_tier"] == "c2"
     assert extra["complaint_detected"] is True
     assert extra["complaint_upgrade_applied"] is True
     assert extra["anti_downgrade_applied"] is False
@@ -636,7 +636,7 @@ async def test_router_classifies_raw_semantic_input_but_injects_prompt_into_disp
 ) -> None:
     strategy = fake_strategy(
         monkeypatch,
-        "t0",
+        "c0",
         0.92,
         {
             "route_class": "R0",
@@ -652,7 +652,7 @@ async def test_router_classifies_raw_semantic_input_but_injects_prompt_into_disp
     routed = await apply_squilla_router(ctx)
 
     assert strategy.messages == ["Summarize the underlying user input."]
-    assert routed.metadata["routed_tier"] == "t0"
+    assert routed.metadata["routed_tier"] == "c0"
     assert routed.metadata["prompt_policy"] == "P0"
     assert routed.message.startswith("Displayed prompt wrapper")
     assert "Summarize the underlying user input." not in routed.message
@@ -665,7 +665,7 @@ async def test_router_passes_transcript_context_into_strategy(
 ) -> None:
     strategy = context_aware_fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.88,
         {
             "route_class": "R2",
@@ -694,7 +694,7 @@ async def test_router_passes_transcript_context_into_strategy(
 
     routed = await apply_squilla_router(ctx)
 
-    assert routed.metadata["routed_tier"] == "t2"
+    assert routed.metadata["routed_tier"] == "c2"
     assert strategy.messages == ["Continue from the previous answer."]
     assert strategy.contexts == [
         {
@@ -811,7 +811,7 @@ async def test_non_image_attachment_does_not_force_vision_route(
 ) -> None:
     strategy = fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.91,
         {
             "route_class": "R1",
@@ -828,7 +828,7 @@ async def test_non_image_attachment_does_not_force_vision_route(
 
     assert strategy.calls == 1
     assert routed.metadata["routing_source"] == "v4_phase3"
-    assert routed.metadata["routed_tier"] == "t1"
+    assert routed.metadata["routed_tier"] == "c1"
 
 
 @pytest.mark.asyncio
@@ -837,7 +837,7 @@ async def test_observe_rollout_records_decisions_without_applying_model_or_promp
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.93,
         {
             "route_class": "R2",
@@ -852,7 +852,7 @@ async def test_observe_rollout_records_decisions_without_applying_model_or_promp
     routed = await apply_squilla_router(ctx)
 
     assert routed.model == baseline_model
-    assert routed.metadata["routed_tier"] == "t2"
+    assert routed.metadata["routed_tier"] == "c2"
     assert routed.metadata["routed_model"] == "z-ai/glm-5.1"
     assert routed.metadata["routing_applied"] is False
     assert routed.metadata["thinking_mode"] == "T2"
@@ -866,7 +866,7 @@ async def test_repeated_message_across_sessions_is_classified_each_time(
 ) -> None:
     strategy = fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.91,
         {
             "route_class": "R1",
@@ -896,7 +896,7 @@ async def test_required_router_runtime_failure_falls_back_to_default_tier(
     routed = await apply_squilla_router(ctx)
 
     assert routed.metadata["routing_source"] == "v4_unavailable"
-    assert routed.metadata["routed_tier"] == "t1"
+    assert routed.metadata["routed_tier"] == "c1"
     assert routed.metadata["routing_confidence"] == 0.0
 
 
@@ -938,7 +938,7 @@ async def test_runtime_router_short_chinese_prompt_injects_localized_p0_hint() -
     routed = await apply_squilla_router(ctx)
 
     assert routed.metadata["routing_source"] == "v4_phase3"
-    assert routed.metadata["routed_tier"] == "t0"
+    assert routed.metadata["routed_tier"] == "c0"
     assert routed.model == "deepseek/deepseek-v4-flash"
     assert routed.metadata["thinking_mode"] == "T0"
     assert routed.metadata.get("thinking_requested") is None
@@ -954,7 +954,7 @@ async def test_runtime_router_complex_request_applies_deep_thinking_without_p2_p
     routed = await apply_squilla_router(ctx)
 
     assert routed.metadata["routing_source"] == "v4_phase3"
-    assert routed.metadata["routed_tier"] == "t3"
+    assert routed.metadata["routed_tier"] == "c3"
     assert routed.model == "anthropic/claude-opus-4.7"
     assert routed.metadata["thinking_mode"] == "T3"
     assert routed.metadata["thinking_requested"] is True

--- a/tests/test_model_router_defaults.py
+++ b/tests/test_model_router_defaults.py
@@ -35,7 +35,7 @@ def test_squilla_router_defaults_match_runtime_router_config() -> None:
     assert cfg.auto_thinking is True
     assert cfg.rollout_phase == "full"
     assert cfg.strategy == "v4_phase3"
-    assert cfg.default_tier == "t1"
+    assert cfg.default_tier == "c1"
     assert cfg.confidence_threshold == 0.5
     assert cfg.v4_use_aux_head is True
     assert cfg.kv_cache_anti_downgrade_enabled is True
@@ -45,14 +45,14 @@ def test_squilla_router_defaults_match_runtime_router_config() -> None:
     assert cfg.complaint_upgrade_max_chars == 160
     assert cfg.require_router_runtime is True
 
-    assert cfg.tiers["t0"]["model"] == "deepseek/deepseek-v4-flash"
-    assert cfg.tiers["t0"]["thinking_level"] == "high"
-    assert cfg.tiers["t1"]["model"] == "deepseek/deepseek-v4-pro"
-    assert cfg.tiers["t1"]["thinking_level"] == "high"
-    assert cfg.tiers["t2"]["model"] == "z-ai/glm-5.1"
-    assert cfg.tiers["t2"]["thinking_level"] == "high"
-    assert cfg.tiers["t3"]["model"] == "anthropic/claude-opus-4.7"
-    assert cfg.tiers["t3"]["thinking_level"] == "high"
+    assert cfg.tiers["c0"]["model"] == "deepseek/deepseek-v4-flash"
+    assert cfg.tiers["c0"]["thinking_level"] == "high"
+    assert cfg.tiers["c1"]["model"] == "deepseek/deepseek-v4-pro"
+    assert cfg.tiers["c1"]["thinking_level"] == "high"
+    assert cfg.tiers["c2"]["model"] == "z-ai/glm-5.1"
+    assert cfg.tiers["c2"]["thinking_level"] == "high"
+    assert cfg.tiers["c3"]["model"] == "anthropic/claude-opus-4.7"
+    assert cfg.tiers["c3"]["thinking_level"] == "high"
     assert cfg.tiers["image_model"]["model"] == "moonshotai/kimi-k2.6"
     assert cfg.tiers["image_model"]["supports_image"] is True
     assert cfg.tiers["image_model"]["image_only"] is True
@@ -66,6 +66,21 @@ def test_squilla_router_explicit_openrouter_profile_matches_default_tiers() -> N
 
     assert explicit_cfg.tiers == default_cfg.tiers
     assert explicit_cfg.tier_profile == "openrouter"
+
+
+def test_squilla_router_canonical_tier_wins_over_legacy_alias() -> None:
+    squilla_router_config_cls = _squilla_router_config_cls()
+
+    cfg = squilla_router_config_cls(
+        tiers={
+            "c1": {"provider": "openrouter", "model": "canonical-model"},
+            "t1": {"provider": "openrouter", "model": "legacy-model"},
+        },
+        default_tier="t1",
+    )
+
+    assert cfg.default_tier == "c1"
+    assert cfg.tiers["c1"]["model"] == "canonical-model"
 
 
 def test_provider_profile_requires_matching_llm_provider() -> None:
@@ -106,8 +121,8 @@ def test_provider_profile_accepts_matching_llm_provider() -> None:
 
     assert cfg.llm.provider == "dashscope"
     assert cfg.squilla_router.tier_profile == "dashscope"
-    assert cfg.squilla_router.tiers["t0"]["provider"] == "dashscope"
-    assert cfg.squilla_router.tiers["t0"]["model"] == "qwen3.6-flash"
+    assert cfg.squilla_router.tiers["c0"]["provider"] == "dashscope"
+    assert cfg.squilla_router.tiers["c0"]["model"] == "qwen3.6-flash"
 
 
 @pytest.mark.parametrize("provider_id", DIRECT_ROUTER_PROFILE_IDS)
@@ -120,7 +135,7 @@ def test_unset_tier_profile_uses_matching_direct_provider_profile(provider_id: s
 
     expected = _router_tier_profile_defaults(provider_id)
     assert cfg.squilla_router.tier_profile == provider_id
-    for tier in ("t0", "t1", "t2", "t3"):
+    for tier in ("c0", "c1", "c2", "c3"):
         assert cfg.squilla_router.tiers[tier]["provider"] == provider_id
         assert cfg.squilla_router.tiers[tier]["model"] == expected[tier]["model"]
 
@@ -138,7 +153,7 @@ def test_direct_legacy_openrouter_router_defaults_are_migrated(provider_id: str)
 
     expected = _router_tier_profile_defaults(provider_id)
     assert cfg.squilla_router.tier_profile == provider_id
-    for tier in ("t0", "t1", "t2", "t3"):
+    for tier in ("c0", "c1", "c2", "c3"):
         assert cfg.squilla_router.tiers[tier]["provider"] == provider_id
         assert cfg.squilla_router.tiers[tier]["model"] == expected[tier]["model"]
 
@@ -161,9 +176,9 @@ def test_each_provider_profile_has_four_text_tiers_without_default_image_model()
 
     for profile in ("dashscope", "deepseek", "gemini", "volcengine"):
         cfg = squilla_router_config_cls(tier_profile=profile)
-        assert {"t0", "t1", "t2", "t3"}.issubset(cfg.tiers)
+        assert {"c0", "c1", "c2", "c3"}.issubset(cfg.tiers)
         assert "image_model" not in cfg.tiers
-        assert {cfg.tiers[tier]["provider"] for tier in ("t0", "t1", "t2", "t3")} == {
+        assert {cfg.tiers[tier]["provider"] for tier in ("c0", "c1", "c2", "c3")} == {
             profile
         }
 
@@ -173,9 +188,9 @@ def test_direct_provider_profiles_have_four_text_tiers_without_default_image_mod
 
     for profile in ("openai", "zhipu", "moonshot"):
         cfg = squilla_router_config_cls(tier_profile=profile)
-        assert {"t0", "t1", "t2", "t3"}.issubset(cfg.tiers)
+        assert {"c0", "c1", "c2", "c3"}.issubset(cfg.tiers)
         assert "image_model" not in cfg.tiers
-        assert {cfg.tiers[tier]["provider"] for tier in ("t0", "t1", "t2", "t3")} == {
+        assert {cfg.tiers[tier]["provider"] for tier in ("c0", "c1", "c2", "c3")} == {
             profile
         }
 
@@ -185,13 +200,13 @@ def test_openai_profile_uses_streaming_compatible_models() -> None:
 
     cfg = squilla_router_config_cls(tier_profile="openai")
 
-    assert cfg.tiers["t0"]["model"] == "gpt-5.4-nano"
-    assert cfg.tiers["t1"]["model"] == "gpt-5.4-mini"
-    assert cfg.tiers["t2"]["model"] == "gpt-5.5"
-    assert cfg.tiers["t3"]["model"] == "gpt-5.5"
-    assert cfg.tiers["t3"]["thinking_level"] == "high"
+    assert cfg.tiers["c0"]["model"] == "gpt-5.4-nano"
+    assert cfg.tiers["c1"]["model"] == "gpt-5.4-mini"
+    assert cfg.tiers["c2"]["model"] == "gpt-5.5"
+    assert cfg.tiers["c3"]["model"] == "gpt-5.5"
+    assert cfg.tiers["c3"]["thinking_level"] == "high"
     assert all(
-        cfg.tiers[tier]["model"] != "gpt-5.5-pro" for tier in ("t0", "t1", "t2", "t3")
+        cfg.tiers[tier]["model"] != "gpt-5.5-pro" for tier in ("c0", "c1", "c2", "c3")
     )
 
 
@@ -200,11 +215,11 @@ def test_zhipu_profile_uses_glm_5_1_for_strong_tiers() -> None:
 
     cfg = squilla_router_config_cls(tier_profile="zhipu")
 
-    assert cfg.tiers["t0"]["model"] == "glm-4.7-flashx"
-    assert cfg.tiers["t1"]["model"] == "glm-5"
-    assert cfg.tiers["t2"]["model"] == "glm-5.1"
-    assert cfg.tiers["t3"]["model"] == "glm-5.1"
-    assert cfg.tiers["t3"]["thinking_level"] == "high"
+    assert cfg.tiers["c0"]["model"] == "glm-4.7-flashx"
+    assert cfg.tiers["c1"]["model"] == "glm-5"
+    assert cfg.tiers["c2"]["model"] == "glm-5.1"
+    assert cfg.tiers["c3"]["model"] == "glm-5.1"
+    assert cfg.tiers["c3"]["thinking_level"] == "high"
 
 
 def test_moonshot_profile_uses_kimi_for_strong_tiers() -> None:
@@ -212,12 +227,12 @@ def test_moonshot_profile_uses_kimi_for_strong_tiers() -> None:
 
     cfg = squilla_router_config_cls(tier_profile="moonshot")
 
-    assert cfg.tiers["t0"]["model"] == "kimi-k2.5"
-    assert cfg.tiers["t1"]["model"] == "kimi-k2.5"
-    assert cfg.tiers["t2"]["model"] == "kimi-k2.6"
-    assert cfg.tiers["t3"]["model"] == "kimi-k2.6"
+    assert cfg.tiers["c0"]["model"] == "kimi-k2.5"
+    assert cfg.tiers["c1"]["model"] == "kimi-k2.5"
+    assert cfg.tiers["c2"]["model"] == "kimi-k2.6"
+    assert cfg.tiers["c3"]["model"] == "kimi-k2.6"
     assert all(
-        cfg.tiers[tier]["supports_image"] is True for tier in ("t0", "t1", "t2", "t3")
+        cfg.tiers[tier]["supports_image"] is True for tier in ("c0", "c1", "c2", "c3")
     )
 
 
@@ -226,14 +241,14 @@ def test_volcengine_profile_uses_seed_2_capability_ladder() -> None:
 
     cfg = squilla_router_config_cls(tier_profile="volcengine")
 
-    assert cfg.tiers["t0"]["model"] == "doubao-seed-2-0-mini-260215"
-    assert cfg.tiers["t0"]["thinking_level"] == "off"
-    assert cfg.tiers["t1"]["model"] == "doubao-seed-2-0-lite-260215"
-    assert cfg.tiers["t1"]["thinking_level"] == "low"
-    assert cfg.tiers["t2"]["model"] == "doubao-seed-2-0-pro-260215"
-    assert cfg.tiers["t2"]["thinking_level"] == "medium"
-    assert cfg.tiers["t3"]["model"] == "doubao-seed-2-0-code-preview-260215"
-    assert cfg.tiers["t3"]["thinking_level"] == "high"
+    assert cfg.tiers["c0"]["model"] == "doubao-seed-2-0-mini-260215"
+    assert cfg.tiers["c0"]["thinking_level"] == "off"
+    assert cfg.tiers["c1"]["model"] == "doubao-seed-2-0-lite-260215"
+    assert cfg.tiers["c1"]["thinking_level"] == "low"
+    assert cfg.tiers["c2"]["model"] == "doubao-seed-2-0-pro-260215"
+    assert cfg.tiers["c2"]["thinking_level"] == "medium"
+    assert cfg.tiers["c3"]["model"] == "doubao-seed-2-0-code-preview-260215"
+    assert cfg.tiers["c3"]["thinking_level"] == "high"
 
 
 def test_profile_tier_override_merges_keys_inside_tier() -> None:
@@ -241,12 +256,12 @@ def test_profile_tier_override_merges_keys_inside_tier() -> None:
 
     cfg = squilla_router_config_cls(
         tier_profile="gemini",
-        tiers={"t2": {"thinking_level": "high"}},
+        tiers={"c2": {"thinking_level": "high"}},
     )
 
-    assert cfg.tiers["t2"]["provider"] == "gemini"
-    assert cfg.tiers["t2"]["model"] == "gemini-2.5-pro"
-    assert cfg.tiers["t2"]["thinking_level"] == "high"
+    assert cfg.tiers["c2"]["provider"] == "gemini"
+    assert cfg.tiers["c2"]["model"] == "gemini-2.5-pro"
+    assert cfg.tiers["c2"]["thinking_level"] == "high"
 
 
 def test_profile_rejects_non_dict_tier_override() -> None:
@@ -278,7 +293,7 @@ def test_profile_preserves_explicit_provider_compatible_image_model() -> None:
 
     assert cfg.tiers["image_model"]["provider"] == "gemini"
     assert cfg.tiers["image_model"]["supports_image"] is True
-    assert cfg.tiers["t0"]["provider"] == "gemini"
+    assert cfg.tiers["c0"]["provider"] == "gemini"
 
 
 def test_example_toml_enables_runtime_router_defaults() -> None:
@@ -294,7 +309,7 @@ def test_example_toml_enables_runtime_router_defaults() -> None:
     assert squilla_router["rollout_phase"] == "full"
     assert squilla_router["strategy"] == "v4_phase3"
     assert "cache_ttl_seconds" not in squilla_router
-    assert squilla_router["default_tier"] == "t1"
+    assert squilla_router["default_tier"] == "c1"
     assert squilla_router["confidence_threshold"] == 0.5
     assert squilla_router["v4_use_aux_head"] is True
     assert squilla_router["kv_cache_anti_downgrade_enabled"] is True
@@ -305,14 +320,14 @@ def test_example_toml_enables_runtime_router_defaults() -> None:
     assert squilla_router["require_router_runtime"] is True
 
     tiers = squilla_router["tiers"]
-    assert tiers["t0"]["model"] == "deepseek/deepseek-v4-flash"
-    assert tiers["t0"]["thinking_level"] == "high"
-    assert tiers["t1"]["model"] == "deepseek/deepseek-v4-pro"
-    assert tiers["t1"]["thinking_level"] == "high"
-    assert tiers["t2"]["model"] == "z-ai/glm-5.1"
-    assert tiers["t2"]["thinking_level"] == "high"
-    assert tiers["t3"]["model"] == "anthropic/claude-opus-4.7"
-    assert tiers["t3"]["thinking_level"] == "high"
+    assert tiers["c0"]["model"] == "deepseek/deepseek-v4-flash"
+    assert tiers["c0"]["thinking_level"] == "high"
+    assert tiers["c1"]["model"] == "deepseek/deepseek-v4-pro"
+    assert tiers["c1"]["thinking_level"] == "high"
+    assert tiers["c2"]["model"] == "z-ai/glm-5.1"
+    assert tiers["c2"]["thinking_level"] == "high"
+    assert tiers["c3"]["model"] == "anthropic/claude-opus-4.7"
+    assert tiers["c3"]["thinking_level"] == "high"
     assert tiers["image_model"]["model"] == "moonshotai/kimi-k2.6"
     assert tiers["image_model"]["supports_image"] is True
     assert tiers["image_model"]["image_only"] is True

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -320,13 +320,13 @@ def test_interactive_onboard_prompts_router_defaults_before_persist(tmp_path, mo
                 return _Answer("SquillaRouter")
             if message == "Default text model":
                 assert kwargs.get("choices") == [
-                    "Fast/simple (t0)",
-                    "Balanced default (t1)",
-                    "Stronger reasoning (t2)",
-                    "Max quality (t3)",
+                    "Route c0",
+                    "Route c1",
+                    "Route c2",
+                    "Route c3",
                 ]
-                assert kwargs.get("default") == "Balanced default (t1)"
-                return _Answer("Stronger reasoning (t2)")
+                assert kwargs.get("default") == "Route c1"
+                return _Answer("Route c2")
             raise AssertionError(f"unexpected select prompt: {message}")
 
         def text(self, message: str, **kwargs):
@@ -358,7 +358,7 @@ def test_interactive_onboard_prompts_router_defaults_before_persist(tmp_path, mo
     data = target.read_text()
     assert 'api_key = ""' in data
     assert 'api_key_env = "OPENROUTER_API_KEY"' in data
-    assert 'default_tier = "t2"' in data
+    assert 'default_tier = "c2"' in data
     assert 'model = "z-ai/glm-5.1"' in data
 
 
@@ -1352,7 +1352,7 @@ def test_router_tier_overrides_edit_only_selected_tiers():
     from opensquilla.onboarding.flow import _router_tier_overrides
 
     calls: list[str] = []
-    selections = iter(["Stronger reasoning (t2)", "Done"])
+    selections = iter(["Route c2", "Done"])
 
     class _Answer:
         def __init__(self, value):
@@ -1367,28 +1367,28 @@ def test_router_tier_overrides_edit_only_selected_tiers():
             assert message == "Tier to edit"
             assert kwargs.get("choices") == [
                 "Done",
-                "Fast/simple (t0)",
-                "Balanced default (t1)",
-                "Stronger reasoning (t2)",
-                "Max quality (t3)",
+                "Route c0",
+                "Route c1",
+                "Route c2",
+                "Route c3",
                 "Image model",
             ]
             return _Answer(next(selections))
 
         def text(self, message: str, **kwargs):
             calls.append(message)
-            if message == "t2 provider":
+            if message == "c2 provider":
                 assert kwargs.get("default") == "openrouter"
                 return _Answer("openrouter")
-            if message == "t2 model":
+            if message == "c2 model":
                 assert kwargs.get("default") == "z-ai/glm-5.1"
                 return _Answer("custom/reasoner")
             raise AssertionError(f"unexpected text prompt: {message}")
 
     overrides = _router_tier_overrides(_Questionary(), GatewayConfig())
 
-    assert calls == ["Tier to edit", "t2 provider", "t2 model", "Tier to edit"]
-    assert overrides == {"t2": {"provider": "openrouter", "model": "custom/reasoner"}}
+    assert calls == ["Tier to edit", "c2 provider", "c2 model", "Tier to edit"]
+    assert overrides == {"c2": {"provider": "openrouter", "model": "custom/reasoner"}}
 
 
 def test_interactive_feishu_websocket_prompts_only_core_fields(tmp_path, monkeypatch):

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -345,7 +345,7 @@ def test_upsert_llm_provider_recomputes_openrouter_mix_on_provider_switch():
     assert res.config.llm.provider == "deepseek"
     assert res.config.squilla_router.enabled is True
     assert res.config.squilla_router.tier_profile == "deepseek"
-    assert res.config.squilla_router.tiers["t0"]["provider"] == "deepseek"
+    assert res.config.squilla_router.tiers["c0"]["provider"] == "deepseek"
     assert "tiers" not in res.config.to_toml_dict()["squilla_router"]
 
 

--- a/tests/test_onboarding/test_next_steps.py
+++ b/tests/test_onboarding/test_next_steps.py
@@ -69,7 +69,7 @@ def test_onboarding_finish_output_uses_product_router_label():
 
     text = format_next_steps(GatewayConfig(), config_path="/tmp/opensquilla/custom.toml")
 
-    assert "  Router: SquillaRouter, default=t1" in text
+    assert "  Router: SquillaRouter, default=c1" in text
     assert "profile=openrouter-mix" not in text
 
 

--- a/tests/test_onboarding/test_router_specs.py
+++ b/tests/test_onboarding/test_router_specs.py
@@ -13,16 +13,16 @@ def test_router_catalog_exposes_supported_profiles_and_tiers():
     assert {"openrouter", "deepseek", "openai"} <= set(profiles)
     deepseek = profiles["deepseek"]
     assert deepseek["providerId"] == "deepseek"
-    assert set(deepseek["tiers"]) == {"t0", "t1", "t2", "t3"}
-    assert deepseek["tiers"]["t0"]["model"]
-    assert deepseek["tiers"]["t0"]["provider"] == "deepseek"
-    assert "description" in deepseek["tiers"]["t0"]
-    assert "thinkingLevel" in deepseek["tiers"]["t0"]
+    assert set(deepseek["tiers"]) == {"c0", "c1", "c2", "c3"}
+    assert deepseek["tiers"]["c0"]["model"]
+    assert deepseek["tiers"]["c0"]["provider"] == "deepseek"
+    assert "description" in deepseek["tiers"]["c0"]
+    assert "thinkingLevel" in deepseek["tiers"]["c0"]
     openrouter = profiles["openrouter"]
     assert "image_model" in openrouter["tiers"]
     assert openrouter["tiers"]["image_model"]["supportsImage"] is True
-    assert payload["defaultTier"] == "t1"
-    assert set(payload["textTiers"]) == {"t0", "t1", "t2", "t3"}
+    assert payload["defaultTier"] == "c1"
+    assert set(payload["textTiers"]) == {"c0", "c1", "c2", "c3"}
 
 
 def test_get_router_setup_profile_rejects_unknown_profile():

--- a/tests/test_onboarding/test_setup_engine.py
+++ b/tests/test_onboarding/test_setup_engine.py
@@ -47,7 +47,7 @@ def test_setup_engine_can_derive_provider_model_from_router_default_tier(tmp_pat
     assert data["llm"]["provider"] == "deepseek"
     assert data["llm"]["model"] == "deepseek-v4-flash"
     assert data["squilla_router"]["tier_profile"] == "deepseek"
-    assert data["squilla_router"]["default_tier"] == "t1"
+    assert data["squilla_router"]["default_tier"] == "c1"
 
 
 def test_setup_engine_router_tier_override_updates_direct_fallback_model(tmp_path):
@@ -65,9 +65,9 @@ def test_setup_engine_router_tier_override_updates_direct_fallback_model(tmp_pat
         "router",
         {
             "mode": "recommended",
-            "defaultTier": "t2",
+            "defaultTier": "c2",
             "tiers": {
-                "t2": {
+                "c2": {
                     "provider": "openai",
                     "model": "gpt-5.5-custom",
                     "thinkingLevel": "high",
@@ -80,9 +80,9 @@ def test_setup_engine_router_tier_override_updates_direct_fallback_model(tmp_pat
     data = tomllib.loads(target.read_text())
     assert data["llm"]["model"] == "gpt-5.5-custom"
     assert data["squilla_router"]["tier_profile"] == "openai"
-    assert data["squilla_router"]["default_tier"] == "t2"
-    assert data["squilla_router"]["tiers"]["t2"]["model"] == "gpt-5.5-custom"
-    assert data["squilla_router"]["tiers"]["t2"]["thinking_level"] == "high"
+    assert data["squilla_router"]["default_tier"] == "c2"
+    assert data["squilla_router"]["tiers"]["c2"]["model"] == "gpt-5.5-custom"
+    assert data["squilla_router"]["tiers"]["c2"]["thinking_level"] == "high"
 
 
 def test_setup_engine_next_steps_do_not_include_secret(tmp_path):

--- a/tests/test_scripts/test_router_live_script_defaults.py
+++ b/tests/test_scripts/test_router_live_script_defaults.py
@@ -9,10 +9,10 @@ from pathlib import Path
 from opensquilla.tools.registry import ToolProfile
 
 EXPECTED_ROUTER_MODELS = {
-    "t0": "deepseek/deepseek-v4-flash",
-    "t1": "deepseek/deepseek-v4-pro",
-    "t2": "z-ai/glm-5.1",
-    "t3": "anthropic/claude-opus-4.7",
+    "c0": "deepseek/deepseek-v4-flash",
+    "c1": "deepseek/deepseek-v4-pro",
+    "c2": "z-ai/glm-5.1",
+    "c3": "anthropic/claude-opus-4.7",
 }
 
 
@@ -35,7 +35,7 @@ def test_smoke_script_tier_defaults_match_router_defaults(tmp_path: Path) -> Non
     smoke._write_live_gateway_config(config_path, "")
 
     data = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    assert data["llm"]["model"] == EXPECTED_ROUTER_MODELS["t1"]
+    assert data["llm"]["model"] == EXPECTED_ROUTER_MODELS["c1"]
     assert {
         tier: cfg["model"]
         for tier, cfg in data["squilla_router"]["tiers"].items()

--- a/tests/test_skills/test_meta_mvp.py
+++ b/tests/test_skills/test_meta_mvp.py
@@ -560,10 +560,10 @@ async def test_meta_resolution_promotes_meta_skill_creator_to_highest_text_tier(
         config=SimpleNamespace(
             squilla_router=SimpleNamespace(
                 tiers={
-                    "t0": {"model": "cheap-model"},
-                    "t1": {"model": "balanced-model"},
-                    "t2": {"model": "strong-model"},
-                    "t3": {"model": "frontier-model"},
+                    "c0": {"model": "cheap-model"},
+                    "c1": {"model": "balanced-model"},
+                    "c2": {"model": "strong-model"},
+                    "c3": {"model": "frontier-model"},
                     "image": {"model": "vision-model", "image_only": True},
                 },
             ),
@@ -578,10 +578,10 @@ async def test_meta_resolution_promotes_meta_skill_creator_to_highest_text_tier(
         "dynamic system prompt"
     )
     assert out.model == "frontier-model"
-    assert out.metadata["meta_required_tier"] == "t3"
+    assert out.metadata["meta_required_tier"] == "c3"
     assert out.metadata["meta_required_model"] == "frontier-model"
     assert out.metadata["meta_required_source"] == "meta-skill-creator"
-    assert out.metadata["routed_tier"] == "t3"
+    assert out.metadata["routed_tier"] == "c3"
     assert out.metadata["routed_model"] == "frontier-model"
     assert out.metadata["routing_source"] == "meta_skill_required_tier"
     assert out.metadata["routing_confidence"] == 1.0
@@ -605,8 +605,8 @@ async def test_meta_resolution_does_not_promote_non_creator_meta_to_highest_text
         config=SimpleNamespace(
             squilla_router=SimpleNamespace(
                 tiers={
-                    "t1": {"model": "cheap-model"},
-                    "t3": {"model": "frontier-model"},
+                    "c1": {"model": "cheap-model"},
+                    "c3": {"model": "frontier-model"},
                     "vision": {"model": "vision-model", "image_only": True},
                 },
             ),

--- a/tests/test_tools/test_router_control_tool.py
+++ b/tests/test_tools/test_router_control_tool.py
@@ -40,8 +40,8 @@ async def test_router_control_set_hold_writes_store_and_requests_replay() -> Non
             tool_name="router_control",
             arguments={
                 "action": "set_hold",
-                "target_id": "tier:t3",
-                "evidence": "use t3",
+                "target_id": "tier:c3",
+                "evidence": "use c3",
             },
         )
     )
@@ -50,12 +50,12 @@ async def test_router_control_set_hold_writes_store_and_requests_replay() -> Non
     assert result.is_error is False
     assert result.terminates_turn is True
     assert payload["accepted"] is True
-    assert payload["target_tier"] == "t3"
+    assert payload["target_tier"] == "c3"
     assert payload["target_model"] == "anthropic/claude-opus-4.7"
     assert payload["replay_required"] is True
     hold = ctx.router_control_hold_store.get_valid(ctx.session_key or "")
     assert hold is not None
-    assert hold.tier == "t3"
+    assert hold.tier == "c3"
 
 
 @pytest.mark.asyncio
@@ -91,8 +91,9 @@ def test_router_control_tool_schema_includes_dynamic_target_enum() -> None:
     target_schema = router_tool.input_schema.properties["target_id"]
 
     assert "enum" in target_schema
-    assert "tier:t3" in target_schema["enum"]
-    assert "model:anthropic/claude-opus-4.7" in target_schema["enum"]
+    assert "tier:c3" in target_schema["enum"]
+    assert "tier:t3" not in target_schema["enum"]
+    assert "model:anthropic/claude-opus-4.7" not in target_schema["enum"]
 
 
 @pytest.mark.asyncio
@@ -101,9 +102,9 @@ async def test_router_control_clear_hold_replays_when_hold_already_selected_turn
     target = next(
         target
         for target in ctx.router_control_hold_store.build_targets(ctx.router_control_config)
-        if target.target_id == "tier:t3"
+        if target.target_id == "tier:c3"
     )
-    ctx.router_control_hold_store.set_hold(ctx.session_key or "", target, evidence="use t3")
+    ctx.router_control_hold_store.set_hold(ctx.session_key or "", target, evidence="use c3")
     handler = build_tool_handler(get_default_registry(), ctx)
 
     result = await handler(


### PR DESCRIPTION
## Summary
- Rename canonical text router tiers from t0-t3 to c0-c3 across config, routing runtime, onboarding, WebUI, scripts, and tests
- Keep legacy t0-t3 accepted at input boundaries while emitting canonical c0-c3 values
- Remove S/M/L/XL tier wording and keep Router Control prompt/schema limited to canonical route targets

## Verification
- uv run ruff check changed Python files
- uv run mypy src/opensquilla --show-error-codes
- uv run pytest router/control/onboarding/gateway/WebUI focused suite: 746 passed, 13 skipped
- uv build --wheel

## Notes
- Full `uv run ruff check src tests ...` currently also reports E501 in `tests/test_gateway/test_chat_view_static.py`, which is unchanged from origin/dev in this branch.