### PR TITLE
Make SSRF fake-IP DNS failures actionable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,6 +248,27 @@ opensquilla agent \
 
 Read: [`tools-and-sandbox.md`](tools-and-sandbox.md)
 
+## Outbound URL Filtering And Fake-IP DNS
+
+URL-fetching tools validate resolved addresses through the shared SSRF guard in
+`opensquilla.tools.ssrf`. Private, loopback, link-local, and reserved ranges are
+blocked by default.
+
+Some trusted proxy or fake-IP DNS setups resolve public hostnames such as
+`github.com` to addresses in the RFC 2544 benchmark range `198.18.0.0/15`.
+OpenSquilla keeps blocking those addresses unless the operator explicitly opts
+in:
+
+```toml
+[tools]
+trusted_fake_ip_cidrs = ["198.18.0.0/15"]
+```
+
+Only subnets of `198.18.0.0/15` are accepted in this setting. Loopback, RFC
+1918 private ranges, link-local addresses, and other internal ranges remain
+hard-blocked even if configured. If a public hostname resolves to one of those
+hard-blocked ranges, fix the DNS or proxy setup instead of bypassing the guard.
+
 ## Gateway Binding
 
 Foreground:

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -63,6 +63,13 @@ frontend = "vue"
 # search_fallback_policy = "off"  # "off" or "network" retry via DuckDuckGo
 # search_diagnostics = false      # true = include provider-attempt diagnostics
 
+# Tool safety settings.
+# Some local proxy/fake-IP DNS setups resolve public domains through RFC 2544
+# test-network addresses (198.18.0.0/15). Leave this empty unless you trust
+# that fake-IP resolver; other private/internal ranges remain hard-blocked.
+# [tools]
+# trusted_fake_ip_cidrs = ["198.18.0.0/15"]
+
 [llm]
 provider = "openrouter"
 model = "deepseek/deepseek-v4-pro"

--- a/src/opensquilla/tools/ssrf.py
+++ b/src/opensquilla/tools/ssrf.py
@@ -117,4 +117,33 @@ def _is_trusted_fake_ip(addr: IPAddress, trusted_networks: tuple[IPNetwork, ...]
 
 
 def _blocked_message(hostname: str, addr: IPAddress, reason: str) -> str:
-    return f"Blocked: {hostname} resolves to {addr} ({reason})"
+    hint = _dns_hijack_hint(hostname, addr)
+    return f"Blocked: {hostname} resolves to {addr} ({reason}{hint})"
+
+
+def _dns_hijack_hint(hostname: str, addr: IPAddress) -> str:
+    if _hostname_is_ip_literal(hostname):
+        return ""
+    if not (addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved):
+        return ""
+
+    hint = (
+        "; if this is a public domain, your DNS/proxy may be returning an "
+        "ISP-level fake/private IP"
+    )
+    if addr.version == 4 and addr in RFC2544_FAKE_IP_NETWORK:
+        hint += (
+            f"; configure [tools].trusted_fake_ip_cidrs = [\"{RFC2544_FAKE_IP_NETWORK}\"] "
+            "only for trusted fake-IP DNS"
+        )
+    else:
+        hint += "; check DNS/proxy settings because this range cannot be bypassed"
+    return hint
+
+
+def _hostname_is_ip_literal(hostname: str) -> bool:
+    try:
+        ipaddress.ip_address(hostname.strip("[]"))
+    except ValueError:
+        return False
+    return True

--- a/tests/test_security/test_ssrf_fake_ip.py
+++ b/tests/test_security/test_ssrf_fake_ip.py
@@ -35,6 +35,19 @@ def test_rfc2544_fake_ip_is_blocked_by_default(monkeypatch):
 
     assert "198.18.0.2" in str(excinfo.value)
     assert "198.18.0.0/15" in str(excinfo.value)
+    assert "ISP-level fake/private IP" in str(excinfo.value)
+
+
+def test_private_dns_hijack_message_names_public_domain_scenario(monkeypatch):
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fake_getaddrinfo("10.0.0.8"))
+
+    with pytest.raises(SSRFBlockedError) as excinfo:
+        ssrf.validate_http_url_for_fetch("https://github.com/OpenSquilla/opensquilla")
+
+    message = str(excinfo.value)
+    assert "github.com" in message
+    assert "ISP-level fake/private IP" in message
+    assert "check DNS/proxy settings" in message
 
 
 def test_rfc2544_fake_ip_can_be_explicitly_trusted(monkeypatch):


### PR DESCRIPTION
## Summary
- land the reviewed SSRF fake-IP DNS guidance from @C1-BA-B1-F3's contributor PR https://github.com/opensquilla/opensquilla/pull/298 on top of current `dev`
- keep default SSRF blocking unchanged while making public-domain fake-IP DNS failures actionable
- document `[tools].trusted_fake_ip_cidrs` in both `opensquilla.toml.example` and `docs/configuration.md`

Closes #294

## Contributor Credit
- Original report and patch: @C1-BA-B1-F3 in https://github.com/opensquilla/opensquilla/pull/298 and https://github.com/opensquilla/opensquilla/issues/294
- Maintainer follow-up: retargeted the change to `dev`, added the missing `docs/configuration.md` acceptance item, and ran the protected CI path.

## Review
- Security boundary remains default-deny: RFC1918, loopback, link-local, and non-RFC2544 internal ranges stay blocked.
- The RFC2544 opt-in remains limited by `validate_trusted_fake_ip_cidrs`.
- The added hint is suppressed for IP-literal hostnames and does not bypass validation.

## Tests
- `PYTHONPATH=src /home/weihe/work/code/rhythm/opensquilla/.venv/bin/python -m py_compile src/opensquilla/tools/ssrf.py tests/test_security/test_ssrf_fake_ip.py`
- `PYTHONPATH=src /home/weihe/work/code/rhythm/opensquilla/.venv/bin/pytest tests/test_security/test_ssrf_fake_ip.py`
- `/home/weihe/work/code/rhythm/opensquilla/.venv/bin/ruff check src/opensquilla/tools/ssrf.py tests/test_security/test_ssrf_fake_ip.py`
- `git diff --check`

## Notes
- The original fork branch could not be updated from this maintainer environment, so this maintainer PR preserved the original patch intent, credited the original contributor explicitly, and added the missing docs acceptance item.
