### PR TITLE
[codex] Document terminal chat usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,9 @@ opensquilla agent -m "your prompt"     # one-shot, automation-friendly
 > ```
 >
 > Leave `OPENSQUILLA_TUI_BACKEND` unset for the stable chat. See
-> [docs/features/tui-frontend.md](docs/features/tui-frontend.md) for details.
+> [docs/tui.md](docs/tui.md) for terminal chat usage and
+> [docs/features/tui-frontend.md](docs/features/tui-frontend.md) for backend
+> details.
 
 Open the Web UI at <http://127.0.0.1:18791/control/>. The **Health**
 view shows whether OpenSquilla is ready, what is not ready, and the

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,17 +11,19 @@ root release README with task-oriented guides.
 4. [`configuration.md`](configuration.md) - provider, router, search, channel,
    memory, and permission configuration.
 5. [`cli.md`](cli.md) - command groups and common CLI workflows.
-6. [`web-ui.md`](web-ui.md) - local control console and chat UI.
-7. [`sessions.md`](sessions.md) - session continuity, export, resume, abort,
+6. [`tui.md`](tui.md) - terminal chat usage, slash commands, files, sessions,
+   and the OpenTUI preview.
+7. [`web-ui.md`](web-ui.md) - local control console and chat UI.
+8. [`sessions.md`](sessions.md) - session continuity, export, resume, abort,
    and cleanup.
-8. [`glossary.md`](glossary.md) - user-facing terminology.
+9. [`glossary.md`](glossary.md) - user-facing terminology.
 
 ## Feature Guides
 
 - [`features.md`](features.md) - capability catalog.
 - [`features/squilla-router.md`](features/squilla-router.md) - model routing.
-- [`features/tui-frontend.md`](features/tui-frontend.md) - terminal streaming,
-  plugin slots, Router HUD, and TUI backend evaluation.
+- [`features/tui-frontend.md`](features/tui-frontend.md) - terminal backend
+  architecture, plugin slots, Router HUD, and OpenTUI evaluation.
 - [`features/tool-compression.md`](features/tool-compression.md) - compact tool
   results and handles.
 - [`features/meta-skills.md`](features/meta-skills.md) - reusable workflow skills.
@@ -56,9 +58,9 @@ root release README with task-oriented guides.
 - [`usage-and-cost.md`](usage-and-cost.md) - token usage, estimated cost, and
   cost investigation workflow.
 - [`diagnostics-and-replay.md`](diagnostics-and-replay.md) - diagnostics,
-  raw capture guidance, and read-only turn replay.
-- [`tui-real-terminal-harness.md`](tui-real-terminal-harness.md) -
-  real-terminal TUI launch, replay, and evidence capture.
+  raw capture guidance, read-only turn replay, and developer replay benchmarks.
+- [`tui-real-terminal-harness.md`](tui-real-terminal-harness.md) - maintainer
+  real-terminal TUI integration harness and evidence capture.
 - [`operations.md`](operations.md) - sessions, cron, usage, diagnostics,
   migration, MCP server, and install inventory commands.
 - [`troubleshooting.md`](troubleshooting.md) - common install/runtime issues.

--- a/docs/approvals-and-permissions.md
+++ b/docs/approvals-and-permissions.md
@@ -56,7 +56,7 @@ the project would be unacceptable.
 ## Interactive Approvals
 
 Interactive chat surfaces can pause sensitive tool calls for a human decision.
-The terminal chat supports:
+Gateway-backed terminal chat supports:
 
 ```text
 /approvals

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,21 +61,28 @@ opensquilla chat
 opensquilla chat --model gpt-5.4-mini
 opensquilla chat --session <session-key>
 opensquilla chat --standalone --workspace /path/to/project
