### PR TITLE
Preserve line breaks in Web UI status text

### DIFF
--- a/opensquilla-webui/e2e/user-message-newlines.spec.ts
+++ b/opensquilla-webui/e2e/user-message-newlines.spec.ts
@@ -34,6 +34,18 @@ async function seedMultilineUserHistory(page: Page) {
                 id: 'msg-user-newlines',
                 timestamp: Math.floor(Date.now() / 1000) - 60,
               },
+              {
+                role: 'system',
+                text: '连接提示第一行\n连接提示第二行',
+                id: 'msg-system-newlines',
+                timestamp: Math.floor(Date.now() / 1000) - 45,
+              },
+              {
+                role: 'error',
+                text: '错误详情第一行\n错误详情第二行',
+                id: 'msg-error-newlines',
+                timestamp: Math.floor(Date.now() / 1000) - 30,
+              },
             ],
             has_more: false,
           },
@@ -72,4 +84,18 @@ test('user message bubbles preserve authored line breaks', async ({ page }) => {
   const bubble = page.locator('.msg-user-bubble').first()
   await expect(bubble).toContainText('你好~\n我测试一下换行功能~\n你好~')
   await expect(bubble).toHaveCSS('white-space', 'pre-wrap')
+})
+
+test('system and error message text preserve authored line breaks', async ({ page }) => {
+  await seedMultilineUserHistory(page)
+  await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(SESSION_KEY))
+  await page.waitForSelector('.conn-pill', { timeout: 10000 })
+
+  const systemText = page.locator('.msg-system__text').first()
+  await expect(systemText).toContainText('连接提示第一行\n连接提示第二行')
+  await expect(systemText).toHaveCSS('white-space', 'pre-wrap')
+
+  const errorText = page.locator('.msg-error-card__text').first()
+  await expect(errorText).toContainText('错误详情第一行\n错误详情第二行')
+  await expect(errorText).toHaveCSS('white-space', 'pre-wrap')
 })

--- a/opensquilla-webui/src/components/chat/SystemMessage.vue
+++ b/opensquilla-webui/src/components/chat/SystemMessage.vue
@@ -24,7 +24,7 @@
         </details>
       </template>
       <template v-else-if="message.text">
-        {{ message.text }}
+        <span class="msg-system__text">{{ message.text }}</span>
       </template>
       <time v-if="timeIso" class="msg-system-time" :datetime="timeIso" :title="timeFull">{{ timeAbs }}</time>
     </div>
@@ -72,6 +72,11 @@ const timeFull = computed(() => fullTime(props.message.ts))
 .msg-system-label {
   font-weight: 600;
   margin-right: 0.375rem;
+}
+
+.msg-system__text {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 /* Quiet, hover-revealed timestamp on the centered status pill. */
@@ -138,7 +143,8 @@ const timeFull = computed(() => fullTime(props.message.ts))
   font-size: 0.8125rem;
   color: var(--text-muted);
   line-height: 1.5;
-  word-break: break-word;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .msg-error-card__time {
@@ -197,6 +203,8 @@ const timeFull = computed(() => fullTime(props.message.ts))
   background: var(--bg-hover);
   border-radius: 0.25rem;
   font-size: 0.8125rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   overflow-x: auto;
   max-height: 200px;
   overflow-y: auto;

--- a/opensquilla-webui/src/components/sessions/SessionInspectDrawer.vue
+++ b/opensquilla-webui/src/components/sessions/SessionInspectDrawer.vue
@@ -520,7 +520,9 @@ onUnmounted(() => {
   line-height: 1.5;
   margin: 0;
   overflow: hidden;
+  overflow-wrap: anywhere;
   padding: var(--sp-2) var(--sp-4) var(--sp-3);
+  white-space: pre-wrap;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
 }


### PR DESCRIPTION
## Scope

- Preserve authored line breaks in Web UI system, error, and subagent status text.
- Preserve line breaks in session inspect snippets.
- Extend the existing newline regression spec beyond normal user bubbles.

## Branch target

main

## Linked issue

None

## Release note status

Fixed: Web UI status/error text now preserves authored line breaks instead of visually collapsing them.

## Test results

- npm run typecheck
- OPENSQUILLA_WEBUI_BASE_URL=http://127.0.0.1:4173 npm run test:e2e -- e2e/user-message-newlines.spec.ts --project=chromium

## Safety notes

UI-only rendering/CSS change. No runtime data, transcripts, credentials, or provider behavior touched.

## Third-party origin details

None