### PR TITLE
Add Windows profile supervisor scripts

### DIFF
--- a/scripts/supervisor/README.md
+++ b/scripts/supervisor/README.md
@@ -1,0 +1,33 @@
+# Windows Profile Supervisor
+
+These scripts are a Windows-only helper for running every explicit OpenSquilla
+profile under one profiles root.
+
+They are intended to be used after profile support is available:
+
+```powershell
+opensquilla --profile coder init
+opensquilla --profile planner init
+.\scripts\supervisor\start-all.ps1
+```
+
+By default the profiles root is:
+
+```text
+%USERPROFILE%\.opensquilla\profiles
+```
+
+You can override it with `-ProfilesRoot` or `OPENSQUILLA_HOME`.
+
+Common commands:
+
+```powershell
+.\scripts\supervisor\start-all.ps1 -ProfilesRoot D:\OpenSquilla\profiles
+.\scripts\supervisor\status.ps1 -ProfilesRoot D:\OpenSquilla\profiles
+.\scripts\supervisor\stop-all.ps1 -ProfilesRoot D:\OpenSquilla\profiles
+.\scripts\supervisor\install-autostart.ps1 -ProfilesRoot D:\OpenSquilla\profiles
+.\scripts\supervisor\uninstall-autostart.ps1
+```
+
+`install-autostart.ps1` registers a per-user Task Scheduler entry that runs at
+interactive logon. It does not require administrator privileges.

