### PR TITLE
Polish 0.4.0 release note highlights

### DIFF
--- a/docs/releases/0.4.0.md
+++ b/docs/releases/0.4.0.md
@@ -12,13 +12,28 @@ coding workflow, search providers, terminal preview path, and runtime
 hardening. Existing gateway and data locations stay the same, so users can
 upgrade without migrating their `~/.opensquilla` state.
 
-## Highlights
+## ✨ What's New
 
-### Desktop installers for the Control UI
+### Signed desktop installers for the Control UI
 
 The release now includes a signed and notarized macOS Apple Silicon installer
 and a Windows x64 NSIS installer for the Electron desktop shell. Both packages
 embed the built Vue control UI and the packaged gateway runtime.
+
+### Coding mode and guarded code-task workflow
+
+Coding mode gives source-editing work a clearer product lane. The
+`opensquilla code-task` workflow routes generated or edited code through
+isolated run directories, trusted-host confirmation, separated build output,
+and verification before source persistence. This keeps coding tasks easier to
+inspect and safer to continue from the Control UI.
+
+### Manual MetaSkills and workflow launch control
+
+MetaSkills are manual-only by default. Use `/meta` to list workflows and
+`/meta <name>` to run one; set `meta_skill.auto_trigger = true` only when the
+older automatic behavior is intentional. MetaSkill progress, clarification,
+run-history reads, and rescue-action surfaces are clearer in the Control UI.
 
 ### Control UI, sessions, and daily workflow polish
 
@@ -26,14 +41,6 @@ The refreshed browser console centers everyday work around conversation state,
 session inspection, Settings, artifact previews, share export, deliverables,
 turn trace, mobile tabs, and clearer Skills, Usage, Cron, Logs, and Approvals
 surfaces.
-
-### Manual MetaSkills and safer coding work
-
-MetaSkills are manual-only by default. Use `/meta` to list workflows and
-`/meta <name>` to run one; set `meta_skill.auto_trigger = true` only when the
-older automatic behavior is intentional. Coding mode and `opensquilla code-task`
-route code edits through isolated run directories, trusted-host confirmation,
-and verification before source persistence.
 
 ### Search, providers, and runtime hardening
 


### PR DESCRIPTION
Summary:
- Match the published v0.4.0 release notes to the prior emoji-highlight style.
- Split Coding mode and the guarded code-task workflow into their own highlight.
- Keep downloads, upgrade notes, and acknowledgements unchanged.

Scope:
- Release documentation only.

Tests:
- diff -u /private/tmp/opensquilla-0.4.0-release-notes.md docs/releases/0.4.0.md
- git diff --cached --check

Main exception:
- release-docs / allow-main-target