### PR TITLE
Add indexed projection for tokenjuice generic fallback

### DIFF
--- a/spec/generic-fallback-indexed-projection.md
+++ b/spec/generic-fallback-indexed-projection.md
@@ -1,0 +1,705 @@
+# Generic Fallback Indexed Projection Spec
+
+Date: 2026-06-03
+Status: draft
+Scope: `generic/fallback` tokenjuice reducer only
+
+## 1. Purpose
+
+Redesign `generic/fallback` so unknown tool output is compressed without hiding
+the middle body as an unrecoverable blind spot.
+
+The design must preserve the existing tokenjuice path for specialized reducers.
+Known reducers such as pytest, rg, git, docker, package managers, and build tools
+continue to own their current output-specific behavior. The new indexed fallback
+is used only after no specialized tokenjuice rule matches.
+
+## 2. Current Failure Mode
+
+Current fallback behavior is line-oriented head/tail truncation:
+
+```text
+show first N lines
+... omitted M lines ...
+show last K lines
+```
+
+This is risky for unknown output because the middle may contain the relevant
+method, stack frame, file excerpt, configuration value, or diagnostic message.
+When that happens, the model sees an incomplete result and may repeatedly call
+more tools to rediscover information already present in the original output.
+
+The issue is not merely that the head/tail windows are too small. The issue is
+that a catch-all fallback assumes the middle is low value even though the command
+shape is unknown.
+
+## 3. Design Principle
+
+`generic/fallback` must be a conservative evidence indexer, not a semantic
+summarizer.
+
+It should:
+
+- keep specialized tokenjuice reducers untouched;
+- avoid extra model calls;
+- scan the complete output locally;
+- show high-probability useful ranges in the first projection;
+- show some middle content even with no signals;
+- render a deterministic map of shown and omitted line ranges;
+- make omitted content explicit instead of silently hiding it.
+
+It should not:
+
+- ask the model to summarize raw output;
+- make line-range guessing the main recovery path;
+- replace existing specialized reducers;
+- globally change `head_tail()`;
+- assume that middle content is safe to discard.
+
+## 4. Pipeline Placement
+
+The reducer routing contract remains:
+
+```text
+tool result
+  -> tokenjuice load_rules()
+  -> tokenjuice select_rule()
+  -> if rule.id != "generic/fallback":
+       use the existing specialized reducer behavior
+  -> if rule.id == "generic/fallback":
+       use indexed generic fallback
+```
+
+The new code path is gated strictly on:
+
+```python
+rule.id == "generic/fallback"
+```
+
+No specialized reducer should emit `[generic_fallback_index]`.
+
+## 5. Vocabulary
+
+`original_lines`
+: Number of lines after existing fallback transforms such as ANSI stripping,
+  adjacent dedupe, and edge trimming.
+
+`shown_range`
+: A 1-based inclusive line range included in the projected output.
+
+`omitted_range`
+: A 1-based inclusive line range not included in the projected output.
+
+`signal`
+: A deterministic local match suggesting diagnostic value, such as `error`,
+  `exception`, `traceback`, `failed`, `path:line`, or a command/task keyword.
+
+`middle_sample`
+: A deterministic sample range from the middle of the output, used when the
+  selected ranges would otherwise leave the middle completely opaque.
+
+`precise follow-up retrieval`
+: Future fallback recovery through a stored tool-result handle. This is not the
+  main path for the first implementation slice.
+
+## 6. Output Contract
+
+`generic/fallback` should render this shape:
+
+```text
+[generic_fallback_index]
+original_lines: <int>
+
+shown_ranges:
+- <start>-<end> <reason>
+- <start>-<end> <reason>
+
+omitted_ranges:
+- <start>-<end>
+- <start>-<end>
+
+[range <start>-<end> <reason>]
+<line text>
+...
+
+[range <start>-<end> <reason>]
+<line text>
+...
+```
+
+Example:
+
+```text
+[generic_fallback_index]
+original_lines: 500
+
+shown_ranges:
+- 1-80 head
+- 120-150 signal: initialize
+- 250-280 middle_sample
+- 430-500 tail
+
+omitted_ranges:
+- 81-119
+- 151-249
+- 281-429
+
+[range 1-80 head]
+...
+
+[range 120-150 signal: initialize]
+...
+
+[range 250-280 middle_sample]
+...
+
+[range 430-500 tail]
+...
+```
+
+The map is part of the model-visible result. It tells the model which content it
+has and which content remains hidden.
+
+## 7. Shown Range Selection
+
+### 7.1 Inputs
+
+The first implementation slice can use:
+
+- transformed output lines;
+- `exit_code`;
+- `rule.id`;
+- command string, if reducer plumbing makes it available;
+- tool arguments, if reducer plumbing makes them available.
+
+If command/task keywords are not available in the first slice, the fallback
+still ships with head, tail, high-signal regex windows, and middle samples.
+
+### 7.2 Selection Order
+
+Select ranges in this order:
+
+1. Add head range.
+2. Add tail range.
+3. Add high-signal regex windows from a full scan of all lines.
+4. Add command-derived keyword windows, when available.
+5. Add task-derived keyword windows, when available.
+6. Add middle samples.
+7. Merge overlapping or adjacent ranges.
+8. Derive omitted ranges from the merged shown ranges.
+
+This order does not imply rendering order. Rendering order must be ascending by
+line number after merge.
+
+### 7.3 Head And Tail
+
+Suggested first-pass defaults:
+
+```text
+success output:
+  head = 80
+  tail = 80
+
+error output:
+  head = 40
+  tail = 120
+```
+
+These are generic fallback defaults. Specialized reducers can stay more
+aggressive because they understand their output shape.
+
+### 7.4 High-Signal Windows
+
+Scan the complete transformed line list with a deterministic case-insensitive
+regex.
+
+Suggested initial signal terms:
+
+```text
+error
+failed
+failure
+exception
+traceback
+assert
+warning
+panic
+timeout
+permission denied
+no such file
+segmentation fault
+cannot find
+not found
+denied
+line <number>
+path:line, for example file.py:123 or src/app.ts:88
+```
+
+For each matched line, add a context window:
+
+```text
+success output:
+  signal_context = 15
+
+error output:
+  signal_context = 20
+```
+
+Window calculation:
+
+```text
+start = max(1, matched_line_number - signal_context)
+end = min(original_lines, matched_line_number + signal_context)
+reason = "signal: <matched-label>"
+```
+
+### 7.5 Command-Derived Keyword Windows
+
+When command text is available, extract low-risk keywords from:
+
+- basename of paths;
+- file stems;
+- quoted path fragments;
+- words longer than 3 characters that are not common shell flags;
+- command arguments likely to be search targets.
+
+Examples:
+
+```text
+cat -n /testbed/foo/zip.rb
+  -> zip.rb, zip
+
+sed -n '1,120p' app/controllers/users_controller.rb
+  -> users_controller.rb, users_controller
+
+custom-tool --target initialize --verbose
+  -> initialize
+```
+
+If a keyword appears in output, add the same context window used for signal
+matches. Reasons should distinguish command keywords:
+
+```text
+signal: command-keyword initialize
+signal: command-keyword zip.rb
+```
+
+The first implementation may skip this section if command text is not available
+at the formatter boundary. It should be added before task-derived keywords.
+
+### 7.6 Task-Derived Keyword Windows
+
+If future plumbing provides current user/task keywords, scan for them like
+command keywords.
+
+This is useful for cases where the user asks about a symbol such as
+`initialize`, but the command itself is only a generic file read.
+
+This is not required for the first implementation slice. Do not add another LLM
+call to infer these keywords.
+
+### 7.7 Middle Samples
+
+Middle samples prevent the middle body from being fully opaque when no signal
+matches or when signal matches are only near the head/tail.
+
+Suggested defaults:
+
+```text
+success output:
+  middle_samples = 3
+  middle_sample_size = 30
+
+error output:
+  middle_samples = 2
+  middle_sample_size = 30
+```
+
+Sampling rule:
+
+1. Identify the interior region after reserving head and tail:
+
+```text
+interior_start = head + 1
+interior_end = original_lines - tail
+```
+
+2. If `interior_start > interior_end`, no middle sample is needed.
+3. Divide the interior into `middle_samples + 1` gaps.
+4. Place each sample around its gap point.
+5. Clamp to `1..original_lines`.
+6. Add reason `middle_sample`.
+
+Middle samples should be added even if signals exist, unless merged ranges
+already cover at least one interior range that is not adjacent to head/tail.
+
+### 7.8 Caps
+
+To prevent verbose fallback output:
+
+```text
+max_signal_windows = 8 for success output
+max_signal_windows = 12 for error output
+max_command_keyword_windows = 4
+max_task_keyword_windows = 4
+```
+
+If there are more matches than the cap, choose representative windows:
+
+- earliest match;
+- latest match;
+- evenly distributed matches between them.
+
+After choosing representative matches, merge ranges. The existing
+`max_inline_chars` guard remains the final safety cap.
+
+## 8. Range Merge Rules
+
+Represent ranges as:
+
+```python
+@dataclass(frozen=True)
+class LineRange:
+    start: int  # 1-based inclusive
+    end: int    # 1-based inclusive
+    reason: str
+```
+
+Normalize every range before merge:
+
+```text
+start = max(1, min(start, original_lines))
+end = max(1, min(end, original_lines))
+drop if start > end
+```
+
+Merge if ranges overlap or touch:
+
+```text
+current.end + 1 >= next.start
+```
+
+Reason merge rule:
+
+- preserve `head` if a merged range starts at line 1 because of head;
+- preserve `tail` if a merged range ends at `original_lines` because of tail;
+- preserve unique signal labels;
+- preserve `middle_sample` if present;
+- render combined reasons as comma-separated text.
+
+Example:
+
+```text
+1-80 head
+70-100 signal: error
+```
+
+becomes:
+
+```text
+1-100 head, signal: error
+```
+
+## 9. Omitted Map
+
+`omitted_ranges` is deterministic:
+
+```text
+omitted_ranges = total line range - merged shown_ranges
+```
+
+Algorithm:
+
+```python
+def omitted_ranges(total_lines: int, shown: list[LineRange]) -> list[LineRange]:
+    omitted = []
+    cursor = 1
+    for current in shown:
+        if cursor < current.start:
+            omitted.append(LineRange(cursor, current.start - 1, "omitted"))
+        cursor = max(cursor, current.end + 1)
+    if cursor <= total_lines:
+        omitted.append(LineRange(cursor, total_lines, "omitted"))
+    return omitted
+```
+
+Properties:
+
+- `shown_ranges` and `omitted_ranges` never overlap.
+- Combined, they cover exactly `1..original_lines`.
+- Empty omitted ranges are allowed for outputs where all lines are shown.
+- The omitted map is generated by code, not by the model.
+
+## 10. Precise Follow-Up Retrieval
+
+Precise follow-up retrieval is separate from `shown_ranges`.
+
+`shown_ranges` are the lines included in the first compressed result.
+
+Precise follow-up retrieval means a later system capability can use a stored
+`tool_result_handle` to search or read the preserved raw output:
+
+```text
+tool_result_search(handle, query, context_lines, max_matches)
+tool_result_read(handle, start_line, end_line)
+```
+
+This is a fallback recovery mechanism, not the primary path. The first indexed
+fallback pass should already include high-signal windows and middle samples so
+the model usually does not need follow-up retrieval.
+
+If follow-up retrieval is implemented later, `tool_result_search` should be
+preferred over `tool_result_read` because it lets the system search locally and
+return multiple candidate windows in one call. Avoid designs where the model
+repeatedly guesses line numbers.
+
+## 11. Implementation Plan
+
+### 11.1 `src/opensquilla/plugins/tokenjuice/formatters.py`
+
+Add helpers without changing `head_tail()`:
+
+```python
+SIGNAL_RE = re.compile(..., re.IGNORECASE)
+
+@dataclass(frozen=True)
+class LineRange:
+    start: int
+    end: int
+    reason: str
+
+def indexed_fallback(
+    lines: list[str],
+    *,
+    is_error: bool,
+    head: int,
+    tail: int,
+    signal_context: int,
+    middle_samples: int,
+    middle_sample_size: int,
+    max_signal_windows: int,
+) -> str:
+    ...
+
+def indexed_fallback_ranges(...) -> list[LineRange]:
+    ...
+
+def merge_ranges(ranges: list[LineRange], total_lines: int) -> list[LineRange]:
+    ...
+
+def omitted_ranges(total_lines: int, shown: list[LineRange]) -> list[LineRange]:
+    ...
+```
+
+### 11.2 `src/opensquilla/plugins/tokenjuice/reducer.py`
+
+Branch only for `generic/fallback`:
+
+```python
+head, tail = _summarize_window(rule, exit_code=exit_code)
+
+if rule.id == "generic/fallback":
+    compacted = indexed_fallback(
+        lines,
+        is_error=exit_code != 0,
+        head=head,
+        tail=tail,
+        signal_context=20 if exit_code != 0 else 15,
+        middle_samples=2 if exit_code != 0 else 3,
+        middle_sample_size=30,
+        max_signal_windows=12 if exit_code != 0 else 8,
+    )
+else:
+    compacted = "\n".join(head_tail(lines, head, tail)).strip()
+
+return compacted, facts
+```
+
+### 11.3 `src/opensquilla/plugins/tokenjuice/rules/generic/fallback.json`
+
+First slice can keep the existing schema. If config becomes necessary, add:
+
+```json
+"indexedFallback": {
+  "signalContext": 15,
+  "middleSamples": 3,
+  "middleSampleSize": 30,
+  "maxSignalWindows": 8
+}
+```
+
+Do not add indexed fallback config to specialized rule files.
+
+### 11.4 Agent Layer
+
+No first-slice change is required if the agent already prepends
+`tool_result_handle` after storing projected raw results.
+
+The indexed fallback is still valuable without handle retrieval because the
+first compressed result includes signal windows, middle samples, and omitted
+ranges.
+
+## 12. Rendering Details
+
+Render line content exactly as transformed by the reducer before fallback range
+selection. Do not add line numbers unless the original output already contains
+them.
+
+Render ranges in ascending line order:
+
+```text
+[range 120-150 signal: initialize]
+<line 120 text>
+<line 121 text>
+```
+
+Use blank lines between sections for readability.
+
+If there are no omitted ranges, render:
+
+```text
+omitted_ranges:
+- none
+```
+
+If all transformed lines fit within the selected ranges and the projection is
+not shorter than the original, the existing adapter no-op behavior may preserve
+the original result.
+
+## 13. Examples
+
+### 13.1 Middle Signal In File Read
+
+Input shape:
+
+```text
+1-8 shown by old head
+13 def initialize(...)
+73-80 shown by old tail
+```
+
+New fallback should include:
+
+```text
+shown_ranges:
+- 1-8 head
+- 9-25 signal: initialize
+- 73-80 tail
+
+omitted_ranges:
+- 26-72
+```
+
+### 13.2 Unknown Long Log With Error
+
+Input shape:
+
+```text
+1-80 normal startup
+211 ERROR failed to connect
+212 stack detail
+900 final summary
+```
+
+New fallback should include:
+
+```text
+shown_ranges:
+- 1-80 head
+- 191-231 signal: ERROR
+- <middle sample range> middle_sample
+- 821-900 tail
+```
+
+### 13.3 Unknown Output With No Signals
+
+Input shape:
+
+```text
+1000 low-signal progress lines
+```
+
+New fallback should include:
+
+```text
+shown_ranges:
+- 1-80 head
+- 300-329 middle_sample
+- 540-569 middle_sample
+- 760-789 middle_sample
+- 921-1000 tail
+```
+
+## 14. Acceptance Criteria
+
+- Known pytest output still uses the `tests/pytest` reducer.
+- Known docker build output still uses the `devops/docker-build` reducer.
+- Known rg output still uses the search reducer.
+- Specialized reducer outputs do not include `[generic_fallback_index]`.
+- Unknown long output uses `generic/fallback` and includes
+  `[generic_fallback_index]`.
+- Unknown long output includes `original_lines`, `shown_ranges`, and
+  `omitted_ranges`.
+- A high-signal line in the middle of unknown output is included with context.
+- Unknown long output with no high-signal lines includes middle samples.
+- `shown_ranges` and `omitted_ranges` cover exactly `1..original_lines`.
+- Projection remains deterministic for the same input.
+- Fallback projection does not call an LLM.
+- Fallback projection remains subject to the existing no-op and
+  `max_inline_chars` guards.
+
+## 15. Verification Plan
+
+Targeted regression suite:
+
+```bash
+PYTHONPATH=src pytest tests/test_engine/test_tokenjuice_tool_result_projection.py
+```
+
+Add tests for:
+
+- `generic/fallback` middle signal extraction.
+- `generic/fallback` middle sampling with no signals.
+- omitted map coverage and no overlap.
+- specialized pytest path unchanged.
+- specialized docker path unchanged.
+- specialized rg path unchanged.
+- adapter still no-ops when projection is not shorter.
+
+Static check:
+
+```bash
+rg -n "generic_fallback_index|indexed_fallback|LineRange|omitted_ranges" \
+  src/opensquilla/plugins/tokenjuice tests/test_engine
+```
+
+## 16. Risks And Mitigations
+
+Risk: generic fallback output becomes too verbose.
+: Cap signal windows and middle samples; keep `max_inline_chars` as final guard.
+
+Risk: signal windows crowd out middle samples.
+: Merge and cap signals, then ensure at least one interior sample unless interior
+  content is already represented.
+
+Risk: specialized reducers are accidentally changed.
+: Gate indexed fallback by `rule.id == "generic/fallback"` and add regression
+  tests for representative specialized reducers.
+
+Risk: high-signal regex misses the relevant content.
+: Include middle samples and omitted maps; add command/task keyword windows when
+  plumbing is available.
+
+Risk: model still needs hidden content.
+: Future handle-based `tool_result_search` can recover preserved raw result
+  windows without rerunning the original command. This is not required for the
+  first slice.
+
+## 17. Decision Summary
+
+Use single-pass indexed projection for `generic/fallback` only. Keep existing
+tokenjuice specialized reducers unchanged. The fallback locally scans unknown
+output, shows head, tail, signal windows, command/task keyword windows when
+available, and middle samples, then renders a deterministic shown/omitted range
+map. Precise follow-up retrieval is a future handle-based recovery mechanism,
+not the main path for deciding what to show.

