### PR TITLE
Add optional Windows init autostart

### DIFF
--- a/scripts/supervisor/README.md
+++ b/scripts/supervisor/README.md
@@ -1,0 +1,33 @@
+# Windows Profile Supervisor
+
+These scripts are a Windows-only helper for running every explicit OpenSquilla
+profile under one profiles root.
+
+They are intended to be used after profile support is available:
+
+```powershell
+opensquilla --profile coder init
+opensquilla --profile planner init
+.\scripts\supervisor\start-all.ps1
+```
+
+By default the profiles root is:
+
+```text
+%USERPROFILE%\.opensquilla\profiles
+```
+
+You can override it with `-ProfilesRoot` or `OPENSQUILLA_HOME`.
+
+Common commands:
+
+```powershell
+.\scripts\supervisor\start-all.ps1 -ProfilesRoot D:\OpenSquilla\profiles
+.\scripts\supervisor\status.ps1 -ProfilesRoot D:\OpenSquilla\profiles
+.\scripts\supervisor\stop-all.ps1 -ProfilesRoot D:\OpenSquilla\profiles
+.\scripts\supervisor\install-autostart.ps1 -ProfilesRoot D:\OpenSquilla\profiles
+.\scripts\supervisor\uninstall-autostart.ps1
+```
+
+`install-autostart.ps1` registers a per-user Task Scheduler entry that runs at
+interactive logon. It does not require administrator privileges.

