### PR TITLE
Gate OpenTUI fd bridge on Windows

### DIFF
--- a/src/opensquilla/cli/tui/opentui/bridge.py
+++ b/src/opensquilla/cli/tui/opentui/bridge.py
@@ -60,6 +60,12 @@ def check_opentui_host_available(
 ) -> RendererBackendAvailability:
     """Check whether the local Bun/OpenTUI host can be launched."""
 
+    if os.name == "nt":
+        return RendererBackendAvailability(
+            available=False,
+            reason="OpenTUI file-descriptor bridge is not supported on Windows yet",
+        )
+
     resolved_runtime = runtime_bin or shutil.which("bun")
     if not resolved_runtime:
         return RendererBackendAvailability(
@@ -145,9 +151,7 @@ class OpenTuiBridge:
         # errors="replace" so a corrupted byte from the host never raises a hard
         # UnicodeDecodeError mid-read; the line is still delivered (and skipped if
         # it no longer parses) instead of tearing down the UI.
-        self._from_host_file = os.fdopen(
-            from_host_read, "r", encoding="utf-8", errors="replace"
-        )
+        self._from_host_file = os.fdopen(from_host_read, "r", encoding="utf-8", errors="replace")
         # Capture the host's stderr so a crash leaves a diagnosable reason instead
         # of corrupting the terminal or vanishing. Draining it also keeps the
         # child from blocking on a full stderr pipe.

--- a/tests/unit/cli/tui/test_opentui_bridge.py
+++ b/tests/unit/cli/tui/test_opentui_bridge.py
@@ -29,6 +29,21 @@ def test_missing_opentui_host_dependencies_report_install_command(tmp_path) -> N
     assert f"bun install --cwd {package_dir}" in availability.reason
 
 
+def test_opentui_host_reports_fd_bridge_unsupported_on_windows(tmp_path, monkeypatch) -> None:
+    package_dir = tmp_path / "package"
+    (package_dir / "node_modules" / "@opentui" / "core").mkdir(parents=True)
+    (package_dir / "src").mkdir()
+    (package_dir / "src" / "main.mjs").write_text("", encoding="utf-8")
+    monkeypatch.setattr(bridge_module.os, "name", "nt")
+
+    availability = check_opentui_host_available(package_dir=package_dir, runtime_bin="bun")
+
+    assert availability.available is False
+    assert availability.reason is not None
+    assert "Windows" in availability.reason
+    assert "file-descriptor" in availability.reason
+
+
 async def _attach_exited_process(bridge: OpenTuiBridge, *, code: int, stderr: str) -> None:
     """Attach a real, already-spawned child that exits with ``code`` to the bridge."""
     script = f"import sys; sys.stderr.write({stderr!r}); sys.exit({code})"
@@ -122,6 +137,10 @@ async def test_close_does_not_treat_intentional_shutdown_as_crash() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="OpenTUI bridge currently uses POSIX fd inheritance via pass_fds",
+)
 async def test_start_surfaces_reason_and_cleans_up_when_host_crashes_on_launch(
     tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary
- mark the OpenTUI file-descriptor bridge unavailable on Windows before it can hit Python's unsupported `pass_fds` path
- skip the POSIX fd-plumbing launch/crash test on Windows while keeping the availability contract covered

Follow-up to the post-merge Windows full CI failure after #422 / #424 for issue #402.

## Verification
- `uv run pytest tests/unit/cli/tui/test_opentui_bridge.py tests/unit/cli/tui/test_renderer_backend_contract.py -q`
- `uv run ruff check src/opensquilla/cli/tui/opentui/bridge.py tests/unit/cli/tui/test_opentui_bridge.py`
- `uv run ruff format --check src/opensquilla/cli/tui/opentui/bridge.py tests/unit/cli/tui/test_opentui_bridge.py`
- `git diff --check`