### PR TITLE
fix(tui): reset EOF state on cached reentry

### DIFF
--- a/src/opensquilla/cli/tui/terminal/app.py
+++ b/src/opensquilla/cli/tui/terminal/app.py
@@ -347,6 +347,30 @@ class ChatApplication:
     def surface(self) -> Surface:
         return self._surface
 
+    def reset_session_state(self) -> None:
+        """Reset state that belongs to one interactive-session lifetime.
+
+        ``ChatApplication`` instances are cached per surface so prompt-toolkit
+        wiring, history, and completion setup can be reused across repeated
+        same-process ``interactive_session()`` entries. EOF/callback/paste
+        state is different: it describes one active session and must not leak
+        into the next cached use.
+        """
+        self._eof_seen = False
+        self._cancel_callback = None
+        self._shutdown_callback = None
+        self._last_ctrl_c_at = None
+        self._active_stream_writer = None
+        self._clear_pasted_content()
+        self._buffer.reset()
+        self._next_paste_index = 1
+        self.set_approval_in_flight(False)
+        while True:
+            try:
+                self._submit_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+
     def set_toolbar(self, key: str, value: str | None) -> None:
         """Mutate the shared toolbar dict in place.
 

--- a/src/opensquilla/cli/tui/terminal/prompt.py
+++ b/src/opensquilla/cli/tui/terminal/prompt.py
@@ -496,6 +496,8 @@ def _get_or_create_chat_app(
             input_header=_input_header_fragments,
         )
         _chat_applications[surface] = cached
+    else:
+        cached.reset_session_state()
     return cached
 
 

--- a/tests/unit/cli/repl/test_interactive_session_lifecycle.py
+++ b/tests/unit/cli/repl/test_interactive_session_lifecycle.py
@@ -58,6 +58,27 @@ async def test_interactive_session_ctrl_d_returns_none() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cached_chat_application_can_emit_eof_after_reentry() -> None:
+    """A cached production ChatApplication must not keep EOF latched forever."""
+    prompt_module._chat_applications.clear()
+    try:
+        app1 = prompt_module._get_or_create_chat_app(Surface.CLI_GATEWAY)
+        app1._emit_eof()
+        first = await asyncio.wait_for(app1.next_line(), timeout=0.2)
+
+        app2 = prompt_module._get_or_create_chat_app(Surface.CLI_GATEWAY)
+        same_cached_app = app1 is app2
+        app2._emit_eof()
+        second = await asyncio.wait_for(app2.next_line(), timeout=0.2)
+    finally:
+        prompt_module._chat_applications.clear()
+
+    assert first is None
+    assert same_cached_app is True
+    assert second is None
+
+
+@pytest.mark.asyncio
 async def test_set_toolbar_mutates_shared_context() -> None:
     """`set_toolbar` writes into `_toolbar_context` and shows up in the
     assistant status header on the next call."""
@@ -166,6 +187,25 @@ async def test_interactive_session_multiple_same_size_pastes_expand_distinctly()
     submitted = await asyncio.wait_for(chat_app.next_line(), timeout=2.0)
 
     assert submitted == f"{first} {second}"
+
+
+@pytest.mark.asyncio
+async def test_cached_session_reset_drops_unsubmitted_paste_marker() -> None:
+    chat_app = _fresh_chat_app()
+    pasted = "x" * 801
+
+    chat_app._insert_pasted_content(chat_app._buffer, pasted)
+    assert chat_app._buffer.text == "[Pasted Content #1 801 chars]"
+
+    chat_app.reset_session_state()
+    assert chat_app._buffer.text == ""
+    assert chat_app._pasted_content == {}
+
+    chat_app._buffer.insert_text("fresh input")
+    chat_app._on_accept(chat_app._buffer)
+    submitted = await asyncio.wait_for(chat_app.next_line(), timeout=2.0)
+
+    assert submitted == "fresh input"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/repl/test_interactive_session_lifecycle.py
+++ b/tests/unit/cli/repl/test_interactive_session_lifecycle.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from prompt_toolkit.application.current import create_app_session
 from prompt_toolkit.formatted_text import to_formatted_text
 from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.input.base import DummyInput
@@ -62,14 +63,15 @@ async def test_cached_chat_application_can_emit_eof_after_reentry() -> None:
     """A cached production ChatApplication must not keep EOF latched forever."""
     prompt_module._chat_applications.clear()
     try:
-        app1 = prompt_module._get_or_create_chat_app(Surface.CLI_GATEWAY)
-        app1._emit_eof()
-        first = await asyncio.wait_for(app1.next_line(), timeout=0.2)
+        with create_app_session(input=DummyInput(), output=DummyOutput()):
+            app1 = prompt_module._get_or_create_chat_app(Surface.CLI_GATEWAY)
+            app1._emit_eof()
+            first = await asyncio.wait_for(app1.next_line(), timeout=0.2)
 
-        app2 = prompt_module._get_or_create_chat_app(Surface.CLI_GATEWAY)
-        same_cached_app = app1 is app2
-        app2._emit_eof()
-        second = await asyncio.wait_for(app2.next_line(), timeout=0.2)
+            app2 = prompt_module._get_or_create_chat_app(Surface.CLI_GATEWAY)
+            same_cached_app = app1 is app2
+            app2._emit_eof()
+            second = await asyncio.wait_for(app2.next_line(), timeout=0.2)
     finally:
         prompt_module._chat_applications.clear()
 


### PR DESCRIPTION
## Summary

Fix a bug where Ctrl-D / EOF fails to exit the TUI chat session on re-entry after the same-process cached `ChatApplication` has already seen EOF once.

After the first Ctrl-D, the cached `ChatApplication` sets `_eof_seen = True` and never resets it. On a subsequent same-process TUI session, Ctrl-D is silently dropped — the EOF sentinel is never sent and the consumer hangs waiting for input.

Changes:

- Add `reset_session_state()` to `ChatApplication`.
- Reset per-session state when a cached `ChatApplication` is reused.
- Reset EOF flag, cancel/shutdown callbacks, Ctrl-C double-press state, paste cache, approval state, and any stale entries in the submit queue.
- Add a regression test that verifies a cached application can emit EOF again after re-entry.

Fixes #100.