### PR TITLE
[codex] Prepare 0.4.0 release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,64 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.4.0] - 2026-06-27
+
+### Added
+
+- The refreshed Control UI is now the default browser console, with a
+  conversation-first sidebar, Settings modal, Sessions ledger, artifact
+  previews, share export, deliverables drawer, turn trace, mobile tabs, and
+  clearer Skills, Usage, Cron, Logs, and Approvals surfaces.
+- Coding mode and the `code-task` workflow provide a guarded path for code
+  changes: code work runs through an isolated run directory, uses trusted-host
+  confirmation, and verifies before persisting changes back to the source.
+- `opensquilla swebench` adds an optional SWE-bench evaluation surface for
+  users who install `opensquilla[swebench]` and have Docker available.
 - OpenTUI preview backend documentation now covers explicit opt-in usage,
   dependency setup, replay benchmarks, and real-terminal harness evidence.
+- Web search now supports DuckDuckGo, Bocha, Brave, Tavily, and Exa through the
+  runtime provider catalog, with source-backed `web_search` and lightweight
+  `web_discover` roles documented for agent workflows.
+- `openai_responses` exposes OpenAI's native Responses API shape alongside
+  `openai`, sharing `OPENAI_API_KEY` and the default OpenAI base URL while
+  making Responses-specific behavior selectable by provider id.
 
 ### Changed
 
+- MetaSkills are now **manual-only by default**. They no longer auto-trigger from
+  message keywords or appear in the runtime prompt; run them explicitly with the
+  new `/meta` command (`/meta` lists available MetaSkills, `/meta <name>` runs
+  one). To restore the previous automatic behavior, set
+  `meta_skill.auto_trigger = true`. Full list+run is available in web chat and
+  the CLI gateway TUI; channel and standalone CLI surfaces support `/meta`
+  listing only.
 - Terminal chat documentation now distinguishes the stable Python-native default
   backend from the opt-in OpenTUI preview backend.
-- Meta-skills are now **manual-only by default**. They no longer auto-trigger from
-  message keywords or appear in the runtime prompt; run them explicitly with the
-  new `/meta` command (`/meta` lists available meta-skills, `/meta <name>` runs
-  one). To restore the previous automatic behavior, set
-  `meta_skill.auto_trigger = true`. Full list+run is available in web chat and the
-  CLI gateway TUI; the channel and standalone CLI surfaces support `/meta` listing
-  only.
+- Search configuration now treats `search_provider` as the credential anchor for
+  a configured key rather than a hard routing promise for automatic searches.
 
 ### Fixed
+
+- Provider stream parsing accepts no-space SSE data lines, and Gemini thought
+  signatures are preserved across tool turns so provider continuity metadata can
+  be replayed safely.
+- The SSRF guard now gives operators actionable fake-IP DNS guidance while
+  keeping private, loopback, link-local, and internal ranges blocked by default.
+- Runtime, gateway, and Web UI fixes improve session recovery, attachment and
+  artifact handling, approval event delivery, share-image export, router
+  visibility, and cross-platform test stability.
+
+### Acknowledgements
+
+- Thanks to the 0.4.0 contributors recorded in
+  [`CONTRIBUTORS.md`](CONTRIBUTORS.md), including PR work from @ab2ence,
+  @myz-ah, @nice-code-la, @openvictory, @weiconghe, @changquanyou, @nkgotcode,
+  @C1-BA-B1-F3, @BlueOcean223, @szdtzpj, @lose4578, and cwan0785
+  (GitHub @Anonymous-4427).
 
 ## [0.3.1] - 2026-06-03
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,29 @@ human-readable ledger together for contributor attribution. This file records
 release-surface community work that can be harder to see when a release is
 squash-merged or replayed onto `main`.
 
