### PR TITLE
Fix desktop gateway startup and install telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,48 @@ For task-oriented product documentation, start with the
 
 ---
 
+## Anonymous Installation Telemetry
+
+OpenSquilla includes anonymous installation telemetry to estimate install
+counts, version distribution, and runtime compatibility. The telemetry path
+is enabled by default and sends to the official OpenSquilla telemetry collector.
+
+The gateway sends a best-effort install event on first startup and one version
+event the first time each OpenSquilla version runs. This covers source, pip,
+Docker, and desktop installs when they start the gateway. Uploads use a short
+timeout and never block startup.
+
+The telemetry payload contains only:
+
+- random `install_id`
+- OpenSquilla version
+- event type (`install` or `version_seen`)
+- install method (`pip`, `source`, `docker`, `desktop`, or `unknown`)
+- operating system, OS version, CPU architecture, and Python major/minor
+  version
+- first-seen and sent timestamps
+
+The telemetry payload does not include usernames, email addresses, hostnames,
+local paths, API keys, provider configuration, chat history, session data,
+memory, agent content, file names, or file contents. HTTP servers can
+technically observe source IP addresses at the transport/logging layer; IP
+addresses are not part of the telemetry payload and should not be used as an
+install-count field by the collector.
+
+Disable telemetry with:
+
+```sh
+OPENSQUILLA_TELEMETRY_DISABLED=true
+```
+
+Point telemetry at a collector you control with:
+
+```sh
+OPENSQUILLA_TELEMETRY_ENDPOINT=https://example.com/v1/install
+```
+
+---
+
 ## Installation
 
 OpenSquilla runs on Windows, macOS, and Linux. Pick the path that

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -12,6 +12,7 @@
     "dev": "npm run build && electron .",
     "dist:local": "npm run build:web && npm run build:gateway && npm run dist",
     "pack:local": "npm run build:web && npm run build:gateway && npm run pack",
+    "verify:package": "node scripts/verify-package.mjs",
     "start": "electron .",
     "pack": "npm run build && electron-builder --dir",
     "dist": "npm run build && electron-builder"
@@ -50,14 +51,32 @@
     "mac": {
       "category": "public.app-category.developer-tools",
       "icon": "assets/icon.icns",
-      "identity": null,
       "target": [
         "dmg",
         "zip"
       ]
     },
     "dmg": {
-      "icon": "assets/icon.icns"
+      "icon": "assets/icon.icns",
+      "backgroundColor": "#ffffff",
+      "iconSize": 92,
+      "window": {
+        "width": 540,
+        "height": 380
+      },
+      "contents": [
+        {
+          "x": 170,
+          "y": 205,
+          "type": "file"
+        },
+        {
+          "x": 370,
+          "y": 205,
+          "type": "link",
+          "path": "/Applications"
+        }
+      ]
     }
   }
 }

