### PR TITLE
Sync PR governance gates to main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,59 @@
-## Checklist
+## Scope
 
-- [ ] This pull request targets `dev`, unless a maintainer asked for a `main` release/hotfix/documentation PR.
-- [ ] Linked issues are declared with `Fixes #...`, `Refs #...`, or `None`.
-- [ ] Release impact is declared: `user-visible`, `internal`, `docs`, or `none`.
-- [ ] I ran `uv run ruff check src tests`.
-- [ ] I ran `uv run pytest -q`.
-- [ ] I ran `uv build --wheel`.
-- [ ] Behavior changes include public regression tests.
-- [ ] The default test path remains offline, deterministic, credential-free, and safe for forks.
-- [ ] I did not commit secrets, local paths, private prompts, real provider transcripts, channel identifiers, or AI session artifacts.
-- [ ] I did not commit maintainer-only files from `tests/_private/` or `.omx/private-golden/`.
-- [ ] Third-party origin is declared: `none`, `inspired-by`, `adapted/ported`, `vendored`, `direct dependency`, or `modified upstream`.
-- [ ] For non-`none` third-party origin, I listed the upstream URL, license, whether code/rules/fixtures/text were copied or adapted, and updated notices/provenance where required.
+Scope boundary:
 
-## Live Checks
+Non-goals:
 
-If this pull request changes provider, browser UI, gateway, or channel behavior, note whether a maintainer should run the `Live Release E2E` workflow.
+## Branch
+
+Base branch: dev | main | staging/collaboration
+
+Main exception: N/A | release | hotfix | release-docs | main-sync | maintainer-approved
+
+## Issue
+
+Linked issue: Fixes #... | Refs #... | None
+
+If None, reason:
+
+## Release Note
+
+Release note: NONE |
+
+## Tests
+
+Ruff:
+
+Pytest:
+
+Build:
+
+Regression tests: added | not needed
+
+Notes:
+
+The default test path remains offline, deterministic, credential-free, and safe for forks.
+
+## Maintainer Live Check
+
+Maintainer live check: no | yes
+
+Surface: N/A | provider | browser | gateway | channel | release
+
+Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.
+
+## Safety
+
+Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.
+
+## Third-Party Origin
+
+Third-party origin: none | inspired-by | adapted/ported | vendored | direct dependency | modified upstream
+
+Details if non-none: upstream URL, license, copied/adapted code/rules/fixtures/text, and notice/provenance updates.
 
 ## Documentation Changes
-
-If this pull request changes documentation:
 
 - [ ] Links point to existing repository files or stable external pages.
 - [ ] Code fences and Markdown tables render correctly on GitHub.
 - [ ] Examples avoid real secrets, local private paths, and private transcripts.
-- [ ] User-facing feature pages explain when to use the feature, how to start, and where to troubleshoot next.

--- a/.github/scripts/issue_link_sync.py
+++ b/.github/scripts/issue_link_sync.py
@@ -49,6 +49,7 @@ CLOSING_KEYWORDS = frozenset(
     }
 )
 REFERENCE_KEYWORDS = frozenset({"ref", "refs", "reference", "references"})
+OPEN_PR_ACTIONS = frozenset({"opened", "reopened", "edited"})
 KEYWORD_RE = re.compile(
     r"\b(?P<keyword>close|closes|closed|fix|fixes|fixed|resolve|resolves|"
     r"resolved|ref|refs|reference|references)\s*:?\s+(?P<ref>"
@@ -233,9 +234,7 @@ def parse_linked_issues(body: str | None, *, owner: str, repo: str) -> ParsedIss
 
 
 def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...]:
-    if event.get("action") != "closed":
-        return ()
-
+    action = event.get("action")
     pr = event.get("pull_request") or {}
     repository = event.get("repository") or {}
     full_name = repository.get("full_name") or ""
@@ -247,8 +246,22 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
     pr_url = str(pr.get("html_url") or "")
     parsed = parse_linked_issues(pr.get("body"), owner=owner, repo=repo)
 
-    if pr.get("merged") is True and (pr.get("base") or {}).get("ref") == "dev":
+    if action in OPEN_PR_ACTIONS:
         return tuple(
+            IssueSyncAction(
+                issue_number=issue_number,
+                kind="linked_pr_open",
+                pr_number=pr_number,
+                pr_url=pr_url,
+            )
+            for issue_number in parsed.all
+        )
+
+    if action != "closed":
+        return ()
+
+    if pr.get("merged") is True and (pr.get("base") or {}).get("ref") == "dev":
+        closing_actions = tuple(
             IssueSyncAction(
                 issue_number=issue_number,
                 kind="merged_to_dev",
@@ -257,6 +270,18 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
             )
             for issue_number in parsed.closing
         )
+        closing_issue_numbers = set(parsed.closing)
+        reference_cleanup_actions = tuple(
+            IssueSyncAction(
+                issue_number=issue_number,
+                kind="remove_linked_pr",
+                pr_number=pr_number,
+                pr_url=pr_url,
+            )
+            for issue_number in parsed.references
+            if issue_number not in closing_issue_numbers
+        )
+        return (*closing_actions, *reference_cleanup_actions)
 
     if pr.get("merged") is not True:
         return tuple(
@@ -269,7 +294,15 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
             for issue_number in parsed.all
         )
 
-    return ()
+    return tuple(
+        IssueSyncAction(
+            issue_number=issue_number,
+            kind="remove_linked_pr",
+            pr_number=pr_number,
+            pr_url=pr_url,
+        )
+        for issue_number in parsed.all
+    )
 
 
 def comment_marker(*, kind: str, pr_number: int) -> str:
@@ -291,6 +324,10 @@ def _merged_to_dev_comment(action: IssueSyncAction) -> str:
 
 
 def apply_action(client: GitHubClient, action: IssueSyncAction) -> None:
+    if action.kind == "linked_pr_open":
+        client.add_labels(action.issue_number, [HAS_LINKED_PR_LABEL])
+        return
+
     if action.kind == "merged_to_dev":
         client.add_labels(
             action.issue_number,
@@ -302,7 +339,7 @@ def apply_action(client: GitHubClient, action: IssueSyncAction) -> None:
             client.create_comment(action.issue_number, _merged_to_dev_comment(action))
         return
 
-    if action.kind == "closed_unmerged":
+    if action.kind in {"closed_unmerged", "remove_linked_pr"}:
         client.remove_label(action.issue_number, HAS_LINKED_PR_LABEL)
         return
 

--- a/.github/scripts/issue_link_sync.py
+++ b/.github/scripts/issue_link_sync.py
@@ -50,6 +50,7 @@ CLOSING_KEYWORDS = frozenset(
 )
 REFERENCE_KEYWORDS = frozenset({"ref", "refs", "reference", "references"})
 OPEN_PR_ACTIONS = frozenset({"opened", "reopened", "edited"})
+FINAL_BASE_REFS = frozenset({"main", "dev"})
 KEYWORD_RE = re.compile(
     r"\b(?P<keyword>close|closes|closed|fix|fixes|fixed|resolve|resolves|"
     r"resolved|ref|refs|reference|references)\s*:?\s+(?P<ref>"
@@ -268,6 +269,15 @@ def parse_linked_issues(body: str | None, *, owner: str, repo: str) -> ParsedIss
     )
 
 
+def _previous_base_ref(event: dict[str, Any]) -> str | None:
+    base_change = (event.get("changes") or {}).get("base") or {}
+    ref_change = base_change.get("ref") or {}
+    previous_ref = ref_change.get("from")
+    if previous_ref is None:
+        return None
+    return str(previous_ref)
+
+
 def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...]:
     action = event.get("action")
     pr = event.get("pull_request") or {}
@@ -279,11 +289,27 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
 
     pr_number = int(pr["number"])
     pr_url = str(pr.get("html_url") or "")
+    base_ref = str((pr.get("base") or {}).get("ref") or "")
     parsed = parse_linked_issues(pr.get("body"), owner=owner, repo=repo)
 
     if action in OPEN_PR_ACTIONS:
         if pr.get("state") != "open":
             return ()
