### PR TITLE
Make PR governance explicit without blocking contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,59 @@
-## Checklist
+## Scope
 
-- [ ] This pull request targets `dev`, unless a maintainer asked for a `main` release/hotfix/documentation PR.
-- [ ] Linked issues are declared with `Fixes #...`, `Refs #...`, or `None`.
-- [ ] Release impact is declared: `user-visible`, `internal`, `docs`, or `none`.
-- [ ] I ran `uv run ruff check src tests`.
-- [ ] I ran `uv run pytest -q`.
-- [ ] I ran `uv build --wheel`.
-- [ ] Behavior changes include public regression tests.
-- [ ] The default test path remains offline, deterministic, credential-free, and safe for forks.
-- [ ] I did not commit secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, or non-public test fixtures.
-- [ ] Third-party origin is declared: `none`, `inspired-by`, `adapted/ported`, `vendored`, `direct dependency`, or `modified upstream`.
-- [ ] For non-`none` third-party origin, I listed the upstream URL, license, whether code/rules/fixtures/text were copied or adapted, and updated notices/provenance where required.
+Scope boundary:
 
-## Live Checks
+Non-goals:
 
-If this pull request changes provider, browser UI, gateway, or channel behavior, note whether a maintainer should run the `Live Release E2E` workflow.
+## Branch
+
+Base branch: dev | main | staging/collaboration
+
+Main exception: N/A | release | hotfix | release-docs | main-sync | maintainer-approved
+
+## Issue
+
+Linked issue: Fixes #... | Refs #... | None
+
+If None, reason:
+
+## Release Note
+
+Release note: NONE |
+
+## Tests
+
+Ruff:
+
+Pytest:
+
+Build:
+
+Regression tests: added | not needed
+
+Notes:
+
+The default test path remains offline, deterministic, credential-free, and safe for forks.
+
+## Maintainer Live Check
+
+Maintainer live check: no | yes
+
+Surface: N/A | provider | browser | gateway | channel | release
+
+Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.
+
+## Safety
+
+Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.
+
+## Third-Party Origin
+
+Third-party origin: none | inspired-by | adapted/ported | vendored | direct dependency | modified upstream
+
+Details if non-none: upstream URL, license, copied/adapted code/rules/fixtures/text, and notice/provenance updates.
 
 ## Documentation Changes
-
-If this pull request changes documentation:
 
 - [ ] Links point to existing repository files or stable external pages.
 - [ ] Code fences and Markdown tables render correctly on GitHub.
 - [ ] Examples avoid real secrets, local private paths, and private transcripts.
-- [ ] User-facing feature pages explain when to use the feature, how to start, and where to troubleshoot next.

--- a/.github/scripts/issue_link_sync.py
+++ b/.github/scripts/issue_link_sync.py
@@ -49,6 +49,7 @@ CLOSING_KEYWORDS = frozenset(
     }
 )
 REFERENCE_KEYWORDS = frozenset({"ref", "refs", "reference", "references"})
+OPEN_PR_ACTIONS = frozenset({"opened", "reopened", "edited"})
 KEYWORD_RE = re.compile(
     r"\b(?P<keyword>close|closes|closed|fix|fixes|fixed|resolve|resolves|"
     r"resolved|ref|refs|reference|references)\s*:?\s+(?P<ref>"
@@ -233,9 +234,7 @@ def parse_linked_issues(body: str | None, *, owner: str, repo: str) -> ParsedIss
 
 
 def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...]:
-    if event.get("action") != "closed":
-        return ()
-
+    action = event.get("action")
     pr = event.get("pull_request") or {}
     repository = event.get("repository") or {}
     full_name = repository.get("full_name") or ""
@@ -247,8 +246,22 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
     pr_url = str(pr.get("html_url") or "")
     parsed = parse_linked_issues(pr.get("body"), owner=owner, repo=repo)
 
