### PR TITLE
Test channel authentication boundaries

### DIFF
--- a/tests/test_channels/test_dingtalk_auth_validation.py
+++ b/tests/test_channels/test_dingtalk_auth_validation.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from opensquilla.channels.dingtalk import DingTalkChannel, DingTalkChannelConfig
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_dingtalk_start_requires_client_id_and_secret() -> None:
+    with pytest.raises(ValueError, match="client_id and client_secret are required"):
+        await DingTalkChannel(DingTalkChannelConfig(client_secret="secret")).start()
+
+    with pytest.raises(ValueError, match="client_id and client_secret are required"):
+        await DingTalkChannel(DingTalkChannelConfig(client_id="client-id")).start()
+
+
+@pytest.mark.anyio
+async def test_dingtalk_start_builds_stream_client_with_client_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credentials: list[tuple[str, str]] = []
+    clients: list[Any] = []
+
+    class FakeChatbotMessage:
+        TOPIC = "chatbot.topic"
+
+        @staticmethod
+        def from_dict(data: dict[str, Any]) -> Any:
+            return data
+
+    class FakeAckMessage:
+        STATUS_OK = "ok"
+
+    class FakeAsyncChatbotHandler:
+        def __init__(self) -> None:
+            return None
+
+    class FakeCredential:
+        def __init__(self, client_id: str, client_secret: str) -> None:
+            self.client_id = client_id
+            self.client_secret = client_secret
+            credentials.append((client_id, client_secret))
+
+    class FakeStreamClient:
+        def __init__(self, credential: FakeCredential) -> None:
+            self.credential = credential
+            self.handlers: list[tuple[str, Any]] = []
+            clients.append(self)
+
+        def register_callback_handler(self, topic: str, handler: Any) -> None:
+            self.handlers.append((topic, handler))
+
+        async def start(self) -> None:
+            await asyncio.sleep(0)
+
+    fake_module = types.ModuleType("dingtalk_stream")
+    setattr(fake_module, "AckMessage", FakeAckMessage)
+    setattr(fake_module, "AsyncChatbotHandler", FakeAsyncChatbotHandler)
+    setattr(fake_module, "ChatbotMessage", FakeChatbotMessage)
+    setattr(fake_module, "Credential", FakeCredential)
+    setattr(fake_module, "DingTalkStreamClient", FakeStreamClient)
+    monkeypatch.setitem(sys.modules, "dingtalk_stream", fake_module)
+
+    channel = DingTalkChannel(
+        DingTalkChannelConfig(client_id="client-id", client_secret="client-secret")
+    )
+
+    await channel.start()
+    await channel.stop()
+
+    assert credentials == [("client-id", "client-secret")]
+    assert len(clients) == 1
+    assert clients[0].handlers
+    assert clients[0].handlers[0][0] == "chatbot.topic"

--- a/tests/test_channels/test_discord_auth_validation.py
+++ b/tests/test_channels/test_discord_auth_validation.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from opensquilla.channels.discord import DiscordChannel, DiscordChannelConfig
+from opensquilla.onboarding.channel_specs import get_channel_setup_spec
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_discord_gateway_url_fetch_uses_bot_token_auth_header() -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        assert request.url.path == "/api/v10/gateway/bot"
+        assert request.headers["Authorization"] == "Bot bot-token"
+        return httpx.Response(200, json={"url": "wss://gateway.discord.gg/"})
+
+    channel = DiscordChannel(DiscordChannelConfig(token="bot-token"))
+    channel._client = httpx.AsyncClient(
+        base_url="https://discord.com/api/v10",
+        transport=httpx.MockTransport(handler),
+    )
+
+    try:
+        url = await channel._fetch_gateway_url()
+    finally:
+        await channel.stop()
+
+    assert url == "wss://gateway.discord.gg/?v=10&encoding=json"
+    assert len(requests) == 1
+
+
+@pytest.mark.anyio
+async def test_discord_identify_payload_uses_bot_token_and_intents() -> None:
+    sent: list[dict] = []
+    channel = DiscordChannel(DiscordChannelConfig(token="bot-token", intents=513))
+
+    async def fake_ws_send(payload: dict) -> None:
+        sent.append(payload)
+
+    channel._ws_send = fake_ws_send  # type: ignore[method-assign]
+
+    await channel._identify()
+
+    assert len(sent) == 1
+    assert sent[0]["op"] == 2
+    assert sent[0]["d"]["token"] == "bot-token"
+    assert sent[0]["d"]["intents"] == 513
+    assert {"os", "browser", "device"} <= set(sent[0]["d"]["properties"])
+
+
+def test_discord_gateway_spec_does_not_accept_interactions_public_key_as_auth() -> None:
+    fields = {field.name: field for field in get_channel_setup_spec("discord").fields}
+
+    assert fields["token"].secret is True
+    assert fields["application_id"].secret is False
+    assert "public_key" not in fields

