### PR TITLE
Point brand link to sessions

### DIFF
--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -20,7 +20,7 @@
     <!-- Brand -->
     <div class="sidebar-brand">
       <router-link
-        to="/"
+        to="/sessions"
         class="sidebar-brand-link"
         :aria-label="t('chrome.brandHome')"
         @click="handleNavClick"


### PR DESCRIPTION
## Scope
- Point the OpenSquilla sidebar brand link directly to `/sessions` instead of the root route.
- Keep the New chat action as the only sidebar affordance that opens a fresh draft chat.

## Why
The root `/` route can apply redirect behavior, so using it for the brand affordance makes the logo feel like a context-dependent navigation control. The brand should behave like a stable return-to-workspace action, matching the desktop activation fix already present on `main`.

## Linked issue
None

## Release note
None — small Web UI navigation polish.

## Test results
- `npm ci` in a clean temporary worktree
- `cd opensquilla-webui && npm run build`
- `git diff --check`

## Safety notes
- One-line route target change only; no protocol, persistence, or auth behavior changes.
- Generated Web UI dist files were intentionally not included in this PR.

## Third-party origin details
None