### PR TITLE
Improve gateway lifecycle conflict diagnostics

### DIFF
--- a/src/opensquilla/cli/gateway_lifecycle.py
+++ b/src/opensquilla/cli/gateway_lifecycle.py
@@ -379,8 +379,9 @@ class GatewayLifecycleManager:
             managed=False,
             code=None if ok else UNMANAGED_GATEWAY_RUNNING,
             message=(
-                "A healthy gateway is already running on the requested host/port, "
-                "but OpenSquilla does not own it."
+                f"A healthy gateway is already running at {_where(self.host, self.port)}, "
+                "but OpenSquilla does not own it. "
+                "Use that URL to talk to the existing gateway, or stop it first."
             ),
             exit_code_value=3,
         )
@@ -393,9 +394,11 @@ class GatewayLifecycleManager:
         pid: int | None,
         record: dict[str, Any],
     ) -> GatewayLifecycleResult:
+        recorded_host = record.get("host") or record.get("recordedHost")
+        recorded_port = record.get("port") or record.get("recordedPort")
         details = {
-            "recordedHost": record.get("host") or record.get("recordedHost"),
-            "recordedPort": record.get("port") or record.get("recordedPort"),
+            "recordedHost": recorded_host,
+            "recordedPort": recorded_port,
             "requestedHost": self.host,
             "requestedPort": self.port,
         }
@@ -410,8 +413,10 @@ class GatewayLifecycleManager:
             managed=True,
             code=None if ok else MANAGED_GATEWAY_TARGET_MISMATCH,
             message=(
-                "A managed gateway is recorded for a different host/port. "
-                "Refusing to mutate it from this target."
+                f"A managed gateway is recorded at {_where(recorded_host, recorded_port)}, "
+                f"but this target is {_where(self.host, self.port)}. "
+                "Refusing to mutate the recorded gateway from this target. "
+                "Use the recorded target, or stop and restart the gateway on the new one."
             ),
             details=details,
             exit_code_value=3,
@@ -675,6 +680,19 @@ def _health_probe_host(host: str) -> str:
 
 def _http_url(host: str, port: int) -> str:
     return f"http://{_format_url_host(host)}:{port}"
+
+
+def _where(host: str | None, port: int | None) -> str:
+    """One-line "url (host=X, port=Y)" used in human error messages.
+
+    Tolerates None inputs (old pidfiles that did not record host/port)
+    by falling back to "<unknown>". Module-level (not a method on
+    GatewayLifecycleManager) so it can format arbitrary host/port pairs
+    such as the recorded target in target_mismatch.
+    """
+    if host is None or port is None:
+        return f"<unknown> (host={host}, port={port})"
+    return f"{_http_url(host, port)} (host={host}, port={port})"
 
 
 def remote_gateway_status(gateway_url: str, *, timeout: float = 0.5) -> GatewayLifecycleResult:

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -269,6 +269,9 @@ def test_gateway_start_refuses_unmanaged_healthy_gateway(tmp_path, monkeypatch) 
     assert payload["ok"] is False
     assert payload["state"] == "unmanaged"
     assert payload["code"] == "UNMANAGED_GATEWAY_RUNNING"
+    assert "http://127.0.0.1:18791" in payload["message"]
+    assert "host=127.0.0.1" in payload["message"]
+    assert "port=18791" in payload["message"]
     assert not gateway_lifecycle.gateway_pidfile_path().exists()
 
 
@@ -580,6 +583,8 @@ def test_gateway_start_refuses_live_pidfile_for_different_target(tmp_path, monke
     payload = _payload(result)
     assert payload["state"] == "target_mismatch"
     assert payload["code"] == "MANAGED_GATEWAY_TARGET_MISMATCH"
+    assert "http://127.0.0.1:18791" in payload["message"]
+    assert "http://127.0.0.1:18792" in payload["message"]
     assert gateway_lifecycle.gateway_pidfile_path().exists()
 
 


### PR DESCRIPTION
Scope: Improve operator-facing diagnostics for local gateway lifecycle conflicts.

Branch target: main

Linked issue: None

If None, reason: Extracts low-risk code from pull request https://github.com/opensquilla/opensquilla/pull/194; this PR is not intended to drive issue label sync for that source PR.

Release note status: Not needed; diagnostic message clarity only.

Test results:
- uv run pytest tests/test_cli/test_gateway_cmd.py -q

Safety notes:
- Does not change gateway process management, pidfile state, exit codes, or JSON state/code/details fields.
- Only expands human-readable message text with URL, host, and port context.

Third-party origin:
- Adapted from tqangxl's gateway lifecycle diagnostics work in https://github.com/opensquilla/opensquilla/pull/194.
- Code commit preserves Tqangxl <tqangxl@gmail.com> as author.
- Source commits: 2028bd19 and fe7b15ce.