### PR TITLE
Fix desktop artifact open for HTML files

### DIFF
--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -756,6 +756,8 @@ interface ArtifactOpenRequest {
 
 const MIME_EXTENSIONS: Record<string, string> = {
   'application/pdf': '.pdf',
+  'text/html': '.html',
+  'application/xhtml+xml': '.xhtml',
   'text/plain': '.txt',
   'text/markdown': '.md',
   'text/csv': '.csv',
@@ -783,15 +785,6 @@ function safeArtifactFileName(raw: unknown): string {
 
 function artifactMimeKey(mime: unknown): string {
   return String(mime ?? '').split(';', 1)[0].trim().toLowerCase()
-}
-
-function isActiveDocumentArtifactRequest(name: string, mime: unknown): boolean {
-  const key = artifactMimeKey(mime)
-  const normalizedName = name.trim().toLowerCase()
-  return key === 'text/html' || key === 'application/xhtml+xml' ||
-    normalizedName.endsWith('.html') ||
-    normalizedName.endsWith('.htm') ||
-    normalizedName.endsWith('.xhtml')
 }
 
 // When the name carries no extension, fall back to one implied by the MIME type
@@ -825,12 +818,6 @@ async function openArtifactWithDefaultApp(payload: ArtifactOpenRequest): Promise
     mkdirSync(dir, { recursive: true, mode: 0o700 })
     void pruneArtifactCache(dir)
     const name = safeArtifactFileName(payload?.name)
-    if (isActiveDocumentArtifactRequest(name, payload?.mime)) {
-      return {
-        ok: false,
-        message: 'Active document artifacts cannot be opened directly. Use Download instead.',
-      }
-    }
     // A random prefix guarantees a unique, non-colliding, non-dotfile path even
     // for two opens in the same millisecond.
     const filePath = join(dir, `${randomUUID()}-${name}${artifactExtension(name, payload?.mime)}`)

--- a/opensquilla-webui/src/components/chat/ChatArtifactList.vue
+++ b/opensquilla-webui/src/components/chat/ChatArtifactList.vue
@@ -202,9 +202,7 @@ import {
   type ArtifactPreviewState,
 } from '@/composables/chat/useArtifactPreview'
 import {
-  artifactOpenFailureMessage,
   fetchArtifactBlob,
-  isActiveDocumentArtifact,
   openArtifactBlobUrl,
 } from '@/utils/chat/artifactAccess'
 import { usePlatform } from '@/platform'
@@ -319,7 +317,8 @@ function openPreview(artifact: ArtifactPayload) {
 // Desktop: `window.open` is denied by the Electron shell handler, so the blob
 // popup path below can never succeed. Fetch the bytes (with auth) and hand them
 // to the main process, which writes a temp file and opens it with the OS
-// default app. Web keeps the in-browser new-tab path.
+// default app. Web keeps the in-browser new-tab path and its active-document
+// guard.
 async function openFile(artifact: ArtifactPayload) {
   if (platform.capabilities.canOpenArtifactsNatively && platform.files.openArtifact) {
     const fetched = await fetchArtifactBlob(artifact, {
@@ -329,10 +328,6 @@ async function openFile(artifact: ArtifactPayload) {
     })
     if (!fetched.ok) {
       pushToast(fetched.message, { tone: 'danger' })
-      return
-    }
-    if (isActiveDocumentArtifact(artifact, fetched.blob)) {
-      pushToast(artifactOpenFailureMessage(0, artifactFileTitle(artifact)), { tone: 'danger' })
       return
     }
     const data = await fetched.blob.arrayBuffer()

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -117,8 +117,9 @@ def test_package_verifier_hard_fails_stale_runtime_and_boot_contract() -> None:
         assert expected in verifier
 
 
-def test_desktop_native_artifact_open_blocks_active_documents() -> None:
+def test_desktop_native_artifact_open_allows_active_documents_with_file_extensions() -> None:
     main_ts = _read("desktop/electron/src/main.ts")
+    artifact_list_vue = _read("opensquilla-webui/src/components/chat/ChatArtifactList.vue")
     mime_extensions = _section(main_ts, "const MIME_EXTENSIONS", "}\n\n")
     native_open = _section(
         main_ts,
@@ -126,7 +127,8 @@ def test_desktop_native_artifact_open_blocks_active_documents() -> None:
         "function createApplicationMenu",
     )
 
-    assert "'text/html'" not in mime_extensions
-    assert "'application/xhtml+xml'" not in mime_extensions
-    assert "function isActiveDocumentArtifactRequest" in main_ts
-    assert "isActiveDocumentArtifactRequest(name, payload?.mime)" in native_open
+    assert "'text/html': '.html'" in mime_extensions
+    assert "'application/xhtml+xml': '.xhtml'" in mime_extensions
+    assert "function isActiveDocumentArtifactRequest" not in main_ts
+    assert "shell.openPath(filePath)" in native_open
+    assert "isActiveDocumentArtifact(artifact, fetched.blob)" not in artifact_list_vue


### PR DESCRIPTION
## Summary

- Allow desktop artifact Open to hand HTML/XHTML files to the OS default app instead of blocking them before anything appears
- Add HTML/XHTML extension fallbacks for native artifact temp files when the artifact name has no extension
- Keep the web blob-open active-document guard intact and add a desktop contract check for the native-open path

## Testing

- `uv run pytest tests/test_desktop/test_electron_startup_contract.py`
- `npm run typecheck` in `opensquilla-webui`
- `npm run test:unit -- artifactAccess` in `opensquilla-webui`
- `npm run build` in `desktop/electron`
- Manual: launched the desktop client from `opensquilla-desktop-open-fix` and verified the updated client starts against the local gateway