### PR TITLE
Fix router fallback for region-unavailable models

### DIFF
--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -3993,7 +3993,23 @@ class TurnRunner:
 
         # Apply routed model back to cloned selector (local, not shared)
         if turn.model and cloned_selector is not None:
-            cloned_selector.override_model(turn.model)
+            router_fallback_chain = (
+                turn.metadata.get("router_fallback_chain")
+                if turn.metadata.get("routing_applied") is True
+                else None
+            )
+            override_with_fallback_chain = getattr(
+                cloned_selector,
+                "override_model_with_fallback_chain",
+                None,
+            )
+            if callable(override_with_fallback_chain) and isinstance(
+                router_fallback_chain,
+                list,
+            ):
+                override_with_fallback_chain(turn.model, router_fallback_chain)
+            else:
+                cloned_selector.override_model(turn.model)
             provider = cloned_selector.resolve()
 
         return turn, provider

--- a/src/opensquilla/engine/steps/squilla_router.py
+++ b/src/opensquilla/engine/steps/squilla_router.py
@@ -24,6 +24,7 @@ from opensquilla.router_tiers import (
     DEFAULT_TEXT_TIER,
     HIGHEST_TEXT_TIER,
     ROUTE_CLASS_TO_TIER,
+    TEXT_TIERS,
     TIER_TO_ROUTE_CLASS,
     normalize_text_tier,
 )
@@ -66,6 +67,34 @@ _ROUTER_RUNTIME_FALLBACK_MESSAGE = (
     "https://aka.ms/vs/17/release/vc_redist.x64.exe. After installing, reopen "
     "PowerShell and restart OpenSquilla."
 )
+
+
+def _router_text_fallback_chain(
+    selected_tier: object,
+    tiers: dict,
+) -> list[dict[str, str]]:
+    selected = normalize_text_tier(selected_tier)
+    if selected is None:
+        return []
+    try:
+        selected_index = TEXT_TIERS.index(selected)
+    except ValueError:
+        return []
+
+    chain: list[dict[str, str]] = []
+    for tier_name in reversed(TEXT_TIERS[:selected_index]):
+        tier_cfg = tiers.get(tier_name)
+        if not isinstance(tier_cfg, dict) or tier_cfg.get("image_only", False):
+            continue
+        model = str(tier_cfg.get("model") or "").strip()
+        if not model:
+            continue
+        provider = str(tier_cfg.get("provider") or "").strip()
+        entry = {"tier": tier_name, "model": model}
+        if provider:
+            entry["provider"] = provider
+        chain.append(entry)
+    return chain
 
 
 class RoutingHistoryStore:
@@ -1003,6 +1032,10 @@ async def apply_squilla_router(ctx: TurnContext) -> TurnContext:
             ctx.metadata["applied_model"] = ctx.model
             ctx.metadata["routing_confidence"] = decision.confidence
             ctx.metadata["routing_source"] = decision.source
+            ctx.metadata["router_fallback_chain"] = _router_text_fallback_chain(
+                decision.tier,
+                tiers,
+            )
             ctx.metadata["router_control_hold_applied"] = True
             ctx.metadata["router_control_action"] = "set_hold"
             ctx.metadata["router_control_target_tier"] = hold.tier
@@ -1163,6 +1196,10 @@ async def apply_squilla_router(ctx: TurnContext) -> TurnContext:
     ctx.metadata["applied_model"] = ctx.model
     ctx.metadata["routing_confidence"] = decision.confidence
     ctx.metadata["routing_source"] = decision.source
