### PR TITLE
Relax macOS release gateway smoke timeout

### DIFF
--- a/.github/workflows/wheelhouse-release.yml
+++ b/.github/workflows/wheelhouse-release.yml
@@ -231,6 +231,7 @@ jobs:
         working-directory: desktop/electron
         env:
           OPENSQUILLA_REQUIRE_PACKAGED_GATEWAY_SMOKE: "1"
+          OPENSQUILLA_GATEWAY_SMOKE_TIMEOUT_MS: "240000"
         run: npm run verify:gateway-smoke
 
       - name: List macOS artifacts

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -85,6 +85,10 @@ def test_release_workflow_hydrates_and_smokes_desktop_router_runtime() -> None:
         assert "npm run verify:package" in job
         assert "npm run verify:gateway-smoke" in job
         assert 'OPENSQUILLA_REQUIRE_PACKAGED_GATEWAY_SMOKE: "1"' in job
+        if job_name == "build-desktop-macos":
+            assert 'OPENSQUILLA_GATEWAY_SMOKE_TIMEOUT_MS: "240000"' in job
+        else:
+            assert "OPENSQUILLA_GATEWAY_SMOKE_TIMEOUT_MS" not in job
 
 
 def test_release_workflow_keeps_macos_signing_identity_auto_selected() -> None:


### PR DESCRIPTION
## Scope
- Increase only the macOS Release Assets packaged gateway smoke timeout to 240s.
- Keep Windows release smoke on the default 90s timeout.
- Lock the macOS-only timeout in the release consistency test.

## Branch target
main

## Linked issue
None

## Release note
None - release pipeline fix only.

## Tests
- uv run --extra dev pytest tests/test_release_consistency.py::test_release_workflow_hydrates_and_smokes_desktop_router_runtime -q
- uv run --extra dev ruff check tests/test_release_consistency.py
- git diff --check

## Safety
No product runtime code changed. This only widens the macOS release asset smoke gate after v0.5.0rc2 packaging reached signed/notarized package verification but the packaged gateway health probe exceeded 90s on the macOS runner.

## Third-party origin
None