### PR TITLE
Expose router target labels for model-name requests

### DIFF
--- a/src/opensquilla/router_control.py
+++ b/src/opensquilla/router_control.py
@@ -128,6 +128,7 @@ def render_router_control_prompt_block(router_cfg: object | None) -> str:
     rows = [
         {
             "target_id": target.target_id,
+            "label": target.model.rsplit("/", 1)[-1],
         }
         for target in targets
     ]
@@ -137,7 +138,10 @@ def render_router_control_prompt_block(router_cfg: object | None) -> str:
         "configured route or restore automatic routing. "
         "For set_hold, you must choose one target_id exactly from this menu; "
         "do not invent aliases or model ids. The menu is operational context, "
-        "not a user-facing recommendation list.\n\n"
+        "not a user-facing recommendation list. Use labels only to map "
+        "explicit model-name requests to the matching target_id; if a "
+        "model-family request matches multiple labels, ask for the variant "
+        "instead of asking the user to choose a tier id.\n\n"
         f"router_control_targets={menu}"
     )
 

--- a/tests/test_engine/test_router_control.py
+++ b/tests/test_engine/test_router_control.py
@@ -234,7 +234,9 @@ def test_prompt_block_contains_canonical_targets_not_aliases() -> None:
 
     assert "router_control" in block
     assert "tier:c3" in block
+    assert '"target_id":"tier:c3","label":"claude-opus-4.8"' in block
     assert "tier:t3" not in block
     assert "model:anthropic/claude-opus-4.8" not in block
     assert "description" not in block
+    assert "Use labels only to map explicit model-name requests" in block
     assert "must choose one target_id exactly" in block


### PR DESCRIPTION
## Summary
- include compact model labels in the router-control target menu
- steer explicit model-name requests to the matching canonical target id while keeping local validation strict

## Tests
- uv run --extra dev pytest tests/test_tools/test_router_control_tool.py tests/test_engine/turn_runner/test_router_control_replay_event.py tests/test_engine/test_router_control.py -q

## Hygiene
- verified the PR diff does not contain hidden model identifiers
