### PR TITLE
Add risk-based PR review gate

### DIFF
--- a/.github/scripts/issue_link_sync.py
+++ b/.github/scripts/issue_link_sync.py
@@ -17,7 +17,8 @@ from urllib.parse import quote
 from urllib.request import Request, urlopen
 
 HAS_LINKED_PR_LABEL = "has-linked-pr"
-MERGED_TO_DEV_LABEL = "merged-to-dev"
+MERGED_TO_STAGING_LABEL = "merged-to-staging"
+LEGACY_MERGED_TO_DEV_LABEL = "merged-to-dev"
 NEEDS_VERIFICATION_LABEL = "needs-verification"
 
 LABEL_DEFINITIONS = {
@@ -25,9 +26,9 @@ LABEL_DEFINITIONS = {
         "color": "C5DEF5",
         "description": "An open pull request is linked to this issue",
     },
-    MERGED_TO_DEV_LABEL: {
+    MERGED_TO_STAGING_LABEL: {
         "color": "5319E7",
-        "description": "A related fix has merged to dev but has not necessarily shipped",
+        "description": "A related fix has merged to staging but has not shipped",
     },
     NEEDS_VERIFICATION_LABEL: {
         "color": "C5DEF5",
@@ -83,6 +84,7 @@ class IssueSyncAction(NamedTuple):
     kind: str
     pr_number: int
     pr_url: str
+    base_ref: str = ""
 
 
 class GitHubClient:
@@ -260,13 +262,16 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
     if action != "closed":
         return ()
 
-    if pr.get("merged") is True and (pr.get("base") or {}).get("ref") == "dev":
+    base_ref = str((pr.get("base") or {}).get("ref") or "")
+
+    if pr.get("merged") is True and base_ref == "main":
         closing_actions = tuple(
             IssueSyncAction(
                 issue_number=issue_number,
-                kind="merged_to_dev",
+                kind="merged_to_main",
                 pr_number=pr_number,
                 pr_url=pr_url,
+                base_ref=base_ref,
             )
             for issue_number in parsed.closing
         )
@@ -277,6 +282,32 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
                 kind="remove_linked_pr",
                 pr_number=pr_number,
                 pr_url=pr_url,
+                base_ref=base_ref,
+            )
+            for issue_number in parsed.references
+            if issue_number not in closing_issue_numbers
+        )
+        return (*closing_actions, *reference_cleanup_actions)
+
+    if pr.get("merged") is True:
+        closing_actions = tuple(
+            IssueSyncAction(
+                issue_number=issue_number,
+                kind="merged_to_staging",
+                pr_number=pr_number,
+                pr_url=pr_url,
+                base_ref=base_ref,
+            )
+            for issue_number in parsed.closing
+        )
+        closing_issue_numbers = set(parsed.closing)
+        reference_cleanup_actions = tuple(
+            IssueSyncAction(
+                issue_number=issue_number,
+                kind="remove_linked_pr",
+                pr_number=pr_number,
+                pr_url=pr_url,
+                base_ref=base_ref,
             )
             for issue_number in parsed.references
             if issue_number not in closing_issue_numbers
@@ -294,15 +325,7 @@ def plan_issue_sync_actions(event: dict[str, Any]) -> tuple[IssueSyncAction, ...
             for issue_number in parsed.all
         )
 
-    return tuple(
-        IssueSyncAction(
-            issue_number=issue_number,
-            kind="remove_linked_pr",
-            pr_number=pr_number,
-            pr_url=pr_url,
-        )
-        for issue_number in parsed.all
-    )
+    return ()
 
 
 def comment_marker(*, kind: str, pr_number: int) -> str:
@@ -314,12 +337,14 @@ def has_marker(comments: list[dict[str, Any]], marker: str) -> bool:
     return any(marker in str(comment.get("body") or "") for comment in comments)
 
 
-def _merged_to_dev_comment(action: IssueSyncAction) -> str:
+def _merged_to_staging_comment(action: IssueSyncAction) -> str:
     marker = comment_marker(kind=action.kind, pr_number=action.pr_number)
+    base_ref = action.base_ref or "a staging branch"
     return (
         f"{marker}\n"
-        f"The linked fix for this issue has merged to `dev` via #{action.pr_number} "
-        f"({action.pr_url}). Keeping it open for verification before release."
+        f"The linked fix for this issue has merged to `{base_ref}` via "
+        f"#{action.pr_number} ({action.pr_url}). Keeping it open for "
+        "verification before mainline release."
     )
 
 
@@ -328,15 +353,22 @@ def apply_action(client: GitHubClient, action: IssueSyncAction) -> None:
         client.add_labels(action.issue_number, [HAS_LINKED_PR_LABEL])
         return
 
-    if action.kind == "merged_to_dev":
+    if action.kind == "merged_to_staging":
         client.add_labels(
             action.issue_number,
-            [MERGED_TO_DEV_LABEL, NEEDS_VERIFICATION_LABEL],
+            [MERGED_TO_STAGING_LABEL, NEEDS_VERIFICATION_LABEL],
         )
         client.remove_label(action.issue_number, HAS_LINKED_PR_LABEL)
         marker = comment_marker(kind=action.kind, pr_number=action.pr_number)
         if not has_marker(client.list_comments(action.issue_number), marker):
-            client.create_comment(action.issue_number, _merged_to_dev_comment(action))
+            client.create_comment(action.issue_number, _merged_to_staging_comment(action))
+        return
+
+    if action.kind == "merged_to_main":
+        client.remove_label(action.issue_number, HAS_LINKED_PR_LABEL)
+        client.remove_label(action.issue_number, MERGED_TO_STAGING_LABEL)
+        client.remove_label(action.issue_number, LEGACY_MERGED_TO_DEV_LABEL)
+        client.remove_label(action.issue_number, NEEDS_VERIFICATION_LABEL)
         return
 
     if action.kind in {"closed_unmerged", "remove_linked_pr"}:

--- a/.github/scripts/validate-pr-target-branch.sh
+++ b/.github/scripts/validate-pr-target-branch.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 base_ref="${PR_BASE_REF:-${BASE_REF:-${BASE:-}}}"
+pr_number="${PR_NUMBER:-}"
+base_sha="${PR_BASE_SHA:-}"
+head_sha="${PR_HEAD_SHA:-}"
 event_path="${GITHUB_EVENT_PATH:-}"
 
 if [[ -z "${base_ref}" ]]; then
@@ -12,7 +15,99 @@ if [[ -z "${base_ref}" ]]; then
   exit 1
 fi
 
+git_fetch_history() {
+  local workdir="${1:?workdir is required}"
+  shift
+
+  local token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+  local server_url="${GITHUB_SERVER_URL:-https://github.com}"
+  if [[ -n "${token}" ]]; then
+    git -C "${workdir}" \
+      -c "http.${server_url}/.extraheader=AUTHORIZATION: bearer ${token}" \
+      fetch --no-tags --filter=blob:none origin "$@"
+    return
+  fi
+
+  git -C "${workdir}" fetch --no-tags --filter=blob:none origin "$@"
+}
+
+validate_related_history() {
+  local local_repo="${PR_HISTORY_REPO_PATH:-}"
+  local local_base="${PR_HISTORY_BASE_REF:-}"
+  local local_head="${PR_HISTORY_HEAD_REF:-}"
+
+  if [[ -n "${local_repo}" ]]; then
+    if [[ -z "${local_base}" || -z "${local_head}" ]]; then
+      {
+        echo "::error title=Missing history refs::PR_HISTORY_BASE_REF and PR_HISTORY_HEAD_REF are required with PR_HISTORY_REPO_PATH."
+        echo "Unable to validate pull request history."
+      } >&2
+      exit 1
+    fi
+    if git -C "${local_repo}" merge-base "${local_base}" "${local_head}" >/dev/null; then
+      echo "Pull request history shares a common ancestor with ${base_ref}."
+      return
+    fi
+    {
+      echo "::error title=Unrelated PR history::This pull request has no common ancestor with ${base_ref}."
+      echo "Recreate the branch from the current ${base_ref} branch, re-apply the changes, and force-push the repaired branch."
+    } >&2
+    exit 1
+  fi
+
+  if [[ -z "${pr_number}" || -z "${GITHUB_REPOSITORY:-}" ]]; then
+    echo "Skipping unrelated history check because PR_NUMBER or GITHUB_REPOSITORY is unavailable."
+    return
+  fi
+
+  local tmp_parent="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+  local workdir
+  workdir="$(mktemp -d "${tmp_parent%/}/opensquilla-pr-history.XXXXXX")"
+
+  local remote_url="${PR_HISTORY_REMOTE_URL:-${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}.git}"
+  git -C "${workdir}" init -q
+  git -C "${workdir}" remote add origin "${remote_url}"
+
+  if [[ -n "${base_sha}" ]]; then
+    if ! git_fetch_history "${workdir}" "+${base_sha}:refs/remotes/origin/pr-base"; then
+      echo "::warning::Could not fetch pull request base SHA ${base_sha}; falling back to ${base_ref}."
+      git_fetch_history "${workdir}" "+refs/heads/${base_ref}:refs/remotes/origin/pr-base"
+    fi
+  else
+    git_fetch_history "${workdir}" "+refs/heads/${base_ref}:refs/remotes/origin/pr-base"
+  fi
+
+  git_fetch_history "${workdir}" "+refs/pull/${pr_number}/head:refs/remotes/origin/pr-head"
+
+  if [[ -n "${head_sha}" ]]; then
+    local fetched_head
+    fetched_head="$(git -C "${workdir}" rev-parse refs/remotes/origin/pr-head)"
+    if [[ "${fetched_head}" != "${head_sha}" ]]; then
+      {
+        echo "::error title=Stale PR history::Fetched PR head ${fetched_head}, expected ${head_sha}."
+        echo "The pull request changed while this check was running. Wait for the newest check run."
+      } >&2
+      rm -rf "${workdir}"
+      exit 1
+    fi
+  fi
+
+  if git -C "${workdir}" merge-base refs/remotes/origin/pr-base refs/remotes/origin/pr-head >/dev/null; then
+    echo "Pull request history shares a common ancestor with ${base_ref}."
+    rm -rf "${workdir}"
+    return
+  fi
+
+  {
+    echo "::error title=Unrelated PR history::This pull request has no common ancestor with ${base_ref}."
+    echo "Recreate the branch from the current ${base_ref} branch, re-apply the changes, and force-push the repaired branch."
+  } >&2
+  rm -rf "${workdir}"
+  exit 1
+}
+
 if [[ "${base_ref}" == "main" ]]; then
+  validate_related_history
   echo "Pull request targets main."
   exit 0
 fi
@@ -81,6 +176,7 @@ is_staging_branch() {
 }
 
 if is_staging_branch || has_allowed_label staging; then
+  validate_related_history
   echo "Pull request targets a staging/collaboration branch."
   echo "This is not a final integration path; final integration should target main."
   exit 0

--- a/.github/scripts/validate_pr_review_gate.py
+++ b/.github/scripts/validate_pr_review_gate.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Require a human review for risky pull requests."""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+from pathlib import Path
+from typing import Any, NamedTuple
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+MAX_UNREVIEWED_CHANGED_FILES = 30
+MAX_UNREVIEWED_LINE_DELTA = 1000
+
+RISK_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "CI",
+        (
+            ".github/workflows/**",
+            ".github/scripts/**",
+            ".github/actions/**",
+            ".github/dependabot.yml",
+        ),
+    ),
+    (
+        "release",
+        (
+            ".github/workflows/wheelhouse-release.yml",
+            ".github/workflows/live-release-e2e.yml",
+            "scripts/build_wheelhouse_zip.py",
+            "scripts/install_source.sh",
+            "scripts/install_source.ps1",
+            "install.sh",
+            "install.ps1",
+            "start.sh",
+            "start.ps1",
+            "README.release.md",
+            "RELEASES.md",
+            "docs/releases/**",
+        ),
+    ),
+    (
+        "security",
+        (
+            "SECURITY.md",
+            "src/opensquilla/sandbox/**",
+            "src/opensquilla/safety/**",
+            "src/opensquilla/tools/builtin/code_exec.py",
+            "src/opensquilla/tools/builtin/filesystem.py",
+            "src/opensquilla/tools/builtin/git.py",
+            "src/opensquilla/tools/builtin/shell.py",
+            "src/opensquilla/tools/builtin/shell_policy.py",
+            "src/opensquilla/tools/path_*.py",
+            "src/opensquilla/tools/policy/**",
+            "src/opensquilla/tools/policy*.py",
+            "src/opensquilla/tools/write_policy.py",
+            "src/opensquilla/skills/hub/installer.py",
+            "tests/test_security/**",
+            "tests/test_sandbox/**",
+            "tests/test_tools/test_*policy*.py",
+            "tests/test_tools/test_path_*.py",
+            "tests/test_tools/test_shell_*.py",
+        ),
+    ),
+    (
+        "provider",
+        (
+            "src/opensquilla/provider/**",
+            "src/opensquilla/search/providers/**",
+            "src/opensquilla/onboarding/provider_specs.py",
+            "src/opensquilla/cli/providers_cmd.py",
+            "tests/test_provider*.py",
+            "tests/test_provider/**",
+            "tests/test_search/test_*provider.py",
+            "tests/test_onboarding/test_provider_specs.py",
+            "docs/providers-and-models.md",
+            "docs/features/bocha-search-provider-design.md",
+        ),
+    ),
+    (
+        "desktop",
+        (
+            "desktop/**",
+            "tests/test_desktop/**",
+        ),
+    ),
+)
+
+
+class PullRequestContext(NamedTuple):
+    number: int
+    author_login: str
+    author_association: str
+    additions: int
+    deletions: int
+    changed_files_count: int
+    files: tuple[str, ...]
+
+    @property
+    def line_delta(self) -> int:
+        return self.additions + self.deletions
+
+
+def _annotation_escape(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _error(title: str, message: str) -> None:
+    print(f"::error title={_annotation_escape(title)}::{_annotation_escape(message)}")
+
+
+def _load_event(path: str) -> dict[str, Any]:
+    with Path(path).open(encoding="utf-8") as event_file:
+        return json.load(event_file)
+
+
+def _repo_from_event(event: dict[str, Any]) -> str:
+    repository = event.get("repository") or {}
+    full_name = str(repository.get("full_name") or "")
+    if full_name:
+        return full_name
+    return os.environ.get("GITHUB_REPOSITORY", "")
+
+
+def _request_json(repo: str, token: str, path: str) -> Any:
+    request = Request(
+        f"https://api.github.com/repos/{repo}{path}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method="GET",
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            raw = response.read()
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub API GET {path} failed: {exc.code} {body}") from exc
+    return json.loads(raw.decode("utf-8")) if raw else None
+
+
+def _fetch_paginated(repo: str, token: str, path: str) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        separator = "&" if "?" in path else "?"
+        page_items = _request_json(repo, token, f"{path}{separator}per_page=100&page={page}")
+        if not isinstance(page_items, list) or not page_items:
+            return items
+        items.extend(page_items)
+        if len(page_items) < 100:
+            return items
+        page += 1
+
+
+def _changed_files_from_env() -> tuple[str, ...] | None:
+    path = os.environ.get("PR_CHANGED_FILES_PATH")
+    if not path:
+        return None
+    return tuple(
+        line.strip()
+        for line in Path(path).read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    )
+
+
+def _reviews_from_env() -> list[dict[str, Any]] | None:
+    path = os.environ.get("PR_REVIEWS_PATH")
+    if not path:
+        return None
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("PR_REVIEWS_PATH must contain a JSON array")
+    return data
+
+
+def _github_token() -> str:
+    return os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or ""
+
+
+def _load_pr_context(event: dict[str, Any]) -> PullRequestContext | None:
+    pr = event.get("pull_request")
+    if not isinstance(pr, dict):
+        return None
+
+    files = _changed_files_from_env()
+    repo = _repo_from_event(event)
+    token = _github_token()
+    if files is None:
+        if not repo or not token:
+            raise RuntimeError(
+                "GITHUB_REPOSITORY and GITHUB_TOKEN/GH_TOKEN are required to load PR files."
+            )
+        files = tuple(
+            str(item.get("filename") or "")
+            for item in _fetch_paginated(repo, token, f"/pulls/{int(pr['number'])}/files")
+            if item.get("filename")
+        )
+
+    user = pr.get("user") or {}
+    return PullRequestContext(
+        number=int(pr["number"]),
+        author_login=str(user.get("login") or ""),
+        author_association=str(pr.get("author_association") or "").upper(),
+        additions=int(pr.get("additions") or 0),
+        deletions=int(pr.get("deletions") or 0),
+        changed_files_count=int(pr.get("changed_files") or len(files)),
+        files=files,
+    )
+
+
+def _matches_any(path: str, patterns: tuple[str, ...]) -> bool:
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns)
+
+
+def review_requirement_reasons(context: PullRequestContext) -> list[str]:
+    reasons: list[str] = []
+
+    if context.changed_files_count > MAX_UNREVIEWED_CHANGED_FILES:
+        reasons.append(
+            f"{context.changed_files_count} changed files "
+            f"(>{MAX_UNREVIEWED_CHANGED_FILES})"
+        )
+
+    if context.line_delta > MAX_UNREVIEWED_LINE_DELTA:
+        reasons.append(f"{context.line_delta} changed lines (>{MAX_UNREVIEWED_LINE_DELTA})")
+
+    for category, patterns in RISK_PATTERNS:
+        matched = next((path for path in context.files if _matches_any(path, patterns)), None)
+        if matched is not None:
+            reasons.append(f"{category} surface changed ({matched})")
+
+    return reasons
+
+
+def active_approvers(reviews: list[dict[str, Any]], *, author_login: str) -> tuple[str, ...]:
+    decisive_states = {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}
+    latest_by_user: dict[str, dict[str, Any]] = {}
+    for index, review in enumerate(reviews):
+        user = review.get("user") or {}
+        login = str(user.get("login") or "")
+        if not login or login == author_login:
+            continue
+        if str(review.get("state") or "").upper() not in decisive_states:
+            continue
+        review_with_index = dict(review)
+        review_with_index["_index"] = index
+        previous = latest_by_user.get(login)
+        if previous is None:
+            latest_by_user[login] = review_with_index
+            continue
+        previous_key = (str(previous.get("submitted_at") or ""), int(previous.get("_index") or 0))
+        current_key = (
+            str(review_with_index.get("submitted_at") or ""),
+            int(review_with_index.get("_index") or 0),
+        )
+        if current_key >= previous_key:
+            latest_by_user[login] = review_with_index
+
+    return tuple(
+        sorted(
+            login
+            for login, review in latest_by_user.items()
+            if str(review.get("state") or "").upper() == "APPROVED"
+        )
+    )
+
+
+def _load_reviews(event: dict[str, Any], pr_number: int) -> list[dict[str, Any]]:
+    reviews = _reviews_from_env()
+    if reviews is not None:
+        return reviews
+
+    repo = _repo_from_event(event)
+    token = _github_token()
+    if not repo or not token:
+        raise RuntimeError(
+            "GITHUB_REPOSITORY and GITHUB_TOKEN/GH_TOKEN are required to load PR reviews."
+        )
+    return _fetch_paginated(repo, token, f"/pulls/{pr_number}/reviews")
+
+
+def main() -> int:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        _error("Missing PR event", "GITHUB_EVENT_PATH is required for review governance.")
+        return 1
+
+    try:
+        event = _load_event(event_path)
+        context = _load_pr_context(event)
+        if context is None:
+            print("Review gate only applies to pull requests.")
+            return 0
+
+        reasons = review_requirement_reasons(context)
+        if not reasons:
+            print("Risk-based review is not required for this pull request.")
+            return 0
+
+        reviews = _load_reviews(event, context.number)
+        approvers = active_approvers(reviews, author_login=context.author_login)
+        if approvers:
+            print(
+                "Risk-based review requirement satisfied by: "
+                + ", ".join(approvers)
+                + "."
+            )
+            return 0
+
+        _error(
+            "Review required",
+            "This pull request needs at least one non-author approval because: "
+            + "; ".join(reasons)
+            + ".",
+        )
+        return 1
+    except Exception as exc:
+        _error("Review gate failed", str(exc))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/validate_pr_review_gate.py
+++ b/.github/scripts/validate_pr_review_gate.py
@@ -13,6 +13,7 @@ from urllib.request import Request, urlopen
 
 MAX_UNREVIEWED_CHANGED_FILES = 30
 MAX_UNREVIEWED_LINE_DELTA = 1000
+TRUSTED_REVIEWER_ASSOCIATIONS = frozenset({"MEMBER", "OWNER"})
 
 RISK_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
@@ -245,6 +246,9 @@ def active_approvers(reviews: list[dict[str, Any]], *, author_login: str) -> tup
         login = str(user.get("login") or "")
         if not login or login == author_login:
             continue
+        association = str(review.get("author_association") or "").upper()
+        if association not in TRUSTED_REVIEWER_ASSOCIATIONS:
+            continue
         if str(review.get("state") or "").upper() not in decisive_states:
             continue
         review_with_index = dict(review)
@@ -314,7 +318,8 @@ def main() -> int:
 
         _error(
             "Review required",
-            "This pull request needs at least one non-author approval because: "
+            "This pull request needs at least one non-author organization member "
+            "approval because: "
             + "; ".join(reasons)
             + ".",
         )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.19.0'
+          node-version: '22.12.0'
           cache: 'npm'
           cache-dependency-path: opensquilla-webui/package-lock.json
 
@@ -127,7 +127,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.19.0'
+          node-version: '22.12.0'
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -410,7 +410,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.19.0'
+          node-version: '22.12.0'
 
       - name: Check README locale parity
         working-directory: opensquilla-webui

--- a/.github/workflows/pr-target-branch.yml
+++ b/.github/workflows/pr-target-branch.yml
@@ -35,3 +35,15 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/validate-pr-target-branch.sh
+
+      - name: Check out bootstrap review gate before first merge
+        if: ${{ hashFiles('.github/scripts/validate_pr_review_gate.py') == '' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Validate risk-based review requirement
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/validate_pr_review_gate.py

--- a/.github/workflows/pr-target-branch.yml
+++ b/.github/workflows/pr-target-branch.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Validate target branch
         env:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/pr-target-branch.yml
+++ b/.github/workflows/pr-target-branch.yml
@@ -3,6 +3,8 @@ name: PR target branch
 "on":
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, dismissed]
 
 permissions:
   contents: read

--- a/tests/test_ci/test_pr_review_gate.py
+++ b/tests/test_ci/test_pr_review_gate.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _load_gate_module():
+    script = (
+        Path(__file__).resolve().parents[2]
+        / ".github"
+        / "scripts"
+        / "validate_pr_review_gate.py"
+    )
+    spec = importlib.util.spec_from_file_location("validate_pr_review_gate", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_review_gate_requires_review_for_large_and_risky_pr() -> None:
+    gate = _load_gate_module()
+
+    reasons = gate.review_requirement_reasons(
+        gate.PullRequestContext(
+            number=123,
+            author_login="external-dev",
+            author_association="CONTRIBUTOR",
+            additions=900,
+            deletions=101,
+            changed_files_count=31,
+            files=(
+                ".github/workflows/ci.yml",
+                "desktop/electron/src/main.ts",
+                "src/opensquilla/provider/openai.py",
+                "src/opensquilla/sandbox/policy.py",
+                "scripts/build_wheelhouse_zip.py",
+            ),
+        )
+    )
+
+    assert "31 changed files (>30)" in reasons
+    assert "1001 changed lines (>1000)" in reasons
+    assert "CI surface changed (.github/workflows/ci.yml)" in reasons
+    assert "desktop surface changed (desktop/electron/src/main.ts)" in reasons
+    assert "provider surface changed (src/opensquilla/provider/openai.py)" in reasons
+    assert "security surface changed (src/opensquilla/sandbox/policy.py)" in reasons
+    assert "release surface changed (scripts/build_wheelhouse_zip.py)" in reasons
+
+
+def test_review_gate_does_not_require_review_for_small_low_risk_pr() -> None:
+    gate = _load_gate_module()
+
+    for association in ["OWNER", "FIRST_TIME_CONTRIBUTOR"]:
+        reasons = gate.review_requirement_reasons(
+            gate.PullRequestContext(
+                number=124,
+                author_login="contributor",
+                author_association=association,
+                additions=40,
+                deletions=5,
+                changed_files_count=2,
+                files=("README.md", "docs/features/skills.md"),
+            )
+        )
+
+        assert reasons == []
+
+
+def test_review_gate_counts_latest_non_author_approval_only() -> None:
+    gate = _load_gate_module()
+
+    reviews = [
+        {
+            "state": "APPROVED",
+            "submitted_at": "2026-06-30T01:00:00Z",
+            "user": {"login": "reviewer-a"},
+        },
+        {
+            "state": "CHANGES_REQUESTED",
+            "submitted_at": "2026-06-30T02:00:00Z",
+            "user": {"login": "reviewer-a"},
+        },
+        {
+            "state": "APPROVED",
+            "submitted_at": "2026-06-30T03:00:00Z",
+            "user": {"login": "reviewer-b"},
+        },
+        {
+            "state": "COMMENTED",
+            "submitted_at": "2026-06-30T03:30:00Z",
+            "user": {"login": "reviewer-b"},
+        },
+        {
+            "state": "APPROVED",
+            "submitted_at": "2026-06-30T04:00:00Z",
+            "user": {"login": "author"},
+        },
+    ]
+
+    assert gate.active_approvers(reviews, author_login="author") == ("reviewer-b",)
+
+
+def test_review_gate_allows_small_external_pr_from_local_event(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    files_path = tmp_path / "files.txt"
+    reviews_path = tmp_path / "reviews.json"
+    event_path.write_text(
+        json.dumps(
+            {
+                "repository": {"full_name": "opensquilla/opensquilla"},
+                "pull_request": {
+                    "number": 125,
+                    "user": {"login": "external-dev"},
+                    "author_association": "FIRST_TIME_CONTRIBUTOR",
+                    "additions": 5,
+                    "deletions": 0,
+                    "changed_files": 1,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    files_path.write_text("README.md\n", encoding="utf-8")
+    reviews_path.write_text("[]", encoding="utf-8")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "GITHUB_EVENT_PATH": event_path.as_posix(),
+            "PR_CHANGED_FILES_PATH": files_path.as_posix(),
+            "PR_REVIEWS_PATH": reviews_path.as_posix(),
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, ".github/scripts/validate_pr_review_gate.py"],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Risk-based review is not required" in result.stdout
+
+
+def test_review_gate_fails_risky_unapproved_pr_from_local_event(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    files_path = tmp_path / "files.txt"
+    reviews_path = tmp_path / "reviews.json"
+    event_path.write_text(
+        json.dumps(
+            {
+                "repository": {"full_name": "opensquilla/opensquilla"},
+                "pull_request": {
+                    "number": 126,
+                    "user": {"login": "external-dev"},
+                    "author_association": "FIRST_TIME_CONTRIBUTOR",
+                    "additions": 5,
+                    "deletions": 0,
+                    "changed_files": 1,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    files_path.write_text("src/opensquilla/provider/openai.py\n", encoding="utf-8")
+    reviews_path.write_text("[]", encoding="utf-8")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "GITHUB_EVENT_PATH": event_path.as_posix(),
+            "PR_CHANGED_FILES_PATH": files_path.as_posix(),
+            "PR_REVIEWS_PATH": reviews_path.as_posix(),
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, ".github/scripts/validate_pr_review_gate.py"],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "::error title=Review required::" in result.stdout
+    assert "provider surface changed (src/opensquilla/provider/openai.py)" in result.stdout

--- a/tests/test_ci/test_pr_review_gate.py
+++ b/tests/test_ci/test_pr_review_gate.py
@@ -72,38 +72,161 @@ def test_review_gate_does_not_require_review_for_small_low_risk_pr() -> None:
         assert reasons == []
 
 
-def test_review_gate_counts_latest_non_author_approval_only() -> None:
+def test_review_gate_counts_latest_non_author_organization_member_approval_only() -> None:
     gate = _load_gate_module()
 
     reviews = [
         {
             "state": "APPROVED",
             "submitted_at": "2026-06-30T01:00:00Z",
+            "author_association": "MEMBER",
             "user": {"login": "reviewer-a"},
         },
         {
             "state": "CHANGES_REQUESTED",
             "submitted_at": "2026-06-30T02:00:00Z",
+            "author_association": "MEMBER",
             "user": {"login": "reviewer-a"},
         },
         {
             "state": "APPROVED",
+            "submitted_at": "2026-06-30T02:30:00Z",
+            "author_association": "CONTRIBUTOR",
+            "user": {"login": "external-reviewer"},
+        },
+        {
+            "state": "APPROVED",
             "submitted_at": "2026-06-30T03:00:00Z",
+            "author_association": "OWNER",
             "user": {"login": "reviewer-b"},
         },
         {
             "state": "COMMENTED",
             "submitted_at": "2026-06-30T03:30:00Z",
+            "author_association": "OWNER",
             "user": {"login": "reviewer-b"},
         },
         {
             "state": "APPROVED",
             "submitted_at": "2026-06-30T04:00:00Z",
+            "author_association": "OWNER",
             "user": {"login": "author"},
         },
     ]
 
     assert gate.active_approvers(reviews, author_login="author") == ("reviewer-b",)
+
+
+def test_review_gate_rejects_external_approval_for_risky_pr(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    files_path = tmp_path / "files.txt"
+    reviews_path = tmp_path / "reviews.json"
+    event_path.write_text(
+        json.dumps(
+            {
+                "repository": {"full_name": "opensquilla/opensquilla"},
+                "pull_request": {
+                    "number": 127,
+                    "user": {"login": "external-dev"},
+                    "author_association": "FIRST_TIME_CONTRIBUTOR",
+                    "additions": 5,
+                    "deletions": 0,
+                    "changed_files": 1,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    files_path.write_text("src/opensquilla/provider/openai.py\n", encoding="utf-8")
+    reviews_path.write_text(
+        json.dumps(
+            [
+                {
+                    "state": "APPROVED",
+                    "submitted_at": "2026-06-30T01:00:00Z",
+                    "author_association": "CONTRIBUTOR",
+                    "user": {"login": "external-reviewer"},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "GITHUB_EVENT_PATH": event_path.as_posix(),
+            "PR_CHANGED_FILES_PATH": files_path.as_posix(),
+            "PR_REVIEWS_PATH": reviews_path.as_posix(),
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, ".github/scripts/validate_pr_review_gate.py"],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "non-author organization member approval" in result.stdout
+
+
+def test_review_gate_accepts_organization_member_approval_for_risky_pr(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    files_path = tmp_path / "files.txt"
+    reviews_path = tmp_path / "reviews.json"
+    event_path.write_text(
+        json.dumps(
+            {
+                "repository": {"full_name": "opensquilla/opensquilla"},
+                "pull_request": {
+                    "number": 128,
+                    "user": {"login": "external-dev"},
+                    "author_association": "FIRST_TIME_CONTRIBUTOR",
+                    "additions": 5,
+                    "deletions": 0,
+                    "changed_files": 1,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    files_path.write_text("src/opensquilla/provider/openai.py\n", encoding="utf-8")
+    reviews_path.write_text(
+        json.dumps(
+            [
+                {
+                    "state": "APPROVED",
+                    "submitted_at": "2026-06-30T01:00:00Z",
+                    "author_association": "MEMBER",
+                    "user": {"login": "org-member"},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "GITHUB_EVENT_PATH": event_path.as_posix(),
+            "PR_CHANGED_FILES_PATH": files_path.as_posix(),
+            "PR_REVIEWS_PATH": reviews_path.as_posix(),
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, ".github/scripts/validate_pr_review_gate.py"],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "satisfied by: org-member" in result.stdout
 
 
 def test_review_gate_allows_small_external_pr_from_local_event(tmp_path: Path) -> None:
@@ -192,4 +315,5 @@ def test_review_gate_fails_risky_unapproved_pr_from_local_event(tmp_path: Path) 
 
     assert result.returncode == 1
     assert "::error title=Review required::" in result.stdout
+    assert "non-author organization member approval" in result.stdout
     assert "provider surface changed (src/opensquilla/provider/openai.py)" in result.stdout

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -131,6 +131,7 @@ def _validate_pr_target(
     title: str = "Example change",
     labels: list[str] | None = None,
     changed_files: list[str] | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     event_path = tmp_path / "event.json"
     changed_files_path = tmp_path / "changed-files.txt"
@@ -163,6 +164,8 @@ def _validate_pr_target(
     )
     if changed_files is not None:
         env["PR_CHANGED_FILES_PATH"] = changed_files_path.as_posix()
+    if extra_env is not None:
+        env.update(extra_env)
     return subprocess.run(
         [_bash_executable(), PR_TARGET_VALIDATOR.as_posix()],
         env=env,
@@ -322,6 +325,76 @@ def test_pr_target_validator_blocks_unknown_target_branches(tmp_path: Path) -> N
     assert "Ordinary pull requests should target main" in result.stderr
 
 
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", repo.as_posix(), *args], check=True)
+
+
+def _write_commit(repo: Path, path: str, content: str, message: str) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    _git(repo, "add", path)
+    _git(repo, "commit", "-m", message)
+
+
+def _history_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "history-repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "ci@example.invalid")
+    _git(repo, "config", "user.name", "CI")
+    _git(repo, "checkout", "-b", "main")
+    _write_commit(repo, "README.md", "base\n", "base")
+    return repo
+
+
+def test_pr_target_validator_allows_related_history(tmp_path: Path) -> None:
+    repo = _history_repo(tmp_path)
+    _git(repo, "checkout", "-b", "feature/related")
+    _write_commit(repo, "feature.txt", "related\n", "related")
+
+    result = _validate_pr_target(
+        tmp_path,
+        base="main",
+        head="feature/related",
+        extra_env={
+            "PR_HISTORY_REPO_PATH": repo.as_posix(),
+            "PR_HISTORY_BASE_REF": "main",
+            "PR_HISTORY_HEAD_REF": "feature/related",
+        },
+    )
+
+    assert result.returncode == 0
+    assert "shares a common ancestor with main" in result.stdout
+
+
+def test_pr_target_validator_blocks_unrelated_history(tmp_path: Path) -> None:
+    repo = _history_repo(tmp_path)
+    _git(repo, "checkout", "--orphan", "feature/unrelated")
+    for child in repo.iterdir():
+        if child.name != ".git":
+            if child.is_dir():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+    _write_commit(repo, "other.txt", "unrelated\n", "unrelated")
+
+    result = _validate_pr_target(
+        tmp_path,
+        base="main",
+        head="feature/unrelated",
+        extra_env={
+            "PR_HISTORY_REPO_PATH": repo.as_posix(),
+            "PR_HISTORY_BASE_REF": "main",
+            "PR_HISTORY_HEAD_REF": "feature/unrelated",
+        },
+    )
+
+    assert result.returncode == 1
+    assert "no common ancestor with main" in result.stderr
+    assert "Recreate the branch from the current main" in result.stderr
+
+
 def test_pr_target_validator_handles_missing_event_path() -> None:
     env = os.environ.copy()
     env.pop("GITHUB_EVENT_PATH", None)
@@ -352,6 +425,8 @@ def test_pr_target_branch_workflow_runs_trusted_base_validator() -> None:
     assert "github.event.repository.default_branch" in text
     assert "hashFiles('.github/scripts/validate-pr-target-branch.sh') == ''" in text
     assert "github.event.pull_request.head.sha" in text
+    assert "PR_BASE_SHA" in text
+    assert "PR_HEAD_SHA" in text
     assert "pull-requests: read" in text
     assert "PR_LABELS" in text
     assert "PR_NUMBER" in text

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -13,6 +13,7 @@ import yaml
 WORKFLOW_DIR = Path(".github/workflows")
 CLASSIFIER = Path(".github/scripts/classify-ci-changes.sh")
 PR_TARGET_VALIDATOR = Path(".github/scripts/validate-pr-target-branch.sh")
+PR_REVIEW_GATE = Path(".github/scripts/validate_pr_review_gate.py")
 PR_BODY_LINT = Path(".github/scripts/validate_pr_body.py")
 TEST_PATH_RE = re.compile(r"tests/[A-Za-z0-9_./-]+\.py")
 
@@ -354,6 +355,10 @@ def test_pr_target_branch_workflow_runs_trusted_base_validator() -> None:
     assert "PR_LABELS" in text
     assert "PR_NUMBER" in text
     assert ".github/scripts/validate-pr-target-branch.sh" in text
+    assert "Validate risk-based review requirement" in text
+    assert "hashFiles('.github/scripts/validate_pr_review_gate.py') == ''" in text
+    assert PR_REVIEW_GATE.as_posix() in text
+    assert "GITHUB_TOKEN: ${{ github.token }}" in text
 
 
 def test_pr_body_lint_workflow_warns_from_trusted_base() -> None:

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -345,7 +345,8 @@ def test_pr_target_branch_workflow_runs_trusted_base_validator() -> None:
     data = _workflow("pr-target-branch.yml")
     text = (WORKFLOW_DIR / "pr-target-branch.yml").read_text(encoding="utf-8")
 
-    assert _trigger_keys(data) == {"pull_request"}
+    assert _trigger_keys(data) == {"pull_request", "pull_request_review"}
+    assert data["on"]["pull_request_review"]["types"] == ["submitted", "dismissed"]
     assert "pull_request_target" not in text
     assert "Validate target branch" in text
     assert "github.event.repository.default_branch" in text

--- a/tests/test_github_issue_link_sync.py
+++ b/tests/test_github_issue_link_sync.py
@@ -98,7 +98,7 @@ def test_parse_linked_issues_deduplicates_and_ignores_pr_style_urls() -> None:
     assert parsed.all == (100, 101)
 
 
-def test_plan_merged_dev_pr_updates_only_closing_issues() -> None:
+def test_plan_merged_staging_pr_updates_only_closing_issues() -> None:
     sync = _load_sync_module()
 
     actions = sync.plan_issue_sync_actions(
@@ -120,15 +120,17 @@ def test_plan_merged_dev_pr_updates_only_closing_issues() -> None:
     assert actions == (
         sync.IssueSyncAction(
             issue_number=100,
-            kind="merged_to_dev",
+            kind="merged_to_staging",
             pr_number=DUMMY_MERGED_DEV_PR,
             pr_url=DUMMY_MERGED_DEV_PR_URL,
+            base_ref="dev",
         ),
         sync.IssueSyncAction(
             issue_number=200,
             kind="remove_linked_pr",
             pr_number=DUMMY_MERGED_DEV_PR,
             pr_url=DUMMY_MERGED_DEV_PR_URL,
+            base_ref="dev",
         ),
     )
 
@@ -169,7 +171,7 @@ def test_plan_open_or_updated_pr_adds_linked_pr_label_to_all_linked_issues() -> 
         )
 
 
-def test_plan_merged_main_pr_removes_linked_pr_label_without_dev_status() -> None:
+def test_plan_merged_main_pr_uses_mainline_cleanup_for_closing_issues() -> None:
     sync = _load_sync_module()
 
     actions = sync.plan_issue_sync_actions(
@@ -191,15 +193,17 @@ def test_plan_merged_main_pr_removes_linked_pr_label_without_dev_status() -> Non
     assert actions == (
         sync.IssueSyncAction(
             issue_number=100,
-            kind="remove_linked_pr",
+            kind="merged_to_main",
             pr_number=DUMMY_MERGED_MAIN_PR,
             pr_url=DUMMY_MERGED_MAIN_PR_URL,
+            base_ref="main",
         ),
         sync.IssueSyncAction(
             issue_number=200,
             kind="remove_linked_pr",
             pr_number=DUMMY_MERGED_MAIN_PR,
             pr_url=DUMMY_MERGED_MAIN_PR_URL,
+            base_ref="main",
         ),
     )
 
@@ -239,54 +243,76 @@ def test_plan_closed_unmerged_pr_removes_linked_pr_label_from_all_linked_issues(
     )
 
 
-def test_comment_marker_is_pr_scoped_for_idempotent_merged_to_dev_comments() -> None:
+def test_comment_marker_is_pr_scoped_for_idempotent_merged_to_staging_comments() -> None:
     sync = _load_sync_module()
 
-    marker = sync.comment_marker(kind="merged_to_dev", pr_number=DUMMY_MERGED_DEV_PR)
+    marker = sync.comment_marker(kind="merged_to_staging", pr_number=DUMMY_MERGED_DEV_PR)
 
-    assert marker == "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9001 -->"
+    assert marker == "<!-- opensquilla-issue-link-sync:merged-to-staging:pr-9001 -->"
     assert sync.has_marker([{"body": f"{marker}\nThis is already posted."}], marker)
     assert not sync.has_marker(
-        [{"body": "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9000 -->"}],
+        [{"body": "<!-- opensquilla-issue-link-sync:merged-to-staging:pr-9000 -->"}],
         marker,
     )
 
 
-def test_apply_merged_dev_action_labels_removes_open_pr_label_and_comments_once() -> None:
+def test_apply_merged_staging_action_labels_removes_open_pr_label_and_comments_once() -> None:
     sync = _load_sync_module()
     action = sync.IssueSyncAction(
         issue_number=100,
-        kind="merged_to_dev",
+        kind="merged_to_staging",
         pr_number=DUMMY_MERGED_DEV_PR,
         pr_url=DUMMY_MERGED_DEV_PR_URL,
+        base_ref="dev",
     )
     client = RecordingClient()
 
     sync.apply_action(client, action)
 
     assert client.calls == [
-        ("add_labels", 100, ("merged-to-dev", "needs-verification")),
+        ("add_labels", 100, ("merged-to-staging", "needs-verification")),
         ("remove_label", 100, "has-linked-pr"),
         ("list_comments", 100),
         (
             "create_comment",
             100,
-            "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9001 -->\n"
+            "<!-- opensquilla-issue-link-sync:merged-to-staging:pr-9001 -->\n"
             "The linked fix for this issue has merged to `dev` via #9001 "
             f"({DUMMY_MERGED_DEV_PR_URL}). "
-            "Keeping it open for verification before release.",
+            "Keeping it open for verification before mainline release.",
         ),
     ]
 
-    marker = sync.comment_marker(kind="merged_to_dev", pr_number=DUMMY_MERGED_DEV_PR)
+    marker = sync.comment_marker(kind="merged_to_staging", pr_number=DUMMY_MERGED_DEV_PR)
     client = RecordingClient(comments=[{"body": marker}])
 
     sync.apply_action(client, action)
 
     assert client.calls == [
-        ("add_labels", 100, ("merged-to-dev", "needs-verification")),
+        ("add_labels", 100, ("merged-to-staging", "needs-verification")),
         ("remove_label", 100, "has-linked-pr"),
         ("list_comments", 100),
+    ]
+
+
+def test_apply_merged_main_action_clears_open_staging_and_legacy_dev_labels() -> None:
+    sync = _load_sync_module()
+    action = sync.IssueSyncAction(
+        issue_number=100,
+        kind="merged_to_main",
+        pr_number=DUMMY_MERGED_MAIN_PR,
+        pr_url=DUMMY_MERGED_MAIN_PR_URL,
+        base_ref="main",
+    )
+    client = RecordingClient()
+
+    sync.apply_action(client, action)
+
+    assert client.calls == [
+        ("remove_label", 100, "has-linked-pr"),
+        ("remove_label", 100, "merged-to-staging"),
+        ("remove_label", 100, "merged-to-dev"),
+        ("remove_label", 100, "needs-verification"),
     ]
 
 
@@ -340,7 +366,7 @@ def test_list_comments_reads_all_pages_before_idempotency_check() -> None:
     client = PaginatedGitHubClient(
         [
             [{"body": f"old comment {index}"} for index in range(100)],
-            [{"body": "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9001 -->"}],
+            [{"body": "<!-- opensquilla-issue-link-sync:merged-to-staging:pr-9001 -->"}],
         ]
     )
 
@@ -348,7 +374,7 @@ def test_list_comments_reads_all_pages_before_idempotency_check() -> None:
 
     assert sync.has_marker(
         comments,
-        "<!-- opensquilla-issue-link-sync:merged-to-dev:pr-9001 -->",
+        "<!-- opensquilla-issue-link-sync:merged-to-staging:pr-9001 -->",
     )
     assert client.paths == [
         "/issues/100/comments?per_page=100&page=1",


### PR DESCRIPTION
## Scope

Scope boundary: add a risk-based pull request review gate, refresh issue-link labels for mainline governance, and align CI workflow Node setup with Node 22.

Non-goals: broad branch cleanup, full ruleset changes, or unrelated CI refactors.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: maintainer governance follow-up, not tied to a public issue.

## Release Note

Release note: NONE

## Tests

Ruff: `uv run --extra dev ruff check .github/scripts/validate_pr_review_gate.py .github/scripts/issue_link_sync.py tests/test_ci/test_pr_review_gate.py tests/test_github_issue_link_sync.py tests/test_ci/test_workflows.py`

Pytest: `uv run pytest tests/test_ci/test_pr_review_gate.py tests/test_github_issue_link_sync.py tests/test_ci/test_workflows.py -q`

Build: not run; workflow/governance change only

Regression tests: added

Notes: validated all workflow YAML loads via `uv run python` and confirmed no explicit `node-version: 20` remains in `.github`.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: N/A

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents were not committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
