### PR TITLE
Fix 0.4.0 release contributor link

### DIFF
--- a/docs/releases/0.4.0.md
+++ b/docs/releases/0.4.0.md
@@ -129,5 +129,5 @@ Thanks to the contributors whose pull-request work is present in the current
   ([@Anonymous-4427](https://github.com/Anonymous-4427)) for TUI and OpenTUI
   fixes and preview-backend work.
 
-See [`../../CONTRIBUTORS.md`](../../CONTRIBUTORS.md) for the full 0.4.0
-attribution ledger and PR evidence.
+See [`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/main/CONTRIBUTORS.md)
+for the full 0.4.0 attribution ledger and PR evidence.


### PR DESCRIPTION
Summary:
- Use an absolute GitHub URL for the v0.4.0 release note CONTRIBUTORS.md link.
- Keep the repository release note document aligned with the already-updated published release body.

Scope:
- Release documentation only.

Tests:
- gh api repos/opensquilla/opensquilla/contents/CONTRIBUTORS.md --jq .html_url
- diff -u /private/tmp/opensquilla-0.4.0-release-notes.md docs/releases/0.4.0.md
- git diff --cached --check

Main exception:
- allow-main-target / release-docs