### PR TITLE
fix(gateway): fallback to canonical transcript when active is empty for shared webchat sessions

### DIFF
--- a/src/opensquilla/gateway/rpc_chat.py
+++ b/src/opensquilla/gateway/rpc_chat.py
@@ -193,8 +193,23 @@ async def _chat_history_transcript(
     transcript_getter = getattr(mgr, "get_transcript", None)
     if not callable(transcript_getter):
         return [], False
-    transcript = await transcript_getter(session_key)
-    return list(transcript or []), False
+    transcript = list(await transcript_getter(session_key) or [])
+    if transcript:
+        return transcript, False
+    # Active transcript is empty — the session may have been compacted or
+    # reset while other users still expect to see history.  Fall back to the
+    # canonical transcript (archived + active) so shared sessions don't
+    # appear to "lose" messages after a compaction or page refresh.
+    if not include_canonical and _is_webchat_session_key(session_key):
+        getter = getattr(mgr, "get_canonical_transcript", None)
+        if callable(getter):
+            try:
+                canonical = list(await getter(session_key))
+                if canonical:
+                    return canonical, True
+            except Exception:  # noqa: BLE001
+                pass
+    return [], False
 
 
 async def _chat_history_summaries(

--- a/tests/test_gateway/test_rpc_chat_history.py
+++ b/tests/test_gateway/test_rpc_chat_history.py
@@ -495,3 +495,124 @@ async def test_chat_history_exposes_download_url_for_transcript_attachment_refs(
         f"/api/v1/attachments/{sha}?sessionKey=agent%3Amain%3Awebchat%3Atest"
         "&name=webchat-paste-test.txt&mime=text%2Fplain"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #127 — canonical fallback when includeCanonical=false & active empty
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_canonical_fallback_when_active_empty_and_include_canonical_false() -> None:
+    """After compaction the active transcript may be empty while the canonical
+    (archived + active) transcript still has entries.  The frontend sends
+    ``includeCanonical: false`` on page refresh; without the fallback, all
+    messages would vanish (issue #127)."""
+    canonical_entries = [_entry(1), _entry(2)]
+    mgr = _FakeSessionManager(
+        entries=[],  # active transcript emptied by compaction
+        canonical_entries=canonical_entries,
+    )
+
+    result = await _handle_chat_history(
+        {"sessionKey": "agent:main:webchat:default", "includeCanonical": False},
+        RpcContext(
+            conn_id="test",
+            principal=SimpleNamespace(role="operator"),
+            session_manager=mgr,
+        ),
+    )
+
+    assert mgr.used_canonical is True
+    assert [msg["text"] for msg in result["messages"]] == ["message 1", "message 2"]
+    assert result["canonical_available"] is True
+
+
+@pytest.mark.asyncio
+async def test_no_canonical_fallback_for_non_webchat_session() -> None:
+    """Non-webchat sessions (e.g. CLI) should NOT get the canonical fallback
+    when the active transcript is empty — they don't share sessions."""
+    mgr = _FakeSessionManager(
+        entries=[],
+        canonical_entries=[_entry(1, role="user")],
+    )
+
+    result = await _handle_chat_history(
+        {"sessionKey": "agent:main:cli:default", "includeCanonical": False},
+        RpcContext(
+            conn_id="test",
+            principal=SimpleNamespace(role="operator"),
+            session_manager=mgr,
+        ),
+    )
+
+    assert result["messages"] == []
+    assert result["canonical_available"] is False
+
+
+@pytest.mark.asyncio
+async def test_no_canonical_fallback_when_active_has_entries() -> None:
+    """If the active transcript is non-empty, canonical fallback should not
+    be triggered even for webchat sessions."""
+    active_entries = [_entry(5)]
+    canonical_entries = [_entry(1), _entry(5)]
+    mgr = _FakeSessionManager(
+        entries=active_entries,
+        canonical_entries=canonical_entries,
+    )
+
+    result = await _handle_chat_history(
+        {"sessionKey": "agent:main:webchat:default", "includeCanonical": False},
+        RpcContext(
+            conn_id="test",
+            principal=SimpleNamespace(role="operator"),
+            session_manager=mgr,
+        ),
+    )
+
+    assert [msg["text"] for msg in result["messages"]] == ["message 5"]
+    assert result["canonical_available"] is False
+
+
+@pytest.mark.asyncio
+async def test_canonical_fallback_returns_empty_when_both_empty() -> None:
+    """When both active and canonical transcripts are empty, the result should
+    still be an empty list — no spurious data."""
+    mgr = _FakeSessionManager(
+        entries=[],
+        canonical_entries=[],
+    )
+
+    result = await _handle_chat_history(
+        {"sessionKey": "agent:main:webchat:default", "includeCanonical": False},
+        RpcContext(
+            conn_id="test",
+            principal=SimpleNamespace(role="operator"),
+            session_manager=mgr,
+        ),
+    )
+
+    assert result["messages"] == []
+    assert result["canonical_available"] is False
+
+
+@pytest.mark.asyncio
+async def test_canonical_fallback_graceful_on_canonical_error() -> None:
+    """If canonical transcript raises an unexpected error, the fallback should
+    silently catch it and return empty — not propagate the exception."""
+    mgr = _FakeSessionManager(
+        entries=[],
+        canonical_exception=RuntimeError("db connection lost"),
+    )
+
+    result = await _handle_chat_history(
+        {"sessionKey": "agent:main:webchat:default", "includeCanonical": False},
+        RpcContext(
+            conn_id="test",
+            principal=SimpleNamespace(role="operator"),
+            session_manager=mgr,
+        ),
+    )
+
+    assert result["messages"] == []
+    assert result["canonical_available"] is False


### PR DESCRIPTION
## Issue for this PR

Closes #127

## Type of change

- [x] Bug fix

## What does this PR do?

### Problem

`_chat_history_transcript()` in `src/opensquilla/gateway/rpc_chat.py:180-212` returns the active transcript when `includeCanonical` is `false`. The WebChat frontend always sends `includeCanonical: false` on page refresh (`_loadHistory()` in `chat.js`).

All WebChat users share the same default session key `agent:main:webchat:default` (defined in `keys.py:build_webchat_key()`). When two users share this session:

1. User A sends messages → entries written to `transcript_entries` table
2. A compaction or session reset occurs → old entries archived to `compacted_transcript_entries`, deleted from active table
3. User B refreshes browser → `chat.history` with `includeCanonical: false` → queries only `transcript_entries` → **empty result**
4. All messages vanish from User B's screen

The same happens for User A on their next refresh. The `includeCanonical` parameter defaults to `true` on the backend, but the frontend explicitly overrides it to `false`, so the backend never queries the canonical (archived + active) transcript.

### Fix

Added a fallback in `_chat_history_transcript()` (line 199-211): after the active transcript returns empty for a webchat session when `includeCanonical` is `false`, the function now queries `get_canonical_transcript()` which performs a `UNION ALL` of `compacted_transcript_entries` + `transcript_entries`. This restores archived messages that were lost after compaction.

The fallback only triggers when:
- `includeCanonical` is `false` (frontend explicitly opted out of canonical)
- The active transcript is empty (no point fetching canonical again if active has data)
- The session key matches the webchat pattern (`agent:*:webchat:*`) — non-webchat sessions (CLI, subagent) are unaffected

### Files changed

- `src/opensquilla/gateway/rpc_chat.py` — `_chat_history_transcript()` adds 15-line fallback block
- `tests/test_gateway/test_rpc_chat_history.py` — 5 new tests covering the fallback behavior

## How did you verify your code works?

1. Ran the full test suite for chat history: `uv run pytest tests/test_gateway/test_rpc_chat_history.py -v` → **21 passed** (16 existing + 5 new)
2. New tests verify:
   - `test_canonical_fallback_when_active_empty_and_include_canonical_false` — core fix: empty active + webchat key + `includeCanonical: false` → falls back to canonical entries
   - `test_no_canonical_fallback_for_non_webchat_session` — CLI session key does NOT get fallback
   - `test_no_canonical_fallback_when_active_has_entries` — fallback not triggered when active has data
   - `test_canonical_fallback_returns_empty_when_both_empty` — no spurious data when both are empty
   - `test_canonical_fallback_graceful_on_canonical_error` — exceptions in canonical fetch are caught, returns empty
3. Verified existing tests still pass (no regression in pagination, cursors, artifacts, provenance, etc.)

## Screenshots / recordings

N/A — backend-only fix, no UI changes.

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR