### PR TITLE
Guard stale Web Chat session responses

### DIFF
--- a/opensquilla-webui/e2e/session-race.spec.ts
+++ b/opensquilla-webui/e2e/session-race.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const CONTROL_URL = '/control/'
+const SESSION_A = 'agent:main:webchat:e2e-race-a'
+const SESSION_B = 'agent:main:webchat:e2e-race-b'
+const SESSION_A_TITLE = 'Race Session A'
+const SESSION_B_TITLE = 'Race Session B'
+
+function wsResponse(id: string, payload: unknown) {
+  return JSON.stringify({ type: 'res', id, ok: true, payload })
+}
+
+async function readSessionDiag(page: Page): Promise<Array<{ source?: string; to?: string }>> {
+  return page.evaluate(() => {
+    const helper = (window as unknown as {
+      OpenSquillaSessionDiag?: { read?: () => Array<{ source?: string; to?: string }> }
+    }).OpenSquillaSessionDiag
+    return helper?.read?.() ?? []
+  })
+}
+
+test('late chat.send response cannot navigate away from the current session', async ({ page }) => {
+  let delayedSend: { id: string; sendResponse: (payload: unknown) => void } | null = null
+
+  await page.route('**/api/approvals', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ pending: [] }),
+  }))
+
+  await page.routeWebSocket(/\/ws$/, ws => {
+    ws.send(JSON.stringify({ type: 'event', event: 'connect.challenge', payload: {} }))
+    ws.onMessage(message => {
+      try {
+        const frame = JSON.parse(String(message))
+        if (frame?.type !== 'req') return
+        if (frame.method === 'connect') {
+          ws.send(JSON.stringify({ protocol: 3, policy: { tick_interval_ms: 30000 } }))
+          return
+        }
+        if (frame.method === 'chat.send') {
+          const id = String(frame.id)
+          delayedSend = {
+            id,
+            sendResponse: payload => ws.send(wsResponse(id, payload)),
+          }
+          return
+        }
+
+        const payloads: Record<string, unknown> = {
+          'agents.list': { agents: [] },
+          'chat.history': { messages: [], has_more: false },
+          'commands.list_for_surface': { commands: [] },
+          'config.get': {
+            squilla_router: { enabled: false, rollout_phase: 'observe', tiers: {} },
+            permissions: {},
+            skills: {},
+          },
+          'sessions.list': {
+            sessions: [
+              {
+                key: SESSION_B,
+                title: SESSION_B_TITLE,
+                sessionKind: 'chat',
+                surface: 'webchat',
+                conversationKind: 'direct',
+                effectiveAgentId: 'main',
+                updatedAt: 200,
+                messageCount: 0,
+                status: 'ok',
+                runStatus: 'idle',
+              },
+              {
+                key: SESSION_A,
+                title: SESSION_A_TITLE,
+                sessionKind: 'chat',
+                surface: 'webchat',
+                conversationKind: 'direct',
+                effectiveAgentId: 'main',
+                updatedAt: 100,
+                messageCount: 0,
+                status: 'ok',
+                runStatus: 'idle',
+              },
+            ],
+            has_more: false,
+          },
+          'sessions.messages.subscribe': {
+            subscribed: true,
+            replay_complete: true,
+            current_stream_seq: 0,
+            run_status: 'idle',
+          },
+          'usage.status': { sessions: [] },
+        }
+
+        ws.send(wsResponse(String(frame.id), payloads[String(frame.method)] ?? {}))
+      } catch {}
+    })
+  })
+
+  await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(SESSION_A))
+  await page.waitForSelector('.conn-pill', { timeout: 10000 })
+  await expect(page.locator('.chat-textarea')).toBeVisible()
+
+  await page.locator('.chat-textarea').fill('hello from A')
+  await page.locator('.chat-send-btn[aria-label="Send"]').click()
+  await expect.poll(() => delayedSend?.id ?? '').not.toBe('')
+
+  await page
+    .locator('.sidebar-history-row[data-family="chats"]')
+    .filter({ hasText: SESSION_B_TITLE })
+    .locator('.sidebar-history-item')
+    .click()
+  await expect.poll(() => new URL(page.url()).searchParams.get('session')).toBe(SESSION_B)
+
+  const send = delayedSend
+  if (!send) throw new Error('chat.send was not captured')
+  send.sendResponse({
+    ok: true,
+    sessionKey: SESSION_A,
+    status: 'accepted',
+  })
+
+  await expect.poll(() => new URL(page.url()).searchParams.get('session')).toBe(SESSION_B)
+  await expect.poll(async () => {
+    const diag = await readSessionDiag(page)
+    return diag.some(entry => entry.source === 'send.response.stale')
+  }).toBe(true)
+})

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -396,6 +396,7 @@ import { useAgentOptions } from './composables/useAgentOptions'
 import { useToasts } from './composables/useToasts'
 import { useNavigation } from './app/useNavigation'
 import { normalizeAgentId } from './utils/chat/sessionKeys'
+import { installSessionNavigationDiagConsole, recordSessionNavigationDiag } from './utils/chat/sessionNavigationDiag'
 import type { RpcEventHandler } from '@/lib/rpc'
 import { isMacPlatform } from './utils/browser'
 import { useShortcutsStore } from './stores/shortcuts'
@@ -410,6 +411,8 @@ const { allSessions, sessionListError, isLoading, loadSessions } = useSessions()
 const { consoleSections, bottomRoutes, workNav } = useNavigation()
 const { pushToast } = useToasts()
 const webConfigEnabled = getPlatform().capabilities.hasWebConfig
+
+installSessionNavigationDiagConsole()
 
 // Shared agents.list state + fetch (singleton): App.vue and ChatView's
 // in-draft switcher use the same list and one fetch.
@@ -716,11 +719,15 @@ function onPaletteToggleTheme() {
 }
 
 function onPaletteSelectSession(key: string) {
-  switchToSession(key)
+  switchToSession(key, 'command_palette.select_session')
 }
 
-function switchToSession(key: string) {
+function switchToSession(key: string, source = 'app.switchToSession') {
   if (!key) return
+  recordSessionNavigationDiag(source, {
+    from: currentSessionKey.value,
+    to: key,
+  })
   router.push({ path: '/chat', query: { session: key } })
   if (appStore.sidebarHovered) {
     appStore.setSidebarHovered(false)
@@ -795,7 +802,7 @@ async function onDeleteSession(key: string) {
 function openBlockedApprovalSession() {
   const oldest = appStore.oldestPendingWithSession
   if (oldest?.sessionKey) {
-    switchToSession(oldest.sessionKey)
+    switchToSession(oldest.sessionKey, 'approval.openBlockedSession')
     return
   }
   router.push('/approvals')

--- a/opensquilla-webui/src/composables/chat/useChatSend.sessionRace.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.sessionRace.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { decideSendResponseSession } from './useChatSend'
+
+describe('decideSendResponseSession', () => {
+  it('ignores a late response after the user navigated to another session', () => {
+    expect(decideSendResponseSession({
+      requestSessionKey: 'agent:main:webchat:A',
+      currentSessionKey: 'agent:main:webchat:B',
+      responseSessionKey: 'agent:main:webchat:A',
+    })).toEqual({
+      action: 'ignore',
+      reason: 'current_session_changed',
+    })
+  })
+
+  it('persists server canonicalization while the request session is still current', () => {
+    expect(decideSendResponseSession({
+      requestSessionKey: 'legacy-A',
+      currentSessionKey: 'legacy-A',
+      responseSessionKey: 'agent:main:webchat:legacy-A',
+    })).toEqual({
+      action: 'persist',
+      responseSessionKey: 'agent:main:webchat:legacy-A',
+    })
+  })
+
+  it('ignores same-session responses', () => {
+    expect(decideSendResponseSession({
+      requestSessionKey: 'agent:main:webchat:A',
+      currentSessionKey: 'agent:main:webchat:A',
+      responseSessionKey: 'agent:main:webchat:A',
+    })).toEqual({
+      action: 'ignore',
+      reason: 'same_session',
+    })
+  })
+
+  it('ignores responses with no session key', () => {
+    expect(decideSendResponseSession({
+      requestSessionKey: 'agent:main:webchat:A',
+      currentSessionKey: 'agent:main:webchat:A',
+      responseSessionKey: undefined,
+    })).toEqual({
+      action: 'ignore',
+      reason: 'missing_response_session',
+    })
+  })
+})

--- a/opensquilla-webui/src/composables/chat/useChatSend.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.ts
@@ -7,9 +7,36 @@ import type {
 } from '@/types/rpc'
 import type { ChatRpcStreamApi } from '@/composables/chat/useChatRpcEventHandlers'
 import type { BusySendMode } from '@/composables/chat/useChatPendingQueue'
+import { recordSessionNavigationDiag } from '@/utils/chat/sessionNavigationDiag'
 
 type RpcClient = {
   call: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+}
+
+type PersistSessionOptions = { updateRoute?: boolean; source?: string }
+
+export type SendResponseSessionDecision =
+  | { action: 'ignore'; reason: 'missing_response_session' | 'current_session_changed' | 'same_session' }
+  | { action: 'persist'; responseSessionKey: string }
+
+export function decideSendResponseSession(input: {
+  requestSessionKey: string
+  currentSessionKey: string
+  responseSessionKey?: string | null
+}): SendResponseSessionDecision {
+  const responseSessionKey = input.responseSessionKey || ''
+  if (!responseSessionKey) return { action: 'ignore', reason: 'missing_response_session' }
+  if (input.currentSessionKey !== input.requestSessionKey) {
+    return { action: 'ignore', reason: 'current_session_changed' }
+  }
+  if (responseSessionKey === input.currentSessionKey) {
+    return { action: 'ignore', reason: 'same_session' }
+  }
+  return { action: 'persist', responseSessionKey }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
 }
 
 export interface UseChatSendOptions {
@@ -25,7 +52,7 @@ export interface UseChatSendOptions {
   autoScroll: Ref<boolean>
   stream: ChatRpcStreamApi
   normalizeElevatedMode: (mode: string) => string
-  persistSession: (key: string) => void
+  persistSession: (key: string, options?: PersistSessionOptions) => void
   isCompactInFlightForCurrentSession: () => boolean
   hasPendingAttachmentWork: () => boolean
   enqueuePendingInput: (text: string) => boolean
@@ -88,10 +115,15 @@ export function useChatSend(options: UseChatSendOptions) {
   }
 
   async function dispatchSend(text: string, sendOpts?: { queueMode?: 'steer' }) {
-    if (!options.sessionKey.value) return
+    const requestSessionKey = options.sessionKey.value
+    if (!requestSessionKey) return
 
     options.aborted.value = false
     options.closeSlashMenu()
+    recordSessionNavigationDiag('send.start', {
+      requestSession: requestSessionKey,
+      current: requestSessionKey,
+    })
 
     const now = new Date().toISOString()
     const userText = text
@@ -99,7 +131,7 @@ export function useChatSend(options: UseChatSendOptions) {
     options.autoScroll.value = true
     options.scrollToBottom()
 
-    const params: ChatSendParams = { message: text || 'Describe these attachments', sessionKey: options.sessionKey.value }
+    const params: ChatSendParams = { message: text || 'Describe these attachments', sessionKey: requestSessionKey }
     if (sendOpts?.queueMode) params.queueMode = sendOpts.queueMode
     const elevated = options.normalizeElevatedMode(options.elevatedMode.value)
     if (elevated) params._source = { elevated }
@@ -129,10 +161,37 @@ export function useChatSend(options: UseChatSendOptions) {
 
     try {
       const res = await options.rpc.call<ChatSendResponse>('chat.send', params)
-      if (res?.sessionKey && res.sessionKey !== options.sessionKey.value) options.persistSession(res.sessionKey)
+      const decision = decideSendResponseSession({
+        requestSessionKey,
+        currentSessionKey: options.sessionKey.value,
+        responseSessionKey: res?.sessionKey,
+      })
+      if (decision.action === 'persist') {
+        recordSessionNavigationDiag('send.response.persist', {
+          requestSession: requestSessionKey,
+          responseSession: decision.responseSessionKey,
+          current: options.sessionKey.value,
+        })
+        options.persistSession(decision.responseSessionKey, { source: 'send.response' })
+      } else if (decision.reason === 'current_session_changed') {
+        recordSessionNavigationDiag('send.response.stale', {
+          requestSession: requestSessionKey,
+          responseSession: res?.sessionKey,
+          current: options.sessionKey.value,
+          reason: decision.reason,
+        })
+      }
     } catch (err: unknown) {
+      if (options.sessionKey.value !== requestSessionKey) {
+        recordSessionNavigationDiag('send.error.stale', {
+          requestSession: requestSessionKey,
+          current: options.sessionKey.value,
+          reason: errorMessage(err),
+        })
+        return
+      }
       if (!wasStreaming) options.stream.endStreaming()
-      const message = err instanceof Error ? err.message : String(err)
+      const message = errorMessage(err)
       options.messages.value.push({ role: 'error', text: 'Send failed: ' + message, ts: new Date().toISOString() })
     }
   }
@@ -164,7 +223,8 @@ export function useChatSend(options: UseChatSendOptions) {
    * a hiddenControl flag) so the drain restores both.
    */
   async function dispatchHiddenSend(providerText: string, displayText: string) {
-    if (!options.sessionKey.value || !providerText) return
+    const requestSessionKey = options.sessionKey.value
+    if (!requestSessionKey || !providerText) return
     const compactInFlight = options.isCompactInFlightForCurrentSession()
     if (options.stream.isStreaming.value || compactInFlight) {
       options.enqueueHiddenControl?.({ text: providerText, displayText })
@@ -172,6 +232,10 @@ export function useChatSend(options: UseChatSendOptions) {
     }
 
     options.aborted.value = false
+    recordSessionNavigationDiag('hiddenSend.start', {
+      requestSession: requestSessionKey,
+      current: requestSessionKey,
+    })
     // Show the visible confirmation as a user bubble (NOT the marker text).
     const now = new Date().toISOString()
     if (displayText) {
@@ -180,7 +244,7 @@ export function useChatSend(options: UseChatSendOptions) {
       options.scrollToBottom()
     }
 
-    const params: ChatSendParams = { message: providerText, sessionKey: options.sessionKey.value }
+    const params: ChatSendParams = { message: providerText, sessionKey: requestSessionKey }
     if (displayText && displayText !== providerText) params.displayText = displayText
     const elevated = options.normalizeElevatedMode(options.elevatedMode.value)
     if (elevated) params._source = { elevated }
@@ -193,10 +257,37 @@ export function useChatSend(options: UseChatSendOptions) {
 
     try {
       const res = await options.rpc.call<ChatSendResponse>('chat.send', params)
-      if (res?.sessionKey && res.sessionKey !== options.sessionKey.value) options.persistSession(res.sessionKey)
+      const decision = decideSendResponseSession({
+        requestSessionKey,
+        currentSessionKey: options.sessionKey.value,
+        responseSessionKey: res?.sessionKey,
+      })
+      if (decision.action === 'persist') {
+        recordSessionNavigationDiag('hiddenSend.response.persist', {
+          requestSession: requestSessionKey,
+          responseSession: decision.responseSessionKey,
+          current: options.sessionKey.value,
+        })
+        options.persistSession(decision.responseSessionKey, { source: 'hiddenSend.response' })
+      } else if (decision.reason === 'current_session_changed') {
+        recordSessionNavigationDiag('hiddenSend.response.stale', {
+          requestSession: requestSessionKey,
+          responseSession: res?.sessionKey,
+          current: options.sessionKey.value,
+          reason: decision.reason,
+        })
+      }
     } catch (err: unknown) {
+      if (options.sessionKey.value !== requestSessionKey) {
+        recordSessionNavigationDiag('hiddenSend.error.stale', {
+          requestSession: requestSessionKey,
+          current: options.sessionKey.value,
+          reason: errorMessage(err),
+        })
+        return
+      }
       if (!wasStreaming) options.stream.endStreaming()
-      const message = err instanceof Error ? err.message : String(err)
+      const message = errorMessage(err)
       options.messages.value.push({ role: 'error', text: 'Send failed: ' + message, ts: new Date().toISOString() })
     }
   }

--- a/opensquilla-webui/src/composables/chat/useChatSessionRoute.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionRoute.ts
@@ -5,9 +5,15 @@ import {
   canonicalSessionKey,
   webchatSessionKey,
 } from '@/utils/chat/sessionKeys'
+import { recordSessionNavigationDiag } from '@/utils/chat/sessionNavigationDiag'
 
 const ACTIVE_SESSION_STORAGE_KEY = 'opensquilla_active_session'
 const DRAFT_CHAT_PATH = '/chat/new'
+
+export interface PersistSessionOptions {
+  updateRoute?: boolean
+  source?: string
+}
 
 function routeStringParam(value: unknown): string {
   return typeof value === 'string' ? value : ''
@@ -25,8 +31,18 @@ export function useChatSessionRoute(sessionKey: Ref<string>) {
   const route = useRoute()
   const router = useRouter()
 
-  function persistSession(key: string, options: { updateRoute?: boolean } = {}) {
-    sessionKey.value = canonicalSessionKey(key)
+  function persistSession(key: string, options: PersistSessionOptions = {}) {
+    const previous = sessionKey.value
+    const next = canonicalSessionKey(key)
+    const routeSession = readSessionFromUrl()
+    recordSessionNavigationDiag(options.source || 'persistSession', {
+      from: previous,
+      to: next,
+      routeSession,
+      reason: options.updateRoute === false ? 'state_only' : 'route_replace',
+    })
+
+    sessionKey.value = next
     writeStoredSession(sessionKey.value)
     if (options.updateRoute === false) return
     if (readSessionFromUrl() === sessionKey.value) return

--- a/opensquilla-webui/src/composables/chat/useChatSessionRuntime.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionRuntime.ts
@@ -3,6 +3,7 @@ import type {
   ChatMessage,
   ChatRunStatusSource,
 } from '@/types/chat'
+import type { PersistSessionOptions } from '@/composables/chat/useChatSessionRoute'
 
 export interface ChatUsageAccumulator {
   input: number
@@ -28,7 +29,7 @@ export interface UseChatSessionRuntimeOptions {
   usageAccum: Ref<ChatUsageAccumulator>
   usageModel: Ref<string>
   createSessionKey: (agentId?: string) => string
-  persistSession: (key: string, options?: { updateRoute?: boolean }) => void
+  persistSession: (key: string, options?: PersistSessionOptions) => void
   unsubscribeSession: () => void | Promise<void>
   subscribeSession: () => void | Promise<void>
   loadHistory: () => void | Promise<void>
@@ -95,7 +96,7 @@ export function useChatSessionRuntime(options: UseChatSessionRuntimeOptions) {
     if (!key || key === options.sessionKey.value) return
 
     options.unsubscribeSession()
-    options.persistSession(key)
+    options.persistSession(key, { source: 'runtime.switchToSession' })
     resetSessionRuntimeState()
     options.pendingSessionIntent.value = null
     resetCompactAndQueueState()

--- a/opensquilla-webui/src/utils/chat/sessionNavigationDiag.test.ts
+++ b/opensquilla-webui/src/utils/chat/sessionNavigationDiag.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  clearSessionNavigationDiag,
+  readSessionNavigationDiag,
+  recordSessionNavigationDiag,
+  setSessionNavigationDiagStorageForTest,
+  type SessionNavigationDiagStorage,
+} from './sessionNavigationDiag'
+
+class MemoryStorage implements SessionNavigationDiagStorage {
+  private values = new Map<string, string>()
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value)
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key)
+  }
+}
+
+describe('sessionNavigationDiag', () => {
+  afterEach(() => {
+    setSessionNavigationDiagStorageForTest(null)
+  })
+
+  it('records newest entries first with session context', () => {
+    setSessionNavigationDiagStorageForTest(new MemoryStorage())
+
+    recordSessionNavigationDiag('send.start', { requestSession: 'A', current: 'A' })
+    recordSessionNavigationDiag('send.response.stale', {
+      requestSession: 'A',
+      responseSession: 'A',
+      current: 'B',
+      reason: 'current_session_changed',
+    })
+
+    expect(readSessionNavigationDiag()).toMatchObject([
+      {
+        source: 'send.response.stale',
+        requestSession: 'A',
+        responseSession: 'A',
+        current: 'B',
+        reason: 'current_session_changed',
+      },
+      {
+        source: 'send.start',
+        requestSession: 'A',
+        current: 'A',
+      },
+    ])
+  })
+
+  it('clears stored diagnostics', () => {
+    setSessionNavigationDiagStorageForTest(new MemoryStorage())
+
+    recordSessionNavigationDiag('persistSession', { from: 'A', to: 'B' })
+    clearSessionNavigationDiag()
+
+    expect(readSessionNavigationDiag()).toEqual([])
+  })
+})

--- a/opensquilla-webui/src/utils/chat/sessionNavigationDiag.ts
+++ b/opensquilla-webui/src/utils/chat/sessionNavigationDiag.ts
@@ -1,0 +1,101 @@
+export const SESSION_NAVIGATION_DIAG_STORAGE_KEY = 'opensquilla.chat.sessionNavigationDiag'
+export const SESSION_NAVIGATION_DIAG_LIMIT = 200
+
+export interface SessionNavigationDiagStorage {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+  removeItem: (key: string) => void
+}
+
+export interface SessionNavigationDiagEntry {
+  t: number
+  iso: string
+  source: string
+  from?: string
+  to?: string
+  current?: string
+  routeSession?: string
+  requestSession?: string
+  responseSession?: string
+  reason?: string
+}
+
+export type SessionNavigationDiagData = Omit<SessionNavigationDiagEntry, 't' | 'iso' | 'source'>
+
+let storageOverride: SessionNavigationDiagStorage | null = null
+
+export function setSessionNavigationDiagStorageForTest(storage: SessionNavigationDiagStorage | null) {
+  storageOverride = storage
+}
+
+function storage(): SessionNavigationDiagStorage | null {
+  if (storageOverride) return storageOverride
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+export function readSessionNavigationDiag(): SessionNavigationDiagEntry[] {
+  const store = storage()
+  if (!store) return []
+  try {
+    const raw = store.getItem(SESSION_NAVIGATION_DIAG_STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.filter(Boolean) : []
+  } catch {
+    return []
+  }
+}
+
+export function clearSessionNavigationDiag() {
+  const store = storage()
+  if (!store) return
+  try {
+    store.removeItem(SESSION_NAVIGATION_DIAG_STORAGE_KEY)
+  } catch {
+    // Ignore diagnostics storage failures.
+  }
+}
+
+export function recordSessionNavigationDiag(
+  source: string,
+  data: SessionNavigationDiagData = {},
+): SessionNavigationDiagEntry | null {
+  const store = storage()
+  if (!store) return null
+  const now = Date.now()
+  const entry: SessionNavigationDiagEntry = {
+    t: now,
+    iso: new Date(now).toISOString(),
+    source,
+    ...data,
+  }
+  try {
+    const next = [entry, ...readSessionNavigationDiag()].slice(0, SESSION_NAVIGATION_DIAG_LIMIT)
+    store.setItem(SESSION_NAVIGATION_DIAG_STORAGE_KEY, JSON.stringify(next))
+    return entry
+  } catch {
+    return null
+  }
+}
+
+export function installSessionNavigationDiagConsole() {
+  if (typeof window === 'undefined') return
+  window.OpenSquillaSessionDiag = {
+    read: readSessionNavigationDiag,
+    clear: clearSessionNavigationDiag,
+  }
+}
+
+declare global {
+  interface Window {
+    OpenSquillaSessionDiag?: {
+      read: () => SessionNavigationDiagEntry[]
+      clear: () => void
+    }
+  }
+}

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -554,6 +554,7 @@ import type { InterruptViewState } from '@/types/parts'
 import { artifactDownloadUrl } from '@/utils/chat/artifacts'
 import { copyTextWithFallback, copyImageToClipboard, downloadBlob, shareCopyImageSupported } from '@/utils/browser'
 import { useCopyFeedback } from '@/composables/chat/useCopyFeedback'
+import { recordSessionNavigationDiag } from '@/utils/chat/sessionNavigationDiag'
 import {
   toolCallGroups,
   toolGroupStatusText,
@@ -1893,7 +1894,7 @@ onMounted(async () => {
     if (!isDraftRoute() || hasLegacyNewChatQuery()) goToDraft({ replace: true })
     consumeDraftPrefill()
   } else {
-    persistSession(sessionKey.value, { updateRoute: false })
+    persistSession(sessionKey.value, { updateRoute: false, source: 'chatView.initialSession' })
   }
 
   // Load elevated mode
@@ -1969,6 +1970,11 @@ useDocumentEvent('keydown', onDocumentKeydown)
 // Watch for route changes
 watch(() => route.query.session, (newSession) => {
   if (newSession && typeof newSession === 'string') {
+    recordSessionNavigationDiag('route.query.session', {
+      from: sessionKey.value,
+      to: newSession,
+      routeSession: newSession,
+    })
     switchToSession(newSession)
   }
 })
@@ -1988,7 +1994,7 @@ watch(() => [route.query.newChat, route.query.new], () => {
 watch(pendingSessionIntent, (intent, previous) => {
   if (previous !== 'new_chat' || intent !== null) return
   if (!isDraftRoute()) return
-  persistSession(sessionKey.value)
+  persistSession(sessionKey.value, { source: 'chatView.draftMaterialized' })
 })
 
 watch(sessionKey, () => {


### PR DESCRIPTION
## Summary
- Guard visible and hidden Web Chat sends so stale chat.send responses cannot navigate back to an older session after the user switches conversations.
- Add local session navigation diagnostics exposed through window.OpenSquillaSessionDiag for future field reports.
- Add unit coverage for the response decision and diagnostics helper plus a Playwright regression for the late-response race.

## Test Plan
- npm run typecheck
- npm run test:unit
- OPENSQUILLA_WEBUI_BASE_URL=http://127.0.0.1:18794 npm run test:e2e -- e2e/session-race.spec.ts