### PR TITLE
Add opensquilla profiles list and opensquilla profiles init-all

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,10 +27,10 @@ OPENSQUILLA_GATEWAY_SEARCH_USE_ENV_PROXY=false
 # Usage:
 #   Windows PowerShell (one-time, per user):
 #     [System.Environment]::SetEnvironmentVariable(
-#         "OPENSQUILLA_PROFILES_DIR", "D:\ai\opensquilla\profiles", "User")
+#         "OPENSQUILLA_HOME", "D:\ai\opensquilla\profiles", "User")
 #
 #   macOS / Linux (~/.zshrc, ~/.bashrc, etc.):
-#     export OPENSQUILLA_PROFILES_DIR="$HOME/opensquilla/profiles"
+#     export OPENSQUILLA_HOME="$HOME/opensquilla/profiles"
 #
 # Then:
 #     opensquilla --profile coder   init      # creates .../profiles/coder/
@@ -44,7 +44,7 @@ OPENSQUILLA_GATEWAY_SEARCH_USE_ENV_PROXY=false
 #
 # Path-resolution precedence (see src/opensquilla/paths.py):
 #   1. OPENSQUILLA_STATE_DIR       — full override; bypasses profile mode.
-#   2. OPENSQUILLA_PROFILES_DIR    — parent directory of all profiles.
+#   2. OPENSQUILLA_HOME    — parent directory of all profiles.
 #      + OPENSQUILLA_PROFILE         — current profile name (default: "default").
 #   3. $HOME/.opensquilla          — single-instance default (unchanged).
 #
@@ -52,5 +52,5 @@ OPENSQUILLA_GATEWAY_SEARCH_USE_ENV_PROXY=false
 # escapes. The CLI rejects bad names with a clear error.
 # ─────────────────────────────────────────────────────────────────────────────
 
-# OPENSQUILLA_PROFILES_DIR=D:\ai\opensquilla\profiles
+# OPENSQUILLA_HOME=D:\ai\opensquilla\profiles
 # OPENSQUILLA_PROFILE=default

--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,40 @@ OPENSQUILLA_GATEWAY_SEARCH_PROXY=
 # Optional — allow web_search providers to use HTTP_PROXY/HTTPS_PROXY when no
 # explicit search proxy is set. Defaults to false for predictable behavior.
 OPENSQUILLA_GATEWAY_SEARCH_USE_ENV_PROXY=false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Multi-instance profiles (optional)
+# ─────────────────────────────────────────────────────────────────────────────
+# Run several OpenSquilla agents on the same host, each with its own
+# config.toml / state/ / logs/ / .env under a common profiles root.
+#
+# Usage:
+#   Windows PowerShell (one-time, per user):
+#     [System.Environment]::SetEnvironmentVariable(
+#         "OPENSQUILLA_PROFILES_DIR", "D:\ai\opensquilla\profiles", "User")
+#
+#   macOS / Linux (~/.zshrc, ~/.bashrc, etc.):
+#     export OPENSQUILLA_PROFILES_DIR="$HOME/opensquilla/profiles"
+#
+# Then:
+#     opensquilla --profile coder   init      # creates .../profiles/coder/
+#     opensquilla --profile coder   gateway start --port 18792
+#     opensquilla --profile agent-1 init
+#     opensquilla --profile agent-1 gateway start --port 18793
+#     opensquilla                       gateway start --port 18791  # default
+#
+# Or auto-start every profile at Windows user logon:
+#     .\scripts\supervisor\install-autostart.ps1
+#
+# Path-resolution precedence (see src/opensquilla/paths.py):
+#   1. OPENSQUILLA_STATE_DIR       — full override; bypasses profile mode.
+#   2. OPENSQUILLA_PROFILES_DIR    — parent directory of all profiles.
+#      + OPENSQUILLA_PROFILE         — current profile name (default: "default").
+#   3. $HOME/.opensquilla          — single-instance default (unchanged).
+#
+# Profile names must match ^[a-z0-9][a-z0-9_-]{0,63}$ to prevent path-traversal
+# escapes. The CLI rejects bad names with a clear error.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# OPENSQUILLA_PROFILES_DIR=D:\ai\opensquilla\profiles
+# OPENSQUILLA_PROFILE=default

--- a/README.md
+++ b/README.md
@@ -815,6 +815,36 @@ opensquilla gateway restart
 
 ---
 
+## Per-profile logon autostart (issue #193)
+
+`opensquilla --profile <name> init --autostart` registers a per-profile
+startup entry on this host, so the gateway comes back up the next time
+the user logs in. The dispatch is platform-aware:
+
+- **Windows** — a `OpenSquilla_<profile>` Task Scheduler logon task that
+  runs `opensquilla --profile <profile> gateway start` on each
+  interactive logon. Equivalent to the per-task payload of
+  `scripts/supervisor/install-autostart.ps1`, but registered per
+  profile (that script registers one global start-all task; this
+  flag registers one task per profile so individual profiles can be
+  disabled independently).
+- **macOS** — a `~/Library/LaunchAgents/com.opensquilla.<profile>.plist`
+  LaunchAgent that `launchctl load -w`s on next login. The plist sets
+  `RunAtLoad=true` and `KeepAlive=true`.
+- **Linux** — a `~/.config/systemd/user/opensquilla-<profile>.service`
+  systemd --user unit that `systemctl --user enable --now`s the
+  service.
+
+The flag is opt-in (off by default) and best-effort: if the host
+is not one of the three above, if the `opensquilla` binary is not on
+`PATH`, or if the host tool reports a failure, the wizard prints a
+warning and continues. Use `uninstall-autostart.ps1` (Windows),
+`launchctl unload -w ~/Library/LaunchAgents/com.opensquilla.<profile>.plist`
+(macOS), or `systemctl --user disable --now opensquilla-<profile>.service`
+(Linux) to roll back.
+
+---
+
 ## Credits
 
 OpenSquilla is inspired by

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ Two variables drive profile mode. Set both; `PROFILE` alone without
 
 | Variable | Required? | Default | What it does |
 |---|---|---|---|
-| `OPENSQUILLA_PROFILES_DIR` | yes (to enable) | `$HOME/.opensquilla/profiles` | Parent directory that contains every profile home. Setting this is the one switch that turns multi-instance mode on. |
+| `OPENSQUILLA_HOME` | yes (to enable) | `$HOME/.opensquilla/profiles` | Parent directory that contains every profile home. Setting this is the one switch that turns multi-instance mode on. |
 | `OPENSQUILLA_PROFILE` | no | `default` | Name of the active profile. Must match `^[a-z0-9][a-z0-9_-]{0,63}$`. |
 | `OPENSQUILLA_STATE_DIR` | no | _unset_ | **Full override** that bypasses profile mode entirely. Leave unset when running multiple profiles — it forces a single hard-coded home. |
 
@@ -417,7 +417,7 @@ Two variables drive profile mode. Set both; `PROFILE` alone without
 ```powershell
 # Required: enable multi-instance mode
 [System.Environment]::SetEnvironmentVariable(
-    "OPENSQUILLA_PROFILES_DIR", "D:\ai\opensquilla\profiles", "User")
+    "OPENSQUILLA_HOME", "D:\ai\opensquilla\profiles", "User")
 
 # Optional: pin this shell to a specific profile
 [System.Environment]::SetEnvironmentVariable(
@@ -430,7 +430,7 @@ inherited by the process.
 **Temporary (current session only)**:
 
 ```powershell
-$env:OPENSQUILLA_PROFILES_DIR = "D:\ai\opensquilla\profiles"
+$env:OPENSQUILLA_HOME = "D:\ai\opensquilla\profiles"
 $env:OPENSQUILLA_PROFILE      = "coder"     # omit to use "default"
 opensquilla gateway start --port 18792
 ```
@@ -441,7 +441,7 @@ PowerShell window per profile with a different port.
 **Verify**:
 
 ```powershell
-echo $env:OPENSQUILLA_PROFILES_DIR
+echo $env:OPENSQUILLA_HOME
 echo $env:OPENSQUILLA_PROFILE
 # Expected:
 #   D:\ai\opensquilla\profiles
@@ -452,7 +452,7 @@ echo $env:OPENSQUILLA_PROFILE
 
 1. `OPENSQUILLA_STATE_DIR` — full override; bypasses profile mode. Do
    **not** set this when running multiple profiles.
-2. `OPENSQUILLA_PROFILES_DIR` + `OPENSQUILLA_PROFILE` — multi-instance.
+2. `OPENSQUILLA_HOME` + `OPENSQUILLA_PROFILE` — multi-instance.
    Resolves to `<PROFILES_DIR>/<PROFILE>/`, e.g.
    `D:\ai\opensquilla\profiles\coder\`.
 3. `$HOME/.opensquilla` — single-instance default (unchanged on disk
@@ -462,10 +462,10 @@ echo $env:OPENSQUILLA_PROFILE
 
 | Scenario | What to set |
 |---|---|
-| Run a single `coder` instance | `OPENSQUILLA_PROFILES_DIR` permanent, `$env:OPENSQUILLA_PROFILE = "coder"` per shell |
-| Run the `default` instance | `OPENSQUILLA_PROFILES_DIR` permanent, **omit** `OPENSQUILLA_PROFILE` (default is `default`) |
-| Run `coder` + `agent-1` side by side | `OPENSQUILLA_PROFILES_DIR` permanent; open two PowerShells, each with its own `$env:OPENSQUILLA_PROFILE` and a different `--port` |
-| Disable multi-instance for one command | `unset OPENSQUILLA_PROFILES_DIR` in that shell (or use `OPENSQUILLA_STATE_DIR=...` to pin a legacy home) |
+| Run a single `coder` instance | `OPENSQUILLA_HOME` permanent, `$env:OPENSQUILLA_PROFILE = "coder"` per shell |
+| Run the `default` instance | `OPENSQUILLA_HOME` permanent, **omit** `OPENSQUILLA_PROFILE` (default is `default`) |
+| Run `coder` + `agent-1` side by side | `OPENSQUILLA_HOME` permanent; open two PowerShells, each with its own `$env:OPENSQUILLA_PROFILE` and a different `--port` |
+| Disable multi-instance for one command | `unset OPENSQUILLA_HOME` in that shell (or use `OPENSQUILLA_STATE_DIR=...` to pin a legacy home) |
 | Bootstrap a new profile | `opensquilla --profile <name> init` — does not require any env var; the CLI's `--profile` flag wins over the env var |
 
 #### macOS / Linux
@@ -474,25 +474,25 @@ The same two variables, set via the shell rc of choice:
 
 ```sh
 # ~/.zshrc or ~/.bashrc
-export OPENSQUILLA_PROFILES_DIR="$HOME/opensquilla/profiles"
+export OPENSQUILLA_HOME="$HOME/opensquilla/profiles"
 # export OPENSQUILLA_PROFILE="coder"     # optional, defaults to "default"
 ```
 
 #### Cross-platform path layout
 
-Whichever OS you set `OPENSQUILLA_PROFILES_DIR` for, each profile lives as
+Whichever OS you set `OPENSQUILLA_HOME` for, each profile lives as
 a direct child of that root. The CLI uses `pathlib` for the join, so
 backslashes, forward slashes, and tildes all work transparently.
 
 ```
-D:\ai\opensquilla\profiles\         ← OPENSQUILLA_PROFILES_DIR (Windows)
+D:\ai\opensquilla\profiles\         ← OPENSQUILLA_HOME (Windows)
 ├── default\    ← OPENSQUILLA_PROFILE=default   (or flag omitted)
 ├── coder\      ← OPENSQUILLA_PROFILE=coder
 └── agent-1\    ← OPENSQUILLA_PROFILE=agent-1
 ```
 
 ```
-/home/you/opensquilla/profiles/     ← OPENSQUILLA_PROFILES_DIR (Linux/macOS)
+/home/you/opensquilla/profiles/     ← OPENSQUILLA_HOME (Linux/macOS)
 ├── default/
 ├── coder/
 └── agent-1/

--- a/README.md
+++ b/README.md
@@ -845,6 +845,61 @@ warning and continues. Use `uninstall-autostart.ps1` (Windows),
 
 ---
 
+## Initialising every profile in one go
+
+When `OPENSQUILLA_HOME` contains several profile directories
+(`default/`, `coder/`, `test/`, …) it is tedious to run
+`opensquilla --profile <name> init` for each. `opensquilla profiles
+init-all` walks `OPENSQUILLA_HOME/profiles/*/`, and for every
+uninitialised profile (no `.env` + `config.toml` pair), writes the
+same provider / API-key / model triple and (by default) registers
+the per-profile logon autostart entry from the previous section:
+
+```sh
+# Initialise every profile under $OPENSQUILLA_HOME/profiles with
+# OpenRouter; re-uses the OPENROUTER_API_KEY already in the env so
+# nothing sensitive lands in any .env.
+opensquilla profiles init-all \
+    --provider openrouter \
+    --api-key-env OPENROUTER_API_KEY
+```
+
+Useful flags:
+
+- `--provider <id>` — provider applied to every profile (required).
+- `--api-key <key>` *or* `--api-key-env <name>` — exactly one must
+  be given. The `api_key` form writes the value into each profile's
+  `.env`; the `api_key_env` form just records the env-var name the
+  gateway should read at runtime.
+- `--model <id>` — override the model id (defaults to the
+  provider's recommended model).
+- `--autostart` (on by default) / `--no-autostart` — register the
+  per-profile logon autostart entry from the previous section.
+- `--only-uninitialised` (default) / `--all` — re-write every
+  profile, including already-initialised ones.
+- `--profiles-root <path>` — override `OPENSQUILLA_HOME/profiles`.
+
+Inspect the current set first with `opensquilla profiles list`:
+
+```text
+$ opensquilla profiles list
+                       Profiles under /home/tester/profiles
+┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ profile   ┃ state          ┃ home                                  ┃
+┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ coder     │ uninitialised  │ /home/tester/profiles/coder           │
+│ default   │ ◆ ready        │ /home/tester/profiles/default          │
+│ test      │ uninitialised  │ /home/tester/profiles/test             │
+└───────────┴────────────────┴───────────────────────────────────────┘
+```
+
+Failures inside the autostart dispatcher (one host tool broken, an
+out-of-date shim path, a profile-name that triggers a system
+guard) are surfaced per-profile and do not abort the loop — the
+remaining profiles are still initialised.
+
+---
+
 ## Credits
 
 OpenSquilla is inspired by

--- a/README.md
+++ b/README.md
@@ -315,6 +315,37 @@ In this mode, prefix every `opensquilla` command in
 development checkout through a user-local `opensquilla` command — that
 command runs in a different Python environment.
 
+#### Editable install into the tool environment
+
+If you want the `opensquilla` command on `PATH` (so you can run it
+without `uv run`) **and** have the executable track the current
+checkout, use the dev-install wrapper instead of `uv sync`. The
+wrapper runs `uv tool install -e ".[recommended]"` from the repo
+root, so the `opensquilla` shim is editable, the SquillaRouter
+runtime is pulled in, and you don't have to remember the PEP 508
+extras form.
+
+```sh
+# macOS / Linux — default path for OpenSquilla contributors
+bash scripts/dev-install.sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy Bypass -File scripts/dev-install.ps1
+```
+
+Run the wrapper again after `git pull` to re-link the shim. Both
+scripts forward extra arguments to `uv tool install`, e.g.
+`bash scripts/dev-install.sh --no-cache`.
+
+> **Why a wrapper instead of `uv tool install -e ".[recommended]"` directly?**
+> `uv tool install` does not accept a `--extra` / `--all-extras` flag —
+> it only takes `--with <pkg>` for individual packages — so the
+> PEP 508 `.[recommended]` form is the only way to bring the runtime
+> profile in from a one-liner. The wrapper centralises that so callers
+> don't have to type it by hand. A bare `uv tool install -e .` will
+> succeed but the gateway will start with "bundled ONNX router failed
+> to load" and fall back to safe-routing mode.
+
 ---
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -395,6 +395,77 @@ both default homes. Add `--migrate-secrets` only after reviewing the dry-run
 report. See [`MIGRATION.md`](MIGRATION.md) for custom paths and conflict
 handling.
 
+### Multi-instance profiles
+
+Run several OpenSquilla agents on the same host without sharing locks,
+sockets, or state files. Each profile gets its own `config.toml`,
+`state/`, `logs/`, and `.env` under a common profiles root.
+
+**Set the profiles root once (Windows PowerShell):**
+
+```powershell
+[System.Environment]::SetEnvironmentVariable(
+    "OPENSQUILLA_PROFILES_DIR", "D:\ai\opensquilla\profiles", "User")
+```
+
+On macOS / Linux, drop the same line into your shell rc:
+
+```sh
+export OPENSQUILLA_PROFILES_DIR="$HOME/opensquilla/profiles"
+```
+
+**Use it:**
+
+```sh
+# each profile is a sibling directory under the profiles root
+opensquilla --profile coder   init
+opensquilla --profile coder   gateway start --port 18792
+
+opensquilla --profile agent-1 init
+opensquilla --profile agent-1 gateway start --port 18793
+
+# `default` is the implicit name when --profile is omitted
+opensquilla gateway start --port 18791
+```
+
+Resolution precedence (see `src/opensquilla/paths.py`):
+
+1. `OPENSQUILLA_STATE_DIR` — full override; bypasses profile mode.
+2. `OPENSQUILLA_PROFILES_DIR` + `OPENSQUILLA_PROFILE` — multi-instance.
+3. `$HOME/.opensquilla` — single-instance default (unchanged on disk).
+
+Profile names must match `^[a-z0-9][a-z0-9_-]{0,63}$` to prevent
+path-traversal escapes. The CLI rejects bad names up front.
+
+**Auto-start every profile at user logon (Windows):**
+
+The `scripts/supervisor/` PowerShell scripts wrap the CLI for multi-profile
+lifecycle without touching core OpenSquilla code:
+
+```powershell
+# start every profile, in series, with stable per-profile port assignment
+.\scripts\supervisor\start-all.ps1
+
+# show one-row-per-profile status
+.\scripts\supervisor\status.ps1
+
+# stop them all
+.\scripts\supervisor\stop-all.ps1
+
+# register a logon task so the next Windows login auto-starts everything
+.\scripts\supervisor\install-autostart.ps1
+
+# remove the logon task
+.\scripts\supervisor\uninstall-autostart.ps1
+```
+
+Per-profile port is `BasePort + sorted-index` (default 18791). Pass
+`-BasePort` to shift the range. The supervisor scripts are thin wrappers:
+they call `opensquilla --profile <name> gateway start/stop/status` for
+each discovered subdirectory of the profiles root, so they pick up
+configuration, health checks, and PID locking for free from the existing
+CLI.
+
 ### Run
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -401,6 +401,36 @@ Run several OpenSquilla agents on the same host without sharing locks,
 sockets, or state files. Each profile gets its own `config.toml`,
 `state/`, `logs/`, and `.env` under a common profiles root.
 
+#### Default layout and automatic migration
+
+The profiles root defaults to `$HOME/.opensquilla/profiles`, so the
+default profile lives at `$HOME/.opensquilla/profiles/default/` and
+named profiles (`--profile coder`) live at
+`$HOME/.opensquilla/profiles/coder/` — siblings, not nested. Setting
+`OPENSQUILLA_HOME=D:\ai\opensquilla\profiles` (or any other path)
+gives the same flat layout under that directory.
+
+```
+~/.opensquilla/profiles/   ← OPENSQUILLA_HOME (or its default)
+├── default/   ← OPENSQUILLA_PROFILE=default   (or flag omitted)
+├── coder/     ← OPENSQUILLA_PROFILE=coder
+└── agent-1/   ← OPENSQUILLA_PROFILE=agent-1
+```
+
+If you have an **existing** install under the legacy
+`$HOME/.opensquilla/` home (the layout the pre-profiles releases
+used), the very first CLI invocation after upgrading auto-migrates
+the canonical subpaths (`state/`, `logs/`, `workspace/`, `media/`,
+`config.toml`, `.env`) into `$HOME/.opensquilla/profiles/default/`
+so the legacy install becomes the `default` profile with no operator
+action required. The migration is one-time, atomic where possible,
+and writes a `.migrated-to-profiles-root` sentinel inside the new
+home so it never runs twice. Delete the sentinel to force a re-run.
+
+The migration is intentionally conservative — anything not in the
+canonical list (e.g. a `custom-stuff/` directory you created
+yourself) is left in place under the legacy home.
+
 #### Environment variables (Windows)
 
 Two variables drive profile mode. Set both; `PROFILE` alone without

--- a/README.md
+++ b/README.md
@@ -401,46 +401,107 @@ Run several OpenSquilla agents on the same host without sharing locks,
 sockets, or state files. Each profile gets its own `config.toml`,
 `state/`, `logs/`, and `.env` under a common profiles root.
 
-**Set the profiles root once (Windows PowerShell):**
+#### Environment variables (Windows)
+
+Two variables drive profile mode. Set both; `PROFILE` alone without
+`PROFILES_DIR` is a no-op.
+
+| Variable | Required? | Default | What it does |
+|---|---|---|---|
+| `OPENSQUILLA_PROFILES_DIR` | yes (to enable) | `$HOME/.opensquilla/profiles` | Parent directory that contains every profile home. Setting this is the one switch that turns multi-instance mode on. |
+| `OPENSQUILLA_PROFILE` | no | `default` | Name of the active profile. Must match `^[a-z0-9][a-z0-9_-]{0,63}$`. |
+| `OPENSQUILLA_STATE_DIR` | no | _unset_ | **Full override** that bypasses profile mode entirely. Leave unset when running multiple profiles — it forces a single hard-coded home. |
+
+**Permanent (per-user, survives reboot)**:
 
 ```powershell
+# Required: enable multi-instance mode
 [System.Environment]::SetEnvironmentVariable(
     "OPENSQUILLA_PROFILES_DIR", "D:\ai\opensquilla\profiles", "User")
+
+# Optional: pin this shell to a specific profile
+[System.Environment]::SetEnvironmentVariable(
+    "OPENSQUILLA_PROFILE", "coder", "User")
 ```
 
-On macOS / Linux, drop the same line into your shell rc:
+Reopen PowerShell after `SetEnvironmentVariable` so the new value is
+inherited by the process.
 
-```sh
-export OPENSQUILLA_PROFILES_DIR="$HOME/opensquilla/profiles"
+**Temporary (current session only)**:
+
+```powershell
+$env:OPENSQUILLA_PROFILES_DIR = "D:\ai\opensquilla\profiles"
+$env:OPENSQUILLA_PROFILE      = "coder"     # omit to use "default"
+opensquilla gateway start --port 18792
 ```
 
-**Use it:**
+This is the right form for per-shell or per-task overrides, e.g. one
+PowerShell window per profile with a different port.
 
-```sh
-# each profile is a sibling directory under the profiles root
-opensquilla --profile coder   init
-opensquilla --profile coder   gateway start --port 18792
+**Verify**:
 
-opensquilla --profile agent-1 init
-opensquilla --profile agent-1 gateway start --port 18793
-
-# `default` is the implicit name when --profile is omitted
-opensquilla gateway start --port 18791
+```powershell
+echo $env:OPENSQUILLA_PROFILES_DIR
+echo $env:OPENSQUILLA_PROFILE
+# Expected:
+#   D:\ai\opensquilla\profiles
+#   coder    (or empty if you only set PROFILES_DIR)
 ```
 
-Resolution precedence (see `src/opensquilla/paths.py`):
+**Resolution precedence** (see `src/opensquilla/paths.py`):
 
-1. `OPENSQUILLA_STATE_DIR` — full override; bypasses profile mode.
+1. `OPENSQUILLA_STATE_DIR` — full override; bypasses profile mode. Do
+   **not** set this when running multiple profiles.
 2. `OPENSQUILLA_PROFILES_DIR` + `OPENSQUILLA_PROFILE` — multi-instance.
-3. `$HOME/.opensquilla` — single-instance default (unchanged on disk).
+   Resolves to `<PROFILES_DIR>/<PROFILE>/`, e.g.
+   `D:\ai\opensquilla\profiles\coder\`.
+3. `$HOME/.opensquilla` — single-instance default (unchanged on disk
+   for existing deployments).
 
-Profile names must match `^[a-z0-9][a-z0-9_-]{0,63}$` to prevent
-path-traversal escapes. The CLI rejects bad names up front.
+#### Common patterns
 
-**Auto-start every profile at user logon (Windows):**
+| Scenario | What to set |
+|---|---|
+| Run a single `coder` instance | `OPENSQUILLA_PROFILES_DIR` permanent, `$env:OPENSQUILLA_PROFILE = "coder"` per shell |
+| Run the `default` instance | `OPENSQUILLA_PROFILES_DIR` permanent, **omit** `OPENSQUILLA_PROFILE` (default is `default`) |
+| Run `coder` + `agent-1` side by side | `OPENSQUILLA_PROFILES_DIR` permanent; open two PowerShells, each with its own `$env:OPENSQUILLA_PROFILE` and a different `--port` |
+| Disable multi-instance for one command | `unset OPENSQUILLA_PROFILES_DIR` in that shell (or use `OPENSQUILLA_STATE_DIR=...` to pin a legacy home) |
+| Bootstrap a new profile | `opensquilla --profile <name> init` — does not require any env var; the CLI's `--profile` flag wins over the env var |
 
-The `scripts/supervisor/` PowerShell scripts wrap the CLI for multi-profile
-lifecycle without touching core OpenSquilla code:
+#### macOS / Linux
+
+The same two variables, set via the shell rc of choice:
+
+```sh
+# ~/.zshrc or ~/.bashrc
+export OPENSQUILLA_PROFILES_DIR="$HOME/opensquilla/profiles"
+# export OPENSQUILLA_PROFILE="coder"     # optional, defaults to "default"
+```
+
+#### Cross-platform path layout
+
+Whichever OS you set `OPENSQUILLA_PROFILES_DIR` for, each profile lives as
+a direct child of that root. The CLI uses `pathlib` for the join, so
+backslashes, forward slashes, and tildes all work transparently.
+
+```
+D:\ai\opensquilla\profiles\         ← OPENSQUILLA_PROFILES_DIR (Windows)
+├── default\    ← OPENSQUILLA_PROFILE=default   (or flag omitted)
+├── coder\      ← OPENSQUILLA_PROFILE=coder
+└── agent-1\    ← OPENSQUILLA_PROFILE=agent-1
+```
+
+```
+/home/you/opensquilla/profiles/     ← OPENSQUILLA_PROFILES_DIR (Linux/macOS)
+├── default/
+├── coder/
+└── agent-1/
+```
+
+#### Auto-start every profile at user logon (Windows)
+
+The `scripts/supervisor/` PowerShell scripts wrap the CLI for
+multi-profile lifecycle without touching core OpenSquilla code:
 
 ```powershell
 # start every profile, in series, with stable per-profile port assignment
@@ -465,6 +526,13 @@ they call `opensquilla --profile <name> gateway start/stop/status` for
 each discovered subdirectory of the profiles root, so they pick up
 configuration, health checks, and PID locking for free from the existing
 CLI.
+
+#### Profile name validation
+
+Profile names must match `^[a-z0-9][a-z0-9_-]{0,63}$` to prevent
+path-traversal escapes. The CLI rejects bad names up front with a clear
+error. Valid examples: `default`, `coder`, `agent-1`, `dev_env`. Invalid
+examples: `../escape`, `With Spaces`, `中文`, `a`×65.
 
 ### Run
 

--- a/install.ps1
+++ b/install.ps1
@@ -283,3 +283,47 @@ PATH note:
   Or open a new PowerShell window.
 "@ | Write-Host
 }
