### PR TITLE
Add explicit profile home support

### DIFF
--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -2,16 +2,67 @@
 
 from __future__ import annotations
 
+import os
+import sys
 from pathlib import Path
 
 import typer
 
 from opensquilla.env import load_env, warn_if_proxy_ignored
+from opensquilla.paths import default_opensquilla_home, is_valid_profile_name
+
+
+def _profile_from_top_level_argv(argv: list[str]) -> str | None:
+    """Return a top-level ``--profile`` value without consuming subcommand flags."""
+    index = 1
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--":
+            return None
+        if arg.startswith("--profile="):
+            return arg.partition("=")[2].strip() or None
+        if arg == "--profile":
+            if index + 1 < len(argv):
+                return argv[index + 1].strip() or None
+            return None
+        if not arg.startswith("-"):
+            return None
+        index += 1
+    return None
+
+
+def _activate_profile(profile: str | None) -> None:
+    if profile is not None:
+        name = profile.strip()
+        if name:
+            if not is_valid_profile_name(name):
+                raise typer.BadParameter(
+                    "use lowercase letters, digits, hyphens, or underscores; "
+                    "start with a letter or digit; max length 64"
+                )
+            os.environ["OPENSQUILLA_PROFILE"] = name
+
+
+def _preactivate_profile_from_argv(argv: list[str]) -> None:
+    profile = _profile_from_top_level_argv(argv)
+    if profile and is_valid_profile_name(profile):
+        os.environ["OPENSQUILLA_PROFILE"] = profile
+
+
+def _load_env_for_active_home() -> None:
+    try:
+        home = default_opensquilla_home()
+    except ValueError:
+        home = Path.home() / ".opensquilla"
+    load_env(home=home)
+
+
+_preactivate_profile_from_argv(sys.argv)
 
 # Populate os.environ from .env files before any submodule import reads keys.
 # Precedence: os.environ > $CWD/.env.test during tests > $CWD/.env
-# > $CWD/.env.test fallback outside tests > ~/.opensquilla/.env.
-load_env()
+# > $CWD/.env.test fallback outside tests > selected OpenSquilla home/.env.
+_load_env_for_active_home()
 warn_if_proxy_ignored()
 
 from opensquilla.cli.agent_cmd import run_agent_command  # noqa: E402
@@ -45,6 +96,20 @@ app = typer.Typer(
     no_args_is_help=True,
     pretty_exceptions_enable=False,
 )
+
+
+@app.callback()
+def _main_callback(
+    profile: str | None = typer.Option(
+        None,
+        "--profile",
+        envvar="OPENSQUILLA_PROFILE",
+        help="Use a named OpenSquilla profile home.",
+    ),
+) -> None:
+    _activate_profile(profile)
+    load_env(home=default_opensquilla_home())
+    warn_if_proxy_ignored()
 
 # ── Sub-apps ─────────────────────────────────────────────────────────────────
 

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -11,6 +11,8 @@ import typer
 from opensquilla.env import load_env, warn_if_proxy_ignored
 from opensquilla.paths import default_opensquilla_home, is_valid_profile_name
 
+_LOADED_ENV_CONTEXTS: set[tuple[Path, Path]] = set()
+
 
 def _profile_from_top_level_argv(argv: list[str]) -> str | None:
     """Return a top-level ``--profile`` value without consuming subcommand flags."""
@@ -54,7 +56,11 @@ def _load_env_for_active_home() -> None:
         home = default_opensquilla_home()
     except ValueError:
         home = Path.home() / ".opensquilla"
+    context = (Path.cwd(), home)
+    if context in _LOADED_ENV_CONTEXTS:
+        return
     load_env(home=home)
+    _LOADED_ENV_CONTEXTS.add(context)
 
 
 _preactivate_profile_from_argv(sys.argv)
@@ -108,7 +114,7 @@ def _main_callback(
     ),
 ) -> None:
     _activate_profile(profile)
