### PR TITLE
feat: add Requesty as an OpenAI-compatible provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,8 +157,8 @@ Onboarding-verified providers include:
 - Volcengine Ark
 
 OpenSquilla also carries provider registry entries for additional
-OpenAI-compatible or self-hosted backends. Use `opensquilla providers list` on
-your install to see the current catalog.
+OpenAI-compatible or self-hosted backends, such as Requesty (`requesty`). Use
+`opensquilla providers list` on your install to see the current catalog.
 
 Read: [`providers-and-models.md`](providers-and-models.md)
 

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -46,6 +46,7 @@ Direct provider examples:
 opensquilla configure provider --provider openai --model gpt-5.4-mini --api-key-env OPENAI_API_KEY
 opensquilla configure provider --provider anthropic --model claude-sonnet-4-5 --api-key-env ANTHROPIC_API_KEY
 opensquilla configure provider --provider gemini --model gemini-2.5-flash --api-key-env GEMINI_API_KEY
+opensquilla configure provider --provider requesty --model openai/gpt-4o-mini --api-key-env REQUESTY_API_KEY
 opensquilla configure provider --provider ollama --model llama3.1
 ```
 
@@ -90,9 +91,10 @@ This build exposes onboarding support for:
 - Baidu Qianfan
 - Volcengine Ark
 
-The provider registry may contain additional compatible providers for advanced
-or self-hosted setups. Use `opensquilla providers list` on your install for the
-current catalog.
+The provider registry also carries experimental OpenAI-compatible providers
+such as Requesty (`requesty`, `REQUESTY_API_KEY`, `https://router.requesty.ai/v1`)
+for advanced or self-hosted setups. Use `opensquilla providers list` on your
+install for the current catalog.
 
 ### OpenAI: `openai` vs `openai_responses`
 

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -111,6 +111,7 @@ base_url = "https://tokenrhythm.studio/v1"
 # provider      env var                 default base_url
 # tokenrhythm   TOKENRHYTHM_API_KEY      https://tokenrhythm.studio/v1
 # openrouter    OPENROUTER_API_KEY       https://openrouter.ai/api/v1
+# requesty      REQUESTY_API_KEY         https://router.requesty.ai/v1
 # openai        OPENAI_API_KEY           https://api.openai.com/v1
 # openai_responses OPENAI_API_KEY        https://api.openai.com/v1  (native Responses-API shape; chat+responses)
 # anthropic     ANTHROPIC_API_KEY        https://api.anthropic.com

--- a/src/opensquilla/onboarding/provider_specs.py
+++ b/src/opensquilla/onboarding/provider_specs.py
@@ -53,6 +53,7 @@ class ProviderSetupSpec:
 
 _PROVIDER_LABELS: dict[str, str] = {
     "openrouter": "OpenRouter",
+    "requesty": "Requesty",
     "openai": "OpenAI",
     "azure": "Azure OpenAI",
     "anthropic": "Anthropic",

--- a/src/opensquilla/provider/registry.py
+++ b/src/opensquilla/provider/registry.py
@@ -201,6 +201,13 @@ for _provider_spec in [
         catalog_source=("openai",),
     ),
     _spec(
+        "requesty",
+        "openai_compat",
+        "requesty",
+        "REQUESTY_API_KEY",
+        "https://router.requesty.ai/v1",
+    ),
+    _spec(
         "openai_responses",
         "openai_responses",
         "openai_responses",

--- a/tests/test_onboarding/test_provider_specs.py
+++ b/tests/test_onboarding/test_provider_specs.py
@@ -78,6 +78,7 @@ EXPECTED_VERIFIED = {
 EXPECTED_EXPERIMENTAL = {
     "azure", "bailian_coding", "bailian_coding_cn", "kimi_coding_openai",
     "kimi_coding_anthropic", "minimax", "minimax_openai", "minimax_coding_openai",
+    "requesty",
     "minimax_coding_anthropic", "minimax_cn", "minimax_global", "mimo_openai",
     "mimo_anthropic", "mistral", "groq", "aihubmix", "vllm", "custom",
     "custom_anthropic",


### PR DESCRIPTION
## Summary

Adds **Requesty** ([requesty.ai](https://requesty.ai)) as an OpenAI-compatible LLM provider, registered the same way as the other OpenAI-compatible gateways.

Requesty is an OpenAI-compatible LLM gateway. It exposes the standard `/v1/chat/completions` API, uses `Authorization: Bearer <key>` auth, and follows `provider/model` naming (e.g. `openai/gpt-4o-mini`), so it slots into the existing OpenAI-compatible path with no new backend code.

## What changed

New `requesty` ProviderSpec:

- `backend = "openai_compat"`
- `provider_kind = "requesty"`
- `env_key = "REQUESTY_API_KEY"`
- `default_base_url = "https://router.requesty.ai/v1"`

Wiring sites:

- `src/opensquilla/provider/registry.py`: new `_spec("requesty", "openai_compat", "requesty", "REQUESTY_API_KEY", "https://router.requesty.ai/v1")` next to the OpenAI spec.
- `src/opensquilla/onboarding/provider_specs.py`: added `requesty` to `_PROVIDER_LABELS` ("Requesty"). It is deliberately not added to `_ONBOARDING_VERIFIED_PROVIDER_IDS`, so it surfaces with the "(experimental)" caveat: I have only exercised chat completions against it, not the full agent stack that the verified tier promises.
- `opensquilla.toml.example`: added a `requesty  REQUESTY_API_KEY  https://router.requesty.ai/v1` row to the provider quick-reference table (active default unchanged).
- `docs/providers-and-models.md` and `docs/configuration.md`: mention Requesty as an experimental registry provider and add a `configure provider` example.
- `tests/test_onboarding/test_provider_specs.py`: added `requesty` to `EXPECTED_EXPERIMENTAL` so the exhaustiveness assertions stay green.

## Verification

- Rebased on current `main` (after the verified/experimental split and the `MAINSTREAM_PROVIDER_LEVELS` removal).
- `uv run pytest tests/test_provider_mainstream_profiles.py tests/test_onboarding/test_provider_specs.py tests/test_provider_request_proof.py -q`: **234 passed**.
- `ruff check` on the edited source modules: clean (the one I001 hint in `test_provider_specs.py` is present on `main` as well).
- Registry resolves: `get_provider_spec("requesty")` returns backend `openai_compat`, env `REQUESTY_API_KEY`, base `https://router.requesty.ai/v1`, and the onboarding payload lists it as runtime-supported with the experimental label.

### Live check

Ran a real chat completion against `https://router.requesty.ai/v1/chat/completions` with model `openai/gpt-4o-mini` (`max_tokens=16`): HTTP **200**, returned a normal assistant completion (`gpt-4o-mini-2024-07-18`). Confirms the base URL, auth scheme, and model-naming convention encoded in the spec are correct.

## Links

- https://requesty.ai
- https://docs.requesty.ai

Disclosure: I work at Requesty. Happy to adjust anything to match project conventions.
