### PR TITLE
Fix release note documentation links

### DIFF
--- a/docs/releases/0.4.0.md
+++ b/docs/releases/0.4.0.md
@@ -58,7 +58,7 @@ Recommended desktop downloads:
 - macOS desktop installer: `OpenSquilla-0.4.0-mac-arm64.dmg`
 - Windows desktop installer: `OpenSquilla-0.4.0-win-x64.exe`
 
-Code signing policy: [`docs/code-signing-policy.md`](../code-signing-policy.md).
+Code signing policy: [`docs/code-signing-policy.md`](https://github.com/opensquilla/opensquilla/blob/7353f2795aa2e77aa408c3e8a9150dd7efbd80d0/docs/code-signing-policy.md).
 
 Terminal and automation downloads:
 
@@ -75,8 +75,8 @@ downloads for existing scripts and portable-folder workflows. New Windows
 desktop users should prefer `OpenSquilla-0.4.0-win-x64.exe`.
 
 Privacy and third-party attribution are documented in
-[`PRIVACY.md`](../../PRIVACY.md) and
-[`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md).
+[`PRIVACY.md`](https://github.com/opensquilla/opensquilla/blob/7353f2795aa2e77aa408c3e8a9150dd7efbd80d0/PRIVACY.md) and
+[`THIRD_PARTY_NOTICES.md`](https://github.com/opensquilla/opensquilla/blob/v0.4.0/THIRD_PARTY_NOTICES.md).
 
 Updater metadata:
 
@@ -146,5 +146,5 @@ Thanks to the contributors whose pull-request work is present in the current
   preview backend implementation commits carried into the 0.4.0 preview
   backend.
 
-See [`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/main/CONTRIBUTORS.md)
+See [`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/v0.4.0/CONTRIBUTORS.md)
 for the full 0.4.0 attribution ledger and PR evidence.

--- a/docs/releases/0.4.1.md
+++ b/docs/releases/0.4.1.md
@@ -67,7 +67,7 @@ hotfix, staging, integration, and sandbox work.
 - macOS desktop zip: `OpenSquilla-0.4.1-mac-arm64.zip`
 - Windows desktop installer: `OpenSquilla-0.4.1-win-x64.exe`
 
-Code signing policy: [`docs/code-signing-policy.md`](../code-signing-policy.md).
+Code signing policy: [`docs/code-signing-policy.md`](https://github.com/opensquilla/opensquilla/blob/7353f2795aa2e77aa408c3e8a9150dd7efbd80d0/docs/code-signing-policy.md).
 
 ⚙️ Terminal and automation downloads:
 
@@ -84,8 +84,8 @@ downloads for existing scripts and portable-folder workflows. New Windows
 desktop users should prefer `OpenSquilla-0.4.1-win-x64.exe`.
 
 Privacy and third-party attribution are documented in
-[`PRIVACY.md`](../../PRIVACY.md) and
-[`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md).
+[`PRIVACY.md`](https://github.com/opensquilla/opensquilla/blob/7353f2795aa2e77aa408c3e8a9150dd7efbd80d0/PRIVACY.md) and
+[`THIRD_PARTY_NOTICES.md`](https://github.com/opensquilla/opensquilla/blob/v0.4.1/THIRD_PARTY_NOTICES.md).
 
 🔄 Updater metadata:
 
@@ -124,5 +124,5 @@ Thanks to the contributors whose pull-request work is newly present in the
 - [@ab2ence](https://github.com/ab2ence) for install telemetry CI/test
   environment skipping and desktop HTML artifact native-open support.
 
-See [`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/main/CONTRIBUTORS.md)
+See [`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/v0.4.1/CONTRIBUTORS.md)
 for the full attribution ledger and PR evidence.

--- a/docs/releases/0.5.0rc1.md
+++ b/docs/releases/0.5.0rc1.md
@@ -65,7 +65,7 @@ Recommended desktop downloads:
 - macOS desktop zip: `OpenSquilla-0.5.0-rc1-mac-arm64.zip`
 - Windows desktop installer: `OpenSquilla-0.5.0-rc1-win-x64.exe`
 
-Code signing policy: [`docs/code-signing-policy.md`](../code-signing-policy.md).
+Code signing policy: [`docs/code-signing-policy.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.0rc1/docs/code-signing-policy.md).
 
 Terminal and automation downloads:
 
@@ -78,8 +78,8 @@ legacy scripts and portable-folder workflows. New Windows users should use the
 Electron installer or the terminal wheel install path.
 
 Privacy and third-party attribution are documented in
-[`PRIVACY.md`](../../PRIVACY.md) and
-[`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md).
+[`PRIVACY.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.0rc1/PRIVACY.md) and
+[`THIRD_PARTY_NOTICES.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.0rc1/THIRD_PARTY_NOTICES.md).
 
 Updater metadata:
 
@@ -128,5 +128,5 @@ release surface:
 - [@HuaXiawithMoon](https://github.com/HuaXiawithMoon), a first-time OpenSquilla
   release contributor, for WeCom AI Bot websocket mode work.
 
-See [`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/main/CONTRIBUTORS.md)
+See [`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.0rc1/CONTRIBUTORS.md)
 for the full attribution ledger and PR/commit evidence.

--- a/docs/releases/0.5.0rc2.md
+++ b/docs/releases/0.5.0rc2.md
@@ -68,7 +68,7 @@ Recommended desktop downloads:
 - macOS desktop zip: `OpenSquilla-0.5.0-rc2-mac-arm64.zip`
 - Windows desktop installer: `OpenSquilla-0.5.0-rc2-win-x64.exe`
 
-Code signing policy: [`docs/code-signing-policy.md`](../code-signing-policy.md).
+Code signing policy: [`docs/code-signing-policy.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.0rc2/docs/code-signing-policy.md).
 
 Terminal and automation downloads:
 
@@ -82,8 +82,8 @@ Electron installer or the terminal wheel install path. Do not expect a new
 0.5.0rc2 portable zip or `/releases/latest/download/` portable alias.
 
 Privacy and third-party attribution are documented in
-[`PRIVACY.md`](../../PRIVACY.md) and
-[`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md).
+[`PRIVACY.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.0rc2/PRIVACY.md) and
+[`THIRD_PARTY_NOTICES.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.0rc2/THIRD_PARTY_NOTICES.md).
 
 Updater metadata:
 
@@ -124,5 +124,5 @@ release surface:
 - [@HuaXiawithMoon](https://github.com/HuaXiawithMoon) for keeping `code-task`
   build scaffolding non-interactive.
 
-See [`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/main/CONTRIBUTORS.md)
+See [`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.0rc2/CONTRIBUTORS.md)
 for the full attribution ledger and PR/commit evidence.


### PR DESCRIPTION
## Scope
- Updates release note repository links in `docs/releases/0.4.0.md`, `0.4.1.md`, `0.5.0rc1.md`, and `0.5.0rc2.md` to absolute GitHub URLs suitable for release bodies.
- Pins 0.5.x links to their release tags and 0.4.x code-signing/privacy links to the current main commit because those files were introduced after the 0.4.x tags.
- Replaces contributor ledger links that pointed at `main` with release-tagged links.

## Branch Target
main

## Linked Issue
None

## Release Note Status
Docs-only release-note maintenance; no product release note needed.

## Test Results
- `git diff --check HEAD~1..HEAD -- docs/releases/0.4.0.md docs/releases/0.4.1.md docs/releases/0.5.0rc1.md docs/releases/0.5.0rc2.md`
- `git cat-file -e` for each linked tag/commit target added by the release notes
- Negative `rg` check confirmed no remaining `blob/main/CONTRIBUTORS.md` links or 0.4.x tag links to missing code-signing/privacy paths

## Safety Notes
- Docs-only change; no runtime, packaging, release tag, or workflow behavior changes.
- No GitHub Release body was edited by this PR.

## Third-Party Origin Details
None.