### PR TITLE
Keep gateway build-service tests from real sandbox setup

### DIFF
--- a/tests/test_gateway/test_boot_media_root.py
+++ b/tests/test_gateway/test_boot_media_root.py
@@ -36,10 +36,23 @@ async def test_build_services_wires_media_root_into_session_manager(
 ) -> None:
     # Keep the build hermetic: redirect all state off the real user home.
     monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "state"))
+
+    def fail_background_sandbox_setup(coro):
+        close = getattr(coro, "close", None)
+        if callable(close):
+            close()
+        raise AssertionError("unit tests must not schedule real sandbox setup")
+
+    monkeypatch.setattr(
+        "opensquilla.gateway.boot.create_background_task",
+        fail_background_sandbox_setup,
+    )
+
     media = tmp_path / "media"
     config = GatewayConfig(
         memory={"flush_enabled": False},
         attachments={"media_root": str(media)},
+        sandbox={"auto_setup": False},
     )
 
     services = await build_services(

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -1502,6 +1502,16 @@ async def test_build_services_registers_session_search_tool(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    def fail_background_sandbox_setup(coro: Any) -> None:
+        close = getattr(coro, "close", None)
+        if callable(close):
+            close()
+        raise AssertionError("unit tests must not schedule real sandbox setup")
+
+    monkeypatch.setattr(
+        "opensquilla.gateway.boot.create_background_task",
+        fail_background_sandbox_setup,
+    )
     monkeypatch.setattr(
         "opensquilla.sandbox.integration.configure_runtime",
         lambda *args, **kwargs: SimpleNamespace(
@@ -1527,6 +1537,7 @@ async def test_build_services_registers_session_search_tool(
         channels={"channels": []},
         mcp={"enabled": False},
         memory={"flush_enabled": False},
+        sandbox={"auto_setup": False},
     )
 
     services = await build_services(
@@ -1652,6 +1663,7 @@ async def test_build_services_fails_fast_for_explicit_remote_memory_without_key(
         state_dir=str(tmp_path / "state"),
         workspace_dir=str(tmp_path / "workspace"),
         memory={"embedding": {"provider": "openai"}},
+        sandbox={"auto_setup": False},
     )
 
     with pytest.raises(ValueError, match="memory.embedding.remote.api_key"):


### PR DESCRIPTION
## Summary
- Disable sandbox auto setup in build_services tests that are not exercising auto setup
- Add guards so hermetic gateway unit tests fail if they schedule real sandbox setup
- Preserve the existing dedicated test that verifies build_services schedules sandbox setup after runtime configuration

## Test Plan
- uv run pytest tests/test_gateway/test_boot_media_root.py::test_build_services_wires_media_root_into_session_manager -q
- uv run pytest tests/test_gateway/test_router_boot.py::test_build_services_registers_session_search_tool tests/test_gateway/test_router_boot.py::test_build_services_fails_fast_for_explicit_remote_memory_without_key tests/test_gateway/test_router_boot.py::test_build_services_schedules_sandbox_setup_after_runtime -q
- uv run pytest tests/test_gateway/test_boot_media_root.py tests/test_gateway/test_router_boot.py -q
- uv run ruff check tests/test_gateway/test_boot_media_root.py tests/test_gateway/test_router_boot.py

Follow-up to #422 main CI run: https://github.com/opensquilla/opensquilla/actions/runs/28620856867