+## OpenSquilla 0.4.0
+
+The 0.4.0 release is prepared from current `dev` after `v0.3.1`. This section
+records non-Open-Squilla contributor work with pull-request evidence in that
+range. Some work was replayed or carried through Open-Squilla integration pull
+requests; those rows name the original contributor and cite both the original
+pull request and the integration pull request when useful.
+
+| Contributor | 0.4.0 contribution | Evidence |
+| --- | --- | --- |
+| [@ab2ence](https://github.com/ab2ence) | Control UI migration and stabilization work, share-image export, Web Chat slash-input handling, bundled AwesomeWebpage MetaSkill work, and the Coding mode toggle carried into `dev`. | [#264](https://github.com/opensquilla/opensquilla/pull/264), [#274](https://github.com/opensquilla/opensquilla/pull/274), [#177](https://github.com/opensquilla/opensquilla/pull/177), [#173](https://github.com/opensquilla/opensquilla/pull/173), [#313](https://github.com/opensquilla/opensquilla/pull/313) |
+| [@myz-ah](https://github.com/myz-ah) | Added the `code-task` workflow for isolated, runner-verified code changes behind Coding mode. | [#311](https://github.com/opensquilla/opensquilla/pull/311) |
+| [@nice-code-la](https://github.com/nice-code-la) | Skills readiness in the Web UI, MetaSkill progress and clarification UX, manual-only `/meta` behavior, scoped MetaSkill run-history reads, router fallback/default refresh work, and image follow-up routing gates. | [#184](https://github.com/opensquilla/opensquilla/pull/184), [#222](https://github.com/opensquilla/opensquilla/pull/222), [#243](https://github.com/opensquilla/opensquilla/pull/243), [#253](https://github.com/opensquilla/opensquilla/pull/253), [#261](https://github.com/opensquilla/opensquilla/pull/261) carried through [#297](https://github.com/opensquilla/opensquilla/pull/297), [#272](https://github.com/opensquilla/opensquilla/pull/272), [#279](https://github.com/opensquilla/opensquilla/pull/279) carried through [#297](https://github.com/opensquilla/opensquilla/pull/297) |
+| [@openvictory](https://github.com/openvictory) | MetaSkill run-history and rescue-action Control UI work carried through the session-contract Control UI integration. | [#264](https://github.com/opensquilla/opensquilla/pull/264) |
+| [@weiconghe](https://github.com/weiconghe) | Preserved and replayed Gemini `thought_signature` metadata across provider tool-call turns. | [#312](https://github.com/opensquilla/opensquilla/pull/312) |
+| [@changquanyou](https://github.com/changquanyou) | Accepted no-space SSE `data:` lines and improved managed-layer MetaSkill inspection. | [#214](https://github.com/opensquilla/opensquilla/pull/214) |
+| [@nkgotcode](https://github.com/nkgotcode) | Fixed DOCX `skill_exec` export behavior. | [#262](https://github.com/opensquilla/opensquilla/pull/262) |
+| [@C1-BA-B1-F3](https://github.com/C1-BA-B1-F3) | Made SSRF fake-IP DNS blocks actionable for operators. | [#298](https://github.com/opensquilla/opensquilla/pull/298) carried through [#309](https://github.com/opensquilla/opensquilla/pull/309) and [#310](https://github.com/opensquilla/opensquilla/pull/310) |
+| [@BlueOcean223](https://github.com/BlueOcean223) | Reset TUI EOF state on cached reentry. | [#203](https://github.com/opensquilla/opensquilla/pull/203) |
+| [@szdtzpj](https://github.com/szdtzpj) | Fixed environment test precedence and the TUI abort hook. | [#176](https://github.com/opensquilla/opensquilla/pull/176) |
+| [@lose4578](https://github.com/lose4578) | Submitted the OpenTUI scrollback-native frontend work carried into the 0.4.0 preview backend. | [#182](https://github.com/opensquilla/opensquilla/pull/182) carried through [#277](https://github.com/opensquilla/opensquilla/pull/277) |
+| cwan0785 (commit author name; GitHub account: [@Anonymous-4427](https://github.com/Anonymous-4427)) | Authored OpenTUI preview backend implementation commits carried into the 0.4.0 preview backend. | [#182](https://github.com/opensquilla/opensquilla/pull/182) carried through [#277](https://github.com/opensquilla/opensquilla/pull/277) |
+
 ## OpenSquilla 0.3.1
 
 The 0.3.1 release is prepared as a release-surface replay from `dev` onto the

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ OpenRouter, OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope,
 and 20+ other LLM providers with no change to your code or config
 schema.
 
-OpenSquilla 0.3.1 is the current release.
+OpenSquilla 0.4.0 is the current release.
 
 For task-oriented product documentation, start with the
 [OpenSquilla Product Guide](README.product.md) or the
@@ -160,7 +160,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Install OpenSquilla** — the same command on every platform.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
 ```
 
 This installs the OpenSquilla wheel from the release URL, then lets
@@ -181,7 +181,7 @@ opensquilla gateway run
 > a new terminal, or re-run the PATH line from step 1.
 
 For a fully pinned install, use the versioned wheel URL:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl`.
 
 ### Install from source
 
@@ -481,27 +481,36 @@ settings live in `opensquilla.toml.example`.
 
 ---
 
-## What's New in 0.3.1
+## What's New in 0.4.0
 
-OpenSquilla 0.3.1 is a maintenance release for the 0.3 line. It updates the
-stable install metadata and brings selected channel, chat, provider, and
-workflow fixes from the integration branch onto the stable release line:
+OpenSquilla 0.4.0 updates the daily control surfaces, workflow launch model,
+coding workflow, search providers, terminal preview path, and runtime hardening:
 
-- **Channel setup and replies** — Slack Socket Mode, app mentions, signing
-  secrets, and threaded replies preserve the channel context needed for setup
-  and replies.
-- **Media and voice workflow handoffs** — short-drama/video helper workflows
-  remain bundled, generated media flows have clearer review pauses, and
-  voice/audio handoffs are usable end to end.
-- **Chat formatting** — user message bubbles preserve multiline text and read
-  like authored messages instead of compressed UI labels.
-- **Provider request hardening** — malformed tool-call history is kept away
-  from providers before it becomes invalid request state.
-- **Install and release checks** — installer URLs, release metadata, version
-  consistency tests, and CI impact gates are updated for 0.3.1.
+- **Refreshed Control UI** — the local console is easier to scan and operate,
+  with conversation navigation, a Settings modal, Sessions ledger, artifact
+  previews, share export, deliverables, turn trace, mobile tabs, and clearer
+  Skills, Usage, Cron, Logs, and Approvals areas.
+- **Manual MetaSkills with `/meta`** — MetaSkills no longer auto-trigger by
+  default. Use `/meta` to list workflows and `/meta <name>` to run one. Set
+  `meta_skill.auto_trigger = true` only when you intentionally want the older
+  automatic behavior.
+- **Coding mode and code-task** — coding mode can route code changes through
+  `opensquilla code-task`, which works in an isolated run directory, requires a
+  trusted-host confirmation, and verifies before persisting changes back to
+  source.
+- **Broader web search** — DuckDuckGo, Bocha, Brave, Tavily, and Exa are
+  runtime-supported search providers, with source-backed `web_search` and
+  lightweight `web_discover` roles.
+- **OpenTUI preview backend** — the stable Python-native terminal backend stays
+  the default, while OpenTUI is available as an explicit preview path with
+  Router HUD and replay benchmark documentation.
+- **Provider and safety hardening** — `openai_responses` exposes OpenAI's native
+  Responses API shape alongside `openai`; provider stream parsing, Gemini
+  thought-signature replay, SSRF fake-IP DNS guidance, session recovery,
+  artifact handling, and approval event delivery are tightened across surfaces.
 
 Full notes: [`CHANGELOG.md`](CHANGELOG.md) ·
-[`docs/releases/0.3.1.md`](docs/releases/0.3.1.md).
+[`docs/releases/0.4.0.md`](docs/releases/0.4.0.md).
 
 ## What's New in 0.2.1
 
@@ -559,7 +568,7 @@ Full notes: [`CHANGELOG.md`](CHANGELOG.md) ·
 
 | Capability | What it does |
 | --- | --- |
-| **Token-efficient routing** | `SquillaRouter` — a local LightGBM + ONNX classifier in the `recommended` extra — scores each turn on length, language, code, keywords, and semantic embeddings, then routes it across four tiers (T0–T3) to the cheapest capable model. Classification runs on-device; your prompt never leaves the machine to make that decision. |
+| **Token-efficient routing** | `SquillaRouter` — a local LightGBM + ONNX classifier in the `recommended` extra — scores each turn on length, language, code, keywords, and semantic embeddings, then routes it across four tiers (C0–C3; legacy T0–T3 names are aliases) to the cheapest capable model. Classification runs on-device; your prompt never leaves the machine to make that decision. |
 | **Adaptive reasoning and prompts** | OpenSquilla requests extended reasoning only for turns the router scores as complex, and the system prompt scales with task complexity — lightweight for trivial turns, full instructions for complex ones. |
 | **20+ LLM providers** | The provider registry targets 20+ LLM backends — OpenRouter, OpenAI, Anthropic, Ollama, DeepSeek, Gemini, DashScope/Qwen, Moonshot, Mistral, Groq, Zhipu, SiliconFlow, vLLM, LM Studio, and more, with primary-plus-fallback selection; first-run onboarding exposes the verified subset. |
 | **On-demand skills and MCP** | 15 bundled skills (coding, GitHub, cron, pptx/docx/xlsx/pdf, summarization, tmux, weather, and more) load only when the task needs them. OpenSquilla is an MCP client, and can also run as an MCP server — `opensquilla mcp-server run` needs the `mcp` extra (install `opensquilla[recommended,mcp]`). Skills can be authored, installed, and published from the CLI. |

--- a/README.product.md
+++ b/README.product.md
@@ -14,7 +14,7 @@ This guide is the product and usage entry point. The existing
 1. Install OpenSquilla:
 
    ```sh
-   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
+   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
    ```
 
 2. Configure your provider:
@@ -166,6 +166,8 @@ user re-describe the same multi-step process. They are useful for repeatable
 research reports, document-to-decision work, daily operating briefs, account
 watching, job-search preparation, kid project planning, academic paper drafting,
 and MetaSkill proposal creation.
+
+By default, launch them deliberately with `/meta` and `/meta <name>`.
 
 Read: [`docs/features/meta-skills.md`](docs/features/meta-skills.md),
 [`docs/features/meta-skill-user-guide.md`](docs/features/meta-skill-user-guide.md),

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
-| 0.3.1 | v0.3.1 | 2026-06-03 | Slack hardening, media workflow handoffs, chat formatting, and install metadata |
+| 0.4.0 | v0.4.0 | 2026-06-27 | Control UI refresh, manual MetaSkills, coding mode, search expansion, and runtime hardening |
 | 0.3.0 | v0.3.0 | 2026-05-31 | MetaSkills, Health Doctor, tool compression, and docs release |
 | 0.2.1 | v0.2.1 | 2026-05-21 | 0.2 maintenance release |
 | 0.2.0 | v0.2.0 | 2026-05-20 | 0.2 release |
@@ -34,21 +34,21 @@ use tag-pinned URLs such as:
 - `https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/OpenSquilla-0.2.0rc1-windows-x64-py312-recommended-portable.zip`
 - `https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/opensquilla-0.2.0rc1-py3-none-any.whl`
 
-0.3.1 install commands use versioned wheel URLs because Python installers
+0.4.0 install commands use versioned wheel URLs because Python installers
 validate wheel filenames. The Windows portable zip may use the
 `/releases/latest/download/` alias after the non-pre-release GitHub Release
 exists. Fully pinned URLs remain available:
 
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/OpenSquilla-0.3.1-windows-x64-py312-recommended-portable.zip`
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/OpenSquilla-0.4.0-windows-x64-py312-recommended-portable.zip`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl`
 
 ## Release SOP
 
 1. Verify `git status` is clean.
 2. Update `CHANGELOG.md`: move entries from `[Unreleased]` to the release section; reopen empty `[Unreleased]`.
 3. Bump `pyproject.toml` and `uv.lock` to the release version.
-4. `git tag -a v0.3.1 -m "OpenSquilla 0.3.1"`
-5. `git push origin v0.3.1` (this triggers `.github/workflows/wheelhouse-release.yml`)
+4. `git tag -a v0.4.0 -m "OpenSquilla 0.4.0"`
+5. `git push origin v0.4.0` (this triggers `.github/workflows/wheelhouse-release.yml`)
 6. Wait for the Windows release workflow → review the draft GitHub Release.
    For non-preview releases, confirm it contains versioned assets, latest
    aliases, `SHA256SUMS`, plus GitHub's generated source archives before
@@ -57,8 +57,8 @@ exists. Fully pinned URLs remain available:
 8. Publish the GitHub Release, then run the post-publish tag URL checks:
 
    ```sh
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/OpenSquilla-0.3.1-windows-x64-py312-recommended-portable.zip
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/OpenSquilla-0.4.0-windows-x64-py312-recommended-portable.zip
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl
    ```
 
 9. Run the post-publish latest URL check:

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ root release README with task-oriented guides.
 
 ## Surfaces and Operations
 
-- [`releases/0.3.1.md`](releases/0.3.1.md) - OpenSquilla 0.3.1 release notes.
+- [`releases/0.4.0.md`](releases/0.4.0.md) - OpenSquilla 0.4.0 release notes.
 - [`releases/0.3.0.md`](releases/0.3.0.md) - OpenSquilla 0.3.0 release notes.
 - [`channels.md`](channels.md) - supported messaging channels and setup flow.
 - [`providers-and-models.md`](providers-and-models.md) - LLM provider catalog,

--- a/docs/authoring/meta-skills.md
+++ b/docs/authoring/meta-skills.md
@@ -403,7 +403,12 @@ text: "{{ outputs.search }}"
 
 ## Activation Guidance
 
-Write triggers as short phrases users naturally type:
+MetaSkills are manual-only by default in normal product use. Users launch them
+with `/meta <name>`, so trigger and soft-activation checks are needed only when
+you are intentionally supporting `meta_skill.auto_trigger = true`.
+
+When maintaining auto-trigger compatibility, write triggers as short phrases
+users naturally type:
 
 - Prefer: `summarize recent history`
 - Prefer: `review current diff`
@@ -412,11 +417,12 @@ Write triggers as short phrases users naturally type:
 Use two to five triggers unless a production workflow has a tested reason to use
 more. Avoid triggers that collide with explanation questions such as "how does
 this meta-skill work?" A user asking about a MetaSkill should not accidentally
-run it.
+run it when auto-trigger compatibility is enabled.
 
-Set `description` to explain when the model should choose the workflow. Do not
-hide critical constraints in the body only; the model primarily sees the
-frontmatter and injected skill summary.
+Set `description` to explain when the model should choose the workflow in
+auto-trigger mode. Do not hide critical constraints in the body only; the model
+primarily sees the frontmatter and injected skill summary when auto-trigger is
+enabled.
 
 ## Validation Checklist
 
@@ -430,8 +436,10 @@ Before sharing or enabling a MetaSkill:
 5. Confirm all user input and step outputs are filtered.
 6. Confirm `metadata.opensquilla.risk` and `metadata.opensquilla.capabilities`
    reflect the workflow's true side effects.
-7. Run deterministic trigger checks with `scripts/meta_trigger_accuracy.py`.
-8. Run model-decision soft activation checks with
+7. If supporting `meta_skill.auto_trigger = true`, run deterministic trigger
+   checks with `scripts/meta_trigger_accuracy.py`.
+8. If supporting `meta_skill.auto_trigger = true`, run model-decision soft
+   activation checks with
    `scripts/live_meta_soft_activation_e2e.py --env-file /path/to/.env`.
 9. For generated skills, inspect the Web UI proposal detail and its auto-enable
    audit before accepting or enabling.
@@ -443,8 +451,12 @@ If the MetaSkill does not appear to run:
 - Check that the `SKILL.md` is under a loaded skill directory.
 - Refresh or restart the gateway if the skill was added outside the proposal
   accept flow.
+- Confirm you ran it with `/meta <name>` on a surface that supports MetaSkill
+  runs.
 - Confirm `disable-model-invocation` is not set for a MetaSkill you expect the
   model to invoke.
+- If you expect natural-language auto-triggering, confirm
+  `meta_skill.auto_trigger = true`.
 - Confirm the skill has `kind: meta` and a non-empty `composition.steps` list.
 - Confirm the user wording matches the triggers or description.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,6 +21,7 @@ opensquilla <command> --help
 | `opensquilla gateway` | Run and manage the gateway server. |
 | `opensquilla chat` | Start interactive terminal chat. |
 | `opensquilla agent` | Run a single automation-friendly agent turn. |
+| `opensquilla code-task` | Run a guarded coding task through Coding mode's host workflow. |
 | `opensquilla sessions` | List, inspect, resume, abort, delete, or export sessions. |
 | `opensquilla skills` | List, search, view, install, update, publish, and inspect skills. |
 | `opensquilla memory` | Inspect and maintain memory. |
@@ -36,6 +37,7 @@ opensquilla <command> --help
 | `opensquilla models` | Inspect available models. |
 | `opensquilla agents` | Manage durable agents. |
 | `opensquilla mcp-server` | Run the OpenSquilla MCP server bridge. |
+| `opensquilla swebench` | Run optional SWE-bench solve/eval workflows. |
 | `opensquilla dist` | Emit a reproducible workspace-state inventory. |
 | `opensquilla reset` | Reset a session and flush memory synchronously. |
 
@@ -69,6 +71,11 @@ rejected before launch. Read
 [`features/tui-frontend.md`](features/tui-frontend.md) for the streaming plane,
 plugin slots, Router HUD, and replay benchmark workflow.
 
+Web chat and the CLI gateway TUI support `/meta` for manual MetaSkill launch:
+`/meta` lists available workflows and `/meta <name>` runs one. Channel surfaces
+and standalone CLI chat can list MetaSkills with `/meta`, but they do not launch
+MetaSkill runs directly.
+
 One-shot automation:
 
 ```sh
@@ -95,6 +102,45 @@ Useful automation flags:
 | `--transcript-path` | Write a JSONL transcript for automation. |
 | `--usage-path` | Write usage JSON. |
 | `--session-db-path` | Persist session replay across invocations. |
+
+## Coding Mode and Code-Task
+
+Coding mode routes code modification work through the `code-task` workflow. It
+is designed for trusted repositories: `code-task` runs an OpenSquilla agent on
+the host, may install dependencies, and is not an OS sandbox.
+
+```sh
+opensquilla code-task solve --repo /path/to/repo --task-file task.md --yes
+opensquilla code-task solve --repo https://github.com/org/project.git --issue 123
+opensquilla code-task solve --verification-mode scratch --task "Create a small CLI parser" --yes
+opensquilla code-task solve --repo /path/to/app --task-file task.md --verification-mode build --yes
+```
+
+Use exactly one task source: `--issue`, `--task`, or `--task-file`.
+Non-interactive callers must pass `--yes` to acknowledge the trusted-host
+boundary. Work happens in an isolated run directory under the OpenSquilla state
+tree; the source repo is updated only after the workflow collects and verifies a
+productive change.
+
+`--verification-mode red-green` is the default for existing repositories.
+`--verification-mode build` is for app or artifact delivery checks.
+`--verification-mode scratch` creates an empty throwaway repo and must not be
+combined with `--repo`.
+
+## SWE-Bench
+
+`opensquilla swebench` is an optional evaluation surface, not part of the normal
+install path. It requires Docker plus the `swebench` extra.
+
+```sh
+uv tool install --python 3.12 "opensquilla[recommended,swebench] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
+opensquilla swebench pull django__django-16429 --dataset verified
+opensquilla swebench solve django__django-16429 --dataset verified --json
+opensquilla swebench eval predictions.jsonl --dataset verified
+```
+
+Use `opensquilla code-task` for trusted real-repository coding tasks when you do
+not need the Docker-based SWE-bench harness.
 
 ## Configuration Commands
 
@@ -166,6 +212,11 @@ opensquilla skills meta runs replay <run-id> --dry-run
 
 Use `skills inspect` when you want to see the compiled step plan for a
 meta-skill before invoking it.
+
+MetaSkills are manual-only by default. In web chat and the CLI gateway TUI,
+run `/meta` to list workflows and `/meta <name>` to launch one. Natural-language
+auto-triggering is disabled unless `meta_skill.auto_trigger = true` is set in
+configuration for compatibility with older behavior.
 
 Read:
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -39,7 +39,8 @@ Read: [`features/tool-compression.md`](features/tool-compression.md)
 ### Meta-Skills
 
 Repeatable multi-step workflows can be represented as skills, inspected,
-proposed, replayed, and reused.
+proposed, replayed, and reused. By default, users launch them manually with
+`/meta` and `/meta <name>`.
 
 Read: [`features/meta-skills.md`](features/meta-skills.md) and
 [`features/meta-skill-user-guide.md`](features/meta-skill-user-guide.md)

--- a/docs/features/meta-skill-user-guide.md
+++ b/docs/features/meta-skill-user-guide.md
@@ -1,7 +1,8 @@
 # OpenSquilla MetaSkill User Guide
 
 MetaSkill lets OpenSquilla move from figuring out complex work from scratch on
-every turn to reusable, triggerable, auditable, and improvable task protocols.
+every turn to reusable, explicitly launchable, auditable, and improvable task
+protocols.
 
 A normal conversation solves one request. A MetaSkill preserves a way of doing
 high-value work.
@@ -55,9 +56,36 @@ MetaSkill provides four main advantages:
 
 - protocolized capability captured in a `SKILL.md` file with `kind: meta` and
   `composition.steps`;
-- triggerable by user intent in natural language;
+- explicit launch through `/meta`, with optional automatic triggering only when
+  `meta_skill.auto_trigger = true`;
 - auditable and replayable step inputs, outputs, status, and results;
 - improvable over time as repeated collaboration patterns become proposals.
+
+## Default Launch Model
+
+MetaSkills are manual-only by default. Use `/meta` to list available workflows
+and `/meta <name>` to run one. This keeps workflow launches deliberate,
+reviewable, and easier to explain.
+
+Web chat and the CLI gateway TUI support both list and run:
+
+```text
+/meta
+/meta meta-kid-project-planner
+```
+
+Channel and standalone CLI surfaces support `/meta` listing only.
+
+To restore the older automatic behavior, set:
+
+```toml
+[meta_skill]
+auto_trigger = true
+```
+
+With `auto_trigger = true`, OpenSquilla may consider MetaSkills during ordinary
+natural-language turns. Leave it off when you want workflows to run only after
+an explicit `/meta <name>` command.
 
 ## User Mental Model
 
@@ -75,7 +103,7 @@ A strong MetaSkill request contains four things:
 Example:
 
 ```text
-Use meta-skill `meta-kid-project-planner`.
+/meta meta-kid-project-planner
 
 I need a safe weekend project plan, not a generic list of ideas.
 Use only materials that are easy to buy locally.
@@ -121,23 +149,24 @@ Common setup surfaces:
 
 ## Two Ways to Use MetaSkill
 
-### Natural Delegation
+### Default: Explicit Command
 
-Describe the outcome directly:
+Start the workflow with `/meta <name>` and then describe the outcome:
 
 ```text
+/meta meta-kid-project-planner
+
 Plan a safe 20-minute balcony plant science project for a 7-year-old. Include
 materials, steps, safety notes, and a simple presentation outline.
 ```
 
-OpenSquilla selects the appropriate MetaSkill based on current intent. This is
-best for ordinary usage when the user does not want to remember names. If the
-request is broad or close to another task category, explicit delegation is more
-stable.
+This is the normal 0.4.0 path. It is best for important, expensive, or easily
+confused tasks because the workflow launch is explicit.
 
-### Explicit Delegation
+### Compatibility: Automatic Triggering
 
-Name the capability:
+If `meta_skill.auto_trigger = true` is set, OpenSquilla can consider MetaSkills
+from natural-language intent:
 
 ```text
 Use meta-skill `meta-kid-project-planner`.
@@ -146,14 +175,15 @@ Plan a safe 20-minute balcony plant science project for a 7-year-old. Include
 materials, steps, safety notes, and a simple presentation outline.
 ```
 
-This is best for important, expensive, or easily confused tasks.
+This mode is for users who intentionally want the older auto-trigger behavior.
+It is not the default.
 
 ## Low-Cost, High-Quality Request Template
 
 Recommended template:
 
 ```text
-Use meta-skill `<name>`.
+/meta <name>
 
 Outcome:
 Context:
@@ -166,7 +196,7 @@ Do not:
 Example:
 
 ```text
-Use meta-skill `meta-kid-project-planner`.
+/meta meta-kid-project-planner
 
 Outcome: plan a child-safe weekend science project.
 Context: 7-year-old, balcony plants, 20 minutes of activity, ordinary household
@@ -205,7 +235,7 @@ Good fit:
 High-quality request:
 
 ```text
-Use meta-skill `meta-kid-project-planner`.
+/meta meta-kid-project-planner
 
 Help my child prepare a second-grade science fair project about plant growth. We
 have beans, paper cups, cotton, water, and a sunny windowsill.
@@ -242,7 +272,7 @@ before asking for a compiled PDF.
 High-quality request:
 
 ```text
-Use meta-skill `meta-paper-write`.
+/meta meta-paper-write
 
 Draft a compact research paper skeleton on retrieval-augmented generation for
 customer-support knowledge bases.
@@ -284,7 +314,7 @@ Poor fit:
 High-quality request:
 
 ```text
-Use meta-skill `meta-skill-creator`.
+/meta meta-skill-creator
 
 Create a new meta-skill for product launch briefs. It should search current
 sources, collect product context, draft a launch memo, generate a DOCX handoff,

--- a/docs/features/meta-skills.md
+++ b/docs/features/meta-skills.md
@@ -47,7 +47,34 @@ requirements from child skills.
   `meta-paper-write` surfaces LaTeX/PDF requirements and
   `meta-short-drama` surfaces local video-tool requirements.
 
-## How to Ask
+## Run MetaSkills
+
+MetaSkills are manual-only by default. They do not auto-trigger from message
+keywords or appear in the runtime prompt unless you explicitly opt into the old
+automatic behavior.
+
+In Web chat and the CLI gateway TUI:
+
+```text
+/meta
+/meta meta-kid-project-planner
+```
+
+`/meta` lists available MetaSkills. `/meta <name>` starts the selected
+workflow. Channel and standalone CLI surfaces can list MetaSkills with `/meta`,
+but they do not run MetaSkills from chat text.
+
+To restore automatic model-triggered behavior, set:
+
+```toml
+[meta_skill]
+auto_trigger = true
+```
+
+Use this compatibility mode only when you want MetaSkills to be considered by
+the model during ordinary chat turns.
+
+## How to Prepare the Request
 
 Ask for the outcome and the standard:
 
@@ -56,10 +83,10 @@ Plan a safe 20-minute balcony plant science project for a 7-year-old. Include
 materials, adult setup, child steps, safety notes, and a presentation outline.
 ```
 
-For important or easily confused work, name the workflow:
+When you start a workflow, include the task after the command:
 
 ```text
-Use meta-skill `meta-kid-project-planner`.
+/meta meta-kid-project-planner
 
 Plan a safe 20-minute balcony plant science project for a 7-year-old. Include
 materials, adult setup, child steps, safety notes, and a presentation outline.
@@ -76,7 +103,13 @@ A strong request usually includes:
 
 ## Discover Meta-Skills
 
-List and search skills:
+Use chat slash commands for the runtime list:
+
+```text
+/meta
+```
+
+Use the CLI for inventory and inspection:
 
 ```sh
 opensquilla skills list

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -12,7 +12,7 @@ UI, CLI, channels, and gateway control console.
 Install OpenSquilla with the MCP extra when you need this bridge:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
 ```
 
 Start the OpenSquilla gateway:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -176,7 +176,7 @@ opensquilla mcp-server run
 Install with:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
 ```
 
 Use this when another MCP-capable client should access OpenSquilla-managed tools

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,7 +16,7 @@ UI, SquillaRouter, memory/search support, and safe local defaults.
 Install the current release wheel with the recommended extras:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.3.1/opensquilla-0.3.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
 ```
 
 The `recommended` extra includes SquillaRouter dependencies and memory/search

--- a/docs/releases/0.4.0.md
+++ b/docs/releases/0.4.0.md
@@ -1,0 +1,105 @@
+# OpenSquilla 0.4.0
+
+OpenSquilla 0.4.0 is a product-facing release for the control console,
+workflow control, search, and coding-oriented operations. It keeps the same
+gateway and install entry points while making day-to-day work easier to inspect,
+resume, and verify.
+
+## Highlights
+
+- **Refreshed Control UI** - the browser console now centers daily work around
+  conversations, session inspection, Settings, Skills readiness, Usage, Cron,
+  Logs, Approvals, artifact previews, share export, deliverables, turn trace,
+  and mobile-friendly navigation.
+- **Manual MetaSkills** - MetaSkills are manual-only by default. Use `/meta` to
+  list available workflows and `/meta <name>` to run one. Set
+  `meta_skill.auto_trigger = true` only when you intentionally want the older
+  automatic behavior.
+- **Coding mode and code-task** - coding mode exposes a guarded code-change
+  workflow that routes code edits through `opensquilla code-task`, isolated run
+  directories, trusted-host confirmation, and verification before source
+  persistence.
+- **Search provider expansion** - DuckDuckGo, Bocha, Brave, Tavily, and Exa are
+  documented as runtime-supported search providers, with `web_search` for
+  source-backed answers and `web_discover` for lightweight link discovery.
+- **Terminal and router visibility** - the stable Python-native terminal backend
+  remains the default, while OpenTUI is available as an explicit preview backend
+  with Router HUD and replay benchmark documentation.
+- **Provider surfaces and runtime hardening** - `openai_responses` exposes
+  OpenAI's native Responses API shape alongside `openai`; provider stream
+  parsing, Gemini thought-signature replay, SSRF fake-IP DNS guidance, session
+  recovery, artifact handling, and approval event delivery are tightened across
+  surfaces.
+
+## Install Assets
+
+- Python wheel: `opensquilla-0.4.0-py3-none-any.whl`
+- Windows portable: `OpenSquilla-0.4.0-windows-x64-py312-recommended-portable.zip`
+- Windows latest alias: `OpenSquilla-windows-x64-portable.zip`
+
+Install with the recommended extras:
+
+```sh
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
+```
+
+Install the optional MCP bridge extra when needed:
+
+```sh
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
+```
+
+## Upgrade Notes
+
+- Existing gateway and Web UI URLs do not change: run `opensquilla gateway run`
+  and open `http://127.0.0.1:18791/control/`.
+- Use `provider = "openai_responses"` when you intentionally want OpenAI
+  Responses-API behavior. `provider = "openai"` remains the chat/completions
+  request shape.
+- MetaSkills no longer auto-trigger unless `meta_skill.auto_trigger = true` is
+  set. Use `/meta` as the normal launch path.
+- `opensquilla code-task` runs trusted host work in isolated run directories.
+  Review the prompt and target repo before using it on unfamiliar code.
+- `opensquilla swebench` is optional and requires `opensquilla[swebench]` plus
+  Docker. It is for evaluation workflows, not the default user install path.
+- If a proxy or fake-IP DNS resolver maps public hosts to `198.18.0.0/15`, use
+  `tools.trusted_fake_ip_cidrs` only for trusted RFC 2544 fake-IP setups. Other
+  internal ranges remain blocked.
+
+## Acknowledgements
+
+Thanks to the contributors whose pull-request work is present in the current
+0.4.0 `dev` release surface:
+
+- [@ab2ence](https://github.com/ab2ence) for Control UI migration and
+  stabilization, share export, Web Chat slash-input handling, AwesomeWebpage
+  MetaSkill work, and the Coding mode toggle.
+- [@myz-ah](https://github.com/myz-ah) for the guarded `code-task` workflow.
+- [@nice-code-la](https://github.com/nice-code-la) for Skills readiness,
+  MetaSkill progress and clarification UX, manual `/meta` behavior, scoped
+  MetaSkill run history, router fallback/default work, and image follow-up
+  routing gates.
+- [@openvictory](https://github.com/openvictory) for MetaSkill run-history and
+  rescue-action Control UI work carried through the session-contract UI work.
+- [@weiconghe](https://github.com/weiconghe), [@changquanyou](https://github.com/changquanyou),
+  [@nkgotcode](https://github.com/nkgotcode), and
+  [@C1-BA-B1-F3](https://github.com/C1-BA-B1-F3) for provider, DOCX export, and
+  SSRF hardening fixes.
+- [@BlueOcean223](https://github.com/BlueOcean223), [@szdtzpj](https://github.com/szdtzpj),
+  [@lose4578](https://github.com/lose4578), and cwan0785
+  ([@Anonymous-4427](https://github.com/Anonymous-4427)) for TUI and OpenTUI
+  fixes and preview-backend work.
+
+See [`../../CONTRIBUTORS.md`](../../CONTRIBUTORS.md) for the full 0.4.0
+attribution ledger and PR evidence.
+
+## Documentation
+
+- Product guide: [`../../README.md`](../../README.md)
+- Quickstart: [`../quickstart.md`](../quickstart.md)
+- Web UI: [`../web-ui.md`](../web-ui.md)
+- MetaSkills: [`../features/meta-skills.md`](../features/meta-skills.md)
+- CLI: [`../cli.md`](../cli.md)
+- Providers: [`../providers-and-models.md`](../providers-and-models.md)
+- Search: [`../search.md`](../search.md)
+- TUI frontend: [`../features/tui-frontend.md`](../features/tui-frontend.md)

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -5,6 +5,10 @@ approvals, channels, logs, agents, usage, and operational status. It is the
 best surface when you want browser-based chat, visible tool activity, durable
 approvals, and a quick view of runtime health.
 
+The default Control UI in 0.4.0 is the Vue product UI served by the gateway.
+The legacy frontend is kept only as a maintainer rollback fallback, not as the
+normal user path.
+
 ## Start the Web UI
 
 Run the gateway in the foreground:
@@ -35,15 +39,16 @@ For gateway lifecycle, host/port, and exposure details, see
 
 | Area | Use it for |
 | --- | --- |
-| Chat | Run and resume chat sessions, inspect tool activity, publish artifacts, and use manual compact controls. |
+| Chat | Run and resume chat sessions, inspect tool activity, launch `/meta` workflows, publish artifacts, and use manual compact controls. |
+| Conversations | Switch active sessions from the sidebar and keep long-running work visible. |
 | Overview / Health | See readiness, provider state, memory state, sandbox posture, and recovery hints. |
+| Settings | Configure providers, router, search, channels, permissions, and other setup sections from a modal flow. |
 | Channels | Inspect configured channel adapter status and jump to guided setup for configuration changes. |
-| Skills | Browse available skills and meta-skill surfaces. |
-| Sessions | Inspect durable conversations and operational state. |
+| Skills | Browse skill readiness and MetaSkill availability. |
+| Sessions | Inspect the durable sessions ledger and operational state. |
 | Agents | Manage durable agent entries. |
 | Usage | Inspect token and estimated-cost rollups. |
 | Cron | View and manage scheduled runs. |
-| Config | Edit setup sections from the browser. |
 | Logs | Inspect runtime logs and diagnostics. |
 | Approvals | Respond to sensitive tool-call approval requests. |
 
@@ -53,15 +58,28 @@ The chat UI supports:
 
 - streaming assistant output;
 - tool-call cards;
-- artifact cards;
+- turn activity and RunTrace views for provider, router, tool, and usage events;
+- inline approval requests for sensitive actions;
+- artifact cards with thumbnails when previews are available;
+- a deliverables drawer for generated outputs;
+- share and export actions for handoff;
+- a conversation sidebar for switching sessions;
+- `/meta` listing and run launch on gateway-backed chat sessions;
 - pending message queue behavior while compaction or runtime work is in flight;
 - manual `/compact`;
 - per-turn usage and savings metadata when available;
-- copyable session keys.
+- copyable session keys;
+- mobile tabs that keep chat, sessions, and operational views reachable on
+  narrow screens.
 
 Use the session selector to switch between existing sessions. Copy the session
 key when reporting a bug or asking another OpenSquilla surface to inspect the
 same session.
+
+Coding mode can be enabled from chat when you want code modifications routed
+through `opensquilla code-task`. With Coding mode on, code changes use the
+guarded host workflow described in [`cli.md`](cli.md#coding-mode-and-code-task)
+instead of ordinary in-session editing.
 
 ## Manual Compaction
 
@@ -85,6 +103,10 @@ cards for:
 - reports and briefings;
 - exported data files;
 - PDFs, slide decks, images, and other generated outputs.
+
+Artifact cards may include thumbnails or preview metadata, and the deliverables
+drawer keeps published outputs discoverable after the originating turn has
+scrolled away.
 
 For channel delivery limits and artifact recovery, see
 [`artifacts-and-media.md`](artifacts-and-media.md).

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v0.3.1'
+$defaultVersion = 'v0.4.0'
 $repoSlug = if ($env:OPENSQUILLA_REPOSITORY) { $env:OPENSQUILLA_REPOSITORY } else { 'opensquilla/opensquilla' }
 $pythonVersion = if ($env:OPENSQUILLA_PYTHON_VERSION) { $env:OPENSQUILLA_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -94,7 +94,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.3.1. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.4.0. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v0.3.1"
+default_version="v0.4.0"
 repo_slug="${OPENSQUILLA_REPOSITORY:-opensquilla/opensquilla}"
 python_version="${OPENSQUILLA_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v0.3.1|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v0.4.0|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  OPENSQUILLA_VERSION=v0.3.1
+  OPENSQUILLA_VERSION=v0.4.0
   OPENSQUILLA_INSTALL_PROFILE=recommended|core
   OPENSQUILLA_INSTALL_EXTRAS=matrix
   OPENSQUILLA_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported OPENSQUILLA_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.3.1." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.4.0." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensquilla"
-version = "0.3.1"
+version = "0.4.0"
 description = "OpenSquilla — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -7,7 +7,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v0.3.1"
+CURRENT_RELEASE_TAG = "v0.4.0"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-CURRENT_VERSION = "0.3.1"
+CURRENT_VERSION = "0.4.0"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.2.0rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"

--- a/uv.lock
+++ b/uv.lock
@@ -1759,7 +1759,7 @@ wheels = [
 
 [[package]]
 name = "opensquilla"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Scope

Prepare the `dev` branch documentation and release surfaces for OpenSquilla 0.4.0.

This PR updates:
- project version and release/install URLs to `0.4.0` / `v0.4.0`
- README, product guide, docs index, release ledger, changelog, and 0.4.0 release notes
- MetaSkills documentation for the manual-only default and `/meta` launch path
- Web UI documentation for the refreshed Control UI and Vue default product UI
- CLI documentation for `code-task`, Coding mode, and optional `swebench`
- contributor attribution for PR work present in the 0.4.0 `dev` release surface
- release consistency tests and installer expectations

## Linked Issue

None.

## Release Note Status

Release notes included in `CHANGELOG.md` and `docs/releases/0.4.0.md`.

## Test Results

- `git diff --check --cached`
- `git diff --check`
- `/tmp/opensquilla-040-docs-venv/bin/python -m pytest tests/test_public_release_hygiene.py tests/test_packaging/test_pyproject_invariants.py tests/test_release_consistency.py tests/test_install_scripts.py tests/test_readme_links.py tests/test_public_release_golden_static.py tests/test_onboarding/test_search_docs_frontend_contract.py tests/test_skills/test_meta_skill_authoring_docs.py -q`

Result: `48 passed`.

## Safety Notes

Documentation, release metadata, installer defaults, and release consistency tests only. No runtime behavior changes.

## Third-Party Origin Details

No third-party code or generated runtime artifacts are introduced. Contributor acknowledgements reference GitHub PR evidence already present in the repository history.
