### PR TITLE
feat(webui): support drag-and-drop file attachments

### DIFF
--- a/docs/features/attachment-drag-upload-spec.md
+++ b/docs/features/attachment-drag-upload-spec.md
@@ -1,0 +1,391 @@
+# Attachment Drag-and-Drop Upload Spec
+
+Date: 2026-06-29
+Status: Draft
+
+## Problem
+
+OpenSquilla should let users attach files by dragging them into the chat surface
+in both the browser Web UI and the Electron desktop client. The behavior must be
+consistent across surfaces and must use the existing gateway attachment
+ingestion path rather than adding a parallel desktop-only file pipeline.
+
+The current code already contains most of the upload path:
+
+- `opensquilla-webui/src/views/ChatView.vue` listens for drag/drop on the chat
+  thread and passes dropped files to `addAttachment`.
+- `opensquilla-webui/src/composables/chat/useChatAttachments.ts` validates file
+  type and size, inlines small files, and stages large files through
+  `/api/v1/files/upload`.
+- `opensquilla-webui/src/composables/chat/useChatSend.ts` sends staged files as
+  `{ type, file_uuid, mime, name }`.
+- `src/opensquilla/gateway/uploads.py` exposes the multipart upload route and
+  stores staged bytes behind an opaque `file_uuid`.
+- `src/opensquilla/gateway/attachment_ingest.py` resolves `file_uuid` entries
+  into transcript material references before a turn runs.
+- `desktop/electron/src/main.ts` creates a sandboxed, context-isolated browser
+  window; `desktop/electron/src/preload.cts` exposes only explicit desktop APIs.
+
+The missing product-quality layer is a complete, reviewed drag-upload UX and
+test contract that covers both browser and desktop surfaces, including auth,
+error states, retry behavior, and cross-platform desktop validation.
+
+## Goals
+
+- Support dragging files from the OS/browser file picker into the Web UI chat
+  surface.
+- Support the same drag behavior in the Electron desktop client without a
+  separate upload implementation.
+- Preserve the existing attachment policy: max count, MIME allow-list, per-MIME
+  size caps, total size cap, MIME sniffing, and staged upload TTL.
+- Make upload progress and failure states visible in the composer.
+- Prevent sending while any attachment is still reading or uploading.
+- Ensure token-authenticated gateways can upload files by using the same bearer
+  token source as the WebSocket/RPC client.
+- Keep raw local file paths out of renderer code and out of chat payloads.
+- Persist only stable transcript material references after `chat.send` accepts
+  the turn; do not persist `file_uuid` in transcripts.
+
+## Non-Goals
+
+- Do not implement folder drag-and-drop.
+- Do not upload directory trees or recursively enumerate local paths.
+- Do not expose arbitrary local filesystem reads through Electron preload.
+- Do not make Electron bypass the gateway upload endpoint.
+- Do not add resumable/chunked uploads in this iteration.
+- Do not broaden the attachment MIME allow-list beyond the existing policy.
+- Do not support remote URL drag/drop as file upload unless the browser supplies
+  a real `File` object.
+
+## Existing Surfaces
+
+### Web UI
+
+- `ChatView.vue` owns high-level chat surface events, including drag/drop and
+  paste.
+- `ChatComposer.vue` renders pending attachment chips and the file input.
+- `useChatAttachments.ts` owns attachment state, MIME resolution, inline reads,
+  staged uploads, and local validation.
+- `useChatSend.ts` serializes pending attachments into the `chat.send` RPC
+  payload.
+
+### Gateway
+
+- `contracts/attachments.py` defines allowed media types and size limits.
+- `uploads.py` handles multipart staging and returns `file_uuid`.
+- `attachment_ingest.py` validates inline and staged attachments, writes
+  transcript material, and returns consumed staged UUIDs.
+- `rpc_sessions.py` evicts consumed `file_uuid` values only after the turn has
+  been accepted into the runtime.
+
+### Desktop
+
+- The Electron renderer runs the same Vue Web UI as the browser.
+- The Electron window is sandboxed and context-isolated.
+- The preload API currently exposes gateway status, settings, onboarding, and
+  artifact open helpers; it does not expose raw file reads.
+
+## Recommended Design
+
+Use one shared Web UI upload path for browser and Electron:
+
+```text
+User drops files
+  -> ChatView drop handler
+  -> useChatAttachments.addAttachments(files)
+  -> inline small files OR POST large files to /api/v1/files/upload
+  -> ChatComposer renders pending chips
+  -> useChatSend serializes attachments
+  -> chat.send RPC
+  -> gateway attachment_ingest resolves file_uuid
+  -> turn runtime receives stable attachment refs
+```
+
+Electron should not get a special upload bridge in the first iteration. When a
+file is dragged from the OS into the Electron browser window, Chromium exposes
+it to renderer code as a `File`. That is the same object shape the browser path
+uses, so the renderer can call the same composable.
+
+Add a desktop-specific bridge only if manual validation proves a platform cannot
+produce usable `DataTransfer.files`, or if a later feature explicitly needs
+native behavior such as folder selection, revealing local file paths, or
+watching local files for changes.
+
+## User Experience
+
+### Drop Zone
+
+The primary drop zone is the chat thread/composer area.
+
+Expected behavior:
+
+- `dragenter` / `dragover` with at least one file item shows a visible drop
+  affordance.
+- `dragleave` uses a drag-depth counter or equivalent containment check so the
+  affordance does not flicker when moving across child elements.
+- `drop` extracts only `File` objects and ignores non-file drag data.
+- Dropping files focuses the composer and appends attachments to the pending
+  list.
+- Unsupported items produce a toast and do not block valid files in the same
+  drop.
+
+### Attachment Chips
+
+Each pending attachment chip should show:
+
+- name;
+- MIME or concise type label;
+- size;
+- state: reading, uploading, ready, failed;
+- thumbnail for image inline attachments when available;
+- remove button;
+- retry button for staged upload failures.
+
+Sending is disabled while any attachment is `reading` or `uploading`.
+
+### Empty Message Behavior
+
+If the user sends with attachments and no text, the existing fallback message
+`Describe these attachments` remains acceptable.
+
+The visible bubble should still show the user's display text when present and
+attachment chips/previews when attachments exist.
+
+## Attachment State Model
+
+Use an explicit state machine in `useChatAttachments.ts`.
+
+Recommended internal states:
+
+| State | Meaning | Sendable |
+| --- | --- | --- |
+| `inline_pending` | FileReader is reading a small file. | No |
+| `inline` | Base64 data is ready in the pending payload. | Yes |
+| `uploading` | Multipart upload is in progress. | No |
+| `staged` | Gateway returned a `file_uuid`. | Yes |
+| `failed` | Read or upload failed and can be removed or retried. | No |
+
+The public type may keep the existing names, but code paths should treat them as
+states rather than ad-hoc variants.
+
+`addAttachment(file)` should be implemented in terms of
+`addAttachments(files: File[])` so file picker, paste, and drag/drop share batch
+validation behavior.
+
+## Data Contracts
+
+### Inline Attachment Payload
+
+Small files are sent through `chat.send` as:
+
+```json
+{
+  "type": "image/png",
+  "mime": "image/png",
+  "name": "screenshot.png",
+  "data": "<base64>"
+}
+```
+
+### Staged Upload Request
+
+Large files are uploaded first:
+
+```http
+POST /api/v1/files/upload
+Content-Type: multipart/form-data
+Authorization: Bearer <token>
+```
+
+Multipart fields:
+
+- `file`: the file bytes and filename;
+- `mime`: the client-resolved MIME, used only as a claim; gateway revalidates.
+
+Expected success response:
+
+```json
+{
+  "file_uuid": "u-...",
+  "filename": "report.pdf",
+  "mime": "application/pdf",
+  "size": 12345
+}
+```
+
+### Staged `chat.send` Payload
+
+After staging, `chat.send` sends:
+
+```json
+{
+  "type": "application/pdf",
+  "mime": "application/pdf",
+  "name": "report.pdf",
+  "file_uuid": "u-..."
+}
+```
+
+The gateway resolves this into a stable attachment ref and must not persist
+`file_uuid` into transcript envelopes.
+
+## Auth Requirements
+
+The multipart upload route intentionally requires header-based auth in token
+mode. Query-string token auth must remain rejected for uploads.
+
+Vue upload requests must therefore include the same token source used by the
+WebSocket/RPC connection:
+
+- read `sessionStorage.getItem("opensquilla.wsToken")`;
+- when present, set `Authorization: Bearer <token>`;
+- keep `credentials: "same-origin"` for same-origin cookies and browser policy;
+- never place the token in the upload URL.
+
+This is important because the current Vue staged upload path uses
+`credentials: "same-origin"` but does not include an authorization header. The
+legacy static chat upload path already includes the bearer token and should be
+used as the behavior reference.
+
+## Security and Safety Rules
+
+- Frontend validation is advisory UX only; gateway validation remains
+  authoritative.
+- The renderer must never send local filesystem paths in chat payloads.
+- Electron preload must not expose an arbitrary `readFile(path)` API for this
+  feature.
+- `file_uuid` is a short-lived upload-store identifier, not a durable reference.
+- Staged upload bytes are evicted only after the turn is accepted.
+- Failed `chat.send` after successful staging must keep the staged file retryable
+  until TTL expiry.
+- MIME sniffing mismatches are handled by gateway policy, not by trusting the
+  browser-provided `File.type`.
+- Directory entries and zero-byte files should be rejected with clear UX.
+
+## Implementation Plan
+
+### Frontend
+
+1. Add `addAttachments(files: File[])` in `useChatAttachments.ts`.
+2. Route file picker, paste, and drop through `addAttachments`.
+3. Add drag-depth or containment-safe drop-zone state in `ChatView.vue`.
+4. Show a drop affordance only when the drag payload contains files.
+5. Add upload auth headers to staged upload requests.
+6. Add retry handling for staged upload failures.
+7. Keep `ChatComposer.vue` presentational: props down, events up.
+8. Ensure `useChatSend.ts` does not clear failed attachments as if they were
+   successfully queued.
+
+### Gateway
+
+1. Keep `/api/v1/files/upload` as the only staged upload endpoint.
+2. Keep the upload route header-token requirement unchanged.
+3. Confirm `UploadStore` and `attachment_ingest` reject unsupported MIME, over
+   size, unknown UUID, restart-lost UUID, and total size overflow.
+4. Add targeted tests only where the new frontend contract exposes gaps.
+
+### Desktop
+
+1. Validate drag/drop in packaged or dev Electron on macOS, Windows, and Linux
+   where available.
+2. Keep Electron preload unchanged unless validation proves native bridging is
+   required.
+3. If a bridge becomes required, expose only a narrow capability such as
+   `stageDroppedFile(handle)` and keep all byte validation in the gateway.
+
+## Test Plan
+
+### Frontend Unit Tests
+
+- `resolveAttachmentMime()` prefers allowed browser MIME and falls back to
+  extension.
+- Unknown UTF-8 text degrades to `text/plain`.
+- Unknown binary files are rejected.
+- Oversize files are rejected by per-MIME cap.
+- `addAttachments()` handles mixed valid and invalid files without dropping the
+  valid ones.
+- Inline files transition from `inline_pending` to `inline`.
+- Large stageable files transition from `uploading` to `staged`.
+- Failed staged upload leaves a failed/removable state.
+- Upload requests include `Authorization: Bearer <token>` when the token exists.
+- Upload requests do not put the token in the URL.
+
+### Vue Component Tests
+
+- Dragging files over the chat surface shows the drop affordance.
+- Dragging non-file data does not show the drop affordance.
+- Dropping files calls the attachment composable once with all dropped files.
+- Sending is disabled while any attachment is reading or uploading.
+- Removing an attachment updates the pending list without mutating child props.
+
+### Gateway Tests
+
+- Multipart upload rejects missing auth header in token mode.
+- Multipart upload accepts bearer token in token mode.
+- Multipart upload rejects query-token-only auth.
+- Staged `file_uuid` resolution returns an attachment ref with no `file_uuid` or
+  inline `data`.
+- Restart-lost UUID produces the re-upload error path.
+- Successful turn acceptance evicts consumed UUIDs.
+- Failed turn acceptance does not evict consumed UUIDs.
+
+### Browser E2E
+
+- Drop one small image into Web UI, send, and assert `chat.send` carries inline
+  base64 attachment data.
+- Drop one large PDF into Web UI, wait for staged chip, send, and assert
+  `chat.send` carries `file_uuid`.
+- Drop a valid file and an invalid file together; valid file remains pending and
+  invalid file produces a toast.
+- Verify mobile and desktop layouts do not overflow with long filenames or wide
+  image thumbnails.
+
+### Desktop Manual Smoke
+
+Run on Electron dev and packaged builds:
+
+1. Start the desktop client.
+2. Drag a small PNG from the OS file manager into the chat thread.
+3. Confirm the composer shows a thumbnail chip.
+4. Send and confirm the user bubble renders the attachment.
+5. Drag a PDF larger than the inline threshold.
+6. Confirm upload progress changes to staged/ready.
+7. Send and confirm the gateway accepts the turn.
+8. Repeat with token auth enabled.
+9. Confirm no local file path appears in the chat payload, transcript, or logs.
+
+## Acceptance Criteria
+
+- Browser Web UI supports drag-and-drop upload for every MIME currently allowed
+  by `contracts/attachments.py`.
+- Electron desktop supports the same drag-and-drop behavior without a separate
+  upload code path.
+- Token-authenticated uploads succeed because the frontend sends bearer auth
+  headers.
+- Query-token-only multipart upload remains rejected.
+- Users cannot send while attachments are still reading or uploading.
+- Failed uploads are visible and removable or retryable.
+- Staged attachments are sent as `file_uuid` and are materialized into stable
+  transcript attachment refs before runtime execution.
+- `file_uuid` never appears in persisted transcript envelopes.
+- Successful turn acceptance evicts consumed staged uploads.
+- Frontend and backend tests cover valid, invalid, oversize, auth, retry, and
+  layout cases.
+
+## Rollout
+
+- Ship behind the normal chat composer behavior with no user-facing setting.
+- Keep existing file input and paste upload behavior working during rollout.
+- Validate Web UI first, then Electron dev, then packaged desktop.
+- Add troubleshooting guidance only if desktop platform differences require
+  user-visible explanation.
+
+## Open Questions
+
+- Should failed staged upload chips offer retry, or should failure remove the
+  chip and rely on toast only?
+- Should duplicate files in the same drop be deduplicated by
+  `name + size + lastModified`, or should duplicates be allowed?
+- Should the drop affordance cover only the chat thread or the full chat view?
+- Should future folder drag support be handled through a separate desktop-only
+  import flow rather than this attachment pipeline?

