### PR TITLE
fix(desktop): avoid reloading active control window

### DIFF
--- a/desktop/electron/scripts/verify-package.mjs
+++ b/desktop/electron/scripts/verify-package.mjs
@@ -199,7 +199,12 @@ async function verifyRuntime(root, label, { platform, executeCommands }) {
 }
 
 function verifyMainProcess(source, label) {
-  for (const expected of ['gatewayStartPromise', 'openOrResumeDesktopApp', 'ensureGatewayStarted']) {
+  for (const expected of [
+    'gatewayStartPromise',
+    'openOrResumeDesktopApp',
+    'ensureGatewayStarted',
+    'isCurrentWindowAtControlUi',
+  ]) {
     if (!source.includes(expected)) fail(`${label} main process is missing ${expected}`)
   }
 
@@ -215,6 +220,18 @@ function verifyMainProcess(source, label) {
   }
   if (!/second-instance[\s\S]{0,240}openOrResumeDesktopApp/.test(source)) {
     fail(`${label} main process second-instance handler does not route through openOrResumeDesktopApp`)
+  }
+
+  const loadCurrentIndex = source.indexOf('async function loadControlUiIntoCurrentWindow')
+  const controlGuardIndex = source.indexOf('isCurrentWindowAtControlUi(window, gatewayUrl)', loadCurrentIndex)
+  const controlLoadIndex = source.indexOf('loadControlUi(window, gatewayUrl)', loadCurrentIndex)
+  if (
+    loadCurrentIndex === -1
+    || controlGuardIndex === -1
+    || controlLoadIndex === -1
+    || controlGuardIndex > controlLoadIndex
+  ) {
+    fail(`${label} main process reloads the Control UI before checking whether it is already loaded`)
   }
 }
 

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -3088,6 +3088,22 @@ async function loadControlUi(window: BrowserWindow, gatewayUrl: string): Promise
   throw lastError ?? new Error(`Failed to load ${url}`)
 }
 
+function isCurrentWindowAtControlUi(window: BrowserWindow, gatewayUrl: string): boolean {
+  const currentUrl = window.webContents.getURL()
+  if (!currentUrl) return false
+
+  try {
+    const current = new URL(currentUrl)
+    const gateway = new URL(gatewayUrl)
+    return (
+      current.origin === gateway.origin
+      && (current.pathname === '/control' || current.pathname.startsWith('/control/'))
+    )
+  } catch {
+    return false
+  }
+}
+
 async function createMainWindow(): Promise<BrowserWindow> {
   if (mainWindow && !mainWindow.isDestroyed()) return mainWindow
 
@@ -3155,6 +3171,11 @@ async function loadControlUiIntoCurrentWindow(gatewayUrl: string): Promise<void>
   if (!window) return
 
   sendBootStatus('control')
+  if (isCurrentWindowAtControlUi(window, gatewayUrl)) {
+    sendBootStatus('ready')
+    return
+  }
+
   try {
     await loadControlUi(window, gatewayUrl)
   } catch (error) {

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -27,7 +27,10 @@ def test_desktop_resume_is_visible_first_and_single_flight() -> None:
     assert "function ensureGatewayStarted(): Promise<GatewayState>" in main_ts
     assert "gatewayStartPromise = startGateway().finally" in main_ts
     assert "gatewayStartPromise = null" in main_ts
-    assert "function isCurrentWindowAtControlUi(window: BrowserWindow, gatewayUrl: string): boolean" in main_ts
+    assert (
+        "function isCurrentWindowAtControlUi(window: BrowserWindow, gatewayUrl: string): boolean"
+        in main_ts
+    )
 
     assert resume.index("await createMainWindow()") < resume.index("ensureGatewayStarted()")
     assert "focusMainWindow()" in resume
@@ -48,9 +51,9 @@ def test_desktop_gateway_completion_uses_current_live_window() -> None:
     assert "if (!window) return" in load_current
     assert "if (window.isDestroyed()) return" in load_current
     assert "isCurrentWindowAtControlUi(window, gatewayUrl)" in load_current
-    assert load_current.index("isCurrentWindowAtControlUi(window, gatewayUrl)") < load_current.index(
-        "await loadControlUi(window, gatewayUrl)"
-    )
+    guard_index = load_current.index("isCurrentWindowAtControlUi(window, gatewayUrl)")
+    load_index = load_current.index("await loadControlUi(window, gatewayUrl)")
+    assert guard_index < load_index
     assert "current.pathname === '/control'" in main_ts
     assert "current.pathname.startsWith('/control/')" in main_ts
     assert "if (mainWindow === window) mainWindow = null" in main_ts

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -27,6 +27,7 @@ def test_desktop_resume_is_visible_first_and_single_flight() -> None:
     assert "function ensureGatewayStarted(): Promise<GatewayState>" in main_ts
     assert "gatewayStartPromise = startGateway().finally" in main_ts
     assert "gatewayStartPromise = null" in main_ts
+    assert "function isCurrentWindowAtControlUi(window: BrowserWindow, gatewayUrl: string): boolean" in main_ts
 
     assert resume.index("await createMainWindow()") < resume.index("ensureGatewayStarted()")
     assert "focusMainWindow()" in resume
@@ -46,6 +47,12 @@ def test_desktop_gateway_completion_uses_current_live_window() -> None:
     assert "const window = currentMainWindow()" in load_current
     assert "if (!window) return" in load_current
     assert "if (window.isDestroyed()) return" in load_current
+    assert "isCurrentWindowAtControlUi(window, gatewayUrl)" in load_current
+    assert load_current.index("isCurrentWindowAtControlUi(window, gatewayUrl)") < load_current.index(
+        "await loadControlUi(window, gatewayUrl)"
+    )
+    assert "current.pathname === '/control'" in main_ts
+    assert "current.pathname.startsWith('/control/')" in main_ts
     assert "if (mainWindow === window) mainWindow = null" in main_ts
 
 


### PR DESCRIPTION
## Summary
- skip reloading the Control UI when the current Electron window is already on the active gateway's /control route
- preserve Dock/App activation and second-instance resume behavior without losing renderer state
- add contract/package checks to prevent regressions

## Tests
- python3 -m pytest tests/test_desktop/test_electron_startup_contract.py
- cd desktop/electron && npm run build
- node --check desktop/electron/scripts/verify-package.mjs
- git diff --check