-OPENSQUILLA_TUI_BACKEND=opentui opensquilla chat
 ```
 
 Terminal chat uses the stable Python-native terminal backend by default.
 OpenTUI is a preview backend selected explicitly with
 `OPENSQUILLA_TUI_BACKEND=opentui` when evaluating that backend. Normal terminal
-chat does not require Bun or OpenTUI node modules. Legacy backend values are
-rejected before launch. Read
-[`features/tui-frontend.md`](features/tui-frontend.md) for the streaming plane,
-plugin slots, Router HUD, and replay benchmark workflow.
+chat does not require Bun or OpenTUI node modules. The OpenTUI preview is for
+source checkouts with local Bun dependencies installed:
+
+```sh
+bun install --frozen-lockfile --cwd=src/opensquilla/cli/tui/opentui/package
+OPENSQUILLA_TUI_BACKEND=opentui uv run opensquilla chat
+```
+
+Legacy backend values are rejected before launch. Read [`tui.md`](tui.md) for
+terminal chat usage and [`features/tui-frontend.md`](features/tui-frontend.md)
+for backend architecture, plugin slots, Router HUD, and replay benchmark
+workflow.
 
 Web chat and the CLI gateway TUI support `/meta` for manual MetaSkill launch:
 `/meta` lists available workflows and `/meta <name>` runs one. Channel surfaces
-and standalone CLI chat can list MetaSkills with `/meta`, but they do not launch
-MetaSkill runs directly.
+can list MetaSkills with `/meta`, but they do not launch MetaSkill runs
+directly. Standalone CLI chat requires gateway mode for `/meta`.
 
 One-shot automation:
 

--- a/docs/diagnostics-and-replay.md
+++ b/docs/diagnostics-and-replay.md
@@ -82,7 +82,7 @@ and errors.
 
 Read [`features/tui-frontend.md`](features/tui-frontend.md) for backend status
 and [`tui-real-terminal-harness.md`](tui-real-terminal-harness.md) for
-terminal-level launch evidence.
+maintainer terminal-level launch evidence.
 
 ## Pair Replay With Sessions
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -27,7 +27,8 @@ Read: [`features/squilla-router.md`](features/squilla-router.md)
 Terminal chat uses a streaming plane for token deltas and a structured UI plane
 for plugin snapshots such as the Router HUD.
 
-Read: [`features/tui-frontend.md`](features/tui-frontend.md)
+Read: [`tui.md`](tui.md) for user-facing terminal chat usage and
+[`features/tui-frontend.md`](features/tui-frontend.md) for backend details.
 
 ### Tool Compression
 
@@ -39,8 +40,8 @@ Read: [`features/tool-compression.md`](features/tool-compression.md)
 ### Meta-Skills
 
 Repeatable multi-step workflows can be represented as skills, inspected,
-proposed, replayed, and reused. By default, users launch them manually with
-`/meta` and `/meta <name>`.
+proposed, replayed, and reused. By default, users launch them manually on
+supported chat surfaces with `/meta` and `/meta <name>`.
 
 Read: [`features/meta-skills.md`](features/meta-skills.md) and
 [`features/meta-skill-user-guide.md`](features/meta-skill-user-guide.md)

--- a/docs/features/meta-skill-user-guide.md
+++ b/docs/features/meta-skill-user-guide.md
@@ -63,9 +63,9 @@ MetaSkill provides four main advantages:
 
 ## Default Launch Model
 
-MetaSkills are manual-only by default. Use `/meta` to list available workflows
-and `/meta <name>` to run one. This keeps workflow launches deliberate,
-reviewable, and easier to explain.
+MetaSkills are manual-only by default. On supported chat surfaces, use `/meta`
+to list available workflows and `/meta <name>` to run one. This keeps workflow
+launches deliberate, reviewable, and easier to explain.
 
 Web chat and the CLI gateway TUI support both list and run:
 
@@ -74,7 +74,8 @@ Web chat and the CLI gateway TUI support both list and run:
 /meta meta-kid-project-planner
 ```
 
-Channel and standalone CLI surfaces support `/meta` listing only.
+Channel surfaces support `/meta` listing only. Standalone CLI chat requires
+gateway mode for `/meta`.
 
 To restore the older automatic behavior, set:
 

