### PR TITLE
[codex] Force UTF-8 for Windows Python launchers

### DIFF
--- a/desktop/electron/scripts/build-gateway.mjs
+++ b/desktop/electron/scripts/build-gateway.mjs
@@ -95,6 +95,8 @@ function pythonPackageFile(packageName, relativePath) {
       env: {
         ...process.env,
         PYTHONUNBUFFERED: '1',
+        PYTHONUTF8: '1',
+        PYTHONIOENCODING: 'utf-8:replace',
       },
       encoding: 'utf8',
       windowsHide: true,
@@ -299,6 +301,8 @@ const result = spawnSync('uv', args, {
   env: {
     ...process.env,
     PYTHONUNBUFFERED: '1',
+    PYTHONUTF8: '1',
+    PYTHONIOENCODING: 'utf-8:replace',
   },
   stdio: 'inherit',
 })

--- a/desktop/electron/scripts/smoke-gateway.mjs
+++ b/desktop/electron/scripts/smoke-gateway.mjs
@@ -128,6 +128,8 @@ function smokeEnv(tempHome, stateDir, config) {
     OPENSQUILLA_STATE_DIR: stateDir,
     OPENSQUILLA_GATEWAY_CONFIG_PATH: config,
     PYTHONUNBUFFERED: '1',
+    PYTHONUTF8: '1',
+    PYTHONIOENCODING: 'utf-8:replace',
   }
 }
 

--- a/desktop/electron/scripts/verify-package.mjs
+++ b/desktop/electron/scripts/verify-package.mjs
@@ -49,7 +49,11 @@ function verificationEnv() {
     'LANG',
     'LC_ALL',
   ]
-  const env = { PYTHONUNBUFFERED: '1' }
+  const env = {
+    PYTHONUNBUFFERED: '1',
+    PYTHONUTF8: '1',
+    PYTHONIOENCODING: 'utf-8:replace',
+  }
 
   for (const key of keys) {
     if (process.env[key] !== undefined) env[key] = process.env[key]

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -3188,6 +3188,8 @@ async function startGateway(): Promise<GatewayState> {
     OPENSQUILLA_STATE_DIR: desktopStateDir(),
     ...(connection.disableNetworkObservability ? { OPENSQUILLA_PRIVACY_DISABLE_NETWORK_OBSERVABILITY: '1' } : {}),
     PYTHONUNBUFFERED: '1',
+    PYTHONUTF8: '1',
+    PYTHONIOENCODING: 'utf-8:replace',
   }
 
   const child = spawn(
@@ -4136,6 +4138,9 @@ async function runUninstallCli(
       OPENSQUILLA_INSTALL_METHOD: 'desktop',
       OPENSQUILLA_GATEWAY_CONFIG_PATH: desktopConfigPath(),
       OPENSQUILLA_STATE_DIR: desktopHome(),
+      PYTHONUNBUFFERED: '1',
+      PYTHONUTF8: '1',
+      PYTHONIOENCODING: 'utf-8:replace',
     },
   })
   let stdout = ''

--- a/scripts/build_wheelhouse_zip.py
+++ b/scripts/build_wheelhouse_zip.py
@@ -876,6 +876,8 @@ def render_start_ps1(profile: str = "recommended") -> str:
 )
 
 $ErrorActionPreference = "Stop"
+$env:PYTHONUTF8 = '1'
+$env:PYTHONIOENCODING = 'utf-8:replace'
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $PackageDir = Join-Path $ScriptDir 'packages'

--- a/start.ps1
+++ b/start.ps1
@@ -5,6 +5,8 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$env:PYTHONUTF8 = '1'
+$env:PYTHONIOENCODING = 'utf-8:replace'
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $PackageDir = Join-Path $ScriptDir 'packages'

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -164,6 +164,25 @@ def test_start_gateway_enriches_child_path_for_code_task_builds() -> None:
     assert "PATH: childPath" in start
 
 
+def test_desktop_python_children_force_utf8_stdio() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    start = _section(
+        main_ts,
+        "async function startGateway",
+        "async function loadControlUi",
+    )
+    uninstall = _section(
+        main_ts,
+        "async function runUninstallCli",
+        "ipcMain.handle('desktop:uninstall:summary'",
+    )
+
+    for section in (start, uninstall):
+        assert "PYTHONUNBUFFERED: '1'" in section
+        assert "PYTHONUTF8: '1'" in section
+        assert "PYTHONIOENCODING: 'utf-8:replace'" in section
+
+
 def test_stop_gateway_sigkill_fallback_uses_real_child_exit_state() -> None:
     main_ts = _read("desktop/electron/src/main.ts")
     stop = _section(

--- a/tests/test_scripts/test_build_wheelhouse_zip.py
+++ b/tests/test_scripts/test_build_wheelhouse_zip.py
@@ -718,6 +718,8 @@ def test_prepare_windows_portable_release_tree_includes_double_click_launcher(
     assert "safe router fallback" in start_ps1
     assert "If automatic installation fails, install it manually" in start_ps1
     assert "After installing, reopen PowerShell and restart OpenSquilla" in start_ps1
+    assert "$env:PYTHONUTF8 = '1'" in start_ps1
+    assert "$env:PYTHONIOENCODING = 'utf-8:replace'" in start_ps1
 
 
 def test_install_portable_wheelhouse_preinstalls_into_bundled_python(


### PR DESCRIPTION
## Summary

- Force `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8:replace` for Electron desktop gateway, uninstall, smoke, package verification, and gateway build Python subprocesses.
- Apply the same UTF-8 stdio guard to the Windows portable PowerShell launcher template and root `start.ps1`.
- Add regression coverage for desktop child-process env and Windows portable generated launcher output.

## Root Cause

The default OpenSquilla system prompt contains non-BMP emoji text. On Windows systems where Python stdio defaults to GBK/cp936, Python subprocesses can raise `UnicodeEncodeError` when that text reaches stdout/stderr unless the launcher forces UTF-8 mode.

## Validation

- `uv run pytest tests/test_desktop/test_electron_startup_contract.py tests/test_scripts/test_build_wheelhouse_zip.py tests/test_root_start_scripts.py -q`
- `uv run ruff check tests/test_desktop/test_electron_startup_contract.py tests/test_scripts/test_build_wheelhouse_zip.py scripts/build_wheelhouse_zip.py`
- `npm --prefix desktop/electron ci`
- `npm --prefix desktop/electron run build`
- `npm --prefix desktop/electron run verify:icons`