### PR TITLE
Refine user-facing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,48 +41,6 @@ For task-oriented product documentation, start with the
 
 ---
 
-## Anonymous Installation Telemetry
-
-OpenSquilla includes anonymous installation telemetry to estimate install
-counts, version distribution, and runtime compatibility. The telemetry path
-is enabled by default and sends to the official OpenSquilla telemetry collector.
-
-The gateway sends a best-effort install event on first startup and one version
-event the first time each OpenSquilla version runs. This covers source, pip,
-Docker, and desktop installs when they start the gateway. Uploads use a short
-timeout and never block startup.
-
-The telemetry payload contains only:
-
-- random `install_id`
-- OpenSquilla version
-- event type (`install` or `version_seen`)
-- install method (`pip`, `source`, `docker`, `desktop`, or `unknown`)
-- operating system, OS version, CPU architecture, and Python major/minor
-  version
-- first-seen and sent timestamps
-
-The telemetry payload does not include usernames, email addresses, hostnames,
-local paths, API keys, provider configuration, chat history, session data,
-memory, agent content, file names, or file contents. HTTP servers can
-technically observe source IP addresses at the transport/logging layer; IP
-addresses are not part of the telemetry payload and should not be used as an
-install-count field by the collector.
-
-Disable telemetry with:
-
-```sh
-OPENSQUILLA_TELEMETRY_DISABLED=true
-```
-
-Point telemetry at a collector you control with:
-
-```sh
-OPENSQUILLA_TELEMETRY_ENDPOINT=https://example.com/v1/install
-```
-
----
-
 ## Installation
 
 OpenSquilla runs on Windows, macOS, and Linux. Pick the path that
@@ -373,6 +331,47 @@ In this mode, prefix every `opensquilla` command in
 [Configuration](#configuration) with `uv run`. Do not debug a
 development checkout through a user-local `opensquilla` command — that
 command runs in a different Python environment.
+
+---
+
+## Installation Privacy
+
+OpenSquilla uses anonymous installation telemetry to estimate install counts,
+version adoption, and runtime compatibility. Data is sent on first gateway
+startup and once per OpenSquilla version. Uploads use a short timeout and never
+block startup.
+
+What is sent:
+
+- schema version
+- random locally generated `install_id`
+- OpenSquilla version
+- event type (`install` or `version_seen`)
+- install method (`pip`, `source`, `docker`, `desktop`, or `unknown`)
+- operating system, OS version, CPU architecture, and Python major/minor
+  version
+- first-seen and sent timestamps
+
+The `install_id` is random and is not derived from your account, device name,
+hostname, or local paths.
+
+What is not sent: usernames, email addresses, hostnames, local paths, API keys,
+provider configuration, chat history, session data, memory, agent content, file
+names, or file contents. HTTP servers can technically observe source IP
+addresses at the transport layer; IP addresses are not part of the payload and
+should not be used as an install-count field by the collector.
+
+To opt out:
+
+```sh
+OPENSQUILLA_TELEMETRY_DISABLED=true
+```
+
+Advanced deployments can use their own endpoint:
+
+```sh
+OPENSQUILLA_TELEMETRY_ENDPOINT=https://example.com/v1/install
+```
 
 ---
 

--- a/src/opensquilla/identity/templates/system_prompt.j2
+++ b/src/opensquilla/identity/templates/system_prompt.j2
@@ -312,6 +312,7 @@ greetings like "hi". Always respond to direct user messages.
 
 - Use the conversation's language for replies
 - When uncertain, ask for clarification rather than guessing
-- Prefer concise replies unless detail is requested
+- Match reply length to the request: keep simple replies brief, and give more
+  detail when the user asks to explain, expand, or go deep.
 
 {% endif -%}


### PR DESCRIPTION
## Summary
- Adjusts the default reply-length guidance so responses better match the user request.
- Moves installation privacy details out of the README intro and keeps them near installation.

## Testing
- `git diff --check origin/main..HEAD`
- `uv run pytest tests/test_identity/test_user_profile_prompt.py -q`

## Scope
Targets `main`.