### PR TITLE
Make main the default PR target

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@ Non-goals:
 
 ## Branch
 
-Base branch: dev | main | staging/collaboration
+Base branch: main | dev (transition) | staging/collaboration
 
-Main exception: N/A | release | hotfix | release-docs | main-sync | maintainer-approved
+Target exception: N/A | dev-transition | release | hotfix | staging/collaboration | maintainer-approved
 
 ## Issue
 

--- a/.github/scripts/validate-pr-target-branch.sh
+++ b/.github/scripts/validate-pr-target-branch.sh
@@ -12,8 +12,13 @@ if [[ -z "${base_ref}" ]]; then
   exit 1
 fi
 
+if [[ "${base_ref}" == "main" ]]; then
+  echo "Pull request targets main."
+  exit 0
+fi
+
 if [[ "${base_ref}" == "dev" ]]; then
-  echo "Pull request targets dev."
+  echo "Pull request targets dev during the main-default transition."
   exit 0
 fi
 
@@ -61,9 +66,6 @@ has_allowed_label() {
 
   while IFS= read -r label; do
     case "${allowed_kind}:${label}" in
-      main:allow-main-target | main:release | main:hotfix | main:main-sync | main:release-docs | main:sync-to-main | main:docs-preview)
-        return 0
-        ;;
       staging:maintainer-staging | staging:collaboration)
         return 0
         ;;
@@ -83,21 +85,16 @@ is_staging_branch() {
   return 1
 }
 
-if [[ "${base_ref}" == "main" ]] && has_allowed_label main; then
-  echo "Pull request targets main with maintainer approval label."
-  exit 0
-fi
-
 if is_staging_branch || has_allowed_label staging; then
   echo "Pull request targets a staging/collaboration branch."
-  echo "This is not a final integration path; final integration should target dev, while release or hotfix work should target main with an approval label."
+  echo "This is not a final integration path; final integration should target main, or dev during the transition window."
   exit 0
 fi
 
 {
-  echo "::error title=Wrong PR target::Ordinary pull requests should target dev."
-  echo "Use main only for maintainer-approved release, hotfix, release-docs, or main-sync work."
+  echo "::error title=Wrong PR target::Ordinary pull requests should target main."
+  echo "Use dev only for existing pull requests during the transition window or when maintainers explicitly request it."
   echo "Use sandbox-*, integration/*, staging/*, release/*, or a maintainer-staging/collaboration label for maintainer collaboration PRs."
-  echo "Retarget this pull request to dev, or ask a maintainer to add an explicit exception label."
+  echo "Retarget this pull request to main, dev during transition, or an approved staging/collaboration branch."
 } >&2
 exit 1

