### PR TITLE
Restore a green full-suite run on main (post-#412 test hygiene)

### DIFF
--- a/tests/test_gateway/test_boot_media_root.py
+++ b/tests/test_gateway/test_boot_media_root.py
@@ -15,6 +15,19 @@ import pytest
 from opensquilla.gateway.boot import build_services
 from opensquilla.gateway.config import GatewayConfig
 from opensquilla.paths import media_root_from_config
+from opensquilla.sandbox.integration import reset_runtime
+
+
+@pytest.fixture(autouse=True)
+def _drop_sandbox_runtime():
+    """build_services configures the process-wide SandboxRuntime; drop it.
+
+    Without this, the runtime (with the config's network mode) leaks into
+    every later test in the session — e.g. the search RPC tests in
+    test_rpc_product_cli_gaps.py got SandboxDenied under PROXY_ALLOWLIST.
+    """
+    yield
+    reset_runtime()
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_rpc_product_cli_gaps.py
+++ b/tests/test_gateway/test_rpc_product_cli_gaps.py
@@ -1303,6 +1303,21 @@ class FailingSearchProvider:
         )
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_sandbox_runtime():
+    """These tests assume the unconfigured (sandbox-off) runtime state.
+
+    Any earlier test that boots gateway services configures the process-wide
+    SandboxRuntime; a leaked runtime with a managed network mode makes the
+    search RPCs fail with SandboxDenied. Reset to the neutral state so this
+    module's behavior does not depend on test ordering.
+    """
+    from opensquilla.sandbox.integration import reset_runtime
+
+    reset_runtime()
+    yield
+
+
 @pytest.mark.asyncio
 async def test_search_status_and_query_return_structured_payloads():
     register_provider(

--- a/tests/test_public_release_hygiene.py
+++ b/tests/test_public_release_hygiene.py
@@ -43,6 +43,8 @@ PUBLIC_RELEASE_MARKER_NAMES = (
 PATH_POLICY_FIXTURE_FILES = {
     "tests/test_artifacts.py",
     "tests/test_provider_image_generation.py",
+    "tests/test_sandbox/test_operation_profile.py",
+    "tests/test_sandbox/test_windows_default_cache.py",
     "tests/test_tools/test_apply_patch_gates.py",
     "tests/test_tools/test_filesystem_read_workspace.py",
     "tests/test_tools/test_git_workdir_policy.py",

--- a/tests/test_search/test_canonical_web_search.py
+++ b/tests/test_search/test_canonical_web_search.py
@@ -367,7 +367,12 @@ async def test_canonical_web_search_primary_auth_failure_does_not_silent_fallbac
 async def test_canonical_web_search_no_key_auto_skips_known_missing_key_providers(
     monkeypatch,
 ) -> None:
-    for key in ("BRAVE_SEARCH_API_KEY", "TAVILY_API_KEY", "EXA_API_KEY"):
+    for key in (
+        "BRAVE_SEARCH_API_KEY",
+        "TAVILY_API_KEY",
+        "EXA_API_KEY",
+        "BOCHA_SEARCH_API_KEY",
+    ):
         monkeypatch.delenv(key, raising=False)
 
     def provider_factory(name: str) -> MissingKeyAuthProvider | FallbackProvider:
@@ -389,7 +394,12 @@ async def test_canonical_web_search_no_key_auto_skips_known_missing_key_provider
 
 @pytest.mark.asyncio
 async def test_canonical_web_search_no_key_default_uses_duckduckgo_directly(monkeypatch) -> None:
-    for key in ("BRAVE_SEARCH_API_KEY", "TAVILY_API_KEY", "EXA_API_KEY"):
+    for key in (
+        "BRAVE_SEARCH_API_KEY",
+        "TAVILY_API_KEY",
+        "EXA_API_KEY",
+        "BOCHA_SEARCH_API_KEY",
+    ):
         monkeypatch.delenv(key, raising=False)
     attempted: list[str] = []
 
@@ -732,7 +742,12 @@ async def test_canonical_web_search_soft_degrades_explicit_duckduckgo_recency() 
 async def test_canonical_web_search_no_key_auto_recency_uses_duckduckgo_soft_degrade(
     monkeypatch,
 ) -> None:
-    for key in ("BRAVE_SEARCH_API_KEY", "TAVILY_API_KEY", "EXA_API_KEY"):
+    for key in (
+        "BRAVE_SEARCH_API_KEY",
+        "TAVILY_API_KEY",
+        "EXA_API_KEY",
+        "BOCHA_SEARCH_API_KEY",
+    ):
         monkeypatch.delenv(key, raising=False)
     calls: list[tuple[str, str, int]] = []
 
@@ -758,6 +773,9 @@ async def test_canonical_web_search_technical_mode_prefers_exa_then_brave(monkey
     monkeypatch.setenv("EXA_API_KEY", "exa-key")
     monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "brave-key")
     monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
+    # A real Bocha key in the developer's environment would outrank brave in
+    # the technical-mode fallback order; keep the ordering assertion hermetic.
+    monkeypatch.delenv("BOCHA_SEARCH_API_KEY", raising=False)
     attempted: list[str] = []
 
     def provider_factory(name: str) -> MissingKeyAuthProvider | FallbackProvider:


### PR DESCRIPTION
## Scope

Restores a green full-suite run on `main`. Four order/env-dependent test failures — three shipped with #412, one older — all verified failing on pure `origin/main` (a2cd842e) before this fix. Test-hygiene only; no sandbox or product behavior changes.

## What's in this PR

1. **Release-hygiene scanner flagged its own PR's fixtures.** `test_public_release_hygiene` (new in #412) scans tracked files for `C:\Users\...` paths, but two of #412's own sandbox test files carry intentional fixture paths and were not in `PATH_POLICY_FIXTURE_FILES`: `tests/test_sandbox/test_operation_profile.py` and `tests/test_sandbox/test_windows_default_cache.py`. Added to the allowlist.

2. **Leaked process-wide SandboxRuntime.** `test_boot_media_root` calls `build_services`, which configures the global `SandboxRuntime` — and never dropped it. Every later test in the session then ran under the leaked network mode; the three search RPC tests in `test_rpc_product_cli_gaps.py` failed with `SandboxDenied` ("NetworkMode.PROXY_ALLOWLIST requires Run Context grants"). Two-sided fix: the boot test drops the runtime after each test (`reset_runtime()`), and the RPC-gaps module resets to the neutral unconfigured state before each of its tests, so it no longer depends on what ran before it.

3. **Canonical-search ordering tests weren't hermetic against a Bocha key.** Four tests cleared `BRAVE/TAVILY/EXA` keys but not `BOCHA_SEARCH_API_KEY`, so a real Bocha key in a developer's environment changed the runtime provider order and failed them (the long-standing "local .env" failures). All 25 now pass hermetically and with real keys exported. (Same change is included in #415; content is identical so the merges compose cleanly.)

## Tests

Full offline suite on this branch: **8475 passed, 0 failed** (excluded: the pre-existing `test_inference_postprocess_rules` numpy collection failure, real-terminal TUI integration tests, and two environment-dependent onnx/opentui tests). Poisoner pair (`test_boot_media_root` + `test_rpc_product_cli_gaps`) verified green; hygiene test green; full `tests/test_gateway` directory green (1558 passed).

## Release Note

NONE — test-only changes.

## Safety

No secrets, private prompts/transcripts, channel identifiers, or non-public fixtures committed.
