### PR TITLE
Preserve chat scroll during replay-gap recovery

### DIFF
--- a/src/opensquilla/gateway/static/js/views/chat.js
+++ b/src/opensquilla/gateway/static/js/views/chat.js
@@ -2775,8 +2775,16 @@ const ChatView = (() => {
         if (typeof res.current_stream_seq === 'number') {
           _setSessionStreamSeq(subscribeKey, res.current_stream_seq);
         }
-        UI.toast('Session stream gap detected; reloading transcript.', 'warn', 5000);
-        _loadHistory();
+        const replayGapReason = res.replay_gap_reason || res.replayGapReason || '';
+        if (_replayGapShouldWarn(replayGapReason)) {
+          UI.toast('Missed live stream events; transcript refreshed.', 'warn', 5000);
+        } else {
+          _chatDiag('session.subscribe.replay_gap.history_refresh', {
+            reason: replayGapReason,
+            currentStreamSeq: res.current_stream_seq,
+          });
+        }
+        _loadHistory(_historyRefreshScrollOptions());
       } else if (
         res
         && typeof res.current_stream_seq === 'number'
@@ -5053,7 +5061,7 @@ const ChatView = (() => {
         _hideThinkingIndicator();
         _subscribeSession();
         _loadCurrentSessionUsage();
-        _loadHistory();
+        _loadHistory(_historyRefreshScrollOptions());
       }
       if (state === 'disconnected' && _isStreaming) {
         _clearStreamIdleTimer();
@@ -5172,11 +5180,27 @@ const ChatView = (() => {
 
   /* ── Chat History ───────────────────────────────────────────────────── */
 
+  function _historyRefreshScrollOptions() {
+    if (!_thread || !_historyHasRendered) return {};
+    const gap = _thread.scrollHeight - _thread.scrollTop - _thread.clientHeight;
+    if (gap < 60) return {};
+    return {
+      preserveScroll: true,
+      previousScrollHeight: _thread.scrollHeight,
+      previousScrollTop: _thread.scrollTop,
+    };
+  }
+
+  function _replayGapShouldWarn(reason) {
+    const value = String(reason || '').toLowerCase();
+    return !['stream_buffer_empty', 'stream_buffer_reset', 'cursor_ahead_of_stream'].includes(value);
+  }
+
   function _scheduleHistorySync() {
     if (_historySyncTimer) clearTimeout(_historySyncTimer);
     _historySyncTimer = setTimeout(() => {
       _historySyncTimer = null;
-      _loadHistory();
+      _loadHistory(_historyRefreshScrollOptions());
     }, 50);
   }
 
@@ -5307,7 +5331,7 @@ const ChatView = (() => {
     _thread.insertBefore(row, _thread.firstChild || null);
   }
 
-  async function _loadHistory() {
+  async function _loadHistory(opts = {}) {
     if (!_sessionKey || !_thread) return;
     const requestSessionKey = _sessionKey;
     const requestSeq = ++_historyRequestSeq;
@@ -5346,7 +5370,7 @@ const ChatView = (() => {
         historyScope: _historyScope,
       });
       _historyHydrating = false;
-      _renderHistoryMessages(messages);
+      _renderHistoryMessages(messages, opts);
     } catch (err) {
       if (requestSessionKey === _sessionKey && requestSeq === _historyRequestSeq) {
         _historyHydrating = false;

--- a/tests/functional/test_webui_browser_chat_e2e.py
+++ b/tests/functional/test_webui_browser_chat_e2e.py
@@ -379,6 +379,209 @@ def test_chat_view_loads_and_reaches_gateway_http_status_in_real_browser(tmp_pat
     }
 
 
+def test_replay_gap_history_refresh_preserves_scroll_in_real_browser(tmp_path: Path) -> None:
+    if os.environ.get("OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E") != "1":
+        pytest.skip("set OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E=1 to run chat browser e2e")
+
+    port = _free_port()
+    server_script = tmp_path / "webui_gap_scroll_server.py"
+    browser_script = tmp_path / "webui_gap_scroll_browser.js"
+    server_script.write_text(
+        textwrap.dedent(
+            f"""
+            import uvicorn
+
+            from opensquilla.gateway.app import create_gateway_app
+            from opensquilla.gateway.config import AuthConfig, GatewayConfig
+
+            config = GatewayConfig(
+                host="127.0.0.1",
+                port={port},
+                auth=AuthConfig(mode="none"),
+            )
+            app = create_gateway_app(config)
+
+            if __name__ == "__main__":
+                uvicorn.run(app, host="127.0.0.1", port={port}, log_level="warning")
+            """
+        ),
+        encoding="utf-8",
+    )
+    browser_script.write_text(
+        textwrap.dedent(
+            r"""
+            const { chromium } = require("playwright");
+
+            (async () => {
+              const browser = await chromium.launch({ headless: true });
+              const page = await browser.newPage({ viewport: { width: 1365, height: 768 } });
+              const errors = [];
+              page.on("pageerror", err => errors.push(String(err)));
+              page.on("console", msg => {
+                if (msg.type() === "error") errors.push(msg.text());
+              });
+
+              await page.goto(process.env.TARGET_URL, {
+                waitUntil: "domcontentloaded",
+                timeout: 30000,
+              });
+              await page.waitForFunction(
+                () =>
+                  typeof App !== "undefined" &&
+                  App.getRpc &&
+                  App.getRpc()?.state === "connected",
+                { timeout: 15000 }
+              );
+
+              await page.evaluate(() => {
+                const rpc = App.getRpc();
+                const originalCall = rpc.call.bind(rpc);
+                const messages = [];
+                for (let i = 1; i <= 70; i += 1) {
+                  messages.push({
+                    role: i % 2 ? "user" : "assistant",
+                    text: `${i % 2 ? "User" : "Assistant"} history row ${String(i).padStart(2, "0")} `.repeat(8),
+                    timestamp: `2026-06-03T00:${String(i % 60).padStart(2, "0")}:00.000Z`,
+                    message_id: `gap-probe-${i}`,
+                  });
+                }
+                window.__gapProbe = { subscribeCount: 0, historyCount: 0, gapInjected: false };
+                rpc.call = async (method, params) => {
+                  if (method === "chat.history") {
+                    window.__gapProbe.historyCount += 1;
+                    return {
+                      messages,
+                      has_more: false,
+                      history_scope: "complete",
+                      oldest_cursor: null,
+                      newest_cursor: null,
+                      compaction_summaries: [],
+                    };
+                  }
+                  if (method === "sessions.messages.subscribe") {
+                    window.__gapProbe.subscribeCount += 1;
+                    if (window.__gapProbe.subscribeCount <= 1) {
+                      return {
+                        subscribed: true,
+                        key: params && params.key,
+                        current_stream_seq: 12,
+                        replay_complete: true,
+                        replayed_count: 0,
+                        run_status: "idle",
+                      };
+                    }
+                    window.__gapProbe.gapInjected = true;
+                    return {
+                      subscribed: true,
+                      key: params && params.key,
+                      current_stream_seq: 18,
+                      replay_complete: false,
+                      replay_gap_reason: "stream_buffer_empty",
+                      replayed_count: 0,
+                      run_status: "idle",
+                    };
+                  }
+                  return originalCall(method, params);
+                };
+              });
+
+              await page.evaluate(() =>
+                Router.navigate("/chat?session=" + encodeURIComponent("agent:main:webchat:gap-playwright-regression"))
+              );
+              await page.waitForSelector("#chat-thread .msg", { timeout: 15000 });
+              await page.waitForFunction(
+                () => document.querySelectorAll("#chat-thread .msg").length >= 60,
+                { timeout: 15000 }
+              );
+
+              const before = await page.evaluate(() => {
+                const thread = document.querySelector("#chat-thread");
+                thread.scrollTop = 120;
+                return {
+                  scrollTop: thread.scrollTop,
+                  scrollHeight: thread.scrollHeight,
+                  clientHeight: thread.clientHeight,
+                  bottomDistance: thread.scrollHeight - thread.clientHeight - thread.scrollTop,
+                  messageCount: document.querySelectorAll("#chat-thread .msg").length,
+                };
+              });
+
+              await page.evaluate(() => {
+                const handlers = App.getRpc()._listeners.get("_state");
+                if (handlers) handlers.forEach(h => h("connected"));
+              });
+              await page.waitForFunction(
+                () => window.__gapProbe && window.__gapProbe.gapInjected === true,
+                { timeout: 15000 }
+              );
+              await page.waitForFunction(
+                () => window.__gapProbe && window.__gapProbe.historyCount >= 3,
+                { timeout: 15000 }
+              );
+
+              const after = await page.evaluate(() => {
+                const thread = document.querySelector("#chat-thread");
+                return {
+                  scrollTop: thread.scrollTop,
+                  scrollHeight: thread.scrollHeight,
+                  clientHeight: thread.clientHeight,
+                  bottomDistance: thread.scrollHeight - thread.clientHeight - thread.scrollTop,
+                  messageCount: document.querySelectorAll("#chat-thread .msg").length,
+                  toasts: Array.from(document.querySelectorAll(".toast")).map(el => el.textContent.trim()),
+                  probe: window.__gapProbe,
+                };
+              });
+
+              await browser.close();
+              console.log(JSON.stringify({ before, after, errors }));
+            })().catch(err => {
+              console.error(err && err.stack ? err.stack : String(err));
+              process.exit(1);
+            });
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["OPENSQUILLA_STATE_DIR"] = str(tmp_path / "state")
+    env["OPENSQUILLA_LOG_DIR"] = str(tmp_path / "logs")
+    server = subprocess.Popen(
+        [sys.executable, str(server_script)],
+        cwd=Path.cwd(),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    try:
+        _wait_for_health(port, server)
+        _install_playwright(tmp_path)
+        result = subprocess.run(
+            [_node(), str(browser_script)],
+            cwd=tmp_path,
+            env=dict(env, TARGET_URL=f"http://127.0.0.1:{port}/control/overview"),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+        assert result.returncode == 0, result.stderr or result.stdout
+        payload = json.loads(result.stdout.strip().splitlines()[-1])
+    finally:
+        _stop_process(server)
+
+    assert payload["errors"] == [], payload["errors"]
+    assert payload["before"]["messageCount"] >= 60
+    assert payload["after"]["messageCount"] == payload["before"]["messageCount"]
+    assert payload["after"]["probe"]["gapInjected"] is True
+    assert payload["after"]["bottomDistance"] > 1000, payload
+    assert payload["after"]["scrollTop"] <= payload["before"]["scrollTop"] + 80, payload
+    assert "Session stream gap detected; reloading transcript." not in payload["after"]["toasts"]
+
+
 def test_chat_topbar_one_row_layout_in_real_browser(tmp_path: Path) -> None:
     if os.environ.get("OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E") != "1":
         pytest.skip("set OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E=1 to run chat browser e2e")

--- a/tests/functional/test_webui_browser_chat_e2e.py
+++ b/tests/functional/test_webui_browser_chat_e2e.py
@@ -438,9 +438,10 @@ def test_replay_gap_history_refresh_preserves_scroll_in_real_browser(tmp_path: P
                 const originalCall = rpc.call.bind(rpc);
                 const messages = [];
                 for (let i = 1; i <= 70; i += 1) {
+                  const label = i % 2 ? "User" : "Assistant";
                   messages.push({
                     role: i % 2 ? "user" : "assistant",
-                    text: `${i % 2 ? "User" : "Assistant"} history row ${String(i).padStart(2, "0")} `.repeat(8),
+                    text: `${label} history row ${String(i).padStart(2, "0")} `.repeat(8),
                     timestamp: `2026-06-03T00:${String(i % 60).padStart(2, "0")}:00.000Z`,
                     message_id: `gap-probe-${i}`,
                   });
@@ -486,7 +487,10 @@ def test_replay_gap_history_refresh_preserves_scroll_in_real_browser(tmp_path: P
               });
 
               await page.evaluate(() =>
-                Router.navigate("/chat?session=" + encodeURIComponent("agent:main:webchat:gap-playwright-regression"))
+                Router.navigate(
+                  "/chat?session=" +
+                    encodeURIComponent("agent:main:webchat:gap-playwright-regression")
+                )
               );
               await page.waitForSelector("#chat-thread .msg", { timeout: 15000 });
               await page.waitForFunction(
@@ -527,7 +531,9 @@ def test_replay_gap_history_refresh_preserves_scroll_in_real_browser(tmp_path: P
                   clientHeight: thread.clientHeight,
                   bottomDistance: thread.scrollHeight - thread.clientHeight - thread.scrollTop,
                   messageCount: document.querySelectorAll("#chat-thread .msg").length,
-                  toasts: Array.from(document.querySelectorAll(".toast")).map(el => el.textContent.trim()),
+                  toasts: Array.from(document.querySelectorAll(".toast")).map(el =>
+                    el.textContent.trim()
+                  ),
                   probe: window.__gapProbe,
                 };
               });

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -395,7 +395,10 @@ def test_chat_streaming_active_mark_reveals_after_visible_bubble_delay() -> None
     reveal_start = source.index("function _maybeRevealStreamActiveMark()")
     reveal_end = source.index("  function _scheduleStreamActiveMarkReveal", reveal_start)
     reveal_body = source[reveal_start:reveal_end]
-    assert "_streamActiveMarkVisibleStartedAt ? Date.now() - _streamActiveMarkVisibleStartedAt : 0" in reveal_body
+    assert (
+        "_streamActiveMarkVisibleStartedAt ? Date.now() - _streamActiveMarkVisibleStartedAt : 0"
+        in reveal_body
+    )
 
     end_stream_start = source.index("function _endStreaming(opts)")
     end_stream_end = source.index("  function _hasViewLocalStreamState", end_stream_start)
@@ -1976,11 +1979,17 @@ def test_router_fx_single_visual_candidate_renders_nothing_live_or_history() -> 
     schedule_start = source.index("function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts) {")
     schedule_end = source.index("  // Render the routing visualisation", schedule_start)
     schedule_body = source[schedule_start:schedule_end]
-    assert "if (_routerFxConfigTiers !== null && !_routerFxHasMultipleCandidates(requestKind, null)) {" in schedule_body
+    assert (
+        "if (_routerFxConfigTiers !== null && !_routerFxHasMultipleCandidates(requestKind, null)) {"
+        in schedule_body
+    )
     assert "_chatDiag('router_scan.schedule.skip.single_candidate'" in schedule_body
 
     pending_start = source.index("async function _finishPendingRouterFxScan() {")
-    pending_end = source.index("function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts) {", pending_start)
+    pending_end = source.index(
+        "function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts) {",
+        pending_start,
+    )
     pending_body = source[pending_start:pending_end]
     assert pending_body.index("await _routerFxAwaitConfig();") < pending_body.index(
         "_routerFxBeginScan(pending.anchorDiv, pending.seedKey"

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -928,7 +928,8 @@ def test_chat_subscribe_uses_stream_replay_cursor() -> None:
     assert "params.since_stream_seq = _lastStreamSeq;" not in source
     assert "if (_lastStreamSeq > 0) params.since_stream_seq = _lastStreamSeq;" not in body
     assert "function _acceptStreamSeq(payload)" in source
-    assert "Session stream gap detected; reloading transcript." in source
+    assert "function _replayGapShouldWarn(reason)" in source
+    assert "Session stream gap detected; reloading transcript." not in body
 
 
 def test_chat_stream_handlers_drop_replayed_duplicate_frames() -> None:
@@ -1001,9 +1002,31 @@ def test_chat_resets_replay_cursor_after_stream_gap() -> None:
 
     assert "if (res && res.replay_complete === false)" in body
     assert "_setSessionStreamSeq(subscribeKey, res.current_stream_seq);" in body
+    assert "const replayGapReason = res.replay_gap_reason || res.replayGapReason || '';" in body
+    assert "if (_replayGapShouldWarn(replayGapReason))" in body
+    assert "_loadHistory(_historyRefreshScrollOptions());" in body
     assert body.index("_setSessionStreamSeq(subscribeKey, res.current_stream_seq);") < body.index(
-        "_loadHistory();"
+        "_loadHistory(_historyRefreshScrollOptions());"
     )
+    assert body.index("if (_replayGapShouldWarn(replayGapReason))") < body.index(
+        "_loadHistory(_historyRefreshScrollOptions());"
+    )
+
+
+def test_chat_replay_gap_history_refresh_preserves_reader_scroll() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+
+    assert "function _historyRefreshScrollOptions()" in source
+    start = source.index("function _historyRefreshScrollOptions()")
+    end = source.index("function _scheduleHistorySync", start)
+    body = source[start:end]
+
+    assert "!_thread || !_historyHasRendered" in body
+    assert "_thread.scrollHeight - _thread.scrollTop - _thread.clientHeight" in body
+    assert "if (gap < 60) return {};" in body
+    assert "preserveScroll: true" in body
+    assert "previousScrollHeight: _thread.scrollHeight" in body
+    assert "previousScrollTop: _thread.scrollTop" in body
 
 
 def test_chat_empty_history_preserves_live_stream_bubble() -> None:
@@ -1314,7 +1337,7 @@ def test_chat_compaction_summary_separator_anchors_to_transcript_ids() -> None:
     )
     sync_end = source.index("function _compactFailureBlocksPending", sync_start)
     sync_body = source[sync_start:sync_end]
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("_chatDiag('history.done'", history_start)
     history_body = source[history_start:history_end]
 
@@ -1715,7 +1738,7 @@ def test_chat_diag_is_opt_in_by_default() -> None:
 
 def test_chat_history_requests_active_paginated_metadata() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("async function _loadEarlierHistory()", history_start)
     history_body = source[history_start:history_end]
     earlier_start = source.index("async function _loadEarlierHistory() {")
@@ -1755,7 +1778,7 @@ def test_chat_history_scope_row_surfaces_partial_compacted_and_error_states() ->
     source = CHAT_JS.read_text(encoding="utf-8")
     css = CHAT_CSS.read_text(encoding="utf-8")
     start = source.index("function _renderHistoryScopeRow() {")
-    end = source.index("async function _loadHistory()", start)
+    end = source.index("async function _loadHistory(opts = {})", start)
     body = source[start:end]
 
     assert "chat-history-scope" in body
@@ -1773,7 +1796,7 @@ def test_chat_history_scope_row_surfaces_partial_compacted_and_error_states() ->
 
 def test_chat_history_render_preserves_visible_messages_on_errors() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    initial_start = source.index("async function _loadHistory() {")
+    initial_start = source.index("async function _loadHistory(opts = {}) {")
     initial_end = source.index("async function _loadEarlierHistory()", initial_start)
     initial_body = source[initial_start:initial_end]
     earlier_start = source.index("async function _loadEarlierHistory() {")
@@ -1791,7 +1814,7 @@ def test_chat_history_render_preserves_visible_messages_on_errors() -> None:
 def test_chat_history_scope_row_is_not_a_message_node() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
     start = source.index("function _renderHistoryScopeRow() {")
-    end = source.index("async function _loadHistory()", start)
+    end = source.index("async function _loadHistory(opts = {})", start)
     body = source[start:end]
 
     assert "row.className = `chat-history-scope chat-history-scope--${tone}`;" in body
@@ -1801,7 +1824,7 @@ def test_chat_history_scope_row_is_not_a_message_node() -> None:
 
 def test_router_fx_history_reuses_settled_strip_for_same_turn_identity() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("  /* ── Send Message", history_start)
     history_body = source[history_start:history_end]
 
@@ -1823,7 +1846,7 @@ def test_router_fx_history_reanchors_stranded_strip() -> None:
     # flag — keep the one whose identity matches, drop extras, and re-anchor the
     # survivor beneath its user message, so the first chat never shows two grids.
     source = CHAT_JS.read_text(encoding="utf-8")
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("  /* ── Send Message", history_start)
     history_body = source[history_start:history_end]
 
@@ -2166,7 +2189,7 @@ def test_router_fx_strip_survives_multistep_turn() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
     assert "delete settledStrip.dataset.live;" not in source
     assert "_routerFxFindAttachedStrip" not in source
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("  /* ── Send Message", history_start)
     history_body = source[history_start:history_end]
     assert "ownStrips.find((el) => el.dataset.live === 'true')" not in history_body
@@ -2204,7 +2227,7 @@ def test_router_decision_without_anchor_is_cached_for_history_replay() -> None:
     assert "_chatDiag('router_decision.cached_pending_anchor'" in source
     assert "_chatDiag('router_decision.skip.no_anchor_user'" not in handler_body
 
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("function _appendHistoryDaySeparator", history_start)
     history_body = source[history_start:history_end]
     assert "_historyHydrating = true;" in history_body
@@ -2289,7 +2312,7 @@ def test_done_stream_bubble_survives_until_history_persists_assistant() -> None:
     mark_marker = "_markPendingFinalizedAssistantBubble(_streamBubble, cleanedText);"
     assert end_body.index(stamp_marker) < end_body.index(mark_marker)
 
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("function _appendHistoryDaySeparator", history_start)
     history_body = source[history_start:history_end]
     assert "_chatDiag('history.empty.keep_pending_finalized_assistant'" in history_body
@@ -2562,7 +2585,7 @@ def test_router_fx_disable_removes_all_strips_without_live_spare_path() -> None:
         in source
     )
     assert ".router-fx:not([data-live=\"true\"])" not in source
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("  /* ── Send Message", history_start)
     history_body = source[history_start:history_end]
     assert "if (!_routerFx.enabled) {" in history_body
@@ -2613,7 +2636,7 @@ def test_router_fx_visualisation_toggle_markup_reuses_switch() -> None:
 
 def test_chat_history_replays_turn_meta_to_restore_combo_streak() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    start = source.index("async function _loadHistory() {")
+    start = source.index("async function _loadHistory(opts = {}) {")
     end = source.index("  /* ── Send Message", start)
     body = source[start:end]
 
@@ -2780,7 +2803,7 @@ def test_rpc_client_passes_event_meta_without_polluting_payload() -> None:
 
 def test_chat_history_reconciles_by_message_identity_without_clear_replace() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    start = source.index("async function _loadHistory() {")
+    start = source.index("async function _loadHistory(opts = {}) {")
     end = source.index("  /* ── Send Message", start)
     body = source[start:end]
 
@@ -2808,7 +2831,7 @@ def test_chat_history_reconciles_by_message_identity_without_clear_replace() -> 
 
 def test_chat_history_reorders_reused_nodes_to_match_transcript_order() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    start = source.index("async function _loadHistory() {")
+    start = source.index("async function _loadHistory(opts = {}) {")
     end = source.index("  /* ── Send Message", start)
     body = source[start:end]
 


### PR DESCRIPTION
## Summary
- Preserve the chat reader's scroll position when replay-gap recovery or reconnect refreshes history.
- Suppress the old severe replay-gap toast for recoverable buffer states and keep warnings for missed/unknown live-event gaps.
- Add a real-browser Playwright regression plus static contracts for the replay-gap recovery path.

## Root Cause
`replay_complete=false` was always treated as a severe stream gap. The frontend then called `_loadHistory()` without scroll options, so `_renderHistoryMessages()` defaulted to `_scrollToBottom()`. Historical messages were still present, but users reading above the bottom were moved to the end of the transcript, which made older history appear missing.

## Validation
- `TMPDIR=/dev/shm PYTHONPATH=src /home/weihe/work/code/rhythm/opensquilla/.venv/bin/python -m pytest tests/test_gateway/test_chat_view_static.py -q` → `168 passed`
- `OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E=1 TMPDIR=/dev/shm PYTHONPATH=src /home/weihe/work/code/rhythm/opensquilla/.venv/bin/python -m pytest tests/functional/test_webui_browser_chat_e2e.py::test_replay_gap_history_refresh_preserves_scroll_in_real_browser -q` → `1 passed`
- `TMPDIR=/dev/shm PYTHONPATH=src /home/weihe/work/code/rhythm/opensquilla/.venv/bin/python -m pytest tests/test_gateway/test_session_streams.py tests/test_gateway/test_rpc_sessions.py::TestSessionsMessagesSubscribe::test_messages_subscribe_reports_persisted_task_state_and_replay_gap -q` → `6 passed`
- `git diff --check`
