### PR TITLE
[codex] Preserve user message line breaks

### DIFF
--- a/opensquilla-webui/e2e/user-message-newlines.spec.ts
+++ b/opensquilla-webui/e2e/user-message-newlines.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const CONTROL_URL = '/control/'
+const SESSION_KEY = 'agent:main:webchat:e2e-user-newlines'
+
+async function seedMultilineUserHistory(page: Page) {
+  await page.route('**/api/approvals', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ pending: [] }),
+  }))
+
+  await page.routeWebSocket(/\/ws$/, ws => {
+    ws.send(JSON.stringify({ type: 'event', event: 'connect.challenge', payload: {} }))
+    ws.onMessage(message => {
+      try {
+        const frame = JSON.parse(String(message))
+        if (frame?.type !== 'req') return
+        if (frame.method === 'connect') {
+          ws.send(JSON.stringify({
+            protocol: 3,
+            policy: { tick_interval_ms: 30000 },
+          }))
+          return
+        }
+
+        const payloads: Record<string, unknown> = {
+          'agents.list': { agents: [] },
+          'chat.history': {
+            messages: [
+              {
+                role: 'user',
+                text: '你好~\n我测试一下换行功能~\n你好~\n我测试一下换行功能~',
+                id: 'msg-user-newlines',
+                timestamp: Math.floor(Date.now() / 1000) - 60,
+              },
+            ],
+            has_more: false,
+          },
+          'commands.list_for_surface': { commands: [] },
+          'config.get': {
+            squilla_router: { enabled: false, rollout_phase: 'observe', tiers: {} },
+            permissions: {},
+            skills: {},
+          },
+          'sessions.list': { sessions: [], has_more: false },
+          'sessions.messages.subscribe': {
+            subscribed: true,
+            replay_complete: true,
+            current_stream_seq: 0,
+            run_status: 'idle',
+          },
+          'usage.status': { sessions: [] },
+        }
+
+        ws.send(JSON.stringify({
+          type: 'res',
+          id: frame.id,
+          ok: true,
+          payload: payloads[String(frame.method)] ?? {},
+        }))
+      } catch {}
+    })
+  })
+}
+
+test('user message bubbles preserve authored line breaks', async ({ page }) => {
+  await seedMultilineUserHistory(page)
+  await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(SESSION_KEY))
+  await page.waitForSelector('.conn-pill', { timeout: 10000 })
+
+  const bubble = page.locator('.msg-user-bubble').first()
+  await expect(bubble).toContainText('你好~\n我测试一下换行功能~\n你好~')
+  await expect(bubble).toHaveCSS('white-space', 'pre-wrap')
+})

--- a/opensquilla-webui/src/components/chat/UserMessage.vue
+++ b/opensquilla-webui/src/components/chat/UserMessage.vue
@@ -188,6 +188,7 @@ function onMessageClick(event: MouseEvent) {
   font-size: 0.875rem;
   line-height: 1.5;
   max-width: 82%;
+  white-space: pre-wrap;
   word-break: break-word;
 }
 


### PR DESCRIPTION
## Scope

Preserve authored line breaks in Web UI user message bubbles and add a Playwright regression test for multiline user history.

## Root Cause

The user message text retained `\n`, but `.msg-user-bubble` used the browser default `white-space: normal`, so rendered chat bubbles collapsed line breaks into spaces.

## Changes

- Set `.msg-user-bubble` to `white-space: pre-wrap`.
- Add an e2e test that mocks chat history with a multiline user message and asserts the bubble keeps `pre-wrap`.

## Linked Issue

None.

## Release Note

Bug fix: Web UI user messages now preserve typed line breaks in chat bubbles.

## Test Results

- `node node_modules/@playwright/test/cli.js test e2e/user-message-newlines.spec.ts --project=chromium` (with system Chrome)
- `node scripts/check-architecture.mjs`
- `node scripts/check-chat-security.mjs`
- `node scripts/check-webui-colors.mjs`
- `node node_modules/vue-tsc/bin/vue-tsc --noEmit`
- `node node_modules/vitest/vitest.mjs run` (20 files / 146 tests)

## Safety Notes

UI-only rendering change. The test data is synthetic and contains no real transcripts, identifiers, or secrets.

## Third-Party Origin

None.