### PR TITLE
[codex] Diagnose DingTalk auth failures in channel status

### DIFF
--- a/src/opensquilla/channels/dingtalk.py
+++ b/src/opensquilla/channels/dingtalk.py
@@ -13,12 +13,16 @@ Streaming edits use :class:`dingtalk_stream.MarkdownCardInstance` —
 from __future__ import annotations
 
 import asyncio
+import json
+import platform
+import socket
 import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+import requests
 import structlog
 from pydantic import BaseModel
 
@@ -60,6 +64,21 @@ FATAL_ERROR_CLASSES: tuple[str, ...] = (
     "target_missing",
     "contract_violation",
 )
+
+_DINGTALK_AUTH_INVALID_MESSAGE = "凭证无效：检查 DingTalk AppKey/AppSecret"
+
+
+class DingTalkAuthError(RuntimeError):
+    """Raised when DingTalk rejects the configured Stream Mode credentials."""
+
+    def __init__(self, *, provider_code: str = "authFailed") -> None:
+        self.diagnostic = {
+            "error_class": "auth_invalid",
+            "provider_code": provider_code or "authFailed",
+            "message": _DINGTALK_AUTH_INVALID_MESSAGE,
+            "retryable": False,
+        }
+        super().__init__("DingTalk credentials were rejected")
 
 
 class DingTalkChannelConfig(BaseModel):
@@ -232,6 +251,136 @@ class DingTalkChannel:
         return bool(msg.metadata.get("bot_mentioned"))
 
     # ------------------------------------------------------------------
+    # Startup diagnostics
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _sdk_version() -> str:
+        try:
+            from dingtalk_stream.version import VERSION_STRING  # type: ignore[import-untyped]
+
+            return str(VERSION_STRING)
+        except Exception:
+            return "unknown"
+
+    @staticmethod
+    def _host_ip() -> str:
+        sock: socket.socket | None = None
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.connect(("8.8.8.8", 80))
+            return str(sock.getsockname()[0])
+        except OSError:
+            return ""
+        finally:
+            if sock is not None:
+                sock.close()
+
+    @staticmethod
+    def _response_json(response: Any) -> dict[str, Any]:
+        try:
+            payload = response.json()
+        except Exception:
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    def _safe_error_text(self, exc: BaseException) -> str:
+        text = str(exc)
+        if self.config.client_secret:
+            text = text.replace(self.config.client_secret, "[redacted]")
+        return text
+
+    @staticmethod
+    def _provider_code(payload: dict[str, Any], *, status_code: int | None) -> str:
+        code = str(payload.get("code") or payload.get("errcode") or "")
+        if code:
+            return code
+        return "authFailed" if status_code == 401 else ""
+
+    @classmethod
+    def _is_auth_failure(
+        cls,
+        *,
+        status_code: int | None,
+        payload: dict[str, Any],
+        response_text: str,
+    ) -> bool:
+        code = cls._provider_code(payload, status_code=status_code).lower()
+        message = str(payload.get("message") or payload.get("errmsg") or "")
+        haystack = f"{response_text}\n{message}".lower()
+        return (
+            status_code == 401
+            or code == "authfailed"
+            or "authfailed" in haystack
+            or "鉴权失败" in response_text
+            or "鉴权失败" in message
+        )
+
+    async def _preflight_open_connection(self, *, endpoint: str, callback_topic: str) -> None:
+        """Probe DingTalk auth once so deterministic credential failures are actionable."""
+        version = self._sdk_version()
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": (
+                "DingTalkStream/1.0 SDK/%s Python/%s "
+                "(+https://github.com/open-dingtalk/dingtalk-stream-sdk-python)"
+            )
+            % (version, platform.python_version()),
+        }
+        body = json.dumps(
+            {
+                "clientId": self.config.client_id,
+                "clientSecret": self.config.client_secret,
+                "subscriptions": [{"type": "CALLBACK", "topic": callback_topic}],
+                "ua": f"dingtalk-sdk-python/v{version}-union",
+                "localIp": self._host_ip(),
+            }
+        ).encode("utf-8")
+
+        def _post() -> Any:
+            return requests.post(endpoint, headers=headers, data=body, timeout=10.0)
+
+        try:
+            response = await asyncio.to_thread(_post)
+        except requests.RequestException as exc:
+            log.warning(
+                "dingtalk.preflight_transient_failed",
+                name=self.config.name,
+                error_type=type(exc).__name__,
+                error=self._safe_error_text(exc),
+            )
+            return
+
+        status_code_raw = getattr(response, "status_code", None)
+        try:
+            status_code = int(status_code_raw) if status_code_raw is not None else None
+        except (TypeError, ValueError):
+            status_code = None
+        payload = self._response_json(response)
+        response_text = str(getattr(response, "text", "") or "")
+        if self._is_auth_failure(
+            status_code=status_code,
+            payload=payload,
+            response_text=response_text,
+        ):
+            provider_code = self._provider_code(payload, status_code=status_code)
+            raise DingTalkAuthError(provider_code=provider_code)
+
+        raise_for_status = getattr(response, "raise_for_status", None)
+        if callable(raise_for_status):
+            try:
+                raise_for_status()
+            except requests.RequestException as exc:
+                log.warning(
+                    "dingtalk.preflight_transient_failed",
+                    name=self.config.name,
+                    status_code=status_code,
+                    error_type=type(exc).__name__,
+                    error=self._safe_error_text(exc),
+                )
+
+    # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
@@ -246,6 +395,16 @@ class DingTalkChannel:
             ChatbotMessage,
             Credential,
             DingTalkStreamClient,
