### PR TITLE
Fix desktop first-run setup window ordering

### DIFF
--- a/desktop/electron/scripts/verify-package.mjs
+++ b/desktop/electron/scripts/verify-package.mjs
@@ -9,6 +9,7 @@ const scriptDir = dirname(fileURLToPath(import.meta.url))
 const packageRoot = resolve(scriptDir, '..')
 const repoRoot = resolve(packageRoot, '..', '..')
 const runtimeGatewayDir = join(packageRoot, 'runtime', 'gateway')
+const sourceMainPath = join(packageRoot, 'src', 'main.ts')
 const compiledMainPath = join(packageRoot, 'dist', 'main.js')
 const desktopOutputDir = join(repoRoot, 'dist', 'desktop-electron')
 
@@ -233,6 +234,47 @@ function verifyMainProcess(source, label) {
   ) {
     fail(`${label} main process reloads the Control UI before checking whether it is already loaded`)
   }
+
+  const onboardingIndex = source.indexOf('async function runOnboarding')
+  const onboardingWindowIndex = source.indexOf('onboardingWindow = new BrowserWindow', onboardingIndex)
+  const parentIndex = source.indexOf('const parentWindow = currentMainWindow()', onboardingIndex)
+  const parentOptionIndex = source.indexOf('parent: parentWindow ?? undefined', onboardingWindowIndex)
+  const modalOptionIndex = source.indexOf('modal: Boolean(parentWindow)', onboardingWindowIndex)
+  if (
+    onboardingIndex === -1
+    || onboardingWindowIndex === -1
+    || parentIndex === -1
+    || parentOptionIndex === -1
+    || modalOptionIndex === -1
+    || parentIndex > onboardingWindowIndex
+  ) {
+    fail(`${label} main process does not make first-run onboarding an owned modal child window`)
+  }
+
+  const focusIndex = source.indexOf('function focusMainWindow')
+  const focusSource = focusIndex === -1 ? '' : source.slice(focusIndex, focusIndex + 800)
+  const onboardingFocusMatch = /if\s*\(\s*focusOnboardingWindow\(\)\s*\)\s*(?:\{\s*)?return true\s*;?/.exec(focusSource)
+  const mainFocusMatch =
+    /if\s*\(\s*!mainWindow\s*\|\|\s*mainWindow\.isDestroyed\(\)\s*\)\s*(?:\{\s*)?return false\s*;?/.exec(
+      focusSource,
+    )
+  if (
+    focusIndex === -1
+    || !onboardingFocusMatch
+    || !mainFocusMatch
+    || onboardingFocusMatch.index > mainFocusMatch.index
+  ) {
+    fail(`${label} main process does not prefer the onboarding window when focusing`)
+  }
+}
+
+async function verifySourceMain() {
+  if (!existsSync(sourceMainPath)) {
+    fail(`source Electron main process is missing at ${sourceMainPath}`)
+    return
+  }
+
+  verifyMainProcess(await readFile(sourceMainPath, 'utf8'), 'source')
 }
 
 async function verifyCompiledMain() {
@@ -308,6 +350,7 @@ async function verifyGeneratedBundle({ label, resourcesDir, platform }) {
 }
 
 await verifyRuntime(runtimeGatewayDir, 'source', { platform: process.platform, executeCommands: true })
+await verifySourceMain()
 await verifyCompiledMain()
 
 const generatedBundles = await findGeneratedBundles(desktopOutputDir)

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -1653,7 +1653,21 @@ function createApplicationMenu(): void {
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
 }
 
+function currentOnboardingWindow(): BrowserWindow | null {
+  return onboardingWindow && !onboardingWindow.isDestroyed() ? onboardingWindow : null
+}
+
+function focusOnboardingWindow(): boolean {
+  const window = currentOnboardingWindow()
+  if (!window) return false
+  if (window.isMinimized()) window.restore()
+  window.show()
+  window.focus()
+  return true
+}
+
 function focusMainWindow(): boolean {
+  if (focusOnboardingWindow()) return true
   if (!mainWindow || mainWindow.isDestroyed()) return false
   if (mainWindow.isMinimized()) mainWindow.restore()
   mainWindow.show()
@@ -2820,6 +2834,7 @@ async function runOnboarding(): Promise<DesktopConnection> {
   return new Promise((resolveCredential, rejectCredential) => {
     resolveOnboarding = resolveCredential
     rejectOnboarding = rejectCredential
+    const parentWindow = currentMainWindow()
     onboardingWindow = new BrowserWindow({
       width: 1040,
       height: 820,
@@ -2828,6 +2843,8 @@ async function runOnboarding(): Promise<DesktopConnection> {
       title: desktopT('window.onboarding'),
       icon: appIconPath(),
       resizable: true,
+      parent: parentWindow ?? undefined,
+      modal: Boolean(parentWindow),
       show: false,
       // Match the onboarding page's base so the first frame is not white.
       backgroundColor: '#f5f2eb',
@@ -2840,7 +2857,11 @@ async function runOnboarding(): Promise<DesktopConnection> {
     })
     installEditingContextMenu(onboardingWindow)
 
-    onboardingWindow.once('ready-to-show', () => onboardingWindow?.show())
+    onboardingWindow.once('ready-to-show', () => {
+      if (!onboardingWindow || onboardingWindow.isDestroyed()) return
+      onboardingWindow.show()
+      onboardingWindow?.focus()
+    })
     onboardingWindow.on('closed', () => {
       onboardingWindow = null
       if (rejectOnboarding) {

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -82,6 +82,36 @@ def test_desktop_activation_retry_and_second_instance_share_resume_helper() -> N
     assert "void openOrResumeDesktopApp()" in retry
 
 
+def test_desktop_onboarding_is_owned_modal_child_of_main_window() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    onboarding = _section(
+        main_ts,
+        "async function runOnboarding",
+        "async function pathExists",
+    )
+
+    assert "const parentWindow = currentMainWindow()" in onboarding
+    assert "parent: parentWindow ?? undefined" in onboarding
+    assert "modal: Boolean(parentWindow)" in onboarding
+    assert "onboardingWindow?.focus()" in onboarding
+
+
+def test_desktop_focus_prefers_open_onboarding_window() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    focus = _section(
+        main_ts,
+        "function focusMainWindow",
+        "function installEditingContextMenu",
+    )
+
+    assert "function currentOnboardingWindow(): BrowserWindow | null" in main_ts
+    assert "function focusOnboardingWindow(): boolean" in main_ts
+    assert "if (focusOnboardingWindow()) return true" in focus
+    onboarding_index = focus.index("if (focusOnboardingWindow()) return true")
+    main_index = focus.index("if (!mainWindow || mainWindow.isDestroyed()) return false")
+    assert onboarding_index < main_index
+
+
 def test_start_gateway_reuses_healthy_gateway_before_spawn() -> None:
     main_ts = _read("desktop/electron/src/main.ts")
     reuse = _section(

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -167,6 +167,8 @@ def test_package_verifier_hard_fails_stale_runtime_and_boot_contract() -> None:
         "gatewayStartPromise",
         "openOrResumeDesktopApp",
         "create the desktop window before gateway startup",
+        "first-run onboarding an owned modal child window",
+        "does not prefer the onboarding window when focusing",
         "process.exit(1)",
     ]:
         assert expected in verifier


### PR DESCRIPTION
## Scope

Scope boundary:
- Fix Electron desktop first-run window ordering so the setup wizard stays above the boot splash.
- Add startup contract coverage and package verifier checks for the source, compiled, and packaged Electron main process.

Non-goals:
- Do not revert boot-first desktop startup behavior.
- Do not change gateway startup, onboarding form content, or provider setup semantics.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #402

If None, reason: N/A

## Release Note

Release note: Fix Windows desktop first-run setup window ordering so the boot splash does not cover the setup wizard.

## Tests

Ruff: not run (desktop Electron-only change)

Pytest:
- `uv run pytest tests/test_desktop/test_electron_startup_contract.py -q` -> 12 passed

Build:
- `cd desktop/electron && npm run build` -> passed
- `cd desktop/electron && npm run verify:package` -> failed only because local `desktop/electron/runtime/gateway` is missing in this checkout; icon verification and main-process checks ran before that prerequisite failure

Regression tests: added

Notes:
- Rebased on latest `origin/main` (`57baea23`) before push.
- `git diff --check origin/main..HEAD` passed.
- Ran `npm ci` after rebase because latest main introduced `electron-updater`.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: release

Maintainer-only note: Please smoke-test a freshly built Windows installer with a clean desktop profile and confirm the setup wizard remains above the boot splash during first launch.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents were not committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