-    load_env(home=default_opensquilla_home())
+    _load_env_for_active_home()
     warn_if_proxy_ignored()
 
 # ── Sub-apps ─────────────────────────────────────────────────────────────────

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -12,6 +12,7 @@ from opensquilla.env import load_env, warn_if_proxy_ignored
 from opensquilla.paths import default_opensquilla_home, is_valid_profile_name
 
 _LOADED_ENV_CONTEXTS: set[tuple[Path, Path]] = set()
+_LOADED_LOCAL_ENV_CWDS: set[Path] = set()
 
 
 def _profile_from_top_level_argv(argv: list[str]) -> str | None:
@@ -52,14 +53,19 @@ def _preactivate_profile_from_argv(argv: list[str]) -> None:
 
 
 def _load_env_for_active_home() -> None:
+    cwd = Path.cwd()
+    if cwd not in _LOADED_LOCAL_ENV_CWDS:
+        load_env(cwd=cwd, include_home=False)
+        _LOADED_LOCAL_ENV_CWDS.add(cwd)
+
     try:
         home = default_opensquilla_home()
     except ValueError:
         home = Path.home() / ".opensquilla"
-    context = (Path.cwd(), home)
+    context = (cwd, home)
     if context in _LOADED_ENV_CONTEXTS:
         return
-    load_env(home=home)
+    load_env(cwd=cwd, home=home)
     _LOADED_ENV_CONTEXTS.add(context)
 
 

--- a/src/opensquilla/env.py
+++ b/src/opensquilla/env.py
@@ -80,8 +80,11 @@ def _is_test_env_enabled() -> bool:
     return "PYTEST_CURRENT_TEST" in os.environ
 
 
-def load_env(cwd: str | Path | None = None) -> int:
+def load_env(cwd: str | Path | None = None, home: str | Path | None = None) -> int:
     """Load .env files into os.environ with precedence rules.
+
+    ``home`` can be provided after the CLI has resolved an explicit profile, so
+    profile-specific ``.env`` files are considered without changing cwd.
 
     Returns the number of new variables injected.
     """
@@ -93,8 +96,9 @@ def load_env(cwd: str | Path | None = None) -> int:
     for name in local_names:
         candidates.append(work_dir / name)
 
-    # 2. ~/.opensquilla/.env (global)
-    candidates.append(default_opensquilla_home() / ".env")
+    # 2. OpenSquilla home .env (legacy home or explicit profile home)
+    opensquilla_home = Path(home) if home is not None else default_opensquilla_home()
+    candidates.append(opensquilla_home / ".env")
 
     # Merge: first file wins per key, but os.environ always wins
     merged: dict[str, str] = {}

--- a/src/opensquilla/env.py
+++ b/src/opensquilla/env.py
@@ -80,11 +80,18 @@ def _is_test_env_enabled() -> bool:
     return "PYTEST_CURRENT_TEST" in os.environ
 
 
-def load_env(cwd: str | Path | None = None, home: str | Path | None = None) -> int:
+def load_env(
+    cwd: str | Path | None = None,
+    home: str | Path | None = None,
+    *,
+    include_home: bool = True,
+) -> int:
     """Load .env files into os.environ with precedence rules.
 
     ``home`` can be provided after the CLI has resolved an explicit profile, so
     profile-specific ``.env`` files are considered without changing cwd.
+    Set ``include_home=False`` when callers need to load only local cwd env
+    files before resolving the active OpenSquilla home.
 
     Returns the number of new variables injected.
     """
@@ -97,8 +104,9 @@ def load_env(cwd: str | Path | None = None, home: str | Path | None = None) -> i
         candidates.append(work_dir / name)
 
     # 2. OpenSquilla home .env (legacy home or explicit profile home)
-    opensquilla_home = Path(home) if home is not None else default_opensquilla_home()
-    candidates.append(opensquilla_home / ".env")
+    if include_home:
+        opensquilla_home = Path(home) if home is not None else default_opensquilla_home()
+        candidates.append(opensquilla_home / ".env")
 
     # Merge: first file wins per key, but os.environ always wins
     merged: dict[str, str] = {}