--- a/tests/test_channels/test_feishu_auth_validation.py
+++ b/tests/test_channels/test_feishu_auth_validation.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import httpx
+import pytest
+from starlette.requests import Request
+
+from opensquilla.channels._util import EventDedupeCache
+from opensquilla.channels.feishu import (
+    FeishuAuthError,
+    FeishuChannel,
+    FeishuChannelConfig,
+    FeishuWebhookTransport,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_tenant_access_token_uses_app_credentials_and_caches_token() -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        payload = json.loads((await request.aread()).decode())
+        assert request.url.path == "/open-apis/auth/v3/tenant_access_token/internal"
+        assert payload == {"app_id": "cli_test", "app_secret": "secret"}
+        return httpx.Response(
+            200,
+            json={
+                "code": 0,
+                "msg": "success",
+                "tenant_access_token": "tenant-token",
+                "expire": 7200,
+            },
+        )
+
+    channel = FeishuChannel(
+        FeishuChannelConfig(app_id="cli_test", app_secret="secret", connection_mode="webhook")
+    )
+    channel._client = httpx.AsyncClient(
+        base_url="https://open.feishu.cn/open-apis",
+        transport=httpx.MockTransport(handler),
+    )
+
+    try:
+        first = await channel._get_token()
+        second = await channel._get_token()
+    finally:
+        await channel.stop()
+
+    assert first == "tenant-token"
+    assert second == "tenant-token"
+    assert len(requests) == 1
+
+
+@pytest.mark.anyio
+async def test_tenant_access_token_error_raises_auth_error() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"code": 999, "msg": "invalid app credentials"})
+
+    channel = FeishuChannel(
+        FeishuChannelConfig(app_id="cli_test", app_secret="bad-secret", connection_mode="webhook")
+    )
+    channel._client = httpx.AsyncClient(
+        base_url="https://open.feishu.cn/open-apis",
+        transport=httpx.MockTransport(handler),
+    )
+
+    try:
+        with pytest.raises(FeishuAuthError, match="invalid app credentials"):
+            await channel._get_token()
+    finally:
+        await channel.stop()
+
+
+async def _feishu_webhook_response(
+    transport: FeishuWebhookTransport,
+    *,
+    body: dict,
+    signature: str | None,
+    timestamp: str = "1710000000",
+    nonce: str = "nonce",
+):
+    headers: list[tuple[bytes, bytes]] = [
+        (b"content-type", b"application/json"),
+        (b"x-lark-request-timestamp", timestamp.encode()),
+        (b"x-lark-request-nonce", nonce.encode()),
+    ]
+    if signature is not None:
+        headers.append((b"x-lark-signature", signature.encode()))
+    raw = json.dumps(body).encode()
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": transport.config.webhook_path,
+        "headers": headers,
+        "query_string": b"",
+    }
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": raw, "more_body": False}
+
+    request = Request(scope, receive)
+    return await transport._handle_webhook(request)
+
+
+def _feishu_signature(*, encrypt_key: str, timestamp: str, nonce: str, body: dict) -> str:
+    body_str = json.dumps(body)
+    return hashlib.sha256(f"{timestamp}{nonce}{encrypt_key}{body_str}".encode()).hexdigest()
+
+
+@pytest.mark.anyio
+async def test_feishu_webhook_rejects_missing_or_wrong_signature() -> None:
+    transport = FeishuWebhookTransport(
+        FeishuChannelConfig(
+            app_id="cli_test",
+            app_secret="secret",
+            encrypt_key="encrypt-key",
+            connection_mode="webhook",
+        ),
+        EventDedupeCache(max_size=10),
+    )
+    body = {"type": "url_verification", "challenge": "challenge-token"}
+
+    missing = await _feishu_webhook_response(transport, body=body, signature=None)
+    wrong = await _feishu_webhook_response(transport, body=body, signature="bad-signature")
+
+    assert missing.status_code == 401
+    assert wrong.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_feishu_webhook_accepts_valid_signature_for_url_verification() -> None:
+    transport = FeishuWebhookTransport(
+        FeishuChannelConfig(
+            app_id="cli_test",
+            app_secret="secret",
+            encrypt_key="encrypt-key",
+            connection_mode="webhook",
+        ),
+        EventDedupeCache(max_size=10),
+    )
+    body = {"type": "url_verification", "challenge": "challenge-token"}
+    signature = _feishu_signature(
+        encrypt_key="encrypt-key",
+        timestamp="1710000000",
+        nonce="nonce",
+        body=body,
+    )
+
+    response = await _feishu_webhook_response(transport, body=body, signature=signature)
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {"challenge": "challenge-token"}
+
+
+def test_feishu_webhook_verification_material_is_kept_in_config() -> None:
+    config = FeishuChannelConfig(
+        app_id="cli_test",
+        app_secret="secret",
+        encrypt_key="encrypt-key",
+        verification_token="verification-token",
+        connection_mode="webhook",
+    )
+
+    assert config.encrypt_key == "encrypt-key"
+    assert config.verification_token == "verification-token"

