### PR TITLE
Keep issue state aligned with dev merges

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 ## Checklist
 
 - [ ] This pull request targets `dev`, unless a maintainer asked for a `main` release/hotfix/documentation PR.
+- [ ] Linked issues are declared with `Fixes #...`, `Refs #...`, or `None`.
+- [ ] Release impact is declared: `user-visible`, `internal`, `docs`, or `none`.
 - [ ] I ran `uv run ruff check src tests`.
 - [ ] I ran `uv run pytest -q`.
 - [ ] I ran `uv build --wheel`.

--- a/.github/scripts/issue_link_sync.py
+++ b/.github/scripts/issue_link_sync.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Synchronize OpenSquilla issue state after pull request lifecycle changes.
+
+This script is intentionally safe for `pull_request_target`: it treats pull
+request text as data only and never executes code from the pull request head.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from typing import Any, NamedTuple
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+HAS_LINKED_PR_LABEL = "has-linked-pr"
+MERGED_TO_DEV_LABEL = "merged-to-dev"
+NEEDS_VERIFICATION_LABEL = "needs-verification"
+
+LABEL_DEFINITIONS = {
+    HAS_LINKED_PR_LABEL: {
+        "color": "C5DEF5",
+        "description": "An open pull request is linked to this issue",
+    },
+    MERGED_TO_DEV_LABEL: {
+        "color": "5319E7",
+        "description": "A related fix has merged to dev but has not necessarily shipped",
+    },
+    NEEDS_VERIFICATION_LABEL: {
+        "color": "C5DEF5",
+        "description": "Maintainers or reporters should retest the current behavior",
+    },
+}
+
+CLOSING_KEYWORDS = frozenset(
+    {
+        "close",
+        "closes",
+        "closed",
+        "fix",
+        "fixes",
+        "fixed",
+        "resolve",
+        "resolves",
+        "resolved",
+    }
+)
+REFERENCE_KEYWORDS = frozenset({"ref", "refs", "reference", "references"})
+KEYWORD_RE = re.compile(
+    r"\b(?P<keyword>close|closes|closed|fix|fixes|fixed|resolve|resolves|"
+    r"resolved|ref|refs|reference|references)\s*:?\s+(?P<ref>"
+    r"#\d+|"
+    r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#\d+|"
+    r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/issues/\d+"
+    r")\b",
+    re.IGNORECASE,
+)
+LOCAL_REF_RE = re.compile(r"^#(?P<number>\d+)$")
+REPO_REF_RE = re.compile(
+    r"^(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)#(?P<number>\d+)$"
+)
+ISSUE_URL_RE = re.compile(
+    r"^https://github\.com/(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)/"
+    r"issues/(?P<number>\d+)$"
+)
+
+
+class ParsedIssueLinks(NamedTuple):
+    closing: tuple[int, ...]
+    references: tuple[int, ...]
+
+    @property
+    def all(self) -> tuple[int, ...]:
+        return tuple(dict.fromkeys((*self.closing, *self.references)))
+
+
+class IssueSyncAction(NamedTuple):
+    issue_number: int
+    kind: str
+    pr_number: int
+    pr_url: str
+
+
+class GitHubClient:
+    def __init__(self, *, token: str, repository: str) -> None:
+        self._token = token
+        self._repository = repository
+        self._api_root = f"https://api.github.com/repos/{repository}"
+
+    def request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        payload: dict[str, Any] | None = None,
+        ignore_statuses: set[int] | None = None,
+    ) -> Any:
+        ignore_statuses = ignore_statuses or set()
+        data = None
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self._token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        request = Request(
+            f"{self._api_root}{path}",
+            data=data,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urlopen(request, timeout=30) as response:
+                raw = response.read()
+        except HTTPError as exc:
+            if exc.code in ignore_statuses:
+                return None
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"GitHub API {method} {path} failed: {exc.code} {body}") from exc
+
+        if not raw:
+            return None
+        return json.loads(raw.decode("utf-8"))
+
+    def ensure_label(self, name: str) -> None:
+        definition = LABEL_DEFINITIONS[name]
+        label_name = quote(name, safe="")
+        found = self.request_json(
+            "GET",
+            f"/labels/{label_name}",
+            ignore_statuses={404},
+        )
+        if found is not None:
+            return
+        self.request_json(
+            "POST",
+            "/labels",
+            payload={
+                "name": name,
+                "color": definition["color"],
+                "description": definition["description"],
+            },
+        )
+
+    def add_labels(self, issue_number: int, labels: list[str]) -> None:
+        for label in labels:
+            self.ensure_label(label)
+        self.request_json(
+            "POST",
+            f"/issues/{issue_number}/labels",
+            payload={"labels": labels},
+        )
+
+    def remove_label(self, issue_number: int, label: str) -> None:
+        label_name = quote(label, safe="")
+        self.request_json(
+            "DELETE",
+            f"/issues/{issue_number}/labels/{label_name}",
+            ignore_statuses={404},
+        )
+
+    def list_comments(self, issue_number: int) -> list[dict[str, Any]]:
+        all_comments: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            comments = self.request_json(
+                "GET",
+                f"/issues/{issue_number}/comments?per_page=100&page={page}",
+            )
+            if not isinstance(comments, list) or not comments:
+                return all_comments
+            all_comments.extend(comments)
+            if len(comments) < 100:
+                return all_comments
+            page += 1
+
+    def create_comment(self, issue_number: int, body: str) -> None:
+        self.request_json(
+            "POST",
+            f"/issues/{issue_number}/comments",
+            payload={"body": body},
+        )
+
+
+def _normalize_repo_ref(raw_ref: str, *, owner: str, repo: str) -> int | None:
+    local = LOCAL_REF_RE.match(raw_ref)
+    if local is not None:
+        return int(local.group("number"))
+
+    repo_ref = REPO_REF_RE.match(raw_ref)
+    if repo_ref is not None:
+        if repo_ref.group("owner").lower() != owner.lower():
+            return None
+        if repo_ref.group("repo").lower() != repo.lower():
+            return None
+        return int(repo_ref.group("number"))
+
+    issue_url = ISSUE_URL_RE.match(raw_ref)
+    if issue_url is not None:
+        if issue_url.group("owner").lower() != owner.lower():
+            return None
+        if issue_url.group("repo").lower() != repo.lower():
+            return None
+        return int(issue_url.group("number"))
+
+    return None
+
+
+def parse_linked_issues(body: str | None, *, owner: str, repo: str) -> ParsedIssueLinks:
+    closing: list[int] = []
+    references: list[int] = []
+
+    for match in KEYWORD_RE.finditer(body or ""):
+        issue_number = _normalize_repo_ref(match.group("ref"), owner=owner, repo=repo)
+        if issue_number is None:
+            continue
+        keyword = match.group("keyword").lower()
+        if keyword in CLOSING_KEYWORDS:
+            closing.append(issue_number)
+        elif keyword in REFERENCE_KEYWORDS:
+            references.append(issue_number)
+
+    return ParsedIssueLinks(
+        closing=tuple(dict.fromkeys(closing)),
+        references=tuple(dict.fromkeys(references)),
+    )
+
+
+def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...]:
+    if event.get("action") != "closed":
+        return ()
+
+    pr = event.get("pull_request") or {}
+    repository = event.get("repository") or {}
+    full_name = repository.get("full_name") or ""
+    if "/" not in full_name:
+        return ()
+    owner, repo = full_name.split("/", 1)
+
+    pr_number = int(pr["number"])
+    pr_url = str(pr.get("html_url") or "")
+    parsed = parse_linked_issues(pr.get("body"), owner=owner, repo=repo)
+
+    if pr.get("merged") is True and (pr.get("base") or {}).get("ref") == "dev":
+        return tuple(
+            IssueSyncAction(
+                issue_number=issue_number,
+                kind="merged_to_dev",
+                pr_number=pr_number,
+                pr_url=pr_url,
+            )
+            for issue_number in parsed.closing
+        )
+
+    if pr.get("merged") is not True:
+        return tuple(
+            IssueSyncAction(
+                issue_number=issue_number,
+                kind="closed_unmerged",
+                pr_number=pr_number,
+                pr_url=pr_url,
+            )
+            for issue_number in parsed.all
+        )
+
+    return ()
+
+
+def comment_marker(*, kind: str, pr_number: int) -> str:
+    marker_kind = kind.replace("_", "-")
+    return f"<!-- opensquilla-issue-link-sync:{marker_kind}:pr-{pr_number} -->"
+
+
+def has_marker(comments: list[dict[str, Any]], marker: str) -> bool:
+    return any(marker in str(comment.get("body") or "") for comment in comments)
+
+
+def _merged_to_dev_comment(action: IssueSyncAction) -> str:
+    marker = comment_marker(kind=action.kind, pr_number=action.pr_number)
+    return (
+        f"{marker}\n"
+        f"The linked fix for this issue has merged to `dev` via #{action.pr_number} "
+        f"({action.pr_url}). Keeping it open for verification before release."
+    )
+
+
+def apply_action(client: GitHubClient, action: IssueSyncAction) -> None:
+    if action.kind == "merged_to_dev":
+        client.add_labels(
+            action.issue_number,
+            [MERGED_TO_DEV_LABEL, NEEDS_VERIFICATION_LABEL],
+        )
+        client.remove_label(action.issue_number, HAS_LINKED_PR_LABEL)
+        marker = comment_marker(kind=action.kind, pr_number=action.pr_number)
+        if not has_marker(client.list_comments(action.issue_number), marker):
+            client.create_comment(action.issue_number, _merged_to_dev_comment(action))
+        return
+
+    if action.kind == "closed_unmerged":
+        client.remove_label(action.issue_number, HAS_LINKED_PR_LABEL)
+        return
+
+    raise ValueError(f"Unsupported issue sync action: {action.kind}")
+
+
+def _load_event(path: str) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> int:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    repository = os.environ.get("GITHUB_REPOSITORY")
+    token = os.environ.get("GITHUB_TOKEN")
+
+    if not event_path:
+        print("GITHUB_EVENT_PATH is required.", file=sys.stderr)
+        return 2
+    if not repository:
+        print("GITHUB_REPOSITORY is required.", file=sys.stderr)
+        return 2
+    if not token:
+        print("GITHUB_TOKEN is required.", file=sys.stderr)
+        return 2
+
+    event = _load_event(event_path)
+    actions = plan_issue_sync_actions(event)
+    if not actions:
+        print("No issue sync actions required.")
+        return 0
+
+    client = GitHubClient(token=token, repository=repository)
+    for action in actions:
+        print(
+            f"Applying {action.kind} for issue #{action.issue_number} "
+            f"from PR #{action.pr_number}."
+        )
+        apply_action(client, action)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/issue-link-sync.yml
+++ b/.github/workflows/issue-link-sync.yml
@@ -1,0 +1,35 @@
+name: Issue Link Sync
+
+"on":
+  pull_request_target:
+    types: [closed]
+    branches: [dev]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  sync-linked-issues:
+    name: Sync linked issue state
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out trusted base branch scripts
+        uses: actions/checkout@v4
+        with:
+          # pull_request_target has write-capable tokens. Run scripts from the
+          # pre-merge base commit, never from the pull request head.
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Sync issue labels and comments
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/issue_link_sync.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,21 @@ latest `main` release point. When that requires replacing the active
 `dev` branch, the previous branch will be archived and contributors
 will be asked to rebase or retarget open pull requests.
 