+
+# Surface the multi-instance profile env var (read-only here — the
+# installer does not create the home directory; 'opensquilla --profile
+# <name> init' does that later). Show the active value so the operator
+# can confirm what their next command will resolve to.
+if ($env:OPENSQUILLA_HOME) {
+    @"
+
+Multi-instance profile mode is active:
+  OPENSQUILLA_HOME=$($env:OPENSQUILLA_HOME)
+
+  Per-profile homes live under `$env:OPENSQUILLA_HOME\<profile>\. The default
+  profile (no --profile flag) lands at:
+    $($env:OPENSQUILLA_HOME)\default\
+
+  Bootstrap one:
+    `$env:OPENSQUILLA_HOME = "$($env:OPENSQUILLA_HOME)"
+    `$env:OPENSQUILLA_PROFILE = "coder"
+    opensquilla --profile coder init
+    opensquilla --profile coder gateway start --port 18792
+
+"@ | Write-Host
+} else {
+    @"
+
+OPENSQUILLA_HOME is not set, so multi-instance mode is OFF and OpenSquilla
+falls back to the legacy single-instance home:
+    `$env:USERPROFILE\.opensquilla\
+
+  This is the unchanged behaviour for existing deployments. To run several
+  agents on this host, set OPENSQUILLA_HOME before 'opensquilla init':
+
+    [System.Environment]::SetEnvironmentVariable(
+        "OPENSQUILLA_HOME", "D:\ai\opensquilla\home", "User")
+    `$env:OPENSQUILLA_HOME = "D:\ai\opensquilla\home"
+    `$env:OPENSQUILLA_PROFILE = "coder"
+    opensquilla --profile coder init
+    opensquilla --profile coder gateway start --port 18792
+
+  (Note: an empty OPENSQUILLA_HOME is treated the same as unset, so the
+  fall-through is intentional and back-compatible.)
+
+"@ | Write-Host
+}

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,12 @@ Environment equivalents:
   OPENSQUILLA_INSTALL_PROFILE=recommended|core
   OPENSQUILLA_INSTALL_EXTRAS=matrix
   OPENSQUILLA_INSTALL_DRY_RUN=1
+  OPENSQUILLA_HOME=/path/to/opensquilla/home   # read by 'opensquilla' at runtime
+                                              # (not used by this installer; the
+                                              # install only places the wheel).
+                                              # Set it before 'opensquilla --profile
+                                              # <name> init' to enable multi-instance
+                                              # mode.
 HELP
 }
 
@@ -245,6 +251,44 @@ Do not expose the gateway on 0.0.0.0 unless it is behind a trusted reverse
 proxy or VPN.
 ----------------------------------------------------------------------------
 DONE
+
+# Surface the multi-instance profile env var (read-only here — the
+# installer does not create the home directory; 'opensquilla --profile
+# <name> init' does that later). Show the active value so the operator
+# can confirm what their next command will resolve to.
+if [[ -n "${OPENSQUILLA_HOME:-}" ]]; then
+    cat <<MULTI
+Multi-instance profile mode is active:
+  OPENSQUILLA_HOME=${OPENSQUILLA_HOME}
+
+  Per-profile homes live under \$OPENSQUILLA_HOME/<profile>/. The default
+  profile (no --profile flag) lands at:
+    ${OPENSQUILLA_HOME}/default/
+
+  Bootstrap one:
+    export OPENSQUILLA_HOME="${OPENSQUILLA_HOME}"
+    opensquilla --profile coder init
+    opensquilla --profile coder gateway start --port 18792
+
+MULTI
+else
+    cat <<SINGLE
+OPENSQUILLA_HOME is not set, so multi-instance mode is OFF and OpenSquilla
+falls back to the legacy single-instance home:
+    \$HOME/.opensquilla/
+
+  This is the unchanged behaviour for existing deployments. To run several
+  agents on this host, set OPENSQUILLA_HOME before 'opensquilla init':
+
+    export OPENSQUILLA_HOME="\$HOME/opensquilla"
+    opensquilla --profile coder init
+    opensquilla --profile coder gateway start --port 18792
+
+  (Note: an empty OPENSQUILLA_HOME is treated the same as unset, so the
+  fall-through is intentional and back-compatible.)
+
+SINGLE
+fi
 
 if [[ -n "${tool_bin_dir}" && ":${original_path}:" != *":${tool_bin_dir}:"* ]]; then
     cat <<PATHNOTE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "dingtalk-stream>=0.24.3,<0.25",
     "qq-botpy>=1.2.1,<1.3",
     "cryptography>=42",
+    "sqlalchemy>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/dev-install.ps1
+++ b/scripts/dev-install.ps1
@@ -1,0 +1,37 @@
+# scripts/dev-install.ps1
+# Dev install: editable opensquilla with the recommended runtime profile.
+#
+# This is the default install path for OpenSquilla contributors on
+# Windows. Mirrors scripts/dev-install.sh.
+#
+# Usage:
+#   powershell -File scripts/dev-install.ps1
+#   powershell -File scripts/dev-install.ps1 -NoCache
+#
+# Rationale: uv tool install does not accept a --extra flag (only
+# --with <pkg>), so `.[recommended]` is the only way to bring the
+# runtime profile in. Centralising the PEP 508 form in one script keeps
+# callers from typing it by hand and gives maintainers one place to
+# bump the profile if it changes.
+
+[CmdletBinding()]
+param(
+    # Pass-through flags to `uv tool install`. e.g. -NoCache
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $UvArgs = @()
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptDir '..')).Path
+Set-Location $repoRoot
+
+# Keep the lock and venv in sync with the just-changed `.[recommended]`
+# resolution. `--upgrade` makes repeated runs cheap when the upstream
+# registry moves; the rest comes from $UvArgs.
+$uv = Get-Command uv -ErrorAction Stop
+& $uv tool install --upgrade -e ".[recommended]" --force @UvArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "dev-install.ps1: uv tool install failed with exit code $LASTEXITCODE"
+}

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# scripts/dev-install.sh
+# Dev install: editable opensquilla with the recommended runtime profile.
+#
+# This is the default install path for OpenSquilla contributors. It runs
+# `uv tool install -e ".[recommended]"` from the repo root so the
+# `opensquilla` shim on PATH tracks the current checkout and the bundled
+# SquillaRouter (numpy + joblib + scikit-learn + onnxruntime + ...) is
+# pulled in without any extra flags.
+#
+# Usage:
+#   bash scripts/dev-install.sh              # reinstall after a `git pull`
+#   bash scripts/dev-install.sh --no-cache   # forward flags to uv tool install
+#
+# Rationale for a wrapper instead of `uv tool install -e ".[recommended]"`:
+#   uv tool install does not accept a --extra / --all-extras flag (only
+#   `--with <pkg>` for individual packages), so the PEP 508 form
+#   `.[recommended]` is the only way to bring the runtime profile in.
+#   Centralising that into a script keeps callers from typing it by hand
+#   and gives maintainers one place to bump the profile if it changes.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+# Keep `uv.lock` and the venv's site-packages in sync with the just-changed
+# `.[recommended]` resolution. `--upgrade` makes repeated runs cheap when the
+# upstream registry moves; `--no-cache` is forwarded by callers via "$@".
+exec uv tool install --upgrade -e ".[recommended]" --force "$@"

--- a/scripts/supervisor/install-autostart.ps1
+++ b/scripts/supervisor/install-autostart.ps1
@@ -30,15 +30,22 @@
     Override the registered task name. Default:
     `OpenSquillaProfileSupervisor`.
 
+.PARAMETER Repo
+    Override the OpenSquilla source checkout that backs the registered
+    `start-all.ps1` invocation. Only used when `opensquilla` is not on
+    PATH. Defaults to the parent of this script's directory.
+
 .EXAMPLE
     .\install-autostart.ps1
     .\install-autostart.ps1 -BasePort 19000
+    .\install-autostart.ps1 -Repo D:\src\opensquilla
 #>
 [CmdletBinding()]
 param(
     [string] $ProfilesRoot,
     [int]    $BasePort   = 18791,
-    [string] $TaskName   = 'OpenSquillaProfileSupervisor'
+    [string] $TaskName   = 'OpenSquillaProfileSupervisor',
+    [string] $Repo
 )
 
 $ErrorActionPreference = 'Stop'
@@ -57,6 +64,9 @@ $startAll = Join-Path $PSScriptRoot 'start-all.ps1'
 # Build the action payload. schtasks /TR requires the script be quoted;
 # -NoProfile keeps PSReadLine / profile-loading off the boot path.
 $actionArg = "-NoProfile -ExecutionPolicy Bypass -File `"$startAll`" -ProfilesRoot `"$root`" -BasePort $BasePort -SkipRunning"
