### PR TITLE
fix(provider,cli): accept no-space SSE data lines; inspect managed-layer meta-skills

### DIFF
--- a/src/opensquilla/cli/skills_cmd.py
+++ b/src/opensquilla/cli/skills_cmd.py
@@ -163,7 +163,38 @@ def inspect_compiled_dag(*, name: str, bundled_dir: Path | None = None) -> str:
 
     from opensquilla.skills.loader import SkillLoader
 
-    loader = SkillLoader(bundled_dir=bundled_dir)
+    if bundled_dir is not None:
+        # Explicit bundled_dir keeps the test-friendly single-layer path.
+        loader = SkillLoader(bundled_dir=bundled_dir)
+    else:
+        # Resolve every skill layer so managed/workspace meta-skills (e.g.
+        # user-installed ones under ~/.opensquilla/skills) are inspectable,
+        # matching `skills list`.
+        import os as _os
+
+        from opensquilla.gateway.config import GatewayConfig
+        from opensquilla.skills.paths import resolve_skill_layer_dirs
+
+        config = GatewayConfig.load(_os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH"))
+        workspace_root = Path(config.workspace_dir) if config.workspace_dir else None
+        workspace_override = (
+            Path(config.skills.workspace_dir) if config.skills.workspace_dir else None
+        )
+        layer_dirs = resolve_skill_layer_dirs(
+            allow_bundled=config.skills.allow_bundled,
+            workspace_root=workspace_root,
+            workspace_override=workspace_override,
+            managed_override=config.skills.managed_dir,
+            extra_dirs=[Path(d) for d in config.skills.extra_dirs],
+        )
+        loader = SkillLoader(
+            bundled_dir=layer_dirs.bundled_dir,
+            workspace_dir=layer_dirs.workspace_dir,
+            managed_dir=layer_dirs.managed_dir,
+            personal_agents_dir=layer_dirs.personal_agents_dir,
+            project_agents_dir=layer_dirs.project_agents_dir,
+            extra_dirs=layer_dirs.extra_dirs,
+        )
     loader.invalidate_cache()
     loader.load_all()
     spec = loader.get_by_name(name)

--- a/src/opensquilla/provider/anthropic.py
+++ b/src/opensquilla/provider/anthropic.py
@@ -440,9 +440,14 @@ class AnthropicProvider:
                         return
 
                     async for line in response.aiter_lines():
-                        if not line.startswith("data: "):
+                        # SSE spec: a single optional space after the colon
+                        # is part of the field syntax. Some gateways emit
+                        # "data:{...}" without the space — accept both.
+                        if not line.startswith("data:"):
                             continue
-                        data_str = line[6:]
+                        data_str = line[5:]
+                        if data_str.startswith(" "):
+                            data_str = data_str[1:]
                         if data_str == "[DONE]":
                             break
                         try:

--- a/tests/test_provider_anthropic_sse_nospace.py
+++ b/tests/test_provider_anthropic_sse_nospace.py
@@ -1,0 +1,101 @@
+"""Regression: Anthropic SSE parser must accept ``data:`` without a space.
+
+The SSE spec treats the single space after the field colon as OPTIONAL.
+Some Anthropic-compatible gateways emit ``data:{...}`` (no space) and
+``event:message_stop`` accordingly. The parser previously required
+``data: `` (with the space) and silently dropped every event, ending the
+stream before a DoneEvent and surfacing ``provider_stream_incomplete``.
+
+This test mocks a no-space SSE stream and asserts the text delta and the
+terminal DoneEvent both come through.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from opensquilla.provider import anthropic as anthropic_mod
+from opensquilla.provider.anthropic import AnthropicProvider
+from opensquilla.provider.types import (
+    ChatConfig,
+    DoneEvent,
+    Message,
+    TextDeltaEvent,
+)
+
+# SSE lines exactly as a no-space gateway emits them (httpx aiter_lines
+# yields one logical line per event field; blank separators included).
+_NO_SPACE_SSE_LINES = [
+    'event:message_start',
+    'data:{"type":"message_start","message":{"usage":{"input_tokens":5}}}',
+    '',
+    'event:content_block_start',
+    'data:{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+    '',
+    'event:content_block_delta',
+    'data:{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}',
+    '',
+    'event:content_block_stop',
+    'data:{"type":"content_block_stop","index":0}',
+    '',
+    'event:message_delta',
+    'data:{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}',
+    '',
+    'event:message_stop',
+    'data:{"type":"message_stop"}',
+    '',
+]
+
+
+def test_anthropic_sse_without_space_after_colon(monkeypatch: Any) -> None:
+    class _StubResponse:
+        status_code = 200
+
+        async def aiter_lines(self):
+            for line in _NO_SPACE_SSE_LINES:
+                yield line
+
+        async def aread(self) -> bytes:
+            return b""
+
+        async def __aenter__(self) -> "_StubResponse":
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+    class _StubClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_StubClient":
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        def stream(self, *args: Any, **kwargs: Any) -> _StubResponse:
+            return _StubResponse()
+
+    monkeypatch.setattr(anthropic_mod.httpx, "AsyncClient", _StubClient)
+
+    provider = AnthropicProvider(api_key="k", model="claude-sonnet-4-6")
+    msg = Message(role="user", content="hi")
+
+    async def _run() -> list[Any]:
+        out: list[Any] = []
+        async for ev in provider.chat([msg], None, ChatConfig()):
+            out.append(ev)
+        return out
+
+    events = asyncio.run(_run())
+
+    text = "".join(
+        e.text for e in events if isinstance(e, TextDeltaEvent)
+    )
+    assert text == "Hi", f"expected decoded text 'Hi', got {text!r} from {events!r}"
+    assert any(isinstance(e, DoneEvent) for e in events), (
+        f"expected a terminal DoneEvent (no-space 'data:' must still close "
+        f"the stream), got {events!r}"
+    )

--- a/tests/test_skills/test_sop_compiler.py
+++ b/tests/test_skills/test_sop_compiler.py
@@ -860,6 +860,52 @@ def test_cli_skills_inspect_prints_compiled_dag(tmp_path: Path) -> None:
     assert "tiny-runner" in output
 
 
+def test_cli_skills_inspect_finds_managed_layer_skill(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """`inspect` (no explicit bundled_dir) must see managed-layer meta-skills.
+
+    Regression: the helper used to build SkillLoader(bundled_dir=...) only,
+    leaving managed_dir=None, so a user meta-skill installed under
+    ~/.opensquilla/skills was always reported "not loaded".
+    """
+
+    managed = tmp_path / "managed"
+    (managed / "meta-managed").mkdir(parents=True)
+    (managed / "meta-managed" / "SKILL.md").write_text(
+        "---\n"
+        "name: meta-managed\n"
+        "description: d\n"
+        "kind: meta\n"
+        "triggers: [m]\n"
+        "composition:\n"
+        "  steps:\n"
+        "    - id: only\n"
+        "      kind: llm_chat\n"
+        "      with:\n"
+        "        system: s\n"
+        "        task: t\n"
+        "---\n"
+        "# body\n",
+    )
+
+    from opensquilla.skills import paths as paths_mod
+    from opensquilla.skills.paths import SkillLayerDirs
+
+    monkeypatch.setattr(
+        paths_mod,
+        "resolve_skill_layer_dirs",
+        lambda **_kw: SkillLayerDirs(bundled_dir=None, managed_dir=managed),
+    )
+
+    from opensquilla.cli.skills_cmd import inspect_compiled_dag
+
+    output = inspect_compiled_dag(name="meta-managed")
+    assert "not loaded" not in output, output
+    assert "only" in output
+    assert "llm_chat" in output
+
+
 # ---------------------------------------------------------------------------
 # Acceptance test
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two independent fixes found while deploying OpenSquilla from source against an Anthropic-compatible gateway and installing a custom managed meta-skill.

### 1. Streaming parser rejected `data:` without a space (`provider/anthropic.py`)

The SSE parser required `data: ` (a space after the colon) and sliced `line[6:]`. The SSE spec treats that single space as **optional**, and some Anthropic-compatible gateways emit `data:{...}` with no space (and `event:message_stop` likewise).

Result: every event was skipped, the stream ended before `message_stop`, and the turn failed with `provider_stream_incomplete` / `got_done_event=False` — even though the gateway's non-streaming and streaming responses were both well-formed.

Fix: accept `startswith("data:")` and strip a single optional leading space. Fully backward compatible with the standard `data: ` form.

### 2. `skills inspect` could not see managed-layer meta-skills (`cli/skills_cmd.py`)

`inspect_compiled_dag` built `SkillLoader(bundled_dir=...)` only, leaving `managed_dir=None`. A user meta-skill installed under `~/.opensquilla/skills/` was therefore always reported `skill '<name>' not loaded`, even though `skills list` showed it.

Fix: when no explicit `bundled_dir` is passed, resolve every skill layer via `resolve_skill_layer_dirs()` (same as `skills list`). The explicit-`bundled_dir` path is preserved for existing tests.

## Tests

Both fixes ship with regression tests, each verified red→green (revert the fix → test fails; restore → passes):

- `tests/test_provider_anthropic_sse_nospace.py` — mocks a no-space SSE stream, asserts the text delta and terminal `DoneEvent` come through.
- `tests/test_skills/test_sop_compiler.py::test_cli_skills_inspect_finds_managed_layer_skill` — installs a meta-skill in a temp managed dir, asserts `inspect` finds it.

`55 passed` across the touched provider + skills test files; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)