### PR TITLE
Improve install telemetry counting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  OPENSQUILLA_TESTING: "true"
+
 jobs:
   classify-changes:
     name: Classify changed files

--- a/README.md
+++ b/README.md
@@ -341,38 +341,24 @@ version adoption, and runtime compatibility. Data is sent on first gateway
 startup and once per OpenSquilla version. Uploads use a short timeout and never
 block startup.
 
-What is sent:
-
-- schema version
-- locally generated stable `install_id` digest
-- OpenSquilla version
-- event type (`install` or `version_seen`)
-- install method (`pip`, `source`, `docker`, `desktop`, or `unknown`)
-- operating system, OS version, CPU architecture, and Python major/minor
-  version
-- first-seen and sent timestamps
-
-The `install_id` is derived locally before upload. OpenSquilla prefers usable
-machine MAC addresses and falls back to usable local machine IP addresses only
-when no usable MAC address is available. The raw MAC or IP value is not uploaded;
-the payload contains only a one-way SHA-256 digest. If neither stable signal is
-available, OpenSquilla falls back to a random locally persisted ID.
+What is sent: schema version, stable `install_id` digest, OpenSquilla version,
+event type, install method, OS/runtime details, and first-seen/sent timestamps.
+The `install_id` is derived locally from usable MAC addresses, or usable local IP
+addresses when no MAC is available. Raw MAC/IP values are never uploaded; the
+payload contains only a one-way SHA-256 digest. If no stable signal is available,
+OpenSquilla falls back to a random locally persisted ID.
 
 What is not sent: usernames, email addresses, hostnames, local paths, API keys,
 provider configuration, chat history, session data, memory, agent content, file
-names, file contents, raw MAC addresses, or raw local IP addresses. HTTP servers
-can technically observe source IP addresses at the transport layer; source IP
-addresses are not part of the payload and should not be used as an install-count
-field by the collector.
+names, file contents, raw MAC addresses, or raw local IP addresses. Source IP may
+be visible to HTTP servers at the transport layer, but it is not part of the
+payload.
 
 To opt out:
 
 ```sh
 OPENSQUILLA_TELEMETRY_DISABLED=true
 ```
-
-Telemetry is also skipped automatically in GitHub Actions, while pytest is
-running, or when `OPENSQUILLA_TESTING=true` is set.
 
 Advanced deployments can use their own endpoint:
 

--- a/README.md
+++ b/README.md
@@ -341,12 +341,23 @@ version adoption, and runtime compatibility. Data is sent on first gateway
 startup and once per OpenSquilla version. Uploads use a short timeout and never
 block startup.
 
-What is sent: schema version, stable `install_id` digest, OpenSquilla version,
-event type, install method, OS/runtime details, and first-seen/sent timestamps.
-The `install_id` is derived locally from usable MAC addresses, or usable local IP
-addresses when no MAC is available. Raw MAC/IP values are never uploaded; the
-payload contains only a one-way SHA-256 digest. If no stable signal is available,
-OpenSquilla falls back to a random locally persisted ID.
+What is sent:
+
+- schema version
+- locally generated stable `install_id` digest
+- OpenSquilla version
+- event type (`install` or `version_seen`)
+- install method (`pip`, `source`, `docker`, `desktop`, or `unknown`)
+- operating system, OS version, CPU architecture, and Python major/minor
+  version
+- first-seen and sent timestamps
+- CI/test-environment marker (`ci_environment`)
+
+The `install_id` is derived locally before upload. OpenSquilla prefers usable
+machine MAC addresses and falls back to usable local machine IP addresses only
+when no usable MAC address is available. The raw MAC or IP value is not uploaded;
+the payload contains only a one-way SHA-256 digest. If neither stable signal is
+available, OpenSquilla falls back to a random locally persisted ID.
 
 What is not sent: usernames, email addresses, hostnames, local paths, API keys,
 provider configuration, chat history, session data, memory, agent content, file

