### PR TITLE
Enforce dev as the ordinary pull request target

### DIFF
--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -82,7 +82,7 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
     src/* | scripts/* | migrations/*)
       mark_runtime_changed
       ;;
-    docs/* | README.md | README.*.md | CHANGELOG.md | CODE_OF_CONDUCT.md | CONTRIBUTING.md | MIGRATION.md | SECURITY.md | SUPPORT.md | THIRD_PARTY_NOTICES.md | META_SKILL_GUIDE.md | RELEASES.md | .github/pull_request_template.md | .github/ISSUE_TEMPLATE/*)
+    docs/* | README.md | README.*.md | CHANGELOG.md | CODE_OF_CONDUCT.md | CONTRIBUTING.md | MIGRATION.md | SECURITY.md | SUPPORT.md | THIRD_PARTY_NOTICES.md | META_SKILL_GUIDE.md | .github/pull_request_template.md | .github/ISSUE_TEMPLATE/*)
       ;;
     *)
       mark_runtime_changed

--- a/.github/scripts/validate-pr-target-branch.sh
+++ b/.github/scripts/validate-pr-target-branch.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${PR_BASE_REF:-${BASE_REF:-${BASE:-}}}"
+event_path="${GITHUB_EVENT_PATH:-}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+classifier="${script_dir}/classify-ci-changes.sh"
+temp_files=()
+trap 'rm -f "${temp_files[@]}"' EXIT
+
+changed_files_path=""
+
+if [[ -z "${base_ref}" ]]; then
+  {
+    echo "::error title=Missing PR target::PR_BASE_REF is required."
+    echo "Unable to validate the pull request target branch."
+  } >&2
+  exit 1
+fi
+
+if [[ "${base_ref}" == "dev" ]]; then
+  echo "Pull request targets dev."
+  exit 0
+fi
+
+set_pr_changed_files_path() {
+  if [[ -n "${PR_CHANGED_FILES_PATH:-}" ]]; then
+    if [[ -f "${PR_CHANGED_FILES_PATH}" ]]; then
+      changed_files_path="${PR_CHANGED_FILES_PATH}"
+      return 0
+    fi
+    echo "::error title=Missing PR files::PR_CHANGED_FILES_PATH does not exist." >&2
+    return 1
+  fi
+
+  if [[ -z "${GITHUB_REPOSITORY:-}" || -z "${PR_NUMBER:-}" ]]; then
+    return 1
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "::error title=Missing GitHub CLI::gh is required to inspect pull request files." >&2
+    return 1
+  fi
+
+  local changed_files
+  changed_files="$(mktemp)"
+  temp_files+=("${changed_files}")
+
+  if ! gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename' > "${changed_files}"; then
+    echo "::error title=Unable to inspect PR files::Could not read changed files for pull request ${PR_NUMBER}." >&2
+    return 1
+  fi
+
+  changed_files_path="${changed_files}"
+}
+
+event_label_names() {
+  if [[ -n "${PR_LABELS:-}" ]]; then
+    tr ',' '\n' <<< "${PR_LABELS}"
+    return
+  fi
+
+  local python_bin=""
+  if command -v python3 >/dev/null 2>&1; then
+    python_bin="python3"
+  elif command -v python >/dev/null 2>&1; then
+    python_bin="python"
+  fi
+
+  if [[ -n "${python_bin}" ]]; then
+    "${python_bin}" - "${event_path}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as event_file:
+    event = json.load(event_file)
+
+for label in event.get("pull_request", {}).get("labels", []):
+    name = label.get("name")
+    if name:
+        print(name)
+PY
+    return
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    jq -r '.pull_request.labels[]?.name // empty' "${event_path}"
+  fi
+}
+
+main_docs_only=false
+if [[ "${base_ref}" == "main" ]]; then
+  if set_pr_changed_files_path; then
+    classifier_output="$(mktemp)"
+    temp_files+=("${classifier_output}")
+    GITHUB_OUTPUT="${classifier_output}" bash "${classifier}" "${changed_files_path}"
+    if grep -qx "docs_only=true" "${classifier_output}"; then
+      main_docs_only=true
+    fi
+  fi
+fi
+
+main_allowed_by_label=false
+if [[ "${base_ref}" == "main" && -n "${event_path}" && -f "${event_path}" ]]; then
+  while IFS= read -r label; do
+    case "${label}" in
+      allow-main-target | release | hotfix | sync-to-main | docs-preview)
+        main_allowed_by_label=true
+        break
+        ;;
+    esac
+  done < <(event_label_names)
+fi
+
+if [[ "${main_docs_only}" == "true" ]]; then
+  echo "Pull request targets main with documentation-only changes."
+  exit 0
+fi
+
+if [[ "${main_allowed_by_label}" == "true" ]]; then
+  echo "Pull request targets main with maintainer approval label."
+  exit 0
+fi
+
+{
+  echo "::error title=Wrong PR target::Ordinary pull requests should target dev."
+  echo "Use main only for documentation-only changes or maintainer-approved release, hotfix, sync, or documentation-preview work."
+  echo "Retarget this pull request to dev, or ask a maintainer to add allow-main-target."
+} >&2
+exit 1

--- a/.github/workflows/pr-target-branch.yml
+++ b/.github/workflows/pr-target-branch.yml
@@ -1,0 +1,37 @@
+name: PR target branch
+
+"on":
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-target:
+    name: Validate target branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out trusted workflow scripts
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Check out bootstrap validator before first merge
+        if: ${{ hashFiles('.github/scripts/validate-pr-target-branch.sh') == '' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Validate target branch
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/validate-pr-target-branch.sh

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -11,6 +12,7 @@ import yaml
 
 WORKFLOW_DIR = Path(".github/workflows")
 CLASSIFIER = Path(".github/scripts/classify-ci-changes.sh")
+PR_TARGET_VALIDATOR = Path(".github/scripts/validate-pr-target-branch.sh")
 TEST_PATH_RE = re.compile(r"tests/[A-Za-z0-9_./-]+\.py")
 
 
@@ -99,6 +101,55 @@ def _classify_changed_files(
     return outputs
 
 
+def _validate_pr_target(
+    tmp_path: Path,
+    *,
+    base: str,
+    head: str = "feature/example",
+    title: str = "Example change",
+    labels: list[str] | None = None,
+    changed_files: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    event_path = tmp_path / "event.json"
+    changed_files_path = tmp_path / "changed-files.txt"
+    if changed_files is not None:
+        changed_files_path.write_text("\n".join(changed_files) + "\n", encoding="utf-8")
+
+    event_path.write_text(
+        json.dumps(
+            {
+                "pull_request": {
+                    "base": {"ref": base},
+                    "head": {"ref": head},
+                    "labels": [{"name": label} for label in labels or []],
+                    "title": title,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "GITHUB_EVENT_PATH": event_path.as_posix(),
+            "PR_BASE_REF": base,
+            "PR_HEAD_REF": head,
+            "PR_LABELS": ",".join(labels or []),
+            "PR_TITLE": title,
+        }
+    )
+    if changed_files is not None:
+        env["PR_CHANGED_FILES_PATH"] = changed_files_path.as_posix()
+    return subprocess.run(
+        [_bash_executable(), PR_TARGET_VALIDATOR.as_posix()],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
 def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     ci_path = WORKFLOW_DIR / "ci.yml"
     if not ci_path.exists():
@@ -128,6 +179,67 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert "release_changed" in text
     assert "code_changed" not in text
     assert "workflow_changed" not in text
+
+
+def test_pr_target_validator_allows_dev_pull_requests(tmp_path: Path) -> None:
+    result = _validate_pr_target(tmp_path, base="dev")
+
+    assert result.returncode == 0
+
+
+def test_pr_target_validator_blocks_ordinary_main_pull_requests(tmp_path: Path) -> None:
+    result = _validate_pr_target(
+        tmp_path,
+        base="main",
+        changed_files=["src/opensquilla/engine/agent.py"],
+    )
+
+    assert result.returncode == 1
+    assert "Ordinary pull requests should target dev" in result.stderr
+
+
+def test_pr_target_validator_allows_docs_only_main_pull_requests(tmp_path: Path) -> None:
+    result = _validate_pr_target(
+        tmp_path,
+        base="main",
+        head="docs/agent-testing",
+        title="docs: add agent testing framework guide",
+        changed_files=["docs/testing/framework.md"],
+    )
+
+    assert result.returncode == 0
+    assert "Pull request targets main with documentation-only changes." in result.stdout
+
+
+def test_pr_target_validator_allows_maintainer_labeled_main_pull_requests(
+    tmp_path: Path,
+) -> None:
+    for label in ["allow-main-target", "release", "hotfix", "sync-to-main", "docs-preview"]:
+        result = _validate_pr_target(
+            tmp_path,
+            base="main",
+            head="release/0.3.2",
+            labels=[label],
+            changed_files=["src/opensquilla/engine/agent.py"],
+        )
+
+        assert result.returncode == 0
+
+
+def test_pr_target_branch_workflow_runs_trusted_base_validator() -> None:
+    data = _workflow("pr-target-branch.yml")
+    text = (WORKFLOW_DIR / "pr-target-branch.yml").read_text(encoding="utf-8")
+
+    assert _trigger_keys(data) == {"pull_request"}
+    assert "pull_request_target" not in text
+    assert "Validate target branch" in text
+    assert "github.event.repository.default_branch" in text
+    assert "hashFiles('.github/scripts/validate-pr-target-branch.sh') == ''" in text
+    assert "github.event.pull_request.head.sha" in text
+    assert "pull-requests: read" in text
+    assert "PR_LABELS" in text
+    assert "PR_NUMBER" in text
+    assert ".github/scripts/validate-pr-target-branch.sh" in text
 
 
 def test_ci_change_classifier_allows_root_and_docs_markdown_only(tmp_path: Path) -> None:
@@ -224,6 +336,7 @@ def test_ci_change_classifier_tracks_release_surface_changes(tmp_path: Path) -> 
             ".github/workflows/wheelhouse-release.yml",
             "scripts/build_wheelhouse_zip.py",
             "README.release.md",
+            "RELEASES.md",
             "tests/test_scripts/test_build_wheelhouse_zip.py",
         ],
     )


### PR DESCRIPTION
## Summary

- Add a dedicated pull request target-branch gate.
- Allow ordinary pull requests targeting `dev`.
- Allow documentation-only pull requests targeting `main` by reusing the existing CI changed-file classifier.
- Require an explicit maintainer exception label for runtime/code changes targeting `main`.

## Impact

This changes repository governance only. It does not modify OpenSquilla runtime, package, provider, CLI, or WebUI source code.

The workflow is intentionally based on `pull_request`, not `pull_request_target`, and uses read-only permissions. It checks out trusted scripts from the repository default branch before evaluating the PR target.

Until this PR is merged, it does not affect other pull requests. After merge, it affects future pull request events such as new PRs, PR updates, base edits, label changes, and ready-for-review transitions.

## Validation

- `uv run pytest tests/test_ci/test_workflows.py -q`
- `uv run ruff check tests/test_ci/test_workflows.py`
- `shellcheck .github/scripts/validate-pr-target-branch.sh .github/scripts/classify-ci-changes.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/pr-target-branch.yml`
- `git diff --check`

## Notes

This PR is based directly on `origin/main` to avoid carrying the current `dev` branch delta into the default branch.