### PR TITLE
fix(webui): refresh expired staged uploads before send

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatAttachments.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatAttachments.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useChatAttachments } from './useChatAttachments'
+import type { Attachment } from '@/types/chat'
 
 const pushToast = vi.hoisted(() => vi.fn())
 
@@ -172,5 +173,193 @@ describe('useChatAttachments', () => {
     expect(attachments.pendingAttachments.value).toMatchObject([
       { kind: 'staged', name: 'retry.pdf', file_uuid: 'file-retry' },
     ])
+  })
+
+  it('refreshes expired staged uploads before send when the original file is available', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ file_uuid: 'file-expired', expires_at: Date.now() / 1000 - 1, ttl_seconds: 600 }),
+        text: async () => '',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ file_uuid: 'file-fresh', expires_at: Date.now() / 1000 + 600, ttl_seconds: 600 }),
+        text: async () => '',
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const attachments = useChatAttachments()
+    await attachments.addAttachment(stagedPdf('refresh.pdf'))
+    await flushUpload()
+
+    expect(attachments.pendingAttachments.value).toMatchObject([
+      { kind: 'staged', name: 'refresh.pdf', file_uuid: 'file-expired' },
+    ])
+
+    const ready = await attachments.prepareAttachmentsForSend()
+
+    expect(ready).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(attachments.pendingAttachments.value).toMatchObject([
+      { kind: 'staged', name: 'refresh.pdf', file_uuid: 'file-fresh' },
+    ])
+  })
+
+  it('refreshes staged uploads that are inside the expiration grace window', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ file_uuid: 'file-fresh', expires_at: Date.now() / 1000 + 600, ttl_seconds: 600 }),
+      text: async () => '',
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const attachments = useChatAttachments()
+    attachments.pendingAttachments.value = [
+      {
+        kind: 'staged',
+        local_id: 1,
+        name: 'near-expiry.pdf',
+        mime: 'application/pdf',
+        file_uuid: 'file-near-expiry',
+        expires_at: Date.now() / 1000 + 10,
+        file: stagedPdf('near-expiry.pdf'),
+      },
+    ]
+
+    const ready = await attachments.prepareAttachmentsForSend()
+
+    expect(ready).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(attachments.pendingAttachments.value).toMatchObject([
+      { kind: 'staged', name: 'near-expiry.pdf', file_uuid: 'file-fresh' },
+    ])
+  })
+
+  it('does not refresh staged uploads that are outside the expiration grace window', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const attachments = useChatAttachments()
+    const stagedAttachment: Attachment = {
+      kind: 'staged',
+      local_id: 1,
+      name: 'fresh.pdf',
+      mime: 'application/pdf',
+      file_uuid: 'file-fresh-enough',
+      expires_at: Date.now() / 1000 + 120,
+      file: stagedPdf('fresh.pdf'),
+    }
+    attachments.pendingAttachments.value = [stagedAttachment]
+
+    const ready = await attachments.prepareAttachmentsForSend()
+
+    expect(ready).toBe(true)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(attachments.pendingAttachments.value).toEqual([stagedAttachment])
+  })
+
+  it('does not rewrite or toast when refresh completes after preparation is stale', async () => {
+    let resolveUpload!: (response: unknown) => void
+    const fetchMock = vi.fn(() => new Promise(resolve => {
+      resolveUpload = resolve
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const attachments = useChatAttachments()
+    const stagedAttachment: Attachment = {
+      kind: 'staged',
+      local_id: 1,
+      name: 'stale-session.pdf',
+      mime: 'application/pdf',
+      file_uuid: 'file-expired',
+      expires_at: Date.now() / 1000 - 1,
+      file: stagedPdf('stale-session.pdf'),
+    }
+    attachments.pendingAttachments.value = [stagedAttachment]
+    let current = true
+
+    const ready = attachments.prepareAttachmentsForSend({ isCurrent: () => current })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(attachments.hasPendingAttachmentWork()).toBe(true)
+    expect(attachments.pendingAttachments.value).toEqual([stagedAttachment])
+
+    current = false
+    resolveUpload({
+      ok: true,
+      status: 200,
+      json: async () => ({ file_uuid: 'file-fresh', expires_at: Date.now() / 1000 + 600, ttl_seconds: 600 }),
+      text: async () => '',
+    })
+
+    await expect(ready).resolves.toBe(false)
+    expect(attachments.hasPendingAttachmentWork()).toBe(false)
+    expect(attachments.pendingAttachments.value).toEqual([stagedAttachment])
+    expect(pushToast).not.toHaveBeenCalled()
+  })
+
+  it('marks expired staged uploads failed when the original file is unavailable', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const attachments = useChatAttachments()
+    attachments.pendingAttachments.value = [
+      {
+        kind: 'staged',
+        local_id: 1,
+        name: 'missing-local-file.pdf',
+        mime: 'application/pdf',
+        file_uuid: 'file-expired',
+        expires_at: Date.now() / 1000 - 1,
+      },
+    ]
+
+    const ready = await attachments.prepareAttachmentsForSend()
+
+    expect(ready).toBe(false)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(attachments.pendingAttachments.value).toMatchObject([
+      { kind: 'failed', name: 'missing-local-file.pdf', error: 'Upload expired; select the file again' },
+    ])
+    expect(attachments.pendingAttachments.value[0].file_uuid).toBeUndefined()
+    expect(pushToast).toHaveBeenCalledWith(
+      'Upload expired for missing-local-file.pdf: select the file again',
+      { tone: 'danger' },
+    )
+  })
+
+  it('marks expired staged uploads failed and retryable when refresh upload fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => 'unavailable',
+      json: async () => ({}),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const attachments = useChatAttachments()
+    attachments.pendingAttachments.value = [
+      {
+        kind: 'staged',
+        local_id: 1,
+        name: 'refresh-fails.pdf',
+        mime: 'application/pdf',
+        file_uuid: 'file-expired',
+        expires_at: Date.now() / 1000 - 1,
+        file: stagedPdf('refresh-fails.pdf'),
+      },
+    ]
+
+    const ready = await attachments.prepareAttachmentsForSend()
+
+    expect(ready).toBe(false)
+    expect(attachments.pendingAttachments.value).toMatchObject([
+      { kind: 'failed', name: 'refresh-fails.pdf', error: 'HTTP 503 unavailable' },
+    ])
+    expect(attachments.pendingAttachments.value[0].file).toBeInstanceOf(File)
+    expect(pushToast).toHaveBeenCalledWith(
+      expect.stringContaining('Upload failed for refresh-fails.pdf: HTTP 503 unavailable'),
+      { tone: 'danger' },
+    )
   })
 })