--- a/opensquilla-webui/e2e/attachment-drag-upload.spec.ts
+++ b/opensquilla-webui/e2e/attachment-drag-upload.spec.ts
@@ -1,0 +1,462 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const CONTROL_URL = '/control/chat/new'
+const HISTORY_IMAGE_DATA = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
+
+type CapturedSend = {
+  message?: string
+  sessionKey?: string
+  displayText?: string
+  attachments?: Array<Record<string, unknown>>
+}
+
+type HistoryAttachmentFixture = 'send' | 'html' | 'image' | 'staged'
+
+type MockRpcOptions = {
+  replayHistoryAfterSend?: boolean
+  historyAttachmentFixture?: HistoryAttachmentFixture
+  historyRequests?: Array<Record<string, unknown>>
+}
+
+function wsResponse(id: string, payload: unknown) {
+  return JSON.stringify({ type: 'res', id, ok: true, payload })
+}
+
+function wsEvent(event: string, payload: Record<string, unknown>) {
+  return JSON.stringify({ type: 'event', event, payload })
+}
+
+async function mockApprovals(page: Page) {
+  await page.route('**/api/approvals', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ pending: [] }),
+    }))
+}
+
+async function mockRpc(page: Page, capturedSends: CapturedSend[], options: MockRpcOptions = {}) {
+  const historyMessages: Array<Record<string, unknown>> = []
+  await page.routeWebSocket(/\/ws$/, ws => {
+    ws.send(JSON.stringify({ type: 'event', event: 'connect.challenge', payload: {} }))
+    ws.onMessage(message => {
+      try {
+        const frame = JSON.parse(String(message))
+        if (frame?.type !== 'req') return
+        const method = String(frame.method || '')
+        if (method === 'connect') {
+          ws.send(JSON.stringify({ protocol: 3, policy: { tick_interval_ms: 30000 } }))
+          return
+        }
+        if (method === 'chat.send') {
+          const params = (frame.params || {}) as CapturedSend
+          capturedSends.push(params)
+          if (options.replayHistoryAfterSend) {
+            const messageIndex = capturedSends.length
+            historyMessages.splice(0, historyMessages.length, {
+              role: 'user',
+              text: params.displayText || '',
+              timestamp: new Date().toISOString(),
+              id: `history-user-${messageIndex}`,
+              message_id: `history-user-${messageIndex}`,
+              attachments: historyAttachmentsFromSend(params, options.historyAttachmentFixture || 'send'),
+            })
+          }
+          ws.send(wsResponse(String(frame.id), {
+            sessionKey: params.sessionKey,
+            status: 'accepted',
+          }))
+          if (options.replayHistoryAfterSend) {
+            ws.send(wsEvent('session.event.done', {
+              key: params.sessionKey || '',
+              sessionKey: params.sessionKey || '',
+              status: 'succeeded',
+              stream_seq: capturedSends.length,
+            }))
+          }
+          return
+        }
+        if (method === 'chat.history') {
+          options.historyRequests?.push(frame.params || {})
+          ws.send(wsResponse(String(frame.id), { messages: historyMessages, has_more: false }))
+          return
+        }
+
+        const payloads: Record<string, unknown> = {
+          'agents.list': { agents: [] },
+          'commands.list_for_surface': { commands: [] },
+          'config.get': {
+            squilla_router: { enabled: false, rollout_phase: 'observe', tiers: {} },
+            permissions: {},
+            skills: {},
+          },
+          'sessions.list': { sessions: [], has_more: false },
+          'sessions.messages.subscribe': {
+            subscribed: true,
+            replay_complete: true,
+            current_stream_seq: 0,
+            run_status: 'idle',
+          },
+          'usage.status': { sessions: [] },
+        }
+
+        ws.send(wsResponse(String(frame.id), payloads[method] ?? {}))
+      } catch (err) {
+        if (!(err instanceof SyntaxError)) throw err
+      }
+    })
+  })
+}
+
+function historyAttachmentsFromSend(params: CapturedSend, fixture: HistoryAttachmentFixture): Array<Record<string, unknown>> {
+  const first = params.attachments?.[0] || {}
+  if (fixture === 'html') {
+    return [{
+      type: 'text/html',
+      name: 'preview.html',
+      data: 'PGh0bWw+',
+    }]
+  }
+  if (fixture === 'image') {
+    return [{
+      type: 'image/png',
+      name: 'photo.png',
+      data: HISTORY_IMAGE_DATA,
+    }]
+  }
+  if (fixture === 'staged') {
+    return [{
+      sha256_ref: 'b'.repeat(64),
+      name: String(first.name || 'quarterly-report.pdf'),
+      mime: String(first.mime || 'application/pdf'),
+      size: 2_000_001,
+      download_url: `/api/v1/attachments/${'b'.repeat(64)}`,
+    }]
+  }
+  return (params.attachments || []).map(att => ({
+    type: att.type,
+    name: att.name,
+    data: att.data,
+  }))
+}
+
+async function openMockedChat(page: Page, capturedSends: CapturedSend[], options: MockRpcOptions = {}) {
+  await mockApprovals(page)
+  await mockRpc(page, capturedSends, options)
+  await page.goto(CONTROL_URL)
+  await expect(page.locator('.chat-textarea')).toBeVisible()
+  await expect(page.locator('.conn-pill.connected')).toBeVisible()
+}
+
+async function dropFiles(page: Page, files: Array<{ name: string; type: string; text?: string; size?: number }>) {
+  await page.evaluate((fileSpecs) => {
+    const dataTransfer = new DataTransfer()
+    for (const spec of fileSpecs) {
+      const parts = spec.size
+        ? [new Uint8Array(spec.size)]
+        : [spec.text || 'drag upload']
+      dataTransfer.items.add(new File(parts, spec.name, { type: spec.type }))
+    }
+    const chat = document.querySelector('.chat')
+    if (!chat) throw new Error('chat root not found')
+    for (const type of ['dragenter', 'dragover', 'drop']) {
+      chat.dispatchEvent(new DragEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      }))
+    }
+  }, files)
+}
+
+async function expectDropOverlayCoversChat(page: Page) {
+  const layout = await page.evaluate(() => {
+    const rect = (box: DOMRect) => ({
+      bottom: box.bottom,
+      left: box.left,
+      right: box.right,
+      top: box.top,
+    })
+    const overlayEl = document.querySelector('.chat-drop-overlay')
+    const chat = document.querySelector('.chat')?.getBoundingClientRect()
+    const body = document.querySelector('.chat-body')?.getBoundingClientRect()
+    const overlay = overlayEl?.getBoundingClientRect()
+    const beacon = document.querySelector('.chat-drop-overlay__beacon')?.getBoundingClientRect()
+    const overlayStyle = overlayEl ? getComputedStyle(overlayEl) : null
+    if (!chat || !body || !overlay || !beacon || !overlayStyle) {
+      throw new Error('drop overlay layout target not found')
+    }
+    return {
+      chat: rect(chat),
+      body: rect(body),
+      overlay: rect(overlay),
+      beacon: rect(beacon),
+      pointerEvents: overlayStyle.pointerEvents,
+    }
+  })
+
+  expect(Math.abs(layout.overlay.left - layout.chat.left)).toBeLessThanOrEqual(2)
+  expect(Math.abs(layout.overlay.top - layout.chat.top)).toBeLessThanOrEqual(2)
+  expect(Math.abs(layout.overlay.right - layout.chat.right)).toBeLessThanOrEqual(2)
+  expect(Math.abs(layout.overlay.bottom - layout.chat.bottom)).toBeLessThanOrEqual(2)
+  expect(layout.overlay.top).toBeLessThan(layout.body.top)
+  expect(layout.overlay.bottom).toBeGreaterThan(layout.body.bottom)
+  expect(layout.beacon.left).toBeGreaterThanOrEqual(layout.overlay.left)
+  expect(layout.beacon.right).toBeLessThanOrEqual(layout.overlay.right)
+  expect(layout.pointerEvents).toBe('none')
+}
+
+test.describe('attachment drag upload', () => {
+  test('ignores non-file drags and keeps file drag affordance stable across children', async ({ page }) => {
+    const capturedSends: CapturedSend[] = []
+    await openMockedChat(page, capturedSends)
+
+    await page.evaluate(() => {
+      const dataTransfer = new DataTransfer()
+      dataTransfer.setData('text/plain', 'not a file')
+      const chat = document.querySelector('.chat')
+      if (!chat) throw new Error('chat root not found')
+      chat.dispatchEvent(new DragEvent('dragenter', { bubbles: true, cancelable: true, dataTransfer }))
+      chat.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer }))
+    })
+    await expect(page.locator('.chat-drop-overlay')).toHaveCount(0)
+
+    const nonFileDropPrevented = await page.evaluate(() => {
+      const dataTransfer = new DataTransfer()
+      dataTransfer.setData('text/uri-list', 'https://example.test/drop-target')
+      dataTransfer.setData('text/plain', 'https://example.test/drop-target')
+      const chat = document.querySelector('.chat')
+      if (!chat) throw new Error('chat root not found')
+      const event = new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer })
+      chat.dispatchEvent(event)
+      return event.defaultPrevented
+    })
+    expect(nonFileDropPrevented).toBe(true)
+    await expect(page.locator('.attachment-chip')).toHaveCount(0)
+
+    await page.evaluate(() => {
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(new File(['stable'], 'stable.txt', { type: 'text/plain' }))
+      const chat = document.querySelector('.chat')
+      const textarea = document.querySelector('.chat-textarea')
+      if (!chat || !textarea) throw new Error('drag targets not found')
+      chat.dispatchEvent(new DragEvent('dragenter', { bubbles: true, cancelable: true, dataTransfer }))
+      textarea.dispatchEvent(new DragEvent('dragenter', { bubbles: true, cancelable: true, dataTransfer }))
+      textarea.dispatchEvent(new DragEvent('dragleave', { bubbles: true, cancelable: true, dataTransfer }))
+    })
+    await expect(page.locator('.chat-drop-overlay')).toBeVisible()
+    await expect(page.locator('.chat-drop-overlay')).toContainText('Drop to attach')
+    await expectDropOverlayCoversChat(page)
+
+    await page.evaluate(() => {
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(new File(['stable'], 'stable.txt', { type: 'text/plain' }))
+      const chat = document.querySelector('.chat')
+      if (!chat) throw new Error('chat root not found')
+      chat.dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer }))
+    })
+    await expect(page.locator('.chat-drop-overlay')).toHaveCount(0)
+    await expect(page.locator('.attachment-chip')).toContainText('stable.txt')
+    await expect(page.locator('.attachment-chip--busy')).toHaveCount(0)
+  })
+
+  test('keeps the drop affordance contained on mobile and honors reduced motion', async ({ page }) => {
+    const capturedSends: CapturedSend[] = []
+    await page.setViewportSize({ width: 390, height: 780 })
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await openMockedChat(page, capturedSends)
+
+    await page.evaluate(() => {
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(new File(['mobile'], 'mobile-check.txt', { type: 'text/plain' }))
+      const chat = document.querySelector('.chat')
+      if (!chat) throw new Error('chat root not found')
+      chat.dispatchEvent(new DragEvent('dragenter', { bubbles: true, cancelable: true, dataTransfer }))
+      chat.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer }))
+    })
+
+    await expect(page.locator('.chat-drop-overlay')).toBeVisible()
+    await expectDropOverlayCoversChat(page)
+
+    const layout = await page.evaluate(() => {
+      const rect = (selector: string) => {
+        const el = document.querySelector(selector)
+        if (!el) throw new Error(`${selector} not found`)
+        const box = el.getBoundingClientRect()
+        return {
+          bottom: box.bottom,
+          left: box.left,
+          right: box.right,
+          top: box.top,
+          width: box.width,
+        }
+      }
+      const beacon = document.querySelector('.chat-drop-overlay__beacon')
+      if (!beacon) throw new Error('beacon not found')
+      return {
+        overlay: rect('.chat-drop-overlay'),
+        beacon: rect('.chat-drop-overlay__beacon'),
+        copy: rect('.chat-drop-overlay__copy'),
+        documentOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+        animationName: getComputedStyle(beacon).animationName,
+      }
+    })
+
+    expect(layout.documentOverflow).toBeLessThanOrEqual(1)
+    expect(layout.beacon.left).toBeGreaterThanOrEqual(layout.overlay.left)
+    expect(layout.beacon.right).toBeLessThanOrEqual(layout.overlay.right)
+    expect(layout.copy.left).toBeGreaterThanOrEqual(layout.overlay.left)
+    expect(layout.copy.right).toBeLessThanOrEqual(layout.overlay.right)
+    expect(layout.animationName).toBe('none')
+  })
+
+  test('drops and sends a small inline file without leaking local paths', async ({ page }) => {
+    const capturedSends: CapturedSend[] = []
+    await openMockedChat(page, capturedSends)
+
+    await dropFiles(page, [
+      { name: 'small.txt', type: 'text/plain', text: 'hello from inline drop' },
+    ])
+    await expect(page.locator('.attachment-chip')).toContainText('small.txt')
+    await expect(page.locator('.attachment-chip--busy')).toHaveCount(0)
+
+    await page.locator('.chat-send-btn[aria-label="Send"]').click()
+    await expect.poll(() => capturedSends.length).toBe(1)
+    await expect(page.locator('.msg-attachments .msg-file-chip')).toContainText('small.txt')
+
+    const params = capturedSends[0]
+    expect(params.message).toBe('Describe these attachments')
+    expect(params.attachments).toHaveLength(1)
+    const attachment = params.attachments?.[0] || {}
+    expect(attachment).toMatchObject({
+      mime: 'text/plain',
+      name: 'small.txt',
+      type: 'text/plain',
+    })
+    expect(String(attachment.data || '')).toBeTruthy()
+    expect(attachment.file_uuid).toBeUndefined()
+    expect(JSON.stringify(params)).not.toContain('/Users/')
+    expect(JSON.stringify(params)).not.toContain('small.txt/')
+  })
+
+  test('keeps non-image history replay attachments as file chips', async ({ page }) => {
+    const capturedSends: CapturedSend[] = []
+    const historyRequests: Array<Record<string, unknown>> = []
+    await openMockedChat(page, capturedSends, {
+      replayHistoryAfterSend: true,
+      historyAttachmentFixture: 'html',
+      historyRequests,
+    })
+
+    await dropFiles(page, [
+      { name: 'preview.html', type: 'text/html', text: '<html><body>preview</body></html>' },
+    ])
+    await expect(page.locator('.attachment-chip')).toContainText('preview.html')
+    await expect(page.locator('.attachment-chip__thumb')).toHaveCount(0)
+
+    const historyCallsBeforeSend = historyRequests.length
+    await page.locator('.chat-send-btn[aria-label="Send"]').click()
+    await expect.poll(() => capturedSends.length).toBe(1)
+    await expect.poll(() => historyRequests.length).toBeGreaterThan(historyCallsBeforeSend)
+
+    await expect(page.locator('.msg-attachments .msg-file-chip')).toContainText('preview.html')
+    await expect(page.locator('.msg-attachments .msg-thumb')).toHaveCount(0)
+  })
+
+  test('keeps image history replay attachments as thumbnails', async ({ page }) => {
+    const capturedSends: CapturedSend[] = []
+    const historyRequests: Array<Record<string, unknown>> = []
+    await openMockedChat(page, capturedSends, {
+      replayHistoryAfterSend: true,
+      historyAttachmentFixture: 'image',
+      historyRequests,
+    })
+
+    await dropFiles(page, [
+      { name: 'photo.png', type: 'image/png', text: 'image placeholder' },
+    ])
+    await expect(page.locator('.attachment-chip')).toContainText('photo.png')
+
+    const historyCallsBeforeSend = historyRequests.length
+    await page.locator('.chat-send-btn[aria-label="Send"]').click()
+    await expect.poll(() => capturedSends.length).toBe(1)
+    await expect.poll(() => historyRequests.length).toBeGreaterThan(historyCallsBeforeSend)
+
+    const thumb = page.locator('.msg-attachments .msg-thumb[alt="photo.png"]')
+    await expect(thumb).toBeVisible()
+    await expect(thumb).toHaveAttribute('src', `data:image/png;base64,${HISTORY_IMAGE_DATA}`)
+    await expect(page.locator('.msg-attachments .msg-file-chip')).toHaveCount(0)
+  })
+
+  test('drops a large staged file through the authenticated upload path', async ({ page }) => {
+    const capturedSends: CapturedSend[] = []
+    const historyRequests: Array<Record<string, unknown>> = []
+    const uploadRequests: Array<{ url: string; authorization?: string }> = []
+    await page.addInitScript(() => {
+      sessionStorage.setItem('opensquilla.wsToken', 'token-e2e')
+    })
+    await page.route('**/api/v1/files/upload', route => {
+      const request = route.request()
+      uploadRequests.push({
+        url: request.url(),
+        authorization: request.headers().authorization,
+      })
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          file_uuid: 'u-e2e-staged',
+          filename: 'quarterly-report.pdf',
+          mime: 'application/pdf',
+          size: 2_000_001,
+        }),
+      })
+    })
+    await openMockedChat(page, capturedSends, {
+      replayHistoryAfterSend: true,
+      historyAttachmentFixture: 'staged',
+      historyRequests,
+    })
+
+    const longName = 'quarterly-report-with-a-very-long-name-that-must-not-overflow-the-composer.pdf'
+    await dropFiles(page, [
+      { name: longName, type: 'application/pdf', size: 2_000_001 },
+    ])
+    await expect(page.locator('.attachment-chip')).toContainText(longName)
+    await expect(page.locator('.attachment-chip--busy')).toHaveCount(0)
+    await expect.poll(() => uploadRequests.length).toBe(1)
+
+    expect(uploadRequests[0].authorization).toBe('Bearer token-e2e')
+    expect(new URL(uploadRequests[0].url).search).not.toContain('token')
+
+    const layout = await page.evaluate(() => {
+      const chip = document.querySelector('.attachment-chip')?.getBoundingClientRect()
+      const composer = document.querySelector('.chat-composer-inner')?.getBoundingClientRect()
+      return {
+        chipRight: chip?.right || 0,
+        composerRight: composer?.right || 0,
+        documentOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      }
+    })
+    expect(layout.chipRight).toBeLessThanOrEqual(layout.composerRight + 1)
+    expect(layout.documentOverflow).toBeLessThanOrEqual(1)
+
+    const historyCallsBeforeSend = historyRequests.length
+    await page.locator('.chat-textarea').fill('summarize')
+    await page.locator('.chat-send-btn[aria-label="Send"]').click()
+    await expect.poll(() => capturedSends.length).toBe(1)
+    await expect.poll(() => historyRequests.length).toBeGreaterThan(historyCallsBeforeSend)
+    await expect(page.locator('.msg-attachments .msg-file-chip')).toContainText(longName)
+    await expect(page.locator('.msg-attachments .msg-thumb')).toHaveCount(0)
+
+    const attachment = capturedSends[0].attachments?.[0] || {}
+    expect(attachment).toMatchObject({
+      file_uuid: 'u-e2e-staged',
+      mime: 'application/pdf',
+      name: longName,
+      type: 'application/pdf',
+    })
+    expect(attachment.data).toBeUndefined()
+    expect(JSON.stringify(capturedSends[0])).not.toContain('/Users/')
+  })
+})

