### PR TITLE
[codex] fix provider-aware model catalog test stub

### DIFF
--- a/tests/test_engine/turn_runner/test_agent_bootstrap_stage_snapshot.py
+++ b/tests/test_engine/turn_runner/test_agent_bootstrap_stage_snapshot.py
@@ -72,10 +72,10 @@ class _StubModelCatalog:
     context_window_value: int = 200_000
     capabilities_value: Any = None
 
-    def resolve_max_tokens(self, model_id, user_override=0):  # noqa: ARG002
+    def resolve_max_tokens(self, model_id, user_override=0, provider=""):  # noqa: ARG002
         return self.max_tokens_value
 
-    def resolve_context_window(self, model_id):  # noqa: ARG002
+    def resolve_context_window(self, model_id, provider=""):  # noqa: ARG002
         return self.context_window_value
 
     def get_capabilities(self, model_id, provider_name="", base_url=""):  # noqa: ARG002


### PR DESCRIPTION
## Summary

- Updates the TurnRunner snapshot test model-catalog stub to accept the new provider-aware catalog arguments.
- Keeps test doubles aligned with production ModelCatalog.resolve_max_tokens/resolve_context_window signatures.

## Root cause

The Ollama/local-provider change began passing provider=... through the TurnRunner model catalog adapter. The production ModelCatalog accepted that argument, but the snapshot-test stub still used the old signature, so full CI converted a TypeError into ErrorEvent and cascaded across TurnRunner snapshot cases.

## Validation

- uv run pytest tests/test_engine/turn_runner/test_agent_bootstrap_stage_snapshot.py tests/test_engine/turn_runner/test_attachment_stage_snapshot.py tests/test_engine/turn_runner/test_compaction_and_history_stage_snapshot.py tests/test_engine/turn_runner/test_stream_consumer_compaction_seam.py tests/test_engine/turn_runner/test_stream_consumer_stage_snapshot.py tests/test_engine/turn_runner/test_turn_finalizer_stage_snapshot.py -q --tb=short