+        )
+
+        endpoint = getattr(
+            DingTalkStreamClient,
+            "OPEN_CONNECTION_API",
+            "https://api.dingtalk.com/v1.0/gateway/connections/open",
+        )
+        await self._preflight_open_connection(
+            endpoint=str(endpoint),
+            callback_topic=str(ChatbotMessage.TOPIC),
         )
 
         credential = Credential(self.config.client_id, self.config.client_secret)

--- a/src/opensquilla/channels/dingtalk.py
+++ b/src/opensquilla/channels/dingtalk.py
@@ -323,10 +323,9 @@ class DingTalkChannel:
             "Content-Type": "application/json",
             "Accept": "application/json",
             "User-Agent": (
-                "DingTalkStream/1.0 SDK/%s Python/%s "
+                f"DingTalkStream/1.0 SDK/{version} Python/{platform.python_version()} "
                 "(+https://github.com/open-dingtalk/dingtalk-stream-sdk-python)"
-            )
-            % (version, platform.python_version()),
+            ),
         }
         body = json.dumps(
             {

--- a/src/opensquilla/channels/dingtalk.py
+++ b/src/opensquilla/channels/dingtalk.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-import requests
+import requests  # type: ignore[import-untyped]
 import structlog
 from pydantic import BaseModel
 

--- a/src/opensquilla/channels/manager.py
+++ b/src/opensquilla/channels/manager.py
@@ -21,6 +21,19 @@ from opensquilla.session.keys import DmScope, build_direct_key, build_group_key,
 log = structlog.get_logger(__name__)
 
 
+def _structured_diagnostic(exc: BaseException) -> dict[str, Any] | None:
+    raw = getattr(exc, "diagnostic", None)
+    if not isinstance(raw, dict):
+        return None
+    diagnostic: dict[str, Any] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str):
+            continue
+        if isinstance(value, str | int | float | bool) or value is None:
+            diagnostic[key] = value
+    return diagnostic or None
+
+
 @dataclass
 class ChannelManager:
     """Manages lifecycle of ManagedChannel instances.
@@ -54,7 +67,7 @@ class ChannelManager:
     # does not look healthy.
     _dispatch_states: dict[str, str] = field(default_factory=dict)
     _restart_counts: dict[str, int] = field(default_factory=dict)
-    _start_errors: dict[str, dict[str, str]] = field(default_factory=dict)
+    _start_errors: dict[str, dict[str, Any]] = field(default_factory=dict)
     # Inner-loop retry policy (overridable for tests).
     _max_retries: int = 5
     _retry_backoff_initial: float = 1.0
@@ -197,18 +210,22 @@ class ChannelManager:
         statuses: dict[str, bool] = {}
         for name, result in zip(self._channels, results):
             if isinstance(result, BaseException):
-                self._start_errors[name] = {
+                details: dict[str, Any] = {
                     "error_type": type(result).__name__,
                     "error": str(result),
                     "exception": repr(result),
                 }
+                diagnostic = _structured_diagnostic(result)
+                if diagnostic:
+                    details["diagnostic"] = diagnostic
+                self._start_errors[name] = details
                 statuses[name] = False
             else:
                 self._start_errors.pop(name, None)
                 statuses[name] = True
         return statuses
 
-    def start_errors(self) -> dict[str, dict[str, str]]:
+    def start_errors(self) -> dict[str, dict[str, Any]]:
         """Return sanitized per-channel startup errors for operator diagnostics."""
         return {name: dict(details) for name, details in self._start_errors.items()}
 

--- a/src/opensquilla/cli/channels_cmd.py
+++ b/src/opensquilla/cli/channels_cmd.py
@@ -91,6 +91,20 @@ def _render_channels_table(entries: list[dict[str, Any]], *, title: str) -> None
     console.print(table)
 
 
+def _status_diagnostic_text(row: dict[str, Any]) -> str:
+    diagnostics = row.get("diagnostics")
+    if not isinstance(diagnostics, dict):
+        return ""
+    last_error = diagnostics.get("last_error")
+    if not isinstance(last_error, dict):
+        return ""
+    message = last_error.get("message")
+    if message:
+        return str(message)
+    error_class = last_error.get("error_class")
+    return str(error_class) if error_class else ""
+
+
 def _render_status_table(payload: dict[str, Any], *, name: str | None = None) -> None:
     rows = _filter_status_rows(payload, name)
     table = Table(title="Channel status", show_header=True, header_style=ACCENT_HEADER)
@@ -101,6 +115,7 @@ def _render_status_table(payload: dict[str, Any], *, name: str | None = None) ->
     table.add_column("Enabled")
     table.add_column("Configured")
     table.add_column("Restart attempts", justify="right")
+    table.add_column("Diagnostic")
     for row in rows:
         table.add_row(
             str(row.get("name") or ""),
@@ -110,6 +125,7 @@ def _render_status_table(payload: dict[str, Any], *, name: str | None = None) ->
             str(row.get("enabled") or False),
             str(row.get("configured") or False),
             str(row.get("restart_attempts") or 0),
+            _status_diagnostic_text(row),
         )
     Console(width=180, force_terminal=False).print(table)
 

--- a/src/opensquilla/gateway/rpc_channels.py
+++ b/src/opensquilla/gateway/rpc_channels.py
@@ -58,13 +58,63 @@ def _platform_manifest_payload(adapter: Any | None) -> dict[str, Any] | None:
     return manifest.to_dict() if manifest is not None else None
 
 
-def _diagnostics_payload() -> dict[str, Any]:
-    return {"network_probe": "not_run"}
+def _manager_start_errors(manager: Any | None) -> dict[str, Any]:
+    if manager is None:
+        return {}
+    start_errors = getattr(manager, "start_errors", None)
+    if not callable(start_errors):
+        return {}
+    try:
+        errors = start_errors()
+    except Exception:
+        return {}
+    return errors if isinstance(errors, dict) else {}
+
+
+def _diagnostic_from_start_error(start_error: Any) -> dict[str, Any] | None:
+    if not isinstance(start_error, dict):
+        return None
+    diagnostic = start_error.get("diagnostic")
+    if isinstance(diagnostic, dict):
+        out = dict(diagnostic)
+        out.setdefault("source", "start_error")
+        return out
+    error_type = str(start_error.get("error_type") or "StartupError")
+    return {
+        "error_class": "startup_failed",
+        "message": f"Channel failed during startup: {error_type}",
+        "retryable": False,
+        "source": "start_error",
+    }
+
+
+def _diagnostic_from_health_extra(extra: dict[str, Any]) -> dict[str, Any] | None:
+    diagnostic = extra.get("last_error")
+    if not isinstance(diagnostic, dict):
+        return None
+    out = dict(diagnostic)
+    out.setdefault("source", "adapter")
+    return out
+
+
+def _diagnostics_payload(
+    *,
+    extra: dict[str, Any] | None = None,
+    start_error: Any = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"network_probe": "not_run"}
+    last_error = _diagnostic_from_start_error(start_error)
+    if last_error is None and extra is not None:
+        last_error = _diagnostic_from_health_extra(extra)
+    if last_error is not None:
+        payload["last_error"] = last_error
+    return payload
 
 
 @_d.method("channels.status", scope="operator.read")
 async def _handle_channels_status(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     health_map = await ctx.channel_manager.health() if ctx.channel_manager else {}
+    start_errors = _manager_start_errors(ctx.channel_manager)
     manager_types = (
         getattr(ctx.channel_manager, "_channel_types", {}) if ctx.channel_manager else {}
     )
@@ -100,7 +150,10 @@ async def _handle_channels_status(params: dict | None, ctx: RpcContext) -> dict[
                 "capabilities": capabilities,
                 "capability_profile": capability_profile,
                 "platform_manifest": platform_manifest,
-                "diagnostics": _diagnostics_payload(),
+                "diagnostics": _diagnostics_payload(
+                    extra=extra,
+                    start_error=start_errors.get(name),
+                ),
             }
         )
         seen.add(name)
@@ -131,7 +184,10 @@ async def _handle_channels_status(params: dict | None, ctx: RpcContext) -> dict[
                 "capabilities": capabilities,
                 "capability_profile": capability_profile,
                 "platform_manifest": platform_manifest,
-                "diagnostics": _diagnostics_payload(),
+                "diagnostics": _diagnostics_payload(
+                    extra=extra,
+                    start_error=start_errors.get(name),
+                ),
             }
         )
 

--- a/src/opensquilla/health/evaluator.py
+++ b/src/opensquilla/health/evaluator.py
@@ -72,6 +72,14 @@ def _diagnostic_incomplete(
     ]
 
 
+def _channel_last_error(row: dict[str, Any]) -> dict[str, Any] | None:
+    diagnostics = row.get("diagnostics")
+    if not isinstance(diagnostics, dict):
+        return None
+    last_error = diagnostics.get("last_error")
+    return last_error if isinstance(last_error, dict) else None
+
+
 def evaluate_provider(payload: dict[str, Any]) -> list[HealthFinding]:
     raw_rows = payload.get("providers")
     if not isinstance(raw_rows, list):
@@ -1077,7 +1085,49 @@ def evaluate_channels(payload: dict[str, Any]) -> list[HealthFinding]:
         name = str(row.get("name") or "unnamed")
         name_arg = _command_arg(name)
         status = str(row.get("status") or "unknown")
-        if row.get("enabled") is False:
+        last_error = _channel_last_error(row)
+        if isinstance(last_error, dict) and last_error.get("error_class") == "auth_invalid":
+            message = str(last_error.get("message") or "Channel credentials are invalid.")
+            provider_code = str(last_error.get("provider_code") or "")
+            channel_type = str(row.get("type") or "channel")
+            findings.append(
+                HealthFinding(
+                    id=f"channel.{name}.auth_invalid",
+                    severity="error",
+                    readiness_impact="degrades",
+                    surface="channels",
+                    title=f"Channel {name} credentials are invalid",
+                    detail=(
+                        f"{message}. {channel_type} rejected the configured credentials. "
+                        "For DingTalk Stream Mode, check that client_id is the AppKey "
+                        "and client_secret is the matching AppSecret from the same "
+                        "DingTalk app or robot."
+                    ),
+                    evidence={
+                        "name": name,
+                        "status": status,
+                        "type": row.get("type"),
+                        "errorClass": "auth_invalid",
+                        "providerCode": provider_code,
+                    },
+                    fix_steps=[
+                        FixStep(
+                            label="Inspect channels",
+                            command=f"opensquilla channels status {name_arg} --json",
+                        ),
+                        FixStep(
+                            label="Check DingTalk credentials",
+                            detail=(
+                                "Update the channel config with the AppKey/AppSecret "
+                                "from the same DingTalk app or robot."
+                            ),
+                        ),
+                        FixStep(label="Restart gateway", command="opensquilla gateway restart"),
+                    ],
+                    restart_required=True,
+                )
+            )
+        elif row.get("enabled") is False:
             findings.append(
                 HealthFinding(
                     id=f"channel.{name}.disabled",

--- a/tests/test_channels/test_channel_manager_lifecycle.py
+++ b/tests/test_channels/test_channel_manager_lifecycle.py
@@ -23,6 +23,20 @@ class _SlowChannel:
         self.stopped = True
 
 
+class _StructuredAuthError(RuntimeError):
+    diagnostic = {
+        "error_class": "auth_invalid",
+        "provider_code": "authFailed",
+        "message": "凭证无效：检查 DingTalk AppKey/AppSecret",
+        "retryable": False,
+    }
+
+
+class _StructuredFailingChannel:
+    async def start(self) -> None:
+        raise _StructuredAuthError("DingTalk credentials were rejected")
+
+
 @pytest.mark.asyncio
 async def test_start_all_retains_start_exception_details():
     manager = ChannelManager({"feishu": _FailingChannel()}, None, None)
@@ -49,3 +63,15 @@ async def test_start_all_honors_adapter_startup_timeout():
     assert results == {"feishu": False}
     assert manager.start_errors()["feishu"]["error_type"] == "TimeoutError"
     assert channel.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_start_all_retains_structured_channel_diagnostic():
+    manager = ChannelManager({"dingtalk": _StructuredFailingChannel()}, None, None)
+
+    results = await manager.start_all()
+
+    assert results == {"dingtalk": False}
+    error = manager.start_errors()["dingtalk"]
+    assert error["diagnostic"] == _StructuredAuthError.diagnostic
+    assert "AppKey/AppSecret" in error["diagnostic"]["message"]

--- a/tests/test_channels/test_dingtalk_auth_validation.py
+++ b/tests/test_channels/test_dingtalk_auth_validation.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 import types
 from typing import Any
 
 import pytest
+import requests
 
 from opensquilla.channels.dingtalk import DingTalkChannel, DingTalkChannelConfig
 
@@ -52,6 +54,8 @@ async def test_dingtalk_start_builds_stream_client_with_client_credentials(
             credentials.append((client_id, client_secret))
 
     class FakeStreamClient:
+        OPEN_CONNECTION_API = "https://api.dingtalk.com/v1.0/gateway/connections/open"
+
         def __init__(self, credential: FakeCredential) -> None:
             self.credential = credential
             self.handlers: list[tuple[str, Any]] = []
@@ -71,6 +75,26 @@ async def test_dingtalk_start_builds_stream_client_with_client_credentials(
     setattr(fake_module, "DingTalkStreamClient", FakeStreamClient)
     monkeypatch.setitem(sys.modules, "dingtalk_stream", fake_module)
 
+    class FakeResponse:
+        status_code = 200
+        text = '{"endpoint":"wss://example.test","ticket":"ticket"}'
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, str]:
+            return {"endpoint": "wss://example.test", "ticket": "ticket"}
+
+    preflight_payloads: list[dict[str, Any]] = []
+
+    def fake_post(url: str, *, headers: dict[str, str], data: bytes, timeout: float) -> Any:
+        assert url == FakeStreamClient.OPEN_CONNECTION_API
+        assert timeout > 0
+        preflight_payloads.append(json.loads(data.decode("utf-8")))
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
     channel = DingTalkChannel(
         DingTalkChannelConfig(client_id="client-id", client_secret="client-secret")
     )
@@ -82,3 +106,88 @@ async def test_dingtalk_start_builds_stream_client_with_client_credentials(
     assert len(clients) == 1
     assert clients[0].handlers
     assert clients[0].handlers[0][0] == "chatbot.topic"
+    assert len(preflight_payloads) == 1
+    assert preflight_payloads[0]["clientId"] == "client-id"
+    assert preflight_payloads[0]["clientSecret"] == "client-secret"
+    assert preflight_payloads[0]["subscriptions"] == [
+        {"type": "CALLBACK", "topic": "chatbot.topic"}
+    ]
+    assert preflight_payloads[0]["ua"].startswith("dingtalk-sdk-python/")
+
+
+@pytest.mark.anyio
+async def test_dingtalk_auth_failed_preflight_raises_structured_diagnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clients: list[Any] = []
+
+    class FakeChatbotMessage:
+        TOPIC = "chatbot.topic"
+
+        @staticmethod
+        def from_dict(data: dict[str, Any]) -> Any:
+            return data
+
+    class FakeAckMessage:
+        STATUS_OK = "ok"
+
+    class FakeAsyncChatbotHandler:
+        def __init__(self) -> None:
+            return None
+
+    class FakeCredential:
+        def __init__(self, client_id: str, client_secret: str) -> None:
+            self.client_id = client_id
+            self.client_secret = client_secret
+
+    class FakeStreamClient:
+        OPEN_CONNECTION_API = "https://api.dingtalk.com/v1.0/gateway/connections/open"
+
+        def __init__(self, credential: FakeCredential) -> None:
+            clients.append(self)
+
+        def register_callback_handler(self, topic: str, handler: Any) -> None:
+            raise AssertionError("SDK client should not register callbacks after auth failure")
+
+        async def start(self) -> None:
+            raise AssertionError("SDK loop should not start after auth failure")
+
+    fake_module = types.ModuleType("dingtalk_stream")
+    setattr(fake_module, "AckMessage", FakeAckMessage)
+    setattr(fake_module, "AsyncChatbotHandler", FakeAsyncChatbotHandler)
+    setattr(fake_module, "ChatbotMessage", FakeChatbotMessage)
+    setattr(fake_module, "Credential", FakeCredential)
+    setattr(fake_module, "DingTalkStreamClient", FakeStreamClient)
+    monkeypatch.setitem(sys.modules, "dingtalk_stream", fake_module)
+
+    class FakeResponse:
+        status_code = 401
+        text = '{"code":"authFailed","message":"鉴权失败"}'
+
+        def raise_for_status(self) -> None:
+            raise requests.HTTPError("401 Client Error: Unauthorized")
+
+        def json(self) -> dict[str, str]:
+            return {"code": "authFailed", "message": "鉴权失败"}
+
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: FakeResponse(),
+    )
+
+    channel = DingTalkChannel(
+        DingTalkChannelConfig(client_id="bad-client", client_secret="super-secret")
+    )
+
+    with pytest.raises(RuntimeError, match="DingTalk credentials were rejected") as exc:
+        await channel.start()
+
+    diagnostic = getattr(exc.value, "diagnostic", {})
+    assert diagnostic["error_class"] == "auth_invalid"
+    assert diagnostic["provider_code"] == "authFailed"
+    assert diagnostic["retryable"] is False
+    assert "AppKey/AppSecret" in diagnostic["message"]
+    assert "super-secret" not in str(diagnostic)
+    assert clients == []
+    assert channel._run_task is None

--- a/tests/test_cli/test_cli_product_completeness.py
+++ b/tests/test_cli/test_cli_product_completeness.py
@@ -847,6 +847,37 @@ def test_channels_status_and_logout_use_existing_rpcs(monkeypatch):
     assert ("channels.logout", {"name": "slack"}) in fake.calls
 
 
+def test_channels_status_table_shows_channel_diagnostic(monkeypatch):
+    fake = _install_fake_gateway(monkeypatch)
+    fake.rpc_payloads = {
+        "channels.status": {
+            "channels": [
+                {
+                    "name": "dingtalk",
+                    "type": "dingtalk",
+                    "status": "stopped",
+                    "connected": False,
+                    "enabled": True,
+                    "configured": True,
+                    "diagnostics": {
+                        "last_error": {
+                            "error_class": "auth_invalid",
+                            "message": "凭证无效：检查 DingTalk AppKey/AppSecret",
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+    result = runner.invoke(app, ["channels", "status", "dingtalk"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "凭证无效：检查 DingTalk AppKey/AppSecret" in result.stdout
+    assert "auth_invalid" not in result.stdout
+    assert ("channels.status", {}) in fake.calls
+
+
 def test_runtime_diagnostics_commands_can_target_configured_gateway(
     tmp_path: Path, monkeypatch
 ):

--- a/tests/test_gateway/test_rpc_channels.py
+++ b/tests/test_gateway/test_rpc_channels.py
@@ -126,3 +126,59 @@ async def test_channels_status_reports_adapter_capabilities_without_network_prob
         "status"
     ] == ChannelPlatformCapabilityStatus.UNSUPPORTED
     assert row["diagnostics"] == {"network_probe": "not_run"}
+
+
+@pytest.mark.asyncio
+async def test_channels_status_merges_start_error_diagnostics_for_configured_channel():
+    ctx = _read_ctx()
+    res = upsert_channel(
+        GatewayConfig(),
+        entry_payload={
+            "type": "dingtalk",
+            "name": "dingtalk",
+            "client_id": "app-key",
+            "client_secret": "app-secret",
+        },
+    )
+    ctx.config = res.config
+
+    class FakeManager:
+        _channel_types = {"dingtalk": "dingtalk"}
+
+        async def health(self):
+            return {}
+
+        def get(self, name: str):
+            assert name == "dingtalk"
+            return None
+
+        def start_errors(self):
+            return {
+                "dingtalk": {
+                    "error_type": "DingTalkAuthError",
+                    "error": "DingTalk credentials were rejected",
+                    "diagnostic": {
+                        "error_class": "auth_invalid",
+                        "provider_code": "authFailed",
+                        "message": "凭证无效：检查 DingTalk AppKey/AppSecret",
+                        "retryable": False,
+                    },
+                }
+            }
+
+    ctx.channel_manager = FakeManager()
+
+    rpc_res = await get_dispatcher().dispatch("r1", "channels.status", {}, ctx)
+
+    assert rpc_res.error is None, rpc_res.error
+    row = rpc_res.payload["channels"][0]
+    assert row["name"] == "dingtalk"
+    assert row["status"] == "stopped"
+    assert row["connected"] is False
+    assert row["diagnostics"]["last_error"] == {
+        "error_class": "auth_invalid",
+        "provider_code": "authFailed",
+        "message": "凭证无效：检查 DingTalk AppKey/AppSecret",
+        "retryable": False,
+        "source": "start_error",
+    }

--- a/tests/test_gateway/test_rpc_doctor.py
+++ b/tests/test_gateway/test_rpc_doctor.py
@@ -658,6 +658,79 @@ async def test_doctor_status_treats_dead_channel_as_surface_degradation(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_doctor_status_reports_dingtalk_auth_invalid_without_stopped_duplicate(
+    monkeypatch,
+) -> None:
+    import opensquilla.gateway.rpc_doctor as rpc_doctor
+
+    async def provider_status(params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        return {
+            "activeProvider": "openrouter",
+            "providers": [
+                {
+                    "providerId": "openrouter",
+                    "active": True,
+                    "configured": True,
+                    "buildable": True,
+                }
+            ],
+        }
+
+    async def channels_status(params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        return {
+            "channels": [
+                {
+                    "name": "dingtalk",
+                    "type": "dingtalk",
+                    "enabled": True,
+                    "status": "stopped",
+                    "diagnostics": {
+                        "last_error": {
+                            "error_class": "auth_invalid",
+                            "provider_code": "authFailed",
+                            "message": "凭证无效：检查 DingTalk AppKey/AppSecret",
+                            "retryable": False,
+                        }
+                    },
+                }
+            ]
+        }
+
+    _patch_ready_support_surfaces(monkeypatch, rpc_doctor)
+    monkeypatch.setattr(rpc_doctor, "_handle_providers_status", provider_status)
+    monkeypatch.setattr(rpc_doctor, "_handle_channels_status", channels_status)
+
+    cfg = GatewayConfig()
+    cfg.config_path = "/tmp/custom-opensquilla.toml"
+
+    response = await get_dispatcher().dispatch(
+        "req-1",
+        "doctor.status",
+        {},
+        RpcContext(conn_id="test", config=cfg),
+    )
+
+    assert response.ok is True
+    ids = [finding["id"] for finding in response.payload["findings"]]
+    assert "channel.dingtalk.auth_invalid" in ids
+    assert "channel.dingtalk.stopped" not in ids
+    channel_finding = next(
+        finding
+        for finding in response.payload["findings"]
+        if finding["id"] == "channel.dingtalk.auth_invalid"
+    )
+    assert channel_finding["severity"] == "error"
+    assert channel_finding["readinessImpact"] == "degrades"
+    assert "AppKey/AppSecret" in channel_finding["detail"]
+    commands = [step["command"] for step in channel_finding["fixSteps"] if "command" in step]
+    assert (
+        "opensquilla channels status dingtalk --json "
+        "--config /tmp/custom-opensquilla.toml"
+    ) in commands
+    assert "opensquilla gateway restart --config /tmp/custom-opensquilla.toml" in commands
+
+
+@pytest.mark.asyncio
 async def test_doctor_status_treats_no_channels_as_optional_setup(monkeypatch) -> None:
     import opensquilla.gateway.rpc_doctor as rpc_doctor
 


### PR DESCRIPTION
## Summary
- Add a DingTalk Stream Mode startup preflight that fail-fast classifies 401/authFailed responses as `auth_invalid` instead of letting the SDK retry loop spam logs.
- Preserve structured channel startup diagnostics through `ChannelManager`, `channels.status`, CLI status output, and `doctor.status` findings.
- Add regression coverage for DingTalk auth failure, status payload diagnostics, CLI display, and doctor de-duplication.

## Linked Issue
None

## Release Note
- Operator-facing channel diagnostics now identify invalid DingTalk credentials and suggest checking AppKey/AppSecret.

## Test Results
- `PYTHONPATH="src:$(find /Users/wailord/.cache/uv/archive-v0 -mindepth 1 -maxdepth 1 -type d | paste -sd ':' -)" /Users/wailord/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_channels/test_dingtalk_auth_validation.py tests/test_channels/test_channel_manager_lifecycle.py tests/test_gateway/test_rpc_channels.py tests/test_gateway/test_rpc_doctor.py tests/test_cli/test_cli_product_completeness.py -q` → 59 passed
- `PYTHONPATH="src:$(find /Users/wailord/.cache/uv/archive-v0 -mindepth 1 -maxdepth 1 -type d | paste -sd ':' -)" /Users/wailord/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile src/opensquilla/channels/dingtalk.py src/opensquilla/channels/manager.py src/opensquilla/gateway/rpc_channels.py src/opensquilla/cli/channels_cmd.py src/opensquilla/health/evaluator.py tests/test_channels/test_dingtalk_auth_validation.py tests/test_channels/test_channel_manager_lifecycle.py tests/test_gateway/test_rpc_channels.py tests/test_gateway/test_rpc_doctor.py tests/test_cli/test_cli_product_completeness.py` → passed
- `git diff --check` → passed

## Safety Notes
- Diagnostics expose only error class, provider code, and user-facing remediation text; `client_secret` is not returned.
- Transient DingTalk preflight failures still fall back to the SDK retry loop instead of failing startup.
- This PR does not change Feishu behavior or address the separate LightGBM/libomp runtime warning.

## Third-Party Origin
None.