--- a/README.md
+++ b/README.md
@@ -353,16 +353,13 @@ What is sent:
 - first-seen and sent timestamps
 - CI/test-environment marker (`ci_environment`)
 
-The `install_id` is derived locally before upload. OpenSquilla prefers usable
-machine MAC addresses and falls back to usable local machine IP addresses only
-when no usable MAC address is available. The raw MAC or IP value is not uploaded;
-the payload contains only a one-way SHA-256 digest. If neither stable signal is
-available, OpenSquilla falls back to a random locally persisted ID.
+The `install_id` is a local one-way SHA-256 digest derived from usable MAC
+addresses, then local IP addresses when no MAC is available, with a random
+persisted fallback. Raw MAC/IP values are not uploaded.
 
-What is not sent: usernames, email addresses, hostnames, local paths, API keys,
-provider configuration, chat history, session data, memory, agent content, file
-names, file contents, raw MAC addresses, or raw local IP addresses. Source IP may
-be visible to HTTP servers at the transport layer, but it is not part of the
+What is not sent: usernames, hostnames, paths, API keys, provider config,
+chat/session/memory/agent content, file names, or file contents. Source IP may
+be visible to HTTP servers at the transport layer, but is not part of the
 payload.
 
 To opt out:

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ block startup.
 What is sent:
 
 - schema version
-- random locally generated `install_id`
+- locally generated stable `install_id` digest
 - OpenSquilla version
 - event type (`install` or `version_seen`)
 - install method (`pip`, `source`, `docker`, `desktop`, or `unknown`)
@@ -352,20 +352,27 @@ What is sent:
   version
 - first-seen and sent timestamps
 
-The `install_id` is random and is not derived from your account, device name,
-hostname, or local paths.
+The `install_id` is derived locally before upload. OpenSquilla prefers usable
+machine MAC addresses and falls back to usable local machine IP addresses only
+when no usable MAC address is available. The raw MAC or IP value is not uploaded;
+the payload contains only a one-way SHA-256 digest. If neither stable signal is
+available, OpenSquilla falls back to a random locally persisted ID.
 
 What is not sent: usernames, email addresses, hostnames, local paths, API keys,
 provider configuration, chat history, session data, memory, agent content, file
-names, or file contents. HTTP servers can technically observe source IP
-addresses at the transport layer; IP addresses are not part of the payload and
-should not be used as an install-count field by the collector.
+names, file contents, raw MAC addresses, or raw local IP addresses. HTTP servers
+can technically observe source IP addresses at the transport layer; source IP
+addresses are not part of the payload and should not be used as an install-count
+field by the collector.
 
 To opt out:
 
 ```sh
 OPENSQUILLA_TELEMETRY_DISABLED=true
 ```
+
+Telemetry is also skipped automatically in GitHub Actions, while pytest is
+running, or when `OPENSQUILLA_TESTING=true` is set.
 
 Advanced deployments can use their own endpoint:
 

--- a/src/opensquilla/observability/install_telemetry.py
+++ b/src/opensquilla/observability/install_telemetry.py
@@ -7,10 +7,14 @@ OpenSquilla collector and can be overridden or disabled by environment variable.
 
 from __future__ import annotations
 
+import hashlib
+import ipaddress
 import json
 import logging
 import os
 import platform
+import re
+import socket
 import sys
 import tempfile
 import uuid
@@ -29,12 +33,17 @@ TELEMETRY_STATE_FILE = "install_telemetry.json"
 TELEMETRY_DISABLED_ENV = "OPENSQUILLA_TELEMETRY_DISABLED"
 TELEMETRY_ENDPOINT_ENV = "OPENSQUILLA_TELEMETRY_ENDPOINT"
 TELEMETRY_INSTALL_METHOD_ENV = "OPENSQUILLA_INSTALL_METHOD"
