### PR TITLE
Expose router panel visual mode config on main

### DIFF
--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -908,6 +908,7 @@ class SquillaRouterConfig(BaseSettings):
     rollout_phase: str = "full"  # "observe" | "prompt_only" | "full"
     strategy: str = "v4_phase3"
     tier_profile: str | None = None
+    visual_mode: str = "real_candidates"
     tiers: dict = Field(default_factory=_default_tiers)
     default_tier: str = DEFAULT_TEXT_TIER
     confidence_threshold: float = 0.5
@@ -922,6 +923,17 @@ class SquillaRouterConfig(BaseSettings):
     require_router_runtime: bool = True
     estimated_output_savings_pct: float = 0.03
     upgrade_to_c3_compaction_enabled: bool = True
+
+    @field_validator("visual_mode", mode="before")
+    @classmethod
+    def _normalize_visual_mode(cls, value: Any) -> str:
+        raw = "real_candidates" if value is None else str(value).strip().lower()
+        normalized = raw.replace("-", "_")
+        if normalized in {"", "real_candidates", "candidates"}:
+            return "real_candidates"
+        if normalized in {"legacy_grid", "model_space", "modelspace"}:
+            return "legacy_grid"
+        raise ValueError("visual_mode must be one of: real_candidates, legacy_grid")
 
     @model_validator(mode="before")
     @classmethod

--- a/src/opensquilla/gateway/rpc_config.py
+++ b/src/opensquilla/gateway/rpc_config.py
@@ -282,6 +282,7 @@ _SAFE_WRITE_PATCH_PATHS = frozenset(
         "squilla_router.enabled",
         "squilla_router.rollout_phase",
         "squilla_router.strategy",
+        "squilla_router.visual_mode",
         "squilla_router.default_tier",
         "squilla_router.confidence_threshold",
     }

--- a/src/opensquilla/gateway/static/css/views/chat.css
+++ b/src/opensquilla/gateway/static/css/views/chat.css
@@ -3026,6 +3026,12 @@ select.clarify-form-input {
   overflow: hidden;
 }
 
+.router-fx[data-panel="legacy-grid"] .router-fx-grid {
+  grid-template-columns: repeat(5, 1fr);
+  grid-template-rows: repeat(3, 30px);
+  grid-auto-rows: auto;
+}
+
 .router-fx-cell {
   position: relative;
   display: flex;
@@ -3290,6 +3296,11 @@ select.clarify-form-input {
     padding: 6px;
     gap: 3px;
   }
+  .router-fx[data-panel="legacy-grid"] .router-fx-grid {
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(5, 28px);
+    grid-auto-rows: auto;
+  }
   .router-fx-cell { font-size: 10px; padding: 0 5px; }
   .router-fx-header { font-size: 9.5px; letter-spacing: 0.36em; }
 }
@@ -3298,6 +3309,11 @@ select.clarify-form-input {
     grid-template-columns: repeat(var(--router-fx-mobile-cols, 2), 1fr);
     grid-template-rows: none;
     grid-auto-rows: 28px;
+  }
+  .router-fx[data-panel="legacy-grid"] .router-fx-grid {
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(5, 26px);
+    grid-auto-rows: auto;
   }
   .router-fx-cell { font-size: 9.5px; padding: 0 4px; }
 }