-    if pr.get("merged") is True and (pr.get("base") or {}).get("ref") == "dev":
+    if action in OPEN_PR_ACTIONS:
         return tuple(
+            IssueSyncAction(
+                issue_number=issue_number,
+                kind="linked_pr_open",
+                pr_number=pr_number,
+                pr_url=pr_url,
+            )
+            for issue_number in parsed.all
+        )
+
+    if action != "closed":
+        return ()
+
+    if pr.get("merged") is True and (pr.get("base") or {}).get("ref") == "dev":
+        closing_actions = tuple(
             IssueSyncAction(
                 issue_number=issue_number,
                 kind="merged_to_dev",
@@ -257,6 +270,18 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
             )
             for issue_number in parsed.closing
         )
+        closing_issue_numbers = set(parsed.closing)
+        reference_cleanup_actions = tuple(
+            IssueSyncAction(
+                issue_number=issue_number,
+                kind="remove_linked_pr",
+                pr_number=pr_number,
+                pr_url=pr_url,
+            )
+            for issue_number in parsed.references
+            if issue_number not in closing_issue_numbers
+        )
+        return (*closing_actions, *reference_cleanup_actions)
 
     if pr.get("merged") is not True:
         return tuple(
@@ -269,7 +294,15 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
             for issue_number in parsed.all
         )
 
-    return ()
+    return tuple(
+        IssueSyncAction(
+            issue_number=issue_number,
+            kind="remove_linked_pr",
+            pr_number=pr_number,
+            pr_url=pr_url,
+        )
+        for issue_number in parsed.all
+    )
 
 
 def comment_marker(*, kind: str, pr_number: int) -> str:
@@ -291,6 +324,10 @@ def _merged_to_dev_comment(action: IssueSyncAction) -> str:
 
 
 def apply_action(client: GitHubClient, action: IssueSyncAction) -> None:
+    if action.kind == "linked_pr_open":
+        client.add_labels(action.issue_number, [HAS_LINKED_PR_LABEL])
+        return
+
     if action.kind == "merged_to_dev":
         client.add_labels(
             action.issue_number,
@@ -302,7 +339,7 @@ def apply_action(client: GitHubClient, action: IssueSyncAction) -> None:
             client.create_comment(action.issue_number, _merged_to_dev_comment(action))
         return
 
-    if action.kind == "closed_unmerged":
+    if action.kind in {"closed_unmerged", "remove_linked_pr"}:
         client.remove_label(action.issue_number, HAS_LINKED_PR_LABEL)
         return
 

--- a/.github/scripts/validate_pr_body.py
+++ b/.github/scripts/validate_pr_body.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Warn when a pull request body misses OpenSquilla governance fields."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+
+class RequiredField(NamedTuple):
+    name: str
+    pattern: re.Pattern[str]
+
+
+REQUIRED_FIELDS = (
+    RequiredField("Scope boundary", re.compile(r"(?im)^\s*Scope boundary\s*:")),
+    RequiredField("Base branch", re.compile(r"(?im)^\s*Base branch\s*:")),
+    RequiredField("Main exception", re.compile(r"(?im)^\s*Main exception\s*:")),
+    RequiredField("Linked issue", re.compile(r"(?im)^\s*Linked issue\s*:")),
+    RequiredField("Release note", re.compile(r"(?im)^\s*Release note\s*:")),
+    RequiredField("Tests", re.compile(r"(?im)^\s*(?:#+\s*)?Tests\s*:?\s*$")),
+    RequiredField("Maintainer live check", re.compile(r"(?im)^\s*Maintainer live check\s*:")),
+    RequiredField("Third-party origin", re.compile(r"(?im)^\s*Third-party origin\s*:")),
+)
+
+
+def missing_fields(body: str | None) -> list[str]:
+    text = body or ""
+    return [field.name for field in REQUIRED_FIELDS if field.pattern.search(text) is None]
+
+
+def _annotation_escape(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _warning(title: str, message: str) -> None:
+    print(f"::warning title={_annotation_escape(title)}::{_annotation_escape(message)}")
+
+
+def _is_strict() -> bool:
+    return os.environ.get("PR_BODY_LINT_STRICT", "0").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _load_pr_body(event_path: str) -> str | None:
+    with Path(event_path).open(encoding="utf-8") as event_file:
+        event = json.load(event_file)
+    return (event.get("pull_request") or {}).get("body")
+
+
+def main() -> int:
+    strict = _is_strict()
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        _warning("Missing PR event", "GITHUB_EVENT_PATH is not set; skipping PR body lint.")
+        return 1 if strict else 0
+
+    try:
+        body = _load_pr_body(event_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        _warning("Unreadable PR event", f"Unable to read pull request event: {exc}")
+        return 1 if strict else 0
+
+    missing = missing_fields(body)
+    if not missing:
+        print("PR body includes required governance fields.")
+        return 0
+
+    for field in missing:
+        _warning(
+            "Missing PR template field",
+            f"Add the `{field}:` field to make review intent explicit.",
+        )
+
+    print(
+        "PR body lint is warning-only. Maintainers may harden it by setting "
+        "PR_BODY_LINT_STRICT=1 after existing pull requests are migrated."
+    )
+    return 1 if strict else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 "on":
   pull_request:
   push:
-    branches: [main]
+    branches: [main, dev]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/issue-link-sync.yml
+++ b/.github/workflows/issue-link-sync.yml
@@ -2,8 +2,8 @@ name: Issue Link Sync
 
 "on":
   pull_request_target:
-    types: [closed]
-    branches: [dev]
+    types: [opened, reopened, edited, closed]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-body-lint.yml
+++ b/.github/workflows/pr-body-lint.yml
@@ -1,0 +1,33 @@
+name: PR body lint
+
+"on":
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-body:
+    name: Validate PR body fields
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out trusted workflow scripts
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Check out bootstrap body linter before first merge
+        if: ${{ hashFiles('.github/scripts/validate_pr_body.py') == '' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Validate PR body fields
+        env:
+          PR_BODY_LINT_STRICT: "0"
+        run: python3 .github/scripts/validate_pr_body.py

--- a/tests/test_ci/test_pr_body_lint.py
+++ b/tests/test_ci/test_pr_body_lint.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _load_lint_module():
+    script = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "validate_pr_body.py"
+    spec = importlib.util.spec_from_file_location("validate_pr_body", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pr_body_lint_accepts_complete_structured_template_body() -> None:
+    lint = _load_lint_module()
+
+    body = "\n".join(
+        [
+            "Scope boundary: update CI governance",
+            "Base branch: dev",
+            "Main exception: N/A",
+            "Linked issue: Refs #210",
+            "Release note: NONE",
+            "Tests:",
+            "Ruff: uv run ruff check tests",
+            "Pytest: uv run pytest tests/test_ci -q",
+            "Build: not run locally; CI only",
+            "Maintainer live check: no",
+            "Third-party origin: none",
+        ]
+    )
+
+    assert lint.missing_fields(body) == []
+
+
+def test_pr_body_lint_accepts_repository_template_fields() -> None:
+    lint = _load_lint_module()
+    template = Path(".github/pull_request_template.md").read_text(encoding="utf-8")
+
+    assert lint.missing_fields(template) == []
+
+
+def test_pr_body_lint_warns_for_old_unstructured_checklist() -> None:
+    lint = _load_lint_module()
+
+    missing = lint.missing_fields("- [ ] I ran `uv run pytest -q`.")
+
+    assert "Scope boundary" in missing
+    assert "Base branch" in missing
+    assert "Linked issue" in missing
+    assert "Release note" in missing
+    assert "Maintainer live check" in missing
+
+
+def test_pr_body_lint_is_warning_only_for_incomplete_body(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps({"pull_request": {"body": "Fixes #100"}}),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["GITHUB_EVENT_PATH"] = event_path.as_posix()
+    env["PR_BODY_LINT_STRICT"] = "0"
+    result = subprocess.run(
+        [
+            sys.executable,
+            ".github/scripts/validate_pr_body.py",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "::warning title=Missing PR template field::" in result.stdout
+    assert "Scope boundary" in result.stdout
+
+
+def test_pr_body_lint_can_fail_in_strict_mode(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps({"pull_request": {"body": "Fixes #100"}}),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["GITHUB_EVENT_PATH"] = event_path.as_posix()
+    env["PR_BODY_LINT_STRICT"] = "1"
+    result = subprocess.run(
+        [
+            sys.executable,
+            ".github/scripts/validate_pr_body.py",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "::warning title=Missing PR template field::" in result.stdout
+
+
+def test_pr_body_lint_handles_missing_event_path_as_warning_only() -> None:
+    env = os.environ.copy()
+    env.pop("GITHUB_EVENT_PATH", None)
+    env["PR_BODY_LINT_STRICT"] = "0"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            ".github/scripts/validate_pr_body.py",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "::warning title=Missing PR event::" in result.stdout

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -13,6 +13,7 @@ import yaml
 WORKFLOW_DIR = Path(".github/workflows")
 CLASSIFIER = Path(".github/scripts/classify-ci-changes.sh")
 PR_TARGET_VALIDATOR = Path(".github/scripts/validate-pr-target-branch.sh")
+PR_BODY_LINT = Path(".github/scripts/validate_pr_body.py")
 TEST_PATH_RE = re.compile(r"tests/[A-Za-z0-9_./-]+\.py")
 
 
@@ -150,7 +151,7 @@ def _validate_pr_target(
     )
 
 
-def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
+def test_default_ci_blocks_pull_requests_and_main_and_dev_pushes() -> None:
     ci_path = WORKFLOW_DIR / "ci.yml"
     if not ci_path.exists():
         return
@@ -159,7 +160,7 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     text = ci_path.read_text(encoding="utf-8")
 
     assert {"pull_request", "push", "workflow_dispatch"} <= _trigger_keys(data)
-    assert "branches: [main]" in text
+    assert "branches: [main, dev]" in text
     assert "PYTHONPATH: ${{ github.workspace }}" in text
     assert "Configure runtime directories" in text
     assert 'OPENSQUILLA_STATE_DIR=%s/opensquilla-state\\n' in text
@@ -320,6 +321,34 @@ def test_pr_target_branch_workflow_runs_trusted_base_validator() -> None:
     assert "PR_LABELS" in text
     assert "PR_NUMBER" in text
     assert ".github/scripts/validate-pr-target-branch.sh" in text
+
+
+def test_pr_body_lint_workflow_warns_from_trusted_base() -> None:
+    data = _workflow("pr-body-lint.yml")
+    text = (WORKFLOW_DIR / "pr-body-lint.yml").read_text(encoding="utf-8")
+
+    assert _trigger_keys(data) == {"pull_request"}
+    assert "pull_request_target" not in text
+    assert "Validate PR body fields" in text
+    assert "github.event.repository.default_branch" in text
+    assert "hashFiles('.github/scripts/validate_pr_body.py') == ''" in text
+    assert "github.event.pull_request.head.sha" in text
+    assert "pull-requests: read" in text
+    assert PR_BODY_LINT.as_posix() in text
+    assert "PR_BODY_LINT_STRICT: \"0\"" in text
+
+
+def test_issue_link_sync_tracks_open_and_closed_final_prs_from_trusted_base() -> None:
+    data = _workflow("issue-link-sync.yml")
+    text = (WORKFLOW_DIR / "issue-link-sync.yml").read_text(encoding="utf-8")
+
+    pull_request_target = data["on"]["pull_request_target"]
+    assert set(pull_request_target["types"]) == {"opened", "reopened", "edited", "closed"}
+    assert pull_request_target["branches"] == ["main", "dev"]
+    assert "ref: ${{ github.event.pull_request.base.sha }}" in text
+    assert "persist-credentials: false" in text
+    assert "issues: write" in text
+    assert ".github/scripts/issue_link_sync.py" in text
 
 
 def test_ci_change_classifier_allows_root_and_docs_markdown_only(tmp_path: Path) -> None:

--- a/tests/test_github_issue_link_sync.py
+++ b/tests/test_github_issue_link_sync.py
@@ -4,6 +4,15 @@ import importlib.util
 from pathlib import Path
 from typing import Any
 
+DUMMY_MERGED_DEV_PR = 9001
+DUMMY_CLOSED_PR = 9002
+DUMMY_OPEN_PR = 9003
+DUMMY_MERGED_MAIN_PR = 9004
+DUMMY_MERGED_DEV_PR_URL = "https://example.invalid/pulls/9001"
+DUMMY_CLOSED_PR_URL = "https://example.invalid/pulls/9002"
+DUMMY_OPEN_PR_URL = "https://example.invalid/pulls/9003"
+DUMMY_MERGED_MAIN_PR_URL = "https://example.invalid/pulls/9004"
+
 
 def _load_sync_module():
     script = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "issue_link_sync.py"
@@ -76,7 +85,7 @@ def test_parse_linked_issues_deduplicates_and_ignores_pr_style_urls() -> None:
             [
                 "Fixes #100",
                 "fixes #100",
-                "Refs https://github.com/opensquilla/opensquilla/pull/203",
+                "Refs https://github.com/opensquilla/opensquilla/pull/9999",
                 "Fixes https://github.com/opensquilla/opensquilla/issues/101",
             ]
         ),
@@ -96,11 +105,11 @@ def test_plan_merged_dev_pr_updates_only_closing_issues() -> None:
         {
             "action": "closed",
             "pull_request": {
-                "number": 203,
+                "number": DUMMY_MERGED_DEV_PR,
                 "merged": True,
                 "body": "Fixes #100\nRefs #200",
                 "base": {"ref": "dev"},
-                "html_url": "https://github.com/opensquilla/opensquilla/pull/203",
+                "html_url": DUMMY_MERGED_DEV_PR_URL,
             },
             "repository": {
                 "full_name": "opensquilla/opensquilla",
@@ -112,8 +121,85 @@ def test_plan_merged_dev_pr_updates_only_closing_issues() -> None:
         sync.IssueSyncAction(
             issue_number=100,
             kind="merged_to_dev",
-            pr_number=203,
-            pr_url="https://github.com/opensquilla/opensquilla/pull/203",
+            pr_number=DUMMY_MERGED_DEV_PR,
+            pr_url=DUMMY_MERGED_DEV_PR_URL,
+        ),
+        sync.IssueSyncAction(
+            issue_number=200,
+            kind="remove_linked_pr",
+            pr_number=DUMMY_MERGED_DEV_PR,
+            pr_url=DUMMY_MERGED_DEV_PR_URL,
+        ),
+    )
+
+
+def test_plan_open_or_updated_pr_adds_linked_pr_label_to_all_linked_issues() -> None:
+    sync = _load_sync_module()
+
+    for action_name in ["opened", "reopened", "edited"]:
+        actions = sync.plan_issue_sync_actions(
+            {
+                "action": action_name,
+                "pull_request": {
+                    "number": DUMMY_OPEN_PR,
+                    "merged": False,
+                    "body": "Fixes #100\nRefs #200",
+                    "base": {"ref": "dev"},
+                    "html_url": DUMMY_OPEN_PR_URL,
+                },
+                "repository": {
+                    "full_name": "opensquilla/opensquilla",
+                },
+            }
+        )
+
+        assert actions == (
+            sync.IssueSyncAction(
+                issue_number=100,
+                kind="linked_pr_open",
+                pr_number=DUMMY_OPEN_PR,
+                pr_url=DUMMY_OPEN_PR_URL,
+            ),
+            sync.IssueSyncAction(
+                issue_number=200,
+                kind="linked_pr_open",
+                pr_number=DUMMY_OPEN_PR,
+                pr_url=DUMMY_OPEN_PR_URL,
+            ),
+        )
+
+
+def test_plan_merged_main_pr_removes_linked_pr_label_without_dev_status() -> None:
+    sync = _load_sync_module()
+
+    actions = sync.plan_issue_sync_actions(
+        {
+            "action": "closed",
+            "pull_request": {
+                "number": DUMMY_MERGED_MAIN_PR,
+                "merged": True,
+                "body": "Fixes #100\nRefs #200",
+                "base": {"ref": "main"},
+                "html_url": DUMMY_MERGED_MAIN_PR_URL,
+            },
+            "repository": {
+                "full_name": "opensquilla/opensquilla",
+            },
+        }
+    )
+
+    assert actions == (
+        sync.IssueSyncAction(
+            issue_number=100,
+            kind="remove_linked_pr",
+            pr_number=DUMMY_MERGED_MAIN_PR,
+            pr_url=DUMMY_MERGED_MAIN_PR_URL,
+        ),
+        sync.IssueSyncAction(
+            issue_number=200,
+            kind="remove_linked_pr",
+            pr_number=DUMMY_MERGED_MAIN_PR,
+            pr_url=DUMMY_MERGED_MAIN_PR_URL,
         ),
     )
 
@@ -125,11 +211,11 @@ def test_plan_closed_unmerged_pr_removes_linked_pr_label_from_all_linked_issues(
         {
             "action": "closed",
             "pull_request": {
-                "number": 204,
+                "number": DUMMY_CLOSED_PR,
                 "merged": False,
                 "body": "Fixes #100\nRefs #200",
                 "base": {"ref": "dev"},
-                "html_url": "https://github.com/opensquilla/opensquilla/pull/204",
+                "html_url": DUMMY_CLOSED_PR_URL,
             },
             "repository": {
                 "full_name": "opensquilla/opensquilla",
@@ -141,14 +227,14 @@ def test_plan_closed_unmerged_pr_removes_linked_pr_label_from_all_linked_issues(
         sync.IssueSyncAction(
             issue_number=100,
             kind="closed_unmerged",
-            pr_number=204,
-            pr_url="https://github.com/opensquilla/opensquilla/pull/204",
+            pr_number=DUMMY_CLOSED_PR,
+            pr_url=DUMMY_CLOSED_PR_URL,
         ),
         sync.IssueSyncAction(
             issue_number=200,
             kind="closed_unmerged",
-            pr_number=204,
-            pr_url="https://github.com/opensquilla/opensquilla/pull/204",
+            pr_number=DUMMY_CLOSED_PR,
+            pr_url=DUMMY_CLOSED_PR_URL,
         ),
     )
 
@@ -156,12 +242,12 @@ def test_plan_closed_unmerged_pr_removes_linked_pr_label_from_all_linked_issues(
 def test_comment_marker_is_pr_scoped_for_idempotent_merged_to_dev_comments() -> None:
     sync = _load_sync_module()
 
-    marker = sync.comment_marker(kind="merged_to_dev", pr_number=203)
+    marker = sync.comment_marker(kind="merged_to_dev", pr_number=DUMMY_MERGED_DEV_PR)
 
-    assert marker == "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-203 -->"
+    assert marker == "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9001 -->"
     assert sync.has_marker([{"body": f"{marker}\nThis is already posted."}], marker)
     assert not sync.has_marker(
-        [{"body": "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-202 -->"}],
+        [{"body": "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9000 -->"}],
         marker,
     )
 
@@ -171,8 +257,8 @@ def test_apply_merged_dev_action_labels_removes_open_pr_label_and_comments_once(
     action = sync.IssueSyncAction(
         issue_number=100,
         kind="merged_to_dev",
-        pr_number=203,
-        pr_url="https://github.com/opensquilla/opensquilla/pull/203",
+        pr_number=DUMMY_MERGED_DEV_PR,
+        pr_url=DUMMY_MERGED_DEV_PR_URL,
     )
     client = RecordingClient()
 
@@ -185,14 +271,14 @@ def test_apply_merged_dev_action_labels_removes_open_pr_label_and_comments_once(
         (
             "create_comment",
             100,
-            "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-203 -->\n"
-            "The linked fix for this issue has merged to `dev` via #203 "
-            "(https://github.com/opensquilla/opensquilla/pull/203). "
+            "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9001 -->\n"
+            "The linked fix for this issue has merged to `dev` via #9001 "
+            f"({DUMMY_MERGED_DEV_PR_URL}). "
             "Keeping it open for verification before release.",
         ),
     ]
 
-    marker = sync.comment_marker(kind="merged_to_dev", pr_number=203)
+    marker = sync.comment_marker(kind="merged_to_dev", pr_number=DUMMY_MERGED_DEV_PR)
     client = RecordingClient(comments=[{"body": marker}])
 
     sync.apply_action(client, action)
@@ -204,13 +290,43 @@ def test_apply_merged_dev_action_labels_removes_open_pr_label_and_comments_once(
     ]
 
 
+def test_apply_open_linked_pr_action_adds_open_pr_label() -> None:
+    sync = _load_sync_module()
+    action = sync.IssueSyncAction(
+        issue_number=100,
+        kind="linked_pr_open",
+        pr_number=DUMMY_OPEN_PR,
+        pr_url=DUMMY_OPEN_PR_URL,
+    )
+    client = RecordingClient()
+
+    sync.apply_action(client, action)
+
+    assert client.calls == [("add_labels", 100, ("has-linked-pr",))]
+
+
+def test_apply_remove_linked_pr_action_only_removes_open_pr_label() -> None:
+    sync = _load_sync_module()
+    action = sync.IssueSyncAction(
+        issue_number=200,
+        kind="remove_linked_pr",
+        pr_number=DUMMY_MERGED_MAIN_PR,
+        pr_url=DUMMY_MERGED_MAIN_PR_URL,
+    )
+    client = RecordingClient()
+
+    sync.apply_action(client, action)
+
+    assert client.calls == [("remove_label", 200, "has-linked-pr")]
+
+
 def test_apply_closed_unmerged_action_only_removes_open_pr_label() -> None:
     sync = _load_sync_module()
     action = sync.IssueSyncAction(
         issue_number=200,
         kind="closed_unmerged",
-        pr_number=204,
-        pr_url="https://github.com/opensquilla/opensquilla/pull/204",
+        pr_number=DUMMY_CLOSED_PR,
+        pr_url=DUMMY_CLOSED_PR_URL,
     )
     client = RecordingClient()
 
@@ -224,7 +340,7 @@ def test_list_comments_reads_all_pages_before_idempotency_check() -> None:
     client = PaginatedGitHubClient(
         [
             [{"body": f"old comment {index}"} for index in range(100)],
-            [{"body": "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-203 -->"}],
+            [{"body": "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9001 -->"}],
         ]
     )
 
@@ -232,7 +348,7 @@ def test_list_comments_reads_all_pages_before_idempotency_check() -> None:
 
     assert sync.has_marker(
         comments,
-        "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-203 -->",
+        "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9001 -->",
     )
     assert client.paths == [
         "/issues/100/comments?per_page=100&page=1",

--- a/tests/test_public_release_hygiene.py
+++ b/tests/test_public_release_hygiene.py
@@ -145,6 +145,30 @@ def test_public_testing_guidance_documents_the_private_boundary() -> None:
         assert phrase in combined
 
 
+def test_pull_request_template_uses_structured_governance_fields() -> None:
+    text = Path(".github/pull_request_template.md").read_text(encoding="utf-8")
+    required_phrases = [
+        "Scope boundary",
+        "Non-goals",
+        "Base branch: dev | main | staging/collaboration",
+        "Main exception: N/A | release | hotfix | release-docs | main-sync | maintainer-approved",
+        "Linked issue: Fixes #... | Refs #... | None",
+        "If None, reason",
+        "Release note: NONE |",
+        "Ruff:",
+        "Pytest:",
+        "Build:",
+        "Maintainer live check",
+        "contributors are not expected to provide secrets",
+        "Third-party origin",
+    ]
+
+    for phrase in required_phrases:
+        assert phrase in text
+
+    assert text.count("[ ]") <= 6
+
+
 def test_public_docs_do_not_use_key_shaped_placeholders() -> None:
     violations: list[str] = []
     placeholder_pattern = re.compile(r"sk-or-v1-[A-Za-z0-9_-]+")


### PR DESCRIPTION
## Scope

Scope boundary: CI governance, PR template fields, PR body warning lint, and issue-link lifecycle labels.

Non-goals: No ruleset changes in this PR body; repository rulesets will be updated after the workflow changes land.

## Branch

Base branch: dev

Main exception: N/A

## Issue

Linked issue: Refs #210

If None, reason: N/A

## Release Note

Release note: NONE

## Tests

Ruff: uv run ruff check tests/test_ci/test_workflows.py tests/test_ci/test_pr_body_lint.py tests/test_public_release_hygiene.py tests/test_github_issue_link_sync.py .github/scripts/validate_pr_body.py .github/scripts/issue_link_sync.py

Pytest: uv run pytest tests/test_ci/test_workflows.py tests/test_ci/test_pr_body_lint.py tests/test_public_release_hygiene.py tests/test_github_issue_link_sync.py -q

Build: not run locally; CI only

Regression tests: added

Notes: actionlint and git diff --check were also run locally.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [ ] Links point to existing repository files or stable external pages.
- [ ] Code fences and Markdown tables render correctly on GitHub.
- [ ] Examples avoid real secrets, local private paths, and private transcripts.