--- a/scripts/supervisor/install-autostart.ps1
+++ b/scripts/supervisor/install-autostart.ps1
@@ -1,0 +1,98 @@
+<#
+.SYNOPSIS
+    Register start-all.ps1 with Windows Task Scheduler at user logon.
+#>
+[CmdletBinding()]
+param(
+    [string] $ProfilesRoot,
+    [int] $BasePort = 18791,
+    [string] $TaskName = 'OpenSquillaProfileSupervisor',
+    [string] $Repo
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+if (-not (Get-Command schtasks.exe -ErrorAction SilentlyContinue)) {
+    throw 'schtasks.exe not found. This script only runs on Windows.'
+}
+
+$root = Get-ProfilesRoot -Override $ProfilesRoot
+$startAll = Join-Path $PSScriptRoot 'start-all.ps1'
+
+$commandParts = @(
+    '&',
+    (ConvertTo-PowerShellSingleQuotedLiteral $startAll),
+    '-ProfilesRoot',
+    (ConvertTo-PowerShellSingleQuotedLiteral $root),
+    '-BasePort',
+    [string]$BasePort,
+    '-SkipRunning'
+)
+if ($Repo) {
+    $commandParts += @('-Repo', (ConvertTo-PowerShellSingleQuotedLiteral $Repo))
+}
+$command = $commandParts -join ' '
+
+$encoded = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($command))
+$arguments = "-NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded"
+$escapedRoot = ConvertTo-XmlEscapedText $root
+$escapedUser = ConvertTo-XmlEscapedText "$env:USERDOMAIN\$env:USERNAME"
+$escapedAuthor = ConvertTo-XmlEscapedText $env:USERNAME
+$escapedArguments = ConvertTo-XmlEscapedText $arguments
+
+$taskXml = @"
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Author>$escapedAuthor</Author>
+    <Description>Auto-start every OpenSquilla profile gateway under $escapedRoot at user logon.</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>$escapedUser</UserId>
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>Parallel</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <ExecutionTimeLimit>PT10M</ExecutionTimeLimit>
+    <Priority>7</Priority>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>powershell.exe</Command>
+      <Arguments>$escapedArguments</Arguments>
+    </Exec>
+  </Actions>
+</Task>
+"@
+
+$safeTaskName = ($TaskName -replace '[^a-zA-Z0-9_.-]', '_')
+$xmlPath = Join-Path $env:TEMP "opensquilla-supervisor-$safeTaskName.xml"
+[System.IO.File]::WriteAllText($xmlPath, $taskXml, [System.Text.Encoding]::Unicode)
+
+try {
+    $proc = Start-Process -FilePath schtasks.exe `
+        -ArgumentList @('/Create', '/TN', $TaskName, '/XML', $xmlPath, '/F') `
+        -NoNewWindow -Wait -PassThru
+    if ($proc.ExitCode -ne 0) {
+        throw "schtasks /Create exited with code $($proc.ExitCode)"
+    }
+    Write-Status "Registered task '$TaskName' to run start-all.ps1 at logon." -Level ok
+    Write-Status "Profiles root: $root" -Level info
+    Write-Status "Base port: $BasePort" -Level info
+} finally {
+    Remove-Item -LiteralPath $xmlPath -ErrorAction SilentlyContinue
+}

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -1,0 +1,223 @@
+<#
+.SYNOPSIS
+    Shared helpers for OpenSquilla Windows multi-profile supervisor scripts.
+
+.DESCRIPTION
+    These helpers keep the Windows Task Scheduler wrapper thin: discover
+    profile directories, allocate stable ports, resolve how to invoke
+    OpenSquilla, and run a CLI command under one selected profile.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+if (Get-Variable -Name OPENSQUILLA_SUPERVISOR_LIB_LOADED -Scope Script -ErrorAction SilentlyContinue) {
+    return
+}
+$Script:OPENSQUILLA_SUPERVISOR_LIB_LOADED = $true
+
+$Script:DEFAULT_BASE_PORT = 18791
+$Script:TASK_NAME = 'OpenSquillaProfileSupervisor'
+$Script:DISPLAY_NAME = 'OpenSquilla Multi-Profile Gateway Supervisor'
+$Script:PROFILE_NAME_PATTERN = '^[a-z0-9][a-z0-9_-]{0,63}$'
+
+function Get-DefaultProfilesRoot {
+    $userProfile = [Environment]::GetFolderPath('UserProfile')
+    if (-not $userProfile) {
+        $userProfile = $HOME
+    }
+    return (Join-Path $userProfile '.opensquilla\profiles')
+}
+
+function Get-ProfilesRoot {
+    param([string]$Override)
+
+    $candidate = if ($Override) {
+        $Override
+    } elseif ($env:OPENSQUILLA_HOME) {
+        $env:OPENSQUILLA_HOME
+    } else {
+        Get-DefaultProfilesRoot
+    }
+
+    if (-not $candidate) {
+        throw 'Profiles root is empty. Pass -ProfilesRoot or set OPENSQUILLA_HOME.'
+    }
+    if (-not (Test-Path -LiteralPath $candidate -PathType Container)) {
+        throw "Profiles root does not exist: $candidate"
+    }
+    return (Resolve-Path -LiteralPath $candidate).Path
+}
+
+function Test-ProfileName {
+    param([Parameter(Mandatory)] [string] $Name)
+    return [bool]($Name -match $Script:PROFILE_NAME_PATTERN)
+}
+
+function Get-OpensquillaRoot {
+    param([string]$Override)
+
+    if ($Override) {
+        if (-not (Test-Path -LiteralPath $Override -PathType Container)) {
+            throw "OpenSquilla repo not found: $Override. Pass -Repo or omit to auto-detect."
+        }
+        return (Resolve-Path -LiteralPath $Override).Path
+    }
+
+    if ($PSScriptRoot) {
+        $candidate = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+        if (Test-Path -LiteralPath (Join-Path $candidate 'pyproject.toml') -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+
+    return $null
+}
+
+function Get-OpensquillaCommand {
+    param([string]$Repo)
+
+    $installed = Get-Command 'opensquilla' -ErrorAction SilentlyContinue
+    if ($installed) {
+        return @{ Mode = 'installed'; Exe = $installed.Path }
+    }
+
+    $resolvedRepo = Get-OpensquillaRoot -Override $Repo
+    if ($resolvedRepo -and (Test-Path -LiteralPath (Join-Path $resolvedRepo 'pyproject.toml') -PathType Leaf)) {
+        return @{ Mode = 'uv-run-repo'; Repo = $resolvedRepo }
+    }
+
+    return @{ Mode = 'none' }
+}
+
+function Get-ProfileEntries {
+    param([Parameter(Mandatory)] [string] $ProfilesRoot)
+
+    if (-not (Test-Path -LiteralPath $ProfilesRoot -PathType Container)) {
+        return @()
+    }
+
+    $entries = Get-ChildItem -LiteralPath $ProfilesRoot -Directory -ErrorAction SilentlyContinue |
+        Where-Object { Test-ProfileName -Name $_.Name } |
+        Sort-Object Name
+
+    $results = @()
+    foreach ($entry in $entries) {
+        $configPath = Join-Path $entry.FullName 'config.toml'
+        $results += [pscustomobject]@{
+            Name = $entry.Name
+            Path = $entry.FullName
+            ConfigPath = $configPath
+            HasConfig = Test-Path -LiteralPath $configPath -PathType Leaf
+        }
+    }
+    return ,$results
+}
+
+function Get-ProfilePort {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [int] $BasePort,
+        [Parameter(Mandatory)] [string] $ProfilesRoot
+    )
+
+    $index = 0
+    foreach ($sibling in (Get-ProfileEntries -ProfilesRoot $ProfilesRoot)) {
+        if ($sibling.Name -eq $Name) {
+            return [int]($BasePort + $index)
+        }
+        $index += 1
+    }
+    return [int]$BasePort
+}
+
+function Write-Status {
+    param(
+        [string] $Message,
+        [ValidateSet('info', 'ok', 'warn', 'err')] [string] $Level = 'info'
+    )
+
+    $prefix = switch ($Level) {
+        'ok' { '[OK]   ' }
+        'warn' { '[WARN] ' }
+        'err' { '[ERR]  ' }
+        default { '[..]   ' }
+    }
+    $color = switch ($Level) {
+        'ok' { 'Green' }
+        'warn' { 'Yellow' }
+        'err' { 'Red' }
+        default { 'Cyan' }
+    }
+    Write-Host ($prefix + $Message) -ForegroundColor $color
+}
+
+function Invoke-Opensquilla {
+    param(
+        [string] $Repo,
+        [Parameter(Mandatory)] [string] $Profile,
+        [Parameter(Mandatory)] [string[]] $Arguments,
+        [switch] $CaptureOutput
+    )
+
+    $profileLeaf = Split-Path -Leaf $Profile
+    $profileRoot = Split-Path -Parent $Profile
+    if (-not (Test-ProfileName -Name $profileLeaf)) {
+        throw "Invalid OpenSquilla profile name: $profileLeaf"
+    }
+
+    $previousHome = $env:OPENSQUILLA_HOME
+    $previousProfile = $env:OPENSQUILLA_PROFILE
+    $env:OPENSQUILLA_HOME = $profileRoot
+    $env:OPENSQUILLA_PROFILE = $profileLeaf
+
+    try {
+        $cmd = Get-OpensquillaCommand -Repo $Repo
+        switch ($cmd.Mode) {
+            'installed' {
+                if ($CaptureOutput) {
+                    $output = & $cmd.Exe @Arguments 2>$null
+                    return @{ ExitCode = $LASTEXITCODE; Output = $output }
+                }
+                & $cmd.Exe @Arguments
+                return @{ ExitCode = $LASTEXITCODE; Output = $null }
+            }
+            'uv-run-repo' {
+                Push-Location -LiteralPath $cmd.Repo
+                try {
+                    if ($CaptureOutput) {
+                        $output = & uv run opensquilla @Arguments 2>$null
+                        return @{ ExitCode = $LASTEXITCODE; Output = $output }
+                    }
+                    & uv run opensquilla @Arguments
+                    return @{ ExitCode = $LASTEXITCODE; Output = $null }
+                } finally {
+                    Pop-Location
+                }
+            }
+            default {
+                throw 'opensquilla is not on PATH and no source checkout was auto-detected next to this script. Install OpenSquilla or pass -Repo.'
+            }
+        }
+    } finally {
+        if ($null -eq $previousHome) {
+            Remove-Item Env:\OPENSQUILLA_HOME -ErrorAction SilentlyContinue
+        } else {
+            $env:OPENSQUILLA_HOME = $previousHome
+        }
+        if ($null -eq $previousProfile) {
+            Remove-Item Env:\OPENSQUILLA_PROFILE -ErrorAction SilentlyContinue
+        } else {
+            $env:OPENSQUILLA_PROFILE = $previousProfile
+        }
+    }
+}
+
+function ConvertTo-PowerShellSingleQuotedLiteral {
+    param([Parameter(Mandatory)] [string] $Value)
+    return "'" + ($Value -replace "'", "''") + "'"
+}
+
+function ConvertTo-XmlEscapedText {
+    param([Parameter(Mandatory)] [string] $Value)
+    return [System.Security.SecurityElement]::Escape($Value)
+}

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -175,8 +175,10 @@ function Invoke-Opensquilla {
 
     $previousHome = $env:OPENSQUILLA_HOME
     $previousProfile = $env:OPENSQUILLA_PROFILE
+    $previousStateDir = $env:OPENSQUILLA_STATE_DIR
     $env:OPENSQUILLA_HOME = $profileRoot
     $env:OPENSQUILLA_PROFILE = $profileLeaf
+    Remove-Item Env:\OPENSQUILLA_STATE_DIR -ErrorAction SilentlyContinue
 
     try {
         $cmd = Get-OpensquillaCommand -Repo $Repo
@@ -216,6 +218,11 @@ function Invoke-Opensquilla {
             Remove-Item Env:\OPENSQUILLA_PROFILE -ErrorAction SilentlyContinue
         } else {
             $env:OPENSQUILLA_PROFILE = $previousProfile
+        }
+        if ($null -eq $previousStateDir) {
+            Remove-Item Env:\OPENSQUILLA_STATE_DIR -ErrorAction SilentlyContinue
+        } else {
+            $env:OPENSQUILLA_STATE_DIR = $previousStateDir
         }
     }
 }

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -50,7 +50,7 @@ function Get-ProfilesRoot {
 
 function Test-ProfileName {
     param([Parameter(Mandatory)] [string] $Name)
-    return [bool]($Name -match $Script:PROFILE_NAME_PATTERN)
+    return [bool]($Name -cmatch $Script:PROFILE_NAME_PATTERN)
 }
 
 function Get-OpensquillaRoot {

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -19,6 +19,7 @@ $Script:DEFAULT_BASE_PORT = 18791
 $Script:TASK_NAME = 'OpenSquillaProfileSupervisor'
 $Script:DISPLAY_NAME = 'OpenSquilla Multi-Profile Gateway Supervisor'
 $Script:PROFILE_NAME_PATTERN = '^[a-z0-9][a-z0-9_-]{0,63}$'
+$Script:PORT_FILE_NAME = 'supervisor-port.txt'
 
 function Get-DefaultProfilesRoot {
     $userProfile = [Environment]::GetFolderPath('UserProfile')
@@ -128,14 +129,63 @@ function Get-ProfilePort {
         [Parameter(Mandatory)] [string] $ProfilesRoot
     )
 
-    $index = 0
-    foreach ($sibling in (Get-ProfileEntries -ProfilesRoot $ProfilesRoot)) {
-        if ($sibling.Name -eq $Name) {
-            return [int]($BasePort + $index)
-        }
-        $index += 1
+    if (-not (Test-ProfileName -Name $Name)) {
+        throw "Invalid OpenSquilla profile name: $Name"
     }
-    return [int]$BasePort
+
+    $profilePath = Join-Path $ProfilesRoot $Name
+    if (-not (Test-Path -LiteralPath $profilePath -PathType Container)) {
+        throw "Profile does not exist: $profilePath"
+    }
+
+    $portFile = Get-ProfilePortFile -ProfilePath $profilePath
+    $existing = Read-ProfilePortFile -PortFile $portFile
+    if ($null -ne $existing) {
+        return [int]$existing
+    }
+
+    $used = Get-UsedProfilePorts -ProfilesRoot $ProfilesRoot
+    $candidate = [int]$BasePort
+    while ($used.ContainsKey($candidate)) {
+        $candidate += 1
+    }
+
+    Set-Content -LiteralPath $portFile -Value ([string]$candidate) -Encoding ASCII
+    return [int]$candidate
+}
+
+function Get-ProfilePortFile {
+    param([Parameter(Mandatory)] [string] $ProfilePath)
+    return (Join-Path $ProfilePath $Script:PORT_FILE_NAME)
+}
+
+function Read-ProfilePortFile {
+    param([Parameter(Mandatory)] [string] $PortFile)
+
+    if (-not (Test-Path -LiteralPath $PortFile -PathType Leaf)) {
+        return $null
+    }
+
+    $raw = (Get-Content -LiteralPath $PortFile -Raw -ErrorAction Stop).Trim()
+    $port = 0
+    if ([int]::TryParse($raw, [ref]$port) -and $port -gt 0 -and $port -lt 65536) {
+        return [int]$port
+    }
+    return $null
+}
+
+function Get-UsedProfilePorts {
+    param([Parameter(Mandatory)] [string] $ProfilesRoot)
+
+    $used = @{}
+    foreach ($entry in (Get-ProfileEntries -ProfilesRoot $ProfilesRoot)) {
+        $portFile = Get-ProfilePortFile -ProfilePath $entry.Path
+        $port = Read-ProfilePortFile -PortFile $portFile
+        if ($null -ne $port) {
+            $used[[int]$port] = $true
+        }
+    }
+    return $used
 }
 
 function Write-Status {

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -76,12 +76,19 @@ function Get-OpensquillaRoot {
 function Get-OpensquillaCommand {
     param([string]$Repo)
 
+    if ($Repo) {
+        $resolvedRepo = Get-OpensquillaRoot -Override $Repo
+        if ($resolvedRepo -and (Test-Path -LiteralPath (Join-Path $resolvedRepo 'pyproject.toml') -PathType Leaf)) {
+            return @{ Mode = 'uv-run-repo'; Repo = $resolvedRepo }
+        }
+    }
+
     $installed = Get-Command 'opensquilla' -ErrorAction SilentlyContinue
     if ($installed) {
         return @{ Mode = 'installed'; Exe = $installed.Path }
     }
 
-    $resolvedRepo = Get-OpensquillaRoot -Override $Repo
+    $resolvedRepo = Get-OpensquillaRoot -Override $null
     if ($resolvedRepo -and (Test-Path -LiteralPath (Join-Path $resolvedRepo 'pyproject.toml') -PathType Leaf)) {
         return @{ Mode = 'uv-run-repo'; Repo = $resolvedRepo }
     }

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -81,6 +81,7 @@ function Get-OpensquillaCommand {
         if ($resolvedRepo -and (Test-Path -LiteralPath (Join-Path $resolvedRepo 'pyproject.toml') -PathType Leaf)) {
             return @{ Mode = 'uv-run-repo'; Repo = $resolvedRepo }
         }
+        throw "OpenSquilla repo lacks pyproject.toml: $resolvedRepo"
     }
 
     $installed = Get-Command 'opensquilla' -ErrorAction SilentlyContinue

--- a/scripts/supervisor/start-all.ps1
+++ b/scripts/supervisor/start-all.ps1
@@ -1,0 +1,74 @@
+<#
+.SYNOPSIS
+    Start every OpenSquilla profile gateway under a Windows profiles root.
+#>
+[CmdletBinding()]
+param(
+    [string] $ProfilesRoot,
+    [int] $BasePort = 18791,
+    [string] $BindHost = '127.0.0.1',
+    [switch] $SkipRunning,
+    [string] $Repo
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+$root = Get-ProfilesRoot -Override $ProfilesRoot
+$cmd = Get-OpensquillaCommand -Repo $Repo
+$entries = Get-ProfileEntries -ProfilesRoot $root
+
+if (-not $entries -or $entries.Count -eq 0) {
+    Write-Status "No profiles found under $root. Run opensquilla --profile <name> init first." -Level warn
+    return
+}
+
+Write-Status "Discovered $($entries.Count) profile(s) under $root" -Level info
+Write-Status "Base port: $BasePort" -Level info
+switch ($cmd.Mode) {
+    'installed' { Write-Status "Mode: installed opensquilla at $($cmd.Exe)" -Level info }
+    'uv-run-repo' { Write-Status "Mode: uv run from $($cmd.Repo)" -Level info }
+    default { Write-Status 'Mode: no opensquilla found; set PATH or pass -Repo' -Level err }
+}
+Write-Host ''
+
+$started = 0
+$skipped = 0
+$failed = 0
+
+foreach ($entry in $entries) {
+    $port = Get-ProfilePort -Name $entry.Name -BasePort $BasePort -ProfilesRoot $root
+    Write-Status ("[{0}] starting on port {1} ..." -f $entry.Name, $port)
+    try {
+        if ($SkipRunning) {
+            $statusArgs = @('--profile', $entry.Name, 'gateway', 'status', '--listen', $BindHost, '--port', [string]$port, '--json')
+            $status = Invoke-Opensquilla -Repo $Repo -Profile $entry.Path -Arguments $statusArgs -CaptureOutput
+            if ($status.ExitCode -eq 0) {
+                Write-Status ("[{0}] already running on port {1}; skipped" -f $entry.Name, $port) -Level ok
+                $skipped += 1
+                continue
+            }
+        }
+
+        $startArgs = @('--profile', $entry.Name, 'gateway', 'start', '--listen', $BindHost, '--port', [string]$port)
+        $result = Invoke-Opensquilla -Repo $Repo -Profile $entry.Path -Arguments $startArgs
+        if ($result.ExitCode -eq 0) {
+            Write-Status ("[{0}] up on port {1}" -f $entry.Name, $port) -Level ok
+            $started += 1
+        } else {
+            Write-Status ("[{0}] start failed (exit={1})" -f $entry.Name, $result.ExitCode) -Level err
+            $failed += 1
+        }
+    } catch {
+        Write-Status ("[{0}] threw: {1}" -f $entry.Name, $_.Exception.Message) -Level err
+        $failed += 1
+    }
+}
+
+Write-Host ''
+$summaryLevel = if ($failed -eq 0) { 'ok' } else { 'warn' }
+Write-Status ("Summary: started={0} skipped={1} failed={2}" -f $started, $skipped, $failed) -Level $summaryLevel
+
+if ($failed -gt 0) {
+    exit 1
+}

--- a/scripts/supervisor/start-all.ps1
+++ b/scripts/supervisor/start-all.ps1
@@ -43,7 +43,11 @@ foreach ($entry in $entries) {
         if ($SkipRunning) {
             $statusArgs = @('--profile', $entry.Name, 'gateway', 'status', '--listen', $BindHost, '--port', [string]$port, '--json')
             $status = Invoke-Opensquilla -Repo $Repo -Profile $entry.Path -Arguments $statusArgs -CaptureOutput
-            if ($status.ExitCode -eq 0) {
+            $parsed = $null
+            if ($status.Output) {
+                $parsed = $status.Output | ConvertFrom-Json -ErrorAction SilentlyContinue
+            }
+            if ($parsed -and [string]$parsed.state -eq 'running') {
                 Write-Status ("[{0}] already running on port {1}; skipped" -f $entry.Name, $port) -Level ok
                 $skipped += 1
                 continue

--- a/scripts/supervisor/status.ps1
+++ b/scripts/supervisor/status.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+    Show one status row per OpenSquilla profile gateway.
+#>
+[CmdletBinding()]
+param(
+    [string] $ProfilesRoot,
+    [int] $BasePort = 18791,
+    [string] $BindHost = '127.0.0.1',
+    [string] $Repo
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+$root = Get-ProfilesRoot -Override $ProfilesRoot
+$entries = Get-ProfileEntries -ProfilesRoot $root
+
+if (-not $entries -or $entries.Count -eq 0) {
+    Write-Status "No profiles found under $root." -Level warn
+    return
+}
+
+$rows = @()
+foreach ($entry in $entries) {
+    $port = Get-ProfilePort -Name $entry.Name -BasePort $BasePort -ProfilesRoot $root
+    $statusArgs = @('--profile', $entry.Name, 'gateway', 'status', '--listen', $BindHost, '--port', [string]$port, '--json')
+    $result = Invoke-Opensquilla -Repo $Repo -Profile $entry.Path -Arguments $statusArgs -CaptureOutput
+    $parsed = $null
+    if ($result.Output) {
+        $parsed = $result.Output | ConvertFrom-Json -ErrorAction SilentlyContinue
+    }
+
+    if ($parsed) {
+        $rows += [pscustomobject]@{
+            Profile = $entry.Name
+            State = [string]$parsed.state
+            Port = [int]$parsed.port
+            Host = [string]$parsed.host
+            Pid = if ($parsed.pid) { [int]$parsed.pid } else { '-' }
+            Log = [string]$parsed.logPath
+        }
+    } else {
+        $rows += [pscustomobject]@{
+            Profile = $entry.Name
+            State = 'unknown'
+            Port = $port
+            Host = '-'
+            Pid = '-'
+            Log = '-'
+        }
+    }
+}
+
+function Format-OpenSquillaTable {
+    param([object[]] $Data)
+
+    $cols = 'Profile', 'State', 'Port', 'Host', 'Pid', 'Log'
+    $widths = @{}
+    foreach ($col in $cols) {
+        $widths[$col] = $col.Length
+    }
+    foreach ($row in $Data) {
+        foreach ($col in $cols) {
+            $value = [string]$row.$col
+            if ($value.Length -gt $widths[$col]) {
+                $widths[$col] = $value.Length
+            }
+        }
+    }
+
+    $header = ($cols | ForEach-Object { $_.PadRight($widths[$_]) }) -join '  '
+    Write-Host $header -ForegroundColor Cyan
+    Write-Host ('-' * $header.Length) -ForegroundColor DarkGray
+    foreach ($row in $Data) {
+        $line = ($cols | ForEach-Object { ([string]$row.$_).PadRight($widths[$_]) }) -join '  '
+        $color = switch ($row.State) {
+            'running' { 'Green' }
+            'unhealthy' { 'Red' }
+            'not_started' { 'DarkGray' }
+            default { 'Yellow' }
+        }
+        Write-Host $line -ForegroundColor $color
+    }
+}
+
+Format-OpenSquillaTable -Data $rows
+
+$misconfigured = $rows | Where-Object { $_.State -notin @('running', 'not_started') }
+if ($misconfigured.Count -gt 0) {
+    Write-Status ("{0} profile(s) need attention" -f $misconfigured.Count) -Level warn
+    exit 1
+}

--- a/scripts/supervisor/stop-all.ps1
+++ b/scripts/supervisor/stop-all.ps1
@@ -1,0 +1,53 @@
+<#
+.SYNOPSIS
+    Stop every OpenSquilla profile gateway under a Windows profiles root.
+#>
+[CmdletBinding()]
+param(
+    [string] $ProfilesRoot,
+    [int] $BasePort = 18791,
+    [string] $BindHost = '127.0.0.1',
+    [string] $Repo
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+$root = Get-ProfilesRoot -Override $ProfilesRoot
+$entries = Get-ProfileEntries -ProfilesRoot $root
+
+if (-not $entries -or $entries.Count -eq 0) {
+    Write-Status "No profiles found under $root." -Level warn
+    return
+}
+
+$stopped = 0
+$skipped = 0
+$failed = 0
+
+foreach ($entry in $entries) {
+    $port = Get-ProfilePort -Name $entry.Name -BasePort $BasePort -ProfilesRoot $root
+    Write-Status ("[{0}] stopping on port {1} ..." -f $entry.Name, $port)
+    try {
+        $stopArgs = @('--profile', $entry.Name, 'gateway', 'stop', '--listen', $BindHost, '--port', [string]$port)
+        $result = Invoke-Opensquilla -Repo $Repo -Profile $entry.Path -Arguments $stopArgs
+        if ($result.ExitCode -eq 0) {
+            Write-Status ("[{0}] stopped" -f $entry.Name) -Level ok
+            $stopped += 1
+        } else {
+            Write-Status ("[{0}] not running (exit={1})" -f $entry.Name, $result.ExitCode) -Level ok
+            $skipped += 1
+        }
+    } catch {
+        Write-Status ("[{0}] threw: {1}" -f $entry.Name, $_.Exception.Message) -Level err
+        $failed += 1
+    }
+}
+
+Write-Host ''
+$summaryLevel = if ($failed -eq 0) { 'ok' } else { 'warn' }
+Write-Status ("Summary: stopped={0} skipped={1} failed={2}" -f $stopped, $skipped, $failed) -Level $summaryLevel
+
+if ($failed -gt 0) {
+    exit 1
+}

--- a/scripts/supervisor/uninstall-autostart.ps1
+++ b/scripts/supervisor/uninstall-autostart.ps1
@@ -1,0 +1,31 @@
+<#
+.SYNOPSIS
+    Remove the OpenSquilla multi-profile supervisor from Task Scheduler.
+#>
+[CmdletBinding()]
+param(
+    [string] $TaskName = 'OpenSquillaProfileSupervisor'
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+if (-not (Get-Command schtasks.exe -ErrorAction SilentlyContinue)) {
+    throw 'schtasks.exe not found. This script only runs on Windows.'
+}
+
+$query = Start-Process -FilePath schtasks.exe `
+    -ArgumentList @('/Query', '/TN', $TaskName) `
+    -NoNewWindow -Wait -PassThru
+if ($query.ExitCode -ne 0) {
+    Write-Status "Task '$TaskName' is not registered; nothing to do." -Level warn
+    return
+}
+
+$delete = Start-Process -FilePath schtasks.exe `
+    -ArgumentList @('/Delete', '/TN', $TaskName, '/F') `
+    -NoNewWindow -Wait -PassThru
+if ($delete.ExitCode -ne 0) {
+    throw "schtasks /Delete exited with code $($delete.ExitCode)"
+}
+Write-Status "Removed task '$TaskName'." -Level ok

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -31,3 +31,10 @@ def test_task_scheduler_registration_uses_encoded_command() -> None:
     assert "-EncodedCommand" in text
     assert "ConvertTo-PowerShellSingleQuotedLiteral" in text
     assert "ConvertTo-XmlEscapedText" in text
+
+
+def test_supervisor_profile_name_match_is_case_sensitive() -> None:
+    lib = (SUPERVISOR / "lib.ps1").read_text(encoding="utf-8")
+
+    assert "-cmatch $Script:PROFILE_NAME_PATTERN" in lib
+    assert "-match $Script:PROFILE_NAME_PATTERN" not in lib

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -74,3 +74,11 @@ def test_supervisor_profile_invocation_masks_inherited_state_dir() -> None:
         < lib.index(resolve_command)
     )
     assert lib.index(resolve_command) < lib.index(restore_state_dir)
+
+
+def test_supervisor_skip_running_checks_gateway_state_not_exit_code() -> None:
+    start_all = (SUPERVISOR / "start-all.ps1").read_text(encoding="utf-8")
+
+    assert "ConvertFrom-Json -ErrorAction SilentlyContinue" in start_all
+    assert "[string]$parsed.state -eq 'running'" in start_all
+    assert "if ($status.ExitCode -eq 0)" not in start_all

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -82,3 +82,13 @@ def test_supervisor_skip_running_checks_gateway_state_not_exit_code() -> None:
     assert "ConvertFrom-Json -ErrorAction SilentlyContinue" in start_all
     assert "[string]$parsed.state -eq 'running'" in start_all
     assert "if ($status.ExitCode -eq 0)" not in start_all
+
+
+def test_supervisor_ports_are_persisted_per_profile() -> None:
+    lib = (SUPERVISOR / "lib.ps1").read_text(encoding="utf-8")
+
+    assert "$Script:PORT_FILE_NAME = 'supervisor-port.txt'" in lib
+    assert "Get-ProfilePortFile" in lib
+    assert "Get-UsedProfilePorts" in lib
+    assert "Set-Content -LiteralPath $portFile" in lib
+    assert "$BasePort + $index" not in lib

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -53,3 +53,24 @@ def test_supervisor_explicit_repo_takes_precedence_over_installed_binary() -> No
     assert auto_detect in lib
     assert lib.index(repo_branch) < lib.index(explicit_error) < lib.index(installed_lookup)
     assert lib.index(installed_lookup) < lib.index(auto_detect)
+
+
+def test_supervisor_profile_invocation_masks_inherited_state_dir() -> None:
+    lib = (SUPERVISOR / "lib.ps1").read_text(encoding="utf-8")
+
+    save_state_dir = "$previousStateDir = $env:OPENSQUILLA_STATE_DIR"
+    clear_state_dir = r"Remove-Item Env:\OPENSQUILLA_STATE_DIR -ErrorAction SilentlyContinue"
+    restore_state_dir = "$env:OPENSQUILLA_STATE_DIR = $previousStateDir"
+    set_profile = "$env:OPENSQUILLA_PROFILE = $profileLeaf"
+    resolve_command = "$cmd = Get-OpensquillaCommand -Repo $Repo"
+
+    assert save_state_dir in lib
+    assert clear_state_dir in lib
+    assert restore_state_dir in lib
+    assert (
+        lib.index(save_state_dir)
+        < lib.index(set_profile)
+        < lib.index(clear_state_dir)
+        < lib.index(resolve_command)
+    )
+    assert lib.index(resolve_command) < lib.index(restore_state_dir)

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SUPERVISOR = ROOT / "scripts" / "supervisor"
+
+
+def test_supervisor_scripts_are_windows_profile_scoped() -> None:
+    scripts = {
+        "lib.ps1",
+        "start-all.ps1",
+        "stop-all.ps1",
+        "status.ps1",
+        "install-autostart.ps1",
+        "uninstall-autostart.ps1",
+    }
+    for name in scripts:
+        assert (SUPERVISOR / name).is_file()
+
+    combined = "\n".join((SUPERVISOR / name).read_text(encoding="utf-8") for name in scripts)
+    assert r"D:\ai\opensquilla" not in combined
+    assert "OPENSQUILLA_HOME" in combined
+    assert "--profile" in combined
+    assert "^[a-z0-9][a-z0-9_-]{0,63}$" in combined
+
+
+def test_task_scheduler_registration_uses_encoded_command() -> None:
+    text = (SUPERVISOR / "install-autostart.ps1").read_text(encoding="utf-8")
+
+    assert "-EncodedCommand" in text
+    assert "ConvertTo-PowerShellSingleQuotedLiteral" in text
+    assert "ConvertTo-XmlEscapedText" in text

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -45,6 +45,11 @@ def test_supervisor_explicit_repo_takes_precedence_over_installed_binary() -> No
 
     repo_branch = "if ($Repo) {"
     installed_lookup = "$installed = Get-Command 'opensquilla'"
+    explicit_error = 'throw "OpenSquilla repo lacks pyproject.toml: $resolvedRepo"'
+    auto_detect = "Get-OpensquillaRoot -Override $null"
     assert repo_branch in lib
     assert installed_lookup in lib
-    assert lib.index(repo_branch) < lib.index(installed_lookup)
+    assert explicit_error in lib
+    assert auto_detect in lib
+    assert lib.index(repo_branch) < lib.index(explicit_error) < lib.index(installed_lookup)
+    assert lib.index(installed_lookup) < lib.index(auto_detect)

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -38,3 +38,13 @@ def test_supervisor_profile_name_match_is_case_sensitive() -> None:
 
     assert "-cmatch $Script:PROFILE_NAME_PATTERN" in lib
     assert "-match $Script:PROFILE_NAME_PATTERN" not in lib
+
+
+def test_supervisor_explicit_repo_takes_precedence_over_installed_binary() -> None:
+    lib = (SUPERVISOR / "lib.ps1").read_text(encoding="utf-8")
+
+    repo_branch = "if ($Repo) {"
+    installed_lookup = "$installed = Get-Command 'opensquilla'"
+    assert repo_branch in lib
+    assert installed_lookup in lib
+    assert lib.index(repo_branch) < lib.index(installed_lookup)


### PR DESCRIPTION
## Summary

This draft extracts the Windows profile-supervisor portion of #210 into a smaller PR targeted at `main`.

It is stacked on #429 because the scripts invoke `opensquilla --profile <name> ...`.

## Why Windows Only

The reusable contribution here is the Windows PowerShell/Task Scheduler supervisor path. macOS LaunchAgent and Linux systemd behavior have different service managers, quoting rules, lifecycle semantics, and validation needs, so they are intentionally excluded from this PR to keep the release path stable. If we want those platforms, they should be follow-up PRs with platform-specific tests.

## Changes

- Add `scripts/supervisor/` PowerShell helpers for Windows profile orchestration:
  - `start-all.ps1`
  - `stop-all.ps1`
  - `status.ps1`
  - `install-autostart.ps1`
  - `uninstall-autostart.ps1`
  - shared `lib.ps1`
- Add a local supervisor README instead of broad top-level README churn.
- Add repository tests that lock the script contract and prevent reintroducing the original hard-coded local path.
- Stabilize profile matching as case-sensitive.
- Prefer an explicit `-Repo` checkout over an installed `opensquilla` binary, and fail fast if the explicit repo is invalid.
- Mask inherited `OPENSQUILLA_STATE_DIR` while invoking each profile, then restore it afterwards, so the profile home actually takes effect.
- Fix `-SkipRunning` to parse `gateway status --json` and skip only when `state == "running"`; `not_started` no longer gets mistaken for already running just because status exits 0.
- Persist each profile's supervisor port in `supervisor-port.txt` under that profile directory so adding/removing/renaming other profiles does not shift existing ports.

## Differences from #210

- Removes the original `D:\ai\opensquilla\...` default path and uses `%USERPROFILE%\.opensquilla\profiles` unless `OPENSQUILLA_HOME` or `-ProfilesRoot` is supplied.
- Keeps the scope Windows-only.
- Uses `-EncodedCommand` when registering Task Scheduler so script/profile paths with spaces or quotes survive command-line/XML boundaries.
- Drops the unsupported `gateway stop --force` call because current `main` does not expose that option.

## Stability

This PR only adds opt-in Windows supervisor scripts. It does not change default runtime startup on macOS/Linux or normal Python CLI behavior. It should remain draft until PowerShell runtime behavior is validated on a Windows host or Windows CI job that exercises these scripts directly.

## Attribution

Extracted from #210, originally contributed by @tqangxl.

Relevant original commits:

- a75397587c0ce9783a7783990251586087463a21 - Add multi-profile supervisor scripts + README section
- e22e5113afff1cda76c345331cd8d73f504441a6 - Address Open-Squilla review on PR #194

The extracted contribution commit includes `Co-authored-by: Tqangxl <tqangxl@gmail.com>`. Follow-up stabilization commits are maintainer-side test/fix commits.

## Validation

Restacked on #429 and `origin/main@ae5e6f10` on 2026-07-03.

- `uv run pytest -q tests/test_supervisor_scripts.py` - 7 passed
- `uv run pytest -q tests/test_paths_profile.py tests/test_cli/test_profile_env_loading.py tests/unit/test_env.py` - 47 passed
- On the top stacked branch (#431): `uv run pytest -q tests/test_paths_profile.py tests/test_cli/test_profile_env_loading.py tests/unit/test_env.py tests/test_cli/test_gateway_cmd.py tests/test_paths_media_root.py tests/test_supervisor_scripts.py tests/test_cli/test_autostart.py tests/test_cli/test_init_cmd.py tests/test_cli/test_onboard_cmd.py::test_configure_search_can_use_env_key_reference tests/test_cli/test_search_cmd.py::test_search_configure_warns_when_env_key_is_not_set` - 118 passed
- `uv run ruff check ...` for the touched Python files/tests - passed
- `git diff --check origin/main..HEAD` on the top stacked branch - passed

Not locally validated: PowerShell AST/runtime execution, because this macOS worktree does not have `pwsh` installed.