--- a/desktop/electron/scripts/verify-package.mjs
+++ b/desktop/electron/scripts/verify-package.mjs
@@ -1,0 +1,162 @@
+import { existsSync } from 'node:fs'
+import { readdir, readFile, stat } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, '..')
+const repoRoot = resolve(packageRoot, '..', '..')
+const runtimeGatewayDir = join(packageRoot, 'runtime', 'gateway')
+const compiledMainPath = join(packageRoot, 'dist', 'main.js')
+const desktopOutputDir = join(repoRoot, 'dist', 'desktop-electron')
+
+const failures = []
+
+function fail(message) {
+  failures.push(message)
+}
+
+async function listFiles(root) {
+  const files = []
+
+  async function walk(dir) {
+    let entries
+    try {
+      entries = await readdir(dir, { withFileTypes: true })
+    } catch (error) {
+      fail(`${root} could not be read: ${error instanceof Error ? error.message : String(error)}`)
+      return
+    }
+
+    for (const entry of entries) {
+      const path = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        await walk(path)
+      } else if (entry.isFile() && entry.name !== '.DS_Store') {
+        files.push(path)
+      }
+    }
+  }
+
+  await walk(root)
+  return files
+}
+
+async function verifyRuntime(root, label) {
+  if (!existsSync(root)) {
+    fail(`${label} runtime is missing at ${root}`)
+    return
+  }
+
+  const info = await stat(root).catch(() => null)
+  if (!info?.isDirectory()) {
+    fail(`${label} runtime is not a directory: ${root}`)
+    return
+  }
+
+  const files = await listFiles(root)
+  if (files.length === 0) {
+    fail(`${label} runtime is empty: ${root}`)
+    return
+  }
+
+  const compatFile = files.find((path) => path.endsWith(join('opensquilla', 'compat', 'aiosqlite.py')))
+  if (!compatFile) {
+    fail(`${label} runtime is missing opensquilla/compat/aiosqlite.py`)
+    return
+  }
+
+  const source = await readFile(compatFile, 'utf8')
+  if (!source.includes('async def create_function(') || !source.includes('self._conn.create_function')) {
+    fail(`${label} runtime aiosqlite.py does not contain _AsyncConnection.create_function`)
+  }
+}
+
+function verifyMainProcess(source, label) {
+  for (const expected of ['gatewayStartPromise', 'openOrResumeDesktopApp', 'ensureGatewayStarted']) {
+    if (!source.includes(expected)) fail(`${label} main process is missing ${expected}`)
+  }
+
+  const helperIndex = source.indexOf('async function openOrResumeDesktopApp')
+  const createIndex = source.indexOf('await createMainWindow()', helperIndex)
+  const ensureIndex = source.indexOf('ensureGatewayStarted()', helperIndex)
+  if (helperIndex === -1 || createIndex === -1 || ensureIndex === -1 || createIndex > ensureIndex) {
+    fail(`${label} main process does not create the desktop window before gateway startup`)
+  }
+
+  if (!/app\.on\(['"]activate['"][\s\S]{0,240}openOrResumeDesktopApp/.test(source)) {
+    fail(`${label} main process activate handler does not route through openOrResumeDesktopApp`)
+  }
+  if (!/second-instance[\s\S]{0,240}openOrResumeDesktopApp/.test(source)) {
+    fail(`${label} main process second-instance handler does not route through openOrResumeDesktopApp`)
+  }
+}
+
+async function verifyCompiledMain() {
+  if (!existsSync(compiledMainPath)) {
+    fail(`compiled Electron main process is missing at ${compiledMainPath}; run npm run build first`)
+    return
+  }
+
+  verifyMainProcess(await readFile(compiledMainPath, 'utf8'), 'compiled')
+}
+
+async function findGeneratedApps(root) {
+  const apps = []
+  if (!existsSync(root)) return apps
+
+  async function walk(dir, depth) {
+    if (depth > 5) return
+    const entries = await readdir(dir, { withFileTypes: true }).catch(() => [])
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      const path = join(dir, entry.name)
+      if (entry.name.endsWith('.app')) {
+        apps.push(path)
+      } else {
+        await walk(path, depth + 1)
+      }
+    }
+  }
+
+  await walk(root, 0)
+  return apps
+}
+
+async function readAsarText(asarPath, innerPath) {
+  const asar = await import('@electron/asar')
+  return asar.extractFile(asarPath, innerPath).toString('utf8')
+}
+
+async function verifyGeneratedApp(appPath) {
+  const resourcesDir = join(appPath, 'Contents', 'Resources')
+  await verifyRuntime(join(resourcesDir, 'runtime', 'gateway'), `app bundle ${appPath}`)
+
+  const asarPath = join(resourcesDir, 'app.asar')
+  if (!existsSync(asarPath)) {
+    fail(`app bundle ${appPath} is missing app.asar`)
+    return
+  }
+
+  try {
+    verifyMainProcess(await readAsarText(asarPath, 'dist/main.js'), `app bundle ${appPath}`)
+  } catch (error) {
+    fail(`app bundle ${appPath} app.asar could not be inspected: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+await verifyRuntime(runtimeGatewayDir, 'source')
+await verifyCompiledMain()
+
+const generatedApps = await findGeneratedApps(desktopOutputDir)
+for (const appPath of generatedApps) {
+  await verifyGeneratedApp(appPath)
+}
+
+if (failures.length > 0) {
+  console.error('OpenSquilla desktop package verification failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log('OpenSquilla desktop package verification passed.')

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -124,7 +124,7 @@ let mainWindow: BrowserWindow | null = null
 let onboardingWindow: BrowserWindow | null = null
 let gatewayProcess: ChildProcessWithoutNullStreams | null = null
 let isQuitting = false
-let startupInProgress = false
+let gatewayStartPromise: Promise<GatewayState> | null = null
 let resolveOnboarding: ((credential: DesktopConnection) => void) | null = null
 let rejectOnboarding: ((error: Error) => void) | null = null
 let bootStatus: BootStatus = {
@@ -790,6 +790,14 @@ function createApplicationMenu(): void {
     },
   ]
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+}
+
+function focusMainWindow(): boolean {
+  if (!mainWindow || mainWindow.isDestroyed()) return false
+  if (mainWindow.isMinimized()) mainWindow.restore()
+  mainWindow.show()
+  mainWindow.focus()
+  return true
 }
 
 function installEditingContextMenu(window: BrowserWindow): void {
@@ -2081,7 +2089,42 @@ async function waitForControlUi(url: string): Promise<void> {
   throw new Error(`Control UI did not become reachable at ${url}/control/`)
 }
 
+function hasGatewayProcessExited(process: ChildProcessWithoutNullStreams | null): boolean {
+  return Boolean(process && (process.exitCode !== null || process.signalCode !== null))
+}
+
+async function reuseHealthyGatewayState(): Promise<GatewayState | null> {
+  if (!gatewayState.url) return null
+  if (gatewayState.status !== 'ready' && !gatewayProcess) return null
+
+  if (await healthCheck(gatewayState.url)) {
+    gatewayState.status = 'ready'
+    gatewayState.error = undefined
+    sendBootStatus('Loading Control UI')
+    return gatewayState
+  }
+
+  if (gatewayProcess && gatewayState.owned && hasGatewayProcessExited(gatewayProcess)) {
+    gatewayProcess = null
+    gatewayState.status = 'stopped'
+  }
+  return null
+}
+
 async function startGateway(): Promise<GatewayState> {
+  const reusableGateway = await reuseHealthyGatewayState()
+  if (reusableGateway) return reusableGateway
+
+  if (gatewayProcess && gatewayState.owned) {
+    if (hasGatewayProcessExited(gatewayProcess)) {
+      gatewayProcess = null
+    } else {
+      stopGateway()
+    }
+    gatewayState.status = 'stopped'
+    gatewayState.error = undefined
+  }
+
   const overrideUrl = process.env.OPENSQUILLA_DESKTOP_GATEWAY_URL
   const explicitPort = process.env.OPENSQUILLA_DESKTOP_GATEWAY_PORT
   if (overrideUrl) {
@@ -2128,7 +2171,7 @@ async function startGateway(): Promise<GatewayState> {
   gatewayState.status = 'starting'
   gatewayState.logPath = logPath
 
-  gatewayProcess = spawn(
+  const child = spawn(
     runtime.command,
     [...runtime.args, '--port', String(port), '--bind', '127.0.0.1', '--config', desktopConfigPath()],
     {
@@ -2138,20 +2181,30 @@ async function startGateway(): Promise<GatewayState> {
         [connection.apiKeyEnv]: apiKey,
         ...(connection.searchApiKeyEnv && searchApiKey ? { [connection.searchApiKeyEnv]: searchApiKey } : {}),
         OPENSQUILLA_DESKTOP: '1',
+        OPENSQUILLA_INSTALL_METHOD: 'desktop',
         OPENSQUILLA_GATEWAY_CONFIG_PATH: desktopConfigPath(),
         OPENSQUILLA_STATE_DIR: desktopStateDir(),
         PYTHONUNBUFFERED: '1',
       },
     }
   )
+  gatewayProcess = child
 
-  gatewayProcess.stdout.pipe(logStream, { end: false })
-  gatewayProcess.stderr.pipe(logStream, { end: false })
-  gatewayProcess.once('exit', (code, signal) => {
-    gatewayState.status = isQuitting ? 'stopped' : 'error'
-    gatewayState.error = `gateway exited code=${code ?? 'null'} signal=${signal ?? 'null'}`
-    logStream.write(`\n[desktop] ${gatewayState.error}\n`)
-    if (!isQuitting && gatewayState.status === 'error') sendBootError(gatewayState.error)
+  child.stdout.pipe(logStream, { end: false })
+  child.stderr.pipe(logStream, { end: false })
+  child.once('exit', (code, signal) => {
+    const message = `gateway exited code=${code ?? 'null'} signal=${signal ?? 'null'}`
+    const isCurrentGateway = gatewayProcess === child
+    if (isCurrentGateway) gatewayProcess = null
+    logStream.write(`\n[desktop] ${message}\n`)
+    if (!isCurrentGateway) return
+    if (isQuitting) {
+      gatewayState.status = 'stopped'
+      return
+    }
+    gatewayState.status = 'error'
+    gatewayState.error = message
+    sendBootError(gatewayState.error)
   })
 
   sendBootStatus('Checking gateway health')
@@ -2180,7 +2233,7 @@ async function loadControlUi(window: BrowserWindow, gatewayUrl: string): Promise
 async function createMainWindow(): Promise<BrowserWindow> {
   if (mainWindow && !mainWindow.isDestroyed()) return mainWindow
 
-  mainWindow = new BrowserWindow({
+  const window = new BrowserWindow({
     width: 1360,
     height: 900,
     minWidth: 960,
@@ -2199,38 +2252,68 @@ async function createMainWindow(): Promise<BrowserWindow> {
       sandbox: true,
     },
   })
-  installEditingContextMenu(mainWindow)
+  mainWindow = window
+  installEditingContextMenu(window)
 
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+  window.webContents.setWindowOpenHandler(({ url }) => {
     void shell.openExternal(url)
     return { action: 'deny' }
   })
 
-  mainWindow.once('ready-to-show', () => {
-    mainWindow?.show()
+  window.once('ready-to-show', () => {
+    if (!window.isDestroyed()) window.show()
   })
 
-  await mainWindow.loadFile(bootPagePath())
-  return mainWindow
+  window.once('closed', () => {
+    if (mainWindow === window) mainWindow = null
+  })
+
+  await window.loadFile(bootPagePath())
+  return window
 }
 
-async function bootDesktopApp(): Promise<void> {
-  if (startupInProgress) return
-  startupInProgress = true
-  sendBootStatus('Preparing desktop profile')
+function currentMainWindow(): BrowserWindow | null {
+  return mainWindow && !mainWindow.isDestroyed() ? mainWindow : null
+}
+
+function ensureGatewayStarted(): Promise<GatewayState> {
+  if (!gatewayStartPromise) {
+    sendBootStatus('Preparing desktop profile')
+    gatewayStartPromise = startGateway().finally(() => {
+      gatewayStartPromise = null
+    })
+  }
+  return gatewayStartPromise
+}
+
+async function loadControlUiIntoCurrentWindow(gatewayUrl: string): Promise<void> {
+  const window = currentMainWindow()
+  if (!window) return
+
+  sendBootStatus('Loading Control UI')
   try {
-    const gateway = await startGateway()
-    const window = await createMainWindow()
-    sendBootStatus('Loading Control UI')
-    await loadControlUi(window, gateway.url)
-    sendBootStatus('Ready')
+    await loadControlUi(window, gatewayUrl)
   } catch (error) {
-    gatewayState.status = 'error'
-    gatewayState.error = error instanceof Error ? error.message : String(error)
-    await createMainWindow().catch(() => null)
-    sendBootError(error)
-  } finally {
-    startupInProgress = false
+    if (window.isDestroyed()) return
+    throw error
+  }
+  sendBootStatus('Ready')
+}
+
+async function openOrResumeDesktopApp(): Promise<void> {
+  await createMainWindow()
+  focusMainWindow()
+
+  try {
+    const reusableGateway = await reuseHealthyGatewayState()
+    const gateway = reusableGateway ?? await ensureGatewayStarted()
+    await loadControlUiIntoCurrentWindow(gateway.url)
+  } catch (error) {
+    if (gatewayState.status !== 'ready') {
+      gatewayState.status = 'error'
+      gatewayState.error = error instanceof Error ? error.message : String(error)
+    }
+    if (currentMainWindow()) sendBootError(error)
   }
 }
 
@@ -2262,12 +2345,20 @@ ipcMain.handle('desktop:boot:state', () => ({
   gateway: { ...gatewayState },
 }))
 ipcMain.handle('desktop:boot:retry', async () => {
-  if (startupInProgress) return { ok: false, reason: 'startup_in_progress' }
-  if (gatewayProcess && gatewayState.owned) stopGateway()
-  gatewayState.status = 'stopped'
-  gatewayState.error = undefined
-  await mainWindow?.loadFile(bootPagePath())
-  void bootDesktopApp()
+  const ready = gatewayState.status === 'ready' && gatewayState.url
+    ? await healthCheck(gatewayState.url)
+    : false
+
+  if (!gatewayStartPromise && !ready && gatewayProcess && gatewayState.owned) {
+    stopGateway()
+  }
+  if (!ready) {
+    gatewayState.status = 'stopped'
+    gatewayState.error = undefined
+    await currentMainWindow()?.loadFile(bootPagePath()).catch(() => null)
+  }
+
+  void openOrResumeDesktopApp()
   return { ok: true }
 })
 ipcMain.handle('desktop:boot:quit', () => {
@@ -2321,13 +2412,21 @@ app.on('window-all-closed', () => {
 })
 
 app.on('activate', () => {
-  if (BrowserWindow.getAllWindows().length === 0) {
-    void bootDesktopApp()
-  }
+  void openOrResumeDesktopApp()
 })
 
-void app.whenReady().then(async () => {
-  app.name = 'OpenSquilla'
-  createApplicationMenu()
-  void bootDesktopApp()
-})
+const gotSingleInstanceLock = app.requestSingleInstanceLock()
+
+if (!gotSingleInstanceLock) {
+  app.quit()
+} else {
+  app.on('second-instance', () => {
+    void openOrResumeDesktopApp()
+  })
+
+  void app.whenReady().then(async () => {
+    app.name = 'OpenSquilla'
+    createApplicationMenu()
+    void openOrResumeDesktopApp()
+  })
+}

--- a/docs/features/desktop-dmg-startup-window-spec.md
+++ b/docs/features/desktop-dmg-startup-window-spec.md
@@ -1,0 +1,207 @@
+# Desktop DMG Startup Window Recovery Spec
+
+## Background
+
+Users reported two macOS DMG installation issues:
+
+1. After installing the latest DMG, the first launch shows no window.
+2. In an earlier DMG, closing the client window with the red close button leaves the OpenSquilla app running in the Dock, but clicking the Dock icon does not reopen any window.
+
+This spec covers the desktop startup and packaging fix. It is separate from the gateway/yoyo migration lock recovery spec, although both can surface during first-run gateway startup.
+
+## Evidence
+
+Local packaged logs showed the bundled gateway crashing during first launch:
+
+```text
+AttributeError: '_AsyncConnection' object has no attribute 'create_function'
+```
+
+The crash path is:
+
+```text
+opensquilla/session/storage.py -> SessionStorage.connect()
+```
+
+The packaged runtime under the built app was missing `create_function` in `opensquilla.compat.aiosqlite._AsyncConnection`, while current source has the compatibility method.
+
+The packaged Electron app also still had this startup order:
+
+```ts
+const gateway = await startGateway()
+const window = await createMainWindow()
+```
+
+That means any gateway crash or long wait can prevent the first visible desktop window from being created.
+
+For the Dock behavior, macOS intentionally keeps the application process alive after all windows are closed. The existing behavior is acceptable only if `activate` reliably recreates or focuses the main window and reuses the already-running gateway instead of trying to perform a full duplicate startup.
+
+## Goals
+
+- Show a desktop window immediately on launch and Dock activation, before gateway startup can block or fail.
+- Surface gateway startup failure inside the desktop UI instead of leaving the user with no visible window.
+- Ensure the packaged gateway runtime contains the aiosqlite compatibility API needed by session storage.
+- Reuse an already-owned, healthy gateway on Dock activation instead of spawning a duplicate process.
+- Prevent duplicate gateway startup while a startup attempt is already in progress.
+- Make the release validation catch stale packaged runtime contents before distributing a DMG.
+
+## Non-Goals
+
+- Do not change macOS close-button semantics by default. Closing the last window may keep the app running unless product decides to switch to quit-on-close.
+- Do not disable yoyo migration locking.
+- Do not change gateway state directory, auth token, or persistence layout.
+- Do not treat a previously built DMG as fixed unless it is rebuilt from the fixed source and revalidated.
+- Do not treat unsigned local validation as equivalent to a distributable release validation.
+
+## Root Causes
+
+### 1. Packaged Gateway Runtime Was Stale
+
+The built app included a runtime copy of `opensquilla.compat.aiosqlite` without `_AsyncConnection.create_function`. Source had moved forward, but the packaged runtime did not contain that fix.
+
+When session storage calls `create_function`, the packaged gateway crashes before becoming healthy.
+
+### 2. Electron Created the Window After Gateway Startup
+
+The app waited for `startGateway()` before calling `createMainWindow()`. If gateway startup crashes, hangs, or waits on a lock, the desktop app can remain running without any visible window.
+
+### 3. macOS Activation Path Did Not Reliably Resume UI
+
+On macOS, `window-all-closed` does not quit the app. After the red close button, the Dock dot remains because the app process and gateway may still be alive.
+
+Clicking the Dock icon must focus an existing window or create a new one and attach it to the existing gateway state. If activation re-enters a full startup path, it can wait unnecessarily, hit duplicate startup guards, or fail silently.
+
+## Design
+
+### Electron Startup
+
+`bootDesktopApp()` must create the main window before gateway startup:
+
+```ts
+const window = await createMainWindow()
+const gateway = await startGateway()
+```
+
+The initial window should display a boot/loading state. If gateway startup succeeds, it loads the gateway URL. If gateway startup fails, it renders the existing startup error state with log details and retry actions.
+
+### Idempotent Gateway Startup
+
+`startGateway()` should become explicitly idempotent:
+
+- If an owned gateway process is already healthy, return the existing `gatewayState`.
+- If startup is already in progress, do not spawn another gateway. Focus or keep the boot window visible.
+- If the owned process exited, clear stale owned state before starting a new process.
+- If a gateway URL is present, health-check it before deciding to reuse it.
+
+This prevents Dock activation, second-instance activation, and retry actions from racing into duplicate gateway processes.
+
+### Dock Activation
+
+The `activate` handler should call a single helper that:
+
+1. Focuses an existing non-destroyed main window, or creates a new boot window.
+2. If `gatewayState.status === "ready"` and the URL passes health check, loads that URL.
+3. If startup is in progress, keeps the boot window visible.
+4. Otherwise starts gateway once and then loads or shows an error state.
+
+The same helper should be used by `second-instance` handling so a second launch focuses the original instance and does not start another gateway against the same state directory.
+
+### Window Close Semantics
+
+The macOS red close button can keep the process alive, but the implementation must clear stale window references on `closed` and make activation recreate the window.
+
+If product later chooses quit-on-close, that should be a separate product decision. It changes expected macOS app behavior and gateway lifetime, so it should not be bundled into this bug fix.
+
+### Gateway Runtime Compatibility
+
+The compatibility layer must provide `create_function` on both the protocol and wrapper implementation:
+
+```py
+class Connection(Protocol):
+    async def create_function(...)
+
+class _AsyncConnection:
+    async def create_function(...)
+```
+
+The wrapper should delegate to the underlying sqlite connection in the same thread-safe style as the other compatibility methods.
+
+### Packaging Guard
+
+Before building a distributable DMG:
+
+1. Rebuild the gateway runtime from current source.
+2. Fail the release if `desktop/electron/runtime/gateway` is empty or stale.
+3. Build the Electron app from current source.
+4. Inspect the packaged runtime and assert `create_function` exists.
+5. Inspect packaged `app.asar` and assert the main window is created before gateway startup.
+6. Sign, notarize, staple, and validate the final DMG.
+
+The previously generated DMG in `dist/desktop-electron` should be treated as stale for this bug because it was built before the latest desktop/runtime fixes.
+
+### Unsigned Functional Testing
+
+It is acceptable to build an unsigned or ad-hoc-signed DMG first for fast local functional testing. This phase should verify application behavior only:
+
+- first launch shows a window immediately;
+- advanced configuration can start the gateway;
+- closing the window with the red close button and clicking the Dock icon reopens the UI;
+- no duplicate gateway process is created;
+- logs do not contain the `create_function` crash or duplicate lock failures.
+
+Code signing and notarization do not rewrite Electron or Python business logic, so they should not change the intended desktop/gateway behavior. However, they can change the effective macOS runtime environment through Gatekeeper, quarantine handling, Hardened Runtime, entitlements, nested executable signing, dynamic library loading, and child process launch policy.
+
+Therefore, unsigned validation is only a pre-release smoke test. The final artifact sent to external users must still be rebuilt, signed, notarized, stapled, and validated end to end.
+
+The final release must not sign only the outer `.dmg`. The `.app` bundle and nested executables must be signed before creating/signing/notarizing the DMG.
+
+## Validation Plan
+
+### Automated
+
+- Run gateway compatibility tests covering `_AsyncConnection.create_function`.
+- Run gateway startup/lock tests to ensure duplicate startup and stale yoyo lock handling still work.
+- Add or keep an Electron-side regression check for startup order, ideally asserting `createMainWindow()` runs before `startGateway()` in the desktop boot path.
+- Add an Electron-side test or factored helper test for activation reuse:
+  - ready gateway state is reused;
+  - startup-in-progress does not spawn a second gateway;
+  - exited owned process is cleared before restart.
+
+### Manual DMG Smoke Test
+
+For the first local pass, this test may use an unsigned or ad-hoc-signed DMG. For external distribution, repeat the same test with a freshly built, signed, notarized, and stapled DMG.
+
+1. Remove or move aside existing user data for a clean first-run test.
+2. Install the app from the DMG.
+3. Launch from `/Applications`; a window must appear immediately.
+4. Complete or enter advanced configuration; the gateway should start and the UI should load.
+5. Close the window with the red close button.
+6. Confirm the Dock dot remains.
+7. Click the Dock icon; the window must reopen and load the existing gateway UI.
+8. Confirm only one `opensquilla-gateway` process is running.
+9. Confirm logs do not contain the `create_function` AttributeError.
+10. Confirm logs do not show duplicate gateway state-dir lock failures during Dock activation.
+
+### Release Validation
+
+Release validation applies only to the final signed and notarized artifact.
+
+Run these checks on the final artifact:
+
+```bash
+spctl --assess --type open --context context:primary-signature -v dist/desktop-electron/OpenSquilla-*.dmg
+spctl --assess --type execute -v dist/desktop-electron/mac-arm64/OpenSquilla.app
+xcrun stapler validate dist/desktop-electron/OpenSquilla-*.dmg
+hdiutil verify dist/desktop-electron/OpenSquilla-*.dmg
+```
+
+Also mount the DMG and inspect the installation window layout.
+
+## Acceptance Criteria
+
+- First launch from a clean DMG install always shows a desktop window before gateway health checks finish.
+- Gateway startup failures are visible in the app window with actionable error UI.
+- Packaged gateway runtime contains `_AsyncConnection.create_function`.
+- Dock activation after red-window-close reopens the UI and reuses the existing healthy gateway.
+- Second launch/focus behavior does not spawn a duplicate gateway process.
+- Final DMG is signed, notarized, stapled, and passes Gatekeeper validation.

--- a/docs/features/gateway-startup-locking-spec.md
+++ b/docs/features/gateway-startup-locking-spec.md
@@ -1,0 +1,219 @@
+# Gateway Startup Locking Spec
+
+Date: 2026-06-27
+Status: Draft
+
+## Problem
+
+Desktop first-run startup can leave the bundled gateway unable to boot when the
+initial process is interrupted or a second gateway process is started while the
+first process is still in schema migration.
+
+The observed failure pattern is:
+
+- A fresh desktop state starts successfully enough to seed the agent workspace.
+- The first bundled gateway process does not reach `gateway.started`.
+- Later gateway processes fail in `apply_pending()` with yoyo `LockTimeout`.
+- The yoyo error reports the same earlier process id for every retry.
+
+The direct failure is a stale or active row in the yoyo migration lock table for
+the desktop `sessions.db`. Once this state exists, repeated desktop retries do
+not recover by themselves.
+
+## Goals
+
+- Prevent the Electron shell from launching duplicate gateway processes for the
+  same desktop profile.
+- Keep the gateway pid lock alive for the full server lifetime and release it
+  on graceful shutdown.
+- Recover from a stale yoyo migration lock only when the recorded pid is proven
+  dead.
+- Preserve yoyo's safety guarantee when another process may still be migrating.
+- Surface actionable startup errors instead of an opaque PyInstaller traceback.
+
+## Non-Goals
+
+- Do not disable yoyo migration locking.
+- Do not blindly run `break-lock` on every migration lock timeout.
+- Do not change the session database schema as part of this fix.
+- Do not make the desktop gateway share a process with Electron.
+- Do not broaden gateway binding or auth behavior.
+
+## Existing Surfaces
+
+- Electron launches the bundled gateway in `desktop/electron/src/main.ts` via
+  `spawn(...)`.
+- Electron waits up to 45 seconds for `/healthz` before reporting that the
+  gateway did not become healthy.
+- The gateway acquires `GatewayPidLock` before `build_services()` and before
+  session database migration.
+- `build_services()` runs `apply_pending(session_db_path, migrations_dir)` before
+  opening `SessionStorage`.
+- `apply_pending()` delegates locking to `with backend.lock():`.
+- yoyo implements the migration lock as a row in `yoyo_lock`, keyed by pid, and
+  removes it in a `finally` block. A hard process exit can leave the row behind.
+
+## Design
+
+Implement three defensive layers. Each layer addresses a different failure mode
+and should be independently testable.
+
+### Layer 1: Electron Single Instance Guard
+
+Add `app.requestSingleInstanceLock()` near Electron app startup, before any
+gateway startup work can run.
+
+Expected behavior:
+
+- If the lock cannot be acquired, the new Electron process exits immediately.
+- On `second-instance`, the existing main window is restored and focused.
+- `bootDesktopApp()` must not run in the second Electron process.
+- The existing process remains the only owner allowed to spawn a gateway.
+
+This reduces duplicate gateway starts caused by double-clicking the app,
+reopening from Finder, or launching from a DMG while a first run is still in
+progress.
+
+### Layer 2: Gateway PID Lock Lifetime
+
+Store the acquired `GatewayPidLock` on the returned `GatewayServer` object and
+release it in `GatewayServer.close()`.
+
+Expected behavior:
+
+- `start_gateway_server()` acquires the lock before database migration, as it
+  does today.
+- The lock object remains strongly referenced for the whole server lifetime.
+- `GatewayServer.close()` calls `release()` exactly once, after shutdown work is
+  complete enough that a new gateway may safely start.
+- `release()` remains idempotent.
+- Existing `atexit` and signal cleanup remain as best-effort fallback paths.
+
+This makes normal gateway shutdown explicit instead of relying only on process
+exit behavior.
+
+### Layer 3: Conservative Yoyo Stale Lock Recovery
+
+Wrap yoyo `LockTimeout` handling inside `apply_pending()`.
+
+When yoyo reports a lock timeout:
+
+1. Inspect the lock table for recorded pids.
+2. If any recorded pid is alive, fail without clearing the lock.
+3. If every recorded pid is dead or invalid, delete the yoyo lock rows.
+4. Retry migration once.
+5. If the retry fails, surface the second failure without another recovery loop.
+
+The liveness check should use platform-appropriate process probing:
+
+- POSIX: `os.kill(pid, 0)`.
+- Windows: `OpenProcess` or equivalent existing helper behavior.
+
+The lock recovery path must log structured events:
+
+- `migrator.lock_timeout`
+- `migrator.lock_held_by_live_process`
+- `migrator.stale_lock_cleared`
+- `migrator.stale_lock_retry_failed`
+
+The operator-facing error should explain whether the gateway is still starting,
+another gateway is running, or a stale migration lock could not be recovered.
+
+## Safety Rules
+
+- Never clear a yoyo lock held by a live pid.
+- Never clear the lock if the database cannot be inspected safely.
+- Never retry migration more than once after clearing a stale lock.
+- Keep migration failure loud if schema state is uncertain.
+- Prefer false negatives over false positives: failing startup is safer than
+  corrupting a migration.
+
+## Implementation Notes
+
+Electron:
+
+- Add single-instance handling in `desktop/electron/src/main.ts`.
+- Keep the current `startupInProgress` guard for the existing process.
+- On a second instance, restore and focus `mainWindow` if it exists.
+
+Gateway:
+
+- Extend `GatewayServer` with an optional pid lock field.
+- Assign the acquired lock after `GatewayPidLock.acquire()` succeeds.
+- Release the lock in `GatewayServer.close()` in a `finally`-safe path.
+
+Migrator:
+
+- Import yoyo `LockTimeout` explicitly.
+- Add a small helper to query `yoyo_lock` rows through the yoyo backend or a
+  separate SQLite connection to the same local database.
+- Add a small helper to clear the yoyo lock table.
+- Keep `:memory:` behavior unchanged.
+- Keep normal no-pending migration behavior unchanged.
+
+## Test Plan
+
+### Unit Tests
+
+- `GatewayPidLock` rejects a second lock acquisition for the same state dir while
+  the first lock is held.
+- `GatewayServer.close()` releases the stored gateway pid lock.
+- `apply_pending()` does not clear a yoyo lock for a live pid.
+- `apply_pending()` clears a yoyo lock for a dead pid and retries once.
+- `apply_pending()` does not enter an unbounded retry loop after stale-lock
+  recovery fails.
+- `apply_pending()` preserves normal migration success and no-op behavior.
+
+### Electron Tests
+
+- A second Electron instance does not call `bootDesktopApp()`.
+- A second Electron instance focuses the existing window.
+- Desktop retry does not spawn a new gateway while startup is already in
+  progress.
+
+### Integration Tests
+
+- Create a temporary desktop state with `sessions.db` containing a stale
+  `yoyo_lock` row. Gateway startup clears it and completes migration.
+- Create a temporary desktop state with a live helper process recorded in
+  `yoyo_lock`. Gateway startup fails with a clear, non-destructive error.
+- Start two gateway processes against the same state dir. The second process
+  fails before database migration.
+
+### Manual DMG Smoke
+
+- Install the DMG into `/Applications`.
+- Start from a clean desktop user data directory.
+- Double-click the app repeatedly during first-run startup.
+- Confirm only one gateway process is launched.
+- Confirm the app becomes ready or surfaces a clear single startup error.
+- Force quit during first-run migration, relaunch, and confirm stale-lock
+  recovery works when the recorded pid is no longer alive.
+
+## Acceptance Criteria
+
+- Fresh DMG first run cannot spawn two owned gateway processes from two Electron
+  instances.
+- A stale yoyo migration lock whose pid is dead is cleared automatically and the
+  gateway starts.
+- A yoyo migration lock whose pid is alive is never cleared automatically.
+- A second gateway using the same desktop state fails before migration work.
+- Graceful gateway shutdown removes `gateway.pid` and releases
+  `gateway.pid.lock`.
+- Failure messages distinguish active startup, already-running gateway, and
+  unrecoverable migration lock states.
+- CI covers stale-lock recovery and live-lock non-recovery.
+
+## Rollout
+
+- Ship behind normal startup behavior, with no user-facing setting.
+- Keep structured logs in the desktop gateway log for post-incident diagnosis.
+- Add a short troubleshooting entry once the behavior is implemented.
+
+## Open Questions
+
+- Whether yoyo lock inspection should use yoyo backend APIs only or direct
+  SQLite for local file databases.
+- Whether desktop startup should extend the first-run health timeout after it
+  detects schema migration is active.
+- Whether the boot splash should show a distinct "Preparing database" phase.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,6 +54,30 @@ http://127.0.0.1:18791/control/
 
 For a focused gateway guide, see [`gateway.md`](gateway.md).
 
+## Desktop Gateway Startup Reports a Migration Lock
+
+During first run, the desktop app starts a local gateway and applies pending
+SQLite migrations before opening the Control UI. If startup is interrupted, the
+gateway may report a yoyo migration lock for `sessions.db`.
+
+Recent versions recover automatically when the lock row points only to dead or
+invalid process ids. The gateway keeps the migration failure loud and does not
+clear the lock when any recorded pid is still alive.
+
+Check the desktop gateway log for these events:
+
+```text
+migrator.lock_timeout
+migrator.stale_lock_cleared
+migrator.lock_held_by_live_process
+migrator.stale_lock_retry_failed
+```
+
+If the log says the lock is held by a live process, wait for that gateway to
+finish starting or stop the process cleanly. Do not remove `yoyo_lock` rows or
+run yoyo break-lock unless you have verified the recorded process is no longer
+running.
+
 ## Port Already In Use
 
 Use another port:

--- a/src/opensquilla/compat/aiosqlite.py
+++ b/src/opensquilla/compat/aiosqlite.py
@@ -11,7 +11,7 @@ import asyncio
 import importlib
 import os
 import sqlite3
-from collections.abc import AsyncIterator, Awaitable, Generator, Iterable
+from collections.abc import AsyncIterator, Awaitable, Callable, Generator, Iterable
 from contextlib import AbstractAsyncContextManager
 from typing import Any, Protocol, cast
 
@@ -99,6 +99,15 @@ class Connection(AbstractAsyncContextManager["Connection"], Protocol):
     async def enable_load_extension(self, enabled: bool) -> None: ...
 
     async def load_extension(self, path: str) -> None: ...
+
+    async def create_function(
+        self,
+        name: str,
+        num_params: int,
+        func: Callable[..., Any],
+        *,
+        deterministic: bool = False,
+    ) -> None: ...
 
 
 _native_available = _native_aiosqlite is not None
@@ -252,6 +261,23 @@ class _AsyncConnection:
     async def load_extension(self, path: str) -> None:
         async with self._locked:
             await asyncio.to_thread(self._conn.load_extension, path)
+
+    async def create_function(
+        self,
+        name: str,
+        num_params: int,
+        func: Callable[..., Any],
+        *,
+        deterministic: bool = False,
+    ) -> None:
+        async with self._locked:
+            await asyncio.to_thread(
+                self._conn.create_function,
+                name,
+                num_params,
+                func,
+                deterministic=deterministic,
+            )
 
     async def __aenter__(self) -> _AsyncConnection:
         return self

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -1176,65 +1176,80 @@ class GatewayServer:
     _channel_manager: Any = field(default=None, repr=False)
     _services: ServiceContainer | None = field(default=None, repr=False)
     _background_completion_manager: Any = field(default=None, repr=False)
+    _pid_lock: Any = field(default=None, repr=False)
+
+    def _release_pid_lock(self) -> None:
+        pid_lock = self._pid_lock
+        if pid_lock is None:
+            return
+        try:
+            pid_lock.release()
+        finally:
+            self._pid_lock = None
 
     async def close(self, reason: str = "shutdown") -> None:
         """Gracefully shut down: stop channels, broadcast shutdown, close WS, stop server."""
-        # Drain in-flight turns FIRST so replies are not lost.
-        # task_runtime.shutdown() waits for all running turns to complete before
-        # returning; only then do we stop channel delivery.
-        if self._services is not None and self._services.task_runtime is not None:
-            try:
-                await self._services.task_runtime.shutdown(graceful=True, graceful_timeout=30.0)
-            except Exception:
-                pass
-
-        if self._background_completion_manager is not None:
-            try:
-                await self._background_completion_manager.close(timeout=30.0)
-            except Exception:
-                log.debug("gateway.background_completion_close_failed", exc_info=True)
-            try:
-                from opensquilla.gateway.subagent_announce import set_background_completion_manager
-
-                set_background_completion_manager(None)
-            except Exception:
-                pass
-            self._background_completion_manager = None
-
-        # Stop channels after task_runtime is drained (no in-flight turns remain)
-        if self._channel_manager is not None:
-            await self._channel_manager.stop_all()
-            log.info("gateway.channels_stopped")
-
-        registry = get_registry()
-        await registry.broadcast("shutdown", {"reason": reason})
-
-        # Close all active WS connections
-        for conn in registry.all():
-            await conn.close()
-
-        # Close MCP clients
         try:
-            from opensquilla.mcp.discovery import close_active_clients
+            # Drain in-flight turns FIRST so replies are not lost.
+            # task_runtime.shutdown() waits for all running turns to complete before
+            # returning; only then do we stop channel delivery.
+            if self._services is not None and self._services.task_runtime is not None:
+                try:
+                    await self._services.task_runtime.shutdown(graceful=True, graceful_timeout=30.0)
+                except Exception:
+                    pass
 
-            await close_active_clients()
-            log.info("gateway.mcp_clients_closed")
-        except ImportError:
-            pass
+            if self._background_completion_manager is not None:
+                try:
+                    await self._background_completion_manager.close(timeout=30.0)
+                except Exception:
+                    log.debug("gateway.background_completion_close_failed", exc_info=True)
+                try:
+                    from opensquilla.gateway.subagent_announce import (
+                        set_background_completion_manager,
+                    )
 
-        if self._server is not None:
-            self._server.should_exit = True
+                    set_background_completion_manager(None)
+                except Exception:
+                    pass
+                self._background_completion_manager = None
 
-        if self._task is not None:
+            # Stop channels after task_runtime is drained (no in-flight turns remain)
+            if self._channel_manager is not None:
+                await self._channel_manager.stop_all()
+                log.info("gateway.channels_stopped")
+
+            registry = get_registry()
+            await registry.broadcast("shutdown", {"reason": reason})
+
+            # Close all active WS connections
+            for conn in registry.all():
+                await conn.close()
+
+            # Close MCP clients
             try:
-                await asyncio.wait_for(self._task, timeout=5.0)
-            except TimeoutError:
-                self._task.cancel()
+                from opensquilla.mcp.discovery import close_active_clients
 
-        if self._services is not None:
-            await self._services.close()
+                await close_active_clients()
+                log.info("gateway.mcp_clients_closed")
+            except ImportError:
+                pass
 
-        log.info("gateway.stopped", reason=reason)
+            if self._server is not None:
+                self._server.should_exit = True
+
+            if self._task is not None:
+                try:
+                    await asyncio.wait_for(self._task, timeout=5.0)
+                except TimeoutError:
+                    self._task.cancel()
+
+            if self._services is not None:
+                await self._services.close()
+
+            log.info("gateway.stopped", reason=reason)
+        finally:
+            self._release_pid_lock()
 
 
 def build_flush_service(
@@ -2212,15 +2227,36 @@ async def start_gateway_server(
     _pid_lock = GatewayPidLock(_state_path(config, ""))
     _pid_lock.acquire()
 
+    # Anonymous install telemetry is best-effort: it must never block gateway
+    # startup. The built-in endpoint is intentionally empty until configured.
+    try:
+        from opensquilla.observability.install_telemetry import collect_install_telemetry
+
+        result = collect_install_telemetry(config=config)
+        log.debug(
+            "gateway.install_telemetry",
+            skipped_reason=result.skipped_reason,
+            event=result.event,
+            sent=result.sent,
+            uploaded=result.uploaded,
+            endpoint_configured=result.endpoint_configured,
+        )
+    except Exception:
+        log.debug("gateway.install_telemetry_skipped", exc_info=True)
+
     # ── Reusable service initialization via build_services ───────────
-    svc = await build_services(
-        config=config,
-        session_manager=session_manager,
-        provider_selector=provider_selector,
-        tool_registry=tool_registry,
-        usage_tracker=usage_tracker,
-        session_db_path=str(_state_path(config, "sessions.db")),
-    )
+    try:
+        svc = await build_services(
+            config=config,
+            session_manager=session_manager,
+            provider_selector=provider_selector,
+            tool_registry=tool_registry,
+            usage_tracker=usage_tracker,
+            session_db_path=str(_state_path(config, "sessions.db")),
+        )
+    except BaseException:
+        _pid_lock.release()
+        raise
 
     # Record boot time for uptime calculation (gateway-specific)
     global _boot_time_ms
@@ -2873,6 +2909,7 @@ async def start_gateway_server(
     app.state.gateway_ready = False
 
     server_handle = GatewayServer(app=app, config=config)
+    server_handle._pid_lock = _pid_lock
     server_handle._channel_manager = channel_manager
     server_handle._services = svc
     server_handle._background_completion_manager = background_completion_manager

--- a/src/opensquilla/observability/install_telemetry.py
+++ b/src/opensquilla/observability/install_telemetry.py
@@ -1,0 +1,297 @@
+"""Anonymous installation telemetry.
+
+The telemetry surface is intentionally narrow: it tracks installation instances
+and version distribution, not users. The default endpoint points at the official
+OpenSquilla collector and can be overridden or disabled by environment variable.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import sys
+import tempfile
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from opensquilla import __version__
+from opensquilla.paths import default_opensquilla_home
+
+log = logging.getLogger(__name__)
+
+TELEMETRY_SCHEMA_VERSION = 1
+TELEMETRY_STATE_FILE = "install_telemetry.json"
+TELEMETRY_DISABLED_ENV = "OPENSQUILLA_TELEMETRY_DISABLED"
+TELEMETRY_ENDPOINT_ENV = "OPENSQUILLA_TELEMETRY_ENDPOINT"
+TELEMETRY_INSTALL_METHOD_ENV = "OPENSQUILLA_INSTALL_METHOD"
+
+DEFAULT_TELEMETRY_ENDPOINT = "https://telemetry.opensquilla.ai/v1/install"
+DEFAULT_TIMEOUT_SECONDS = 2.0
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_SUCCESS_STATUS_CODES = {200, 201, 202, 204}
+
+
+@dataclass(frozen=True)
+class InstallTelemetryResult:
+    state_path: Path
+    endpoint_configured: bool
+    disabled: bool = False
+    event: str | None = None
+    sent: bool = False
+    uploaded: bool = False
+    skipped_reason: str | None = None
+    error: str | None = None
+
+
+def collect_install_telemetry(
+    *,
+    config: Any | None = None,
+    state_path: str | Path | None = None,
+    version: str | None = None,
+) -> InstallTelemetryResult:
+    """Collect and upload anonymous installation telemetry if needed.
+
+    This function never raises. It is safe to call during gateway startup.
+    """
+    path = _state_path(config=config, explicit=state_path)
+    endpoint = _endpoint()
+
+    try:
+        if _telemetry_disabled():
+            return InstallTelemetryResult(
+                state_path=path,
+                endpoint_configured=bool(endpoint),
+                disabled=True,
+                skipped_reason="disabled",
+            )
+
+        current_version = (version or __version__ or "unknown").strip() or "unknown"
+        state = _load_or_create_state(path)
+        event = _next_event(state, current_version)
+        if event is None:
+            return InstallTelemetryResult(
+                state_path=path,
+                endpoint_configured=bool(endpoint),
+                skipped_reason="already_uploaded",
+            )
+
+        if not endpoint:
+            state["last_skip_reason"] = "endpoint_empty"
+            _write_state(path, state)
+            return InstallTelemetryResult(
+                state_path=path,
+                endpoint_configured=False,
+                event=event,
+                skipped_reason="endpoint_empty",
+            )
+
+        now = _utc_now()
+        payload = _build_payload(
+            state,
+            event=event,
+            current_version=current_version,
+            sent_at=now,
+        )
+        state["last_attempt_at"] = now
+        state["last_skip_reason"] = None
+        uploaded, error = _post_payload(endpoint, payload, timeout=DEFAULT_TIMEOUT_SECONDS)
+        if uploaded:
+            state["last_success_at"] = now
+            state["last_error"] = None
+            state["uploaded_install"] = True
+            _add_uploaded_version(state, current_version)
+        else:
+            state["last_error"] = error or "upload_failed"
+
+        _write_state(path, state)
+        return InstallTelemetryResult(
+            state_path=path,
+            endpoint_configured=True,
+            event=event,
+            sent=True,
+            uploaded=uploaded,
+            error=error,
+        )
+    except Exception as exc:  # pragma: no cover - defensive startup guard
+        log.debug("Install telemetry skipped: %s", exc, exc_info=True)
+        return InstallTelemetryResult(
+            state_path=path,
+            endpoint_configured=bool(endpoint),
+            skipped_reason="error",
+            error=str(exc),
+        )
+
+
+def _state_path(*, config: Any | None, explicit: str | Path | None) -> Path:
+    if explicit is not None:
+        return Path(explicit).expanduser()
+    configured_state_dir = getattr(config, "state_dir", None)
+    if isinstance(configured_state_dir, str) and configured_state_dir.strip():
+        root = Path(configured_state_dir.strip()).expanduser()
+    else:
+        root = default_opensquilla_home() / "state"
+    return root / TELEMETRY_STATE_FILE
+
+
+def _telemetry_disabled() -> bool:
+    value = os.environ.get(TELEMETRY_DISABLED_ENV, "").strip().lower()
+    return value in _TRUE_VALUES
+
+
+def _endpoint() -> str:
+    return os.environ.get(TELEMETRY_ENDPOINT_ENV, DEFAULT_TELEMETRY_ENDPOINT).strip()
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_or_create_state(path: Path) -> dict[str, Any]:
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return _normalize_state(data)
+        except (json.JSONDecodeError, OSError):
+            log.debug("Install telemetry state unreadable; replacing", exc_info=True)
+    return _new_state()
+
+
+def _new_state() -> dict[str, Any]:
+    now = _utc_now()
+    return {
+        "schema_version": TELEMETRY_SCHEMA_VERSION,
+        "install_id": str(uuid.uuid4()),
+        "first_seen_at": now,
+        "uploaded_install": False,
+        "uploaded_versions": [],
+        "last_attempt_at": None,
+        "last_success_at": None,
+        "last_error": None,
+        "last_skip_reason": None,
+    }
+
+
+def _normalize_state(data: dict[str, Any]) -> dict[str, Any]:
+    state = dict(data)
+    install_id = state.get("install_id")
+    if not isinstance(install_id, str) or not install_id.strip():
+        state["install_id"] = str(uuid.uuid4())
+    first_seen = state.get("first_seen_at")
+    if not isinstance(first_seen, str) or not first_seen.strip():
+        state["first_seen_at"] = _utc_now()
+    uploaded_versions = state.get("uploaded_versions")
+    if not isinstance(uploaded_versions, list):
+        uploaded_versions = []
+    state["uploaded_versions"] = [
+        str(item) for item in uploaded_versions if isinstance(item, str) and item.strip()
+    ]
+    state["schema_version"] = TELEMETRY_SCHEMA_VERSION
+    state["uploaded_install"] = bool(state.get("uploaded_install"))
+    state.setdefault("last_attempt_at", None)
+    state.setdefault("last_success_at", None)
+    state.setdefault("last_error", None)
+    state.setdefault("last_skip_reason", None)
+    return state
+
+
+def _write_state(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(state, fh, ensure_ascii=False, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, path)
+        os.chmod(path, 0o600)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _next_event(state: dict[str, Any], current_version: str) -> str | None:
+    if not state.get("uploaded_install", False):
+        return "install"
+    uploaded_versions = set(state.get("uploaded_versions") or [])
+    if current_version not in uploaded_versions:
+        return "version_seen"
+    return None
+
+
+def _add_uploaded_version(state: dict[str, Any], current_version: str) -> None:
+    versions = list(state.get("uploaded_versions") or [])
+    if current_version not in versions:
+        versions.append(current_version)
+    state["uploaded_versions"] = versions
+
+
+def _build_payload(
+    state: dict[str, Any],
+    *,
+    event: str,
+    current_version: str,
+    sent_at: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": TELEMETRY_SCHEMA_VERSION,
+        "event": event,
+        "install_id": state["install_id"],
+        "opensquilla_version": current_version,
+        "install_method": _detect_install_method(),
+        "os": _safe_str(platform.system()),
+        "os_version": _safe_str(platform.release()),
+        "architecture": _safe_str(platform.machine()),
+        "python_version": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "first_seen_at": state["first_seen_at"],
+        "sent_at": sent_at,
+    }
+
+
+def _safe_str(value: object) -> str:
+    text = str(value or "").strip()
+    return text or "unknown"
+
+
+def _detect_install_method() -> str:
+    explicit = os.environ.get(TELEMETRY_INSTALL_METHOD_ENV, "").strip().lower()
+    if explicit in {"pip", "source", "docker", "desktop", "unknown"}:
+        return explicit
+    if os.environ.get("OPENSQUILLA_DESKTOP", "").strip().lower() in _TRUE_VALUES:
+        return "desktop"
+    if os.environ.get("OPENSQUILLA_RUNNING_IN_CONTAINER", "").strip().lower() in _TRUE_VALUES:
+        return "docker"
+    if Path("/.dockerenv").exists():
+        return "docker"
+    source_root = Path(__file__).resolve().parents[3]
+    if (source_root / ".git").exists():
+        return "source"
+    return "pip"
+
+
+def _post_payload(
+    endpoint: str,
+    payload: dict[str, Any],
+    *,
+    timeout: float,
+) -> tuple[bool, str | None]:
+    try:
+        import httpx
+
+        with httpx.Client(timeout=timeout) as client:
+            response = client.post(endpoint, json=payload)
+        if response.status_code in _SUCCESS_STATUS_CODES:
+            return True, None
+        return False, f"http_status_{response.status_code}"
+    except Exception as exc:
+        log.debug("Install telemetry upload failed: %s", exc)
+        return False, str(exc)

--- a/src/opensquilla/persistence/migrator.py
+++ b/src/opensquilla/persistence/migrator.py
@@ -77,7 +77,8 @@ def _is_pid_alive(pid: int) -> bool:
         if handle:
             kernel32.CloseHandle(handle)
             return True
-        return kernel32.GetLastError() == 5
+        last_error = int(kernel32.GetLastError())
+        return last_error == 5
 
     try:
         os.kill(pid, 0)

--- a/src/opensquilla/persistence/migrator.py
+++ b/src/opensquilla/persistence/migrator.py
@@ -14,8 +14,9 @@ import sqlite3
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
-from yoyo import get_backend, read_migrations
+from yoyo import exceptions, get_backend, read_migrations
 
 log = logging.getLogger(__name__)
 
@@ -43,6 +44,124 @@ def _to_yoyo_url(db_url: str) -> str:
     # bare filesystem path — normalise to absolute so yoyo opens the same db
     # regardless of the worker cwd.
     return "sqlite:///" + os.path.abspath(db_url)
+
+
+def _sqlite_path_from_db_url(db_url: str) -> Path | None:
+    """Return a local SQLite database path when direct lock inspection is safe."""
+
+    if db_url == ":memory:":
+        return None
+    if "://" not in db_url:
+        return Path(db_url).expanduser().resolve()
+
+    parsed = urlparse(db_url)
+    if parsed.scheme != "sqlite" or parsed.netloc:
+        return None
+    if parsed.path in {"", "/:memory:"}:
+        return None
+
+    path = unquote(parsed.path)
+    if os.name != "nt" and path.startswith("//") and not path.startswith("///"):
+        path = path[1:]
+    return Path(path).expanduser().resolve()
+
+
+def _is_pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    if os.name == "nt":
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = kernel32.OpenProcess(0x1000, False, pid)
+        if handle:
+            kernel32.CloseHandle(handle)
+            return True
+        return kernel32.GetLastError() == 5
+
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _read_yoyo_lock_pids(db_path: Path) -> list[int] | None:
+    try:
+        connection = sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True)
+    except sqlite3.Error as exc:
+        log.warning(
+            "migrator.lock_inspect_failed",
+            extra={"db_path": str(db_path), "error": str(exc)},
+        )
+        return None
+
+    try:
+        rows = connection.execute("SELECT pid FROM yoyo_lock").fetchall()
+    except sqlite3.Error as exc:
+        log.warning(
+            "migrator.lock_inspect_failed",
+            extra={"db_path": str(db_path), "error": str(exc)},
+        )
+        return None
+    finally:
+        connection.close()
+
+    pids: list[int] = []
+    for (raw_pid,) in rows:
+        try:
+            pids.append(int(raw_pid))
+        except (TypeError, ValueError):
+            pids.append(0)
+    return pids
+
+
+def _clear_yoyo_lock(db_path: Path) -> bool:
+    try:
+        with sqlite3.connect(db_path) as connection:
+            connection.execute("DELETE FROM yoyo_lock")
+    except sqlite3.Error as exc:
+        log.warning(
+            "migrator.stale_lock_clear_failed",
+            extra={"db_path": str(db_path), "error": str(exc)},
+        )
+        return False
+    return True
+
+
+def _recover_stale_yoyo_lock(db_url: str, error: exceptions.LockTimeout) -> bool:
+    log.warning("migrator.lock_timeout", extra={"db_url": db_url, "error": str(error)})
+    db_path = _sqlite_path_from_db_url(db_url)
+    if db_path is None:
+        return False
+
+    pids = _read_yoyo_lock_pids(db_path)
+    if not pids:
+        return False
+
+    live_pids = [pid for pid in pids if _is_pid_alive(pid)]
+    if live_pids:
+        log.warning(
+            "migrator.lock_held_by_live_process",
+            extra={"db_path": str(db_path), "pids": live_pids},
+        )
+        pid_text = ", ".join(str(pid) for pid in live_pids)
+        raise exceptions.LockTimeout(
+            f"Gateway migration database is locked by live process pid={pid_text} "
+            f"at {db_path}"
+        ) from error
+
+    if not _clear_yoyo_lock(db_path):
+        return False
+    log.warning(
+        "migrator.stale_lock_cleared",
+        extra={"db_path": str(db_path), "pids": pids},
+    )
+    return True
 
 
 @contextlib.contextmanager
@@ -82,10 +201,27 @@ def apply_pending(db_url: str, migrations_dir: Path) -> list[str]:
         return []
 
     _ensure_sqlite_datetime_adapter()
+    try:
+        ids = _apply_pending_once(db_url, path)
+    except exceptions.LockTimeout as exc:
+        if not _recover_stale_yoyo_lock(db_url, exc):
+            raise
+        try:
+            ids = _apply_pending_once(db_url, path)
+        except exceptions.LockTimeout:
+            log.warning("migrator.stale_lock_retry_failed", extra={"db_url": db_url})
+            raise
+
+    if ids:
+        log.info("migrator.applied", extra={"count": len(ids), "ids": ids})
+    return ids
+
+
+def _apply_pending_once(db_url: str, migrations_dir: Path) -> list[str]:
     backend = get_backend(_to_yoyo_url(db_url))
     try:
         with _yoyo_utf8_open():
-            migrations = read_migrations(str(path))
+            migrations = read_migrations(str(migrations_dir))
             pending = backend.to_apply(migrations)
             ids = [m.id for m in pending]
             if not ids:
@@ -93,7 +229,6 @@ def apply_pending(db_url: str, migrations_dir: Path) -> list[str]:
 
             with backend.lock():
                 backend.apply_migrations(pending)
-        log.info("migrator.applied", extra={"count": len(ids), "ids": ids})
         return ids
     finally:
         close = getattr(backend, "close", None)

--- a/tests/test_compat/test_aiosqlite.py
+++ b/tests/test_compat/test_aiosqlite.py
@@ -27,6 +27,13 @@ async def test_sqlite3_fallback_execute_supports_await_and_async_context(
 
         assert row is not None
         assert row[0] == "alpha"
+
+        await conn.create_function("py_upper", 1, lambda value: value.upper())
+        async with conn.execute("SELECT py_upper(name) FROM items") as cur:
+            transformed = await cur.fetchone()
+
+        assert transformed is not None
+        assert transformed[0] == "ALPHA"
     finally:
         await conn.close()
         monkeypatch.delenv("OPENSQUILLA_FORCE_SQLITE3_BACKEND", raising=False)

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -1,0 +1,113 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def _section(source: str, start: str, end: str) -> str:
+    start_index = source.index(start)
+    end_index = source.index(end, start_index)
+    return source[start_index:end_index]
+
+
+def test_desktop_resume_is_visible_first_and_single_flight() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    resume = _section(
+        main_ts,
+        "async function openOrResumeDesktopApp",
+        "function stopGateway",
+    )
+
+    assert "let gatewayStartPromise: Promise<GatewayState> | null = null" in main_ts
+    assert "startupInProgress" not in main_ts
+    assert "function ensureGatewayStarted(): Promise<GatewayState>" in main_ts
+    assert "gatewayStartPromise = startGateway().finally" in main_ts
+    assert "gatewayStartPromise = null" in main_ts
+
+    assert resume.index("await createMainWindow()") < resume.index("ensureGatewayStarted()")
+    assert "focusMainWindow()" in resume
+    assert "reuseHealthyGatewayState()" in resume
+    assert "loadControlUiIntoCurrentWindow(gateway.url)" in resume
+
+
+def test_desktop_gateway_completion_uses_current_live_window() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    load_current = _section(
+        main_ts,
+        "async function loadControlUiIntoCurrentWindow",
+        "async function openOrResumeDesktopApp",
+    )
+
+    assert "function currentMainWindow(): BrowserWindow | null" in main_ts
+    assert "const window = currentMainWindow()" in load_current
+    assert "if (!window) return" in load_current
+    assert "if (window.isDestroyed()) return" in load_current
+    assert "if (mainWindow === window) mainWindow = null" in main_ts
+
+
+def test_desktop_activation_retry_and_second_instance_share_resume_helper() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    retry = _section(
+        main_ts,
+        "ipcMain.handle('desktop:boot:retry'",
+        "ipcMain.handle('desktop:boot:quit'",
+    )
+
+    assert "if (process.platform !== 'darwin') app.quit()" in main_ts
+    assert "app.on('activate', () => {\n  void openOrResumeDesktopApp()" in main_ts
+    assert "app.on('second-instance', () => {\n    void openOrResumeDesktopApp()" in main_ts
+    assert "void app.whenReady().then" in main_ts
+    assert "void openOrResumeDesktopApp()" in _section(
+        main_ts,
+        "void app.whenReady().then",
+        "})\n}",
+    )
+
+    assert "!gatewayStartPromise && !ready && gatewayProcess && gatewayState.owned" in retry
+    assert "stopGateway()" in retry
+    assert "void openOrResumeDesktopApp()" in retry
+
+
+def test_start_gateway_reuses_healthy_gateway_before_spawn() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    reuse = _section(
+        main_ts,
+        "async function reuseHealthyGatewayState",
+        "async function startGateway",
+    )
+    start = _section(
+        main_ts,
+        "async function startGateway",
+        "async function loadControlUi",
+    )
+
+    assert "await healthCheck(gatewayState.url)" in reuse
+    assert "gatewayState.status = 'ready'" in reuse
+    assert "const reusableGateway = await reuseHealthyGatewayState()" in start
+    assert start.index("const reusableGateway = await reuseHealthyGatewayState()") < start.index(
+        "const overrideUrl"
+    )
+    assert "if (reusableGateway) return reusableGateway" in start
+    assert "hasGatewayProcessExited(gatewayProcess)" in start
+    assert "stopGateway()" in start
+
+
+def test_package_verifier_hard_fails_stale_runtime_and_boot_contract() -> None:
+    verifier = _read("desktop/electron/scripts/verify-package.mjs")
+    package_json = json.loads(_read("desktop/electron/package.json"))
+
+    assert package_json["scripts"]["verify:package"] == "node scripts/verify-package.mjs"
+    for expected in [
+        "runtime is empty",
+        "_AsyncConnection.create_function",
+        "app.asar",
+        "gatewayStartPromise",
+        "openOrResumeDesktopApp",
+        "create the desktop window before gateway startup",
+        "process.exit(1)",
+    ]:
+        assert expected in verifier

--- a/tests/test_gateway/test_pidfile_lock.py
+++ b/tests/test_gateway/test_pidfile_lock.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from opensquilla.gateway.pidlock import GatewayPidLock
 
 
@@ -23,3 +25,29 @@ def test_pid_file_in_state_dir_not_parent(tmp_path: Path) -> None:
         )
     finally:
         lock.release()
+
+
+def test_pid_lock_rejects_second_acquisition_while_first_is_held(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    first = GatewayPidLock(state_dir)
+    first.acquire()
+    try:
+        second = GatewayPidLock(state_dir)
+        with pytest.raises(SystemExit) as exc_info:
+            second.acquire()
+
+        assert exc_info.value.code == 1
+    finally:
+        first.release()
+
+
+def test_pid_lock_release_is_idempotent(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    lock = GatewayPidLock(state_dir)
+    lock.acquire()
+
+    lock.release()
+    lock.release()
+
+    assert not (state_dir / "gateway.pid").exists()
+    assert not (state_dir / "gateway.pid.lock").exists()

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -60,6 +60,75 @@ def test_task_runtime_hard_deadline_honors_explicit_config() -> None:
     assert _task_runtime_turn_hard_deadline_s(config) == 12.5
 
 
+def test_gateway_server_close_releases_pid_lock_when_shutdown_step_fails() -> None:
+    from opensquilla.gateway import boot
+
+    released: list[str] = []
+
+    class FakePidLock:
+        def release(self) -> None:
+            released.append("released")
+
+    class FailingChannelManager:
+        async def stop_all(self) -> None:
+            raise RuntimeError("channel stop failed")
+
+    server = boot.GatewayServer(
+        app=SimpleNamespace(),
+        config=GatewayConfig(),
+        _channel_manager=FailingChannelManager(),
+        _pid_lock=FakePidLock(),
+    )
+
+    async def run_case() -> None:
+        with pytest.raises(RuntimeError, match="channel stop failed"):
+            await server.close()
+
+        assert released == ["released"]
+        assert server._pid_lock is None
+
+    asyncio.run(run_case())
+
+
+def test_start_gateway_server_releases_pid_lock_when_build_services_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.gateway import boot
+
+    events: list[str] = []
+
+    async def fail_build_services(**_kwargs: Any) -> Any:
+        events.append("build_services")
+        raise RuntimeError("service construction failed")
+
+    monkeypatch.setattr(boot, "build_services", fail_build_services)
+    monkeypatch.setattr(boot, "_setup_file_logging", lambda config: None)
+    monkeypatch.setattr(boot, "emit_skill_filter_banner", lambda config: None)
+    monkeypatch.setattr(
+        "opensquilla.gateway.pidlock.GatewayPidLock.acquire",
+        lambda self: events.append("acquire"),
+    )
+    monkeypatch.setattr(
+        "opensquilla.gateway.pidlock.GatewayPidLock.release",
+        lambda self: events.append("release"),
+    )
+    config = GatewayConfig(
+        state_dir=str(tmp_path / "state"),
+        workspace_dir=str(tmp_path / "workspace"),
+        control_ui={"enabled": False},
+        channels={"channels": []},
+    )
+
+    async def run_case() -> None:
+        with pytest.raises(RuntimeError, match="service construction failed"):
+            await boot.start_gateway_server(config=config, run=False)
+
+        assert events == ["acquire", "build_services", "release"]
+
+    asyncio.run(run_case())
+
+
 def test_build_task_runtime_run_kwargs_forwards_fresh_user_session() -> None:
     run = SimpleNamespace(
         agent_id="main",

--- a/tests/test_observability/test_install_telemetry.py
+++ b/tests/test_observability/test_install_telemetry.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from opensquilla.observability import install_telemetry as telemetry
+
+TEST_ENDPOINT = "https://telemetry.example.test/v1/install"
+PRODUCTION_ENDPOINT = "https://telemetry.opensquilla.ai/v1/install"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_default_endpoint_uploads_install_once_and_dedupes(tmp_path, monkeypatch):
+    monkeypatch.delenv(telemetry.TELEMETRY_ENDPOINT_ENV, raising=False)
+    monkeypatch.delenv(telemetry.TELEMETRY_DISABLED_ENV, raising=False)
+    state_path = tmp_path / "install_telemetry.json"
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_post(
+        endpoint: str,
+        payload: dict[str, Any],
+        *,
+        timeout: float,
+    ) -> tuple[bool, str | None]:
+        calls.append((endpoint, payload))
+        return True, None
+
+    monkeypatch.setattr(telemetry, "_post_payload", fake_post)
+
+    first = telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+    second = telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+
+    assert first.sent is True
+    assert first.uploaded is True
+    assert first.event == "install"
+    assert second.sent is False
+    assert second.skipped_reason == "already_uploaded"
+    assert len(calls) == 1
+    endpoint, payload = calls[0]
+    assert endpoint == PRODUCTION_ENDPOINT
+    assert payload["event"] == "install"
+    assert payload["opensquilla_version"] == "1.0.0"
+    state = _load(state_path)
+    assert state["uploaded_install"] is True
+    assert state["uploaded_versions"] == ["1.0.0"]
+
+
+def test_endpoint_empty_creates_install_id_without_upload(tmp_path, monkeypatch):
+    monkeypatch.delenv(telemetry.TELEMETRY_ENDPOINT_ENV, raising=False)
+    monkeypatch.delenv(telemetry.TELEMETRY_DISABLED_ENV, raising=False)
+    monkeypatch.setattr(telemetry, "DEFAULT_TELEMETRY_ENDPOINT", "")
+    state_path = tmp_path / "install_telemetry.json"
+
+    result = telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+
+    assert result.sent is False
+    assert result.uploaded is False
+    assert result.event == "install"
+    assert result.skipped_reason == "endpoint_empty"
+    state = _load(state_path)
+    assert state["install_id"]
+    assert state["uploaded_install"] is False
+    assert state["uploaded_versions"] == []
+    assert state["last_skip_reason"] == "endpoint_empty"
+
+
+def test_configured_endpoint_uploads_install_once_and_dedupes(tmp_path, monkeypatch):
+    monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    state_path = tmp_path / "install_telemetry.json"
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_post(
+        endpoint: str,
+        payload: dict[str, Any],
+        *,
+        timeout: float,
+    ) -> tuple[bool, str | None]:
+        calls.append((endpoint, payload))
+        return True, None
+
+    monkeypatch.setattr(telemetry, "_post_payload", fake_post)
+
+    first = telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+    second = telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+
+    assert first.sent is True
+    assert first.uploaded is True
+    assert first.event == "install"
+    assert second.sent is False
+    assert second.skipped_reason == "already_uploaded"
+    assert len(calls) == 1
+    endpoint, payload = calls[0]
+    assert endpoint == TEST_ENDPOINT
+    assert payload["event"] == "install"
+    assert payload["opensquilla_version"] == "1.0.0"
+    assert set(payload) == {
+        "schema_version",
+        "event",
+        "install_id",
+        "opensquilla_version",
+        "install_method",
+        "os",
+        "os_version",
+        "architecture",
+        "python_version",
+        "first_seen_at",
+        "sent_at",
+    }
+    state = _load(state_path)
+    assert state["uploaded_install"] is True
+    assert state["uploaded_versions"] == ["1.0.0"]
+
+
+def test_new_version_uploads_version_seen(tmp_path, monkeypatch):
+    monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    state_path = tmp_path / "install_telemetry.json"
+    events: list[str] = []
+
+    def fake_post(
+        endpoint: str,
+        payload: dict[str, Any],
+        *,
+        timeout: float,
+    ) -> tuple[bool, str | None]:
+        events.append(str(payload["event"]))
+        return True, None
+
+    monkeypatch.setattr(telemetry, "_post_payload", fake_post)
+
+    telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+    result = telemetry.collect_install_telemetry(state_path=state_path, version="1.1.0")
+
+    assert result.sent is True
+    assert result.uploaded is True
+    assert result.event == "version_seen"
+    assert events == ["install", "version_seen"]
+    assert _load(state_path)["uploaded_versions"] == ["1.0.0", "1.1.0"]
+
+
+def test_disabled_env_skips_without_creating_state(tmp_path, monkeypatch):
+    monkeypatch.setenv(telemetry.TELEMETRY_DISABLED_ENV, "true")
+    monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    state_path = tmp_path / "install_telemetry.json"
+
+    result = telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+
+    assert result.disabled is True
+    assert result.sent is False
+    assert result.skipped_reason == "disabled"
+    assert not state_path.exists()
+
+
+def test_upload_failure_does_not_mark_install_uploaded(tmp_path, monkeypatch):
+    monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    state_path = tmp_path / "install_telemetry.json"
+
+    def fake_post(
+        endpoint: str,
+        payload: dict[str, Any],
+        *,
+        timeout: float,
+    ) -> tuple[bool, str | None]:
+        return False, "network_down"
+
+    monkeypatch.setattr(telemetry, "_post_payload", fake_post)
+
+    result = telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+
+    assert result.sent is True
+    assert result.uploaded is False
+    assert result.error == "network_down"
+    state = _load(state_path)
+    assert state["uploaded_install"] is False
+    assert state["uploaded_versions"] == []
+    assert state["last_error"] == "network_down"
+
+
+def test_desktop_env_sets_install_method(monkeypatch):
+    monkeypatch.delenv(telemetry.TELEMETRY_INSTALL_METHOD_ENV, raising=False)
+    monkeypatch.setenv("OPENSQUILLA_DESKTOP", "1")
+
+    assert telemetry._detect_install_method() == "desktop"

--- a/tests/test_persistence/test_migrator.py
+++ b/tests/test_persistence/test_migrator.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import builtins
 import contextlib
+import sqlite3
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
+from yoyo import exceptions
 
 from opensquilla.persistence import migrator
 from opensquilla.persistence.migrator import apply_pending
@@ -75,3 +79,181 @@ def test_apply_pending_forces_utf8_when_yoyo_loads_python_migrations(
     assert seen["content"] == "marker = '— 界'\n"
     assert seen["pending"] == ["V999__utf8"]
     assert seen["closed"] is True
+
+
+def _create_yoyo_lock(db_path: Path, pid: int) -> None:
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            "CREATE TABLE yoyo_lock (locked INTEGER PRIMARY KEY, ctime TIMESTAMP, pid INTEGER)"
+        )
+        connection.execute(
+            "INSERT INTO yoyo_lock (locked, ctime, pid) VALUES (1, CURRENT_TIMESTAMP, ?)",
+            (pid,),
+        )
+
+
+def _yoyo_lock_pids(db_path: Path) -> list[int]:
+    with sqlite3.connect(db_path) as connection:
+        return [row[0] for row in connection.execute("SELECT pid FROM yoyo_lock")]
+
+
+class _RaisingLock:
+    def __init__(self, message: str = "Process 424242 has locked this database") -> None:
+        self._message = message
+
+    def __enter__(self) -> None:
+        raise exceptions.LockTimeout(self._message)
+
+    def __exit__(self, *_args) -> None:  # type: ignore[no-untyped-def]
+        return None
+
+
+class _FakeBackend:
+    def __init__(self, lock_context: object, applied: list[list[str]], closed: list[str]) -> None:
+        self._lock_context = lock_context
+        self._applied = applied
+        self._closed = closed
+
+    def to_apply(self, migrations):  # type: ignore[no-untyped-def]
+        return migrations
+
+    def lock(self):
+        return self._lock_context
+
+    def apply_migrations(self, pending) -> None:  # type: ignore[no-untyped-def]
+        self._applied.append([item.id for item in pending])
+
+    def close(self) -> None:
+        self._closed.append("closed")
+
+
+def test_apply_pending_clears_dead_yoyo_lock_and_retries_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "sessions.db"
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    _create_yoyo_lock(db_path, 424242)
+
+    applied: list[list[str]] = []
+    closed: list[str] = []
+    backends = [
+        _FakeBackend(_RaisingLock(), applied, closed),
+        _FakeBackend(contextlib.nullcontext(), applied, closed),
+    ]
+
+    monkeypatch.setattr(migrator, "_is_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(migrator, "read_migrations", lambda _path: [SimpleNamespace(id="V001")])
+    monkeypatch.setattr(migrator, "get_backend", lambda _url: backends.pop(0))
+
+    result = apply_pending(str(db_path), migrations_dir)
+
+    assert result == ["V001"]
+    assert applied == [["V001"]]
+    assert closed == ["closed", "closed"]
+    assert _yoyo_lock_pids(db_path) == []
+    assert backends == []
+
+
+def test_apply_pending_recovers_stale_yoyo_lock_with_real_backend(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "V001__real_backend.py").write_text(
+        "from yoyo import step\n"
+        "__depends__ = set()\n"
+        "steps = [step('CREATE TABLE real_backend_demo (id INTEGER PRIMARY KEY)')]\n",
+        encoding="utf-8",
+    )
+    db_path = tmp_path / "sessions.db"
+    _create_yoyo_lock(db_path, 424242)
+    real_get_backend = migrator.get_backend
+
+    def get_fast_lock_backend(url: str):
+        backend = real_get_backend(url)
+        real_lock = backend.lock
+
+        def fast_lock(timeout: float = 10):
+            return real_lock(timeout=0.01)
+
+        backend.lock = fast_lock  # type: ignore[method-assign]
+        return backend
+
+    monkeypatch.setattr(migrator, "_is_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(migrator, "get_backend", get_fast_lock_backend)
+
+    result = apply_pending(str(db_path), migrations_dir)
+
+    assert result == ["V001__real_backend"]
+    assert _yoyo_lock_pids(db_path) == []
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='real_backend_demo'"
+        ).fetchall()
+    assert rows == [("real_backend_demo",)]
+
+
+def test_apply_pending_does_not_clear_live_yoyo_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "sessions.db"
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    _create_yoyo_lock(db_path, 12345)
+
+    applied: list[list[str]] = []
+    closed: list[str] = []
+    backends = [
+        _FakeBackend(_RaisingLock("Process 12345 has locked this database"), applied, closed)
+    ]
+
+    monkeypatch.setattr(migrator, "_is_pid_alive", lambda pid: pid == 12345)
+    monkeypatch.setattr(migrator, "read_migrations", lambda _path: [SimpleNamespace(id="V001")])
+    monkeypatch.setattr(migrator, "get_backend", lambda _url: backends.pop(0))
+
+    with pytest.raises(exceptions.LockTimeout, match="live process pid=12345"):
+        apply_pending(str(db_path), migrations_dir)
+
+    assert applied == []
+    assert closed == ["closed"]
+    assert _yoyo_lock_pids(db_path) == [12345]
+    assert backends == []
+
+
+def test_apply_pending_does_not_loop_when_stale_lock_retry_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "sessions.db"
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    _create_yoyo_lock(db_path, 424242)
+
+    applied: list[list[str]] = []
+    closed: list[str] = []
+    backends = [
+        _FakeBackend(_RaisingLock(), applied, closed),
+        _FakeBackend(_RaisingLock("Database locked after cleanup"), applied, closed),
+    ]
+
+    monkeypatch.setattr(migrator, "_is_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(migrator, "read_migrations", lambda _path: [SimpleNamespace(id="V001")])
+    monkeypatch.setattr(migrator, "get_backend", lambda _url: backends.pop(0))
+
+    with pytest.raises(exceptions.LockTimeout, match="Database locked after cleanup"):
+        apply_pending(str(db_path), migrations_dir)
+
+    assert applied == []
+    assert closed == ["closed", "closed"]
+    assert _yoyo_lock_pids(db_path) == []
+    assert backends == []
+
+
+def test_sqlite_path_from_db_url_rejects_unsupported_database_urls() -> None:
+    assert migrator._sqlite_path_from_db_url(":memory:") is None
+    assert migrator._sqlite_path_from_db_url("sqlite:///:memory:") is None
+    assert migrator._sqlite_path_from_db_url("postgresql://example/db") is None


### PR DESCRIPTION
## Summary
- Add anonymous gateway install/version telemetry that covers desktop and source launches without blocking startup.
- Harden gateway startup ownership, pid locking, stale yoyo lock recovery, and packaged desktop first-run window behavior.
- Add desktop package verification plus specs/tests for the DMG startup and migration lock failure modes.

## Notes
- Desktop build artifacts are intentionally not included in this PR.
- This branch is based directly on the latest `origin/dev`; it does not depend on the previous login-info or DMG fix branches.

## Verification
- `uv run --frozen pytest tests/test_desktop/test_electron_startup_contract.py tests/test_compat/test_aiosqlite.py tests/test_gateway/test_pidfile_lock.py tests/test_gateway/test_router_boot.py tests/test_persistence/test_migrator.py tests/test_observability/test_install_telemetry.py`
- `uv run --frozen ruff check src/opensquilla/compat/aiosqlite.py src/opensquilla/gateway/boot.py src/opensquilla/persistence/migrator.py src/opensquilla/observability/install_telemetry.py tests/test_compat/test_aiosqlite.py tests/test_gateway/test_pidfile_lock.py tests/test_gateway/test_router_boot.py tests/test_persistence/test_migrator.py tests/test_observability/test_install_telemetry.py`
- `npm run build` from `desktop/electron`
- `npm run verify:package` from `desktop/electron`
