### PR TITLE
Keep OpenTUI dependency check platform-neutral

### DIFF
--- a/tests/unit/cli/tui/test_opentui_bridge.py
+++ b/tests/unit/cli/tui/test_opentui_bridge.py
@@ -17,9 +17,10 @@ from opensquilla.cli.tui.opentui.bridge import (
 from opensquilla.cli.tui.renderers.selection import RendererBackendAvailability
 
 
-def test_missing_opentui_host_dependencies_report_install_command(tmp_path) -> None:
+def test_missing_opentui_host_dependencies_report_install_command(tmp_path, monkeypatch) -> None:
     package_dir = tmp_path / "package"
     package_dir.mkdir()
+    monkeypatch.setattr(bridge_module.os, "name", "posix")
 
     availability = check_opentui_host_available(package_dir=package_dir, runtime_bin="bun")
 


### PR DESCRIPTION
## Summary
- make the OpenTUI missing-dependency test explicitly exercise the fd-capable platform path
- avoid conflicting with the Windows fd-bridge availability guard added in #425

Follow-up to the post-merge Windows full CI failure for #425.

## Verification
- `uv run pytest tests/unit/cli/tui/test_opentui_bridge.py tests/unit/cli/tui/test_renderer_backend_contract.py -q`
- `uv run ruff check tests/unit/cli/tui/test_opentui_bridge.py`
- `uv run ruff format --check tests/unit/cli/tui/test_opentui_bridge.py`
- `git diff --check`