### PR TITLE
Fix macOS startup diagnostics for 0.5.0rc1

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,8 +37,8 @@ lists.
 | [@ab2ence](https://github.com/ab2ence) | Added drag-and-drop attachments, dynamic Model Ensemble routing, and ensemble timeout tuning. | [#388](https://github.com/opensquilla/opensquilla/pull/388), [`bc9ab2fe`](https://github.com/opensquilla/opensquilla/commit/bc9ab2fe), [#454](https://github.com/opensquilla/opensquilla/pull/454) |
 | [@Liu-RK](https://github.com/Liu-RK) | Aligned sandbox run-mode authorization and approval behavior, then fixed managed execution host routing. | [#412](https://github.com/opensquilla/opensquilla/pull/412), [#450](https://github.com/opensquilla/opensquilla/pull/450) |
 | [@TUOXI293](https://github.com/TUOXI293) | Added image preview navigation. | [#447](https://github.com/opensquilla/opensquilla/pull/447) |
-| Tqangxl | Improved gateway lifecycle conflict diagnostics and promoted SQLAlchemy to a core dependency. | [`1fede3ea`](https://github.com/opensquilla/opensquilla/commit/1fede3ea), [`eb6776f2`](https://github.com/opensquilla/opensquilla/commit/eb6776f2) |
-| Shuo Zhang | Fixed WeCom AI Bot websocket mode. | [`94e4b1c1`](https://github.com/opensquilla/opensquilla/commit/94e4b1c1) |
+| [@tqangxl](https://github.com/tqangxl) | Improved gateway lifecycle conflict diagnostics and promoted SQLAlchemy to a core dependency. | [`1fede3ea`](https://github.com/opensquilla/opensquilla/commit/1fede3ea), [`eb6776f2`](https://github.com/opensquilla/opensquilla/commit/eb6776f2) |
+| [@HuaXiawithMoon](https://github.com/HuaXiawithMoon) | Fixed WeCom AI Bot websocket mode. | [`94e4b1c1`](https://github.com/opensquilla/opensquilla/commit/94e4b1c1) |
 
 ## OpenSquilla 0.4.1
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ gateway runtime in an Electron shell.
 - macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.0rc1/OpenSquilla-0.5.0-rc1-mac-arm64.dmg>
 - Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.0rc1/OpenSquilla-0.5.0-rc1-win-x64.exe>
 
-Quit any running OpenSquilla desktop app before upgrading. Existing
-`~/.opensquilla/config.toml` and session data are reused.
+Quit any running OpenSquilla desktop app before upgrading. On macOS, drag the
+app from the DMG into Applications for installation or updates, eject the DMG,
+then open the Applications copy. Existing `~/.opensquilla/config.toml` and
+session data are reused.
 
 Code signing policy: [`docs/code-signing-policy.md`](docs/code-signing-policy.md).
 
@@ -695,6 +697,16 @@ totals for the full run.
 ---
 
 ## Troubleshooting
+
+<details>
+<summary>macOS desktop app keeps bouncing or reports AppTranslocation</summary>
+
+If macOS starts OpenSquilla from a temporary AppTranslocation path, quit
+OpenSquilla, drag the app into Applications if you are installing it, eject the
+DMG, then open OpenSquilla again. If an old OpenSquilla icon is still bouncing,
+force quit the old process first and reopen OpenSquilla.
+
+</details>
 
 <details>
 <summary>macOS: <code>Library not loaded: @rpath/libomp.dylib</code></summary>

--- a/desktop/electron/src/boot.html
+++ b/desktop/electron/src/boot.html
@@ -192,6 +192,7 @@
       font-size: 13px;
       line-height: 1.45;
       margin: 0;
+      white-space: pre-line;
     }
 
     .actions {

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -122,6 +122,13 @@ interface BootError {
   at: string
 }
 
+interface MacInstallContext {
+  appBundlePath: string | null
+  translocated: boolean
+  inApplications: boolean
+  blocked: boolean
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const packageRoot = resolve(__dirname, '..')
 const defaultRepoRoot = resolve(packageRoot, '..', '..')
@@ -179,6 +186,65 @@ function appIconPath(): string {
   return app.isPackaged
     ? join(process.resourcesPath, 'app.asar', 'assets', 'icon.png')
     : join(packageRoot, 'assets', 'icon.png')
+}
+
+const MAC_APP_TRANSLOCATION_SEGMENT = '/AppTranslocation/'
+const MAC_APP_RESOURCES_SUFFIX = '.app/Contents/Resources'
+
+function normalizedPosixPath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+function macAppBundlePath(resourcesPath = process.resourcesPath): string | null {
+  const normalized = normalizedPosixPath(resourcesPath)
+  const markerIndex = normalized.indexOf(MAC_APP_RESOURCES_SUFFIX)
+  if (markerIndex < 0) return null
+  return normalized.slice(0, markerIndex + '.app'.length)
+}
+
+function isMacApplicationsBundlePath(bundlePath: string | null): boolean {
+  if (!bundlePath) return false
+  const normalized = normalizedPosixPath(bundlePath)
+  return normalized === '/Applications/OpenSquilla.app' || normalized.startsWith('/Applications/')
+}
+
+function macDesktopInstallContext(): MacInstallContext {
+  if (process.platform !== 'darwin' || !app.isPackaged) {
+    return {
+      appBundlePath: null,
+      translocated: false,
+      inApplications: true,
+      blocked: false,
+    }
+  }
+
+  const resourcesPath = normalizedPosixPath(process.resourcesPath)
+  const appBundlePath = macAppBundlePath(resourcesPath)
+  const installPath = appBundlePath || resourcesPath
+  const translocated = installPath.includes(MAC_APP_TRANSLOCATION_SEGMENT)
+  const inApplications = isMacApplicationsBundlePath(appBundlePath)
+  return {
+    appBundlePath,
+    translocated,
+    inApplications,
+    blocked: translocated,
+  }
+}
+
+function macDesktopInstallBlockerMessage(context = macDesktopInstallContext()): string | null {
+  if (!context.blocked) return null
+  const currentLocation = context.appBundlePath ? ` Current location: ${context.appBundlePath}` : ''
+  return (
+    'OpenSquilla is running from a temporary macOS AppTranslocation location. ' +
+    'Quit OpenSquilla, drag OpenSquilla.app from the DMG into Applications if you are installing it, ' +
+    'eject the DMG, then open OpenSquilla again.' +
+    currentLocation
+  )
+}
+
+function assertSupportedMacInstallLocation(): void {
+  const message = macDesktopInstallBlockerMessage()
+  if (message) throw new Error(message)
 }
 
 function sendBootStatus(phaseId: BootPhaseId): void {
@@ -563,6 +629,19 @@ function routerConfigTomlLines(credential: DesktopConnection): string[] {
   ]
 }
 
+function desktopConfigShouldWritePrivacySection(credential: DesktopConnection): boolean {
+  return credential.disableNetworkObservability || readDesktopConfigNetworkObservabilitySetting() !== null
+}
+
+function privacyConfigTomlLines(credential: DesktopConnection): string[] {
+  if (!desktopConfigShouldWritePrivacySection(credential)) return []
+  return [
+    '',
+    '[privacy]',
+    `disable_network_observability = ${credential.disableNetworkObservability ? 'true' : 'false'}`,
+  ]
+}
+
 function plainSecret(secret: string): { value: string; encryption: SecretEncryption } {
   return {
     value: Buffer.from(secret, 'utf8').toString('base64'),
@@ -770,9 +849,7 @@ async function writeDesktopConfig(credential: DesktopConnection): Promise<void> 
     `base_url = ${tomlString(credential.baseUrl)}`,
     '',
     ...routerConfigTomlLines(credential),
-    '',
-    '[privacy]',
-    `disable_network_observability = ${credential.disableNetworkObservability ? 'true' : 'false'}`,
+    ...privacyConfigTomlLines(credential),
     '',
     '[control_ui]',
     'enabled = true',
@@ -3076,12 +3153,49 @@ async function healthCheck(url: string): Promise<boolean> {
   }
 }
 
-async function waitForGateway(url: string): Promise<void> {
+const GATEWAY_OUTPUT_TAIL_MAX_CHARS = 12_000
+const NEWER_CONFIG_DIAGNOSTIC_FIELDS = [
+  'llm_ensemble',
+  'privacy',
+  'sandbox.auto_setup',
+  'llm_profiles',
+] as const
+
+function appendGatewayOutputTail(tail: string, chunk: Buffer | string): string {
+  const next = tail + String(chunk)
+  return next.length > GATEWAY_OUTPUT_TAIL_MAX_CHARS ? next.slice(-GATEWAY_OUTPUT_TAIL_MAX_CHARS) : next
+}
+
+function gatewayExitLooksLikeNewerConfig(output: string): boolean {
+  const normalized = output.toLowerCase()
+  const hasValidationSignal = (
+    normalized.includes('validationerror') ||
+    normalized.includes('extra_forbidden') ||
+    normalized.includes('extra inputs are not permitted')
+  )
+  return hasValidationSignal && NEWER_CONFIG_DIAGNOSTIC_FIELDS.some((field) => normalized.includes(field))
+}
+
+function classifyGatewayExitMessage(message: string, outputTail: string): string {
+  if (!gatewayExitLooksLikeNewerConfig(outputTail)) return message
+  return (
+    message +
+    '\n\nOpenSquilla could not read this config because it contains settings written by a newer OpenSquilla version. ' +
+    'Reopen OpenSquilla 0.5.0 Preview 1, or reset the desktop config before running an older version. ' +
+    'Use Reveal log for details.'
+  )
+}
+
+async function waitForGateway(url: string, earlyExitMessage?: () => string | null): Promise<void> {
   const startedAt = Date.now()
   while (Date.now() - startedAt < 45_000) {
+    const earlyExit = earlyExitMessage?.()
+    if (earlyExit) throw new Error(earlyExit)
     if (await healthCheck(url)) return
     await new Promise((resolveWait) => setTimeout(resolveWait, 500))
   }
+  const earlyExit = earlyExitMessage?.()
+  if (earlyExit) throw new Error(earlyExit)
   throw new Error(`Gateway did not become healthy at ${url}`)
 }
 
@@ -3124,6 +3238,8 @@ async function reuseHealthyGatewayState(): Promise<GatewayState | null> {
 async function startGateway(): Promise<GatewayState> {
   const reusableGateway = await reuseHealthyGatewayState()
   if (reusableGateway) return reusableGateway
+
+  assertSupportedMacInstallLocation()
 
   if (gatewayProcess && gatewayState.owned) {
     if (hasGatewayProcessExited(gatewayProcess)) {
@@ -3202,10 +3318,18 @@ async function startGateway(): Promise<GatewayState> {
   )
   gatewayProcess = child
 
+  let gatewayOutputTail = ''
+  let childExitMessage: string | null = null
+  const rememberGatewayOutput = (chunk: Buffer | string) => {
+    gatewayOutputTail = appendGatewayOutputTail(gatewayOutputTail, chunk)
+  }
+  child.stdout.on('data', rememberGatewayOutput)
+  child.stderr.on('data', rememberGatewayOutput)
   child.stdout.pipe(logStream, { end: false })
   child.stderr.pipe(logStream, { end: false })
   child.once('exit', (code, signal) => {
     const message = `gateway exited code=${code ?? 'null'} signal=${signal ?? 'null'}`
+    const classifiedMessage = classifyGatewayExitMessage(message, gatewayOutputTail)
     const isCurrentGateway = gatewayProcess === child
     if (isCurrentGateway) gatewayProcess = null
     logStream.write(`\n[desktop] ${message}\n`)
@@ -3215,12 +3339,13 @@ async function startGateway(): Promise<GatewayState> {
       return
     }
     gatewayState.status = 'error'
-    gatewayState.error = message
+    gatewayState.error = classifiedMessage
+    childExitMessage = classifiedMessage
     sendBootError(gatewayState.error)
   })
 
   sendBootStatus('gateway-health')
-  await waitForGateway(url)
+  await waitForGateway(url, () => childExitMessage)
   await waitForControlUi(url)
   sendBootStatus('control')
   gatewayState.status = 'ready'

--- a/docs/releases/0.5.0rc1.md
+++ b/docs/releases/0.5.0rc1.md
@@ -102,8 +102,11 @@ OpenSquilla gateway or desktop app before upgrading, then restart it after the
 install. Existing `~/.opensquilla/config.toml` and session data are reused.
 
 Desktop users should quit the running desktop app before replacing it. macOS
-users install the `.dmg` by dragging OpenSquilla into Applications. Windows
-users run the `.exe` installer.
+users install the `.dmg` by dragging OpenSquilla into Applications, ejecting
+the mounted DMG, and opening the Applications copy. If the Dock icon keeps
+bouncing or startup reports a busy/translocated app, force quit any old
+OpenSquilla process, eject the DMG, and reopen OpenSquilla. Windows users run
+the `.exe` installer.
 
 Legacy Windows portable users should switch to the Windows Electron installer
 or terminal wheel install path for 0.5.0 previews. Do not expect a new
@@ -120,10 +123,10 @@ release surface:
   managed execution host routing.
 - [@TUOXI293](https://github.com/TUOXI293), a first-time OpenSquilla release
   contributor, for image preview navigation.
-- Tqangxl, a first-time OpenSquilla release contributor, for gateway lifecycle
-  conflict diagnostics and SQLAlchemy core dependency work.
-- Shuo Zhang, a first-time OpenSquilla release contributor, for WeCom AI Bot
-  websocket mode work.
+- [@tqangxl](https://github.com/tqangxl), a first-time OpenSquilla release contributor,
+  for gateway lifecycle conflict diagnostics and SQLAlchemy core dependency work.
+- [@HuaXiawithMoon](https://github.com/HuaXiawithMoon), a first-time OpenSquilla
+  release contributor, for WeCom AI Bot websocket mode work.
 
 See [`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/main/CONTRIBUTORS.md)
 for the full attribution ledger and PR/commit evidence.

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -149,6 +149,60 @@ def test_start_gateway_does_not_attach_to_unrequested_default_dev_gateway() -> N
     assert "gatewayState.url = 'http://127.0.0.1:18791'" not in start
 
 
+def test_desktop_blocks_macos_app_translocation_without_forcing_applications() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    start = _section(
+        main_ts,
+        "async function startGateway",
+        "async function loadControlUi",
+    )
+
+    assert "const MAC_APP_TRANSLOCATION_SEGMENT = '/AppTranslocation/'" in main_ts
+    assert "function macDesktopInstallContext(): MacInstallContext" in main_ts
+    assert "function assertSupportedMacInstallLocation(): void" in main_ts
+    assert "process.platform !== 'darwin' || !app.isPackaged" in main_ts
+    assert "blocked: translocated" in main_ts
+    assert "translocated || !inApplications" not in main_ts
+    assert "drag OpenSquilla.app from the DMG into Applications" in main_ts
+    assert "then open OpenSquilla again" in main_ts
+    assert "assertSupportedMacInstallLocation()" in start
+    assert start.index("if (reusableGateway) return reusableGateway") < start.index(
+        "assertSupportedMacInstallLocation()"
+    )
+    assert start.index("assertSupportedMacInstallLocation()") < start.index("const overrideUrl")
+
+
+def test_desktop_gateway_exit_classifies_newer_config_validation_errors() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    start = _section(
+        main_ts,
+        "async function startGateway",
+        "async function loadControlUi",
+    )
+    wait = _section(
+        main_ts,
+        "async function waitForGateway",
+        "async function waitForControlUi",
+    )
+
+    assert "const GATEWAY_OUTPUT_TAIL_MAX_CHARS = 12_000" in main_ts
+    assert "const NEWER_CONFIG_DIAGNOSTIC_FIELDS = [" in main_ts
+    for field in ["'llm_ensemble'", "'privacy'", "'sandbox.auto_setup'", "'llm_profiles'"]:
+        assert field in main_ts
+    assert (
+        "function classifyGatewayExitMessage(message: string, outputTail: string): string"
+        in main_ts
+    )
+    assert "settings written by a newer OpenSquilla version" in main_ts
+    assert "let gatewayOutputTail = ''" in start
+    assert "let childExitMessage: string | null = null" in start
+    assert "appendGatewayOutputTail(gatewayOutputTail, chunk)" in start
+    assert "classifyGatewayExitMessage(message, gatewayOutputTail)" in start
+    assert "await waitForGateway(url, () => childExitMessage)" in start
+    assert "earlyExitMessage?: () => string | null" in wait
+    assert "if (earlyExit) throw new Error(earlyExit)" in wait
+
+
 def test_start_gateway_enriches_child_path_for_code_task_builds() -> None:
     main_ts = _read("desktop/electron/src/main.ts")
     start = _section(
@@ -596,11 +650,17 @@ def test_desktop_persists_network_observability_privacy_setting() -> None:
     assert "payload.disableNetworkObservability" in save
     assert "existing?.disableNetworkObservability" in save
     assert "disableNetworkObservability," in save
-    assert "'[privacy]'" in config_writer
+    assert "privacyConfigTomlLines(credential)" in config_writer
+    assert "function privacyConfigTomlLines" in main_ts
+    assert "function desktopConfigShouldWritePrivacySection" in main_ts
+    assert (
+        "credential.disableNetworkObservability || "
+        "readDesktopConfigNetworkObservabilitySetting() !== null"
+    ) in main_ts
     assert (
         "`disable_network_observability = "
         "${credential.disableNetworkObservability ? 'true' : 'false'}`"
-        in config_writer
+        in main_ts
     )
 
 
@@ -628,6 +688,29 @@ def test_desktop_credential_save_preserves_config_privacy_without_payload_settin
     assert "if (!existsSync(path)) return null" in read_config
     assert "return parseDesktopNetworkObservabilityPrivacyConfig(raw)" in read_config
     assert "return true" in read_config
+
+
+def test_desktop_config_writer_does_not_emit_new_privacy_section_by_default() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    config_writer = _section(
+        main_ts,
+        "async function writeDesktopConfig",
+        "function settingsSnapshot",
+    )
+    privacy_lines = _section(
+        main_ts,
+        "function privacyConfigTomlLines",
+        "function plainSecret",
+    )
+
+    assert "'[privacy]'" not in config_writer
+    assert "'[llm_ensemble]'" not in config_writer
+    assert "if (!desktopConfigShouldWritePrivacySection(credential)) return []" in privacy_lines
+    assert (
+        "credential.disableNetworkObservability || "
+        "readDesktopConfigNetworkObservabilitySetting() !== null"
+        in main_ts
+    )
 
 
 def test_desktop_network_observability_disable_gates_native_update_and_gateway_env() -> None:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -394,8 +394,8 @@ def test_current_contributor_ledger_records_050rc1_attribution() -> None:
     assert "#447" in section
     assert "#450" in section
     assert "#454" in section
-    assert "Tqangxl" in section
-    assert "Shuo Zhang" in section
+    assert "[@tqangxl](https://github.com/tqangxl)" in section
+    assert "[@HuaXiawithMoon](https://github.com/HuaXiawithMoon)" in section
     assert "@nice-code-la" not in section
     assert "Codex" not in section
     assert "Claude Code" not in section


### PR DESCRIPTION
## Summary
- pause packaged macOS startup only when the app is running from an AppTranslocation path, without blocking normal DMG launches
- surface newer-config validation failures with actionable boot messaging instead of only `gateway exited code=1`
- avoid writing a default `[privacy]` section unless privacy was explicitly enabled or already present
- refresh 0.5.0 Preview 1 macOS upgrade guidance and contributor handle attribution

## Review
- No blocking issues found in self-review after rebasing onto current `origin/main`.
- The key side-effect risk was over-blocking normal DMG usage; the implementation now only blocks paths containing `/AppTranslocation/` and has a contract test for that.

## Verification
- `uv run pytest tests/test_desktop/test_electron_startup_contract.py tests/test_gateway_config_legacy.py tests/test_release_consistency.py tests/test_public_release_hygiene.py`
- `npm run build`
- `npm run verify:package`
- `npm run verify:gateway-smoke`
- `npm run test:secret-storage`
- `npm run test:mock-update-flow`
- `npm run pack`
- packaged metadata check: `Info.plist` and `app.asar/package.json` both report `0.5.0-rc1`

## Release note
Do not move `v0.5.0rc1` or replace draft assets until this PR is merged and main CI is green.