### PR TITLE
Fix Ollama / local-provider end-to-end support

### DIFF
--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -2464,6 +2464,7 @@ class Agent:
                                         cache_read_tokens=raw_ev.cached_tokens,
                                         cache_write_tokens=raw_ev.cache_write_tokens,
                                         billed_cost=raw_ev.billed_cost,
+                                        provider=getattr(self.provider, "provider_name", ""),
                                     )
 
                             elif isinstance(raw_ev, ProviderErrorEvent):

--- a/src/opensquilla/engine/pricing.py
+++ b/src/opensquilla/engine/pricing.py
@@ -435,6 +435,11 @@ _PRICING_TABLE: list[tuple[str, PriceEntry]] = [
 
 _DEFAULT_PRICING = PriceEntry(3.0, 15.0)
 
+# Providers whose runtime is local — inference is free regardless of the model
+# id. Their model ids are unqualified (e.g. ``qwen3:4b``), so without this the
+# pricing table misses the ``ollama/`` free entry and applies the cloud default.
+_LOCAL_FREE_PROVIDERS = frozenset({"ollama", "lm_studio", "ovms", "vllm", "local"})
+
 
 def _lookup_static_price(model_id: str) -> PriceEntry:
     override = _lookup_price_override(model_id)
@@ -458,13 +463,19 @@ def _should_fetch_live_price(model_id: str) -> bool:
     return True
 
 
-def lookup_price(model_id: str) -> PriceEntry:
+def lookup_price(model_id: str, provider: str = "") -> PriceEntry:
     """Look up pricing, preferring live OpenRouter endpoint prices.
 
     Live lookup uses ``prompt``/``completion`` endpoint prices, explicitly not
     cache-read prices. If OpenRouter is unreachable, the static table is only a
     fail-open fallback so cost estimation keeps working offline.
+
+    ``provider`` is the configured provider id. Local runtimes (Ollama, …) are
+    free regardless of the model id, which is otherwise unqualified (e.g.
+    ``qwen3:4b``) and would fall through to the cloud default estimate.
     """
+    if provider and provider.strip().lower() in _LOCAL_FREE_PROVIDERS:
+        return PriceEntry(0.0, 0.0)
     model_id = str(model_id or "").strip()
     override = _lookup_price_override(model_id)
     if override is not None:

--- a/src/opensquilla/engine/turn_runner/harness.py
+++ b/src/opensquilla/engine/turn_runner/harness.py
@@ -405,12 +405,14 @@ class _TurnRunnerModelCatalogAdapter(ModelCatalogPort):
         llm_cfg = getattr(runner._config, "llm", None) if runner._config else None
         user_max_tokens = getattr(llm_cfg, "max_tokens", 0)
         if runner._model_catalog is not None:
-            max_tokens = runner._model_catalog.resolve_max_tokens(
-                model_id, user_override=user_max_tokens
-            )
-            context_window = runner._model_catalog.resolve_context_window(model_id)
             provider_name = getattr(llm_cfg, "provider", "openrouter")
             base_url = getattr(llm_cfg, "base_url", "")
+            max_tokens = runner._model_catalog.resolve_max_tokens(
+                model_id, user_override=user_max_tokens, provider=provider_name
+            )
+            context_window = runner._model_catalog.resolve_context_window(
+                model_id, provider=provider_name
+            )
             capabilities = runner._model_catalog.get_capabilities(
                 model_id, provider_name=provider_name, base_url=base_url
             )

--- a/src/opensquilla/engine/usage.py
+++ b/src/opensquilla/engine/usage.py
@@ -43,10 +43,14 @@ class ModelUsage:
     # model_breakdown serializer prefers this over the pricing-table estimate,
     # avoiding cache-discount drift in the per-model split.
     billed_cost: float = 0.0
+    # Configured provider id (e.g. "ollama"). Appended at the end to keep
+    # existing positional ModelUsage(model_id, in, out) callers aligned. Local
+    # providers are free, so the estimate must not apply the cloud default.
+    provider: str = ""
 
     @property
     def cost(self) -> float:
-        price = lookup_price(self.model_id)
+        price = lookup_price(self.model_id, self.provider)
         return (
             self.input_tokens * price.input_per_m + self.output_tokens * price.output_per_m
         ) / 1_000_000
@@ -64,13 +68,14 @@ class SessionUsage:
     # (e.g. SessionUsage(1, 2, "model")) keep aligning with `model_id`.
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
+    provider: str = ""
 
     @property
     def cost(self) -> float:
         """Calculate cost in USD based on pricing table."""
         if self._per_model:
             return sum(m.cost for m in self._per_model.values())
-        price = lookup_price(self.model_id)
+        price = lookup_price(self.model_id, self.provider)
         input_cost = self.input_tokens * price.input_per_m
         output_cost = self.output_tokens * price.output_per_m
         return (input_cost + output_cost) / 1_000_000
@@ -136,6 +141,7 @@ class SessionUsage:
         cache_read_tokens: int = 0,
         cache_write_tokens: int = 0,
         billed_cost: float = 0.0,
+        provider: str = "",
     ) -> None:
         """Accumulate token counts, tracking per-model breakdown.
 
@@ -143,11 +149,16 @@ class SessionUsage:
         accumulation (typically one provider call). Forwarded into the per-model
         ``ModelUsage`` so the breakdown serializer can return the actual billed
         figure instead of the cache-blind pricing-table estimate.
+
+        ``provider`` is the configured provider id; it lets local providers
+        (Ollama, …) estimate as free instead of the cloud default price.
         """
         self.input_tokens += input_tokens
         self.output_tokens += output_tokens
         self.cache_read_tokens += cache_read_tokens
         self.cache_write_tokens += cache_write_tokens
