### PR TITLE
openai_codex provider: run turns on a ChatGPT subscription via Codex CLI OAuth

### DIFF
--- a/scripts/live_codex_smoke.py
+++ b/scripts/live_codex_smoke.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Live smoke for the openai_codex (ChatGPT OAuth) provider.
+
+Gated on the Codex CLI auth file existing (``$CODEX_HOME/auth.json`` or
+``~/.codex/auth.json``); exits 2 with guidance when it does not. Runs one
+text turn and one tool-call turn against the real ChatGPT backend and
+prints a compact JSON verdict. No secrets are printed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from typing import Any
+
+from opensquilla.provider.codex_auth import CodexAuthError, codex_auth_path, load_codex_credentials
+from opensquilla.provider.openai_codex import OpenAICodexProvider
+from opensquilla.provider.types import (
+    ChatConfig,
+    DoneEvent,
+    ErrorEvent,
+    Message,
+    ReasoningDeltaEvent,
+    TextDeltaEvent,
+    ToolDefinition,
+    ToolInputSchema,
+    ToolUseEndEvent,
+)
+
+
+async def _run_turn(
+    provider: OpenAICodexProvider,
+    prompt: str,
+    *,
+    tools: list[ToolDefinition] | None = None,
+    timeout: float = 120.0,
+) -> dict[str, Any]:
+    start = time.perf_counter()
+    text_parts: list[str] = []
+    tool_ends: list[dict[str, Any]] = []
+    reasoning_chars = 0
+    done: DoneEvent | None = None
+    error: ErrorEvent | None = None
+    async for event in provider.chat(
+        [Message(role="user", content=prompt)],
+        tools=tools,
+        config=ChatConfig(max_tokens=512, timeout=timeout),
+    ):
+        if isinstance(event, TextDeltaEvent):
+            text_parts.append(event.text)
+        elif isinstance(event, ReasoningDeltaEvent):
+            reasoning_chars += len(event.text)
+        elif isinstance(event, ToolUseEndEvent):
+            tool_ends.append({"name": event.tool_name, "arguments": event.arguments})
+        elif isinstance(event, DoneEvent):
+            done = event
+        elif isinstance(event, ErrorEvent):
+            error = event
+    return {
+        "content": "".join(text_parts),
+        "tool_calls": tool_ends,
+        "reasoning_chars": reasoning_chars,
+        "usage": (
+            {
+                "input_tokens": done.input_tokens,
+                "output_tokens": done.output_tokens,
+                "cached_tokens": done.cached_tokens,
+                "reasoning_tokens": done.reasoning_tokens,
+                "model": done.model,
+                "stop_reason": done.stop_reason,
+            }
+            if done
+            else None
+        ),
+        "error": {"code": error.code, "message": error.message[:300]} if error else None,
+        "latency_ms": int((time.perf_counter() - start) * 1000),
+    }
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="gpt-5.5")
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--skip-tools", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        credentials = load_codex_credentials()
+    except CodexAuthError as exc:
+        print(f"SKIP: {exc}", file=sys.stderr)
+        return 2
+    account_hint = credentials.account_id[:8] if credentials.account_id else "(from JWT)"
+    print(f"auth file: {codex_auth_path()} (account {account_hint}...)", file=sys.stderr)
+
+    provider = OpenAICodexProvider(model=args.model)
+    report: dict[str, Any] = {"model": args.model}
+
+    marker = f"codex smoke {int(time.time())}"
+    text = await _run_turn(
+        provider, f"Reply exactly with: {marker}", timeout=args.timeout
+    )
+    text["marker_present"] = marker in text.pop("content", "")
+    report["text_turn"] = text
+
+    if not args.skip_tools:
+        tool = ToolDefinition(
+            name="get_weather",
+            description="Get current weather for a city.",
+            input_schema=ToolInputSchema(
+                properties={"city": {"type": "string"}}, required=["city"]
+            ),
+        )
+        tool_turn = await _run_turn(
+            provider,
+            "Use the get_weather tool to check the weather in Tokyo.",
+            tools=[tool],
+            timeout=args.timeout,
+        )
+        tool_turn.pop("content", None)
+        report["tool_turn"] = tool_turn
+
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    text_ok = bool(report["text_turn"].get("marker_present")) and not report["text_turn"]["error"]
+    tool_ok = args.skip_tools or (
+        bool(report.get("tool_turn", {}).get("tool_calls"))
+        and not report.get("tool_turn", {}).get("error")
+    )
+    return 0 if text_ok and tool_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/opensquilla/provider/codex_auth.py
+++ b/src/opensquilla/provider/codex_auth.py
@@ -1,0 +1,204 @@
+"""ChatGPT-account (Codex CLI) OAuth credential source.
+
+The ``openai_codex`` provider authenticates with the operator's ChatGPT
+subscription using the credentials the Codex CLI maintains at
+``$CODEX_HOME/auth.json`` (default ``~/.codex/auth.json``): a Bearer access
+token, a refresh token, and the ChatGPT account id. OpenSquilla reads that
+file, refreshes the access token against ``auth.openai.com`` when the
+backend rejects it, and persists refreshed tokens back — token values are
+never logged.
+
+A full in-app OAuth login flow is intentionally out of scope: ``codex
+login`` owns credential creation; this module only consumes and refreshes.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import tempfile
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import structlog
+
+from opensquilla.env import trust_env as _trust_env
+
+log = structlog.get_logger(__name__)
+
+# OAuth client id of the Codex CLI application; the stored refresh token was
+# minted for this client, so refreshes must present the same id.
+CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+CODEX_TOKEN_REFRESH_URL = "https://auth.openai.com/oauth/token"
+
+_ACCOUNT_ID_JWT_CLAIM = "https://api.openai.com/auth"
+
+
+class CodexAuthError(Exception):
+    """Raised when ChatGPT credentials are missing, unreadable, or expired."""
+
+
+@dataclass(frozen=True)
+class CodexCredentials:
+    """In-memory view of the Codex CLI's stored ChatGPT tokens."""
+
+    access_token: str
+    refresh_token: str = ""
+    account_id: str = ""
+    id_token: str = ""
+
+
+def codex_auth_path() -> Path:
+    """Return the Codex CLI auth file path (``$CODEX_HOME`` overrides)."""
+    home = os.environ.get("CODEX_HOME", "").strip()
+    base = Path(home).expanduser() if home else Path.home() / ".codex"
+    return base / "auth.json"
+
+
+def _jwt_claims(token: str) -> dict[str, Any]:
+    """Best-effort decode of a JWT payload (no signature verification)."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        return {}
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)
+    try:
+        decoded = json.loads(base64.urlsafe_b64decode(payload))
+    except (ValueError, json.JSONDecodeError):
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _account_id_from_tokens(tokens: dict[str, Any]) -> str:
+    explicit = str(tokens.get("account_id") or "").strip()
+    if explicit:
+        return explicit
+    for key in ("id_token", "access_token"):
+        claims = _jwt_claims(str(tokens.get(key) or ""))
+        auth_claim = claims.get(_ACCOUNT_ID_JWT_CLAIM)
+        if isinstance(auth_claim, dict):
+            account_id = str(auth_claim.get("chatgpt_account_id") or "").strip()
+            if account_id:
+                return account_id
+    return ""
+
+
+def load_codex_credentials(path: Path | None = None) -> CodexCredentials:
+    """Load ChatGPT tokens from the Codex CLI auth file.
+
+    Raises ``CodexAuthError`` with an actionable message when the file or
+    the ChatGPT token section is missing — the fix is always ``codex login``.
+    """
+    auth_path = path or codex_auth_path()
+    try:
+        payload = json.loads(auth_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise CodexAuthError(
+            f"No ChatGPT credentials at {auth_path}; run `codex login` to sign in."
+        ) from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CodexAuthError(
+            f"Could not read ChatGPT credentials at {auth_path}: {exc}"
+        ) from exc
+
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict) or not str(tokens.get("access_token") or "").strip():
+        raise CodexAuthError(
+            f"{auth_path} has no ChatGPT access token; run `codex login` to sign in."
+        )
+    return CodexCredentials(
+        access_token=str(tokens["access_token"]).strip(),
+        refresh_token=str(tokens.get("refresh_token") or "").strip(),
+        account_id=_account_id_from_tokens(tokens),
+        id_token=str(tokens.get("id_token") or "").strip(),
+    )
+
+
+def _persist_refreshed_tokens(auth_path: Path, refreshed: dict[str, Any]) -> None:
+    """Merge refreshed token fields into auth.json atomically."""
+    try:
+        payload = json.loads(auth_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        payload = {}
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        tokens = {}
+    for key in ("id_token", "access_token", "refresh_token"):
+        value = refreshed.get(key)
+        if isinstance(value, str) and value:
+            tokens[key] = value
+    payload["tokens"] = tokens
+    payload["last_refresh"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(auth_path.parent), prefix=".auth-")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+        os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, auth_path)
+    except OSError:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+async def refresh_codex_credentials(
+    credentials: CodexCredentials,
+    *,
+    path: Path | None = None,
+    refresh_url: str = CODEX_TOKEN_REFRESH_URL,
+    proxy: str | None = None,
+) -> CodexCredentials:
+    """Exchange the refresh token for a new access token and persist it."""
+    if not credentials.refresh_token:
+        raise CodexAuthError(
+            "ChatGPT access token was rejected and no refresh token is stored; "
+            "run `codex login` to sign in again."
+        )
+    auth_path = path or codex_auth_path()
+    async with httpx.AsyncClient(
+        timeout=30.0, trust_env=_trust_env(), proxy=proxy or None
+    ) as client:
+        response = await client.post(
+            refresh_url,
+            json={
+                "client_id": CODEX_OAUTH_CLIENT_ID,
+                "grant_type": "refresh_token",
+                "refresh_token": credentials.refresh_token,
+            },
+        )
+    if response.status_code != 200:
+        raise CodexAuthError(
+            f"ChatGPT token refresh failed (HTTP {response.status_code}); "
+            "run `codex login` to sign in again."
+        )
+    try:
+        refreshed = response.json()
+    except json.JSONDecodeError as exc:
+        raise CodexAuthError("ChatGPT token refresh returned invalid JSON.") from exc
+    if not isinstance(refreshed, dict) or not str(refreshed.get("access_token") or "").strip():
+        raise CodexAuthError("ChatGPT token refresh returned no access token.")
+
+    _persist_refreshed_tokens(auth_path, refreshed)
+    log.info("codex_auth.token_refreshed", path=str(auth_path))
+    updated = replace(
+        credentials,
+        access_token=str(refreshed["access_token"]).strip(),
+        refresh_token=str(refreshed.get("refresh_token") or credentials.refresh_token).strip(),
+        id_token=str(refreshed.get("id_token") or credentials.id_token).strip(),
+    )
+    if not updated.account_id:
+        updated = replace(
+            updated,
+            account_id=_account_id_from_tokens(
+                {"id_token": updated.id_token, "access_token": updated.access_token}
+            ),
+        )
+    return updated

--- a/src/opensquilla/provider/openai_codex.py
+++ b/src/opensquilla/provider/openai_codex.py
@@ -171,6 +171,17 @@ class OpenAICodexProvider:
             "stream": True,
             "include": ["reasoning.encrypted_content"],
         }
+        # The ChatGPT codex backend rejects max_output_tokens outright
+        # ("Unsupported parameter", verified live 2026-07-02), matching
+        # codex-rs which never sends it — subscription turns have no
+        # client-set output cap. Surface the dropped budget for operators
+        # instead of silently ignoring it.
+        if cfg.max_tokens > 0:
+            log.debug(
+                "openai_codex.max_tokens_unsupported",
+                requested_max_tokens=cfg.max_tokens,
+                model=self._model,
+            )
         if tools:
             payload["tools"] = [_codex_tool(tool) for tool in tools]
         if cfg.thinking:

--- a/src/opensquilla/provider/openai_codex.py
+++ b/src/opensquilla/provider/openai_codex.py
@@ -1,0 +1,382 @@
+"""OpenAI Codex (ChatGPT-account OAuth) provider.
+
+Speaks the ``chatgpt.com/backend-api/codex/responses`` protocol — an OpenAI
+Responses-flavored SSE endpoint authenticated with the operator's ChatGPT
+subscription (Bearer access token + ``chatgpt-account-id`` header) instead
+of a platform API key. Credentials come from the Codex CLI's auth file via
+``codex_auth``; a 401 triggers one token refresh + retry.
+
+Wire facts mirror the reference implementation in codex-rs: flat function
+tools (``{type, name, description, strict, parameters}``), Responses input
+items, ``store: false`` + ``include: ["reasoning.encrypted_content"]``, and
+``response.*`` SSE events.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import structlog
+
+from opensquilla.env import trust_env as _trust_env
+
+from .codex_auth import (
+    CodexAuthError,
+    CodexCredentials,
+    load_codex_credentials,
+    refresh_codex_credentials,
+)
+from .openai import _http_error_body_text, _resolve_llm_proxy
+from .openai_responses import _responses_input
+from .protocol import ProviderConnectionConfig, ProviderMetadata
+from .stream_assembly import (
+    ReasoningAccumulator,
+    ToolStreamAccumulator,
+    parse_tool_arguments,
+)
+from .types import (
+    ChatConfig,
+    DoneEvent,
+    ErrorEvent,
+    Message,
+    ModelInfo,
+    StreamEvent,
+    TextDeltaEvent,
+    ToolDefinition,
+)
+
+log = structlog.get_logger(__name__)
+
+_CODEX_BACKEND_BASE = "https://chatgpt.com/backend-api"
+# Matches the current Codex CLI default; older -codex suffixed slugs are
+# rejected for ChatGPT-account requests on current backends.
+_DEFAULT_CODEX_MODEL = "gpt-5.5"
+# The stored tokens were minted for the Codex CLI application; requests carry
+# its originator so the backend sees the client the credentials belong to.
+_CODEX_ORIGINATOR = "codex_cli_rs"
+
+_KNOWN_CODEX_MODELS: tuple[tuple[str, str], ...] = (
+    ("gpt-5.5", "GPT-5.5"),
+    ("gpt-5.4-mini", "GPT-5.4 Mini"),
+    ("gpt-5", "GPT-5"),
+)
+
+
+def _codex_tool(tool: ToolDefinition) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "name": tool.name,
+        "description": tool.description,
+        "strict": False,
+        "parameters": {
+            "type": tool.input_schema.type,
+            "properties": tool.input_schema.properties,
+            "required": tool.input_schema.required,
+        },
+    }
+
+
+def _reasoning_effort(cfg: ChatConfig) -> str:
+    level = getattr(cfg.thinking_level, "value", None) or str(cfg.thinking_level or "")
+    normalized = level.strip().lower()
+    if normalized in {"minimal", "low"}:
+        return "low"
+    if normalized in {"high", "xhigh"}:
+        return "high"
+    return "medium"
+
+
+class OpenAICodexProvider:
+    """Streams from the ChatGPT backend-api Responses endpoint via OAuth."""
+
+    provider_name = "openai_codex"
+
+    def __init__(
+        self,
+        model: str = _DEFAULT_CODEX_MODEL,
+        base_url: str = _CODEX_BACKEND_BASE,
+        proxy: str | None = None,
+        auth_path: str | None = None,
+        api_key: str = "",  # accepted for constructor parity; OAuth ignores it
+    ) -> None:
+        self._model = model
+        self._base_url = self._normalize_base_url(base_url)
+        self._proxy = _resolve_llm_proxy(proxy)
+        self._auth_path = Path(auth_path).expanduser() if auth_path else None
+
+    @staticmethod
+    def _normalize_base_url(base_url: str) -> str:
+        base = (base_url or _CODEX_BACKEND_BASE).rstrip("/")
+        host_only = base.lower()
+        if (
+            ("chatgpt.com" in host_only or "chat.openai.com" in host_only)
+            and "/backend-api" not in host_only
+        ):
+            base = f"{base}/backend-api"
+        return base
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def provider_metadata(self) -> ProviderMetadata:
+        return ProviderMetadata(
+            provider_name=self.provider_name,
+            provider_kind="openai_codex",
+            model=self._model,
+            base_url=self._base_url,
+        )
+
+    def provider_connection_config(self) -> ProviderConnectionConfig:
+        # OAuth tokens are deliberately not exposed through this surface.
+        return ProviderConnectionConfig(
+            provider_kind="openai_codex",
+            model=self._model,
+            api_key="",
+            base_url=self._base_url,
+        )
+
+    def _responses_url(self) -> str:
+        return f"{self._base_url}/codex/responses"
+
+    def _headers(self, credentials: CodexCredentials) -> dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {credentials.access_token}",
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+            "originator": _CODEX_ORIGINATOR,
+            "User-Agent": _CODEX_ORIGINATOR,
+        }
+        if credentials.account_id:
+            headers["chatgpt-account-id"] = credentials.account_id
+        return headers
+
+    def _build_payload(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None,
+        cfg: ChatConfig,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "instructions": cfg.system or "",
+            "input": _responses_input(messages),
+            "tool_choice": cfg.tool_choice or "auto",
+            "parallel_tool_calls": True,
+            "store": False,
+            "stream": True,
+            "include": ["reasoning.encrypted_content"],
+        }
+        if tools:
+            payload["tools"] = [_codex_tool(tool) for tool in tools]
+        if cfg.thinking:
+            payload["reasoning"] = {"effort": _reasoning_effort(cfg), "summary": "auto"}
+        return payload
+
+    def chat(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None = None,
+        config: ChatConfig | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        return self._stream(messages, tools, config or ChatConfig())
+
+    async def _stream(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None,
+        cfg: ChatConfig,
+    ) -> AsyncIterator[StreamEvent]:
+        try:
+            credentials = load_codex_credentials(self._auth_path)
+        except CodexAuthError as exc:
+            yield ErrorEvent(message=str(exc), code="401")
+            return
+
+        payload = self._build_payload(messages, tools, cfg)
+
+        try:
+            async with httpx.AsyncClient(
+                timeout=cfg.timeout,
+                trust_env=_trust_env(),
+                proxy=self._proxy,
+            ) as client:
+                refreshed = False
+                while True:
+                    async with client.stream(
+                        "POST",
+                        self._responses_url(),
+                        headers=self._headers(credentials),
+                        json=payload,
+                    ) as response:
+                        if response.status_code == 401 and not refreshed:
+                            refreshed = True
+                            try:
+                                credentials = await refresh_codex_credentials(
+                                    credentials,
+                                    path=self._auth_path,
+                                    proxy=self._proxy,
+                                )
+                            except CodexAuthError as exc:
+                                yield ErrorEvent(message=str(exc), code="401")
+                                return
+                            continue
+                        if response.status_code != 200:
+                            body = await response.aread()
+                            yield ErrorEvent(
+                                message=(
+                                    "ChatGPT Codex request failed "
+                                    f"(HTTP {response.status_code}): "
+                                    f"{_http_error_body_text(body)}"
+                                ),
+                                code=str(response.status_code),
+                            )
+                            return
+
+                        async for event in self._parse_sse(response, cfg):
+                            yield event
+                        return
+        except httpx.TimeoutException as exc:
+            yield ErrorEvent(message=f"Request timed out: {exc}", code="timeout")
+        except httpx.RequestError as exc:
+            yield ErrorEvent(message=f"Request error: {exc}", code="request_error")
+        except Exception as exc:  # noqa: BLE001 - chat() contract: ErrorEvent instead of raising
+            log.exception(
+                "provider.stream_internal_error",
+                provider=self.provider_name,
+                model=self._model,
+            )
+            yield ErrorEvent(
+                message=f"Provider response handling failed: {exc}",
+                code="provider_internal",
+            )
+
+    async def _parse_sse(
+        self,
+        response: httpx.Response,
+        cfg: ChatConfig,
+    ) -> AsyncIterator[StreamEvent]:
+        tools_acc = ToolStreamAccumulator()
+        reasoning = ReasoningAccumulator()
+        actual_model = self._model
+        input_tokens = 0
+        output_tokens = 0
+        reasoning_tokens = 0
+        cached_tokens = 0
+        stop_reason: str | None = None
+
+        async for line in response.aiter_lines():
+            if not line.startswith("data:"):
+                continue
+            data_str = line[5:].strip()
+            if not data_str or data_str == "[DONE]":
+                continue
+            try:
+                event = json.loads(data_str)
+            except json.JSONDecodeError:
+                continue
+            etype = str(event.get("type") or "")
+
+            if etype == "response.output_text.delta":
+                delta = str(event.get("delta") or "")
+                if delta:
+                    yield TextDeltaEvent(text=delta)
+
+            elif etype in (
+                "response.reasoning_summary_text.delta",
+                "response.reasoning_text.delta",
+            ):
+                reasoning_event = reasoning.emit(str(event.get("delta") or ""))
+                if reasoning_event is not None:
+                    yield reasoning_event
+
+            elif etype == "response.output_item.added":
+                item = event.get("item") or {}
+                if item.get("type") == "function_call":
+                    key = item.get("id") or item.get("call_id")
+                    for tool_event in tools_acc.start(
+                        key,
+                        tool_use_id=str(item.get("call_id") or item.get("id") or ""),
+                        tool_name=str(item.get("name") or ""),
+                    ):
+                        yield tool_event
+
+            elif etype == "response.function_call_arguments.delta":
+                key = event.get("item_id")
+                fragment = str(event.get("delta") or "")
+                if fragment:
+                    for tool_event in tools_acc.append(key, fragment):
+                        yield tool_event
+
+            elif etype == "response.output_item.done":
+                item = event.get("item") or {}
+                if item.get("type") == "function_call":
+                    key = item.get("id") or item.get("call_id")
+                    for tool_event in tools_acc.start(
+                        key,
+                        tool_use_id=str(item.get("call_id") or item.get("id") or ""),
+                        tool_name=str(item.get("name") or ""),
+                    ):
+                        yield tool_event
+                    # The done item carries the authoritative full arguments.
+                    for tool_event in tools_acc.finish_with_arguments(
+                        key,
+                        parse_tool_arguments(str(item.get("arguments") or "")),
+                    ):
+                        yield tool_event
+
+            elif etype == "response.completed":
+                body = event.get("response") or {}
+                actual_model = str(body.get("model") or self._model)
+                usage = body.get("usage") or {}
+                input_tokens = int(usage.get("input_tokens") or 0)
+                output_tokens = int(usage.get("output_tokens") or 0)
+                input_details = usage.get("input_tokens_details") or {}
+                cached_tokens = int(input_details.get("cached_tokens") or 0)
+                output_details = usage.get("output_tokens_details") or {}
+                reasoning_tokens = int(output_details.get("reasoning_tokens") or 0)
+                stop_reason = "end_turn"
+                break
+
+            elif etype == "response.failed":
+                body = event.get("response") or {}
+                error = body.get("error") or {}
+                yield ErrorEvent(
+                    message=str(error.get("message") or "ChatGPT Codex response failed"),
+                    code=str(error.get("code") or "response_failed"),
+                )
+                return
+
+        # Termination contract: close any open tool calls and always emit
+        # DoneEvent, including for streams truncated before response.completed.
+        emitted_tool = False
+        for tool_event in tools_acc.finish_all():
+            emitted_tool = True
+            yield tool_event
+        if tools_acc.has_calls:
+            emitted_tool = True
+        yield DoneEvent(
+            stop_reason="tool_use" if emitted_tool else (stop_reason or "end_turn"),
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            reasoning_content=reasoning.finalize(),
+            reasoning_tokens=reasoning_tokens,
+            cached_tokens=cached_tokens,
+            model=actual_model,
+        )
+
+    async def list_models(self) -> list[ModelInfo]:
+        return [
+            ModelInfo(
+                provider=self.provider_name,
+                model_id=model_id,
+                display_name=display_name,
+                context_window=272_000,
+                max_output_tokens=128_000,
+            )
+            for model_id, display_name in _KNOWN_CODEX_MODELS
+        ]

--- a/src/opensquilla/provider/registry.py
+++ b/src/opensquilla/provider/registry.py
@@ -12,6 +12,7 @@ ProviderBackend = Literal[
     "openai_responses",
     "anthropic",
     "ollama",
+    "openai_codex",
     "unsupported_oauth",
     "unsupported_responses",
 ]
@@ -278,12 +279,14 @@ for _provider_spec in [
     ),
     _spec(
         "openai_codex",
-        "unsupported_oauth",
+        "openai_codex",
         "openai_codex",
         "OAuth",
         "https://chatgpt.com/backend-api",
-        runtime_supported=False,
-        capabilities=frozenset({"coding_plan"}),
+        # OAuth via the Codex CLI's stored ChatGPT credentials — no API key
+        # field; `codex login` owns credential creation.
+        required_fields=frozenset({"model"}),
+        capabilities=frozenset({"chat", "coding_plan"}),
     ),
     _spec(
         "github_copilot",

--- a/src/opensquilla/provider/selector.py
+++ b/src/opensquilla/provider/selector.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field, replace
 from .anthropic import AnthropicProvider
 from .ollama import OllamaProvider
 from .openai import OpenAIProvider
+from .openai_codex import OpenAICodexProvider
 from .openai_responses import OpenAIResponsesProvider
 from .protocol import LLMProvider, ProviderPlugin, resolve_failover_chain
 from .registry import UnknownProviderError, get_provider_spec
@@ -140,6 +141,14 @@ def _build_provider(cfg: ProviderConfig) -> LLMProvider:
             if cfg.api_key:
                 kwargs["api_key"] = cfg.api_key
             return OllamaProvider(**kwargs)
+
+        case "openai_codex":
+            kwargs = {"model": cfg.model}
+            if base_url:
+                kwargs["base_url"] = base_url
+            if cfg.proxy:
+                kwargs["proxy"] = cfg.proxy
+            return OpenAICodexProvider(**kwargs)
 
         case _:
             raise ProviderBuildError(_unsupported_runtime_message(cfg.provider))

--- a/tests/test_cli/test_providers_cmd.py
+++ b/tests/test_cli/test_providers_cmd.py
@@ -49,7 +49,7 @@ def test_providers_configure_writes_config(tmp_path, monkeypatch):
 def test_providers_configure_unsupported_fails(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(tmp_path / "c.toml"))
     result = runner.invoke(
-        app, ["providers", "configure", "openai_codex", "--model", "x"]
+        app, ["providers", "configure", "github_copilot", "--model", "x"]
     )
     assert result.exit_code != 0
     assert (

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -144,7 +144,7 @@ def test_upsert_memory_embedding_auto_without_changes_does_not_require_restart()
 def test_unsupported_provider_rejected():
     cfg = GatewayConfig()
     with pytest.raises(ValueError, match="not runtime-supported"):
-        upsert_llm_provider(cfg, provider_id="openai_codex", model="x")
+        upsert_llm_provider(cfg, provider_id="github_copilot", model="x")
 
 
 def test_experimental_provider_configurable_with_required_fields():
@@ -166,7 +166,7 @@ def test_experimental_provider_configurable_with_required_fields():
 def test_coding_plan_provider_still_rejected():
     cfg = GatewayConfig()
     with pytest.raises(ValueError, match="not runtime-supported"):
-        upsert_llm_provider(cfg, provider_id="openai_codex", model="x", api_key="k")
+        upsert_llm_provider(cfg, provider_id="volcengine_coding_plan", model="x", api_key="k")
 
 
 def test_ollama_does_not_require_api_key():

--- a/tests/test_onboarding/test_provider_specs.py
+++ b/tests/test_onboarding/test_provider_specs.py
@@ -67,13 +67,13 @@ EXPECTED_VERIFIED = {
 EXPECTED_EXPERIMENTAL = {
     "azure", "bailian_coding", "minimax", "minimax_openai", "minimax_cn",
     "minimax_global", "mistral", "groq", "aihubmix", "vllm",
-    "lm_studio", "siliconflow", "ovms", "litellm_proxy",
+    "lm_studio", "siliconflow", "ovms", "litellm_proxy", "openai_codex",
 }
 EXPECTED_SUPPORTED = EXPECTED_VERIFIED | EXPECTED_EXPERIMENTAL
 # No runtime support at all (coding-plan/OAuth stubs): never configurable.
 EXPECTED_DISABLED = {
     "volcengine_coding_plan", "byteplus_coding_plan",
-    "openai_codex", "github_copilot",
+    "github_copilot",
 }
 
 

--- a/tests/test_provider_openai_codex.py
+++ b/tests/test_provider_openai_codex.py
@@ -227,6 +227,10 @@ def test_stream_maps_responses_events(tmp_path: Path, monkeypatch) -> None:
     assert payload["instructions"] == "be brief"
     assert payload["store"] is False and payload["stream"] is True
     assert payload["include"] == ["reasoning.encrypted_content"]
+    # Protocol fact (verified live): the ChatGPT codex backend rejects
+    # max_output_tokens with HTTP 400 "Unsupported parameter" — it must
+    # never be sent; subscription turns carry no client-set output cap.
+    assert "max_output_tokens" not in payload
     (tool,) = payload["tools"]
     assert tool["type"] == "function" and tool["name"] == "search"
     assert "function" not in tool  # flat Responses shape, not chat-completions nesting

--- a/tests/test_provider_openai_codex.py
+++ b/tests/test_provider_openai_codex.py
@@ -1,0 +1,419 @@
+"""Contract tests for the openai_codex (ChatGPT OAuth) provider."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from opensquilla.provider.codex_auth import (
+    CodexAuthError,
+    load_codex_credentials,
+    refresh_codex_credentials,
+)
+from opensquilla.provider.openai_codex import OpenAICodexProvider
+from opensquilla.provider.registry import get_provider_spec
+from opensquilla.provider.selector import build_provider
+from opensquilla.provider.types import (
+    ChatConfig,
+    DoneEvent,
+    ErrorEvent,
+    Message,
+    ReasoningDeltaEvent,
+    TextDeltaEvent,
+    ToolDefinition,
+    ToolInputSchema,
+    ToolUseDeltaEvent,
+    ToolUseEndEvent,
+    ToolUseStartEvent,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_auth(path: Path, *, access="tok-access", refresh="tok-refresh", account="acct-1"):
+    payload = {
+        "auth_mode": "chatgpt",
+        "OPENAI_API_KEY": None,
+        "tokens": {
+            "id_token": "",
+            "access_token": access,
+            "refresh_token": refresh,
+            "account_id": account,
+        },
+        "last_refresh": "2026-06-29T21:53:00Z",
+    }
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def _sse(events: list[dict[str, Any]]) -> bytes:
+    return b"".join(f"data: {json.dumps(ev)}\n\n".encode() for ev in events)
+
+
+def _happy_sse() -> bytes:
+    return _sse(
+        [
+            {"type": "response.created", "response": {"id": "resp-1"}},
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "id": "fc-1",
+                    "call_id": "call-1",
+                    "name": "search",
+                },
+            },
+            {"type": "response.function_call_arguments.delta", "item_id": "fc-1", "delta": '{"que'},
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc-1",
+                "delta": 'ry": "x"}',
+            },
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "id": "fc-1",
+                    "call_id": "call-1",
+                    "name": "search",
+                    "arguments": '{"query": "x"}',
+                },
+            },
+            {"type": "response.output_text.delta", "delta": "done"},
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp-1",
+                    "model": "gpt-5.2-codex",
+                    "usage": {
+                        "input_tokens": 40,
+                        "output_tokens": 9,
+                        "input_tokens_details": {"cached_tokens": 12},
+                        "output_tokens_details": {"reasoning_tokens": 3},
+                    },
+                },
+            },
+        ]
+    )
+
+
+def _patch_codex_transport(monkeypatch, handler) -> None:
+    transport = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+
+    def patched(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr("opensquilla.provider.openai_codex.httpx.AsyncClient", patched)
+
+
+def _collect(provider: OpenAICodexProvider, *, tools=None, cfg=None):
+    async def _run():
+        return [
+            ev
+            async for ev in provider.chat(
+                [Message(role="user", content="hi")], tools=tools, config=cfg or ChatConfig()
+            )
+        ]
+
+    return asyncio.run(_run())
+
+
+_SEARCH_TOOL = ToolDefinition(
+    name="search",
+    description="Search things.",
+    input_schema=ToolInputSchema(properties={"query": {"type": "string"}}),
+)
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def test_load_credentials_from_auth_file(tmp_path: Path) -> None:
+    auth = _write_auth(tmp_path / "auth.json")
+    creds = load_codex_credentials(auth)
+    assert creds.access_token == "tok-access"
+    assert creds.refresh_token == "tok-refresh"
+    assert creds.account_id == "acct-1"
+
+
+def test_missing_auth_file_points_at_codex_login(tmp_path: Path) -> None:
+    with pytest.raises(CodexAuthError, match="codex login"):
+        load_codex_credentials(tmp_path / "missing.json")
+
+
+def test_account_id_falls_back_to_jwt_claim(tmp_path: Path) -> None:
+    claims = {"https://api.openai.com/auth": {"chatgpt_account_id": "acct-jwt"}}
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    jwt = f"h.{payload}.s"
+    auth = tmp_path / "auth.json"
+    auth.write_text(
+        json.dumps({"tokens": {"access_token": "tok", "id_token": jwt, "account_id": None}})
+    )
+    assert load_codex_credentials(auth).account_id == "acct-jwt"
+
+
+def test_refresh_persists_new_tokens(tmp_path: Path, monkeypatch) -> None:
+    auth = _write_auth(tmp_path / "auth.json")
+    creds = load_codex_credentials(auth)
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"access_token": "tok-new", "refresh_token": "refresh-new", "id_token": ""},
+        )
+
+    transport = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+    monkeypatch.setattr(
+        "opensquilla.provider.codex_auth.httpx.AsyncClient",
+        lambda *a, **kw: real(*a, **{**kw, "transport": transport}),
+    )
+
+    updated = asyncio.run(refresh_codex_credentials(creds, path=auth))
+    assert updated.access_token == "tok-new"
+    assert captured["body"]["grant_type"] == "refresh_token"
+    assert captured["body"]["client_id"].startswith("app_")
+    on_disk = json.loads(auth.read_text())
+    assert on_disk["tokens"]["access_token"] == "tok-new"
+    assert on_disk["tokens"]["refresh_token"] == "refresh-new"
+    assert on_disk["last_refresh"].endswith("Z")
+
+
+# ---------------------------------------------------------------------------
+# Provider wire behavior
+# ---------------------------------------------------------------------------
+
+
+def test_stream_maps_responses_events(tmp_path: Path, monkeypatch) -> None:
+    auth = _write_auth(tmp_path / "auth.json")
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, content=_happy_sse()
+        )
+
+    _patch_codex_transport(monkeypatch, handler)
+    provider = OpenAICodexProvider(
+        model="gpt-5.2-codex",
+        base_url="https://chatgpt.com",  # normalization adds /backend-api
+        auth_path=str(auth),
+    )
+    events = _collect(provider, tools=[_SEARCH_TOOL], cfg=ChatConfig(system="be brief"))
+
+    assert captured["url"] == "https://chatgpt.com/backend-api/codex/responses"
+    assert captured["headers"]["authorization"] == "Bearer tok-access"
+    assert captured["headers"]["chatgpt-account-id"] == "acct-1"
+    assert captured["headers"]["originator"] == "codex_cli_rs"
+    payload = captured["payload"]
+    assert payload["instructions"] == "be brief"
+    assert payload["store"] is False and payload["stream"] is True
+    assert payload["include"] == ["reasoning.encrypted_content"]
+    (tool,) = payload["tools"]
+    assert tool["type"] == "function" and tool["name"] == "search"
+    assert "function" not in tool  # flat Responses shape, not chat-completions nesting
+
+    starts = [e for e in events if isinstance(e, ToolUseStartEvent)]
+    deltas = [e for e in events if isinstance(e, ToolUseDeltaEvent)]
+    ends = [e for e in events if isinstance(e, ToolUseEndEvent)]
+    texts = [e for e in events if isinstance(e, TextDeltaEvent)]
+    (done,) = [e for e in events if isinstance(e, DoneEvent)]
+    assert [s.tool_use_id for s in starts] == ["call-1"]
+    assert [d.json_fragment for d in deltas] == ['{"que', 'ry": "x"}']
+    assert ends[0].arguments == {"query": "x"}
+    assert [t.text for t in texts] == ["done"]
+    assert done.stop_reason == "tool_use"
+    assert (done.input_tokens, done.output_tokens) == (40, 9)
+    assert done.cached_tokens == 12 and done.reasoning_tokens == 3
+    assert done.model == "gpt-5.2-codex"
+
+
+def test_burst_function_call_without_deltas(tmp_path: Path, monkeypatch) -> None:
+    auth = _write_auth(tmp_path / "auth.json")
+    body = _sse(
+        [
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "id": "fc-9",
+                    "call_id": "call-9",
+                    "name": "search",
+                    "arguments": '{"query": "y"}',
+                },
+            },
+            {"type": "response.completed", "response": {"id": "r", "usage": {}}},
+        ]
+    )
+    _patch_codex_transport(
+        monkeypatch,
+        lambda request: httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, content=body
+        ),
+    )
+    provider = OpenAICodexProvider(auth_path=str(auth))
+    events = _collect(provider, tools=[_SEARCH_TOOL])
+    ends = [e for e in events if isinstance(e, ToolUseEndEvent)]
+    assert len(ends) == 1 and ends[0].arguments == {"query": "y"}
+    assert any(isinstance(e, ToolUseStartEvent) for e in events)
+
+
+def test_reasoning_deltas_reach_done_event(tmp_path: Path, monkeypatch) -> None:
+    auth = _write_auth(tmp_path / "auth.json")
+    body = _sse(
+        [
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "delta": "think ",
+                "summary_index": 0,
+            },
+            {"type": "response.reasoning_text.delta", "delta": "hard", "content_index": 0},
+            {"type": "response.output_text.delta", "delta": "hi"},
+            {"type": "response.completed", "response": {"id": "r", "usage": {}}},
+        ]
+    )
+    _patch_codex_transport(
+        monkeypatch,
+        lambda request: httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, content=body
+        ),
+    )
+    provider = OpenAICodexProvider(auth_path=str(auth))
+    events = _collect(provider)
+    assert [e.text for e in events if isinstance(e, ReasoningDeltaEvent)] == ["think ", "hard"]
+    (done,) = [e for e in events if isinstance(e, DoneEvent)]
+    assert done.reasoning_content == "think hard"
+
+
+def test_401_refreshes_and_retries_once(tmp_path: Path, monkeypatch) -> None:
+    auth = _write_auth(tmp_path / "auth.json")
+    calls = {"stream": 0, "refresh": 0}
+
+    # One handler for both endpoints: the provider and the auth module share
+    # the global httpx module, so separate transports would fight over it.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "auth.openai.com" in str(request.url):
+            calls["refresh"] += 1
+            return httpx.Response(200, json={"access_token": "tok-new"})
+        calls["stream"] += 1
+        if request.headers.get("authorization") == "Bearer tok-access":
+            return httpx.Response(401, json={"error": {"message": "expired"}})
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=_sse(
+                [
+                    {"type": "response.output_text.delta", "delta": "ok"},
+                    {"type": "response.completed", "response": {"id": "r", "usage": {}}},
+                ]
+            ),
+        )
+
+    _patch_codex_transport(monkeypatch, handler)
+    transport = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+    monkeypatch.setattr(
+        "opensquilla.provider.codex_auth.httpx.AsyncClient",
+        lambda *a, **kw: real(*a, **{**kw, "transport": transport}),
+    )
+
+    provider = OpenAICodexProvider(auth_path=str(auth))
+    events = _collect(provider)
+    assert calls["stream"] == 2
+    assert calls["refresh"] == 1
+    assert any(isinstance(e, TextDeltaEvent) and e.text == "ok" for e in events)
+    assert any(isinstance(e, DoneEvent) for e in events)
+    assert json.loads(auth.read_text())["tokens"]["access_token"] == "tok-new"
+
+
+def test_response_failed_yields_error_event(tmp_path: Path, monkeypatch) -> None:
+    auth = _write_auth(tmp_path / "auth.json")
+    body = _sse(
+        [
+            {
+                "type": "response.failed",
+                "response": {"error": {"code": "usage_limit_reached", "message": "limit"}},
+            }
+        ]
+    )
+    _patch_codex_transport(
+        monkeypatch,
+        lambda request: httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, content=body
+        ),
+    )
+    provider = OpenAICodexProvider(auth_path=str(auth))
+    events = _collect(provider)
+    (error,) = [e for e in events if isinstance(e, ErrorEvent)]
+    assert error.code == "usage_limit_reached"
+    assert not any(isinstance(e, DoneEvent) for e in events)
+
+
+def test_truncated_stream_still_terminates_with_done(tmp_path: Path, monkeypatch) -> None:
+    auth = _write_auth(tmp_path / "auth.json")
+    body = _sse(
+        [
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "id": "fc-1",
+                    "call_id": "call-1",
+                    "name": "search",
+                },
+            },
+            {"type": "response.function_call_arguments.delta", "item_id": "fc-1", "delta": "{}"},
+            # stream drops before output_item.done / response.completed
+        ]
+    )
+    _patch_codex_transport(
+        monkeypatch,
+        lambda request: httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, content=body
+        ),
+    )
+    provider = OpenAICodexProvider(auth_path=str(auth))
+    events = _collect(provider, tools=[_SEARCH_TOOL])
+    assert any(isinstance(e, ToolUseEndEvent) for e in events)
+    assert any(isinstance(e, DoneEvent) for e in events)
+
+
+def test_missing_credentials_is_auth_error_event(tmp_path: Path) -> None:
+    provider = OpenAICodexProvider(auth_path=str(tmp_path / "missing.json"))
+    events = _collect(provider)
+    (error,) = [e for e in events if isinstance(e, ErrorEvent)]
+    assert error.code == "401"
+    assert "codex login" in error.message
+
+
+# ---------------------------------------------------------------------------
+# Registry / selector wiring
+# ---------------------------------------------------------------------------
+
+
+def test_registry_and_selector_wire_openai_codex() -> None:
+    spec = get_provider_spec("openai_codex")
+    assert spec.backend == "openai_codex"
+    assert spec.runtime_supported is True
+    assert spec.requires_api_key() is False  # OAuth, not an API key field
+    assert spec.requires_base_url() is False
+    provider = build_provider("openai_codex", "gpt-5.2-codex")
+    assert isinstance(provider, OpenAICodexProvider)


### PR DESCRIPTION
## Scope

Runtime support for the `openai_codex` provider: OpenSquilla turns run on the operator's ChatGPT subscription via the Codex CLI's OAuth credentials. Turns the long-standing `runtime_supported=False` registry stub into a working, live-verified backend.

**Stacked on #415** (base branch: `feature/provider-stack-overhaul`) — it builds on the CompatPolicy/accumulator architecture and the P0 stream-termination contracts from that PR.

## What's in this PR

- **`provider/codex_auth.py`** — reads the Codex CLI auth file (`$CODEX_HOME/auth.json`, default `~/.codex/auth.json`), resolves the ChatGPT account id from the stored field or the JWT claim, and exchanges the refresh token at `auth.openai.com` when the backend returns 401 (one retry), persisting refreshed tokens back atomically with 0600 permissions. Credential creation stays with `codex login`; token values are never logged.
- **`provider/openai_codex.py`** — speaks `chatgpt.com/backend-api/codex/responses`: SSE POST with Bearer + `chatgpt-account-id` auth, flat Responses function tools, `store: false`, `include: ["reasoning.encrypted_content"]`. The `response.*` event stream maps onto the StreamEvent contract through `ToolStreamAccumulator`, covering both the delta grammar (`function_call_arguments.delta`) and the burst grammar (complete `output_item.done` items), with the termination guarantees: truncated streams close open tool calls and always emit `DoneEvent`; internal failures become `ErrorEvent`.
- **Registry/selector wiring** — new `openai_codex` backend; the provider surfaces in onboarding as an experimental OAuth provider and is live-probe-able like any other.
- Default model `gpt-5.5` (the current Codex CLI default; the backend rejects older `-codex`-suffixed slugs for ChatGPT accounts).

Protocol facts were extracted from the codex-rs reference implementation (request path, header set, flat tool serialization, SSE event vocabulary, refresh flow) rather than guessed.

## Tests

13 contract tests (auth load/JWT fallback/refresh persistence, SSE mapping incl. usage/cached/reasoning tokens, 401-refresh-retry, `response.failed`, truncation termination, registry/selector wiring) + `scripts/live_codex_smoke.py` gated on the auth file. **Live-verified against a real ChatGPT account**: text turn returned the exact marker (reasoning tokens accounted), and a `get_weather` tool call round-tripped cleanly — both ~2s on `gpt-5.5`. Full offline suite green at HEAD: 7707 passed, ruff/mypy clean.

## Release Note

- New provider `openai_codex`: use your ChatGPT subscription as an LLM backend. Sign in once with the Codex CLI (`codex login`); OpenSquilla picks up the credentials automatically, refreshes tokens as needed, and supports text, tool calls, and reasoning models (default `gpt-5.5`).

## Safety

No secrets committed; tokens are read from the operator's local auth file, never logged, and not exposed through provider metadata surfaces.