--- a/opensquilla-webui/src/components/chat/ChatComposer.vue
+++ b/opensquilla-webui/src/components/chat/ChatComposer.vue
@@ -6,17 +6,24 @@
           v-for="(att, i) in attachments"
           :key="att.local_id"
           class="attachment-chip"
-          :class="{ 'attachment-chip--busy': att.kind === 'inline_pending' || att.kind === 'uploading' }"
+          :class="{ 'attachment-chip--busy': isAttachmentBusy(att), 'attachment-chip--failed': att.kind === 'failed' }"
           :data-mime="att.mime || ''"
+          :title="attachmentTitle(att)"
         >
           <span class="attachment-chip__icon" aria-hidden="true">
-            <span v-if="att.kind === 'inline_pending' || att.kind === 'uploading'" class="spinner attachment-chip__spinner" />
-            <img v-else-if="att.dataUrl" class="attachment-chip__thumb" :src="att.dataUrl" alt="" />
+            <span v-if="isAttachmentBusy(att)" class="spinner attachment-chip__spinner" />
+            <Icon v-else-if="att.kind === 'failed'" name="info" :size="15" />
+            <img v-else-if="isImageDisplayAttachment(att) && att.dataUrl" class="attachment-chip__thumb" :src="att.dataUrl" alt="" />
             <Icon v-else :name="attachmentIcon(att)" :size="15" />
           </span>
           <span class="attachment-chip__name">{{ att.name }}</span>
           <span class="attachment-chip__meta">{{ attachmentMeta(att) }}</span>
-          <button class="attachment-remove" :title="t('chat.remove')" @click="emit('removeAttachment', i)">&times;</button>
+          <button v-if="att.kind === 'failed' && att.file" class="attachment-action" title="Retry upload" aria-label="Retry upload" @click="emit('retryAttachment', i)">
+            <Icon name="refresh" :size="12" />
+          </button>
+          <button class="attachment-action attachment-remove" :title="t('chat.remove')" :aria-label="t('chat.remove')" @click="emit('removeAttachment', i)">
+            <Icon name="x" :size="12" />
+          </button>
         </div>
       </div>
       <div class="chat-input-panel">
@@ -134,6 +141,7 @@ import Icon from '@/components/Icon.vue'
 import type { IconName } from '@/utils/icons'
 import ChatComposerSettings from '@/components/chat/ChatComposerSettings.vue'
 import type { Attachment } from '@/types/chat'
