### PR TITLE
Add bundled AwesomeWebpage meta skill

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -70,6 +70,8 @@ These bundled skill descriptors are authored and maintained by OpenSquilla and
 are released under OpenSquilla's repository license (Apache-2.0; see `LICENSE`):
 
 - `cron`
+- `AwesomeWebpageMetaSkill`
+- `awesome-webpage-research`
 - `deep-research`
 - `docx`
 - `git-diff`
@@ -90,6 +92,7 @@ are released under OpenSquilla's repository license (Apache-2.0; see `LICENSE`):
 - `meta-web-research-to-report`
 - `multi-search-engine`
 - `nano-pdf`
+- `openrouter-video-generator`
 - `paper-abstract-author`
 - `paper-citation-planner`
 - `paper-experiment-stub`
@@ -205,15 +208,20 @@ SOFTWARE.
 
 - Component: SKILL.md frontmatter and instruction text for these bundled skills:
   - `ai-video-script`
+  - `audio-cog`
   - `deep-research`
   - `docx`
+  - `filesystem`
+  - `html-coder`
   - `html-to-pdf`
   - `multi-search-engine`
   - `nano-banana-pro`
+  - `nano-banana-pro-openrouter`
   - `pdf-toolkit`
   - `pptx`
   - `seedance-2-prompt`
   - `video-merger`
+  - `web-search`
   - `xlsx`
 - Upstream registry: https://clawhub.ai
 - License: MIT-0 (Public-domain-equivalent; no attribution required, but

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -71,6 +71,7 @@ are released under OpenSquilla's repository license (Apache-2.0; see `LICENSE`):
 
 - `cron`
 - `AwesomeWebpageMetaSkill`
+- `awesome-webpage-image-download`
 - `awesome-webpage-research`
 - `deep-research`
 - `docx`

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -211,7 +211,6 @@ SOFTWARE.
   - `audio-cog`
   - `deep-research`
   - `docx`
-  - `filesystem`
   - `html-coder`
   - `html-to-pdf`
   - `multi-search-engine`
@@ -244,6 +243,45 @@ in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## ClawHub MIT bundled skill descriptors
+
+- Component: SKILL.md frontmatter and instruction text for these bundled skills:
+  - `filesystem`
+- Upstream registry: https://clawhub.ai
+- Upstream package: https://clawhub.ai/gtrusler/clawdbot-filesystem
+- License: MIT
+- Copyright notice: Copyright (c) 2026 Clawdbot Community
+
+The `filesystem` bundled skill metadata, package manifest, and skill card
+identify this upstream artifact as MIT licensed. OpenSquilla excludes
+skill-local `LICENSE.md` files from wheels as non-runtime skill resources, so
+the required MIT notice for this copied descriptor is reproduced here in the
+top-level notices distributed with release artifacts.
+
+```
+MIT License
+
+Copyright (c) 2026 Clawdbot Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,9 @@ packages = ["src/opensquilla"]
 exclude = [
     "src/opensquilla/scheduler/templates/*.md",
     "src/opensquilla/skills/bundled/**/THIRD_PARTY_NOTICES.md",
+    "src/opensquilla/skills/bundled/**/README.md",
+    "src/opensquilla/skills/bundled/**/LICENSE.md",
+    "src/opensquilla/skills/bundled/**/skill-card.md",
     "src/opensquilla/skills/bundled/**/references/*.md",
     "src/opensquilla/skills/exp/**",
     "src/opensquilla/skills/meta/META_SKILL_AUTHORING.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "dingtalk-stream>=0.24.3,<0.25",
     "qq-botpy>=1.2.1,<1.3",
     "cryptography>=42",
+    "duckduckgo-search>=8.1.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,13 @@ exclude = [
 
 [tool.hatch.build.targets.wheel.force-include]
 "migrations/" = "opensquilla/_migrations/"
+"src/opensquilla/skills/bundled/html-coder/references/add-css-style.md" = "opensquilla/skills/bundled/html-coder/references/add-css-style.md"
+"src/opensquilla/skills/bundled/html-coder/references/add-javascript.md" = "opensquilla/skills/bundled/html-coder/references/add-javascript.md"
+"src/opensquilla/skills/bundled/html-coder/references/attributes.md" = "opensquilla/skills/bundled/html-coder/references/attributes.md"
+"src/opensquilla/skills/bundled/html-coder/references/essentials.md" = "opensquilla/skills/bundled/html-coder/references/essentials.md"
+"src/opensquilla/skills/bundled/html-coder/references/global-attributes.md" = "opensquilla/skills/bundled/html-coder/references/global-attributes.md"
+"src/opensquilla/skills/bundled/html-coder/references/glossary.md" = "opensquilla/skills/bundled/html-coder/references/glossary.md"
+"src/opensquilla/skills/bundled/html-coder/references/standards.md" = "opensquilla/skills/bundled/html-coder/references/standards.md"
 "src/opensquilla/skills/bundled/pptx/references/pptxgenjs.md" = "opensquilla/skills/bundled/pptx/references/pptxgenjs.md"
 "src/opensquilla/skills/bundled/pptx/references/python_pptx.md" = "opensquilla/skills/bundled/pptx/references/python_pptx.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ select = ["E", "F", "I", "N", "W", "UP"]
 # ffmpeg filter graphs, Chinese error strings, and OpenRouter payload
 # field comments meant to stay readable as one unit.
 "src/opensquilla/skills/bundled/ai-video-script/scripts/*.py" = ["E501"]
+"src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/*.py" = ["E501"]
 "src/opensquilla/skills/bundled/nano-banana-pro/scripts/*.py" = ["E501"]
 "src/opensquilla/skills/bundled/seedance-2-prompt/scripts/*.py" = ["E501"]
 "src/opensquilla/skills/bundled/srt-from-script/scripts/*.py" = ["E501"]

--- a/scripts/build_wheelhouse_zip.py
+++ b/scripts/build_wheelhouse_zip.py
@@ -39,6 +39,13 @@ ROUTER_PROVENANCE_WHEEL_PATH = (
 TOKENJUICE_PROVENANCE_WHEEL_PATH = "opensquilla/plugins/tokenjuice/PROVENANCE.md"
 ALLOWED_SKILL_REFERENCE_WHEEL_PATHS = frozenset(
     {
+        "opensquilla/skills/bundled/html-coder/references/add-css-style.md",
+        "opensquilla/skills/bundled/html-coder/references/add-javascript.md",
+        "opensquilla/skills/bundled/html-coder/references/attributes.md",
+        "opensquilla/skills/bundled/html-coder/references/essentials.md",
+        "opensquilla/skills/bundled/html-coder/references/global-attributes.md",
+        "opensquilla/skills/bundled/html-coder/references/glossary.md",
+        "opensquilla/skills/bundled/html-coder/references/standards.md",
         "opensquilla/skills/bundled/pptx/references/pptxgenjs.md",
         "opensquilla/skills/bundled/pptx/references/python_pptx.md",
     }

--- a/src/opensquilla/engine/steps/meta_resolution.py
+++ b/src/opensquilla/engine/steps/meta_resolution.py
@@ -388,7 +388,40 @@ def _deserialize_awaiting_schema(schema_json: str):
 
 
 _META_SKILL_EXPLANATION_RE = re.compile(
-    r"\b(how|what|why|explain|describe)\b.*\bmeta-skill\b"
+    r"\b(how|what|why|explain|describe)\b.*\bmeta[-\s]?skills?\b"
+)
+
+_META_SKILL_SUBJECT_RE = re.compile(
+    r"(?:meta[-_\s]?skills?|元技能|meta\s*技能)",
+    re.IGNORECASE,
+)
+_META_SKILL_DISCUSSION_CUES = (
+    "吗",
+    "么",
+    "是否",
+    "有没有",
+    "调用了",
+    "调用过",
+    "为什么",
+    "怎么",
+    "如何",
+    "机制",
+    "教程",
+    "注意",
+    "原因",
+    "质量",
+    "好差",
+    "太差",
+    "生成的差",
+    "generated poorly",
+    "bad quality",
+    "called",
+    "invoked",
+    "invoke",
+    "why",
+    "how",
+    "explain",
+    "describe",
 )
 
 _PASTED_CONTEXT_MARKERS = (
@@ -425,6 +458,18 @@ def _looks_like_pasted_context(message: str) -> bool:
     if not marker_hit:
         return False
     return len(text) > 1200 or text.count("\n") >= 8
+
+
+def _is_meta_skill_discussion_intent(query: str) -> bool:
+    """Detect questions about meta-skills themselves, not requests to run one."""
+
+    text = (query or "").strip()
+    if not text:
+        return False
+    lower = text.lower()
+    if not _META_SKILL_SUBJECT_RE.search(lower):
+        return False
+    return any(cue in lower for cue in _META_SKILL_DISCUSSION_CUES)
 
 
 def _trigger_match_text(message: str) -> str:
@@ -1038,6 +1083,10 @@ async def meta_resolution(ctx: TurnContext) -> TurnContext:
     pasted_context = _looks_like_pasted_context(semantic_text)
     if pasted_context:
         _sticky_drop(session_id)
+
+    if _is_meta_skill_discussion_intent(semantic_text):
+        _sticky_drop(session_id)
+        return ctx
 
     # Sticky-cancel: explicit user opt-out always wins over a stale match.
     if _hits_cancel_keywords(semantic_text, _STICKY_CANCEL_KEYWORDS):

--- a/src/opensquilla/engine/steps/meta_resolution.py
+++ b/src/opensquilla/engine/steps/meta_resolution.py
@@ -417,7 +417,6 @@ _META_SKILL_DISCUSSION_CUES = (
     "bad quality",
     "called",
     "invoked",
-    "invoke",
     "why",
     "how",
     "explain",

--- a/src/opensquilla/safety/sandbox.py
+++ b/src/opensquilla/safety/sandbox.py
@@ -98,6 +98,14 @@ def _filtered_env(whitelist: Sequence[str]) -> dict[str, str]:
     return {key: parent[key] for key in whitelist if key in parent}
 
 
+def _decode_stream(value: bytes | str | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
 def run_sandboxed(
     cmd: Sequence[str],
     limits: SandboxLimits | None = None,
@@ -138,7 +146,6 @@ def run_sandboxed(
             stdin=subprocess.PIPE if stdin is not None else None,
             env=env,
             preexec_fn=_preexec(effective),  # noqa: PLW1509 — POSIX setrlimit
-            text=True,
         )
     except (OSError, ValueError) as exc:
         return SandboxResult(
@@ -150,15 +157,14 @@ def run_sandboxed(
         )
 
     try:
-        stdin_text = stdin.decode("utf-8", errors="replace") if stdin is not None else None
-        stdout, stderr = proc.communicate(input=stdin_text, timeout=effective.wall_seconds)
+        stdout, stderr = proc.communicate(input=stdin, timeout=effective.wall_seconds)
     except subprocess.TimeoutExpired:
         proc.kill()
         stdout, stderr = proc.communicate()
         return SandboxResult(
             returncode=proc.returncode if proc.returncode is not None else -1,
-            stdout=stdout or "",
-            stderr=stderr or "",
+            stdout=_decode_stream(stdout),
+            stderr=_decode_stream(stderr),
             reason=REASON_WALL_LIMIT,
             limits=effective,
         )
@@ -174,8 +180,8 @@ def run_sandboxed(
 
     return SandboxResult(
         returncode=proc.returncode,
-        stdout=stdout or "",
-        stderr=stderr or "",
+        stdout=_decode_stream(stdout),
+        stderr=_decode_stream(stderr),
         reason=reason,
         limits=effective,
     )

--- a/src/opensquilla/safety/sandbox.py
+++ b/src/opensquilla/safety/sandbox.py
@@ -111,6 +111,7 @@ def run_sandboxed(
     limits: SandboxLimits | None = None,
     *,
     stdin: bytes | None = None,
+    env: dict[str, str] | None = None,
 ) -> SandboxResult:
     """Run ``cmd`` under ``limits`` and return a :class:`SandboxResult`.
 
@@ -136,7 +137,12 @@ def run_sandboxed(
             limits=effective,
         )
 
-    env = _filtered_env(effective.env_whitelist)
+    child_env = _filtered_env(effective.env_whitelist)
+    if env:
+        allowlist = set(effective.env_whitelist)
+        child_env.update(
+            {key: value for key, value in env.items() if key in allowlist}
+        )
 
     try:
         proc = subprocess.Popen(  # noqa: S603 — cmd is caller-controlled
@@ -144,7 +150,7 @@ def run_sandboxed(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             stdin=subprocess.PIPE if stdin is not None else None,
-            env=env,
+            env=child_env,
             preexec_fn=_preexec(effective),  # noqa: PLW1509 — POSIX setrlimit
         )
     except (OSError, ValueError) as exc:

--- a/src/opensquilla/safety/sandbox.py
+++ b/src/opensquilla/safety/sandbox.py
@@ -101,6 +101,8 @@ def _filtered_env(whitelist: Sequence[str]) -> dict[str, str]:
 def run_sandboxed(
     cmd: Sequence[str],
     limits: SandboxLimits | None = None,
+    *,
+    stdin: bytes | None = None,
 ) -> SandboxResult:
     """Run ``cmd`` under ``limits`` and return a :class:`SandboxResult`.
 
@@ -133,6 +135,7 @@ def run_sandboxed(
             list(cmd),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            stdin=subprocess.PIPE if stdin is not None else None,
             env=env,
             preexec_fn=_preexec(effective),  # noqa: PLW1509 — POSIX setrlimit
             text=True,
@@ -147,7 +150,8 @@ def run_sandboxed(
         )
 
     try:
-        stdout, stderr = proc.communicate(timeout=effective.wall_seconds)
+        stdin_text = stdin.decode("utf-8", errors="replace") if stdin is not None else None
+        stdout, stderr = proc.communicate(input=stdin_text, timeout=effective.wall_seconds)
     except subprocess.TimeoutExpired:
         proc.kill()
         stdout, stderr = proc.communicate()

--- a/src/opensquilla/sandbox/backend/noop.py
+++ b/src/opensquilla/sandbox/backend/noop.py
@@ -57,7 +57,7 @@ class NoopBackend(Backend):
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
             None,
-            functools.partial(run_sandboxed, list(request.argv), limits),
+            functools.partial(run_sandboxed, list(request.argv), limits, stdin=request.stdin),
         )
         elapsed = time.monotonic() - started
         timed_out = result.reason == "wall_limit"

--- a/src/opensquilla/sandbox/backend/noop.py
+++ b/src/opensquilla/sandbox/backend/noop.py
@@ -33,6 +33,15 @@ def _limits_from_policy(request: SandboxRequest) -> SandboxLimits:
     )
 
 
+def _filtered_request_env(request: SandboxRequest) -> dict[str, str]:
+    allowlist = set(request.policy.env_allowlist)
+    return {
+        key: value
+        for key, value in request.env.items()
+        if key in allowlist and isinstance(value, str)
+    }
+
+
 class NoopBackend(Backend):
     """Runs commands on the host with rlimits but no isolation."""
 
@@ -57,7 +66,13 @@ class NoopBackend(Backend):
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
             None,
-            functools.partial(run_sandboxed, list(request.argv), limits, stdin=request.stdin),
+            functools.partial(
+                run_sandboxed,
+                list(request.argv),
+                limits,
+                stdin=request.stdin,
+                env=_filtered_request_env(request),
+            ),
         )
         elapsed = time.monotonic() - started
         timed_out = result.reason == "wall_limit"

--- a/src/opensquilla/sandbox/policy.py
+++ b/src/opensquilla/sandbox/policy.py
@@ -37,6 +37,8 @@ _DEFAULT_ENV_ALLOWLIST: tuple[str, ...] = (
     "LOGNAME",
     "HOSTNAME",
     "PWD",
+    "WORKSPACE_DIR",
+    "PROJECT_ROOT",
 )
 
 

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
@@ -733,15 +733,28 @@ composition:
           Media assets:
           {{ outputs.media_assets_collect | truncate(6000) }}
 
+    - id: webpage_source_validate
+      kind: tool_call
+      tool: exec_command
+      tool_allowlist: [exec_command]
+      depends_on: [webpage_generation]
+      tool_args:
+        command: |
+          python -m opensquilla.skills.bundled.AwesomeWebpageMetaSkill.scripts.webpage_source_validate
+        timeout: 15
+        stdin: "{{ outputs.webpage_generation | tojson }}"
+
     - id: webpage_generation_retry
       kind: llm_chat
-      depends_on: [webpage_generation, media_slots_normalize]
-      when: "not outputs.get('webpage_generation', '').strip()"
+      depends_on: [webpage_generation, webpage_source_validate, media_slots_normalize]
+      when: >-
+        not outputs.get('webpage_generation', '').strip() or
+        'WEBPAGE_SOURCE_INVALID:' in outputs.get('webpage_source_validate', '')
       with:
         system: |
           You are the fallback Webpage Source Authoring stage for
           AwesomeWebpageMetaSkill. The primary source authoring step returned
-          empty output. Produce compact source JSON only.
+          empty or invalid output. Produce compact source JSON only.
         task: |
           {{ inputs.language_instruction }}
 
@@ -788,7 +801,7 @@ composition:
       kind: tool_call
       tool: exec_command
       tool_allowlist: [exec_command]
-      depends_on: [webpage_generation, webpage_generation_retry]
+      depends_on: [webpage_generation, webpage_source_validate, webpage_generation_retry]
       tool_args:
         command: |
           python -m opensquilla.skills.bundled.AwesomeWebpageMetaSkill.scripts.webpage_write

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
@@ -1,0 +1,916 @@
+---
+name: AwesomeWebpageMetaSkill
+description: "Build a local multimedia webpage project from a user topic, audience, language, style, and media preferences by framing requirements, researching, planning, acquiring media, generating files, packaging, validating, repairing, and delivering usage guidance."
+kind: meta
+meta_priority: 65
+always: false
+final_text_mode: "step:delivery_guide"
+triggers:
+  - "create awesome webpage"
+  - "build multimedia webpage project"
+  - "生成图文音视频网页"
+  - "做一个多媒体网页项目"
+  - "AwesomeWebpageMetaSkill"
+provenance:
+  origin: opensquilla-original
+  license: Apache-2.0
+  maintained_by: OpenSquilla
+metadata:
+  opensquilla:
+    risk: high
+    capabilities: [network-read, network-write, filesystem-read, filesystem-write, command-exec]
+    requires:
+      config:
+        - awesome_webpage.provider
+        - awesome_webpage.openrouter.api_key
+        - awesome_webpage.openrouter.models.page_generation
+        - awesome_webpage.openrouter.models.image_generation
+        - awesome_webpage.openrouter.models.audio_generation
+        - awesome_webpage.openrouter.models.video_generation
+        - awesome_webpage.output_dir
+        - awesome_webpage.media_strategy
+config:
+  awesome_webpage:
+    provider: openrouter
+    openrouter:
+      api_key: null
+      api_key_env: OPENROUTER_API_KEY
+      base_url: https://openrouter.ai/api/v1
+      models:
+        page_generation: moonshotai/kimi-k2.6
+        image_generation: google/gemini-3-pro-image-preview
+        audio_generation: openai/gpt-audio-mini
+        video_generation: bytedance/seedance-2.0-fast
+    output_dir: "{{ inputs.workspace_dir }}/awesome-webpage-output"
+    media_strategy:
+      search_first: true
+      aigc_fallback_when_search_empty: true
+      allow_remote_embeds: false
+      default_modalities: [text, images, audio, video]
+      search_modalities: [images]
+      direct_aigc_modalities: [audio, video]
+      confirmation_steps: [ask_images, ask_audio, ask_video, ask_style]
+      aigc_policy: search_images_direct_generate_audio_video
+      placeholder_policy: visible_replacement_slot_when_generation_unavailable
+      target_assets:
+        images: 6
+        audio: 1
+        video: 1
+      licensing: prefer_reusable_or_user_supplied
+    clawhub_skills:
+      web_search:
+        skill: web-search
+        url: https://clawhub.ai/billyutw/web-search
+      image_generation:
+        skill: nano-banana-pro-openrouter
+        url: https://clawhub.ai/skills/nano-banana-pro-openrouter
+        opensquilla_compatibility: deterministic-skill-exec
+        notes: |
+          The image_aigc step runs this deterministic skill_exec adapter.
+          It does not invoke a prompt-building skill as an agent. No
+          GEMINI_API_KEY required; only OPENROUTER_API_KEY.
+      audio_generation:
+        skill: audio-cog
+        url: https://clawhub.ai/skills/audio-cog
+        opensquilla_compatibility: openrouter-config-first
+      video_generation:
+        skill: openrouter-video-generator
+        url: openrouter-configured-video-generation
+      webpage_generation:
+        skill: html-coder
+        url: https://clawhub.ai/jhauga/html-coder
+        opensquilla_compatibility: scoped-agent
+        notes: |
+          Invoked by the webpage_generation step as the HTML/CSS/JS authoring
+          skill. The meta-skill task constrains it to source JSON only;
+          packaging, validation, repair, and media generation remain separate
+          steps.
+      filesystem:
+        skill: filesystem
+        url: https://clawhub.ai/gtrusler/clawdbot-filesystem
+composition:
+  steps:
+    - id: requirement_framing
+      kind: llm_chat
+      with:
+        system: |
+          You are the Requirement Framing stage for AwesomeWebpageMetaSkill.
+          Produce a compact, structured brief. Do not call tools.
+        task: |
+          {{ inputs.language_instruction }}
+
+          Extract and normalize the user's webpage request.
+
+          Required fields:
+          - topic
+          - target_audience
+          - output_language
+          - visual_style
+          - media_preferences: infer the user's requested images, audio, video, remote embeds, and local-only needs
+          - configured_output_dir: use the resolved config below; only mark CONFIG_NEEDED if it is empty
+          - constraints and risks
+
+          Do not invent provider names, model ids, API keys, output paths, or media strategy values.
+          They must come from the `awesome_webpage` config.
+          A missing OpenRouter model value means CONFIG_NEEDED for that generator; it does not mean
+          the user does not want that media modality. Do not mark audio or video as unwanted only
+          because its configured model is null.
+
+          Resolved awesome_webpage config for this run:
+          provider: openrouter
+          openrouter.api_key_env: OPENROUTER_API_KEY
+          openrouter.models.page_generation: moonshotai/kimi-k2.6
+          openrouter.models.image_generation: google/gemini-3-pro-image-preview
+          openrouter.models.audio_generation: openai/gpt-audio-mini
+          openrouter.models.video_generation: bytedance/seedance-2.0-fast
+          output_dir: {{ inputs.workspace_dir }}/awesome-webpage-output
+          This resolved output_dir is configured and must not be reported as CONFIG_NEEDED.
+          media_strategy.search_first: true
+          media_strategy.search_modalities: images only
+          media_strategy.direct_aigc_modalities: audio, video
+          media_strategy.aigc_fallback_when_search_empty: true
+          media_strategy.allow_remote_embeds: false
+
+          User request:
+          {{ inputs.user_message | xml_escape | truncate(1600) }}
+
+    - id: project_slug
+      kind: llm_chat
+      depends_on: [requirement_framing]
+      with:
+        system: |
+          You produce a single filesystem-safe slug identifying this webpage
+          project. Do not call tools.
+        task: |
+          Output ONLY a single slug derived from the topic in the framed
+          requirements below. Constraints:
+          - lowercase ASCII letters, digits, and hyphens only
+          - no spaces, no path separators, no file extension, no quotes
+          - max 40 characters
+          - topic-derived, so different topics produce different slugs
+
+          Examples (do NOT reuse — derive from the actual topic):
+          - "海洋塑料污染" → ocean-plastic-pollution
+          - "Quantum computing intro" → quantum-computing-intro
+          - "我们公司年会回顾" → company-annual-recap
+
+          If you cannot derive a meaningful slug, output `webpage`.
+
+          Output: a single line containing just the slug. No prefix, no
+          explanation, no backticks, no quotes.
+
+          Framed requirements:
+          {{ outputs.requirement_framing | truncate(1500) }}
+
+    - id: ask_images
+      kind: user_input
+      depends_on: [requirement_framing]
+      clarify:
+        mode: chat
+        intro: |
+          先逐项确认网页媒体配置，再继续研究、搜索素材和生成项目。
+          默认需要图片；后续会先搜索，搜不到合适素材才生成。
+        nl_extract: true
+        fields:
+          - name: include_images
+            type: enum
+            choices: ["YES", "NO"]
+            default: "YES"
+            prompt: "是否需要图片？"
+        cancel_keywords: ["取消", "算了", "cancel", "stop", "abort"]
+        timeout_hours: 24
+
+    - id: ask_audio
+      kind: user_input
+      depends_on: [ask_images]
+      clarify:
+        mode: chat
+        intro: |
+          已记录图片选择。现在确认音频。
+          默认需要音频；音频不走素材搜索，会直接按 OpenRouter 配置生成或给出可替换位置。
+        nl_extract: true
+        fields:
+          - name: include_audio
+            type: enum
+            choices: ["YES", "NO"]
+            default: "YES"
+            prompt: "是否需要音频？"
+        cancel_keywords: ["取消", "算了", "cancel", "stop", "abort"]
+        timeout_hours: 24
+
+    - id: ask_video
+      kind: user_input
+      depends_on: [ask_audio]
+      clarify:
+        mode: chat
+        intro: |
+          已记录音频选择。现在确认视频。
+          默认需要视频；视频不走素材搜索，会直接按 OpenRouter 配置生成或给出可替换位置。
+        nl_extract: true
+        fields:
+          - name: include_video
+            type: enum
+            choices: ["YES", "NO"]
+            default: "YES"
+            prompt: "是否需要视频？"
+        cancel_keywords: ["取消", "算了", "cancel", "stop", "abort"]
+        timeout_hours: 24
+
+    - id: ask_style
+      kind: user_input
+      depends_on: [ask_video]
+      clarify:
+        mode: chat
+        intro: |
+          已记录视频选择。最后确认网页整体风格，然后开始研究、规划和素材获取。
+        nl_extract: true
+        fields:
+          - name: visual_style
+            type: string
+            prompt: "网页整体风格是什么？例如：科技感、纪录片风、极简、儿童科普、商业发布会风。"
+            max_chars: 500
+        cancel_keywords: ["取消", "算了", "cancel", "stop", "abort"]
+        timeout_hours: 24
+
+    - id: deep_research
+      kind: agent
+      skill: awesome-webpage-research
+      depends_on: [requirement_framing, ask_images, ask_audio, ask_video, ask_style]
+      with:
+        question: |
+          Research the topic for a multimedia webpage project.
+
+          Single bounded round only. Produce a short cited brief with 3-5
+          page anchors. Do not run multi-round investigation.
+
+          Requirement framing:
+          {{ outputs.requirement_framing | truncate(3000) }}
+
+          Confirmed interactive choices:
+          images: {{ inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') }}
+          audio: {{ inputs.get('collected', {}).get('ask_audio', {}).get('include_audio', 'YES') }}
+          video: {{ inputs.get('collected', {}).get('ask_video', {}).get('include_video', 'YES') }}
+          visual_style: {{ inputs.get('collected', {}).get('ask_style', {}).get('visual_style', '') }}
+
+          Original request:
+          {{ inputs.user_message | xml_escape | truncate(1000) }}
+
+    - id: page_outline
+      kind: llm_chat
+      depends_on: [requirement_framing, project_slug, ask_images, ask_audio, ask_video, ask_style, deep_research]
+      with:
+        system: |
+          You are the Page Outline stage for AwesomeWebpageMetaSkill.
+          Produce a structural outline + media intent list — NOT a final
+          asset binding. Later steps will normalize media results into a
+          compact manifest and then bind actual files to sections. Do not
+          call tools.
+        task: |
+          {{ inputs.language_instruction }}
+
+          Output the webpage OUTLINE — section structure + media intents
+          only. Downstream media steps read this to decide WHAT to fetch
+          or generate; the deterministic `media_assets_collect` step later
+          turns producer output into concrete browser-relative asset paths.
+
+          Required sections:
+
+          1. Page hierarchy
+             - Ordered list of sections: section_id, title, narrative
+               purpose, 1-2 sentence summary.
+             - Overall narrative arc (one paragraph).
+
+          2. Visual style summary (one paragraph)
+
+          3. Media intent list — one entry per desired asset, with:
+             - slot_id: short kebab-case key, unique within outline
+               (e.g. `hero-ocean`, `foodchain-flow`, `narration-intro`).
+             - modality: image | audio | video
+             - placement: which section_id it belongs to + role
+               (e.g. "hero background", "section illustration",
+               "section narration").
+             - subject: one-sentence concrete description of what the
+               asset should depict / convey.
+             - prompt_hint: 1-2 sentences of stylistic / compositional
+               guidance for AIGC steps.
+             - search_keywords: 3-6 short keywords for image search
+               (only meaningful for image slots).
+             - load_bearing: true | false. `true` means the section
+               structurally relies on this asset (e.g. hero video). If
+               the asset later fails to produce, the final media binding
+               gate reports it instead of hiding the missing modality.
+               `false` means the section degrades gracefully to
+               text-only.
+
+             HARD: do NOT specify filenames or paths. slot_id is a
+             semantic key; the producer step (image_download,
+             image_aigc, audio_aigc, video_aigc) decides the on-disk
+             filename and the deterministic media binding step performs
+             final src/path checks.
+
+          4. Local file plan: project/index.html, project/style.css,
+             project/script.js.
+
+          5. Accessibility plan: alt-text strategy, ARIA roles,
+             keyboard navigation, reduced-motion handling.
+
+          Hard rules:
+          - No filenames. No paths. No `.jpg` / `.mp3` / `.mp4`.
+          - If the user said NO to a modality, do not include any media
+            intents of that modality.
+          - Include only as many media intents as the section narrative
+            actually needs — do not pad to hit a target count.
+          - Outline must remain coherent even if every media intent
+            fails downstream (text + headings carry the page).
+
+          Requirement framing:
+          {{ outputs.requirement_framing | truncate(3000) }}
+
+          Research report:
+          {{ outputs.deep_research | truncate(6000) }}
+
+          Confirmed interactive choices:
+          images: {{ inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') }}
+          audio: {{ inputs.get('collected', {}).get('ask_audio', {}).get('include_audio', 'YES') }}
+          video: {{ inputs.get('collected', {}).get('ask_video', {}).get('include_video', 'YES') }}
+          visual_style: {{ inputs.get('collected', {}).get('ask_style', {}).get('visual_style', '') }}
+
+    - id: media_slots_normalize
+      kind: tool_call
+      tool: exec_command
+      tool_allowlist: [exec_command]
+      depends_on: [page_outline]
+      tool_args:
+        command: |
+          python -m opensquilla.skills.bundled.AwesomeWebpageMetaSkill.scripts.media_slots_normalize
+        timeout: 20
+        env:
+          PAGE_OUTLINE: "{{ outputs.page_outline }}"
+          REQUIREMENT_FRAMING: "{{ outputs.requirement_framing }}"
+          INCLUDE_IMAGE: "{{ inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') }}"
+          INCLUDE_AUDIO: "{{ inputs.get('collected', {}).get('ask_audio', {}).get('include_audio', 'YES') }}"
+          INCLUDE_VIDEO: "{{ inputs.get('collected', {}).get('ask_video', {}).get('include_video', 'YES') }}"
+          VISUAL_STYLE: "{{ inputs.get('collected', {}).get('ask_style', {}).get('visual_style', '') }}"
+
+    - id: media_search
+      kind: agent
+      skill: web-search
+      depends_on: [media_slots_normalize]
+      when: "inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') == 'YES'"
+      with:
+        query: |
+          Search only for reusable webpage image candidates for this plan.
+          Do not search for audio or video; those modalities are generated directly
+          through the configured OpenRouter models when the user requests them.
+          Prefer assets that can be used locally or replaced cleanly. Return URLs, titles,
+          image type, likely license/provenance, and download/replacement notes.
+
+          Tool contract for this step:
+          - Use the platform-provided `web_search` tool ONLY (provider is configured
+            globally; you do not need to know which engine — just call the tool).
+          - Do NOT run any local Python script (no `python scripts/search.py`,
+            no `duckduckgo-search`, no `pip install`).
+          - Do NOT call `web_fetch`. Snippets from `web_search` are enough.
+          - Issue at most 2 `web_search` calls, each with `type=images` and
+            `max_results=6`, grouped by visual theme — do not search per asset.
+          - Stop as soon as you have ~4-6 usable candidates total.
+          - If results are empty, unusable, off-topic, or licensing is unclear,
+            stop immediately and return:
+            {"status":"NO_USABLE_IMAGE_CANDIDATES","candidates":[]}
+          - Otherwise return one JSON object with:
+            candidates[] (title, url, source_domain, likely_license, suggested_alt).
+
+          Normalized media slots (authoritative):
+          {{ outputs.media_slots_normalize | truncate(3500) }}
+
+          Page plan context:
+          {{ outputs.page_outline | truncate(1200) }}
+
+          Confirmed interactive choices:
+          images: {{ inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') }}
+          audio: {{ inputs.get('collected', {}).get('ask_audio', {}).get('include_audio', 'YES') }}
+          video: {{ inputs.get('collected', {}).get('ask_video', {}).get('include_video', 'YES') }}
+          visual_style: {{ inputs.get('collected', {}).get('ask_style', {}).get('visual_style', '') }}
+        format: json
+
+    - id: media_strategy
+      kind: llm_classify
+      output_choices:
+        - IMAGE_SEARCH_READY
+        - NEEDS_AIGC_IMAGE
+      depends_on: [media_search, media_slots_normalize]
+      with:
+        text: |
+          Decide whether searched image media is enough or whether image AIGC fallback is required.
+
+          Fast media policy:
+          - Use the confirmed interactive choices as the source of truth.
+          - Search is image-only. Audio and video must not be evaluated through web search.
+          - If include_images is NO, choose IMAGE_SEARCH_READY.
+          - If include_images is YES, evaluate only image candidates from web-search.
+          - Choose NEEDS_AIGC_IMAGE when image search is empty, unusable, off-topic,
+            not downloadable/localizable, or has unclear licensing.
+          - Choose IMAGE_SEARCH_READY only when the search results provide enough usable
+            local/downloadable image assets for the requested page.
+          - Audio and video are direct AIGC modalities. They are handled by audio_aigc
+            and video_aigc based on user confirmation and OpenRouter config, not by this classifier.
+
+          Rules:
+          - IMAGE_SEARCH_READY: image search results are sufficient, or images were not requested.
+          - NEEDS_AIGC_IMAGE: image generation is needed.
+
+          If search is empty and config.awesome_webpage.media_strategy.aigc_fallback_when_search_empty is true,
+          choose NEEDS_AIGC_IMAGE. Do not choose a model here; model choice belongs to config.
+
+          Requirement framing:
+          {{ outputs.requirement_framing | truncate(2000) }}
+
+          Page plan:
+          {{ outputs.page_outline | truncate(2500) }}
+
+          Normalized media slots:
+          {{ outputs.media_slots_normalize | truncate(2000) }}
+
+          Confirmed interactive choices:
+          images: {{ inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') }}
+          audio: {{ inputs.get('collected', {}).get('ask_audio', {}).get('include_audio', 'YES') }}
+          video: {{ inputs.get('collected', {}).get('ask_video', {}).get('include_video', 'YES') }}
+          visual_style: {{ inputs.get('collected', {}).get('ask_style', {}).get('visual_style', '') }}
+
+          Primary search:
+          {{ outputs.media_search | truncate(3500) }}
+
+    - id: image_download
+      kind: agent
+      skill: filesystem
+      depends_on: [media_strategy, media_slots_normalize]
+      when: "inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') == 'YES' and outputs.media_strategy == 'IMAGE_SEARCH_READY'"
+      with:
+        task: |
+          Download searched image candidates to local disk. The normalized
+          media slots below define image SLOTS by semantic key (slot_id) and subject —
+          NOT by filename. Save each downloaded file as `<slot_id>.<ext>`
+          so the later media collection step can bind by slot_id match.
+
+          ABSOLUTE_IMAGE_DIR = {{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/images
+
+          Steps:
+          1. `mkdir -p` ABSOLUTE_IMAGE_DIR.
+          2. Read MEDIA_SLOTS_JSON below and extract `slots[]` entries where
+             `modality` is `image`. Each entry has:
+                slot_id (kebab-case key, e.g. `hero-ocean`)
+                subject (one-sentence description)
+                search_keywords (3-6 keywords)
+             This is your shopping list. Do NOT invent new slot_ids and do
+             NOT rename outline slot_ids.
+          3. For each image slot, scan the candidate URL lists below and
+             pick ONE direct image URL whose title/subject best matches the
+             slot's subject + search_keywords. Skip search-result pages,
+             login walls, and data: URIs. Stay within the URL set; do not
+             call web_search.
+          4. Save each picked URL using the slot_id as filename plus an
+             extension matching the URL or Content-Type
+             (`<slot_id>.jpg` / `.png` / `.webp`). Example: slot_id
+             `hero-ocean` + JPEG URL → `hero-ocean.jpg`. Do NOT prefix
+             with an index, do NOT pluralize.
+          5. Download with
+             `curl -L --fail --max-time 20 -o <abs_path> <url>`.
+             Run up to 4 in parallel via `xargs -P 4` or backgrounded `&`
+             followed by `wait`.
+          6. After all downloads complete, `ls -la` ABSOLUTE_IMAGE_DIR.
+          7. Validate every file is a real image:
+             `file --mime-type <abs_path>` and drop anything not
+             `image/jpeg|image/png|image/webp|image/gif`. HTML pages
+             masquerading as `.jpg` count as failed downloads.
+          8. Return one JSON object:
+             {downloaded: [{slot_id, url, local_path, bytes}],
+              unfilled: [{slot_id, reason}],
+              skipped: [{url, reason}]}.
+             `unfilled` lists outline slot_ids that no candidate covered;
+             the downstream image_aigc step handles missing image slots.
+          9. After the JSON object, emit one `IMAGE_READY:` line per
+             surviving file so media collection and the webpage generator can
+             pick them up:
+             `IMAGE_READY: {"local_path": "project/assets/images/<slot_id>.<ext>", "mime": "<mime>", "bytes": <int>, "slot_id": "<slot_id>", "subject": "<subject from outline>"}`
+             `local_path` MUST be the relative `project/assets/images/...`
+             form. Never an absolute path.
+          10. If no image survives validation OR any outline image slot remains
+              unfilled, emit one final single-line marker:
+              `IMAGE_DOWNLOAD_INCOMPLETE: {"reason": "<short reason>", "unfilled_slot_ids": ["<slot_id>", "..."]}`.
+              This marker lets the next step generate only the missing image
+              slots instead of leaving load-bearing replacement slots.
+
+          Hard rules:
+          - Total budget 90 s. If wall-clock exceeds this, stop and return
+            whatever is on disk; do not retry.
+          - Do not call web_search, web_fetch, or any LLM tool here. Just curl.
+          - Do not read image bytes back. Trust `curl --fail` exit codes and
+            on-disk presence as evidence.
+          - URLs that return non-2xx are dropped silently — do not retry,
+            and do not perform AIGC inside this step. The downstream image_aigc
+            step handles fallback when `IMAGE_DOWNLOAD_INCOMPLETE:` is present
+            or when no `IMAGE_READY:` line was produced.
+
+          MEDIA_SLOTS_JSON (extract `modality: image` slots — slot_ids are
+          authoritative):
+          {{ outputs.media_slots_normalize | truncate(3500) }}
+
+          Primary search URLs:
+          {{ outputs.media_search | truncate(3000) }}
+
+    - id: image_aigc
+      kind: skill_exec
+      skill: nano-banana-pro-openrouter
+      depends_on: [media_strategy, image_download, media_slots_normalize]
+      when: "inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') == 'YES' and (outputs.media_strategy == 'NEEDS_AIGC_IMAGE' or 'IMAGE_DOWNLOAD_INCOMPLETE:' in outputs.get('image_download', '') or (outputs.media_strategy == 'IMAGE_SEARCH_READY' and 'IMAGE_READY:' not in outputs.get('image_download', '')))"
+      with:
+        model: google/gemini-3-pro-image-preview
+        base_url: https://openrouter.ai/api/v1
+        output_dir: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/images"
+        filename: "{{ outputs.project_slug | slugify }}.png"
+        resolution: "1K"
+        max_images: "6"
+        local_path_prefix: project/assets/images
+        payload: |
+          {
+            "requirement_framing": {{ outputs.requirement_framing | tojson }},
+            "media_slots": {{ outputs.media_slots_normalize | tojson }},
+            "page_outline": {{ outputs.page_outline | tojson }},
+            "image_download": {{ outputs.get('image_download', '') | tojson }},
+            "include_images": {{ inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') | tojson }},
+            "visual_style": {{ inputs.get('collected', {}).get('ask_style', {}).get('visual_style', '') | tojson }}
+          }
+
+    - id: audio_aigc
+      kind: skill_exec
+      skill: audio-cog
+      depends_on: [audio_script]
+      when: "inputs.get('collected', {}).get('ask_audio', {}).get('include_audio', 'YES') == 'YES'"
+      with:
+        model: openai/gpt-audio-mini
+        base_url: https://openrouter.ai/api/v1
+        output_dir: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/audio"
+        filename: "{{ outputs.project_slug | slugify }}-narration.wav"
+        voice: cedar
+        payload: |
+          {
+            "script": {{ outputs.audio_script | tojson }},
+            "requirement_framing": {{ outputs.requirement_framing | tojson }},
+            "media_slots": {{ outputs.media_slots_normalize | tojson }}
+          }
+
+    - id: audio_script
+      kind: llm_chat
+      depends_on: [requirement_framing, page_outline, media_slots_normalize]
+      when: "inputs.get('collected', {}).get('ask_audio', {}).get('include_audio', 'YES') == 'YES'"
+      with:
+        system: |
+          You write only final spoken narration text for webpage audio.
+          Do not call tools. Do not acknowledge the request.
+        task: |
+          {{ inputs.language_instruction }}
+
+          Write the exact narration script that the audio model should speak.
+          Output spoken text only. No title, no markdown, no filename, no JSON,
+          no labels, no stage directions, no "我明白了", no "接下来", no
+          "我将为你生成", no assistant-style acknowledgement.
+
+          Requirements:
+          - Make it a polished webpage narration or guide, not a response to
+            the user.
+          - 45-75 seconds when spoken.
+          - Match the requested language and style.
+          - Use the audio slot placement/subject from media slots when present.
+          - It must stand alone as content a visitor hears on the page.
+
+          Requirement framing:
+          {{ outputs.requirement_framing | truncate(1800) }}
+
+          Page outline:
+          {{ outputs.page_outline | truncate(2600) }}
+
+          Normalized media slots:
+          {{ outputs.media_slots_normalize | truncate(2200) }}
+
+    - id: video_aigc
+      kind: skill_exec
+      skill: openrouter-video-generator
+      depends_on: [page_outline]
+      when: "inputs.get('collected', {}).get('ask_video', {}).get('include_video', 'YES') == 'YES'"
+      with:
+        model: bytedance/seedance-2.0-fast
+        base_url: https://openrouter.ai/api/v1
+        output_dir: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/video"
+        filename: "{{ outputs.project_slug | slugify }}-intro.mp4"
+        duration: "10"
+        aspect_ratio: "16:9"
+        prompt: |
+          Generate the short video asset requested by the page outline. Do not
+          run web search for video assets.
+
+          Requirement framing:
+          {{ outputs.requirement_framing | truncate(1800) }}
+
+          Page plan:
+          {{ outputs.page_outline | truncate(3000) }}
+
+          Confirmed interactive choices:
+          video: {{ inputs.get('collected', {}).get('ask_video', {}).get('include_video', 'YES') }}
+          visual_style: {{ inputs.get('collected', {}).get('ask_style', {}).get('visual_style', '') }}
+
+    - id: media_assets_collect
+      kind: tool_call
+      tool: exec_command
+      tool_allowlist: [exec_command]
+      depends_on:
+        - image_download
+        - image_aigc
+        - audio_aigc
+        - video_aigc
+      tool_args:
+        command: |
+          python -m opensquilla.skills.bundled.AwesomeWebpageMetaSkill.scripts.media_assets_collect
+        timeout: 30
+        env:
+          PROJECT_ROOT: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project"
+          IMAGE_DOWNLOAD: "{{ outputs.get('image_download', '') }}"
+          IMAGE_AIGC: "{{ outputs.get('image_aigc', '') }}"
+          AUDIO_AIGC: "{{ outputs.get('audio_aigc', '') }}"
+          VIDEO_AIGC: "{{ outputs.get('video_aigc', '') }}"
+
+    - id: webpage_generation
+      kind: agent
+      skill: html-coder
+      depends_on:
+        - requirement_framing
+        - deep_research
+        - page_outline
+        - media_slots_normalize
+        - media_assets_collect
+      with:
+        mode: generate
+        task: |
+          {{ inputs.language_instruction }}
+
+          You are the Webpage Source Authoring stage for AwesomeWebpageMetaSkill.
+          Produce source text only. Do not call tools and do not write files.
+          Apply a professional HTML/CSS quality standard: clear visual
+          hierarchy, semantic HTML, restrained but distinctive typography and
+          color, accessible media controls, responsive layout, and intentional
+          composition rather than a thin placeholder page.
+
+          Generate a complete local webpage as strict JSON with exactly these keys:
+          - `index_html`
+          - `style_css`
+          - `script_js`
+          - `summary`
+
+          Output JSON only. Do not wrap it in Markdown fences. Ignore
+          html-coder's default Markdown/code-block output format for this
+          invocation; the final answer must be the strict JSON object only.
+
+          Scope:
+          - Author only the contents for project/index.html, project/style.css,
+            and project/script.js.
+          - Do not download, search, generate, copy, move, delete, package, validate, repair, normalize paths, or clean up assets.
+          - Do not mention or choose filesystem paths. A deterministic later
+            step writes the files to the exact project root.
+          - Use only browser-relative `assets/...` paths listed in
+            `media_assets_collect.assets[]`.
+          - Include available image, audio, and video assets in the authored
+            page. A deterministic later step patches any asset the model misses.
+          - Do not show "pending", "to be added", or "replace this asset"
+            placeholders for requested media.
+          - Place audio controls according to the audio slot placement in
+            `media_slots_normalize.slots[]`; for narration/guide audio, put
+            the player near the intro/hero or the referenced section, never as
+            footer-only/end-of-page content unless the slot explicitly says so.
+
+          Design-quality contract, adapted from html-coder
+          (https://clawhub.ai/jhauga/html-coder):
+          - Build a real, production-quality webpage, not a short landing-page
+            stub. Represent the page outline in semantic
+            HTML (`header`, `main`, `section`, `figure`, `footer`).
+          - Use strong visual hierarchy, clear grid alignment, intentional
+            whitespace, readable line lengths, and a balanced 2-3 color system.
+            Avoid a one-note dark/slate/blue page unless the requested style
+            specifically requires it.
+          - Include accessible local media: `<audio controls>` for any
+            audio asset, `<video>` for any video asset, and `<img>` with
+            meaningful alt text/captions for every image asset.
+          - If `media_assets_collect` contains extra image assets, render a gallery,
+            evidence wall, or visual sequence section so generated assets do
+            not sit unused on disk.
+          - Add keyboard-accessible controls where interaction exists, visible
+            focus states, reduced-motion handling, and mobile layouts without
+            overlapping text.
+          - Do not show "replace this asset" placeholders when a real asset is
+            present in `media_assets_collect`.
+
+          Media assets:
+          The authoritative asset facts are `media_assets_collect` below.
+          Use only `media_assets_collect.assets[].src` values in generated
+          HTML/CSS/JS. Those values are already `assets/...` browser paths.
+          Do not scan raw producer output and do not use raw
+          `project/assets/...` local_path values as browser src paths.
+
+          Page outline (narrative + section structure):
+          {{ outputs.page_outline | truncate(1500) }}
+
+          Normalized media slots (placement/role contract):
+          {{ outputs.media_slots_normalize | truncate(3500) }}
+
+          Media strategy:
+          {{ outputs.media_strategy }}
+
+          Confirmed interactive choices:
+          images: {{ inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') }}
+          audio: {{ inputs.get('collected', {}).get('ask_audio', {}).get('include_audio', 'YES') }}
+          video: {{ inputs.get('collected', {}).get('ask_video', {}).get('include_video', 'YES') }}
+          visual_style: {{ inputs.get('collected', {}).get('ask_style', {}).get('visual_style', '') }}
+
+          Media assets:
+          {{ outputs.media_assets_collect | truncate(6000) }}
+
+    - id: webpage_generation_retry
+      kind: llm_chat
+      depends_on: [webpage_generation, media_slots_normalize]
+      when: "not outputs.get('webpage_generation', '').strip()"
+      with:
+        system: |
+          You are the fallback Webpage Source Authoring stage for
+          AwesomeWebpageMetaSkill. The primary source authoring step returned
+          empty output. Produce compact source JSON only.
+        task: |
+          {{ inputs.language_instruction }}
+
+          Generate strict JSON with exactly these keys:
+          - `index_html`
+          - `style_css`
+          - `script_js`
+          - `summary`
+
+          Output JSON only. Do not wrap it in Markdown fences.
+
+          Scope:
+          - Author only project/index.html, project/style.css, and
+            project/script.js contents.
+          - Do not call tools, write files, download assets, search, generate
+            media, package, validate, repair, or normalize paths.
+          - Use only `assets/...` browser paths already present in
+            media_assets_collect.assets[].src.
+          - Do not invent pending audio/video controls or "to be added"
+            placeholders.
+          - Place audio controls near the audio slot placement from
+            media_slots_normalize, not as footer-only/end-of-page content
+            unless the slot explicitly says footer.
+          - Keep the page production-quality: semantic sections, accessible
+            local media, responsive layout, meaningful hierarchy, and no
+            overlapping mobile text.
+
+          Page outline:
+          {{ outputs.page_outline | truncate(900) }}
+
+          Normalized media slots:
+          {{ outputs.media_slots_normalize | truncate(2200) }}
+
+          Media assets:
+          {{ outputs.media_assets_collect | truncate(3500) }}
+
+          Confirmed interactive choices:
+          images: {{ inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') }}
+          audio: {{ inputs.get('collected', {}).get('ask_audio', {}).get('include_audio', 'YES') }}
+          video: {{ inputs.get('collected', {}).get('ask_video', {}).get('include_video', 'YES') }}
+          visual_style: {{ inputs.get('collected', {}).get('ask_style', {}).get('visual_style', '') }}
+
+    - id: webpage_write
+      kind: tool_call
+      tool: exec_command
+      tool_allowlist: [exec_command]
+      depends_on: [webpage_generation, webpage_generation_retry]
+      tool_args:
+        command: |
+          python -m opensquilla.skills.bundled.AwesomeWebpageMetaSkill.scripts.webpage_write
+        timeout: 30
+        env:
+          WORKSPACE_DIR: "{{ inputs.workspace_dir }}"
+          PROJECT_ROOT: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}"
+          WEBPAGE_SOURCE_JSON: "{{ (outputs.get('webpage_generation_retry', '') or outputs.webpage_generation) | tojson }}"
+
+    - id: media_bind_validate
+      kind: tool_call
+      tool: exec_command
+      tool_allowlist: [exec_command]
+      depends_on: [webpage_write, media_assets_collect]
+      tool_args:
+        command: |
+          python -m opensquilla.skills.bundled.AwesomeWebpageMetaSkill.scripts.media_bind_validate
+        timeout: 30
+        env:
+          PROJECT_ROOT: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}"
+          IMAGE_DOWNLOAD: "{{ outputs.get('image_download', '') }}"
+          IMAGE_AIGC: "{{ outputs.get('image_aigc', '') }}"
+          AUDIO_AIGC: "{{ outputs.get('audio_aigc', '') }}"
+          VIDEO_AIGC: "{{ outputs.get('video_aigc', '') }}"
+          INCLUDE_IMAGE: "{{ inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') }}"
+          INCLUDE_AUDIO: "{{ inputs.get('collected', {}).get('ask_audio', {}).get('include_audio', 'YES') }}"
+          INCLUDE_VIDEO: "{{ inputs.get('collected', {}).get('ask_video', {}).get('include_video', 'YES') }}"
+
+    - id: quick_validate
+      kind: agent
+      skill: filesystem
+      depends_on: [media_bind_validate]
+      with:
+        task: |
+          Quick path-level sanity pass over the generated local webpage project.
+
+          Fixed ClawHub skill URL: https://clawhub.ai/gtrusler/clawdbot-filesystem
+          Use only the per-project root:
+          {{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}
+          Do not choose a new output directory and do not install another filesystem skill.
+
+          Expected tree:
+          - project/index.html
+          - project/style.css
+          - project/script.js
+          - project/assets/images
+          - project/assets/audio
+          - project/assets/video
+
+          Allowed operations (path-level only, no content reads):
+          - `test -f` each of the three authored files; report MISSING_FILE
+            with the specific path for any missing one.
+          - `ls` the three asset directories; missing dirs are warnings, not
+            failures. `mkdir -p` to create any missing asset directory.
+          - Normalize relative links at the path level only — do not open
+            files to check link targets.
+
+          Hard prohibitions:
+          - Do NOT run `cat`, `head`, `tail`, `sed`, `grep`, `wc`, `diff`,
+            or any content-inspection command on index.html, style.css, or
+            script.js. Trust the webpage_generation output as the source of
+            truth.
+          - Do not regenerate, rewrite, or patch authored file content. If a
+            file is missing, report it; do not synthesize a replacement.
+          - Skip any packaging step (zip/tar) — the project tree is the
+            deliverable.
+
+          Output: a 1-paragraph summary stating either VALIDATED (all three
+          authored files exist and asset directories are present) or one of
+          MISSING_FILE / MISSING_ASSETS with the specific path. Stop within
+          three shell commands.
+
+          Webpage write output:
+          {{ outputs.webpage_write | truncate(2500) }}
+
+          Media bind/validate output:
+          {{ outputs.media_bind_validate | truncate(3500) }}
+
+    - id: delivery_guide
+      kind: llm_chat
+      depends_on: [quick_validate]
+      with:
+        system: |
+          You are the Delivery Guide stage for AwesomeWebpageMetaSkill.
+          Produce concise user-facing run and edit instructions.
+        task: |
+          {{ inputs.language_instruction }}
+
+          Write a delivery guide containing:
+          - output project path from config.awesome_webpage.output_dir: {{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project
+          - how to open project/index.html locally
+          - how to replace images, audio, and video assets
+          - how to edit content in index.html, style.css, and script.js
+          - what was validated, including the deterministic media bind gate
+          - any CONFIG_NEEDED items if config values were missing
+          - do not claim a requested media modality is available unless the
+            media bind report says it is present and referenced
+
+          Validation report:
+          {{ outputs.quick_validate | truncate(5000) }}
+
+          Media bind report:
+          {{ outputs.media_bind_validate | truncate(5000) }}
+---
+
+# AwesomeWebpageMetaSkill
+
+Build a local multimedia webpage project from a topic, audience, language,
+style, and media preference request.
+
+Pipeline:
+
+1. Requirement Framing
+2. Deep Research
+3. Page Outline (section structure + media intents; no filenames)
+4. Media Acquisition (search / AIGC; producers emit `*_READY:` lines)
+5. Media Assets Collect (deterministic path + existence check)
+6. Webpage Source Generation
+7. Deterministic Webpage Write
+8. Deterministic Media Bind + Validation
+9. Local Validation
+10. Delivery Guide
+
+Provider, OpenRouter model, API key, output directory, and media strategy are
+configuration-owned. The meta-skill may pass the config contract through the
+DAG, but individual steps must not invent those values.

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
@@ -119,17 +119,17 @@ composition:
           Resolved awesome_webpage config for this run:
           provider: openrouter
           openrouter.api_key_env: OPENROUTER_API_KEY
-          openrouter.models.page_generation: moonshotai/kimi-k2.6
-          openrouter.models.image_generation: google/gemini-3-pro-image-preview
-          openrouter.models.audio_generation: openai/gpt-audio-mini
-          openrouter.models.video_generation: bytedance/seedance-2.0-fast
+          openrouter.models.page_generation: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('models', {}).get('page_generation', 'moonshotai/kimi-k2.6') }}
+          openrouter.models.image_generation: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('models', {}).get('image_generation', 'google/gemini-3-pro-image-preview') }}
+          openrouter.models.audio_generation: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('models', {}).get('audio_generation', 'openai/gpt-audio-mini') }}
+          openrouter.models.video_generation: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('models', {}).get('video_generation', 'bytedance/seedance-2.0-fast') }}
           output_dir: {{ inputs.workspace_dir }}/awesome-webpage-output
           This resolved output_dir is configured and must not be reported as CONFIG_NEEDED.
-          media_strategy.search_first: true
-          media_strategy.search_modalities: images only
-          media_strategy.direct_aigc_modalities: audio, video
-          media_strategy.aigc_fallback_when_search_empty: true
-          media_strategy.allow_remote_embeds: false
+          media_strategy.search_first: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('media_strategy', {}).get('search_first', true) }}
+          media_strategy.search_modalities: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('media_strategy', {}).get('search_modalities', ['images']) | join(', ') }}
+          media_strategy.direct_aigc_modalities: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('media_strategy', {}).get('direct_aigc_modalities', ['audio', 'video']) | join(', ') }}
+          media_strategy.aigc_fallback_when_search_empty: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('media_strategy', {}).get('aigc_fallback_when_search_empty', true) }}
+          media_strategy.allow_remote_embeds: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('media_strategy', {}).get('allow_remote_embeds', false) }}
 
           User request:
           {{ inputs.user_message | xml_escape | truncate(1600) }}
@@ -356,7 +356,7 @@ composition:
       kind: agent
       skill: web-search
       depends_on: [media_slots_normalize]
-      when: "inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') == 'YES'"
+      when: "inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') == 'YES' and inputs.get('config', {}).get('awesome_webpage', {}).get('media_strategy', {}).get('search_first', True) and 'images' in inputs.get('config', {}).get('awesome_webpage', {}).get('media_strategy', {}).get('search_modalities', ['images'])"
       with:
         query: |
           Search only for reusable webpage image candidates for this plan.
@@ -406,7 +406,11 @@ composition:
 
           Fast media policy:
           - Use the confirmed interactive choices as the source of truth.
-          - Search is image-only. Audio and video must not be evaluated through web search.
+          - Search is image-only and only runs when config.awesome_webpage.media_strategy.search_first
+            is true and `images` is present in search_modalities.
+          - When image search is disabled by config, ignore media_search output and choose
+            NEEDS_AIGC_IMAGE for requested images so the direct image generator handles them.
+          - Audio and video must not be evaluated through web search.
           - If include_images is NO, choose IMAGE_SEARCH_READY.
           - If include_images is YES, evaluate only image candidates from web-search.
           - Choose NEEDS_AIGC_IMAGE when image search is empty, unusable, off-topic,
@@ -422,6 +426,11 @@ composition:
 
           If search is empty and config.awesome_webpage.media_strategy.aigc_fallback_when_search_empty is true,
           choose NEEDS_AIGC_IMAGE. Do not choose a model here; model choice belongs to config.
+
+          Resolved media strategy:
+          search_first: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('media_strategy', {}).get('search_first', true) }}
+          search_modalities: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('media_strategy', {}).get('search_modalities', ['images']) | join(', ') }}
+          aigc_fallback_when_search_empty: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('media_strategy', {}).get('aigc_fallback_when_search_empty', true) }}
 
           Requirement framing:
           {{ outputs.requirement_framing | truncate(2000) }}
@@ -525,8 +534,8 @@ composition:
       depends_on: [media_strategy, image_download, media_slots_normalize]
       when: "inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') == 'YES' and (outputs.media_strategy == 'NEEDS_AIGC_IMAGE' or 'IMAGE_DOWNLOAD_INCOMPLETE:' in outputs.get('image_download', '') or (outputs.media_strategy == 'IMAGE_SEARCH_READY' and 'IMAGE_READY:' not in outputs.get('image_download', '')))"
       with:
-        model: google/gemini-3-pro-image-preview
-        base_url: https://openrouter.ai/api/v1
+        model: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('models', {}).get('image_generation', 'google/gemini-3-pro-image-preview') }}"
+        base_url: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('base_url', 'https://openrouter.ai/api/v1') }}"
         api_key: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('api_key', '') }}"
         output_dir: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/images"
         filename: "{{ outputs.project_slug | slugify }}.png"
@@ -549,8 +558,8 @@ composition:
       depends_on: [audio_script]
       when: "inputs.get('collected', {}).get('ask_audio', {}).get('include_audio', 'YES') == 'YES'"
       with:
-        model: openai/gpt-audio-mini
-        base_url: https://openrouter.ai/api/v1
+        model: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('models', {}).get('audio_generation', 'openai/gpt-audio-mini') }}"
+        base_url: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('base_url', 'https://openrouter.ai/api/v1') }}"
         api_key: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('api_key', '') }}"
         output_dir: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/audio"
         filename: "{{ outputs.project_slug | slugify }}-narration.wav"
@@ -601,8 +610,8 @@ composition:
       depends_on: [page_outline]
       when: "inputs.get('collected', {}).get('ask_video', {}).get('include_video', 'YES') == 'YES'"
       with:
-        model: bytedance/seedance-2.0-fast
-        base_url: https://openrouter.ai/api/v1
+        model: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('models', {}).get('video_generation', 'bytedance/seedance-2.0-fast') }}"
+        base_url: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('base_url', 'https://openrouter.ai/api/v1') }}"
         api_key: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('api_key', '') }}"
         output_dir: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/video"
         filename: "{{ outputs.project_slug | slugify }}-intro.mp4"

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
@@ -123,7 +123,7 @@ composition:
           openrouter.models.image_generation: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('models', {}).get('image_generation', 'google/gemini-3-pro-image-preview') }}
           openrouter.models.audio_generation: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('models', {}).get('audio_generation', 'openai/gpt-audio-mini') }}
           openrouter.models.video_generation: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('models', {}).get('video_generation', 'bytedance/seedance-2.0-fast') }}
-          output_dir: {{ inputs.workspace_dir }}/awesome-webpage-output
+          output_dir: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('output_dir') or (inputs.workspace_dir ~ '/awesome-webpage-output') }}
           This resolved output_dir is configured and must not be reported as CONFIG_NEEDED.
           media_strategy.search_first: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('media_strategy', {}).get('search_first', true) }}
           media_strategy.search_modalities: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('media_strategy', {}).get('search_modalities', ['images']) | join(', ') }}
@@ -344,13 +344,13 @@ composition:
         command: |
           python -m opensquilla.skills.bundled.AwesomeWebpageMetaSkill.scripts.media_slots_normalize
         timeout: 20
-        env:
-          PAGE_OUTLINE: "{{ outputs.page_outline }}"
-          REQUIREMENT_FRAMING: "{{ outputs.requirement_framing }}"
-          INCLUDE_IMAGE: "{{ inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') }}"
-          INCLUDE_AUDIO: "{{ inputs.get('collected', {}).get('ask_audio', {}).get('include_audio', 'YES') }}"
-          INCLUDE_VIDEO: "{{ inputs.get('collected', {}).get('ask_video', {}).get('include_video', 'YES') }}"
-          VISUAL_STYLE: "{{ inputs.get('collected', {}).get('ask_style', {}).get('visual_style', '') }}"
+        stdin: |
+          {"page_outline": {{ outputs.page_outline | tojson }},
+           "requirement_framing": {{ outputs.requirement_framing | tojson }},
+           "include_image": {{ inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') | tojson }},
+           "include_audio": {{ inputs.get('collected', {}).get('ask_audio', {}).get('include_audio', 'YES') | tojson }},
+           "include_video": {{ inputs.get('collected', {}).get('ask_video', {}).get('include_video', 'YES') | tojson }},
+           "visual_style": {{ inputs.get('collected', {}).get('ask_style', {}).get('visual_style', '') | tojson }}}
 
     - id: media_search
       kind: agent
@@ -451,82 +451,16 @@ composition:
           {{ outputs.media_search | truncate(3500) }}
 
     - id: image_download
-      kind: agent
-      skill: filesystem
+      kind: skill_exec
+      skill: awesome-webpage-image-download
       depends_on: [media_strategy, media_slots_normalize]
       when: "inputs.get('collected', {}).get('ask_images', {}).get('include_images', 'YES') == 'YES' and outputs.media_strategy == 'IMAGE_SEARCH_READY'"
       with:
-        task: |
-          Download searched image candidates to local disk. The normalized
-          media slots below define image SLOTS by semantic key (slot_id) and subject —
-          NOT by filename. Save each downloaded file as `<slot_id>.<ext>`
-          so the later media collection step can bind by slot_id match.
-
-          ABSOLUTE_IMAGE_DIR = {{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/images
-
-          Steps:
-          1. `mkdir -p` ABSOLUTE_IMAGE_DIR.
-          2. Read MEDIA_SLOTS_JSON below and extract `slots[]` entries where
-             `modality` is `image`. Each entry has:
-                slot_id (kebab-case key, e.g. `hero-ocean`)
-                subject (one-sentence description)
-                search_keywords (3-6 keywords)
-             This is your shopping list. Do NOT invent new slot_ids and do
-             NOT rename outline slot_ids.
-          3. For each image slot, scan the candidate URL lists below and
-             pick ONE direct image URL whose title/subject best matches the
-             slot's subject + search_keywords. Skip search-result pages,
-             login walls, and data: URIs. Stay within the URL set; do not
-             call web_search.
-          4. Save each picked URL using the slot_id as filename plus an
-             extension matching the URL or Content-Type
-             (`<slot_id>.jpg` / `.png` / `.webp`). Example: slot_id
-             `hero-ocean` + JPEG URL → `hero-ocean.jpg`. Do NOT prefix
-             with an index, do NOT pluralize.
-          5. Download with
-             `curl -L --fail --max-time 20 -o <abs_path> <url>`.
-             Run up to 4 in parallel via `xargs -P 4` or backgrounded `&`
-             followed by `wait`.
-          6. After all downloads complete, `ls -la` ABSOLUTE_IMAGE_DIR.
-          7. Validate every file is a real image:
-             `file --mime-type <abs_path>` and drop anything not
-             `image/jpeg|image/png|image/webp|image/gif`. HTML pages
-             masquerading as `.jpg` count as failed downloads.
-          8. Return one JSON object:
-             {downloaded: [{slot_id, url, local_path, bytes}],
-              unfilled: [{slot_id, reason}],
-              skipped: [{url, reason}]}.
-             `unfilled` lists outline slot_ids that no candidate covered;
-             the downstream image_aigc step handles missing image slots.
-          9. After the JSON object, emit one `IMAGE_READY:` line per
-             surviving file so media collection and the webpage generator can
-             pick them up:
-             `IMAGE_READY: {"local_path": "project/assets/images/<slot_id>.<ext>", "mime": "<mime>", "bytes": <int>, "slot_id": "<slot_id>", "subject": "<subject from outline>"}`
-             `local_path` MUST be the relative `project/assets/images/...`
-             form. Never an absolute path.
-          10. If no image survives validation OR any outline image slot remains
-              unfilled, emit one final single-line marker:
-              `IMAGE_DOWNLOAD_INCOMPLETE: {"reason": "<short reason>", "unfilled_slot_ids": ["<slot_id>", "..."]}`.
-              This marker lets the next step generate only the missing image
-              slots instead of leaving load-bearing replacement slots.
-
-          Hard rules:
-          - Total budget 90 s. If wall-clock exceeds this, stop and return
-            whatever is on disk; do not retry.
-          - Do not call web_search, web_fetch, or any LLM tool here. Just curl.
-          - Do not read image bytes back. Trust `curl --fail` exit codes and
-            on-disk presence as evidence.
-          - URLs that return non-2xx are dropped silently — do not retry,
-            and do not perform AIGC inside this step. The downstream image_aigc
-            step handles fallback when `IMAGE_DOWNLOAD_INCOMPLETE:` is present
-            or when no `IMAGE_READY:` line was produced.
-
-          MEDIA_SLOTS_JSON (extract `modality: image` slots — slot_ids are
-          authoritative):
-          {{ outputs.media_slots_normalize | truncate(3500) }}
-
-          Primary search URLs:
-          {{ outputs.media_search | truncate(3000) }}
+        output_dir: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('output_dir') or (inputs.workspace_dir ~ '/awesome-webpage-output') }}/{{ outputs.project_slug | slugify }}/project/assets/images"
+        local_path_prefix: project/assets/images
+        payload: |
+          {"media_slots": {{ outputs.media_slots_normalize | tojson }},
+           "media_search": {{ outputs.media_search | tojson }}}
 
     - id: image_aigc
       kind: skill_exec
@@ -537,10 +471,11 @@ composition:
         model: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('models', {}).get('image_generation', 'google/gemini-3-pro-image-preview') }}"
         base_url: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('base_url', 'https://openrouter.ai/api/v1') }}"
         api_key: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('api_key', '') }}"
-        output_dir: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/images"
+        api_key_env: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('api_key_env', 'OPENROUTER_API_KEY') }}"
+        output_dir: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('output_dir') or (inputs.workspace_dir ~ '/awesome-webpage-output') }}/{{ outputs.project_slug | slugify }}/project/assets/images"
         filename: "{{ outputs.project_slug | slugify }}.png"
         resolution: "1K"
-        max_images: "6"
+        max_images: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('media_strategy', {}).get('target_assets', {}).get('images', 6) }}"
         local_path_prefix: project/assets/images
         payload: |
           {
@@ -561,7 +496,8 @@ composition:
         model: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('models', {}).get('audio_generation', 'openai/gpt-audio-mini') }}"
         base_url: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('base_url', 'https://openrouter.ai/api/v1') }}"
         api_key: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('api_key', '') }}"
-        output_dir: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/audio"
+        api_key_env: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('api_key_env', 'OPENROUTER_API_KEY') }}"
+        output_dir: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('output_dir') or (inputs.workspace_dir ~ '/awesome-webpage-output') }}/{{ outputs.project_slug | slugify }}/project/assets/audio"
         filename: "{{ outputs.project_slug | slugify }}-narration.wav"
         voice: cedar
         payload: |
@@ -613,7 +549,8 @@ composition:
         model: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('models', {}).get('video_generation', 'bytedance/seedance-2.0-fast') }}"
         base_url: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('base_url', 'https://openrouter.ai/api/v1') }}"
         api_key: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('api_key', '') }}"
-        output_dir: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/video"
+        api_key_env: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('api_key_env', 'OPENROUTER_API_KEY') }}"
+        output_dir: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('output_dir') or (inputs.workspace_dir ~ '/awesome-webpage-output') }}/{{ outputs.project_slug | slugify }}/project/assets/video"
         filename: "{{ outputs.project_slug | slugify }}-intro.mp4"
         duration: "10"
         aspect_ratio: "16:9"
@@ -645,7 +582,7 @@ composition:
           python -m opensquilla.skills.bundled.AwesomeWebpageMetaSkill.scripts.media_assets_collect
         timeout: 30
         env:
-          PROJECT_ROOT: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project"
+          PROJECT_ROOT: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('output_dir') or (inputs.workspace_dir ~ '/awesome-webpage-output') }}/{{ outputs.project_slug | slugify }}/project"
           IMAGE_DOWNLOAD: "{{ outputs.get('image_download', '') }}"
           IMAGE_AIGC: "{{ outputs.get('image_aigc', '') }}"
           AUDIO_AIGC: "{{ outputs.get('audio_aigc', '') }}"
@@ -821,7 +758,7 @@ composition:
         stdin: "{{ (outputs.get('webpage_generation_retry', '') or outputs.webpage_generation) | tojson }}"
         env:
           WORKSPACE_DIR: "{{ inputs.workspace_dir }}"
-          PROJECT_ROOT: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}"
+          PROJECT_ROOT: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('output_dir') or (inputs.workspace_dir ~ '/awesome-webpage-output') }}/{{ outputs.project_slug | slugify }}"
 
     - id: media_bind_validate
       kind: tool_call
@@ -833,7 +770,7 @@ composition:
           python -m opensquilla.skills.bundled.AwesomeWebpageMetaSkill.scripts.media_bind_validate
         timeout: 30
         env:
-          PROJECT_ROOT: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}"
+          PROJECT_ROOT: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('output_dir') or (inputs.workspace_dir ~ '/awesome-webpage-output') }}/{{ outputs.project_slug | slugify }}"
           IMAGE_DOWNLOAD: "{{ outputs.get('image_download', '') }}"
           IMAGE_AIGC: "{{ outputs.get('image_aigc', '') }}"
           AUDIO_AIGC: "{{ outputs.get('audio_aigc', '') }}"
@@ -852,7 +789,7 @@ composition:
 
           Fixed ClawHub skill URL: https://clawhub.ai/gtrusler/clawdbot-filesystem
           Use only the per-project root:
-          {{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}
+          {{ inputs.get('config', {}).get('awesome_webpage', {}).get('output_dir') or (inputs.workspace_dir ~ '/awesome-webpage-output') }}/{{ outputs.project_slug | slugify }}
           Do not choose a new output directory and do not install another filesystem skill.
 
           Expected tree:
@@ -903,7 +840,7 @@ composition:
           {{ inputs.language_instruction }}
 
           Write a delivery guide containing:
-          - output project path from config.awesome_webpage.output_dir: {{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project
+          - output project path from config.awesome_webpage.output_dir: {{ inputs.get('config', {}).get('awesome_webpage', {}).get('output_dir') or (inputs.workspace_dir ~ '/awesome-webpage-output') }}/{{ outputs.project_slug | slugify }}/project
           - how to open project/index.html locally
           - how to replace images, audio, and video assets
           - how to edit content in index.html, style.css, and script.js

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
@@ -792,10 +792,10 @@ composition:
         command: |
           python -m opensquilla.skills.bundled.AwesomeWebpageMetaSkill.scripts.webpage_write
         timeout: 30
+        stdin: "{{ (outputs.get('webpage_generation_retry', '') or outputs.webpage_generation) | tojson }}"
         env:
           WORKSPACE_DIR: "{{ inputs.workspace_dir }}"
           PROJECT_ROOT: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}"
-          WEBPAGE_SOURCE_JSON: "{{ (outputs.get('webpage_generation_retry', '') or outputs.webpage_generation) | tojson }}"
 
     - id: media_bind_validate
       kind: tool_call

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
@@ -371,8 +371,9 @@ composition:
           - Do NOT run any local Python script (no `python scripts/search.py`,
             no `duckduckgo-search`, no `pip install`).
           - Do NOT call `web_fetch`. Snippets from `web_search` are enough.
-          - Issue at most 2 `web_search` calls, each with `type=images` and
-            `max_results=6`, grouped by visual theme — do not search per asset.
+          - Issue at most 2 `web_search` calls, each using only the supported
+            arguments `query` and `max_results=6`; include image intent in the
+            query text itself, grouped by visual theme — do not search per asset.
           - Stop as soon as you have ~4-6 usable candidates total.
           - If results are empty, unusable, off-topic, or licensing is unclear,
             stop immediately and return:

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/SKILL.md
@@ -527,6 +527,7 @@ composition:
       with:
         model: google/gemini-3-pro-image-preview
         base_url: https://openrouter.ai/api/v1
+        api_key: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('api_key', '') }}"
         output_dir: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/images"
         filename: "{{ outputs.project_slug | slugify }}.png"
         resolution: "1K"
@@ -550,6 +551,7 @@ composition:
       with:
         model: openai/gpt-audio-mini
         base_url: https://openrouter.ai/api/v1
+        api_key: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('api_key', '') }}"
         output_dir: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/audio"
         filename: "{{ outputs.project_slug | slugify }}-narration.wav"
         voice: cedar
@@ -601,6 +603,7 @@ composition:
       with:
         model: bytedance/seedance-2.0-fast
         base_url: https://openrouter.ai/api/v1
+        api_key: "{{ inputs.get('config', {}).get('awesome_webpage', {}).get('openrouter', {}).get('api_key', '') }}"
         output_dir: "{{ inputs.workspace_dir }}/awesome-webpage-output/{{ outputs.project_slug | slugify }}/project/assets/video"
         filename: "{{ outputs.project_slug | slugify }}-intro.mp4"
         duration: "10"

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/__init__.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled AwesomeWebpage meta skill package."""

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/__init__.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic helper scripts for AwesomeWebpageMetaSkill."""

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_assets_collect.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_assets_collect.py
@@ -1,0 +1,94 @@
+import json
+import os
+import re
+from pathlib import Path
+
+project_root = Path(os.environ["PROJECT_ROOT"]).expanduser().resolve()
+project_parent = project_root.parent
+
+ready_re = re.compile(r"^(IMAGE|AUDIO|VIDEO)_READY:\s*(\{.*\})\s*$", re.M)
+fail_re = re.compile(r"^(IMAGE|AUDIO|VIDEO)_(CONFIG_NEEDED|GENERATION_FAILED|MODEL_UNSUPPORTED):\s*(\{.*\})\s*$", re.M)
+sources = {
+    "image_download": os.environ.get("IMAGE_DOWNLOAD", ""),
+    "image_aigc": os.environ.get("IMAGE_AIGC", ""),
+    "audio_aigc": os.environ.get("AUDIO_AIGC", ""),
+    "video_aigc": os.environ.get("VIDEO_AIGC", ""),
+}
+
+def load_payload(raw):
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+def normalize_path(value):
+    raw = str(value or "").strip().replace("\\", "/")
+    if not raw or raw.startswith("/") or ".." in Path(raw).parts:
+        return None, None
+    if raw.startswith("project/"):
+        src = raw[len("project/"):]
+        disk = project_parent / raw
+    else:
+        src = raw
+        disk = project_root / raw
+    if not src.startswith(("assets/images/", "assets/audio/", "assets/video/")):
+        return None, None
+    return src, disk
+
+assets = []
+missing_assets = []
+generation_failures = []
+invalid_records = []
+
+for source, text in sources.items():
+    for match in ready_re.finditer(text):
+        kind = match.group(1).lower()
+        payload = load_payload(match.group(2))
+        if payload is None:
+            invalid_records.append({"source": source, "kind": kind, "reason": "invalid_ready_json"})
+            continue
+        src, disk = normalize_path(payload.get("local_path"))
+        if src is None or disk is None:
+            invalid_records.append({"source": source, "kind": kind, "reason": "invalid_local_path", "local_path": payload.get("local_path")})
+            continue
+        record = {
+            "kind": kind,
+            "src": src,
+            "local_path": payload.get("local_path"),
+            "source_step": source,
+            "mime": payload.get("mime"),
+            "slot_id": payload.get("slot_id"),
+            "subject": payload.get("subject") or payload.get("prompt_preview") or payload.get("script_preview"),
+        }
+        if disk.is_file():
+            size = disk.stat().st_size
+            record["bytes"] = size
+            assets.append(record)
+        else:
+            record["reason"] = "file_missing"
+            missing_assets.append(record)
+
+    for match in fail_re.finditer(text):
+        kind = match.group(1).lower()
+        label = f"{match.group(1)}_{match.group(2)}"
+        payload = load_payload(match.group(3)) or {}
+        replacement_src, _ = normalize_path(payload.get("replacement_slot"))
+        generation_failures.append({
+            "kind": kind,
+            "label": label,
+            "source_step": source,
+            "replacement_src": replacement_src,
+            "missing": payload.get("missing", []),
+            "reason": payload.get("reason") or payload.get("status") or payload.get("phase"),
+        })
+
+manifest = {
+    "project_root": str(project_root),
+    "assets": assets,
+    "missing_assets": missing_assets,
+    "generation_failures": generation_failures,
+    "invalid_records": invalid_records,
+    "path_policy": "Use assets[].src for HTML/CSS/JS references. Do not use raw project/assets local_path values as browser src paths.",
+}
+print(json.dumps(manifest, ensure_ascii=True, separators=(",", ":")))

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_bind_validate.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_bind_validate.py
@@ -2,6 +2,7 @@ import html
 import json
 import os
 import re
+from html.parser import HTMLParser
 from pathlib import Path
 
 project_root = Path(os.environ["PROJECT_ROOT"]).expanduser().resolve()
@@ -27,6 +28,50 @@ def normalize_path(value):
         if not src.startswith(("assets/images/", "assets/audio/", "assets/video/")):
             return None, None
     return src, disk
+
+
+def normalize_browser_src(value):
+    src = str(value or "").strip().replace("\\", "/")
+    while src.startswith("./"):
+        src = src[2:]
+    src = src.split("?", 1)[0].split("#", 1)[0]
+    return src or None
+
+
+class MediaSourceParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.sources = {"audio": set(), "video": set()}
+        self.media_stack = []
+
+    def handle_starttag(self, tag, attrs):
+        tag = tag.lower()
+        attr_map = {name.lower(): value for name, value in attrs}
+        if tag in self.sources:
+            self.media_stack.append(tag)
+            src = normalize_browser_src(attr_map.get("src"))
+            if src:
+                self.sources[tag].add(src)
+        elif tag == "source" and self.media_stack:
+            src = normalize_browser_src(attr_map.get("src"))
+            if src:
+                self.sources[self.media_stack[-1]].add(src)
+
+    def handle_endtag(self, tag):
+        tag = tag.lower()
+        if tag not in self.sources:
+            return
+        for idx in range(len(self.media_stack) - 1, -1, -1):
+            if self.media_stack[idx] == tag:
+                del self.media_stack[idx:]
+                return
+
+
+def media_sources_by_kind(index_html):
+    parser = MediaSourceParser()
+    parser.feed(index_html)
+    return parser.sources
+
 
 def collect_assets():
     ready_re = re.compile(r"^(IMAGE|AUDIO|VIDEO)_READY:\s*(\{.*\})\s*$", re.M)
@@ -97,6 +142,7 @@ style_css = style_path.read_text(encoding="utf-8")
 script_js = script_path.read_text(encoding="utf-8")
 combined = "\n".join([index_html, style_css, script_js])
 lower_html = index_html.lower()
+media_sources = media_sources_by_kind(index_html)
 
 repair_map = {}
 for asset in assets:
@@ -104,11 +150,11 @@ for asset in assets:
         repair_map[(asset["kind"], asset["src"])] = asset
 audio_assets = [asset for asset in assets if asset["kind"] == "audio"]
 video_assets = [asset for asset in assets if asset["kind"] == "video"]
-if audio_assets and ("<audio" not in lower_html or not any(asset["src"] in index_html for asset in audio_assets)):
-    for asset in audio_assets:
+for asset in audio_assets:
+    if asset["src"] not in media_sources["audio"]:
         repair_map[(asset["kind"], asset["src"])] = asset
-if video_assets and ("<video" not in lower_html or not any(asset["src"] in index_html for asset in video_assets)):
-    for asset in video_assets:
+for asset in video_assets:
+    if asset["src"] not in media_sources["video"]:
         repair_map[(asset["kind"], asset["src"])] = asset
 
 if repair_map:
@@ -245,6 +291,7 @@ style_css = style_path.read_text(encoding="utf-8")
 script_js = script_path.read_text(encoding="utf-8")
 combined = "\n".join([index_html, style_css, script_js])
 lower_html = index_html.lower()
+media_sources = media_sources_by_kind(index_html)
 assets_by_kind = {"image": [], "audio": [], "video": []}
 for asset in assets:
     assets_by_kind[asset["kind"]].append(asset)
@@ -271,10 +318,14 @@ for kind, is_required in required.items():
     for asset in assets_by_kind[kind]:
         if asset["src"] not in combined:
             failures.append({"kind": kind, "reason": "asset_not_referenced_by_page", "src": asset["src"]})
-    if kind == "audio" and ("<audio" not in lower_html or not any(a["src"] in index_html for a in assets_by_kind[kind])):
-        failures.append({"kind": kind, "reason": "audio_control_missing_or_unbound"})
-    if kind == "video" and ("<video" not in lower_html or not any(a["src"] in index_html for a in assets_by_kind[kind])):
-        failures.append({"kind": kind, "reason": "video_control_missing_or_unbound"})
+    if kind in {"audio", "video"}:
+        for asset in assets_by_kind[kind]:
+            if asset["src"] not in media_sources[kind]:
+                failures.append({
+                    "kind": kind,
+                    "reason": f"{kind}_control_missing_or_unbound",
+                    "src": asset["src"],
+                })
 requested_degraded = {
     kind: items
     for kind, items in degraded_by_kind.items()

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_bind_validate.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_bind_validate.py
@@ -67,11 +67,15 @@ def collect_assets():
                 payload = json.loads(match.group(3))
             except json.JSONDecodeError:
                 payload = {}
+            replacement_src, _ = normalize_path(payload.get("replacement_slot"))
             generation_failures.append({
                 "kind": match.group(1).lower(),
                 "label": f"{match.group(1)}_{match.group(2)}",
                 "source_step": source,
                 "reason": payload.get("reason") or payload.get("status") or payload.get("phase"),
+                "missing": payload.get("missing", []),
+                "replacement_slot": payload.get("replacement_slot"),
+                "replacement_src": replacement_src,
             })
     return assets, generation_failures
 
@@ -244,12 +248,24 @@ lower_html = index_html.lower()
 assets_by_kind = {"image": [], "audio": [], "video": []}
 for asset in assets:
     assets_by_kind[asset["kind"]].append(asset)
+degraded_by_kind = {"image": [], "audio": [], "video": []}
+fatal_generation_failures_by_kind = {"image": [], "audio": [], "video": []}
+for failure in generation_failures:
+    kind = failure.get("kind")
+    label = str(failure.get("label") or "")
+    if kind in degraded_by_kind:
+        if label.endswith(("_CONFIG_NEEDED", "_MODEL_UNSUPPORTED")):
+            degraded_by_kind[kind].append(failure)
+        else:
+            fatal_generation_failures_by_kind[kind].append(failure)
 
 required = {"image": requested("image"), "audio": requested("audio"), "video": requested("video")}
 for kind, is_required in required.items():
     if not is_required:
         continue
     if not assets_by_kind[kind]:
+        if degraded_by_kind[kind] and not fatal_generation_failures_by_kind[kind]:
+            continue
         failures.append({"kind": kind, "reason": "requested_modality_has_no_ready_asset"})
         continue
     for asset in assets_by_kind[kind]:
@@ -259,9 +275,16 @@ for kind, is_required in required.items():
         failures.append({"kind": kind, "reason": "audio_control_missing_or_unbound"})
     if kind == "video" and ("<video" not in lower_html or not any(a["src"] in index_html for a in assets_by_kind[kind])):
         failures.append({"kind": kind, "reason": "video_control_missing_or_unbound"})
+requested_degraded = {
+    kind: items
+    for kind, items in degraded_by_kind.items()
+    if required[kind] and items
+}
 
 report = {
-    "status": "MEDIA_BIND_OK" if not failures else "MEDIA_BIND_FAILED",
+    "status": "MEDIA_BIND_FAILED" if failures else (
+        "MEDIA_BIND_DEGRADED" if requested_degraded else "MEDIA_BIND_OK"
+    ),
     "requested": required,
     "ready_counts": {kind: len(items) for kind, items in assets_by_kind.items()},
     "referenced": {
@@ -269,6 +292,7 @@ report = {
         for kind, items in assets_by_kind.items()
     },
     "patched_assets": [asset["src"] for asset in repair_map.values()],
+    "degraded": requested_degraded,
     "generation_failures": generation_failures,
     "failures": failures,
 }

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_bind_validate.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_bind_validate.py
@@ -280,10 +280,20 @@ requested_degraded = {
     for kind, items in degraded_by_kind.items()
     if required[kind] and items
 }
+partial_generation_failures = {
+    kind: items
+    for kind, items in fatal_generation_failures_by_kind.items()
+    if required[kind] and assets_by_kind[kind] and items
+}
+reported_degraded = {
+    kind: requested_degraded.get(kind, []) + partial_generation_failures.get(kind, [])
+    for kind in assets_by_kind
+    if requested_degraded.get(kind) or partial_generation_failures.get(kind)
+}
 
 report = {
     "status": "MEDIA_BIND_FAILED" if failures else (
-        "MEDIA_BIND_DEGRADED" if requested_degraded else "MEDIA_BIND_OK"
+        "MEDIA_BIND_DEGRADED" if reported_degraded else "MEDIA_BIND_OK"
     ),
     "requested": required,
     "ready_counts": {kind: len(items) for kind, items in assets_by_kind.items()},
@@ -292,7 +302,8 @@ report = {
         for kind, items in assets_by_kind.items()
     },
     "patched_assets": [asset["src"] for asset in repair_map.values()],
-    "degraded": requested_degraded,
+    "degraded": reported_degraded,
+    "partial_generation_failures": partial_generation_failures,
     "generation_failures": generation_failures,
     "failures": failures,
 }

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_bind_validate.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_bind_validate.py
@@ -38,38 +38,91 @@ def normalize_browser_src(value):
     return src or None
 
 
+def srcset_sources(value):
+    sources = []
+    for part in str(value or "").split(","):
+        candidate = part.strip().split()
+        if not candidate:
+            continue
+        src = normalize_browser_src(candidate[0])
+        if src:
+            sources.append(src)
+    return sources
+
+
+def css_url_sources(value):
+    sources = []
+    for match in re.finditer(r"url\(\s*['\"]?([^'\"\)]+)['\"]?\s*\)", str(value or ""), re.I):
+        src = normalize_browser_src(match.group(1))
+        if src:
+            sources.append(src)
+    return sources
+
+
 class MediaSourceParser(HTMLParser):
     def __init__(self):
         super().__init__()
-        self.sources = {"audio": set(), "video": set()}
+        self.sources = {"image": set(), "audio": set(), "video": set()}
         self.media_stack = []
+        self.picture_depth = 0
+        self.style_depth = 0
+        self.style_chunks = []
+
+    def add_sources(self, kind, *values):
+        for value in values:
+            src = normalize_browser_src(value)
+            if src:
+                self.sources[kind].add(src)
+
+    def add_srcset_sources(self, kind, value):
+        for src in srcset_sources(value):
+            self.sources[kind].add(src)
 
     def handle_starttag(self, tag, attrs):
         tag = tag.lower()
         attr_map = {name.lower(): value for name, value in attrs}
-        if tag in self.sources:
+        for src in css_url_sources(attr_map.get("style")):
+            self.sources["image"].add(src)
+        if tag == "style":
+            self.style_depth += 1
+        elif tag == "picture":
+            self.picture_depth += 1
+        elif tag == "img":
+            self.add_sources("image", attr_map.get("src"))
+            self.add_srcset_sources("image", attr_map.get("srcset"))
+        elif tag in {"audio", "video"}:
             self.media_stack.append(tag)
-            src = normalize_browser_src(attr_map.get("src"))
-            if src:
-                self.sources[tag].add(src)
+            self.add_sources(tag, attr_map.get("src"))
         elif tag == "source" and self.media_stack:
-            src = normalize_browser_src(attr_map.get("src"))
-            if src:
-                self.sources[self.media_stack[-1]].add(src)
+            self.add_sources(self.media_stack[-1], attr_map.get("src"))
+        elif tag == "source" and self.picture_depth:
+            self.add_sources("image", attr_map.get("src"))
+            self.add_srcset_sources("image", attr_map.get("srcset"))
+
+    def handle_data(self, data):
+        if self.style_depth:
+            self.style_chunks.append(data)
 
     def handle_endtag(self, tag):
         tag = tag.lower()
-        if tag not in self.sources:
-            return
-        for idx in range(len(self.media_stack) - 1, -1, -1):
-            if self.media_stack[idx] == tag:
-                del self.media_stack[idx:]
-                return
+        if tag == "style" and self.style_depth:
+            self.style_depth -= 1
+        elif tag == "picture" and self.picture_depth:
+            self.picture_depth -= 1
+        elif tag in {"audio", "video"}:
+            for idx in range(len(self.media_stack) - 1, -1, -1):
+                if self.media_stack[idx] == tag:
+                    del self.media_stack[idx:]
+                    return
 
 
-def media_sources_by_kind(index_html):
+def rendered_sources_by_kind(index_html, style_css):
     parser = MediaSourceParser()
     parser.feed(index_html)
+    for src in css_url_sources(style_css):
+        parser.sources["image"].add(src)
+    for src in css_url_sources("\n".join(parser.style_chunks)):
+        parser.sources["image"].add(src)
     return parser.sources
 
 
@@ -142,19 +195,23 @@ style_css = style_path.read_text(encoding="utf-8")
 script_js = script_path.read_text(encoding="utf-8")
 combined = "\n".join([index_html, style_css, script_js])
 lower_html = index_html.lower()
-media_sources = media_sources_by_kind(index_html)
+rendered_sources = rendered_sources_by_kind(index_html, style_css)
 
 repair_map = {}
 for asset in assets:
     if asset["src"] not in combined:
         repair_map[(asset["kind"], asset["src"])] = asset
+image_assets = [asset for asset in assets if asset["kind"] == "image"]
 audio_assets = [asset for asset in assets if asset["kind"] == "audio"]
 video_assets = [asset for asset in assets if asset["kind"] == "video"]
+for asset in image_assets:
+    if asset["src"] not in rendered_sources["image"]:
+        repair_map[(asset["kind"], asset["src"])] = asset
 for asset in audio_assets:
-    if asset["src"] not in media_sources["audio"]:
+    if asset["src"] not in rendered_sources["audio"]:
         repair_map[(asset["kind"], asset["src"])] = asset
 for asset in video_assets:
-    if asset["src"] not in media_sources["video"]:
+    if asset["src"] not in rendered_sources["video"]:
         repair_map[(asset["kind"], asset["src"])] = asset
 
 if repair_map:
@@ -291,7 +348,7 @@ style_css = style_path.read_text(encoding="utf-8")
 script_js = script_path.read_text(encoding="utf-8")
 combined = "\n".join([index_html, style_css, script_js])
 lower_html = index_html.lower()
-media_sources = media_sources_by_kind(index_html)
+rendered_sources = rendered_sources_by_kind(index_html, style_css)
 assets_by_kind = {"image": [], "audio": [], "video": []}
 for asset in assets:
     assets_by_kind[asset["kind"]].append(asset)
@@ -318,9 +375,17 @@ for kind, is_required in required.items():
     for asset in assets_by_kind[kind]:
         if asset["src"] not in combined:
             failures.append({"kind": kind, "reason": "asset_not_referenced_by_page", "src": asset["src"]})
+    if kind == "image":
+        for asset in assets_by_kind[kind]:
+            if asset["src"] not in rendered_sources[kind]:
+                failures.append({
+                    "kind": kind,
+                    "reason": "image_render_missing_or_unbound",
+                    "src": asset["src"],
+                })
     if kind in {"audio", "video"}:
         for asset in assets_by_kind[kind]:
-            if asset["src"] not in media_sources[kind]:
+            if asset["src"] not in rendered_sources[kind]:
                 failures.append({
                     "kind": kind,
                     "reason": f"{kind}_control_missing_or_unbound",

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_bind_validate.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_bind_validate.py
@@ -1,0 +1,277 @@
+import html
+import json
+import os
+import re
+from pathlib import Path
+
+project_root = Path(os.environ["PROJECT_ROOT"]).expanduser().resolve()
+project_dir = project_root / "project"
+index_path = project_dir / "index.html"
+style_path = project_dir / "style.css"
+script_path = project_dir / "script.js"
+
+def requested(name):
+    return os.environ.get(f"INCLUDE_{name.upper()}", "YES") == "YES"
+
+def normalize_path(value):
+    raw = str(value or "").strip().replace("\\", "/")
+    if not raw or raw.startswith("/") or ".." in Path(raw).parts:
+        return None, None
+    if raw.startswith("project/"):
+        src = raw[len("project/"):]
+        disk = project_root / raw
+    else:
+        src = raw
+        disk = project_dir / raw
+    if not raw.startswith(("assets/images/", "assets/audio/", "assets/video/")):
+        if not src.startswith(("assets/images/", "assets/audio/", "assets/video/")):
+            return None, None
+    return src, disk
+
+def collect_assets():
+    ready_re = re.compile(r"^(IMAGE|AUDIO|VIDEO)_READY:\s*(\{.*\})\s*$", re.M)
+    fail_re = re.compile(r"^(IMAGE|AUDIO|VIDEO)_(CONFIG_NEEDED|GENERATION_FAILED|MODEL_UNSUPPORTED):\s*(\{.*\})\s*$", re.M)
+    sources = {
+        "image_download": os.environ.get("IMAGE_DOWNLOAD", ""),
+        "image_aigc": os.environ.get("IMAGE_AIGC", ""),
+        "audio_aigc": os.environ.get("AUDIO_AIGC", ""),
+        "video_aigc": os.environ.get("VIDEO_AIGC", ""),
+    }
+    assets = []
+    generation_failures = []
+    seen = set()
+    for source, text in sources.items():
+        for match in ready_re.finditer(text):
+            kind = match.group(1).lower()
+            try:
+                payload = json.loads(match.group(2))
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            src, disk = normalize_path(payload.get("local_path"))
+            if src is None or disk is None or not disk.is_file() or disk.stat().st_size <= 0:
+                continue
+            key = (kind, src)
+            if key in seen:
+                continue
+            seen.add(key)
+            assets.append({
+                "kind": kind,
+                "src": src,
+                "bytes": disk.stat().st_size,
+                "subject": str(payload.get("subject") or payload.get("slot_id") or payload.get("prompt_preview") or payload.get("script_preview") or src),
+            })
+        for match in fail_re.finditer(text):
+            try:
+                payload = json.loads(match.group(3))
+            except json.JSONDecodeError:
+                payload = {}
+            generation_failures.append({
+                "kind": match.group(1).lower(),
+                "label": f"{match.group(1)}_{match.group(2)}",
+                "source_step": source,
+                "reason": payload.get("reason") or payload.get("status") or payload.get("phase"),
+            })
+    return assets, generation_failures
+
+failures = []
+for path, label in [
+    (index_path, "project/index.html"),
+    (style_path, "project/style.css"),
+    (script_path, "project/script.js"),
+]:
+    if not path.is_file():
+        failures.append({"kind": "page", "reason": "missing_authored_file", "path": label})
+if failures:
+    print(json.dumps({"status": "MEDIA_BIND_FAILED", "failures": failures}, ensure_ascii=True, separators=(",", ":")))
+    raise SystemExit("MEDIA_BIND_FAILED")
+
+assets, generation_failures = collect_assets()
+index_html = index_path.read_text(encoding="utf-8")
+style_css = style_path.read_text(encoding="utf-8")
+script_js = script_path.read_text(encoding="utf-8")
+combined = "\n".join([index_html, style_css, script_js])
+lower_html = index_html.lower()
+
+repair_map = {}
+for asset in assets:
+    if asset["src"] not in combined:
+        repair_map[(asset["kind"], asset["src"])] = asset
+audio_assets = [asset for asset in assets if asset["kind"] == "audio"]
+video_assets = [asset for asset in assets if asset["kind"] == "video"]
+if audio_assets and ("<audio" not in lower_html or not any(asset["src"] in index_html for asset in audio_assets)):
+    for asset in audio_assets:
+        repair_map[(asset["kind"], asset["src"])] = asset
+if video_assets and ("<video" not in lower_html or not any(asset["src"] in index_html for asset in video_assets)):
+    for asset in video_assets:
+        repair_map[(asset["kind"], asset["src"])] = asset
+
+if repair_map:
+    repair_assets = list(repair_map.values())
+    images = [asset for asset in repair_assets if asset["kind"] == "image"]
+    audio = [asset for asset in repair_assets if asset["kind"] == "audio"]
+    video = [asset for asset in repair_assets if asset["kind"] == "video"]
+    blocks = [
+        '<section id="generated-media-assets" class="generated-media-assets" aria-labelledby="generated-media-title">',
+        '  <div class="generated-media-assets__inner">',
+        '    <p class="generated-media-assets__eyebrow">Generated media</p>',
+        '    <h2 id="generated-media-title">本地生成媒体</h2>',
+        '    <p class="generated-media-assets__intro">以下素材已生成并绑定到页面，可直接播放或替换同名文件。</p>',
+    ]
+    for asset in audio:
+        label = html.escape(asset["subject"][:120])
+        src = html.escape(asset["src"], quote=True)
+        blocks.extend([
+            '    <article class="generated-media-card generated-media-card--audio">',
+            '      <div><h3>音频导览</h3>',
+            f'      <p>{label}</p></div>',
+            f'      <audio controls preload="metadata" src="{src}"></audio>',
+            '    </article>',
+        ])
+    for asset in video:
+        label = html.escape(asset["subject"][:120])
+        src = html.escape(asset["src"], quote=True)
+        blocks.extend([
+            '    <article class="generated-media-card generated-media-card--video">',
+            '      <div><h3>视频片段</h3>',
+            f'      <p>{label}</p></div>',
+            f'      <video controls playsinline preload="metadata" src="{src}"></video>',
+            '    </article>',
+        ])
+    if images:
+        blocks.append('    <div class="generated-media-gallery" aria-label="生成图片素材">')
+        for asset in images:
+            label = html.escape(asset["subject"][:120])
+            src = html.escape(asset["src"], quote=True)
+            blocks.extend([
+                '      <figure>',
+                f'        <img loading="lazy" src="{src}" alt="{label}">',
+                f'        <figcaption>{label}</figcaption>',
+                '      </figure>',
+            ])
+        blocks.append('    </div>')
+    blocks.extend(['  </div>', '</section>'])
+    repair_html = "\n".join(blocks)
+    insert_idx = lower_html.rfind("</main>")
+    if insert_idx < 0:
+        insert_idx = lower_html.rfind("</body>")
+    if insert_idx >= 0:
+        index_html = index_html[:insert_idx] + repair_html + "\n" + index_html[insert_idx:]
+    else:
+        index_html += "\n" + repair_html + "\n"
+    if ".generated-media-assets" not in style_css:
+        style_css += """
+
+.generated-media-assets {
+  background: #f5f7fb;
+  color: #15202b;
+  padding: clamp(2rem, 6vw, 5rem) clamp(1rem, 4vw, 3rem);
+}
+.generated-media-assets__inner {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+.generated-media-assets__eyebrow {
+  margin: 0 0 .5rem;
+  color: #0f766e;
+  font-size: .78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.generated-media-assets h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.75rem, 4vw, 3.25rem);
+  line-height: 1.08;
+}
+.generated-media-assets__intro {
+  max-width: 64ch;
+  margin: 0 0 2rem;
+  color: #475569;
+  line-height: 1.75;
+}
+.generated-media-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 460px);
+  gap: 1.5rem;
+  align-items: center;
+  padding: clamp(1rem, 3vw, 2rem);
+  margin-bottom: 1.5rem;
+  border: 1px solid rgba(15, 23, 42, .12);
+  border-radius: 8px;
+  background: #fff;
+}
+.generated-media-card audio,
+.generated-media-card video {
+  width: 100%;
+}
+.generated-media-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+.generated-media-gallery figure {
+  margin: 0;
+  overflow: hidden;
+  border-radius: 8px;
+  background: #fff;
+}
+.generated-media-gallery img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+.generated-media-gallery figcaption {
+  padding: .85rem 1rem 1rem;
+  color: #475569;
+  line-height: 1.55;
+}
+@media (max-width: 760px) {
+  .generated-media-card {
+    grid-template-columns: 1fr;
+  }
+}
+"""
+    index_path.write_text(index_html, encoding="utf-8")
+    style_path.write_text(style_css, encoding="utf-8")
+
+index_html = index_path.read_text(encoding="utf-8")
+style_css = style_path.read_text(encoding="utf-8")
+script_js = script_path.read_text(encoding="utf-8")
+combined = "\n".join([index_html, style_css, script_js])
+lower_html = index_html.lower()
+assets_by_kind = {"image": [], "audio": [], "video": []}
+for asset in assets:
+    assets_by_kind[asset["kind"]].append(asset)
+
+required = {"image": requested("image"), "audio": requested("audio"), "video": requested("video")}
+for kind, is_required in required.items():
+    if not is_required:
+        continue
+    if not assets_by_kind[kind]:
+        failures.append({"kind": kind, "reason": "requested_modality_has_no_ready_asset"})
+        continue
+    for asset in assets_by_kind[kind]:
+        if asset["src"] not in combined:
+            failures.append({"kind": kind, "reason": "asset_not_referenced_by_page", "src": asset["src"]})
+    if kind == "audio" and ("<audio" not in lower_html or not any(a["src"] in index_html for a in assets_by_kind[kind])):
+        failures.append({"kind": kind, "reason": "audio_control_missing_or_unbound"})
+    if kind == "video" and ("<video" not in lower_html or not any(a["src"] in index_html for a in assets_by_kind[kind])):
+        failures.append({"kind": kind, "reason": "video_control_missing_or_unbound"})
+
+report = {
+    "status": "MEDIA_BIND_OK" if not failures else "MEDIA_BIND_FAILED",
+    "requested": required,
+    "ready_counts": {kind: len(items) for kind, items in assets_by_kind.items()},
+    "referenced": {
+        kind: [asset["src"] for asset in items if asset["src"] in combined]
+        for kind, items in assets_by_kind.items()
+    },
+    "patched_assets": [asset["src"] for asset in repair_map.values()],
+    "generation_failures": generation_failures,
+    "failures": failures,
+}
+print(json.dumps(report, ensure_ascii=True, separators=(",", ":")))
+if failures:
+    raise SystemExit("MEDIA_BIND_FAILED")

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_slots_normalize.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_slots_normalize.py
@@ -1,13 +1,37 @@
 import json
 import os
 import re
+import sys
 
-outline = os.environ.get("PAGE_OUTLINE", "")
-requirement = os.environ.get("REQUIREMENT_FRAMING", "")
-visual_style = os.environ.get("VISUAL_STYLE", "")
+
+def load_payload():
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+payload = load_payload()
+
+outline = str(payload.get("page_outline") or os.environ.get("PAGE_OUTLINE", ""))
+requirement = str(
+    payload.get("requirement_framing") or os.environ.get("REQUIREMENT_FRAMING", "")
+)
+visual_style = str(payload.get("visual_style") or os.environ.get("VISUAL_STYLE", ""))
+
 
 def wants(name):
-    value = os.environ.get(name, "YES").strip().lower()
+    payload_name = {
+        "INCLUDE_IMAGE": "include_image",
+        "INCLUDE_AUDIO": "include_audio",
+        "INCLUDE_VIDEO": "include_video",
+    }.get(name)
+    raw = payload.get(payload_name) if payload_name else None
+    value = str(raw if raw is not None else os.environ.get(name, "YES")).strip().lower()
     return value not in {"no", "false", "0", "n", "否", "不要", "不需要"}
 
 include_image = wants("INCLUDE_IMAGE")
@@ -20,6 +44,7 @@ if include_audio:
     allowed.add("audio")
 if include_video:
     allowed.add("video")
+
 
 def clean_slot(raw, fallback):
     text = re.sub(r"[^a-zA-Z0-9_-]+", "-", str(raw or "").strip()).strip("-").lower()
@@ -95,8 +120,8 @@ def cell(cells, index):
         return ""
     return cells[index].strip().strip("`\"'")
 
-slots = []
-seen = set()
+slots: list[dict[str, object]] = []
+seen: set[str] = set()
 
 matches = list(re.finditer(r"slot_id\s*[:：]\s*([a-zA-Z0-9][a-zA-Z0-9_-]{0,80})", outline, re.I))
 for index, match in enumerate(matches):
@@ -115,7 +140,7 @@ for index, match in enumerate(matches):
         load_bearing=truthy(field(block, "load_bearing", "required", "必要")),
     )
 
-headers = None
+headers: list[str] | None = None
 for raw_line in outline.splitlines():
     cells = split_table_row(raw_line)
     if not cells:
@@ -151,10 +176,10 @@ for line in outline.splitlines():
     kind = modality(line)
     if not kind:
         continue
-    match = re.search(r"slot[_\s-]*id\s*[:：=]\s*([a-zA-Z0-9][a-zA-Z0-9_-]{0,80})", line, re.I)
-    if not match:
+    line_match = re.search(r"slot[_\s-]*id\s*[:：=]\s*([a-zA-Z0-9][a-zA-Z0-9_-]{0,80})", line, re.I)
+    if not line_match:
         continue
-    append(slots, seen, slot_id=match.group(1), kind=kind, subject=line[:500], prompt_hint=line[:500])
+    append(slots, seen, slot_id=line_match.group(1), kind=kind, subject=line[:500], prompt_hint=line[:500])
 
 def topic():
     text = re.sub(r"[#*_`|>{}\[\]\"]+", " ", requirement + "\n" + outline)
@@ -165,7 +190,7 @@ def topic():
             return match.group(1).strip()[:160]
     return (text[:160] if text else "requested webpage topic")
 
-synthesized = []
+synthesized: list[str] = []
 image_count = sum(1 for slot in slots if slot["modality"] == "image")
 if include_image and image_count == 0:
     base = topic()

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_slots_normalize.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/media_slots_normalize.py
@@ -1,0 +1,205 @@
+import json
+import os
+import re
+
+outline = os.environ.get("PAGE_OUTLINE", "")
+requirement = os.environ.get("REQUIREMENT_FRAMING", "")
+visual_style = os.environ.get("VISUAL_STYLE", "")
+
+def wants(name):
+    value = os.environ.get(name, "YES").strip().lower()
+    return value not in {"no", "false", "0", "n", "否", "不要", "不需要"}
+
+include_image = wants("INCLUDE_IMAGE")
+include_audio = wants("INCLUDE_AUDIO")
+include_video = wants("INCLUDE_VIDEO")
+allowed = set()
+if include_image:
+    allowed.add("image")
+if include_audio:
+    allowed.add("audio")
+if include_video:
+    allowed.add("video")
+
+def clean_slot(raw, fallback):
+    text = re.sub(r"[^a-zA-Z0-9_-]+", "-", str(raw or "").strip()).strip("-").lower()
+    return (text or fallback)[:64]
+
+def field(block, *names):
+    for name in names:
+        match = re.search(rf"{name}\s*[:：]\s*(.+)", block, re.I)
+        if match:
+            return match.group(1).strip().strip("`\"'")[:500]
+    return ""
+
+def modality(value):
+    text = str(value or "").strip().lower()
+    raw = str(value or "")
+    if re.search(r"\bimage\b", text) or any(x in raw for x in ("图片", "图像", "视觉", "插图")):
+        return "image"
+    if re.search(r"\baudio\b|\bsound\b|voice|narration", text) or any(x in raw for x in ("音频", "声音", "旁白")):
+        return "audio"
+    if re.search(r"\bvideo\b|motion|film", text) or any(x in raw for x in ("视频", "影片", "短片")):
+        return "video"
+    return ""
+
+def split_keywords(value):
+    if isinstance(value, list):
+        return [str(x).strip()[:80] for x in value if str(x).strip()][:8]
+    text = str(value or "").strip()
+    if not text:
+        return []
+    return [x.strip()[:80] for x in re.split(r"[,，;/、]+", text) if x.strip()][:8]
+
+def truthy(value):
+    return str(value or "").strip().lower() in {"true", "yes", "1", "y", "是", "需要"}
+
+def append(slots, seen, *, slot_id, kind, placement="", subject="", prompt_hint="", keywords="", load_bearing=False, source="outline"):
+    if kind not in allowed:
+        return
+    slot = clean_slot(slot_id, f"{kind}-{len(slots) + 1}")
+    if slot in seen:
+        return
+    seen.add(slot)
+    slots.append({
+        "slot_id": slot,
+        "modality": kind,
+        "placement": str(placement or "").strip()[:240],
+        "subject": str(subject or placement or slot.replace("-", " ")).strip()[:500],
+        "prompt_hint": str(prompt_hint or "").strip()[:500],
+        "search_keywords": split_keywords(keywords),
+        "load_bearing": bool(load_bearing),
+        "source": source,
+    })
+
+def split_table_row(line):
+    stripped = line.strip()
+    if not stripped.startswith("|") or "|" not in stripped[1:]:
+        return []
+    return [cell.strip() for cell in stripped.strip("|").split("|")]
+
+def separator(cells):
+    return bool(cells) and all(re.fullmatch(r":?-{2,}:?", cell.strip()) for cell in cells)
+
+def hindex(headers, *needles):
+    normalized = [re.sub(r"[\s_\-/]+", "", h.strip().lower()) for h in headers]
+    for needle in needles:
+        n = re.sub(r"[\s_\-/]+", "", needle.strip().lower())
+        for index, header in enumerate(normalized):
+            if n and n in header:
+                return index
+    return None
+
+def cell(cells, index):
+    if index is None or index >= len(cells):
+        return ""
+    return cells[index].strip().strip("`\"'")
+
+slots = []
+seen = set()
+
+matches = list(re.finditer(r"slot_id\s*[:：]\s*([a-zA-Z0-9][a-zA-Z0-9_-]{0,80})", outline, re.I))
+for index, match in enumerate(matches):
+    end = matches[index + 1].start() if index + 1 < len(matches) else min(len(outline), match.start() + 900)
+    block = outline[match.start():end]
+    kind = modality(field(block, "modality", "media", "type", "类型", "媒体", "模态"))
+    append(
+        slots,
+        seen,
+        slot_id=match.group(1),
+        kind=kind,
+        placement=field(block, "placement", "section", "位置", "章节"),
+        subject=field(block, "subject", "画面主题", "主题", "description", "描述"),
+        prompt_hint=field(block, "prompt_hint", "prompt", "hint", "构图", "描述"),
+        keywords=field(block, "search_keywords", "keywords", "关键词"),
+        load_bearing=truthy(field(block, "load_bearing", "required", "必要")),
+    )
+
+headers = None
+for raw_line in outline.splitlines():
+    cells = split_table_row(raw_line)
+    if not cells:
+        headers = None
+        continue
+    if separator(cells):
+        continue
+    if headers is None:
+        lower = [c.lower() for c in cells]
+        has_slot = any("slot" in c or "槽位" in c for c in lower + cells)
+        has_media = any("modality" in c or "media" in c or "媒体" in c or "模态" in c or "类型" in c for c in lower + cells)
+        if has_slot and has_media:
+            headers = cells
+        continue
+    slot_idx = hindex(headers, "slot_id", "slot id", "slot", "槽位")
+    modality_idx = hindex(headers, "modality", "media", "媒体", "模态", "类型")
+    if slot_idx is None or modality_idx is None:
+        continue
+    kind = modality(cell(cells, modality_idx))
+    append(
+        slots,
+        seen,
+        slot_id=cell(cells, slot_idx),
+        kind=kind,
+        placement=cell(cells, hindex(headers, "placement", "section", "role", "位置", "章节", "角色")),
+        subject=cell(cells, hindex(headers, "subject", "visual", "description", "画面", "主题", "描述")),
+        prompt_hint=cell(cells, hindex(headers, "prompt_hint", "prompt", "hint", "构图", "风格")),
+        keywords=cell(cells, hindex(headers, "search_keywords", "keywords", "关键词")),
+        load_bearing=truthy(cell(cells, hindex(headers, "load_bearing", "required", "必要"))),
+    )
+
+for line in outline.splitlines():
+    kind = modality(line)
+    if not kind:
+        continue
+    match = re.search(r"slot[_\s-]*id\s*[:：=]\s*([a-zA-Z0-9][a-zA-Z0-9_-]{0,80})", line, re.I)
+    if not match:
+        continue
+    append(slots, seen, slot_id=match.group(1), kind=kind, subject=line[:500], prompt_hint=line[:500])
+
+def topic():
+    text = re.sub(r"[#*_`|>{}\[\]\"]+", " ", requirement + "\n" + outline)
+    text = re.sub(r"\s+", " ", text).strip()
+    for marker in ("主题", "topic", "brief", "request", "需求"):
+        match = re.search(rf"{marker}\s*[:：]\s*([^。.\n|]{{6,120}})", text, re.I)
+        if match:
+            return match.group(1).strip()[:160]
+    return (text[:160] if text else "requested webpage topic")
+
+synthesized = []
+image_count = sum(1 for slot in slots if slot["modality"] == "image")
+if include_image and image_count == 0:
+    base = topic()
+    synthetic = [
+        ("hero-visual", "hero", f"Primary webpage hero visual for {base}", "wide 16:9 polished webpage hero, no text overlays"),
+        ("supporting-visual", "body section", f"Supporting explanatory visual for {base}", "clean editorial webpage image, no text overlays"),
+    ]
+    for slot_id, placement, subject, hint in synthetic:
+        append(
+            slots,
+            seen,
+            slot_id=slot_id,
+            kind="image",
+            placement=placement,
+            subject=subject,
+            prompt_hint=f"{hint}. Visual style: {visual_style}".strip(),
+            keywords=base,
+            load_bearing=True,
+            source="synthesized",
+        )
+        synthesized.append(slot_id)
+
+if include_audio and not any(slot["modality"] == "audio" for slot in slots):
+    append(slots, seen, slot_id="narration-audio", kind="audio", placement="page narration", subject=f"Narration or soundscape for {topic()}", source="synthesized")
+    synthesized.append("narration-audio")
+if include_video and not any(slot["modality"] == "video" for slot in slots):
+    append(slots, seen, slot_id="intro-video", kind="video", placement="intro section", subject=f"Short intro video for {topic()}", source="synthesized")
+    synthesized.append("intro-video")
+
+counts = {kind: sum(1 for slot in slots if slot["modality"] == kind) for kind in ("image", "audio", "video")}
+print(json.dumps({
+    "status": "MEDIA_SLOTS_READY",
+    "slots": slots,
+    "counts": counts,
+    "synthesized": synthesized,
+    "policy": "Downstream media producers must use slots[] as the authoritative shopping list.",
+}, ensure_ascii=True, separators=(",", ":")))

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/webpage_source.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/webpage_source.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import re
+
+REQUIRED_SOURCE_KEYS = {
+    "index_html": "index.html",
+    "style_css": "style.css",
+    "script_js": "script.js",
+}
+
+
+class WebpageSourceError(ValueError):
+    pass
+
+
+class WebpageSourcePayloadError(WebpageSourceError):
+    pass
+
+
+class WebpageSourceParseError(WebpageSourceError):
+    pass
+
+
+def require_object(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return value
+    raise WebpageSourceParseError("source must be a JSON object")
+
+
+def parse_json_object(text: str) -> dict[str, object]:
+    text = text.strip()
+    errors: list[str] = []
+    if not text:
+        raise WebpageSourceParseError("empty source JSON")
+
+    candidates = [text]
+    candidates.extend(
+        match.group(1).strip()
+        for match in re.finditer(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.S)
+    )
+
+    for candidate in candidates:
+        try:
+            return require_object(json.loads(candidate))
+        except (json.JSONDecodeError, WebpageSourceParseError) as exc:
+            errors.append(str(exc))
+
+    depth = 0
+    start = None
+    in_string = False
+    escape = False
+    for idx, char in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            if depth == 0:
+                start = idx
+            depth += 1
+        elif char == "}" and depth:
+            depth -= 1
+            if depth == 0 and start is not None:
+                candidate = text[start : idx + 1]
+                try:
+                    return require_object(json.loads(candidate))
+                except (json.JSONDecodeError, WebpageSourceParseError) as exc:
+                    errors.append(str(exc))
+
+    raise WebpageSourceParseError(errors[-1] if errors else "no JSON object found")
+
+
+def load_source_payload(raw_payload_source: str) -> dict[str, object]:
+    try:
+        raw_payload = json.loads(raw_payload_source)
+    except json.JSONDecodeError as exc:
+        raise WebpageSourcePayloadError(f"invalid source JSON payload: {exc}") from exc
+
+    if isinstance(raw_payload, str):
+        return parse_json_object(raw_payload)
+    return require_object(raw_payload)
+
+
+def missing_required_keys(data: dict[str, object]) -> list[str]:
+    return [key for key in REQUIRED_SOURCE_KEYS if not str(data.get(key, "")).strip()]

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/webpage_source_validate.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/webpage_source_validate.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Validate primary webpage source output before fallback authoring."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from .webpage_source import (
+    WebpageSourceError,
+    load_source_payload,
+    missing_required_keys,
+)
+
+
+def _print_record(label: str, payload: dict[str, object]) -> None:
+    print(f"{label}: {json.dumps(payload, ensure_ascii=True, separators=(',', ':'))}")
+
+
+def main() -> int:
+    raw_payload_source = "" if sys.stdin.isatty() else sys.stdin.read()
+    try:
+        data = load_source_payload(raw_payload_source)
+        missing = missing_required_keys(data)
+        if missing:
+            raise WebpageSourceError("missing keys " + ",".join(missing))
+    except WebpageSourceError as exc:
+        _print_record(
+            "WEBPAGE_SOURCE_INVALID",
+            {
+                "reason": str(exc)[:500],
+            },
+        )
+        return 0
+
+    _print_record(
+        "WEBPAGE_SOURCE_OK",
+        {
+            "keys": sorted(data),
+            "summary": str(data.get("summary", ""))[:500],
+        },
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/webpage_write.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/webpage_write.py
@@ -1,17 +1,21 @@
 import json
 import os
 import re
+import sys
 from pathlib import Path
 
 workspace = Path(os.environ["WORKSPACE_DIR"]).expanduser().resolve()
 project_root = Path(os.environ["PROJECT_ROOT"]).expanduser().resolve()
 project_root.relative_to(workspace)
 
-raw_env = os.environ.get("WEBPAGE_SOURCE_JSON", "")
+raw_env = os.environ.get("WEBPAGE_SOURCE_JSON")
+raw_payload_source = raw_env if raw_env is not None else (
+    "" if sys.stdin.isatty() else sys.stdin.read()
+)
 try:
-    raw_payload = json.loads(raw_env)
+    raw_payload = json.loads(raw_payload_source)
 except json.JSONDecodeError as exc:
-    raise SystemExit(f"WEBPAGE_WRITE_FAILED: invalid env JSON: {exc}") from exc
+    raise SystemExit(f"WEBPAGE_WRITE_FAILED: invalid source JSON payload: {exc}") from exc
 
 def require_object(value):
     if isinstance(value, dict):

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/webpage_write.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/webpage_write.py
@@ -1,0 +1,109 @@
+import json
+import os
+import re
+from pathlib import Path
+
+workspace = Path(os.environ["WORKSPACE_DIR"]).expanduser().resolve()
+project_root = Path(os.environ["PROJECT_ROOT"]).expanduser().resolve()
+project_root.relative_to(workspace)
+
+raw_env = os.environ.get("WEBPAGE_SOURCE_JSON", "")
+try:
+    raw_payload = json.loads(raw_env)
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"WEBPAGE_WRITE_FAILED: invalid env JSON: {exc}") from exc
+
+def require_object(value):
+    if isinstance(value, dict):
+        return value
+    raise ValueError("source must be a JSON object")
+
+def parse_json_object(text):
+    text = text.strip()
+    errors = []
+    if not text:
+        raise ValueError("empty source JSON")
+
+    candidates = [text]
+    candidates.extend(match.group(1).strip() for match in re.finditer(
+        r"```(?:json)?\s*(\{.*?\})\s*```",
+        text,
+        re.S,
+    ))
+
+    for candidate in candidates:
+        try:
+            return require_object(json.loads(candidate))
+        except (json.JSONDecodeError, ValueError) as exc:
+            errors.append(str(exc))
+
+    depth = 0
+    start = None
+    in_string = False
+    escape = False
+    for idx, char in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            if depth == 0:
+                start = idx
+            depth += 1
+        elif char == "}" and depth:
+            depth -= 1
+            if depth == 0 and start is not None:
+                candidate = text[start : idx + 1]
+                try:
+                    return require_object(json.loads(candidate))
+                except (json.JSONDecodeError, ValueError) as exc:
+                    errors.append(str(exc))
+
+    raise ValueError(errors[-1] if errors else "no JSON object found")
+
+if isinstance(raw_payload, str):
+    try:
+        data = parse_json_object(raw_payload)
+    except ValueError as exc:
+        raise SystemExit(f"WEBPAGE_WRITE_FAILED: invalid source JSON: {exc}") from exc
+elif isinstance(raw_payload, dict):
+    data = raw_payload
+else:
+    raise SystemExit("WEBPAGE_WRITE_FAILED: source must be a JSON object")
+
+required = {
+    "index_html": "index.html",
+    "style_css": "style.css",
+    "script_js": "script.js",
+}
+missing = [key for key in required if not str(data.get(key, "")).strip()]
+if missing:
+    raise SystemExit("WEBPAGE_WRITE_FAILED: missing keys " + ",".join(missing))
+
+project_dir = project_root / "project"
+for rel in [
+    "assets/images",
+    "assets/audio",
+    "assets/video",
+]:
+    (project_dir / rel).mkdir(parents=True, exist_ok=True)
+
+written = []
+for key, filename in required.items():
+    target = (project_dir / filename).resolve()
+    target.relative_to(project_dir.resolve())
+    target.write_text(str(data[key]), encoding="utf-8")
+    written.append(str(target))
+
+print(json.dumps({
+    "status": "WEBPAGE_FILES_WRITTEN",
+    "project_root": str(project_root),
+    "files": written,
+    "summary": str(data.get("summary", ""))[:500],
+}, ensure_ascii=True, separators=(",", ":")))

--- a/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/webpage_write.py
+++ b/src/opensquilla/skills/bundled/AwesomeWebpageMetaSkill/scripts/webpage_write.py
@@ -1,8 +1,15 @@
 import json
 import os
-import re
 import sys
 from pathlib import Path
+
+from .webpage_source import (
+    REQUIRED_SOURCE_KEYS,
+    WebpageSourceParseError,
+    WebpageSourcePayloadError,
+    load_source_payload,
+    missing_required_keys,
+)
 
 workspace = Path(os.environ["WORKSPACE_DIR"]).expanduser().resolve()
 project_root = Path(os.environ["PROJECT_ROOT"]).expanduser().resolve()
@@ -13,80 +20,15 @@ raw_payload_source = raw_env if raw_env is not None else (
     "" if sys.stdin.isatty() else sys.stdin.read()
 )
 try:
-    raw_payload = json.loads(raw_payload_source)
-except json.JSONDecodeError as exc:
-    raise SystemExit(f"WEBPAGE_WRITE_FAILED: invalid source JSON payload: {exc}") from exc
+    data = load_source_payload(raw_payload_source)
+except WebpageSourcePayloadError as exc:
+    raise SystemExit(f"WEBPAGE_WRITE_FAILED: {exc}") from exc
+except WebpageSourceParseError as exc:
+    if str(exc) == "source must be a JSON object":
+        raise SystemExit("WEBPAGE_WRITE_FAILED: source must be a JSON object") from exc
+    raise SystemExit(f"WEBPAGE_WRITE_FAILED: invalid source JSON: {exc}") from exc
 
-def require_object(value):
-    if isinstance(value, dict):
-        return value
-    raise ValueError("source must be a JSON object")
-
-def parse_json_object(text):
-    text = text.strip()
-    errors = []
-    if not text:
-        raise ValueError("empty source JSON")
-
-    candidates = [text]
-    candidates.extend(match.group(1).strip() for match in re.finditer(
-        r"```(?:json)?\s*(\{.*?\})\s*```",
-        text,
-        re.S,
-    ))
-
-    for candidate in candidates:
-        try:
-            return require_object(json.loads(candidate))
-        except (json.JSONDecodeError, ValueError) as exc:
-            errors.append(str(exc))
-
-    depth = 0
-    start = None
-    in_string = False
-    escape = False
-    for idx, char in enumerate(text):
-        if in_string:
-            if escape:
-                escape = False
-            elif char == "\\":
-                escape = True
-            elif char == '"':
-                in_string = False
-            continue
-        if char == '"':
-            in_string = True
-        elif char == "{":
-            if depth == 0:
-                start = idx
-            depth += 1
-        elif char == "}" and depth:
-            depth -= 1
-            if depth == 0 and start is not None:
-                candidate = text[start : idx + 1]
-                try:
-                    return require_object(json.loads(candidate))
-                except (json.JSONDecodeError, ValueError) as exc:
-                    errors.append(str(exc))
-
-    raise ValueError(errors[-1] if errors else "no JSON object found")
-
-if isinstance(raw_payload, str):
-    try:
-        data = parse_json_object(raw_payload)
-    except ValueError as exc:
-        raise SystemExit(f"WEBPAGE_WRITE_FAILED: invalid source JSON: {exc}") from exc
-elif isinstance(raw_payload, dict):
-    data = raw_payload
-else:
-    raise SystemExit("WEBPAGE_WRITE_FAILED: source must be a JSON object")
-
-required = {
-    "index_html": "index.html",
-    "style_css": "style.css",
-    "script_js": "script.js",
-}
-missing = [key for key in required if not str(data.get(key, "")).strip()]
+missing = missing_required_keys(data)
 if missing:
     raise SystemExit("WEBPAGE_WRITE_FAILED: missing keys " + ",".join(missing))
 
@@ -99,7 +41,7 @@ for rel in [
     (project_dir / rel).mkdir(parents=True, exist_ok=True)
 
 written = []
-for key, filename in required.items():
+for key, filename in REQUIRED_SOURCE_KEYS.items():
     target = (project_dir / filename).resolve()
     target.relative_to(project_dir.resolve())
     target.write_text(str(data[key]), encoding="utf-8")

--- a/src/opensquilla/skills/bundled/audio-cog/SKILL.md
+++ b/src/opensquilla/skills/bundled/audio-cog/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: audio-cog
+description: "OpenSquilla-compatible audio generation adapter for webpage audio requests. Prefer OpenRouter config/API key in OpenSquilla; preserve the upstream CellCog workflow only as optional ClawHub provenance."
+metadata:
+  openclaw:
+    emoji: "🎵"
+    os: [darwin, linux, windows]
+    requires:
+      bins: [python3]
+      env: [CELLCOG_API_KEY]
+  opensquilla:
+    risk: medium
+    capabilities: [network-write, filesystem-write]
+    requires:
+      bins: [python3]
+      env: []
+      config:
+        - awesome_webpage.provider
+        - awesome_webpage.openrouter.api_key
+        - awesome_webpage.openrouter.api_key_env
+        - awesome_webpage.openrouter.models.audio_generation
+        - awesome_webpage.output_dir
+author: CellCog
+homepage: https://cellcog.ai
+dependencies: [cellcog]
+provenance:
+  origin: clawhub-mit0
+  license: MIT-0
+  upstream_url: https://clawhub.ai/skills/audio-cog
+  maintained_by: OpenSquilla
+entrypoint:
+  command: python {baseDir}/scripts/openrouter_audio.py
+  args:
+    - --model
+    - "{{ with.model | default('openai/gpt-audio-mini') }}"
+    - --base-url
+    - "{{ with.base_url | default('https://openrouter.ai/api/v1') }}"
+    - --output-dir
+    - "{{ with.output_dir }}"
+    - --filename
+    - "{{ with.filename | default('narration.wav') }}"
+    - --voice
+    - "{{ with.voice | default('cedar') }}"
+  stdin: "{{ with.payload | default(with.prompt | default(inputs.user_message)) }}"
+  parse: text
+  timeout: 240
+---
+# Audio Cog - AI Audio Generation Powered by CellCog
+
+Create professional audio with AI — voiceovers, music, sound effects, and personalized avatar voices.
+
+## Meta-Skill Entrypoint
+
+Meta-skills should run this skill as `skill_exec` when they need OpenRouter
+audio. The entrypoint is a deterministic Python adapter: it reads
+`OPENROUTER_API_KEY` from the child process environment, calls the configured
+OpenRouter audio model, writes a browser-playable WAV file under the supplied
+output directory, and prints either `AUDIO_READY:` or a single failure label.
+Do not spawn an LLM sub-agent just to generate audio.
+
+Prefer JSON payload mode when the caller already has a narration script:
+
+```json
+{"script": "exact spoken narration text"}
+```
+
+In payload mode the adapter asks the audio model to speak exactly that
+transcript and not add acknowledgements, titles, or setup text.
+
+## OpenSquilla Compatibility Contract
+
+When invoked from OpenSquilla, this skill is an adapter around the caller's
+configured provider. Do not require `CELLCOG_API_KEY`, do not assume the
+`cellcog` package is installed, and do not invent provider credentials.
+
+For `AwesomeWebpageMetaSkill`:
+
+- Read provider settings from `config.awesome_webpage`.
+- Use `config.awesome_webpage.provider`; the expected value is `openrouter`.
+- Use `config.awesome_webpage.openrouter.api_key` or the configured
+  `api_key_env` value, normally `OPENROUTER_API_KEY`.
+- Use only `config.awesome_webpage.openrouter.models.audio_generation` for
+  audio model selection.
+- Save generated or processed files only under
+  `config.awesome_webpage.output_dir/project/assets/audio`.
+- If the OpenRouter key, audio model, or output directory is missing, return a
+  concise `AUDIO_CONFIG_NEEDED` report listing the missing config keys.
+- If the configured OpenRouter model cannot return a browser-playable audio
+  file, return `AUDIO_MODEL_UNSUPPORTED` with the narration/script, desired
+  duration, style, and target filename so the webpage can expose a clean
+  replacement slot instead of failing the whole project.
+
+### On success: `AUDIO_READY` manifest line (required)
+
+After every successful save, end your reply with one single-line JSON record
+per file so `AwesomeWebpageMetaSkill` can collect and bind the assets:
+
+```
+AUDIO_READY: {"local_path": "project/assets/audio/<slug>.wav", "mime": "audio/wav", "duration_s": <int_or_null>, "voice": "<voice>", "script_preview": "<first 80 chars>"}
+```
+
+- One `AUDIO_READY:` line per audio file. No trailing prose on that line.
+- `local_path` MUST be the relative path `project/assets/audio/...`. Do NOT
+  emit an absolute path here.
+- On failure, emit one of `AUDIO_CONFIG_NEEDED`, `AUDIO_MODEL_UNSUPPORTED`, or
+  `AUDIO_GENERATION_FAILED` as a single-line label with the replacement-slot
+  path so the page can render a placeholder.
+
+## OpenRouter Audio API Contract (hard rule for `openai/gpt-audio*`)
+
+The default CellCog code-path is **wrong** for OpenSquilla and will fail.
+OpenRouter routes `openai/gpt-audio` / `openai/gpt-audio-mini` through OpenAI's
+audio-output mode, which has a strict request shape:
+
+- `POST {base_url}/chat/completions` with body:
+  ```
+  {
+    "model": "<audio_generation>",
+    "stream": true,
+    "modalities": ["text", "audio"],
+    "audio": {"voice": "alloy", "format": "pcm16"},
+    "messages": [...]
+  }
+  ```
+- `stream: true` is REQUIRED. Non-streaming requests are rejected with
+  HTTP 400 "Audio output requires stream: true".
+- `audio.format` MUST be `pcm16` when streaming. `mp3`, `opus`, `flac`,
+  `wav` are all rejected as "unsupported_value" — there is no alternative
+  combo. Sending `format=mp3` (any stream setting) burns ~190 s of
+  per-attempt timeout for nothing; do not try it.
+- Read the SSE response, base64-decode each `delta.audio.data` chunk,
+  concatenate the raw 24kHz mono signed-16-bit-little-endian PCM stream,
+  then save it as a browser-playable WAV file.
+- Final on-disk asset is `.wav`. Set MIME to `audio/wav` in the manifest.
+- If `OPENROUTER_API_KEY` is missing, return `AUDIO_CONFIG_NEEDED`. Do not
+  fall back to CELLCOG_API_KEY or any other provider.
+
+Upstream CellCog instructions are intentionally omitted from the executable
+prompt body. OpenSquilla meta-skills use the entrypoint above; provenance is
+kept in frontmatter for registry/audit purposes.

--- a/src/opensquilla/skills/bundled/audio-cog/SKILL.md
+++ b/src/opensquilla/skills/bundled/audio-cog/SKILL.md
@@ -35,14 +35,16 @@ entrypoint:
     - "{{ with.model | default('openai/gpt-audio-mini') }}"
     - --base-url
     - "{{ with.base_url | default('https://openrouter.ai/api/v1') }}"
-    - --api-key
-    - "{{ with.api_key | default('') }}"
+    - --api-key-env
+    - "{{ with.api_key_env | default('OPENROUTER_API_KEY') }}"
     - --output-dir
     - "{{ with.output_dir }}"
     - --filename
     - "{{ with.filename | default('narration.wav') }}"
     - --voice
     - "{{ with.voice | default('cedar') }}"
+  env:
+    "{{ with.api_key_env | default('OPENROUTER_API_KEY') }}": "{{ with.api_key | default('') }}"
   stdin: "{{ with.payload | default(with.prompt | default(inputs.user_message)) }}"
   parse: text
   timeout: 240
@@ -55,8 +57,8 @@ Create professional audio with AI — voiceovers, music, sound effects, and pers
 
 Meta-skills should run this skill as `skill_exec` when they need OpenRouter
 audio. The entrypoint is a deterministic Python adapter: it uses an explicit
-`with.api_key`/`--api-key` value when provided, otherwise reads
-`OPENROUTER_API_KEY` from the child process environment, calls the configured
+`with.api_key` value by injecting it into the configured `with.api_key_env`
+child process environment variable, calls the configured
 OpenRouter audio model, writes a browser-playable WAV file under the supplied
 output directory, and prints either `AUDIO_READY:` or a single failure label.
 Do not spawn an LLM sub-agent just to generate audio.

--- a/src/opensquilla/skills/bundled/audio-cog/SKILL.md
+++ b/src/opensquilla/skills/bundled/audio-cog/SKILL.md
@@ -35,6 +35,8 @@ entrypoint:
     - "{{ with.model | default('openai/gpt-audio-mini') }}"
     - --base-url
     - "{{ with.base_url | default('https://openrouter.ai/api/v1') }}"
+    - --api-key
+    - "{{ with.api_key | default('') }}"
     - --output-dir
     - "{{ with.output_dir }}"
     - --filename
@@ -52,7 +54,8 @@ Create professional audio with AI — voiceovers, music, sound effects, and pers
 ## Meta-Skill Entrypoint
 
 Meta-skills should run this skill as `skill_exec` when they need OpenRouter
-audio. The entrypoint is a deterministic Python adapter: it reads
+audio. The entrypoint is a deterministic Python adapter: it uses an explicit
+`with.api_key`/`--api-key` value when provided, otherwise reads
 `OPENROUTER_API_KEY` from the child process environment, calls the configured
 OpenRouter audio model, writes a browser-playable WAV file under the supplied
 output directory, and prints either `AUDIO_READY:` or a single failure label.

--- a/src/opensquilla/skills/bundled/audio-cog/_meta.json
+++ b/src/opensquilla/skills/bundled/audio-cog/_meta.json
@@ -1,0 +1,6 @@
+{
+  "ownerId": "kn7a96cj9q65e0bhmzahv790en80ffqm",
+  "slug": "audio-cog",
+  "version": "1.0.12",
+  "publishedAt": 1776925103817
+}

--- a/src/opensquilla/skills/bundled/audio-cog/scripts/openrouter_audio.py
+++ b/src/opensquilla/skills/bundled/audio-cog/scripts/openrouter_audio.py
@@ -105,6 +105,12 @@ def _failure(label: str, filename: str, **extra: object) -> None:
     _print_record(label, payload)
 
 
+def _failure_reason(exc: BaseException) -> str:
+    if isinstance(exc, URLError):
+        return exc.reason.__class__.__name__
+    return exc.__class__.__name__
+
+
 def _iter_sse_audio_chunks(response: object) -> bytes:
     pcm = bytearray()
     for raw in response:  # type: ignore[operator]
@@ -183,8 +189,8 @@ def main() -> int:
     except HTTPError as exc:
         _failure("AUDIO_GENERATION_FAILED", filename, status=exc.code)
         return 0
-    except URLError as exc:
-        _failure("AUDIO_GENERATION_FAILED", filename, reason=exc.reason.__class__.__name__)
+    except (URLError, TimeoutError) as exc:
+        _failure("AUDIO_GENERATION_FAILED", filename, reason=_failure_reason(exc))
         return 0
 
     if not pcm:

--- a/src/opensquilla/skills/bundled/audio-cog/scripts/openrouter_audio.py
+++ b/src/opensquilla/skills/bundled/audio-cog/scripts/openrouter_audio.py
@@ -10,6 +10,7 @@ import os
 import re
 import sys
 import wave
+from collections.abc import Iterable
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -111,9 +112,9 @@ def _failure_reason(exc: BaseException) -> str:
     return exc.__class__.__name__
 
 
-def _iter_sse_audio_chunks(response: object) -> bytes:
+def _iter_sse_audio_chunks(response: Iterable[bytes]) -> bytes:
     pcm = bytearray()
-    for raw in response:  # type: ignore[operator]
+    for raw in response:
         line = raw.decode("utf-8", "replace").strip()
         if not line.startswith("data:"):
             continue
@@ -139,6 +140,7 @@ def main() -> int:
     parser.add_argument("--model", required=True)
     parser.add_argument("--base-url", default="https://openrouter.ai/api/v1")
     parser.add_argument("--api-key", default="")
+    parser.add_argument("--api-key-env", default="OPENROUTER_API_KEY")
     parser.add_argument("--output-dir", required=True)
     parser.add_argument("--filename", default="narration.wav")
     parser.add_argument("--voice", default="cedar")
@@ -147,10 +149,11 @@ def main() -> int:
     filename = _safe_filename(args.filename, "narration.wav")
     messages, script_text = _audio_messages(sys.stdin.read())
 
-    key = args.api_key.strip() or os.environ.get("OPENROUTER_API_KEY")
+    api_key_env = args.api_key_env.strip() or "OPENROUTER_API_KEY"
+    key = str(args.api_key.strip() or os.environ.get(api_key_env, ""))
     missing = []
     if not key:
-        missing.append("OPENROUTER_API_KEY")
+        missing.append(api_key_env)
     if not args.model:
         missing.append("awesome_webpage.openrouter.models.audio_generation")
     if not args.output_dir:

--- a/src/opensquilla/skills/bundled/audio-cog/scripts/openrouter_audio.py
+++ b/src/opensquilla/skills/bundled/audio-cog/scripts/openrouter_audio.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""OpenRouter audio entrypoint for meta-skill ``skill_exec`` steps."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import wave
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+SAMPLE_RATE = 24_000
+
+
+def _safe_filename(value: str, default: str) -> str:
+    name = Path(value or default).name
+    name = re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip(".-")
+    if not name:
+        name = default
+    if not name.lower().endswith(".wav"):
+        name = re.sub(r"\.[A-Za-z0-9]+$", "", name) + ".wav"
+    return name
+
+
+def _preview(text: str) -> str:
+    return " ".join(text.split())[:80]
+
+
+def _clean_script(value: object) -> str:
+    text = str(value or "").strip()
+    text = re.sub(r"^```(?:text|markdown)?\s*", "", text, flags=re.I)
+    text = re.sub(r"\s*```$", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _audio_messages(raw: str) -> tuple[list[dict[str, str]], str]:
+    text = raw.strip()
+    if text:
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            payload = None
+        if isinstance(payload, dict):
+            script = _clean_script(
+                payload.get("script")
+                or payload.get("transcript")
+                or payload.get("narration")
+                or payload.get("text")
+            )
+            if script:
+                return (
+                    [
+                        {
+                            "role": "system",
+                            "content": (
+                                "You are a text-to-speech renderer. Return and speak exactly the "
+                                "provided narration transcript. Do not acknowledge the request. "
+                                "Do not say you understand. Do not add introductions, titles, "
+                                "stage directions, markdown, file names, or closing remarks."
+                            ),
+                        },
+                        {
+                            "role": "user",
+                            "content": (
+                                "Speak this exact narration transcript and no other words:\n\n"
+                                + script
+                            ),
+                        },
+                    ],
+                    script,
+                )
+
+    prompt = text or "Create a short, clear narration for this webpage."
+    return (
+        [
+            {
+                "role": "system",
+                "content": (
+                    "You produce finished webpage narration audio. Respond only with the "
+                    "spoken narration itself. Never acknowledge the request, never say "
+                    "you understand, and never describe what you will create."
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ],
+        prompt,
+    )
+
+
+def _print_record(label: str, payload: dict[str, object]) -> None:
+    print(f"{label}: {json.dumps(payload, ensure_ascii=False, separators=(',', ':'))}")
+
+
+def _failure(label: str, filename: str, **extra: object) -> None:
+    payload: dict[str, object] = {
+        "replacement_slot": f"project/assets/audio/{filename}",
+    }
+    payload.update(extra)
+    _print_record(label, payload)
+
+
+def _iter_sse_audio_chunks(response: object) -> bytes:
+    pcm = bytearray()
+    for raw in response:  # type: ignore[operator]
+        line = raw.decode("utf-8", "replace").strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line[5:].strip()
+        if not payload or payload == "[DONE]":
+            continue
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        for choice in obj.get("choices") or []:
+            delta = choice.get("delta") or {}
+            message = choice.get("message") or {}
+            audio = delta.get("audio") or message.get("audio") or {}
+            data_b64 = audio.get("data")
+            if isinstance(data_b64, str) and data_b64:
+                pcm.extend(base64.b64decode(data_b64))
+    return bytes(pcm)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--base-url", default="https://openrouter.ai/api/v1")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--filename", default="narration.wav")
+    parser.add_argument("--voice", default="cedar")
+    args = parser.parse_args()
+
+    filename = _safe_filename(args.filename, "narration.wav")
+    messages, script_text = _audio_messages(sys.stdin.read())
+
+    key = os.environ.get("OPENROUTER_API_KEY")
+    missing = []
+    if not key:
+        missing.append("OPENROUTER_API_KEY")
+    if not args.model:
+        missing.append("awesome_webpage.openrouter.models.audio_generation")
+    if not args.output_dir:
+        missing.append("awesome_webpage.output_dir")
+    if missing:
+        _failure("AUDIO_CONFIG_NEEDED", filename, missing=missing)
+        return 0
+
+    output_dir = Path(args.output_dir).expanduser()
+    output_path = output_dir / filename
+    local_path = f"project/assets/audio/{filename}"
+    base_url = args.base_url.rstrip("/")
+
+    body = json.dumps(
+        {
+            "model": args.model,
+            "stream": True,
+            "modalities": ["text", "audio"],
+            "audio": {"voice": args.voice, "format": "pcm16"},
+            "messages": messages,
+        }
+    ).encode("utf-8")
+    req = Request(
+        f"{base_url}/chat/completions",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+        },
+        method="POST",
+    )
+
+    try:
+        with urlopen(req, timeout=180) as resp:
+            pcm = _iter_sse_audio_chunks(resp)
+    except HTTPError as exc:
+        _failure("AUDIO_GENERATION_FAILED", filename, status=exc.code)
+        return 0
+    except URLError as exc:
+        _failure("AUDIO_GENERATION_FAILED", filename, reason=exc.reason.__class__.__name__)
+        return 0
+
+    if not pcm:
+        _failure("AUDIO_MODEL_UNSUPPORTED", filename, reason="no_audio_pcm")
+        return 0
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(output_path), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(SAMPLE_RATE)
+        wav.writeframes(pcm)
+
+    _print_record(
+        "AUDIO_READY",
+        {
+            "local_path": local_path,
+            "mime": "audio/wav",
+            "duration_s": round(len(pcm) / 2 / SAMPLE_RATE, 2),
+            "voice": args.voice,
+            "script_preview": _preview(script_text),
+        },
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/opensquilla/skills/bundled/audio-cog/scripts/openrouter_audio.py
+++ b/src/opensquilla/skills/bundled/audio-cog/scripts/openrouter_audio.py
@@ -138,6 +138,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", required=True)
     parser.add_argument("--base-url", default="https://openrouter.ai/api/v1")
+    parser.add_argument("--api-key", default="")
     parser.add_argument("--output-dir", required=True)
     parser.add_argument("--filename", default="narration.wav")
     parser.add_argument("--voice", default="cedar")
@@ -146,7 +147,7 @@ def main() -> int:
     filename = _safe_filename(args.filename, "narration.wav")
     messages, script_text = _audio_messages(sys.stdin.read())
 
-    key = os.environ.get("OPENROUTER_API_KEY")
+    key = args.api_key.strip() or os.environ.get("OPENROUTER_API_KEY")
     missing = []
     if not key:
         missing.append("OPENROUTER_API_KEY")

--- a/src/opensquilla/skills/bundled/awesome-webpage-image-download/SKILL.md
+++ b/src/opensquilla/skills/bundled/awesome-webpage-image-download/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: awesome-webpage-image-download
+description: "Deterministic image downloader for AwesomeWebpageMetaSkill search results. Use as skill_exec to fetch candidate image URLs into the configured local project tree without sandboxed shell curl."
+homepage: ""
+user-invocable: false
+disable-model-invocation: true
+provenance:
+  origin: opensquilla-original
+  license: Apache-2.0
+  maintained_by: OpenSquilla
+metadata:
+  opensquilla:
+    risk: high
+    capabilities: [network-read, filesystem-write]
+    requires:
+      bins: [python3]
+      config:
+        - awesome_webpage.output_dir
+entrypoint:
+  command: python {baseDir}/scripts/image_download.py
+  args:
+    - --output-dir
+    - "{{ with.output_dir }}"
+    - --local-path-prefix
+    - "{{ with.local_path_prefix | default('project/assets/images') }}"
+  stdin: "{{ with.payload }}"
+  parse: text
+  timeout: 120
+---
+
+# AwesomeWebpage Image Download
+
+Internal deterministic downloader used by `AwesomeWebpageMetaSkill` after the
+bounded web-search step has produced candidate image URLs.
+
+It receives normalized media slots and search output on stdin, downloads direct
+image URLs with Python HTTP APIs, validates the response MIME/magic bytes, saves
+files by `slot_id`, and emits `IMAGE_READY:` records plus
+`IMAGE_DOWNLOAD_INCOMPLETE:` when any requested image slot remains unfilled.

--- a/src/opensquilla/skills/bundled/awesome-webpage-image-download/scripts/image_download.py
+++ b/src/opensquilla/skills/bundled/awesome-webpage-image-download/scripts/image_download.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Download searched image candidates for AwesomeWebpageMetaSkill."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+IMAGE_MIME_BY_MAGIC = (
+    (b"\x89PNG\r\n\x1a\n", "image/png", ".png"),
+    (b"\xff\xd8\xff", "image/jpeg", ".jpg"),
+    (b"GIF87a", "image/gif", ".gif"),
+    (b"GIF89a", "image/gif", ".gif"),
+    (b"RIFF", "image/webp", ".webp"),
+)
+
+
+def _emit(label: str, payload: dict[str, Any]) -> None:
+    print(f"{label}: {json.dumps(payload, ensure_ascii=False, separators=(',', ':'))}")
+
+
+def _loads(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not text:
+        return value
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return value
+
+
+def _payload() -> dict[str, Any]:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"media_search": raw}
+    return value if isinstance(value, dict) else {}
+
+
+def _clean_slot(raw: Any, fallback: str) -> str:
+    value = re.sub(r"[^A-Za-z0-9_-]+", "-", str(raw or "").strip()).strip("-").lower()
+    return (value or fallback)[:64]
+
+
+def _image_slots(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    media_slots = _loads(payload.get("media_slots"))
+    if isinstance(media_slots, dict):
+        raw_slots = media_slots.get("slots")
+    elif isinstance(media_slots, list):
+        raw_slots = media_slots
+    else:
+        raw_slots = None
+    slots: list[dict[str, Any]] = []
+    if not isinstance(raw_slots, list):
+        return slots
+    for index, item in enumerate(raw_slots, start=1):
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("modality") or "").lower() != "image":
+            continue
+        slot_id = _clean_slot(item.get("slot_id"), f"image-{index}")
+        slots.append(
+            {
+                "slot_id": slot_id,
+                "subject": str(item.get("subject") or item.get("placement") or slot_id),
+                "search_keywords": item.get("search_keywords") or [],
+            }
+        )
+    return slots
+
+
+def _urls_from_value(value: Any) -> list[str]:
+    if isinstance(value, dict):
+        found: list[str] = []
+        for nested in value.values():
+            found.extend(_urls_from_value(nested))
+        return found
+    if isinstance(value, list):
+        found = []
+        for nested in value:
+            found.extend(_urls_from_value(nested))
+        return found
+    text = str(value or "")
+    return [
+        url.rstrip(").,;]'\"")
+        for url in re.findall(r"https?://[^\s<>()\"']+", text)
+        if not url.startswith("data:")
+    ]
+
+
+def _candidate_urls(payload: dict[str, Any]) -> list[str]:
+    media_search = _loads(payload.get("media_search"))
+    urls = _urls_from_value(media_search)
+    seen: set[str] = set()
+    unique: list[str] = []
+    for url in urls:
+        if url in seen:
+            continue
+        seen.add(url)
+        unique.append(url)
+    return unique
+
+
+def _score(url: str, slot: dict[str, Any]) -> int:
+    haystack = urllib.parse.unquote(url).lower()
+    terms = [str(slot.get("subject") or "")]
+    keywords = slot.get("search_keywords") or []
+    if isinstance(keywords, list):
+        terms.extend(str(item) for item in keywords)
+    else:
+        terms.extend(re.split(r"[,，;/、\s]+", str(keywords)))
+    return sum(1 for term in terms if term and term.lower() in haystack)
+
+
+def _looks_like_image(data: bytes, content_type: str, url: str) -> tuple[str, str] | None:
+    lowered = content_type.split(";", 1)[0].strip().lower()
+    for magic, mime, ext in IMAGE_MIME_BY_MAGIC:
+        if data.startswith(magic):
+            if mime == "image/webp" and data[8:12] != b"WEBP":
+                continue
+            return mime, ext
+    if lowered in {"image/jpeg", "image/png", "image/webp", "image/gif"}:
+        ext = mimetypes.guess_extension(lowered) or Path(urllib.parse.urlparse(url).path).suffix
+        return lowered, ext or ".jpg"
+    return None
+
+
+def _fetch(url: str) -> tuple[str, bytes, str]:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "image/avif,image/webp,image/png,image/jpeg,image/gif;q=0.9,*/*;q=0.1",
+            "User-Agent": "OpenSquilla-AwesomeWebpage/1.0",
+        },
+        method="GET",
+    )
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        content_type = resp.headers.get("Content-Type", "")
+        return content_type, resp.read(12 * 1024 * 1024), resp.geturl()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--local-path-prefix", default="project/assets/images")
+    args = parser.parse_args()
+
+    payload = _payload()
+    slots = _image_slots(payload)
+    urls = _candidate_urls(payload)
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    downloaded: list[dict[str, Any]] = []
+    unfilled: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    used_urls: set[str] = set()
+
+    for slot in slots:
+        candidates = sorted(
+            [url for url in urls if url not in used_urls],
+            key=lambda url: _score(url, slot),
+            reverse=True,
+        )
+        saved = None
+        for url in candidates:
+            try:
+                content_type, data, final_url = _fetch(url)
+                match = _looks_like_image(data, content_type, final_url)
+                if match is None:
+                    skipped.append({"url": url, "reason": "not_image"})
+                    continue
+                mime, ext = match
+                filename = f"{slot['slot_id']}{ext}"
+                path = (output_dir / filename).resolve()
+                path.relative_to(output_dir)
+                path.write_bytes(data)
+                saved = {
+                    "slot_id": slot["slot_id"],
+                    "url": final_url,
+                    "local_path": f"{args.local_path_prefix.rstrip('/')}/{filename}",
+                    "mime": mime,
+                    "bytes": len(data),
+                    "subject": slot.get("subject", ""),
+                }
+                used_urls.add(url)
+                break
+            except (urllib.error.URLError, TimeoutError, ValueError, OSError) as exc:
+                skipped.append({"url": url, "reason": exc.__class__.__name__})
+        if saved is None:
+            unfilled.append({"slot_id": slot["slot_id"], "reason": "no_downloadable_image_url"})
+        else:
+            downloaded.append(saved)
+
+    print(
+        json.dumps(
+            {"downloaded": downloaded, "unfilled": unfilled, "skipped": skipped},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    )
+    for item in downloaded:
+        _emit(
+            "IMAGE_READY",
+            {
+                "local_path": item["local_path"],
+                "mime": item["mime"],
+                "bytes": item["bytes"],
+                "slot_id": item["slot_id"],
+                "subject": item.get("subject", ""),
+            },
+        )
+    if unfilled or (slots and not downloaded):
+        _emit(
+            "IMAGE_DOWNLOAD_INCOMPLETE",
+            {
+                "reason": "unfilled_image_slots",
+                "unfilled_slot_ids": [item["slot_id"] for item in unfilled],
+            },
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/opensquilla/skills/bundled/awesome-webpage-research/SKILL.md
+++ b/src/opensquilla/skills/bundled/awesome-webpage-research/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: awesome-webpage-research
+description: "Single-pass mini research for AwesomeWebpageMetaSkill: produce a short cited topic brief from one bounded web-search round. Not a general deep-research replacement."
+homepage: ""
+user-invocable: false
+disable-model-invocation: true
+provenance:
+  origin: opensquilla-original
+  license: Apache-2.0
+  maintained_by: OpenSquilla
+metadata:
+  opensquilla:
+    risk: medium
+    capabilities: [network-read]
+    requires:
+      bins: []
+      env: []
+---
+
+# Awesome Webpage Research (mini)
+
+Lightweight, single-pass topic research used only by `AwesomeWebpageMetaSkill`.
+Produce a concise topic brief with a short citation list so the page planner has
+factual anchors. This is **not** a replacement for the bundled `deep-research`
+skill; do not invoke it for general literature reviews or multi-round
+investigations.
+
+## Inputs
+
+The caller supplies:
+
+- `question`: the topic, audience, language, style, and webpage context to
+  research.
+
+## Protocol
+
+Single round. Three steps. No iteration, no plan.json, no state file.
+
+1. **Identify 3-5 focused sub-questions** that the page planner needs answered
+   to ground page sections. Cover what the topic is, why it matters, key facts,
+   common misconceptions, and at most one stat or date anchor. Do not exceed 5
+   sub-questions.
+2. **Run one bounded web-search round**: at most one search query per
+   sub-question. Use `web-search` for every language. Prefer recent, reputable
+   sources. Stop at one usable source per sub-question; do not chase broader
+   coverage and do not run a second round.
+3. **Compile a single brief** (target ~300-500 words) containing:
+   - one paragraph topic summary
+   - one paragraph "key facts" with inline `[1]`-style citation tags
+   - a `Sources` list of 3-5 entries formatted as `[n] Title — URL`
+   - a final `Page anchors:` line listing 3-5 short phrases that can become
+     section headings or callouts on the webpage
+
+## Rules
+
+- Do not iterate. One search round, one synthesis pass. Return as soon as the
+  brief is written.
+- Do not fetch full articles. Use search snippets; perform at most one quick
+  fetch per sub-question if a snippet is unusable.
+- Do not invent citations. Every `[n]` must map to a source in the `Sources`
+  list. If a source cannot be cited, drop the claim instead of fabricating one.
+- Do not produce a multi-page literature review. Cap the brief at ~500 words.
+- Do not search for images, audio, or video media here; media acquisition is
+  handled by other meta-skill steps.
+- Do not call `deep-research`, `summarize`, or any meta-skill from this step.
+- If the search round returns nothing usable, prepend a single line
+  `RESEARCH_THIN` to the brief and continue with a question-only summary
+  without inventing citations or sources.
+
+## Output
+
+Return only the brief text. No methodology notes, no per-source commentary,
+no JSON wrapper. The caller will truncate this output before feeding it to
+the page planner.

--- a/src/opensquilla/skills/bundled/filesystem/LICENSE.md
+++ b/src/opensquilla/skills/bundled/filesystem/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Clawdbot Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/opensquilla/skills/bundled/filesystem/README.md
+++ b/src/opensquilla/skills/bundled/filesystem/README.md
@@ -1,0 +1,322 @@
+# 📁 Filesystem Management
+
+Advanced filesystem operations for AI agents. Comprehensive file and directory operations with intelligent filtering, searching, and batch processing capabilities.
+
+[![Version](https://img.shields.io/badge/version-1.0.0-blue)](https://clawdhub.com/unknown/clawdbot-filesystem)
+[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D14.0.0-brightgreen)](https://nodejs.org/)
+
+## 🚀 Features
+
+### 📋 **Smart File Listing**
+- **Advanced Filtering** - Filter by file types, patterns, size, and date
+- **Recursive Traversal** - Deep directory scanning with depth control
+- **Rich Formatting** - Table, tree, and JSON output formats
+- **Sort Options** - By name, size, date, or type
+
+### 🔍 **Powerful Search**
+- **Pattern Matching** - Glob patterns and regex support
+- **Content Search** - Full-text search within files
+- **Multi-criteria** - Combine filename and content searches
+- **Context Display** - Show matching lines with context
+
+### 🔄 **Batch Operations**
+- **Safe Copying** - Pattern-based file copying with validation
+- **Dry Run Mode** - Preview operations before execution
+- **Progress Tracking** - Real-time operation progress
+- **Error Handling** - Graceful failure recovery
+
+### 🌳 **Directory Analysis**
+- **Tree Visualization** - ASCII tree structure display
+- **Statistics** - File counts, size distribution, type analysis
+- **Space Analysis** - Identify large files and directories
+- **Performance Metrics** - Operation timing and optimization
+
+## 📦 Installation
+
+### Via ClawdHub (Recommended)
+
+```bash
+clawdhub install filesystem
+```
+
+### Manual Installation
+
+```bash
+# Clone the skill
+git clone https://github.com/gtrusler/clawdbot-filesystem.git
+cd clawdbot-filesystem
+
+# Make executable
+chmod +x filesystem
+
+# Optional: Install globally
+npm install -g .
+```
+
+## 🛠️ Usage
+
+### Basic Commands
+
+```bash
+# List files in current directory
+filesystem list
+
+# List with details and filtering
+filesystem list --path ./src --recursive --filter "*.js" --details
+
+# Search for content
+filesystem search --pattern "TODO" --path ./src --content
+
+# Copy files safely
+filesystem copy --pattern "*.log" --to ./backup/ --dry-run
+
+# Show directory tree
+filesystem tree --path ./ --depth 3
+
+# Analyze directory
+filesystem analyze --path ./logs --stats --largest 10
+```
+
+### Advanced Examples
+
+#### Development Workflow
+```bash
+# Find all JavaScript files in project
+filesystem list --path ./src --recursive --filter "*.js" --sort size
+
+# Search for TODO comments with context
+filesystem search --pattern "TODO|FIXME|HACK" --content --context 3
+
+# Copy all configuration files
+filesystem copy --pattern "*.config.*" --to ./backup/configs/ --preserve
+
+# Analyze project structure
+filesystem tree --depth 2 --size
+```
+
+#### System Administration
+```bash
+# Find large log files
+filesystem analyze --path /var/log --sizes --largest 15
+
+# Search for error patterns in logs
+filesystem search --pattern "ERROR|FATAL" --path /var/log --content --include "*.log"
+
+# List recent files
+filesystem list --path /tmp --sort date --details
+
+# Clean analysis before deletion
+filesystem list --path /tmp --filter "*.tmp" --details
+```
+
+## ⚙️ Configuration
+
+The skill uses a `config.json` file for default settings:
+
+```json
+{
+  "defaultPath": "./",
+  "maxDepth": 10,
+  "excludePatterns": ["node_modules", ".git", ".DS_Store"],
+  "outputFormat": "table",
+  "colorOutput": true,
+  "performance": {
+    "maxFileSize": 52428800,
+    "maxFiles": 10000
+  },
+  "safety": {
+    "requireConfirmation": true,
+    "preventSystemPaths": true
+  }
+}
+```
+
+## 📖 Command Reference
+
+### `filesystem list`
+List files and directories with advanced filtering.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--path, -p` | Target directory | Current directory |
+| `--recursive, -r` | Include subdirectories | false |
+| `--filter, -f` | Filter by pattern | `*` |
+| `--details, -d` | Show file details | false |
+| `--sort, -s` | Sort by field | name |
+| `--format` | Output format | table |
+
+### `filesystem search`
+Search files by name patterns or content.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--pattern` | Search pattern | Required |
+| `--path, -p` | Search directory | Current directory |
+| `--content, -c` | Search file contents | false |
+| `--context` | Context lines | 2 |
+| `--include` | Include patterns | All files |
+| `--exclude` | Exclude patterns | None |
+
+### `filesystem copy`
+Batch copy files with pattern matching.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--pattern` | Source pattern | `*` |
+| `--to` | Destination directory | Required |
+| `--dry-run` | Preview only | false |
+| `--overwrite` | Allow overwrites | false |
+| `--preserve` | Preserve timestamps | false |
+
+### `filesystem tree`
+Display directory structure as a tree.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--path, -p` | Root directory | Current directory |
+| `--depth, -d` | Maximum depth | 3 |
+| `--dirs-only` | Show directories only | false |
+| `--size` | Show file sizes | false |
+| `--no-color` | Disable colors | false |
+
+### `filesystem analyze`
+Analyze directory structure and statistics.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--path, -p` | Target directory | Current directory |
+| `--stats` | Show statistics | true |
+| `--types` | Analyze file types | false |
+| `--sizes` | Size distribution | false |
+| `--largest` | Show N largest files | 10 |
+
+## 🛡️ Safety Features
+
+- **Path Validation** - Prevents directory traversal attacks
+- **Permission Checks** - Verifies access before operations
+- **Dry Run Mode** - Preview destructive operations
+- **Protected Paths** - Blocks system directory access
+- **Size Limits** - Prevents processing huge files
+- **Timeout Protection** - Prevents infinite operations
+
+## 🔧 Integration
+
+### With Other Clawdbot Skills
+
+```bash
+# Use with security skill
+security validate-command "filesystem list --path /etc"
+
+# Pipe to analysis tools
+filesystem list --format json | jq '.[] | select(.size > 1000000)'
+
+# Integration with Git workflows
+filesystem list --filter "*.js" --format json | git-analyze-changes
+```
+
+### Automation Examples
+
+```bash
+# Daily log analysis
+filesystem analyze --path /var/log --stats --largest 5
+
+# Code quality checks
+filesystem search --pattern "TODO|FIXME" --content --path ./src
+
+# Backup preparation
+filesystem copy --pattern "*.config*" --to ./backup/$(date +%Y%m%d)/
+```
+
+## 🧪 Testing
+
+Test the installation:
+
+```bash
+# Basic functionality
+filesystem help
+filesystem list --path . --details
+
+# Search capabilities
+echo "TODO: Test this function" > test.txt
+filesystem search --pattern "TODO" --content
+
+# Tree visualization
+filesystem tree --depth 2 --size
+
+# Analysis features
+filesystem analyze --stats --types
+```
+
+## 🐛 Troubleshooting
+
+### Common Issues
+
+**Permission Denied**
+```bash
+# Check file permissions
+ls -la filesystem
+chmod +x filesystem
+```
+
+**Large Directory Performance**
+```bash
+# Use filtering to narrow scope
+filesystem list --filter "*.log" --exclude "node_modules/*"
+
+# Limit depth for tree operations
+filesystem tree --depth 2
+```
+
+**Memory Issues with Large Files**
+```bash
+# Files larger than 50MB are skipped by default
+# Check current limits
+node -e "console.log(require('./config.json').performance)"
+```
+
+## 📈 Performance Tips
+
+- Use `--filter` to narrow file scope
+- Set appropriate `--depth` limits for tree operations
+- Enable exclusion patterns for common build directories
+- Use `--dry-run` first for batch operations
+- Monitor output with `--stats` for large directories
+
+## 🤝 Contributing
+
+1. **Report Issues** - Submit bugs and feature requests
+2. **Add Patterns** - Contribute common file patterns
+3. **Performance** - Submit optimization improvements
+4. **Documentation** - Help improve examples and guides
+
+## 📄 License
+
+MIT License - Free for personal and commercial use.
+
+See [LICENSE](LICENSE) file for details.
+
+## 🔗 Links
+
+- **ClawdHub** - [clawdhub.com/unknown/clawdbot-filesystem](https://clawdhub.com/unknown/clawdbot-filesystem)
+- **Issues** - [GitHub Issues](https://github.com/gtrusler/clawdbot-filesystem/issues)
+- **Documentation** - [Clawdbot Docs](https://docs.clawd.bot)
+
+## 📢 Updates & Community
+
+**Stay informed about the latest Clawdbot skills and filesystem tools:**
+
+- 🐦 **Follow [@LexpertAI](https://x.com/LexpertAI)** on X for skill updates and releases
+- 🛠️ **New filesystem features** and enhancements
+- 📋 **Best practices** for file management automation
+- 💡 **Tips and tricks** for productivity workflows
+
+Get early access to new skills and improvements by following @LexpertAI for:
+- **Skill announcements** and new releases
+- **Performance optimizations** and feature updates
+- **Integration examples** and workflow automation
+- **Community discussions** on productivity tools
+
+---
+
+**Built with ❤️ for the Clawdbot community**

--- a/src/opensquilla/skills/bundled/filesystem/SKILL.md
+++ b/src/opensquilla/skills/bundled/filesystem/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: filesystem
+description: Advanced filesystem operations - listing, searching, batch processing, and directory analysis for Clawdbot
+homepage: https://clawhub.ai/gtrusler/clawdbot-filesystem
+provenance:
+  origin: clawhub-mit0
+  license: MIT-0
+  upstream_url: https://clawhub.ai/gtrusler/clawdbot-filesystem
+  maintained_by: OpenSquilla
+metadata:
+  clawdbot:
+    emoji: "📁"
+    requires:
+      bins: [node]
+  opensquilla:
+    risk: medium
+    capabilities: [filesystem-read, filesystem-write, command-exec]
+    requires:
+      bins: []
+      env: []
+---
+
+# 📁 Filesystem Management
+
+Advanced filesystem operations for AI agents. Comprehensive file and directory operations with intelligent filtering, searching, and batch processing capabilities.
+
+## OpenSquilla Compatibility Contract
+
+When invoked from OpenSquilla, use the host-provided filesystem tools in the
+current workspace. Do not install `clawdbot-filesystem`, do not call ClawHub,
+and do not assume a standalone `filesystem` binary exists.
+
+For `AwesomeWebpageMetaSkill` local packaging:
+
+- Use only the `config.awesome_webpage.output_dir` supplied by the caller.
+- Create or verify exactly:
+  - `project/index.html`
+  - `project/style.css`
+  - `project/script.js`
+  - `project/assets/images`
+  - `project/assets/audio`
+  - `project/assets/video`
+- Keep all paths inside the current OpenSquilla workspace or the supplied
+  output directory.
+- If generation did not produce files, return `PACKAGING_BLOCKED` with the
+  missing paths; do not try to discover unrelated config files.
+
+## Features
+
+### 📋 **Smart File Listing**
+- **Advanced Filtering** - Filter by file types, patterns, size, and date
+- **Recursive Traversal** - Deep directory scanning with depth control
+- **Rich Formatting** - Table, tree, and JSON output formats
+- **Sort Options** - By name, size, date, or type
+
+### 🔍 **Powerful Search**
+- **Pattern Matching** - Glob patterns and regex support
+- **Content Search** - Full-text search within files
+- **Multi-criteria** - Combine filename and content searches
+- **Context Display** - Show matching lines with context
+
+### 🔄 **Batch Operations**
+- **Safe Copying** - Pattern-based file copying with validation
+- **Dry Run Mode** - Preview operations before execution
+- **Progress Tracking** - Real-time operation progress
+- **Error Handling** - Graceful failure recovery
+
+### 🌳 **Directory Analysis**
+- **Tree Visualization** - ASCII tree structure display
+- **Statistics** - File counts, size distribution, type analysis
+- **Space Analysis** - Identify large files and directories
+- **Performance Metrics** - Operation timing and optimization
+
+## Quick Start
+
+```bash
+# List files with filtering
+filesystem list --path ./src --recursive --filter "*.js"
+
+# Search for content
+filesystem search --pattern "TODO" --path ./src --content
+
+# Batch copy with safety
+filesystem copy --pattern "*.log" --to ./backup/ --dry-run
+
+# Show directory tree
+filesystem tree --path ./ --depth 3
+
+# Analyze directory structure
+filesystem analyze --path ./logs --stats
+```
+
+## Command Reference
+
+### `filesystem list`
+Advanced file and directory listing with filtering options.
+
+**Options:**
+- `--path, -p <dir>` - Target directory (default: current)
+- `--recursive, -r` - Include subdirectories
+- `--filter, -f <pattern>` - Filter files by pattern
+- `--details, -d` - Show detailed information
+- `--sort, -s <field>` - Sort by name|size|date
+- `--format <type>` - Output format: table|json|list
+
+### `filesystem search`
+Search files by name patterns or content.
+
+**Options:**
+- `--pattern <pattern>` - Search pattern (glob or regex)
+- `--path, -p <dir>` - Search directory
+- `--content, -c` - Search file contents
+- `--context <lines>` - Show context lines
+- `--include <pattern>` - Include file patterns
+- `--exclude <pattern>` - Exclude file patterns
+
+### `filesystem copy`
+Batch copy files with pattern matching and safety checks.
+
+**Options:**
+- `--pattern <glob>` - Source file pattern
+- `--to <dir>` - Destination directory
+- `--dry-run` - Preview without executing
+- `--overwrite` - Allow file overwrites
+- `--preserve` - Preserve timestamps and permissions
+
+### `filesystem tree`
+Display directory structure as a tree.
+
+**Options:**
+- `--path, -p <dir>` - Root directory
+- `--depth, -d <num>` - Maximum depth
+- `--dirs-only` - Show directories only
+- `--size` - Include file sizes
+- `--no-color` - Disable colored output
+
+### `filesystem analyze`
+Analyze directory structure and generate statistics.
+
+**Options:**
+- `--path, -p <dir>` - Target directory
+- `--stats` - Show detailed statistics
+- `--types` - Analyze file types
+- `--sizes` - Show size distribution
+- `--largest <num>` - Show N largest files
+
+## Installation
+
+```bash
+# Clone or install the skill
+cd ~/.clawdbot/skills
+git clone <filesystem-skill-repo>
+
+# Or install via ClawdHub
+clawdhub install filesystem
+
+# Make executable
+chmod +x filesystem/filesystem
+```
+
+## Configuration
+
+Customize behavior via `config.json`:
+
+```json
+{
+  "defaultPath": "./",
+  "maxDepth": 10,
+  "defaultFilters": ["*"],
+  "excludePatterns": ["node_modules", ".git", ".DS_Store"],
+  "outputFormat": "table",
+  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+  "sizeFormat": "human",
+  "colorOutput": true
+}
+```
+
+## Examples
+
+### Development Workflow
+```bash
+# Find all JavaScript files in src
+filesystem list --path ./src --recursive --filter "*.js" --details
+
+# Search for TODO comments
+filesystem search --pattern "TODO|FIXME" --path ./src --content --context 2
+
+# Copy all logs to backup
+filesystem copy --pattern "*.log" --to ./backup/logs/ --preserve
+
+# Analyze project structure
+filesystem tree --path ./ --depth 2 --size
+```
+
+### System Administration
+```bash
+# Find large files
+filesystem analyze --path /var/log --sizes --largest 10
+
+# List recent files
+filesystem list --path /tmp --sort date --details
+
+# Clean old temp files
+filesystem list --path /tmp --filter "*.tmp" --older-than 7d
+```
+
+## Safety Features
+
+- **Path Validation** - Prevents directory traversal attacks
+- **Permission Checks** - Verifies read/write access before operations
+- **Dry Run Mode** - Preview destructive operations
+- **Backup Prompts** - Suggests backups before overwrites
+- **Error Recovery** - Graceful handling of permission errors
+
+## Integration
+
+Works seamlessly with other Clawdbot tools:
+- **Security Skill** - Validates all filesystem operations
+- **Git Operations** - Respects .gitignore patterns
+- **Backup Tools** - Integrates with backup workflows
+- **Log Analysis** - Perfect for log file management
+
+## Updates & Community
+
+**Stay informed about the latest Clawdbot skills and filesystem tools:**
+
+- 🐦 **Follow [@LexpertAI](https://x.com/LexpertAI)** on X for skill updates and releases
+- 🛠️ **New filesystem features** and enhancements
+- 📋 **Best practices** for file management automation
+- 💡 **Tips and tricks** for productivity workflows
+
+Get early access to new skills and improvements by following @LexpertAI for:
+- **Skill announcements** and new releases
+- **Performance optimizations** and feature updates
+- **Integration examples** and workflow automation
+- **Community discussions** on productivity tools
+
+## License
+
+MIT License - Free for personal and commercial use.
+
+---
+
+**Remember**: Great filesystem management starts with the right tools. This skill provides comprehensive operations while maintaining safety and performance.

--- a/src/opensquilla/skills/bundled/filesystem/SKILL.md
+++ b/src/opensquilla/skills/bundled/filesystem/SKILL.md
@@ -3,8 +3,8 @@ name: filesystem
 description: Advanced filesystem operations - listing, searching, batch processing, and directory analysis for Clawdbot
 homepage: https://clawhub.ai/gtrusler/clawdbot-filesystem
 provenance:
-  origin: clawhub-mit0
-  license: MIT-0
+  origin: clawhub-mit
+  license: MIT
   upstream_url: https://clawhub.ai/gtrusler/clawdbot-filesystem
   maintained_by: OpenSquilla
 metadata:

--- a/src/opensquilla/skills/bundled/filesystem/_meta.json
+++ b/src/opensquilla/skills/bundled/filesystem/_meta.json
@@ -1,0 +1,6 @@
+{
+  "ownerId": "kn75ern1yrt48gjz2dekpapg497zytck",
+  "slug": "clawdbot-filesystem",
+  "version": "1.0.2",
+  "publishedAt": 1769481608074
+}

--- a/src/opensquilla/skills/bundled/filesystem/config.json
+++ b/src/opensquilla/skills/bundled/filesystem/config.json
@@ -1,0 +1,41 @@
+{
+  "name": "clawdbot-filesystem",
+  "version": "1.0.0",
+  "description": "Advanced filesystem operations for Clawdbot",
+  "defaultPath": "./",
+  "maxDepth": 10,
+  "defaultFilters": ["*"],
+  "excludePatterns": [
+    "node_modules",
+    ".git",
+    ".DS_Store",
+    "*.tmp",
+    "*.swp",
+    "*.log~",
+    ".cache",
+    "dist",
+    "build"
+  ],
+  "outputFormat": "table",
+  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+  "sizeFormat": "human",
+  "colorOutput": true,
+  "performance": {
+    "maxFileSize": 52428800,
+    "maxFiles": 10000,
+    "timeoutMs": 30000
+  },
+  "safety": {
+    "requireConfirmation": true,
+    "preventSystemPaths": true,
+    "allowedOperations": ["read", "copy", "analyze"],
+    "protectedPaths": [
+      "/etc",
+      "/var/lib",
+      "/usr/bin",
+      "/system",
+      "C:\\Windows",
+      "C:\\Program Files"
+    ]
+  }
+}

--- a/src/opensquilla/skills/bundled/filesystem/package.json
+++ b/src/opensquilla/skills/bundled/filesystem/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "clawdbot-filesystem",
+  "version": "1.0.2",
+  "description": "Advanced filesystem operations - listing, searching, batch processing, and analysis",
+  "main": "filesystem",
+  "bin": {
+    "filesystem": "./filesystem"
+  },
+  "scripts": {
+    "start": "node filesystem",
+    "test": "node filesystem help",
+    "install-global": "npm link",
+    "uninstall-global": "npm unlink"
+  },
+  "keywords": [
+    "clawdbot",
+    "filesystem",
+    "files",
+    "directories",
+    "search",
+    "batch-operations",
+    "file-management",
+    "cli-tool",
+    "ai-agent",
+    "automation"
+  ],
+  "author": "Clawdbot Community",
+  "license": "MIT",
+  "homepage": "https://clawdhub.com/unknown/clawdbot-filesystem",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gtrusler/clawdbot-filesystem"
+  },
+  "bugs": {
+    "url": "https://github.com/gtrusler/clawdbot-filesystem/issues"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "os": ["darwin", "linux", "win32"],
+  "preferGlobal": true,
+  "files": [
+    "filesystem",
+    "config.json",
+    "SKILL.md",
+    "README.md",
+    "LICENSE.md"
+  ],
+  "clawdbot": {
+    "skill": true,
+    "emoji": "📁",
+    "category": "System Tools",
+    "requires": {
+      "bins": ["node"]
+    },
+    "permissions": {
+      "filesystem": "read-write",
+      "network": "none",
+      "system": "none"
+    },
+    "tags": [
+      "filesystem",
+      "files",
+      "search",
+      "batch-ops",
+      "productivity"
+    ]
+  }
+}

--- a/src/opensquilla/skills/bundled/filesystem/skill-card.md
+++ b/src/opensquilla/skills/bundled/filesystem/skill-card.md
@@ -1,0 +1,40 @@
+## Description: <br>
+Advanced filesystem operations for listing, searching, batch processing, and directory analysis. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Publisher: <br>
+[gtrusler](https://clawhub.ai/user/gtrusler) <br>
+
+### License/Terms of Use: <br>
+MIT <br>
+
+
+## Use Case: <br>
+Developers and automation users use this skill to inspect local directories, search file names or contents, analyze storage patterns, and prepare controlled copy operations. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: The skill is designed to inspect and copy local files, so broad paths or sensitive directories can expose or move data unintentionally. <br>
+Mitigation: Keep paths narrow, avoid sensitive directories unless intended, and use dry-run mode before copy operations. <br>
+Risk: The security evidence notes that the scanned artifact set did not include the runnable filesystem binary. <br>
+Mitigation: Review the actual CLI implementation from the resolved package or source before executing it in a trusted environment. <br>
+
+
+## Reference(s): <br>
+- [ClawHub skill page](https://clawhub.ai/gtrusler/clawdbot-filesystem) <br>
+
+
+## Skill Output: <br>
+**Output Type(s):** [text, markdown, shell commands, configuration, guidance] <br>
+**Output Format:** [Markdown or plain text with inline shell commands and optional JSON output from the filesystem CLI] <br>
+**Output Parameters:** [1D] <br>
+**Other Properties Related to Output:** [Requires Node.js and local filesystem access; dry-run mode is recommended before copy operations.] <br>
+
+## Skill Version(s): <br>
+1.0.2 (source: server release metadata and package.json) <br>
+
+## Ethical Considerations: <br>
+Users should evaluate whether this skill is appropriate for their environment, review any generated or modified files before relying on them, and apply their organization's safety, security, and compliance requirements before deployment. <br>

--- a/src/opensquilla/skills/bundled/html-coder/SKILL.md
+++ b/src/opensquilla/skills/bundled/html-coder/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: html-coder
+description: 'Expert HTML development skill for building web pages, forms, and interactive content. Use when creating HTML documents, structuring web content, implementing semantic markup, adding forms and media, working with HTML5 APIs, or needing HTML templates, best practices, and accessibility guidance. Supports modern HTML5 standards and responsive design patterns.'
+homepage: https://clawhub.ai/jhauga/html-coder
+collaborators:
+  - make-skill-template
+  - finalize-agent-prompt
+provenance:
+  origin: clawhub-mit0
+  license: MIT-0
+  upstream_url: https://clawhub.ai/jhauga/html-coder
+  maintained_by: OpenSquilla
+---
+
+# HTML Coder Skill
+
+Expert skill for professional HTML development with focus on semantic markup, accessibility, HTML5 features, and standards-compliant web content.
+
+## When to Use This Skill
+
+- Creating HTML documents with semantic structure
+- Building accessible forms with HTML5 validation
+- Implementing responsive markup and multimedia
+- Using HTML5 APIs (Canvas, SVG, Storage, Geolocation)
+- Troubleshooting validation or accessibility issues
+
+## Core Capabilities
+
+- **Semantic HTML**: Document structure, content sections, accessibility-first markup
+- **Forms**: All input types, validation attributes, fieldsets, labels
+- **Media**: Responsive images, audio/video, Canvas, SVG
+- **HTML5 APIs**: Web Storage, Geolocation, Drag & Drop, Web Workers
+- **Accessibility**: ARIA, screen reader support, WCAG compliance
+
+## Essential References
+
+Core documentation for HTML experts:
+
+- [`references/add-css-style.md`](references/add-css-style.md) - Add CSS via `link` tag, inline, or embedded in html
+- [`references/add-javascript.md`](references/add-javascript.md) - Add JavaScript via `script src="link.js"` tag, inline `script`, or embedded in html
+- [`references/attributes.md`](references/attributes.md) - HTML attribute essentials
+- [`references/essentials.md`](references/essentials.md) - Semantic markup, validation, responsive techniques
+- [`references/global-attributes.md`](references/global-attributes.md) - Complete global attribute information
+- [`references/glossary.md`](references/glossary.md) - Complete HTML element and attribute reference
+- [`references/standards.md`](references/standards.md) - HTML5 specifications and standards
+
+## Best Practices
+
+**Semantic HTML** - Use elements that convey meaning: `<article>`, `<nav>`, `<header>`, `<section>`, `<footer>`, not div soup.
+
+**Accessibility First** - Proper heading hierarchy, alt text, labels with inputs, keyboard navigation, ARIA when needed.
+
+**HTML5 Validation** - Leverage built-in validation (`required`, `pattern`, `type="email"`) before JavaScript.
+
+**Responsive Images** - Use `<picture>`, srcset, and `loading="lazy"` for performance.
+
+**Performance** - Minimize DOM depth, optimize images, defer non-critical scripts, use semantic elements.
+
+## Quick Patterns
+
+### Semantic Page Structure
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Title</title>
+</head>
+<body>
+  <header><nav><!-- Navigation --></nav></header>
+  <main><article><!-- Content --></article></main>
+  <aside><!-- Sidebar --></aside>
+  <footer><!-- Footer --></footer>
+</body>
+</html>
+```
+
+### Accessible Form
+```html
+<form method="post" action="/submit">
+  <fieldset>
+    <legend>Contact</legend>
+    <label for="email">Email:</label>
+    <input type="email" id="email" name="email" required
+           pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$">
+    <button type="submit">Send</button>
+  </fieldset>
+</form>
+```
+
+### Responsive Image
+```html
+<picture>
+  <source media="(min-width: 1200px)" srcset="large.webp">
+  <source media="(min-width: 768px)" srcset="medium.webp">
+  <img src="small.jpg" alt="Description" loading="lazy">
+</picture>
+```
+
+## Troubleshooting
+
+- **Validation**: W3C Validator (validator.w3.org), check unclosed tags, verify nesting
+- **Accessibility**: Lighthouse audit, screen reader testing, keyboard nav, color contrast
+- **Compatibility**: Can I Use (caniuse.com), feature detection, provide fallbacks
+
+## Key Standards
+
+- **WHATWG HTML Living Standard**: https://html.spec.whatwg.org/
+- **WCAG Accessibility**: https://www.w3.org/WAI/WCAG21/quickref/
+- **MDN Web Docs**: https://developer.mozilla.org/en-US/docs/Web/HTML
+
+---

--- a/src/opensquilla/skills/bundled/html-coder/_meta.json
+++ b/src/opensquilla/skills/bundled/html-coder/_meta.json
@@ -1,0 +1,6 @@
+{
+  "ownerId": "kn71kvdba3t2jfkk6nbgnytg0s81617g",
+  "slug": "html-coder",
+  "version": "2.0.1",
+  "publishedAt": 1773099612731
+}

--- a/src/opensquilla/skills/bundled/html-coder/references/add-css-style.md
+++ b/src/opensquilla/skills/bundled/html-coder/references/add-css-style.md
@@ -1,0 +1,591 @@
+# Adding CSS Styling to HTML
+
+Complete guide to integrating CSS (Cascading Style Sheets) with HTML for presentation and layout.
+
+## Methods of Adding CSS
+
+### 1. External Stylesheet (Recommended)
+
+**Best for**: Production websites, reusable styles, maintainable code
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page Title</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Heading</h1>
+  <p>Content</p>
+</body>
+</html>
+```
+
+**Advantages**:
+- ✅ Separates content from presentation
+- ✅ Reusable across multiple pages
+- ✅ Cached by browser (faster page loads)
+- ✅ Easier to maintain
+- ✅ Can be developed separately
+
+**Multiple stylesheets**:
+```html
+<link rel="stylesheet" href="reset.css">
+<link rel="stylesheet" href="layout.css">
+<link rel="stylesheet" href="theme.css">
+```
+
+### 2. Internal Stylesheet
+
+**Best for**: Single-page applications, unique page-specific styles, email HTML
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page Title</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f0f0f0;
+      margin: 0;
+      padding: 20px;
+    }
+
+    h1 {
+      color: #333;
+      border-bottom: 2px solid #0066cc;
+    }
+
+    .highlight {
+      background-color: yellow;
+    }
+  </style>
+</head>
+<body>
+  <h1>Heading</h1>
+  <p class="highlight">Highlighted text</p>
+</body>
+</html>
+```
+
+**Advantages**:
+- ✅ No external HTTP request
+- ✅ Good for critical above-the-fold CSS
+- ✅ Useful for email templates
+
+**Disadvantages**:
+- ❌ Not reusable across pages
+- ❌ Not cached separately
+- ❌ Increases HTML file size
+
+### 3. Inline Styles
+
+**Best for**: Dynamic styles, urgent overrides, email HTML (when required)
+
+```html
+<p style="color: red; font-weight: bold;">Important text</p>
+
+<div style="background-color: #f0f0f0; padding: 20px; border-radius: 8px;">
+  <h2 style="margin-top: 0;">Box Title</h2>
+  <p style="color: #666;">Box content</p>
+</div>
+```
+
+**Advantages**:
+- ✅ Highest specificity (overrides other styles)
+- ✅ No class/ID needed
+- ✅ Works in HTML emails
+
+**Disadvantages**:
+- ❌ Hard to maintain
+- ❌ Not reusable
+- ❌ Mixes content and presentation
+- ❌ Increases HTML file size
+- ❌ Can't use pseudo-classes/elements
+
+**When to use**:
+- Dynamically generated styles via JavaScript
+- Email HTML templates
+- Quick testing (remove before production)
+
+## Link Element Attributes
+
+### Basic Link Element
+
+```html
+<link rel="stylesheet" href="styles.css">
+```
+
+### Complete Link Element
+
+```html
+<link rel="stylesheet"
+      href="styles.css"
+      type="text/css"
+      media="screen"
+      title="Main Styles">
+```
+
+### Important Attributes
+
+| Attribute | Purpose | Values |
+|-----------|---------|--------|
+| `rel` | Relationship | `stylesheet` (required) |
+| `href` | File location | URL or path |
+| `type` | MIME type | `text/css` (optional, default) |
+| `media` | Media query | `screen`, `print`, `all`, custom query |
+| `title` | Stylesheet name | Text (for alternate stylesheets) |
+| `crossorigin` | CORS mode | `anonymous`, `use-credentials` |
+| `integrity` | SRI hash | Hash value for security |
+
+## Media Queries in HTML
+
+### Responsive Stylesheets
+
+Load different CSS files for different devices:
+
+```html
+<!-- Mobile-first approach -->
+<link rel="stylesheet" href="base.css">
+<link rel="stylesheet" href="tablet.css" media="(min-width: 768px)">
+<link rel="stylesheet" href="desktop.css" media="(min-width: 1024px)">
+
+<!-- Print styles -->
+<link rel="stylesheet" href="print.css" media="print">
+
+<!-- Dark mode support -->
+<link rel="stylesheet" href="light.css" media="(prefers-color-scheme: light)">
+<link rel="stylesheet" href="dark.css" media="(prefers-color-scheme: dark)">
+```
+
+### Common Media Queries
+
+```html
+<!-- Screen size -->
+<link rel="stylesheet" href="mobile.css" media="(max-width: 767px)">
+<link rel="stylesheet" href="desktop.css" media="(min-width: 768px)">
+
+<!-- Orientation -->
+<link rel="stylesheet" href="portrait.css" media="(orientation: portrait)">
+<link rel="stylesheet" href="landscape.css" media="(orientation: landscape)">
+
+<!-- High resolution displays -->
+<link rel="stylesheet" href="retina.css" media="(-webkit-min-device-pixel-ratio: 2)">
+
+<!-- Combined conditions -->
+<link rel="stylesheet" href="tablet-portrait.css"
+      media="(min-width: 768px) and (max-width: 1023px) and (orientation: portrait)">
+```
+
+## CSS Loading Strategies
+
+### Critical CSS
+
+Inline critical above-the-fold CSS:
+
+```html
+<head>
+  <style>
+    /* Critical CSS for initial render */
+    body { margin: 0; font-family: sans-serif; }
+    .header { background: #333; color: white; padding: 1rem; }
+    .hero { min-height: 400px; background: #f0f0f0; }
+  </style>
+
+  <!-- Load full stylesheet asynchronously -->
+  <link rel="preload" href="styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="styles.css"></noscript>
+</head>
+```
+
+### Async CSS Loading
+
+Load non-critical CSS asynchronously:
+
+```html
+<!-- Method 1: Using preload -->
+<link rel="preload" href="styles.css" as="style" onload="this.rel='stylesheet'">
+
+<!-- Method 2: Using media query trick -->
+<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">
+```
+
+### Deferred Loading
+
+Load CSS after page load:
+
+```html
+<script>
+  // Load CSS after page load
+  window.addEventListener('load', function() {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'deferred.css';
+    document.head.appendChild(link);
+  });
+</script>
+```
+
+## CSS with Classes and IDs
+
+### Using Classes
+
+**HTML**:
+```html
+<div class="card">
+  <h2 class="card-title">Card Title</h2>
+  <p class="card-content">Card content goes here.</p>
+  <button class="btn btn-primary">Action</button>
+</div>
+```
+
+**CSS (external file)**:
+```css
+.card {
+  background: white;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.card-title {
+  font-size: 1.5rem;
+  margin-top: 0;
+}
+
+.card-content {
+  color: #666;
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background-color: #007bff;
+  color: white;
+}
+```
+
+### Using IDs
+
+**HTML**:
+```html
+<header id="main-header">
+  <nav id="primary-nav">
+    <!-- Navigation -->
+  </nav>
+</header>
+```
+
+**CSS**:
+```css
+#main-header {
+  background-color: #333;
+  color: white;
+  padding: 1rem;
+}
+
+#primary-nav {
+  display: flex;
+  gap: 1rem;
+}
+```
+
+**When to use**:
+- **Classes**: Reusable styles (preferred for styling)
+- **IDs**: Unique elements, JavaScript selection, anchor links
+
+## CSS Frameworks Integration
+
+### Bootstrap
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Bootstrap Page</title>
+
+  <!-- Bootstrap CSS -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+
+  <!-- Custom CSS (after Bootstrap) -->
+  <link rel="stylesheet" href="custom.css">
+</head>
+<body>
+  <div class="container">
+    <h1 class="text-primary">Hello Bootstrap</h1>
+    <button class="btn btn-success">Click Me</button>
+  </div>
+
+  <!-- Bootstrap JS -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>
+```
+
+### Tailwind CSS
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tailwind Page</title>
+
+  <!-- Tailwind CSS -->
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body>
+  <div class="container mx-auto px-4">
+    <h1 class="text-3xl font-bold text-blue-600">Hello Tailwind</h1>
+    <button class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">
+      Click Me
+    </button>
+  </div>
+</body>
+</html>
+```
+
+## CSS Variables in HTML
+
+Define CSS custom properties inline:
+
+```html
+<div style="--primary-color: #007bff; --spacing: 20px;">
+  <p style="color: var(--primary-color); padding: var(--spacing);">
+    Text using CSS variables
+  </p>
+</div>
+```
+
+**Better approach** (in `<style>` or external CSS):
+```html
+<style>
+  :root {
+    --primary-color: #007bff;
+    --secondary-color: #6c757d;
+    --spacing-sm: 0.5rem;
+    --spacing-md: 1rem;
+    --spacing-lg: 1.5rem;
+  }
+
+  .button {
+    background-color: var(--primary-color);
+    padding: var(--spacing-md);
+  }
+</style>
+```
+
+## Import Statements
+
+### @import in HTML
+
+```html
+<style>
+  @import url('reset.css');
+  @import url('typography.css');
+  @import url('layout.css');
+
+  /* Additional styles */
+  body {
+    background: white;
+  }
+</style>
+```
+
+**Note**: `@import` is slower than `<link>` because it blocks parallel downloads. Prefer multiple `<link>` tags.
+
+## Conditional CSS
+
+### Browser-Specific Styles
+
+```html
+<!--[if IE]>
+  <link rel="stylesheet" href="ie.css">
+<![endif]-->
+
+<!--[if lt IE 9]>
+  <script src="html5shiv.js"></script>
+<![endif]-->
+```
+
+**Note**: Conditional comments only work in IE ≤ 9 (obsolete).
+
+### Modern Feature Detection
+
+Use CSS feature queries in stylesheets:
+
+```css
+/* Modern grid layout */
+@supports (display: grid) {
+  .container {
+    display: grid;
+  }
+}
+
+/* Fallback for older browsers */
+@supports not (display: grid) {
+  .container {
+    display: flex;
+  }
+}
+```
+
+## CSS Reset/Normalize
+
+Include before custom styles:
+
+```html
+<head>
+  <!-- CSS Reset -->
+  <link rel="stylesheet" href="reset.css">
+
+  <!-- OR Normalize.css -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/normalize.css@8.0.1/normalize.min.css">
+
+  <!-- Custom styles -->
+  <link rel="stylesheet" href="styles.css">
+</head>
+```
+
+## Performance Optimization
+
+### Resource Hints
+
+```html
+<!-- Preconnect to font/CDN servers -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+<!-- Preload critical CSS -->
+<link rel="preload" href="critical.css" as="style">
+
+<!-- DNS prefetch for later resources -->
+<link rel="dns-prefetch" href="https://cdn.example.com">
+```
+
+### Font Loading
+
+```html
+<!-- Google Fonts optimized -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+
+<!-- Self-hosted fonts -->
+<link rel="preload" href="font.woff2" as="font" type="font/woff2" crossorigin>
+<style>
+  @font-face {
+    font-family: 'CustomFont';
+    src: url('font.woff2') format('woff2');
+    font-display: swap;
+  }
+</style>
+```
+
+## Best Practices
+
+### ✅ Do
+
+1. **Use external stylesheets** for reusable styles
+2. **Place `<link>` in `<head>`** for proper rendering
+3. **Use meaningful class names** (descriptive, not presentational)
+4. **Group related styles** in separate files
+5. **Minimize CSS file size** (minify for production)
+6. **Use CSS variables** for consistent theming
+7. **Implement mobile-first** responsive design
+8. **Load critical CSS inline** for faster initial render
+9. **Use `preload` for critical resources**
+10. **Version your CSS files** for cache busting (`styles.css?v=1.2`)
+
+### ❌ Don't
+
+1. **Don't use inline styles** extensively (hard to maintain)
+2. **Don't use `@import`** in production (blocks parallel downloads)
+3. **Don't override styles excessively** (indicates poor architecture)
+4. **Don't use !important** unless absolutely necessary
+5. **Don't write non-semantic class names** (`red-text`, `big-margin`)
+6. **Don't load unused CSS** (remove unused framework code)
+7. **Don't forget print styles** if printing is relevant
+8. **Don't mix CSS with HTML** attributes (use classes instead)
+9. **Don't use deprecated CSS** prefixes without autoprefixer
+10. **Don't forget to minify** CSS for production
+
+## Complete Example
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Complete CSS Integration Example</title>
+
+  <!-- Preconnect to external resources -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+  <!-- Critical CSS inline -->
+  <style>
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, sans-serif;
+      line-height: 1.6;
+    }
+    .header {
+      background: #333;
+      color: white;
+      padding: 1rem;
+    }
+  </style>
+
+  <!-- External stylesheets -->
+  <link rel="stylesheet" href="normalize.css">
+  <link rel="stylesheet" href="layout.css">
+  <link rel="stylesheet" href="components.css">
+  <link rel="stylesheet" href="utilities.css">
+
+  <!-- Media-specific styles -->
+  <link rel="stylesheet" href="print.css" media="print">
+
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="header">
+    <h1>Website Title</h1>
+  </header>
+
+  <main class="container">
+    <article class="card">
+      <h2 class="card-title">Article Title</h2>
+      <p class="card-content">Article content goes here.</p>
+    </article>
+  </main>
+
+  <footer class="footer">
+    <p>&copy; 2024 Website Name</p>
+  </footer>
+</body>
+</html>
+```
+
+## Resources
+
+- **MDN CSS Reference**: https://developer.mozilla.org/en-US/docs/Web/CSS
+- **CSS Tricks**: https://css-tricks.com/
+- **Can I Use**: https://caniuse.com/ (browser support)
+- **CSS Validator**: https://jigsaw.w3.org/css-validator/
+- **Google Fonts**: https://fonts.google.com/
+- **Normalize.css**: https://necolas.github.io/normalize.css/

--- a/src/opensquilla/skills/bundled/html-coder/references/add-javascript.md
+++ b/src/opensquilla/skills/bundled/html-coder/references/add-javascript.md
@@ -1,0 +1,792 @@
+# Adding JavaScript to HTML
+
+Complete guide to integrating JavaScript with HTML for interactivity and dynamic behavior.
+
+## Methods of Adding JavaScript
+
+### 1. External JavaScript File (Recommended)
+
+**Best for**: Production websites, reusable code, maintainable applications
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page Title</title>
+</head>
+<body>
+  <h1 id="heading">Hello World</h1>
+  <button id="changeBtn">Change Text</button>
+
+  <!-- Script at end of body -->
+  <script src="script.js"></script>
+</body>
+</html>
+```
+
+**script.js**:
+```javascript
+document.getElementById('changeBtn').addEventListener('click', function() {
+  document.getElementById('heading').textContent = 'Hello JavaScript!';
+});
+```
+
+**Advantages**:
+- ✅ Separates content from behavior
+- ✅ Reusable across multiple pages
+- ✅ Cached by browser (faster page loads)
+- ✅ Easier to maintain and debug
+- ✅ Can be developed separately
+- ✅ Cleaner HTML
+
+### 2. Inline JavaScript
+
+**Best for**: Small scripts, event handlers, quick testing
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Inline JavaScript</title>
+</head>
+<body>
+  <h1 id="heading">Hello World</h1>
+
+  <button onclick="changeText()">Change Text</button>
+  <button onclick="alert('Button clicked!')">Show Alert</button>
+
+  <script>
+    function changeText() {
+      document.getElementById('heading').textContent = 'Text Changed!';
+    }
+  </script>
+</body>
+</html>
+```
+
+**Advantages**:
+- ✅ Quick to implement
+- ✅ No external HTTP request
+- ✅ Good for small, page-specific scripts
+
+**Disadvantages**:
+- ❌ Not reusable across pages
+- ❌ Harder to maintain
+- ❌ Violates Content Security Policy (CSP)
+- ❌ Mixes content and behavior
+
+### 3. Inline Event Handlers
+
+**Best for**: Quick prototypes, simple interactions (not recommended for production)
+
+```html
+<!-- Inline onclick -->
+<button onclick="alert('Clicked!')">Click Me</button>
+
+<!-- Inline with parameters -->
+<button onclick="greet('John')">Greet John</button>
+
+<script>
+  function greet(name) {
+    alert('Hello, ' + name + '!');
+  }
+</script>
+
+<!-- Multiple statements (avoid) -->
+<button onclick="console.log('Log'); alert('Alert');">Click</button>
+```
+
+**Better approach** (external event listeners):
+```html
+<button id="myButton">Click Me</button>
+
+<script>
+  document.getElementById('myButton').addEventListener('click', function() {
+    alert('Clicked!');
+  });
+</script>
+```
+
+## Script Element Attributes
+
+### Basic Script Element
+
+```html
+<script src="script.js"></script>
+```
+
+### Important Attributes
+
+| Attribute | Purpose | Values |
+|-----------|---------|--------|
+| `src` | External file path | URL or relative path |
+| `type` | MIME type | `text/javascript` (default), `module` |
+| `async` | Async loading | Boolean (no value needed) |
+| `defer` | Deferred loading | Boolean (no value needed) |
+| `crossorigin` | CORS mode | `anonymous`, `use-credentials` |
+| `integrity` | SRI hash | Hash for security verification |
+| `nomodule` | Fallback for old browsers | Boolean |
+| `referrerpolicy` | Referrer header | `no-referrer`, `origin`, etc. |
+
+## Script Loading Strategies
+
+### 1. Default Loading (Blocking)
+
+```html
+<head>
+  <script src="script.js"></script>
+  <!-- Blocks HTML parsing and rendering -->
+</head>
+```
+
+**Behavior**:
+- Stops HTML parsing
+- Downloads script
+- Executes script immediately
+- Resumes HTML parsing
+
+**When to use**: Never (use `defer` or `async` instead)
+
+### 2. Defer Loading (Recommended for Most Scripts)
+
+```html
+<head>
+  <script src="script.js" defer></script>
+  <!-- HTML parsing continues -->
+</head>
+```
+
+**Behavior**:
+1. HTML parsing continues
+2. Script downloads in parallel
+3. Script executes after HTML parsing completes
+4. Maintains script order
+
+**When to use**:
+- ✅ Scripts that manipulate DOM
+- ✅ Scripts that depend on full HTML
+- ✅ Multiple scripts with dependencies
+- ✅ Most common use case
+
+### 3. Async Loading
+
+```html
+<head>
+  <script src="analytics.js" async></script>
+  <!-- HTML parsing continues -->
+</head>
+```
+
+**Behavior**:
+1. HTML parsing continues
+2. Script downloads in parallel
+3. Script executes as soon as downloaded (pauses HTML parsing)
+4. Does NOT maintain script order
+
+**When to use**:
+- ✅ Independent scripts (analytics, ads)
+- ✅ Scripts that don't depend on DOM
+- ✅ Scripts that don't depend on other scripts
+- ❌ NOT for scripts with dependencies
+
+### 4. Script at End of Body (Traditional)
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Page Title</title>
+</head>
+<body>
+  <h1>Content</h1>
+  <p>More content</p>
+
+  <!-- Scripts at end -->
+  <script src="script.js"></script>
+</body>
+</html>
+```
+
+**When to use**:
+- ✅ When `defer` is not available
+- ✅ Ensures DOM is fully loaded
+- ❌ Less efficient than `defer` in `<head>`
+
+### Comparison Table
+
+| Method | Parsing | Download | Execution | Order | Use Case |
+|--------|---------|----------|-----------|-------|----------|
+| Default | Blocks | Immediate | Immediate | Yes | ❌ Avoid |
+| `defer` | Continues | Parallel | After parse | Yes | ✅ DOM manipulation |
+| `async` | Continues | Parallel | ASAP | No | ✅ Independent scripts |
+| End of body | Continues | After parse | Immediate | Yes | ✅ Fallback method |
+
+## ES6 Modules
+
+### Module Script
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ES6 Modules</title>
+</head>
+<body>
+  <div id="app"></div>
+
+  <!-- ES6 module (automatically deferred) -->
+  <script type="module" src="main.js"></script>
+</body>
+</html>
+```
+
+**main.js**:
+```javascript
+import { greet } from './utils.js';
+import { render } from './render.js';
+
+greet('World');
+render();
+```
+
+**utils.js**:
+```javascript
+export function greet(name) {
+  console.log(`Hello, ${name}!`);
+}
+```
+
+### Module Features
+
+```html
+<!-- Import module -->
+<script type="module" src="app.js"></script>
+
+<!-- Inline module -->
+<script type="module">
+  import { func } from './module.js';
+  func();
+</script>
+
+<!-- Fallback for old browsers -->
+<script type="module" src="modern.js"></script>
+<script nomodule src="legacy.js"></script>
+```
+
+**Module characteristics**:
+- ✅ Automatically in strict mode
+- ✅ Automatically deferred
+- ✅ Have their own scope (not global)
+- ✅ Can use `import` and `export`
+- ✅ Only execute once (even if imported multiple times)
+
+## JavaScript Placement Best Practices
+
+### In `<head>` with `defer`
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page Title</title>
+
+  <!-- Recommended: defer in head -->
+  <script src="main.js" defer></script>
+  <script src="utils.js" defer></script>
+</head>
+<body>
+  <h1>Content loads without blocking</h1>
+</body>
+</html>
+```
+
+### Multiple Scripts with Dependencies
+
+```html
+<head>
+  <!-- Load in order (with defer) -->
+  <script src="jquery.min.js" defer></script>
+  <script src="plugin.js" defer></script>
+  <script src="app.js" defer></script>
+</head>
+```
+
+### Critical vs Non-Critical Scripts
+
+```html
+<head>
+  <!-- Critical: defer -->
+  <script src="critical.js" defer></script>
+
+  <!-- Non-critical: async -->
+  <script src="analytics.js" async></script>
+  <script src="ads.js" async></script>
+</head>
+```
+
+## Data Attributes for JavaScript
+
+### Storing Data in HTML
+
+```html
+<button
+  id="userBtn"
+  data-user-id="12345"
+  data-user-name="John Doe"
+  data-user-role="admin">
+  View Profile
+</button>
+
+<script>
+  const btn = document.getElementById('userBtn');
+
+  // Access dataset
+  console.log(btn.dataset.userId);    // "12345"
+  console.log(btn.dataset.userName);  // "John Doe"
+  console.log(btn.dataset.userRole);  // "admin"
+
+  // Modify dataset
+  btn.dataset.userId = '67890';
+</script>
+```
+
+### Complex Data
+
+```html
+<div id="config" data-settings='{"theme":"dark","lang":"en"}'></div>
+
+<script>
+  const config = document.getElementById('config');
+  const settings = JSON.parse(config.dataset.settings);
+  console.log(settings.theme); // "dark"
+</script>
+```
+
+## Common Integration Patterns
+
+### 1. DOM Content Loaded
+
+Wait for HTML to fully load:
+
+```html
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    // DOM is ready
+    console.log('DOM loaded');
+
+    const heading = document.getElementById('heading');
+    heading.textContent = 'DOM is ready!';
+  });
+</script>
+```
+
+### 2. Window Load Event
+
+Wait for everything (including images):
+
+```html
+<script>
+  window.addEventListener('load', function() {
+    // All resources loaded
+    console.log('Page fully loaded');
+  });
+</script>
+```
+
+### 3. Event Delegation
+
+```html
+<ul id="list">
+  <li>Item 1</li>
+  <li>Item 2</li>
+  <li>Item 3</li>
+</ul>
+
+<script>
+  // Event delegation on parent
+  document.getElementById('list').addEventListener('click', function(e) {
+    if (e.target.tagName === 'LI') {
+      console.log('Clicked:', e.target.textContent);
+    }
+  });
+</script>
+```
+
+### 4. Form Handling
+
+```html
+<form id="myForm">
+  <input type="text" id="name" name="name" required>
+  <input type="email" id="email" name="email" required>
+  <button type="submit">Submit</button>
+</form>
+
+<script>
+  document.getElementById('myForm').addEventListener('submit', function(e) {
+    e.preventDefault(); // Prevent default form submission
+
+    const formData = new FormData(this);
+    const name = formData.get('name');
+    const email = formData.get('email');
+
+    console.log('Name:', name);
+    console.log('Email:', email);
+
+    // Send data via AJAX
+    // fetch('/api/submit', { method: 'POST', body: formData });
+  });
+</script>
+```
+
+## CDN Integration
+
+### Popular Libraries
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>CDN JavaScript</title>
+</head>
+<body>
+  <div id="app"></div>
+
+  <!-- jQuery -->
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+          integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+          crossorigin="anonymous"></script>
+
+  <!-- React -->
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+
+  <!-- Vue.js -->
+  <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script>
+
+  <!-- Custom script (load after libraries) -->
+  <script src="app.js"></script>
+</body>
+</html>
+```
+
+### CDN Best Practices
+
+```html
+<!-- Always use integrity for security -->
+<script src="https://cdn.example.com/lib.js"
+        integrity="sha384-HASH"
+        crossorigin="anonymous"></script>
+
+<!-- Provide fallback -->
+<script src="https://cdn.example.com/jquery.min.js"></script>
+<script>
+  window.jQuery || document.write('<script src="local/jquery.min.js"><\/script>');
+</script>
+```
+
+## Script Loading Performance
+
+### Preloading Scripts
+
+```html
+<head>
+  <!-- Preload critical script -->
+  <link rel="preload" href="critical.js" as="script">
+
+  <!-- Actual script tag -->
+  <script src="critical.js" defer></script>
+</head>
+```
+
+### DNS Prefetch
+
+```html
+<head>
+  <!-- Resolve DNS early -->
+  <link rel="dns-prefetch" href="https://cdn.example.com">
+
+  <!-- Later in page -->
+  <script src="https://cdn.example.com/script.js" async></script>
+</head>
+```
+
+### Preconnect
+
+```html
+<head>
+  <!-- Establish connection early -->
+  <link rel="preconnect" href="https://api.example.com">
+
+  <!-- Script will use this connection -->
+  <script src="https://api.example.com/sdk.js" async></script>
+</head>
+```
+
+## Content Security Policy (CSP)
+
+### Strict CSP
+
+```html
+<head>
+  <!-- Only allow scripts from same origin -->
+  <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
+</head>
+```
+
+### Allowing specific sources
+
+```html
+<meta http-equiv="Content-Security-Policy"
+      content="script-src 'self' https://cdn.example.com https://analytics.example.com">
+```
+
+### Using nonce
+
+```html
+<head>
+  <meta http-equiv="Content-Security-Policy"
+        content="script-src 'nonce-r@nd0m'">
+</head>
+<body>
+  <!-- Only scripts with matching nonce execute -->
+  <script nonce="r@nd0m">
+    console.log('This script runs');
+  </script>
+
+  <script>
+    console.log('This script is blocked');
+  </script>
+</body>
+```
+
+## JavaScript Framework Integration
+
+### React
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>React App</title>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+  <script type="text/babel">
+    function App() {
+      return <h1>Hello React!</h1>;
+    }
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<App />);
+  </script>
+</body>
+</html>
+```
+
+### Vue.js
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Vue App</title>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+</head>
+<body>
+  <div id="app">
+    <h1>{{ message }}</h1>
+    <button @click="changeMessage">Click Me</button>
+  </div>
+
+  <script>
+    const { createApp } = Vue;
+
+    createApp({
+      data() {
+        return {
+          message: 'Hello Vue!'
+        };
+      },
+      methods: {
+        changeMessage() {
+          this.message = 'Message changed!';
+        }
+      }
+    }).mount('#app');
+  </script>
+</body>
+</html>
+```
+
+## Error Handling
+
+### Global Error Handler
+
+```html
+<script>
+  window.addEventListener('error', function(event) {
+    console.error('Error:', event.message);
+    console.error('File:', event.filename);
+    console.error('Line:', event.lineno);
+
+    // Log to error tracking service
+    // trackError(event);
+  });
+</script>
+```
+
+### Try-Catch Blocks
+
+```html
+<script>
+  try {
+    // Code that might throw error
+    riskyFunction();
+  } catch (error) {
+    console.error('Caught error:', error.message);
+    // Handle error gracefully
+  } finally {
+    console.log('Cleanup code');
+  }
+</script>
+```
+
+## Best Practices
+
+### ✅ Do
+
+1. **Use `defer` for regular scripts** in `<head>`
+2. **Use `async` for independent scripts** (analytics, ads)
+3. **Place scripts before closing `</body>`** if `defer` not supported
+4. **Use external files** for reusable code
+5. **Use event listeners** instead of inline handlers
+6. **Validate user input** on both client and server
+7. **Use `type="module"`** for modern JavaScript
+8. **Implement error handling** for better UX
+9. **Minify JavaScript** for production
+10. **Use SRI** for CDN scripts (`integrity` attribute)
+11. **Separate concerns** (HTML, CSS, JS)
+12. **Use data attributes** for passing data from HTML to JS
+13. **Implement CSP** for security
+14. **Test across browsers** for compatibility
+15. **Use descriptive function/variable names**
+
+### ❌ Don't
+
+1. **Don't use inline event handlers** (violates CSP)
+2. **Don't block HTML parsing** (avoid scripts in `<head>` without `defer`)
+3. **Don't use `document.write()`** (deprecated)
+4. **Don't trust user input** (always validate/sanitize)
+5. **Don't use global variables excessively** (use modules/closures)
+6. **Don't load unnecessary libraries** (increases page size)
+7. **Don't ignore browser console errors**
+8. **Don't use `eval()`** (security risk)
+9. **Don't forget fallbacks** for CDN resources
+10. **Don't mix inline and external code** unnecessarily
+11. **Don't forget to remove `console.log()`** in production
+12. **Don't use deprecated features** (check browser compatibility)
+13. **Don't ignore accessibility** (keyboard navigation, screen readers)
+14. **Don't forget mobile optimization**
+15. **Don't hardcode sensitive data** in JavaScript
+
+## Complete Example
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Complete JavaScript Integration</title>
+
+  <!-- Content Security Policy -->
+  <meta http-equiv="Content-Security-Policy"
+        content="script-src 'self' https://cdn.example.com">
+
+  <!-- Preconnect to CDN -->
+  <link rel="preconnect" href="https://cdn.example.com">
+
+  <!-- Preload critical script -->
+  <link rel="preload" href="app.js" as="script">
+
+  <!-- Critical scripts with defer -->
+  <script src="app.js" defer></script>
+  <script src="utils.js" defer></script>
+
+  <!-- Analytics with async -->
+  <script src="https://cdn.example.com/analytics.js" async></script>
+</head>
+<body>
+  <header>
+    <h1 id="heading">Hello World</h1>
+  </header>
+
+  <main>
+    <button id="changeBtn" data-text="Hello JavaScript!">
+      Change Text
+    </button>
+
+    <form id="contactForm">
+      <input type="text" id="name" name="name" required>
+      <input type="email" id="email" name="email" required>
+      <button type="submit">Submit</button>
+    </form>
+  </main>
+
+  <!-- Inline script for critical functionality -->
+  <script>
+    // Global error handler
+    window.addEventListener('error', function(event) {
+      console.error('Error:', event.message);
+    });
+  </script>
+</body>
+</html>
+```
+
+**app.js**:
+```javascript
+// Wait for DOM to be ready (note: defer already ensures this)
+document.addEventListener('DOMContentLoaded', function() {
+  // Button click handler
+  const btn = document.getElementById('changeBtn');
+  btn.addEventListener('click', function() {
+    const newText = this.dataset.text;
+    document.getElementById('heading').textContent = newText;
+  });
+
+  // Form submission handler
+  const form = document.getElementById('contactForm');
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+
+    const formData = new FormData(this);
+    console.log('Form submitted:', Object.fromEntries(formData));
+
+    // Process form data
+    // submitForm(formData);
+  });
+});
+```
+
+## Resources
+
+- **MDN JavaScript Guide**: https://developer.mozilla.org/en-US/docs/Web/JavaScript
+- **JavaScript.info**: https://javascript.info/
+- **Can I Use**: https://caniuse.com/ (browser support)
+- **JSHint**: https://jshint.com/ (code quality)
+- **ESLint**: https://eslint.org/ (linting)
+- **Babel**: https://babeljs.io/ (transpiler)
+- **SRI Hash Generator**: https://www.srihash.org/

--- a/src/opensquilla/skills/bundled/html-coder/references/attributes.md
+++ b/src/opensquilla/skills/bundled/html-coder/references/attributes.md
@@ -1,0 +1,368 @@
+# HTML Attributes Reference
+
+Comprehensive guide to common HTML attributes, input types, script configurations, and meta element usage.
+
+## Input Types (`<input type="...">`)
+
+The `type` attribute determines the behavior and appearance of input controls.
+
+### Text-Based Input Types
+
+| Type | Purpose | Key Attributes |
+|------|---------|----------------|
+| `text` | Single-line text (default) | `maxlength`, `minlength`, `pattern`, `placeholder`, `size` |
+| `password` | Obscured text for passwords | `maxlength`, `minlength`, `pattern` |
+| `email` | Email address validation | `multiple`, `pattern`, `placeholder` |
+| `url` | URL validation | `pattern`, `placeholder` |
+| `tel` | Telephone number input | `pattern`, `placeholder` |
+| `search` | Search field with clear button | `placeholder`, `list` |
+| `textarea` | Multi-line text (separate element) | `rows`, `cols`, `maxlength`, `wrap` |
+
+### Date and Time Input Types
+
+| Type | Format | Example |
+|------|--------|---------|
+| `date` | Year-month-day | 2024-01-15 |
+| `datetime-local` | Date and time, no timezone | 2024-01-15T14:30 |
+| `month` | Year and month | 2024-01 |
+| `week` | Year and week number | 2024-W03 |
+| `time` | Hours and minutes | 14:30 |
+
+**Common attributes**: `min`, `max`, `step`
+
+### Numeric Input Types
+
+| Type | Purpose | Attributes |
+|------|---------|------------|
+| `number` | Numeric input with spinner | `min`, `max`, `step` |
+| `range` | Slider control | `min`, `max`, `step` |
+
+### Selection Input Types
+
+| Type | Purpose | Usage |
+|------|---------|-------|
+| `checkbox` | Toggle option on/off | Groups by `name`, checked individually |
+| `radio` | Select one from group | Same `name` required for grouping |
+| `select` | Dropdown menu (separate element) | Contains `<option>` elements |
+
+### File and Media Input Types
+
+| Type | Purpose | Attributes |
+|------|---------|------------|
+| `file` | File upload | `accept`, `multiple`, `capture` |
+| `color` | Color picker | `value` (hex color) |
+| `image` | Graphical submit button | `src`, `alt`, `width`, `height` |
+
+### Button Input Types
+
+| Type | Purpose | Default Behavior |
+|------|---------|-----------------|
+| `button` | Generic button | None (requires JavaScript) |
+| `submit` | Form submission | Submits form to `action` URL |
+| `reset` | Form reset (not recommended) | Resets all fields to default |
+
+### Special Input Types
+
+| Type | Purpose |
+|------|---------|
+| `hidden` | Invisible data field |
+
+### Deprecated Input Type
+
+| Type | Status | Alternative |
+|------|--------|-------------|
+| `datetime` | Deprecated | Use `datetime-local` |
+
+## Common Input Attributes
+
+### Form Control Attributes
+
+| Attribute | Valid For | Purpose |
+|-----------|-----------|---------|
+| `name` | All except image/button without form | Identifies field in form submission |
+| `value` | All | Initial/current value of control |
+| `id` | All | Unique identifier for labeling |
+| `required` | Most types | Field must be filled before submission |
+| `disabled` | All | Prevents interaction and submission |
+| `readonly` | Text-based types | Prevents editing but allows submission |
+| `autofocus` | All | Automatically focused on page load |
+| `placeholder` | Text-based types | Hint text displayed when empty |
+
+### Validation Attributes
+
+| Attribute | Valid For | Purpose |
+|-----------|-----------|---------|
+| `pattern` | Text-based types | Regular expression for validation |
+| `min` | Numeric, date/time | Minimum value |
+| `max` | Numeric, date/time | Maximum value |
+| `minlength` | Text-based types | Minimum character count |
+| `maxlength` | Text-based types | Maximum character count |
+| `step` | Numeric, date/time | Increment value (`any` allows decimals) |
+
+### Autocomplete Attributes
+
+| Attribute | Purpose | Values |
+|-----------|---------|--------|
+| `autocomplete` | Browser autofill behavior | `on`, `off`, or specific values (e.g., `name`, `email`, `tel`) |
+| `list` | Links to `<datalist>` | ID of datalist element |
+| `multiple` | Multiple values | For `email` and `file` types |
+
+### Form Override Attributes
+
+Valid only for `submit` and `image` types:
+
+| Attribute | Overrides |
+|-----------|-----------|
+| `formaction` | Form's `action` |
+| `formenctype` | Form's `enctype` |
+| `formmethod` | Form's `method` |
+| `formnovalidate` | Form's validation |
+| `formtarget` | Form's `target` |
+
+### Other Input Attributes
+
+| Attribute | Valid For | Purpose |
+|-----------|-----------|---------|
+| `checked` | `checkbox`, `radio` | Initially checked state |
+| `accept` | `file` | Allowed file types (e.g., `image/*`, `.pdf`) |
+| `capture` | `file` | Media capture method (`user`, `environment`) |
+| `size` | Text-based types | Visual width in characters |
+| `src` | `image` | Image URL |
+| `alt` | `image` | Alternative text |
+| `width`, `height` | `image` | Image dimensions |
+| `dirname` | Text types | Submits text directionality (`ltr`/`rtl`) |
+
+## Script Types (`<script type="...">`)
+
+### Standard Script Types
+
+| Type | Purpose | Behavior |
+|------|---------|----------|
+| **(default)** | Classic JavaScript | Blocks parsing, executes immediately |
+| `text/javascript` | Classic JavaScript (explicit) | Same as default (optional to specify) |
+| `module` | ES6 module script | Deferred, strict mode, separate scope |
+| `importmap` | Import map for modules | JSON configuration for module imports |
+| `speculationrules` | Speculation rules (experimental) | JSON for prefetch/prerender configuration |
+
+### Data Block Types
+
+Any non-JavaScript MIME type creates a data block:
+
+```html
+<script type="application/json" id="data">
+  {"key": "value"}
+</script>
+```
+
+Access via: `JSON.parse(document.getElementById('data').textContent)`
+
+### Script Attributes
+
+| Attribute | Purpose | Compatible With |
+|-----------|---------|-----------------|
+| `async` | Load asynchronously, execute when ready | Classic scripts, external files |
+| `defer` | Load asynchronously, execute after parsing | Classic scripts, external files |
+| `src` | External script URL | All types |
+| `integrity` | SRI hash for security verification | External files |
+| `crossorigin` | CORS mode | External files (`anonymous`, `use-credentials`) |
+| `referrerpolicy` | Referrer policy | External files |
+| `nomodule` | Skip in module-supporting browsers | Fallback scripts |
+| `blocking="render"` | Blocks rendering until loaded | Scripts in `<head>` |
+
+**Loading Behavior Comparison**:
+
+- **No attributes**: Blocks parsing, executes immediately
+- **`async`**: Loads in parallel, executes as soon as loaded (order not guaranteed)
+- **`defer`**: Loads in parallel, executes after DOM parsing in document order
+- **`type="module"`**: Deferred by default
+
+## Meta Element Attributes
+
+### Meta Charset
+
+Specifies character encoding (must be UTF-8):
+
+```html
+<meta charset="UTF-8">
+```
+
+### Meta Name/Content Pairs
+
+Common `name` values:
+
+| Name | Purpose | Content Examples |
+|------|---------|------------------|
+| `description` | Page description for search engines | Max 155 characters |
+| `keywords` | Keywords (largely ignored by search engines) | Comma-separated list |
+| `author` | Document author | Name or organization |
+| `viewport` | Mobile viewport configuration | `width=device-width, initial-scale=1` |
+| `theme-color` | Browser UI color | Hex color (`#4285f4`) |
+| `color-scheme` | Preferred color scheme | `light`, `dark`, `light dark` |
+| `referrer` | Referrer policy | `no-referrer`, `origin`, etc. |
+| `robots` | Search engine indexing instructions | `index,follow`, `noindex`, etc. |
+| `generator` | Software that generated the page | Application name |
+
+### Meta HTTP-Equiv
+
+Simulates HTTP headers:
+
+| http-equiv | Purpose | Content Examples |
+|------------|---------|------------------|
+| `content-type` | MIME type and charset (deprecated, use `<meta charset>`) | `text/html; charset=UTF-8` |
+| `refresh` | Auto-refresh or redirect | `5`, `3;url=https://example.com` |
+| `content-security-policy` | CSP directives | `default-src 'self'` |
+| `x-ua-compatible` | IE compatibility mode | `IE=edge` |
+
+### Viewport Configuration
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1">
+```
+
+**Viewport Properties**:
+
+| Property | Values | Purpose |
+|----------|--------|---------|
+| `width` | Pixels or `device-width` | Viewport width |
+| `height` | Pixels or `device-height` | Viewport height |
+| `initial-scale` | 0-10 | Initial zoom level |
+| `minimum-scale` | 0-10 | Minimum zoom level |
+| `maximum-scale` | 0-10 | Maximum zoom level |
+| `user-scalable` | `yes`, `no` | Allow pinch zoom |
+| `viewport-fit` | `auto`, `contain`, `cover` | Safe area insets (notches) |
+| `interactive-widget` | `resizes-visual`, `resizes-content`, `overlays-content` | On-screen keyboard behavior |
+
+## Link Relationship Types (`<link rel="...">`)
+
+| rel Value | Purpose | Example |
+|-----------|---------|---------|
+| `stylesheet` | External CSS file | `<link rel="stylesheet" href="style.css">` |
+| `icon` | Favicon | `<link rel="icon" href="favicon.ico">` |
+| `apple-touch-icon` | iOS home screen icon | `<link rel="apple-touch-icon" href="icon.png">` |
+| `manifest` | Web app manifest | `<link rel="manifest" href="manifest.json">` |
+| `alternate` | Alternate version | `<link rel="alternate" hreflang="es" href="/es/">` |
+| `canonical` | Preferred URL | `<link rel="canonical" href="https://example.com/page">` |
+| `preload` | Priority resource loading | `<link rel="preload" href="font.woff2" as="font">` |
+| `prefetch` | Low-priority future resource | `<link rel="prefetch" href="next-page.html">` |
+| `preconnect` | Early connection to origin | `<link rel="preconnect" href="https://cdn.example.com">` |
+| `dns-prefetch` | Early DNS lookup | `<link rel="dns-prefetch" href="https://cdn.example.com">` |
+| `modulepreload` | Preload ES module | `<link rel="modulepreload" href="module.js">` |
+| `author` | Author information | `<link rel="author" href="/about">` |
+| `license` | License information | `<link rel="license" href="/license">` |
+| `next` | Next page in series | `<link rel="next" href="/page2">` |
+| `prev` | Previous page in series | `<link rel="prev" href="/page1">` |
+
+## Form Attributes
+
+### Form Element Attributes
+
+| Attribute | Purpose | Values |
+|-----------|---------|--------|
+| `action` | Submission URL | URL |
+| `method` | HTTP method | `get`, `post` |
+| `enctype` | Encoding type | `application/x-www-form-urlencoded`, `multipart/form-data`, `text/plain` |
+| `target` | Where to display response | `_self`, `_blank`, `_parent`, `_top`, frame name |
+| `autocomplete` | Form autofill | `on`, `off` |
+| `novalidate` | Skip validation | Boolean |
+| `accept-charset` | Character encodings | `UTF-8` |
+
+## Autocomplete Values
+
+Detailed autocomplete tokens for better autofill:
+
+**Personal Information**:
+- `name`, `given-name`, `family-name`, `additional-name`, `honorific-prefix`, `honorific-suffix`, `nickname`
+
+**Contact Information**:
+- `email`, `tel`, `tel-country-code`, `tel-national`, `tel-area-code`, `tel-local`
+
+**Address Information**:
+- `street-address`, `address-line1`, `address-line2`, `address-level1` (state/province), `address-level2` (city), `postal-code`, `country`, `country-name`
+
+**Payment Information**:
+- `cc-name`, `cc-number`, `cc-exp`, `cc-exp-month`, `cc-exp-year`, `cc-csc`, `cc-type`
+- `transaction-currency`, `transaction-amount`
+
+**Account Information**:
+- `username`, `new-password`, `current-password`, `one-time-code`
+
+**Other**:
+- `bday`, `bday-day`, `bday-month`, `bday-year`, `sex`, `url`, `photo`, `organization`, `job-title`
+
+**Section and Shipping**:
+- Prefix with `shipping` or `billing` (e.g., `shipping email`, `billing address-line1`)
+
+## Global Attributes
+
+Applicable to all HTML elements:
+
+| Attribute | Purpose |
+|-----------|---------|
+| `id` | Unique identifier |
+| `class` | CSS class name(s) |
+| `style` | Inline CSS styles |
+| `title` | Advisory tooltip text |
+| `lang` | Language code |
+| `dir` | Text direction (`ltr`, `rtl`, `auto`) |
+| `hidden` | Element hidden from display |
+| `tabindex` | Tab navigation order |
+| `accesskey` | Keyboard shortcut |
+| `contenteditable` | Editable content (`true`, `false`) |
+| `draggable` | Draggable element (`true`, `false`) |
+| `spellcheck` | Spell checking (`true`, `false`) |
+| `translate` | Translation hint (`yes`, `no`) |
+| `data-*` | Custom data attributes |
+
+## ARIA Attributes
+
+Improve accessibility (prefix with `aria-`):
+
+**Roles**: `role="navigation"`, `role="main"`, `role="complementary"`, `role="button"`, `role="alert"`
+
+**States/Properties**:
+- `aria-label` - Accessible name
+- `aria-describedby` - Description reference
+- `aria-labelledby` - Label reference
+- `aria-hidden` - Hide from screen readers
+- `aria-live` - Live region announcements
+- `aria-expanded` - Expanded state
+- `aria-checked` - Checked state
+- `aria-selected` - Selected state
+- `aria-disabled` - Disabled state
+
+## Event Attributes
+
+JavaScript event handlers (use cautiously, prefer addEventListener):
+
+**Mouse Events**: `onclick`, `ondblclick`, `onmousedown`, `onmouseup`, `onmouseover`, `onmouseout`, `onmousemove`
+
+**Keyboard Events**: `onkeydown`, `onkeyup`, `onkeypress`
+
+**Form Events**: `onsubmit`, `onchange`, `oninput`, `onfocus`, `onblur`, `onreset`
+
+**Media Events**: `onplay`, `onpause`, `onended`, `onvolumechange`
+
+**Window Events**: `onload`, `onunload`, `onresize`, `onscroll`, `onerror`
+
+## Best Practices
+
+1. **Use semantic attributes**: Choose `type="email"` over `type="text"` with pattern
+2. **Always include labels**: Use `<label for="id">` with form controls
+3. **Validate appropriately**: Use HTML5 validation before JavaScript
+4. **Provide accessible names**: Use `aria-label` when labels aren't visible
+5. **Be specific with autocomplete**: Use detailed tokens for better UX
+6. **Avoid inline event handlers**: Use `addEventListener()` instead
+7. **Use `defer` for scripts**: Better performance than blocking scripts
+8. **Set proper viewport**: Essential for responsive mobile design
+9. **Include meta description**: Improves SEO and search result display
+10. **Use data attributes wisely**: For JavaScript-only data, not visible content
+
+## Resources
+
+- [MDN: Input Types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)
+- [MDN: Input Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attributes)
+- [MDN: Script Element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script)
+- [MDN: Meta Element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta)
+- [MDN: Link Types](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types)
+- [MDN: Autocomplete Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)
+- [MDN: Global Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes)

--- a/src/opensquilla/skills/bundled/html-coder/references/essentials.md
+++ b/src/opensquilla/skills/bundled/html-coder/references/essentials.md
@@ -1,0 +1,414 @@
+# HTML Essentials
+
+Essential HTML concepts, techniques, and best practices for modern web development.
+
+## HTML Comments
+
+Comments add notes to code without affecting display. Browsers ignore comments.
+
+**Syntax**:
+```html
+<!-- Single line comment -->
+
+<!--
+  Multi-line comment
+  spanning several lines
+-->
+```
+
+**Usage**:
+- Add explanatory notes about code
+- Temporarily disable HTML without deleting it
+- Document complex sections
+- Leave notes for collaborators
+
+**Rules**:
+- Can be placed before/after DOCTYPE and `<html>`
+- Can be used as content in most elements
+- **Cannot** be used inside tags (e.g., within attributes)
+- **Cannot** be nested
+- Not allowed in `<script>`, `<style>`, `<title>`, `<textarea>` (raw text elements)
+- First `-->` after `<!--` closes the comment
+
+**Example**:
+```html
+<!-- Navigation section -->
+<nav>
+  <ul>
+    <li><a href="/">Home</a></li>
+    <!-- <li><a href="/old">Old Page</a></li> Disabled temporarily -->
+    <li><a href="/contact">Contact</a></li>
+  </ul>
+</nav>
+```
+
+## Content Categories
+
+HTML elements belong to content categories that define what they can contain and where they can be used.
+
+### Main Categories
+
+**1. Metadata Content**
+- Elements in `<head>` that modify presentation or link to resources
+- Examples: `<base>`, `<link>`, `<meta>`, `<noscript>`, `<script>`, `<style>`, `<template>`, `<title>`
+
+**2. Flow Content**
+- Broad category of most elements that can go in `<body>`
+- Includes headings, sections, text, embedded content, interactive elements, forms
+- Most common elements are flow content
+
+**3. Sectioning Content**
+- Defines document sections and creates outline structure
+- Elements: `<article>`, `<aside>`, `<nav>`, `<section>`
+- Defines scope of `<header>` and `<footer>`
+
+**4. Heading Content**
+- Defines section titles
+- Elements: `<h1>` through `<h6>`, `<hgroup>`
+
+**5. Phrasing Content**
+- Text and inline markup within a document
+- Examples: `<a>`, `<abbr>`, `<audio>`, `<b>`, `<bdi>`,  `<bdo>`, `<br>`, `<button>`, `<cite>`, `<code>`, `<data>`, `<em>`, `<i>`, `<img>`, `<input>`, `<kbd>`, `<label>`, `<mark>`, `<q>`, `<s>`, `<small>`, `<span>`, `<strong>`, `<sub>`, `<sup>`, `<time>`, `<u>`, `<var>`, `<video>`
+
+**6. Embedded Content**
+- Imports resources or inserts content from other sources
+- Elements: `<audio>`, `<canvas>`, `<embed>`, `<iframe>`, `<img>`, `<math>`, `<object>`, `<picture>`, `<svg>`, `<video>`
+
+**7. Interactive Content**
+- Elements designed for user interaction
+- Examples: `<button>`, `<details>`, `<embed>`, `<iframe>`, `<label>`, `<select>`, `<textarea>`
+- Conditional: `<a>` (with href), `<audio>`/`<video>` (with controls), `<input>` (not hidden type)
+
+**8. Palpable Content**
+- Content that is rendered and substantial (not empty or hidden)
+- Must contain at least one node that is not hidden
+
+### Form-Associated Content
+
+Elements with a form owner (containing `<form>` or linked via `form` attribute):
+
+- **Listed**: In form element collections (`<button>`, `<fieldset>`, `<input>`, `<object>`, `<output>`, `<select>`, `<textarea>`)
+- **Submittable**: Used in form data (`<button>`, `<input>`, `<select>`, `<textarea>`)
+- **Resettable**: Affected by form reset (`<input>`, `<output>`, `<select>`, `<textarea>`)
+- **Labelable**: Can associate with `<label>` (most form elements except hidden inputs)
+
+### Transparent Content Model
+
+Some elements have "transparent" content - their permitted content is determined by their parent element. Examples: `<a>`, `<ins>`, `<del>`, `<map>`
+
+## Responsive Images
+
+Techniques for serving appropriate images based on device capabilities.
+
+### The Problem
+
+- **Resolution switching**: Smaller images for mobile, larger for desktop
+- **Art direction**: Different cropped/composed images for different layouts
+- **Pixel density**: Higher resolution images for Retina/high-DPI displays
+
+### Solution 1: srcset and sizes
+
+For serving different image sizes/resolutions:
+
+```html
+<img
+  srcset="small.jpg 480w,
+          medium.jpg 800w,
+          large.jpg 1200w"
+  sizes="(max-width: 600px) 480px,
+         (max-width: 900px) 800px,
+         1200px"
+  src="medium.jpg"
+  alt="Description"
+/>
+```
+
+**How it works**:
+1. Browser checks screen size, pixel density, zoom, orientation, network speed
+2. Finds first true media condition in `sizes`
+3. Loads image from `srcset` matching that slot size
+4. Falls back to `src` for older browsers
+
+**`srcset` syntax**: `filename width`, e.g., `photo.jpg 800w`
+**`sizes` syntax**: `(media-condition) slot-width`, last value is default
+
+### Solution 2: x-descriptors for Pixel Density
+
+For same size, different resolutions:
+
+```html
+<img
+  srcset="image.jpg,
+          image-1.5x.jpg 1.5x,
+          image-2x.jpg 2x"
+  src="image.jpg"
+  alt="Description"
+  width="320"
+/>
+```
+
+Browser picks appropriate resolution based on device pixel ratio.
+
+### Solution 3: Picture Element for Art Direction
+
+Different images for different layouts:
+
+```html
+<picture>
+  <source media="(max-width: 799px)" srcset="portrait-crop.jpg">
+  <source media="(min-width: 800px)" srcset="landscape.jpg">
+  <img src="landscape.jpg" alt="Description">
+</picture>
+```
+
+**Rules**:
+- `<source>` elements test media conditions
+- First matching condition's image is used
+- `<img>` is required as fallback
+- Can combine with `srcset` and `sizes` on `<source>`
+
+### Why Not CSS or JavaScript?
+
+Browsers preload images before CSS/JavaScript parse, so responsive image solutions must be in HTML.
+
+## Media Formats
+
+### Image Formats
+
+- **JPEG**: Photos, complex images, good compression
+- **PNG**: Images needing transparency, sharp edges
+- **GIF**: Simple animations, limited colors
+- **SVG**: Vector graphics, logos, icons, scales perfectly
+- **WebP**: Modern format, better compression, good browser support
+- **AVIF**: Newest format, excellent compression, growing support
+
+### Audio Formats
+
+- **MP3**: Universal support, good compression
+- **AAC**: Better quality than MP3 at same bitrate
+- **OGG Vorbis**: Open format, good quality
+- **WAV**: Uncompressed, large files, best quality
+- **FLAC**: Lossless compression, better than WAV size
+
+### Video Formats
+
+- **MP4 (H.264)**: Universal support, good quality
+- **WebM (VP8/VP9)**: Open format, good compression
+- **OGG (Theora)**: Open format, older
+- **MP4 (H.265/HEVC)**: Better compression than H.264
+- **AV1**: Newest, best compression, growing support
+
+**Always provide multiple formats for compatibility**:
+
+```html
+<audio controls>
+  <source src="audio.mp3" type="audio/mpeg">
+  <source src="audio.ogg" type="audio/ogg">
+  Fallback text for unsupported browsers
+</audio>
+
+<video controls width="640">
+  <source src="video.mp4" type="video/mp4">
+  <source src="video.webm" type="video/webm">
+  Fallback text
+</video>
+```
+
+## Audio and Video Elements
+
+### Audio Element
+
+```html
+<audio controls>
+  <source src="song.mp3" type="audio/mpeg">
+  <source src="song.ogg" type="audio/ogg">
+  Your browser doesn't support audio.
+</audio>
+```
+
+**Attributes**:
+- `controls` - Show playback controls
+- `autoplay` - Start automatically (usually blocked by browsers)
+- `loop` - Repeat playback
+- `muted` - Start muted
+- `preload` - none, metadata, auto
+
+### Video Element
+
+```html
+<video controls width="640" height="360" poster="thumbnail.jpg">
+  <source src="video.mp4" type="video/mp4">
+  <source src="video.webm" type="video/webm">
+  <track kind="subtitles" src="subs-en.vtt" srclang="en" label="English">
+  Your browser doesn't support video.
+</video>
+```
+
+**Attributes**:
+- `controls` - Show playback controls
+- `width`, `height` - Dimensions (maintain aspect ratio)
+- `poster` - Image shown before playback
+- `autoplay` - Auto-start (use with `muted`)
+- `loop` - Repeat playback
+- `muted` - Start muted
+- `preload` - none, metadata, auto
+
+**Tracks** (captions/subtitles):
+```html
+<track kind="subtitles" src="subs.vtt" srclang="en" label="English" default>
+```
+
+Kinds: `subtitles`, `captions`, `descriptions`, `chapters`, `metadata`
+
+## Form Validation
+
+HTML5 provides built-in validation before JavaScript.
+
+### Validation Attributes
+
+```html
+<input type="email" required>
+<input type="url" required>
+<input type="number" min="0" max="100" step="5">
+<input type="text" pattern="[A-Za-z]{3,}" title="At least 3 letters">
+<input type="text" minlength="3" maxlength="20">
+```
+
+**Common validation attributes**:
+- `required` - Field must be filled
+- `pattern` - Regex pattern to match
+- `min`, `max` - Numeric/date range
+- `minlength`, `maxlength` - String length
+- `step` - Increment for numbers
+- `type` - Built-in validation (email, url, tel, etc.)
+
+### Input Types with Validation
+
+- `email` - Validates email format
+- `url` - Validates URL format
+- `tel` - Telephone number
+- `number` - Numeric input
+- `range` - Slider
+- `date`, `time`, `datetime-local` - Date/time pickers
+- `color` - Color picker
+
+### Constraint Validation API
+
+Check validation via JavaScript:
+
+```javascript
+const input = document.querySelector('input');
+if (input.checkValidity()) {
+  // Valid
+} else {
+  console.log(input.validationMessage);
+}
+```
+
+## Date and Time Formats
+
+The `<time>` element and datetime attributes use ISO 8601 format.
+
+```html
+<!-- Date only -->
+<time datetime="2026-03-08">March 8, 2026</time>
+
+<!-- Time only -->
+<time datetime="14:30">2:30 PM</time>
+
+<!-- Date and time -->
+<time datetime="2026-03-08T14:30">March 8, 2026 at 2:30 PM</time>
+
+<!-- With timezone -->
+<time datetime="2026-03-08T14:30:00-05:00">2:30 PM EST</time>
+
+<!-- Duration -->
+<time datetime="PT2H30M">2 hours 30 minutes</time>
+```
+
+**Format patterns**:
+- Date: `YYYY-MM-DD`
+- Time: `HH:MM` or `HH:MM:SS`
+- Combined: `YYYY-MM-DDTHH:MM:SS`
+- Timezone: `+HH:MM` or `-HH:MM` or `Z` (UTC)
+- Duration: `P` prefix, e.g., `PT2H` (2 hours)
+
+## Quirks Mode and Standards Mode
+
+Browsers render pages in different  modes based on DOCTYPE:
+
+**Standards Mode** (recommended):
+```html
+<!DOCTYPE html>
+```
+- Follows modern web standards
+- Consistent, predictable rendering
+
+**Quirks Mode**:
+- No DOCTYPE or old DOCTYPE
+- Emulates old browser bugs for legacy sites
+- **Avoid this!**
+
+**Limited Quirks Mode**:
+- Some old DOCTYPEs trigger this
+- Between standards and quirks
+
+**Always use `<!DOCTYPE html>` for standards mode.**
+
+## Microdata
+
+Add machine-readable data to HTML:
+
+```html
+<div itemscope itemtype="https://schema.org/Person">
+  <h1 itemprop="name">John Doe</h1>
+  <img itemprop="image" src="photo.jpg" alt="John">
+  <p itemprop="jobTitle">Software Engineer</p>
+  <a itemprop="url" href="https://example.com">Website</a>
+</div>
+```
+
+**Attributes**:
+- `itemscope` - Creates item
+- `itemtype` - Defines type (URL to vocabulary)
+- `itemprop` - Names property
+
+Common vocabularies at [Schema.org](https://schema.org)
+
+## Microformats
+
+Simpler alternative to microdata using class names:
+
+```html
+<div class="h-card">
+  <span class="p-name">John Doe</span>
+  <span class="p-org">Company Inc</span>
+  <a class="u-email" href="mailto:john@example.com">Email</a>
+</div>
+```
+
+Common microformats: `h-card` (person), `h-entry` (blog post), `h-event` (event)
+
+## Best Practices
+
+1. **Always use `<!DOCTYPE html>`** - Ensures standards mode
+2. **Provide multiple media formats** - For cross-browser support
+3. **Use responsive images** - Optimize for device and bandwidth
+4. **Leverage HTML5 validation** - Before adding JavaScript
+5. **Add meaningful metadata** - Microdata/microformats for SEO
+6. **Comment complex sections** - Help future maintainers
+7. **Test different devices** - Responsive images and media
+8. **Include fallback content** - For unsupported features
+9. **Use semantic elements** - Follow content categories
+10. **Validate regularly** - Check with W3C validator
+
+## Resources
+
+- [MDN: HTML Comments](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Comments)
+- [MDN: Content Categories](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Content_categories)
+- [MDN: Responsive Images](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Responsive_images)
+- [MDN: Constraint Validation](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Constraint_validation)
+- [MDN: Date and Time Formats](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Date_and_time_formats)
+- [MDN: Media Formats](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats)
+- [Schema.org](https://schema.org)
+- [Microformats Wiki](http://microformats.org/wiki/)

--- a/src/opensquilla/skills/bundled/html-coder/references/global-attributes.md
+++ b/src/opensquilla/skills/bundled/html-coder/references/global-attributes.md
@@ -1,0 +1,701 @@
+# Global Attributes Reference
+
+Detailed guide to HTML global attributes that can be used on any element.
+
+## What Are Global Attributes?
+
+Global attributes are attributes that can be applied to **any HTML element**, regardless of the element type. They provide common functionality like styling hooks, accessibility features, custom data storage, and user interaction controls.
+
+## Complete Global Attributes List
+
+### `accesskey`
+
+**Purpose**: Keyboard shortcut to activate or focus element
+
+**Values**: Single character (letter, number, symbol)
+
+**Example**:
+```html
+<button accesskey="s">Save</button>
+<a href="#content" accesskey="c">Skip to Content</a>
+```
+
+**Usage**:
+- Activated by browser-specific key combination:
+  - Windows: `Alt + key`
+  - Mac: `Ctrl + Option + key`
+  - Linux: `Alt + key`
+- Avoid conflicts with browser shortcuts
+- Not widely used due to inconsistent browser support
+
+---
+
+### `autocapitalize`
+
+**Purpose**: Control text capitalization on mobile devices
+
+**Values**:
+- `off` or `none` - No autocapitalization
+- `on` or `sentences` - Capitalize first letter of sentences (default)
+- `words` - Capitalize first letter of each word
+- `characters` - Capitalize all characters
+
+**Example**:
+```html
+<input type="text" autocapitalize="words" placeholder="Enter your name">
+<textarea autocapitalize="sentences"></textarea>
+```
+
+**Usage**: Primarily affects mobile virtual keyboards
+
+---
+
+### `autofocus`
+
+**Purpose**: Automatically focus element when page loads
+
+**Values**: Boolean (no value needed)
+
+**Example**:
+```html
+<input type="search" autofocus placeholder="Search...">
+```
+
+**Usage**:
+- Only one element per page should have `autofocus`
+- Be cautious with accessibility (can disorient users)
+- Avoid on login pages (security risk)
+
+---
+
+### `class`
+
+**Purpose**: Assign CSS class(es) to element
+
+**Values**: Space-separated class names
+
+**Example**:
+```html
+<div class="container">Single class</div>
+<button class="btn btn-primary btn-large">Multiple classes</button>
+<article class="card featured">Card with modifier</article>
+```
+
+**Usage**:
+- Most commonly used global attribute
+- Multiple classes separated by spaces
+- Class names are case-sensitive
+- Use descriptive, semantic names
+- Convention: lowercase with hyphens (`btn-primary`) or camelCase (`btnPrimary`)
+
+---
+
+### `contenteditable`
+
+**Purpose**: Make element content editable by user
+
+**Values**:
+- `true` - Element is editable
+- `false` - Element is not editable
+- `plaintext-only` - Only plain text (no formatting)
+
+**Example**:
+```html
+<div contenteditable="true">
+  You can edit this text directly!
+</div>
+
+<p contenteditable="false">This cannot be edited</p>
+
+<article contenteditable="plaintext-only">
+  Plain text only - no rich formatting
+</article>
+```
+
+**Usage**:
+- Inherits to child elements (unless overridden)
+- Use with JavaScript to capture changes
+- WYSIWYG editors use this feature
+- Accessibility: ensure keyboard navigation works
+
+---
+
+### `data-*`
+
+**Purpose**: Store custom data attributes
+
+**Values**: Any string value
+
+**Example**:
+```html
+<button data-user-id="12345" data-action="delete">Delete User</button>
+
+<article
+  data-post-id="789"
+  data-author="John Doe"
+  data-published="2024-01-15"
+  data-category="Technology">
+  Article content
+</article>
+
+<div data-config='{"theme":"dark","lang":"en"}'>Settings</div>
+```
+
+**JavaScript Access**:
+```html
+<button id="btn" data-user-id="123" data-user-name="John">Click</button>
+
+<script>
+  const btn = document.getElementById('btn');
+
+  // Access via dataset
+  console.log(btn.dataset.userId);    // "123"
+  console.log(btn.dataset.userName);  // "John"
+
+  // Modify dataset
+  btn.dataset.userId = '456';
+
+  // Add new data attribute
+  btn.dataset.role = 'admin';
+</script>
+```
+
+**Usage**:
+- Must start with `data-`
+- Followed by at least one character (no uppercase)
+- CamelCase in JavaScript (data-user-id → dataset.userId)
+- Ideal for passing data from HTML to JavaScript
+- Better than using class names for data storage
+
+---
+
+### `dir`
+
+**Purpose**: Text directionality
+
+**Values**:
+- `ltr` - Left-to-right (default for most languages)
+- `rtl` - Right-to-left (Arabic, Hebrew)
+- `auto` - Browser determines based on content
+
+**Example**:
+```html
+<p dir="ltr">English text (left to right)</p>
+<p dir="rtl">مرحبا (right to left)</p>
+<p dir="auto">Mixed content: Hello مرحبا</p>
+```
+
+**Usage**:
+- Inherit to all child elements
+- Set on `<html>` for entire document
+- Use `auto` for user-generated content with unknown direction
+
+---
+
+### `draggable`
+
+**Purpose**: Enable drag-and-drop functionality
+
+**Values**:
+- `true` - Element is draggable
+- `false` - Element is not draggable
+- `auto` - Browser default (images and links draggable)
+
+**Example**:
+```html
+<div draggable="true">Drag me!</div>
+<img src="image.jpg" alt="Image" draggable="false">
+```
+
+**Usage**:
+- Requires JavaScript drag-and-drop event handlers
+- Events: `dragstart`, `drag`, `dragend`, `dragenter`, `dragleave`, `dragover`, `drop`
+
+---
+
+### `enterkeyhint`
+
+**Purpose**: Customize Enter key label on virtual keyboards
+
+**Values**:
+- `enter` - Default Enter key
+- `done` - "Done" label
+- `go` - "Go" label
+- `next` - "Next" label
+- `previous` - "Previous" label
+- `search` - "Search" label
+- `send` - "Send" label
+
+**Example**:
+```html
+<input type="text" enterkeyhint="next">
+<input type="search" enterkeyhint="search">
+<textarea enterkeyhint="send"></textarea>
+```
+
+**Usage**: Mobile-specific, affects virtual keyboard appearance
+
+---
+
+### `hidden`
+
+**Purpose**: Hide element from display
+
+**Values**: Boolean (no value needed)
+
+**Example**:
+```html
+<div hidden>This is hidden</div>
+<p hidden>Not displayed on page</p>
+```
+
+**Usage**:
+- Equivalent to `display: none` in CSS
+- Element not rendered and not accessible
+- Screen readers ignore hidden content
+- Use `aria-hidden="true"` to hide from screen readers but keep visible
+- Can be toggled with JavaScript
+
+---
+
+### `id`
+
+**Purpose**: Unique identifier for element
+
+**Values**: Unique string (must be unique per document)
+
+**Example**:
+```html
+<header id="main-header">Header</header>
+<button id="submit-btn">Submit</button>
+<article id="post-123">Article content</article>
+```
+
+**Usage**:
+- Must be unique within the document
+- Can be referenced by CSS (`#main-header`) and JavaScript
+- Used for fragment identifiers (`#main-header` in URLs)
+- Used with `<label for="id">` to associate labels with inputs
+- Convention: lowercase with hyphens or camelCase
+- Cannot start with a number
+
+---
+
+### `inert`
+
+**Purpose**: Make element non-interactive
+
+**Values**: Boolean (no value needed)
+
+**Example**:
+```html
+<div inert>
+  <button>Cannot be clicked</button>
+  <a href="#">Cannot be focused</a>
+  <input type="text">Cannot be edited</input>
+</div>
+```
+
+**Usage**:
+- Element and descendants cannot receive focus
+- Element and descendants removed from tab order
+- Element and descendants ignored by screen readers
+- Useful for modals (inert background content)
+- Relatively new attribute (check browser support)
+
+---
+
+### `inputmode`
+
+**Purpose**: Hint for virtual keyboard type
+
+**Values**:
+- `none` - No virtual keyboard
+- `text` - Standard text keyboard (default)
+- `decimal` - Numeric keyboard with decimal
+- `numeric` - Numeric keyboard
+- `tel` - Telephone number pad
+- `search` - Search-optimized keyboard
+- `email` - Email keyboard (@ symbol)
+- `url` - URL keyboard (/ and .com)
+
+**Example**:
+```html
+<input type="text" inputmode="numeric" placeholder="Enter PIN">
+<input type="text" inputmode="email" placeholder="Email">
+<input type="text" inputmode="tel" placeholder="Phone">
+```
+
+**Usage**:
+- Mobile-specific optimization
+- Use with `type="text"` to get specific keyboards without validation
+- Better UX than wrong keyboard type
+
+---
+
+### `is`
+
+**Purpose**: Specify custom element name (Web Components)
+
+**Values**: Custom element name
+
+**Example**:
+```html
+<button is="fancy-button">Click Me</button>
+<ul is="expanding-list">
+  <li>Item 1</li>
+  <li>Item 2</li>
+</ul>
+```
+
+**Usage**:
+- Used with Web Components
+- Extends built-in elements
+- Requires JavaScript custom element definition
+
+---
+
+### `itemid`, `itemprop`, `itemref`, `itemscope`, `itemtype`
+
+**Purpose**: Microdata attributes for structured data
+
+**Example**:
+```html
+<div itemscope itemtype="https://schema.org/Person">
+  <span itemprop="name">John Doe</span>
+  <span itemprop="jobTitle">Software Engineer</span>
+  <a href="mailto:john@example.com" itemprop="email">Email</a>
+</div>
+
+<div itemscope itemtype="https://schema.org/Product" itemid="urn:isbn:978-0-12-345678-9">
+  <span itemprop="name">Product Name</span>
+  <span itemprop="price" content="29.99">$29.99</span>
+</div>
+```
+
+**Usage**:
+- SEO: helps search engines understand content
+- Use with Schema.org types
+- Alternative to JSON-LD for structured data
+
+---
+
+### `lang`
+
+**Purpose**: Specify language of element content
+
+**Values**: Language code (ISO 639-1)
+
+**Example**:
+```html
+<html lang="en">
+<p lang="es">Hola, ¿cómo estás?</p>
+<p lang="fr">Bonjour, comment ça va?</p>
+<blockquote lang="de">Guten Tag!</blockquote>
+```
+
+**Common Language Codes**:
+- `en` - English
+- `en-US` - English (United States)
+- `en-GB` - English (United Kingdom)
+- `es` - Spanish
+- `fr` - French
+- `de` - German
+- `it` - Italian
+- `pt` - Portuguese
+- `ja` - Japanese
+- `zh` - Chinese
+- `ar` - Arabic
+- `ru` - Russian
+
+**Usage**:
+- Set on `<html>` for primary page language
+- Override for sections in different languages
+- Helps screen readers with pronunciation
+- Assists search engines and translation tools
+
+---
+
+### `nonce`
+
+**Purpose**: Cryptographic nonce for Content Security Policy (CSP)
+
+**Values**: Random string (unique per page load)
+
+**Example**:
+```html
+<!-- In HTML head -->
+<meta http-equiv="Content-Security-Policy" content="script-src 'nonce-r@nd0mStr1ng'">
+
+<!-- Script with matching nonce -->
+<script nonce="r@nd0mStr1ng">
+  console.log('This script is allowed');
+</script>
+
+<!-- This script without nonce is blocked -->
+<script>
+  console.log('This script is blocked');
+</script>
+```
+
+**Usage**:
+- Security feature for CSP
+- Server must generate random nonce per page load
+- Only scripts/styles with matching nonce execute
+- Prevents XSS attacks
+
+---
+
+### `part`
+
+**Purpose**: Expose shadow DOM parts for styling (Web Components)
+
+**Values**: Space-separated part names
+
+**Example**:
+```html
+<custom-button>
+  <button part="button">Click Me</button>
+  <span part="icon">🔔</span>
+</custom-button>
+
+<style>
+  custom-button::part(button) {
+    background: blue;
+  }
+  custom-button::part(icon) {
+    font-size: 2em;
+  }
+</style>
+```
+
+**Usage**: Advanced feature for Web Components
+
+---
+
+### `slot`
+
+**Purpose**: Assign content to named slot in Web Components
+
+**Values**: Slot name
+
+**Example**:
+```html
+<custom-card>
+  <h2 slot="title">Card Title</h2>
+  <p slot="content">Card content goes here.</p>
+  <button slot="actions">Action</button>
+</custom-card>
+```
+
+**Usage**: Used with Shadow DOM and Web Components
+
+---
+
+### `spellcheck`
+
+**Purpose**: Enable/disable spell checking
+
+**Values**:
+- `true` - Enable spell checking
+- `false` - Disable spell checking
+
+**Example**:
+```html
+<input type="text" spellcheck="true" placeholder="Spell checked">
+<textarea spellcheck="false">No spell check here</textarea>
+<div contenteditable="true" spellcheck="true">Editable with spellcheck</div>
+```
+
+**Usage**:
+- Works on editable content
+- Applies to `<input>`, `<textarea>`, and `contenteditable` elements
+- Default behavior varies by browser and element type
+
+---
+
+### `style`
+
+**Purpose**: Inline CSS styles
+
+**Values**: CSS declarations
+
+**Example**:
+```html
+<p style="color: red; font-weight: bold;">Red and bold text</p>
+<div style="background-color: #f0f0f0; padding: 20px; border-radius: 8px;">
+  Styled container
+</div>
+```
+
+**Usage**:
+- Highest CSS specificity (overrides external/internal styles)
+- Not recommended for production (hard to maintain)
+- Useful for dynamic styles via JavaScript
+- Avoid when possible (use CSS classes instead)
+
+---
+
+### `tabindex`
+
+**Purpose**: Control tab order and focusability
+
+**Values**:
+- Positive number - Explicit tab order (not recommended)
+- `0` - Natural tab order, element focusable
+- `-1` - Programmatically focusable, not in tab order
+
+**Example**:
+```html
+<!-- Natural tab order -->
+<button tabindex="0">First</button>
+<button tabindex="0">Second</button>
+
+<!-- Remove from tab order -->
+<div tabindex="-1">Focusable via JavaScript only</div>
+
+<!-- Avoid explicit order (anti-pattern) -->
+<button tabindex="3">Third</button>
+<button tabindex="1">First</button>
+<button tabindex="2">Second</button>
+```
+
+**Usage**:
+- `0` - Add focusability to non-interactive elements
+- `-1` - Remove from tab order (still focusable via JS)
+- Positive values - Avoid (confusing for users)
+- Essential for custom interactive components
+
+---
+
+### `title`
+
+**Purpose**: Advisory information (tooltip)
+
+**Values**: Text string
+
+**Example**:
+```html
+<button title="Save your changes">💾</button>
+<abbr title="HyperText Markup Language">HTML</abbr>
+<a href="#" title="Go to homepage">Home</a>
+<img src="icon.svg" alt="Icon" title="Additional info about icon">
+```
+
+**Usage**:
+- Displays as tooltip on hover
+- Should not contain essential information (not accessible on mobile)
+- Good for abbreviations and supplementary info
+- Not a substitute for proper labels or alt text
+- Screen readers may announce title, but inconsistently
+
+---
+
+### `translate`
+
+**Purpose**: Specify if content should be translated
+
+**Values**:
+- `yes` - Content should be translated (default)
+- `no` - Content should not be translated
+
+**Example**:
+```html
+<p translate="yes">This text can be translated.</p>
+<p translate="no">Brand Name™</p>
+<code translate="no">console.log('hello');</code>
+```
+
+**Usage**:
+- Hint for translation tools
+- Use for proper nouns, brand names, code
+- Not widely supported
+
+---
+
+## Global Attributes Usage Patterns
+
+### Styling Hooks
+```html
+<div id="app" class="container dark-theme">
+  <h1 class="title">Page Title</h1>
+  <p class="description">Description text</p>
+</div>
+```
+
+### JavaScript Interaction
+```html
+<button
+  id="submit-btn"
+  data-user-id="123"
+  data-action="submit"
+  onclick="handleClick()">
+  Submit
+</button>
+```
+
+### Accessibility
+```html
+<div
+  role="dialog"
+  aria-labelledby="dialog-title"
+  aria-describedby="dialog-desc"
+  tabindex="-1">
+  <h2 id="dialog-title">Dialog Title</h2>
+  <p id="dialog-desc">Dialog description</p>
+</div>
+```
+
+### Internationalization
+```html
+<html lang="en" dir="ltr">
+  <p lang="es">Hola</p>
+  <p lang="ar" dir="rtl">مرحبا</p>
+</html>
+```
+
+### Custom Data Storage
+```html
+<article
+  data-post-id="789"
+  data-author="John Doe"
+  data-published="2024-01-15"
+  data-tags='["tech","web","html"]'>
+  Article content
+</article>
+```
+
+## Best Practices
+
+### ✅ Do
+
+1. **Use semantic `class` names** (`.btn-primary` not `.blue-button`)
+2. **Keep `id` unique** within document
+3. **Prefer CSS classes over inline `style`**
+4. **Use `data-*` for custom data** (not `class` or `id`)
+5. **Set `lang` on `<html>`** for accessibility
+6. **Use `tabindex="0"`** to make custom components focusable
+7. **Use `hidden`** to hide content completely
+8. **Provide descriptive `title`** for abbreviations
+
+### ❌ Don't
+
+1. **Don't use positive `tabindex`** values (confusing order)
+2. **Don't rely on `title` for essential info** (inaccessible on mobile)
+3. **Don't use `accesskey`** (conflicts with browser shortcuts)
+4. **Don't use multiple `autofocus`** on one page
+5. **Don't use inline `style`** extensively (hard to maintain)
+6. **Don't use `id` for styling multiple elements** (use `class`)
+7. **Don't forget to make `contenteditable` keyboard accessible**
+8. **Don't use `hidden` with CSS `display`** (creates conflicts)
+
+## Browser Support
+
+Most global attributes have excellent browser support. Notable exceptions:
+
+- **`inert`**: Limited support (newer attribute)
+- **`enterkeyhint`**: Mobile browsers only
+- **`part`** and **`slot`**: Require Web Components support
+- **`inputmode`**: Mobile browsers primarily
+
+Always check [Can I Use](https://caniuse.com/) for current browser support.

--- a/src/opensquilla/skills/bundled/html-coder/references/glossary.md
+++ b/src/opensquilla/skills/bundled/html-coder/references/glossary.md
@@ -1,0 +1,1409 @@
+# HTML Glossary
+
+Quick reference for all HTML elements organized by category.
+
+## HTML Tag Glossary
+
+### Document Structure
+
+| Tag | Description | Usage |
+|-----|-------------|-------|
+| `<!DOCTYPE>` | Document type declaration | `<!DOCTYPE html>` |
+| `<html>` | Root element | Contains entire HTML document |
+| `<head>` | Document metadata container | Information about the document |
+| `<title>` | Document title | Shown in browser tab/title bar |
+| `<body>` | Document body | Visible page content |
+| `<base>` | Base URL for relative URLs | `<base href="https://example.com/">` |
+| `<link>` | External resource link | CSS files, favicons, etc. |
+| `<meta>` | Metadata | Charset, viewport, description, etc. |
+| `<style>` | Internal CSS | Embedded stylesheets |
+
+### Metadata Elements
+
+| Tag | Description | Common Use |
+|-----|-------------|------------|
+| `<meta charset>` | Character encoding | `<meta charset="UTF-8">` |
+| `<meta name>` | Named metadata | Description, keywords, author |
+| `<meta property>` | Property metadata | Open Graph, Twitter Cards |
+| `<meta http-equiv>` | HTTP header equivalent | Content-Type, refresh, CSP |
+| `<meta viewport>` | Viewport settings | Mobile responsive design |
+
+### Content Sectioning
+
+| Tag | Description | Purpose |
+|-----|-------------|---------|
+| `<header>` | Header section | Site/page/article header |
+| `<nav>` | Navigation section | Navigation links |
+| `<main>` | Main content | Primary page content (unique) |
+| `<section>` | Generic section | Thematic grouping of content |
+| `<article>` | Self-contained content | Blog post, news article, forum post |
+| `<aside>` | Tangential content | Sidebars, pull quotes, ads |
+| `<footer>` | Footer section | Site/page/article footer |
+| `<h1>` to `<h6>` | Headings | Content hierarchy (H1 most important) |
+| `<address>` | Contact information | Author/owner contact details |
+
+### Text Content
+
+| Tag | Description | Usage |
+|-----|-------------|-------|
+| `<div>` | Generic container | Block-level grouping (no semantic meaning) |
+| `<p>` | Paragraph | Text paragraphs |
+| `<hr>` | Thematic break | Horizontal rule/separator |
+| `<pre>` | Preformatted text | Code blocks, ASCII art |
+| `<blockquote>` | Block quotation | Long quotes with optional `cite` |
+| `<ol>` | Ordered list | Numbered list |
+| `<ul>` | Unordered list | Bulleted list |
+| `<li>` | List item | Item in `<ol>`, `<ul>`, or `<menu>` |
+| `<dl>` | Description list | Term-definition pairs |
+| `<dt>` | Description term | Term in description list |
+| `<dd>` | Description details | Definition in description list |
+| `<figure>` | Self-contained content | Images, diagrams, code with caption |
+| `<figcaption>` | Figure caption | Caption for `<figure>` |
+
+### Inline Text Semantics
+
+| Tag | Description | Purpose |
+|-----|-------------|---------|
+| `<a>` | Anchor/hyperlink | Links to other pages/resources |
+| `<span>` | Generic inline container | Inline grouping (no semantic meaning) |
+| `<strong>` | Strong importance | Bold text (semantic) |
+| `<em>` | Emphasis | Italic text (semantic) |
+| `<b>` | Bold text | Bold (presentational, use CSS instead) |
+| `<i>` | Italic text | Italic (presentational, use CSS instead) |
+| `<u>` | Underlined text | Underline (avoid, looks like link) |
+| `<s>` | Strikethrough | Incorrect/irrelevant text |
+| `<mark>` | Highlighted text | Marked/highlighted for reference |
+| `<small>` | Fine print | Side comments, legal text |
+| `<abbr>` | Abbreviation | Abbreviations with `title` |
+| `<cite>` | Citation | Title of creative work |
+| `<code>` | Inline code | Code snippets |
+| `<kbd>` | Keyboard input | Keyboard keys to press |
+| `<samp>` | Sample output | Computer program output |
+| `<var>` | Variable | Mathematical/programming variable |
+| `<time>` | Date/time | Machine-readable date/time |
+| `<data>` | Machine-readable content | Data with value attribute |
+| `<q>` | Inline quotation | Short inline quotes |
+| `<dfn>` | Definition term | Term being defined |
+| `<sub>` | Subscript | H₂O |
+| `<sup>` | Superscript | x² |
+| `<del>` | Deleted text | Removed content (with `<ins>`) |
+| `<ins>` | Inserted text | Added content (with `<del>`) |
+| `<br>` | Line break | Force line break |
+| `<wbr>` | Word break opportunity | Suggest line break point |
+| `<bdi>` | Bidirectional isolate | Text with different direction |
+| `<bdo>` | Bidirectional override | Override text direction |
+| `<ruby>` | Ruby annotation | East Asian typography |
+| `<rt>` | Ruby text | Pronunciation guide in `<ruby>` |
+| `<rp>` | Ruby parenthesis | Fallback for browsers without ruby |
+
+### Images and Multimedia
+
+| Tag | Description | Usage |
+|-----|-------------|-------|
+| `<img>` | Image | Embed raster images |
+| `<picture>` | Responsive image container | Art direction, multiple formats |
+| `<source>` | Media source | Source for `<picture>`, `<audio>`, `<video>` |
+| `<audio>` | Audio content | Embed audio files |
+| `<video>` | Video content | Embed video files |
+| `<track>` | Text track | Subtitles, captions for video/audio |
+| `<map>` | Image map | Define clickable areas in image |
+| `<area>` | Image map area | Clickable region in `<map>` |
+| `<svg>` | Scalable Vector Graphics | Inline vector graphics |
+| `<canvas>` | Graphics canvas | Drawing surface for JavaScript |
+
+### Embedded Content
+
+| Tag | Description | Purpose |
+|-----|-------------|---------|
+| `<iframe>` | Inline frame | Embed external content |
+| `<embed>` | External content | Embed plugins (legacy) |
+| `<object>` | External object | Embed multimedia, PDFs |
+| `<param>` | Object parameters | Parameters for `<object>` |
+| `<portal>` | Portal element | Preview/navigate to other pages |
+
+### Scripting
+
+| Tag | Description | Usage |
+|-----|-------------|-------|
+| `<script>` | JavaScript | Embed or link JavaScript |
+| `<noscript>` | No script fallback | Content when JavaScript disabled |
+| `<template>` | Content template | HTML template for cloning |
+| `<slot>` | Web component slot | Placeholder in web components |
+
+### Tables
+
+| Tag | Description | Purpose |
+|-----|-------------|---------|
+| `<table>` | Table | Tabular data |
+| `<caption>` | Table caption | Table title/description |
+| `<thead>` | Table header | Header rows |
+| `<tbody>` | Table body | Main table content |
+| `<tfoot>` | Table footer | Footer rows |
+| `<tr>` | Table row | Row of cells |
+| `<th>` | Header cell | Column/row header |
+| `<td>` | Data cell | Table data |
+| `<col>` | Column | Column properties |
+| `<colgroup>` | Column group | Group of columns |
+
+### Forms
+
+| Tag | Description | Purpose |
+|-----|-------------|---------|
+| `<form>` | Form | User input form |
+| `<input>` | Input field | Various input types |
+| `<label>` | Input label | Label for form control |
+| `<button>` | Button | Clickable button |
+| `<select>` | Dropdown | Selection list |
+| `<option>` | Select option | Option in `<select>` |
+| `<optgroup>` | Option group | Group options in `<select>` |
+| `<textarea>` | Multi-line text | Large text input |
+| `<fieldset>` | Field grouping | Group related form fields |
+| `<legend>` | Fieldset caption | Title for `<fieldset>` |
+| `<datalist>` | Input suggestions | Predefined options for input |
+| `<output>` | Calculation result | Result of calculation |
+| `<progress>` | Progress bar | Task progress indicator |
+| `<meter>` | Measurement gauge | Scalar measurement |
+
+### Interactive Elements
+
+| Tag | Description | Usage |
+|-----|-------------|-------|
+| `<details>` | Disclosure widget | Expandable content |
+| `<summary>` | Details summary | Title for `<details>` |
+| `<dialog>` | Dialog box | Modal or non-modal dialog |
+| `<menu>` | Menu | List of commands (experimental) |
+
+### Web Components
+
+| Tag | Description | Purpose |
+|-----|-------------|---------|
+| `<template>` | Content template | Reusable HTML template |
+| `<slot>` | Content slot | Placeholder in shadow DOM |
+| Custom elements | User-defined elements | `<my-component>` |
+
+### Deprecated/Obsolete Elements
+
+❌ **Do not use these elements** (use CSS or semantic alternatives instead):
+
+| Tag | Reason | Alternative |
+|-----|--------|-------------|
+| `<acronym>` | Obsolete | Use `<abbr>` |
+| `<applet>` | Obsolete | Use `<object>` or `<embed>` |
+| `<basefont>` | Obsolete | Use CSS `font` properties |
+| `<big>` | Obsolete | Use CSS `font-size` |
+| `<blink>` | Obsolete | Use CSS `animation` |
+| `<center>` | Obsolete | Use CSS `text-align: center` |
+| `<dir>` | Obsolete | Use `<ul>` |
+| `<font>` | Obsolete | Use CSS `color`, `font-family`, `font-size` |
+| `<frame>` | Obsolete | Use `<iframe>` or CSS layout |
+| `<frameset>` | Obsolete | Use CSS layout |
+| `<marquee>` | Obsolete | Use CSS `animation` |
+| `<nobr>` | Obsolete | Use CSS `white-space: nowrap` |
+| `<noframes>` | Obsolete | N/A (frames obsolete) |
+| `<plaintext>` | Obsolete | Use `<pre>` or `<code>` |
+| `<spacer>` | Obsolete | Use CSS `margin`, `padding` |
+| `<strike>` | Obsolete | Use `<del>` or `<s>` |
+| `<tt>` | Obsolete | Use `<code>` or `<kbd>` |
+| `<xmp>` | Obsolete | Use `<pre>` or `<code>` |
+
+### Elements by Display Type
+
+### Block-Level Elements (Default)
+
+Display as block (full width, new line):
+
+```
+<address>, <article>, <aside>, <blockquote>, <canvas>, <dd>, <div>,
+<dl>, <dt>, <fieldset>, <figcaption>, <figure>, <footer>, <form>,
+<h1>-<h6>, <header>, <hr>, <li>, <main>, <nav>, <ol>, <p>, <pre>,
+<section>, <table>, <ul>, <video>
+```
+
+### Inline Elements (Default)
+
+Display inline (no line break):
+
+```
+<a>, <abbr>, <b>, <bdi>, <bdo>, <br>, <button>, <cite>, <code>,
+<data>, <dfn>, <em>, <i>, <img>, <input>, <kbd>, <label>, <mark>,
+<q>, <s>, <samp>, <select>, <small>, <span>, <strong>, <sub>,
+<sup>, <textarea>, <time>, <u>, <var>, <wbr>
+```
+
+### Void Elements (Self-Closing)
+
+Cannot have content:
+
+```
+<area>, <base>, <br>, <col>, <embed>, <hr>, <img>, <input>, <link>,
+<meta>, <param>, <source>, <track>, <wbr>
+```
+
+### Elements by Purpose
+
+### Navigation
+```
+<nav>, <a>, <menu>
+```
+
+### Grouping Content
+```
+<div>, <section>, <article>, <aside>, <header>, <footer>, <main>
+```
+
+### Text Formatting
+```
+<p>, <h1>-<h6>, <strong>, <em>, <mark>, <del>, <ins>
+```
+
+### Lists
+```
+<ul>, <ol>, <li>, <dl>, <dt>, <dd>
+```
+
+### Forms
+```
+<form>, <input>, <textarea>, <select>, <button>, <label>, <fieldset>, <legend>
+```
+
+### Media
+```
+<img>, <audio>, <video>, <picture>, <source>, <track>
+```
+
+### Tables
+```
+<table>, <tr>, <td>, <th>, <thead>, <tbody>, <tfoot>, <caption>
+```
+
+### Code/Programming
+```
+<code>, <pre>, <kbd>, <samp>, <var>
+```
+
+### Quick Reference by Use Case
+
+### Basic Page Structure
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Page Title</title>
+  </head>
+  <body>
+    <header>Header</header>
+    <nav>Navigation</nav>
+    <main>Main Content</main>
+    <footer>Footer</footer>
+  </body>
+</html>
+```
+
+### Content Organization
+```html
+<article>
+  <header>
+    <h1>Article Title</h1>
+    <time>Date</time>
+  </header>
+  <section>
+    <h2>Section</h2>
+    <p>Content</p>
+  </section>
+  <footer>Article footer</footer>
+</article>
+```
+
+### Text Semantics
+```html
+<p>Normal text with <strong>important</strong> and <em>emphasized</em> parts.</p>
+<p>Use <code>code</code> for inline code and <pre> for blocks.</p>
+<p><abbr title="HyperText Markup Language">HTML</abbr> example.</p>
+```
+
+### Forms
+```html
+<form>
+  <label for="name">Name:</label>
+  <input type="text" id="name" name="name">
+  <button type="submit">Submit</button>
+</form>
+```
+
+### Media
+```html
+<img src="image.jpg" alt="Description">
+<video controls>
+  <source src="video.mp4" type="video/mp4">
+</video>
+<audio controls>
+  <source src="audio.mp3" type="audio/mpeg">
+</audio>
+```
+
+### Lists
+```html
+<!-- Unordered -->
+<ul>
+  <li>Item 1</li>
+  <li>Item 2</li>
+</ul>
+
+<!-- Ordered -->
+<ol>
+  <li>First</li>
+  <li>Second</li>
+</ol>
+
+<!-- Description -->
+<dl>
+  <dt>Term</dt>
+  <dd>Definition</dd>
+</dl>
+```
+
+### Tables
+```html
+<table>
+  <caption>Table Title</caption>
+  <thead>
+    <tr><th>Header</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Data</td></tr>
+  </tbody>
+</table>
+```
+
+### Notes
+
+- **Semantic HTML**: Prefer semantic elements (`<article>`, `<nav>`, etc.) over generic `<div>` and `<span>`
+- **Accessibility**: Use proper structure and attributes (alt, labels, ARIA)
+- **Void elements**: Self-closing tags like `<img>`, `<br>`, `<input>` don't need closing tags
+- **Block vs Inline**: Can be changed with CSS `display` property
+- **Nesting rules**: Some elements cannot contain others (e.g., `<p>` cannot contain `<div>`)
+
+## HTML Attributes Glossary
+
+Complete reference of HTML attributes organized by category and element.
+
+### Global Attributes
+
+Attributes that can be used on **any** HTML element:
+
+| Attribute | Description | Values | Example |
+|-----------|-------------|--------|---------|
+| `accesskey` | Keyboard shortcut | Character | `accesskey="s"` |
+| `class` | CSS class(es) | Space-separated classes | `class="btn primary"` |
+| `contenteditable` | Editable content | `true`, `false` | `contenteditable="true"` |
+| `data-*` | Custom data | Any value | `data-user-id="123"` |
+| `dir` | Text direction | `ltr`, `rtl`, `auto` | `dir="rtl"` |
+| `draggable` | Draggable element | `true`, `false` | `draggable="true"` |
+| `hidden` | Hide element | Boolean | `hidden` |
+| `id` | Unique identifier | Unique string | `id="header"` |
+| `inert` | Inert subtree | Boolean | `inert` |
+| `inputmode` | Virtual keyboard type | See table below | `inputmode="numeric"` |
+| `is` | Custom element | Element name | `is="my-element"` |
+| `itemid` | Microdata item ID | URL | `itemid="urn:isbn:123"` |
+| `itemprop` | Microdata property | Property name | `itemprop="name"` |
+| `itemref` | Microdata reference | ID references | `itemref="ref1 ref2"` |
+| `itemscope` | Microdata scope | Boolean | `itemscope` |
+| `itemtype` | Microdata type | URL | `itemtype="https://schema.org/Person"` |
+| `lang` | Language | Language code | `lang="en"`, `lang="es"` |
+| `nonce` | CSP nonce | Random string | `nonce="r@nd0m"` |
+| `part` | Shadow part name | Part name | `part="button"` |
+| `slot` | Slot name | Slot identifier | `slot="header"` |
+| `spellcheck` | Spell checking | `true`, `false` | `spellcheck="false"` |
+| `style` | Inline CSS | CSS declarations | `style="color: red;"` |
+| `tabindex` | Tab order | Integer | `tabindex="0"`, `tabindex="-1"` |
+| `title` | Advisory information | Text | `title="Click for more info"` |
+| `translate` | Translation support | `yes`, `no` | `translate="no"` |
+
+#### Inputmode Values
+
+| Value | Description | Keyboard Type |
+|-------|-------------|---------------|
+| `none` | No virtual keyboard | N/A |
+| `text` | Standard text | Full keyboard |
+| `decimal` | Decimal numbers | Numeric with decimal |
+| `numeric` | Numeric only | Number pad |
+| `tel` | Telephone | Phone number pad |
+| `search` | Search | Search-optimized |
+| `email` | Email address | Email keyboard |
+| `url` | URL | URL keyboard |
+
+### ARIA Attributes
+
+Accessibility attributes (prefix `aria-`):
+
+#### ARIA Roles
+| Attribute | Description | Example |
+|-----------|-------------|---------|
+| `role` | Element role | `role="button"`, `role="navigation"` |
+
+#### ARIA States and Properties
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `aria-activedescendant` | Active child element | ID |
+| `aria-atomic` | Entire region announced | `true`, `false` |
+| `aria-autocomplete` | Autocomplete type | `none`, `inline`, `list`, `both` |
+| `aria-busy` | Loading state | `true`, `false` |
+| `aria-checked` | Checkbox/radio state | `true`, `false`, `mixed` |
+| `aria-colcount` | Total columns | Integer |
+| `aria-colindex` | Column index | Integer |
+| `aria-colspan` | Column span | Integer |
+| `aria-controls` | Controlled elements | ID references |
+| `aria-current` | Current item | `page`, `step`, `location`, `date`, `time`, `true`, `false` |
+| `aria-describedby` | Description reference | ID references |
+| `aria-details` | Details reference | ID reference |
+| `aria-disabled` | Disabled state | `true`, `false` |
+| `aria-dropeffect` | Drag-drop operation | `copy`, `move`, `link`, `execute`, `popup`, `none` |
+| `aria-errormessage` | Error message reference | ID reference |
+| `aria-expanded` | Expanded state | `true`, `false` |
+| `aria-flowto` | Reading order | ID references |
+| `aria-grabbed` | Grabbed state | `true`, `false` |
+| `aria-haspopup` | Popup type | `true`, `false`, `menu`, `listbox`, `tree`, `grid`, `dialog` |
+| `aria-hidden` | Hidden from screen readers | `true`, `false` |
+| `aria-invalid` | Validation state | `true`, `false`, `grammar`, `spelling` |
+| `aria-keyshortcuts` | Keyboard shortcuts | Text |
+| `aria-label` | Accessible label | Text |
+| `aria-labelledby` | Label reference | ID references |
+| `aria-level` | Hierarchical level | Integer |
+| `aria-live` | Live region | `off`, `polite`, `assertive` |
+| `aria-modal` | Modal dialog | `true`, `false` |
+| `aria-multiline` | Multi-line input | `true`, `false` |
+| `aria-multiselectable` | Multi-selection | `true`, `false` |
+| `aria-orientation` | Orientation | `horizontal`, `vertical` |
+| `aria-owns` | Owned elements | ID references |
+| `aria-placeholder` | Placeholder text | Text |
+| `aria-posinset` | Position in set | Integer |
+| `aria-pressed` | Pressed state | `true`, `false`, `mixed` |
+| `aria-readonly` | Read-only state | `true`, `false` |
+| `aria-relevant` | Relevant changes | `additions`, `removals`, `text`, `all` |
+| `aria-required` | Required field | `true`, `false` |
+| `aria-roledescription` | Role description | Text |
+| `aria-rowcount` | Total rows | Integer |
+| `aria-rowindex` | Row index | Integer |
+| `aria-rowspan` | Row span | Integer |
+| `aria-selected` | Selected state | `true`, `false` |
+| `aria-setsize` | Set size | Integer |
+| `aria-sort` | Sort order | `ascending`, `descending`, `none`, `other` |
+| `aria-valuemax` | Maximum value | Number |
+| `aria-valuemin` | Minimum value | Number |
+| `aria-valuenow` | Current value | Number |
+| `aria-valuetext` | Value as text | Text |
+
+### Link Attributes (`<a>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `href` | Target URL | URL |
+| `target` | Where to open | `_self`, `_blank`, `_parent`, `_top`, frame name |
+| `download` | Download filename | Filename (optional) |
+| `rel` | Relationship | See Link Relationships below |
+| `hreflang` | Target language | Language code |
+| `type` | MIME type | MIME type |
+| `ping` | Ping URLs | Space-separated URLs |
+| `referrerpolicy` | Referrer policy | See Referrer Policy below |
+
+#### Link Relationships (`rel`)
+
+| Value | Description | Usage |
+|-------|-------------|-------|
+| `alternate` | Alternate version | RSS feed, translations |
+| `author` | Author page | `<link rel="author">` |
+| `bookmark` | Permalink | Bookmark for section |
+| `canonical` | Canonical URL | Preferred version |
+| `dns-prefetch` | DNS prefetch | `<link rel="dns-prefetch">` |
+| `external` | External site | Links to other domains |
+| `help` | Help document | Help/support page |
+| `icon` | Favicon | `<link rel="icon">` |
+| `license` | License | Copyright/license page |
+| `manifest` | Web manifest | PWA manifest file |
+| `modulepreload` | Module preload | ES6 module preload |
+| `next` | Next page | Pagination |
+| `nofollow` | Don't follow | SEO: don't follow link |
+| `noopener` | No opener reference | Security for `_blank` |
+| `noreferrer` | No referrer | Don't send referrer |
+| `opener` | Has opener | Opposite of noopener |
+| `pingback` | Pingback URL | Blog pingbacks |
+| `preconnect` | Preconnect | Early connection |
+| `prefetch` | Prefetch resource | Future navigation |
+| `preload` | Preload resource | Current page resource |
+| `prerender` | Prerender page | Next page prerender |
+| `prev` | Previous page | Pagination |
+| `search` | Search tool | Search functionality |
+| `stylesheet` | CSS stylesheet | `<link rel="stylesheet">` |
+| `tag` | Tag/keyword | Tag for content |
+
+#### Referrer Policy
+
+| Value | Description |
+|-------|-------------|
+| `no-referrer` | Never send referrer |
+| `no-referrer-when-downgrade` | Don't send on HTTPS→HTTP (default) |
+| `origin` | Send origin only |
+| `origin-when-cross-origin` | Full URL same-origin, origin only cross-origin |
+| `same-origin` | Send only same-origin |
+| `strict-origin` | Origin only, not on downgrade |
+| `strict-origin-when-cross-origin` | Full same-origin, origin cross-origin, none downgrade |
+| `unsafe-url` | Always send full URL |
+
+### Image Attributes (`<img>`)
+
+| Attribute | Description | Required | Example |
+|-----------|-------------|----------|---------|
+| `src` | Image URL | Yes | `src="image.jpg"` |
+| `alt` | Alternative text | Yes | `alt="Description"` |
+| `width` | Image width | No | `width="800"` |
+| `height` | Image height | No | `height="600"` |
+| `srcset` | Responsive sources | No | `srcset="img-400.jpg 400w, img-800.jpg 800w"` |
+| `sizes` | Image sizes | No | `sizes="(max-width: 600px) 400px, 800px"` |
+| `loading` | Loading strategy | No | `loading="lazy"`, `loading="eager"` |
+| `decoding` | Decode strategy | No | `decoding="async"`, `decoding="sync"`, `decoding="auto"` |
+| `crossorigin` | CORS mode | No | `crossorigin="anonymous"` |
+| `ismap` | Server-side map | No | `ismap` (boolean) |
+| `usemap` | Client-side map | No | `usemap="#mapname"` |
+| `referrerpolicy` | Referrer policy | No | See Referrer Policy above |
+
+### Form Attributes (`<form>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `action` | Submit URL | URL |
+| `method` | HTTP method | `GET`, `POST` |
+| `enctype` | Encoding type | `application/x-www-form-urlencoded` (default), `multipart/form-data`, `text/plain` |
+| `accept-charset` | Character encodings | Space-separated encodings |
+| `autocomplete` | Autocomplete | `on`, `off` |
+| `name` | Form name | String |
+| `novalidate` | Skip validation | Boolean |
+| `target` | Response target | `_self`, `_blank`, `_parent`, `_top` |
+| `rel` | Link relationship | See Link Relationships |
+
+### Input Attributes (`<input>`)
+
+#### Universal Input Attributes
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `type` | Input type | See Input Types below |
+| `name` | Field name | String |
+| `value` | Initial value | String |
+| `id` | Unique ID | String |
+| `required` | Required field | Boolean |
+| `disabled` | Disabled field | Boolean |
+| `readonly` | Read-only | Boolean |
+| `autofocus` | Auto focus | Boolean |
+| `autocomplete` | Autocomplete | See Autocomplete Values below |
+| `placeholder` | Placeholder text | String |
+| `form` | Associated form | Form ID |
+
+#### Input Types
+
+| Type | Description | Additional Attributes |
+|------|-------------|----------------------|
+| `text` | Single-line text | `maxlength`, `minlength`, `pattern`, `size` |
+| `password` | Password field | `maxlength`, `minlength`, `pattern`, `size` |
+| `email` | Email address | `maxlength`, `minlength`, `multiple`, `pattern`, `size` |
+| `tel` | Telephone | `maxlength`, `minlength`, `pattern`, `size` |
+| `url` | URL | `maxlength`, `minlength`, `pattern`, `size` |
+| `search` | Search field | `maxlength`, `minlength`, `pattern`, `size` |
+| `number` | Numeric input | `min`, `max`, `step` |
+| `range` | Slider | `min`, `max`, `step` |
+| `date` | Date picker | `min`, `max`, `step` |
+| `time` | Time picker | `min`, `max`, `step` |
+| `datetime-local` | Date and time | `min`, `max`, `step` |
+| `month` | Month picker | `min`, `max`, `step` |
+| `week` | Week picker | `min`, `max`, `step` |
+| `color` | Color picker | N/A |
+| `checkbox` | Checkbox | `checked` |
+| `radio` | Radio button | `checked` |
+| `file` | File upload | `accept`, `multiple`, `capture` |
+| `submit` | Submit button | `formaction`, `formenctype`, `formmethod`, `formnovalidate`, `formtarget` |
+| `reset` | Reset button | N/A |
+| `button` | Generic button | N/A |
+| `image` | Image button | `src`, `alt`, `width`, `height`, `formaction`, etc. |
+| `hidden` | Hidden field | N/A |
+
+#### Type-Specific Attributes
+
+| Attribute | Applies To | Description |
+|-----------|------------|-------------|
+| `accept` | `file` | File types accepted |
+| `capture` | `file` | Camera capture |
+| `checked` | `checkbox`, `radio` | Pre-checked state |
+| `max` | `number`, `range`, date/time | Maximum value |
+| `maxlength` | `text`, `password`, `email`, etc. | Maximum length |
+| `min` | `number`, `range`, date/time | Minimum value |
+| `minlength` | `text`, `password`, `email`, etc. | Minimum length |
+| `multiple` | `email`, `file` | Accept multiple values |
+| `pattern` | `text`, `password`, `email`, etc. | Regex validation |
+| `size` | `text`, `password`, `email`, etc. | Visible width |
+| `step` | `number`, `range`, date/time | Step increment |
+| `list` | Most types | Datalist reference |
+
+#### Autocomplete Values
+
+Common values for `autocomplete` attribute:
+
+| Value | Description |
+|-------|-------------|
+| `off` | Disable autocomplete |
+| `on` | Enable autocomplete |
+| `name` | Full name |
+| `given-name` | First name |
+| `additional-name` | Middle name |
+| `family-name` | Last name |
+| `nickname` | Nickname |
+| `email` | Email address |
+| `username` | Username |
+| `new-password` | New password |
+| `current-password` | Current password |
+| `tel` | Phone number |
+| `tel-country-code` | Country code |
+| `tel-national` | National number |
+| `street-address` | Street address |
+| `address-line1` | Address line 1 |
+| `address-line2` | Address line 2 |
+| `address-level1` | State/province |
+| `address-level2` | City |
+| `postal-code` | Postal/ZIP code |
+| `country` | Country code |
+| `country-name` | Country name |
+| `cc-name` | Cardholder name |
+| `cc-number` | Credit card number |
+| `cc-exp` | Expiration date |
+| `cc-exp-month` | Expiration month |
+| `cc-exp-year` | Expiration year |
+| `cc-csc` | Security code |
+| `cc-type` | Card type |
+| `bday` | Birthday |
+| `bday-day` | Birth day |
+| `bday-month` | Birth month |
+| `bday-year` | Birth year |
+| `sex` | Gender |
+| `url` | Website URL |
+| `photo` | Photo URL |
+
+### Button Attributes (`<button>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `type` | Button type | `submit`, `reset`, `button` |
+| `name` | Button name | String |
+| `value` | Button value | String |
+| `disabled` | Disabled state | Boolean |
+| `form` | Associated form | Form ID |
+| `formaction` | Submit URL override | URL |
+| `formenctype` | Encoding override | See Form `enctype` |
+| `formmethod` | Method override | `GET`, `POST` |
+| `formnovalidate` | Skip validation | Boolean |
+| `formtarget` | Target override | See Form `target` |
+
+### Select Attributes (`<select>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `name` | Field name | String |
+| `size` | Visible options | Integer |
+| `multiple` | Multiple selection | Boolean |
+| `required` | Required field | Boolean |
+| `disabled` | Disabled state | Boolean |
+| `autofocus` | Auto focus | Boolean |
+| `form` | Associated form | Form ID |
+
+### Option Attributes (`<option>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `value` | Option value | String |
+| `label` | Option label | String |
+| `selected` | Pre-selected | Boolean |
+| `disabled` | Disabled option | Boolean |
+
+### Textarea Attributes (`<textarea>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `name` | Field name | String |
+| `rows` | Visible rows | Integer |
+| `cols` | Visible columns | Integer |
+| `maxlength` | Maximum length | Integer |
+| `minlength` | Minimum length | Integer |
+| `placeholder` | Placeholder text | String |
+| `required` | Required field | Boolean |
+| `disabled` | Disabled state | Boolean |
+| `readonly` | Read-only | Boolean |
+| `autofocus` | Auto focus | Boolean |
+| `autocomplete` | Autocomplete | `on`, `off` |
+| `spellcheck` | Spell check | `true`, `false` |
+| `wrap` | Text wrapping | `soft`, `hard` |
+| `form` | Associated form | Form ID |
+
+### Media Attributes (`<audio>`, `<video>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `src` | Media source | URL |
+| `controls` | Show controls | Boolean |
+| `autoplay` | Auto play | Boolean |
+| `loop` | Loop playback | Boolean |
+| `muted` | Muted audio | Boolean |
+| `preload` | Preload strategy | `none`, `metadata`, `auto` |
+| `poster` | Poster image (video only) | URL |
+| `width` | Width (video only) | Integer |
+| `height` | Height (video only) | Integer |
+| `crossorigin` | CORS mode | `anonymous`, `use-credentials` |
+| `playsinline` | Inline playback (mobile) | Boolean |
+
+### Script Attributes (`<script>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `src` | Script URL | URL |
+| `type` | MIME type | `text/javascript` (default), `module` |
+| `async` | Async loading | Boolean |
+| `defer` | Deferred loading | Boolean |
+| `crossorigin` | CORS mode | `anonymous`, `use-credentials` |
+| `integrity` | SRI hash | Hash string |
+| `nomodule` | Fallback for old browsers | Boolean |
+| `nonce` | CSP nonce | Random string |
+| `referrerpolicy` | Referrer policy | See Referrer Policy |
+
+### Table Attributes
+
+#### Table (`<table>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `border` | Border (deprecated) | Integer (use CSS) |
+| `cellspacing` | Cell spacing (deprecated) | Integer (use CSS) |
+| `cellpadding` | Cell padding (deprecated) | Integer (use CSS) |
+
+#### Table Cell (`<td>`, `<th>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `colspan` | Column span | Integer |
+| `rowspan` | Row span | Integer |
+| `headers` | Header references | Space-separated IDs |
+| `scope` | Header scope (`<th>` only) | `row`, `col`, `rowgroup`, `colgroup` |
+
+### Iframe Attributes (`<iframe>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `src` | Frame URL | URL |
+| `srcdoc` | Inline HTML | HTML string |
+| `name` | Frame name | String |
+| `width` | Frame width | Integer or percentage |
+| `height` | Frame height | Integer or percentage |
+| `sandbox` | Security restrictions | See Sandbox below |
+| `allow` | Feature policy | Semicolon-separated policies |
+| `allowfullscreen` | Allow fullscreen | Boolean |
+| `allowpaymentrequest` | Allow payment | Boolean |
+| `loading` | Loading strategy | `lazy`, `eager` |
+| `referrerpolicy` | Referrer policy | See Referrer Policy |
+
+#### Sandbox Values
+
+| Value | Description |
+|-------|-------------|
+| (empty) | All restrictions |
+| `allow-forms` | Allow form submission |
+| `allow-modals` | Allow modals |
+| `allow-orientation-lock` | Allow screen orientation |
+| `allow-pointer-lock` | Allow pointer lock |
+| `allow-popups` | Allow popups |
+| `allow-popups-to-escape-sandbox` | Popups inherit sandbox |
+| `allow-presentation` | Allow presentation API |
+| `allow-same-origin` | Treat as same origin |
+| `allow-scripts` | Allow scripts |
+| `allow-top-navigation` | Allow top navigation |
+| `allow-top-navigation-by-user-activation` | Allow with user action |
+
+### Meta Attributes (`<meta>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `charset` | Character encoding | `UTF-8` (most common) |
+| `name` | Metadata name | `description`, `keywords`, `author`, `viewport`, etc. |
+| `content` | Metadata content | String |
+| `http-equiv` | HTTP header | `content-type`, `refresh`, `content-security-policy`, etc. |
+| `property` | Property name (Open Graph) | `og:title`, `og:image`, etc. |
+
+### Progress/Meter Attributes
+
+#### Progress (`<progress>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `value` | Current value | Number |
+| `max` | Maximum value | Number |
+
+#### Meter (`<meter>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `value` | Current value | Number |
+| `min` | Minimum value | Number |
+| `max` | Maximum value | Number |
+| `low` | Low threshold | Number |
+| `high` | High threshold | Number |
+| `optimum` | Optimum value | Number |
+
+### Details Attributes (`<details>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `open` | Initially open | Boolean |
+
+### Dialog Attributes (`<dialog>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `open` | Visible dialog | Boolean |
+
+### Canvas Attributes (`<canvas>`)
+
+| Attribute | Description | Values |
+|-----------|-------------|--------|
+| `width` | Canvas width | Integer (pixels) |
+| `height` | Canvas height | Integer (pixels) |
+
+### Quick Reference
+
+#### Most Common Attributes
+
+```html
+<!-- Links -->
+<a href="url" target="_blank" rel="noopener">Link</a>
+
+<!-- Images -->
+<img src="image.jpg" alt="Description" width="800" height="600" loading="lazy">
+
+<!-- Forms -->
+<form action="/submit" method="POST">
+  <input type="text" name="username" required>
+  <button type="submit">Submit</button>
+</form>
+
+<!-- Containers -->
+<div id="container" class="wrapper" data-role="main"></div>
+
+<!-- Media -->
+<video src="video.mp4" controls poster="poster.jpg" preload="metadata"></video>
+
+<!-- Scripts -->
+<script src="app.js" defer></script>
+
+<!-- Metadata -->
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+```
+
+### Notes
+
+- **Boolean attributes**: Presence = true, absence = false (e.g., `disabled`, `required`)
+- **Global attributes**: Can be used on any element
+- **Deprecated attributes**: Many presentational attributes deprecated (use CSS instead)
+- **Validation**: Use W3C Validator to check attribute usage
+- **Accessibility**: ARIA attributes enhance accessibility for screen readers
+
+## HTML Event Attributes Glossary
+
+Complete reference for HTML event handler attributes (inline event handlers).
+
+### What Are Event Attributes?
+
+Event attributes (also called inline event handlers) are HTML attributes that execute JavaScript code when specific events occur. They all start with `on` followed by the event name (e.g., `onclick`, `onload`, `onsubmit`).
+
+### ⚠️ Important Note
+
+**Modern best practice**: Use JavaScript `.addEventListener()` instead of inline event attributes for better:
+- **Separation of concerns** (HTML structure vs behavior)
+- **Multiple handlers** per event
+- **Easier maintenance**
+- **Content Security Policy (CSP) compatibility**
+
+```html
+<!-- ❌ Avoid: Inline handler -->
+<button onclick="alert('Clicked')">Click</button>
+
+<!-- ✅ Prefer: Event listener -->
+<button id="myBtn">Click</button>
+<script>
+  document.getElementById('myBtn').addEventListener('click', function() {
+    alert('Clicked');
+  });
+</script>
+```
+
+### Window Events
+
+Events that occur on the window object:
+
+| Event Attribute | When It Fires | Example |
+|-----------------|---------------|---------|
+| `onafterprint` | After print dialog closes | `<body onafterprint="handleAfterPrint()">` |
+| `onbeforeprint` | Before print dialog opens | `<body onbeforeprint="handleBeforePrint()">` |
+| `onbeforeunload` | Before page unload | `<body onbeforeunload="return 'Leave page?'">` |
+| `onerror` | When error occurs | `<body onerror="handleError()">` |
+| `onhashchange` | When URL hash changes | `<body onhashchange="handleHashChange()">` |
+| `onload` | When page/element loads | `<body onload="init()">` |
+| `onmessage` | When message received (postMessage) | `<body onmessage="handleMessage()">` |
+| `onoffline` | When browser goes offline | `<body onoffline="handleOffline()">` |
+| `ononline` | When browser goes online | `<body ononline="handleOnline()">` |
+| `onpagehide` | When navigating away | `<body onpagehide="handlePageHide()">` |
+| `onpageshow` | When navigating to page | `<body onpageshow="handlePageShow()">` |
+| `onpopstate` | When history state changes | `<body onpopstate="handlePopState()">` |
+| `onresize` | When window is resized | `<body onresize="handleResize()">` |
+| `onstorage` | When storage changes | `<body onstorage="handleStorage()">` |
+| `onunload` | When page is unloaded | `<body onunload="cleanup()">` |
+
+**Example**:
+```html
+<body onload="console.log('Page loaded')" onresize="console.log('Window resized')">
+  <h1>Welcome</h1>
+</body>
+```
+
+### Mouse Events
+
+Events triggered by mouse actions:
+
+| Event Attribute | When It Fires | Example |
+|-----------------|---------------|---------|
+| `onclick` | Element is clicked | `<button onclick="handleClick()">Click</button>` |
+| `oncontextmenu` | Right-click (context menu) | `<div oncontextmenu="return false">No right-click</div>` |
+| `ondblclick` | Element is double-clicked | `<div ondblclick="handleDoubleClick()">Double-click</div>` |
+| `onmousedown` | Mouse button pressed down | `<button onmousedown="handleMouseDown()">Press</button>` |
+| `onmouseenter` | Mouse enters element | `<div onmouseenter="highlight()">Hover</div>` |
+| `onmouseleave` | Mouse leaves element | `<div onmouseleave="unhighlight()">Hover</div>` |
+| `onmousemove` | Mouse moves over element | `<div onmousemove="trackMouse()">Move mouse</div>` |
+| `onmouseout` | Mouse moves out (bubbles) | `<div onmouseout="handleOut()">Hover out</div>` |
+| `onmouseover` | Mouse moves over (bubbles) | `<div onmouseover="handleOver()">Hover over</div>` |
+| `onmouseup` | Mouse button released | `<button onmouseup="handleMouseUp()">Release</button>` |
+
+**Mouse Event Differences**:
+- **`onmouseenter` vs `onmouseover`**: `enter` doesn't bubble, `over` does
+- **`onmouseleave` vs `onmouseout`**: `leave` doesn't bubble, `out` does
+- **`onclick`**: Fires on mousedown + mouseup
+
+**Example**:
+```html
+<button
+  onmouseenter="this.style.backgroundColor='blue'"
+  onmouseleave="this.style.backgroundColor=''">
+  Hover me
+</button>
+```
+
+### Keyboard Events
+
+Events triggered by keyboard actions:
+
+| Event Attribute | When It Fires | Example |
+|-----------------|---------------|---------|
+| `onkeydown` | Key is pressed down | `<input onkeydown="handleKeyDown(event)">` |
+| `onkeypress` | Key is pressed (deprecated) | `<input onkeypress="handleKeyPress(event)">` |
+| `onkeyup` | Key is released | `<input onkeyup="handleKeyUp(event)">` |
+
+**Note**: `onkeypress` is deprecated. Use `onkeydown` instead.
+
+**Example**:
+```html
+<input
+  type="text"
+  onkeydown="if(event.key === 'Enter') submitForm()"
+  placeholder="Press Enter to submit">
+```
+
+### Form Events
+
+Events related to forms and form controls:
+
+| Event Attribute | When It Fires | Applies To |
+|-----------------|---------------|------------|
+| `onblur` | Element loses focus | Input, textarea, select |
+| `onchange` | Value changes and loses focus | Input, textarea, select |
+| `onfocus` | Element gains focus | Input, textarea, select |
+| `onfocusin` | Element about to gain focus (bubbles) | Input, textarea, select |
+| `onfocusout` | Element about to lose focus (bubbles) | Input, textarea, select |
+| `oninput` | Value changes (immediately) | Input, textarea |
+| `oninvalid` | Input validation fails | Input, textarea, select |
+| `onreset` | Form is reset | Form |
+| `onsearch` | User initiates search | Input type="search" |
+| `onselect` | Text is selected | Input, textarea |
+| `onsubmit` | Form is submitted | Form |
+
+**Event Differences**:
+- **`oninput`**: Fires immediately on every change
+- **`onchange`**: Fires when value changes AND element loses focus
+- **`onblur` vs `onfocusout`**: `blur` doesn't bubble, `focusout` does
+- **`onfocus` vs `onfocusin`**: `focus` doesn't bubble, `focusin` does
+
+**Example**:
+```html
+<form onsubmit="return validateForm()">
+  <input
+    type="text"
+    name="username"
+    oninput="checkAvailability(this.value)"
+    onblur="validateUsername(this.value)"
+    onfocus="showHint()"
+    required>
+  <button type="submit">Submit</button>
+</form>
+
+<input
+  type="search"
+  onsearch="performSearch(this.value)"
+  placeholder="Search...">
+```
+
+### Clipboard Events
+
+Events triggered by clipboard operations:
+
+| Event Attribute | When It Fires | Example |
+|-----------------|---------------|---------|
+| `oncopy` | Content is copied | `<p oncopy="alert('Copied!')">Copy this</p>` |
+| `oncut` | Content is cut | `<input oncut="handleCut()">` |
+| `onpaste` | Content is pasted | `<input onpaste="handlePaste(event)">` |
+
+**Example**:
+```html
+<input
+  type="text"
+  onpaste="event.preventDefault(); alert('Paste disabled')"
+  placeholder="Cannot paste here">
+```
+
+### Drag Events
+
+Events for drag-and-drop operations:
+
+| Event Attribute | When It Fires | Target |
+|-----------------|---------------|--------|
+| `ondrag` | Element is being dragged | Draggable element |
+| `ondragend` | Drag operation ends | Draggable element |
+| `ondragenter` | Dragged element enters drop target | Drop target |
+| `ondragleave` | Dragged element leaves drop target | Drop target |
+| `ondragover` | Dragged element is over drop target | Drop target |
+| `ondragstart` | Drag operation starts | Draggable element |
+| `ondrop` | Element is dropped | Drop target |
+
+**Example**:
+```html
+<div
+  draggable="true"
+  ondragstart="event.dataTransfer.setData('text', this.id)">
+  Drag me
+</div>
+
+<div
+  ondragover="event.preventDefault()"
+  ondrop="handleDrop(event)">
+  Drop here
+</div>
+```
+
+### Media Events
+
+Events for audio and video elements:
+
+| Event Attribute | When It Fires |
+|-----------------|---------------|
+| `onabort` | Media loading aborted |
+| `oncanplay` | Media can start playing |
+| `oncanplaythrough` | Media can play without buffering |
+| `ondurationchange` | Duration changes |
+| `onemptied` | Media becomes empty |
+| `onended` | Media playback ends |
+| `onerror` | Error loading media |
+| `onloadeddata` | Media data loaded |
+| `onloadedmetadata` | Metadata loaded |
+| `onloadstart` | Browser starts loading |
+| `onpause` | Media is paused |
+| `onplay` | Media starts playing |
+| `onplaying` | Media is playing after pause/buffer |
+| `onprogress` | Browser is downloading media |
+| `onratechange` | Playback speed changes |
+| `onseeked` | Seeking completes |
+| `onseeking` | Seeking starts |
+| `onstalled` | Browser trying to get media data |
+| `onsuspend` | Browser stops getting media data |
+| `ontimeupdate` | Current playback time changes |
+| `onvolumechange` | Volume changes |
+| `onwaiting` | Media paused waiting for data |
+
+**Example**:
+```html
+<video
+  src="video.mp4"
+  controls
+  onplay="console.log('Playing')"
+  onpause="console.log('Paused')"
+  onended="console.log('Finished')">
+</video>
+
+<audio
+  src="audio.mp3"
+  onloadedmetadata="showDuration()"
+  ontimeupdate="updateProgress()">
+</audio>
+```
+
+### Miscellaneous Events
+
+Other useful event attributes:
+
+| Event Attribute | When It Fires | Applies To |
+|-----------------|---------------|------------|
+| `onscroll` | Element is scrolled | Scrollable elements |
+| `ontoggle` | Details element toggled | `<details>` |
+| `onwheel` | Mouse wheel scrolled | Any element |
+
+**Example**:
+```html
+<div onscroll="handleScroll()" style="height: 200px; overflow: auto;">
+  <p>Scrollable content...</p>
+</div>
+
+<details ontoggle="console.log('Toggled')">
+  <summary>Click to toggle</summary>
+  <p>Hidden content</p>
+</details>
+```
+
+### Animation and Transition Events
+
+CSS animation and transition events:
+
+| Event Attribute | When It Fires |
+|-----------------|---------------|
+| `onanimationend` | CSS animation completes |
+| `onanimationiteration` | CSS animation repeats |
+| `onanimationstart` | CSS animation starts |
+| `ontransitionend` | CSS transition completes |
+| `ontransitioncancel` | CSS transition cancelled |
+| `ontransitionrun` | CSS transition starts |
+
+**Example**:
+```html
+<div
+  class="animated"
+  onanimationend="console.log('Animation finished')"
+  onanimationstart="console.log('Animation started')">
+  Animated element
+</div>
+```
+
+### Touch Events (Mobile)
+
+Touch events for mobile devices:
+
+| Event Attribute | When It Fires |
+|-----------------|---------------|
+| `ontouchcancel` | Touch interrupted |
+| `ontouchend` | Touch ends |
+| `ontouchmove` | Touch moves |
+| `ontouchstart` | Touch starts |
+
+**Example**:
+```html
+<div
+  ontouchstart="handleTouchStart(event)"
+  ontouchmove="handleTouchMove(event)"
+  ontouchend="handleTouchEnd(event)">
+  Touch me (mobile)
+</div>
+```
+
+### Event Object
+
+All event handlers receive an event object with useful properties:
+
+```html
+<button onclick="handleClick(event)">Click</button>
+
+<script>
+function handleClick(event) {
+  console.log('Event type:', event.type);           // 'click'
+  console.log('Target element:', event.target);     // <button>
+  console.log('Mouse X:', event.clientX);           // X coordinate
+  console.log('Mouse Y:', event.clientY);           // Y coordinate
+
+  event.preventDefault();  // Prevent default action
+  event.stopPropagation(); // Stop event bubbling
+}
+</script>
+```
+
+### Common Patterns
+
+#### Prevent Default Behavior
+
+```html
+<!-- Prevent form submission -->
+<form onsubmit="return false">...</form>
+<form onsubmit="event.preventDefault()">...</form>
+
+<!-- Prevent link navigation -->
+<a href="#" onclick="return false">Don't navigate</a>
+
+<!-- Prevent right-click menu -->
+<div oncontextmenu="return false">No right-click</div>
+```
+
+#### Access Element
+
+```html
+<!-- Using 'this' keyword -->
+<button onclick="console.log(this.textContent)">Click</button>
+
+<!-- Using event.target -->
+<button onclick="console.log(event.target.textContent)">Click</button>
+
+<!-- Passing 'this' explicitly -->
+<button onclick="handleClick(this)">Click</button>
+```
+
+#### Conditional Execution
+
+```html
+<!-- Check key pressed -->
+<input onkeydown="if(event.key === 'Enter') submitForm()">
+
+<!-- Check Ctrl key -->
+<div onclick="if(event.ctrlKey) console.log('Ctrl + Click')">Click</div>
+
+<!-- Check button (0=left, 1=middle, 2=right) -->
+<div onmousedown="if(event.button === 2) console.log('Right click')">Click</div>
+```
+
+### Best Practices
+
+#### ✅ Do
+
+1. **Use `addEventListener()` instead** of inline handlers
+2. **Call `preventDefault()`** to stop default behavior
+3. **Call `stopPropagation()`** to prevent bubbling when needed
+4. **Pass `event` object** to handlers for access to event details
+5. **Return false** to prevent default (works for some events)
+6. **Use semantic events** (onclick for clickable, onsubmit for forms)
+
+#### ❌ Don't
+
+1. **Don't use inline handlers in production** (violates CSP, hard to maintain)
+2. **Don't use `onkeypress`** (deprecated, use `onkeydown`)
+3. **Don't forget to prevent default** when needed (links, forms)
+4. **Don't mix inline and addEventListener** (confusing)
+5. **Don't put complex logic inline** (use external functions)
+6. **Don't use `onclick` on non-interactive elements** (use buttons/links)
+
+### Modern Alternative: addEventListener()
+
+**Why addEventListener is better**:
+
+```html
+<!-- ❌ Inline: Limited to one handler -->
+<button onclick="doA()">Click</button>
+
+<!-- ✅ addEventListener: Multiple handlers -->
+<button id="btn">Click</button>
+<script>
+  const btn = document.getElementById('btn');
+  btn.addEventListener('click', doA);
+  btn.addEventListener('click', doB);  // Both run!
+  btn.addEventListener('click', doC);  // All three run!
+</script>
+```
+
+**Separation of concerns**:
+
+```html
+<!-- ❌ Inline: Mixed HTML and JavaScript -->
+<button onclick="alert('Clicked')">Click</button>
+
+<!-- ✅ Separate: Clean HTML, JS in script -->
+<button id="myBtn">Click</button>
+<script>
+  document.getElementById('myBtn').addEventListener('click', function() {
+    alert('Clicked');
+  });
+</script>
+```
+
+**CSP compatibility**:
+
+```html
+<!-- ❌ Inline: Blocked by strict CSP -->
+<button onclick="alert('Blocked')">Click</button>
+
+<!-- ✅ External: Allowed by CSP -->
+<button id="btn">Click</button>
+<script src="app.js"></script>
+<!-- app.js: document.getElementById('btn').addEventListener('click', ...) -->
+```
+
+### Quick Reference Table
+
+#### Most Common Events
+
+| Event | Use For | Example |
+|-------|---------|---------|
+| `onclick` | Click actions | Buttons, links |
+| `onsubmit` | Form submission | Forms |
+| `oninput` | Real-time input | Search, validation |
+| `onchange` | Final value change | Select, checkbox |
+| `onload` | Page/image load | Body, images |
+| `onkeydown` | Keyboard shortcuts | Inputs, body |
+| `onmouseenter` | Hover effects | Any element |
+| `onfocus` | Input focus | Form fields |
+| `onblur` | Input unfocus | Form fields |
+
+#### Event Order
+
+**Mouse Click**:
+1. `onmousedown`
+2. `onmouseup`
+3. `onclick`
+
+**Form Submission**:
+1. `onsubmit` (can prevent)
+2. Form submits
+
+**Input Change**:
+1. `oninput` (every keystroke)
+2. `onchange` (on blur)
+
+**Page Load**:
+1. `DOMContentLoaded` (not an attribute)
+2. `onload`
+
+### Debugging Events
+
+```html
+<!-- Log all event details -->
+<button onclick="console.log(event)">Debug Event</button>
+
+<!-- See event properties -->
+<div onclick="console.table({
+  type: event.type,
+  target: event.target.tagName,
+  x: event.clientX,
+  y: event.clientY,
+  ctrlKey: event.ctrlKey,
+  shiftKey: event.shiftKey
+})">Click to inspect</div>
+```
+
+### Resource
+
+For complete reference, see:
+- **MDN Event Reference**: https://developer.mozilla.org/en-US/docs/Web/Events
+- **addEventListener()**: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener

--- a/src/opensquilla/skills/bundled/html-coder/references/standards.md
+++ b/src/opensquilla/skills/bundled/html-coder/references/standards.md
@@ -1,0 +1,506 @@
+# HTML Standards and Best Practices
+
+Guidelines for writing valid, standards-compliant HTML based on the WHATWG HTML Living Standard and W3C specifications.
+
+## HTML Standard Bodies
+
+### WHATWG (Web Hypertext Application Technology Working Group)
+
+**HTML Living Standard**: The primary, continuously-updated HTML specification.
+- URL: https://html.spec.whatwg.org/
+- Single, evolving document
+- Adopted by all major browsers
+- Authoritative source for HTML
+
+### W3C (World Wide Web Consortium)
+
+**W3C HTML**: Previously maintained HTML5, now defers to WHATWG
+- Historical specifications (HTML 4.01, XHTML 1.0)
+- Accessibility guidelines (WCAG)
+- Related standards (CSS, SVG)
+
+## Document Structure Requirements
+
+### Minimal Valid HTML Document
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page Title</title>
+</head>
+<body>
+  <!-- Content -->
+</body>
+</html>
+```
+
+### Required Elements
+
+1. **`<!DOCTYPE html>`**: Document type declaration (must be first)
+2. **`<html>`**: Root element
+3. **`<head>`**: Document metadata container
+4. **`<title>`**: Document title (required in `<head>`)
+5. **`<body>`**: Document content container
+
+### Recommended Elements
+
+1. **`<meta charset="UTF-8">`**: Character encoding (must be in first 1024 bytes)
+2. **`lang` attribute on `<html>`**: Primary language (e.g., `lang="en"`)
+3. **`<meta name="viewport">`**: Responsive design viewport settings
+
+## Syntax Rules
+
+### Element Syntax
+
+**Start and end tags**:
+```html
+<p>Paragraph content</p>
+```
+
+**Void elements** (no closing tag):
+```html
+<img src="image.jpg" alt="Description">
+<br>
+<hr>
+<input type="text">
+<link rel="stylesheet" href="style.css">
+<meta charset="UTF-8">
+```
+
+**Optional closing tags** (HTML allows omission in certain contexts, but not recommended):
+- `</li>`, `</p>`, `</td>`, etc.
+
+### Attribute Syntax
+
+**With values**:
+```html
+<input type="text" name="username">
+```
+
+**Boolean attributes** (presence means true):
+```html
+<input type="checkbox" checked>
+<input type="text" disabled>
+<script src="script.js" defer></script>
+```
+
+**Quotes**: Optional for simple values, required for values with spaces or special characters
+```html
+<!-- Both valid, but quotes preferred -->
+<div class="container"></div>
+<div class=container></div>
+```
+
+### Case Sensitivity
+
+HTML is **case-insensitive** for:
+- Element names: `<DIV>` = `<div>`
+- Attribute names: `CLASS` = `class`
+
+But **case-sensitive** for:
+- Attribute values (most): `class="MyClass"` ≠ `class="myclass"`
+- IDs and classes in CSS/JavaScript
+
+**Best practice**: Use lowercase for elements and attributes.
+
+## Content Models
+
+### Content Categories
+
+Elements belong to one or more categories that determine where they can be used:
+
+1. **Metadata content**: `<link>`, `<meta>`, `<style>`, `<title>`, `<script>`
+2. **Flow content**: Most body elements (`<div>`, `<p>`, `<ul>`, etc.)
+3. **Sectioning content**: `<article>`, `<aside>`, `<nav>`, `<section>`
+4. **Heading content**: `<h1>` to `<h6>`, `<hgroup>`
+5. **Phrasing content**: Text-level elements (`<span>`, `<a>`, `<strong>`, etc.)
+6. **Embedded content**: `<img>`, `<video>`, `<audio>`, `<iframe>`, `<svg>`
+7. **Interactive content**: `<a>`, `<button>`, `<input>`, `<select>`, `<textarea>`
+
+### Nesting Rules
+
+**Valid nesting**:
+```html
+<div><p>Text</p></div>
+<ul><li>Item</li></ul>
+<p><strong>Bold text</strong></p>
+```
+
+**Invalid nesting**:
+```html
+<!-- Inline element containing block element -->
+<span><div>Invalid</div></span>
+
+<!-- Paragraphs cannot contain other paragraphs -->
+<p><p>Invalid</p></p>
+
+<!-- Links cannot contain interactive content -->
+<a href="#"><button>Invalid</button></a>
+
+<!-- List items must be direct children -->
+<ul><div><li>Invalid</li></div></ul>
+```
+
+## Semantic HTML
+
+### Principle: Use Elements for Meaning, Not Appearance
+
+**Bad** (presentational):
+```html
+<div class="heading">Section Title</div>
+<div onclick="doSomething()">Click me</div>
+<div class="bold">Important text</div>
+```
+
+**Good** (semantic):
+```html
+<h2>Section Title</h2>
+<button onclick="doSomething()">Click me</button>
+<strong>Important text</strong>
+```
+
+### Semantic Element Usage
+
+| Purpose | Use | Don't Use |
+|---------|-----|-----------|
+| Page header | `<header>` | `<div class="header">` |
+| Navigation | `<nav>` | `<div id="nav">` |
+| Main content | `<main>` | `<div id="main">` |
+| Article/post | `<article>` | `<div class="post">` |
+| Sidebar | `<aside>` | `<div class="sidebar">` |
+| Page footer | `<footer>` | `<div class="footer">` |
+| Buttons | `<button>` | `<div class="button">` |
+
+### Document Outline
+
+Create logical document structure with headings:
+
+```html
+<h1>Site Title</h1>
+  <h2>Section 1</h2>
+    <h3>Subsection 1.1</h3>
+    <h3>Subsection 1.2</h3>
+  <h2>Section 2</h2>
+    <h3>Subsection 2.1</h3>
+```
+
+**Rules**:
+- One `<h1>` per page (usually)
+- Don't skip heading levels
+- Use headings for structure, not styling
+
+## Validation Standards
+
+### Character Encoding
+
+**Always specify UTF-8**:
+```html
+<meta charset="UTF-8">
+```
+
+Must appear:
+- Within first 1024 bytes of document
+- Before any content that uses non-ASCII characters
+
+### Required Attributes
+
+Certain attributes are required for validity:
+
+| Element | Required Attributes |
+|---------|-------------------|
+| `<img>` | `src`, `alt` |
+| `<a>` (if href present) | `href` |
+| `<input>` (for forms) | `name` (except submit/button) |
+| `<label>` | `for` or contains input |
+| `<optgroup>` | `label` |
+| `<map>` | `name` |
+| `<area>` | `alt` (for image maps) |
+
+### Attribute Values
+
+**Valid attribute characters**: Letters, digits, hyphens, periods, underscores, colons
+**ID restrictions**:
+- Must be unique within document
+- Cannot contain spaces
+- For CSS selector convenience, prefer starting with a letter; IDs starting with digits may require escaping in some selectors
+
+**Class names**:
+- Can have multiple (space-separated)
+- Case-sensitive in CSS
+- Should be descriptive, not presentational
+
+## Accessibility Requirements
+
+### ARIA (Accessible Rich Internet Applications)
+
+Override or enhance semantic meaning when needed:
+
+```html
+<div role="button" tabindex="0" aria-pressed="false">
+  Toggle Button
+</div>
+```
+
+**Rules**:
+- Use semantic HTML first (button is better than div with role="button")
+- All interactive elements must be keyboard accessible
+- Provide text alternatives for non-text content
+- Ensure sufficient color contrast
+
+### Alt Text
+
+**Required for images**:
+```html
+<!-- Informative image -->
+<img src="chart.png" alt="Sales increased 40% in Q4 2024">
+
+<!-- Decorative image -->
+<img src="decorative.png" alt="">
+
+<!-- Functional image (link/button) -->
+<a href="home.html"><img src="logo.png" alt="Home"></a>
+```
+
+### Form Accessibility
+
+**Always label inputs**:
+```html
+<label for="email">Email:</label>
+<input type="email" id="email" name="email">
+```
+
+**Group related inputs**:
+```html
+<fieldset>
+  <legend>Shipping Address</legend>
+  <!-- Address fields -->
+</fieldset>
+```
+
+## Performance Standards
+
+### Critical Rendering Path
+
+Optimize document loading:
+
+1. **Place CSS in `<head>`**:
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+2. **Place scripts at end of `<body>` or use `defer`**:
+```html
+<script src="script.js" defer></script>
+```
+
+3. **Inline critical CSS** (optional, for above-the-fold content)
+
+### Resource Hints
+
+Improve loading performance:
+
+```html
+<!-- Preconnect to external domains -->
+<link rel="preconnect" href="https://cdn.example.com">
+
+<!-- Prefetch likely next page -->
+<link rel="prefetch" href="next-page.html">
+
+<!-- Preload critical resources -->
+<link rel="preload" href="font.woff2" as="font" crossorigin>
+```
+
+### Image Optimization
+
+**Responsive images**:
+```html
+<img src="image-800w.jpg"
+     srcset="image-400w.jpg 400w,
+             image-800w.jpg 800w,
+             image-1200w.jpg 1200w"
+     sizes="(max-width: 600px) 400px,
+            (max-width: 1000px) 800px,
+            1200px"
+     alt="Description">
+```
+
+**Modern image formats**:
+```html
+<picture>
+  <source srcset="image.webp" type="image/webp">
+  <source srcset="image.jpg" type="image/jpeg">
+  <img src="image.jpg" alt="Description">
+</picture>
+```
+
+## Security Standards
+
+### Content Security Policy
+
+Prevent XSS attacks:
+
+```html
+<meta http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' https://trusted.cdn.com">
+```
+
+### Subresource Integrity (SRI)
+
+Verify external resources:
+
+```html
+<script src="https://cdn.example.com/lib.js"
+        integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"
+        crossorigin="anonymous"></script>
+```
+
+### Referrer Policy
+
+Control referrer information:
+
+```html
+<meta name="referrer" content="strict-origin-when-cross-origin">
+```
+
+## HTML5 Features
+
+### New Semantic Elements
+
+HTML5 introduced elements for better document structure:
+- `<header>`, `<nav>`, `<main>`, `<aside>`, `<footer>`
+- `<article>`, `<section>`
+- `<figure>`, `<figcaption>`
+- `<mark>`, `<time>`, `<progress>`, `<meter>`
+
+### New Form Types
+
+Enhanced form inputs:
+- `email`, `url`, `tel`, `number`, `range`, `date`, `color`
+- Form validation attributes: `required`, `pattern`, `min`, `max`
+
+### Multimedia Elements
+
+Native audio and video:
+```html
+<video controls width="640" height="360">
+  <source src="video.mp4" type="video/mp4">
+  <source src="video.webm" type="video/webm">
+  Your browser doesn't support video.
+</video>
+```
+
+### APIs
+
+HTML5 includes JavaScript APIs:
+- Canvas, SVG
+- Geolocation
+- Web Storage (localStorage, sessionStorage)
+- Web Workers
+- WebSockets
+
+## Deprecated Elements and Attributes
+
+### Don't Use These Elements
+
+| Element | Why Deprecated | Use Instead |
+|---------|---------------|-------------|
+| `<font>` | Presentational | CSS `font-family`, `color` |
+| `<center>` | Presentational | CSS `text-align: center` |
+| `<big>`, `<small>` (for styling) | Presentational | CSS `font-size` |
+| `<frame>`, `<frameset>` | Accessibility, usability | Modern layout techniques |
+| `<marquee>` | Poor UX | CSS animations |
+| `<blink>` | Poor UX | CSS animations |
+
+### Don't Use These Attributes
+
+| Attribute | Use Instead |
+|-----------|-------------|
+| `align`, `valign` | CSS `text-align`, `vertical-align` |
+| `bgcolor` | CSS `background-color` |
+| `border` (except on tables) | CSS `border` |
+| `width`, `height` (except media) | CSS dimensions |
+
+## Validation Tools
+
+### Online Validators
+
+1. **W3C Markup Validation Service**: https://validator.w3.org/
+2. **Nu Html Checker**: https://validator.w3.org/nu/
+3. **HTML5 Outliner**: View document structure
+
+### Browser DevTools
+
+All major browsers include HTML inspection and validation:
+- Chrome/Edge DevTools
+- Firefox Developer Tools
+- Safari Web Inspector
+
+### Automated Testing
+
+**Linters and checkers**:
+- HTMLHint
+- HTML-validate
+- Lighthouse (Chrome DevTools)
+
+## Best Practices Summary
+
+1. ✅ **Use semantic HTML**: Choose elements by meaning, not appearance
+2. ✅ **Validate your HTML**: Use W3C validator regularly
+3. ✅ **Ensure accessibility**: WCAG 2.1 AA minimum compliance
+4. ✅ **Specify language**: Add `lang` attribute to `<html>`
+5. ✅ **Use UTF-8 encoding**: Always include `<meta charset="UTF-8">`
+6. ✅ **Include viewport meta**: For responsive design
+7. ✅ **Provide alt text**: For all images (empty string if decorative)
+8. ✅ **Label form inputs**: Every input needs associated label
+9. ✅ **Use lowercase**: For elements and attributes
+10. ✅ **Close all elements**: Even though some closings are optional
+11. ✅ **Indent properly**: For readability and maintainability
+12. ✅ **Separate concerns**: HTML for structure, CSS for presentation, JS for behavior
+13. ✅ **Optimize performance**: Proper resource loading order
+14. ✅ **Test cross-browser**: Check major browsers and devices
+15. ✅ **Avoid inline styles**: Use external CSS files
+
+## Common Mistakes to Avoid
+
+1. ❌ Missing `<!DOCTYPE html>`
+2. ❌ Missing `<title>` element
+3. ❌ Missing character encoding declaration
+4. ❌ Using divs for everything (non-semantic HTML)
+5. ❌ Missing alt attributes on images
+6. ❌ Using deprecated elements (font, center, etc.)
+7. ❌ Incorrect nesting (inline containing block elements)
+8. ❌ Missing or incorrect form labels
+9. ❌ Not closing elements properly
+10. ❌ Mixing HTML and CSS (inline styles everywhere)
+11. ❌ Using tables for layout (use CSS Grid/Flexbox)
+12. ❌ Missing heading hierarchy (skipping levels)
+13. ❌ Too many or too few headings
+14. ❌ Not validating HTML
+15. ❌ Ignoring accessibility
+
+## HTML Conformance Checkers
+
+**Document conformance** means:
+- Follows HTML syntax rules
+- Elements used correctly per content model
+- Required attributes present
+- No deprecated features
+- Accessibility requirements met
+
+**Check with**:
+```bash
+# Command-line validator
+npm install -g html-validate
+html-validate index.html
+```
+
+## Resources
+
+- **WHATWG HTML Living Standard**: https://html.spec.whatwg.org/
+- **MDN Web Docs HTML**: https://developer.mozilla.org/en-US/docs/Web/HTML
+- **W3C HTML Validator**: https://validator.w3.org/
+- **WCAG Guidelines**: https://www.w3.org/WAI/WCAG21/quickref/
+- **Can I Use**: https://caniuse.com/ (browser support)
+- **HTML5 Doctor**: http://html5doctor.com/ (element usage guide)

--- a/src/opensquilla/skills/bundled/html-coder/skill-card.md
+++ b/src/opensquilla/skills/bundled/html-coder/skill-card.md
@@ -1,0 +1,48 @@
+## Description: <br>
+Expert HTML development skill for building web pages, forms, and interactive content. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Publisher: <br>
+[jhauga](https://clawhub.ai/user/jhauga) <br>
+
+### License/Terms of Use: <br>
+MIT-0 <br>
+
+
+## Use Case: <br>
+Developers and engineers use this skill to create standards-compliant HTML documents, semantic page structures, accessible forms, responsive media, and HTML5 API examples. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Generated HTML may include copied CDN, hosted-font, analytics, or JavaScript snippets that affect privacy, supply-chain exposure, or production security. <br>
+Mitigation: Review external assets before publishing, and prefer self-hosted or integrity-pinned resources for sensitive production sites. <br>
+
+
+## Reference(s): <br>
+- [HTML Coder release page](https://clawhub.ai/jhauga/html-coder) <br>
+- [Adding CSS Styling to HTML](references/add-css-style.md) <br>
+- [Adding JavaScript to HTML](references/add-javascript.md) <br>
+- [HTML Attributes Reference](references/attributes.md) <br>
+- [HTML Essentials](references/essentials.md) <br>
+- [Global Attributes Reference](references/global-attributes.md) <br>
+- [HTML Glossary](references/glossary.md) <br>
+- [HTML Standards and Best Practices](references/standards.md) <br>
+- [WHATWG HTML Living Standard](https://html.spec.whatwg.org/) <br>
+- [WCAG Accessibility Quick Reference](https://www.w3.org/WAI/WCAG21/quickref/) <br>
+- [MDN Web Docs: HTML](https://developer.mozilla.org/en-US/docs/Web/HTML) <br>
+
+
+## Skill Output: <br>
+**Output Type(s):** [text, markdown, code, configuration, guidance] <br>
+**Output Format:** [Markdown with HTML, CSS, and JavaScript code blocks] <br>
+**Output Parameters:** [1D] <br>
+**Other Properties Related to Output:** [May include web markup examples, accessibility guidance, validation advice, and references to external web standards.] <br>
+
+## Skill Version(s): <br>
+2.0.1 (source: server release metadata) <br>
+
+## Ethical Considerations: <br>
+Users should evaluate whether this skill is appropriate for their environment, review any generated or modified files before relying on them, and apply their organization's safety, security, and compliance requirements before deployment. <br>

--- a/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/SKILL.md
+++ b/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: nano-banana-pro-openrouter
+description: "Deterministic OpenRouter image generation adapter for Nano Banana Pro / Gemini image models. Use as skill_exec when a meta-skill needs local image files and structured IMAGE_READY records without spawning an LLM agent."
+user-invocable: false
+disable-model-invocation: true
+homepage: https://clawhub.ai/skills/nano-banana-pro-openrouter
+provenance:
+  origin: clawhub-mit0
+  license: MIT-0
+  upstream_url: https://clawhub.ai/skills/nano-banana-pro-openrouter
+  maintained_by: OpenSquilla
+metadata:
+  opensquilla:
+    risk: high
+    capabilities: [network-write, filesystem-write]
+    requires:
+      bins: [python3]
+      env: []
+      config:
+        - awesome_webpage.openrouter.api_key_env
+        - awesome_webpage.openrouter.base_url
+        - awesome_webpage.openrouter.models.image_generation
+        - awesome_webpage.output_dir
+entrypoint:
+  command: python {baseDir}/scripts/openrouter_image.py
+  args:
+    - --model
+    - "{{ with.model | default('google/gemini-3-pro-image-preview') }}"
+    - --base-url
+    - "{{ with.base_url | default('https://openrouter.ai/api/v1') }}"
+    - --output-dir
+    - "{{ with.output_dir }}"
+    - --filename
+    - "{{ with.filename | default('image.png') }}"
+    - --resolution
+    - "{{ with.resolution | default('1K') }}"
+    - --max-images
+    - "{{ with.max_images | default('6') }}"
+    - --local-path-prefix
+    - "{{ with.local_path_prefix | default('project/assets/images') }}"
+  stdin: "{{ with.payload | default(with.prompt | default(inputs.user_message)) }}"
+  parse: text
+  timeout: 300
+---
+
+# Nano Banana Pro OpenRouter Adapter
+
+This skill is a deterministic adapter around OpenRouter image generation. It is
+intended for meta-skill `skill_exec` use, not as an open-ended agent surface.
+
+## Contract
+
+- Reads `OPENROUTER_API_KEY` from the child process environment.
+- Does not read `.env` files, prompt for credentials, print credentials, or
+  write credentials to disk.
+- Uses only the model, base URL, output directory, and local path prefix passed
+  by the caller.
+- Saves generated image bytes under the supplied output directory.
+- Emits one `IMAGE_READY:` JSON line per saved image.
+- On missing config or provider failure, emits `IMAGE_CONFIG_NEEDED` or
+  `IMAGE_GENERATION_FAILED` instead of raising non-zero process errors.
+
+## Meta-Skill Payload Mode
+
+When stdin is JSON containing `media_slots`, `image_slots`, `slots`, or
+`page_outline`, the adapter generates image slots and preserves already
+downloaded images. Structured slots are preferred over free-form outline text:
+
+```json
+{
+  "requirement_framing": "...",
+  "media_slots": {"slots": [{"slot_id": "hero-visual", "modality": "image"}]},
+  "page_outline": "...",
+  "image_download": "...",
+  "include_images": "YES",
+  "visual_style": "..."
+}
+```
+
+Existing `IMAGE_READY:` records in `image_download` are preserved. If
+`IMAGE_DOWNLOAD_INCOMPLETE:` lists `unfilled_slot_ids`, only those slots are
+generated. If the caller requested images but both structured slots and outline
+slot parsing are empty, the adapter synthesizes minimal webpage-safe image
+slots from the brief instead of emitting `no_image_slots_to_generate`.
+
+## Plain Prompt Mode
+
+When stdin is plain text, the adapter generates one image using that text as the
+prompt and the `--filename` stem as the `slot_id`.

--- a/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/SKILL.md
+++ b/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/SKILL.md
@@ -28,8 +28,8 @@ entrypoint:
     - "{{ with.model | default('google/gemini-3-pro-image-preview') }}"
     - --base-url
     - "{{ with.base_url | default('https://openrouter.ai/api/v1') }}"
-    - --api-key
-    - "{{ with.api_key | default('') }}"
+    - --api-key-env
+    - "{{ with.api_key_env | default('OPENROUTER_API_KEY') }}"
     - --output-dir
     - "{{ with.output_dir }}"
     - --filename
@@ -40,6 +40,8 @@ entrypoint:
     - "{{ with.max_images | default('6') }}"
     - --local-path-prefix
     - "{{ with.local_path_prefix | default('project/assets/images') }}"
+  env:
+    "{{ with.api_key_env | default('OPENROUTER_API_KEY') }}": "{{ with.api_key | default('') }}"
   stdin: "{{ with.payload | default(with.prompt | default(inputs.user_message)) }}"
   parse: text
   timeout: 300
@@ -52,8 +54,9 @@ intended for meta-skill `skill_exec` use, not as an open-ended agent surface.
 
 ## Contract
 
-- Uses an explicit `with.api_key`/`--api-key` value when provided, otherwise
-  reads `OPENROUTER_API_KEY` from the child process environment.
+- Uses an explicit `with.api_key` value by injecting it into the configured
+  `with.api_key_env` child process environment variable; it never renders the
+  key into argv.
 - Does not read `.env` files, prompt for credentials, print credentials, or
   write credentials to disk.
 - Uses only the model, base URL, output directory, and local path prefix passed

--- a/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/SKILL.md
+++ b/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/SKILL.md
@@ -28,6 +28,8 @@ entrypoint:
     - "{{ with.model | default('google/gemini-3-pro-image-preview') }}"
     - --base-url
     - "{{ with.base_url | default('https://openrouter.ai/api/v1') }}"
+    - --api-key
+    - "{{ with.api_key | default('') }}"
     - --output-dir
     - "{{ with.output_dir }}"
     - --filename
@@ -50,7 +52,8 @@ intended for meta-skill `skill_exec` use, not as an open-ended agent surface.
 
 ## Contract
 
-- Reads `OPENROUTER_API_KEY` from the child process environment.
+- Uses an explicit `with.api_key`/`--api-key` value when provided, otherwise
+  reads `OPENROUTER_API_KEY` from the child process environment.
 - Does not read `.env` files, prompt for credentials, print credentials, or
   write credentials to disk.
 - Uses only the model, base URL, output directory, and local path prefix passed

--- a/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/_meta.json
+++ b/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/_meta.json
@@ -1,0 +1,6 @@
+{
+  "ownerId": "opensquilla",
+  "slug": "nano-banana-pro-openrouter",
+  "version": "1.0.2",
+  "publishedAt": 1770104417525
+}

--- a/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/scripts/openrouter_image.py
+++ b/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/scripts/openrouter_image.py
@@ -1,0 +1,652 @@
+#!/usr/bin/env python3
+"""Deterministic OpenRouter image adapter for Nano Banana Pro."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import concurrent.futures
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+def _emit(label: str, payload: dict[str, Any]) -> None:
+    print(f"{label}: {json.dumps(payload, ensure_ascii=False, separators=(',', ':'))}")
+
+
+def _clean_slot(raw: str) -> str:
+    slot = re.sub(r"[^a-zA-Z0-9_-]+", "-", raw.strip()).strip("-").lower()
+    return slot[:64] or "image"
+
+
+def _extract_field(block: str, name: str) -> str:
+    match = re.search(rf"{name}\s*[:：]\s*(.+)", block, re.I)
+    if not match:
+        return ""
+    value = match.group(1).strip().strip("`\"'")
+    return value[:500]
+
+
+def _is_image_modality(value: str) -> bool:
+    text = value.strip().lower()
+    return bool(re.search(r"\bimage\b", text)) or any(
+        marker in value for marker in ("图片", "图像", "影像")
+    )
+
+
+def _header_index(headers: list[str], *names: str) -> int | None:
+    normalized = [re.sub(r"[\s_\-/]+", "", h.strip().lower()) for h in headers]
+    for needle in names:
+        needle_norm = re.sub(r"[\s_\-/]+", "", needle.strip().lower())
+        for index, header in enumerate(normalized):
+            if needle_norm and needle_norm in header:
+                return index
+    return None
+
+
+def _cell(cells: list[str], index: int | None) -> str:
+    if index is None or index >= len(cells):
+        return ""
+    return cells[index].strip().strip("`\"'")
+
+
+def _append_slot(
+    slots: list[dict[str, str]],
+    seen: set[str],
+    *,
+    slot_id: str,
+    subject: str = "",
+    prompt_hint: str = "",
+    keywords: str = "",
+) -> None:
+    cleaned = _clean_slot(slot_id)
+    if cleaned in seen:
+        return
+    seen.add(cleaned)
+    slots.append(
+        {
+            "slot_id": cleaned,
+            "subject": (subject or cleaned.replace("-", " "))[:500],
+            "prompt_hint": prompt_hint[:500],
+            "keywords": keywords[:500],
+        }
+    )
+
+
+def _extract_field_blocks(outline: str, slots: list[dict[str, str]], seen: set[str]) -> None:
+    matches = list(
+        re.finditer(r"slot_id\s*[:：]\s*([a-zA-Z0-9][a-zA-Z0-9_-]{0,80})", outline, re.I)
+    )
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else min(
+            len(outline), match.start() + 900
+        )
+        block = outline[match.start() : end]
+        modality = _extract_field(block, "modality")
+        if not _is_image_modality(modality):
+            continue
+        subject = (
+            _extract_field(block, "subject")
+            or _extract_field(block, "placement")
+        )
+        _append_slot(
+            slots,
+            seen,
+            slot_id=match.group(1),
+            subject=subject,
+            prompt_hint=_extract_field(block, "prompt_hint"),
+            keywords=_extract_field(block, "search_keywords"),
+        )
+
+
+def _split_table_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if not stripped.startswith("|") or "|" not in stripped[1:]:
+        return []
+    return [cell.strip() for cell in stripped.strip("|").split("|")]
+
+
+def _looks_like_separator(cells: list[str]) -> bool:
+    return bool(cells) and all(re.fullmatch(r":?-{2,}:?", cell.strip()) for cell in cells)
+
+
+def _extract_table_rows(outline: str, slots: list[dict[str, str]], seen: set[str]) -> None:
+    headers: list[str] | None = None
+    for raw_line in outline.splitlines():
+        cells = _split_table_row(raw_line)
+        if not cells:
+            headers = None
+            continue
+        if _looks_like_separator(cells):
+            continue
+
+        if headers is None:
+            lower_cells = [cell.lower() for cell in cells]
+            has_slot = any("slot" in cell or "槽位" in cell for cell in lower_cells + cells)
+            has_modality = any(
+                "modality" in cell
+                or "媒体" in cell
+                or "模态" in cell
+                or "类型" in cell
+                for cell in lower_cells + cells
+            )
+            if has_slot and has_modality:
+                headers = cells
+            continue
+
+        slot_idx = _header_index(headers, "slot_id", "slot id", "slot", "槽位")
+        modality_idx = _header_index(headers, "modality", "media", "媒体", "模态", "类型")
+        if slot_idx is None or modality_idx is None:
+            continue
+        if not _is_image_modality(_cell(cells, modality_idx)):
+            continue
+        slot_id = _cell(cells, slot_idx)
+        if not slot_id:
+            match = re.search(r"\b([a-zA-Z0-9][a-zA-Z0-9_-]{1,80})\b", raw_line)
+            slot_id = match.group(1) if match else ""
+        if not slot_id:
+            continue
+        subject_idx = _header_index(
+            headers,
+            "subject",
+            "placement",
+            "section",
+            "visual",
+            "画面",
+            "主题",
+            "位置",
+            "章节",
+        )
+        prompt_idx = _header_index(headers, "prompt_hint", "prompt", "hint", "描述", "构图")
+        keyword_idx = _header_index(headers, "search_keywords", "keywords", "关键词")
+        _append_slot(
+            slots,
+            seen,
+            slot_id=slot_id,
+            subject=_cell(cells, subject_idx),
+            prompt_hint=_cell(cells, prompt_idx),
+            keywords=_cell(cells, keyword_idx),
+        )
+
+
+def _extract_inline_rows(outline: str, slots: list[dict[str, str]], seen: set[str]) -> None:
+    for line in outline.splitlines():
+        if not _is_image_modality(line):
+            continue
+        match = re.search(
+            r"slot[_\s-]*id\s*[:：=]\s*([a-zA-Z0-9][a-zA-Z0-9_-]{0,80})",
+            line,
+            re.I,
+        )
+        if not match:
+            continue
+        _append_slot(slots, seen, slot_id=match.group(1), subject=line[:500])
+
+
+def _extract_slots(outline: str) -> list[dict[str, str]]:
+    slots: list[dict[str, str]] = []
+    seen: set[str] = set()
+    _extract_field_blocks(outline, slots, seen)
+    _extract_table_rows(outline, slots, seen)
+    _extract_inline_rows(outline, slots, seen)
+    return slots
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, (dict, list)):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return None
+
+
+def _slot_text(raw: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = raw.get(key)
+        if isinstance(value, list):
+            text = " ".join(str(item).strip() for item in value if str(item).strip())
+        else:
+            text = str(value or "").strip()
+        if text:
+            return text[:500]
+    return ""
+
+
+def _coerce_slot(raw: dict[str, Any], fallback_id: str) -> dict[str, str] | None:
+    modality = str(raw.get("modality") or raw.get("media") or raw.get("type") or "").strip()
+    if modality and not _is_image_modality(modality):
+        return None
+    slot_id = _slot_text(raw, "slot_id", "slot", "id", "name") or fallback_id
+    subject = _slot_text(raw, "subject", "description", "alt", "placement", "role")
+    prompt_hint = _slot_text(raw, "prompt_hint", "prompt", "hint", "composition")
+    keywords = _slot_text(raw, "search_keywords", "keywords", "tags")
+    return {
+        "slot_id": _clean_slot(slot_id),
+        "subject": subject or _clean_slot(slot_id).replace("-", " "),
+        "prompt_hint": prompt_hint,
+        "keywords": keywords,
+    }
+
+
+def _coerce_slots(value: Any) -> list[dict[str, str]]:
+    data = _json_value(value)
+    if isinstance(data, dict):
+        if isinstance(data.get("slots"), list):
+            candidates = data["slots"]
+        elif isinstance(data.get("image_slots"), list):
+            candidates = data["image_slots"]
+        else:
+            candidates = []
+    elif isinstance(data, list):
+        candidates = data
+    else:
+        candidates = []
+
+    slots: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for index, item in enumerate(candidates, start=1):
+        if not isinstance(item, dict):
+            continue
+        slot = _coerce_slot(item, f"image-{index}")
+        if slot is None or slot["slot_id"] in seen:
+            continue
+        seen.add(slot["slot_id"])
+        slots.append(slot)
+    return slots
+
+
+def _payload_slots(payload: dict[str, Any]) -> list[dict[str, str]]:
+    for key in ("image_slots", "media_slots", "slots"):
+        slots = _coerce_slots(payload.get(key))
+        if slots:
+            return slots
+    return []
+
+
+def _images_requested(payload: dict[str, Any]) -> bool:
+    value = str(payload.get("include_images", "YES")).strip().lower()
+    return value not in {"no", "false", "0", "n", "否", "不要", "不需要"}
+
+
+def _brief_topic(payload: dict[str, Any]) -> str:
+    text = "\n".join(
+        str(payload.get(key) or "")
+        for key in ("requirement_framing", "page_outline", "visual_style")
+    )
+    text = re.sub(r"[#*_`|>{}\[\]\"]+", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if not text:
+        return "requested webpage topic"
+    for marker in ("主题", "topic", "brief", "request", "需求"):
+        match = re.search(rf"{marker}\s*[:：]\s*([^。.\n|]{{6,120}})", text, re.I)
+        if match:
+            return match.group(1).strip()[:160]
+    return text[:160]
+
+
+def _fallback_slots(payload: dict[str, Any]) -> list[dict[str, str]]:
+    if not _images_requested(payload):
+        return []
+    topic = _brief_topic(payload)
+    return [
+        {
+            "slot_id": "hero-visual",
+            "subject": f"hero image representing {topic}",
+            "prompt_hint": "wide 16:9 polished webpage hero, documentary clarity, no text overlays",
+            "keywords": topic,
+        },
+        {
+            "slot_id": "supporting-visual",
+            "subject": f"supporting explanatory visual for {topic}",
+            "prompt_hint": (
+                "clean editorial webpage illustration/photo, balanced composition, "
+                "no text overlays"
+            ),
+            "keywords": topic,
+        },
+    ]
+
+
+def _ready_slots(text: str) -> set[str]:
+    found: set[str] = set()
+    for match in re.finditer(r"^IMAGE_READY:\s*(\{.*\})\s*$", text or "", re.M):
+        try:
+            payload = json.loads(match.group(1))
+        except Exception:
+            continue
+        slot_id = _clean_slot(str(payload.get("slot_id") or ""))
+        if slot_id:
+            found.add(slot_id)
+    return found
+
+
+def _incomplete_slots(text: str) -> set[str]:
+    for match in re.finditer(r"^IMAGE_DOWNLOAD_INCOMPLETE:\s*(\{.*\})\s*$", text or "", re.M):
+        try:
+            payload = json.loads(match.group(1))
+        except Exception:
+            continue
+        slot_ids = payload.get("unfilled_slot_ids")
+        if isinstance(slot_ids, list):
+            return {_clean_slot(str(x)) for x in slot_ids if str(x).strip()}
+    return set()
+
+
+def _api_url(base_url: str, path: str) -> str:
+    if base_url.endswith("/v1") and path.startswith("/v1/"):
+        return base_url + path[3:]
+    return base_url + path
+
+
+def _extract_image_url(data: dict[str, Any]) -> str | None:
+    for choice in data.get("choices") or []:
+        message = choice.get("message") or {}
+        for image in message.get("images") or []:
+            image_url = image.get("image_url") or image.get("imageUrl") or {}
+            url = image_url.get("url")
+            if isinstance(url, str) and url:
+                return url
+        content = message.get("content")
+        if isinstance(content, list):
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                image_url = item.get("image_url") or item.get("imageUrl") or {}
+                url = image_url.get("url") if isinstance(image_url, dict) else None
+                if isinstance(url, str) and url:
+                    return url
+    return None
+
+
+def _decode_image(url: str, api_key: str) -> tuple[str, bytes]:
+    if url.startswith("data:"):
+        prefix, sep, encoded = url.partition(",")
+        if not sep or ";base64" not in prefix:
+            raise RuntimeError("unsupported_data_url")
+        mime = prefix.removeprefix("data:").split(";", 1)[0] or "image/png"
+        return mime, base64.b64decode(encoded)
+    if url.startswith(("http://", "https://")):
+        req = urllib.request.Request(url, headers={"Authorization": "Bearer " + api_key})
+        with urllib.request.urlopen(req, timeout=45) as resp:
+            mime = resp.headers.get_content_type() or "image/png"
+            return mime, resp.read()
+    raise RuntimeError("unsupported_image_url")
+
+
+def _extension_for_mime(mime: str) -> str:
+    if mime == "image/jpeg":
+        return ".jpg"
+    if mime == "image/webp":
+        return ".webp"
+    if mime == "image/gif":
+        return ".gif"
+    return ".png"
+
+
+def _scrub_error(exc: object, api_key: str) -> str:
+    text = str(exc)
+    if api_key:
+        text = text.replace(api_key, "[REDACTED]")
+    return re.sub(r"\s+", " ", text)[:220]
+
+
+def _build_slot_prompt(slot: dict[str, str], *, requirement: str, visual_style: str) -> str:
+    parts = [
+        f"Create one high-quality webpage image for slot `{slot['slot_id']}`.",
+        f"Subject: {slot['subject']}",
+    ]
+    if slot.get("prompt_hint"):
+        parts.append(f"Composition/style hint: {slot['prompt_hint']}")
+    if slot.get("keywords"):
+        parts.append(f"Relevant keywords: {slot['keywords']}")
+    if visual_style:
+        parts.append(f"Overall webpage visual style: {visual_style}")
+    parts.append(
+        "No text overlays, no logos, no watermarks. "
+        "Suitable for a polished public webpage."
+    )
+    if requirement:
+        parts.append("Project brief excerpt: " + requirement[:600])
+    return "\n".join(parts)
+
+
+def _generate_one(
+    *,
+    slot_id: str,
+    prompt: str,
+    model: str,
+    base_url: str,
+    api_key: str,
+    output_dir: Path,
+    local_path_prefix: str,
+    resolution: str,
+) -> dict[str, Any]:
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "modalities": ["image", "text"],
+        "stream": False,
+        "image_config": {"aspect_ratio": "16:9", "image_size": resolution},
+    }
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        _api_url(base_url, "/v1/chat/completions"),
+        data=body,
+        headers={
+            "Authorization": "Bearer " + api_key,
+            "Content-Type": "application/json",
+            "X-Title": "OpenSquilla Nano Banana Pro OpenRouter",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=90) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        image_url = _extract_image_url(data)
+        if not image_url:
+            raise RuntimeError("provider_returned_no_image")
+        mime, image_bytes = _decode_image(image_url, api_key)
+        if not mime.startswith("image/") or len(image_bytes) < 1024:
+            raise RuntimeError("invalid_image_payload")
+        ext = _extension_for_mime(mime)
+        filename = _clean_slot(slot_id) + ext
+        out_path = (output_dir / filename).resolve()
+        out_path.relative_to(output_dir)
+        out_path.write_bytes(image_bytes)
+        return {
+            "ok": True,
+            "slot_id": _clean_slot(slot_id),
+            "local_path": f"{local_path_prefix.rstrip('/')}/{filename}",
+            "mime": mime,
+            "bytes": len(image_bytes),
+            "prompt_preview": prompt[:80],
+        }
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read(400).decode("utf-8", errors="replace")
+        except Exception:
+            detail = ""
+        return {
+            "ok": False,
+            "slot_id": _clean_slot(slot_id),
+            "reason": f"http_{exc.code}: {_scrub_error(detail or exc, api_key)}",
+        }
+    except Exception as exc:
+        return {"ok": False, "slot_id": _clean_slot(slot_id), "reason": _scrub_error(exc, api_key)}
+
+
+def _load_stdin() -> tuple[dict[str, Any] | None, str]:
+    raw = sys.stdin.read()
+    text = raw.strip()
+    if not text:
+        return None, ""
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError:
+        return None, text
+    return value if isinstance(value, dict) else None, text
+
+
+def _target_slots(payload: dict[str, Any], max_images: int) -> list[dict[str, str]]:
+    outline = str(payload.get("page_outline") or "")
+    all_slots = _payload_slots(payload) or _extract_slots(outline)
+    if not all_slots:
+        all_slots = _fallback_slots(payload)
+    download_outcome = str(payload.get("image_download") or "")
+    existing = _ready_slots(download_outcome)
+    requested_missing = _incomplete_slots(download_outcome)
+    if requested_missing:
+        slots = [
+            slot
+            for slot in all_slots
+            if slot["slot_id"] in requested_missing and slot["slot_id"] not in existing
+        ]
+    elif existing:
+        slots = [slot for slot in all_slots if slot["slot_id"] not in existing]
+    else:
+        slots = all_slots
+    return slots[:max_images]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--base-url", default="https://openrouter.ai/api/v1")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--filename", default="image.png")
+    parser.add_argument("--resolution", choices=["1K", "2K", "4K"], default="1K")
+    parser.add_argument("--max-images", type=int, default=6)
+    parser.add_argument("--local-path-prefix", default="project/assets/images")
+    args = parser.parse_args()
+
+    api_key = os.environ.get("OPENROUTER_API_KEY", "")
+    replacement_slot = (
+        f"{args.local_path_prefix.rstrip('/')}/replace-with-generated-image.png"
+    )
+    if not args.model.strip():
+        _emit(
+            "IMAGE_CONFIG_NEEDED",
+            {
+                "missing": ["awesome_webpage.openrouter.models.image_generation"],
+                "reason": "missing_image_model",
+                "replacement_slot": replacement_slot,
+            },
+        )
+        return 0
+    if not api_key:
+        _emit(
+            "IMAGE_CONFIG_NEEDED",
+            {
+                "missing": ["OPENROUTER_API_KEY"],
+                "reason": "missing_api_key",
+                "replacement_slot": replacement_slot,
+            },
+        )
+        return 0
+
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    payload, raw_text = _load_stdin()
+
+    if payload is not None and (
+        "page_outline" in payload
+        or "media_slots" in payload
+        or "image_slots" in payload
+        or "slots" in payload
+    ):
+        slots = _target_slots(payload, max(1, args.max_images))
+        if not slots:
+            _emit(
+                "IMAGE_GENERATION_FAILED",
+                {
+                    "reason": "no_image_slots_to_generate",
+                    "replacement_slot": replacement_slot,
+                },
+            )
+            return 0
+        requirement = str(payload.get("requirement_framing") or "")
+        visual_style = str(payload.get("visual_style") or "")
+        jobs = [
+            {
+                "slot_id": slot["slot_id"],
+                "prompt": _build_slot_prompt(
+                    slot,
+                    requirement=requirement,
+                    visual_style=visual_style,
+                ),
+            }
+            for slot in slots
+        ]
+    else:
+        prompt = raw_text or "Create a polished webpage image."
+        slot_id = Path(args.filename).stem or "image"
+        jobs = [{"slot_id": slot_id, "prompt": prompt}]
+
+    max_workers = min(3, len(jobs))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+        results = list(
+            pool.map(
+                lambda job: _generate_one(
+                    slot_id=job["slot_id"],
+                    prompt=job["prompt"],
+                    model=args.model.strip(),
+                    base_url=args.base_url.rstrip("/"),
+                    api_key=api_key,
+                    output_dir=output_dir,
+                    local_path_prefix=args.local_path_prefix,
+                    resolution=args.resolution,
+                ),
+                jobs,
+            )
+        )
+
+    generated = [r for r in results if r.get("ok")]
+    failed = [r for r in results if not r.get("ok")]
+    print(
+        "IMAGE_AIGC_ATTEMPT: "
+        + json.dumps(
+            {
+                "requested": [job["slot_id"] for job in jobs],
+                "generated": [r["slot_id"] for r in generated],
+                "failed": failed,
+                "model": args.model.strip(),
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    )
+    for record in generated:
+        _emit(
+            "IMAGE_READY",
+            {
+                "local_path": record["local_path"],
+                "mime": record["mime"],
+                "bytes": record["bytes"],
+                "slot_id": record["slot_id"],
+                "prompt_preview": record["prompt_preview"],
+            },
+        )
+    if failed:
+        _emit(
+            "IMAGE_GENERATION_FAILED",
+            {
+                "reason": "one_or_more_images_failed",
+                "missing": [{"slot_id": r["slot_id"], "reason": r["reason"]} for r in failed],
+                "replacement_slot": replacement_slot,
+            },
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/scripts/openrouter_image.py
+++ b/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/scripts/openrouter_image.py
@@ -203,10 +203,16 @@ def _json_value(value: Any) -> Any:
         return value
     if not isinstance(value, str) or not value.strip():
         return None
-    try:
-        return json.loads(value)
-    except json.JSONDecodeError:
-        return None
+    text = value.strip()
+    candidates = [text]
+    if text.startswith("exit_code=0\n"):
+        candidates.append(text.split("\n", 1)[1].strip())
+    for candidate in candidates:
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    return None
 
 
 def _slot_text(raw: dict[str, Any], *keys: str) -> str:

--- a/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/scripts/openrouter_image.py
+++ b/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/scripts/openrouter_image.py
@@ -546,6 +546,7 @@ def main() -> int:
     parser.add_argument("--model", required=True)
     parser.add_argument("--base-url", default="https://openrouter.ai/api/v1")
     parser.add_argument("--api-key", default="")
+    parser.add_argument("--api-key-env", default="OPENROUTER_API_KEY")
     parser.add_argument("--output-dir", required=True)
     parser.add_argument("--filename", default="image.png")
     parser.add_argument("--resolution", choices=["1K", "2K", "4K"], default="1K")
@@ -553,7 +554,8 @@ def main() -> int:
     parser.add_argument("--local-path-prefix", default="project/assets/images")
     args = parser.parse_args()
 
-    api_key = args.api_key.strip() or os.environ.get("OPENROUTER_API_KEY", "")
+    api_key_env = args.api_key_env.strip() or "OPENROUTER_API_KEY"
+    api_key = args.api_key.strip() or os.environ.get(api_key_env, "")
     replacement_slot = (
         f"{args.local_path_prefix.rstrip('/')}/replace-with-generated-image.png"
     )
@@ -571,7 +573,7 @@ def main() -> int:
         _emit(
             "IMAGE_CONFIG_NEEDED",
             {
-                "missing": ["OPENROUTER_API_KEY"],
+                "missing": [api_key_env],
                 "reason": "missing_api_key",
                 "replacement_slot": replacement_slot,
             },

--- a/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/scripts/openrouter_image.py
+++ b/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/scripts/openrouter_image.py
@@ -11,6 +11,7 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -353,6 +354,16 @@ def _api_url(base_url: str, path: str) -> str:
     return base_url + path
 
 
+def _resolve_url(url: str, *, base_url: str) -> str:
+    return urllib.parse.urljoin(f"{base_url.rstrip('/')}/", url)
+
+
+def _same_origin(url: str, *, base_url: str) -> bool:
+    parsed = urllib.parse.urlparse(url)
+    base = urllib.parse.urlparse(base_url)
+    return parsed.scheme == base.scheme and parsed.netloc == base.netloc
+
+
 def _extract_image_url(data: dict[str, Any]) -> str | None:
     for choice in data.get("choices") or []:
         message = choice.get("message") or {}
@@ -373,15 +384,21 @@ def _extract_image_url(data: dict[str, Any]) -> str | None:
     return None
 
 
-def _decode_image(url: str, api_key: str) -> tuple[str, bytes]:
+def _decode_image(url: str, api_key: str, *, base_url: str) -> tuple[str, bytes]:
     if url.startswith("data:"):
         prefix, sep, encoded = url.partition(",")
         if not sep or ";base64" not in prefix:
             raise RuntimeError("unsupported_data_url")
         mime = prefix.removeprefix("data:").split(";", 1)[0] or "image/png"
         return mime, base64.b64decode(encoded)
-    if url.startswith(("http://", "https://")):
-        req = urllib.request.Request(url, headers={"Authorization": "Bearer " + api_key})
+    resolved_url = _resolve_url(url, base_url=base_url)
+    if resolved_url.startswith(("http://", "https://")):
+        headers = (
+            {"Authorization": "Bearer " + api_key}
+            if _same_origin(resolved_url, base_url=base_url)
+            else {}
+        )
+        req = urllib.request.Request(resolved_url, headers=headers)
         with urllib.request.urlopen(req, timeout=45) as resp:
             mime = resp.headers.get_content_type() or "image/png"
             return mime, resp.read()
@@ -460,7 +477,7 @@ def _generate_one(
         image_url = _extract_image_url(data)
         if not image_url:
             raise RuntimeError("provider_returned_no_image")
-        mime, image_bytes = _decode_image(image_url, api_key)
+        mime, image_bytes = _decode_image(image_url, api_key, base_url=base_url)
         if not mime.startswith("image/") or len(image_bytes) < 1024:
             raise RuntimeError("invalid_image_payload")
         ext = _extension_for_mime(mime)

--- a/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/scripts/openrouter_image.py
+++ b/src/opensquilla/skills/bundled/nano-banana-pro-openrouter/scripts/openrouter_image.py
@@ -545,6 +545,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", required=True)
     parser.add_argument("--base-url", default="https://openrouter.ai/api/v1")
+    parser.add_argument("--api-key", default="")
     parser.add_argument("--output-dir", required=True)
     parser.add_argument("--filename", default="image.png")
     parser.add_argument("--resolution", choices=["1K", "2K", "4K"], default="1K")
@@ -552,7 +553,7 @@ def main() -> int:
     parser.add_argument("--local-path-prefix", default="project/assets/images")
     args = parser.parse_args()
 
-    api_key = os.environ.get("OPENROUTER_API_KEY", "")
+    api_key = args.api_key.strip() or os.environ.get("OPENROUTER_API_KEY", "")
     replacement_slot = (
         f"{args.local_path_prefix.rstrip('/')}/replace-with-generated-image.png"
     )

--- a/src/opensquilla/skills/bundled/openrouter-video-generator/SKILL.md
+++ b/src/opensquilla/skills/bundled/openrouter-video-generator/SKILL.md
@@ -27,8 +27,8 @@ entrypoint:
     - "{{ with.model | default('bytedance/seedance-2.0-fast') }}"
     - --base-url
     - "{{ with.base_url | default('https://openrouter.ai/api/v1') }}"
-    - --api-key
-    - "{{ with.api_key | default('') }}"
+    - --api-key-env
+    - "{{ with.api_key_env | default('OPENROUTER_API_KEY') }}"
     - --output-dir
     - "{{ with.output_dir }}"
     - --filename
@@ -37,6 +37,8 @@ entrypoint:
     - "{{ with.duration | default(10) }}"
     - --aspect-ratio
     - "{{ with.aspect_ratio | default('16:9') }}"
+  env:
+    "{{ with.api_key_env | default('OPENROUTER_API_KEY') }}": "{{ with.api_key | default('') }}"
   stdin: "{{ with.prompt | default(inputs.user_message) }}"
   parse: text
   timeout: 420
@@ -52,8 +54,8 @@ choose providers or invent model ids.
 
 Meta-skills should run this skill as `skill_exec`. The entrypoint is a
 deterministic Python adapter around OpenRouter's async video endpoint; it uses
-an explicit `with.api_key`/`--api-key` value when provided, otherwise reads
-`OPENROUTER_API_KEY` inside the child process, writes the MP4 under the supplied
+an explicit `with.api_key` value by injecting it into the configured
+`with.api_key_env` child process environment variable, writes the MP4 under the supplied
 output directory, and prints either `VIDEO_READY:` or a single failure label.
 Do not spawn an LLM sub-agent just to generate video.
 

--- a/src/opensquilla/skills/bundled/openrouter-video-generator/SKILL.md
+++ b/src/opensquilla/skills/bundled/openrouter-video-generator/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: openrouter-video-generator
+description: "Generate or declare a configured OpenRouter video asset for AwesomeWebpageMetaSkill. Use only when the meta skill needs a local webpage video and the provider, model, API key, and output directory come from config."
+homepage: ""
+user-invocable: false
+disable-model-invocation: true
+provenance:
+  origin: opensquilla-original
+  license: Apache-2.0
+  maintained_by: OpenSquilla
+metadata:
+  opensquilla:
+    risk: high
+    capabilities: [network-write, filesystem-read, filesystem-write]
+    requires:
+      env: []
+      config:
+        - awesome_webpage.openrouter.api_key
+        - awesome_webpage.openrouter.api_key_env
+        - awesome_webpage.openrouter.base_url
+        - awesome_webpage.openrouter.models.video_generation
+        - awesome_webpage.output_dir
+entrypoint:
+  command: python {baseDir}/scripts/openrouter_video.py
+  args:
+    - --model
+    - "{{ with.model | default('bytedance/seedance-2.0-fast') }}"
+    - --base-url
+    - "{{ with.base_url | default('https://openrouter.ai/api/v1') }}"
+    - --output-dir
+    - "{{ with.output_dir }}"
+    - --filename
+    - "{{ with.filename | default('intro.mp4') }}"
+    - --duration
+    - "{{ with.duration | default(10) }}"
+    - --aspect-ratio
+    - "{{ with.aspect_ratio | default('16:9') }}"
+  stdin: "{{ with.prompt | default(inputs.user_message) }}"
+  parse: text
+  timeout: 420
+---
+
+# OpenRouter Video Generator
+
+Create a short browser-playable video asset for `AwesomeWebpageMetaSkill`.
+This is an adapter around the configured OpenRouter video model, not a place to
+choose providers or invent model ids.
+
+## Meta-Skill Entrypoint
+
+Meta-skills should run this skill as `skill_exec`. The entrypoint is a
+deterministic Python adapter around OpenRouter's async video endpoint; it reads
+`OPENROUTER_API_KEY` inside the child process, writes the MP4 under the supplied
+output directory, and prints either `VIDEO_READY:` or a single failure label.
+Do not spawn an LLM sub-agent just to generate video.
+
+## Contract
+
+- Read provider settings from `config.awesome_webpage.openrouter`.
+- Resolve the API key from `awesome_webpage.openrouter.api_key`; if empty, use
+  the environment variable named by `awesome_webpage.openrouter.api_key_env`.
+- Use only `awesome_webpage.openrouter.models.video_generation` as the model.
+- Use only `awesome_webpage.output_dir` as the output root.
+- Save generated files under `project/assets/video/`.
+- Return a media manifest with local path, MIME type, duration if known,
+  provenance, and replacement notes.
+
+## OpenRouter Video API Contract (hard rule)
+
+OpenRouter video models are exposed through an **async job endpoint**, not
+the chat-completions endpoint. Hitting `/chat/completions` with a video
+model id returns HTTP 500 and burns the full per-attempt budget. Do not
+attempt it.
+
+- **Submit**: `POST {base_url}/videos` with JSON body
+  `{"model": "<video_generation>", "prompt": "<text>", "duration": <int>}`.
+  Optional fields: `resolution`, `aspect_ratio`, `frame_images`,
+  `input_references`, `provider`, `callback_url`. Do NOT send `messages` or
+  `modalities` — those are chat-only and will be rejected.
+- **Response** (immediate): `{"id": "...", "polling_url": "...",
+  "status": "pending"}`.
+- **Poll**: GET the `polling_url` with the same `Authorization: Bearer ...`
+  header every 8-15 seconds until `status` becomes one of
+  `completed | failed | cancelled | expired`. Cap the loop at ~5 minutes per
+  clip; treat anything beyond that as `VIDEO_GENERATION_FAILED`.
+- **Download** (only on `completed`): take the first URL from
+  `unsigned_urls`, GET it with the same bearer token, and save the body to
+  `<output_dir>/project/assets/video/<slug>.mp4`. Set MIME to `video/mp4`.
+- **Terminal-failure statuses** map to `VIDEO_GENERATION_FAILED`; include
+  the job `id` and a replacement-slot path so the page can render a clean
+  placeholder.
+
+Typical successful job completes in 60-120 s for short clips; do not abort
+before that window.
+
+## Failure Labels
+
+Return one of these labels instead of silently skipping video:
+
+- `VIDEO_CONFIG_NEEDED`: model, API key, base URL, or output directory is
+  missing.
+- `VIDEO_MODEL_UNSUPPORTED`: the configured model cannot return a local
+  browser-playable asset in this environment.
+- `VIDEO_GENERATION_FAILED`: the provider call failed after a concrete attempt.
+
+When returning a failure label, also return a replacement slot such as
+`project/assets/video/replace-with-topic-intro.mp4` and enough prompt/context
+for a later repair pass.
+
+## Output Requirements
+
+- Prefer `.mp4` with `video/mp4`; `.webm` is acceptable when browser playable.
+- Keep clips short, usually 8-20 seconds.
+- Do not use remote embeds unless config explicitly allows them.
+- Do not hardcode OpenRouter model names, API keys, or output directories.
+
+### On success: `VIDEO_READY` manifest line (required)
+
+After every successful download, end your reply with one single-line JSON
+record per file so `AwesomeWebpageMetaSkill` can collect and bind the asset:
+
+```
+VIDEO_READY: {"local_path": "project/assets/video/<slug>.mp4", "mime": "video/mp4", "duration_s": <int_or_null>, "resolution": "<WxH_or_null>", "prompt_preview": "<first 80 chars>"}
+```
+
+- One `VIDEO_READY:` line per video file. No trailing prose on that line.
+- `local_path` MUST be the relative path `project/assets/video/...`. Do NOT
+  emit an absolute path here.
+- On failure, emit one of `VIDEO_CONFIG_NEEDED`, `VIDEO_MODEL_UNSUPPORTED`, or
+  `VIDEO_GENERATION_FAILED` as a single-line label with the replacement-slot
+  path so the page can render a placeholder.

--- a/src/opensquilla/skills/bundled/openrouter-video-generator/SKILL.md
+++ b/src/opensquilla/skills/bundled/openrouter-video-generator/SKILL.md
@@ -27,6 +27,8 @@ entrypoint:
     - "{{ with.model | default('bytedance/seedance-2.0-fast') }}"
     - --base-url
     - "{{ with.base_url | default('https://openrouter.ai/api/v1') }}"
+    - --api-key
+    - "{{ with.api_key | default('') }}"
     - --output-dir
     - "{{ with.output_dir }}"
     - --filename
@@ -49,7 +51,8 @@ choose providers or invent model ids.
 ## Meta-Skill Entrypoint
 
 Meta-skills should run this skill as `skill_exec`. The entrypoint is a
-deterministic Python adapter around OpenRouter's async video endpoint; it reads
+deterministic Python adapter around OpenRouter's async video endpoint; it uses
+an explicit `with.api_key`/`--api-key` value when provided, otherwise reads
 `OPENROUTER_API_KEY` inside the child process, writes the MP4 under the supplied
 output directory, and prints either `VIDEO_READY:` or a single failure label.
 Do not spawn an LLM sub-agent just to generate video.

--- a/src/opensquilla/skills/bundled/openrouter-video-generator/scripts/openrouter_video.py
+++ b/src/opensquilla/skills/bundled/openrouter-video-generator/scripts/openrouter_video.py
@@ -96,7 +96,7 @@ def _download(
         headers["Authorization"] = f"Bearer {key}"
     req = Request(resolved_url, headers=headers, method="GET")
     with urlopen(req, timeout=timeout) as resp:
-        return resp.read()
+        return bytes(resp.read())
 
 
 def main() -> int:
@@ -104,6 +104,7 @@ def main() -> int:
     parser.add_argument("--model", required=True)
     parser.add_argument("--base-url", default="https://openrouter.ai/api/v1")
     parser.add_argument("--api-key", default="")
+    parser.add_argument("--api-key-env", default="OPENROUTER_API_KEY")
     parser.add_argument("--output-dir", required=True)
     parser.add_argument("--filename", default="intro.mp4")
     parser.add_argument("--duration", type=int, default=10)
@@ -117,10 +118,11 @@ def main() -> int:
     if not prompt:
         prompt = "Create a short browser-playable video for this webpage."
 
-    key = args.api_key.strip() or os.environ.get("OPENROUTER_API_KEY")
+    api_key_env = args.api_key_env.strip() or "OPENROUTER_API_KEY"
+    key = str(args.api_key.strip() or os.environ.get(api_key_env, ""))
     missing = []
     if not key:
-        missing.append("OPENROUTER_API_KEY")
+        missing.append(api_key_env)
     if not args.model:
         missing.append("awesome_webpage.openrouter.models.video_generation")
     if not args.output_dir:

--- a/src/opensquilla/skills/bundled/openrouter-video-generator/scripts/openrouter_video.py
+++ b/src/opensquilla/skills/bundled/openrouter-video-generator/scripts/openrouter_video.py
@@ -103,6 +103,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", required=True)
     parser.add_argument("--base-url", default="https://openrouter.ai/api/v1")
+    parser.add_argument("--api-key", default="")
     parser.add_argument("--output-dir", required=True)
     parser.add_argument("--filename", default="intro.mp4")
     parser.add_argument("--duration", type=int, default=10)
@@ -116,7 +117,7 @@ def main() -> int:
     if not prompt:
         prompt = "Create a short browser-playable video for this webpage."
 
-    key = os.environ.get("OPENROUTER_API_KEY")
+    key = args.api_key.strip() or os.environ.get("OPENROUTER_API_KEY")
     missing = []
     if not key:
         missing.append("OPENROUTER_API_KEY")

--- a/src/opensquilla/skills/bundled/openrouter-video-generator/scripts/openrouter_video.py
+++ b/src/opensquilla/skills/bundled/openrouter-video-generator/scripts/openrouter_video.py
@@ -43,6 +43,12 @@ def _failure(label: str, filename: str, **extra: object) -> None:
     _print_record(label, payload)
 
 
+def _failure_reason(exc: BaseException) -> str:
+    if isinstance(exc, URLError):
+        return exc.reason.__class__.__name__
+    return exc.__class__.__name__
+
+
 def _request_json(
     url: str,
     *,
@@ -142,12 +148,12 @@ def main() -> int:
     except HTTPError as exc:
         _failure("VIDEO_GENERATION_FAILED", filename, phase="submit", status=exc.code)
         return 0
-    except (URLError, ValueError) as exc:
+    except (URLError, TimeoutError, ValueError) as exc:
         _failure(
             "VIDEO_GENERATION_FAILED",
             filename,
             phase="submit",
-            reason=exc.__class__.__name__,
+            reason=_failure_reason(exc),
         )
         return 0
 
@@ -172,12 +178,12 @@ def main() -> int:
                 job_id=job_id,
             )
             return 0
-        except (URLError, ValueError) as exc:
+        except (URLError, TimeoutError, ValueError) as exc:
             _failure(
                 "VIDEO_GENERATION_FAILED",
                 filename,
                 phase="poll",
-                reason=exc.__class__.__name__,
+                reason=_failure_reason(exc),
                 job_id=job_id,
             )
             return 0
@@ -204,12 +210,12 @@ def main() -> int:
             job_id=job_id,
         )
         return 0
-    except URLError as exc:
+    except (URLError, TimeoutError) as exc:
         _failure(
             "VIDEO_GENERATION_FAILED",
             filename,
             phase="download",
-            reason=exc.reason.__class__.__name__,
+            reason=_failure_reason(exc),
             job_id=job_id,
         )
         return 0

--- a/src/opensquilla/skills/bundled/openrouter-video-generator/scripts/openrouter_video.py
+++ b/src/opensquilla/skills/bundled/openrouter-video-generator/scripts/openrouter_video.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""OpenRouter video entrypoint for meta-skill ``skill_exec`` steps."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+TERMINAL_STATUSES = {"completed", "failed", "cancelled", "expired"}
+
+
+def _safe_filename(value: str, default: str) -> str:
+    name = Path(value or default).name
+    name = re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip(".-")
+    if not name:
+        name = default
+    if not name.lower().endswith(".mp4"):
+        name = re.sub(r"\.[A-Za-z0-9]+$", "", name) + ".mp4"
+    return name
+
+
+def _preview(text: str) -> str:
+    return " ".join(text.split())[:80]
+
+
+def _print_record(label: str, payload: dict[str, object]) -> None:
+    print(f"{label}: {json.dumps(payload, ensure_ascii=False, separators=(',', ':'))}")
+
+
+def _failure(label: str, filename: str, **extra: object) -> None:
+    payload: dict[str, object] = {
+        "replacement_slot": f"project/assets/video/{filename}",
+    }
+    payload.update(extra)
+    _print_record(label, payload)
+
+
+def _request_json(
+    url: str,
+    *,
+    key: str,
+    method: str = "GET",
+    body: dict[str, object] | None = None,
+    timeout: float = 60.0,
+) -> dict[str, object]:
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Accept": "application/json",
+    }
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = Request(url, data=data, headers=headers, method=method)
+    with urlopen(req, timeout=timeout) as resp:
+        parsed = json.loads(resp.read().decode("utf-8", "replace"))
+    if not isinstance(parsed, dict):
+        raise ValueError("response_not_object")
+    return parsed
+
+
+def _download(url: str, *, key: str, timeout: float = 120.0) -> bytes:
+    req = Request(url, headers={"Authorization": f"Bearer {key}"}, method="GET")
+    with urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--base-url", default="https://openrouter.ai/api/v1")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--filename", default="intro.mp4")
+    parser.add_argument("--duration", type=int, default=10)
+    parser.add_argument("--aspect-ratio", default="16:9")
+    parser.add_argument("--poll-interval", type=float, default=10.0)
+    parser.add_argument("--max-wait", type=float, default=300.0)
+    args = parser.parse_args()
+
+    filename = _safe_filename(args.filename, "intro.mp4")
+    prompt = sys.stdin.read().strip()
+    if not prompt:
+        prompt = "Create a short browser-playable video for this webpage."
+
+    key = os.environ.get("OPENROUTER_API_KEY")
+    missing = []
+    if not key:
+        missing.append("OPENROUTER_API_KEY")
+    if not args.model:
+        missing.append("awesome_webpage.openrouter.models.video_generation")
+    if not args.output_dir:
+        missing.append("awesome_webpage.output_dir")
+    if missing:
+        _failure("VIDEO_CONFIG_NEEDED", filename, missing=missing)
+        return 0
+
+    output_dir = Path(args.output_dir).expanduser()
+    output_path = output_dir / filename
+    local_path = f"project/assets/video/{filename}"
+    base_url = args.base_url.rstrip("/")
+
+    try:
+        submit = _request_json(
+            f"{base_url}/videos",
+            key=key,
+            method="POST",
+            body={
+                "model": args.model,
+                "prompt": prompt,
+                "duration": args.duration,
+                "aspect_ratio": args.aspect_ratio,
+            },
+        )
+    except HTTPError as exc:
+        _failure("VIDEO_GENERATION_FAILED", filename, phase="submit", status=exc.code)
+        return 0
+    except (URLError, ValueError) as exc:
+        _failure(
+            "VIDEO_GENERATION_FAILED",
+            filename,
+            phase="submit",
+            reason=exc.__class__.__name__,
+        )
+        return 0
+
+    job_id = str(submit.get("id") or "")
+    poll_url = str(submit.get("polling_url") or f"{base_url}/videos/{job_id}")
+    last = submit
+    status = str(last.get("status") or "pending")
+    deadline = time.time() + max(1.0, args.max_wait)
+    while status not in TERMINAL_STATUSES and time.time() < deadline:
+        time.sleep(max(1.0, args.poll_interval))
+        try:
+            last = _request_json(poll_url, key=key)
+        except HTTPError as exc:
+            _failure(
+                "VIDEO_GENERATION_FAILED",
+                filename,
+                phase="poll",
+                status=exc.code,
+                job_id=job_id,
+            )
+            return 0
+        except (URLError, ValueError) as exc:
+            _failure(
+                "VIDEO_GENERATION_FAILED",
+                filename,
+                phase="poll",
+                reason=exc.__class__.__name__,
+                job_id=job_id,
+            )
+            return 0
+        status = str(last.get("status") or "unknown")
+
+    if status != "completed":
+        _failure("VIDEO_GENERATION_FAILED", filename, status=status, job_id=job_id)
+        return 0
+
+    urls = last.get("unsigned_urls") or last.get("urls") or []
+    if not isinstance(urls, list) or not urls:
+        _failure("VIDEO_MODEL_UNSUPPORTED", filename, reason="no_download_url", job_id=job_id)
+        return 0
+
+    try:
+        body = _download(str(urls[0]), key=key)
+    except HTTPError as exc:
+        _failure(
+            "VIDEO_GENERATION_FAILED",
+            filename,
+            phase="download",
+            status=exc.code,
+            job_id=job_id,
+        )
+        return 0
+    except URLError as exc:
+        _failure(
+            "VIDEO_GENERATION_FAILED",
+            filename,
+            phase="download",
+            reason=exc.reason.__class__.__name__,
+            job_id=job_id,
+        )
+        return 0
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(body)
+    _print_record(
+        "VIDEO_READY",
+        {
+            "local_path": local_path,
+            "mime": "video/mp4",
+            "duration_s": args.duration,
+            "resolution": None,
+            "prompt_preview": _preview(prompt),
+            "job_id": job_id,
+        },
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/opensquilla/skills/bundled/openrouter-video-generator/scripts/openrouter_video.py
+++ b/src/opensquilla/skills/bundled/openrouter-video-generator/scripts/openrouter_video.py
@@ -11,6 +11,7 @@ import sys
 import time
 from pathlib import Path
 from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlparse
 from urllib.request import Request, urlopen
 
 TERMINAL_STATUSES = {"completed", "failed", "cancelled", "expired"}
@@ -66,8 +67,28 @@ def _request_json(
     return parsed
 
 
-def _download(url: str, *, key: str, timeout: float = 120.0) -> bytes:
-    req = Request(url, headers={"Authorization": f"Bearer {key}"}, method="GET")
+def _resolve_url(url: str, *, base_url: str) -> str:
+    return urljoin(f"{base_url.rstrip('/')}/", url)
+
+
+def _same_origin(url: str, *, base_url: str) -> bool:
+    parsed = urlparse(url)
+    base = urlparse(base_url)
+    return parsed.scheme == base.scheme and parsed.netloc == base.netloc
+
+
+def _download(
+    url: str,
+    *,
+    key: str,
+    base_url: str,
+    timeout: float = 120.0,
+) -> bytes:
+    resolved_url = _resolve_url(url, base_url=base_url)
+    headers = {}
+    if _same_origin(resolved_url, base_url=base_url):
+        headers["Authorization"] = f"Bearer {key}"
+    req = Request(resolved_url, headers=headers, method="GET")
     with urlopen(req, timeout=timeout) as resp:
         return resp.read()
 
@@ -131,7 +152,10 @@ def main() -> int:
         return 0
 
     job_id = str(submit.get("id") or "")
-    poll_url = str(submit.get("polling_url") or f"{base_url}/videos/{job_id}")
+    poll_url = _resolve_url(
+        str(submit.get("polling_url") or f"videos/{job_id}"),
+        base_url=base_url,
+    )
     last = submit
     status = str(last.get("status") or "pending")
     deadline = time.time() + max(1.0, args.max_wait)
@@ -169,7 +193,8 @@ def main() -> int:
         return 0
 
     try:
-        body = _download(str(urls[0]), key=key)
+        download_url = _resolve_url(str(urls[0]), base_url=base_url)
+        body = _download(download_url, key=key, base_url=base_url)
     except HTTPError as exc:
         _failure(
             "VIDEO_GENERATION_FAILED",

--- a/src/opensquilla/skills/bundled/web-search/SKILL.md
+++ b/src/opensquilla/skills/bundled/web-search/SKILL.md
@@ -33,13 +33,9 @@ Use this skill when users request:
 
 ## Prerequisites
 
-Install the required dependency:
-
-```bash
-pip install duckduckgo-search
-```
-
-This library provides a simple Python interface to DuckDuckGo's search API without requiring API keys or authentication.
+OpenSquilla declares the required `duckduckgo-search` Python package as a runtime dependency.
+For source checkouts, run the normal project dependency sync before invoking this bundled skill.
+The library provides a simple Python interface to DuckDuckGo's search API without requiring API keys or authentication.
 
 ## Core Capabilities
 
@@ -461,7 +457,7 @@ python scripts/search.py --help
 
 **Common issues:**
 
-- **"Missing required dependency"**: Run `pip install duckduckgo-search`
+- **"Missing required dependency"**: Sync or reinstall the OpenSquilla project dependencies
 - **No results found**: Try broader search terms or remove time filters
 - **Timeout errors**: The search service may be temporarily unavailable; retry after a moment
 - **Rate limiting**: Space out searches if making many requests

--- a/src/opensquilla/skills/bundled/web-search/SKILL.md
+++ b/src/opensquilla/skills/bundled/web-search/SKILL.md
@@ -1,0 +1,529 @@
+---
+name: web-search
+description: This skill should be used when users need to search the web for information, find current content, look up news articles, search for images, or find videos. It uses DuckDuckGo's search API to return results in clean, formatted output (text, markdown, or JSON). Use for research, fact-checking, finding recent information, or gathering web resources.
+homepage: https://clawhub.ai/billyutw/web-search
+provenance:
+  origin: clawhub-mit0
+  license: MIT-0
+  upstream_url: https://clawhub.ai/billyutw/web-search
+  maintained_by: OpenSquilla
+metadata:
+  opensquilla:
+    risk: medium
+    capabilities: [network-read]
+---
+
+# Web Search
+
+## Overview
+
+Search the web using DuckDuckGo's API to find information across web pages, news articles, images, and videos. Returns results in multiple formats (text, markdown, JSON) with filtering options for time range, region, and safe search.
+
+## When to Use This Skill
+
+Use this skill when users request:
+- Web searches for information or resources
+- Finding current or recent information online
+- Looking up news articles about specific topics
+- Searching for images by description or topic
+- Finding videos on specific subjects
+- Research requiring current web data
+- Fact-checking or verification using web sources
+- Gathering URLs and resources on a topic
+
+## Prerequisites
+
+Install the required dependency:
+
+```bash
+pip install duckduckgo-search
+```
+
+This library provides a simple Python interface to DuckDuckGo's search API without requiring API keys or authentication.
+
+## Core Capabilities
+
+### 1. Basic Web Search
+
+Search for web pages and information:
+
+```bash
+python scripts/search.py "<query>"
+```
+
+**Example:**
+```bash
+python scripts/search.py "python asyncio tutorial"
+```
+
+Returns the top 10 web results with titles, URLs, and descriptions in a clean text format.
+
+### 2. Limiting Results
+
+Control the number of results returned:
+
+```bash
+python scripts/search.py "<query>" --max-results <N>
+```
+
+**Example:**
+```bash
+python scripts/search.py "machine learning frameworks" --max-results 20
+```
+
+Useful for:
+- Getting more comprehensive results (increase limit)
+- Quick lookups with fewer results (decrease limit)
+- Balancing detail vs. processing time
+
+### 3. Time Range Filtering
+
+Filter results by recency:
+
+```bash
+python scripts/search.py "<query>" --time-range <d|w|m|y>
+```
+
+**Time range options:**
+- `d` - Past day
+- `w` - Past week
+- `m` - Past month
+- `y` - Past year
+
+**Example:**
+```bash
+python scripts/search.py "artificial intelligence news" --time-range w
+```
+
+Great for:
+- Finding recent news or updates
+- Filtering out outdated content
+- Tracking recent developments
+
+### 4. News Search
+
+Search specifically for news articles:
+
+```bash
+python scripts/search.py "<query>" --type news
+```
+
+**Example:**
+```bash
+python scripts/search.py "climate change" --type news --time-range w --max-results 15
+```
+
+News results include:
+- Article title
+- Source publication
+- Publication date
+- URL
+- Article summary/description
+
+### 5. Image Search
+
+Search for images:
+
+```bash
+python scripts/search.py "<query>" --type images
+```
+
+**Example:**
+```bash
+python scripts/search.py "sunset over mountains" --type images --max-results 20
+```
+
+**Image filtering options:**
+
+Size filters:
+```bash
+python scripts/search.py "landscape photos" --type images --image-size Large
+```
+Options: `Small`, `Medium`, `Large`, `Wallpaper`
+
+Color filters:
+```bash
+python scripts/search.py "abstract art" --type images --image-color Blue
+```
+Options: `color`, `Monochrome`, `Red`, `Orange`, `Yellow`, `Green`, `Blue`, `Purple`, `Pink`, `Brown`, `Black`, `Gray`, `Teal`, `White`
+
+Type filters:
+```bash
+python scripts/search.py "icons" --type images --image-type transparent
+```
+Options: `photo`, `clipart`, `gif`, `transparent`, `line`
+
+Layout filters:
+```bash
+python scripts/search.py "wallpapers" --type images --image-layout Wide
+```
+Options: `Square`, `Tall`, `Wide`
+
+Image results include:
+- Image title
+- Image URL (direct link to image)
+- Thumbnail URL
+- Source website
+- Dimensions (width x height)
+
+### 6. Video Search
+
+Search for videos:
+
+```bash
+python scripts/search.py "<query>" --type videos
+```
+
+**Example:**
+```bash
+python scripts/search.py "python tutorial" --type videos --max-results 15
+```
+
+**Video filtering options:**
+
+Duration filters:
+```bash
+python scripts/search.py "cooking recipes" --type videos --video-duration short
+```
+Options: `short`, `medium`, `long`
+
+Resolution filters:
+```bash
+python scripts/search.py "documentary" --type videos --video-resolution high
+```
+Options: `high`, `standard`
+
+Video results include:
+- Video title
+- Publisher/channel
+- Duration
+- Publication date
+- Video URL
+- Description
+
+### 7. Region-Specific Search
+
+Search with region-specific results:
+
+```bash
+python scripts/search.py "<query>" --region <region-code>
+```
+
+**Common region codes:**
+- `us-en` - United States (English)
+- `uk-en` - United Kingdom (English)
+- `ca-en` - Canada (English)
+- `au-en` - Australia (English)
+- `de-de` - Germany (German)
+- `fr-fr` - France (French)
+- `wt-wt` - Worldwide (default)
+
+**Example:**
+```bash
+python scripts/search.py "local news" --region us-en --type news
+```
+
+### 8. Safe Search Control
+
+Control safe search filtering:
+
+```bash
+python scripts/search.py "<query>" --safe-search <on|moderate|off>
+```
+
+**Options:**
+- `on` - Strict filtering
+- `moderate` - Balanced filtering (default)
+- `off` - No filtering
+
+**Example:**
+```bash
+python scripts/search.py "medical information" --safe-search on
+```
+
+### 9. Output Formats
+
+Choose how results are formatted:
+
+**Text format (default):**
+```bash
+python scripts/search.py "quantum computing"
+```
+
+Clean, readable plain text with numbered results.
+
+**Markdown format:**
+```bash
+python scripts/search.py "quantum computing" --format markdown
+```
+
+Formatted markdown with headers, bold text, and links.
+
+**JSON format:**
+```bash
+python scripts/search.py "quantum computing" --format json
+```
+
+Structured JSON data for programmatic processing.
+
+### 10. Saving Results to File
+
+Save search results to a file:
+
+```bash
+python scripts/search.py "<query>" --output <file-path>
+```
+
+**Example:**
+```bash
+python scripts/search.py "artificial intelligence" --output ai_results.txt
+python scripts/search.py "AI news" --type news --format markdown --output ai_news.md
+python scripts/search.py "AI research" --format json --output ai_data.json
+```
+
+The file format is determined by the `--format` flag, not the file extension.
+
+## Output Format Examples
+
+### Text Format
+```
+1. Page Title Here
+   URL: https://example.com/page
+   Brief description of the page content...
+
+2. Another Result
+   URL: https://example.com/another
+   Another description...
+```
+
+### Markdown Format
+```markdown
+## 1. Page Title Here
+
+**URL:** https://example.com/page
+
+Brief description of the page content...
+
+## 2. Another Result
+
+**URL:** https://example.com/another
+
+Another description...
+```
+
+### JSON Format
+```json
+[
+  {
+    "title": "Page Title Here",
+    "href": "https://example.com/page",
+    "body": "Brief description of the page content..."
+  },
+  {
+    "title": "Another Result",
+    "href": "https://example.com/another",
+    "body": "Another description..."
+  }
+]
+```
+
+## Common Usage Patterns
+
+### Research on a Topic
+
+Gather comprehensive information about a subject:
+
+```bash
+# Get overview from web
+python scripts/search.py "machine learning basics" --max-results 15 --output ml_web.txt
+
+# Get recent news
+python scripts/search.py "machine learning" --type news --time-range m --output ml_news.txt
+
+# Find tutorial videos
+python scripts/search.py "machine learning tutorial" --type videos --max-results 10 --output ml_videos.txt
+```
+
+### Current Events Monitoring
+
+Track news on specific topics:
+
+```bash
+python scripts/search.py "climate summit" --type news --time-range d --format markdown --output daily_climate_news.md
+```
+
+### Finding Visual Resources
+
+Search for images with specific criteria:
+
+```bash
+python scripts/search.py "data visualization examples" --type images --image-type photo --image-size Large --max-results 25 --output viz_images.txt
+```
+
+### Fact-Checking
+
+Verify information with recent sources:
+
+```bash
+python scripts/search.py "specific claim to verify" --time-range w --max-results 20
+```
+
+### Academic Research
+
+Find resources on scholarly topics:
+
+```bash
+python scripts/search.py "quantum entanglement research" --time-range y --max-results 30 --output quantum_research.txt
+```
+
+### Market Research
+
+Gather information about products or companies:
+
+```bash
+python scripts/search.py "electric vehicle market 2025" --max-results 20 --format markdown --output ev_market.md
+python scripts/search.py "EV news" --type news --time-range m --output ev_news.txt
+```
+
+## Implementation Approach
+
+When users request web searches:
+
+1. **Identify search intent**:
+   - What type of content (web, news, images, videos)?
+   - How recent should results be?
+   - How many results are needed?
+   - Any filtering requirements?
+
+2. **Configure search parameters**:
+   - Choose appropriate search type (`--type`)
+   - Set time range if currency matters (`--time-range`)
+   - Adjust result count (`--max-results`)
+   - Apply filters (image size, video duration, etc.)
+
+3. **Select output format**:
+   - Text for quick reading
+   - Markdown for documentation
+   - JSON for further processing
+
+4. **Execute search**:
+   - Run the search command
+   - Save to file if results need to be preserved
+   - Print to stdout for immediate review
+
+5. **Process results**:
+   - Read saved files if needed
+   - Extract URLs or specific information
+   - Combine results from multiple searches
+
+## Quick Reference
+
+**Command structure:**
+```bash
+python scripts/search.py "<query>" [options]
+```
+
+**Essential options:**
+- `-t, --type` - Search type (web, news, images, videos)
+- `-n, --max-results` - Maximum results (default: 10)
+- `--time-range` - Time filter (d, w, m, y)
+- `-r, --region` - Region code (e.g., us-en, uk-en)
+- `--safe-search` - Safe search level (on, moderate, off)
+- `-f, --format` - Output format (text, markdown, json)
+- `-o, --output` - Save to file
+
+**Image-specific options:**
+- `--image-size` - Size filter (Small, Medium, Large, Wallpaper)
+- `--image-color` - Color filter
+- `--image-type` - Type filter (photo, clipart, gif, transparent, line)
+- `--image-layout` - Layout filter (Square, Tall, Wide)
+
+**Video-specific options:**
+- `--video-duration` - Duration filter (short, medium, long)
+- `--video-resolution` - Resolution filter (high, standard)
+
+**Get full help:**
+```bash
+python scripts/search.py --help
+```
+
+## Best Practices
+
+1. **Be specific** - Use clear, specific search queries for better results
+2. **Use time filters** - Apply `--time-range` for current information
+3. **Adjust result count** - Start with 10-20 results, increase if needed
+4. **Save important searches** - Use `--output` to preserve results
+5. **Choose appropriate type** - Use news search for current events, web for general info
+6. **Use JSON for automation** - JSON format is easiest to parse programmatically
+7. **Respect usage** - Don't hammer the API with rapid repeated searches
+
+## Troubleshooting
+
+**Common issues:**
+
+- **"Missing required dependency"**: Run `pip install duckduckgo-search`
+- **No results found**: Try broader search terms or remove time filters
+- **Timeout errors**: The search service may be temporarily unavailable; retry after a moment
+- **Rate limiting**: Space out searches if making many requests
+- **Unexpected results**: DuckDuckGo's results may differ from Google; try refining the query
+
+**Limitations:**
+
+- Results quality depends on DuckDuckGo's index and algorithms
+- No advanced search operators (unlike Google's site:, filetype:, etc.)
+- Image and video searches may have fewer results than web search
+- No control over result ranking or relevance scoring
+- Some specialized searches may work better on dedicated search engines
+
+## Advanced Use Cases
+
+### Combining Multiple Searches
+
+Gather comprehensive information by combining search types:
+
+```bash
+# Web overview
+python scripts/search.py "topic" --max-results 15 --output topic_web.txt
+
+# Recent news
+python scripts/search.py "topic" --type news --time-range w --output topic_news.txt
+
+# Images
+python scripts/search.py "topic" --type images --max-results 20 --output topic_images.txt
+```
+
+### Programmatic Processing
+
+Use JSON output for automated processing:
+
+```bash
+python scripts/search.py "research topic" --format json --output results.json
+# Then process with another script
+python analyze_results.py results.json
+```
+
+### Building a Knowledge Base
+
+Create searchable documentation from web results:
+
+```bash
+# Search multiple related topics
+python scripts/search.py "topic1" --format markdown --output kb/topic1.md
+python scripts/search.py "topic2" --format markdown --output kb/topic2.md
+python scripts/search.py "topic3" --format markdown --output kb/topic3.md
+```
+
+## Resources
+
+### scripts/search.py
+
+The main search tool implementing DuckDuckGo search functionality. Key features:
+
+- **Multiple search types** - Web, news, images, and videos
+- **Flexible filtering** - Time range, region, safe search, and type-specific filters
+- **Multiple output formats** - Text, Markdown, and JSON
+- **File output** - Save results for later processing
+- **Clean formatting** - Human-readable output with all essential information
+- **Error handling** - Graceful handling of network errors and empty results
+
+The script can be executed directly and includes comprehensive command-line help via `--help`.

--- a/src/opensquilla/skills/bundled/web-search/SKILL.md
+++ b/src/opensquilla/skills/bundled/web-search/SKILL.md
@@ -11,6 +11,18 @@ metadata:
   opensquilla:
     risk: medium
     capabilities: [network-read]
+entrypoint:
+  command: python {baseDir}/scripts/search.py
+  args:
+    - "{{ with.query | default(inputs.user_message) }}"
+    - --type
+    - "{{ with.type | default('web') }}"
+    - --max-results
+    - "{{ with.max_results | default('10') }}"
+    - --format
+    - "{{ with.format | default('text') }}"
+  parse: text
+  timeout: 45
 ---
 
 # Web Search
@@ -44,12 +56,12 @@ The library provides a simple Python interface to DuckDuckGo's search API withou
 Search for web pages and information:
 
 ```bash
-python scripts/search.py "<query>"
+python {baseDir}/scripts/search.py "<query>"
 ```
 
 **Example:**
 ```bash
-python scripts/search.py "python asyncio tutorial"
+python {baseDir}/scripts/search.py "python asyncio tutorial"
 ```
 
 Returns the top 10 web results with titles, URLs, and descriptions in a clean text format.
@@ -59,12 +71,12 @@ Returns the top 10 web results with titles, URLs, and descriptions in a clean te
 Control the number of results returned:
 
 ```bash
-python scripts/search.py "<query>" --max-results <N>
+python {baseDir}/scripts/search.py "<query>" --max-results <N>
 ```
 
 **Example:**
 ```bash
-python scripts/search.py "machine learning frameworks" --max-results 20
+python {baseDir}/scripts/search.py "machine learning frameworks" --max-results 20
 ```
 
 Useful for:
@@ -77,7 +89,7 @@ Useful for:
 Filter results by recency:
 
 ```bash
-python scripts/search.py "<query>" --time-range <d|w|m|y>
+python {baseDir}/scripts/search.py "<query>" --time-range <d|w|m|y>
 ```
 
 **Time range options:**
@@ -88,7 +100,7 @@ python scripts/search.py "<query>" --time-range <d|w|m|y>
 
 **Example:**
 ```bash
-python scripts/search.py "artificial intelligence news" --time-range w
+python {baseDir}/scripts/search.py "artificial intelligence news" --time-range w
 ```
 
 Great for:
@@ -101,12 +113,12 @@ Great for:
 Search specifically for news articles:
 
 ```bash
-python scripts/search.py "<query>" --type news
+python {baseDir}/scripts/search.py "<query>" --type news
 ```
 
 **Example:**
 ```bash
-python scripts/search.py "climate change" --type news --time-range w --max-results 15
+python {baseDir}/scripts/search.py "climate change" --type news --time-range w --max-results 15
 ```
 
 News results include:
@@ -121,37 +133,37 @@ News results include:
 Search for images:
 
 ```bash
-python scripts/search.py "<query>" --type images
+python {baseDir}/scripts/search.py "<query>" --type images
 ```
 
 **Example:**
 ```bash
-python scripts/search.py "sunset over mountains" --type images --max-results 20
+python {baseDir}/scripts/search.py "sunset over mountains" --type images --max-results 20
 ```
 
 **Image filtering options:**
 
 Size filters:
 ```bash
-python scripts/search.py "landscape photos" --type images --image-size Large
+python {baseDir}/scripts/search.py "landscape photos" --type images --image-size Large
 ```
 Options: `Small`, `Medium`, `Large`, `Wallpaper`
 
 Color filters:
 ```bash
-python scripts/search.py "abstract art" --type images --image-color Blue
+python {baseDir}/scripts/search.py "abstract art" --type images --image-color Blue
 ```
 Options: `color`, `Monochrome`, `Red`, `Orange`, `Yellow`, `Green`, `Blue`, `Purple`, `Pink`, `Brown`, `Black`, `Gray`, `Teal`, `White`
 
 Type filters:
 ```bash
-python scripts/search.py "icons" --type images --image-type transparent
+python {baseDir}/scripts/search.py "icons" --type images --image-type transparent
 ```
 Options: `photo`, `clipart`, `gif`, `transparent`, `line`
 
 Layout filters:
 ```bash
-python scripts/search.py "wallpapers" --type images --image-layout Wide
+python {baseDir}/scripts/search.py "wallpapers" --type images --image-layout Wide
 ```
 Options: `Square`, `Tall`, `Wide`
 
@@ -167,25 +179,25 @@ Image results include:
 Search for videos:
 
 ```bash
-python scripts/search.py "<query>" --type videos
+python {baseDir}/scripts/search.py "<query>" --type videos
 ```
 
 **Example:**
 ```bash
-python scripts/search.py "python tutorial" --type videos --max-results 15
+python {baseDir}/scripts/search.py "python tutorial" --type videos --max-results 15
 ```
 
 **Video filtering options:**
 
 Duration filters:
 ```bash
-python scripts/search.py "cooking recipes" --type videos --video-duration short
+python {baseDir}/scripts/search.py "cooking recipes" --type videos --video-duration short
 ```
 Options: `short`, `medium`, `long`
 
 Resolution filters:
 ```bash
-python scripts/search.py "documentary" --type videos --video-resolution high
+python {baseDir}/scripts/search.py "documentary" --type videos --video-resolution high
 ```
 Options: `high`, `standard`
 
@@ -202,7 +214,7 @@ Video results include:
 Search with region-specific results:
 
 ```bash
-python scripts/search.py "<query>" --region <region-code>
+python {baseDir}/scripts/search.py "<query>" --region <region-code>
 ```
 
 **Common region codes:**
@@ -216,7 +228,7 @@ python scripts/search.py "<query>" --region <region-code>
 
 **Example:**
 ```bash
-python scripts/search.py "local news" --region us-en --type news
+python {baseDir}/scripts/search.py "local news" --region us-en --type news
 ```
 
 ### 8. Safe Search Control
@@ -224,7 +236,7 @@ python scripts/search.py "local news" --region us-en --type news
 Control safe search filtering:
 
 ```bash
-python scripts/search.py "<query>" --safe-search <on|moderate|off>
+python {baseDir}/scripts/search.py "<query>" --safe-search <on|moderate|off>
 ```
 
 **Options:**
@@ -234,7 +246,7 @@ python scripts/search.py "<query>" --safe-search <on|moderate|off>
 
 **Example:**
 ```bash
-python scripts/search.py "medical information" --safe-search on
+python {baseDir}/scripts/search.py "medical information" --safe-search on
 ```
 
 ### 9. Output Formats
@@ -243,21 +255,21 @@ Choose how results are formatted:
 
 **Text format (default):**
 ```bash
-python scripts/search.py "quantum computing"
+python {baseDir}/scripts/search.py "quantum computing"
 ```
 
 Clean, readable plain text with numbered results.
 
 **Markdown format:**
 ```bash
-python scripts/search.py "quantum computing" --format markdown
+python {baseDir}/scripts/search.py "quantum computing" --format markdown
 ```
 
 Formatted markdown with headers, bold text, and links.
 
 **JSON format:**
 ```bash
-python scripts/search.py "quantum computing" --format json
+python {baseDir}/scripts/search.py "quantum computing" --format json
 ```
 
 Structured JSON data for programmatic processing.
@@ -267,14 +279,14 @@ Structured JSON data for programmatic processing.
 Save search results to a file:
 
 ```bash
-python scripts/search.py "<query>" --output <file-path>
+python {baseDir}/scripts/search.py "<query>" --output <file-path>
 ```
 
 **Example:**
 ```bash
-python scripts/search.py "artificial intelligence" --output ai_results.txt
-python scripts/search.py "AI news" --type news --format markdown --output ai_news.md
-python scripts/search.py "AI research" --format json --output ai_data.json
+python {baseDir}/scripts/search.py "artificial intelligence" --output ai_results.txt
+python {baseDir}/scripts/search.py "AI news" --type news --format markdown --output ai_news.md
+python {baseDir}/scripts/search.py "AI research" --format json --output ai_data.json
 ```
 
 The file format is determined by the `--format` flag, not the file extension.
@@ -331,13 +343,13 @@ Gather comprehensive information about a subject:
 
 ```bash
 # Get overview from web
-python scripts/search.py "machine learning basics" --max-results 15 --output ml_web.txt
+python {baseDir}/scripts/search.py "machine learning basics" --max-results 15 --output ml_web.txt
 
 # Get recent news
-python scripts/search.py "machine learning" --type news --time-range m --output ml_news.txt
+python {baseDir}/scripts/search.py "machine learning" --type news --time-range m --output ml_news.txt
 
 # Find tutorial videos
-python scripts/search.py "machine learning tutorial" --type videos --max-results 10 --output ml_videos.txt
+python {baseDir}/scripts/search.py "machine learning tutorial" --type videos --max-results 10 --output ml_videos.txt
 ```
 
 ### Current Events Monitoring
@@ -345,7 +357,7 @@ python scripts/search.py "machine learning tutorial" --type videos --max-results
 Track news on specific topics:
 
 ```bash
-python scripts/search.py "climate summit" --type news --time-range d --format markdown --output daily_climate_news.md
+python {baseDir}/scripts/search.py "climate summit" --type news --time-range d --format markdown --output daily_climate_news.md
 ```
 
 ### Finding Visual Resources
@@ -353,7 +365,7 @@ python scripts/search.py "climate summit" --type news --time-range d --format ma
 Search for images with specific criteria:
 
 ```bash
-python scripts/search.py "data visualization examples" --type images --image-type photo --image-size Large --max-results 25 --output viz_images.txt
+python {baseDir}/scripts/search.py "data visualization examples" --type images --image-type photo --image-size Large --max-results 25 --output viz_images.txt
 ```
 
 ### Fact-Checking
@@ -361,7 +373,7 @@ python scripts/search.py "data visualization examples" --type images --image-typ
 Verify information with recent sources:
 
 ```bash
-python scripts/search.py "specific claim to verify" --time-range w --max-results 20
+python {baseDir}/scripts/search.py "specific claim to verify" --time-range w --max-results 20
 ```
 
 ### Academic Research
@@ -369,7 +381,7 @@ python scripts/search.py "specific claim to verify" --time-range w --max-results
 Find resources on scholarly topics:
 
 ```bash
-python scripts/search.py "quantum entanglement research" --time-range y --max-results 30 --output quantum_research.txt
+python {baseDir}/scripts/search.py "quantum entanglement research" --time-range y --max-results 30 --output quantum_research.txt
 ```
 
 ### Market Research
@@ -377,8 +389,8 @@ python scripts/search.py "quantum entanglement research" --time-range y --max-re
 Gather information about products or companies:
 
 ```bash
-python scripts/search.py "electric vehicle market 2025" --max-results 20 --format markdown --output ev_market.md
-python scripts/search.py "EV news" --type news --time-range m --output ev_news.txt
+python {baseDir}/scripts/search.py "electric vehicle market 2025" --max-results 20 --format markdown --output ev_market.md
+python {baseDir}/scripts/search.py "EV news" --type news --time-range m --output ev_news.txt
 ```
 
 ## Implementation Approach
@@ -416,7 +428,7 @@ When users request web searches:
 
 **Command structure:**
 ```bash
-python scripts/search.py "<query>" [options]
+python {baseDir}/scripts/search.py "<query>" [options]
 ```
 
 **Essential options:**
@@ -440,7 +452,7 @@ python scripts/search.py "<query>" [options]
 
 **Get full help:**
 ```bash
-python scripts/search.py --help
+python {baseDir}/scripts/search.py --help
 ```
 
 ## Best Practices
@@ -479,13 +491,13 @@ Gather comprehensive information by combining search types:
 
 ```bash
 # Web overview
-python scripts/search.py "topic" --max-results 15 --output topic_web.txt
+python {baseDir}/scripts/search.py "topic" --max-results 15 --output topic_web.txt
 
 # Recent news
-python scripts/search.py "topic" --type news --time-range w --output topic_news.txt
+python {baseDir}/scripts/search.py "topic" --type news --time-range w --output topic_news.txt
 
 # Images
-python scripts/search.py "topic" --type images --max-results 20 --output topic_images.txt
+python {baseDir}/scripts/search.py "topic" --type images --max-results 20 --output topic_images.txt
 ```
 
 ### Programmatic Processing
@@ -493,7 +505,7 @@ python scripts/search.py "topic" --type images --max-results 20 --output topic_i
 Use JSON output for automated processing:
 
 ```bash
-python scripts/search.py "research topic" --format json --output results.json
+python {baseDir}/scripts/search.py "research topic" --format json --output results.json
 # Then process with another script
 python analyze_results.py results.json
 ```
@@ -504,9 +516,9 @@ Create searchable documentation from web results:
 
 ```bash
 # Search multiple related topics
-python scripts/search.py "topic1" --format markdown --output kb/topic1.md
-python scripts/search.py "topic2" --format markdown --output kb/topic2.md
-python scripts/search.py "topic3" --format markdown --output kb/topic3.md
+python {baseDir}/scripts/search.py "topic1" --format markdown --output kb/topic1.md
+python {baseDir}/scripts/search.py "topic2" --format markdown --output kb/topic2.md
+python {baseDir}/scripts/search.py "topic3" --format markdown --output kb/topic3.md
 ```
 
 ## Resources

--- a/src/opensquilla/skills/bundled/web-search/_meta.json
+++ b/src/opensquilla/skills/bundled/web-search/_meta.json
@@ -1,0 +1,6 @@
+{
+  "ownerId": "kn7cz85m29bj398zc6mnggkv19805nzz",
+  "slug": "web-search",
+  "version": "1.0.0",
+  "publishedAt": 1769673454302
+}

--- a/src/opensquilla/skills/bundled/web-search/scripts/search.py
+++ b/src/opensquilla/skills/bundled/web-search/scripts/search.py
@@ -7,7 +7,7 @@ Search the web using DuckDuckGo's search API. Supports web search, news,
 images, and videos with various output formats.
 
 Requirements:
-    pip install duckduckgo-search
+    duckduckgo-search, declared by the OpenSquilla project dependencies
 """
 
 import argparse
@@ -21,7 +21,7 @@ try:
     from duckduckgo_search import DDGS
 except ImportError as e:
     print(f"Error: Missing required dependency: {e}", file=sys.stderr)
-    print("Install with: pip install duckduckgo-search", file=sys.stderr)
+    print("Sync or reinstall the OpenSquilla project dependencies.", file=sys.stderr)
     sys.exit(1)
 
 

--- a/src/opensquilla/skills/bundled/web-search/scripts/search.py
+++ b/src/opensquilla/skills/bundled/web-search/scripts/search.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+# ruff: noqa
+"""
+Web Search Tool
+
+Search the web using DuckDuckGo's search API. Supports web search, news,
+images, and videos with various output formats.
+
+Requirements:
+    pip install duckduckgo-search
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Optional, Any
+
+try:
+    from duckduckgo_search import DDGS
+except ImportError as e:
+    print(f"Error: Missing required dependency: {e}", file=sys.stderr)
+    print("Install with: pip install duckduckgo-search", file=sys.stderr)
+    sys.exit(1)
+
+
+class WebSearch:
+    """Web search using DuckDuckGo."""
+
+    def __init__(
+        self,
+        region: str = "wt-wt",
+        safe_search: str = "moderate",
+        timeout: int = 20,
+    ):
+        """
+        Initialize the search client.
+
+        Args:
+            region: Region code (e.g., "us-en", "uk-en", "wt-wt" for worldwide)
+            safe_search: Safe search setting ("on", "moderate", "off")
+            timeout: Request timeout in seconds
+        """
+        self.region = region
+        self.safe_search = safe_search
+        self.timeout = timeout
+
+    def search_text(
+        self,
+        query: str,
+        max_results: int = 10,
+        time_range: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Perform a text/web search.
+
+        Args:
+            query: Search query
+            max_results: Maximum number of results (default: 10)
+            time_range: Time filter ("d" day, "w" week, "m" month, "y" year)
+
+        Returns:
+            List of search results with title, href, and body
+        """
+        try:
+            with DDGS() as ddgs:
+                results = list(ddgs.text(
+                    keywords=query,
+                    region=self.region,
+                    safesearch=self.safe_search,
+                    timelimit=time_range,
+                    max_results=max_results,
+                ))
+            return results
+        except Exception as e:
+            print(f"Error performing text search: {e}", file=sys.stderr)
+            return []
+
+    def search_news(
+        self,
+        query: str,
+        max_results: int = 10,
+        time_range: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Search for news articles.
+
+        Args:
+            query: Search query
+            max_results: Maximum number of results
+            time_range: Time filter ("d" day, "w" week, "m" month)
+
+        Returns:
+            List of news results with title, url, body, date, source
+        """
+        try:
+            with DDGS() as ddgs:
+                results = list(ddgs.news(
+                    keywords=query,
+                    region=self.region,
+                    safesearch=self.safe_search,
+                    timelimit=time_range,
+                    max_results=max_results,
+                ))
+            return results
+        except Exception as e:
+            print(f"Error performing news search: {e}", file=sys.stderr)
+            return []
+
+    def search_images(
+        self,
+        query: str,
+        max_results: int = 10,
+        size: Optional[str] = None,
+        color: Optional[str] = None,
+        type_image: Optional[str] = None,
+        layout: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Search for images.
+
+        Args:
+            query: Search query
+            max_results: Maximum number of results
+            size: Image size ("Small", "Medium", "Large", "Wallpaper")
+            color: Color filter ("color", "Monochrome", "Red", "Orange", "Yellow",
+                   "Green", "Blue", "Purple", "Pink", "Brown", "Black", "Gray", "Teal", "White")
+            type_image: Image type ("photo", "clipart", "gif", "transparent", "line")
+            layout: Layout ("Square", "Tall", "Wide")
+
+        Returns:
+            List of image results with title, image URL, thumbnail, source, etc.
+        """
+        try:
+            with DDGS() as ddgs:
+                results = list(ddgs.images(
+                    keywords=query,
+                    region=self.region,
+                    safesearch=self.safe_search,
+                    size=size,
+                    color=color,
+                    type_image=type_image,
+                    layout=layout,
+                    max_results=max_results,
+                ))
+            return results
+        except Exception as e:
+            print(f"Error performing image search: {e}", file=sys.stderr)
+            return []
+
+    def search_videos(
+        self,
+        query: str,
+        max_results: int = 10,
+        duration: Optional[str] = None,
+        resolution: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Search for videos.
+
+        Args:
+            query: Search query
+            max_results: Maximum number of results
+            duration: Video duration ("short", "medium", "long")
+            resolution: Video resolution ("high", "standard")
+
+        Returns:
+            List of video results with title, content, description, publisher, etc.
+        """
+        try:
+            with DDGS() as ddgs:
+                results = list(ddgs.videos(
+                    keywords=query,
+                    region=self.region,
+                    safesearch=self.safe_search,
+                    duration=duration,
+                    resolution=resolution,
+                    max_results=max_results,
+                ))
+            return results
+        except Exception as e:
+            print(f"Error performing video search: {e}", file=sys.stderr)
+            return []
+
+
+def format_text_results(results: List[Dict[str, Any]], format_type: str = "text") -> str:
+    """
+    Format search results for display.
+
+    Args:
+        results: List of search results
+        format_type: Output format ("text", "markdown", "json")
+
+    Returns:
+        Formatted string
+    """
+    if not results:
+        return "No results found."
+
+    if format_type == "json":
+        return json.dumps(results, indent=2, ensure_ascii=False)
+
+    elif format_type == "markdown":
+        output = []
+        for i, result in enumerate(results, 1):
+            title = result.get('title', 'No title')
+            url = result.get('href') or result.get('url', '')
+            body = result.get('body') or result.get('description', '')
+
+            output.append(f"## {i}. {title}\n")
+            output.append(f"**URL:** {url}\n")
+            if body:
+                output.append(f"{body}\n")
+            output.append("")
+        return "\n".join(output)
+
+    else:  # text format
+        output = []
+        for i, result in enumerate(results, 1):
+            title = result.get('title', 'No title')
+            url = result.get('href') or result.get('url', '')
+            body = result.get('body') or result.get('description', '')
+
+            output.append(f"{i}. {title}")
+            output.append(f"   URL: {url}")
+            if body:
+                # Wrap body text
+                output.append(f"   {body}")
+            output.append("")
+        return "\n".join(output)
+
+
+def format_news_results(results: List[Dict[str, Any]], format_type: str = "text") -> str:
+    """Format news search results."""
+    if not results:
+        return "No news results found."
+
+    if format_type == "json":
+        return json.dumps(results, indent=2, ensure_ascii=False)
+
+    elif format_type == "markdown":
+        output = []
+        for i, result in enumerate(results, 1):
+            title = result.get('title', 'No title')
+            url = result.get('url', '')
+            body = result.get('body', '')
+            date = result.get('date', '')
+            source = result.get('source', '')
+
+            output.append(f"## {i}. {title}\n")
+            if source:
+                output.append(f"**Source:** {source}")
+            if date:
+                output.append(f"**Date:** {date}")
+            output.append(f"**URL:** {url}\n")
+            if body:
+                output.append(f"{body}\n")
+            output.append("")
+        return "\n".join(output)
+
+    else:  # text format
+        output = []
+        for i, result in enumerate(results, 1):
+            title = result.get('title', 'No title')
+            url = result.get('url', '')
+            body = result.get('body', '')
+            date = result.get('date', '')
+            source = result.get('source', '')
+
+            output.append(f"{i}. {title}")
+            if source and date:
+                output.append(f"   {source} - {date}")
+            elif source:
+                output.append(f"   {source}")
+            elif date:
+                output.append(f"   {date}")
+            output.append(f"   URL: {url}")
+            if body:
+                output.append(f"   {body}")
+            output.append("")
+        return "\n".join(output)
+
+
+def format_image_results(results: List[Dict[str, Any]], format_type: str = "text") -> str:
+    """Format image search results."""
+    if not results:
+        return "No image results found."
+
+    if format_type == "json":
+        return json.dumps(results, indent=2, ensure_ascii=False)
+
+    elif format_type == "markdown":
+        output = []
+        for i, result in enumerate(results, 1):
+            title = result.get('title', 'No title')
+            image_url = result.get('image', '')
+            thumbnail = result.get('thumbnail', '')
+            source = result.get('source', '')
+            width = result.get('width', '')
+            height = result.get('height', '')
+
+            output.append(f"## {i}. {title}\n")
+            if width and height:
+                output.append(f"**Dimensions:** {width}x{height}")
+            if source:
+                output.append(f"**Source:** {source}")
+            output.append(f"**Image URL:** {image_url}")
+            if thumbnail:
+                output.append(f"**Thumbnail:** {thumbnail}")
+            output.append("")
+        return "\n".join(output)
+
+    else:  # text format
+        output = []
+        for i, result in enumerate(results, 1):
+            title = result.get('title', 'No title')
+            image_url = result.get('image', '')
+            source = result.get('source', '')
+            width = result.get('width', '')
+            height = result.get('height', '')
+
+            output.append(f"{i}. {title}")
+            if width and height:
+                output.append(f"   Dimensions: {width}x{height}")
+            if source:
+                output.append(f"   Source: {source}")
+            output.append(f"   Image URL: {image_url}")
+            output.append("")
+        return "\n".join(output)
+
+
+def format_video_results(results: List[Dict[str, Any]], format_type: str = "text") -> str:
+    """Format video search results."""
+    if not results:
+        return "No video results found."
+
+    if format_type == "json":
+        return json.dumps(results, indent=2, ensure_ascii=False)
+
+    elif format_type == "markdown":
+        output = []
+        for i, result in enumerate(results, 1):
+            title = result.get('title', 'No title')
+            url = result.get('content', '')
+            description = result.get('description', '')
+            publisher = result.get('publisher', '')
+            duration = result.get('duration', '')
+            published = result.get('published', '')
+
+            output.append(f"## {i}. {title}\n")
+            if publisher:
+                output.append(f"**Publisher:** {publisher}")
+            if duration:
+                output.append(f"**Duration:** {duration}")
+            if published:
+                output.append(f"**Published:** {published}")
+            output.append(f"**URL:** {url}\n")
+            if description:
+                output.append(f"{description}\n")
+            output.append("")
+        return "\n".join(output)
+
+    else:  # text format
+        output = []
+        for i, result in enumerate(results, 1):
+            title = result.get('title', 'No title')
+            url = result.get('content', '')
+            description = result.get('description', '')
+            publisher = result.get('publisher', '')
+            duration = result.get('duration', '')
+
+            output.append(f"{i}. {title}")
+            if publisher and duration:
+                output.append(f"   {publisher} - {duration}")
+            elif publisher:
+                output.append(f"   {publisher}")
+            output.append(f"   URL: {url}")
+            if description:
+                output.append(f"   {description}")
+            output.append("")
+        return "\n".join(output)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Search the web using DuckDuckGo",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Basic web search
+  %(prog)s "python tutorials"
+
+  # Search with more results
+  %(prog)s "machine learning" --max-results 20
+
+  # News search
+  %(prog)s "climate change" --type news --time-range w
+
+  # Image search
+  %(prog)s "sunset photos" --type images --max-results 15
+
+  # Save results to file
+  %(prog)s "artificial intelligence" --output results.txt
+
+  # JSON output format
+  %(prog)s "quantum computing" --format json --output results.json
+
+  # Region-specific search
+  %(prog)s "local news" --region us-en --type news
+
+Time range filters (--time-range):
+  d = past day
+  w = past week
+  m = past month
+  y = past year
+        """
+    )
+
+    parser.add_argument(
+        'query',
+        help='Search query'
+    )
+
+    # Search options
+    search_group = parser.add_argument_group('search options')
+    search_group.add_argument(
+        '-t', '--type',
+        choices=['web', 'news', 'images', 'videos'],
+        default='web',
+        help='Search type (default: web)'
+    )
+    search_group.add_argument(
+        '-n', '--max-results',
+        type=int,
+        default=10,
+        help='Maximum number of results (default: 10)'
+    )
+    search_group.add_argument(
+        '--time-range',
+        choices=['d', 'w', 'm', 'y'],
+        help='Time range filter (d=day, w=week, m=month, y=year)'
+    )
+    search_group.add_argument(
+        '-r', '--region',
+        default='wt-wt',
+        help='Region code (e.g., us-en, uk-en, wt-wt for worldwide, default: wt-wt)'
+    )
+    search_group.add_argument(
+        '--safe-search',
+        choices=['on', 'moderate', 'off'],
+        default='moderate',
+        help='Safe search setting (default: moderate)'
+    )
+
+    # Image-specific options
+    image_group = parser.add_argument_group('image search options')
+    image_group.add_argument(
+        '--image-size',
+        choices=['Small', 'Medium', 'Large', 'Wallpaper'],
+        help='Image size filter'
+    )
+    image_group.add_argument(
+        '--image-color',
+        choices=['color', 'Monochrome', 'Red', 'Orange', 'Yellow', 'Green',
+                 'Blue', 'Purple', 'Pink', 'Brown', 'Black', 'Gray', 'Teal', 'White'],
+        help='Image color filter'
+    )
+    image_group.add_argument(
+        '--image-type',
+        choices=['photo', 'clipart', 'gif', 'transparent', 'line'],
+        help='Image type filter'
+    )
+    image_group.add_argument(
+        '--image-layout',
+        choices=['Square', 'Tall', 'Wide'],
+        help='Image layout filter'
+    )
+
+    # Video-specific options
+    video_group = parser.add_argument_group('video search options')
+    video_group.add_argument(
+        '--video-duration',
+        choices=['short', 'medium', 'long'],
+        help='Video duration filter'
+    )
+    video_group.add_argument(
+        '--video-resolution',
+        choices=['high', 'standard'],
+        help='Video resolution filter'
+    )
+
+    # Output options
+    output_group = parser.add_argument_group('output options')
+    output_group.add_argument(
+        '-f', '--format',
+        choices=['text', 'markdown', 'json'],
+        default='text',
+        help='Output format (default: text)'
+    )
+    output_group.add_argument(
+        '-o', '--output',
+        help='Output file path (prints to stdout if not specified)'
+    )
+
+    args = parser.parse_args()
+
+    # Initialize search client
+    searcher = WebSearch(
+        region=args.region,
+        safe_search=args.safe_search,
+    )
+
+    # Perform search based on type
+    print(f"Searching for: {args.query}", file=sys.stderr)
+    print(f"Type: {args.type}, Max results: {args.max_results}", file=sys.stderr)
+    if args.time_range:
+        time_labels = {'d': 'past day', 'w': 'past week', 'm': 'past month', 'y': 'past year'}
+        print(f"Time range: {time_labels[args.time_range]}", file=sys.stderr)
+    print("", file=sys.stderr)
+
+    results = []
+    formatter = format_text_results
+
+    if args.type == 'web':
+        results = searcher.search_text(
+            query=args.query,
+            max_results=args.max_results,
+            time_range=args.time_range,
+        )
+        formatter = format_text_results
+
+    elif args.type == 'news':
+        results = searcher.search_news(
+            query=args.query,
+            max_results=args.max_results,
+            time_range=args.time_range,
+        )
+        formatter = format_news_results
+
+    elif args.type == 'images':
+        results = searcher.search_images(
+            query=args.query,
+            max_results=args.max_results,
+            size=args.image_size,
+            color=args.image_color,
+            type_image=args.image_type,
+            layout=args.image_layout,
+        )
+        formatter = format_image_results
+
+    elif args.type == 'videos':
+        results = searcher.search_videos(
+            query=args.query,
+            max_results=args.max_results,
+            duration=args.video_duration,
+            resolution=args.video_resolution,
+        )
+        formatter = format_video_results
+
+    # Format results
+    output = formatter(results, args.format)
+
+    # Output results
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(output, encoding='utf-8')
+        print(f"✓ Results saved to {args.output}", file=sys.stderr)
+        print(f"  Found {len(results)} result(s)", file=sys.stderr)
+    else:
+        print(output)
+        print(f"\nFound {len(results)} result(s)", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/opensquilla/skills/bundled/web-search/skill-card.md
+++ b/src/opensquilla/skills/bundled/web-search/skill-card.md
@@ -1,0 +1,42 @@
+## Description: <br>
+This skill should be used when users need to search the web for information, find current content, look up news articles, search for images, or find videos. It uses DuckDuckGo's search API to return results in clean, formatted output (text, markdown, or JSON). Use for research, fact-checking, finding recent information, or gathering web resources. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Publisher: <br>
+[billyutw](https://clawhub.ai/user/billyutw) <br>
+
+### License/Terms of Use: <br>
+
+
+## Use Case: <br>
+Developers, researchers, and agents use this skill to search current web, news, image, and video results with optional filters for recency, region, safe search, and result type. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Search terms are sent to DuckDuckGo through the installed dependency. <br>
+Mitigation: Avoid searching for secrets, credentials, confidential business data, or highly sensitive personal information. <br>
+Risk: Using --output can overwrite files at the selected output path. <br>
+Mitigation: Choose intentional, non-sensitive output paths and review paths before running file-saving searches. <br>
+Risk: Web, news, image, and video result quality depends on DuckDuckGo availability, ranking, and index coverage. <br>
+Mitigation: Review returned sources before relying on results, especially for time-sensitive or high-impact decisions. <br>
+
+
+## Reference(s): <br>
+- [ClawHub skill page](https://clawhub.ai/billyutw/web-search) <br>
+- [Publisher profile](https://clawhub.ai/user/billyutw) <br>
+
+
+## Skill Output: <br>
+**Output Type(s):** [text, markdown, JSON, files] <br>
+**Output Format:** [Plain text, Markdown, or JSON search results; optional saved output files.] <br>
+**Output Parameters:** [1D] <br>
+**Other Properties Related to Output:** [Results include titles, URLs, summaries, and type-specific fields such as sources, dates, thumbnails, dimensions, publishers, or durations when available.] <br>
+
+## Skill Version(s): <br>
+1.0.0 (source: server release metadata) <br>
+
+## Ethical Considerations: <br>
+Users should evaluate whether this skill is appropriate for their environment, review any generated or modified files before relying on them, and apply their organization's safety, security, and compliance requirements before deployment. <br>

--- a/src/opensquilla/skills/meta/executors/skill_exec.py
+++ b/src/opensquilla/skills/meta/executors/skill_exec.py
@@ -149,6 +149,7 @@ async def run_skill_exec_step(
                 f"{resolved_workdir!s} escapes allowed root "
                 f"{allowed_root!s}",
             )
+        resolved_workdir.mkdir(parents=True, exist_ok=True)
         workdir = str(resolved_workdir)
 
     # Optional assemble: render templated files to disk before exec.

--- a/src/opensquilla/skills/meta/executors/skill_exec.py
+++ b/src/opensquilla/skills/meta/executors/skill_exec.py
@@ -2,7 +2,7 @@
 
 Runs a wrapped-CLI skill via its ``entrypoint`` manifest — no LLM, no
 sub-Agent. Resolves ``skill.entrypoint`` from the injected ``skill_loader``,
-renders ``command`` / ``args`` (and optional ``stdin`` / ``assemble``
+renders ``command`` / ``args`` (and optional ``env`` / ``stdin`` / ``assemble``
 templates) against ``inputs`` + ``outputs`` + ``with`` (the step's
 rendered ``with_args``), then ``asyncio.create_subprocess_exec``\\s the
 process. Stdout is interpreted per ``parse`` (``text`` | ``json`` |
@@ -48,6 +48,9 @@ async def run_skill_exec_step(
 
     Optional features:
 
+    * ``entrypoint.env`` — Jinja-rendered environment override keys and
+      values. Empty rendered values are ignored so parent environment
+      fallbacks survive.
     * ``entrypoint.stdin`` — Jinja-rendered template (with ``{baseDir}``
       substitution) piped to the subprocess's stdin.
     * ``entrypoint.assemble`` — a list of ``{into, from_template}``
@@ -232,6 +235,31 @@ async def run_skill_exec_step(
         timeout = 60.0
     parse_mode = str(entrypoint.get("parse", "text"))
 
+    raw_env = entrypoint.get("env") or {}
+    if raw_env and not isinstance(raw_env, dict):
+        raise RuntimeError(
+            f"step {step.id!r}: entrypoint.env must be a mapping",
+        )
+    child_env = os.environ.copy()
+    if isinstance(raw_env, dict):
+        for key, value in raw_env.items():
+            if not isinstance(key, str) or not key:
+                raise RuntimeError(
+                    f"step {step.id!r}: entrypoint.env keys must be non-empty strings",
+                )
+            if not isinstance(value, str):
+                raise RuntimeError(
+                    f"step {step.id!r}: entrypoint.env[{key!r}] must be a string template",
+                )
+            rendered_key = _render(key.replace("{baseDir}", base_dir))
+            if not rendered_key:
+                raise RuntimeError(
+                    f"step {step.id!r}: entrypoint.env key rendered empty",
+                )
+            rendered_value = _render(value.replace("{baseDir}", base_dir))
+            if rendered_value:
+                child_env[rendered_key] = rendered_value
+
     # Optional stdin: render Jinja template and pipe to the subprocess.
     stdin_raw = entrypoint.get("stdin")
     stdin_bytes: bytes | None = None
@@ -271,6 +299,7 @@ async def run_skill_exec_step(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=workdir,
+            env=child_env,
         )
     except FileNotFoundError as exc:
         raise RuntimeError(

--- a/src/opensquilla/tools/builtin/shell.py
+++ b/src/opensquilla/tools/builtin/shell.py
@@ -580,6 +580,61 @@ async def _terminate_exec_process_tree(proc: Any) -> None:
         log.warning("exec_command_termination_timeout", pid=proc.pid)
 
 
+async def _write_exec_stdin(proc: Any, stdin_bytes: bytes | None) -> None:
+    if stdin_bytes is None or proc.stdin is None:
+        return
+    try:
+        proc.stdin.write(stdin_bytes)
+        await proc.stdin.drain()
+    except (BrokenPipeError, ConnectionResetError):
+        pass
+    finally:
+        if proc.stdin is not None and not proc.stdin.is_closing():
+            proc.stdin.close()
+            with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                await proc.stdin.wait_closed()
+
+
+async def _run_host_shell_command(
+    command: str,
+    *,
+    cwd: str | None,
+    env: dict[str, str],
+    stdin_bytes: bytes | None,
+    effective_timeout: float,
+) -> str:
+    try:
+        with tempfile.TemporaryFile() as output_file:
+            subprocess_kwargs: dict[str, Any] = {
+                "stdin": asyncio.subprocess.PIPE if stdin_bytes is not None else None,
+                "stdout": output_file,
+                "stderr": asyncio.subprocess.STDOUT,
+                "cwd": cwd,
+                "env": env,
+            }
+            if os.name == "posix":
+                subprocess_kwargs["start_new_session"] = True
+            else:
+                creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                if creationflags:
+                    subprocess_kwargs["creationflags"] = creationflags
+
+            proc = await asyncio.create_subprocess_shell(command, **subprocess_kwargs)
+            await _write_exec_stdin(proc, stdin_bytes)
+            if not await _wait_exec_process(proc, effective_timeout):
+                await _terminate_exec_process_tree(proc)
+                return f"[timeout after {effective_timeout}s]\ncommand: {command}"
+            if os.name == "posix":
+                _signal_exec_process_tree(proc, signal.SIGTERM)
+
+            output_file.flush()
+            output_file.seek(0)
+            output = output_file.read().decode("utf-8", errors="replace")
+            return f"exit_code={proc.returncode}\n{output}"
+    except Exception as e:
+        return f"[error] {e}"
+
+
 async def _await_bg_output_task(output_task: asyncio.Task[None]) -> None:
     try:
         await asyncio.wait_for(output_task, timeout=_BACKGROUND_KILL_TIMEOUT)
@@ -701,27 +756,13 @@ async def exec_command(
             )
             if isinstance(escalation, DenialResult):
                 return json.dumps(escalation.to_dict())
-            try:
-                proc = await asyncio.create_subprocess_shell(
-                    command,
-                    stdin=asyncio.subprocess.PIPE if stdin_bytes is not None else None,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.STDOUT,
-                    cwd=cwd,
-                    env=merged_env,
-                )
-                try:
-                    stdout_bytes, _ = await asyncio.wait_for(
-                        proc.communicate(input=stdin_bytes), timeout=effective_timeout
-                    )
-                except TimeoutError:
-                    proc.kill()
-                    await proc.communicate()
-                    return f"[timeout after {effective_timeout}s]\ncommand: {command}"
-                output = stdout_bytes.decode("utf-8", errors="replace")
-                return f"exit_code={proc.returncode}\n{output}"
-            except Exception as e:
-                return f"[error] {e}"
+            return await _run_host_shell_command(
+                command,
+                cwd=cwd,
+                env=merged_env,
+                stdin_bytes=stdin_bytes,
+                effective_timeout=effective_timeout,
+            )
         output = sandbox_result.stdout
         if sandbox_result.stderr:
             output += sandbox_result.stderr
@@ -731,45 +772,13 @@ async def exec_command(
     if elevated_bypass:
         log.info("shell_exec_elevated_host", command=_audit_command(command))
 
-    try:
-        with tempfile.TemporaryFile() as output_file:
-            subprocess_kwargs: dict[str, Any] = {
-                "stdin": asyncio.subprocess.PIPE if stdin_bytes is not None else None,
-                "stdout": output_file,
-                "stderr": asyncio.subprocess.STDOUT,
-                "cwd": cwd,
-                "env": merged_env,
-            }
-            if os.name == "posix":
-                subprocess_kwargs["start_new_session"] = True
-            else:
-                creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-                if creationflags:
-                    subprocess_kwargs["creationflags"] = creationflags
-
-            proc = await asyncio.create_subprocess_shell(command, **subprocess_kwargs)
-            if stdin_bytes is None:
-                if not await _wait_exec_process(proc, effective_timeout):
-                    await _terminate_exec_process_tree(proc)
-                    return f"[timeout after {effective_timeout}s]\ncommand: {command}"
-            else:
-                try:
-                    await asyncio.wait_for(
-                        proc.communicate(input=stdin_bytes),
-                        timeout=effective_timeout,
-                    )
-                except TimeoutError:
-                    await _terminate_exec_process_tree(proc)
-                    return f"[timeout after {effective_timeout}s]\ncommand: {command}"
-            if os.name == "posix":
-                _signal_exec_process_tree(proc, signal.SIGTERM)
-
-            output_file.flush()
-            output_file.seek(0)
-            output = output_file.read().decode("utf-8", errors="replace")
-            return f"exit_code={proc.returncode}\n{output}"
-    except Exception as e:
-        return f"[error] {e}"
+    return await _run_host_shell_command(
+        command,
+        cwd=cwd,
+        env=merged_env,
+        stdin_bytes=stdin_bytes,
+        effective_timeout=effective_timeout,
+    )
 
 
 @tool(

--- a/src/opensquilla/tools/builtin/shell.py
+++ b/src/opensquilla/tools/builtin/shell.py
@@ -13,7 +13,7 @@ import subprocess
 import tempfile
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
@@ -61,6 +61,9 @@ _BACKGROUND_TERMINATE_TIMEOUT = 1.0
 _BACKGROUND_KILL_TIMEOUT = 1.0
 _EXEC_TERMINATE_TIMEOUT = 0.25
 _EXEC_KILL_TIMEOUT = 0.25
+_EXEC_STDIN_WRITE_CHUNK_BYTES = 64 * 1024
+_EXEC_STDIN_GUARD_CHUNK_CHARS = 64 * 1024
+_EXEC_STDIN_GUARD_OVERLAP_CHARS = 1024
 _COMMAND_AUDIT_MAX_CHARS = 4096
 _SANDBOX_NETWORK_HINT = (
     "Hint: sandboxed shell/code has no network. Use http_request or web_fetch, "
@@ -197,11 +200,45 @@ def _workdir_is_configured_workspace(workdir: str | None) -> bool:
         return False
 
 
+def _sensitive_payload_block(tool_name: str, text: str) -> str | None:
+    from opensquilla.tools.builtin.web import (
+        _sensitive_body_block,
+        _sensitive_body_marker,
+        _sensitive_url_marker,
+    )
+
+    for token in text.split():
+        stripped = token.strip("'\"")
+        if stripped.startswith(("http://", "https://")):
+            marker = _sensitive_url_marker(stripped)
+            if marker is not None:
+                return _sensitive_body_block(tool_name, marker)
+    marker = _sensitive_body_marker(text)
+    if marker is not None:
+        return _sensitive_body_block(tool_name, marker)
+    return None
+
+
+def _iter_stdin_guard_chunks(text: str) -> Iterator[str]:
+    if len(text) <= _EXEC_STDIN_GUARD_CHUNK_CHARS:
+        yield text
+        return
+    step = _EXEC_STDIN_GUARD_CHUNK_CHARS - _EXEC_STDIN_GUARD_OVERLAP_CHARS
+    start = 0
+    while start < len(text):
+        end = min(len(text), start + _EXEC_STDIN_GUARD_CHUNK_CHARS)
+        yield text[start:end]
+        if end >= len(text):
+            break
+        start += step
+
+
 def _sensitive_shell_block(
     tool_name: str,
     command: str,
     *,
     workdir: str | None = None,
+    stdin: str | None = None,
 ) -> str | None:
     if _context_elevated_mode() == "full":
         return None
@@ -220,21 +257,27 @@ def _sensitive_shell_block(
             ensure_ascii=False,
         )
 
-    from opensquilla.tools.builtin.web import (
-        _sensitive_body_block,
-        _sensitive_body_marker,
-        _sensitive_url_marker,
-    )
+    payload_block = _sensitive_payload_block(tool_name, checked_text)
+    if payload_block is not None:
+        return payload_block
+    if stdin is None:
+        return None
 
-    for token in checked_text.split():
-        stripped = token.strip("'\"")
-        if stripped.startswith(("http://", "https://")):
-            marker = _sensitive_url_marker(stripped)
-            if marker is not None:
-                return _sensitive_body_block(tool_name, marker)
-    marker = _sensitive_body_marker(checked_text)
-    if marker is not None:
-        return _sensitive_body_block(tool_name, marker)
+    for stdin_chunk in _iter_stdin_guard_chunks(stdin):
+        marker = sensitive_path_in_text(stdin_chunk, workspace=workspace)
+        if marker is not None:
+            return json.dumps(
+                build_block_envelope(
+                    f"{checked_command}\n[stdin omitted]",
+                    marker,
+                    tool_name=tool_name,
+                ),
+                ensure_ascii=False,
+            )
+    for stdin_chunk in _iter_stdin_guard_chunks(stdin):
+        payload_block = _sensitive_payload_block(tool_name, stdin_chunk)
+        if payload_block is not None:
+            return payload_block
     return None
 
 
@@ -279,15 +322,25 @@ def _shell_write_targets(command: str) -> list[str]:
     return targets
 
 
+def _shell_write_targets_from_inputs(command: str, stdin: str | None) -> list[str]:
+    targets = _shell_write_targets(command)
+    if stdin is not None:
+        for stdin_chunk in _iter_stdin_guard_chunks(stdin):
+            targets.extend(_shell_write_targets(stdin_chunk))
+    return targets
+
+
 def _workspace_lockdown_shell_block(
     tool_name: str,
     command: str,
     workdir: str | None,
+    *,
+    stdin: str | None = None,
 ) -> dict[str, object] | None:
     roots = _workspace_lockdown_roots()
     if not roots:
         return None
-    for target in _shell_write_targets(command):
+    for target in _shell_write_targets_from_inputs(command, stdin):
         resolved = _resolve_shell_write_target(target, workdir)
         if _path_inside_any_root(resolved, roots):
             continue
@@ -312,6 +365,8 @@ def _workspace_write_deny_shell_block(
     tool_name: str,
     command: str,
     workdir: str | None,
+    *,
+    stdin: str | None = None,
 ) -> dict[str, object] | None:
     from opensquilla.tools.write_policy import (
         match_workspace_write_deny,
@@ -324,7 +379,7 @@ def _workspace_write_deny_shell_block(
         if ctx is not None and ctx.workspace_dir
         else None
     )
-    for target in _shell_write_targets(command):
+    for target in _shell_write_targets_from_inputs(command, stdin):
         resolved = _resolve_shell_write_target(target, workdir)
         deny_match = match_workspace_write_deny(
             resolved,
@@ -584,15 +639,14 @@ async def _write_exec_stdin(proc: Any, stdin_bytes: bytes | None) -> None:
     if stdin_bytes is None or proc.stdin is None:
         return
     try:
-        proc.stdin.write(stdin_bytes)
-        await proc.stdin.drain()
+        for offset in range(0, len(stdin_bytes), _EXEC_STDIN_WRITE_CHUNK_BYTES):
+            proc.stdin.write(stdin_bytes[offset : offset + _EXEC_STDIN_WRITE_CHUNK_BYTES])
+            await proc.stdin.drain()
     except (BrokenPipeError, ConnectionResetError):
         pass
     finally:
         if proc.stdin is not None and not proc.stdin.is_closing():
             proc.stdin.close()
-            with contextlib.suppress(BrokenPipeError, ConnectionResetError):
-                await proc.stdin.wait_closed()
 
 
 async def _run_host_shell_command(
@@ -619,11 +673,25 @@ async def _run_host_shell_command(
                 if creationflags:
                     subprocess_kwargs["creationflags"] = creationflags
 
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + effective_timeout
+            timeout_result = f"[timeout after {effective_timeout}s]\ncommand: {command}"
+
             proc = await asyncio.create_subprocess_shell(command, **subprocess_kwargs)
-            await _write_exec_stdin(proc, stdin_bytes)
-            if not await _wait_exec_process(proc, effective_timeout):
+            remaining = deadline - loop.time()
+            if remaining <= 0:
                 await _terminate_exec_process_tree(proc)
-                return f"[timeout after {effective_timeout}s]\ncommand: {command}"
+                return timeout_result
+            try:
+                await asyncio.wait_for(_write_exec_stdin(proc, stdin_bytes), timeout=remaining)
+            except TimeoutError:
+                await _terminate_exec_process_tree(proc)
+                return timeout_result
+
+            remaining = deadline - loop.time()
+            if remaining <= 0 or not await _wait_exec_process(proc, remaining):
+                await _terminate_exec_process_tree(proc)
+                return timeout_result
             if os.name == "posix":
                 _signal_exec_process_tree(proc, signal.SIGTERM)
 
@@ -687,13 +755,19 @@ async def exec_command(
     if not result.allowed:
         raise ToolError(result.reason)
 
-    sensitive_block = _sensitive_shell_block("exec_command", command, workdir=cwd)
+    sensitive_block = _sensitive_shell_block(
+        "exec_command", command, workdir=cwd, stdin=stdin
+    )
     if sensitive_block is not None:
         return sensitive_block
-    lockdown_block = _workspace_lockdown_shell_block("exec_command", command, cwd)
+    lockdown_block = _workspace_lockdown_shell_block(
+        "exec_command", command, cwd, stdin=stdin
+    )
     if lockdown_block is not None:
         return json.dumps(lockdown_block, ensure_ascii=False)
-    deny_block = _workspace_write_deny_shell_block("exec_command", command, cwd)
+    deny_block = _workspace_write_deny_shell_block(
+        "exec_command", command, cwd, stdin=stdin
+    )
     if deny_block is not None:
         return json.dumps(deny_block, ensure_ascii=False)
 

--- a/src/opensquilla/tools/builtin/shell.py
+++ b/src/opensquilla/tools/builtin/shell.py
@@ -601,6 +601,10 @@ async def _await_bg_output_task(output_task: asyncio.Task[None]) -> None:
             "description": "Extra environment variable overrides.",
             "additionalProperties": {"type": "string"},
         },
+        "stdin": {
+            "type": "string",
+            "description": "Data to write to the command's standard input.",
+        },
         "approval_id": {
             "type": "string",
             "description": "Approval record to consume for warned commands.",
@@ -616,6 +620,7 @@ async def exec_command(
     workdir: str | None = None,
     timeout: float = _DEFAULT_EXEC_TIMEOUT,
     env: dict[str, str] | None = None,
+    stdin: str | None = None,
     approval_id: str | None = None,
 ) -> str:
     import os
@@ -659,6 +664,7 @@ async def exec_command(
     if env:
         merged_env.update(env)
     effective_timeout = _resolve_exec_timeout(timeout)
+    stdin_bytes = stdin.encode("utf-8") if stdin is not None else None
 
     # /elevated on|bypass|full — route exec around the sandbox backend so host
     # paths are actually reachable. Approval is still handled above (elevated
@@ -681,7 +687,7 @@ async def exec_command(
             cwd=request.cwd,
             action_kind=request.action_kind,
             policy=request.policy,
-            stdin=None,
+            stdin=stdin_bytes,
             env=dict(merged_env),
             reason=request.reason,
         )
@@ -698,6 +704,7 @@ async def exec_command(
             try:
                 proc = await asyncio.create_subprocess_shell(
                     command,
+                    stdin=asyncio.subprocess.PIPE if stdin_bytes is not None else None,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.STDOUT,
                     cwd=cwd,
@@ -705,7 +712,7 @@ async def exec_command(
                 )
                 try:
                     stdout_bytes, _ = await asyncio.wait_for(
-                        proc.communicate(), timeout=effective_timeout
+                        proc.communicate(input=stdin_bytes), timeout=effective_timeout
                     )
                 except TimeoutError:
                     proc.kill()
@@ -727,6 +734,7 @@ async def exec_command(
     try:
         with tempfile.TemporaryFile() as output_file:
             subprocess_kwargs: dict[str, Any] = {
+                "stdin": asyncio.subprocess.PIPE if stdin_bytes is not None else None,
                 "stdout": output_file,
                 "stderr": asyncio.subprocess.STDOUT,
                 "cwd": cwd,
@@ -740,9 +748,19 @@ async def exec_command(
                     subprocess_kwargs["creationflags"] = creationflags
 
             proc = await asyncio.create_subprocess_shell(command, **subprocess_kwargs)
-            if not await _wait_exec_process(proc, effective_timeout):
-                await _terminate_exec_process_tree(proc)
-                return f"[timeout after {effective_timeout}s]\ncommand: {command}"
+            if stdin_bytes is None:
+                if not await _wait_exec_process(proc, effective_timeout):
+                    await _terminate_exec_process_tree(proc)
+                    return f"[timeout after {effective_timeout}s]\ncommand: {command}"
+            else:
+                try:
+                    await asyncio.wait_for(
+                        proc.communicate(input=stdin_bytes),
+                        timeout=effective_timeout,
+                    )
+                except TimeoutError:
+                    await _terminate_exec_process_tree(proc)
+                    return f"[timeout after {effective_timeout}s]\ncommand: {command}"
             if os.name == "posix":
                 _signal_exec_process_tree(proc, signal.SIGTERM)
 

--- a/tests/test_engine/test_meta_resolution_sticky.py
+++ b/tests/test_engine/test_meta_resolution_sticky.py
@@ -272,6 +272,49 @@ async def test_skill_marketplace_intent_clears_sticky_replay():
 
 
 @pytest.mark.asyncio
+async def test_meta_skill_discussion_clears_sticky_replay():
+    skills = [_meta_spec(name="AwesomeWebpageMetaSkill", triggers=("生成图文音视频网页",))]
+    await meta_resolution(_ctx(
+        message="帮我生成图文音视频网页：主题是海洋塑料污染",
+        session_id="S-META-DISCUSS",
+        skills=skills,
+    ))
+    assert mr._sticky_get("S-META-DISCUSS") is not None
+
+    out = await meta_resolution(_ctx(
+        message="你最后生成的时候调用了meta skills吗，怎么生成的好差",
+        session_id="S-META-DISCUSS",
+        skills=skills,
+    ))
+
+    assert "meta_match" not in out.metadata
+    assert mr._sticky_get("S-META-DISCUSS") is None
+
+
+@pytest.mark.asyncio
+async def test_meta_skill_discussion_skips_semantic_fallback(monkeypatch):
+    skills = [_meta_spec(name="AwesomeWebpageMetaSkill", triggers=("生成图文音视频网页",))]
+    semantic_called = False
+
+    def fake_semantic_candidate(ctx, candidates):
+        nonlocal semantic_called
+        semantic_called = True
+        priority, name, plan, _spec = candidates[0]
+        return (priority, name, plan, "semantic")
+
+    monkeypatch.setattr(mr, "_semantic_meta_candidate", fake_semantic_candidate)
+
+    out = await meta_resolution(_ctx(
+        message="你最后生成的时候调用了meta skills吗，怎么生成的好差",
+        session_id="S-META-SEMANTIC",
+        skills=skills,
+    ))
+
+    assert semantic_called is False
+    assert "meta_match" not in out.metadata
+
+
+@pytest.mark.asyncio
 async def test_skill_marketplace_guard_does_not_block_explicit_meta_trigger():
     skills = [_meta_spec(name="meta-skill-creator", triggers=("create a meta-skill",))]
 

--- a/tests/test_packaging/test_pyproject_invariants.py
+++ b/tests/test_packaging/test_pyproject_invariants.py
@@ -117,3 +117,35 @@ def test_readme_points_at_user_facing_file(project_table: dict) -> None:
     assert project_table["readme"] == "README.md", (
         "readme should point at the canonical README.md after the 0.1.0 refactor"
     )
+
+
+def test_html_coder_reference_files_are_packaged() -> None:
+    """html-coder's SKILL.md links to local references that must survive wheels."""
+
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    force_include = data["tool"]["hatch"]["build"]["targets"]["wheel"][
+        "force-include"
+    ]
+    references_dir = (
+        PYPROJECT.parent
+        / "src"
+        / "opensquilla"
+        / "skills"
+        / "bundled"
+        / "html-coder"
+        / "references"
+    )
+    expected_sources = {
+        str(path.relative_to(PYPROJECT.parent))
+        for path in references_dir.glob("*.md")
+    }
+
+    missing_sources = expected_sources - set(force_include)
+    assert not missing_sources, (
+        "html-coder reference files must be force-included in wheels: "
+        f"{sorted(missing_sources)}"
+    )
+    for source in expected_sources:
+        assert (
+            force_include[source] == source.removeprefix("src/")
+        ), f"{source} should be packaged at its import-time skill path"

--- a/tests/test_packaging/test_pyproject_invariants.py
+++ b/tests/test_packaging/test_pyproject_invariants.py
@@ -136,7 +136,7 @@ def test_html_coder_reference_files_are_packaged() -> None:
         / "references"
     )
     expected_sources = {
-        str(path.relative_to(PYPROJECT.parent))
+        path.relative_to(PYPROJECT.parent).as_posix()
         for path in references_dir.glob("*.md")
     }
 

--- a/tests/test_sandbox/test_noop_backend.py
+++ b/tests/test_sandbox/test_noop_backend.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from opensquilla.safety.sandbox import HAS_RESOURCE
+from opensquilla.sandbox.backend.noop import NoopBackend
+from opensquilla.sandbox.types import (
+    MountSpec,
+    NetworkMode,
+    ResourceLimits,
+    SandboxPolicy,
+    SandboxRequest,
+    SecurityLevel,
+)
+
+
+def _policy(workspace: Path) -> SandboxPolicy:
+    return SandboxPolicy(
+        level=SecurityLevel.STANDARD,
+        network=NetworkMode.NONE,
+        mounts=(MountSpec(host_path=workspace, sandbox_path=Path("/workspace"), mode="rw"),),
+        workspace_rw=True,
+        tmp_writable=True,
+        limits=ResourceLimits(wall_timeout_s=5.0),
+        env_allowlist=("PATH",),
+        require_approval=False,
+    )
+
+
+@pytest.mark.skipif(not HAS_RESOURCE, reason="noop backend safety runner is POSIX-only")
+@pytest.mark.asyncio
+async def test_noop_backend_preserves_request_stdin(tmp_path: Path) -> None:
+    request = SandboxRequest(
+        argv=(
+            sys.executable,
+            "-c",
+            "import sys; print('STDIN:' + sys.stdin.read())",
+        ),
+        cwd=tmp_path,
+        action_kind="shell.exec",
+        policy=_policy(tmp_path),
+        stdin=b"payload",
+    )
+
+    result = await NoopBackend().run(request)
+
+    assert result.returncode == 0
+    assert result.stdout.splitlines() == ["STDIN:payload"]

--- a/tests/test_sandbox/test_noop_backend.py
+++ b/tests/test_sandbox/test_noop_backend.py
@@ -30,6 +30,21 @@ def _policy(workspace: Path) -> SandboxPolicy:
     )
 
 
+def _policy_with_env(workspace: Path) -> SandboxPolicy:
+    policy = _policy(workspace)
+    return SandboxPolicy(
+        level=policy.level,
+        network=policy.network,
+        mounts=policy.mounts,
+        workspace_rw=policy.workspace_rw,
+        tmp_writable=policy.tmp_writable,
+        limits=policy.limits,
+        env_allowlist=("PATH", "VISIBLE_REQUEST_ENV"),
+        require_approval=policy.require_approval,
+        description=policy.description,
+    )
+
+
 @pytest.mark.skipif(not HAS_RESOURCE, reason="noop backend safety runner is POSIX-only")
 @pytest.mark.asyncio
 async def test_noop_backend_preserves_request_stdin(tmp_path: Path) -> None:
@@ -70,3 +85,31 @@ async def test_noop_backend_preserves_binary_request_stdin(tmp_path: Path) -> No
 
     assert result.returncode == 0
     assert result.stdout.splitlines() == ["ff00616263"]
+
+
+@pytest.mark.skipif(not HAS_RESOURCE, reason="noop backend safety runner is POSIX-only")
+@pytest.mark.asyncio
+async def test_noop_backend_forwards_allowlisted_request_env(tmp_path: Path) -> None:
+    request = SandboxRequest(
+        argv=(
+            sys.executable,
+            "-c",
+            (
+                "import os; "
+                "print(os.environ.get('VISIBLE_REQUEST_ENV', '')); "
+                "print(os.environ.get('HIDDEN_REQUEST_ENV', 'missing'))"
+            ),
+        ),
+        cwd=tmp_path,
+        action_kind="shell.exec",
+        policy=_policy_with_env(tmp_path),
+        env={
+            "VISIBLE_REQUEST_ENV": "visible",
+            "HIDDEN_REQUEST_ENV": "hidden",
+        },
+    )
+
+    result = await NoopBackend().run(request)
+
+    assert result.returncode == 0
+    assert result.stdout.splitlines() == ["visible", "missing"]

--- a/tests/test_sandbox/test_noop_backend.py
+++ b/tests/test_sandbox/test_noop_backend.py
@@ -49,3 +49,24 @@ async def test_noop_backend_preserves_request_stdin(tmp_path: Path) -> None:
 
     assert result.returncode == 0
     assert result.stdout.splitlines() == ["STDIN:payload"]
+
+
+@pytest.mark.skipif(not HAS_RESOURCE, reason="noop backend safety runner is POSIX-only")
+@pytest.mark.asyncio
+async def test_noop_backend_preserves_binary_request_stdin(tmp_path: Path) -> None:
+    request = SandboxRequest(
+        argv=(
+            sys.executable,
+            "-c",
+            "import sys; print(sys.stdin.buffer.read().hex())",
+        ),
+        cwd=tmp_path,
+        action_kind="shell.exec",
+        policy=_policy(tmp_path),
+        stdin=b"\xff\x00abc",
+    )
+
+    result = await NoopBackend().run(request)
+
+    assert result.returncode == 0
+    assert result.stdout.splitlines() == ["ff00616263"]

--- a/tests/test_sandbox/test_policy_network.py
+++ b/tests/test_sandbox/test_policy_network.py
@@ -39,3 +39,16 @@ def test_standard_shell_and_code_exec_keep_network_none(tmp_path: Path) -> None:
 
     assert shell_policy.network is NetworkMode.NONE
     assert code_policy.network is NetworkMode.NONE
+
+
+def test_shell_exec_policy_allows_meta_skill_workspace_env(tmp_path: Path) -> None:
+    policy = build_policy(
+        SecurityLevel.STANDARD,
+        "shell.exec",
+        tmp_path,
+        SandboxSettings(),
+        trusted=True,
+    )
+
+    assert "WORKSPACE_DIR" in policy.env_allowlist
+    assert "PROJECT_ROOT" in policy.env_allowlist

--- a/tests/test_scripts/test_build_wheelhouse_zip.py
+++ b/tests/test_scripts/test_build_wheelhouse_zip.py
@@ -148,6 +148,9 @@ def test_release_wheel_allows_router_provenance_markdown() -> None:
     unrelated_skill_reference = (
         "opensquilla/skills/bundled/example/references/private-notes.md"
     )
+    skill_readme = "opensquilla/skills/bundled/filesystem/README.md"
+    skill_license = "opensquilla/skills/bundled/filesystem/LICENSE.md"
+    skill_card = "opensquilla/skills/bundled/filesystem/skill-card.md"
     unrelated_router_doc = (
         "opensquilla/squilla_router/models/v4.2_phase3_inference/README.md"
     )
@@ -160,6 +163,9 @@ def test_release_wheel_allows_router_provenance_markdown() -> None:
             "opensquilla/skills/bundled/example/SKILL.md",
             pptx_reference,
             unrelated_skill_reference,
+            skill_readme,
+            skill_license,
+            skill_card,
         )
     )
 
@@ -169,6 +175,9 @@ def test_release_wheel_allows_router_provenance_markdown() -> None:
     assert pptx_reference not in violations
     assert unrelated_router_doc in violations
     assert unrelated_skill_reference in violations
+    assert skill_readme in violations
+    assert skill_license in violations
+    assert skill_card in violations
 
 
 def test_pyproject_release_wheel_config_excludes_forbidden_skill_resources() -> None:
@@ -179,6 +188,9 @@ def test_pyproject_release_wheel_config_excludes_forbidden_skill_resources() -> 
     force_includes = wheel_config.get("force-include", {})
 
     assert "src/opensquilla/skills/bundled/**/THIRD_PARTY_NOTICES.md" in excludes
+    assert "src/opensquilla/skills/bundled/**/README.md" in excludes
+    assert "src/opensquilla/skills/bundled/**/LICENSE.md" in excludes
+    assert "src/opensquilla/skills/bundled/**/skill-card.md" in excludes
     assert "src/opensquilla/skills/bundled/**/references/*.md" in excludes
     assert "src/opensquilla/skills/exp/**" in excludes
     assert "src/opensquilla/skills/meta/META_SKILL_AUTHORING.md" in excludes

--- a/tests/test_skills/test_awesome_webpage_meta_skill.py
+++ b/tests/test_skills/test_awesome_webpage_meta_skill.py
@@ -828,6 +828,42 @@ def test_media_bind_validate_degrades_when_requested_audio_needs_config(
     assert "requested_modality_has_no_ready_asset" not in output
 
 
+def test_media_bind_validate_degrades_when_requested_image_partially_fails(
+    tmp_path: Path,
+) -> None:
+    result = _run_media_bind_step(
+        tmp_path,
+        assets=[
+            {"kind": "image", "src": "assets/images/hero.png"},
+            {"kind": "audio", "src": "assets/audio/narration.wav"},
+            {"kind": "video", "src": "assets/video/intro.mp4"},
+        ],
+        index_html=(
+            '<main><img src="assets/images/hero.png">'
+            '<audio controls src="assets/audio/narration.wav"></audio>'
+            '<video controls src="assets/video/intro.mp4"></video></main>'
+        ),
+        image_aigc=(
+            "IMAGE_GENERATION_FAILED: "
+            + json.dumps(
+                {
+                    "slot_id": "missing-gallery-card",
+                    "reason": "provider_timeout",
+                },
+                separators=(",", ":"),
+            )
+        ),
+    )
+
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert result.returncode == 0, output
+    report = json.loads(result.stdout.decode("utf-8"))
+    partial_image = report["partial_generation_failures"]["image"][0]
+    assert report["status"] == "MEDIA_BIND_DEGRADED"
+    assert partial_image["label"] == "IMAGE_GENERATION_FAILED"
+    assert partial_image["reason"] == "provider_timeout"
+
+
 def test_media_bind_validate_skips_modalities_user_declined(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_skills/test_awesome_webpage_meta_skill.py
+++ b/tests/test_skills/test_awesome_webpage_meta_skill.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import os
 import re
@@ -28,6 +29,21 @@ def _frontmatter() -> dict:
     data = yaml.safe_load(match.group(1))
     assert isinstance(data, dict)
     return data
+
+
+def _load_openrouter_video_module():
+    script = (
+        BUNDLED
+        / "openrouter-video-generator"
+        / "scripts"
+        / "openrouter_video.py"
+    )
+    spec = importlib.util.spec_from_file_location("openrouter_video", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_awesome_webpage_meta_skill_loads_and_references_fixed_skills(tmp_path: Path) -> None:
@@ -454,6 +470,112 @@ def test_audio_cog_json_payload_builds_exact_transcript_messages() -> None:
     assert "Do not acknowledge" in messages[0]["content"]
     assert "Speak this exact narration transcript and no other words" in messages[1]["content"]
     assert "雨水花园会截留雨水" in messages[1]["content"]
+
+
+def test_openrouter_video_resolves_relative_polling_url(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_openrouter_video_module()
+    requests: list[tuple[str, str]] = []
+
+    def fake_request_json(
+        url: str,
+        *,
+        key: str,
+        method: str = "GET",
+        body: dict[str, object] | None = None,
+        timeout: float = 60.0,
+    ) -> dict[str, object]:
+        del body, timeout
+        assert key == "sk-or-test"
+        requests.append((method, url))
+        if method == "POST":
+            return {
+                "id": "job-abc123",
+                "status": "queued",
+                "polling_url": "/api/v1/videos/job-abc123",
+            }
+        return {
+            "status": "completed",
+            "unsigned_urls": ["https://storage.example/video.mp4"],
+        }
+
+    def fake_download(
+        url: str,
+        *,
+        key: str,
+        base_url: str,
+        timeout: float = 120.0,
+    ) -> bytes:
+        del key, base_url, timeout
+        assert url == "https://storage.example/video.mp4"
+        return b"video-bytes"
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.setattr(module, "_request_json", fake_request_json)
+    monkeypatch.setattr(module, "_download", fake_download)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("make a short video"))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "openrouter_video.py",
+            "--model",
+            "bytedance/seedance-2.0-fast",
+            "--output-dir",
+            str(tmp_path),
+            "--filename",
+            "sample.mp4",
+        ],
+    )
+
+    assert module.main() == 0
+
+    assert ("GET", "https://openrouter.ai/api/v1/videos/job-abc123") in requests
+    assert (tmp_path / "sample.mp4").read_bytes() == b"video-bytes"
+
+
+def test_openrouter_video_download_auth_stays_on_openrouter_origin(monkeypatch) -> None:
+    module = _load_openrouter_video_module()
+    opened_headers: list[dict[str, str]] = []
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"video-bytes"
+
+    def fake_urlopen(req, timeout: float = 120.0):
+        del timeout
+        opened_headers.append({key.lower(): value for key, value in req.header_items()})
+        return FakeResponse()
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+
+    assert (
+        module._download(
+            "https://storage.example/video.mp4",
+            key="sk-or-secret",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        == b"video-bytes"
+    )
+    assert "authorization" not in opened_headers[-1]
+
+    assert (
+        module._download(
+            "https://openrouter.ai/api/v1/videos/job-abc123/content",
+            key="sk-or-secret",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        == b"video-bytes"
+    )
+    assert opened_headers[-1]["authorization"] == "Bearer sk-or-secret"
 
 
 def test_openrouter_media_entrypoints_return_config_needed_without_key(

--- a/tests/test_skills/test_awesome_webpage_meta_skill.py
+++ b/tests/test_skills/test_awesome_webpage_meta_skill.py
@@ -71,6 +71,16 @@ def _load_openrouter_image_module():
     return module
 
 
+def _load_awesome_image_download_module():
+    script = BUNDLED / "awesome-webpage-image-download" / "scripts" / "image_download.py"
+    spec = importlib.util.spec_from_file_location("awesome_image_download", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_awesome_webpage_meta_skill_loads_and_references_fixed_skills(tmp_path: Path) -> None:
     loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
     loader.invalidate_cache()
@@ -84,6 +94,7 @@ def test_awesome_webpage_meta_skill_loads_and_references_fixed_skills(tmp_path: 
     refs = {step.skill for step in plan.steps if step.kind in {"agent", "skill_exec"}}
     assert {
         "awesome-webpage-research",
+        "awesome-webpage-image-download",
         "web-search",
         "html-coder",
         "nano-banana-pro-openrouter",
@@ -342,22 +353,17 @@ def test_awesome_webpage_media_strategy_covers_video_and_required_modalities() -
 
     assert "image_download" in steps
     image_download = steps["image_download"]
-    assert image_download["kind"] == "agent"
-    assert image_download["skill"] == "filesystem"
+    assert image_download["kind"] == "skill_exec"
+    assert image_download["skill"] == "awesome-webpage-image-download"
     assert image_download["depends_on"] == ["media_strategy", "media_slots_normalize"]
     assert "outputs.media_strategy == 'IMAGE_SEARCH_READY'" in image_download["when"]
     assert "include_images" in image_download["when"]
     assert "image_download" in steps["media_assets_collect"]["depends_on"]
     assert "image_download" not in steps["webpage_generation"]["depends_on"]
-    assert "curl -L --fail" in image_download["with"]["task"]
-    assert "Do not call web_search" in image_download["with"]["task"]
-    download_task = image_download["with"]["task"]
-    assert "MEDIA_SLOTS_JSON" in download_task
-    assert "outputs.media_slots_normalize | truncate(3500)" in download_task
-    assert "shopping list" in download_task
-    assert "slot_id as filename" in download_task
-    assert "IMAGE_DOWNLOAD_INCOMPLETE:" in download_task
-    assert "downstream image_aigc" in download_task
+    assert "curl" not in str(image_download)
+    assert "outputs.media_slots_normalize | tojson" in image_download["with"]["payload"]
+    assert "outputs.media_search | tojson" in image_download["with"]["payload"]
+    assert "get('config', {})" in image_download["with"]["output_dir"]
 
     assert steps["image_aigc"]["depends_on"] == [
         "media_strategy",
@@ -477,21 +483,23 @@ def test_media_slots_normalize_synthesizes_image_slots_when_outline_has_no_slots
 ) -> None:
     fm = _frontmatter()
     steps = {step["id"]: step for step in fm["composition"]["steps"]}
-    command = steps["media_slots_normalize"]["tool_args"]["command"]
-    env = os.environ.copy()
-    env.update(
+    tool_args = steps["media_slots_normalize"]["tool_args"]
+    command = tool_args["command"]
+    assert "env" not in tool_args
+    assert "PAGE_OUTLINE" not in str(tool_args)
+    stdin = json.dumps(
         {
-            "PAGE_OUTLINE": """
+            "page_outline": """
             | section_id | title | purpose |
             | --- | --- | --- |
             | hero | 海洋塑料污染 | establish urgency |
             | impact | 食物链影响 | explain microplastics |
             """,
-            "REQUIREMENT_FRAMING": "主题: 海洋塑料污染科普网页，包含音频、视频和图片",
-            "INCLUDE_IMAGE": "YES",
-            "INCLUDE_AUDIO": "YES",
-            "INCLUDE_VIDEO": "YES",
-            "VISUAL_STYLE": "纪录片风，清晰可信",
+            "requirement_framing": "主题: 海洋塑料污染科普网页，包含音频、视频和图片",
+            "include_image": "YES",
+            "include_audio": "YES",
+            "include_video": "YES",
+            "visual_style": "纪录片风，清晰可信",
         }
     )
 
@@ -499,7 +507,7 @@ def test_media_slots_normalize_synthesizes_image_slots_when_outline_has_no_slots
         command,
         shell=True,
         cwd=tmp_path,
-        env=env,
+        input=stdin,
         capture_output=True,
         text=True,
         check=False,
@@ -530,12 +538,24 @@ def test_awesome_webpage_media_entrypoints_are_code_backed(tmp_path: Path) -> No
     assert image is not None
     assert image.entrypoint is not None
     assert image.entrypoint["command"] == "python {baseDir}/scripts/openrouter_image.py"
-    assert "--api-key" in image.entrypoint["args"]
+    assert "--api-key" not in image.entrypoint["args"]
+    assert "--api-key-env" in image.entrypoint["args"]
+    assert image.entrypoint["env"][
+        "{{ with.api_key_env | default('OPENROUTER_API_KEY') }}"
+    ] == (
+        "{{ with.api_key | default('') }}"
+    )
 
     assert audio is not None
     assert audio.entrypoint is not None
     assert audio.entrypoint["command"] == "python {baseDir}/scripts/openrouter_audio.py"
-    assert "--api-key" in audio.entrypoint["args"]
+    assert "--api-key" not in audio.entrypoint["args"]
+    assert "--api-key-env" in audio.entrypoint["args"]
+    assert audio.entrypoint["env"][
+        "{{ with.api_key_env | default('OPENROUTER_API_KEY') }}"
+    ] == (
+        "{{ with.api_key | default('') }}"
+    )
     assert audio.entrypoint["parse"] == "text"
 
     assert video is not None
@@ -543,7 +563,13 @@ def test_awesome_webpage_media_entrypoints_are_code_backed(tmp_path: Path) -> No
     assert video.entrypoint["command"] == (
         "python {baseDir}/scripts/openrouter_video.py"
     )
-    assert "--api-key" in video.entrypoint["args"]
+    assert "--api-key" not in video.entrypoint["args"]
+    assert "--api-key-env" in video.entrypoint["args"]
+    assert video.entrypoint["env"][
+        "{{ with.api_key_env | default('OPENROUTER_API_KEY') }}"
+    ] == (
+        "{{ with.api_key | default('') }}"
+    )
     assert video.entrypoint["parse"] == "text"
 
 
@@ -562,6 +588,82 @@ def test_web_search_uses_bundled_script_entrypoint(tmp_path: Path) -> None:
     )
     assert "python scripts/search.py" not in body
     assert "python {baseDir}/scripts/search.py" in body
+
+
+def test_awesome_image_downloader_emits_ready_record(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_awesome_image_download_module()
+    image_bytes = (
+        b"\x89PNG\r\n\x1a\n"
+        b"\x00\x00\x00\rIHDR"
+        b"\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x02\x00\x00\x00"
+    )
+
+    class FakeResponse:
+        headers = {"Content-Type": "image/png"}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+            return None
+
+        def read(self, *_args: object) -> bytes:
+            return image_bytes
+
+        def geturl(self) -> str:
+            return "https://cdn.example/hero.png"
+
+    def fake_urlopen(*_args: object, **_kwargs: object) -> FakeResponse:
+        return FakeResponse()
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(
+                {
+                    "media_slots": json.dumps(
+                        {
+                            "slots": [
+                                {
+                                    "slot_id": "hero-visual",
+                                    "modality": "image",
+                                    "subject": "hero ocean",
+                                    "search_keywords": ["hero", "ocean"],
+                                }
+                            ]
+                        }
+                    ),
+                    "media_search": "candidate https://cdn.example/hero.png",
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "image_download.py",
+            "--output-dir",
+            str(tmp_path),
+            "--local-path-prefix",
+            "project/assets/images",
+        ],
+    )
+
+    assert module.main() == 0
+
+    out = capsys.readouterr().out
+    assert (tmp_path / "hero-visual.png").read_bytes() == image_bytes
+    assert "IMAGE_READY" in out
+    assert "project/assets/images/hero-visual.png" in out
 
 
 def test_audio_cog_json_payload_builds_exact_transcript_messages() -> None:
@@ -1020,6 +1122,7 @@ def test_awesome_webpage_media_steps_forward_configured_openrouter_settings() ->
             "awesome_webpage": {
                 "openrouter": {
                     "api_key": "sk-configured",
+                    "api_key_env": "CUSTOM_OPENROUTER_KEY",
                     "base_url": "https://openrouter.example/v1",
                     "models": {
                         "image_generation": "provider/custom-image",
@@ -1054,6 +1157,7 @@ def test_awesome_webpage_media_steps_forward_configured_openrouter_settings() ->
     for step_id, model in expected_models.items():
         rendered = render_with_args(steps[step_id]["with"], inputs=inputs, outputs=outputs)
         assert rendered["api_key"] == "sk-configured"
+        assert rendered["api_key_env"] == "CUSTOM_OPENROUTER_KEY"
         assert rendered["base_url"] == "https://openrouter.example/v1"
         assert rendered["model"] == model
 
@@ -1422,6 +1526,12 @@ def test_awesome_webpage_rendered_steps_resolve_output_dir(tmp_path: Path) -> No
             "ask_video": {"include_video": "YES"},
             "ask_style": {"visual_style": "纪录片风，清晰、可信、适合科普"},
         },
+        "config": {
+            "awesome_webpage": {
+                "output_dir": "/tmp/custom-awesome-output",
+                "media_strategy": {"target_assets": {"images": 2}},
+            },
+        },
     }
     outputs = {
         key: key
@@ -1453,22 +1563,46 @@ def test_awesome_webpage_rendered_steps_resolve_output_dir(tmp_path: Path) -> No
 
     for step_id in [
         "requirement_framing",
+        "image_download",
+        "image_aigc",
+        "audio_aigc",
+        "video_aigc",
         "quick_validate",
         "delivery_guide",
     ]:
         step = next(step for step in plan.steps if step.id == step_id)
         rendered = render_with_args(step.with_args, inputs=inputs, outputs=outputs)
         text = "\n".join(str(value) for value in rendered.values())
-        assert "/tmp/osq-workspace/awesome-webpage-output" in text
+        assert "/tmp/custom-awesome-output" in text
+        assert "/tmp/osq-workspace/awesome-webpage-output" not in text
+
+    fm_steps = {step["id"]: step for step in _frontmatter()["composition"]["steps"]}
+    for step_id in ["media_assets_collect", "webpage_write", "media_bind_validate"]:
+        rendered = render_with_args(
+            fm_steps[step_id]["tool_args"],
+            inputs=inputs,
+            outputs=outputs,
+        )
+        text = "\n".join(str(value) for value in rendered.values())
+        assert "/tmp/custom-awesome-output" in text
+        assert "/tmp/osq-workspace/awesome-webpage-output" not in text
 
     for step_id in ["quick_validate", "delivery_guide"]:
         step = next(step for step in plan.steps if step.id == step_id)
         rendered = render_with_args(step.with_args, inputs=inputs, outputs=outputs)
         text = "\n".join(str(value) for value in rendered.values())
-        assert "/tmp/osq-workspace/awesome-webpage-output/project_slug" in text
+        assert "/tmp/custom-awesome-output/project_slug" in text
 
     for step_id in ["delivery_guide"]:
         step = next(step for step in plan.steps if step.id == step_id)
         rendered = render_with_args(step.with_args, inputs=inputs, outputs=outputs)
         text = "\n".join(str(value) for value in rendered.values())
-        assert "/tmp/osq-workspace/awesome-webpage-output/project_slug/project" in text
+        assert "/tmp/custom-awesome-output/project_slug/project" in text
+
+    image_step = next(step for step in plan.steps if step.id == "image_aigc")
+    rendered_image = render_with_args(
+        image_step.with_args,
+        inputs=inputs,
+        outputs=outputs,
+    )
+    assert rendered_image["max_images"] == "2"

--- a/tests/test_skills/test_awesome_webpage_meta_skill.py
+++ b/tests/test_skills/test_awesome_webpage_meta_skill.py
@@ -236,9 +236,13 @@ def test_awesome_webpage_media_strategy_covers_video_and_required_modalities() -
         steps["media_search"]["with"]["query"]
     )
     assert "include_images" in steps["media_search"]["when"]
+    assert "search_first" in steps["media_search"]["when"]
+    assert "search_modalities" in steps["media_search"]["when"]
     assert "media_search_cn" not in steps
 
     assert steps["media_strategy"]["depends_on"] == ["media_search", "media_slots_normalize"]
+    assert "search_first" in media_strategy["with"]["text"]
+    assert "search_modalities" in media_strategy["with"]["text"]
     assert steps["video_aigc"]["skill"] == "openrouter-video-generator"
     assert steps["audio_script"]["kind"] == "llm_chat"
     assert steps["audio_script"]["depends_on"] == [
@@ -366,6 +370,49 @@ def test_awesome_webpage_media_strategy_covers_video_and_required_modalities() -
     assert "image_download" in image_payload
     assert "include_images" in image_payload
     assert "visual_style" in image_payload
+
+
+def test_awesome_webpage_media_search_respects_configured_strategy() -> None:
+    fm = _frontmatter()
+    steps = {step["id"]: step for step in fm["composition"]["steps"]}
+    when = steps["media_search"]["when"]
+    base_inputs = {
+        "collected": {
+            "ask_images": {"include_images": "YES"},
+        },
+    }
+
+    assert evaluate_when(when, inputs=base_inputs, outputs={})
+    assert not evaluate_when(
+        when,
+        inputs={
+            **base_inputs,
+            "config": {
+                "awesome_webpage": {
+                    "media_strategy": {
+                        "search_first": False,
+                        "search_modalities": ["images"],
+                    },
+                },
+            },
+        },
+        outputs={},
+    )
+    assert not evaluate_when(
+        when,
+        inputs={
+            **base_inputs,
+            "config": {
+                "awesome_webpage": {
+                    "media_strategy": {
+                        "search_first": True,
+                        "search_modalities": [],
+                    },
+                },
+            },
+        },
+        outputs={},
+    )
 
 
 def test_image_aigc_runs_when_search_download_produces_no_images() -> None:
@@ -964,7 +1011,7 @@ def test_webpage_source_validate_marks_malformed_non_empty_source_invalid(
     assert "WEBPAGE_SOURCE_INVALID" in output
 
 
-def test_awesome_webpage_media_steps_forward_configured_openrouter_api_key() -> None:
+def test_awesome_webpage_media_steps_forward_configured_openrouter_settings() -> None:
     fm = _frontmatter()
     steps = {step["id"]: step for step in fm["composition"]["steps"]}
     inputs = {
@@ -973,6 +1020,12 @@ def test_awesome_webpage_media_steps_forward_configured_openrouter_api_key() -> 
             "awesome_webpage": {
                 "openrouter": {
                     "api_key": "sk-configured",
+                    "base_url": "https://openrouter.example/v1",
+                    "models": {
+                        "image_generation": "provider/custom-image",
+                        "audio_generation": "provider/custom-audio",
+                        "video_generation": "provider/custom-video",
+                    },
                 },
             },
         },
@@ -993,9 +1046,16 @@ def test_awesome_webpage_media_steps_forward_configured_openrouter_api_key() -> 
         "audio_script": "demo narration",
     }
 
-    for step_id in ["image_aigc", "audio_aigc", "video_aigc"]:
+    expected_models = {
+        "image_aigc": "provider/custom-image",
+        "audio_aigc": "provider/custom-audio",
+        "video_aigc": "provider/custom-video",
+    }
+    for step_id, model in expected_models.items():
         rendered = render_with_args(steps[step_id]["with"], inputs=inputs, outputs=outputs)
         assert rendered["api_key"] == "sk-configured"
+        assert rendered["base_url"] == "https://openrouter.example/v1"
+        assert rendered["model"] == model
 
 
 def test_awesome_webpage_media_bind_validate_is_deterministic() -> None:

--- a/tests/test_skills/test_awesome_webpage_meta_skill.py
+++ b/tests/test_skills/test_awesome_webpage_meta_skill.py
@@ -237,7 +237,8 @@ def test_awesome_webpage_media_strategy_covers_video_and_required_modalities() -
         "webpage_generation",
         "webpage_generation_retry",
     ]
-    assert steps["webpage_write"]["tool_args"]["env"]["WEBPAGE_SOURCE_JSON"] == (
+    assert "WEBPAGE_SOURCE_JSON" not in steps["webpage_write"]["tool_args"]["env"]
+    assert steps["webpage_write"]["tool_args"]["stdin"] == (
         "{{ (outputs.get('webpage_generation_retry', '') or outputs.webpage_generation) | tojson }}"
     )
 
@@ -604,7 +605,6 @@ def test_webpage_write_accepts_prose_wrapped_fenced_json(tmp_path: Path) -> None
         {
             "WORKSPACE_DIR": str(tmp_path),
             "PROJECT_ROOT": str(project_root),
-            "WEBPAGE_SOURCE_JSON": json.dumps(wrapped_source),
         }
     )
 
@@ -613,6 +613,7 @@ def test_webpage_write_accepts_prose_wrapped_fenced_json(tmp_path: Path) -> None
         shell=True,
         cwd=tmp_path,
         env=env,
+        input=json.dumps(wrapped_source).encode("utf-8"),
         capture_output=True,
         check=False,
     )

--- a/tests/test_skills/test_awesome_webpage_meta_skill.py
+++ b/tests/test_skills/test_awesome_webpage_meta_skill.py
@@ -56,6 +56,21 @@ def _load_openrouter_audio_module():
     return module
 
 
+def _load_openrouter_image_module():
+    script = (
+        BUNDLED
+        / "nano-banana-pro-openrouter"
+        / "scripts"
+        / "openrouter_image.py"
+    )
+    spec = importlib.util.spec_from_file_location("openrouter_image", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_awesome_webpage_meta_skill_loads_and_references_fixed_skills(tmp_path: Path) -> None:
     loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
     loader.invalidate_cache()
@@ -251,6 +266,9 @@ def test_awesome_webpage_media_strategy_covers_video_and_required_modalities() -
     assert "include_video" in steps["video_aigc"]["when"]
     assert "include_audio" in steps["audio_aigc"]["when"]
     assert "include_images" in steps["image_aigc"]["when"]
+    assert "api_key" in steps["image_aigc"]["with"]
+    assert "api_key" in steps["audio_aigc"]["with"]
+    assert "api_key" in steps["video_aigc"]["with"]
     assert "video_aigc" not in steps["webpage_generation"]["depends_on"]
     assert "media_slots_normalize" in steps["webpage_generation"]["depends_on"]
     assert "media_manifest_normalize" not in steps["webpage_generation"]["depends_on"]
@@ -458,12 +476,19 @@ def test_awesome_webpage_media_entrypoints_are_code_backed(tmp_path: Path) -> No
     loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
     loader.invalidate_cache()
 
+    image = loader.get_by_name("nano-banana-pro-openrouter")
     audio = loader.get_by_name("audio-cog")
     video = loader.get_by_name("openrouter-video-generator")
+
+    assert image is not None
+    assert image.entrypoint is not None
+    assert image.entrypoint["command"] == "python {baseDir}/scripts/openrouter_image.py"
+    assert "--api-key" in image.entrypoint["args"]
 
     assert audio is not None
     assert audio.entrypoint is not None
     assert audio.entrypoint["command"] == "python {baseDir}/scripts/openrouter_audio.py"
+    assert "--api-key" in audio.entrypoint["args"]
     assert audio.entrypoint["parse"] == "text"
 
     assert video is not None
@@ -471,7 +496,25 @@ def test_awesome_webpage_media_entrypoints_are_code_backed(tmp_path: Path) -> No
     assert video.entrypoint["command"] == (
         "python {baseDir}/scripts/openrouter_video.py"
     )
+    assert "--api-key" in video.entrypoint["args"]
     assert video.entrypoint["parse"] == "text"
+
+
+def test_web_search_uses_bundled_script_entrypoint(tmp_path: Path) -> None:
+    loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
+    loader.invalidate_cache()
+
+    web_search = loader.get_by_name("web-search")
+    assert web_search is not None
+    assert web_search.entrypoint is not None
+    assert web_search.entrypoint["command"] == "python {baseDir}/scripts/search.py"
+    assert "{{ with.query | default(inputs.user_message) }}" in web_search.entrypoint["args"]
+
+    body = SKILL_MD.parent.parent.joinpath("web-search", "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "python scripts/search.py" not in body
+    assert "python {baseDir}/scripts/search.py" in body
 
 
 def test_audio_cog_json_payload_builds_exact_transcript_messages() -> None:
@@ -599,6 +642,54 @@ def test_openrouter_video_download_auth_stays_on_openrouter_origin(monkeypatch) 
     assert opened_headers[-1]["authorization"] == "Bearer sk-or-secret"
 
 
+def test_openrouter_image_uses_explicit_api_key_without_env(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_openrouter_image_module()
+    seen_keys: list[str] = []
+
+    def fake_generate_one(**kwargs: object) -> dict[str, object]:
+        seen_keys.append(str(kwargs["api_key"]))
+        return {
+            "ok": True,
+            "slot_id": "image",
+            "local_path": "project/assets/images/image.png",
+            "mime": "image/png",
+            "bytes": 1,
+            "prompt_preview": "demo",
+        }
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(module, "_generate_one", fake_generate_one)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("demo prompt"))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "openrouter_image.py",
+            "--model",
+            "google/gemini-3-pro-image-preview",
+            "--base-url",
+            "https://openrouter.ai/api/v1",
+            "--api-key",
+            "sk-configured",
+            "--output-dir",
+            str(tmp_path),
+            "--filename",
+            "image.png",
+        ],
+    )
+
+    assert module.main() == 0
+
+    out = capsys.readouterr().out
+    assert seen_keys == ["sk-configured"]
+    assert "IMAGE_READY" in out
+    assert "IMAGE_CONFIG_NEEDED" not in out
+
+
 def test_openrouter_audio_timeout_reports_generation_failed(
     tmp_path: Path,
     monkeypatch,
@@ -610,7 +701,7 @@ def test_openrouter_audio_timeout_reports_generation_failed(
         del args, kwargs
         raise TimeoutError("timed out")
 
-    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     monkeypatch.setattr(module, "urlopen", fake_urlopen)
     monkeypatch.setattr(sys, "stdin", io.StringIO("short narration"))
     monkeypatch.setattr(
@@ -620,6 +711,8 @@ def test_openrouter_audio_timeout_reports_generation_failed(
             "openrouter_audio.py",
             "--model",
             "openai/gpt-audio-mini",
+            "--api-key",
+            "sk-configured",
             "--output-dir",
             str(tmp_path),
             "--filename",
@@ -645,7 +738,7 @@ def test_openrouter_video_submit_timeout_reports_generation_failed(
         del args, kwargs
         raise TimeoutError("timed out")
 
-    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     monkeypatch.setattr(module, "urlopen", fake_urlopen)
     monkeypatch.setattr(sys, "stdin", io.StringIO("short video prompt"))
     monkeypatch.setattr(
@@ -655,6 +748,8 @@ def test_openrouter_video_submit_timeout_reports_generation_failed(
             "openrouter_video.py",
             "--model",
             "bytedance/seedance-2.0-fast",
+            "--api-key",
+            "sk-configured",
             "--output-dir",
             str(tmp_path),
             "--filename",
@@ -869,6 +964,40 @@ def test_webpage_source_validate_marks_malformed_non_empty_source_invalid(
     assert "WEBPAGE_SOURCE_INVALID" in output
 
 
+def test_awesome_webpage_media_steps_forward_configured_openrouter_api_key() -> None:
+    fm = _frontmatter()
+    steps = {step["id"]: step for step in fm["composition"]["steps"]}
+    inputs = {
+        "workspace_dir": "/tmp/osq-workspace",
+        "config": {
+            "awesome_webpage": {
+                "openrouter": {
+                    "api_key": "sk-configured",
+                },
+            },
+        },
+        "collected": {
+            "ask_images": {"include_images": "YES"},
+            "ask_audio": {"include_audio": "YES"},
+            "ask_video": {"include_video": "YES"},
+            "ask_style": {"visual_style": "clean"},
+        },
+    }
+    outputs = {
+        "project_slug": "demo",
+        "requirement_framing": "demo",
+        "page_outline": "demo",
+        "media_slots_normalize": "{}",
+        "media_strategy": "NEEDS_AIGC_IMAGE",
+        "image_download": "",
+        "audio_script": "demo narration",
+    }
+
+    for step_id in ["image_aigc", "audio_aigc", "video_aigc"]:
+        rendered = render_with_args(steps[step_id]["with"], inputs=inputs, outputs=outputs)
+        assert rendered["api_key"] == "sk-configured"
+
+
 def test_awesome_webpage_media_bind_validate_is_deterministic() -> None:
     fm = _frontmatter()
     steps = {step["id"]: step for step in fm["composition"]["steps"]}
@@ -904,6 +1033,7 @@ def _run_media_bind_step(
     image_aigc: str = "",
     audio_aigc: str = "",
     video_aigc: str = "",
+    style_css: str = "body{margin:0}",
 ) -> subprocess.CompletedProcess[bytes]:
     fm = _frontmatter()
     steps = {step["id"]: step for step in fm["composition"]["steps"]}
@@ -915,7 +1045,7 @@ def _run_media_bind_step(
     (project_dir / "assets" / "audio").mkdir(parents=True)
     (project_dir / "assets" / "video").mkdir(parents=True)
     (project_dir / "index.html").write_text(index_html, encoding="utf-8")
-    (project_dir / "style.css").write_text("body{margin:0}", encoding="utf-8")
+    (project_dir / "style.css").write_text(style_css, encoding="utf-8")
     (project_dir / "script.js").write_text("console.log('ok')", encoding="utf-8")
     ready_lines = {"image": [], "audio": [], "video": []}
     for asset in assets:
@@ -1029,6 +1159,66 @@ def test_media_bind_validate_repairs_audio_when_asset_path_is_not_control_src(
             '<p>assets/audio/narration.wav</p>'
             '<video controls src="assets/video/intro.mp4"></video></main>'
         ),
+    )
+
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert result.returncode == 0, output
+    index_html = (
+        tmp_path
+        / "awesome-webpage-output"
+        / "demo"
+        / "project"
+        / "index.html"
+    ).read_text(encoding="utf-8")
+    assert '<audio controls preload="metadata" src="assets/audio/narration.wav">' in index_html
+
+
+def test_media_bind_validate_repairs_image_when_asset_path_is_not_rendered(
+    tmp_path: Path,
+) -> None:
+    assets = [
+        {"kind": "image", "src": "assets/images/hero.png"},
+        {"kind": "audio", "src": "assets/audio/narration.wav"},
+        {"kind": "video", "src": "assets/video/intro.mp4"},
+    ]
+    result = _run_media_bind_step(
+        tmp_path,
+        assets=assets,
+        index_html=(
+            '<main><p>assets/images/hero.png</p>'
+            '<audio controls src="assets/audio/narration.wav"></audio>'
+            '<video controls src="assets/video/intro.mp4"></video></main>'
+        ),
+    )
+
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert result.returncode == 0, output
+    index_html = (
+        tmp_path
+        / "awesome-webpage-output"
+        / "demo"
+        / "project"
+        / "index.html"
+    ).read_text(encoding="utf-8")
+    assert '<img loading="lazy" src="assets/images/hero.png"' in index_html
+
+
+def test_media_bind_validate_persists_repair_when_generated_media_css_exists(
+    tmp_path: Path,
+) -> None:
+    assets = [
+        {"kind": "image", "src": "assets/images/hero.png"},
+        {"kind": "audio", "src": "assets/audio/narration.wav"},
+        {"kind": "video", "src": "assets/video/intro.mp4"},
+    ]
+    result = _run_media_bind_step(
+        tmp_path,
+        assets=assets,
+        index_html=(
+            '<main><img src="assets/images/hero.png">'
+            '<video controls src="assets/video/intro.mp4"></video></main>'
+        ),
+        style_css=".generated-media-assets{display:block}",
     )
 
     output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")

--- a/tests/test_skills/test_awesome_webpage_meta_skill.py
+++ b/tests/test_skills/test_awesome_webpage_meta_skill.py
@@ -46,6 +46,16 @@ def _load_openrouter_video_module():
     return module
 
 
+def _load_openrouter_audio_module():
+    script = BUNDLED / "audio-cog" / "scripts" / "openrouter_audio.py"
+    spec = importlib.util.spec_from_file_location("openrouter_audio", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_awesome_webpage_meta_skill_loads_and_references_fixed_skills(tmp_path: Path) -> None:
     loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
     loader.invalidate_cache()
@@ -245,15 +255,26 @@ def test_awesome_webpage_media_strategy_covers_video_and_required_modalities() -
     assert "media_slots_normalize" in steps["webpage_generation"]["depends_on"]
     assert "media_manifest_normalize" not in steps["webpage_generation"]["depends_on"]
     assert "media_assets_collect" in steps["webpage_generation"]["depends_on"]
+    assert steps["webpage_source_validate"]["kind"] == "tool_call"
+    assert steps["webpage_source_validate"]["depends_on"] == ["webpage_generation"]
+    assert steps["webpage_source_validate"]["tool_args"]["command"].strip() == (
+        f"python -m {AWESOME_MODULE}.webpage_source_validate"
+    )
+    assert steps["webpage_source_validate"]["tool_args"]["stdin"] == (
+        "{{ outputs.webpage_generation | tojson }}"
+    )
     assert steps["webpage_generation_retry"]["depends_on"] == [
         "webpage_generation",
+        "webpage_source_validate",
         "media_slots_normalize",
     ]
     assert steps["webpage_generation_retry"]["when"] == (
-        "not outputs.get('webpage_generation', '').strip()"
+        "not outputs.get('webpage_generation', '').strip() "
+        "or 'WEBPAGE_SOURCE_INVALID:' in outputs.get('webpage_source_validate', '')"
     )
     assert steps["webpage_write"]["depends_on"] == [
         "webpage_generation",
+        "webpage_source_validate",
         "webpage_generation_retry",
     ]
     assert "WEBPAGE_SOURCE_JSON" not in steps["webpage_write"]["tool_args"]["env"]
@@ -578,6 +599,81 @@ def test_openrouter_video_download_auth_stays_on_openrouter_origin(monkeypatch) 
     assert opened_headers[-1]["authorization"] == "Bearer sk-or-secret"
 
 
+def test_openrouter_audio_timeout_reports_generation_failed(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_openrouter_audio_module()
+
+    def fake_urlopen(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise TimeoutError("timed out")
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("short narration"))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "openrouter_audio.py",
+            "--model",
+            "openai/gpt-audio-mini",
+            "--output-dir",
+            str(tmp_path),
+            "--filename",
+            "sample.wav",
+        ],
+    )
+
+    assert module.main() == 0
+
+    out = capsys.readouterr().out
+    assert "AUDIO_GENERATION_FAILED" in out
+    assert "TimeoutError" in out
+
+
+def test_openrouter_video_submit_timeout_reports_generation_failed(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_openrouter_video_module()
+
+    def fake_urlopen(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise TimeoutError("timed out")
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("short video prompt"))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "openrouter_video.py",
+            "--model",
+            "bytedance/seedance-2.0-fast",
+            "--output-dir",
+            str(tmp_path),
+            "--filename",
+            "sample.mp4",
+            "--poll-interval",
+            "1",
+            "--max-wait",
+            "1",
+        ],
+    )
+
+    assert module.main() == 0
+
+    out = capsys.readouterr().out
+    assert "VIDEO_GENERATION_FAILED" in out
+    assert '"phase":"submit"' in out
+    assert "TimeoutError" in out
+
+
 def test_openrouter_media_entrypoints_return_config_needed_without_key(
     tmp_path: Path,
     monkeypatch,
@@ -752,6 +848,27 @@ def test_webpage_write_accepts_prose_wrapped_fenced_json(tmp_path: Path) -> None
     assert (project_dir / "script.js").read_text(encoding="utf-8") == source["script_js"]
 
 
+def test_webpage_source_validate_marks_malformed_non_empty_source_invalid(
+    tmp_path: Path,
+) -> None:
+    fm = _frontmatter()
+    steps = {step["id"]: step for step in fm["composition"]["steps"]}
+    command = steps["webpage_source_validate"]["tool_args"]["command"]
+
+    result = subprocess.run(
+        command,
+        shell=True,
+        cwd=tmp_path,
+        input=json.dumps("not json {broken").encode("utf-8"),
+        capture_output=True,
+        check=False,
+    )
+
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert result.returncode == 0, output
+    assert "WEBPAGE_SOURCE_INVALID" in output
+
+
 def test_awesome_webpage_media_bind_validate_is_deterministic() -> None:
     fm = _frontmatter()
     steps = {step["id"]: step for step in fm["composition"]["steps"]}
@@ -885,6 +1002,37 @@ def test_media_bind_validate_repairs_when_requested_audio_is_unbound(
     output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
     assert result.returncode == 0
     assert "MEDIA_BIND_OK" in output
+    index_html = (
+        tmp_path
+        / "awesome-webpage-output"
+        / "demo"
+        / "project"
+        / "index.html"
+    ).read_text(encoding="utf-8")
+    assert '<audio controls preload="metadata" src="assets/audio/narration.wav">' in index_html
+
+
+def test_media_bind_validate_repairs_audio_when_asset_path_is_not_control_src(
+    tmp_path: Path,
+) -> None:
+    assets = [
+        {"kind": "image", "src": "assets/images/hero.png"},
+        {"kind": "audio", "src": "assets/audio/narration.wav"},
+        {"kind": "video", "src": "assets/video/intro.mp4"},
+    ]
+    result = _run_media_bind_step(
+        tmp_path,
+        assets=assets,
+        index_html=(
+            '<main><img src="assets/images/hero.png">'
+            '<audio controls></audio>'
+            '<p>assets/audio/narration.wav</p>'
+            '<video controls src="assets/video/intro.mp4"></video></main>'
+        ),
+    )
+
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert result.returncode == 0, output
     index_html = (
         tmp_path
         / "awesome-webpage-output"

--- a/tests/test_skills/test_awesome_webpage_meta_skill.py
+++ b/tests/test_skills/test_awesome_webpage_meta_skill.py
@@ -658,6 +658,9 @@ def _run_media_bind_step(
     include_image: str = "YES",
     include_audio: str = "YES",
     include_video: str = "YES",
+    image_aigc: str = "",
+    audio_aigc: str = "",
+    video_aigc: str = "",
 ) -> subprocess.CompletedProcess[bytes]:
     fm = _frontmatter()
     steps = {step["id"]: step for step in fm["composition"]["steps"]}
@@ -696,9 +699,9 @@ def _run_media_bind_step(
         {
             "PROJECT_ROOT": str(project_root),
             "IMAGE_DOWNLOAD": "\n".join(ready_lines["image"]),
-            "IMAGE_AIGC": "",
-            "AUDIO_AIGC": "\n".join(ready_lines["audio"]),
-            "VIDEO_AIGC": "\n".join(ready_lines["video"]),
+            "IMAGE_AIGC": image_aigc,
+            "AUDIO_AIGC": "\n".join(ready_lines["audio"] + [audio_aigc]),
+            "VIDEO_AIGC": "\n".join(ready_lines["video"] + [video_aigc]),
             "INCLUDE_IMAGE": include_image,
             "INCLUDE_AUDIO": include_audio,
             "INCLUDE_VIDEO": include_video,
@@ -785,6 +788,44 @@ def test_media_bind_validate_fails_when_requested_audio_has_no_ready_asset(
     assert result.returncode != 0
     assert "MEDIA_BIND_FAILED" in output
     assert "requested_modality_has_no_ready_asset" in output
+
+
+def test_media_bind_validate_degrades_when_requested_audio_needs_config(
+    tmp_path: Path,
+) -> None:
+    result = _run_media_bind_step(
+        tmp_path,
+        assets=[
+            {"kind": "image", "src": "assets/images/hero.png"},
+            {"kind": "video", "src": "assets/video/intro.mp4"},
+        ],
+        index_html=(
+            '<main><img src="assets/images/hero.png">'
+            '<video controls src="assets/video/intro.mp4"></video></main>'
+        ),
+        audio_aigc=(
+            "AUDIO_CONFIG_NEEDED: "
+            + json.dumps(
+                {
+                    "missing": ["OPENROUTER_API_KEY"],
+                    "replacement_slot": "project/assets/audio/narration.wav",
+                    "reason": "missing_api_key",
+                },
+                separators=(",", ":"),
+            )
+        ),
+    )
+
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert result.returncode == 0, output
+    report = json.loads(result.stdout.decode("utf-8"))
+    degraded_audio = report["degraded"]["audio"][0]
+    assert report["status"] == "MEDIA_BIND_DEGRADED"
+    assert degraded_audio["label"] == "AUDIO_CONFIG_NEEDED"
+    assert degraded_audio["reason"] == "missing_api_key"
+    assert degraded_audio["missing"] == ["OPENROUTER_API_KEY"]
+    assert degraded_audio["replacement_src"] == "assets/audio/narration.wav"
+    assert "requested_modality_has_no_ready_asset" not in output
 
 
 def test_media_bind_validate_skips_modalities_user_declined(

--- a/tests/test_skills/test_awesome_webpage_meta_skill.py
+++ b/tests/test_skills/test_awesome_webpage_meta_skill.py
@@ -1,0 +1,873 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from opensquilla.skills.eligibility import EligibilityContext, check_eligibility
+from opensquilla.skills.loader import SkillLoader
+from opensquilla.skills.meta.parser import parse_meta_plan
+from opensquilla.skills.meta.templating import evaluate_when, render_with_args
+
+REPO = Path(__file__).resolve().parents[2]
+BUNDLED = REPO / "src" / "opensquilla" / "skills" / "bundled"
+SKILL_MD = BUNDLED / "AwesomeWebpageMetaSkill" / "SKILL.md"
+AWESOME_MODULE = "opensquilla.skills.bundled.AwesomeWebpageMetaSkill.scripts"
+
+
+def _frontmatter() -> dict:
+    text = SKILL_MD.read_text(encoding="utf-8")
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n", text, re.DOTALL)
+    assert match is not None
+    data = yaml.safe_load(match.group(1))
+    assert isinstance(data, dict)
+    return data
+
+
+def test_awesome_webpage_meta_skill_loads_and_references_fixed_skills(tmp_path: Path) -> None:
+    loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
+    loader.invalidate_cache()
+
+    spec = loader.get_by_name("AwesomeWebpageMetaSkill")
+    assert spec is not None
+    plan = parse_meta_plan(spec)
+    assert plan is not None
+    assert plan.final_text_mode == "step:delivery_guide"
+
+    refs = {step.skill for step in plan.steps if step.kind in {"agent", "skill_exec"}}
+    assert {
+        "awesome-webpage-research",
+        "web-search",
+        "html-coder",
+        "nano-banana-pro-openrouter",
+        "audio-cog",
+        "openrouter-video-generator",
+        "filesystem",
+    }.issubset(refs)
+    assert "awesome-webpage-generator" not in refs
+    assert "deep-research" not in refs
+
+    assert loader.get_by_name("web-search-cn") is None
+    assert loader.get_by_name("audio") is None
+    assert loader.get_by_name("awesome-webpage-generator") is None
+    html_coder = loader.get_by_name("html-coder")
+    assert html_coder is not None
+    assert html_coder.provenance.origin == "clawhub-mit0"
+    mini_research = loader.get_by_name("awesome-webpage-research")
+    assert mini_research is not None
+    assert mini_research.user_invocable is False
+    assert mini_research.disable_model_invocation is True
+    video_generator = loader.get_by_name("openrouter-video-generator")
+    assert video_generator is not None
+    assert video_generator.user_invocable is False
+    assert video_generator.disable_model_invocation is True
+    filesystem = loader.get_by_name("filesystem")
+    assert filesystem is not None
+    assert filesystem.metadata is not None
+    assert filesystem.metadata.requires is not None
+    assert filesystem.metadata.requires.bins == []
+
+
+def test_audio_cog_is_openrouter_compatible_without_cellcog_key(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    monkeypatch.delenv("CELLCOG_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+    loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
+    loader.invalidate_cache()
+
+    spec = loader.get_by_name("audio-cog")
+    assert spec is not None
+    assert spec.metadata is not None
+    assert spec.metadata.requires is not None
+    assert "CELLCOG_API_KEY" not in spec.metadata.requires.env
+    assert check_eligibility(spec, EligibilityContext.auto())
+
+
+def test_awesome_webpage_config_contract_keeps_runtime_values_in_config() -> None:
+    fm = _frontmatter()
+    cfg = fm["config"]["awesome_webpage"]
+
+    assert cfg["provider"] == "openrouter"
+    assert cfg["openrouter"]["api_key"] is None
+    assert cfg["openrouter"]["api_key_env"] == "OPENROUTER_API_KEY"
+    assert set(cfg["openrouter"]["models"]) == {
+        "page_generation",
+        "image_generation",
+        "audio_generation",
+        "video_generation",
+    }
+    assert cfg["openrouter"]["models"]["page_generation"] == "moonshotai/kimi-k2.6"
+    assert cfg["openrouter"]["models"]["image_generation"] == (
+        "google/gemini-3-pro-image-preview"
+    )
+    assert cfg["openrouter"]["models"]["audio_generation"] == "openai/gpt-audio-mini"
+    assert cfg["openrouter"]["models"]["video_generation"] == (
+        "bytedance/seedance-2.0-fast"
+    )
+    assert cfg["output_dir"] == "{{ inputs.workspace_dir }}/awesome-webpage-output"
+    assert "media_strategy" in cfg
+
+    clawhub = cfg["clawhub_skills"]
+    assert clawhub["web_search"]["url"] == "https://clawhub.ai/billyutw/web-search"
+    assert "web_search_cn" not in clawhub
+    assert clawhub["image_generation"]["url"] == "https://clawhub.ai/skills/nano-banana-pro-openrouter"
+    assert clawhub["image_generation"]["skill"] == "nano-banana-pro-openrouter"
+    assert clawhub["image_generation"]["opensquilla_compatibility"] == (
+        "deterministic-skill-exec"
+    )
+    assert clawhub["audio_generation"]["url"] == "https://clawhub.ai/skills/audio-cog"
+    assert clawhub["audio_generation"]["opensquilla_compatibility"] == (
+        "openrouter-config-first"
+    )
+    assert clawhub["video_generation"]["skill"] == "openrouter-video-generator"
+    assert clawhub["webpage_generation"]["skill"] == "html-coder"
+    assert clawhub["webpage_generation"]["url"] == "https://clawhub.ai/jhauga/html-coder"
+    assert clawhub["webpage_generation"]["opensquilla_compatibility"] == "scoped-agent"
+    assert clawhub["filesystem"]["url"] == "https://clawhub.ai/gtrusler/clawdbot-filesystem"
+
+
+def test_awesome_webpage_media_strategy_covers_video_and_required_modalities() -> None:
+    fm = _frontmatter()
+    cfg = fm["config"]["awesome_webpage"]
+    assert cfg["media_strategy"]["default_modalities"] == ["text", "images", "audio", "video"]
+    assert cfg["media_strategy"]["search_modalities"] == ["images"]
+    assert cfg["media_strategy"]["direct_aigc_modalities"] == ["audio", "video"]
+    assert cfg["media_strategy"]["confirmation_steps"] == [
+        "ask_images",
+        "ask_audio",
+        "ask_video",
+        "ask_style",
+    ]
+    assert cfg["media_strategy"]["aigc_policy"] == "search_images_direct_generate_audio_video"
+
+    steps = {step["id"]: step for step in fm["composition"]["steps"]}
+    assert steps["ask_images"]["kind"] == "user_input"
+    assert steps["ask_audio"]["kind"] == "user_input"
+    assert steps["ask_video"]["kind"] == "user_input"
+    assert steps["ask_style"]["kind"] == "user_input"
+    assert steps["ask_images"]["depends_on"] == ["requirement_framing"]
+    assert steps["ask_audio"]["depends_on"] == ["ask_images"]
+    assert steps["ask_video"]["depends_on"] == ["ask_audio"]
+    assert steps["ask_style"]["depends_on"] == ["ask_video"]
+    assert steps["ask_images"]["clarify"]["fields"][0]["name"] == "include_images"
+    assert steps["ask_images"]["clarify"]["fields"][0]["choices"] == ["YES", "NO"]
+    assert steps["ask_audio"]["clarify"]["fields"][0]["name"] == "include_audio"
+    assert steps["ask_audio"]["clarify"]["fields"][0]["choices"] == ["YES", "NO"]
+    assert steps["ask_video"]["clarify"]["fields"][0]["name"] == "include_video"
+    assert steps["ask_video"]["clarify"]["fields"][0]["choices"] == ["YES", "NO"]
+    assert steps["ask_style"]["clarify"]["fields"][0]["name"] == "visual_style"
+    assert steps["deep_research"]["depends_on"] == [
+        "requirement_framing",
+        "ask_images",
+        "ask_audio",
+        "ask_video",
+        "ask_style",
+    ]
+
+    media_strategy = steps["media_strategy"]
+    assert set(media_strategy["output_choices"]) == {"IMAGE_SEARCH_READY", "NEEDS_AIGC_IMAGE"}
+    assert "Use the confirmed interactive choices as the source of truth" in (
+        media_strategy["with"]["text"]
+    )
+    assert "Search is image-only" in media_strategy["with"]["text"]
+    assert "Audio and video are direct AIGC modalities" in media_strategy["with"]["text"]
+    assert "Do not search for audio or video" in steps["media_search"]["with"]["query"]
+    assert "at most 2 `web_search` calls" in steps["media_search"]["with"]["query"]
+    assert "NO_USABLE_IMAGE_CANDIDATES" in steps["media_search"]["with"]["query"]
+    assert steps["media_slots_normalize"]["kind"] == "tool_call"
+    assert steps["media_slots_normalize"]["depends_on"] == ["page_outline"]
+    assert steps["media_slots_normalize"]["tool_args"]["command"].strip() == (
+        f"python -m {AWESOME_MODULE}.media_slots_normalize"
+    )
+    assert steps["media_search"]["depends_on"] == ["media_slots_normalize"]
+    assert "outputs.media_slots_normalize | truncate(3500)" in (
+        steps["media_search"]["with"]["query"]
+    )
+    assert "include_images" in steps["media_search"]["when"]
+    assert "media_search_cn" not in steps
+
+    assert steps["media_strategy"]["depends_on"] == ["media_search", "media_slots_normalize"]
+    assert steps["video_aigc"]["skill"] == "openrouter-video-generator"
+    assert steps["audio_script"]["kind"] == "llm_chat"
+    assert steps["audio_script"]["depends_on"] == [
+        "requirement_framing",
+        "page_outline",
+        "media_slots_normalize",
+    ]
+    audio_script_task = steps["audio_script"]["with"]["task"]
+    assert "spoken text only" in audio_script_task
+    assert "我明白了" in audio_script_task
+    assert "outputs.media_slots_normalize | truncate(2200)" in audio_script_task
+    assert steps["audio_aigc"]["kind"] == "skill_exec"
+    assert steps["video_aigc"]["kind"] == "skill_exec"
+    assert steps["audio_aigc"]["depends_on"] == ["audio_script"]
+    assert "payload" in steps["audio_aigc"]["with"]
+    assert "outputs.audio_script | tojson" in steps["audio_aigc"]["with"]["payload"]
+    assert "Generate the narration" not in str(steps["audio_aigc"]["with"])
+    assert steps["video_aigc"]["depends_on"] == ["page_outline"]
+    assert "outputs.media_strategy" not in steps["audio_aigc"]["when"]
+    assert "outputs.media_strategy" not in steps["video_aigc"]["when"]
+    image_aigc_when = steps["image_aigc"]["when"]
+    assert "outputs.media_strategy == 'NEEDS_AIGC_IMAGE'" in image_aigc_when
+    assert "IMAGE_DOWNLOAD_INCOMPLETE:" in image_aigc_when
+    assert "'IMAGE_READY:' not in outputs.get('image_download', '')" in image_aigc_when
+    assert "include_video" in steps["video_aigc"]["when"]
+    assert "include_audio" in steps["audio_aigc"]["when"]
+    assert "include_images" in steps["image_aigc"]["when"]
+    assert "video_aigc" not in steps["webpage_generation"]["depends_on"]
+    assert "media_slots_normalize" in steps["webpage_generation"]["depends_on"]
+    assert "media_manifest_normalize" not in steps["webpage_generation"]["depends_on"]
+    assert "media_assets_collect" in steps["webpage_generation"]["depends_on"]
+    assert steps["webpage_generation_retry"]["depends_on"] == [
+        "webpage_generation",
+        "media_slots_normalize",
+    ]
+    assert steps["webpage_generation_retry"]["when"] == (
+        "not outputs.get('webpage_generation', '').strip()"
+    )
+    assert steps["webpage_write"]["depends_on"] == [
+        "webpage_generation",
+        "webpage_generation_retry",
+    ]
+    assert steps["webpage_write"]["tool_args"]["env"]["WEBPAGE_SOURCE_JSON"] == (
+        "{{ (outputs.get('webpage_generation_retry', '') or outputs.webpage_generation) | tojson }}"
+    )
+
+    assert "project_slug" in steps
+    project_slug = steps["project_slug"]
+    assert project_slug["kind"] == "llm_chat"
+    assert project_slug["depends_on"] == ["requirement_framing"]
+    assert "project_slug" in steps["page_outline"]["depends_on"]
+    slug_task = project_slug["with"]["task"]
+    assert "lowercase ASCII letters" in slug_task
+    assert "max 40 characters" in slug_task
+    assert "If you cannot derive a meaningful slug, output `webpage`" in slug_task
+
+    assert "page_outline" in steps
+    outline_task = steps["page_outline"]["with"]["task"]
+    assert "slot_id" in outline_task
+    assert "Do NOT specify filenames" in outline_task or "No filenames" in outline_task
+    assert "load_bearing" in outline_task
+
+    assert "page_layout" not in steps
+    assert "layout_media_manifest_normalize" not in steps
+    assert "media_manifest_normalize" not in steps
+
+    assert "media_assets_collect" in steps
+    manifest = steps["media_assets_collect"]
+    assert manifest["kind"] == "tool_call"
+    assert manifest["tool"] == "exec_command"
+    assert set(manifest["depends_on"]) == {
+        "image_download",
+        "image_aigc",
+        "audio_aigc",
+        "video_aigc",
+    }
+    manifest_command = manifest["tool_args"]["command"]
+    assert manifest_command.strip() == (
+        f"python -m {AWESOME_MODULE}.media_assets_collect"
+    )
+    assert "PROJECT_ROOT" in manifest["tool_args"]["env"]
+
+    assert "image_download" in steps
+    image_download = steps["image_download"]
+    assert image_download["kind"] == "agent"
+    assert image_download["skill"] == "filesystem"
+    assert image_download["depends_on"] == ["media_strategy", "media_slots_normalize"]
+    assert "outputs.media_strategy == 'IMAGE_SEARCH_READY'" in image_download["when"]
+    assert "include_images" in image_download["when"]
+    assert "image_download" in steps["media_assets_collect"]["depends_on"]
+    assert "image_download" not in steps["webpage_generation"]["depends_on"]
+    assert "curl -L --fail" in image_download["with"]["task"]
+    assert "Do not call web_search" in image_download["with"]["task"]
+    download_task = image_download["with"]["task"]
+    assert "MEDIA_SLOTS_JSON" in download_task
+    assert "outputs.media_slots_normalize | truncate(3500)" in download_task
+    assert "shopping list" in download_task
+    assert "slot_id as filename" in download_task
+    assert "IMAGE_DOWNLOAD_INCOMPLETE:" in download_task
+    assert "downstream image_aigc" in download_task
+
+    assert steps["image_aigc"]["depends_on"] == [
+        "media_strategy",
+        "image_download",
+        "media_slots_normalize",
+    ]
+    image_payload = steps["image_aigc"]["with"]["payload"]
+    assert "media_slots" in image_payload
+    assert "page_outline" in image_payload
+    assert "image_download" in image_payload
+    assert "include_images" in image_payload
+    assert "visual_style" in image_payload
+
+
+def test_image_aigc_runs_when_search_download_produces_no_images() -> None:
+    fm = _frontmatter()
+    steps = {step["id"]: step for step in fm["composition"]["steps"]}
+    when = steps["image_aigc"]["when"]
+    inputs = {
+        "collected": {
+            "ask_images": {"include_images": "YES"},
+        },
+    }
+
+    assert evaluate_when(
+        when,
+        inputs=inputs,
+        outputs={
+            "media_strategy": "NEEDS_AIGC_IMAGE",
+            "image_download": "",
+        },
+    )
+    assert evaluate_when(
+        when,
+        inputs=inputs,
+        outputs={
+            "media_strategy": "IMAGE_SEARCH_READY",
+            "image_download": "downloaded=[]\nall candidates were text/html",
+        },
+    )
+    assert evaluate_when(
+        when,
+        inputs=inputs,
+        outputs={
+            "media_strategy": "IMAGE_SEARCH_READY",
+            "image_download": (
+                'IMAGE_READY: {"local_path":"project/assets/images/hero.jpg"}\n'
+                'IMAGE_DOWNLOAD_INCOMPLETE: {"unfilled_slot_ids":["turtle"]}'
+            ),
+        },
+    )
+    assert not evaluate_when(
+        when,
+        inputs=inputs,
+        outputs={
+            "media_strategy": "IMAGE_SEARCH_READY",
+            "image_download": (
+                'IMAGE_READY: {"local_path":"project/assets/images/hero.jpg"}'
+            ),
+        },
+    )
+    assert not evaluate_when(
+        when,
+        inputs={"collected": {"ask_images": {"include_images": "NO"}}},
+        outputs={
+            "media_strategy": "IMAGE_SEARCH_READY",
+            "image_download": "",
+        },
+    )
+
+
+def test_media_slots_normalize_synthesizes_image_slots_when_outline_has_no_slots(
+    tmp_path: Path,
+) -> None:
+    fm = _frontmatter()
+    steps = {step["id"]: step for step in fm["composition"]["steps"]}
+    command = steps["media_slots_normalize"]["tool_args"]["command"]
+    env = os.environ.copy()
+    env.update(
+        {
+            "PAGE_OUTLINE": """
+            | section_id | title | purpose |
+            | --- | --- | --- |
+            | hero | 海洋塑料污染 | establish urgency |
+            | impact | 食物链影响 | explain microplastics |
+            """,
+            "REQUIREMENT_FRAMING": "主题: 海洋塑料污染科普网页，包含音频、视频和图片",
+            "INCLUDE_IMAGE": "YES",
+            "INCLUDE_AUDIO": "YES",
+            "INCLUDE_VIDEO": "YES",
+            "VISUAL_STYLE": "纪录片风，清晰可信",
+        }
+    )
+
+    result = subprocess.run(
+        command,
+        shell=True,
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "MEDIA_SLOTS_READY"
+    assert payload["counts"]["image"] >= 2
+    assert payload["counts"]["audio"] == 1
+    assert payload["counts"]["video"] == 1
+    image_slots = [slot for slot in payload["slots"] if slot["modality"] == "image"]
+    assert {slot["slot_id"] for slot in image_slots} >= {
+        "hero-visual",
+        "supporting-visual",
+    }
+    assert all(slot["source"] == "synthesized" for slot in image_slots)
+
+
+def test_awesome_webpage_media_entrypoints_are_code_backed(tmp_path: Path) -> None:
+    loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
+    loader.invalidate_cache()
+
+    audio = loader.get_by_name("audio-cog")
+    video = loader.get_by_name("openrouter-video-generator")
+
+    assert audio is not None
+    assert audio.entrypoint is not None
+    assert audio.entrypoint["command"] == "python {baseDir}/scripts/openrouter_audio.py"
+    assert audio.entrypoint["parse"] == "text"
+
+    assert video is not None
+    assert video.entrypoint is not None
+    assert video.entrypoint["command"] == (
+        "python {baseDir}/scripts/openrouter_video.py"
+    )
+    assert video.entrypoint["parse"] == "text"
+
+
+def test_audio_cog_json_payload_builds_exact_transcript_messages() -> None:
+    script = BUNDLED / "audio-cog" / "scripts" / "openrouter_audio.py"
+    spec = importlib.util.spec_from_file_location("openrouter_audio", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    messages, preview = module._audio_messages(
+        json.dumps({"script": "雨水花园会截留雨水，净化径流，并滋养社区绿地。"}, ensure_ascii=False)
+    )
+
+    assert preview == "雨水花园会截留雨水，净化径流，并滋养社区绿地。"
+    assert messages[0]["role"] == "system"
+    assert "Do not acknowledge" in messages[0]["content"]
+    assert "Speak this exact narration transcript and no other words" in messages[1]["content"]
+    assert "雨水花园会截留雨水" in messages[1]["content"]
+
+
+def test_openrouter_media_entrypoints_return_config_needed_without_key(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    audio_script = BUNDLED / "audio-cog" / "scripts" / "openrouter_audio.py"
+    audio = subprocess.run(
+        [
+            sys.executable,
+            str(audio_script),
+            "--model",
+            "openai/gpt-audio-mini",
+            "--output-dir",
+            str(tmp_path / "audio"),
+            "--filename",
+            "sample.wav",
+        ],
+        input=b"short narration",
+        capture_output=True,
+        check=False,
+    )
+    assert audio.returncode == 0
+    assert "AUDIO_CONFIG_NEEDED" in audio.stdout.decode("utf-8")
+    assert not audio.stderr
+
+    video_script = (
+        BUNDLED
+        / "openrouter-video-generator"
+        / "scripts"
+        / "openrouter_video.py"
+    )
+    video = subprocess.run(
+        [
+            sys.executable,
+            str(video_script),
+            "--model",
+            "bytedance/seedance-2.0-fast",
+            "--output-dir",
+            str(tmp_path / "video"),
+            "--filename",
+            "sample.mp4",
+        ],
+        input=b"short video prompt",
+        capture_output=True,
+        check=False,
+    )
+    assert video.returncode == 0
+    assert "VIDEO_CONFIG_NEEDED" in video.stdout.decode("utf-8")
+    assert not video.stderr
+
+
+def test_awesome_webpage_steps_pass_resolved_output_dir() -> None:
+    text = SKILL_MD.read_text(encoding="utf-8")
+    assert "{{ inputs.workspace_dir }}/awesome-webpage-output" in text
+    assert "must not be reported as CONFIG_NEEDED" in text
+    assert "do not install another filesystem skill" in text
+    assert "does not mean\n          the user does not want that media modality" in text
+    assert "音频不走素材搜索" in text
+    assert "视频不走素材搜索" in text
+
+
+def test_webpage_generation_is_scoped_to_core_file_authoring() -> None:
+    fm = _frontmatter()
+    steps = {step["id"]: step for step in fm["composition"]["steps"]}
+    webpage_generation = steps["webpage_generation"]
+    task = webpage_generation["with"]["task"]
+
+    assert webpage_generation["kind"] == "agent"
+    assert webpage_generation["skill"] == "html-coder"
+    assert webpage_generation["with"]["mode"] == "generate"
+    assert webpage_generation["depends_on"] == [
+        "requirement_framing",
+        "deep_research",
+        "page_outline",
+        "media_slots_normalize",
+        "media_assets_collect",
+    ]
+    assert "Produce source text only" in task
+    assert "Ignore\nhtml-coder's default Markdown/code-block output format" in task
+    assert "professional HTML/CSS quality standard" in task
+    assert "Author only the contents for project/index.html, project/style.css" in (
+        task
+    )
+    assert "Do not download, search, generate, copy, move, delete, package, validate, repair" in (
+        task
+    )
+    assert "media_assets_collect.assets[]" in task
+    assert "Design-quality contract, adapted from html-coder" in task
+    assert "https://clawhub.ai/jhauga/html-coder" in task
+    assert "<audio controls>" in task
+    assert "Place audio controls according to the audio slot placement" in task
+    assert "footer-only/end-of-page" in task
+    assert "gallery" in task
+    assert "page_layout" not in task
+    assert "layout manifest" not in task
+    assert "Do not scan raw" in task
+    assert "project/assets/..." in task
+    assert "research_report" not in webpage_generation["with"]
+    assert "framed_requirements" not in webpage_generation["with"]
+    assert "outputs.page_outline | truncate(1500)" in task
+    assert "outputs.media_slots_normalize | truncate(3500)" in task
+    assert "outputs.media_assets_collect | truncate(6000)" in task
+    assert "outputs.media_manifest_normalize | truncate(5000)" not in task
+    assert "outputs.media_search | truncate" not in task
+    assert "outputs.media_search_cn | truncate" not in task
+    assert "outputs.image_download | truncate" not in task
+    assert "outputs.image_aigc | truncate" not in task
+    assert "outputs.audio_aigc | truncate" not in task
+    assert "outputs.video_aigc | truncate" not in task
+
+    retry = steps["webpage_generation_retry"]
+    retry_task = retry["with"]["task"]
+    assert retry["kind"] == "llm_chat"
+    assert "primary source authoring step returned" in retry["with"]["system"]
+    assert "Output JSON only" in retry_task
+    assert "Do not call tools" in retry_task
+    assert "Do not invent pending audio/video" in retry_task
+    assert "media_slots_normalize" in retry_task
+    assert "footer-only/end-of-page" in retry_task
+    assert "outputs.page_outline | truncate(900)" in retry_task
+    assert "outputs.media_slots_normalize | truncate(2200)" in retry_task
+    assert "outputs.media_assets_collect | truncate(3500)" in retry_task
+    assert "outputs.media_manifest_normalize | truncate" not in retry_task
+
+
+def test_webpage_write_accepts_prose_wrapped_fenced_json(tmp_path: Path) -> None:
+    fm = _frontmatter()
+    steps = {step["id"]: step for step in fm["composition"]["steps"]}
+    command = steps["webpage_write"]["tool_args"]["command"]
+
+    project_root = tmp_path / "awesome-webpage-output" / "demo"
+    source = {
+        "index_html": (
+            '<main><h1>Demo</h1><img src="assets/images/hero.png">'
+            '<audio controls src="assets/audio/narration.wav"></audio>'
+            '<video controls src="assets/video/intro.mp4"></video></main>'
+        ),
+        "style_css": "body{margin:0}.hero{display:grid}",
+        "script_js": "document.documentElement.dataset.ready = 'true';",
+        "summary": "demo page",
+    }
+    wrapped_source = (
+        "Here is the requested source JSON:\n```json\n"
+        + json.dumps(source)
+        + "\n```\nDone."
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "WORKSPACE_DIR": str(tmp_path),
+            "PROJECT_ROOT": str(project_root),
+            "WEBPAGE_SOURCE_JSON": json.dumps(wrapped_source),
+        }
+    )
+
+    result = subprocess.run(
+        command,
+        shell=True,
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert result.returncode == 0, output
+    assert "WEBPAGE_FILES_WRITTEN" in output
+    project_dir = project_root / "project"
+    assert (project_dir / "index.html").read_text(encoding="utf-8") == source["index_html"]
+    assert (project_dir / "style.css").read_text(encoding="utf-8") == source["style_css"]
+    assert (project_dir / "script.js").read_text(encoding="utf-8") == source["script_js"]
+
+
+def test_awesome_webpage_media_bind_validate_is_deterministic() -> None:
+    fm = _frontmatter()
+    steps = {step["id"]: step for step in fm["composition"]["steps"]}
+    assert "asset_usage_repair" not in steps
+    assert "media_completeness_validate" not in steps
+
+    bind = steps["media_bind_validate"]
+    assert bind["kind"] == "tool_call"
+    assert bind["tool"] == "exec_command"
+    assert bind["depends_on"] == ["webpage_write", "media_assets_collect"]
+    assert "MEDIA_MANIFEST" not in bind["tool_args"]["env"]
+    command = bind["tool_args"]["command"]
+    assert command.strip() == f"python -m {AWESOME_MODULE}.media_bind_validate"
+    assert "OPENROUTER_API_KEY" not in command
+
+    assert steps["quick_validate"]["depends_on"] == ["media_bind_validate"]
+    assert "outputs.media_bind_validate | truncate(3500)" in (
+        steps["quick_validate"]["with"]["task"]
+    )
+    assert "outputs.media_bind_validate | truncate(5000)" in (
+        steps["delivery_guide"]["with"]["task"]
+    )
+
+
+def _run_media_bind_step(
+    tmp_path: Path,
+    *,
+    assets: list[dict],
+    index_html: str,
+    include_image: str = "YES",
+    include_audio: str = "YES",
+    include_video: str = "YES",
+) -> subprocess.CompletedProcess[bytes]:
+    fm = _frontmatter()
+    steps = {step["id"]: step for step in fm["composition"]["steps"]}
+    command = steps["media_bind_validate"]["tool_args"]["command"]
+
+    project_root = tmp_path / "awesome-webpage-output" / "demo"
+    project_dir = project_root / "project"
+    (project_dir / "assets" / "images").mkdir(parents=True)
+    (project_dir / "assets" / "audio").mkdir(parents=True)
+    (project_dir / "assets" / "video").mkdir(parents=True)
+    (project_dir / "index.html").write_text(index_html, encoding="utf-8")
+    (project_dir / "style.css").write_text("body{margin:0}", encoding="utf-8")
+    (project_dir / "script.js").write_text("console.log('ok')", encoding="utf-8")
+    ready_lines = {"image": [], "audio": [], "video": []}
+    for asset in assets:
+        src = str(asset.get("src") or "")
+        if src:
+            target = project_dir / src
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"media-bytes")
+            kind = str(asset.get("kind"))
+            ready_lines[kind].append(
+                f'{kind.upper()}_READY: '
+                + json.dumps(
+                    {
+                        "local_path": f"project/{src}",
+                        "mime": asset.get("mime"),
+                        "subject": asset.get("subject", src),
+                    },
+                    separators=(",", ":"),
+                )
+            )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PROJECT_ROOT": str(project_root),
+            "IMAGE_DOWNLOAD": "\n".join(ready_lines["image"]),
+            "IMAGE_AIGC": "",
+            "AUDIO_AIGC": "\n".join(ready_lines["audio"]),
+            "VIDEO_AIGC": "\n".join(ready_lines["video"]),
+            "INCLUDE_IMAGE": include_image,
+            "INCLUDE_AUDIO": include_audio,
+            "INCLUDE_VIDEO": include_video,
+        }
+    )
+    return subprocess.run(
+        command,
+        shell=True,
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_media_bind_validate_passes_when_requested_media_is_bound(
+    tmp_path: Path,
+) -> None:
+    assets = [
+        {"kind": "image", "src": "assets/images/hero.png"},
+        {"kind": "audio", "src": "assets/audio/narration.wav"},
+        {"kind": "video", "src": "assets/video/intro.mp4"},
+    ]
+    result = _run_media_bind_step(
+        tmp_path,
+        assets=assets,
+        index_html=(
+            '<main><img src="assets/images/hero.png">'
+            '<audio controls src="assets/audio/narration.wav"></audio>'
+            '<video controls src="assets/video/intro.mp4"></video></main>'
+        ),
+    )
+
+    assert result.returncode == 0
+    assert "MEDIA_BIND_OK" in result.stdout.decode("utf-8")
+
+
+def test_media_bind_validate_repairs_when_requested_audio_is_unbound(
+    tmp_path: Path,
+) -> None:
+    assets = [
+        {"kind": "image", "src": "assets/images/hero.png"},
+        {"kind": "audio", "src": "assets/audio/narration.wav"},
+        {"kind": "video", "src": "assets/video/intro.mp4"},
+    ]
+    result = _run_media_bind_step(
+        tmp_path,
+        assets=assets,
+        index_html=(
+            '<main><img src="assets/images/hero.png">'
+            '<video controls src="assets/video/intro.mp4"></video></main>'
+        ),
+    )
+
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert result.returncode == 0
+    assert "MEDIA_BIND_OK" in output
+    index_html = (
+        tmp_path
+        / "awesome-webpage-output"
+        / "demo"
+        / "project"
+        / "index.html"
+    ).read_text(encoding="utf-8")
+    assert '<audio controls preload="metadata" src="assets/audio/narration.wav">' in index_html
+
+
+def test_media_bind_validate_fails_when_requested_audio_has_no_ready_asset(
+    tmp_path: Path,
+) -> None:
+    result = _run_media_bind_step(
+        tmp_path,
+        assets=[
+            {"kind": "image", "src": "assets/images/hero.png"},
+            {"kind": "video", "src": "assets/video/intro.mp4"},
+        ],
+        index_html=(
+            '<main><img src="assets/images/hero.png">'
+            '<video controls src="assets/video/intro.mp4"></video></main>'
+        ),
+    )
+
+    output = result.stdout.decode("utf-8") + result.stderr.decode("utf-8")
+    assert result.returncode != 0
+    assert "MEDIA_BIND_FAILED" in output
+    assert "requested_modality_has_no_ready_asset" in output
+
+
+def test_media_bind_validate_skips_modalities_user_declined(
+    tmp_path: Path,
+) -> None:
+    result = _run_media_bind_step(
+        tmp_path,
+        assets=[],
+        index_html="<main><p>text-only requested</p></main>",
+        include_image="NO",
+        include_audio="NO",
+        include_video="NO",
+    )
+
+    assert result.returncode == 0
+    assert "MEDIA_BIND_OK" in result.stdout.decode("utf-8")
+
+
+def test_awesome_webpage_rendered_steps_resolve_output_dir(tmp_path: Path) -> None:
+    loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
+    loader.invalidate_cache()
+    spec = loader.get_by_name("AwesomeWebpageMetaSkill")
+    assert spec is not None
+    plan = parse_meta_plan(spec)
+    assert plan is not None
+
+    inputs = {
+        "user_message": "请使用 AwesomeWebpageMetaSkill。主题：海洋塑料污染",
+        "language_instruction": "Output language rule: Chinese.",
+        "workspace_dir": "/tmp/osq-workspace",
+        "collected": {
+            "ask_images": {"include_images": "YES"},
+            "ask_audio": {"include_audio": "YES"},
+            "ask_video": {"include_video": "YES"},
+            "ask_style": {"visual_style": "纪录片风，清晰、可信、适合科普"},
+        },
+    }
+    outputs = {
+        key: key
+        for key in [
+            "requirement_framing",
+            "project_slug",
+            "ask_images",
+            "ask_audio",
+            "ask_video",
+            "ask_style",
+            "deep_research",
+            "page_outline",
+            "media_slots_normalize",
+            "media_search",
+            "media_strategy",
+            "image_download",
+            "image_aigc",
+            "audio_script",
+            "audio_aigc",
+            "video_aigc",
+            "media_assets_collect",
+            "webpage_generation",
+            "webpage_generation_retry",
+            "webpage_write",
+            "media_bind_validate",
+            "quick_validate",
+        ]
+    }
+
+    for step_id in [
+        "requirement_framing",
+        "quick_validate",
+        "delivery_guide",
+    ]:
+        step = next(step for step in plan.steps if step.id == step_id)
+        rendered = render_with_args(step.with_args, inputs=inputs, outputs=outputs)
+        text = "\n".join(str(value) for value in rendered.values())
+        assert "/tmp/osq-workspace/awesome-webpage-output" in text
+
+    for step_id in ["quick_validate", "delivery_guide"]:
+        step = next(step for step in plan.steps if step.id == step_id)
+        rendered = render_with_args(step.with_args, inputs=inputs, outputs=outputs)
+        text = "\n".join(str(value) for value in rendered.values())
+        assert "/tmp/osq-workspace/awesome-webpage-output/project_slug" in text
+
+    for step_id in ["delivery_guide"]:
+        step = next(step for step in plan.steps if step.id == step_id)
+        rendered = render_with_args(step.with_args, inputs=inputs, outputs=outputs)
+        text = "\n".join(str(value) for value in rendered.values())
+        assert "/tmp/osq-workspace/awesome-webpage-output/project_slug/project" in text

--- a/tests/test_skills/test_awesome_webpage_meta_skill.py
+++ b/tests/test_skills/test_awesome_webpage_meta_skill.py
@@ -179,9 +179,12 @@ def test_awesome_webpage_media_strategy_covers_video_and_required_modalities() -
     )
     assert "Search is image-only" in media_strategy["with"]["text"]
     assert "Audio and video are direct AIGC modalities" in media_strategy["with"]["text"]
-    assert "Do not search for audio or video" in steps["media_search"]["with"]["query"]
-    assert "at most 2 `web_search` calls" in steps["media_search"]["with"]["query"]
-    assert "NO_USABLE_IMAGE_CANDIDATES" in steps["media_search"]["with"]["query"]
+    media_search_query = steps["media_search"]["with"]["query"]
+    assert "Do not search for audio or video" in media_search_query
+    assert "at most 2 `web_search` calls" in media_search_query
+    assert "arguments `query` and `max_results=6`" in media_search_query
+    assert "type=images" not in media_search_query
+    assert "NO_USABLE_IMAGE_CANDIDATES" in media_search_query
     assert steps["media_slots_normalize"]["kind"] == "tool_call"
     assert steps["media_slots_normalize"]["depends_on"] == ["page_outline"]
     assert steps["media_slots_normalize"]["tool_args"]["command"].strip() == (

--- a/tests/test_skills/test_loader_list_meta_specs.py
+++ b/tests/test_skills/test_loader_list_meta_specs.py
@@ -37,6 +37,7 @@ def test_list_meta_specs_includes_compiled_meta_sop(loader: SkillLoader) -> None
 def test_list_meta_specs_includes_known_meta_bundles(loader: SkillLoader) -> None:
     names = {s.name for s in loader.list_meta_specs()}
     assert names == {
+        "AwesomeWebpageMetaSkill",
         "meta-competitive-intel",
         "meta-daily-operator-brief",
         "meta-document-to-decision",

--- a/tests/test_skills/test_meta_dsl_extensions.py
+++ b/tests/test_skills/test_meta_dsl_extensions.py
@@ -82,6 +82,68 @@ async def test_skill_exec_pipes_rendered_stdin_to_subprocess(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
+async def test_skill_exec_renders_entrypoint_env_to_subprocess(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = tmp_path / "env_probe.py"
+    script.write_text(
+        "import os\n"
+        "print(os.environ.get('CUSTOM_OPENROUTER_KEY', ''))\n",
+        encoding="utf-8",
+    )
+    skill = SkillSpec(
+        name="env-skill",
+        description="d",
+        layer=SkillLayer.BUNDLED,
+        always=False,
+        triggers=[],
+        content="x",
+        kind="skill",
+        base_dir=str(tmp_path),
+        entrypoint={
+            "command": "python {baseDir}/env_probe.py",
+            "args": [],
+            "env": {
+                "{{ with.api_key_env | default('OPENROUTER_API_KEY') }}": (
+                    "{{ with.api_key | default('') }}"
+                )
+            },
+            "parse": "text",
+        },
+    )
+    plan_spec = _meta_spec(
+        [
+            {
+                "id": "p",
+                "kind": "skill_exec",
+                "skill": "env-skill",
+                "with": {
+                    "api_key": "sk-rendered",
+                    "api_key_env": "CUSTOM_OPENROUTER_KEY",
+                },
+            },
+        ],
+    )
+    plan = parse_meta_plan(plan_spec)
+    assert plan is not None
+
+    async def runner(_s: str, _u: str) -> AsyncIterator[AgentEvent]:
+        raise AssertionError("no sub-Agent")
+        yield  # pragma: no cover
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-parent")
+    orch = MetaOrchestrator(agent_runner=runner, skill_loader=_Loader([skill]))
+    final: MetaResult | None = None
+    async for ev in orch.iter_events(MetaMatch(plan=plan, inputs={})):
+        if isinstance(ev, MetaResult):
+            final = ev
+
+    assert final is not None and final.ok, final.error if final else "no result"
+    assert final.step_outputs["p"] == "sk-rendered"
+
+
+@pytest.mark.asyncio
 async def test_skill_exec_assemble_writes_template_files_before_exec(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_skills/test_meta_mvp.py
+++ b/tests/test_skills/test_meta_mvp.py
@@ -1451,6 +1451,52 @@ async def test_orchestrator_skill_exec_rejects_cwd_outside_workspace(
 
 
 @pytest.mark.asyncio
+async def test_orchestrator_skill_exec_creates_missing_workspace_dir(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / "cwd_skill"
+    skill_dir.mkdir()
+    script = skill_dir / "echo_cwd.py"
+    script.write_text(
+        "from pathlib import Path\n"
+        "print(Path.cwd())\n",
+        encoding="utf-8",
+    )
+
+    workspace = tmp_path / "missing" / "workspace"
+    assert not workspace.exists()
+
+    fake_spec = _make_skill_spec("cwd-skill", content="x")
+    fake_spec.base_dir = str(skill_dir)
+    fake_spec.entrypoint = {"command": "python {baseDir}/echo_cwd.py"}
+
+    plan_spec = _make_meta_spec(
+        composition={
+            "steps": [
+                {"id": "x", "kind": "skill_exec", "skill": "cwd-skill"},
+            ],
+        },
+    )
+    plan = parse_meta_plan(plan_spec)
+    assert plan is not None
+
+    async def runner(_s: str, _u: str) -> AsyncIterator[AgentEvent]:
+        raise AssertionError("no sub-Agent")
+        yield  # pragma: no cover
+
+    orch = MetaOrchestrator(
+        agent_runner=runner,
+        skill_loader=_FakeLoader([fake_spec]),
+        workspace_dir=str(workspace),
+    )
+    result = await orch.run(MetaMatch(plan=plan, inputs={}))
+
+    assert result.ok, result.error
+    assert workspace.exists()
+    assert Path(result.step_outputs["x"]) == workspace
+
+
+@pytest.mark.asyncio
 async def test_orchestrator_skill_exec_requires_entrypoint() -> None:
     """A skill with no entrypoint manifest cannot run as skill_exec."""
 

--- a/tests/test_skills/test_meta_mvp.py
+++ b/tests/test_skills/test_meta_mvp.py
@@ -522,6 +522,31 @@ async def test_meta_resolution_ignores_triggers_inside_pasted_webchat_dump() -> 
 
 
 @pytest.mark.asyncio
+async def test_meta_resolution_invokes_explicit_named_meta_skill_request() -> None:
+    spec = _make_meta_spec(
+        name="AwesomeWebpageMetaSkill",
+        composition={"steps": [{"id": "a", "skill": "summarize"}]},
+        triggers=["AwesomeWebpageMetaSkill"],
+        priority=50,
+    )
+    loader = _FakeLoader([spec])
+    ctx = SimpleNamespace(
+        message="invoke AwesomeWebpageMetaSkill to create a webpage",
+        semantic_message="invoke AwesomeWebpageMetaSkill to create a webpage",
+        system_prompt=("base prompt", ""),
+        metadata={"skill_loader": loader},
+    )
+
+    out = await meta_resolution(ctx)  # type: ignore[arg-type]
+
+    assert out.metadata["meta_match"].plan.name == "AwesomeWebpageMetaSkill"
+    assert out.metadata["meta_match_tool_choice"] == {
+        "type": "function",
+        "function": {"name": "meta_invoke"},
+    }
+
+
+@pytest.mark.asyncio
 async def test_meta_resolution_still_matches_current_cjk_intent() -> None:
     spec = _make_meta_spec(
         name="meta-household-calendar-test",

--- a/tests/test_skills/test_nano_banana_openrouter_image.py
+++ b/tests/test_skills/test_nano_banana_openrouter_image.py
@@ -205,3 +205,45 @@ def test_target_slots_does_not_synthesize_when_images_are_declined() -> None:
     )
 
     assert slots == []
+
+
+def test_decode_image_auth_stays_on_openrouter_origin(monkeypatch) -> None:
+    mod = _module()
+    opened_headers: list[dict[str, str]] = []
+
+    class FakeHeaders:
+        def get_content_type(self) -> str:
+            return "image/png"
+
+    class FakeResponse:
+        headers = FakeHeaders()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"image-bytes"
+
+    def fake_urlopen(req, timeout: float = 45.0):
+        del timeout
+        opened_headers.append({key.lower(): value for key, value in req.header_items()})
+        return FakeResponse()
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+
+    assert mod._decode_image(
+        "https://storage.example/image.png",
+        "sk-or-secret",
+        base_url="https://openrouter.ai/api/v1",
+    ) == ("image/png", b"image-bytes")
+    assert "authorization" not in opened_headers[-1]
+
+    assert mod._decode_image(
+        "https://openrouter.ai/api/v1/images/result.png",
+        "sk-or-secret",
+        base_url="https://openrouter.ai/api/v1",
+    ) == ("image/png", b"image-bytes")
+    assert opened_headers[-1]["authorization"] == "Bearer sk-or-secret"

--- a/tests/test_skills/test_nano_banana_openrouter_image.py
+++ b/tests/test_skills/test_nano_banana_openrouter_image.py
@@ -144,6 +144,38 @@ def test_target_slots_prefers_explicit_media_slots_json() -> None:
     ]
 
 
+def test_target_slots_accepts_exec_command_wrapped_media_slots_json() -> None:
+    mod = _module()
+    media_slots = json.dumps(
+        {
+            "slots": [
+                {
+                    "slot_id": "normalized-cn-visual",
+                    "modality": "图片",
+                    "subject": "规范化后的中文图片槽位",
+                }
+            ]
+        }
+    )
+
+    slots = mod._target_slots(
+        {
+            "media_slots": f"exit_code=0\n{media_slots}\n",
+            "page_outline": "no parseable image slot here",
+        },
+        6,
+    )
+
+    assert slots == [
+        {
+            "slot_id": "normalized-cn-visual",
+            "subject": "规范化后的中文图片槽位",
+            "prompt_hint": "",
+            "keywords": "",
+        }
+    ]
+
+
 def test_target_slots_synthesizes_fallback_when_requested_images_have_no_slots() -> None:
     mod = _module()
 

--- a/tests/test_skills/test_nano_banana_openrouter_image.py
+++ b/tests/test_skills/test_nano_banana_openrouter_image.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = (
+    REPO
+    / "src"
+    / "opensquilla"
+    / "skills"
+    / "bundled"
+    / "nano-banana-pro-openrouter"
+    / "scripts"
+    / "openrouter_image.py"
+)
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("openrouter_image", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extract_slots_keeps_field_block_contract() -> None:
+    mod = _module()
+
+    slots = mod._extract_slots(
+        """
+        slot_id: hero-visual
+        modality: image
+        subject: ocean plastic across a shoreline
+        prompt_hint: wide documentary photo
+        search_keywords: ocean plastic pollution
+
+        slot_id: narration
+        modality: audio
+        subject: short narration
+        """
+    )
+
+    assert slots == [
+        {
+            "slot_id": "hero-visual",
+            "subject": "ocean plastic across a shoreline",
+            "prompt_hint": "wide documentary photo",
+            "keywords": "ocean plastic pollution",
+        }
+    ]
+
+
+def test_extract_slots_reads_markdown_table_and_ignores_non_images() -> None:
+    mod = _module()
+
+    slots = mod._extract_slots(
+        """
+        | slot_id | modality | subject | prompt_hint | search_keywords |
+        | --- | --- | --- | --- | --- |
+        | hero | image | turtle near plastic | documentary hero | turtle plastic |
+        | narration | audio | spoken intro | warm narration | |
+        | impact-visual | image | microplastics | science diagram | microplastic |
+        | intro-video | video | quick explainer | motion | |
+        """
+    )
+
+    assert [slot["slot_id"] for slot in slots] == ["hero", "impact-visual"]
+    assert slots[0]["subject"] == "turtle near plastic"
+    assert slots[0]["prompt_hint"] == "documentary hero"
+    assert slots[0]["keywords"] == "turtle plastic"
+    assert slots[1]["subject"] == "microplastics"
+
+
+def test_extract_slots_reads_cjk_markdown_table_headers() -> None:
+    mod = _module()
+
+    slots = mod._extract_slots(
+        """
+        | 槽位 | 媒体类型 | 画面主题 | 描述 | 关键词 |
+        | --- | --- | --- | --- | --- |
+        | science-hero | 图片 | 海洋塑料污染主视觉 | 适合首屏 | 海洋 塑料 污染 |
+        | voiceover | 音频 | 旁白 | 60秒 | |
+        """
+    )
+
+    assert slots == [
+        {
+            "slot_id": "science-hero",
+            "subject": "海洋塑料污染主视觉",
+            "prompt_hint": "适合首屏",
+            "keywords": "海洋 塑料 污染",
+        }
+    ]
+
+
+def test_extract_slots_reads_inline_slot_lines() -> None:
+    mod = _module()
+
+    slots = mod._extract_slots(
+        "- slot_id: fallback-map, modality: image, subject: current cleanup hotspots"
+    )
+
+    assert slots[0]["slot_id"] == "fallback-map"
+
+
+def test_target_slots_prefers_explicit_media_slots_json() -> None:
+    mod = _module()
+
+    slots = mod._target_slots(
+        {
+            "media_slots": json.dumps(
+                {
+                    "slots": [
+                        {
+                            "slot_id": "hero-visual",
+                            "modality": "image",
+                            "subject": "ocean cleanup hero",
+                            "prompt_hint": "wide documentary photo",
+                            "search_keywords": ["ocean", "plastic"],
+                        },
+                        {
+                            "slot_id": "narration-audio",
+                            "modality": "audio",
+                            "subject": "voiceover",
+                        },
+                    ]
+                }
+            ),
+            "page_outline": "no parseable image slot here",
+        },
+        6,
+    )
+
+    assert slots == [
+        {
+            "slot_id": "hero-visual",
+            "subject": "ocean cleanup hero",
+            "prompt_hint": "wide documentary photo",
+            "keywords": "ocean plastic",
+        }
+    ]
+
+
+def test_target_slots_synthesizes_fallback_when_requested_images_have_no_slots() -> None:
+    mod = _module()
+
+    slots = mod._target_slots(
+        {
+            "requirement_framing": "主题: 海洋塑料污染科普网页",
+            "page_outline": "| section_id | title |\n| --- | --- |\n| hero | 海洋塑料污染 |",
+            "include_images": "YES",
+        },
+        6,
+    )
+
+    assert [slot["slot_id"] for slot in slots] == ["hero-visual", "supporting-visual"]
+    assert "海洋塑料污染" in slots[0]["subject"]
+
+
+def test_target_slots_does_not_synthesize_when_images_are_declined() -> None:
+    mod = _module()
+
+    slots = mod._target_slots(
+        {
+            "requirement_framing": "主题: text-only page",
+            "page_outline": "no image slots",
+            "include_images": "NO",
+        },
+        6,
+    )
+
+    assert slots == []

--- a/tests/test_skills_default_prompt_contract.py
+++ b/tests/test_skills_default_prompt_contract.py
@@ -22,13 +22,17 @@ AUDIO_DEFAULTS = {
     "voiceover-studio",
 }
 DEFAULTS = {
+    "AwesomeWebpageMetaSkill",
     "ai-video-script",
+    "audio-cog",
     "cron",
     "deep-research",
     "docx",
+    "filesystem",
     "git-diff",
     "github",
     "history-explorer",
+    "html-coder",
     "html-to-pdf",
     "http-fetch",
     "latex-compile",
@@ -69,10 +73,14 @@ DEFAULTS = {
     "video-merger",
     "video-still-animator",
     "weather",
+    "web-search",
     "xlsx",
 } | AUDIO_DEFAULTS
 PROMPT_DEFAULTS_WITHOUT_AUDIO_TOOLS = DEFAULTS - AUDIO_DEFAULTS
 INTERNAL_HELPERS = {
+    "awesome-webpage-research",
+    "nano-banana-pro-openrouter",
+    "openrouter-video-generator",
     "skill-creator-linter",
     "skill-creator-proposals",
     "skill-creator-smoke-test",
@@ -160,6 +168,7 @@ async def test_default_prompt_only_injects_retained_bundled_skills(
             has_bin_cache={
                 "codex": True,
                 "curl": True,
+                "bibtex": True,
                 "ffmpeg": True,
                 "ffprobe": True,
                 "xelatex": True,

--- a/tests/test_skills_default_prompt_contract.py
+++ b/tests/test_skills_default_prompt_contract.py
@@ -166,9 +166,9 @@ async def test_default_prompt_only_injects_retained_bundled_skills(
         EligibilityContext(
             os_name="linux",
             has_bin_cache={
+                "bibtex": True,
                 "codex": True,
                 "curl": True,
-                "bibtex": True,
                 "ffmpeg": True,
                 "ffprobe": True,
                 "xelatex": True,

--- a/tests/test_skills_default_prompt_contract.py
+++ b/tests/test_skills_default_prompt_contract.py
@@ -78,6 +78,7 @@ DEFAULTS = {
 } | AUDIO_DEFAULTS
 PROMPT_DEFAULTS_WITHOUT_AUDIO_TOOLS = DEFAULTS - AUDIO_DEFAULTS
 INTERNAL_HELPERS = {
+    "awesome-webpage-image-download",
     "awesome-webpage-research",
     "nano-banana-pro-openrouter",
     "openrouter-video-generator",

--- a/tests/test_skills_provenance_contract.py
+++ b/tests/test_skills_provenance_contract.py
@@ -21,6 +21,7 @@ def test_default_bundled_skills_have_release_provenance(tmp_path: Path) -> None:
             "opensquilla-original",
             "bundled-derived",
             "openclaw-derived",
+            "clawhub-mit",
             "clawhub-mit0",
         }
         assert provenance.maintained_by == "OpenSquilla"
@@ -33,6 +34,9 @@ def test_default_bundled_skills_have_release_provenance(tmp_path: Path) -> None:
         elif provenance.origin == "clawhub-mit0":
             assert provenance.upstream_url.startswith("https://clawhub.ai/")
             assert provenance.license == "MIT-0"
+        elif provenance.origin == "clawhub-mit":
+            assert provenance.upstream_url.startswith("https://clawhub.ai/")
+            assert provenance.license == "MIT"
         else:
             assert provenance.license == "Apache-2.0"
 

--- a/tests/test_skills_third_party_notices.py
+++ b/tests/test_skills_third_party_notices.py
@@ -10,6 +10,8 @@ NOTICES = ROOT / "THIRD_PARTY_NOTICES.md"
 ORIGINALS = {
     "advanced-dubbing-studio",
     "cron",
+    "AwesomeWebpageMetaSkill",
+    "awesome-webpage-research",
     "deep-research",
     "docx",
     "git-diff",
@@ -31,6 +33,7 @@ ORIGINALS = {
     "multi-search-engine",
     "music-and-singing-studio",
     "nano-pdf",
+    "openrouter-video-generator",
     "paper-abstract-author",
     "paper-citation-planner",
     "paper-experiment-stub",

--- a/tests/test_skills_third_party_notices.py
+++ b/tests/test_skills_third_party_notices.py
@@ -85,6 +85,7 @@ def test_all_bundled_skills_have_complete_provenance(tmp_path: Path) -> None:
             "opensquilla-original",
             "bundled-derived",
             "openclaw-derived",
+            "clawhub-mit",
             "clawhub-mit0",
         }, skill.name
         assert provenance.maintained_by == "OpenSquilla", skill.name
@@ -97,6 +98,9 @@ def test_all_bundled_skills_have_complete_provenance(tmp_path: Path) -> None:
         elif provenance.origin == "clawhub-mit0":
             assert provenance.upstream_url.startswith("https://clawhub.ai/"), skill.name
             assert provenance.license == "MIT-0", skill.name
+        elif provenance.origin == "clawhub-mit":
+            assert provenance.upstream_url.startswith("https://clawhub.ai/"), skill.name
+            assert provenance.license == "MIT", skill.name
         else:
             assert skill.name in ORIGINALS
             assert provenance.license == "Apache-2.0", skill.name
@@ -111,17 +115,22 @@ def test_third_party_notices_match_bundled_provenance(tmp_path: Path) -> None:
     openclaw_derived = sorted(
         name for name, origin in skills.items() if origin == "openclaw-derived"
     )
+    clawhub_mit = sorted(name for name, origin in skills.items() if origin == "clawhub-mit")
     clawhub_derived = sorted(name for name, origin in skills.items() if origin == "clawhub-mit0")
 
     assert "## OpenClaw-derived bundled skill descriptors" in text
     assert "## OpenSquilla-original bundled skills" in text
     if clawhub_derived:
         assert "## ClawHub-derived bundled skill descriptors" in text
+    if clawhub_mit:
+        assert "## ClawHub MIT bundled skill descriptors" in text
     for name in derived:
         assert f"- `{name}`" in text
     for name in originals:
         assert f"- `{name}`" in text
     for name in openclaw_derived:
+        assert f"- `{name}`" in text
+    for name in clawhub_mit:
         assert f"- `{name}`" in text
     for name in clawhub_derived:
         assert f"- `{name}`" in text
@@ -132,6 +141,23 @@ def test_third_party_notices_match_bundled_provenance(tmp_path: Path) -> None:
         if line.strip().startswith("- `") and line.strip().endswith("`")
     }
     assert listed == set(skills)
+
+    if "filesystem" in clawhub_mit:
+        assert "Copyright (c) 2026 Clawdbot Community" in text
+        assert "clawdbot-filesystem" in text
+
+
+def test_filesystem_skill_records_mit_notice_provenance(tmp_path: Path) -> None:
+    text = NOTICES.read_text(encoding="utf-8")
+    loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
+    filesystem = loader.get_by_name("filesystem")
+
+    assert filesystem is not None
+    assert filesystem.provenance.origin == "clawhub-mit"
+    assert filesystem.provenance.license == "MIT"
+    assert "## ClawHub MIT bundled skill descriptors" in text
+    assert "- `filesystem`" in text
+    assert "Copyright (c) 2026 Clawdbot Community" in text
 
 
 def test_tokenjuice_backend_has_third_party_provenance() -> None:

--- a/tests/test_skills_third_party_notices.py
+++ b/tests/test_skills_third_party_notices.py
@@ -11,6 +11,7 @@ ORIGINALS = {
     "advanced-dubbing-studio",
     "cron",
     "AwesomeWebpageMetaSkill",
+    "awesome-webpage-image-download",
     "awesome-webpage-research",
     "deep-research",
     "docx",

--- a/tests/test_tools/test_shell_approval_policy.py
+++ b/tests/test_tools/test_shell_approval_policy.py
@@ -501,6 +501,29 @@ async def test_workspace_write_deny_globs_block_direct_shell_command(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_workspace_write_deny_globs_inspect_shell_stdin(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    ctx.interaction_mode = InteractionMode.UNATTENDED
+    ctx.elevated = "bypass"
+    ctx.workspace_dir = str(workspace)
+    ctx.workspace_write_deny_globs = ["reports/*.txt"]  # type: ignore[attr-defined]
+
+    result = await shell.exec_command(
+        "sh",
+        workdir=str(workspace),
+        stdin="mkdir -p reports\necho secret > reports/out.txt\n",
+    )
+
+    payload = json.loads(result)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "workspace_write_deny"
+    assert payload["matched_pattern"] == "reports/*.txt"
+
+
+@pytest.mark.asyncio
 async def test_bypass_still_blocks_sensitive_shell_targets() -> None:
     ctx = current_tool_context.get()
     assert ctx is not None

--- a/tests/test_tools/test_shell_process_isolation.py
+++ b/tests/test_tools/test_shell_process_isolation.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import shlex
+import subprocess
 import sys
 import time
 from dataclasses import dataclass
@@ -13,6 +14,13 @@ import structlog.testing
 
 from opensquilla.tools.builtin import shell
 from opensquilla.tools.types import CallerKind, ToolContext, ToolError, current_tool_context
+
+
+def _python_shell_command(script: str) -> str:
+    argv = [sys.executable, "-c", script]
+    if os.name == "nt":
+        return subprocess.list2cmdline(argv)
+    return " ".join(shlex.quote(part) for part in argv)
 
 
 class _FakeStdin:
@@ -160,6 +168,17 @@ async def test_exec_command_timeout_still_stops_foreground_process() -> None:
 
     assert "[timeout after 0.1s]" in result
     assert elapsed < 1.0
+
+
+@pytest.mark.asyncio
+async def test_exec_command_writes_optional_stdin() -> None:
+    command = _python_shell_command(
+        "import sys; data = sys.stdin.read(); print('STDIN:' + data)"
+    )
+
+    result = await shell.exec_command(command, stdin="payload", timeout=1.0)
+
+    assert result == "exit_code=0\nSTDIN:payload\n"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools/test_shell_process_isolation.py
+++ b/tests/test_tools/test_shell_process_isolation.py
@@ -178,7 +178,9 @@ async def test_exec_command_writes_optional_stdin() -> None:
 
     result = await shell.exec_command(command, stdin="payload", timeout=1.0)
 
-    assert result == "exit_code=0\nSTDIN:payload\n"
+    exit_line, stdout = result.split("\n", 1)
+    assert exit_line == "exit_code=0"
+    assert stdout.splitlines() == ["STDIN:payload"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools/test_shell_process_isolation.py
+++ b/tests/test_tools/test_shell_process_isolation.py
@@ -8,10 +8,12 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 import pytest
 import structlog.testing
 
+from opensquilla.sandbox.types import SandboxResult
 from opensquilla.tools.builtin import shell
 from opensquilla.tools.types import CallerKind, ToolContext, ToolError, current_tool_context
 
@@ -181,6 +183,57 @@ async def test_exec_command_writes_optional_stdin() -> None:
     exit_line, stdout = result.split("\n", 1)
     assert exit_line == "exit_code=0"
     assert stdout.splitlines() == ["STDIN:payload"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name != "posix", reason="POSIX shell quoting is required")
+async def test_exec_command_sandbox_escalation_stdin_returns_when_shell_exits(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = SimpleNamespace(effective=SimpleNamespace(sandbox_enabled=True))
+    child_script = "import time; time.sleep(5)"
+    parent_script = (
+        "import subprocess, sys; "
+        "sys.stdin.read(); "
+        "subprocess.Popen([sys.executable, '-c', "
+        f"{child_script!r}], stdout=sys.stdout, stderr=sys.stderr)"
+    )
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(parent_script)}"
+
+    async def fake_gate_action(**kwargs: object):
+        request = SimpleNamespace(
+            cwd=tmp_path,
+            action_kind="shell.exec",
+            policy=SimpleNamespace(),
+            reason="test",
+        )
+        return object(), SimpleNamespace(), request
+
+    async def fake_run_under_backend(*args: object, **kwargs: object) -> SandboxResult:
+        return SandboxResult(
+            returncode=1,
+            stdout="",
+            stderr="",
+            wall_time_s=0.0,
+            backend_used="seatbelt",
+            backend_notes=("sandbox denied",),
+        )
+
+    async def fake_escalate_backend_denial(*args: object, **kwargs: object) -> object:
+        return object()
+
+    monkeypatch.setattr(shell, "get_runtime", lambda: runtime)
+    monkeypatch.setattr(shell, "gate_action", fake_gate_action)
+    monkeypatch.setattr(shell, "run_under_backend", fake_run_under_backend)
+    monkeypatch.setattr(shell, "escalate_backend_denial", fake_escalate_backend_denial)
+
+    started = time.monotonic()
+    result = await shell.exec_command(command, stdin="payload", timeout=0.5)
+    elapsed = time.monotonic() - started
+
+    assert result.startswith("exit_code=0\n")
+    assert elapsed < 0.5
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools/test_shell_process_isolation.py
+++ b/tests/test_tools/test_shell_process_isolation.py
@@ -186,6 +186,19 @@ async def test_exec_command_writes_optional_stdin() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(os.name != "posix", reason="large pipe backpressure is POSIX-specific")
+async def test_exec_command_stdin_write_obeys_timeout() -> None:
+    command = _python_shell_command("import time; time.sleep(5)")
+
+    started = time.monotonic()
+    result = await shell.exec_command(command, stdin="x" * 1_000_000, timeout=0.2)
+    elapsed = time.monotonic() - started
+
+    assert "[timeout after 0.2s]" in result
+    assert elapsed < 2.0
+
+
+@pytest.mark.asyncio
 @pytest.mark.skipif(os.name != "posix", reason="POSIX shell quoting is required")
 async def test_exec_command_sandbox_escalation_stdin_returns_when_shell_exits(
     tmp_path,

--- a/tests/test_tools/test_shell_sensitive.py
+++ b/tests/test_tools/test_shell_sensitive.py
@@ -24,6 +24,34 @@ async def test_exec_command_blocks_sensitive_workdir(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_exec_command_blocks_sensitive_stdin_payload() -> None:
+    result = await shell.exec_command(
+        "cat >/tmp/opensquilla-stdin-sensitive-test",
+        stdin='{"OPENROUTER_API_KEY":"sk-or-secret"}',
+    )
+
+    payload = json.loads(result)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "sensitive_payload"
+    assert payload["sensitive_payload"] == "secret_json_key"
+    assert "sk-or-secret" not in result
+
+
+@pytest.mark.asyncio
+async def test_exec_command_blocks_sensitive_path_in_stdin() -> None:
+    result = await shell.exec_command(
+        "python -",
+        stdin="from pathlib import Path\nPath('/etc/passwd').read_text()\n",
+    )
+
+    payload = json.loads(result)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "sensitive_path"
+    assert payload["sensitive_path"] == "/etc"
+    assert "/etc/passwd" not in payload["command"]
+
+
+@pytest.mark.asyncio
 async def test_exec_command_blocks_nested_sensitive_workdir() -> None:
     sensitive_dir = Path.home() / ".ssh" / "id_rsa"
 

--- a/uv.lock
+++ b/uv.lock
@@ -572,6 +572,20 @@ wheels = [
 ]
 
 [[package]]
+name = "duckduckgo-search"
+version = "8.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/ef/07791a05751e6cc9de1dd49fb12730259ee109b18e6d097e25e6c32d5617/duckduckgo_search-8.1.1.tar.gz", hash = "sha256:9da91c9eb26a17e016ea1da26235d40404b46b0565ea86d75a9f78cc9441f935", size = 22868, upload-time = "2025-07-06T15:30:59.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/72/c027b3b488b1010cf71670032fcf7e681d44b81829d484bb04e31a949a8d/duckduckgo_search-8.1.1-py3-none-any.whl", hash = "sha256:f48adbb06626ee05918f7e0cef3a45639e9939805c4fc179e68c48a12f1b5062", size = 18932, upload-time = "2025-07-06T15:30:58.339Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1656,6 +1670,7 @@ dependencies = [
     { name = "croniter" },
     { name = "cryptography" },
     { name = "dingtalk-stream" },
+    { name = "duckduckgo-search" },
     { name = "html2text" },
     { name = "httpx" },
     { name = "jinja2" },
@@ -1741,6 +1756,7 @@ requires-dist = [
     { name = "croniter", specifier = ">=2.0" },
     { name = "cryptography", specifier = ">=42" },
     { name = "dingtalk-stream", specifier = ">=0.24.3,<0.25" },
+    { name = "duckduckgo-search", specifier = ">=8.1.1" },
     { name = "html2text", specifier = ">=2024.2" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jieba", marker = "extra == 'memory'", specifier = ">=0.42" },
@@ -1930,6 +1946,44 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "primp"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/4b/7efa54f38da7de8df6b70dfed173bb41a52b740b144e4be24c1172db4209/primp-1.3.1.tar.gz", hash = "sha256:b04a5941bf9c876d011c5defaf5a25be093d56e7270b8da52c9788b9df2a829a", size = 1360029, upload-time = "2026-05-23T17:39:25.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/80/c4885a783a7493e396d89a592ba19fce63ef6bd6ad47230924a884a30ec0/primp-1.3.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:27b87e6370045a0c65c0e4dfdfacbfe637387d05673ce8ddcce400263f7c27f0", size = 5123967, upload-time = "2026-05-23T17:39:08.586Z" },
+    { url = "https://files.pythonhosted.org/packages/58/c1/c965cc23f96a364803d44b4331f33e4465bb6f269add37e39d0ad77ffe33/primp-1.3.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:27a8804eb9a3f641f379ee2b443591428cf85c898816e93d04d3e7b6f229ebcb", size = 4743059, upload-time = "2026-05-23T17:39:15.536Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/99/f4248d8d833d43fd8ba78208f2f4bf7fba7d3aec8c516090a95d18d6f550/primp-1.3.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:862974796552a51af8e276bb19c5d5e189168ab8bad216aef7ce3726a8d3b1dd", size = 5100121, upload-time = "2026-05-23T17:39:04.64Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ad/519e32e0184763e1a76c9321fdeac0bb9b30bf85746f12058feec0cc4a27/primp-1.3.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ceb24198994799706f4020a00173ba9c1b491aa9805b1e014d87946677bc3c5d", size = 4738042, upload-time = "2026-05-23T17:39:35.967Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7b/723cb40694b47ec79a142ed8492835c0ecae9fef7acbed014f04b018d1de/primp-1.3.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3298b8afcf0a88ba6622bfc18e78aeb11afbb7d5afa4774f24acf7491f54a2d", size = 5001773, upload-time = "2026-05-23T17:39:03.01Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/80a2e3bdab1c51d738b82ea210a5ab93986b443c561e792e42cae296ec10/primp-1.3.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6b8d38c5a6d0a863274cbcae9678f265fcdcead3c20d12d152244e88f5f2186b", size = 5334228, upload-time = "2026-05-23T17:39:24.214Z" },
+    { url = "https://files.pythonhosted.org/packages/19/70/c95b8054c7d1fe2d84226ec60a5f48ce6c95a08b7c8b1702d7742082f444/primp-1.3.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96f831c78ddb5900873f51e294bf9bbb4bbfdac3a2f39ce4023f8c558d299332", size = 5157269, upload-time = "2026-05-23T17:38:48.142Z" },
+    { url = "https://files.pythonhosted.org/packages/34/bb/9b66986b7ecf2eff987134cd94bde533142e3085d6f67531f1a369ceaaae/primp-1.3.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:329d0c320841f65b39d80801d8bae126732b84ec1094ca17b14fda0bda1b20ff", size = 5347438, upload-time = "2026-05-23T17:39:17.405Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/5d127748d06f3c6a3367f3c4974e45b98cda61cd28ea79ef91ad3fe9e093/primp-1.3.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6c3c67670c38a03e9e8da45b212243d35afc8efa018317c46ecdce47f05329d1", size = 5264862, upload-time = "2026-05-23T17:39:20.625Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f3/1aac229425cac142c48418e2de9f70597161ea936543b5e3c9e7476e1921/primp-1.3.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:9409a31028a8c62a609d389554ad4f5339aad075130300cd443beef0336d7179", size = 4969889, upload-time = "2026-05-23T17:39:22.412Z" },
+    { url = "https://files.pythonhosted.org/packages/38/86/a94d6e6166139c76ae42eb941328679309ca85139e8753d639657a24474c/primp-1.3.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:88ca36c2bd1b7c64b96ad07ca367d2d111ac8e9670549be5f232da8bf795d21e", size = 5082679, upload-time = "2026-05-23T17:39:28.411Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/61/21d297db575ed660c6aaf35c9014c1874ace45d6dcb79d1a4d3d2608bffb/primp-1.3.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:74d13800b501aa003fb05c263d38f8d61656c83a60b2951046c0fc412bc73976", size = 5605392, upload-time = "2026-05-23T17:39:38.007Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d6/9262a7ebb1d980a2db0cd505bb902bb3e66acd8a1cb763a4c2921f2f6a5b/primp-1.3.1-cp310-abi3-win32.whl", hash = "sha256:09ada1752629fe89d7b128beeb59cb641f404af462e24177ba36aed1cf322299", size = 4270373, upload-time = "2026-05-23T17:38:44.98Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/68/f0c6a60fadff0c185aef232b951a6fa4bbb64511facc48d34734db14f16f/primp-1.3.1-cp310-abi3-win_amd64.whl", hash = "sha256:c0d1e294466cd5ec7ef173eedf8df25cbdc050138d40447a906e92b8553e7765", size = 4661498, upload-time = "2026-05-23T17:39:32.213Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1d/232a52abc77384ac66b9c1741691dec3659b1207bb6c5e55c1e9b59d22f1/primp-1.3.1-cp310-abi3-win_arm64.whl", hash = "sha256:43304cb41cbb46f361de49faf1cbdba57f969f628c9297239c7ed8ef0cac420f", size = 4624481, upload-time = "2026-05-23T17:38:42.724Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/0b/34333b26c533c3122b936dad829f0a6e04f32065d39673c92b157d97aa16/primp-1.3.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:72249a4540d0a8965f36eb9a86cd16801d1c7e8dac2f0b0fa23a0a5a03402d36", size = 5116098, upload-time = "2026-05-23T17:38:55.219Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/56/7fe14708adf9a5cb5d6a15ad840a3de036cebfaf20692a5bc3b72e188a73/primp-1.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:db4e2eaa5707e47899eeba6026f420f9b0108a28c08d63f1826d0cab8d50f06f", size = 4736300, upload-time = "2026-05-23T17:38:51.792Z" },
+    { url = "https://files.pythonhosted.org/packages/31/cb/521a8c18e8808a75450b6e91dc62cc1149c0178b7d4a8697d3f9b73fa385/primp-1.3.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d62e7609c98b4bc99c9cecc47f16f332fb8fe1a023002176267b0043dedad0c7", size = 5093823, upload-time = "2026-05-23T17:38:50.059Z" },
+    { url = "https://files.pythonhosted.org/packages/57/84/90f776fe46aeb0e3b86df72c674c0651326dd6a61846dd86bddbabe903ac/primp-1.3.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3d692e912c2b25271163ba7719df0afdb733a7e7c3073c9094e9001882463543", size = 4734511, upload-time = "2026-05-23T17:39:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/d9bfbc0df0394f18a98b512a65f4bcf3dd7d17bd871937127e1ce4549172/primp-1.3.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c08693517dc160a12c0f9e2565c5319173cef738893a303ff2fb28ecccbd84d", size = 4999315, upload-time = "2026-05-23T17:39:12.061Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d8/5a986957ee1874d08567d7749668cd78a063048d47d6e46a874742b7fed1/primp-1.3.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d134ebfa31adc619e4e48289fe3e7eebc8310141560e6a6a04269cc94893d9ab", size = 5329375, upload-time = "2026-05-23T17:39:30.307Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/1d/321cac9902cc3992174ed530719141a0da2e426f54f8a90b7b971571d104/primp-1.3.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48e27e7c0e015a6de495cf79c0c8d599ba5f69d091af31572bec2de020522d9c", size = 5140921, upload-time = "2026-05-23T17:38:53.528Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/19/ccbe6b67e0e91beb5c9d5cf804354225d5a3a7a9adf84fee3d6acc53febd/primp-1.3.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c3d682df08c1b1f37b1f66b21fd173baebcfcb52490830b12292d8fe89b2147", size = 5344288, upload-time = "2026-05-23T17:39:18.965Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e5/a735751bd11558163e83e0961fc866e4f94634df9eb24937c5f59624e393/primp-1.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fabaac4280df0802377d34b869949d617a0ecf22ca7fd5f9bded3f5c981031f1", size = 5262909, upload-time = "2026-05-23T17:39:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8e/4e3d4520e2e751f2de825dbe2cb43f837d33a5528adc44255f9770ea125a/primp-1.3.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f510e5881e0a4c4b9e7dbc03722c316d58454388b88000a0e7bf18a4b36d601e", size = 4964809, upload-time = "2026-05-23T17:38:59.023Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/e7b7495687d07df693325a12c497a9e5185d5001b7b216f32019fa7437a0/primp-1.3.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0504de2901c97903a9c369856a4b186dc90a782d8320652c142b066e697d5a1a", size = 5083654, upload-time = "2026-05-23T17:39:06.598Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f9/e4652e93beb14a16cc4218cfb1ccc18eaca8ee7d93b517d614a135928ec9/primp-1.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c3b24e302d95d327e873834b9423823b9c8af2abf5e0bbf57a03f3354cfe528", size = 5594738, upload-time = "2026-05-23T17:39:27.001Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/49/e8c8a7bc6b741ab6f15896022eee4f906d04d7ccd15aeeb515dd04bbeb6d/primp-1.3.1-cp314-cp314t-win32.whl", hash = "sha256:4346dcef805279028bf4a54bb87dd43d0920130e25b5790689f5c96c9ba0d9e5", size = 4262615, upload-time = "2026-05-23T17:39:13.88Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/84/7ae4a257dec6dff329d4a8d9051d907316095c27ffc8d1ea15c359e6eeb5/primp-1.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:6c55f152a73b6d6af8ac37bdb648d8bbfd7e656f9ef40d87feb3c0d81cee930a", size = 4660584, upload-time = "2026-05-23T17:39:10.081Z" },
+    { url = "https://files.pythonhosted.org/packages/99/20/10e0d96bfaeef1f0cd339ccf9bb8feb4bf798fde93198f7a96c73441080a/primp-1.3.1-cp314-cp314t-win_arm64.whl", hash = "sha256:46a529d74583d6ceba52e15bf4c678fcf24e6d669c1ce935262d5490d1b25801", size = 4623226, upload-time = "2026-05-23T17:38:57.256Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add the bundled `AwesomeWebpageMetaSkill` workflow and supporting bundled execution skills for research, HTML coding, filesystem work, web search, image, video, and audio generation.
- Keep meta-skill discussion prompts from replaying stale sticky matches.
- Ensure `skill_exec` workspaces exist before subprocess launch.
- Align bundled skill loader/default prompt contracts and third-party notices for the new bundles.
- Move deterministic AwesomeWebpage tool-call helpers into code-backed modules so Windows CI does not rely on POSIX heredocs, oversized shell commands, or non-UTF console output.

## Verification
- `UV_PYTHON=3.12 uv sync --extra dev --extra recommended --extra mcp --frozen`
- `uv run pytest tests/test_skills/test_awesome_webpage_meta_skill.py -q`
- `uv run pytest tests/test_engine/test_meta_resolution_sticky.py tests/test_skills/test_meta_mvp.py tests/test_skills/test_loader_list_meta_specs.py tests/test_skills_third_party_notices.py tests/test_skills/test_awesome_webpage_meta_skill.py tests/test_skills/test_nano_banana_openrouter_image.py tests/test_skills_default_prompt_contract.py::test_bundled_directory_only_contains_retained_default_skills tests/test_skills_default_prompt_contract.py::test_default_prompt_only_injects_retained_bundled_skills tests/test_skills_loader_namespaces.py::test_existing_bundled_skills_still_parse -q`
- `uv run ruff check src tests`
- `uv run mypy src/opensquilla --show-error-codes`
- `git diff --check`
- `git diff --cached --check`

Not tested: live OpenRouter media generation APIs.
