### PR TITLE
[codex] Fix Windows pidlock exit-code check

### DIFF
--- a/src/opensquilla/gateway/pidlock.py
+++ b/src/opensquilla/gateway/pidlock.py
@@ -237,14 +237,25 @@ def _is_alive(pid: int) -> bool:
     if os.name == "nt":
         try:
             import ctypes
+            from ctypes import wintypes
 
             ctypes_mod = cast(Any, ctypes)
-            synchronize = 0x00100000
-            handle = ctypes_mod.windll.kernel32.OpenProcess(synchronize, False, pid)
-            if handle == 0:
+            kernel32 = ctypes_mod.windll.kernel32
+            process_query_limited_information = 0x1000
+            still_active = 259
+            handle = kernel32.OpenProcess(process_query_limited_information, False, int(pid))
+            if not handle:
                 return False
-            ctypes_mod.windll.kernel32.CloseHandle(handle)
-            return True
+            try:
+                exit_code = wintypes.DWORD()
+                if not kernel32.GetExitCodeProcess(handle, ctypes_mod.byref(exit_code)):
+                    return True
+                return int(exit_code.value) == still_active
+            finally:
+                try:
+                    kernel32.CloseHandle(handle)
+                except Exception:  # noqa: BLE001
+                    pass
         except Exception:  # noqa: BLE001
             return False
     else:

--- a/tests/test_gateway/test_pidfile_lock.py
+++ b/tests/test_gateway/test_pidfile_lock.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import sys
+import types
 from pathlib import Path
 
 import pytest
 
+from opensquilla.gateway import pidlock
 from opensquilla.gateway.pidlock import GatewayPidLock
 
 
@@ -51,3 +54,47 @@ def test_pid_lock_release_is_idempotent(tmp_path: Path) -> None:
 
     assert not (state_dir / "gateway.pid").exists()
     assert not (state_dir / "gateway.pid.lock").exists()
+
+
+def test_windows_is_alive_rejects_opened_process_with_non_active_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Dword:
+        def __init__(self) -> None:
+            self.value = 0
+
+    class Kernel32:
+        def __init__(self) -> None:
+            self.closed_handles: list[int] = []
+
+        def open_process(self, access: int, inherit_handle: bool, process_id: int) -> int:
+            return 123
+
+        def get_exit_code_process(self, handle: int, exit_code: Dword) -> int:
+            exit_code.value = 0
+            return 1
+
+        def close_handle(self, handle: int) -> int:
+            self.closed_handles.append(handle)
+            return 1
+
+    def byref(value: Dword) -> Dword:
+        return value
+
+    kernel32 = Kernel32()
+    fake_ctypes = types.ModuleType("ctypes")
+    fake_ctypes.windll = types.SimpleNamespace(
+        kernel32=types.SimpleNamespace(
+            OpenProcess=kernel32.open_process,
+            GetExitCodeProcess=kernel32.get_exit_code_process,
+            CloseHandle=kernel32.close_handle,
+        )
+    )
+    fake_ctypes.wintypes = types.SimpleNamespace(DWORD=Dword)
+    fake_ctypes.byref = byref
+
+    monkeypatch.setattr(pidlock.os, "name", "nt")
+    monkeypatch.setitem(sys.modules, "ctypes", fake_ctypes)
+
+    assert pidlock._is_alive(456) is False
+    assert kernel32.closed_handles == [123]


### PR DESCRIPTION
## Summary

- Update the Windows `GatewayPidLock` liveness probe to check `GetExitCodeProcess` after `OpenProcess` succeeds.
- Treat only `STILL_ACTIVE` (`259`) as a live process, while keeping the handle cleanup in a `finally` block.
- Add a regression test for the case where Windows can open a process handle even though the process has already exited.

## Root Cause

`pidlock._is_alive()` previously returned `True` on Windows whenever `OpenProcess` succeeded. A stale `gateway.pid` could therefore be misclassified as an active gateway when the process object was still openable but no longer running, causing subsequent desktop/gateway starts to fail with an "already running" error.

## Code Review

- Reviewed the staged diff for behavior and test scope.
- No blocking findings found.
- The fix fails closed if `GetExitCodeProcess` itself fails, preserving the safer behavior for ambiguous process state.

## Validation

- `uv run pytest tests/test_gateway/test_pidfile_lock.py -q`
- `uv run ruff check src/opensquilla/gateway/pidlock.py tests/test_gateway/test_pidfile_lock.py`
- `git diff --check -- src/opensquilla/gateway/pidlock.py tests/test_gateway/test_pidfile_lock.py`