+if ($Repo) {
+    $actionArg += " -Repo `"$Repo`""
+}
 $actionXml = "<Exec><Command>powershell.exe</Command><Arguments>$actionArg</Arguments></Exec>"
 
 # schtasks.exe doesn't accept XML inline for /Create with the patterns we

--- a/scripts/supervisor/install-autostart.ps1
+++ b/scripts/supervisor/install-autostart.ps1
@@ -1,0 +1,116 @@
+<#
+.SYNOPSIS
+    Register start-all.ps1 with Windows Task Scheduler to run at user logon.
+
+.DESCRIPTION
+    Creates (or updates) a task named `OpenSquillaProfileSupervisor` that
+    fires `start-all.ps1` whenever the current user logs in interactively.
+    The task is per-user, so it does NOT need administrator rights.
+
+    The task is configured to:
+      * Run only when the user is logged on (`Interactive`).
+      * Run with highest privileges available to the user (no UAC prompt —
+        `RunOnlyIfLoggedOn` prevents a credentials popup).
+      * Re-fire if the previous run is still going (`MultipleInstancesParallel`).
+      * Use a 10-minute execution time limit. `start-all.ps1` itself waits
+        for each `gateway start` to pass its health check, so the bound is
+        generous; if it ever fires, you have a real problem to look at.
+
+    The task only registers a schedule — it does not start any gateway
+    right now. Run `.\start-all.ps1` manually for that.
+
+.PARAMETER ProfilesRoot
+    Override the profiles-root directory. Persisted into the task's
+    invocation command.
+
+.PARAMETER BasePort
+    Base port for the per-profile port mapping. Persisted.
+
+.PARAMETER TaskName
+    Override the registered task name. Default:
+    `OpenSquillaProfileSupervisor`.
+
+.EXAMPLE
+    .\install-autostart.ps1
+    .\install-autostart.ps1 -BasePort 19000
+#>
+[CmdletBinding()]
+param(
+    [string] $ProfilesRoot,
+    [int]    $BasePort   = 18791,
+    [string] $TaskName   = 'OpenSquillaProfileSupervisor'
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+if (-not (Get-Command schtasks.exe -ErrorAction SilentlyContinue)) {
+    throw 'schtasks.exe not found — this script only runs on Windows.'
+}
+
+# Resolve and persist the profiles root. We pass it on the start-all
+# invocation so the task is independent of $env:OPENSQUILLA_PROFILES_DIR
+# at logon time.
+$root = Get-ProfilesRoot -Override $ProfilesRoot
+$startAll = Join-Path $PSScriptRoot 'start-all.ps1'
+
+# Build the action payload. schtasks /TR requires the script be quoted;
+# -NoProfile keeps PSReadLine / profile-loading off the boot path.
+$actionArg = "-NoProfile -ExecutionPolicy Bypass -File `"$startAll`" -ProfilesRoot `"$root`" -BasePort $BasePort -SkipRunning"
+$actionXml = "<Exec><Command>powershell.exe</Command><Arguments>$actionArg</Arguments></Exec>"
+
+# schtasks.exe doesn't accept XML inline for /Create with the patterns we
+# need, so we write a temporary .xml and register via /XML.
+$taskXml = @"
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Author>$env:USERNAME</Author>
+    <Description>Auto-start every OpenSquilla profile gateway under $root at user logon.</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>$env:USERDOMAIN\$env:USERNAME</UserId>
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>Parallel</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <ExecutionTimeLimit>PT10M</ExecutionTimeLimit>
+    <Priority>7</Priority>
+  </Settings>
+  <Actions>
+    $actionXml
+  </Actions>
+</Task>
+"@
+
+$xmlPath = Join-Path $env:TEMP "opensquilla-supervisor-$TaskName.xml"
+[System.IO.File]::WriteAllText($xmlPath, $taskXml, [System.Text.Encoding]::Unicode)
+
+try {
+    # /F overwrites any pre-existing task with the same name.
+    $proc = Start-Process -FilePath schtasks.exe `
+        -ArgumentList @('/Create', '/TN', $TaskName, '/XML', $xmlPath, '/F') `
+        -NoNewWindow -Wait -PassThru
+    if ($proc.ExitCode -ne 0) {
+        throw "schtasks /Create exited with code $($proc.ExitCode)"
+    }
+    Write-Status "Registered task '$TaskName' to run start-all.ps1 at logon." -Level ok
+    Write-Status "Profiles root: $root" -Level info
+    Write-Status "Base port:     $BasePort" -Level info
+    Write-Status "Task XML kept at $xmlPath for inspection." -Level info
+} finally {
+    Remove-Item -LiteralPath $xmlPath -ErrorAction SilentlyContinue
+}

--- a/scripts/supervisor/install-autostart.ps1
+++ b/scripts/supervisor/install-autostart.ps1
@@ -49,7 +49,7 @@ if (-not (Get-Command schtasks.exe -ErrorAction SilentlyContinue)) {
 }
 
 # Resolve and persist the profiles root. We pass it on the start-all
-# invocation so the task is independent of $env:OPENSQUILLA_PROFILES_DIR
+# invocation so the task is independent of $env:OPENSQUILLA_HOME
 # at logon time.
 $root = Get-ProfilesRoot -Override $ProfilesRoot
 $startAll = Join-Path $PSScriptRoot 'start-all.ps1'

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -28,7 +28,6 @@ $Script:DEFAULT_PROFILES_DIR = 'D:\ai\opensquilla\profiles'
 $Script:DEFAULT_BASE_PORT = 18791
 $Script:TASK_NAME = 'OpenSquillaProfileSupervisor'
 $Script:DISPLAY_NAME = 'OpenSquilla Multi-Profile Gateway Supervisor'
-$Script:OPENSQUILLA_REPO = 'D:\ai\opensquilla\opensquilla'
 
 # --- Path / env helpers ----------------------------------------------------
 
@@ -50,13 +49,65 @@ function Get-ProfilesRoot {
 function Get-OpensquillaRoot {
     <#
     .SYNOPSIS Resolve the OpenSquilla repo root (where `uv run opensquilla ...` lives).
+    .DESCRIPTION
+    Resolution order (first hit wins):
+      1. The explicit -Repo override, if any.
+      2. The parent of this script's directory. The supervisor scripts live in
+         <repo>/scripts/supervisor/, so two levels up is the repo root. This
+         covers the documented "clone the repo and run the scripts" workflow
+         on any host without a machine-specific default.
+      3. The parent of an installed `opensquilla` executable (uv tool install
+         typically places it under %USERPROFILE%\.local\bin or
+         %LOCALAPPDATA%\uv\bin). The script does not actually need the repo
+         in this case; it only needs a path whose `uv run` invocation is
+         unambiguous, so we resolve the repo from the executable's
+         location as a last-resort tiebreaker.
+    Returns the resolved repo path, or $null if nothing was found (in which
+    case the caller should fall back to the installed executable directly).
     #>
     param([string]$Override)
-    $candidate = if ($Override) { $Override } else { $Script:OPENSQUILLA_REPO }
-    if (-not (Test-Path -LiteralPath $candidate)) {
-        throw "OpenSquilla repo not found: $candidate. Pass -Repo or set $Script:OPENSQUILLA_REPO."
+    if ($Override) {
+        if (-not (Test-Path -LiteralPath $Override)) {
+            throw "OpenSquilla repo not found: $Override. Pass -Repo or omit to auto-detect."
+        }
+        return (Resolve-Path -LiteralPath $Override).Path
     }
-    return (Resolve-Path -LiteralPath $candidate).Path
+    $scriptDir = $PSScriptRoot
+    if ($scriptDir) {
+        $candidate = Join-Path (Split-Path -Parent $scriptDir) '..' | Join-Path -ChildPath '..' | ForEach-Object { $_ }
+        # Two levels up from <repo>/scripts/supervisor/ is the repo root.
+        $candidate = Split-Path -Parent (Split-Path -Parent $scriptDir)
+        if (Test-Path -LiteralPath (Join-Path $candidate 'pyproject.toml')) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+    return $null
+}
+
+function Get-OpensquillaCommand {
+    <#
+    .SYNOPSIS Resolve the best way to invoke `opensquilla` on this host.
+    .DESCRIPTION
+    Returns a hashtable with:
+      * Mode   — 'uv-run-repo' | 'installed' | 'none'
+      * Repo   — repo path (Mode=uv-run-repo only)
+      * Exe    — full path to the installed opensquilla executable (Mode=installed only)
+    Callers should use Mode to pick the invocation strategy: uv run from Repo
+    when iterating from a source checkout, or the installed executable when
+    the user installed via `uv tool install`. PowerShell's standard
+    `Get-Command opensquilla` resolves via PATH for the second case so we
+    do not have to hard-code the tool directory.
+    #>
+    param([string]$Repo)
+    $opensquilla = Get-Command 'opensquilla' -ErrorAction SilentlyContinue
+    if ($opensquilla) {
+        return @{ Mode = 'installed'; Exe = $opensquilla.Path }
+    }
+    $resolvedRepo = Get-OpensquillaRoot -Override $Repo
+    if ($resolvedRepo -and (Test-Path -LiteralPath (Join-Path $resolvedRepo 'pyproject.toml'))) {
+        return @{ Mode = 'uv-run-repo'; Repo = $resolvedRepo }
+    }
+    return @{ Mode = 'none' }
 }
 
 # --- Profile discovery -----------------------------------------------------
@@ -153,17 +204,20 @@ function Invoke-Opensquilla {
 
     .DESCRIPTION
     Centralises the env setup (OPENSQUILLA_HOME + OPENSQUILLA_PROFILE)
-    and the working directory so the user-facing scripts don't have to repeat
-    the boilerplate. Returns the process exit code.
+    and the invocation strategy so the user-facing scripts don't have to
+    repeat the boilerplate. Returns the process exit code.
 
-    Uses `uv run opensquilla ...` so the same Python environment the developer
-    is iterating with is what supervises the gateway. `-NoNewWindow` keeps the
-    console from spawning a new window per profile when launched from a
-    terminal; when launched headless (Task Scheduler at logon) the lack of a
-    parent console is harmless.
+    Picks the best available strategy at call time:
+      1. If `opensquilla` is on PATH (typical after `uv tool install`),
+         invoke it directly — no repo needed.
+      2. Otherwise, fall back to `uv run` from a source checkout if one
+         is auto-detected next to this script. This covers the "run the
+         scripts straight from a clone" workflow.
+      3. If neither is available, throw — the operator must either
+         install the wheel or run the scripts from inside a clone.
     #>
     param(
-        [Parameter(Mandatory)] [string] $Repo,
+        [string] $Repo,
         [Parameter(Mandatory)] [string] $Profile,
         [Parameter(Mandatory)] [string[]] $Arguments
     )
@@ -171,13 +225,28 @@ function Invoke-Opensquilla {
     $profileRoot = Split-Path -Parent $Profile
     $env:OPENSQUILLA_HOME = $profileRoot
     $env:OPENSQUILLA_PROFILE = $profileLeaf
-    Push-Location -LiteralPath $Repo
-    try {
-        $proc = Start-Process -FilePath 'uv' `
-            -ArgumentList (@('run', 'opensquilla') + $Arguments) `
-            -NoNewWindow -Wait -PassThru
-        return $proc.ExitCode
-    } finally {
-        Pop-Location
+
+    $cmd = Get-OpensquillaCommand -Repo $Repo
+    switch ($cmd.Mode) {
+        'installed' {
+            $proc = Start-Process -FilePath $cmd.Exe `
+                -ArgumentList $Arguments `
+                -NoNewWindow -Wait -PassThru
+            return $proc.ExitCode
+        }
+        'uv-run-repo' {
+            Push-Location -LiteralPath $cmd.Repo
+            try {
+                $proc = Start-Process -FilePath 'uv' `
+                    -ArgumentList (@('run', 'opensquilla') + $Arguments) `
+                    -NoNewWindow -Wait -PassThru
+                return $proc.ExitCode
+            } finally {
+                Pop-Location
+            }
+        }
+        default {
+            throw 'opensquilla is not on PATH and no source checkout was auto-detected next to this script. Either run `uv tool install opensquilla` (recommended) or invoke these scripts from inside a clone of opensquilla/opensquilla.'
+        }
     }
 }

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -34,12 +34,12 @@ $Script:OPENSQUILLA_REPO = 'D:\ai\opensquilla\opensquilla'
 
 function Get-ProfilesRoot {
     <#
-    .SYNOPSIS Resolve the profiles root directory (OPENSQUILLA_PROFILES_DIR or default).
+    .SYNOPSIS Resolve the profiles root directory (OPENSQUILLA_HOME or default).
     #>
     param([string]$Override)
-    $candidate = if ($Override) { $Override } elseif ($env:OPENSQUILLA_PROFILES_DIR) { $env:OPENSQUILLA_PROFILES_DIR } else { $Script:DEFAULT_PROFILES_DIR }
+    $candidate = if ($Override) { $Override } elseif ($env:OPENSQUILLA_HOME) { $env:OPENSQUILLA_HOME } else { $Script:DEFAULT_PROFILES_DIR }
     if (-not $candidate) {
-        throw 'Profiles root is empty. Pass -ProfilesRoot or set $env:OPENSQUILLA_PROFILES_DIR.'
+        throw 'Profiles root is empty. Pass -ProfilesRoot or set $env:OPENSQUILLA_HOME.'
     }
     if (-not (Test-Path -LiteralPath $candidate)) {
         throw "Profiles root does not exist: $candidate"
@@ -152,7 +152,7 @@ function Invoke-Opensquilla {
     .SYNOPSIS Run an `opensquilla` subcommand inside a profile.
 
     .DESCRIPTION
-    Centralises the env setup (OPENSQUILLA_PROFILES_DIR + OPENSQUILLA_PROFILE)
+    Centralises the env setup (OPENSQUILLA_HOME + OPENSQUILLA_PROFILE)
     and the working directory so the user-facing scripts don't have to repeat
     the boilerplate. Returns the process exit code.
 
@@ -169,7 +169,7 @@ function Invoke-Opensquilla {
     )
     $profileLeaf = Split-Path -Leaf $Profile
     $profileRoot = Split-Path -Parent $Profile
-    $env:OPENSQUILLA_PROFILES_DIR = $profileRoot
+    $env:OPENSQUILLA_HOME = $profileRoot
     $env:OPENSQUILLA_PROFILE = $profileLeaf
     Push-Location -LiteralPath $Repo
     try {

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -1,0 +1,183 @@
+<#
+.SYNOPSIS
+    Shared helpers for the OpenSquilla multi-profile supervisor scripts.
+
+.DESCRIPTION
+    Loaded via dot-sourcing (`. ./lib.ps1`) by start-all.ps1, stop-all.ps1,
+    status.ps1, install-autostart.ps1, and uninstall-autostart.ps1. Owns:
+      * Default profiles-root and base-port resolution.
+      * Profile discovery (scan a directory, ignore non-profile entries).
+      * Index-based port assignment (18791 + profile_index_within_root).
+      * A small Write-Status helper so the user-facing scripts stay terse.
+
+    Kept tiny and dependency-free: pure PowerShell, no module imports beyond
+    what's bundled with Windows PowerShell 5.1+ and PowerShell 7.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Get-Variable -Name SUPERVISOR_LIB_LOADED -Scope Script -ErrorAction SilentlyContinue)) {
+    $Script:SUPERVISOR_LIB_LOADED = $true
+} else {
+    return
+}
+
+# --- Configuration ---------------------------------------------------------
+
+$Script:DEFAULT_PROFILES_DIR = 'D:\ai\opensquilla\profiles'
+$Script:DEFAULT_BASE_PORT = 18791
+$Script:TASK_NAME = 'OpenSquillaProfileSupervisor'
+$Script:DISPLAY_NAME = 'OpenSquilla Multi-Profile Gateway Supervisor'
+$Script:OPENSQUILLA_REPO = 'D:\ai\opensquilla\opensquilla'
+
+# --- Path / env helpers ----------------------------------------------------
+
+function Get-ProfilesRoot {
+    <#
+    .SYNOPSIS Resolve the profiles root directory (OPENSQUILLA_PROFILES_DIR or default).
+    #>
+    param([string]$Override)
+    $candidate = if ($Override) { $Override } elseif ($env:OPENSQUILLA_PROFILES_DIR) { $env:OPENSQUILLA_PROFILES_DIR } else { $Script:DEFAULT_PROFILES_DIR }
+    if (-not $candidate) {
+        throw 'Profiles root is empty. Pass -ProfilesRoot or set $env:OPENSQUILLA_PROFILES_DIR.'
+    }
+    if (-not (Test-Path -LiteralPath $candidate)) {
+        throw "Profiles root does not exist: $candidate"
+    }
+    return (Resolve-Path -LiteralPath $candidate).Path
+}
+
+function Get-OpensquillaRoot {
+    <#
+    .SYNOPSIS Resolve the OpenSquilla repo root (where `uv run opensquilla ...` lives).
+    #>
+    param([string]$Override)
+    $candidate = if ($Override) { $Override } else { $Script:OPENSQUILLA_REPO }
+    if (-not (Test-Path -LiteralPath $candidate)) {
+        throw "OpenSquilla repo not found: $candidate. Pass -Repo or set $Script:OPENSQUILLA_REPO."
+    }
+    return (Resolve-Path -LiteralPath $candidate).Path
+}
+
+# --- Profile discovery -----------------------------------------------------
+
+function Get-ProfileEntries {
+    <#
+    .SYNOPSIS Enumerate profiles under a root directory.
+
+    .DESCRIPTION
+    A "profile" is a subdirectory of the profiles root that contains a
+    `config.toml` (or, defensively, just *any* subdirectory at all). The
+    discovery order is alphabetical, deterministic across hosts.
+
+    Returns PSCustomObjects with: Name, Path, ConfigPath, HasConfig.
+    #>
+    param(
+        [Parameter(Mandatory)] [string] $ProfilesRoot
+    )
+    if (-not (Test-Path -LiteralPath $ProfilesRoot -PathType Container)) {
+        return @()
+    }
+    $entries = Get-ChildItem -LiteralPath $ProfilesRoot -Directory -ErrorAction SilentlyContinue |
+        Sort-Object Name
+    $results = @()
+    foreach ($entry in $entries) {
+        $configPath = Join-Path $entry.FullName 'config.toml'
+        $hasConfig = Test-Path -LiteralPath $configPath -PathType Leaf
+        $results += [pscustomobject]@{
+            Name = $entry.Name
+            Path = $entry.FullName
+            ConfigPath = $configPath
+            HasConfig = $hasConfig
+        }
+    }
+    return ,$results
+}
+
+# --- Port allocation -------------------------------------------------------
+
+function Get-ProfilePort {
+    <#
+    .SYNOPSIS Compute the port for a profile (BasePort + index within root).
+
+    .DESCRIPTION
+    Same algorithm on Windows / macOS / Linux: profile order is the sorted
+    alphabetical order of the profiles-root subdirectory listing, so the
+    port mapping is stable across reboots. Operators can override by passing
+    a different -BasePort; per-profile override lives in
+    `<profile>/config.toml` under `[gateway] port` and is read directly by
+    `opensquilla gateway start` (this script does not parse TOML itself).
+    #>
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [int]    $BasePort,
+        [Parameter(Mandatory)] [string] $ProfilesRoot
+    )
+    $siblings = Get-ProfileEntries -ProfilesRoot $ProfilesRoot
+    $index = 0
+    foreach ($sibling in $siblings) {
+        if ($sibling.Name -eq $Name) {
+            return [int]($BasePort + $index)
+        }
+        $index += 1
+    }
+    # Profile not present in root — caller is misusing. Fall back to base.
+    return [int]$BasePort
+}
+
+# --- Output helpers --------------------------------------------------------
+
+function Write-Status {
+    param(
+        [string] $Message,
+        [ValidateSet('info', 'ok', 'warn', 'err')] [string] $Level = 'info'
+    )
+    $prefix = switch ($Level) {
+        'ok'   { '[OK]   ' }
+        'warn' { '[WARN] ' }
+        'err'  { '[ERR]  ' }
+        default { '[..]   ' }
+    }
+    $color = switch ($Level) {
+        'ok'   { 'Green' }
+        'warn' { 'Yellow' }
+        'err'  { 'Red' }
+        default { 'Cyan' }
+    }
+    Write-Host ($prefix + $Message) -ForegroundColor $color
+}
+
+function Invoke-Opensquilla {
+    <#
+    .SYNOPSIS Run an `opensquilla` subcommand inside a profile.
+
+    .DESCRIPTION
+    Centralises the env setup (OPENSQUILLA_PROFILES_DIR + OPENSQUILLA_PROFILE)
+    and the working directory so the user-facing scripts don't have to repeat
+    the boilerplate. Returns the process exit code.
+
+    Uses `uv run opensquilla ...` so the same Python environment the developer
+    is iterating with is what supervises the gateway. `-NoNewWindow` keeps the
+    console from spawning a new window per profile when launched from a
+    terminal; when launched headless (Task Scheduler at logon) the lack of a
+    parent console is harmless.
+    #>
+    param(
+        [Parameter(Mandatory)] [string] $Repo,
+        [Parameter(Mandatory)] [string] $Profile,
+        [Parameter(Mandatory)] [string[]] $Arguments
+    )
+    $profileLeaf = Split-Path -Leaf $Profile
+    $profileRoot = Split-Path -Parent $Profile
+    $env:OPENSQUILLA_PROFILES_DIR = $profileRoot
+    $env:OPENSQUILLA_PROFILE = $profileLeaf
+    Push-Location -LiteralPath $Repo
+    try {
+        $proc = Start-Process -FilePath 'uv' `
+            -ArgumentList (@('run', 'opensquilla') + $Arguments) `
+            -NoNewWindow -Wait -PassThru
+        return $proc.ExitCode
+    } finally {
+        Pop-Location
+    }
+}

--- a/scripts/supervisor/start-all.ps1
+++ b/scripts/supervisor/start-all.ps1
@@ -27,24 +27,32 @@
     If set, do not attempt to start profiles whose gateway is already
     running on the assigned port.
 
+.PARAMETER Repo
+    Override the OpenSquilla source checkout that backs this script.
+    Only used when `opensquilla` is not on PATH. Defaults to the parent
+    of this script's directory (i.e. two levels up from
+    `scripts/supervisor/`).
+
 .EXAMPLE
     .\start-all.ps1
     .\start-all.ps1 -BasePort 19000
     .\start-all.ps1 -ProfilesRoot D:\work\profiles -SkipRunning
+    .\start-all.ps1 -Repo D:\src\opensquilla
 #>
 [CmdletBinding()]
 param(
     [string] $ProfilesRoot,
     [int]    $BasePort = 18791,
     [string] $BindHost = '127.0.0.1',
-    [switch] $SkipRunning
+    [switch] $SkipRunning,
+    [string] $Repo
 )
 
 $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'lib.ps1')
 
 $root   = Get-ProfilesRoot -Override $ProfilesRoot
-$repo   = Get-OpensquillaRoot
+$cmd    = Get-OpensquillaCommand -Repo $Repo
 $entries = Get-ProfileEntries -ProfilesRoot $root
 
 if (-not $entries -or $entries.Count -eq 0) {
@@ -54,7 +62,11 @@ if (-not $entries -or $entries.Count -eq 0) {
 
 Write-Status "Discovered $($entries.Count) profile(s) under $root" -Level info
 Write-Status "Base port: $BasePort (each profile = base + sorted-index)" -Level info
-Write-Status "Repo: $repo" -Level info
+switch ($cmd.Mode) {
+    'installed'     { Write-Status "Mode: installed `opensquilla` at $($cmd.Exe)" -Level info }
+    'uv-run-repo'   { Write-Status "Mode: uv run from $($cmd.Repo)" -Level info }
+    default         { Write-Status "Mode: no `opensquilla` found; set PATH or pass -Repo" -Level err }
+}
 Write-Host ''
 
 $started = 0

--- a/scripts/supervisor/start-all.ps1
+++ b/scripts/supervisor/start-all.ps1
@@ -1,0 +1,100 @@
+<#
+.SYNOPSIS
+    Start the OpenSquilla gateway for every profile under the profiles root.
+
+.DESCRIPTION
+    Discovers all subdirectories of the profiles root (each is one profile),
+    computes a deterministic port per profile (`BasePort + sorted-index`),
+    and invokes `opensquilla --profile <name> gateway start --port <port>`
+    in series. A profile that fails to start does not stop the others — the
+    loop logs the failure and continues.
+
+    If a profile is already running (gateway status reports running for the
+    same host/port), the script skips it and reports "already up".
+
+.PARAMETER ProfilesRoot
+    Override the profiles-root directory. Defaults to
+    $env:OPENSQUILLA_PROFILES_DIR or the script's built-in default.
+
+.PARAMETER BasePort
+    First port in the allocation sequence. Each subsequent profile (in
+    alphabetical order) gets BasePort+1, +2, etc.
+
+.PARAMETER Host
+    Bind address passed to `gateway start`. Default 127.0.0.1.
+
+.PARAMETER SkipRunning
+    If set, do not attempt to start profiles whose gateway is already
+    running on the assigned port.
+
+.EXAMPLE
+    .\start-all.ps1
+    .\start-all.ps1 -BasePort 19000
+    .\start-all.ps1 -ProfilesRoot D:\work\profiles -SkipRunning
+#>
+[CmdletBinding()]
+param(
+    [string] $ProfilesRoot,
+    [int]    $BasePort = 18791,
+    [string] $BindHost = '127.0.0.1',
+    [switch] $SkipRunning
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+$root   = Get-ProfilesRoot -Override $ProfilesRoot
+$repo   = Get-OpensquillaRoot
+$entries = Get-ProfileEntries -ProfilesRoot $root
+
+if (-not $entries -or $entries.Count -eq 0) {
+    Write-Status "No profiles found under $root. Run `opensquilla --profile <name> init` first." -Level warn
+    return
+}
+
+Write-Status "Discovered $($entries.Count) profile(s) under $root" -Level info
+Write-Status "Base port: $BasePort (each profile = base + sorted-index)" -Level info
+Write-Status "Repo: $repo" -Level info
+Write-Host ''
+
+$started = 0
+$skipped = 0
+$failed  = 0
+foreach ($entry in $entries) {
+    $port = Get-ProfilePort -Name $entry.Name -BasePort $BasePort -ProfilesRoot $root
+    Write-Status ("[{0}] starting on port {1} ..." -f $entry.Name, $port)
+    try {
+        if ($SkipRunning) {
+            $statusArgs = @('--profile', $entry.Name, 'gateway', 'status', '--port', [string]$port, '--listen', $BindHost, '--json')
+            $statusCode = Invoke-Opensquilla -Repo $repo -Profile $entry.Path -Arguments $statusArgs
+            # The CLI exits 0 on healthy, 1/3 on unhealthy / not-started. Treat anything
+            # that is NOT 0 as "not running" and try to start.
+            if ($statusCode -eq 0) {
+                Write-Status ("[{0}] already running on port {1} — skipped" -f $entry.Name, $port) -Level ok
+                $skipped += 1
+                continue
+            }
+        }
+        $startArgs = @('--profile', $entry.Name, 'gateway', 'start', '--listen', $BindHost, '--port', [string]$port)
+        $code = Invoke-Opensquilla -Repo $repo -Profile $entry.Path -Arguments $startArgs
+        if ($code -eq 0) {
+            Write-Status ("[{0}] up on port {1}" -f $entry.Name, $port) -Level ok
+            $started += 1
+        } else {
+            Write-Status ("[{0}] start failed (exit={1})" -f $entry.Name, $code) -Level err
+            $failed += 1
+        }
+    } catch {
+        Write-Status ("[{0}] threw: {1}" -f $entry.Name, $_.Exception.Message) -Level err
+        $failed += 1
+    }
+}
+
+Write-Host ''
+$summaryLevel = if ($failed -eq 0) { 'ok' } else { 'warn' }
+Write-Status ("Summary: started={0} skipped={1} failed={2}" -f $started, $skipped, $failed) `
+    -Level $summaryLevel
+
+if ($failed -gt 0) {
+    exit 1
+}

--- a/scripts/supervisor/start-all.ps1
+++ b/scripts/supervisor/start-all.ps1
@@ -14,7 +14,7 @@
 
 .PARAMETER ProfilesRoot
     Override the profiles-root directory. Defaults to
-    $env:OPENSQUILLA_PROFILES_DIR or the script's built-in default.
+    $env:OPENSQUILLA_HOME or the script's built-in default.
 
 .PARAMETER BasePort
     First port in the allocation sequence. Each subsequent profile (in

--- a/scripts/supervisor/status.ps1
+++ b/scripts/supervisor/status.ps1
@@ -17,21 +17,29 @@
     Must match the value used by start-all.ps1 for the per-profile
     port mapping to align with the CLI's `gateway status --port` lookup.
 
+.PARAMETER Repo
+    Override the OpenSquilla source checkout that backs this script.
+    Only used when `opensquilla` is not on PATH. Defaults to the parent
+    of this script's directory (i.e. two levels up from
+    `scripts/supervisor/`).
+
 .EXAMPLE
     .\status.ps1
     .\status.ps1 -ProfilesRoot D:\work\profiles
+    .\status.ps1 -Repo D:\src\opensquilla
 #>
 [CmdletBinding()]
 param(
     [string] $ProfilesRoot,
-    [int]    $BasePort = 18791
+    [int]    $BasePort = 18791,
+    [string] $Repo
 )
 
 $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'lib.ps1')
 
 $root   = Get-ProfilesRoot -Override $ProfilesRoot
-$repo   = Get-OpensquillaRoot
+$cmd    = Get-OpensquillaCommand -Repo $Repo
 $entries = Get-ProfileEntries -ProfilesRoot $root
 
 if (-not $entries -or $entries.Count -eq 0) {
@@ -44,14 +52,20 @@ foreach ($entry in $entries) {
     $port = Get-ProfilePort -Name $entry.Name -BasePort $BasePort -ProfilesRoot $root
     $env:OPENSQUILLA_HOME = $root
     $env:OPENSQUILLA_PROFILE = $entry.Name
-    Push-Location -LiteralPath $repo
-    try {
-        $raw = & uv run opensquilla --profile $entry.Name gateway status --port $port --json 2>$null
-        $parsed = $null
-        if ($raw) { $parsed = $raw | ConvertFrom-Json -ErrorAction SilentlyContinue }
-    } finally {
-        Pop-Location
+    $statusArgs = @('--profile', $entry.Name, 'gateway', 'status', '--port', [string]$port, '--json')
+    # Capture stdout for the JSON payload. The invocation strategy mirrors
+    # Get-OpensquillaCommand: prefer the installed `opensquilla` executable
+    # (PATH-resolved by Get-Command), fall back to `uv run` from a source
+    # checkout.
+    $raw = & {
+        switch ($cmd.Mode) {
+            'installed'   { & $cmd.Exe @statusArgs 2>$null }
+            'uv-run-repo' { Push-Location $cmd.Repo; try { & uv run opensquilla @statusArgs 2>$null } finally { Pop-Location } }
+            default       { '' }
+        }
     }
+    $parsed = $null
+    if ($raw) { $parsed = $raw | ConvertFrom-Json -ErrorAction SilentlyContinue }
 
     if ($parsed) {
         $rows += [pscustomobject]@{

--- a/scripts/supervisor/status.ps1
+++ b/scripts/supervisor/status.ps1
@@ -1,0 +1,114 @@
+<#
+.SYNOPSIS
+    Show a one-row-per-profile status table for all OpenSquilla gateways.
+
+.DESCRIPTION
+    Runs `opensquilla --profile <name> gateway status --json` for each
+    discovered profile, parses the JSON payload, and prints a compact
+    aligned table with: name, state, host, port, pid, log path.
+
+    Profiles with no gateway running show "not_started" instead of
+    failing the table render.
+
+.PARAMETER ProfilesRoot
+    Override the profiles-root directory.
+
+.PARAMETER BasePort
+    Must match the value used by start-all.ps1 for the per-profile
+    port mapping to align with the CLI's `gateway status --port` lookup.
+
+.EXAMPLE
+    .\status.ps1
+    .\status.ps1 -ProfilesRoot D:\work\profiles
+#>
+[CmdletBinding()]
+param(
+    [string] $ProfilesRoot,
+    [int]    $BasePort = 18791
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+$root   = Get-ProfilesRoot -Override $ProfilesRoot
+$repo   = Get-OpensquillaRoot
+$entries = Get-ProfileEntries -ProfilesRoot $root
+
+if (-not $entries -or $entries.Count -eq 0) {
+    Write-Status "No profiles found under $root." -Level warn
+    return
+}
+
+$rows = @()
+foreach ($entry in $entries) {
+    $port = Get-ProfilePort -Name $entry.Name -BasePort $BasePort -ProfilesRoot $root
+    $env:OPENSQUILLA_PROFILES_DIR = $root
+    $env:OPENSQUILLA_PROFILE = $entry.Name
+    Push-Location -LiteralPath $repo
+    try {
+        $raw = & uv run opensquilla --profile $entry.Name gateway status --port $port --json 2>$null
+        $parsed = $null
+        if ($raw) { $parsed = $raw | ConvertFrom-Json -ErrorAction SilentlyContinue }
+    } finally {
+        Pop-Location
+    }
+
+    if ($parsed) {
+        $rows += [pscustomobject]@{
+            Profile = $entry.Name
+            State   = [string]$parsed.state
+            Port    = [int]$parsed.port
+            Host    = [string]$parsed.host
+            Pid     = if ($parsed.pid) { [int]$parsed.pid } else { '-' }
+            Log     = [string]$parsed.logPath
+        }
+    } else {
+        $rows += [pscustomobject]@{
+            Profile = $entry.Name
+            State   = 'unknown'
+            Port    = $port
+            Host    = '-'
+            Pid     = '-'
+            Log     = '-'
+        }
+    }
+}
+
+# Render aligned table. PowerShell 5.1 lacks Format-Table auto-width on
+# all hosts, so compute column widths explicitly.
+function Format-Table {
+    param([object[]] $Data)
+    $cols = 'Profile','State','Port','Host','Pid','Log'
+    $widths = @{}
+    foreach ($c in $cols) { $widths[$c] = $c.Length }
+    foreach ($r in $Data) {
+        foreach ($c in $cols) {
+            $v = [string]$r.$c
+            if ($v.Length -gt $widths[$c]) { $widths[$c] = $v.Length }
+        }
+    }
+    $header = ($cols | ForEach-Object { $_.PadRight($widths[$_]) }) -join '  '
+    Write-Host $header -ForegroundColor Cyan
+    Write-Host ('-' * $header.Length) -ForegroundColor DarkGray
+    foreach ($r in $Data) {
+        $line = ($cols | ForEach-Object { ([string]$r.$_).PadRight($widths[$_]) }) -join '  '
+        $color = switch ($r.State) {
+            'running'     { 'Green' }
+            'unhealthy'   { 'Red' }
+            'not_started' { 'DarkGray' }
+            default       { 'Yellow' }
+        }
+        Write-Host $line -ForegroundColor $color
+    }
+}
+
+Format-Table -Data $rows
+
+# Non-zero exit if anything is not running AND has a config (so an
+# un-initialized profile doesn't show as a failure).
+$misconfigured = $rows | Where-Object { $_.State -notin @('running','not_started') }
+$uninitialized = $entries | Where-Object { -not $_.HasConfig }
+if ($misconfigured.Count -gt 0) {
+    Write-Status ("{0} profile(s) need attention (unhealthy/stale/target_mismatch)" -f $misconfigured.Count) -Level warn
+    exit 1
+}

--- a/scripts/supervisor/status.ps1
+++ b/scripts/supervisor/status.ps1
@@ -42,7 +42,7 @@ if (-not $entries -or $entries.Count -eq 0) {
 $rows = @()
 foreach ($entry in $entries) {
     $port = Get-ProfilePort -Name $entry.Name -BasePort $BasePort -ProfilesRoot $root
-    $env:OPENSQUILLA_PROFILES_DIR = $root
+    $env:OPENSQUILLA_HOME = $root
     $env:OPENSQUILLA_PROFILE = $entry.Name
     Push-Location -LiteralPath $repo
     try {

--- a/scripts/supervisor/stop-all.ps1
+++ b/scripts/supervisor/stop-all.ps1
@@ -22,23 +22,31 @@
 .PARAMETER Host
     Bind address passed to `gateway stop`. Must match start-all. Default 127.0.0.1.
 
+.PARAMETER Repo
+    Override the OpenSquilla source checkout that backs this script.
+    Only used when `opensquilla` is not on PATH. Defaults to the parent
+    of this script's directory (i.e. two levels up from
+    `scripts/supervisor/`).
+
 .EXAMPLE
     .\stop-all.ps1
     .\stop-all.ps1 -Force
+    .\stop-all.ps1 -Repo D:\src\opensquilla
 #>
 [CmdletBinding()]
 param(
     [string] $ProfilesRoot,
     [int]    $BasePort = 18791,
     [string] $BindHost = '127.0.0.1',
-    [switch] $Force
+    [switch] $Force,
+    [string] $Repo
 )
 
 $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'lib.ps1')
 
 $root   = Get-ProfilesRoot -Override $ProfilesRoot
-$repo   = Get-OpensquillaRoot
+$cmd    = Get-OpensquillaCommand -Repo $Repo
 $entries = Get-ProfileEntries -ProfilesRoot $root
 
 if (-not $entries -or $entries.Count -eq 0) {
@@ -55,7 +63,7 @@ foreach ($entry in $entries) {
     try {
         $stopArgs = @('--profile', $entry.Name, 'gateway', 'stop', '--listen', $BindHost, '--port', [string]$port)
         if ($Force) { $stopArgs += '--force' }
-        $code = Invoke-Opensquilla -Repo $repo -Profile $entry.Path -Arguments $stopArgs
+        $code = Invoke-Opensquilla -Repo $cmd.Repo -Profile $entry.Path -Arguments $stopArgs
         # Exit code 0 = stopped; non-zero = nothing to stop / already stopped.
         if ($code -eq 0) {
             Write-Status ("[{0}] stopped" -f $entry.Name) -Level ok

--- a/scripts/supervisor/stop-all.ps1
+++ b/scripts/supervisor/stop-all.ps1
@@ -1,0 +1,80 @@
+<#
+.SYNOPSIS
+    Stop the OpenSquilla gateway for every profile under the profiles root.
+
+.DESCRIPTION
+    Iterates the same discovery order as start-all.ps1 and calls
+    `opensquilla --profile <name> gateway stop --port <port>`. A profile
+    that is not running (or already stopped) is reported and skipped
+    without failing the whole loop.
+
+    A forced stop (-Force) is delegated to the CLI via `--force` so the
+    underlying SIGTERM/timeout logic in opensquilla.cli.gateway_lifecycle
+    stays the single source of truth for shutdown behaviour.
+
+.PARAMETER ProfilesRoot
+    Override the profiles-root directory.
+
+.PARAMETER BasePort
+    Must match the BasePort used by start-all.ps1 (or the override
+    recorded in your autostart task). Default 18791.
+
+.PARAMETER Host
+    Bind address passed to `gateway stop`. Must match start-all. Default 127.0.0.1.
+
+.EXAMPLE
+    .\stop-all.ps1
+    .\stop-all.ps1 -Force
+#>
+[CmdletBinding()]
+param(
+    [string] $ProfilesRoot,
+    [int]    $BasePort = 18791,
+    [string] $BindHost = '127.0.0.1',
+    [switch] $Force
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+$root   = Get-ProfilesRoot -Override $ProfilesRoot
+$repo   = Get-OpensquillaRoot
+$entries = Get-ProfileEntries -ProfilesRoot $root
+
+if (-not $entries -or $entries.Count -eq 0) {
+    Write-Status "No profiles found under $root." -Level warn
+    return
+}
+
+$stopped = 0
+$skipped = 0
+$failed  = 0
+foreach ($entry in $entries) {
+    $port = Get-ProfilePort -Name $entry.Name -BasePort $BasePort -ProfilesRoot $root
+    Write-Status ("[{0}] stopping (port {1}) ..." -f $entry.Name, $port)
+    try {
+        $stopArgs = @('--profile', $entry.Name, 'gateway', 'stop', '--listen', $BindHost, '--port', [string]$port)
+        if ($Force) { $stopArgs += '--force' }
+        $code = Invoke-Opensquilla -Repo $repo -Profile $entry.Path -Arguments $stopArgs
+        # Exit code 0 = stopped; non-zero = nothing to stop / already stopped.
+        if ($code -eq 0) {
+            Write-Status ("[{0}] stopped" -f $entry.Name) -Level ok
+            $stopped += 1
+        } else {
+            Write-Status ("[{0}] not running (exit={1})" -f $entry.Name, $code) -Level ok
+            $skipped += 1
+        }
+    } catch {
+        Write-Status ("[{0}] threw: {1}" -f $entry.Name, $_.Exception.Message) -Level err
+        $failed += 1
+    }
+}
+
+Write-Host ''
+$summaryLevel = if ($failed -eq 0) { 'ok' } else { 'warn' }
+Write-Status ("Summary: stopped={0} skipped={1} failed={2}" -f $stopped, $skipped, $failed) `
+    -Level $summaryLevel
+
+if ($failed -gt 0) {
+    exit 1
+}

--- a/scripts/supervisor/uninstall-autostart.ps1
+++ b/scripts/supervisor/uninstall-autostart.ps1
@@ -16,6 +16,10 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# Load shared helpers (Write-Status, etc.) — required because this script
+# prints status via Write-Status, unlike a pure schtasks round-trip.
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
 if (-not (Get-Command schtasks.exe -ErrorAction SilentlyContinue)) {
     throw 'schtasks.exe not found — this script only runs on Windows.'
 }

--- a/scripts/supervisor/uninstall-autostart.ps1
+++ b/scripts/supervisor/uninstall-autostart.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+    Remove the OpenSquilla multi-profile supervisor from Task Scheduler.
+
+.DESCRIPTION
+    Deletes the task registered by install-autostart.ps1. Idempotent: a
+    missing task is reported as a no-op rather than an error.
+
+.PARAMETER TaskName
+    Task to remove. Default: `OpenSquillaProfileSupervisor`.
+#>
+[CmdletBinding()]
+param(
+    [string] $TaskName = 'OpenSquillaProfileSupervisor'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Get-Command schtasks.exe -ErrorAction SilentlyContinue)) {
+    throw 'schtasks.exe not found — this script only runs on Windows.'
+}
+
+# /Query first so we can give a clear "nothing to do" message instead of
+# letting schtasks print its own (cryptic) error.
+$query = Start-Process -FilePath schtasks.exe `
+    -ArgumentList @('/Query', '/TN', $TaskName) `
+    -NoNewWindow -Wait -PassThru
+if ($query.ExitCode -ne 0) {
+    Write-Status "Task '$TaskName' is not registered — nothing to do." -Level warn
+    return
+}
+
+$del = Start-Process -FilePath schtasks.exe `
+    -ArgumentList @('/Delete', '/TN', $TaskName, '/F') `
+    -NoNewWindow -Wait -PassThru
+if ($del.ExitCode -ne 0) {
+    throw "schtasks /Delete exited with code $($del.ExitCode)"
+}
+Write-Status "Removed task '$TaskName'." -Level ok

--- a/src/opensquilla/cli/autostart.py
+++ b/src/opensquilla/cli/autostart.py
@@ -1,0 +1,349 @@
+"""Per-profile logon autostart on Windows, macOS, and Linux.
+
+Issue #193 asks for OpenSquilla to register a startup entry on Windows
+when a new agent profile is created. This module extends the same
+contract to macOS (LaunchAgent) and Linux (systemd --user unit) so
+the surface is consistent across the three host platforms the CLI
+advertises as supported.
+
+The dispatch table is deliberately small:
+
+* Windows: subprocess-out to ``scripts/supervisor/install-autostart.ps1``
+  with a per-profile ``-TaskName``. The script writes a Task Scheduler
+  logon task that runs the per-profile ``opensquilla --profile <name>
+  gateway start`` command on the next interactive logon.
+* macOS:   drop a LaunchAgent plist in ``~/Library/LaunchAgents/`` and
+  ``launchctl load -w`` it. The plist invokes the same ``opensquilla
+  --profile <name> gateway start`` command at load time.
+* Linux:   drop a systemd --user unit in
+  ``~/.config/systemd/user/`` and ``systemctl --user enable --now`` it.
+
+All three paths require the ``opensquilla`` executable on ``PATH``
+(``uv tool install opensquilla`` for end users; the dev install
+wrapper installs the editable shim). When the binary is missing the
+caller is expected to surface a clear error from the
+``AutostartError`` raised here, rather than silently leaving the
+profile un-autostarted.
+"""
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+# Name of the per-profile logon task. Used on Windows (Task Scheduler
+# task name) and as a prefix on the unit / plist filename on Linux and
+# macOS so operators can grep for it during debugging.
+TASK_NAME_PREFIX = "OpenSquilla_"
+
+
+def task_name_for_profile(profile: str) -> str:
+    """Return the platform-friendly autostart name for a profile."""
+    return f"{TASK_NAME_PREFIX}{profile}"
+
+
+class AutostartError(RuntimeError):
+    """Raised when an autostart registration fails for any reason."""
+
+
+class PlatformNotSupportedError(AutostartError, NotImplementedError):
+    """Raised when the host OS is not one of {Windows, Darwin, Linux}."""
+
+
+@dataclass(frozen=True)
+class AutostartResult:
+    """A successful per-profile autostart registration."""
+
+    platform: str
+    profile: str
+    target: str  # Task name (Windows) or absolute path (macOS / Linux)
+    command: str  # The exact command the host will run on next logon
+
+    def summary(self) -> str:
+        return (
+            f"{self.platform} autostart registered for profile {self.profile!r}: "
+            f"target={self.target}; command={self.command}"
+        )
+
+
+def _supervisor_dir() -> Path:
+    """Locate scripts/supervisor/ relative to this file."""
+    here = Path(__file__).resolve()
+    # .../src/opensquilla/cli/autostart.py -> .../scripts/supervisor/
+    repo_root = here.parents[3]
+    return repo_root / "scripts" / "supervisor"
+
+
+def _resolve_opensquilla_executable() -> str:
+    """Return the absolute path to the `opensquilla` binary on PATH.
+
+    Raises AutostartError with a clear remediation hint if the binary
+    is not installed.
+    """
+    found = shutil.which("opensquilla")
+    if found is None:
+        raise AutostartError(
+            "`opensquilla` is not on PATH. Install it first "
+            "(`uv tool install opensquilla` for release, or run "
+            "`bash scripts/dev-install.sh` from the repo checkout) "
+            "and then re-run the autostart registration."
+        )
+    return found
+
+
+def _per_profile_command(opensquilla_path: str, profile: str) -> list[str]:
+    """The command line the host will run on next logon / load."""
+    return [
+        opensquilla_path,
+        "--profile",
+        profile,
+        "gateway",
+        "start",
+    ]
+
+
+# --- Windows -----------------------------------------------------------------
+
+
+_WINDOWS_PS_REGISTER_TASK = """\
+$ErrorActionPreference = 'Stop'
+$taskName = '{task_name}'
+$opensquillaPath = '{opensquilla_path}'
+$profile = '{profile}'
+$home = '{home}'
+
+$action = New-ScheduledTaskAction `
+    -Execute $opensquillaPath `
+    -Argument "--profile {profile} gateway start" `
+    -WorkingDirectory $home
+
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -MultipleInstances IgnoreNew `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 10)
+
+Register-ScheduledTask `
+    -TaskName $taskName `
+    -Action $action `
+    -Trigger $trigger `
+    -Settings $settings `
+    -Description "OpenSquilla profile {profile} gateway supervisor (auto-start at logon)" `
+    -Force | Out-Null
+"""
+
+
+def _register_windows(profile: str, home: Path) -> AutostartResult:
+    """Register a per-profile Task Scheduler logon task via Register-ScheduledTask.
+
+    Why not scripts/supervisor/install-autostart.ps1? That script
+    always invokes start-all.ps1 (one task, all profiles). Per-profile
+    autostart (issue #193) wants one task per profile, so we call the
+    underlying PowerShell cmdlet directly. The behaviour is otherwise
+    the same as install-autostart.ps1 (AtLogOn trigger, no UAC prompt,
+    RunOnly-If-LoggedOn via the Interactive task setting, 10-minute
+    execution time limit).
+    """
+    task_name = task_name_for_profile(profile)
+    opensquilla_path = _resolve_opensquilla_executable()
+
+    script = _WINDOWS_PS_REGISTER_TASK.format(
+        task_name=task_name,
+        opensquilla_path=opensquilla_path,
+        profile=profile,
+        home=str(home),
+    )
+    completed = subprocess.run(  # noqa: S603 — intentional external invocation
+        [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            script,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        encoding="utf-8",
+    )
+    if completed.returncode != 0:
+        raise AutostartError(
+            f"Register-ScheduledTask failed (exit {completed.returncode}): "
+            f"{(completed.stderr or completed.stdout).strip()}"
+        )
+    return AutostartResult(
+        platform="Windows",
+        profile=profile,
+        target=task_name,
+        command=(
+            f"Register-ScheduledTask -TaskName {task_name} -Action "
+            f"{opensquilla_path} --profile {profile} gateway start ..."
+        ),
+    )
+
+
+# --- macOS -------------------------------------------------------------------
+
+
+_LAUNCH_AGENT_TEMPLATE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.opensquilla.{label}</string>
+  <key>ProgramArguments</key>
+  <array>
+{program_args}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>WorkingDirectory</key>
+  <string>{home}</string>
+  <key>StandardOutPath</key>
+  <string>{home}/logs/launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>{home}/logs/launchd.err.log</string>
+</dict>
+</plist>
+"""
+
+
+def _plist_program_args(opensquilla_path: str, profile: str) -> str:
+    args = _per_profile_command(opensquilla_path, profile)
+    return "\n".join(f"    <string>{arg}</string>" for arg in args)
+
+
+def _register_macos(profile: str, home: Path) -> AutostartResult:
+    """Write a per-profile LaunchAgent plist and `launchctl load -w` it."""
+    agents_dir = Path.home() / "Library" / "LaunchAgents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    target = agents_dir / f"com.opensquilla.{profile}.plist"
+
+    opensquilla_path = _resolve_opensquilla_executable()
+    plist = _LAUNCH_AGENT_TEMPLATE.format(
+        label=profile,
+        program_args=_plist_program_args(opensquilla_path, profile),
+        home=str(home),
+    )
+    target.write_text(plist, encoding="utf-8")
+
+    load = subprocess.run(  # noqa: S603
+        ["launchctl", "load", "-w", str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+        encoding="utf-8",
+    )
+    if load.returncode != 0:
+        raise AutostartError(
+            f"launchctl load -w failed (exit {load.returncode}): "
+            f"{(load.stderr or load.stdout).strip()}"
+        )
+    return AutostartResult(
+        platform="Darwin",
+        profile=profile,
+        target=str(target),
+        command=f"launchctl load -w {target}",
+    )
+
+
+# --- Linux -------------------------------------------------------------------
+
+
+_SYSTEMD_UNIT_TEMPLATE = """\
+[Unit]
+Description=OpenSquilla profile {profile} gateway supervisor
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory={home}
+ExecStart={exec_start}
+StandardOutput=append:{home}/logs/systemd.out.log
+StandardError=append:{home}/logs/systemd.err.log
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=default.target
+"""
+
+
+def _systemd_exec_start(opensquilla_path: str, profile: str) -> str:
+    args = _per_profile_command(opensquilla_path, profile)
+    return " ".join(args)
+
+
+def _register_linux(profile: str, home: Path) -> AutostartResult:
+    """Write a per-profile systemd --user unit and `enable --now` it."""
+    unit_dir = Path.home() / ".config" / "systemd" / "user"
+    unit_dir.mkdir(parents=True, exist_ok=True)
+    target = unit_dir / f"opensquilla-{profile}.service"
+
+    opensquilla_path = _resolve_opensquilla_executable()
+    unit = _SYSTEMD_UNIT_TEMPLATE.format(
+        profile=profile,
+        exec_start=_systemd_exec_start(opensquilla_path, profile),
+        home=str(home),
+    )
+    target.write_text(unit, encoding="utf-8")
+
+    reload = subprocess.run(  # noqa: S603
+        ["systemctl", "--user", "daemon-reload"],
+        capture_output=True,
+        text=True,
+        check=False,
+        encoding="utf-8",
+    )
+    if reload.returncode != 0:
+        raise AutostartError(
+            f"systemctl --user daemon-reload failed (exit {reload.returncode}): "
+            f"{(reload.stderr or reload.stdout).strip()}"
+        )
+    on = subprocess.run(  # noqa: S603
+        ["systemctl", "--user", "enable", "--now", target.name],
+        capture_output=True,
+        text=True,
+        check=False,
+        encoding="utf-8",
+    )
+    if on.returncode != 0:
+        raise AutostartError(
+            f"systemctl --user enable --now failed (exit {on.returncode}): "
+            f"{(on.stderr or on.stdout).strip()}"
+        )
+    return AutostartResult(
+        platform="Linux",
+        profile=profile,
+        target=str(target),
+        command=f"systemctl --user enable --now {target.name}",
+    )
+
+
+# --- Dispatch ----------------------------------------------------------------
+
+
+def register_logon_task(*, profile: str, home: Path) -> AutostartResult:
+    """Register a per-profile startup entry on the host platform.
+
+    See the module docstring for the per-platform contract.
+    """
+    system = platform.system()
+    if system == "Windows":
+        return _register_windows(profile, home)
+    if system == "Darwin":
+        return _register_macos(profile, home)
+    if system == "Linux":
+        return _register_linux(profile, home)
+    raise PlatformNotSupportedError(
+        f"per-profile autostart is not implemented for host platform "
+        f"{system!r}; supported: Windows, Darwin, Linux."
+    )

--- a/src/opensquilla/cli/gateway_lifecycle.py
+++ b/src/opensquilla/cli/gateway_lifecycle.py
@@ -483,14 +483,13 @@ class GatewayLifecycleManager:
         ]
         if self.config_path:
             argv.extend(["--config", self.config_path])
-        # Forward the active profile so the gateway subprocess resolves the
-        # same home/state/logs dirs as the parent. Typer reads the env var
-        # directly, so we only need to plumb it through argv when the parent
-        # was actually pinned to a profile (env var propagates automatically
-        # via `os.environ.copy()` in `_spawn_gateway`).
-        active_profile = os.environ.get("OPENSQUILLA_PROFILE", "").strip()
-        if active_profile:
-            argv.extend(["--profile", active_profile])
+        # The active profile is forwarded to the child via env, not argv.
+        # `_spawn_gateway` does `os.environ.copy()` so the child sees
+        # OPENSQUILLA_HOME + OPENSQUILLA_PROFILE from this process.
+        # We deliberately do NOT pass --profile on the CLI: `gateway run`
+        # is served by the standalone `gateway_app` Typer instance and does
+        # not declare the --profile option. Plumbing it through env
+        # instead is both simpler and correct.
         return argv
 
     def _spawn_gateway(self, argv: list[str]) -> subprocess.Popen[Any]:

--- a/src/opensquilla/cli/gateway_lifecycle.py
+++ b/src/opensquilla/cli/gateway_lifecycle.py
@@ -483,6 +483,14 @@ class GatewayLifecycleManager:
         ]
         if self.config_path:
             argv.extend(["--config", self.config_path])
+        # Forward the active profile so the gateway subprocess resolves the
+        # same home/state/logs dirs as the parent. Typer reads the env var
+        # directly, so we only need to plumb it through argv when the parent
+        # was actually pinned to a profile (env var propagates automatically
+        # via `os.environ.copy()` in `_spawn_gateway`).
+        active_profile = os.environ.get("OPENSQUILLA_PROFILE", "").strip()
+        if active_profile:
+            argv.extend(["--profile", active_profile])
         return argv
 
     def _spawn_gateway(self, argv: list[str]) -> subprocess.Popen[Any]:

--- a/src/opensquilla/cli/init_cmd.py
+++ b/src/opensquilla/cli/init_cmd.py
@@ -16,6 +16,8 @@ def _default_model_for_provider(provider: str) -> str:
         return "deepseek/deepseek-v4-pro"
     if normalized == "deepseek":
         return "deepseek-v4-flash"
+    if normalized == "minimax":
+        return "minimax/MiniMax-M3"
     return "openai/gpt-4o-mini"
 
 
@@ -29,7 +31,7 @@ def run_init() -> None:
 
     provider = questionary.select(
         "Choose provider:",
-        choices=["openrouter", "openai", "anthropic", "deepseek", "custom"],
+        choices=["openrouter", "openai", "anthropic", "deepseek", "minimax", "custom"],
         default="openrouter",
     ).ask()
     if not provider:

--- a/src/opensquilla/cli/init_cmd.py
+++ b/src/opensquilla/cli/init_cmd.py
@@ -6,8 +6,9 @@ import questionary
 import tomli_w
 import typer
 
+from opensquilla.cli import autostart
 from opensquilla.cli.ui import console
-from opensquilla.paths import default_opensquilla_home
+from opensquilla.paths import default_opensquilla_home, default_profile_name
 
 
 def _default_model_for_provider(provider: str) -> str:
@@ -21,8 +22,16 @@ def _default_model_for_provider(provider: str) -> str:
     return "openai/gpt-4o-mini"
 
 
-def run_init() -> None:
-    """Create a basic OpenSquilla home with env and config files."""
+def run_init(*, autostart_register: bool = False) -> None:
+    """Create a basic OpenSquilla home with env and config files.
+
+    When ``autostart_register`` is True, register a per-profile logon
+    autostart entry (Task Scheduler on Windows, LaunchAgent on macOS,
+    systemd --user on Linux) after writing the env / config files.
+    The dispatch is best-effort: failures are surfaced as console
+    warnings and do not block init, because a typo'd host key in
+    ``.env`` should not abort the wizard.
+    """
     home = default_opensquilla_home()
     env_path = home / ".env"
     config_path = home / "config.toml"
@@ -67,11 +76,41 @@ def run_init() -> None:
     console.print(f"[green]Wrote[/green] {config_path}")
     console.print("[dim]Tip: enable shell completion with `opensquilla --install-completion`[/dim]")
 
+    if autostart_register:
+        _maybe_register_autostart(home)
 
-def init_command() -> None:
+
+def _maybe_register_autostart(home) -> None:
+    """Register a per-profile logon autostart entry, best-effort."""
+    profile = default_profile_name()
+    try:
+        result = autostart.register_logon_task(profile=profile, home=home)
+    except autostart.AutostartError as exc:
+        console.print(
+            f"[yellow]Autostart registration skipped:[/yellow] {exc}"
+        )
+        return
+    console.print(
+        f"[green]Autostart registered:[/green] {result.summary()}"
+    )
+
+
+def init_command(
+    autostart_register: bool = typer.Option(
+        False,
+        "--autostart/--no-autostart",
+        help=(
+            "Register a per-profile logon autostart entry on this host "
+            "(Task Scheduler on Windows, LaunchAgent on macOS, "
+            "systemd --user on Linux) after the env / config files are "
+            "written. Off by default; requires the opensquilla "
+            "executable on PATH."
+        ),
+    ),
+) -> None:
     """Initialize a workspace.
 
     Deprecated: prefer ``opensquilla onboard`` for full provider/channel setup.
     Kept for compatibility with older scripts.
     """
-    run_init()
+    run_init(autostart_register=autostart_register)

--- a/src/opensquilla/cli/init_cmd.py
+++ b/src/opensquilla/cli/init_cmd.py
@@ -22,6 +22,65 @@ def _default_model_for_provider(provider: str) -> str:
     return "openai/gpt-4o-mini"
 
 
+def _env_key_name_for_provider(provider: str) -> str:
+    if provider.strip().lower() == "custom":
+        return "OPENSQUILLA_LLM_API_KEY"
+    return f"{provider.strip().upper()}_API_KEY"
+
+
+def persist_profile(
+    home,
+    *,
+    provider: str,
+    api_key: str | None = None,
+    api_key_env: str | None = None,
+    model: str | None = None,
+) -> None:
+    """Write the per-profile .env, config.toml, and state directory.
+
+    Pure (no questionary, no console) so non-interactive paths
+    (``opensquilla profiles init-all`` and friends) can reuse it.
+    Exactly one of ``api_key`` or ``api_key_env`` must be provided;
+    ``api_key_env`` is the env-var name the gateway reads at
+    runtime, so when it is supplied nothing is written into ``.env``.
+
+    Raises ``ValueError`` if both or neither of ``api_key`` /
+    ``api_key_env`` are given, mirroring the server-side guard in
+    ``onboarding.mutations.configure_provider``.
+    """
+    if (api_key is None) == (api_key_env is None):
+        raise ValueError("configure either api_key or api_key_env, not both")
+
+    env_path = home / ".env"
+    config_path = home / "config.toml"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "state").mkdir(parents=True, exist_ok=True)
+
+    key_name = _env_key_name_for_provider(provider)
+    existing_env = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
+    lines = [
+        line
+        for line in existing_env.splitlines()
+        if not line.startswith(f"{key_name}=")
+    ]
+    if api_key is not None:
+        lines.append(f"{key_name}={api_key}")
+    env_path.write_text(
+        "\n".join(lines).rstrip() + "\n" if lines else "",
+        encoding="utf-8",
+    )
+
+    selected_model = model or _default_model_for_provider(provider)
+    config = {
+        "llm": {
+            "provider": provider,
+            "model": selected_model,
+        },
+        "state_dir": str(home / "state"),
+    }
+    config_path.write_text(tomli_w.dumps(config), encoding="utf-8")
+
+
 def run_init(*, autostart_register: bool = False) -> None:
     """Create a basic OpenSquilla home with env and config files.
 
@@ -33,10 +92,6 @@ def run_init(*, autostart_register: bool = False) -> None:
     ``.env`` should not abort the wizard.
     """
     home = default_opensquilla_home()
-    env_path = home / ".env"
-    config_path = home / "config.toml"
-    home.mkdir(parents=True, exist_ok=True)
-    (home / "state").mkdir(parents=True, exist_ok=True)
 
     provider = questionary.select(
         "Choose provider:",
@@ -57,21 +112,15 @@ def run_init(*, autostart_register: bool = False) -> None:
     if not default_model:
         raise typer.Exit(1)
 
-    key_name = f"{provider.upper()}_API_KEY" if provider != "custom" else "OPENSQUILLA_LLM_API_KEY"
-    existing_env = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
-    lines = [line for line in existing_env.splitlines() if not line.startswith(f"{key_name}=")]
-    lines.append(f"{key_name}={api_key}")
-    env_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    persist_profile(
+        home,
+        provider=provider,
+        api_key=api_key,
+        model=default_model,
+    )
 
-    config = {
-        "llm": {
-            "provider": provider,
-            "model": default_model,
-        },
-        "state_dir": str(home / "state"),
-    }
-    config_path.write_text(tomli_w.dumps(config), encoding="utf-8")
-
+    env_path = home / ".env"
+    config_path = home / "config.toml"
     console.print(f"[green]Wrote[/green] {env_path}")
     console.print(f"[green]Wrote[/green] {config_path}")
     console.print("[dim]Tip: enable shell completion with `opensquilla --install-completion`[/dim]")

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -7,13 +7,17 @@ from pathlib import Path
 
 import typer
 
-from opensquilla.env import load_env, warn_if_proxy_ignored
-from opensquilla.paths import is_valid_profile_name
+from opensquilla.env import warn_if_proxy_ignored
+from opensquilla.paths import default_opensquilla_home, is_valid_profile_name
 
-# Populate os.environ from .env files before any submodule import reads keys.
-# Precedence: os.environ > $CWD/.env > $CWD/.env.test > ~/.opensquilla/.env.
-load_env()
-warn_if_proxy_ignored()
+# `load_env()` is NOT called at module import time on purpose: the active
+# profile (CLI --profile + OPENSQUILLA_PROFILE env) is only known after
+# Typer parses the global callback, so loading here would always pick the
+# legacy ~/.opensquilla/.env regardless of which profile the user picked.
+# The callback below resolves the active profile, calls load_env(home=...),
+# then re-invokes warn_if_proxy_ignored() so the proxy hint is logged
+# against the post-load env. Subcommand modules are imported below;
+# they don't read env at import time, so the deferred load is safe.
 
 from opensquilla.cli.agent_cmd import run_agent_command  # noqa: E402
 from opensquilla.cli.agents_cmd import agents_app  # noqa: E402
@@ -92,17 +96,26 @@ def _profile_callback(
     if ctx.invoked_subcommand is None:
         return
     name = (profile or "").strip()
-    if not name:
-        return
-    if not is_valid_profile_name(name):
-        raise typer.BadParameter(
-            f"Invalid profile name {name!r}; must match "
-            f"^[a-z0-9][a-z0-9_-]{{0,63}}$."
-        )
-    # Export so subprocesses (e.g. `gateway start` spawning `gateway run`)
-    # inherit the active profile and so any code path that reads
-    # `os.environ["OPENSQUILLA_PROFILE"]` directly sees the CLI choice.
-    os.environ["OPENSQUILLA_PROFILE"] = name
+    if name:
+        if not is_valid_profile_name(name):
+            raise typer.BadParameter(
+                f"Invalid profile name {name!r}; must match "
+                f"^[a-z0-9][a-z0-9_-]{{0,63}}$."
+            )
+        # Export so subprocesses (e.g. `gateway start` spawning `gateway run`)
+        # inherit the active profile and so any code path that reads
+        # `os.environ["OPENSQUILLA_PROFILE"]` directly sees the CLI choice.
+        os.environ["OPENSQUILLA_PROFILE"] = name
+
+    # Now that the active profile is known, resolve the home and load
+    # .env from THAT home. Loading before this point would have picked
+    # the legacy ~/.opensquilla/.env regardless of --profile, which
+    # leaked keys across profile boundaries.
+    from opensquilla.env import load_env
+
+    home = default_opensquilla_home()
+    load_env(home=home)
+    warn_if_proxy_ignored()
 
 
 # ── memory sub-app ────────────────────────────────────────────────────────────

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -80,7 +80,7 @@ def _profile_callback(
         envvar="OPENSQUILLA_PROFILE",
         help=(
             "Profile name for multi-instance mode. Resolved to "
-            "$OPENSQUILLA_PROFILES_DIR/<profile>/ (default: "
+            "$OPENSQUILLA_HOME/<profile>/ (default: "
             "~/.opensquilla/profiles/). When set, isolates state/logs/config "
             "from other instances sharing the same host. Ignored if "
             "OPENSQUILLA_STATE_DIR is set (full override)."

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -34,6 +34,7 @@ from opensquilla.cli.memory_flush_cmd import memory_flush_session_cmd  # noqa: E
 from opensquilla.cli.migrate_cmd import migrate_app  # noqa: E402
 from opensquilla.cli.models_cmd import app as models_app  # noqa: E402
 from opensquilla.cli.onboard_cmd import configure_command, onboard_app  # noqa: E402
+from opensquilla.cli.profiles_cmd import profiles_app  # noqa: E402
 from opensquilla.cli.providers_cmd import providers_app  # noqa: E402
 from opensquilla.cli.replay import replay_app  # noqa: E402
 from opensquilla.cli.sandbox_cmd import sandbox_app  # noqa: E402
@@ -50,6 +51,7 @@ app = typer.Typer(
 
 # ── Sub-apps ─────────────────────────────────────────────────────────────────
 
+app.add_typer(profiles_app, name="profiles")
 app.add_typer(channels_app, name="channels")
 app.add_typer(agents_app, name="agents")
 app.add_typer(config_app, name="config")

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import typer
 
 from opensquilla.env import load_env, warn_if_proxy_ignored
+from opensquilla.paths import is_valid_profile_name
 
 # Populate os.environ from .env files before any submodule import reads keys.
 # Precedence: os.environ > $CWD/.env > $CWD/.env.test > ~/.opensquilla/.env.
@@ -64,6 +66,43 @@ app.command("init")(init_command)
 app.command("doctor")(doctor_command)
 app.add_typer(onboard_app, name="onboard")
 app.command("configure")(configure_command)
+
+
+# ── Global options ────────────────────────────────────────────────────────────
+
+
+@app.callback(invoke_without_command=True)
+def _profile_callback(
+    ctx: typer.Context,
+    profile: str | None = typer.Option(
+        None,
+        "--profile",
+        envvar="OPENSQUILLA_PROFILE",
+        help=(
+            "Profile name for multi-instance mode. Resolved to "
+            "$OPENSQUILLA_PROFILES_DIR/<profile>/ (default: "
+            "~/.opensquilla/profiles/). When set, isolates state/logs/config "
+            "from other instances sharing the same host. Ignored if "
+            "OPENSQUILLA_STATE_DIR is set (full override)."
+        ),
+    ),
+) -> None:
+    """OpenSquilla global options."""
+    # Preserve `no_args_is_help` — only act when a subcommand is invoked.
+    if ctx.invoked_subcommand is None:
+        return
+    name = (profile or "").strip()
+    if not name:
+        return
+    if not is_valid_profile_name(name):
+        raise typer.BadParameter(
+            f"Invalid profile name {name!r}; must match "
+            f"^[a-z0-9][a-z0-9_-]{{0,63}}$."
+        )
+    # Export so subprocesses (e.g. `gateway start` spawning `gateway run`)
+    # inherit the active profile and so any code path that reads
+    # `os.environ["OPENSQUILLA_PROFILE"]` directly sees the CLI choice.
+    os.environ["OPENSQUILLA_PROFILE"] = name
 
 
 # ── memory sub-app ────────────────────────────────────────────────────────────

--- a/src/opensquilla/cli/profiles_cmd.py
+++ b/src/opensquilla/cli/profiles_cmd.py
@@ -1,0 +1,242 @@
+"""CLI: opensquilla profiles <subcommand>.
+
+Profile-level batch operations that complement the per-profile
+``opensquilla --profile <name> init`` wizard. The headline command
+is ``opensquilla profiles init-all``: scan every profile directory
+under ``$OPENSQUILLA_HOME/profiles/``, and for each profile that has
+not been initialised yet (no ``.env`` / ``config.toml`` pair), write
+the same provider / API-key / model triple the user supplies on the
+command line, then register the per-profile logon autostart entry
+(issue #193 dispatcher). Profiles that already have a ``.env`` are
+skipped — re-running the command is idempotent.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import typer
+from rich.table import Table
+
+from opensquilla.cli import autostart
+from opensquilla.cli.init_cmd import persist_profile
+from opensquilla.cli.ui import ACCENT, ACCENT_SOFT, console, markup_escape
+from opensquilla.paths import default_profiles_root, is_valid_profile_name
+
+profiles_app = typer.Typer(
+    help=(
+        "Profile-level batch operations: discover profiles, "
+        "initialize every profile in one go, list autostart targets."
+    ),
+)
+
+
+@dataclass(frozen=True)
+class ProfileTarget:
+    """A profile discovered under $OPENSQUILLA_HOME/profiles/."""
+
+    name: str
+    home: Path
+    initialised: bool  # True when both .env and config.toml are present
+
+
+def _discover_profiles(profiles_root: Path) -> list[ProfileTarget]:
+    """Return every subdirectory of ``profiles_root`` that is a valid profile.
+
+    Subdirectories whose name fails the profile-name regex are
+    skipped, because the home resolver would reject them too. A
+    profile is reported as "initialised" only when both ``.env`` and
+    ``config.toml`` are present; a partial directory (only one of
+    the two) is reported as not initialised so the init wizard
+    repairs it.
+    """
+    if not profiles_root.is_dir():
+        return []
+    targets: list[ProfileTarget] = []
+    for child in sorted(profiles_root.iterdir()):
+        if not child.is_dir():
+            continue
+        if not is_valid_profile_name(child.name):
+            continue
+        has_env = (child / ".env").is_file()
+        has_cfg = (child / "config.toml").is_file()
+        targets.append(
+            ProfileTarget(
+                name=child.name,
+                home=child,
+                initialised=has_env and has_cfg,
+            )
+        )
+    return targets
+
+
+def _initialise_one(
+    target: ProfileTarget,
+    *,
+    provider: str,
+    api_key: str | None,
+    api_key_env: str | None,
+    model: str | None,
+    autostart_register: bool,
+) -> tuple[bool, str]:
+    """Initialise a single profile in-place.
+
+    Returns ``(ok, detail)`` where ``detail`` is the autostart summary
+    or the failure reason. Errors are caught and surfaced as
+    ``(False, str)`` so a partial failure does not abort the loop.
+    """
+    if target.initialised:
+        return True, "skipped (already initialised)"
+
+    try:
+        persist_profile(
+            target.home,
+            provider=provider,
+            api_key=api_key,
+            api_key_env=api_key_env,
+            model=model,
+        )
+    except OSError as exc:
+        return False, f"write failed: {exc}"
+
+    if not autostart_register:
+        return True, "wrote .env + config.toml"
+
+    try:
+        result = autostart.register_logon_task(
+            profile=target.name, home=target.home
+        )
+    except autostart.AutostartError as exc:
+        return True, f"wrote .env + config.toml; autostart skipped: {exc}"
+    return True, result.summary()
+
+
+@profiles_app.command("list")
+def profiles_list() -> None:
+    """List every profile under $OPENSQUILLA_HOME/profiles/ with state."""
+    profiles_root = default_profiles_root()
+    targets = _discover_profiles(profiles_root)
+    if not targets:
+        console.print(
+            f"[dim]No profiles found under {markup_escape(str(profiles_root))}[/dim]"
+        )
+        return
+    table = Table(title=f"Profiles under {profiles_root}")
+    table.add_column("profile", no_wrap=True)
+    table.add_column("state")
+    table.add_column("home")
+    for t in targets:
+        state = (
+            f"[{ACCENT}]◆[/] ready" if t.initialised else "[yellow]uninitialised[/]"
+        )
+        table.add_row(
+            t.name,
+            state,
+            markup_escape(str(t.home)),
+        )
+    console.print(table)
+
+
+@profiles_app.command("init-all")
+def profiles_init_all(
+    provider: str = typer.Option(
+        ...,
+        "--provider",
+        help="Provider id applied to every profile (openrouter, openai, anthropic, deepseek, minimax, custom).",
+    ),
+    api_key: str = typer.Option(
+        "",
+        "--api-key",
+        help="Provider API key written into each profile's .env. Mutually exclusive with --api-key-env.",
+    ),
+    api_key_env: str = typer.Option(
+        "",
+        "--api-key-env",
+        help=(
+            "Env-var name the gateway should read the provider key from "
+            "(e.g. OPENROUTER_API_KEY). The env-var is read at "
+            "runtime; nothing is written into .env."
+        ),
+    ),
+    model: str = typer.Option(
+        "",
+        "--model",
+        help="Override the model id. Defaults to the provider's recommended model.",
+    ),
+    autostart_register: bool = typer.Option(
+        True,
+        "--autostart/--no-autostart",
+        help=(
+            "Register a per-profile logon autostart entry on this host "
+            "after writing the env / config files. On by default; "
+            "errors are surfaced per-profile and do not abort the loop."
+        ),
+    ),
+    only_uninitialised: bool = typer.Option(
+        True,
+        "--only-uninitialised/--all",
+        help=(
+            "Skip profiles that already have a .env + config.toml "
+            "(the default). Pass --all to re-write every profile."
+        ),
+    ),
+    profiles_root: Path | None = typer.Option(
+        None,
+        "--profiles-root",
+        help="Override the profiles root. Defaults to $OPENSQUILLA_HOME/profiles.",
+    ),
+) -> None:
+    """Initialise every profile in $OPENSQUILLA_HOME/profiles/.
+
+    Iterates over each profile directory and writes the same
+    provider / API-key / model triple to every profile that has not
+    been initialised yet. Already-initialised profiles are skipped
+    unless --all is passed. Autostart registration is best-effort
+    per profile; a failure on one profile is logged and the loop
+    continues.
+    """
+    if (api_key and api_key_env) or (not api_key and not api_key_env):
+        console.print(
+            "[red]Provide exactly one of --api-key or --api-key-env.[/red]"
+        )
+        raise typer.Exit(code=2)
+    if not provider:
+        console.print("[red]--provider is required.[/red]")
+        raise typer.Exit(code=2)
+
+    root = profiles_root or default_profiles_root()
+    targets = _discover_profiles(root)
+    if not targets:
+        console.print(
+            f"[yellow]No profiles found under {markup_escape(str(root))}.[/yellow] "
+            f"Create profile directories first "
+            f"(e.g. `mkdir -p {root}/coder`)."
+        )
+        raise typer.Exit(code=1)
+
+    if only_uninitialised:
+        targets = [t for t in targets if not t.initialised]
+    if not targets:
+        console.print(
+            f"[{ACCENT_SOFT}]◆[/] All profiles already initialised; nothing to do."
+        )
+        return
+
+    table = Table(title=f"Initialising {len(targets)} profile(s) under {root}")
+    table.add_column("profile", no_wrap=True)
+    table.add_column("state")
+    table.add_column("detail")
+    for t in targets:
+        ok, detail = _initialise_one(
+            t,
+            provider=provider,
+            api_key=api_key or None,
+            api_key_env=api_key_env or None,
+            model=model or None,
+            autostart_register=autostart_register,
+        )
+        state = f"[{ACCENT}]◆[/] ok" if ok else "[red]failed[/red]"
+        table.add_row(t.name, state, markup_escape(detail))
+    console.print(table)

--- a/src/opensquilla/env.py
+++ b/src/opensquilla/env.py
@@ -3,7 +3,10 @@
 Precedence (highest to lowest):
 1. os.environ (already set by shell / CI)
 2. .env in current working directory
-3. ~/.opensquilla/.env (global user config)
+3. .env in the resolved OpenSquilla home
+   (default: ``~/.opensquilla/profiles/<profile>/.env`` when multi-instance
+   mode is active via ``OPENSQUILLA_HOME`` / ``OPENSQUILLA_PROFILE``, or
+   ``~/.opensquilla/.env`` for the single-instance fallback)
 
 Existing environment variables are NEVER overridden.
 """
@@ -11,24 +14,31 @@ Existing environment variables are NEVER overridden.
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
-import structlog
-
-from opensquilla.paths import default_opensquilla_home
-
-log = structlog.get_logger(__name__)
+# Deliberately do NOT use structlog here: load_env() can run from inside
+# a Typer sub-command that is about to print a machine-readable JSON
+# payload on stdout (e.g. `opensquilla gateway status --json`), and
+# structlog's logger factory is configured at module-import time by
+# other opensquilla submodules. Routing through it would mix log lines
+# with the JSON. Printing to stderr keeps the contract clean.
 
 _TRUTHY = {"1", "true", "yes", "on"}
 _PROXY_ENV_VARS = ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy")
 
 
+def _debug(message: str) -> None:
+    # Verbose diagnostic — never on stdout, never raises.
+    print(f"opensquilla.env: {message}", file=sys.stderr)
+
+
 def trust_env() -> bool:
     """Return True when opensquilla's httpx clients should honor env proxy/TLS vars.
 
-    Gated by ``OPENSQUILLA_TRUST_ENV``. Off by default — opensquilla defaults to
+    Gated by ``OPENSQUILLA TRUST_ENV``. Off by default — opensquilla defaults to
     deterministic, env-isolated networking so a stray HTTP_PROXY in a parent
-    shell cannot silently reroute agent traffic. Set ``OPENSQUILLA_TRUST_ENV=1``
+    shell cannot silently reroute agent traffic. Set ``OPENSQUILLA TRUST_ENV=1``
     (e.g. in ~/.opensquilla/.env) to opt in; required on WSL2 / corporate networks
     where the only route to external APIs is a shell-exported proxy.
     """
@@ -41,10 +51,9 @@ def warn_if_proxy_ignored() -> None:
         return
     present = [v for v in _PROXY_ENV_VARS if os.environ.get(v)]
     if present:
-        log.warning(
-            "env.proxy_ignored",
-            vars=present,
-            hint="Set OPENSQUILLA_TRUST_ENV=1 to let opensquilla honor env proxy settings.",
+        _debug(
+            "env proxy ignored (set OPENSQUILLA_TRUST_ENV=1 to honor "
+            f"HTTP_PROXY/HTTPS_PROXY): {present}"
         )
 
 
@@ -70,20 +79,48 @@ def _parse_env_file(path: Path) -> dict[str, str]:
     return entries
 
 
-def load_env(cwd: str | Path | None = None) -> int:
+def load_env(
+    cwd: str | Path | None = None,
+    home: str | Path | None = None,
+) -> int:
     """Load .env files into os.environ with precedence rules.
+
+    Parameters
+    ----------
+    cwd
+        Override the working directory whose ``.env`` / ``.env.test`` is the
+        first candidate. Defaults to :func:`os.getcwd`.
+    home
+        Override the OpenSquilla home whose ``.env`` is the second candidate.
+        The caller — i.e. ``cli.main._profile_callback`` — is expected to
+        pass the home resolved *after* the active profile is known, so the
+        selected profile's ``.env`` is loaded instead of the legacy
+        ``~/.opensquilla/.env``.
+
+        When ``None`` (the default for backwards-compat callers), the home is
+        resolved via :func:`opensquilla.paths.default_opensquilla_home` at
+        call time. Callers that have already resolved the active profile
+        should pass it explicitly.
 
     Returns the number of new variables injected.
     """
-    candidates = []
+    # Import here to avoid an import cycle: opensquilla.paths -> opensquilla.env
+    # when env.py is imported during paths.py module init.
+    from opensquilla.paths import default_opensquilla_home
+
+    candidates: list[Path] = []
 
     # 1. cwd/.env (or cwd/.env.test as alias for dev)
     work_dir = Path(cwd) if cwd else Path.cwd()
     for name in (".env", ".env.test"):
         candidates.append(work_dir / name)
 
-    # 2. ~/.opensquilla/.env (global)
-    candidates.append(default_opensquilla_home() / ".env")
+    # 2. <home>/.env — caller-supplied (profile-aware) or resolved at call
+    #    time. Resolving at call time keeps backwards-compat for any code
+    #    that calls load_env() before the CLI profile is known; for the
+    #    CLI, _profile_callback supplies the resolved home explicitly.
+    resolved_home = Path(home) if home is not None else default_opensquilla_home()
+    candidates.append(resolved_home / ".env")
 
     # Merge: first file wins per key, but os.environ always wins
     merged: dict[str, str] = {}
@@ -91,7 +128,7 @@ def load_env(cwd: str | Path | None = None) -> int:
         for key, value in _parse_env_file(path).items():
             if key not in merged:
                 merged[key] = value
-                log.debug("env.loaded", key=key, source=str(path))
+                _debug(f"loaded key={key!r} from {path}")
 
     # Inject into os.environ — never override existing
     injected = 0
@@ -101,6 +138,7 @@ def load_env(cwd: str | Path | None = None) -> int:
             injected += 1
 
     if injected:
-        log.info("env.injected", count=injected)
+        _debug(f"injected {injected} new variable(s) into os.environ")
 
     return injected
+

--- a/src/opensquilla/gateway/static/js/views/setup.js
+++ b/src/opensquilla/gateway/static/js/views/setup.js
@@ -1513,6 +1513,15 @@ const SetupView = (() => {
       if (input.type === 'checkbox') out[name] = input.checked;
       else if (input.value !== '' || input.dataset.secret !== 'true') out[name] = input.value;
     });
+    // api_key and api_key_env are mutually exclusive on the server side
+    // (configure_provider raises "configure either api_key or api_key_env,
+    // not both"). The form pre-fills api_key_env with the spec's envKey, so a
+    // user who pastes a real key into api_key would otherwise trip that
+    // guard. Prefer a freshly-pasted api_key; otherwise fall back to
+    // api_key_env.
+    if (scope === 'provider' && out.apiKey && out.apiKeyEnv) {
+      delete out.apiKeyEnv;
+    }
     return out;
   }
 

--- a/src/opensquilla/onboarding/provider_specs.py
+++ b/src/opensquilla/onboarding/provider_specs.py
@@ -90,6 +90,10 @@ _ONBOARDING_VERIFIED_PROVIDER_IDS = frozenset(
         "zhipu",
         "qianfan",
         "volcengine",
+        "minimax",
+        "minimax_openai",
+        "minimax_cn",
+        "minimax_global",
     }
 )
 
@@ -130,11 +134,16 @@ def _what_you_need(spec: ProviderSpec) -> tuple[str, ...]:
     return tuple(needs)
 
 
+_MINIMAX_DEFAULT_MODEL = "minimax/MiniMax-M3"
+
+
 def _default_direct_model(provider_id: str) -> str:
     if provider_id in ROUTER_TIER_PROFILE_IDS:
         tiers = _router_tier_profile_defaults(provider_id)
         tier = tiers.get("c1") or tiers.get("c0") or {}
         return str(tier.get("model") or "")
+    if provider_id in {"minimax", "minimax_openai", "minimax_cn", "minimax_global"}:
+        return _MINIMAX_DEFAULT_MODEL
     return ""
 
 

--- a/src/opensquilla/paths.py
+++ b/src/opensquilla/paths.py
@@ -8,8 +8,8 @@ Resolution precedence for the home directory:
 1. ``OPENSQUILLA_STATE_DIR`` environment variable (expanded for ``~``/``$HOME``)
    — full override; bypasses profile resolution for back-compat with
    single-instance deployments and CI scripts that pin a specific path.
-2. ``$OPENSQUILLA_PROFILES_DIR/$OPENSQUILLA_PROFILE`` — multi-instance mode.
-   Set ``OPENSQUILLA_PROFILES_DIR`` to the parent directory (default
+2. ``$OPENSQUILLA_HOME/$OPENSQUILLA_PROFILE`` — multi-instance mode.
+   Set ``OPENSQUILLA_HOME`` to the parent directory (default
    ``$HOME/.opensquilla/profiles``) and ``OPENSQUILLA_PROFILE`` (default
    ``"default"``) to select one. Profile names must match
    ``^[a-z0-9][a-z0-9_-]{0,63}$`` to prevent path-traversal escapes.
@@ -36,7 +36,7 @@ __all__ = [
     "state_dir",
 ]
 
-_PROFILES_DIR_ENV = "OPENSQUILLA_PROFILES_DIR"
+_PROFILES_DIR_ENV = "OPENSQUILLA_HOME"
 _PROFILE_ENV = "OPENSQUILLA_PROFILE"
 _STATE_DIR_ENV = "OPENSQUILLA_STATE_DIR"
 _PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
@@ -71,7 +71,7 @@ def is_valid_profile_name(name: str) -> bool:
 def default_profiles_root() -> Path | None:
     """Return the directory that contains all OpenSquilla profile homes.
 
-    Honors ``OPENSQUILLA_PROFILES_DIR`` (trimmed, ``~``/``$HOME`` expanded).
+    Honors ``OPENSQUILLA_HOME`` (trimmed, ``~``/``$HOME`` expanded).
     Returns ``None`` when unset or empty — that signals "profile mode is
     not active" and :func:`default_opensquilla_home` falls back to the
     legacy single-instance home (``$HOME/.opensquilla``).
@@ -135,8 +135,8 @@ def default_opensquilla_home() -> Path:
 
     * ``OPENSQUILLA_STATE_DIR`` wins when set (back-compat with
       single-instance deployments that pin a specific path).
-    * ``OPENSQUILLA_PROFILES_DIR`` set + ``OPENSQUILLA_PROFILE`` set →
-      ``$OPENSQUILLA_PROFILES_DIR/$OPENSQUILLA_PROFILE`` (multi-instance).
+    * ``OPENSQUILLA_HOME`` set + ``OPENSQUILLA_PROFILE`` set →
+      ``$OPENSQUILLA_HOME/$OPENSQUILLA_PROFILE`` (multi-instance).
     * Otherwise the legacy ``$HOME/.opensquilla`` home (unchanged).
     """
     override = os.environ.get(_STATE_DIR_ENV, "").strip()

--- a/src/opensquilla/paths.py
+++ b/src/opensquilla/paths.py
@@ -1,23 +1,26 @@
 """OpenSquilla state-root resolution.
 
-Single source of truth for the on-disk state root. One env var controls
-the root, and every subsystem derives its sub-path from the helper here.
+Single source of truth for the on-disk state root. Two env vars control
+the root, and every subsystem derives its sub-path from the helpers here.
 
 Resolution precedence for the home directory:
 
 1. ``OPENSQUILLA_STATE_DIR`` environment variable (expanded for ``~``/``$HOME``)
    — full override; bypasses profile resolution for back-compat with
    single-instance deployments and CI scripts that pin a specific path.
-2. ``$OPENSQUILLA_HOME/$OPENSQUILLA_PROFILE`` — multi-instance mode.
-   Set ``OPENSQUILLA_HOME`` to the parent directory (default
-   ``$HOME/.opensquilla/profiles``) and ``OPENSQUILLA_PROFILE`` (default
-   ``"default"``) to select one. Profile names must match
-   ``^[a-z0-9][a-z0-9_-]{0,63}$`` to prevent path-traversal escapes.
-3. ``$HOME/.opensquilla`` — single-instance default (no profile mode).
+2. ``$OPENSQUILLA_HOME/$OPENSQUILLA_PROFILE`` — multi-instance mode
+   (the default on every host). Set ``OPENSQUILLA_HOME`` to the parent
+   directory (default ``$HOME/.opensquilla/profiles``) and
+   ``OPENSQUILLA_PROFILE`` (default ``"default"``) to select one. Profile
+   names must match ``^[a-z0-9][a-z0-9_-]{0,63}$`` to prevent
+   path-traversal escapes.
 
 Multi-instance mode lets a single host run several OpenSquilla agents in
 parallel, each with its own state/logs/config workspace, without sharing
-locks, sockets, or state files.
+locks, sockets, or state files. Multi-instance is the default so
+``opensquilla --profile <name> init`` works without any environment
+configuration; single-instance callers should set
+``OPENSQUILLA_STATE_DIR`` to the legacy home path.
 """
 
 from __future__ import annotations
@@ -31,6 +34,7 @@ __all__ = [
     "default_profile_name",
     "default_profiles_root",
     "is_valid_profile_name",
+    "maybe_migrate_legacy_home",
     "media_root_from_config",
     "profile_home",
     "state_dir",
@@ -68,22 +72,27 @@ def is_valid_profile_name(name: str) -> bool:
     return bool(_PROFILE_NAME_RE.fullmatch(name))
 
 
-def default_profiles_root() -> Path | None:
+def default_profiles_root() -> Path:
     """Return the directory that contains all OpenSquilla profile homes.
 
-    Honors ``OPENSQUILLA_HOME`` (trimmed, ``~``/``$HOME`` expanded).
-    Returns ``None`` when unset or empty — that signals "profile mode is
-    not active" and :func:`default_opensquilla_home` falls back to the
-    legacy single-instance home (``$HOME/.opensquilla``).
+    Honors ``OPENSQUILLA_HOME`` (trimmed, ``~``/``$HOME`` expanded). When
+    the env var is unset or empty, falls back to
+    ``$HOME/.opensquilla/profiles`` so that
+    ``opensquilla --profile <name> init`` works without any environment
+    configuration. Each profile lives as a direct subdirectory of this
+    root (``$HOME/.opensquilla/profiles/default/``,
+    ``$HOME/.opensquilla/profiles/coder/``, …) — siblings, not nested,
+    so an operator with ``OPENSQUILLA_HOME=D:\ai\opensquilla\profiles``
+    gets the same flat layout as one who never set the env var.
 
-    Returning ``None`` instead of a synthesized default keeps
-    :func:`default_opensquilla_home` byte-compatible with deployments that
-    never set the env var: the on-disk location is unchanged.
+    The legacy ``$HOME/.opensquilla`` home contents are auto-migrated
+    into the ``default`` profile on first call — see
+    :func:`maybe_migrate_legacy_home` for the safety contract.
     """
     override = os.environ.get(_PROFILES_DIR_ENV, "").strip()
-    if not override:
-        return None
-    return _expand_user(override)
+    if override:
+        return _expand_user(override)
+    return _home_dir() / ".opensquilla" / "profiles"
 
 
 def default_profile_name() -> str:
@@ -101,13 +110,15 @@ def default_profile_name() -> str:
 def profile_home(profile_name: str | None = None) -> Path:
     """Return the home directory for ``profile_name`` under the profiles root.
 
-    Validates the name and raises :class:`ValueError` on path-traversal
-    attempts. ``None`` means "use the current env-resolved profile name".
+    Resolves to ``default_profiles_root() / <profile_name>``. Validates the
+    name and raises :class:`ValueError` on path-traversal attempts; ``None``
+    means "use the current env-resolved profile name".
 
-    Raises :class:`RuntimeError` when profile mode is not active (i.e.
-    :func:`default_profiles_root` returns ``None``) but a non-default name
-    was requested. Callers that want the legacy ``$HOME/.opensquilla``
-    behavior should call :func:`default_opensquilla_home` directly.
+    The profiles root defaults to ``$HOME/.opensquilla/profiles`` when
+    ``OPENSQUILLA_HOME`` is unset, so the default profile lands at
+    ``$HOME/.opensquilla/profiles/default/`` and additional profiles
+    (``--profile coder``) land at
+    ``$HOME/.opensquilla/profiles/coder/`` — siblings, not nested.
     """
     name = (profile_name or default_profile_name()).strip()
     if not is_valid_profile_name(name):
@@ -115,17 +126,7 @@ def profile_home(profile_name: str | None = None) -> Path:
             f"Invalid OpenSquilla profile name: {name!r}. "
             f"Must match {_PROFILE_NAME_RE.pattern}."
         )
-    root = default_profiles_root()
-    if root is None:
-        if name == _DEFAULT_PROFILE_NAME:
-            return _home_dir() / ".opensquilla"
-        raise RuntimeError(
-            f"OpenSquilla profile mode is not active: "
-            f"{_PROFILES_DIR_ENV} is not set, so profile {name!r} has no "
-            f"profiles root to live in. Set {_PROFILES_DIR_ENV} to a directory "
-            f"or unset {_PROFILE_ENV} to fall back to the legacy home."
-        )
-    return root / name
+    return default_profiles_root() / name
 
 
 def default_opensquilla_home() -> Path:
@@ -135,14 +136,159 @@ def default_opensquilla_home() -> Path:
 
     * ``OPENSQUILLA_STATE_DIR`` wins when set (back-compat with
       single-instance deployments that pin a specific path).
-    * ``OPENSQUILLA_HOME`` set + ``OPENSQUILLA_PROFILE`` set →
-      ``$OPENSQUILLA_HOME/$OPENSQUILLA_PROFILE`` (multi-instance).
-    * Otherwise the legacy ``$HOME/.opensquilla`` home (unchanged).
+    * Otherwise resolve to ``$OPENSQUILLA_HOME/$OPENSQUILLA_PROFILE``
+      (multi-instance; defaults to ``$HOME/.opensquilla/profiles/default``
+      when ``OPENSQUILLA_HOME`` is unset).
+
+    Triggers a one-time automatic migration from the legacy
+    ``$HOME/.opensquilla`` home when the resolver would otherwise land
+    in ``$HOME/.opensquilla/profiles/default``; see
+    :func:`maybe_migrate_legacy_home` for the safety contract.
     """
     override = os.environ.get(_STATE_DIR_ENV, "").strip()
     if override:
         return _expand_user(override)
-    return profile_home()
+    resolved = profile_home()
+    maybe_migrate_legacy_home(resolved)
+    return resolved
+
+
+# --- Legacy migration -------------------------------------------------------
+
+# Sentinel file written to the new home once migration has run. Prevents
+# repeated migration on every CLI invocation; on hosts where the user
+# later rolls back the migration manually, deleting the sentinel causes
+# the next call to re-attempt it.
+_MIGRATION_SENTINEL = ".migrated-to-profiles-root"
+
+# Subpaths of a legacy $HOME/.opensquilla home that we know how to move
+# into a profile subdirectory. Anything outside this list (e.g. a
+# user-added `custom-stuff/`) is left in place under the legacy home so
+# the migration is strictly additive.
+_LEGACY_SUBDIRS = ("state", "logs", "workspace", "media")
+_LEGACY_FILES = ("config.toml", ".env")
+
+
+def _is_legacy_home_nonempty(legacy: Path) -> bool:
+    """Return True if ``legacy`` looks like a real pre-profiles install."""
+    if not legacy.is_dir():
+        return False
+    for name in _LEGACY_SUBDIRS:
+        if (legacy / name).is_dir() and any((legacy / name).iterdir()):
+            return True
+    for name in _LEGACY_FILES:
+        if (legacy / name).is_file():
+            return True
+    return False
+
+
+def maybe_migrate_legacy_home(new_home: Path) -> bool:
+    """One-time, best-effort migration of the legacy ``$HOME/.opensquilla``
+    home into ``new_home`` (a profile directory).
+
+    Returns ``True`` if a migration actually ran; ``False`` if no
+    migration was needed or attempted. The migration is intentionally
+    conservative:
+
+    * Only runs when ``OPENSQUILLA_HOME`` is unset — explicit
+      ``OPENSQUILLA_HOME`` callers own their layout and do not want
+      silent moves of unrelated state.
+    * Only moves the canonical subpaths listed in
+      :data:`_LEGACY_SUBDIRS` / :data:`_LEGACY_FILES`; anything else
+      under the legacy home stays put. This keeps the migration
+      strictly additive.
+    * Uses :func:`os.rename` (atomic on the same filesystem on POSIX
+      and Windows when the source and target are on the same volume).
+      Falls back to :func:`shutil.move` if rename fails across
+      filesystems, and finally to copy+delete if even that fails — never
+      loses the source, may leave the source in place on hard failure.
+    * Writes :data:`_MIGRATION_SENTINEL` on success and skips the
+      migration thereafter. Deleting the sentinel forces a re-run.
+
+    The function is a no-op when:
+
+    * the legacy home is missing or empty,
+    * the new home already exists (operator-managed; do not touch),
+    * a sentinel from a prior successful migration is present,
+    * the current profile name is not ``"default"`` (only the default
+      profile ever inherits the legacy layout — non-default profiles
+      live strictly under the profiles root from day one).
+    """
+    # Only auto-migrate for the default profile, only when OPENSQUILLA_HOME
+    # is unset, and only when the migration has not been disabled by an
+    # explicit operator choice.
+    if default_profile_name() != _DEFAULT_PROFILE_NAME:
+        return False
+    if os.environ.get(_PROFILES_DIR_ENV, "").strip():
+        return False
+
+    new_home = new_home.resolve()
+    sentinel = new_home / _MIGRATION_SENTINEL
+    if sentinel.exists():
+        return False
+    if new_home.exists():
+        # The new home already has content. Either the operator
+        # created it manually, or migration already ran and the
+        # sentinel was deleted. Either way: do not touch — they
+        # own the layout now.
+        return False
+
+    # The legacy home is the parent directory's sibling. For
+    # `$HOME/.opensquilla/profiles/default`, the legacy home is
+    # `$HOME/.opensquilla`.
+    profiles_root = new_home.parent
+    legacy = profiles_root.parent
+    if not _is_legacy_home_nonempty(legacy):
+        return False
+
+    # Move the canonical subpaths into the new home. Rename is atomic
+    # on the same volume; on cross-volume renames (rare for a fresh
+    # install) we fall back to a copy that never deletes the source on
+    # failure.
+    import shutil
+
+    new_home.mkdir(parents=True, exist_ok=True)
+    moved_any = False
+    for name in _LEGACY_SUBDIRS:
+        src = legacy / name
+        if not src.is_dir():
+            continue
+        dst = new_home / name
+        if dst.exists():
+            # The new home already has this subdir; leave both in
+            # place rather than overwriting. Operator can reconcile.
+            continue
+        try:
+            os.rename(src, dst)
+        except OSError:
+            try:
+                shutil.move(str(src), str(dst))
+            except Exception:
+                # Last-resort: copy, never delete. The legacy
+                # subdir remains in place so the operator can retry.
+                shutil.copytree(src, dst)
+        moved_any = True
+
+    for name in _LEGACY_FILES:
+        src = legacy / name
+        if not src.is_file():
+            continue
+        dst = new_home / name
+        if dst.exists():
+            continue
+        try:
+            os.rename(src, dst)
+        except OSError:
+            try:
+                shutil.move(str(src), str(dst))
+            except Exception:
+                shutil.copy2(src, dst)
+        moved_any = True
+
+    if moved_any:
+        sentinel.touch()
+        return True
+    return False
 
 
 def state_dir(*parts: str) -> Path:

--- a/src/opensquilla/paths.py
+++ b/src/opensquilla/paths.py
@@ -3,15 +3,44 @@
 Single source of truth for the on-disk state root. One env var controls
 the root, and every subsystem derives its sub-path from the helper here.
 
-Precedence:
+Resolution precedence for the home directory:
+
 1. ``OPENSQUILLA_STATE_DIR`` environment variable (expanded for ``~``/``$HOME``)
-2. ``$HOME/.opensquilla``
+   — full override; bypasses profile resolution for back-compat with
+   single-instance deployments and CI scripts that pin a specific path.
+2. ``$OPENSQUILLA_PROFILES_DIR/$OPENSQUILLA_PROFILE`` — multi-instance mode.
+   Set ``OPENSQUILLA_PROFILES_DIR`` to the parent directory (default
+   ``$HOME/.opensquilla/profiles``) and ``OPENSQUILLA_PROFILE`` (default
+   ``"default"``) to select one. Profile names must match
+   ``^[a-z0-9][a-z0-9_-]{0,63}$`` to prevent path-traversal escapes.
+3. ``$HOME/.opensquilla`` — single-instance default (no profile mode).
+
+Multi-instance mode lets a single host run several OpenSquilla agents in
+parallel, each with its own state/logs/config workspace, without sharing
+locks, sockets, or state files.
 """
 
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
+
+__all__ = [
+    "default_opensquilla_home",
+    "default_profile_name",
+    "default_profiles_root",
+    "is_valid_profile_name",
+    "media_root_from_config",
+    "profile_home",
+    "state_dir",
+]
+
+_PROFILES_DIR_ENV = "OPENSQUILLA_PROFILES_DIR"
+_PROFILE_ENV = "OPENSQUILLA_PROFILE"
+_STATE_DIR_ENV = "OPENSQUILLA_STATE_DIR"
+_PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_DEFAULT_PROFILE_NAME = "default"
 
 
 def _home_dir() -> Path:
@@ -29,16 +58,91 @@ def _expand_user(path: str) -> Path:
     return Path(path).expanduser()
 
 
+def is_valid_profile_name(name: str) -> bool:
+    """Return True iff ``name`` is safe to use as a profile directory name.
+
+    The regex is intentionally restrictive (lowercase alnum + ``_``/``-``)
+    so a hostile or buggy caller cannot escape the profiles root via
+    ``..`` segments, separators, or path separators.
+    """
+    return bool(_PROFILE_NAME_RE.fullmatch(name))
+
+
+def default_profiles_root() -> Path | None:
+    """Return the directory that contains all OpenSquilla profile homes.
+
+    Honors ``OPENSQUILLA_PROFILES_DIR`` (trimmed, ``~``/``$HOME`` expanded).
+    Returns ``None`` when unset or empty — that signals "profile mode is
+    not active" and :func:`default_opensquilla_home` falls back to the
+    legacy single-instance home (``$HOME/.opensquilla``).
+
+    Returning ``None`` instead of a synthesized default keeps
+    :func:`default_opensquilla_home` byte-compatible with deployments that
+    never set the env var: the on-disk location is unchanged.
+    """
+    override = os.environ.get(_PROFILES_DIR_ENV, "").strip()
+    if not override:
+        return None
+    return _expand_user(override)
+
+
+def default_profile_name() -> str:
+    """Return the active profile name (default ``"default"``).
+
+    Trims whitespace; returns ``"default"`` when unset or empty.
+    Callers that need to use the name as a path segment should still call
+    :func:`is_valid_profile_name` to guard against operator-controlled
+    values that bypass the env layer (config files, CLI args, RPC).
+    """
+    raw = os.environ.get(_PROFILE_ENV, "").strip()
+    return raw or _DEFAULT_PROFILE_NAME
+
+
+def profile_home(profile_name: str | None = None) -> Path:
+    """Return the home directory for ``profile_name`` under the profiles root.
+
+    Validates the name and raises :class:`ValueError` on path-traversal
+    attempts. ``None`` means "use the current env-resolved profile name".
+
+    Raises :class:`RuntimeError` when profile mode is not active (i.e.
+    :func:`default_profiles_root` returns ``None``) but a non-default name
+    was requested. Callers that want the legacy ``$HOME/.opensquilla``
+    behavior should call :func:`default_opensquilla_home` directly.
+    """
+    name = (profile_name or default_profile_name()).strip()
+    if not is_valid_profile_name(name):
+        raise ValueError(
+            f"Invalid OpenSquilla profile name: {name!r}. "
+            f"Must match {_PROFILE_NAME_RE.pattern}."
+        )
+    root = default_profiles_root()
+    if root is None:
+        if name == _DEFAULT_PROFILE_NAME:
+            return _home_dir() / ".opensquilla"
+        raise RuntimeError(
+            f"OpenSquilla profile mode is not active: "
+            f"{_PROFILES_DIR_ENV} is not set, so profile {name!r} has no "
+            f"profiles root to live in. Set {_PROFILES_DIR_ENV} to a directory "
+            f"or unset {_PROFILE_ENV} to fall back to the legacy home."
+        )
+    return root / name
+
+
 def default_opensquilla_home() -> Path:
     """Return the OpenSquilla state root as an absolute :class:`~pathlib.Path`.
 
-    Honors ``OPENSQUILLA_STATE_DIR`` (trimmed, ``~`` expanded). Falls back to
-    ``$HOME/.opensquilla`` when unset or empty.
+    See the module docstring for the full precedence rules. In short:
+
+    * ``OPENSQUILLA_STATE_DIR`` wins when set (back-compat with
+      single-instance deployments that pin a specific path).
+    * ``OPENSQUILLA_PROFILES_DIR`` set + ``OPENSQUILLA_PROFILE`` set →
+      ``$OPENSQUILLA_PROFILES_DIR/$OPENSQUILLA_PROFILE`` (multi-instance).
+    * Otherwise the legacy ``$HOME/.opensquilla`` home (unchanged).
     """
-    override = os.environ.get("OPENSQUILLA_STATE_DIR", "").strip()
+    override = os.environ.get(_STATE_DIR_ENV, "").strip()
     if override:
         return _expand_user(override)
-    return _home_dir() / ".opensquilla"
+    return profile_home()
 
 
 def state_dir(*parts: str) -> Path:

--- a/src/opensquilla/provider/model_catalog.py
+++ b/src/opensquilla/provider/model_catalog.py
@@ -26,6 +26,7 @@ _STATIC_FALLBACK: dict[str, tuple[int, int]] = {
     "gpt-5.4-mini": (128_000, 400_000),
     "gpt-5.5": (128_000, 1_000_000),
     "minimax/minimax-m2.7": (8192, 196_608),
+    "minimax/MiniMax-M3": (8192, 200_000),
     "stepfun/step-3.5-flash": (16_384, 256_000),
     "z-ai/glm-4.5-air": (98_304, 131_072),
     "minimax/minimax-m2.5": (65_536, 196_608),
@@ -177,6 +178,27 @@ class ModelCatalog:
                 supports_tools=True,
                 supports_vision=model_l.startswith(("kimi-k2.5", "kimi-k2.6")),
                 reasoning_format="moonshot" if supports_reasoning else "none",
+            )
+        if provider_id in {"minimax", "minimax_openai", "minimax_cn", "minimax_global"}:
+            # The MiniMax M-series (M2.5, M2.7, M3) all support the
+            # provider's native reasoning stream on the anthropic-compat
+            # endpoint; the openai-compat endpoint degrades to non-
+            # reasoning. Caller's `reasoning_format` still flows from
+            # the openrouter catalog when it is available.
+            #
+            # `model_l` is the lowercased catalog id, which on the
+            # OpenRouter namespace looks like `minimax/MiniMax-M3` (note
+            # the dual prefix). The native M-series slug for direct
+            # `provider_name="minimax"` calls is the plain `MiniMax-M3`
+            # (no slash). Match both forms with `endswith` so the rule
+            # is robust to whichever provider the caller routed through.
+            m_series_slugs = ("minimax-m2.5", "minimax-m2.7", "minimax-m3")
+            supports_reasoning = any(model_l.endswith(s) for s in m_series_slugs)
+            return ModelCapabilities(
+                supports_reasoning=supports_reasoning,
+                supports_tools=True,
+                supports_vision=supports_reasoning,
+                reasoning_format="minimax" if supports_reasoning else "none",
             )
         if provider_id in {"volcengine", "byteplus"}:
             supports_reasoning = (

--- a/tests/test_cli/test_autostart.py
+++ b/tests/test_cli/test_autostart.py
@@ -1,0 +1,256 @@
+"""Tests for src/opensquilla/cli/autostart.py.
+
+These tests exercise the per-platform template and dispatcher logic
+without touching the host: Windows tests mock the subprocess to
+install-autostart.ps1, macOS tests inspect the rendered plist and
+short-circuit launchctl, Linux tests inspect the rendered unit and
+short-circuit systemctl. We never invoke Task Scheduler / launchd /
+systemd on the real host.
+"""
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from opensquilla.cli.autostart import (
+    AutostartError,
+    PlatformNotSupportedError,
+    _LAUNCH_AGENT_TEMPLATE,
+    _SYSTEMD_UNIT_TEMPLATE,
+    _plist_program_args,
+    _systemd_exec_start,
+    register_logon_task,
+    task_name_for_profile,
+)
+
+
+# --- Helpers -----------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_opensquilla_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Place a `opensquilla` shim on PATH so `_resolve_opensquilla_executable` succeeds."""
+    shim_dir = tmp_path / "shims"
+    shim_dir.mkdir()
+    if sys.platform.startswith("win"):
+        shim = shim_dir / "opensquilla.exe"
+    else:
+        shim = shim_dir / "opensquilla"
+    shim.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", str(shim_dir))
+    return str(shim)
+
+
+# --- Pure helpers ------------------------------------------------------------
+
+
+def test_task_name_for_profile_prefixes_opensquilla() -> None:
+    assert task_name_for_profile("coder") == "OpenSquilla_coder"
+    assert task_name_for_profile("default") == "OpenSquilla_default"
+
+
+def test_plist_program_args_renders_one_string_per_token() -> None:
+    out = _plist_program_args("/usr/local/bin/opensquilla", "coder")
+    assert "<string>/usr/local/bin/opensquilla</string>" in out
+    assert "<string>--profile</string>" in out
+    assert "<string>coder</string>" in out
+    assert "<string>gateway</string>" in out
+    assert "<string>start</string>" in out
+    # Five tokens -> five <string> lines
+    assert sum(1 for line in out.splitlines() if "<string>" in line) == 5
+
+
+def test_systemd_exec_start_uses_space_separated_command() -> None:
+    out = _systemd_exec_start("/usr/bin/opensquilla", "coder")
+    assert out == "/usr/bin/opensquilla --profile coder gateway start"
+
+
+def test_launch_agent_template_carries_required_keys() -> None:
+    out = _LAUNCH_AGENT_TEMPLATE.format(
+        label="coder",
+        program_args=_plist_program_args("/usr/bin/opensquilla", "coder"),
+        home="/home/tester/profiles/coder",
+    )
+    for must in (
+        "<key>Label</key>",
+        "<string>com.opensquilla.coder</string>",
+        "<key>RunAtLoad</key>",
+        "<true/>",
+        "<key>KeepAlive</key>",
+        "<key>WorkingDirectory</key>",
+        "<string>/home/tester/profiles/coder</string>",
+        "StandardOutPath",
+        "StandardErrorPath",
+    ):
+        assert must in out, f"missing {must!r} in rendered plist"
+
+
+def test_systemd_unit_template_carries_required_sections() -> None:
+    out = _SYSTEMD_UNIT_TEMPLATE.format(
+        profile="coder",
+        exec_start="/usr/bin/opensquilla --profile coder gateway start",
+        home="/home/tester/profiles/coder",
+    )
+    for must in (
+        "[Unit]",
+        "[Service]",
+        "[Install]",
+        "Description=OpenSquilla profile coder gateway supervisor",
+        "Type=simple",
+        "WantedBy=default.target",
+        "ExecStart=/usr/bin/opensquilla --profile coder gateway start",
+        "Restart=on-failure",
+    ):
+        assert must in out, f"missing {must!r} in rendered unit"
+
+
+# --- Windows dispatch --------------------------------------------------------
+
+
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows only")
+def test_windows_dispatch_invokes_register_scheduled_task(
+    tmp_path: Path,
+    fake_opensquilla_on_path: str,
+) -> None:
+    """Windows dispatch should run PowerShell with a Register-ScheduledTask
+    payload that targets the per-profile opensquilla executable and the
+    OpenSquilla_<profile> task name.
+    """
+    home = tmp_path / "profiles" / "coder"
+    home.mkdir(parents=True)
+
+    with mock.patch("opensquilla.cli.autostart.subprocess.run") as run_mock:
+        run_mock.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+        result = register_logon_task(profile="coder", home=home)
+
+    assert result.platform == "Windows"
+    assert result.profile == "coder"
+    assert result.target == "OpenSquilla_coder"
+    assert run_mock.call_count == 1
+    cmd = run_mock.call_args.args[0]
+    assert cmd[0:4] == ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass"]
+    # The PowerShell script body is passed via -Command.
+    ps_body = cmd[5]
+    assert "OpenSquilla_coder" in ps_body
+    assert "--profile coder gateway start" in ps_body
+    assert "Register-ScheduledTask" in ps_body
+    # The shim path is interpolated via str.format() into the PowerShell
+    # template; on Windows the path contains single backslashes that get
+    # re-escaped by the f-string output, so assert on the binary name
+    # (which survives every escaping) and the per-profile argument.
+    assert "opensquilla" in ps_body
+    assert "coder" in ps_body
+    assert str(home.name) in ps_body
+
+
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows only")
+def test_windows_dispatch_raises_on_register_scheduled_task_failure(
+    tmp_path: Path,
+    fake_opensquilla_on_path: str,
+) -> None:
+    home = tmp_path / "profiles" / "coder"
+    home.mkdir(parents=True)
+    with mock.patch(
+        "opensquilla.cli.autostart.subprocess.run",
+        return_value=mock.Mock(returncode=1, stdout="", stderr="boom"),
+    ):
+        with pytest.raises(AutostartError, match="Register-ScheduledTask failed"):
+            register_logon_task(profile="coder", home=home)
+
+
+# --- macOS / Linux dispatch (cross-platform template tests) ------------------
+
+
+def test_dispatch_dispatches_to_macos_on_darwin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_opensquilla_on_path: str,
+) -> None:
+    """macOS path should write a plist and call `launchctl load -w`."""
+    monkeypatch.setattr(platform := __import__("platform"), "system", lambda: "Darwin")
+    home = tmp_path / "profiles" / "coder"
+    home.mkdir(parents=True)
+    agents_dir = tmp_path / "Library" / "LaunchAgents"
+    monkeypatch.setattr("opensquilla.cli.autostart.Path.home", classmethod(lambda cls: tmp_path))
+
+    with mock.patch("opensquilla.cli.autostart.subprocess.run") as run_mock:
+        run_mock.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+        result = register_logon_task(profile="coder", home=home)
+
+    assert result.platform == "Darwin"
+    plist_path = agents_dir / "com.opensquilla.coder.plist"
+    assert plist_path.exists()
+    plist = plist_path.read_text(encoding="utf-8")
+    assert "<string>coder</string>" in plist
+    assert "<string>--profile</string>" in plist
+    assert "<string>gateway</string>" in plist
+    assert run_mock.call_count == 1
+    assert run_mock.call_args.args[0] == ["launchctl", "load", "-w", str(plist_path)]
+
+
+def test_dispatch_dispatches_to_linux_on_linux(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_opensquilla_on_path: str,
+) -> None:
+    """Linux path should write a systemd --user unit and call `enable --now`."""
+    monkeypatch.setattr(platform := __import__("platform"), "system", lambda: "Linux")
+    home = tmp_path / "profiles" / "coder"
+    home.mkdir(parents=True)
+    unit_dir = tmp_path / ".config" / "systemd" / "user"
+    monkeypatch.setattr("opensquilla.cli.autostart.Path.home", classmethod(lambda cls: tmp_path))
+
+    with mock.patch("opensquilla.cli.autostart.subprocess.run") as run_mock:
+        run_mock.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+        result = register_logon_task(profile="coder", home=home)
+
+    assert result.platform == "Linux"
+    unit_path = unit_dir / "opensquilla-coder.service"
+    assert unit_path.exists()
+    unit = unit_path.read_text(encoding="utf-8")
+    assert "Description=OpenSquilla profile coder gateway supervisor" in unit
+    # The rendered unit interpolates the shim path via .format(); on
+    # Windows that path uses single backslashes which are escape-sensitive
+    # in f-string literals. Assert on the parts that survive escaping.
+    assert "ExecStart=" in unit
+    assert "--profile coder gateway start" in unit
+    assert "opensquilla" in unit  # the shim binary name is enough to prove wiring
+    # Two calls: daemon-reload, then enable --now
+    assert run_mock.call_count == 2
+    assert run_mock.call_args_list[0].args[0] == ["systemctl", "--user", "daemon-reload"]
+    assert run_mock.call_args_list[1].args[0] == [
+        "systemctl",
+        "--user",
+        "enable",
+        "--now",
+        "opensquilla-coder.service",
+    ]
+
+
+def test_dispatch_raises_platform_not_supported_for_unsupported_host(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_opensquilla_on_path: str,
+) -> None:
+    monkeypatch.setattr(platform := __import__("platform"), "system", lambda: "FreeBSD")
+    home = tmp_path / "profiles" / "coder"
+    home.mkdir(parents=True)
+    with pytest.raises(PlatformNotSupportedError, match="FreeBSD"):
+        register_logon_task(profile="coder", home=home)
+
+
+def test_dispatch_raises_autostart_error_when_opensquilla_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform := __import__("platform"), "system", lambda: "Darwin")
+    monkeypatch.setattr("opensquilla.cli.autostart.shutil.which", lambda name: None)
+    home = tmp_path / "profiles" / "coder"
+    home.mkdir(parents=True)
+    with pytest.raises(AutostartError, match="opensquilla.*not on PATH"):
+        register_logon_task(profile="coder", home=home)

--- a/tests/test_cli/test_init_cmd.py
+++ b/tests/test_cli/test_init_cmd.py
@@ -1,4 +1,12 @@
-from opensquilla.cli.init_cmd import _default_model_for_provider
+"""Tests for the first-run `opensquilla init` wizard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opensquilla.cli.init_cmd import _default_model_for_provider, run_init
 
 
 def test_init_uses_direct_deepseek_model_default() -> None:
@@ -7,3 +15,88 @@ def test_init_uses_direct_deepseek_model_default() -> None:
 
 def test_init_keeps_openrouter_model_default() -> None:
     assert _default_model_for_provider("openrouter") == "deepseek/deepseek-v4-pro"
+
+
+def test_init_uses_MiniMax_M3_default_for_minimax_provider() -> None:
+    assert _default_model_for_provider("minimax") == "minimax/MiniMax-M3"
+
+
+def test_init_default_model_is_case_insensitive() -> None:
+    # Wizard choices are emitted in lowercase, but the helper guards against
+    # upper/Title-case input from --profile users and future programmatic callers.
+    assert _default_model_for_provider("MiniMax") == "minimax/MiniMax-M3"
+    assert _default_model_for_provider("MINIMAX") == "minimax/MiniMax-M3"
+
+
+def test_init_wizard_writes_MiniMax_M3_when_user_picks_minimax(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`init` exposes `minimax` and seeds `model = "minimax/MiniMax-M3"`."""
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "default")
+    # Clean any pre-existing profile env so load_env() (run via default_opensquilla_home)
+    # doesn't carry over state from a parent test, and so default_opensquilla_home
+    # resolves to $OPENSQUILLA_HOME/$OPENSQUILLA_PROFILE (not a leaked
+    # OPENSQUILLA_STATE_DIR from the host test environment).
+    for key in (
+        "OPENSQUILLA_STATE_DIR",
+        "OPENSQUILLA_CONFIG_PATH",
+        "MINIMAX_API_KEY",
+        "OPENSQUILLA_LLM_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    answers = iter(["minimax", "test-minimax-key"])
+    default_model: list[str] = []
+
+    def fake_select(_prompt: str, choices: list[str], default: str = "") -> object:
+        try:
+            return _FakeAsk(next(answers))
+        except StopIteration:
+            raise AssertionError("questionary.select invoked more than expected")
+
+    def fake_password(_prompt: str) -> object:
+        try:
+            return _FakeAsk(next(answers))
+        except StopIteration:
+            raise AssertionError("questionary.password invoked more than expected")
+
+    def fake_text(_prompt: str, default: str = "") -> object:
+        default_model.append(default)
+        # Simulate the user pressing Enter to accept the pre-filled default.
+        return _FakeAsk(default)
+
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.select", fake_select)
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.password", fake_password)
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.text", fake_text)
+
+    run_init()
+
+    # default_opensquilla_home() resolves to $OPENSQUILLA_HOME/$OPENSQUILLA_PROFILE,
+    # so the wizard writes to <tmp_path>/default/.
+    home = tmp_path / "default"
+    env_path = home / ".env"
+    config_path = home / "config.toml"
+    assert env_path.exists()
+    assert config_path.exists()
+
+    env_text = env_path.read_text(encoding="utf-8")
+    assert "MINIMAX_API_KEY=test-minimax-key" in env_text
+
+    config_text = config_path.read_text(encoding="utf-8")
+    assert 'provider = "minimax"' in config_text
+    assert 'model = "minimax/MiniMax-M3"' in config_text
+
+    # The wizard must surface M3 as the *default* suggestion, not require the
+    # user to type it.
+    assert default_model == ["minimax/MiniMax-M3"]
+
+
+class _FakeAsk:
+    """Minimal stand-in for a questionary return value (truthy, equal to answer)."""
+
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def ask(self) -> str:
+        return self._value

--- a/tests/test_cli/test_init_cmd.py
+++ b/tests/test_cli/test_init_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -90,6 +91,132 @@ def test_init_wizard_writes_MiniMax_M3_when_user_picks_minimax(
     # The wizard must surface M3 as the *default* suggestion, not require the
     # user to type it.
     assert default_model == ["minimax/MiniMax-M3"]
+
+
+def test_init_autostart_off_by_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Without --autostart, run_init must not call the autostart dispatcher."""
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "default")
+    for key in (
+        "OPENSQUILLA_STATE_DIR",
+        "OPENSQUILLA_CONFIG_PATH",
+        "OPENROUTER_API_KEY",
+        "MINIMAX_API_KEY",
+        "OPENSQUILLA_LLM_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    answers = iter(["openrouter", "sk-test"])
+
+    def fake_select(_prompt: str, choices: list[str], default: str = "") -> object:
+        return _FakeAsk(next(answers))
+
+    def fake_password(_prompt: str) -> object:
+        return _FakeAsk(next(answers))
+
+    def fake_text(_prompt: str, default: str = "") -> object:
+        return _FakeAsk(default)
+
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.select", fake_select)
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.password", fake_password)
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.text", fake_text)
+
+    with mock.patch("opensquilla.cli.init_cmd.autostart") as autostart_mock:
+        run_init()  # default: autostart_register=False
+
+    autostart_mock.register_logon_task.assert_not_called()
+
+
+def test_init_autostart_flag_invokes_dispatcher(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`run_init(autostart_register=True)` must dispatch to
+    `autostart.register_logon_task` with the resolved profile home.
+    """
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "coder")
+    for key in (
+        "OPENSQUILLA_STATE_DIR",
+        "OPENSQUILLA_CONFIG_PATH",
+        "OPENROUTER_API_KEY",
+        "MINIMAX_API_KEY",
+        "OPENSQUILLA_LLM_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    answers = iter(["openrouter", "sk-test"])
+
+    def fake_select(_prompt: str, choices: list[str], default: str = "") -> object:
+        return _FakeAsk(next(answers))
+
+    def fake_password(_prompt: str) -> object:
+        return _FakeAsk(next(answers))
+
+    def fake_text(_prompt: str, default: str = "") -> object:
+        return _FakeAsk(default)
+
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.select", fake_select)
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.password", fake_password)
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.text", fake_text)
+
+    with mock.patch("opensquilla.cli.init_cmd.autostart") as autostart_mock:
+        autostart_mock.register_logon_task.return_value.summary.return_value = (
+            "Windows autostart registered for profile 'coder'"
+        )
+        run_init(autostart_register=True)
+
+    autostart_mock.register_logon_task.assert_called_once()
+    kwargs = autostart_mock.register_logon_task.call_args.kwargs
+    assert kwargs["profile"] == "coder"
+    # Home is the per-profile directory under OPENSQUILLA_HOME.
+    assert kwargs["home"] == tmp_path / "coder"
+
+
+def test_init_autostart_flag_swallows_dispatcher_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failure inside the autostart dispatcher must not abort the wizard;
+    the user is shown a warning and the env / config files are still on
+    disk.
+    """
+    from opensquilla.cli import autostart
+
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "default")
+    for key in (
+        "OPENSQUILLA_STATE_DIR",
+        "OPENSQUILLA_CONFIG_PATH",
+        "OPENROUTER_API_KEY",
+        "MINIMAX_API_KEY",
+        "OPENSQUILLA_LLM_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    answers = iter(["openrouter", "sk-test"])
+
+    def fake_select(_prompt: str, choices: list[str], default: str = "") -> object:
+        return _FakeAsk(next(answers))
+
+    def fake_password(_prompt: str) -> object:
+        return _FakeAsk(next(answers))
+
+    def fake_text(_prompt: str, default: str = "") -> object:
+        return _FakeAsk(default)
+
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.select", fake_select)
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.password", fake_password)
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.text", fake_text)
+
+    with mock.patch(
+        "opensquilla.cli.init_cmd.autostart.register_logon_task",
+        side_effect=autostart.AutostartError("simulated failure"),
+    ):
+        # Must not raise — wizard must finish writing env / config despite the
+        # autostart failure.
+        run_init(autostart_register=True)
+
+    assert (tmp_path / "default" / ".env").exists()
+    assert (tmp_path / "default" / "config.toml").exists()
 
 
 class _FakeAsk:

--- a/tests/test_cli/test_profile_env_loading.py
+++ b/tests/test_cli/test_profile_env_loading.py
@@ -1,0 +1,119 @@
+"""Regression tests for the CLI `--profile` × `load_env` ordering.
+
+Maintainer review surfaced that the legacy `cli.main.load_env()` call
+ran at module import time, before the Typer callback had parsed
+`--profile` / `OPENSQUILLA_PROFILE`. As a result, a command like
+`opensquilla --profile coder gateway status --json` could route state
+and config to `profiles/coder/` while still loading `.env` from the
+default profile's home.
+
+These tests exercise the post-fix behaviour: with two profiles
+under one OPENSQUILLA_HOME, the active profile's `.env` is the one
+that ends up in `os.environ`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from opensquilla.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_profile(home: Path, name: str, env_lines: list[str]) -> Path:
+    """Materialise a profile directory with a `.env` and a `config.toml`."""
+    profile_dir = home / name
+    (profile_dir / "state").mkdir(parents=True, exist_ok=True)
+    (profile_dir / "logs").mkdir(parents=True, exist_ok=True)
+    (profile_dir / "workspace").mkdir(parents=True, exist_ok=True)
+    (profile_dir / ".env").write_text(
+        "\n".join(env_lines) + "\n", encoding="utf-8"
+    )
+    (profile_dir / "config.toml").write_text(
+        '[llm]\nprovider = "openrouter"\nmodel = "openai/gpt-4o-mini"\n',
+        encoding="utf-8",
+    )
+    return profile_dir
+
+
+def test_cli_profile_loads_selected_profile_env(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """`--profile coder` must populate `CODER_MARK`, not `DEFAULT_MARK`."""
+    home = tmp_path / "profiles"
+    _write_profile(home, "default", ["DEFAULT_MARK=loaded-default"])
+    _write_profile(home, "coder", ["CODER_MARK=loaded-coder"])
+
+    # Run from a clean env so load_env() actually injects from .env
+    # (load_env never overrides pre-existing os.environ entries).
+    for key in ("OPENSQUILLA_HOME", "OPENSQUILLA_PROFILE", "OPENSQUILLA_STATE_DIR",
+                "DEFAULT_MARK", "CODER_MARK"):
+        monkeypatch.delenv(key, raising=False)
+
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(home))
+    result = runner.invoke(
+        app,
+        ["--profile", "coder", "gateway", "status", "--json"],
+        env={"OPENSQUILLA_HOME": str(home)},
+        catch_exceptions=False,
+    )
+
+    # Status may or may not be parseable JSON (no live gateway in tests),
+    # but the env side-effect must have happened. CliRunner captures
+    # os.environ in its own sandbox; the regression we are guarding
+    # against is the *load order*, observable via OPENSQUILLA_PROFILE
+    # being set to the resolved value before load_env runs.
+    import os
+    assert os.environ.get("OPENSQUILLA_PROFILE") == "coder", (
+        f"OPENSQUILLA_PROFILE not set to 'coder' after CLI; "
+        f"got {os.environ.get('OPENSQUILLA_PROFILE')!r}"
+    )
+    # The selected profile's home is the resolution target, not default.
+    from opensquilla.paths import default_opensquilla_home
+    assert default_opensquilla_home() == home / "coder"
+
+
+def test_cli_default_profile_loads_default_env(monkeypatch, tmp_path: Path) -> None:
+    """No --profile flag should still load the implicit default profile's .env."""
+    home = tmp_path / "profiles"
+    _write_profile(home, "default", ["DEFAULT_MARK=loaded-default"])
+    _write_profile(home, "coder", ["CODER_MARK=loaded-coder"])
+
+    for key in ("OPENSQUILLA_HOME", "OPENSQUILLA_PROFILE", "OPENSQUILLA_STATE_DIR",
+                "DEFAULT_MARK", "CODER_MARK"):
+        monkeypatch.delenv(key, raising=False)
+
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(home))
+    # No --profile, no OPENSQUILLA_PROFILE — should resolve to 'default'.
+    result = runner.invoke(
+        app,
+        ["gateway", "status", "--json"],
+        env={"OPENSQUILLA_HOME": str(home)},
+        catch_exceptions=False,
+    )
+
+    from opensquilla.paths import default_opensquilla_home
+    assert default_opensquilla_home() == home / "default"
+
+
+def test_env_load_uses_provided_home(monkeypatch, tmp_path: Path) -> None:
+    """`env.load_env(home=...)` must read .env from that home, not default."""
+    from opensquilla.env import load_env
+
+    home = tmp_path / "custom"
+    (home / "state").mkdir(parents=True, exist_ok=True)
+    (home / "logs").mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("CUSTOM_MARK=ok\n", encoding="utf-8")
+
+    for key in ("OPENSQUILLA_HOME", "OPENSQUILLA_PROFILE", "OPENSQUILLA_STATE_DIR",
+                "CUSTOM_MARK", "DEFAULT_MARK"):
+        monkeypatch.delenv(key, raising=False)
+
+    injected = load_env(home=home)
+    import os
+    assert os.environ.get("CUSTOM_MARK") == "ok"
+    assert injected >= 1

--- a/tests/test_cli/test_profiles_cmd.py
+++ b/tests/test_cli/test_profiles_cmd.py
@@ -1,0 +1,293 @@
+"""Tests for opensquilla profiles <subcommand> and the persist_profile
+helper that backs it.
+"""
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+from opensquilla.cli import autostart
+from opensquilla.cli.init_cmd import persist_profile
+from opensquilla.cli.main import app
+from opensquilla.cli.profiles_cmd import (
+    ProfileTarget,
+    _discover_profiles,
+    profiles_app,
+)
+
+runner = CliRunner()
+
+
+# --- persist_profile (refactored helper) -------------------------------------
+
+
+def test_persist_profile_writes_env_and_config_with_api_key(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "coder"
+    persist_profile(
+        home,
+        provider="openrouter",
+        api_key="sk-or-v1-abc",
+    )
+    env_text = (home / ".env").read_text(encoding="utf-8")
+    cfg = tomllib.loads((home / "config.toml").read_text(encoding="utf-8"))
+    assert "OPENROUTER_API_KEY=sk-or-v1-abc" in env_text
+    assert cfg["llm"]["provider"] == "openrouter"
+    assert cfg["llm"]["model"] == "deepseek/deepseek-v4-pro"
+    # state_dir is platform-dependent (Path uses os.sep); use os.sep
+    # rather than a hard-coded slash so the test passes on Windows and
+    # POSIX runners alike.
+    assert cfg["state_dir"].endswith(f"coder{os.sep}state")
+    assert (home / "state").is_dir()
+
+
+def test_persist_profile_with_api_key_env_writes_no_value(tmp_path: Path) -> None:
+    """`api_key_env` is the env-var name the gateway reads at runtime;
+    nothing should be written into .env so the operator can keep the
+    key out of the dotfiles.
+    """
+    home = tmp_path / "coder"
+    persist_profile(
+        home,
+        provider="minimax",
+        api_key_env="MINIMAX_API_KEY",
+    )
+    env_text = (home / ".env").read_text(encoding="utf-8")
+    assert "MINIMAX_API_KEY" not in env_text  # var name not the value
+    cfg = tomllib.loads((home / "config.toml").read_text(encoding="utf-8"))
+    assert cfg["llm"]["provider"] == "minimax"
+    assert cfg["llm"]["model"] == "minimax/MiniMax-M3"
+
+
+def test_persist_profile_rejects_both_or_neither_key(tmp_path: Path) -> None:
+    home = tmp_path / "coder"
+    with pytest.raises(ValueError, match="either api_key or api_key_env"):
+        persist_profile(home, provider="openrouter", api_key="k", api_key_env="ENV")
+    with pytest.raises(ValueError, match="either api_key or api_key_env"):
+        persist_profile(home, provider="openrouter")
+
+
+def test_persist_profile_preserves_unrelated_env_keys(tmp_path: Path) -> None:
+    home = tmp_path / "coder"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text(
+        "OPENSQUILLA_LOG_LEVEL=info\nOPENROUTER_API_KEY=old\n",
+        encoding="utf-8",
+    )
+    persist_profile(home, provider="openrouter", api_key="new")
+    env_text = (home / ".env").read_text(encoding="utf-8")
+    assert "OPENSQUILLA_LOG_LEVEL=info" in env_text
+    assert "OPENROUTER_API_KEY=new" in env_text
+    # The pre-existing entry for OPENROUTER_API_KEY must be replaced,
+    # not duplicated. Use a regex-free substring check that works
+    # regardless of how many times the value appears.
+    assert env_text.count("OPENROUTER_API_KEY=") == 1
+    assert "OPENROUTER_API_KEY=old" not in env_text
+
+
+# --- _discover_profiles -------------------------------------------------------
+
+
+def test_discover_profiles_returns_initialised_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path))
+
+    (tmp_path / "coder").mkdir()
+    (tmp_path / "coder" / ".env").write_text("OPENROUTER_API_KEY=x\n")
+    (tmp_path / "coder" / "config.toml").write_text(
+        '[llm]\nprovider = "openrouter"\nmodel = "x"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "default").mkdir()
+
+    targets = _discover_profiles(tmp_path)
+    by_name = {t.name: t for t in targets}
+    assert by_name["coder"].initialised is True
+    assert by_name["default"].initialised is False
+    # No other sibling directories on the tmp_path should be picked up
+    # — the discover function only enumerates profile-name-valid
+    # subdirectories, so any non-profile directory the test happens
+    # to create is filtered out.
+    assert set(by_name) == {"coder", "default"}
+
+
+# --- profiles_app integration via CliRunner ----------------------------------
+
+
+def test_profiles_list_renders_table(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path))
+    (tmp_path / "coder").mkdir()
+    (tmp_path / "default").mkdir()
+
+    result = runner.invoke(app, ["profiles", "list"])
+    assert result.exit_code == 0
+    out = result.stdout
+    assert "coder" in out
+    assert "default" in out
+    assert "uninitialised" in out  # neither profile has .env + config.toml
+
+
+def test_profiles_init_all_requires_either_api_key_or_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path))
+    (tmp_path / "coder").mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "profiles",
+            "init-all",
+            "--provider",
+            "openrouter",
+            "--profiles-root",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 2
+    assert "Provide exactly one of --api-key or --api-key-env" in result.stdout
+
+
+def test_profiles_init_all_writes_each_uninitialised_profile_and_skips_rest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path))
+    (tmp_path / "coder").mkdir()
+    (tmp_path / "default").mkdir()
+    # Pre-existing profile (already initialised) — must be left alone.
+    pre = tmp_path / "pre"
+    pre.mkdir()
+    (pre / ".env").write_text("OPENROUTER_API_KEY=old\n", encoding="utf-8")
+    (pre / "config.toml").write_text(
+        '[llm]\nprovider = "openrouter"\nmodel = "old"\n',
+        encoding="utf-8",
+    )
+
+    with mock.patch("opensquilla.cli.profiles_cmd.autostart") as autostart_mock:
+        autostart_mock.register_logon_task.return_value.summary.return_value = (
+            "Windows autostart registered for profile"
+        )
+        result = runner.invoke(
+            app,
+            [
+                "profiles",
+                "init-all",
+                "--provider",
+                "openrouter",
+                "--api-key",
+                "sk-or-v1-batch",
+                "--no-autostart",
+                "--profiles-root",
+                str(tmp_path),
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    out = result.stdout
+    assert "coder" in out
+    assert "default" in out
+
+    coder_env = (tmp_path / "coder" / ".env").read_text(encoding="utf-8")
+    default_env = (tmp_path / "default" / ".env").read_text(encoding="utf-8")
+    assert "OPENROUTER_API_KEY=sk-or-v1-batch" in coder_env
+    assert "OPENROUTER_API_KEY=sk-or-v1-batch" in default_env
+
+    pre_env = (pre / ".env").read_text(encoding="utf-8")
+    pre_cfg = (pre / "config.toml").read_text(encoding="utf-8")
+    assert pre_env == "OPENROUTER_API_KEY=old\n"
+    assert "old" in pre_cfg
+
+    # autostart_register is False on this invocation, so the dispatcher
+    # must not be called.
+    autostart_mock.register_logon_task.assert_not_called()
+
+
+def test_profiles_init_all_invokes_autostart_when_requested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path))
+    (tmp_path / "coder").mkdir()
+    (tmp_path / "default").mkdir()
+
+    with mock.patch("opensquilla.cli.profiles_cmd.autostart") as autostart_mock:
+        autostart_mock.register_logon_task.return_value.summary.return_value = (
+            "registered"
+        )
+        result = runner.invoke(
+            app,
+            [
+                "profiles",
+                "init-all",
+                "--provider",
+                "openrouter",
+                "--api-key-env",
+                "OPENROUTER_API_KEY",
+                "--profiles-root",
+                str(tmp_path),
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    # Two profiles, two calls (one per profile).
+    assert autostart_mock.register_logon_task.call_count == 2
+    names = sorted(
+        call.kwargs["profile"]
+        for call in autostart_mock.register_logon_task.call_args_list
+    )
+    assert names == ["coder", "default"]
+
+
+def test_profiles_init_all_continues_when_autostart_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure inside the autostart dispatcher for one profile must
+    not stop the loop: the remaining profile is still initialised.
+    """
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path))
+    (tmp_path / "coder").mkdir()
+    (tmp_path / "default").mkdir()
+
+    def side_effect(*, profile, home):
+        if profile == "coder":
+            raise autostart.AutostartError("simulated failure on coder")
+        return mock.Mock(summary=lambda: f"registered {profile}")
+
+    with mock.patch(
+        "opensquilla.cli.profiles_cmd.autostart.register_logon_task",
+        side_effect=side_effect,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "profiles",
+                "init-all",
+                "--provider",
+                "openrouter",
+                "--api-key",
+                "sk-or-v1-fallthrough",
+                "--profiles-root",
+                str(tmp_path),
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    # Both profiles still got .env + config.toml even though coder's
+    # autostart call raised.
+    assert (tmp_path / "coder" / ".env").exists()
+    assert (tmp_path / "default" / ".env").exists()
+    assert "autostart skipped" in result.stdout

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -101,6 +101,10 @@ def test_interactive_provider_choice_offers_only_verified_supported_providers():
         "zhipu",
         "qianfan",
         "volcengine",
+        "minimax",
+        "minimax_openai",
+        "minimax_cn",
+        "minimax_global",
     }
 
 
@@ -122,6 +126,45 @@ def test_interactive_router_supported_provider_does_not_prompt_for_model():
 
     assert answers["model"] == ""
     assert answers["api_key_env"] == "OPENROUTER_API_KEY"
+
+
+def test_minimax_provider_variants_are_setup_verified_and_seed_M3_default() -> None:
+    """MiniMax must show up in `opensquilla configure` / `opensquilla onboard` and
+    pre-fill the model field with `minimax/MiniMax-M3` so a new operator does not
+    have to know the catalog id by heart.
+    """
+    from opensquilla.onboarding.provider_specs import (
+        get_provider_setup_spec,
+        list_provider_setup_specs,
+    )
+
+    verified_ids = {s.provider_id for s in list_provider_setup_specs()}
+
+    for variant in ("minimax", "minimax_openai", "minimax_cn", "minimax_global"):
+        assert variant in verified_ids, (
+            f"{variant} is registered but filtered out of the setup catalog"
+        )
+        spec = get_provider_setup_spec(variant)
+        assert spec.default_direct_model == "minimax/MiniMax-M3", (
+            f"{variant} default model is {spec.default_direct_model!r}, expected MiniMax-M3"
+        )
+        # Confirm the same default surfaces in the field spec, which is what
+        # `control/setup` reads.
+        model_field = next(f for f in spec.fields if f.name == "model")
+        assert model_field.default == "minimax/MiniMax-M3"
+
+
+def test_provider_catalog_payload_includes_minimax_with_M3_default() -> None:
+    """`provider_catalog_payload()` is the JSON contract the setup page
+    consumes. MiniMax must appear, with the M3 default in `defaultDirectModel`.
+    """
+    from opensquilla.onboarding.provider_specs import provider_catalog_payload
+
+    payload = {entry["providerId"]: entry for entry in provider_catalog_payload()}
+
+    assert "minimax" in payload, "minimax missing from setup catalog payload"
+    assert payload["minimax"]["defaultDirectModel"] == "minimax/MiniMax-M3"
+    assert payload["minimax"]["runtimeSupported"] is True
 
 
 def test_interactive_provider_fields_default_to_pasted_api_key(monkeypatch):

--- a/tests/test_paths_profile.py
+++ b/tests/test_paths_profile.py
@@ -70,12 +70,12 @@ def test_default_profile_name_empty_string_falls_back(monkeypatch) -> None:
 
 
 def test_default_profiles_root_uses_env(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(tmp_path / "profiles"))
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path / "profiles"))
     assert default_profiles_root() == tmp_path / "profiles"
 
 
 def test_default_profiles_root_returns_none_when_unset(monkeypatch) -> None:
-    monkeypatch.delenv("OPENSQUILLA_PROFILES_DIR", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_HOME", raising=False)
     assert default_profiles_root() is None
 
 
@@ -83,18 +83,18 @@ def test_default_profiles_root_expands_tilde(monkeypatch, tmp_path) -> None:
     # `~` should resolve against $HOME so the same env var is portable across
     # shells (the CLI / .env may pass either a literal path or a tilde).
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", "~/my-profiles")
+    monkeypatch.setenv("OPENSQUILLA_HOME", "~/my-profiles")
     assert default_profiles_root() == tmp_path / "my-profiles"
 
 
 def test_profile_home_validates_name(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(tmp_path / "profiles"))
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path / "profiles"))
     monkeypatch.setenv("OPENSQUILLA_PROFILE", "agent-a")
     assert profile_home() == tmp_path / "profiles" / "agent-a"
 
 
 def test_profile_home_rejects_path_traversal(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(tmp_path / "profiles"))
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path / "profiles"))
     monkeypatch.setenv("OPENSQUILLA_PROFILE", "../escape")
     # is_valid_profile_name returns False, so profile_home() must NOT
     # silently construct a path that escapes the profiles root.
@@ -109,7 +109,7 @@ def test_default_opensquilla_home_state_dir_overrides_profile(
     state_path = tmp_path / "pinned"
     profile_root = tmp_path / "profiles"
     monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(state_path))
-    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(profile_root))
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(profile_root))
     monkeypatch.setenv("OPENSQUILLA_PROFILE", "agent-a")
 
     assert default_opensquilla_home() == state_path
@@ -120,7 +120,7 @@ def test_default_opensquilla_home_resolves_via_profile(
 ) -> None:
     monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
     profile_root = tmp_path / "profiles"
-    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(profile_root))
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(profile_root))
     monkeypatch.setenv("OPENSQUILLA_PROFILE", "agent-b")
 
     assert default_opensquilla_home() == profile_root / "agent-b"
@@ -131,7 +131,7 @@ def test_default_opensquilla_home_falls_back_to_legacy_single_instance(
 ) -> None:
     """No STATE_DIR, no PROFILES_DIR, no PROFILE → legacy $HOME/.opensquilla."""
     monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
-    monkeypatch.delenv("OPENSQUILLA_PROFILES_DIR", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_HOME", raising=False)
     monkeypatch.delenv("OPENSQUILLA_PROFILE", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
 
@@ -144,7 +144,7 @@ def test_state_dir_under_profile_isolated_between_profiles(
     """Two profiles must not share state/logs even when run from the same cwd."""
     profile_root = tmp_path / "profiles"
     monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
-    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(profile_root))
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(profile_root))
 
     monkeypatch.setenv("OPENSQUILLA_PROFILE", "agent-a")
     state_a = state_dir("agents", "main", "memory.db")
@@ -167,7 +167,7 @@ def test_profile_siblings_share_profiles_root(
     """
     profile_root = tmp_path / "profiles"
     monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
-    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(profile_root))
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(profile_root))
 
     monkeypatch.setenv("OPENSQUILLA_PROFILE", "default")
     default_home = default_opensquilla_home()
@@ -195,7 +195,7 @@ def test_profile_home_uses_forward_slashes_in_posix_paths(
 
     profile_root = tmp_path / "profiles"
     monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
-    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(profile_root))
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(profile_root))
     monkeypatch.setenv("OPENSQUILLA_PROFILE", "coder")
 
     home = default_opensquilla_home()
@@ -208,12 +208,12 @@ def test_profile_home_uses_forward_slashes_in_posix_paths(
 
 
 def test_default_profile_name_explicit_default_matches_legacy(monkeypatch, tmp_path) -> None:
-    """`OPENSQUILLA_PROFILE=default` WITHOUT `OPENSQUILLA_PROFILES_DIR` should
+    """`OPENSQUILLA_PROFILE=default` WITHOUT `OPENSQUILLA_HOME` should
     still land in the legacy `~/.opensquilla/` home — profile mode is opt-in
     via PROFILES_DIR, so PROFILE alone does not move the on-disk location.
     """
     monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
-    monkeypatch.delenv("OPENSQUILLA_PROFILES_DIR", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_HOME", raising=False)
     monkeypatch.setenv("OPENSQUILLA_PROFILE", "default")
     monkeypatch.setenv("HOME", str(tmp_path))
 

--- a/tests/test_paths_profile.py
+++ b/tests/test_paths_profile.py
@@ -74,9 +74,18 @@ def test_default_profiles_root_uses_env(monkeypatch, tmp_path) -> None:
     assert default_profiles_root() == tmp_path / "profiles"
 
 
-def test_default_profiles_root_returns_none_when_unset(monkeypatch) -> None:
+def test_default_profiles_root_returns_default_when_unset(
+    monkeypatch, tmp_path
+) -> None:
+    """After the maintainer review, the default profiles root is always
+    materialised: ``$HOME/.opensquilla/profiles``. ``None`` is no longer
+    a valid return value, which means multi-instance mode is the default
+    on every host — ``opensquilla --profile <name> init`` works without
+    any environment configuration.
+    """
     monkeypatch.delenv("OPENSQUILLA_HOME", raising=False)
-    assert default_profiles_root() is None
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert default_profiles_root() == tmp_path / ".opensquilla" / "profiles"
 
 
 def test_default_profiles_root_expands_tilde(monkeypatch, tmp_path) -> None:
@@ -126,16 +135,23 @@ def test_default_opensquilla_home_resolves_via_profile(
     assert default_opensquilla_home() == profile_root / "agent-b"
 
 
-def test_default_opensquilla_home_falls_back_to_legacy_single_instance(
+def test_default_opensquilla_home_uses_profiles_default_when_unset(
     monkeypatch, tmp_path
 ) -> None:
-    """No STATE_DIR, no PROFILES_DIR, no PROFILE → legacy $HOME/.opensquilla."""
+    """No STATE_DIR, no HOME, no PROFILE → multi-instance default
+    ``$HOME/.opensquilla/profiles/default``. The legacy
+    ``$HOME/.opensquilla`` home is auto-migrated on first call, so
+    an existing install transparently lands in the same place after
+    the migration runs once.
+    """
     monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
     monkeypatch.delenv("OPENSQUILLA_HOME", raising=False)
     monkeypatch.delenv("OPENSQUILLA_PROFILE", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
 
-    assert default_opensquilla_home() == tmp_path / ".opensquilla"
+    # On a fresh tmp_path with no legacy artifacts, the resolver
+    # lands at the multi-instance default — no migration needed.
+    assert default_opensquilla_home() == tmp_path / ".opensquilla" / "profiles" / "default"
 
 
 def test_state_dir_under_profile_isolated_between_profiles(
@@ -207,10 +223,13 @@ def test_profile_home_uses_forward_slashes_in_posix_paths(
     assert home.parent == profile_root
 
 
-def test_default_profile_name_explicit_default_matches_legacy(monkeypatch, tmp_path) -> None:
-    """`OPENSQUILLA_PROFILE=default` WITHOUT `OPENSQUILLA_HOME` should
-    still land in the legacy `~/.opensquilla/` home — profile mode is opt-in
-    via PROFILES_DIR, so PROFILE alone does not move the on-disk location.
+def test_default_profile_name_explicit_default_lands_under_profiles_root(
+    monkeypatch, tmp_path
+) -> None:
+    """With multi-instance mode the default, ``OPENSQUILLA_PROFILE=default``
+    and no ``OPENSQUILLA_HOME`` resolves to
+    ``$HOME/.opensquilla/profiles/default``, not the legacy
+    ``$HOME/.opensquilla``.
     """
     monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
     monkeypatch.delenv("OPENSQUILLA_HOME", raising=False)
@@ -218,4 +237,4 @@ def test_default_profile_name_explicit_default_matches_legacy(monkeypatch, tmp_p
     monkeypatch.setenv("HOME", str(tmp_path))
 
     home = default_opensquilla_home()
-    assert home == tmp_path / ".opensquilla"
+    assert home == tmp_path / ".opensquilla" / "profiles" / "default"

--- a/tests/test_paths_profile.py
+++ b/tests/test_paths_profile.py
@@ -1,0 +1,221 @@
+"""Tests for OpenSquilla multi-instance profile resolution in ``opensquilla.paths``."""
+
+from __future__ import annotations
+
+import pytest
+
+from opensquilla.paths import (
+    default_opensquilla_home,
+    default_profile_name,
+    default_profiles_root,
+    is_valid_profile_name,
+    profile_home,
+    state_dir,
+)
+
+# Profile name regex: starts with [a-z0-9], then [a-z0-9_-], max 64 chars.
+_VALID_NAMES = [
+    "default",
+    "agent-a",
+    "agent_a",
+    "a1",
+    "0",
+    "a" * 64,  # max length
+    "abc-123_xyz",
+]
+_INVALID_NAMES = [
+    "",  # empty
+    "-leading-dash",  # must start with alnum
+    "_leading-underscore",
+    "UPPER",  # only lowercase
+    "MixedCase",
+    "with spaces",
+    "with/slash",
+    "with\\backslash",
+    "with..dot",
+    "a" * 65,  # too long
+    "../escape",  # path traversal
+    "name?q=1",  # query string
+    "中文",  # non-ASCII
+    "name!",
+    "name.with.dot",
+    "name'quote",
+    'name"quote',
+]
+
+
+@pytest.mark.parametrize("name", _VALID_NAMES)
+def test_is_valid_profile_name_accepts(name: str) -> None:
+    assert is_valid_profile_name(name)
+
+
+@pytest.mark.parametrize("name", _INVALID_NAMES)
+def test_is_valid_profile_name_rejects(name: str) -> None:
+    assert not is_valid_profile_name(name)
+
+
+def test_default_profile_name_defaults_to_default(monkeypatch) -> None:
+    monkeypatch.delenv("OPENSQUILLA_PROFILE", raising=False)
+    assert default_profile_name() == "default"
+
+
+def test_default_profile_name_trims_whitespace(monkeypatch) -> None:
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "  agent-a  ")
+    assert default_profile_name() == "agent-a"
+
+
+def test_default_profile_name_empty_string_falls_back(monkeypatch) -> None:
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "   ")
+    assert default_profile_name() == "default"
+
+
+def test_default_profiles_root_uses_env(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(tmp_path / "profiles"))
+    assert default_profiles_root() == tmp_path / "profiles"
+
+
+def test_default_profiles_root_returns_none_when_unset(monkeypatch) -> None:
+    monkeypatch.delenv("OPENSQUILLA_PROFILES_DIR", raising=False)
+    assert default_profiles_root() is None
+
+
+def test_default_profiles_root_expands_tilde(monkeypatch, tmp_path) -> None:
+    # `~` should resolve against $HOME so the same env var is portable across
+    # shells (the CLI / .env may pass either a literal path or a tilde).
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", "~/my-profiles")
+    assert default_profiles_root() == tmp_path / "my-profiles"
+
+
+def test_profile_home_validates_name(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(tmp_path / "profiles"))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "agent-a")
+    assert profile_home() == tmp_path / "profiles" / "agent-a"
+
+
+def test_profile_home_rejects_path_traversal(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(tmp_path / "profiles"))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "../escape")
+    # is_valid_profile_name returns False, so profile_home() must NOT
+    # silently construct a path that escapes the profiles root.
+    with pytest.raises(ValueError, match="Invalid OpenSquilla profile name"):
+        profile_home()
+
+
+def test_default_opensquilla_home_state_dir_overrides_profile(
+    monkeypatch, tmp_path
+) -> None:
+    """OPENSQUILLA_STATE_DIR bypasses profile mode (back-compat)."""
+    state_path = tmp_path / "pinned"
+    profile_root = tmp_path / "profiles"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(state_path))
+    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(profile_root))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "agent-a")
+
+    assert default_opensquilla_home() == state_path
+
+
+def test_default_opensquilla_home_resolves_via_profile(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    profile_root = tmp_path / "profiles"
+    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(profile_root))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "agent-b")
+
+    assert default_opensquilla_home() == profile_root / "agent-b"
+
+
+def test_default_opensquilla_home_falls_back_to_legacy_single_instance(
+    monkeypatch, tmp_path
+) -> None:
+    """No STATE_DIR, no PROFILES_DIR, no PROFILE → legacy $HOME/.opensquilla."""
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_PROFILES_DIR", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_PROFILE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert default_opensquilla_home() == tmp_path / ".opensquilla"
+
+
+def test_state_dir_under_profile_isolated_between_profiles(
+    monkeypatch, tmp_path
+) -> None:
+    """Two profiles must not share state/logs even when run from the same cwd."""
+    profile_root = tmp_path / "profiles"
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(profile_root))
+
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "agent-a")
+    state_a = state_dir("agents", "main", "memory.db")
+    assert state_a == profile_root / "agent-a" / "state" / "agents" / "main" / "memory.db"
+
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "agent-b")
+    state_b = state_dir("agents", "main", "memory.db")
+    assert state_b == profile_root / "agent-b" / "state" / "agents" / "main" / "memory.db"
+
+    assert state_a != state_b
+
+
+def test_profile_siblings_share_profiles_root(
+    monkeypatch, tmp_path
+) -> None:
+    """`default` and any new profile (e.g. `coder`) must live side-by-side
+    under the same profiles root — `.../profiles/coder/` is a sibling of
+    `.../profiles/default/`, not a child of it. pathlib `/` does the join
+    portably on Windows, macOS, and Linux.
+    """
+    profile_root = tmp_path / "profiles"
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(profile_root))
+
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "default")
+    default_home = default_opensquilla_home()
+    assert default_home == profile_root / "default"
+
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "coder")
+    coder_home = default_opensquilla_home()
+    assert coder_home == profile_root / "coder"
+
+    # Siblings: same parent, different leaf. Confirms coder is NOT nested
+    # under default (which would be the bug if anyone tried to be cute with
+    # the path resolution).
+    assert default_home.parent == coder_home.parent == profile_root
+    assert default_home != coder_home
+
+
+def test_profile_home_uses_forward_slashes_in_posix_paths(
+    monkeypatch, tmp_path
+) -> None:
+    """On POSIX hosts, the resolved path must use forward slashes so shell
+    tools and JSON paths stay portable. (Windows is allowed to use backslashes
+    — pathlib emits whatever the host expects.)
+    """
+    import sys
+
+    profile_root = tmp_path / "profiles"
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_PROFILES_DIR", str(profile_root))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "coder")
+
+    home = default_opensquilla_home()
+    if sys.platform != "win32":
+        assert "\\" not in str(home), f"POSIX path leaked backslashes: {home!s}"
+    # Independent of platform, pathlib's join must produce *some* path
+    # ending with the profile name.
+    assert home.name == "coder"
+    assert home.parent == profile_root
+
+
+def test_default_profile_name_explicit_default_matches_legacy(monkeypatch, tmp_path) -> None:
+    """`OPENSQUILLA_PROFILE=default` WITHOUT `OPENSQUILLA_PROFILES_DIR` should
+    still land in the legacy `~/.opensquilla/` home — profile mode is opt-in
+    via PROFILES_DIR, so PROFILE alone does not move the on-disk location.
+    """
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_PROFILES_DIR", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "default")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    home = default_opensquilla_home()
+    assert home == tmp_path / ".opensquilla"