+        previous_body = ((event.get("changes") or {}).get("body") or {}).get("from")
+        previous = parse_linked_issues(previous_body, owner=owner, repo=repo)
+        if base_ref not in FINAL_BASE_REFS:
+            if action != "edited" or _previous_base_ref(event) not in FINAL_BASE_REFS:
+                return ()
+            issue_numbers = tuple(dict.fromkeys((*parsed.all, *previous.all)))
+            return tuple(
+                IssueSyncAction(
+                    issue_number=issue_number,
+                    kind="remove_linked_pr",
+                    pr_number=pr_number,
+                    pr_url=pr_url,
+                )
+                for issue_number in issue_numbers
+            )
         open_actions = tuple(
             IssueSyncAction(
                 issue_number=issue_number,
@@ -296,8 +322,6 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
         if action != "edited":
             return open_actions
 
-        previous_body = ((event.get("changes") or {}).get("body") or {}).get("from")
-        previous = parse_linked_issues(previous_body, owner=owner, repo=repo)
         current_issue_numbers = set(parsed.all)
         remove_actions = tuple(
             IssueSyncAction(
@@ -314,11 +338,34 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
     if action != "closed":
         return ()
 
-    if pr.get("merged") is True and (pr.get("base") or {}).get("ref") == "dev":
+    if pr.get("merged") is True and base_ref == "dev":
         closing_actions = tuple(
             IssueSyncAction(
                 issue_number=issue_number,
                 kind="merged_to_dev",
+                pr_number=pr_number,
+                pr_url=pr_url,
+            )
+            for issue_number in parsed.closing
+        )
+        closing_issue_numbers = set(parsed.closing)
+        reference_cleanup_actions = tuple(
+            IssueSyncAction(
+                issue_number=issue_number,
+                kind="remove_linked_pr",
+                pr_number=pr_number,
+                pr_url=pr_url,
+            )
+            for issue_number in parsed.references
+            if issue_number not in closing_issue_numbers
+        )
+        return (*closing_actions, *reference_cleanup_actions)
+
+    if pr.get("merged") is True and base_ref == "main":
+        closing_actions = tuple(
+            IssueSyncAction(
+                issue_number=issue_number,
+                kind="merged_to_main",
                 pr_number=pr_number,
                 pr_url=pr_url,
             )
@@ -403,6 +450,16 @@ def apply_action(client: GitHubClient, action: IssueSyncAction) -> None:
             action.pr_number,
         ):
             client.remove_label(action.issue_number, HAS_LINKED_PR_LABEL)
+        return
+
+    if action.kind == "merged_to_main":
+        if not client.has_other_open_linked_pull_request(
+            action.issue_number,
+            action.pr_number,
+        ):
+            client.remove_label(action.issue_number, HAS_LINKED_PR_LABEL)
+        client.remove_label(action.issue_number, MERGED_TO_DEV_LABEL)
+        client.remove_label(action.issue_number, NEEDS_VERIFICATION_LABEL)
         return
 
     raise ValueError(f"Unsupported issue sync action: {action.kind}")

--- a/.github/scripts/issue_link_sync.py
+++ b/.github/scripts/issue_link_sync.py
@@ -340,6 +340,9 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
     if action != "closed":
         return ()
 
+    if base_ref not in FINAL_BASE_REFS:
+        return ()
+
     if pr.get("merged") is True and base_ref == "dev":
         closing_actions = tuple(
             IssueSyncAction(

--- a/.github/scripts/issue_link_sync.py
+++ b/.github/scripts/issue_link_sync.py
@@ -188,6 +188,41 @@ class GitHubClient:
             payload={"body": body},
         )
 
+    def list_open_pull_requests(self) -> list[dict[str, Any]]:
+        all_pulls: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            pulls = self.request_json(
+                "GET",
+                f"/pulls?state=open&per_page=100&page={page}",
+            )
+            if not isinstance(pulls, list) or not pulls:
+                return all_pulls
+            all_pulls.extend(pulls)
+            if len(pulls) < 100:
+                return all_pulls
+            page += 1
+
+    def has_other_open_linked_pull_request(self, issue_number: int, pr_number: int) -> bool:
+        if "/" not in self._repository:
+            return False
+        owner, repo = self._repository.split("/", 1)
+        for pull_request in self.list_open_pull_requests():
+            try:
+                other_number = int(pull_request.get("number"))
+            except (TypeError, ValueError):
+                continue
+            if other_number == pr_number:
+                continue
+            parsed = parse_linked_issues(
+                pull_request.get("body"),
+                owner=owner,
+                repo=repo,
+            )
+            if issue_number in parsed.all:
+                return True
+        return False
+
 
 def _normalize_repo_ref(raw_ref: str, *, owner: str, repo: str) -> int | None:
     local = LOCAL_REF_RE.match(raw_ref)
@@ -247,7 +282,9 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
     parsed = parse_linked_issues(pr.get("body"), owner=owner, repo=repo)
 
     if action in OPEN_PR_ACTIONS:
-        return tuple(
+        if pr.get("state") != "open":
+            return ()
+        open_actions = tuple(
             IssueSyncAction(
                 issue_number=issue_number,
                 kind="linked_pr_open",
@@ -256,6 +293,23 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
             )
             for issue_number in parsed.all
         )
+        if action != "edited":
+            return open_actions
+
+        previous_body = ((event.get("changes") or {}).get("body") or {}).get("from")
+        previous = parse_linked_issues(previous_body, owner=owner, repo=repo)
+        current_issue_numbers = set(parsed.all)
+        remove_actions = tuple(
+            IssueSyncAction(
+                issue_number=issue_number,
+                kind="remove_linked_pr",
+                pr_number=pr_number,
+                pr_url=pr_url,
+            )
+            for issue_number in previous.all
+            if issue_number not in current_issue_numbers
+        )
+        return (*open_actions, *remove_actions)
 
     if action != "closed":
         return ()
@@ -333,14 +387,22 @@ def apply_action(client: GitHubClient, action: IssueSyncAction) -> None:
             action.issue_number,
             [MERGED_TO_DEV_LABEL, NEEDS_VERIFICATION_LABEL],
         )
-        client.remove_label(action.issue_number, HAS_LINKED_PR_LABEL)
+        if not client.has_other_open_linked_pull_request(
+            action.issue_number,
+            action.pr_number,
+        ):
+            client.remove_label(action.issue_number, HAS_LINKED_PR_LABEL)
         marker = comment_marker(kind=action.kind, pr_number=action.pr_number)
         if not has_marker(client.list_comments(action.issue_number), marker):
             client.create_comment(action.issue_number, _merged_to_dev_comment(action))
         return
 
     if action.kind in {"closed_unmerged", "remove_linked_pr"}:
-        client.remove_label(action.issue_number, HAS_LINKED_PR_LABEL)
+        if not client.has_other_open_linked_pull_request(
+            action.issue_number,
+            action.pr_number,
+        ):
+            client.remove_label(action.issue_number, HAS_LINKED_PR_LABEL)
         return
 
     raise ValueError(f"Unsupported issue sync action: {action.kind}")

--- a/.github/scripts/issue_link_sync.py
+++ b/.github/scripts/issue_link_sync.py
@@ -215,6 +215,8 @@ class GitHubClient:
                 continue
             if other_number == pr_number:
                 continue
+            if str((pull_request.get("base") or {}).get("ref") or "") not in FINAL_BASE_REFS:
+                continue
             parsed = parse_linked_issues(
                 pull_request.get("body"),
                 owner=owner,

--- a/.github/scripts/validate-pr-target-branch.sh
+++ b/.github/scripts/validate-pr-target-branch.sh
@@ -3,12 +3,6 @@ set -euo pipefail
 
 base_ref="${PR_BASE_REF:-${BASE_REF:-${BASE:-}}}"
 event_path="${GITHUB_EVENT_PATH:-}"
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-classifier="${script_dir}/classify-ci-changes.sh"
-temp_files=()
-trap 'rm -f "${temp_files[@]}"' EXIT
-
-changed_files_path=""
 
 if [[ -z "${base_ref}" ]]; then
   {
@@ -23,40 +17,13 @@ if [[ "${base_ref}" == "dev" ]]; then
   exit 0
 fi
 
-set_pr_changed_files_path() {
-  if [[ -n "${PR_CHANGED_FILES_PATH:-}" ]]; then
-    if [[ -f "${PR_CHANGED_FILES_PATH}" ]]; then
-      changed_files_path="${PR_CHANGED_FILES_PATH}"
-      return 0
-    fi
-    echo "::error title=Missing PR files::PR_CHANGED_FILES_PATH does not exist." >&2
-    return 1
-  fi
-
-  if [[ -z "${GITHUB_REPOSITORY:-}" || -z "${PR_NUMBER:-}" ]]; then
-    return 1
-  fi
-
-  if ! command -v gh >/dev/null 2>&1; then
-    echo "::error title=Missing GitHub CLI::gh is required to inspect pull request files." >&2
-    return 1
-  fi
-
-  local changed_files
-  changed_files="$(mktemp)"
-  temp_files+=("${changed_files}")
-
-  if ! gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename' > "${changed_files}"; then
-    echo "::error title=Unable to inspect PR files::Could not read changed files for pull request ${PR_NUMBER}." >&2
-    return 1
-  fi
-
-  changed_files_path="${changed_files}"
-}
-
 event_label_names() {
   if [[ -n "${PR_LABELS:-}" ]]; then
     tr ',' '\n' <<< "${PR_LABELS}"
+    return
+  fi
+
+  if [[ -z "${event_path}" || ! -f "${event_path}" ]]; then
     return
   fi
 
@@ -88,43 +55,49 @@ PY
   fi
 }
 
-main_docs_only=false
-if [[ "${base_ref}" == "main" ]]; then
-  if set_pr_changed_files_path; then
-    classifier_output="$(mktemp)"
-    temp_files+=("${classifier_output}")
-    GITHUB_OUTPUT="${classifier_output}" bash "${classifier}" "${changed_files_path}"
-    if grep -qx "docs_only=true" "${classifier_output}"; then
-      main_docs_only=true
-    fi
-  fi
-fi
+has_allowed_label() {
+  local allowed_kind="${1:?allowed kind is required}"
+  local label
 
-main_allowed_by_label=false
-if [[ "${base_ref}" == "main" && -n "${event_path}" && -f "${event_path}" ]]; then
   while IFS= read -r label; do
-    case "${label}" in
-      allow-main-target | release | hotfix | sync-to-main | docs-preview)
-        main_allowed_by_label=true
-        break
+    case "${allowed_kind}:${label}" in
+      main:allow-main-target | main:release | main:hotfix | main:main-sync | main:release-docs | main:sync-to-main | main:docs-preview)
+        return 0
+        ;;
+      staging:maintainer-staging | staging:collaboration)
+        return 0
         ;;
     esac
   done < <(event_label_names)
-fi
 
-if [[ "${main_docs_only}" == "true" ]]; then
-  echo "Pull request targets main with documentation-only changes."
+  return 1
+}
+
+is_staging_branch() {
+  case "${base_ref}" in
+    sandbox-* | integration/* | staging/* | release/*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+if [[ "${base_ref}" == "main" ]] && has_allowed_label main; then
+  echo "Pull request targets main with maintainer approval label."
   exit 0
 fi
 
-if [[ "${main_allowed_by_label}" == "true" ]]; then
-  echo "Pull request targets main with maintainer approval label."
+if is_staging_branch || has_allowed_label staging; then
+  echo "Pull request targets a staging/collaboration branch."
+  echo "This is not a final integration path; final integration should target dev, while release or hotfix work should target main with an approval label."
   exit 0
 fi
 
 {
   echo "::error title=Wrong PR target::Ordinary pull requests should target dev."
-  echo "Use main only for documentation-only changes or maintainer-approved release, hotfix, sync, or documentation-preview work."
-  echo "Retarget this pull request to dev, or ask a maintainer to add allow-main-target."
+  echo "Use main only for maintainer-approved release, hotfix, release-docs, or main-sync work."
+  echo "Use sandbox-*, integration/*, staging/*, release/*, or a maintainer-staging/collaboration label for maintainer collaboration PRs."
+  echo "Retarget this pull request to dev, or ask a maintainer to add an explicit exception label."
 } >&2
 exit 1

--- a/.github/scripts/validate-pr-target-branch.sh
+++ b/.github/scripts/validate-pr-target-branch.sh
@@ -88,7 +88,7 @@ if [[ "${base_ref}" == "main" ]] && has_allowed_label main; then
   exit 0
 fi
 
-if is_staging_branch || has_allowed_label staging; then
+if [[ "${base_ref}" != "main" ]] && { is_staging_branch || has_allowed_label staging; }; then
   echo "Pull request targets a staging/collaboration branch."
   echo "This is not a final integration path; final integration should target dev, while release or hotfix work should target main with an approval label."
   exit 0

--- a/.github/scripts/validate-pr-target-branch.sh
+++ b/.github/scripts/validate-pr-target-branch.sh
@@ -64,9 +64,6 @@ has_allowed_label() {
       main:allow-main-target | main:release | main:hotfix | main:main-sync | main:release-docs | main:sync-to-main | main:docs-preview)
         return 0
         ;;
-      staging:maintainer-staging | staging:collaboration)
-        return 0
-        ;;
     esac
   done < <(event_label_names)
 
@@ -88,7 +85,7 @@ if [[ "${base_ref}" == "main" ]] && has_allowed_label main; then
   exit 0
 fi
 
-if [[ "${base_ref}" != "main" ]] && { is_staging_branch || has_allowed_label staging; }; then
+if [[ "${base_ref}" != "main" ]] && is_staging_branch; then
   echo "Pull request targets a staging/collaboration branch."
   echo "This is not a final integration path; final integration should target dev, while release or hotfix work should target main with an approval label."
   exit 0
@@ -97,7 +94,7 @@ fi
 {
   echo "::error title=Wrong PR target::Ordinary pull requests should target dev."
   echo "Use main only for maintainer-approved release, hotfix, release-docs, or main-sync work."
-  echo "Use sandbox-*, integration/*, staging/*, release/*, or a maintainer-staging/collaboration label for maintainer collaboration PRs."
+  echo "Use sandbox-*, integration/*, staging/*, or release/* for maintainer collaboration PRs."
   echo "Retarget this pull request to dev, or ask a maintainer to add an explicit exception label."
 } >&2
 exit 1

--- a/.github/scripts/validate_pr_body.py
+++ b/.github/scripts/validate_pr_body.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Warn when a pull request body misses OpenSquilla governance fields."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+
+class RequiredField(NamedTuple):
+    name: str
+    pattern: re.Pattern[str]
+
+
+REQUIRED_FIELDS = (
+    RequiredField("Scope boundary", re.compile(r"(?im)^\s*Scope boundary\s*:")),
+    RequiredField("Base branch", re.compile(r"(?im)^\s*Base branch\s*:")),
+    RequiredField("Main exception", re.compile(r"(?im)^\s*Main exception\s*:")),
+    RequiredField("Linked issue", re.compile(r"(?im)^\s*Linked issue\s*:")),
+    RequiredField("Release note", re.compile(r"(?im)^\s*Release note\s*:")),
+    RequiredField("Tests", re.compile(r"(?im)^\s*(?:#+\s*)?Tests\s*:?\s*$")),
+    RequiredField("Maintainer live check", re.compile(r"(?im)^\s*Maintainer live check\s*:")),
+    RequiredField("Third-party origin", re.compile(r"(?im)^\s*Third-party origin\s*:")),
+)
+
+
+def missing_fields(body: str | None) -> list[str]:
+    text = body or ""
+    return [field.name for field in REQUIRED_FIELDS if field.pattern.search(text) is None]
+
+
+def _annotation_escape(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _warning(title: str, message: str) -> None:
+    print(f"::warning title={_annotation_escape(title)}::{_annotation_escape(message)}")
+
+
+def _is_strict() -> bool:
+    return os.environ.get("PR_BODY_LINT_STRICT", "0").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _load_pr_body(event_path: str) -> str | None:
+    with Path(event_path).open(encoding="utf-8") as event_file:
+        event = json.load(event_file)
+    return (event.get("pull_request") or {}).get("body")
+
+
+def main() -> int:
+    strict = _is_strict()
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        _warning("Missing PR event", "GITHUB_EVENT_PATH is not set; skipping PR body lint.")
+        return 1 if strict else 0
+
+    try:
+        body = _load_pr_body(event_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        _warning("Unreadable PR event", f"Unable to read pull request event: {exc}")
+        return 1 if strict else 0
+
+    missing = missing_fields(body)
+    if not missing:
+        print("PR body includes required governance fields.")
+        return 0
+
+    for field in missing:
+        _warning(
+            "Missing PR template field",
+            f"Add the `{field}:` field to make review intent explicit.",
+        )
+
+    print(
+        "PR body lint is warning-only. Maintainers may harden it by setting "
+        "PR_BODY_LINT_STRICT=1 after existing pull requests are migrated."
+    )
+    return 1 if strict else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 "on":
   pull_request:
   push:
-    branches: [main]
+    branches: [main, dev]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/issue-link-sync.yml
+++ b/.github/workflows/issue-link-sync.yml
@@ -2,8 +2,8 @@ name: Issue Link Sync
 
 "on":
   pull_request_target:
-    types: [closed]
-    branches: [dev]
+    types: [opened, reopened, edited, closed]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/issue-link-sync.yml
+++ b/.github/workflows/issue-link-sync.yml
@@ -3,11 +3,12 @@ name: Issue Link Sync
 "on":
   pull_request_target:
     types: [opened, reopened, edited, closed]
-    branches: [main, dev]
+    branches: [main, dev, "sandbox-*", "integration/*", "staging/*", "release/*"]
 
 permissions:
   contents: read
   issues: write
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/issue-link-sync.yml
+++ b/.github/workflows/issue-link-sync.yml
@@ -3,7 +3,6 @@ name: Issue Link Sync
 "on":
   pull_request_target:
     types: [opened, reopened, edited, closed]
-    branches: [main, dev, "sandbox-*", "integration/*", "staging/*", "release/*"]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-body-lint.yml
+++ b/.github/workflows/pr-body-lint.yml
@@ -1,0 +1,33 @@
+name: PR body lint
+
+"on":
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-body:
+    name: Validate PR body fields
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out trusted workflow scripts
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Check out bootstrap body linter before first merge
+        if: ${{ hashFiles('.github/scripts/validate_pr_body.py') == '' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Validate PR body fields
+        env:
+          PR_BODY_LINT_STRICT: "0"
+        run: python3 .github/scripts/validate_pr_body.py

--- a/tests/test_ci/test_pr_body_lint.py
+++ b/tests/test_ci/test_pr_body_lint.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _load_lint_module():
+    script = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "validate_pr_body.py"
+    spec = importlib.util.spec_from_file_location("validate_pr_body", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pr_body_lint_accepts_complete_structured_template_body() -> None:
+    lint = _load_lint_module()
+
+    body = "\n".join(
+        [
+            "Scope boundary: update CI governance",
+            "Base branch: dev",
+            "Main exception: N/A",
+            "Linked issue: Refs #210",
+            "Release note: NONE",
+            "Tests:",
+            "Ruff: uv run ruff check tests",
+            "Pytest: uv run pytest tests/test_ci -q",
+            "Build: not run locally; CI only",
+            "Maintainer live check: no",
+            "Third-party origin: none",
+        ]
+    )
+
+    assert lint.missing_fields(body) == []
+
+
+def test_pr_body_lint_accepts_repository_template_fields() -> None:
+    lint = _load_lint_module()
+    template = Path(".github/pull_request_template.md").read_text(encoding="utf-8")
+
+    assert lint.missing_fields(template) == []
+
+
+def test_pr_body_lint_warns_for_old_unstructured_checklist() -> None:
+    lint = _load_lint_module()
+
+    missing = lint.missing_fields("- [ ] I ran `uv run pytest -q`.")
+
+    assert "Scope boundary" in missing
+    assert "Base branch" in missing
+    assert "Linked issue" in missing
+    assert "Release note" in missing
+    assert "Maintainer live check" in missing
+
+
+def test_pr_body_lint_is_warning_only_for_incomplete_body(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps({"pull_request": {"body": "Fixes #100"}}),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["GITHUB_EVENT_PATH"] = event_path.as_posix()
+    env["PR_BODY_LINT_STRICT"] = "0"
+    result = subprocess.run(
+        [
+            sys.executable,
+            ".github/scripts/validate_pr_body.py",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "::warning title=Missing PR template field::" in result.stdout
+    assert "Scope boundary" in result.stdout
+
+
+def test_pr_body_lint_can_fail_in_strict_mode(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps({"pull_request": {"body": "Fixes #100"}}),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["GITHUB_EVENT_PATH"] = event_path.as_posix()
+    env["PR_BODY_LINT_STRICT"] = "1"
+    result = subprocess.run(
+        [
+            sys.executable,
+            ".github/scripts/validate_pr_body.py",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "::warning title=Missing PR template field::" in result.stdout
+
+
+def test_pr_body_lint_handles_missing_event_path_as_warning_only() -> None:
+    env = os.environ.copy()
+    env.pop("GITHUB_EVENT_PATH", None)
+    env["PR_BODY_LINT_STRICT"] = "0"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            ".github/scripts/validate_pr_body.py",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "::warning title=Missing PR event::" in result.stdout

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -13,6 +13,7 @@ import yaml
 WORKFLOW_DIR = Path(".github/workflows")
 CLASSIFIER = Path(".github/scripts/classify-ci-changes.sh")
 PR_TARGET_VALIDATOR = Path(".github/scripts/validate-pr-target-branch.sh")
+PR_BODY_LINT = Path(".github/scripts/validate_pr_body.py")
 TEST_PATH_RE = re.compile(r"tests/[A-Za-z0-9_./-]+\.py")
 
 
@@ -150,7 +151,7 @@ def _validate_pr_target(
     )
 
 
-def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
+def test_default_ci_blocks_pull_requests_and_main_and_dev_pushes() -> None:
     ci_path = WORKFLOW_DIR / "ci.yml"
     if not ci_path.exists():
         return
@@ -159,7 +160,7 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     text = ci_path.read_text(encoding="utf-8")
 
     assert {"pull_request", "push", "workflow_dispatch"} <= _trigger_keys(data)
-    assert "branches: [main]" in text
+    assert "branches: [main, dev]" in text
     assert "PYTHONPATH: ${{ github.workspace }}" in text
     assert "Configure runtime directories" in text
     assert 'OPENSQUILLA_STATE_DIR=%s/opensquilla-state\\n' in text
@@ -198,7 +199,9 @@ def test_pr_target_validator_blocks_ordinary_main_pull_requests(tmp_path: Path) 
     assert "Ordinary pull requests should target dev" in result.stderr
 
 
-def test_pr_target_validator_allows_docs_only_main_pull_requests(tmp_path: Path) -> None:
+def test_pr_target_validator_blocks_unlabeled_docs_only_main_pull_requests(
+    tmp_path: Path,
+) -> None:
     result = _validate_pr_target(
         tmp_path,
         base="main",
@@ -207,14 +210,23 @@ def test_pr_target_validator_allows_docs_only_main_pull_requests(tmp_path: Path)
         changed_files=["docs/testing/framework.md"],
     )
 
-    assert result.returncode == 0
-    assert "Pull request targets main with documentation-only changes." in result.stdout
+    assert result.returncode == 1
+    assert "Ordinary pull requests should target dev" in result.stderr
 
 
 def test_pr_target_validator_allows_maintainer_labeled_main_pull_requests(
     tmp_path: Path,
 ) -> None:
-    for label in ["allow-main-target", "release", "hotfix", "sync-to-main", "docs-preview"]:
+    labels = [
+        "allow-main-target",
+        "release",
+        "hotfix",
+        "main-sync",
+        "release-docs",
+        "sync-to-main",
+        "docs-preview",
+    ]
+    for label in labels:
         result = _validate_pr_target(
             tmp_path,
             base="main",
@@ -224,6 +236,75 @@ def test_pr_target_validator_allows_maintainer_labeled_main_pull_requests(
         )
 
         assert result.returncode == 0
+        assert "Pull request targets main with maintainer approval label." in result.stdout
+
+
+def test_pr_target_validator_allows_staging_branch_pull_requests(
+    tmp_path: Path,
+) -> None:
+    for base in [
+        "sandbox-optimization",
+        "integration/sandbox-hardening",
+        "staging/sandbox-hardening",
+        "release/0.3.2",
+    ]:
+        result = _validate_pr_target(
+            tmp_path,
+            base=base,
+            head="pr/sandbox-run-modes-sandbox-optimization",
+            changed_files=["src/opensquilla/sandbox/backend/windows_appcontainer.py"],
+        )
+
+        assert result.returncode == 0
+        assert "staging/collaboration" in result.stdout
+        assert "final integration" in result.stdout
+
+
+def test_pr_target_validator_allows_labeled_staging_pull_requests(
+    tmp_path: Path,
+) -> None:
+    for label in ["maintainer-staging", "collaboration"]:
+        result = _validate_pr_target(
+            tmp_path,
+            base="sandbox-review",
+            head="feature/shared-sandbox-work",
+            labels=[label],
+            changed_files=["src/opensquilla/sandbox/policy.py"],
+        )
+
+        assert result.returncode == 0
+        assert "staging/collaboration" in result.stdout
+
+
+def test_pr_target_validator_blocks_unknown_target_branches(tmp_path: Path) -> None:
+    result = _validate_pr_target(
+        tmp_path,
+        base="feature/private-target",
+        head="feature/example",
+        changed_files=["src/opensquilla/engine/agent.py"],
+    )
+
+    assert result.returncode == 1
+    assert "Ordinary pull requests should target dev" in result.stderr
+
+
+def test_pr_target_validator_handles_missing_event_path() -> None:
+    env = os.environ.copy()
+    env.pop("GITHUB_EVENT_PATH", None)
+    env.pop("PR_LABELS", None)
+    env["PR_BASE_REF"] = "feature/private-target"
+
+    result = subprocess.run(
+        [_bash_executable(), PR_TARGET_VALIDATOR.as_posix()],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Ordinary pull requests should target dev" in result.stderr
+    assert "Traceback" not in result.stderr
 
 
 def test_pr_target_branch_workflow_runs_trusted_base_validator() -> None:
@@ -240,6 +321,34 @@ def test_pr_target_branch_workflow_runs_trusted_base_validator() -> None:
     assert "PR_LABELS" in text
     assert "PR_NUMBER" in text
     assert ".github/scripts/validate-pr-target-branch.sh" in text
+
+
+def test_pr_body_lint_workflow_warns_from_trusted_base() -> None:
+    data = _workflow("pr-body-lint.yml")
+    text = (WORKFLOW_DIR / "pr-body-lint.yml").read_text(encoding="utf-8")
+
+    assert _trigger_keys(data) == {"pull_request"}
+    assert "pull_request_target" not in text
+    assert "Validate PR body fields" in text
+    assert "github.event.repository.default_branch" in text
+    assert "hashFiles('.github/scripts/validate_pr_body.py') == ''" in text
+    assert "github.event.pull_request.head.sha" in text
+    assert "pull-requests: read" in text
+    assert PR_BODY_LINT.as_posix() in text
+    assert "PR_BODY_LINT_STRICT: \"0\"" in text
+
+
+def test_issue_link_sync_tracks_open_and_closed_final_prs_from_trusted_base() -> None:
+    data = _workflow("issue-link-sync.yml")
+    text = (WORKFLOW_DIR / "issue-link-sync.yml").read_text(encoding="utf-8")
+
+    pull_request_target = data["on"]["pull_request_target"]
+    assert set(pull_request_target["types"]) == {"opened", "reopened", "edited", "closed"}
+    assert pull_request_target["branches"] == ["main", "dev"]
+    assert "ref: ${{ github.event.pull_request.base.sha }}" in text
+    assert "persist-credentials: false" in text
+    assert "issues: write" in text
+    assert ".github/scripts/issue_link_sync.py" in text
 
 
 def test_ci_change_classifier_allows_root_and_docs_markdown_only(tmp_path: Path) -> None:

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -360,10 +360,18 @@ def test_issue_link_sync_tracks_open_and_closed_final_prs_from_trusted_base() ->
 
     pull_request_target = data["on"]["pull_request_target"]
     assert set(pull_request_target["types"]) == {"opened", "reopened", "edited", "closed"}
-    assert pull_request_target["branches"] == ["main", "dev"]
+    assert pull_request_target["branches"] == [
+        "main",
+        "dev",
+        "sandbox-*",
+        "integration/*",
+        "staging/*",
+        "release/*",
+    ]
     assert "ref: ${{ github.event.pull_request.base.sha }}" in text
     assert "persist-credentials: false" in text
     assert "issues: write" in text
+    assert "pull-requests: read" in text
     assert ".github/scripts/issue_link_sync.py" in text
 
 

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -376,14 +376,7 @@ def test_issue_link_sync_tracks_open_and_closed_final_prs_from_trusted_base() ->
 
     pull_request_target = data["on"]["pull_request_target"]
     assert set(pull_request_target["types"]) == {"opened", "reopened", "edited", "closed"}
-    assert pull_request_target["branches"] == [
-        "main",
-        "dev",
-        "sandbox-*",
-        "integration/*",
-        "staging/*",
-        "release/*",
-    ]
+    assert "branches" not in pull_request_target
     assert "ref: ${{ github.event.pull_request.base.sha }}" in text
     assert "persist-credentials: false" in text
     assert "issues: write" in text

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -292,6 +292,22 @@ def test_pr_target_validator_allows_labeled_staging_pull_requests(
         assert "staging/collaboration" in result.stdout
 
 
+def test_pr_target_validator_blocks_label_only_unknown_collaboration_targets(
+    tmp_path: Path,
+) -> None:
+    for label in ["maintainer-staging", "collaboration"]:
+        result = _validate_pr_target(
+            tmp_path,
+            base="feature/shared-work",
+            head="feature/shared-sandbox-work",
+            labels=[label],
+            changed_files=["src/opensquilla/sandbox/policy.py"],
+        )
+
+        assert result.returncode == 1
+        assert "Ordinary pull requests should target dev" in result.stderr
+
+
 def test_pr_target_validator_blocks_unknown_target_branches(tmp_path: Path) -> None:
     result = _validate_pr_target(
         tmp_path,

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -239,6 +239,22 @@ def test_pr_target_validator_allows_maintainer_labeled_main_pull_requests(
         assert "Pull request targets main with maintainer approval label." in result.stdout
 
 
+def test_pr_target_validator_blocks_main_pull_requests_with_only_staging_labels(
+    tmp_path: Path,
+) -> None:
+    for label in ["maintainer-staging", "collaboration"]:
+        result = _validate_pr_target(
+            tmp_path,
+            base="main",
+            head="feature/shared-sandbox-work",
+            labels=[label],
+            changed_files=["src/opensquilla/sandbox/policy.py"],
+        )
+
+        assert result.returncode == 1
+        assert "Ordinary pull requests should target dev" in result.stderr
+
+
 def test_pr_target_validator_allows_staging_branch_pull_requests(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_github_issue_link_sync.py
+++ b/tests/test_github_issue_link_sync.py
@@ -4,6 +4,15 @@ import importlib.util
 from pathlib import Path
 from typing import Any
 
+DUMMY_MERGED_DEV_PR = 9001
+DUMMY_CLOSED_PR = 9002
+DUMMY_OPEN_PR = 9003
+DUMMY_MERGED_MAIN_PR = 9004
+DUMMY_MERGED_DEV_PR_URL = "https://example.invalid/pulls/9001"
+DUMMY_CLOSED_PR_URL = "https://example.invalid/pulls/9002"
+DUMMY_OPEN_PR_URL = "https://example.invalid/pulls/9003"
+DUMMY_MERGED_MAIN_PR_URL = "https://example.invalid/pulls/9004"
+
 
 def _load_sync_module():
     script = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "issue_link_sync.py"
@@ -76,7 +85,7 @@ def test_parse_linked_issues_deduplicates_and_ignores_pr_style_urls() -> None:
             [
                 "Fixes #100",
                 "fixes #100",
-                "Refs https://github.com/opensquilla/opensquilla/pull/203",
+                "Refs https://github.com/opensquilla/opensquilla/pull/9999",
                 "Fixes https://github.com/opensquilla/opensquilla/issues/101",
             ]
         ),
@@ -96,11 +105,11 @@ def test_plan_merged_dev_pr_updates_only_closing_issues() -> None:
         {
             "action": "closed",
             "pull_request": {
-                "number": 203,
+                "number": DUMMY_MERGED_DEV_PR,
                 "merged": True,
                 "body": "Fixes #100\nRefs #200",
                 "base": {"ref": "dev"},
-                "html_url": "https://github.com/opensquilla/opensquilla/pull/203",
+                "html_url": DUMMY_MERGED_DEV_PR_URL,
             },
             "repository": {
                 "full_name": "opensquilla/opensquilla",
@@ -112,8 +121,85 @@ def test_plan_merged_dev_pr_updates_only_closing_issues() -> None:
         sync.IssueSyncAction(
             issue_number=100,
             kind="merged_to_dev",
-            pr_number=203,
-            pr_url="https://github.com/opensquilla/opensquilla/pull/203",
+            pr_number=DUMMY_MERGED_DEV_PR,
+            pr_url=DUMMY_MERGED_DEV_PR_URL,
+        ),
+        sync.IssueSyncAction(
+            issue_number=200,
+            kind="remove_linked_pr",
+            pr_number=DUMMY_MERGED_DEV_PR,
+            pr_url=DUMMY_MERGED_DEV_PR_URL,
+        ),
+    )
+
+
+def test_plan_open_or_updated_pr_adds_linked_pr_label_to_all_linked_issues() -> None:
+    sync = _load_sync_module()
+
+    for action_name in ["opened", "reopened", "edited"]:
+        actions = sync.plan_issue_sync_actions(
+            {
+                "action": action_name,
+                "pull_request": {
+                    "number": DUMMY_OPEN_PR,
+                    "merged": False,
+                    "body": "Fixes #100\nRefs #200",
+                    "base": {"ref": "dev"},
+                    "html_url": DUMMY_OPEN_PR_URL,
+                },
+                "repository": {
+                    "full_name": "opensquilla/opensquilla",
+                },
+            }
+        )
+
+        assert actions == (
+            sync.IssueSyncAction(
+                issue_number=100,
+                kind="linked_pr_open",
+                pr_number=DUMMY_OPEN_PR,
+                pr_url=DUMMY_OPEN_PR_URL,
+            ),
+            sync.IssueSyncAction(
+                issue_number=200,
+                kind="linked_pr_open",
+                pr_number=DUMMY_OPEN_PR,
+                pr_url=DUMMY_OPEN_PR_URL,
+            ),
+        )
+
+
+def test_plan_merged_main_pr_removes_linked_pr_label_without_dev_status() -> None:
+    sync = _load_sync_module()
+
+    actions = sync.plan_issue_sync_actions(
+        {
+            "action": "closed",
+            "pull_request": {
+                "number": DUMMY_MERGED_MAIN_PR,
+                "merged": True,
+                "body": "Fixes #100\nRefs #200",
+                "base": {"ref": "main"},
+                "html_url": DUMMY_MERGED_MAIN_PR_URL,
+            },
+            "repository": {
+                "full_name": "opensquilla/opensquilla",
+            },
+        }
+    )
+
+    assert actions == (
+        sync.IssueSyncAction(
+            issue_number=100,
+            kind="remove_linked_pr",
+            pr_number=DUMMY_MERGED_MAIN_PR,
+            pr_url=DUMMY_MERGED_MAIN_PR_URL,
+        ),
+        sync.IssueSyncAction(
+            issue_number=200,
+            kind="remove_linked_pr",
+            pr_number=DUMMY_MERGED_MAIN_PR,
+            pr_url=DUMMY_MERGED_MAIN_PR_URL,
         ),
     )
 
@@ -125,11 +211,11 @@ def test_plan_closed_unmerged_pr_removes_linked_pr_label_from_all_linked_issues(
         {
             "action": "closed",
             "pull_request": {
-                "number": 204,
+                "number": DUMMY_CLOSED_PR,
                 "merged": False,
                 "body": "Fixes #100\nRefs #200",
                 "base": {"ref": "dev"},
-                "html_url": "https://github.com/opensquilla/opensquilla/pull/204",
+                "html_url": DUMMY_CLOSED_PR_URL,
             },
             "repository": {
                 "full_name": "opensquilla/opensquilla",
@@ -141,14 +227,14 @@ def test_plan_closed_unmerged_pr_removes_linked_pr_label_from_all_linked_issues(
         sync.IssueSyncAction(
             issue_number=100,
             kind="closed_unmerged",
-            pr_number=204,
-            pr_url="https://github.com/opensquilla/opensquilla/pull/204",
+            pr_number=DUMMY_CLOSED_PR,
+            pr_url=DUMMY_CLOSED_PR_URL,
         ),
         sync.IssueSyncAction(
             issue_number=200,
             kind="closed_unmerged",
-            pr_number=204,
-            pr_url="https://github.com/opensquilla/opensquilla/pull/204",
+            pr_number=DUMMY_CLOSED_PR,
+            pr_url=DUMMY_CLOSED_PR_URL,
         ),
     )
 
@@ -156,12 +242,12 @@ def test_plan_closed_unmerged_pr_removes_linked_pr_label_from_all_linked_issues(
 def test_comment_marker_is_pr_scoped_for_idempotent_merged_to_dev_comments() -> None:
     sync = _load_sync_module()
 
-    marker = sync.comment_marker(kind="merged_to_dev", pr_number=203)
+    marker = sync.comment_marker(kind="merged_to_dev", pr_number=DUMMY_MERGED_DEV_PR)
 
-    assert marker == "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-203 -->"
+    assert marker == "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9001 -->"
     assert sync.has_marker([{"body": f"{marker}\nThis is already posted."}], marker)
     assert not sync.has_marker(
-        [{"body": "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-202 -->"}],
+        [{"body": "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9000 -->"}],
         marker,
     )
 
@@ -171,8 +257,8 @@ def test_apply_merged_dev_action_labels_removes_open_pr_label_and_comments_once(
     action = sync.IssueSyncAction(
         issue_number=100,
         kind="merged_to_dev",
-        pr_number=203,
-        pr_url="https://github.com/opensquilla/opensquilla/pull/203",
+        pr_number=DUMMY_MERGED_DEV_PR,
+        pr_url=DUMMY_MERGED_DEV_PR_URL,
     )
     client = RecordingClient()
 
@@ -185,14 +271,14 @@ def test_apply_merged_dev_action_labels_removes_open_pr_label_and_comments_once(
         (
             "create_comment",
             100,
-            "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-203 -->\n"
-            "The linked fix for this issue has merged to `dev` via #203 "
-            "(https://github.com/opensquilla/opensquilla/pull/203). "
+            "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9001 -->\n"
+            "The linked fix for this issue has merged to `dev` via #9001 "
+            f"({DUMMY_MERGED_DEV_PR_URL}). "
             "Keeping it open for verification before release.",
         ),
     ]
 
-    marker = sync.comment_marker(kind="merged_to_dev", pr_number=203)
+    marker = sync.comment_marker(kind="merged_to_dev", pr_number=DUMMY_MERGED_DEV_PR)
     client = RecordingClient(comments=[{"body": marker}])
 
     sync.apply_action(client, action)
@@ -204,13 +290,43 @@ def test_apply_merged_dev_action_labels_removes_open_pr_label_and_comments_once(
     ]
 
 
+def test_apply_open_linked_pr_action_adds_open_pr_label() -> None:
+    sync = _load_sync_module()
+    action = sync.IssueSyncAction(
+        issue_number=100,
+        kind="linked_pr_open",
+        pr_number=DUMMY_OPEN_PR,
+        pr_url=DUMMY_OPEN_PR_URL,
+    )
+    client = RecordingClient()
+
+    sync.apply_action(client, action)
+
+    assert client.calls == [("add_labels", 100, ("has-linked-pr",))]
+
+
+def test_apply_remove_linked_pr_action_only_removes_open_pr_label() -> None:
+    sync = _load_sync_module()
+    action = sync.IssueSyncAction(
+        issue_number=200,
+        kind="remove_linked_pr",
+        pr_number=DUMMY_MERGED_MAIN_PR,
+        pr_url=DUMMY_MERGED_MAIN_PR_URL,
+    )
+    client = RecordingClient()
+
+    sync.apply_action(client, action)
+
+    assert client.calls == [("remove_label", 200, "has-linked-pr")]
+
+
 def test_apply_closed_unmerged_action_only_removes_open_pr_label() -> None:
     sync = _load_sync_module()
     action = sync.IssueSyncAction(
         issue_number=200,
         kind="closed_unmerged",
-        pr_number=204,
-        pr_url="https://github.com/opensquilla/opensquilla/pull/204",
+        pr_number=DUMMY_CLOSED_PR,
+        pr_url=DUMMY_CLOSED_PR_URL,
     )
     client = RecordingClient()
 
@@ -224,7 +340,7 @@ def test_list_comments_reads_all_pages_before_idempotency_check() -> None:
     client = PaginatedGitHubClient(
         [
             [{"body": f"old comment {index}"} for index in range(100)],
-            [{"body": "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-203 -->"}],
+            [{"body": "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9001 -->"}],
         ]
     )
 
@@ -232,7 +348,7 @@ def test_list_comments_reads_all_pages_before_idempotency_check() -> None:
 
     assert sync.has_marker(
         comments,
-        "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-203 -->",
+        "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9001 -->",
     )
     assert client.paths == [
         "/issues/100/comments?per_page=100&page=1",

--- a/tests/test_github_issue_link_sync.py
+++ b/tests/test_github_issue_link_sync.py
@@ -249,7 +249,76 @@ def test_plan_edited_closed_pr_does_not_readd_open_pr_label() -> None:
     assert actions == ()
 
 
-def test_plan_merged_main_pr_removes_linked_pr_label_without_dev_status() -> None:
+def test_plan_edited_pr_retargeted_from_final_base_removes_linked_labels() -> None:
+    sync = _load_sync_module()
+
+    actions = sync.plan_issue_sync_actions(
+        {
+            "action": "edited",
+            "changes": {
+                "base": {
+                    "ref": {
+                        "from": "dev",
+                    },
+                },
+                "body": {
+                    "from": "Fixes #100",
+                },
+            },
+            "pull_request": {
+                "number": DUMMY_OPEN_PR,
+                "state": "open",
+                "merged": False,
+                "body": "Refs #200",
+                "base": {"ref": "sandbox-optimization"},
+                "html_url": DUMMY_OPEN_PR_URL,
+            },
+            "repository": {
+                "full_name": "opensquilla/opensquilla",
+            },
+        }
+    )
+
+    assert actions == (
+        sync.IssueSyncAction(
+            issue_number=200,
+            kind="remove_linked_pr",
+            pr_number=DUMMY_OPEN_PR,
+            pr_url=DUMMY_OPEN_PR_URL,
+        ),
+        sync.IssueSyncAction(
+            issue_number=100,
+            kind="remove_linked_pr",
+            pr_number=DUMMY_OPEN_PR,
+            pr_url=DUMMY_OPEN_PR_URL,
+        ),
+    )
+
+
+def test_plan_open_staging_pr_does_not_add_linked_pr_label() -> None:
+    sync = _load_sync_module()
+
+    actions = sync.plan_issue_sync_actions(
+        {
+            "action": "opened",
+            "pull_request": {
+                "number": DUMMY_OPEN_PR,
+                "state": "open",
+                "merged": False,
+                "body": "Fixes #100",
+                "base": {"ref": "sandbox-optimization"},
+                "html_url": DUMMY_OPEN_PR_URL,
+            },
+            "repository": {
+                "full_name": "opensquilla/opensquilla",
+            },
+        }
+    )
+
+    assert actions == ()
+
+
+def test_plan_merged_main_pr_releases_closing_issues_and_removes_open_labels() -> None:
     sync = _load_sync_module()
 
     actions = sync.plan_issue_sync_actions(
@@ -271,7 +340,7 @@ def test_plan_merged_main_pr_removes_linked_pr_label_without_dev_status() -> Non
     assert actions == (
         sync.IssueSyncAction(
             issue_number=100,
-            kind="remove_linked_pr",
+            kind="merged_to_main",
             pr_number=DUMMY_MERGED_MAIN_PR,
             pr_url=DUMMY_MERGED_MAIN_PR_URL,
         ),
@@ -464,6 +533,45 @@ def test_apply_remove_action_keeps_label_when_another_open_pr_links_issue() -> N
 
     assert client.calls == [
         ("has_other_open_linked_pull_request", 200, DUMMY_CLOSED_PR),
+    ]
+
+
+def test_apply_merged_main_action_clears_dev_verification_labels() -> None:
+    sync = _load_sync_module()
+    action = sync.IssueSyncAction(
+        issue_number=100,
+        kind="merged_to_main",
+        pr_number=DUMMY_MERGED_MAIN_PR,
+        pr_url=DUMMY_MERGED_MAIN_PR_URL,
+    )
+    client = RecordingClient()
+
+    sync.apply_action(client, action)
+
+    assert client.calls == [
+        ("has_other_open_linked_pull_request", 100, DUMMY_MERGED_MAIN_PR),
+        ("remove_label", 100, "has-linked-pr"),
+        ("remove_label", 100, "merged-to-dev"),
+        ("remove_label", 100, "needs-verification"),
+    ]
+
+
+def test_apply_merged_main_action_keeps_open_label_when_another_pr_remains() -> None:
+    sync = _load_sync_module()
+    action = sync.IssueSyncAction(
+        issue_number=100,
+        kind="merged_to_main",
+        pr_number=DUMMY_MERGED_MAIN_PR,
+        pr_url=DUMMY_MERGED_MAIN_PR_URL,
+    )
+    client = RecordingClient(other_open_linked_issues={100})
+
+    sync.apply_action(client, action)
+
+    assert client.calls == [
+        ("has_other_open_linked_pull_request", 100, DUMMY_MERGED_MAIN_PR),
+        ("remove_label", 100, "merged-to-dev"),
+        ("remove_label", 100, "needs-verification"),
     ]
 
 

--- a/tests/test_github_issue_link_sync.py
+++ b/tests/test_github_issue_link_sync.py
@@ -295,6 +295,52 @@ def test_plan_edited_pr_retargeted_from_final_base_removes_linked_labels() -> No
     )
 
 
+def test_plan_edited_pr_retargeted_from_final_base_to_unknown_base_removes_linked_labels() -> None:
+    sync = _load_sync_module()
+
+    actions = sync.plan_issue_sync_actions(
+        {
+            "action": "edited",
+            "changes": {
+                "base": {
+                    "ref": {
+                        "from": "dev",
+                    },
+                },
+                "body": {
+                    "from": "Fixes #100",
+                },
+            },
+            "pull_request": {
+                "number": DUMMY_OPEN_PR,
+                "state": "open",
+                "merged": False,
+                "body": "Refs #200",
+                "base": {"ref": "feature/shared-work"},
+                "html_url": DUMMY_OPEN_PR_URL,
+            },
+            "repository": {
+                "full_name": "opensquilla/opensquilla",
+            },
+        }
+    )
+
+    assert actions == (
+        sync.IssueSyncAction(
+            issue_number=200,
+            kind="remove_linked_pr",
+            pr_number=DUMMY_OPEN_PR,
+            pr_url=DUMMY_OPEN_PR_URL,
+        ),
+        sync.IssueSyncAction(
+            issue_number=100,
+            kind="remove_linked_pr",
+            pr_number=DUMMY_OPEN_PR,
+            pr_url=DUMMY_OPEN_PR_URL,
+        ),
+    )
+
+
 def test_plan_open_staging_pr_does_not_add_linked_pr_label() -> None:
     sync = _load_sync_module()
 
@@ -308,6 +354,28 @@ def test_plan_open_staging_pr_does_not_add_linked_pr_label() -> None:
                 "body": "Fixes #100",
                 "base": {"ref": "sandbox-optimization"},
                 "html_url": DUMMY_OPEN_PR_URL,
+            },
+            "repository": {
+                "full_name": "opensquilla/opensquilla",
+            },
+        }
+    )
+
+    assert actions == ()
+
+
+def test_plan_closed_non_final_pr_does_not_remove_linked_pr_label() -> None:
+    sync = _load_sync_module()
+
+    actions = sync.plan_issue_sync_actions(
+        {
+            "action": "closed",
+            "pull_request": {
+                "number": DUMMY_CLOSED_PR,
+                "merged": False,
+                "body": "Fixes #100\nRefs #200",
+                "base": {"ref": "feature/shared-work"},
+                "html_url": DUMMY_CLOSED_PR_URL,
             },
             "repository": {
                 "full_name": "opensquilla/opensquilla",

--- a/tests/test_github_issue_link_sync.py
+++ b/tests/test_github_issue_link_sync.py
@@ -581,7 +581,11 @@ def test_github_client_detects_other_open_pull_requests_linking_issue() -> None:
         [
             [
                 {"number": DUMMY_OPEN_PR, "body": "Fixes #100"},
-                {"number": DUMMY_CLOSED_PR, "body": "Refs #200"},
+                {
+                    "number": DUMMY_CLOSED_PR,
+                    "body": "Refs #200",
+                    "base": {"ref": "dev"},
+                },
             ],
         ]
     )
@@ -590,6 +594,28 @@ def test_github_client_detects_other_open_pull_requests_linking_issue() -> None:
         client,
         issue_number=200,
         pr_number=DUMMY_OPEN_PR,
+    )
+    assert client.paths == ["/pulls?state=open&per_page=100&page=1"]
+
+
+def test_github_client_ignores_non_final_open_pull_requests_when_preserving_labels() -> None:
+    sync = _load_sync_module()
+    client = PaginatedGitHubClient(
+        [
+            [
+                {
+                    "number": DUMMY_OPEN_PR,
+                    "body": "Refs #200",
+                    "base": {"ref": "sandbox-optimization"},
+                },
+            ],
+        ]
+    )
+
+    assert not sync.GitHubClient.has_other_open_linked_pull_request(
+        client,
+        issue_number=200,
+        pr_number=DUMMY_CLOSED_PR,
     )
     assert client.paths == ["/pulls?state=open&per_page=100&page=1"]
 

--- a/tests/test_github_issue_link_sync.py
+++ b/tests/test_github_issue_link_sync.py
@@ -25,8 +25,13 @@ def _load_sync_module():
 
 
 class RecordingClient:
-    def __init__(self, comments: list[dict[str, Any]] | None = None) -> None:
+    def __init__(
+        self,
+        comments: list[dict[str, Any]] | None = None,
+        other_open_linked_issues: set[int] | None = None,
+    ) -> None:
         self.comments = comments or []
+        self.other_open_linked_issues = other_open_linked_issues or set()
         self.calls: list[tuple[Any, ...]] = []
 
     def add_labels(self, issue_number: int, labels: list[str]) -> None:
@@ -42,16 +47,26 @@ class RecordingClient:
     def create_comment(self, issue_number: int, body: str) -> None:
         self.calls.append(("create_comment", issue_number, body))
 
+    def has_other_open_linked_pull_request(self, issue_number: int, pr_number: int) -> bool:
+        self.calls.append(("has_other_open_linked_pull_request", issue_number, pr_number))
+        return issue_number in self.other_open_linked_issues
+
 
 class PaginatedGitHubClient:
     def __init__(self, pages: list[list[dict[str, Any]]]) -> None:
         self.pages = pages
+        self._repository = "opensquilla/opensquilla"
         self.paths: list[str] = []
 
-    def request_json(self, method: str, path: str) -> list[dict[str, Any]]:
+    def request_json(self, method: str, path: str, **_kwargs: Any) -> list[dict[str, Any]]:
         assert method == "GET"
         self.paths.append(path)
         return self.pages.pop(0)
+
+    def list_open_pull_requests(self) -> list[dict[str, Any]]:
+        pulls = self.request_json("GET", "/pulls?state=open&per_page=100&page=1")
+        assert isinstance(pulls, list)
+        return pulls
 
 
 def test_parse_linked_issues_splits_closing_and_reference_keywords() -> None:
@@ -142,6 +157,7 @@ def test_plan_open_or_updated_pr_adds_linked_pr_label_to_all_linked_issues() -> 
                 "action": action_name,
                 "pull_request": {
                     "number": DUMMY_OPEN_PR,
+                    "state": "open",
                     "merged": False,
                     "body": "Fixes #100\nRefs #200",
                     "base": {"ref": "dev"},
@@ -167,6 +183,70 @@ def test_plan_open_or_updated_pr_adds_linked_pr_label_to_all_linked_issues() -> 
                 pr_url=DUMMY_OPEN_PR_URL,
             ),
         )
+
+
+def test_plan_edited_open_pr_removes_links_deleted_from_body() -> None:
+    sync = _load_sync_module()
+
+    actions = sync.plan_issue_sync_actions(
+        {
+            "action": "edited",
+            "changes": {
+                "body": {
+                    "from": "Fixes #100\nRefs #200",
+                },
+            },
+            "pull_request": {
+                "number": DUMMY_OPEN_PR,
+                "state": "open",
+                "merged": False,
+                "body": "Refs #200",
+                "base": {"ref": "dev"},
+                "html_url": DUMMY_OPEN_PR_URL,
+            },
+            "repository": {
+                "full_name": "opensquilla/opensquilla",
+            },
+        }
+    )
+
+    assert actions == (
+        sync.IssueSyncAction(
+            issue_number=200,
+            kind="linked_pr_open",
+            pr_number=DUMMY_OPEN_PR,
+            pr_url=DUMMY_OPEN_PR_URL,
+        ),
+        sync.IssueSyncAction(
+            issue_number=100,
+            kind="remove_linked_pr",
+            pr_number=DUMMY_OPEN_PR,
+            pr_url=DUMMY_OPEN_PR_URL,
+        ),
+    )
+
+
+def test_plan_edited_closed_pr_does_not_readd_open_pr_label() -> None:
+    sync = _load_sync_module()
+
+    actions = sync.plan_issue_sync_actions(
+        {
+            "action": "edited",
+            "pull_request": {
+                "number": DUMMY_OPEN_PR,
+                "state": "closed",
+                "merged": True,
+                "body": "Fixes #100",
+                "base": {"ref": "dev"},
+                "html_url": DUMMY_OPEN_PR_URL,
+            },
+            "repository": {
+                "full_name": "opensquilla/opensquilla",
+            },
+        }
+    )
+
+    assert actions == ()
 
 
 def test_plan_merged_main_pr_removes_linked_pr_label_without_dev_status() -> None:
@@ -266,6 +346,7 @@ def test_apply_merged_dev_action_labels_removes_open_pr_label_and_comments_once(
 
     assert client.calls == [
         ("add_labels", 100, ("merged-to-dev", "needs-verification")),
+        ("has_other_open_linked_pull_request", 100, DUMMY_MERGED_DEV_PR),
         ("remove_label", 100, "has-linked-pr"),
         ("list_comments", 100),
         (
@@ -285,8 +366,36 @@ def test_apply_merged_dev_action_labels_removes_open_pr_label_and_comments_once(
 
     assert client.calls == [
         ("add_labels", 100, ("merged-to-dev", "needs-verification")),
+        ("has_other_open_linked_pull_request", 100, DUMMY_MERGED_DEV_PR),
         ("remove_label", 100, "has-linked-pr"),
         ("list_comments", 100),
+    ]
+
+
+def test_apply_merged_dev_action_keeps_open_pr_label_when_another_pr_remains() -> None:
+    sync = _load_sync_module()
+    action = sync.IssueSyncAction(
+        issue_number=100,
+        kind="merged_to_dev",
+        pr_number=DUMMY_MERGED_DEV_PR,
+        pr_url=DUMMY_MERGED_DEV_PR_URL,
+    )
+    client = RecordingClient(other_open_linked_issues={100})
+
+    sync.apply_action(client, action)
+
+    assert client.calls == [
+        ("add_labels", 100, ("merged-to-dev", "needs-verification")),
+        ("has_other_open_linked_pull_request", 100, DUMMY_MERGED_DEV_PR),
+        ("list_comments", 100),
+        (
+            "create_comment",
+            100,
+            "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9001 -->\n"
+            "The linked fix for this issue has merged to `dev` via #9001 "
+            f"({DUMMY_MERGED_DEV_PR_URL}). "
+            "Keeping it open for verification before release.",
+        ),
     ]
 
 
@@ -317,7 +426,10 @@ def test_apply_remove_linked_pr_action_only_removes_open_pr_label() -> None:
 
     sync.apply_action(client, action)
 
-    assert client.calls == [("remove_label", 200, "has-linked-pr")]
+    assert client.calls == [
+        ("has_other_open_linked_pull_request", 200, DUMMY_MERGED_MAIN_PR),
+        ("remove_label", 200, "has-linked-pr"),
+    ]
 
 
 def test_apply_closed_unmerged_action_only_removes_open_pr_label() -> None:
@@ -332,7 +444,46 @@ def test_apply_closed_unmerged_action_only_removes_open_pr_label() -> None:
 
     sync.apply_action(client, action)
 
-    assert client.calls == [("remove_label", 200, "has-linked-pr")]
+    assert client.calls == [
+        ("has_other_open_linked_pull_request", 200, DUMMY_CLOSED_PR),
+        ("remove_label", 200, "has-linked-pr"),
+    ]
+
+
+def test_apply_remove_action_keeps_label_when_another_open_pr_links_issue() -> None:
+    sync = _load_sync_module()
+    action = sync.IssueSyncAction(
+        issue_number=200,
+        kind="closed_unmerged",
+        pr_number=DUMMY_CLOSED_PR,
+        pr_url=DUMMY_CLOSED_PR_URL,
+    )
+    client = RecordingClient(other_open_linked_issues={200})
+
+    sync.apply_action(client, action)
+
+    assert client.calls == [
+        ("has_other_open_linked_pull_request", 200, DUMMY_CLOSED_PR),
+    ]
+
+
+def test_github_client_detects_other_open_pull_requests_linking_issue() -> None:
+    sync = _load_sync_module()
+    client = PaginatedGitHubClient(
+        [
+            [
+                {"number": DUMMY_OPEN_PR, "body": "Fixes #100"},
+                {"number": DUMMY_CLOSED_PR, "body": "Refs #200"},
+            ],
+        ]
+    )
+
+    assert sync.GitHubClient.has_other_open_linked_pull_request(
+        client,
+        issue_number=200,
+        pr_number=DUMMY_OPEN_PR,
+    )
+    assert client.paths == ["/pulls?state=open&per_page=100&page=1"]
 
 
 def test_list_comments_reads_all_pages_before_idempotency_check() -> None:

--- a/tests/test_public_release_hygiene.py
+++ b/tests/test_public_release_hygiene.py
@@ -145,6 +145,30 @@ def test_public_testing_guidance_documents_the_private_boundary() -> None:
         assert phrase in combined
 
 
+def test_pull_request_template_uses_structured_governance_fields() -> None:
+    text = Path(".github/pull_request_template.md").read_text(encoding="utf-8")
+    required_phrases = [
+        "Scope boundary",
+        "Non-goals",
+        "Base branch: dev | main | staging/collaboration",
+        "Main exception: N/A | release | hotfix | release-docs | main-sync | maintainer-approved",
+        "Linked issue: Fixes #... | Refs #... | None",
+        "If None, reason",
+        "Release note: NONE |",
+        "Ruff:",
+        "Pytest:",
+        "Build:",
+        "Maintainer live check",
+        "contributors are not expected to provide secrets",
+        "Third-party origin",
+    ]
+
+    for phrase in required_phrases:
+        assert phrase in text
+
+    assert text.count("[ ]") <= 6
+
+
 def test_public_docs_do_not_use_key_shaped_placeholders() -> None:
     violations: list[str] = []
     placeholder_pattern = re.compile(r"sk-or-v1-[A-Za-z0-9_-]+")


### PR DESCRIPTION
## Scope

Scope boundary: Sync the dev PR target gate, structured PR template, warning-only PR body lint, CI dev push trigger, and issue-link lifecycle automation to the default/release branch.

Non-goals: This does not merge ordinary dev feature history into main and does not change release artifacts.

## Branch

Base branch: main

Main exception: main-sync

## Issue

Linked issue: Refs #210

If None, reason: N/A

## Release Note

Release note: NONE

## Tests

Ruff: uv run ruff check tests/test_ci/test_workflows.py tests/test_ci/test_pr_body_lint.py tests/test_public_release_hygiene.py tests/test_github_issue_link_sync.py .github/scripts/validate_pr_body.py .github/scripts/issue_link_sync.py

Pytest: uv run pytest tests/test_ci/test_workflows.py tests/test_ci/test_pr_body_lint.py tests/test_public_release_hygiene.py tests/test_github_issue_link_sync.py -q

Build: not run locally; CI only

Regression tests: added

Notes: shellcheck, actionlint, and git diff --check were also run locally.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [ ] Links point to existing repository files or stable external pages.
- [ ] Code fences and Markdown tables render correctly on GitHub.
- [ ] Examples avoid real secrets, local private paths, and private transcripts.
