### PR TITLE
fix(stream): normalize cumulative post-tool text deltas

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatStream.render.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatStream.render.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { ref } from 'vue'
 import { useChatStream } from './useChatStream'
+import type { ChatMessage } from '@/types/chat'
 
 // Focused coverage for the streaming render coalescer: stream deltas are
 // batched onto the frame clock (requestAnimationFrame) and the live reveal
@@ -8,8 +9,9 @@ import { useChatStream } from './useChatStream'
 // stubbed and driven manually; fake timers cover the Date.now() flush throttle.
 function makeStream(renderMarkdown = vi.fn((t: string, _o?: { highlight?: boolean }) => `<p>${t}</p>`)) {
   const scrollToBottom = vi.fn()
+  const messages = ref<ChatMessage[]>([])
   const api = useChatStream({
-    messages: ref([]) as never,
+    messages,
     lastHeaderRole: ref(''),
     aborted: ref(false),
     autoScroll: ref(true),
@@ -20,7 +22,7 @@ function makeStream(renderMarkdown = vi.fn((t: string, _o?: { highlight?: boolea
     stripProtocolTextLeak: (t: string) => t,
     scrollToBottom,
   })
-  return { api, scrollToBottom, renderMarkdown }
+  return { api, messages, scrollToBottom, renderMarkdown }
 }
 
 describe('useChatStream render coalescing', () => {
@@ -92,5 +94,58 @@ describe('useChatStream render coalescing', () => {
     rafCbs[0](0) // firing the cancelled frame must not render
 
     expect(renderMarkdown).not.toHaveBeenCalled()
+  })
+
+  it('renders cumulative post-tool text snapshots as only the new suffix', () => {
+    const { api, messages } = makeStream()
+    const prefix = 'prefix'
+    const suffix = 'suffix'
+
+    api.appendDelta(prefix)
+    api.appendToolCall({ tool_use_id: 'tool-1', tool_name: 'web_search' })
+    api.appendToolResult({ tool_use_id: 'tool-1', tool_name: 'web_search', result: 'ok' })
+    api.appendDelta(prefix + suffix)
+
+    expect(api.foldedTurn.value.rawText).toBe(prefix + suffix)
+
+    api.endStreaming()
+
+    expect(messages.value[0]?.text).toBe(prefix + suffix)
+    expect(messages.value[0]?.timeline).toEqual([
+      { type: 'text', raw: prefix },
+      { type: 'tool-group', groupId: 'stream:tool-group:web.search:0', operationKey: 'web.search' },
+      { type: 'text', raw: suffix },
+    ])
+    api.cleanup()
+  })
+
+  it('keeps additive post-tool text deltas unchanged', () => {
+    const { api, messages } = makeStream()
+
+    api.appendDelta('prefix')
+    api.appendToolCall({ tool_use_id: 'tool-1', tool_name: 'web_search' })
+    api.appendToolResult({ tool_use_id: 'tool-1', tool_name: 'web_search', result: 'ok' })
+    api.appendDelta('suffix')
+
+    expect(api.foldedTurn.value.rawText).toBe('prefixsuffix')
+
+    api.endStreaming()
+
+    expect(messages.value[0]?.text).toBe('prefixsuffix')
+    api.cleanup()
+  })
+
+  it('keeps cumulative-looking text before a tool boundary unchanged', () => {
+    const { api, messages } = makeStream()
+
+    api.appendDelta('prefix')
+    api.appendDelta('prefixsuffix')
+
+    expect(api.foldedTurn.value.rawText).toBe('prefixprefixsuffix')
+
+    api.endStreaming()
+
+    expect(messages.value[0]?.text).toBe('prefixprefixsuffix')
+    api.cleanup()
   })
 })

--- a/opensquilla-webui/src/composables/chat/useChatStream.ts
+++ b/opensquilla-webui/src/composables/chat/useChatStream.ts
@@ -336,21 +336,37 @@ export function useChatStream(options: UseChatStreamOptions) {
     streamBubble.value = false
   }
 
+  function normalizeIncomingTextDelta(text: string): string {
+    const raw = typeof text === 'string' ? text : ''
+    if (!raw || !streamRaw.value) return raw
+
+    const sawToolBoundary =
+      streamToolCalls.value.length > 0 ||
+      streamSegments.value.some(seg => seg.type === 'tool-group')
+    if (!sawToolBoundary) return raw
+
+    if (raw === streamRaw.value) return ''
+    if (raw.startsWith(streamRaw.value)) return raw.slice(streamRaw.value.length)
+    return raw
+  }
+
   function appendDelta(text: string) {
     if (options.aborted.value) return
+    const deltaText = normalizeIncomingTextDelta(text)
+    if (!deltaText) return
     if (!isStreaming.value) startStreaming()
     setStreamActivity('Writing reply', `write:${streamRound.value}`)
-    streamRaw.value += text
+    streamRaw.value += deltaText
 
     const lastSegment = streamSegments.value[streamSegments.value.length - 1]
     if (!lastSegment || lastSegment.type !== 'text') {
-      streamSegments.value.push({ type: 'text', raw: text, html: '', dirty: true })
+      streamSegments.value.push({ type: 'text', raw: deltaText, html: '', dirty: true })
     } else {
-      lastSegment.raw = (lastSegment.raw || '') + text
+      lastSegment.raw = (lastSegment.raw || '') + deltaText
       lastSegment.dirty = true
     }
 
-    if (useReducer.value) appendFrame({ kind: 'text', text })
+    if (useReducer.value) appendFrame({ kind: 'text', text: deltaText })
     scheduleRender()
   }
 

--- a/src/opensquilla/engine/turn_runner/stream_consumer_stage.py
+++ b/src/opensquilla/engine/turn_runner/stream_consumer_stage.py
@@ -270,6 +270,29 @@ class StreamConsumerStageInput:
 # Per-event handler classes
 # ---------------------------------------------------------------------------
 
+def _has_tool_boundary(state: _StreamState) -> bool:
+    return any(
+        segment.get("type") in {"tool_use", "tool_result"}
+        for segment in state.turn_segments
+    )
+
+
+def _normalize_cumulative_text_delta(text: str, state: _StreamState) -> str:
+    """Convert a post-tool cumulative text snapshot back into a delta."""
+
+    if not text or not _has_tool_boundary(state):
+        return text
+
+    accumulated_text = "".join(state.final_text_parts)
+    if not accumulated_text:
+        return text
+    if text == accumulated_text:
+        return ""
+    if text.startswith(accumulated_text):
+        return text[len(accumulated_text) :]
+    return text
+
+
 class _TextDeltaHandler:
     """Accumulate streamed text deltas into the final-text and current-text buffers."""
 
@@ -278,7 +301,10 @@ class _TextDeltaHandler:
         event: TextDeltaEvent,
         state: _StreamState,
     ) -> TextDeltaEvent:
-        cleaned_delta = state.protocol_text_guard.push(event.text)
+        cleaned_delta = _normalize_cumulative_text_delta(
+            state.protocol_text_guard.push(event.text),
+            state,
+        )
         if cleaned_delta:
             state.final_text_parts.append(cleaned_delta)
             state.current_text_parts.append(cleaned_delta)

--- a/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
@@ -340,6 +340,78 @@ def test_text_delta_handler_holds_split_malformed_tool_protocol_html() -> None:
     assert "<tvoe" not in "".join(state.final_text_parts)
 
 
+def test_text_delta_handler_strips_cumulative_post_tool_snapshot() -> None:
+    state = _make_state()
+    text_handler = _TextDeltaHandler()
+    text_handler.handle(TextDeltaEvent(text="prefix"), state)
+    _ToolUseStartHandler().handle(
+        ToolUseStartEvent(tool_use_id="tool-1", tool_name="web_search"),
+        state,
+    )
+    _ToolResultHandler().handle(
+        ToolResultEvent(tool_use_id="tool-1", tool_name="web_search", result="ok"),
+        state,
+    )
+
+    out = text_handler.handle(TextDeltaEvent(text="prefixsuffix"), state)
+
+    assert out.text == "suffix"
+    assert state.final_text_parts == ["prefix", "suffix"]
+    assert state.current_text_parts == ["suffix"]
+
+
+def test_text_delta_handler_preserves_plain_post_tool_delta() -> None:
+    state = _make_state()
+    text_handler = _TextDeltaHandler()
+    text_handler.handle(TextDeltaEvent(text="prefix"), state)
+    _ToolUseStartHandler().handle(
+        ToolUseStartEvent(tool_use_id="tool-1", tool_name="web_search"),
+        state,
+    )
+    _ToolResultHandler().handle(
+        ToolResultEvent(tool_use_id="tool-1", tool_name="web_search", result="ok"),
+        state,
+    )
+
+    out = text_handler.handle(TextDeltaEvent(text="suffix"), state)
+
+    assert out.text == "suffix"
+    assert state.final_text_parts == ["prefix", "suffix"]
+    assert state.current_text_parts == ["suffix"]
+
+
+def test_text_delta_handler_preserves_cumulative_text_before_tool_boundary() -> None:
+    state = _make_state()
+    handler = _TextDeltaHandler()
+    handler.handle(TextDeltaEvent(text="prefix"), state)
+
+    out = handler.handle(TextDeltaEvent(text="prefixsuffix"), state)
+
+    assert out.text == "prefixsuffix"
+    assert state.final_text_parts == ["prefix", "prefixsuffix"]
+    assert state.current_text_parts == ["prefix", "prefixsuffix"]
+
+
+def test_text_delta_handler_drops_duplicate_post_tool_snapshot() -> None:
+    state = _make_state()
+    text_handler = _TextDeltaHandler()
+    text_handler.handle(TextDeltaEvent(text="prefix"), state)
+    _ToolUseStartHandler().handle(
+        ToolUseStartEvent(tool_use_id="tool-1", tool_name="web_search"),
+        state,
+    )
+    _ToolResultHandler().handle(
+        ToolResultEvent(tool_use_id="tool-1", tool_name="web_search", result="ok"),
+        state,
+    )
+
+    out = text_handler.handle(TextDeltaEvent(text="prefix"), state)
+
+    assert out.text == ""
+    assert state.final_text_parts == ["prefix"]
+    assert state.current_text_parts == []
+
+
 def test_tool_use_start_handler_drops_tool_scaffold_text_segment() -> None:
     state = _make_state()
     text_handler = _TextDeltaHandler()


### PR DESCRIPTION
## Summary
- normalize cumulative text snapshots after tool boundaries in the shared stream consumer
- guard the current Vue live stream renderer against post-tool prefix replay
- add backend and Vue regression coverage for cumulative snapshots, duplicate snapshots, and plain additive deltas

## Branch target
main

## Linked issue
Refs #108
Supersedes #224

## Release note
Bug fix: live chat no longer repeats pre-tool text when a provider emits a cumulative text snapshot after a tool call.

## Tests
- uv run pytest tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py -q
- npm run test:unit -- src/composables/chat/useChatStream.render.test.ts
- npm run typecheck

## Safety notes
- Preserves additive text deltas unchanged.
- Only strips exact prefix replay after a tool boundary has been observed.
- Does not change the wire protocol or provider event producer.

## Third-party origin
None