### PR TITLE
Allow scoped MetaSkill run history reads

### DIFF
--- a/src/opensquilla/gateway/rpc_meta_runs.py
+++ b/src/opensquilla/gateway/rpc_meta_runs.py
@@ -134,9 +134,11 @@ def _session_key_for_history(params: dict[str, Any], ctx: RpcContext) -> str | N
         if session_key:
             return str(session_key)
         return None
+    if session_key:
+        return str(session_key)
     raise RpcHandlerError(
         ERROR_UNAUTHORIZED,
-        "meta run history requires owner/admin scope.",
+        "meta run history requires a sessionKey for read-only access.",
     )
 
 

--- a/src/opensquilla/gateway/static/js/views/chat/meta-run-history.js
+++ b/src/opensquilla/gateway/static/js/views/chat/meta-run-history.js
@@ -11,6 +11,8 @@
     if (typeof rpc.waitForConnection === 'function') {
       await rpc.waitForConnection();
     }
+    const existing = document.querySelector('.meta-run-history');
+    if (existing) existing.remove();
     const panel = renderRunHistoryPanel({ runs: [], loading: true });
     document.body.appendChild(panel);
     try {

--- a/tests/test_gateway/test_chat_meta_ribbon_static.py
+++ b/tests/test_gateway/test_chat_meta_ribbon_static.py
@@ -280,6 +280,8 @@ def test_meta_run_history_module_exists():
         assert method in text
     for name in ("renderRunHistoryPanel", "openRunHistory"):
         assert f"function {name}" in text
+    assert "document.querySelector('.meta-run-history')" in text
+    assert "existing.remove()" in text
     assert "showRunError" in text
     assert "catch (err)" in text
     assert "run.validation || {}" in text

--- a/tests/test_gateway/test_rpc_meta_runs.py
+++ b/tests/test_gateway/test_rpc_meta_runs.py
@@ -426,8 +426,27 @@ async def test_meta_runs_read_only_requires_session_key_for_history(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_meta_runs_read_only_denies_arbitrary_session_key(tmp_path: Path) -> None:
+async def test_meta_runs_read_only_allows_session_scoped_history(tmp_path: Path) -> None:
     writer, run_id = _seed_writer(tmp_path)
+    other_plan = MetaPlan(
+        name="beta-skill",
+        triggers=("beta request",),
+        priority=10,
+        steps=(MetaStep(id="s1", skill="writer", kind="agent", label="Write"),),
+    )
+    other_run_id = writer.begin_run_sync(
+        meta_skill_name="beta-skill",
+        meta_plan=other_plan,
+        triggered_by="soft_meta_invoke",
+        inputs={"user_message": "Write a beta brief"},
+        session_key="sess-2",
+        turn_id="turn-2",
+    )
+    writer.finish_run_sync(
+        run_id=other_run_id,
+        status="ok",
+        result=MetaResult(ok=True, final_text="done"),
+    )
     read_only = Principal(
         role="operator",
         scopes=frozenset({READ_SCOPE}),
@@ -442,14 +461,15 @@ async def test_meta_runs_read_only_denies_arbitrary_session_key(tmp_path: Path) 
             {"sessionKey": "sess-1", "limit": 5},
             ctx,
         )
-        assert res.error is not None
-        assert res.error.code == ERROR_UNAUTHORIZED
+        assert res.error is None, res.error
+        assert [run["run_id"] for run in res.payload["runs"]] == [run_id]
+        assert all(run["session_key"] == "sess-1" for run in res.payload["runs"])
     finally:
         writer.close()
 
 
 @pytest.mark.asyncio
-async def test_meta_runs_failures_read_only_denies_arbitrary_session_key(
+async def test_meta_runs_failures_read_only_allows_session_scoped_history(
     tmp_path: Path,
 ) -> None:
     writer, run_id = _seed_writer(tmp_path)
@@ -457,6 +477,25 @@ async def test_meta_runs_failures_read_only_denies_arbitrary_session_key(
         run_id=run_id,
         status="failed",
         result=MetaResult(ok=False, error="failed", failed_step_id="s1"),
+    )
+    other_plan = MetaPlan(
+        name="beta-skill",
+        triggers=("beta request",),
+        priority=10,
+        steps=(MetaStep(id="s1", skill="writer", kind="agent", label="Write"),),
+    )
+    other_run_id = writer.begin_run_sync(
+        meta_skill_name="beta-skill",
+        meta_plan=other_plan,
+        triggered_by="soft_meta_invoke",
+        inputs={"user_message": "Write a beta brief"},
+        session_key="sess-2",
+        turn_id="turn-2",
+    )
+    writer.finish_run_sync(
+        run_id=other_run_id,
+        status="failed",
+        result=MetaResult(ok=False, error="other failed", failed_step_id="s1"),
     )
     read_only = Principal(
         role="operator",
@@ -472,8 +511,9 @@ async def test_meta_runs_failures_read_only_denies_arbitrary_session_key(
             {"sessionKey": "sess-1", "limit": 5},
             ctx,
         )
-        assert res.error is not None
-        assert res.error.code == ERROR_UNAUTHORIZED
+        assert res.error is None, res.error
+        assert [run["run_id"] for run in res.payload["runs"]] == [run_id]
+        assert all(run["session_key"] == "sess-1" for run in res.payload["runs"])
     finally:
         writer.close()
 


### PR DESCRIPTION
## Summary
- allow read-only MetaSkill run history calls when they are scoped by sessionKey
- keep unscoped MetaSkill history owner/admin-only
- avoid stacking duplicate MetaSkill run history panels in the WebUI

Fixes #249

## Tests
- UV_CACHE_DIR=.uv-cache uv run pytest tests/test_gateway/test_rpc_meta_runs.py tests/test_gateway/test_chat_meta_ribbon_static.py -q
- node --check src/opensquilla/gateway/static/js/views/chat/meta-run-history.js
- UV_CACHE_DIR=.uv-cache uv run ruff check src/opensquilla/gateway/rpc_meta_runs.py tests/test_gateway/test_rpc_meta_runs.py tests/test_gateway/test_chat_meta_ribbon_static.py