### PR TITLE
Sync PR #183 skill key fallback to dev

### DIFF
--- a/src/opensquilla/skills/bundled/nano-banana-pro/SKILL.md
+++ b/src/opensquilla/skills/bundled/nano-banana-pro/SKILL.md
@@ -63,9 +63,22 @@ through `with:` by convention; for edit workflows call the script.
 
 ## Auth
 
-Reads `OPENROUTER_API_KEY` from the process environment. The gateway
-already injects it from `.env` if configured. No Google Gemini key
-needed.
+API-key resolution order (first hit wins):
+1. `--api-key` CLI argument (rarely used; meta-skills don't pass it)
+2. `OPENROUTER_API_KEY` environment variable (gateway injects from `.env`)
+3. `OPENSQUILLA_LLM_API_KEY` environment variable, only when the
+   effective OpenSquilla LLM provider resolves to `openrouter`.
+4. `llm.api_key` or `llm.api_key_env` from the selected OpenSquilla TOML
+   config file. Config discovery matches `GatewayConfig.load`: explicit
+   `OPENSQUILLA_GATEWAY_CONFIG_PATH` first; otherwise
+   `./opensquilla.toml`, then `default_opensquilla_home()/config.toml`.
+   `OPENSQUILLA_STATE_DIR` changes `default_opensquilla_home()`, so a
+   state-dir profile does not fall through to `~/.opensquilla`.
+   Config-file credentials are consumed only when the selected config's
+   `llm.provider` is `openrouter` or omitted.
+
+No Google Gemini key needed — OpenRouter routes the request to the
+Gemini image model on the user's behalf.
 
 ## Output
 
@@ -81,7 +94,9 @@ any error; stderr carries the diagnostic.
 
 ## Common failures
 
-- `OPENROUTER_API_KEY not set` → check `.env` or `$env:OPENROUTER_API_KEY`.
+- `no OpenRouter API key found` → set `OPENROUTER_API_KEY`, pass
+  `--api-key`, or configure `[llm] provider = "openrouter"` with
+  `api_key` / `api_key_env` in the selected OpenSquilla config.
 - `OpenRouter returned no image` → the model rejected the prompt
   (content moderation or unsupported request). Rewrite prompt; check
   IP-safety rules in `ai-video-script`.

--- a/src/opensquilla/skills/bundled/nano-banana-pro/scripts/generate_image.py
+++ b/src/opensquilla/skills/bundled/nano-banana-pro/scripts/generate_image.py
@@ -26,6 +26,8 @@ Usage:
 Auth:
     1. --api-key argument
     2. OPENROUTER_API_KEY environment variable
+    3. OPENSQUILLA_LLM_API_KEY when the effective LLM provider is openrouter
+    4. llm.api_key / llm.api_key_env from the selected OpenSquilla config
 
 Output: prints the absolute path of the saved PNG on stdout.
 """
@@ -75,10 +77,110 @@ def _openrouter_attribution_headers(url: str | None) -> dict[str, str]:
     }
 
 
+def _home_dir() -> Path:
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return Path(home).expanduser()
+    return Path.home()
+
+
+def _expand_user(path: str) -> Path:
+    if path == "~":
+        return _home_dir()
+    if path.startswith("~/") or path.startswith("~\\"):
+        return _home_dir() / path[2:]
+    return Path(path).expanduser()
+
+
+def _default_opensquilla_home() -> Path:
+    state_dir = (os.environ.get("OPENSQUILLA_STATE_DIR") or "").strip()
+    if state_dir:
+        return _expand_user(state_dir)
+    return _home_dir() / ".opensquilla"
+
+
+def _gateway_config_candidates() -> list[Path]:
+    config_path = (os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH") or "").strip()
+    if config_path:
+        return [_expand_user(config_path)]
+    return [
+        Path.cwd() / "opensquilla.toml",
+        _default_opensquilla_home() / "config.toml",
+    ]
+
+
+def _selected_llm_config() -> dict | None:
+    """Return the llm table from the config file GatewayConfig would select.
+
+    This intentionally stops at the first existing candidate, matching
+    ``GatewayConfig.load``. In particular, ``OPENSQUILLA_STATE_DIR`` replaces
+    the default home; it is not a profile layered over ``~/.opensquilla``.
+    """
+    import tomllib
+
+    for path in _gateway_config_candidates():
+        try:
+            if not path.is_file():
+                continue
+            with open(path, "rb") as f:
+                data = tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError):
+            return {}
+        llm = data.get("llm") if isinstance(data, dict) else None
+        return llm if isinstance(llm, dict) else {}
+    return None
+
+
+def _config_llm_provider(llm: dict | None) -> str:
+    if llm is None:
+        return "openrouter"
+    return str(llm.get("provider") or "openrouter").strip().lower()
+
+
+def _effective_llm_provider(llm: dict | None) -> str:
+    if isinstance(llm, dict) and "provider" in llm:
+        return _config_llm_provider(llm)
+    env_provider = (os.environ.get("OPENSQUILLA_LLM_PROVIDER") or "").strip()
+    if env_provider:
+        return env_provider.lower()
+    return _config_llm_provider(llm)
+
+
+def _openrouter_llm_env_key(llm: dict | None) -> str | None:
+    if _effective_llm_provider(llm) != "openrouter":
+        return None
+    return (os.environ.get("OPENSQUILLA_LLM_API_KEY") or "").strip() or None
+
+
+def _openrouter_key_from_config(llm: dict | None) -> str | None:
+    """Fallback: read OpenRouter credentials from the selected TOML config.
+
+    Bundled skills run as detached Python subprocesses and cannot import
+    opensquilla itself, so this duplicates the config-discovery logic
+    from ``opensquilla.gateway.config.GatewayConfig.load`` and
+    ``opensquilla.paths.default_opensquilla_home`` deliberately.
+    """
+    if not isinstance(llm, dict) or _effective_llm_provider(llm) != "openrouter":
+        return None
+    key = str(llm.get("api_key") or "").strip()
+    if key:
+        return key
+    key_env = str(llm.get("api_key_env") or "").strip()
+    if key_env:
+        return (os.environ.get(key_env) or "").strip() or None
+    return None
+
+
 def resolve_api_key(provided: str | None) -> str | None:
     if provided:
-        return provided.strip()
-    return (os.environ.get("OPENROUTER_API_KEY") or "").strip() or None
+        key = provided.strip()
+        if key:
+            return key
+    val = (os.environ.get("OPENROUTER_API_KEY") or "").strip()
+    if val:
+        return val
+    llm = _selected_llm_config()
+    return _openrouter_llm_env_key(llm) or _openrouter_key_from_config(llm)
 
 
 def encode_input_image(path: str) -> str:
@@ -269,7 +371,12 @@ def main() -> int:
 
     api_key = resolve_api_key(args.api_key)
     if not api_key:
-        print("Error: OPENROUTER_API_KEY not set and --api-key not provided.", file=sys.stderr)
+        print(
+            "Error: no OpenRouter API key found. Pass --api-key, set "
+            "OPENROUTER_API_KEY, or configure an OpenRouter llm key in "
+            "OpenSquilla config.",
+            file=sys.stderr,
+        )
         return 1
 
     if args.input_image and not Path(args.input_image).is_file():

--- a/src/opensquilla/skills/bundled/seedance-2-prompt/SKILL.md
+++ b/src/opensquilla/skills/bundled/seedance-2-prompt/SKILL.md
@@ -102,9 +102,24 @@ See `references/recipes.md`, `references/modes-and-recipes.md`,
 
 ## Auth
 
-- `openrouter` provider reads `OPENROUTER_API_KEY`.
+- `openrouter` provider API-key resolution order:
+  1. `--api-key` CLI argument
+  2. `OPENROUTER_API_KEY` env var
+  3. `OPENSQUILLA_LLM_API_KEY` env var, only when the effective
+     OpenSquilla LLM provider resolves to `openrouter`
+  4. `llm.api_key` or `llm.api_key_env` from the selected OpenSquilla
+     TOML config. Config discovery matches `GatewayConfig.load`:
+     explicit `OPENSQUILLA_GATEWAY_CONFIG_PATH` first; otherwise
+     `./opensquilla.toml`, then `default_opensquilla_home()/config.toml`.
+     `OPENSQUILLA_STATE_DIR` changes `default_opensquilla_home()`, so a
+     state-dir profile does not fall through to `~/.opensquilla`.
+     Config-file credentials are consumed only when the selected config's
+     `llm.provider` is `openrouter` or omitted.
 - `volcengine` / `byteplus` provider reads `ARK_API_KEY` (with provider-
-  specific fallbacks `VOLC_ARK_API_KEY` / `BYTEPLUS_API_KEY`).
+  specific fallbacks `VOLC_ARK_API_KEY` / `BYTEPLUS_API_KEY`). No
+  config-file fallback for these — the OpenSquilla `[llm]` config
+  describes the agent's selected LLM provider, not ARK / BytePlus video
+  credentials.
 - All three send the key as `Authorization: Bearer <key>`.
 - For OpenRouter the same bearer is also added when downloading the
   resulting `unsigned_urls[0]`. Volcengine returns pre-signed object

--- a/src/opensquilla/skills/bundled/seedance-2-prompt/scripts/generate_video.py
+++ b/src/opensquilla/skills/bundled/seedance-2-prompt/scripts/generate_video.py
@@ -275,13 +275,117 @@ def _encode_input_image(path: str) -> str:
     return f"data:{mime};base64,{base64.b64encode(raw).decode('ascii')}"
 
 
-def _resolve_api_key(provided: str | None, env_names: Iterable[str]) -> str | None:
+def _home_dir() -> Path:
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return Path(home).expanduser()
+    return Path.home()
+
+
+def _expand_user(path: str) -> Path:
+    if path == "~":
+        return _home_dir()
+    if path.startswith("~/") or path.startswith("~\\"):
+        return _home_dir() / path[2:]
+    return Path(path).expanduser()
+
+
+def _default_opensquilla_home() -> Path:
+    state_dir = (os.environ.get("OPENSQUILLA_STATE_DIR") or "").strip()
+    if state_dir:
+        return _expand_user(state_dir)
+    return _home_dir() / ".opensquilla"
+
+
+def _gateway_config_candidates() -> list[Path]:
+    config_path = (os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH") or "").strip()
+    if config_path:
+        return [_expand_user(config_path)]
+    return [
+        Path.cwd() / "opensquilla.toml",
+        _default_opensquilla_home() / "config.toml",
+    ]
+
+
+def _selected_llm_config() -> dict | None:
+    """Return the llm table from the config file GatewayConfig would select.
+
+    This intentionally stops at the first existing candidate, matching
+    ``GatewayConfig.load``. In particular, ``OPENSQUILLA_STATE_DIR`` replaces
+    the default home; it is not a profile layered over ``~/.opensquilla``.
+    """
+    import tomllib
+
+    for path in _gateway_config_candidates():
+        try:
+            if not path.is_file():
+                continue
+            with open(path, "rb") as f:
+                data = tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError):
+            return {}
+        llm = data.get("llm") if isinstance(data, dict) else None
+        return llm if isinstance(llm, dict) else {}
+    return None
+
+
+def _config_llm_provider(llm: dict | None) -> str:
+    if llm is None:
+        return "openrouter"
+    return str(llm.get("provider") or "openrouter").strip().lower()
+
+
+def _effective_llm_provider(llm: dict | None) -> str:
+    if isinstance(llm, dict) and "provider" in llm:
+        return _config_llm_provider(llm)
+    env_provider = (os.environ.get("OPENSQUILLA_LLM_PROVIDER") or "").strip()
+    if env_provider:
+        return env_provider.lower()
+    return _config_llm_provider(llm)
+
+
+def _openrouter_llm_env_key(llm: dict | None) -> str | None:
+    if _effective_llm_provider(llm) != "openrouter":
+        return None
+    return (os.environ.get("OPENSQUILLA_LLM_API_KEY") or "").strip() or None
+
+
+def _openrouter_key_from_config(llm: dict | None) -> str | None:
+    """Fallback: read OpenRouter credentials from the selected TOML config.
+
+    Bundled skills run as detached Python subprocesses and cannot
+    import opensquilla, so this duplicates the config-discovery logic
+    from ``opensquilla.gateway.config.GatewayConfig.load`` and
+    ``opensquilla.paths.default_opensquilla_home`` deliberately.
+    """
+    if not isinstance(llm, dict) or _effective_llm_provider(llm) != "openrouter":
+        return None
+    key = str(llm.get("api_key") or "").strip()
+    if key:
+        return key
+    key_env = str(llm.get("api_key_env") or "").strip()
+    if key_env:
+        return (os.environ.get(key_env) or "").strip() or None
+    return None
+
+
+def _resolve_api_key(
+    provided: str | None,
+    env_names: Iterable[str],
+    *,
+    provider_name: str = "",
+) -> str | None:
     if provided:
-        return provided.strip()
+        key = provided.strip()
+        if key:
+            return key
     for name in env_names:
         val = (os.environ.get(name) or "").strip()
         if val:
             return val
+    if provider_name == "openrouter":
+        llm = _selected_llm_config()
+        return _openrouter_llm_env_key(llm) or _openrouter_key_from_config(llm)
     return None
 
 
@@ -481,13 +585,23 @@ def main() -> int:
     provider = PROVIDERS[raw.provider]
     base_url = raw.base_url or provider.default_base_url
     model_id = raw.model or provider.default_model
-    api_key = _resolve_api_key(raw.api_key or None, provider.default_env)
+    api_key = _resolve_api_key(
+        raw.api_key or None, provider.default_env, provider_name=provider.name,
+    )
     if not api_key:
         env_hint = " / ".join(provider.default_env)
-        print(
-            f"Error: no API key. Pass --api-key or set one of: {env_hint}.",
-            file=sys.stderr,
-        )
+        if provider.name == "openrouter":
+            print(
+                "Error: no OpenRouter API key found. Pass --api-key, set "
+                "OPENROUTER_API_KEY, or configure an OpenRouter llm key in "
+                "OpenSquilla config.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"Error: no API key. Pass --api-key or set one of: {env_hint}.",
+                file=sys.stderr,
+            )
         return 1
 
     if raw.input_image and not Path(raw.input_image).is_file():

--- a/tests/test_skills/test_openrouter_skill_key_resolution.py
+++ b/tests/test_skills/test_openrouter_skill_key_resolution.py
@@ -1,0 +1,236 @@
+"""Regression tests for bundled OpenRouter skill key fallback.
+
+The bundled scripts are intentionally imported by file path here because the
+skill directories contain hyphens and run as standalone subprocess scripts.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IMAGE_SCRIPT = (
+    REPO_ROOT
+    / "src/opensquilla/skills/bundled/nano-banana-pro/scripts/generate_image.py"
+)
+VIDEO_SCRIPT = (
+    REPO_ROOT
+    / "src/opensquilla/skills/bundled/seedance-2-prompt/scripts/generate_video.py"
+)
+
+
+def _load_script(path: Path, module_name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def image_script() -> ModuleType:
+    return _load_script(IMAGE_SCRIPT, "_opensquilla_test_generate_image")
+
+
+@pytest.fixture(scope="module")
+def video_script() -> ModuleType:
+    return _load_script(VIDEO_SCRIPT, "_opensquilla_test_generate_video")
+
+
+@pytest.fixture
+def isolated_runtime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    for name in (
+        "OPENROUTER_API_KEY",
+        "OPENSQUILLA_LLM_API_KEY",
+        "OPENSQUILLA_LLM_PROVIDER",
+        "OPENSQUILLA_GATEWAY_CONFIG_PATH",
+        "OPENSQUILLA_STATE_DIR",
+        "CUSTOM_OPENROUTER_KEY",
+        "ARK_API_KEY",
+        "VOLC_ARK_API_KEY",
+        "BYTEPLUS_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    home.mkdir()
+    workspace.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(workspace)
+    return tmp_path
+
+
+def _write_toml(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body.strip() + "\n", encoding="utf-8")
+    return path
+
+
+def _resolve_video_openrouter(video_script: ModuleType) -> str | None:
+    return video_script._resolve_api_key(
+        None,
+        ("OPENROUTER_API_KEY",),
+        provider_name="openrouter",
+    )
+
+
+def test_openrouter_skills_use_explicit_gateway_config_path(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _write_toml(
+        isolated_runtime / "custom" / "gateway.toml",
+        """
+        [llm]
+        provider = "openrouter"
+        api_key = "explicit-config-key"
+        """,
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(config_path))
+
+    assert image_script.resolve_api_key(None) == "explicit-config-key"
+    assert _resolve_video_openrouter(video_script) == "explicit-config-key"
+
+
+def test_openrouter_skills_use_configured_api_key_env(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_toml(
+        Path.cwd() / "opensquilla.toml",
+        """
+        [llm]
+        provider = "openrouter"
+        api_key_env = "CUSTOM_OPENROUTER_KEY"
+        """,
+    )
+    monkeypatch.setenv("CUSTOM_OPENROUTER_KEY", "custom-env-key")
+
+    assert image_script.resolve_api_key(None) == "custom-env-key"
+    assert _resolve_video_openrouter(video_script) == "custom-env-key"
+
+
+def test_openrouter_skills_do_not_treat_other_provider_llm_env_as_openrouter(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_LLM_PROVIDER", "anthropic")
+    monkeypatch.setenv("OPENSQUILLA_LLM_API_KEY", "anthropic-key")
+
+    assert image_script.resolve_api_key(None) is None
+    assert _resolve_video_openrouter(video_script) is None
+
+
+def test_selected_config_provider_beats_conflicting_env_provider(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_toml(
+        Path.cwd() / "opensquilla.toml",
+        """
+        [llm]
+        provider = "anthropic"
+        """,
+    )
+    monkeypatch.setenv("OPENSQUILLA_LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("OPENSQUILLA_LLM_API_KEY", "generic-env-key")
+
+    assert image_script.resolve_api_key(None) is None
+    assert _resolve_video_openrouter(video_script) is None
+
+
+def test_missing_config_provider_can_use_openrouter_env_provider(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_toml(
+        Path.cwd() / "opensquilla.toml",
+        """
+        [llm]
+        api_key = "toml-key"
+        """,
+    )
+    monkeypatch.setenv("OPENSQUILLA_LLM_PROVIDER", "openrouter")
+
+    assert image_script.resolve_api_key(None) == "toml-key"
+    assert _resolve_video_openrouter(video_script) == "toml-key"
+
+
+def test_openrouter_skills_do_not_fall_back_to_home_when_state_dir_config_exists(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_dir = isolated_runtime / "state-profile"
+    _write_toml(
+        state_dir / "config.toml",
+        """
+        [llm]
+        provider = "anthropic"
+        api_key = "state-anthropic-key"
+        """,
+    )
+    _write_toml(
+        isolated_runtime / "home" / ".opensquilla" / "config.toml",
+        """
+        [llm]
+        provider = "openrouter"
+        api_key = "global-openrouter-key"
+        """,
+    )
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(state_dir))
+
+    assert image_script.resolve_api_key(None) is None
+    assert _resolve_video_openrouter(video_script) is None
+
+
+def test_openrouter_specific_env_still_wins_for_openrouter_skills(
+    image_script: ModuleType,
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-env-key")
+    monkeypatch.setenv("OPENSQUILLA_LLM_PROVIDER", "anthropic")
+    monkeypatch.setenv("OPENSQUILLA_LLM_API_KEY", "anthropic-key")
+
+    assert image_script.resolve_api_key(None) == "openrouter-env-key"
+    assert _resolve_video_openrouter(video_script) == "openrouter-env-key"
+
+
+def test_non_openrouter_video_provider_uses_only_its_provider_env(
+    video_script: ModuleType,
+    isolated_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARK_API_KEY", "ark-key")
+    monkeypatch.setenv("OPENSQUILLA_LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("OPENSQUILLA_LLM_API_KEY", "openrouter-key")
+
+    assert (
+        video_script._resolve_api_key(
+            None,
+            ("ARK_API_KEY", "VOLC_ARK_API_KEY"),
+            provider_name="volcengine",
+        )
+        == "ark-key"
+    )


### PR DESCRIPTION
## Summary

Sync the already-merged PR #183 OpenRouter credential fallback fix from `main` to `dev`.

This cherry-picks main commit `34cffd69` onto current `origin/dev` as `52f75537`.

## Scope

- Reuse configured OpenRouter credentials in bundled media skill scripts.
- Keep Volcengine / BytePlus video credentials isolated to their provider-specific env vars.
- Add regression coverage for config path, provider matching, `api_key_env`, and state-dir behavior.

## Validation

- `uv run pytest tests/test_skills/test_openrouter_skill_key_resolution.py`
- `uv run --with ruff ruff check src/opensquilla/skills/bundled/nano-banana-pro/scripts/generate_image.py src/opensquilla/skills/bundled/seedance-2-prompt/scripts/generate_video.py tests/test_skills/test_openrouter_skill_key_resolution.py`
- `uv run python -m compileall -q src/opensquilla/skills/bundled/nano-banana-pro/scripts/generate_image.py src/opensquilla/skills/bundled/seedance-2-prompt/scripts/generate_video.py`
- `git diff --check origin/dev..HEAD`
- `uv run --with pytest-asyncio pytest tests/test_skills_default_prompt_contract.py tests/test_skills_paths.py tests/test_ci/test_meta_skill_lint.py`

## Not Tested

- Live OpenRouter, Volcengine, or BytePlus API calls.