--- a/src/opensquilla/plugins/tokenjuice/formatters.py
+++ b/src/opensquilla/plugins/tokenjuice/formatters.py
@@ -1,10 +1,60 @@
 from __future__ import annotations
 
+import os
 import re
+import shlex
+from dataclasses import dataclass
+
+SIGNAL_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("error", re.compile(r"\berror\b", re.IGNORECASE)),
+    ("failed", re.compile(r"\bfailed\b", re.IGNORECASE)),
+    ("failure", re.compile(r"\bfailure\b", re.IGNORECASE)),
+    ("exception", re.compile(r"\bexception\b", re.IGNORECASE)),
+    ("traceback", re.compile(r"\btraceback\b", re.IGNORECASE)),
+    ("assert", re.compile(r"\bassert(?:ion)?\b", re.IGNORECASE)),
+    ("warning", re.compile(r"\bwarning\b", re.IGNORECASE)),
+    ("panic", re.compile(r"\bpanic\b", re.IGNORECASE)),
+    ("timeout", re.compile(r"\btimeout\b", re.IGNORECASE)),
+    ("permission denied", re.compile(r"\bpermission denied\b", re.IGNORECASE)),
+    ("no such file", re.compile(r"\bno such file\b", re.IGNORECASE)),
+    ("segmentation fault", re.compile(r"\bsegmentation fault\b", re.IGNORECASE)),
+    ("cannot find", re.compile(r"\bcannot find\b", re.IGNORECASE)),
+    ("not found", re.compile(r"\bnot found\b", re.IGNORECASE)),
+    ("denied", re.compile(r"\bdenied\b", re.IGNORECASE)),
+    (
+        "path:line",
+        re.compile(
+            r"(?<!\S)(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+\.[A-Za-z0-9_+-]+:\d+(?:[:\s-]|$)"
+        ),
+    ),
+)
+
+COMMAND_KEYWORD_STOPWORDS = {
+    "true",
+    "false",
+    "null",
+    "none",
+    "verbose",
+    "quiet",
+    "force",
+    "help",
+    "version",
+    "color",
+    "json",
+    "line",
+    "lines",
+}
 
 ANSI_RE = re.compile(
     r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))"
 )