--- a/docs/features/meta-skills.md
+++ b/docs/features/meta-skills.md
@@ -61,8 +61,9 @@ In Web chat and the CLI gateway TUI:
 ```
 
 `/meta` lists available MetaSkills. `/meta <name>` starts the selected
-workflow. Channel and standalone CLI surfaces can list MetaSkills with `/meta`,
-but they do not run MetaSkills from chat text.
+workflow. Channel surfaces can list MetaSkills with `/meta`, but they do not run
+MetaSkills from chat text. Standalone CLI chat requires gateway mode for
+`/meta`.
 
 To restore automatic model-triggered behavior, set:
 

--- a/docs/features/tui-frontend.md
+++ b/docs/features/tui-frontend.md
@@ -6,7 +6,7 @@ backend:
 | Backend or target | Status | How to use | Requirements |
 | --- | --- | --- | --- |
 | `native` | Stable default | `opensquilla chat` | Python package only |
-| `opentui` | Preview opt-in | `OPENSQUILLA_TUI_BACKEND=opentui opensquilla chat` | Bun and local OpenTUI package dependencies |
+| `opentui` | Preview opt-in | `OPENSQUILLA_TUI_BACKEND=opentui uv run opensquilla chat` | Source checkout, Bun, and local OpenTUI package dependencies |
 | `live-opentui` | Manual harness target | Real-terminal harness only | tmux, OpenTUI deps, and live provider config |
 
 `live-opentui` is not an `OPENSQUILLA_TUI_BACKEND` value. It is a guarded test
@@ -20,8 +20,8 @@ The TUI contracts are renderer-independent and built around two separate planes:
   snapshots can be rendered by capable TUI backends and by future renderers.
 
 The stable default terminal chat is Python-native and does not require Bun,
-npm, or OpenTUI node modules. OpenTUI is a preview backend selected explicitly
-with `OPENSQUILLA_TUI_BACKEND=opentui`.
+npm, or OpenTUI node modules. OpenTUI is a source-checkout preview backend
+selected explicitly with `OPENSQUILLA_TUI_BACKEND=opentui`.
 
 ## Plugin Slots
 
@@ -69,19 +69,17 @@ routes use warning styling.
 The default backend is stable Python-native terminal chat.
 
 The internal backend selector reads `OPENSQUILLA_TUI_BACKEND`. Unset or empty
-values select stable terminal chat. Set the variable to `opentui` only when
-evaluating the preview backend. Legacy values fail before chat launch with a
-clear unsupported-backend error.
-
-```sh
-OPENSQUILLA_TUI_BACKEND=opentui opensquilla chat
-```
-
-The preview backend requires Bun and the local OpenTUI package dependencies:
+values select stable terminal chat. Set the variable to `opentui` only in a
+source checkout when evaluating the preview backend. Legacy values fail before
+chat launch with a clear unsupported-backend error.
 
 ```sh
 bun install --frozen-lockfile --cwd=src/opensquilla/cli/tui/opentui/package
