### PR TITLE
Fix Windows desktop release gateway bundling

### DIFF
--- a/.github/workflows/wheelhouse-release.yml
+++ b/.github/workflows/wheelhouse-release.yml
@@ -364,9 +364,11 @@ jobs:
 
       - name: Build Windows installer
         working-directory: desktop/electron
+        shell: bash
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
         run: |
+          set -euo pipefail
           npm run build:web
           npm run build:gateway
           npm run build

--- a/desktop/electron/scripts/build-gateway.mjs
+++ b/desktop/electron/scripts/build-gateway.mjs
@@ -118,10 +118,14 @@ function addBinaryArg(sourcePath, destinationDir) {
   return ['--add-binary', `${sourcePath}${addDataSeparator}${destinationDir}`]
 }
 
-function platformLightgbmLibraryName() {
-  if (process.platform === 'win32') return 'lib_lightgbm.dll'
-  if (process.platform === 'darwin') return 'lib_lightgbm.dylib'
-  return 'lib_lightgbm.so'
+function platformLightgbmLibraryPath() {
+  if (process.platform === 'win32') return join('bin', 'lib_lightgbm.dll')
+  if (process.platform === 'darwin') return join('lib', 'lib_lightgbm.dylib')
+  return join('lib', 'lib_lightgbm.so')
+}
+
+function platformLightgbmBundleDir() {
+  return process.platform === 'win32' ? 'lightgbm/bin' : 'lightgbm/lib'
 }
 
 function readFileHead(path, bytes = 96) {
@@ -210,8 +214,8 @@ mkdirSync(runtimeGatewayDir, { recursive: true })
 mkdirSync(pyinstallerWorkDir, { recursive: true })
 
 const lightgbmBinaryArgs = addBinaryArg(
-  pythonPackageFile('lightgbm', join('lib', platformLightgbmLibraryName())),
-  'lightgbm/lib',
+  pythonPackageFile('lightgbm', platformLightgbmLibraryPath()),
+  platformLightgbmBundleDir(),
 )
 const macOpenMpBinaryArgs = process.platform === 'darwin'
   ? addBinaryArg(pythonPackageFile('sklearn', join('.dylibs', 'libomp.dylib')), '.')

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -152,6 +152,9 @@ def test_desktop_gateway_build_and_verifier_cover_runtime_capabilities() -> None
     assert "'--collect-all',\n  'sklearn'" not in build_gateway
     assert "'--collect-all',\n  'lightgbm'" not in build_gateway
     assert "'--collect-binaries',\n  'sklearn'" in build_gateway
+    assert "join('bin', 'lib_lightgbm.dll')" in build_gateway
+    assert "platformLightgbmBundleDir()" in build_gateway
+    assert "'lightgbm/bin'" in build_gateway
     assert "lib_lightgbm.dylib" in build_gateway
     assert "libomp.dylib" in build_gateway
     assert "Git LFS pointer file, not the real router artifact" in build_gateway
@@ -170,6 +173,21 @@ def test_desktop_gateway_build_and_verifier_cover_runtime_capabilities() -> None
     assert "code-task', 'smoke-imports'" in verifier
     assert "code-task', 'smoke-router'" in verifier
     assert "timeout: 120000" in verifier
+
+
+def test_windows_release_workflow_fails_fast_after_gateway_build_failure() -> None:
+    workflow = _read(".github/workflows/wheelhouse-release.yml")
+    windows_build = _section(
+        workflow,
+        "      - name: Build Windows installer",
+        "      - name: Verify Electron package",
+    )
+
+    assert "shell: bash" in windows_build
+    assert "set -euo pipefail" in windows_build
+    assert windows_build.index("npm run build:gateway") < windows_build.index(
+        "          npm run build\n"
+    )
 
 
 def test_desktop_native_artifact_open_allows_active_documents_with_file_extensions() -> None:


### PR DESCRIPTION
## Scope

Fix the 0.4.1 release asset workflow after the first tag run exposed Windows desktop gateway bundling failures.

- Bundle the Windows LightGBM runtime from `lightgbm/bin/lib_lightgbm.dll`, matching the upstream wheel layout and loader path.
- Keep macOS/Linux LightGBM bundling on `lightgbm/lib`.
- Make the Windows Electron release build fail fast if `npm run build:gateway` fails, instead of continuing to package an empty runtime.

## Branch Target

Base branch: main
Target exception: N/A

## Linked Issue

None. Release-blocking packaging fix for v0.4.1.

## Release Note

Fixes Windows desktop release packaging for OpenSquilla 0.4.1 assets.

## Tests

- `uv run --extra dev pytest tests/test_desktop/test_electron_startup_contract.py tests/test_release_consistency.py tests/test_ci/test_workflows.py -q`
- `uv run --extra dev ruff check tests/test_desktop/test_electron_startup_contract.py tests/test_release_consistency.py tests/test_ci/test_workflows.py`
- `node --check desktop/electron/scripts/build-gateway.mjs`
- `git diff --check`

## Safety Notes

No secrets, runtime data, transcripts, or local artifacts are included. The existing `v0.4.1` tag points to the pre-fix release commit and will need to be moved only after this fix lands and main checks pass.

## Third-Party Origin

None.
