### PR TITLE
Fix env test precedence and TUI abort hook

### DIFF
--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -9,7 +9,8 @@ import typer
 from opensquilla.env import load_env, warn_if_proxy_ignored
 
 # Populate os.environ from .env files before any submodule import reads keys.
-# Precedence: os.environ > $CWD/.env > $CWD/.env.test > ~/.opensquilla/.env.
+# Precedence: os.environ > $CWD/.env.test during tests > $CWD/.env
+# > $CWD/.env.test fallback outside tests > ~/.opensquilla/.env.
 load_env()
 warn_if_proxy_ignored()
 

--- a/src/opensquilla/cli/tui/backend/runtime.py
+++ b/src/opensquilla/cli/tui/backend/runtime.py
@@ -42,15 +42,21 @@ async def run_tui_runtime(
             with contextlib.suppress(Exception):
                 await abort_turn
 
-        def _cancel_inflight_turn() -> None:
+        def _cancel_inflight_turn() -> asyncio.Task[None] | None:
             task = turn_task
             if task is not None and not task.done():
+                abort_task: asyncio.Task[None] | None = None
                 with contextlib.suppress(Exception):
                     abort_turn = hooks.on_cancel_active_turn()
-                    asyncio.create_task(_schedule_abort(abort_turn))
+                    abort_task = asyncio.create_task(_schedule_abort(abort_turn))
                 task.cancel()
+                return abort_task
+            return None
 
-        tui_surface.set_cancel_callback(_cancel_inflight_turn)
+        def _cancel_callback() -> None:
+            _cancel_inflight_turn()
+
+        tui_surface.set_cancel_callback(_cancel_callback)
 
         def _shutdown_drain_then_exit() -> None:
             tui_surface.emit_eof()
@@ -187,11 +193,13 @@ async def run_tui_runtime(
                 if category is TuiInputKind.DESTRUCTIVE:
                     runtime_state.clear_pending()
                     if turn_task is not None and not turn_task.done():
-                        turn_task.cancel()
+                        abort_task = _cancel_inflight_turn()
                         try:
                             await turn_task
                         except asyncio.CancelledError:
                             hooks.clear_current_cancel()
+                        if abort_task is not None:
+                            await abort_task
                         turn_task = None
                     keep_going = await _run_dispatch(user_input)
                     if not keep_going:

--- a/src/opensquilla/env.py
+++ b/src/opensquilla/env.py
@@ -2,8 +2,10 @@
 
 Precedence (highest to lowest):
 1. os.environ (already set by shell / CI)
-2. .env in current working directory
-3. ~/.opensquilla/.env (global user config)
+2. .env.test in current working directory during test runs
+3. .env in current working directory
+4. .env.test in current working directory outside test runs, for keys absent from .env
+5. ~/.opensquilla/.env (global user config)
 
 Existing environment variables are NEVER overridden.
 """
@@ -70,6 +72,15 @@ def _parse_env_file(path: Path) -> dict[str, str]:
     return entries
 
 
+def _is_test_env_enabled() -> bool:
+    """Return True when local test env files should override local dev env files."""
+    # PYTEST_CURRENT_TEST is unavailable during collection/import, so tests that
+    # need import-time .env.test precedence should set OPENSQUILLA_TEST=1.
+    if os.environ.get("OPENSQUILLA_TEST", "").strip().lower() in _TRUTHY:
+        return True
+    return "PYTEST_CURRENT_TEST" in os.environ
+
+
 def load_env(cwd: str | Path | None = None) -> int:
     """Load .env files into os.environ with precedence rules.
 
@@ -77,9 +88,10 @@ def load_env(cwd: str | Path | None = None) -> int:
     """
     candidates = []
 
-    # 1. cwd/.env (or cwd/.env.test as alias for dev)
+    # 1. cwd/.env.test in test runs, otherwise cwd/.env wins for normal dev runs.
     work_dir = Path(cwd) if cwd else Path.cwd()
-    for name in (".env", ".env.test"):
+    local_names = (".env.test", ".env") if _is_test_env_enabled() else (".env", ".env.test")
+    for name in local_names:
         candidates.append(work_dir / name)
 
     # 2. ~/.opensquilla/.env (global)

--- a/tests/unit/cli/tui/test_runtime.py
+++ b/tests/unit/cli/tui/test_runtime.py
@@ -151,6 +151,8 @@ async def test_runtime_destructive_slash_cancels_active_turn_and_purges_queue() 
     first_started = asyncio.Event()
     first_cancelled = asyncio.Event()
     clear_completed = asyncio.Event()
+    cancel_calls: list[str] = []
+    clear_cancel_snapshots: list[list[str]] = []
 
     async def _dispatch(user_input: str) -> bool:
         if user_input == "first":
@@ -165,8 +167,13 @@ async def test_runtime_destructive_slash_cancels_active_turn_and_purges_queue() 
             return True
         executed.append(user_input)
         if user_input == "/clear":
+            clear_cancel_snapshots.append(list(cancel_calls))
             clear_completed.set()
         return True
+
+    async def _cancel_active_turn() -> None:
+        await asyncio.sleep(0)
+        cancel_calls.append("cancel")
 
     task = asyncio.create_task(
         run_tui_runtime(
@@ -177,7 +184,7 @@ async def test_runtime_destructive_slash_cancels_active_turn_and_purges_queue() 
                     TuiInputKind.DESTRUCTIVE if text == "/clear" else TuiInputKind.NORMAL
                 )
             ),
-            hooks=_runtime_hooks(),
+            hooks=_runtime_hooks(on_cancel_active_turn=_cancel_active_turn),
         )
     )
 
@@ -195,6 +202,8 @@ async def test_runtime_destructive_slash_cancels_active_turn_and_purges_queue() 
     await asyncio.wait_for(task, timeout=2.0)
 
     assert executed == ["first-start", "/clear"]
+    assert cancel_calls == ["cancel"]
+    assert clear_cancel_snapshots == [["cancel"]]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_env.py
+++ b/tests/unit/test_env.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opensquilla import env as env_mod
+
+
+def _isolate_global_env(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
+    home.mkdir()
+    monkeypatch.setattr(env_mod, "default_opensquilla_home", lambda: home)
+
+
+def test_load_env_opensquilla_test_overrides_dotenv_before_pytest_current_test(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    _isolate_global_env(monkeypatch, tmp_path / "home")
+    monkeypatch.setenv("OPENSQUILLA_TEST", "1")
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_ENV_TEST_KEY", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_ENV_TEST_SHARED", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_ENV_TEST_ONLY", raising=False)
+
+    (tmp_path / ".env").write_text(
+        "OPENSQUILLA_ENV_TEST_KEY=from-dotenv\n"
+        "OPENSQUILLA_ENV_TEST_SHARED=from-dotenv\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".env.test").write_text(
+        "OPENSQUILLA_ENV_TEST_KEY=from-dotenv-test\n"
+        "OPENSQUILLA_ENV_TEST_ONLY=from-dotenv-test\n",
+        encoding="utf-8",
+    )
+
+    assert env_mod.load_env(tmp_path) == 3
+    assert env_mod.os.environ["OPENSQUILLA_ENV_TEST_KEY"] == "from-dotenv-test"
+    assert env_mod.os.environ["OPENSQUILLA_ENV_TEST_SHARED"] == "from-dotenv"
+    assert env_mod.os.environ["OPENSQUILLA_ENV_TEST_ONLY"] == "from-dotenv-test"
+
+
+def test_load_env_dotenv_keeps_priority_outside_test_env(monkeypatch, tmp_path) -> None:
+    _isolate_global_env(monkeypatch, tmp_path / "home")
+    monkeypatch.delenv("OPENSQUILLA_TEST", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_ENV_TEST_KEY", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_ENV_TEST_ONLY", raising=False)
+
+    (tmp_path / ".env").write_text(
+        "OPENSQUILLA_ENV_TEST_KEY=from-dotenv\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".env.test").write_text(
+        "OPENSQUILLA_ENV_TEST_KEY=from-dotenv-test\n"
+        "OPENSQUILLA_ENV_TEST_ONLY=from-dotenv-test\n",
+        encoding="utf-8",
+    )
+
+    assert env_mod.load_env(tmp_path) == 2
+    assert env_mod.os.environ["OPENSQUILLA_ENV_TEST_KEY"] == "from-dotenv"
+    assert env_mod.os.environ["OPENSQUILLA_ENV_TEST_ONLY"] == "from-dotenv-test"
+
+
+def test_load_env_existing_environment_still_wins_in_test_env(monkeypatch, tmp_path) -> None:
+    _isolate_global_env(monkeypatch, tmp_path / "home")
+    monkeypatch.setenv("OPENSQUILLA_TEST", "1")
+    monkeypatch.setenv("OPENSQUILLA_ENV_TEST_KEY", "from-shell")
+
+    (tmp_path / ".env").write_text(
+        "OPENSQUILLA_ENV_TEST_KEY=from-dotenv\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".env.test").write_text(
+        "OPENSQUILLA_ENV_TEST_KEY=from-dotenv-test\n",
+        encoding="utf-8",
+    )
+
+    assert env_mod.load_env(tmp_path) == 0
+    assert env_mod.os.environ["OPENSQUILLA_ENV_TEST_KEY"] == "from-shell"


### PR DESCRIPTION
## Summary

- Load `.env.test` ahead of `.env` only in explicit test contexts while preserving normal `.env` priority and `.env.test` fallback behavior outside tests.
- Document and cover the import-time path where `PYTEST_CURRENT_TEST` is not available yet, so tests can use `OPENSQUILLA_TEST=1` for `.env.test` precedence during collection/import.
- Route destructive TUI slash-command cancellation through the active-turn abort hook and wait for that hook before dispatching the slash handler.
- Add regression coverage for env precedence, existing shell env priority, and destructive slash cancellation.

Fixes #71.
Fixes #101.

## Validation

- `New-Item -ItemType Directory -Force .tmp\pytest | Out-Null; $tmp = (Resolve-Path .tmp\pytest).Path; $env:TEMP=$tmp; $env:TMP=$tmp; $env:PYTHONPATH='src'; .venv\Scripts\python -m pytest tests\unit\test_env.py tests\unit\cli\tui\test_runtime.py tests\unit\cli\repl\test_terminal_chat_adapter.py tests\unit\cli\repl\test_interactive_session_lifecycle.py -q -p no:cacheprovider`
- `.venv\Scripts\python -m ruff check src\opensquilla\env.py src\opensquilla\cli\main.py src\opensquilla\cli\tui\backend\runtime.py tests\unit\cli\tui\test_runtime.py tests\unit\test_env.py`
- `git diff --check`