### PR TITLE
Fix web search source grounding

### DIFF
--- a/opensquilla-webui/src/components/chat/SourcesRow.vue
+++ b/opensquilla-webui/src/components/chat/SourcesRow.vue
@@ -34,6 +34,12 @@
             <span class="sources-row__favicon">{{ initialFor(source) }}</span>
           </span>
           <span class="sources-row__title">{{ source.title || source.domain }}</span>
+          <span
+            class="sources-row__status"
+            :class="`sources-row__status--${sourceTrust(source)}`"
+          >
+            {{ sourceTrustLabel(source) }}
+          </span>
           <span class="sources-row__domain">{{ source.domain }}</span>
         </a>
       </li>
@@ -58,6 +64,17 @@ interface SourceLink {
   url: string
   title: string
   domain: string
+  canonicalUrl?: string
+  provider?: string
+  fetched?: boolean
+  fetchStatus?: string
+}
+
+interface SourceMeta {
+  canonicalUrl?: string
+  provider?: string
+  fetched?: boolean
+  fetchStatus?: string
 }
 
 const props = defineProps<{
@@ -118,7 +135,42 @@ function domainFor(url: string): string {
   }
 }
 
-function addSource(out: SourceLink[], seen: Map<string, SourceLink>, url: unknown, title: unknown) {
+function sourceText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function sourceMeta(entry: Record<string, unknown>): SourceMeta {
+  const meta: SourceMeta = {}
+  const canonicalUrl = sourceText(entry.canonical_url) || sourceText(entry.canonicalUrl)
+  const provider = sourceText(entry.provider)
+  const fetchStatus = sourceText(entry.fetch_status) || sourceText(entry.fetchStatus)
+  if (canonicalUrl) meta.canonicalUrl = canonicalUrl
+  if (provider) meta.provider = provider
+  if (typeof entry.fetched === 'boolean') meta.fetched = entry.fetched
+  if (fetchStatus) meta.fetchStatus = fetchStatus
+  return meta
+}
+
+function mergeMeta(source: SourceLink, meta: SourceMeta) {
+  if (!source.canonicalUrl && meta.canonicalUrl) source.canonicalUrl = meta.canonicalUrl
+  if (!source.provider && meta.provider) source.provider = meta.provider
+  if (source.fetched !== true && meta.fetched === true) source.fetched = true
+  if (
+    meta.fetchStatus === 'ok' ||
+    !source.fetchStatus ||
+    source.fetchStatus === 'not_requested'
+  ) {
+    if (meta.fetchStatus) source.fetchStatus = meta.fetchStatus
+  }
+}
+
+function addSource(
+  out: SourceLink[],
+  seen: Map<string, SourceLink>,
+  url: unknown,
+  title: unknown,
+  meta: SourceMeta = {},
+) {
   if (typeof url !== 'string') return
   const trimmed = url.trim()
   // Persisted tool results compact long strings with a trailing '…'; a
@@ -131,9 +183,10 @@ function addSource(out: SourceLink[], seen: Map<string, SourceLink>, url: unknow
   const existing = seen.get(key)
   if (existing) {
     if (!existing.title && cleanTitle) existing.title = cleanTitle
+    mergeMeta(existing, meta)
     return
   }
-  const source: SourceLink = { url: trimmed, title: cleanTitle, domain }
+  const source: SourceLink = { url: trimmed, title: cleanTitle, domain, ...meta }
   seen.set(key, source)
   out.push(source)
 }
@@ -144,7 +197,13 @@ function extractSources(raw: unknown, out: SourceLink[], seen: Map<string, Sourc
   for (const item of raw) {
     if (item && typeof item === 'object') {
       const entry = item as Record<string, unknown>
-      addSource(out, seen, entry.url || entry.final_url || entry.canonical_url, entry.title)
+      addSource(
+        out,
+        seen,
+        entry.url || entry.final_url || entry.canonical_url,
+        entry.title,
+        sourceMeta(entry),
+      )
     }
   }
   return out.length - before
@@ -194,7 +253,7 @@ const derivedSources = computed<SourcePart[]>(() => {
         for (const item of results) {
           if (item && typeof item === 'object') {
             const entry = item as Record<string, unknown>
-            addSource(out, seen, entry.url, entry.title)
+            addSource(out, seen, entry.url, entry.title, sourceMeta(entry))
           }
         }
       } else if (call.result) {
@@ -203,7 +262,7 @@ const derivedSources = computed<SourcePart[]>(() => {
       continue
     }
     if (record) {
-      addSource(out, seen, record.final_url || record.url, record.title)
+      addSource(out, seen, record.final_url || record.url, record.title, sourceMeta(record))
     } else {
       const input = parseJsonRecord(call.inputRaw || '')
       addSource(out, seen, input?.url, '')
@@ -214,6 +273,10 @@ const derivedSources = computed<SourcePart[]>(() => {
     url: source.url,
     title: source.title,
     domain: source.domain,
+    canonicalUrl: source.canonicalUrl,
+    provider: source.provider,
+    fetched: source.fetched,
+    fetchStatus: source.fetchStatus,
   }))
 })
 
@@ -228,6 +291,21 @@ const chipSources = computed(() => sources.value.slice(0, MAX_CHIPS))
 function initialFor(source: SourcePart): string {
   const base = source.domain.replace(/^www\./, '')
   return (base[0] || '?').toUpperCase()
+}
+
+function sourceTrust(source: SourcePart): 'verified' | 'search' | 'failed' {
+  if (source.fetched === true) return 'verified'
+  if (source.fetchStatus && source.fetchStatus !== 'ok' && source.fetchStatus !== 'not_requested') {
+    return 'failed'
+  }
+  return 'search'
+}
+
+function sourceTrustLabel(source: SourcePart): string {
+  const trust = sourceTrust(source)
+  if (trust === 'verified') return 'Verified'
+  if (trust === 'failed') return 'Fetch failed'
+  return 'Search result'
 }
 </script>
 
@@ -387,6 +465,30 @@ function initialFor(source: SourcePart): string {
   white-space: nowrap;
 }
 
+.sources-row__status {
+  flex-shrink: 0;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  line-height: 1.3;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  background: var(--bg-hover);
+}
+
+.sources-row__status--verified {
+  color: var(--ok);
+  border-color: color-mix(in srgb, var(--ok) 35%, var(--border));
+  background: color-mix(in srgb, var(--ok) 9%, var(--bg-hover));
+}
+
+.sources-row__status--failed {
+  color: var(--warn);
+  border-color: color-mix(in srgb, var(--warn) 35%, var(--border));
+  background: color-mix(in srgb, var(--warn) 10%, var(--bg-hover));
+}
+
 .sources-row__domain {
   margin-left: auto;
   flex-shrink: 0;
@@ -406,6 +508,10 @@ function initialFor(source: SourcePart): string {
   }
 
   .sources-row__domain {
+    display: none;
+  }
+
+  .sources-row__status {
     display: none;
   }
 }

--- a/opensquilla-webui/src/components/chat/parts/TextPart.vue
+++ b/opensquilla-webui/src/components/chat/parts/TextPart.vue
@@ -1,9 +1,14 @@
 <template>
-  <div ref="rootEl" class="msg-ai-text" v-html="part.html" />
+  <div>
+    <div ref="rootEl" class="msg-ai-text" v-html="part.html" />
+    <p v-if="missingCitationLabel" class="msg-ai-citation-warning">
+      Some citations do not map to available sources: {{ missingCitationLabel }}
+    </p>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import type { ChatPart, SourcePart } from '@/types/parts'
 import { decorateCitations } from '@/utils/chat/citations'
 
@@ -18,6 +23,11 @@ const props = withDefaults(
 const emit = defineEmits<{ citation: [sourceId: number] }>()
 
 const rootEl = ref<HTMLDivElement | null>(null)
+const missingCitationIds = ref<number[]>([])
+
+const missingCitationLabel = computed(() =>
+  missingCitationIds.value.map(id => `[${id}]`).join(', '),
+)
 
 function labelFor(sourceId: number): string {
   const source = props.sources[sourceId - 1]
@@ -31,9 +41,13 @@ function labelFor(sourceId: number): string {
 function decorate() {
   const root = rootEl.value
   if (!root) return
+  missingCitationIds.value = []
   decorateCitations(root, props.sources, {
     onActivate: n => emit('citation', n),
     labelFor,
+    onMissingCitations: ids => {
+      missingCitationIds.value = props.sources.length > 0 ? ids : []
+    },
   })
 }
 
@@ -74,6 +88,13 @@ watch(() => props.sources, decorate, { flush: 'post' })
 .msg-ai-text :deep(pre code) {
   background: transparent;
   padding: 0;
+}
+
+.msg-ai-citation-warning {
+  margin: 0.25rem 0 0.5rem;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--text-muted);
 }
 
 /* Citation pills are injected outside Vue's template (built by decorateCitations

--- a/opensquilla-webui/src/types/parts.ts
+++ b/opensquilla-webui/src/types/parts.ts
@@ -94,7 +94,17 @@ export type Part =
       error?: string            // == output when isError, else undefined
     }
   | { type: 'artifact'; artifact: ArtifactPayload }
-  | { type: 'source'; sourceId: number; url: string; title: string; domain: string }
+  | {
+      type: 'source'
+      sourceId: number
+      url: string
+      title: string
+      domain: string
+      canonicalUrl?: string
+      provider?: string
+      fetched?: boolean
+      fetchStatus?: string
+    }
   | {
       type: 'interrupt'
       interruptKind: 'approval' | 'clarify'
@@ -119,6 +129,10 @@ export interface SourcePart {
   url: string
   title: string
   domain: string
+  canonicalUrl?: string
+  provider?: string
+  fetched?: boolean
+  fetchStatus?: string
 }
 
 export interface StatusPart {

--- a/opensquilla-webui/src/utils/chat/citations.test.ts
+++ b/opensquilla-webui/src/utils/chat/citations.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest'
+import { decorateCitations } from './citations'
+import type { SourcePart } from '@/types/parts'
+
+const sources: SourcePart[] = [
+  {
+    sourceId: 1,
+    url: 'https://example.com/a',
+    title: 'Example result',
+    domain: 'example.com',
+  },
+]
+
+describe('decorateCitations', () => {
+  it('creates pills for valid citations and reports missing ids', () => {
+    const root = document.createElement('div')
+    root.textContent = 'Supported [1], missing [9].'
+    const onActivate = vi.fn()
+    let missing: number[] = []
+
+    const created = decorateCitations(root, sources, {
+      onActivate,
+      labelFor: () => 'Example result',
+      onMissingCitations: ids => {
+        missing = ids
+      },
+    })
+
+    const pill = root.querySelector<HTMLButtonElement>('button.citation-pill')
+    expect(created).toBe(1)
+    expect(pill?.textContent).toBe('[1]')
+    expect(pill?.getAttribute('data-citation')).toBe('1')
+    expect(root.textContent).toContain('[9]')
+    expect(missing).toEqual([9])
+  })
+
+  it('does not report missing citations when there are no sources', () => {
+    const root = document.createElement('div')
+    root.textContent = 'Nothing should be upgraded [1].'
+    const onMissingCitations = vi.fn()
+
+    const created = decorateCitations(root, [], {
+      onActivate: vi.fn(),
+      labelFor: () => '',
+      onMissingCitations,
+    })
+
+    expect(created).toBe(0)
+    expect(root.querySelector('button.citation-pill')).toBeNull()
+    expect(onMissingCitations).not.toHaveBeenCalled()
+  })
+})

--- a/opensquilla-webui/src/utils/chat/citations.ts
+++ b/opensquilla-webui/src/utils/chat/citations.ts
@@ -15,6 +15,8 @@ export interface CitationDecorateOptions {
   onActivate: (sourceId: number) => void
   /** Accessible label fragment for a source, keyed by sourceId (title or domain). */
   labelFor: (sourceId: number) => string
+  /** Called with citation ids that were present in prose but not in sources. */
+  onMissingCitations?: (sourceIds: number[]) => void
 }
 
 /**
@@ -48,8 +50,12 @@ export function decorateCitations(
   }
 
   let created = 0
+  const missing = new Set<number>()
   for (const node of candidates) {
-    created += decorateTextNode(node, sources, opts)
+    created += decorateTextNode(node, sources, opts, missing)
+  }
+  if (missing.size > 0) {
+    opts.onMissingCitations?.([...missing].sort((a, b) => a - b))
   }
   return created
 }
@@ -68,6 +74,7 @@ function decorateTextNode(
   node: Text,
   sources: readonly SourcePart[],
   opts: CitationDecorateOptions,
+  missing: Set<number>,
 ): number {
   const text = node.nodeValue ?? ''
   CITATION_RE.lastIndex = 0
@@ -91,6 +98,8 @@ function decorateTextNode(
       lastIndex = end
       created += 1
       changed = true
+    } else {
+      missing.add(n)
     }
     match = CITATION_RE.exec(text)
   }

--- a/opensquilla-webui/src/utils/chat/toSources.test.ts
+++ b/opensquilla-webui/src/utils/chat/toSources.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { toSources } from './toSources'
+import type { ChatRenderedMessage, ChatToolCall } from '@/types/chat'
+
+function baseCall(overrides: Partial<ChatToolCall>): ChatToolCall {
+  return {
+    toolId: 'tool-1',
+    name: 'web_search',
+    displayName: 'Web search',
+    inputPreview: '',
+    isRunning: false,
+    status: 'success',
+    isError: false,
+    result: '',
+    resultPreview: '',
+    isOpen: false,
+    ...overrides,
+  }
+}
+
+function message(toolCalls: ChatToolCall[]): ChatRenderedMessage {
+  return {
+    role: 'assistant',
+    displayRole: 'assistant',
+    roleLabel: 'Assistant',
+    text: '',
+    timeStr: '',
+    showHeader: false,
+    toolCalls,
+  }
+}
+
+describe('toSources', () => {
+  it('preserves source trust metadata and merges duplicate URLs', () => {
+    const sources = toSources(message([
+      baseCall({
+        sources: [
+          {
+            url: 'https://example.com/a',
+            canonical_url: 'https://example.com/a',
+            provider: 'duckduckgo',
+            fetched: false,
+            fetch_status: 'not_requested',
+          },
+          {
+            url: 'https://example.com/a#section',
+            title: 'Example result',
+            provider: 'duckduckgo',
+            fetched: true,
+            fetch_status: 'ok',
+          },
+        ],
+      }),
+    ]))
+
+    expect(sources).toEqual([
+      {
+        sourceId: 1,
+        url: 'https://example.com/a',
+        title: 'Example result',
+        domain: 'example.com',
+        canonicalUrl: 'https://example.com/a',
+        provider: 'duckduckgo',
+        fetched: true,
+        fetchStatus: 'ok',
+      },
+    ])
+  })
+
+  it('upgrades duplicate source metadata when a later entry is verified', () => {
+    const sources = toSources(message([
+      baseCall({
+        sources: [
+          {
+            url: 'https://example.com/a',
+            title: 'Initial result',
+            provider: 'duckduckgo',
+            fetched: false,
+            fetch_status: 'fetch_failed',
+          },
+          {
+            url: 'https://example.com/a',
+            provider: 'duckduckgo',
+            fetched: true,
+            fetch_status: 'ok',
+          },
+        ],
+      }),
+    ]))
+
+    expect(sources[0]).toMatchObject({
+      url: 'https://example.com/a',
+      title: 'Initial result',
+      fetched: true,
+      fetchStatus: 'ok',
+    })
+  })
+})

--- a/opensquilla-webui/src/utils/chat/toSources.ts
+++ b/opensquilla-webui/src/utils/chat/toSources.ts
@@ -8,6 +8,17 @@ interface SourceLink {
   url: string
   title: string
   domain: string
+  canonicalUrl?: string
+  provider?: string
+  fetched?: boolean
+  fetchStatus?: string
+}
+
+interface SourceMeta {
+  canonicalUrl?: string
+  provider?: string
+  fetched?: boolean
+  fetchStatus?: string
 }
 
 function parseJsonRecord(text: string): Record<string, unknown> | null {
@@ -33,7 +44,42 @@ function domainFor(url: string): string {
   }
 }
 
-function addSource(out: SourceLink[], seen: Map<string, SourceLink>, url: unknown, title: unknown) {
+function sourceText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function sourceMeta(entry: Record<string, unknown>): SourceMeta {
+  const meta: SourceMeta = {}
+  const canonicalUrl = sourceText(entry.canonical_url) || sourceText(entry.canonicalUrl)
+  const provider = sourceText(entry.provider)
+  const fetchStatus = sourceText(entry.fetch_status) || sourceText(entry.fetchStatus)
+  if (canonicalUrl) meta.canonicalUrl = canonicalUrl
+  if (provider) meta.provider = provider
+  if (typeof entry.fetched === 'boolean') meta.fetched = entry.fetched
+  if (fetchStatus) meta.fetchStatus = fetchStatus
+  return meta
+}
+
+function mergeMeta(source: SourceLink, meta: SourceMeta) {
+  if (!source.canonicalUrl && meta.canonicalUrl) source.canonicalUrl = meta.canonicalUrl
+  if (!source.provider && meta.provider) source.provider = meta.provider
+  if (source.fetched !== true && meta.fetched === true) source.fetched = true
+  if (
+    meta.fetchStatus === 'ok' ||
+    !source.fetchStatus ||
+    source.fetchStatus === 'not_requested'
+  ) {
+    if (meta.fetchStatus) source.fetchStatus = meta.fetchStatus
+  }
+}
+
+function addSource(
+  out: SourceLink[],
+  seen: Map<string, SourceLink>,
+  url: unknown,
+  title: unknown,
+  meta: SourceMeta = {},
+) {
   if (typeof url !== 'string') return
   const trimmed = url.trim()
   // Persisted tool results compact long strings with a trailing '…'; a
@@ -46,9 +92,10 @@ function addSource(out: SourceLink[], seen: Map<string, SourceLink>, url: unknow
   const existing = seen.get(key)
   if (existing) {
     if (!existing.title && cleanTitle) existing.title = cleanTitle
+    mergeMeta(existing, meta)
     return
   }
-  const source: SourceLink = { url: trimmed, title: cleanTitle, domain }
+  const source: SourceLink = { url: trimmed, title: cleanTitle, domain, ...meta }
   seen.set(key, source)
   out.push(source)
 }
@@ -59,7 +106,13 @@ function extractSources(raw: unknown, out: SourceLink[], seen: Map<string, Sourc
   for (const item of raw) {
     if (item && typeof item === 'object') {
       const entry = item as Record<string, unknown>
-      addSource(out, seen, entry.url || entry.final_url || entry.canonical_url, entry.title)
+      addSource(
+        out,
+        seen,
+        entry.url || entry.final_url || entry.canonical_url,
+        entry.title,
+        sourceMeta(entry),
+      )
     }
   }
   return out.length - before
@@ -112,7 +165,7 @@ export function toSources(msg: ChatRenderedMessage): SourcePart[] {
         for (const item of results) {
           if (item && typeof item === 'object') {
             const entry = item as Record<string, unknown>
-            addSource(out, seen, entry.url, entry.title)
+            addSource(out, seen, entry.url, entry.title, sourceMeta(entry))
           }
         }
       } else if (call.result) {
@@ -121,7 +174,7 @@ export function toSources(msg: ChatRenderedMessage): SourcePart[] {
       continue
     }
     if (record) {
-      addSource(out, seen, record.final_url || record.url, record.title)
+      addSource(out, seen, record.final_url || record.url, record.title, sourceMeta(record))
     } else {
       const input = parseJsonRecord(call.inputRaw || '')
       addSource(out, seen, input?.url, '')
@@ -132,5 +185,9 @@ export function toSources(msg: ChatRenderedMessage): SourcePart[] {
     url: source.url,
     title: source.title,
     domain: source.domain,
+    canonicalUrl: source.canonicalUrl,
+    provider: source.provider,
+    fetched: source.fetched,
+    fetchStatus: source.fetchStatus,
   }))
 }

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -878,6 +878,9 @@ def _persisted_web_search_source(candidate: Any) -> dict[str, Any] | None:
     fetched = candidate.get("fetched")
     if isinstance(fetched, bool):
         source["fetched"] = fetched
+    fetch_status = _persisted_source_text(candidate.get("fetch_status"), max_chars=64)
+    if fetch_status:
+        source["fetch_status"] = fetch_status
     return source
 
 

--- a/src/opensquilla/search/canonical.py
+++ b/src/opensquilla/search/canonical.py
@@ -158,6 +158,8 @@ async def run_canonical_web_search(
 
     diagnostics.returned_chars = sum(len(hit.excerpt) for hit in hits)
     diagnostics.budget_clamped = any(hit.content_truncated for hit in hits)
+    if not hits:
+        diagnostics.empty_reason = "no_results" if not raw_results else "filtered"
 
     payload = {
         "ok": True,
@@ -546,6 +548,8 @@ def _public_error_message(provider: str, kind: str) -> str:
         return f"{provider_name} search request timed out."
     if kind == "rate_limit":
         return f"{provider_name} search rate limit was reached."
+    if kind == "blocked":
+        return f"{provider_name} search was blocked by an upstream challenge."
     if kind == "http":
         return f"{provider_name} search request failed."
     return f"{provider_name} search request failed."
@@ -570,4 +574,5 @@ def _public_source_payload(hit: SearchHit) -> dict[str, Any]:
         "domain": hit.domain,
         "provider": hit.provider,
         "fetched": hit.fetched,
+        "fetch_status": hit.fetch_status,
     }

--- a/src/opensquilla/search/providers/duckduckgo.py
+++ b/src/opensquilla/search/providers/duckduckgo.py
@@ -17,6 +17,18 @@ _HEADERS = {
         "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
     ),
 }
+_BLOCKED_MARKERS = (
+    "anomaly.js",
+    "challenge-form",
+    "anomaly-modal",
+    "bots use duckduckgo",
+    "please complete the following challenge",
+)
+_NO_RESULTS_MARKERS = (
+    "no results found",
+    "no results.",
+    "not many results contain",
+)
 
 
 class DuckDuckGoProvider:
@@ -72,6 +84,15 @@ class DuckDuckGoProvider:
                 ),
             ) from exc
 
+        if response.status_code == 202 or _is_blocked_response(response.text):
+            raise SearchProviderError(
+                provider=self.name,
+                kind="blocked",
+                message="DuckDuckGo returned an anti-bot challenge.",
+                retryable=True,
+                status_code=response.status_code,
+            )
+
         soup = BeautifulSoup(response.text, "html.parser")
         results: list[SearchResult] = []
 
@@ -107,7 +128,28 @@ class DuckDuckGoProvider:
             if len(results) >= max_results:
                 break
 
+        if not results and not _is_no_results_response(soup):
+            raise SearchProviderError(
+                provider=self.name,
+                kind="parse",
+                message="DuckDuckGo search response did not contain parseable results.",
+                retryable=True,
+                status_code=response.status_code,
+            )
+
         return results
+
+
+def _is_blocked_response(html: str) -> bool:
+    lowered = html.lower()
+    return any(marker in lowered for marker in _BLOCKED_MARKERS)
+
+
+def _is_no_results_response(soup: BeautifulSoup) -> bool:
+    if soup.select_one("#no-results, .no-results, .no-results__message, .result--no-result"):
+        return True
+    lowered = " ".join(soup.get_text(" ", strip=True).lower().split())
+    return any(marker in lowered for marker in _NO_RESULTS_MARKERS)
 
 
 register_provider("duckduckgo", DuckDuckGoProvider)

--- a/src/opensquilla/search/types.py
+++ b/src/opensquilla/search/types.py
@@ -7,7 +7,16 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, Protocol, runtime_checkable
 from urllib.parse import urlsplit
 
-SearchErrorKind = Literal["auth", "rate_limit", "timeout", "network", "http", "parse", "unknown"]
+SearchErrorKind = Literal[
+    "auth",
+    "rate_limit",
+    "timeout",
+    "network",
+    "http",
+    "parse",
+    "blocked",
+    "unknown",
+]
 SearchMode = Literal["auto", "news", "technical", "broad"]
 Recency = Literal["day", "week", "month", "year"]
 
@@ -150,6 +159,7 @@ class SearchDiagnostics:
     recency_supported: bool = True
     recency_degraded: bool = False
     cache_status: str = "disabled"
+    empty_reason: str = ""
     loop_guard: dict[str, Any] = field(default_factory=dict)
 
 

--- a/tests/test_gateway/test_webui_sources_row_static.py
+++ b/tests/test_gateway/test_webui_sources_row_static.py
@@ -3,7 +3,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 SOURCES_ROW = ROOT / "opensquilla-webui/src/components/chat/SourcesRow.vue"
 CHAT_TYPES = ROOT / "opensquilla-webui/src/types/chat.ts"
+PART_TYPES = ROOT / "opensquilla-webui/src/types/parts.ts"
 RENDERED_MESSAGES = ROOT / "opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts"
+TEXT_PART = ROOT / "opensquilla-webui/src/components/chat/parts/TextPart.vue"
+CITATIONS = ROOT / "opensquilla-webui/src/utils/chat/citations.ts"
 
 
 def _read(path: Path) -> str:
@@ -33,3 +36,35 @@ def test_chat_tool_call_type_and_history_normalizer_preserve_sources() -> None:
     assert "sources?: unknown" in raw_tool_call_payload_source
     assert "sources: item.sources" in rendered_source
     assert "if (tc.sources !== undefined) item.sources = tc.sources" in rendered_source
+
+
+def test_source_part_type_preserves_search_trust_metadata() -> None:
+    source = _read(PART_TYPES)
+    source_part = source[source.index("export interface SourcePart") :]
+
+    assert "canonicalUrl?: string" in source_part
+    assert "provider?: string" in source_part
+    assert "fetched?: boolean" in source_part
+    assert "fetchStatus?: string" in source_part
+
+
+def test_sources_row_renders_search_trust_states() -> None:
+    source = _read(SOURCES_ROW)
+
+    assert "sourceTrustLabel(source)" in source
+    assert "Verified" in source
+    assert "Search result" in source
+    assert "Fetch failed" in source
+    assert "sources-row__status--verified" in source
+    assert "sources-row__status--failed" in source
+
+
+def test_text_part_reports_missing_citations_from_decorator() -> None:
+    text_part = _read(TEXT_PART)
+    citations = _read(CITATIONS)
+
+    assert "Some citations do not map to available sources" in text_part
+    assert "onMissingCitations" in text_part
+    assert "missingCitationIds" in text_part
+    assert "onMissingCitations?: (sourceIds: number[]) => void" in citations
+    assert "missing.add(n)" in citations

--- a/tests/test_search/test_brave_config.py
+++ b/tests/test_search/test_brave_config.py
@@ -133,6 +133,66 @@ async def test_duckduckgo_provider_maps_provider_and_source() -> None:
 
 
 @pytest.mark.asyncio
+async def test_duckduckgo_provider_treats_anomaly_challenge_as_blocked() -> None:
+    html = """
+    <html>
+      <body>
+        <form id="challenge-form" action="//duckduckgo.com/anomaly.js">
+          <div class="anomaly-modal">Unfortunately, bots use DuckDuckGo too.</div>
+        </form>
+      </body>
+    </html>
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(202, text=html)
+
+    provider = DuckDuckGoProvider(transport=httpx.MockTransport(handler))
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("duck")
+
+    assert exc_info.value.provider == "duckduckgo"
+    assert exc_info.value.kind == "blocked"
+    assert exc_info.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_duckduckgo_provider_allows_real_no_results() -> None:
+    html = """
+    <html>
+      <body>
+        <div class="no-results">No results found for improbable query.</div>
+      </body>
+    </html>
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=html)
+
+    provider = DuckDuckGoProvider(transport=httpx.MockTransport(handler))
+
+    assert await provider.search("improbable query") == []
+
+
+@pytest.mark.asyncio
+async def test_duckduckgo_provider_treats_unparseable_empty_page_as_parse_error() -> None:
+    html = "<html><body><main>DuckDuckGo</main></body></html>"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=html)
+
+    provider = DuckDuckGoProvider(transport=httpx.MockTransport(handler))
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("duck")
+
+    assert exc_info.value.provider == "duckduckgo"
+    assert exc_info.value.kind == "parse"
+    assert exc_info.value.retryable is True
+
+
+@pytest.mark.asyncio
 async def test_duckduckgo_provider_surfaces_network_failures() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("network down", request=request)

--- a/tests/test_search/test_canonical_web_search.py
+++ b/tests/test_search/test_canonical_web_search.py
@@ -120,6 +120,26 @@ class NetworkFailProvider:
         raise SearchProviderError("tavily", "network", "Network failed", retryable=True)
 
 
+class BlockedProvider:
+    def __init__(self, name: str = "duckduckgo") -> None:
+        self.name = name
+
+    async def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+        raise SearchProviderError(
+            self.name,
+            "blocked",
+            "Provider returned an anti-bot challenge",
+            retryable=True,
+        )
+
+
+class EmptyProvider:
+    name = "duckduckgo"
+
+    async def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+        return []
+
+
 class FallbackProvider:
     name = "duckduckgo"
 
@@ -326,6 +346,7 @@ async def test_canonical_web_search_dedupes_and_uses_provider_content_without_fe
             "domain": "www.python.org",
             "provider": "tavily",
             "fetched": False,
+            "fetch_status": "not_requested",
         }
     ]
 
@@ -568,6 +589,57 @@ async def test_canonical_web_search_explicit_provider_does_not_fallback_when_pol
     assert payload["provider_attempts"] == [
         {"provider": "tavily", "status": "error", "error_kind": "network"}
     ]
+
+
+@pytest.mark.asyncio
+async def test_canonical_web_search_surfaces_blocked_provider_failure() -> None:
+    payload = await run_canonical_web_search(
+        SearchOptions(query="q", provider="duckduckgo", fetch_top_k=0),
+        provider_factory=lambda name: BlockedProvider(name),
+    )
+
+    assert payload["ok"] is False
+    assert payload["error_kind"] == "blocked"
+    assert payload["provider_attempts"] == [
+        {"provider": "duckduckgo", "status": "error", "error_kind": "blocked"}
+    ]
+    assert payload["diagnostics"]["empty_reason"] == ""
+
+
+@pytest.mark.asyncio
+async def test_canonical_web_search_falls_back_on_retryable_blocked_error() -> None:
+    def provider_factory(name: str) -> BlockedProvider | FallbackProvider:
+        if name == "tavily":
+            return BlockedProvider(name)
+        return FallbackProvider()
+
+    payload = await run_canonical_web_search(
+        SearchOptions(query="q", provider="tavily", fetch_top_k=0),
+        runtime=resolve_search_runtime(
+            SearchRuntimeConfig(provider="tavily", api_key="tavily-key", fallback_policy="network")
+        ),
+        provider_factory=provider_factory,
+    )
+
+    assert payload["ok"] is True
+    assert payload["provider_attempts"] == [
+        {"provider": "tavily", "status": "error", "error_kind": "blocked"},
+        {"provider": "duckduckgo", "status": "success"},
+    ]
+    assert payload["results"][0]["provider"] == "duckduckgo"
+
+
+@pytest.mark.asyncio
+async def test_canonical_web_search_marks_true_empty_results() -> None:
+    payload = await run_canonical_web_search(
+        SearchOptions(query="q", provider="duckduckgo", fetch_top_k=0),
+        provider_factory=lambda name: EmptyProvider(),
+    )
+
+    assert payload["ok"] is True
+    assert payload["results"] == []
+    assert payload["sources"] == []
+    assert payload["diagnostics"]["empty_reason"] == "no_results"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

Fixes #340.

This PR tightens web search grounding so upstream search failures are no longer silently rendered as trustworthy empty results, and the Web UI carries source trust metadata through to the user-facing source row.

## What changed

- Added `blocked` as a search provider error kind.
- Detect DuckDuckGo anti-bot/challenge pages and classify them as retryable `blocked` failures.
- Treat true DuckDuckGo no-results pages as empty success, while structural drift without result/no-result/challenge markers becomes a parse failure.
- Add `empty_reason` diagnostics for true empty canonical search responses.
- Preserve source metadata (`canonicalUrl`, `provider`, `fetched`, `fetchStatus`) through persisted search sources and Web UI source folding.
- Render lightweight source trust labels: `Verified`, `Search result`, and `Fetch failed`.
- Report prose citations such as `[9]` when no corresponding source exists, without blocking ordinary links.

## Root cause

DuckDuckGo challenge or changed-result HTML could flow through the provider as an empty result set. Downstream canonical search and the UI could then make a failed or unparsed search look like a valid empty success, leaving users with no clear signal that source grounding had degraded.

## User impact

Normal successful search stays low-noise. Search-only results are shown neutrally as `Search result`; fetched sources are marked `Verified`; failed fetch/search metadata is visible without preventing the user from opening links. Missing numbered citations get a small inline hint instead of silently pointing nowhere.

## Validation

- `uv run --extra dev --extra recommended --extra mcp pytest tests/test_search tests/test_tools/test_web_search_tool.py tests/test_gateway/test_webui_sources_row_static.py -q` — 124 passed
- `uv run --extra dev --extra recommended --extra mcp ruff check src/opensquilla/search/types.py src/opensquilla/search/providers/duckduckgo.py src/opensquilla/search/canonical.py src/opensquilla/engine/runtime.py tests/test_search/test_brave_config.py tests/test_search/test_canonical_web_search.py tests/test_gateway/test_webui_sources_row_static.py` — passed
- `cd opensquilla-webui && npm run test:unit -- src/utils/chat/toSources.test.ts src/utils/chat/citations.test.ts` — 2 files / 4 tests passed
- `cd opensquilla-webui && npm run typecheck` — passed

## Safety notes

No secrets, credentials, real transcripts, or runtime state are included. The change does not add frontend DNS/HEAD validation or make citations a hard blocking error.

## Third-party origin

None.