--- a/scripts/supervisor/install-autostart.ps1
+++ b/scripts/supervisor/install-autostart.ps1
@@ -1,0 +1,98 @@
+<#
+.SYNOPSIS
+    Register start-all.ps1 with Windows Task Scheduler at user logon.
+#>
+[CmdletBinding()]
+param(
+    [string] $ProfilesRoot,
+    [int] $BasePort = 18791,
+    [string] $TaskName = 'OpenSquillaProfileSupervisor',
+    [string] $Repo
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+if (-not (Get-Command schtasks.exe -ErrorAction SilentlyContinue)) {
+    throw 'schtasks.exe not found. This script only runs on Windows.'
+}
+
+$root = Get-ProfilesRoot -Override $ProfilesRoot
+$startAll = Join-Path $PSScriptRoot 'start-all.ps1'
+
+$commandParts = @(
+    '&',
+    (ConvertTo-PowerShellSingleQuotedLiteral $startAll),
+    '-ProfilesRoot',
+    (ConvertTo-PowerShellSingleQuotedLiteral $root),
+    '-BasePort',
+    [string]$BasePort,
+    '-SkipRunning'
+)
+if ($Repo) {
+    $commandParts += @('-Repo', (ConvertTo-PowerShellSingleQuotedLiteral $Repo))
+}
+$command = $commandParts -join ' '
+
+$encoded = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($command))
+$arguments = "-NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded"
+$escapedRoot = ConvertTo-XmlEscapedText $root
+$escapedUser = ConvertTo-XmlEscapedText "$env:USERDOMAIN\$env:USERNAME"
+$escapedAuthor = ConvertTo-XmlEscapedText $env:USERNAME
+$escapedArguments = ConvertTo-XmlEscapedText $arguments
+
+$taskXml = @"
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Author>$escapedAuthor</Author>
+    <Description>Auto-start every OpenSquilla profile gateway under $escapedRoot at user logon.</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>$escapedUser</UserId>
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>Parallel</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <ExecutionTimeLimit>PT10M</ExecutionTimeLimit>
+    <Priority>7</Priority>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>powershell.exe</Command>
+      <Arguments>$escapedArguments</Arguments>
+    </Exec>
+  </Actions>
+</Task>
+"@
+
+$safeTaskName = ($TaskName -replace '[^a-zA-Z0-9_.-]', '_')
+$xmlPath = Join-Path $env:TEMP "opensquilla-supervisor-$safeTaskName.xml"
+[System.IO.File]::WriteAllText($xmlPath, $taskXml, [System.Text.Encoding]::Unicode)
+
+try {
+    $proc = Start-Process -FilePath schtasks.exe `
+        -ArgumentList @('/Create', '/TN', $TaskName, '/XML', $xmlPath, '/F') `
+        -NoNewWindow -Wait -PassThru
+    if ($proc.ExitCode -ne 0) {
+        throw "schtasks /Create exited with code $($proc.ExitCode)"
+    }
+    Write-Status "Registered task '$TaskName' to run start-all.ps1 at logon." -Level ok
+    Write-Status "Profiles root: $root" -Level info
+    Write-Status "Base port: $BasePort" -Level info
+} finally {
+    Remove-Item -LiteralPath $xmlPath -ErrorAction SilentlyContinue
+}

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -1,0 +1,223 @@
+<#
+.SYNOPSIS
+    Shared helpers for OpenSquilla Windows multi-profile supervisor scripts.
+
+.DESCRIPTION
+    These helpers keep the Windows Task Scheduler wrapper thin: discover
+    profile directories, allocate stable ports, resolve how to invoke
+    OpenSquilla, and run a CLI command under one selected profile.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+if (Get-Variable -Name OPENSQUILLA_SUPERVISOR_LIB_LOADED -Scope Script -ErrorAction SilentlyContinue) {
+    return
+}
+$Script:OPENSQUILLA_SUPERVISOR_LIB_LOADED = $true
+
+$Script:DEFAULT_BASE_PORT = 18791
+$Script:TASK_NAME = 'OpenSquillaProfileSupervisor'
+$Script:DISPLAY_NAME = 'OpenSquilla Multi-Profile Gateway Supervisor'
+$Script:PROFILE_NAME_PATTERN = '^[a-z0-9][a-z0-9_-]{0,63}$'
+
+function Get-DefaultProfilesRoot {
+    $userProfile = [Environment]::GetFolderPath('UserProfile')
+    if (-not $userProfile) {
+        $userProfile = $HOME
+    }
+    return (Join-Path $userProfile '.opensquilla\profiles')
+}
+
+function Get-ProfilesRoot {
+    param([string]$Override)
+
+    $candidate = if ($Override) {
+        $Override
+    } elseif ($env:OPENSQUILLA_HOME) {
+        $env:OPENSQUILLA_HOME
+    } else {
+        Get-DefaultProfilesRoot
+    }
+
+    if (-not $candidate) {
+        throw 'Profiles root is empty. Pass -ProfilesRoot or set OPENSQUILLA_HOME.'
+    }
+    if (-not (Test-Path -LiteralPath $candidate -PathType Container)) {
+        throw "Profiles root does not exist: $candidate"
+    }
+    return (Resolve-Path -LiteralPath $candidate).Path
+}
+
+function Test-ProfileName {
+    param([Parameter(Mandatory)] [string] $Name)
+    return [bool]($Name -match $Script:PROFILE_NAME_PATTERN)
+}
+
+function Get-OpensquillaRoot {
+    param([string]$Override)
+
+    if ($Override) {
+        if (-not (Test-Path -LiteralPath $Override -PathType Container)) {
+            throw "OpenSquilla repo not found: $Override. Pass -Repo or omit to auto-detect."
+        }
+        return (Resolve-Path -LiteralPath $Override).Path
+    }
+
+    if ($PSScriptRoot) {
+        $candidate = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+        if (Test-Path -LiteralPath (Join-Path $candidate 'pyproject.toml') -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+
+    return $null
+}
+
+function Get-OpensquillaCommand {
+    param([string]$Repo)
+
+    $installed = Get-Command 'opensquilla' -ErrorAction SilentlyContinue
+    if ($installed) {
+        return @{ Mode = 'installed'; Exe = $installed.Path }
+    }
+
+    $resolvedRepo = Get-OpensquillaRoot -Override $Repo
+    if ($resolvedRepo -and (Test-Path -LiteralPath (Join-Path $resolvedRepo 'pyproject.toml') -PathType Leaf)) {
+        return @{ Mode = 'uv-run-repo'; Repo = $resolvedRepo }
+    }
+
+    return @{ Mode = 'none' }
+}
+
+function Get-ProfileEntries {
+    param([Parameter(Mandatory)] [string] $ProfilesRoot)
+
+    if (-not (Test-Path -LiteralPath $ProfilesRoot -PathType Container)) {
+        return @()
+    }
+
+    $entries = Get-ChildItem -LiteralPath $ProfilesRoot -Directory -ErrorAction SilentlyContinue |
+        Where-Object { Test-ProfileName -Name $_.Name } |
+        Sort-Object Name
+
+    $results = @()
+    foreach ($entry in $entries) {
+        $configPath = Join-Path $entry.FullName 'config.toml'
+        $results += [pscustomobject]@{
+            Name = $entry.Name
+            Path = $entry.FullName
+            ConfigPath = $configPath
+            HasConfig = Test-Path -LiteralPath $configPath -PathType Leaf
+        }
+    }
+    return ,$results
+}
+
+function Get-ProfilePort {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [int] $BasePort,
+        [Parameter(Mandatory)] [string] $ProfilesRoot
+    )
+
+    $index = 0
+    foreach ($sibling in (Get-ProfileEntries -ProfilesRoot $ProfilesRoot)) {
+        if ($sibling.Name -eq $Name) {
+            return [int]($BasePort + $index)
+        }
+        $index += 1
+    }
+    return [int]$BasePort
+}
+
+function Write-Status {
+    param(
+        [string] $Message,
+        [ValidateSet('info', 'ok', 'warn', 'err')] [string] $Level = 'info'
+    )
+
+    $prefix = switch ($Level) {
+        'ok' { '[OK]   ' }
+        'warn' { '[WARN] ' }
+        'err' { '[ERR]  ' }
+        default { '[..]   ' }
+    }
+    $color = switch ($Level) {
+        'ok' { 'Green' }
+        'warn' { 'Yellow' }
+        'err' { 'Red' }
+        default { 'Cyan' }
+    }
+    Write-Host ($prefix + $Message) -ForegroundColor $color
+}
+
+function Invoke-Opensquilla {
+    param(
+        [string] $Repo,
+        [Parameter(Mandatory)] [string] $Profile,
+        [Parameter(Mandatory)] [string[]] $Arguments,
+        [switch] $CaptureOutput
+    )
+
+    $profileLeaf = Split-Path -Leaf $Profile
+    $profileRoot = Split-Path -Parent $Profile
+    if (-not (Test-ProfileName -Name $profileLeaf)) {
+        throw "Invalid OpenSquilla profile name: $profileLeaf"
+    }
+
+    $previousHome = $env:OPENSQUILLA_HOME
+    $previousProfile = $env:OPENSQUILLA_PROFILE
+    $env:OPENSQUILLA_HOME = $profileRoot
+    $env:OPENSQUILLA_PROFILE = $profileLeaf
+
+    try {
+        $cmd = Get-OpensquillaCommand -Repo $Repo
+        switch ($cmd.Mode) {
+            'installed' {
+                if ($CaptureOutput) {
+                    $output = & $cmd.Exe @Arguments 2>$null
+                    return @{ ExitCode = $LASTEXITCODE; Output = $output }
+                }
+                & $cmd.Exe @Arguments
+                return @{ ExitCode = $LASTEXITCODE; Output = $null }
+            }
+            'uv-run-repo' {
+                Push-Location -LiteralPath $cmd.Repo
+                try {
+                    if ($CaptureOutput) {
+                        $output = & uv run opensquilla @Arguments 2>$null
+                        return @{ ExitCode = $LASTEXITCODE; Output = $output }
+                    }
+                    & uv run opensquilla @Arguments
+                    return @{ ExitCode = $LASTEXITCODE; Output = $null }
+                } finally {
+                    Pop-Location
+                }
+            }
+            default {
+                throw 'opensquilla is not on PATH and no source checkout was auto-detected next to this script. Install OpenSquilla or pass -Repo.'
+            }
+        }
+    } finally {
+        if ($null -eq $previousHome) {
+            Remove-Item Env:\OPENSQUILLA_HOME -ErrorAction SilentlyContinue
+        } else {
+            $env:OPENSQUILLA_HOME = $previousHome
+        }
+        if ($null -eq $previousProfile) {
+            Remove-Item Env:\OPENSQUILLA_PROFILE -ErrorAction SilentlyContinue
+        } else {
+            $env:OPENSQUILLA_PROFILE = $previousProfile
+        }
+    }
+}
+
+function ConvertTo-PowerShellSingleQuotedLiteral {
+    param([Parameter(Mandatory)] [string] $Value)
+    return "'" + ($Value -replace "'", "''") + "'"
+}
+
+function ConvertTo-XmlEscapedText {
+    param([Parameter(Mandatory)] [string] $Value)
+    return [System.Security.SecurityElement]::Escape($Value)
+}

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -175,8 +175,10 @@ function Invoke-Opensquilla {
 
     $previousHome = $env:OPENSQUILLA_HOME
     $previousProfile = $env:OPENSQUILLA_PROFILE
+    $previousStateDir = $env:OPENSQUILLA_STATE_DIR
     $env:OPENSQUILLA_HOME = $profileRoot
     $env:OPENSQUILLA_PROFILE = $profileLeaf
+    Remove-Item Env:\OPENSQUILLA_STATE_DIR -ErrorAction SilentlyContinue
 
     try {
         $cmd = Get-OpensquillaCommand -Repo $Repo
@@ -216,6 +218,11 @@ function Invoke-Opensquilla {
             Remove-Item Env:\OPENSQUILLA_PROFILE -ErrorAction SilentlyContinue
         } else {
             $env:OPENSQUILLA_PROFILE = $previousProfile
+        }
+        if ($null -eq $previousStateDir) {
+            Remove-Item Env:\OPENSQUILLA_STATE_DIR -ErrorAction SilentlyContinue
+        } else {
+            $env:OPENSQUILLA_STATE_DIR = $previousStateDir
         }
     }
 }

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -50,7 +50,7 @@ function Get-ProfilesRoot {
 
 function Test-ProfileName {
     param([Parameter(Mandatory)] [string] $Name)
-    return [bool]($Name -match $Script:PROFILE_NAME_PATTERN)
+    return [bool]($Name -cmatch $Script:PROFILE_NAME_PATTERN)
 }
 
 function Get-OpensquillaRoot {

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -19,6 +19,7 @@ $Script:DEFAULT_BASE_PORT = 18791
 $Script:TASK_NAME = 'OpenSquillaProfileSupervisor'
 $Script:DISPLAY_NAME = 'OpenSquilla Multi-Profile Gateway Supervisor'
 $Script:PROFILE_NAME_PATTERN = '^[a-z0-9][a-z0-9_-]{0,63}$'
+$Script:PORT_FILE_NAME = 'supervisor-port.txt'
 
 function Get-DefaultProfilesRoot {
     $userProfile = [Environment]::GetFolderPath('UserProfile')
@@ -128,14 +129,63 @@ function Get-ProfilePort {
         [Parameter(Mandatory)] [string] $ProfilesRoot
     )
 
-    $index = 0
-    foreach ($sibling in (Get-ProfileEntries -ProfilesRoot $ProfilesRoot)) {
-        if ($sibling.Name -eq $Name) {
-            return [int]($BasePort + $index)
-        }
-        $index += 1
+    if (-not (Test-ProfileName -Name $Name)) {
+        throw "Invalid OpenSquilla profile name: $Name"
     }
-    return [int]$BasePort
+
+    $profilePath = Join-Path $ProfilesRoot $Name
+    if (-not (Test-Path -LiteralPath $profilePath -PathType Container)) {
+        throw "Profile does not exist: $profilePath"
+    }
+
+    $portFile = Get-ProfilePortFile -ProfilePath $profilePath
+    $existing = Read-ProfilePortFile -PortFile $portFile
+    if ($null -ne $existing) {
+        return [int]$existing
+    }
+
+    $used = Get-UsedProfilePorts -ProfilesRoot $ProfilesRoot
+    $candidate = [int]$BasePort
+    while ($used.ContainsKey($candidate)) {
+        $candidate += 1
+    }
+
+    Set-Content -LiteralPath $portFile -Value ([string]$candidate) -Encoding ASCII
+    return [int]$candidate
+}
+
+function Get-ProfilePortFile {
+    param([Parameter(Mandatory)] [string] $ProfilePath)
+    return (Join-Path $ProfilePath $Script:PORT_FILE_NAME)
+}
+
+function Read-ProfilePortFile {
+    param([Parameter(Mandatory)] [string] $PortFile)
+
+    if (-not (Test-Path -LiteralPath $PortFile -PathType Leaf)) {
+        return $null
+    }
+
+    $raw = (Get-Content -LiteralPath $PortFile -Raw -ErrorAction Stop).Trim()
+    $port = 0
+    if ([int]::TryParse($raw, [ref]$port) -and $port -gt 0 -and $port -lt 65536) {
+        return [int]$port
+    }
+    return $null
+}
+
+function Get-UsedProfilePorts {
+    param([Parameter(Mandatory)] [string] $ProfilesRoot)
+
+    $used = @{}
+    foreach ($entry in (Get-ProfileEntries -ProfilesRoot $ProfilesRoot)) {
+        $portFile = Get-ProfilePortFile -ProfilePath $entry.Path
+        $port = Read-ProfilePortFile -PortFile $portFile
+        if ($null -ne $port) {
+            $used[[int]$port] = $true
+        }
+    }
+    return $used
 }
 
 function Write-Status {

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -76,12 +76,19 @@ function Get-OpensquillaRoot {
 function Get-OpensquillaCommand {
     param([string]$Repo)
 
+    if ($Repo) {
+        $resolvedRepo = Get-OpensquillaRoot -Override $Repo
+        if ($resolvedRepo -and (Test-Path -LiteralPath (Join-Path $resolvedRepo 'pyproject.toml') -PathType Leaf)) {
+            return @{ Mode = 'uv-run-repo'; Repo = $resolvedRepo }
+        }
+    }
+
     $installed = Get-Command 'opensquilla' -ErrorAction SilentlyContinue
     if ($installed) {
         return @{ Mode = 'installed'; Exe = $installed.Path }
     }
 
-    $resolvedRepo = Get-OpensquillaRoot -Override $Repo
+    $resolvedRepo = Get-OpensquillaRoot -Override $null
     if ($resolvedRepo -and (Test-Path -LiteralPath (Join-Path $resolvedRepo 'pyproject.toml') -PathType Leaf)) {
         return @{ Mode = 'uv-run-repo'; Repo = $resolvedRepo }
     }

--- a/scripts/supervisor/lib.ps1
+++ b/scripts/supervisor/lib.ps1
@@ -81,6 +81,7 @@ function Get-OpensquillaCommand {
         if ($resolvedRepo -and (Test-Path -LiteralPath (Join-Path $resolvedRepo 'pyproject.toml') -PathType Leaf)) {
             return @{ Mode = 'uv-run-repo'; Repo = $resolvedRepo }
         }
+        throw "OpenSquilla repo lacks pyproject.toml: $resolvedRepo"
     }
 
     $installed = Get-Command 'opensquilla' -ErrorAction SilentlyContinue

--- a/scripts/supervisor/start-all.ps1
+++ b/scripts/supervisor/start-all.ps1
@@ -1,0 +1,74 @@
+<#
+.SYNOPSIS
+    Start every OpenSquilla profile gateway under a Windows profiles root.
+#>
+[CmdletBinding()]
+param(
+    [string] $ProfilesRoot,
+    [int] $BasePort = 18791,
+    [string] $BindHost = '127.0.0.1',
+    [switch] $SkipRunning,
+    [string] $Repo
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+$root = Get-ProfilesRoot -Override $ProfilesRoot
+$cmd = Get-OpensquillaCommand -Repo $Repo
+$entries = Get-ProfileEntries -ProfilesRoot $root
+
+if (-not $entries -or $entries.Count -eq 0) {
+    Write-Status "No profiles found under $root. Run opensquilla --profile <name> init first." -Level warn
+    return
+}
+
+Write-Status "Discovered $($entries.Count) profile(s) under $root" -Level info
+Write-Status "Base port: $BasePort" -Level info
+switch ($cmd.Mode) {
+    'installed' { Write-Status "Mode: installed opensquilla at $($cmd.Exe)" -Level info }
+    'uv-run-repo' { Write-Status "Mode: uv run from $($cmd.Repo)" -Level info }
+    default { Write-Status 'Mode: no opensquilla found; set PATH or pass -Repo' -Level err }
+}
+Write-Host ''
+
+$started = 0
+$skipped = 0
+$failed = 0
+
+foreach ($entry in $entries) {
+    $port = Get-ProfilePort -Name $entry.Name -BasePort $BasePort -ProfilesRoot $root
+    Write-Status ("[{0}] starting on port {1} ..." -f $entry.Name, $port)
+    try {
+        if ($SkipRunning) {
+            $statusArgs = @('--profile', $entry.Name, 'gateway', 'status', '--listen', $BindHost, '--port', [string]$port, '--json')
+            $status = Invoke-Opensquilla -Repo $Repo -Profile $entry.Path -Arguments $statusArgs -CaptureOutput
+            if ($status.ExitCode -eq 0) {
+                Write-Status ("[{0}] already running on port {1}; skipped" -f $entry.Name, $port) -Level ok
+                $skipped += 1
+                continue
+            }
+        }
+
+        $startArgs = @('--profile', $entry.Name, 'gateway', 'start', '--listen', $BindHost, '--port', [string]$port)
+        $result = Invoke-Opensquilla -Repo $Repo -Profile $entry.Path -Arguments $startArgs
+        if ($result.ExitCode -eq 0) {
+            Write-Status ("[{0}] up on port {1}" -f $entry.Name, $port) -Level ok
+            $started += 1
+        } else {
+            Write-Status ("[{0}] start failed (exit={1})" -f $entry.Name, $result.ExitCode) -Level err
+            $failed += 1
+        }
+    } catch {
+        Write-Status ("[{0}] threw: {1}" -f $entry.Name, $_.Exception.Message) -Level err
+        $failed += 1
+    }
+}
+
+Write-Host ''
+$summaryLevel = if ($failed -eq 0) { 'ok' } else { 'warn' }
+Write-Status ("Summary: started={0} skipped={1} failed={2}" -f $started, $skipped, $failed) -Level $summaryLevel
+
+if ($failed -gt 0) {
+    exit 1
+}

--- a/scripts/supervisor/start-all.ps1
+++ b/scripts/supervisor/start-all.ps1
@@ -43,7 +43,11 @@ foreach ($entry in $entries) {
         if ($SkipRunning) {
             $statusArgs = @('--profile', $entry.Name, 'gateway', 'status', '--listen', $BindHost, '--port', [string]$port, '--json')
             $status = Invoke-Opensquilla -Repo $Repo -Profile $entry.Path -Arguments $statusArgs -CaptureOutput
-            if ($status.ExitCode -eq 0) {
+            $parsed = $null
+            if ($status.Output) {
+                $parsed = $status.Output | ConvertFrom-Json -ErrorAction SilentlyContinue
+            }
+            if ($parsed -and [string]$parsed.state -eq 'running') {
                 Write-Status ("[{0}] already running on port {1}; skipped" -f $entry.Name, $port) -Level ok
                 $skipped += 1
                 continue

--- a/scripts/supervisor/status.ps1
+++ b/scripts/supervisor/status.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+    Show one status row per OpenSquilla profile gateway.
+#>
+[CmdletBinding()]
+param(
+    [string] $ProfilesRoot,
+    [int] $BasePort = 18791,
+    [string] $BindHost = '127.0.0.1',
+    [string] $Repo
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+$root = Get-ProfilesRoot -Override $ProfilesRoot
+$entries = Get-ProfileEntries -ProfilesRoot $root
+
+if (-not $entries -or $entries.Count -eq 0) {
+    Write-Status "No profiles found under $root." -Level warn
+    return
+}
+
+$rows = @()
+foreach ($entry in $entries) {
+    $port = Get-ProfilePort -Name $entry.Name -BasePort $BasePort -ProfilesRoot $root
+    $statusArgs = @('--profile', $entry.Name, 'gateway', 'status', '--listen', $BindHost, '--port', [string]$port, '--json')
+    $result = Invoke-Opensquilla -Repo $Repo -Profile $entry.Path -Arguments $statusArgs -CaptureOutput
+    $parsed = $null
+    if ($result.Output) {
+        $parsed = $result.Output | ConvertFrom-Json -ErrorAction SilentlyContinue
+    }
+
+    if ($parsed) {
+        $rows += [pscustomobject]@{
+            Profile = $entry.Name
+            State = [string]$parsed.state
+            Port = [int]$parsed.port
+            Host = [string]$parsed.host
+            Pid = if ($parsed.pid) { [int]$parsed.pid } else { '-' }
+            Log = [string]$parsed.logPath
+        }
+    } else {
+        $rows += [pscustomobject]@{
+            Profile = $entry.Name
+            State = 'unknown'
+            Port = $port
+            Host = '-'
+            Pid = '-'
+            Log = '-'
+        }
+    }
+}
+
+function Format-OpenSquillaTable {
+    param([object[]] $Data)
+
+    $cols = 'Profile', 'State', 'Port', 'Host', 'Pid', 'Log'
+    $widths = @{}
+    foreach ($col in $cols) {
+        $widths[$col] = $col.Length
+    }
+    foreach ($row in $Data) {
+        foreach ($col in $cols) {
+            $value = [string]$row.$col
+            if ($value.Length -gt $widths[$col]) {
+                $widths[$col] = $value.Length
+            }
+        }
+    }
+
+    $header = ($cols | ForEach-Object { $_.PadRight($widths[$_]) }) -join '  '
+    Write-Host $header -ForegroundColor Cyan
+    Write-Host ('-' * $header.Length) -ForegroundColor DarkGray
+    foreach ($row in $Data) {
+        $line = ($cols | ForEach-Object { ([string]$row.$_).PadRight($widths[$_]) }) -join '  '
+        $color = switch ($row.State) {
+            'running' { 'Green' }
+            'unhealthy' { 'Red' }
+            'not_started' { 'DarkGray' }
+            default { 'Yellow' }
+        }
+        Write-Host $line -ForegroundColor $color
+    }
+}
+
+Format-OpenSquillaTable -Data $rows
+
+$misconfigured = $rows | Where-Object { $_.State -notin @('running', 'not_started') }
+if ($misconfigured.Count -gt 0) {
+    Write-Status ("{0} profile(s) need attention" -f $misconfigured.Count) -Level warn
+    exit 1
+}

--- a/scripts/supervisor/stop-all.ps1
+++ b/scripts/supervisor/stop-all.ps1
@@ -1,0 +1,53 @@
+<#
+.SYNOPSIS
+    Stop every OpenSquilla profile gateway under a Windows profiles root.
+#>
+[CmdletBinding()]
+param(
+    [string] $ProfilesRoot,
+    [int] $BasePort = 18791,
+    [string] $BindHost = '127.0.0.1',
+    [string] $Repo
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+$root = Get-ProfilesRoot -Override $ProfilesRoot
+$entries = Get-ProfileEntries -ProfilesRoot $root
+
+if (-not $entries -or $entries.Count -eq 0) {
+    Write-Status "No profiles found under $root." -Level warn
+    return
+}
+
+$stopped = 0
+$skipped = 0
+$failed = 0
+
+foreach ($entry in $entries) {
+    $port = Get-ProfilePort -Name $entry.Name -BasePort $BasePort -ProfilesRoot $root
+    Write-Status ("[{0}] stopping on port {1} ..." -f $entry.Name, $port)
+    try {
+        $stopArgs = @('--profile', $entry.Name, 'gateway', 'stop', '--listen', $BindHost, '--port', [string]$port)
+        $result = Invoke-Opensquilla -Repo $Repo -Profile $entry.Path -Arguments $stopArgs
+        if ($result.ExitCode -eq 0) {
+            Write-Status ("[{0}] stopped" -f $entry.Name) -Level ok
+            $stopped += 1
+        } else {
+            Write-Status ("[{0}] not running (exit={1})" -f $entry.Name, $result.ExitCode) -Level ok
+            $skipped += 1
+        }
+    } catch {
+        Write-Status ("[{0}] threw: {1}" -f $entry.Name, $_.Exception.Message) -Level err
+        $failed += 1
+    }
+}
+
+Write-Host ''
+$summaryLevel = if ($failed -eq 0) { 'ok' } else { 'warn' }
+Write-Status ("Summary: stopped={0} skipped={1} failed={2}" -f $stopped, $skipped, $failed) -Level $summaryLevel
+
+if ($failed -gt 0) {
+    exit 1
+}

--- a/scripts/supervisor/uninstall-autostart.ps1
+++ b/scripts/supervisor/uninstall-autostart.ps1
@@ -1,0 +1,31 @@
+<#
+.SYNOPSIS
+    Remove the OpenSquilla multi-profile supervisor from Task Scheduler.
+#>
+[CmdletBinding()]
+param(
+    [string] $TaskName = 'OpenSquillaProfileSupervisor'
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+if (-not (Get-Command schtasks.exe -ErrorAction SilentlyContinue)) {
+    throw 'schtasks.exe not found. This script only runs on Windows.'
+}
+
+$query = Start-Process -FilePath schtasks.exe `
+    -ArgumentList @('/Query', '/TN', $TaskName) `
+    -NoNewWindow -Wait -PassThru
+if ($query.ExitCode -ne 0) {
+    Write-Status "Task '$TaskName' is not registered; nothing to do." -Level warn
+    return
+}
+
+$delete = Start-Process -FilePath schtasks.exe `
+    -ArgumentList @('/Delete', '/TN', $TaskName, '/F') `
+    -NoNewWindow -Wait -PassThru
+if ($delete.ExitCode -ne 0) {
+    throw "schtasks /Delete exited with code $($delete.ExitCode)"
+}
+Write-Status "Removed task '$TaskName'." -Level ok

--- a/src/opensquilla/cli/autostart.py
+++ b/src/opensquilla/cli/autostart.py
@@ -75,6 +75,7 @@ def _launch_script(
     elif profile:
         if not is_valid_profile_name(profile):
             raise AutostartError(f"Invalid OpenSquilla profile name: {profile}")
+        lines.append(r"Remove-Item Env:\OPENSQUILLA_STATE_DIR -ErrorAction SilentlyContinue")
         lines.append(f"$env:OPENSQUILLA_HOME = {_powershell_literal(str(home.parent))}")
         lines.append(f"$env:OPENSQUILLA_PROFILE = {_powershell_literal(profile)}")
         args = ["--profile", profile, *args]

--- a/src/opensquilla/cli/autostart.py
+++ b/src/opensquilla/cli/autostart.py
@@ -124,7 +124,7 @@ def _registration_script(
                 "$Principal = New-ScheduledTaskPrincipal "
                 '-UserId "$env:USERDOMAIN\\$env:USERNAME" '
                 "-LogonType Interactive "
-                "-RunLevel LeastPrivilege"
+                "-RunLevel Limited"
             ),
             (
                 "$Settings = New-ScheduledTaskSettingsSet "

--- a/src/opensquilla/cli/autostart.py
+++ b/src/opensquilla/cli/autostart.py
@@ -1,0 +1,168 @@
+"""Windows logon autostart helpers for OpenSquilla init."""
+
+from __future__ import annotations
+
+import base64
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from opensquilla.paths import is_valid_profile_name
+
+
+class AutostartError(RuntimeError):
+    """Raised when logon autostart registration fails."""
+
+
+class PlatformNotSupportedError(AutostartError):
+    """Raised when the current platform has no supported autostart backend."""
+
+
+@dataclass(frozen=True)
+class AutostartResult:
+    platform: str
+    profile: str | None
+    target: str
+
+    def summary(self) -> str:
+        if self.profile:
+            return (
+                f"{self.platform} autostart registered for profile "
+                f"'{self.profile}' as {self.target}."
+            )
+        return (
+            f"{self.platform} autostart registered for the default "
+            f"OpenSquilla home as {self.target}."
+        )
+
+
+def task_name_for_profile(profile: str | None) -> str:
+    if not profile:
+        return "OpenSquilla"
+    return f"OpenSquilla_{profile}"
+
+
+def _powershell_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _encoded_powershell(script: str) -> str:
+    return base64.b64encode(script.encode("utf-16-le")).decode("ascii")
+
+
+def _resolve_executable(name: str) -> str:
+    resolved = shutil.which(name)
+    if not resolved:
+        raise AutostartError(
+            f"{name} is not on PATH; install OpenSquilla before enabling autostart."
+        )
+    return resolved
+
+
+def _launch_script(*, opensquilla: str, profile: str | None, home: Path) -> str:
+    lines = ["$ErrorActionPreference = 'Stop'"]
+    args = ["gateway", "start"]
+    if profile:
+        if not is_valid_profile_name(profile):
+            raise AutostartError(f"Invalid OpenSquilla profile name: {profile}")
+        lines.append(f"$env:OPENSQUILLA_HOME = {_powershell_literal(str(home.parent))}")
+        lines.append(f"$env:OPENSQUILLA_PROFILE = {_powershell_literal(profile)}")
+        args = ["--profile", profile, *args]
+
+    rendered_args = " ".join(_powershell_literal(arg) for arg in args)
+    lines.append(f"& {_powershell_literal(opensquilla)} {rendered_args}")
+    lines.append("exit $LASTEXITCODE")
+    return "\n".join(lines)
+
+
+def _registration_script(
+    *,
+    powershell: str,
+    opensquilla: str,
+    profile: str | None,
+    home: Path,
+    task_name: str,
+) -> str:
+    launch_script = _launch_script(opensquilla=opensquilla, profile=profile, home=home)
+    launch_args = (
+        "-NoProfile -ExecutionPolicy Bypass -EncodedCommand "
+        + _encoded_powershell(launch_script)
+    )
+    description = (
+        f"Auto-start OpenSquilla profile {profile} at user logon."
+        if profile
+        else "Auto-start OpenSquilla gateway at user logon."
+    )
+
+    return "\n".join(
+        [
+            "$ErrorActionPreference = 'Stop'",
+            (
+                "$Action = New-ScheduledTaskAction "
+                f"-Execute {_powershell_literal(powershell)} "
+                f"-Argument {_powershell_literal(launch_args)} "
+                f"-WorkingDirectory {_powershell_literal(str(home))}"
+            ),
+            "$Trigger = New-ScheduledTaskTrigger -AtLogOn",
+            (
+                "$Principal = New-ScheduledTaskPrincipal "
+                '-UserId "$env:USERDOMAIN\\$env:USERNAME" '
+                "-LogonType Interactive "
+                "-RunLevel LeastPrivilege"
+            ),
+            (
+                "$Settings = New-ScheduledTaskSettingsSet "
+                "-MultipleInstances Parallel "
+                "-ExecutionTimeLimit (New-TimeSpan -Minutes 10) "
+                "-AllowStartIfOnBatteries "
+                "-DontStopIfGoingOnBatteries"
+            ),
+            (
+                "Register-ScheduledTask "
+                f"-TaskName {_powershell_literal(task_name)} "
+                f"-Description {_powershell_literal(description)} "
+                "-Action $Action "
+                "-Trigger $Trigger "
+                "-Principal $Principal "
+                "-Settings $Settings "
+                "-Force | Out-Null"
+            ),
+        ]
+    )
+
+
+def register_logon_task(*, profile: str | None, home: Path) -> AutostartResult:
+    system = platform.system()
+    if system != "Windows":
+        raise PlatformNotSupportedError(f"Autostart registration is Windows-only for now: {system}")
+
+    opensquilla = _resolve_executable("opensquilla")
+    powershell = shutil.which("powershell.exe") or shutil.which("powershell")
+    if not powershell:
+        raise AutostartError("powershell.exe is not on PATH; cannot register Task Scheduler entry.")
+
+    task_name = task_name_for_profile(profile)
+    script = _registration_script(
+        powershell=powershell,
+        opensquilla=opensquilla,
+        profile=profile,
+        home=home,
+        task_name=task_name,
+    )
+    command = [
+        powershell,
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-EncodedCommand",
+        _encoded_powershell(script),
+    ]
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        details = (result.stderr or result.stdout or "").strip()
+        suffix = f": {details}" if details else ""
+        raise AutostartError(f"Register-ScheduledTask failed{suffix}")
+
+    return AutostartResult(platform=system, profile=profile, target=task_name)

--- a/src/opensquilla/cli/autostart.py
+++ b/src/opensquilla/cli/autostart.py
@@ -61,10 +61,18 @@ def _resolve_executable(name: str) -> str:
     return resolved
 
 
-def _launch_script(*, opensquilla: str, profile: str | None, home: Path) -> str:
+def _launch_script(
+    *,
+    opensquilla: str,
+    profile: str | None,
+    home: Path,
+    state_dir: Path | None = None,
+) -> str:
     lines = ["$ErrorActionPreference = 'Stop'"]
     args = ["gateway", "start"]
-    if profile:
+    if state_dir is not None:
+        lines.append(f"$env:OPENSQUILLA_STATE_DIR = {_powershell_literal(str(state_dir))}")
+    elif profile:
         if not is_valid_profile_name(profile):
             raise AutostartError(f"Invalid OpenSquilla profile name: {profile}")
         lines.append(f"$env:OPENSQUILLA_HOME = {_powershell_literal(str(home.parent))}")
@@ -84,8 +92,14 @@ def _registration_script(
     profile: str | None,
     home: Path,
     task_name: str,
+    state_dir: Path | None = None,
 ) -> str:
-    launch_script = _launch_script(opensquilla=opensquilla, profile=profile, home=home)
+    launch_script = _launch_script(
+        opensquilla=opensquilla,
+        profile=profile,
+        home=home,
+        state_dir=state_dir,
+    )
     launch_args = (
         "-NoProfile -ExecutionPolicy Bypass -EncodedCommand "
         + _encoded_powershell(launch_script)
@@ -133,7 +147,9 @@ def _registration_script(
     )
 
 
-def register_logon_task(*, profile: str | None, home: Path) -> AutostartResult:
+def register_logon_task(
+    *, profile: str | None, home: Path, state_dir: Path | None = None
+) -> AutostartResult:
     system = platform.system()
     if system != "Windows":
         raise PlatformNotSupportedError(f"Autostart registration is Windows-only for now: {system}")
@@ -149,6 +165,7 @@ def register_logon_task(*, profile: str | None, home: Path) -> AutostartResult:
         opensquilla=opensquilla,
         profile=profile,
         home=home,
+        state_dir=state_dir,
         task_name=task_name,
     )
     command = [

--- a/src/opensquilla/cli/init_cmd.py
+++ b/src/opensquilla/cli/init_cmd.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import os
+
 import questionary
 import tomli_w
 import typer
 
+from opensquilla.cli import autostart
 from opensquilla.cli.ui import console
-from opensquilla.paths import default_opensquilla_home
+from opensquilla.paths import default_opensquilla_home, default_profile_name
 
 
 def _default_model_for_provider(provider: str) -> str:
@@ -19,7 +22,25 @@ def _default_model_for_provider(provider: str) -> str:
     return "openai/gpt-4o-mini"
 
 
-def run_init() -> None:
+def _profile_for_autostart() -> str | None:
+    if os.environ.get("OPENSQUILLA_PROFILE", "").strip():
+        return default_profile_name()
+    if os.environ.get("OPENSQUILLA_HOME", "").strip():
+        return default_profile_name()
+    return None
+
+
+def _maybe_register_autostart(home) -> None:
+    profile = _profile_for_autostart()
+    try:
+        result = autostart.register_logon_task(profile=profile, home=home)
+    except autostart.AutostartError as exc:
+        console.print(f"[yellow]Autostart was not registered:[/yellow] {exc}")
+        return
+    console.print(f"[green]{result.summary()}[/green]")
+
+
+def run_init(autostart_register: bool = False) -> None:
     """Create a basic OpenSquilla home with env and config files."""
     home = default_opensquilla_home()
     env_path = home / ".env"
@@ -63,13 +84,21 @@ def run_init() -> None:
 
     console.print(f"[green]Wrote[/green] {env_path}")
     console.print(f"[green]Wrote[/green] {config_path}")
+    if autostart_register:
+        _maybe_register_autostart(home)
     console.print("[dim]Tip: enable shell completion with `opensquilla --install-completion`[/dim]")
 
 
-def init_command() -> None:
+def init_command(
+    autostart_register: bool = typer.Option(
+        False,
+        "--autostart/--no-autostart",
+        help="Register Windows logon autostart after writing the init files.",
+    ),
+) -> None:
     """Initialize a workspace.
 
     Deprecated: prefer ``opensquilla onboard`` for full provider/channel setup.
     Kept for compatibility with older scripts.
     """
-    run_init()
+    run_init(autostart_register=autostart_register)

--- a/src/opensquilla/cli/init_cmd.py
+++ b/src/opensquilla/cli/init_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import questionary
 import tomli_w
@@ -22,18 +23,24 @@ def _default_model_for_provider(provider: str) -> str:
     return "openai/gpt-4o-mini"
 
 
-def _profile_for_autostart() -> str | None:
+def _autostart_context(home: Path) -> tuple[str | None, Path | None]:
+    if os.environ.get("OPENSQUILLA_STATE_DIR", "").strip():
+        return None, home
     if os.environ.get("OPENSQUILLA_PROFILE", "").strip():
-        return default_profile_name()
+        return default_profile_name(), None
     if os.environ.get("OPENSQUILLA_HOME", "").strip():
-        return default_profile_name()
-    return None
+        return default_profile_name(), None
+    return None, None
 
 
-def _maybe_register_autostart(home) -> None:
-    profile = _profile_for_autostart()
+def _maybe_register_autostart(home: Path) -> None:
+    profile, state_dir = _autostart_context(home)
     try:
-        result = autostart.register_logon_task(profile=profile, home=home)
+        result = autostart.register_logon_task(
+            profile=profile,
+            home=home,
+            state_dir=state_dir,
+        )
     except autostart.AutostartError as exc:
         console.print(f"[yellow]Autostart was not registered:[/yellow] {exc}")
         return

--- a/tests/test_cli/test_autostart.py
+++ b/tests/test_cli/test_autostart.py
@@ -81,6 +81,19 @@ def test_registration_script_uses_encoded_inner_launch_command(tmp_path: Path) -
     assert "--profile" in inner
 
 
+def test_registration_script_uses_valid_limited_runlevel(tmp_path: Path) -> None:
+    script = _registration_script(
+        powershell="C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+        opensquilla="C:/Program Files/OpenSquilla/opensquilla.exe",
+        profile=None,
+        home=tmp_path,
+        task_name="OpenSquilla",
+    )
+
+    assert "-RunLevel Limited" in script
+    assert "LeastPrivilege" not in script
+
+
 def test_register_logon_task_windows_dispatches_encoded_registration(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli/test_autostart.py
+++ b/tests/test_cli/test_autostart.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from opensquilla.cli.autostart import (
+    AutostartError,
+    PlatformNotSupportedError,
+    _encoded_powershell,
+    _launch_script,
+    _registration_script,
+    register_logon_task,
+    task_name_for_profile,
+)
+
+
+def _decode_powershell(encoded: str) -> str:
+    return base64.b64decode(encoded.encode("ascii")).decode("utf-16-le")
+
+
+def test_task_name_for_profile() -> None:
+    assert task_name_for_profile(None) == "OpenSquilla"
+    assert task_name_for_profile("coder") == "OpenSquilla_coder"
+
+
+def test_launch_script_for_profile_sets_profile_env(tmp_path: Path) -> None:
+    home = tmp_path / "profiles" / "coder"
+    script = _launch_script(opensquilla="C:/Tools/opensquilla.exe", profile="coder", home=home)
+
+    assert "OPENSQUILLA_HOME" in script
+    assert "OPENSQUILLA_PROFILE" in script
+    assert "'--profile' 'coder' 'gateway' 'start'" in script
+
+
+def test_launch_script_without_profile_uses_legacy_gateway_start(tmp_path: Path) -> None:
+    script = _launch_script(opensquilla="C:/Tools/opensquilla.exe", profile=None, home=tmp_path)
+
+    assert "OPENSQUILLA_PROFILE" not in script
+    assert "'gateway' 'start'" in script
+    assert "--profile" not in script
+
+
+def test_registration_script_uses_encoded_inner_launch_command(tmp_path: Path) -> None:
+    home = tmp_path / "profiles with space" / "coder"
+    script = _registration_script(
+        powershell="C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+        opensquilla="C:/Program Files/OpenSquilla/opensquilla.exe",
+        profile="coder",
+        home=home,
+        task_name="OpenSquilla_coder",
+    )
+
+    assert "New-ScheduledTaskAction" in script
+    assert "Register-ScheduledTask" in script
+    assert "OpenSquilla_coder" in script
+    marker = "-EncodedCommand "
+    encoded = script.split(marker, 1)[1].split("'", 1)[0]
+    inner = _decode_powershell(encoded)
+    assert "C:/Program Files/OpenSquilla/opensquilla.exe" in inner
+    assert "--profile" in inner
+
+
+def test_register_logon_task_windows_dispatches_encoded_registration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "profiles" / "coder"
+    home.mkdir(parents=True)
+    monkeypatch.setattr("opensquilla.cli.autostart.platform.system", lambda: "Windows")
+
+    def fake_which(name: str) -> str | None:
+        if name == "opensquilla":
+            return "C:/Tools/opensquilla.exe"
+        if name in {"powershell.exe", "powershell"}:
+            return "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+        return None
+
+    monkeypatch.setattr("opensquilla.cli.autostart.shutil.which", fake_which)
+    with mock.patch("opensquilla.cli.autostart.subprocess.run") as run_mock:
+        run_mock.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+        result = register_logon_task(profile="coder", home=home)
+
+    assert result.platform == "Windows"
+    assert result.profile == "coder"
+    assert result.target == "OpenSquilla_coder"
+    cmd = run_mock.call_args.args[0]
+    assert cmd[:4] == [
+        "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+    ]
+    assert cmd[4] == "-EncodedCommand"
+    outer = _decode_powershell(cmd[5])
+    assert "Register-ScheduledTask" in outer
+    assert "OpenSquilla_coder" in outer
+
+
+def test_register_logon_task_rejects_unsupported_platform(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("opensquilla.cli.autostart.platform.system", lambda: "Darwin")
+
+    with pytest.raises(PlatformNotSupportedError, match="Windows-only"):
+        register_logon_task(profile="coder", home=tmp_path)
+
+
+def test_register_logon_task_raises_when_opensquilla_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("opensquilla.cli.autostart.platform.system", lambda: "Windows")
+    monkeypatch.setattr("opensquilla.cli.autostart.shutil.which", lambda name: None)
+
+    with pytest.raises(AutostartError, match="opensquilla is not on PATH"):
+        register_logon_task(profile="coder", home=tmp_path)
+
+
+def test_encoded_powershell_round_trips() -> None:
+    script = "$env:OPENSQUILLA_PROFILE = 'coder'"
+    assert _decode_powershell(_encoded_powershell(script)) == script

--- a/tests/test_cli/test_autostart.py
+++ b/tests/test_cli/test_autostart.py
@@ -21,6 +21,10 @@ def _decode_powershell(encoded: str) -> str:
     return base64.b64decode(encoded.encode("ascii")).decode("utf-16-le")
 
 
+def _extract_encoded_after(script: str, marker: str) -> str:
+    return script.split(marker, 1)[1].split("'", 1)[0]
+
+
 def test_task_name_for_profile() -> None:
     assert task_name_for_profile(None) == "OpenSquilla"
     assert task_name_for_profile("coder") == "OpenSquilla_coder"
@@ -110,6 +114,35 @@ def test_register_logon_task_windows_dispatches_encoded_registration(
     outer = _decode_powershell(cmd[5])
     assert "Register-ScheduledTask" in outer
     assert "OpenSquilla_coder" in outer
+
+
+def test_register_logon_task_state_dir_reaches_nested_launch_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "state-home"
+    home.mkdir(parents=True)
+    monkeypatch.setattr("opensquilla.cli.autostart.platform.system", lambda: "Windows")
+
+    def fake_which(name: str) -> str | None:
+        if name == "opensquilla":
+            return "C:/Tools/opensquilla.exe"
+        if name in {"powershell.exe", "powershell"}:
+            return "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+        return None
+
+    monkeypatch.setattr("opensquilla.cli.autostart.shutil.which", fake_which)
+    with mock.patch("opensquilla.cli.autostart.subprocess.run") as run_mock:
+        run_mock.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+        result = register_logon_task(profile=None, home=home, state_dir=home)
+
+    assert result.profile is None
+    cmd = run_mock.call_args.args[0]
+    outer = _decode_powershell(cmd[5])
+    inner_encoded = _extract_encoded_after(outer, "-EncodedCommand ")
+    inner = _decode_powershell(inner_encoded)
+    assert "OPENSQUILLA_STATE_DIR" in inner
+    assert str(home) in inner
+    assert "--profile" not in inner
 
 
 def test_register_logon_task_rejects_unsupported_platform(

--- a/tests/test_cli/test_autostart.py
+++ b/tests/test_cli/test_autostart.py
@@ -39,6 +39,18 @@ def test_launch_script_for_profile_sets_profile_env(tmp_path: Path) -> None:
     assert "'--profile' 'coder' 'gateway' 'start'" in script
 
 
+def test_launch_script_for_profile_masks_inherited_state_dir(tmp_path: Path) -> None:
+    home = tmp_path / "profiles" / "coder"
+    script = _launch_script(opensquilla="C:/Tools/opensquilla.exe", profile="coder", home=home)
+
+    clear_state_dir = r"Remove-Item Env:\OPENSQUILLA_STATE_DIR -ErrorAction SilentlyContinue"
+    set_home = "$env:OPENSQUILLA_HOME"
+    set_profile = "$env:OPENSQUILLA_PROFILE"
+
+    assert clear_state_dir in script
+    assert script.index(clear_state_dir) < script.index(set_home) < script.index(set_profile)
+
+
 def test_launch_script_without_profile_uses_legacy_gateway_start(tmp_path: Path) -> None:
     script = _launch_script(opensquilla="C:/Tools/opensquilla.exe", profile=None, home=tmp_path)
 

--- a/tests/test_cli/test_autostart.py
+++ b/tests/test_cli/test_autostart.py
@@ -43,6 +43,20 @@ def test_launch_script_without_profile_uses_legacy_gateway_start(tmp_path: Path)
     assert "--profile" not in script
 
 
+def test_launch_script_with_state_dir_sets_state_override(tmp_path: Path) -> None:
+    home = tmp_path / "state-home"
+    script = _launch_script(
+        opensquilla="C:/Tools/opensquilla.exe",
+        profile=None,
+        home=home,
+        state_dir=home,
+    )
+
+    assert "OPENSQUILLA_STATE_DIR" in script
+    assert str(home) in script
+    assert "--profile" not in script
+
+
 def test_registration_script_uses_encoded_inner_launch_command(tmp_path: Path) -> None:
     home = tmp_path / "profiles with space" / "coder"
     script = _registration_script(

--- a/tests/test_cli/test_init_cmd.py
+++ b/tests/test_cli/test_init_cmd.py
@@ -92,6 +92,28 @@ def test_init_autostart_state_dir_override_is_registered(
     )
 
 
+def test_init_autostart_state_dir_wins_over_profile_env(
+    monkeypatch, tmp_path: Path
+) -> None:
+    state_home = tmp_path / "state-home"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(state_home))
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path / "profiles"))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "coder")
+    _patch_init_answers(monkeypatch)
+
+    with mock.patch("opensquilla.cli.init_cmd.autostart") as autostart_mock:
+        autostart_mock.register_logon_task.return_value.summary.return_value = (
+            "Windows autostart registered for default home"
+        )
+        run_init(autostart_register=True)
+
+    autostart_mock.register_logon_task.assert_called_once_with(
+        profile=None,
+        home=state_home,
+        state_dir=state_home,
+    )
+
+
 def test_init_autostart_errors_are_non_fatal(monkeypatch, tmp_path: Path) -> None:
     from opensquilla.cli import autostart
 

--- a/tests/test_cli/test_init_cmd.py
+++ b/tests/test_cli/test_init_cmd.py
@@ -1,4 +1,9 @@
-from opensquilla.cli.init_cmd import _default_model_for_provider
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+from opensquilla.cli.init_cmd import _default_model_for_provider, run_init
 
 
 def test_init_uses_direct_deepseek_model_default() -> None:
@@ -7,3 +12,96 @@ def test_init_uses_direct_deepseek_model_default() -> None:
 
 def test_init_keeps_openrouter_model_default() -> None:
     assert _default_model_for_provider("openrouter") == "deepseek/deepseek-v4-pro"
+
+
+class _FakeAsk:
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def ask(self) -> str:
+        return self._value
+
+
+def _patch_init_answers(monkeypatch) -> None:
+    answers = iter(["openrouter", "sk-test"])
+
+    def fake_select(_prompt: str, choices: list[str], default: str = "") -> object:
+        return _FakeAsk(next(answers))
+
+    def fake_password(_prompt: str) -> object:
+        return _FakeAsk(next(answers))
+
+    def fake_text(_prompt: str, default: str = "") -> object:
+        return _FakeAsk(default)
+
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.select", fake_select)
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.password", fake_password)
+    monkeypatch.setattr("opensquilla.cli.init_cmd.questionary.text", fake_text)
+
+
+def test_init_autostart_off_by_default(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "home"))
+    monkeypatch.delenv("OPENSQUILLA_HOME", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_PROFILE", raising=False)
+    _patch_init_answers(monkeypatch)
+
+    with mock.patch("opensquilla.cli.init_cmd.autostart") as autostart_mock:
+        run_init()
+
+    autostart_mock.register_logon_task.assert_not_called()
+
+
+def test_init_autostart_flag_uses_active_profile(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(tmp_path / "profiles"))
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "coder")
+    _patch_init_answers(monkeypatch)
+
+    with mock.patch("opensquilla.cli.init_cmd.autostart") as autostart_mock:
+        autostart_mock.register_logon_task.return_value.summary.return_value = (
+            "Windows autostart registered for profile 'coder'"
+        )
+        run_init(autostart_register=True)
+
+    autostart_mock.register_logon_task.assert_called_once_with(
+        profile="coder",
+        home=tmp_path / "profiles" / "coder",
+    )
+
+
+def test_init_autostart_without_profile_uses_legacy_home(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "legacy-home"))
+    monkeypatch.delenv("OPENSQUILLA_HOME", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_PROFILE", raising=False)
+    _patch_init_answers(monkeypatch)
+
+    with mock.patch("opensquilla.cli.init_cmd.autostart") as autostart_mock:
+        autostart_mock.register_logon_task.return_value.summary.return_value = (
+            "Windows autostart registered for default home"
+        )
+        run_init(autostart_register=True)
+
+    autostart_mock.register_logon_task.assert_called_once_with(
+        profile=None,
+        home=tmp_path / "legacy-home",
+    )
+
+
+def test_init_autostart_errors_are_non_fatal(monkeypatch, tmp_path: Path) -> None:
+    from opensquilla.cli import autostart
+
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "home"))
+    monkeypatch.delenv("OPENSQUILLA_HOME", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_PROFILE", raising=False)
+    _patch_init_answers(monkeypatch)
+
+    with mock.patch(
+        "opensquilla.cli.init_cmd.autostart.register_logon_task",
+        side_effect=autostart.AutostartError("simulated failure"),
+    ):
+        run_init(autostart_register=True)
+
+    assert (tmp_path / "home" / ".env").exists()
+    assert (tmp_path / "home" / "config.toml").exists()

--- a/tests/test_cli/test_init_cmd.py
+++ b/tests/test_cli/test_init_cmd.py
@@ -66,13 +66,15 @@ def test_init_autostart_flag_uses_active_profile(monkeypatch, tmp_path: Path) ->
     autostart_mock.register_logon_task.assert_called_once_with(
         profile="coder",
         home=tmp_path / "profiles" / "coder",
+        state_dir=None,
     )
 
 
-def test_init_autostart_without_profile_uses_legacy_home(
+def test_init_autostart_state_dir_override_is_registered(
     monkeypatch, tmp_path: Path
 ) -> None:
-    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "legacy-home"))
+    home = tmp_path / "state-home"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
     monkeypatch.delenv("OPENSQUILLA_HOME", raising=False)
     monkeypatch.delenv("OPENSQUILLA_PROFILE", raising=False)
     _patch_init_answers(monkeypatch)
@@ -85,7 +87,8 @@ def test_init_autostart_without_profile_uses_legacy_home(
 
     autostart_mock.register_logon_task.assert_called_once_with(
         profile=None,
-        home=tmp_path / "legacy-home",
+        home=home,
+        state_dir=home,
     )
 
 

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -31,3 +31,10 @@ def test_task_scheduler_registration_uses_encoded_command() -> None:
     assert "-EncodedCommand" in text
     assert "ConvertTo-PowerShellSingleQuotedLiteral" in text
     assert "ConvertTo-XmlEscapedText" in text
+
+
+def test_supervisor_profile_name_match_is_case_sensitive() -> None:
+    lib = (SUPERVISOR / "lib.ps1").read_text(encoding="utf-8")
+
+    assert "-cmatch $Script:PROFILE_NAME_PATTERN" in lib
+    assert "-match $Script:PROFILE_NAME_PATTERN" not in lib

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -74,3 +74,11 @@ def test_supervisor_profile_invocation_masks_inherited_state_dir() -> None:
         < lib.index(resolve_command)
     )
     assert lib.index(resolve_command) < lib.index(restore_state_dir)
+
+
+def test_supervisor_skip_running_checks_gateway_state_not_exit_code() -> None:
+    start_all = (SUPERVISOR / "start-all.ps1").read_text(encoding="utf-8")
+
+    assert "ConvertFrom-Json -ErrorAction SilentlyContinue" in start_all
+    assert "[string]$parsed.state -eq 'running'" in start_all
+    assert "if ($status.ExitCode -eq 0)" not in start_all

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -82,3 +82,13 @@ def test_supervisor_skip_running_checks_gateway_state_not_exit_code() -> None:
     assert "ConvertFrom-Json -ErrorAction SilentlyContinue" in start_all
     assert "[string]$parsed.state -eq 'running'" in start_all
     assert "if ($status.ExitCode -eq 0)" not in start_all
+
+
+def test_supervisor_ports_are_persisted_per_profile() -> None:
+    lib = (SUPERVISOR / "lib.ps1").read_text(encoding="utf-8")
+
+    assert "$Script:PORT_FILE_NAME = 'supervisor-port.txt'" in lib
+    assert "Get-ProfilePortFile" in lib
+    assert "Get-UsedProfilePorts" in lib
+    assert "Set-Content -LiteralPath $portFile" in lib
+    assert "$BasePort + $index" not in lib

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -53,3 +53,24 @@ def test_supervisor_explicit_repo_takes_precedence_over_installed_binary() -> No
     assert auto_detect in lib
     assert lib.index(repo_branch) < lib.index(explicit_error) < lib.index(installed_lookup)
     assert lib.index(installed_lookup) < lib.index(auto_detect)
+
+
+def test_supervisor_profile_invocation_masks_inherited_state_dir() -> None:
+    lib = (SUPERVISOR / "lib.ps1").read_text(encoding="utf-8")
+
+    save_state_dir = "$previousStateDir = $env:OPENSQUILLA_STATE_DIR"
+    clear_state_dir = r"Remove-Item Env:\OPENSQUILLA_STATE_DIR -ErrorAction SilentlyContinue"
+    restore_state_dir = "$env:OPENSQUILLA_STATE_DIR = $previousStateDir"
+    set_profile = "$env:OPENSQUILLA_PROFILE = $profileLeaf"
+    resolve_command = "$cmd = Get-OpensquillaCommand -Repo $Repo"
+
+    assert save_state_dir in lib
+    assert clear_state_dir in lib
+    assert restore_state_dir in lib
+    assert (
+        lib.index(save_state_dir)
+        < lib.index(set_profile)
+        < lib.index(clear_state_dir)
+        < lib.index(resolve_command)
+    )
+    assert lib.index(resolve_command) < lib.index(restore_state_dir)

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SUPERVISOR = ROOT / "scripts" / "supervisor"
+
+
+def test_supervisor_scripts_are_windows_profile_scoped() -> None:
+    scripts = {
+        "lib.ps1",
+        "start-all.ps1",
+        "stop-all.ps1",
+        "status.ps1",
+        "install-autostart.ps1",
+        "uninstall-autostart.ps1",
+    }
+    for name in scripts:
+        assert (SUPERVISOR / name).is_file()
+
+    combined = "\n".join((SUPERVISOR / name).read_text(encoding="utf-8") for name in scripts)
+    assert r"D:\ai\opensquilla" not in combined
+    assert "OPENSQUILLA_HOME" in combined
+    assert "--profile" in combined
+    assert "^[a-z0-9][a-z0-9_-]{0,63}$" in combined
+
+
+def test_task_scheduler_registration_uses_encoded_command() -> None:
+    text = (SUPERVISOR / "install-autostart.ps1").read_text(encoding="utf-8")
+
+    assert "-EncodedCommand" in text
+    assert "ConvertTo-PowerShellSingleQuotedLiteral" in text
+    assert "ConvertTo-XmlEscapedText" in text

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -45,6 +45,11 @@ def test_supervisor_explicit_repo_takes_precedence_over_installed_binary() -> No
 
     repo_branch = "if ($Repo) {"
     installed_lookup = "$installed = Get-Command 'opensquilla'"
+    explicit_error = 'throw "OpenSquilla repo lacks pyproject.toml: $resolvedRepo"'
+    auto_detect = "Get-OpensquillaRoot -Override $null"
     assert repo_branch in lib
     assert installed_lookup in lib
-    assert lib.index(repo_branch) < lib.index(installed_lookup)
+    assert explicit_error in lib
+    assert auto_detect in lib
+    assert lib.index(repo_branch) < lib.index(explicit_error) < lib.index(installed_lookup)
+    assert lib.index(installed_lookup) < lib.index(auto_detect)

--- a/tests/test_supervisor_scripts.py
+++ b/tests/test_supervisor_scripts.py
@@ -38,3 +38,13 @@ def test_supervisor_profile_name_match_is_case_sensitive() -> None:
 
     assert "-cmatch $Script:PROFILE_NAME_PATTERN" in lib
     assert "-match $Script:PROFILE_NAME_PATTERN" not in lib
+
+
+def test_supervisor_explicit_repo_takes_precedence_over_installed_binary() -> None:
+    lib = (SUPERVISOR / "lib.ps1").read_text(encoding="utf-8")
+
+    repo_branch = "if ($Repo) {"
+    installed_lookup = "$installed = Get-Command 'opensquilla'"
+    assert repo_branch in lib
+    assert installed_lookup in lib
+    assert lib.index(repo_branch) < lib.index(installed_lookup)


### PR DESCRIPTION
## Summary

This draft extracts the `init --autostart` idea from #210 into a smaller Windows-only PR targeted at `main`.

It is stacked after #429 and #430. It should remain draft until the profile foundation has landed and the Windows scheduled-task path has been validated on a Windows host.

## Why Windows Only

The stable part of #210 that maps cleanly onto current `main` is Windows per-user Task Scheduler registration. macOS LaunchAgent and Linux systemd support need separate launch semantics, quoting rules, uninstall/update behavior, and host validation. Keeping this PR Windows-only reduces release risk and avoids pretending cross-platform autostart is tested when it is not.

## Changes

- Add `opensquilla init --autostart/--no-autostart`.
- Add a small Windows-only `opensquilla.cli.autostart` helper that registers a per-user Task Scheduler logon task.
- Preserve legacy behavior: without an explicit profile, autostart launches `opensquilla gateway start` for the legacy home; with an explicit profile, it launches `opensquilla --profile <name> gateway start` and persists `OPENSQUILLA_HOME`/`OPENSQUILLA_PROFILE` inside the scheduled PowerShell command.
- Preserve `OPENSQUILLA_STATE_DIR` autostart context when init is operating on an explicit state directory instead of a named profile.
- Mask inherited `OPENSQUILLA_STATE_DIR` in profile autostart launch payloads, so a global/user env override cannot defeat the selected profile.
- Use the ScheduledTasks-supported `-RunLevel Limited` value for per-user registration.
- Treat autostart registration as best-effort: failures warn but do not abort init after `.env` and `config.toml` are written.
- Add mocked unit tests for scheduled-task command generation, nested encoded launch payloads, state-dir propagation, profile state-dir masking, valid RunLevel, and init integration.

## Differences from #210

- Windows-only for now; macOS LaunchAgent and Linux systemd support are intentionally excluded.
- Uses encoded PowerShell command payloads to avoid path/argument quoting issues.
- Does not change provider defaults or pull in MiniMax/provider catalog changes.

## Stability

This path is opt-in through `opensquilla init --autostart`. The registration helper is Windows-gated and best-effort, so normal init and non-Windows startup remain unaffected. It should stay draft until actual Task Scheduler registration is exercised on Windows.

## Attribution

Extracted from #210, originally contributed by @tqangxl.

Relevant original commit:

- 22784f7f6b80e8770429b03b2d3849f1f9962aaf - Add per-profile logon autostart on Windows / macOS / Linux (issue #193)

The extracted contribution commit includes `Co-authored-by: Tqangxl <tqangxl@gmail.com>`. Follow-up stabilization commits are maintainer-side test/fix commits.

## Validation

Restacked on #430/#429 and `origin/main@ae5e6f10` on 2026-07-03.

- `uv run pytest -q tests/test_cli/test_autostart.py tests/test_cli/test_init_cmd.py tests/test_cli/test_profile_env_loading.py` - 27 passed
- `uv run pytest -q tests/test_paths_profile.py tests/test_cli/test_profile_env_loading.py tests/unit/test_env.py tests/test_cli/test_gateway_cmd.py tests/test_paths_media_root.py tests/test_supervisor_scripts.py tests/test_cli/test_autostart.py tests/test_cli/test_init_cmd.py tests/test_cli/test_onboard_cmd.py::test_configure_search_can_use_env_key_reference tests/test_cli/test_search_cmd.py::test_search_configure_warns_when_env_key_is_not_set` - 118 passed
- `uv run ruff check ...` for the touched Python files and tests - passed
- `git diff --check origin/main..HEAD` - passed

Not locally validated: actual Task Scheduler registration on Windows. The tests mock subprocess execution and inspect the generated PowerShell payload.

Local full-suite note: `uv run pytest -q` is not a clean local gating signal in this macOS worktree because representative failures reproduce on `origin/main` itself: OpenTUI tests require `@opentui/core`, and the router artifact manifest freshness test is already stale on main.
