### PR TITLE
Fix Windows CI artifact open and golden checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *.sh text eol=lf
+tests/test_provider/golden/requests/**/*.json text eol=lf
 
 src/opensquilla/squilla_router/models/*.pkl filter=lfs diff=lfs merge=lfs -text
 src/opensquilla/squilla_router/models/*.txt filter=lfs diff=lfs merge=lfs -text

--- a/src/opensquilla/gateway/artifacts.py
+++ b/src/opensquilla/gateway/artifacts.py
@@ -110,15 +110,16 @@ def _artifact_open_cache_dir() -> Path:
         pass
     if root.is_symlink() or not root.is_dir():
         raise OSError("unsafe artifact open temp directory")
-    uid = getattr(os, "getuid", lambda: None)()
-    stat_result = root.stat()
-    if uid is not None and getattr(stat_result, "st_uid", uid) != uid:
-        raise OSError("artifact open temp directory is owned by another user")
-    if stat_result.st_mode & 0o077:
-        root.chmod(0o700)
+    if sys.platform != "win32":
+        uid = getattr(os, "getuid", lambda: None)()
         stat_result = root.stat()
+        if uid is not None and getattr(stat_result, "st_uid", uid) != uid:
+            raise OSError("artifact open temp directory is owned by another user")
         if stat_result.st_mode & 0o077:
-            raise OSError("artifact open temp directory permissions are too broad")
+            root.chmod(0o700)
+            stat_result = root.stat()
+            if stat_result.st_mode & 0o077:
+                raise OSError("artifact open temp directory permissions are too broad")
     return root
 
 

--- a/tests/test_gateway/test_artifacts_download.py
+++ b/tests/test_gateway/test_artifacts_download.py
@@ -164,6 +164,22 @@ def test_artifact_native_open_owner_opens_html_copy(tmp_path: Path, monkeypatch)
     assert opened[0].read_bytes() == b"<!doctype html><title>ok</title>"
 
 
+def test_artifact_open_cache_dir_skips_posix_mode_bits_on_windows(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from opensquilla.gateway import artifacts as artifact_routes
+
+    temp_root = tmp_path / "tmp"
+    cache_root = temp_root / "opensquilla-artifacts"
+    cache_root.mkdir(parents=True)
+    cache_root.chmod(0o777)
+    monkeypatch.setattr(artifact_routes.tempfile, "gettempdir", lambda: str(temp_root))
+    monkeypatch.setattr(artifact_routes.sys, "platform", "win32")
+
+    assert artifact_routes._artifact_open_cache_dir() == cache_root
+
+
 def test_artifact_native_open_requires_auth_and_owner(tmp_path: Path, monkeypatch) -> None:
     pytest.importorskip("starlette.testclient")
     from starlette.testclient import TestClient

--- a/tests/test_provider/test_request_goldens.py
+++ b/tests/test_provider/test_request_goldens.py
@@ -51,6 +51,8 @@ def test_goldens_contain_no_credential_material() -> None:
     files = sorted(harness.GOLDEN_ROOT.rglob("*.json"))
     assert files, "no golden files found"
     for path in files:
-        text = path.read_text(encoding="utf-8")
+        raw = path.read_bytes()
+        assert b"\r\n" not in raw, f"golden file must be checked out with LF endings: {path}"
+        text = raw.decode("utf-8")
         assert harness.FAKE_API_KEY not in text, f"credential material leaked into {path}"
         assert "Bearer " not in text, f"auth header value leaked into {path}"


### PR DESCRIPTION
## Scope
- Fix Windows artifact native-open temp cache handling by skipping POSIX mode-bit enforcement on win32.
- Pin provider request golden JSON files to LF checkout via .gitattributes.
- Add regression coverage for Windows temp cache behavior and LF-only request goldens.

## Branch target
main

## Linked issue
None

## Release note
None; CI/release-readiness fix only.

## Test results
- uv run --extra dev pytest tests/test_gateway/test_artifacts_download.py tests/test_provider/test_request_goldens.py -q
- uv run --extra dev ruff check src/opensquilla/gateway/artifacts.py tests/test_gateway/test_artifacts_download.py tests/test_provider/test_request_goldens.py
- git diff --check
- git check-attr text eol -- tests/test_provider/golden/requests/openai_compat/openai__plain.json

## Safety notes
No runtime data, credentials, or generated user artifacts are committed.

## Third-party origin
None