--- a/.github/scripts/validate_pr_body.py
+++ b/.github/scripts/validate_pr_body.py
@@ -18,7 +18,10 @@ class RequiredField(NamedTuple):
 REQUIRED_FIELDS = (
     RequiredField("Scope boundary", re.compile(r"(?im)^\s*Scope boundary\s*:")),
     RequiredField("Base branch", re.compile(r"(?im)^\s*Base branch\s*:")),
-    RequiredField("Main exception", re.compile(r"(?im)^\s*Main exception\s*:")),
+    RequiredField(
+        "Target exception",
+        re.compile(r"(?im)^\s*(?:Target exception|Main exception)\s*:"),
+    ),
     RequiredField("Linked issue", re.compile(r"(?im)^\s*Linked issue\s*:")),
     RequiredField("Release note", re.compile(r"(?im)^\s*Release note\s*:")),
     RequiredField("Tests", re.compile(r"(?im)^\s*(?:#+\s*)?Tests\s*:?\s*$")),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,16 @@ Thanks for improving OpenSquilla. Keep pull requests small, focused, and covered
 
 ## Target Branch
 
-Open pull requests against `dev` by default. OpenSquilla uses `dev` as the active integration branch for feature work, bug fixes, tests, and contributor changes.
+Open pull requests against `main` by default. OpenSquilla now uses `main` as the active integration branch for feature work, bug fixes, tests, documentation, and contributor changes.
 
-Use `main` only for maintainer-directed release candidates, release stabilization, documentation-only preview, or urgent hotfix work that starts from the current published line. When in doubt, target `dev`; maintainers will route release-ready changes from `dev` to `main`. If a pull request was opened against `main` by mistake, retarget it to `dev` before review.
+The `dev` branch remains available during the transition for existing pull
+requests and maintainer-directed compatibility work. When in doubt, target
+`main`; maintainers will ask you to retarget only when a temporary integration
+branch is needed.
 
 After a release, maintainers may start a new development cycle from the
-latest `main` release point. When that requires replacing the active
-`dev` branch, the previous branch will be archived and contributors
-will be asked to rebase or retarget open pull requests.
+latest `main` release point. If the transition branch is retired, contributors
+with open `dev` pull requests will be asked to rebase or retarget.
 
 ## Linked Issues
 
@@ -21,12 +23,14 @@ Declare issue relationships in pull request descriptions with GitHub keywords:
 - Use `Refs #123` when the pull request is related but should not move the issue toward closure.
 - Use `None` when no public issue is linked.
 
-OpenSquilla keeps issue closure tied to the release branch. Merging a fixing
-pull request into `dev` marks the issue as `merged-to-dev` and
-`needs-verification`; the issue remains open until the fix reaches the default
-branch through a release or hotfix pull request. Maintainers may use
-`has-linked-pr` while work is still under review. If a linked pull request is
-closed without merging, the automation removes `has-linked-pr`.
+OpenSquilla keeps issue closure tied to the default branch. Merging a fixing
+pull request into `main` removes the linked-pull-request marker so the issue
+can follow GitHub's normal closing flow. During the transition, merging a
+fixing pull request into `dev` still marks the issue as `merged-to-dev` and
+`needs-verification`; the issue remains open until the fix reaches `main`.
+Maintainers may use `has-linked-pr` while work is still under review. If a
+linked pull request is closed without merging, the automation removes
+`has-linked-pr`.
 
 ## Attribution On Squash Or Replay
 

--- a/README.product.md
+++ b/README.product.md
@@ -216,7 +216,8 @@ trust. For tool behavior, approval flow, and workspace containment, see
 
 OpenSquilla documentation is part of the product. If a setup step is confusing,
 a command is stale, or a feature guide needs a clearer example, open a small
-pull request against `dev`.
+pull request against `main`. Existing `dev` pull requests may continue during
+the branch transition.
 
 Read [`docs/contributing-docs.md`](docs/contributing-docs.md) for docs-specific
 guidance.

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,14 +67,15 @@ root release README with task-oriented guides.
 
 Documentation improvements are welcome. Start with
 [`contributing-docs.md`](contributing-docs.md) for docs-specific guidance, then
-open a small pull request against `dev`.
+open a small pull request against `main`. Existing `dev` pull requests may
+continue during the branch transition.
 
 Fast paths:
 
 - Report a stale command, broken link, or confusing page with the
   [documentation issue template](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml).
 - Edit the affected Markdown page on GitHub and open a focused pull request
-  against `dev`.
+  against `main`.
 - For new feature documentation, keep independent features on independent pages
   under `docs/features/`.
 

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -26,7 +26,8 @@ write access will submit this through a fork and pull request.
 2. If you are not sure of the fix, open a
    [documentation issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)
    with the affected page and expected outcome.
-3. Open documentation pull requests against `dev`.
+3. Open documentation pull requests against `main`. Existing `dev` pull
+   requests may continue during the branch transition.
 4. Keep docs changes small and topic-focused.
 5. Use relative links for repository pages.
 6. Prefer concrete commands and examples over abstract descriptions.

--- a/tests/test_ci/test_pr_body_lint.py
+++ b/tests/test_ci/test_pr_body_lint.py
@@ -24,6 +24,28 @@ def test_pr_body_lint_accepts_complete_structured_template_body() -> None:
     body = "\n".join(
         [
             "Scope boundary: update CI governance",
+            "Base branch: main",
+            "Target exception: N/A",
+            "Linked issue: Refs #210",
+            "Release note: NONE",
+            "Tests:",
+            "Ruff: uv run ruff check tests",
+            "Pytest: uv run pytest tests/test_ci -q",
+            "Build: not run locally; CI only",
+            "Maintainer live check: no",
+            "Third-party origin: none",
+        ]
+    )
+
+    assert lint.missing_fields(body) == []
+
+
+def test_pr_body_lint_accepts_legacy_main_exception_field() -> None:
+    lint = _load_lint_module()
+
+    body = "\n".join(
+        [
+            "Scope boundary: update CI governance",
             "Base branch: dev",
             "Main exception: N/A",
             "Linked issue: Refs #210",
@@ -54,6 +76,7 @@ def test_pr_body_lint_warns_for_old_unstructured_checklist() -> None:
 
     assert "Scope boundary" in missing
     assert "Base branch" in missing
+    assert "Target exception" in missing
     assert "Linked issue" in missing
     assert "Release note" in missing
     assert "Maintainer live check" in missing

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -182,24 +182,27 @@ def test_default_ci_blocks_pull_requests_and_main_and_dev_pushes() -> None:
     assert "workflow_changed" not in text
 
 
-def test_pr_target_validator_allows_dev_pull_requests(tmp_path: Path) -> None:
-    result = _validate_pr_target(tmp_path, base="dev")
-
-    assert result.returncode == 0
-
-
-def test_pr_target_validator_blocks_ordinary_main_pull_requests(tmp_path: Path) -> None:
+def test_pr_target_validator_allows_main_pull_requests(tmp_path: Path) -> None:
     result = _validate_pr_target(
         tmp_path,
         base="main",
         changed_files=["src/opensquilla/engine/agent.py"],
     )
 
-    assert result.returncode == 1
-    assert "Ordinary pull requests should target dev" in result.stderr
+    assert result.returncode == 0
+    assert "Pull request targets main." in result.stdout
 
 
-def test_pr_target_validator_blocks_unlabeled_docs_only_main_pull_requests(
+def test_pr_target_validator_allows_dev_pull_requests_during_transition(
+    tmp_path: Path,
+) -> None:
+    result = _validate_pr_target(tmp_path, base="dev")
+
+    assert result.returncode == 0
+    assert "main-default transition" in result.stdout
+
+
+def test_pr_target_validator_allows_docs_only_main_pull_requests(
     tmp_path: Path,
 ) -> None:
     result = _validate_pr_target(
@@ -210,11 +213,11 @@ def test_pr_target_validator_blocks_unlabeled_docs_only_main_pull_requests(
         changed_files=["docs/testing/framework.md"],
     )
 
-    assert result.returncode == 1
-    assert "Ordinary pull requests should target dev" in result.stderr
+    assert result.returncode == 0
+    assert "Pull request targets main." in result.stdout
 
 
-def test_pr_target_validator_allows_maintainer_labeled_main_pull_requests(
+def test_pr_target_validator_allows_labeled_main_pull_requests_without_exception(
     tmp_path: Path,
 ) -> None:
     labels = [
@@ -236,7 +239,7 @@ def test_pr_target_validator_allows_maintainer_labeled_main_pull_requests(
         )
 
         assert result.returncode == 0
-        assert "Pull request targets main with maintainer approval label." in result.stdout
+        assert "Pull request targets main." in result.stdout
 
 
 def test_pr_target_validator_allows_staging_branch_pull_requests(
@@ -257,7 +260,7 @@ def test_pr_target_validator_allows_staging_branch_pull_requests(
 
         assert result.returncode == 0
         assert "staging/collaboration" in result.stdout
-        assert "final integration" in result.stdout
+        assert "target main" in result.stdout
 
 
 def test_pr_target_validator_allows_labeled_staging_pull_requests(
@@ -285,7 +288,7 @@ def test_pr_target_validator_blocks_unknown_target_branches(tmp_path: Path) -> N
     )
 
     assert result.returncode == 1
-    assert "Ordinary pull requests should target dev" in result.stderr
+    assert "Ordinary pull requests should target main" in result.stderr
 
 
 def test_pr_target_validator_handles_missing_event_path() -> None:
@@ -303,7 +306,7 @@ def test_pr_target_validator_handles_missing_event_path() -> None:
     )
 
     assert result.returncode == 1
-    assert "Ordinary pull requests should target dev" in result.stderr
+    assert "Ordinary pull requests should target main" in result.stderr
     assert "Traceback" not in result.stderr
 
 

--- a/tests/test_public_release_hygiene.py
+++ b/tests/test_public_release_hygiene.py
@@ -150,8 +150,11 @@ def test_pull_request_template_uses_structured_governance_fields() -> None:
     required_phrases = [
         "Scope boundary",
         "Non-goals",
-        "Base branch: dev | main | staging/collaboration",
-        "Main exception: N/A | release | hotfix | release-docs | main-sync | maintainer-approved",
+        "Base branch: main | dev (transition) | staging/collaboration",
+        (
+            "Target exception: N/A | dev-transition | release | hotfix | "
+            "staging/collaboration | maintainer-approved"
+        ),
         "Linked issue: Fixes #... | Refs #... | None",
         "If None, reason",
         "Release note: NONE |",


### PR DESCRIPTION
## Scope

Scope boundary: make `main` the default pull request target while keeping `dev` accepted during the transition.

Non-goals: retiring `dev`, retargeting existing open PRs, changing issue-link sync semantics, or changing release workflows.

## Branch

Base branch: main

Target exception: N/A

Main exception: N/A (legacy lint compatibility while this PR is under review)

## Issue

Linked issue: None

If None, reason: branch governance migration requested by maintainers after the 0.4.0 release.

## Release Note

Release note: NONE

## Tests

Ruff: `uv run --frozen ruff check .github/scripts tests/test_ci tests/test_public_release_hygiene.py tests/test_github_issue_link_sync.py`

Pytest: `uv run --frozen pytest tests/test_ci/test_workflows.py tests/test_ci/test_pr_body_lint.py tests/test_public_release_hygiene.py tests/test_github_issue_link_sync.py -q`

Build: not run locally; docs/CI governance only

Regression tests: added

Notes: `dev` remains accepted by the target validator during the transition window.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
