### PR TITLE
Enable static OpenRouter B5 ensemble by default

### DIFF
--- a/docs/features/llm-ensemble-router-dynamic.md
+++ b/docs/features/llm-ensemble-router-dynamic.md
@@ -1,9 +1,11 @@
 # LLM Ensemble: `router_dynamic` Selection Strategy
 
-`router_dynamic` is the model-selection strategy used by `llm_ensemble` to pick
-which models act as proposers and which model acts as the aggregator for a
-given turn. It replaces static, hand-configured proposer/aggregator lists with
-a scoring system driven by SquillaRouter's tier decision for that turn.
+`router_dynamic` is the dynamic model-selection strategy used by
+`llm_ensemble` to pick which models act as proposers and which model acts as
+the aggregator for a given turn. It uses a scoring system driven by
+SquillaRouter's tier decision for that turn. Fresh configs default to the
+packaged `static_openrouter_b5` profile; set
+`llm_ensemble.selection_mode = "router_dynamic"` to use this strategy.
 
 This document describes how `router_dynamic` works. It does not cover the
 ensemble runtime mechanics (streaming, timeouts, fallback) — only how the set
@@ -179,8 +181,15 @@ recorded in `selection_plan` for debugging.
 
 ## Configuration Surface
 
-`router_dynamic` itself is not configurable by name — it is the only
-selection strategy `llm_ensemble` implements. What operators can tune:
+Operators enable this strategy with:
+
+```toml
+[llm_ensemble]
+enabled = true
+selection_mode = "router_dynamic"
+```
+
+What operators can tune:
 
 - `llm_ensemble.model_options` — extends the candidate pool beyond the router
   anchor and configured router tiers.

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -37,7 +37,11 @@ from opensquilla.artifacts import enrich_artifact_event_dict
 from opensquilla.asyncio_utils import create_background_task
 from opensquilla.engine.usage import UsageTracker as _UsageTracker
 from opensquilla.gateway.app import create_gateway_app
-from opensquilla.gateway.config import GatewayConfig, is_public_bind
+from opensquilla.gateway.config import (
+    GatewayConfig,
+    effective_agent_stream_idle_timeout_seconds,
+    is_public_bind,
+)
 from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
 from opensquilla.gateway.rpc import get_dispatcher
 from opensquilla.gateway.session_events import build_sessions_changed_payload
@@ -880,8 +884,9 @@ async def dispatch_task_runtime_turn(
         ),
     )
     raw_stream = turn_runner.run(run.message, run.session_key, **run_kwargs)