+        if provider:
+            self.provider = provider
         mid = model_id or self.model_id
         if mid:
             if self._per_model is None:
@@ -161,6 +172,8 @@ class SessionUsage:
             mu.cache_read_tokens += cache_read_tokens
             mu.cache_write_tokens += cache_write_tokens
             mu.billed_cost += billed_cost
+            if provider:
+                mu.provider = provider
 
     @staticmethod
     def _breakdown_cost_fields(mu_or_self: ModelUsage | SessionUsage) -> dict:
@@ -229,6 +242,7 @@ def _clone_session_usage(usage: SessionUsage) -> SessionUsage:
         model_id=usage.model_id,
         cache_read_tokens=usage.cache_read_tokens,
         cache_write_tokens=usage.cache_write_tokens,
+        provider=usage.provider,
     )
     if usage._per_model:
         clone._per_model = {
@@ -239,6 +253,7 @@ def _clone_session_usage(usage: SessionUsage) -> SessionUsage:
                 cache_read_tokens=mu.cache_read_tokens,
                 cache_write_tokens=mu.cache_write_tokens,
                 billed_cost=mu.billed_cost,
+                provider=mu.provider,
             )
             for mid, mu in usage._per_model.items()
         }
@@ -251,10 +266,11 @@ def _model_delta_cost(
     input_tokens: int,
     output_tokens: int,
     billed_cost: float,
+    provider: str = "",
 ) -> float:
     if billed_cost > 0.0:
         return billed_cost
-    price = lookup_price(model_id)
+    price = lookup_price(model_id, provider)
     return (input_tokens * price.input_per_m + output_tokens * price.output_per_m) / 1_000_000
 
 
@@ -304,12 +320,14 @@ class UsageTracker:
         cache_read_tokens: int = 0,
         cache_write_tokens: int = 0,
         billed_cost: float = 0.0,
+        provider: str = "",
     ) -> None:
         """Record token usage for a session.
 
         ``billed_cost`` flows through to :py:attr:`ModelUsage.billed_cost` so
         the per-model breakdown can report real provider-billed figures
-        instead of the cache-blind pricing-table estimate.
+        instead of the cache-blind pricing-table estimate. ``provider`` lets
+        local runtimes (Ollama, …) estimate as free.
         """
         usage = self._sessions.get(session_key)
         if usage is None:
@@ -322,6 +340,7 @@ class UsageTracker:
             cache_read_tokens=cache_read_tokens,
             cache_write_tokens=cache_write_tokens,
             billed_cost=billed_cost,
+            provider=provider,
         )
         if model_id:
             usage.model_id = model_id
@@ -337,6 +356,7 @@ class UsageTracker:
                 model_id=model_id,
                 cache_read_tokens=cache_read_tokens,
                 cache_write_tokens=cache_write_tokens,
+                provider=provider,
                 billed_cost=billed_cost,
             )
             if model_id:
@@ -402,6 +422,7 @@ class UsageTracker:
                         input_tokens=max(0, delta_input),
                         output_tokens=max(0, delta_output),
                         billed_cost=max(0.0, delta_billed),