+OPENSQUILLA_TUI_BACKEND=opentui uv run opensquilla chat
 ```
+
+The preview backend is loaded from the OpenTUI package next to the running
+source tree; it is not required for normal terminal chat.
 
 Do not add parallel terminal/frontend implementations without fresh product
 direction and replay plus real-terminal evidence.

--- a/docs/tui-real-terminal-harness.md
+++ b/docs/tui-real-terminal-harness.md
@@ -4,24 +4,37 @@ The real-terminal harness launches the OpenTUI chat surface in a child process,
 drives it through tmux when available, falls back to PTY when needed, and stores
 evidence under `.artifacts/tui-real-terminal/runs`.
 
-## Platform requirements (Windows needs WSL2)
+## Platform requirements
 
-The harness drives a real terminal through tmux or a Unix pseudo-terminal
-(Python's `pty` module). Both are Unix-only:
+The harness runs on Unix-like terminal environments. Linux and macOS can run it
+directly. Windows users need WSL2 because the harness depends on Unix terminal
+primitives. It prefers tmux when available and falls back to a Unix
+pseudo-terminal (Python's `pty` module) when tmux is missing.
 
-- `pty` ships in the Python standard library **only on Unix**; on native Windows
-  `import pty` fails, so there is no PTY driver.
-- `tmux` has no native Windows build.
+- Linux and macOS can run the deterministic suite with either tmux or the PTY
+  fallback.
+- Native Windows shells such as PowerShell and `cmd.exe` are not supported:
+  Python's `pty` module is Unix-only, and tmux has no native Windows build.
+- WSL2 is mentioned only as the Windows compatibility path; inside WSL2 this is
+  just the Linux path.
 
-**Native PowerShell is not supported for this harness, and Windows users must run
-it under WSL2.** Inside a WSL2 distro the Linux `pty`/`tmux` stack works exactly
-as on Linux:
+Install tmux when you want the tmux driver:
+
+```bash
+# Debian/Ubuntu Linux, including WSL2:
+sudo apt-get update && sudo apt-get install -y tmux
+
+# macOS:
+brew install tmux
+```
+
+Windows-only setup:
 
 ```bash
 # In an elevated PowerShell, once:
 wsl --install            # installs WSL2 + a default Ubuntu distro
 