+import { isAttachmentBusy, isImageDisplayAttachment } from '@/utils/chat/attachments'
 
 interface ChatComposerExpose {
   composerElement: () => HTMLElement | null
@@ -168,6 +176,7 @@ const emit = defineEmits<{
   input: [event: Event]
   keydown: [event: KeyboardEvent]
   removeAttachment: [index: number]
+  retryAttachment: [index: number]
   send: []
   setBusySendMode: [mode: 'queue' | 'steer']
   setElevatedMode: [mode: string]
@@ -188,10 +197,11 @@ const fileInputEl = ref<HTMLInputElement | null>(null)
 const settingsOpen = ref(false)
 
 function attachmentIcon(att: Attachment): IconName {
-  return (att.mime || '').startsWith('image/') ? 'image' : 'fileText'
+  return isImageDisplayAttachment(att) ? 'image' : 'fileText'
 }
 
 function attachmentMeta(att: Attachment): string {
+  if (att.kind === 'failed') return att.error ? `FAILED · ${att.error}` : 'FAILED'
   const mime = att.mime || ''
   const subtype = mime.includes('/') ? mime.split('/')[1] : mime
   const label = subtype ? subtype.toUpperCase() : 'FILE'
@@ -199,6 +209,13 @@ function attachmentMeta(att: Attachment): string {
     ? `${Math.max(1, Math.round(att.size / 1024))} KB`
     : ''
   return [label, size].filter(Boolean).join(' · ')
+}
+
+function attachmentTitle(att: Attachment): string {
+  if (att.kind === 'failed') {
+    return att.error ? `${att.name}: ${att.error}` : `${att.name}: failed`
+  }
+  return att.name
 }
 
 function composerElement(): HTMLElement | null {
@@ -270,6 +287,7 @@ defineExpose<ChatComposerExpose>({
   align-items: center;
   gap: 0.375rem;
   padding: 0.25rem 0.5rem;
+  max-width: min(100%, 360px);
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: 0.375rem;
@@ -278,6 +296,16 @@ defineExpose<ChatComposerExpose>({
 
 .attachment-chip--busy {
   opacity: 0.7;
+}
+
+.attachment-chip--failed {
+  border-color: color-mix(in srgb, var(--danger) 38%, var(--border));
+  background: color-mix(in srgb, var(--danger) 8%, var(--bg-elevated));
+}
+
+.attachment-chip--failed .attachment-chip__icon,
+.attachment-chip--failed .attachment-chip__meta {
+  color: var(--danger);
 }
 
 .attachment-chip__icon {
@@ -308,6 +336,7 @@ defineExpose<ChatComposerExpose>({
 .attachment-chip__name {
   font-weight: 500;
   max-width: 150px;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -316,12 +345,18 @@ defineExpose<ChatComposerExpose>({
 .attachment-chip__meta {
   color: var(--text-dim);
   font-size: 0.6875rem;
+  min-width: 0;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.attachment-remove {
+.attachment-action {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex: 0 0 16px;
   padding: 0;
   width: 16px;
   height: 16px;
@@ -332,8 +367,8 @@ defineExpose<ChatComposerExpose>({
   font-size: 0.875rem;
 }
 
-.attachment-remove:hover {
-  color: var(--danger);
+.attachment-action:hover {
+  color: var(--text);
 }
 
 .chat-input-panel {

--- a/opensquilla-webui/src/components/chat/UserMessage.vue
+++ b/opensquilla-webui/src/components/chat/UserMessage.vue
@@ -24,17 +24,21 @@
         {{ stripTimePrefix(message.text) }}
       </template>
       <div v-if="message.attachments?.length" class="msg-attachments">
-        <template v-for="attachment in message.attachments" :key="attachment.name">
+        <template v-for="attachment in message.attachments" :key="attachment.renderKey">
           <img
-            v-if="attachment.dataUrl || attachment.data"
+            v-if="isImageDisplayAttachment(attachment) && (attachment.dataUrl || attachment.data)"
             class="msg-thumb"
-            :src="attachment.dataUrl || `data:${attachment.mime || 'image/png'};base64,${attachment.data}`"
+            :src="attachmentImageSrc(attachment)"
             :alt="attachment.name"
           />
           <span v-else class="msg-file-chip" :title="attachment.name">
-            <span class="msg-file-chip__icon" aria-hidden="true">file</span>
-            <span class="msg-file-chip__name">{{ attachment.name }}</span>
-            <span class="msg-file-chip__meta">{{ attachment.mime || 'attachment' }}</span>
+            <span class="msg-file-chip__icon" aria-hidden="true">
+              <Icon name="fileText" :size="16" />
+            </span>
+            <span class="msg-file-chip__body">
+              <span class="msg-file-chip__name">{{ attachment.name }}</span>
+              <span class="msg-file-chip__meta">{{ attachmentMeta(attachment) }}</span>
+            </span>
           </span>
         </template>
       </div>
@@ -68,7 +72,8 @@ import { useI18n } from 'vue-i18n'
 import Icon from '@/components/Icon.vue'
 import { useCopyFeedback } from '@/composables/chat/useCopyFeedback'
 import { useRelativeNow } from '@/composables/useRelativeNow'
-import type { ChatRenderedMessage } from '@/types/chat'
+import type { ChatRenderedMessage, DisplayAttachment } from '@/types/chat'
+import { isImageDisplayAttachment } from '@/utils/chat/attachments'
 import { absoluteTime, fullTime, isoTime, relativeTime } from '@/utils/messageTime'
 
 const { t } = useI18n()
@@ -103,6 +108,17 @@ function onMessageClick(event: MouseEvent) {
   if (!props.shareMode) return
   if ((event.target as HTMLElement | null)?.closest('button,a,input,textarea,select')) return
   emit('toggleShare', props.shareMessageId)
+}
+
+function attachmentImageSrc(attachment: DisplayAttachment): string {
+  return attachment.dataUrl || `data:${attachment.mime || 'image/png'};base64,${attachment.data || ''}`
+}
+
+function attachmentMeta(attachment: DisplayAttachment): string {
+  const mime = attachment.mime || 'attachment'
+  const subtype = mime.includes('/') ? mime.split('/').pop() || mime : mime
+  const label = subtype.includes('.') ? subtype.split('.').pop() || subtype : subtype
+  return label.toUpperCase()
 }
 </script>
 
@@ -271,8 +287,13 @@ function onMessageClick(event: MouseEvent) {
 .msg-attachments {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.375rem;
-  margin-top: 0.5rem;
+  gap: 0.5rem;
+  margin-top: 0.625rem;
+  max-width: min(100%, 24rem);
+}
+
+.msg-attachments:first-child {
+  margin-top: 0;
 }
 
 .msg-thumb {
@@ -286,21 +307,50 @@ function onMessageClick(event: MouseEvent) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.125rem 0.375rem;
-  background: var(--bg-hover);
-  border-radius: 0.25rem;
-  font-size: 0.6875rem;
-  font-weight: 600;
-  text-transform: uppercase;
+  flex: 0 0 2rem;
+  width: 2rem;
+  height: 2rem;
+  background: color-mix(in srgb, var(--text) 7%, var(--bg-surface));
+  border: 1px solid color-mix(in srgb, var(--text) 9%, var(--border));
+  border-radius: 0.375rem;
+  color: var(--text-muted);
+}
+
+.msg-file-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.625rem;
+  min-width: min(15rem, 100%);
+  max-width: min(100%, 24rem);
+  padding: 0.5rem 0.625rem;
+  border: 1px solid color-mix(in srgb, var(--text) 8%, var(--border));
+  border-radius: 0.625rem;
+  background: color-mix(in srgb, var(--bg-surface) 74%, var(--bg-elevated));
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--text) 6%, transparent);
+  text-align: left;
+}
+
+.msg-file-chip__body {
+  display: grid;
+  gap: 0.0625rem;
+  min-width: 0;
 }
 
 .msg-file-chip__name {
   font-weight: 500;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .msg-file-chip__meta {
-  font-size: 0.8125rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0;
   color: var(--text-dim);
+  line-height: 1.2;
+  text-transform: uppercase;
 }
 
 @media (max-width: 640px) {

--- a/opensquilla-webui/src/composables/chat/useChatAttachments.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatAttachments.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useChatAttachments } from './useChatAttachments'
+
+const pushToast = vi.hoisted(() => vi.fn())
+
+vi.mock('@/composables/useToasts', () => ({
+  useToasts: () => ({ pushToast }),
+}))
+
+function stagedPdf(name = 'paper.pdf') {
+  return new File([new Uint8Array(2_000_001)], name, { type: 'application/pdf' })
+}
+
+function unsupportedBinary(name = 'bad.bin') {
+  return new File([new Uint8Array([0])], name, { type: 'application/octet-stream' })
+}
+
+function successfulUploadResponse(fileUuid = 'file-1') {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ file_uuid: fileUuid }),
+    text: async () => '',
+  }
+}
+
+async function flushUpload() {
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+describe('useChatAttachments', () => {
+  beforeEach(() => {
+    pushToast.mockClear()
+    vi.stubGlobal('sessionStorage', {
+      getItem: vi.fn((key: string) => key === 'opensquilla.wsToken' ? 'token-123' : null),
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps valid files from a mixed batch when another file is rejected', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successfulUploadResponse('file-valid'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const attachments = useChatAttachments()
+
+    await attachments.addAttachments([stagedPdf('valid.pdf'), unsupportedBinary()])
+    await flushUpload()
+
+    expect(attachments.pendingAttachments.value).toMatchObject([
+      { kind: 'staged', name: 'valid.pdf', file_uuid: 'file-valid' },
+    ])
+    expect(pushToast).toHaveBeenCalledWith(
+      expect.stringContaining('Unsupported file: bad.bin'),
+      { tone: 'danger' },
+    )
+  })
+
+  it('rejects zero-byte files before read or upload work starts', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const attachments = useChatAttachments()
+
+    await attachments.addAttachments([new File([], 'empty.txt', { type: 'text/plain' })])
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(attachments.pendingAttachments.value).toHaveLength(0)
+    expect(pushToast).toHaveBeenCalledWith('Empty file: empty.txt', { tone: 'danger' })
+  })
+
+  it('enforces the frontend aggregate attachment count before upload work starts', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successfulUploadResponse('file-count'))
+    vi.stubGlobal('fetch', fetchMock)
+    const attachments = useChatAttachments()
+
+    const files = Array.from({ length: 11 }, (_, index) => stagedPdf(`paper-${index}.pdf`))
+    await attachments.addAttachments(files)
+    await flushUpload()
+
+    expect(fetchMock).toHaveBeenCalledTimes(10)
+    expect(attachments.pendingAttachments.value).toHaveLength(10)
+    expect(pushToast).toHaveBeenCalledWith('Too many attachments: max 10', { tone: 'danger' })
+  })
+
+  it('enforces the frontend aggregate attachment size before upload work starts', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const attachments = useChatAttachments()
+    attachments.pendingAttachments.value = Array.from({ length: 4 }, (_, index) => ({
+      kind: 'staged',
+      local_id: index + 1,
+      name: `existing-${index}.pdf`,
+      mime: 'application/pdf',
+      size: 15 * 1024 * 1024,
+      file_uuid: `existing-${index}`,
+    }))
+
+    await attachments.addAttachment(stagedPdf('overflow.pdf'))
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(attachments.pendingAttachments.value).toHaveLength(4)
+    expect(pushToast).toHaveBeenCalledWith(
+      'Attachments too large: overflow.pdf would exceed 60 MiB total',
+      { tone: 'danger' },
+    )
+  })
+
+  it('adds the WebSocket token as a bearer header on staged uploads', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successfulUploadResponse('file-token'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const attachments = useChatAttachments()
+    await attachments.addAttachment(stagedPdf())
+    await flushUpload()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/files/upload', expect.objectContaining({
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { Authorization: 'Bearer token-123' },
+    }))
+  })
+
+  it('marks a staged upload failed when the upload response omits file_uuid', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      text: async () => '',
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const attachments = useChatAttachments()
+    await attachments.addAttachment(stagedPdf('missing-uuid.pdf'))
+    await flushUpload()
+
+    expect(attachments.pendingAttachments.value).toMatchObject([
+      { kind: 'failed', name: 'missing-uuid.pdf', error: 'Upload response missing file_uuid' },
+    ])
+    expect(pushToast).toHaveBeenCalledWith(
+      'Upload failed for missing-uuid.pdf: Upload response missing file_uuid',
+      { tone: 'danger' },
+    )
+  })
+
+  it('keeps failed staged uploads retryable without reselecting the file', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'boom',
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce(successfulUploadResponse('file-retry'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const attachments = useChatAttachments()
+    await attachments.addAttachment(stagedPdf('retry.pdf'))
+    await flushUpload()
+
+    expect(attachments.pendingAttachments.value).toMatchObject([
+      { kind: 'failed', name: 'retry.pdf', error: 'HTTP 500 boom' },
+    ])
+    expect(attachments.pendingAttachments.value[0].file).toBeInstanceOf(File)
+
+    await attachments.retryAttachment(0)
+    await flushUpload()
+
+    expect(attachments.pendingAttachments.value).toMatchObject([
+      { kind: 'staged', name: 'retry.pdf', file_uuid: 'file-retry' },
+    ])
+  })
+})

--- a/opensquilla-webui/src/composables/chat/useChatAttachments.ts
+++ b/opensquilla-webui/src/composables/chat/useChatAttachments.ts
@@ -8,6 +8,8 @@ const ATTACHMENT_TEXT_HARD_CAP_BYTES = INLINE_THRESHOLD_BYTES
 const ATTACHMENT_IMAGE_HARD_CAP_BYTES = 5 * 1024 * 1024
 const ATTACHMENT_PDF_HARD_CAP_BYTES = 30 * 1024 * 1024
 const ATTACHMENT_OFFICE_HARD_CAP_BYTES = 30 * 1024 * 1024
+const MAX_ATTACHMENTS = 10
+const MAX_TOTAL_ATTACHMENT_BYTES = 60 * 1024 * 1024
 // Email is held to the text cap (bounded text is extracted; large emails are
 // large only due to attachments we never read), so it inlines and never stages.
 const ATTACHMENT_EMAIL_HARD_CAP_BYTES = ATTACHMENT_TEXT_HARD_CAP_BYTES
@@ -90,57 +92,76 @@ export function useChatAttachments() {
   function onFileInputChange(e: Event) {
     const target = e.target as HTMLInputElement
     if (target.files) {
-      Array.from(target.files).forEach(addAttachment)
+      void addAttachments(Array.from(target.files))
       target.value = ''
     }
   }
 
+  async function addAttachments(files: File[]) {
+    for (const file of files) {
+      await addAttachmentFile(file)
+    }
+  }
+
   async function addAttachment(file: File) {
+    await addAttachments([file])
+  }
+
+  async function addAttachmentFile(file: File) {
+    const fileName = file.name || 'Untitled file'
+    if (file.size === 0) {
+      pushToast(`Empty file: ${fileName}`, { tone: 'danger' })
+      return
+    }
+
     let mime = resolveAttachmentMime(file)
     if (!isAllowedAttachmentMime(mime)) {
       if (await fileLooksLikeUtf8Text(file)) {
         mime = 'text/plain'
       } else {
-        pushToast(i18n.global.t('chat.toast.unsupportedFile', { name: file.name, mime }), { tone: 'danger' })
+        pushToast(i18n.global.t('chat.toast.unsupportedFile', { name: fileName, mime }), { tone: 'danger' })
         return
       }
     }
     const hardCap = attachmentHardCapBytes(mime)
     if (file.size > hardCap) {
-      pushToast(i18n.global.t('chat.toast.fileTooLarge', { name: file.name }), { tone: 'danger' })
+      pushToast(i18n.global.t('chat.toast.fileTooLarge', { name: fileName }), { tone: 'danger' })
       return
     }
+    if (!canAcceptAttachment(fileName, file.size)) return
 
     const localId = nextAttachmentId.value++
 
     if (file.size <= INLINE_THRESHOLD_BYTES) {
-      pendingAttachments.value.push({ kind: 'inline_pending', local_id: localId, name: file.name, mime, size: file.size })
+      pendingAttachments.value.push({ kind: 'inline_pending', local_id: localId, name: fileName, mime, size: file.size, file })
       const reader = new FileReader()
       reader.onload = (e) => {
         const dataUrl = e.target?.result as string
         const b64 = dataUrl?.split(',')[1] || ''
         const idx = pendingAttachments.value.findIndex(a => a.local_id === localId)
         if (idx >= 0) {
-          pendingAttachments.value[idx] = { kind: 'inline', local_id: localId, name: file.name, mime, size: file.size, data: b64, dataUrl }
+          pendingAttachments.value[idx] = { kind: 'inline', local_id: localId, name: fileName, mime, size: file.size, data: b64, dataUrl }
         }
       }
       reader.onerror = () => {
-        removeAttachmentByLocalId(localId)
-        pushToast(i18n.global.t('chat.toast.couldNotReadFile', { name: file.name }), { tone: 'danger' })
+        const message = i18n.global.t('chat.toast.couldNotReadFile', { name: fileName })
+        markAttachmentFailed(localId, file, mime, message)
+        pushToast(message, { tone: 'danger' })
       }
       reader.readAsDataURL(file)
       return
     }
 
     if (!canStageAttachmentMime(mime)) {
-      pushToast(i18n.global.t('chat.toast.fileTooLarge', { name: file.name }), { tone: 'danger' })
+      pushToast(i18n.global.t('chat.toast.fileTooLarge', { name: fileName }), { tone: 'danger' })
       return
     }
 
-    pendingAttachments.value.push({ kind: 'uploading', local_id: localId, name: file.name, mime, size: file.size })
+    pendingAttachments.value.push({ kind: 'uploading', local_id: localId, name: fileName, mime, size: file.size, file })
     uploadAttachmentStaged(file, mime, localId).catch((err) => {
-      removeAttachmentByLocalId(localId)
-      pushToast(i18n.global.t('chat.toast.uploadFailed', { name: file.name }) + ': ' + (err?.message || err), { tone: 'danger' })
+      const message = uploadFailureMessage(err)
+      markAttachmentFailed(localId, file, mime, message)
+      pushToast(`${i18n.global.t('chat.toast.uploadFailed', { name: fileName })}: ${message}`, { tone: 'danger' })
     })
   }
 
@@ -152,15 +173,17 @@ export function useChatAttachments() {
       method: 'POST',
       body: form,
       credentials: 'same-origin',
+      headers: uploadAuthHeaders(),
     })
     if (!response.ok) {
       const detail = await response.text().catch(() => '')
       throw new Error(`HTTP ${response.status} ${detail}`)
     }
     const result = await response.json()
+    const fileUuid = uploadResponseFileUuid(result)
     const idx = pendingAttachments.value.findIndex(a => a.local_id === localId)
     if (idx >= 0) {
-      pendingAttachments.value[idx] = { kind: 'staged', local_id: localId, name: file.name, mime, size: file.size, file_uuid: result.file_uuid }
+      pendingAttachments.value[idx] = { kind: 'staged', local_id: localId, name: file.name || 'Untitled file', mime, size: file.size, file_uuid: fileUuid }
     }
   }
 
@@ -168,19 +191,87 @@ export function useChatAttachments() {
     pendingAttachments.value.splice(index, 1)
   }
 
-  function removeAttachmentByLocalId(localId: number) {
-    pendingAttachments.value = pendingAttachments.value.filter(a => a.local_id !== localId)
+  async function retryAttachment(index: number) {
+    const attachment = pendingAttachments.value[index]
+    if (!attachment || attachment.kind !== 'failed') return
+    if (!attachment.file) {
+      pushToast(`Cannot retry ${attachment.name}: select the file again`, { tone: 'danger' })
+      return
+    }
+    pendingAttachments.value.splice(index, 1)
+    await addAttachment(attachment.file)
+  }
+
+  function markAttachmentFailed(localId: number, file: File, mime: string, error: string) {
+    const idx = pendingAttachments.value.findIndex(a => a.local_id === localId)
+    if (idx >= 0) {
+      pendingAttachments.value[idx] = {
+        kind: 'failed',
+        local_id: localId,
+        name: file.name || 'Untitled file',
+        mime,
+        size: file.size,
+        error,
+        file,
+      }
+    }
   }
 
   function hasPendingAttachmentWork(): boolean {
     return pendingAttachments.value.some(a => a.kind === 'inline_pending' || a.kind === 'uploading')
   }
 
+  function canAcceptAttachment(fileName: string, size: number): boolean {
+    const activeAttachments = pendingAttachments.value.filter(attachmentCountsTowardLimits)
+    if (activeAttachments.length >= MAX_ATTACHMENTS) {
+      pushToast(`Too many attachments: max ${MAX_ATTACHMENTS}`, { tone: 'danger' })
+      return false
+    }
+    const totalBytes = activeAttachments.reduce((sum, attachment) => sum + (attachment.size || 0), 0) + size
+    if (totalBytes > MAX_TOTAL_ATTACHMENT_BYTES) {
+      pushToast(`Attachments too large: ${fileName} would exceed ${formatMiB(MAX_TOTAL_ATTACHMENT_BYTES)} total`, { tone: 'danger' })
+      return false
+    }
+    return true
+  }
+
   return {
     pendingAttachments,
     onFileInputChange,
+    addAttachments,
     addAttachment,
     removeAttachment,
+    retryAttachment,
     hasPendingAttachmentWork,
   }
+}
+
+function uploadAuthHeaders(): HeadersInit | undefined {
+  try {
+    const token = globalThis.sessionStorage?.getItem('opensquilla.wsToken')?.trim()
+    return token ? { Authorization: `Bearer ${token}` } : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function uploadFailureMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+function uploadResponseFileUuid(result: unknown): string {
+  const fileUuid = typeof (result as { file_uuid?: unknown } | null)?.file_uuid === 'string'
+    ? (result as { file_uuid: string }).file_uuid.trim()
+    : ''
+  if (!fileUuid) throw new Error('Upload response missing file_uuid')
+  return fileUuid
+}
+
+function attachmentCountsTowardLimits(attachment: Attachment): boolean {
+  return attachment.kind !== 'failed'
+}
+
+function formatMiB(bytes: number): string {
+  return `${Math.round(bytes / 1024 / 1024)} MiB`
 }

--- a/opensquilla-webui/src/composables/chat/useChatHistory.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.ts
@@ -6,6 +6,7 @@ import type {
   RawToolCallPayload,
 } from '@/types/chat'
 import type { ChatHistoryMessage, ChatHistoryResponse } from '@/types/rpc'
+import { normalizeDisplayAttachments } from '@/utils/chat/attachments'
 import { reconcileHistoryMessages } from '@/utils/chat/historyMerge'
 
 type RpcClient = {
@@ -95,6 +96,7 @@ export function useChatHistory(options: UseChatHistoryOptions) {
     // History rows carry the turn's reasoning text but not the measured
     // thinking duration; live turn records re-fill seconds after sync.
     const reasoningText = typeof msg.reasoning_content === 'string' ? msg.reasoning_content.trim() : ''
+    const messageId = msg.message_id || msg.id || ''
     return {
       role: msg.role || 'assistant',
       text: msg.role === 'user' ? options.stripTimePrefix(msg.text || '') : msg.text || '',
@@ -104,7 +106,7 @@ export function useChatHistory(options: UseChatHistoryOptions) {
       artifacts: msg.artifacts || [],
       tool_calls: recordArray<RawToolCallPayload>(msg.tool_calls),
       timeline: recordArray<ChatTimelineSegment>(msg.timeline),
-      attachments: msg.attachments || [],
+      attachments: normalizeDisplayAttachments(msg.attachments, { messageId }),
       provenanceKind: msg.provenance_kind || '',
       provenanceSourceSessionKey: msg.provenance_source_session_key || '',
       provenanceSourceTool: msg.provenance_source_tool || '',
@@ -112,7 +114,7 @@ export function useChatHistory(options: UseChatHistoryOptions) {
       model: msg.model || undefined,
       input: msg.input || msg.input_tokens || undefined,
       output: msg.output || msg.output_tokens || undefined,
-      messageId: msg.message_id || msg.id || '',
+      messageId,
       restoredFromHistory: true,
     }
   }

--- a/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { useChatSend, type UseChatSendOptions } from './useChatSend'
+import type { FoldLiveTurnMode } from './useChatTurnLog'
+import type { Attachment, ChatMessage } from '@/types/chat'
+import type { BusySendMode } from '@/composables/chat/useChatPendingQueue'
+
+const pushToast = vi.hoisted(() => vi.fn())
+
+vi.mock('@/composables/useToasts', () => ({
+  useToasts: () => ({ pushToast }),
+}))
+
+function makeOptions(overrides: Partial<UseChatSendOptions> = {}) {
+  const rpc = {
+    call: vi.fn().mockResolvedValue({ sessionKey: 'agent:main:webchat:test' }),
+  }
+  const stream: UseChatSendOptions['stream'] = {
+    isStreaming: ref(false),
+    streamBubble: ref(false),
+    streamHasVisibleOutput: ref(false),
+    startStreaming: vi.fn(),
+    endStreaming: vi.fn(),
+    appendDelta: vi.fn(),
+    scheduleRender: vi.fn(),
+    appendToolCall: vi.fn(),
+    appendToolDelta: vi.fn(),
+    appendToolResult: vi.fn(),
+    appendArtifact: vi.fn(),
+    reconcileFinalText: vi.fn(),
+    resetStreamIdleTimer: vi.fn(),
+    clearStreamIdleTimer: vi.fn(),
+    setStreamActivity: vi.fn(),
+    showThinkingIndicator: vi.fn(),
+    hideThinkingIndicator: vi.fn(),
+    appendFrame: vi.fn(),
+    useReducer: ref<FoldLiveTurnMode>(false),
+  }
+  const options: UseChatSendOptions = {
+    rpc,
+    inputText: ref('hello'),
+    messages: ref<ChatMessage[]>([]),
+    sessionKey: ref('agent:main:webchat:test'),
+    busySendMode: ref<BusySendMode>('queue'),
+    elevatedMode: ref(''),
+    pendingAttachments: ref<Attachment[]>([]),
+    pendingSessionIntent: ref(null),
+    aborted: ref(false),
+    activeStreamTaskId: ref(''),
+    autoScroll: ref(false),
+    stream,
+    normalizeElevatedMode: mode => mode,
+    persistSession: vi.fn(),
+    isCompactInFlightForCurrentSession: () => false,
+    hasPendingAttachmentWork: () => false,
+    enqueuePendingInput: vi.fn(() => true),
+    popAllPendingIntoComposer: vi.fn(() => false),
+    executeSlashCommand: vi.fn(async () => false),
+    closeSlashMenu: vi.fn(),
+    autoResizeTextarea: vi.fn(),
+    scrollToBottom: vi.fn(),
+    ...overrides,
+  }
+  return { api: useChatSend(options), options, rpc, stream }
+}
+
+describe('useChatSend attachment payloads', () => {
+  it('serializes only sendable attachments and leaves failed attachments in the composer', async () => {
+    const failed: Attachment = {
+      kind: 'failed',
+      local_id: 1,
+      name: 'failed.pdf',
+      mime: 'application/pdf',
+      error: 'HTTP 500',
+      file: new File(['failed'], 'failed.pdf', { type: 'application/pdf' }),
+    }
+    const ready: Attachment = {
+      kind: 'staged',
+      local_id: 2,
+      name: 'ready.pdf',
+      mime: 'application/pdf',
+      file_uuid: 'file-ready',
+    }
+    const pendingAttachments = ref<Attachment[]>([failed, ready])
+    const { api, options, rpc } = makeOptions({ pendingAttachments })
+
+    await api.onSend()
+
+    expect(rpc.call).toHaveBeenCalledWith('chat.send', expect.objectContaining({
+      attachments: [
+        { type: 'application/pdf', file_uuid: 'file-ready', mime: 'application/pdf', name: 'ready.pdf' },
+      ],
+    }))
+    expect(options.messages.value[0]).toMatchObject({
+      role: 'user',
+      text: 'hello',
+      attachments: [
+        { kind: 'staged', displayId: 'local:2', renderKey: 'local:2', name: 'ready.pdf', mime: 'application/pdf' },
+      ],
+    })
+    expect(JSON.stringify(options.messages.value[0])).not.toContain('file-ready')
+    expect(JSON.stringify(options.messages.value[0])).not.toContain('failed.pdf')
+    expect(pendingAttachments.value).toEqual([failed])
+  })
+
+  it('does not dispatch an empty failed-only attachment draft', async () => {
+    const failed: Attachment = {
+      kind: 'failed',
+      local_id: 1,
+      name: 'failed.pdf',
+      mime: 'application/pdf',
+      error: 'HTTP 500',
+      file: new File(['failed'], 'failed.pdf', { type: 'application/pdf' }),
+    }
+    const pendingAttachments = ref<Attachment[]>([failed])
+    const { api, rpc } = makeOptions({
+      inputText: ref(''),
+      pendingAttachments,
+    })
+
+    await api.onSend()
+
+    expect(rpc.call).not.toHaveBeenCalled()
+    expect(pendingAttachments.value).toEqual([failed])
+  })
+
+  it('restores staged attachments if chat.send fails after upload succeeded', async () => {
+    const ready: Attachment = {
+      kind: 'staged',
+      local_id: 1,
+      name: 'ready.pdf',
+      mime: 'application/pdf',
+      file_uuid: 'file-ready',
+    }
+    const pendingAttachments = ref<Attachment[]>([ready])
+    const rpc = {
+      call: vi.fn().mockRejectedValue(new Error('network down')),
+    }
+    const { api, options } = makeOptions({ rpc, pendingAttachments })
+
+    await api.onSend()
+
+    expect(pendingAttachments.value).toEqual([ready])
+    expect(options.messages.value[options.messages.value.length - 1]).toMatchObject({
+      role: 'error',
+      text: 'Send failed: network down',
+    })
+  })
+})

--- a/opensquilla-webui/src/composables/chat/useChatSend.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.ts
@@ -9,6 +9,7 @@ import type {
 import type { ChatRpcStreamApi } from '@/composables/chat/useChatRpcEventHandlers'
 import type { BusySendMode } from '@/composables/chat/useChatPendingQueue'
 import { recordSessionNavigationDiag } from '@/utils/chat/sessionNavigationDiag'
+import { isSendableAttachment, serializeDisplayAttachment, serializeSendableAttachment, type SendableAttachment } from '@/utils/chat/attachments'
 
 type RpcClient = {
   call: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
@@ -73,7 +74,8 @@ export function useChatSend(options: UseChatSendOptions) {
 
   async function onSend() {
     let text = options.inputText.value.trim()
-    let hasPayload = text || options.pendingAttachments.value.length > 0
+    let sendableAttachments = options.pendingAttachments.value.filter(isSendableAttachment)
+    let hasPayload = text || sendableAttachments.length > 0
     let isLiteralSlash = false
 
     if (options.hasPendingAttachmentWork()) {
@@ -84,7 +86,8 @@ export function useChatSend(options: UseChatSendOptions) {
     if (text.startsWith('//')) {
       isLiteralSlash = true
       text = text.slice(1)
-      hasPayload = text || options.pendingAttachments.value.length > 0
+      sendableAttachments = options.pendingAttachments.value.filter(isSendableAttachment)
+      hasPayload = text || sendableAttachments.length > 0
     }
 
     const compactInFlight = options.isCompactInFlightForCurrentSession()
@@ -124,6 +127,8 @@ export function useChatSend(options: UseChatSendOptions) {
   async function dispatchSend(text: string, sendOpts?: { queueMode?: 'steer' }) {
     const requestSessionKey = options.sessionKey.value
     if (!requestSessionKey) return
+    const attachmentsToSend = options.pendingAttachments.value.filter(isSendableAttachment)
+    const attachmentsToKeep = options.pendingAttachments.value.filter(a => !isSendableAttachment(a))
 
     options.aborted.value = false
     options.closeSlashMenu()
@@ -134,7 +139,13 @@ export function useChatSend(options: UseChatSendOptions) {
 
     const now = new Date().toISOString()
     const userText = text
-    options.messages.value.push({ role: 'user', text: userText, ts: now })
+    const displayAttachments = attachmentsToSend.map(serializeDisplayAttachment)
+    options.messages.value.push({
+      role: 'user',
+      text: userText,
+      ts: now,
+      ...(displayAttachments.length > 0 ? { attachments: displayAttachments } : {}),
+    })
     options.autoScroll.value = true
     options.scrollToBottom()
 
@@ -146,17 +157,14 @@ export function useChatSend(options: UseChatSendOptions) {
       params.intent = options.pendingSessionIntent.value
       options.pendingSessionIntent.value = null
     }
-    if (options.pendingAttachments.value.length > 0) {
+    if (attachmentsToSend.length > 0) {
       params.displayText = userText
-      params.attachments = options.pendingAttachments.value.map((a) => {
-        if (a.kind === 'staged') return { type: a.mime, file_uuid: a.file_uuid, mime: a.mime, name: a.name }
-        return { type: a.mime || 'image/png', data: a.data, mime: a.mime, name: a.name }
-      })
+      params.attachments = attachmentsToSend.map(serializeSendableAttachment)
     }
 
     options.inputText.value = ''
     options.autoResizeTextarea()
-    options.pendingAttachments.value = []
+    options.pendingAttachments.value = attachmentsToKeep
 
     // A steer send rides an already-active stream; restarting it would wipe
     // the partial output of the run being steered.
@@ -206,8 +214,18 @@ export function useChatSend(options: UseChatSendOptions) {
         return
       }
       if (!wasStreaming) options.stream.endStreaming()
+      restoreSendableAttachments(attachmentsToSend)
       const message = errorMessage(err)
       options.messages.value.push({ role: 'error', text: 'Send failed: ' + message, ts: new Date().toISOString() })
+    }
+  }
+
+  function restoreSendableAttachments(attachments: SendableAttachment[]) {
+    if (attachments.length === 0) return
+    const currentLocalIds = new Set(options.pendingAttachments.value.map(attachment => attachment.local_id))
+    const missing = attachments.filter(attachment => !currentLocalIds.has(attachment.local_id))
+    if (missing.length > 0) {
+      options.pendingAttachments.value = [...missing, ...options.pendingAttachments.value]
     }
   }
 

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -1414,6 +1414,8 @@
     "remove": "Entfernen",
     "attachFiles": "Dateien anhängen",
     "attachFilesTitle": "Dateien anhängen: PNG, JPEG, GIF, WEBP, PDF, TXT, MD, HTML, CSV, JSON",
+    "dropOverlayTitle": "Zum Anhängen loslassen",
+    "dropOverlayHint": "Dateien werden dem Verfasser hinzugefügt",
     "composerSettings": "Verfasser-Einstellungen",
     "closeComposerSettings": "Verfasser-Einstellungen schließen",
     "recordVoice": "Spracheingabe aufnehmen",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -1414,6 +1414,8 @@
     "remove": "Remove",
     "attachFiles": "Attach files",
     "attachFilesTitle": "Attach files: PNG, JPEG, GIF, WEBP, PDF, TXT, MD, HTML, CSV, JSON",
+    "dropOverlayTitle": "Drop to attach",
+    "dropOverlayHint": "Files will be added to the composer",
     "composerSettings": "Composer settings",
     "closeComposerSettings": "Close composer settings",
     "recordVoice": "Record voice input",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -1414,6 +1414,8 @@
     "remove": "Quitar",
     "attachFiles": "Adjuntar archivos",
     "attachFilesTitle": "Adjuntar archivos: PNG, JPEG, GIF, WEBP, PDF, TXT, MD, HTML, CSV, JSON",
+    "dropOverlayTitle": "Suelta para adjuntar",
+    "dropOverlayHint": "Los archivos se añadirán al redactor",
     "composerSettings": "Ajustes del redactor",
     "closeComposerSettings": "Cerrar ajustes del redactor",
     "recordVoice": "Grabar entrada de voz",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -1414,6 +1414,8 @@
     "remove": "Supprimer",
     "attachFiles": "Joindre des fichiers",
     "attachFilesTitle": "Joindre des fichiers : PNG, JPEG, GIF, WEBP, PDF, TXT, MD, HTML, CSV, JSON",
+    "dropOverlayTitle": "Déposez pour joindre",
+    "dropOverlayHint": "Les fichiers seront ajoutés au compositeur",
     "composerSettings": "Paramètres du compositeur",
     "closeComposerSettings": "Fermer les paramètres du compositeur",
     "recordVoice": "Enregistrer une entrée vocale",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -1414,6 +1414,8 @@
     "remove": "削除",
     "attachFiles": "ファイルを添付",
     "attachFilesTitle": "ファイルを添付: PNG、JPEG、GIF、WEBP、PDF、TXT、MD、HTML、CSV、JSON",
+    "dropOverlayTitle": "離して添付",
+    "dropOverlayHint": "ファイルは入力欄に追加されます",
     "composerSettings": "入力欄の設定",
     "closeComposerSettings": "入力欄の設定を閉じる",
     "recordVoice": "音声入力を録音",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -1414,6 +1414,8 @@
     "remove": "移除",
     "attachFiles": "添加文件",
     "attachFilesTitle": "添加文件：PNG、JPEG、GIF、WEBP、PDF、TXT、MD、HTML、CSV、JSON",
+    "dropOverlayTitle": "松开即可附加",
+    "dropOverlayHint": "文件会添加到输入框",
     "composerSettings": "输入框设置",
     "closeComposerSettings": "关闭输入框设置",
     "recordVoice": "录制语音输入",

--- a/opensquilla-webui/src/styles/chat-view.css
+++ b/opensquilla-webui/src/styles/chat-view.css
@@ -284,6 +284,7 @@
 }
 
 .chat-body {
+  position: relative;
   flex: 1;
   overflow: hidden;
   display: flex;
@@ -1071,8 +1072,137 @@
 }
 
 /* Drag over */
-.drag-over {
-  background: color-mix(in srgb, var(--info) 5%, transparent);
+.chat-drop-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 2.4vw, 1.75rem);
+  overflow: hidden;
+  background: color-mix(in srgb, var(--bg-surface) 58%, transparent);
+  backdrop-filter: blur(16px) saturate(0.9);
+  -webkit-backdrop-filter: blur(16px) saturate(0.9);
+  color: var(--text);
+  pointer-events: none;
+}
+
+.chat-drop-overlay__frame {
+  position: absolute;
+  inset: clamp(0.875rem, 2vw, 1.5rem);
+  border: 1px solid color-mix(in srgb, var(--info) 42%, var(--border));
+  border-radius: var(--radius-lg);
+  opacity: 0.92;
+}
+
+.chat-drop-overlay__frame::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--text) 8%, transparent);
+}
+
+.chat-drop-overlay__frame::after {
+  content: none;
+}
+
+.chat-drop-overlay__beacon {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  width: min(21rem, 100%);
+  text-align: center;
+  animation: chat-drop-beacon-in var(--dur-enter) var(--ease-out);
+}
+
+.chat-drop-overlay__glyph {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 5rem;
+  height: 5rem;
+  border: 1px solid color-mix(in srgb, var(--info) 44%, var(--border));
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--bg-elevated) 54%, transparent);
+  box-shadow:
+    0 18px 44px color-mix(in srgb, var(--bg) 24%, transparent),
+    inset 0 0 0 8px color-mix(in srgb, var(--bg-surface) 24%, transparent);
+  color: var(--text);
+}
+
+.chat-drop-overlay__glyph::before {
+  content: "";
+  position: absolute;
+  inset: 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--accent) 34%, transparent);
+  border-radius: 50%;
+}
+
+.chat-drop-overlay__plus {
+  position: absolute;
+  right: 0.75rem;
+  bottom: 0.8rem;
+  display: grid;
+  place-items: center;
+  width: 1.35rem;
+  height: 1.35rem;
+  border: 1px solid color-mix(in srgb, var(--bg-surface) 72%, transparent);
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--accent-foreground);
+  box-shadow: 0 0.4rem 1rem color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
+.chat-drop-overlay__copy {
+  display: grid;
+  gap: 0.3125rem;
+  max-width: 20rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-surface) 62%, transparent);
+  box-shadow: 0 0.75rem 2rem color-mix(in srgb, var(--bg) 16%, transparent);
+}
+
+.chat-drop-overlay__title {
+  color: var(--text);
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.chat-drop-overlay__hint {
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+@keyframes chat-drop-beacon-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.4rem) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .chat-drop-overlay {
+    background: color-mix(in srgb, var(--bg-surface) 88%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-drop-overlay__beacon {
+    animation: none;
+  }
 }
 
 /* Hidden */

--- a/opensquilla-webui/src/types/chat.ts
+++ b/opensquilla-webui/src/types/chat.ts
@@ -2,7 +2,7 @@ import type { ArtifactPayload } from './rpc'
 import type { IconName } from '@/utils/icons'
 
 export interface Attachment {
-  kind: 'inline' | 'staged' | 'inline_pending' | 'uploading'
+  kind: 'inline' | 'staged' | 'inline_pending' | 'uploading' | 'failed'
   local_id: number
   name: string
   mime: string
@@ -10,6 +10,21 @@ export interface Attachment {
   data?: string
   dataUrl?: string
   file_uuid?: string
+  error?: string
+  file?: File
+}
+
+export interface DisplayAttachment {
+  kind: 'inline' | 'staged' | 'file'
+  displayId: string
+  renderKey: string
+  name: string
+  mime: string
+  size?: number
+  data?: string
+  dataUrl?: string
+  download_url?: string
+  sha256_ref?: string
 }
 
 export interface ChatPendingItem {
@@ -177,7 +192,7 @@ export interface ChatMessage {
   artifacts?: ArtifactPayload[]
   tool_calls?: RawToolCallPayload[]
   timeline?: ChatTimelineSegment[]
-  attachments?: Attachment[]
+  attachments?: DisplayAttachment[]
   provenanceKind?: string
   provenanceSourceSessionKey?: string
   provenanceSourceTool?: string
@@ -224,7 +239,7 @@ export interface ChatRenderedMessage {
   isStreaming?: boolean
   messageId?: string
   hasAttachments?: boolean
-  attachments?: Attachment[]
+  attachments?: DisplayAttachment[]
   toolCalls?: ChatToolCall[]
   timelineItems?: ChatStreamTimelineItem[]
   artifacts?: ArtifactPayload[]

--- a/opensquilla-webui/src/types/rpc.ts
+++ b/opensquilla-webui/src/types/rpc.ts
@@ -1,5 +1,3 @@
-import type { Attachment } from './chat'
-
 export interface AgentOption {
   id: string
   name: string
@@ -252,6 +250,23 @@ export interface ChatSendResponse {
   taskId?: string
 }
 
+export interface ChatHistoryAttachmentPayload {
+  type?: unknown
+  mime?: unknown
+  mime_type?: unknown
+  media_type?: unknown
+  name?: unknown
+  filename?: unknown
+  size?: unknown
+  data?: unknown
+  dataUrl?: unknown
+  data_url?: unknown
+  sha256_ref?: unknown
+  download_url?: unknown
+  kind?: unknown
+  [key: string]: unknown
+}
+
 export interface ChatHistoryMessage {
   role?: string
   text?: string
@@ -259,7 +274,7 @@ export interface ChatHistoryMessage {
   ts?: string | number | null
   id?: string
   message_id?: string
-  attachments?: Attachment[]
+  attachments?: ChatHistoryAttachmentPayload[]
   artifacts?: ArtifactPayload[]
   router_decision?: RouterDecisionPayload | null
   routerDecision?: RouterDecisionPayload | null

--- a/opensquilla-webui/src/utils/chat/attachments.test.ts
+++ b/opensquilla-webui/src/utils/chat/attachments.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isImageDisplayAttachment,
+  normalizeDisplayAttachment,
+  normalizeDisplayAttachments,
+  serializeDisplayAttachment,
+} from './attachments'
+import type { Attachment } from '@/types/chat'
+
+describe('attachment display normalization', () => {
+  it('renders inline HTML history attachments as file chips without data payloads', () => {
+    const attachment = normalizeDisplayAttachment(
+      { type: 'text/html', name: 'preview.html', data: 'PGh0bWw+' },
+      { messageId: 'm1', index: 0 },
+    )
+
+    expect(attachment).toMatchObject({
+      kind: 'inline',
+      displayId: 'm1:att:0',
+      renderKey: 'm1:att:0',
+      name: 'preview.html',
+      mime: 'text/html',
+    })
+    expect(attachment.data).toBeUndefined()
+    expect(attachment.dataUrl).toBeUndefined()
+    expect(isImageDisplayAttachment(attachment)).toBe(false)
+  })
+
+  it('keeps inline image data for image history attachments', () => {
+    const attachment = normalizeDisplayAttachment(
+      { type: 'image/png', name: 'photo.png', data: 'aW1hZ2U=' },
+      { messageId: 'm1', index: 1 },
+    )
+
+    expect(attachment).toMatchObject({
+      kind: 'inline',
+      displayId: 'm1:att:1',
+      name: 'photo.png',
+      mime: 'image/png',
+      data: 'aW1hZ2U=',
+    })
+    expect(isImageDisplayAttachment(attachment)).toBe(true)
+  })
+
+  it('preserves staged history refs without exposing file_uuid', () => {
+    const attachment = normalizeDisplayAttachment(
+      {
+        sha256_ref: 'd'.repeat(64),
+        name: 'report.pdf',
+        mime: 'application/pdf',
+        size: 1234,
+        download_url: '/api/v1/attachments/d',
+        file_uuid: 'u-secret',
+      },
+      { messageId: 'm2', index: 0 },
+    )
+
+    expect(attachment).toMatchObject({
+      kind: 'staged',
+      displayId: `sha:${'d'.repeat(64)}:0`,
+      name: 'report.pdf',
+      mime: 'application/pdf',
+      size: 1234,
+      download_url: '/api/v1/attachments/d',
+      sha256_ref: 'd'.repeat(64),
+    })
+    expect(JSON.stringify(attachment)).not.toContain('u-secret')
+    expect(attachment.data).toBeUndefined()
+  })
+
+  it('chooses the first valid MIME-like value and ignores generic type values', () => {
+    expect(normalizeDisplayAttachment({ mime: 'file', mime_type: 'application/pdf', type: 'image/png' }).mime).toBe('application/pdf')
+    expect(normalizeDisplayAttachment({ media_type: 'text/csv', type: 'image/png' }).mime).toBe('text/csv')
+    expect(normalizeDisplayAttachment({ type: 'file' }).mime).toBe('application/octet-stream')
+  })
+
+  it('preserves data only when the inferred MIME is image/*', () => {
+    const nonImage = normalizeDisplayAttachment({
+      mime_type: 'application/pdf',
+      type: 'image/png',
+      data: 'payload',
+      dataUrl: 'data:image/png;base64,payload',
+    })
+    const image = normalizeDisplayAttachment({
+      mime: 'image/webp',
+      type: 'attachment',
+      data: 'payload',
+      dataUrl: 'data:image/webp;base64,payload',
+    })
+
+    expect(nonImage.mime).toBe('application/pdf')
+    expect(nonImage.data).toBeUndefined()
+    expect(nonImage.dataUrl).toBeUndefined()
+    expect(image.data).toBe('payload')
+    expect(image.dataUrl).toBe('data:image/webp;base64,payload')
+  })
+
+  it('normalizes batches with stable index-based keys for duplicate filenames', () => {
+    const attachments = normalizeDisplayAttachments([
+      { type: 'text/plain', name: 'same.txt', data: 'a' },
+      { type: 'text/plain', name: 'same.txt', data: 'b' },
+    ], { messageId: 'm3' })
+
+    expect(attachments.map(att => att.renderKey)).toEqual(['m3:att:0', 'm3:att:1'])
+  })
+})
+
+describe('attachment send display serialization', () => {
+  it('serializes staged optimistic display attachments without file_uuid or local_id', () => {
+    const staged: Attachment & { kind: 'staged'; file_uuid: string } = {
+      kind: 'staged',
+      local_id: 7,
+      name: 'ready.pdf',
+      mime: 'application/pdf',
+      file_uuid: 'u-secret',
+    }
+
+    const display = serializeDisplayAttachment(staged)
+
+    expect(display).toMatchObject({
+      kind: 'staged',
+      displayId: 'local:7',
+      renderKey: 'local:7',
+      name: 'ready.pdf',
+      mime: 'application/pdf',
+    })
+    expect(JSON.stringify(display)).not.toContain('u-secret')
+    expect(JSON.stringify(display)).not.toContain('local_id')
+  })
+
+  it('strips non-image inline optimistic data but keeps image data', () => {
+    const text: Attachment & { kind: 'inline'; data: string } = {
+      kind: 'inline',
+      local_id: 1,
+      name: 'preview.html',
+      mime: 'text/html',
+      data: 'PGh0bWw+',
+      dataUrl: 'data:text/html;base64,PGh0bWw+',
+    }
+    const image: Attachment & { kind: 'inline'; data: string } = {
+      kind: 'inline',
+      local_id: 2,
+      name: 'photo.png',
+      mime: 'image/png',
+      data: 'aW1hZ2U=',
+      dataUrl: 'data:image/png;base64,aW1hZ2U=',
+    }
+
+    expect(serializeDisplayAttachment(text).data).toBeUndefined()
+    expect(serializeDisplayAttachment(text).dataUrl).toBeUndefined()
+    expect(serializeDisplayAttachment(image).data).toBe('aW1hZ2U=')
+    expect(serializeDisplayAttachment(image).dataUrl).toBe('data:image/png;base64,aW1hZ2U=')
+  })
+})

--- a/opensquilla-webui/src/utils/chat/attachments.ts
+++ b/opensquilla-webui/src/utils/chat/attachments.ts
@@ -1,0 +1,146 @@
+import type { Attachment, DisplayAttachment } from '@/types/chat'
+import type { ChatHistoryAttachmentPayload, ChatSendAttachmentPayload } from '@/types/rpc'
+
+export type SendableAttachment = Attachment & (
+  | { kind: 'inline'; data: string }
+  | { kind: 'staged'; file_uuid: string }
+)
+
+export function isAttachmentBusy(attachment: Attachment): boolean {
+  return attachment.kind === 'inline_pending' || attachment.kind === 'uploading'
+}
+
+export function isMimeLike(value: unknown): value is string {
+  return typeof value === 'string' && /^[^/\s]+\/[^/\s;]+(?:\s*;.*)?$/.test(value.trim())
+}
+
+export function normalizeAttachmentMimeValue(value: unknown, fallback = 'application/octet-stream'): string {
+  return isMimeLike(value) ? value.trim().toLowerCase() : fallback
+}
+
+export function displayAttachmentMime(attachment: Record<string, unknown>): string {
+  for (const key of ['mime', 'mime_type', 'media_type', 'type']) {
+    const value = attachment[key]
+    if (isMimeLike(value)) return value.trim().toLowerCase()
+  }
+  return 'application/octet-stream'
+}
+
+export function isImageAttachmentMime(mime: unknown): boolean {
+  return normalizeAttachmentMimeValue(mime, '').startsWith('image/')
+}
+
+export function isImageDisplayAttachment(attachment: Pick<DisplayAttachment, 'mime'> | Pick<Attachment, 'mime'>): boolean {
+  return isImageAttachmentMime(attachment.mime)
+}
+
+export function isSendableAttachment(attachment: Attachment): attachment is SendableAttachment {
+  if (attachment.kind === 'inline') return Boolean(attachment.data)
+  if (attachment.kind === 'staged') return Boolean(attachment.file_uuid)
+  return false
+}
+
+export function serializeSendableAttachment(attachment: SendableAttachment): ChatSendAttachmentPayload {
+  if (attachment.kind === 'staged') {
+    return {
+      type: attachment.mime,
+      file_uuid: attachment.file_uuid,
+      mime: attachment.mime,
+      name: attachment.name,
+    }
+  }
+  return {
+    type: attachment.mime || 'image/png',
+    data: attachment.data,
+    mime: attachment.mime,
+    name: attachment.name,
+  }
+}
+
+export function serializeDisplayAttachment(attachment: SendableAttachment): DisplayAttachment {
+  const displayId = `local:${attachment.local_id}`
+  const base = {
+    displayId,
+    renderKey: displayId,
+    name: attachment.name,
+    mime: attachment.mime,
+    size: attachment.size,
+  }
+  if (attachment.kind === 'staged') {
+    return { ...base, kind: 'staged' }
+  }
+  const isImage = isImageDisplayAttachment(attachment)
+  return {
+    ...base,
+    kind: 'inline',
+    data: isImage ? attachment.data : undefined,
+    dataUrl: isImage ? attachment.dataUrl : undefined,
+  }
+}
+
+export function normalizeDisplayAttachment(
+  raw: Attachment | DisplayAttachment | ChatHistoryAttachmentPayload,
+  options: { messageId?: string, index?: number } = {},
+): DisplayAttachment {
+  const record = raw as Record<string, unknown>
+  const mime = displayAttachmentMime(record)
+  const image = isImageAttachmentMime(mime)
+  const name = typeof record.name === 'string' && record.name.trim()
+    ? record.name.trim()
+    : typeof record.filename === 'string' && record.filename.trim()
+      ? record.filename.trim()
+      : 'attachment'
+  const sha = typeof record.sha256_ref === 'string' && record.sha256_ref.trim()
+    ? record.sha256_ref.trim()
+    : ''
+  const existingDisplayId = typeof record.displayId === 'string' && record.displayId.trim()
+    ? record.displayId.trim()
+    : ''
+  const localId = typeof record.local_id === 'number' && Number.isFinite(record.local_id)
+    ? `local:${record.local_id}`
+    : ''
+  const index = typeof options.index === 'number' ? options.index : 0
+  const messagePart = options.messageId || 'history'
+  const displayId = existingDisplayId || localId || (sha ? `sha:${sha}:${index}` : `${messagePart}:att:${index}`)
+  const size = typeof record.size === 'number' && Number.isFinite(record.size)
+    ? record.size
+    : typeof record.size === 'string' && Number.isFinite(Number(record.size))
+      ? Number(record.size)
+      : undefined
+  const data = typeof record.data === 'string' ? record.data : undefined
+  const dataUrl = typeof record.dataUrl === 'string'
+    ? record.dataUrl
+    : typeof record.data_url === 'string'
+      ? record.data_url
+      : undefined
+  const rawKind = typeof record.kind === 'string' ? record.kind : ''
+  const kind: DisplayAttachment['kind'] = rawKind === 'staged' || sha
+    ? 'staged'
+    : rawKind === 'inline' || data || dataUrl
+      ? 'inline'
+      : 'file'
+
+  return {
+    kind,
+    displayId,
+    renderKey: typeof record.renderKey === 'string' && record.renderKey.trim()
+      ? record.renderKey.trim()
+      : displayId,
+    name,
+    mime,
+    size,
+    data: image ? data : undefined,
+    dataUrl: image ? dataUrl : undefined,
+    download_url: typeof record.download_url === 'string' ? record.download_url : undefined,
+    sha256_ref: sha || undefined,
+  }
+}
+
+export function normalizeDisplayAttachments(
+  attachments: Array<Attachment | DisplayAttachment | ChatHistoryAttachmentPayload> | undefined,
+  options: { messageId?: string } = {},
+): DisplayAttachment[] {
+  return (attachments || []).map((attachment, index) =>
+    normalizeDisplayAttachment(attachment, { messageId: options.messageId, index }),
+  )
+}

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -1,5 +1,26 @@
 <template>
-  <div class="chat" :class="{ 'chat--new-landing': isNewChatLanding }">
+  <div
+    class="chat"
+    :class="{ 'chat--new-landing': isNewChatLanding, 'chat--drag-over': threadDragOver }"
+    @dragenter="onChatDragEnter"
+    @dragover="onChatDragOver"
+    @dragleave="onChatDragLeave"
+    @drop="onChatDrop"
+  >
+    <div v-if="threadDragOver" class="chat-drop-overlay" role="status" aria-live="polite" aria-atomic="true">
+      <div class="chat-drop-overlay__frame" aria-hidden="true"></div>
+      <div class="chat-drop-overlay__beacon">
+        <span class="chat-drop-overlay__glyph" aria-hidden="true">
+          <Icon name="fileText" :size="30" />
+          <Icon class="chat-drop-overlay__plus" name="plus" :size="12" />
+        </span>
+        <span class="chat-drop-overlay__copy">
+          <span class="chat-drop-overlay__title">{{ t('chat.dropOverlayTitle') }}</span>
+          <span class="chat-drop-overlay__hint">{{ t('chat.dropOverlayHint') }}</span>
+        </span>
+      </div>
+    </div>
+
     <!-- Header -->
     <div v-if="!isNewChatLanding" class="chat-header">
       <div class="chat-header-left">
@@ -91,10 +112,6 @@
         :aria-label="t('chat.conversation')"
         :aria-busy="isStreaming"
         @scroll="onThreadScroll"
-        @dragover.prevent="threadDragOver = true"
-        @dragleave="threadDragOver = false"
-        @drop.prevent="onThreadDrop"
-        :class="{ 'drag-over': threadDragOver }"
       >
         <template v-if="isNewChatLanding">
           <div ref="agentSwitcherRef" class="chat-landing-agent">
@@ -432,6 +449,7 @@
       @input="onTextareaInput"
       @keydown="onTextareaKeydown"
       @remove-attachment="removeAttachment"
+      @retry-attachment="retryAttachment"
       @set-busy-send-mode="busySendMode = $event"
       @set-elevated-mode="setComposerElevatedMode"
       @set-router-enabled="setComposerRouterEnabled"
@@ -563,6 +581,7 @@ import {
   toolSecondaryText,
   toolStatusText,
 } from '@/utils/chat/toolDisplay'
+import { isSendableAttachment } from '@/utils/chat/attachments'
 import { isShareableChatMessage } from '@/utils/chat/messageIdentity'
 import { agentIdFromSessionKey, normalizeAgentId } from '@/utils/chat/sessionKeys'
 
@@ -627,6 +646,7 @@ const messages = ref<Message[]>([])
 const lastHeaderRole = ref('')
 const lastHeaderDay = ref('')
 const threadDragOver = ref(false)
+const threadDragDepth = ref(0)
 const shareMode = ref(false)
 const shareSaving = ref(false)
 const selectedShareMessageIds = ref<Set<string>>(new Set())
@@ -752,8 +772,9 @@ const chatAttachments = useChatAttachments()
 const {
   pendingAttachments,
   onFileInputChange,
-  addAttachment,
+  addAttachments,
   removeAttachment,
+  retryAttachment,
   hasPendingAttachmentWork,
 } = chatAttachments
 
@@ -1380,7 +1401,7 @@ const composerPlaceholder = computed(() => {
 })
 
 const hasSendContent = computed(() => {
-  return inputText.value.trim().length > 0 || pendingAttachments.value.length > 0
+  return inputText.value.trim().length > 0 || pendingAttachments.value.some(isSendableAttachment)
 })
 
 const sendButtonTitle = computed(() => {
@@ -1794,11 +1815,42 @@ function showToolResultModal(content: string, title = t('chat.toolResult')) {
 
 /* ── Attachments ───────────────────────────────────────────────────── */
 
-function onThreadDrop(e: DragEvent) {
-  threadDragOver.value = false
-  if (e.dataTransfer?.files) {
-    Array.from(e.dataTransfer.files).forEach(addAttachment)
+function dragEventHasFiles(e: DragEvent): boolean {
+  const types = Array.from(e.dataTransfer?.types || [])
+  return types.includes('Files')
+}
+
+function onChatDragEnter(e: DragEvent) {
+  if (!dragEventHasFiles(e)) return
+  e.preventDefault()
+  threadDragDepth.value += 1
+  threadDragOver.value = true
+}
+
+function onChatDragOver(e: DragEvent) {
+  if (!dragEventHasFiles(e)) return
+  e.preventDefault()
+  if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
+  threadDragOver.value = true
+}
+
+function onChatDragLeave(e: DragEvent) {
+  if (!dragEventHasFiles(e)) return
+  threadDragDepth.value = Math.max(0, threadDragDepth.value - 1)
+  if (threadDragDepth.value === 0) {
+    threadDragOver.value = false
   }
+}
+
+function onChatDrop(e: DragEvent) {
+  e.preventDefault()
+  threadDragDepth.value = 0
+  threadDragOver.value = false
+  if (!dragEventHasFiles(e)) return
+  const files = Array.from(e.dataTransfer?.files || [])
+  if (files.length === 0) return
+  void addAttachments(files)
+  composerRef.value?.focusTextarea()
 }
 
 /* ── Textarea ──────────────────────────────────────────────────────── */
@@ -1812,16 +1864,18 @@ function autoResizeTextarea() {
 function onDocumentPaste(e: ClipboardEvent) {
   const items = e.clipboardData?.items
   if (!items) return
+  const files: File[] = []
   let attachedImage = false
   for (let i = 0; i < items.length; i++) {
     if (items[i].type.startsWith('image/')) {
       const file = items[i].getAsFile()
       if (file) {
-        addAttachment(file)
+        files.push(file)
         attachedImage = true
       }
     }
   }
+  if (files.length > 0) void addAttachments(files)
   // Screenshot tools put both the image and its local file path on the
   // clipboard; once we have attached the image, suppress the default paste so
   // the path text is not also dumped into the composer (and then sent to the


### PR DESCRIPTION
## Summary

Adds drag-and-drop file attachment support to the chat UI while keeping browser and desktop behavior on the shared WebUI/gateway upload path.

## Changes

- Add chat-surface drag/drop handling with a full-surface glass overlay and stable drag-depth tracking.
- Route file picker, paste, and drop flows through the same attachment batch pipeline.
- Add attachment count and total-size guards, upload auth headers, failed upload state, and retry support.
- Disable attachment-only send until attachments are actually sendable.
- Normalize attachment display data from send/history paths so non-image files render as file chips instead of broken image previews.
- Polish user-message file chips with a dedicated icon, filename, and compact type label.
- Add localized drop-overlay strings.
- Add a feature spec for the attachment drag-and-drop upload flow.
- Add focused unit/e2e coverage for attachment normalization, send serialization, and drag upload behavior.

## Testing

- `npm --prefix opensquilla-webui run typecheck`
- `npm --prefix opensquilla-webui run test:unit -- attachments`
- `OPENSQUILLA_WEBUI_BASE_URL=http://127.0.0.1:18790 npm --prefix opensquilla-webui run test:e2e -- e2e/attachment-drag-upload.spec.ts`
