### PR TITLE
Sync OpenSquilla 0.3.1 release metadata to dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color=false
 
   ubuntu-quality:
-    name: Ubuntu quality gate
+    name: Lint, test, and build (ubuntu-latest, 3.12)
     needs: classify-changes
     if: needs.classify-changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
@@ -143,7 +143,7 @@ jobs:
         run: uv build --wheel
 
   windows-compat:
-    name: Windows compatibility tests
+    name: Lint, test, and build (windows-latest, 3.12)
     needs: classify-changes
     if: needs.classify-changes.outputs.docs_only != 'true'
     runs-on: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,54 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+## [0.3.1] - 2026-06-03
+
+### Added
+
+- Slack Socket Mode support now covers app mentions, self-targeting replies,
+  channel metadata, and threaded response routing across onboarding and channel
+  runtime paths.
+- Short-drama and video helper workflows remain available in the bundled
+  MetaSkill catalog, with stronger Windows-safe script handling and clearer
+  review pauses for generated media flows.
+- CI impact-surface gates classify docs, runtime, dependency, release, and test
+  changes so pull requests can run the right checks without forcing the full
+  matrix for every documentation-only edit.
+
+### Changed
+
+- WebChat and the Skills view now make MetaSkill readiness, active runs, and
+  install visibility easier to inspect while workflows are being reviewed.
+- Release install documentation and installer defaults now point to the 0.3.1
+  wheel and Windows portable asset names.
+
+### Fixed
+
+- User chat bubbles preserve multiline text and read like authored messages
+  instead of collapsing or visually blending with generated output.
+- Slack onboarding and runtime paths now reject incomplete Socket Mode setup,
+  preserve existing secrets, enforce webhook signing secrets where needed, and
+  keep threaded reply channel context.
+- Voice/audio workflows and clarification pauses are represented on the main
+  release line, so release users get the same usable handoff and resume
+  behavior already validated on integration branches.
+- Provider request hardening keeps malformed tool-call history from reaching
+  providers as invalid request state.
+
+### Acknowledgements
+
+- Thanks @openvictory for #123, #133, and #137, which helped bring visible
+  running-state feedback plus short-drama and media helper workflows into the
+  0.3.1 release line.
+- Thanks @freeaccount-create for #142, which helped bring Slack Socket Mode and
+  self-targeting replies into the channel workflow.
+- Thanks @ruhook for #124, and thanks @qq712696307 for the authored commit in
+  that pull request, which preserved user message newlines in WebChat.
+- Thanks @Cola-Alex for #143, which increased tokenjuice summarize and
+  failure-context windows for fallback tool-result projection.
+- Thanks @nice-code-la for #165 and #166, which helped make voice workflows
+  usable end to end and clarification pauses resume cleanly.
+
 ## [0.3.0] - 2026-05-31
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,22 @@ human-readable ledger together for contributor attribution. This file records
 release-surface community work that can be harder to see when a release is
 squash-merged or replayed onto `main`.
 