--- a/src/opensquilla/paths.py
+++ b/src/opensquilla/paths.py
@@ -1,17 +1,26 @@
 """OpenSquilla state-root resolution.
 
-Single source of truth for the on-disk state root. One env var controls
-the root, and every subsystem derives its sub-path from the helper here.
+Single source of truth for the on-disk state root. Most users keep the
+legacy single-instance home, while operators can opt into explicit
+multi-profile homes for side-by-side agents.
 
 Precedence:
 1. ``OPENSQUILLA_STATE_DIR`` environment variable (expanded for ``~``/``$HOME``)
-2. ``$HOME/.opensquilla``
+2. ``OPENSQUILLA_HOME`` + ``OPENSQUILLA_PROFILE`` profile mode
+3. ``$HOME/.opensquilla``
 """
 
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
+
+_STATE_DIR_ENV = "OPENSQUILLA_STATE_DIR"
+_PROFILES_ROOT_ENV = "OPENSQUILLA_HOME"
+_PROFILE_ENV = "OPENSQUILLA_PROFILE"
+_DEFAULT_PROFILE = "default"
+_PROFILE_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
 
 def _home_dir() -> Path:
@@ -29,15 +38,55 @@ def _expand_user(path: str) -> Path:
     return Path(path).expanduser()
 
 
+def is_valid_profile_name(name: str) -> bool:
+    """Return True when ``name`` is safe to use as one profile path segment."""
+    return bool(_PROFILE_RE.fullmatch(name))
+
+
+def default_profile_name() -> str:
+    """Return the selected profile name, defaulting to ``default``."""
+    profile = os.environ.get(_PROFILE_ENV, "").strip()
+    return profile or _DEFAULT_PROFILE
+
+
+def default_profiles_root() -> Path:
+    """Return the root directory that contains explicit profile homes."""
+    root = os.environ.get(_PROFILES_ROOT_ENV, "").strip()
+    if root:
+        return _expand_user(root)
+    return _home_dir() / ".opensquilla" / "profiles"
+
+
+def profile_home(profile: str | None = None, *, root: Path | None = None) -> Path:
+    """Return the home directory for ``profile`` under the profiles root."""
+    name = (profile or default_profile_name()).strip()
+    if not is_valid_profile_name(name):
+        raise ValueError(
+            "Invalid OpenSquilla profile name. Use lowercase letters, digits, "
+            "hyphens, or underscores; start with a letter or digit; max length 64."
+        )
+    return (root or default_profiles_root()) / name
+
+
+def _profile_mode_requested() -> bool:
+    return bool(
+        os.environ.get(_PROFILES_ROOT_ENV, "").strip()
+        or os.environ.get(_PROFILE_ENV, "").strip()
+    )
+
+
 def default_opensquilla_home() -> Path:
     """Return the OpenSquilla state root as an absolute :class:`~pathlib.Path`.
 
-    Honors ``OPENSQUILLA_STATE_DIR`` (trimmed, ``~`` expanded). Falls back to
-    ``$HOME/.opensquilla`` when unset or empty.
+    Honors ``OPENSQUILLA_STATE_DIR`` (trimmed, ``~`` expanded). Explicit profile
+    mode uses ``OPENSQUILLA_HOME/<profile>``; the default remains the legacy
+    ``$HOME/.opensquilla`` when no profile env vars are set.
     """
-    override = os.environ.get("OPENSQUILLA_STATE_DIR", "").strip()
+    override = os.environ.get(_STATE_DIR_ENV, "").strip()
     if override:
         return _expand_user(override)
+    if _profile_mode_requested():
+        return profile_home()
     return _home_dir() / ".opensquilla"
 
 

