### PR TITLE
Skill API-key resolution: fall back to opensquilla config when env unset

### DIFF
--- a/src/opensquilla/skills/bundled/nano-banana-pro/SKILL.md
+++ b/src/opensquilla/skills/bundled/nano-banana-pro/SKILL.md
@@ -63,9 +63,18 @@ through `with:` by convention; for edit workflows call the script.
 
 ## Auth
 
-Reads `OPENROUTER_API_KEY` from the process environment. The gateway
-already injects it from `.env` if configured. No Google Gemini key
-needed.
+API-key resolution order (first hit wins):
+1. `--api-key` CLI argument (rarely used; meta-skills don't pass it)
+2. `OPENROUTER_API_KEY` environment variable (gateway injects from `.env`)
+3. `OPENSQUILLA_LLM_API_KEY` environment variable (Pydantic-settings
+   shortcut for the `llm.api_key` config field)
+4. `llm.api_key` from the OpenSquilla TOML config file —
+   `./opensquilla.toml`, then `$OPENSQUILLA_STATE_DIR/config.toml`,
+   then `~/.opensquilla/config.toml`. Only consumed when `llm.provider`
+   in the same file equals `"openrouter"`.
+
+No Google Gemini key needed — OpenRouter routes the request to the
+Gemini image model on the user's behalf.
 
 ## Output
 

--- a/src/opensquilla/skills/bundled/nano-banana-pro/SKILL.md
+++ b/src/opensquilla/skills/bundled/nano-banana-pro/SKILL.md
@@ -66,12 +66,16 @@ through `with:` by convention; for edit workflows call the script.
 API-key resolution order (first hit wins):
 1. `--api-key` CLI argument (rarely used; meta-skills don't pass it)
 2. `OPENROUTER_API_KEY` environment variable (gateway injects from `.env`)
-3. `OPENSQUILLA_LLM_API_KEY` environment variable (Pydantic-settings
-   shortcut for the `llm.api_key` config field)
-4. `llm.api_key` from the OpenSquilla TOML config file —
-   `./opensquilla.toml`, then `$OPENSQUILLA_STATE_DIR/config.toml`,
-   then `~/.opensquilla/config.toml`. Only consumed when `llm.provider`
-   in the same file equals `"openrouter"`.
+3. `OPENSQUILLA_LLM_API_KEY` environment variable, only when the
+   effective OpenSquilla LLM provider resolves to `openrouter`.
+4. `llm.api_key` or `llm.api_key_env` from the selected OpenSquilla TOML
+   config file. Config discovery matches `GatewayConfig.load`: explicit
+   `OPENSQUILLA_GATEWAY_CONFIG_PATH` first; otherwise
+   `./opensquilla.toml`, then `default_opensquilla_home()/config.toml`.
+   `OPENSQUILLA_STATE_DIR` changes `default_opensquilla_home()`, so a
+   state-dir profile does not fall through to `~/.opensquilla`.
+   Config-file credentials are consumed only when the selected config's
+   `llm.provider` is `openrouter` or omitted.
 
 No Google Gemini key needed — OpenRouter routes the request to the
 Gemini image model on the user's behalf.
@@ -90,7 +94,9 @@ any error; stderr carries the diagnostic.
 
 ## Common failures
 
-- `OPENROUTER_API_KEY not set` → check `.env` or `$env:OPENROUTER_API_KEY`.
+- `no OpenRouter API key found` → set `OPENROUTER_API_KEY`, pass
+  `--api-key`, or configure `[llm] provider = "openrouter"` with
+  `api_key` / `api_key_env` in the selected OpenSquilla config.
 - `OpenRouter returned no image` → the model rejected the prompt
   (content moderation or unsupported request). Rewrite prompt; check
   IP-safety rules in `ai-video-script`.

--- a/src/opensquilla/skills/bundled/nano-banana-pro/scripts/generate_image.py
+++ b/src/opensquilla/skills/bundled/nano-banana-pro/scripts/generate_image.py
@@ -75,10 +75,53 @@ def _openrouter_attribution_headers(url: str | None) -> dict[str, str]:
     }
 
 
+def _openrouter_key_from_config() -> str | None:
+    """Fallback: read llm.api_key from the OpenSquilla TOML config file.
+
+    Bundled skills run as detached Python subprocesses and cannot import
+    opensquilla itself, so this duplicates the config-discovery logic
+    from ``opensquilla.gateway.config.GatewayConfig.load`` and
+    ``opensquilla.paths.default_opensquilla_home`` deliberately. Only
+    returns a key when ``llm.provider`` resolves to OpenRouter (the
+    config-file key is whatever the main agent uses, which only makes
+    sense to reuse here when both providers match).
+    """
+    import tomllib
+
+    candidates: list[Path] = [Path.cwd() / "opensquilla.toml"]
+    state_dir = (os.environ.get("OPENSQUILLA_STATE_DIR") or "").strip()
+    if state_dir:
+        candidates.append(Path(state_dir).expanduser() / "config.toml")
+    candidates.append(Path.home() / ".opensquilla" / "config.toml")
+
+    for path in candidates:
+        try:
+            if not path.is_file():
+                continue
+            with open(path, "rb") as f:
+                data = tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+        llm = data.get("llm") if isinstance(data, dict) else None
+        if not isinstance(llm, dict):
+            continue
+        provider = str(llm.get("provider") or "openrouter").strip().lower()
+        if provider != "openrouter":
+            continue
+        key = str(llm.get("api_key") or "").strip()
+        if key:
+            return key
+    return None
+
+
 def resolve_api_key(provided: str | None) -> str | None:
     if provided:
         return provided.strip()
-    return (os.environ.get("OPENROUTER_API_KEY") or "").strip() or None
+    for env_name in ("OPENROUTER_API_KEY", "OPENSQUILLA_LLM_API_KEY"):
+        val = (os.environ.get(env_name) or "").strip()
+        if val:
+            return val
+    return _openrouter_key_from_config()
 
 
 def encode_input_image(path: str) -> str:

--- a/src/opensquilla/skills/bundled/nano-banana-pro/scripts/generate_image.py
+++ b/src/opensquilla/skills/bundled/nano-banana-pro/scripts/generate_image.py
@@ -26,6 +26,8 @@ Usage:
 Auth:
     1. --api-key argument
     2. OPENROUTER_API_KEY environment variable
+    3. OPENSQUILLA_LLM_API_KEY when the effective LLM provider is openrouter
+    4. llm.api_key / llm.api_key_env from the selected OpenSquilla config
 
 Output: prints the absolute path of the saved PNG on stdout.
 """
@@ -75,53 +77,110 @@ def _openrouter_attribution_headers(url: str | None) -> dict[str, str]:
     }
 
 
-def _openrouter_key_from_config() -> str | None:
-    """Fallback: read llm.api_key from the OpenSquilla TOML config file.
+def _home_dir() -> Path:
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return Path(home).expanduser()
+    return Path.home()
 
-    Bundled skills run as detached Python subprocesses and cannot import
-    opensquilla itself, so this duplicates the config-discovery logic
-    from ``opensquilla.gateway.config.GatewayConfig.load`` and
-    ``opensquilla.paths.default_opensquilla_home`` deliberately. Only
-    returns a key when ``llm.provider`` resolves to OpenRouter (the
-    config-file key is whatever the main agent uses, which only makes
-    sense to reuse here when both providers match).
+
+def _expand_user(path: str) -> Path:
+    if path == "~":
+        return _home_dir()
+    if path.startswith("~/") or path.startswith("~\\"):
+        return _home_dir() / path[2:]
+    return Path(path).expanduser()
+
+
+def _default_opensquilla_home() -> Path:
+    state_dir = (os.environ.get("OPENSQUILLA_STATE_DIR") or "").strip()
+    if state_dir:
+        return _expand_user(state_dir)
+    return _home_dir() / ".opensquilla"
+
+
+def _gateway_config_candidates() -> list[Path]:
+    config_path = (os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH") or "").strip()
+    if config_path:
+        return [_expand_user(config_path)]
+    return [
+        Path.cwd() / "opensquilla.toml",
+        _default_opensquilla_home() / "config.toml",
+    ]
+
+
+def _selected_llm_config() -> dict | None:
+    """Return the llm table from the config file GatewayConfig would select.
+
+    This intentionally stops at the first existing candidate, matching
+    ``GatewayConfig.load``. In particular, ``OPENSQUILLA_STATE_DIR`` replaces
+    the default home; it is not a profile layered over ``~/.opensquilla``.
     """
     import tomllib
 
-    candidates: list[Path] = [Path.cwd() / "opensquilla.toml"]
-    state_dir = (os.environ.get("OPENSQUILLA_STATE_DIR") or "").strip()
-    if state_dir:
-        candidates.append(Path(state_dir).expanduser() / "config.toml")
-    candidates.append(Path.home() / ".opensquilla" / "config.toml")
-
-    for path in candidates:
+    for path in _gateway_config_candidates():
         try:
             if not path.is_file():
                 continue
             with open(path, "rb") as f:
                 data = tomllib.load(f)
         except (OSError, tomllib.TOMLDecodeError):
-            continue
+            return {}
         llm = data.get("llm") if isinstance(data, dict) else None
-        if not isinstance(llm, dict):
-            continue
-        provider = str(llm.get("provider") or "openrouter").strip().lower()
-        if provider != "openrouter":
-            continue
-        key = str(llm.get("api_key") or "").strip()
-        if key:
-            return key
+        return llm if isinstance(llm, dict) else {}
+    return None
+
+
+def _config_llm_provider(llm: dict | None) -> str:
+    if llm is None:
+        return "openrouter"
+    return str(llm.get("provider") or "openrouter").strip().lower()
+
+
+def _effective_llm_provider(llm: dict | None) -> str:
+    if isinstance(llm, dict) and "provider" in llm:
+        return _config_llm_provider(llm)
+    env_provider = (os.environ.get("OPENSQUILLA_LLM_PROVIDER") or "").strip()
+    if env_provider:
+        return env_provider.lower()
+    return _config_llm_provider(llm)
+
+
+def _openrouter_llm_env_key(llm: dict | None) -> str | None:
+    if _effective_llm_provider(llm) != "openrouter":
+        return None
+    return (os.environ.get("OPENSQUILLA_LLM_API_KEY") or "").strip() or None
+
+
+def _openrouter_key_from_config(llm: dict | None) -> str | None:
+    """Fallback: read OpenRouter credentials from the selected TOML config.
+
+    Bundled skills run as detached Python subprocesses and cannot import
+    opensquilla itself, so this duplicates the config-discovery logic
+    from ``opensquilla.gateway.config.GatewayConfig.load`` and
+    ``opensquilla.paths.default_opensquilla_home`` deliberately.
+    """
+    if not isinstance(llm, dict) or _effective_llm_provider(llm) != "openrouter":
+        return None
+    key = str(llm.get("api_key") or "").strip()
+    if key:
+        return key
+    key_env = str(llm.get("api_key_env") or "").strip()
+    if key_env:
+        return (os.environ.get(key_env) or "").strip() or None
     return None
 
 
 def resolve_api_key(provided: str | None) -> str | None:
     if provided:
-        return provided.strip()
-    for env_name in ("OPENROUTER_API_KEY", "OPENSQUILLA_LLM_API_KEY"):
-        val = (os.environ.get(env_name) or "").strip()
-        if val:
-            return val
-    return _openrouter_key_from_config()
+        key = provided.strip()
+        if key:
+            return key
+    val = (os.environ.get("OPENROUTER_API_KEY") or "").strip()
+    if val:
+        return val
+    llm = _selected_llm_config()
+    return _openrouter_llm_env_key(llm) or _openrouter_key_from_config(llm)
 
 
 def encode_input_image(path: str) -> str:
@@ -312,7 +371,12 @@ def main() -> int:
 
     api_key = resolve_api_key(args.api_key)
     if not api_key:
-        print("Error: OPENROUTER_API_KEY not set and --api-key not provided.", file=sys.stderr)
+        print(
+            "Error: no OpenRouter API key found. Pass --api-key, set "
+            "OPENROUTER_API_KEY, or configure an OpenRouter llm key in "
+            "OpenSquilla config.",
+            file=sys.stderr,
+        )
         return 1
 
     if args.input_image and not Path(args.input_image).is_file():

--- a/src/opensquilla/skills/bundled/seedance-2-prompt/SKILL.md
+++ b/src/opensquilla/skills/bundled/seedance-2-prompt/SKILL.md
@@ -102,9 +102,17 @@ See `references/recipes.md`, `references/modes-and-recipes.md`,
 
 ## Auth
 
-- `openrouter` provider reads `OPENROUTER_API_KEY`.
+- `openrouter` provider API-key resolution order:
+  1. `OPENROUTER_API_KEY` env var
+  2. `OPENSQUILLA_LLM_API_KEY` env var (Pydantic shortcut for `llm.api_key`)
+  3. `llm.api_key` from the OpenSquilla TOML config (`./opensquilla.toml`,
+     then `$OPENSQUILLA_STATE_DIR/config.toml`, then
+     `~/.opensquilla/config.toml`) — only used when `llm.provider` in
+     the same file equals `"openrouter"`.
 - `volcengine` / `byteplus` provider reads `ARK_API_KEY` (with provider-
-  specific fallbacks `VOLC_ARK_API_KEY` / `BYTEPLUS_API_KEY`).
+  specific fallbacks `VOLC_ARK_API_KEY` / `BYTEPLUS_API_KEY`). No
+  config-file fallback for these — the OpenSquilla config file holds
+  the **agent's** key, which is OpenRouter, so it would not apply.
 - All three send the key as `Authorization: Bearer <key>`.
 - For OpenRouter the same bearer is also added when downloading the
   resulting `unsigned_urls[0]`. Volcengine returns pre-signed object

--- a/src/opensquilla/skills/bundled/seedance-2-prompt/SKILL.md
+++ b/src/opensquilla/skills/bundled/seedance-2-prompt/SKILL.md
@@ -103,16 +103,23 @@ See `references/recipes.md`, `references/modes-and-recipes.md`,
 ## Auth
 
 - `openrouter` provider API-key resolution order:
-  1. `OPENROUTER_API_KEY` env var
-  2. `OPENSQUILLA_LLM_API_KEY` env var (Pydantic shortcut for `llm.api_key`)
-  3. `llm.api_key` from the OpenSquilla TOML config (`./opensquilla.toml`,
-     then `$OPENSQUILLA_STATE_DIR/config.toml`, then
-     `~/.opensquilla/config.toml`) — only used when `llm.provider` in
-     the same file equals `"openrouter"`.
+  1. `--api-key` CLI argument
+  2. `OPENROUTER_API_KEY` env var
+  3. `OPENSQUILLA_LLM_API_KEY` env var, only when the effective
+     OpenSquilla LLM provider resolves to `openrouter`
+  4. `llm.api_key` or `llm.api_key_env` from the selected OpenSquilla
+     TOML config. Config discovery matches `GatewayConfig.load`:
+     explicit `OPENSQUILLA_GATEWAY_CONFIG_PATH` first; otherwise
+     `./opensquilla.toml`, then `default_opensquilla_home()/config.toml`.
+     `OPENSQUILLA_STATE_DIR` changes `default_opensquilla_home()`, so a
+     state-dir profile does not fall through to `~/.opensquilla`.
+     Config-file credentials are consumed only when the selected config's
+     `llm.provider` is `openrouter` or omitted.
 - `volcengine` / `byteplus` provider reads `ARK_API_KEY` (with provider-
   specific fallbacks `VOLC_ARK_API_KEY` / `BYTEPLUS_API_KEY`). No
-  config-file fallback for these — the OpenSquilla config file holds
-  the **agent's** key, which is OpenRouter, so it would not apply.
+  config-file fallback for these — the OpenSquilla `[llm]` config
+  describes the agent's selected LLM provider, not ARK / BytePlus video
+  credentials.
 - All three send the key as `Authorization: Bearer <key>`.
 - For OpenRouter the same bearer is also added when downloading the
   resulting `unsigned_urls[0]`. Volcengine returns pre-signed object

--- a/src/opensquilla/skills/bundled/seedance-2-prompt/scripts/generate_video.py
+++ b/src/opensquilla/skills/bundled/seedance-2-prompt/scripts/generate_video.py
@@ -275,13 +275,62 @@ def _encode_input_image(path: str) -> str:
     return f"data:{mime};base64,{base64.b64encode(raw).decode('ascii')}"
 
 
-def _resolve_api_key(provided: str | None, env_names: Iterable[str]) -> str | None:
+def _openrouter_key_from_config() -> str | None:
+    """Fallback: read llm.api_key from the OpenSquilla TOML config file.
+
+    Bundled skills run as detached Python subprocesses and cannot
+    import opensquilla, so this duplicates the config-discovery logic
+    from ``opensquilla.gateway.config.GatewayConfig.load`` and
+    ``opensquilla.paths.default_opensquilla_home`` deliberately. Only
+    returns a key when ``llm.provider`` is openrouter — the config key
+    is what the main agent talks to, and reusing it here only makes
+    sense when both share the same provider host.
+    """
+    import tomllib
+
+    candidates: list[Path] = [Path.cwd() / "opensquilla.toml"]
+    state_dir = (os.environ.get("OPENSQUILLA_STATE_DIR") or "").strip()
+    if state_dir:
+        candidates.append(Path(state_dir).expanduser() / "config.toml")
+    candidates.append(Path.home() / ".opensquilla" / "config.toml")
+
+    for path in candidates:
+        try:
+            if not path.is_file():
+                continue
+            with open(path, "rb") as f:
+                data = tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+        llm = data.get("llm") if isinstance(data, dict) else None
+        if not isinstance(llm, dict):
+            continue
+        provider = str(llm.get("provider") or "openrouter").strip().lower()
+        if provider != "openrouter":
+            continue
+        key = str(llm.get("api_key") or "").strip()
+        if key:
+            return key
+    return None
+
+
+def _resolve_api_key(
+    provided: str | None,
+    env_names: Iterable[str],
+    *,
+    provider_name: str = "",
+) -> str | None:
     if provided:
         return provided.strip()
-    for name in env_names:
+    extra_env_names: tuple[str, ...] = ()
+    if provider_name == "openrouter":
+        extra_env_names = ("OPENSQUILLA_LLM_API_KEY",)
+    for name in (*env_names, *extra_env_names):
         val = (os.environ.get(name) or "").strip()
         if val:
             return val
+    if provider_name == "openrouter":
+        return _openrouter_key_from_config()
     return None
 
 
@@ -481,7 +530,9 @@ def main() -> int:
     provider = PROVIDERS[raw.provider]
     base_url = raw.base_url or provider.default_base_url
     model_id = raw.model or provider.default_model
-    api_key = _resolve_api_key(raw.api_key or None, provider.default_env)
+    api_key = _resolve_api_key(
+        raw.api_key or None, provider.default_env, provider_name=provider.name,
+    )
     if not api_key:
         env_hint = " / ".join(provider.default_env)
         print(

--- a/src/opensquilla/skills/bundled/seedance-2-prompt/scripts/generate_video.py
+++ b/src/opensquilla/skills/bundled/seedance-2-prompt/scripts/generate_video.py
@@ -275,42 +275,97 @@ def _encode_input_image(path: str) -> str:
     return f"data:{mime};base64,{base64.b64encode(raw).decode('ascii')}"
 
 
-def _openrouter_key_from_config() -> str | None:
-    """Fallback: read llm.api_key from the OpenSquilla TOML config file.
+def _home_dir() -> Path:
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return Path(home).expanduser()
+    return Path.home()
 
-    Bundled skills run as detached Python subprocesses and cannot
-    import opensquilla, so this duplicates the config-discovery logic
-    from ``opensquilla.gateway.config.GatewayConfig.load`` and
-    ``opensquilla.paths.default_opensquilla_home`` deliberately. Only
-    returns a key when ``llm.provider`` is openrouter — the config key
-    is what the main agent talks to, and reusing it here only makes
-    sense when both share the same provider host.
+
+def _expand_user(path: str) -> Path:
+    if path == "~":
+        return _home_dir()
+    if path.startswith("~/") or path.startswith("~\\"):
+        return _home_dir() / path[2:]
+    return Path(path).expanduser()
+
+
+def _default_opensquilla_home() -> Path:
+    state_dir = (os.environ.get("OPENSQUILLA_STATE_DIR") or "").strip()
+    if state_dir:
+        return _expand_user(state_dir)
+    return _home_dir() / ".opensquilla"
+
+
+def _gateway_config_candidates() -> list[Path]:
+    config_path = (os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH") or "").strip()
+    if config_path:
+        return [_expand_user(config_path)]
+    return [
+        Path.cwd() / "opensquilla.toml",
+        _default_opensquilla_home() / "config.toml",
+    ]
+
+
+def _selected_llm_config() -> dict | None:
+    """Return the llm table from the config file GatewayConfig would select.
+
+    This intentionally stops at the first existing candidate, matching
+    ``GatewayConfig.load``. In particular, ``OPENSQUILLA_STATE_DIR`` replaces
+    the default home; it is not a profile layered over ``~/.opensquilla``.
     """
     import tomllib
 
-    candidates: list[Path] = [Path.cwd() / "opensquilla.toml"]
-    state_dir = (os.environ.get("OPENSQUILLA_STATE_DIR") or "").strip()
-    if state_dir:
-        candidates.append(Path(state_dir).expanduser() / "config.toml")
-    candidates.append(Path.home() / ".opensquilla" / "config.toml")
-
-    for path in candidates:
+    for path in _gateway_config_candidates():
         try:
             if not path.is_file():
                 continue
             with open(path, "rb") as f:
                 data = tomllib.load(f)
         except (OSError, tomllib.TOMLDecodeError):
-            continue
+            return {}
         llm = data.get("llm") if isinstance(data, dict) else None
-        if not isinstance(llm, dict):
-            continue
-        provider = str(llm.get("provider") or "openrouter").strip().lower()
-        if provider != "openrouter":
-            continue
-        key = str(llm.get("api_key") or "").strip()
-        if key:
-            return key
+        return llm if isinstance(llm, dict) else {}
+    return None
+
+
+def _config_llm_provider(llm: dict | None) -> str:
+    if llm is None:
+        return "openrouter"
+    return str(llm.get("provider") or "openrouter").strip().lower()
+
+
+def _effective_llm_provider(llm: dict | None) -> str:
+    if isinstance(llm, dict) and "provider" in llm:
+        return _config_llm_provider(llm)
+    env_provider = (os.environ.get("OPENSQUILLA_LLM_PROVIDER") or "").strip()
+    if env_provider:
+        return env_provider.lower()
+    return _config_llm_provider(llm)
+
+
+def _openrouter_llm_env_key(llm: dict | None) -> str | None:
+    if _effective_llm_provider(llm) != "openrouter":
+        return None
+    return (os.environ.get("OPENSQUILLA_LLM_API_KEY") or "").strip() or None
+
+
+def _openrouter_key_from_config(llm: dict | None) -> str | None:
+    """Fallback: read OpenRouter credentials from the selected TOML config.
+
+    Bundled skills run as detached Python subprocesses and cannot
+    import opensquilla, so this duplicates the config-discovery logic
+    from ``opensquilla.gateway.config.GatewayConfig.load`` and
+    ``opensquilla.paths.default_opensquilla_home`` deliberately.
+    """
+    if not isinstance(llm, dict) or _effective_llm_provider(llm) != "openrouter":
+        return None
+    key = str(llm.get("api_key") or "").strip()
+    if key:
+        return key
+    key_env = str(llm.get("api_key_env") or "").strip()
+    if key_env:
+        return (os.environ.get(key_env) or "").strip() or None
     return None
 
 
@@ -321,16 +376,16 @@ def _resolve_api_key(
     provider_name: str = "",
 ) -> str | None:
     if provided:
-        return provided.strip()
-    extra_env_names: tuple[str, ...] = ()
-    if provider_name == "openrouter":
-        extra_env_names = ("OPENSQUILLA_LLM_API_KEY",)
-    for name in (*env_names, *extra_env_names):
+        key = provided.strip()
+        if key:
+            return key
+    for name in env_names:
         val = (os.environ.get(name) or "").strip()
         if val:
             return val
     if provider_name == "openrouter":
-        return _openrouter_key_from_config()
+        llm = _selected_llm_config()
+        return _openrouter_llm_env_key(llm) or _openrouter_key_from_config(llm)
     return None
 
 
@@ -535,10 +590,18 @@ def main() -> int:
     )
     if not api_key:
         env_hint = " / ".join(provider.default_env)
-        print(
-            f"Error: no API key. Pass --api-key or set one of: {env_hint}.",
-            file=sys.stderr,
-        )
+        if provider.name == "openrouter":
+            print(
+                "Error: no OpenRouter API key found. Pass --api-key, set "
+                "OPENROUTER_API_KEY, or configure an OpenRouter llm key in "
+                "OpenSquilla config.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"Error: no API key. Pass --api-key or set one of: {env_hint}.",
+                file=sys.stderr,
+            )
         return 1
 
     if raw.input_image and not Path(raw.input_image).is_file():

--- a/tests/test_skills/test_openrouter_skill_key_resolution.py
+++ b/tests/test_skills/test_openrouter_skill_key_resolution.py
@@ -1,0 +1,236 @@
+"""Regression tests for bundled OpenRouter skill key fallback.
+
+The bundled scripts are intentionally imported by file path here because the
+skill directories contain hyphens and run as standalone subprocess scripts.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IMAGE_SCRIPT = (
+    REPO_ROOT
+    / "src/opensquilla/skills/bundled/nano-banana-pro/scripts/generate_image.py"
+)
+VIDEO_SCRIPT = (
+    REPO_ROOT
+    / "src/opensquilla/skills/bundled/seedance-2-prompt/scripts/generate_video.py"
+)
+
+
+def _load_script(path: Path, module_name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def image_script() -> ModuleType:
+    return _load_script(IMAGE_SCRIPT, "_opensquilla_test_generate_image")
+
+
+@pytest.fixture(scope="module")
+def video_script() -> ModuleType:
+    return _load_script(VIDEO_SCRIPT, "_opensquilla_test_generate_video")
+
+
+@pytest.fixture
+def isolated_runtime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    for name in (
+        "OPENROUTER_API_KEY",
+        "OPENSQUILLA_LLM_API_KEY",
+        "OPENSQUILLA_LLM_PROVIDER",
+        "OPENSQUILLA_GATEWAY_CONFIG_PATH",
+        "OPENSQUILLA_STATE_DIR",
+        "CUSTOM_OPENROUTER_KEY",
+        "ARK_API_KEY",
+        "VOLC_ARK_API_KEY",
+        "BYTEPLUS_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    home.mkdir()
+    workspace.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(workspace)
+    return tmp_path
+
+
+def _write_toml(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body.strip() + "\n", encoding="utf-8")
+    return path
+
+
+def _resolve_video_openrouter(video_script: ModuleType) -> str | None:
+    return video_script._resolve_api_key(
+        None,
+        ("OPENROUTER_API_KEY",),
+        provider_name="openrouter",
+    )
+
+
+def test_openrouter_skills_use_explicit_gateway_config_path(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _write_toml(
+        isolated_runtime / "custom" / "gateway.toml",
+        """
+        [llm]
+        provider = "openrouter"
+        api_key = "explicit-config-key"
+        """,
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(config_path))
+
+    assert image_script.resolve_api_key(None) == "explicit-config-key"
+    assert _resolve_video_openrouter(video_script) == "explicit-config-key"
+
+
+def test_openrouter_skills_use_configured_api_key_env(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_toml(
+        Path.cwd() / "opensquilla.toml",
+        """
+        [llm]
+        provider = "openrouter"
+        api_key_env = "CUSTOM_OPENROUTER_KEY"
+        """,
+    )
+    monkeypatch.setenv("CUSTOM_OPENROUTER_KEY", "custom-env-key")
+
+    assert image_script.resolve_api_key(None) == "custom-env-key"
+    assert _resolve_video_openrouter(video_script) == "custom-env-key"
+
+
+def test_openrouter_skills_do_not_treat_other_provider_llm_env_as_openrouter(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_LLM_PROVIDER", "anthropic")
+    monkeypatch.setenv("OPENSQUILLA_LLM_API_KEY", "anthropic-key")
+
+    assert image_script.resolve_api_key(None) is None
+    assert _resolve_video_openrouter(video_script) is None
+
+
+def test_selected_config_provider_beats_conflicting_env_provider(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_toml(
+        Path.cwd() / "opensquilla.toml",
+        """
+        [llm]
+        provider = "anthropic"
+        """,
+    )
+    monkeypatch.setenv("OPENSQUILLA_LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("OPENSQUILLA_LLM_API_KEY", "generic-env-key")
+
+    assert image_script.resolve_api_key(None) is None
+    assert _resolve_video_openrouter(video_script) is None
+
+
+def test_missing_config_provider_can_use_openrouter_env_provider(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_toml(
+        Path.cwd() / "opensquilla.toml",
+        """
+        [llm]
+        api_key = "toml-key"
+        """,
+    )
+    monkeypatch.setenv("OPENSQUILLA_LLM_PROVIDER", "openrouter")
+
+    assert image_script.resolve_api_key(None) == "toml-key"
+    assert _resolve_video_openrouter(video_script) == "toml-key"
+
+
+def test_openrouter_skills_do_not_fall_back_to_home_when_state_dir_config_exists(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_dir = isolated_runtime / "state-profile"
+    _write_toml(
+        state_dir / "config.toml",
+        """
+        [llm]
+        provider = "anthropic"
+        api_key = "state-anthropic-key"
+        """,
+    )
+    _write_toml(
+        isolated_runtime / "home" / ".opensquilla" / "config.toml",
+        """
+        [llm]
+        provider = "openrouter"
+        api_key = "global-openrouter-key"
+        """,
+    )
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(state_dir))
+
+    assert image_script.resolve_api_key(None) is None
+    assert _resolve_video_openrouter(video_script) is None
+
+
+def test_openrouter_specific_env_still_wins_for_openrouter_skills(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-env-key")
+    monkeypatch.setenv("OPENSQUILLA_LLM_PROVIDER", "anthropic")
+    monkeypatch.setenv("OPENSQUILLA_LLM_API_KEY", "anthropic-key")
+
+    assert image_script.resolve_api_key(None) == "openrouter-env-key"
+    assert _resolve_video_openrouter(video_script) == "openrouter-env-key"
+
+
+def test_non_openrouter_video_provider_uses_only_its_provider_env(
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARK_API_KEY", "ark-key")
+    monkeypatch.setenv("OPENSQUILLA_LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("OPENSQUILLA_LLM_API_KEY", "openrouter-key")
+
+    assert (
+        video_script._resolve_api_key(
+            None,
+            ("ARK_API_KEY", "VOLC_ARK_API_KEY"),
+            provider_name="volcengine",
+        )
+        == "ark-key"
+    )


### PR DESCRIPTION
## Summary

`nano-banana-pro` and `seedance-2-prompt` resolved the OpenRouter API
key from the process environment only. The gateway injects it from
`.env` at boot, so that works for users who keep the key there — but
a user who put `llm.api_key` in `opensquilla.toml` or
`~/.opensquilla/config.toml` and nothing in env would see
meta-short-drama die with `OPENROUTER_API_KEY not set` even though the
main agent has been talking to the same key the whole time.

Extend the resolver in both scripts to walk this chain:

1. `--api-key` CLI argument (unchanged)
2. `OPENROUTER_API_KEY` env var (unchanged)
3. `OPENSQUILLA_LLM_API_KEY` env var (Pydantic-settings shortcut for
   the `llm.api_key` config field)
4. `llm.api_key` from the TOML config — discovered in the same order
   as `GatewayConfig.load`: `./opensquilla.toml` → `$OPENSQUILLA_STATE_DIR/config.toml` → `~/.opensquilla/config.toml`.
   Only consumed when `llm.provider` in that file equals `openrouter`.

For seedance the config-file branch is OpenRouter-only; volcengine /
byteplus providers continue to read `ARK_API_KEY` / `VOLC_ARK_API_KEY`
/ `BYTEPLUS_API_KEY` (the agent's TOML key only makes sense to reuse
when the chat and video providers share a host).

The helper is duplicated inline in each script — bundled skills run as
detached Python subprocesses and cannot import `opensquilla`. ~30
extra lines per script; same trade-off the existing
`_OPENROUTER_APP_REFERER` constants already make.

## Test plan

- [x] Smoke-tested `nano-banana-pro/scripts/generate_image.py::resolve_api_key` across 5 cases (no-config, config-only, env-wins, cli-wins, wrong-provider-ignored) — all green.
- [x] Smoke-tested `seedance-2-prompt/scripts/generate_video.py::_resolve_api_key` across 7 cases including the volcengine-shouldn't-pick-up-openrouter-config negative case — all green.
- [x] `ruff check` passes on both skill directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)