--- a/src/opensquilla/gateway/static/js/views/chat.js
+++ b/src/opensquilla/gateway/static/js/views/chat.js
@@ -1460,6 +1460,7 @@ const ChatView = (() => {
       // per browser, so it survives view re-render / navigation. Inherits the
       // visibility/focus refresh that re-runs this function for free.
       _routerFxLoadPref();
+      _routerFxApplyConfigVisualMode(cfg?.squilla_router?.visual_mode);
       const routerFxToggle = _el?.querySelector('#toggle-router-fx');
       if (routerFxToggle) routerFxToggle.checked = _routerFx.enabled;
       if (window.SavingsFX) window.SavingsFX.setEnabled(_routerFx.enabled);
@@ -3312,10 +3313,70 @@ const ChatView = (() => {
   // the whole animation (scan + ~360ms settle transition) stays under ~1s.
   const _ROUTER_FX_SCAN_MS = 600;
   const _ROUTER_FX_START_DELAY_MS = 280;
-  const _routerFx = { enabled: true, variant: 'default' };
+  const _ROUTER_FX_GRID_COLS = 5;
+  const _ROUTER_FX_GRID_ROWS = 3;
+  const _ROUTER_FX_GRID_CELLS = _ROUTER_FX_GRID_COLS * _ROUTER_FX_GRID_ROWS;
+  const _ROUTER_FX_REAL_ANCHOR_CELLS = [1, 6, 8, 13, 11, 3, 5, 9, 12, 14, 0, 4, 7, 10, 2];
+  const _ROUTER_FX_DECOY_POOL = [
+    'deepseek-v4-flash',
+    'claude-sonnet-4.6',
+    'qwen3.6-plus',
+    'minimax-m2.7',
+    'gpt-5.5',
+    'gemini-3.5-flash',
+    'glm-5-turbo',
+    'claude-opus-4.8',
+    'nemotron-3-super',
+    'deepseek-v4-pro',
+    'mimo-v2.5-pro',
+    'gpt-5.4',
+    'kimi-k2.6',
+    'claude-opus-4.7',
+    'gemini-3.1-flash-lite',
+    'glm-5.1',
+    'qwen3.6-max',
+    'claude-haiku-4.5',
+    'grok-4.3',
+    'gpt-5.4-mini',
+    'gemini-2.5-flash',
+    'step-3.5-flash',
+    'mistral-medium-3.5',
+    'ling-2.6-1t',
+    'deepseek-v3.2',
+    'trinity-large-thinking',
+    'gemini-2.5-pro',
+    'seed-2.0-mini',
+    'gpt-5.3-codex',
+    'grok-4.20',
+    'mercury-2',
+    'hunyuan-3',
+    'mimo-v2-omni',
+    'command-r-plus',
+    'llama-4-405b',
+    'sonar-large',
+  ];
+  const _routerFx = { enabled: true, visualMode: 'real_candidates', variant: 'default' };
+  function _routerFxNormalizeVisualMode(mode) {
+    const normalized = typeof mode === 'string'
+      ? mode.trim().toLowerCase().replace(/-/g, '_')
+      : '';
+    if (normalized === 'legacy_grid' || normalized === 'model_space') {
+      return 'legacy_grid';
+    }
+    return 'real_candidates';
+  }
+  function _routerFxPanelDataset(mode) {
+    return _routerFxNormalizeVisualMode(mode) === 'legacy_grid'
+      ? 'legacy-grid'
+      : 'real-candidates';
+  }
+  function _routerFxApplyConfigVisualMode(mode) {
+    _routerFx.visualMode = _routerFxNormalizeVisualMode(mode);
+  }
   function _routerFxLoadPref() {
     // Defaults stand (enabled ON, default variant) unless a stored pref
     // overrides them. localStorage may throw (private mode / quota) — swallow.
+    _routerFx.visualMode = 'real_candidates';
     _routerFx.variant = 'default';
     try {
       const raw = localStorage.getItem(_ROUTER_FX_PREF_KEY);
@@ -3610,9 +3671,9 @@ const ChatView = (() => {
     return _routerFxVisualEntries(requestKind, decision);
   }
 
-  // Assemble the grid from real candidates only. No filler/decoy wall: every
-  // visible model name is a candidate that could actually be called this turn.
-  function _routerFxBuildGridCells(realEntries, seedKey) {
+  // Assemble the default panel from real candidates only. No filler/decoy
+  // wall: every visible model name is callable for this turn.
+  function _routerFxBuildCandidateGridCells(realEntries, seedKey) {
     const orderedRealEntries = realEntries.slice().sort((a, b) => (
       (a.displayName || a.key || '').localeCompare(b.displayName || b.key || '')
     ));
@@ -3621,6 +3682,63 @@ const ChatView = (() => {
       entry,
       displayName: entry.displayName,
     }));
+  }
+
+  // Legacy grid is a visual wall only: real candidates keep their in-memory
+  // entries for winner lookup, while decoys are labels with no tier metadata.
+  function _routerFxBuildLegacyGridCells(realEntries, seedKey) {
+    const cells = Array.from({ length: _ROUTER_FX_GRID_CELLS }, () => null);
+    const realNames = new Set();
+    const orderedRealEntries = realEntries.slice().sort((a, b) => (
+      (a.label || a.displayName || a.key || '').localeCompare(b.label || b.displayName || b.key || '')
+    ));
+    orderedRealEntries.forEach((entry, i) => {
+      const anchor = _ROUTER_FX_REAL_ANCHOR_CELLS[i];
+      const idx = typeof anchor === 'number' ? anchor : cells.findIndex((cell) => cell == null);
+      if (idx < 0 || idx >= cells.length) return;
+      cells[idx] = {
+        kind: 'real',
+        entry,
+        displayName: entry.displayName,
+        label: entry.label || entry.displayName,
+        title: entry.title || entry.label || entry.displayName,
+      };
+      if (entry.displayName) realNames.add(entry.displayName);
+      if (entry.label) realNames.add(entry.label);
+    });
+
+    const decoys = [];
+    for (let i = 0; i < _ROUTER_FX_DECOY_POOL.length && decoys.length < _ROUTER_FX_GRID_CELLS; i++) {
+      const name = _ROUTER_FX_DECOY_POOL[i];
+      if (realNames.has(name)) continue;
+      decoys.push({
+        kind: 'decoy',
+        displayName: name,
+        label: name,
+        title: name,
+      });
+    }
+    while (decoys.length < _ROUTER_FX_GRID_CELLS) {
+      decoys.push({
+        kind: 'decoy',
+        displayName: '-',
+        label: '-',
+        title: '-',
+      });
+    }
+    const orderedDecoys = _routerFxShuffle(decoys, seedKey ? seedKey + ':decoy' : undefined);
+    let decoyIdx = 0;
+    for (let i = 0; i < cells.length; i++) {
+      if (cells[i] == null) cells[i] = orderedDecoys[decoyIdx++];
+    }
+    return cells;
+  }
+
+  function _routerFxBuildGridCells(realEntries, seedKey, visualMode) {
+    if (_routerFxNormalizeVisualMode(visualMode) === 'legacy_grid') {
+      return _routerFxBuildLegacyGridCells(realEntries, seedKey);
+    }
+    return _routerFxBuildCandidateGridCells(realEntries, seedKey);
   }
 
   function _buildRouterFxElement(decision, opts) {
@@ -3661,11 +3779,15 @@ const ChatView = (() => {
     // layout on every rebuild, so the field never reshuffles after lock.
     const seedKey = opts && opts.seedKey ? String(opts.seedKey) : '';
     if (seedKey) wrap.dataset.seed = seedKey;
+    const visualMode = _routerFxNormalizeVisualMode(
+      opts.visualMode != null ? opts.visualMode : _routerFx.visualMode,
+    );
+    wrap.dataset.panel = _routerFxPanelDataset(visualMode);
 
     const requestKind = _routerFxRequestKindFromDecision(decision, opts.requestKind);
     const realEntries = _routerFxRealEntries(decision, requestKind);
     if (realEntries.length <= 1) return null;
-    const gridCells = _routerFxBuildGridCells(realEntries, seedKey || undefined);
+    const gridCells = _routerFxBuildGridCells(realEntries, seedKey || undefined, visualMode);
 
     const grid = document.createElement('div');
     grid.className = 'router-fx-grid';
@@ -5634,6 +5756,7 @@ const ChatView = (() => {
                 if (identityChanged) savedUsage.__savings_ui_suppressed = true;
               }
               if (window.SavingsFX) window.SavingsFX.noteTurn(savedUsage);
+              const routerPanel = _routerFxPanelDataset(_routerFx.visualMode);
               // Place a pre-settled router slider directly beneath the
               // user message that triggered this turn — never above
               // it, never with anything wedged in between.
@@ -5657,7 +5780,8 @@ const ChatView = (() => {
               if (userMsg && userMsg.parentNode === _thread) {
                 const ownStrips = Array.from(_thread.querySelectorAll('.router-fx')).filter(
                   (el) => el.dataset.sessionKey === (_sessionKey || '')
-                    && el.dataset.turnIndex === String(_histUserIdx),
+                    && el.dataset.turnIndex === String(_histUserIdx)
+                    && _routerFxPanelDataset(el.dataset.panel) === routerPanel,
                 );
                 const keep = ownStrips.find((el) => el.dataset.routerIdentity === routerIdentity)
                   || null;
@@ -5678,7 +5802,8 @@ const ChatView = (() => {
               const existingStrip = (placed && placed.classList
                   && placed.classList.contains('router-fx')) ? placed : null;
               const alreadyInPlace = existingStrip
-                && existingStrip.dataset.routerIdentity === routerIdentity;
+                && existingStrip.dataset.routerIdentity === routerIdentity
+                && _routerFxPanelDataset(existingStrip.dataset.panel) === routerPanel;
               if (!alreadyInPlace) {
                 if (existingStrip) _routerFxRemoveStrip(existingStrip);
                 const hint = msg.timestamp || msg.ts || msg.message_id || '';

--- a/tests/test_gateway/test_boot_provider_env.py
+++ b/tests/test_gateway/test_boot_provider_env.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 import tomllib
 from types import SimpleNamespace
 
+import pytest
+
 from opensquilla.gateway.config import GatewayConfig
 from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
-from opensquilla.gateway.rpc_config import _handle_config_patch, _sync_provider_selector
+from opensquilla.gateway.rpc_config import (
+    _handle_config_patch,
+    _handle_config_patch_safe,
+    _sync_provider_selector,
+)
 
 
 class _CapturingSelector:
@@ -96,6 +102,28 @@ def test_direct_provider_runtime_does_not_inherit_openrouter_provider_routing() 
     assert runtime.provider_routing == {}
 
 
+def test_squilla_router_visual_mode_defaults_to_real_candidates() -> None:
+    cfg = GatewayConfig()
+
+    assert cfg.squilla_router.visual_mode == "real_candidates"
+    assert cfg.to_public_dict()["squilla_router"]["visual_mode"] == "real_candidates"
+
+
+def test_squilla_router_visual_mode_accepts_legacy_grid_and_model_space_alias() -> None:
+    legacy_cfg = GatewayConfig(squilla_router={"visual_mode": "legacy_grid"})
+    alias_cfg = GatewayConfig(squilla_router={"visual_mode": "model_space"})
+    dashed_alias_cfg = GatewayConfig(squilla_router={"visual_mode": "model-space"})
+
+    assert legacy_cfg.squilla_router.visual_mode == "legacy_grid"
+    assert alias_cfg.squilla_router.visual_mode == "legacy_grid"
+    assert dashed_alias_cfg.squilla_router.visual_mode == "legacy_grid"
+
+
+def test_squilla_router_visual_mode_rejects_unknown_value() -> None:
+    with pytest.raises(ValueError, match="visual_mode must be one of"):
+        GatewayConfig(squilla_router={"visual_mode": "all_models"})
+
+
 def test_runtime_config_sync_resolves_selected_provider_env(monkeypatch) -> None:
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     monkeypatch.setenv("DEEPSEEK_API_KEY", "deepseek-key")
@@ -131,3 +159,17 @@ async def test_config_patch_runtime_env_key_is_not_persisted(monkeypatch, tmp_pa
     persisted = tomllib.loads((tmp_path / "config.toml").read_text())
     assert persisted["squilla_router"]["tier_profile"] == "deepseek"
     assert "api_key" not in persisted["llm"]
+
+
+async def test_safe_config_patch_allows_router_visual_mode(tmp_path) -> None:
+    cfg = GatewayConfig(config_path=str(tmp_path / "config.toml"))
+    ctx = SimpleNamespace(config=cfg, provider_selector=_CapturingSelector())
+
+    await _handle_config_patch_safe(
+        {"patches": {"squilla_router.visual_mode": "legacy_grid"}},
+        ctx,
+    )
+
+    assert ctx.config.squilla_router.visual_mode == "legacy_grid"
+    persisted = tomllib.loads((tmp_path / "config.toml").read_text())
+    assert persisted["squilla_router"]["visual_mode"] == "legacy_grid"

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -1953,13 +1953,12 @@ def test_router_fx_history_reanchors_stranded_strip() -> None:
 
 def test_router_fx_uses_only_effective_real_candidates() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
-    builder_start = source.index("function _routerFxBuildGridCells(realEntries, seedKey) {")
-    builder_end = source.index("  function _buildRouterFxElement", builder_start)
+    builder_start = source.index(
+        "function _routerFxBuildCandidateGridCells(realEntries, seedKey) {",
+    )
+    builder_end = source.index("  function _routerFxBuildLegacyGridCells", builder_start)
     builder_body = source[builder_start:builder_end]
 
-    assert "const _ROUTER_FX_DECOY_POOL" not in source
-    assert "_ROUTER_FX_REAL_ANCHOR_CELLS" not in source
-    assert "_ROUTER_FX_GRID_CELLS" not in source
     assert "function _routerFxResolveLayoutSeed(sessionKey, hintTimestamp)" in source
     assert "function _routerFxVisualEntries(requestKind, decision) {" in source
     assert "const cachedSeed = _routerFxResolveLayoutSeed(_sessionKey, hint);" in source
@@ -1968,6 +1967,47 @@ def test_router_fx_uses_only_effective_real_candidates() -> None:
     assert "kind: 'real'," in builder_body
     assert "kind: 'decoy'" not in builder_body
     assert "return _routerFxShuffle(cells, seedKey);" not in builder_body
+
+
+def test_router_fx_legacy_grid_is_config_driven_visual_only() -> None:
+    source = CHAT_JS.read_text(encoding="utf-8")
+    css = CHAT_CSS.read_text(encoding="utf-8")
+
+    assert "Router panel" not in source
+    assert "data-router-panel" not in source
+    assert "const _ROUTER_FX_DECOY_POOL = [" in source
+    assert "const _ROUTER_FX_REAL_ANCHOR_CELLS" in source
+    assert "function _routerFxNormalizeVisualMode(mode) {" in source
+    assert "return 'legacy_grid';" in source
+    assert "_routerFxApplyConfigVisualMode(cfg?.squilla_router?.visual_mode);" in source
+    assert "saved.visualMode" not in source
+    assert "saved.panel" not in source
+    assert "visualMode:" not in source[
+        source.index("function _routerFxSavePref() {"):
+        source.index("function _routerFxSortTiers(", source.index("function _routerFxSavePref() {"))
+    ]
+
+    legacy_start = source.index("function _routerFxBuildLegacyGridCells(realEntries, seedKey) {")
+    legacy_end = source.index("  function _routerFxBuildGridCells", legacy_start)
+    legacy_body = source[legacy_start:legacy_end]
+    assert "Array.from({ length: _ROUTER_FX_GRID_CELLS }" in legacy_body
+    assert "cells[idx] = {" in legacy_body
+    assert "kind: 'real'," in legacy_body
+    assert "kind: 'decoy'," in legacy_body
+    assert "realNames.add(entry.displayName);" in legacy_body
+
+    builder_start = source.index(
+        "function _routerFxBuildGridCells(realEntries, seedKey, visualMode) {",
+    )
+    builder_end = source.index("  function _buildRouterFxElement", builder_start)
+    builder_body = source[builder_start:builder_end]
+    assert "_routerFxNormalizeVisualMode(visualMode) === 'legacy_grid'" in builder_body
+    assert "_routerFxBuildLegacyGridCells(realEntries, seedKey)" in builder_body
+    assert "_routerFxBuildCandidateGridCells(realEntries, seedKey)" in builder_body
+    assert "wrap.dataset.panel = _routerFxPanelDataset(visualMode);" in source
+    assert "_routerFxBuildGridCells(realEntries, seedKey || undefined, visualMode);" in source
+    assert "cells[i].kind === 'real' && cells[i].entry.tiers.indexOf(norm) >= 0" in source
+    assert '.router-fx[data-panel="legacy-grid"] .router-fx-grid' in css
 
 
 def test_router_fx_cells_render_plain_model_names_only() -> None:
@@ -2579,7 +2619,10 @@ def test_router_fx_visualisation_pref_is_client_side_localstorage() -> None:
     source = CHAT_JS.read_text(encoding="utf-8")
 
     assert "const _ROUTER_FX_PREF_KEY = 'opensquilla-router-fx';" in source
-    assert "const _routerFx = { enabled: true, variant: 'default' };" in source
+    assert (
+        "const _routerFx = { enabled: true, visualMode: 'real_candidates', "
+        "variant: 'default' };"
+    ) in source
     assert "function _routerFxLoadPref() {" in source
     assert "function _routerFxSavePref() {" in source
     assert "localStorage.getItem(_ROUTER_FX_PREF_KEY)" in source
@@ -2596,6 +2639,8 @@ def test_router_fx_visualisation_pref_is_client_side_localstorage() -> None:
     load_body = source[load_start:load_end]
     assert "const saved = JSON.parse(raw);" in load_body
     assert "if (typeof saved.enabled === 'boolean') _routerFx.enabled = saved.enabled;" in load_body
+    assert "saved.visualMode" not in load_body
+    assert "saved.panel" not in load_body
     assert "saved.variant" not in load_body
     assert "_routerFx.variant = 'default';" in load_body
     assert "} catch { /* keep defaults */ }" in load_body
@@ -2606,6 +2651,8 @@ def test_router_fx_visualisation_pref_is_client_side_localstorage() -> None:
     save_body = source[save_start:save_end]
     assert "localStorage.setItem(_ROUTER_FX_PREF_KEY, JSON.stringify({" in save_body
     assert "enabled: _routerFx.enabled," in save_body
+    assert "visualMode:" not in save_body
+    assert "panel:" not in save_body
     assert "variant:" not in save_body
     assert "} catch { /* preference is best-effort */ }" in save_body
 
@@ -2630,7 +2677,10 @@ def test_router_effects_default_on_and_cloud_choice_hidden() -> None:
         .read_text(encoding="utf-8")
     )
 
-    assert "const _routerFx = { enabled: true, variant: 'default' };" in chat_source
+    assert (
+        "const _routerFx = { enabled: true, visualMode: 'real_candidates', "
+        "variant: 'default' };"
+    ) in chat_source
     assert (
         "try { return window.localStorage.getItem(_PREF_KEY) !== '0'; } catch { return true; }"
         in savings_source


### PR DESCRIPTION
## Summary
- Hotfix replay of c023d9e466286c971cd237f9cdad3fab1c5e5bc6 onto current origin/main.
- Adds squilla_router.visual_mode with default real_candidates and config-safe legacy_grid / model_space aliases.
- Keeps legacy_grid visual-only: decoy cells do not carry tier metadata or affect winner lookup.

## Conflict handling
- Cherry-picked the source commit with conflicts only in gateway tests.
- Resolved tests by keeping main-line context and adding only the visual_mode assertions from the source change, excluding unrelated parent-commit test context.

## Validation
- uv run ruff check src tests
- /home/weihe/.config/superpowers/worktrees/opensquilla/multi-provider-routing/.venv/bin/python -m pytest tests/test_gateway/test_boot_provider_env.py tests/test_gateway/test_chat_view_static.py -q
- node --check src/opensquilla/gateway/static/js/views/chat.js
- git diff --check

## Risk
- Narrow UI/config hotfix. Default behavior remains real_candidates.
- Browser functional router-fx suite was not run; coverage here is static WebUI assertions plus config/runtime unit tests.