### PR TITLE
Fix 0.4.0 portable release cache path

### DIFF
--- a/scripts/build_wheelhouse_zip.py
+++ b/scripts/build_wheelhouse_zip.py
@@ -113,10 +113,14 @@ def repo_root_from_script() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
-def build_subprocess_env(work_dir: Path) -> dict[str, str]:
+def build_subprocess_env(work_dir: Path, *, repo_root: Path | None = None) -> dict[str, str]:
     env = os.environ.copy()
-    uv_cache = work_dir / "uv-cache"
-    pip_cache = work_dir / "pip-cache"
+    cache_root = work_dir
+    if repo_root is not None:
+        resolved_repo_root = repo_root.resolve()
+        cache_root = resolved_repo_root.parent / f".{resolved_repo_root.name}-wheelhouse-cache"
+    uv_cache = cache_root / "uv-cache"
+    pip_cache = cache_root / "pip-cache"
     uv_cache.mkdir(parents=True, exist_ok=True)
     pip_cache.mkdir(parents=True, exist_ok=True)
     env["UV_CACHE_DIR"] = str(uv_cache)
@@ -1705,7 +1709,7 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
     work_dir = (repo_root / args.work_dir).resolve()
-    env = build_subprocess_env(work_dir)
+    env = build_subprocess_env(work_dir, repo_root=repo_root)
     wheel_dir = work_dir / "wheels"
     tag = args.platform_tag or platform_tag()
     if not args.skip_wheelhouse:

--- a/tests/test_scripts/test_build_wheelhouse_zip.py
+++ b/tests/test_scripts/test_build_wheelhouse_zip.py
@@ -59,6 +59,22 @@ def test_build_wheel_retries_once_after_transient_uv_failure(monkeypatch, tmp_pa
     assert len(calls) == 2
 
 
+def test_build_subprocess_env_keeps_uv_cache_outside_repo_root(tmp_path: Path) -> None:
+    module = load_script()
+    repo_root = tmp_path / "repo"
+    work_dir = repo_root / "build" / "wheelhouse-zip"
+    repo_root.mkdir()
+
+    env = module.build_subprocess_env(work_dir, repo_root=repo_root)
+
+    uv_cache = Path(env["UV_CACHE_DIR"]).resolve()
+    pip_cache = Path(env["PIP_CACHE_DIR"]).resolve()
+    assert not uv_cache.is_relative_to(repo_root.resolve())
+    assert not pip_cache.is_relative_to(repo_root.resolve())
+    assert uv_cache.name == "uv-cache"
+    assert pip_cache.name == "pip-cache"
+
+
 def test_release_name_records_platform_python_profile() -> None:
     module = load_script()
 


### PR DESCRIPTION
Summary:
- Move release builder UV/PIP caches outside the repository source tree when running from the release script.
- Add a regression test for the Windows portable release failure seen in the v0.4.0 tag workflow.

Root cause:
- The release workflow failed because uv build rejects UV_CACHE_DIR when it lives under the build source directory.

Tests:
- UV_CACHE_DIR=/private/tmp/opensquilla-uv-cache uv run --frozen --extra dev pytest tests/test_scripts/test_build_wheelhouse_zip.py::test_build_subprocess_env_keeps_uv_cache_outside_repo_root -q
- UV_CACHE_DIR=/private/tmp/opensquilla-uv-cache uv run --frozen --extra dev pytest tests/test_scripts/test_build_wheelhouse_zip.py tests/test_ci/test_workflows.py tests/test_release_consistency.py tests/test_public_release_hygiene.py -q
- UV_CACHE_DIR=/private/tmp/opensquilla-uv-cache uv run --frozen --extra dev ruff check scripts/build_wheelhouse_zip.py tests/test_scripts/test_build_wheelhouse_zip.py

Release note:
- None; release infrastructure only.