+## OpenSquilla 0.3.1
+
+The 0.3.1 release is prepared as a release-surface replay from `dev` onto the
+stable `main` release ledger. Some community work in the release window was
+already represented by earlier `main` attribution work; this section records
+the 0.3.1-specific community contributions acknowledged in the release notes.
+
+| Contributor | 0.3.1 contribution | Evidence |
+| --- | --- | --- |
+| [@openvictory](https://github.com/openvictory) | Visible running-state feedback plus short-drama and media helper workflows. | [#123](https://github.com/opensquilla/opensquilla/pull/123), [#133](https://github.com/opensquilla/opensquilla/pull/133), [#137](https://github.com/opensquilla/opensquilla/pull/137) |
+| [@freeaccount-create](https://github.com/freeaccount-create) | Slack Socket Mode and self-targeting replies for channel workflows. | [#142](https://github.com/opensquilla/opensquilla/pull/142) |
+| [@ruhook](https://github.com/ruhook) | Submitted the WebChat user-message newline preservation pull request. | [#124](https://github.com/opensquilla/opensquilla/pull/124) |
+| [@qq712696307](https://github.com/qq712696307) | Authored the commit in #124 that preserved user-message newlines in WebChat. | [#124](https://github.com/opensquilla/opensquilla/pull/124) |
+| [@Cola-Alex](https://github.com/Cola-Alex) | Increased tokenjuice summarize and failure-context windows for fallback tool-result projection. | [#143](https://github.com/opensquilla/opensquilla/pull/143) |
+| [@nice-code-la](https://github.com/nice-code-la) | Voice workflow usability and clarification-pause resume behavior. | [#165](https://github.com/opensquilla/opensquilla/pull/165), [#166](https://github.com/opensquilla/opensquilla/pull/166) |
+
 ## OpenSquilla 0.3.0
 
 The 0.3.0 release reached `main` through release synchronization after work had

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ OpenRouter, OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope,
 and 20+ other LLM providers with no change to your code or config
 schema.
 
-OpenSquilla 0.3.0 is the current release.
+OpenSquilla 0.3.1 is the current release.
 
 For task-oriented product documentation, start with the
 [OpenSquilla Product Guide](README.product.md) or the
@@ -160,7 +160,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Install OpenSquilla** — the same command on every platform.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
 ```
 
 This installs the OpenSquilla wheel from the release URL, then lets
@@ -181,7 +181,7 @@ opensquilla gateway run
 > a new terminal, or re-run the PATH line from step 1.
 
 For a fully pinned install, use the versioned wheel URL:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl`.
 
 ### Install from source
 
@@ -439,9 +439,10 @@ opensquilla channels status <name> --json
 
 Treat a channel as connected only when the status payload reports
 `enabled=true`, `configured=true`, and `connected=true`. Feishu
-defaults to websocket mode and Telegram to polling — neither needs a
-public URL. Feishu webhook mode, Telegram webhook mode, Slack, and
-WeCom require a public, provider-reachable URL.
+defaults to websocket mode, Telegram to polling, and Slack can use
+Socket Mode — none of those modes needs a public URL. Feishu webhook
+mode, Telegram webhook mode, Slack webhook mode, and WeCom require a
+public, provider-reachable URL.
 
 **Public network binding**
 
@@ -479,31 +480,27 @@ settings live in `opensquilla.toml.example`.
 
 ---
 
-## What's New in 0.3.0
+## What's New in 0.3.1
 
-OpenSquilla 0.3.0 makes reusable agent workflows first-class with
-MetaSkills, then strengthens the runtime around diagnostics, context
-management, and documentation:
+OpenSquilla 0.3.1 is a maintenance release for the 0.3 line. It updates the
+stable install metadata and brings selected channel, chat, provider, and
+workflow fixes from the integration branch onto the stable release line:
 
-- **MetaSkills** — repeatable multi-step work can now run as reusable,
-  inspectable workflows with composition parsing, scheduling, pause/resume
-  user input, proposal gates, run history, and authoring documentation.
-- **Health Doctor** — `opensquilla doctor` and the WebUI Health view now turn
-  provider, gateway, memory, search, router, sandbox, and channel problems into
-  actionable findings with recovery commands.
-- **Structured tool compression** — Tokenjuice-backed projection keeps large
-  logs, diffs, test output, JSON, and package-manager results useful without
-  flooding the provider context.
-- **Real product documentation** — the docs now cover quickstart,
-  configuration, CLI, WebUI, providers, sessions, tools, memory, compaction,
-  MetaSkills, tool compression, scheduling, channels, MCP, and
-  troubleshooting.
-- **Runtime and WebUI stability** — long-session compaction, attachment
-  rendering, artifact downloads, router replay, stream recovery, and
-  cross-platform CLI behavior were tightened across the release.
+- **Channel setup and replies** — Slack Socket Mode, app mentions, signing
+  secrets, and threaded replies preserve the channel context needed for setup
+  and replies.
+- **Media and voice workflow handoffs** — short-drama/video helper workflows
+  remain bundled, generated media flows have clearer review pauses, and
+  voice/audio handoffs are usable end to end.
+- **Chat formatting** — user message bubbles preserve multiline text and read
+  like authored messages instead of compressed UI labels.
+- **Provider request hardening** — malformed tool-call history is kept away
+  from providers before it becomes invalid request state.
+- **Install and release checks** — installer URLs, release metadata, version
+  consistency tests, and CI impact gates are updated for 0.3.1.
 
 Full notes: [`CHANGELOG.md`](CHANGELOG.md) ·
-[`docs/releases/0.3.0.md`](docs/releases/0.3.0.md).
+[`docs/releases/0.3.1.md`](docs/releases/0.3.1.md).
 
 ## What's New in 0.2.1
 

--- a/README.product.md
+++ b/README.product.md
@@ -14,7 +14,7 @@ This guide is the product and usage entry point. The existing
 1. Install OpenSquilla:
 
    ```sh
-   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl"
+   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
    ```
 
 2. Configure your provider:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 0.3.1 | v0.3.1 | 2026-06-03 | Slack hardening, media workflow handoffs, chat formatting, and install metadata |
 | 0.3.0 | v0.3.0 | 2026-05-31 | MetaSkills, Health Doctor, tool compression, and docs release |
 | 0.2.1 | v0.2.1 | 2026-05-21 | 0.2 maintenance release |
 | 0.2.0 | v0.2.0 | 2026-05-20 | 0.2 release |
@@ -22,7 +23,7 @@ Windows portable zip `/releases/latest/download/` URL:
 GitHub source archives remain available for code review and developer
 reference; source installs should use `git clone` plus Git LFS. Public
 wheelhouse zips, macOS portable zips, and Linux portable zips are intentionally
-not published for 0.2.x or 0.3.0. macOS and Linux users install the same wheel
+not published for 0.2.x or 0.3.x. macOS and Linux users install the same wheel
 through the versioned `uv tool install` command documented in the README.
 Python wheel filenames must remain versioned because installers validate the
 version segment inside the wheel filename.
@@ -33,21 +34,21 @@ use tag-pinned URLs such as:
 - `https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/OpenSquilla-0.2.0rc1-windows-x64-py312-recommended-portable.zip`
 - `https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/opensquilla-0.2.0rc1-py3-none-any.whl`
 
-0.3.0 install commands use versioned wheel URLs because Python installers
+0.3.1 install commands use versioned wheel URLs because Python installers
 validate wheel filenames. The Windows portable zip may use the
 `/releases/latest/download/` alias after the non-pre-release GitHub Release
 exists. Fully pinned URLs remain available:
 
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/OpenSquilla-0.3.0-windows-x64-py312-recommended-portable.zip`
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/OpenSquilla-0.3.1-windows-x64-py312-recommended-portable.zip`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl`
 
 ## Release SOP
 
 1. Verify `git status` is clean.
 2. Update `CHANGELOG.md`: move entries from `[Unreleased]` to the release section; reopen empty `[Unreleased]`.
 3. Bump `pyproject.toml` and `uv.lock` to the release version.
-4. `git tag -a v0.3.0 -m "OpenSquilla 0.3.0"`
-5. `git push origin v0.3.0` (this triggers `.github/workflows/wheelhouse-release.yml`)
+4. `git tag -a v0.3.1 -m "OpenSquilla 0.3.1"`
+5. `git push origin v0.3.1` (this triggers `.github/workflows/wheelhouse-release.yml`)
 6. Wait for the Windows release workflow → review the draft GitHub Release.
    For non-preview releases, confirm it contains versioned assets, latest
    aliases, `SHA256SUMS`, plus GitHub's generated source archives before
@@ -56,8 +57,8 @@ exists. Fully pinned URLs remain available:
 8. Publish the GitHub Release, then run the post-publish tag URL checks:
 
    ```sh
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/OpenSquilla-0.3.0-windows-x64-py312-recommended-portable.zip
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/OpenSquilla-0.3.1-windows-x64-py312-recommended-portable.zip
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl
    ```
 
 9. Run the post-publish latest URL check:
@@ -66,7 +67,7 @@ exists. Fully pinned URLs remain available:
    curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/latest/download/OpenSquilla-windows-x64-portable.zip
    ```
 
-10. For subsequent previews: bump `pyproject.toml`, `uv.lock`, `CHANGELOG.md`, and the tag to the next preview version, for example `0.3.1rc1` / `v0.3.1rc1`. Preview GitHub Releases must be marked as pre-releases and should use tag-pinned README URLs until the next non-preview release exists.
+10. For subsequent previews: bump `pyproject.toml`, `uv.lock`, `CHANGELOG.md`, and the tag to the next preview version, for example `0.3.2rc1` / `v0.3.2rc1`. Preview GitHub Releases must be marked as pre-releases and should use tag-pinned README URLs until the next non-preview release exists.
 
 ## GitHub-only release checks
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ root release README with task-oriented guides.
 
 ## Surfaces and Operations
 
+- [`releases/0.3.1.md`](releases/0.3.1.md) - OpenSquilla 0.3.1 release notes.
 - [`releases/0.3.0.md`](releases/0.3.0.md) - OpenSquilla 0.3.0 release notes.
 - [`channels.md`](channels.md) - supported messaging channels and setup flow.
 - [`providers-and-models.md`](providers-and-models.md) - LLM provider catalog,

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -24,7 +24,7 @@ This build exposes the following channel families:
 | `feishu` | Feishu / Lark | mixed | depends on mode |
 | `matrix` | Matrix | websocket | no |
 | `qq` | QQ Bot | websocket | no |
-| `slack` | Slack | webhook | yes |
+| `slack` | Slack | mixed | depends on mode |
 | `telegram` | Telegram | mixed | depends on mode |
 | `wecom` | WeCom | webhook | yes |
 
@@ -45,10 +45,20 @@ Add a channel explicitly:
 opensquilla channels add telegram --name personal
 ```
 
-Add provider-specific fields as needed:
+Add provider-specific fields as needed. Slack supports two modes:
 
 ```sh
-opensquilla channels add slack --name team --field signing_secret=... --token ...
+# Slack Socket Mode: outbound websocket, no public URL.
+opensquilla channels add slack --name team \
+  --field connection_mode=socket \
+  --field app_token=xapp-... \
+  --token xoxb-...
+
+# Slack Events API webhook: requires a public Request URL and signing secret.
+opensquilla channels add slack --name team-webhook \
+  --field connection_mode=webhook \
+  --field signing_secret=... \
+  --token xoxb-...
 ```
 
 Restart the gateway process after config edits:
@@ -82,10 +92,23 @@ opensquilla channels remove <name>
 Use `gateway restart` after config changes. Use `channels restart <name>` only
 for an already-loaded live adapter.
 
+## Slack Modes
+
+Slack Socket Mode uses an outbound websocket and does not require a public
+Request URL. It requires the bot token (`xoxb-...`) plus an app-level token
+(`xapp-...`) saved as `app_token`.
+
+Slack webhook mode uses the Events API Request URL. It requires the bot token
+plus `signing_secret`, and the gateway must be reachable by Slack.
+
+Leave `slack_channel_id` empty when the adapter should reply to the incoming
+conversation. Set it only when you want a default fallback channel. Enable
+`reply_in_thread` when replies should stay in Slack threads.
+
 ## Webhook Channels
 
-Slack and WeCom require a public, provider-reachable URL. Feishu and Telegram
-may require one depending on mode.
+Slack webhook mode and WeCom require a public, provider-reachable URL. Feishu
+and Telegram may require one depending on mode.
 
 For public channels:
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -12,7 +12,7 @@ UI, CLI, channels, and gateway control console.
 Install OpenSquilla with the MCP extra when you need this bridge:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
 ```
 
 Start the OpenSquilla gateway:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -176,7 +176,7 @@ opensquilla mcp-server run
 Install with:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
 ```
 
 Use this when another MCP-capable client should access OpenSquilla-managed tools

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,7 +16,7 @@ UI, SquillaRouter, memory/search support, and safe local defaults.
 Install the current release wheel with the recommended extras:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.0/opensquilla-0.3.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
 ```
 
 The `recommended` extra includes SquillaRouter dependencies and memory/search

--- a/docs/releases/0.3.1.md
+++ b/docs/releases/0.3.1.md
@@ -1,0 +1,94 @@
+# OpenSquilla 0.3.1
+
+## Overview
+
+OpenSquilla 0.3.1 is a maintenance release for the 0.3 line. It updates the
+stable install metadata and brings selected channel, chat, provider, and
+workflow fixes from the integration branch onto the stable release line.
+
+Use this release when you want the current 0.3 install assets plus the latest
+Slack setup fixes, media and voice workflow handoffs, multiline chat rendering,
+and provider request hardening on the stable release line.
+
+## Fixed
+
+### Chat messages preserve authored formatting
+
+User-authored WebChat messages preserve multiline input and use spacing that
+makes them read like messages instead of compressed UI labels.
+
+### Channel setup preserves the context needed for replies
+
+Slack Socket Mode, app mentions, signing-secret checks, existing-secret
+preservation, and threaded replies are hardened across onboarding and runtime
+paths. Incomplete Socket Mode setup is rejected earlier, and Slack reply
+handling keeps the channel metadata needed to answer in the right place.
+
+### Voice, media, and MetaSkill handoffs are more usable
+
+Voice/audio workflow handoffs and clarification pauses are on the stable
+release line. The bundled short-drama and video helper workflows remain
+available, with Windows-safe script handling and review pauses that make media
+workflow output easier to inspect before continuing.
+
+### Provider and release checks fail earlier
+
+Malformed tool-call history is kept away from providers before it becomes an
+invalid request. PR CI also classifies changed files by impact surface, so docs,
+runtime, dependency, release, and test changes can trigger the checks they need
+without forcing unnecessary work for every pull request.
+
+## Changed
+
+- Release installer defaults now point to `v0.3.1`.
+- README, quickstart, MCP, and operations docs now use the 0.3.1 wheel URL.
+- `pyproject.toml`, `uv.lock`, release consistency tests, and install-script
+  tests now agree on version `0.3.1`.
+- `docs/releases/0.3.1.md` is the GitHub Release body source for the final
+  release review.
+
+## Downloads
+
+- Python wheel: `opensquilla-0.3.1-py3-none-any.whl`
+- Windows portable: `OpenSquilla-0.3.1-windows-x64-py312-recommended-portable.zip`
+- Stable Windows portable alias: `OpenSquilla-windows-x64-portable.zip`
+- Checksums: `SHA256SUMS`
+
+Linux and macOS users should install the Python wheel with `uv tool install`.
+Windows users can use either the wheel or the portable zip.
+
+## Upgrading from 0.3.0
+
+If OpenSquilla was installed with `uv tool install`, reinstall 0.3.1 over the
+existing tool environment:
+
+```sh
+uv tool install --python 3.12 --force --reinstall-package opensquilla \
+  "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
+```
+
+The release installers use the same forced reinstall path. Close any running
+OpenSquilla gateway before upgrading, then restart it after the install.
+Existing `~/.opensquilla/config.toml` and session data are reused.
+
+Windows portable users should extract the 0.3.1 zip to a fresh folder, or
+replace the whole extracted 0.3.0 folder while the gateway is stopped. Do not
+copy only individual files from the new zip into an old portable tree.
+
+## Acknowledgements
+
+Thanks @openvictory for #123, #133, and #137, which helped bring visible
+running-state feedback plus short-drama and media helper workflows into the
+0.3.1 release line.
+
+Thanks @freeaccount-create for #142, which helped bring Slack Socket Mode and
+self-targeting replies into the channel workflow.
+
+Thanks @ruhook for #124, and thanks @qq712696307 for the authored commit in
+that pull request, which preserved user message newlines in WebChat.
+
+Thanks @Cola-Alex for #143, which increased tokenjuice summarize and
+failure-context windows for fallback tool-result projection.
+
+Thanks @nice-code-la for #165 and #166, which helped make voice workflows usable
+end to end and clarification pauses resume cleanly.

--- a/docs/releases/0.3.1.md
+++ b/docs/releases/0.3.1.md
@@ -40,8 +40,7 @@ without forcing unnecessary work for every pull request.
 - README, quickstart, MCP, and operations docs now use the 0.3.1 wheel URL.
 - `pyproject.toml`, `uv.lock`, release consistency tests, and install-script
   tests now agree on version `0.3.1`.
-- `docs/releases/0.3.1.md` is the GitHub Release body source for the final
-  release review.
+- `docs/releases/0.3.1.md` records the GitHub Release body used for this release.
 
 ## Downloads
 

--- a/docs/releases/0.3.1.md
+++ b/docs/releases/0.3.1.md
@@ -10,7 +10,7 @@ Use this release when you want the current 0.3 install assets plus the latest
 Slack setup fixes, media and voice workflow handoffs, multiline chat rendering,
 and provider request hardening on the stable release line.
 
-## Fixed
+## 🛠 Fixed
 
 ### Chat messages preserve authored formatting
 
@@ -56,6 +56,9 @@ without forcing unnecessary work for every pull request.
 
 Linux and macOS users should install the Python wheel with `uv tool install`.
 Windows users can use either the wheel or the portable zip.
+
+The stable Windows portable alias contains the same build as the versioned
+portable zip, but keeps a fixed filename for scripts and docs.
 
 ## Upgrading from 0.3.0
 

--- a/docs/releases/0.3.1.md
+++ b/docs/releases/0.3.1.md
@@ -3,33 +3,29 @@
 ## Overview
 
 OpenSquilla 0.3.1 is a maintenance release for the 0.3 line. It updates the
-stable install metadata and brings selected channel, chat, provider, and
-workflow fixes from the integration branch onto the stable release line.
+stable install path while bringing the most user-visible fixes from the
+integration branch onto the release line.
 
-Use this release when you want the current 0.3 install assets plus the latest
-Slack setup fixes, media and voice workflow handoffs, multiline chat rendering,
-and provider request hardening on the stable release line.
+The release focuses on making day-to-day use less fragile: chat messages render
+as authored, Slack channel setup and replies keep the context they need, media
+and voice workflow handoffs are easier to continue, and invalid provider or
+release states are caught earlier.
 
 ## 🛠 Fixed
 
-### Chat messages preserve authored formatting
+### Chat and channel replies keep their context
 
-User-authored WebChat messages preserve multiline input and use spacing that
-makes them read like messages instead of compressed UI labels.
+WebChat now preserves multiline user messages and gives authored messages more
+readable spacing. Slack setup and reply paths also keep more of the context they
+need, including Socket Mode and app-mention setup, signing-secret checks,
+existing-secret preservation, and thread/channel metadata for replies.
 
-### Channel setup preserves the context needed for replies
+### Workflow handoffs recover more cleanly
 
-Slack Socket Mode, app mentions, signing-secret checks, existing-secret
-preservation, and threaded replies are hardened across onboarding and runtime
-paths. Incomplete Socket Mode setup is rejected earlier, and Slack reply
-handling keeps the channel metadata needed to answer in the right place.
-
-### Voice, media, and MetaSkill handoffs are more usable
-
-Voice/audio workflow handoffs and clarification pauses are on the stable
-release line. The bundled short-drama and video helper workflows remain
-available, with Windows-safe script handling and review pauses that make media
-workflow output easier to inspect before continuing.
+Voice/audio, media helper, and MetaSkill clarification handoffs are now on the
+stable release line. The bundled short-drama and video helper workflows remain
+available, with Windows-safe script handling and review pauses so generated
+workflow output is easier to inspect before continuing.
 
 ### Provider and release checks fail earlier
 

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v0.3.0'
+$defaultVersion = 'v0.3.1'
 $repoSlug = if ($env:OPENSQUILLA_REPOSITORY) { $env:OPENSQUILLA_REPOSITORY } else { 'opensquilla/opensquilla' }
 $pythonVersion = if ($env:OPENSQUILLA_PYTHON_VERSION) { $env:OPENSQUILLA_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -94,7 +94,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.3.0. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.3.1. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v0.3.0"
+default_version="v0.3.1"
 repo_slug="${OPENSQUILLA_REPOSITORY:-opensquilla/opensquilla}"
 python_version="${OPENSQUILLA_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v0.3.0|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v0.3.1|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  OPENSQUILLA_VERSION=v0.3.0
+  OPENSQUILLA_VERSION=v0.3.1
   OPENSQUILLA_INSTALL_PROFILE=recommended|core
   OPENSQUILLA_INSTALL_EXTRAS=matrix
   OPENSQUILLA_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported OPENSQUILLA_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.3.0." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.3.1." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -293,7 +293,11 @@ default_mode = "bypass"                 # off | on | bypass | full
 # name = "my-slack"
 # type = "slack"
 # token = "xoxb-..."
+# connection_mode = "socket"  # socket = no public URL; webhook = Events API
+# app_token = "xapp-..."      # required for Slack Socket Mode
+# signing_secret = ""         # required for Slack webhook mode
 # slack_channel_id = "C12345"
+# reply_in_thread = false
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Meta-Skill subsystem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensquilla"
-version = "0.3.0"
+version = "0.3.1"
 description = "OpenSquilla — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -7,7 +7,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v0.3.0"
+CURRENT_RELEASE_TAG = "v0.3.1"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-CURRENT_VERSION = "0.3.0"
+CURRENT_VERSION = "0.3.1"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.2.0rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"

--- a/tests/test_skills_default_prompt_contract.py
+++ b/tests/test_skills_default_prompt_contract.py
@@ -158,6 +158,7 @@ async def test_default_prompt_only_injects_retained_bundled_skills(
         EligibilityContext(
             os_name="linux",
             has_bin_cache={
+                "bibtex": True,
                 "codex": True,
                 "curl": True,
                 "ffmpeg": True,

--- a/uv.lock
+++ b/uv.lock
@@ -1644,7 +1644,7 @@ wheels = [
 
 [[package]]
 name = "opensquilla"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Sync the published OpenSquilla 0.3.1 release metadata back to `dev` without merging `main` wholesale.

This PR intentionally replays only the release-maintenance surface from the published `main` release:

- version/install metadata for `0.3.1`
- release notes source for `docs/releases/0.3.1.md`
- changelog/contributor/release documentation updates
- the prompt-contract CI fixture fix for `meta-paper-write` tool availability
- CI job display names required by the current `main` branch ruleset
- a small post-publish wording cleanup so the release source stays public-facing

It does **not** replay the broad `main` release-surface rollup commit, because that content was already sourced from `dev` and would only duplicate or blur the integration ledger.

## Published Release Evidence

- Release: https://github.com/opensquilla/opensquilla/releases/tag/v0.3.1
- Release target: `dc658e36b1fbb427915969b5d5590862fd17dc82`
- Release workflow: https://github.com/opensquilla/opensquilla/actions/runs/26865995069
- Assets present: wheel, versioned Windows portable zip, stable Windows portable alias, `SHA256SUMS`

## Validation

- `git diff --check origin/dev..HEAD`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color=false`
- `UV_PYTHON=3.12 PYTHONPATH="$PWD" uv run --extra dev pytest tests/test_release_consistency.py tests/test_public_release_hygiene.py tests/test_skills_default_prompt_contract.py -q` — 33 passed
- `UV_PYTHON=3.12 PYTHONPATH="$PWD" uv run --extra dev ruff check tests/test_release_consistency.py tests/test_public_release_hygiene.py tests/test_skills_default_prompt_contract.py`

## Notes

The first test attempt without `--extra dev` failed because the fresh worktree virtualenv lacked `pytest-asyncio` and `ruff`. The same checks passed after rerunning with the repo's dev dependency set.