--- a/tests/test_cli/test_profile_env_loading.py
+++ b/tests/test_cli/test_profile_env_loading.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -117,3 +119,58 @@ def test_cli_profile_env_wins_over_legacy_home_for_same_key(
     assert result.exit_code == 0, result.output
     assert os.environ["PROFILE_SHARED_MARK"] == "coder"
     assert default_opensquilla_home() == profiles_root / "coder"
+
+
+def test_cli_profile_env_wins_on_cold_start_import(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    legacy_home = tmp_path / ".opensquilla"
+    legacy_home.mkdir()
+    (legacy_home / ".env").write_text("PROFILE_SHARED_MARK=legacy\n", encoding="utf-8")
+    profiles_root = tmp_path / "profiles"
+    _write_profile(profiles_root, "coder", ["PROFILE_SHARED_MARK=coder"])
+
+    env = os.environ.copy()
+    env.update({"HOME": str(tmp_path), "OPENSQUILLA_HOME": str(profiles_root)})
+    env.pop("OPENSQUILLA_PROFILE", None)
+    env.pop("OPENSQUILLA_STATE_DIR", None)
+    env.pop("PROFILE_SHARED_MARK", None)
+    pythonpath = [
+        str(repo_root / "src"),
+        str(repo_root),
+        env.get("PYTHONPATH", ""),
+    ]
+    env["PYTHONPATH"] = os.pathsep.join(path for path in pythonpath if path)
+
+    script = """
+import os
+import sys
+from typer.testing import CliRunner
+
+sys.argv = ["opensquilla", "--profile", "coder", "providers", "list", "--json"]
+from opensquilla.cli.main import app
+
+cold_start_mark = os.environ.get("PROFILE_SHARED_MARK", "")
+if cold_start_mark != "coder":
+    print(cold_start_mark)
+    raise SystemExit(2)
+
+result = CliRunner().invoke(app, ["--profile", "coder", "providers", "list", "--json"])
+if result.exit_code != 0:
+    print(result.output)
+    raise SystemExit(result.exit_code)
+
+print(os.environ.get("PROFILE_SHARED_MARK", ""))
+raise SystemExit(0 if os.environ.get("PROFILE_SHARED_MARK") == "coder" else 2)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_cli/test_profile_env_loading.py
+++ b/tests/test_cli/test_profile_env_loading.py
@@ -91,3 +91,29 @@ def test_env_load_uses_provided_home(monkeypatch, tmp_path: Path) -> None:
 
     assert load_env(home=home) >= 1
     assert os.environ["CUSTOM_MARK"] == "ok"
+
+
+def test_cli_profile_env_wins_over_legacy_home_for_same_key(
+    monkeypatch, tmp_path: Path
+) -> None:
+    profiles_root = tmp_path / "profiles"
+    legacy_home = tmp_path / ".opensquilla"
+    legacy_home.mkdir()
+    (legacy_home / ".env").write_text("PROFILE_SHARED_MARK=legacy\n", encoding="utf-8")
+    _write_profile(profiles_root, "coder", ["PROFILE_SHARED_MARK=coder"])
+
+    for key in (
+        "OPENSQUILLA_HOME",
+        "OPENSQUILLA_PROFILE",
+        "OPENSQUILLA_STATE_DIR",
+        "PROFILE_SHARED_MARK",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(profiles_root))
+
+    result = runner.invoke(app, ["--profile", "coder", "providers", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert os.environ["PROFILE_SHARED_MARK"] == "coder"
+    assert default_opensquilla_home() == profiles_root / "coder"

--- a/tests/test_cli/test_profile_env_loading.py
+++ b/tests/test_cli/test_profile_env_loading.py
@@ -1,0 +1,93 @@
+"""Regression tests for CLI profile resolution before home .env loading."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from opensquilla.cli.main import app
+from opensquilla.paths import default_opensquilla_home
+
+runner = CliRunner()
+
+
+def _write_profile(home: Path, name: str, env_lines: list[str]) -> Path:
+    profile_dir = home / name
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / ".env").write_text("\n".join(env_lines) + "\n", encoding="utf-8")
+    return profile_dir
+
+
+def test_cli_profile_loads_selected_profile_env(monkeypatch, tmp_path: Path) -> None:
+    home = tmp_path / "profiles"
+    _write_profile(home, "default", ["PROFILE_MARK=loaded-default"])
+    _write_profile(home, "coder", ["CODER_MARK=loaded-coder"])
+
+    for key in (
+        "OPENSQUILLA_HOME",
+        "OPENSQUILLA_PROFILE",
+        "OPENSQUILLA_STATE_DIR",
+        "PROFILE_MARK",
+        "CODER_MARK",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(home))
+
+    result = runner.invoke(app, ["--profile", "coder", "providers", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert os.environ["OPENSQUILLA_PROFILE"] == "coder"
+    assert os.environ["CODER_MARK"] == "loaded-coder"
+    assert "PROFILE_MARK" not in os.environ
+    assert default_opensquilla_home() == home / "coder"
+
+
+def test_cli_without_profile_keeps_legacy_home(monkeypatch, tmp_path: Path) -> None:
+    legacy_home = tmp_path / ".opensquilla"
+    legacy_home.mkdir()
+    (legacy_home / ".env").write_text("LEGACY_MARK=loaded\n", encoding="utf-8")
+
+    for key in (
+        "OPENSQUILLA_HOME",
+        "OPENSQUILLA_PROFILE",
+        "OPENSQUILLA_STATE_DIR",
+        "LEGACY_MARK",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = runner.invoke(app, ["providers", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert os.environ["LEGACY_MARK"] == "loaded"
+    assert default_opensquilla_home() == legacy_home
+
+
+def test_cli_rejects_invalid_profile(monkeypatch) -> None:
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+
+    result = runner.invoke(app, ["--profile", "../escape", "providers", "list"])
+
+    assert result.exit_code != 0
+    assert "lowercase letters" in result.output
+
+
+def test_env_load_uses_provided_home(monkeypatch, tmp_path: Path) -> None:
+    from opensquilla.env import load_env
+
+    home = tmp_path / "custom"
+    home.mkdir(parents=True)
+    (home / ".env").write_text("CUSTOM_MARK=ok\n", encoding="utf-8")
+
+    for key in (
+        "OPENSQUILLA_HOME",
+        "OPENSQUILLA_PROFILE",
+        "OPENSQUILLA_STATE_DIR",
+        "CUSTOM_MARK",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    assert load_env(home=home) >= 1
+    assert os.environ["CUSTOM_MARK"] == "ok"

--- a/tests/test_cli/test_profile_env_loading.py
+++ b/tests/test_cli/test_profile_env_loading.py
@@ -206,3 +206,55 @@ raise SystemExit(0 if os.environ.get("PROFILE_SHARED_MARK") == "coder" else 2)
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_cli_profile_from_cwd_env_wins_over_legacy_home_on_cold_start(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    (cwd / ".env").write_text("OPENSQUILLA_PROFILE=coder\n", encoding="utf-8")
+    legacy_home = tmp_path / ".opensquilla"
+    profiles_root = legacy_home / "profiles"
+    legacy_home.mkdir()
+    (legacy_home / ".env").write_text("PROFILE_SHARED_MARK=legacy\n", encoding="utf-8")
+    _write_profile(profiles_root, "coder", ["PROFILE_SHARED_MARK=coder"])
+
+    env = os.environ.copy()
+    env.update({"HOME": str(tmp_path)})
+    env.pop("OPENSQUILLA_HOME", None)
+    env.pop("OPENSQUILLA_PROFILE", None)
+    env.pop("OPENSQUILLA_STATE_DIR", None)
+    env.pop("PROFILE_SHARED_MARK", None)
+    pythonpath = [
+        str(repo_root / "src"),
+        str(repo_root),
+        env.get("PYTHONPATH", ""),
+    ]
+    env["PYTHONPATH"] = os.pathsep.join(path for path in pythonpath if path)
+
+    script = """
+import os
+from opensquilla.paths import default_opensquilla_home
+
+from opensquilla.cli.main import app
+
+if os.environ.get("PROFILE_SHARED_MARK") != "coder":
+    print(os.environ.get("PROFILE_SHARED_MARK", ""))
+    raise SystemExit(2)
+if default_opensquilla_home().name != "coder":
+    print(default_opensquilla_home())
+    raise SystemExit(3)
+raise SystemExit(0)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_cli/test_profile_env_loading.py
+++ b/tests/test_cli/test_profile_env_loading.py
@@ -98,8 +98,8 @@ def test_env_load_uses_provided_home(monkeypatch, tmp_path: Path) -> None:
 def test_cli_profile_env_wins_over_legacy_home_for_same_key(
     monkeypatch, tmp_path: Path
 ) -> None:
-    profiles_root = tmp_path / "profiles"
     legacy_home = tmp_path / ".opensquilla"
+    profiles_root = legacy_home / "profiles"
     legacy_home.mkdir()
     (legacy_home / ".env").write_text("PROFILE_SHARED_MARK=legacy\n", encoding="utf-8")
     _write_profile(profiles_root, "coder", ["PROFILE_SHARED_MARK=coder"])
@@ -112,7 +112,9 @@ def test_cli_profile_env_wins_over_legacy_home_for_same_key(
     ):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("OPENSQUILLA_HOME", str(profiles_root))
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
 
     result = runner.invoke(app, ["--profile", "coder", "providers", "list", "--json"])
 
@@ -126,13 +128,14 @@ def test_cli_profile_env_wins_on_cold_start_import(tmp_path: Path) -> None:
     cwd = tmp_path / "cwd"
     cwd.mkdir()
     legacy_home = tmp_path / ".opensquilla"
+    profiles_root = legacy_home / "profiles"
     legacy_home.mkdir()
     (legacy_home / ".env").write_text("PROFILE_SHARED_MARK=legacy\n", encoding="utf-8")
-    profiles_root = tmp_path / "profiles"
     _write_profile(profiles_root, "coder", ["PROFILE_SHARED_MARK=coder"])
 
     env = os.environ.copy()
-    env.update({"HOME": str(tmp_path), "OPENSQUILLA_HOME": str(profiles_root)})
+    env.update({"HOME": str(tmp_path)})
+    env.pop("OPENSQUILLA_HOME", None)
     env.pop("OPENSQUILLA_PROFILE", None)
     env.pop("OPENSQUILLA_STATE_DIR", None)
     env.pop("PROFILE_SHARED_MARK", None)

--- a/tests/test_cli/test_profile_env_loading.py
+++ b/tests/test_cli/test_profile_env_loading.py
@@ -67,6 +67,35 @@ def test_cli_without_profile_keeps_legacy_home(monkeypatch, tmp_path: Path) -> N
     assert default_opensquilla_home() == legacy_home
 
 
+def test_cli_does_not_reload_same_home_env_after_key_removed(
+    monkeypatch, tmp_path: Path
+) -> None:
+    legacy_home = tmp_path / ".opensquilla"
+    legacy_home.mkdir()
+    (legacy_home / ".env").write_text("RELOAD_MARK=loaded\n", encoding="utf-8")
+
+    for key in (
+        "OPENSQUILLA_HOME",
+        "OPENSQUILLA_PROFILE",
+        "OPENSQUILLA_STATE_DIR",
+        "RELOAD_MARK",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = runner.invoke(app, ["providers", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert os.environ["RELOAD_MARK"] == "loaded"
+
+    monkeypatch.delenv("RELOAD_MARK", raising=False)
+
+    result = runner.invoke(app, ["providers", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "RELOAD_MARK" not in os.environ
+
+
 def test_cli_rejects_invalid_profile(monkeypatch) -> None:
     monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
 

--- a/tests/test_paths_profile.py
+++ b/tests/test_paths_profile.py
@@ -1,0 +1,146 @@
+"""Tests for explicit OpenSquilla profile home resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from opensquilla.paths import (
+    default_opensquilla_home,
+    default_profile_name,
+    default_profiles_root,
+    is_valid_profile_name,
+    profile_home,
+    state_dir,
+)
+
+_VALID_NAMES = [
+    "default",
+    "agent-a",
+    "agent_a",
+    "a1",
+    "0",
+    "a" * 64,
+    "abc-123_xyz",
+]
+
+_INVALID_NAMES = [
+    "",
+    "-leading-dash",
+    "_leading-underscore",
+    "UPPER",
+    "MixedCase",
+    "with spaces",
+    "with/slash",
+    "with\\backslash",
+    "with..dot",
+    "a" * 65,
+    "../escape",
+    "name?q=1",
+    "中文",
+    "name!",
+    "name.with.dot",
+    "name'quote",
+    'name"quote',
+]
+
+
+@pytest.mark.parametrize("name", _VALID_NAMES)
+def test_is_valid_profile_name_accepts(name: str) -> None:
+    assert is_valid_profile_name(name)
+
+
+@pytest.mark.parametrize("name", _INVALID_NAMES)
+def test_is_valid_profile_name_rejects(name: str) -> None:
+    assert not is_valid_profile_name(name)
+
+
+def test_default_opensquilla_home_keeps_legacy_default(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_HOME", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_PROFILE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert default_opensquilla_home() == tmp_path / ".opensquilla"
+
+
+def test_default_profile_name_defaults_to_default(monkeypatch) -> None:
+    monkeypatch.delenv("OPENSQUILLA_PROFILE", raising=False)
+    assert default_profile_name() == "default"
+
+
+def test_default_profile_name_trims_whitespace(monkeypatch) -> None:
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "  agent-a  ")
+    assert default_profile_name() == "agent-a"
+
+
+def test_default_profiles_root_uses_env(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path / "profiles"))
+    assert default_profiles_root() == tmp_path / "profiles"
+
+
+def test_default_profiles_root_falls_back_under_legacy_home(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.delenv("OPENSQUILLA_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert default_profiles_root() == tmp_path / ".opensquilla" / "profiles"
+
+
+def test_default_profiles_root_expands_tilde(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OPENSQUILLA_HOME", "~/my-profiles")
+
+    assert default_profiles_root() == tmp_path / "my-profiles"
+
+
+def test_profile_home_rejects_path_traversal(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path / "profiles"))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "../escape")
+
+    with pytest.raises(ValueError, match="Invalid OpenSquilla profile name"):
+        profile_home()
+
+
+def test_state_dir_override_wins_over_profile(monkeypatch, tmp_path) -> None:
+    state_path = tmp_path / "pinned"
+    profile_root = tmp_path / "profiles"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(state_path))
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(profile_root))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "agent-a")
+
+    assert default_opensquilla_home() == state_path
+
+
+def test_explicit_profile_uses_profiles_root(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    profile_root = tmp_path / "profiles"
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(profile_root))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "agent-b")
+
+    assert default_opensquilla_home() == profile_root / "agent-b"
+
+
+def test_profile_without_home_uses_default_profiles_root(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_HOME", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "coder")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert default_opensquilla_home() == tmp_path / ".opensquilla" / "profiles" / "coder"
+
+
+def test_profile_state_dirs_are_isolated(monkeypatch, tmp_path) -> None:
+    profile_root = tmp_path / "profiles"
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(profile_root))
+
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "agent-a")
+    state_a = state_dir("agents", "main", "memory.db")
+
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "agent-b")
+    state_b = state_dir("agents", "main", "memory.db")
+
+    assert state_a == profile_root / "agent-a" / "state" / "agents" / "main" / "memory.db"
+    assert state_b == profile_root / "agent-b" / "state" / "agents" / "main" / "memory.db"
+    assert state_a != state_b

--- a/tests/unit/test_env.py
+++ b/tests/unit/test_env.py
@@ -78,3 +78,21 @@ def test_load_env_existing_environment_still_wins_in_test_env(monkeypatch, tmp_p
 
     assert env_mod.load_env(tmp_path) == 0
     assert env_mod.os.environ["OPENSQUILLA_ENV_TEST_KEY"] == "from-shell"
+
+
+def test_load_env_uses_explicit_home(monkeypatch, tmp_path) -> None:
+    default_home = tmp_path / "default-home"
+    explicit_home = tmp_path / "explicit-home"
+    _isolate_global_env(monkeypatch, default_home)
+    explicit_home.mkdir()
+    monkeypatch.delenv("OPENSQUILLA_ENV_TEST_KEY", raising=False)
+
+    (default_home / ".env").write_text(
+        "OPENSQUILLA_ENV_TEST_KEY=from-default\n", encoding="utf-8"
+    )
+    (explicit_home / ".env").write_text(
+        "OPENSQUILLA_ENV_TEST_KEY=from-explicit\n", encoding="utf-8"
+    )
+
+    assert env_mod.load_env(tmp_path, home=explicit_home) == 1
+    assert env_mod.os.environ["OPENSQUILLA_ENV_TEST_KEY"] == "from-explicit"


### PR DESCRIPTION
## Summary

This draft extracts the profile-home foundation from #210 into a small PR targeted at `main`.

Legacy behavior stays intact: when no profile is selected, OpenSquilla still resolves to `~/.opensquilla`. Explicit profile mode is only activated by `--profile`, `OPENSQUILLA_PROFILE`, or `OPENSQUILLA_HOME`; `OPENSQUILLA_STATE_DIR` remains the highest-precedence state-root override.

## Changes

- Add profile-name validation and profile home helpers in `opensquilla.paths`.
- Add `load_env(home=...)` so profile-specific `.env` files can be loaded after the profile is resolved.
- Load cwd `.env/.env.test` before resolving the active OpenSquilla home, so `OPENSQUILLA_PROFILE` or `OPENSQUILLA_HOME` selected from local env does not accidentally load legacy-home secrets first.
- Add a top-level CLI `--profile` option while preserving import-time env loading before subcommand imports.
- Avoid reloading the same `(cwd, home)` env context repeatedly in one CLI process, which prevents tests or embedded CLI runners from rehydrating env keys that were intentionally cleared.
- Add regression tests for profile path isolation, profile `.env` loading order, local-env profile activation, and same-context env reload behavior.

## Stability

This PR does not migrate existing users out of `~/.opensquilla`, does not start background services, and does not change provider defaults. It only adds an explicit opt-in profile path.

## Attribution

Extracted from #210, originally contributed by @tqangxl.

Relevant original commits:

- 9ef343925f637b0659f87262679894a4c5fdb97d - Add multi-instance profile support
- 9f4e98ce8531c528511b1ed6538934be34907240 - Rename OPENSQUILLA_PROFILES_DIR to OPENSQUILLA_HOME
- e22e5113afff1cda76c345331cd8d73f504441a6 - Address Open-Squilla review on PR #194

The extracted contribution commit includes `Co-authored-by: Tqangxl <tqangxl@gmail.com>`. Follow-up stabilization commits are maintainer-side test/fix commits.

## Validation

Restacked on `origin/main@ae5e6f10` on 2026-07-03.

- `uv run pytest -q tests/test_paths_profile.py tests/test_cli/test_profile_env_loading.py tests/unit/test_env.py tests/test_cli/test_gateway_cmd.py tests/test_paths_media_root.py tests/test_cli/test_onboard_cmd.py::test_configure_search_can_use_env_key_reference tests/test_cli/test_search_cmd.py::test_search_configure_warns_when_env_key_is_not_set` - 92 passed
- On the top stacked branch (#431): `uv run pytest -q tests/test_paths_profile.py tests/test_cli/test_profile_env_loading.py tests/unit/test_env.py tests/test_cli/test_gateway_cmd.py tests/test_paths_media_root.py tests/test_supervisor_scripts.py tests/test_cli/test_autostart.py tests/test_cli/test_init_cmd.py tests/test_cli/test_onboard_cmd.py::test_configure_search_can_use_env_key_reference tests/test_cli/test_search_cmd.py::test_search_configure_warns_when_env_key_is_not_set` - 115 passed
- `uv run ruff check ...` for the touched Python files and tests - passed
- `git diff --check origin/main..HEAD` on the top stacked branch - passed
- GitHub CI for this PR completed successfully after the latest push.

## Notes

This deliberately does not include the automatic legacy-home migration from #210. That migration changes every default user path and should be reviewed separately, if we still want it.