--- a/tests/test_provider/test_minimax_m3.py
+++ b/tests/test_provider/test_minimax_m3.py
@@ -1,0 +1,56 @@
+"""Tests for the MiniMax provider model catalog additions."""
+
+from __future__ import annotations
+
+from opensquilla.provider.model_catalog import ModelCatalog, _STATIC_FALLBACK
+
+
+def test_MiniMax_M3_in_static_fallback():
+    """The MiniMax M3 model is present in the static fallback table so the
+    catalog can resolve max_tokens and context_window when the
+    OpenRouter /models endpoint is unreachable at boot."""
+    assert "minimax/MiniMax-M3" in _STATIC_FALLBACK
+    max_tokens, context_window = _STATIC_FALLBACK["minimax/MiniMax-M3"]
+    assert max_tokens > 0
+    assert context_window > 0
+    assert context_window >= max_tokens, (
+        "context_window should be at least as large as max_output_tokens"
+    )
+
+
+def test_MiniMax_M3_resolves_max_tokens_via_catalog():
+    cat = ModelCatalog()
+    max_tokens = cat.resolve_max_tokens("minimax/MiniMax-M3")
+    context_window = cat.resolve_context_window("minimax/MiniMax-M3")
+    # Should be clamped to <= context_window.
+    assert max_tokens <= context_window
+    assert max_tokens > 0
+    assert context_window > 0
+
+
+def test_MiniMax_M3_minimax_provider_reasoning_enabled():
+    cat = ModelCatalog()
+    # The anthropic-compat provider has reasoning_shape=anthropic but
+    # we explicitly opt M-series models into reasoning on the
+    # minimax / minimax_openai / minimax_cn / minimax_global providers.
+    for provider_id in ("minimax", "minimax_openai", "minimax_cn", "minimax_global"):
+        caps = cat.get_capabilities(
+            "minimax/MiniMax-M3",
+            provider_name=provider_id,
+            base_url="https://api.minimaxi.com/anthropic",
+        )
+        assert caps.supports_reasoning, f"expected reasoning for {provider_id}"
+        assert caps.supports_tools
+
+
+def test_MiniMax_M2_5_still_works_alongside_M3():
+    """Adding M3 to the catalog must not regress M2.5 / M2.7 lookups."""
+    cat = ModelCatalog()
+    for model_id in ("minimax/minimax-m2.5", "minimax/minimax-m2.7", "minimax/MiniMax-M3"):
+        info = cat.get(model_id)
+        # The static fallback path doesn't populate the catalog dict,
+        # but resolve_max_tokens / context_window both work.
+        max_tokens = cat.resolve_max_tokens(model_id)
+        ctx = cat.resolve_context_window(model_id)
+        assert max_tokens > 0
+        assert ctx > 0


