### PR TITLE
Pin Control UI static asset Content-Types against corrupt host MIME databases

### DIFF
--- a/src/opensquilla/gateway/control_ui.py
+++ b/src/opensquilla/gateway/control_ui.py
@@ -6,7 +6,7 @@ import json
 import os
 import re
 import time
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from starlette.requests import Request
 from starlette.responses import HTMLResponse
@@ -28,23 +28,71 @@ from opensquilla.gateway.config import GatewayConfig
 # untouched.
 _STATIC_CACHE_CONTROL = "public, max-age=2592000"
 
+# Content-Types for the static assets the Control UI ships, keyed by lowercase
+# extension. Starlette derives Content-Type from ``mimetypes.guess_type``, which
+# seeds itself from the host OS MIME database. On Windows machines whose
+# ``HKEY_CLASSES_ROOT\\.js`` registry entry has been rewritten to ``text/plain``
+# (a common side effect of some third-party installers), every ``.js`` asset is
+# served as ``text/plain``; Chromium's strict MIME check then refuses to execute
+# the Vite ``<script type="module">`` entry and the console renders blank even
+# though gateway boot and health checks pass. We therefore pin the Content-Type
+# for these extensions at the serving boundary rather than trusting the
+# environment. Extensions not listed here keep flowing through Starlette's own
+# guess.
+#
+# For most extensions the pinned value equals what a correctly configured host
+# already produces. A few are deliberately more correct than a bare host would
+# emit: ``.map``/``.woff``/``.woff2``/``.ttf`` are absent from CPython's built-in
+# table (so a host with no OS MIME registry falls back to ``text/plain``), and
+# ``.ico`` resolves to ``image/vnd.microsoft.icon`` in the stdlib. Pinning
+# normalizes these to their standard types on every host. All values are
+# browser-accepted, so the change is safe on clean machines.
+_PINNED_CONTENT_TYPES = {
+    ".js": "text/javascript",
+    ".mjs": "text/javascript",
+    ".css": "text/css",
+    ".json": "application/json",
+    ".map": "application/json",
+    ".svg": "image/svg+xml",
+    ".wasm": "application/wasm",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".ttf": "font/ttf",
+    ".html": "text/html",
+    ".htm": "text/html",
+    ".png": "image/png",
+    ".ico": "image/x-icon",
+}
+
 
 class _CachedStaticFiles(StaticFiles):
-    """StaticFiles subclass that attaches Cache-Control to 200 responses.
+    """StaticFiles subclass that attaches Cache-Control to 200 responses and
+    pins Content-Type for known code assets.
 
     Source maps (.map) are excluded from long-term caching since they are
     only used for debugging and should not be aggressively cached.
