### PR TITLE
Harden desktop client and fix macOS prerelease auto-update

### DIFF
--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -13,6 +13,7 @@ release_changed=false
 windows_full_required=false
 frontend_changed=false
 tui_changed=false
+desktop_changed=false
 python_changed=false
 platform_sensitive_changed=false
 build_wheel_required=false
@@ -65,6 +66,11 @@ mark_tui_changed() {
   tui_changed=true
 }
 
+mark_desktop_changed() {
+  mark_non_docs_changed
+  desktop_changed=true
+}
+
 mark_platform_sensitive_changed() {
   mark_non_docs_changed
   platform_sensitive_changed=true
@@ -81,6 +87,7 @@ mark_full_required() {
   windows_full_required=true
   frontend_changed=true
   tui_changed=true
+  desktop_changed=true
   python_changed=true
   platform_sensitive_changed=true
   build_wheel_required=true
@@ -135,6 +142,7 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       ;;
     desktop/*)
       mark_platform_sensitive_changed
+      mark_desktop_changed
       ;;
     src/opensquilla/sandbox/* | src/opensquilla/tools/boundary.py | src/opensquilla/tools/builtin/code_exec.py | src/opensquilla/tools/builtin/filesystem.py | src/opensquilla/tools/builtin/git.py | src/opensquilla/tools/builtin/shell.py | src/opensquilla/tools/builtin/shell_policy.py | src/opensquilla/tools/path_* | src/opensquilla/tools/policy* | src/opensquilla/tools/write_*)
       mark_runtime_changed
@@ -165,6 +173,7 @@ fi
   printf 'windows_full_required=%s\n' "${windows_full_required}"
   printf 'frontend_changed=%s\n' "${frontend_changed}"
   printf 'tui_changed=%s\n' "${tui_changed}"
+  printf 'desktop_changed=%s\n' "${desktop_changed}"
   printf 'python_changed=%s\n' "${python_changed}"
   printf 'platform_sensitive_changed=%s\n' "${platform_sensitive_changed}"
   printf 'build_wheel_required=%s\n' "${build_wheel_required}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       windows_full_required: ${{ steps.classify.outputs.windows_full_required }}
       frontend_changed: ${{ steps.classify.outputs.frontend_changed }}
       tui_changed: ${{ steps.classify.outputs.tui_changed }}
+      desktop_changed: ${{ steps.classify.outputs.desktop_changed }}
       python_changed: ${{ steps.classify.outputs.python_changed }}
       platform_sensitive_changed: ${{ steps.classify.outputs.platform_sensitive_changed }}
       build_wheel_required: ${{ steps.classify.outputs.build_wheel_required }}
@@ -159,6 +160,42 @@ jobs:
       - name: Run OpenTUI Bun tests
         working-directory: src/opensquilla/cli/tui/opentui/package
         run: bun run test:bun
+
+  desktop-check:
+    name: Desktop Electron unit tests
+    needs: classify-changes
+    if: ${{ needs.classify-changes.outputs.desktop_changed == 'true' || needs.classify-changes.outputs.full_required == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      # The pure-logic unit tests run against the compiled dist and never launch
+      # Electron, so skip the heavy Electron/Playwright binary downloads.
+      ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.0'
+          cache: 'npm'
+          cache-dependency-path: desktop/electron/package-lock.json
+
+      - name: Install desktop dependencies
+        working-directory: desktop/electron
+        run: npm ci
+
+      - name: Build desktop TypeScript
+        working-directory: desktop/electron
+        run: npm run build
+
+      - name: Run desktop unit tests
+        working-directory: desktop/electron
+        run: |
+          node scripts/test-secret-storage-policy.mjs
+          node scripts/test-update-resolver.mjs
 
   ubuntu-quality:
     name: Lint, test, and build (ubuntu-latest, 3.12)
@@ -437,6 +474,7 @@ jobs:
       - readme-locale-check
       - frontend-check
       - tui-check
+      - desktop-check
       - ubuntu-quality
       - windows-compat
       - windows-full
@@ -455,6 +493,7 @@ jobs:
           readme_locale_result="${{ needs.readme-locale-check.result }}"
           frontend_result="${{ needs.frontend-check.result }}"
           tui_result="${{ needs.tui-check.result }}"
+          desktop_result="${{ needs.desktop-check.result }}"
           ubuntu_result="${{ needs.ubuntu-quality.result }}"
           windows_smoke_result="${{ needs.windows-compat.result }}"
           windows_full_result="${{ needs.windows-full.result }}"
@@ -468,6 +507,7 @@ jobs:
           windows_full_required="${{ needs.classify-changes.outputs.windows_full_required }}"
           frontend_changed="${{ needs.classify-changes.outputs.frontend_changed }}"
           tui_changed="${{ needs.classify-changes.outputs.tui_changed }}"
+          desktop_changed="${{ needs.classify-changes.outputs.desktop_changed }}"
           python_changed="${{ needs.classify-changes.outputs.python_changed }}"
           platform_sensitive_changed="${{ needs.classify-changes.outputs.platform_sensitive_changed }}"
           build_wheel_required="${{ needs.classify-changes.outputs.build_wheel_required }}"
@@ -496,6 +536,7 @@ jobs:
           printf 'readme-locale-check: %s\n' "${readme_locale_result}"
           printf 'frontend-check: %s\n' "${frontend_result}"
           printf 'tui-check: %s\n' "${tui_result}"
+          printf 'desktop-check: %s\n' "${desktop_result}"
           printf 'ubuntu-quality: %s\n' "${ubuntu_result}"
           printf 'windows-compat-smoke: %s\n' "${windows_smoke_result}"
           printf 'windows-full: %s\n' "${windows_full_result}"
@@ -517,6 +558,12 @@ jobs:
             require_success "${tui_result}" "OpenTUI package tests"
           else
             allow_success_or_skipped "${tui_result}" "OpenTUI package tests"
+          fi
+
+          if [[ "${desktop_changed}" == "true" || "${full_required}" == "true" ]]; then
+            require_success "${desktop_result}" "Desktop Electron unit tests"
+          else
+            allow_success_or_skipped "${desktop_result}" "Desktop Electron unit tests"
           fi
 
           if [[ "${python_changed}" == "true" || "${full_required}" == "true" ]]; then

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -20,6 +20,7 @@
     "verify:package": "npm run verify:icons && node scripts/verify-package.mjs",
     "verify:gateway-smoke": "node scripts/smoke-gateway.mjs",
     "test:secret-storage": "npm run build && node scripts/test-secret-storage-policy.mjs",
+    "test:update-resolver": "npm run build && node scripts/test-update-resolver.mjs",
     "test:mock-update-flow": "npm run build && node scripts/test-mock-update-flow.mjs",
     "test:onboarding-flow": "npm run build && node scripts/test-onboarding-flow.mjs",
     "start": "electron .",

--- a/desktop/electron/scripts/test-update-resolver.mjs
+++ b/desktop/electron/scripts/test-update-resolver.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict'
+
+import {
+  parseOpenSquillaReleaseTag,
+  selectMacPrereleaseCandidate,
+} from '../dist/update-feed-resolver.js'
+
+// --- tag parsing: PEP440 rc, semver rc, stable, and rejects ---
+assert.deepEqual(parseOpenSquillaReleaseTag('v0.5.0rc2'), { base: '0.5.0', rc: 2 })
+assert.deepEqual(parseOpenSquillaReleaseTag('0.5.0-rc2'), { base: '0.5.0', rc: 2 })
+assert.deepEqual(parseOpenSquillaReleaseTag('v0.5.0-rc.3'), { base: '0.5.0', rc: 3 })
+assert.deepEqual(parseOpenSquillaReleaseTag('v0.5.0'), { base: '0.5.0', rc: null })
+assert.equal(parseOpenSquillaReleaseTag('website-2026-01'), null)
+assert.equal(parseOpenSquillaReleaseTag('v0.5'), null)
+
+const withMacFeed = (tag) => ({ tag_name: tag, assets: [{ name: 'latest-mac.yml' }] })
+const noMacFeed = (tag) => ({ tag_name: tag, assets: [{ name: 'OpenSquilla-mac.zip' }] })
+
+// 1. 0.5.0-rc1 sees v0.5.0rc2 (PEP440 tag).
+{
+  const c = selectMacPrereleaseCandidate({ base: '0.5.0', rc: 1 }, [
+    withMacFeed('v0.5.0rc2'),
+    withMacFeed('v0.5.0rc1'),
+  ])
+  assert.ok(c, 'rc1 should find rc2')
+  assert.equal(c.tag, 'v0.5.0rc2')
+  assert.equal(c.version, '0.5.0-rc2')
+  assert.equal(c.feedUrl, 'https://github.com/opensquilla/opensquilla/releases/download/v0.5.0rc2')
+}
+
+// 2. 0.5.0-rc2 sees the final stable v0.5.0 (stable outranks a later rc).
+{
+  const c = selectMacPrereleaseCandidate({ base: '0.5.0', rc: 2 }, [
+    withMacFeed('v0.5.0'),
+    withMacFeed('v0.5.0rc3'),
+    withMacFeed('v0.5.0rc2'),
+  ])
+  assert.ok(c, 'rc2 should find a candidate')
+  assert.equal(c.tag, 'v0.5.0')
+  assert.equal(c.version, '0.5.0')
+}
+
+// 2b. Two-digit rc ordering is numeric, not string: rc9 sees rc10 (not the
+//     reverse). electron-updater's own semver gate sorts rc10 below rc9, which is
+//     why the resolver path also sets allowDowngrade — see main.ts.
+{
+  const c = selectMacPrereleaseCandidate({ base: '0.5.0', rc: 9 }, [
+    withMacFeed('v0.5.0rc10'),
+    withMacFeed('v0.5.0rc9'),
+  ])
+  assert.ok(c, 'rc9 should find rc10')
+  assert.equal(c.tag, 'v0.5.0rc10')
+  assert.equal(c.version, '0.5.0-rc10')
+}
+// rc10 does not regress to rc9.
+{
+  const c = selectMacPrereleaseCandidate({ base: '0.5.0', rc: 10 }, [
+    withMacFeed('v0.5.0rc10'),
+    withMacFeed('v0.5.0rc9'),
+  ])
+  assert.equal(c, null, 'rc10 must not pick the lower rc9')
+}
+
+// 3. A prerelease does NOT jump to a different base's preview (0.5.0-rc2 ignores v0.6.0rc1).
+{
+  const c = selectMacPrereleaseCandidate({ base: '0.5.0', rc: 2 }, [
+    withMacFeed('v0.6.0rc1'),
+    withMacFeed('v0.5.0rc2'),
+  ])
+  assert.equal(c, null, 'rc2 must not cross to a different base')
+}
+
+// 4a. A newer same-base release without latest-mac.yml is skipped.
+{
+  const c = selectMacPrereleaseCandidate({ base: '0.5.0', rc: 1 }, [noMacFeed('v0.5.0rc2')])
+  assert.equal(c, null, 'candidate without latest-mac.yml is skipped')
+}
+
+// 4b. When the highest release lacks the feed, fall back to the highest that has it.
+{
+  const c = selectMacPrereleaseCandidate({ base: '0.5.0', rc: 1 }, [
+    noMacFeed('v0.5.0rc3'),
+    withMacFeed('v0.5.0rc2'),
+  ])
+  assert.ok(c, 'should fall back to rc2 which has the feed')
+  assert.equal(c.tag, 'v0.5.0rc2')
+}
+
+// 5. No newer same-base release → no candidate (current rc is the latest).
+{
+  const c = selectMacPrereleaseCandidate({ base: '0.5.0', rc: 2 }, [withMacFeed('v0.5.0rc2')])
+  assert.equal(c, null, 'only the current rc exists → up to date')
+}
+
+// 6. Draft releases are ignored.
+{
+  const c = selectMacPrereleaseCandidate({ base: '0.5.0', rc: 1 }, [
+    { tag_name: 'v0.5.0rc2', draft: true, assets: [{ name: 'latest-mac.yml' }] },
+  ])
+  assert.equal(c, null, 'draft releases are not upgrade candidates')
+}
+
+console.log('Update resolver tests passed.')

--- a/desktop/electron/src/boot.html
+++ b/desktop/electron/src/boot.html
@@ -123,6 +123,13 @@
       width: 38%;
     }
 
+    /* On a startup failure the splash is paused, not working — freeze the
+       indeterminate sweep so it doesn't contradict the "Startup paused" state. */
+    body.errored .status-line::before {
+      animation: none;
+      opacity: 0.2;
+    }
+
     .status-copy {
       align-items: baseline;
       display: flex;
@@ -430,6 +437,9 @@
       // local default phase string only when no label was provided.
       phase.textContent = payload && payload.label ? String(payload.label) : msg.phaseDefault;
       errorPanel.classList.remove('visible');
+      // Leaving the error state: resume the sweep and the elapsed timer.
+      document.body.classList.remove('errored');
+      if (!timerInterval) timerInterval = setInterval(updateTimer, 100);
       setStepState(stepMap[phaseId] || 'profile', phaseId === 'ready');
     }
 
@@ -438,6 +448,14 @@
       phase.textContent = msg.startupPaused;
       errorMessage.textContent = message;
       errorPanel.classList.add('visible');
+      // Stop signalling progress: freeze the elapsed timer, pause the sweep (via
+      // the .errored class), and drop the active step highlight so a failed phase
+      // is not shown as still running.
+      document.body.classList.add('errored');
+      if (timerInterval) { clearInterval(timerInterval); timerInterval = null; }
+      for (const step of Object.values(steps)) {
+        if (step) step.classList.remove('active');
+      }
     }
 
     async function resetSetup() {
@@ -457,9 +475,10 @@
       }
     }
 
