### PR TITLE
docs: note the OpenTUI terminal UI is a source-install-only preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,14 +503,16 @@ opensquilla agent -m "your prompt"     # one-shot, automation-friendly
 
 > **Preview — the OpenTUI terminal UI.** `opensquilla chat` runs the stable,
 > Python-native chat by default. A richer OpenTUI frontend (themes, one-card
-> turns, a live router HUD, drag-select copy) is an opt-in preview that is
-> **source-install only**: it is not bundled in the release wheel and requires
-> [Bun](https://bun.sh) plus the OpenTUI package dependencies. From a source
-> checkout ([Install from source](#install-from-source)):
+> turns, a live router HUD, drag-select copy) is an opt-in preview that runs
+> **only from a [Develop from source](#develop-from-source) checkout**: the host
+> is loaded from the OpenTUI package next to the running code, and that package
+> (plus its [Bun](https://bun.sh) dependencies) is not shipped in the release
+> wheel or the `Install from source` install. From the checkout, install the Bun
+> deps once, then launch with `uv run` so it runs against that same tree:
 >
 > ```sh
 > bun install --frozen-lockfile --cwd=src/opensquilla/cli/tui/opentui/package
-> OPENSQUILLA_TUI_BACKEND=opentui opensquilla chat
+> OPENSQUILLA_TUI_BACKEND=opentui uv run opensquilla chat
 > ```
 >
 > Leave `OPENSQUILLA_TUI_BACKEND` unset for the stable chat. See

--- a/README.md
+++ b/README.md
@@ -501,6 +501,21 @@ opensquilla chat                       # interactive REPL
 opensquilla agent -m "your prompt"     # one-shot, automation-friendly
 ```
 
+> **Preview — the OpenTUI terminal UI.** `opensquilla chat` runs the stable,
+> Python-native chat by default. A richer OpenTUI frontend (themes, one-card
+> turns, a live router HUD, drag-select copy) is an opt-in preview that is
+> **source-install only**: it is not bundled in the release wheel and requires
+> [Bun](https://bun.sh) plus the OpenTUI package dependencies. From a source
+> checkout ([Install from source](#install-from-source)):
+>
+> ```sh
+> bun install --frozen-lockfile --cwd=src/opensquilla/cli/tui/opentui/package
+> OPENSQUILLA_TUI_BACKEND=opentui opensquilla chat
+> ```
+>
+> Leave `OPENSQUILLA_TUI_BACKEND` unset for the stable chat. See
+> [docs/features/tui-frontend.md](docs/features/tui-frontend.md) for details.
+
 Open the Web UI at <http://127.0.0.1:18791/control/>. The **Health**
 view shows whether OpenSquilla is ready, what is not ready, and the
 next recovery steps. From the CLI, run:


### PR DESCRIPTION
The README never mentioned the OpenTUI terminal frontend or how to opt into it. Its only documentation (`docs/features/tui-frontend.md`) is linked only from `docs/README.md` and its setup assumes a Git checkout — so a user installing the normal way (release wheel / desktop) had no guidance, and the release wheel doesn't bundle the OpenTUI host anyway.

Adds a short, honest note in the **Run** section:
- `opensquilla chat` runs the stable, Python-native chat by default.
- The OpenTUI frontend is an opt-in preview that is **source-install only** (needs Bun + the OpenTUI package deps; not in the release wheel).
- Shows the exact commands (`bun install --cwd=…` + `OPENSQUILLA_TUI_BACKEND=opentui opensquilla chat`) and links the full doc.

Scope: `README.md` only. The locale-parity guard checks README file existence (unchanged), and `test_readme_links.py` passes. Localized READMEs can pick up the note in a follow-up.

## Release note
Documented that the OpenTUI terminal UI is an opt-in, source-install-only preview and how to enable it (`OPENSQUILLA_TUI_BACKEND=opentui`).