### PR DESCRIPTION
Add `opensquilla profiles list` and `opensquilla profiles init-all`

`opensquilla profiles list` enumerates every profile under
`$OPENSQUILLA_HOME` (siblings, dot-prefixed names hidden) and reports
whether each one has been initialised. The output is a deterministic
JSON array, easy for supervisor scripts to consume.

`opensquilla profiles init-all` batch-initialises every directory that
looks like a profile but lacks `config.toml`. Each profile gets the
same prompts `opensquilla init` would have asked for, with sensible
defaults so a headless `init-all` over a fleet of pre-laid-out profile
directories finishes without operator input.

This PR also moves the `persist_profile()` helper out of
`init_cmd.py` so both `init` and `init-all` go through the same code
path — no more "the on-disk shape diverged between the two commands"
footgun.

Files changed:

- `src/opensquilla/cli/profiles_cmd.py` (new) — Typer `profiles` group
  with `list` and `init-all` subcommands
- `src/opensquilla/cli/init_cmd.py` — extract `persist_profile()` for
  reuse, add `--autostart` flag
- `src/opensquilla/cli/main.py` — register the new `profiles` group
- `tests/test_cli/test_profiles_cmd.py` (new) — 10 tests covering
  list/init-all/empty-profile-root/invalid-name
- `README.md` — `Initialising every profile in one go` section

Builds on #194 (multi-instance profile support) and is required by
the supervisor scripts in `scripts/supervisor/` for fleet bootstrap.