+
+    Content-Type is forced from ``_PINNED_CONTENT_TYPES`` for extensions the
+    console depends on, so a host with a corrupt MIME database cannot mislabel
+    JavaScript (which browsers refuse to execute under strict MIME checking).
     """
 
     async def get_response(self, path: str, scope):  # type: ignore[override]
         response = await super().get_response(path, scope)
-        if response.status_code == 200 and not os.environ.get(
-            "OPENSQUILLA_STATIC_NO_CACHE"
-        ):
+        if response.status_code != 200:
+            return response
+        if not os.environ.get("OPENSQUILLA_STATIC_NO_CACHE"):
             # Skip cache-control for source maps — debug files should not be
             # cached aggressively (or served in production at all).
             if not path.endswith(".map"):
                 response.headers.setdefault("Cache-Control", _STATIC_CACHE_CONTROL)
+        pinned = _PINNED_CONTENT_TYPES.get(PurePosixPath(path).suffix.lower())
+        if pinned is not None:
+            if pinned.startswith("text/"):
+                # Match Starlette's charset convention for text/* types so
+                # headers on healthy hosts stay byte-identical.
+                pinned = f"{pinned}; charset=utf-8"
+            response.headers["content-type"] = pinned
         return response
 
 

--- a/tests/test_gateway/test_static_mime_hardening.py
+++ b/tests/test_gateway/test_static_mime_hardening.py
@@ -1,0 +1,189 @@
+"""Regression tests: Control UI static assets carry correct Content-Types even
+when the host OS MIME database is wrong.
+
+On some Windows machines third-party installers rewrite the
+``HKEY_CLASSES_ROOT\\.js`` registry entry to ``text/plain``. Python's
+``mimetypes`` seeds itself from that registry, and Starlette's ``FileResponse``
+picks its Content-Type via ``mimetypes.guess_type`` — so the gateway serves
+every ``.js`` file as ``text/plain``. Chromium's strict MIME check then refuses
+to run the Vite ``<script type="module">`` entry and the console renders as a
+white screen, even though gateway boot and health checks all pass.
+
+``_CachedStaticFiles`` therefore pins the Content-Type for the asset extensions
+it ships instead of trusting the environment. These tests simulate the polluted
+host by patching the ``guess_type`` symbol that ``starlette.responses`` binds at
+import time — the same effect a corrupt registry has on a real deployment.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+
+import pytest
+import starlette.responses as starlette_responses
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from opensquilla.gateway import control_ui
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.control_ui import _PINNED_CONTENT_TYPES, create_control_ui_routes
+
+# One synthetic asset per extension in _PINNED_CONTENT_TYPES, with the
+# Content-Type the browser needs. A drift-guard test asserts this map covers
+# every pinned extension so new pins cannot ship untested.
+#
+# Note on .map: the pinned application/json deliberately differs from what a
+# healthy host serves today (CPython's mimetypes has no .map entry, so Starlette
+# falls back to text/plain). Do not "correct" this expectation back.
+_ASSETS: dict[str, tuple[bytes, str]] = {
+    "app.js": (b"export {};\n", "text/javascript"),
+    "upper.JS": (b"export {};\n", "text/javascript"),  # extension match is case-insensitive
+    "chunk.mjs": (b"export {};\n", "text/javascript"),
+    "app.css": (b"body{}\n", "text/css"),
+    "logo.svg": (b"<svg xmlns='http://www.w3.org/2000/svg'/>\n", "image/svg+xml"),
+    "manifest.json": (b"{}\n", "application/json"),
+    "app.js.map": (b"{}\n", "application/json"),
+    "mod.wasm": (b"\x00asm\x01\x00\x00\x00", "application/wasm"),
+    "font.woff2": (b"wOF2", "font/woff2"),
+    "font.woff": (b"wOFF", "font/woff"),
+    "font.ttf": (b"\x00\x01\x00\x00", "font/ttf"),
+    "page.html": (b"<!doctype html>\n", "text/html"),
+    "page.htm": (b"<!doctype html>\n", "text/html"),
+    "icon.png": (b"\x89PNG\r\n\x1a\n", "image/png"),
+    "favicon.ico": (b"\x00\x00\x01\x00", "image/x-icon"),
+}
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    for name, (body, _mime) in _ASSETS.items():
+        (static_dir / name).write_bytes(body)
+    (static_dir / "readme.unknownext").write_bytes(b"hello")
+    monkeypatch.setattr(control_ui, "_STATIC_DIR", static_dir)
+    monkeypatch.delenv("OPENSQUILLA_STATIC_NO_CACHE", raising=False)
+
+    config = GatewayConfig()
+    config.control_ui.enabled = True
+    app = Starlette(routes=create_control_ui_routes(config))
+    return TestClient(app)
+
+
+def _pollute_mime_db(
+    monkeypatch: pytest.MonkeyPatch, mime: str = "text/plain"
+) -> None:
+    """Make guess_type behave like a corrupt Windows registry: everything the
+    registry knows about comes back as `mime` (text/plain in the wild)."""
+
+    def polluted(path: object) -> tuple[str | None, str | None]:
+        return (mime, None)
+
+    monkeypatch.setattr(starlette_responses, "guess_type", polluted)
+
+
+def test_assets_cover_every_pinned_extension() -> None:
+    # Drift guard: every extension in _PINNED_CONTENT_TYPES must have a test
+    # asset asserting its exact pinned value, so a typo'd or dropped pin can
+    # never ship silently.
+    covered = {PurePosixPath(name).suffix.lower() for name in _ASSETS}
+    assert covered == set(_PINNED_CONTENT_TYPES)
+    for name, (_body, mime) in _ASSETS.items():
+        assert _PINNED_CONTENT_TYPES[PurePosixPath(name).suffix.lower()] == mime, name
+
+
+@pytest.mark.parametrize(("name", "expected"), [(n, m) for n, (_b, m) in _ASSETS.items()])
+def test_pinned_content_type_survives_polluted_mime_db(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient, name: str, expected: str
+) -> None:
+    _pollute_mime_db(monkeypatch)
+
+    response = client.get(f"/control/static/{name}")
+
+    assert response.status_code == 200, response.text
+    content_type = response.headers.get("content-type", "")
+    assert content_type.split(";")[0].strip() == expected, content_type
+
+
+def test_text_types_keep_charset_parity(client: TestClient) -> None:
+    # Starlette appends "; charset=utf-8" to text/* media types it derives
+    # itself; the pinned headers must follow the same convention so text
+    # responses on healthy hosts keep their charset.
+    for name, charset_expected in (("app.js", True), ("app.css", True), ("icon.png", False)):
+        content_type = client.get(f"/control/static/{name}").headers["content-type"]
+        assert ("charset=utf-8" in content_type) is charset_expected, (name, content_type)
+
+
+def test_unknown_extension_still_uses_environment_guess(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    # Only extensions the Control UI knows are pinned; anything else keeps
+    # flowing through the environment's MIME database, polluted or not. The
+    # sentinel value doubles as a canary that the pollution patch actually
+    # reaches the serving path (text/plain would be indistinguishable from
+    # Starlette's own unknown-extension fallback).
+    _pollute_mime_db(monkeypatch, mime="application/x-corrupt-registry")
+
+    response = client.get("/control/static/readme.unknownext")
+
+    assert response.status_code == 200
+    content_type = response.headers.get("content-type", "")
+    assert content_type.startswith("application/x-corrupt-registry"), content_type
+
+
+def test_pin_survives_no_cache_debug_knob(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    # OPENSQUILLA_STATIC_NO_CACHE=1 disables the Cache-Control header, and is
+    # exactly the knob an operator debugging a white screen would reach for —
+    # the Content-Type pin must not be tied to it.
+    monkeypatch.setenv("OPENSQUILLA_STATIC_NO_CACHE", "1")
+    _pollute_mime_db(monkeypatch)
+
+    response = client.get("/control/static/app.js")
+
+    assert response.status_code == 200
+    assert response.headers.get("content-type", "").startswith("text/javascript")
+    assert "max-age=2592000" not in response.headers.get("Cache-Control", "")
+
+
+def test_pinned_type_coexists_with_cache_control(client: TestClient) -> None:
+    response = client.get("/control/static/app.js")
+
+    assert response.status_code == 200
+    assert response.headers.get("content-type", "").startswith("text/javascript")
+    assert "max-age=2592000" in response.headers.get("Cache-Control", "")
+
+
+def test_missing_asset_still_404s(client: TestClient) -> None:
+    response = client.get("/control/static/does-not-exist.js")
+
+    assert response.status_code == 404
+
+
+def test_real_assets_pinned_on_polluted_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # End-to-end against the real shipped static tree: the Vite module entry
+    # (the asset whose text/plain mislabel white-screens the Vue console), the
+    # legacy frontend entry, and the prism vendor scripts the white-screen
+    # reports also named.
+    _pollute_mime_db(monkeypatch)
+    monkeypatch.delenv("OPENSQUILLA_STATIC_NO_CACHE", raising=False)
+    config = GatewayConfig()
+    config.control_ui.enabled = True
+    client = TestClient(Starlette(routes=create_control_ui_routes(config)))
+
+    vite_js_url, _css_urls = control_ui._read_vite_assets(config.control_ui.base_path)
+    assert vite_js_url.startswith("/control/static/dist/assets/"), vite_js_url
+
+    for path in (
+        vite_js_url,
+        "/control/static/js/app.js",
+        "/control/static/vendor/prism-core.min.js",
+        "/control/static/vendor/prism-autoloader.min.js",
+    ):
+        response = client.get(path)
+        assert response.status_code == 200, path
+        content_type = response.headers.get("content-type", "")
+        assert content_type.startswith("text/javascript"), (path, content_type)


### PR DESCRIPTION
## Scope

Fixes a Control UI white-screen that affects some Windows users. Static assets are served with a `Content-Type` derived from `mimetypes.guess_type`, which seeds itself from the host OS MIME database. On Windows machines where a third-party installer has rewritten the `HKEY_CLASSES_ROOT\.js` registry entry to `text/plain`, the gateway serves every `.js` file as `text/plain`. Chromium's strict MIME check then refuses to execute the Vite `<script type="module">` entry, so the console renders blank — even though gateway boot and every health check pass (they never fetch a JS module).

The fix pins the `Content-Type` for the asset extensions the console ships, at the serving boundary in `_CachedStaticFiles`, so a corrupt or minimal host MIME table can no longer mislabel JavaScript.

### Why the serving boundary, not `mimetypes.add_type`

A process-global `mimetypes.add_type("text/javascript", ".js")` was considered and rejected: Starlette binds `guess_type` at import, and any later `mimetypes.init()` rebuilds the table from the still-polluted registry, silently clobbering the override. Pinning inside `get_response` is immune to both the pollution and re-initialization, and is local to the code that depends on it.

### Behavior notes (public HTTP surface)

For most extensions the pinned value equals what a correctly configured host already emits. A few are deliberately normalized to be *more* correct on minimal hosts: `.map`, `.woff`, `.woff2`, `.ttf` are absent from CPython's built-in MIME table (a host with no OS registry falls back to `text/plain`), and `.ico` resolves to `image/vnd.microsoft.icon` in the stdlib. All pinned values are browser-accepted, and no client, contract test, or golden file asserts on these headers. `304`/`206` paths are unaffected (`NotModifiedResponse` strips `content-type`; the pin is computed while the response is still `200`), and the `OPENSQUILLA_STATIC_NO_CACHE` debug knob continues to disable only `Cache-Control`.

## Branch target

`main`.

## Linked issue

None.

## Release note

User-facing bug fix — suggested note: "Fixed a blank Control UI console on Windows systems whose registry maps `.js` files to `text/plain`."

## Tests

- New `tests/test_gateway/test_static_mime_hardening.py` simulates the corrupt registry by patching the `guess_type` symbol `starlette.responses` binds at import, and locks the pinned types — including the real Vite module entry, case-insensitive extensions, the `OPENSQUILLA_STATIC_NO_CACHE` interaction, a sentinel canary proving the pollution reaches the serving path, and a drift guard keeping the pin map and its coverage in sync.
- `tests/test_gateway/test_static_mime_hardening.py` + `tests/test_gateway/test_static_cache_header.py`: green.
- Full gateway suite: green. `ruff` and `mypy` clean; `uv build --wheel` succeeds.

## Safety

No new external calls, no auth or sandbox surface touched. The change only sets response headers for files already served from the bundled static tree; it cannot broaden what is served.

## Third-party origin

None — original work.
