### PR TITLE
Align provider switch test with OpenRouter mix default

### DIFF
--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -428,7 +428,10 @@ def test_upsert_llm_provider_can_use_env_key_without_secret():
 def test_upsert_llm_provider_recomputes_router_preset_on_provider_switch():
     cfg = GatewayConfig(llm={"provider": "openrouter", "model": "deepseek/x"})
     assert cfg.squilla_router.enabled is True
-    assert cfg.squilla_router.tier_profile == "openrouter"
+    # Fresh OpenRouter configs remain the openrouter-mix/direct-router shape.
+    # Saving a different packaged provider below should still recompute that
+    # provider's compact router profile.
+    assert cfg.squilla_router.tier_profile is None
 
     res = upsert_llm_provider(
         cfg,


### PR DESCRIPTION
## Scope

- Align the provider-switch onboarding mutation test with the 0.5.0rc2 routing contract:
  - fresh OpenRouter configs remain the `openrouter-mix` / direct-router shape with no persisted `tier_profile`;
  - switching to another packaged provider through `upsert_llm_provider` still recomputes that provider's compact router profile.

## Branch target

`main`

## Linked issue

None.

## Release note

None; test-only contract correction for the 0.5.0rc2 main CI gate.

## Test results

- `uv run pytest tests/test_onboarding/test_mutations.py::test_upsert_llm_provider_recomputes_router_preset_on_provider_switch tests/test_onboarding/test_mutations.py tests/test_model_router_defaults.py tests/test_contracts/test_onboarding_status.py tests/test_gateway/test_router_boot.py tests/test_provider/test_resolution.py -q` -> 179 passed
- `uv run ruff check tests/test_onboarding/test_mutations.py` -> passed
- `git diff --check` -> passed

## Safety notes

- Test-only change.
- No secrets, transcripts, memory data, runtime state, or generated artifacts are included.

## Third-party origin

No third-party code copied.
