### PR TITLE
Relax packaged gateway smoke startup deadline

### DIFF
--- a/desktop/electron/scripts/smoke-gateway.mjs
+++ b/desktop/electron/scripts/smoke-gateway.mjs
@@ -13,7 +13,7 @@ const repoRoot = resolve(packageRoot, '..', '..')
 const desktopOutputDir = join(repoRoot, 'dist', 'desktop-electron')
 const sourceRuntimeGatewayDir = join(packageRoot, 'runtime', 'gateway')
 const binaryName = process.platform === 'win32' ? 'opensquilla-gateway.exe' : 'opensquilla-gateway'
-const deadlineMs = 30_000
+const deadlineMs = Number.parseInt(process.env.OPENSQUILLA_GATEWAY_SMOKE_TIMEOUT_MS || '90000', 10)
 const pollIntervalMs = 250
 const killGraceMs = 3_000
 const maxTailLines = 80

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -173,6 +173,10 @@ def test_desktop_gateway_build_and_verifier_cover_runtime_capabilities() -> None
     assert "code-task', 'smoke-imports'" in verifier
     assert "code-task', 'smoke-router'" in verifier
     assert "timeout: 120000" in verifier
+    assert "OPENSQUILLA_GATEWAY_SMOKE_TIMEOUT_MS" in _read(
+        "desktop/electron/scripts/smoke-gateway.mjs"
+    )
+    assert "'90000'" in _read("desktop/electron/scripts/smoke-gateway.mjs")
 
 
 def test_windows_release_workflow_fails_fast_after_gateway_build_failure() -> None:


### PR DESCRIPTION
## Scope

Fix the second 0.4.1 Release Assets blocker: macOS packaged gateway smoke can exceed the previous 30 second startup window even though the packaged gateway remains alive and continues initialization.

- Increase the packaged gateway smoke startup deadline to 90 seconds.
- Keep the deadline configurable with `OPENSQUILLA_GATEWAY_SMOKE_TIMEOUT_MS`.
- Add a desktop contract test covering the configurable release smoke timeout.

## Branch Target

Base branch: main
Target exception: N/A

## Linked Issue

None. Release-blocking packaging smoke fix for v0.4.1.

## Release Note

Fixes macOS desktop release smoke timing for OpenSquilla 0.4.1 assets.

## Tests

- `uv run --extra dev pytest tests/test_desktop/test_electron_startup_contract.py tests/test_release_consistency.py -q`
- `uv run --extra dev ruff check tests/test_desktop/test_electron_startup_contract.py tests/test_release_consistency.py`
- `node --check desktop/electron/scripts/smoke-gateway.mjs`
- `git diff --check`

## Safety Notes

No secrets, runtime data, transcripts, or local artifacts are included. The existing `v0.4.1` tag points to the previous release-fix commit and will need to be moved after this fix lands and main checks pass.

## Third-Party Origin

None.