+TELEMETRY_TESTING_ENV = "OPENSQUILLA_TESTING"
 
 DEFAULT_TELEMETRY_ENDPOINT = "https://telemetry.opensquilla.ai/v1/install"
 DEFAULT_TIMEOUT_SECONDS = 2.0
 
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _SUCCESS_STATUS_CODES = {200, 201, 202, 204}
+_AUTO_SKIP_ENV_VARS = ("GITHUB_ACTIONS", "PYTEST_CURRENT_TEST", TELEMETRY_TESTING_ENV)
+_STABLE_INSTALL_ID_PREFIX = "opensquilla-install-v2"
+_STABLE_INSTALL_ID_SOURCES = {"stable-v2-mac", "stable-v2-ip"}
+_MAC_HEX_RE = re.compile(r"^[0-9a-f]{12}$")
 
 
 @dataclass(frozen=True)
@@ -63,12 +72,13 @@ def collect_install_telemetry(
     endpoint = _endpoint()
 
     try:
-        if _telemetry_disabled():
+        skip_reason = _telemetry_skip_reason()
+        if skip_reason:
             return InstallTelemetryResult(
                 state_path=path,
                 endpoint_configured=bool(endpoint),
                 disabled=True,
-                skipped_reason="disabled",
+                skipped_reason=skip_reason,
             )
 
         current_version = (version or __version__ or "unknown").strip() or "unknown"
@@ -144,6 +154,20 @@ def _telemetry_disabled() -> bool:
     return value in _TRUE_VALUES
 
 
+def _telemetry_skip_reason() -> str | None:
+    if _telemetry_disabled():
+        return "disabled"
+    for name in _AUTO_SKIP_ENV_VARS:
+        value = os.environ.get(name, "")
+        if name == "PYTEST_CURRENT_TEST":
+            if value.strip():
+                return f"environment:{name}"
+            continue
+        if value.strip().lower() in _TRUE_VALUES:
+            return f"environment:{name}"
+    return None
+
+
 def _endpoint() -> str:
     return os.environ.get(TELEMETRY_ENDPOINT_ENV, DEFAULT_TELEMETRY_ENDPOINT).strip()
 
@@ -165,9 +189,11 @@ def _load_or_create_state(path: Path) -> dict[str, Any]:
 
 def _new_state() -> dict[str, Any]:
     now = _utc_now()
+    install_id, install_id_source = _resolve_install_id(existing_install_id=None)
     return {
         "schema_version": TELEMETRY_SCHEMA_VERSION,
-        "install_id": str(uuid.uuid4()),
+        "install_id": install_id,
+        "install_id_source": install_id_source,
         "first_seen_at": now,
         "uploaded_install": False,
         "uploaded_versions": [],
@@ -180,9 +206,15 @@ def _new_state() -> dict[str, Any]:
 
 def _normalize_state(data: dict[str, Any]) -> dict[str, Any]:
     state = dict(data)
-    install_id = state.get("install_id")
-    if not isinstance(install_id, str) or not install_id.strip():
-        state["install_id"] = str(uuid.uuid4())
+    install_id = _valid_install_id(state.get("install_id"))
+    install_id_source = state.get("install_id_source")
+    if isinstance(install_id_source, str) and install_id_source in _STABLE_INSTALL_ID_SOURCES:
+        if install_id is None:
+            install_id, install_id_source = _resolve_install_id(existing_install_id=None)
+    else:
+        install_id, install_id_source = _resolve_install_id(existing_install_id=install_id)
+    state["install_id"] = install_id
+    state["install_id_source"] = install_id_source
     first_seen = state.get("first_seen_at")
     if not isinstance(first_seen, str) or not first_seen.strip():
         state["first_seen_at"] = _utc_now()
@@ -199,6 +231,125 @@ def _normalize_state(data: dict[str, Any]) -> dict[str, Any]:
     state.setdefault("last_error", None)
     state.setdefault("last_skip_reason", None)
     return state
+
+
+def _resolve_install_id(existing_install_id: str | None) -> tuple[str, str]:
+    mac_addresses = _normalized_mac_addresses(_collect_mac_address_candidates())
+    if mac_addresses:
+        return _stable_install_id("mac", mac_addresses), "stable-v2-mac"
+
+    ip_addresses = _normalized_ip_addresses(_collect_ip_address_candidates())
+    if ip_addresses:
+        return _stable_install_id("ip", ip_addresses), "stable-v2-ip"
+
+    if existing_install_id:
+        return existing_install_id, "random-persisted"
+    return str(uuid.uuid4()), "random-persisted"
+
+
+def _valid_install_id(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _stable_install_id(source: str, values: list[str]) -> str:
+    stable_input = f"{_STABLE_INSTALL_ID_PREFIX}|{source}|{','.join(values)}"
+    return hashlib.sha256(stable_input.encode("utf-8")).hexdigest()
+
+
+def _collect_mac_address_candidates() -> list[str]:
+    candidates: list[str] = []
+    sys_class_net = Path("/sys/class/net")
+    try:
+        for address_path in sys_class_net.glob("*/address"):
+            try:
+                candidates.append(address_path.read_text(encoding="utf-8").strip())
+            except OSError:
+                continue
+    except OSError:
+        pass
+
+    try:
+        candidates.append(f"{uuid.getnode():012x}")
+    except Exception:
+        pass
+
+    return candidates
+
+
+def _normalized_mac_addresses(candidates: list[str]) -> list[str]:
+    addresses: set[str] = set()
+    for candidate in candidates:
+        normalized = _normalize_mac_address(candidate)
+        if normalized is not None:
+            addresses.add(normalized)
+    return sorted(addresses)
+
+
+def _normalize_mac_address(value: object) -> str | None:
+    text = re.sub(r"[^0-9a-fA-F]", "", str(value or "")).lower()
+    if not _MAC_HEX_RE.match(text):
+        return None
+    if text in {"000000000000", "ffffffffffff"}:
+        return None
+    first_octet = int(text[:2], 16)
+    if first_octet & 1:
+        return None
+    return text
+
+
+def _collect_ip_address_candidates() -> list[str]:
+    candidates: list[str] = []
+    hosts = {socket.gethostname(), socket.getfqdn()}
+    for host in hosts:
+        if not host:
+            continue
+        try:
+            infos = socket.getaddrinfo(host, None, type=socket.SOCK_DGRAM)
+        except OSError:
+            continue
+        for info in infos:
+            sockaddr = info[4]
+            if sockaddr:
+                candidates.append(str(sockaddr[0]))
+
+    udp_targets = (
+        (socket.AF_INET, ("8.8.8.8", 80)),
+        (socket.AF_INET6, ("2001:4860:4860::8888", 80)),
+    )
+    for family, target in udp_targets:
+        try:
+            with socket.socket(family, socket.SOCK_DGRAM) as sock:
+                sock.connect(target)
+                candidates.append(str(sock.getsockname()[0]))
+        except OSError:
+            continue
+
+    return candidates
+
+
+def _normalized_ip_addresses(candidates: list[str]) -> list[str]:
+    addresses: set[str] = set()
+    for candidate in candidates:
+        normalized = _normalize_ip_address(candidate)
+        if normalized is not None:
+            addresses.add(normalized)
+    return sorted(addresses)
+
+
+def _normalize_ip_address(value: object) -> str | None:
+    text = str(value or "").strip()
+    if "%" in text:
+        text = text.split("%", 1)[0]
+    try:
+        ip = ipaddress.ip_address(text)
+    except ValueError:
+        return None
+    if ip.is_loopback or ip.is_unspecified or ip.is_link_local or ip.is_multicast:
+        return None
+    return str(ip)
 
 
 def _write_state(path: Path, state: dict[str, Any]) -> None:

--- a/src/opensquilla/observability/install_telemetry.py
+++ b/src/opensquilla/observability/install_telemetry.py
@@ -157,14 +157,25 @@ def _telemetry_disabled() -> bool:
 def _telemetry_skip_reason() -> str | None:
     if _telemetry_disabled():
         return "disabled"
+    ci_env = _ci_environment_name()
+    if ci_env is not None:
+        return f"environment:{ci_env}"
+    return None
+
+
+def _ci_environment_detected() -> bool:
+    return _ci_environment_name() is not None
+
+
+def _ci_environment_name() -> str | None:
     for name in _AUTO_SKIP_ENV_VARS:
         value = os.environ.get(name, "")
         if name == "PYTEST_CURRENT_TEST":
             if value.strip():
-                return f"environment:{name}"
+                return name
             continue
         if value.strip().lower() in _TRUE_VALUES:
-            return f"environment:{name}"
+            return name
     return None
 
 
@@ -405,6 +416,7 @@ def _build_payload(
         "python_version": f"{sys.version_info.major}.{sys.version_info.minor}",
         "first_seen_at": state["first_seen_at"],
         "sent_at": sent_at,
+        "ci_environment": _ci_environment_detected(),
     }
 
 

--- a/tests/test_observability/test_install_telemetry.py
+++ b/tests/test_observability/test_install_telemetry.py
@@ -132,7 +132,9 @@ def test_configured_endpoint_uploads_install_once_and_dedupes(tmp_path, monkeypa
         "python_version",
         "first_seen_at",
         "sent_at",
+        "ci_environment",
     }
+    assert payload["ci_environment"] is False
     state = _load(state_path)
     assert state["uploaded_install"] is True
     assert state["uploaded_versions"] == ["1.0.0"]
@@ -220,6 +222,23 @@ def test_opensquilla_testing_env_skips_without_creating_state(tmp_path, monkeypa
     assert result.sent is False
     assert result.skipped_reason == "environment:OPENSQUILLA_TESTING"
     assert not state_path.exists()
+
+
+def test_payload_marks_ci_environment_when_detected(monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+    payload = telemetry._build_payload(
+        {
+            "install_id": "stable-install-id",
+            "first_seen_at": "2026-06-29T00:00:00Z",
+        },
+        event="install",
+        current_version="1.0.0",
+        sent_at="2026-06-29T00:00:01Z",
+    )
+
+    assert payload["ci_environment"] is True
 
 
 def test_upload_failure_does_not_mark_install_uploaded(tmp_path, monkeypatch):

--- a/tests/test_observability/test_install_telemetry.py
+++ b/tests/test_observability/test_install_telemetry.py
@@ -14,9 +14,27 @@ def _load(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def test_default_endpoint_uploads_install_once_and_dedupes(tmp_path, monkeypatch):
-    monkeypatch.delenv(telemetry.TELEMETRY_ENDPOINT_ENV, raising=False)
+def _enable_telemetry_for_test(monkeypatch):
     monkeypatch.delenv(telemetry.TELEMETRY_DISABLED_ENV, raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv(telemetry.TELEMETRY_TESTING_ENV, raising=False)
+
+
+def _set_stable_sources(
+    monkeypatch,
+    *,
+    macs: list[str] | None = None,
+    ips: list[str] | None = None,
+) -> None:
+    monkeypatch.setattr(telemetry, "_collect_mac_address_candidates", lambda: macs or [])
+    monkeypatch.setattr(telemetry, "_collect_ip_address_candidates", lambda: ips or [])
+
+
+def test_default_endpoint_uploads_install_once_and_dedupes(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.delenv(telemetry.TELEMETRY_ENDPOINT_ENV, raising=False)
+    _set_stable_sources(monkeypatch, macs=["02:00:00:00:00:01"])
     state_path = tmp_path / "install_telemetry.json"
     calls: list[tuple[str, dict[str, Any]]] = []
 
@@ -45,14 +63,17 @@ def test_default_endpoint_uploads_install_once_and_dedupes(tmp_path, monkeypatch
     assert payload["event"] == "install"
     assert payload["opensquilla_version"] == "1.0.0"
     state = _load(state_path)
+    assert state["install_id"] == telemetry._stable_install_id("mac", ["020000000001"])
+    assert state["install_id_source"] == "stable-v2-mac"
     assert state["uploaded_install"] is True
     assert state["uploaded_versions"] == ["1.0.0"]
 
 
 def test_endpoint_empty_creates_install_id_without_upload(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
     monkeypatch.delenv(telemetry.TELEMETRY_ENDPOINT_ENV, raising=False)
-    monkeypatch.delenv(telemetry.TELEMETRY_DISABLED_ENV, raising=False)
     monkeypatch.setattr(telemetry, "DEFAULT_TELEMETRY_ENDPOINT", "")
+    _set_stable_sources(monkeypatch, macs=["02:00:00:00:00:02"])
     state_path = tmp_path / "install_telemetry.json"
 
     result = telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
@@ -69,7 +90,9 @@ def test_endpoint_empty_creates_install_id_without_upload(tmp_path, monkeypatch)
 
 
 def test_configured_endpoint_uploads_install_once_and_dedupes(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
     monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    _set_stable_sources(monkeypatch, macs=["02:00:00:00:00:03"])
     state_path = tmp_path / "install_telemetry.json"
     calls: list[tuple[str, dict[str, Any]]] = []
 
@@ -116,7 +139,9 @@ def test_configured_endpoint_uploads_install_once_and_dedupes(tmp_path, monkeypa
 
 
 def test_new_version_uploads_version_seen(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
     monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    _set_stable_sources(monkeypatch, macs=["02:00:00:00:00:04"])
     state_path = tmp_path / "install_telemetry.json"
     events: list[str] = []
 
@@ -142,6 +167,7 @@ def test_new_version_uploads_version_seen(tmp_path, monkeypatch):
 
 
 def test_disabled_env_skips_without_creating_state(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
     monkeypatch.setenv(telemetry.TELEMETRY_DISABLED_ENV, "true")
     monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
     state_path = tmp_path / "install_telemetry.json"
@@ -154,8 +180,52 @@ def test_disabled_env_skips_without_creating_state(tmp_path, monkeypatch):
     assert not state_path.exists()
 
 
-def test_upload_failure_does_not_mark_install_uploaded(tmp_path, monkeypatch):
+def test_github_actions_env_skips_without_creating_state(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
     monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    state_path = tmp_path / "install_telemetry.json"
+
+    result = telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+
+    assert result.disabled is True
+    assert result.sent is False
+    assert result.skipped_reason == "environment:GITHUB_ACTIONS"
+    assert not state_path.exists()
+
+
+def test_pytest_current_test_env_skips_without_creating_state(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_file.py::test_name (call)")
+    monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    state_path = tmp_path / "install_telemetry.json"
+
+    result = telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+
+    assert result.disabled is True
+    assert result.sent is False
+    assert result.skipped_reason == "environment:PYTEST_CURRENT_TEST"
+    assert not state_path.exists()
+
+
+def test_opensquilla_testing_env_skips_without_creating_state(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv(telemetry.TELEMETRY_TESTING_ENV, "true")
+    monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    state_path = tmp_path / "install_telemetry.json"
+
+    result = telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+
+    assert result.disabled is True
+    assert result.sent is False
+    assert result.skipped_reason == "environment:OPENSQUILLA_TESTING"
+    assert not state_path.exists()
+
+
+def test_upload_failure_does_not_mark_install_uploaded(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    _set_stable_sources(monkeypatch, macs=["02:00:00:00:00:05"])
     state_path = tmp_path / "install_telemetry.json"
 
     def fake_post(
@@ -180,7 +250,101 @@ def test_upload_failure_does_not_mark_install_uploaded(tmp_path, monkeypatch):
 
 
 def test_desktop_env_sets_install_method(monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
     monkeypatch.delenv(telemetry.TELEMETRY_INSTALL_METHOD_ENV, raising=False)
     monkeypatch.setenv("OPENSQUILLA_DESKTOP", "1")
 
     assert telemetry._detect_install_method() == "desktop"
+
+
+def test_mac_addresses_generate_stable_install_id(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    _set_stable_sources(
+        monkeypatch,
+        macs=["02:00:00:00:00:0A", "ff:ff:ff:ff:ff:ff", "01:00:5e:00:00:fb"],
+        ips=["10.0.0.5"],
+    )
+    state_path = tmp_path / "install_telemetry.json"
+    calls: list[dict[str, Any]] = []
+
+    def fake_post(
+        endpoint: str,
+        payload: dict[str, Any],
+        *,
+        timeout: float,
+    ) -> tuple[bool, str | None]:
+        calls.append(payload)
+        return True, None
+
+    monkeypatch.setattr(telemetry, "_post_payload", fake_post)
+
+    telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+
+    expected = telemetry._stable_install_id("mac", ["02000000000a"])
+    state = _load(state_path)
+    assert state["install_id"] == expected
+    assert state["install_id_source"] == "stable-v2-mac"
+    assert calls[0]["install_id"] == expected
+
+
+def test_mac_address_order_does_not_change_install_id():
+    first = telemetry._normalized_mac_addresses(
+        ["02:00:00:00:00:0b", "02:00:00:00:00:0a"]
+    )
+    second = telemetry._normalized_mac_addresses(
+        ["02:00:00:00:00:0A", "02:00:00:00:00:0B"]
+    )
+
+    assert first == ["02000000000a", "02000000000b"]
+    assert telemetry._stable_install_id("mac", first) == telemetry._stable_install_id(
+        "mac",
+        second,
+    )
+
+
+def test_ip_fallback_generates_stable_install_id_when_no_usable_mac(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    _set_stable_sources(
+        monkeypatch,
+        macs=["00:00:00:00:00:00", "01:00:5e:00:00:fb"],
+        ips=["127.0.0.1", "169.254.10.20", "10.0.0.8"],
+    )
+    state_path = tmp_path / "install_telemetry.json"
+
+    monkeypatch.setattr(telemetry, "_post_payload", lambda *args, **kwargs: (True, None))
+
+    telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+
+    state = _load(state_path)
+    assert state["install_id"] == telemetry._stable_install_id("ip", ["10.0.0.8"])
+    assert state["install_id_source"] == "stable-v2-ip"
+
+
+def test_loopback_endpoint_host_does_not_influence_install_id(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv(
+        telemetry.TELEMETRY_ENDPOINT_ENV,
+        "http://127.0.0.1:8787/v1/install",
+    )
+    _set_stable_sources(monkeypatch, macs=[], ips=["127.0.0.1", "10.0.0.9"])
+    state_path = tmp_path / "install_telemetry.json"
+    calls: list[dict[str, Any]] = []
+
+    def fake_post(
+        endpoint: str,
+        payload: dict[str, Any],
+        *,
+        timeout: float,
+    ) -> tuple[bool, str | None]:
+        calls.append(payload)
+        return True, None
+
+    monkeypatch.setattr(telemetry, "_post_payload", fake_post)
+
+    telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+
+    expected = telemetry._stable_install_id("ip", ["10.0.0.9"])
+    assert _load(state_path)["install_id"] == expected
+    assert calls[0]["install_id"] == expected


### PR DESCRIPTION
## Summary

- Generate install telemetry IDs from a stable local digest instead of a random per-state ID, preferring usable MAC addresses and falling back to usable local IP addresses only when needed
- Keep raw MAC/IP values out of the telemetry payload and persist the ID source in local telemetry state
- Skip install telemetry automatically in GitHub Actions, pytest, and `OPENSQUILLA_TESTING=true`
- Document the updated install telemetry behavior and privacy boundaries

## Testing

- `uv run pytest tests/test_observability/test_install_telemetry.py`