+## Linked Issues
+
+Declare issue relationships in pull request descriptions with GitHub keywords:
+
+- Use `Fixes #123`, `Closes #123`, or `Resolves #123` when the pull request is intended to fix the issue.
+- Use `Refs #123` when the pull request is related but should not move the issue toward closure.
+- Use `None` when no public issue is linked.
+
+OpenSquilla keeps issue closure tied to the release branch. Merging a fixing
+pull request into `dev` marks the issue as `merged-to-dev` and
+`needs-verification`; the issue remains open until the fix reaches the default
+branch through a release or hotfix pull request. Maintainers may use
+`has-linked-pr` while work is still under review. If a linked pull request is
+closed without merging, the automation removes `has-linked-pr`.
+
 ## Attribution On Squash Or Replay
 
 When maintainer cleanup, replay, or squash merging collapses contributor

--- a/tests/test_github_issue_link_sync.py
+++ b/tests/test_github_issue_link_sync.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+
+def _load_sync_module():
+    script = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "issue_link_sync.py"
+    spec = importlib.util.spec_from_file_location("issue_link_sync", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RecordingClient:
+    def __init__(self, comments: list[dict[str, Any]] | None = None) -> None:
+        self.comments = comments or []
+        self.calls: list[tuple[Any, ...]] = []
+
+    def add_labels(self, issue_number: int, labels: list[str]) -> None:
+        self.calls.append(("add_labels", issue_number, tuple(labels)))
+
+    def remove_label(self, issue_number: int, label: str) -> None:
+        self.calls.append(("remove_label", issue_number, label))
+
+    def list_comments(self, issue_number: int) -> list[dict[str, Any]]:
+        self.calls.append(("list_comments", issue_number))
+        return self.comments
+
+    def create_comment(self, issue_number: int, body: str) -> None:
+        self.calls.append(("create_comment", issue_number, body))
+
+
+class PaginatedGitHubClient:
+    def __init__(self, pages: list[list[dict[str, Any]]]) -> None:
+        self.pages = pages
+        self.paths: list[str] = []
+
+    def request_json(self, method: str, path: str) -> list[dict[str, Any]]:
+        assert method == "GET"
+        self.paths.append(path)
+        return self.pages.pop(0)
+
+
+def test_parse_linked_issues_splits_closing_and_reference_keywords() -> None:
+    sync = _load_sync_module()
+
+    parsed = sync.parse_linked_issues(
+        "\n".join(
+            [
+                "Fixes #100",
+                "Closes: opensquilla/opensquilla#101",
+                "resolves https://github.com/opensquilla/opensquilla/issues/102",
+                "Refs #200",
+                "References opensquilla/opensquilla#201",
+                "Fixes other/project#999",
+            ]
+        ),
+        owner="opensquilla",
+        repo="opensquilla",
+    )
+
+    assert parsed.closing == (100, 101, 102)
+    assert parsed.references == (200, 201)
+    assert parsed.all == (100, 101, 102, 200, 201)
+
+
+def test_parse_linked_issues_deduplicates_and_ignores_pr_style_urls() -> None:
+    sync = _load_sync_module()
+
+    parsed = sync.parse_linked_issues(
+        "\n".join(
+            [
+                "Fixes #100",
+                "fixes #100",
+                "Refs https://github.com/opensquilla/opensquilla/pull/203",
+                "Fixes https://github.com/opensquilla/opensquilla/issues/101",
+            ]
+        ),
+        owner="opensquilla",
+        repo="opensquilla",
+    )
+
+    assert parsed.closing == (100, 101)
+    assert parsed.references == ()
+    assert parsed.all == (100, 101)
+
+
+def test_plan_merged_dev_pr_updates_only_closing_issues() -> None:
+    sync = _load_sync_module()
+
+    actions = sync.plan_issue_sync_actions(
+        {
+            "action": "closed",
+            "pull_request": {
+                "number": 203,
+                "merged": True,
+                "body": "Fixes #100\nRefs #200",
+                "base": {"ref": "dev"},
+                "html_url": "https://github.com/opensquilla/opensquilla/pull/203",
+            },
+            "repository": {
+                "full_name": "opensquilla/opensquilla",
+            },
+        }
+    )
+
+    assert actions == (
+        sync.IssueSyncAction(
+            issue_number=100,
+            kind="merged_to_dev",
+            pr_number=203,
+            pr_url="https://github.com/opensquilla/opensquilla/pull/203",
+        ),
+    )
+
+
+def test_plan_closed_unmerged_pr_removes_linked_pr_label_from_all_linked_issues() -> None:
+    sync = _load_sync_module()
+
+    actions = sync.plan_issue_sync_actions(
+        {
+            "action": "closed",
+            "pull_request": {
+                "number": 204,
+                "merged": False,
+                "body": "Fixes #100\nRefs #200",
+                "base": {"ref": "dev"},
+                "html_url": "https://github.com/opensquilla/opensquilla/pull/204",
+            },
+            "repository": {
+                "full_name": "opensquilla/opensquilla",
+            },
+        }
+    )
+
+    assert actions == (
+        sync.IssueSyncAction(
+            issue_number=100,
+            kind="closed_unmerged",
+            pr_number=204,
+            pr_url="https://github.com/opensquilla/opensquilla/pull/204",
+        ),
+        sync.IssueSyncAction(
+            issue_number=200,
+            kind="closed_unmerged",
+            pr_number=204,
+            pr_url="https://github.com/opensquilla/opensquilla/pull/204",
+        ),
+    )
+
+
+def test_comment_marker_is_pr_scoped_for_idempotent_merged_to_dev_comments() -> None:
+    sync = _load_sync_module()
+
+    marker = sync.comment_marker(kind="merged_to_dev", pr_number=203)
+
+    assert marker == "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-203 -->"
+    assert sync.has_marker([{"body": f"{marker}\nThis is already posted."}], marker)
+    assert not sync.has_marker(
+        [{"body": "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-202 -->"}],
+        marker,
+    )
+
+
+def test_apply_merged_dev_action_labels_removes_open_pr_label_and_comments_once() -> None:
+    sync = _load_sync_module()
+    action = sync.IssueSyncAction(
+        issue_number=100,
+        kind="merged_to_dev",
+        pr_number=203,
+        pr_url="https://github.com/opensquilla/opensquilla/pull/203",
+    )
+    client = RecordingClient()
+
+    sync.apply_action(client, action)
+
+    assert client.calls == [
+        ("add_labels", 100, ("merged-to-dev", "needs-verification")),
+        ("remove_label", 100, "has-linked-pr"),
+        ("list_comments", 100),
+        (
+            "create_comment",
+            100,
+            "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-203 -->\n"
+            "The linked fix for this issue has merged to `dev` via #203 "
+            "(https://github.com/opensquilla/opensquilla/pull/203). "
+            "Keeping it open for verification before release.",
+        ),
+    ]
+
+    marker = sync.comment_marker(kind="merged_to_dev", pr_number=203)
+    client = RecordingClient(comments=[{"body": marker}])
+
+    sync.apply_action(client, action)
+
+    assert client.calls == [
+        ("add_labels", 100, ("merged-to-dev", "needs-verification")),
+        ("remove_label", 100, "has-linked-pr"),
+        ("list_comments", 100),
+    ]
+
+
+def test_apply_closed_unmerged_action_only_removes_open_pr_label() -> None:
+    sync = _load_sync_module()
+    action = sync.IssueSyncAction(
+        issue_number=200,
+        kind="closed_unmerged",
+        pr_number=204,
+        pr_url="https://github.com/opensquilla/opensquilla/pull/204",
+    )
+    client = RecordingClient()
+
+    sync.apply_action(client, action)
+
+    assert client.calls == [("remove_label", 200, "has-linked-pr")]
+
+
+def test_list_comments_reads_all_pages_before_idempotency_check() -> None:
+    sync = _load_sync_module()
+    client = PaginatedGitHubClient(
+        [
+            [{"body": f"old comment {index}"} for index in range(100)],
+            [{"body": "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-203 -->"}],
+        ]
+    )
+
+    comments = sync.GitHubClient.list_comments(client, 100)
+
+    assert sync.has_marker(
+        comments,
+        "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-203 -->",
+    )
+    assert client.paths == [
+        "/issues/100/comments?per_page=100&page=1",
+        "/issues/100/comments?per_page=100&page=2",
+    ]


### PR DESCRIPTION
## Summary

Sync the issue-link automation commit from dev to main so pull_request_target can run from the default branch.

- add the trusted-base issue sync workflow and script
- add focused tests for keyword parsing, label/comment actions, and comment pagination
- document linked issue labels and PR metadata expectations

## Checklist

- [x] This pull request targets `main` because the repository rules require a PR and GitHub Actions pull_request_target workflows must exist on the default branch before they can run.
- [x] Linked issues are declared with `Fixes #...`, `Refs #...`, or `None`: None.
- [x] Release impact is declared: internal.
- [x] I ran `uv run ruff check src tests`.
- [x] I ran `uv run pytest tests/test_github_issue_link_sync.py -q`.
- [x] I ran `uv run pytest tests/test_public_release_hygiene.py -q`.
- [x] I ran `uv build --wheel`.
- [x] Behavior changes include public regression tests.
- [x] The default test path remains offline, deterministic, credential-free, and safe for forks.
- [x] Third-party origin is declared: none.

## Validation

- `uv run pytest tests/test_github_issue_link_sync.py -q` -> 8 passed
- `uv run pytest tests/test_public_release_hygiene.py -q` -> 12 passed
- `uv run ruff check src tests` -> passed
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color=false` -> passed
- `uv build --wheel` -> passed
- `git diff --check origin/main...HEAD` -> passed
