### PR TITLE
fix: clarify SSRF fake-IP DNS blocks

### DIFF
--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -54,6 +54,13 @@
 # search_proxy = ""               # e.g. "http://127.0.0.1:7890"
 # search_use_env_proxy = false    # true = allow HTTP_PROXY/HTTPS_PROXY if search_proxy is empty
 
+# Tool safety settings.
+# Some local proxy/fake-IP DNS setups resolve public domains through RFC 2544
+# test-network addresses (198.18.0.0/15). Leave this empty unless you trust
+# that fake-IP resolver; other private/internal ranges remain hard-blocked.
+# [tools]
+# trusted_fake_ip_cidrs = ["198.18.0.0/15"]
+
 [llm]
 provider = "openrouter"
 model = "deepseek/deepseek-v4-pro"

--- a/src/opensquilla/tools/ssrf.py
+++ b/src/opensquilla/tools/ssrf.py
@@ -117,4 +117,33 @@ def _is_trusted_fake_ip(addr: IPAddress, trusted_networks: tuple[IPNetwork, ...]
 
 
 def _blocked_message(hostname: str, addr: IPAddress, reason: str) -> str:
-    return f"Blocked: {hostname} resolves to {addr} ({reason})"
+    hint = _dns_hijack_hint(hostname, addr)
+    return f"Blocked: {hostname} resolves to {addr} ({reason}{hint})"
+
+
+def _dns_hijack_hint(hostname: str, addr: IPAddress) -> str:
+    if _hostname_is_ip_literal(hostname):
+        return ""
+    if not (addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved):
+        return ""
+
+    hint = (
+        "; if this is a public domain, your DNS/proxy may be returning an "
+        "ISP-level fake/private IP"
+    )
+    if addr.version == 4 and addr in RFC2544_FAKE_IP_NETWORK:
+        hint += (
+            f"; configure [tools].trusted_fake_ip_cidrs = [\"{RFC2544_FAKE_IP_NETWORK}\"] "
+            "only for trusted fake-IP DNS"
+        )
+    else:
+        hint += "; check DNS/proxy settings because this range cannot be bypassed"
+    return hint
+
+
+def _hostname_is_ip_literal(hostname: str) -> bool:
+    try:
+        ipaddress.ip_address(hostname.strip("[]"))
+    except ValueError:
+        return False
+    return True

--- a/tests/test_security/test_ssrf_fake_ip.py
+++ b/tests/test_security/test_ssrf_fake_ip.py
@@ -35,6 +35,19 @@ def test_rfc2544_fake_ip_is_blocked_by_default(monkeypatch):
 
     assert "198.18.0.2" in str(excinfo.value)
     assert "198.18.0.0/15" in str(excinfo.value)
+    assert "ISP-level fake/private IP" in str(excinfo.value)
+
+
+def test_private_dns_hijack_message_names_public_domain_scenario(monkeypatch):
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("10.0.0.8"))
+
+    with pytest.raises(SSRFBlockedError) as excinfo:
+        ssrf.validate_http_url_for_fetch("https://github.com/OpenSquilla/opensquilla")
+
+    message = str(excinfo.value)
+    assert "github.com" in message
+    assert "ISP-level fake/private IP" in message
+    assert "check DNS/proxy settings" in message
 
 
 def test_rfc2544_fake_ip_can_be_explicitly_trusted(monkeypatch):


### PR DESCRIPTION
## Summary
- add SSRF block guidance that names ISP/proxy fake-IP DNS for public domains resolving to private/reserved ranges
- keep non-RFC2544 private ranges hard-blocked while pointing users to DNS/proxy settings
- document the RFC2544 trusted fake-IP DNS escape hatch in the sample config

## Tests
- python3 -m py_compile src/opensquilla/tools/ssrf.py tests/test_security/test_ssrf_fake_ip.py
- not run: python3 -m pytest tests/test_security/test_ssrf_fake_ip.py (pytest is not installed in this environment)