-# Then inside the WSL2 shell, install tmux and run the harness:
+# Then inside the WSL2 shell:
 sudo apt-get update && sudo apt-get install -y tmux
 uv run pytest tests/integration/cli/tui_real_terminal -q
 ```

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -1,0 +1,157 @@
+# Terminal Chat (TUI)
+
+Terminal chat, also called the TUI, is the command-line chat surface for
+OpenSquilla. Use it when you want an interactive conversation in a shell,
+especially while working in a local project directory.
+
+## Start Chat
+
+Start the default terminal chat:
+
+```sh
+opensquilla chat
+```
+
+This uses the stable Python-native terminal backend. It does not require Bun,
+npm, tmux, or OpenTUI dependencies.
+
+If gateway-backed chat cannot connect, start the gateway first:
+
+```sh
+opensquilla gateway start --json
+opensquilla chat
+```
+
+Use a specific model for the session:
+
+```sh
+opensquilla chat --model gpt-5.4-mini
+```
+
+Resume an existing session:
+
+```sh
+opensquilla chat --session <session-key>
+```
+
+Terminal chat is interactive and requires a real TTY. For scripts, pipes, CI,
+or one-shot automation, use:
+
+```sh
+opensquilla agent -m "Inspect this workspace"
+```
+
+## Gateway and Standalone Modes
+
+By default, `opensquilla chat` uses the gateway-backed chat path, so it shares
+sessions, configuration, approvals, usage, and model/provider state with the Web
+UI and other gateway clients.
+
+Use standalone mode when you want direct terminal chat without the gateway
+daemon:
+
+```sh
+opensquilla chat --standalone
+```
+
+Standalone mode accepts workspace flags for local file and tool work:
+
+```sh
+opensquilla chat --standalone --workspace /path/to/project --workspace-strict
+```
+
+In gateway mode, `--workspace` is ignored by terminal chat. Use a gateway-visible
+path with `/path`, or use `/file` to upload a local file from the CLI machine.
+
+## Common Commands
+
+Type `/help` in terminal chat to see the commands supported by the current mode.
+
+Commands available in both gateway and standalone chat include:
+
+| Command | Purpose |
+| --- | --- |
+| `/help` | Show command help. |
+| `/status` or `/session` | Show the active session and model. |
+| `/new [title]` | Start a new session. |
+| `/model [model]` | Show or change the active model. |
+| `/cost` | Show usage for the current chat state. |
+| `/clear` or `/reset` | Clear the current session context. |
+| `/compact` or `/cmp` | Compact long context when possible. |
+| `/save [path]` | Save the transcript. |
+| `/image <path> [prompt]` | Send an image file with an optional prompt. |
+| `/path <path> [prompt]` | Attach a file by path. |
+| `/theme ...` | Change terminal theme settings when the active backend supports it. |
+| `/quit` or `/exit` | Leave chat. |
+
+Gateway-backed chat also supports session and operations commands:
+
+| Command | Purpose |
+| --- | --- |
+| `/sessions [limit]` | List recent sessions. |
+| `/resume <id>` | Resume a session. |
+| `/delete <id>` | Delete a session. |
+| `/models` | List available models. |
+| `/usage` | Show aggregate usage. |
+| `/meta` | List MetaSkills. |
+| `/meta <name>` | Run a MetaSkill in the current session. |
+| `/file <path> [prompt]` | Upload a local file and send it with a prompt. |
+| `/permissions ...` | Inspect or change interactive permission mode. |
+| `/approvals ...` | Inspect or reset approval state. |
+| `/forget` | Clear remembered approvals. |
+
+Standalone chat supports the core commands above, but `/models`, `/meta`, and
+gateway-wide usage or approval commands require gateway mode.
+
+## Files and Images
+
+Use `/image` for image files:
+
+```text
+/image ./screenshot.png Describe the UI issue
+```
+
+Use `/path` when the file path is visible to the running chat process:
+
+```text
+/path ./docs/quickstart.md Summarize the setup steps
+```
+
+In gateway mode with a remote gateway, prefer `/file` so the CLI uploads the
+local file before sending the turn:
+
+```text
+/file ./report.pdf Extract the action items
+```
+
+## OpenTUI Preview
+
+The default terminal chat is the supported path for normal use. OpenTUI is an
+opt-in preview backend for evaluating a richer terminal UI from a source
+checkout. It is not required for day-to-day terminal chat.
+
+From a source checkout:
+
+```sh
+bun install --frozen-lockfile --cwd=src/opensquilla/cli/tui/opentui/package
+OPENSQUILLA_TUI_BACKEND=opentui uv run opensquilla chat
+```
+
+Leave `OPENSQUILLA_TUI_BACKEND` unset to use the stable terminal chat.
+
+Read [`features/tui-frontend.md`](features/tui-frontend.md) for OpenTUI backend
+status, Router HUD details, and replay benchmarks. Read
+[`tui-real-terminal-harness.md`](tui-real-terminal-harness.md) only when you are
+running maintainer integration tests for terminal rendering.
+
+## Related Pages
+
+- [`cli.md`](cli.md) for the full CLI reference.
+- [`sessions.md`](sessions.md) for listing, resuming, exporting, and deleting
+  sessions.
+- [`approvals-and-permissions.md`](approvals-and-permissions.md) for permission
+  profiles and approval workflows.
+- [`features/meta-skill-user-guide.md`](features/meta-skill-user-guide.md) for
+  `/meta` workflows.
+
+[Docs index](README.md) · [Product guide](../README.product.md) · [Improve this page](contributing-docs.md) · [Report a docs issue](https://github.com/opensquilla/opensquilla/issues/new?template=docs_report.yml)


### PR DESCRIPTION
## Summary

Adds a user-facing Terminal Chat (TUI) guide and aligns related documentation so the user path, OpenTUI preview path, and maintainer real-terminal harness are clearly separated.

## Details

- Adds `docs/tui.md` for terminal chat startup, gateway vs standalone mode, slash commands, file/image commands, and OpenTUI preview usage.
- Updates docs entry points to route users to the TUI guide and keep backend/harness pages framed as developer or maintainer material.
- Aligns OpenTUI preview wording around source checkouts, Bun dependencies, and `uv run`.
- Clarifies MetaSkill `/meta` support across Web chat, CLI gateway TUI, channels, and standalone CLI chat.
- Clarifies gateway-backed approval commands and real-terminal harness platform support.

## Validation

- `git diff --cached --check`
- `uv run pytest tests/test_cli/test_chat_cmd.py tests/unit/cli/repl/test_standalone_slash_adapter.py tests/unit/cli/repl/test_slash_adapter.py tests/test_cli/test_tui_meta_command.py tests/test_engine/test_meta_command_registration.py tests/integration/cli/tui_real_terminal/test_driver_capabilities.py -q`
- Local Markdown link check over 53 Markdown files