### PR TITLE
Prepare OpenSquilla 0.3.1 release

### DIFF
--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+changed_files="${1:?usage: classify-ci-changes.sh <changed-files-list>}"
+output_file="${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
+
+docs_only=true
+runtime_changed=false
+test_changed=false
+ci_changed=false
+dependency_changed=false
+release_changed=false
+seen_file=false
+
+mark_runtime_changed() {
+  docs_only=false
+  runtime_changed=true
+}
+
+mark_test_changed() {
+  docs_only=false
+  test_changed=true
+}
+
+mark_ci_changed() {
+  docs_only=false
+  ci_changed=true
+}
+
+mark_dependency_changed() {
+  mark_runtime_changed
+  dependency_changed=true
+  release_changed=true
+}
+
+mark_release_changed() {
+  docs_only=false
+  release_changed=true
+}
+
+while IFS= read -r path || [[ -n "${path}" ]]; do
+  path="${path%$'\r'}"
+  [[ -z "${path}" ]] && continue
+  seen_file=true
+
+  case "${path}" in
+    .ci/run-all)
+      docs_only=false
+      runtime_changed=true
+      test_changed=true
+      ci_changed=true
+      dependency_changed=true
+      release_changed=true
+      ;;
+    pyproject.toml | uv.lock)
+      mark_dependency_changed
+      ;;
+    .github/workflows/wheelhouse-release.yml)
+      mark_ci_changed
+      mark_release_changed
+      ;;
+    .github/workflows/*)
+      mark_ci_changed
+      ;;
+    .github/scripts/*)
+      mark_ci_changed
+      ;;
+    tests/test_scripts/test_build_wheelhouse_zip.py | tests/test_install_scripts.py | tests/test_root_start_scripts.py | tests/test_release_consistency.py | tests/test_public_release_hygiene.py)
+      mark_test_changed
+      mark_release_changed
+      ;;
+    tests/*)
+      mark_test_changed
+      ;;
+    scripts/build_wheelhouse_zip.py | scripts/install_source.sh | scripts/install_source.ps1)
+      mark_runtime_changed
+      mark_release_changed
+      ;;
+    install.sh | install.ps1 | start.sh | start.ps1 | README.release.md | RELEASES.md)
+      mark_release_changed
+      ;;
+    src/* | scripts/* | migrations/*)
+      mark_runtime_changed
+      ;;
+    docs/* | README.md | README.*.md | CHANGELOG.md | CODE_OF_CONDUCT.md | CONTRIBUTING.md | MIGRATION.md | SECURITY.md | SUPPORT.md | THIRD_PARTY_NOTICES.md | META_SKILL_GUIDE.md | RELEASES.md | .github/pull_request_template.md | .github/ISSUE_TEMPLATE/*)
+      ;;
+    *)
+      mark_runtime_changed
+      ;;
+  esac
+done < "${changed_files}"
+
+if [[ "${seen_file}" == "false" ]]; then
+  docs_only=false
+  runtime_changed=true
+  test_changed=true
+  ci_changed=true
+  dependency_changed=true
+  release_changed=true
+fi
+
+{
+  printf 'docs_only=%s\n' "${docs_only}"
+  printf 'runtime_changed=%s\n' "${runtime_changed}"
+  printf 'test_changed=%s\n' "${test_changed}"
+  printf 'ci_changed=%s\n' "${ci_changed}"
+  printf 'dependency_changed=%s\n' "${dependency_changed}"
+  printf 'release_changed=%s\n' "${release_changed}"
+} >> "${output_file}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  classify-changes:
+    name: Classify changed files
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+      runtime_changed: ${{ steps.classify.outputs.runtime_changed }}
+      test_changed: ${{ steps.classify.outputs.test_changed }}
+      ci_changed: ${{ steps.classify.outputs.ci_changed }}
+      dependency_changed: ${{ steps.classify.outputs.dependency_changed }}
+      release_changed: ${{ steps.classify.outputs.release_changed }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: List changed files
+        shell: bash
+        run: |
+          set -euo pipefail
+          changed_files="${RUNNER_TEMP}/changed-files.txt"
+
+          case "${{ github.event_name }}" in
+            pull_request)
+              git diff --name-only \
+                "${{ github.event.pull_request.base.sha }}" \
+                "${{ github.event.pull_request.head.sha }}" > "${changed_files}"
+              ;;
+            push)
+              printf '.ci/run-all\n' > "${changed_files}"
+              ;;
+            *)
+              printf '.ci/run-all\n' > "${changed_files}"
+              ;;
+          esac
+
+          echo "Changed files:"
+          sed 's/^/  /' "${changed_files}"
+          printf 'CHANGED_FILES=%s\n' "${changed_files}" >> "${GITHUB_ENV}"
+
+      - name: Classify changed files
+        id: classify
+        shell: bash
+        run: bash .github/scripts/classify-ci-changes.sh "${CHANGED_FILES}"
+
   workflow-lint:
     name: Validate GitHub Actions workflows
     runs-on: ubuntu-latest
@@ -25,19 +71,15 @@ jobs:
       - name: Run actionlint
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color=false
 
-  checks:
-    name: Lint, test, and build
-    runs-on: ${{ matrix.os }}
+  ubuntu-quality:
+    name: Ubuntu quality gate
+    needs: classify-changes
+    if: needs.classify-changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: ['3.12']
-
     env:
-      UV_PYTHON: ${{ matrix.python-version }}
+      UV_PYTHON: "3.12"
       PYTHONPATH: ${{ github.workspace }}
       OPENSQUILLA_TURN_CALL_LOG: "0"
 
@@ -56,7 +98,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
@@ -99,3 +141,150 @@ jobs:
       - name: Build wheel
         shell: bash
         run: uv build --wheel
+
+  windows-compat:
+    name: Windows compatibility tests
+    needs: classify-changes
+    if: needs.classify-changes.outputs.docs_only != 'true'
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    env:
+      UV_PYTHON: "3.12"
+      PYTHONPATH: ${{ github.workspace }}
+      OPENSQUILLA_TURN_CALL_LOG: "0"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Configure runtime directories
+        shell: bash
+        run: |
+          printf 'OPENSQUILLA_STATE_DIR=%s/opensquilla-state\n' "$RUNNER_TEMP" >> "$GITHUB_ENV"
+          printf 'OPENSQUILLA_LOG_DIR=%s/opensquilla-logs\n' "$RUNNER_TEMP" >> "$GITHUB_ENV"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        shell: bash
+        run: uv sync --extra dev --extra recommended --extra mcp --frozen
+
+      - name: Test
+        shell: bash
+        run: uv run pytest tests -q
+
+  release-packaging:
+    name: Release packaging contracts
+    needs: classify-changes
+    if: needs.classify-changes.outputs.release_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      UV_PYTHON: "3.12"
+      PYTHONPATH: ${{ github.workspace }}
+      OPENSQUILLA_TURN_CALL_LOG: "0"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        shell: bash
+        run: uv sync --extra dev --extra recommended --extra mcp --frozen
+
+      - name: Run release packaging contract tests
+        shell: bash
+        run: |
+          uv run pytest \
+            tests/test_scripts/test_build_wheelhouse_zip.py \
+            tests/test_install_scripts.py \
+            tests/test_root_start_scripts.py \
+            tests/test_release_consistency.py \
+            tests/test_public_release_hygiene.py \
+            -q
+
+  ci-result:
+    name: CI result
+    needs:
+      - classify-changes
+      - workflow-lint
+      - ubuntu-quality
+      - windows-compat
+      - release-packaging
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check required CI results
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          classify_result="${{ needs.classify-changes.result }}"
+          workflow_lint_result="${{ needs.workflow-lint.result }}"
+          ubuntu_result="${{ needs.ubuntu-quality.result }}"
+          windows_result="${{ needs.windows-compat.result }}"
+          release_result="${{ needs.release-packaging.result }}"
+          docs_only="${{ needs.classify-changes.outputs.docs_only }}"
+          runtime_changed="${{ needs.classify-changes.outputs.runtime_changed }}"
+          test_changed="${{ needs.classify-changes.outputs.test_changed }}"
+          ci_changed="${{ needs.classify-changes.outputs.ci_changed }}"
+          dependency_changed="${{ needs.classify-changes.outputs.dependency_changed }}"
+          release_changed="${{ needs.classify-changes.outputs.release_changed }}"
+
+          printf 'classify-changes: %s\n' "${classify_result}"
+          printf 'workflow-lint: %s\n' "${workflow_lint_result}"
+          printf 'ubuntu-quality: %s\n' "${ubuntu_result}"
+          printf 'windows-compat: %s\n' "${windows_result}"
+          printf 'release-packaging: %s\n' "${release_result}"
+          printf 'docs_only=%s runtime_changed=%s test_changed=%s ci_changed=%s dependency_changed=%s release_changed=%s\n' \
+            "${docs_only}" "${runtime_changed}" "${test_changed}" "${ci_changed}" "${dependency_changed}" "${release_changed}"
+
+          if [[ "${classify_result}" != "success" ]]; then
+            echo "Classify changed files must succeed."
+            exit 1
+          fi
+
+          if [[ "${workflow_lint_result}" != "success" ]]; then
+            echo "Workflow lint must succeed."
+            exit 1
+          fi
+
+          if [[ "${docs_only}" != "true" && "${ubuntu_result}" != "success" ]]; then
+            echo "Ubuntu quality gate must succeed for non-documentation changes."
+            exit 1
+          fi
+
+          if [[ "${docs_only}" != "true" && "${windows_result}" != "success" ]]; then
+            echo "Windows compatibility tests must succeed for non-documentation changes."
+            exit 1
+          fi
+
+          if [[ "${release_changed}" == "true" && "${release_result}" != "success" ]]; then
+            echo "Release packaging contracts must succeed for release-surface changes."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color=false
 
   ubuntu-quality:
-    name: Ubuntu quality gate
+    name: Lint, test, and build (ubuntu-latest, 3.12)
     needs: classify-changes
     if: needs.classify-changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
@@ -143,7 +143,7 @@ jobs:
         run: uv build --wheel
 
   windows-compat:
-    name: Windows compatibility tests
+    name: Lint, test, and build (windows-latest, 3.12)
     needs: classify-changes
     if: needs.classify-changes.outputs.docs_only != 'true'
     runs-on: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,54 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+## [0.3.1] - 2026-06-03
+
+### Added
+
+- Slack Socket Mode support now covers app mentions, self-targeting replies,
+  channel metadata, and threaded response routing across onboarding and channel
+  runtime paths.
+- Short-drama and video helper workflows remain available in the bundled
+  MetaSkill catalog, with stronger Windows-safe script handling and clearer
+  review pauses for generated media flows.
+- CI impact-surface gates classify docs, runtime, dependency, release, and test
+  changes so pull requests can run the right checks without forcing the full
+  matrix for every documentation-only edit.
+
+### Changed
+
+- WebChat and the Skills view now make MetaSkill readiness, active runs, and
+  install visibility easier to inspect while workflows are being reviewed.
+- Release install documentation and installer defaults now point to the 0.3.1
+  wheel and Windows portable asset names.
+
+### Fixed
+
+- User chat bubbles preserve multiline text and read like authored messages
+  instead of collapsing or visually blending with generated output.
+- Slack onboarding and runtime paths now reject incomplete Socket Mode setup,
+  preserve existing secrets, enforce webhook signing secrets where needed, and
+  keep threaded reply channel context.
+- Voice/audio workflows and clarification pauses are represented on the main
+  release line, so release users get the same usable handoff and resume
+  behavior already validated on integration branches.
+- Provider request hardening keeps malformed tool-call history from reaching
+  providers as invalid request state.
+
+### Acknowledgements
+
+- Thanks @openvictory for #123, #133, and #137, which helped bring visible
+  running-state feedback plus short-drama and media helper workflows into the
+  0.3.1 release line.
+- Thanks @freeaccount-create for #142, which helped bring Slack Socket Mode and
+  self-targeting replies into the channel workflow.
+- Thanks @ruhook for #124, and thanks @qq712696307 for the authored commit in
+  that pull request, which preserved user message newlines in WebChat.
+- Thanks @Cola-Alex for #143, which increased tokenjuice summarize and
+  failure-context windows for fallback tool-result projection.
+- Thanks @nice-code-la for #165 and #166, which helped make voice workflows
+  usable end to end and clarification pauses resume cleanly.
+
 ## [0.3.0] - 2026-05-31
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,22 @@ human-readable ledger together for contributor attribution. This file records
 release-surface community work that can be harder to see when a release is
 squash-merged or replayed onto `main`.
 
+## OpenSquilla 0.3.1
+
+The 0.3.1 release is prepared as a release-surface replay from `dev` onto the
+stable `main` release ledger. Some community work in the release window was
+already represented by earlier `main` attribution work; this section records
+the 0.3.1-specific community contributions acknowledged in the release notes.
+
+| Contributor | 0.3.1 contribution | Evidence |
+| --- | --- | --- |
+| [@openvictory](https://github.com/openvictory) | Visible running-state feedback plus short-drama and media helper workflows. | [#123](https://github.com/opensquilla/opensquilla/pull/123), [#133](https://github.com/opensquilla/opensquilla/pull/133), [#137](https://github.com/opensquilla/opensquilla/pull/137) |
+| [@freeaccount-create](https://github.com/freeaccount-create) | Slack Socket Mode and self-targeting replies for channel workflows. | [#142](https://github.com/opensquilla/opensquilla/pull/142) |
+| [@ruhook](https://github.com/ruhook) | Submitted the WebChat user-message newline preservation pull request. | [#124](https://github.com/opensquilla/opensquilla/pull/124) |
+| [@qq712696307](https://github.com/qq712696307) | Authored the commit in #124 that preserved user-message newlines in WebChat. | [#124](https://github.com/opensquilla/opensquilla/pull/124) |
+| [@Cola-Alex](https://github.com/Cola-Alex) | Increased tokenjuice summarize and failure-context windows for fallback tool-result projection. | [#143](https://github.com/opensquilla/opensquilla/pull/143) |
+| [@nice-code-la](https://github.com/nice-code-la) | Voice workflow usability and clarification-pause resume behavior. | [#165](https://github.com/opensquilla/opensquilla/pull/165), [#166](https://github.com/opensquilla/opensquilla/pull/166) |
+
 ## OpenSquilla 0.3.0
 
 The 0.3.0 release reached `main` through release synchronization after work had

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ OpenRouter, OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope,
 and 20+ other LLM providers with no change to your code or config
 schema.
 
-OpenSquilla 0.3.0 is the current release.
+OpenSquilla 0.3.1 is the current release.
 
 For task-oriented product documentation, start with the
 [OpenSquilla Product Guide](README.product.md) or the
@@ -160,7 +160,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Install OpenSquilla** — the same command on every platform.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
 ```
 
 This installs the OpenSquilla wheel from the release URL, then lets
@@ -181,7 +181,7 @@ opensquilla gateway run
 > a new terminal, or re-run the PATH line from step 1.
 
 For a fully pinned install, use the versioned wheel URL:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl`.
 
 ### Install from source
 
@@ -439,9 +439,10 @@ opensquilla channels status <name> --json
 
 Treat a channel as connected only when the status payload reports
 `enabled=true`, `configured=true`, and `connected=true`. Feishu
-defaults to websocket mode and Telegram to polling — neither needs a
-public URL. Feishu webhook mode, Telegram webhook mode, Slack, and
-WeCom require a public, provider-reachable URL.
+defaults to websocket mode, Telegram to polling, and Slack can use
+Socket Mode — none of those modes needs a public URL. Feishu webhook
+mode, Telegram webhook mode, Slack webhook mode, and WeCom require a
+public, provider-reachable URL.
 
 **Public network binding**
 
@@ -479,31 +480,27 @@ settings live in `opensquilla.toml.example`.
 
 ---
 
-## What's New in 0.3.0
+## What's New in 0.3.1
 
-OpenSquilla 0.3.0 makes reusable agent workflows first-class with
-MetaSkills, then strengthens the runtime around diagnostics, context
-management, and documentation:
+OpenSquilla 0.3.1 is a maintenance release for the 0.3 line. It updates the
+stable install metadata and brings selected channel, chat, provider, and
+workflow fixes from the integration branch onto the stable release line:
 
-- **MetaSkills** — repeatable multi-step work can now run as reusable,
-  inspectable workflows with composition parsing, scheduling, pause/resume
-  user input, proposal gates, run history, and authoring documentation.
-- **Health Doctor** — `opensquilla doctor` and the WebUI Health view now turn
-  provider, gateway, memory, search, router, sandbox, and channel problems into
-  actionable findings with recovery commands.
-- **Structured tool compression** — Tokenjuice-backed projection keeps large
-  logs, diffs, test output, JSON, and package-manager results useful without
-  flooding the provider context.
-- **Real product documentation** — the docs now cover quickstart,
-  configuration, CLI, WebUI, providers, sessions, tools, memory, compaction,
-  MetaSkills, tool compression, scheduling, channels, MCP, and
-  troubleshooting.
-- **Runtime and WebUI stability** — long-session compaction, attachment
-  rendering, artifact downloads, router replay, stream recovery, and
-  cross-platform CLI behavior were tightened across the release.
+- **Channel setup and replies** — Slack Socket Mode, app mentions, signing
+  secrets, and threaded replies preserve the channel context needed for setup
+  and replies.
+- **Media and voice workflow handoffs** — short-drama/video helper workflows
+  remain bundled, generated media flows have clearer review pauses, and
+  voice/audio handoffs are usable end to end.
+- **Chat formatting** — user message bubbles preserve multiline text and read
+  like authored messages instead of compressed UI labels.
+- **Provider request hardening** — malformed tool-call history is kept away
+  from providers before it becomes invalid request state.
+- **Install and release checks** — installer URLs, release metadata, version
+  consistency tests, and CI impact gates are updated for 0.3.1.
 
 Full notes: [`CHANGELOG.md`](CHANGELOG.md) ·
-[`docs/releases/0.3.0.md`](docs/releases/0.3.0.md).
+[`docs/releases/0.3.1.md`](docs/releases/0.3.1.md).
 
 ## What's New in 0.2.1
 

--- a/README.product.md
+++ b/README.product.md
@@ -14,7 +14,7 @@ This guide is the product and usage entry point. The existing
 1. Install OpenSquilla:
 
    ```sh
-   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl"
+   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
    ```
 
 2. Configure your provider:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 0.3.1 | v0.3.1 | 2026-06-03 | Slack hardening, media workflow handoffs, chat formatting, and install metadata |
 | 0.3.0 | v0.3.0 | 2026-05-31 | MetaSkills, Health Doctor, tool compression, and docs release |
 | 0.2.1 | v0.2.1 | 2026-05-21 | 0.2 maintenance release |
 | 0.2.0 | v0.2.0 | 2026-05-20 | 0.2 release |
@@ -22,7 +23,7 @@ Windows portable zip `/releases/latest/download/` URL:
 GitHub source archives remain available for code review and developer
 reference; source installs should use `git clone` plus Git LFS. Public
 wheelhouse zips, macOS portable zips, and Linux portable zips are intentionally
-not published for 0.2.x or 0.3.0. macOS and Linux users install the same wheel
+not published for 0.2.x or 0.3.x. macOS and Linux users install the same wheel
 through the versioned `uv tool install` command documented in the README.
 Python wheel filenames must remain versioned because installers validate the
 version segment inside the wheel filename.
@@ -33,21 +34,21 @@ use tag-pinned URLs such as:
 - `https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/OpenSquilla-0.2.0rc1-windows-x64-py312-recommended-portable.zip`
 - `https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/opensquilla-0.2.0rc1-py3-none-any.whl`
 
-0.3.0 install commands use versioned wheel URLs because Python installers
+0.3.1 install commands use versioned wheel URLs because Python installers
 validate wheel filenames. The Windows portable zip may use the
 `/releases/latest/download/` alias after the non-pre-release GitHub Release
 exists. Fully pinned URLs remain available:
 
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/OpenSquilla-0.3.0-windows-x64-py312-recommended-portable.zip`
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/OpenSquilla-0.3.1-windows-x64-py312-recommended-portable.zip`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl`
 
 ## Release SOP
 
 1. Verify `git status` is clean.
 2. Update `CHANGELOG.md`: move entries from `[Unreleased]` to the release section; reopen empty `[Unreleased]`.
 3. Bump `pyproject.toml` and `uv.lock` to the release version.
-4. `git tag -a v0.3.0 -m "OpenSquilla 0.3.0"`
-5. `git push origin v0.3.0` (this triggers `.github/workflows/wheelhouse-release.yml`)
+4. `git tag -a v0.3.1 -m "OpenSquilla 0.3.1"`
+5. `git push origin v0.3.1` (this triggers `.github/workflows/wheelhouse-release.yml`)
 6. Wait for the Windows release workflow → review the draft GitHub Release.
    For non-preview releases, confirm it contains versioned assets, latest
    aliases, `SHA256SUMS`, plus GitHub's generated source archives before
@@ -56,8 +57,8 @@ exists. Fully pinned URLs remain available:
 8. Publish the GitHub Release, then run the post-publish tag URL checks:
 
    ```sh
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/OpenSquilla-0.3.0-windows-x64-py312-recommended-portable.zip
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/OpenSquilla-0.3.1-windows-x64-py312-recommended-portable.zip
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl
    ```
 
 9. Run the post-publish latest URL check:
@@ -66,7 +67,7 @@ exists. Fully pinned URLs remain available:
    curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/latest/download/OpenSquilla-windows-x64-portable.zip
    ```
 
-10. For subsequent previews: bump `pyproject.toml`, `uv.lock`, `CHANGELOG.md`, and the tag to the next preview version, for example `0.3.1rc1` / `v0.3.1rc1`. Preview GitHub Releases must be marked as pre-releases and should use tag-pinned README URLs until the next non-preview release exists.
+10. For subsequent previews: bump `pyproject.toml`, `uv.lock`, `CHANGELOG.md`, and the tag to the next preview version, for example `0.3.2rc1` / `v0.3.2rc1`. Preview GitHub Releases must be marked as pre-releases and should use tag-pinned README URLs until the next non-preview release exists.
 
 ## GitHub-only release checks
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ root release README with task-oriented guides.
 
 ## Surfaces and Operations
 
+- [`releases/0.3.1.md`](releases/0.3.1.md) - OpenSquilla 0.3.1 release notes.
 - [`releases/0.3.0.md`](releases/0.3.0.md) - OpenSquilla 0.3.0 release notes.
 - [`channels.md`](channels.md) - supported messaging channels and setup flow.
 - [`providers-and-models.md`](providers-and-models.md) - LLM provider catalog,

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -24,7 +24,7 @@ This build exposes the following channel families:
 | `feishu` | Feishu / Lark | mixed | depends on mode |
 | `matrix` | Matrix | websocket | no |
 | `qq` | QQ Bot | websocket | no |
-| `slack` | Slack | webhook | yes |
+| `slack` | Slack | mixed | depends on mode |
 | `telegram` | Telegram | mixed | depends on mode |
 | `wecom` | WeCom | webhook | yes |
 
@@ -45,10 +45,20 @@ Add a channel explicitly:
 opensquilla channels add telegram --name personal
 ```
 
-Add provider-specific fields as needed:
+Add provider-specific fields as needed. Slack supports two modes:
 
 ```sh
-opensquilla channels add slack --name team --field signing_secret=... --token ...
+# Slack Socket Mode: outbound websocket, no public URL.
+opensquilla channels add slack --name team \
+  --field connection_mode=socket \
+  --field app_token=xapp-... \
+  --token xoxb-...
+
+# Slack Events API webhook: requires a public Request URL and signing secret.
+opensquilla channels add slack --name team-webhook \
+  --field connection_mode=webhook \
+  --field signing_secret=... \
+  --token xoxb-...
 ```
 
 Restart the gateway process after config edits:
@@ -82,10 +92,23 @@ opensquilla channels remove <name>
 Use `gateway restart` after config changes. Use `channels restart <name>` only
 for an already-loaded live adapter.
 
+## Slack Modes
+
+Slack Socket Mode uses an outbound websocket and does not require a public
+Request URL. It requires the bot token (`xoxb-...`) plus an app-level token
+(`xapp-...`) saved as `app_token`.
+
+Slack webhook mode uses the Events API Request URL. It requires the bot token
+plus `signing_secret`, and the gateway must be reachable by Slack.
+
+Leave `slack_channel_id` empty when the adapter should reply to the incoming
+conversation. Set it only when you want a default fallback channel. Enable
+`reply_in_thread` when replies should stay in Slack threads.
+
 ## Webhook Channels
 
-Slack and WeCom require a public, provider-reachable URL. Feishu and Telegram
-may require one depending on mode.
+Slack webhook mode and WeCom require a public, provider-reachable URL. Feishu
+and Telegram may require one depending on mode.
 
 For public channels:
 

--- a/docs/features/meta-skill-user-guide.md
+++ b/docs/features/meta-skill-user-guide.md
@@ -97,11 +97,32 @@ The retained built-in MetaSkills cover a focused set of high-value task classes.
 | `meta-job-search-pipeline` | Turns a JD, resume, and application goal into an application package and interview prep. |
 | `meta-kid-project-planner` | Produces safe, age-appropriate plans for school projects, show-and-tell, or science activities. |
 | `meta-paper-write` | Supports academic drafts, manuscript structure, citation planning, experiment placeholders, and LaTeX/PDF paths. |
+| `meta-short-drama` | Produces short-drama scripts, visual prompts, video assembly plans, subtitles, and rendered local video artifacts. |
 | `meta-skill-creator` | Turns repeated multi-skill collaboration patterns into new MetaSkill proposals. |
 | `meta-web-research-to-report` | Turns source-backed research needs into reports, briefs, or decision memos. |
 
 These are designed around quality over quantity. Immature, duplicate, or
 single-skill wrapper MetaSkills should not remain in the bundled catalog.
+
+## Requirements Before Running MetaSkills
+
+The Skill page is the source of truth for current readiness. Open the skill
+detail dialog and check the **Requirements** section before running workflows
+that export files, compile PDFs, or render video.
+
+Common setup surfaces:
+
+- Paper/PDF workflows such as `meta-paper-write` require `xelatex` and
+  `bibtex` on `PATH`. Install a TeX distribution such as TeX Live, MiKTeX, or
+  BasicTeX before requesting compiled PDFs.
+- Video workflows such as `meta-short-drama` require `ffmpeg` and `ffprobe` on
+  `PATH` for clip animation, merging, and subtitle burn-in.
+- Office-document workflows roll up requirements from child skills such as
+  `docx`, `xlsx`, `pdf-toolkit`, and `pptx`; these usually surface Python
+  package requirements in the Skill page.
+- Search, weather, image, and video-provider steps may require configured API
+  keys or provider credentials. The workflow should treat missing credentials as
+  setup blockers rather than silently degrading output.
 
 ## Two Ways to Use MetaSkill
 
@@ -388,6 +409,10 @@ Good fit:
 - citation plan;
 - experiment and figure/table placeholders;
 - LaTeX/PDF path when explicitly requested.
+
+PDF compilation requires `xelatex` and `bibtex` on `PATH`. If those binaries are
+missing, use the LaTeX source output or install TeX Live, MiKTeX, or BasicTeX
+before asking for a compiled PDF.
 
 High-quality request:
 

--- a/docs/features/meta-skills.md
+++ b/docs/features/meta-skills.md
@@ -31,11 +31,25 @@ The retained stable catalog is intentionally small:
 | `meta-job-search-pipeline` | Turns a JD, resume, and application goal into an application package and interview prep. |
 | `meta-kid-project-planner` | Produces safe, age-appropriate plans for school projects, show-and-tell, or science activities. |
 | `meta-paper-write` | Supports academic drafts, manuscript structure, citation planning, experiment placeholders, and LaTeX/PDF paths. |
+| `meta-short-drama` | Produces short-drama scripts, visual prompts, subtitles, and local video artifacts. |
 | `meta-skill-creator` | Turns repeated multi-skill collaboration patterns into new MetaSkill proposals. |
 | `meta-web-research-to-report` | Turns source-backed research needs into reports, briefs, or decision memos. |
 
 Experimental meta-skills may exist under development trees, but this page lists
-only stable built-ins that should be presented as retained product capabilities.
+only bundled built-ins that should be presented as retained product
+capabilities.
+
+## Requirements
+
+Use the Skill page detail dialog before running a MetaSkill. Its
+**Requirements** section shows the MetaSkill's own requirements plus one-hop
+requirements from child skills.
+
+- `meta-paper-write` needs `xelatex` and `bibtex` for PDF compilation.
+- `meta-short-drama` needs `ffmpeg` and `ffprobe` for local video rendering,
+  merge, and subtitle steps.
+- Document/report MetaSkills inherit readiness from child skills such as
+  `docx`, `xlsx`, `pdf-toolkit`, `pptx`, `multi-search-engine`, and `weather`.
 
 ## How to Ask
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -12,7 +12,7 @@ UI, CLI, channels, and gateway control console.
 Install OpenSquilla with the MCP extra when you need this bridge:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
 ```
 
 Start the OpenSquilla gateway:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -176,7 +176,7 @@ opensquilla mcp-server run
 Install with:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
 ```
 
 Use this when another MCP-capable client should access OpenSquilla-managed tools

--- a/docs/plans/2026-06-03-router-tier-c0-c3-plan.md
+++ b/docs/plans/2026-06-03-router-tier-c0-c3-plan.md
@@ -1,0 +1,211 @@
+# Router Tier c0-c3 Migration Plan
+
+Date: 2026-06-03
+
+## Goal
+
+Migrate OpenSquilla's text router tier identifiers from `t0-t3` to `c0-c3`, remove `S/M/L/XL tier` labels from user-facing/operator descriptions, and prevent Router Control prompt context from exposing tier-strength descriptions to the model.
+
+The bundled router's route classes (`R0-R3`) remain internal. Existing configurations and historical metadata using `t0-t3` should be accepted at input boundaries and normalized to canonical `c0-c3`.
+
+## Requirements
+
+- Canonical text router tier ids are `c0`, `c1`, `c2`, and `c3`.
+- Legacy `t0-t3` are read-only aliases at config/RPC/history/tool input boundaries.
+- Product output surfaces emit only `c0-c3`, not `t0-t3`.
+- `description` remains available for configuration, onboarding, diagnostics, and operator UI.
+- Router Control prompt must not include tier descriptions or explicit strength labels.
+- Default descriptions must not include `S tier`, `M tier`, `L tier`, or `XL tier`.
+- Router behavior must remain equivalent: `R0 -> c0`, `R1 -> c1`, `R2 -> c2`, `R3 -> c3`.
+- Existing routing controls, anti-downgrade behavior, large-context floors, savings display, and highest-tier compaction must continue to work.
+
+## Non-Goals
+
+- Do not retrain or regenerate the bundled router model artifacts.
+- Do not remove internal `T0-T3` thinking-mode names in this change.
+- Do not make descriptions private; only keep them out of model prompt context.
+- Do not preserve `t0-t3` as canonical public output.
+
+## Design Decisions
+
+### Canonical Tier Module
+
+Add one shared tier helper module, likely `src/opensquilla/squilla_router/tiers.py`, with:
+
+- `TEXT_TIERS = ("c0", "c1", "c2", "c3")`
+- `LEGACY_TEXT_TIER_ALIASES = {"t0": "c0", "t1": "c1", "t2": "c2", "t3": "c3"}`
+- `ROUTE_CLASS_TO_TIER = {"R0": "c0", "R1": "c1", "R2": "c2", "R3": "c3"}`
+- `TIER_TO_ROUTE_CLASS = {"c0": "R0", "c1": "R1", "c2": "R2", "c3": "R3"}`
+- `normalize_text_tier(value: object) -> str | None`
+- `normalize_tier_mapping(mapping: Mapping[str, Any]) -> dict[str, Any]`
+- `tier_index(value: object) -> int`
+- `highest_text_tier() -> str`
+- `default_text_tier() -> str`
+
+This avoids scattered string rewrites and fixes existing assumptions such as `str(routed_tier).lstrip("t")`.
+
+### Legacy Compatibility
+
+Normalize legacy ids at these boundaries:
+
+- Gateway config load and tier profile merge.
+- `default_tier` values from config files, environment-derived payloads, and RPC payloads.
+- Onboarding router configuration payloads.
+- Router history entries before anti-downgrade and previous-tier comparison.
+- Router Control target resolution for legacy requests like `tier:t3`.
+
+After normalization, runtime metadata and responses should store/emit canonical `c*` values.
+
+### Router Control Prompt
+
+Change `render_router_control_prompt_block()` so the model receives only operational target ids, not descriptions:
+
+```text
+Use `router_control` only when the user explicitly asks to use a configured route or restore automatic routing.
+Choose one target_id exactly from this menu; do not invent aliases or model ids.
+
+router_control_targets=[{"target_id":"tier:c0"},{"target_id":"tier:c1"},{"target_id":"tier:c2"},{"target_id":"tier:c3"}]
+```
+
+If model-specific targets are retained, expose only `target_id`, for example `{"target_id":"model:deepseek/deepseek-v4-pro"}`. Do not include `tier`, `description`, or `thinking_level` in the prompt menu unless a later requirement proves they are necessary.
+
+Router Control success/replay events may keep detailed metadata for observability, but model prompt context should remain minimal.
+
+### Descriptions
+
+Keep descriptions in config/profile data, but remove `S/M/L/XL tier` and similar explicit tier-label phrasing.
+
+Examples:
+
+- `DeepSeek V4 Flash route for trivial chat, short rewrites, extraction, and low-risk simple Q&A.`
+- `Default balanced text model for normal agent work, coding assistance, debugging, and moderate analysis.`
+- `Stronger text model for multi-step coding, structured reasoning, larger context synthesis, and harder analysis.`
+- `Highest-quality text reasoning model for difficult planning, deep review, complex debugging, and high-stakes synthesis.`
+
+Provider profiles should also avoid `fast tier`, `balanced tier`, `strong tier`, and `highest tier` phrasing. Use `route` or direct model description instead.
+
+## Implementation Steps
+
+1. Add shared tier helpers.
+   - Add `src/opensquilla/squilla_router/tiers.py`.
+   - Update `src/opensquilla/squilla_router/controller.py` to import canonical tier order.
+   - Keep internal thinking-mode values unchanged.
+
+2. Convert default router configuration.
+   - Update `src/opensquilla/gateway/config.py` default tiers and provider profiles to `c0-c3`.
+   - Change `SquillaRouterConfig.default_tier` to `c1`.
+   - Add config validators to normalize legacy tier mappings and legacy default tier values.
+   - Ensure config serialization writes canonical `c*`.
+
+3. Convert routing runtime.
+   - Update `src/opensquilla/squilla_router/v4_phase3.py` so `R0-R3` map to `c0-c3`.
+   - Update `src/opensquilla/engine/steps/squilla_router.py` to use shared helper constants.
+   - Change large-context floors from `t2/t3` to canonical `c2/c3`.
+   - Normalize previous routing history tiers before comparisons.
+   - Replace hardcoded fallback default `t1` with shared default tier.
+
+4. Convert special tier-dependent behavior.
+   - Update `src/opensquilla/engine/router_decision.py` to use `tier_index()`.
+   - Update Dream model selection in `src/opensquilla/memory/dream_factory.py` to use the default canonical tier instead of hardcoded `t1`.
+   - Update highest-tier compaction checks in `src/opensquilla/engine/runtime.py` from hardcoded `t3` to canonical highest text tier. Public names can remain `t3_upgrade` temporarily if renaming the feature would broaden the change too much.
+   - Update auto-propose paths in `src/opensquilla/gateway/boot.py` that currently read `tiers["t3"]`.
+
+5. Convert Router Control.
+   - Update `src/opensquilla/router_control.py` target building, tier strength ordering, target resolution, and prompt rendering.
+   - Accept `tier:t0-t3` as legacy input aliases but emit `tier:c0-c3`.
+   - Remove descriptions from prompt menu output.
+   - Remove `upgrade`/`downgrade` wording from prompt instructions where it implies tier strength.
+   - Update `src/opensquilla/tools/builtin/router_control.py` description if needed.
+
+6. Convert onboarding, CLI, and setup surfaces.
+   - Update `src/opensquilla/onboarding/mutations.py`.
+   - Update `src/opensquilla/onboarding/router_specs.py`.
+   - Update `src/opensquilla/onboarding/flow.py`.
+   - Update `src/opensquilla/onboarding/next_steps.py`.
+   - Update `src/opensquilla/cli/onboard_cmd.py`.
+   - Ensure setup payloads accept legacy ids but display canonical ids.
+
+7. Convert WebUI router display.
+   - Update `src/opensquilla/gateway/static/js/views/setup.js` text tiers and labels.
+   - Update `src/opensquilla/gateway/static/js/views/chat.js` router-fx default tiers, sorting, comments, history handling, and placeholder handling.
+   - Update `src/opensquilla/gateway/static/css/components.css` tier badge classes from `.t0/.t2/.t3` to `.c0/.c2/.c3`.
+
+8. Update docs, examples, scripts, and tests.
+   - Update `opensquilla.toml.example`.
+   - Update router behavior tests.
+   - Update Router Control tests.
+   - Update onboarding tests.
+   - Update WebUI functional tests.
+   - Update live/smoke scripts that define tier configs.
+   - Leave unrelated `t0` variables, scheduler anchors, Slack channel ids, and bundled tokenizer vocabulary untouched.
+
+## Acceptance Criteria
+
+- New default config uses `c0-c3` and `default_tier = "c1"`.
+- Old config with `t0-t3` starts successfully and runtime-normalizes to `c0-c3`.
+- Router classifier output maps `R0-R3` to `c0-c3`.
+- `routed_tier`, `final_tier`, `base_tier`, `previous_tier`, and router events emit `c*` values after normalization.
+- `RouterDecisionEvent.tier_index` returns `0-3` for `c0-c3`.
+- Router Control accepts `tier:t3` as a legacy alias but emits `tier:c3`.
+- Router Control prompt output contains no `description`, `S tier`, `M tier`, `L tier`, `XL tier`, or `tier:t0-t3`.
+- WebUI setup and chat surfaces display `c0-c3`.
+- `description` remains visible in config/operator-facing payloads where already supported.
+- Highest-tier compaction still triggers on upgrades into `c3`.
+- Dream/default model selection still resolves a valid default text model.
+
+## Verification Plan
+
+Run targeted tests first:
+
+```bash
+pytest \
+  tests/test_model_router_behavior.py \
+  tests/test_engine/test_router_decision_event.py \
+  tests/test_engine/test_router_control.py \
+  tests/test_tools/test_router_control_tool.py \
+  tests/test_onboarding/test_router_specs.py \
+  tests/test_onboarding/test_mutations.py \
+  tests/test_onboarding/test_flow.py \
+  tests/test_gateway/test_static_onboarding_views.py
+```
+
+Run high-risk behavior tests:
+
+```bash
+pytest \
+  tests/test_engine/test_t3_upgrade_compaction.py \
+  tests/test_memory_dream_factory.py \
+  tests/functional/test_webui_browser_chat_e2e.py
+```
+
+Run static checks for prompt leakage:
+
+```bash
+rg -n "S tier|M tier|L tier|XL tier|tier:t[0-3]|router_control_targets=.*description" \
+  src opensquilla.toml.example tests
+```
+
+Expected remaining matches should be limited to legacy-compat tests or irrelevant fixtures, with each remaining match reviewed.
+
+## Risks And Mitigations
+
+- Risk: old configs fail to route correctly.
+  - Mitigation: normalize legacy `t*` config keys and defaults during config model validation.
+
+- Risk: hidden runtime comparisons still assume `t*`.
+  - Mitigation: replace all tier ordering/index logic with shared helpers and add regression tests for `c*`.
+
+- Risk: model still infers strength from Router Control prompt.
+  - Mitigation: remove descriptions and strength wording from prompt menu; expose only exact target ids.
+
+- Risk: UI loses router history strips for old sessions.
+  - Mitigation: normalize incoming `routed_tier` values in history/event handling or backend history projection.
+
+- Risk: changing public metadata breaks downstream consumers expecting `t*`.
+  - Mitigation: treat `c*` as the new canonical contract, but accept `t*` at input boundaries. Document the change in release notes.
+
+## Implementation Decisions
+
+- Legacy `t*` config is normalized in memory at load time; existing files are not automatically rewritten except through normal config save flows.
+- Public config now uses `upgrade_to_c3_compaction_enabled`; the old `upgrade_to_t3_compaction_enabled` key is accepted as an input alias so explicit false values are preserved.
+- Router Control prompt and dynamic tool schema expose only canonical route target ids (`tier:c0` through `tier:c3`), not model ids or descriptions.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,7 +16,7 @@ UI, SquillaRouter, memory/search support, and safe local defaults.
 Install the current release wheel with the recommended extras:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
 ```
 
 The `recommended` extra includes SquillaRouter dependencies and memory/search

--- a/docs/releases/0.3.1.md
+++ b/docs/releases/0.3.1.md
@@ -1,0 +1,94 @@
+# OpenSquilla 0.3.1
+
+## Overview
+
+OpenSquilla 0.3.1 is a maintenance release for the 0.3 line. It updates the
+stable install metadata and brings selected channel, chat, provider, and
+workflow fixes from the integration branch onto the stable release line.
+
+Use this release when you want the current 0.3 install assets plus the latest
+Slack setup fixes, media and voice workflow handoffs, multiline chat rendering,
+and provider request hardening on the stable release line.
+
+## Fixed
+
+### Chat messages preserve authored formatting
+
+User-authored WebChat messages preserve multiline input and use spacing that
+makes them read like messages instead of compressed UI labels.
+
+### Channel setup preserves the context needed for replies
+
+Slack Socket Mode, app mentions, signing-secret checks, existing-secret
+preservation, and threaded replies are hardened across onboarding and runtime
+paths. Incomplete Socket Mode setup is rejected earlier, and Slack reply
+handling keeps the channel metadata needed to answer in the right place.
+
+### Voice, media, and MetaSkill handoffs are more usable
+
+Voice/audio workflow handoffs and clarification pauses are on the stable
+release line. The bundled short-drama and video helper workflows remain
+available, with Windows-safe script handling and review pauses that make media
+workflow output easier to inspect before continuing.
+
+### Provider and release checks fail earlier
+
+Malformed tool-call history is kept away from providers before it becomes an
+invalid request. PR CI also classifies changed files by impact surface, so docs,
+runtime, dependency, release, and test changes can trigger the checks they need
+without forcing unnecessary work for every pull request.
+
+## Changed
+
+- Release installer defaults now point to `v0.3.1`.
+- README, quickstart, MCP, and operations docs now use the 0.3.1 wheel URL.
+- `pyproject.toml`, `uv.lock`, release consistency tests, and install-script
+  tests now agree on version `0.3.1`.
+- `docs/releases/0.3.1.md` is the GitHub Release body source for the final
+  release review.
+
+## Downloads
+
+- Python wheel: `opensquilla-0.3.1-py3-none-any.whl`
+- Windows portable: `OpenSquilla-0.3.1-windows-x64-py312-recommended-portable.zip`
+- Stable Windows portable alias: `OpenSquilla-windows-x64-portable.zip`
+- Checksums: `SHA256SUMS`
+
+Linux and macOS users should install the Python wheel with `uv tool install`.
+Windows users can use either the wheel or the portable zip.
+
+## Upgrading from 0.3.0
+
+If OpenSquilla was installed with `uv tool install`, reinstall 0.3.1 over the
+existing tool environment:
+
+```sh
+uv tool install --python 3.12 --force --reinstall-package opensquilla \
+  "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
+```
+
+The release installers use the same forced reinstall path. Close any running
+OpenSquilla gateway before upgrading, then restart it after the install.
+Existing `~/.opensquilla/config.toml` and session data are reused.
+
+Windows portable users should extract the 0.3.1 zip to a fresh folder, or
+replace the whole extracted 0.3.0 folder while the gateway is stopped. Do not
+copy only individual files from the new zip into an old portable tree.
+
+## Acknowledgements
+
+Thanks @openvictory for #123, #133, and #137, which helped bring visible
+running-state feedback plus short-drama and media helper workflows into the
+0.3.1 release line.
+
+Thanks @freeaccount-create for #142, which helped bring Slack Socket Mode and
+self-targeting replies into the channel workflow.
+
+Thanks @ruhook for #124, and thanks @qq712696307 for the authored commit in
+that pull request, which preserved user message newlines in WebChat.
+
+Thanks @Cola-Alex for #143, which increased tokenjuice summarize and
+failure-context windows for fallback tool-result projection.
+
+Thanks @nice-code-la for #165 and #166, which helped make voice workflows usable
+end to end and clarification pauses resume cleanly.

--- a/docs/releases/0.3.1.md
+++ b/docs/releases/0.3.1.md
@@ -10,7 +10,7 @@ Use this release when you want the current 0.3 install assets plus the latest
 Slack setup fixes, media and voice workflow handoffs, multiline chat rendering,
 and provider request hardening on the stable release line.
 
-## Fixed
+## 🛠 Fixed
 
 ### Chat messages preserve authored formatting
 
@@ -56,6 +56,9 @@ without forcing unnecessary work for every pull request.
 
 Linux and macOS users should install the Python wheel with `uv tool install`.
 Windows users can use either the wheel or the portable zip.
+
+The stable Windows portable alias contains the same build as the versioned
+portable zip, but keeps a fixed filename for scripts and docs.
 
 ## Upgrading from 0.3.0
 

--- a/docs/releases/0.3.1.md
+++ b/docs/releases/0.3.1.md
@@ -3,33 +3,29 @@
 ## Overview
 
 OpenSquilla 0.3.1 is a maintenance release for the 0.3 line. It updates the
-stable install metadata and brings selected channel, chat, provider, and
-workflow fixes from the integration branch onto the stable release line.
+stable install path while bringing the most user-visible fixes from the
+integration branch onto the release line.
 
-Use this release when you want the current 0.3 install assets plus the latest
-Slack setup fixes, media and voice workflow handoffs, multiline chat rendering,
-and provider request hardening on the stable release line.
+The release focuses on making day-to-day use less fragile: chat messages render
+as authored, Slack channel setup and replies keep the context they need, media
+and voice workflow handoffs are easier to continue, and invalid provider or
+release states are caught earlier.
 
 ## 🛠 Fixed
 
-### Chat messages preserve authored formatting
+### Chat and channel replies keep their context
 
-User-authored WebChat messages preserve multiline input and use spacing that
-makes them read like messages instead of compressed UI labels.
+WebChat now preserves multiline user messages and gives authored messages more
+readable spacing. Slack setup and reply paths also keep more of the context they
+need, including Socket Mode and app-mention setup, signing-secret checks,
+existing-secret preservation, and thread/channel metadata for replies.
 
-### Channel setup preserves the context needed for replies
+### Workflow handoffs recover more cleanly
 
-Slack Socket Mode, app mentions, signing-secret checks, existing-secret
-preservation, and threaded replies are hardened across onboarding and runtime
-paths. Incomplete Socket Mode setup is rejected earlier, and Slack reply
-handling keeps the channel metadata needed to answer in the right place.
-
-### Voice, media, and MetaSkill handoffs are more usable
-
-Voice/audio workflow handoffs and clarification pauses are on the stable
-release line. The bundled short-drama and video helper workflows remain
-available, with Windows-safe script handling and review pauses that make media
-workflow output easier to inspect before continuing.
+Voice/audio, media helper, and MetaSkill clarification handoffs are now on the
+stable release line. The bundled short-drama and video helper workflows remain
+available, with Windows-safe script handling and review pauses so generated
+workflow output is easier to inspect before continuing.
 
 ### Provider and release checks fail earlier
 

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v0.3.0'
+$defaultVersion = 'v0.3.1'
 $repoSlug = if ($env:OPENSQUILLA_REPOSITORY) { $env:OPENSQUILLA_REPOSITORY } else { 'opensquilla/opensquilla' }
 $pythonVersion = if ($env:OPENSQUILLA_PYTHON_VERSION) { $env:OPENSQUILLA_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -94,7 +94,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.3.0. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.3.1. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v0.3.0"
+default_version="v0.3.1"
 repo_slug="${OPENSQUILLA_REPOSITORY:-opensquilla/opensquilla}"
 python_version="${OPENSQUILLA_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v0.3.0|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v0.3.1|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  OPENSQUILLA_VERSION=v0.3.0
+  OPENSQUILLA_VERSION=v0.3.1
   OPENSQUILLA_INSTALL_PROFILE=recommended|core
   OPENSQUILLA_INSTALL_EXTRAS=matrix
   OPENSQUILLA_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported OPENSQUILLA_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.3.0." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.3.1." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -182,7 +182,7 @@ strategy = "v4_phase3"
 #   1. install with `uv sync --extra model-router` or `uv sync --extra recommended`
 #   2. hydrate model assets via:
 #      git lfs pull --include="src/opensquilla/squilla_router/models/**"
-default_tier = "t1"
+default_tier = "c1"
 confidence_threshold = 0.5
 v4_use_aux_head = true
 kv_cache_anti_downgrade_enabled = true
@@ -192,33 +192,33 @@ complaint_upgrade_steps = 1
 complaint_upgrade_max_chars = 160
 require_router_runtime = true
 estimated_output_savings_pct = 0.03
-upgrade_to_t3_compaction_enabled = true
+upgrade_to_c3_compaction_enabled = true
 
-[squilla_router.tiers.t0]
+[squilla_router.tiers.c0]
 provider = "openrouter"
 model = "deepseek/deepseek-v4-flash"
-description = "S tier: fast DeepSeek V4 Flash route for trivial chat, short rewrites, extraction, and low-risk simple Q&A"
+description = "Fast DeepSeek V4 Flash route for trivial chat, short rewrites, extraction, and low-risk simple Q&A"
 supports_image = false
 thinking_level = "high"
 
-[squilla_router.tiers.t1]
+[squilla_router.tiers.c1]
 provider = "openrouter"
 model = "deepseek/deepseek-v4-pro"
-description = "M tier: default balanced text model for normal agent work, coding assistance, debugging, and moderate analysis"
+description = "Default balanced text route for normal agent work, coding assistance, debugging, and moderate analysis"
 supports_image = false
 thinking_level = "high"
 
-[squilla_router.tiers.t2]
+[squilla_router.tiers.c2]
 provider = "openrouter"
 model = "z-ai/glm-5.1"
-description = "L tier: stronger text model for multi-step coding, structured reasoning, larger context synthesis, and harder analysis"
+description = "Stronger text route for multi-step coding, structured reasoning, larger context synthesis, and harder analysis"
 supports_image = false
 thinking_level = "high"
 
-[squilla_router.tiers.t3]
+[squilla_router.tiers.c3]
 provider = "openrouter"
 model = "anthropic/claude-opus-4.7"
-description = "XL tier: highest-quality text reasoning model for difficult planning, deep review, complex debugging, and high-stakes synthesis"
+description = "Highest-quality text reasoning route for difficult planning, deep review, complex debugging, and high-stakes synthesis"
 supports_image = false
 thinking_level = "high"
 

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -293,7 +293,11 @@ default_mode = "bypass"                 # off | on | bypass | full
 # name = "my-slack"
 # type = "slack"
 # token = "xoxb-..."
+# connection_mode = "socket"  # socket = no public URL; webhook = Events API
+# app_token = "xapp-..."      # required for Slack Socket Mode
+# signing_secret = ""         # required for Slack webhook mode
 # slack_channel_id = "C12345"
+# reply_in_thread = false
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Meta-Skill subsystem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensquilla"
-version = "0.3.0"
+version = "0.3.1"
 description = "OpenSquilla — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/live_meta_skill_creator_auto_propose_e2e.py
+++ b/scripts/live_meta_skill_creator_auto_propose_e2e.py
@@ -102,11 +102,11 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
     )
     from opensquilla.tools.dispatch import build_tool_handler
 
-    t3_tiers = {
-        "t0": {"provider": args.provider, "model": args.model, "thinking_level": "off"},
-        "t1": {"provider": args.provider, "model": args.model, "thinking_level": "low"},
-        "t2": {"provider": args.provider, "model": args.model, "thinking_level": "medium"},
-        "t3": {"provider": args.provider, "model": args.model, "thinking_level": "high"},
+    text_tiers = {
+        "c0": {"provider": args.provider, "model": args.model, "thinking_level": "off"},
+        "c1": {"provider": args.provider, "model": args.model, "thinking_level": "low"},
+        "c2": {"provider": args.provider, "model": args.model, "thinking_level": "medium"},
+        "c3": {"provider": args.provider, "model": args.model, "thinking_level": "high"},
     }
     actual_cron = args.actual_scheduler and args.trigger == "cron"
     actual_dream = args.actual_scheduler and args.trigger == "dream"
@@ -121,8 +121,8 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
         },
         squilla_router={
             "enabled": True,
-            "tiers": t3_tiers,
-            "default_tier": "t3",
+            "tiers": text_tiers,
+            "default_tier": "c3",
         },
         meta_skill={
             "auto_propose": {
@@ -184,7 +184,7 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
             metadata={
                 "routing_source": "meta_skill_auto_propose",
                 "routing_applied": True,
-                "routed_tier": "t3",
+                "routed_tier": "c3",
                 "routed_model": args.model,
                 "applied_model": args.model,
                 "thinking_requested": True,

--- a/scripts/live_provider_profile_gateway_e2e.py
+++ b/scripts/live_provider_profile_gateway_e2e.py
@@ -59,19 +59,19 @@ BASE_ENV = {
     "moonshot": "MOONSHOT_BASE_URL",
     "zhipu": "ZAI_BASE_URL",
 }
-TEXT_PROFILE_SLOTS = ("t0", "t1", "t2", "t3")
+TEXT_PROFILE_SLOTS = ("c0", "c1", "c2", "c3")
 LIVE_AGENT_MAX_ITERATIONS = 6
 LIVE_AGENT_RUNTIME_TIMEOUT_SECONDS = 75.0
 LIVE_TURN_HARD_DEADLINE_SECONDS = 90.0
 
 TIER_CASES = [
     {
-        "tier": "t0",
+        "tier": "c0",
         "id": "r0_short_ack",
         "message": "谢谢。不要调用工具，请只回复一个短句，包含 {marker}。",
     },
     {
-        "tier": "t1",
+        "tier": "c1",
         "id": "r1_structured_compare",
         "message": (
             "不要调用工具，只输出 Markdown 表格和 marker。用不超过 4 行的表格比较 "
@@ -80,7 +80,7 @@ TIER_CASES = [
         ),
     },
     {
-        "tier": "t2",
+        "tier": "c2",
         "id": "r2_debugging",
         "message": (
             "下面是异步服务偶发超时的日志片段：连接池耗尽、慢查询、重试风暴、队列积压。"
@@ -89,7 +89,7 @@ TIER_CASES = [
         ),
     },
     {
-        "tier": "t3",
+        "tier": "c3",
         "id": "r3_architecture",
         "message": (
             "请设计跨机房分布式任务调度系统，解释一致性、故障恢复和容量评估。"
@@ -222,7 +222,7 @@ def _write_config(
     model: str,
     *,
     max_tokens: int,
-    default_tier: str = "t1",
+    default_tier: str = "c1",
     tier_overrides: dict[str, dict[str, Any]] | None = None,
 ) -> None:
     tier_override_toml = _render_tier_overrides(tier_overrides)
@@ -407,7 +407,7 @@ def _run_gateway_case_batch(
     max_tokens: int,
     timeout_seconds: float,
     case_mode: str,
-    default_tier: str = "t1",
+    default_tier: str = "c1",
     tier_overrides: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     active_tiers = tier_overrides or tiers

--- a/scripts/smoke_v4_phase3_router.py
+++ b/scripts/smoke_v4_phase3_router.py
@@ -32,25 +32,25 @@ from opensquilla.env import load_env  # noqa: E402
 from opensquilla.gateway.config import GatewayConfig  # noqa: E402
 
 TIERS = {
-    "t0": {
+    "c0": {
         "provider": "openrouter",
         "model": "deepseek/deepseek-v4-flash",
         "description": "short text and trivial follow-ups",
         "thinking_level": "high",
     },
-    "t1": {
+    "c1": {
         "provider": "openrouter",
         "model": "deepseek/deepseek-v4-pro",
         "description": "normal coding and agent tasks",
         "thinking_level": "high",
     },
-    "t2": {
+    "c2": {
         "provider": "openrouter",
         "model": "z-ai/glm-5.1",
         "description": "structured multi-step work",
         "thinking_level": "high",
     },
-    "t3": {
+    "c3": {
         "provider": "openrouter",
         "model": "anthropic/claude-opus-4.7",
         "description": "deep reasoning and hard recovery turns",
@@ -316,7 +316,7 @@ DIALOGUE_ROUTER_CASES = [
         "id": "dialogue_r3_then_summarize",
         "category": "continuous_kv_cache",
         "description": (
-            "A hard architecture turn followed by a short compression request should keep t3."
+            "A hard architecture turn followed by a short compression request should keep c3."
         ),
         "turns": [
             {
@@ -330,7 +330,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "好的，把上面的方案压缩成三句话。",
                 "expected_route_class": "R1",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
@@ -352,7 +352,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "收到。",
                 "expected_route_class": "R0",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
@@ -371,14 +371,14 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "谢谢，先按这个方向查。",
                 "expected_route_class": "R1",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
     {
         "id": "dialogue_r2_then_more_detail",
         "category": "continuous_kv_cache",
-        "description": "A reasoning task followed by detail expansion should stay at or above t2.",
+        "description": "A reasoning task followed by detail expansion should stay at or above c2.",
         "turns": [
             {
                 "message": "发布后 P95 延迟从 300ms 涨到 2s，请给出从指标到代码的回归定位流程。",
@@ -388,7 +388,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "继续展开数据库和缓存两个方向。",
                 "expected_route_class": "R2",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
@@ -404,7 +404,7 @@ DIALOGUE_ROUTER_CASES = [
             {
                 "message": "再给一个团队协作中的例子。",
                 "expected_route_class": "R1",
-                "expected_final_tier": "t1",
+                "expected_final_tier": "c1",
             },
         ],
     },
@@ -412,7 +412,7 @@ DIALOGUE_ROUTER_CASES = [
         "id": "dialogue_r1_then_ack",
         "category": "continuous_followup",
         "description": (
-            "A standard task followed by acknowledgement should keep the active t1 model."
+            "A standard task followed by acknowledgement should keep the active c1 model."
         ),
         "turns": [
             {
@@ -423,7 +423,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "好的。",
                 "expected_route_class": "R0",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t1",
+                "expected_final_tier": "c1",
             },
         ],
     },
@@ -440,7 +440,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "不对，你没理解我的意思，重新回答。",
                 "expected_route_class": "R0",
                 "expect_complaint_upgrade": True,
-                "expected_final_tier": "t1",
+                "expected_final_tier": "c1",
             },
         ],
     },
@@ -457,7 +457,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "这不对，太泛了，按客户视角重新写。",
                 "expected_route_class": "R2",
                 "expect_complaint_upgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
@@ -480,7 +480,7 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "不对，刚才漏掉了 scheduler event 和 admission webhook，重新排查。",
                 "expected_route_class": "R1",
                 "expect_complaint_upgrade": True,
-                "expected_final_tier": "t2",
+                "expected_final_tier": "c2",
             },
         ],
     },
@@ -503,20 +503,20 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "先只保留权限边界。",
                 "expected_route_class": "R0",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
             {
                 "message": "再压缩成三条。",
                 "expected_route_class": "R0",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
     {
         "id": "dialogue_three_turn_r2_sticky",
         "category": "continuous_kv_cache",
-        "description": "A multi-turn debugging flow should keep t2 across brief narrowing turns.",
+        "description": "A multi-turn debugging flow should keep c2 across brief narrowing turns.",
         "turns": [
             {
                 "message": (
@@ -529,13 +529,13 @@ DIALOGUE_ROUTER_CASES = [
                 "message": "只看异步任务这一块。",
                 "expected_route_class": "R0",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t2",
+                "expected_final_tier": "c2",
             },
             {
                 "message": "再压缩成三条。",
                 "expected_route_class": "R0",
                 "expect_anti_downgrade": True,
-                "expected_final_tier": "t2",
+                "expected_final_tier": "c2",
             },
         ],
     },
@@ -543,7 +543,7 @@ DIALOGUE_ROUTER_CASES = [
         "id": "dialogue_r0_to_r1_no_sticky_jump",
         "category": "continuous_followup",
         "description": (
-            "A trivial first turn should not block a later standard task from choosing t1."
+            "A trivial first turn should not block a later standard task from choosing c1."
         ),
         "turns": [
             {
@@ -553,7 +553,7 @@ DIALOGUE_ROUTER_CASES = [
             {
                 "message": "比较 PostgreSQL 和 MySQL 在事务、索引、复制方面的差异，用表格输出。",
                 "expected_route_class": "R1",
-                "expected_final_tier": "t1",
+                "expected_final_tier": "c1",
             },
         ],
     },
@@ -574,7 +574,7 @@ DIALOGUE_ROUTER_CASES = [
                     "连接池耗尽、慢查询、重试风暴、队列积压同时出现。"
                 ),
                 "expected_route_class": "R2",
-                "expected_final_tier": "t2",
+                "expected_final_tier": "c2",
             },
         ],
     },
@@ -582,7 +582,7 @@ DIALOGUE_ROUTER_CASES = [
         "id": "dialogue_r1_to_r3_upgrade",
         "category": "continuous_followup",
         "description": (
-            "A standard first turn should allow a later architecture request to upgrade to t3."
+            "A standard first turn should allow a later architecture request to upgrade to c3."
         ),
         "turns": [
             {
@@ -592,7 +592,7 @@ DIALOGUE_ROUTER_CASES = [
             {
                 "message": "现在基于这三个组件设计一个跨区域高可用架构，说明故障恢复和容量评估。",
                 "expected_route_class": "R3",
-                "expected_final_tier": "t3",
+                "expected_final_tier": "c3",
             },
         ],
     },
@@ -618,7 +618,7 @@ def _router_config() -> GatewayConfig:
             "strategy": "v4_phase3",
             "rollout_phase": "full",
             "tiers": TIERS,
-            "default_tier": "t1",
+            "default_tier": "c1",
             "require_router_runtime": True,
             "confidence_threshold": 0.5,
             "kv_cache_anti_downgrade_enabled": True,
@@ -705,8 +705,8 @@ async def _forced_recent_history_scenario() -> dict[str, Any]:
             "text": "上一轮是一个长上下文的架构设计问题。",
             "route_class": "R3",
             "final_route_class": "R3",
-            "base_tier": "t3",
-            "final_tier": "t3",
+            "base_tier": "c3",
+            "final_tier": "c3",
             "difficulty": 2.0,
             "margin": 0.8,
             "top1_label": "R3",
@@ -716,8 +716,8 @@ async def _forced_recent_history_scenario() -> dict[str, Any]:
     extra = ctx.metadata.get("routing_extra") or {}
     ok = (
         extra.get("anti_downgrade_applied") is True
-        and ctx.metadata.get("routed_tier") == "t3"
-        and extra.get("previous_tier") == "t3"
+        and ctx.metadata.get("routed_tier") == "c3"
+        and extra.get("previous_tier") == "c3"
     )
     scenario = _scenario_from_ctx(
         "forced_recent_history_blocks_downgrade",
@@ -938,14 +938,30 @@ def _post_json(url: str, payload: dict[str, Any], timeout: float = 5.0) -> dict[
 
 
 def _live_tier_model_map(live_model: str) -> dict[str, str]:
+    def _tier_model_env(canonical: str, legacy: str, default: str) -> str:
+        return os.environ.get(canonical, os.environ.get(legacy, default)).strip()
+
     live_tier_models = {
-        "t0": os.environ.get("OPENSQUILLA_LIVE_LLM_T0_MODEL", "deepseek/deepseek-v4-flash").strip(),
-        "t1": os.environ.get("OPENSQUILLA_LIVE_LLM_T1_MODEL", "deepseek/deepseek-v4-pro").strip(),
-        "t2": os.environ.get("OPENSQUILLA_LIVE_LLM_T2_MODEL", "z-ai/glm-5.1").strip(),
-        "t3": os.environ.get(
+        "c0": _tier_model_env(
+            "OPENSQUILLA_LIVE_LLM_C0_MODEL",
+            "OPENSQUILLA_LIVE_LLM_T0_MODEL",
+            "deepseek/deepseek-v4-flash",
+        ),
+        "c1": _tier_model_env(
+            "OPENSQUILLA_LIVE_LLM_C1_MODEL",
+            "OPENSQUILLA_LIVE_LLM_T1_MODEL",
+            "deepseek/deepseek-v4-pro",
+        ),
+        "c2": _tier_model_env(
+            "OPENSQUILLA_LIVE_LLM_C2_MODEL",
+            "OPENSQUILLA_LIVE_LLM_T2_MODEL",
+            "z-ai/glm-5.1",
+        ),
+        "c3": _tier_model_env(
+            "OPENSQUILLA_LIVE_LLM_C3_MODEL",
             "OPENSQUILLA_LIVE_LLM_T3_MODEL",
             "anthropic/claude-opus-4.7",
-        ).strip(),
+        ),
     }
     if live_model:
         return {tier: live_model for tier in live_tier_models}
@@ -956,10 +972,10 @@ def _write_live_gateway_config(path: Path, live_model: str) -> None:
     live_tier_models = _live_tier_model_map(live_model)
     tier_blocks = []
     for tier, description in {
-        "t0": "live smoke fast tier",
-        "t1": "live smoke standard tier",
-        "t2": "live smoke reasoning tier",
-        "t3": "live smoke frontier tier",
+        "c0": "live smoke fast route",
+        "c1": "live smoke standard route",
+        "c2": "live smoke reasoning route",
+        "c3": "live smoke frontier route",
     }.items():
         tier_blocks.append(
             f"""
@@ -990,7 +1006,7 @@ source = "state"
 
 [llm]
 provider = "openrouter"
-model = "{live_model or live_tier_models['t1']}"
+model = "{live_model or live_tier_models['c1']}"
 base_url = "https://openrouter.ai/api/v1"
 max_tokens = 192
 
@@ -999,7 +1015,7 @@ enabled = true
 auto_thinking = true
 rollout_phase = "full"
 strategy = "v4_phase3"
-default_tier = "t1"
+default_tier = "c1"
 confidence_threshold = 0.5
 kv_cache_anti_downgrade_enabled = true
 kv_cache_anti_downgrade_window_seconds = 600

--- a/src/opensquilla/cli/onboard_cmd.py
+++ b/src/opensquilla/cli/onboard_cmd.py
@@ -583,7 +583,7 @@ _CATALOG_COMMANDS = {
         "--api-key-env <ENV_NAME>"
     ),
     "routerProfiles": (
-        "opensquilla onboard configure router --router recommended --default-tier t1"
+        "opensquilla onboard configure router --router recommended --default-tier c1"
     ),
     "searchProviders": (
         "opensquilla onboard configure search --search-provider <provider> "
@@ -841,7 +841,7 @@ def _router_tier_summary(profile: dict[str, object]) -> str:
     if not isinstance(tiers, dict):
         return ""
     summary: list[str] = []
-    for tier in ("t0", "t1", "t2", "t3"):
+    for tier in ("c0", "c1", "c2", "c3"):
         tier_spec = tiers.get(tier)
         if isinstance(tier_spec, dict):
             summary.append(f"{tier}: {tier_spec.get('model', '')}")
@@ -1085,7 +1085,7 @@ def configure_command(
     default_tier: str = typer.Option(
         "",
         "--default-tier",
-        help="Default router text tier: t0, t1, t2, or t3.",
+        help="Default router text tier: c0, c1, c2, or c3.",
         rich_help_panel="Router",
     ),
     search_provider: str = typer.Option(

--- a/src/opensquilla/engine/router_decision.py
+++ b/src/opensquilla/engine/router_decision.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 from opensquilla.engine.pipeline import TurnContext
 from opensquilla.engine.types import RouterDecisionEvent
+from opensquilla.router_tiers import normalize_text_tier, tier_index
 
 
 def _coerce_probs(value: object) -> list[float]:
@@ -53,11 +54,8 @@ def build_router_decision_event(turn: TurnContext) -> RouterDecisionEvent | None
     if isinstance(tier_savings, dict):
         savings_pct = savings_pct or _coerce_float(tier_savings.get("pct"))
 
-    tier_idx = -1
-    try:
-        tier_idx = int(str(routed_tier).lstrip("t"))
-    except (TypeError, ValueError):
-        tier_idx = -1
+    routed_tier = normalize_text_tier(routed_tier) or routed_tier
+    tier_idx = tier_index(routed_tier)
 
     source = str(turn.metadata.get("routing_source") or "none")
     routing_applied = turn.metadata.get("routing_applied")

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -150,6 +150,7 @@ from opensquilla.router_control import (
     RouterControlHoldStore,
     render_router_control_prompt_block,
 )
+from opensquilla.router_tiers import HIGHEST_TEXT_TIER, normalize_text_tier, tier_index
 from opensquilla.safety import injection_guard, permission_matrix, sandbox, tool_tiers
 from opensquilla.session.compaction_lifecycle import (
     COMPACTION_CHUNK_SUMMARIZED_EVENT,
@@ -4316,27 +4317,32 @@ class TurnRunner:
         and compact failures that should trip the circuit without retrying.
         """
         router_cfg = getattr(self._config, "squilla_router", None)
-        if not getattr(router_cfg, "upgrade_to_t3_compaction_enabled", False):
+        upgrade_compaction_enabled = getattr(
+            router_cfg,
+            "upgrade_to_c3_compaction_enabled",
+            getattr(router_cfg, "upgrade_to_t3_compaction_enabled", False),
+        )
+        if not upgrade_compaction_enabled:
             return _T3_NOT_APPLICABLE
 
-        routed_tier = turn.metadata.get("routed_tier")
-        if routed_tier != "t3":
+        routed_tier = normalize_text_tier(turn.metadata.get("routed_tier"))
+        if routed_tier != HIGHEST_TEXT_TIER:
             return _T3_NOT_APPLICABLE
 
         if not turn.metadata.get("routing_applied", False):
             return _T3_NOT_APPLICABLE
 
         routing_extra = turn.metadata.get("routing_extra", {})
-        previous = routing_extra.get("previous_tier")
+        previous = normalize_text_tier(routing_extra.get("previous_tier"))
         if previous is None:
-            final = routing_extra.get("final_tier")
-            base = routing_extra.get("base_tier")
-            if final == "t3" and base in {"t0", "t1", "t2"}:
+            final = normalize_text_tier(routing_extra.get("final_tier"))
+            base = normalize_text_tier(routing_extra.get("base_tier"))
+            if final == HIGHEST_TEXT_TIER and tier_index(base) in {0, 1, 2}:
                 previous = base
             else:
                 return _T3_NOT_APPLICABLE
 
-        if previous not in {"t0", "t1", "t2"}:
+        if tier_index(previous) not in {0, 1, 2}:
             return _T3_NOT_APPLICABLE
 
         if session_key.startswith(("cron:", "subagent:")):
@@ -4409,7 +4415,7 @@ class TurnRunner:
             "t3_upgrade_compaction.triggered",
             session_key=session_key,
             previous_tier=previous,
-            final_tier="t3",
+            final_tier=HIGHEST_TEXT_TIER,
             context_window_tokens=context_window_tokens,
         )
         self.mark_compaction_attempted_this_turn(session_key)

--- a/src/opensquilla/engine/steps/meta_resolution.py
+++ b/src/opensquilla/engine/steps/meta_resolution.py
@@ -456,9 +456,9 @@ def _trigger_match_text(message: str) -> str:
 
 
 def _tier_sort_key(name: str, index: int) -> tuple[int, int]:
-    """Prefer numeric router tiers (t0 < t1 < t2 < t3), then declaration order."""
+    """Prefer canonical router tiers (c0 < c1 < c2 < c3), then declaration order."""
 
-    match = re.fullmatch(r"t(\d+)", name.strip().lower())
+    match = re.fullmatch(r"c(\d+)", name.strip().lower())
     if match:
         return (int(match.group(1)), index)
     return (-1, index)

--- a/src/opensquilla/engine/steps/squilla_router.py
+++ b/src/opensquilla/engine/steps/squilla_router.py
@@ -20,6 +20,13 @@ from opensquilla.engine.pipeline import TurnContext
 from opensquilla.engine.pricing import lookup_price
 from opensquilla.provider.context_capabilities import provider_state_continuity_diagnostic
 from opensquilla.router_control import RouterControlHoldStore
+from opensquilla.router_tiers import (
+    DEFAULT_TEXT_TIER,
+    HIGHEST_TEXT_TIER,
+    ROUTE_CLASS_TO_TIER,
+    TIER_TO_ROUTE_CLASS,
+    normalize_text_tier,
+)
 from opensquilla.squilla_router.controller import (
     derive_prompt_policy,
     derive_thinking_mode,
@@ -97,8 +104,8 @@ _DEFER_ROUTING_HISTORY_KEY = "_defer_squilla_router_history"
 _PENDING_ROUTING_HISTORY_ENTRY_KEY = "_pending_squilla_router_history_entry"
 _PENDING_ROUTING_HISTORY_SESSION_KEY = "_pending_squilla_router_history_session"
 _THINKING_LEVELS = {"minimal", "low", "medium", "high", "xhigh", "adaptive"}
-_TIER_TO_ROUTE_CLASS = {"t0": "R0", "t1": "R1", "t2": "R2", "t3": "R3"}
-_ROUTE_CLASS_TO_TIER = {v: k for k, v in _TIER_TO_ROUTE_CLASS.items()}
+_TIER_TO_ROUTE_CLASS = dict(TIER_TO_ROUTE_CLASS)
+_ROUTE_CLASS_TO_TIER = dict(ROUTE_CLASS_TO_TIER)
 _THINKING_MODE_ORDER = {"T0": 0, "T1": 1, "T2": 2, "T3": 3}
 _LARGE_CONTEXT_T2_FLOOR_TOKENS = 25_000
 _LARGE_CONTEXT_T3_FLOOR_TOKENS = 80_000
@@ -282,7 +289,11 @@ class _UnavailableV4Strategy:
         routing_history: list[dict] | None = None,
         **kwargs: object,
     ) -> tuple[str, float, str, dict]:
-        tier = "t1" if "t1" in valid_tiers else (valid_tiers[0] if valid_tiers else "t1")
+        tier = (
+            DEFAULT_TEXT_TIER
+            if DEFAULT_TEXT_TIER in valid_tiers
+            else (valid_tiers[0] if valid_tiers else DEFAULT_TEXT_TIER)
+        )
         return (
             tier,
             0.0,
@@ -490,7 +501,8 @@ def _inject_prompt_hint(message: str, hint: str) -> str:
 
 
 def _tier_index(tier: str, valid_tiers: list[str]) -> int:
-    return valid_tiers.index(tier) if tier in valid_tiers else -1
+    normalized = normalize_text_tier(tier) or tier
+    return valid_tiers.index(normalized) if normalized in valid_tiers else -1
 
 
 def _token_estimate(value: object) -> int | None:
@@ -542,9 +554,9 @@ def _large_context_min_tier(
         material_tokens >= _LARGE_CONTEXT_T3_FLOOR_TOKENS
         or material_tokens >= int(context_window * _LARGE_CONTEXT_T3_CONTEXT_RATIO)
     ):
-        return "t3", material_tokens
+        return HIGHEST_TEXT_TIER, material_tokens
     if material_tokens >= _LARGE_CONTEXT_T2_FLOOR_TOKENS:
-        return "t2", material_tokens
+        return "c2", material_tokens
     return None
 
 
@@ -573,7 +585,7 @@ def _confidence_protected_tier(
     default_tier = getattr(router_cfg, "default_tier", None)
     if default_tier is None:
         return tier, False, threshold, None
-    default_tier = str(default_tier)
+    default_tier = normalize_text_tier(default_tier) or str(default_tier)
     selected_cfg = tiers.get(tier, {}) if isinstance(tiers, dict) else {}
     if bool(_tier_config_value(selected_cfg, "image_only", False)):
         return tier, False, threshold, default_tier
@@ -596,7 +608,8 @@ def _detect_complaint(message: str, max_chars: int | None = None) -> list[str]:
 
 
 def _route_class_for_tier(tier: str) -> str | None:
-    return _TIER_TO_ROUTE_CLASS.get(tier)
+    normalized = normalize_text_tier(tier) or tier
+    return _TIER_TO_ROUTE_CLASS.get(normalized)
 
 
 def _apply_large_context_floor(
@@ -655,11 +668,12 @@ def _tier_for_route_class(route_class: object) -> str | None:
 
 
 def _min_thinking_mode_for_tier(tier: str | None) -> str | None:
-    if tier == "t3":
+    tier = normalize_text_tier(tier)
+    if tier == HIGHEST_TEXT_TIER:
         return "T3"
-    if tier == "t2":
+    if tier == "c2":
         return "T2"
-    if tier == "t1":
+    if tier == DEFAULT_TEXT_TIER:
         return "T1"
     return None
 
@@ -680,8 +694,8 @@ def _reconcile_controller_with_final_tier(
     extra: dict,
 ) -> tuple[str | None, str | None]:
     """Keep controller output consistent with OpenSquilla's final tier overrides."""
-    final_tier = extra.get("final_tier")
-    base_tier = extra.get("base_tier")
+    final_tier = normalize_text_tier(extra.get("final_tier")) or extra.get("final_tier")
+    base_tier = normalize_text_tier(extra.get("base_tier")) or extra.get("base_tier")
     if not final_tier or final_tier == base_tier:
         return thinking_mode, prompt_policy
 
@@ -693,7 +707,7 @@ def _reconcile_controller_with_final_tier(
         _min_thinking_mode_for_tier(str(final_tier)),
     )
     if prompt_policy == "P0" and (
-        str(final_tier) in {"t2", "t3"} or extra.get("complaint_detected")
+        str(final_tier) in {"c2", HIGHEST_TEXT_TIER} or extra.get("complaint_detected")
     ):
         prompt_policy = "P1"
     if thinking_mode is not None and prompt_policy is not None:
@@ -729,7 +743,7 @@ def _previous_final_tier(entry: dict | None) -> str | None:
         return None
     tier = entry.get("final_tier")
     if tier:
-        return str(tier)
+        return normalize_text_tier(tier) or str(tier)
     return _tier_for_route_class(entry.get("final_route_class") or entry.get("route_class"))
 
 
@@ -747,7 +761,7 @@ def _finalize_decision(
     if not _is_history_strategy(strategy_name):
         return decision
 
-    base_tier = decision.tier
+    base_tier = normalize_text_tier(decision.tier) or decision.tier
     final_tier = base_tier
     base_route_class = extra.get("route_class") or _route_class_for_tier(base_tier)
     if base_route_class is not None:
@@ -817,7 +831,8 @@ def _finalize_decision(
     extra.update(
         {
             "base_tier": base_tier,
-            "pre_confidence_tier": pre_confidence_tier,
+            "pre_confidence_tier": normalize_text_tier(pre_confidence_tier)
+            or pre_confidence_tier,
             "confidence_threshold": confidence_threshold,
             "confidence_default_tier": confidence_default_tier,
             "confidence_gate_applied": confidence_gate_applied,
@@ -831,7 +846,7 @@ def _finalize_decision(
                 getattr(router_cfg, "complaint_upgrade_max_chars", 160)
             ),
             "anti_downgrade_applied": anti_downgrade_applied,
-            "previous_tier": previous_tier,
+            "previous_tier": normalize_text_tier(previous_tier) or previous_tier,
             "previous_route_class": previous_route_class,
             "kv_cache_window_seconds": window,
         }
@@ -918,11 +933,14 @@ async def apply_squilla_router(ctx: TurnContext) -> TurnContext:
 
         image_tiers = {k: v for k, v in tiers.items() if v.get("supports_image", False)}
         if not image_tiers:
-            log.debug(
+            log.warning(
                 "squilla_router.no_image_tier",
                 note="image detected but no supports_image tier",
             )
-            return ctx
+            raise RuntimeError(
+                "No image-capable SquillaRouter tier is configured for this image request. "
+                "Configure squilla_router.tiers.image_model with supports_image=true."
+            )
         tier_name = random.choice(list(image_tiers.keys()))
         decision = RoutingDecision(
             tier=tier_name,
@@ -978,8 +996,6 @@ async def apply_squilla_router(ctx: TurnContext) -> TurnContext:
             ctx.metadata["router_control_target_model"] = hold.model
             ctx.metadata["router_control_target_provider"] = hold.provider
             ctx.metadata["router_control_evidence"] = hold.evidence
-            if hold.duplicate_model_resolution:
-                ctx.metadata["router_control_duplicate_model_resolution"] = True
             ctx.metadata.update(_compute_savings(decision.model, tiers))
             _record_thinking_metadata(ctx, router_cfg, tiers[decision.tier])
             log.debug(
@@ -1048,13 +1064,16 @@ async def apply_squilla_router(ctx: TurnContext) -> TurnContext:
         routing_history=routing_history,
         **classify_context,
     )
+    tier_name = normalize_text_tier(tier_name) or tier_name
     if extra:
         ctx.metadata["routing_extra"] = extra
         thinking_mode = extra.get("thinking_mode")
         prompt_policy = extra.get("prompt_policy")
 
     if tier_name is None or tier_name not in tiers:
-        default = getattr(router_cfg, "default_tier", "t1")
+        default = normalize_text_tier(getattr(router_cfg, "default_tier", DEFAULT_TEXT_TIER))
+        if default is None:
+            default = DEFAULT_TEXT_TIER
         tier_name = default if default in tiers else next(iter(tiers), None)
         if tier_name is None:
             return ctx

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -2485,7 +2485,9 @@ async def start_gateway_server(
             provider_selector = svc.provider_selector
             router_cfg = getattr(config, "squilla_router", None)
             tiers = getattr(router_cfg, "tiers", {}) if router_cfg is not None else {}
-            t3_tier = tiers.get("t3") if isinstance(tiers, dict) else None
+            from opensquilla.router_tiers import HIGHEST_TEXT_TIER
+
+            t3_tier = tiers.get(HIGHEST_TEXT_TIER) if isinstance(tiers, dict) else None
             t3_model = ""
             t3_thinking_level = ""
             if isinstance(t3_tier, dict):
@@ -2533,7 +2535,7 @@ async def start_gateway_server(
             }
             if t3_model:
                 auto_metadata.update({
-                    "routed_tier": "t3",
+                    "routed_tier": HIGHEST_TEXT_TIER,
                     "routed_model": t3_model,
                     "applied_model": t3_model,
                 })

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -27,6 +27,11 @@ from opensquilla.gateway.config_migration import (
     migrate_config_payload,
 )
 from opensquilla.paths import default_opensquilla_home
+from opensquilla.router_tiers import (
+    DEFAULT_TEXT_TIER,
+    normalize_text_tier,
+    normalize_tier_mapping,
+)
 from opensquilla.sandbox.config import SandboxSettings
 
 
@@ -534,41 +539,41 @@ class MemoryConfig(BaseSettings):
 def _default_tiers() -> dict:
     """Default model routing config."""
     return {
-        "t0": {
+        "c0": {
             "provider": "openrouter",
             "model": "deepseek/deepseek-v4-flash",
             "description": (
-                "S tier: fast DeepSeek V4 Flash route for trivial chat, short rewrites, "
+                "fast DeepSeek V4 Flash route for trivial chat, short rewrites, "
                 "extraction, and low-risk simple Q&A"
             ),
             "supports_image": False,
             "thinking_level": "high",
         },
-        "t1": {
+        "c1": {
             "provider": "openrouter",
             "model": "deepseek/deepseek-v4-pro",
             "description": (
-                "M tier: default balanced text model for normal agent work, coding assistance, "
+                "default balanced text model for normal agent work, coding assistance, "
                 "debugging, and moderate analysis"
             ),
             "supports_image": False,
             "thinking_level": "high",
         },
-        "t2": {
+        "c2": {
             "provider": "openrouter",
             "model": "z-ai/glm-5.1",
             "description": (
-                "L tier: stronger text model for multi-step coding, structured reasoning, "
+                "stronger text model for multi-step coding, structured reasoning, "
                 "larger context synthesis, and harder analysis"
             ),
             "supports_image": False,
             "thinking_level": "high",
         },
-        "t3": {
+        "c3": {
             "provider": "openrouter",
             "model": "anthropic/claude-opus-4.7",
             "description": (
-                "XL tier: highest-quality text reasoning model for difficult planning, "
+                "Highest-quality text reasoning model for difficult planning, "
                 "deep review, complex debugging, and high-stakes synthesis"
             ),
             "supports_image": False,
@@ -629,34 +634,34 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
         return _default_tiers()
     profiles = {
         "openai": {
-            "t0": {
+            "c0": {
                 "provider": "openai",
                 "model": "gpt-5.4-nano",
                 "description": (
-                    "OpenAI fast tier: GPT-5.4 Nano for fast, high-throughput simple work."
+                    "OpenAI fast route: GPT-5.4 Nano for fast, high-throughput simple work."
                 ),
                 "supports_image": False,
                 "thinking_level": "none",
             },
-            "t1": {
+            "c1": {
                 "provider": "openai",
                 "model": "gpt-5.4-mini",
-                "description": "OpenAI balanced tier: GPT-5.4 Mini for normal agent work.",
+                "description": "OpenAI balanced route: GPT-5.4 Mini for normal agent work.",
                 "supports_image": False,
                 "thinking_level": "low",
             },
-            "t2": {
+            "c2": {
                 "provider": "openai",
                 "model": "gpt-5.5",
-                "description": "OpenAI strong tier: GPT-5.5 for complex text tasks.",
+                "description": "OpenAI strong route: GPT-5.5 for complex text tasks.",
                 "supports_image": False,
                 "thinking_level": "medium",
             },
-            "t3": {
+            "c3": {
                 "provider": "openai",
                 "model": "gpt-5.5",
                 "description": (
-                    "OpenAI highest tier: GPT-5.5 with high reasoning; GPT-5.5 Pro is "
+                    "OpenAI highest route: GPT-5.5 with high reasoning; GPT-5.5 Pro is "
                     "excluded because it is not streaming-compatible."
                 ),
                 "supports_image": False,
@@ -664,76 +669,76 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
             },
         },
         "dashscope": {
-            "t0": {
+            "c0": {
                 "provider": "dashscope",
                 "model": "qwen3.6-flash",
                 "description": (
-                    "DashScope fast tier: Qwen3.6 Flash for simple text tasks; "
+                    "DashScope fast route: Qwen3.6 Flash for simple text tasks; "
                     "pending live smoke."
                 ),
                 "supports_image": False,
             },
-            "t1": {
+            "c1": {
                 "provider": "dashscope",
                 "model": "qwen3.6-plus",
                 "description": (
-                    "DashScope balanced tier: Qwen3.6 Plus for normal agent and "
+                    "DashScope balanced route: Qwen3.6 Plus for normal agent and "
                     "coding work; pending live smoke."
                 ),
                 "supports_image": False,
             },
-            "t2": {
+            "c2": {
                 "provider": "dashscope",
                 "model": "qwen3-max",
-                "description": "DashScope strong tier: Qwen3 Max for complex text tasks.",
+                "description": "DashScope strong route: Qwen3 Max for complex text tasks.",
                 "supports_image": False,
             },
-            "t3": {
+            "c3": {
                 "provider": "dashscope",
                 "model": "qwen3-max",
                 "description": (
-                    "DashScope highest tier: Qwen3 Max; higher-thinking behavior "
+                    "DashScope highest route: Qwen3 Max; higher-thinking behavior "
                     "requires future payload support."
                 ),
                 "supports_image": False,
             },
         },
         "deepseek": {
-            "t0": {
+            "c0": {
                 "provider": "deepseek",
                 "model": "deepseek-v4-flash",
                 "description": (
-                    "DeepSeek fast tier: V4 Flash with no router-requested thinking; "
+                    "DeepSeek fast route: V4 Flash with no router-requested thinking; "
                     "request ID pending live smoke."
                 ),
                 "supports_image": False,
                 "thinking_level": "off",
             },
-            "t1": {
+            "c1": {
                 "provider": "deepseek",
                 "model": "deepseek-v4-flash",
                 "description": (
-                    "DeepSeek balanced tier: V4 Flash with thinking enabled; request "
+                    "DeepSeek balanced route: V4 Flash with thinking enabled; request "
                     "ID pending live smoke."
                 ),
                 "supports_image": False,
                 "thinking_level": "low",
             },
-            "t2": {
+            "c2": {
                 "provider": "deepseek",
                 "model": "deepseek-v4-pro",
                 "description": (
-                    "DeepSeek strong tier: V4 Pro with thinking enabled; request ID "
+                    "DeepSeek strong route: V4 Pro with thinking enabled; request ID "
                     "pending live smoke."
                 ),
                 "supports_image": False,
                 "thinking_level": "medium",
             },
-            "t3": {
+            "c3": {
                 "provider": "deepseek",
                 "model": "deepseek-v4-pro",
                 "description": (
-                    "DeepSeek highest tier: same V4 Pro wire behavior until "
+                    "DeepSeek highest route: same V4 Pro wire behavior until "
                     "effort-level support is added."
                 ),
                 "supports_image": False,
@@ -741,31 +746,31 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
             },
         },
         "gemini": {
-            "t0": {
+            "c0": {
                 "provider": "gemini",
                 "model": "gemini-2.5-flash-lite",
-                "description": "Gemini fast tier: 2.5 Flash-Lite for low-latency tasks.",
+                "description": "Gemini fast route: 2.5 Flash-Lite for low-latency tasks.",
                 "supports_image": False,
             },
-            "t1": {
+            "c1": {
                 "provider": "gemini",
                 "model": "gemini-2.5-flash",
-                "description": "Gemini balanced tier: 2.5 Flash for normal agent work.",
+                "description": "Gemini balanced route: 2.5 Flash for normal agent work.",
                 "supports_image": False,
                 "thinking_level": "low",
             },
-            "t2": {
+            "c2": {
                 "provider": "gemini",
                 "model": "gemini-2.5-pro",
-                "description": "Gemini strong tier: 2.5 Pro for complex coding and reasoning.",
+                "description": "Gemini strong route: 2.5 Pro for complex coding and reasoning.",
                 "supports_image": False,
                 "thinking_level": "medium",
             },
-            "t3": {
+            "c3": {
                 "provider": "gemini",
                 "model": "gemini-2.5-pro",
                 "description": (
-                    "Gemini highest tier: 2.5 Pro with high thinking; 3.1 preview "
+                    "Gemini highest route: 2.5 Pro with high thinking; 3.1 preview "
                     "remains opt-in."
                 ),
                 "supports_image": False,
@@ -773,73 +778,73 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
             },
         },
         "zhipu": {
-            "t0": {
+            "c0": {
                 "provider": "zhipu",
                 "model": "glm-4.7-flashx",
                 "description": (
-                    "Zhipu fast tier: GLM-4.7 FlashX for simple text tasks; live smoke "
+                    "Zhipu fast route: GLM-4.7 FlashX for simple text tasks; live smoke "
                     "may require fallback."
                 ),
                 "supports_image": False,
             },
-            "t1": {
+            "c1": {
                 "provider": "zhipu",
                 "model": "glm-5",
-                "description": "Zhipu balanced tier: GLM-5 for normal agent work.",
+                "description": "Zhipu balanced route: GLM-5 for normal agent work.",
                 "supports_image": False,
                 "thinking_level": "low",
             },
-            "t2": {
+            "c2": {
                 "provider": "zhipu",
                 "model": "glm-5.1",
-                "description": "Zhipu strong tier: GLM-5.1 for complex text tasks.",
+                "description": "Zhipu strong route: GLM-5.1 for complex text tasks.",
                 "supports_image": False,
                 "thinking_level": "medium",
             },
-            "t3": {
+            "c3": {
                 "provider": "zhipu",
                 "model": "glm-5.1",
-                "description": "Zhipu highest tier: GLM-5.1 with high reasoning effort.",
+                "description": "Zhipu highest route: GLM-5.1 with high reasoning effort.",
                 "supports_image": False,
                 "thinking_level": "high",
             },
         },
         "moonshot": {
-            "t0": {
+            "c0": {
                 "provider": "moonshot",
                 "model": "kimi-k2.5",
                 "description": (
-                    "Moonshot fast tier: Kimi K2.5 for cost-efficient agent work "
+                    "Moonshot fast route: Kimi K2.5 for cost-efficient agent work "
                     "with 256K context."
                 ),
                 "supports_image": True,
                 "thinking_level": "low",
             },
-            "t1": {
+            "c1": {
                 "provider": "moonshot",
                 "model": "kimi-k2.5",
                 "description": (
-                    "Moonshot balanced tier: Kimi K2.5 for normal multimodal "
+                    "Moonshot balanced route: Kimi K2.5 for normal multimodal "
                     "agent work."
                 ),
                 "supports_image": True,
                 "thinking_level": "medium",
             },
-            "t2": {
+            "c2": {
                 "provider": "moonshot",
                 "model": "kimi-k2.6",
                 "description": (
-                    "Moonshot strong tier: Kimi K2.6 for complex coding, reasoning, "
+                    "Moonshot strong route: Kimi K2.6 for complex coding, reasoning, "
                     "and multimodal tasks."
                 ),
                 "supports_image": True,
                 "thinking_level": "medium",
             },
-            "t3": {
+            "c3": {
                 "provider": "moonshot",
                 "model": "kimi-k2.6",
                 "description": (
-                    "Moonshot highest tier: Kimi K2.6 for the hardest long-horizon "
+                    "Moonshot highest route: Kimi K2.6 for the hardest long-horizon "
                     "agent work."
                 ),
                 "supports_image": True,
@@ -847,41 +852,41 @@ def _router_tier_profile_defaults(profile: str | None) -> dict:
             },
         },
         "volcengine": {
-            "t0": {
+            "c0": {
                 "provider": "volcengine",
                 "model": "doubao-seed-2-0-mini-260215",
                 "description": (
-                    "Volcengine fast tier: Doubao Seed 2.0 Mini for low-latency, "
+                    "Volcengine fast route: Doubao Seed 2.0 Mini for low-latency, "
                     "low-cost simple text tasks."
                 ),
                 "supports_image": False,
                 "thinking_level": "off",
             },
-            "t1": {
+            "c1": {
                 "provider": "volcengine",
                 "model": "doubao-seed-2-0-lite-260215",
                 "description": (
-                    "Volcengine balanced tier: Doubao Seed 2.0 Lite for daily agent "
+                    "Volcengine balanced route: Doubao Seed 2.0 Lite for daily agent "
                     "work with lower cost than Pro."
                 ),
                 "supports_image": False,
                 "thinking_level": "low",
             },
-            "t2": {
+            "c2": {
                 "provider": "volcengine",
                 "model": "doubao-seed-2-0-pro-260215",
                 "description": (
-                    "Volcengine strong tier: Doubao Seed 2.0 Pro for complex "
+                    "Volcengine strong route: Doubao Seed 2.0 Pro for complex "
                     "reasoning and multimodal-capable text work."
                 ),
                 "supports_image": False,
                 "thinking_level": "medium",
             },
-            "t3": {
+            "c3": {
                 "provider": "volcengine",
                 "model": "doubao-seed-2-0-code-preview-260215",
                 "description": (
-                    "Volcengine highest tier: Doubao Seed 2.0 Code Preview for the "
+                    "Volcengine highest route: Doubao Seed 2.0 Code Preview for the "
                     "hardest coding and code-review routes."
                 ),
                 "supports_image": False,
@@ -904,7 +909,7 @@ class SquillaRouterConfig(BaseSettings):
     strategy: str = "v4_phase3"
     tier_profile: str | None = None
     tiers: dict = Field(default_factory=_default_tiers)
-    default_tier: str = "t1"
+    default_tier: str = DEFAULT_TEXT_TIER
     confidence_threshold: float = 0.5
     v4_bundle_dir: str | None = None  # V4 Phase 3 bundle root; defaults to bundled assets
     v4_use_aux_head: bool | None = True  # override router.runtime.yaml aux head when set
@@ -916,13 +921,27 @@ class SquillaRouterConfig(BaseSettings):
     complaint_upgrade_max_chars: int = 160
     require_router_runtime: bool = True
     estimated_output_savings_pct: float = 0.03
-    upgrade_to_t3_compaction_enabled: bool = True
+    upgrade_to_c3_compaction_enabled: bool = True
 
     @model_validator(mode="before")
     @classmethod
     def _resolve_tier_profile_defaults(cls, values: Any) -> Any:
         if not isinstance(values, dict):
             return values
+        values = dict(values)
+        if (
+            "upgrade_to_c3_compaction_enabled" not in values
+            and "upgrade_to_t3_compaction_enabled" in values
+        ):
+            values["upgrade_to_c3_compaction_enabled"] = values[
+                "upgrade_to_t3_compaction_enabled"
+            ]
+        if "default_tier" in values:
+            values["default_tier"] = normalize_text_tier(values.get("default_tier")) or values.get(
+                "default_tier"
+            )
+        if isinstance(values.get("tiers"), dict):
+            values["tiers"] = normalize_tier_mapping(values["tiers"])
         profile = values.get("tier_profile")
         if profile is None:
             return values
@@ -1140,6 +1159,12 @@ class SlackChannelEntry(ConfiguredChannelEntry):
     # Events API webhook. Socket Mode additionally requires ``app_token``.
     connection_mode: Literal["webhook", "socket"] = "webhook"
     app_token: str = ""
+
+    @model_validator(mode="after")
+    def _validate_socket_app_token(self) -> SlackChannelEntry:
+        if self.connection_mode == "socket" and not self.app_token.strip():
+            raise ValueError("slack socket channels require app_token")
+        return self
 
 
 class FeishuChannelEntry(ConfiguredChannelEntry):

--- a/src/opensquilla/gateway/rpc_skills.py
+++ b/src/opensquilla/gateway/rpc_skills.py
@@ -85,7 +85,83 @@ def _status_detail(spec: Any, report: EligibilityReport) -> str:
     return f"Ready — {total}/{total} dependencies satisfied"
 
 
-def _skill_to_dict(spec: Any, report: EligibilityReport, os_name: str = "") -> dict[str, Any]:
+def _requirements_item(
+    name: str,
+    source: str,
+    spec: Any | None,
+    report: EligibilityReport | None,
+) -> dict[str, Any]:
+    """Build a compact dependency-readiness row for the Skill dialog."""
+    if spec is None or report is None:
+        return {
+            "name": name,
+            "source": source,
+            "status": "missing_skill",
+            "requires_bins": [],
+            "requires_any_bins": [],
+            "requires_env": [],
+            "missing_bins": [],
+            "missing_env": [],
+        }
+
+    meta = getattr(spec, "metadata", None)
+    requires = meta.requires if meta is not None else None
+    return {
+        "name": name,
+        "source": source,
+        "status": _status_from_report(report),
+        "requires_bins": list(requires.bins) if requires else [],
+        "requires_any_bins": list(requires.any_bins) if requires else [],
+        "requires_env": list(requires.env) if requires else [],
+        "missing_bins": list(report.missing_bins),
+        "missing_env": list(report.missing_env),
+    }
+
+
+def _requirements_summary(items: list[dict[str, Any]]) -> str:
+    if not items:
+        return "not_declared"
+    statuses = {str(item.get("status", "")) for item in items}
+    if "needs_setup" in statuses or "missing_skill" in statuses:
+        return "needs_setup"
+    if "ready" in statuses:
+        return "ready"
+    return "not_declared"
+
+
+def _requirements_payload(
+    spec: Any,
+    report: EligibilityReport,
+    sub_skills: list[str],
+    *,
+    skill_index: dict[str, Any] | None = None,
+    eligibility_ctx: EligibilityContext | None = None,
+) -> dict[str, Any]:
+    """Return current-skill requirements plus one-hop meta sub-skill rollup."""
+    items: list[dict[str, Any]] = []
+    if report.declared:
+        items.append(_requirements_item(spec.name, "self", spec, report))
+
+    kind = getattr(spec, "kind", "skill") or "skill"
+    if kind in {"meta", "meta_sop"} and skill_index is not None and eligibility_ctx is not None:
+        for sub_name in sub_skills:
+            sub_spec = skill_index.get(sub_name)
+            sub_report = (
+                diagnose_eligibility(sub_spec, eligibility_ctx) if sub_spec is not None else None
+            )
+            items.append(_requirements_item(sub_name, "sub_skill", sub_spec, sub_report))
+
+    return {"summary": _requirements_summary(items), "items": items}
+
+
+def _skill_to_dict(
+    spec: Any,
+    report: EligibilityReport,
+    os_name: str = "",
+    *,
+    skill_index: dict[str, Any] | None = None,
+    eligibility_ctx: EligibilityContext | None = None,
+) -> dict[str, Any]:
     """Convert a SkillSpec to a dict with eligibility diagnostics.
 
     Install options are filtered against ``os_name`` before serialization.
@@ -154,6 +230,13 @@ def _skill_to_dict(spec: Any, report: EligibilityReport, os_name: str = "") -> d
         "install": install_entries,
         "kind": kind,
         "sub_skills": sub_skills,
+        "requirements": _requirements_payload(
+            spec,
+            report,
+            sub_skills,
+            skill_index=skill_index,
+            eligibility_ctx=eligibility_ctx,
+        ),
     }
     provenance = getattr(spec, "provenance", None)
     d["provenance"] = {
@@ -181,8 +264,15 @@ async def _handle_skills_status(params: dict | None, ctx: RpcContext) -> list[di
 
     ctx_eligible = EligibilityContext.auto()
     skills = loader.load_all()
+    skill_index = {skill.name: skill for skill in skills}
     return [
-        _skill_to_dict(skill, diagnose_eligibility(skill, ctx_eligible), ctx_eligible.os_name)
+        _skill_to_dict(
+            skill,
+            diagnose_eligibility(skill, ctx_eligible),
+            ctx_eligible.os_name,
+            skill_index=skill_index,
+            eligibility_ctx=ctx_eligible,
+        )
         for skill in skills
     ]
 
@@ -195,10 +285,18 @@ async def _handle_skills_list(params: dict | None, ctx: RpcContext) -> dict[str,
         return {"skills": []}
 
     ctx_eligible = EligibilityContext.auto()
-    skills = loader.get_user_invocable()
+    all_skills = loader.load_all()
+    skill_index = {skill.name: skill for skill in all_skills}
+    skills = [skill for skill in all_skills if skill.user_invocable]
     return {
         "skills": [
-            _skill_to_dict(skill, diagnose_eligibility(skill, ctx_eligible), ctx_eligible.os_name)
+            _skill_to_dict(
+                skill,
+                diagnose_eligibility(skill, ctx_eligible),
+                ctx_eligible.os_name,
+                skill_index=skill_index,
+                eligibility_ctx=ctx_eligible,
+            )
             for skill in skills
         ]
     }
@@ -236,12 +334,20 @@ async def _handle_skills_get(params: dict | None, ctx: RpcContext) -> dict[str, 
     if loader is None:
         raise KeyError("No skill loader available")
 
-    skill = loader.get_by_name(params["name"])
+    skills = loader.load_all()
+    skill_index = {item.name: item for item in skills}
+    skill = skill_index.get(params["name"])
     if skill is None:
         raise KeyError(f"Skill not found: {params['name']}")
 
     ctx_eligible = EligibilityContext.auto()
-    result = _skill_to_dict(skill, diagnose_eligibility(skill, ctx_eligible), ctx_eligible.os_name)
+    result = _skill_to_dict(
+        skill,
+        diagnose_eligibility(skill, ctx_eligible),
+        ctx_eligible.os_name,
+        skill_index=skill_index,
+        eligibility_ctx=ctx_eligible,
+    )
     result["content"] = skill.content
     result["file_path"] = skill.file_path
     result["base_dir"] = skill.base_dir

--- a/src/opensquilla/gateway/static/css/components.css
+++ b/src/opensquilla/gateway/static/css/components.css
@@ -290,7 +290,7 @@
   animation: conn-pill-heartbeat 2.4s ease-in-out infinite;
 }
 
-/* Tier badge — compact monospaced t0/t1/t2/t3 indicator for router decisions. */
+/* Tier badge — compact monospaced c0/c1/c2/c3 indicator for router decisions. */
 .tier {
   display: inline-flex;
   align-items: center;
@@ -305,9 +305,9 @@
   color: var(--accent);
   border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border));
 }
-.tier.t0 { background: color-mix(in srgb, var(--text-dim) 18%, transparent); color: var(--text-muted); border-color: var(--border); }
-.tier.t2 { background: color-mix(in srgb, var(--info) 14%, transparent); color: var(--info); border-color: color-mix(in srgb, var(--info) 30%, var(--border)); }
-.tier.t3 { background: color-mix(in srgb, var(--warn) 14%, transparent); color: var(--warn); border-color: color-mix(in srgb, var(--warn) 30%, var(--border)); }
+.tier.c0 { background: color-mix(in srgb, var(--text-dim) 18%, transparent); color: var(--text-muted); border-color: var(--border); }
+.tier.c2 { background: color-mix(in srgb, var(--info) 14%, transparent); color: var(--info); border-color: color-mix(in srgb, var(--info) 30%, var(--border)); }
+.tier.c3 { background: color-mix(in srgb, var(--warn) 14%, transparent); color: var(--warn); border-color: color-mix(in srgb, var(--warn) 30%, var(--border)); }
 
 /* Spinner — generic 18px loading indicator. */
 .spinner {

--- a/src/opensquilla/gateway/static/css/views/chat.css
+++ b/src/opensquilla/gateway/static/css/views/chat.css
@@ -472,6 +472,10 @@
   box-shadow: var(--shadow-sm);
   font-size: var(--fs-sm);
   line-height: 1.6;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  text-align: start;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   word-break: break-word;
@@ -591,14 +595,60 @@
   position: relative;
 }
 
-.chat-msg--streaming .chat-msg-text::after,
-.msg.streaming .msg-body:not(:has(.msg-text-seg:not(:empty)))::after,
-.msg.streaming .msg-text-seg:not(:empty):last-of-type::after {
-  content: '\25CD';
-  display: inline-block;
-  color: var(--accent);
-  animation: blink 1.2s ease-in-out infinite;
-  margin-left: 2px;
+/* Streaming active mark — delayed bottom dock. The mark appears only after
+   short turns have had time to finish, then sits in the bubble's bottom-left
+   corner, aligned with the content-left edge (the tool-card / text icon
+   column) so it reads as part of that column rather than an orphaned dot.
+   It sits centered in the reserved footer band (padding-bottom below), which
+   gives the orbiting ring a clear gap from the last tool card above and the
+   bubble's bottom edge — earlier the mark was lifted 8px, which pushed the
+   ring up into the card and caused a visible overlap. */
+.msg.streaming.streaming-active-mark:not(.awaiting-model) .msg-body {
+  padding-bottom: calc(var(--sp-2) + 24px);
+}
+
+.msg.streaming.streaming-active-mark:not(.awaiting-model) .msg-body::after {
+  content: '';
+  display: block;
+  position: absolute;
+  left: var(--sp-4);
+  bottom: var(--sp-2);
+  width: 16px;
+  height: 16px;
+  pointer-events: none;
+  border-radius: 50%;
+  background-color: color-mix(in srgb, var(--bg-surface) 90%, var(--bg) 10%);
+  background-image: url('../../img/opensquilla-mark.png');
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 11px 11px;
+  /* The mark stays UPRIGHT and legible — it is a figurative, directional
+     squilla, so it must never tumble. The motion lives in the orbiting
+     ring below (::before), not in the brand mark itself. */
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 7%, transparent);
+}
+
+/* Orbital sweep — a conic highlight rides a hairline ring around the mark.
+   This is the element that animates; circles are built to rotate, the
+   shrimp is not. Reuses --accent / --accent-secondary so it auto-themes. */
+.msg.streaming.streaming-active-mark:not(.awaiting-model) .msg-body::before {
+  content: '';
+  display: block;
+  position: absolute;
+  left: calc(var(--sp-4) - 4px);
+  bottom: calc(var(--sp-2) - 4px);
+  width: 24px;
+  height: 24px;
+  pointer-events: none;
+  border-radius: 50%;
+  background: conic-gradient(from 0deg,
+    transparent 200deg,
+    var(--accent-secondary) 320deg,
+    var(--accent) 350deg,
+    transparent 360deg);
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 2px), #000 calc(100% - 2px));
+          mask: radial-gradient(farthest-side, transparent calc(100% - 2px), #000 calc(100% - 2px));
+  animation: squilla-activity-spin 1.15s linear infinite;
 }
 
 .msg.streaming.awaiting-model::after {
@@ -620,6 +670,20 @@
 @keyframes awaitingModelPulse {
   0%, 100% { opacity: 0.82; }
   50%      { opacity: 0.48; }
+}
+
+@keyframes squilla-activity-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Freeze the orbiting ring into a static arc so the indicator is still
+     legibly "active" without motion. The mark itself is already static. */
+  .msg.streaming.streaming-active-mark:not(.awaiting-model) .msg-body::before {
+    animation: none;
+    background: conic-gradient(from 0deg,
+      var(--accent) 90deg, transparent 90deg);
+  }
 }
 
 @keyframes blink {
@@ -1407,6 +1471,7 @@
   min-height: 32px;
   min-width: 56px;
   padding: var(--sp-2) var(--sp-4);
+  text-align: start;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   word-break: break-word;
@@ -1546,6 +1611,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.chat-context-separator--session {
+  margin-top: auto;
 }
 
 .chat-context-separator--live span {
@@ -2871,17 +2940,16 @@ select.clarify-form-input {
  * Router slider — arcade-brutalist whac-a-mole grid that fires when
  * the squilla router lands a tier.
  *
- * The strip is a 3 × 4 grid of cells: the operator's real configured
- * tiers (deduped by model) sit in the top rows, padded with popular
- * decoy model names so the grid feels populated. A square hammer-
- * selector hops between cells with bouncy easing and locks onto the
- * routed cell — each visited cell does a quick mole-pop, the winner
- * cell additionally fires a particle burst.
+ * The strip is a compact grid of real candidates for the current
+ * request kind. A square hammer-selector hops between cells with
+ * bouncy easing and locks onto the routed cell — each visited cell
+ * does a quick mole-pop, the winner cell additionally fires a
+ * particle burst.
  *
  * Aesthetic: hairline mantis-brutalist. Orange is the only colour
- * that signals; decoys read dim. Live and history-loaded renders
- * share the same component (history skips the hop animation and
- * settles immediately on the winner cell). ─────────────────────── */
+ * that signals. Live and history-loaded renders share the same
+ * component (history skips the hop animation and settles immediately
+ * on the winner cell). ─────────────────────────────────────────── */
 .router-fx {
   display: flex;
   flex-direction: column;
@@ -2945,10 +3013,9 @@ select.clarify-form-input {
 .router-fx-grid {
   position: relative;
   display: grid;
-  /* 5 × 3 cells. JS pulls from _ROUTER_FX_GRID_COLS / _ROUTER_FX_GRID_ROWS;
-     keep these in sync with that constant when changing dimensions. */
-  grid-template-columns: repeat(5, 1fr);
-  grid-template-rows: repeat(3, 30px);
+  grid-template-columns: repeat(var(--router-fx-cols, 2), 1fr);
+  grid-template-rows: none;
+  grid-auto-rows: 34px;
   gap: 4px;
   padding: 8px;
   background:
@@ -2996,11 +3063,8 @@ select.clarify-form-input {
   white-space: nowrap;
 }
 
-/* Equal prominence: every model cell renders identically at rest — no
- * "this one is configured" accent dot and no dimmed/italic "decoy"
- * treatment. The grid reads as one uniform field so an observer cannot
- * tell which names are actually on the operator's router; only the
- * routing RESULT (.win, below) is ever emphasised. */
+/* Equal prominence: every candidate cell renders identically at rest. Only
+ * the routing RESULT (.win, below) is emphasised. */
 
 /* Mole-pop: scale up + tiny lift + accent tint as the hammer arrives. */
 @keyframes router-fx-mole-pop {
@@ -3213,18 +3277,16 @@ select.clarify-form-input {
   background: var(--text-muted);
 }
 
-/* NOTE: the router grid deliberately does NOT honour prefers-reduced-motion
- * either — same rationale as the cloud: the "Router animation" switch is the
- * explicit opt-in, so OS reduce-motion does not suppress the chase. */
+/* NOTE: the router grid deliberately does NOT honour prefers-reduced-motion:
+ * the "Visual effects" switch is the explicit opt-in, so OS reduce-motion
+ * does not suppress the chase. */
 
-/* Mobile: collapse to 3 columns × 5 rows + smaller type. The hammer
- * still hops; the grid just gets denser. JS still renders 15 cells —
- * keep the cell count divisible across the active grid template so no
- * row ends short. */
+/* Mobile: keep the same real-candidate roster, but wrap compactly. */
 @media (max-width: 640px) {
   .router-fx-grid {
-    grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: repeat(5, 28px);
+    grid-template-columns: repeat(var(--router-fx-mobile-cols, var(--router-fx-cols, 2)), 1fr);
+    grid-template-rows: none;
+    grid-auto-rows: 30px;
     padding: 6px;
     gap: 3px;
   }
@@ -3233,161 +3295,11 @@ select.clarify-form-input {
 }
 @media (max-width: 380px) {
   .router-fx-grid {
-    grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: repeat(5, 26px);
+    grid-template-columns: repeat(var(--router-fx-mobile-cols, 2), 1fr);
+    grid-template-rows: none;
+    grid-auto-rows: 28px;
   }
   .router-fx-cell { font-size: 9.5px; padding: 0 4px; }
-}
-
-/* ── Router-fx style variants ────────────────────────────────────────────
- * Groundwork for future frontend experiments. The visible style today is the
- * BASE look above, rendered when no data-variant attribute is present. JS
- * (_buildRouterFxElement) stamps data-variant="<name>" on the .router-fx root
- * only for non-'default' variants, so adding a skin is purely additive here.
- *
- * To add a variant:
- *   .router-fx[data-variant="<name>"] { --accent: …; --danger: …; }
- * Prefer redefining the custom properties the strip already consumes (--accent,
- * --danger, --text*, --bg*, --hairline, --radius-*) — they inherit down the
- * subtree and stay light/dark-correct for free. Add structural/keyframe rules
- * ONLY when a variant changes shape or motion, and if so mirror the
- * prefers-reduced-motion guard and the 640px/380px grid-collapse rules above,
- * and keep the JS grid-cell count in sync.
- *
- * Keep palette-only variants PALETTE-ONLY: the data-source="fallback" and
- * data-observe="true" rules are semantic overlays at depth (0,1,2,0); a
- * token-only variant layers cleanly under them instead of fighting specificity.
- * The "cloud" variant below is a STRUCTURAL one (its own layout + motion). */
-
-/* ── Cloud variant: "model nebula" / rack-focus ──────────────────────────
- * An optical instrument focusing, not a marketing tag-cloud. ~36 model names
- * hang in an organic, edge-dissolved field at seeded focal DEPTHS where blur,
- * scale and opacity move together (near = sharp/large/bright; far =
- * soft/small/dim). Two layers per name keep motion from fighting: the OUTER
- * owns position + a perpetual parallax drift (the field stays alive even once
- * settled) and the winner's glide to focus; the INNER owns the rack-focus
- * (scale/blur/opacity/glow). Routing: idle -> playing (the whole field
- * defocuses, ease-IN) -> settled (the winner glides to the focal point and
- * resolves sharp with an accent bloom; the rest sink to bokeh). */
-.router-fx[data-variant="cloud"] .router-fx-cloud {
-  position: relative;
-  width: 100%;
-  height: 268px;
-  margin-top: 2px;
-  overflow: visible;
-  /* no border, no box — a faint accent core; the radial mask dissolves the
-   * edges so the nebula has no rigid rectangular boundary. */
-  background:
-    radial-gradient(58% 64% at 50% 47%,
-      color-mix(in srgb, var(--accent) 7%, transparent) 0%,
-      transparent 72%);
-  -webkit-mask-image: radial-gradient(74% 76% at 50% 49%, #000 50%, transparent 100%);
-  mask-image: radial-gradient(74% 76% at 50% 49%, #000 50%, transparent 100%);
-}
-
-/* OUTER: position + (winner only) the glide to focus. NO perpetual motion —
- * the panel must be perfectly still once settled / while output renders. */
-.router-fx[data-variant="cloud"] .router-fx-mote {
-  position: absolute;
-  left: var(--x, 50%);
-  top: var(--y, 50%);
-  z-index: var(--z, 1);
-  transform: translate(-50%, -50%);
-  pointer-events: none;
-  transition:
-    left 360ms cubic-bezier(.2,.85,.25,1),
-    top 360ms cubic-bezier(.2,.85,.25,1);
-}
-
-/* INNER: the focal optics (scale / blur / opacity / colour / glow). */
-.router-fx[data-variant="cloud"] .router-fx-mote-i {
-  display: inline-block;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  line-height: 1;
-  letter-spacing: 0.02em;
-  white-space: nowrap;
-  color: var(--text);
-  opacity: var(--op, 0.6);
-  filter: blur(var(--blur, 0));
-  transform: scale(var(--sc, 1));
-  transform-origin: center;
-  transition:
-    transform 360ms cubic-bezier(.2,.85,.25,1),
-    filter 340ms cubic-bezier(.2,.85,.25,1),
-    opacity 300ms ease,
-    color 280ms ease,
-    letter-spacing 360ms cubic-bezier(.2,.85,.25,1),
-    text-shadow 360ms ease;
-}
-
-/* Scanning — the live "search" before the decision arrives. JS toggles
- * .is-scan across motes (~170ms) so a candidate roams into sharp accent
- * focus while the rest sit softly defocused. Discrete class swaps, so the
- * motion shows even where CSS keyframes are suppressed. */
-.router-fx[data-variant="cloud"][data-state="scanning"] .router-fx-mote-i {
-  filter: blur(calc(var(--blur, 0) + 1.6px));
-  opacity: calc(var(--op, 0.6) * 0.7);
-  transition:
-    transform 200ms cubic-bezier(.2,.85,.25,1),
-    filter 200ms ease,
-    opacity 200ms ease,
-    color 200ms ease,
-    text-shadow 200ms ease;
-}
-.router-fx[data-variant="cloud"][data-state="scanning"] .router-fx-mote.is-scan {
-  z-index: 250;
-}
-.router-fx[data-variant="cloud"][data-state="scanning"] .router-fx-mote.is-scan .router-fx-mote-i {
-  filter: blur(0);
-  opacity: 1;
-  transform: scale(1.4);
-  color: var(--accent);
-  text-shadow:
-    0 0 8px color-mix(in srgb, var(--accent) 60%, transparent),
-    0 0 20px color-mix(in srgb, var(--accent) 32%, transparent);
-}
-
-/* Playing — the lens leaves focus: the whole field defocuses (ease-IN).
- * Only the INNER changes; the outer keeps drifting underneath. */
-.router-fx[data-variant="cloud"][data-state="playing"] .router-fx-mote-i {
-  filter: blur(calc(var(--blur, 0) + 3.6px));
-  opacity: calc(var(--op, 0.6) * 0.4);
-  transform: scale(calc(var(--sc, 1) * 0.86));
-  transition:
-    transform 360ms ease-in,
-    filter 340ms ease-in,
-    opacity 340ms ease-in;
-}
-
-/* Settled — the field sinks to soft bokeh (the outer keeps drifting, so it is
- * never frozen). */
-.router-fx[data-variant="cloud"][data-state="settled"] .router-fx-mote-i {
-  filter: blur(calc(var(--blur, 0) + 2.6px));
-  opacity: 0.16;
-  transform: scale(calc(var(--sc, 1) * 0.9));
-}
-
-/* ...except the winner: the OUTER glides to the focal point (left/top eased)
- * while the INNER resolves sharp with a layered accent bloom. STATIC once
- * settled — no breathe — so the panel is still while output renders.
- * The --winner class outranks the generic settled rule above on specificity. */
-.router-fx[data-variant="cloud"][data-state="settled"] .router-fx-mote--winner {
-  left: 50%;
-  top: 47%;
-  z-index: 300;
-}
-.router-fx[data-variant="cloud"][data-state="settled"] .router-fx-mote--winner .router-fx-mote-i {
-  filter: blur(0);
-  opacity: 1;
-  color: var(--accent);
-  font-weight: 600;
-  letter-spacing: 0.09em;
-  transform: scale(1.9);
-  text-shadow:
-    0 0 8px color-mix(in srgb, var(--accent) 70%, transparent),
-    0 0 22px color-mix(in srgb, var(--accent) 46%, transparent),
-    0 0 48px color-mix(in srgb, var(--accent) 24%, transparent);
 }
 
 /* Once settled, the chase hammer is gone — the .win cell is the marker. */
@@ -3404,65 +3316,16 @@ select.clarify-form-input {
   transition: none !important;
 }
 
-/* Focal reticle: two corner ticks that close on the winner as it locks. */
-.router-fx[data-variant="cloud"] .router-fx-reticle {
-  position: absolute;
-  left: 50%;
-  top: 47%;
-  width: 168px;
-  height: 58px;
-  transform: translate(-50%, -50%) scale(0.82);
-  opacity: 0;
-  pointer-events: none;
-  transition:
-    opacity 460ms ease 220ms,
-    transform 600ms cubic-bezier(.2,.85,.25,1) 220ms;
-}
-.router-fx[data-variant="cloud"] .router-fx-reticle::before,
-.router-fx[data-variant="cloud"] .router-fx-reticle::after {
-  content: '';
-  position: absolute;
-  width: 14px;
-  height: 14px;
-  border: 1px solid color-mix(in srgb, var(--accent) 55%, transparent);
-}
-.router-fx[data-variant="cloud"] .router-fx-reticle::before { left: 0; top: 0; border-right: none; border-bottom: none; }
-.router-fx[data-variant="cloud"] .router-fx-reticle::after  { right: 0; bottom: 0; border-left: none; border-top: none; }
-.router-fx[data-variant="cloud"][data-state="settled"] .router-fx-reticle {
-  opacity: 0.9;
-  transform: translate(-50%, -50%) scale(1);
-}
-
-/* Observe mode: routed model did not drive the turn — dim the whole field. */
-.router-fx[data-variant="cloud"][data-observe="true"] .router-fx-cloud { opacity: 0.6; }
-
-/* Fallback: the chosen tier was the safety net — carry the signal in danger
- * (static glow, no breathe). */
-.router-fx[data-variant="cloud"][data-source="fallback"][data-state="settled"] .router-fx-mote--winner .router-fx-mote-i {
-  color: var(--danger);
-  text-shadow:
-    0 0 7px color-mix(in srgb, var(--danger) 68%, transparent),
-    0 0 20px color-mix(in srgb, var(--danger) 45%, transparent),
-    0 0 46px color-mix(in srgb, var(--danger) 24%, transparent);
-  animation: none;
-}
-.router-fx[data-variant="cloud"][data-source="fallback"] .router-fx-reticle::before,
-.router-fx[data-variant="cloud"][data-source="fallback"] .router-fx-reticle::after {
-  border-color: color-mix(in srgb, var(--danger) 55%, transparent);
-}
-
-/* NOTE: the cloud deliberately does NOT honour prefers-reduced-motion — the
- * panel is an explicitly toggled decorative effect (the "Router animation" /
- * "Cloud view" switches are the opt-in), so OS reduce-motion does not
- * blanket-suppress it. Turn the switch off to stop the motion. */
-
-/* Mobile: a shorter field + smaller type so the nebula still breathes. */
-@media (max-width: 640px) {
-  .router-fx[data-variant="cloud"] .router-fx-cloud {
-    height: 200px;
-  }
-  .router-fx[data-variant="cloud"] .router-fx-mote-i { font-size: 10px; }
-  .router-fx[data-variant="cloud"][data-state="settled"] .router-fx-mote--winner .router-fx-mote-i {
-    transform: scale(1.6);
-  }
-}
+/* ── Router-fx style variants ────────────────────────────────────────────
+ * Groundwork for future frontend experiments. The visible style today is the
+ * BASE look above, rendered when no data-variant attribute is present. JS
+ * (_buildRouterFxElement) stamps data-variant="<name>" on the .router-fx root
+ * only for non-'default' variants, so adding a skin is purely additive here.
+ *
+ * To add a variant:
+ *   .router-fx[data-variant="<name>"] { --accent: …; --danger: …; }
+ * Prefer redefining the custom properties the strip already consumes (--accent,
+ * --danger, --text*, --bg*, --hairline, --radius-*). Keep variants
+ * palette-only unless the router contract changes to support a second visual
+ * grammar for real candidates.
+ */

--- a/src/opensquilla/gateway/static/css/views/skills.css
+++ b/src/opensquilla/gateway/static/css/views/skills.css
@@ -507,6 +507,36 @@
   padding: 4px 0;
   font-size: var(--fs-sm);
 }
+.sk-dialog__requirements {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.sk-dialog__req-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) auto minmax(0, 1.4fr);
+  align-items: center;
+  gap: 8px;
+  font-size: var(--fs-sm);
+}
+.sk-dialog__req-name {
+  min-width: 0;
+  font-family: var(--font-mono);
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+.sk-dialog__req-detail {
+  min-width: 0;
+  color: var(--text-dim);
+  overflow-wrap: anywhere;
+}
+.sk-dialog__req-detail code {
+  font-family: var(--font-mono);
+  background: var(--bg-elevated);
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+  color: var(--accent);
+}
 .sk-dialog__link { color: var(--accent); font-weight: 500; font-size: var(--fs-sm); }
 .sk-dialog__foot {
   display: flex; align-items: center; justify-content: space-between;

--- a/src/opensquilla/gateway/static/js/components/savings-fx.js
+++ b/src/opensquilla/gateway/static/js/components/savings-fx.js
@@ -104,7 +104,7 @@ const SavingsFX = (() => {
 
   function _isComboTier(tier) {
     const value = String(tier || '').trim().toLowerCase();
-    const numeric = /^t(\d+)$/.exec(value);
+    const numeric = /^c(\d+)$/.exec(value) || /^t(\d+)$/.exec(value);
     if (numeric) return Number(numeric[1]) < 3;
     return value !== 'highest' && value !== 'top' && value !== 'flagship';
   }

--- a/src/opensquilla/gateway/static/js/views/chat.js
+++ b/src/opensquilla/gateway/static/js/views/chat.js
@@ -43,6 +43,10 @@ const ChatView = (() => {
   let _currentRunStatus = 'idle';
   let _historySyncTimer = null;
   const _AWAITING_MODEL_CLASS = 'awaiting-model';
+  const _STREAM_ACTIVE_MARK_CLASS = 'streaming-active-mark';
+  const _STREAM_ACTIVE_MARK_DELAY_MS = 3500;
+  let _streamActiveMarkTimer = null;
+  let _streamActiveMarkVisibleStartedAt = 0;
   let _lastVisibleStreamEvent = '';
   const _DEFAULT_STREAM_IDLE_TIMEOUT_MS = 210000; // server should emit terminal first
   let _streamIdleTimeoutMs = _DEFAULT_STREAM_IDLE_TIMEOUT_MS;
@@ -714,6 +718,13 @@ const ChatView = (() => {
       + '<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>';
   }
 
+  function _clearMessageActionFocus(reason = '') {
+    const active = document.activeElement;
+    if (!active || !active.closest || !active.closest('.msg-actions')) return;
+    active.blur();
+    _chatDiag('message_actions.focus_cleared', { reason: reason || '' });
+  }
+
   // Append the hover-action row to a message bubble. Buttons are CSS-hidden
   // until the bubble is hovered/focus-within; click handling lives in
   // _bindHoverActions (delegated on the thread). The row is anchored inside
@@ -912,6 +923,7 @@ const ChatView = (() => {
       ev.stopPropagation();
       const bubble = btn.closest('.msg');
       if (!bubble) return;
+      btn.blur();
       const action = btn.dataset.action;
       if (action === 'copy') {
         const text = _extractBubbleText(bubble);
@@ -1303,7 +1315,7 @@ const ChatView = (() => {
     // Config (which populates _routerFxModels and registers all
     // configured tiers including image_only ones) must finish before
     // the first history render — otherwise non-winner cells fall back
-    // to the tier id ("t1", "t2") instead of the real model name.
+    // to the tier id ("c1", "c2") instead of the real model name.
     _loadFeatureToggles()
       .catch(() => { /* fall through to history anyway */ })
       .finally(() => _loadHistory());
@@ -1361,6 +1373,9 @@ const ChatView = (() => {
     if (routerToggle) {
       routerToggle.addEventListener('change', async () => {
         const enabled = routerToggle.checked;
+        const previousRouterFeatureEnabled = _routerFeatureEnabled;
+        _routerFeatureEnabled = enabled;
+        if (!enabled) _clearRouterFxVisuals('router_disabled');
         try {
           const patches = { 'squilla_router.enabled': enabled };
           patches['squilla_router.rollout_phase'] = enabled ? 'full' : 'observe';
@@ -1372,7 +1387,10 @@ const ChatView = (() => {
           UI.toast('Squilla Router: ' + (enabled ? 'ON' : 'OFF'), 'info');
         } catch (e) {
           // Revert on failure
+          _routerFeatureEnabled = previousRouterFeatureEnabled;
           routerToggle.checked = !enabled;
+          if (!previousRouterFeatureEnabled) _clearRouterFxVisuals('router_patch_reverted');
+          else _scheduleHistorySync();
           UI.toast('Failed: ' + e.message, 'err');
         }
       });
@@ -1450,12 +1468,10 @@ const ChatView = (() => {
       _updateElevatedPill();
       _refreshToolbarTriggerGlow();
 
-      // Pre-populate the router slider's tier list and model cache
-      // from the operator's actual configured tiers. We register EVERY
-      // tier (including image-only ones like "image_model") into the
-      // slot list, so image-capable models like kimi-k2.6 show up in
-      // the slider even before the first image route fires for the
-      // current session.
+      // Pre-populate the router visualisation from the operator's actual
+      // configured tiers. We keep every tier in the cache, including
+      // image-only routes, but render-time request-kind filtering decides
+      // which candidates can really be called for this turn.
       //
       // We REPLACE _routerFxSlotList from config (rather than merge)
       // so that tiers the operator has removed drop out of the grid
@@ -1468,17 +1484,25 @@ const ChatView = (() => {
       if (tiers && typeof tiers === 'object') {
         Object.keys(tiers).forEach((tier) => {
           if (typeof tier !== 'string' || !tier) return;
-          const lower = tier.toLowerCase();
+          const lower = _routerFxNormalizeTier(tier);
+          if (!lower) return;
           configTierKeys.push(lower);
           configTierSet.add(lower);
-          const model = tiers[tier]?.model;
-          if (typeof model === 'string' && model) {
-            _routerFxModels[lower] = model;
-          }
+          const rawTier = tiers[tier];
+          const tierConfig = {
+            model: typeof rawTier?.model === 'string' ? rawTier.model : '',
+            supportsImage: rawTier?.supports_image === true,
+            imageOnly: rawTier?.image_only === true,
+          };
+          _routerFxTierConfigs[lower] = tierConfig;
+          if (tierConfig.model) _routerFxModels[lower] = tierConfig.model;
         });
       }
       Object.keys(_routerFxModels).forEach((tier) => {
         if (!configTierSet.has(tier)) delete _routerFxModels[tier];
+      });
+      Object.keys(_routerFxTierConfigs).forEach((tier) => {
+        if (!configTierSet.has(tier)) delete _routerFxTierConfigs[tier];
       });
       _routerFxConfigTiers = configTierSet;
       if (configTierKeys.length > 0) {
@@ -2352,8 +2376,9 @@ const ChatView = (() => {
     });
 
     // Keyboard: Enter to send; slash navigation; ↑/↓ history; Alt+↑/↓ pending edit.
-    // ESC streaming abort lives on the document-level handler below, except in
-    // editable targets where ESC belongs to text editing / menu dismissal.
+    // ESC streaming abort lives on the document-level handler below. The
+    // composer textarea is allowed to bubble there while streaming; other
+    // editable targets keep ESC for text editing / menu dismissal.
     _textarea.addEventListener('keydown', (e) => {
       if (_composing || e.isComposing || e.keyCode === 229) return;
 
@@ -2439,7 +2464,8 @@ const ChatView = (() => {
       }
     });
 
-    // Document-level ESC: works outside editable targets. Priority chain:
+    // Document-level ESC: works across the chat view, while preserving
+    // non-composer editable targets. Priority chain:
     //   1. streaming  → _onStop (which also recovers pending)
     //   2. pending    → _popAllPendingIntoComposer
     //   3. otherwise drop through to the textarea handler / popovers / no-op
@@ -2454,19 +2480,20 @@ const ChatView = (() => {
     //   - DOM probe: catches sibling document-level consumers that haven't
     //     run yet — if any overlay is currently visible, defer to its handler
     //     instead of treating ESC as a turn abort.
+    //   - editable guard: preserves ESC inside non-composer inputs, while the
+    //     chat textarea can still abort the active stream.
     function _onDocKeydown(e) {
       if (e.key !== 'Escape') return;
       if (typeof Router !== 'undefined' && Router.currentPath && Router.currentPath() !== '/chat') return;
       if (e.defaultPrevented) return;
       if (_chatOverlayVisible()) return;
       const target = e.target;
-      const inEditable = target && (
-        target === _textarea
-        || target.tagName === 'INPUT'
+      const inOtherEditable = target && target !== _textarea && (
+        target.tagName === 'INPUT'
         || target.tagName === 'TEXTAREA'
         || target.isContentEditable
       );
-      if (inEditable) return; // textarea handler will deal with the empty-clear case
+      if (inOtherEditable) return;
       if (_isStreaming) {
         e.preventDefault();
         _onStop('webui_escape');
@@ -2766,8 +2793,16 @@ const ChatView = (() => {
         if (typeof res.current_stream_seq === 'number') {
           _setSessionStreamSeq(subscribeKey, res.current_stream_seq);
         }
-        UI.toast('Session stream gap detected; reloading transcript.', 'warn', 5000);
-        _loadHistory();
+        const replayGapReason = res.replay_gap_reason || res.replayGapReason || '';
+        if (_replayGapShouldWarn(replayGapReason)) {
+          UI.toast('Missed live stream events; transcript refreshed.', 'warn', 5000);
+        } else {
+          _chatDiag('session.subscribe.replay_gap.history_refresh', {
+            reason: replayGapReason,
+            currentStreamSeq: res.current_stream_seq,
+          });
+        }
+        _loadHistory(_historyRefreshScrollOptions());
       } else if (
         res
         && typeof res.current_stream_seq === 'number'
@@ -2845,7 +2880,7 @@ const ChatView = (() => {
     if (!_thread) return null;
     if (!_compactionSeparatorEl || !_compactionSeparatorEl.isConnected) {
       _compactionSeparatorEl = document.createElement('div');
-      _compactionSeparatorEl.className = 'chat-context-separator chat-context-separator--info';
+      _compactionSeparatorEl.className = 'chat-context-separator chat-context-separator--session chat-context-separator--info';
       _compactionSeparatorEl.setAttribute('role', 'status');
       _compactionSeparatorEl.setAttribute('aria-live', 'polite');
     }
@@ -2896,7 +2931,7 @@ const ChatView = (() => {
       return !!overrides.persist;
     }
     if (!_compactionTerminalStatus(status)) return false;
-    return source === 'manual' && status === 'completed';
+    return status === 'completed';
   }
 
   function _compactionStatusLabel(payload, source, status) {
@@ -2945,6 +2980,7 @@ const ChatView = (() => {
       : '';
     separator.className = [
       'chat-context-separator',
+      'chat-context-separator--session',
       liveClass,
       `chat-context-separator--${tone}`,
       `chat-context-separator--${status || 'unknown'}`,
@@ -2953,6 +2989,7 @@ const ChatView = (() => {
     separator.dataset.source = source || '';
     separator.innerHTML = `<span>${_esc(label)}</span>`;
     _placeCompactionSeparator();
+    if (_autoScroll) _scrollToBottom();
     if (_compactionTerminalStatus(status)) {
       if (_shouldPersistCompactionSeparator(status, source, overrides)) return;
       _scheduleCompactionSeparatorRemoval();
@@ -3243,80 +3280,20 @@ const ChatView = (() => {
   }
 
   /* ── Router slider — arcade-brutalist whac-a-mole grid ─────────────
-   * Fires once per user message when session.event.router_decision
-   * lands. A 3 × 4 cell grid mixes the operator's real configured
-   * tiers (deduped by model) with popular decoy models from the
-   * OpenRouter ecosystem; a hammer-selector hops between cells with
-   * bouncy easing and locks onto the routed cell with a particle
-   * burst. The strip is non-blocking — assistant text streams below
-   * the grid while the chase plays above. */
-
-  // 5 cols × 3 rows = 15 cells. The wider grid gives the hammer more
-  // hops to play and shows the model space as a proper "dial" rather
-  // than a tight 4-cell strip. Mobile breakpoints collapse this down
-  // (see chat.css @media rules).
-  const _ROUTER_FX_GRID_COLS = 5;
-  const _ROUTER_FX_GRID_ROWS = 3;
-  const _ROUTER_FX_GRID_CELLS = _ROUTER_FX_GRID_COLS * _ROUTER_FX_GRID_ROWS;
-  const _ROUTER_FX_REAL_ANCHOR_CELLS = [1, 6, 8, 13, 11, 3, 5, 9, 12, 14, 0, 4, 7, 10, 2];
-
-  // Popular OpenRouter models used as visual decoys, ordered by
-  // approximate openrouter.ai traffic ranking (highest volume first),
-  // refreshed 2026-05 from the OpenRouter usage leaderboard. Anything
-  // already on the operator's router (matched after stripping the
-  // provider prefix) is filtered out at render-time, so the
-  // highest-traffic models that aren't on this user's dial bubble to
-  // the top of the visible field. The actual route is always chosen
-  // from the operator's configured tiers — these only populate the
-  // field. With the real/decoy distinction removed, configured models
-  // are no longer VISUALLY distinguishable from the rest (the roster can
-  // still be inferred by correlating shown names against this public
-  // pool — closing that fully is a separate, deeper change).
-  const _ROUTER_FX_DECOY_POOL = [
-    'deepseek-v4-flash',
-    'claude-sonnet-4.6',
-    'qwen3.6-plus',
-    'minimax-m2.7',
-    'gpt-5.5',
-    'gemini-3.5-flash',
-    'glm-5-turbo',
-    'claude-opus-4.8',
-    'nemotron-3-super',
-    'deepseek-v4-pro',
-    'mimo-v2.5-pro',
-    'gpt-5.4',
-    'kimi-k2.6',
-    'claude-opus-4.7',
-    'gemini-3.1-flash-lite',
-    'glm-5.1',
-    'qwen3.6-max',
-    'claude-haiku-4.5',
-    'grok-4.3',
-    'gpt-5.4-mini',
-    'gemini-2.5-flash',
-    'step-3.5-flash',
-    'mistral-medium-3.5',
-    'ling-2.6-1t',
-    'deepseek-v3.2',
-    'trinity-large-thinking',
-    'gemini-2.5-pro',
-    'seed-2.0-mini',
-    'gpt-5.3-codex',
-    'grok-4.20',
-    'mercury-2',
-    'hunyuan-3',
-    'mimo-v2-omni',
-    'command-r-plus',
-    'llama-4-405b',
-    'sonar-large',
-  ];
+   * Fires once per user message when session.event.router_decision lands.
+   * The grid contains only the effective candidates that could actually be
+   * called for this request kind, deduped by display model name. A
+   * hammer-selector hops between those real cells and locks onto the routed
+   * cell with a particle burst. The strip is non-blocking — assistant text
+   * streams below the grid while the chase plays above. */
 
   // OpenSquilla's tier ids vary by tier_profile. We seed the slot
   // list from config and register any decision tier we haven't seen
   // before, so the grid never silently drops an unfamiliar tier.
-  const _ROUTER_FX_DEFAULT_TIERS = ['t0', 't1', 't2', 't3'];
+  const _ROUTER_FX_DEFAULT_TIERS = ['c0', 'c1', 'c2', 'c3'];
   let _routerFxSlotList = _ROUTER_FX_DEFAULT_TIERS.slice();
   const _routerFxModels = {};
+  const _routerFxTierConfigs = {};
   // Authoritative set of tier ids that exist in the *current* config
   // snapshot (populated by _loadFeatureToggles). Used to skip history
   // strips whose routed_tier has been removed from config and to know
@@ -3359,8 +3336,8 @@ const ChatView = (() => {
 
   function _routerFxSortTiers(list) {
     return list.slice().sort((a, b) => {
-      const am = /^t(\d+)$/.exec(a);
-      const bm = /^t(\d+)$/.exec(b);
+      const am = /^c(\d+)$/.exec(a);
+      const bm = /^c(\d+)$/.exec(b);
       if (am && bm) return parseInt(am[1], 10) - parseInt(bm[1], 10);
       if (am) return -1;
       if (bm) return 1;
@@ -3368,9 +3345,14 @@ const ChatView = (() => {
     });
   }
 
+  function _routerFxNormalizeTier(tier) {
+    if (typeof tier !== 'string' || !tier) return '';
+    return tier.toLowerCase().replace(/^t([0-3])$/, 'c$1');
+  }
+
   function _routerFxRegisterTier(tier) {
-    if (typeof tier !== 'string' || !tier) return;
-    const norm = tier.toLowerCase();
+    const norm = _routerFxNormalizeTier(tier);
+    if (!norm) return;
     if (_routerFxSlotList.indexOf(norm) >= 0) return;
     _routerFxSlotList = _routerFxSortTiers(_routerFxSlotList.concat([norm]));
   }
@@ -3388,10 +3370,110 @@ const ChatView = (() => {
     return _modelDisplayName(name);
   }
 
+  function _routerFxRequestKindFromAttachments(attachments) {
+    const list = Array.isArray(attachments) ? attachments : [];
+    for (const item of list) {
+      const mime = String(item?.mime || item?.type || '').toLowerCase();
+      if (mime.indexOf('image/') === 0) return 'image';
+    }
+    return 'text';
+  }
+
+  function _routerFxNormalizeRequestKind(requestKind) {
+    return requestKind === 'image' ? 'image' : 'text';
+  }
+
+  function _routerFxTierConfig(tier) {
+    const norm = typeof tier === 'string' ? tier.toLowerCase() : '';
+    const known = norm ? _routerFxTierConfigs[norm] : null;
+    if (known) return known;
+    return {
+      model: norm && _routerFxModels[norm] ? _routerFxModels[norm] : '',
+      supportsImage: false,
+      imageOnly: false,
+    };
+  }
+
+  function _routerFxRememberTierDecision(tier, model) {
+    if (typeof tier !== 'string' || !tier) return;
+    const norm = tier.toLowerCase();
+    _routerFxRegisterTier(norm);
+    if (!model) return;
+    const modelName = String(model);
+    _routerFxModels[norm] = modelName;
+    const current = _routerFxTierConfigs[norm] || {};
+    _routerFxTierConfigs[norm] = {
+      model: modelName,
+      supportsImage: current.supportsImage === true,
+      imageOnly: current.imageOnly === true,
+    };
+  }
+
+  function _routerFxTierMatchesRequestKind(tierConfig, requestKind) {
+    const kind = _routerFxNormalizeRequestKind(requestKind);
+    if (kind === 'image') return !!(tierConfig.supportsImage || tierConfig.imageOnly);
+    return !tierConfig.imageOnly;
+  }
+
+  function _routerFxRequestKindFromDecision(decision, fallbackKind) {
+    if (fallbackKind) return _routerFxNormalizeRequestKind(fallbackKind);
+    const source = String(decision?.source || decision?.routing_source || '').toLowerCase();
+    const tier = String(decision?.tier || decision?.routed_tier || '').toLowerCase();
+    if (source === 'image_route' || tier === 'image_model') return 'image';
+    return 'text';
+  }
+
+  function _routerFxVisualEntries(requestKind, decision) {
+    if (_routerFxConfigTiers === null) return [];
+    const kind = _routerFxRequestKindFromDecision(decision, requestKind);
+    const byDisplay = new Map();
+    _routerFxSlotList.forEach((tier) => {
+      if (_routerFxConfigTiers !== null && !_routerFxConfigTiers.has(tier)) return;
+      const tierConfig = _routerFxTierConfig(tier);
+      if (!_routerFxTierMatchesRequestKind(tierConfig, kind)) return;
+      const displayName = tierConfig.model ? _routerFxStripProvider(tierConfig.model) : tier;
+      const key = displayName ? displayName.toLowerCase() : tier;
+      let entry = byDisplay.get(key);
+      if (!entry) {
+        entry = { key, tiers: [], model: tierConfig.model || '', displayName };
+        byDisplay.set(key, entry);
+      }
+      entry.tiers.push(tier);
+      if (!entry.model && tierConfig.model) entry.model = tierConfig.model;
+    });
+    const decisionTier = decision && typeof decision.tier === 'string'
+      ? decision.tier.toLowerCase()
+      : '';
+    const decisionModel = decision && typeof decision.model === 'string' ? decision.model : '';
+    if (decisionTier && decisionModel) {
+      const displayName = _routerFxStripProvider(decisionModel);
+      const key = displayName ? displayName.toLowerCase() : decisionTier;
+      let entry = byDisplay.get(key);
+      if (!entry && _routerFxTierMatchesRequestKind(_routerFxTierConfig(decisionTier), kind)) {
+        entry = { key, tiers: [], model: decisionModel, displayName };
+        byDisplay.set(key, entry);
+      }
+      if (entry) {
+        if (entry.tiers.indexOf(decisionTier) < 0) entry.tiers.push(decisionTier);
+        if (!entry.model) entry.model = decisionModel;
+      }
+    }
+    return Array.from(byDisplay.values()).map((e) => ({
+      key: e.key,
+      tiers: _routerFxSortTiers(e.tiers),
+      model: e.model,
+      displayName: e.displayName || (e.model ? _routerFxStripProvider(e.model) : e.tiers[0]),
+    }));
+  }
+
+  function _routerFxHasMultipleCandidates(requestKind, decision) {
+    return _routerFxVisualEntries(requestKind, decision).length > 1;
+  }
+
   // Promise resolved when _loadFeatureToggles has populated tier
   // models from config. Any _loadHistory call awaits this gate so the
   // first history rebuild never renders strips with empty tier names
-  // ("t1", "t2", …) just because config hadn't returned yet.
+  // ("c1", "c2", …) just because config hadn't returned yet.
   let _routerFxConfigReadyResolve = null;
   const _routerFxConfigReady = new Promise((resolve) => {
     _routerFxConfigReadyResolve = resolve;
@@ -3466,7 +3548,7 @@ const ChatView = (() => {
   }
   function _routerFxIdentity(model, tier) {
     const modelPart = typeof model === 'string' ? model.trim().toLowerCase() : '';
-    const tierPart = typeof tier === 'string' ? tier.trim().toLowerCase() : '';
+    const tierPart = _routerFxNormalizeTier(tier);
     if (!modelPart && !tierPart) return '';
     return modelPart + '|' + tierPart;
   }
@@ -3520,110 +3602,25 @@ const ChatView = (() => {
     }
   }
 
-  // Group tiers by their backing model so two tiers that resolve to
-  // the same model don't get two cells.
-  function _routerFxRealEntries(decision) {
-    const winnerTier = decision && typeof decision.tier === 'string' ? decision.tier.toLowerCase() : '';
-    const winnerModel = decision && typeof decision.model === 'string' ? decision.model : '';
-    const slotKeyOf = (tier) => {
-      const m = _routerFxModels[tier];
-      return m ? m : 'tier:' + tier;
-    };
-    const byKey = new Map();
-    _routerFxSlotList.forEach((tier) => {
-      const key = slotKeyOf(tier);
-      let entry = byKey.get(key);
-      if (!entry) {
-        entry = { key, tiers: [], model: _routerFxModels[tier] || '' };
-        byKey.set(key, entry);
-      }
-      entry.tiers.push(tier);
-    });
-    if (winnerTier && winnerModel) {
-      const target = byKey.get(slotKeyOf(winnerTier));
-      if (target && !target.model) target.model = winnerModel;
-    }
-    return Array.from(byKey.values()).map((e) => ({
-      key: e.key,
-      tiers: e.tiers,
-      model: e.model,
-      displayName: e.model ? _routerFxStripProvider(e.model) : e.tiers[0],
-    }));
+  // Build the visual roster for this turn only. Text requests exclude
+  // image-only routes; image requests include only image-capable routes.
+  // Entries are deduped by display model name so provider/thinking/tier
+  // differences do not create extra visual cells.
+  function _routerFxRealEntries(decision, requestKind) {
+    return _routerFxVisualEntries(requestKind, decision);
   }
 
-  // FNV-1a 32-bit hash of a string — folds the seed key down to a
-  // single integer for mulberry32 to seed off.
-  function _routerFxHashSeed(key) {
-    let h = 0x811c9dc5;
-    const s = String(key == null ? '' : key);
-    for (let i = 0; i < s.length; i++) {
-      h ^= s.charCodeAt(i);
-      h = Math.imul(h, 0x01000193);
-    }
-    return h >>> 0;
-  }
-
-  // mulberry32 PRNG — deterministic, well-distributed, ~10 LoC.
-  function _routerFxMulberry32(seed) {
-    let state = seed >>> 0;
-    return function () {
-      state = (state + 0x6D2B79F5) >>> 0;
-      let t = state;
-      t = Math.imul(t ^ (t >>> 15), t | 1);
-      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-    };
-  }
-
-  // Fisher-Yates in place using the supplied RNG (defaults to
-  // Math.random when no seed key is given — exclusively for code
-  // paths that don't have a stable identifier).
-  function _routerFxShuffle(arr, seedKey) {
-    const rng = seedKey != null
-      ? _routerFxMulberry32(_routerFxHashSeed(seedKey))
-      : Math.random;
-    for (let i = arr.length - 1; i > 0; i--) {
-      const j = Math.floor(rng() * (i + 1));
-      const tmp = arr[i];
-      arr[i] = arr[j];
-      arr[j] = tmp;
-    }
-    return arr;
-  }
-
-  // Assemble the grid (_ROUTER_FX_GRID_CELLS cells): real (deduped) entries + decoys.
-  // Real cells land on distributed anchor slots in a deterministic model order,
-  // so each available model keeps a stable position. The live selector animation
-  // remains random; only the underlying dial layout is fixed.
+  // Assemble the grid from real candidates only. No filler/decoy wall: every
+  // visible model name is a candidate that could actually be called this turn.
   function _routerFxBuildGridCells(realEntries, seedKey) {
-    const cells = Array.from({ length: _ROUTER_FX_GRID_CELLS }, () => null);
-    const realNames = new Set();
     const orderedRealEntries = realEntries.slice().sort((a, b) => (
       (a.displayName || a.key || '').localeCompare(b.displayName || b.key || '')
     ));
-    orderedRealEntries.forEach((entry, i) => {
-      const anchor = _ROUTER_FX_REAL_ANCHOR_CELLS[i];
-      const idx = typeof anchor === 'number' ? anchor : cells.findIndex((cell) => cell == null);
-      if (idx < 0 || idx >= cells.length) return;
-      cells[idx] = { kind: 'real', entry, displayName: entry.displayName };
-      if (entry.displayName) realNames.add(entry.displayName);
-    });
-
-    const decoys = [];
-    for (let i = 0; i < _ROUTER_FX_DECOY_POOL.length && decoys.length < _ROUTER_FX_GRID_CELLS; i++) {
-      const name = _ROUTER_FX_DECOY_POOL[i];
-      if (realNames.has(name)) continue;
-      decoys.push({ kind: 'decoy', displayName: name });
-    }
-    while (decoys.length < _ROUTER_FX_GRID_CELLS) {
-      decoys.push({ kind: 'decoy', displayName: '—' });
-    }
-    const orderedDecoys = _routerFxShuffle(decoys, seedKey ? seedKey + ':decoy' : undefined);
-    let decoyIdx = 0;
-    for (let i = 0; i < cells.length; i++) {
-      if (cells[i] == null) cells[i] = orderedDecoys[decoyIdx++];
-    }
-    return cells;
+    return orderedRealEntries.map((entry) => ({
+      kind: 'real',
+      entry,
+      displayName: entry.displayName,
+    }));
   }
 
   function _buildRouterFxElement(decision, opts) {
@@ -3633,7 +3630,7 @@ const ChatView = (() => {
     wrap.setAttribute('data-history-role', 'router');
     wrap.dataset.renderMode = opts.renderMode || (opts.preSettled ? 'history' : 'live');
     wrap.dataset.state = 'idle';
-    wrap.dataset.tier = decision.tier || '';
+    wrap.dataset.tier = _routerFxNormalizeTier(decision.tier);
     wrap.dataset.source = decision.source || 'none';
     const identity = _routerFxDecisionIdentity(decision);
     if (identity) wrap.dataset.routerIdentity = identity;
@@ -3665,32 +3662,21 @@ const ChatView = (() => {
     const seedKey = opts && opts.seedKey ? String(opts.seedKey) : '';
     if (seedKey) wrap.dataset.seed = seedKey;
 
-    // Cloud variant: a focal-depth nebula of pool models + the routed winner.
-    // No configured roster is rendered. Returns early; the grid build below
-    // is the default look.
-    if (variant === 'cloud') {
-      _routerFxBuildCloud(wrap, decision, seedKey);
-      if (opts.preSettled) {
-        _settleRouterFxCloud(wrap);
-        _routerFxNormalizeSettledStrip(wrap, opts.renderMode || 'history', decision);
-      }
-      return wrap;
-    }
-
-    const realEntries = _routerFxRealEntries(decision);
+    const requestKind = _routerFxRequestKindFromDecision(decision, opts.requestKind);
+    const realEntries = _routerFxRealEntries(decision, requestKind);
+    if (realEntries.length <= 1) return null;
     const gridCells = _routerFxBuildGridCells(realEntries, seedKey || undefined);
 
     const grid = document.createElement('div');
     grid.className = 'router-fx-grid';
+    const cols = Math.min(4, Math.max(2, gridCells.length));
+    const mobileCols = gridCells.length > 2 ? 2 : gridCells.length;
+    grid.style.setProperty('--router-fx-cols', String(cols));
+    grid.style.setProperty('--router-fx-mobile-cols', String(Math.max(1, mobileCols)));
     gridCells.forEach((cellInfo, i) => {
       const cell = document.createElement('div');
       cell.className = 'router-fx-cell';
       cell.dataset.cellIdx = String(i);
-      // Intentionally NOT stamping which cell is real (configured) vs decoy:
-      // every cell renders identically, and the DOM must not leak the
-      // operator's wired-up model roster. Winner detection reads the in-memory
-      // _fxGridCells array (below), not any DOM attribute, so the routing
-      // result still lands on the right cell without exposing the rest.
       // title surfaces the full name on hover when a long one is ellipsized.
       cell.innerHTML = `<span class="nm" title="${_esc(cellInfo.displayName)}">${_esc(cellInfo.displayName)}</span>`;
       grid.appendChild(cell);
@@ -3702,9 +3688,10 @@ const ChatView = (() => {
 
     wrap._fxGridCells = gridCells;
     wrap._fxRealEntries = realEntries;
+    wrap._fxRequestKind = requestKind;
 
     if (opts.preSettled) {
-      const winnerIdx = _routerFxWinnerCellIndex(wrap, decision.tier);
+      const winnerIdx = _routerFxWinnerCellIndex(wrap, _routerFxNormalizeTier(decision.tier));
       if (winnerIdx >= 0) {
         _settleRouterFxImmediate(wrap, winnerIdx, { burst: false, decision });
         _routerFxNormalizeSettledStrip(wrap, opts.renderMode || 'history', decision);
@@ -3788,9 +3775,6 @@ const ChatView = (() => {
     if (selector) selector.classList.remove('visible', 'lock', 'lock-impact');
     wrap.querySelectorAll('.router-fx-cell.pinging').forEach((cell) => {
       cell.classList.remove('pinging');
-    });
-    wrap.querySelectorAll('.router-fx-mote.is-scan').forEach((mote) => {
-      mote.classList.remove('is-scan');
     });
     wrap.querySelectorAll('.router-fx-burst').forEach((burst) => burst.remove());
   }
@@ -3947,116 +3931,13 @@ const ChatView = (() => {
     });
   }
 
-  // ── Cloud variant ("model nebula" / rack-focus) ─────────────────────
-  // A focal-depth field of ~36 pool models + the routed winner, scattered
-  // at seeded positions/depths. Routing reads as a camera rack-focus pull:
-  // the whole field defocuses, then the winner snaps sharp and blooms an
-  // accent glow at the focal point while the rest recede to bokeh. The field
-  // is pool + winner ONLY (never the configured roster), so it exposes
-  // nothing beyond the already-public routed model.
+  // Winner label used for settled semantics and assistive text.
   function _routerFxWinnerName(decision) {
     const model = decision && (decision.model || decision.routed_model);
     if (model) return _routerFxStripProvider(String(model));
-    const tier = decision && decision.tier ? String(decision.tier).toLowerCase() : '';
+    const tier = _routerFxNormalizeTier(decision && decision.tier);
     if (tier && _routerFxModels[tier]) return _routerFxStripProvider(_routerFxModels[tier]);
     return tier || '';
-  }
-
-  function _routerFxBuildCloud(wrap, decision, seedKey) {
-    const cloud = document.createElement('div');
-    cloud.className = 'router-fx-cloud';
-    const winnerName = _routerFxWinnerName(decision);
-    // Field = the public decoy pool + the routed winner (deduped). No
-    // configured-roster names beyond the winner are ever rendered.
-    const seen = new Set();
-    const names = [];
-    if (winnerName) { names.push(winnerName); seen.add(winnerName.toLowerCase()); }
-    _ROUTER_FX_DECOY_POOL.forEach((n) => {
-      const k = n.toLowerCase();
-      if (!seen.has(k)) { seen.add(k); names.push(n); }
-    });
-    // Deterministic per seed so a history rebuild reproduces the same nebula.
-    const rng = _routerFxMulberry32(_routerFxHashSeed((seedKey || '') + ':cloud'));
-    const wkey = winnerName ? winnerName.toLowerCase() : '';
-    let winnerEl = null;
-    names.forEach((name) => {
-      // Two layers, so motion never fights: the OUTER mote owns position +
-      // a perpetual parallax drift (transform) + the winner's travel-to-
-      // focus (left/top), while the INNER owns the rack-focus (scale, blur,
-      // opacity, glow). Splitting them means the field keeps breathing even
-      // once settled, and the winner glides to the focal point instead of
-      // teleporting.
-      const mote = document.createElement('span');
-      mote.className = 'router-fx-mote';
-      // Organic elliptical scatter: area-uniform radius (sqrt) at a random
-      // angle clusters names toward the core and thins to the edges — a soft
-      // nebula, no rigid rows. Focal depth d∈[0,1] drives blur, scale and
-      // opacity TOGETHER so it reads as coherent optical depth, not a tag cloud.
-      const d = rng();
-      const ang = rng() * Math.PI * 2;
-      const rad = Math.sqrt(rng());
-      const x = (50 + Math.cos(ang) * rad * 47).toFixed(2);
-      const y = (50 + Math.sin(ang) * rad * 41).toFixed(2);
-      const blur = (d * 3.4).toFixed(2);
-      const scale = (1.22 - d * 0.62).toFixed(3);
-      const op = (0.92 - d * 0.64).toFixed(3);
-      const z = Math.round((1 - d) * 100);
-      const driftDur = (11 + rng() * 9).toFixed(2);
-      const driftDelay = (-(rng() * 20)).toFixed(2);
-      const dx = (rng() * 2 - 1).toFixed(2);
-      const dy = (rng() * 2 - 1).toFixed(2);
-      mote.style.cssText =
-        `--x:${x}%;--y:${y}%;--z:${z};--drift:${driftDur}s;`
-        + `--ddelay:${driftDelay}s;--dx:${dx};--dy:${dy};`;
-      const inner = document.createElement('span');
-      inner.className = 'router-fx-mote-i';
-      inner.style.cssText = `--blur:${blur}px;--sc:${scale};--op:${op};`;
-      inner.textContent = name;
-      mote.appendChild(inner);
-      if (!winnerEl && wkey && name.toLowerCase() === wkey) {
-        mote.classList.add('router-fx-mote--winner');
-        winnerEl = mote;
-      }
-      cloud.appendChild(mote);
-    });
-    const reticle = document.createElement('div');
-    reticle.className = 'router-fx-reticle';
-    reticle.setAttribute('aria-hidden', 'true');
-    cloud.appendChild(reticle);
-    wrap.appendChild(cloud);
-    wrap._fxCloud = true;
-    wrap._fxWinnerEl = winnerEl;
-  }
-
-  // Settle with no animation (history rebuild, observe mode, reduced motion):
-  // winner in focus, the rest already receded — the CSS settled state does it.
-  function _settleRouterFxCloud(wrap) {
-    if (!wrap) return;
-    wrap.dataset.state = 'settled';
-    delete wrap.dataset.live;
-    delete wrap.dataset.scanning;
-    wrap._fxFinished = true;
-    _routerFxClearVisualResidue(wrap);
-    _routerFxApplySettledSemantics(wrap, wrap._fxDecision || null, wrap.dataset.renderMode);
-  }
-
-  // Live rack-focus: brief beat on the full field, defocus the whole field
-  // (ease-in, lens leaving focus), then snap the winner sharp (decelerate).
-  // The optical pull is CSS (mote transitions keyed off data-state); JS only
-  // flips the phase with the right timing.
-  function _animateRouterFxCloud(wrap) {
-    if (!wrap) return;
-    // Opt-in via the toggle, independent of OS reduce-motion (see
-    // _animateRouterFx). Settle directly only if there is no winner to focus.
-    if (!wrap._fxWinnerEl) { _settleRouterFxCloud(wrap); return; }
-    _routerFxClearAnimationTimers(wrap);
-    // Hold the in-focus field a beat so the defocus reads as intentional.
-    wrap._fxAnimTimers.push(setTimeout(() => {
-      if (wrap.isConnected && wrap.dataset.renderMode === 'live') wrap.dataset.state = 'playing';
-    }, 260));
-    wrap._fxAnimTimers.push(setTimeout(() => {
-      if (wrap.isConnected && wrap.dataset.renderMode === 'live') _settleRouterFxCloud(wrap);
-    }, 680));
   }
 
   // ── Scan → lock ─────────────────────────────────────────────────────────
@@ -4082,7 +3963,13 @@ const ChatView = (() => {
     }
   }
 
-  function _finishPendingRouterFxScan() {
+  function _clearRouterFxVisuals(reason = '') {
+    _cancelPendingRouterFxScan(reason || 'clear_visuals');
+    if (!_thread) return;
+    _thread.querySelectorAll('.router-fx').forEach((el) => _routerFxRemoveStrip(el));
+  }
+
+  async function _finishPendingRouterFxScan() {
     const pending = _routerFxScanPending;
     _routerFxScanDelayTimer = null;
     _routerFxScanPending = null;
@@ -4102,7 +3989,25 @@ const ChatView = (() => {
       });
       return;
     }
-    const started = _routerFxBeginScan(pending.anchorDiv, pending.seedKey);
+    await _routerFxAwaitConfig();
+    if (pending.sessionKey !== (_sessionKey || '')) {
+      _chatDiag('router_scan.pending.drop.session_changed_after_config', {
+        pendingSessionKey: pending.sessionKey || '',
+        sessionKey: _sessionKey || '',
+      });
+      return;
+    }
+    if (_isCompactInFlightForCurrentSession()
+        || _routerFxIsSuppressedForCompactionTurn(pending.turnIndex)) {
+      _chatDiag('router_scan.pending.drop.compaction_suppressed_after_config', {
+        sessionKey: pending.sessionKey || '',
+        turnIndex: pending.turnIndex || '',
+      });
+      return;
+    }
+    const started = _routerFxBeginScan(pending.anchorDiv, pending.seedKey, {
+      requestKind: pending.requestKind,
+    });
     if (!started || !pending.decision || !_thread) return;
     const liveStrip = _thread.querySelector('.router-fx[data-live="true"]');
     if (!liveStrip || liveStrip.dataset.turnIndex !== String(pending.turnIndex)) return;
@@ -4117,7 +4022,9 @@ const ChatView = (() => {
     }
   }
 
-  function _scheduleRouterFxBeginScan(anchorDiv, seedKey) {
+  function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts) {
+    opts = opts || {};
+    const requestKind = _routerFxNormalizeRequestKind(opts.requestKind);
     _cancelPendingRouterFxScan('reschedule');
     if (_routerFxIsSuppressedForCompactionTurn(_routerFxCountUserMessages())) {
       _chatDiag('router_scan.schedule.skip.compaction_suppressed', {
@@ -4133,16 +4040,27 @@ const ChatView = (() => {
       });
       return false;
     }
+    if (_routerFxConfigTiers !== null && !_routerFxHasMultipleCandidates(requestKind, null)) {
+      _chatDiag('router_scan.schedule.skip.single_candidate', {
+        requestKind,
+        candidates: _routerFxVisualEntries(requestKind, null).length,
+      });
+      return false;
+    }
     _routerFxScanPending = {
       anchorDiv,
       seedKey,
+      requestKind,
       sessionKey: _sessionKey || '',
       turnIndex: String(_routerFxCountUserMessages()),
       decision: null,
     };
-    _routerFxScanDelayTimer = setTimeout(_finishPendingRouterFxScan, _ROUTER_FX_START_DELAY_MS);
+    _routerFxScanDelayTimer = setTimeout(() => {
+      void _finishPendingRouterFxScan();
+    }, _ROUTER_FX_START_DELAY_MS);
     _chatDiag('router_scan.scheduled', {
       seedKey,
+      requestKind,
       delayMs: _ROUTER_FX_START_DELAY_MS,
       turnIndex: _routerFxScanPending.turnIndex,
       anchor: _chatDiagDescribeElement(anchorDiv),
@@ -4155,7 +4073,9 @@ const ChatView = (() => {
   // winner. The scan is JS-driven (discrete class/position changes every
   // ~170ms), so it renders regardless of any CSS-animation quirk — and it
   // fills the wait instead of trailing it, replacing the "Watching" placeholder.
-  function _routerFxBeginScan(anchorDiv, seedKey) {
+  function _routerFxBeginScan(anchorDiv, seedKey, opts) {
+    opts = opts || {};
+    const requestKind = _routerFxNormalizeRequestKind(opts.requestKind);
     if (_routerFxIsSuppressedForCompactionTurn(_routerFxCountUserMessages())) {
       _chatDiag('router_scan.skip.compaction_suppressed', {
         turnIndex: String(_routerFxCountUserMessages()),
@@ -4172,10 +4092,28 @@ const ChatView = (() => {
       });
       return false;
     }
+    if (!_routerFxHasMultipleCandidates(requestKind, null)) {
+      _chatDiag('router_scan.skip.single_candidate', {
+        requestKind,
+        candidates: _routerFxVisualEntries(requestKind, null).length,
+      });
+      return false;
+    }
     _thread.querySelectorAll('.router-fx[data-live="true"]').forEach((el) => {
       _routerFxRemoveStrip(el);
     });
-    const wrap = _buildRouterFxElement({ source: 'none' }, { seedKey, renderMode: 'live' });
+    const wrap = _buildRouterFxElement({ source: 'none' }, {
+      seedKey,
+      renderMode: 'live',
+      requestKind,
+    });
+    if (!wrap) {
+      _chatDiag('router_scan.skip.single_candidate', {
+        requestKind,
+        candidates: _routerFxVisualEntries(requestKind, null).length,
+      });
+      return false;
+    }
     wrap.dataset.live = 'true';
     wrap.dataset.scanning = 'true';
     wrap.dataset.state = 'scanning';
@@ -4227,15 +4165,14 @@ const ChatView = (() => {
     }
   }
 
-  // JS-driven roaming "search": every ~170ms a different candidate is brought
-  // into focus (cloud: a mote sharpens via .is-scan; grid: the hammer hops).
+  // JS-driven roaming "search": every ~190ms the selector hops across a real
+  // candidate cell.
   function _routerFxScanRoam(wrap) {
-    const isCloud = !!wrap._fxCloud;
-    const container = wrap.querySelector(isCloud ? '.router-fx-cloud' : '.router-fx-grid');
-    if (!container) return;
-    const targets = container.querySelectorAll(isCloud ? '.router-fx-mote' : '.router-fx-cell');
+    const grid = wrap.querySelector('.router-fx-grid');
+    if (!grid) return;
+    const targets = grid.querySelectorAll('.router-fx-cell');
     if (!targets.length) return;
-    const selector = isCloud ? null : container.querySelector('.router-fx-selector');
+    const selector = grid.querySelector('.router-fx-selector');
     if (selector) selector.classList.add('visible');
     let prev = -1;
     const step = () => {
@@ -4244,13 +4181,11 @@ const ChatView = (() => {
       let g = 0;
       do { i = Math.floor(Math.random() * targets.length); g++; } while (i === prev && g < 8);
       prev = i;
-      if (isCloud) {
-        targets.forEach((m, idx) => m.classList.toggle('is-scan', idx === i));
-      } else if (selector) {
+      if (selector) {
         _routerFxPositionSelector(selector, targets[i], { hopIdx: i });
         _routerFxPing(targets[i]);
       }
-      wrap._fxScanTimer = setTimeout(step, isCloud ? 170 : 190);
+      wrap._fxScanTimer = setTimeout(step, 190);
     };
     step();
   }
@@ -4260,7 +4195,6 @@ const ChatView = (() => {
     if (wrap._fxScanTimer) { clearTimeout(wrap._fxScanTimer); wrap._fxScanTimer = null; }
     if (wrap._fxScanCap) { clearTimeout(wrap._fxScanCap); wrap._fxScanCap = null; }
     delete wrap.dataset.scanning;
-    wrap.querySelectorAll('.router-fx-mote.is-scan').forEach((m) => m.classList.remove('is-scan'));
   }
 
   function _routerFxPauseScanTimers(wrap) {
@@ -4297,7 +4231,7 @@ const ChatView = (() => {
     _thread.querySelectorAll('.router-fx[data-live="true"]').forEach((wrap) => {
       // Output already complete/arriving → finish the scan immediately, locking
       // onto the cached winner (no half-scan left hanging). Do not mark frozen:
-      // _routerFxLockGrid/_routerFxLockCloud own the visible selection motion.
+      // _routerFxLockGrid owns the visible selection motion.
       if (wrap._fxDecision) {
         _routerFxFinishScan(wrap);
       } else {
@@ -4313,7 +4247,7 @@ const ChatView = (() => {
     if (!wrap) return;
     decision = decision || {};
     _routerFxStopScan(wrap);
-    wrap.dataset.tier = decision.tier || '';
+    wrap.dataset.tier = _routerFxNormalizeTier(decision.tier);
     wrap.dataset.source = decision.source || 'none';
     wrap.dataset.renderMode = wrap.dataset.renderMode || 'live';
     wrap._fxDecision = decision;
@@ -4324,36 +4258,13 @@ const ChatView = (() => {
       wrap.dataset.rolloutPhase = typeof decision.rollout_phase === 'string'
         ? decision.rollout_phase : 'observe';
     }
-    if (wrap._fxCloud) _routerFxLockCloud(wrap, decision);
-    else _routerFxLockGrid(wrap, decision);
-  }
-
-  function _routerFxLockCloud(wrap, decision) {
-    const winnerName = _routerFxWinnerName(decision);
-    const wkey = winnerName ? winnerName.toLowerCase() : '';
-    let winnerEl = null;
-    const motes = wrap.querySelectorAll('.router-fx-mote');
-    if (wkey) {
-      motes.forEach((m) => {
-        const inner = m.querySelector('.router-fx-mote-i');
-        if (!winnerEl && inner && (inner.textContent || '').trim().toLowerCase() === wkey) winnerEl = m;
-      });
-      if (!winnerEl && motes.length) {
-        // Routed model isn't in the field — relabel the first mote to it.
-        winnerEl = motes[0];
-        const inner = winnerEl.querySelector('.router-fx-mote-i');
-        if (inner) inner.textContent = winnerName;
-      }
-    }
-    if (winnerEl) { winnerEl.classList.add('router-fx-mote--winner'); wrap._fxWinnerEl = winnerEl; }
-    requestAnimationFrame(() => { if (wrap.isConnected) _settleRouterFxCloud(wrap); });
+    _routerFxLockGrid(wrap, decision);
   }
 
   function _routerFxLockGrid(wrap, decision) {
-    const tier = decision.tier ? String(decision.tier) : '';
+    const tier = _routerFxNormalizeTier(decision.tier);
     if (tier) {
-      _routerFxRegisterTier(tier);
-      if (decision.model) _routerFxModels[tier.toLowerCase()] = String(decision.model);
+      _routerFxRememberTierDecision(tier, decision.model || '');
     }
     const winnerIdx = _routerFxWinnerCellIndex(wrap, tier);
     if (winnerIdx >= 0) {
@@ -4494,15 +4405,12 @@ const ChatView = (() => {
       _chatDiag('router_decision.skip.invalid_payload', {});
       return;
     }
-    const tier = typeof payload.tier === 'string' ? payload.tier : '';
+    const tier = _routerFxNormalizeTier(payload.tier);
     if (!tier) {
       _chatDiag('router_decision.skip.no_tier', _chatDiagSummarizePayload(payload));
       return;
     }
-    _routerFxRegisterTier(tier);
-    if (payload.model) {
-      _routerFxModels[tier.toLowerCase()] = String(payload.model);
-    }
+    _routerFxRememberTierDecision(tier, payload.model || '');
     const turnIndex = _routerFxCountUserMessages();
     if (_routerFxIsSuppressedForCompactionTurn(turnIndex)) {
       if (_thread) {
@@ -4536,6 +4444,7 @@ const ChatView = (() => {
       _chatDiag('router_decision.cached_on_pending_scan', {
         payload: _chatDiagSummarizePayload(payload),
         turnIndex: _routerFxScanPending.turnIndex || '',
+        requestKind: _routerFxScanPending.requestKind || '',
       });
       return;
     }
@@ -4576,6 +4485,11 @@ const ChatView = (() => {
       _chatDiag('router_decision.skip.disabled_post_config', _chatDiagSummarizePayload(payload));
       return;
     }
+    const replayRequestKind = _routerFxRequestKindFromDecision(payload, null);
+    if (!_routerFxHasMultipleCandidates(replayRequestKind, payload)) {
+      _chatDiag('router_decision.skip.single_candidate', _chatDiagSummarizePayload(payload));
+      return;
+    }
     if (!_historyHasRendered || _historyHydrating) {
       _cachePendingRouterDecision(payload);
       _chatDiag('router_decision.cached_during_history_hydration', {
@@ -4602,14 +4516,16 @@ const ChatView = (() => {
       preSettled: true,
       renderMode: 'history',
       seedKey: replaySeed,
+      requestKind: replayRequestKind,
     });
-    // Cloud flags its winner mote at build time; the grid resolves a winning
-    // cell index. Either way, bail if there is no winner to focus.
-    const winnerIdx = wrap._fxCloud ? -1 : _routerFxWinnerCellIndex(wrap, tier);
-    if (wrap._fxCloud ? !wrap._fxWinnerEl : winnerIdx < 0) {
+    if (!wrap) {
+      _chatDiag('router_decision.skip.single_candidate', _chatDiagSummarizePayload(payload));
+      return;
+    }
+    const winnerIdx = _routerFxWinnerCellIndex(wrap, tier);
+    if (winnerIdx < 0) {
       _chatDiag('router_decision.skip.no_winner', {
         payload: _chatDiagSummarizePayload(payload),
-        cloud: !!wrap._fxCloud,
         winnerIdx,
       });
       return;
@@ -4648,7 +4564,8 @@ const ChatView = (() => {
   // `seedKey` should be a stable per-turn identifier (msg.timestamp
   // or message id) so the cell shuffle reproduces deterministically
   // across page refreshes.
-  function _buildRouterFxFromUsage(usage, seedKey) {
+  function _buildRouterFxFromUsage(usage, seedKey, opts) {
+    opts = opts || {};
     if (!usage) return null;
     // User-pref gate: the viewer has hidden the router-fx visualisation, so
     // no history strip is built. Distinct from the operator routing flag below
@@ -4659,16 +4576,16 @@ const ChatView = (() => {
     // was recorded, drop the historic strip on the next rebuild —
     // the slider's whole point is conveying live router behaviour.
     if (_routerFxConfigTiers !== null && !_routerFeatureEnabled) return null;
-    const tier = typeof usage.routed_tier === 'string' ? usage.routed_tier : '';
+    const tier = _routerFxNormalizeTier(usage.routed_tier);
     if (!tier) return null;
     // If the operator has REMOVED this tier from config since the
     // turn was recorded, skip — rendering the strip would show a
-    // ghost cell ("t2") with no current meaning.
+    // ghost cell ("c2") with no current meaning.
     if (_routerFxConfigTiers !== null
-        && !_routerFxConfigTiers.has(tier.toLowerCase())) {
+        && !_routerFxConfigTiers.has(tier)) {
       return null;
     }
-    _routerFxRegisterTier(tier);
+    _routerFxRememberTierDecision(tier, usage.routed_model || usage.model || '');
     const decision = {
       tier,
       model: usage.routed_model || usage.model || '',
@@ -4678,7 +4595,7 @@ const ChatView = (() => {
       routing_applied: usage.routing_applied !== false,
       rollout_phase: usage.rollout_phase || 'full',
     };
-    if (decision.model) _routerFxModels[tier.toLowerCase()] = decision.model;
+    const requestKind = _routerFxRequestKindFromDecision(decision, opts.requestKind);
     // The cached seed from _routerFxResolveSeed already encodes
     // (stamp, tier, turnIndex) — pass it through verbatim so that
     // live and history paths derive the SAME shuffle for the same
@@ -4688,6 +4605,7 @@ const ChatView = (() => {
     return _buildRouterFxElement(decision, {
       preSettled: true,
       seedKey: seedKey != null ? String(seedKey) : ('history:' + tier),
+      requestKind: requestKind,
     });
   }
 
@@ -5174,7 +5092,7 @@ const ChatView = (() => {
         _hideThinkingIndicator();
         _subscribeSession();
         _loadCurrentSessionUsage();
-        _loadHistory();
+        _loadHistory(_historyRefreshScrollOptions());
       }
       if (state === 'disconnected' && _isStreaming) {
         _clearStreamIdleTimer();
@@ -5293,11 +5211,27 @@ const ChatView = (() => {
 
   /* ── Chat History ───────────────────────────────────────────────────── */
 
+  function _historyRefreshScrollOptions() {
+    if (!_thread || !_historyHasRendered) return {};
+    const gap = _thread.scrollHeight - _thread.scrollTop - _thread.clientHeight;
+    if (gap < 60) return {};
+    return {
+      preserveScroll: true,
+      previousScrollHeight: _thread.scrollHeight,
+      previousScrollTop: _thread.scrollTop,
+    };
+  }
+
+  function _replayGapShouldWarn(reason) {
+    const value = String(reason || '').toLowerCase();
+    return !['stream_buffer_empty', 'stream_buffer_reset', 'cursor_ahead_of_stream'].includes(value);
+  }
+
   function _scheduleHistorySync() {
     if (_historySyncTimer) clearTimeout(_historySyncTimer);
     _historySyncTimer = setTimeout(() => {
       _historySyncTimer = null;
-      _loadHistory();
+      _loadHistory(_historyRefreshScrollOptions());
     }, 50);
   }
 
@@ -5428,7 +5362,7 @@ const ChatView = (() => {
     _thread.insertBefore(row, _thread.firstChild || null);
   }
 
-  async function _loadHistory() {
+  async function _loadHistory(opts = {}) {
     if (!_sessionKey || !_thread) return;
     const requestSessionKey = _sessionKey;
     const requestSeq = ++_historyRequestSeq;
@@ -5442,7 +5376,7 @@ const ChatView = (() => {
     try {
       await _rpc.waitForConnection();
       // Wait until router config (tier → model cache) is populated so
-      // historical strips never render with "t1"/"t2"/"t3" placeholders
+      // historical strips never render with "c1"/"c2"/"c3" placeholders
       // just because we raced the config.get response.
       await _routerFxAwaitConfig();
       const data = await _rpc.call('chat.history', {
@@ -5467,7 +5401,7 @@ const ChatView = (() => {
         historyScope: _historyScope,
       });
       _historyHydrating = false;
-      _renderHistoryMessages(messages);
+      _renderHistoryMessages(messages, opts);
     } catch (err) {
       if (requestSessionKey === _sessionKey && requestSeq === _historyRequestSeq) {
         _historyHydrating = false;
@@ -5540,6 +5474,7 @@ const ChatView = (() => {
 
   function _renderHistoryMessages(messages, opts = {}) {
     if (!_thread) return;
+    _clearMessageActionFocus('history_rebuild');
     _removeHistoryScopeRows();
     if (messages.length === 0) {
       const liveRouterStrips = _currentSessionLiveRouterStrips(_sessionKey || '');
@@ -5615,14 +5550,19 @@ const ChatView = (() => {
     // keyed by (sessionKey, userMsgIndex, tier); using this counter
     // means live + history rebuilds for the same turn reuse the same layout.
     let _histUserIdx = 0;
+    let _histLastUserRequestKind = 'text';
     const consumedHistoryElements = new Set();
     messages.forEach((msg) => {
-        if (msg.role === 'user') _histUserIdx++;
+        if (msg.role === 'user') {
+          _histUserIdx++;
+          _histLastUserRequestKind = _routerFxRequestKindFromAttachments(msg.attachments || []);
+        }
         const rawText = msg.text || '';
         const displayText = msg.role === 'user' ? _stripTimePrefix(rawText) : rawText;
         const stableIdentity = _historyStableMessageIdentity(msg);
         const fallbackIdentity = _historyFallbackMessageIdentity(msg.role, displayText);
         const msgOptions = {
+          timestamp: msg.timestamp || msg.ts || null,
           provenanceKind: msg.provenance_kind || '',
           provenanceSourceSessionKey: msg.provenance_source_session_key || '',
           provenanceSourceTool: msg.provenance_source_tool || '',
@@ -5743,7 +5683,9 @@ const ChatView = (() => {
                 if (existingStrip) _routerFxRemoveStrip(existingStrip);
                 const hint = msg.timestamp || msg.ts || msg.message_id || '';
                 const cachedSeed = _routerFxResolveLayoutSeed(_sessionKey, hint);
-                const routerStrip = _buildRouterFxFromUsage(savedUsage, cachedSeed);
+                const routerStrip = _buildRouterFxFromUsage(savedUsage, cachedSeed, {
+                  requestKind: _histLastUserRequestKind,
+                });
                 if (routerStrip) {
                   routerStrip.dataset.sessionKey = _sessionKey || '';
                   routerStrip.dataset.turnIndex = String(_histUserIdx);
@@ -5818,14 +5760,22 @@ const ChatView = (() => {
 	      });
 	  }
 
+  function _historyLiveTailAnchor() {
+    if (!_isStreaming) return null;
+    if (_isCurrentSessionStreamBubble(_streamBubble)) return _streamBubble;
+    if (_isCurrentSessionThinkingIndicator(_thinkingEl)) return _thinkingEl;
+    return null;
+  }
+
   function _appendHistoryDaySeparator(timestamp) {
     const day = _dayKey(timestamp);
     if (!day || day === _lastHeaderDay) return;
     const sep = document.createElement('div');
     sep.className = 'chat-day-sep';
     sep.innerHTML = `<span>${_dayLabel(day)}</span>`;
-    if (_isStreaming && _isCurrentSessionStreamBubble(_streamBubble)) {
-      _thread.insertBefore(sep, _streamBubble);
+    const liveTail = _historyLiveTailAnchor();
+    if (liveTail) {
+      _thread.insertBefore(sep, liveTail);
     } else {
       _thread.appendChild(sep);
     }
@@ -5840,8 +5790,9 @@ const ChatView = (() => {
     // turn unit; otherwise the DOM reorder can strand the strip above the user
     // while output is streaming.
     const attachedRouterStrip = _routerFxStripImmediatelyAfterUser(div);
-    if (_isStreaming && _isCurrentSessionStreamBubble(_streamBubble) && div !== _streamBubble) {
-      _thread.insertBefore(div, _streamBubble);
+    const liveTail = _historyLiveTailAnchor();
+    if (liveTail && div !== liveTail) {
+      _thread.insertBefore(div, liveTail);
       _restoreRouterFxAfterHistoryUser(div, attachedRouterStrip);
       return;
     }
@@ -6030,10 +5981,39 @@ const ChatView = (() => {
     }
   }
 
+  function _syncMessageHeader(div, displayRole, timestamp, options = {}) {
+    if (!div) return;
+    const day = _dayKey(timestamp);
+    const collapsible = (displayRole === 'user' || displayRole === 'assistant');
+    const sameGroup = collapsible
+      && (displayRole === _lastHeaderRole)
+      && day === _lastHeaderDay
+      && day !== '';
+    if (collapsible) _lastHeaderRole = displayRole;
+    const existing = div.querySelector(':scope > .msg-header');
+    const isoStr = timestamp
+      ? (typeof timestamp === 'string' ? timestamp : new Date(timestamp).toISOString())
+      : '';
+    if (sameGroup) {
+      if (existing) existing.remove();
+      if (isoStr) div.title = new Date(isoStr).toLocaleString();
+      return;
+    }
+    const header = existing || document.createElement('div');
+    header.className = 'msg-header';
+    if (isoStr) {
+      header.title = new Date(isoStr).toLocaleString();
+      div.removeAttribute('title');
+    }
+    header.innerHTML = `<span class="role-label">${_esc(_displayRoleLabel(displayRole))}</span>${_renderMessageTags(options)}<span class="msg-time">${_esc(timestamp ? _relTime(timestamp) : '')}</span>`;
+    if (!existing) div.insertBefore(header, div.firstChild);
+  }
+
   function _replaceHistoryMessage(div, role, text, options = {}) {
     const isSubagentCompletion = _isSubagentCompletionMessage(role, text, options);
     const displayRole = isSubagentCompletion ? 'subagent' : role;
     div.className = `msg ${displayRole}`;
+    _syncMessageHeader(div, displayRole, options.timestamp || null, options);
     const body = div.querySelector('.msg-body');
     if (body) {
       _renderMessageBody(body, role, text, options);
@@ -6186,6 +6166,7 @@ const ChatView = (() => {
     }
     const normalizationProvenance = _inputNormalizationProvenanceFromAttachments(_pendingAttachments);
     if (normalizationProvenance) params.inputProvenance = normalizationProvenance;
+    const routerFxRequestKind = _routerFxRequestKindFromAttachments(params.attachments || []);
 
     // Clear input and attachments
     _textarea.value = '';
@@ -6196,7 +6177,9 @@ const ChatView = (() => {
     // Start streaming UI. Delay the routing scan briefly so request-time
     // compaction can claim the turn without a competing one-frame router flash.
     _startStreaming();
-    const routerScanStarted = _scheduleRouterFxBeginScan(userDiv, _routerFxResolveLayoutSeed(_sessionKey));
+    const routerScanStarted = _scheduleRouterFxBeginScan(userDiv, _routerFxResolveLayoutSeed(_sessionKey), {
+      requestKind: routerFxRequestKind,
+    });
     _chatDiag('send.start', {
       textLen: providerText.length,
       attachments: params.attachments ? params.attachments.length : 0,
@@ -6536,6 +6519,38 @@ const ChatView = (() => {
     return true;
   }
 
+  function _clearStreamActiveMarkReveal() {
+    if (_streamActiveMarkTimer) {
+      clearTimeout(_streamActiveMarkTimer);
+      _streamActiveMarkTimer = null;
+    }
+    _streamActiveMarkVisibleStartedAt = 0;
+    if (_streamBubble) _streamBubble.classList.remove(_STREAM_ACTIVE_MARK_CLASS);
+  }
+
+  function _beginStreamActiveMarkRevealWindow() {
+    _streamActiveMarkVisibleStartedAt = Date.now();
+    _scheduleStreamActiveMarkReveal();
+  }
+
+  function _maybeRevealStreamActiveMark() {
+    if (!_isStreaming || !_streamBubble) return false;
+    const elapsedMs = _streamActiveMarkVisibleStartedAt ? Date.now() - _streamActiveMarkVisibleStartedAt : 0;
+    if (elapsedMs < _STREAM_ACTIVE_MARK_DELAY_MS) return false;
+    _streamBubble.classList.add(_STREAM_ACTIVE_MARK_CLASS);
+    return true;
+  }
+
+  function _scheduleStreamActiveMarkReveal() {
+    if (_streamActiveMarkTimer) clearTimeout(_streamActiveMarkTimer);
+    const generation = _streamGeneration;
+    _streamActiveMarkTimer = setTimeout(() => {
+      _streamActiveMarkTimer = null;
+      if (_streamGeneration !== generation) return;
+      _maybeRevealStreamActiveMark();
+    }, _STREAM_ACTIVE_MARK_DELAY_MS);
+  }
+
   function _startStreaming() {
     _chatDiag('stream.start.before', {
       wasStreaming: _isStreaming,
@@ -6609,6 +6624,7 @@ const ChatView = (() => {
       }
 
       _thread.appendChild(_streamBubble);
+      _beginStreamActiveMarkRevealWindow();
 
       // Create the first text segment
       _newTextSegment();
@@ -6616,6 +6632,7 @@ const ChatView = (() => {
         streamBubble: _chatDiagDescribeElement(_streamBubble),
       });
     }
+    _maybeRevealStreamActiveMark();
     return _streamBubble;
   }
 
@@ -6714,6 +6731,7 @@ const ChatView = (() => {
     if (_renderRafId) { cancelAnimationFrame(_renderRafId); _renderRafId = null; }
     _renderDirty = false;
     _clearStreamIdleTimer();
+    _clearStreamActiveMarkReveal();
     _streamIdlePausedForApproval = false;
     _approvalPendingForCurrentSession = false;
     if (_streamBubble) {
@@ -9289,6 +9307,7 @@ const ChatView = (() => {
     // Clear the root --composer-h so other views' toasts don't keep that offset.
     document.documentElement.style.removeProperty('--composer-h');
     if (_isStreaming) _endStreaming();
+    _clearStreamActiveMarkReveal();
     _hideThinkingIndicator();
     _cancelPendingRouterFxScan('destroy');
     if (_renderRafId) { cancelAnimationFrame(_renderRafId); _renderRafId = null; }

--- a/src/opensquilla/gateway/static/js/views/setup.js
+++ b/src/opensquilla/gateway/static/js/views/setup.js
@@ -8,12 +8,12 @@ const SetupView = (() => {
     { id: 'extras', label: 'Capabilities' },
     { id: 'finish', label: 'Finish' },
   ];
-  const TEXT_TIERS = ['t0', 't1', 't2', 't3'];
+  const TEXT_TIERS = ['c0', 'c1', 'c2', 'c3'];
   const TIER_LABELS = {
-    t0: 'Fast/simple (t0)',
-    t1: 'Balanced default (t1)',
-    t2: 'Stronger reasoning (t2)',
-    t3: 'Max quality (t3)',
+    c0: 'Route c0',
+    c1: 'Route c1',
+    c2: 'Route c2',
+    c3: 'Route c3',
   };
   const READINESS_LABELS = {
     ok: 'Ready',
@@ -482,7 +482,7 @@ const SetupView = (() => {
     const profiles = catalog.profiles || [];
     const profile = provider ? profiles.find(p => p.providerId === provider) || {} : {};
     const tiers = provider ? Object.assign({}, profile.tiers || {}, router.tiers || {}) : {};
-    const defaultTier = router.default_tier || catalog.defaultTier || 't1';
+    const defaultTier = router.default_tier || catalog.defaultTier || 'c1';
     const mode = router.enabled === false ? 'disabled' : 'recommended';
     const routerSummary = provider
       ? `${provider} / ${_tierLabel(defaultTier)}`
@@ -524,6 +524,9 @@ const SetupView = (() => {
   }
 
   function _tierRow(name, tier) {
+    const isImageModel = name === 'image_model';
+    const imageCheckedAttr = isImageModel ? ' checked disabled' :
+      (tier.supportsImage || tier.supports_image ? ' checked' : '');
     return `<div class="setup-tier-table__row" role="row" data-tier="${_esc(name)}">
       <span><code>${_esc(name)}</code></span>
       <input ${_tierControlAttrs(name, 'provider', 'provider')} data-tier-field="provider" value="${_esc(tier.provider || '')}">
@@ -531,7 +534,7 @@ const SetupView = (() => {
       <select ${_tierControlAttrs(name, 'thinkingLevel', 'thinking level')} data-tier-field="thinkingLevel">
         ${['', 'off', 'none', 'minimal', 'low', 'medium', 'high', 'xhigh'].map(v => `<option value="${v}"${v === (tier.thinkingLevel || tier.thinking_level || '') ? ' selected' : ''}>${v || '-'}</option>`).join('')}
       </select>
-      <input ${_tierControlAttrs(name, 'supportsImage', 'supports image')} type="checkbox" data-tier-field="supportsImage"${tier.supportsImage || tier.supports_image ? ' checked' : ''}>
+      <input ${_tierControlAttrs(name, 'supportsImage', 'supports image')} type="checkbox" data-tier-field="supportsImage"${imageCheckedAttr}>
     </div>`;
   }
 
@@ -544,7 +547,7 @@ const SetupView = (() => {
   }
 
   function _tierLabel(tier) {
-    return TIER_LABELS[tier] || tier || 'Balanced default (t1)';
+    return TIER_LABELS[tier] || tier || 'Route c1';
   }
 
   function _renderChannelsStep() {
@@ -1580,12 +1583,16 @@ const SetupView = (() => {
         const key = input.dataset.tierField;
         tier[key] = input.type === 'checkbox' ? input.checked : input.value;
       });
+      if (row.dataset.tier === 'image_model') {
+        tier.supportsImage = true;
+        tier.image_only = true;
+      }
       tiers[row.dataset.tier] = tier;
     });
     try {
       await _rpc.call('onboarding.router.configure', {
         mode: _el.querySelector('[data-router-mode]')?.value || 'recommended',
-        defaultTier: _el.querySelector('[data-default-tier]')?.value || 't1',
+        defaultTier: _el.querySelector('[data-default-tier]')?.value || 'c1',
         tiers,
       });
       UI.toast('Router saved.', 'info');

--- a/src/opensquilla/gateway/static/js/views/skills.js
+++ b/src/opensquilla/gateway/static/js/views/skills.js
@@ -774,6 +774,42 @@ const SkillsView = (() => {
     </button>`;
   }
 
+  function _renderRequirements(requirements) {
+    const items = requirements && Array.isArray(requirements.items) ? requirements.items : [];
+    if (!items.length) return '';
+    const rows = items.map(item => {
+      const missing = [];
+      (item.missing_bins || []).forEach(b => missing.push(`<code>${_esc(b)}</code>`));
+      (item.missing_env || []).forEach(e => missing.push(`<code>${_esc(e)}</code>`));
+      const requires = [];
+      (item.requires_bins || []).forEach(b => requires.push(_esc(b)));
+      if ((item.requires_any_bins || []).length) {
+        requires.push(`one of ${(item.requires_any_bins || []).map(_esc).join(' / ')}`);
+      }
+      (item.requires_env || []).forEach(e => requires.push(`${_esc(e)} env`));
+      const status = item.status || 'not_declared';
+      const statusLabel = status === 'ready' ? 'ready'
+        : status === 'needs_setup' ? 'needs setup'
+          : status === 'missing_skill' ? 'missing skill'
+            : 'no deps declared';
+      const statusClass = status === 'ready' ? 'sk-chip--ok'
+        : status === 'needs_setup' || status === 'missing_skill' ? 'sk-chip--warn'
+          : 'sk-chip--unverified';
+      const detail = missing.length
+        ? `Missing ${missing.join(', ')}`
+        : requires.length ? requires.join(', ') : 'No declared dependencies';
+      return `<div class="sk-dialog__req-row">
+        <span class="sk-dialog__req-name">${_esc(item.name || 'unknown')}</span>
+        <span class="sk-chip ${statusClass}">${statusLabel}</span>
+        <span class="sk-dialog__req-detail">${detail}</span>
+      </div>`;
+    }).join('');
+    return `<div class="sk-dialog__section">
+      <div class="sk-dialog__section-title">Requirements</div>
+      <div class="sk-dialog__requirements">${rows}</div>
+    </div>`;
+  }
+
   function _openSkillDialog(skill) {
     const dlg = _el.querySelector('#skill-detail-dialog');
     const body = _el.querySelector('#skill-detail-body');
@@ -803,6 +839,8 @@ const SkillsView = (() => {
         </div>`;
       }
     }
+
+    const requirementsHtml = _renderRequirements(skill.requirements);
 
     let installHtml = '';
     const hasMissingBins = (skill.missing_bins || []).length > 0;
@@ -874,6 +912,7 @@ const SkillsView = (() => {
         <p class="sk-dialog__desc">${_esc(skill.description || '')}</p>
         ${triggersHtml}
         ${compositionHtml}
+        ${requirementsHtml}
         ${missingHtml}
         ${installHtml}
         ${homepage ? `<div class="sk-dialog__section">${homepage}</div>` : ''}

--- a/src/opensquilla/memory/dream_factory.py
+++ b/src/opensquilla/memory/dream_factory.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from opensquilla.agents.scope import resolve_agent_workspace_dir
 from opensquilla.memory.dream import Dream
+from opensquilla.router_tiers import DEFAULT_TEXT_TIER, normalize_text_tier
 
 
 def _router_model_routing_enabled(router_cfg: Any | None) -> bool:
@@ -25,11 +26,15 @@ def _dream_provider_target(config: Any) -> tuple[str, str]:
     router_cfg = getattr(config, "squilla_router", None)
     if _router_model_routing_enabled(router_cfg):
         tiers = getattr(router_cfg, "tiers", {}) or {}
-        t1 = tiers.get("t1") if isinstance(tiers, dict) else None
-        if not isinstance(t1, dict) or not str(t1.get("model") or "").strip():
-            raise RuntimeError("squilla_router.tiers.t1 model is required for Dream")
-        provider = str(t1.get("provider") or getattr(llm_cfg, "provider", "openrouter"))
-        model = str(t1["model"])
+        default_tier = normalize_text_tier(getattr(router_cfg, "default_tier", None))
+        default_tier = default_tier or DEFAULT_TEXT_TIER
+        tier_cfg = tiers.get(default_tier) if isinstance(tiers, dict) else None
+        if not isinstance(tier_cfg, dict) or not str(tier_cfg.get("model") or "").strip():
+            raise RuntimeError(
+                f"squilla_router.tiers.{default_tier} model is required for Dream"
+            )
+        provider = str(tier_cfg.get("provider") or getattr(llm_cfg, "provider", "openrouter"))
+        model = str(tier_cfg["model"])
         return provider, model
 
     return str(getattr(llm_cfg, "provider", "openrouter")), str(getattr(llm_cfg, "model", ""))

--- a/src/opensquilla/onboarding/flow.py
+++ b/src/opensquilla/onboarding/flow.py
@@ -58,6 +58,12 @@ from opensquilla.onboarding.search_specs import (
 )
 from opensquilla.onboarding.setup_paths import web_setup_url
 from opensquilla.onboarding.status import get_onboarding_status
+from opensquilla.router_tiers import (
+    DEFAULT_TEXT_TIER,
+    IMAGE_TIER,
+    TEXT_TIERS,
+    normalize_text_tier,
+)
 from opensquilla.ui import (
     ACCENT,
     ACCENT_DIM,
@@ -862,13 +868,13 @@ def run_interactive_memory_embedding_configure(
     return persisted
 
 
-_TEXT_ROUTER_TIERS = ("t0", "t1", "t2", "t3")
-_EXPOSED_ROUTER_TIERS = ("t0", "t1", "t2", "t3", "image_model")
+_TEXT_ROUTER_TIERS = TEXT_TIERS
+_EXPOSED_ROUTER_TIERS = (*TEXT_TIERS, IMAGE_TIER)
 _TEXT_TIER_LABELS = {
-    "t0": "Fast/simple (t0)",
-    "t1": "Balanced default (t1)",
-    "t2": "Stronger reasoning (t2)",
-    "t3": "Max quality (t3)",
+    "c0": "Route c0",
+    "c1": "Route c1",
+    "c2": "Route c2",
+    "c3": "Route c3",
 }
 _IMAGE_TIER_LABEL = "Image model"
 _DONE_LABEL = "Done"
@@ -910,16 +916,20 @@ def _router_mode_to_internal(selected: str | None) -> str:
 
 
 def _text_tier_label(tier: str | None) -> str:
-    return _TEXT_TIER_LABELS.get(str(tier or "t1"), _TEXT_TIER_LABELS["t1"])
+    normalized = normalize_text_tier(tier) or DEFAULT_TEXT_TIER
+    return _TEXT_TIER_LABELS.get(normalized, _TEXT_TIER_LABELS[DEFAULT_TEXT_TIER])
 
 
 def _text_tier_to_internal(selected: str | None) -> str:
+    normalized = normalize_text_tier(selected)
+    if normalized:
+        return normalized
     if selected in _TEXT_ROUTER_TIERS:
         return str(selected)
     for tier, label in _TEXT_TIER_LABELS.items():
         if selected == label:
             return tier
-    return "t1"
+    return DEFAULT_TEXT_TIER
 
 
 def _tier_choice_label(tier: str) -> str:
@@ -948,7 +958,7 @@ def _print_router_defaults(config) -> None:
             f"[{ACCENT_DIM}]router[/] [dim]disabled — requests bypass tier routing[/dim]"
         )
         return
-    default_tier = str(getattr(router, "default_tier", "t1") or "t1")
+    default_tier = _text_tier_to_internal(getattr(router, "default_tier", None))
     default = router.tiers.get(default_tier, {})
     console.print(
         f"[bold {ACCENT}]◆ router[/] "
@@ -1027,7 +1037,7 @@ def _ask_router_fields(
     default_tier_choice = questionary.select(
         "Default text model",
         choices=[_TEXT_TIER_LABELS[tier] for tier in _TEXT_ROUTER_TIERS],
-        default=_text_tier_label(str(preview.squilla_router.default_tier or "t1")),
+        default=_text_tier_label(str(preview.squilla_router.default_tier or "c1")),
     ).ask()
     default_tier = _text_tier_to_internal(default_tier_choice)
     preview = upsert_router(config, mode=mode, default_tier=default_tier).config

--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -32,11 +32,16 @@ from opensquilla.onboarding.redaction import (
     redact_search_payload,
 )
 from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
+from opensquilla.router_tiers import (
+    DEFAULT_TEXT_TIER,
+    TEXT_TIERS,
+    normalize_text_tier,
+)
 from opensquilla.secrets import clean_header_secret
 
 SearchFallbackPolicy = Literal["off", "network"]
 RouterMode = Literal["recommended", "openrouter-mix", "disabled"]
-_TEXT_ROUTER_TIERS = ("t0", "t1", "t2", "t3")
+_TEXT_ROUTER_TIERS = TEXT_TIERS
 _ROUTER_TIER_KEYS = set(_TEXT_ROUTER_TIERS) | {"image_model"}
 _TIER_KEY_ALIASES = {
     "thinkingLevel": "thinking_level",
@@ -91,7 +96,7 @@ def _reconcile_router_profile_for_provider(
     if (
         not current_profile
         and provider_id == "openrouter"
-        and cfg.squilla_router.tiers.get("t0", {}).get("provider") == "openrouter"
+        and cfg.squilla_router.tiers.get("c0", {}).get("provider") == "openrouter"
     ):
         return
     router_payload = cfg.squilla_router.model_dump(mode="python")
@@ -105,16 +110,18 @@ def _reconcile_router_profile_for_provider(
 
 
 def _default_text_tier(default_tier: str | None) -> str:
-    tier = (default_tier or "t1").strip()
-    return tier if tier in _TEXT_ROUTER_TIERS else "t1"
+    tier = normalize_text_tier(default_tier or DEFAULT_TEXT_TIER)
+    return tier if tier in _TEXT_ROUTER_TIERS else DEFAULT_TEXT_TIER
 
 
 def _normalize_explicit_text_tier(default_tier: str | None) -> str | None:
     if default_tier is None:
         return None
-    tier = str(default_tier).strip()
-    if not tier:
+    if not str(default_tier).strip():
         return None
+    tier = normalize_text_tier(default_tier)
+    if not tier:
+        raise ValueError("defaultTier must reference a text tier")
     if tier not in _TEXT_ROUTER_TIERS:
         raise ValueError("defaultTier must reference a text tier")
     return tier
@@ -124,7 +131,7 @@ def _router_default_model_for_provider(provider_id: str, default_tier: str | Non
     if provider_id not in ROUTER_TIER_PROFILE_IDS:
         return ""
     tiers = _router_tier_profile_defaults(provider_id)
-    tier = tiers.get(_default_text_tier(default_tier)) or tiers.get("t1") or {}
+    tier = tiers.get(_default_text_tier(default_tier)) or tiers.get("c1") or {}
     return str(tier.get("model") or "").strip()
 
 
@@ -139,6 +146,15 @@ def _normalize_tier_payload(name: str, payload: Any) -> dict[str, Any]:
     return out
 
 
+def _enforce_router_tier_role_invariants(name: str, tier: dict[str, Any]) -> dict[str, Any]:
+    if name != "image_model":
+        return tier
+    out = dict(tier)
+    out["supports_image"] = True
+    out["image_only"] = True
+    return out
+
+
 def _merge_router_tiers(
     base: dict[str, Any],
     overrides: dict[str, Any] | None,
@@ -149,11 +165,11 @@ def _merge_router_tiers(
     if not isinstance(overrides, dict):
         raise ValueError("router tiers must be an object")
     for name, raw_override in overrides.items():
-        tier_name = str(name)
+        tier_name = normalize_text_tier(name) or str(name)
         override = _normalize_tier_payload(tier_name, raw_override)
         current = dict(merged.get(tier_name, {}))
         current.update(override)
-        merged[tier_name] = current
+        merged[tier_name] = _enforce_router_tier_role_invariants(tier_name, current)
     return merged
 
 
@@ -174,7 +190,7 @@ def _sync_llm_model_to_router_default(cfg: GatewayConfig) -> None:
     router = cfg.squilla_router
     if not getattr(router, "enabled", True):
         return
-    default_tier = str(getattr(router, "default_tier", "t1") or "t1")
+    default_tier = _default_text_tier(getattr(router, "default_tier", DEFAULT_TEXT_TIER))
     _validate_router_tiers(router.tiers, default_tier)
     tier = router.tiers[default_tier]
     model = str(tier.get("model") or "").strip()
@@ -202,7 +218,7 @@ def upsert_llm_provider(
     if not model_clean:
         model_clean = _router_default_model_for_provider(
             provider_id,
-            getattr(config.squilla_router, "default_tier", "t1"),
+            getattr(config.squilla_router, "default_tier", "c1"),
         )
     if not model_clean:
         raise ValueError("model is required")
@@ -281,7 +297,7 @@ def upsert_router(
 
     default_tier_override = _normalize_explicit_text_tier(default_tier)
     default_tier_clean = default_tier_override or str(
-        router_payload.get("default_tier") or "t1"
+        normalize_text_tier(router_payload.get("default_tier")) or DEFAULT_TEXT_TIER
     )
     if default_tier_override is not None:
         router_payload["default_tier"] = default_tier_clean

--- a/src/opensquilla/onboarding/next_steps.py
+++ b/src/opensquilla/onboarding/next_steps.py
@@ -50,7 +50,7 @@ _HEADLESS_SETUP_COMMANDS = {
     ),
     "router": (
         "Headless router",
-        "opensquilla onboard configure router --router recommended --default-tier t1",
+        "opensquilla onboard configure router --router recommended --default-tier c1",
     ),
     "channels": (
         "Channel recipes",
@@ -258,7 +258,7 @@ def format_next_steps(config: Any, *, config_path: str | Path | None = None) -> 
     provider = str(getattr(llm, "provider", "") or "")
     model = str(getattr(llm, "model", "") or "")
     env_key = str(getattr(llm, "api_key_env", "") or "")
-    router_default = str(getattr(router, "default_tier", "") or "t1")
+    router_default = str(getattr(router, "default_tier", "") or "c1")
     router_line = (
         "  Router: disabled"
         if not router.enabled

--- a/src/opensquilla/onboarding/provider_specs.py
+++ b/src/opensquilla/onboarding/provider_specs.py
@@ -133,7 +133,7 @@ def _what_you_need(spec: ProviderSpec) -> tuple[str, ...]:
 def _default_direct_model(provider_id: str) -> str:
     if provider_id in ROUTER_TIER_PROFILE_IDS:
         tiers = _router_tier_profile_defaults(provider_id)
-        tier = tiers.get("t1") or tiers.get("t0") or {}
+        tier = tiers.get("c1") or tiers.get("c0") or {}
         return str(tier.get("model") or "")
     return ""
 

--- a/src/opensquilla/onboarding/router_specs.py
+++ b/src/opensquilla/onboarding/router_specs.py
@@ -9,6 +9,7 @@ from opensquilla.gateway.config import (
     ROUTER_TIER_PROFILE_IDS,
     _router_tier_profile_defaults,
 )
+from opensquilla.router_tiers import DEFAULT_TEXT_TIER, TEXT_TIERS
 
 
 @dataclass(frozen=True)
@@ -39,7 +40,7 @@ def _profile_to_setup(profile_id: str) -> RouterSetupProfile:
     exposed_tiers = {
         name: dict(value)
         for name, value in raw_tiers.items()
-        if name in {"t0", "t1", "t2", "t3", "image_model"}
+        if name in set(TEXT_TIERS) | {"image_model"}
     }
     return RouterSetupProfile(
         profile_id=normalized,
@@ -69,13 +70,13 @@ def _tier_payload(tier: dict[str, Any]) -> dict[str, Any]:
 
 def router_catalog_payload() -> dict[str, Any]:
     return {
-        "defaultTier": "t1",
-        "textTiers": ["t0", "t1", "t2", "t3"],
+        "defaultTier": DEFAULT_TEXT_TIER,
+        "textTiers": list(TEXT_TIERS),
         "modes": [
             {
                 "mode": "recommended",
                 "label": "Recommended provider profile",
-                "description": "Use the selected provider's default t0-t3 routing profile.",
+                "description": "Use the selected provider's default c0-c3 routing profile.",
             },
             {
                 "mode": "openrouter-mix",

--- a/src/opensquilla/onboarding/status.py
+++ b/src/opensquilla/onboarding/status.py
@@ -136,7 +136,7 @@ def _router_detail(cfg: GatewayConfig, llm_source: str) -> str:
     profile = str(getattr(router, "tier_profile", "") or "").strip()
     if profile:
         return f"SquillaRouter profile: {profile}"
-    default_tier = str(getattr(router, "default_tier", "") or "t1").strip()
+    default_tier = str(getattr(router, "default_tier", "") or "c1").strip()
     return f"SquillaRouter default tier: {default_tier}"
 
 

--- a/src/opensquilla/router_control.py
+++ b/src/opensquilla/router_control.py
@@ -7,6 +7,11 @@ import time
 from dataclasses import dataclass, fields, is_dataclass
 from typing import Any
 
+from opensquilla.router_tiers import (
+    normalize_target_id,
+    normalize_tier_mapping,
+)
+
 # Zero means no turn-count cap; the hold expires after an idle TTL.
 DEFAULT_HOLD_TURNS = 0
 DEFAULT_HOLD_TTL_SECONDS = 600.0
@@ -25,7 +30,6 @@ class RouterControlTarget:
     provider: str | None = None
     description: str | None = None
     thinking_level: str | None = None
-    duplicate_model_resolution: bool = False
 
 
 @dataclass
@@ -40,7 +44,6 @@ class RouterControlHold:
     turns_remaining: int = DEFAULT_HOLD_TURNS
     ttl_seconds: float = DEFAULT_HOLD_TTL_SECONDS
     source: str = "router_control_tool"
-    duplicate_model_resolution: bool = False
 
     def is_expired(self, now_monotonic: float) -> tuple[bool, str | None]:
         if self.turns_remaining < 0:
@@ -64,19 +67,10 @@ def _router_tiers(router_cfg: object | None) -> dict[str, dict[str, Any]]:
     }
 
 
-def _tier_strength(tier: str) -> tuple[int, str]:
-    lowered = tier.lower()
-    if lowered.startswith("t") and lowered[1:].isdigit():
-        return int(lowered[1:]), lowered
-    if lowered == "image_model":
-        return -1, lowered
-    return 0, lowered
-
-
 def _text_tiers(router_cfg: object | None) -> dict[str, dict[str, Any]]:
     return {
         name: cfg
-        for name, cfg in _router_tiers(router_cfg).items()
+        for name, cfg in normalize_tier_mapping(_router_tiers(router_cfg)).items()
         if not bool(cfg.get("image_only", False))
     }
 
@@ -104,23 +98,6 @@ def build_router_control_targets(router_cfg: object | None) -> list[RouterContro
             )
         )
 
-    by_model: dict[str, list[RouterControlTarget]] = {}
-    for target in targets:
-        by_model.setdefault(target.model, []).append(target)
-    for model, tier_targets in by_model.items():
-        strongest = max(tier_targets, key=lambda target: _tier_strength(target.tier))
-        targets.append(
-            RouterControlTarget(
-                target_id=f"model:{model}",
-                target_type="model",
-                tier=strongest.tier,
-                model=model,
-                provider=strongest.provider,
-                description=strongest.description,
-                thinking_level=strongest.thinking_level,
-                duplicate_model_resolution=len(tier_targets) > 1,
-            )
-        )
     return targets
 
 
@@ -128,7 +105,7 @@ def resolve_router_control_target(
     router_cfg: object | None,
     target_id: str,
 ) -> RouterControlTarget:
-    normalized = str(target_id or "").strip()
+    normalized = normalize_target_id(target_id)
     if not normalized:
         raise RouterControlValidationError("router_control target_id is required")
     targets = {target.target_id: target for target in build_router_control_targets(router_cfg)}
@@ -141,24 +118,23 @@ def resolve_router_control_target(
 
 
 def render_router_control_prompt_block(router_cfg: object | None) -> str:
-    targets = build_router_control_targets(router_cfg)
+    targets = [
+        target
+        for target in build_router_control_targets(router_cfg)
+        if target.target_type == "tier"
+    ]
     if not targets:
         return ""
     rows = [
         {
             "target_id": target.target_id,
-            "tier": target.tier,
-            "model": target.model,
-            "provider": target.provider,
-            "description": target.description,
-            "thinking_level": target.thinking_level,
         }
         for target in targets
     ]
     menu = json.dumps(rows, ensure_ascii=False, separators=(",", ":"))
     return (
-        "Use `router_control` when the user semantically asks to upgrade, "
-        "downgrade, use a configured tier/model, or restore automatic routing. "
+        "Use `router_control` only when the user explicitly asks to use a "
+        "configured route or restore automatic routing. "
         "For set_hold, you must choose one target_id exactly from this menu; "
         "do not invent aliases or model ids. The menu is operational context, "
         "not a user-facing recommendation list.\n\n"
@@ -203,7 +179,6 @@ class RouterControlHoldStore:
             last_activity_at_monotonic=now,
             turns_remaining=turns_remaining,
             ttl_seconds=ttl_seconds,
-            duplicate_model_resolution=target.duplicate_model_resolution,
         )
         self._holds[session_key] = hold
         return hold
@@ -254,8 +229,6 @@ def router_control_success_payload(
         "replay_required": replay_required,
         "evidence": evidence,
     }
-    if target and target.duplicate_model_resolution:
-        payload["duplicate_model_resolution"] = True
     return json.dumps(payload, ensure_ascii=False)
 
 

--- a/src/opensquilla/router_tiers.py
+++ b/src/opensquilla/router_tiers.py
@@ -1,0 +1,91 @@
+"""Canonical router tier identifiers and legacy aliases."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+TEXT_TIERS: tuple[str, str, str, str] = ("c0", "c1", "c2", "c3")
+DEFAULT_TEXT_TIER = "c1"
+HIGHEST_TEXT_TIER = "c3"
+IMAGE_TIER = "image_model"
+
+LEGACY_TEXT_TIER_ALIASES: dict[str, str] = {
+    "t0": "c0",
+    "t1": "c1",
+    "t2": "c2",
+    "t3": "c3",
+}
+
+ROUTE_CLASS_TO_TIER: dict[str, str] = {
+    "R0": "c0",
+    "R1": "c1",
+    "R2": "c2",
+    "R3": "c3",
+}
+TIER_TO_ROUTE_CLASS: dict[str, str] = {tier: route for route, tier in ROUTE_CLASS_TO_TIER.items()}
+
+
+def normalize_text_tier(value: object) -> str | None:
+    """Return the canonical text tier id for *value*, accepting legacy t0-t3."""
+
+    if value is None:
+        return None
+    tier = str(value).strip().lower()
+    if not tier:
+        return None
+    if tier in TEXT_TIERS:
+        return tier
+    return LEGACY_TEXT_TIER_ALIASES.get(tier)
+
+
+def normalize_tier_id(value: object) -> str | None:
+    """Normalize any known tier id, preserving the image tier."""
+
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    if raw == IMAGE_TIER:
+        return IMAGE_TIER
+    return normalize_text_tier(raw)
+
+
+def normalize_target_id(value: object) -> str:
+    """Normalize router-control target ids such as tier:t3 -> tier:c3."""
+
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    if raw.startswith("tier:"):
+        tier = normalize_text_tier(raw.removeprefix("tier:"))
+        return f"tier:{tier}" if tier else raw
+    return raw
+
+
+def normalize_tier_mapping(mapping: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return a copy of a tier mapping with legacy text tier keys canonicalized."""
+
+    if not isinstance(mapping, Mapping):
+        return {}
+    normalized: dict[str, Any] = {}
+    for key, value in mapping.items():
+        tier = normalize_tier_id(key)
+        out_key = tier or str(key)
+        if out_key in normalized and str(key).strip().lower() not in TEXT_TIERS:
+            continue
+        normalized[out_key] = value
+    return normalized
+
+
+def tier_index(value: object) -> int:
+    """Return 0-3 for known text tiers; -1 for unknown values."""
+
+    tier = normalize_text_tier(value)
+    if tier is None:
+        return -1
+    try:
+        return TEXT_TIERS.index(tier)
+    except ValueError:
+        return -1

--- a/src/opensquilla/skills/bundled/meta-paper-write/SKILL.md
+++ b/src/opensquilla/skills/bundled/meta-paper-write/SKILL.md
@@ -19,10 +19,14 @@ provenance:
   origin: opensquilla-original
   license: Apache-2.0
 metadata:
+  platform:
+    requires:
+      bins: ["xelatex", "bibtex"]
   opensquilla:
-    risk: low
+    risk: high
     capabilities:
       - filesystem-write
+      - process-control
 composition:
   steps:
     - id: paper_collect

--- a/src/opensquilla/squilla_router/controller.py
+++ b/src/opensquilla/squilla_router/controller.py
@@ -7,7 +7,9 @@ are retained only for safe fallback/default handling.
 
 from __future__ import annotations
 
-TIER_ORDER: list[str] = ["t0", "t1", "t2", "t3"]
+from opensquilla.router_tiers import TEXT_TIERS
+
+TIER_ORDER: list[str] = list(TEXT_TIERS)
 
 _SYNTHETIC_PEAK = 0.85
 

--- a/src/opensquilla/squilla_router/v4_phase3.py
+++ b/src/opensquilla/squilla_router/v4_phase3.py
@@ -13,16 +13,15 @@ from typing import Any
 import structlog
 import yaml
 
+from opensquilla.router_tiers import (
+    DEFAULT_TEXT_TIER,
+    ROUTE_CLASS_TO_TIER,
+)
 from opensquilla.squilla_router.controller import TIER_ORDER, select_localized_prompt_hint
 
 log = structlog.get_logger(__name__)
 
-_ROUTE_CLASS_TO_TIER: dict[str, str] = {
-    "R0": "t0",
-    "R1": "t1",
-    "R2": "t2",
-    "R3": "t3",
-}
+_ROUTE_CLASS_TO_TIER: dict[str, str] = dict(ROUTE_CLASS_TO_TIER)
 
 
 def default_bundle_dir() -> Path:
@@ -43,7 +42,7 @@ def runtime_src_import_path(bundle_dir: Path) -> Iterator[None]:
 
 def _find_valid_tier(start_tier: str, valid_tiers: list[str]) -> str:
     if not valid_tiers:
-        return "t1"
+        return DEFAULT_TEXT_TIER
     start_idx = TIER_ORDER.index(start_tier) if start_tier in TIER_ORDER else 1
     for idx in range(start_idx, len(TIER_ORDER)):
         if TIER_ORDER[idx] in valid_tiers:
@@ -165,7 +164,7 @@ class V4Phase3Strategy:
         self,
         valid_tiers: list[str],
     ) -> tuple[str, float, str, dict]:
-        tier = _find_valid_tier("t1", valid_tiers)
+        tier = _find_valid_tier(DEFAULT_TEXT_TIER, valid_tiers)
         route_class = next(
             (key for key, value in _ROUTE_CLASS_TO_TIER.items() if value == tier),
             "R1",
@@ -243,7 +242,7 @@ class V4Phase3Strategy:
     ) -> tuple[str, float, str, dict]:
         decision = result.decision
         route_class = str(getattr(decision, "route_class", "R1"))
-        tier = _ROUTE_CLASS_TO_TIER.get(route_class, "t1")
+        tier = _ROUTE_CLASS_TO_TIER.get(route_class, DEFAULT_TEXT_TIER)
         if tier not in valid_tiers:
             tier = _find_valid_tier(tier, valid_tiers)
 

--- a/src/opensquilla/tools/builtin/router_control.py
+++ b/src/opensquilla/tools/builtin/router_control.py
@@ -17,8 +17,7 @@ from opensquilla.tools.types import current_tool_context
     name="router_control",
     description=(
         "Control the Squilla router for this session. Use only when the user asks "
-        "to switch, upgrade, downgrade, use a configured tier/model, or restore "
-        "automatic routing."
+        "to switch to a configured route or restore automatic routing."
     ),
     params={
         "action": {

--- a/src/opensquilla/tools/registry.py
+++ b/src/opensquilla/tools/registry.py
@@ -117,7 +117,9 @@ class ToolRegistry:
             from opensquilla.router_control import build_router_control_targets
 
             target_ids = [
-                target.target_id for target in build_router_control_targets(router_cfg)
+                target.target_id
+                for target in build_router_control_targets(router_cfg)
+                if target.target_type == "tier"
             ]
         except Exception:  # noqa: BLE001 - schema enrichment must not hide the tool
             return parameters

--- a/tests/functional/test_webui_browser_chat_e2e.py
+++ b/tests/functional/test_webui_browser_chat_e2e.py
@@ -379,6 +379,215 @@ def test_chat_view_loads_and_reaches_gateway_http_status_in_real_browser(tmp_pat
     }
 
 
+def test_replay_gap_history_refresh_preserves_scroll_in_real_browser(tmp_path: Path) -> None:
+    if os.environ.get("OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E") != "1":
+        pytest.skip("set OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E=1 to run chat browser e2e")
+
+    port = _free_port()
+    server_script = tmp_path / "webui_gap_scroll_server.py"
+    browser_script = tmp_path / "webui_gap_scroll_browser.js"
+    server_script.write_text(
+        textwrap.dedent(
+            f"""
+            import uvicorn
+
+            from opensquilla.gateway.app import create_gateway_app
+            from opensquilla.gateway.config import AuthConfig, GatewayConfig
+
+            config = GatewayConfig(
+                host="127.0.0.1",
+                port={port},
+                auth=AuthConfig(mode="none"),
+            )
+            app = create_gateway_app(config)
+
+            if __name__ == "__main__":
+                uvicorn.run(app, host="127.0.0.1", port={port}, log_level="warning")
+            """
+        ),
+        encoding="utf-8",
+    )
+    browser_script.write_text(
+        textwrap.dedent(
+            r"""
+            const { chromium } = require("playwright");
+
+            (async () => {
+              const browser = await chromium.launch({ headless: true });
+              const page = await browser.newPage({ viewport: { width: 1365, height: 768 } });
+              const errors = [];
+              page.on("pageerror", err => errors.push(String(err)));
+              page.on("console", msg => {
+                if (msg.type() === "error") errors.push(msg.text());
+              });
+
+              await page.goto(process.env.TARGET_URL, {
+                waitUntil: "domcontentloaded",
+                timeout: 30000,
+              });
+              await page.waitForFunction(
+                () =>
+                  typeof App !== "undefined" &&
+                  App.getRpc &&
+                  App.getRpc()?.state === "connected",
+                { timeout: 15000 }
+              );
+
+              await page.evaluate(() => {
+                const rpc = App.getRpc();
+                const originalCall = rpc.call.bind(rpc);
+                const messages = [];
+                for (let i = 1; i <= 70; i += 1) {
+                  const label = i % 2 ? "User" : "Assistant";
+                  messages.push({
+                    role: i % 2 ? "user" : "assistant",
+                    text: `${label} history row ${String(i).padStart(2, "0")} `.repeat(8),
+                    timestamp: `2026-06-03T00:${String(i % 60).padStart(2, "0")}:00.000Z`,
+                    message_id: `gap-probe-${i}`,
+                  });
+                }
+                window.__gapProbe = { subscribeCount: 0, historyCount: 0, gapInjected: false };
+                rpc.call = async (method, params) => {
+                  if (method === "chat.history") {
+                    window.__gapProbe.historyCount += 1;
+                    return {
+                      messages,
+                      has_more: false,
+                      history_scope: "complete",
+                      oldest_cursor: null,
+                      newest_cursor: null,
+                      compaction_summaries: [],
+                    };
+                  }
+                  if (method === "sessions.messages.subscribe") {
+                    window.__gapProbe.subscribeCount += 1;
+                    if (window.__gapProbe.subscribeCount <= 1) {
+                      return {
+                        subscribed: true,
+                        key: params && params.key,
+                        current_stream_seq: 12,
+                        replay_complete: true,
+                        replayed_count: 0,
+                        run_status: "idle",
+                      };
+                    }
+                    window.__gapProbe.gapInjected = true;
+                    return {
+                      subscribed: true,
+                      key: params && params.key,
+                      current_stream_seq: 18,
+                      replay_complete: false,
+                      replay_gap_reason: "stream_buffer_empty",
+                      replayed_count: 0,
+                      run_status: "idle",
+                    };
+                  }
+                  return originalCall(method, params);
+                };
+              });
+
+              await page.evaluate(() =>
+                Router.navigate(
+                  "/chat?session=" +
+                    encodeURIComponent("agent:main:webchat:gap-playwright-regression")
+                )
+              );
+              await page.waitForSelector("#chat-thread .msg", { timeout: 15000 });
+              await page.waitForFunction(
+                () => document.querySelectorAll("#chat-thread .msg").length >= 60,
+                { timeout: 15000 }
+              );
+
+              const before = await page.evaluate(() => {
+                const thread = document.querySelector("#chat-thread");
+                thread.scrollTop = 120;
+                return {
+                  scrollTop: thread.scrollTop,
+                  scrollHeight: thread.scrollHeight,
+                  clientHeight: thread.clientHeight,
+                  bottomDistance: thread.scrollHeight - thread.clientHeight - thread.scrollTop,
+                  messageCount: document.querySelectorAll("#chat-thread .msg").length,
+                };
+              });
+
+              await page.evaluate(() => {
+                const handlers = App.getRpc()._listeners.get("_state");
+                if (handlers) handlers.forEach(h => h("connected"));
+              });
+              await page.waitForFunction(
+                () => window.__gapProbe && window.__gapProbe.gapInjected === true,
+                { timeout: 15000 }
+              );
+              await page.waitForFunction(
+                () => window.__gapProbe && window.__gapProbe.historyCount >= 3,
+                { timeout: 15000 }
+              );
+
+              const after = await page.evaluate(() => {
+                const thread = document.querySelector("#chat-thread");
+                return {
+                  scrollTop: thread.scrollTop,
+                  scrollHeight: thread.scrollHeight,
+                  clientHeight: thread.clientHeight,
+                  bottomDistance: thread.scrollHeight - thread.clientHeight - thread.scrollTop,
+                  messageCount: document.querySelectorAll("#chat-thread .msg").length,
+                  toasts: Array.from(document.querySelectorAll(".toast")).map(el =>
+                    el.textContent.trim()
+                  ),
+                  probe: window.__gapProbe,
+                };
+              });
+
+              await browser.close();
+              console.log(JSON.stringify({ before, after, errors }));
+            })().catch(err => {
+              console.error(err && err.stack ? err.stack : String(err));
+              process.exit(1);
+            });
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["OPENSQUILLA_STATE_DIR"] = str(tmp_path / "state")
+    env["OPENSQUILLA_LOG_DIR"] = str(tmp_path / "logs")
+    server = subprocess.Popen(
+        [sys.executable, str(server_script)],
+        cwd=Path.cwd(),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    try:
+        _wait_for_health(port, server)
+        _install_playwright(tmp_path)
+        result = subprocess.run(
+            [_node(), str(browser_script)],
+            cwd=tmp_path,
+            env=dict(env, TARGET_URL=f"http://127.0.0.1:{port}/control/overview"),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+        assert result.returncode == 0, result.stderr or result.stdout
+        payload = json.loads(result.stdout.strip().splitlines()[-1])
+    finally:
+        _stop_process(server)
+
+    assert payload["errors"] == [], payload["errors"]
+    assert payload["before"]["messageCount"] >= 60
+    assert payload["after"]["messageCount"] == payload["before"]["messageCount"]
+    assert payload["after"]["probe"]["gapInjected"] is True
+    assert payload["after"]["bottomDistance"] > 1000, payload
+    assert payload["after"]["scrollTop"] <= payload["before"]["scrollTop"] + 80, payload
+    assert "Session stream gap detected; reloading transcript." not in payload["after"]["toasts"]
+
+
 def test_chat_topbar_one_row_layout_in_real_browser(tmp_path: Path) -> None:
     if os.environ.get("OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E") != "1":
         pytest.skip("set OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E=1 to run chat browser e2e")
@@ -903,6 +1112,205 @@ def test_chat_slash_menu_aligns_with_composer_in_real_browser(tmp_path: Path) ->
     assert layouts["mobile"]["layout"]["exportButton"]["visible"] is False
 
 
+def test_chat_escape_in_composer_aborts_streaming_turn_in_real_browser(
+    tmp_path: Path,
+) -> None:
+    if os.environ.get("OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E") != "1":
+        pytest.skip("set OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E=1 to run chat browser e2e")
+
+    port = _free_port()
+    server_script = tmp_path / "webui_escape_abort_server.py"
+    browser_script = tmp_path / "webui_escape_abort_browser.js"
+    server_script.write_text(
+        textwrap.dedent(
+            f"""
+            import uvicorn
+
+            from opensquilla.gateway.app import create_gateway_app
+            from opensquilla.gateway.config import AuthConfig, GatewayConfig
+
+            config = GatewayConfig(
+                host="127.0.0.1",
+                port={port},
+                auth=AuthConfig(mode="none"),
+            )
+            app = create_gateway_app(config)
+
+            if __name__ == "__main__":
+                uvicorn.run(app, host="127.0.0.1", port={port}, log_level="warning")
+            """
+        ),
+        encoding="utf-8",
+    )
+    browser_script.write_text(
+        textwrap.dedent(
+            r"""
+            const { chromium } = require("playwright");
+
+            async function waitRpc(page) {
+              await page.waitForFunction(
+                () =>
+                  typeof App !== "undefined" &&
+                  App.getRpc &&
+                  App.getRpc()?.state === "connected",
+                { timeout: 15000 }
+              );
+            }
+
+            (async () => {
+              const browser = await chromium.launch({ headless: true });
+              const page = await browser.newPage();
+              const errors = [];
+              page.on("pageerror", err => errors.push(String(err)));
+
+              await page.goto(process.env.TARGET_URL, {
+                waitUntil: "domcontentloaded",
+                timeout: 30000,
+              });
+              await page.waitForSelector("#chat-textarea", { timeout: 15000 });
+              await waitRpc(page);
+
+              await page.evaluate(() => {
+                const rpc = App.getRpc();
+                const originalCall = rpc.call.bind(rpc);
+                window.__escapeAbort = { sendCalls: [], abortCalls: [] };
+                rpc.call = (method, params = {}) => {
+                  if (method === "tools.search_provider") {
+                    return Promise.resolve({ provider: "none" });
+                  }
+                  if (method === "config.get") {
+                    return Promise.resolve({
+                      permissions: { default_mode: "ask" },
+                      squilla_router: { enabled: true, rollout_phase: "full", tiers: {} },
+                    });
+                  }
+                  if (method === "chat.history") {
+                    return Promise.resolve({
+                      messages: [],
+                      history_scope: "complete",
+                      has_more: false,
+                    });
+                  }
+                  if (method === "sessions.messages.subscribe") {
+                    return Promise.resolve({
+                      subscribed: true,
+                      key: params.key,
+                      current_stream_seq: 0,
+                      replay_complete: true,
+                      replayed_count: 0,
+                      run_status: "idle",
+                    });
+                  }
+                  if (method === "chat.send") {
+                    window.__escapeAbort.sendCalls.push(params);
+                    return Promise.resolve({ task_id: "escape-abort-task" });
+                  }
+                  if (method === "chat.abort") {
+                    window.__escapeAbort.abortCalls.push(params);
+                    return Promise.resolve({ aborted: true, key: params.sessionKey });
+                  }
+                  return originalCall(method, params);
+                };
+              });
+
+              await page.evaluate(() =>
+                Router.navigate("/chat?session=agent:main:webchat:escape-abort")
+              );
+              await page.waitForSelector("#chat-textarea", { timeout: 15000 });
+              await page.fill("#chat-textarea", "turn to abort from textarea");
+              await page.click("#chat-btn-send");
+              await page.waitForFunction(
+                () =>
+                  window.__escapeAbort.sendCalls.length === 1 &&
+                  OpenSquillaChatDiag.snapshot().isStreaming === true,
+                null, { timeout: 5000 }
+              );
+
+              await page.focus("#chat-textarea");
+              const before = await page.evaluate(() => ({
+                focusId: document.activeElement?.id || "",
+                isStreaming: OpenSquillaChatDiag.snapshot().isStreaming,
+                stopVisible:
+                  !document.querySelector("#chat-btn-stop")?.classList.contains("hidden"),
+              }));
+              await page.locator("#chat-textarea").press("Escape");
+              await page.waitForFunction(
+                () => window.__escapeAbort.abortCalls.length === 1,
+                null, { timeout: 5000 }
+              );
+              await page.waitForFunction(
+                () => OpenSquillaChatDiag.snapshot().isStreaming === false,
+                null, { timeout: 5000 }
+              );
+              const afterState = await page.evaluate(() => ({
+                isStreaming: OpenSquillaChatDiag.snapshot().isStreaming,
+                streamingCount: document.querySelectorAll(".msg.streaming").length,
+                thinkingCount: document.querySelectorAll(".msg.thinking").length,
+                stopVisible:
+                  !document.querySelector("#chat-btn-stop")?.classList.contains("hidden"),
+                abortCalls: window.__escapeAbort.abortCalls,
+              }));
+              const after = { ...afterState, pageErrors: errors };
+
+              await browser.close();
+              console.log(JSON.stringify({ before, after }));
+            })().catch(err => {
+              console.error(err && err.stack ? err.stack : String(err));
+              process.exit(1);
+            });
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["OPENSQUILLA_STATE_DIR"] = str(tmp_path / "state")
+    env["OPENSQUILLA_LOG_DIR"] = str(tmp_path / "logs")
+    server = subprocess.Popen(
+        [sys.executable, str(server_script)],
+        cwd=Path.cwd(),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    try:
+        _wait_for_health(port, server)
+        _install_playwright(tmp_path)
+        result = subprocess.run(
+            [_node(), str(browser_script)],
+            cwd=tmp_path,
+            env=dict(env, TARGET_URL=f"http://127.0.0.1:{port}/control/chat"),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+        assert result.returncode == 0, result.stderr or result.stdout
+        payload = json.loads(result.stdout.strip().splitlines()[-1])
+    finally:
+        _stop_process(server)
+
+    before = payload["before"]
+    after = payload["after"]
+    assert before["focusId"] == "chat-textarea", before
+    assert before["isStreaming"] is True, before
+    assert before["stopVisible"] is True, before
+    assert after["abortCalls"] == [
+        {
+            "sessionKey": "agent:main:webchat:escape-abort",
+            "source": "webui_escape",
+        }
+    ], after
+    assert after["isStreaming"] is False, after
+    assert after["streamingCount"] == 0, after
+    assert after["thinkingCount"] == 0, after
+    assert after["stopVisible"] is False, after
+    assert after["pageErrors"] == [], after
+
+
 def test_chat_tool_result_full_view_handles_large_payloads_in_real_browser(
     tmp_path: Path,
 ) -> None:
@@ -1189,7 +1597,28 @@ def test_chat_compaction_events_render_recoverable_toasts_in_real_browser(
             async function lastSeparatorText(page) {
               return await page.evaluate(() => {
                 const separators = document.querySelectorAll(".chat-context-separator");
-                return separators.length ? separators[separators.length - 1].innerText : "";
+                return separators.length
+                  ? separators[separators.length - 1].textContent
+                  : "";
+              });
+            }
+
+            async function lastSeparatorPlacement(page) {
+              return await page.evaluate(() => {
+                const thread = document.querySelector("#chat-thread");
+                const separators = document.querySelectorAll(".chat-context-separator");
+                const separator = separators[separators.length - 1];
+                if (!thread || !separator) return null;
+                const threadBox = thread.getBoundingClientRect();
+                const separatorBox = separator.getBoundingClientRect();
+                return {
+                  bottomGap: Math.round(threadBox.bottom - separatorBox.bottom),
+                  topGap: Math.round(separatorBox.top - threadBox.top),
+                  className: separator.className,
+                  scrollTop: Math.round(thread.scrollTop),
+                  scrollHeight: Math.round(thread.scrollHeight),
+                  clientHeight: Math.round(thread.clientHeight),
+                };
               });
             }
 
@@ -1237,6 +1666,7 @@ def test_chat_compaction_events_render_recoverable_toasts_in_real_browser(
               await page.waitForTimeout(600);
               const startedStatusVisible = await lastSeparatorText(page);
               const manualSeparatorStarted = startedStatusVisible;
+              const manualSeparatorStartedPlacement = await lastSeparatorPlacement(page);
               await emitCompaction(page, { status: "skipped", source: "manual" });
               await page.waitForTimeout(250);
               const skippedStatusVisible = await lastSeparatorText(page);
@@ -1248,7 +1678,7 @@ def test_chat_compaction_events_render_recoverable_toasts_in_real_browser(
                 tokens_after: 1300,
               });
               await page.waitForFunction(
-                () => document.body.innerText.includes("context compacted"),
+                () => document.body.textContent.includes("context compacted"),
                 null, { timeout: 5000 }
               );
 
@@ -1290,6 +1720,7 @@ def test_chat_compaction_events_render_recoverable_toasts_in_real_browser(
               await page.waitForTimeout(800);
               const automaticStartedStatusVisible = await lastSeparatorText(page);
               const automaticSeparatorStarted = automaticStartedStatusVisible;
+              const automaticSeparatorStartedPlacement = await lastSeparatorPlacement(page);
               await page.fill("#chat-textarea", "queued during automatic compact");
               await page.click("#chat-btn-send");
               await page.waitForTimeout(150);
@@ -1346,7 +1777,9 @@ def test_chat_compaction_events_render_recoverable_toasts_in_real_browser(
               const automaticNoopSeparatorHidden = await page
                 .locator(".chat-context-separator")
                 .count();
-              const automaticNoopBodyText = await page.locator("body").innerText();
+              const automaticNoopBodyText = await page.evaluate(
+                () => document.body.textContent
+              );
 
               await page.waitForTimeout(1600);
               await emitCompaction(page, {
@@ -1422,6 +1855,11 @@ def test_chat_compaction_events_render_recoverable_toasts_in_real_browser(
                 startedStatusVisible: startedStatusVisible.includes("context compacting"),
                 manualRailStarted:
                   manualSeparatorStarted.includes("context compacting"),
+                manualRailBottomAnchored:
+                  manualSeparatorStartedPlacement &&
+                  manualSeparatorStartedPlacement.bottomGap <= 60 &&
+                  manualSeparatorStartedPlacement.className
+                    .includes("chat-context-separator--session"),
                 skippedStatusVisible: skippedStatusVisible.includes(
                   "no compaction needed"
                 ),
@@ -1437,6 +1875,11 @@ def test_chat_compaction_events_render_recoverable_toasts_in_real_browser(
                 ),
                 automaticRailStarted:
                   automaticSeparatorStarted.includes("context compacting"),
+                automaticRailBottomAnchored:
+                  automaticSeparatorStartedPlacement &&
+                  automaticSeparatorStartedPlacement.bottomGap <= 60 &&
+                  automaticSeparatorStartedPlacement.className
+                    .includes("chat-context-separator--session"),
                 automaticObservedStatusVisible: automaticObservedStatusVisible.includes(
                   "context compacting"
                 ),
@@ -1522,12 +1965,14 @@ def test_chat_compaction_events_render_recoverable_toasts_in_real_browser(
         "hasReplayedFailureToast": False,
         "startedStatusVisible": True,
         "manualRailStarted": True,
+        "manualRailBottomAnchored": True,
         "skippedStatusVisible": True,
         "failedStatusVisible": True,
         "queuedBeforeSkipped": 0,
         "skippedDrainedQueuedSend": True,
         "automaticStartedStatusVisible": True,
         "automaticRailStarted": True,
+        "automaticRailBottomAnchored": True,
         "automaticObservedStatusVisible": True,
         "automaticRailObserved": True,
         "automaticRailCompleted": True,
@@ -1632,6 +2077,8 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                   winners: strips.map(
                     el => el.querySelector(".router-fx-cell.win .nm")?.textContent || ""
                   ),
+                  cellCount: cells.length,
+                  cellLabels: cells.map(el => el.textContent || ""),
                   hasLongLabel: cells.some(el => el.textContent === "gemini-3.1-flash-lite"),
                   overflows,
                   gridWithinViewport: gridRect
@@ -1662,6 +2109,20 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                   sessionKey: "agent:main:webchat:router-fx-panel",
                   historyMessages: [],
                   chatCalls: [],
+                  routerConfig: {
+                    enabled: true,
+                    rollout_phase: "full",
+                    tiers: {
+                      c1: { model: "openrouter/deepseek-v4-flash" },
+                      c2: { model: "openrouter/gemini-3.1-flash-lite" },
+                      c3: { model: "openrouter/qwen3.6-max" },
+                      image_model: {
+                        model: "openrouter/kimi-k2.6",
+                        supports_image: true,
+                        image_only: true,
+                      },
+                    },
+                  },
                 };
                 const rpc = App.getRpc();
                 const originalCall = rpc.call.bind(rpc);
@@ -1672,15 +2133,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                   if (method === "config.get") {
                     return Promise.resolve({
                       permissions: { default_mode: "ask" },
-                      squilla_router: {
-                        enabled: true,
-                        rollout_phase: "full",
-                        tiers: {
-                          t1: { model: "openrouter/deepseek-v4-flash" },
-                          t2: { model: "openrouter/gemini-3.1-flash-lite" },
-                          t3: { model: "openrouter/qwen3.6-max" },
-                        },
-                      },
+                      squilla_router: window.__routerFxTest.routerConfig,
                     });
                   }
                   if (method === "chat.history") {
@@ -1738,7 +2191,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
               await emit(page, "session.event.router_decision", {
                 session_key: sessionKey,
                 stream_seq: 101,
-                tier: "t1",
+                tier: "c1",
                 model: "openrouter/deepseek-v4-flash",
                 routing_source: "squilla_router",
                 routing_applied: true,
@@ -1765,7 +2218,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                     usage: {
                       model: "openrouter/deepseek-v4-flash",
                       routed_model: "openrouter/deepseek-v4-flash",
-                      routed_tier: "t1",
+                      routed_tier: "c1",
                       routing_source: "squilla_router",
                       routing_applied: true,
                       input_tokens: 11,
@@ -1785,7 +2238,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
               await emit(page, "session.event.router_decision", {
                 session_key: sessionKey,
                 stream_seq: 102,
-                tier: "t1",
+                tier: "c1",
                 model: "openrouter/deepseek-v4-flash",
                 routing_source: "squilla_router",
                 routing_applied: true,
@@ -1815,7 +2268,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                     usage: {
                       model: "openrouter/deepseek-v4-flash",
                       routed_model: "openrouter/deepseek-v4-flash",
-                      routed_tier: "t1",
+                      routed_tier: "c1",
                       routing_source: "squilla_router",
                       routing_applied: true,
                       input_tokens: 11,
@@ -1850,7 +2303,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                     usage: {
                       model: "openrouter/deepseek-v4-flash",
                       routed_model: "openrouter/deepseek-v4-flash",
-                      routed_tier: "t1",
+                      routed_tier: "c1",
                       routing_source: "squilla_router",
                       routing_applied: true,
                       input_tokens: 11,
@@ -1872,7 +2325,7 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                     usage: {
                       model: "openrouter/gemini-3.1-flash-lite",
                       routed_model: "openrouter/gemini-3.1-flash-lite",
-                      routed_tier: "t2",
+                      routed_tier: "c2",
                       routing_source: "squilla_router",
                       routing_applied: true,
                       input_tokens: 13,
@@ -1881,13 +2334,13 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                   },
                 ];
                 window.__routerFxTest.deferHistory = true;
-                const stateHandlers = App.getRpc()._listeners.get("_state");
-                if (stateHandlers) stateHandlers.forEach(h => h("connected"));
+                Router.navigate("/overview");
+                Router.navigate("/chat?session=agent:main:webchat:router-fx-panel");
               });
               await emit(page, "session.event.router_decision", {
                 session_key: sessionKey,
                 stream_seq: 103,
-                tier: "t2",
+                tier: "c2",
                 model: "openrouter/gemini-3.1-flash-lite",
                 routing_source: "squilla_router",
                 routing_applied: true,
@@ -1908,6 +2361,94 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
               await page.waitForTimeout(300);
               const afterHistoryHydrationReplay = await snapshot(page);
 
+              await page.evaluate(() => {
+                window.__routerFxTest.historyMessages = [
+                  {
+                    role: "user",
+                    text: "describe image",
+                    message_id: "router-fx-u-image",
+                    timestamp: "2026-05-30T00:00:04Z",
+                    attachments: [{
+                      mime: "image/png",
+                      type: "image/png",
+                      name: "preview.png",
+                      data: "data:image/png;base64,iVBORw0KGgo=",
+                    }],
+                  },
+                  {
+                    role: "assistant",
+                    text: "image done",
+                    message_id: "router-fx-a-image",
+                    timestamp: "2026-05-30T00:00:05Z",
+                    model: "openrouter/kimi-k2.6",
+                    usage: {
+                      model: "openrouter/kimi-k2.6",
+                      routed_model: "openrouter/kimi-k2.6",
+                      routed_tier: "image_model",
+                      routing_source: "image_route",
+                      routing_applied: true,
+                      input_tokens: 21,
+                      output_tokens: 5,
+                    },
+                  },
+                ];
+                Router.navigate("/overview");
+                Router.navigate("/chat?session=agent:main:webchat:router-fx-panel");
+              });
+              await page.waitForFunction(
+                () =>
+                  document.querySelector(".msg.user .msg-attachments") &&
+                  document.querySelectorAll(".router-fx").length === 0,
+                { timeout: 15000 }
+              );
+              const singleImageCandidate = await snapshot(page);
+
+              await page.evaluate(() => {
+                window.__routerFxTest.routerConfig = {
+                  enabled: true,
+                  rollout_phase: "full",
+                  tiers: {
+                    t1: { model: "openrouter/shared-model" },
+                    t2: { model: "other-provider/shared-model" },
+                  },
+                };
+                window.__routerFxTest.historyMessages = [
+                  {
+                    role: "user",
+                    text: "same model different provider",
+                    message_id: "router-fx-u-same-display",
+                    timestamp: "2026-05-30T00:00:06Z",
+                  },
+                  {
+                    role: "assistant",
+                    text: "same done",
+                    message_id: "router-fx-a-same-display",
+                    timestamp: "2026-05-30T00:00:07Z",
+                    model: "openrouter/shared-model",
+                    usage: {
+                      model: "openrouter/shared-model",
+                      routed_model: "openrouter/shared-model",
+                      routed_tier: "t1",
+                      routing_source: "squilla_router",
+                      routing_applied: true,
+                      input_tokens: 8,
+                      output_tokens: 2,
+                    },
+                  },
+                ];
+                Router.navigate("/overview");
+                Router.navigate("/chat?session=agent:main:webchat:router-fx-panel");
+              });
+              await page.waitForFunction(
+                () =>
+                  document.querySelector(".msg.user")?.textContent.includes(
+                    "same model different provider"
+                  ) &&
+                  document.querySelectorAll(".router-fx").length === 0,
+                { timeout: 15000 }
+              );
+              const sameDisplaySingleCandidate = await snapshot(page);
+
               const result = {
                 liveSettled,
                 reopened,
@@ -1915,6 +2456,8 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
                 narrow,
                 duringHistoryHydrationReplay,
                 afterHistoryHydrationReplay,
+                singleImageCandidate,
+                sameDisplaySingleCandidate,
                 pageErrors: errors,
               };
               await browser.close();
@@ -1966,6 +2509,13 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
     assert payload["liveSettled"]["selectorVisible"] == 0
     assert payload["liveSettled"]["winner"] == "deepseek-v4-flash"
     assert "Router selected deepseek-v4-flash" in payload["liveSettled"]["aria"]
+    assert payload["liveSettled"]["cellCount"] == 3
+    assert set(payload["liveSettled"]["cellLabels"]) == {
+        "deepseek-v4-flash",
+        "gemini-3.1-flash-lite",
+        "qwen3.6-max",
+    }
+    assert "kimi-k2.6" not in payload["liveSettled"]["cellLabels"]
 
     for key in ("reopened", "afterReplay", "narrow"):
         snap = payload[key]
@@ -1980,12 +2530,15 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
         assert snap["animations"] == [], snap
         assert snap["winner"] == "deepseek-v4-flash", snap
         assert snap["hasLongLabel"] is True, snap
+        assert snap["cellCount"] == 3, snap
+        assert "kimi-k2.6" not in snap["cellLabels"], snap
         assert snap["overflows"] == [], snap
         assert snap["gridWithinViewport"] is True, snap
 
     during = payload["duringHistoryHydrationReplay"]
-    assert during["count"] == 1, during
-    assert during["winners"] == ["deepseek-v4-flash"], during
+    assert during["count"] in (0, 1), during
+    if during["count"] == 1:
+        assert during["winners"] == ["deepseek-v4-flash"], during
     assert during["liveCount"] == 0, during
     assert during["scanningCount"] == 0, during
     assert during["selectorVisible"] == 0, during
@@ -2005,6 +2558,18 @@ def test_router_fx_live_then_reopen_stays_settled_in_real_browser(tmp_path: Path
         "deepseek-v4-flash",
         "gemini-3.1-flash-lite",
     }, after_hydration
+
+    image_single = payload["singleImageCandidate"]
+    assert image_single["count"] == 0, image_single
+    assert image_single["cellCount"] == 0, image_single
+    assert image_single["liveCount"] == 0, image_single
+    assert image_single["scanningCount"] == 0, image_single
+
+    same_display_single = payload["sameDisplaySingleCandidate"]
+    assert same_display_single["count"] == 0, same_display_single
+    assert same_display_single["cellCount"] == 0, same_display_single
+    assert same_display_single["liveCount"] == 0, same_display_single
+    assert same_display_single["scanningCount"] == 0, same_display_single
 
 
 def test_webchat_large_paste_auto_attaches_text_in_real_browser(tmp_path: Path) -> None:
@@ -2841,7 +3406,7 @@ def test_completed_reconnect_without_replay_refreshes_history_in_real_browser(
                         enabled: true,
                         rollout_phase: "full",
                         tiers: {
-                          t1: { model: "openrouter/deepseek-v4-flash" },
+                          c1: { model: "openrouter/deepseek-v4-flash" },
                         },
                       },
                     });
@@ -2876,7 +3441,7 @@ def test_completed_reconnect_without_replay_refreshes_history_in_real_browser(
                             usage: {
                               model: "openrouter/deepseek-v4-flash",
                               routed_model: "openrouter/deepseek-v4-flash",
-                              routed_tier: "t1",
+                              routed_tier: "c1",
                               routing_source: "squilla_router",
                               routing_applied: true,
                               input_tokens: 0,
@@ -3074,7 +3639,7 @@ def test_replayed_savings_done_restores_reply_without_replaying_popup_in_real_br
                         enabled: true,
                         rollout_phase: "full",
                         tiers: {
-                          t1: { model: "openrouter/deepseek-v4-flash" },
+                          c1: { model: "openrouter/deepseek-v4-flash" },
                         },
                       },
                     });
@@ -3127,7 +3692,7 @@ def test_replayed_savings_done_restores_reply_without_replaying_popup_in_real_br
                     output_tokens: 661,
                     model: "openrouter/deepseek-v4-flash",
                     routed_model: "openrouter/deepseek-v4-flash",
-                    routed_tier: "t1",
+                    routed_tier: "c1",
                     routing_source: "squilla_router",
                     routing_applied: true,
                     total_savings_pct: 97,

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import os
 import re
+import shutil
+import subprocess
+from collections.abc import Callable
 from pathlib import Path
 
 import yaml
 
 WORKFLOW_DIR = Path(".github/workflows")
+CLASSIFIER = Path(".github/scripts/classify-ci-changes.sh")
 TEST_PATH_RE = re.compile(r"tests/[A-Za-z0-9_./-]+\.py")
 
 
@@ -28,6 +33,72 @@ def _workflow_texts() -> list[str]:
     return [path.read_text(encoding="utf-8") for path in WORKFLOW_DIR.glob("*.yml")]
 
 
+def _is_windows_wsl_bash(path: str) -> bool:
+    normalized = path.replace("\\", "/").lower()
+    return normalized.endswith("/windows/system32/bash.exe")
+
+
+def _bash_executable(
+    *,
+    os_name: str = os.name,
+    path_lookup: Callable[[str], str | None] = shutil.which,
+    exists: Callable[[Path], bool] = Path.is_file,
+    program_files: str | None = None,
+) -> str:
+    found = path_lookup("bash")
+    if os_name != "nt":
+        return found or "bash"
+
+    candidates: list[Path] = []
+    if found and not _is_windows_wsl_bash(found):
+        candidates.append(Path(found))
+
+    git_root = Path(program_files or os.environ.get("ProgramFiles", r"C:\Program Files")) / "Git"
+    candidates.extend(
+        [
+            git_root / "bin" / "bash.exe",
+            git_root / "usr" / "bin" / "bash.exe",
+        ]
+    )
+
+    for candidate in candidates:
+        if exists(candidate):
+            return str(candidate)
+
+    raise AssertionError("Git Bash is required to run the CI change classifier on Windows")
+
+
+def _classify_changed_files(
+    tmp_path: Path,
+    paths: list[str],
+    *,
+    line_ending: str = "\n",
+) -> dict[str, str]:
+    changed_file = tmp_path / "changed-files.txt"
+    output_file = tmp_path / "github-output.txt"
+    changed_file.write_text(
+        line_ending.join(paths) + line_ending,
+        encoding="utf-8",
+        newline="",
+    )
+
+    env = os.environ.copy()
+    env["GITHUB_OUTPUT"] = output_file.as_posix()
+    subprocess.run(
+        [_bash_executable(), CLASSIFIER.as_posix(), changed_file.as_posix()],
+        check=True,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    outputs: dict[str, str] = {}
+    for line in output_file.read_text(encoding="utf-8").splitlines():
+        key, value = line.split("=", 1)
+        outputs[key] = value
+    return outputs
+
+
 def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     ci_path = WORKFLOW_DIR / "ci.yml"
     if not ci_path.exists():
@@ -44,6 +115,125 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert 'OPENSQUILLA_LOG_DIR=%s/opensquilla-logs\\n' in text
     assert "OPENSQUILLA_TURN_CALL_LOG: \"0\"" in text
     assert "actionlint@v1.7.12" in text
+    assert "Classify changed files" in text
+    assert "Ubuntu quality gate" in text
+    assert "Windows compatibility tests" in text
+    assert "Release packaging contracts" in text
+    assert "CI result" in text
+    assert 'push)\n              printf \'.ci/run-all\\n\' > "${changed_files}"' in text
+    assert "runtime_changed" in text
+    assert "test_changed" in text
+    assert "ci_changed" in text
+    assert "dependency_changed" in text
+    assert "release_changed" in text
+    assert "code_changed" not in text
+    assert "workflow_changed" not in text
+
+
+def test_ci_change_classifier_allows_root_and_docs_markdown_only(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [
+            "README.md",
+            "CHANGELOG.md",
+            "docs/features/skills.md",
+            ".github/pull_request_template.md",
+        ],
+    )
+
+    assert outputs == {
+        "docs_only": "true",
+        "runtime_changed": "false",
+        "test_changed": "false",
+        "ci_changed": "false",
+        "dependency_changed": "false",
+        "release_changed": "false",
+    }
+
+
+def test_classifier_helper_prefers_git_bash_over_windows_wsl_bash(tmp_path: Path) -> None:
+    git_bash = tmp_path / "Git" / "bin" / "bash.exe"
+
+    result = _bash_executable(
+        os_name="nt",
+        path_lookup=lambda _name: r"C:\Windows\System32\bash.exe",
+        exists=lambda path: path == git_bash,
+        program_files=str(tmp_path),
+    )
+
+    assert result == str(git_bash)
+
+
+def test_ci_change_classifier_accepts_crlf_changed_files(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        ["README.md", "docs/features/skills.md"],
+        line_ending="\r\n",
+    )
+
+    assert outputs["docs_only"] == "true"
+    assert outputs["runtime_changed"] == "false"
+
+
+def test_ci_change_classifier_treats_runtime_markdown_as_runtime(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        ["src/opensquilla/identity/templates/bootstrap/AGENTS.md"],
+    )
+
+    assert outputs["docs_only"] == "false"
+    assert outputs["runtime_changed"] == "true"
+    assert outputs["test_changed"] == "false"
+    assert outputs["ci_changed"] == "false"
+    assert outputs["dependency_changed"] == "false"
+    assert outputs["release_changed"] == "false"
+
+
+def test_ci_change_classifier_tracks_test_changes_separately(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        ["tests/test_ci/test_workflows.py"],
+    )
+
+    assert outputs["docs_only"] == "false"
+    assert outputs["runtime_changed"] == "false"
+    assert outputs["test_changed"] == "true"
+    assert outputs["ci_changed"] == "false"
+    assert outputs["dependency_changed"] == "false"
+    assert outputs["release_changed"] == "false"
+
+
+def test_ci_change_classifier_tracks_ci_dependency_and_release_changes(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [".github/workflows/ci.yml", ".github/scripts/classify-ci-changes.sh", "uv.lock"],
+    )
+
+    assert outputs["docs_only"] == "false"
+    assert outputs["runtime_changed"] == "true"
+    assert outputs["test_changed"] == "false"
+    assert outputs["ci_changed"] == "true"
+    assert outputs["dependency_changed"] == "true"
+    assert outputs["release_changed"] == "true"
+
+
+def test_ci_change_classifier_tracks_release_surface_changes(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [
+            ".github/workflows/wheelhouse-release.yml",
+            "scripts/build_wheelhouse_zip.py",
+            "README.release.md",
+            "tests/test_scripts/test_build_wheelhouse_zip.py",
+        ],
+    )
+
+    assert outputs["docs_only"] == "false"
+    assert outputs["runtime_changed"] == "true"
+    assert outputs["test_changed"] == "true"
+    assert outputs["ci_changed"] == "true"
+    assert outputs["dependency_changed"] == "false"
+    assert outputs["release_changed"] == "true"
 
 
 def test_manual_workflows_reference_existing_test_files() -> None:

--- a/tests/test_cli/test_agent_cmd.py
+++ b/tests/test_cli/test_agent_cmd.py
@@ -277,7 +277,7 @@ def test_run_agent_command_json_includes_routing(
             errors=[],
         )
         result.routing = {  # type: ignore[attr-defined]
-            "routed_tier": "t2",
+            "routed_tier": "c2",
             "routing_source": "v4_phase3",
             "routing_confidence": 0.91,
             "baseline_model": "openrouter/heavy",
@@ -291,7 +291,7 @@ def test_run_agent_command_json_includes_routing(
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["routing"] == {
-        "routed_tier": "t2",
+        "routed_tier": "c2",
         "routing_source": "v4_phase3",
         "routing_confidence": 0.91,
         "baseline_model": "openrouter/heavy",
@@ -310,7 +310,7 @@ async def test_run_agent_once_collects_done_routing(
         async def run(self, message: str, session_key: str, **kwargs: Any):
             yield DoneEvent(
                 text="ok",
-                routed_tier="t2",
+                routed_tier="c2",
                 routing_source="v4_phase3",
                 routing_confidence=0.91,
                 baseline_model="openrouter/heavy",
@@ -326,7 +326,7 @@ async def test_run_agent_once_collects_done_routing(
     result = await run_agent_once(message="hello", config=GatewayConfig())
 
     assert result.routing == {  # type: ignore[attr-defined]
-        "routed_tier": "t2",
+        "routed_tier": "c2",
         "routing_source": "v4_phase3",
         "routing_confidence": 0.91,
         "baseline_model": "openrouter/heavy",

--- a/tests/test_cli/test_onboard_cmd.py
+++ b/tests/test_cli/test_onboard_cmd.py
@@ -830,7 +830,7 @@ def test_onboard_catalog_accepts_short_capability_section_aliases(
     ("section", "expected"),
     [
         ("providers", ["openrouter", "OPENROUTER_API_KEY", "deepseek/deepseek-v4-pro"]),
-        ("router", ["recommended", "openrouter-mix", "t0", "t3"]),
+        ("router", ["recommended", "openrouter-mix", "c0", "c3"]),
         ("search", ["duckduckgo", "brave", "BRAVE_SEARCH_API_KEY"]),
         ("channels", ["discord", "Bot token", "opensquilla channels describe discord --json"]),
         ("image-generation", ["openrouter", "openrouter/google/gemini", "OPENROUTER_API_KEY"]),
@@ -925,7 +925,7 @@ def test_onboard_catalog_router_focus_offers_a_real_recipe(tmp_path, monkeypatch
     result = runner.invoke(app, ["onboard", "catalog", "router", "--config", str(target)])
 
     assert result.exit_code == 0, result.stdout
-    assert "Try: opensquilla onboard configure router --router recommended --default-tier t1" in (
+    assert "Try: opensquilla onboard configure router --router recommended --default-tier c1" in (
         result.stdout
     )
     assert "Configure with:" not in result.stdout
@@ -1544,7 +1544,7 @@ def test_onboard_if_needed_non_tty_hint_targets_blocking_memory_section(
         (
             "router",
             "Headless router:",
-            "opensquilla onboard configure router --router recommended --default-tier t1",
+            "opensquilla onboard configure router --router recommended --default-tier c1",
         ),
         (
             "channels",
@@ -1816,14 +1816,14 @@ def test_configure_router_noninteractive_can_set_default_tier(tmp_path, monkeypa
 
     result = runner.invoke(
         app,
-        ["configure", "router", "--router", "recommended", "--default-tier", "t2"],
+        ["configure", "router", "--router", "recommended", "--default-tier", "c2"],
     )
 
     assert result.exit_code == 0, result.stdout
     data = tomllib.loads(target.read_text())
     assert data["squilla_router"]["enabled"] is True
     assert data["squilla_router"]["tier_profile"] == "deepseek"
-    assert data["squilla_router"]["default_tier"] == "t2"
+    assert data["squilla_router"]["default_tier"] == "c2"
 
 
 def test_configure_router_rejects_invalid_default_tier_without_writing(

--- a/tests/test_engine/test_router_control.py
+++ b/tests/test_engine/test_router_control.py
@@ -28,7 +28,7 @@ def _router_cfg(tiers: dict) -> SquillaRouterConfig:
         require_router_runtime=False,
         auto_thinking=False,
         tiers=tiers,
-        default_tier="t1" if "t1" in tiers else next(iter(tiers)),
+        default_tier="c1" if "c1" in tiers else next(iter(tiers)),
     )
 
 
@@ -41,26 +41,21 @@ def test_router_control_targets_generalize_to_every_profile() -> None:
         for tier_name, tier_cfg in tiers.items():
             if tier_cfg.get("image_only"):
                 assert f"tier:{tier_name}" not in target_ids
-                assert f"model:{tier_cfg['model']}" not in target_ids
                 continue
             assert f"tier:{tier_name}" in target_ids
-            assert f"model:{tier_cfg['model']}" in target_ids
 
 
-def test_duplicate_exact_model_target_resolves_to_strongest_text_tier() -> None:
+def test_model_targets_are_rejected_by_local_validation() -> None:
     cfg = _router_cfg(
         {
-            "t0": {"provider": "openrouter", "model": "same/model", "supports_image": False},
-            "t1": {"provider": "openrouter", "model": "other/model", "supports_image": False},
-            "t3": {"provider": "openrouter", "model": "same/model", "supports_image": False},
+            "c0": {"provider": "openrouter", "model": "same/model", "supports_image": False},
+            "c1": {"provider": "openrouter", "model": "other/model", "supports_image": False},
+            "c3": {"provider": "openrouter", "model": "same/model", "supports_image": False},
         }
     )
 
-    target = resolve_router_control_target(cfg, "model:same/model")
-
-    assert target.tier == "t3"
-    assert target.model == "same/model"
-    assert target.duplicate_model_resolution is True
+    with pytest.raises(RouterControlValidationError):
+        resolve_router_control_target(cfg, "model:same/model")
 
 
 def test_natural_language_aliases_are_rejected_by_local_validation() -> None:
@@ -70,14 +65,23 @@ def test_natural_language_aliases_are_rejected_by_local_validation() -> None:
         resolve_router_control_target(cfg, "Claude Opus 4.7")
 
 
+def test_legacy_tier_target_aliases_resolve_to_canonical_routes() -> None:
+    cfg = _router_cfg(_router_tier_profile_defaults("openrouter"))
+
+    target = resolve_router_control_target(cfg, "tier:t3")
+
+    assert target.target_id == "tier:c3"
+    assert target.tier == "c3"
+
+
 def test_hold_store_expires_by_explicit_turn_count_and_sliding_idle_time() -> None:
     cfg = _router_cfg(_router_tier_profile_defaults("openrouter"))
-    target = resolve_router_control_target(cfg, "tier:t3")
+    target = resolve_router_control_target(cfg, "tier:c3")
     store = RouterControlHoldStore()
     store.set_hold(
         "agent:main:test",
         target,
-        evidence="use t3",
+        evidence="use c3",
         now_monotonic=100.0,
         turns_remaining=1,
         ttl_seconds=10.0,
@@ -85,13 +89,13 @@ def test_hold_store_expires_by_explicit_turn_count_and_sliding_idle_time() -> No
 
     first = store.get_valid("agent:main:test", now_monotonic=101.0, decrement=True)
     assert first is not None
-    assert first.tier == "t3"
+    assert first.tier == "c3"
     assert store.get_valid("agent:main:test", now_monotonic=102.0) is None
 
     store.set_hold(
         "agent:main:test",
         target,
-        evidence="use t3 again",
+        evidence="use c3 again",
         now_monotonic=100.0,
         ttl_seconds=10.0,
     )
@@ -102,12 +106,12 @@ def test_hold_store_expires_by_explicit_turn_count_and_sliding_idle_time() -> No
 
 def test_hold_store_deepcopy_preserves_session_identity_for_ttl_refresh() -> None:
     cfg = _router_cfg(_router_tier_profile_defaults("openrouter"))
-    target = resolve_router_control_target(cfg, "tier:t3")
+    target = resolve_router_control_target(cfg, "tier:c3")
     store = RouterControlHoldStore()
     store.set_hold(
         "agent:main:test",
         target,
-        evidence="use t3",
+        evidence="use c3",
         now_monotonic=100.0,
         ttl_seconds=10.0,
     )
@@ -125,12 +129,12 @@ async def test_squilla_router_refreshes_hold_idle_ttl_through_copied_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cfg = _router_cfg(_router_tier_profile_defaults("openrouter"))
-    target = resolve_router_control_target(cfg, "tier:t3")
+    target = resolve_router_control_target(cfg, "tier:c3")
     store = RouterControlHoldStore()
     store.set_hold(
         "agent:main:test-refresh",
         target,
-        evidence="use t3",
+        evidence="use c3",
         now_monotonic=100.0,
         ttl_seconds=10.0,
     )
@@ -161,9 +165,9 @@ async def test_squilla_router_refreshes_hold_idle_ttl_through_copied_metadata(
 @pytest.mark.asyncio
 async def test_squilla_router_applies_hold_before_normal_classification(monkeypatch) -> None:
     cfg = _router_cfg(_router_tier_profile_defaults("openrouter"))
-    target = resolve_router_control_target(cfg, "tier:t3")
+    target = resolve_router_control_target(cfg, "tier:c3")
     store = RouterControlHoldStore()
-    store.set_hold("agent:main:test", target, evidence="use t3")
+    store.set_hold("agent:main:test", target, evidence="use c3")
 
     def fail_strategy(_cfg: object) -> object:
         raise AssertionError("router classification should not run while hold is valid")
@@ -185,15 +189,15 @@ async def test_squilla_router_applies_hold_before_normal_classification(monkeypa
     assert out.model == "anthropic/claude-opus-4.7"
     assert out.metadata["routing_source"] == "router_control_hold"
     assert out.metadata["router_control_hold_applied"] is True
-    assert out.metadata["router_control_target_tier"] == "t3"
+    assert out.metadata["router_control_target_tier"] == "c3"
 
 
 @pytest.mark.asyncio
 async def test_image_attachments_bypass_text_hold(monkeypatch) -> None:
     cfg = _router_cfg(_router_tier_profile_defaults("openrouter"))
-    target = resolve_router_control_target(cfg, "tier:t3")
+    target = resolve_router_control_target(cfg, "tier:c3")
     store = RouterControlHoldStore()
-    store.set_hold("agent:main:test-image", target, evidence="use t3")
+    store.set_hold("agent:main:test-image", target, evidence="use c3")
 
     def fail_strategy(_cfg: object) -> object:
         raise AssertionError("image route should not classify")
@@ -224,6 +228,8 @@ def test_prompt_block_contains_canonical_targets_not_aliases() -> None:
     block = render_router_control_prompt_block(cfg)
 
     assert "router_control" in block
-    assert "tier:t3" in block
-    assert "model:anthropic/claude-opus-4.7" in block
+    assert "tier:c3" in block
+    assert "tier:t3" not in block
+    assert "model:anthropic/claude-opus-4.7" not in block
+    assert "description" not in block
     assert "must choose one target_id exactly" in block

--- a/tests/test_engine/test_router_decision_event.py
+++ b/tests/test_engine/test_router_decision_event.py
@@ -41,7 +41,7 @@ def test_returns_none_when_routed_tier_empty_string() -> None:
 
 def test_full_router_metadata_populates_all_event_fields() -> None:
     metadata = {
-        "routed_tier": "t2",
+        "routed_tier": "c2",
         "routed_model": "claude-sonnet-4.6",
         "baseline_model": "claude-opus-4.7",
         "routing_source": "router",
@@ -56,7 +56,7 @@ def test_full_router_metadata_populates_all_event_fields() -> None:
     event = build_router_decision_event(_ctx(metadata))
     assert isinstance(event, RouterDecisionEvent)
     assert event.kind == "router_decision"
-    assert event.tier == "t2"
+    assert event.tier == "c2"
     assert event.tier_index == 2
     assert event.model == "claude-sonnet-4.6"
     assert event.baseline_model == "claude-opus-4.7"
@@ -73,7 +73,7 @@ def test_legacy_router_probability_and_savings_keys_still_work() -> None:
     event = build_router_decision_event(
         _ctx(
             {
-                "routed_tier": "t2",
+                "routed_tier": "c2",
                 "routing_extra": {
                     "probs": [0.12, 0.71, 0.14, 0.03],
                     "tier_savings": {"pct": 64.0},
@@ -88,7 +88,7 @@ def test_legacy_router_probability_and_savings_keys_still_work() -> None:
 
 def test_falls_back_to_turn_model_when_routed_model_absent() -> None:
     event = build_router_decision_event(
-        _ctx({"routed_tier": "t1"}, model="deepseek-v4-flash")
+        _ctx({"routed_tier": "c1"}, model="deepseek-v4-flash")
     )
     assert event is not None
     assert event.model == "deepseek-v4-flash"
@@ -99,7 +99,7 @@ def test_falls_back_to_turn_model_when_routed_model_absent() -> None:
 
 def test_fallback_source_sets_fallback_flag() -> None:
     event = build_router_decision_event(
-        _ctx({"routed_tier": "t2", "routed_model": "x", "routing_source": "fallback"})
+        _ctx({"routed_tier": "c2", "routed_model": "x", "routing_source": "fallback"})
     )
     assert event is not None
     assert event.fallback is True
@@ -110,7 +110,7 @@ def test_malformed_probs_do_not_crash() -> None:
     event = build_router_decision_event(
         _ctx(
             {
-                "routed_tier": "t3",
+                "routed_tier": "c3",
                 "routed_model": "claude-opus-4.7",
                 "routing_extra": {"probs": ["bad", None, 0.5, "x"]},
             }
@@ -129,18 +129,18 @@ def test_unknown_tier_string_results_in_negative_tier_index() -> None:
     assert event.tier_index == -1
 
 
-def test_tier_index_maps_naturally_so_t0_and_t1_dont_collide() -> None:
-    # Regression: an earlier max(0, int(...) - 1) collapsed both t0
-    # and t1 onto index 0. The natural mapping puts t0 at 0, t1 at 1,
+def test_tier_index_maps_naturally_so_c0_and_c1_dont_collide() -> None:
+    # Regression: an earlier max(0, int(...) - 1) collapsed both c0
+    # and c1 onto index 0. The natural mapping puts c0 at 0, c1 at 1,
     # and so on.
     t0_event = build_router_decision_event(
-        _ctx({"routed_tier": "t0", "routed_model": "deepseek-v4-flash"})
+        _ctx({"routed_tier": "c0", "routed_model": "deepseek-v4-flash"})
     )
     t1_event = build_router_decision_event(
-        _ctx({"routed_tier": "t1", "routed_model": "claude-sonnet-4.6"})
+        _ctx({"routed_tier": "c1", "routed_model": "claude-sonnet-4.6"})
     )
     t3_event = build_router_decision_event(
-        _ctx({"routed_tier": "t3", "routed_model": "claude-opus-4.7"})
+        _ctx({"routed_tier": "c3", "routed_model": "claude-opus-4.7"})
     )
     assert t0_event is not None and t0_event.tier_index == 0
     assert t1_event is not None and t1_event.tier_index == 1
@@ -153,7 +153,7 @@ def test_routing_applied_and_rollout_phase_round_trip() -> None:
     observe_event = build_router_decision_event(
         _ctx(
             {
-                "routed_tier": "t2",
+                "routed_tier": "c2",
                 "routed_model": "claude-sonnet-4.6",
                 "routing_applied": False,
                 "rollout_phase": "observe",
@@ -168,7 +168,7 @@ def test_routing_applied_and_rollout_phase_round_trip() -> None:
     full_event = build_router_decision_event(
         _ctx(
             {
-                "routed_tier": "t2",
+                "routed_tier": "c2",
                 "routed_model": "claude-sonnet-4.6",
                 "routing_applied": True,
                 "rollout_phase": "full",
@@ -185,7 +185,7 @@ def test_legacy_metadata_without_routing_applied_defaults_to_applied() -> None:
     # metadata fields. The event helper must fall back to applied=True
     # + rollout_phase="full" so historic strips keep rendering normally.
     event = build_router_decision_event(
-        _ctx({"routed_tier": "t2", "routed_model": "claude-sonnet-4.6"})
+        _ctx({"routed_tier": "c2", "routed_model": "claude-sonnet-4.6"})
     )
     assert event is not None
     assert event.routing_applied is True
@@ -245,7 +245,7 @@ async def test_turn_runner_emits_router_decision_event_from_pipeline_metadata(
                 system_prompt=base_prompt,
                 attachments=attachments,
                 metadata={
-                    "routed_tier": "t2",
+                    "routed_tier": "c2",
                     "routed_model": "routed-model",
                     "routing_source": "router",
                     "routing_confidence": 0.8,
@@ -270,5 +270,5 @@ async def test_turn_runner_emits_router_decision_event_from_pipeline_metadata(
 
     router_events = [event for event in events if isinstance(event, RouterDecisionEvent)]
     assert len(router_events) == 1
-    assert router_events[0].tier == "t2"
+    assert router_events[0].tier == "c2"
     assert router_events[0].model == "routed-model"

--- a/tests/test_engine/test_runtime_router_fallback.py
+++ b/tests/test_engine/test_runtime_router_fallback.py
@@ -39,7 +39,7 @@ class _SlowHistoryStrategy:
     ) -> tuple[str, float, str, dict]:
         time.sleep(0.08)
         return (
-            "t2",
+            "c2",
             0.95,
             "v4_phase3",
             {
@@ -62,7 +62,7 @@ class _MutatingHistoryStrategy:
         assert routing_history
         routing_history[0]["final_tier"] = "poisoned"
         return (
-            "t2",
+            "c2",
             0.95,
             "v4_phase3",
             {
@@ -172,7 +172,7 @@ async def test_squilla_router_timeout_does_not_late_mutate_history_entries(
             "turn_index": 0,
             "_ts": time.monotonic(),
             "text": "previous",
-            "final_tier": "t1",
+            "final_tier": "c1",
         }
     ]
     squilla_router_step._history_store.clear()
@@ -206,7 +206,7 @@ async def test_squilla_router_timeout_does_not_late_mutate_history_entries(
     stored_history = squilla_router_step._history_store.get(session_key)
     assert stored_history == original_history
     assert stored_history is not None
-    assert stored_history[0]["final_tier"] == "t1"
+    assert stored_history[0]["final_tier"] == "c1"
     router_record = next(
         record
         for record in turn.metadata["pipeline_steps"]

--- a/tests/test_engine/test_savings_score.py
+++ b/tests/test_engine/test_savings_score.py
@@ -9,9 +9,9 @@ from opensquilla.engine.runtime import _compute_comprehensive_turn_savings
 from opensquilla.engine.types import DoneEvent
 
 TEXT_TIERS = {
-    "t0": {"model": "deepseek/deepseek-v4-flash"},
-    "t2": {"model": "deepseek/deepseek-v4-pro"},
-    "t3": {"model": "anthropic/claude-opus-4.7"},
+    "c0": {"model": "deepseek/deepseek-v4-flash"},
+    "c2": {"model": "deepseek/deepseek-v4-pro"},
+    "c3": {"model": "anthropic/claude-opus-4.7"},
     "image_model": {"model": "moonshotai/kimi-k2.6", "image_only": True},
 }
 

--- a/tests/test_engine/test_t3_upgrade_compaction.py
+++ b/tests/test_engine/test_t3_upgrade_compaction.py
@@ -159,8 +159,8 @@ def _within_budget_transcript() -> list[TranscriptEntry]:
 
 
 def _make_turn(
-    routed_tier: str = "t3",
-    previous_tier: str | None = "t2",
+    routed_tier: str = "c3",
+    previous_tier: str | None = "c2",
     base_tier: str | None = None,
     final_tier: str | None = None,
     routing_applied: bool = True,
@@ -200,7 +200,7 @@ def _make_runner(
     flush_compaction_requires_safe_receipt: bool = False,
 ) -> TurnRunner:
     config = SimpleNamespace(
-        squilla_router=SimpleNamespace(upgrade_to_t3_compaction_enabled=enabled),
+        squilla_router=SimpleNamespace(upgrade_to_c3_compaction_enabled=enabled),
         memory=SimpleNamespace(
             flush_enabled=flush_enabled,
             flush_timeout_seconds=flush_timeout_seconds,
@@ -227,7 +227,7 @@ async def test_t2_to_t3_triggers_flush_then_compact() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -243,7 +243,7 @@ async def test_t3_within_budget_skips_flush_and_compact() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -266,7 +266,7 @@ async def test_t3_completed_event_reports_compaction_metadata(
     )
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -317,7 +317,7 @@ async def test_t3_stale_preimage_skip_does_not_mark_compacted(
     runner = _make_runner(session_manager=sm, flush_service=fs)
     session_key = "agent:main:webchat:default"
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade(session_key, turn, 100_000)
 
     assert result == "handled"
@@ -332,12 +332,12 @@ async def test_t3_stale_preimage_skip_does_not_mark_compacted(
 
 @pytest.mark.asyncio
 async def test_t0_t1_to_t3_triggers() -> None:
-    for prev in ("t0", "t1"):
+    for prev in ("c0", "c1"):
         sm = _FakeSessionManager(_sample_transcript())
         fs = _FakeFlushService()
         runner = _make_runner(session_manager=sm, flush_service=fs)
 
-        turn = _make_turn(routed_tier="t3", previous_tier=prev)
+        turn = _make_turn(routed_tier="c3", previous_tier=prev)
         result = await runner._maybe_compact_on_t3_upgrade(
             "agent:main:webchat:default", turn, 100_000
         )
@@ -354,7 +354,7 @@ async def test_t3_to_t3_skips() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t3")
+    turn = _make_turn(routed_tier="c3", previous_tier="c3")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "not_applicable"
@@ -368,7 +368,7 @@ async def test_non_t3_route_skips() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t1", previous_tier="t0")
+    turn = _make_turn(routed_tier="c1", previous_tier="c0")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "not_applicable"
@@ -382,7 +382,7 @@ async def test_config_disabled_skips() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs, enabled=False)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "not_applicable"
@@ -396,7 +396,7 @@ async def test_observe_mode_skips() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2", routing_applied=False)
+    turn = _make_turn(routed_tier="c3", previous_tier="c2", routing_applied=False)
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "not_applicable"
@@ -410,7 +410,7 @@ async def test_flush_raises_does_not_block_compaction() -> None:
     fs = _FakeFlushService(raise_exc=RuntimeError("flush boom"))
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -425,7 +425,7 @@ async def test_flush_error_receipt_does_not_block_compaction() -> None:
     fs = _FakeFlushService(receipt=_FakeFlushReceipt(mode="error", error="provider down"))
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -453,7 +453,7 @@ async def test_degraded_flush_receipts_do_not_block_compaction(
     fs = _FakeFlushService(receipt=receipt)
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -472,7 +472,7 @@ async def test_t3_strict_flush_receipt_skips_destructive_compaction() -> None:
         flush_compaction_requires_safe_receipt=True,
     )
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -486,7 +486,7 @@ async def test_backfilled_flush_receipt_allows_compact() -> None:
     fs = _FakeFlushService(receipt=_FakeFlushReceipt(obligation_status="backfilled"))
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -506,7 +506,7 @@ async def test_t3_flush_uses_background_timeout_for_service_call() -> None:
         flush_background_timeout_seconds=42.0,
     )
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -520,7 +520,7 @@ async def test_t3_flush_uses_longer_default_background_timeout() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -539,7 +539,7 @@ async def test_t3_flush_grace_timeout_does_not_block_compaction() -> None:
         flush_background_timeout_seconds=42.0,
     )
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -558,7 +558,7 @@ async def test_memory_flush_disabled_compacts_without_flush_service() -> None:
         flush_enabled=False,
     )
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -575,7 +575,7 @@ async def test_env_flush_disabled_compacts_without_flush_service(
     sm = _FakeSessionManager(_sample_transcript())
     runner = _make_runner(session_manager=sm, flush_service=None)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "handled"
@@ -593,7 +593,7 @@ async def test_compact_raises_continues() -> None:
     fs = _FakeFlushService()
     runner = _make_runner(session_manager=sm, flush_service=fs)
 
-    turn = _make_turn(routed_tier="t3", previous_tier="t2")
+    turn = _make_turn(routed_tier="c3", previous_tier="c2")
     result = await runner._maybe_compact_on_t3_upgrade("agent:main:webchat:default", turn, 100_000)
 
     assert result == "compact_failed"
@@ -632,7 +632,7 @@ async def test_t3_compact_failure_uses_emergency_ephemeral_history_trim(
 
     result = await runner._maybe_compact_on_t3_upgrade(
         session_key,
-        _make_turn(routed_tier="t3", previous_tier="t2"),
+        _make_turn(routed_tier="c3", previous_tier="c2"),
         1000,
     )
 
@@ -691,7 +691,7 @@ async def test_t3_open_circuit_still_uses_request_scoped_emergency_trim(
 
     result = await runner._maybe_compact_on_t3_upgrade(
         session_key,
-        _make_turn(routed_tier="t3", previous_tier="t2"),
+        _make_turn(routed_tier="c3", previous_tier="c2"),
         1000,
     )
 

--- a/tests/test_engine/turn_runner/test_router_control_replay_event.py
+++ b/tests/test_engine/turn_runner/test_router_control_replay_event.py
@@ -34,7 +34,7 @@ class _Strategy:
         routing_history: list[dict] | None = None,
         **kwargs: object,
     ) -> tuple[str, float, str, dict]:
-        return "t1", 0.9, "v4_phase3", {"route_class": "R1"}
+        return "c1", 0.9, "v4_phase3", {"route_class": "R1"}
 
 
 class _ReplayProvider:
@@ -57,8 +57,8 @@ class _ReplayProvider:
                 tool_name="router_control",
                 arguments={
                     "action": "set_hold",
-                    "target_id": "tier:t3",
-                    "evidence": "use t3",
+                    "target_id": "tier:c3",
+                    "evidence": "use c3",
                 },
             )
             yield ProviderDone(model=self.model)
@@ -112,7 +112,7 @@ async def test_router_control_replay_event_replays_turn_once(monkeypatch) -> Non
     events = [
         event
         async for event in runner.run(
-            "Use t3 for this",
+            "Use c3 for this",
             "agent:main:router-control-replay",
             tool_context=ToolContext(is_owner=True, caller_kind=CallerKind.CLI),
             history_has_persisted_user=False,
@@ -125,7 +125,7 @@ async def test_router_control_replay_event_replays_turn_once(monkeypatch) -> Non
     text = "".join(getattr(event, "text", "") for event in events if event.kind == "text_delta")
 
     assert len(replay_events) == 1
-    assert replay_events[0].target_tier == "t3"
+    assert replay_events[0].target_tier == "c3"
     assert provider.calls == ["deepseek/deepseek-v4-pro", "anthropic/claude-opus-4.7"]
     assert done_events[-1].text == "new final"
     assert text.endswith("new final")

--- a/tests/test_engine/turn_runner/test_turn_finalizer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_turn_finalizer_stage_unit.py
@@ -264,7 +264,7 @@ async def test_simple_text_with_done_event_fires_rollup() -> None:
         input_tokens=5,
         output_tokens=3,
         model="synthetic-turn-model-4.5",
-        routed_tier="t2",
+        routed_tier="c2",
         routing_applied=False,
         rollout_phase="observe",
     )
@@ -280,7 +280,7 @@ async def test_simple_text_with_done_event_fires_rollup() -> None:
     assert recs["transcript_append"].calls[0]["turn_usage"]["input_tokens"] == 5
     assert recs["transcript_append"].calls[0]["turn_usage"]["output_tokens"] == 3
     assert recs["transcript_append"].calls[0]["turn_usage"]["model"] == "synthetic-turn-model-4.5"
-    assert recs["transcript_append"].calls[0]["turn_usage"]["routed_tier"] == "t2"
+    assert recs["transcript_append"].calls[0]["turn_usage"]["routed_tier"] == "c2"
     assert recs["transcript_append"].calls[0]["turn_usage"]["routing_applied"] is False
     assert recs["transcript_append"].calls[0]["turn_usage"]["rollout_phase"] == "observe"
 
@@ -335,7 +335,7 @@ async def test_turn_with_artifacts_persists_json_wrapped_content() -> None:
 @pytest.mark.asyncio
 async def test_tool_use_segments_persist_with_tool_calls() -> None:
     segments: list[dict[str, Any]] = [
-        {"type": "tool_use", "tool_use_id": "t1", "name": "echo", "input": ""},
+        {"type": "tool_use", "tool_use_id": "c1", "name": "echo", "input": ""},
     ]
     stage, recs = _make_stage()
     inp = _make_input(turn_segments=segments)
@@ -350,7 +350,7 @@ async def test_unknown_background_tool_status_adds_confirmation_guard() -> None:
     segments: list[dict[str, Any]] = [
         {
             "type": "tool_result",
-            "tool_use_id": "t1",
+            "tool_use_id": "c1",
             "name": "background_process",
             "result": "session: open-browser\nstatus: running",
             "is_error": False,
@@ -385,7 +385,7 @@ async def test_successful_background_tool_status_does_not_add_confirmation_guard
     segments: list[dict[str, Any]] = [
         {
             "type": "tool_result",
-            "tool_use_id": "t1",
+            "tool_use_id": "c1",
             "name": "background_process",
             "result": "session: open-browser\nstatus: complete",
             "is_error": False,

--- a/tests/test_gateway/test_chat_static_assets.py
+++ b/tests/test_gateway/test_chat_static_assets.py
@@ -425,16 +425,19 @@ def test_chat_js_has_document_level_escape_handler() -> None:
     assert "if (_chatOverlayVisible()) return;" in source
 
 
-def test_chat_escape_does_not_abort_from_editable_target() -> None:
+def test_chat_escape_aborts_from_composer_but_not_other_editable_targets() -> None:
     source = _read_chat_js()
     handler_start = source.index("function _onDocKeydown(e) {")
     handler_end = source.index("document.addEventListener('keydown', _onDocKeydown)", handler_start)
     handler = source[handler_start:handler_end]
 
-    editable_idx = handler.index("const inEditable = target && (")
+    other_editable_idx = handler.index(
+        "const inOtherEditable = target && target !== _textarea && ("
+    )
     streaming_idx = handler.index("if (_isStreaming) {")
-    assert editable_idx < streaming_idx
-    assert "if (inEditable) return;" in handler
+    assert other_editable_idx < streaming_idx
+    assert "if (inOtherEditable) return;" in handler
+    assert "target !== _textarea" in handler
     assert "_onStop('webui_escape')" in handler
 
 

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -1,4 +1,3 @@
-import re
 from pathlib import Path
 
 CHAT_JS = Path("src/opensquilla/gateway/static/js/views/chat.js")
@@ -83,6 +82,18 @@ def test_chat_day_separator_stays_on_centered_chat_axis() -> None:
     assert "margin: var(--sp-2) auto;" in block
 
 
+def test_chat_user_bubble_text_uses_reading_direction_alignment() -> None:
+    css = CHAT_CSS.read_text(encoding="utf-8")
+    start = css.index(".chat-msg--user .chat-msg-text,")
+    end = css.index("/* Assistant", start)
+    block = css[start:end]
+
+    assert "display: flex;" in block
+    assert "align-items: center;" in block
+    assert "justify-content: flex-start;" in block
+    assert "text-align: start;" in block
+
+
 def test_chat_sent_attachment_images_render_as_separate_thumbnail_attachments() -> None:
     css = CHAT_CSS.read_text(encoding="utf-8")
     body_start = css.index(".msg.user .msg-body.msg-body--has-attachments {")
@@ -128,8 +139,10 @@ def test_chat_user_message_bubbles_preserve_multiline_text() -> None:
 
     assert "white-space: pre-wrap;" in user_block
     assert "overflow-wrap: anywhere;" in user_block
+    assert "text-align: start;" in user_block
     assert "white-space: pre-wrap;" in attachment_text_block
     assert "overflow-wrap: anywhere;" in attachment_text_block
+    assert "text-align: start;" in attachment_text_block
 
 
 def test_chat_non_image_message_attachments_render_download_links_when_data_exists() -> None:
@@ -240,6 +253,31 @@ def test_chat_artifact_downloads_use_direct_links_to_preserve_user_activation() 
     assert 'download="${_escAttr(name)}"' in render_body
 
 
+def test_chat_message_actions_do_not_stick_after_history_rebuild_or_click() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+    assert "function _clearMessageActionFocus(reason = '') {" in source
+
+    clear_start = source.index("function _clearMessageActionFocus(reason = '') {")
+    clear_end = source.index("function _attachHoverActions", clear_start)
+    clear_body = source[clear_start:clear_end]
+    assert "const active = document.activeElement;" in clear_body
+    assert "active.closest('.msg-actions')" in clear_body
+    assert "active.blur();" in clear_body
+    assert "_chatDiag('message_actions.focus_cleared'" in clear_body
+
+    hover_start = source.index("function _bindHoverActions()")
+    hover_end = source.index("  function _truncate", hover_start)
+    hover_body = source[hover_start:hover_end]
+    assert "btn.blur();" in hover_body
+    assert "const action = btn.dataset.action;" in hover_body
+    assert hover_body.index("btn.blur();") < hover_body.index("const action = btn.dataset.action;")
+
+    history_start = source.index("function _renderHistoryMessages(messages, opts = {})")
+    history_end = source.index("function _historyLiveTailAnchor", history_start)
+    history_body = source[history_start:history_end]
+    assert "_clearMessageActionFocus('history_rebuild');" in history_body
+
+
 def test_chat_artifact_images_render_as_preview_cards_and_refresh_on_done() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
     css = CHAT_CSS.read_text(encoding="utf-8")
@@ -339,6 +377,89 @@ def test_chat_shows_awaiting_model_hint_after_tool_result_heartbeat() -> None:
     assert "content: 'waiting for model response...';" in css
     assert "textContent = 'waiting for model response" not in source
     assert "document.createTextNode('waiting for model response" not in source
+
+
+def test_chat_streaming_indicator_uses_delayed_bottom_dock() -> None:
+    css = CHAT_CSS.read_text(encoding="utf-8")
+
+    assert ".msg.streaming.streaming-active-mark:not(.awaiting-model) .msg-body::after" in css
+    assert "padding-bottom: calc(var(--sp-2) + 24px);" in css
+    # Mark is corner-aligned to the content-left edge and centered in the
+    # reserved footer band, so the orbiting ring clears the tool card above
+    # and the bubble's bottom edge — no overlap, no rightward-inset orphan.
+    assert "left: var(--sp-4);" in css
+    assert "bottom: var(--sp-2);" in css
+    assert "left: calc(var(--sp-4) - 4px);" in css
+    assert "bottom: calc(var(--sp-2) - 4px);" in css
+    assert "left: calc(var(--sp-4) + 16px);" not in css
+    assert "background-image: url('../../img/opensquilla-mark.png');" in css
+    assert "width: 16px;" in css
+    assert "height: 16px;" in css
+    assert "background-size: 11px 11px;" in css
+    assert "border-radius: 50%;" in css
+    assert "0 0 0 1px color-mix(in srgb, var(--accent) 7%, transparent)" in css
+    # Orbital-sweep design: the figurative squilla mark stays UPRIGHT and
+    # legible (no spin on ::after); the motion lives in an orbiting ring
+    # rendered on ::before. The mark must not tumble.
+    assert "animation: squilla-activity-spin 1.6s linear infinite;" not in css
+    assert ".msg.streaming.streaming-active-mark:not(.awaiting-model) .msg-body::before" in css
+    assert "background: conic-gradient(from 0deg," in css
+    assert "var(--accent-secondary) 320deg," in css
+    assert (
+        "mask: radial-gradient(farthest-side, transparent calc(100% - 2px), "
+        "#000 calc(100% - 2px));"
+        in css
+    )
+    assert "animation: squilla-activity-spin 1.15s linear infinite;" in css
+    assert "@keyframes squilla-activity-spin" in css
+    assert "@media (prefers-reduced-motion: reduce)" in css
+    assert ".chat-tools-collapse--running > .chat-tools-summary .chat-tools-icon" not in css
+    assert ".msg-text-seg:not(:empty):last-of-type > :last-child::after" not in css
+    assert "streaming-harbor" not in css
+    assert "animation: squilla-harbor-peek" not in css
+    assert "@keyframes squilla-harbor-peek" not in css
+    assert "animation: squilla-harbor-spin" not in css
+    assert "@keyframes squilla-harbor-spin" not in css
+    assert "animation: squilla-harbor-wave" not in css
+    assert "@keyframes squilla-harbor-wave" not in css
+    assert "animation: squilla-dock-patrol" not in css
+    assert "@keyframes squilla-dock-patrol" not in css
+    assert "animation: shrimp-roll" not in css
+    assert "@keyframes shrimp-roll" not in css
+
+
+def test_chat_streaming_active_mark_reveals_after_visible_bubble_delay() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+
+    assert "const _STREAM_ACTIVE_MARK_CLASS = 'streaming-active-mark';" in source
+    assert "const _STREAM_ACTIVE_MARK_DELAY_MS = 3500;" in source
+    assert "let _streamActiveMarkVisibleStartedAt = 0;" in source
+    assert "function _beginStreamActiveMarkRevealWindow()" in source
+
+    start_stream_start = source.index("function _startStreaming()")
+    start_stream_end = source.index("  function _ensureStreamBubble", start_stream_start)
+    start_stream_body = source[start_stream_start:start_stream_end]
+    assert "_scheduleStreamActiveMarkReveal();" not in start_stream_body
+    assert "_beginStreamActiveMarkRevealWindow();" not in start_stream_body
+
+    ensure_start = source.index("function _ensureStreamBubble()")
+    ensure_end = source.index("  /** Create a new .msg-text-seg", ensure_start)
+    ensure_body = source[ensure_start:ensure_end]
+    assert "_beginStreamActiveMarkRevealWindow();" in ensure_body
+    assert "_maybeRevealStreamActiveMark();" in ensure_body
+
+    reveal_start = source.index("function _maybeRevealStreamActiveMark()")
+    reveal_end = source.index("  function _scheduleStreamActiveMarkReveal", reveal_start)
+    reveal_body = source[reveal_start:reveal_end]
+    assert (
+        "_streamActiveMarkVisibleStartedAt ? Date.now() - _streamActiveMarkVisibleStartedAt : 0"
+        in reveal_body
+    )
+
+    end_stream_start = source.index("function _endStreaming(opts)")
+    end_stream_end = source.index("  function _hasViewLocalStreamState", end_stream_start)
+    end_stream_body = source[end_stream_start:end_stream_end]
+    assert "_clearStreamActiveMarkReveal();" in end_stream_body
 
 
 def test_chat_clears_awaiting_model_hint_on_next_visible_event_and_stream_reset() -> None:
@@ -866,7 +987,8 @@ def test_chat_subscribe_uses_stream_replay_cursor() -> None:
     assert "params.since_stream_seq = _lastStreamSeq;" not in source
     assert "if (_lastStreamSeq > 0) params.since_stream_seq = _lastStreamSeq;" not in body
     assert "function _acceptStreamSeq(payload)" in source
-    assert "Session stream gap detected; reloading transcript." in source
+    assert "function _replayGapShouldWarn(reason)" in source
+    assert "Session stream gap detected; reloading transcript." not in body
 
 
 def test_chat_stream_handlers_drop_replayed_duplicate_frames() -> None:
@@ -939,9 +1061,31 @@ def test_chat_resets_replay_cursor_after_stream_gap() -> None:
 
     assert "if (res && res.replay_complete === false)" in body
     assert "_setSessionStreamSeq(subscribeKey, res.current_stream_seq);" in body
+    assert "const replayGapReason = res.replay_gap_reason || res.replayGapReason || '';" in body
+    assert "if (_replayGapShouldWarn(replayGapReason))" in body
+    assert "_loadHistory(_historyRefreshScrollOptions());" in body
     assert body.index("_setSessionStreamSeq(subscribeKey, res.current_stream_seq);") < body.index(
-        "_loadHistory();"
+        "_loadHistory(_historyRefreshScrollOptions());"
     )
+    assert body.index("if (_replayGapShouldWarn(replayGapReason))") < body.index(
+        "_loadHistory(_historyRefreshScrollOptions());"
+    )
+
+
+def test_chat_replay_gap_history_refresh_preserves_reader_scroll() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+
+    assert "function _historyRefreshScrollOptions()" in source
+    start = source.index("function _historyRefreshScrollOptions()")
+    end = source.index("function _scheduleHistorySync", start)
+    body = source[start:end]
+
+    assert "!_thread || !_historyHasRendered" in body
+    assert "_thread.scrollHeight - _thread.scrollTop - _thread.clientHeight" in body
+    assert "if (gap < 60) return {};" in body
+    assert "preserveScroll: true" in body
+    assert "previousScrollHeight: _thread.scrollHeight" in body
+    assert "previousScrollTop: _thread.scrollTop" in body
 
 
 def test_chat_empty_history_preserves_live_stream_bubble() -> None:
@@ -1252,7 +1396,7 @@ def test_chat_compaction_summary_separator_anchors_to_transcript_ids() -> None:
     )
     sync_end = source.index("function _compactFailureBlocksPending", sync_start)
     sync_body = source[sync_start:sync_end]
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("_chatDiag('history.done'", history_start)
     history_body = source[history_start:history_end]
 
@@ -1268,6 +1412,21 @@ def test_chat_compaction_summary_separator_anchors_to_transcript_ids() -> None:
     assert "function _scheduleCompactionSeparatorRemoval(delayMs = 4500)" in source
     assert "_scheduleCompactionSeparatorRemoval();" in sync_body
     assert "status === 'skipped'" in sync_body
+
+
+def test_chat_current_compaction_separator_bottom_anchors_and_autoscrolls() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+    css = CHAT_CSS.read_text(encoding="utf-8")
+    sync_start = source.index(
+        "function _syncCompactionSeparator(payload, status, source, overrides = {})"
+    )
+    sync_end = source.index("function _clearCompactionSummarySeparators", sync_start)
+    sync_body = source[sync_start:sync_end]
+
+    assert "chat-context-separator--session" in sync_body
+    assert "if (_autoScroll) _scrollToBottom();" in sync_body
+    assert ".chat-context-separator--session" in css
+    assert "margin-top: auto;" in css
 
 
 def test_chat_compaction_separator_does_not_render_token_details() -> None:
@@ -1653,7 +1812,7 @@ def test_chat_diag_is_opt_in_by_default() -> None:
 
 def test_chat_history_requests_active_paginated_metadata() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("async function _loadEarlierHistory()", history_start)
     history_body = source[history_start:history_end]
     earlier_start = source.index("async function _loadEarlierHistory() {")
@@ -1693,7 +1852,7 @@ def test_chat_history_scope_row_surfaces_partial_compacted_and_error_states() ->
     source = CHAT_JS.read_text(encoding="utf-8")
     css = CHAT_CSS.read_text(encoding="utf-8")
     start = source.index("function _renderHistoryScopeRow() {")
-    end = source.index("async function _loadHistory()", start)
+    end = source.index("async function _loadHistory(opts = {})", start)
     body = source[start:end]
 
     assert "chat-history-scope" in body
@@ -1711,7 +1870,7 @@ def test_chat_history_scope_row_surfaces_partial_compacted_and_error_states() ->
 
 def test_chat_history_render_preserves_visible_messages_on_errors() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    initial_start = source.index("async function _loadHistory() {")
+    initial_start = source.index("async function _loadHistory(opts = {}) {")
     initial_end = source.index("async function _loadEarlierHistory()", initial_start)
     initial_body = source[initial_start:initial_end]
     earlier_start = source.index("async function _loadEarlierHistory() {")
@@ -1729,7 +1888,7 @@ def test_chat_history_render_preserves_visible_messages_on_errors() -> None:
 def test_chat_history_scope_row_is_not_a_message_node() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
     start = source.index("function _renderHistoryScopeRow() {")
-    end = source.index("async function _loadHistory()", start)
+    end = source.index("async function _loadHistory(opts = {})", start)
     body = source[start:end]
 
     assert "row.className = `chat-history-scope chat-history-scope--${tone}`;" in body
@@ -1739,7 +1898,7 @@ def test_chat_history_scope_row_is_not_a_message_node() -> None:
 
 def test_router_fx_history_reuses_settled_strip_for_same_turn_identity() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("  /* ── Send Message", history_start)
     history_body = source[history_start:history_end]
 
@@ -1761,7 +1920,7 @@ def test_router_fx_history_reanchors_stranded_strip() -> None:
     # flag — keep the one whose identity matches, drop extras, and re-anchor the
     # survivor beneath its user message, so the first chat never shows two grids.
     source = CHAT_JS.read_text(encoding="utf-8")
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("  /* ── Send Message", history_start)
     history_body = source[history_start:history_end]
 
@@ -1792,199 +1951,133 @@ def test_router_fx_history_reanchors_stranded_strip() -> None:
     assert "if (!anchored) _routerFxRemoveStrip(el);" in history_body
 
 
-def test_router_fx_uses_fixed_model_slots_and_keeps_decoy_seed() -> None:
+def test_router_fx_uses_only_effective_real_candidates() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
     builder_start = source.index("function _routerFxBuildGridCells(realEntries, seedKey) {")
     builder_end = source.index("  function _buildRouterFxElement", builder_start)
     builder_body = source[builder_start:builder_end]
-    live_start = source.index("async function _handleRouterDecision(payload) {")
-    live_end = source.index("  // History-load entry point", live_start)
-    live_body = source[live_start:live_end]
 
-    assert "const _ROUTER_FX_REAL_ANCHOR_CELLS = [1, 6, 8, 13, 11" in source
+    assert "const _ROUTER_FX_DECOY_POOL" not in source
+    assert "_ROUTER_FX_REAL_ANCHOR_CELLS" not in source
+    assert "_ROUTER_FX_GRID_CELLS" not in source
     assert "function _routerFxResolveLayoutSeed(sessionKey, hintTimestamp)" in source
-    assert "const replaySeed = _routerFxResolveLayoutSeed(_sessionKey);" in live_body
+    assert "function _routerFxVisualEntries(requestKind, decision) {" in source
     assert "const cachedSeed = _routerFxResolveLayoutSeed(_sessionKey, hint);" in source
     assert "const orderedRealEntries = realEntries.slice().sort" in builder_body
-    assert "const anchor = _ROUTER_FX_REAL_ANCHOR_CELLS[i];" in builder_body
-    assert "const orderedDecoys = _routerFxShuffle(decoys," in builder_body
+    assert "return orderedRealEntries.map((entry) => ({" in builder_body
+    assert "kind: 'real'," in builder_body
+    assert "kind: 'decoy'" not in builder_body
     assert "return _routerFxShuffle(cells, seedKey);" not in builder_body
 
 
-def test_router_fx_cells_have_equal_prominence_and_hide_roster() -> None:
-    # Every model cell must render identically; the panel must not reveal which
-    # names are the operator's actually-configured (active) models. So the old
-    # real/decoy visual distinction is gone (no breathing accent dot, no
-    # dimmed/italic decoys) AND the DOM no longer carries data-kind/data-tiers.
+def test_router_fx_cells_render_plain_model_names_only() -> None:
+    # The panel intentionally shows the real candidates for this request. Cells
+    # show only the user-facing model name: no S/M/L/XL, no provider labels, no
+    # thinking badges, and no DOM roster metadata beyond the cell index needed
+    # for the selector.
     source = CHAT_JS.read_text(encoding="utf-8")
     css = CHAT_CSS.read_text(encoding="utf-8")
 
-    # No DOM attribute leaks the real/decoy split.
     assert "cell.dataset.kind" not in source
     assert "cell.dataset.tiers" not in source
-    # No CSS differentiates real vs decoy cells; the "on the dial" dot is gone.
     assert '[data-kind="real"]' not in css
     assert '[data-kind="decoy"]' not in css
     assert "router-fx-dot-idle" not in css
-    # Cells share one uniform colour; only the winner is emphasised.
     cell_start = css.index(".router-fx-cell {")
     cell_end = css.index("}", cell_start)
     assert "color: var(--text);" in css[cell_start:cell_end]
     assert ".router-fx-cell.win {" in css
-    # Winner keeps a self-contained lock dot (no longer inherited from a
-    # real-cell dot that no longer exists).
     win_after = css.index(".router-fx-cell.win::after {")
     win_after_end = css.index("}", win_after)
     assert "content: '';" in css[win_after:win_after_end]
-    # Winner detection reads the in-memory grid-cell array, not a DOM attribute,
-    # so it still lands on the routed cell without exposing the rest. Pin the
-    # predicate (reads .kind off the array) and the cell-idx stamping that the
-    # positional DOM lookup relies on — so a refactor that broke landing fails.
     assert "const cells = wrap._fxGridCells || [];" in source
     assert "cells[i].kind === 'real'" in source
     assert "cell.dataset.cellIdx = String(i);" in source
+    assert "cell.dataset.provider" not in source
+    assert "cell.dataset.thinking" not in source
+    for size_label in (">S<", ">M<", ">L<", ">XL<"):
+        assert size_label not in source
 
 
-def test_router_fx_decoy_pool_doubled_with_current_models() -> None:
-    # Roster expanded to >= 2x the previous 16, sourced from OpenRouter's
-    # highest-usage models (ordered by volume, highest first).
+def test_router_fx_config_caches_text_and_image_capability_flags() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    pool_start = source.index("const _ROUTER_FX_DECOY_POOL = [")
-    pool_end = source.index("];", pool_start)
-    pool = source[pool_start:pool_end]
-    names = re.findall(r"'([^']+)'", pool)
-    assert len(names) >= 32, f"expected >= 32 pooled models, found {len(names)}"
-    # Ordered by usage, highest first — the documented #1 leads.
-    assert names[0] == "deepseek-v4-flash"
-    for name in ("claude-sonnet-4.6", "glm-5.1", "qwen3.6-plus"):
-        assert name in names
+    load_start = source.index("async function _loadFeatureToggles() {")
+    load_end = source.index("  /* ── Session Chip", load_start)
+    body = source[load_start:load_end]
+
+    assert "const _routerFxTierConfigs = {};" in source
+    assert "model: typeof rawTier?.model === 'string' ? rawTier.model : ''," in body
+    assert "supportsImage: rawTier?.supports_image === true," in body
+    assert "imageOnly: rawTier?.image_only === true," in body
+    assert "_routerFxTierConfigs[lower] = tierConfig;" in body
+    assert "delete _routerFxTierConfigs[tier];" in body
 
 
-def test_router_fx_cloud_variant_renders_seeded_depth_field() -> None:
-    # The cloud variant builds a focal-depth nebula: each mote gets a seeded
-    # depth driving blur/scale/opacity TOGETHER (coherent optical depth, not a
-    # random tag cloud), deterministic per layout seed for history rebuilds.
-    source = CHAT_JS.read_text(encoding="utf-8")
-
-    assert "function _routerFxBuildCloud(wrap, decision, seedKey) {" in source
-    build_start = source.index("function _routerFxBuildCloud(wrap, decision, seedKey) {")
-    build_end = source.index("function _settleRouterFxCloud(wrap) {", build_start)
-    body = source[build_start:build_end]
-    # Seeded RNG keyed off the layout seed → reproducible nebula.
-    assert "_routerFxMulberry32(_routerFxHashSeed((seedKey || '') + ':cloud'))" in body
-    # blur, scale, opacity all derive from the same depth d.
-    assert "const d = rng();" in body
-    assert "const blur = (d * 3.4).toFixed(2);" in body
-    assert "const scale = (1.22 - d * 0.62).toFixed(3);" in body
-    assert "const op = (0.92 - d * 0.64).toFixed(3);" in body
-    # Organic elliptical scatter (area-uniform radius at a random angle).
-    assert "const rad = Math.sqrt(rng());" in body
-    assert "Math.cos(ang)" in body and "Math.sin(ang)" in body
-    # Two layers so drift (outer) and rack-focus (inner) never fight.
-    assert "inner.className = 'router-fx-mote-i';" in body
-    assert "mote.appendChild(inner);" in body
-    assert "mote.classList.add('router-fx-mote--winner');" in body
-    assert "wrap._fxCloud = true;" in body
-    assert "wrap._fxWinnerEl = winnerEl;" in body
-    # Builder branches to the cloud and returns before the grid build.
-    assert "if (variant === 'cloud') {" in source
-    assert "_routerFxBuildCloud(wrap, decision, seedKey);" in source
-
-
-def test_router_fx_cloud_shows_pool_plus_winner_not_roster() -> None:
-    # Privacy: the cloud field is the public decoy pool + the (already-public)
-    # routed winner only — it must NOT render the operator's configured roster.
-    source = CHAT_JS.read_text(encoding="utf-8")
-    build_start = source.index("function _routerFxBuildCloud(wrap, decision, seedKey) {")
-    build_end = source.index("function _settleRouterFxCloud(wrap) {", build_start)
-    body = source[build_start:build_end]
-
-    assert "_ROUTER_FX_DECOY_POOL.forEach(" in body
-    assert "const winnerName = _routerFxWinnerName(decision);" in body
-    # The roster builder is never consulted inside the cloud build.
-    assert "_routerFxRealEntries" not in body
-    assert "function _routerFxWinnerName(decision) {" in source
-
-
-def test_router_fx_cloud_rack_focus_dispatch_is_motion_opt_in() -> None:
-    # Cloud strips still have a live scan/lock path, but replay/history
-    # decisions must render settled instead of re-running rack-focus motion.
+def test_router_fx_filters_text_and_image_candidates_by_request_kind() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
 
-    assert "function _animateRouterFxCloud(wrap) {" in source
-    assert "function _settleRouterFxCloud(wrap) {" in source
-    anim_start = source.index("function _animateRouterFxCloud(wrap) {")
-    anim_end = source.index("// Anchor invariant", anim_start)
-    anim = source[anim_start:anim_end]
-    assert "if (!wrap._fxWinnerEl) { _settleRouterFxCloud(wrap); return; }" in anim
-    assert "prefers-reduced-motion" not in anim   # decoupled from OS reduce-motion
-    assert "wrap.dataset.state = 'playing';" in anim
-    assert "wrap.dataset.state = 'settled';" in anim
-    assert anim.index("'playing'") < anim.index("'settled'")
-    # Live strips lock through the cloud-specific settle path.
-    assert "wrap._fxCloud" in source
-    assert "if (wrap._fxCloud) _routerFxLockCloud(wrap, decision);" in source
-    lock_start = source.index("function _routerFxLockCloud(wrap, decision) {")
-    lock_end = source.index("function _routerFxLockGrid(wrap, decision) {", lock_start)
-    lock_cloud = source[lock_start:lock_end]
-    assert "_settleRouterFxCloud(wrap)" in lock_cloud
+    assert "function _routerFxRequestKindFromAttachments(attachments) {" in source
+    request_start = source.index("function _routerFxRequestKindFromAttachments(attachments) {")
+    request_end = source.index("function _routerFxTierMatchesRequestKind", request_start)
+    request_body = source[request_start:request_end]
+    assert "return 'image';" in request_body
+    assert "return 'text';" in request_body
 
-    handler_start = source.index("async function _handleRouterDecision(payload) {")
-    handler_end = source.index("// History-load entry point", handler_start)
-    handler = source[handler_start:handler_end]
-    assert "_animateRouterFxCloud(wrap)" not in handler
-    assert "preSettled: true" in handler
-    assert "renderMode: 'history'" in handler
+    match_start = source.index("function _routerFxTierMatchesRequestKind")
+    match_end = source.index("function _routerFxVisualEntries", match_start)
+    match_body = source[match_start:match_end]
+    assert "return !!(tierConfig.supportsImage || tierConfig.imageOnly);" in match_body
+    assert "return !tierConfig.imageOnly;" in match_body
+
+    send_start = source.index("async function _onSend()")
+    send_end = source.index("    // Send", send_start)
+    send_body = source[send_start:send_end]
+    assert (
+        "const routerFxRequestKind = "
+        "_routerFxRequestKindFromAttachments(params.attachments || []);"
+    ) in send_body
+    assert "requestKind: routerFxRequestKind" in send_body
 
 
-def test_router_fx_cloud_css_rack_focus_states() -> None:
-    css = CHAT_CSS.read_text(encoding="utf-8")
-
-    # Borderless/organic: no rigid box — a radial mask dissolves the edges,
-    # and content-visibility keeps off-screen history strips cheap.
-    cloud_start = css.index('.router-fx[data-variant="cloud"] .router-fx-cloud {')
-    cloud_block = css[cloud_start:css.index("}", cloud_start)]
-    assert "border:" not in cloud_block          # no rigid rectangular boundary
-    assert "mask-image: radial-gradient(" in cloud_block
-    # content-visibility was removed — it paused animation on auto-scroll.
-    assert "content-visibility" not in cloud_block
-    # Two layers: OUTER owns position + (winner) glide; INNER owns the optics.
-    # NO perpetual motion — the panel must be still once settled / when output
-    # renders (the absolute red line), so there is no drift/breathe loop.
-    mote_start = css.index('.router-fx[data-variant="cloud"] .router-fx-mote {')
-    mote_block = css[mote_start:css.index("}", mote_start)]
-    assert "animation:" not in mote_block               # no perpetual drift
-    assert "will-change" not in mote_block              # not pinned permanently (perf)
-    assert "@keyframes router-fx-drift" not in css      # drift loop removed
-    assert "router-fx-winner-breathe" not in css        # breathe loop removed
-    assert '.router-fx[data-variant="cloud"] .router-fx-mote-i {' in css
-    # Defocus (ease-IN) and the winner resolve target the INNER; the winner's
-    # glide to focus is on the OUTER (left/top), so it travels, never teleports.
-    assert '.router-fx[data-variant="cloud"][data-state="playing"] .router-fx-mote-i {' in css
-    assert ('.router-fx[data-variant="cloud"][data-state="settled"] '
-            '.router-fx-mote--winner .router-fx-mote-i {') in css
-    assert '.router-fx[data-variant="cloud"] .router-fx-reticle {' in css
-    # Output start no longer freezes the winner-lock animation; once settled,
-    # the grid hides only the chase hammer.
-    assert '.router-fx[data-frozen="true"]' not in css
-    selector_hide = (".router-fx[data-state=\"settled\"] .router-fx-selector"
-                     " { opacity: 0 !important; }")
-    assert selector_hide in css
-    # Motion is opt-in via the toggle, so the cloud does NOT honour OS
-    # reduce-motion (no @media block suppressing the cloud motes).
-    assert "deliberately does NOT honour prefers-reduced-motion" in css
-
-
-def test_router_fx_cloud_view_toggle_is_not_exposed() -> None:
+def test_router_fx_single_visual_candidate_renders_nothing_live_or_history() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    popover_start = source.index('id="chat-toolbar-popover"')
-    popover_end = source.index("chat-input-wrap", popover_start)
-    popover = source[popover_start:popover_end]
 
-    assert 'id="toggle-router-cloud"' not in popover
-    assert "Cloud view" not in popover
-    assert "const routerCloudToggle = _el.querySelector('#toggle-router-cloud');" not in source
-    assert "routerCloudToggle.checked = _routerFx.variant === 'cloud';" not in source
+    builder_start = source.index("function _buildRouterFxElement(decision, opts) {")
+    builder_end = source.index("  function _routerFxWinnerCellIndex", builder_start)
+    builder_body = source[builder_start:builder_end]
+    assert "if (realEntries.length <= 1) return null;" in builder_body
+
+    schedule_start = source.index("function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts) {")
+    schedule_end = source.index("  // Render the routing visualisation", schedule_start)
+    schedule_body = source[schedule_start:schedule_end]
+    assert (
+        "if (_routerFxConfigTiers !== null "
+        "&& !_routerFxHasMultipleCandidates(requestKind, null)) {"
+        in schedule_body
+    )
+    assert "_chatDiag('router_scan.schedule.skip.single_candidate'" in schedule_body
+
+    pending_start = source.index("async function _finishPendingRouterFxScan() {")
+    pending_end = source.index(
+        "function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts) {",
+        pending_start,
+    )
+    pending_body = source[pending_start:pending_end]
+    assert pending_body.index("await _routerFxAwaitConfig();") < pending_body.index(
+        "_routerFxBeginScan(pending.anchorDiv, pending.seedKey"
+    )
+
+    begin_start = source.index("function _routerFxBeginScan(anchorDiv, seedKey, opts) {")
+    begin_end = source.index("function _routerFxScanRoam(", begin_start)
+    begin_body = source[begin_start:begin_end]
+    assert "if (!wrap) {" in begin_body
+    assert "_chatDiag('router_scan.skip.single_candidate'" in begin_body
+
+    history_start = source.index("function _buildRouterFxFromUsage(usage, seedKey, opts) {")
+    history_end = source.index("  /* ── RPC Event Subscriptions", history_start)
+    history_body = source[history_start:history_end]
+    assert "requestKind: requestKind" in history_body
+    assert "return _buildRouterFxElement(decision, {" in history_body
 
 
 def test_router_fx_grid_labels_shrink_to_fit() -> None:
@@ -2039,7 +2132,7 @@ def test_router_fx_scan_to_lock_fills_the_wait() -> None:
     css = CHAT_CSS.read_text(encoding="utf-8")
 
     for fn in ("_routerFxBeginScan", "_routerFxScanRoam", "_routerFxStopScan",
-               "_routerFxLock", "_routerFxLockCloud", "_routerFxLockGrid"):
+               "_routerFxLock", "_routerFxLockGrid"):
         assert f"function {fn}(" in source
     # Scan is gated on BOTH the viz pref and routing actually being on.
     begin_start = source.index("function _routerFxBeginScan(")
@@ -2048,10 +2141,11 @@ def test_router_fx_scan_to_lock_fills_the_wait() -> None:
     assert "if (!_thread || !_routerFx.enabled || !_routerFeatureEnabled) {" in begin
     assert "_chatDiag('router_scan.skip'" in begin
     assert "return false;" in begin
+    assert "_routerFxHasMultipleCandidates(requestKind, null)" in begin
     # Scheduled from the send path.
     assert (
         "const routerScanStarted = _scheduleRouterFxBeginScan("
-        "userDiv, _routerFxResolveLayoutSeed(_sessionKey));"
+        "userDiv, _routerFxResolveLayoutSeed(_sessionKey), {"
     ) in source
     # The scan runs for a FIXED, hard-capped window (≤1s), then locks — not
     # "roam until the decision WS event lands".
@@ -2063,16 +2157,14 @@ def test_router_fx_scan_to_lock_fills_the_wait() -> None:
     assert "liveStrip._fxDecision = payload;" in source
     assert "if (liveStrip._fxFinished) {" in source
     assert "_routerFxLock(wrap, wrap._fxDecision);" in source  # finish locks the cached winner
-    # Roam is JS-driven discrete swaps (cloud: .is-scan; grid: hammer hop).
+    # Roam is JS-driven discrete selector hops across the real candidate cells.
     roam_start = source.index("function _routerFxScanRoam(")
     roam_end = source.index("function _routerFxStopScan(", roam_start)
     roam = source[roam_start:roam_end]
-    assert "m.classList.toggle('is-scan', idx === i)" in roam
-    assert "wrap._fxScanTimer = setTimeout(step, isCloud ? 170 : 190);" in roam
-    # CSS gives the roaming focus a sharp accent pop.
-    scan_css = ('.router-fx[data-variant="cloud"][data-state="scanning"] '
-                '.router-fx-mote.is-scan .router-fx-mote-i {')
-    assert scan_css in css
+    assert "const grid = wrap.querySelector('.router-fx-grid');" in roam
+    assert "const targets = grid.querySelectorAll('.router-fx-cell');" in roam
+    assert "wrap._fxScanTimer = setTimeout(step, 190);" in roam
+    assert ".router-fx-mote" not in css
 
 
 def test_chat_compaction_suppresses_current_turn_router_wait_panel() -> None:
@@ -2081,7 +2173,7 @@ def test_chat_compaction_suppresses_current_turn_router_wait_panel() -> None:
     assert "let _compactSuppressedRouterTurnIndex = '';" in source
     assert "function _suppressRouterFxForCompaction(payload = {})" in source
     assert "const _ROUTER_FX_START_DELAY_MS = 280;" in source
-    assert "function _scheduleRouterFxBeginScan(anchorDiv, seedKey)" in source
+    assert "function _scheduleRouterFxBeginScan(anchorDiv, seedKey, opts)" in source
     assert "function _cancelPendingRouterFxScan(reason = '')" in source
 
     toast_start = source.index("function _showCompactionToast(payload, meta = {})")
@@ -2104,7 +2196,7 @@ def test_chat_compaction_suppresses_current_turn_router_wait_panel() -> None:
     send_end = source.index("    // Send", send_start)
     send_body = source[send_start:send_end]
     assert (
-        "_scheduleRouterFxBeginScan(userDiv, _routerFxResolveLayoutSeed(_sessionKey))"
+        "_scheduleRouterFxBeginScan(userDiv, _routerFxResolveLayoutSeed(_sessionKey), {"
         in send_body
     )
     assert "_routerFxBeginScan(userDiv, _routerFxResolveLayoutSeed(_sessionKey))" not in send_body
@@ -2171,6 +2263,31 @@ def test_chat_history_refresh_preserves_active_thinking_indicator() -> None:
     assert "if (_isStreaming && _isCurrentSessionThinkingIndicator(el)) return;" in render_body
 
 
+def test_chat_history_reorders_before_live_thinking_indicator() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+
+    assert "function _historyLiveTailAnchor()" in source
+    helper_start = source.index("function _historyLiveTailAnchor()")
+    helper_end = source.index("function _appendHistoryDaySeparator", helper_start)
+    helper_body = source[helper_start:helper_end]
+    assert "if (!_isStreaming) return null;" in helper_body
+    assert "if (_isCurrentSessionStreamBubble(_streamBubble)) return _streamBubble;" in helper_body
+    assert "if (_isCurrentSessionThinkingIndicator(_thinkingEl)) return _thinkingEl;" in helper_body
+
+    day_start = source.index("function _appendHistoryDaySeparator(timestamp)")
+    day_end = source.index("function _appendHistoryElementInOrder(div)", day_start)
+    day_body = source[day_start:day_end]
+    assert "const liveTail = _historyLiveTailAnchor();" in day_body
+    assert "_thread.insertBefore(sep, liveTail);" in day_body
+
+    append_start = source.index("function _appendHistoryElementInOrder(div)")
+    append_end = source.index("function _historyStableMessageIdentity", append_start)
+    append_body = source[append_start:append_end]
+    assert "const liveTail = _historyLiveTailAnchor();" in append_body
+    assert "if (liveTail && div !== liveTail)" in append_body
+    assert "_thread.insertBefore(div, liveTail);" in append_body
+
+
 def test_router_fx_strip_survives_multistep_turn() -> None:
     # History reorder moves .msg nodes. The router strip is a sibling, so the
     # root fix is to move an attached strip together with its user message
@@ -2178,7 +2295,7 @@ def test_router_fx_strip_survives_multistep_turn() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
     assert "delete settledStrip.dataset.live;" not in source
     assert "_routerFxFindAttachedStrip" not in source
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("  /* ── Send Message", history_start)
     history_body = source[history_start:history_end]
     assert "ownStrips.find((el) => el.dataset.live === 'true')" not in history_body
@@ -2216,7 +2333,7 @@ def test_router_decision_without_anchor_is_cached_for_history_replay() -> None:
     assert "_chatDiag('router_decision.cached_pending_anchor'" in source
     assert "_chatDiag('router_decision.skip.no_anchor_user'" not in handler_body
 
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("function _appendHistoryDaySeparator", history_start)
     history_body = source[history_start:history_end]
     assert "_historyHydrating = true;" in history_body
@@ -2249,7 +2366,6 @@ def test_router_fx_settled_cleanup_clears_live_animation_state() -> None:
     clear = source[clear_start:clear_end]
     assert "selector.classList.remove('visible', 'lock', 'lock-impact')" in clear
     assert ".router-fx-cell.pinging" in clear
-    assert ".router-fx-mote.is-scan" in clear
     assert ".router-fx-burst" in clear
 
     settle_start = source.index("function _settleRouterFxImmediate(wrap, winnerIdx, opts) {")
@@ -2257,12 +2373,6 @@ def test_router_fx_settled_cleanup_clears_live_animation_state() -> None:
     settle = source[settle_start:settle_end]
     assert "delete wrap.dataset.live;" in settle
     assert "delete wrap.dataset.scanning;" in settle
-
-    cloud_start = source.index("function _settleRouterFxCloud(wrap) {")
-    cloud_end = source.index("// Live rack-focus", cloud_start)
-    cloud = source[cloud_start:cloud_end]
-    assert "delete wrap.dataset.live;" in cloud
-    assert "delete wrap.dataset.scanning;" in cloud
 
 
 def test_router_fx_config_refresh_prunes_stale_model_cache() -> None:
@@ -2273,6 +2383,7 @@ def test_router_fx_config_refresh_prunes_stale_model_cache() -> None:
 
     assert "Object.keys(_routerFxModels).forEach((tier) => {" in body
     assert "if (!configTierSet.has(tier)) delete _routerFxModels[tier];" in body
+    assert "if (!configTierSet.has(tier)) delete _routerFxTierConfigs[tier];" in body
     assert "_routerFxConfigTiers = configTierSet;" in body
 
 
@@ -2307,7 +2418,7 @@ def test_done_stream_bubble_survives_until_history_persists_assistant() -> None:
     mark_marker = "_markPendingFinalizedAssistantBubble(_streamBubble, cleanedText);"
     assert end_body.index(stamp_marker) < end_body.index(mark_marker)
 
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("function _appendHistoryDaySeparator", history_start)
     history_body = source[history_start:history_end]
     assert "_chatDiag('history.empty.keep_pending_finalized_assistant'" in history_body
@@ -2430,7 +2541,7 @@ def test_router_fx_history_mode_has_no_motion_effects() -> None:
 
 def test_router_fx_history_and_turn_meta_preserve_observe_rollout_state() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    history_start = source.index("function _buildRouterFxFromUsage(usage, seedKey) {")
+    history_start = source.index("function _buildRouterFxFromUsage(usage, seedKey, opts) {")
     history_end = source.index("  /* ── RPC Event Subscriptions", history_start)
     history_body = source[history_start:history_end]
     store_start = source.index("_storeTurnMeta(_sessionKey, _metaIdx")
@@ -2444,22 +2555,21 @@ def test_router_fx_history_and_turn_meta_preserve_observe_rollout_state() -> Non
     assert "rollout_phase: u.rollout_phase || 'full'," in store_body
 
 
-def test_router_fx_mobile_grid_matches_explicit_cell_count() -> None:
-    """Mobile router-fx grid rows×cols stays in lockstep with the JS cell count.
-
-    The JS constant ``_ROUTER_FX_GRID_CELLS`` is 15 (5 cols × 3 rows on desktop);
-    mobile and tiny breakpoints collapse to 3×5 so no row ends short.
-    """
+def test_router_fx_mobile_grid_uses_dynamic_candidate_columns() -> None:
+    """Mobile router-fx grid follows actual candidate count, not a fixed wall."""
     css = CHAT_CSS.read_text(encoding="utf-8")
     mobile_start = css.index("@media (max-width: 640px)")
     tiny_start = css.index("@media (max-width: 380px)")
     mobile_body = css[mobile_start:tiny_start]
     tiny_body = css[tiny_start:]
 
-    assert "grid-template-columns: repeat(3, 1fr);" in mobile_body
-    assert "grid-template-rows: repeat(5, 28px);" in mobile_body
-    assert "grid-template-columns: repeat(3, 1fr);" in tiny_body
-    assert "grid-template-rows: repeat(5, 26px);" in tiny_body
+    assert (
+        "grid-template-columns: "
+        "repeat(var(--router-fx-mobile-cols, var(--router-fx-cols, 2)), 1fr);"
+    ) in mobile_body
+    assert "grid-template-rows: none;" in mobile_body
+    assert "grid-template-columns: repeat(var(--router-fx-mobile-cols, 2), 1fr);" in tiny_body
+    assert "grid-template-rows: none;" in tiny_body
 
 
 def test_router_fx_visualisation_pref_is_client_side_localstorage() -> None:
@@ -2555,7 +2665,7 @@ def test_router_fx_render_gated_in_both_live_and_history_paths() -> None:
     )
     assert pre_gate in handler_body
     assert post_gate in handler_body
-    assert handler_body.index("_routerFxModels[tier.toLowerCase()] = String(payload.model);") < \
+    assert handler_body.index("_routerFxRememberTierDecision(tier, payload.model || '');") < \
         handler_body.index(pre_gate)
     assert handler_body.index(pre_gate) < \
         handler_body.index("await _routerFxAwaitConfig();")
@@ -2581,7 +2691,7 @@ def test_router_fx_disable_removes_all_strips_without_live_spare_path() -> None:
         in source
     )
     assert ".router-fx:not([data-live=\"true\"])" not in source
-    history_start = source.index("async function _loadHistory() {")
+    history_start = source.index("async function _loadHistory(opts = {}) {")
     history_end = source.index("  /* ── Send Message", history_start)
     history_body = source[history_start:history_end]
     assert "if (!_routerFx.enabled) {" in history_body
@@ -2592,6 +2702,31 @@ def test_router_fx_disable_removes_all_strips_without_live_spare_path() -> None:
         in sweep
     )
     assert "dataset.live" not in sweep
+
+
+def test_router_toggle_off_immediately_stops_router_visuals() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+    start = source.index("const routerToggle = _el.querySelector('#toggle-router');")
+    end = source.index("// Router-fx visualisation toggle", start)
+    body = source[start:end]
+
+    assert "const previousRouterFeatureEnabled = _routerFeatureEnabled;" in body
+    assert "_routerFeatureEnabled = enabled;" in body
+    assert "if (!enabled) _clearRouterFxVisuals('router_disabled');" in body
+    assert "_routerFeatureEnabled = previousRouterFeatureEnabled;" in body
+    assert "_clearRouterFxVisuals('router_patch_reverted');" in body
+    assert "_scheduleHistorySync();" in body
+
+    assert "function _clearRouterFxVisuals(reason = '') {" in source
+    clear_start = source.index("function _clearRouterFxVisuals(reason = '') {")
+    clear_end = source.index("async function _finishPendingRouterFxScan", clear_start)
+    clear_body = source[clear_start:clear_end]
+    assert "_cancelPendingRouterFxScan(reason || 'clear_visuals');" in clear_body
+    assert (
+        "_thread.querySelectorAll('.router-fx').forEach((el) => "
+        "_routerFxRemoveStrip(el));"
+        in clear_body
+    )
 
 
 def test_router_fx_variant_seam_stamps_data_variant() -> None:
@@ -2632,7 +2767,7 @@ def test_router_fx_visualisation_toggle_markup_reuses_switch() -> None:
 
 def test_chat_history_replays_turn_meta_to_restore_combo_streak() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    start = source.index("async function _loadHistory() {")
+    start = source.index("async function _loadHistory(opts = {}) {")
     end = source.index("  /* ── Send Message", start)
     body = source[start:end]
 
@@ -2769,7 +2904,7 @@ def test_chat_replayed_compaction_terminal_restores_separator_without_toast() ->
     assert "if (!isReplay) {\n        UI.toast(\n          'Compact cancelled'" in body
 
 
-def test_chat_manual_terminal_compaction_separator_persists_only_when_completed() -> None:
+def test_chat_terminal_compaction_separator_persists_for_completed_manual_and_auto() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
     sync_start = source.index(
         "function _syncCompactionSeparator(payload, status, source, overrides = {})"
@@ -2779,7 +2914,7 @@ def test_chat_manual_terminal_compaction_separator_persists_only_when_completed(
 
     assert "function _compactionSeparatorAnimated(status, overrides = {})" in source
     assert "function _shouldPersistCompactionSeparator(status, source, overrides = {})" in source
-    assert "return source === 'manual' && status === 'completed';" in source
+    assert "return status === 'completed';" in source
     assert "const liveClass = _compactionSeparatorAnimated(status, overrides)" in sync_body
     assert "filter(Boolean)" in sync_body
     assert "if (_shouldPersistCompactionSeparator(status, source, overrides)) return;" in sync_body
@@ -2799,7 +2934,7 @@ def test_rpc_client_passes_event_meta_without_polluting_payload() -> None:
 
 def test_chat_history_reconciles_by_message_identity_without_clear_replace() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    start = source.index("async function _loadHistory() {")
+    start = source.index("async function _loadHistory(opts = {}) {")
     end = source.index("  /* ── Send Message", start)
     body = source[start:end]
 
@@ -2827,17 +2962,15 @@ def test_chat_history_reconciles_by_message_identity_without_clear_replace() -> 
 
 def test_chat_history_reorders_reused_nodes_to_match_transcript_order() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    start = source.index("async function _loadHistory() {")
+    start = source.index("async function _loadHistory(opts = {}) {")
     end = source.index("  /* ── Send Message", start)
     body = source[start:end]
 
     assert "_thread.querySelectorAll('.chat-day-sep').forEach((el) => el.remove());" in body
     assert "function _appendHistoryElementInOrder(div)" in source
-    assert (
-        "if (_isStreaming && _isCurrentSessionStreamBubble(_streamBubble) "
-        "&& div !== _streamBubble)"
-    ) in source
-    assert "_thread.insertBefore(div, _streamBubble);" in source
+    assert "const liveTail = _historyLiveTailAnchor();" in source
+    assert "if (liveTail && div !== liveTail)" in source
+    assert "_thread.insertBefore(div, liveTail);" in source
     assert "_thread.appendChild(div);" in source
     stamp_idx = body.index(
         "_stampHistoryElement(div, stableIdentity, msg.role, displayText, "
@@ -2916,6 +3049,36 @@ def test_chat_history_replacement_preserves_message_body_rendering() -> None:
     assert visible_text_assignment in render_body
     assert markdown_render in render_body
     assert "Markdown.bindHighlight(body);" in render_body
+
+
+def test_chat_history_replacement_rebuilds_role_header() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+    assert "function _syncMessageHeader(div, displayRole, timestamp, options = {}) {" in source
+
+    helper_start = source.index(
+        "function _syncMessageHeader(div, displayRole, timestamp, options = {}) {"
+    )
+    helper_end = source.index("function _replaceHistoryMessage", helper_start)
+    helper_body = source[helper_start:helper_end]
+    assert "const existing = div.querySelector(':scope > .msg-header');" in helper_body
+    assert "_displayRoleLabel(displayRole)" in helper_body
+    assert "_renderMessageTags(options)" in helper_body
+    assert "div.insertBefore(header, div.firstChild);" in helper_body
+    assert "if (sameGroup) {" in helper_body
+    assert "if (existing) existing.remove();" in helper_body
+
+    replace_start = source.index("function _replaceHistoryMessage")
+    replace_end = source.index("  function _replaceStreamText", replace_start)
+    replace_body = source[replace_start:replace_end]
+    assert (
+        "_syncMessageHeader(div, displayRole, options.timestamp || null, options);"
+        in replace_body
+    )
+
+    history_start = source.index("const msgOptions = {")
+    history_end = source.index("_messages.push({", history_start)
+    history_body = source[history_start:history_end]
+    assert "timestamp: msg.timestamp || msg.ts || null," in history_body
 
 
 def test_chat_streaming_text_strips_generated_artifact_markers() -> None:

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -834,7 +834,7 @@ async def test_start_gateway_server_wires_meta_skill_auto_propose_routes(
         },
         squilla_router={
             "tiers": {
-                "t3": {
+                "c3": {
                     "model": "frontier-t3-model",
                     "thinking_level": "high",
                 },
@@ -855,7 +855,7 @@ async def test_start_gateway_server_wires_meta_skill_auto_propose_routes(
         assert runtime_contexts[-1]["skill_loader"] is server._services.skill_loader
         base_config = runtime_contexts[-1]["base_config"]
         assert base_config.model_id == "frontier-t3-model"
-        assert base_config.metadata["routed_tier"] == "t3"
+        assert base_config.metadata["routed_tier"] == "c3"
         assert base_config.metadata["thinking_level"] == "high"
         assert runtime_contexts[-1]["baseline_model"] == "frontier-t3-model"
         with pytest.raises(RuntimeError):

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -162,9 +162,9 @@ async def test_router_configure_accepts_tier_overrides_and_syncs_llm_model(
         "onboarding.router.configure",
         {
             "mode": "recommended",
-            "defaultTier": "t2",
+            "defaultTier": "c2",
             "tiers": {
-                "t2": {"provider": "openai", "model": "gpt-5.5-custom"},
+                "c2": {"provider": "openai", "model": "gpt-5.5-custom"},
                 "image_model": {
                     "provider": "openai",
                     "model": "gpt-5.4-mini",
@@ -177,11 +177,50 @@ async def test_router_configure_accepts_tier_overrides_and_syncs_llm_model(
 
     assert res.error is None, res.error
     assert ctx.config.llm.model == "gpt-5.5-custom"
-    assert ctx.config.squilla_router.default_tier == "t2"
+    assert ctx.config.squilla_router.default_tier == "c2"
     persisted = tomllib.loads((tmp_path / "c.toml").read_text())
     assert persisted["llm"]["model"] == "gpt-5.5-custom"
-    assert persisted["squilla_router"]["tiers"]["t2"]["model"] == "gpt-5.5-custom"
+    assert persisted["squilla_router"]["tiers"]["c2"]["model"] == "gpt-5.5-custom"
     assert persisted["squilla_router"]["tiers"]["image_model"]["supports_image"] is True
+
+
+@pytest.mark.asyncio
+async def test_router_configure_persists_image_model_as_image_capable(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(tmp_path / "c.toml"))
+    from opensquilla.gateway.config import GatewayConfig
+
+    ctx = _admin_ctx()
+    ctx.config = GatewayConfig(llm={"provider": "openrouter", "model": "z-ai/glm-5.1"})
+    ctx.config.config_path = str(tmp_path / "c.toml")
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.router.configure",
+        {
+            "mode": "openrouter-mix",
+            "defaultTier": "t1",
+            "tiers": {
+                "image_model": {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-opus-4.7",
+                    "supportsImage": False,
+                },
+            },
+        },
+        ctx,
+    )
+
+    assert res.error is None, res.error
+    persisted = tomllib.loads((tmp_path / "c.toml").read_text())
+    image_tier = persisted["squilla_router"]["tiers"]["image_model"]
+    assert image_tier["model"] == "anthropic/claude-opus-4.7"
+    assert image_tier["supports_image"] is True
+    assert image_tier["image_only"] is True
+    assert ctx.config.squilla_router.tiers["image_model"]["supports_image"] is True
+    assert ctx.config.squilla_router.tiers["image_model"]["image_only"] is True
 
 
 @pytest.mark.asyncio
@@ -317,6 +356,27 @@ async def test_channel_upsert_rejects_slack_webhook_without_signing_secret(tmp_p
 
     assert res.error is not None
     assert "signing_secret" in res.error.message
+
+
+@pytest.mark.asyncio
+async def test_channel_upsert_rejects_slack_socket_without_app_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(tmp_path / "c.toml"))
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.channel.upsert",
+        {
+            "entry": {
+                "type": "slack",
+                "name": "w",
+                "token": "supersecret",
+                "connection_mode": "socket",
+            }
+        },
+        _admin_ctx(),
+    )
+
+    assert res.error is not None
+    assert "app_token" in res.error.message
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_rpc_skills_install_visibility.py
+++ b/tests/test_gateway/test_rpc_skills_install_visibility.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -8,63 +9,169 @@ from opensquilla.gateway import rpc_skills
 from opensquilla.gateway.rpc import RpcContext
 from opensquilla.skills.hub.installer import InstallResult
 from opensquilla.skills.loader import SkillLoader
+from opensquilla.skills.types import SkillLayer, SkillPlatformMeta, SkillRequires, SkillSpec
 
 
-@pytest.mark.asyncio
-async def test_rpc_skill_install_uses_loader_managed_dir_and_list_sees_skill(
+def test_rpc_skill_install_uses_loader_managed_dir_and_list_sees_skill(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    managed_dir = tmp_path / "managed"
-    loader = SkillLoader(managed_dir=managed_dir, snapshot_path=tmp_path / "snapshot.json")
-    ctx = RpcContext(conn_id="test", skill_loader=loader)
-    captured: dict[str, Path | None] = {}
+    async def run() -> None:
+        managed_dir = tmp_path / "managed"
+        loader = SkillLoader(
+            managed_dir=managed_dir,
+            snapshot_path=tmp_path / "snapshot.json",
+        )
+        ctx = RpcContext(conn_id="test", skill_loader=loader)
+        captured: dict[str, Path | None] = {}
 
-    class FakeInstaller:
-        def __init__(self, managed_dir: Path) -> None:
-            self.managed_dir = managed_dir
+        class FakeInstaller:
+            def __init__(self, managed_dir: Path) -> None:
+                self.managed_dir = managed_dir
 
-        async def install(
-            self,
-            identifier: str,
-            source_id: str,
-            force: bool = False,
-        ) -> InstallResult:
-            skill_dir = self.managed_dir / identifier
-            skill_dir.mkdir(parents=True)
-            (skill_dir / "SKILL.md").write_text(
-                "---\n"
-                f"name: {identifier}\n"
-                "description: Installed from chat\n"
-                "---\n"
-                "Installed body.\n",
-                encoding="utf-8",
-            )
-            return InstallResult(
-                success=True,
-                name=identifier,
-                message="installed",
-                path=str(skill_dir),
-            )
+            async def install(
+                self,
+                identifier: str,
+                source_id: str,
+                force: bool = False,
+            ) -> InstallResult:
+                skill_dir = self.managed_dir / identifier
+                skill_dir.mkdir(parents=True)
+                (skill_dir / "SKILL.md").write_text(
+                    "---\n"
+                    f"name: {identifier}\n"
+                    "description: Installed from chat\n"
+                    "---\n"
+                    "Installed body.\n",
+                    encoding="utf-8",
+                )
+                return InstallResult(
+                    success=True,
+                    name=identifier,
+                    message="installed",
+                    path=str(skill_dir),
+                )
 
-    def fake_builder(*, managed_dir: Path | None = None) -> FakeInstaller:
-        assert managed_dir is not None
-        captured["managed_dir"] = managed_dir
-        return FakeInstaller(managed_dir)
+        def fake_builder(*, managed_dir: Path | None = None) -> FakeInstaller:
+            assert managed_dir is not None
+            captured["managed_dir"] = managed_dir
+            return FakeInstaller(managed_dir)
 
-    monkeypatch.setattr(rpc_skills, "build_default_skill_installer", fake_builder)
-    assert await rpc_skills._handle_skills_list(None, ctx) == {"skills": []}
-    assert loader._cached is not None
+        monkeypatch.setattr(rpc_skills, "build_default_skill_installer", fake_builder)
+        assert await rpc_skills._handle_skills_list(None, ctx) == {"skills": []}
+        assert loader._cached is not None
 
-    installed = await rpc_skills._handle_skills_install(
-        {"identifier": "plotter", "source": "clawhub"},
-        ctx,
+        installed = await rpc_skills._handle_skills_install(
+            {"identifier": "plotter", "source": "clawhub"},
+            ctx,
+        )
+        listed = await rpc_skills._handle_skills_list(None, ctx)
+
+        assert captured["managed_dir"] == managed_dir
+        assert installed["success"] is True
+        assert Path(installed["path"]).name == "plotter"
+        row = next(skill for skill in listed["skills"] if skill["name"] == "plotter")
+        assert row["layer"] == "managed"
+        assert row["description"] == "Installed from chat"
+
+    asyncio.run(run())
+
+
+def test_skill_payload_rolls_up_meta_subskill_requirements() -> None:
+    python_skill = SkillSpec(
+        name="docx",
+        description="Docx export",
+        layer=SkillLayer.BUNDLED,
+        always=False,
+        triggers=[],
+        content="",
+        metadata=SkillPlatformMeta(requires=SkillRequires(any_bins=["python", "python3"])),
     )
-    listed = await rpc_skills._handle_skills_list(None, ctx)
+    ffmpeg_skill = SkillSpec(
+        name="video-merger",
+        description="Video merge",
+        layer=SkillLayer.BUNDLED,
+        always=False,
+        triggers=[],
+        content="",
+        metadata=SkillPlatformMeta(requires=SkillRequires(bins=["ffmpeg", "ffprobe"])),
+    )
+    meta_skill = SkillSpec(
+        name="meta-demo",
+        description="Meta demo",
+        layer=SkillLayer.BUNDLED,
+        always=False,
+        triggers=[],
+        content="",
+        kind="meta",
+        composition_raw={
+            "steps": [
+                {"id": "export", "kind": "skill_exec", "skill": "docx"},
+                {"id": "merge", "kind": "skill_exec", "skill": "video-merger"},
+            ]
+        },
+    )
 
-    assert captured["managed_dir"] == managed_dir
-    assert installed["success"] is True
-    assert Path(installed["path"]).name == "plotter"
-    row = next(skill for skill in listed["skills"] if skill["name"] == "plotter")
-    assert row["layer"] == "managed"
-    assert row["description"] == "Installed from chat"
+    ctx = rpc_skills.EligibilityContext.auto()
+    ctx.has_bin_cache.update(
+        {"python": True, "python3": True, "ffmpeg": False, "ffprobe": False}
+    )
+    skill_index = {s.name: s for s in (meta_skill, python_skill, ffmpeg_skill)}
+    payload = rpc_skills._skill_to_dict(
+        meta_skill,
+        rpc_skills.diagnose_eligibility(meta_skill, ctx),
+        ctx.os_name,
+        skill_index=skill_index,
+        eligibility_ctx=ctx,
+    )
+
+    assert payload["requirements"]["summary"] == "needs_setup"
+    assert payload["requirements"]["items"] == [
+        {
+            "name": "docx",
+            "source": "sub_skill",
+            "status": "ready",
+            "requires_bins": [],
+            "requires_any_bins": ["python", "python3"],
+            "requires_env": [],
+            "missing_bins": [],
+            "missing_env": [],
+        },
+        {
+            "name": "video-merger",
+            "source": "sub_skill",
+            "status": "needs_setup",
+            "requires_bins": ["ffmpeg", "ffprobe"],
+            "requires_any_bins": [],
+            "requires_env": [],
+            "missing_bins": ["ffmpeg", "ffprobe"],
+            "missing_env": [],
+        },
+    ]
+
+
+def test_meta_paper_write_declares_pdf_compile_binaries() -> None:
+    bundled = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "opensquilla"
+        / "skills"
+        / "bundled"
+    )
+    loader = SkillLoader(bundled_dir=bundled)
+    skills = loader.load_all()
+    skill_index = {skill.name: skill for skill in skills}
+    ctx = rpc_skills.EligibilityContext.auto()
+    spec = skill_index["meta-paper-write"]
+    payload = rpc_skills._skill_to_dict(
+        spec,
+        rpc_skills.diagnose_eligibility(spec, ctx),
+        ctx.os_name,
+        skill_index=skill_index,
+        eligibility_ctx=ctx,
+    )
+
+    own_requirements = next(
+        item for item in payload["requirements"]["items"] if item["source"] == "self"
+    )
+    assert own_requirements["requires_bins"] == ["xelatex", "bibtex"]

--- a/tests/test_gateway/test_skills_view_static.py
+++ b/tests/test_gateway/test_skills_view_static.py
@@ -35,6 +35,21 @@ def test_skill_detail_dialog_shows_full_description_for_touch_users() -> None:
     assert "_truncDesc" not in source
 
 
+def test_skill_detail_dialog_surfaces_requirements_rollup() -> None:
+    source = SKILLS_JS.read_text(encoding="utf-8")
+    dialog_start = source.index("function _openSkillDialog(skill)")
+    dialog_end = source.index("  async function _installDeps", dialog_start)
+    dialog_body = source[dialog_start:dialog_end]
+
+    assert "function _renderRequirements" in source
+    assert "skill.requirements" in dialog_body
+    assert "Requirements" in source
+    assert "requirementsHtml" in dialog_body
+    assert "${requirementsHtml}" in dialog_body
+    assert "${compositionHtml}" in dialog_body
+    assert dialog_body.index("${compositionHtml}") < dialog_body.index("${requirementsHtml}")
+
+
 def test_skills_primary_controls_keep_touch_friendly_hit_areas() -> None:
     css = SKILLS_CSS.read_text(encoding="utf-8")
 

--- a/tests/test_gateway/test_static_onboarding_views.py
+++ b/tests/test_gateway/test_static_onboarding_views.py
@@ -85,6 +85,15 @@ def test_setup_view_is_available_and_uses_canonical_cli_fallbacks():
     assert "Connected" in txt
 
 
+def test_setup_view_locks_image_model_image_support():
+    txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
+
+    assert "const isImageModel = name === 'image_model';" in txt
+    assert "isImageModel ? ' checked disabled' :" in txt
+    assert "tier.supportsImage = true;" in txt
+    assert "tier.image_only = true;" in txt
+
+
 def test_setup_finish_cli_commands_target_active_config_path():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
     start = txt.index("function _renderFinishStep()")
@@ -725,8 +734,8 @@ def test_setup_router_controls_use_user_facing_labels():
     txt = (VIEWS / "setup.js").read_text(encoding="utf-8")
     assert "SquillaRouter" in txt
     assert "OpenRouter mix" not in txt
-    assert "Balanced default (t1)" in txt
-    assert "Stronger reasoning (t2)" in txt
+    assert "Route c1" in txt
+    assert "Route c2" in txt
 
 
 def test_setup_view_preserves_unsaved_form_values_across_step_navigation():

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -7,7 +7,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v0.3.0"
+CURRENT_RELEASE_TAG = "v0.3.1"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_live_provider_profile_gateway_e2e.py
+++ b/tests/test_live_provider_profile_gateway_e2e.py
@@ -55,9 +55,9 @@ def test_debugging_case_is_bounded_to_keep_marker_in_smoke_budget() -> None:
 
 
 def test_case_markers_are_stable_text_not_millisecond_numbers() -> None:
-    marker = e2e._case_marker("openrouter", "t2", "coverage_t2")
+    marker = e2e._case_marker("openrouter", "c2", "coverage_t2")
 
-    assert marker == "E2E_OPENROUTER_T2_COVERAGE_T2"
+    assert marker == "E2E_OPENROUTER_C2_COVERAGE_T2"
     assert not marker.rsplit("_", 1)[-1].isdigit()
 
 
@@ -80,14 +80,14 @@ def test_live_gateway_profile_config_bounds_agent_runtime(tmp_path: Path) -> Non
 
 def test_profile_slot_targets_cover_slots_not_unique_models() -> None:
     tiers = {
-        "t0": {"provider": "deepseek", "model": "deepseek-v4-flash"},
-        "t1": {
+        "c0": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        "c1": {
             "provider": "deepseek",
             "model": "deepseek-v4-flash",
             "thinking_level": "low",
         },
-        "t2": {"provider": "deepseek", "model": "deepseek-v4-pro"},
-        "t3": {
+        "c2": {"provider": "deepseek", "model": "deepseek-v4-pro"},
+        "c3": {
             "provider": "deepseek",
             "model": "deepseek-v4-pro",
             "thinking_level": "high",
@@ -97,53 +97,53 @@ def test_profile_slot_targets_cover_slots_not_unique_models() -> None:
 
     targets = e2e._profile_slot_targets(tiers)
 
-    assert list(targets) == ["t0", "t1", "t2", "t3"]
-    assert targets["t0"]["model"] == targets["t1"]["model"]
-    assert targets["t1"]["thinking_level"] == "low"
+    assert list(targets) == ["c0", "c1", "c2", "c3"]
+    assert targets["c0"]["model"] == targets["c1"]["model"]
+    assert targets["c1"]["thinking_level"] == "low"
 
 
 def test_forced_tier_overrides_make_only_target_slot_text_routable() -> None:
     tiers = {
-        "t0": {"provider": "deepseek", "model": "deepseek-v4-flash"},
-        "t1": {"provider": "deepseek", "model": "deepseek-v4-flash"},
-        "t2": {"provider": "deepseek", "model": "deepseek-v4-pro"},
-        "t3": {"provider": "deepseek", "model": "deepseek-v4-pro"},
+        "c0": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        "c1": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        "c2": {"provider": "deepseek", "model": "deepseek-v4-pro"},
+        "c3": {"provider": "deepseek", "model": "deepseek-v4-pro"},
     }
 
-    overrides = e2e._forced_tier_overrides_for_slot(tiers, "t2")
+    overrides = e2e._forced_tier_overrides_for_slot(tiers, "c2")
 
-    assert overrides["t2"]["image_only"] is False
-    assert overrides["t2"]["model"] == "deepseek-v4-pro"
-    assert overrides["t0"]["image_only"] is True
-    assert overrides["t1"]["image_only"] is True
-    assert overrides["t3"]["image_only"] is True
+    assert overrides["c2"]["image_only"] is False
+    assert overrides["c2"]["model"] == "deepseek-v4-pro"
+    assert overrides["c0"]["image_only"] is True
+    assert overrides["c1"]["image_only"] is True
+    assert overrides["c3"]["image_only"] is True
 
 
 def test_missing_profile_slots_are_computed_by_slot() -> None:
     tiers = {
-        "t0": {"provider": "deepseek", "model": "deepseek-v4-flash"},
-        "t1": {"provider": "deepseek", "model": "deepseek-v4-flash"},
-        "t2": {"provider": "deepseek", "model": "deepseek-v4-pro"},
-        "t3": {"provider": "deepseek", "model": "deepseek-v4-pro"},
+        "c0": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        "c1": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        "c2": {"provider": "deepseek", "model": "deepseek-v4-pro"},
+        "c3": {"provider": "deepseek", "model": "deepseek-v4-pro"},
     }
     rows = [
         {
             "ok": True,
-            "expected_slot": "t0",
-            "actual_slot_covered": "t0",
+            "expected_slot": "c0",
+            "actual_slot_covered": "c0",
             "expected_model": "deepseek-v4-flash",
             "actual_request_model": "deepseek-v4-flash",
         },
         {
             "ok": True,
-            "expected_slot": "t2",
-            "actual_slot_covered": "t2",
+            "expected_slot": "c2",
+            "actual_slot_covered": "c2",
             "expected_model": "deepseek-v4-pro",
             "actual_request_model": "deepseek-v4-pro",
         },
     ]
 
-    assert e2e._missing_profile_slots(tiers, rows) == ["t1", "t3"]
+    assert e2e._missing_profile_slots(tiers, rows) == ["c1", "c3"]
 
 
 def test_cost_summary_never_promotes_gateway_placeholder_to_provider_bill() -> None:
@@ -178,7 +178,7 @@ def test_router_step_is_extracted_from_decision_log() -> None:
             {"step_name": "resolve_model", "routed_tier": None},
             {
                 "step_name": "apply_squilla_router",
-                "routed_tier": "t2",
+                "routed_tier": "c2",
                 "routing_source": "v4_phase3",
                 "confidence": 0.91,
             },
@@ -187,6 +187,6 @@ def test_router_step_is_extracted_from_decision_log() -> None:
 
     step = e2e._router_step_from_decision(decision)
 
-    assert step["routed_tier"] == "t2"
+    assert step["routed_tier"] == "c2"
     assert step["routing_source"] == "v4_phase3"
     assert step["confidence"] == 0.91

--- a/tests/test_memory_dream_factory.py
+++ b/tests/test_memory_dream_factory.py
@@ -37,7 +37,7 @@ def test_dream_provider_follows_llm_model_when_router_disabled() -> None:
     assert primary.model == "user/custom-model"
 
 
-def test_dream_provider_uses_router_t1_model_when_router_active() -> None:
+def test_dream_provider_uses_legacy_router_default_alias_when_router_active() -> None:
     config = GatewayConfig(
         llm={
             "provider": "openrouter",
@@ -61,6 +61,8 @@ def test_dream_provider_uses_router_t1_model_when_router_active() -> None:
     primary = _primary_config(selector)
     assert primary.provider == "openrouter"
     assert primary.model == "router/t1-model"
+    assert config.squilla_router.default_tier == "c1"
+    assert "c1" in config.squilla_router.tiers
 
 
 def test_dream_rejects_dream_specific_model_override() -> None:

--- a/tests/test_model_router_behavior.py
+++ b/tests/test_model_router_behavior.py
@@ -139,7 +139,7 @@ async def test_full_rollout_applies_routed_model_thinking_and_p0_prompt(
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.91,
         {
             "route_class": "R1",
@@ -153,7 +153,7 @@ async def test_full_rollout_applies_routed_model_thinking_and_p0_prompt(
     routed = await apply_squilla_router(ctx)
 
     assert routed.model == "deepseek/deepseek-v4-pro"
-    assert routed.metadata["routed_tier"] == "t1"
+    assert routed.metadata["routed_tier"] == "c1"
     assert routed.metadata["routed_model"] == "deepseek/deepseek-v4-pro"
     assert routed.metadata["routing_applied"] is True
     assert routed.metadata["applied_model"] == "deepseek/deepseek-v4-pro"
@@ -176,7 +176,7 @@ async def test_router_reports_provider_state_loss_without_changing_route(
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.91,
         {
             "route_class": "R1",
@@ -217,7 +217,7 @@ async def test_router_continuity_diagnostic_ignores_expired_provider_state(
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.91,
         {
             "route_class": "R1",
@@ -261,7 +261,7 @@ async def test_p2_prompt_hint_is_recorded_but_not_injected(
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t3",
+        "c3",
         0.97,
         {
             "route_class": "R3",
@@ -275,7 +275,7 @@ async def test_p2_prompt_hint_is_recorded_but_not_injected(
     routed = await apply_squilla_router(ctx)
 
     assert routed.model == "anthropic/claude-opus-4.7"
-    assert routed.metadata["routed_tier"] == "t3"
+    assert routed.metadata["routed_tier"] == "c3"
     assert routed.metadata["thinking_level"] == "high"
     assert routed.metadata["prompt_policy"] == "P2"
     assert routed.metadata["routing_extra"]["prompt_hint"] == "Use a careful plan before answering."
@@ -288,7 +288,7 @@ async def test_v4_thinking_mode_overrides_explicit_tier_thinking_level(
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.92,
         {
             "route_class": "R2",
@@ -300,7 +300,7 @@ async def test_v4_thinking_mode_overrides_explicit_tier_thinking_level(
 
     routed = await apply_squilla_router(ctx)
 
-    assert routed.metadata["routed_tier"] == "t2"
+    assert routed.metadata["routed_tier"] == "c2"
     assert routed.metadata["thinking_mode"] == "T2"
     assert routed.metadata["thinking_requested"] is True
     assert routed.metadata["thinking_level"] == "medium"
@@ -312,7 +312,7 @@ async def test_confidence_gate_promotes_low_confidence_t0_to_default_t1_and_reco
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t0",
+        "c0",
         0.1,
         {
             "route_class": "R0",
@@ -325,11 +325,11 @@ async def test_confidence_gate_promotes_low_confidence_t0_to_default_t1_and_reco
     routed = await apply_squilla_router(ctx)
     extra = routed.metadata["routing_extra"]
 
-    assert routed.metadata["routed_tier"] == "t1"
+    assert routed.metadata["routed_tier"] == "c1"
     assert routed.model == "deepseek/deepseek-v4-pro"
     assert extra["confidence_gate_applied"] is True
-    assert extra["base_tier"] == "t0"
-    assert extra["final_tier"] == "t1"
+    assert extra["base_tier"] == "c0"
+    assert extra["final_tier"] == "c1"
     assert routed.metadata["thinking_mode"] == "T1"
     assert routed.metadata["thinking_level"] == "low"
     assert "[RESPONSE_POLICY: Answer directly" in routed.message
@@ -341,7 +341,7 @@ async def test_confidence_gate_falls_back_low_confidence_non_default_text_tier(
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.1,
         {
             "route_class": "R2",
@@ -354,18 +354,18 @@ async def test_confidence_gate_falls_back_low_confidence_non_default_text_tier(
     routed = await apply_squilla_router(ctx)
     extra = routed.metadata["routing_extra"]
 
-    assert routed.metadata["routed_tier"] == "t1"
+    assert routed.metadata["routed_tier"] == "c1"
     assert routed.model == "deepseek/deepseek-v4-pro"
     assert extra["confidence_gate_applied"] is True
-    assert extra["pre_confidence_tier"] == "t2"
-    assert extra["final_tier"] == "t1"
+    assert extra["pre_confidence_tier"] == "c2"
+    assert extra["final_tier"] == "c1"
 
 
 @pytest.mark.asyncio
 async def test_large_material_estimate_floors_low_router_tier(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    fake_strategy(monkeypatch, "t1", 0.91, {"route_class": "R1"})
+    fake_strategy(monkeypatch, "c1", 0.91, {"route_class": "R1"})
     ctx = make_context("Please process the attached pasted text.")
     ctx.metadata["input_normalization"] = {
         "guard_action": "generated_text_attachment",
@@ -375,18 +375,18 @@ async def test_large_material_estimate_floors_low_router_tier(
 
     routed = await apply_squilla_router(ctx)
 
-    assert routed.metadata["routed_tier"] == "t2"
+    assert routed.metadata["routed_tier"] == "c2"
     assert routed.metadata["routing_source"] == "large_context_floor"
-    assert routed.metadata["large_context_floor_from_tier"] == "t1"
+    assert routed.metadata["large_context_floor_from_tier"] == "c1"
     assert routed.metadata["large_context_material_tokens"] == 45_000
-    assert routed.metadata["routing_extra"]["final_tier"] == "t2"
+    assert routed.metadata["routing_extra"]["final_tier"] == "c2"
 
 
 @pytest.mark.asyncio
 async def test_large_material_ratio_floors_low_router_tier_to_t3(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    fake_strategy(monkeypatch, "t1", 0.91, {"route_class": "R1"})
+    fake_strategy(monkeypatch, "c1", 0.91, {"route_class": "R1"})
     ctx = make_context("Please process the attached pasted text.")
     object.__setattr__(ctx.config.squilla_router, "context_window_tokens", 100_000)
     ctx.metadata["input_normalization"] = {
@@ -396,9 +396,9 @@ async def test_large_material_ratio_floors_low_router_tier_to_t3(
 
     routed = await apply_squilla_router(ctx)
 
-    assert routed.metadata["routed_tier"] == "t3"
+    assert routed.metadata["routed_tier"] == "c3"
     assert routed.metadata["routing_source"] == "large_context_floor"
-    assert routed.metadata["large_context_floor_from_tier"] == "t1"
+    assert routed.metadata["large_context_floor_from_tier"] == "c1"
     assert routed.metadata["large_context_material_tokens"] == 40_000
 
 
@@ -409,7 +409,7 @@ async def test_anti_downgrade_keeps_recent_higher_tier_despite_confidence_gate(
     ctx1 = make_context("Hard first turn.", session_key="test-confidence-history")
     fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.9,
         {
             "route_class": "R2",
@@ -418,11 +418,11 @@ async def test_anti_downgrade_keeps_recent_higher_tier_despite_confidence_gate(
         },
     )
     routed1 = await apply_squilla_router(ctx1)
-    assert routed1.metadata["routed_tier"] == "t2"
+    assert routed1.metadata["routed_tier"] == "c2"
 
     fake_strategy(
         monkeypatch,
-        "t0",
+        "c0",
         0.1,
         {
             "route_class": "R0",
@@ -435,17 +435,17 @@ async def test_anti_downgrade_keeps_recent_higher_tier_despite_confidence_gate(
     routed2 = await apply_squilla_router(ctx2)
     extra = routed2.metadata["routing_extra"]
 
-    assert routed2.metadata["routed_tier"] == "t2"
+    assert routed2.metadata["routed_tier"] == "c2"
     assert routed2.model == "z-ai/glm-5.1"
     assert extra["confidence_gate_applied"] is True
-    assert extra["pre_confidence_tier"] == "t0"
-    assert extra["final_tier"] == "t2"
+    assert extra["pre_confidence_tier"] == "c0"
+    assert extra["final_tier"] == "c2"
     assert extra["anti_downgrade_applied"] is True
-    assert extra["previous_tier"] == "t2"
+    assert extra["previous_tier"] == "c2"
 
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.9,
         {
             "route_class": "R1",
@@ -458,11 +458,11 @@ async def test_anti_downgrade_keeps_recent_higher_tier_despite_confidence_gate(
     routed3 = await apply_squilla_router(ctx3)
     extra3 = routed3.metadata["routing_extra"]
 
-    assert routed3.metadata["routed_tier"] == "t2"
+    assert routed3.metadata["routed_tier"] == "c2"
     assert routed3.model == "z-ai/glm-5.1"
     assert extra3["confidence_gate_applied"] is False
     assert extra3["anti_downgrade_applied"] is True
-    assert extra3["previous_tier"] == "t2"
+    assert extra3["previous_tier"] == "c2"
 
 
 @pytest.mark.asyncio
@@ -472,7 +472,7 @@ async def test_anti_downgrade_uses_previous_turn_not_window_highest(
     session_key = "test-previous-not-highest"
     fake_strategy(
         monkeypatch,
-        "t3",
+        "c3",
         0.9,
         {
             "route_class": "R3",
@@ -481,13 +481,13 @@ async def test_anti_downgrade_uses_previous_turn_not_window_highest(
         },
     )
     routed1 = await apply_squilla_router(make_context("Very hard turn.", session_key=session_key))
-    assert routed1.metadata["routed_tier"] == "t3"
+    assert routed1.metadata["routed_tier"] == "c3"
 
     ctx2 = make_context("Less hard turn.", session_key=session_key)
     ctx2.config.squilla_router.kv_cache_anti_downgrade_enabled = False
     fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.9,
         {
             "route_class": "R2",
@@ -496,12 +496,12 @@ async def test_anti_downgrade_uses_previous_turn_not_window_highest(
         },
     )
     routed2 = await apply_squilla_router(ctx2)
-    assert routed2.metadata["routed_tier"] == "t2"
+    assert routed2.metadata["routed_tier"] == "c2"
 
     ctx3 = make_context("Easy follow-up.", session_key=session_key)
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.9,
         {
             "route_class": "R1",
@@ -512,10 +512,10 @@ async def test_anti_downgrade_uses_previous_turn_not_window_highest(
     routed3 = await apply_squilla_router(ctx3)
     extra3 = routed3.metadata["routing_extra"]
 
-    assert routed3.metadata["routed_tier"] == "t2"
+    assert routed3.metadata["routed_tier"] == "c2"
     assert routed3.model == "z-ai/glm-5.1"
     assert extra3["anti_downgrade_applied"] is True
-    assert extra3["previous_tier"] == "t2"
+    assert extra3["previous_tier"] == "c2"
 
 
 @pytest.mark.asyncio
@@ -525,7 +525,7 @@ async def test_anti_downgrade_keeps_previous_high_tier_without_margin_gate(
     session_key = "test-anti-downgrade-ignore-margin"
     fake_strategy(
         monkeypatch,
-        "t3",
+        "c3",
         0.95,
         {
             "route_class": "R3",
@@ -537,11 +537,11 @@ async def test_anti_downgrade_keeps_previous_high_tier_without_margin_gate(
     routed1 = await apply_squilla_router(
         make_context("Architecture review.", session_key=session_key)
     )
-    assert routed1.metadata["routed_tier"] == "t3"
+    assert routed1.metadata["routed_tier"] == "c3"
 
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.99,
         {
             "route_class": "R1",
@@ -553,10 +553,10 @@ async def test_anti_downgrade_keeps_previous_high_tier_without_margin_gate(
     routed2 = await apply_squilla_router(make_context("Follow-up.", session_key=session_key))
     extra = routed2.metadata["routing_extra"]
 
-    assert routed2.metadata["routed_tier"] == "t3"
+    assert routed2.metadata["routed_tier"] == "c3"
     assert routed2.model == "anthropic/claude-opus-4.7"
     assert extra["anti_downgrade_applied"] is True
-    assert extra["previous_tier"] == "t3"
+    assert extra["previous_tier"] == "c3"
     assert extra["kv_cache_window_seconds"] == 600
 
 
@@ -566,7 +566,7 @@ async def test_complaint_upgrade_promotes_tier_thinking_and_blocks_compressed_pr
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.9,
         {
             "route_class": "R1",
@@ -579,7 +579,7 @@ async def test_complaint_upgrade_promotes_tier_thinking_and_blocks_compressed_pr
     routed = await apply_squilla_router(ctx)
     extra = routed.metadata["routing_extra"]
 
-    assert routed.metadata["routed_tier"] == "t2"
+    assert routed.metadata["routed_tier"] == "c2"
     assert routed.model == "z-ai/glm-5.1"
     assert extra["complaint_detected"] is True
     assert extra["complaint_upgrade_applied"] is True
@@ -596,7 +596,7 @@ async def test_complaint_upgrade_starts_from_previous_experienced_tier(
     session_key = "test-complaint-upgrade-previous-tier"
     fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.9,
         {
             "route_class": "R2",
@@ -607,11 +607,11 @@ async def test_complaint_upgrade_starts_from_previous_experienced_tier(
     routed1 = await apply_squilla_router(
         make_context("Analyze this tricky failure.", session_key=session_key)
     )
-    assert routed1.metadata["routed_tier"] == "t2"
+    assert routed1.metadata["routed_tier"] == "c2"
 
     fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.9,
         {
             "route_class": "R1",
@@ -622,9 +622,9 @@ async def test_complaint_upgrade_starts_from_previous_experienced_tier(
     routed2 = await apply_squilla_router(make_context("答非所问", session_key=session_key))
     extra = routed2.metadata["routing_extra"]
 
-    assert routed2.metadata["routed_tier"] == "t3"
+    assert routed2.metadata["routed_tier"] == "c3"
     assert routed2.model == "anthropic/claude-opus-4.7"
-    assert extra["previous_tier"] == "t2"
+    assert extra["previous_tier"] == "c2"
     assert extra["complaint_detected"] is True
     assert extra["complaint_upgrade_applied"] is True
     assert extra["anti_downgrade_applied"] is False
@@ -636,7 +636,7 @@ async def test_router_classifies_raw_semantic_input_but_injects_prompt_into_disp
 ) -> None:
     strategy = fake_strategy(
         monkeypatch,
-        "t0",
+        "c0",
         0.92,
         {
             "route_class": "R0",
@@ -652,7 +652,7 @@ async def test_router_classifies_raw_semantic_input_but_injects_prompt_into_disp
     routed = await apply_squilla_router(ctx)
 
     assert strategy.messages == ["Summarize the underlying user input."]
-    assert routed.metadata["routed_tier"] == "t0"
+    assert routed.metadata["routed_tier"] == "c0"
     assert routed.metadata["prompt_policy"] == "P0"
     assert routed.message.startswith("Displayed prompt wrapper")
     assert "Summarize the underlying user input." not in routed.message
@@ -665,7 +665,7 @@ async def test_router_passes_transcript_context_into_strategy(
 ) -> None:
     strategy = context_aware_fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.88,
         {
             "route_class": "R2",
@@ -694,7 +694,7 @@ async def test_router_passes_transcript_context_into_strategy(
 
     routed = await apply_squilla_router(ctx)
 
-    assert routed.metadata["routed_tier"] == "t2"
+    assert routed.metadata["routed_tier"] == "c2"
     assert strategy.messages == ["Continue from the previous answer."]
     assert strategy.contexts == [
         {
@@ -782,12 +782,36 @@ async def test_image_input_routes_directly_to_vision_model_without_prompt_inject
 
 
 @pytest.mark.asyncio
+async def test_image_attachment_without_image_tier_fails_locally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        squilla_router_step,
+        "_get_strategy",
+        lambda _config: pytest.fail(
+            "image routing without image tier should not invoke text strategy"
+        ),
+    )
+    ctx = make_context(
+        "What is in this screenshot?",
+        attachments=[{"type": "image", "mime_type": "image/png"}],
+    )
+    ctx.config.squilla_router.tiers["image_model"]["supports_image"] = False
+
+    with pytest.raises(
+        RuntimeError,
+        match="No image-capable SquillaRouter tier is configured",
+    ):
+        await apply_squilla_router(ctx)
+
+
+@pytest.mark.asyncio
 async def test_non_image_attachment_does_not_force_vision_route(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     strategy = fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.91,
         {
             "route_class": "R1",
@@ -804,7 +828,7 @@ async def test_non_image_attachment_does_not_force_vision_route(
 
     assert strategy.calls == 1
     assert routed.metadata["routing_source"] == "v4_phase3"
-    assert routed.metadata["routed_tier"] == "t1"
+    assert routed.metadata["routed_tier"] == "c1"
 
 
 @pytest.mark.asyncio
@@ -813,7 +837,7 @@ async def test_observe_rollout_records_decisions_without_applying_model_or_promp
 ) -> None:
     fake_strategy(
         monkeypatch,
-        "t2",
+        "c2",
         0.93,
         {
             "route_class": "R2",
@@ -828,7 +852,7 @@ async def test_observe_rollout_records_decisions_without_applying_model_or_promp
     routed = await apply_squilla_router(ctx)
 
     assert routed.model == baseline_model
-    assert routed.metadata["routed_tier"] == "t2"
+    assert routed.metadata["routed_tier"] == "c2"
     assert routed.metadata["routed_model"] == "z-ai/glm-5.1"
     assert routed.metadata["routing_applied"] is False
     assert routed.metadata["thinking_mode"] == "T2"
@@ -842,7 +866,7 @@ async def test_repeated_message_across_sessions_is_classified_each_time(
 ) -> None:
     strategy = fake_strategy(
         monkeypatch,
-        "t1",
+        "c1",
         0.91,
         {
             "route_class": "R1",
@@ -872,7 +896,7 @@ async def test_required_router_runtime_failure_falls_back_to_default_tier(
     routed = await apply_squilla_router(ctx)
 
     assert routed.metadata["routing_source"] == "v4_unavailable"
-    assert routed.metadata["routed_tier"] == "t1"
+    assert routed.metadata["routed_tier"] == "c1"
     assert routed.metadata["routing_confidence"] == 0.0
 
 
@@ -914,7 +938,7 @@ async def test_runtime_router_short_chinese_prompt_injects_localized_p0_hint() -
     routed = await apply_squilla_router(ctx)
 
     assert routed.metadata["routing_source"] == "v4_phase3"
-    assert routed.metadata["routed_tier"] == "t0"
+    assert routed.metadata["routed_tier"] == "c0"
     assert routed.model == "deepseek/deepseek-v4-flash"
     assert routed.metadata["thinking_mode"] == "T0"
     assert routed.metadata.get("thinking_requested") is None
@@ -930,7 +954,7 @@ async def test_runtime_router_complex_request_applies_deep_thinking_without_p2_p
     routed = await apply_squilla_router(ctx)
 
     assert routed.metadata["routing_source"] == "v4_phase3"
-    assert routed.metadata["routed_tier"] == "t3"
+    assert routed.metadata["routed_tier"] == "c3"
     assert routed.model == "anthropic/claude-opus-4.7"
     assert routed.metadata["thinking_mode"] == "T3"
     assert routed.metadata["thinking_requested"] is True

--- a/tests/test_model_router_defaults.py
+++ b/tests/test_model_router_defaults.py
@@ -35,7 +35,7 @@ def test_squilla_router_defaults_match_runtime_router_config() -> None:
     assert cfg.auto_thinking is True
     assert cfg.rollout_phase == "full"
     assert cfg.strategy == "v4_phase3"
-    assert cfg.default_tier == "t1"
+    assert cfg.default_tier == "c1"
     assert cfg.confidence_threshold == 0.5
     assert cfg.v4_use_aux_head is True
     assert cfg.kv_cache_anti_downgrade_enabled is True
@@ -45,14 +45,14 @@ def test_squilla_router_defaults_match_runtime_router_config() -> None:
     assert cfg.complaint_upgrade_max_chars == 160
     assert cfg.require_router_runtime is True
 
-    assert cfg.tiers["t0"]["model"] == "deepseek/deepseek-v4-flash"
-    assert cfg.tiers["t0"]["thinking_level"] == "high"
-    assert cfg.tiers["t1"]["model"] == "deepseek/deepseek-v4-pro"
-    assert cfg.tiers["t1"]["thinking_level"] == "high"
-    assert cfg.tiers["t2"]["model"] == "z-ai/glm-5.1"
-    assert cfg.tiers["t2"]["thinking_level"] == "high"
-    assert cfg.tiers["t3"]["model"] == "anthropic/claude-opus-4.7"
-    assert cfg.tiers["t3"]["thinking_level"] == "high"
+    assert cfg.tiers["c0"]["model"] == "deepseek/deepseek-v4-flash"
+    assert cfg.tiers["c0"]["thinking_level"] == "high"
+    assert cfg.tiers["c1"]["model"] == "deepseek/deepseek-v4-pro"
+    assert cfg.tiers["c1"]["thinking_level"] == "high"
+    assert cfg.tiers["c2"]["model"] == "z-ai/glm-5.1"
+    assert cfg.tiers["c2"]["thinking_level"] == "high"
+    assert cfg.tiers["c3"]["model"] == "anthropic/claude-opus-4.7"
+    assert cfg.tiers["c3"]["thinking_level"] == "high"
     assert cfg.tiers["image_model"]["model"] == "moonshotai/kimi-k2.6"
     assert cfg.tiers["image_model"]["supports_image"] is True
     assert cfg.tiers["image_model"]["image_only"] is True
@@ -66,6 +66,21 @@ def test_squilla_router_explicit_openrouter_profile_matches_default_tiers() -> N
 
     assert explicit_cfg.tiers == default_cfg.tiers
     assert explicit_cfg.tier_profile == "openrouter"
+
+
+def test_squilla_router_canonical_tier_wins_over_legacy_alias() -> None:
+    squilla_router_config_cls = _squilla_router_config_cls()
+
+    cfg = squilla_router_config_cls(
+        tiers={
+            "c1": {"provider": "openrouter", "model": "canonical-model"},
+            "t1": {"provider": "openrouter", "model": "legacy-model"},
+        },
+        default_tier="t1",
+    )
+
+    assert cfg.default_tier == "c1"
+    assert cfg.tiers["c1"]["model"] == "canonical-model"
 
 
 def test_provider_profile_requires_matching_llm_provider() -> None:
@@ -106,8 +121,8 @@ def test_provider_profile_accepts_matching_llm_provider() -> None:
 
     assert cfg.llm.provider == "dashscope"
     assert cfg.squilla_router.tier_profile == "dashscope"
-    assert cfg.squilla_router.tiers["t0"]["provider"] == "dashscope"
-    assert cfg.squilla_router.tiers["t0"]["model"] == "qwen3.6-flash"
+    assert cfg.squilla_router.tiers["c0"]["provider"] == "dashscope"
+    assert cfg.squilla_router.tiers["c0"]["model"] == "qwen3.6-flash"
 
 
 @pytest.mark.parametrize("provider_id", DIRECT_ROUTER_PROFILE_IDS)
@@ -120,7 +135,7 @@ def test_unset_tier_profile_uses_matching_direct_provider_profile(provider_id: s
 
     expected = _router_tier_profile_defaults(provider_id)
     assert cfg.squilla_router.tier_profile == provider_id
-    for tier in ("t0", "t1", "t2", "t3"):
+    for tier in ("c0", "c1", "c2", "c3"):
         assert cfg.squilla_router.tiers[tier]["provider"] == provider_id
         assert cfg.squilla_router.tiers[tier]["model"] == expected[tier]["model"]
 
@@ -138,7 +153,7 @@ def test_direct_legacy_openrouter_router_defaults_are_migrated(provider_id: str)
 
     expected = _router_tier_profile_defaults(provider_id)
     assert cfg.squilla_router.tier_profile == provider_id
-    for tier in ("t0", "t1", "t2", "t3"):
+    for tier in ("c0", "c1", "c2", "c3"):
         assert cfg.squilla_router.tiers[tier]["provider"] == provider_id
         assert cfg.squilla_router.tiers[tier]["model"] == expected[tier]["model"]
 
@@ -161,9 +176,9 @@ def test_each_provider_profile_has_four_text_tiers_without_default_image_model()
 
     for profile in ("dashscope", "deepseek", "gemini", "volcengine"):
         cfg = squilla_router_config_cls(tier_profile=profile)
-        assert {"t0", "t1", "t2", "t3"}.issubset(cfg.tiers)
+        assert {"c0", "c1", "c2", "c3"}.issubset(cfg.tiers)
         assert "image_model" not in cfg.tiers
-        assert {cfg.tiers[tier]["provider"] for tier in ("t0", "t1", "t2", "t3")} == {
+        assert {cfg.tiers[tier]["provider"] for tier in ("c0", "c1", "c2", "c3")} == {
             profile
         }
 
@@ -173,9 +188,9 @@ def test_direct_provider_profiles_have_four_text_tiers_without_default_image_mod
 
     for profile in ("openai", "zhipu", "moonshot"):
         cfg = squilla_router_config_cls(tier_profile=profile)
-        assert {"t0", "t1", "t2", "t3"}.issubset(cfg.tiers)
+        assert {"c0", "c1", "c2", "c3"}.issubset(cfg.tiers)
         assert "image_model" not in cfg.tiers
-        assert {cfg.tiers[tier]["provider"] for tier in ("t0", "t1", "t2", "t3")} == {
+        assert {cfg.tiers[tier]["provider"] for tier in ("c0", "c1", "c2", "c3")} == {
             profile
         }
 
@@ -185,13 +200,13 @@ def test_openai_profile_uses_streaming_compatible_models() -> None:
 
     cfg = squilla_router_config_cls(tier_profile="openai")
 
-    assert cfg.tiers["t0"]["model"] == "gpt-5.4-nano"
-    assert cfg.tiers["t1"]["model"] == "gpt-5.4-mini"
-    assert cfg.tiers["t2"]["model"] == "gpt-5.5"
-    assert cfg.tiers["t3"]["model"] == "gpt-5.5"
-    assert cfg.tiers["t3"]["thinking_level"] == "high"
+    assert cfg.tiers["c0"]["model"] == "gpt-5.4-nano"
+    assert cfg.tiers["c1"]["model"] == "gpt-5.4-mini"
+    assert cfg.tiers["c2"]["model"] == "gpt-5.5"
+    assert cfg.tiers["c3"]["model"] == "gpt-5.5"
+    assert cfg.tiers["c3"]["thinking_level"] == "high"
     assert all(
-        cfg.tiers[tier]["model"] != "gpt-5.5-pro" for tier in ("t0", "t1", "t2", "t3")
+        cfg.tiers[tier]["model"] != "gpt-5.5-pro" for tier in ("c0", "c1", "c2", "c3")
     )
 
 
@@ -200,11 +215,11 @@ def test_zhipu_profile_uses_glm_5_1_for_strong_tiers() -> None:
 
     cfg = squilla_router_config_cls(tier_profile="zhipu")
 
-    assert cfg.tiers["t0"]["model"] == "glm-4.7-flashx"
-    assert cfg.tiers["t1"]["model"] == "glm-5"
-    assert cfg.tiers["t2"]["model"] == "glm-5.1"
-    assert cfg.tiers["t3"]["model"] == "glm-5.1"
-    assert cfg.tiers["t3"]["thinking_level"] == "high"
+    assert cfg.tiers["c0"]["model"] == "glm-4.7-flashx"
+    assert cfg.tiers["c1"]["model"] == "glm-5"
+    assert cfg.tiers["c2"]["model"] == "glm-5.1"
+    assert cfg.tiers["c3"]["model"] == "glm-5.1"
+    assert cfg.tiers["c3"]["thinking_level"] == "high"
 
 
 def test_moonshot_profile_uses_kimi_for_strong_tiers() -> None:
@@ -212,12 +227,12 @@ def test_moonshot_profile_uses_kimi_for_strong_tiers() -> None:
 
     cfg = squilla_router_config_cls(tier_profile="moonshot")
 
-    assert cfg.tiers["t0"]["model"] == "kimi-k2.5"
-    assert cfg.tiers["t1"]["model"] == "kimi-k2.5"
-    assert cfg.tiers["t2"]["model"] == "kimi-k2.6"
-    assert cfg.tiers["t3"]["model"] == "kimi-k2.6"
+    assert cfg.tiers["c0"]["model"] == "kimi-k2.5"
+    assert cfg.tiers["c1"]["model"] == "kimi-k2.5"
+    assert cfg.tiers["c2"]["model"] == "kimi-k2.6"
+    assert cfg.tiers["c3"]["model"] == "kimi-k2.6"
     assert all(
-        cfg.tiers[tier]["supports_image"] is True for tier in ("t0", "t1", "t2", "t3")
+        cfg.tiers[tier]["supports_image"] is True for tier in ("c0", "c1", "c2", "c3")
     )
 
 
@@ -226,14 +241,14 @@ def test_volcengine_profile_uses_seed_2_capability_ladder() -> None:
 
     cfg = squilla_router_config_cls(tier_profile="volcengine")
 
-    assert cfg.tiers["t0"]["model"] == "doubao-seed-2-0-mini-260215"
-    assert cfg.tiers["t0"]["thinking_level"] == "off"
-    assert cfg.tiers["t1"]["model"] == "doubao-seed-2-0-lite-260215"
-    assert cfg.tiers["t1"]["thinking_level"] == "low"
-    assert cfg.tiers["t2"]["model"] == "doubao-seed-2-0-pro-260215"
-    assert cfg.tiers["t2"]["thinking_level"] == "medium"
-    assert cfg.tiers["t3"]["model"] == "doubao-seed-2-0-code-preview-260215"
-    assert cfg.tiers["t3"]["thinking_level"] == "high"
+    assert cfg.tiers["c0"]["model"] == "doubao-seed-2-0-mini-260215"
+    assert cfg.tiers["c0"]["thinking_level"] == "off"
+    assert cfg.tiers["c1"]["model"] == "doubao-seed-2-0-lite-260215"
+    assert cfg.tiers["c1"]["thinking_level"] == "low"
+    assert cfg.tiers["c2"]["model"] == "doubao-seed-2-0-pro-260215"
+    assert cfg.tiers["c2"]["thinking_level"] == "medium"
+    assert cfg.tiers["c3"]["model"] == "doubao-seed-2-0-code-preview-260215"
+    assert cfg.tiers["c3"]["thinking_level"] == "high"
 
 
 def test_profile_tier_override_merges_keys_inside_tier() -> None:
@@ -241,12 +256,12 @@ def test_profile_tier_override_merges_keys_inside_tier() -> None:
 
     cfg = squilla_router_config_cls(
         tier_profile="gemini",
-        tiers={"t2": {"thinking_level": "high"}},
+        tiers={"c2": {"thinking_level": "high"}},
     )
 
-    assert cfg.tiers["t2"]["provider"] == "gemini"
-    assert cfg.tiers["t2"]["model"] == "gemini-2.5-pro"
-    assert cfg.tiers["t2"]["thinking_level"] == "high"
+    assert cfg.tiers["c2"]["provider"] == "gemini"
+    assert cfg.tiers["c2"]["model"] == "gemini-2.5-pro"
+    assert cfg.tiers["c2"]["thinking_level"] == "high"
 
 
 def test_profile_rejects_non_dict_tier_override() -> None:
@@ -278,7 +293,7 @@ def test_profile_preserves_explicit_provider_compatible_image_model() -> None:
 
     assert cfg.tiers["image_model"]["provider"] == "gemini"
     assert cfg.tiers["image_model"]["supports_image"] is True
-    assert cfg.tiers["t0"]["provider"] == "gemini"
+    assert cfg.tiers["c0"]["provider"] == "gemini"
 
 
 def test_example_toml_enables_runtime_router_defaults() -> None:
@@ -294,7 +309,7 @@ def test_example_toml_enables_runtime_router_defaults() -> None:
     assert squilla_router["rollout_phase"] == "full"
     assert squilla_router["strategy"] == "v4_phase3"
     assert "cache_ttl_seconds" not in squilla_router
-    assert squilla_router["default_tier"] == "t1"
+    assert squilla_router["default_tier"] == "c1"
     assert squilla_router["confidence_threshold"] == 0.5
     assert squilla_router["v4_use_aux_head"] is True
     assert squilla_router["kv_cache_anti_downgrade_enabled"] is True
@@ -305,14 +320,14 @@ def test_example_toml_enables_runtime_router_defaults() -> None:
     assert squilla_router["require_router_runtime"] is True
 
     tiers = squilla_router["tiers"]
-    assert tiers["t0"]["model"] == "deepseek/deepseek-v4-flash"
-    assert tiers["t0"]["thinking_level"] == "high"
-    assert tiers["t1"]["model"] == "deepseek/deepseek-v4-pro"
-    assert tiers["t1"]["thinking_level"] == "high"
-    assert tiers["t2"]["model"] == "z-ai/glm-5.1"
-    assert tiers["t2"]["thinking_level"] == "high"
-    assert tiers["t3"]["model"] == "anthropic/claude-opus-4.7"
-    assert tiers["t3"]["thinking_level"] == "high"
+    assert tiers["c0"]["model"] == "deepseek/deepseek-v4-flash"
+    assert tiers["c0"]["thinking_level"] == "high"
+    assert tiers["c1"]["model"] == "deepseek/deepseek-v4-pro"
+    assert tiers["c1"]["thinking_level"] == "high"
+    assert tiers["c2"]["model"] == "z-ai/glm-5.1"
+    assert tiers["c2"]["thinking_level"] == "high"
+    assert tiers["c3"]["model"] == "anthropic/claude-opus-4.7"
+    assert tiers["c3"]["thinking_level"] == "high"
     assert tiers["image_model"]["model"] == "moonshotai/kimi-k2.6"
     assert tiers["image_model"]["supports_image"] is True
     assert tiers["image_model"]["image_only"] is True

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -320,13 +320,13 @@ def test_interactive_onboard_prompts_router_defaults_before_persist(tmp_path, mo
                 return _Answer("SquillaRouter")
             if message == "Default text model":
                 assert kwargs.get("choices") == [
-                    "Fast/simple (t0)",
-                    "Balanced default (t1)",
-                    "Stronger reasoning (t2)",
-                    "Max quality (t3)",
+                    "Route c0",
+                    "Route c1",
+                    "Route c2",
+                    "Route c3",
                 ]
-                assert kwargs.get("default") == "Balanced default (t1)"
-                return _Answer("Stronger reasoning (t2)")
+                assert kwargs.get("default") == "Route c1"
+                return _Answer("Route c2")
             raise AssertionError(f"unexpected select prompt: {message}")
 
         def text(self, message: str, **kwargs):
@@ -358,7 +358,7 @@ def test_interactive_onboard_prompts_router_defaults_before_persist(tmp_path, mo
     data = target.read_text()
     assert 'api_key = ""' in data
     assert 'api_key_env = "OPENROUTER_API_KEY"' in data
-    assert 'default_tier = "t2"' in data
+    assert 'default_tier = "c2"' in data
     assert 'model = "z-ai/glm-5.1"' in data
 
 
@@ -1352,7 +1352,7 @@ def test_router_tier_overrides_edit_only_selected_tiers():
     from opensquilla.onboarding.flow import _router_tier_overrides
 
     calls: list[str] = []
-    selections = iter(["Stronger reasoning (t2)", "Done"])
+    selections = iter(["Route c2", "Done"])
 
     class _Answer:
         def __init__(self, value):
@@ -1367,28 +1367,28 @@ def test_router_tier_overrides_edit_only_selected_tiers():
             assert message == "Tier to edit"
             assert kwargs.get("choices") == [
                 "Done",
-                "Fast/simple (t0)",
-                "Balanced default (t1)",
-                "Stronger reasoning (t2)",
-                "Max quality (t3)",
+                "Route c0",
+                "Route c1",
+                "Route c2",
+                "Route c3",
                 "Image model",
             ]
             return _Answer(next(selections))
 
         def text(self, message: str, **kwargs):
             calls.append(message)
-            if message == "t2 provider":
+            if message == "c2 provider":
                 assert kwargs.get("default") == "openrouter"
                 return _Answer("openrouter")
-            if message == "t2 model":
+            if message == "c2 model":
                 assert kwargs.get("default") == "z-ai/glm-5.1"
                 return _Answer("custom/reasoner")
             raise AssertionError(f"unexpected text prompt: {message}")
 
     overrides = _router_tier_overrides(_Questionary(), GatewayConfig())
 
-    assert calls == ["Tier to edit", "t2 provider", "t2 model", "Tier to edit"]
-    assert overrides == {"t2": {"provider": "openrouter", "model": "custom/reasoner"}}
+    assert calls == ["Tier to edit", "c2 provider", "c2 model", "Tier to edit"]
+    assert overrides == {"c2": {"provider": "openrouter", "model": "custom/reasoner"}}
 
 
 def test_interactive_feishu_websocket_prompts_only_core_fields(tmp_path, monkeypatch):

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -234,6 +234,20 @@ def test_slack_socket_channel_does_not_require_signing_secret():
     assert "signing_secret" not in entry or entry["signing_secret"] in (None, "")
 
 
+def test_slack_socket_channel_requires_app_token():
+    cfg = GatewayConfig()
+    with pytest.raises(ValueError, match="app_token"):
+        upsert_channel(
+            cfg,
+            entry_payload={
+                "type": "slack",
+                "name": "w",
+                "token": "xoxb-test",
+                "connection_mode": "socket",
+            },
+        )
+
+
 def test_remove_channel():
     cfg = GatewayConfig()
     res1 = upsert_channel(
@@ -331,7 +345,7 @@ def test_upsert_llm_provider_recomputes_openrouter_mix_on_provider_switch():
     assert res.config.llm.provider == "deepseek"
     assert res.config.squilla_router.enabled is True
     assert res.config.squilla_router.tier_profile == "deepseek"
-    assert res.config.squilla_router.tiers["t0"]["provider"] == "deepseek"
+    assert res.config.squilla_router.tiers["c0"]["provider"] == "deepseek"
     assert "tiers" not in res.config.to_toml_dict()["squilla_router"]
 
 
@@ -344,6 +358,28 @@ def test_upsert_router_recommended_writes_profile_without_expanded_tiers():
     assert res.config.squilla_router.tier_profile == "deepseek"
     assert "tiers" not in res.config.to_toml_dict()["squilla_router"]
     assert res.public_payload["mode"] == "recommended"
+
+
+def test_upsert_router_forces_image_model_role_invariants():
+    cfg = GatewayConfig(llm={"provider": "openrouter", "model": "z-ai/glm-5.1"})
+
+    res = upsert_router(
+        cfg,
+        mode="openrouter-mix",
+        tiers={
+            "image_model": {
+                "provider": "openrouter",
+                "model": "anthropic/claude-opus-4.7",
+                "supportsImage": False,
+                "image_only": False,
+            }
+        },
+    )
+
+    image_tier = res.config.squilla_router.tiers["image_model"]
+    assert image_tier["model"] == "anthropic/claude-opus-4.7"
+    assert image_tier["supports_image"] is True
+    assert image_tier["image_only"] is True
 
 
 def test_upsert_router_can_disable():

--- a/tests/test_onboarding/test_next_steps.py
+++ b/tests/test_onboarding/test_next_steps.py
@@ -69,7 +69,7 @@ def test_onboarding_finish_output_uses_product_router_label():
 
     text = format_next_steps(GatewayConfig(), config_path="/tmp/opensquilla/custom.toml")
 
-    assert "  Router: SquillaRouter, default=t1" in text
+    assert "  Router: SquillaRouter, default=c1" in text
     assert "profile=openrouter-mix" not in text
 
 

--- a/tests/test_onboarding/test_router_specs.py
+++ b/tests/test_onboarding/test_router_specs.py
@@ -13,16 +13,16 @@ def test_router_catalog_exposes_supported_profiles_and_tiers():
     assert {"openrouter", "deepseek", "openai"} <= set(profiles)
     deepseek = profiles["deepseek"]
     assert deepseek["providerId"] == "deepseek"
-    assert set(deepseek["tiers"]) == {"t0", "t1", "t2", "t3"}
-    assert deepseek["tiers"]["t0"]["model"]
-    assert deepseek["tiers"]["t0"]["provider"] == "deepseek"
-    assert "description" in deepseek["tiers"]["t0"]
-    assert "thinkingLevel" in deepseek["tiers"]["t0"]
+    assert set(deepseek["tiers"]) == {"c0", "c1", "c2", "c3"}
+    assert deepseek["tiers"]["c0"]["model"]
+    assert deepseek["tiers"]["c0"]["provider"] == "deepseek"
+    assert "description" in deepseek["tiers"]["c0"]
+    assert "thinkingLevel" in deepseek["tiers"]["c0"]
     openrouter = profiles["openrouter"]
     assert "image_model" in openrouter["tiers"]
     assert openrouter["tiers"]["image_model"]["supportsImage"] is True
-    assert payload["defaultTier"] == "t1"
-    assert set(payload["textTiers"]) == {"t0", "t1", "t2", "t3"}
+    assert payload["defaultTier"] == "c1"
+    assert set(payload["textTiers"]) == {"c0", "c1", "c2", "c3"}
 
 
 def test_get_router_setup_profile_rejects_unknown_profile():

--- a/tests/test_onboarding/test_setup_engine.py
+++ b/tests/test_onboarding/test_setup_engine.py
@@ -47,7 +47,7 @@ def test_setup_engine_can_derive_provider_model_from_router_default_tier(tmp_pat
     assert data["llm"]["provider"] == "deepseek"
     assert data["llm"]["model"] == "deepseek-v4-flash"
     assert data["squilla_router"]["tier_profile"] == "deepseek"
-    assert data["squilla_router"]["default_tier"] == "t1"
+    assert data["squilla_router"]["default_tier"] == "c1"
 
 
 def test_setup_engine_router_tier_override_updates_direct_fallback_model(tmp_path):
@@ -65,9 +65,9 @@ def test_setup_engine_router_tier_override_updates_direct_fallback_model(tmp_pat
         "router",
         {
             "mode": "recommended",
-            "defaultTier": "t2",
+            "defaultTier": "c2",
             "tiers": {
-                "t2": {
+                "c2": {
                     "provider": "openai",
                     "model": "gpt-5.5-custom",
                     "thinkingLevel": "high",
@@ -80,9 +80,9 @@ def test_setup_engine_router_tier_override_updates_direct_fallback_model(tmp_pat
     data = tomllib.loads(target.read_text())
     assert data["llm"]["model"] == "gpt-5.5-custom"
     assert data["squilla_router"]["tier_profile"] == "openai"
-    assert data["squilla_router"]["default_tier"] == "t2"
-    assert data["squilla_router"]["tiers"]["t2"]["model"] == "gpt-5.5-custom"
-    assert data["squilla_router"]["tiers"]["t2"]["thinking_level"] == "high"
+    assert data["squilla_router"]["default_tier"] == "c2"
+    assert data["squilla_router"]["tiers"]["c2"]["model"] == "gpt-5.5-custom"
+    assert data["squilla_router"]["tiers"]["c2"]["thinking_level"] == "high"
 
 
 def test_setup_engine_next_steps_do_not_include_secret(tmp_path):

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-CURRENT_VERSION = "0.3.0"
+CURRENT_VERSION = "0.3.1"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.2.0rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"

--- a/tests/test_scripts/test_router_live_script_defaults.py
+++ b/tests/test_scripts/test_router_live_script_defaults.py
@@ -9,10 +9,10 @@ from pathlib import Path
 from opensquilla.tools.registry import ToolProfile
 
 EXPECTED_ROUTER_MODELS = {
-    "t0": "deepseek/deepseek-v4-flash",
-    "t1": "deepseek/deepseek-v4-pro",
-    "t2": "z-ai/glm-5.1",
-    "t3": "anthropic/claude-opus-4.7",
+    "c0": "deepseek/deepseek-v4-flash",
+    "c1": "deepseek/deepseek-v4-pro",
+    "c2": "z-ai/glm-5.1",
+    "c3": "anthropic/claude-opus-4.7",
 }
 
 
@@ -35,7 +35,7 @@ def test_smoke_script_tier_defaults_match_router_defaults(tmp_path: Path) -> Non
     smoke._write_live_gateway_config(config_path, "")
 
     data = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    assert data["llm"]["model"] == EXPECTED_ROUTER_MODELS["t1"]
+    assert data["llm"]["model"] == EXPECTED_ROUTER_MODELS["c1"]
     assert {
         tier: cfg["model"]
         for tier, cfg in data["squilla_router"]["tiers"].items()

--- a/tests/test_skills/test_meta_mvp.py
+++ b/tests/test_skills/test_meta_mvp.py
@@ -560,10 +560,10 @@ async def test_meta_resolution_promotes_meta_skill_creator_to_highest_text_tier(
         config=SimpleNamespace(
             squilla_router=SimpleNamespace(
                 tiers={
-                    "t0": {"model": "cheap-model"},
-                    "t1": {"model": "balanced-model"},
-                    "t2": {"model": "strong-model"},
-                    "t3": {"model": "frontier-model"},
+                    "c0": {"model": "cheap-model"},
+                    "c1": {"model": "balanced-model"},
+                    "c2": {"model": "strong-model"},
+                    "c3": {"model": "frontier-model"},
                     "image": {"model": "vision-model", "image_only": True},
                 },
             ),
@@ -578,10 +578,10 @@ async def test_meta_resolution_promotes_meta_skill_creator_to_highest_text_tier(
         "dynamic system prompt"
     )
     assert out.model == "frontier-model"
-    assert out.metadata["meta_required_tier"] == "t3"
+    assert out.metadata["meta_required_tier"] == "c3"
     assert out.metadata["meta_required_model"] == "frontier-model"
     assert out.metadata["meta_required_source"] == "meta-skill-creator"
-    assert out.metadata["routed_tier"] == "t3"
+    assert out.metadata["routed_tier"] == "c3"
     assert out.metadata["routed_model"] == "frontier-model"
     assert out.metadata["routing_source"] == "meta_skill_required_tier"
     assert out.metadata["routing_confidence"] == 1.0
@@ -605,8 +605,8 @@ async def test_meta_resolution_does_not_promote_non_creator_meta_to_highest_text
         config=SimpleNamespace(
             squilla_router=SimpleNamespace(
                 tiers={
-                    "t1": {"model": "cheap-model"},
-                    "t3": {"model": "frontier-model"},
+                    "c1": {"model": "cheap-model"},
+                    "c3": {"model": "frontier-model"},
                     "vision": {"model": "vision-model", "image_only": True},
                 },
             ),

--- a/tests/test_skills_default_prompt_contract.py
+++ b/tests/test_skills_default_prompt_contract.py
@@ -158,6 +158,7 @@ async def test_default_prompt_only_injects_retained_bundled_skills(
         EligibilityContext(
             os_name="linux",
             has_bin_cache={
+                "bibtex": True,
                 "codex": True,
                 "curl": True,
                 "ffmpeg": True,

--- a/tests/test_tools/test_router_control_tool.py
+++ b/tests/test_tools/test_router_control_tool.py
@@ -40,8 +40,8 @@ async def test_router_control_set_hold_writes_store_and_requests_replay() -> Non
             tool_name="router_control",
             arguments={
                 "action": "set_hold",
-                "target_id": "tier:t3",
-                "evidence": "use t3",
+                "target_id": "tier:c3",
+                "evidence": "use c3",
             },
         )
     )
@@ -50,12 +50,12 @@ async def test_router_control_set_hold_writes_store_and_requests_replay() -> Non
     assert result.is_error is False
     assert result.terminates_turn is True
     assert payload["accepted"] is True
-    assert payload["target_tier"] == "t3"
+    assert payload["target_tier"] == "c3"
     assert payload["target_model"] == "anthropic/claude-opus-4.7"
     assert payload["replay_required"] is True
     hold = ctx.router_control_hold_store.get_valid(ctx.session_key or "")
     assert hold is not None
-    assert hold.tier == "t3"
+    assert hold.tier == "c3"
 
 
 @pytest.mark.asyncio
@@ -91,8 +91,9 @@ def test_router_control_tool_schema_includes_dynamic_target_enum() -> None:
     target_schema = router_tool.input_schema.properties["target_id"]
 
     assert "enum" in target_schema
-    assert "tier:t3" in target_schema["enum"]
-    assert "model:anthropic/claude-opus-4.7" in target_schema["enum"]
+    assert "tier:c3" in target_schema["enum"]
+    assert "tier:t3" not in target_schema["enum"]
+    assert "model:anthropic/claude-opus-4.7" not in target_schema["enum"]
 
 
 @pytest.mark.asyncio
@@ -101,9 +102,9 @@ async def test_router_control_clear_hold_replays_when_hold_already_selected_turn
     target = next(
         target
         for target in ctx.router_control_hold_store.build_targets(ctx.router_control_config)
-        if target.target_id == "tier:t3"
+        if target.target_id == "tier:c3"
     )
-    ctx.router_control_hold_store.set_hold(ctx.session_key or "", target, evidence="use t3")
+    ctx.router_control_hold_store.set_hold(ctx.session_key or "", target, evidence="use c3")
     handler = build_tool_handler(get_default_registry(), ctx)
 
     result = await handler(

--- a/uv.lock
+++ b/uv.lock
@@ -1644,7 +1644,7 @@ wheels = [
 
 [[package]]
 name = "opensquilla"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Prepare the 0.3.1 release branch for publication to `main`, `v0.3.1`, and the GitHub Release.

This branch currently contains six commits:

- `9fa871c5` replays the selected 0.3.1 release surface from `origin/dev@520c2f09` onto the `main` release ledger without importing dev integration history.
- `9bcd0b0e` updates the 0.3.1 release ledger: version metadata, installer URLs, release notes source, Slack Socket Mode docs, and community attribution.
- `1a9d9dd6` fixes the prompt-contract CI fixture so the mocked bundled-skill eligibility includes `bibtex`, matching the `meta-paper-write` platform requirements.
- `a6005a5e` aligns the 0.3.1 release body format with the published 0.3.0 release page while keeping 0.3.1 scoped as a maintenance release.
- `b9e31155` refines the 0.3.1 release narrative so the public body reads like a maintenance release instead of a feature list.
- `9bbadfe0` keeps the split CI workflow compatible with the current `main` branch ruleset by restoring the exact required Ubuntu and Windows check names.

## Release Notes Source

The GitHub Release body source is `docs/releases/0.3.1.md`.

The public wording is intentionally maintenance-focused: less fragile daily use, Slack setup and reply context, media/voice workflow recovery, multiline chat formatting, provider request hardening, and install/release metadata. It avoids promoting internal router/replay mechanics as release highlights.

## Contributor Attribution

`CONTRIBUTORS.md`, `CHANGELOG.md`, and `docs/releases/0.3.1.md` include 0.3.1 acknowledgements for:

- `@openvictory` (#123, #133, and #137)
- `@freeaccount-create` (#142)
- `@ruhook` and commit author `@qq712696307` (#124)
- `@Cola-Alex` (#143)
- `@nice-code-la` (#165 and #166)

The rollup commit keeps `Co-authored-by: openvictory <openvictory@users.noreply.github.com>` because line-level final release-surface diff newly replayed onto `main` only required that default-branch co-author trailer; the other contributors are preserved in the human-readable release attribution surfaces.

## Validation

Local preparation checks:

- `git diff --check`
- Release/readme hygiene tests: 33 passed
- Slack/onboarding/config tests: 294 passed
- Contributor/release doc checks: 23 passed
- Additional targeted release-surface tests previously passed: 223 passed
- `uv run pytest tests/test_skills_default_prompt_contract.py -q`: 11 passed
- `uv run ruff check tests/test_skills_default_prompt_contract.py`: passed
- `uv run pytest tests/test_release_consistency.py tests/test_public_release_hygiene.py -q`: 22 passed
- `uv run ruff check tests/test_release_consistency.py tests/test_public_release_hygiene.py`: passed
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color=false`: passed

GitHub PR CI is rerunning on head `9bbadfe0`. Auto-merge is enabled with rebase merge and should complete after the required checks pass.

## Maintainer Gate

The maintainer has requested publishing. The intended public-state sequence is: rebase-merge this PR to `main`, tag `v0.3.1` at the merged `main` commit, wait for the release asset workflow, update the GitHub Release body from `docs/releases/0.3.1.md`, publish the release, and rerun post-publish release checks. After `main` publication, replay only the release/docs ledger, CI fixture, release narrative, and ruleset-compatible CI-name changes back to `dev` if `dev` would otherwise regress them; do not merge `main` wholesale into `dev`.

## Known Pending Checks

`release_audit.py` currently reports `GitHub Release v0.3.1 not found`, which is expected before the tag/release workflow creates the release. Rerun the release audit after maintainer-approved main/tag/release actions.