### PR TITLE
Multi-provider config scaffolding + real catalog budgets (handoff draft)

### DIFF
--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -257,6 +257,21 @@ class TaskRuntimeConfig(BaseModel):
         return value
 
 
+class MultiProviderConfig(BaseModel):
+    """Feature gate for cross-provider routing/fallback enforcement.
+
+    Default off: while disabled, multi-provider configuration (cross-provider
+    fallbacks, per-tier providers) is inert and existing single-provider
+    setups behave exactly as before. Enabling it activates the
+    credential-resolution invariant and cross-provider switching introduced
+    in later changes.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+
+
 class LlmProviderConfig(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="OPENSQUILLA_LLM_")
 
@@ -274,6 +289,10 @@ class LlmProviderConfig(BaseSettings):
     # send provider.order=[name] so the provider is preferred without disabling
     # OpenRouter fallback.
     provider_routing: dict[str, str] = Field(default_factory=dict)
+    # Feature gate (default off) for cross-provider routing/fallback
+    # enforcement; see MultiProviderConfig. Inert until later changes consume
+    # it, so single-provider configs are unaffected.
+    multi_provider: MultiProviderConfig = Field(default_factory=MultiProviderConfig)
 
     @model_validator(mode="after")
     def _normalize_direct_deepseek_model(self) -> LlmProviderConfig:

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -1677,6 +1677,47 @@ class TlsConfig(BaseSettings):
     certfile: str = ""
 
 
+def validate_multi_provider_config(config: GatewayConfig) -> None:
+    """Reject not-yet-supported multi-provider router config.
+
+    ``llm.multi_provider.enabled`` is a PREVIEW flag: per-tier cross-provider
+    routing is not wired into the runtime yet (a routed tier only changes the
+    model, not the active provider), so a tier whose provider differs from
+    ``llm.provider`` would silently run against the primary provider. Until the
+    routing is implemented, reject such a tier at config-load/save time with an
+    actionable error rather than letting a mis-routing config validate. No-op
+    unless the flag is on; a disabled router is skipped (its tiers never route).
+
+    When per-tier cross-provider routing lands, this becomes a credential-
+    resolution check (inline api_key / api_key_env / provider default env var /
+    keyless local providers) instead of an outright rejection.
+    """
+    if not config.llm.multi_provider.enabled:
+        return
+
+    router = config.squilla_router
+    if not getattr(router, "enabled", False):
+        return  # router disabled: its tiers never route
+
+    llm_provider = str(getattr(config.llm, "provider", "") or "").strip().lower()
+    tiers = getattr(router, "tiers", None)
+    if not isinstance(tiers, dict):
+        return
+
+    for tier_id, tier in tiers.items():
+        if not isinstance(tier, dict):
+            continue
+        tier_provider = str(tier.get("provider") or "").strip().lower()
+        if not tier_provider or tier_provider == llm_provider:
+            continue  # inherits / matches the primary provider
+        raise ValueError(
+            f"squilla_router tier {tier_id!r} sets provider {tier_provider!r} "
+            f"(!= llm.provider {llm_provider!r}), but per-tier cross-provider routing is "
+            f"not supported yet — llm.multi_provider is a preview flag with no runtime "
+            f"routing effect. Remove the tier's provider or set it to {llm_provider!r}."
+        )
+
+
 class GatewayConfig(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="OPENSQUILLA_GATEWAY_",
@@ -1776,6 +1817,14 @@ class GatewayConfig(BaseSettings):
                 "squilla_router.tier_profile requires llm.provider to match "
                 f"({normalized_profile!r} != {provider!r})"
             )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_multi_provider_config(self) -> GatewayConfig:
+        # Fires on every full validation (boot load + persist save), so a
+        # not-yet-supported cross-provider tier is rejected before it can be
+        # written or loaded. Inert unless the multi_provider flag is on.
+        validate_multi_provider_config(self)
         return self
 
     # --- Context overflow policy -----------------------------------------

--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -265,6 +265,10 @@ def upsert_llm_provider(
         base_url=effective_base_url,
         proxy=proxy,
         provider_routing=dict(provider_routing or {}),
+        # Preserve the multi-provider feature gate across a provider
+        # reconfigure; onboarding doesn't manage it, so rebuilding the
+        # config from scratch must not silently reset it to the default.
+        multi_provider=config.llm.multi_provider.model_dump(),
     )
     _reconcile_router_profile_for_provider(new_cfg, provider_id)
     if api_key:

--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -17,6 +17,7 @@ from opensquilla.gateway.config import (
     MemoryEmbeddingConfig,
     SquillaRouterConfig,
     _router_tier_profile_defaults,
+    validate_multi_provider_config,
 )
 from opensquilla.onboarding.audio_specs import get_audio_provider_setup_spec
 from opensquilla.onboarding.image_generation_specs import (
@@ -29,6 +30,7 @@ from opensquilla.onboarding.redaction import (
     redact_image_generation_payload,
     redact_memory_embedding_payload,
     redact_provider_payload,
+    redact_router_tiers,
     redact_search_payload,
 )
 from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
@@ -268,7 +270,7 @@ def upsert_llm_provider(
         # Preserve the multi-provider feature gate across a provider
         # reconfigure; onboarding doesn't manage it, so rebuilding the
         # config from scratch must not silently reset it to the default.
-        multi_provider=config.llm.multi_provider.model_dump(),
+        multi_provider=config.llm.multi_provider.model_copy(deep=True),
     )
     _reconcile_router_profile_for_provider(new_cfg, provider_id)
     if api_key:
@@ -286,6 +288,9 @@ def upsert_llm_provider(
         "proxy": proxy,
         "provider_routing": dict(provider_routing or {}),
     }
+    # Validate before the RPC applies/persists, so an uncredentialed
+    # cross-provider tier is rejected without touching the live runtime.
+    validate_multi_provider_config(new_cfg)
     return MutationResult(
         config=new_cfg,
         changed=True,
@@ -354,7 +359,10 @@ def upsert_router(
     new_cfg.squilla_router = SquillaRouterConfig(**router_payload)
     _sync_llm_model_to_router_default(new_cfg)
     public_payload["default_tier"] = new_cfg.squilla_router.default_tier
-    public_payload["tiers"] = new_cfg.squilla_router.tiers
+    public_payload["tiers"] = redact_router_tiers(new_cfg.squilla_router.tiers)
+    # Validate before the RPC applies/persists, so an uncredentialed
+    # cross-provider tier is rejected without touching the live runtime.
+    validate_multi_provider_config(new_cfg)
     return MutationResult(
         config=new_cfg,
         changed=True,

--- a/src/opensquilla/onboarding/redaction.py
+++ b/src/opensquilla/onboarding/redaction.py
@@ -52,6 +52,21 @@ def redact_memory_embedding_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def redact_router_tiers(tiers: dict[str, Any]) -> dict[str, Any]:
+    """Redact per-tier ``api_key`` secrets before echoing router config back.
+
+    A router tier may carry an inline ``api_key`` for a cross-provider
+    provider; ``api_key_env`` is only an env-var name and is preserved.
+    """
+    out: dict[str, Any] = {}
+    for tier_id, tier in tiers.items():
+        if isinstance(tier, dict) and tier.get("api_key"):
+            tier = dict(tier)
+            tier["api_key"] = REDACTED_PLACEHOLDER
+        out[tier_id] = tier
+    return out
+
+
 def redact_channel_entry(type_name: str, payload: dict[str, Any]) -> dict[str, Any]:
     try:
         spec = get_channel_setup_spec(type_name)

--- a/src/opensquilla/provider/model_catalog.py
+++ b/src/opensquilla/provider/model_catalog.py
@@ -30,13 +30,14 @@ _LOCAL_PROVIDERS = frozenset({"ollama", "lm_studio", "ovms", "vllm", "local"})
 # Used when the OpenRouter API is unreachable at boot.
 # Format: model_id → (max_output_tokens, context_window)
 #
-# Keys are provider-agnostic basenames (no "vendor/" prefix); a model that
-# was previously listed under both spellings is merged to ONE conservative
-# (per-dimension min) tuple. Conservative because over-estimating the
-# context window causes silent server-side truncation, while
-# under-estimating only triggers compaction earlier. Lookups normalize the
-# requested id via ``_static_fallback_entry`` so either spelling resolves
-# to the same entry. When offline, the live catalog still overrides this.
+# Keys are provider-agnostic basenames (no "vendor/" prefix), one entry per
+# physical model; lookups normalize the requested id via
+# ``_static_fallback_entry`` so either spelling ("glm-5" / "z-ai/glm-5")
+# resolves to the same entry. Values track the provider's real limits
+# (verified against OpenRouter's /v1/models); where a provider reports its
+# max output as the whole context window (a non-requestable ceiling), we keep
+# a smaller requestable max_output instead. This is only an offline bootstrap
+# — the live catalog overrides it whenever it is reachable.
 _STATIC_FALLBACK: dict[str, tuple[int, int]] = {
     "claude-opus-4.8": (128_000, 1_000_000),
     "claude-sonnet-4.6": (128_000, 1_000_000),
@@ -49,14 +50,14 @@ _STATIC_FALLBACK: dict[str, tuple[int, int]] = {
     "glm-4.5-air": (98_304, 131_072),
     "glm-4.6": (131_072, 202_752),
     "glm-4.7-flashx": (128_000, 200_000),
-    "glm-5": (80_000, 80_000),
-    "glm-5.1": (128_000, 200_000),
-    "glm-5.2": (262_144, 1_048_576),
+    "glm-5": (80_000, 202_752),
+    "glm-5.1": (128_000, 202_752),
+    "glm-5.2": (32_768, 1_048_576),
     "minimax-m2.5": (65_536, 196_608),
     "minimax-m2.7": (8192, 196_608),
     "step-3.5-flash": (16_384, 256_000),
-    "deepseek-v4-flash": (16_384, 1_048_576),
-    "deepseek-v4-pro": (16_384, 1_048_576),
+    "deepseek-v4-flash": (131_072, 1_048_576),
+    "deepseek-v4-pro": (384_000, 1_048_576),
     "deepseek-v3.2": (16_384, 163_840),
     "moonshot-v1-8k": (8192, 8192),
     "moonshot-v1-32k": (32_768, 32_768),

--- a/tests/test_engine/test_preflight_compaction.py
+++ b/tests/test_engine/test_preflight_compaction.py
@@ -1322,9 +1322,8 @@ async def test_run_forwards_routed_provider_and_model_to_preflight() -> None:
         pass
 
     assert seen["session_key"] == "agent:main:abc123"
-    # Conservative-min static fallback for glm-5.1 (formerly 202_752 under the
-    # z-ai/ spelling; merged with the bare glm-5.1 entry's 200_000 window).
-    assert seen["context_window_tokens"] == 200_000
+    # Real glm-5.1 context window (verified against OpenRouter's /v1/models).
+    assert seen["context_window_tokens"] == 202_752
     assert seen["compaction_model"] == "z-ai/glm-5.1"
     assert getattr(seen["compaction_provider"], "model") == "z-ai/glm-5.1"
     assert selector.override_calls == []

--- a/tests/test_gateway/test_rpc_usage.py
+++ b/tests/test_gateway/test_rpc_usage.py
@@ -201,8 +201,8 @@ def test_usage_status_reports_context_pressure_from_session_context_not_lifetime
     assert context_status == row["context_status"]
     assert context_status["contextTokens"] == 36_809
     assert context_status["context_tokens"] == 36_809
-    assert context_status["contextWindowTokens"] == 200_000
-    assert context_status["context_window_tokens"] == 200_000
+    assert context_status["contextWindowTokens"] == 202_752
+    assert context_status["context_window_tokens"] == 202_752
     assert context_status["compactionCount"] == 0
     assert context_status["pressure"] < 0.25
     assert context_status["pressure"] < row["inputTokens"] / context_status["contextWindowTokens"]

--- a/tests/test_model_router_defaults.py
+++ b/tests/test_model_router_defaults.py
@@ -4,8 +4,9 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
-from opensquilla.gateway.config import ROUTER_TIER_PROFILE_IDS
+from opensquilla.gateway.config import ROUTER_TIER_PROFILE_IDS, LlmProviderConfig
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DIRECT_ROUTER_PROFILE_IDS = sorted(ROUTER_TIER_PROFILE_IDS - {"openrouter"})
@@ -374,3 +375,18 @@ def test_runtime_router_config_does_not_ship_unused_cost_fields() -> None:
     assert "cost_matrix:" not in text
     assert "under_routing_multiplier" not in text
     assert "over_routing_multiplier" not in text
+
+
+def test_multi_provider_flag_defaults_off() -> None:
+    assert LlmProviderConfig().multi_provider.enabled is False
+
+
+def test_multi_provider_flag_round_trips_through_config_dump() -> None:
+    enabled = LlmProviderConfig(multi_provider={"enabled": True})
+    reloaded = LlmProviderConfig(**enabled.model_dump(exclude_defaults=False))
+    assert reloaded.multi_provider.enabled is True
+
+
+def test_multi_provider_flag_rejects_unknown_key() -> None:
+    with pytest.raises(ValidationError):
+        LlmProviderConfig(multi_provider={"enabled": True, "bogus": 1})

--- a/tests/test_model_router_defaults.py
+++ b/tests/test_model_router_defaults.py
@@ -6,7 +6,12 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
-from opensquilla.gateway.config import ROUTER_TIER_PROFILE_IDS, LlmProviderConfig
+from opensquilla.gateway.config import (
+    ROUTER_TIER_PROFILE_IDS,
+    GatewayConfig,
+    LlmProviderConfig,
+    validate_multi_provider_config,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DIRECT_ROUTER_PROFILE_IDS = sorted(ROUTER_TIER_PROFILE_IDS - {"openrouter"})
@@ -390,3 +395,54 @@ def test_multi_provider_flag_round_trips_through_config_dump() -> None:
 def test_multi_provider_flag_rejects_unknown_key() -> None:
     with pytest.raises(ValidationError):
         LlmProviderConfig(multi_provider={"enabled": True, "bogus": 1})
+
+
+def _cross_provider_cfg(*, enabled: bool, tier: dict) -> GatewayConfig:
+    cfg = GatewayConfig()
+    cfg.llm.provider = "openrouter"
+    cfg.llm.multi_provider.enabled = enabled
+    cfg.squilla_router.tiers = {"c1": tier}
+    return cfg
+
+
+def test_cross_provider_tier_inert_when_flag_off() -> None:
+    cfg = _cross_provider_cfg(enabled=False, tier={"provider": "deepseek", "model": "x"})
+    validate_multi_provider_config(cfg)  # no raise
+
+
+def test_cross_provider_tier_rejected_as_unsupported_when_enabled() -> None:
+    cfg = _cross_provider_cfg(enabled=True, tier={"provider": "deepseek", "model": "x"})
+    with pytest.raises(ValueError, match="not supported yet"):
+        validate_multi_provider_config(cfg)
+
+
+def test_cross_provider_tier_rejected_even_with_inline_credential() -> None:
+    # The preview flag has no routing effect, so a credential does not make a
+    # cross-provider tier runnable — it is still rejected as unsupported.
+    cfg = _cross_provider_cfg(
+        enabled=True, tier={"provider": "deepseek", "model": "x", "api_key": "sk"}
+    )
+    with pytest.raises(ValueError, match="not supported yet"):
+        validate_multi_provider_config(cfg)
+
+
+def test_same_provider_tier_is_allowed() -> None:
+    cfg = _cross_provider_cfg(enabled=True, tier={"provider": "openrouter", "model": "x"})
+    validate_multi_provider_config(cfg)  # no raise
+
+
+def test_cross_provider_tier_rejected_by_full_validation() -> None:
+    with pytest.raises(ValidationError):
+        GatewayConfig.model_validate(
+            {
+                "llm": {"provider": "openrouter", "multi_provider": {"enabled": True}},
+                "squilla_router": {"tiers": {"c1": {"provider": "deepseek", "model": "x"}}},
+            }
+        )
+
+
+def test_cross_provider_tier_not_checked_when_router_disabled() -> None:
+    cfg = _cross_provider_cfg(enabled=True, tier={"provider": "deepseek", "model": "x"})
+    cfg.squilla_router.enabled = False
+    # Router disabled: its tiers never route, so nothing to reject.
+    validate_multi_provider_config(cfg)  # no raise

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -38,6 +38,20 @@ def test_upsert_provider_persists_fields():
     assert res.changed is True
 
 
+def test_upsert_provider_preserves_multi_provider_flag():
+    cfg = GatewayConfig()
+    cfg.llm.multi_provider.enabled = True
+    res = upsert_llm_provider(
+        cfg,
+        provider_id="openrouter",
+        model="deepseek/deepseek-v4-flash",
+        api_key="sk-test",
+    )
+    # Reconfiguring a provider rebuilds llm from scratch; the multi-provider
+    # gate is not managed here and must survive instead of resetting to off.
+    assert res.config.llm.multi_provider.enabled is True
+
+
 def test_upsert_provider_strips_trailing_paste_punctuation_from_api_key():
     cfg = GatewayConfig()
     res = upsert_llm_provider(

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -784,3 +784,45 @@ def test_upsert_image_generation_rejects_bad_fallback_reference():
             cfg, provider_id="openrouter", primary=_IMG_PRIMARY, api_key="sk-img",
             fallbacks=["no-slash-ref"],
         )
+
+
+def test_upsert_router_rejects_cross_provider_tier_as_unsupported():
+    cfg = GatewayConfig()
+    cfg.llm.provider = "openrouter"
+    cfg.llm.multi_provider.enabled = True
+    # The c1 override routes to deepseek (!= primary); per-tier cross-provider
+    # routing is not wired yet, so the mutation must refuse before the RPC can
+    # apply/persist (validate-before-apply).
+    with pytest.raises(ValueError, match="not supported yet"):
+        upsert_router(
+            cfg,
+            mode="openrouter-mix",
+            tiers={"c1": {"provider": "deepseek", "model": "deepseek-chat"}},
+        )
+
+
+def test_upsert_router_redacts_tier_api_key_in_public_payload():
+    cfg = GatewayConfig()
+    cfg.llm.provider = "openrouter"
+    # A same-provider tier carrying an inline api_key is accepted; the secret
+    # must be redacted in the echoed public payload but kept in the real config.
+    res = upsert_router(
+        cfg,
+        mode="openrouter-mix",
+        tiers={"c1": {"provider": "openrouter", "model": "x", "api_key": "sk-secret"}},
+    )
+    assert res.public_payload["tiers"]["c1"]["api_key"] == REDACTED_PLACEHOLDER
+    assert res.config.squilla_router.tiers["c1"]["api_key"] == "sk-secret"
+
+
+def test_upsert_router_allows_cross_provider_tier_when_flag_off(monkeypatch):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    cfg = GatewayConfig()
+    cfg.llm.provider = "openrouter"
+    # Flag off (default): cross-provider tiers are inert, not enforced.
+    res = upsert_router(
+        cfg,
+        mode="openrouter-mix",
+        tiers={"c1": {"provider": "deepseek", "model": "deepseek-chat"}},
+    )
+    assert res.config.squilla_router.tiers["c1"]["provider"] == "deepseek"

--- a/tests/test_provider_model_catalog.py
+++ b/tests/test_provider_model_catalog.py
@@ -7,13 +7,15 @@ import pytest
 from opensquilla.provider.model_catalog import _STATIC_FALLBACK, ModelCatalog
 
 
-def test_deepseek_v4_direct_models_use_conservative_output_window() -> None:
+def test_deepseek_v4_direct_models_use_real_output_windows() -> None:
     catalog = ModelCatalog()
 
+    # Real OpenRouter max-output (pro 384k; flash's per direct-provider data is
+    # lower), both on the 1M context window.
+    expected_max = {"deepseek-v4-flash": 131_072, "deepseek-v4-pro": 384_000}
     for model in ("deepseek-v4-flash", "deepseek-v4-pro"):
         assert catalog.resolve_context_window(model) == 1_048_576
-        # Conservative-min of the former qualified (16k) vs bare (393k) entries.
-        assert catalog.resolve_max_tokens(model) == 16_384
+        assert catalog.resolve_max_tokens(model) == expected_max[model]
         caps = catalog.get_capabilities(model, provider_name="deepseek")
         assert caps.supports_reasoning is True
         assert caps.supports_tools is True
@@ -28,8 +30,8 @@ def test_direct_profile_static_fallbacks_cover_context_windows() -> None:
         "gpt-5.4-mini": 400_000,
         "gpt-5.5": 1_000_000,
         "glm-4.7-flashx": 200_000,
-        "glm-5": 80_000,
-        "glm-5.1": 200_000,
+        "glm-5": 202_752,
+        "glm-5.1": 202_752,
         "z-ai/glm-5.2": 1_048_576,
         "moonshot-v1-8k": 8_192,
         "moonshot-v1-128k": 131_072,
@@ -44,13 +46,16 @@ def test_direct_profile_static_fallbacks_cover_context_windows() -> None:
         assert max_tokens <= context_window
 
 
-def test_static_fallback_keys_are_provider_agnostic_and_conservative() -> None:
+def test_static_fallback_keys_are_provider_agnostic() -> None:
     # No provider-qualified spellings remain, so one physical model cannot
     # carry two divergent budget tuples.
     assert all("/" not in key for key in _STATIC_FALLBACK)
-    # Conservative-min merges of formerly divergent pairs.
-    assert _STATIC_FALLBACK["glm-5"] == (80_000, 80_000)
-    assert _STATIC_FALLBACK["deepseek-v4-flash"] == (16_384, 1_048_576)
+    # Real per-model budgets (verified against OpenRouter's /v1/models).
+    assert _STATIC_FALLBACK["glm-5"] == (80_000, 202_752)
+    assert _STATIC_FALLBACK["deepseek-v4-pro"] == (384_000, 1_048_576)
+    assert _STATIC_FALLBACK["deepseek-v4-flash"] == (131_072, 1_048_576)
+    # kimi-k2.6's OpenRouter max_out equals its context (a non-requestable
+    # ceiling); keep a smaller requestable value instead.
     assert _STATIC_FALLBACK["kimi-k2.6"] == (32_768, 262_144)
 
 


### PR DESCRIPTION
## Scope

**Handoff draft** for the multi-provider config scaffolding, stacked on top of the catalog/registry hardening that already merged in #398. Two things:

1. **One catalog correction that missed #398's merge window** — #398 shipped conservative-min placeholder budgets; this restores the real OpenRouter values.
2. **Multi-provider config scaffolding (WIP)** — the `llm.multi_provider.enabled` preview flag + a config-time guard. **No runtime cross-provider routing yet.**

**Status: Draft, not ready to merge.** This is the foundation another maintainer can build per-tier cross-provider routing on. See Roadmap.

## Branch

Base: `main`. Three commits on top of the merged #398:
- `fix(catalog): use real OpenRouter budgets for router-tier models`
- `feat(config): add llm.multi_provider.enabled feature gate (default off)`
- `feat(config): reject unsupported cross-provider tiers under preview flag`

## Issue

None — maintainer handoff branch for the multi-provider foundation.

## What's in this PR

- **Real static-fallback budgets.** #398 collapsed the static fallback to conservative-min placeholders; this corrects them to values verified against OpenRouter's `/v1/models` (deepseek-v4-pro output 384k, glm-5 ctx 202k, glm-5.2 output 32k, …), keyed by provider-agnostic basename. Offline bootstrap only — the live catalog overrides online, so OpenRouter deployments are unaffected; this is the persistent path for direct providers.
- **`llm.multi_provider.enabled` preview flag** (default off; preserved across onboarding reconfigure).
- **Config-time guard (`validate_multi_provider_config`).** While the flag is on, a router tier whose provider ≠ `llm.provider` is **rejected as not-yet-supported** (at config load/save and inside onboarding, before apply) — because there is no runtime cross-provider routing yet, this stops a mis-routing config from validating. Per-tier `api_key` is redacted in the router-configure RPC response.

## Roadmap / next steps (for whoever picks this up)

Ordered, each independently shippable:
1. **R3 — per-tier cross-provider routing (the core feature).** Plumb tier `provider`/`api_key`/`api_key_env`/`base_url` into the per-turn `ProviderConfig`/selector when a routed tier's provider differs from the primary. When this lands, flip `validate_multi_provider_config` from "reject" back to a **credential-resolution check** (the logic is spelled out in its docstring).
2. **R6 — local-provider cost via operator id.** Local openai-compat providers (vllm/lm_studio/ovms) currently bill at cloud prices; thread the resolved operator provider id into the usage `add()` path.
3. **R1 / R2 (hot path).** Continuity-diagnostic actuator (moved before model commit) + strip provider-bound thinking signatures on a cross-provider switch.
4. **Model metadata (bigger, separate PR).** Stop hand-maintaining `_STATIC_FALLBACK`: vendor a curated cross-provider dataset (**models.dev** — its schema is natively `(provider, model)`) as a bundled snapshot + refresh with integrity gates (litellm-style) + an override overlay; build a `(model_id, resolved_provider)`-aware resolver — the one piece no upstream project (litellm/aider/models.dev) has, because only squilla-router multiplexes one model across providers per turn.

## Design context the taker needs

- **Provider awareness already exists** for the single-provider case via the model-id spelling convention (`vendor/model` = OpenRouter/gateway, bare = direct) + active-provider threading (merged in #398). A full two-level `[provider][model]` catalog is only needed once R3 makes two providers live at once — deferred on purpose.
- **Why the validator rejects instead of checking credentials:** shipping a credential validator for routing that doesn't exist would let a mis-routing config look valid (flagged by an adversarial Codex review). It flips to a credential check when R3 lands.

## Codex adversarial review

Two findings addressed: (1) router-configure response echoed per-tier `api_key` → now redacted; (2) validator accepted cross-provider tiers that don't route → now rejects them as not-yet-supported.

## Tests

`uv run ruff check` clean · `uv run mypy` clean · targeted suite (catalog, preflight, rpc_usage, router defaults, onboarding mutations) **178 passed**. The full offline suite was green on this content before rebase (**7581 passed**; only pre-existing `test_inference_postprocess_rules` numpy/router cases and local-`.env` `test_canonical_web_search` cases fail, unrelated to this branch).

## Release Note

NONE while draft — the catalog change is internal (offline bootstrap only), and the flag is an inert preview default-off.

## Safety

No secrets, private prompts/transcripts, channel identifiers, or non-public fixtures committed.