+    ctx.metadata["router_fallback_chain"] = _router_text_fallback_chain(
+        decision.tier,
+        tiers,
+    )
     ctx.metadata.update(_compute_savings(decision.model, tiers))
 
     context_states = ctx.metadata.get("session_context_states") or ctx.metadata.get(

--- a/src/opensquilla/engine/turn_runner/prompt_assembler_stage.py
+++ b/src/opensquilla/engine/turn_runner/prompt_assembler_stage.py
@@ -449,7 +449,23 @@ class PromptAssemblerStage:
         # 6. Effective runtime message + selector override / fallback wrap
         effective_runtime_message = getattr(turn, "message", inp.runtime_message)
         if inp.model and inp.cloned_selector is not None:
-            inp.cloned_selector.override_model(inp.model)
+            router_fallback_chain = (
+                turn.metadata.get("router_fallback_chain")
+                if turn.metadata.get("routing_applied") is True
+                else None
+            )
+            override_with_fallback_chain = getattr(
+                inp.cloned_selector,
+                "override_model_with_fallback_chain",
+                None,
+            )
+            if callable(override_with_fallback_chain) and isinstance(
+                router_fallback_chain,
+                list,
+            ):
+                override_with_fallback_chain(inp.model, router_fallback_chain)
+            else:
+                inp.cloned_selector.override_model(inp.model)
             provider = inp.cloned_selector.resolve()
         if inp.cloned_selector is not None:
             # Local import to avoid pulling _SelectorFallbackProvider name

--- a/src/opensquilla/provider/failures.py
+++ b/src/opensquilla/provider/failures.py
@@ -114,6 +114,20 @@ def _is_empty_response(raw_code: str, message: str) -> bool:
     }
 
 
+def _is_model_unavailable(text: str) -> bool:
+    return any(
+        marker in text
+        for marker in (
+            "no endpoints found",
+            "model not found",
+            "model is not available",
+            "model not available",
+            "not available in your region",
+            "not available in the requested region",
+        )
+    )
+
+
 def _is_gateway_transient(text: str) -> bool:
     return bool(_GATEWAY_TRANSIENT_RE.search(text))
 
