### PR TITLE
Prepare OpenSquilla 0.4.1 release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@ Non-goals:
 
 ## Branch
 
-Base branch: main | dev (transition) | staging/collaboration
+Base branch: main | staging/collaboration
 
-Target exception: N/A | dev-transition | release | hotfix | staging/collaboration | maintainer-approved
+Target exception: N/A | release | hotfix | staging/collaboration | maintainer-approved
 
 ## Issue
 

--- a/.github/scripts/validate-pr-target-branch.sh
+++ b/.github/scripts/validate-pr-target-branch.sh
@@ -17,11 +17,6 @@ if [[ "${base_ref}" == "main" ]]; then
   exit 0
 fi
 
-if [[ "${base_ref}" == "dev" ]]; then
-  echo "Pull request targets dev during the main-default transition."
-  exit 0
-fi
-
 event_label_names() {
   if [[ -n "${PR_LABELS:-}" ]]; then
     tr ',' '\n' <<< "${PR_LABELS}"
@@ -77,7 +72,7 @@ has_allowed_label() {
 
 is_staging_branch() {
   case "${base_ref}" in
-    sandbox-* | integration/* | staging/* | release/*)
+    sandbox-* | integration/* | staging/* | release/* | hotfix/*)
       return 0
       ;;
   esac
@@ -87,14 +82,13 @@ is_staging_branch() {
 
 if is_staging_branch || has_allowed_label staging; then
   echo "Pull request targets a staging/collaboration branch."
-  echo "This is not a final integration path; final integration should target main, or dev during the transition window."
+  echo "This is not a final integration path; final integration should target main."
   exit 0
 fi
 
 {
   echo "::error title=Wrong PR target::Ordinary pull requests should target main."
-  echo "Use dev only for existing pull requests during the transition window or when maintainers explicitly request it."
-  echo "Use sandbox-*, integration/*, staging/*, release/*, or a maintainer-staging/collaboration label for maintainer collaboration PRs."
-  echo "Retarget this pull request to main, dev during transition, or an approved staging/collaboration branch."
+  echo "Use sandbox-*, integration/*, staging/*, release/*, hotfix/*, or a maintainer-staging/collaboration label for maintainer collaboration PRs."
+  echo "Retarget this pull request to main or an approved staging/collaboration branch."
 } >&2
 exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 "on":
   pull_request:
   push:
-    branches: [main, dev]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/issue-link-sync.yml
+++ b/.github/workflows/issue-link-sync.yml
@@ -3,7 +3,7 @@ name: Issue Link Sync
 "on":
   pull_request_target:
     types: [opened, reopened, edited, closed]
-    branches: [main, dev]
+    branches: [main]
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.4.1] - 2026-06-30
+
+### Added
+
 - `opensquilla uninstall` removes OpenSquilla across install methods (uv-tool,
   pip, pipx, and source; portable removes its venv; Docker and desktop print
   guided removal steps). It keeps your data by default — pass `--purge-state`,
@@ -16,6 +24,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   exact remove/keep/manual plan without touching anything. Deletion is contained
   to the OpenSquilla home; a relocated or shared root is refused. The desktop
   Settings → Runtime panel gains a matching "Danger zone".
+- The Control UI and desktop client now ship first-class localization for
+  English, Simplified Chinese, Japanese, French, German, and Spanish, including
+  first-paint desktop boot text, settings surfaces, and persisted language
+  selection.
 
 ### Changed
 
@@ -25,8 +37,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `OPENSQUILLA_GATEWAY_GRACEFUL_TIMEOUT`); on Windows, an owner-only
   `POST /api/system/shutdown` endpoint provides the same graceful stop where
   POSIX signals are unavailable.
+- OpenSquilla now treats `main` as the active development and release
+  integration branch, with release guidance and pull-request targeting language
+  aligned around `main`.
+- Desktop packaging now fails fast when SquillaRouter assets are missing or
+  still Git LFS pointer files, and the packaged gateway smoke tests exercise
+  coding mode, `code-task`, and the router runtime before release assets are
+  uploaded.
 
 ### Fixed
+
+- Install telemetry now skips CI and test environments before creating local
+  telemetry state or uploading install events, so GitHub Actions and pytest
+  runs do not count as user installs.
+- The Windows Electron app, installer, and uninstaller now use the OpenSquilla
+  icon.
+- Web UI fixes keep streaming turns, stale task events, session deletion,
+  settings restore, topbar connection state, status line breaks, and desktop
+  HTML artifact opening stable across refreshed sessions.
+- Provider and router fixes improve Volcengine and BytePlus profiles, macOS
+  router runtime diagnostics, and the target labels shown for model requests.
 
 ## [0.4.0] - 2026-06-27
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,9 @@ Thanks for improving OpenSquilla. Keep pull requests small, focused, and covered
 
 Open pull requests against `main` by default. OpenSquilla now uses `main` as the active integration branch for feature work, bug fixes, tests, documentation, and contributor changes.
 
-The `dev` branch remains available during the transition for existing pull
-requests and maintainer-directed compatibility work. When in doubt, target
-`main`; maintainers will ask you to retarget only when a temporary integration
-branch is needed.
-
-After a release, maintainers may start a new development cycle from the
-latest `main` release point. If the transition branch is retired, contributors
-with open `dev` pull requests will be asked to rebase or retarget.
+Use `release/*`, `hotfix/*`, `staging/*`, `integration/*`, `sandbox-*`, or a
+maintainer-approved staging/collaboration label only when maintainers request a
+temporary collaboration branch. When in doubt, target `main`.
 
 ## Linked Issues
 
@@ -25,12 +20,9 @@ Declare issue relationships in pull request descriptions with GitHub keywords:
 
 OpenSquilla keeps issue closure tied to the default branch. Merging a fixing
 pull request into `main` removes the linked-pull-request marker so the issue
-can follow GitHub's normal closing flow. During the transition, merging a
-fixing pull request into `dev` still marks the issue as `merged-to-dev` and
-`needs-verification`; the issue remains open until the fix reaches `main`.
-Maintainers may use `has-linked-pr` while work is still under review. If a
-linked pull request is closed without merging, the automation removes
-`has-linked-pr`.
+can follow GitHub's normal closing flow. Maintainers may use `has-linked-pr`
+while work is still under review. If a linked pull request is closed without
+merging, the automation removes `has-linked-pr`.
 
 ## Attribution On Squash Or Replay
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,16 @@ human-readable ledger together for contributor attribution. This file records
 release-surface community work that can be harder to see when a release is
 squash-merged or replayed onto `main`.
 
+## OpenSquilla 0.4.1
+
+The 0.4.1 release records new human contributor work after the 0.4.0
+attribution ledger was merged. It intentionally does not repeat the larger
+0.4.0 contributor list.
+
+| Contributor | 0.4.1 contribution | Evidence |
+| --- | --- | --- |
+| [@ab2ence](https://github.com/ab2ence) | Hardened install telemetry so CI and test environments are not counted as installs, and allowed desktop HTML artifacts to open natively. | [#348](https://github.com/opensquilla/opensquilla/pull/348), [#355](https://github.com/opensquilla/opensquilla/pull/355) |
+
 ## OpenSquilla 0.4.0
 
 The 0.4.0 release is prepared from current `dev` after `v0.3.1`. This section

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ OpenRouter, OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope,
 and 20+ other LLM providers with no change to your code or config
 schema.
 
-OpenSquilla 0.4.0 is the current release.
+OpenSquilla 0.4.1 is the current release.
 
 For task-oriented product documentation, start with the
 [OpenSquilla Product Guide](README.product.md) or the
@@ -55,9 +55,9 @@ Windows portable zip also has a `/releases/latest/download/` alias for
 the current release. Python wheel installs use versioned wheel filenames
 because installers validate the version embedded in the wheel filename.
 
-For 0.4.0 desktop use, prefer the signed desktop installers from the GitHub
-Release: `OpenSquilla-0.4.0-mac-arm64.dmg` on macOS and
-`OpenSquilla-0.4.0-win-x64.exe` on Windows. The Windows portable zip remains
+For 0.4.1 desktop use, prefer the signed desktop installers from the GitHub
+Release: `OpenSquilla-0.4.1-mac-arm64.dmg` on macOS and
+`OpenSquilla-0.4.1-win-x64.exe` on Windows. The Windows portable zip remains
 available as a legacy compatibility package for scripts and portable-folder
 workflows.
 
@@ -105,11 +105,11 @@ Install links: [Git](https://git-scm.com/downloads) ·
 
 ### Desktop installers
 
-The 0.4.0 desktop installers package the Vue control console and gateway
+The 0.4.1 desktop installers package the Vue control console and gateway
 runtime in an Electron shell.
 
-- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/OpenSquilla-0.4.0-mac-arm64.dmg>
-- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/OpenSquilla-0.4.0-win-x64.exe>
+- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/OpenSquilla-0.4.1-mac-arm64.dmg>
+- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/OpenSquilla-0.4.1-win-x64.exe>
 
 Quit any running OpenSquilla desktop app before upgrading. Existing
 `~/.opensquilla/config.toml` and session data are reused.
@@ -185,7 +185,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Install OpenSquilla** — the same command on every platform.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/opensquilla-0.4.1-py3-none-any.whl"
 ```
 
 This installs the OpenSquilla wheel from the release URL, then lets
@@ -209,7 +209,7 @@ opensquilla gateway run
 > a new terminal, or re-run the PATH line from step 1.
 
 For a fully pinned install, use the versioned wheel URL:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/opensquilla-0.4.1-py3-none-any.whl`.
 
 ### Install from source
 
@@ -573,36 +573,27 @@ settings live in `opensquilla.toml.example`.
 
 ---
 
-## What's New in 0.4.0
+## What's New in 0.4.1
 
-OpenSquilla 0.4.0 updates the daily control surfaces, workflow launch model,
-coding workflow, search providers, terminal preview path, and runtime hardening:
+OpenSquilla 0.4.1 is a maintenance release for the desktop and Control UI line:
 
-- **Refreshed Control UI** — the local console is easier to scan and operate,
-  with conversation navigation, a Settings modal, Sessions ledger, artifact
-  previews, share export, deliverables, turn trace, mobile tabs, and clearer
-  Skills, Usage, Cron, Logs, and Approvals areas.
-- **Manual MetaSkills with `/meta`** — MetaSkills no longer auto-trigger by
-  default. Use `/meta` to list workflows and `/meta <name>` to run one. Set
-  `meta_skill.auto_trigger = true` only when you intentionally want the older
-  automatic behavior.
-- **Coding mode and code-task** — coding mode can route code changes through
-  `opensquilla code-task`, which works in an isolated run directory, requires a
-  trusted-host confirmation, and verifies before persisting changes back to
-  source.
-- **Broader web search** — DuckDuckGo, Bocha, Brave, Tavily, and Exa are
-  runtime-supported search providers, with source-backed `web_search` and
-  lightweight `web_discover` roles.
-- **OpenTUI preview backend** — the stable Python-native terminal backend stays
-  the default, while OpenTUI is available as an explicit preview path with
-  Router HUD and replay benchmark documentation.
-- **Provider and safety hardening** — `openai_responses` exposes OpenAI's native
-  Responses API shape alongside `openai`; provider stream parsing, Gemini
-  thought-signature replay, SSRF fake-IP DNS guidance, session recovery,
-  artifact handling, and approval event delivery are tightened across surfaces.
+- **Desktop reliability** - packaged gateway checks now cover Coding mode,
+  `code-task`, and SquillaRouter startup, and desktop window/artifact handling
+  is more stable.
+- **Six-language client support** - the Control UI and desktop client support
+  English, Simplified Chinese, Japanese, French, German, and Spanish across
+  first-paint and settings surfaces.
+- **Coding mode and router packaging** - desktop builds fail fast if router
+  assets are missing or still Git LFS pointers, preventing degraded release
+  packages.
+- **Telemetry and Windows polish** - install telemetry skips CI and test
+  environments, and Windows desktop assets use the OpenSquilla logo.
+- **Mainline governance** - ordinary pull requests and release integration are
+  aligned around `main`, with maintainer branches reserved for release, hotfix,
+  staging, integration, and sandbox work.
 
 Full notes: [`CHANGELOG.md`](CHANGELOG.md) ·
-[`docs/releases/0.4.0.md`](docs/releases/0.4.0.md).
+[`docs/releases/0.4.1.md`](docs/releases/0.4.1.md).
 
 ## What's New in 0.2.1
 

--- a/README.product.md
+++ b/README.product.md
@@ -14,7 +14,7 @@ This guide is the product and usage entry point. The existing
 1. Install OpenSquilla:
 
    ```sh
-   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
+   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/opensquilla-0.4.1-py3-none-any.whl"
    ```
 
 2. Configure your provider:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 0.4.1 | v0.4.1 | 2026-06-30 | Desktop reliability, six-language client support, telemetry accuracy, router packaging, and mainline governance |
 | 0.4.0 | v0.4.0 | 2026-06-27 | Control UI refresh, manual MetaSkills, coding mode, search expansion, and runtime hardening |
 | 0.3.0 | v0.3.0 | 2026-05-31 | MetaSkills, Health Doctor, tool compression, and docs release |
 | 0.2.1 | v0.2.1 | 2026-05-21 | 0.2 maintenance release |
@@ -15,7 +16,7 @@ Preview releases publish only versioned assets:
 - `opensquilla-<version>-py3-none-any.whl`
 - `SHA256SUMS`
 
-0.4.0 non-preview releases publish signed desktop installers plus the Python
+0.4.x non-preview releases publish signed desktop installers plus the Python
 wheel. The Windows portable zip is still published as a legacy compatibility
 asset for existing scripts and portable-folder workflows. Non-preview releases
 also publish a version-independent alias for the legacy Windows portable zip
@@ -43,23 +44,23 @@ use tag-pinned URLs such as:
 - `https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/OpenSquilla-0.2.0rc1-windows-x64-py312-recommended-portable.zip`
 - `https://github.com/opensquilla/opensquilla/releases/download/v0.2.0rc1/opensquilla-0.2.0rc1-py3-none-any.whl`
 
-0.4.0 install commands use versioned wheel URLs because Python installers
+0.4.x install commands use versioned wheel URLs because Python installers
 validate wheel filenames. The legacy Windows portable zip may use the
 `/releases/latest/download/` alias after the non-pre-release GitHub Release
 exists. Fully pinned URLs remain available for every primary asset:
 
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/OpenSquilla-0.4.0-mac-arm64.dmg`
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/OpenSquilla-0.4.0-win-x64.exe`
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/OpenSquilla-0.4.0-windows-x64-py312-recommended-portable.zip`
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/OpenSquilla-0.4.1-mac-arm64.dmg`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/OpenSquilla-0.4.1-win-x64.exe`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/OpenSquilla-0.4.1-windows-x64-py312-recommended-portable.zip`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/opensquilla-0.4.1-py3-none-any.whl`
 
 ## Release SOP
 
 1. Verify `git status` is clean.
 2. Update `CHANGELOG.md`: move entries from `[Unreleased]` to the release section; reopen empty `[Unreleased]`.
 3. Bump `pyproject.toml` and `uv.lock` to the release version.
-4. `git tag -a v0.4.0 -m "OpenSquilla 0.4.0"`
-5. `git push origin v0.4.0` (this triggers `.github/workflows/wheelhouse-release.yml`)
+4. `git tag -a v0.4.1 -m "OpenSquilla 0.4.1"`
+5. `git push origin v0.4.1` (this triggers `.github/workflows/wheelhouse-release.yml`)
 6. Wait for the Release Assets workflow → review the draft GitHub Release.
    For non-preview releases, confirm it contains desktop installers, the
    versioned wheel, the legacy Windows portable assets, `SHA256SUMS`, plus
@@ -68,10 +69,10 @@ exists. Fully pinned URLs remain available for every primary asset:
 8. Publish the GitHub Release, then run the post-publish tag URL checks:
 
    ```sh
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/OpenSquilla-0.4.0-mac-arm64.dmg
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/OpenSquilla-0.4.0-win-x64.exe
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/OpenSquilla-0.4.0-windows-x64-py312-recommended-portable.zip
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/OpenSquilla-0.4.1-mac-arm64.dmg
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/OpenSquilla-0.4.1-win-x64.exe
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/OpenSquilla-0.4.1-windows-x64-py312-recommended-portable.zip
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/opensquilla-0.4.1-py3-none-any.whl
    ```
 
 9. Run the post-publish latest URL check:

--- a/desktop/electron/package-lock.json
+++ b/desktop/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensquilla/desktop-electron",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensquilla/desktop-electron",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
         "@types/node": "^25.9.1",
         "electron": "^42.3.3",

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensquilla/desktop-electron",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "description": "Electron desktop shell for the OpenSquilla Control UI.",
   "repository": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,8 +67,7 @@ root release README with task-oriented guides.
 
 Documentation improvements are welcome. Start with
 [`contributing-docs.md`](contributing-docs.md) for docs-specific guidance, then
-open a small pull request against `main`. Existing `dev` pull requests may
-continue during the branch transition.
+open a small pull request against `main`.
 
 Fast paths:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ root release README with task-oriented guides.
 
 ## Surfaces and Operations
 
+- [`releases/0.4.1.md`](releases/0.4.1.md) - OpenSquilla 0.4.1 release notes.
 - [`releases/0.4.0.md`](releases/0.4.0.md) - OpenSquilla 0.4.0 release notes.
 - [`releases/0.3.0.md`](releases/0.3.0.md) - OpenSquilla 0.3.0 release notes.
 - [`channels.md`](channels.md) - supported messaging channels and setup flow.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -134,7 +134,7 @@ combined with `--repo`.
 install path. It requires Docker plus the `swebench` extra.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,swebench] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,swebench] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/opensquilla-0.4.1-py3-none-any.whl"
 opensquilla swebench pull django__django-16429 --dataset verified
 opensquilla swebench solve django__django-16429 --dataset verified --json
 opensquilla swebench eval predictions.jsonl --dataset verified

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -26,8 +26,7 @@ write access will submit this through a fork and pull request.
 2. If you are not sure of the fix, open a
    [documentation issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)
    with the affected page and expected outcome.
-3. Open documentation pull requests against `main`. Existing `dev` pull
-   requests may continue during the branch transition.
+3. Open documentation pull requests against `main`.
 4. Keep docs changes small and topic-focused.
 5. Use relative links for repository pages.
 6. Prefer concrete commands and examples over abstract descriptions.

--- a/docs/features/meta-skill-user-guide.md
+++ b/docs/features/meta-skill-user-guide.md
@@ -160,8 +160,8 @@ Plan a safe 20-minute balcony plant science project for a 7-year-old. Include
 materials, steps, safety notes, and a simple presentation outline.
 ```
 
-This is the normal 0.4.0 path. It is best for important, expensive, or easily
-confused tasks because the workflow launch is explicit.
+This is the normal 0.4 release-line path. It is best for important, expensive,
+or easily confused tasks because the workflow launch is explicit.
 
 ### Compatibility: Automatic Triggering
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -12,7 +12,7 @@ UI, CLI, channels, and gateway control console.
 Install OpenSquilla with the MCP extra when you need this bridge:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/opensquilla-0.4.1-py3-none-any.whl"
 ```
 
 Start the OpenSquilla gateway:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -176,7 +176,7 @@ opensquilla mcp-server run
 Install with:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/opensquilla-0.4.1-py3-none-any.whl"
 ```
 
 Use this when another MCP-capable client should access OpenSquilla-managed tools

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,7 +16,7 @@ UI, SquillaRouter, memory/search support, and safe local defaults.
 Install the current release wheel with the recommended extras:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.0/opensquilla-0.4.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/opensquilla-0.4.1-py3-none-any.whl"
 ```
 
 The `recommended` extra includes SquillaRouter dependencies and memory/search

--- a/docs/releases/0.4.1.md
+++ b/docs/releases/0.4.1.md
@@ -11,9 +11,9 @@ Existing gateway configuration and session data stay in place. Users upgrading
 from 0.4.0 should close any running desktop app or gateway process, install the
 0.4.1 package, and restart OpenSquilla.
 
-## What's Improved
+## ✨ What's Improved
 
-### Desktop and Coding mode reliability
+### 🖥️ Desktop and Coding mode reliability
 
 The desktop package now fails fast when SquillaRouter model assets are missing
 or still Git LFS pointer files, and packaged gateway smoke checks cover
@@ -21,13 +21,13 @@ or still Git LFS pointer files, and packaged gateway smoke checks cover
 published. Windows desktop cleanup wording and active-window reload behavior are
 also tightened.
 
-### Multilingual Control UI and client
+### 🌐 Multilingual Control UI and client
 
 The Control UI and desktop client now support English, Simplified Chinese,
 Japanese, French, German, and Spanish across first-paint desktop boot text,
 settings surfaces, connection state, and persisted language selection.
 
-### Telemetry, icons, and user-facing polish
+### 🧰 Telemetry, icons, and user-facing polish
 
 Install telemetry now skips GitHub Actions, pytest, and explicit test
 environments before creating telemetry state or uploading events. The Windows
@@ -36,7 +36,7 @@ improve streaming recovery, stale task isolation, settings restore behavior,
 session deletion, topbar layout, status line breaks, and HTML artifact opening
 from the desktop app.
 
-### Providers, router labels, and mainline governance
+### 🧭 Providers, router labels, and mainline governance
 
 Provider profile fixes cover Volcengine and BytePlus, macOS router runtime
 diagnostics are clearer, and model request logs expose router target labels.
@@ -46,18 +46,18 @@ hotfix, staging, integration, and sandbox work.
 
 ## Downloads
 
-Recommended desktop downloads:
+🖥️ Recommended desktop downloads:
 
 - macOS desktop installer: `OpenSquilla-0.4.1-mac-arm64.dmg`
 - macOS desktop zip: `OpenSquilla-0.4.1-mac-arm64.zip`
 - Windows desktop installer: `OpenSquilla-0.4.1-win-x64.exe`
 
-Terminal and automation downloads:
+⚙️ Terminal and automation downloads:
 
 - Python wheel: `opensquilla-0.4.1-py3-none-any.whl`
 - Checksums: `SHA256SUMS`
 
-Legacy compatibility downloads:
+🧳 Legacy compatibility downloads:
 
 - Legacy Windows portable, versioned: `OpenSquilla-0.4.1-windows-x64-py312-recommended-portable.zip`
 - Legacy Windows portable, stable alias: `OpenSquilla-windows-x64-portable.zip`
@@ -66,7 +66,7 @@ The legacy Windows portable assets remain available as legacy compatibility
 downloads for existing scripts and portable-folder workflows. New Windows
 desktop users should prefer `OpenSquilla-0.4.1-win-x64.exe`.
 
-Updater metadata:
+🔄 Updater metadata:
 
 - `latest-mac.yml`
 - `latest.yml`

--- a/docs/releases/0.4.1.md
+++ b/docs/releases/0.4.1.md
@@ -1,0 +1,107 @@
+# OpenSquilla 0.4.1
+
+## Overview
+
+OpenSquilla 0.4.1 is a maintenance release for the 0.4 desktop and Control UI
+line. It focuses on packaged desktop reliability, Web UI recovery, Coding mode
+and SquillaRouter packaging, installer telemetry accuracy, and the project move
+to `main` as the active development branch.
+
+Existing gateway configuration and session data stay in place. Users upgrading
+from 0.4.0 should close any running desktop app or gateway process, install the
+0.4.1 package, and restart OpenSquilla.
+
+## What's Improved
+
+### Desktop and Coding mode reliability
+
+The desktop package now fails fast when SquillaRouter model assets are missing
+or still Git LFS pointer files, and packaged gateway smoke checks cover
+`code-task`, Coding mode support, and router startup before release assets are
+published. Windows desktop cleanup wording and active-window reload behavior are
+also tightened.
+
+### Multilingual Control UI and client
+
+The Control UI and desktop client now support English, Simplified Chinese,
+Japanese, French, German, and Spanish across first-paint desktop boot text,
+settings surfaces, connection state, and persisted language selection.
+
+### Telemetry, icons, and user-facing polish
+
+Install telemetry now skips GitHub Actions, pytest, and explicit test
+environments before creating telemetry state or uploading events. The Windows
+Electron app, installer, and uninstaller use the OpenSquilla logo. Web UI fixes
+improve streaming recovery, stale task isolation, settings restore behavior,
+session deletion, topbar layout, status line breaks, and HTML artifact opening
+from the desktop app.
+
+### Providers, router labels, and mainline governance
+
+Provider profile fixes cover Volcengine and BytePlus, macOS router runtime
+diagnostics are clearer, and model request logs expose router target labels.
+OpenSquilla now treats `main` as the ordinary development and integration
+branch; maintainer collaboration branches remain available for release,
+hotfix, staging, integration, and sandbox work.
+
+## Downloads
+
+Recommended desktop downloads:
+
+- macOS desktop installer: `OpenSquilla-0.4.1-mac-arm64.dmg`
+- macOS desktop zip: `OpenSquilla-0.4.1-mac-arm64.zip`
+- Windows desktop installer: `OpenSquilla-0.4.1-win-x64.exe`
+
+Terminal and automation downloads:
+
+- Python wheel: `opensquilla-0.4.1-py3-none-any.whl`
+- Checksums: `SHA256SUMS`
+
+Legacy compatibility downloads:
+
+- Legacy Windows portable, versioned: `OpenSquilla-0.4.1-windows-x64-py312-recommended-portable.zip`
+- Legacy Windows portable, stable alias: `OpenSquilla-windows-x64-portable.zip`
+
+The legacy Windows portable assets remain available as legacy compatibility
+downloads for existing scripts and portable-folder workflows. New Windows
+desktop users should prefer `OpenSquilla-0.4.1-win-x64.exe`.
+
+Updater metadata:
+
+- `latest-mac.yml`
+- `latest.yml`
+- `*.blockmap`
+
+## Upgrading from 0.4.0
+
+If OpenSquilla was installed with `uv tool install`, reinstall 0.4.1 over the
+existing tool environment:
+
+```sh
+uv tool install --python 3.12 --force --reinstall-package opensquilla \
+  "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.4.1/opensquilla-0.4.1-py3-none-any.whl"
+```
+
+The release installers use the same forced reinstall path. Close any running
+OpenSquilla gateway or desktop app before upgrading, then restart it after the
+install. Existing `~/.opensquilla/config.toml` and session data are reused.
+
+Desktop users should quit the running desktop app before replacing it. macOS
+users install the `.dmg` by dragging OpenSquilla into Applications. Windows
+users run the `.exe` installer.
+
+Legacy Windows portable users should extract the 0.4.1 portable zip to a fresh
+folder, or replace the whole extracted 0.4.0 folder while the gateway is
+stopped. Do not copy only individual files from the new zip into an old
+portable tree.
+
+## Acknowledgements
+
+Thanks to the contributors whose pull-request work is newly present in the
+0.4.1 release surface:
+
+- [@ab2ence](https://github.com/ab2ence) for install telemetry CI/test
+  environment skipping and desktop HTML artifact native-open support.
+
+See [`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/main/CONTRIBUTORS.md)
+for the full attribution ledger and PR evidence.

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -5,7 +5,7 @@ approvals, channels, logs, agents, usage, and operational status. It is the
 best surface when you want browser-based chat, visible tool activity, durable
 approvals, and a quick view of runtime health.
 
-The default Control UI in 0.4.0 is the Vue product UI served by the gateway.
+The default Control UI in the 0.4 release line is the Vue product UI served by the gateway.
 The legacy frontend is kept only as a maintainer rollback fallback, not as the
 normal user path.
 

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v0.4.0'
+$defaultVersion = 'v0.4.1'
 $repoSlug = if ($env:OPENSQUILLA_REPOSITORY) { $env:OPENSQUILLA_REPOSITORY } else { 'opensquilla/opensquilla' }
 $pythonVersion = if ($env:OPENSQUILLA_PYTHON_VERSION) { $env:OPENSQUILLA_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -94,7 +94,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.4.0. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.4.1. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v0.4.0"
+default_version="v0.4.1"
 repo_slug="${OPENSQUILLA_REPOSITORY:-opensquilla/opensquilla}"
 python_version="${OPENSQUILLA_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v0.4.0|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v0.4.1|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  OPENSQUILLA_VERSION=v0.4.0
+  OPENSQUILLA_VERSION=v0.4.1
   OPENSQUILLA_INSTALL_PROFILE=recommended|core
   OPENSQUILLA_INSTALL_EXTRAS=matrix
   OPENSQUILLA_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported OPENSQUILLA_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.4.0." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.4.1." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensquilla"
-version = "0.4.0"
+version = "0.4.1"
 description = "OpenSquilla — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -171,7 +171,7 @@ def _validate_pr_target(
     )
 
 
-def test_default_ci_blocks_pull_requests_and_main_and_dev_pushes() -> None:
+def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     ci_path = WORKFLOW_DIR / "ci.yml"
     if not ci_path.exists():
         return
@@ -180,7 +180,7 @@ def test_default_ci_blocks_pull_requests_and_main_and_dev_pushes() -> None:
     text = ci_path.read_text(encoding="utf-8")
 
     assert {"pull_request", "push", "workflow_dispatch"} <= _trigger_keys(data)
-    assert "branches: [main, dev]" in text
+    assert "branches: [main]" in text
     assert "PYTHONPATH: ${{ github.workspace }}" in text
     assert "Configure runtime directories" in text
     assert 'OPENSQUILLA_STATE_DIR=%s/opensquilla-state\\n' in text
@@ -223,13 +223,13 @@ def test_pr_target_validator_allows_main_pull_requests(tmp_path: Path) -> None:
     assert "Pull request targets main." in result.stdout
 
 
-def test_pr_target_validator_allows_dev_pull_requests_during_transition(
+def test_pr_target_validator_blocks_dev_pull_requests(
     tmp_path: Path,
 ) -> None:
     result = _validate_pr_target(tmp_path, base="dev")
 
-    assert result.returncode == 0
-    assert "main-default transition" in result.stdout
+    assert result.returncode == 1
+    assert "Ordinary pull requests should target main" in result.stderr
 
 
 def test_pr_target_validator_allows_docs_only_main_pull_requests(
@@ -377,7 +377,7 @@ def test_issue_link_sync_tracks_open_and_closed_final_prs_from_trusted_base() ->
 
     pull_request_target = data["on"]["pull_request_target"]
     assert set(pull_request_target["types"]) == {"opened", "reopened", "edited", "closed"}
-    assert pull_request_target["branches"] == ["main", "dev"]
+    assert pull_request_target["branches"] == ["main"]
     assert "ref: ${{ github.event.pull_request.base.sha }}" in text
     assert "persist-credentials: false" in text
     assert "issues: write" in text

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -7,7 +7,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v0.4.0"
+CURRENT_RELEASE_TAG = "v0.4.1"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_public_release_hygiene.py
+++ b/tests/test_public_release_hygiene.py
@@ -150,10 +150,10 @@ def test_pull_request_template_uses_structured_governance_fields() -> None:
     required_phrases = [
         "Scope boundary",
         "Non-goals",
-        "Base branch: main | dev (transition) | staging/collaboration",
+        "Base branch: main | staging/collaboration",
         (
-            "Target exception: N/A | dev-transition | release | hotfix | "
-            "staging/collaboration | maintainer-approved"
+            "Target exception: N/A | release | hotfix | staging/collaboration "
+            "| maintainer-approved"
         ),
         "Linked issue: Fixes #... | Refs #... | None",
         "If None, reason",

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -4,7 +4,7 @@ import json
 import tomllib
 from pathlib import Path
 
-CURRENT_VERSION = "0.4.0"
+CURRENT_VERSION = "0.4.1"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 PREVIEW_VERSION = "0.2.0rc1"
 PREVIEW_TAG = f"v{PREVIEW_VERSION}"
@@ -210,14 +210,35 @@ def test_release_workflow_marks_preview_tags_as_prereleases() -> None:
     assert "opensquilla-latest-py3-none-any.whl" not in workflow
 
 
-def test_040_release_notes_prioritize_desktop_and_legacy_portable() -> None:
+def test_historical_040_release_notes_remain_available() -> None:
     notes = Path("docs/releases/0.4.0.md").read_text(encoding="utf-8")
+
+    assert "# OpenSquilla 0.4.0" in notes
+    assert "OpenSquilla-0.4.0-mac-arm64.dmg" in notes
+
+
+def test_current_release_notes_prioritize_desktop_and_legacy_portable() -> None:
+    notes = Path(f"docs/releases/{CURRENT_VERSION}.md").read_text(encoding="utf-8")
 
     assert "## Downloads" in notes
     assert f"OpenSquilla-{CURRENT_VERSION}-mac-arm64.dmg" in notes
+    assert f"OpenSquilla-{CURRENT_VERSION}-mac-arm64.zip" in notes
     assert f"OpenSquilla-{CURRENT_VERSION}-win-x64.exe" in notes
+    assert f"opensquilla-{CURRENT_VERSION}-py3-none-any.whl" in notes
     assert "Legacy Windows portable" in notes
     assert "legacy compatibility" in notes
+    assert "## Upgrading from 0.4.0" in notes
     assert "## Acknowledgements" in notes
     assert "@ab2ence" in notes
-    assert "@nice-code-la" in notes
+
+
+def test_current_contributor_ledger_records_041_attribution_without_repeating_040() -> None:
+    ledger = Path("CONTRIBUTORS.md").read_text(encoding="utf-8")
+    section = ledger.split("## OpenSquilla 0.4.1", 1)[1].split("## OpenSquilla 0.4.0", 1)[0]
+
+    assert "@ab2ence" in section
+    assert "#348" in section
+    assert "#355" in section
+    assert "@nice-code-la" not in section
+    assert "Codex" not in section
+    assert "Claude Code" not in section

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import tomllib
 from pathlib import Path
 
@@ -188,6 +189,34 @@ def test_readme_release_install_uses_latest_assets_and_pinned_alternative() -> N
     assert "Release install commands use published GitHub release assets" in readme
 
 
+def test_user_facing_install_docs_use_current_release_wheel() -> None:
+    current_wheel_url = (
+        f"releases/download/{CURRENT_TAG}/opensquilla-{CURRENT_VERSION}-py3-none-any.whl"
+    )
+    wheel_url_pattern = re.compile(
+        r"releases/download/v(?P<tag_version>[^/]+)/"
+        r"opensquilla-(?P<file_version>[^/]+)-py3-none-any\.whl"
+    )
+    install_docs = [
+        Path("README.md"),
+        Path("README.product.md"),
+        Path("docs/quickstart.md"),
+        Path("docs/cli.md"),
+        Path("docs/mcp-server.md"),
+        Path("docs/operations.md"),
+    ]
+
+    for path in install_docs:
+        text = path.read_text(encoding="utf-8")
+        wheel_urls = list(wheel_url_pattern.finditer(text))
+
+        assert wheel_urls, f"{path} must include a pinned release wheel URL"
+        assert current_wheel_url in text, f"{path} must install from {CURRENT_TAG}"
+        for match in wheel_urls:
+            assert match.group("tag_version") == CURRENT_VERSION
+            assert match.group("file_version") == CURRENT_VERSION
+
+
 def test_release_installers_default_to_current_tag() -> None:
     for path in [Path("install.sh"), Path("install.ps1")]:
         text = path.read_text(encoding="utf-8")
@@ -230,6 +259,13 @@ def test_current_release_notes_prioritize_desktop_and_legacy_portable() -> None:
     assert "## Upgrading from 0.4.0" in notes
     assert "## Acknowledgements" in notes
     assert "@ab2ence" in notes
+
+
+def test_docs_index_links_current_release_notes() -> None:
+    index = Path("docs/README.md").read_text(encoding="utf-8")
+
+    assert f"releases/{CURRENT_VERSION}.md" in index
+    assert "releases/0.4.0.md" in index
 
 
 def test_current_contributor_ledger_records_041_attribution_without_repeating_040() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1993,7 +1993,7 @@ wheels = [
 
 [[package]]
 name = "opensquilla"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Scope

Prepare the OpenSquilla 0.4.1 stable patch release from `main`.

- Bump Python, uv lock, Electron, and installer release metadata to 0.4.1.
- Add 0.4.1 release notes, README install links, changelog, release ledger, and contributor attribution.
- Record only the new 0.4.1 contributor attribution for @ab2ence (#348, #355).
- Retire `dev` as an ordinary PR target while keeping maintainer staging/release/hotfix/integration/sandbox exceptions.

## Branch Target

Base branch: main
Target exception: N/A

## Linked Issue

None. Release preparation and branch-governance cleanup.

## Release Note

0.4.1 release prep: desktop reliability, six-language client support, install telemetry CI skip, Windows icon polish, Coding mode/router packaging checks, and mainline governance.

## Tests

- `uv run --extra dev pytest tests/test_release_consistency.py tests/test_install_scripts.py tests/test_ci/test_workflows.py tests/test_public_release_hygiene.py -q`
- `uv run --extra dev pytest tests/test_observability/test_install_telemetry.py tests/test_engine/test_coding_mode.py tests/test_gateway/test_control_ui_locale.py -q`
- `uv build --wheel`
- `uv run --extra dev ruff check tests/test_release_consistency.py tests/test_install_scripts.py tests/test_ci/test_workflows.py tests/test_public_release_hygiene.py`
- `git diff --check`

## Safety Notes

No runtime secrets, transcripts, memory data, or local artifacts are included. The release is still draft-gated after tag creation; final GitHub Release publication remains a maintainer confirmation step.

## Third-Party Origin

None.