--- a/opensquilla-webui/src/composables/chat/useChatAttachments.ts
+++ b/opensquilla-webui/src/composables/chat/useChatAttachments.ts
@@ -10,9 +10,20 @@ const ATTACHMENT_PDF_HARD_CAP_BYTES = 30 * 1024 * 1024
 const ATTACHMENT_OFFICE_HARD_CAP_BYTES = 30 * 1024 * 1024
 const MAX_ATTACHMENTS = 10
 const MAX_TOTAL_ATTACHMENT_BYTES = 60 * 1024 * 1024
+const STAGED_UPLOAD_REFRESH_GRACE_MS = 30_000
 // Email is held to the text cap (bounded text is extracted; large emails are
 // large only due to attachments we never read), so it inlines and never stages.
 const ATTACHMENT_EMAIL_HARD_CAP_BYTES = ATTACHMENT_TEXT_HARD_CAP_BYTES
+
+type UploadResponseMeta = {
+  fileUuid: string
+  expiresAt?: number
+  ttlSeconds?: number
+}
+
+type AttachmentPreparationOptions = {
+  isCurrent?: () => boolean
+}
 
 const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
 const XLSX_MIME = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
@@ -88,6 +99,7 @@ export function useChatAttachments() {
   const { pushToast } = useToasts()
   const pendingAttachments = ref<Attachment[]>([])
   const nextAttachmentId = ref(1)
+  const refreshInFlightAttachmentIds = new Set<number>()
 
   function onFileInputChange(e: Event) {
     const target = e.target as HTMLInputElement
@@ -166,6 +178,24 @@ export function useChatAttachments() {
   }
 
   async function uploadAttachmentStaged(file: File, mime: string, localId: number) {
+    const meta = await uploadAttachmentFile(file, mime)
+    const idx = pendingAttachments.value.findIndex(a => a.local_id === localId)
+    if (idx >= 0) {
+      pendingAttachments.value[idx] = {
+        kind: 'staged',
+        local_id: localId,
+        name: file.name || 'Untitled file',
+        mime,
+        size: file.size,
+        file_uuid: meta.fileUuid,
+        expires_at: meta.expiresAt,
+        ttl_seconds: meta.ttlSeconds,
+        file,
+      }
+    }
+  }
+
+  async function uploadAttachmentFile(file: File, mime: string): Promise<UploadResponseMeta> {
     const form = new FormData()
     form.append('file', file, file.name)
     form.append('mime', mime)
@@ -180,11 +210,7 @@ export function useChatAttachments() {
       throw new Error(`HTTP ${response.status} ${detail}`)
     }
     const result = await response.json()
-    const fileUuid = uploadResponseFileUuid(result)
-    const idx = pendingAttachments.value.findIndex(a => a.local_id === localId)
-    if (idx >= 0) {
-      pendingAttachments.value[idx] = { kind: 'staged', local_id: localId, name: file.name || 'Untitled file', mime, size: file.size, file_uuid: fileUuid }
-    }
+    return uploadResponseMeta(result)
   }
 
   function removeAttachment(index: number) {
@@ -218,7 +244,57 @@ export function useChatAttachments() {
   }
 
   function hasPendingAttachmentWork(): boolean {
-    return pendingAttachments.value.some(a => a.kind === 'inline_pending' || a.kind === 'uploading')
+    return refreshInFlightAttachmentIds.size > 0 || pendingAttachments.value.some(a => a.kind === 'inline_pending' || a.kind === 'uploading')
+  }
+
+  async function prepareAttachmentsForSend(options: AttachmentPreparationOptions = {}): Promise<boolean> {
+    const isCurrent = options.isCurrent ?? (() => true)
+    const staged = [...pendingAttachments.value].filter(stagedUploadNeedsRefresh)
+    for (const attachment of staged) {
+      if (!isCurrent()) return false
+      if (refreshInFlightAttachmentIds.has(attachment.local_id)) return false
+      const idx = pendingAttachments.value.findIndex(a => a.local_id === attachment.local_id)
+      if (idx < 0 || pendingAttachments.value[idx].kind !== 'staged') continue
+      if (!attachment.file) {
+        pendingAttachments.value[idx] = {
+          kind: 'failed',
+          local_id: attachment.local_id,
+          name: attachment.name,
+          mime: attachment.mime,
+          size: attachment.size,
+          error: 'Upload expired; select the file again',
+        }
+        pushToast(`Upload expired for ${attachment.name}: select the file again`, { tone: 'danger' })
+        return false
+      }
+      refreshInFlightAttachmentIds.add(attachment.local_id)
+      try {
+        const meta = await uploadAttachmentFile(attachment.file, attachment.mime)
+        if (!isCurrent()) return false
+        const currentIdx = pendingAttachments.value.findIndex(a => a.local_id === attachment.local_id)
+        if (currentIdx < 0 || pendingAttachments.value[currentIdx].kind !== 'staged') continue
+        pendingAttachments.value[currentIdx] = {
+          kind: 'staged',
+          local_id: attachment.local_id,
+          name: attachment.name,
+          mime: attachment.mime,
+          size: attachment.size,
+          file_uuid: meta.fileUuid,
+          expires_at: meta.expiresAt,
+          ttl_seconds: meta.ttlSeconds,
+          file: attachment.file,
+        }
+      } catch (err: unknown) {
+        if (!isCurrent()) return false
+        const message = uploadFailureMessage(err)
+        markAttachmentFailed(attachment.local_id, attachment.file, attachment.mime, message)
+        pushToast(`${i18n.global.t('chat.toast.uploadFailed', { name: attachment.name })}: ${message}`, { tone: 'danger' })
+        return false
+      } finally {
+        refreshInFlightAttachmentIds.delete(attachment.local_id)
+      }
+    }
+    return true
   }
 
   function canAcceptAttachment(fileName: string, size: number): boolean {
@@ -243,6 +319,7 @@ export function useChatAttachments() {
     removeAttachment,
     retryAttachment,
     hasPendingAttachmentWork,
+    prepareAttachmentsForSend,
   }
 }
 
@@ -260,12 +337,27 @@ function uploadFailureMessage(err: unknown): string {
   return String(err)
 }
 
-function uploadResponseFileUuid(result: unknown): string {
-  const fileUuid = typeof (result as { file_uuid?: unknown } | null)?.file_uuid === 'string'
-    ? (result as { file_uuid: string }).file_uuid.trim()
-    : ''
+function uploadResponseMeta(result: unknown): UploadResponseMeta {
+  const record = (result && typeof result === 'object' ? result : {}) as {
+    file_uuid?: unknown
+    expires_at?: unknown
+    ttl_seconds?: unknown
+  }
+  const fileUuid = typeof record.file_uuid === 'string' ? record.file_uuid.trim() : ''
   if (!fileUuid) throw new Error('Upload response missing file_uuid')
-  return fileUuid
+  const expiresAt = typeof record.expires_at === 'number' && Number.isFinite(record.expires_at)
+    ? record.expires_at
+    : undefined
+  const ttlSeconds = typeof record.ttl_seconds === 'number' && Number.isFinite(record.ttl_seconds)
+    ? record.ttl_seconds
+    : undefined
+  return { fileUuid, expiresAt, ttlSeconds }
+}
+
+function stagedUploadNeedsRefresh(attachment: Attachment): boolean {
+  if (attachment.kind !== 'staged') return false
+  if (typeof attachment.expires_at !== 'number' || !Number.isFinite(attachment.expires_at)) return false
+  return attachment.expires_at * 1000 <= Date.now() + STAGED_UPLOAD_REFRESH_GRACE_MS
 }
 
 function attachmentCountsTowardLimits(attachment: Attachment): boolean {

--- a/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
@@ -119,6 +119,144 @@ describe('useChatSend attachment payloads', () => {
     expect(pendingAttachments.value).toEqual([failed])
   })
 
+  it('refreshes staged uploads before serializing chat.send attachments', async () => {
+    const pendingAttachments = ref<Attachment[]>([
+      {
+        kind: 'staged',
+        local_id: 1,
+        name: 'ready.pdf',
+        mime: 'application/pdf',
+        file_uuid: 'file-expired',
+        expires_at: Date.now() / 1000 - 1,
+        file: new File(['pdf'], 'ready.pdf', { type: 'application/pdf' }),
+      },
+    ])
+    const prepareAttachmentsForSend = vi.fn(async () => {
+      pendingAttachments.value = [
+        {
+          kind: 'staged',
+          local_id: 1,
+          name: 'ready.pdf',
+          mime: 'application/pdf',
+          file_uuid: 'file-fresh',
+          expires_at: Date.now() / 1000 + 600,
+          file: new File(['pdf'], 'ready.pdf', { type: 'application/pdf' }),
+        },
+      ]
+      return true
+    })
+    const { api, rpc } = makeOptions({ pendingAttachments, prepareAttachmentsForSend })
+
+    await api.onSend()
+
+    expect(prepareAttachmentsForSend).toHaveBeenCalledTimes(1)
+    expect(rpc.call).toHaveBeenCalledWith('chat.send', expect.objectContaining({
+      attachments: [
+        { type: 'application/pdf', file_uuid: 'file-fresh', mime: 'application/pdf', name: 'ready.pdf' },
+      ],
+    }))
+  })
+
+  it('does not include attachments added while preparing an earlier send', async () => {
+    const initialAttachment: Attachment = {
+      kind: 'staged',
+      local_id: 1,
+      name: 'initial.pdf',
+      mime: 'application/pdf',
+      file_uuid: 'file-initial',
+    }
+    const addedAttachment: Attachment = {
+      kind: 'staged',
+      local_id: 2,
+      name: 'added-later.pdf',
+      mime: 'application/pdf',
+      file_uuid: 'file-added-later',
+    }
+    const pendingAttachments = ref<Attachment[]>([initialAttachment])
+    const prepareAttachmentsForSend = vi.fn(async () => {
+      pendingAttachments.value = [initialAttachment, addedAttachment]
+      return true
+    })
+    const { api, rpc } = makeOptions({ pendingAttachments, prepareAttachmentsForSend })
+
+    await api.onSend()
+
+    expect(rpc.call).toHaveBeenCalledWith('chat.send', expect.objectContaining({
+      attachments: [
+        { type: 'application/pdf', file_uuid: 'file-initial', mime: 'application/pdf', name: 'initial.pdf' },
+      ],
+    }))
+    expect(pendingAttachments.value).toEqual([addedAttachment])
+  })
+
+  it('does not mutate or send when attachment preparation returns false', async () => {
+    const inputText = ref('hello')
+    const expiredAttachment: Attachment = {
+      kind: 'staged',
+      local_id: 1,
+      name: 'ready.pdf',
+      mime: 'application/pdf',
+      file_uuid: 'file-expired',
+      expires_at: Date.now() / 1000 - 1,
+      file: new File(['pdf'], 'ready.pdf', { type: 'application/pdf' }),
+    }
+    const pendingAttachments = ref<Attachment[]>([expiredAttachment])
+    const prepareAttachmentsForSend = vi.fn(async () => false)
+    const { api, options, rpc, stream } = makeOptions({
+      inputText,
+      pendingAttachments,
+      prepareAttachmentsForSend,
+    })
+
+    await api.onSend()
+
+    expect(prepareAttachmentsForSend).toHaveBeenCalledTimes(1)
+    expect(rpc.call).not.toHaveBeenCalled()
+    expect(options.messages.value).toHaveLength(0)
+    expect(inputText.value).toBe('hello')
+    expect(pendingAttachments.value).toEqual([expiredAttachment])
+    expect(stream.startStreaming).not.toHaveBeenCalled()
+  })
+
+  it('does not mutate or send when session changes during attachment preparation', async () => {
+    let resolvePrepare!: (ready: boolean) => void
+    let prepareContext: { isCurrent?: () => boolean } | undefined
+    const inputText = ref('hello')
+    const sessionKey = ref('agent:main:webchat:first')
+    const stagedAttachment: Attachment = {
+      kind: 'staged',
+      local_id: 1,
+      name: 'ready.pdf',
+      mime: 'application/pdf',
+      file_uuid: 'file-ready',
+      file: new File(['pdf'], 'ready.pdf', { type: 'application/pdf' }),
+    }
+    const pendingAttachments = ref<Attachment[]>([stagedAttachment])
+    const prepareAttachmentsForSend = vi.fn((context?: { isCurrent?: () => boolean }) => new Promise<boolean>(resolve => {
+      prepareContext = context
+      resolvePrepare = resolve
+    }))
+    const { api, options, rpc, stream } = makeOptions({
+      inputText,
+      sessionKey,
+      pendingAttachments,
+      prepareAttachmentsForSend,
+    })
+
+    const send = api.onSend()
+    sessionKey.value = 'agent:main:webchat:second'
+    expect(prepareContext?.isCurrent?.()).toBe(false)
+    resolvePrepare(true)
+    await send
+
+    expect(prepareAttachmentsForSend).toHaveBeenCalledTimes(1)
+    expect(rpc.call).not.toHaveBeenCalled()
+    expect(options.messages.value).toHaveLength(0)
+    expect(inputText.value).toBe('hello')
+    expect(pendingAttachments.value).toEqual([stagedAttachment])
+    expect(stream.startStreaming).not.toHaveBeenCalled()
+  })
+
   it('does not dispatch an empty failed-only attachment draft', async () => {
     const failed: Attachment = {
       kind: 'failed',

--- a/opensquilla-webui/src/composables/chat/useChatSend.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.ts
@@ -74,6 +74,7 @@ export interface UseChatSendOptions {
   persistSession: (key: string, options?: PersistSessionOptions) => void
   isCompactInFlightForCurrentSession: () => boolean
   hasPendingAttachmentWork: () => boolean
+  prepareAttachmentsForSend?: (options?: { isCurrent?: () => boolean }) => Promise<boolean>
   enqueuePendingInput: (text: string) => boolean
   enqueueHiddenControl?: (item: { text: string; displayText: string }) => boolean
   popAllPendingIntoComposer: () => boolean
@@ -175,8 +176,21 @@ export function useChatSend(options: UseChatSendOptions) {
   async function dispatchSend(text: string, sendOpts?: { queueMode?: 'steer' }) {
     const requestSessionKey = options.sessionKey.value
     if (!requestSessionKey) return
-    const attachmentsToSend = options.pendingAttachments.value.filter(isSendableAttachment)
-    const attachmentsToKeep = options.pendingAttachments.value.filter(a => !isSendableAttachment(a))
+    const sendAttachmentIds = new Set(
+      options.pendingAttachments.value
+        .filter(isSendableAttachment)
+        .map(attachment => attachment.local_id),
+    )
+    if (options.prepareAttachmentsForSend) {
+      const ready = await options.prepareAttachmentsForSend({
+        isCurrent: () => options.sessionKey.value === requestSessionKey,
+      })
+      if (!ready) return
+      if (options.sessionKey.value !== requestSessionKey) return
+    }
+    const attachmentsToSend = options.pendingAttachments.value.filter((a): a is SendableAttachment => sendAttachmentIds.has(a.local_id) && isSendableAttachment(a))
+    const attachmentsToKeep = options.pendingAttachments.value.filter(a => !sendAttachmentIds.has(a.local_id) || !isSendableAttachment(a))
+    if (!text && attachmentsToSend.length === 0) return
 
     options.aborted.value = false
     options.closeSlashMenu()

--- a/opensquilla-webui/src/types/chat.ts
+++ b/opensquilla-webui/src/types/chat.ts
@@ -10,6 +10,8 @@ export interface Attachment {
   data?: string
   dataUrl?: string
   file_uuid?: string
+  expires_at?: number
+  ttl_seconds?: number
   error?: string
   file?: File
 }

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -802,6 +802,7 @@ const {
   removeAttachment,
   retryAttachment,
   hasPendingAttachmentWork,
+  prepareAttachmentsForSend,
 } = chatAttachments
 
 let sendCurrentInput: () => void = () => {}
@@ -1248,6 +1249,7 @@ const chatSend = useChatSend({
   persistSession,
   isCompactInFlightForCurrentSession,
   hasPendingAttachmentWork,
+  prepareAttachmentsForSend,
   enqueuePendingInput,
   enqueueHiddenControl,
   popAllPendingIntoComposer,


### PR DESCRIPTION
## Summary
- Refresh expired or near-expired staged upload file_uuid values before chat.send when the original File is still available.
- Keep expired uploads recoverable: require reselect when the local File is gone, preserve retry state when refresh fails.
- Guard refresh/send races for session changes and attachments added while preparation is pending.

## Linked issues
Fixes #468
Linear: OSQ-431

## Test plan
- npm --prefix opensquilla-webui run test:unit -- src/composables/chat/useChatAttachments.test.ts src/composables/chat/useChatSend.attachments.test.ts
- npm --prefix opensquilla-webui run typecheck
- uv run pytest tests/test_gateway/test_uploads_endpoint.py::test_uuid_expires_after_ttl tests/test_gateway/test_uploads_endpoint.py::test_post_restart_returns_specific_error_for_lost_uuid tests/test_gateway/test_uploads_endpoint.py::test_post_restart_expired_marker_is_not_reported_as_lost tests/test_gateway/test_uploads_endpoint.py::test_unknown_uuid_rejected tests/test_gateway/test_uploads_endpoint.py::test_file_uuid_resolved_via_store_returns_material_ref tests/test_gateway/test_rpc_sessions_attachments.py::test_file_uuid_reference_resolved tests/test_gateway/test_rpc_sessions_attachments.py::test_attachment_with_both_data_and_file_uuid_rejected -q
- git diff --check