-    setInterval(() => {
+    function updateTimer() {
       timer.textContent = `${((performance.now() - started) / 1000).toFixed(1).padStart(4, '0')}s`;
-    }, 100);
+    }
+    let timerInterval = setInterval(updateTimer, 100);
 
     const api = window.opensquillaDesktop;
     if (api) {

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -2,12 +2,19 @@ import { app, BrowserWindow, dialog, Menu, ipcMain, nativeTheme, safeStorage, sh
 import electronUpdater from 'electron-updater'
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { appendFileSync, createWriteStream, existsSync, mkdirSync, readFileSync } from 'node:fs'
-import { access, constants, readFile, readdir, rm, stat, unlink, writeFile } from 'node:fs/promises'
+import { appendFileSync, createWriteStream, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { access, constants, readFile, readdir, rename, rm, stat, unlink, writeFile } from 'node:fs/promises'
 import net from 'node:net'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { secretStorageBackendForPolicy, shouldUseChromiumMockKeychainForPolicy } from './secret-storage-policy.js'
+import {
+  GITHUB_UPDATE_OWNER,
+  GITHUB_UPDATE_REPO,
+  parseOpenSquillaReleaseTag,
+  selectMacPrereleaseCandidate,
+  type ReleaseSummary,
+} from './update-feed-resolver.js'
 
 interface GatewayState {
   url: string
@@ -84,6 +91,7 @@ interface OnboardingPayload {
   searchProvider?: unknown
   searchApiKey?: unknown
   disableNetworkObservability?: unknown
+  locale?: unknown
 }
 
 interface DesktopSettingsPayload extends OnboardingPayload {}
@@ -144,6 +152,10 @@ let mainWindow: BrowserWindow | null = null
 let onboardingWindow: BrowserWindow | null = null
 let gatewayProcess: ChildProcessWithoutNullStreams | null = null
 let isQuitting = false
+// Opt stopGateway into the Windows HTTP graceful-drain path even while isQuitting
+// is set, for the update/uninstall flows that keep the main process alive and
+// await the child's exit (so the fire-and-forget drain is not racing app teardown).
+let allowGracefulShutdownWhileQuitting = false
 
 // Main-process lifecycle log (distinct from the gateway child's gateway.log).
 // Records launch, single-instance-lock acquisition, and quit phases so a
@@ -206,9 +218,14 @@ function bootPagePath(): string {
 }
 
 function appIconPath(): string {
+  // Only icon.icns (macOS) and icon.ico (Windows) ship in assets/ — there is no
+  // icon.png, so the previous path resolved to a missing file everywhere. On
+  // macOS BrowserWindow.icon is ignored (the bundle icon is used), so pointing at
+  // the platform icon that exists is correct for the surfaces that do read it.
+  const iconFile = process.platform === 'win32' ? 'icon.ico' : 'icon.icns'
   return app.isPackaged
-    ? join(process.resourcesPath, 'app.asar', 'assets', 'icon.png')
-    : join(packageRoot, 'assets', 'icon.png')
+    ? join(process.resourcesPath, 'app.asar', 'assets', iconFile)
+    : join(packageRoot, 'assets', iconFile)
 }
 
 const MAC_APP_TRANSLOCATION_SEGMENT = '/AppTranslocation/'
@@ -616,6 +633,11 @@ function normalizeRouterTiers(raw: unknown, fallback: Record<string, RouterTier>
   for (const [rawName, value] of Object.entries(source)) {
     if (!value || typeof value !== 'object') continue
     const name = canonicalTierKey(rawName)
+    // Tier keys are emitted raw into TOML table headers ([squilla_router.tiers.NAME]),
+    // so a key that is not a TOML bare key (spaces, dots, quotes, brackets, newlines)
+    // would produce an unparseable config the gateway rejects on every boot. Drop
+    // such keys and fall back to the profile defaults instead.
+    if (!/^[A-Za-z0-9_-]+$/.test(name)) continue
     const tier = value as Record<string, unknown>
     const provider = String(tier.provider || out[name]?.provider || '').trim()
     const model = String(tier.model || out[name]?.model || '').trim()
@@ -841,6 +863,21 @@ function normalizeDesktopCredential(parsed: Partial<DesktopConnection>): Desktop
   }
 }
 
+// Write via a temp file + atomic rename so a crash, power loss, or full disk
+// mid-write cannot leave a truncated credential (silent re-onboarding + lost
+// key) or a truncated config.toml (which, since it is only reseeded when
+// missing, would wedge boot on every launch).
+async function atomicWriteFile(filePath: string, data: string, mode: number): Promise<void> {
+  const tmpPath = `${filePath}.${randomUUID()}.tmp`
+  try {
+    await writeFile(tmpPath, data, { mode })
+    await rename(tmpPath, filePath)
+  } catch (err) {
+    await rm(tmpPath, { force: true }).catch(() => null)
+    throw err
+  }
+}
+
 async function loadDesktopCredential(): Promise<DesktopConnection | null> {
   try {
     const raw = await readFile(credentialPath(), 'utf8')
@@ -923,23 +960,82 @@ async function saveDesktopCredential(payload: OnboardingPayload): Promise<Deskto
   }
 
   mkdirSync(app.getPath('userData'), { recursive: true })
-  await writeFile(credentialPath(), JSON.stringify(credential, null, 2), { mode: 0o600 })
+  await atomicWriteFile(credentialPath(), JSON.stringify(credential, null, 2), 0o600)
   await writeDesktopConfig(credential)
   return credential
+}
+
+// Sections the desktop config template owns and regenerates from the credential
+// on every write. Everything else in config.toml is treated as foreign
+// (Control-UI/RPC-owned) and preserved verbatim across regenerations.
+const DESKTOP_OWNED_CONFIG_SECTIONS = ['llm', 'squilla_router', 'llm_ensemble', 'privacy', 'control_ui']
+// Top-level (pre-section) keys the desktop template emits itself. Any OTHER
+// top-level key present in config.toml was written by the Control UI / RPC (which
+// serializes the whole GatewayConfig, so scalar fields like
+// llm_request_timeout_seconds land in the TOML preamble) and must be preserved.
+const DESKTOP_OWNED_CONFIG_PREAMBLE_KEYS = ['state_dir', 'search_provider', 'search_api_key_env']
+
+function isDesktopOwnedConfigSection(header: string): boolean {
+  const name = header.trim()
+  return DESKTOP_OWNED_CONFIG_SECTIONS.some((owned) => name === owned || name.startsWith(`${owned}.`))
+}
+
+// Return the lines of every top-level section that the desktop template does not
+// own, so they survive a config regeneration. Line-based (like the privacy-config
+// reader) to avoid taking on a TOML parser dependency.
+function foreignConfigSectionLines(raw: string): string[] {
+  const out: string[] = []
+  let keeping = false
+  for (const rawLine of raw.split(/\r?\n/)) {
+    const header = rawLine.trim().match(/^\[+\s*([^\]]+?)\s*\]+$/)
+    if (header) keeping = !isDesktopOwnedConfigSection(header[1] ?? '')
+    if (keeping) out.push(rawLine)
+  }
+  while (out.length && out[out.length - 1].trim() === '') out.pop()
+  return out
+}
+
+// Return the top-level (pre-first-section) key lines the desktop template does
+// NOT emit itself, so RPC-written global scalars (llm_request_timeout_seconds,
+// log_level, workspace_dir, diagnostics_enabled, …) survive a regeneration. These
+// must be re-emitted in the preamble (before any [section]) to stay top-level.
+function foreignConfigPreambleLines(raw: string): string[] {
+  const out: string[] = []
+  for (const rawLine of raw.split(/\r?\n/)) {
+    if (/^\s*\[/.test(rawLine)) break // reached the first section header
+    const key = rawLine.match(/^\s*([A-Za-z0-9_-]+)\s*=/)
+    if (!key) continue // blank line or comment
+    if (DESKTOP_OWNED_CONFIG_PREAMBLE_KEYS.includes(key[1] ?? '')) continue
+    out.push(rawLine)
+  }
+  return out
 }
 
 async function writeDesktopConfig(credential: DesktopConnection): Promise<void> {
   mkdirSync(desktopHome(), { recursive: true })
   mkdirSync(desktopStateDir(), { recursive: true })
+  // Only the desktop-owned sections/keys are regenerated from the credential; any
+  // other sections (channels, memory, sandbox, mcp, scheduler, …) AND top-level
+  // scalar keys (llm_request_timeout_seconds, log_level, …) the Control UI wrote
+  // via RPC are read back and preserved, so a settings save no longer wipes live
+  // configuration.
+  let preservedForeignSections: string[] = []
+  let preservedForeignPreamble: string[] = []
+  try {
+    const existingRaw = readFileSync(desktopConfigPath(), 'utf8')
+    preservedForeignSections = foreignConfigSectionLines(existingRaw)
+    preservedForeignPreamble = foreignConfigPreambleLines(existingRaw)
+  } catch {
+    // No existing config to preserve (fresh install) or unreadable.
+  }
   const config = [
     `state_dir = ${tomlString(desktopStateDir())}`,
     `search_provider = ${tomlString(credential.searchProvider)}`,
     ...(credential.searchApiKeyEnv ? [`search_api_key_env = ${tomlString(credential.searchApiKeyEnv)}`] : []),
     // search_max_results is intentionally omitted so the gateway's own default
-    // governs instead of pinning it to a hardcoded value. Note this writer
-    // regenerates the whole config file, so it still does not preserve a value
-    // set through the control UI — that broader limitation of the desktop config
-    // writer is tracked separately.
+    // governs instead of pinning it to a hardcoded value.
+    // Preserved RPC-written top-level keys stay in the preamble (before any table).
+    ...preservedForeignPreamble,
     '',
     '[llm]',
     `provider = ${tomlString(credential.provider)}`,
@@ -955,8 +1051,9 @@ async function writeDesktopConfig(credential: DesktopConnection): Promise<void> 
     'enabled = true',
     'base_path = "/control"',
     '',
+    ...(preservedForeignSections.length ? [...preservedForeignSections, ''] : []),
   ].join('\n')
-  await writeFile(desktopConfigPath(), config, { mode: 0o600 })
+  await atomicWriteFile(desktopConfigPath(), config, 0o600)
 }
 
 function settingsSnapshot(connection: DesktopConnection | null): DesktopSettingsSnapshot {
@@ -1057,23 +1154,35 @@ function artifactMimeKey(mime: unknown): string {
   return String(mime ?? '').split(';', 1)[0].trim().toLowerCase()
 }
 
-// When the name carries no extension, fall back to one implied by the MIME type
-// so shell.openPath can still associate a default application.
+// Append an extension implied by the MIME type unless the name already ends with
+// a recognized document/image extension. The previous "any .xxx suffix counts as
+// an extension" heuristic misclassified version/date suffixes (report.v2,
+// plan.rev3), so the authoritative MIME extension was dropped and shell.openPath
+// hit a missing/incorrect OS association.
 function artifactExtension(name: string, mime: unknown): string {
-  if (/\.[A-Za-z0-9]{1,8}$/.test(name)) return ''
+  const lower = name.toLowerCase()
+  if (Object.values(MIME_EXTENSIONS).some((ext) => lower.endsWith(ext))) return ''
   return MIME_EXTENSIONS[artifactMimeKey(mime)] || ''
 }
 
+// Artifacts opened this session, so the prune never deletes a file that an
+// external viewer (Preview, Excel, a browser) still has open — deleting it out
+// from under the app loses the document and any unsaved edits made there.
+const openedArtifactPaths = new Set<string>()
+
 // Best-effort prune so opened artifacts do not accumulate unboundedly in temp.
+// Skips files opened this session and only removes prior-session leftovers older
+// than a day, so a document a user is actively viewing is never yanked away.
 async function pruneArtifactCache(dir: string): Promise<void> {
   try {
     const now = Date.now()
     const entries = await readdir(dir)
     await Promise.all(entries.map(async (entry) => {
       const full = join(dir, entry)
+      if (openedArtifactPaths.has(full)) return
       try {
         const info = await stat(full)
-        if (now - info.mtimeMs > 60 * 60 * 1000) await unlink(full)
+        if (now - info.mtimeMs > 24 * 60 * 60 * 1000) await unlink(full)
       } catch {}
     }))
   } catch {}
@@ -1083,6 +1192,9 @@ async function openArtifactWithDefaultApp(payload: ArtifactOpenRequest): Promise
   const raw = payload?.data
   if (!raw) return { ok: false, message: 'No artifact data to open.' }
   try {
+    // Reuse the received bytes directly; fs.writeFile accepts a Uint8Array, so
+    // Buffer.from() here would just memcpy a second full copy of the payload
+    // (hundreds of MB for media artifacts) into the main process.
     const bytes = raw instanceof Uint8Array ? raw : new Uint8Array(raw)
     const dir = join(app.getPath('temp'), 'opensquilla-artifacts')
     mkdirSync(dir, { recursive: true, mode: 0o700 })
@@ -1091,7 +1203,8 @@ async function openArtifactWithDefaultApp(payload: ArtifactOpenRequest): Promise
     // A random prefix guarantees a unique, non-colliding, non-dotfile path even
     // for two opens in the same millisecond.
     const filePath = join(dir, `${randomUUID()}-${name}${artifactExtension(name, payload?.mime)}`)
-    await writeFile(filePath, Buffer.from(bytes), { mode: 0o600 })
+    await writeFile(filePath, bytes, { mode: 0o600 })
+    openedArtifactPaths.add(filePath)
     const error = await shell.openPath(filePath)
     if (error) return { ok: false, message: error }
     return { ok: true }
@@ -1204,6 +1317,55 @@ const PROVIDER_NOTE_MESSAGES: Record<DesktopLocale, Record<string, string>> = {
   },
 }
 
+// Localized descriptive notes for the search providers, mirroring
+// PROVIDER_NOTE_MESSAGES. Without these the onboarding search cards always
+// rendered the hardcoded English catalog notes, so their localized fallbacks
+// were unreachable in every non-English locale.
+const SEARCH_PROVIDER_NOTE_MESSAGES: Record<DesktopLocale, Record<string, string>> = {
+  en: {
+    duckduckgo: 'No key required. Good default for getting started.',
+    bocha: 'Web search with inline summaries and freshness support.',
+    brave: 'Managed search access with freshness support.',
+    tavily: 'Freshness-oriented web search for current research.',
+    exa: 'Semantic and content-oriented search for research workflows.',
+  },
+  'zh-Hans': {
+    duckduckgo: '无需密钥。适合入门的默认选项。',
+    bocha: '带内联摘要和时效性支持的网络搜索。',
+    brave: '带时效性支持的托管搜索访问。',
+    tavily: '面向时效性的网络搜索，适合最新研究。',
+    exa: '面向语义和内容的搜索，适合研究工作流。',
+  },
+  ja: {
+    duckduckgo: 'キー不要。始めるのに適したデフォルトです。',
+    bocha: 'インライン要約と鮮度対応を備えたウェブ検索です。',
+    brave: '鮮度対応を備えたマネージド検索アクセスです。',
+    tavily: '最新の調査向けの、鮮度重視のウェブ検索です。',
+    exa: '調査ワークフロー向けのセマンティック／コンテンツ指向検索です。',
+  },
+  fr: {
+    duckduckgo: 'Aucune clé requise. Bon choix par défaut pour démarrer.',
+    bocha: 'Recherche web avec résumés en ligne et prise en charge de la fraîcheur.',
+    brave: 'Accès de recherche géré avec prise en charge de la fraîcheur.',
+    tavily: 'Recherche web axée sur la fraîcheur pour la recherche actuelle.',
+    exa: 'Recherche sémantique et orientée contenu pour les flux de recherche.',
+  },
+  de: {
+    duckduckgo: 'Kein Schlüssel erforderlich. Gute Voreinstellung für den Einstieg.',
+    bocha: 'Websuche mit Inline-Zusammenfassungen und Aktualitätsunterstützung.',
+    brave: 'Verwalteter Suchzugriff mit Aktualitätsunterstützung.',
+    tavily: 'Aktualitätsorientierte Websuche für aktuelle Recherche.',
+    exa: 'Semantische und inhaltsorientierte Suche für Recherche-Workflows.',
+  },
+  es: {
+    duckduckgo: 'No se requiere clave. Buena opción predeterminada para empezar.',
+    bocha: 'Búsqueda web con resúmenes en línea y soporte de actualidad.',
+    brave: 'Acceso de búsqueda gestionado con soporte de actualidad.',
+    tavily: 'Búsqueda web orientada a la actualidad para investigación actual.',
+    exa: 'Búsqueda semántica y orientada a contenido para flujos de investigación.',
+  },
+}
+
 function resolveDesktopLocale(): DesktopLocale {
   const preferred = typeof app.getPreferredSystemLanguages === 'function'
     ? app.getPreferredSystemLanguages()
@@ -1211,12 +1373,53 @@ function resolveDesktopLocale(): DesktopLocale {
   for (const raw of [...preferred, app.getLocale()]) {
     if (typeof raw !== 'string') continue
     const t = raw.toLowerCase()
-    if (t.startsWith('zh')) return 'zh-Hans'
+    if (t.startsWith('zh')) {
+      // Only Simplified Chinese is bundled. Route Traditional variants
+      // (zh-Hant / zh-TW / zh-HK / zh-MO) to the English fallback rather than
+      // forcing Simplified text a Traditional reader may not want.
+      if (t.includes('hant') || /-(tw|hk|mo)\b/.test(t)) continue
+      return 'zh-Hans'
+    }
     for (const code of ['ja', 'fr', 'de', 'es'] as const) {
       if (t === code || t.startsWith(code + '-')) return code
     }
   }
   return 'en'
+}
+
+function desktopLocalePath(): string {
+  return join(app.getPath('userData'), 'desktop-locale')
+}
+
+// Persist the locale the user picked during onboarding so every main-process
+// surface (menu, dialogs, boot splash, next onboarding) honors it across
+// launches instead of reverting to the OS locale.
+function loadPersistedDesktopLocale(): DesktopLocale | null {
+  try {
+    const raw = readFileSync(desktopLocalePath(), 'utf8').trim()
+    return DESKTOP_LOCALES.includes(raw as DesktopLocale) ? (raw as DesktopLocale) : null
+  } catch {
+    return null
+  }
+}
+
+function persistDesktopLocale(locale: DesktopLocale): void {
+  try {
+    mkdirSync(app.getPath('userData'), { recursive: true })
+    writeFileSync(desktopLocalePath(), locale, 'utf8')
+  } catch {
+    // Best-effort; a failed persist just means the next launch re-resolves the OS locale.
+  }
+}
+
+function applyDesktopLocaleChoice(raw: unknown): void {
+  const requested = String(raw ?? '')
+  if (!DESKTOP_LOCALES.includes(requested as DesktopLocale)) return
+  if (requested !== desktopLocale) {
+    desktopLocale = requested as DesktopLocale
+    createApplicationMenu()
+  }
+  persistDesktopLocale(desktopLocale)
 }
 
 const DESKTOP_MESSAGES: Record<DesktopLocale, Record<string, string>> = {
@@ -1240,6 +1443,13 @@ const DESKTOP_MESSAGES: Record<DesktopLocale, Record<string, string>> = {
     'update.gatewayShutdownTimeout': 'OpenSquilla could not stop the local runtime. Try relaunching to update again.',
     'update.mockInstallTitle': 'Mock update restart',
     'update.mockInstallDetail': 'Mock mode: OpenSquilla would restart now to install {version}. No files were changed.',
+    'uninstall.confirmTitle': 'Delete local OpenSquilla desktop data?',
+    'uninstall.confirmMessage': 'This permanently deletes the local desktop profile on this machine.',
+    'uninstall.confirmDetail': 'Sessions, configuration, and secrets will be removed. The installed app itself will remain; remove it through your OS after the app closes.',
+    'uninstall.cancel': 'Cancel',
+    'uninstall.deleteEverything': 'Delete everything',
+    'launch.alreadyRunningTitle': 'OpenSquilla is already running',
+    'launch.alreadyRunningMessage': 'Another OpenSquilla window is already open on this machine. Bringing it to the front.',
     'window.onboarding': 'Set up OpenSquilla',
     'boot.profile': 'Preparing desktop profile',
     'boot.gateway-start': 'Starting local runtime',
@@ -1324,6 +1534,13 @@ const DESKTOP_MESSAGES: Record<DesktopLocale, Record<string, string>> = {
     'update.gatewayShutdownTimeout': 'OpenSquilla 无法停止本地运行时。请再次尝试重启以更新。',
     'update.mockInstallTitle': '模拟重启更新',
     'update.mockInstallDetail': '模拟模式：OpenSquilla 现在会重启并安装 {version}。没有修改任何文件。',
+    'uninstall.confirmTitle': '删除本地 OpenSquilla 桌面数据？',
+    'uninstall.confirmMessage': '这将永久删除本机上的本地桌面配置。',
+    'uninstall.confirmDetail': '会话、配置和密钥都将被移除。已安装的应用本身会保留；应用关闭后请通过操作系统将其卸载。',
+    'uninstall.cancel': '取消',
+    'uninstall.deleteEverything': '全部删除',
+    'launch.alreadyRunningTitle': 'OpenSquilla 已在运行',
+    'launch.alreadyRunningMessage': '本机已打开另一个 OpenSquilla 窗口。正在将其置于前台。',
     'window.onboarding': '设置 OpenSquilla',
     'boot.profile': '正在准备桌面配置',
     'boot.gateway-start': '正在启动本地运行时',
@@ -1406,6 +1623,13 @@ const DESKTOP_MESSAGES: Record<DesktopLocale, Record<string, string>> = {
     'update.errorTitle': 'アップデートの確認に失敗しました',
     'update.moveToApplications': '自動アップデートを有効にするには、OpenSquilla を「アプリケーション」フォルダに移動してから再試行してください。',
     'update.gatewayShutdownTimeout': 'ローカルランタイムを停止できませんでした。もう一度、再起動してアップデートをお試しください。',
+    'uninstall.confirmTitle': 'ローカルの OpenSquilla デスクトップデータを削除しますか？',
+    'uninstall.confirmMessage': 'このマシン上のローカルデスクトッププロファイルを完全に削除します。',
+    'uninstall.confirmDetail': 'セッション、設定、シークレットが削除されます。インストール済みのアプリ自体は残ります。アプリを閉じた後、OS から削除してください。',
+    'uninstall.cancel': 'キャンセル',
+    'uninstall.deleteEverything': 'すべて削除',
+    'launch.alreadyRunningTitle': 'OpenSquilla はすでに実行中です',
+    'launch.alreadyRunningMessage': 'このマシンでは別の OpenSquilla ウィンドウがすでに開いています。前面に表示します。',
     'window.onboarding': 'OpenSquilla をセットアップ',
     'boot.profile': 'デスクトッププロファイルを準備しています',
     'boot.gateway-start': 'ローカルランタイムを起動しています',
@@ -1448,6 +1672,15 @@ const DESKTOP_MESSAGES: Record<DesktopLocale, Record<string, string>> = {
     'onboarding.step2.directModel': '直接モデル',
     'onboarding.step2.back': '戻る',
     'onboarding.step2.next': '次へ',
+    'onboarding.nav.routing.title': 'ルーティング',
+    'onboarding.nav.routing.sub': 'モード',
+    'onboarding.aria.modelRoutingMode': 'ルーティングモード',
+    'onboarding.step3.badge': '詳細',
+    'onboarding.step3.heading': 'ルーティングモードを選択',
+    'onboarding.step3.subtitle': 'OpenSquilla が Smart Router のティアを使うか、固定モデルを 1 つ呼び出すか、OpenRouter アンサンブルを使うかを選びます。',
+    'onboarding.step3.back': '戻る',
+    'onboarding.step3.next': '次へ',
+    'onboarding.step3.directModel': '直接モデル',
     'onboarding.step4.badge': 'モデル',
     'onboarding.step4.heading': 'ティアのモデルを確認',
     'onboarding.step4.subtitle': 'デフォルトのテキストティアを選んで CLI のデフォルトを維持するか、起動前にモデル id をカスタマイズします。',
@@ -1479,6 +1712,13 @@ const DESKTOP_MESSAGES: Record<DesktopLocale, Record<string, string>> = {
     'update.errorTitle': 'Échec de la recherche de mises à jour',
     'update.moveToApplications': 'Déplacez OpenSquilla dans votre dossier Applications pour activer les mises à jour automatiques, puis réessayez.',
     'update.gatewayShutdownTimeout': 'OpenSquilla n\'a pas pu arrêter le runtime local. Réessayez de relancer la mise à jour.',
+    'uninstall.confirmTitle': 'Supprimer les données locales du bureau OpenSquilla ?',
+    'uninstall.confirmMessage': 'Cela supprime définitivement le profil de bureau local sur cette machine.',
+    'uninstall.confirmDetail': 'Les sessions, la configuration et les secrets seront supprimés. L’application installée elle-même sera conservée ; supprimez-la via votre système d’exploitation après la fermeture de l’application.',
+    'uninstall.cancel': 'Annuler',
+    'uninstall.deleteEverything': 'Tout supprimer',
+    'launch.alreadyRunningTitle': 'OpenSquilla est déjà en cours d’exécution',
+    'launch.alreadyRunningMessage': 'Une autre fenêtre OpenSquilla est déjà ouverte sur cette machine. Elle va être mise au premier plan.',
     'window.onboarding': 'Configurer OpenSquilla',
     'boot.profile': 'Préparation du profil de bureau',
     'boot.gateway-start': 'Démarrage du runtime local',
@@ -1521,6 +1761,15 @@ const DESKTOP_MESSAGES: Record<DesktopLocale, Record<string, string>> = {
     'onboarding.step2.directModel': 'Modèle direct',
     'onboarding.step2.back': 'Retour',
     'onboarding.step2.next': 'Suivant',
+    'onboarding.nav.routing.title': 'Routage',
+    'onboarding.nav.routing.sub': 'Mode',
+    'onboarding.aria.modelRoutingMode': 'Mode de routage',
+    'onboarding.step3.badge': 'Avancé',
+    'onboarding.step3.heading': 'Choisir le mode de routage',
+    'onboarding.step3.subtitle': "Décidez si OpenSquilla doit utiliser les niveaux du Smart Router, appeler un seul modèle fixe, ou utiliser l'ensemble OpenRouter.",
+    'onboarding.step3.back': 'Retour',
+    'onboarding.step3.next': 'Suivant',
+    'onboarding.step3.directModel': 'Modèle direct',
     'onboarding.step4.badge': 'Modèles',
     'onboarding.step4.heading': 'Examiner les modèles par niveau',
     'onboarding.step4.subtitle': 'Choisissez le niveau de texte par défaut et conservez les valeurs par défaut de la CLI, ou personnalisez les id de modèle avant le démarrage.',
@@ -1552,6 +1801,13 @@ const DESKTOP_MESSAGES: Record<DesktopLocale, Record<string, string>> = {
     'update.errorTitle': 'Update-Prüfung fehlgeschlagen',
     'update.moveToApplications': 'Verschieben Sie OpenSquilla in Ihren Programme-Ordner, um automatische Updates zu aktivieren, und versuchen Sie es erneut.',
     'update.gatewayShutdownTimeout': 'OpenSquilla konnte die lokale Laufzeitumgebung nicht stoppen. Versuchen Sie erneut, zum Aktualisieren neu zu starten.',
+    'uninstall.confirmTitle': 'Lokale OpenSquilla-Desktop-Daten löschen?',
+    'uninstall.confirmMessage': 'Dies löscht das lokale Desktop-Profil auf diesem Gerät dauerhaft.',
+    'uninstall.confirmDetail': 'Sitzungen, Konfiguration und Secrets werden entfernt. Die installierte App selbst bleibt erhalten; entfernen Sie sie nach dem Schließen der App über Ihr Betriebssystem.',
+    'uninstall.cancel': 'Abbrechen',
+    'uninstall.deleteEverything': 'Alles löschen',
+    'launch.alreadyRunningTitle': 'OpenSquilla läuft bereits',
+    'launch.alreadyRunningMessage': 'Auf diesem Gerät ist bereits ein anderes OpenSquilla-Fenster geöffnet. Es wird in den Vordergrund geholt.',
     'window.onboarding': 'OpenSquilla einrichten',
     'boot.profile': 'Desktop-Profil wird vorbereitet',
     'boot.gateway-start': 'Lokale Laufzeitumgebung wird gestartet',
@@ -1594,6 +1850,15 @@ const DESKTOP_MESSAGES: Record<DesktopLocale, Record<string, string>> = {
     'onboarding.step2.directModel': 'Direktes Modell',
     'onboarding.step2.back': 'Zurück',
     'onboarding.step2.next': 'Weiter',
+    'onboarding.nav.routing.title': 'Routing',
+    'onboarding.nav.routing.sub': 'Modus',
+    'onboarding.aria.modelRoutingMode': 'Routing-Modus',
+    'onboarding.step3.badge': 'Erweitert',
+    'onboarding.step3.heading': 'Routing-Modus wählen',
+    'onboarding.step3.subtitle': 'Legen Sie fest, ob OpenSquilla die Smart-Router-Stufen verwenden, ein festes Modell aufrufen oder das OpenRouter-Ensemble nutzen soll.',
+    'onboarding.step3.back': 'Zurück',
+    'onboarding.step3.next': 'Weiter',
+    'onboarding.step3.directModel': 'Direktes Modell',
     'onboarding.step4.badge': 'Modelle',
     'onboarding.step4.heading': 'Stufenmodelle prüfen',
     'onboarding.step4.subtitle': 'Wählen Sie die Standard-Textstufe und behalten Sie die CLI-Standards bei, oder passen Sie die Modell-ids vor dem Start an.',
@@ -1625,6 +1890,13 @@ const DESKTOP_MESSAGES: Record<DesktopLocale, Record<string, string>> = {
     'update.errorTitle': 'Error al buscar actualizaciones',
     'update.moveToApplications': 'Mueve OpenSquilla a tu carpeta de Aplicaciones para habilitar las actualizaciones automáticas e inténtalo de nuevo.',
     'update.gatewayShutdownTimeout': 'OpenSquilla no pudo detener el runtime local. Intenta reiniciar para actualizar de nuevo.',
+    'uninstall.confirmTitle': '¿Eliminar los datos locales de escritorio de OpenSquilla?',
+    'uninstall.confirmMessage': 'Esto elimina permanentemente el perfil de escritorio local en esta máquina.',
+    'uninstall.confirmDetail': 'Se eliminarán las sesiones, la configuración y los secretos. La aplicación instalada en sí permanecerá; elimínala a través de tu sistema operativo después de cerrar la aplicación.',
+    'uninstall.cancel': 'Cancelar',
+    'uninstall.deleteEverything': 'Eliminar todo',
+    'launch.alreadyRunningTitle': 'OpenSquilla ya se está ejecutando',
+    'launch.alreadyRunningMessage': 'Ya hay otra ventana de OpenSquilla abierta en esta máquina. Se traerá al frente.',
     'window.onboarding': 'Configurar OpenSquilla',
     'boot.profile': 'Preparando el perfil de escritorio',
     'boot.gateway-start': 'Iniciando el runtime local',
@@ -1667,6 +1939,15 @@ const DESKTOP_MESSAGES: Record<DesktopLocale, Record<string, string>> = {
     'onboarding.step2.directModel': 'Modelo directo',
     'onboarding.step2.back': 'Atrás',
     'onboarding.step2.next': 'Siguiente',
+    'onboarding.nav.routing.title': 'Enrutamiento',
+    'onboarding.nav.routing.sub': 'Modo',
+    'onboarding.aria.modelRoutingMode': 'Modo de enrutamiento',
+    'onboarding.step3.badge': 'Avanzado',
+    'onboarding.step3.heading': 'Elige el modo de enrutamiento',
+    'onboarding.step3.subtitle': 'Decide si OpenSquilla debe usar los niveles del Smart Router, llamar a un único modelo fijo o usar el ensemble de OpenRouter.',
+    'onboarding.step3.back': 'Atrás',
+    'onboarding.step3.next': 'Siguiente',
+    'onboarding.step3.directModel': 'Modelo directo',
     'onboarding.step4.badge': 'Modelos',
     'onboarding.step4.heading': 'Revisa los modelos por nivel',
     'onboarding.step4.subtitle': 'Elige el nivel de texto predeterminado y mantén los valores predeterminados de la CLI, o personaliza los id de modelo antes del inicio.',
@@ -1748,6 +2029,16 @@ const ONBOARDING_SCRIPT_MESSAGES: Record<DesktopLocale, Record<string, string>> 
   },
   ja: {
     tierDefaultsAvailable: 'ティアのデフォルトを利用できます。',
+    modeSmartRouterTitle: 'Smart Router',
+    modeSmartRouterDesc: 'このプロバイダー向けの既存の階層化された Squilla Router のデフォルトを使用します。',
+    modeDirectTitle: '直接単一モデル',
+    modeDirectDesc: 'すべてのリクエストを、ティアルーティングやアンサンブルなしで 1 つのプロバイダーモデルに送信します。',
+    modeEnsembleTitle: 'アンサンブル',
+    modeEnsembleDesc: 'OpenRouter の static B5 アンサンブルを使用し、ティア表をスキップします。',
+    modeSmartRouterUnavailable: 'このプロバイダーにはまだデスクトップ用のティアデフォルトがありません。',
+    modeEnsembleUnavailable: 'アンサンブルの設定には現在 OpenRouter が必要です。',
+    directModelPrompt: 'リクエストはこのモデルを直接使用します。',
+    directModelRequiredDirect: '直接単一モデルモードには直接モデルが必要です。',
     directModelLabel: '直接モデル',
     noModel: 'モデルなし',
     directModelNote: 'Smart Router はオフです。すべてのリクエストでこのモデルを直接使用します。',
@@ -1767,6 +2058,16 @@ const ONBOARDING_SCRIPT_MESSAGES: Record<DesktopLocale, Record<string, string>> 
   },
   fr: {
     tierDefaultsAvailable: 'Valeurs de niveau par défaut disponibles.',
+    modeSmartRouterTitle: 'Smart Router',
+    modeSmartRouterDesc: 'Utiliser les valeurs par défaut existantes du Squilla Router en couches pour ce fournisseur.',
+    modeDirectTitle: 'Modèle unique direct',
+    modeDirectDesc: 'Envoyer chaque requête à un seul modèle du fournisseur, sans routage par niveaux ni ensemble.',
+    modeEnsembleTitle: 'Ensemble',
+    modeEnsembleDesc: "Utiliser l'ensemble statique B5 d'OpenRouter et ignorer le tableau des niveaux.",
+    modeSmartRouterUnavailable: "Ce fournisseur n'a pas encore de niveaux par défaut pour le bureau.",
+    modeEnsembleUnavailable: "La configuration de l'ensemble nécessite actuellement OpenRouter.",
+    directModelPrompt: 'Les requêtes utiliseront directement ce modèle.',
+    directModelRequiredDirect: 'Un modèle direct est requis pour le mode Modèle unique direct.',
     directModelLabel: 'Modèle direct',
     noModel: 'Aucun modèle',
     directModelNote: 'Smart Router est désactivé. Chaque requête utilise directement ce modèle.',
@@ -1786,6 +2087,16 @@ const ONBOARDING_SCRIPT_MESSAGES: Record<DesktopLocale, Record<string, string>> 
   },
   de: {
     tierDefaultsAvailable: 'Stufenstandards verfügbar.',
+    modeSmartRouterTitle: 'Smart Router',
+    modeSmartRouterDesc: 'Die vorhandenen mehrstufigen Squilla-Router-Standards für diesen Anbieter verwenden.',
+    modeDirectTitle: 'Einzelnes Direktmodell',
+    modeDirectDesc: 'Jede Anfrage an ein einzelnes Anbietermodell senden, ohne Stufenrouting oder Ensemble.',
+    modeEnsembleTitle: 'Ensemble',
+    modeEnsembleDesc: 'Das statische B5-Ensemble von OpenRouter verwenden und die Stufentabelle überspringen.',
+    modeSmartRouterUnavailable: 'Dieser Anbieter hat noch keine Desktop-Stufenstandards.',
+    modeEnsembleUnavailable: 'Die Ensemble-Einrichtung erfordert derzeit OpenRouter.',
+    directModelPrompt: 'Anfragen verwenden dieses Modell direkt.',
+    directModelRequiredDirect: 'Für den Modus „Einzelnes Direktmodell“ ist ein direktes Modell erforderlich.',
     directModelLabel: 'Direktes Modell',
     noModel: 'Kein Modell',
     directModelNote: 'Smart Router ist aus. Jede Anfrage verwendet dieses Modell direkt.',
@@ -1805,6 +2116,16 @@ const ONBOARDING_SCRIPT_MESSAGES: Record<DesktopLocale, Record<string, string>> 
   },
   es: {
     tierDefaultsAvailable: 'Valores de nivel predeterminados disponibles.',
+    modeSmartRouterTitle: 'Smart Router',
+    modeSmartRouterDesc: 'Usar los valores predeterminados por niveles existentes del Squilla Router para este proveedor.',
+    modeDirectTitle: 'Modelo único directo',
+    modeDirectDesc: 'Enviar cada solicitud a un único modelo del proveedor, sin enrutamiento por niveles ni ensemble.',
+    modeEnsembleTitle: 'Ensemble',
+    modeEnsembleDesc: 'Usar el ensemble estático B5 de OpenRouter y omitir la tabla de niveles.',
+    modeSmartRouterUnavailable: 'Este proveedor aún no tiene valores de nivel predeterminados para el escritorio.',
+    modeEnsembleUnavailable: 'La configuración del ensemble requiere actualmente OpenRouter.',
+    directModelPrompt: 'Las solicitudes usarán este modelo directamente.',
+    directModelRequiredDirect: 'Se requiere un modelo directo para el modo Modelo único directo.',
     directModelLabel: 'Modelo directo',
     noModel: 'Sin modelo',
     directModelNote: 'Smart Router está desactivado. Cada solicitud usa este modelo directamente.',
@@ -1875,8 +2196,11 @@ function createApplicationMenu(): void {
     {
       label: desktopT('menu.view'),
       submenu: [
-        { role: 'reload' },
-        { role: 'forceReload' },
+        // Disable reload while the onboarding wizard is open: its state lives only
+        // in the renderer of a one-shot data: URL, so a reload would silently wipe
+        // the in-progress setup (typed key, provider, step, tier edits).
+        { role: 'reload', enabled: currentOnboardingWindow() === null },
+        { role: 'forceReload', enabled: currentOnboardingWindow() === null },
         { role: 'toggleDevTools' },
         { type: 'separator' },
         { role: 'resetZoom' },
@@ -2703,6 +3027,7 @@ function onboardingHtml(): string {
     const desktopMessages = ${JSON.stringify(DESKTOP_MESSAGES)};
     const onboardingMessageCatalog = ${JSON.stringify(ONBOARDING_SCRIPT_MESSAGES)};
     const providerNoteCatalog = ${JSON.stringify(PROVIDER_NOTE_MESSAGES)};
+    const searchNoteCatalog = ${JSON.stringify(SEARCH_PROVIDER_NOTE_MESSAGES)};
     let activeLocale = ${JSON.stringify(desktopLocale)};
     let t = messagesFor(activeLocale);
     function messagesFor(locale) {
@@ -2805,7 +3130,11 @@ function onboardingHtml(): string {
         '<span class="provider-tag">' + escapeHtml(t.providerField) + '</span><strong>' + escapeHtml(item.label) + '</strong><small>' + escapeHtml(item.routerSupported ? t.tierDefaultsAvailable : providerNote(item)) + '</small></button>'
       )).join('');
       function selectProvider(nextProvider) {
-	        provider.value = nextProvider || 'openrouter';
+	        const next = nextProvider || 'openrouter';
+	        // Re-clicking the already-active provider must not reset base URL, model,
+	        // routing mode, and customized tiers back to catalog defaults.
+	        if (next === provider.value) return;
+	        provider.value = next;
 	        errorBox.textContent = '';
 	        syncProviderDefaults(true);
 	        renderProviderGrid();
@@ -2928,10 +3257,16 @@ function onboardingHtml(): string {
     function currentSearchProvider() {
       return searchProviders.find((item) => item.providerId === searchProvider.value) || searchProviders[0];
     }
+    function searchProviderNote(item) {
+      return (searchNoteCatalog[activeLocale] && searchNoteCatalog[activeLocale][item.providerId])
+        || (searchNoteCatalog.en && searchNoteCatalog.en[item.providerId])
+        || item.note
+        || (item.requiresApiKey ? t.requiresApiKey : t.noKeyRequired);
+    }
     function renderSearchProviderGrid() {
       searchProviderGrid.innerHTML = searchProviders.map((item) => (
         '<button class="choice' + (item.providerId === searchProvider.value ? ' active' : '') + '" type="button" data-search-provider="' + escapeAttr(item.providerId) + '">' +
-        '<strong>' + escapeHtml(item.label) + '</strong><small>' + escapeHtml(item.note || (item.requiresApiKey ? t.requiresApiKey : t.noKeyRequired)) + '</small></button>'
+        '<strong>' + escapeHtml(item.label) + '</strong><small>' + escapeHtml(searchProviderNote(item)) + '</small></button>'
       )).join('');
       searchProviderGrid.querySelectorAll('[data-search-provider]').forEach((button) => {
         button.addEventListener('click', () => {
@@ -2946,7 +3281,7 @@ function onboardingHtml(): string {
       searchKeyLabel.hidden = !selected.requiresApiKey;
       const input = document.getElementById('searchApiKey');
       if (input) input.placeholder = selected.keyPlaceholder || selected.envKey || 'SEARCH_API_KEY';
-      searchHint.textContent = selected.note || (selected.requiresApiKey ? fmt('searchAvailable', { label: selected.label }) : t.searchHintDefault);
+      searchHint.textContent = searchProviderNote(selected);
     }
     function isSimpleSetup() {
       return setupMode.value === 'simple';
@@ -3049,7 +3384,14 @@ function onboardingHtml(): string {
       const selected = currentProvider();
       const selectedSearch = currentSearchProvider();
       if (step === 1 && selected.requiresApiKey && !document.getElementById('apiKey').value.trim()) return fmt('apiKeyRequired', { label: selected.label });
-      if (step === 2 && modelRoutingMode.value === 'direct' && !model.value.trim()) return t.directModelRequiredDirect;
+      // Direct mode needs a model. In Simple setup the routing screen (step 2) is
+      // not in the route, so the model is entered on the provider screen (step 1);
+      // validate on whichever step is actually reachable, or the check silently
+      // never runs and the save fails late with a raw main-process error.
+      if (modelRoutingMode.value === 'direct' && !model.value.trim()) {
+        if (isSimpleSetup() && step === 1) return t.directModelRequiredDirect;
+        if (!isSimpleSetup() && step === 2) return t.directModelRequiredDirect;
+      }
       if (step === 3 && modelRoutingMode.value === 'squilla_router') {
         const defaultTier = document.getElementById('routerDefaultTier')?.value || 'c1';
         if (!routerTiers[defaultTier] || !routerTiers[defaultTier].model) return t.defaultTierRequiresModel;
@@ -3096,6 +3438,7 @@ function onboardingHtml(): string {
           routerTiers,
           searchProvider: searchProvider.value,
           searchApiKey: document.getElementById('searchApiKey').value,
+          locale: activeLocale,
         });
       } catch (error) {
         errorBox.textContent = error && error.message ? error.message : String(error);
@@ -3112,6 +3455,22 @@ function onboardingHtml(): string {
 
 async function runOnboarding(): Promise<DesktopConnection> {
   const existing = await loadDesktopCredential()
+  // A saved credential encrypted with the OS keychain that this session cannot
+  // read (keychain locked or unavailable) must not be treated as "no credential":
+  // silently re-onboarding would re-save the key as plaintext. Surface an
+  // actionable error so the user can unlock and retry, or Reset setup.
+  if (
+    existing
+    && existing.encryptedApiKey
+    && existing.encryption === 'safeStorage'
+    && desktopSecretStorageBackend() !== 'safeStorage'
+  ) {
+    throw new Error(
+      'Your saved OpenSquilla credential is stored in the OS keychain, which is '
+      + 'currently unavailable (locked or inaccessible). Unlock it and reopen '
+      + 'OpenSquilla, or use "Reset setup" to start over.'
+    )
+  }
   if (existing && isConnectionReady(existing)) {
     // Seed the gateway config from the saved credential only when it does not
     // exist yet. Once it exists the Control UI owns it via RPC, so regenerating
@@ -3149,6 +3508,20 @@ async function runOnboarding(): Promise<DesktopConnection> {
     })
     installEditingContextMenu(onboardingWindow)
 
+    // The wizard is a single data: URL page; block any renderer-initiated
+    // top-frame navigation (e.g. a dropped file/link) so it can't replace the
+    // onboarding UI — which holds the preload IPC bridge — with a foreign document.
+    const guardOnboardingNavigation = (event: Electron.Event, targetUrl: string) => {
+      event.preventDefault()
+      if (/^https?:\/\//i.test(targetUrl) || targetUrl.startsWith('mailto:')) {
+        void shell.openExternal(targetUrl)
+      }
+    }
+    onboardingWindow.webContents.on('will-navigate', guardOnboardingNavigation)
+    onboardingWindow.webContents.on('will-redirect', guardOnboardingNavigation)
+    // Rebuild the app menu so View → Reload is disabled while onboarding is open.
+    createApplicationMenu()
+
     onboardingWindow.once('ready-to-show', () => {
       if (!onboardingWindow || onboardingWindow.isDestroyed()) return
       onboardingWindow.show()
@@ -3156,6 +3529,8 @@ async function runOnboarding(): Promise<DesktopConnection> {
     })
     onboardingWindow.on('closed', () => {
       onboardingWindow = null
+      // Re-enable View → Reload now that the wizard is gone.
+      createApplicationMenu()
       if (rejectOnboarding) {
         const reject = rejectOnboarding
         resolveOnboarding = null
@@ -3373,7 +3748,7 @@ function classifyGatewayExitMessage(message: string, outputTail: string): string
   return (
     message +
     '\n\nOpenSquilla could not read this config because it contains settings written by a newer OpenSquilla version. ' +
-    'Reopen OpenSquilla 0.5.0 Preview 1, or reset the desktop config before running an older version. ' +
+    `Reopen the newer OpenSquilla version that created it, or reset the desktop config before running this version (${app.getVersion()}). ` +
     'Use Reveal log for details.'
   )
 }
@@ -3391,9 +3766,11 @@ async function waitForGateway(url: string, earlyExitMessage?: () => string | nul
   throw new Error(`Gateway did not become healthy at ${url}`)
 }
 
-async function waitForControlUi(url: string): Promise<void> {
+async function waitForControlUi(url: string, earlyExitMessage?: () => string | null): Promise<void> {
   const startedAt = Date.now()
   while (Date.now() - startedAt < 45_000) {
+    const earlyExit = earlyExitMessage?.()
+    if (earlyExit) throw new Error(earlyExit)
     try {
       const response = await fetch(`${url}/control/`, { signal: AbortSignal.timeout(1500) })
       if (response.ok) return
@@ -3402,6 +3779,8 @@ async function waitForControlUi(url: string): Promise<void> {
     }
     await new Promise((resolveWait) => setTimeout(resolveWait, 500))
   }
+  const earlyExit = earlyExitMessage?.()
+  if (earlyExit) throw new Error(earlyExit)
   throw new Error(`Control UI did not become reachable at ${url}/control/`)
 }
 
@@ -3437,7 +3816,14 @@ async function startGateway(): Promise<GatewayState> {
     if (hasGatewayProcessExited(gatewayProcess)) {
       gatewayProcess = null
     } else {
+      // Wait for the old child to actually exit before spawning a replacement.
+      // stopGateway() only initiates termination; the gateway drains for several
+      // seconds and holds gateway.pid.lock until it exits, so respawning
+      // immediately makes the new gateway abort on the held lock and the restart
+      // fails with an unclassified error.
+      const previousChild = gatewayProcess
       stopGateway()
+      await waitForGatewayProcessExit(previousChild)
     }
     gatewayState.status = 'stopped'
     gatewayState.error = undefined
@@ -3460,7 +3846,12 @@ async function startGateway(): Promise<GatewayState> {
   const connection = await runOnboarding()
   forceOnboardingOnNextStartup = false
   const apiKey = decryptApiKey(connection)
-  if (!apiKey) throw new Error('Saved desktop API key could not be read.')
+  // Keyless providers (e.g. Ollama) ship requiresApiKey=false and are accepted
+  // by onboarding without a key, so only treat a missing key as fatal when the
+  // provider actually needs one — otherwise every keyless credential wedges boot.
+  if (providerDefaults(connection.provider).requiresApiKey && !apiKey) {
+    throw new Error('Saved desktop API key could not be read.')
+  }
   const searchApiKey = decryptSearchApiKey(connection)
   // Config is seeded (when missing) inside runOnboarding / the onboarding save,
   // and is otherwise the RPC-owned source of truth — so it is intentionally NOT
@@ -3475,6 +3866,19 @@ async function startGateway(): Promise<GatewayState> {
   mkdirSync(logDir, { recursive: true })
   const logPath = join(logDir, 'gateway.log')
   const logStream = createWriteStream(logPath, { flags: 'a' })
+  // Node can emit both 'error' and 'exit' for one child, and each handler closes
+  // the stream — so guard writes/close to be idempotent, and swallow any late
+  // write-after-end/EPIPE rather than letting it crash the main process.
+  let logStreamClosed = false
+  logStream.on('error', () => {})
+  const writeLogLine = (text: string) => {
+    if (!logStreamClosed) logStream.write(text)
+  }
+  const closeLogStream = () => {
+    if (logStreamClosed) return
+    logStreamClosed = true
+    logStream.end()
+  }
 
   gatewayState.url = url
   gatewayState.port = port
@@ -3488,7 +3892,7 @@ async function startGateway(): Promise<GatewayState> {
     ...process.env,
     PATH: childPath,
     ...(process.platform === 'win32' ? { Path: childPath } : {}),
-    [connection.apiKeyEnv]: apiKey,
+    ...(connection.apiKeyEnv && apiKey ? { [connection.apiKeyEnv]: apiKey } : {}),
     ...(connection.searchApiKeyEnv && searchApiKey ? { [connection.searchApiKeyEnv]: searchApiKey } : {}),
     OPENSQUILLA_DESKTOP: '1',
     OPENSQUILLA_INSTALL_METHOD: 'desktop',
@@ -3508,6 +3912,9 @@ async function startGateway(): Promise<GatewayState> {
       cwd: runtime.cwd,
       env: childEnv,
       detached: runtime.mode === 'dev' && process.platform !== 'win32',
+      // The bundled gateway is a console-subsystem binary; without this Windows
+      // allocates a stray console window whose closure would kill the gateway.
+      windowsHide: true,
     }
   )
   gatewayProcess = child
@@ -3529,7 +3936,10 @@ async function startGateway(): Promise<GatewayState> {
     const classifiedMessage = classifyGatewayExitMessage(exitMessage, gatewayOutputTail)
     const isCurrentGateway = gatewayProcess === child
     if (isCurrentGateway) gatewayProcess = null
-    logStream.write(`\n[desktop] ${message}\n`)
+    writeLogLine(`\n[desktop] ${message}\n`)
+    // Release the append fd; without this every (re)start leaks one open handle
+    // to gateway.log for the lifetime of the main process.
+    closeLogStream()
     if (!isCurrentGateway) return
     if (isQuitting) {
       gatewayState.status = 'stopped'
@@ -3544,17 +3954,55 @@ async function startGateway(): Promise<GatewayState> {
       return
     }
     sendBootError(gatewayState.error)
+    // After boot the window is on the gateway-served Control UI, which never
+    // listens for boot:error. Restore the boot splash so the crash message and
+    // the Retry/Reset recovery affordances are visible instead of a dead origin.
+    void restoreMainWindowToBootPage()
+  })
+
+  // A failed spawn (uv missing in dev, non-executable bundled binary) emits
+  // 'error' and never 'exit'; without a listener Node rethrows it as an uncaught
+  // main-process exception (raw Electron crash dialog) and the boot wait hangs.
+  child.once('error', (err) => {
+    const message = `gateway failed to start: ${err instanceof Error ? err.message : String(err)}`
+    const isCurrentGateway = gatewayProcess === child
+    if (isCurrentGateway) gatewayProcess = null
+    closeLogStream()
+    if (!isCurrentGateway) return
+    childExitMessage = message
+    if (isQuitting) {
+      gatewayState.status = 'stopped'
+      return
+    }
+    gatewayState.status = 'error'
+    gatewayState.error = message
+    sendBootError(message)
   })
 
   sendBootStatus('gateway-health')
   await waitForGateway(url, () => childExitMessage)
-  await waitForControlUi(url)
+  await waitForControlUi(url, () => childExitMessage)
+  // Guard against adopting a foreign gateway that won the probe→bind race: if our
+  // spawned child has already exited, it lost the exclusive bind and the healthy
+  // endpoint belongs to someone else (e.g. a CLI `opensquilla gateway run` on the
+  // same port). Surface it as a port conflict so recovery advances to the next
+  // port instead of silently attaching the window to the wrong profile.
+  if (hasGatewayProcessExited(child) || gatewayProcess !== child) {
+    throw new Error(childExitMessage
+      || 'OPENSQUILLA_GATEWAY_PORT_IN_USE: desktop gateway did not keep the port bind.')
+  }
   sendBootStatus('control')
   gatewayState.status = 'ready'
   return gatewayState
 }
 
 async function startGatewayWithPortRecovery(): Promise<GatewayState> {
+  // Begin each fresh recovery sequence at the first port so a previously-used
+  // port that is now free is reused. The cursor still advances within this loop
+  // to skip a port whose bind lost a post-probe race, but it must not persist
+  // across separate starts — otherwise every in-session restart hops to a new
+  // 127.0.0.1:<port> origin and silently drops the Control UI's per-origin state.
+  if (!hasExplicitGatewayPort()) gatewayPortCursor = GATEWAY_PORT_FIRST
   const maxAttempts = hasExplicitGatewayPort() ? 1 : GATEWAY_PORT_LAST - GATEWAY_PORT_FIRST + 1
   let lastError: unknown = null
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
@@ -3583,6 +4031,25 @@ async function loadControlUi(window: BrowserWindow, gatewayUrl: string): Promise
     }
   }
   throw lastError ?? new Error(`Failed to load ${url}`)
+}
+
+// The main window is only ever meant to sit on the gateway-served Control UI
+// origin (its /control paths). Anything else — a dropped file:// document, an
+// off-origin redirect — is a foreign navigation and must be blocked. The boot
+// splash is loaded programmatically (loadFile), which does not go through the
+// navigation guard, so it needs no allow-entry here.
+function isAllowedMainWindowNavigation(targetUrl: string): boolean {
+  if (!gatewayState.url) return false
+  try {
+    const target = new URL(targetUrl)
+    const gateway = new URL(gatewayState.url)
+    return (
+      target.origin === gateway.origin
+      && (target.pathname === '/control' || target.pathname.startsWith('/control/'))
+    )
+  } catch {
+    return false
+  }
 }
 
 function isCurrentWindowAtControlUi(window: BrowserWindow, gatewayUrl: string): boolean {
@@ -3637,6 +4104,22 @@ async function createMainWindow(): Promise<BrowserWindow> {
     return { action: 'deny' }
   })
 
+  // Top-frame navigation guard. Programmatic loadFile/loadURL from the main
+  // process do NOT emit these, so this only blocks renderer-initiated top-frame
+  // navigations: a dropped file/link (Chromium's default drop action) or an
+  // in-content redirect that would replace the Control UI with a foreign document
+  // while keeping the full opensquillaDesktop IPC bridge. SPA route changes use
+  // history.pushState and are unaffected.
+  const guardMainWindowNavigation = (event: Electron.Event, targetUrl: string) => {
+    if (isAllowedMainWindowNavigation(targetUrl)) return
+    event.preventDefault()
+    if (/^https?:\/\//i.test(targetUrl) || targetUrl.startsWith('mailto:')) {
+      void shell.openExternal(targetUrl)
+    }
+  }
+  window.webContents.on('will-navigate', guardMainWindowNavigation)
+  window.webContents.on('will-redirect', guardMainWindowNavigation)
+
   window.once('ready-to-show', () => {
     if (!window.isDestroyed()) window.show()
   })
@@ -3682,7 +4165,25 @@ async function loadControlUiIntoCurrentWindow(gatewayUrl: string): Promise<void>
   sendBootStatus('ready')
 }
 
+// Bring the main window back to the boot splash when a gateway failure happens
+// while the window is showing the gateway-served Control UI. The splash owns the
+// boot:error listener plus the Retry/Reset recovery buttons, so this is what
+// turns an otherwise-dead Control UI origin back into a recoverable state.
+async function restoreMainWindowToBootPage(): Promise<void> {
+  const window = currentMainWindow()
+  if (!window) return
+  // Already on the boot splash (initial boot); its own onBootError handler will
+  // render the error. Only navigate back when the window left for the Control UI.
+  if (window.webContents.getURL().startsWith('file:')) return
+  try {
+    await window.loadFile(bootPagePath())
+  } catch {
+    // Best-effort: the diagnostic log and gatewayState still record the failure.
+  }
+}
+
 async function openOrResumeDesktopApp(): Promise<void> {
+  if (isQuitting) return
   await createMainWindow()
   focusMainWindow()
 
@@ -3790,7 +4291,7 @@ function stopGateway(): void {
   // and orphan the child — leaving it holding the listen port + PID lock and
   // breaking the next launch. So only take the graceful path when NOT quitting;
   // on quit, fall through to a synchronous TerminateProcess.
-  if (process.platform === 'win32' && !isQuitting) {
+  if (process.platform === 'win32' && (!isQuitting || allowGracefulShutdownWhileQuitting)) {
     // Windows has no real SIGTERM — child.kill('SIGTERM') maps to an immediate
     // TerminateProcess that skips the drain. Trigger the HTTP graceful path,
     // wait for the child to exit on its own, and only force-terminate if it
@@ -3882,12 +4383,24 @@ const NETWORK_OBSERVABILITY_DISABLE_ENV_KEYS = [
   'OPENSQUILLA_UPDATE_CHECK_DISABLED',
 ] as const
 
+// mtime-keyed caches so the update-state publish path (which runs on every
+// download-progress tick) does not re-read + JSON.parse the credential and
+// re-scan config.toml on every call. Invalidated automatically when the file
+// changes — atomicWriteFile's rename bumps mtime, and deletion falls through the
+// existsSync guard.
+let persistedNetObsCache: { mtime: number; value: boolean } | null = null
+let configNetObsCache: { mtime: number; value: boolean | null } | null = null
+
 function desktopPersistedNetworkObservabilityDisabled(): boolean {
   try {
     const path = credentialPath()
     if (!existsSync(path)) return false
+    const mtime = statSync(path).mtimeMs
+    if (persistedNetObsCache && persistedNetObsCache.mtime === mtime) return persistedNetObsCache.value
     const raw = readFileSync(path, 'utf8')
-    return normalizeDesktopCredential(JSON.parse(raw) as Partial<DesktopConnection>).disableNetworkObservability
+    const value = normalizeDesktopCredential(JSON.parse(raw) as Partial<DesktopConnection>).disableNetworkObservability
+    persistedNetObsCache = { mtime, value }
+    return value
   } catch {
     return true
   }
@@ -3918,8 +4431,12 @@ function readDesktopConfigNetworkObservabilitySetting(): boolean | null {
   try {
     const path = desktopConfigPath()
     if (!existsSync(path)) return null
+    const mtime = statSync(path).mtimeMs
+    if (configNetObsCache && configNetObsCache.mtime === mtime) return configNetObsCache.value
     const raw = readFileSync(path, 'utf8')
-    return parseDesktopNetworkObservabilityPrivacyConfig(raw)
+    const value = parseDesktopNetworkObservabilityPrivacyConfig(raw)
+    configNetObsCache = { mtime, value }
+    return value
   } catch {
     return true
   }
@@ -4111,6 +4628,12 @@ function showUpdateError(err: unknown): void {
   manualUpdateCheck = false
   updateDownloadInProgress = false
   if (!shouldNotify) {
+    // electron-updater delivers each failure twice (it emits 'error' AND rejects
+    // the promise our try/catch awaits). The first delivery publishes the visible
+    // error and clears the notify flags; without this guard the second, now-silent
+    // delivery would clobber that error back to idle and wipe the known
+    // latestVersion. Leave an already-published error in place.
+    if (desktopUpdateStatus === 'error') return
     setDesktopUpdateState({
       status: downloadedUpdateVersion ? 'downloaded' : 'idle',
       latestVersion: downloadedUpdateVersion,
@@ -4286,6 +4809,52 @@ function initAutoUpdater(): void {
   })
 }
 
+// ── macOS prerelease update discovery ───────────────────────────────────────
+// The tag-parsing + candidate-selection logic lives in ./update-feed-resolver so
+// it can be unit-tested without Electron; the pieces below are the Electron-bound
+// glue (current version, GitHub fetch, feed wiring).
+
+// The running app version if it is a prerelease we can resolve upgrades for.
+function currentPrereleaseReleaseTarget(): { base: string; rc: number } | null {
+  const parsed = parseOpenSquillaReleaseTag(app.getVersion())
+  return parsed && parsed.rc !== null ? { base: parsed.base, rc: parsed.rc } : null
+}
+
+async function fetchGithubReleaseSummaries(): Promise<ReleaseSummary[]> {
+  const url = `https://api.github.com/repos/${GITHUB_UPDATE_OWNER}/${GITHUB_UPDATE_REPO}/releases?per_page=50`
+  const response = await fetch(url, {
+    headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'OpenSquilla-Desktop' },
+    signal: AbortSignal.timeout(8000),
+  })
+  if (!response.ok) throw new Error(`GitHub releases request failed: ${response.status}`)
+  const data = await response.json()
+  return Array.isArray(data) ? (data as ReleaseSummary[]) : []
+}
+
+// Returns 'default' to leave the built-in GitHub provider in place (stable
+// builds, non-macOS, dev), 'configured' after pointing a generic feed at the
+// resolved candidate, or 'up-to-date' when no newer same-base release exists.
+async function configureDesktopUpdateFeed(): Promise<'default' | 'configured' | 'up-to-date'> {
+  // Default (stable builds, GitHub provider path): never silently downgrade.
+  autoUpdater.allowDowngrade = false
+  if (process.platform !== 'darwin' || !app.isPackaged) return 'default'
+  const current = currentPrereleaseReleaseTarget()
+  if (!current) return 'default'
+  const candidate = selectMacPrereleaseCandidate(current, await fetchGithubReleaseSummaries())
+  if (!candidate) return 'up-to-date'
+  // Generic provider + channel 'latest' fetches latest-mac.yml from this exact
+  // release; the yml's version is then gated by electron-updater's isUpdateAvailable.
+  autoUpdater.setFeedURL({ provider: 'generic', url: candidate.feedUrl, channel: 'latest' })
+  // The resolver already decided this candidate is the correct forward move by
+  // NUMERIC rc order. electron-updater's gate uses semver.gt, which sorts rc
+  // identifiers as strings — so 0.5.0-rc10 ranks BELOW 0.5.0-rc9/rc2 and the
+  // update would be wrongly rejected. Allow the "downgrade": we only ever point
+  // the feed at a genuinely newer release, never an older one.
+  autoUpdater.allowDowngrade = true
+  desktopLog('update_feed_resolved', { tag: candidate.tag, version: candidate.version })
+  return 'configured'
+}
+
 async function checkForUpdates(manual: boolean): Promise<void> {
   if (updateDownloadInProgress || updateApplying) return
 
@@ -4335,6 +4904,21 @@ async function checkForUpdates(manual: boolean): Promise<void> {
     error: null,
   })
   try {
+    const feed = await configureDesktopUpdateFeed()
+    if (feed === 'up-to-date') {
+      // A packaged macOS prerelease with no newer same-base release. Report
+      // up-to-date directly — the default GitHub provider would find nothing
+      // (the rc tags are PEP440, not npm semver) and raise a spurious error.
+      manualUpdateCheck = false
+      setDesktopUpdateState({
+        status: 'not-available',
+        latestVersion: app.getVersion(),
+        progress: null,
+        checkedAt: new Date().toISOString(),
+        error: null,
+      })
+      return
+    }
     await autoUpdater.checkForUpdates()
   } catch (err) {
     console.error('[updater] checkForUpdates failed', err)
@@ -4434,7 +5018,14 @@ async function applyDownloadedUpdate(): Promise<void> {
   if (child) {
     if (gatewayProcess === child && gatewayState.owned) {
       updateGatewayShutdownProcess = child
-      stopGateway()
+      // We stay alive and await the exit below, so let the gateway take its
+      // Windows HTTP graceful drain instead of an immediate TerminateProcess.
+      allowGracefulShutdownWhileQuitting = true
+      try {
+        stopGateway()
+      } finally {
+        allowGracefulShutdownWhileQuitting = false
+      }
     }
     const exited = await waitForGatewayProcessExit(child)
     if (!exited) {
@@ -4463,6 +5054,11 @@ async function applyDownloadedUpdate(): Promise<void> {
       message: desktopT('update.errorTitle'),
       detail: String(err instanceof Error ? err.message : err ?? ''),
     })
+    // The owned gateway was stopped for the (now-failed) handoff and its exit was
+    // swallowed as intentional (isQuitting was true). restoreDownloadedUpdateRetryState
+    // cleared isQuitting, so bring the runtime back up instead of leaving the
+    // window stranded on the dead gateway's Control UI.
+    void openOrResumeDesktopApp()
   }
 }
 
@@ -4486,9 +5082,20 @@ ipcMain.handle('desktop:update:dismiss', async () => dismissDesktopUpdate())
 ipcMain.handle('desktop:os-locale', () => desktopLocale)
 ipcMain.handle('gateway:status', () => ({ ...gatewayState }))
 ipcMain.handle('gateway:reveal-log', async () => {
-  if (!gatewayState.logPath) return false
-  await shell.showItemInFolder(gatewayState.logPath)
-  return true
+  if (gatewayState.logPath) {
+    await shell.showItemInFolder(gatewayState.logPath)
+    return true
+  }
+  // Startup can fail before the gateway log path is assigned (e.g. onboarding or
+  // port selection error), so Reveal log would otherwise be a dead button on the
+  // error panel. Fall back to the always-present desktop lifecycle log.
+  const desktopLogPath = join(app.getPath('userData'), 'logs', 'desktop.log')
+  if (existsSync(desktopLogPath)) {
+    await shell.showItemInFolder(desktopLogPath)
+    return true
+  }
+  await shell.openPath(join(app.getPath('userData'), 'logs')).catch(() => null)
+  return false
 })
 ipcMain.handle('desktop:settings:get', async () => loadDesktopSettings())
 ipcMain.handle('desktop:settings:save', async (_event, payload: DesktopSettingsPayload) => saveDesktopSettings(payload))
@@ -4501,6 +5108,14 @@ ipcMain.handle('desktop:settings:reset', async () => {
     await waitForGatewayProcessExit(child)
   }
   clearReusableGatewayState()
+  // This IPC is also reachable from the live Control UI (Settings → Runtime),
+  // which stays on the now-dead gateway after the reset. Return the window to the
+  // boot splash and re-run startup so onboarding re-runs, instead of stranding
+  // the user on a dead page. (The boot.html caller also calls retryStartup; the
+  // in-flight start is joined, not double-started.)
+  bootError = null
+  await currentMainWindow()?.loadFile(bootPagePath()).catch(() => null)
+  void openOrResumeDesktopApp()
   return { ok: true }
 })
 ipcMain.handle('desktop:artifact:open', async (_event, payload: ArtifactOpenRequest) => openArtifactWithDefaultApp(payload))
@@ -4523,6 +5138,7 @@ async function runUninstallCli(
   const prefix = runtime.args.slice(0, -2) // drop the trailing ['gateway','run']
   const child = spawn(runtime.command, [...prefix, 'uninstall', ...extraArgs], {
     cwd: runtime.cwd,
+    windowsHide: true,
     env: {
       ...process.env,
       OPENSQUILLA_DESKTOP: '1',
@@ -4566,12 +5182,12 @@ ipcMain.handle('desktop:uninstall:run', async (_event, payload?: { purgeData?: b
   if (purgeData) {
     const { response } = await dialog.showMessageBox({
       type: 'warning',
-      buttons: ['Cancel', 'Delete everything'],
+      buttons: [desktopT('uninstall.cancel'), desktopT('uninstall.deleteEverything')],
       defaultId: 0,
       cancelId: 0,
-      title: 'Delete local OpenSquilla desktop data?',
-      message: 'This permanently deletes the local desktop profile on this machine.',
-      detail: 'Sessions, configuration, and secrets will be removed. The installed app itself will remain; remove it through your OS after the app closes.',
+      title: desktopT('uninstall.confirmTitle'),
+      message: desktopT('uninstall.confirmMessage'),
+      detail: desktopT('uninstall.confirmDetail'),
     })
     if (response !== 1) return { ok: false, aborted: true, detail: 'cancelled' }
   }
@@ -4582,7 +5198,14 @@ ipcMain.handle('desktop:uninstall:run', async (_event, payload?: { purgeData?: b
   isQuitting = true
   if (gatewayProcess && gatewayState.owned) {
     const child = gatewayProcess
-    stopGateway()
+    // We stay alive and await the exit, so let the gateway take its Windows HTTP
+    // graceful drain instead of an immediate TerminateProcess.
+    allowGracefulShutdownWhileQuitting = true
+    try {
+      stopGateway()
+    } finally {
+      allowGracefulShutdownWhileQuitting = false
+    }
     await new Promise<void>((res) => {
       if (child.exitCode !== null || child.signalCode !== null) return res()
       child.once('exit', () => res())
@@ -4619,6 +5242,10 @@ ipcMain.handle('desktop:uninstall:run', async (_event, payload?: { purgeData?: b
     await rm(credentialPath(), { force: true }).catch(() => null)
     await rm(join(app.getPath('userData'), 'logs'), { recursive: true, force: true }).catch(() => null)
   }
+  // The app keeps running after a successful data cleanup (the user closes it
+  // later), so clear the quit latch — otherwise it stays true and silently
+  // suppresses reporting of any later gateway crash.
+  isQuitting = false
   return result
 })
 ipcMain.handle('desktop:boot:state', () => ({
@@ -4627,18 +5254,28 @@ ipcMain.handle('desktop:boot:state', () => ({
   gateway: { ...gatewayState },
 }))
 ipcMain.handle('desktop:boot:retry', async () => {
-  const ready = gatewayState.status === 'ready' && gatewayState.url
-    ? await healthCheck(gatewayState.url)
-    : false
+  // Backs both the boot-error "Retry" button and the Control UI "Restart
+  // runtime" action. If a start attempt is already in flight, join it and clear
+  // the stale bootError so the reloaded splash shows live progress instead of
+  // instantly re-rendering the previous error panel.
+  if (gatewayStartPromise) {
+    bootError = null
+    void openOrResumeDesktopApp()
+    return { ok: true }
+  }
 
-  if (!gatewayStartPromise && !ready && gatewayProcess && gatewayState.owned) {
+  // Otherwise force a real runtime restart. "Restart runtime" must relaunch the
+  // child even when the current gateway is healthy, so always tear an owned
+  // gateway down and wait for it to release its port + PID lock before
+  // openOrResumeDesktopApp respawns it — never reuse the existing one here.
+  if (gatewayProcess && gatewayState.owned) {
+    const previousChild = gatewayProcess
     stopGateway()
+    await waitForGatewayProcessExit(previousChild)
   }
-  if (!ready) {
-    gatewayState.status = 'stopped'
-    gatewayState.error = undefined
-    await currentMainWindow()?.loadFile(bootPagePath()).catch(() => null)
-  }
+  clearReusableGatewayState()
+  bootError = null
+  await currentMainWindow()?.loadFile(bootPagePath()).catch(() => null)
 
   void openOrResumeDesktopApp()
   return { ok: true }
@@ -4659,7 +5296,13 @@ ipcMain.handle('desktop:onboarding:defaults', () => ({
   },
 }))
 ipcMain.handle('desktop:onboarding:save', async (_event, payload: OnboardingPayload) => {
+  // Only honor this while an onboarding flow is actually awaiting a result. The
+  // same preload bridge is attached to the Control UI window, so without this
+  // guard any script on the gateway-served page could rewrite the credential and
+  // regenerate config.toml outside onboarding.
+  if (!resolveOnboarding) return { ok: false, error: 'No onboarding in progress.' }
   const credential = await saveDesktopCredential(payload)
+  applyDesktopLocaleChoice(payload.locale)
   const resolve = resolveOnboarding
   resolveOnboarding = null
   rejectOnboarding = null
@@ -4673,6 +5316,9 @@ ipcMain.handle('desktop:onboarding:cancel', () => {
   rejectOnboarding = null
   onboardingWindow?.close()
   reject?.(new Error('OpenSquilla setup was cancelled.'))
+  // The onboarding "Quit" button routes here; it is a deliberate exit, so quit
+  // the app instead of surfacing the cancellation as a boot failure panel.
+  app.quit()
   return { ok: true }
 })
 
@@ -4756,6 +5402,11 @@ configureChromiumKeychainPolicy()
 // unavailable — surface an explicit error instead of exiting silently.
 function acquireSingleInstanceLockWithRetry(): boolean {
   const deadline = Date.now() + 5_000
+  // Atomics.wait blocks this thread without an event loop (app.whenReady has not
+  // fired) and, unlike a Date.now() spin, does not peg a CPU core. Larger sleep
+  // slices also cut the retry count — each failed requestSingleInstanceLock
+  // notifies the running instance (firing its second-instance handler).
+  const sleepSignal = new Int32Array(new SharedArrayBuffer(4))
   let attempt = 0
   for (;;) {
     attempt += 1
@@ -4763,16 +5414,12 @@ function acquireSingleInstanceLockWithRetry(): boolean {
       desktopLog('single_instance_lock_acquired', { attempt })
       return true
     }
-    if (Date.now() >= deadline) {
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) {
       desktopLog('single_instance_lock_unavailable', { attempt })
       return false
     }
-    // Synchronous busy-wait bounded by the deadline: app.whenReady has not
-    // fired yet, so there is no event loop to await on and the window is short.
-    const spinUntil = Math.min(deadline, Date.now() + 150)
-    while (Date.now() < spinUntil) {
-      /* brief spin before the next lock attempt */
-    }
+    Atomics.wait(sleepSignal, 0, 0, Math.min(400, remaining))
   }
 }
 
@@ -4786,9 +5433,12 @@ if (!gotSingleInstanceLock) {
   // silent no-op, then quit.
   desktopLog('launch_aborted_lock_held')
   try {
+    // This runs before app.whenReady, so app.getLocale() is unreliable; fall back
+    // to the persisted onboarding locale (a plain file read) for this dialog.
+    desktopLocale = loadPersistedDesktopLocale() ?? desktopLocale
     dialog.showErrorBox(
-      'OpenSquilla is already running',
-      'Another OpenSquilla window is already open on this machine. Bringing it to the front.',
+      desktopT('launch.alreadyRunningTitle'),
+      desktopT('launch.alreadyRunningMessage'),
     )
   } catch {
     // Dialog is best-effort; the diagnostic log is the durable record.
@@ -4802,7 +5452,7 @@ if (!gotSingleInstanceLock) {
 
   void app.whenReady().then(async () => {
     app.name = 'OpenSquilla'
-    desktopLocale = resolveDesktopLocale()
+    desktopLocale = loadPersistedDesktopLocale() ?? resolveDesktopLocale()
     createApplicationMenu()
     void openOrResumeDesktopApp()
     initAutoUpdater()

--- a/desktop/electron/src/update-feed-resolver.ts
+++ b/desktop/electron/src/update-feed-resolver.ts
@@ -1,0 +1,75 @@
+// Pure release-tag resolution for the macOS desktop updater, split out of
+// main.ts so it can be unit-tested without pulling in Electron.
+//
+// OpenSquilla ships two spellings of the same release: PEP440 for the Git tag /
+// Python wheel (e.g. v0.5.0rc2) and npm semver for the Electron app metadata
+// (0.5.0-rc2). electron-updater's GitHub provider filters release tags with
+// semver.valid(), which rejects PEP440 rc tags, so a packaged prerelease build
+// finds no updates. Even semver-spelled rc tags land on distinct electron-updater
+// channels (rc1 vs rc2), so rc1 would never see rc2. This module resolves the
+// correct candidate release ourselves; a generic feed is then pointed at it.
+
+export const GITHUB_UPDATE_OWNER = 'opensquilla'
+export const GITHUB_UPDATE_REPO = 'opensquilla'
+export const MAC_UPDATE_FEED_ASSET = 'latest-mac.yml'
+
+export interface ParsedReleaseTag {
+  base: string
+  rc: number | null
+}
+
+export interface ReleaseSummary {
+  tag_name?: string
+  draft?: boolean
+  assets?: { name?: string }[]
+}
+
+export interface MacPrereleaseCandidate {
+  tag: string
+  version: string
+  feedUrl: string
+}
+
+// Accept the PEP440 rc tag (v0.5.0rc2), the semver rc spelling (v0.5.0-rc2 /
+// v0.5.0-rc.2), and a plain stable tag (v0.5.0). Returns null for anything else
+// (doc/website releases, monorepo tags, malformed tags).
+export function parseOpenSquillaReleaseTag(tag: string): ParsedReleaseTag | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-?rc\.?(\d+))?$/i.exec(String(tag ?? '').trim())
+  if (!match) return null
+  const [, major, minor, patch, rc] = match
+  return {
+    base: `${Number(major)}.${Number(minor)}.${Number(patch)}`,
+    rc: rc === undefined ? null : Number(rc),
+  }
+}
+
+// Given the running prerelease (base + rc) and the repo's releases, pick the
+// highest same-base release that is newer than the current rc — a later rc or the
+// final stable for this base — and that actually ships the macOS update feed. The
+// final stable outranks any rc of the same base; among rcs, the higher wins.
+// Returns null when nothing newer for this base is publishable (e.g. only the
+// current rc exists, or the newer release is missing latest-mac.yml).
+export function selectMacPrereleaseCandidate(
+  current: { base: string; rc: number },
+  releases: ReleaseSummary[],
+): MacPrereleaseCandidate | null {
+  let best: { parsed: ParsedReleaseTag; tag: string; rank: number } | null = null
+  for (const release of releases) {
+    if (release?.draft) continue
+    const tag = String(release?.tag_name ?? '')
+    const parsed = parseOpenSquillaReleaseTag(tag)
+    if (!parsed || parsed.base !== current.base) continue
+    const isStable = parsed.rc === null
+    const isHigherRc = parsed.rc !== null && parsed.rc > current.rc
+    if (!isStable && !isHigherRc) continue
+    if (!(release.assets || []).some((asset) => asset?.name === MAC_UPDATE_FEED_ASSET)) continue
+    const rank = isStable ? Number.MAX_SAFE_INTEGER : (parsed.rc as number)
+    if (!best || rank > best.rank) best = { parsed, tag, rank }
+  }
+  if (!best) return null
+  return {
+    tag: best.tag,
+    version: best.parsed.rc === null ? best.parsed.base : `${best.parsed.base}-rc${best.parsed.rc}`,
+    feedUrl: `https://github.com/${GITHUB_UPDATE_OWNER}/${GITHUB_UPDATE_REPO}/releases/download/${best.tag}`,
+  }
+}

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -113,6 +113,7 @@ def _expected_classifier_outputs(**overrides: str) -> dict[str, str]:
         "windows_full_required": "false",
         "frontend_changed": "false",
         "tui_changed": "false",
+        "desktop_changed": "false",
         "python_changed": "false",
         "platform_sensitive_changed": "false",
         "build_wheel_required": "false",
@@ -203,6 +204,7 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert "windows_full_required" in text
     assert "frontend_changed" in text
     assert "tui_changed" in text
+    assert "desktop_changed" in text
     assert "python_changed" in text
     assert "platform_sensitive_changed" in text
     assert "build_wheel_required" in text
@@ -544,6 +546,21 @@ def test_ci_change_classifier_tracks_platform_sensitive_changes(tmp_path: Path) 
     )
 
 
+def test_ci_change_classifier_tracks_desktop_changes(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        ["desktop/electron/src/main.ts"],
+    )
+
+    # A desktop change gates the desktop-check Node tests and, as a platform-
+    # sensitive surface, the Windows full suite — but not the Python quality gate.
+    assert outputs == _expected_classifier_outputs(
+        desktop_changed="true",
+        platform_sensitive_changed="true",
+        windows_full_required="true",
+    )
+
+
 def test_ci_change_classifier_run_all_requires_full_ci(tmp_path: Path) -> None:
     outputs = _classify_changed_files(tmp_path, [".ci/run-all"])
 
@@ -556,6 +573,7 @@ def test_ci_change_classifier_run_all_requires_full_ci(tmp_path: Path) -> None:
         windows_full_required="true",
         frontend_changed="true",
         tui_changed="true",
+        desktop_changed="true",
         python_changed="true",
         platform_sensitive_changed="true",
         build_wheel_required="true",
@@ -571,11 +589,13 @@ def test_default_ci_uses_layered_job_conditions() -> None:
     assert "frontend_changed == 'true'" in jobs["frontend-check"]["if"]
     assert "full_required == 'true'" in jobs["frontend-check"]["if"]
     assert "tui_changed == 'true'" in jobs["tui-check"]["if"]
+    assert "desktop_changed == 'true'" in jobs["desktop-check"]["if"]
     assert "python_changed == 'true'" in jobs["ubuntu-quality"]["if"]
     assert "platform_sensitive_changed == 'true'" in jobs["windows-compat"]["if"]
     assert "windows_full_required == 'true'" in jobs["windows-full"]["if"]
     assert "release_changed == 'true'" in jobs["release-packaging"]["if"]
     assert "tui-check" in jobs["ci-result"]["needs"]
+    assert "desktop-check" in jobs["ci-result"]["needs"]
 
 
 def test_windows_smoke_does_not_install_bun_by_default() -> None:

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -84,8 +84,14 @@ def test_desktop_activation_retry_and_second_instance_share_resume_helper() -> N
         "})\n}",
     )
 
-    assert "!gatewayStartPromise && !ready && gatewayProcess && gatewayState.owned" in retry
+    # Retry backs both the boot-error button and the Control UI "Restart runtime"
+    # action, so it forces a real restart: an in-flight start is joined (clearing
+    # the stale error), otherwise an owned gateway is torn down and awaited before
+    # respawn rather than reused, so a healthy-but-misbehaving runtime can restart.
+    assert "if (gatewayStartPromise)" in retry
     assert "stopGateway()" in retry
+    assert "await waitForGatewayProcessExit(previousChild)" in retry
+    assert "clearReusableGatewayState()" in retry
     assert "void openOrResumeDesktopApp()" in retry
 
 
@@ -863,7 +869,7 @@ def test_desktop_credential_save_preserves_config_privacy_without_payload_settin
         in save
     )
     assert "if (!existsSync(path)) return null" in read_config
-    assert "return parseDesktopNetworkObservabilityPrivacyConfig(raw)" in read_config
+    assert "parseDesktopNetworkObservabilityPrivacyConfig(raw)" in read_config
     assert "return true" in read_config
 
 
@@ -1059,7 +1065,10 @@ def test_desktop_cleanup_does_not_claim_os_app_uninstall() -> None:
     assert "OPENSQUILLA_INSTALL_METHOD: 'desktop'" in cleanup
     assert "OPENSQUILLA_STATE_DIR: desktopHome()" in cleanup
     assert "remove the installed .app / NSIS application" in cleanup
-    assert "installed app itself will remain" in cleanup
+    # The purge confirmation is localized via desktopT; the "app remains"
+    # guarantee now lives in the (localized) message catalog rather than inline.
+    assert "desktopT('uninstall.confirmDetail')" in cleanup
+    assert "installed app itself will remain" in main_ts
     assert "does not remove the installed app bundle itself" in panel_vue
 
     en_runtime = en_locale["setup"]["runtime"]
@@ -1107,3 +1116,46 @@ def test_desktop_windows_quit_drains_gateway_before_exit() -> None:
     assert "app.exit(0)" in before_quit
     # The drain runs once, then the re-issued quit falls through.
     assert "windowsQuitDrainDone" in before_quit
+
+
+def test_desktop_macos_prerelease_update_resolver_wires_generic_feed() -> None:
+    # Issue #485: PEP440 rc git tags (v0.5.0rc2) are not npm-semver, so
+    # electron-updater's GitHub provider skips them and a packaged prerelease
+    # discovers no updates. A resolver selects the candidate release and points a
+    # generic feed at its latest-mac.yml; stable tags keep the default provider.
+    main_ts = _read("desktop/electron/src/main.ts")
+    resolver = _read("desktop/electron/src/update-feed-resolver.ts")
+    package_json = json.loads(_read("desktop/electron/package.json"))
+    check = _section(
+        main_ts,
+        "async function checkForUpdates",
+        "function gatewayProcessForUpdateInstall",
+    )
+
+    assert "export function parseOpenSquillaReleaseTag" in resolver
+    assert "export function selectMacPrereleaseCandidate" in resolver
+    assert "latest-mac.yml" in resolver
+    # Only same-base upgrades; a different base is not crossed automatically.
+    assert "parsed.base !== current.base" in resolver
+
+    assert "async function configureDesktopUpdateFeed()" in main_ts
+    assert "if (process.platform !== 'darwin' || !app.isPackaged) return 'default'" in main_ts
+    assert "provider: 'generic', url: candidate.feedUrl, channel: 'latest'" in main_ts
+    # Numeric rc order can disagree with electron-updater's string-based semver
+    # gate (0.5.0-rc10 sorts below rc9), so the resolved-candidate path allows the
+    # "downgrade"; the default path forbids it so stable users never regress.
+    resolver_feed = _section(
+        main_ts,
+        "async function configureDesktopUpdateFeed()",
+        "async function checkForUpdates",
+    )
+    assert "autoUpdater.allowDowngrade = false" in resolver_feed
+    assert "autoUpdater.allowDowngrade = true" in resolver_feed
+    # checkForUpdates consults the resolver and reports up-to-date without a
+    # spurious GitHub-provider error when no newer same-base release exists.
+    assert "const feed = await configureDesktopUpdateFeed()" in check
+    assert "if (feed === 'up-to-date')" in check
+
+    assert package_json["scripts"]["test:update-resolver"] == (
+        "npm run build && node scripts/test-update-resolver.mjs"
+    )


### PR DESCRIPTION
## Scope

Scope boundary: Desktop Electron client (`desktop/electron/`) — an audited batch
of upgrade, stability, usability, and performance fixes, plus the macOS
prerelease auto-update discovery fix for #485. Also adds a gated CI job for the
desktop unit tests.

Non-goals: Web UI, gateway/engine, agent, and channel behavior. Windows native
auto-update stays disabled by design (unsigned builds) — see below.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #485

Notes: #485's maintainer diagnostic scopes the fix to the macOS packaged updater
(PEP440 rc git tags are not npm-semver, so `electron-updater`'s GitHub provider
skips them). This PR adds a client-side resolver for that path. Windows native
auto-update remains intentionally disabled until code signing lands, so Windows
continues to use the passive in-app "update available" notice. #484 (custom Base
URL not persisting via Web UI settings) was examined and is **not** in scope: it
concerns the desktop-owned `[llm]` section / gateway RPC persistence, not the
foreign-config preservation this PR adds.

## Release Note

Release note: Desktop app — macOS now discovers and installs new preview
releases from Settings → Runtime → Desktop update; plus stability, onboarding,
i18n, and config-integrity fixes.

## Tests

Ruff: `ruff check` clean on the changed test file.

Pytest: `pytest tests/test_desktop tests/test_release_consistency.py` — 67 passed.

Build: `tsc -p tsconfig.json` clean; `npm run build` succeeds.

Regression tests: added — `scripts/test-update-resolver.mjs` (rc1→rc2, rc2→stable,
rc9→rc10 numeric ordering, no cross-base jump, missing `latest-mac.yml` skipped,
drafts ignored) and contract assertions in
`tests/test_desktop/test_electron_startup_contract.py`. The new `desktop-check`
CI job runs the desktop Electron unit tests and is enforced by `ci-result`.

Notes: The Electron app was not launched end-to-end in this environment; runtime
behavior is validated by typecheck, extracted-logic unit tests, source-contract
tests, and adversarial diff review.

## Maintainer Live Check

Maintainer live check: yes (recommended)

Surface: release — a maintainer with a signed macOS build and a real GitHub
prerelease should confirm rc → rc / rc → stable discovery + install end to end.

## Safety

No secrets, transcripts, private prompts, channel identifiers, or non-public
fixtures. Tests use synthetic data only.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