-    stream_idle_timeout = _optional_positive_timeout(
-        config, "agent_stream_idle_timeout_seconds", 600.0
+    raw_stream_idle_timeout = effective_agent_stream_idle_timeout_seconds(config)
+    stream_idle_timeout: float | None = (
+        raw_stream_idle_timeout if raw_stream_idle_timeout > 0 else None
     )
     heartbeat_interval = _optional_positive_timeout(
         config, "agent_stream_heartbeat_interval_seconds", 15.0

--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -60,6 +60,7 @@ from opensquilla.engine.types import (
 )
 from opensquilla.execution_status import normalize_execution_status
 from opensquilla.gateway.attachment_ingest import AttachmentIngestResult, ingest_attachments
+from opensquilla.gateway.config import effective_agent_stream_idle_timeout_seconds
 from opensquilla.gateway.session_events import build_sessions_changed_payload
 from opensquilla.paths import media_root_from_config
 from opensquilla.permissions import configured_default_elevated
@@ -223,7 +224,6 @@ _INTERNAL_COMPACTION_MARKER_PREFIXES = (
 )
 _DIRECTIVE_TAG_BUFFER_LIMIT = 256
 _DEFAULT_STREAM_HEARTBEAT_INTERVAL_SECONDS = 15.0
-_DEFAULT_STREAM_IDLE_TIMEOUT_SECONDS = 600.0
 
 
 def _strip_inline_directive_tags(content: str) -> str:
@@ -1189,13 +1189,13 @@ def _optional_positive_config_float(config: Any, attr: str, default: float) -> f
 def _wrap_channel_turn_stream(stream: Any, config: Any) -> Any:
     from opensquilla.engine.stream_wrappers import wrap_stream
 
+    raw_stream_idle_timeout = effective_agent_stream_idle_timeout_seconds(config)
+    stream_idle_timeout: float | None = (
+        raw_stream_idle_timeout if raw_stream_idle_timeout > 0 else None
+    )
     return wrap_stream(
         stream,
-        idle_timeout=_optional_positive_config_float(
-            config,
-            "agent_stream_idle_timeout_seconds",
-            _DEFAULT_STREAM_IDLE_TIMEOUT_SECONDS,
-        ),
+        idle_timeout=stream_idle_timeout,
         heartbeat_interval=_optional_positive_config_float(
             config,
             "agent_stream_heartbeat_interval_seconds",

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -319,10 +319,12 @@ class LlmEnsembleConfig(BaseSettings):
         extra="ignore",
     )
 
-    # Off by default so a fresh install lands on the single-model AI router
-    # (squilla_router). Ensemble is opt-in via the composer's routing control.
-    enabled: bool = False
+    # Static OpenRouter B5 is the default routing surface. The legacy scalar
+    # timeout/min-success field defaults remain below so `router_dynamic` keeps
+    # its historical behaviour when an operator explicitly selects it.
+    enabled: bool = True
     mode: Literal["b5_fusion"] = "b5_fusion"
+    selection_mode: Literal["router_dynamic", "static_openrouter_b5"] = "static_openrouter_b5"
     proposer_tools: bool = False
     min_successful_proposers: int = Field(default=1, ge=1)
     all_failed_policy: Literal["fallback_single", "error"] = "fallback_single"
@@ -347,6 +349,54 @@ class LlmEnsembleConfig(BaseSettings):
             raise ValueError("llm_ensemble.model_options must define at least one model")
         self.model_options = model_options
         return self
+
+
+STATIC_OPENROUTER_B5_SELECTION_MODE = "static_openrouter_b5"
+STATIC_OPENROUTER_B5_MIN_AGENT_STREAM_IDLE_TIMEOUT_SECONDS = 1200.0
+STATIC_OPENROUTER_B5_MIN_WEBUI_STREAM_IDLE_GRACE_SECONDS = 1260.0
+
+
+def _non_negative_float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(0.0, parsed)
+
+
+def static_openrouter_b5_ensemble_enabled(config: Any) -> bool:
+    ensemble_cfg = getattr(config, "llm_ensemble", None)
+    if ensemble_cfg is None:
+        return False
+    return bool(getattr(ensemble_cfg, "enabled", False)) and (
+        str(getattr(ensemble_cfg, "selection_mode", "") or "")
+        == STATIC_OPENROUTER_B5_SELECTION_MODE
+    )
+
+
+def effective_agent_stream_idle_timeout_seconds(config: Any) -> float:
+    value = _non_negative_float(
+        getattr(config, "agent_stream_idle_timeout_seconds", 600.0),
+        600.0,
+    )
+    if static_openrouter_b5_ensemble_enabled(config):
+        value = max(value, STATIC_OPENROUTER_B5_MIN_AGENT_STREAM_IDLE_TIMEOUT_SECONDS)
+    return value
+
+
+def effective_webui_stream_idle_grace_seconds(config: Any) -> float:
+    value = _non_negative_float(
+        getattr(config, "webui_stream_idle_grace_seconds", 630.0),
+        630.0,
+    )
+    if static_openrouter_b5_ensemble_enabled(config):
+        server_idle = effective_agent_stream_idle_timeout_seconds(config)
+        value = max(
+            value,
+            STATIC_OPENROUTER_B5_MIN_WEBUI_STREAM_IDLE_GRACE_SECONDS,
+            server_idle + 60.0,
+        )
+    return value
 
 
 # Module-level dedupe state for the legacy ``enabled`` deprecation warning.

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -16,6 +16,7 @@ from opensquilla.engine.cache_break_monitor import notify_compaction
 from opensquilla.engine.start_turn import start_turn_via_runtime
 from opensquilla.gateway import attachment_ingest as _attachment_ingest
 from opensquilla.gateway.agent_tasks import get_agent_task_registry
+from opensquilla.gateway.config import effective_agent_stream_idle_timeout_seconds
 from opensquilla.gateway.input_normalization import (
     infer_normalized_input_from_attachments,
     materialize_generated_text_attachments,
@@ -1755,8 +1756,9 @@ async def _handle_sessions_send(params: dict | None, ctx: RpcContext) -> dict:
                 semantic_message=semantic_message_text,
                 fresh_user_session=fresh_user_session,
             )
-            stream_idle_timeout = _optional_positive_timeout(
-                ctx.config, "agent_stream_idle_timeout_seconds", 600.0
+            raw_stream_idle_timeout = effective_agent_stream_idle_timeout_seconds(ctx.config)
+            stream_idle_timeout: float | None = (
+                raw_stream_idle_timeout if raw_stream_idle_timeout > 0 else None
             )
             heartbeat_interval = _optional_positive_timeout(
                 ctx.config, "agent_stream_heartbeat_interval_seconds", 15.0

--- a/src/opensquilla/gateway/websocket.py
+++ b/src/opensquilla/gateway/websocket.py
@@ -14,7 +14,11 @@ from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
 from opensquilla import __version__
 from opensquilla.gateway.auth import Principal
-from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.config import (
+    GatewayConfig,
+    effective_agent_stream_idle_timeout_seconds,
+    effective_webui_stream_idle_grace_seconds,
+)
 from opensquilla.gateway.protocol import (
     PREAUTH_TIMEOUT_MS,
     PROTOCOL_VERSION,
@@ -642,12 +646,10 @@ async def handle_ws_connection(
                 * 1000
             ),
             agent_stream_idle_timeout_ms=int(
-                max(0.0, float(getattr(config, "agent_stream_idle_timeout_seconds", 600.0)))
-                * 1000
+                effective_agent_stream_idle_timeout_seconds(config) * 1000
             ),
             webui_stream_idle_grace_ms=int(
-                max(0.0, float(getattr(config, "webui_stream_idle_grace_seconds", 630.0)))
-                * 1000
+                effective_webui_stream_idle_grace_seconds(config) * 1000
             ),
             client_ws_keepalive_timeout_ms=int(
                 max(0.0, float(getattr(config, "client_ws_keepalive_timeout_s", 120.0)))

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -250,13 +250,28 @@ def _member_model_capabilities(member: EnsembleMemberConfig) -> ModelCapabilitie
         return ModelCapabilities()
 
 
+def _member_max_tokens(member: EnsembleMemberConfig) -> int:
+    if member.max_tokens and member.max_tokens > 0:
+        return member.max_tokens
+    cfg = member.provider_config
+    try:
+        return ModelCatalog().resolve_max_tokens(
+            cfg.model,
+            user_override=0,
+            provider=cfg.provider,
+        )
+    except Exception:
+        return ChatConfig().max_tokens
+
+
 def _member_chat_config(base: ChatConfig | None, member: EnsembleMemberConfig) -> ChatConfig:
     cfg = base.model_copy(deep=True) if base is not None else ChatConfig()
-    updates: dict[str, Any] = {"model_capabilities": _member_model_capabilities(member)}
+    updates: dict[str, Any] = {
+        "max_tokens": _member_max_tokens(member),
+        "model_capabilities": _member_model_capabilities(member),
+    }
     if member.temperature is not None:
         updates["temperature"] = member.temperature
-    if member.max_tokens and member.max_tokens > 0:
-        updates["max_tokens"] = member.max_tokens
     thinking, thinking_level = _normalize_thinking(member.thinking)
     if thinking is not None:
         updates["thinking"] = thinking
@@ -367,6 +382,7 @@ class EnsembleProvider:
         shuffle_candidates: bool = True,
         record_candidates: bool = False,
         proposer_tools: bool = False,
+        quorum_grace_seconds: float = 0.0,
         selection_plan: Mapping[str, Any] | None = None,
     ) -> None:
         self.profile_name = profile_name
@@ -381,6 +397,7 @@ class EnsembleProvider:
         self.shuffle_candidates = bool(shuffle_candidates)
         self.record_candidates = bool(record_candidates)
         self.proposer_tools = bool(proposer_tools)
+        self.quorum_grace_seconds = max(0.0, float(quorum_grace_seconds or 0.0))
         self.selection_plan = dict(selection_plan or {})
 
     def provider_metadata(self) -> ProviderMetadata:
@@ -528,27 +545,99 @@ class EnsembleProvider:
         progress: Callable[[EnsembleProgressEvent], None] | None = None,
     ) -> list[_CandidateResult]:
         tasks: list[asyncio.Task[_CandidateResult]] = []
+        task_meta: dict[
+            asyncio.Task[_CandidateResult],
+            tuple[int, int, EnsembleMemberConfig],
+        ] = {}
         index = 0
         for member in self.proposers:
             k = max(1, int(member.k or 1))
             for sample_index in range(k):
-                tasks.append(
-                    asyncio.create_task(
-                        self._collect_candidate(
-                            index=index,
-                            sample_index=sample_index,
-                            member=member,
-                            messages=messages,
-                            tools=tools if self.proposer_tools else None,
-                            config=config,
-                            progress=progress,
-                        )
+                task = asyncio.create_task(
+                    self._collect_candidate(
+                        index=index,
+                        sample_index=sample_index,
+                        member=member,
+                        messages=messages,
+                        tools=tools if self.proposer_tools else None,
+                        config=config,
+                        progress=progress,
                     )
                 )
+                tasks.append(task)
+                task_meta[task] = (index, sample_index, member)
                 index += 1
         if not tasks:
             return []
-        return [result for result in await asyncio.gather(*tasks)]
+        if (
+            self.quorum_grace_seconds <= 0
+            or self.min_successful_proposers >= len(tasks)
+        ):
+            return sorted(
+                await asyncio.gather(*tasks),
+                key=lambda result: (result.index, result.sample_index),
+            )
+
+        results: list[_CandidateResult] = []
+        pending: set[asyncio.Task[_CandidateResult]] = set(tasks)
+        try:
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for task in done:
+                    results.append(await task)
+                if sum(1 for result in results if result.ok) >= self.min_successful_proposers:
+                    break
+
+            if pending:
+                done, pending = await asyncio.wait(
+                    pending,
+                    timeout=self.quorum_grace_seconds,
+                )
+                for task in done:
+                    results.append(await task)
+
+            if pending:
+                for task in pending:
+                    setattr(task, "_opensquilla_ensemble_cancel_code", "quorum_cancelled")
+                    setattr(
+                        task,
+                        "_opensquilla_ensemble_cancel_message",
+                        (
+                            "proposer cancelled after "
+                            f"{self.quorum_grace_seconds:g}s ensemble quorum grace"
+                        ),
+                    )
+                    task.cancel()
+                remaining = list(pending)
+                cancelled_results = await asyncio.gather(*remaining, return_exceptions=True)
+                for task, item in zip(remaining, cancelled_results, strict=True):
+                    if isinstance(item, _CandidateResult):
+                        results.append(item)
+                    else:
+                        index, sample_index, member = task_meta[task]
+                        cfg = member.provider_config
+                        results.append(
+                            _CandidateResult(
+                                index=index,
+                                sample_index=sample_index,
+                                label=member.label or f"proposer_{index + 1}",
+                                provider=cfg.provider,
+                                model=cfg.model,
+                                error=str(item),
+                                error_code=type(item).__name__,
+                            )
+                        )
+            return sorted(results, key=lambda result: (result.index, result.sample_index))
+        except BaseException:
+            for task in pending:
+                if not task.done():
+                    task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+            raise
 
     async def _collect_candidate(
         self,
@@ -596,6 +685,20 @@ class EnsembleProvider:
                     if self.proposer_timeout_seconds > 0
                     else None
                 ),
+            )
+        except asyncio.CancelledError:
+            current_task = asyncio.current_task()
+            code = str(getattr(current_task, "_opensquilla_ensemble_cancel_code", "") or "")
+            if not code:
+                raise
+            result.error_code = code
+            result.error = str(
+                getattr(
+                    current_task,
+                    "_opensquilla_ensemble_cancel_message",
+                    "proposer cancelled after ensemble quorum was reached",
+                )
+                or "proposer cancelled after ensemble quorum was reached"
             )
         except TimeoutError:
             result.error = f"proposer timed out after {self.proposer_timeout_seconds:g}s"
@@ -736,6 +839,9 @@ class EnsembleProvider:
             "shuffle_candidates": self.shuffle_candidates,
             "record_candidates": self.record_candidates,
             "proposer_tools": self.proposer_tools,
+            "proposer_timeout_seconds": self.proposer_timeout_seconds,
+            "aggregator_timeout_seconds": self.aggregator_timeout_seconds,
+            "quorum_grace_seconds": self.quorum_grace_seconds,
             "content_max_chars": TRACE_CONTENT_MAX_CHARS,
             "final_request_role": final_request_role,
             "llm_request_count": len(candidates) + (1 if final_request_role else 0),
@@ -1102,6 +1208,23 @@ _DYNAMIC_AGGREGATOR_SLOT = {
     "c2": "aggregator_strong",
     "c3": "aggregator_strong",
 }
+
+_STATIC_OPENROUTER_B5_PROFILE_NAME = "static_openrouter_b5"
+_STATIC_OPENROUTER_B5_PROPOSER_MODELS = (
+    "deepseek/deepseek-v4-pro",
+    "z-ai/glm-5.2",
+    "moonshotai/kimi-k2.7-code",
+    "qwen/qwen3.7-max",
+)
+_STATIC_OPENROUTER_B5_AGGREGATOR_MODEL = "z-ai/glm-5.2"
+_LEGACY_ENSEMBLE_MIN_SUCCESSFUL_PROPOSERS = 1
+_LEGACY_ENSEMBLE_TIMEOUT_SECONDS = 3600.0
+_LEGACY_ENSEMBLE_SHUFFLE_CANDIDATES = True
+_STATIC_OPENROUTER_B5_DEFAULT_MIN_SUCCESSFUL_PROPOSERS = 3
+_STATIC_OPENROUTER_B5_DEFAULT_PROPOSER_TIMEOUT_SECONDS = 300.0
+_STATIC_OPENROUTER_B5_DEFAULT_AGGREGATOR_TIMEOUT_SECONDS = 480.0
+_STATIC_OPENROUTER_B5_DEFAULT_SHUFFLE_CANDIDATES = False
+_STATIC_OPENROUTER_B5_QUORUM_GRACE_SECONDS = 30.0
 
 _DYNAMIC_SLOT_WEIGHTS = {
     "cheap_contrast": {
@@ -1888,6 +2011,49 @@ def _build_router_dynamic_members(
     return f"router_dynamic/{routed_tier}", proposers, aggregator, plan
 
 
+def _openrouter_ref(model: str) -> _DynamicModelRef:
+    return _DynamicModelRef(provider="openrouter", model=model, thinking=None)
+
+
+def _static_default_if_legacy(
+    *,
+    is_static: bool,
+    value: float,
+    legacy: float,
+    static_default: float,
+) -> float:
+    if is_static and value == legacy:
+        return static_default
+    return value
+
+
+def _build_static_openrouter_b5_members(
+    *,
+    inherited_provider_config: ProviderConfig,
+) -> tuple[str, list[EnsembleMemberConfig], EnsembleMemberConfig, dict[str, Any]]:
+    proposers = [
+        _member_from_ref(
+            _openrouter_ref(model),
+            inherited=inherited_provider_config,
+            label=f"proposer_{index + 1}",
+        )
+        for index, model in enumerate(_STATIC_OPENROUTER_B5_PROPOSER_MODELS)
+    ]
+    aggregator = _member_from_ref(
+        _openrouter_ref(_STATIC_OPENROUTER_B5_AGGREGATOR_MODEL),
+        inherited=inherited_provider_config,
+        label="aggregator",
+    )
+    plan = {
+        "strategy": _STATIC_OPENROUTER_B5_PROFILE_NAME,
+        "profile": _STATIC_OPENROUTER_B5_PROFILE_NAME,
+        "proposer_models": list(_STATIC_OPENROUTER_B5_PROPOSER_MODELS),
+        "aggregator_model": _STATIC_OPENROUTER_B5_AGGREGATOR_MODEL,
+        "proposer_count": len(proposers),
+    }
+    return _STATIC_OPENROUTER_B5_PROFILE_NAME, proposers, aggregator, plan
+
+
 def _secret_from_env(env_name: str) -> str:
     return os.environ.get(env_name, "").strip() if env_name else ""
 
@@ -1952,15 +2118,67 @@ def build_ensemble_provider_from_config(
     ensemble_cfg = getattr(config, "llm_ensemble", None)
     if ensemble_cfg is None:
         raise ValueError("config.llm_ensemble is required")
-    profile_name, proposers, aggregator, selection_plan = _build_router_dynamic_members(
-        config=config,
-        inherited_provider_config=inherited_provider_config,
-        turn_metadata=turn_metadata,
-    )
+    selection_mode = str(getattr(ensemble_cfg, "selection_mode", "router_dynamic") or "")
+    if selection_mode == _STATIC_OPENROUTER_B5_PROFILE_NAME:
+        profile_name, proposers, aggregator, selection_plan = _build_static_openrouter_b5_members(
+            inherited_provider_config=inherited_provider_config,
+        )
+    elif selection_mode == "router_dynamic":
+        profile_name, proposers, aggregator, selection_plan = _build_router_dynamic_members(
+            config=config,
+            inherited_provider_config=inherited_provider_config,
+            turn_metadata=turn_metadata,
+        )
+    else:
+        raise ValueError(f"unknown llm_ensemble.selection_mode {selection_mode!r}")
+    is_static_openrouter_b5 = selection_mode == _STATIC_OPENROUTER_B5_PROFILE_NAME
     configured_min_success = int(getattr(ensemble_cfg, "min_successful_proposers", 1) or 1)
-    min_successful_proposers = min(configured_min_success, max(1, len(proposers)))
+    requested_min_success = configured_min_success
+    if (
+        is_static_openrouter_b5
+        and configured_min_success == _LEGACY_ENSEMBLE_MIN_SUCCESSFUL_PROPOSERS
+    ):
+        requested_min_success = _STATIC_OPENROUTER_B5_DEFAULT_MIN_SUCCESSFUL_PROPOSERS
+    min_successful_proposers = min(requested_min_success, max(1, len(proposers)))
+    configured_proposer_timeout_seconds = float(
+        getattr(ensemble_cfg, "proposer_timeout_seconds", _LEGACY_ENSEMBLE_TIMEOUT_SECONDS)
+    )
+    proposer_timeout_seconds = _static_default_if_legacy(
+        is_static=is_static_openrouter_b5,
+        value=configured_proposer_timeout_seconds,
+        legacy=_LEGACY_ENSEMBLE_TIMEOUT_SECONDS,
+        static_default=_STATIC_OPENROUTER_B5_DEFAULT_PROPOSER_TIMEOUT_SECONDS,
+    )
+    configured_aggregator_timeout_seconds = float(
+        getattr(ensemble_cfg, "aggregator_timeout_seconds", _LEGACY_ENSEMBLE_TIMEOUT_SECONDS)
+    )
+    aggregator_timeout_seconds = _static_default_if_legacy(
+        is_static=is_static_openrouter_b5,
+        value=configured_aggregator_timeout_seconds,
+        legacy=_LEGACY_ENSEMBLE_TIMEOUT_SECONDS,
+        static_default=_STATIC_OPENROUTER_B5_DEFAULT_AGGREGATOR_TIMEOUT_SECONDS,
+    )
+    configured_shuffle_candidates = bool(
+        getattr(ensemble_cfg, "shuffle_candidates", _LEGACY_ENSEMBLE_SHUFFLE_CANDIDATES)
+    )
+    shuffle_candidates = configured_shuffle_candidates
+    if (
+        is_static_openrouter_b5
+        and configured_shuffle_candidates == _LEGACY_ENSEMBLE_SHUFFLE_CANDIDATES
+    ):
+        shuffle_candidates = _STATIC_OPENROUTER_B5_DEFAULT_SHUFFLE_CANDIDATES
+    quorum_grace_seconds = (
+        _STATIC_OPENROUTER_B5_QUORUM_GRACE_SECONDS if is_static_openrouter_b5 else 0.0
+    )
     selection_plan["configured_min_successful_proposers"] = configured_min_success
     selection_plan["effective_min_successful_proposers"] = min_successful_proposers
+    selection_plan["configured_proposer_timeout_seconds"] = configured_proposer_timeout_seconds
+    selection_plan["effective_proposer_timeout_seconds"] = proposer_timeout_seconds
+    selection_plan["configured_aggregator_timeout_seconds"] = configured_aggregator_timeout_seconds
+    selection_plan["effective_aggregator_timeout_seconds"] = aggregator_timeout_seconds
+    selection_plan["configured_shuffle_candidates"] = configured_shuffle_candidates
+    selection_plan["effective_shuffle_candidates"] = shuffle_candidates
+    selection_plan["quorum_grace_seconds"] = quorum_grace_seconds
     return EnsembleProvider(
         profile_name=profile_name,
         proposers=proposers,
@@ -1968,13 +2186,12 @@ def build_ensemble_provider_from_config(
         fallback_provider=fallback_provider,
         min_successful_proposers=min_successful_proposers,
         all_failed_policy=getattr(ensemble_cfg, "all_failed_policy", "fallback_single"),
-        proposer_timeout_seconds=float(getattr(ensemble_cfg, "proposer_timeout_seconds", 3600.0)),
-        aggregator_timeout_seconds=float(
-            getattr(ensemble_cfg, "aggregator_timeout_seconds", 3600.0)
-        ),
+        proposer_timeout_seconds=proposer_timeout_seconds,
+        aggregator_timeout_seconds=aggregator_timeout_seconds,
         candidate_max_chars=int(getattr(ensemble_cfg, "candidate_max_chars", 24_000) or 0),
-        shuffle_candidates=bool(getattr(ensemble_cfg, "shuffle_candidates", True)),
+        shuffle_candidates=shuffle_candidates,
         record_candidates=bool(getattr(ensemble_cfg, "record_candidates", False)),
         proposer_tools=bool(getattr(ensemble_cfg, "proposer_tools", False)),
+        quorum_grace_seconds=quorum_grace_seconds,
         selection_plan=selection_plan,
     )

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -23,7 +23,12 @@ from opensquilla.gateway.boot import (
     emit_skill_filter_banner,
     validate_squilla_router_runtime,
 )
-from opensquilla.gateway.config import AgentEntryConfig, GatewayConfig
+from opensquilla.gateway.config import (
+    AgentEntryConfig,
+    GatewayConfig,
+    effective_agent_stream_idle_timeout_seconds,
+    effective_webui_stream_idle_grace_seconds,
+)
 from opensquilla.gateway.diagnostics import DiagnosticsState
 from opensquilla.gateway.routing import build_cli_route_envelope, build_cron_route_envelope
 from opensquilla.onboarding.mutations import upsert_channel
@@ -250,12 +255,56 @@ def test_build_task_runtime_run_kwargs_forwards_fresh_user_session() -> None:
     assert kwargs["fresh_user_session"] is True
 
 
-def test_gateway_stream_timeouts_allow_long_silent_agent_work() -> None:
+def test_gateway_stream_timeout_config_defaults_remain_serializable() -> None:
     config = GatewayConfig()
 
     assert config.agent_stream_idle_timeout_seconds == 600.0
     assert config.webui_stream_idle_grace_seconds == 630.0
     assert config.webui_stream_idle_grace_seconds > config.agent_stream_idle_timeout_seconds
+    assert effective_agent_stream_idle_timeout_seconds(config) == 1200.0
+    assert effective_webui_stream_idle_grace_seconds(config) == 1260.0
+
+
+def test_gateway_stream_timeouts_keep_legacy_effective_values_when_static_disabled() -> None:
+    config = GatewayConfig(
+        llm_ensemble={
+            "enabled": True,
+            "selection_mode": "router_dynamic",
+        }
+    )
+
+    assert config.agent_stream_idle_timeout_seconds == 600.0
+    assert config.webui_stream_idle_grace_seconds == 630.0
+    assert effective_agent_stream_idle_timeout_seconds(config) == 600.0
+    assert effective_webui_stream_idle_grace_seconds(config) == 630.0
+
+
+def test_static_openrouter_b5_effective_stream_timeouts_extend_webui_budget() -> None:
+    config = GatewayConfig(
+        llm_ensemble={
+            "enabled": True,
+            "selection_mode": "static_openrouter_b5",
+        }
+    )
+
+    assert config.agent_stream_idle_timeout_seconds == 600.0
+    assert config.webui_stream_idle_grace_seconds == 630.0
+    assert effective_agent_stream_idle_timeout_seconds(config) == 1200.0
+    assert effective_webui_stream_idle_grace_seconds(config) == 1260.0
+
+
+def test_static_openrouter_b5_webui_grace_stays_above_custom_stream_idle() -> None:
+    config = GatewayConfig(
+        agent_stream_idle_timeout_seconds=2000.0,
+        webui_stream_idle_grace_seconds=630.0,
+        llm_ensemble={
+            "enabled": True,
+            "selection_mode": "static_openrouter_b5",
+        },
+    )
+
+    assert effective_agent_stream_idle_timeout_seconds(config) == 2000.0
+    assert effective_webui_stream_idle_grace_seconds(config) == 2060.0
 
 
 def test_compaction_time_budget_defaults_allow_long_chain_work() -> None:

--- a/tests/test_llm_ensemble_config.py
+++ b/tests/test_llm_ensemble_config.py
@@ -7,14 +7,13 @@ from opensquilla.provider.ensemble import build_ensemble_provider_from_config
 from opensquilla.provider.selector import ProviderConfig
 
 
-def test_llm_ensemble_defaults_to_disabled() -> None:
-    # Off by default so a fresh install lands on the single-model AI router;
-    # ensemble is opt-in via the composer's routing control.
+def test_llm_ensemble_defaults_enable_static_openrouter_b5() -> None:
     cfg = GatewayConfig()
 
     ensemble = cfg.llm_ensemble
-    assert ensemble.enabled is False
+    assert ensemble.enabled is True
     assert ensemble.mode == "b5_fusion"
+    assert ensemble.selection_mode == "static_openrouter_b5"
     assert ensemble.proposer_tools is False
     assert ensemble.min_successful_proposers == 1
     assert ensemble.model_options == [
@@ -33,10 +32,40 @@ def test_llm_ensemble_defaults_to_disabled() -> None:
     assert ensemble.shuffle_candidates is True
     assert ensemble.record_candidates is False
 
+    provider = build_ensemble_provider_from_config(
+        config=cfg,
+        inherited_provider_config=ProviderConfig(
+            provider="openrouter",
+            model="routed/model",
+            api_key="fake",
+            base_url="https://openrouter.example/api/v1",
+        ),
+        fallback_provider=None,
+        turn_metadata={"routed_tier": "c0"},
+    )
+    assert provider.profile_name == "static_openrouter_b5"
+    assert [member.provider_config.model for member in provider.proposers] == [
+        "deepseek/deepseek-v4-pro",
+        "z-ai/glm-5.2",
+        "moonshotai/kimi-k2.7-code",
+        "qwen/qwen3.7-max",
+    ]
+    assert provider.aggregator.provider_config.model == "z-ai/glm-5.2"
+    assert provider.min_successful_proposers == 3
+    assert provider.proposer_timeout_seconds == 300.0
+    assert provider.aggregator_timeout_seconds == 480.0
+    assert provider.shuffle_candidates is False
+    assert provider.quorum_grace_seconds == 30.0
+
 
 def test_llm_ensemble_validates_model_options_not_empty() -> None:
     with pytest.raises(ValueError, match="model_options"):
         GatewayConfig(llm_ensemble={"model_options": []})
+
+
+def test_llm_ensemble_validates_selection_mode() -> None:
+    with pytest.raises(ValueError, match="selection_mode"):
+        GatewayConfig(llm_ensemble={"selection_mode": "static_unknown"})
 
 
 def test_llm_ensemble_model_options_are_operator_configurable() -> None:
@@ -80,6 +109,7 @@ def test_router_dynamic_ensemble_uses_small_c0_slot_template() -> None:
     cfg = GatewayConfig(
         llm_ensemble={
             "enabled": True,
+            "selection_mode": "router_dynamic",
             "min_successful_proposers": 4,
         }
     )
@@ -107,12 +137,16 @@ def test_router_dynamic_ensemble_uses_small_c0_slot_template() -> None:
     assert provider.selection_plan["slot_template"] == ["anchor", "cheap_contrast"]
     assert provider.selection_plan["aggregator_slot"] == "aggregator_fast"
     assert provider.selection_plan["duplicate_policy"] == "selected_penalty"
+    assert provider.proposer_timeout_seconds == 3600.0
+    assert provider.aggregator_timeout_seconds == 3600.0
+    assert provider.quorum_grace_seconds == 0.0
 
 
 def test_router_dynamic_ensemble_uses_slot_specific_c2_selection() -> None:
     cfg = GatewayConfig(
         llm_ensemble={
             "enabled": True,
+            "selection_mode": "router_dynamic",
             "model_options": [
                 "deepseek/deepseek-v4-pro",
                 "z-ai/glm-5.2",
@@ -148,3 +182,130 @@ def test_router_dynamic_ensemble_uses_slot_specific_c2_selection() -> None:
     assert provider.selection_plan["slots"][2]["slot"] == "orthogonal_family"
     assert provider.selection_plan["aggregator"]["slot"] == "aggregator_strong"
     assert provider.selection_plan["candidate_pool_size"] >= 5
+
+
+def test_static_openrouter_b5_ensemble_locks_members_across_routed_tiers() -> None:
+    cfg = GatewayConfig(
+        llm_ensemble={
+            "enabled": True,
+            "selection_mode": "static_openrouter_b5",
+            "min_successful_proposers": 9,
+            "shuffle_candidates": False,
+        }
+    )
+    inherited = ProviderConfig(
+        provider="openrouter",
+        model="routed/model",
+        api_key="fake",
+        base_url="https://openrouter.example/api/v1",
+        proxy="http://proxy.local:7890",
+        provider_routing={"z-ai/glm-5.2": "z-ai"},
+    )
+    expected_proposers = [
+        "deepseek/deepseek-v4-pro",
+        "z-ai/glm-5.2",
+        "moonshotai/kimi-k2.7-code",
+        "qwen/qwen3.7-max",
+    ]
+
+    for tier in ("c0", "c1", "c2", "c3"):
+        provider = build_ensemble_provider_from_config(
+            config=cfg,
+            inherited_provider_config=inherited,
+            fallback_provider=None,
+            turn_metadata={"routed_tier": tier, "routing_confidence": 0.99},
+        )
+
+        assert provider.profile_name == "static_openrouter_b5"
+        assert [member.provider_config.model for member in provider.proposers] == expected_proposers
+        assert provider.aggregator.provider_config.model == "z-ai/glm-5.2"
+        assert provider.selection_plan == {
+            "strategy": "static_openrouter_b5",
+            "profile": "static_openrouter_b5",
+            "proposer_models": expected_proposers,
+            "aggregator_model": "z-ai/glm-5.2",
+            "proposer_count": 4,
+            "configured_min_successful_proposers": 9,
+            "effective_min_successful_proposers": 4,
+            "configured_proposer_timeout_seconds": 3600.0,
+            "effective_proposer_timeout_seconds": 300.0,
+            "configured_aggregator_timeout_seconds": 3600.0,
+            "effective_aggregator_timeout_seconds": 480.0,
+            "configured_shuffle_candidates": False,
+            "effective_shuffle_candidates": False,
+            "quorum_grace_seconds": 30.0,
+        }
+        assert provider.min_successful_proposers == 4
+        assert provider.proposer_timeout_seconds == 300.0
+        assert provider.aggregator_timeout_seconds == 480.0
+        assert provider.shuffle_candidates is False
+        assert provider.quorum_grace_seconds == 30.0
+        members = [*provider.proposers, provider.aggregator]
+        assert all(member.provider_config.provider == "openrouter" for member in members)
+        assert all(member.provider_config.api_key == "fake" for member in members)
+        assert all(
+            member.provider_config.base_url == "https://openrouter.example/api/v1"
+            for member in members
+        )
+        assert all(member.provider_config.proxy == "http://proxy.local:7890" for member in members)
+        assert all(
+            member.provider_config.provider_routing == {"z-ai/glm-5.2": "z-ai"}
+            for member in members
+        )
+
+
+def test_static_openrouter_b5_ensemble_uses_profile_effective_defaults() -> None:
+    cfg = GatewayConfig(
+        llm_ensemble={
+            "enabled": True,
+            "selection_mode": "static_openrouter_b5",
+        }
+    )
+    provider = build_ensemble_provider_from_config(
+        config=cfg,
+        inherited_provider_config=ProviderConfig(
+            provider="openrouter",
+            model="routed/model",
+            api_key="fake",
+            base_url="https://openrouter.example/api/v1",
+        ),
+        fallback_provider=None,
+    )
+
+    assert cfg.llm_ensemble.min_successful_proposers == 1
+    assert cfg.llm_ensemble.proposer_timeout_seconds == 3600.0
+    assert cfg.llm_ensemble.aggregator_timeout_seconds == 3600.0
+    assert cfg.llm_ensemble.shuffle_candidates is True
+    assert provider.min_successful_proposers == 3
+    assert provider.proposer_timeout_seconds == 300.0
+    assert provider.aggregator_timeout_seconds == 480.0
+    assert provider.shuffle_candidates is False
+    assert provider.quorum_grace_seconds == 30.0
+
+
+def test_static_openrouter_b5_ensemble_preserves_custom_effective_values() -> None:
+    cfg = GatewayConfig(
+        llm_ensemble={
+            "enabled": True,
+            "selection_mode": "static_openrouter_b5",
+            "min_successful_proposers": 2,
+            "proposer_timeout_seconds": 180.0,
+            "aggregator_timeout_seconds": 900.0,
+            "shuffle_candidates": False,
+        }
+    )
+    provider = build_ensemble_provider_from_config(
+        config=cfg,
+        inherited_provider_config=ProviderConfig(
+            provider="openrouter",
+            model="routed/model",
+            api_key="fake",
+            base_url="https://openrouter.example/api/v1",
+        ),
+        fallback_provider=None,
+    )
+
+    assert provider.min_successful_proposers == 2
+    assert provider.proposer_timeout_seconds == 180.0
+    assert provider.aggregator_timeout_seconds == 900.0
+    assert provider.shuffle_candidates is False

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -317,7 +317,7 @@ async def test_ensemble_runs_proposers_concurrently_and_tools_only_reach_aggrega
     assert first_candidate["execution"]["model"] == "p1"
     assert first_candidate["execution"]["thinking_override"] == "high"
     assert first_candidate["execution"]["tools_enabled"] is False
-    assert first_candidate["execution"]["effective_max_tokens"] == 99
+    assert first_candidate["execution"]["effective_max_tokens"] == 16384
     assert first_candidate["content"]["text"] == "draft one"
     assert first_candidate["content"]["truncated"] is False
     final_request = done.ensemble_trace["final_request"]
@@ -325,11 +325,85 @@ async def test_ensemble_runs_proposers_concurrently_and_tools_only_reach_aggrega
     assert final_request["execution"]["model"] == "agg"
     assert final_request["execution"]["tools_enabled"] is True
     assert final_request["execution"]["tool_names"] == ["lookup"]
-    assert final_request["execution"]["effective_max_tokens"] == 99
+    assert final_request["execution"]["effective_max_tokens"] == 16384
     assert "draft one" in final_request["input"]["messages"][-1]["content"]["text"]
     assert final_request["output"]["text"] == "final"
     assert final_request["usage"]["model"] == "agg"
     json.dumps(done.ensemble_trace)
+
+
+@pytest.mark.asyncio
+async def test_ensemble_resolves_max_tokens_per_openrouter_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    models = [
+        "deepseek/deepseek-v4-pro",
+        "z-ai/glm-5.2",
+        "moonshotai/kimi-k2.7-code",
+        "qwen/qwen3.7-max",
+    ]
+    registry = _FakeRegistry(
+        {
+            **{
+                model: _FakePlan(
+                    [
+                        TextDeltaEvent(text=f"draft from {model}"),
+                        DoneEvent(input_tokens=1, output_tokens=1, model=model),
+                    ]
+                )
+                for model in models
+            },
+            "agg": _FakePlan(
+                [
+                    TextDeltaEvent(text="final"),
+                    DoneEvent(input_tokens=1, output_tokens=1, model="agg"),
+                ]
+            ),
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    provider = EnsembleProvider(
+        profile_name="static_openrouter_b5",
+        proposers=[_openrouter_member(model, thinking=None) for model in models],
+        aggregator=EnsembleMemberConfig(
+            provider_config=ProviderConfig(
+                provider="openrouter",
+                model="agg",
+                base_url="https://openrouter.ai/api/v1",
+            ),
+            label="aggregator",
+            max_tokens=123,
+            thinking=None,
+        ),
+        proposer_timeout_seconds=1,
+        aggregator_timeout_seconds=1,
+        shuffle_candidates=False,
+    )
+
+    events = [
+        event
+        async for event in provider.chat(
+            [Message(role="user", content="answer this")],
+            config=ChatConfig(max_tokens=384000, thinking=False),
+        )
+    ]
+
+    by_model = {call["model"]: call["config"].max_tokens for call in registry.calls}
+    assert by_model == {
+        "deepseek/deepseek-v4-pro": 384000,
+        "z-ai/glm-5.2": 32768,
+        "moonshotai/kimi-k2.7-code": 16384,
+        "qwen/qwen3.7-max": 65536,
+        "agg": 123,
+    }
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.ensemble_trace is not None
+    traced = {
+        candidate["execution"]["model"]: candidate["execution"]["effective_max_tokens"]
+        for candidate in done.ensemble_trace["candidates"]
+    }
+    assert traced["moonshotai/kimi-k2.7-code"] == 16384
+    assert done.ensemble_trace["final_request"]["execution"]["effective_max_tokens"] == 123
 
 
 @pytest.mark.asyncio
@@ -534,6 +608,105 @@ async def test_ensemble_streams_proposer_progress_live_not_buffered(
         if isinstance(e, EnsembleProgressEvent) and e.event_type == "proposer_finish"
     }
     assert finishes == {"p1", "p2"}
+
+
+@pytest.mark.asyncio
+async def test_static_openrouter_b5_quorum_cancels_slow_proposer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    slow_gate = asyncio.Event()
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan([TextDeltaEvent(text="d1"), DoneEvent(model="p1")]),
+            "p2": _FakePlan([TextDeltaEvent(text="d2"), DoneEvent(model="p2")]),
+            "p3": _FakePlan([TextDeltaEvent(text="d3"), DoneEvent(model="p3")]),
+            "p4": _FakePlan(
+                [TextDeltaEvent(text="d4"), DoneEvent(model="p4")],
+                gate=slow_gate,
+            ),
+            "agg": _FakePlan(
+                [
+                    TextDeltaEvent(text="final"),
+                    DoneEvent(input_tokens=1, output_tokens=1, model="agg"),
+                ]
+            ),
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    provider = EnsembleProvider(
+        profile_name="static_openrouter_b5",
+        proposers=[_member("p1"), _member("p2"), _member("p3"), _member("p4")],
+        aggregator=_member("agg"),
+        min_successful_proposers=3,
+        proposer_timeout_seconds=10,
+        aggregator_timeout_seconds=1,
+        quorum_grace_seconds=0.02,
+        shuffle_candidates=False,
+    )
+
+    started = time.monotonic()
+    events = await _collect(provider)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5
+    assert [call["model"] for call in registry.calls] == ["p1", "p2", "p3", "p4", "agg"]
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["successful_proposers"] == 3
+    assert done.ensemble_trace["selected_candidate_count"] == 3
+    assert done.ensemble_trace["selected_candidate_indexes"] == [0, 1, 2]
+    assert done.ensemble_trace["llm_request_count"] == 5
+    assert done.ensemble_trace["quorum_grace_seconds"] == 0.02
+    p4 = done.ensemble_trace["candidates"][3]
+    assert p4["model"] == "p4"
+    assert p4["ok"] is False
+    assert p4["error_code"] == "quorum_cancelled"
+    assert "quorum grace" in p4["error"]
+    assert "d1" in str(registry.calls[-1]["messages"][-1].content)
+    assert "d2" in str(registry.calls[-1]["messages"][-1].content)
+    assert "d3" in str(registry.calls[-1]["messages"][-1].content)
+    assert "d4" not in str(registry.calls[-1]["messages"][-1].content)
+
+
+@pytest.mark.asyncio
+async def test_default_ensemble_waits_for_all_proposers_without_quorum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    slow_gate = asyncio.Event()
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan([TextDeltaEvent(text="d1"), DoneEvent(model="p1")]),
+            "p2": _FakePlan(
+                [TextDeltaEvent(text="d2"), DoneEvent(model="p2")],
+                gate=slow_gate,
+            ),
+            "agg": _FakePlan([TextDeltaEvent(text="final"), DoneEvent(model="agg")]),
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    provider = EnsembleProvider(
+        profile_name="router_dynamic/c1",
+        proposers=[_member("p1"), _member("p2")],
+        aggregator=_member("agg"),
+        min_successful_proposers=1,
+        proposer_timeout_seconds=2,
+        aggregator_timeout_seconds=1,
+        quorum_grace_seconds=0.0,
+        shuffle_candidates=False,
+    )
+
+    consume_task = asyncio.create_task(_collect(provider))
+    await asyncio.sleep(0.05)
+    assert "agg" not in [call["model"] for call in registry.calls]
+
+    slow_gate.set()
+    events = await asyncio.wait_for(consume_task, timeout=1.0)
+
+    assert [call["model"] for call in registry.calls] == ["p1", "p2", "agg"]
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["successful_proposers"] == 2
+    assert done.ensemble_trace["quorum_grace_seconds"] == 0.0
 
 
 def test_runtime_wrap_is_after_selector_resolution() -> None:


### PR DESCRIPTION
## Scope
- Make `llm_ensemble` default to `enabled = true` and `selection_mode = "static_openrouter_b5"`.
- Add the built-in static OpenRouter B5 profile with four fixed proposer models and GLM as aggregator.
- Resolve max token budgets per ensemble member so mixed-model static/profile runs do not inherit an unsafe outer routed-model budget.
- Add static-profile execution defaults: 3-proposer quorum, 300s proposer timeout, 480s aggregator timeout, deterministic candidate order, and 30s quorum grace cancellation.
- Raise effective gateway/WebUI stream idle budgets only when the static profile is enabled.
- Keep `router_dynamic` available by explicit config and preserve its legacy timeout/quorum behavior.

## Branch Target
Base: `main`

## Linked Issue
None

## Release Note
Changed default model ensemble behavior: new configs now use the packaged static OpenRouter B5 ensemble profile by default.

## Test Results
- `uv run ruff check src/opensquilla/provider/ensemble.py src/opensquilla/gateway/config.py src/opensquilla/gateway/rpc_sessions.py src/opensquilla/gateway/websocket.py src/opensquilla/gateway/boot.py src/opensquilla/gateway/channel_dispatch.py tests/test_provider_ensemble.py tests/test_llm_ensemble_config.py tests/test_gateway/test_router_boot.py`
- `uv run pytest tests/test_llm_ensemble_config.py tests/test_provider_ensemble.py tests/test_gateway/test_router_boot.py -q` -> 69 passed
- `uv run pytest tests/test_provider_model_catalog.py tests/test_engine/test_runtime_router_fallback.py tests/test_gateway_config_legacy.py -q` -> 35 passed, 3 expected legacy warnings
- `uv run pytest tests -q` -> 8895 passed, 113 skipped, 10 failed locally: 9 OpenTUI real-terminal tests need `@opentui/core` installed via `bun install --cwd src/opensquilla/cli/tui/opentui/package`; 1 shell pipe timeout test exceeded the local 3s threshold by ~0.33s.

## Safety Notes
- No secrets, runtime transcripts, session data, or generated local artifacts are included.
- Static members inherit OpenRouter credentials/base URL/proxy/provider routing through the existing provider config path.
- The no-key path is unchanged: provider calls still fail through existing provider error handling.

## Third-party Origin
No third-party code copied. Static profile entries are provider/model identifiers only.