+                        provider=mu.provider,
                     )
         else:
             cost_usd = _model_delta_cost(
@@ -409,6 +430,7 @@ class UsageTracker:
                 input_tokens=max(0, input_tokens),
                 output_tokens=max(0, output_tokens),
                 billed_cost=max(0.0, billed_cost),
+                provider=usage.provider,
             )
 
         return SessionTotalsSnapshot(

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -1766,7 +1766,19 @@ async def build_services(
     resolved_base = llm_runtime.base_url
     proxy = llm_runtime.proxy
     if provider_selector is None:
-        if api_key:
+        # Local providers (Ollama, LM Studio, …) need no API key, so gating
+        # provider setup on a key would leave the gateway with "no provider".
+        provider_requires_key = True
+        if llm_runtime.provider:
+            try:
+                from opensquilla.provider.registry import get_provider_spec
+
+                provider_requires_key = get_provider_spec(
+                    llm_runtime.provider
+                ).requires_api_key()
+            except Exception:
+                provider_requires_key = True
+        if llm_runtime.provider and (api_key or not provider_requires_key):
             from opensquilla.provider.selector import (
                 ModelSelector,
                 ProviderConfig,

--- a/src/opensquilla/gateway/rpc_usage.py
+++ b/src/opensquilla/gateway/rpc_usage.py
@@ -66,12 +66,13 @@ def _resolve_context_window(model: str | None, ctx: RpcContext) -> tuple[int | N
         if window is not None:
             return window, "config"
     if model:
+        provider = str(getattr(getattr(config, "llm", None), "provider", "") or "")
         catalog = getattr(getattr(ctx, "turn_runner", None), "_model_catalog", None)
         if catalog is not None and hasattr(catalog, "resolve_context_window"):
-            window = _positive_int(catalog.resolve_context_window(model))
+            window = _positive_int(catalog.resolve_context_window(model, provider))
             if window is not None:
                 return window, "runtime_model_catalog"
-        window = _positive_int(_CONTEXT_WINDOW_CATALOG.resolve_context_window(model))
+        window = _positive_int(_CONTEXT_WINDOW_CATALOG.resolve_context_window(model, provider))
         if window is not None:
             return window, "static_model_catalog"
     return None, "unavailable"

--- a/src/opensquilla/memory/embedding.py
+++ b/src/opensquilla/memory/embedding.py
@@ -194,25 +194,29 @@ class OllamaEmbeddingProvider:
     def model(self) -> str:
         return self._model
 
-    async def embed_query(self, text: str) -> list[float]:
+    async def _embed(self, inputs: list[str], timeout: float) -> list[list[float]]:
         async def _call():
             async with httpx.AsyncClient(trust_env=_trust_env()) as client:
                 resp = await client.post(
-                    f"{self._base_url}/api/embeddings",
-                    json={"model": self._model, "prompt": text},
-                    timeout=self._timeout_query,
+                    f"{self._base_url}/api/embed",
+                    json={"model": self._model, "input": inputs},
+                    timeout=timeout,
                 )
                 resp.raise_for_status()
-                return resp.json()["embedding"]
+                return resp.json()["embeddings"]
 
         return await _retry_with_backoff(_call)  # type: ignore[no-any-return]
 
+    async def embed_query(self, text: str) -> list[float]:
+        vectors = await self._embed([text], self._timeout_query)
+        return vectors[0]
+
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:
-        results = []
-        for text in texts:
-            vec = await self.embed_query(text)
-            results.append(vec)
-        return results
+        # /api/embed embeds the whole batch in one request (the legacy
+        # /api/embeddings endpoint only took a single prompt).
+        if not texts:
+            return []
+        return await self._embed(texts, self._timeout_batch)
 
     async def probe(self) -> tuple[bool, str | None]:
         try:

--- a/src/opensquilla/provider/model_catalog.py
+++ b/src/opensquilla/provider/model_catalog.py
@@ -8,6 +8,7 @@ import structlog
 from opensquilla.env import trust_env as _trust_env
 from opensquilla.secrets import clean_header_secret
 
+from .ollama import _OLLAMA_DEFAULT_NUM_CTX
 from .openrouter_attribution import openrouter_app_headers
 from .registry import UnknownProviderError, get_provider_spec
 from .types import ModelCapabilities, ModelInfo
@@ -17,6 +18,13 @@ log = structlog.get_logger(__name__)
 DEFAULT_MAX_TOKENS = 16384
 SAFE_OPENROUTER_DEFAULT_MAX_TOKENS = 8192
 DEFAULT_CONTEXT_WINDOW = 200_000
+
+# Local runtimes (Ollama, …) have unqualified model ids that miss the catalog
+# and the static table, so the 200k cloud default would make the turn budget
+# over-estimate and skip trimming while the runtime silently truncates. Report
+# the runtime's own default window so budgeting matches what it actually allows.
+_LOCAL_CONTEXT_WINDOW = _OLLAMA_DEFAULT_NUM_CTX
+_LOCAL_PROVIDERS = frozenset({"ollama", "lm_studio", "ovms", "vllm", "local"})
 
 # Static fallback for squilla-router tier models + default model.
 # Used when OpenRouter API is unreachable at boot.
@@ -244,9 +252,11 @@ class ModelCatalog:
         """Look up model metadata by ID."""
         return self._models.get(model_id)
 
-    def resolve_max_tokens(self, model_id: str, user_override: int = 0) -> int:
+    def resolve_max_tokens(
+        self, model_id: str, user_override: int = 0, provider: str = ""
+    ) -> int:
         """Resolve max_tokens: user > catalog > static fallback > default, then clamp."""
-        context_window = self.resolve_context_window(model_id)
+        context_window = self.resolve_context_window(model_id, provider)
         info = self._models.get(model_id)
 
         using_user_override = user_override > 0
@@ -274,11 +284,13 @@ class ModelCatalog:
 
         return effective
 
-    def resolve_context_window(self, model_id: str) -> int:
-        """Resolve context window: catalog > static fallback > default."""
+    def resolve_context_window(self, model_id: str, provider: str = "") -> int:
+        """Resolve context window: catalog > static fallback > local/default."""
         info = self._models.get(model_id)
         if info and info.context_window > 0:
             return info.context_window
         if model_id in _STATIC_FALLBACK:
             return _STATIC_FALLBACK[model_id][1]
+        if provider and provider.strip().lower() in _LOCAL_PROVIDERS:
+            return _LOCAL_CONTEXT_WINDOW
         return DEFAULT_CONTEXT_WINDOW

--- a/src/opensquilla/provider/ollama.py
+++ b/src/opensquilla/provider/ollama.py
@@ -1,4 +1,4 @@
-"""OllamaProvider — streams via Ollama local API using httpx."""
+"""OllamaProvider — streams via Ollama local/cloud API using httpx."""
 
 from __future__ import annotations
 
@@ -9,6 +9,7 @@ from typing import Any
 import httpx
 
 from opensquilla.env import trust_env as _trust_env
+from opensquilla.secrets import clean_header_secret
 
 from .types import (
     ChatConfig,
@@ -25,6 +26,11 @@ from .types import (
 )
 
 _OLLAMA_DEFAULT_BASE = "http://localhost:11434"
+# Ollama's server default num_ctx is 2048, which silently truncates the front of
+# an agent prompt (system prompt + tool schemas) and makes tool use look broken.
+# Default to a context window large enough for real agent turns; callers can
+# override via the ``num_ctx`` constructor argument.
+_OLLAMA_DEFAULT_NUM_CTX = 8192
 
 
 def _build_ollama_tool(tool: ToolDefinition) -> dict[str, Any]:
@@ -38,26 +44,82 @@ def _build_ollama_tool(tool: ToolDefinition) -> dict[str, Any]:
     }
 
 
-def _build_ollama_message(msg: Message) -> dict[str, Any]:
+def _tool_result_content(block: Any) -> str:
+    content = block.content
+    return content if isinstance(content, str) else json.dumps(content)
+
+
+def _build_ollama_messages(
+    msg: Message,
+    tool_names: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Convert one internal message into one or more Ollama chat messages.
+
+    A single message may expand into several Ollama messages: assistant turns
+    carry their ``tool_calls`` so the model keeps a record of what it invoked,
+    and each ``tool_result`` block becomes its own ``tool`` role message (Ollama
+    has no notion of bundled parallel results) tagged with ``tool_name`` so the
+    model can correlate the result with the call.
+    """
     if isinstance(msg.content, str):
-        return {"role": msg.role, "content": msg.content}
-    # Flatten to text for Ollama (tool_result -> tool role)
-    parts: list[str] = []
+        return [{"role": msg.role, "content": msg.content}]
+
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    images: list[str] = []
+    tool_messages: list[dict[str, Any]] = []
+
     for block in msg.content:
         if block.type == "text":
-            parts.append(block.text)
+            text_parts.append(block.text)
+        elif block.type == "tool_use":
+            tool_calls.append({"function": {"name": block.name, "arguments": block.input}})
+        elif block.type == "image":
+            # Ollama expects raw base64 strings in `images`; it does not fetch URLs.
+            if block.source_type == "base64":
+                images.append(block.data)
         elif block.type == "tool_result":
-            return {
+            tool_message: dict[str, Any] = {
                 "role": "tool",
-                "content": (
-                    block.content if isinstance(block.content, str) else json.dumps(block.content)
-                ),
+                "content": _tool_result_content(block),
             }
-    return {"role": msg.role, "content": " ".join(parts)}
+            name = tool_names.get(block.tool_use_id)
+            if name:
+                tool_message["tool_name"] = name
+            tool_messages.append(tool_message)
+
+    out: list[dict[str, Any]] = []
+    if text_parts or tool_calls or images:
+        main: dict[str, Any] = {"role": msg.role, "content": " ".join(text_parts)}
+        if tool_calls:
+            main["tool_calls"] = tool_calls
+        if images:
+            main["images"] = images
+        out.append(main)
+    out.extend(tool_messages)
+    return out
+
+
+def _convert_messages(messages: list[Message], system: str | None) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if system:
+        out.append({"role": "system", "content": system})
+
+    # Map tool_use ids to their tool name so tool results can be correlated.
+    tool_names: dict[str, str] = {}
+    for msg in messages:
+        if isinstance(msg.content, list):
+            for block in msg.content:
+                if block.type == "tool_use":
+                    tool_names[block.id] = block.name
+
+    for msg in messages:
+        out.extend(_build_ollama_messages(msg, tool_names))
+    return out
 
 
 class OllamaProvider:
-    """Streams from a local Ollama instance using the /api/chat endpoint."""
+    """Streams from an Ollama instance (local or cloud) using /api/chat."""
 
     provider_name = "ollama"
 
@@ -66,10 +128,14 @@ class OllamaProvider:
         model: str = "llama3",
         base_url: str = _OLLAMA_DEFAULT_BASE,
         proxy: str | None = None,
+        api_key: str | None = None,
+        num_ctx: int | None = None,
     ) -> None:
         self._model = model
         self._base_url = base_url.rstrip("/")
         self._proxy = proxy or None
+        self._api_key = clean_header_secret(api_key, label="Ollama API key") if api_key else ""
+        self._num_ctx = num_ctx or _OLLAMA_DEFAULT_NUM_CTX
 
     @property
     def model(self) -> str:
@@ -79,6 +145,11 @@ class OllamaProvider:
         the underlying model without prying at private state.
         """
         return self._model
+
+    def _headers(self) -> dict[str, str]:
+        if self._api_key:
+            return {"Authorization": f"Bearer {self._api_key}"}
+        return {}
 
     def chat(
         self,
@@ -95,19 +166,21 @@ class OllamaProvider:
         tools: list[ToolDefinition] | None,
         cfg: ChatConfig,
     ) -> AsyncIterator[StreamEvent]:
-        ollama_messages: list[dict[str, Any]] = []
-        if cfg.system:
-            ollama_messages.append({"role": "system", "content": cfg.system})
-        ollama_messages.extend(_build_ollama_message(m) for m in messages)
+        ollama_messages = _convert_messages(messages, cfg.system)
+
+        options: dict[str, Any] = {
+            "num_predict": cfg.max_tokens,
+            "num_ctx": self._num_ctx,
+        }
+        if cfg.temperature is not None:
+            options["temperature"] = cfg.temperature
 
         payload: dict[str, Any] = {
             "model": self._model,
             "messages": ollama_messages,
             "stream": True,
-            "options": {"num_predict": cfg.max_tokens},
+            "options": options,
         }
-        if cfg.temperature is not None:
-            payload["options"]["temperature"] = cfg.temperature
         if tools:
             payload["tools"] = [_build_ollama_tool(t) for t in tools]
 
@@ -126,6 +199,7 @@ class OllamaProvider:
                     "POST",
                     f"{self._base_url}/api/chat",
                     json=payload,
+                    headers=self._headers(),
                 ) as response:
                     if response.status_code != 200:
                         body = await response.aread()
@@ -195,7 +269,10 @@ class OllamaProvider:
                 trust_env=_trust_env(),
                 proxy=self._proxy,
             ) as client:
-                resp = await client.get(f"{self._base_url}/api/tags")
+                resp = await client.get(
+                    f"{self._base_url}/api/tags",
+                    headers=self._headers(),
+                )
                 resp.raise_for_status()
                 data = resp.json()
                 return [

--- a/src/opensquilla/provider/registry.py
+++ b/src/opensquilla/provider/registry.py
@@ -140,7 +140,11 @@ for _provider_spec in [
         "ollama",
         "ollama",
         "ollama",
+        "OLLAMA_API_KEY",
         default_base_url="http://localhost:11434",
+        # Local provider: the key is optional (only needed for Ollama Cloud or a
+        # secured remote host), so keep onboarding from demanding it.
+        required_fields=frozenset({"model"}),
         support_level="native",
         failure_family="ollama",
     ),

--- a/src/opensquilla/provider/selector.py
+++ b/src/opensquilla/provider/selector.py
@@ -123,6 +123,8 @@ def _build_provider(cfg: ProviderConfig) -> LLMProvider:
                 kwargs["base_url"] = base_url
             if cfg.proxy:
                 kwargs["proxy"] = cfg.proxy
+            if cfg.api_key:
+                kwargs["api_key"] = cfg.api_key
             return OllamaProvider(**kwargs)
 
         case _:

--- a/tests/test_engine/test_pricing.py
+++ b/tests/test_engine/test_pricing.py
@@ -285,3 +285,29 @@ def test_direct_openai_zhipu_kimi_and_minimax_prices_do_not_fall_back_to_default
 
     assert price.input_per_m == pytest.approx(input_per_m)
     assert price.output_per_m == pytest.approx(output_per_m)
+
+
+def test_local_provider_is_free_even_for_unqualified_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
+    # Bare ollama model id misses the "ollama/" table entry -> cloud default.
+    assert lookup_price("qwen3:4b").input_per_m == pytest.approx(3.0)
+    # Passing the local provider makes it free regardless of the model id.
+    free = lookup_price("qwen3:4b", provider="ollama")
+    assert free.input_per_m == 0.0
+    assert free.output_per_m == 0.0
+
+
+def test_local_provider_case_insensitive_and_covers_local_runtimes() -> None:
+    for prov in ("ollama", "OLLAMA", "lm_studio", "vllm", "ovms", "local"):
+        price = lookup_price("some-model", provider=prov)
+        assert (price.input_per_m, price.output_per_m) == (0.0, 0.0)
+
+
+def test_cloud_provider_arg_does_not_zero_priced_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
+    price = lookup_price("claude-sonnet-4", provider="anthropic")
+    assert price.input_per_m == pytest.approx(3.0)

--- a/tests/test_engine/test_usage_tracker.py
+++ b/tests/test_engine/test_usage_tracker.py
@@ -388,3 +388,29 @@ def test_model_usage_positional_construction_keeps_billed_cost_default() -> None
     assert mu.cache_read_tokens == 200
     assert mu.cache_write_tokens == 80
     assert mu.billed_cost == 0.0  # default at the tail
+
+
+def test_local_provider_estimates_as_free() -> None:
+    usage = SessionUsage()
+    usage.add(10_000, 500, "qwen3:4b", provider="ollama")
+    assert usage.cost == 0.0
+    assert usage._per_model is not None
+    assert usage._per_model["qwen3:4b"].cost == 0.0
+    breakdown = usage.model_breakdown[0]
+    assert breakdown["costUsd"] == 0.0
+    assert breakdown["billedCostUsd"] == 0.0
+
+
+def test_cloud_provider_cost_unchanged() -> None:
+    usage = SessionUsage()
+    usage.add(1_000_000, 0, "claude-sonnet-4", provider="anthropic")
+    assert usage.cost == pytest.approx(3.0)
+
+
+def test_usage_tracker_threads_provider_to_per_model() -> None:
+    tracker = UsageTracker()
+    tracker.add("s", 8000, 300, "gemma3:4b", provider="ollama")
+    sess = tracker._sessions["s"]
+    assert sess.cost == 0.0
+    assert sess._per_model is not None
+    assert sess._per_model["gemma3:4b"].provider == "ollama"

--- a/tests/test_gateway/test_local_provider_keyless_e2e.py
+++ b/tests/test_gateway/test_local_provider_keyless_e2e.py
@@ -1,0 +1,95 @@
+"""End-to-end guard: a keyless local (Ollama) provider works across the stack.
+
+These cover a whole bug class where the gateway / cost / catalog assumed every
+LLM provider has an API key or a provider-qualified model id, silently breaking
+local Ollama (whose model ids are bare, e.g. ``qwen3:4b``):
+
+- the gateway built the provider selector only ``if api_key:`` -> keyless local
+  providers ended every turn with "No provider available";
+- a bare ollama model id missed the ``ollama/`` price entry and was billed at the
+  cloud default ($3/$15 per 1M tokens);
+- a bare ollama model id reported the 200k cloud context window, so the turn
+  budget over-estimated and never trimmed while the runtime truncated.
+
+One regression net for all three so the local path can't silently rot again.
+"""
+
+from __future__ import annotations
+
+from opensquilla.engine.pricing import lookup_price
+from opensquilla.engine.usage import SessionUsage
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
+from opensquilla.gateway.rpc_config import _sync_provider_selector
+from opensquilla.provider.model_catalog import (
+    DEFAULT_CONTEXT_WINDOW,
+    ModelCatalog,
+)
+from opensquilla.provider.ollama import _OLLAMA_DEFAULT_NUM_CTX, OllamaProvider
+from opensquilla.provider.registry import get_provider_spec
+from opensquilla.provider.selector import ProviderConfig, _build_provider
+
+
+def _keyless_ollama_cfg() -> GatewayConfig:
+    return GatewayConfig(llm={"provider": "ollama", "model": "qwen3:4b", "api_key": ""})
+
+
+def test_keyless_ollama_resolves_and_builds_without_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+    cfg = _keyless_ollama_cfg()
+
+    # registry is the source of truth: local providers need no key.
+    assert get_provider_spec("ollama").requires_api_key() is False
+
+    runtime = resolve_llm_runtime_config(cfg)
+    assert runtime.provider == "ollama"
+    assert runtime.api_key == ""
+
+    # boot path: the selector must still build a provider for a keyless config.
+    provider = _build_provider(
+        ProviderConfig(
+            provider=runtime.provider,
+            model=runtime.model,
+            api_key=runtime.api_key,
+            base_url=runtime.base_url,
+        )
+    )
+    assert isinstance(provider, OllamaProvider)
+    assert provider._headers() == {}  # no Authorization header without a key
+
+
+def test_keyless_ollama_estimates_as_free() -> None:
+    usage = SessionUsage()
+    usage.add(50_000, 2_000, "qwen3:4b", provider="ollama")
+    assert usage.cost == 0.0
+    # Sanity: the bare id alone (no provider) WOULD have been mispriced.
+    assert lookup_price("qwen3:4b").input_per_m > 0
+
+
+def test_keyless_ollama_context_window_is_local_not_cloud() -> None:
+    catalog = ModelCatalog()
+    window = catalog.resolve_context_window("qwen3:4b", provider="ollama")
+    assert window == _OLLAMA_DEFAULT_NUM_CTX
+    assert window < DEFAULT_CONTEXT_WINDOW
+    # max_tokens cannot exceed the (smaller) local window.
+    assert catalog.resolve_max_tokens("qwen3:4b", provider="ollama") <= window
+
+
+def test_runtime_switch_to_keyless_ollama_syncs_selector() -> None:
+    class _CapturingSelector:
+        def __init__(self) -> None:
+            self.synced: ProviderConfig | None = None
+
+        def sync_primary(self, cfg: ProviderConfig) -> None:
+            self.synced = cfg
+
+    selector = _CapturingSelector()
+    ctx = type("Ctx", (), {"config": _keyless_ollama_cfg(), "provider_selector": selector})()
+
+    _sync_provider_selector(ctx, ctx.config)
+
+    assert selector.synced is not None
+    assert selector.synced.provider == "ollama"
+    assert selector.synced.api_key == ""
+    # And the synced config builds a real provider end-to-end.
+    assert isinstance(_build_provider(selector.synced), OllamaProvider)

--- a/tests/test_memory_embedding_ollama.py
+++ b/tests/test_memory_embedding_ollama.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+
+from opensquilla.memory.embedding import OllamaEmbeddingProvider
+
+
+def _patch(monkeypatch: Any, captured: dict[str, Any], embeddings: list[list[float]]) -> None:
+    captured["calls"] = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["calls"] += 1
+        captured["url"] = str(request.url)
+        captured["payload"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(200, json={"model": "nomic-embed-text", "embeddings": embeddings})
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("opensquilla.memory.embedding.httpx.AsyncClient", patched_async_client)
+
+
+def test_embed_query_uses_api_embed_endpoint(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch(monkeypatch, captured, [[0.1, 0.2, 0.3]])
+    provider = OllamaEmbeddingProvider(model="nomic-embed-text")
+
+    vec = asyncio.run(provider.embed_query("hello"))
+
+    assert captured["url"] == "http://localhost:11434/api/embed"
+    assert captured["payload"] == {"model": "nomic-embed-text", "input": ["hello"]}
+    assert vec == [0.1, 0.2, 0.3]
+
+
+def test_embed_batch_sends_single_request_with_all_inputs(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch(monkeypatch, captured, [[1.0], [2.0], [3.0]])
+    provider = OllamaEmbeddingProvider(model="nomic-embed-text")
+
+    vectors = asyncio.run(provider.embed_batch(["a", "b", "c"]))
+
+    # One round trip for the whole batch, not one per text.
+    assert captured["calls"] == 1
+    assert captured["payload"]["input"] == ["a", "b", "c"]
+    assert vectors == [[1.0], [2.0], [3.0]]
+
+
+def test_embed_batch_empty_makes_no_request(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch(monkeypatch, captured, [])
+    provider = OllamaEmbeddingProvider(model="nomic-embed-text")
+
+    vectors = asyncio.run(provider.embed_batch([]))
+
+    assert vectors == []
+    assert captured["calls"] == 0

--- a/tests/test_provider_model_catalog.py
+++ b/tests/test_provider_model_catalog.py
@@ -117,3 +117,35 @@ async def test_fetch_openrouter_adds_app_attribution_headers() -> None:
     model = catalog.get("openai/gpt-4o")
     assert model is not None
     assert model.context_window == 128_000
+
+
+def test_local_provider_context_window_uses_runtime_default_not_cloud() -> None:
+    from opensquilla.provider.model_catalog import (
+        _LOCAL_CONTEXT_WINDOW,
+        DEFAULT_CONTEXT_WINDOW,
+    )
+
+    catalog = ModelCatalog()
+    # Without provider context a bare ollama id falls to the 200k cloud default.
+    assert catalog.resolve_context_window("qwen3:4b") == DEFAULT_CONTEXT_WINDOW
+    # With the local provider it reports the runtime window instead.
+    assert catalog.resolve_context_window("qwen3:4b", provider="ollama") == _LOCAL_CONTEXT_WINDOW
+    assert _LOCAL_CONTEXT_WINDOW < DEFAULT_CONTEXT_WINDOW
+
+
+def test_local_provider_max_tokens_clamped_to_local_window() -> None:
+    from opensquilla.provider.model_catalog import _LOCAL_CONTEXT_WINDOW
+
+    catalog = ModelCatalog()
+    # max_tokens cannot exceed the (smaller) local context window.
+    assert catalog.resolve_max_tokens("llama3.2:3b", provider="ollama") <= _LOCAL_CONTEXT_WINDOW
+
+
+def test_cloud_provider_context_window_unchanged() -> None:
+    from opensquilla.provider.model_catalog import DEFAULT_CONTEXT_WINDOW
+
+    catalog = ModelCatalog()
+    # An unknown cloud model id is unaffected by the provider argument.
+    assert catalog.resolve_context_window("some-cloud-model", provider="openai") == (
+        DEFAULT_CONTEXT_WINDOW
+    )

--- a/tests/test_provider_ollama.py
+++ b/tests/test_provider_ollama.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+
+from opensquilla.provider.ollama import _OLLAMA_DEFAULT_NUM_CTX, OllamaProvider
+from opensquilla.provider.selector import ProviderConfig, _build_provider
+from opensquilla.provider.types import (
+    ChatConfig,
+    ContentBlockImage,
+    ContentBlockText,
+    ContentBlockToolResult,
+    ContentBlockToolUse,
+    DoneEvent,
+    Message,
+    TextDeltaEvent,
+    ToolDefinition,
+    ToolInputSchema,
+    ToolUseEndEvent,
+)
+
+
+def _ndjson(*chunks: dict[str, Any]) -> bytes:
+    return b"".join((json.dumps(chunk) + "\n").encode() for chunk in chunks)
+
+
+_DEFAULT_BODY = _ndjson(
+    {"model": "llama3", "message": {"role": "assistant", "content": "ok"}},
+    {
+        "model": "llama3",
+        "message": {"role": "assistant", "content": ""},
+        "done": True,
+        "prompt_eval_count": 3,
+        "eval_count": 2,
+    },
+)
+
+
+def _patch_stream(monkeypatch: Any, captured: dict[str, Any], body: bytes = _DEFAULT_BODY) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = request.headers
+        captured["payload"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(200, content=body)
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("opensquilla.provider.ollama.httpx.AsyncClient", patched_async_client)
+
+
+def _collect(
+    provider: OllamaProvider,
+    messages: list[Message],
+    cfg: ChatConfig | None = None,
+    tools: list[ToolDefinition] | None = None,
+) -> list[Any]:
+    async def _run() -> list[Any]:
+        return [
+            event
+            async for event in provider.chat(messages, tools=tools, config=cfg or ChatConfig())
+        ]
+
+    return asyncio.run(_run())
+
+
+def test_tool_use_replayed_as_tool_calls_and_correlated_tool_message(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_stream(monkeypatch, captured)
+    provider = OllamaProvider(model="llama3")
+    messages = [
+        Message(role="user", content="look it up"),
+        Message(
+            role="assistant",
+            content=[ContentBlockToolUse(id="call_1", name="lookup", input={"q": "cache"})],
+        ),
+        Message(
+            role="user",
+            content=[ContentBlockToolResult(tool_use_id="call_1", content="cache is warm")],
+        ),
+        Message(role="user", content="continue"),
+    ]
+
+    _collect(provider, messages)
+
+    msgs = captured["payload"]["messages"]
+    # Assistant turn keeps its tool_calls instead of being dropped.
+    assert msgs[1]["role"] == "assistant"
+    assert msgs[1]["tool_calls"] == [{"function": {"name": "lookup", "arguments": {"q": "cache"}}}]
+    # Tool result becomes its own tool-role message, correlated by tool_name.
+    assert msgs[2] == {"role": "tool", "content": "cache is warm", "tool_name": "lookup"}
+    assert msgs[3] == {"role": "user", "content": "continue"}
+
+
+def test_parallel_tool_results_expand_to_separate_tool_messages(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_stream(monkeypatch, captured)
+    provider = OllamaProvider(model="llama3")
+    messages = [
+        Message(
+            role="assistant",
+            content=[
+                ContentBlockToolUse(id="call_a", name="foo", input={"x": 1}),
+                ContentBlockToolUse(id="call_b", name="bar", input={"y": 2}),
+            ],
+        ),
+        Message(
+            role="user",
+            content=[
+                ContentBlockToolResult(tool_use_id="call_a", content="ra"),
+                ContentBlockToolResult(tool_use_id="call_b", content="rb"),
+            ],
+        ),
+    ]
+
+    _collect(provider, messages)
+
+    msgs = captured["payload"]["messages"]
+    assert msgs[0]["tool_calls"] == [
+        {"function": {"name": "foo", "arguments": {"x": 1}}},
+        {"function": {"name": "bar", "arguments": {"y": 2}}},
+    ]
+    # Both results survive as distinct tool messages (the old code dropped all but one).
+    assert msgs[1] == {"role": "tool", "content": "ra", "tool_name": "foo"}
+    assert msgs[2] == {"role": "tool", "content": "rb", "tool_name": "bar"}
+
+
+def test_tool_result_list_content_is_json_encoded(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_stream(monkeypatch, captured)
+    provider = OllamaProvider(model="llama3")
+    messages = [
+        Message(
+            role="user",
+            content=[ContentBlockToolResult(tool_use_id="call_x", content=[{"k": "v"}])],
+        ),
+    ]
+
+    _collect(provider, messages)
+
+    assert captured["payload"]["messages"][0]["content"] == json.dumps([{"k": "v"}])
+
+
+def test_num_ctx_defaults_above_ollama_2048(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_stream(monkeypatch, captured)
+    provider = OllamaProvider(model="llama3")
+
+    _collect(provider, [Message(role="user", content="hi")], ChatConfig(max_tokens=512))
+
+    options = captured["payload"]["options"]
+    assert options["num_ctx"] == _OLLAMA_DEFAULT_NUM_CTX
+    assert _OLLAMA_DEFAULT_NUM_CTX > 2048
+    assert options["num_predict"] == 512
+
+
+def test_num_ctx_is_configurable(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_stream(monkeypatch, captured)
+    provider = OllamaProvider(model="llama3", num_ctx=32768)
+
+    _collect(provider, [Message(role="user", content="hi")])
+
+    assert captured["payload"]["options"]["num_ctx"] == 32768
+
+
+def test_bearer_header_sent_when_api_key_set(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_stream(monkeypatch, captured)
+    provider = OllamaProvider(
+        model="gpt-oss:120b-cloud", base_url="https://ollama.com", api_key="secret"
+    )
+
+    _collect(provider, [Message(role="user", content="hi")])
+
+    assert captured["url"] == "https://ollama.com/api/chat"
+    assert captured["headers"]["authorization"] == "Bearer secret"
+
+
+def test_no_authorization_header_without_api_key(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_stream(monkeypatch, captured)
+    provider = OllamaProvider(model="llama3")
+
+    _collect(provider, [Message(role="user", content="hi")])
+
+    assert "authorization" not in captured["headers"]
+
+
+def test_image_block_attached_to_message_images(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_stream(monkeypatch, captured)
+    provider = OllamaProvider(model="llava")
+    messages = [
+        Message(
+            role="user",
+            content=[
+                ContentBlockText(text="what is this"),
+                ContentBlockImage(source_type="base64", media_type="image/png", data="QkFTRTY0"),
+            ],
+        ),
+    ]
+
+    _collect(provider, messages)
+
+    msg = captured["payload"]["messages"][0]
+    assert msg["content"] == "what is this"
+    assert msg["images"] == ["QkFTRTY0"]
+
+
+def test_system_prompt_is_first_message(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_stream(monkeypatch, captured)
+    provider = OllamaProvider(model="llama3")
+
+    _collect(provider, [Message(role="user", content="hi")], ChatConfig(system="be brief"))
+
+    assert captured["payload"]["messages"][0] == {"role": "system", "content": "be brief"}
+
+
+def test_stream_emits_text_and_done_with_usage(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_stream(monkeypatch, captured)
+    provider = OllamaProvider(model="llama3")
+
+    events = _collect(provider, [Message(role="user", content="hi")])
+
+    text = next(e for e in events if isinstance(e, TextDeltaEvent))
+    done = next(e for e in events if isinstance(e, DoneEvent))
+    assert text.text == "ok"
+    assert done.input_tokens == 3
+    assert done.output_tokens == 2
+
+
+def test_stream_tool_call_emits_tool_events(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    body = _ndjson(
+        {
+            "model": "llama3",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"function": {"name": "lookup", "arguments": {"q": "hi"}}}],
+            },
+        },
+        {
+            "model": "llama3",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "prompt_eval_count": 4,
+            "eval_count": 1,
+        },
+    )
+    _patch_stream(monkeypatch, captured, body)
+    provider = OllamaProvider(model="llama3")
+    tool = ToolDefinition(
+        name="lookup",
+        description="Lookup a value.",
+        input_schema=ToolInputSchema(properties={"q": {"type": "string"}}, required=["q"]),
+    )
+
+    events = _collect(provider, [Message(role="user", content="hi")], tools=[tool])
+
+    tool_end = next(e for e in events if isinstance(e, ToolUseEndEvent))
+    assert tool_end.tool_name == "lookup"
+    assert tool_end.arguments == {"q": "hi"}
+    assert captured["payload"]["tools"][0]["function"]["name"] == "lookup"
+
+
+def test_selector_passes_api_key_to_ollama_provider() -> None:
+    cfg = ProviderConfig(
+        provider="ollama",
+        model="gpt-oss:120b-cloud",
+        api_key="sk-test",
+        base_url="https://ollama.com",
+    )
+
+    provider = _build_provider(cfg)
+
+    assert isinstance(provider, OllamaProvider)
+    assert provider._headers() == {"Authorization": "Bearer sk-test"}
+
+
+def test_selector_omits_api_key_for_local_ollama() -> None:
+    cfg = ProviderConfig(provider="ollama", model="llama3")
+
+    provider = _build_provider(cfg)
+
+    assert isinstance(provider, OllamaProvider)
+    assert provider._headers() == {}


### PR DESCRIPTION
## Summary

OpenSquilla assumed every LLM provider has an API key and a provider-qualified model id, which silently broke keyless **local providers (Ollama)** across the stack. This addresses that class of bug end-to-end.

## Changes

**Provider runtime** — `provider/ollama.py`, `selector.py`, `registry.py`
- Preserve assistant `tool_use` as Ollama `tool_calls`, and emit each `tool_result` as its own `tool`-role message (multi-turn tool calling was broken; parallel results were dropped).
- Send a configurable `num_ctx` (default 8192) so Ollama's 2048 default no longer truncates the agent prompt.
- Support an optional API key (`Authorization: Bearer`) + `OLLAMA_API_KEY` env for Ollama Cloud / secured remote hosts (key stays optional for local).
- Pass image blocks through to Ollama's `images` field.

**Gateway** — `gateway/boot.py`
- Build the provider selector when the provider needs no API key, so local providers no longer end every turn with "No provider available".

**Cost** — `engine/pricing.py`, `usage.py`, `agent.py`
- Thread the provider into cost estimation; local providers estimate as **$0** instead of the cloud default a bare ollama model id fell through to ($3/$15 per 1M tokens).

**Context window** — `provider/model_catalog.py`, `turn_runner/harness.py`, `gateway/rpc_usage.py`
- Report the runtime's own window for local models instead of the 200k cloud default, so the turn budget trims history before the runtime truncates.

**Memory embeddings** — `memory/embedding.py`
- Use the `/api/embed` endpoint (whole batch in one request) instead of the legacy `/api/embeddings`.

## Tests
New provider, embedding, and keyless local-provider end-to-end tests; extended pricing / usage / model-catalog suites. `419 passed` against this branch (the 2 unrelated OpenRouter brand-attribution failures pre-date this branch on `main`).

## Notes
A desktop (`electron/main.ts`) keyless-startup fix was developed against an older revision and is **not** included here — that file has been refactored on `main` and needs separate verification.