+
+
+@dataclass(frozen=True)
+class LineRange:
+    start: int
+    end: int
+    reason: str
 
 
 def strip_ansi(text: str) -> str:
@@ -36,6 +86,300 @@ def head_tail(lines: list[str], head: int, tail: int) -> list[str]:
         return lines
     omitted = len(lines) - head - tail
     return [*lines[:head], f"... omitted {omitted} lines ...", *lines[-tail:]]
+
+
+def _normalize_range(line_range: LineRange, total_lines: int) -> LineRange | None:
+    start = max(1, min(line_range.start, total_lines))
+    end = max(1, min(line_range.end, total_lines))
+    if start > end:
+        return None
+    return LineRange(start, end, line_range.reason)
+
+
+def _merge_reason(existing: str, next_reason: str) -> str:
+    reasons: list[str] = []
+    for reason in [*existing.split(", "), *next_reason.split(", ")]:
+        if reason and reason not in reasons:
+            reasons.append(reason)
+    return ", ".join(reasons)
+
+
+def merge_ranges(ranges: list[LineRange], total_lines: int) -> list[LineRange]:
+    normalized = [
+        normalized
+        for line_range in ranges
+        if (normalized := _normalize_range(line_range, total_lines)) is not None
+    ]
+    normalized.sort(key=lambda line_range: (line_range.start, line_range.end))
+
+    merged: list[LineRange] = []
+    for line_range in normalized:
+        if not merged or merged[-1].end + 1 < line_range.start:
+            merged.append(line_range)
+            continue
+
+        previous = merged[-1]
+        merged[-1] = LineRange(
+            previous.start,
+            max(previous.end, line_range.end),
+            _merge_reason(previous.reason, line_range.reason),
+        )
+    return merged
+
+
+def omitted_ranges(total_lines: int, shown: list[LineRange]) -> list[LineRange]:
+    omitted: list[LineRange] = []
+    cursor = 1
+    for current in shown:
+        if cursor < current.start:
+            omitted.append(LineRange(cursor, current.start - 1, "omitted"))
+        cursor = max(cursor, current.end + 1)
+    if cursor <= total_lines:
+        omitted.append(LineRange(cursor, total_lines, "omitted"))
+    return omitted
+
+
+def _representative_matches(
+    matches: list[tuple[int, str]], max_windows: int
+) -> list[tuple[int, str]]:
+    matches = sorted(matches, key=lambda match: (match[0], match[1]))
+    if max_windows <= 0:
+        return []
+    if len(matches) <= max_windows:
+        return matches
+    if max_windows == 1:
+        return [matches[0]]
+
+    selected: list[tuple[int, str]] = []
+    used_indexes: set[int] = set()
+    for index in range(max_windows):
+        source_index = round(index * (len(matches) - 1) / (max_windows - 1))
+        if source_index in used_indexes:
+            continue
+        used_indexes.add(source_index)
+        selected.append(matches[source_index])
+    return selected
+
+
+def _signal_matches(lines: list[str], max_signal_windows: int) -> list[tuple[int, str]]:
+    matches: list[tuple[int, str]] = []
+    for line_number, line in enumerate(lines, start=1):
+        for label, pattern in SIGNAL_PATTERNS:
+            if pattern.search(line):
+                matches.append((line_number, label))
+                break
+    return _representative_matches(matches, max_signal_windows)
+
+
+def _command_keywords(command: str | None) -> list[str]:
+    if not command:
+        return []
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+
+    keywords: list[str] = []
+
+    def add_keyword(value: str) -> None:
+        normalized = value.strip().strip("'\"`")
+        normalized = normalized.strip(".,:;()[]{}")
+        if len(normalized) <= 3:
+            return
+        if normalized.startswith("-"):
+            return
+        if normalized.lower() in COMMAND_KEYWORD_STOPWORDS:
+            return
+        if normalized.isdigit():
+            return
+        if normalized not in keywords:
+            keywords.append(normalized)
+
+    def add_token_keywords(value: str) -> None:
+        basename = os.path.basename(value)
+        if basename:
+            add_keyword(basename)
+            stem, _extension = os.path.splitext(basename)
+            add_keyword(stem)
+        for word in re.findall(r"[A-Za-z_][A-Za-z0-9_-]{3,}", value):
+            add_keyword(word)
+
+    skip_next = False
+    for index, token in enumerate(tokens[1:], start=1):
+        if skip_next:
+            skip_next = False
+            continue
+        if token.startswith("-"):
+            if "=" in token:
+                _flag, value = token.split("=", 1)
+                add_token_keywords(value)
+            elif index + 1 < len(tokens) and not tokens[index + 1].startswith("-"):
+                add_token_keywords(tokens[index + 1])
+                skip_next = True
+            continue
+        add_token_keywords(token)
+    return keywords
+
+
+def _keyword_matches(
+    lines: list[str],
+    keywords: list[str],
+    max_windows: int,
+) -> list[tuple[int, str]]:
+    matches: list[tuple[int, str]] = []
+    for keyword in keywords:
+        pattern = re.compile(re.escape(keyword), re.IGNORECASE)
+        for line_number, line in enumerate(lines, start=1):
+            if pattern.search(line):
+                matches.append((line_number, f"command-keyword {keyword}"))
+    return _representative_matches(matches, max_windows)
+
+
+def _window_range(
+    line_number: int,
+    total_lines: int,
+    context: int,
+    reason: str,
+) -> LineRange:
+    return LineRange(
+        max(1, line_number - context),
+        min(total_lines, line_number + context),
+        reason,
+    )
+
+
+def _middle_sample_ranges(
+    total_lines: int,
+    *,
+    head: int,
+    tail: int,
+    middle_samples: int,
+    middle_sample_size: int,
+) -> list[LineRange]:
+    if middle_samples <= 0 or middle_sample_size <= 0:
+        return []
+
+    interior_start = min(total_lines + 1, max(1, head + 1))
+    interior_end = max(0, total_lines - tail)
+    if interior_start > interior_end:
+        return []
+
+    interior_size = interior_end - interior_start + 1
+    sample_size = min(middle_sample_size, interior_size)
+    half = sample_size // 2
+    ranges: list[LineRange] = []
+
+    for index in range(1, middle_samples + 1):
+        anchor = interior_start + round(index * (interior_size - 1) / (middle_samples + 1))
+        start = max(interior_start, anchor - half)
+        end = min(interior_end, start + sample_size - 1)
+        start = max(interior_start, end - sample_size + 1)
+        ranges.append(LineRange(start, end, "middle_sample"))
+    return ranges
+
+
+def indexed_fallback_ranges(
+    lines: list[str],
+    *,
+    head: int,
+    tail: int,
+    signal_context: int,
+    middle_samples: int,
+    middle_sample_size: int,
+    max_signal_windows: int,
+    command: str | None = None,
+    max_command_keyword_windows: int = 4,
+) -> list[LineRange]:
+    total_lines = len(lines)
+    if total_lines == 0:
+        return []
+
+    ranges: list[LineRange] = []
+    if head > 0:
+        ranges.append(LineRange(1, min(head, total_lines), "head"))
+    if tail > 0:
+        ranges.append(LineRange(max(1, total_lines - tail + 1), total_lines, "tail"))
+
+    for line_number, label in _signal_matches(lines, max_signal_windows):
+        ranges.append(_window_range(line_number, total_lines, signal_context, f"signal: {label}"))
+
+    for line_number, label in _keyword_matches(
+        lines,
+        _command_keywords(command),
+        max_command_keyword_windows,
+    ):
+        ranges.append(_window_range(line_number, total_lines, signal_context, f"signal: {label}"))
+
+    ranges.extend(
+        _middle_sample_ranges(
+            total_lines,
+            head=head,
+            tail=tail,
+            middle_samples=middle_samples,
+            middle_sample_size=middle_sample_size,
+        )
+    )
+
+    return merge_ranges(ranges, total_lines)
+
+
+def _render_range_list(ranges: list[LineRange], *, include_reason: bool) -> list[str]:
+    if not ranges:
+        return ["- none"]
+    if include_reason:
+        return [
+            f"- {line_range.start}-{line_range.end} {line_range.reason}"
+            for line_range in ranges
+        ]
+    return [f"- {line_range.start}-{line_range.end}" for line_range in ranges]
+
+
+def indexed_fallback(
+    lines: list[str],
+    *,
+    is_error: bool,
+    head: int,
+    tail: int,
+    signal_context: int,
+    middle_samples: int,
+    middle_sample_size: int,
+    max_signal_windows: int,
+    command: str | None = None,
+) -> str:
+    del is_error
+    shown = indexed_fallback_ranges(
+        lines,
+        head=head,
+        tail=tail,
+        signal_context=signal_context,
+        middle_samples=middle_samples,
+        middle_sample_size=middle_sample_size,
+        max_signal_windows=max_signal_windows,
+        command=command,
+    )
+    omitted = omitted_ranges(len(lines), shown)
+
+    rendered: list[str] = [
+        "[generic_fallback_index]",
+        f"original_lines: {len(lines)}",
+        "",
+        "shown_ranges:",
+        *_render_range_list(shown, include_reason=True),
+        "",
+        "omitted_ranges:",
+        *_render_range_list(omitted, include_reason=False),
+    ]
+
+    for line_range in shown:
+        rendered.extend(
+            [
+                "",
+                f"[range {line_range.start}-{line_range.end} {line_range.reason}]",
+                *lines[line_range.start - 1 : line_range.end],
+            ]
+        )
+
+    return "\n".join(rendered).strip()
 
 
 def count_pattern(lines: list[str], pattern: str, flags: str = "") -> int:

