### PR TITLE
Stabilize attachment e2e terminal waits

### DIFF
--- a/tests/functional/test_gateway_attachment_history_e2e.py
+++ b/tests/functional/test_gateway_attachment_history_e2e.py
@@ -49,6 +49,7 @@ _PNG_BYTES = (
 _TEXT_MODEL = "test/text"
 _GATE_MODEL = "test/gate"
 _VISION_MODEL = "test/vision"
+_TURN_TERMINAL_EVENT_TIMEOUT_SECONDS = 30.0
 
 
 class _RecordingProvider:
@@ -229,6 +230,7 @@ async def _send_session_turn(
     attachments: list[dict[str, Any]] | None = None,
 ) -> None:
     done_before = sum(1 for event, _payload in sink.events if event == "session.event.done")
+    event_count_before = len(sink.events)
     result = await get_dispatcher().dispatch(
         "test",
         "sessions.send",
@@ -237,18 +239,31 @@ async def _send_session_turn(
     )
     assert result.ok, result.error
 
-    deadline = asyncio.get_running_loop().time() + 5.0
-    while asyncio.get_running_loop().time() < deadline:
+    task = get_agent_task_registry().get(key)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _TURN_TERMINAL_EVENT_TIMEOUT_SECONDS
+    while loop.time() < deadline:
         done_count = sum(
             1 for event, _payload in sink.events if event == "session.event.done"
         )
         if done_count > done_before:
-            task = get_agent_task_registry().get(key)
             if task is not None:
                 await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
             return
-        if any(event == "session.event.error" for event, _payload in sink.events):
+        new_errors = [
+            payload
+            for event, payload in sink.events[event_count_before:]
+            if event == "session.event.error"
+        ]
+        if new_errors:
             raise AssertionError(f"turn emitted error events: {sink.events!r}")
+        if task is not None and task.done():
+            if task.cancelled():
+                raise AssertionError(f"agent task was cancelled; events={sink.events!r}")
+            exc = task.exception()
+            if exc is not None:
+                raise AssertionError(f"agent task failed; events={sink.events!r}") from exc
+            raise AssertionError(f"agent task ended without done event; events={sink.events!r}")
         await asyncio.sleep(0.01)
     raise AssertionError(f"timed out waiting for done event; events={sink.events!r}")
 

--- a/tests/functional/test_gateway_non_image_attachment_materialization_e2e.py
+++ b/tests/functional/test_gateway_non_image_attachment_materialization_e2e.py
@@ -44,6 +44,7 @@ from opensquilla.session.storage import SessionStorage
 _TEXT_MODEL = "test/text"
 _GATE_MODEL = "test/gate"
 _VISION_MODEL = "test/vision"
+_TURN_TERMINAL_EVENT_TIMEOUT_SECONDS = 30.0
 
 _PNG_BYTES = (
     b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
@@ -272,6 +273,7 @@ async def _send_session_turn(
     attachments: list[dict[str, Any]] | None = None,
 ) -> None:
     done_before = sum(1 for event, _payload in sink.events if event == "session.event.done")
+    event_count_before = len(sink.events)
     result = await get_dispatcher().dispatch(
         "test",
         "sessions.send",
@@ -280,18 +282,31 @@ async def _send_session_turn(
     )
     assert result.ok, result.error
 
-    deadline = asyncio.get_running_loop().time() + 5.0
-    while asyncio.get_running_loop().time() < deadline:
+    task = get_agent_task_registry().get(key)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _TURN_TERMINAL_EVENT_TIMEOUT_SECONDS
+    while loop.time() < deadline:
         done_count = sum(
             1 for event, _payload in sink.events if event == "session.event.done"
         )
         if done_count > done_before:
-            task = get_agent_task_registry().get(key)
             if task is not None:
                 await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
             return
-        if any(event == "session.event.error" for event, _payload in sink.events):
+        new_errors = [
+            payload
+            for event, payload in sink.events[event_count_before:]
+            if event == "session.event.error"
+        ]
+        if new_errors:
             raise AssertionError(f"turn emitted error events: {sink.events!r}")
+        if task is not None and task.done():
+            if task.cancelled():
+                raise AssertionError(f"agent task was cancelled; events={sink.events!r}")
+            exc = task.exception()
+            if exc is not None:
+                raise AssertionError(f"agent task failed; events={sink.events!r}") from exc
+            raise AssertionError(f"agent task ended without done event; events={sink.events!r}")
         await asyncio.sleep(0.01)
     raise AssertionError(f"timed out waiting for done event; events={sink.events!r}")
 


### PR DESCRIPTION
## Scope
- Stabilize the attachment history and non-image attachment functional e2e helpers that wait for `sessions.send` completion.
- Keep the change test-only: no CI workflow changes and no production runtime behavior changes.

## Branch Target
- Target: `main`

## Linked Issue
- None

## Root Cause
- The merged `main` run for #452 failed only on `Windows high-risk/full tests (conditional)` because `test_gateway_upload_history_image_replays_through_squilla_router_gate_history` used a fixed 5s terminal-event wait. On Windows full-suite runners, the background `TurnRunner` had emitted `session.event.router_decision` but had not reached `session.event.done` within that narrow helper timeout.

## Changes
- Extend the e2e helper terminal-event wait to 30s.
- Capture only new error events for the current send.
- Fail with a clearer diagnostic if the registered background agent task completes, cancels, or raises before emitting `session.event.done`.
- Apply the same helper hardening to the sibling non-image attachment e2e test file.

## Release Note
- None. Test-only CI stabilization.

## Tests
- `OPENSQUILLA_TESTING=true OPENSQUILLA_OPENROUTER_LIVE_PRICING=0 PYTHONPATH=$PWD uv run pytest tests/functional/test_gateway_attachment_history_e2e.py::test_gateway_upload_history_image_replays_through_squilla_router_gate_history tests/functional/test_gateway_non_image_attachment_materialization_e2e.py -q`
- `OPENSQUILLA_TESTING=true OPENSQUILLA_OPENROUTER_LIVE_PRICING=0 PYTHONPATH=$PWD uv run pytest tests/functional/test_gateway_attachment_history_e2e.py -q`
- `uv run ruff check tests/functional/test_gateway_attachment_history_e2e.py tests/functional/test_gateway_non_image_attachment_materialization_e2e.py`
- `uv run ruff check src tests`

## Safety Notes
- No secrets, transcripts, runtime state, generated assets, or workflow files changed.
- The timeout remains bounded and now surfaces task failures directly instead of hiding them behind a generic done-event timeout.

## Third-Party Origin
- None.