### PR TITLE
Skip real SIGINT TUI test on Windows

### DIFF
--- a/tests/unit/cli/tui/test_native_input.py
+++ b/tests/unit/cli/tui/test_native_input.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import os
 import signal
+import sys
 
 import pytest
 
@@ -73,6 +74,10 @@ def test_on_sigint_cancels_turn_without_exiting() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="Windows delivers SIGINT to pytest itself; fallback behavior is covered separately",
+)
 async def test_real_sigint_cancels_turn_and_does_not_exit() -> None:
     cancelled: list[bool] = []
     shutdown: list[bool] = []


### PR DESCRIPTION
## Summary
- Skip the integration-style real SIGINT TUI test on Windows, where SIGINT can interrupt pytest itself
- Keep the pure _on_sigint unit test and KeyboardInterrupt fallback test active across platforms

## Test Plan
- uv run pytest tests/unit/cli/tui/test_native_input.py -q
- uv run ruff check tests/unit/cli/tui/test_native_input.py
- git diff --check

Follow-up to main CI run: https://github.com/opensquilla/opensquilla/actions/runs/28622057595