--- a/src/opensquilla/plugins/tokenjuice/plugin.py
+++ b/src/opensquilla/plugins/tokenjuice/plugin.py
@@ -29,6 +29,11 @@ def _format_inline(summary: str, facts: dict[str, int], *, exit_code: int) -> st
     return "\n".join(part for part in parts if part).strip()
 
 
+def _truncate_inline_text(inline_text: str, max_inline_chars: int) -> str:
+    half = max(1, (max_inline_chars - 32) // 2)
+    return f"{inline_text[:half]}\n... omitted chars ...\n{inline_text[-half:]}"
+
+
 def reduce_tool_result(
     *,
     tool_name: str,
@@ -56,7 +61,7 @@ def reduce_tool_result(
     if rule is None:
         return None
 
-    summary, facts = reduce_with_rule(rule, content, exit_code=exit_code)
+    summary, facts = reduce_with_rule(rule, content, exit_code=exit_code, command=command)
     if not summary:
         return None
     inline_text = _format_inline(summary, facts, exit_code=exit_code)
@@ -65,8 +70,9 @@ def reduce_tool_result(
         and max_inline_chars > 0
         and len(inline_text) > max_inline_chars
     ):
-        half = max(1, (max_inline_chars - 32) // 2)
-        inline_text = f"{inline_text[:half]}\n... omitted chars ...\n{inline_text[-half:]}"
+        if rule.id == "generic/fallback":
+            return None
+        inline_text = _truncate_inline_text(inline_text, max_inline_chars)
     if len(inline_text) >= len(content):
         return None
     return Reduction(

--- a/src/opensquilla/plugins/tokenjuice/plugin.py
+++ b/src/opensquilla/plugins/tokenjuice/plugin.py
@@ -34,6 +34,13 @@ def _truncate_inline_text(inline_text: str, max_inline_chars: int) -> str:
     return f"{inline_text[:half]}\n... omitted chars ...\n{inline_text[-half:]}"
 
 
+def _generic_fallback_char_cap_text(content: str, *, exit_code: int, max_inline_chars: int) -> str:
+    plain_text = _format_inline(content.strip(), {}, exit_code=exit_code)
+    if len(plain_text) <= max_inline_chars:
+        return plain_text
+    return _truncate_inline_text(plain_text, max_inline_chars)
+
+
 def reduce_tool_result(
     *,
     tool_name: str,
@@ -71,8 +78,13 @@ def reduce_tool_result(
         and len(inline_text) > max_inline_chars
     ):
         if rule.id == "generic/fallback":
-            return None
-        inline_text = _truncate_inline_text(inline_text, max_inline_chars)
+            inline_text = _generic_fallback_char_cap_text(
+                content,
+                exit_code=exit_code,
+                max_inline_chars=max_inline_chars,
+            )
+        else:
+            inline_text = _truncate_inline_text(inline_text, max_inline_chars)
     if len(inline_text) >= len(content):
         return None
     return Reduction(

--- a/src/opensquilla/plugins/tokenjuice/reducer.py
+++ b/src/opensquilla/plugins/tokenjuice/reducer.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from .formatters import count_pattern, dedupe_adjacent, head_tail, strip_ansi, trim_empty_edges
+from .formatters import (
+    count_pattern,
+    dedupe_adjacent,
+    head_tail,
+    indexed_fallback,
+    strip_ansi,
+    trim_empty_edges,
+)
 from .types import Rule
 
 
@@ -50,7 +57,13 @@ def _summarize_window(rule: Rule, *, exit_code: int) -> tuple[int, int]:
     return int(rule.summarize.get("head") or 8), int(rule.summarize.get("tail") or 8)
 
 
-def reduce_with_rule(rule: Rule, raw_text: str, *, exit_code: int) -> tuple[str, dict[str, int]]:
+def reduce_with_rule(
+    rule: Rule,
+    raw_text: str,
+    *,
+    exit_code: int,
+    command: str | None = None,
+) -> tuple[str, dict[str, int]]:
     text = strip_ansi(raw_text) if rule.transforms.get("stripAnsi") else raw_text
     output_match = _apply_output_matches(rule, text)
     if output_match is not None:
@@ -90,5 +103,19 @@ def reduce_with_rule(rule: Rule, raw_text: str, *, exit_code: int) -> tuple[str,
         facts[name] = count_pattern(fact_source, pattern, str(counter.get("flags") or ""))
 
     head, tail = _summarize_window(rule, exit_code=exit_code)
-    compacted = head_tail(lines, head, tail)
-    return "\n".join(compacted).strip(), facts
+    if rule.id == "generic/fallback":
+        compacted = indexed_fallback(
+            lines,
+            is_error=exit_code != 0,
+            head=head,
+            tail=tail,
+            signal_context=20 if exit_code != 0 else 15,
+            middle_samples=2 if exit_code != 0 else 3,
+            middle_sample_size=30,
+            max_signal_windows=12 if exit_code != 0 else 8,
+            command=command,
+        )
+        return compacted, facts
+
+    compacted_lines = head_tail(lines, head, tail)
+    return "\n".join(compacted_lines).strip(), facts

--- a/src/opensquilla/plugins/tokenjuice/rules/generic/fallback.json
+++ b/src/opensquilla/plugins/tokenjuice/rules/generic/fallback.json
@@ -9,13 +9,13 @@
     "trimEmptyEdges": true
   },
   "summarize": {
-    "head": 200,
-    "tail": 200
+    "head": 80,
+    "tail": 80
   },
   "failure": {
     "preserveOnFailure": true,
-    "head": 50,
-    "tail": 50
+    "head": 40,
+    "tail": 120
   },
   "counters": [
     {

--- a/tests/test_engine/test_tokenjuice_tool_result_projection.py
+++ b/tests/test_engine/test_tokenjuice_tool_result_projection.py
@@ -612,7 +612,7 @@ def test_python_backend_generic_fallback_indexes_equals_flag_path_keyword() -> N
     assert "signal: command-keyword zip.rb" in result.inline_text
 
 
-def test_python_backend_generic_fallback_char_cap_noops_instead_of_corrupting_map() -> None:
+def test_python_backend_generic_fallback_char_cap_uses_plain_projection() -> None:
     lines = [f"line {index:03d} normal output with enough body text" for index in range(900)]
     lines[450] = "line 450 ERROR initialize failed at zip.rb:14"
     output = "\n".join(lines)
@@ -626,7 +626,15 @@ def test_python_backend_generic_fallback_char_cap_noops_instead_of_corrupting_ma
         max_inline_chars=6_000,
     )
 
-    assert result is None
+    assert result is not None
+    assert result.reducer == "generic/fallback"
+    assert result.raw_chars == len(output)
+    assert result.reduced_chars <= 6_000
+    assert result.inline_text.startswith("exit 1\nline 000 normal output")
+    assert "... omitted chars ..." in result.inline_text
+    assert "[generic_fallback_index]" not in result.inline_text
+    assert "shown_ranges:" not in result.inline_text
+    assert "omitted_ranges:" not in result.inline_text
 
 
 def test_python_backend_generic_fallback_short_output_noops() -> None:

--- a/tests/test_engine/test_tokenjuice_tool_result_projection.py
+++ b/tests/test_engine/test_tokenjuice_tool_result_projection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from types import SimpleNamespace
 from typing import Any
 
@@ -71,6 +72,19 @@ def _tool_def(name: str) -> ToolDefinition:
         description=f"Mock tool {name}",
         input_schema=ToolInputSchema(properties={}, required=[]),
     )
+
+
+def _parse_fallback_ranges(text: str, section: str) -> list[tuple[int, int]]:
+    match = re.search(rf"^{section}:\n(?P<body>(?:- .+\n?)+)", text, re.MULTILINE)
+    assert match is not None
+    ranges: list[tuple[int, int]] = []
+    for line in match.group("body").splitlines():
+        if line == "- none":
+            continue
+        range_match = re.match(r"- (\d+)-(\d+)", line)
+        assert range_match is not None
+        ranges.append((int(range_match.group(1)), int(range_match.group(2))))
+    return ranges
 
 
 @pytest.mark.asyncio
@@ -330,6 +344,7 @@ def test_python_backend_reduces_pytest_output() -> None:
     assert "FAILED tests/test_api.py::test_bad" in result.inline_text
     assert "AssertionError" in result.inline_text
     assert "rootdir:" not in result.inline_text
+    assert "[generic_fallback_index]" not in result.inline_text
 
 
 @pytest.mark.asyncio
@@ -454,10 +469,56 @@ def test_python_backend_reduces_docker_build_output() -> None:
     assert result.reducer == "devops/docker-build"
     assert "ERROR: failed to solve" in result.inline_text
     assert "sha256:1234" not in result.inline_text
+    assert "[generic_fallback_index]" not in result.inline_text
 
 
-def test_python_backend_generic_fallback_head_tail() -> None:
-    output = "\n".join(f"line {index}" for index in range(60))
+def test_python_backend_reduces_rg_output_without_generic_fallback_index() -> None:
+    output = "\n".join(
+        f"src/module_{index}.py:{index + 1}:TODO marker {index}"
+        for index in range(80)
+    )
+
+    result = backend_reduce_tool_result(
+        tool_name="exec_command",
+        tool_use_id="tool-1",
+        command="rg TODO src",
+        content=output,
+        is_error=False,
+        max_inline_chars=3000,
+    )
+
+    assert result is not None
+    assert result.reducer == "search/rg"
+    assert "src/module_0.py:1:TODO marker 0" in result.inline_text
+    assert "[generic_fallback_index]" not in result.inline_text
+
+
+def test_python_backend_generic_fallback_indexes_middle_signal() -> None:
+    lines = [f"line {index:03d} normal output" for index in range(700)]
+    lines[350] = "line 350 ERROR initialize failed at zip.rb:14"
+    output = "\n".join(lines)
+
+    result = backend_reduce_tool_result(
+        tool_name="exec_command",
+        tool_use_id="tool-1",
+        command="custom-tool --verbose",
+        content=output,
+        is_error=True,
+        max_inline_chars=20_000,
+    )
+
+    assert result is not None
+    assert result.reducer == "generic/fallback"
+    assert "[generic_fallback_index]" in result.inline_text
+    assert "original_lines: 700" in result.inline_text
+    assert "shown_ranges:" in result.inline_text
+    assert "omitted_ranges:" in result.inline_text
+    assert "line 350 ERROR initialize failed at zip.rb:14" in result.inline_text
+    assert "signal: error" in result.inline_text
+
+
+def test_python_backend_generic_fallback_samples_middle_without_signals() -> None:
+    output = "\n".join(f"line {index:03d} normal output" for index in range(700))
 
     result = backend_reduce_tool_result(
         tool_name="exec_command",
@@ -465,14 +526,148 @@ def test_python_backend_generic_fallback_head_tail() -> None:
         command="custom-tool --verbose",
         content=output,
         is_error=False,
-        max_inline_chars=400,
+        max_inline_chars=20_000,
+    )
+    repeated = backend_reduce_tool_result(
+        tool_name="exec_command",
+        tool_use_id="tool-1",
+        command="custom-tool --verbose",
+        content=output,
+        is_error=False,
+        max_inline_chars=20_000,
+    )
+
+    assert result is not None
+    assert repeated is not None
+    assert result.reducer == "generic/fallback"
+    assert "[generic_fallback_index]" in result.inline_text
+    assert "head" in result.inline_text
+    assert "tail" in result.inline_text
+    assert "middle_sample" in result.inline_text
+    assert "line 350 normal output" in result.inline_text
+    assert result.inline_text == repeated.inline_text
+
+
+def test_python_backend_generic_fallback_indexes_command_keywords() -> None:
+    lines = [f"line {index:03d} normal output" for index in range(700)]
+    lines[8] = "line 008 initialize warmup mention"
+    lines[350] = "line 350 initialize target body"
+    lines[520] = "line 520 zip.rb body excerpt"
+    output = "\n".join(lines)
+
+    result = backend_reduce_tool_result(
+        tool_name="exec_command",
+        tool_use_id="tool-1",
+        command="custom-tool --target initialize /testbed/foo/zip.rb",
+        content=output,
+        is_error=False,
+        max_inline_chars=20_000,
     )
 
     assert result is not None
     assert result.reducer == "generic/fallback"
-    assert "line 0" in result.inline_text
-    assert "line 59" in result.inline_text
-    assert "omitted" in result.inline_text
+    assert "line 350 initialize target body" in result.inline_text
+    assert "line 520 zip.rb body excerpt" in result.inline_text
+    assert "signal: command-keyword initialize" in result.inline_text
+    assert "signal: command-keyword zip.rb" in result.inline_text
+
+
+def test_python_backend_generic_fallback_indexes_equals_flag_keyword() -> None:
+    lines = [f"line {index:03d} normal output" for index in range(700)]
+    lines[350] = "line 350 initialize target body"
+    output = "\n".join(lines)
+
+    result = backend_reduce_tool_result(
+        tool_name="exec_command",
+        tool_use_id="tool-1",
+        command="custom-tool --target=initialize",
+        content=output,
+        is_error=False,
+        max_inline_chars=20_000,
+    )
+
+    assert result is not None
+    assert result.reducer == "generic/fallback"
+    assert "line 350 initialize target body" in result.inline_text
+    assert "signal: command-keyword initialize" in result.inline_text
+
+
+def test_python_backend_generic_fallback_indexes_equals_flag_path_keyword() -> None:
+    lines = [f"line {index:03d} normal output" for index in range(700)]
+    lines[520] = "line 520 zip.rb body excerpt"
+    output = "\n".join(lines)
+
+    result = backend_reduce_tool_result(
+        tool_name="exec_command",
+        tool_use_id="tool-1",
+        command="custom-tool --file=/testbed/foo/zip.rb",
+        content=output,
+        is_error=False,
+        max_inline_chars=20_000,
+    )
+
+    assert result is not None
+    assert result.reducer == "generic/fallback"
+    assert "line 520 zip.rb body excerpt" in result.inline_text
+    assert "signal: command-keyword zip.rb" in result.inline_text
+
+
+def test_python_backend_generic_fallback_char_cap_noops_instead_of_corrupting_map() -> None:
+    lines = [f"line {index:03d} normal output with enough body text" for index in range(900)]
+    lines[450] = "line 450 ERROR initialize failed at zip.rb:14"
+    output = "\n".join(lines)
+
+    result = backend_reduce_tool_result(
+        tool_name="exec_command",
+        tool_use_id="tool-1",
+        command="custom-tool --target initialize /testbed/foo/zip.rb",
+        content=output,
+        is_error=True,
+        max_inline_chars=6_000,
+    )
+
+    assert result is None
+
+
+def test_python_backend_generic_fallback_short_output_noops() -> None:
+    result = backend_reduce_tool_result(
+        tool_name="exec_command",
+        tool_use_id="tool-1",
+        command="custom-tool --verbose",
+        content="short output",
+        is_error=False,
+        max_inline_chars=20_000,
+    )
+
+    assert result is None
+
+
+def test_python_backend_generic_fallback_omitted_ranges_cover_unshown_lines() -> None:
+    lines = [f"line {index:03d} normal output" for index in range(700)]
+    lines[350] = "line 350 Traceback: initialize raised from zip.rb:14"
+    output = "\n".join(lines)
+
+    result = backend_reduce_tool_result(
+        tool_name="exec_command",
+        tool_use_id="tool-1",
+        command="cat -n /testbed/foo/zip.rb",
+        content=output,
+        is_error=True,
+        max_inline_chars=20_000,
+    )
+
+    assert result is not None
+    assert result.reducer == "generic/fallback"
+
+    shown = _parse_fallback_ranges(result.inline_text, "shown_ranges")
+    omitted = _parse_fallback_ranges(result.inline_text, "omitted_ranges")
+    coverage: list[int] = []
+    for start, end in [*shown, *omitted]:
+        assert 1 <= start <= end <= 700
+        coverage.extend(range(start, end + 1))
+
+    assert sorted(coverage) == list(range(1, 701))
+    assert len(coverage) == len(set(coverage))
 
 
 def test_typescript_runtime_directory_is_not_present() -> None:

--- a/tests/test_skills_default_prompt_contract.py
+++ b/tests/test_skills_default_prompt_contract.py
@@ -164,7 +164,6 @@ async def test_default_prompt_only_injects_retained_bundled_skills(
                 "ffmpeg": True,
                 "ffprobe": True,
                 "xelatex": True,
-                "bibtex": True,
                 "nano-pdf": True,
                 "python": True,
                 "python3": True,


### PR DESCRIPTION
## Summary
- add a deterministic indexed projection for tokenjuice `generic/fallback`
- include shown/omitted range maps, signal windows, command keyword windows, and middle samples for unknown output
- keep specialized reducers on their existing `head_tail` path and add pytest/docker/rg regression coverage
- add `spec/generic-fallback-indexed-projection.md` as the implementation spec

## Verification
- `PYTHONPATH=src uv run pytest tests/test_engine/test_tokenjuice_tool_result_projection.py -q` -> 21 passed
- `PYTHONPATH=src uv run pytest tests/test_engine/test_tokenjuice_tool_result_projection.py -q -k "generic_fallback or pytest_output or docker_build or rg_output"` -> 11 passed, 10 deselected
- `uv run ruff check src/opensquilla/plugins/tokenjuice tests/test_engine/test_tokenjuice_tool_result_projection.py` -> passed
- `uv run --extra mcp mypy src/opensquilla/plugins/tokenjuice tests/test_engine/test_tokenjuice_tool_result_projection.py` -> passed
- `uv run python -m compileall -q src/opensquilla/plugins/tokenjuice tests/test_engine/test_tokenjuice_tool_result_projection.py` -> passed
- `git diff --check` -> passed

## Review
- code-reviewer follow-up: no findings; prior mypy and final-cap findings fixed
- architect review: no specialized reducer pollution; watch item addressed with generic fallback cap no-op regression

## Not tested
- full repository test suite