@@ -137,14 +151,14 @@ def classify_provider_error(
         return ProviderFailureKind.EMPTY_RESPONSE
 
     if provider in _OPENAI_COMPAT_PROVIDERS:
+        if _is_model_unavailable(text):
+            return ProviderFailureKind.MODEL_NOT_FOUND
         if status_code in {401, 403} or "invalid api key" in text or "unauthorized" in text:
             return ProviderFailureKind.AUTH_INVALID
         if status_code == 402 or "insufficient credits" in text or "no credits" in text:
             return ProviderFailureKind.INSUFFICIENT_CREDITS
         if status_code == 429 or "rate limit" in text or "rate_limit" in text:
             return ProviderFailureKind.RATE_LIMITED
-        if "no endpoints found" in text or "model not found" in text:
-            return ProviderFailureKind.MODEL_NOT_FOUND
         if "does not support" in text or "unsupported" in text:
             return ProviderFailureKind.UNSUPPORTED_FEATURE
         if (

--- a/src/opensquilla/provider/selector.py
+++ b/src/opensquilla/provider/selector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 
 from .anthropic import AnthropicProvider
@@ -46,6 +47,21 @@ def _unsupported_runtime_message(provider: str) -> str:
 
 def _missing_base_url_message(provider: str) -> str:
     return f"Provider '{provider}' requires an explicit base_url"
+
+
+def _provider_config_identity(
+    cfg: ProviderConfig,
+) -> tuple[str, str, str, str, str, str, tuple[tuple[str, str], ...]]:
+    provider_routing = tuple(sorted((str(k), str(v)) for k, v in cfg.provider_routing.items()))
+    return (
+        cfg.provider,
+        cfg.model,
+        cfg.api_key,
+        cfg.base_url,
+        cfg.org_id,
+        cfg.proxy,
+        provider_routing,
+    )
 
 
 def _build_provider(cfg: ProviderConfig) -> LLMProvider:
@@ -173,17 +189,22 @@ class ModelSelector:
         replaces the static fallback chain from ``SelectorConfig``. An
         empty chain raises ``IndexError`` exactly like ``next_fallback``.
         """
-        chain = resolve_failover_chain(primary_failure, self._config, self._plugin)
+        current = self._chain[self._index]
+        if self._plugin is not None and hasattr(self._plugin, "failover_hook"):
+            chain = resolve_failover_chain(primary_failure, self._config, self._plugin)
+        else:
+            chain = list(self._chain[self._index + 1 :])
         if not chain:
             raise IndexError("No fallback chain available")
-        self._chain = [self._chain[0], *chain]
+        self._chain = [current, *chain]
         self._index = 1
         return _build_provider(self._chain[self._index])
 
     def override_model(self, model: str) -> None:
         """Update the model on the primary provider config (for runtime switching)."""
         if model and model != self._chain[0].model:
-            self._chain[0] = ProviderConfig(
+            original_primary = self._chain[0]
+            overridden_primary = ProviderConfig(
                 provider=self._chain[0].provider,
                 model=model,
                 api_key=self._chain[0].api_key,
@@ -192,6 +213,83 @@ class ModelSelector:
                 proxy=self._chain[0].proxy,
                 provider_routing=self._chain[0].provider_routing,
             )
+            fallback_chain = [original_primary, *self._chain[1:]]
+            deduped_fallbacks: list[ProviderConfig] = []
+            seen: set[tuple[str, str, str, str, str, str, tuple[tuple[str, str], ...]]] = {
+                _provider_config_identity(overridden_primary)
+            }
+            for cfg in fallback_chain:
+                identity = _provider_config_identity(cfg)
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                deduped_fallbacks.append(cfg)
+            self._chain = [overridden_primary, *deduped_fallbacks]
+            self._index = 0
+
+    def override_model_with_fallback_chain(
+        self,
+        model: str,
+        fallback_chain: list[object],
+    ) -> None:
+        """Override primary model and prefer router-provided fallback models.
+
+        Router fallback entries are intentionally small metadata dictionaries.
+        The selector can safely synthesize same-provider fallbacks by reusing
+        the current provider credentials. Cross-provider entries require a
+        configured fallback with matching credentials; otherwise they are
+        skipped instead of guessing secrets.
+        """
+        self.override_model(model)
+        if not fallback_chain:
+            return
+
+        current = self._chain[0]
+        existing_tail = list(self._chain[1:])
+        existing_by_provider_model = {
+            (cfg.provider, cfg.model): cfg for cfg in existing_tail
+        }
+
+        router_fallbacks: list[ProviderConfig] = []
+        for entry in fallback_chain:
+            if not isinstance(entry, Mapping):
+                continue
+            candidate_model = str(entry.get("model") or "").strip()
+            if not candidate_model:
+                continue
+            candidate_provider = (
+                str(entry.get("provider") or current.provider).strip() or current.provider
+            )
+            existing = existing_by_provider_model.get((candidate_provider, candidate_model))
+            if existing is not None:
+                router_fallbacks.append(existing)
+                continue
+            if candidate_provider != current.provider:
+                continue
+            router_fallbacks.append(
+                ProviderConfig(
+                    provider=current.provider,
+                    model=candidate_model,
+                    api_key=current.api_key,
+                    base_url=current.base_url,
+                    org_id=current.org_id,
+                    proxy=current.proxy,
+                    provider_routing=current.provider_routing,
+                )
+            )
+
+        deduped_tail: list[ProviderConfig] = []
+        seen: set[tuple[str, str, str, str, str, str, tuple[tuple[str, str], ...]]] = {
+            _provider_config_identity(current)
+        }
+        for cfg in [*router_fallbacks, *existing_tail]:
+            identity = _provider_config_identity(cfg)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            deduped_tail.append(cfg)
+        self._chain = [current, *deduped_tail]
+        self._index = 0
 
     def sync_primary(self, cfg: ProviderConfig) -> None:
         """Replace the primary provider config for future resolves and clones."""

--- a/tests/test_engine/test_router_control.py
+++ b/tests/test_engine/test_router_control.py
@@ -190,6 +190,11 @@ async def test_squilla_router_applies_hold_before_normal_classification(monkeypa
     assert out.metadata["routing_source"] == "router_control_hold"
     assert out.metadata["router_control_hold_applied"] is True
     assert out.metadata["router_control_target_tier"] == "c3"
+    assert [item["tier"] for item in out.metadata["router_fallback_chain"]] == [
+        "c2",
+        "c1",
+        "c0",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_selector_fallback_region_unavailable.py
+++ b/tests/test_engine/test_selector_fallback_region_unavailable.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from opensquilla.engine.runtime import _SelectorFallbackProvider
+from opensquilla.provider import DoneEvent, ErrorEvent, TextDeltaEvent
+from opensquilla.provider.selector import ModelSelector, ProviderConfig, SelectorConfig
+
+HIGH_TIER_MODEL = "openrouter/high-tier-region-locked"
+MID_TIER_MODEL = "openrouter/mid-tier-available"
+LOW_TIER_MODEL = "openrouter/low-tier-available"
+BASELINE_MODEL = "openrouter/baseline-available"
+
+
+class FakeProvider:
+    def __init__(
+        self,
+        provider_name: str,
+        model: str,
+        events: list[Any],
+        calls: list[str],
+    ) -> None:
+        self.provider_name = provider_name
+        self.model = model
+        self._events = events
+        self._calls = calls
+
+    async def chat(
+        self,
+        messages: list[Any],
+        tools: Any = None,
+        config: Any = None,
+    ) -> AsyncIterator[Any]:
+        self._calls.append(self.model)
+        for event in self._events:
+            yield event
+
+    async def list_models(self) -> list[Any]:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_runtime_falls_back_from_region_unavailable_router_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_build_provider(cfg: ProviderConfig) -> FakeProvider:
+        if cfg.model == HIGH_TIER_MODEL:
+            return FakeProvider(
+                cfg.provider,
+                cfg.model,
+                [
+                    ErrorEvent(
+                        message="HTTP 403: This model is not available in your region.",
+                        code="403",
+                    )
+                ],
+                calls,
+            )
+        return FakeProvider(
+            cfg.provider,
+            cfg.model,
+            [
+                TextDeltaEvent(text=f"fallback-response-from:{cfg.model}"),
+                DoneEvent(model=cfg.model),
+            ],
+            calls,
+        )
+
+    monkeypatch.setattr("opensquilla.provider.selector._build_provider", fake_build_provider)
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig(
+                provider="openrouter",
+                model=BASELINE_MODEL,
+                api_key="sk-test",
+                base_url="https://openrouter.ai/api",
+            )
+        )
+    )
+    selector.override_model_with_fallback_chain(
+        HIGH_TIER_MODEL,
+        [
+            {"tier": "c2", "provider": "openrouter", "model": MID_TIER_MODEL},
+            {"tier": "c1", "provider": "openrouter", "model": BASELINE_MODEL},
+            {"tier": "c0", "provider": "openrouter", "model": LOW_TIER_MODEL},
+        ],
+    )
+    provider = _SelectorFallbackProvider(selector.resolve(), selector)
+
+    events = [event async for event in provider.chat([{"role": "user", "content": "hi"}])]
+
+    assert calls == [HIGH_TIER_MODEL, MID_TIER_MODEL]
+    assert [getattr(event, "kind", "") for event in events] == ["text_delta", "done"]
+    assert events[0].text == f"fallback-response-from:{MID_TIER_MODEL}"
+    assert events[1].model == MID_TIER_MODEL
+
+
+@pytest.mark.asyncio
+async def test_runtime_keeps_successful_router_model_without_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_build_provider(cfg: ProviderConfig) -> FakeProvider:
+        return FakeProvider(
+            cfg.provider,
+            cfg.model,
+            [
+                TextDeltaEvent(text=f"primary-response-from:{cfg.model}"),
+                DoneEvent(model=cfg.model),
+            ],
+            calls,
+        )
+
+    monkeypatch.setattr("opensquilla.provider.selector._build_provider", fake_build_provider)
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig(
+                provider="openrouter",
+                model=BASELINE_MODEL,
+                api_key="sk-test",
+                base_url="https://openrouter.ai/api",
+            )
+        )
+    )
+    selector.override_model_with_fallback_chain(
+        HIGH_TIER_MODEL,
+        [
+            {"tier": "c2", "provider": "openrouter", "model": MID_TIER_MODEL},
+            {"tier": "c1", "provider": "openrouter", "model": BASELINE_MODEL},
+            {"tier": "c0", "provider": "openrouter", "model": LOW_TIER_MODEL},
+        ],
+    )
+    provider = _SelectorFallbackProvider(selector.resolve(), selector)
+
+    events = [event async for event in provider.chat([{"role": "user", "content": "hi"}])]
+
+    assert calls == [HIGH_TIER_MODEL]
+    assert [getattr(event, "kind", "") for event in events] == ["text_delta", "done"]
+    assert events[0].text == f"primary-response-from:{HIGH_TIER_MODEL}"
+    assert events[1].model == HIGH_TIER_MODEL

--- a/tests/test_model_router_behavior.py
+++ b/tests/test_model_router_behavior.py
@@ -183,6 +183,36 @@ async def test_full_rollout_applies_routed_model_thinking_and_p0_prompt(
 
 
 @pytest.mark.asyncio
+async def test_router_records_lower_text_tier_fallback_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_strategy(
+        monkeypatch,
+        "c3",
+        0.91,
+        {
+            "route_class": "R3",
+            "thinking_mode": "T1",
+            "prompt_policy": "P0",
+        },
+    )
+
+    routed = await apply_squilla_router(make_context("Solve a difficult architecture problem."))
+
+    assert routed.metadata["routed_tier"] == "c3"
+    assert [item["tier"] for item in routed.metadata["router_fallback_chain"]] == [
+        "c2",
+        "c1",
+        "c0",
+    ]
+    assert [item["model"] for item in routed.metadata["router_fallback_chain"]] == [
+        "z-ai/glm-5.1",
+        "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-v4-flash",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_router_reports_provider_state_loss_without_changing_route(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_provider_failure_classification.py
+++ b/tests/test_provider_failure_classification.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import pytest
 
 from opensquilla.engine.fallback import FallbackPolicy, ProviderErrorKind
-from opensquilla.provider.failures import ProviderFailureKind, classify_provider_error
+from opensquilla.provider.failures import (
+    ProviderFailureKind,
+    ProviderRecoveryAction,
+    classify_provider_error,
+    decide_recovery_action,
+)
 
 
 @pytest.mark.parametrize(
@@ -199,6 +204,27 @@ def test_agent_fallback_still_does_not_retry_auth_failures() -> None:
 
     assert kind is ProviderErrorKind.AUTH_FAILURE
     assert policy.should_retry(kind, attempt=0) is False
+
+
+@pytest.mark.parametrize("provider", ["openrouter", "openai"])
+def test_openai_compatible_region_unavailable_403_falls_back_to_next_model(
+    provider: str,
+) -> None:
+    kind = classify_provider_error(
+        provider,
+        403,
+        message="HTTP 403: This model is not available in your region.",
+    )
+
+    assert kind is ProviderFailureKind.MODEL_NOT_FOUND
+    assert decide_recovery_action(kind) is ProviderRecoveryAction.FALLBACK_PROVIDER
+
+
+def test_openrouter_plain_403_still_fails_as_auth_configuration() -> None:
+    kind = classify_provider_error("openrouter", 403, message="HTTP 403: forbidden")
+
+    assert kind is ProviderFailureKind.AUTH_INVALID
+    assert decide_recovery_action(kind) is ProviderRecoveryAction.FAIL_CONFIG
 
 
 @pytest.mark.parametrize(

--- a/tests/test_provider_selector.py
+++ b/tests/test_provider_selector.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from opensquilla.provider.selector import ModelSelector, ProviderConfig, SelectorConfig
+
+HIGH_TIER_MODEL = "openrouter/high-tier-region-locked"
+MID_TIER_MODEL = "openrouter/mid-tier-available"
+LOW_TIER_MODEL = "openrouter/low-tier-available"
+BASELINE_MODEL = "openrouter/baseline-available"
+
+
+def test_override_model_keeps_original_primary_as_first_fallback(monkeypatch) -> None:
+    built: list[ProviderConfig] = []
+
+    def fake_build_provider(cfg: ProviderConfig) -> ProviderConfig:
+        built.append(cfg)
+        return cfg
+
+    monkeypatch.setattr("opensquilla.provider.selector._build_provider", fake_build_provider)
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig(
+                provider="openrouter",
+                model=BASELINE_MODEL,
+                api_key="sk-test",
+                base_url="https://openrouter.ai/api",
+            )
+        )
+    )
+
+    selector.override_model(HIGH_TIER_MODEL)
+    primary = selector.resolve()
+    fallback = selector.next_fallback_after_failure(
+        RuntimeError("HTTP 403: This model is not available in your region.")
+    )
+
+    assert primary.model == HIGH_TIER_MODEL
+    assert fallback.model == BASELINE_MODEL
+    assert fallback.provider == "openrouter"
+    assert [cfg.model for cfg in built] == [
+        HIGH_TIER_MODEL,
+        BASELINE_MODEL,
+    ]
+
+
+def test_override_model_with_router_fallback_chain_prefers_lower_tiers(monkeypatch) -> None:
+    built: list[ProviderConfig] = []
+
+    def fake_build_provider(cfg: ProviderConfig) -> ProviderConfig:
+        built.append(cfg)
+        return cfg
+
+    monkeypatch.setattr("opensquilla.provider.selector._build_provider", fake_build_provider)
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig(
+                provider="openrouter",
+                model=BASELINE_MODEL,
+                api_key="sk-test",
+                base_url="https://openrouter.ai/api",
+            )
+        )
+    )
+
+    selector.override_model_with_fallback_chain(
+        HIGH_TIER_MODEL,
+        [
+            {"tier": "c2", "provider": "openrouter", "model": MID_TIER_MODEL},
+            {"tier": "c1", "provider": "openrouter", "model": BASELINE_MODEL},
+            {"tier": "c0", "provider": "openrouter", "model": LOW_TIER_MODEL},
+        ],
+    )
+
+    resolved_models = [selector.resolve().model]
+    for _ in range(3):
+        resolved_models.append(
+            selector.next_fallback_after_failure(
+                RuntimeError("HTTP 403: This model is not available in your region.")
+            ).model
+        )
+
+    assert resolved_models == [
+        HIGH_TIER_MODEL,
+        MID_TIER_MODEL,
+        BASELINE_MODEL,
+        LOW_TIER_MODEL,
+    ]
+    assert [cfg.model for cfg in built] == resolved_models


### PR DESCRIPTION
## Summary
- Classify OpenAI-compatible model-unavailable 403s as fallbackable instead of auth failures.
- Carry Squilla Router lower-tier fallback chains into runtime selector overrides.
- Add runtime stream regressions proving region-unavailable high-tier selections fall back before user-visible output, while healthy primary streams do not fall back.

## Test Plan
- UV_CACHE_DIR=.uv-cache uv run pytest tests/test_provider_failure_classification.py tests/test_provider_selector.py tests/test_model_router_behavior.py tests/test_engine/test_router_control.py tests/test_engine/test_selector_fallback_region_unavailable.py -q
- UV_CACHE_DIR=.uv-cache uv run --extra dev ruff check src/opensquilla/provider/failures.py src/opensquilla/provider/selector.py src/opensquilla/engine/steps/squilla_router.py src/opensquilla/engine/runtime.py src/opensquilla/engine/turn_runner/prompt_assembler_stage.py tests/test_provider_failure_classification.py tests/test_provider_selector.py tests/test_model_router_behavior.py tests/test_engine/test_router_control.py tests/test_engine/test_selector_fallback_region_unavailable.py

Fixes #245
