### PR TITLE
Fix 0.5.0rc1 Electron prerelease semver

### DIFF
--- a/desktop/electron/package-lock.json
+++ b/desktop/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensquilla/desktop-electron",
-  "version": "0.5.0rc1",
+  "version": "0.5.0-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensquilla/desktop-electron",
-      "version": "0.5.0rc1",
+      "version": "0.5.0-rc1",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensquilla/desktop-electron",
-  "version": "0.5.0rc1",
+  "version": "0.5.0-rc1",
   "private": true,
   "description": "Electron desktop shell for the OpenSquilla Control UI.",
   "repository": {

--- a/desktop/electron/scripts/verify-package.mjs
+++ b/desktop/electron/scripts/verify-package.mjs
@@ -334,6 +334,25 @@ async function readAsarText(asarPath, innerPath) {
   return asar.extractFile(asarPath, innerPath).toString('utf8')
 }
 
+async function verifyAsarPackageVersion(asarPath, label) {
+  let packageJson
+  try {
+    packageJson = JSON.parse(await readAsarText(asarPath, 'package.json'))
+  } catch (error) {
+    fail(`${label} app.asar package.json could not be inspected: ${error instanceof Error ? error.message : String(error)}`)
+    return
+  }
+
+  const version = typeof packageJson.version === 'string' ? packageJson.version : ''
+  const semverPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
+  if (!semverPattern.test(version) || /\d(?:a|b|rc)\d+$/.test(version)) {
+    fail(
+      `${label} app.asar package.json version is not npm semver: ${JSON.stringify(version)}; ` +
+        'prereleases must use 0.5.0-rc1 style, not 0.5.0rc1'
+    )
+  }
+}
+
 async function verifyGeneratedBundle({ label, resourcesDir, platform }) {
   await verifyRuntime(join(resourcesDir, 'runtime', 'gateway'), label, {
     platform,
@@ -347,6 +366,7 @@ async function verifyGeneratedBundle({ label, resourcesDir, platform }) {
   }
 
   try {
+    await verifyAsarPackageVersion(asarPath, label)
     verifyMainProcess(await readAsarText(asarPath, 'dist/main.js'), label)
   } catch (error) {
     fail(`${label} app.asar could not be inspected: ${error instanceof Error ? error.message : String(error)}`)

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -708,6 +708,8 @@ def test_package_verifier_hard_fails_stale_runtime_and_boot_contract() -> None:
         "create the desktop window before gateway startup",
         "first-run onboarding an owned modal child window",
         "does not prefer the onboarding window when focusing",
+        "app.asar package.json version is not npm semver",
+        "prereleases must use 0.5.0-rc1 style, not 0.5.0rc1",
         "process.exit(1)",
     ]:
         assert expected in verifier

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -29,9 +29,14 @@ def test_lockfile_version_matches_current_release() -> None:
 
 def test_desktop_electron_release_config_matches_current_release() -> None:
     package = json.loads(Path("desktop/electron/package.json").read_text(encoding="utf-8"))
+    lock = json.loads(Path("desktop/electron/package-lock.json").read_text(encoding="utf-8"))
     build = package["build"]
 
-    assert package["version"] == CURRENT_VERSION
+    assert package["version"] == CURRENT_DESKTOP_VERSION
+    assert lock["version"] == CURRENT_DESKTOP_VERSION
+    assert lock["packages"][""]["version"] == CURRENT_DESKTOP_VERSION
+    assert re.fullmatch(r"\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?", package["version"])
+    assert not re.search(r"(?<=\d)(?:a|b|rc)\d+$", package["version"])
     assert package["repository"] == {
         "type": "git",
         "url": "https://github.com/opensquilla/opensquilla.git",


### PR DESCRIPTION
## Summary
- use npm semver `0.5.0-rc1` for the Electron desktop package version
- keep Python/tag/wheel release version on PEP 440 `0.5.0rc1`
- fail package verification if `app.asar/package.json` contains a non-semver prerelease version

## Why
The macOS app crashed at startup when electron-updater initialized with `0.5.0rc1`: `App version is not a valid semver version`. The release asset names were already semver-normalized, but the Electron app package metadata was not.

## Tests
- `uv run pytest tests/test_release_consistency.py tests/test_desktop/test_electron_startup_contract.py -q`
- `node --check desktop/electron/scripts/verify-package.mjs`