--- a/tests/test_channels/test_feishu_websocket_transport.py
+++ b/tests/test_channels/test_feishu_websocket_transport.py
@@ -74,7 +74,9 @@ def _install_fake_lark_module(monkeypatch: pytest.MonkeyPatch) -> tuple[types.Mo
     class FakeClient:
         instances: list[FakeClient] = []
 
-        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.args = args
+            self.kwargs = kwargs
             self.disconnect_called = False
             self.started = False
             self.start_loop: asyncio.AbstractEventLoop | None = None
@@ -131,6 +133,7 @@ async def test_feishu_websocket_stop_stops_sdk_loop_thread(
 
     client = fake_client.instances[-1]
     assert client.start_loop is sdk_module.loop
+    assert client.args[:2] == ("app", "secret")
 
     await transport.stop()
 

--- a/tests/test_channels/test_telegram_auth_validation.py
+++ b/tests/test_channels/test_telegram_auth_validation.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from starlette.requests import Request
+
+from opensquilla.channels.telegram import TelegramChannel, TelegramChannelConfig
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class RecordingTelegramChannel(TelegramChannel):
+    def __init__(self, config: TelegramChannelConfig) -> None:
+        super().__init__(config)
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def _api(self, method: str, payload: dict[str, Any] | None = None) -> Any:
+        self.calls.append((method, payload or {}))
+        if method == "getMe":
+            return {"id": 12345, "username": "opensquilla_test_bot"}
+        return True
+
+
+@pytest.mark.anyio
+async def test_webhook_start_validates_token_with_get_me_then_sets_secret_token() -> None:
+    channel = RecordingTelegramChannel(
+        TelegramChannelConfig(
+            token="bot-token",
+            transport_name="webhook",
+            webhook_url="https://example.test/telegram/events",
+            webhook_secret_token="secret-token",
+            drop_pending_updates=True,
+        )
+    )
+
+    await channel.start()
+
+    assert channel.bot_user_id == "12345"
+    assert channel.bot_username == "opensquilla_test_bot"
+    assert channel.calls == [
+        ("getMe", {}),
+        (
+            "setWebhook",
+            {
+                "url": "https://example.test/telegram/events",
+                "drop_pending_updates": True,
+                "allowed_updates": [
+                    "message",
+                    "edited_message",
+                    "channel_post",
+                    "edited_channel_post",
+                ],
+                "secret_token": "secret-token",
+            },
+        ),
+    ]
+
+
+@pytest.mark.anyio
+async def test_webhook_mode_requires_url_and_secret_token() -> None:
+    with pytest.raises(ValueError, match="webhook_url is required"):
+        await RecordingTelegramChannel(
+            TelegramChannelConfig(
+                token="bot-token",
+                transport_name="webhook",
+                webhook_secret_token="secret-token",
+            )
+        ).start()
+
+    with pytest.raises(ValueError, match="webhook_secret_token is required"):
+        await RecordingTelegramChannel(
+            TelegramChannelConfig(
+                token="bot-token",
+                transport_name="webhook",
+                webhook_url="https://example.test/telegram/events",
+            )
+        ).start()
+
+
+async def _webhook_response(
+    channel: TelegramChannel,
+    *,
+    secret_header: str | None,
+    body: dict[str, Any],
+):
+    headers: list[tuple[bytes, bytes]] = [(b"content-type", b"application/json")]
+    if secret_header is not None:
+        headers.append((b"x-telegram-bot-api-secret-token", secret_header.encode()))
+    raw = json.dumps(body).encode()
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": channel.config.webhook_path,
+        "headers": headers,
+        "query_string": b"",
+    }
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": raw, "more_body": False}
+
+    request = Request(scope, receive)
+    return await channel._handle_webhook(request)
+
+
+@pytest.mark.anyio
+async def test_webhook_rejects_missing_or_wrong_secret_header() -> None:
+    channel = TelegramChannel(
+        TelegramChannelConfig(
+            token="bot-token",
+            transport_name="webhook",
+            webhook_url="https://example.test/telegram/events",
+            webhook_secret_token="expected-secret",
+        )
+    )
+
+    missing = await _webhook_response(channel, secret_header=None, body={})
+    wrong = await _webhook_response(channel, secret_header="wrong-secret", body={})
+
+    assert missing.status_code == 401
+    assert wrong.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_webhook_accepts_matching_secret_header() -> None:
+    channel = TelegramChannel(
+        TelegramChannelConfig(
+            token="bot-token",
+            transport_name="webhook",
+            webhook_url="https://example.test/telegram/events",
+            webhook_secret_token="expected-secret",
+        )
+    )
+
+    response = await _webhook_response(
+        channel,
+        secret_header="expected-secret",
+        body={"update_id": 1, "unknown": {}},
+    )
+
+    assert response.status_code == 200

--- a/tests/test_onboarding/test_channel_specs.py
+++ b/tests/test_onboarding/test_channel_specs.py
@@ -92,6 +92,33 @@ def test_telegram_secrets_are_marked_secret():
     assert {"token", "webhook_secret_token"} <= secrets
 
 
+def test_discord_gateway_auth_fields_do_not_expose_interactions_public_key():
+    spec = get_channel_setup_spec("discord")
+    fields = {f.name: f for f in spec.fields}
+
+    assert fields["token"].required is True
+    assert fields["token"].secret is True
+    assert fields["application_id"].secret is False
+    assert "public_key" not in fields
+
+
+def test_dingtalk_stream_credentials_are_marked_correctly():
+    spec = get_channel_setup_spec("dingtalk")
+    fields = {f.name: f for f in spec.fields}
+
+    assert fields["client_id"].required is True
+    assert fields["client_id"].secret is False
+    assert fields["client_secret"].required is True
+    assert fields["client_secret"].secret is True
+
+
+def test_feishu_webhook_secrets_are_marked_secret():
+    spec = get_channel_setup_spec("feishu")
+    secrets = {f.name for f in spec.fields if f.secret}
+
+    assert {"app_secret", "encrypt_key", "verification_token"} <= secrets
+
+
 def test_feishu_connection_mode_choices():
     spec = get_channel_setup_spec("feishu")
     field = next(f for f in spec.fields if f.name == "connection_mode")


### PR DESCRIPTION
## Summary
- Add non-live auth boundary tests for Telegram, Feishu, DingTalk, and Discord channel adapters
- Assert onboarding secret/public field contracts for channel credentials
- Cover Feishu webhook signature handling and websocket credential handoff without live provider calls

## Verification
- uv run pytest tests/test_onboarding/test_channel_specs.py tests/test_channels/test_telegram_auth_validation.py tests/test_channels/test_feishu_auth_validation.py tests/test_channels/test_dingtalk_auth_validation.py tests/test_channels/test_discord_auth_validation.py tests/test_channels/test_feishu_websocket_transport.py
- uv run pytest tests/test_channels tests/test_onboarding/test_channel_specs.py
- uv run --extra dev ruff check tests/test_onboarding/test_channel_specs.py tests/test_channels/test_telegram_auth_validation.py tests/test_channels/test_feishu_auth_validation.py tests/test_channels/test_dingtalk_auth_validation.py tests/test_channels/test_discord_auth_validation.py tests/test_channels/test_feishu_websocket_transport.py
- MYPYPATH=src uv run --extra dev mypy tests/test_channels/test_dingtalk_auth_validation.py tests/test_channels/test_feishu_auth_validation.py tests/test_channels/test_discord_auth_validation.py tests/test_channels/test_telegram_auth_validation.py