### PR TITLE
[codex] Avoid structlog event field collisions

### DIFF
--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -2236,7 +2236,7 @@ async def start_gateway_server(
         log.debug(
             "gateway.install_telemetry",
             skipped_reason=result.skipped_reason,
-            event=result.event,
+            telemetry_event=result.event,
             sent=result.sent,
             uploaded=result.uploaded,
             endpoint_configured=result.endpoint_configured,

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -1745,7 +1745,7 @@ async def _emit_to_subscribers(
             try:
                 await conn.send_event(event_name, send_payload)
             except Exception:
-                log.warning("emit.send_failed", conn_id=conn_id, event=event_name)
+                log.warning("emit.send_failed", conn_id=conn_id, ws_event=event_name)
 
 
 @_d.method("sessions.abort", scope="operator.write")

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -129,6 +129,110 @@ def test_start_gateway_server_releases_pid_lock_when_build_services_fails(
     asyncio.run(run_case())
 
 
+def test_start_gateway_server_logs_install_telemetry_without_structlog_event_collision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.gateway import boot
+
+    debug_logs: list[tuple[str, dict[str, Any]]] = []
+
+    class FakeLog:
+        def debug(self, event: str, **kwargs: Any) -> None:
+            debug_logs.append((event, kwargs))
+
+        def info(self, _event: str, **_kwargs: Any) -> None:
+            return None
+
+        def warning(self, _event: str, **_kwargs: Any) -> None:
+            return None
+
+    class FakeTurnRunner:
+        def __init__(self, **_kwargs: Any) -> None:
+            return None
+
+        def set_session_lock_provider(self, _provider: Any) -> None:
+            return None
+
+    async def fake_build_services(**kwargs: Any) -> Any:
+        config = kwargs["config"]
+
+        async def close() -> None:
+            return None
+
+        return SimpleNamespace(
+            provider_selector=object(),
+            tool_registry=object(),
+            session_manager=object(),
+            skill_loader=object(),
+            usage_tracker=object(),
+            config=config,
+            memory_sync_managers={},
+            model_catalog=None,
+            memory_retrievers={},
+            turn_capture_services={},
+            flush_service=None,
+            cron_scheduler=None,
+            task_runtime=None,
+            agent_registry=None,
+            memory_managers={},
+            memory_stores={},
+            _turn_runner_ref=[],
+            close=close,
+        )
+
+    def fake_collect_install_telemetry(*, config: GatewayConfig) -> Any:
+        return SimpleNamespace(
+            skipped_reason=None,
+            event="install",
+            sent=True,
+            uploaded=False,
+            endpoint_configured=True,
+        )
+
+    monkeypatch.setattr(boot, "log", FakeLog())
+    monkeypatch.setattr("opensquilla.engine.runtime.TurnRunner", FakeTurnRunner)
+    monkeypatch.setattr(boot, "build_services", fake_build_services)
+    monkeypatch.setattr(boot, "_setup_file_logging", lambda config: None)
+    monkeypatch.setattr(boot, "emit_skill_filter_banner", lambda config: None)
+    monkeypatch.setattr(
+        "opensquilla.observability.install_telemetry.collect_install_telemetry",
+        fake_collect_install_telemetry,
+    )
+    monkeypatch.setattr(
+        "opensquilla.gateway.pidlock.GatewayPidLock.acquire",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        "opensquilla.gateway.pidlock.GatewayPidLock.release",
+        lambda self: None,
+    )
+    config = GatewayConfig(
+        state_dir=str(tmp_path / "state"),
+        workspace_dir=str(tmp_path / "workspace"),
+        control_ui={"enabled": False},
+        channels={"channels": []},
+    )
+
+    async def run_case() -> None:
+        server = await boot.start_gateway_server(config=config, run=False)
+
+        try:
+            telemetry_logs = [
+                kwargs for event, kwargs in debug_logs if event == "gateway.install_telemetry"
+            ]
+            assert len(telemetry_logs) == 1
+            assert telemetry_logs[0]["telemetry_event"] == "install"
+            assert "event" not in telemetry_logs[0]
+            assert "gateway.install_telemetry_skipped" not in {
+                event for event, _kwargs in debug_logs
+            }
+        finally:
+            await server.close()
+
+    asyncio.run(run_case())
+
+
 def test_build_task_runtime_run_kwargs_forwards_fresh_user_session() -> None:
     run = SimpleNamespace(
         agent_id="main",

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -359,6 +359,49 @@ def _capture_compaction_emits(
     return emitted
 
 
+def test_emit_to_subscribers_logs_send_failure_without_structlog_event_collision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warning_logs: list[tuple[str, dict[str, Any]]] = []
+
+    class FakeLog:
+        def warning(self, event: str, **kwargs: Any) -> None:
+            warning_logs.append((event, kwargs))
+
+    key = "agent:main:emit-failure"
+    conn_id = "emit-failure-conn"
+    conn = _FailingReplayConn(conn_id)
+    registry = get_registry()
+    subscription_manager = SubscriptionManager()
+    subscription_manager.subscribe_messages(conn_id, key)
+    ctx = make_ctx(
+        session_manager=FakeSessionManager([FakeSession(session_key=key)]),
+        subscription_manager=subscription_manager,
+    )
+
+    monkeypatch.setattr(rpc_sessions, "log", FakeLog())
+    async def run_case() -> None:
+        registry.register(conn)
+        try:
+            await rpc_sessions._emit_to_subscribers(
+                ctx,
+                key,
+                "session.event.done",
+                {"reason": "stop"},
+            )
+        finally:
+            registry.unregister(conn_id)
+
+    asyncio.run(run_case())
+
+    assert warning_logs == [
+        (
+            "emit.send_failed",
+            {"conn_id": conn_id, "ws_event": "session.event.done"},
+        )
+    ]
+
+
 def _checkpoint_receipt(
     session: FakeSession,
     *,
@@ -452,6 +495,19 @@ class _ReplayConn:
         meta: dict | None = None,
     ) -> None:
         self.events.append((event, payload or {}, meta))
+
+
+class _FailingReplayConn:
+    def __init__(self, conn_id: str) -> None:
+        self.conn_id = conn_id
+
+    async def send_event(
+        self,
+        event: str,
+        payload: dict | None = None,
+        meta: dict | None = None,
+    ) -> None:
+        raise RuntimeError("send failed")
 
 
 class _RecordingTurnRunner:


### PR DESCRIPTION
## Summary
- Rename gateway install telemetry debug log field from `event` to `telemetry_event`.
- Rename session subscriber send-failure log field from `event` to `ws_event`.
- Add regression tests that use logger stubs with `event` as the first positional parameter to catch structlog-style collisions.

## Root Cause
`structlog` treats the first positional log argument as the event name. Passing a structured keyword field named `event` to the same call can raise `TypeError: ... got multiple values for argument 'event'`. Two gateway paths hit that pattern during install telemetry logging and failed WebSocket event emission logging.

## Impact
This only changes internal log field names. It does not change telemetry upload payloads, RPC protocols, WebSocket event names, or public APIs.

## Code Review
Manual review found no blocking issues. I also scanned Python log calls for remaining exact `event=` keyword usage and found no remaining `log.*(..., event=...)` matches.

## Test Plan
- `.venv/bin/pytest tests/test_gateway/test_router_boot.py tests/test_gateway/test_rpc_sessions.py tests/test_observability/test_install_telemetry.py -q` -> 187 passed
- `.venv/bin/ruff check src/opensquilla/gateway/boot.py src/opensquilla/gateway/rpc_sessions.py tests/test_gateway/test_router_boot.py tests/test_gateway/test_rpc_sessions.py` -> All checks passed
- `git diff --check -- src/opensquilla/gateway/boot.py src/opensquilla/gateway/rpc_sessions.py tests/test_gateway/test_router_boot.py tests/test_gateway/test_rpc_sessions.py` -> clean

## Release Notes
- None; release-prep bugfix only.

## Safety
- No secrets, transcripts, memory data, or runtime artifacts added.
- No third-party code or assets added.