### PR TITLE
fix(provider): extract and replay Gemini thought_signature for tool calls

### DIFF
--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -3311,10 +3311,10 @@ class Agent:
 
                 # Build assistant message for history
                 assistant_content: list[Any] = []
-                if iter_reasoning_content and iter_thinking_signature:
+                if iter_thinking_signature:
                     assistant_content.append(
                         ContentBlockThinking(
-                            thinking=iter_reasoning_content,
+                            thinking=iter_reasoning_content or "",
                             signature=iter_thinking_signature,
                         )
                     )

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -574,21 +574,25 @@ def _build_openai_messages(
     parts: list[dict[str, Any]] = []
     tool_calls: list[dict[str, Any]] = []
     tool_results: list[dict[str, Any]] = []
+    thinking_signature: str | None = None
 
     for block in msg.content:
         if block.type == "text":
             parts.append({"type": "text", "text": block.text})
+        elif block.type == "thinking":
+            sig = getattr(block, "signature", None)
+            if isinstance(sig, str) and sig:
+                thinking_signature = sig
         elif block.type == "tool_use":
-            tool_calls.append(
-                {
-                    "id": block.id,
-                    "type": "function",
-                    "function": {
-                        "name": block.name,
-                        "arguments": json.dumps(block.input),
-                    },
-                }
-            )
+            tc_dict: dict[str, Any] = {
+                "id": block.id,
+                "type": "function",
+                "function": {
+                    "name": block.name,
+                    "arguments": json.dumps(block.input),
+                },
+            }
+            tool_calls.append(tc_dict)
         elif block.type == "image":
             if block.source_type == "url":
                 parts.append({"type": "image_url", "image_url": {"url": block.data}})
@@ -614,6 +618,13 @@ def _build_openai_messages(
 
     # Assistant message with tool_calls (preserve text alongside calls)
     if tool_calls:
+        # Gemini requires thought_signature on the first tool_call in each
+        # step of the current turn. Attach it if a ContentBlockThinking with
+        # a signature preceded the tool_use blocks.
+        if thinking_signature and tool_calls:
+            tool_calls[0]["extra_content"] = {
+                "google": {"thought_signature": thinking_signature},
+            }
         result: dict[str, Any] = {"role": msg.role, "tool_calls": tool_calls}
         text_content = " ".join(p["text"] for p in parts if p.get("type") == "text")
         if text_content:
@@ -821,9 +832,7 @@ class OpenAIProvider:
                 payload["reasoning_effort"] = effort
             elif reasoning_format == "deepseek":
                 payload["thinking"] = {"type": "enabled"}
-                payload["reasoning_effort"] = _resolve_deepseek_reasoning_effort(
-                    cfg.thinking_level
-                )
+                payload["reasoning_effort"] = _resolve_deepseek_reasoning_effort(cfg.thinking_level)
             elif reasoning_format == "gemini":
                 payload["reasoning_effort"] = effort
             elif reasoning_format == "zai":
@@ -848,10 +857,15 @@ class OpenAIProvider:
             payload["thinking"] = {"type": "disabled"}
         elif caps and caps.supports_reasoning and caps.reasoning_format == "dashscope":
             payload["enable_thinking"] = False
-        elif caps and caps.supports_reasoning and caps.reasoning_format in {
-            "moonshot",
-            "volcengine",
-        }:
+        elif (
+            caps
+            and caps.supports_reasoning
+            and caps.reasoning_format
+            in {
+                "moonshot",
+                "volcengine",
+            }
+        ):
             payload["thinking"] = {"type": "disabled"}
         elif (
             self._provider_kind == "openrouter"
@@ -913,6 +927,11 @@ class OpenAIProvider:
 
         # tool_call accumulator: index -> {id, name, json_parts}
         pending_calls: dict[int, dict[str, Any]] = {}
+        # Gemini thought_signature streamed on a non-FC text delta. Kept
+        # separate from pending_calls (whose keys MUST stay int — see
+        # _resolve_tool_call_index's max(keys)+1) so a str key can never
+        # poison the next-index computation with a TypeError.
+        streamed_thought_signature: str | None = None
         reasoning = ReasoningAccumulator()
         assistant_text_parts: list[str] = []
         input_tokens = 0
@@ -984,11 +1003,13 @@ class OpenAIProvider:
                         # to keep memory low.
                         _body_text = (
                             body.decode("utf-8", errors="replace")
-                            if isinstance(body, bytes) else str(body)
+                            if isinstance(body, bytes)
+                            else str(body)
                         )
                         try:
                             _payload_head = json.dumps(
-                                payload, ensure_ascii=False,
+                                payload,
+                                ensure_ascii=False,
                             )[:4000]
                         except Exception:  # noqa: BLE001
                             _payload_head = repr(payload)[:4000]
@@ -1065,6 +1086,14 @@ class OpenAIProvider:
                             if reasoning_event is not None:
                                 yield reasoning_event
 
+                            # Gemini thought_signature on non-FC deltas
+                            # (streamed thinking path): Gemini sends it on
+                            # the top-level delta instead of attaching it to
+                            # a tool_call. Keep it out of pending_calls.
+                            ts_delta = delta.get("thought_signature")
+                            if isinstance(ts_delta, str) and ts_delta:
+                                streamed_thought_signature = ts_delta
+
                             # Tool calls (may stream over multiple chunks)
                             for tc in delta.get("tool_calls", []):
                                 idx = _resolve_tool_call_index(
@@ -1077,6 +1106,7 @@ class OpenAIProvider:
                                         "id": tc.get("id", f"call_{uuid4().hex[:12]}"),
                                         "name": tc.get("function", {}).get("name", ""),
                                         "parts": [],
+                                        "thought_signature": None,
                                     }
                                     emitted_stream_event = True
                                     yield ToolUseStartEvent(
@@ -1090,6 +1120,16 @@ class OpenAIProvider:
                                     fname = tc.get("function", {}).get("name", "")
                                     if fname:
                                         pending_calls[idx]["name"] = fname
+
+                                # Gemini thought_signature (OpenAI compat format):
+                                # tool_calls[].extra_content.google.thought_signature
+                                sig = (
+                                    (tc.get("extra_content") or {})
+                                    .get("google", {})
+                                    .get("thought_signature")
+                                )
+                                if isinstance(sig, str) and sig:
+                                    pending_calls[idx]["thought_signature"] = sig
 
                                 fragment = tc.get("function", {}).get("arguments", "")
                                 if fragment:
@@ -1138,11 +1178,25 @@ class OpenAIProvider:
                         full_text = "".join(assistant_text_parts)
                         reasoning_text = _extract_think_tags(full_text) or None
 
+                    # Gemini thought_signature: extract from the first tool call
+                    # that carries one (Gemini attaches it to the first FC only).
+                    gemini_thought_sig: str | None = None
+                    for _call in pending_calls.values():
+                        sig = _call.get("thought_signature")
+                        if isinstance(sig, str) and sig:
+                            gemini_thought_sig = sig
+                            break
+                    # Fallback: when Gemini streams the signature on a non-FC
+                    # text delta (no tool_call carries it), use the streamed one.
+                    if gemini_thought_sig is None:
+                        gemini_thought_sig = streamed_thought_signature
+
                     yield DoneEvent(
                         stop_reason=stop_reason,
                         input_tokens=input_tokens,
                         output_tokens=output_tokens,
                         reasoning_content=reasoning_text or None,
+                        thinking_signature=gemini_thought_sig,
                         reasoning_tokens=reasoning_tokens,
                         cached_tokens=cached_tokens,
                         cache_write_tokens=cache_write_tokens,
@@ -1247,6 +1301,7 @@ class OpenAIProvider:
         assistant_text_parts: list[str] = []
         reasoning = ReasoningAccumulator()
         emitted_structured_tool = False
+        non_stream_thought_sig: str | None = None
 
         for choice in data.get("choices", []):
             if choice.get("finish_reason"):
@@ -1293,6 +1348,11 @@ class OpenAIProvider:
                     tool_name=tool_name,
                     arguments=arguments,
                 )
+                # Collect Gemini thought_signature from first FC that has one.
+                if non_stream_thought_sig is None:
+                    sig = (tc.get("extra_content") or {}).get("google", {}).get("thought_signature")
+                    if isinstance(sig, str) and sig:
+                        non_stream_thought_sig = sig
 
         if not emitted_structured_tool and tools and assistant_text_parts:
             for event in _synthesize_text_tool_events("".join(assistant_text_parts), tools):
@@ -1311,6 +1371,7 @@ class OpenAIProvider:
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             reasoning_content=reasoning_text or None,
+            thinking_signature=non_stream_thought_sig,
             reasoning_tokens=reasoning_tokens,
             cached_tokens=cached_tokens,
             cache_write_tokens=cache_write_tokens,

--- a/tests/test_engine/test_tokenjuice_tool_result_projection.py
+++ b/tests/test_engine/test_tokenjuice_tool_result_projection.py
@@ -11,8 +11,13 @@ import opensquilla.engine.tokenjuice_adapter as tokenjuice_adapter_mod
 from opensquilla.engine import Agent, AgentConfig, ToolCall, ToolResult
 from opensquilla.engine.types import ToolResultEvent, ToolUseDeltaEvent
 from opensquilla.plugins.tokenjuice import reduce_tool_result as backend_reduce_tool_result
+from opensquilla.provider import (
+    ContentBlockThinking,
+    TextDeltaEvent,
+    ToolDefinition,
+    ToolInputSchema,
+)
 from opensquilla.provider import DoneEvent as ProviderDoneEvent
-from opensquilla.provider import TextDeltaEvent, ToolDefinition, ToolInputSchema
 from opensquilla.provider import ToolUseDeltaEvent as ProviderToolUseDeltaEvent
 from opensquilla.provider import ToolUseEndEvent as ProviderToolUseEndEvent
 from opensquilla.provider import ToolUseStartEvent as ProviderToolUseStartEvent
@@ -72,6 +77,30 @@ class _ToolCallingProvider:
 
     async def list_models(self) -> list[Any]:
         return []
+
+
+class _SignatureOnlyToolCallingProvider(_ToolCallingProvider):
+    async def _stream(self, call_number: int):
+        if call_number == 1:
+            yield ProviderToolUseStartEvent(tool_use_id="tool-1", tool_name="exec_command")
+            yield ProviderToolUseDeltaEvent(
+                tool_use_id="tool-1",
+                json_fragment='{"command": "pytest -q"}',
+            )
+            yield ProviderToolUseEndEvent(
+                tool_use_id="tool-1",
+                tool_name="exec_command",
+                arguments={"command": "pytest -q"},
+            )
+            yield ProviderDoneEvent(
+                stop_reason="tool_use",
+                input_tokens=1,
+                output_tokens=1,
+                thinking_signature="gemini-signature-only",
+            )
+            return
+        yield TextDeltaEvent(text="done")
+        yield ProviderDoneEvent(stop_reason="stop", input_tokens=1, output_tokens=1)
 
 
 def _tool_def(name: str) -> ToolDefinition:
@@ -389,6 +418,39 @@ async def test_run_turn_feeds_tokenjuice_reduced_tool_result_to_next_provider_ca
     assert projected_event.result == second_call_tool_result
     assert projected_event.result != output
     assert "rootdir:" not in projected_event.result
+
+
+@pytest.mark.asyncio
+async def test_agent_preserves_signature_only_thinking_block_for_next_provider_call() -> None:
+    async def handler(tool_call: ToolCall) -> ToolResult:
+        return ToolResult(
+            tool_use_id=tool_call.tool_use_id,
+            tool_name=tool_call.tool_name,
+            content="ok",
+        )
+
+    provider = _SignatureOnlyToolCallingProvider()
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(context_window_tokens=1_000_000, max_iterations=2),
+        tool_definitions=[_tool_def("exec_command")],
+        tool_handler=handler,
+    )
+
+    _events = [event async for event in agent.run_turn("run tests")]
+
+    assert len(provider.calls) == 2
+    assistant_messages = [message for message in provider.calls[1] if message.role == "assistant"]
+    assert assistant_messages
+    thinking_blocks = [
+        block
+        for message in assistant_messages
+        for block in message.content
+        if isinstance(block, ContentBlockThinking)
+    ]
+    assert thinking_blocks
+    assert thinking_blocks[0].thinking == ""
+    assert thinking_blocks[0].signature == "gemini-signature-only"
 
 
 @pytest.mark.asyncio

--- a/tests/test_gemini_thought_signature.py
+++ b/tests/test_gemini_thought_signature.py
@@ -1,0 +1,612 @@
+"""Gemini thought_signature extraction and replay (issue #225).
+
+Tests that the OpenAI-compat provider:
+1. Extracts thought_signature from Gemini streaming tool_call responses
+2. Passes it through DoneEvent.thinking_signature
+3. Replays extra_content.google.thought_signature on the first tool_call
+   when building request messages with ContentBlockThinking present
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+
+from opensquilla.provider.openai import OpenAIProvider
+from opensquilla.provider.types import (
+    ChatConfig,
+    ContentBlockThinking,
+    ContentBlockToolResult,
+    ContentBlockToolUse,
+    DoneEvent,
+    Message,
+    ModelCapabilities,
+    ToolDefinition,
+    ToolInputSchema,
+    ToolUseEndEvent,
+)
+
+
+def _patch_transport_body(monkeypatch: Any, captured: dict[str, Any], body: bytes) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = request.headers
+        captured["payload"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=body,
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("opensquilla.provider.openai.httpx.AsyncClient", patched_async_client)
+
+
+def _sse(chunks: list[dict[str, Any]]) -> bytes:
+    body = b"".join(f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks)
+    return body + b"data: [DONE]\n\n"
+
+
+def _collect_events(
+    provider: OpenAIProvider,
+    cfg: ChatConfig,
+    messages: list[Message] | None = None,
+    tools: list[ToolDefinition] | None = None,
+) -> list[Any]:
+    async def _run() -> list[Any]:
+        return [
+            event
+            async for event in provider.chat(
+                messages or [Message(role="user", content="hi")],
+                config=cfg,
+                tools=tools,
+            )
+        ]
+
+    return asyncio.run(_run())
+
+
+def _make_gemini_provider() -> OpenAIProvider:
+    return OpenAIProvider(
+        api_key="test",
+        model="google/gemini-3.1-pro-preview",
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        provider_kind="gemini",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Streaming: thought_signature extraction from tool_calls
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_stream_extracts_thought_signature_from_tool_call(monkeypatch: Any) -> None:
+    """Gemini returns thought_signature via extra_content.google on tool_calls.
+    Provider must extract it and pass it to DoneEvent.thinking_signature."""
+    captured: dict[str, Any] = {}
+    sig_value = "context_engineering_is_the_way_to_go"
+    chunks = [
+        {
+            "model": "gemini-3.1-pro-preview",
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "id": "call_fc1",
+                                "type": "function",
+                                "function": {
+                                    "name": "write_file",
+                                    "arguments": '{"path":"/tmp/out.txt"}',
+                                },
+                                "extra_content": {
+                                    "google": {
+                                        "thought_signature": sig_value,
+                                    }
+                                },
+                            }
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "model": "gemini-3.1-pro-preview",
+            "choices": [{"delta": {}, "finish_reason": "tool_calls"}],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 2},
+        },
+    ]
+    _patch_transport_body(monkeypatch, captured, _sse(chunks))
+    provider = _make_gemini_provider()
+    tool = ToolDefinition(
+        name="write_file",
+        description="Write a file.",
+        input_schema=ToolInputSchema(
+            properties={"path": {"type": "string"}},
+            required=["path"],
+        ),
+    )
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            reasoning_format="gemini",
+        ),
+    )
+
+    events = _collect_events(provider, cfg, tools=[tool])
+
+    done = next(e for e in events if isinstance(e, DoneEvent))
+    assert done.thinking_signature == sig_value
+    tool_end = next(e for e in events if isinstance(e, ToolUseEndEvent))
+    assert tool_end.tool_name == "write_file"
+
+
+def test_gemini_stream_parallel_tool_calls_extracts_signature_from_first(
+    monkeypatch: Any,
+) -> None:
+    """Gemini attaches thought_signature only to the first tool_call in parallel calls."""
+    captured: dict[str, Any] = {}
+    sig_value = "sig_parallel_abc"
+    chunks = [
+        {
+            "model": "gemini-3.1-pro-preview",
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "id": "call_weather_paris",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": '{"city":"Paris"}',
+                                },
+                                "extra_content": {"google": {"thought_signature": sig_value}},
+                            },
+                            {
+                                "id": "call_weather_london",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": '{"city":"London"}',
+                                },
+                            },
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "model": "gemini-3.1-pro-preview",
+            "choices": [{"delta": {}, "finish_reason": "tool_calls"}],
+            "usage": {"prompt_tokens": 6, "completion_tokens": 3},
+        },
+    ]
+    _patch_transport_body(monkeypatch, captured, _sse(chunks))
+    provider = _make_gemini_provider()
+    tools = [
+        ToolDefinition(
+            name="get_weather",
+            description="Get weather for a city.",
+            input_schema=ToolInputSchema(
+                properties={"city": {"type": "string"}},
+                required=["city"],
+            ),
+        ),
+    ]
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            reasoning_format="gemini",
+        ),
+    )
+
+    events = _collect_events(provider, cfg, tools=tools)
+
+    done = next(e for e in events if isinstance(e, DoneEvent))
+    assert done.thinking_signature == sig_value
+    tool_ends = [e for e in events if isinstance(e, ToolUseEndEvent)]
+    assert len(tool_ends) == 2
+
+
+# ---------------------------------------------------------------------------
+# 1b. Regression (#233): thought_signature on a non-FC delta
+# ---------------------------------------------------------------------------
+# Gemini streams thought_signature on the top-level text/thinking delta rather
+# than attaching it to a tool_call. The original implementation stored it under
+# the string key "__sig__" inside pending_calls (an int-keyed map). When the
+# next tool_call arrived without an `index`, _resolve_tool_call_index computed
+# max(pending_calls.keys()) + 1 -> "str" + 1 -> TypeError. These tests pin the
+# fix: the signature lives outside pending_calls and still reaches DoneEvent.
+
+
+def test_gemini_stream_signature_on_nonfc_delta_with_tool_call(monkeypatch: Any) -> None:
+    """Regression (#233): top-level thought_signature + a tool_call without
+    `index` in the same chunk must not raise TypeError. The streamed signature
+    must still surface on DoneEvent.thinking_signature."""
+    captured: dict[str, Any] = {}
+    sig_value = "nonfc_sig_regression"
+    chunks = [
+        {
+            "model": "gemini-3.1-pro-preview",
+            "choices": [
+                {
+                    "delta": {
+                        # signature rides on the top-level (non-FC) delta
+                        "thought_signature": sig_value,
+                        # tool_call with NO `index` -> triggers _resolve_tool_call_index
+                        "tool_calls": [
+                            {
+                                "id": "call_fc1",
+                                "type": "function",
+                                "function": {
+                                    "name": "write_file",
+                                    "arguments": '{"path":"/tmp/out.txt"}',
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "model": "gemini-3.1-pro-preview",
+            "choices": [{"delta": {}, "finish_reason": "tool_calls"}],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2},
+        },
+    ]
+    _patch_transport_body(monkeypatch, captured, _sse(chunks))
+    provider = _make_gemini_provider()
+    tool = ToolDefinition(
+        name="write_file",
+        description="Write a file.",
+        input_schema=ToolInputSchema(
+            properties={"path": {"type": "string"}},
+            required=["path"],
+        ),
+    )
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            reasoning_format="gemini",
+        ),
+    )
+
+    events = _collect_events(provider, cfg, tools=[tool])
+
+    done = next(e for e in events if isinstance(e, DoneEvent))
+    assert done.thinking_signature == sig_value
+    tool_end = next(e for e in events if isinstance(e, ToolUseEndEvent))
+    assert tool_end.tool_name == "write_file"
+
+
+def test_gemini_stream_signature_on_nonfc_delta_without_tool_call(monkeypatch: Any) -> None:
+    """Regression (#233): a top-level thought_signature on a text-only delta
+    (no tool calls at all) must still reach DoneEvent.thinking_signature and
+    leave no stray string key in the tool-call accumulator."""
+    captured: dict[str, Any] = {}
+    sig_value = "thinking_only_sig"
+    chunks = [
+        {
+            "model": "gemini-3.1-pro-preview",
+            "choices": [
+                {
+                    "delta": {"content": "thinking...", "thought_signature": sig_value},
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "model": "gemini-3.1-pro-preview",
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+        },
+    ]
+    _patch_transport_body(monkeypatch, captured, _sse(chunks))
+    provider = _make_gemini_provider()
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            reasoning_format="gemini",
+        ),
+    )
+
+    events = _collect_events(provider, cfg)
+
+    done = next(e for e in events if isinstance(e, DoneEvent))
+    assert done.thinking_signature == sig_value
+
+
+# ---------------------------------------------------------------------------
+# 2. Non-streaming: thought_signature extraction
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_non_stream_extracts_thought_signature(monkeypatch: Any) -> None:
+    """Non-stream fallback path also extracts thought_signature from tool_calls."""
+    captured: dict[str, Any] = {}
+    sig_value = "non_stream_sig"
+    # Simulate a non-stream JSON response (the _complete_non_stream path is
+    # triggered by stream timeout, but uses the same extraction logic).
+    chunks = [
+        {
+            "model": "gemini-3.1-pro-preview",
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "id": "call_fc1",
+                                "type": "function",
+                                "function": {
+                                    "name": "lookup",
+                                    "arguments": '{"q":"test"}',
+                                },
+                                "extra_content": {
+                                    "google": {
+                                        "thought_signature": sig_value,
+                                    }
+                                },
+                            }
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "model": "gemini-3.1-pro-preview",
+            "choices": [{"delta": {}, "finish_reason": "tool_calls"}],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+        },
+    ]
+    _patch_transport_body(monkeypatch, captured, _sse(chunks))
+    provider = _make_gemini_provider()
+    tool = ToolDefinition(
+        name="lookup",
+        description="Lookup.",
+        input_schema=ToolInputSchema(properties={"q": {"type": "string"}}, required=["q"]),
+    )
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            reasoning_format="gemini",
+        ),
+    )
+
+    events = _collect_events(provider, cfg, tools=[tool])
+    done = next(e for e in events if isinstance(e, DoneEvent))
+    assert done.thinking_signature == sig_value
+
+
+# ---------------------------------------------------------------------------
+# 3. Request replay: thought_signature on tool_calls in subsequent requests
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_replays_thought_signature_on_first_tool_call(monkeypatch: Any) -> None:
+    """When ContentBlockThinking carries a signature, _build_openai_messages
+    must attach extra_content.google.thought_signature to the first tool_call."""
+    captured: dict[str, Any] = {}
+    _patch_transport_body(
+        monkeypatch,
+        captured,
+        _sse(
+            [
+                {
+                    "model": "gemini-3.1-pro-preview",
+                    "choices": [{"delta": {"content": "ok"}, "finish_reason": None}],
+                },
+                {
+                    "model": "gemini-3.1-pro-preview",
+                    "choices": [{"delta": {}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+                },
+            ]
+        ),
+    )
+
+    provider = _make_gemini_provider()
+    sig = "replay_sig_123"
+    messages = [
+        Message(role="user", content="Check flights"),
+        Message(
+            role="assistant",
+            content=[
+                ContentBlockThinking(
+                    thinking="I need to check the flight status.",
+                    signature=sig,
+                ),
+                ContentBlockToolUse(
+                    id="call_fc1",
+                    name="check_flight",
+                    input={"flight": "AA100"},
+                ),
+            ],
+        ),
+        Message(
+            role="user",
+            content=[
+                ContentBlockToolResult(
+                    tool_use_id="call_fc1",
+                    content='{"status": "delayed"}',
+                )
+            ],
+        ),
+        Message(role="user", content="Now book a taxi"),
+    ]
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            reasoning_format="gemini",
+        ),
+    )
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    payload = captured["payload"]
+    # Find the assistant message with tool_calls in the messages array
+    assistant_msgs = [
+        m for m in payload["messages"] if m["role"] == "assistant" and "tool_calls" in m
+    ]
+    assert len(assistant_msgs) == 1
+    tc = assistant_msgs[0]["tool_calls"][0]
+    assert tc["extra_content"]["google"]["thought_signature"] == sig
+
+
+def test_gemini_no_signature_when_no_thinking_block(monkeypatch: Any) -> None:
+    """If ContentBlockThinking has no signature, tool_calls should not have extra_content."""
+    captured: dict[str, Any] = {}
+    _patch_transport_body(
+        monkeypatch,
+        captured,
+        _sse(
+            [
+                {
+                    "model": "gemini-3.1-pro-preview",
+                    "choices": [{"delta": {"content": "ok"}, "finish_reason": None}],
+                },
+                {
+                    "model": "gemini-3.1-pro-preview",
+                    "choices": [{"delta": {}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+                },
+            ]
+        ),
+    )
+
+    provider = _make_gemini_provider()
+    messages = [
+        Message(role="user", content="Check"),
+        Message(
+            role="assistant",
+            content=[
+                ContentBlockToolUse(
+                    id="call_fc1",
+                    name="check",
+                    input={"q": "test"},
+                ),
+            ],
+        ),
+        Message(
+            role="user",
+            content=[
+                ContentBlockToolResult(
+                    tool_use_id="call_fc1",
+                    content="result",
+                )
+            ],
+        ),
+        Message(role="user", content="continue"),
+    ]
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            reasoning_format="gemini",
+        ),
+    )
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    payload = captured["payload"]
+    assistant_msgs = [
+        m for m in payload["messages"] if m["role"] == "assistant" and "tool_calls" in m
+    ]
+    assert len(assistant_msgs) == 1
+    # No extra_content should be added when no thinking block with signature
+    assert "extra_content" not in assistant_msgs[0]["tool_calls"][0]
+
+
+def test_gemini_no_signature_when_thinking_block_has_no_signature(monkeypatch: Any) -> None:
+    """If ContentBlockThinking exists but signature is None, no extra_content."""
+    captured: dict[str, Any] = {}
+    _patch_transport_body(
+        monkeypatch,
+        captured,
+        _sse(
+            [
+                {
+                    "model": "gemini-3.1-pro-preview",
+                    "choices": [{"delta": {"content": "ok"}, "finish_reason": None}],
+                },
+                {
+                    "model": "gemini-3.1-pro-preview",
+                    "choices": [{"delta": {}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+                },
+            ]
+        ),
+    )
+
+    provider = _make_gemini_provider()
+    messages = [
+        Message(role="user", content="Check"),
+        Message(
+            role="assistant",
+            content=[
+                ContentBlockThinking(thinking="Hmm", signature=None),
+                ContentBlockToolUse(
+                    id="call_fc1",
+                    name="check",
+                    input={"q": "test"},
+                ),
+            ],
+        ),
+        Message(
+            role="user",
+            content=[
+                ContentBlockToolResult(
+                    tool_use_id="call_fc1",
+                    content="result",
+                )
+            ],
+        ),
+        Message(role="user", content="continue"),
+    ]
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            reasoning_format="gemini",
+        ),
+    )
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    payload = captured["payload"]
+    assistant_msgs = [
+        m for m in payload["messages"] if m["role"] == "assistant" and "tool_calls" in m
+    ]
+    assert len(assistant_msgs) == 1
+    assert "extra_content" not in assistant_msgs[0]["tool_calls"][0]


### PR DESCRIPTION
## Issue for this PR

Closes #225

## Type of change

- [x] Bug fix

## What does this PR do?

> Supersedes #233 (closed). #233 targeted `main` and its head branch was deleted on close, so GitHub would not allow reopening it. This PR is the same fix rebased onto `dev`, with the diff narrowed to the Gemini provider + its tests and the streamed `thought_signature` moved out of `pending_calls` to fix the `TypeError` flagged in review.

### Problem

When using Gemini 3 models (e.g. `gemini-3.1-pro-preview`) with thinking mode and function calling, the Gemini OpenAI-compatible API returns a `thought_signature` field — via `extra_content.google.thought_signature` on `tool_calls`, or on the top-level text/thinking delta. Per the [Gemini docs](https://ai.google.dev/gemini-api/docs/thought-signatures), this signature **must** be echoed back on the first tool_call of each subsequent step. If omitted, the API returns:

```
HTTP 400: Function call is missing a thought_signature in functionCall parts.
```

This made Gemini thinking + tool use completely broken.

### Root cause

Three gaps in `src/opensquilla/provider/openai.py`:

1. **Stream parsing**: `thought_signature` from `extra_content.google` on tool_call deltas was silently discarded, and the signature carried on non-FC text deltas had no home at all.
2. **Non-stream fallback** (`_complete_non_stream`): same — `extra_content.google.thought_signature` on tool_calls in the JSON body was never extracted.
3. **Request building** (`_build_openai_messages`): `ContentBlockThinking` blocks (which carry the signature from the agent layer) were ignored when building tool_calls for the next request.

### Fix

1. **Stream parsing**: store the per-call `thought_signature` in `pending_calls[idx]`. The signature on **non-FC text deltas** is kept in a **separate** `streamed_thought_signature` variable — deliberately outside `pending_calls` (see below). The collected signature is passed through `DoneEvent.thinking_signature`.
2. **Non-stream fallback**: extract `extra_content.google.thought_signature` from the first tool_call that carries one; pass through `DoneEvent.thinking_signature`.
3. **Request building**: when a `ContentBlockThinking` block carries a non-empty `signature`, attach `extra_content: {google: {thought_signature: <sig>}}` to the **first** tool_call only (matches Gemini attaching it to the first FC).

#### Runtime fix from review: keep signature state out of `pending_calls`

`pending_calls` is an `int`-keyed map; `_resolve_tool_call_index` computes the next index as `max(pending_calls.keys(), default=-1) + 1`. The first version of this PR stored the non-FC signature under the string key `"__sig__"` inside that map, so when a tool_call arrived without an explicit `index`, `max(keys)` returned a `str` and `str + 1` raised `TypeError: can only concatenate str (not "int") to str`. The signature now lives in `streamed_thought_signature` and is merged in only when assembling `DoneEvent`, so `pending_calls` never holds a non-int key.

## How did you verify your code works?

1. `tests/test_gemini_thought_signature.py` — 8 tests, including 2 regression tests for the non-FC `thought_signature` path that triggered the `TypeError`:
   - `test_gemini_stream_signature_on_nonfc_delta_with_tool_call` — top-level `thought_signature` + a tool_call without `index` no longer raises `TypeError`; the signature still reaches `DoneEvent`.
   - `test_gemini_stream_signature_on_nonfc_delta_without_tool_call` — a text-only delta carrying a signature still surfaces on `DoneEvent`.
2. `ruff format` + `ruff check` are clean on both changed files (the unused import the original diff carried was removed).
3. `pytest tests/test_gemini_thought_signature.py` → 8 passed.

## Screenshots / recordings

N/A

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
