### PR TITLE
Improve CLI onboarding configure and rerun flows

### DIFF
--- a/src/opensquilla/cli/channel_fields.py
+++ b/src/opensquilla/cli/channel_fields.py
@@ -18,14 +18,51 @@ TOKEN_ALIASES = (
     "corp_secret",
 )
 
+_BOOL_TRUE_SPELLINGS = frozenset({"1", "true", "yes", "on"})
+_BOOL_FALSE_SPELLINGS = frozenset({"0", "false", "no", "off"})
+_BOOL_ACCEPTED_HINT = "1/0, true/false, yes/no, on/off"
 
-def coerce_channel_field_value(field_type: str, raw: str) -> Any:
+
+def _field_label(field_name: str) -> str:
+    return f"--field {field_name}" if field_name else "--field value"
+
+
+def coerce_channel_field_value(
+    field_type: str,
+    raw: str,
+    *,
+    field_name: str = "",
+) -> Any:
+    """Coerce one ``--field key=value`` string to the spec's field type.
+
+    Coercion failures raise ``typer.BadParameter`` naming the offending
+    ``--field`` so the operator sees which key was rejected. Bool parsing is
+    strict: a typo such as ``enabled=ture`` must not silently become False.
+    """
     if field_type == "int":
-        return int(raw)
+        try:
+            return int(raw)
+        except ValueError:
+            raise typer.BadParameter(
+                f"{_field_label(field_name)} expects an integer, got {raw!r}"
+            ) from None
     if field_type == "float":
-        return float(raw)
+        try:
+            return float(raw)
+        except ValueError:
+            raise typer.BadParameter(
+                f"{_field_label(field_name)} expects a number, got {raw!r}"
+            ) from None
     if field_type == "bool":
-        return raw.strip().lower() in {"1", "true", "yes", "on"}
+        normalized = raw.strip().lower()
+        if normalized in _BOOL_TRUE_SPELLINGS:
+            return True
+        if normalized in _BOOL_FALSE_SPELLINGS:
+            return False
+        raise typer.BadParameter(
+            f"{_field_label(field_name)} expects a boolean "
+            f"({_BOOL_ACCEPTED_HINT}), got {raw!r}"
+        )
     return raw
 
 
@@ -41,7 +78,9 @@ def parse_channel_field_pairs(pairs: list[str], type_name: str) -> dict[str, Any
             raise typer.BadParameter(
                 f"unknown field {key!r} for channel type {type_name!r}"
             )
-        out[key] = coerce_channel_field_value(by_name[key].field_type, value)
+        out[key] = coerce_channel_field_value(
+            by_name[key].field_type, value, field_name=key
+        )
     return out
 
 

--- a/src/opensquilla/cli/onboard_cmd.py
+++ b/src/opensquilla/cli/onboard_cmd.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import json as _json
-import shlex
 import tomllib
 from pathlib import Path
+from typing import NoReturn
 
 import typer
 from pydantic import ValidationError
@@ -22,6 +22,7 @@ from opensquilla.cli.ui import (
     warning_panel,
 )
 from opensquilla.onboarding.config_store import load_config, resolve_config_path
+from opensquilla.onboarding.errors import UserCancelledError
 from opensquilla.onboarding.flow import (
     OnboardOptions,
     run_interactive_configure,
@@ -33,10 +34,12 @@ from opensquilla.onboarding.next_steps import (
     env_reference_warnings,
     format_next_steps,
     headless_setup_commands,
+    quote_cli_arg,
     setup_catalog_command,
 )
-from opensquilla.onboarding.section_status import SectionStatus
+from opensquilla.onboarding.section_status import SECTION_STATUS_DISPLAY, SectionStatus
 from opensquilla.onboarding.setup_engine import (
+    AUDIO_SECTION_ALIASES,
     ENSEMBLE_SECTION_ALIASES,
     IMAGE_GENERATION_SECTION_ALIASES,
     MEMORY_EMBEDDING_SECTION_ALIASES,
@@ -44,16 +47,17 @@ from opensquilla.onboarding.setup_engine import (
 )
 from opensquilla.onboarding.setup_paths import web_setup_url
 from opensquilla.onboarding.status import OnboardingStatus, get_onboarding_status
-from opensquilla.search.types import DEFAULT_SEARCH_MAX_RESULTS
+from opensquilla.router_tiers import DEFAULT_TEXT_TIER, TEXT_TIERS
+
+# Exit code for a user-initiated cancellation (Esc/Ctrl+C in the wizard).
+# 130 = 128 + SIGINT, the conventional shell exit status for an interrupt;
+# there is no earlier repo convention for wizard cancellation, so this pins it.
+_CANCELLED_EXIT_CODE = 130
 
 _STATUS_BLOCKING = {SectionStatus.MISSING, SectionStatus.DEGRADED, SectionStatus.UNKNOWN}
-_STATUS_DISPLAY: dict[SectionStatus, str] = {
-    SectionStatus.OK: "Ready",
-    SectionStatus.OPTIONAL: "Later",
-    SectionStatus.MISSING: "Missing",
-    SectionStatus.DEGRADED: "Needs action",
-    SectionStatus.UNKNOWN: "Check",
-}
+# Single source of truth for the status words lives in section_status so the
+# table below and the next-steps capability summary can never diverge.
+_STATUS_DISPLAY: dict[SectionStatus, str] = SECTION_STATUS_DISPLAY
 _LLM_SOURCE_DISPLAY = {
     "explicit": "explicit key",
     "env": "env key visible",
@@ -180,7 +184,43 @@ def _format_config_load_error(exc: Exception) -> str:
     return str(exc).splitlines()[0]
 
 
-def _exit_config_load_error(exc: Exception, path: str | Path | None = None) -> None:
+def _format_validation_error(exc: ValidationError) -> str:
+    """Render a ValidationError as a field-naming summary.
+
+    Never echoes pydantic's ``input_value`` dump — a mispasted secret must
+    not surface on stderr. Only field paths and validator messages appear.
+    """
+    parts: list[str] = []
+    for error in exc.errors(include_url=False, include_context=False, include_input=False):
+        loc = ".".join(str(item) for item in error.get("loc", ()) or ())
+        msg = str(error.get("msg") or "invalid value")
+        parts.append(f"{loc}: {msg}" if loc else msg)
+    return "; ".join(parts) or "invalid value"
+
+
+def _exit_cancelled(exc: BaseException) -> NoReturn:
+    """Productize a wizard cancellation (Esc/Ctrl+C) at the CLI boundary."""
+    error_console.print(
+        "[yellow]Setup cancelled[/yellow] "
+        "[dim]— rerun `opensquilla onboard` when you are ready.[/dim]"
+    )
+    raise typer.Exit(code=_CANCELLED_EXIT_CODE) from exc
+
+
+def _print_restart_guidance(result: object, config_path: Path | None = None) -> None:
+    """Surface ``PersistResult.restart_required`` instead of discarding it."""
+    if not getattr(result, "restart_required", False):
+        return
+    config_arg = _config_cli_arg(config_path)
+    console.print(
+        f"[{ACCENT_SOFT}]◆[/] [bold]restart required[/] "
+        "[dim]— apply this change with[/dim] "
+        f"[{ACCENT_SOFT}]opensquilla gateway restart{markup_escape(config_arg)}[/]",
+        soft_wrap=True,
+    )
+
+
+def _exit_config_load_error(exc: Exception, path: str | Path | None = None) -> NoReturn:
     target, _ = resolve_config_path(path)
     config_arg = _config_cli_arg(target)
     error_console.print(
@@ -230,7 +270,8 @@ def _status_cockpit_summary(status: OnboardingStatus) -> str:
 def _config_cli_arg(config_path: Path | None) -> str:
     if config_path is None:
         return ""
-    return f" --config {shlex.quote(str(config_path))}"
+    # Platform-appropriate quoting: PowerShell on Windows, POSIX elsewhere.
+    return f" --config {quote_cli_arg(config_path)}"
 
 
 def _headless_section_paths(
@@ -429,15 +470,27 @@ onboard_app = typer.Typer(
 def onboard_command(
     ctx: typer.Context,
     provider: str = typer.Option("", "--provider", help="Provider id to configure."),
-    model: str = typer.Option("", "--model", help="Model id for the provider."),
+    model: str | None = typer.Option(
+        None,
+        "--model",
+        help="Model id for the provider (unchanged if omitted on a re-save).",
+    ),
     api_key: str = typer.Option("", "--api-key", help="Provider key to store in config."),
     api_key_env: str = typer.Option(
         "",
         "--api-key-env",
         help="Read the provider key from this environment variable.",
     ),
-    base_url: str = typer.Option("", "--base-url", help="Custom provider base URL."),
-    proxy: str = typer.Option("", "--proxy", help="Explicit HTTP proxy URL for upstream calls."),
+    base_url: str | None = typer.Option(
+        None,
+        "--base-url",
+        help="Custom provider base URL (unchanged if omitted on a re-save).",
+    ),
+    proxy: str | None = typer.Option(
+        None,
+        "--proxy",
+        help="Explicit HTTP proxy URL for upstream calls (unchanged if omitted on a re-save).",
+    ),
     router: str = typer.Option(
         "recommended",
         "--router",
@@ -506,6 +559,10 @@ def onboard_command(
             )
 
     if provider:
+        # Productize config-file load failures up front so a corrupt config
+        # surfaces as the standard config-error handoff instead of leaking a
+        # mutation-shaped error (or a raw traceback) below.
+        _load_config_for_cli(config_path)
         try:
             result = run_noninteractive_provider_configure(
                 provider,
@@ -519,6 +576,15 @@ def onboard_command(
                 },
                 path=config_path,
             )
+        except ValidationError as exc:
+            # Handle before ValueError (its base class): pydantic's message
+            # embeds input_value, which can echo a secret pasted into the
+            # wrong field. Print a redacted, field-naming summary instead.
+            error_console.print(
+                "[red]Error:[/red] invalid provider configuration: "
+                f"{markup_escape(_format_validation_error(exc))}"
+            )
+            raise typer.Exit(code=2) from exc
         except (KeyError, TypeError, ValueError) as exc:
             error_console.print(f"[red]Error:[/red] {markup_escape(str(exc))}")
             if "model is required" in str(exc):
@@ -562,7 +628,20 @@ def onboard_command(
         skip_migration=skip_migration,
         config_path=config_path,
     )
-    result = run_interactive_onboard(options)
+    try:
+        result = run_interactive_onboard(options)
+    except (UserCancelledError, KeyboardInterrupt) as exc:
+        _exit_cancelled(exc)
+    except (OSError, tomllib.TOMLDecodeError, ValidationError) as exc:
+        # Corrupt or unreadable config: route through the same productized
+        # handoff as `--if-needed`/`status` instead of a raw traceback.
+        _exit_config_load_error(exc, config_path)
+    except (KeyError, TypeError, ValueError) as exc:
+        # Mutation-level validation failures (e.g. "model is required") must
+        # exit like the headless path does, not as a raw traceback after the
+        # operator already typed the credentials.
+        error_console.print(f"[red]Error:[/red] {markup_escape(str(exc))}")
+        raise typer.Exit(code=2) from exc
     if "tty_required" in result.warnings:
         raise typer.Exit(code=2)
     console.print(
@@ -591,6 +670,14 @@ _STATUS_STYLE: dict[SectionStatus, str] = {
 
 
 def _status_payload(status: OnboardingStatus) -> dict:
+    """Machine-readable ``onboard status --json`` payload.
+
+    Superset contract: every key of the RPC ``onboarding.status`` payload
+    (contract-frozen in tests/test_contracts/test_onboarding_status.py) must
+    appear here under the same name so scripts can consume either surface;
+    ``sectionAliases`` plus the ``provider`` alias entries are the only
+    CLI-side additions. Pinned by tests/test_cli/test_onboard_status_json.py.
+    """
     sections = {name: state.value for name, state in status.sections.items()}
     section_details = {name: dict(detail) for name, detail in status.section_details.items()}
     if "llm" in sections:
@@ -605,22 +692,34 @@ def _status_payload(status: OnboardingStatus) -> dict:
         "sections": sections,
         "sectionDetails": section_details,
         "sectionAliases": {"llm": "provider"},
+        "llmConfigured": status.llm_configured,
         "llmSource": status.llm_source,
         "llmEnvKey": status.llm_env_key,
+        "llmCredentialStatus": dict(status.llm_credential_status),
+        "searchConfigured": status.search_configured,
         "searchProvider": status.search_provider,
         "searchSource": status.search_source,
         "searchEnvKey": status.search_env_key,
+        "imageGenerationConfigured": status.image_generation_configured,
         "imageGenerationEnabled": status.image_generation_enabled,
         "imageGenerationSource": status.image_generation_source,
         "imageGenerationProvider": status.image_generation_provider,
         "imageGenerationPrimary": status.image_generation_primary,
         "imageGenerationEnvKey": status.image_generation_env_key,
+        "audioConfigured": status.audio_configured,
+        "audioEnabled": status.audio_enabled,
+        "audioSource": status.audio_source,
+        "audioProvider": status.audio_provider,
+        "audioEnvKey": status.audio_env_key,
         "memoryEmbeddingConfigured": status.memory_embedding_configured,
         "memoryEmbeddingProvider": status.memory_embedding_provider,
         "memoryEmbeddingSource": status.memory_embedding_source,
         "memoryEmbeddingEnvKey": status.memory_embedding_env_key,
+        "ensembleCredentialStatus": list(status.ensemble_credential_status),
         "envRecoveryCommands": env_recovery_commands(status),
         "channelCount": status.channel_count,
+        "channelsConfigured": status.channels_configured,
+        "warnings": list(status.warnings),
     }
 
 
@@ -638,7 +737,8 @@ _CATALOG_COMMANDS = {
         "--api-key-env <ENV_NAME>"
     ),
     "routerProfiles": (
-        "opensquilla onboard configure router --router recommended --default-tier c1"
+        "opensquilla onboard configure router --router recommended "
+        f"--default-tier {DEFAULT_TEXT_TIER}"
     ),
     "searchProviders": (
         "opensquilla onboard configure search --search-provider <provider> "
@@ -652,6 +752,9 @@ _CATALOG_COMMANDS = {
         "opensquilla onboard configure image --image-provider <provider> "
         "--primary <model> --api-key-env <ENV_NAME>"
     ),
+    # Voice audio has no headless configure recipe yet; the Web UI setup page
+    # is the supported configuration surface.
+    "audioProviders": "opensquilla gateway run",
     "memoryEmbeddingProviders": (
         "opensquilla onboard configure memory --memory-provider <provider> "
         "--model <model> --api-key-env <ENV_NAME>"
@@ -664,6 +767,7 @@ _CATALOG_SECTION_COMMANDS = {
     "searchProviders": "opensquilla onboard catalog search",
     "channels": "opensquilla onboard catalog channels",
     "imageGenerationProviders": "opensquilla onboard catalog image",
+    "audioProviders": "opensquilla onboard catalog audio",
     "memoryEmbeddingProviders": "opensquilla onboard catalog memory",
 }
 
@@ -673,6 +777,7 @@ _CATALOG_TITLES = {
     "searchProviders": "Web search providers",
     "channels": "Channel types",
     "imageGenerationProviders": "Image generation providers",
+    "audioProviders": "Voice audio providers",
     "memoryEmbeddingProviders": "Memory embedding providers",
 }
 
@@ -784,6 +889,11 @@ def _catalog_try_command(
             command += f" --base-url {_catalog_value(row, 'defaultBaseUrl', '<base-url>')}"
         return f"{command}{config_arg}"
 
+    if name == "audioProviders":
+        # No headless configure recipe exists for voice audio yet; point at
+        # the gateway so the Web UI setup page can finish the job.
+        return f"opensquilla gateway run{config_arg}"
+
     if name == "memoryEmbeddingProviders":
         provider_id = _catalog_value(row, "providerId", "<provider>")
         command = (
@@ -878,6 +988,22 @@ def _print_list_catalog(
             _print_catalog_try_command(name, row, config_arg)
         return
 
+    if name == "audioProviders":
+        console.print("[bold]OpenSquilla voice audio provider options[/bold]")
+        console.print(
+            "Configure voice audio from the Web UI setup page after starting "
+            "the gateway with the Try command."
+        )
+        for row in rows:
+            _print_catalog_line(
+                f"- {_catalog_value(row, 'providerId')}: {_catalog_value(row, 'label')}"
+                f" | {_catalog_value(row, 'deployment')}"
+                f" | key {_catalog_key_requirement(row)}"
+                f" | tts {_catalog_value(row, 'defaultTtsModel', 'custom')}"
+            )
+            _print_catalog_try_command(name, row, config_arg)
+        return
+
     if name == "memoryEmbeddingProviders":
         console.print("[bold]OpenSquilla memory embedding provider options[/bold]")
         _print_catalog_recipe_hint()
@@ -896,7 +1022,7 @@ def _router_tier_summary(profile: dict[str, object]) -> str:
     if not isinstance(tiers, dict):
         return ""
     summary: list[str] = []
-    for tier in ("c0", "c1", "c2", "c3"):
+    for tier in TEXT_TIERS:
         tier_spec = tiers.get(tier)
         if isinstance(tier_spec, dict):
             summary.append(f"{tier}: {tier_spec.get('model', '')}")
@@ -1074,6 +1200,79 @@ def onboard_status_command(
             _print_status_path(label, command, suffix)
 
 
+# Canonical wizard slug per accepted configure section spelling. Anything
+# outside this map is not configurable via `onboard configure` and exits 2.
+_CONFIGURE_SECTION_SLUGS: dict[str, str] = {
+    "provider": "provider",
+    "providers": "provider",
+    "router": "router",
+    **{alias: "ensemble" for alias in ENSEMBLE_SECTION_ALIASES},
+    "channel": "channels",
+    "channels": "channels",
+    "search": "search",
+    **{alias: "image-generation" for alias in IMAGE_GENERATION_SECTION_ALIASES},
+    **{alias: "memory-embedding" for alias in MEMORY_EMBEDDING_SECTION_ALIASES},
+}
+_CONFIGURE_SECTION_HINT = (
+    "provider, router, ensemble, channels, search, image (alias for "
+    "image-generation), or memory (alias for memory-embedding)"
+)
+
+
+def _exit_unknown_configure_section(selected: str, normalized: str) -> NoReturn:
+    if normalized in AUDIO_SECTION_ALIASES:
+        error_console.print(
+            "[red]Error:[/red] voice audio has no headless configure recipe yet; "
+            "view options with `opensquilla onboard catalog audio` and configure "
+            "it from the Web UI setup page."
+        )
+    else:
+        error_console.print(
+            f"[red]Error:[/red] unknown configure section: {markup_escape(repr(selected))}"
+        )
+        error_console.print(f"[dim]Sections: {_CONFIGURE_SECTION_HINT}.[/dim]")
+    raise typer.Exit(code=2)
+
+
+def _missing_headless_gate_flags(
+    normalized: str,
+    given: dict[str, bool],
+) -> list[str]:
+    """Name the gate flag(s) a headless `configure <section>` call still needs.
+
+    Called only when explicit flags were passed but no headless branch
+    matched — silently dropping those flags (the pre-fix behavior) made
+    `configure router --default-tier c2` a no-op with exit 0.
+    """
+    if normalized in {"provider", "providers"}:
+        return ["--provider"]
+    if normalized == "router":
+        return ["--router"]
+    if normalized in ENSEMBLE_SECTION_ALIASES:
+        return ["--enabled/--disabled (or another ensemble flag)"]
+    if normalized == "search":
+        return ["--search-provider"]
+    if normalized in {"channel", "channels"}:
+        return [flag for flag in ("--channel-type", "--name") if not given[flag]]
+    if normalized in IMAGE_GENERATION_SECTION_ALIASES:
+        return ["--image-provider"]
+    if normalized in MEMORY_EMBEDDING_SECTION_ALIASES:
+        return ["--memory-provider"]
+    return []
+
+
+def _exit_incomplete_headless_flags(normalized: str, given: dict[str, bool]) -> NoReturn:
+    missing = _missing_headless_gate_flags(normalized, given)
+    flags = " and ".join(missing) if missing else "its gate flag"
+    error_console.print(
+        f"[red]Error:[/red] `configure {markup_escape(normalized)}` received "
+        f"explicit flags but is missing {markup_escape(flags)}; no changes were "
+        "made. Add the missing flag(s), or rerun without flags for the guided "
+        "wizard."
+    )
+    raise typer.Exit(code=2)
+
+
 @onboard_app.command("configure")
 def configure_command(
     section_arg: str = typer.Argument(
@@ -1107,10 +1306,10 @@ def configure_command(
         help="Explicitly apply this router preset id when saving the provider.",
         rich_help_panel="Text provider",
     ),
-    model: str = typer.Option(
-        "",
+    model: str | None = typer.Option(
+        None,
         "--model",
-        help="Model id for provider or remote memory embedding.",
+        help="Model id for provider or remote memory embedding (unchanged if omitted).",
         rich_help_panel="Shared keys and endpoints",
     ),
     api_key: str = typer.Option(
@@ -1125,16 +1324,22 @@ def configure_command(
         help="Read that capability key from this environment variable.",
         rich_help_panel="Shared keys and endpoints",
     ),
-    base_url: str = typer.Option(
-        "",
+    base_url: str | None = typer.Option(
+        None,
         "--base-url",
-        help="Custom upstream base URL for provider, image, or remote memory.",
+        help=(
+            "Custom upstream base URL for provider, image, or remote memory "
+            "(unchanged if omitted)."
+        ),
         rich_help_panel="Shared keys and endpoints",
     ),
-    proxy: str = typer.Option(
-        "",
+    proxy: str | None = typer.Option(
+        None,
         "--proxy",
-        help="Explicit HTTP proxy URL for provider or search upstream calls.",
+        help=(
+            "Explicit HTTP proxy URL for provider or search upstream calls "
+            "(unchanged if omitted)."
+        ),
         rich_help_panel="Shared keys and endpoints",
     ),
     router: str = typer.Option(
@@ -1146,7 +1351,7 @@ def configure_command(
     default_tier: str = typer.Option(
         "",
         "--default-tier",
-        help="Default router text tier: c0, c1, c2, or c3.",
+        help=f"Default router text tier: {', '.join(TEXT_TIERS)}.",
         rich_help_panel="Router",
     ),
     enabled: bool | None = typer.Option(
@@ -1185,28 +1390,34 @@ def configure_command(
         help="Search provider id.",
         rich_help_panel="Search",
     ),
-    max_results: int = typer.Option(
-        DEFAULT_SEARCH_MAX_RESULTS,
+    max_results: int | None = typer.Option(
+        None,
         "--max-results",
-        help="Default Web search result limit.",
+        help="Default Web search result limit (unchanged if omitted).",
         rich_help_panel="Search",
     ),
-    use_env_proxy: bool = typer.Option(
-        False,
+    use_env_proxy: bool | None = typer.Option(
+        None,
         "--use-env-proxy/--no-use-env-proxy",
-        help="Let Web search use HTTP(S)_PROXY from the gateway environment.",
+        help=(
+            "Let Web search use HTTP(S)_PROXY from the gateway environment "
+            "(unchanged if omitted)."
+        ),
         rich_help_panel="Search",
     ),
     fallback_policy: str = typer.Option(
-        "off",
+        "",
         "--fallback-policy",
-        help="Search fallback policy: off or network.",
+        help="Search fallback policy: off or network (unchanged if omitted).",
         rich_help_panel="Search",
     ),
-    diagnostics: bool = typer.Option(
-        False,
+    diagnostics: bool | None = typer.Option(
+        None,
         "--diagnostics/--no-diagnostics",
-        help="Include search provider attempt/error details for troubleshooting.",
+        help=(
+            "Include search provider attempt/error details for troubleshooting "
+            "(unchanged if omitted)."
+        ),
         rich_help_panel="Search",
     ),
     channel_type: str = typer.Option(
@@ -1240,10 +1451,10 @@ def configure_command(
         help="Image provider id.",
         rich_help_panel="Image generation",
     ),
-    image_enabled: bool = typer.Option(
-        True,
+    image_enabled: bool | None = typer.Option(
+        None,
         "--image-enabled/--no-image-enabled",
-        help="Enable or disable image generation.",
+        help="Enable or disable image generation (unchanged if omitted).",
         rich_help_panel="Image generation",
     ),
     primary: str = typer.Option(
@@ -1273,10 +1484,47 @@ def configure_command(
 ) -> None:
     """Reconfigure provider, router, ensemble, channels, search, image generation, or memory."""
     selected = section or section_arg
+    # Which headless flags the operator explicitly passed (None/""/[] means
+    # "not given" — the None-defaulted options keep stored values downstream).
+    given = {
+        "--provider": bool(provider),
+        "--preset": bool(preset),
+        "--model": model is not None,
+        "--api-key": bool(api_key),
+        "--api-key-env": bool(api_key_env),
+        "--base-url": base_url is not None,
+        "--proxy": proxy is not None,
+        "--router": bool(router),
+        "--default-tier": bool(default_tier),
+        "--enabled/--disabled": enabled is not None,
+        "--selection-mode": bool(selection_mode),
+        "--model-options": bool(model_options),
+        "--min-successful-proposers": min_successful_proposers is not None,
+        "--all-failed-policy": bool(all_failed_policy),
+        "--search-provider": bool(search_provider),
+        "--max-results": max_results is not None,
+        "--use-env-proxy/--no-use-env-proxy": use_env_proxy is not None,
+        "--fallback-policy": bool(fallback_policy),
+        "--diagnostics/--no-diagnostics": diagnostics is not None,
+        "--channel-type": bool(channel_type),
+        "--name": bool(name),
+        "--token": bool(token),
+        "--field": bool(fields),
+        "--image-provider": bool(image_provider),
+        "--image-enabled/--no-image-enabled": image_enabled is not None,
+        "--primary": bool(primary),
+        "--memory-provider": bool(memory_provider),
+        "--onnx-dir": bool(onnx_dir),
+    }
+    any_flag_given = any(given.values())
+    wizard_section: str | None = None
     if selected:
+        normalized = selected.strip().lower()
+        wizard_section = _CONFIGURE_SECTION_SLUGS.get(normalized)
+        if wizard_section is None:
+            _exit_unknown_configure_section(selected, normalized)
         from opensquilla.onboarding.setup_engine import SetupEngine
 
-        normalized = selected.strip().lower()
         try:
             if normalized in {"provider", "providers"} and provider:
                 engine = SetupEngine(path=config_path)
@@ -1294,6 +1542,7 @@ def configure_command(
                 )
                 result = engine.persist()
                 _print_saved_path(result.path)
+                _print_restart_guidance(result, config_path)
                 _print_env_reference_warnings(_load_config_for_cli(result.path))
                 return
             if normalized == "router" and router:
@@ -1301,6 +1550,7 @@ def configure_command(
                 engine.apply("router", {"mode": router, "defaultTier": default_tier})
                 result = engine.persist()
                 _print_saved_path(result.path)
+                _print_restart_guidance(result, config_path)
                 _print_env_reference_warnings(_load_config_for_cli(result.path))
                 return
             ensemble_flags_given = (
@@ -1332,6 +1582,7 @@ def configure_command(
                 )
                 result = engine.persist()
                 _print_saved_path(result.path)
+                _print_restart_guidance(result, config_path)
                 return
             if normalized == "search" and search_provider:
                 engine = SetupEngine(path=config_path)
@@ -1341,15 +1592,17 @@ def configure_command(
                         "providerId": search_provider,
                         "apiKey": api_key,
                         "apiKeyEnv": api_key_env,
+                        # None = keep the stored global search settings.
                         "maxResults": max_results,
                         "proxy": proxy,
                         "useEnvProxy": use_env_proxy,
-                        "fallbackPolicy": fallback_policy,
+                        "fallbackPolicy": fallback_policy or None,
                         "diagnostics": diagnostics,
                     },
                 )
                 result = engine.persist()
                 _print_saved_path(result.path)
+                _print_restart_guidance(result, config_path)
                 _print_env_reference_warnings(_load_config_for_cli(result.path))
                 return
             if normalized in {"channel", "channels"} and channel_type and name:
@@ -1365,9 +1618,10 @@ def configure_command(
                 engine.apply("channel", {"entry": entry})
                 result = engine.persist()
                 _print_saved_path(result.path)
+                _print_restart_guidance(result, config_path)
                 return
             if normalized in IMAGE_GENERATION_SECTION_ALIASES and (
-                image_provider or not image_enabled
+                image_provider or image_enabled is False
             ):
                 engine = SetupEngine(path=config_path)
                 engine.apply(
@@ -1378,11 +1632,14 @@ def configure_command(
                         "apiKey": api_key,
                         "apiKeyEnv": api_key_env,
                         "baseUrl": base_url,
+                        # None = keep the stored enabled flag (a deliberate
+                        # enabled=false survives a key rotation).
                         "enabled": image_enabled,
                     },
                 )
                 result = engine.persist()
                 _print_saved_path(result.path)
+                _print_restart_guidance(result, config_path)
                 _print_env_reference_warnings(_load_config_for_cli(result.path))
                 return
             if normalized in MEMORY_EMBEDDING_SECTION_ALIASES and memory_provider:
@@ -1400,14 +1657,45 @@ def configure_command(
                 )
                 result = engine.persist()
                 _print_saved_path(result.path)
+                _print_restart_guidance(result, config_path)
                 _print_env_reference_warnings(_load_config_for_cli(result.path))
                 return
+            if any_flag_given:
+                # Explicit flags without the section's gate flag: refuse
+                # instead of silently forwarding nothing to the wizard.
+                _exit_incomplete_headless_flags(normalized, given)
         except (OSError, tomllib.TOMLDecodeError, ValidationError) as exc:
             _exit_config_load_error(exc, config_path)
         except (KeyError, TypeError, ValueError) as exc:
             error_console.print(f"[red]Error:[/red] {markup_escape(exc)}")
             raise typer.Exit(code=2) from exc
+    elif any_flag_given:
+        error_console.print(
+            "[red]Error:[/red] configuration flags need a target section, e.g. "
+            "`opensquilla onboard configure router --router recommended`; "
+            "no changes were made."
+        )
+        error_console.print(f"[dim]Sections: {_CONFIGURE_SECTION_HINT}.[/dim]")
+        raise typer.Exit(code=2)
 
-    interactive_result = run_interactive_configure(selected or None, config_path=config_path)
+    try:
+        interactive_result = run_interactive_configure(
+            wizard_section, config_path=config_path
+        )
+    except (UserCancelledError, KeyboardInterrupt) as exc:
+        _exit_cancelled(exc)
+    except (OSError, tomllib.TOMLDecodeError, ValidationError) as exc:
+        _exit_config_load_error(exc, config_path)
+    except (KeyError, TypeError, ValueError) as exc:
+        # Mutation-level validation failures reachable from the wizard (e.g.
+        # a blank required channel secret) must surface like the headless
+        # boundary above — productized message, exit 2, no traceback.
+        error_console.print(f"[red]Error:[/red] {markup_escape(str(exc))}")
+        raise typer.Exit(code=2) from exc
     if interactive_result is not None:
         _print_saved_path(interactive_result.path)
+        _print_restart_guidance(interactive_result, config_path)
+        return
+    # ``run_interactive_configure`` returns ``None`` only after printing the
+    # non-TTY hint; exit 2 like bare `onboard` so scripts see the failure.
+    raise typer.Exit(code=2)

--- a/src/opensquilla/cli/onboard_cmd.py
+++ b/src/opensquilla/cli/onboard_cmd.py
@@ -1696,6 +1696,14 @@ def configure_command(
         _print_saved_path(interactive_result.path)
         _print_restart_guidance(interactive_result, config_path)
         return
+    if not selected:
+        # Bare interactive `onboard configure` can exit the hub without changes
+        # via "Exit (nothing changed)"; that is a successful no-op, not the
+        # non-TTY error path below.
+        from opensquilla.onboarding.flow import _is_tty
+
+        if _is_tty():
+            return
     # ``run_interactive_configure`` returns ``None`` only after printing the
     # non-TTY hint; exit 2 like bare `onboard` so scripts see the failure.
     raise typer.Exit(code=2)

--- a/src/opensquilla/env.py
+++ b/src/opensquilla/env.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from pathlib import Path
 
 from opensquilla.paths import default_opensquilla_home
@@ -22,6 +23,10 @@ log = logging.getLogger(__name__)
 
 _TRUTHY = {"1", "true", "yes", "on"}
 _PROXY_ENV_VARS = ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy")
+
+# Paths already reported as unloadable, so repeated load_env calls (the CLI
+# loads env at import time and again in the app callback) warn only once.
+_warned_unloadable_files: set[str] = set()
 
 
 def trust_env() -> bool:
@@ -50,11 +55,33 @@ def warn_if_proxy_ignored() -> None:
 
 
 def _parse_env_file(path: Path) -> dict[str, str]:
-    """Parse a .env file into a dict. Skips comments and blank lines."""
+    """Parse a .env file into a dict. Skips comments and blank lines.
+
+    A file that cannot be read or decoded is skipped with a warning instead
+    of raising: ``load_env`` runs at CLI import time, so one bad byte in
+    ``~/.opensquilla/.env`` must not kill every command (including the
+    onboarding wizard that could repair the file).
+    """
     if not path.is_file():
         return {}
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError) as exc:
+        if str(path) not in _warned_unloadable_files:
+            _warned_unloadable_files.add(str(path))
+            reason = (
+                "not valid UTF-8 (re-save the file as UTF-8)"
+                if isinstance(exc, UnicodeDecodeError)
+                else str(exc)
+            )
+            # stderr only: load_env runs at CLI import time, before any
+            # logging is configured. An unconfigured structlog logger would
+            # print to stdout and corrupt machine-readable command output
+            # (e.g. `onboard status --json`).
+            sys.stderr.write(f"opensquilla: skipping env file {path}: {reason}\n")
+        return {}
     entries: dict[str, str] = {}
-    for line in path.read_text(encoding="utf-8").splitlines():
+    for line in raw.splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
             continue

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -2061,6 +2061,28 @@ class GatewayConfig(BaseSettings):
             "dream_enabled": str(self.memory.dream.enabled).lower(),
         }
     _runtime_secret_paths: set[str] = PrivateAttr(default_factory=set)
+    # Paths whose secret value was explicitly entered by the operator (set by
+    # ``clear_runtime_secret``): value-coincidence redaction heuristics in
+    # ``to_toml_dict`` must not strip them, even when the entered value
+    # happens to equal the corresponding environment variable.
+    _explicit_secret_paths: set[str] = PrivateAttr(default_factory=set)
+    # Sparse-persist provenance (consumed by onboarding.config_store):
+    # - _persist_baseline: the TOML dump captured when THIS instance was
+    #   loaded (or last persisted). Instance-scoped by design — a path-keyed
+    #   global baseline lets a second live object for the same file diff
+    #   against another writer's snapshot and silently revert its changes.
+    # - _runtime_field_overrides: path -> (stored_value, applied_value) for
+    #   fields the runtime resolved in place from the environment (e.g.
+    #   llm.base_url from OPENAI_BASE_URL). Persisting restores stored_value
+    #   whenever the field still equals applied_value, so env-derived values
+    #   never leak into config.toml.
+    # - _force_persist_paths: paths an explicit mutation set that must be
+    #   written even when equal to the model default (e.g. a deliberate
+    #   image_generation.enabled = false on a fresh config), so keep-current
+    #   logic can see the decision on the next load.
+    _persist_baseline: dict[str, Any] | None = PrivateAttr(default=None)
+    _runtime_field_overrides: dict[str, tuple[Any, Any]] = PrivateAttr(default_factory=dict)
+    _force_persist_paths: set[str] = PrivateAttr(default_factory=set)
 
     def to_toml_dict(self) -> dict[str, Any]:
         """Convert config to a TOML-writable dict."""
@@ -2077,13 +2099,19 @@ class GatewayConfig(BaseSettings):
             data.pop("search_api_key_env", None)
         elif not data.get("search_api_key"):
             data.pop("search_api_key", None)
-        _delete_env_sourced_secret(
-            data,
-            "audio.providers.elevenlabs.api_key",
-            "audio.providers.elevenlabs.api_key_env",
-            default_env="ELEVENLABS_API_KEY",
-            settings_env="OPENSQUILLA_AUDIO_PROVIDERS__ELEVENLABS__API_KEY",
-        )
+        # Heuristic guard for the pre-provenance era: a value equal to the
+        # env var is assumed env-sourced and dropped. Skipped when the
+        # operator explicitly entered the key (recorded by
+        # ``clear_runtime_secret``) — an explicit entry must persist even
+        # when it coincides with the env value.
+        if "audio.providers.elevenlabs.api_key" not in self._explicit_secret_paths:
+            _delete_env_sourced_secret(
+                data,
+                "audio.providers.elevenlabs.api_key",
+                "audio.providers.elevenlabs.api_key_env",
+                default_env="ELEVENLABS_API_KEY",
+                settings_env="OPENSQUILLA_AUDIO_PROVIDERS__ELEVENLABS__API_KEY",
+            )
         router = data.get("squilla_router")
         if isinstance(router, dict) and router.get("tier_profile"):
             profile = str(router["tier_profile"]).strip().lower()
@@ -2127,9 +2155,43 @@ class GatewayConfig(BaseSettings):
 
     def clear_runtime_secret(self, path: str) -> None:
         self._runtime_secret_paths.discard(path)
+        # Clearing records operator provenance: every mutation surface calls
+        # this exactly when the user supplied an explicit new value for the
+        # secret, so value-coincidence heuristics (the env == value deletion
+        # in ``to_toml_dict``) must no longer strip the path from persist
+        # dumps — an explicit key equal to the env value is still explicit.
+        self._explicit_secret_paths.add(path)
 
     def inherit_runtime_secrets(self, other: GatewayConfig) -> None:
         self._runtime_secret_paths = set(other._runtime_secret_paths)
+        self._explicit_secret_paths = set(other._explicit_secret_paths)
+
+    def record_runtime_override(self, path: str, stored: Any, applied: Any) -> None:
+        """Record that ``path`` was resolved in place from the environment.
+
+        ``stored`` is the value the persisted config carried before the
+        runtime override; ``applied`` is the value now living on the model.
+        The sparse persister restores ``stored`` whenever the field still
+        equals ``applied``, so a boot-time env override never gets baked
+        into config.toml by an unrelated save.
+        """
+        self._runtime_field_overrides[path] = (stored, applied)
+
+    def clear_runtime_override(self, path: str) -> None:
+        self._runtime_field_overrides.pop(path, None)
+
+    def runtime_field_overrides(self) -> dict[str, tuple[Any, Any]]:
+        return dict(self._runtime_field_overrides)
+
+    def mark_force_persist(self, path: str) -> None:
+        """Always write ``path`` on the next persist, even if it equals the
+        model default — used for explicit boolean decisions (e.g. a
+        deliberate ``image_generation.enabled = false``) that keep-current
+        logic must be able to see in the file."""
+        self._force_persist_paths.add(path)
+
+    def force_persist_paths(self) -> set[str]:
+        return set(self._force_persist_paths)
 
     @classmethod
     def load_from_toml(cls, path: str | Path) -> GatewayConfig:

--- a/src/opensquilla/gateway/llm_runtime.py
+++ b/src/opensquilla/gateway/llm_runtime.py
@@ -92,6 +92,19 @@ def resolve_llm_runtime_config(config: Any) -> LlmRuntimeConfig:
     base_url = env_base_url or llm.base_url or (spec.default_base_url if spec else "")
     proxy = os.environ.get("OPENSQUILLA_LLM_PROXY", "") or getattr(llm, "proxy", "")
 
+    # Record runtime provenance BEFORE mutating the live model: values
+    # resolved from the environment (or spec defaults) here must never be
+    # baked into config.toml by a later unrelated persist. Only api_key has
+    # the runtime-secret mark; base_url/proxy get the override record that
+    # onboarding.config_store restores at persist time.
+    if hasattr(config, "record_runtime_override"):
+        stored_base_url = llm.base_url
+        if base_url != stored_base_url:
+            config.record_runtime_override("llm.base_url", stored_base_url, base_url)
+        stored_proxy = getattr(llm, "proxy", "")
+        if proxy != stored_proxy:
+            config.record_runtime_override("llm.proxy", stored_proxy, proxy)
+
     llm.provider = provider
     llm.api_key = api_key
     llm.base_url = base_url

--- a/src/opensquilla/gateway/rpc_onboarding.py
+++ b/src/opensquilla/gateway/rpc_onboarding.py
@@ -314,25 +314,42 @@ def _require(params: Any, key: str) -> Any:
     return params[key]
 
 
+def _param(params: Any, key: str, default: Any) -> Any:
+    """``params.get`` that also maps an explicit JSON ``null`` to ``default``.
+
+    The onboarding mutations widened several parameters to ``None`` =
+    keep-current for the CLI, but over RPC the legacy contract is pinned:
+    an absent key AND an explicit ``null`` both mean the legacy default
+    (reset/derive/clear), so hand-written clients sending ``null`` keep the
+    pre-widening behavior instead of silently keeping stored values.
+    """
+    if not isinstance(params, dict):
+        return default
+    value = params.get(key, default)
+    return default if value is None else value
+
+
 @_d.method("onboarding.provider.configure", scope="operator.admin")
 async def _provider_configure(params: Any, ctx: RpcContext) -> dict[str, Any]:
     from opensquilla.onboarding.mutations import upsert_llm_provider
 
     provider_id = _require(params, "providerId")
-    model = params.get("model", "") if isinstance(params, dict) else ""
+    # Legacy null semantics pinned: absent key OR explicit null = legacy
+    # default ("" -> derive/reset), never keep-current (see _param).
+    model = _param(params, "model", "")
     cfg = _active_config(ctx)
     with _validation_error("onboarding.provider.invalid"):
         res = upsert_llm_provider(
             cfg,
             provider_id=provider_id,
             model=model,
-            api_key=params.get("apiKey", "") if isinstance(params, dict) else "",
-            api_key_env=params.get("apiKeyEnv", "") if isinstance(params, dict) else "",
-            base_url=params.get("baseUrl", "") if isinstance(params, dict) else "",
-            proxy=params.get("proxy", "") if isinstance(params, dict) else "",
+            api_key=_param(params, "apiKey", ""),
+            api_key_env=_param(params, "apiKeyEnv", ""),
+            base_url=_param(params, "baseUrl", ""),
+            proxy=_param(params, "proxy", ""),
             # Explicit-user-action only (D18): a preset is applied exactly when
             # the client sends presetId; a plain save never auto-applies one.
-            preset_id=params.get("presetId", "") if isinstance(params, dict) else "",
+            preset_id=_param(params, "presetId", ""),
         )
     _apply_inplace(ctx, res.config)
     _sync_provider_selector(ctx, res.config.llm)
@@ -506,14 +523,23 @@ async def _ensemble_configure(params: Any, ctx: RpcContext) -> dict[str, Any]:
 
 @_d.method("onboarding.channel.probe", scope="operator.admin")
 async def _channel_probe(params: Any, ctx: RpcContext) -> dict[str, Any]:
-    from opensquilla.onboarding.mutations import validate_channel_entry
+    from opensquilla.onboarding.mutations import (
+        merge_channel_entry_secrets,
+        validate_channel_entry,
+    )
     from opensquilla.onboarding.redaction import redact_channel_entry
 
     entry = _require(params, "entry")
     if not isinstance(entry, dict):
         raise ValueError("params.entry must be an object")
+    # Merge-aware probe: blank secrets resolve against the stored entry the
+    # same way onboarding.channel.upsert does, so probing a keep-current
+    # payload validates the entry the upsert would actually persist instead
+    # of hard-failing on the non-blank-secret requirement. A genuinely blank
+    # secret (no stored entry to merge from) still fails validation.
+    cfg = _active_config(ctx)
     with _channel_error():
-        normalized = validate_channel_entry(entry)
+        normalized = validate_channel_entry(merge_channel_entry_secrets(cfg, entry))
     type_name = str(normalized.get("type") or "")
     return {
         "status": "ready",
@@ -534,19 +560,15 @@ async def _search_configure(params: Any, ctx: RpcContext) -> dict[str, Any]:
         res = upsert_search_provider(
             cfg,
             provider_id=provider_id,
-            api_key=params.get("apiKey", "") if isinstance(params, dict) else "",
-            api_key_env=params.get("apiKeyEnv", "") if isinstance(params, dict) else "",
-            max_results=(
-                params.get("maxResults", DEFAULT_SEARCH_MAX_RESULTS)
-                if isinstance(params, dict)
-                else DEFAULT_SEARCH_MAX_RESULTS
-            ),
-            proxy=params.get("proxy", "") if isinstance(params, dict) else "",
-            use_env_proxy=(params.get("useEnvProxy", False) if isinstance(params, dict) else False),
-            fallback_policy=(
-                params.get("fallbackPolicy", "off") if isinstance(params, dict) else "off"
-            ),
-            diagnostics=params.get("diagnostics", False) if isinstance(params, dict) else False,
+            # Legacy null semantics pinned: absent key OR explicit null maps
+            # to the legacy default (reset/clear), never keep-current.
+            api_key=_param(params, "apiKey", ""),
+            api_key_env=_param(params, "apiKeyEnv", ""),
+            max_results=_param(params, "maxResults", DEFAULT_SEARCH_MAX_RESULTS),
+            proxy=_param(params, "proxy", ""),
+            use_env_proxy=_param(params, "useEnvProxy", False),
+            fallback_policy=_param(params, "fallbackPolicy", "off"),
+            diagnostics=_param(params, "diagnostics", False),
         )
     _apply_inplace(ctx, res.config)
     _sync_search_provider(res.config)

--- a/src/opensquilla/migration/env_file.py
+++ b/src/opensquilla/migration/env_file.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import os
+import tempfile
+from pathlib import Path
+
 
 def env_line_key(text: str) -> str | None:
     stripped = text.strip()
@@ -28,3 +32,62 @@ def merge_env_lines(existing_lines: list[str], additions: dict[str, str]) -> lis
         if key not in consumed:
             lines.append(f"{key}={value}")
     return lines
+
+
+def write_secret_env_file(env_path: Path, lines: list[str]) -> None:
+    """Atomically write ``lines`` to ``env_path`` with owner-only permissions.
+
+    The temp file comes from ``mkstemp`` (created 0600 on POSIX) in the
+    destination directory, so the secret bytes never exist on disk with
+    umask-default permissions; ``os.replace`` then swaps it into place so a
+    crash mid-write cannot leave a truncated ``.env``. Failures propagate to
+    the caller after the temp file has been removed \u2014 a secret write that
+    cannot be completed securely must never be silently swallowed.
+
+    Two compatibility guarantees on top of the atomic swap:
+
+    - A symlinked ``env_path`` (dotfiles-managed setups) is resolved first so
+      the swap replaces the link *target*, not the link \u2014 mirroring the
+      write-through behavior of ``onboarding.config_store.persist_config``.
+    - When the containing directory is not writable (``mkstemp`` fails with
+      ``PermissionError``) but the file itself exists and is writable, the
+      write falls back to an in-place rewrite so previously-succeeding
+      migrations do not start failing partway through; the atomic guarantee
+      is best-effort in that degraded case.
+    """
+    target = env_path
+    if target.is_symlink():
+        target = target.resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    content = "\n".join(lines) + "\n"
+    try:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{target.name}.", suffix=".tmp", dir=str(target.parent)
+        )
+    except PermissionError:
+        if not target.is_file():
+            raise
+        # Directory not writable, file writable: preserve the pre-atomic
+        # behavior (plain in-place write) instead of failing the migration.
+        with target.open("w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.chmod(target, 0o600)
+        except OSError:
+            pass
+        return
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, target)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+

--- a/src/opensquilla/migration/env_file.py
+++ b/src/opensquilla/migration/env_file.py
@@ -90,4 +90,3 @@ def write_secret_env_file(env_path: Path, lines: list[str]) -> None:
         except OSError:
             pass
         raise
-

--- a/src/opensquilla/migration/hermes.py
+++ b/src/opensquilla/migration/hermes.py
@@ -14,7 +14,7 @@ from typing import Any, Literal
 import yaml
 
 from opensquilla.gateway.config import ChannelsConfig, GatewayConfig, MCPServerEntry
-from opensquilla.migration.env_file import merge_env_lines
+from opensquilla.migration.env_file import merge_env_lines, write_secret_env_file
 from opensquilla.onboarding.config_store import load_config, persist_config
 from opensquilla.paths import default_opensquilla_home
 
@@ -1050,9 +1050,8 @@ class HermesMigrator:
             if env_path.exists()
             else []
         )
-        env_path.write_text(
-            "\n".join(merge_env_lines(existing_lines, self._env_additions)) + "\n",
-            encoding="utf-8",
+        write_secret_env_file(
+            env_path, merge_env_lines(existing_lines, self._env_additions)
         )
 
     def _write_config(self) -> None:

--- a/src/opensquilla/migration/openclaw.py
+++ b/src/opensquilla/migration/openclaw.py
@@ -25,7 +25,7 @@ from opensquilla.gateway.config import (
     GatewayConfig,
     MCPServerEntry,
 )
-from opensquilla.migration.env_file import merge_env_lines
+from opensquilla.migration.env_file import merge_env_lines, write_secret_env_file
 from opensquilla.onboarding.config_store import load_config, persist_config
 from opensquilla.paths import default_opensquilla_home
 
@@ -2016,11 +2016,7 @@ class OpenClawMigrator:
             else []
         )
         lines = merge_env_lines(existing_lines, self._env_additions)
-        env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-        try:
-            os.chmod(env_path, 0o600)
-        except OSError:
-            pass
+        write_secret_env_file(env_path, lines)
 
     def _backup_file(self, path: Path) -> None:
         backup = path.with_name(f"{path.name}.backup.{self.timestamp}")

--- a/src/opensquilla/onboarding/channel_specs.py
+++ b/src/opensquilla/onboarding/channel_specs.py
@@ -220,8 +220,12 @@ def _wecom_spec() -> ChannelSetupSpec:
         ),
         fields=(
             *_common_fields(),
+            # The default must mirror ``WeComChannelEntry.connection_mode``:
+            # a headless entry that omits connection_mode is validated in the
+            # pydantic default mode, so an advertised minimal setup seeded
+            # from a diverging spec default would always fail validation.
             ChannelSetupField("connection_mode", "Connection mode", "select",
-                              required=False, default="websocket",
+                              required=False, default="webhook",
                               choices=("websocket", "webhook")),
             ChannelSetupField("bot_id", "Bot ID", "text", required=True,
                               group="credentials",

--- a/src/opensquilla/onboarding/config_store.py
+++ b/src/opensquilla/onboarding/config_store.py
@@ -1,15 +1,29 @@
-"""Config persistence: load/validate/atomic write with backup + 0600 mode."""
+"""Config persistence: load/validate/atomic sparse write with backup + 0600 mode.
+
+Persistence is diff-based: ``persist_config`` writes only the fields the
+caller actually changed, merged onto the current on-disk TOML. Values that
+merely reflect environment variables or built-in defaults (for example an
+``OPENSQUILLA_AUTH_TOKEN`` picked up by a pydantic-settings default factory)
+never leak into the file, small configs stay small, and non-conflicting
+concurrent edits made by another writer between load and persist survive.
+
+TOML comments are not preserved across a save: ``tomli_w`` has no comment
+support, so a save rewrites the file without them (pre-existing limitation).
+"""
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import tempfile
+import types
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Union, get_args, get_origin
 
 import tomli_w
+from pydantic import BaseModel
 
 try:
     import tomllib  # py311+
@@ -25,6 +39,33 @@ from opensquilla.gateway.config_migration import (
 from opensquilla.paths import default_opensquilla_home
 
 log = logging.getLogger(__name__)
+
+# Persist baselines are INSTANCE-scoped: load_config (and persist_config)
+# snapshot the model's TOML dump onto the GatewayConfig object itself
+# (``_persist_baseline``), so a save diffs exactly what the caller mutated
+# since ITS load. A path-keyed global registry is deliberately avoided: two
+# live objects for the same file would overwrite each other's snapshot, and
+# the second object's save would diff against the first one's post-persist
+# state — silently reverting (and baking in) the other writer's changes.
+
+# Top-level fields that record runtime provenance rather than operator
+# choices; they are never diffed into the persisted file (whatever the raw
+# file already contains for them is left untouched).
+_NON_PERSISTED_TOP_LEVEL_FIELDS = frozenset({"config_path"})
+
+
+class _Removed:
+    """Sentinel diff node: the key exists in the baseline but not anymore."""
+
+
+_REMOVED = _Removed()
+
+
+@dataclass(frozen=True)
+class _SetValue:
+    """Diff leaf: replace the raw value wholesale with ``value``."""
+
+    value: Any
 
 
 @dataclass(frozen=True)
@@ -61,13 +102,62 @@ def _resolve_path(path: str | Path | None) -> Path:
     return resolve_config_path(path)[0]
 
 
+def _raw_key_present(raw: Any, path: str) -> bool:
+    current = raw
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return False
+        current = current[part]
+    return True
+
+
+# Nested credential fields whose sections are pydantic-settings models: the
+# environment can absorb a value into them at load (e.g.
+# ``OPENSQUILLA_AUDIO_PROVIDERS__ELEVENLABS__API_KEY``). Each entry is marked
+# as a runtime secret when the raw TOML did not supply it, mirroring
+# ``llm.api_key``/``search_api_key`` — without the mark an explicit user
+# entry equal to the env value diffs as unchanged and is silently dropped
+# from the file (the mutations' ``clear_runtime_secret_paths`` calls for
+# these exact paths are what make an explicit entry stick).
+_ENV_ABSORBED_NESTED_SECRET_SECTIONS = (
+    ("audio.providers", "api_key"),
+    ("image_generation.providers", "api_key"),
+)
+
+
+def _mark_env_absorbed_runtime_secrets(cfg: GatewayConfig, raw: Any) -> None:
+    """Mark credentials that exist on the model only because env supplied them.
+
+    ``raw`` is the TOML payload as read from disk (``None``/``{}`` for a
+    missing file). A non-empty credential absent from ``raw`` can only have
+    come from the environment; marking it keeps it out of the persist
+    baseline so explicit entries — even ones equal to the env value — are
+    written to the file, while env-only values never leak into it.
+    """
+    if cfg.llm.api_key and not _raw_key_present(raw, "llm.api_key"):
+        cfg.mark_runtime_secret("llm.api_key")
+    if cfg.search_api_key and not _raw_key_present(raw, "search_api_key"):
+        cfg.mark_runtime_secret("search_api_key")
+    for section_path, key in _ENV_ABSORBED_NESTED_SECRET_SECTIONS:
+        section: Any = cfg
+        for part in section_path.split("."):
+            section = getattr(section, part, None)
+        if not isinstance(section, BaseModel):
+            continue
+        for provider_name in type(section).model_fields:
+            path = f"{section_path}.{provider_name}.{key}"
+            provider_cfg = getattr(section, provider_name, None)
+            if getattr(provider_cfg, key, "") and not _raw_key_present(raw, path):
+                cfg.mark_runtime_secret(path)
+
+
 def load_config(path: str | Path | None = None) -> GatewayConfig:
     target = _resolve_path(path)
     if not target.exists():
         cfg = GatewayConfig()
-        if cfg.llm.api_key:
-            cfg.mark_runtime_secret("llm.api_key")
+        _mark_env_absorbed_runtime_secrets(cfg, None)
         cfg.config_path = str(target)
+        _remember_load_baseline(cfg)
         return cfg
     with target.open("rb") as fh:
         data = tomllib.load(fh)
@@ -75,13 +165,9 @@ def load_config(path: str | Path | None = None) -> GatewayConfig:
     cfg = GatewayConfig.model_validate(migration.payload)
     if migration.changed:
         backup_and_write_migrated_config(target, migration.payload, migration)
-    llm_payload = data.get("llm") if isinstance(data, dict) else None
-    if (
-        (not isinstance(llm_payload, dict) or "api_key" not in llm_payload)
-        and cfg.llm.api_key
-    ):
-        cfg.mark_runtime_secret("llm.api_key")
+    _mark_env_absorbed_runtime_secrets(cfg, data)
     cfg.config_path = str(target)
+    _remember_load_baseline(cfg)
     return cfg
 
 
@@ -104,13 +190,199 @@ def _toml_safe(value: Any) -> Any:
     return str(value)
 
 
-def _config_to_toml_dict(cfg: GatewayConfig) -> dict[str, Any]:
+def _model_toml_payload(cfg: GatewayConfig) -> dict[str, Any]:
+    """Return the model's TOML-oriented dump (pre-coercion python values)."""
     raw = cfg.to_toml_dict() if hasattr(cfg, "to_toml_dict") else cfg.model_dump(
         mode="python", exclude_none=True
     )
-    coerced = _toml_safe(raw)
+    assert isinstance(raw, dict)
+    return raw
+
+
+def _config_to_toml_dict(cfg: GatewayConfig) -> dict[str, Any]:
+    """Full TOML-safe dump of a config (diagnostic/round-trip helper)."""
+    coerced = _toml_safe(_model_toml_payload(cfg))
     assert isinstance(coerced, dict)
     return coerced
+
+
+def _remember_load_baseline(cfg: GatewayConfig) -> None:
+    cfg._persist_baseline = copy.deepcopy(_model_toml_payload(cfg))
+
+
+def _get_dotted(obj: dict[str, Any], path: str) -> Any:
+    current: Any = obj
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _set_dotted(obj: dict[str, Any], path: str, value: Any) -> None:
+    parts = path.split(".")
+    current = obj
+    for part in parts[:-1]:
+        child = current.get(part)
+        if not isinstance(child, dict):
+            child = {}
+            current[part] = child
+        current = child
+    current[parts[-1]] = value
+
+
+def _restore_runtime_overrides(dump: dict[str, Any], config: GatewayConfig) -> None:
+    """Undo in-place runtime env resolutions before diffing for persist.
+
+    ``resolve_llm_runtime_config`` writes provider env overrides (e.g.
+    ``OPENAI_BASE_URL`` -> ``llm.base_url``, ``OPENSQUILLA_LLM_PROXY`` ->
+    ``llm.proxy``) directly into the live model at boot. Those values must
+    never be baked into config.toml by an unrelated save, so each recorded
+    override is restored to its stored value — but only while the field
+    still equals the applied env value; an operator edit since boot wins.
+    """
+    overrides = getattr(config, "runtime_field_overrides", None)
+    if overrides is None:
+        return
+    for path, (stored, applied) in overrides().items():
+        if _get_dotted(dump, path) == applied:
+            _set_dotted(dump, path, stored)
+
+
+def _submodel_class(model_cls: type[BaseModel] | None, key: str) -> type[BaseModel] | None:
+    """Return the BaseModel subclass behind ``key`` on ``model_cls``, if any.
+
+    Used to decide whether a mapping in the dump is a schema-backed section
+    (safe to diff per key: absent keys re-resolve from field defaults/env) or
+    a free-form dict value (must be replaced wholesale: a partial write would
+    change how the whole value resolves on the next load).
+    """
+    if model_cls is None:
+        return None
+    fld = model_cls.model_fields.get(key)
+    if fld is None:
+        return None
+    ann = fld.annotation
+    candidates = get_args(ann) if get_origin(ann) in (Union, types.UnionType) else (ann,)
+    for candidate in candidates:
+        if isinstance(candidate, type) and issubclass(candidate, BaseModel):
+            return candidate
+    return None
+
+
+def _diff_payload(
+    current: dict[str, Any],
+    baseline: dict[str, Any],
+    model_cls: type[BaseModel] | None,
+) -> dict[str, Any]:
+    """Recursively diff two model dumps.
+
+    Returns a mapping whose values are ``_SetValue`` (write wholesale),
+    ``_REMOVED`` (drop the key), or a nested diff mapping for schema-backed
+    sections whose dict values changed only partially. Free-form dict values
+    (e.g. router tier tables) are treated as leaves and replaced wholesale so
+    the persisted value never depends on a default factory filling in the
+    untouched part.
+    """
+    diff: dict[str, Any] = {}
+    for key, cur in current.items():
+        if key not in baseline:
+            diff[key] = _SetValue(cur)
+            continue
+        base = baseline[key]
+        sub_cls = _submodel_class(model_cls, key)
+        if sub_cls is not None and isinstance(cur, dict) and isinstance(base, dict):
+            sub = _diff_payload(cur, base, sub_cls)
+            if sub:
+                diff[key] = sub
+        elif cur != base:
+            diff[key] = _SetValue(cur)
+    for key in baseline:
+        if key not in current:
+            diff[key] = _REMOVED
+    return diff
+
+
+def _merge_diff(base: dict[str, Any], diff: dict[str, Any]) -> None:
+    """Apply a ``_diff_payload`` result onto a raw TOML mapping in place.
+
+    Raw keys not named by the diff are left untouched, so values another
+    writer put on disk (or hand-edits the model never saw) survive a save.
+    """
+    for key, node in diff.items():
+        if isinstance(node, _SetValue):
+            base[key] = _toml_safe(node.value)
+        elif isinstance(node, _Removed):
+            base.pop(key, None)
+        else:  # nested diff mapping
+            child = base.get(key)
+            if isinstance(child, dict):
+                _merge_diff(child, node)
+                continue
+            fresh: dict[str, Any] = {}
+            _merge_diff(fresh, node)
+            if fresh:
+                base[key] = fresh
+
+
+def _persist_plan(
+    target: Path, config: GatewayConfig, *, use_instance_baseline: bool
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return ``(baseline_dump, merge_base)`` for a sparse persist.
+
+    ``merge_base`` is the current on-disk TOML (migrated, empty if absent or
+    unusable); the caller merges the current-vs-baseline diff onto it. The
+    baseline is, in order of preference: the snapshot carried by the config
+    instance itself (captured at ``load_config`` or the instance's previous
+    persist — the diff is exactly what THIS caller changed), a model rebuilt
+    from the on-disk TOML the same way ``load_config`` would build it, or a
+    fresh env/default model when the on-disk state is missing or unusable.
+
+    ``use_instance_baseline`` is False for a save-as (the config is being
+    persisted to a path other than the one it was loaded from): diffing a
+    different target against the instance's own load snapshot would erase
+    every loaded value from the copy, so those saves fall through to the
+    disk/default baselines exactly like a config that was never loaded.
+    """
+    instance_baseline = (
+        getattr(config, "_persist_baseline", None) if use_instance_baseline else None
+    )
+    raw: dict[str, Any] | None = None
+    disk_usable = True
+    if target.is_file():
+        try:
+            with target.open("rb") as fh:
+                raw = tomllib.load(fh)
+        except (tomllib.TOMLDecodeError, ValueError) as exc:
+            disk_usable = False
+            log.warning(
+                "onboarding.config_persist_unreadable_toml path=%s error=%s; "
+                "rewriting from the in-memory config",
+                str(target),
+                exc,
+            )
+    if raw is not None:
+        migration = migrate_config_payload(raw)
+        try:
+            disk_model = GatewayConfig.model_validate(migration.payload)
+        except Exception as exc:
+            disk_usable = False
+            log.warning(
+                "onboarding.config_persist_invalid_existing path=%s error=%s; "
+                "rewriting from the in-memory config",
+                str(target),
+                type(exc).__name__,
+            )
+        else:
+            if instance_baseline is not None:
+                return copy.deepcopy(instance_baseline), migration.payload
+            return _model_toml_payload(disk_model), migration.payload
+
+    merge_base = migrate_config_payload({}).payload
+    if disk_usable and instance_baseline is not None:
+        # target file simply does not exist yet
+        return copy.deepcopy(instance_baseline), merge_base
+    return _model_toml_payload(GatewayConfig()), merge_base
 
 
 def persist_config(
@@ -120,11 +392,35 @@ def persist_config(
     backup: bool = True,
     restart_required: bool = False,
 ) -> PersistResult:
-    payload = _config_to_toml_dict(config)
-    # Re-validate to catch any invariant breakage that survived model_dump.
-    GatewayConfig.model_validate(payload)
+    resolved = _resolve_path(path)
+    # The instance baseline only describes the file the config was loaded
+    # from; a save-as to a different path must not diff against it.
+    same_path = config.config_path == str(resolved)
+    target = resolved
+    if target.is_symlink():
+        # Write through the symlink: update the real file in place so the
+        # link (and anything else resolving through it) survives the swap.
+        target = target.resolve()
 
-    target = _resolve_path(path)
+    baseline_dump, merged = _persist_plan(target, config, use_instance_baseline=same_path)
+    current_dump = _model_toml_payload(config)
+    _restore_runtime_overrides(current_dump, config)
+    diff = _diff_payload(current_dump, baseline_dump, GatewayConfig)
+    for provenance_key in _NON_PERSISTED_TOP_LEVEL_FIELDS:
+        diff.pop(provenance_key, None)
+    _merge_diff(merged, diff)
+    # Force-persisted paths (explicit mutations that may equal the model
+    # default, e.g. a deliberate image_generation.enabled = false on a fresh
+    # config) are written regardless of the diff so the decision survives in
+    # the file for keep-current logic to see on the next load.
+    for force_path in sorted(getattr(config, "_force_persist_paths", set()) or set()):
+        forced_value = _get_dotted(current_dump, force_path)
+        if forced_value is not None:
+            _set_dotted(merged, force_path, _toml_safe(forced_value))
+
+    # Re-validate to catch any invariant breakage that survived model_dump.
+    GatewayConfig.model_validate(copy.deepcopy(merged))
+
     target.parent.mkdir(parents=True, exist_ok=True)
 
     backup_path: Path | None = None
@@ -136,7 +432,12 @@ def persist_config(
     )
     try:
         with os.fdopen(fd, "wb") as fh:
-            tomli_w.dump(payload, fh)
+            tomli_w.dump(merged, fh)
+            # Flush user-space buffers and force the temp file to stable
+            # storage before the rename, so a power loss cannot leave a
+            # truncated config behind the atomic swap.
+            fh.flush()
+            os.fsync(fh.fileno())
         os.chmod(tmp_name, 0o600)
         os.replace(tmp_name, target)
     except Exception:
@@ -147,6 +448,16 @@ def persist_config(
         raise
 
     os.chmod(target, 0o600)
+
+    # The file now reflects this instance's state: refresh the instance's
+    # baseline so a later save of the same object diffs against what was
+    # just written instead of the original load snapshot. (current_dump has
+    # runtime overrides restored, matching what a fresh load would see.)
+    # A save-as leaves the baseline alone — the instance still describes the
+    # file it was loaded from, and a later save back there must diff against
+    # THAT snapshot, not the copy's contents.
+    if same_path:
+        config._persist_baseline = copy.deepcopy(current_dump)
 
     log.debug(
         "onboarding.config_persisted path=%s backup=%s restart_required=%s",

--- a/src/opensquilla/onboarding/flow.py
+++ b/src/opensquilla/onboarding/flow.py
@@ -59,6 +59,7 @@ from opensquilla.onboarding.search_specs import (
     get_search_provider_setup_spec,
     list_search_provider_setup_specs,
 )
+from opensquilla.onboarding.section_status import SECTION_STATUS_DISPLAY
 from opensquilla.onboarding.setup_engine import (
     ENSEMBLE_SECTION_ALIASES,
     IMAGE_GENERATION_SECTION_ALIASES,
@@ -296,7 +297,15 @@ def _ask_provider_choice(questionary, options: OnboardOptions):
     choices = [f"{s.provider_id} ({s.label})" for s in supported]
     default = next((choice for choice in choices if choice.startswith("openrouter ")), None)
     pid = _ask_or_cancel(
-        questionary.select("LLM provider", choices=choices, default=default),
+        questionary.select(
+            "LLM provider",
+            choices=choices,
+            default=default,
+            # ~30 entries: let the operator type to filter instead of
+            # arrowing through the list (requires questionary >= 2.1).
+            use_search_filter=True,
+            use_jk_keys=False,
+        ),
         section="provider",
     )
     pid_clean = pid.split(" ")[0]
@@ -2427,6 +2436,106 @@ def _ensure_config_dir_writable(config_path: str | Path | None) -> None:
         raise SystemExit(2) from exc
 
 
+_ONBOARD_UPDATE_CHOICE = "Update settings (keep current values as defaults)"
+_ONBOARD_SECTIONS_CHOICE = "Change specific sections"
+_ONBOARD_RESET_CHOICE = "Start fresh (back up current config first)"
+
+
+def _is_full_interactive_rerun(options: OnboardOptions) -> bool:
+    """True only for a plain `opensquilla onboard` over a working install.
+
+    Scoped invocations (configure provider re-runs, --if-needed, --minimal,
+    any skip flag, or headless-shaped provider/model/key options) keep the
+    linear walk so their pinned prompt sequences stay unchanged.
+    """
+    return not (
+        options.if_needed
+        or options.minimal
+        or options.skip_migration
+        or options.skip_channels
+        or options.skip_search
+        or options.skip_image_generation
+        or options.provider_id
+        or options.model
+        or options.api_key
+        or options.api_key_env
+        or options.base_url
+        or options.proxy
+    )
+
+
+def _ask_existing_setup_action(
+    questionary,
+    cfg,
+    status,
+    options: OnboardOptions,
+) -> str | None:
+    """Re-run fork: 'update' (linear walk), 'sections' (hub), or 'reset'.
+
+    Returns ``None`` when the fork does not apply (fresh install, unfinished
+    setup, or a scoped run) — the caller then proceeds exactly as before.
+    Declining the reset confirmation falls back to 'update' rather than
+    aborting; Esc anywhere cancels the whole run like every wizard prompt.
+    """
+    if not status.has_config or not status.llm_configured:
+        return None
+    if not _is_full_interactive_rerun(options):
+        return None
+    resolved, _source = resolve_config_path(options.config_path)
+    provider = str(getattr(cfg.llm, "provider", "") or "")
+    model = str(getattr(cfg.llm, "model", "") or "")
+    router_word = "SquillaRouter" if cfg.squilla_router.enabled else "router disabled"
+    llm_part = f"{provider} / {model}".strip(" /")
+    summary = " · ".join(part for part in (llm_part, router_word) if part)
+    console.print(
+        f"[{ACCENT_DIM}]Existing setup detected:[/] [{ACCENT_SOFT}]{markup_escape(summary)}[/]"
+        f" [dim]({markup_escape(str(resolved))})[/dim]"
+    )
+    choice = _ask_or_cancel(
+        questionary.select(
+            "This install is already configured — what would you like to do?",
+            choices=[
+                _ONBOARD_UPDATE_CHOICE,
+                _ONBOARD_SECTIONS_CHOICE,
+                _ONBOARD_RESET_CHOICE,
+            ],
+            default=_ONBOARD_UPDATE_CHOICE,
+        ),
+        section="onboard",
+    )
+    if choice == _ONBOARD_SECTIONS_CHOICE:
+        return "sections"
+    if choice == _ONBOARD_RESET_CHOICE:
+        confirmed = _ask_or_cancel(
+            questionary.confirm(
+                f"Back up {resolved} and restart setup from defaults?",
+                default=False,
+            ),
+            section="onboard",
+        )
+        return "reset" if confirmed else "update"
+    return "update"
+
+
+def _backup_and_reset_config(config_path: str | Path | None) -> None:
+    """Move the existing config aside (never delete) before a fresh walk."""
+    import time as _time
+
+    resolved, _source = resolve_config_path(config_path)
+    if not resolved.exists():
+        return
+    stamp = _time.strftime("%Y%m%d-%H%M%S")
+    backup = resolved.with_name(f"{resolved.name}.bak-{stamp}")
+    counter = 0
+    while backup.exists():
+        counter += 1
+        backup = resolved.with_name(f"{resolved.name}.bak-{stamp}-{counter}")
+    os.replace(resolved, backup)
+    console.print(
+        f"[dim]Backed up existing config to {markup_escape(str(backup))}[/dim]"
+    )
+
+
 def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
     cfg = load_config(options.config_path)
     status = get_onboarding_status(cfg)
@@ -2467,6 +2576,22 @@ def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
         )
 
     config_path = _config_path_from_loaded_config(cfg)
+    rerun_action = _ask_existing_setup_action(questionary, cfg, status, options)
+    if rerun_action == "sections":
+        hub_result = _run_configure_hub(questionary, config_path=options.config_path)
+        if hub_result is not None:
+            return hub_result
+        return persist_config(
+            load_config(options.config_path),
+            path=options.config_path,
+            restart_required=False,
+            backup=False,
+        )
+    if rerun_action == "reset":
+        _backup_and_reset_config(options.config_path)
+        cfg = load_config(options.config_path)
+        status = get_onboarding_status(cfg)
+
     migration_result: Any | None = None
     if not options.skip_migration:
         migration_result = _run_onboard_migration_step(
@@ -2807,6 +2932,89 @@ def run_interactive_channel_edit(
     return persisted
 
 
+_CONFIGURE_MENU_SECTIONS: tuple[tuple[str, str, str], ...] = (
+    # (menu label, configure slug, key in OnboardingStatus.sections)
+    ("Provider", "provider", "llm"),
+    ("Router", "router", "router"),
+    ("Ensemble", "ensemble", "ensemble"),
+    ("Channels", "channels", "channels"),
+    ("Web search", "search", "search"),
+    ("Image generation", "image-generation", "image_generation"),
+    ("Memory embedding", "memory-embedding", "memory_embedding"),
+)
+
+
+def _merge_persist_results(
+    previous: PersistResult | None, latest: PersistResult
+) -> PersistResult:
+    """Fold one hub section's save into the running result.
+
+    The hub can persist several sections in one sitting; the CLI boundary
+    prints restart guidance from a single ``PersistResult``, so the flag must
+    stay sticky once any section required a restart.
+    """
+    if previous is None:
+        return latest
+    merged_warnings = list(previous.warnings)
+    merged_warnings.extend(w for w in latest.warnings if w not in merged_warnings)
+    return PersistResult(
+        path=latest.path,
+        backup_path=latest.backup_path or previous.backup_path,
+        restart_required=previous.restart_required or latest.restart_required,
+        warnings=merged_warnings,
+    )
+
+
+def _run_configure_hub(
+    questionary,
+    *,
+    config_path: str | Path | None = None,
+) -> PersistResult | None:
+    """Menu loop over the configure sections: edit one, return to the menu.
+
+    Each section persists as soon as it completes, so progress survives a
+    later cancel. Cancelling INSIDE a section returns to the menu (the
+    section is simply left unchanged); cancelling AT the menu raises
+    ``UserCancelledError`` like every other wizard prompt — "Done" is the
+    graceful exit.
+    """
+    console.print(
+        f"[{ACCENT_DIM}]Voice audio is configured from the Web UI setup page; "
+        "`opensquilla onboard catalog audio` lists the options.[/]"
+    )
+    aggregated: PersistResult | None = None
+    while True:
+        status = get_onboarding_status(load_config(config_path))
+        title_to_slug: dict[str, str] = {}
+        choices: list[str] = []
+        for label, slug, status_key in _CONFIGURE_MENU_SECTIONS:
+            state = status.sections.get(status_key)
+            word = SECTION_STATUS_DISPLAY.get(state, "") if state is not None else ""
+            title = f"{label} — {word}" if word else label
+            title_to_slug[title] = slug
+            choices.append(title)
+        done_title = "Done" if aggregated is not None else "Exit (nothing changed)"
+        choices.append(done_title)
+        picked = _ask_or_cancel(
+            questionary.select("Section", choices=choices),
+            section="configure",
+        )
+        picked_slug = title_to_slug.get(picked)
+        if picked_slug is None:
+            return aggregated
+        try:
+            result = _run_configure_section(
+                picked_slug, questionary, config_path=config_path
+            )
+        except UserCancelledError:
+            console.print(
+                f"[dim]{picked_slug} left unchanged — back to the section menu.[/dim]"
+            )
+            continue
+        if result is not None:
+            aggregated = _merge_persist_results(aggregated, result)
+
+
 def run_interactive_configure(
     section: str | None = None,
     *,
@@ -2820,21 +3028,19 @@ def run_interactive_configure(
     import questionary as _qmod
     questionary = _styled(_qmod)
 
-    section = section or _ask_or_cancel(
-        questionary.select(
-            "Section",
-            choices=[
-                "provider",
-                "router",
-                "ensemble",
-                "channels",
-                "search",
-                "image-generation",
-                "memory-embedding",
-            ],
-        ),
-        section="configure",
-    )
+    if section is not None:
+        # Explicit section: one-shot edit, exactly like `configure <section>`
+        # has always behaved.
+        return _run_configure_section(section, questionary, config_path=config_path)
+    return _run_configure_hub(questionary, config_path=config_path)
+
+
+def _run_configure_section(
+    section: str,
+    questionary,
+    *,
+    config_path: str | Path | None = None,
+) -> PersistResult | None:
     if section in {"provider", "providers"}:
         # A scoped provider re-run: swapping a key must not re-trigger the
         # legacy-migration pre-step or the optional capability prompts the

--- a/src/opensquilla/onboarding/flow.py
+++ b/src/opensquilla/onboarding/flow.py
@@ -8,6 +8,7 @@ import os
 import re
 import shlex
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -23,6 +24,7 @@ from opensquilla.onboarding.config_store import (
     default_config_path,
     load_config,
     persist_config,
+    resolve_config_path,
 )
 from opensquilla.onboarding.errors import UserCancelledError
 from opensquilla.onboarding.image_generation_specs import (
@@ -56,6 +58,11 @@ from opensquilla.onboarding.provider_specs import (
 from opensquilla.onboarding.search_specs import (
     get_search_provider_setup_spec,
     list_search_provider_setup_specs,
+)
+from opensquilla.onboarding.setup_engine import (
+    ENSEMBLE_SECTION_ALIASES,
+    IMAGE_GENERATION_SECTION_ALIASES,
+    MEMORY_EMBEDDING_SECTION_ALIASES,
 )
 from opensquilla.onboarding.setup_paths import web_setup_url
 from opensquilla.onboarding.status import get_onboarding_status
@@ -202,39 +209,6 @@ def run_noninteractive_provider_configure(
     return engine.persist()
 
 
-def run_noninteractive_channel_add(
-    type_name: str,
-    values: dict[str, Any],
-    *,
-    path: str | Path | None = None,
-) -> PersistResult:
-    cfg = load_config(path)
-    payload = {"type": type_name, **values}
-    result = upsert_channel(cfg, entry_payload=payload)
-    return persist_config(result.config, path=path, restart_required=True)
-
-
-def run_noninteractive_search_configure(
-    provider_id: str,
-    values: dict[str, Any],
-    *,
-    path: str | Path | None = None,
-) -> PersistResult:
-    cfg = load_config(path)
-    result = upsert_search_provider(
-        cfg,
-        provider_id=provider_id,
-        api_key=values.get("api_key", ""),
-        api_key_env=values.get("api_key_env", ""),
-        max_results=int(values.get("max_results", DEFAULT_SEARCH_MAX_RESULTS)),
-        proxy=values.get("proxy", ""),
-        use_env_proxy=bool(values.get("use_env_proxy", False)),
-        fallback_policy=values.get("fallback_policy", "off"),
-        diagnostics=bool(values.get("diagnostics", False)),
-    )
-    return persist_config(result.config, path=path, restart_required=False)
-
-
 def _config_cli_arg(config_path: str | Path | None) -> str:
     if config_path is None:
         return ""
@@ -374,6 +348,18 @@ def _api_key_source_default(env_key: str) -> str:
     return _PASTE_API_KEY_CHOICE
 
 
+def _secret_paste_error(value: str) -> str | None:
+    stripped = str(value or "").strip()
+    if _TERMINAL_ESCAPE_RE.search(stripped) or _LEADING_TERMINAL_KEY_RE.search(
+        stripped
+    ):
+        return (
+            "Paste was not read correctly by this terminal. Use right-click, "
+            "Shift+Insert, or the environment variable option."
+        )
+    return None
+
+
 def _secret_value_validator(label: str):
     required = _required_value(label)
 
@@ -381,14 +367,71 @@ def _secret_value_validator(label: str):
         result = cast(bool | str, required(value))
         if result is not True:
             return result
+        paste_error = _secret_paste_error(value)
+        if paste_error is not None:
+            return paste_error
+        return True
+
+    return _validate
+
+
+def _secret_keep_current_validator(label: str):
+    """Secret validator for edit prompts: blank keeps the stored value."""
+
+    def _validate(value: str) -> bool | str:
+        if not str(value or "").strip():
+            return True
+        paste_error = _secret_paste_error(value)
+        if paste_error is not None:
+            return paste_error
+        return True
+
+    return _validate
+
+
+def _int_value_validator(label: str, *, minimum: int | None = None):
+    """Re-prompt on non-numeric input instead of crashing at ``int()`` time.
+
+    Blank input stays valid — callers coerce it to their own default, so an
+    accepted-as-is Enter keeps the quick-start path free of new friction.
+    """
+
+    def _validate(value: str) -> bool | str:
         stripped = str(value or "").strip()
-        if _TERMINAL_ESCAPE_RE.search(stripped) or _LEADING_TERMINAL_KEY_RE.search(
-            stripped
-        ):
-            return (
-                "Paste was not read correctly by this terminal. Use right-click, "
-                "Shift+Insert, or the environment variable option."
-            )
+        if not stripped:
+            return True
+        try:
+            parsed = int(stripped)
+        except ValueError:
+            return f"{label} must be a whole number"
+        if minimum is not None and parsed < minimum:
+            return f"{label} must be at least {minimum}"
+        return True
+
+    return _validate
+
+
+def _float_value_validator(label: str):
+    def _validate(value: str) -> bool | str:
+        stripped = str(value or "").strip()
+        if not stripped:
+            return True
+        try:
+            float(stripped)
+        except ValueError:
+            return f"{label} must be a number"
+        return True
+
+    return _validate
+
+
+def _base_url_validator(label: str = "Base URL"):
+    def _validate(value: str) -> bool | str:
+        stripped = str(value or "").strip()
+        if not stripped:
+            return f"{label} is required for this provider"
+        if not stripped.lower().startswith(("http://", "https://")):
+            return f"{label} must start with http:// or https://"
         return True
 
     return _validate
@@ -403,10 +446,26 @@ def _search_api_key_prompt(spec) -> str:
     return "Search API key"
 
 
+def _stored_llm_entry(config: Any, provider_id: str) -> Any | None:
+    """Return ``config.llm`` when it already holds this provider's entry.
+
+    A wizard re-run must seed prompt defaults from what the operator stored
+    last time, not from spec defaults — otherwise accepting the defaults
+    silently wipes a custom ``base_url``/``proxy``.
+    """
+    llm = getattr(config, "llm", None)
+    if str(getattr(llm, "provider", "") or "") == provider_id:
+        return llm
+    return None
+
+
 def _ask_provider_fields(
-    questionary, spec, options: OnboardOptions
+    questionary, spec, options: OnboardOptions, *, config: Any = None
 ) -> dict[str, Any]:
     answers: dict[str, Any] = {}
+    stored = _stored_llm_entry(config, spec.provider_id) if config is not None else None
+    stored_base_url = str(getattr(stored, "base_url", "") or "")
+    stored_proxy = str(getattr(stored, "proxy", "") or "")
     # Resolve credentials and endpoint BEFORE the model so an optional live
     # discovery can enumerate the candidate provider's models for the picker.
     if spec.requires_api_key:
@@ -418,11 +477,14 @@ def _ask_provider_fields(
             answers["api_key"] = ""
             answers["api_key_env"] = options.api_key_env
         else:
-            key_source = questionary.select(
-                "LLM API key source",
-                choices=_api_key_source_choices(env_key or ""),
-                default=_api_key_source_default(env_key or ""),
-            ).ask()
+            key_source = _ask_or_cancel(
+                questionary.select(
+                    "LLM API key source",
+                    choices=_api_key_source_choices(env_key or ""),
+                    default=_api_key_source_default(env_key or ""),
+                ),
+                section="provider",
+            )
             selected_env_key = _api_key_env_from_choice(key_source or "")
             answers["api_key_env"] = selected_env_key
             answers["api_key"] = ""
@@ -439,20 +501,52 @@ def _ask_provider_fields(
         answers["api_key"] = options.api_key or ""
         answers["api_key_env"] = ""
     if spec.requires_base_url:
-        answers["base_url"] = options.base_url or (
-            questionary.text("Base URL", default=spec.default_base_url).ask() or ""
-        )
+        answers["base_url"] = options.base_url or str(
+            _ask_or_cancel(
+                questionary.text(
+                    "Base URL",
+                    default=stored_base_url or spec.default_base_url,
+                    validate=_base_url_validator("Base URL"),
+                ),
+                section="provider",
+            )
+        ).strip()
     else:
-        answers["base_url"] = options.base_url or spec.default_base_url
-    answers["proxy"] = options.proxy or ""
+        answers["base_url"] = options.base_url or stored_base_url or spec.default_base_url
+    answers["proxy"] = options.proxy or stored_proxy
 
     if options.model:
         answers["model"] = options.model
     elif getattr(spec, "router_supported", False):
+        _verify_router_provider_connection(questionary, spec, answers)
         answers["model"] = ""
     else:
         answers["model"] = _ask_direct_provider_model(questionary, spec, answers)
     return answers
+
+
+def _quiet_provider_logs():
+    """Silence structlog output while a wizard-run probe/discovery is in flight.
+
+    The provider layer logs request/response details at debug/warning level.
+    The wizard process leaves structlog unconfigured, so those records would
+    print raw into the interactive prompt stream; the probe outcome is already
+    surfaced to the user through the redacted result panel.
+    """
+    import contextlib
+
+    import structlog
+
+    @contextlib.contextmanager
+    def _suppressed():
+        saved = structlog.get_config()
+        structlog.configure(logger_factory=structlog.ReturnLoggerFactory())
+        try:
+            yield
+        finally:
+            structlog.configure(**saved)
+
+    return _suppressed()
 
 
 def _run_provider_probe(
@@ -476,16 +570,17 @@ def _run_provider_probe(
     from opensquilla.onboarding.probe import probe_llm_provider
 
     try:
-        return asyncio.run(
-            probe_llm_provider(
-                provider_id=provider_id,
-                model=model,
-                api_key=api_key,
-                api_key_env=api_key_env,
-                base_url=base_url,
-                proxy=proxy,
+        with _quiet_provider_logs():
+            return asyncio.run(
+                probe_llm_provider(
+                    provider_id=provider_id,
+                    model=model,
+                    api_key=api_key,
+                    api_key_env=api_key_env,
+                    base_url=base_url,
+                    proxy=proxy,
+                )
             )
-        )
     except Exception:  # noqa: BLE001 - verification is best-effort, never fatal
         return None
 
@@ -508,15 +603,16 @@ def _run_provider_discovery(
     from opensquilla.onboarding.probe import discover_provider_models
 
     try:
-        return asyncio.run(
-            discover_provider_models(
-                provider_id=provider_id,
-                api_key=api_key,
-                api_key_env=api_key_env,
-                base_url=base_url,
-                proxy=proxy,
+        with _quiet_provider_logs():
+            return asyncio.run(
+                discover_provider_models(
+                    provider_id=provider_id,
+                    api_key=api_key,
+                    api_key_env=api_key_env,
+                    base_url=base_url,
+                    proxy=proxy,
+                )
             )
-        )
     except Exception:  # noqa: BLE001 - discovery is best-effort, never fatal
         return None
 
@@ -537,7 +633,17 @@ def _discovered_model_label(model: dict[str, Any]) -> str:
 
 
 def _prompt_free_text_model(questionary) -> str:
-    return questionary.text("Model id").ask() or ""
+    # Non-empty validation: providers without a derivable default model raise
+    # "model is required" deep in the mutation layer, so an empty submit must
+    # re-prompt here instead of surfacing a raw error after the operator has
+    # already typed the API key.
+    return str(
+        _ask_or_cancel(
+            questionary.text("Model id", validate=_required_value("Model id")),
+            section="provider",
+        )
+        or ""
+    )
 
 
 def _ask_direct_provider_model(questionary, spec, answers: dict[str, Any]) -> str:
@@ -633,6 +739,45 @@ def _confirm_save_after_failed_check(questionary, spec, detail: str) -> bool:
     )
 
 
+def _verify_router_provider_connection(questionary, spec, answers: dict[str, Any]) -> None:
+    """Pre-save connection check for router-supported providers.
+
+    A router-driven provider never types a direct model, so the free-text
+    verify/discover path never runs for it — historically a bad API key
+    surfaced only as an HTTP error in the middle of the first chat. The save
+    applies the provider's router tier profile, and the spec's
+    ``default_direct_model`` is that profile's default-tier model — i.e. the
+    model the first routed turn will actually use — so probe with it.
+
+    The UX mirrors the direct-provider check exactly: a failed probe surfaces
+    the redacted detail plus the default-yes "Save anyway?" escape, an
+    unattemptable probe (``None``) degrades silently, and a spec without a
+    determinable model (or without probe support) keeps the old behavior of
+    verifying nothing.
+    """
+    if not getattr(spec, "can_probe", False):
+        return
+    probe_model = str(getattr(spec, "default_direct_model", "") or "").strip()
+    if not probe_model:
+        return
+    console.print("[dim]Checking the connection…[/dim]")
+    probe = _run_provider_probe(
+        provider_id=spec.provider_id,
+        model=probe_model,
+        api_key=answers.get("api_key", ""),
+        api_key_env=answers.get("api_key_env", ""),
+        base_url=answers.get("base_url", ""),
+        proxy=answers.get("proxy", ""),
+    )
+    if probe is None:
+        return
+    if not probe.ok:
+        if not _confirm_save_after_failed_check(questionary, spec, probe.message):
+            raise UserCancelledError(section="provider")
+        return
+    console.print(f"[{ACCENT_SOFT}]◆[/] [dim]connection verified[/dim]")
+
+
 def _ask_search_choice(questionary):
     supported = [s for s in list_search_provider_setup_specs() if s.runtime_supported]
     provider_id = _ask_or_cancel(
@@ -646,7 +791,26 @@ def _ask_search_choice(questionary):
     return get_search_provider_setup_spec(provider_id_clean), provider_id_clean
 
 
-def _ask_search_fields(questionary, spec) -> dict[str, Any]:
+def _ask_search_fields(questionary, spec, config: Any = None) -> dict[str, Any]:
+    """Collect search settings, seeding every default from the stored config.
+
+    A wizard re-run (e.g. rotating a key) must not reset the stored global
+    search settings to factory defaults: pressing Enter through the prompts
+    keeps ``max_results``/``proxy``/``use_env_proxy``/``fallback_policy``/
+    ``diagnostics`` exactly as persisted, matching the headless keep-current
+    contract.
+    """
+    stored_max_results = int(
+        getattr(config, "search_max_results", DEFAULT_SEARCH_MAX_RESULTS)
+        or DEFAULT_SEARCH_MAX_RESULTS
+    )
+    stored_proxy = str(getattr(config, "search_proxy", "") or "")
+    stored_use_env_proxy = bool(getattr(config, "search_use_env_proxy", False))
+    stored_fallback = str(getattr(config, "search_fallback_policy", "off") or "off")
+    if stored_fallback not in _SEARCH_FALLBACK_LABELS:
+        stored_fallback = "off"
+    stored_diagnostics = bool(getattr(config, "search_diagnostics", False))
+
     answers: dict[str, Any] = {}
     if spec.requires_api_key:
         env_key = spec.env_key or ""
@@ -676,19 +840,26 @@ def _ask_search_fields(questionary, spec) -> dict[str, Any]:
     else:
         answers["api_key"] = ""
         answers["api_key_env"] = ""
-    max_results = _ask_or_cancel(
+    max_results_raw = _ask_or_cancel(
         questionary.text(
-            "Max search results", default=str(DEFAULT_SEARCH_MAX_RESULTS)
+            "Max search results",
+            default=str(stored_max_results),
+            validate=_int_value_validator("Max search results", minimum=1),
         ),
         section="search",
-    ) or str(DEFAULT_SEARCH_MAX_RESULTS)
-    answers["max_results"] = int(max_results)
+    )
+    max_results_clean = str(max_results_raw or "").strip()
+    answers["max_results"] = (
+        int(max_results_clean) if max_results_clean else stored_max_results
+    )
     answers["proxy"] = _ask_or_cancel(
-        questionary.text("Search HTTP proxy", default=""), section="search"
+        questionary.text("Search HTTP proxy", default=stored_proxy), section="search"
     )
     answers["use_env_proxy"] = bool(
         _ask_or_cancel(
-            questionary.confirm("Use environment proxy for search?", default=False),
+            questionary.confirm(
+                "Use environment proxy for search?", default=stored_use_env_proxy
+            ),
             section="search",
         )
     )
@@ -696,14 +867,14 @@ def _ask_search_fields(questionary, spec) -> dict[str, Any]:
         questionary.select(
             "Search fallback policy",
             choices=list(_SEARCH_FALLBACK_LABELS.values()),
-            default=_SEARCH_FALLBACK_LABELS["off"],
+            default=_SEARCH_FALLBACK_LABELS[stored_fallback],
         ),
         section="search",
     )
     answers["fallback_policy"] = _search_fallback_choice_to_value(fallback_choice)
     answers["diagnostics"] = bool(
         _ask_or_cancel(
-            questionary.confirm(_SEARCH_DIAGNOSTICS_PROMPT, default=False),
+            questionary.confirm(_SEARCH_DIAGNOSTICS_PROMPT, default=stored_diagnostics),
             section="search",
         )
     )
@@ -720,9 +891,9 @@ def run_interactive_search_configure(
     questionary = _styled(_qmod)
 
     console.print(banner_panel("Search Setup", "Wire a web search provider"))
-    spec, provider_id = _ask_search_choice(questionary)
-    answers = _ask_search_fields(questionary, spec)
     cfg = load_config(config_path)
+    spec, provider_id = _ask_search_choice(questionary)
+    answers = _ask_search_fields(questionary, spec, cfg)
     result = upsert_search_provider(
         cfg,
         provider_id=provider_id,
@@ -766,11 +937,14 @@ def _ask_image_generation_choice(questionary, config):
         (spec for spec in supported if spec.provider_id == preferred),
         supported[0],
     )
-    selected = questionary.select(
-        "Image generation provider",
-        choices=[_image_generation_choice_label(spec) for spec in supported],
-        default=_image_generation_choice_label(default_spec),
-    ).ask()
+    selected = _ask_or_cancel(
+        questionary.select(
+            "Image generation provider",
+            choices=[_image_generation_choice_label(spec) for spec in supported],
+            default=_image_generation_choice_label(default_spec),
+        ),
+        section="image-generation",
+    )
     provider_id = _image_generation_choice_to_provider_id(selected)
     return get_image_generation_provider_setup_spec(provider_id), provider_id
 
@@ -780,9 +954,36 @@ def _ask_image_generation_fields(
     spec: ImageGenerationProviderSetupSpec,
     config,
 ) -> dict[str, Any]:
+    """Collect image settings, seeding defaults from the stored config.
+
+    A wizard re-run (e.g. rotating a key) must not reset a stored custom
+    primary model, base URL, or a deliberate ``enabled = false`` back to
+    factory defaults: pressing Enter through the prompts keeps what the
+    operator persisted, matching the headless keep-current contract.
+    """
+    image_cfg = getattr(config, "image_generation", None)
+    stored_primary = str(getattr(image_cfg, "primary", "") or "")
+    if not stored_primary.startswith(f"{spec.provider_id}/"):
+        stored_primary = ""
+    provider_cfg = getattr(
+        getattr(image_cfg, "providers", None), spec.provider_id, None
+    )
+    stored_base_url = str(getattr(provider_cfg, "base_url", "") or "")
+    if image_cfg is not None and "enabled" in image_cfg.model_fields_set:
+        stored_enabled = bool(image_cfg.enabled)
+    else:
+        stored_enabled = True
+
     answers: dict[str, Any] = {}
     answers["primary"] = (
-        questionary.text("Primary image model", default=spec.default_model).ask()
+        _ask_or_cancel(
+            questionary.text(
+                "Primary image model",
+                default=stored_primary or spec.default_model,
+            ),
+            section="image-generation",
+        )
+        or stored_primary
         or spec.default_model
     )
 
@@ -801,19 +1002,22 @@ def _ask_image_generation_fields(
     if env_choice and not os.environ.get(spec.env_key):
         key_choices.append(env_choice)
 
-    key_source = questionary.select(
-        "Image API key source",
-        choices=key_choices,
-        default=key_choices[0],
-    ).ask()
+    key_source = _ask_or_cancel(
+        questionary.select(
+            "Image API key source",
+            choices=key_choices,
+            default=key_choices[0],
+        ),
+        section="image-generation",
+    )
     selected_env_key = _api_key_env_from_choice(key_source or "")
     if key_source == _PASTE_API_KEY_CHOICE:
-        answers["api_key"] = (
+        answers["api_key"] = _ask_or_cancel(
             questionary.password(
                 "Image API key",
                 validate=_secret_value_validator("Image API key"),
-            ).ask()
-            or ""
+            ),
+            section="image-generation",
         )
         answers["api_key_env"] = ""
     elif selected_env_key:
@@ -824,12 +1028,25 @@ def _ask_image_generation_fields(
         answers["api_key_env"] = ""
 
     answers["base_url"] = (
-        questionary.text("Image base URL", default=spec.default_base_url).ask()
+        _ask_or_cancel(
+            questionary.text(
+                "Image base URL",
+                default=stored_base_url or spec.default_base_url,
+            ),
+            section="image-generation",
+        )
+        or stored_base_url
         or spec.default_base_url
     )
-    answers["enabled"] = questionary.confirm(
-        "Image generation enabled?", default=True
-    ).ask()
+    # A cancel at the consent confirm must cancel the section — coercing the
+    # ``None`` answer through ``bool()`` would silently persist enabled=false
+    # while the wizard prints a success message.
+    answers["enabled"] = bool(
+        _ask_or_cancel(
+            questionary.confirm("Image generation enabled?", default=stored_enabled),
+            section="image-generation",
+        )
+    )
     return answers
 
 
@@ -1043,7 +1260,14 @@ def run_interactive_memory_embedding_configure(
         base_url=answers.get("base_url"),
         onnx_dir=answers.get("onnx_dir"),
     )
-    persisted = persist_config(result.config, path=config_path, restart_required=False)
+    # The mutation knows whether the edit actually changed the embedding
+    # setup (embedding changes need a full gateway restart to take effect);
+    # hardcoding False here silently dropped that signal.
+    persisted = persist_config(
+        result.config,
+        path=config_path,
+        restart_required=result.restart_required,
+    )
     console.print(
         f"[bold {ACCENT}]◆[/] [bold]Memory embedding configured.[/]"
     )
@@ -1174,25 +1398,37 @@ def _router_tier_overrides(questionary, config) -> dict[str, dict[str, Any]]:
         if isinstance(config.squilla_router.tiers.get(tier_name), dict)
     ]
     while True:
-        selected = questionary.select(
-            "Tier to edit",
-            choices=choices,
-            default=_DONE_LABEL,
-        ).ask()
+        # Cancel contract: Esc/Ctrl+C must abort the router section, not map
+        # to "Done"/keep-current — the callers persist the returned payload,
+        # so a swallowed cancel would rewrite config.toml on explicit abort.
+        selected = _ask_or_cancel(
+            questionary.select(
+                "Tier to edit",
+                choices=choices,
+                default=_DONE_LABEL,
+            ),
+            section="router",
+        )
         tier_name = _tier_choice_to_internal(selected)
         if not tier_name:
             break
         tier = config.squilla_router.tiers.get(tier_name)
         if not isinstance(tier, dict):
             continue
-        provider = questionary.text(
-            f"{tier_name} provider",
-            default=str(tier.get("provider") or ""),
-        ).ask() or str(tier.get("provider") or "")
-        model = questionary.text(
-            f"{tier_name} model",
-            default=str(tier.get("model") or ""),
-        ).ask() or str(tier.get("model") or "")
+        provider = _ask_or_cancel(
+            questionary.text(
+                f"{tier_name} provider",
+                default=str(tier.get("provider") or ""),
+            ),
+            section="router",
+        ) or str(tier.get("provider") or "")
+        model = _ask_or_cancel(
+            questionary.text(
+                f"{tier_name} model",
+                default=str(tier.get("model") or ""),
+            ),
+            section="router",
+        ) or str(tier.get("model") or "")
         overrides[tier_name] = {"provider": provider, "model": model}
         if tier_name == "image_model":
             overrides[tier_name]["supportsImage"] = True
@@ -1207,11 +1443,17 @@ def _ask_router_fields(
     requested_mode: str,
 ) -> dict[str, Any]:
     choices = _router_mode_choices(provider_id)
-    selected_mode = questionary.select(
-        "Router mode",
-        choices=choices,
-        default=_router_mode_default(provider_id, requested_mode),
-    ).ask()
+    # A cancel here must never be read as consent: mapping the ``None`` answer
+    # through ``_router_mode_to_internal`` would silently persist
+    # ``squilla_router.enabled = true`` and print the success handoff.
+    selected_mode = _ask_or_cancel(
+        questionary.select(
+            "Router mode",
+            choices=choices,
+            default=_router_mode_default(provider_id, requested_mode),
+        ),
+        section="router",
+    )
     mode = _router_mode_to_internal(selected_mode)
     if mode == "disabled":
         preview = upsert_router(config, mode=mode).config
@@ -1220,19 +1462,67 @@ def _ask_router_fields(
 
     preview = upsert_router(config, mode=mode).config
     _print_router_defaults(preview)
-    default_tier_choice = questionary.select(
-        "Default text model",
-        choices=[_TEXT_TIER_LABELS[tier] for tier in _TEXT_ROUTER_TIERS],
-        default=_text_tier_label(str(preview.squilla_router.default_tier or "c1")),
-    ).ask()
+    default_tier_choice = _ask_or_cancel(
+        questionary.select(
+            "Default text model",
+            choices=[_TEXT_TIER_LABELS[tier] for tier in _TEXT_ROUTER_TIERS],
+            default=_text_tier_label(str(preview.squilla_router.default_tier or "c1")),
+        ),
+        section="router",
+    )
     default_tier = _text_tier_to_internal(default_tier_choice)
     preview = upsert_router(config, mode=mode, default_tier=default_tier).config
     _print_router_defaults(preview)
 
     payload: dict[str, Any] = {"mode": mode, "defaultTier": default_tier}
-    if questionary.confirm("Edit router tier models now?", default=False).ask():
+    if bool(
+        _ask_or_cancel(
+            questionary.confirm("Edit router tier models now?", default=False),
+            section="router",
+        )
+    ):
         payload["tiers"] = _router_tier_overrides(questionary, preview)
     return payload
+
+
+def _apply_router_section(
+    questionary,
+    config,
+    *,
+    provider_id: str,
+    requested_mode: str,
+    config_path: str | Path | None = None,
+):
+    """Run the inline router step of the full wizard; a cancel skips it.
+
+    The router prompts follow directly after the provider credentials in
+    ``run_interactive_onboard``. Letting a router-stage cancel propagate would
+    discard the API key the user just pasted, so the cancel is scoped to the
+    router section here: nothing router-related is persisted and the caller
+    keeps the provider config it already collected.
+    """
+    try:
+        payload = _ask_router_fields(
+            questionary,
+            config,
+            provider_id=provider_id,
+            requested_mode=requested_mode,
+        )
+    except UserCancelledError:
+        config_arg = _config_cli_arg(config_path)
+        console.print("[yellow]router setup cancelled — keeping current router settings.[/yellow]")
+        console.print(
+            f"  [dim]Resume later with[/dim] "
+            f"[{ACCENT_SOFT}]opensquilla onboard configure router{config_arg}[/]"
+        )
+        return config
+    result = upsert_router(
+        config,
+        mode=payload["mode"],
+        default_tier=payload.get("defaultTier"),
+        tiers=payload.get("tiers"),
+    )
+    return result.config
 
 
 def run_interactive_router_configure(
@@ -1331,6 +1621,7 @@ def _ask_ensemble_fields(questionary, cfg) -> dict[str, Any]:
         questionary.text(
             "Minimum successful proposers",
             default=str(getattr(ensemble, "min_successful_proposers", 1)),
+            validate=_int_value_validator("Minimum successful proposers", minimum=1),
         ),
         section="ensemble",
     )
@@ -1353,10 +1644,15 @@ def _print_ensemble_saved(cfg) -> None:
     ensemble = cfg.llm_ensemble
     state = "enabled" if getattr(ensemble, "enabled", False) else "disabled"
     console.print(f"[bold {ACCENT}]◆[/] [bold]LLM ensemble {state}.[/]")
+    # This runner writes the config file on disk, which the gateway only
+    # reads at boot — unlike the RPC hot-apply path, the change is NOT live
+    # on the next turn until a reload/restart picks the file up.
     console.print(
         f"  [dim]Selection mode:[/dim] "
         f"[{ACCENT_SOFT}]{markup_escape(getattr(ensemble, 'selection_mode', ''))}[/]"
-        " [dim]· applies to the next turn, no restart needed[/dim]"
+        " [dim]· saved to the config file — run[/dim]"
+        f" [{ACCENT_SOFT}]opensquilla gateway reload[/]"
+        " [dim](or restart) to apply it[/dim]"
     )
 
 
@@ -1447,30 +1743,76 @@ def _ask_channel_field(questionary, field: ChannelSetupField, default: Any) -> A
         )
     if field.field_type == "select":
         select_default = default if isinstance(default, str) else None
-        return questionary.select(
-            field.label, choices=list(field.choices), default=select_default
-        ).ask()
+        return _ask_or_cancel(
+            questionary.select(
+                field.label, choices=list(field.choices), default=select_default
+            ),
+            section="channels",
+        )
     if field.field_type == "bool":
-        return questionary.confirm(field.label, default=bool(default)).ask()
+        return bool(
+            _ask_or_cancel(
+                questionary.confirm(field.label, default=bool(default)),
+                section="channels",
+            )
+        )
     if field.field_type == "password":
+        if field.secret and default not in (None, ""):
+            # Editing an entry that already stores this secret: the wizard
+            # keeps the stored value for a blank submit. Resolving it here
+            # (instead of relying on the mutation's by-name merge) keeps the
+            # promise even when the operator renames the entry in the same
+            # edit — a blank submit then must not crash with "requires a
+            # non-empty value".
+            console.print(
+                f"  [dim]{markup_escape(field.label)}: "
+                "leave blank to keep the stored value[/dim]"
+            )
+            answer = _ask_or_cancel(
+                questionary.password(
+                    field.label,
+                    validate=_secret_keep_current_validator(field.label),
+                ),
+                section="channels",
+            )
+            return answer if str(answer or "").strip() else default
         return (
-            questionary.password(
-                field.label,
-                validate=_secret_value_validator(field.label),
-            ).ask()
+            _ask_or_cancel(
+                questionary.password(
+                    field.label,
+                    validate=_secret_value_validator(field.label),
+                ),
+                section="channels",
+            )
             or ""
         )
     if field.field_type == "int":
-        raw = questionary.text(
-            field.label, default=str(default if default is not None else 0)
-        ).ask() or "0"
-        return int(raw)
+        raw = _ask_or_cancel(
+            questionary.text(
+                field.label,
+                default=str(default if default is not None else 0),
+                validate=_int_value_validator(field.label),
+            ),
+            section="channels",
+        )
+        return int(str(raw or "").strip() or "0")
     if field.field_type == "float":
-        raw = questionary.text(
-            field.label, default=str(default if default is not None else 0.0)
-        ).ask() or "0"
-        return float(raw)
-    return questionary.text(field.label, default=str(default or "")).ask() or ""
+        raw = _ask_or_cancel(
+            questionary.text(
+                field.label,
+                default=str(default if default is not None else 0.0),
+                validate=_float_value_validator(field.label),
+            ),
+            section="channels",
+        )
+        return float(str(raw or "").strip() or "0")
+    return (
+        _ask_or_cancel(
+            questionary.text(field.label, default=str(default or "")),
+            section="channels",
+        )
+        or ""
+    )
 
 
 def _ask_channel_fields(
@@ -1949,6 +2291,7 @@ def _use_imported_provider_credentials_with_router_defaults(
     cfg: Any,
     *,
     requested_mode: str,
+    config_path: str | Path | None = None,
 ):
     llm = getattr(cfg, "llm", None)
     provider = _provider_id_from_config(cfg)
@@ -1965,19 +2308,13 @@ def _use_imported_provider_credentials_with_router_defaults(
     )
     cfg_after_provider = res.config
     if requested_mode:
-        router_payload = _ask_router_fields(
+        cfg_after_provider = _apply_router_section(
             questionary,
             cfg_after_provider,
             provider_id=provider,
             requested_mode=requested_mode,
+            config_path=config_path,
         )
-        router_res = upsert_router(
-            cfg_after_provider,
-            mode=router_payload["mode"],
-            default_tier=router_payload.get("defaultTier"),
-            tiers=router_payload.get("tiers"),
-        )
-        cfg_after_provider = router_res.config
     return cfg_after_provider
 
 
@@ -2058,6 +2395,38 @@ def _ask_imported_provider_credentials(
     }
 
 
+def _ensure_config_dir_writable(config_path: str | Path | None) -> None:
+    """Fail fast (exit code 2) when the config directory cannot be written.
+
+    The wizard saves only after every prompt has been answered, so an
+    unwritable state/config directory used to surface as a raw
+    ``PermissionError`` traceback after the operator had already typed
+    everything — including the API key. Probe writability before the first
+    prompt so the failure is actionable and costs no input.
+    """
+    target, _source = resolve_config_path(config_path)
+    directory = target.parent
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        fd, probe_name = tempfile.mkstemp(
+            prefix=".opensquilla-setup-probe-", dir=str(directory)
+        )
+        os.close(fd)
+        os.unlink(probe_name)
+    except OSError as exc:
+        console.print(
+            warning_panel(
+                f"Cannot write the configuration directory "
+                f"{markup_escape(str(directory))}: {markup_escape(str(exc))}\n\n"
+                "Fix the directory permissions, or point --config / "
+                "OPENSQUILLA_GATEWAY_CONFIG_PATH at a writable location, "
+                "then re-run setup.",
+                title="Setup directory not writable",
+            )
+        )
+        raise SystemExit(2) from exc
+
+
 def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
     cfg = load_config(options.config_path)
     status = get_onboarding_status(cfg)
@@ -2071,6 +2440,8 @@ def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
 
     if not _is_tty():
         return _print_noninteractive_hint(cfg, options.config_path)
+
+    _ensure_config_dir_writable(options.config_path)
 
     import questionary as _qmod
     questionary = _styled(_qmod)
@@ -2119,6 +2490,7 @@ def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
                     questionary,
                     cfg,
                     requested_mode=options.router_mode,
+                    config_path=options.config_path,
                 )
                 persist = persist_config(
                     cfg_after_provider,
@@ -2145,19 +2517,13 @@ def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
         if completed_imported is not None:
             cfg_after_provider = completed_imported
             if _imported_provider_router_supported(cfg_after_provider) and options.router_mode:
-                router_payload = _ask_router_fields(
+                cfg_after_provider = _apply_router_section(
                     questionary,
                     cfg_after_provider,
                     provider_id=_provider_id_from_config(cfg_after_provider),
                     requested_mode=options.router_mode,
+                    config_path=options.config_path,
                 )
-                router_res = upsert_router(
-                    cfg_after_provider,
-                    mode=router_payload["mode"],
-                    default_tier=router_payload.get("defaultTier"),
-                    tiers=router_payload.get("tiers"),
-                )
-                cfg_after_provider = router_res.config
         else:
             if migration_result is not None and not status.llm_configured:
                 console.print(
@@ -2167,7 +2533,7 @@ def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
                     )
                 )
             spec, provider_id = _ask_provider_choice(questionary, options)
-            answers = _ask_provider_fields(questionary, spec, options)
+            answers = _ask_provider_fields(questionary, spec, options, config=cfg)
             res = upsert_llm_provider(
                 cfg,
                 provider_id=provider_id,
@@ -2179,19 +2545,13 @@ def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
             )
             cfg_after_provider = res.config
             if options.router_mode:
-                router_payload = _ask_router_fields(
+                cfg_after_provider = _apply_router_section(
                     questionary,
                     cfg_after_provider,
                     provider_id=provider_id,
                     requested_mode=options.router_mode,
+                    config_path=options.config_path,
                 )
-                router_res = upsert_router(
-                    cfg_after_provider,
-                    mode=router_payload["mode"],
-                    default_tier=router_payload.get("defaultTier"),
-                    tiers=router_payload.get("tiers"),
-                )
-                cfg_after_provider = router_res.config
         persist = persist_config(
             cfg_after_provider,
             path=options.config_path,
@@ -2376,10 +2736,13 @@ def run_interactive_channel_add(
     questionary = _styled(_qmod)
 
     if type_name is None:
-        type_name = questionary.select(
-            "Channel type",
-            choices=[s.type for s in list_channel_setup_specs()],
-        ).ask()
+        type_name = _ask_or_cancel(
+            questionary.select(
+                "Channel type",
+                choices=[s.type for s in list_channel_setup_specs()],
+            ),
+            section="channels",
+        )
     spec = get_channel_setup_spec(type_name)
     _print_channel_intro(spec)
     answers = _ask_channel_fields(questionary, spec, type_name=type_name)
@@ -2418,10 +2781,13 @@ def run_interactive_channel_edit(
         )
 
     if name is None:
-        name = questionary.select(
-            "Channel to edit",
-            choices=[e["name"] for e in existing_entries],
-        ).ask()
+        name = _ask_or_cancel(
+            questionary.select(
+                "Channel to edit",
+                choices=[e["name"] for e in existing_entries],
+            ),
+            section="channels",
+        )
     target_entry = next(e for e in existing_entries if e["name"] == name)
     type_name = target_entry["type"]
     spec = get_channel_setup_spec(type_name)
@@ -2454,50 +2820,65 @@ def run_interactive_configure(
     import questionary as _qmod
     questionary = _styled(_qmod)
 
-    section = section or questionary.select(
-        "Section",
-        choices=[
-            "provider",
-            "router",
-            "ensemble",
-            "channels",
-            "search",
-            "image-generation",
-            "memory-embedding",
-        ],
-    ).ask()
+    section = section or _ask_or_cancel(
+        questionary.select(
+            "Section",
+            choices=[
+                "provider",
+                "router",
+                "ensemble",
+                "channels",
+                "search",
+                "image-generation",
+                "memory-embedding",
+            ],
+        ),
+        section="configure",
+    )
     if section in {"provider", "providers"}:
+        # A scoped provider re-run: swapping a key must not re-trigger the
+        # legacy-migration pre-step or the optional capability prompts the
+        # full first-run wizard walks through.
         return run_interactive_onboard(
             OnboardOptions(
                 skip_channels=True,
                 skip_search=True,
+                skip_image_generation=True,
+                skip_migration=True,
                 config_path=config_path,
             )
         )
     if section == "router":
         return run_interactive_router_configure(config_path=config_path)
-    if section in {"ensemble", "llm-ensemble", "llm_ensemble"}:
+    if section in ENSEMBLE_SECTION_ALIASES:
         return run_interactive_ensemble_configure(config_path=config_path)
     if section in {"channel", "channels"}:
         existing = load_config(config_path).channels.channels
         if existing:
-            mode = questionary.select(
-                "Channel action",
-                choices=["add", "edit"],
-                default="add",
-            ).ask()
+            mode = _ask_or_cancel(
+                questionary.select(
+                    "Channel action",
+                    choices=["add", "edit"],
+                    default="add",
+                ),
+                section="channels",
+            )
             if mode == "edit":
                 return run_interactive_channel_edit(None, config_path=config_path)
         return run_interactive_channel_add(None, config_path=config_path)
     if section == "search":
         return run_interactive_search_configure(config_path=config_path)
-    if section in {"image-generation", "image_generation"}:
+    # The alias sets are shared with the setup engine and the CLI help, so
+    # every advertised spelling (including the short "image"/"memory"
+    # aliases) reaches the wizard instead of the unsupported-section notice.
+    if section in IMAGE_GENERATION_SECTION_ALIASES:
         return run_interactive_image_generation_configure(config_path=config_path)
-    if section in {"memory-embedding", "memory_embedding"}:
+    if section in MEMORY_EMBEDDING_SECTION_ALIASES:
         return run_interactive_memory_embedding_configure(config_path=config_path)
+    fallback_path, _source = resolve_config_path(config_path)
     console.print(
         f"[{ACCENT_DIM}]section[/] [{ACCENT_SOFT}]{markup_escape(repr(section))}[/]"
         " [dim]not yet supported in the wizard · edit "
-        "~/.opensquilla/config.toml directly[/dim]"
+        f"{markup_escape(str(fallback_path))} directly[/dim]"
     )
     return None

--- a/src/opensquilla/onboarding/flow.py
+++ b/src/opensquilla/onboarding/flow.py
@@ -2522,15 +2522,16 @@ def _backup_and_reset_config(config_path: str | Path | None) -> None:
     import time as _time
 
     resolved, _source = resolve_config_path(config_path)
-    if not resolved.exists():
+    target = resolved.resolve() if resolved.is_symlink() else resolved
+    if not target.exists():
         return
     stamp = _time.strftime("%Y%m%d-%H%M%S")
-    backup = resolved.with_name(f"{resolved.name}.bak-{stamp}")
+    backup = target.with_name(f"{target.name}.bak-{stamp}")
     counter = 0
     while backup.exists():
         counter += 1
-        backup = resolved.with_name(f"{resolved.name}.bak-{stamp}-{counter}")
-    os.replace(resolved, backup)
+        backup = target.with_name(f"{target.name}.bak-{stamp}-{counter}")
+    os.replace(target, backup)
     console.print(
         f"[dim]Backed up existing config to {markup_escape(str(backup))}[/dim]"
     )

--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -18,6 +18,7 @@ from opensquilla.gateway.config import (
     LlmProviderConfig,
     MemoryEmbeddingConfig,
     SquillaRouterConfig,
+    _default_tiers,
     _router_tier_profile_defaults,
 )
 from opensquilla.gateway.config_secrets import (
@@ -32,6 +33,7 @@ from opensquilla.onboarding.provider_specs import get_provider_setup_spec
 from opensquilla.onboarding.redaction import (
     redact_audio_payload,
     redact_channel_entry,
+    redact_error_text,
     redact_image_generation_payload,
     redact_memory_embedding_payload,
     redact_provider_payload,
@@ -45,7 +47,7 @@ from opensquilla.router_tiers import (
     TEXT_TIERS,
     normalize_text_tier,
 )
-from opensquilla.search.types import DEFAULT_SEARCH_MAX_RESULTS, MAX_SEARCH_RESULTS
+from opensquilla.search.types import MAX_SEARCH_RESULTS
 from opensquilla.secrets import clean_header_secret
 
 SearchFallbackPolicy = Literal["off", "network"]
@@ -223,6 +225,49 @@ def _tiers_equal_after_canonical_normalization(
     return _canonical_tier_map(candidate) == _canonical_tier_map(preset_tiers)
 
 
+def _router_tiers_hand_customized(config: GatewayConfig, *, explicit_model: str = "") -> bool:
+    """True when squilla_router carries an inline, hand-edited tier ladder.
+
+    A set ``tier_profile`` means the ladder is profile-derived (reconciling
+    rewrites the same compact form, which is not destructive). Inline tiers
+    that canonically equal the model default or the active provider's preset
+    seeded with a machine-known model are reconcile-refreshable states a
+    previous save produced — only anything else is an operator-authored
+    ladder that a same-provider re-save must not overwrite.
+
+    The seeded comparison runs against several candidate models, not just
+    the currently stored ``llm.model``: after an out-of-band ``llm.model``
+    change (config.set RPC, TOML hand-edit) the stored ladder still carries
+    the model of the save that seeded it, so testing the save's explicit
+    model and each model the ladder itself names keeps machine-seeded
+    ladders recognizable — otherwise a re-save naming the new model would
+    skip reconciliation and leave every tier pinned to the old model.
+    """
+    router = config.squilla_router
+    if getattr(router, "tier_profile", None):
+        return False
+    tiers = getattr(router, "tiers", {}) or {}
+    if not tiers:
+        return False
+    if _tiers_equal_after_canonical_normalization(tiers, _default_tiers()):
+        return False
+    provider = str(getattr(config.llm, "provider", "") or "").strip().lower()
+    preset = get_preset(provider)
+    if preset is not None:
+        candidate_models = {
+            str(getattr(config.llm, "model", "") or "").strip(),
+            str(explicit_model or "").strip(),
+        }
+        for tier in tiers.values():
+            if isinstance(tier, Mapping):
+                candidate_models.add(str(tier.get("model") or "").strip())
+        for candidate in sorted(candidate_models):
+            seeded = _preset_tiers_with_model(preset, candidate)
+            if _tiers_equal_after_canonical_normalization(tiers, seeded):
+                return False
+    return True
+
+
 def _validate_router_tiers(tiers: dict[str, Any], default_tier: str) -> None:
     if default_tier not in _TEXT_ROUTER_TIERS:
         raise ValueError("defaultTier must reference a text tier")
@@ -369,21 +414,48 @@ def upsert_llm_provider(
     config: GatewayConfig,
     *,
     provider_id: str,
-    model: str = "",
-    api_key: str = "",
-    api_key_env: str = "",
-    base_url: str = "",
-    proxy: str = "",
+    model: str | None = None,
+    api_key: str | None = None,
+    api_key_env: str | None = None,
+    base_url: str | None = None,
+    proxy: str | None = None,
     provider_routing: dict[str, str] | None = None,
-    preset_id: str = "",
+    preset_id: str | None = None,
 ) -> MutationResult:
+    """Save the active LLM provider configuration.
+
+    Keep-current contract (``None`` = "not passed"): when re-saving the
+    provider that is already active (``config.llm.provider == provider_id``,
+    e.g. a key rotation), every optional field left at ``None`` keeps its
+    stored value — ``model``, ``base_url``, ``proxy``, ``provider_routing``,
+    plus parameterless fields such as ``max_tokens`` and ``thinking``, which
+    are always carried over verbatim on a same-provider re-save. Explicit
+    values always win, and an explicit empty string keeps its legacy
+    meaning: ``model=""``/``base_url=""`` fall back to derived defaults
+    (preset/tier model, spec base URL) and ``proxy=""`` clears the proxy.
+    On a provider switch nothing is carried over except the caller's values
+    (and the documented api_key keep-current never crosses providers).
+
+    A same-provider re-save also never overwrites an operator-authored
+    inline router ladder: the router profile is reconciled only when the
+    provider id actually changes or when the current router state is one a
+    previous save produced (compact ``tier_profile`` form, the packaged
+    default, or the provider preset seeded with the stored model).
+    """
     spec = get_provider_setup_spec(provider_id)
     if not spec.runtime_supported:
         raise ValueError(
             f"provider {provider_id!r} is not runtime-supported and cannot be configured"
         )
-    preset = _resolve_provider_preset(preset_id, provider_id)
+    api_key = api_key or ""
+    api_key_env = api_key_env or ""
+    preset = _resolve_provider_preset(preset_id or "", provider_id)
+    same_provider = config.llm.provider == provider_id
     model_clean = _clean_optional_str(model)
+    if not model_clean and model is None and same_provider:
+        # Not passed at all: keep the stored model on a same-provider
+        # re-save instead of resetting it to a derived default.
+        model_clean = str(config.llm.model or "").strip()
     if not model_clean and preset is not None:
         # Explicit preset application: the preset's default model fills the
         # provider's direct model when the caller gave none.
@@ -403,40 +475,77 @@ def upsert_llm_provider(
     if api_key and api_key_env.strip():
         raise ValueError("configure either api_key or api_key_env, not both")
     effective_api_key_env = "" if api_key else api_key_env.strip()
-    if not api_key and not effective_api_key_env and config.llm.provider == provider_id:
+    if not api_key and not effective_api_key_env and same_provider:
         effective_api_key_env = getattr(config.llm, "api_key_env", "").strip()
     if (
         not effective_api_key
         and spec.requires_api_key
         and not api_key_env
-        and config.llm.provider == provider_id
+        and same_provider
         and config.llm.api_key
     ):
         effective_api_key = config.llm.api_key
     if spec.requires_api_key and not effective_api_key and not effective_api_key_env:
         raise ValueError(f"provider {provider_id!r} requires an api_key")
-    effective_base_url = base_url or spec.default_base_url
+    effective_base_url = base_url or ""
+    if not effective_base_url and base_url is None and same_provider:
+        effective_base_url = str(config.llm.base_url or "")
+    if not effective_base_url:
+        effective_base_url = spec.default_base_url
     if spec.requires_base_url and not effective_base_url:
         raise ValueError(f"provider {provider_id!r} requires a base_url")
+    if proxy is None:
+        effective_proxy = str(config.llm.proxy or "") if same_provider else ""
+    else:
+        effective_proxy = proxy
+    if provider_routing is None:
+        effective_provider_routing = (
+            dict(config.llm.provider_routing or {}) if same_provider else {}
+        )
+    else:
+        effective_provider_routing = dict(provider_routing)
 
     new_cfg = _clone(config)
-    new_cfg.llm = LlmProviderConfig(
-        provider=provider_id,
-        model=model_clean,
-        api_key=effective_api_key,
-        api_key_env=effective_api_key_env,
-        base_url=effective_base_url,
-        proxy=proxy,
-        provider_routing=dict(provider_routing or {}),
+    # Seed from the stored section on a same-provider re-save so fields
+    # without a parameter here (max_tokens, thinking, future additions) keep
+    # their values instead of silently resetting to model defaults.
+    llm_payload: dict[str, Any] = (
+        config.llm.model_dump(mode="python") if same_provider else {}
     )
+    llm_payload.update(
+        {
+            "provider": provider_id,
+            "model": model_clean,
+            "api_key": effective_api_key,
+            "api_key_env": effective_api_key_env,
+            "base_url": effective_base_url,
+            "proxy": effective_proxy,
+            "provider_routing": effective_provider_routing,
+        }
+    )
+    new_cfg.llm = LlmProviderConfig(**llm_payload)
     if preset is not None:
         # Explicit user action only — a plain save (no presetId) must keep
         # today's reconcile behavior byte-for-byte (D18).
         _apply_provider_preset(new_cfg, preset, model_clean)
+    elif same_provider and _router_tiers_hand_customized(
+        config, explicit_model=model_clean
+    ):
+        # Same-provider re-save over a hand-edited inline ladder: the router
+        # state already belongs to this provider, and reconciling would only
+        # replace the operator's tiers with the packaged profile. Leave it.
+        pass
     else:
         _reconcile_router_profile_for_provider(new_cfg, provider_id)
     if api_key:
         clear_runtime_secret_paths(new_cfg, {"llm.api_key"})
+    # Explicit endpoint/proxy values override any boot-time env resolution:
+    # drop the runtime-override record so the persist layer writes exactly
+    # what the operator passed even when it equals the env value.
+    if base_url is not None and hasattr(new_cfg, "clear_runtime_override"):
+        new_cfg.clear_runtime_override("llm.base_url")
+    if proxy is not None and hasattr(new_cfg, "clear_runtime_override"):
+        new_cfg.clear_runtime_override("llm.proxy")
 
     payload = {
         "provider": provider_id,
@@ -447,8 +556,8 @@ def upsert_llm_provider(
             "explicit" if effective_api_key else ("env" if effective_api_key_env else "none")
         ),
         "base_url": effective_base_url,
-        "proxy": proxy,
-        "provider_routing": dict(provider_routing or {}),
+        "proxy": effective_proxy,
+        "provider_routing": effective_provider_routing,
     }
     return MutationResult(
         config=new_cfg,
@@ -495,6 +604,13 @@ def upsert_router(
     if router_mode == "disabled":
         router_payload["enabled"] = False
         router_payload["tier_profile"] = None
+        # Keep the effective ladder stored inline while disabled so a later
+        # re-enable can restore an operator-authored tier ladder instead of
+        # silently resetting it to the packaged defaults.
+        router_payload["tiers"] = {
+            name: (dict(tier) if isinstance(tier, dict) else tier)
+            for name, tier in (getattr(config.squilla_router, "tiers", {}) or {}).items()
+        }
         public_payload["mode"] = "disabled"
         public_payload.update({"enabled": False, "tier_profile": None})
     else:
@@ -510,7 +626,39 @@ def upsert_router(
             source_tiers = (
                 tiers if tiers is not None else getattr(config.squilla_router, "tiers", {})
             )
+        elif router_mode == "custom" and tiers is None:
+            # No tiers passed: an inline (possibly hand-edited) ladder —
+            # including one preserved across a disable — is the effective
+            # state, so keep it rather than resetting to the preset base.
+            stored_tiers = getattr(config.squilla_router, "tiers", {}) or {}
+            if (
+                getattr(config.squilla_router, "tier_profile", None) is None
+                and stored_tiers
+                and not _tiers_equal_after_canonical_normalization(
+                    stored_tiers, _default_tiers()
+                )
+            ):
+                source_tiers = stored_tiers
         merged_tiers = _merge_router_tiers(base_tiers, source_tiers)
+        if preset is None:
+            # A hand-edited, non-registry llm.provider has no packaged
+            # profile to seed tiers from; unless the caller supplied a full
+            # ladder, the advertised router one-liner would otherwise die on
+            # the cryptic "router tier 'c0' must be an object".
+            missing_tiers = [
+                tier_name
+                for tier_name in _TEXT_ROUTER_TIERS
+                if not isinstance(merged_tiers.get(tier_name), dict)
+            ]
+            if missing_tiers:
+                raise ValueError(
+                    f"llm.provider {provider!r} is not a registered provider, so no "
+                    f"packaged router profile can seed tiers "
+                    f"{', '.join(missing_tiers)}. Configure a registered provider "
+                    f"first (opensquilla onboard configure provider --provider "
+                    f"<id>) or disable the router (opensquilla onboard configure "
+                    f"router --router disabled)."
+                )
         writes_packaged_profile = (
             router_mode in {"recommended", "openrouter-mix"}
             and preset is not None
@@ -638,6 +786,12 @@ def upsert_llm_ensemble(
 
     new_cfg = _clone(config)
     new_cfg.llm_ensemble = new_ensemble
+    if enabled is not None and hasattr(new_cfg, "mark_force_persist"):
+        # An explicit enabled/disabled decision must be visible in the file
+        # even when it equals the model default — otherwise a headless
+        # `configure ensemble --disabled` on a fresh config persists nothing
+        # and is indistinguishable from a silent no-op.
+        new_cfg.mark_force_persist("llm_ensemble.enabled")
 
     payload: dict[str, Any] = {
         "enabled": new_ensemble.enabled,
@@ -664,28 +818,53 @@ def upsert_search_provider(
     config: GatewayConfig,
     *,
     provider_id: str,
-    api_key: str = "",
-    api_key_env: str = "",
-    max_results: int | str = DEFAULT_SEARCH_MAX_RESULTS,
-    proxy: str = "",
-    use_env_proxy: bool = False,
-    fallback_policy: str = "off",
-    diagnostics: bool = False,
+    api_key: str | None = None,
+    api_key_env: str | None = None,
+    max_results: int | str | None = None,
+    proxy: str | None = None,
+    use_env_proxy: bool | None = None,
+    fallback_policy: str | None = None,
+    diagnostics: bool | None = None,
 ) -> MutationResult:
+    """Save the web search provider configuration.
+
+    Keep-current contract (``None`` = "not passed"): ``max_results``,
+    ``proxy``, ``use_env_proxy``, ``fallback_policy``, and ``diagnostics``
+    keep their currently stored values when omitted — these are global
+    search settings, so keep-current applies even when ``provider_id``
+    changes. Explicit values always win (``proxy=""`` clears the proxy).
+    A blank ``api_key`` keeps the stored key when re-saving the provider
+    that is already active.
+    """
     spec = get_search_provider_setup_spec(provider_id)
     if not spec.runtime_supported:
         raise ValueError(
             f"search provider {provider_id!r} is not runtime-supported and cannot be configured"
         )
-    # Cap the write side to the same ceiling the config field enforces so an
-    # over-range request is clamped here with a clear path rather than failing
-    # late with a raw validation error at persist time.
-    effective_max_results = min(
-        _positive_int(max_results, label="max_results"), MAX_SEARCH_RESULTS
+    api_key = api_key or ""
+    api_key_env = api_key_env or ""
+    if max_results is None:
+        effective_max_results = int(config.search_max_results)
+    else:
+        # Cap the write side to the same ceiling the config field enforces so
+        # an over-range request is clamped here with a clear path rather than
+        # failing late with a raw validation error at persist time.
+        effective_max_results = min(
+            _positive_int(max_results, label="max_results"), MAX_SEARCH_RESULTS
+        )
+    if fallback_policy is None:
+        fallback_policy_value = cast(SearchFallbackPolicy, config.search_fallback_policy)
+    else:
+        if fallback_policy not in {"off", "network"}:
+            raise ValueError("fallback_policy must be 'off' or 'network'")
+        fallback_policy_value = cast(SearchFallbackPolicy, fallback_policy)
+    effective_proxy = str(config.search_proxy or "") if proxy is None else proxy
+    effective_use_env_proxy = (
+        bool(config.search_use_env_proxy) if use_env_proxy is None else bool(use_env_proxy)
     )
-    if fallback_policy not in {"off", "network"}:
-        raise ValueError("fallback_policy must be 'off' or 'network'")
-    fallback_policy_value = cast(SearchFallbackPolicy, fallback_policy)
+    effective_diagnostics = (
+        bool(config.search_diagnostics) if diagnostics is None else bool(diagnostics)
+    )
 
     effective_api_key = (
         clean_header_secret(api_key, label="Search API key")
@@ -713,10 +892,10 @@ def upsert_search_provider(
     new_cfg.search_api_key = effective_api_key
     new_cfg.search_api_key_env = effective_api_key_env
     new_cfg.search_max_results = effective_max_results
-    new_cfg.search_proxy = proxy
-    new_cfg.search_use_env_proxy = bool(use_env_proxy)
+    new_cfg.search_proxy = effective_proxy
+    new_cfg.search_use_env_proxy = effective_use_env_proxy
     new_cfg.search_fallback_policy = fallback_policy_value
-    new_cfg.search_diagnostics = bool(diagnostics)
+    new_cfg.search_diagnostics = effective_diagnostics
     if api_key:
         clear_runtime_secret_paths(new_cfg, {"search_api_key"})
 
@@ -729,10 +908,10 @@ def upsert_search_provider(
         "api_key_env": effective_api_key_env,
         "api_key_source": api_key_source,
         "max_results": effective_max_results,
-        "proxy": proxy,
-        "use_env_proxy": bool(use_env_proxy),
+        "proxy": effective_proxy,
+        "use_env_proxy": effective_use_env_proxy,
         "fallback_policy": fallback_policy_value,
-        "diagnostics": bool(diagnostics),
+        "diagnostics": effective_diagnostics,
     }
     return MutationResult(
         config=new_cfg,
@@ -860,6 +1039,13 @@ def upsert_image_generation_provider(
 
     new_cfg = _clone(config)
     new_cfg.image_generation.enabled = bool(enabled)
+    # The enabled decision is explicit at this layer (callers resolve
+    # keep-current before invoking): force it into the file even when it
+    # equals the model default, otherwise a first-time enabled=false is
+    # dropped by the sparse persist and a later key rotation flips the tool
+    # back on via the legacy configure-implies-enable fallback.
+    if hasattr(new_cfg, "mark_force_persist"):
+        new_cfg.mark_force_persist("image_generation.enabled")
     new_cfg.image_generation.primary = primary_model
     new_cfg.image_generation.size = effective_size
     new_cfg.image_generation.output_format = cast(ImageOutputFormat, effective_output_format)
@@ -897,6 +1083,11 @@ def upsert_image_generation_provider(
 def disable_image_generation(config: GatewayConfig) -> MutationResult:
     new_cfg = _clone(config)
     new_cfg.image_generation.enabled = False
+    # Explicit off switch: must land in the file even on a fresh config where
+    # it equals the model default, so a later provider save that omits the
+    # flag keeps it off instead of re-enabling via configure-implies-enable.
+    if hasattr(new_cfg, "mark_force_persist"):
+        new_cfg.mark_force_persist("image_generation.enabled")
     return MutationResult(
         config=new_cfg,
         changed=True,
@@ -1130,6 +1321,52 @@ def list_channel_entries(config: GatewayConfig) -> list[dict[str, Any]]:
     return [redact_channel_entry(d.get("type", ""), d) for d in _channel_entries_as_dicts(config)]
 
 
+def _format_channel_validation_error(exc: ValidationError) -> str:
+    """Render a channel-entry ValidationError as a field-naming summary.
+
+    Never echoes pydantic's ``input_value`` dump: channel payloads carry
+    credentials (bot tokens, app secrets) and this message surfaces on
+    stderr and RPC error responses. Only field paths and validator messages
+    are included, with the free-text redactor as a final guard.
+    """
+    parts: list[str] = []
+    for error in exc.errors(include_url=False, include_context=False, include_input=False):
+        loc = ".".join(str(item) for item in error.get("loc", ()) or ())
+        msg = str(error.get("msg") or "invalid value")
+        parts.append(f"{loc}: {msg}" if loc else msg)
+    detail = "; ".join(parts) or "invalid value"
+    return f"invalid channel entry: {redact_error_text(detail, max_len=500)}"
+
+
+def _require_non_blank_secret_fields(type_name: str, entry: Mapping[str, Any]) -> None:
+    """Reject blank required credential fields at mutation time.
+
+    An empty or whitespace-only secret (e.g. ``--field token=``) would
+    otherwise persist cleanly and only fail much later at gateway start.
+    Fields gated by ``show_when`` are checked only when their condition
+    matches the normalized entry.
+    """
+    from opensquilla.onboarding.channel_specs import get_channel_setup_spec
+
+    try:
+        spec = get_channel_setup_spec(type_name)
+    except KeyError:
+        return
+    for field_spec in spec.fields:
+        if not (field_spec.required and field_spec.secret):
+            continue
+        if field_spec.show_when and not all(
+            str(entry.get(key, "")) == str(expected)
+            for key, expected in field_spec.show_when.items()
+        ):
+            continue
+        value = entry.get(field_spec.name)
+        if value is None or not str(value).strip():
+            raise ValueError(
+                f"channel field {field_spec.name!r} requires a non-empty value"
+            )
+
+
 def validate_channel_entry(payload: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise TypeError("channel entry payload must be a dict")
@@ -1142,14 +1379,16 @@ def validate_channel_entry(payload: dict[str, Any]) -> dict[str, Any]:
     try:
         entry = parse_channel_entry(full)
     except ValidationError as exc:
-        raise ValueError(str(exc)) from exc
+        raise ValueError(_format_channel_validation_error(exc)) from exc
+    normalized = entry.model_dump(mode="python")
+    _require_non_blank_secret_fields(type_name, normalized)
     if (
         type_name == "slack"
         and getattr(entry, "connection_mode", "webhook") == "webhook"
         and not str(getattr(entry, "signing_secret", "") or "").strip()
     ):
         raise ValueError("slack webhook channels require signing_secret")
-    return entry.model_dump(mode="python")
+    return normalized
 
 
 def upsert_channel(
@@ -1215,9 +1454,25 @@ def _merge_with_existing_secrets(
     for f in spec.fields:
         if not f.secret:
             continue
-        if merged.get(f.name) in ("", None) and existing.get(f.name):
+        provided = merged.get(f.name)
+        blank = provided is None or (isinstance(provided, str) and not provided.strip())
+        if blank and existing.get(f.name):
             merged[f.name] = existing[f.name]
     return merged
+
+
+def merge_channel_entry_secrets(
+    config: GatewayConfig, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """Public wrapper over the blank-secret keep-current merge.
+
+    Lets validation-only surfaces (gateway ``onboarding.channel.probe``)
+    resolve blank secrets against the stored entry exactly the way
+    ``upsert_channel`` does, so a probe of a keep-current payload does not
+    hard-fail on the non-blank-secret requirement that the subsequent upsert
+    would satisfy via the merge.
+    """
+    return _merge_with_existing_secrets(config, payload)
 
 
 def remove_channel(

--- a/src/opensquilla/onboarding/next_steps.py
+++ b/src/opensquilla/onboarding/next_steps.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import platform
+import re
 import shlex
 from pathlib import Path
 from typing import Any
@@ -12,8 +13,10 @@ from opensquilla.onboarding.image_generation_specs import (
     get_image_generation_provider_setup_spec,
 )
 from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
+from opensquilla.onboarding.section_status import SECTION_STATUS_DISPLAY
 from opensquilla.onboarding.setup_paths import web_setup_url
 from opensquilla.onboarding.status import get_onboarding_status
+from opensquilla.paths import default_opensquilla_home
 
 _KEY_URLS = {
     "openrouter": "https://openrouter.ai/keys",
@@ -28,12 +31,11 @@ _CAPABILITY_SECTIONS = (
     "audio",
     "memory_embedding",
 )
-_CAPABILITY_STATUS_DISPLAY = {
-    "ok": "Ready",
-    "optional": "Later",
-    "missing": "Missing",
-    "degraded": "Needs action",
-    "unknown": "Check",
+# String-keyed view of the shared status words (section_status is the single
+# source of truth); derived so the summary lookup below can use raw ``.value``
+# strings without drifting from the ``onboard status`` table wording.
+_CAPABILITY_STATUS_DISPLAY: dict[str, str] = {
+    status.value: display for status, display in SECTION_STATUS_DISPLAY.items()
 }
 _HEADLESS_SECTION_ALIASES = {
     "llm": "provider",
@@ -104,10 +106,53 @@ def setup_catalog_command(config_arg: str = "") -> tuple[str, str]:
     return "Explore options", f"opensquilla onboard catalog{config_arg}"
 
 
-def set_env_hint(env_key: str) -> str:
-    if platform.system().lower().startswith("win"):
-        return f'PowerShell: $env:{env_key} = "<your-key>"'
+def _is_windows() -> bool:
+    return platform.system().lower().startswith("win")
+
+
+# Mirror of the character class ``shlex.quote`` treats as safe, so POSIX and
+# PowerShell quoting agree on *when* to quote and only differ in *how*.
+_SHELL_UNSAFE_RE = re.compile(r"[^\w@%+=:,./-]", re.ASCII)
+
+
+def quote_cli_arg(value: str | Path) -> str:
+    """Quote one copy-paste CLI argument for the operator's shell.
+
+    POSIX shells get ``shlex.quote``. On Windows the copyable commands are
+    presented as PowerShell (matching the env hints below), whose
+    single-quoted strings are literal except for doubled single quotes —
+    ``shlex.quote``'s ``'"'"'`` escape is not valid there.
+    """
+    text = str(value)
+    if not _is_windows():
+        return shlex.quote(text)
+    if not text:
+        return "''"
+    if _SHELL_UNSAFE_RE.search(text) is None:
+        return text
+    return "'" + text.replace("'", "''") + "'"
+
+
+def persistent_env_file() -> str:
+    """Path of the supported persistent ``.env`` file (names only, no values)."""
+    return str(default_opensquilla_home() / ".env")
+
+
+def set_env_command(env_key: str) -> str:
+    """The bare set-this-env-var command for the operator's shell.
+
+    Machine-readable surfaces (``onboard status --json`` and the RPC status
+    payload) must carry only this command — no human labels.
+    """
+    if _is_windows():
+        return f'$env:{env_key} = "<your-key>"'
     return f'export {env_key}="<your-key>"'
+
+
+def set_env_hint(env_key: str) -> str:
+    """Human-facing variant of :func:`set_env_command` (labels the shell)."""
+    command = set_env_command(env_key)
+    return f"PowerShell: {command}" if _is_windows() else command
 
 
 def _set_env_hint(env_key: str) -> str:
@@ -153,7 +198,9 @@ def env_recovery_commands(status: Any) -> list[dict[str, str]]:
             {
                 "section": section,
                 "label": label,
-                "command": set_env_hint(env_key),
+                # Machine-readable field: the bare command only. Human
+                # renderers wanting a shell label wrap it via set_env_hint.
+                "command": set_env_command(env_key),
             }
         )
     return commands
@@ -163,14 +210,15 @@ def _missing_env_warning(surface: str, env_key: str) -> str:
     return (
         f"{surface}: ${env_key} is not set in this shell. "
         "The config saved the environment-variable reference, but this feature "
-        "will not work until the gateway is started with that variable set."
+        "will not work until the gateway is started with that variable set. "
+        f"Persist it by adding {env_key}=<your-key> to {persistent_env_file()}."
     )
 
 
 def _config_cli_arg(config_path: str | Path | None) -> str:
     if not config_path:
         return ""
-    return f" --config {shlex.quote(str(config_path))}"
+    return f" --config {quote_cli_arg(config_path)}"
 
 
 def _image_generation_provider_id(config: Any) -> str:
@@ -296,6 +344,10 @@ def format_next_steps(config: Any, *, config_path: str | Path | None = None) -> 
     ]
     if key_source == "missing_env" and env_key:
         lines.append(f"  Set key before starting gateway: {set_env_hint(env_key)}")
+        lines.append(
+            f"  Persist key across restarts: add {env_key}=<your-key> to "
+            f"{persistent_env_file()}"
+        )
     lines.extend(["", "Reference:"])
     setup_url = web_setup_url(config)
     if setup_url:

--- a/src/opensquilla/onboarding/next_steps.py
+++ b/src/opensquilla/onboarding/next_steps.py
@@ -244,6 +244,37 @@ def _capabilities_summary(status: Any) -> str:
     return " | ".join(parts)
 
 
+def _capability_fix_lines(status: Any, config_arg: str) -> list[str]:
+    """One actionable line per capability that needs operator attention.
+
+    Deliberate opt-outs ("Later") are not nagged about; only blocking,
+    missing, degraded, or unverifiable capabilities get a line, and each
+    names the exact command that fixes it. Audio has no `configure audio`
+    path, so it points at the catalog instead of a command that exits 2.
+    """
+    fix_lines: list[str] = []
+    for name in _CAPABILITY_SECTIONS:
+        detail = status.section_details.get(name, {})
+        state = status.sections.get(name)
+        value = str(getattr(state, "value", detail.get("status") or ""))
+        needs_action = bool(detail.get("blocking") or detail.get("actionRequired"))
+        if not needs_action and value not in {"missing", "degraded", "unknown"}:
+            continue
+        label = str(detail.get("label") or name.replace("_", " ").title())
+        display = (
+            "Needs action"
+            if needs_action
+            else _CAPABILITY_STATUS_DISPLAY.get(value, value.replace("_", " ").title())
+        )
+        slug = _normalize_headless_section(name)
+        if slug == "audio":
+            command = f"opensquilla onboard catalog audio{config_arg}"
+        else:
+            command = f"opensquilla onboard configure {slug}{config_arg}"
+        fix_lines.append(f"  {label} ({display}): {command}")
+    return fix_lines
+
+
 def env_reference_warnings(config: Any) -> list[str]:
     """Return operator-facing warnings for saved env references not visible now."""
     warnings: list[str] = []
@@ -341,6 +372,7 @@ def format_next_steps(config: Any, *, config_path: str | Path | None = None) -> 
         f"  Run gateway now: opensquilla gateway run{config_arg}",
         f"  Start gateway in background: opensquilla gateway start --json{config_arg}",
         f"  Restart running gateway: opensquilla gateway restart --json{config_arg}",
+        f"  Change settings anytime: opensquilla onboard configure{config_arg}",
     ]
     if key_source == "missing_env" and env_key:
         lines.append(f"  Set key before starting gateway: {set_env_hint(env_key)}")
@@ -348,6 +380,10 @@ def format_next_steps(config: Any, *, config_path: str | Path | None = None) -> 
             f"  Persist key across restarts: add {env_key}=<your-key> to "
             f"{persistent_env_file()}"
         )
+    fix_lines = _capability_fix_lines(status, config_arg)
+    if fix_lines:
+        lines.extend(["", "Fix next:"])
+        lines.extend(fix_lines)
     lines.extend(["", "Reference:"])
     setup_url = web_setup_url(config)
     if setup_url:

--- a/src/opensquilla/onboarding/probe.py
+++ b/src/opensquilla/onboarding/probe.py
@@ -13,12 +13,16 @@ for its live model list, enriching each row from the layered model catalog.
 
 from __future__ import annotations
 
+import inspect
 import os
 from dataclasses import dataclass, field
+from typing import Any, cast
 
+import httpx
 import structlog
 
 from opensquilla.provider.failures import ProviderFailureKind, classify_provider_error
+from opensquilla.provider.protocol import LLMProvider
 from opensquilla.provider.registry import get_provider_spec
 from opensquilla.provider.selector import (
     ProviderBuildError,
@@ -244,6 +248,25 @@ def _discover_model_row(info: ModelInfo, provider_id: str) -> dict[str, object]:
     }
 
 
+async def _list_models_for_discovery(provider: LLMProvider) -> list[ModelInfo]:
+    """List the provider's models, surfacing failures where the adapter can.
+
+    Runtime adapters historically swallow list-models errors and return an
+    empty list, which is indistinguishable from a genuinely empty catalog.
+    Adapters that grew the keyword-only ``raise_on_error`` parameter re-raise
+    auth/transport failures when asked, so discovery can classify them; older
+    adapters without the parameter keep the legacy swallow-errors behavior.
+    """
+    list_models: Any = provider.list_models
+    try:
+        accepts_raise = "raise_on_error" in inspect.signature(list_models).parameters
+    except (TypeError, ValueError):  # C-implemented or exotic callables
+        accepts_raise = False
+    if accepts_raise:
+        return cast("list[ModelInfo]", await list_models(raise_on_error=True))
+    return cast("list[ModelInfo]", await list_models())
+
+
 async def discover_provider_models(
     *,
     provider_id: str,
@@ -294,13 +317,18 @@ async def discover_provider_models(
         )
 
     try:
-        provider_models = await provider.list_models()
+        provider_models = await _list_models_for_discovery(provider)
     except Exception as exc:  # noqa: BLE001 - same classification as list_models_detailed
         kind = classify_provider_error(
             provider_id,
             _exception_status_code(exc),
             message=str(exc),
         )
+        if kind is ProviderFailureKind.UNKNOWN and isinstance(exc, httpx.TransportError):
+            # Raw socket noise ("connection refused", DNS failures) carries no
+            # status code and often no classifiable message; it is transport
+            # trouble by construction, exactly like the chat probe's guard.
+            kind = ProviderFailureKind.TRANSPORT_TRANSIENT
         log.warning(
             "onboarding.models_discover_failed",
             provider=provider_id,

--- a/src/opensquilla/onboarding/provider_specs.py
+++ b/src/opensquilla/onboarding/provider_specs.py
@@ -178,7 +178,13 @@ def _fields_for(spec: ProviderSpec) -> tuple[ProviderSetupField, ...]:
             required=spec.requires_api_key(),
             default="",
             description=(
-                f"Stored under env key {spec.env_key}." if spec.env_key else ""
+                (
+                    "Saved as plaintext api_key in the config file and used "
+                    f"ahead of {spec.env_key}. Leave blank to read "
+                    f"{spec.env_key} from the environment instead."
+                )
+                if spec.env_key
+                else "Saved as plaintext api_key in the config file."
             ),
             secret=True,
         ),

--- a/src/opensquilla/onboarding/search_specs.py
+++ b/src/opensquilla/onboarding/search_specs.py
@@ -57,7 +57,15 @@ def _fields_for(spec: SearchProviderSpec) -> tuple[SearchProviderSetupField, ...
             label="API key",
             field_type="password",
             required=spec.requires_api_key,
-            description=f"Stored under env key {spec.env_key}." if spec.env_key else "",
+            description=(
+                (
+                    "Saved as plaintext search_api_key in the config file and "
+                    f"used ahead of {spec.env_key}. Leave blank to read "
+                    f"{spec.env_key} from the environment instead."
+                )
+                if spec.env_key
+                else ""
+            ),
             secret=True,
         ),
         SearchProviderSetupField(

--- a/src/opensquilla/onboarding/section_status.py
+++ b/src/opensquilla/onboarding/section_status.py
@@ -24,7 +24,7 @@ from collections.abc import Callable, Collection
 from enum import StrEnum
 from typing import Any, cast
 
-from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.config import GatewayConfig, ImageGenerationConfig
 from opensquilla.onboarding.audio_specs import get_audio_provider_setup_spec
 from opensquilla.onboarding.image_generation_specs import (
     get_image_generation_provider_setup_spec,
@@ -34,6 +34,13 @@ from opensquilla.onboarding.provider_specs import get_provider_setup_spec
 from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
 
 FIRST_RUN_REQUIRED_SECTIONS = frozenset({"llm"})
+
+# The packaged default image-generation primary model, read straight from the
+# pydantic field default so onboarding provider resolution can never drift
+# from what ``GatewayConfig`` actually ships.
+DEFAULT_IMAGE_GENERATION_PRIMARY: str = str(
+    ImageGenerationConfig.model_fields["primary"].default
+)
 
 
 class SectionStatus(StrEnum):
@@ -51,6 +58,19 @@ class SectionStatus(StrEnum):
     DEGRADED = "degraded"
     OPTIONAL = "optional"
     UNKNOWN = "unknown"
+
+
+# Single source of truth for the operator-facing status words. Every CLI
+# renderer (the ``onboard status`` table and the next-steps capability
+# summary) must display a section state through this mapping so the wording
+# can never drift between surfaces.
+SECTION_STATUS_DISPLAY: dict[SectionStatus, str] = {
+    SectionStatus.OK: "Ready",
+    SectionStatus.OPTIONAL: "Later",
+    SectionStatus.MISSING: "Missing",
+    SectionStatus.DEGRADED: "Needs action",
+    SectionStatus.UNKNOWN: "Check",
+}
 
 
 def _str(cfg: object, name: str) -> str:
@@ -343,11 +363,18 @@ def needs_onboarding(
 
 
 def _configured_image_generation_provider_ids(cfg: GatewayConfig) -> list[str]:
+    """Resolve which image-generation providers the config points at.
+
+    Shared by the section verifier above and by ``status.py``'s annotation
+    derivation — keep this the only implementation of the resolution order
+    (operator credentials beat model routing beats spec defaults).
+    """
     image_cfg = cfg.image_generation
     primary = getattr(image_cfg, "primary", "")
     fallbacks = list(getattr(image_cfg, "fallbacks", []) or [])
-    default_primary = "openai/gpt-image-1"
-    explicit_routing = bool(fallbacks) or bool(primary and primary != default_primary)
+    explicit_routing = bool(fallbacks) or bool(
+        primary and primary != DEFAULT_IMAGE_GENERATION_PRIMARY
+    )
     specs = [
         spec
         for spec in list_image_generation_provider_setup_specs()

--- a/src/opensquilla/onboarding/setup_engine.py
+++ b/src/opensquilla/onboarding/setup_engine.py
@@ -32,7 +32,6 @@ from opensquilla.onboarding.provider_specs import provider_catalog_payload
 from opensquilla.onboarding.router_specs import router_catalog_payload
 from opensquilla.onboarding.search_specs import search_provider_catalog_payload
 from opensquilla.onboarding.status import OnboardingStatus, get_onboarding_status
-from opensquilla.search.types import DEFAULT_SEARCH_MAX_RESULTS
 
 IMAGE_GENERATION_SECTION_ALIASES = frozenset(
     {"image", "image-generation", "image_generation"}
@@ -75,6 +74,16 @@ def setup_catalog_payload(section: str | None = None) -> dict[str, Any]:
     return {key: payload[key]}
 
 
+def _optional_str(value: Any) -> str | None:
+    """``None`` = "not passed" (keep-current); anything else coerces to str."""
+    return None if value is None else str(value)
+
+
+def _optional_bool(value: Any) -> bool | None:
+    """``None`` = "not passed" (keep-current); anything else coerces to bool."""
+    return None if value is None else bool(value)
+
+
 class SetupEngine:
     """Apply onboarding sections against one in-memory config before persisting."""
 
@@ -98,15 +107,19 @@ class SetupEngine:
     def apply(self, section: str, payload: dict[str, Any]) -> MutationResult:
         normalized = section.strip().lower()
         if normalized in {"provider", "providers"}:
+            # Keep-current semantics: keys absent from the payload (or set to
+            # None) mean "leave the stored value alone" on a same-provider
+            # re-save; explicit values — including an explicit empty string —
+            # keep their legacy meaning in the mutation.
             res = upsert_llm_provider(
                 self.config,
                 provider_id=str(payload["providerId"]),
-                model=str(payload.get("model", "")),
-                api_key=str(payload.get("apiKey", "")),
-                api_key_env=str(payload.get("apiKeyEnv", "")),
-                base_url=str(payload.get("baseUrl", "")),
-                proxy=str(payload.get("proxy", "")),
-                preset_id=str(payload.get("presetId", "")),
+                model=_optional_str(payload.get("model")),
+                api_key=str(payload.get("apiKey") or ""),
+                api_key_env=str(payload.get("apiKeyEnv") or ""),
+                base_url=_optional_str(payload.get("baseUrl")),
+                proxy=_optional_str(payload.get("proxy")),
+                preset_id=str(payload.get("presetId") or ""),
             )
         elif normalized == "router":
             res = upsert_router(
@@ -151,16 +164,22 @@ class SetupEngine:
                 ),
             )
         elif normalized == "search":
+            # Keep-current semantics for the global search settings: values
+            # absent from the payload (None) never touch the stored
+            # max_results/proxy/use_env_proxy/fallback_policy/diagnostics.
+            fallback_policy = payload.get("fallbackPolicy")
             res = upsert_search_provider(
                 self.config,
                 provider_id=str(payload["providerId"]),
-                api_key=str(payload.get("apiKey", "")),
-                api_key_env=str(payload.get("apiKeyEnv", "")),
-                max_results=int(payload.get("maxResults", DEFAULT_SEARCH_MAX_RESULTS)),
-                proxy=str(payload.get("proxy", "")),
-                use_env_proxy=bool(payload.get("useEnvProxy", False)),
-                fallback_policy=str(payload.get("fallbackPolicy", "off")),
-                diagnostics=bool(payload.get("diagnostics", False)),
+                api_key=str(payload.get("apiKey") or ""),
+                api_key_env=str(payload.get("apiKeyEnv") or ""),
+                max_results=payload.get("maxResults"),
+                proxy=_optional_str(payload.get("proxy")),
+                use_env_proxy=_optional_bool(payload.get("useEnvProxy")),
+                fallback_policy=(
+                    None if fallback_policy in (None, "") else str(fallback_policy)
+                ),
+                diagnostics=_optional_bool(payload.get("diagnostics")),
             )
         elif normalized in {"channel", "channels"}:
             entry = payload.get("entry", payload)
@@ -168,31 +187,44 @@ class SetupEngine:
                 raise ValueError("channel payload must contain an entry object")
             res = upsert_channel(self.config, entry_payload=entry)
         elif normalized in IMAGE_GENERATION_SECTION_ALIASES:
-            enabled = bool(payload.get("enabled", True))
-            provider_id = str(payload.get("providerId", ""))
+            raw_enabled = payload.get("enabled")
+            if raw_enabled is None:
+                # Keep-current: a deliberate enabled=false persisted in the
+                # config must survive a key rotation that omits the flag. A
+                # config that never stored the flag keeps the legacy
+                # configure-implies-enable behavior for a fresh setup.
+                image_cfg = self.config.image_generation
+                enabled = (
+                    bool(image_cfg.enabled)
+                    if "enabled" in image_cfg.model_fields_set
+                    else True
+                )
+            else:
+                enabled = bool(raw_enabled)
+            provider_id = str(payload.get("providerId") or "")
             if not enabled and not provider_id:
                 res = disable_image_generation(self.config)
             else:
                 res = upsert_image_generation_provider(
                     self.config,
                     provider_id=provider_id,
-                    primary=str(payload.get("primary", "")),
-                    api_key=str(payload.get("apiKey", "")),
-                    api_key_env=str(payload.get("apiKeyEnv", "")),
-                    base_url=str(payload.get("baseUrl", "")),
+                    primary=str(payload.get("primary") or ""),
+                    api_key=str(payload.get("apiKey") or ""),
+                    api_key_env=str(payload.get("apiKeyEnv") or ""),
+                    base_url=str(payload.get("baseUrl") or ""),
                     enabled=enabled,
                 )
         elif normalized in AUDIO_SECTION_ALIASES:
             res = upsert_audio_provider(
                 self.config,
-                provider_id=str(payload.get("providerId", "elevenlabs")),
-                api_key=str(payload.get("apiKey", "")),
-                api_key_env=str(payload.get("apiKeyEnv", "")),
-                base_url=str(payload.get("baseUrl", "")),
+                provider_id=str(payload.get("providerId") or "elevenlabs"),
+                api_key=str(payload.get("apiKey") or ""),
+                api_key_env=str(payload.get("apiKeyEnv") or ""),
+                base_url=str(payload.get("baseUrl") or ""),
                 enabled=bool(payload.get("enabled", True)),
-                tts_voice=str(payload.get("ttsVoice", "")),
-                tts_model=str(payload.get("ttsModel", "")),
-                language_code=str(payload.get("languageCode", "")),
+                tts_voice=str(payload.get("ttsVoice") or ""),
+                tts_model=str(payload.get("ttsModel") or ""),
+                language_code=str(payload.get("languageCode") or ""),
             )
         elif normalized in MEMORY_EMBEDDING_SECTION_ALIASES:
             res = upsert_memory_embedding(

--- a/src/opensquilla/onboarding/status.py
+++ b/src/opensquilla/onboarding/status.py
@@ -17,13 +17,13 @@ from opensquilla.onboarding.audio_specs import get_audio_provider_setup_spec
 from opensquilla.onboarding.config_store import default_config_path
 from opensquilla.onboarding.image_generation_specs import (
     get_image_generation_provider_setup_spec,
-    list_image_generation_provider_setup_specs,
 )
 from opensquilla.onboarding.provider_specs import get_provider_setup_spec
 from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
 from opensquilla.onboarding.section_status import (
     FIRST_RUN_REQUIRED_SECTIONS,
     SectionStatus,
+    _configured_image_generation_provider_ids,
     audio_section_status,
     channels_section_status,
     ensemble_section_status,
@@ -121,6 +121,8 @@ def _source_detail(source: str, env_key: str = "") -> str:
         return f"env key not visible: {env_key}" if env_key else "env key not visible"
     if source == "not_required":
         return "no key required"
+    if source == "unsupported":
+        return "registered but not runtime-supported"
     return ""
 
 
@@ -215,6 +217,17 @@ def _llm_provider_credential_status(
         return {"provider": provider, "available": False, "source": "none", "envKey": ""}
 
     env_key = str(getattr(spec, "env_key", "") or "").strip()
+    if not spec.runtime_supported:
+        # Keep this aligned with ``_llm_source``: a registered but
+        # runtime-unsupported provider must never report a satisfied
+        # credential state ("not_required") while llmSource says
+        # "unsupported" — nothing can run against it.
+        return {
+            "provider": provider,
+            "available": False,
+            "source": "unsupported",
+            "envKey": env_key,
+        }
     if not spec.requires_api_key:
         return {
             "provider": provider,
@@ -308,6 +321,19 @@ def _llm_credential_status(cfg: GatewayConfig) -> dict[str, object]:
     env_key = str(getattr(spec, "env_key", "") or "").strip()
     configured_env_key = str(getattr(llm, "api_key_env", "") or "").strip()
     resolved_env_key = configured_env_key or env_key
+
+    if not spec.runtime_supported:
+        # Mirror ``_llm_source``'s "unsupported" enumerant so the status
+        # payload is internally consistent (llmSource vs
+        # llmCredentialStatus.source) for the same provider.
+        return {
+            "provider": provider,
+            "available": False,
+            "source": "unsupported",
+            "envKey": resolved_env_key,
+            "masked": "",
+            "revealAllowed": False,
+        }
 
     if not spec.requires_api_key:
         return {
@@ -404,7 +430,12 @@ def _llm_source(cfg: GatewayConfig, status: SectionStatus) -> tuple[str, str]:
         spec = get_provider_setup_spec(llm.provider)
     except KeyError:
         return "none", ""
-    if not spec.runtime_supported or not spec.requires_api_key:
+    if not spec.runtime_supported:
+        # Registered but runtime-unsupported providers (e.g. coding-plan
+        # stubs) are not "no key required": nothing can run against them,
+        # so never report the credential state as satisfied.
+        return "unsupported", ""
+    if not spec.requires_api_key:
         return "not_required", ""
     if status is SectionStatus.OK and llm.api_key and (
         "llm.api_key" not in getattr(cfg, "_runtime_secret_paths", set())
@@ -484,60 +515,6 @@ def _image_generation_provider_source(
     if getattr(llm, "provider", "").strip().lower() == provider_id and getattr(llm, "api_key", ""):
         return "llm_fallback", spec.env_key
     return "", spec_env_key
-
-
-def _image_generation_provider_has_operator_credential(
-    cfg: GatewayConfig,
-    provider_id: str,
-    spec: object,
-) -> bool:
-    provider_cfg = _image_generation_provider_config(cfg, provider_id)
-    if provider_cfg is None:
-        return False
-    if getattr(provider_cfg, "api_key", ""):
-        return True
-    spec_env_key = (getattr(spec, "env_key", "") or "").strip()
-    cfg_env_key = (getattr(provider_cfg, "api_key_env", "") or "").strip()
-    return bool(cfg_env_key and cfg_env_key != spec_env_key)
-
-
-def _configured_image_generation_provider_ids(cfg: GatewayConfig) -> list[str]:
-    image_cfg = cfg.image_generation
-    refs: list[str] = []
-    primary = getattr(image_cfg, "primary", "")
-    fallbacks = list(getattr(image_cfg, "fallbacks", []) or [])
-    default_primary = "openai/gpt-image-1"
-    explicit_model_routing = bool(fallbacks) or bool(primary and primary != default_primary)
-    specs = [
-        spec
-        for spec in list_image_generation_provider_setup_specs()
-        if spec.runtime_supported
-    ]
-    explicit_provider_ids = [
-        spec.provider_id
-        for spec in specs
-        if _image_generation_provider_has_operator_credential(
-            cfg,
-            spec.provider_id,
-            spec,
-        )
-    ]
-    if not explicit_model_routing and explicit_provider_ids:
-        return explicit_provider_ids
-    if explicit_model_routing:
-        refs = [primary, *fallbacks]
-    else:
-        refs = [spec.default_model for spec in specs]
-
-    provider_ids: list[str] = []
-    seen: set[str] = set()
-    for ref in refs:
-        provider_id, sep, _model = ref.partition("/")
-        provider_id = provider_id.strip()
-        if sep and provider_id and provider_id not in seen:
-            seen.add(provider_id)
-            provider_ids.append(provider_id)
-    return provider_ids
 
 
 def _image_generation_annotations(

--- a/src/opensquilla/provider/ollama.py
+++ b/src/opensquilla/provider/ollama.py
@@ -284,7 +284,15 @@ class OllamaProvider:
                 code="provider_internal",
             )
 
-    async def list_models(self) -> list[ModelInfo]:
+    async def list_models(self, *, raise_on_error: bool = False) -> list[ModelInfo]:
+        """List available models.
+
+        By default any auth/transport failure degrades to an empty list (the
+        historical contract every runtime caller relies on). Pass
+        ``raise_on_error=True`` to surface the underlying exception instead,
+        so callers that must distinguish an unreachable/secured host from an
+        empty catalog (e.g. onboarding discovery) can classify it.
+        """
         try:
             async with httpx.AsyncClient(
                 timeout=5.0,
@@ -307,4 +315,6 @@ class OllamaProvider:
                     for m in data.get("models", [])
                 ]
         except Exception:
+            if raise_on_error:
+                raise
             return []

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -1335,7 +1335,15 @@ class OpenAIProvider:
             cost_source=cost_source,
         )
 
-    async def list_models(self) -> list[ModelInfo]:
+    async def list_models(self, *, raise_on_error: bool = False) -> list[ModelInfo]:
+        """List available models.
+
+        By default any auth/transport failure degrades to an empty list (the
+        historical contract every runtime caller relies on). Pass
+        ``raise_on_error=True`` to surface the underlying exception instead,
+        so callers that must distinguish a wrong key from an empty catalog
+        (e.g. onboarding discovery) can classify it.
+        """
         headers = {"Authorization": f"Bearer {self._api_key}"}
         headers.update(openrouter_app_headers(self._base_url))
         try:
@@ -1359,4 +1367,6 @@ class OpenAIProvider:
                     for m in data.get("data", [])
                 ]
         except Exception:
+            if raise_on_error:
+                raise
             return []

--- a/src/opensquilla/provider/openai_responses.py
+++ b/src/opensquilla/provider/openai_responses.py
@@ -304,7 +304,15 @@ class OpenAIResponsesProvider:
             model=data.get("model") or self._model,
         )
 
-    async def list_models(self) -> list[ModelInfo]:
+    async def list_models(self, *, raise_on_error: bool = False) -> list[ModelInfo]:
+        """List available models.
+
+        By default any auth/transport failure degrades to an empty list (the
+        historical contract every runtime caller relies on). Pass
+        ``raise_on_error=True`` to surface the underlying exception instead,
+        so callers that must distinguish a wrong key from an empty catalog
+        (e.g. onboarding discovery) can classify it.
+        """
         headers = {"Authorization": f"Bearer {self._api_key}"}
         try:
             async with httpx.AsyncClient(
@@ -314,13 +322,21 @@ class OpenAIResponsesProvider:
             ) as client:
                 response = await client.get(self._api_url("/v1/models"), headers=headers)
         except httpx.HTTPError:
+            if raise_on_error:
+                raise
             return []
 
         if response.status_code != 200:
+            if raise_on_error:
+                # 4xx/5xx raise a classifiable HTTPStatusError; an unexpected
+                # non-200 success shape still degrades to the empty list.
+                response.raise_for_status()
             return []
         try:
             data = response.json()
         except json.JSONDecodeError:
+            if raise_on_error:
+                raise
             return []
 
         models: list[ModelInfo] = []

--- a/tests/test_cli/test_onboard_cmd.py
+++ b/tests/test_cli/test_onboard_cmd.py
@@ -35,6 +35,18 @@ def _config_arg(path) -> str:
     return shlex.quote(str(path))
 
 
+def _effective_config(path):
+    """Load the effective config exactly as the gateway would.
+
+    The sparse TOML persist omits values equal to model defaults, so raw-TOML
+    asserts are reserved for keys a save actually writes; everything else is
+    checked against the loaded (effective) configuration.
+    """
+    from opensquilla.onboarding.config_store import load_config
+
+    return load_config(path)
+
+
 def test_onboard_noninteractive_provider(tmp_path, monkeypatch):
     target = tmp_path / "c.toml"
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
@@ -138,8 +150,16 @@ def test_onboard_accepts_skip_image_generation_option(tmp_path, monkeypatch):
     )
 
     assert result.exit_code == 0, result.stdout
+    # A save marker: the flag-accepting run must actually persist the
+    # provider config; a fresh-config default check alone is vacuous.
+    # (Values equal to model defaults are omitted by the sparse persist, so
+    # the stored key and router profile are the observable markers.)
+    assert target.exists()
     data = tomllib.loads(target.read_text())
-    assert data["image_generation"]["enabled"] is False
+    assert data["llm"]["api_key"] == "sk"
+    assert data["squilla_router"]["tier_profile"] == "openrouter"
+    assert "image_generation" not in data or not data["image_generation"].get("enabled")
+    assert _effective_config(target).image_generation.enabled is False
 
 
 def test_onboard_passes_skip_migration_to_interactive_flow(tmp_path, monkeypatch):
@@ -256,7 +276,7 @@ def test_onboard_noninteractive_provider_without_router_profile_seeds_router_tie
     assert data["llm"]["provider"] == "anthropic"
     assert data["llm"]["api_key_env"] == "ANTHROPIC_API_KEY"
     assert "api_key" not in data["llm"]
-    assert data["squilla_router"]["enabled"] is True
+    assert _effective_config(target).squilla_router.enabled is True
     assert "tier_profile" not in data["squilla_router"]
     for tier in ("c0", "c1", "c2", "c3"):
         assert data["squilla_router"]["tiers"][tier]["provider"] == "anthropic"
@@ -1595,7 +1615,9 @@ def test_configure_without_tty_hint_targets_selected_section(
 
     result = runner.invoke(app, ["configure", section, "--config", str(target)])
 
-    assert result.exit_code == 0
+    # A non-TTY fallthrough is a failure to configure anything: exit 2 like
+    # bare `onboard`, with the hint still naming runnable setup paths.
+    assert result.exit_code == 2
     assert label in result.stdout
     assert command in result.stdout
     assert f"--config {_config_arg(target)}" in result.stdout
@@ -1626,7 +1648,7 @@ def test_onboard_configure_provider_alias_uses_setup_engine(tmp_path, monkeypatc
 
     assert result.exit_code == 0, result.stdout
     data = tomllib.loads(target.read_text())
-    assert data["llm"]["provider"] == "openrouter"
+    assert _effective_config(target).llm.provider == "openrouter"
     assert data["llm"]["api_key_env"] == "OPENROUTER_API_KEY"
     assert "api_key" not in data["llm"]
 
@@ -1653,7 +1675,7 @@ def test_configure_provider_noninteractive_uses_setup_engine(tmp_path, monkeypat
 
     assert result.exit_code == 0, result.stdout
     data = tomllib.loads(target.read_text())
-    assert data["llm"]["provider"] == "openrouter"
+    assert _effective_config(target).llm.provider == "openrouter"
     assert data["llm"]["api_key_env"] == "OPENROUTER_API_KEY"
     assert data["llm"]["proxy"] == "http://127.0.0.1:7890"
     assert "api_key" not in data["llm"]
@@ -1682,7 +1704,7 @@ def test_configure_provider_uses_explicit_config_path(tmp_path, monkeypatch):
 
     assert result.exit_code == 0, result.stdout
     data = tomllib.loads(target.read_text())
-    assert data["llm"]["provider"] == "openrouter"
+    assert _effective_config(target).llm.provider == "openrouter"
     assert data["llm"]["api_key_env"] == "OPENROUTER_API_KEY"
     assert not default_target.exists()
 
@@ -1836,8 +1858,9 @@ def test_configure_router_noninteractive_can_set_default_tier(tmp_path, monkeypa
 
     assert result.exit_code == 0, result.stdout
     data = tomllib.loads(target.read_text())
-    assert data["squilla_router"]["enabled"] is True
-    assert data["squilla_router"]["tier_profile"] == "deepseek"
+    router = _effective_config(target).squilla_router
+    assert router.enabled is True
+    assert router.tier_profile == "deepseek"
     assert data["squilla_router"]["default_tier"] == "c2"
 
 
@@ -1905,7 +1928,7 @@ def test_configure_search_noninteractive(tmp_path, monkeypatch):
 
     assert result.exit_code == 0, result.stdout
     data = tomllib.loads(target.read_text())
-    assert data["search_provider"] == "duckduckgo"
+    assert _effective_config(target).search_provider == "duckduckgo"
     assert data["search_max_results"] == 7
     assert data["search_proxy"] == "http://127.0.0.1:7890"
     assert data["search_use_env_proxy"] is True
@@ -2088,7 +2111,7 @@ def test_configure_image_generation_noninteractive_uses_env(tmp_path, monkeypatc
     assert result.exit_code == 0, result.stdout
     data = tomllib.loads(target.read_text())
     assert data["image_generation"]["enabled"] is True
-    assert data["image_generation"]["providers"]["openrouter"]["api_key"] == ""
+    assert _effective_config(target).image_generation.providers.openrouter.api_key == ""
 
 
 def test_configure_image_generation_can_use_nondefault_env_reference(
@@ -2117,7 +2140,7 @@ def test_configure_image_generation_can_use_nondefault_env_reference(
     assert result.exit_code == 0, result.stdout
     data = tomllib.loads(target.read_text())
     provider = data["image_generation"]["providers"]["openrouter"]
-    assert provider["api_key"] == ""
+    assert _effective_config(target).image_generation.providers.openrouter.api_key == ""
     assert provider["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
 
 
@@ -2174,11 +2197,60 @@ def test_configure_image_generation_can_disable_from_cli(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.stdout
     data = tomllib.loads(target.read_text())
     provider = data["image_generation"]["providers"]["openrouter"]
+    # The explicit off decision must be IN THE FILE, not just resolvable as
+    # the model default — keep-current on a later rotation depends on it.
     assert data["image_generation"]["enabled"] is False
+    assert _effective_config(target).image_generation.enabled is False
     assert data["image_generation"]["primary"] == (
         "openrouter/google/gemini-3.1-flash-image-preview"
     )
     assert provider["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
+
+
+def test_configure_image_first_time_disable_survives_key_rotation(
+    tmp_path, monkeypatch
+):
+    """R1 end-to-end: an explicit --no-image-enabled at FIRST configure (fresh
+    config, value equal to the model default) must be written to the file and
+    must survive a later key rotation that omits the flag — the rotation used
+    to fall into configure-implies-enable and flip the tool back on."""
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    first = runner.invoke(
+        app,
+        [
+            "configure",
+            "image",
+            "--image-provider",
+            "openai",
+            "--primary",
+            "openai/gpt-image-1",
+            "--api-key",
+            "sk-image-1",
+            "--no-image-enabled",
+        ],
+    )
+    assert first.exit_code == 0, first.output
+    data = tomllib.loads(target.read_text())
+    assert data["image_generation"]["enabled"] is False
+
+    rotation = runner.invoke(
+        app,
+        [
+            "configure",
+            "image",
+            "--image-provider",
+            "openai",
+            "--api-key",
+            "sk-image-2",
+        ],
+    )
+    assert rotation.exit_code == 0, rotation.output
+    data = tomllib.loads(target.read_text())
+    assert data["image_generation"]["enabled"] is False
+    assert data["image_generation"]["providers"]["openai"]["api_key"] == "sk-image-2"
+    assert _effective_config(target).image_generation.enabled is False
 
 
 def test_configure_image_generation_can_disable_without_provider_from_cli(
@@ -2188,6 +2260,9 @@ def test_configure_image_generation_can_disable_without_provider_from_cli(
     target = tmp_path / "c.toml"
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    # Seed the non-default state so a silent no-op cannot masquerade as a
+    # save: the command must actually flip the on-disk value.
+    target.write_text("[image_generation]\nenabled = true\n", encoding="utf-8")
 
     result = runner.invoke(
         app,
@@ -2201,6 +2276,7 @@ def test_configure_image_generation_can_disable_without_provider_from_cli(
     assert result.exit_code == 0, result.stdout
     data = tomllib.loads(target.read_text())
     assert data["image_generation"]["enabled"] is False
+    assert _effective_config(target).image_generation.enabled is False
     assert "requires an api_key" not in result.output
 
 
@@ -2225,7 +2301,7 @@ def test_configure_accepts_short_capability_section_aliases(tmp_path, monkeypatc
     assert image.exit_code == 0, image.output
     assert memory.exit_code == 0, memory.output
     data = tomllib.loads(target.read_text())
-    assert data["image_generation"]["enabled"] is False
+    assert _effective_config(target).image_generation.enabled is False
     assert data["memory"]["embedding"]["provider"] == "local"
     assert data["memory"]["embedding"]["local"]["onnx_dir"] == "models/bge"
 
@@ -2253,7 +2329,7 @@ def test_configure_image_generation_can_disable_provider_without_key_from_cli(
 
     assert result.exit_code == 0, result.output
     data = tomllib.loads(target.read_text())
-    assert data["image_generation"]["enabled"] is False
+    assert _effective_config(target).image_generation.enabled is False
     assert data["image_generation"]["primary"] == (
         "openrouter/google/gemini-3.1-flash-image-preview"
     )
@@ -2367,6 +2443,9 @@ def test_configure_ensemble_noninteractive(tmp_path, monkeypatch):
 def test_onboard_configure_ensemble_alias_uses_setup_engine(tmp_path, monkeypatch):
     target = tmp_path / "c.toml"
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    # Seed the non-default state: `--disabled` must observably flip the file,
+    # not exit 0 while persisting/applying nothing.
+    target.write_text("[llm_ensemble]\nenabled = true\n", encoding="utf-8")
 
     result = runner.invoke(
         app,
@@ -2376,6 +2455,7 @@ def test_onboard_configure_ensemble_alias_uses_setup_engine(tmp_path, monkeypatc
     assert result.exit_code == 0, result.output
     data = tomllib.loads(target.read_text())
     assert data["llm_ensemble"]["enabled"] is False
+    assert _effective_config(target).llm_ensemble.enabled is False
 
 
 def test_configure_ensemble_omitted_flags_keep_stored_values(tmp_path, monkeypatch):
@@ -2550,3 +2630,78 @@ def test_onboard_without_probe_flag_never_probes(tmp_path, monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert "Probe" not in result.stdout
+
+
+def test_advertised_router_command_actionable_for_non_registry_provider(
+    tmp_path, monkeypatch
+):
+    """X1: the advertised next-steps router one-liner against a hand-edited,
+    non-registry llm.provider used to exit 2 with the cryptic "router tier
+    'c0' must be an object"; the error must now name the provider and the
+    two runnable ways out (exit code stays 2)."""
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    target.write_text(
+        '[llm]\nprovider = "acme-llm"\nmodel = "acme-model"\n', encoding="utf-8"
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "router",
+            "--router",
+            "recommended",
+            "--default-tier",
+            "c1",
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    text = _plain_text(result.output)
+    assert "acme-llm" in text
+    assert "opensquilla onboard configure provider --provider" in text
+    assert "--router disabled" in text
+    assert "must be an object" not in text
+
+
+def test_onboard_interactive_value_error_is_productized(tmp_path, monkeypatch):
+    """R9 boundary: a mutation-level ValueError escaping the wizard (e.g.
+    "model is required" for a provider without a derivable default) must
+    exit 2 with a productized message, not a raw traceback."""
+    from opensquilla.cli import onboard_cmd
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    def boom(_options):
+        raise ValueError("model is required")
+
+    monkeypatch.setattr(onboard_cmd, "run_interactive_onboard", boom)
+
+    result = runner.invoke(app, ["onboard"])
+
+    assert result.exit_code == 2, result.output
+    assert "model is required" in _plain_text(result.output)
+    assert "Traceback" not in result.output
+
+
+def test_configure_interactive_value_error_is_productized(tmp_path, monkeypatch):
+    """R8 boundary: a mutation ValueError from the configure wizard (e.g. a
+    blank required channel secret) must exit 2 like the headless path."""
+    from opensquilla.cli import onboard_cmd
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    def boom(_section, config_path=None):
+        raise ValueError("channel field 'token' requires a non-empty value")
+
+    monkeypatch.setattr(onboard_cmd, "run_interactive_configure", boom)
+
+    result = runner.invoke(app, ["configure", "channels"])
+
+    assert result.exit_code == 2, result.output
+    assert "requires a non-empty value" in _plain_text(result.output)
+    assert "Traceback" not in result.output

--- a/tests/test_cli/test_onboard_cmd_headless_semantics.py
+++ b/tests/test_cli/test_onboard_cmd_headless_semantics.py
@@ -1,0 +1,811 @@
+"""Headless `onboard`/`configure` CLI semantics.
+
+Pins the gate-flag error contract (explicit-but-incomplete flag sets exit 2),
+keep-current re-saves, cancellation and config-error productization, restart
+guidance, the voice-audio catalog section, and strict `--field` coercion.
+All tests are offline and use synthetic dummy data only.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from typer.testing import CliRunner
+
+from opensquilla.cli.main import app
+from opensquilla.onboarding.config_store import load_config
+
+runner = CliRunner()
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _plain(value: str) -> str:
+    return " ".join(_ANSI_RE.sub("", value).split())
+
+
+# ---------------------------------------------------------------------------
+# B2-1: explicit-but-incomplete headless flag combinations must exit 2 and
+# name the missing gate flag instead of silently no-opping with exit 0.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("args", "missing_flag"),
+    [
+        (["configure", "router", "--default-tier", "c2"], "--router"),
+        (["configure", "provider", "--model", "some/model"], "--provider"),
+        (["configure", "search", "--max-results", "9"], "--search-provider"),
+        (["configure", "channels", "--channel-type", "slack"], "--name"),
+        (["configure", "channels", "--name", "work"], "--channel-type"),
+        (["configure", "image", "--primary", "openrouter/x"], "--image-provider"),
+        (["configure", "memory", "--onnx-dir", "models/bge"], "--memory-provider"),
+    ],
+)
+def test_configure_incomplete_flags_exit_2_naming_missing_gate(
+    tmp_path, monkeypatch, args, missing_flag
+):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", *args])
+
+    assert result.exit_code == 2, result.output
+    assert missing_flag in _plain(result.stderr)
+    assert "no changes were made" in _plain(result.stderr)
+    assert not target.exists()
+
+
+def test_configure_router_incomplete_flags_do_not_touch_existing_config(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "c.toml"
+    target.write_text(
+        '[llm]\nprovider = "openrouter"\nmodel = "m"\napi_key = "sk"\n',
+        encoding="utf-8",
+    )
+    before = target.read_text(encoding="utf-8")
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "configure", "router", "--default-tier", "c2"])
+
+    assert result.exit_code == 2
+    assert target.read_text(encoding="utf-8") == before
+
+
+def test_configure_flags_without_section_exit_2(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "configure", "--router", "recommended"])
+
+    assert result.exit_code == 2
+    assert "target section" in _plain(result.stderr)
+    assert not target.exists()
+
+
+def test_configure_unknown_section_exits_2(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "configure", "not-a-section"])
+
+    assert result.exit_code == 2
+    assert "unknown configure section" in _plain(result.stderr)
+    assert "not-a-section" in _plain(result.stderr)
+    assert not target.exists()
+
+
+def test_configure_audio_section_exits_2_with_catalog_pointer(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "configure", "audio"])
+
+    assert result.exit_code == 2
+    assert "opensquilla onboard catalog audio" in _plain(result.stderr)
+    assert not target.exists()
+
+
+def test_configure_bare_non_tty_exits_2_with_hint(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "configure"])
+
+    assert result.exit_code == 2
+    assert "requires a TTY" in result.stdout
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# B2-2: `onboard catalog audio` must render usable output, and the overview
+# must not leak the raw audioProviders key.
+# ---------------------------------------------------------------------------
+
+
+def test_onboard_catalog_audio_prints_provider_rows(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "catalog", "audio"])
+
+    assert result.exit_code == 0, result.stdout
+    assert result.stdout.strip()
+    assert "voice audio provider options" in result.stdout
+    assert "elevenlabs" in result.stdout
+    assert "ELEVENLABS_API_KEY" in result.stdout
+    assert "Try:" in result.stdout
+    assert not target.exists()
+
+
+def test_onboard_catalog_overview_names_voice_audio_without_raw_key(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "catalog"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Voice audio providers" in result.stdout
+    assert "audioProviders" not in result.stdout
+    compact = "".join(result.stdout.split())
+    assert "opensquillaonboardcatalogaudio" in compact
+
+
+# ---------------------------------------------------------------------------
+# B2-3: an explicitly stored enabled=false must survive an image key rotation
+# that omits --image-enabled/--no-image-enabled.
+# ---------------------------------------------------------------------------
+
+
+def test_configure_image_rotation_keeps_deliberate_disabled_state(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "c.toml"
+    target.write_text(
+        '[llm]\nprovider = "openrouter"\nmodel = "m"\napi_key = "sk"\n'
+        "\n"
+        "[image_generation]\n"
+        "enabled = false\n"
+        'primary = "openrouter/google/gemini-3.1-flash-image-preview"\n'
+        "\n"
+        "[image_generation.providers.openrouter]\n"
+        'api_key_env = "OPENSQUILLA_TEST_IMAGE_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.setenv("OPENSQUILLA_TEST_IMAGE_KEY", "sk-image-env")
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "image",
+            "--image-provider",
+            "openrouter",
+            "--primary",
+            "openrouter/google/gemini-3.1-flash-image-preview",
+            "--api-key-env",
+            "OPENSQUILLA_TEST_IMAGE_KEY",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert load_config(target).image_generation.enabled is False
+
+
+def test_configure_image_rotation_keeps_enabled_true(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    target.write_text(
+        "[image_generation]\n"
+        "enabled = true\n"
+        'primary = "openrouter/google/gemini-3.1-flash-image-preview"\n'
+        "\n"
+        "[image_generation.providers.openrouter]\n"
+        'api_key_env = "OPENSQUILLA_TEST_IMAGE_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.setenv("OPENSQUILLA_TEST_IMAGE_KEY", "sk-image-env")
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "image",
+            "--image-provider",
+            "openrouter",
+            "--primary",
+            "openrouter/google/gemini-3.1-flash-image-preview",
+            "--api-key-env",
+            "OPENSQUILLA_TEST_IMAGE_KEY",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert load_config(target).image_generation.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# B2-4: key rotation must not clobber stored provider/search settings when
+# the corresponding flags are omitted.
+# ---------------------------------------------------------------------------
+
+
+def test_configure_provider_key_rotation_keeps_model_base_url_and_proxy(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "c.toml"
+    target.write_text(
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/model-x"\n'
+        'api_key = "sk-old"\n'
+        'base_url = "https://gateway.example.test/v1"\n'
+        'proxy = "http://127.0.0.1:7890"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "provider",
+            "--provider",
+            "openrouter",
+            "--api-key",
+            "sk-new",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    cfg = load_config(target)
+    assert cfg.llm.model == "custom/model-x"
+    assert cfg.llm.base_url == "https://gateway.example.test/v1"
+    assert cfg.llm.proxy == "http://127.0.0.1:7890"
+    assert cfg.llm.api_key == "sk-new"
+
+
+def test_onboard_provider_key_rotation_keeps_base_url_and_proxy(
+    tmp_path, monkeypatch
+):
+    # The top-level `onboard --provider` path must honor the same
+    # keep-current contract for endpoint settings. Its `--router` flag
+    # defaults to "recommended" (stable contract), so the model stays
+    # router-governed on this path; `configure provider` pins model
+    # keep-current end to end.
+    target = tmp_path / "c.toml"
+    target.write_text(
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/model-x"\n'
+        'api_key = "sk-old"\n'
+        'base_url = "https://gateway.example.test/v1"\n'
+        'proxy = "http://127.0.0.1:7890"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        ["onboard", "--provider", "openrouter", "--api-key", "sk-new", "--minimal"],
+    )
+
+    assert result.exit_code == 0, result.output
+    cfg = load_config(target)
+    assert cfg.llm.base_url == "https://gateway.example.test/v1"
+    assert cfg.llm.proxy == "http://127.0.0.1:7890"
+    assert cfg.llm.api_key == "sk-new"
+
+
+def test_onboard_provider_key_rotation_with_router_disabled_keeps_model(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "c.toml"
+    target.write_text(
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/model-x"\n'
+        'api_key = "sk-old"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "--provider",
+            "openrouter",
+            "--api-key",
+            "sk-new",
+            "--router",
+            "disabled",
+            "--minimal",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    cfg = load_config(target)
+    assert cfg.llm.model == "custom/model-x"
+    assert cfg.llm.api_key == "sk-new"
+
+
+def test_configure_search_key_rotation_keeps_stored_global_settings(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "c.toml"
+    target.write_text(
+        'search_provider = "brave"\n'
+        'search_api_key = "sk-old"\n'
+        "search_max_results = 9\n"
+        'search_proxy = "http://127.0.0.1:7890"\n'
+        "search_use_env_proxy = true\n"
+        'search_fallback_policy = "network"\n'
+        "search_diagnostics = true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "search",
+            "--search-provider",
+            "brave",
+            "--api-key",
+            "sk-new",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    cfg = load_config(target)
+    assert cfg.search_max_results == 9
+    assert cfg.search_proxy == "http://127.0.0.1:7890"
+    assert cfg.search_use_env_proxy is True
+    assert cfg.search_fallback_policy == "network"
+    assert cfg.search_diagnostics is True
+    assert cfg.search_api_key == "sk-new"
+
+
+def test_configure_search_explicit_flags_still_override_stored(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    target.write_text(
+        'search_provider = "duckduckgo"\n'
+        "search_max_results = 9\n"
+        'search_proxy = "http://127.0.0.1:7890"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "search",
+            "--search-provider",
+            "duckduckgo",
+            "--max-results",
+            "3",
+            "--proxy",
+            "",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    cfg = load_config(target)
+    assert cfg.search_max_results == 3
+    assert cfg.search_proxy == ""
+
+
+# ---------------------------------------------------------------------------
+# B2-5: a wizard cancellation (Esc/Ctrl+C) must exit with one short line and
+# code 130 instead of a raw traceback.
+# ---------------------------------------------------------------------------
+
+
+def test_onboard_wizard_cancellation_is_productized(tmp_path, monkeypatch):
+    from opensquilla.cli import onboard_cmd
+    from opensquilla.onboarding.errors import UserCancelledError
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    def cancelled(_options):
+        raise UserCancelledError(section="provider")
+
+    monkeypatch.setattr(onboard_cmd, "run_interactive_onboard", cancelled)
+
+    result = runner.invoke(app, ["onboard"])
+
+    assert result.exit_code == 130
+    assert "Setup cancelled" in _plain(result.stderr)
+    assert "Traceback" not in result.output + result.stderr
+    assert not target.exists()
+
+
+def test_configure_wizard_cancellation_is_productized(tmp_path, monkeypatch):
+    from opensquilla.cli import onboard_cmd
+    from opensquilla.onboarding.errors import UserCancelledError
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    def cancelled(_section, *, config_path=None):
+        raise UserCancelledError(section="configure")
+
+    monkeypatch.setattr(onboard_cmd, "run_interactive_configure", cancelled)
+
+    result = runner.invoke(app, ["onboard", "configure", "router"])
+
+    assert result.exit_code == 130
+    assert "Setup cancelled" in _plain(result.stderr)
+    assert "Traceback" not in result.output + result.stderr
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# B2-6: bare `onboard` with a corrupt config must route through the
+# productized config-error handoff (exit 2), never a raw traceback.
+# ---------------------------------------------------------------------------
+
+
+def test_bare_onboard_toml_decode_error_is_productized(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    target.write_text("not toml :::", encoding="utf-8")
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard"])
+
+    assert result.exit_code == 2
+    assert "OpenSquilla config error" in result.stderr
+    assert "Traceback" not in result.output + result.stderr
+
+
+def test_bare_onboard_validation_error_is_productized(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    target.write_text("[search]\n", encoding="utf-8")
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard"])
+
+    assert result.exit_code == 2
+    assert "OpenSquilla config error" in result.stderr
+    assert "pydantic_core" not in result.stderr
+    assert "Traceback" not in result.output + result.stderr
+
+
+def test_bare_onboard_os_error_is_productized(tmp_path, monkeypatch):
+    target = tmp_path / "config-dir.toml"
+    target.mkdir()  # opening a directory raises IsADirectoryError (OSError)
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard"])
+
+    assert result.exit_code == 2
+    assert "OpenSquilla config error" in result.stderr
+    assert "Traceback" not in result.output + result.stderr
+
+
+def test_onboard_provider_with_corrupt_config_is_productized(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    target.write_text("not toml :::", encoding="utf-8")
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        ["onboard", "--provider", "openrouter", "--api-key", "sk", "--minimal"],
+    )
+
+    assert result.exit_code == 2
+    assert "OpenSquilla config error" in result.stderr
+    assert "Traceback" not in result.output + result.stderr
+
+
+# ---------------------------------------------------------------------------
+# B2-7: a ValidationError on the `onboard --provider` path must not echo
+# pydantic's input_value (which can carry a mispasted secret).
+# ---------------------------------------------------------------------------
+
+
+def test_onboard_provider_validation_error_never_echoes_input_value(
+    tmp_path, monkeypatch
+):
+    from pydantic import BaseModel, ValidationError
+
+    from opensquilla.cli import onboard_cmd
+
+    class _Probe(BaseModel):
+        max_tokens: int
+
+    try:
+        _Probe(max_tokens="sk-super-secret-value")  # type: ignore[arg-type]
+    except ValidationError as exc:
+        captured = exc
+    else:  # pragma: no cover - the construction above always fails
+        raise AssertionError("expected a ValidationError")
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    def raising(*_a, **_kw):
+        raise captured
+
+    monkeypatch.setattr(onboard_cmd, "run_noninteractive_provider_configure", raising)
+
+    result = runner.invoke(
+        app,
+        ["onboard", "--provider", "openrouter", "--api-key", "sk", "--minimal"],
+    )
+
+    assert result.exit_code == 2
+    combined = result.output + result.stderr
+    assert "sk-super-secret-value" not in combined
+    assert "input_value" not in combined
+    assert "max_tokens" in _plain(result.stderr)
+    assert "Traceback" not in combined
+
+
+# ---------------------------------------------------------------------------
+# B2-8: headless channels/memory saves must surface PersistResult's
+# restart_required instead of printing only the saved path.
+# ---------------------------------------------------------------------------
+
+
+def test_configure_channels_prints_restart_guidance(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "channels",
+            "--channel-type",
+            "slack",
+            "--name",
+            "work",
+            "--token",
+            "xoxb-secret",
+            "--field",
+            "signing_secret=ss",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    plain = _plain(result.stdout)
+    assert "restart required" in plain
+    assert "opensquilla gateway restart" in plain
+
+
+def test_configure_memory_prints_restart_guidance_with_config_path(
+    tmp_path, monkeypatch
+):
+    default_target = tmp_path / "default.toml"
+    target = tmp_path / "custom.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(default_target))
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "memory",
+            "--memory-provider",
+            "local",
+            "--onnx-dir",
+            "models/bge",
+            "--config",
+            str(target),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    plain = _plain(result.stdout)
+    assert "restart required" in plain
+    assert "opensquilla gateway restart" in plain
+    assert str(target) in plain
+    assert not default_target.exists()
+
+
+def test_configure_search_does_not_print_restart_guidance(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        ["onboard", "configure", "search", "--search-provider", "duckduckgo"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "restart required" not in _plain(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# B2-10: strict --field coercion (bool typos and numeric garbage must name
+# the offending field and the accepted spellings).
+# ---------------------------------------------------------------------------
+
+
+def test_configure_channels_field_bool_typo_exits_2_naming_field(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "channels",
+            "--channel-type",
+            "slack",
+            "--name",
+            "work",
+            "--token",
+            "xoxb-secret",
+            "--field",
+            "signing_secret=ss",
+            "--field",
+            "enabled=ture",
+        ],
+    )
+
+    assert result.exit_code == 2
+    plain = _plain(result.output + result.stderr)
+    assert "enabled" in plain
+    assert "true/false" in plain
+    assert "'ture'" in plain
+    assert not target.exists()
+
+
+def test_configure_channels_field_int_garbage_exits_2_naming_field(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "channels",
+            "--channel-type",
+            "discord",
+            "--name",
+            "guild",
+            "--token",
+            "bot-secret",
+            "--field",
+            "intents=lots",
+        ],
+    )
+
+    assert result.exit_code == 2
+    plain = _plain(result.output + result.stderr)
+    assert "intents" in plain
+    assert "integer" in plain
+    assert not target.exists()
+
+
+def test_parse_channel_field_pairs_strict_coercion_unit():
+    import typer
+
+    from opensquilla.cli.channel_fields import parse_channel_field_pairs
+
+    assert parse_channel_field_pairs(["enabled=TRUE"], "slack")["enabled"] is True
+    assert parse_channel_field_pairs(["enabled=off"], "slack")["enabled"] is False
+
+    with pytest.raises(typer.BadParameter, match=r"--field enabled .*'ture'"):
+        parse_channel_field_pairs(["enabled=ture"], "slack")
+    with pytest.raises(typer.BadParameter, match=r"--field intents .*integer"):
+        parse_channel_field_pairs(["intents=lots"], "discord")
+    with pytest.raises(typer.BadParameter, match=r"--field poll_idle_sleep_s .*number"):
+        parse_channel_field_pairs(["poll_idle_sleep_s=fast"], "telegram")
+
+
+# ---------------------------------------------------------------------------
+# B2-11: previously untested branches.
+# ---------------------------------------------------------------------------
+
+
+def test_onboard_probe_flag_exits_nonzero_when_probe_raises(tmp_path, monkeypatch):
+    from opensquilla.onboarding import probe as probe_module
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    async def exploding_probe(**_kwargs):
+        raise RuntimeError("socket exploded mid-flight")
+
+    monkeypatch.setattr(probe_module, "probe_llm_provider", exploding_probe)
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "--provider",
+            "openrouter",
+            "--model",
+            "deepseek/deepseek-v4-flash",
+            "--api-key",
+            "sk",
+            "--minimal",
+            "--probe",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Probe failed" in result.stderr
+    assert "socket exploded mid-flight" in result.stderr
+    assert "Traceback" not in result.output + result.stderr
+    # The probe is a gate, not a rollback: the save sticks.
+    assert "openrouter" in target.read_text()
+
+
+def test_onboard_catalog_unknown_section_exits_2(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "catalog", "not-a-section"])
+
+    assert result.exit_code == 2
+    assert "unknown setup section" in _plain(result.stderr)
+    assert "Traceback" not in result.output + result.stderr
+
+
+def test_onboard_if_needed_names_unfinished_sections(tmp_path, monkeypatch):
+    # has_config=True but the referenced env key is missing: the gate must
+    # explain which sections are unfinished before falling into the wizard.
+    target = tmp_path / "c.toml"
+    target.write_text(
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key_env = "CUSTOM_LLM_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("CUSTOM_LLM_KEY", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(app, ["onboard", "--if-needed"])
+
+    assert result.exit_code == 2  # non-TTY still exits 2 afterwards
+    assert "onboarding has unfinished sections" in result.stdout
+    assert "Provider" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# B2-9: router tier ids in the CLI stay sourced from the router_tiers
+# helpers instead of raw tuples/literals.
+# ---------------------------------------------------------------------------
+
+
+def test_router_catalog_tracks_router_tier_helpers(tmp_path, monkeypatch):
+    from opensquilla.cli import onboard_cmd
+    from opensquilla.router_tiers import DEFAULT_TEXT_TIER, TEXT_TIERS
+
+    assert (
+        f"--default-tier {DEFAULT_TEXT_TIER}"
+        in onboard_cmd._CATALOG_COMMANDS["routerProfiles"]
+    )
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    result = runner.invoke(app, ["onboard", "catalog", "router"])
+
+    assert result.exit_code == 0, result.stdout
+    for tier in TEXT_TIERS:
+        assert f"{tier}:" in result.stdout

--- a/tests/test_cli/test_onboard_cmd_headless_semantics.py
+++ b/tests/test_cli/test_onboard_cmd_headless_semantics.py
@@ -787,6 +787,51 @@ def test_onboard_if_needed_names_unfinished_sections(tmp_path, monkeypatch):
     assert "Provider" in result.stdout
 
 
+def test_bare_configure_hub_exit_without_changes_is_success(tmp_path, monkeypatch):
+    import sys
+    import types
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    from opensquilla.onboarding import flow
+
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    class _Answer:
+        def __init__(self, value):
+            self.value = value
+
+        def ask(self):
+            return self.value
+
+    class _Questionary(types.SimpleNamespace):
+        def select(self, message: str, **kwargs):
+            assert message == "Section"
+            assert kwargs["choices"][-1] == "Exit (nothing changed)"
+            return _Answer("Exit (nothing changed)")
+
+        def text(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+        def confirm(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected confirm prompt: {message}")
+
+        def password(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected password prompt: {message}")
+
+        def checkbox(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected checkbox prompt: {message}")
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    result = runner.invoke(app, ["onboard", "configure"])
+
+    assert result.exit_code == 0, result.output
+    assert "requires a TTY" not in result.stdout
+    assert not target.exists()
+
+
 # ---------------------------------------------------------------------------
 # B2-9: router tier ids in the CLI stay sourced from the router_tiers
 # helpers instead of raw tuples/literals.

--- a/tests/test_cli/test_onboard_status_json.py
+++ b/tests/test_cli/test_onboard_status_json.py
@@ -1,0 +1,150 @@
+"""Shape freeze for ``opensquilla onboard status --json``.
+
+The CLI JSON payload must stay a strict superset of the RPC
+``onboarding.status`` payload (contract-frozen in
+tests/test_contracts/test_onboarding_status.py): every RPC key appears here
+under the same name, and ``sectionAliases`` (plus the ``provider`` alias
+entries inside ``sections``/``sectionDetails``) is the only CLI-side
+addition. Renaming or dropping a key is a contract break and must fail here;
+adding one requires consciously extending the frozen set below.
+"""
+
+from __future__ import annotations
+
+import json as _json
+
+from typer.testing import CliRunner
+
+from opensquilla.cli.main import app
+
+runner = CliRunner()
+
+# RPC onboarding.status keys (mirrors STATUS_TOP_LEVEL_KEYS in
+# tests/test_contracts/test_onboarding_status.py) — every one of these must
+# also appear in the CLI JSON payload.
+RPC_STATUS_KEYS = frozenset(
+    {
+        "configPath",
+        "hasConfig",
+        "llmConfigured",
+        "llmSource",
+        "llmEnvKey",
+        "llmCredentialStatus",
+        "imageGenerationConfigured",
+        "imageGenerationEnabled",
+        "imageGenerationSource",
+        "imageGenerationProvider",
+        "imageGenerationPrimary",
+        "imageGenerationEnvKey",
+        "audioConfigured",
+        "audioEnabled",
+        "audioSource",
+        "audioProvider",
+        "audioEnvKey",
+        "searchConfigured",
+        "searchProvider",
+        "searchSource",
+        "searchEnvKey",
+        "memoryEmbeddingConfigured",
+        "memoryEmbeddingProvider",
+        "memoryEmbeddingSource",
+        "memoryEmbeddingEnvKey",
+        "channelCount",
+        "channelsConfigured",
+        "ensembleCredentialStatus",
+        "needsOnboarding",
+        "sections",
+        "sectionDetails",
+        "envRecoveryCommands",
+        "warnings",
+    }
+)
+
+# Exact CLI JSON shape: the RPC keys plus the CLI-only alias map.
+CLI_STATUS_KEYS = RPC_STATUS_KEYS | {"sectionAliases"}
+
+
+def _write_config(tmp_path, monkeypatch):
+    target = tmp_path / "config.toml"
+    target.write_text(
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "deepseek/deepseek-v4-flash"\n'
+        'api_key_env = "DUMMY_UNSET_LLM_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("DUMMY_UNSET_LLM_KEY", raising=False)
+    return target
+
+
+def _status_json(target):
+    result = runner.invoke(app, ["onboard", "status", "--json", "--config", str(target)])
+    assert result.exit_code == 0, result.output
+    return _json.loads(result.stdout)
+
+
+def test_status_json_key_set_is_frozen(tmp_path, monkeypatch):
+    payload = _status_json(_write_config(tmp_path, monkeypatch))
+
+    assert set(payload) == CLI_STATUS_KEYS
+
+
+def test_status_json_is_a_superset_of_the_rpc_payload(tmp_path, monkeypatch):
+    """Anti-drift: compare against the live RPC payload, not a copied list."""
+    from opensquilla.gateway.rpc import RpcContext
+    from opensquilla.gateway.rpc_onboarding import _status_payload as rpc_status_payload
+    from opensquilla.onboarding.config_store import load_config
+
+    target = _write_config(tmp_path, monkeypatch)
+    cli_payload = _status_json(target)
+    rpc_payload = rpc_status_payload(
+        RpcContext(conn_id="cli-freeze", config=load_config(target))
+    )
+
+    missing = set(rpc_payload) - set(cli_payload)
+    assert not missing, f"CLI status --json lost RPC keys: {sorted(missing)}"
+    assert set(cli_payload) - set(rpc_payload) == {"sectionAliases"}
+
+
+def test_status_json_new_keys_carry_the_expected_values(tmp_path, monkeypatch):
+    payload = _status_json(_write_config(tmp_path, monkeypatch))
+
+    assert payload["llmConfigured"] is False
+    assert payload["llmSource"] == "missing_env"
+    credential = payload["llmCredentialStatus"]
+    assert credential["provider"] == "openrouter"
+    assert credential["available"] is False
+    assert credential["source"] == "missing_env"
+    assert credential["envKey"] == "DUMMY_UNSET_LLM_KEY"
+    assert payload["audioConfigured"] is False
+    assert payload["audioEnabled"] is False
+    # Default search provider (duckduckgo) needs no key, so the section is
+    # already configured on a fresh config.
+    assert payload["searchConfigured"] is True
+    assert payload["channelsConfigured"] is False
+    assert isinstance(payload["ensembleCredentialStatus"], list)
+    assert isinstance(payload["warnings"], list)
+
+
+def test_status_json_command_field_is_bare_on_posix(tmp_path, monkeypatch):
+    from opensquilla.onboarding import next_steps
+
+    monkeypatch.setattr(next_steps.platform, "system", lambda: "Linux")
+    payload = _status_json(_write_config(tmp_path, monkeypatch))
+
+    commands = payload["envRecoveryCommands"]
+    assert commands
+    assert commands[0]["command"] == 'export DUMMY_UNSET_LLM_KEY="<your-key>"'
+
+
+def test_status_json_command_field_has_no_shell_label_on_windows(tmp_path, monkeypatch):
+    """Machine-readable command fields must contain only the command."""
+    from opensquilla.onboarding import next_steps
+
+    monkeypatch.setattr(next_steps.platform, "system", lambda: "Windows")
+    payload = _status_json(_write_config(tmp_path, monkeypatch))
+
+    commands = payload["envRecoveryCommands"]
+    assert commands
+    assert commands[0]["command"] == '$env:DUMMY_UNSET_LLM_KEY = "<your-key>"'
+    assert all("PowerShell" not in entry["command"] for entry in commands)

--- a/tests/test_cli/test_sandbox_cmd.py
+++ b/tests/test_cli/test_sandbox_cmd.py
@@ -50,10 +50,14 @@ def test_sandbox_trust_persists_trusted_run_mode(tmp_path: Path) -> None:
     assert cfg.permissions.default_mode == "off"
     data = tomllib.loads(config_path.read_text(encoding="utf-8"))
     assert data["sandbox"]["run_mode"] == "trusted"
-    assert data["sandbox"]["sandbox"] is True
-    assert data["sandbox"]["security_grading"] is True
-    assert data["sandbox"]["network_default"] == "proxy_allowlist"
-    assert data["permissions"]["default_mode"] == "off"
+    # Sparse persistence omits values equal to the built-in defaults
+    # (sandbox on, grading on, proxy allowlist, permissions off); the
+    # effective posture is asserted via load_config above. Any value that
+    # is written must match the trusted posture.
+    assert data["sandbox"].get("sandbox", True) is True
+    assert data["sandbox"].get("security_grading", True) is True
+    assert data["sandbox"].get("network_default", "proxy_allowlist") == "proxy_allowlist"
+    assert data.get("permissions", {}).get("default_mode", "off") == "off"
     assert "restart" in result.output.lower()
 
 

--- a/tests/test_contracts/test_onboarding_status.py
+++ b/tests/test_contracts/test_onboarding_status.py
@@ -199,3 +199,44 @@ async def test_env_recovery_command_rows_are_frozen(
     assert commands, "missing_env must surface a recovery command"
     for command in commands:
         assert set(command) == ENV_RECOVERY_COMMAND_KEYS
+
+
+# Every value ``llmSource`` may carry over the wire. ``unsupported`` is a
+# deliberate additive extension: registered-but-runtime-unsupported providers
+# (e.g. coding-plan stubs) used to report ``not_required``, which read as a
+# satisfied credential state for a provider nothing can run against. Client
+# authors switching on llmSource must treat unknown values as
+# not-configured; extending this set here is the conscious decision the
+# freeze forces.
+LLM_SOURCE_VALUES = frozenset(
+    {"explicit", "env", "missing_env", "none", "not_required", "unsupported"}
+)
+
+
+async def test_llm_source_value_space_is_frozen(tmp_path) -> None:
+    payload = _status_payload(
+        RpcContext(conn_id="contract", config=_synthetic_config(tmp_path))
+    )
+    assert payload["llmSource"] in LLM_SOURCE_VALUES
+
+
+async def test_unsupported_provider_source_is_consistent_across_the_payload(
+    tmp_path,
+) -> None:
+    """llmSource and llmCredentialStatus.source must agree for a registered
+    but runtime-unsupported provider: both say "unsupported" (never a
+    satisfied "not_required") and the credential is not available."""
+    cfg = _synthetic_config(
+        tmp_path,
+        llm=LlmProviderConfig(provider="github_copilot", model="stub-model"),
+    )
+
+    payload = _status_payload(RpcContext(conn_id="contract", config=cfg))
+
+    assert payload["llmSource"] == "unsupported"
+    credential = payload["llmCredentialStatus"]
+    assert credential["source"] == "unsupported"
+    assert credential["available"] is False
+    assert payload["sectionDetails"]["llm"]["detail"] == (
+        "registered but not runtime-supported"
+    )

--- a/tests/test_contracts/test_rpc_onboarding_semantics.py
+++ b/tests/test_contracts/test_rpc_onboarding_semantics.py
@@ -1,0 +1,304 @@
+"""Wire-contract pins for onboarding mutation RPC semantics.
+
+The CLI onboarding hardening pass widened several mutation signatures to
+``None`` = keep-current and made re-saves state-dependent. Those semantics
+are reachable from the unmodified gateway RPC handlers
+(``onboarding.provider.configure``, ``onboarding.router.configure``,
+``onboarding.search.configure``, ``onboarding.channel.probe``/``upsert``),
+so this module is the explicit sign-off: each test pins one wire-visible
+behavior so any future change to it is a conscious contract decision.
+
+Pinned here:
+
+- **Keep-current re-saves** (deliberate change): a same-provider re-save
+  carries over stored ``provider_routing``/``max_tokens``, a blank
+  ``apiKey`` keeps the stored key, and an operator-authored inline router
+  ladder survives a provider save. ``onboarding.router.configure`` with
+  ``mode=disabled`` keeps the effective ladder stored inline for re-enable.
+- **Explicit JSON null = legacy default** (compatibility): a client sending
+  ``null`` for ``model``/``proxy``/``maxResults``/... gets the pre-widening
+  reset/derive behavior, not keep-current.
+- **Blank required channel secrets hard-fail** (deliberate change): probe
+  and upsert reject a genuinely blank secret; with a stored entry both are
+  merge-aware, so blank-means-keep round-trips.
+
+All configs are synthetic; no network or credentials involved.
+"""
+
+from __future__ import annotations
+
+import tomllib
+
+import pytest
+
+import opensquilla.gateway.rpc_onboarding  # noqa: F401  ensures registration
+from opensquilla.gateway.auth import Principal
+from opensquilla.gateway.rpc import RpcContext, get_dispatcher
+
+
+def _admin_ctx() -> RpcContext:
+    return RpcContext(
+        conn_id="contract",
+        principal=Principal(
+            role="operator",
+            scopes=frozenset({"operator.admin"}),
+            is_owner=True,
+            authenticated=True,
+        ),
+    )
+
+
+async def _dispatch(method: str, params: dict):
+    return await get_dispatcher().dispatch("r1", method, params, _admin_ctx())
+
+
+@pytest.fixture()
+def config_file(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Keep-current re-save semantics (deliberate wire-visible change).
+# ---------------------------------------------------------------------------
+
+
+async def test_provider_resave_keeps_stored_provider_routing_and_max_tokens(
+    config_file,
+):
+    config_file.write_text(
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/model-x"\n'
+        'api_key = "sk-old"\n'
+        "max_tokens = 4096\n"
+        "[llm.provider_routing]\n"
+        '"custom/model-x" = "custom-upstream"\n',
+        encoding="utf-8",
+    )
+
+    res = await _dispatch(
+        "onboarding.provider.configure",
+        {"providerId": "openrouter", "model": "custom/model-x", "apiKey": "sk-new"},
+    )
+
+    assert res.error is None, res.error
+    # providerRouting was never sent: the stored table is carried over
+    # (legacy behavior reset it to {}); max_tokens rides the stored section.
+    assert res.payload["entry"]["provider_routing"] == {
+        "custom/model-x": "custom-upstream"
+    }
+    data = tomllib.loads(config_file.read_text())
+    assert data["llm"]["provider_routing"] == {"custom/model-x": "custom-upstream"}
+    assert data["llm"]["max_tokens"] == 4096
+
+
+async def test_provider_resave_blank_api_key_keeps_stored_key(config_file):
+    config_file.write_text(
+        '[llm]\nprovider = "openrouter"\nmodel = "custom/model-x"\napi_key = "sk-stored"\n',
+        encoding="utf-8",
+    )
+
+    res = await _dispatch(
+        "onboarding.provider.configure",
+        {"providerId": "openrouter", "model": "custom/model-x", "apiKey": ""},
+    )
+
+    # Legacy behavior raised "requires an api_key"; blank now keeps stored.
+    assert res.error is None, res.error
+    data = tomllib.loads(config_file.read_text())
+    assert data["llm"]["api_key"] == "sk-stored"
+
+
+async def test_provider_resave_keeps_operator_authored_router_ladder(config_file):
+    config_file.write_text(
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/model-x"\n'
+        'api_key = "sk-old"\n'
+        "[squilla_router]\n"
+        "enabled = true\n"
+        "[squilla_router.tiers.c0]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/cheap"\n'
+        "[squilla_router.tiers.c1]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/model-x"\n'
+        "[squilla_router.tiers.c2]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/mid"\n'
+        "[squilla_router.tiers.c3]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/big"\n',
+        encoding="utf-8",
+    )
+
+    res = await _dispatch(
+        "onboarding.provider.configure",
+        {"providerId": "openrouter", "model": "custom/model-x", "apiKey": "sk-new"},
+    )
+
+    assert res.error is None, res.error
+    data = tomllib.loads(config_file.read_text())
+    # Legacy behavior reverted the ladder to the packaged openrouter profile.
+    assert data["squilla_router"]["tiers"]["c0"]["model"] == "custom/cheap"
+    assert data["squilla_router"]["tiers"]["c3"]["model"] == "custom/big"
+    assert "tier_profile" not in data["squilla_router"]
+
+
+async def test_router_disable_keeps_effective_ladder_inline(config_file):
+    config_file.write_text(
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/model-x"\n'
+        'api_key = "sk"\n'
+        "[squilla_router]\n"
+        "enabled = true\n"
+        "[squilla_router.tiers.c0]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/cheap"\n'
+        "[squilla_router.tiers.c1]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/model-x"\n'
+        "[squilla_router.tiers.c2]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/mid"\n'
+        "[squilla_router.tiers.c3]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/big"\n',
+        encoding="utf-8",
+    )
+
+    res = await _dispatch("onboarding.router.configure", {"mode": "disabled"})
+
+    assert res.error is None, res.error
+    assert res.payload["entry"]["mode"] == "disabled"
+    data = tomllib.loads(config_file.read_text())
+    assert data["squilla_router"]["enabled"] is False
+    # The operator's ladder stays stored inline so a re-enable can restore
+    # it (legacy behavior reset it to the packaged profile).
+    assert data["squilla_router"]["tiers"]["c0"]["model"] == "custom/cheap"
+    assert data["squilla_router"]["tiers"]["c3"]["model"] == "custom/big"
+
+
+# ---------------------------------------------------------------------------
+# Explicit JSON null keeps the LEGACY defaults (compatibility pin).
+# ---------------------------------------------------------------------------
+
+
+async def test_provider_configure_null_model_resets_to_derived_default(config_file):
+    config_file.write_text(
+        '[llm]\nprovider = "deepseek"\nmodel = "custom-stored-model"\napi_key = "sk-old"\n',
+        encoding="utf-8",
+    )
+
+    res = await _dispatch(
+        "onboarding.provider.configure",
+        {"providerId": "deepseek", "model": None, "apiKey": "sk-new"},
+    )
+
+    assert res.error is None, res.error
+    # null must behave like the legacy empty string: derive the router
+    # profile default, NOT keep the stored custom model.
+    assert res.payload["entry"]["model"] != "custom-stored-model"
+    assert res.payload["entry"]["model"]
+
+
+async def test_search_configure_null_params_reset_to_legacy_defaults(config_file):
+    from opensquilla.search.types import DEFAULT_SEARCH_MAX_RESULTS
+
+    config_file.write_text(
+        'search_provider = "duckduckgo"\n'
+        "search_max_results = 9\n"
+        'search_proxy = "http://127.0.0.1:7890"\n'
+        'search_fallback_policy = "network"\n'
+        "search_diagnostics = true\n",
+        encoding="utf-8",
+    )
+
+    res = await _dispatch(
+        "onboarding.search.configure",
+        {
+            "providerId": "duckduckgo",
+            "maxResults": None,
+            "proxy": None,
+            "useEnvProxy": None,
+            "fallbackPolicy": None,
+            "diagnostics": None,
+        },
+    )
+
+    assert res.error is None, res.error
+    entry = res.payload["entry"]
+    assert entry["max_results"] == DEFAULT_SEARCH_MAX_RESULTS
+    assert entry["proxy"] == ""
+    assert entry["fallback_policy"] == "off"
+    assert entry["diagnostics"] is False
+
+
+async def test_search_configure_absent_params_also_reset_to_legacy_defaults(
+    config_file,
+):
+    """Over RPC, ABSENT optional search params keep the legacy reset
+    semantics (the keep-current widening is CLI-only); pinned so the two
+    surfaces cannot drift apart silently."""
+    from opensquilla.search.types import DEFAULT_SEARCH_MAX_RESULTS
+
+    config_file.write_text(
+        'search_provider = "duckduckgo"\nsearch_max_results = 9\n', encoding="utf-8"
+    )
+
+    res = await _dispatch(
+        "onboarding.search.configure", {"providerId": "duckduckgo"}
+    )
+
+    assert res.error is None, res.error
+    assert res.payload["entry"]["max_results"] == DEFAULT_SEARCH_MAX_RESULTS
+
+
+# ---------------------------------------------------------------------------
+# Blank required channel secrets: hard-fail without a stored entry,
+# merge-aware with one (probe mirrors upsert).
+# ---------------------------------------------------------------------------
+
+
+async def test_channel_probe_blank_secret_without_stored_entry_fails(config_file):
+    res = await _dispatch(
+        "onboarding.channel.probe",
+        {"entry": {"type": "telegram", "name": "t1", "token": ""}},
+    )
+
+    assert res.error is not None
+    assert res.error.code == "onboarding.channel.invalid"
+    assert "token" in res.error.message
+
+
+async def test_channel_upsert_blank_secret_without_stored_entry_fails(config_file):
+    res = await _dispatch(
+        "onboarding.channel.upsert",
+        {"entry": {"type": "telegram", "name": "t1", "token": ""}},
+    )
+
+    assert res.error is not None
+    assert res.error.code == "onboarding.channel.invalid"
+
+
+async def test_channel_probe_blank_secret_merges_stored_entry(config_file):
+    config_file.write_text(
+        "[[channels.channels]]\n"
+        'type = "telegram"\n'
+        'name = "t1"\n'
+        'token = "tg-stored"\n',
+        encoding="utf-8",
+    )
+
+    res = await _dispatch(
+        "onboarding.channel.probe",
+        {"entry": {"type": "telegram", "name": "t1", "token": ""}},
+    )
+
+    assert res.error is None, res.error
+    assert res.payload["status"] == "ready"
+    # Secrets never round-trip in the probe response.
+    assert res.payload["entry"]["token"] != "tg-stored"

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -620,7 +620,9 @@ async def test_image_generation_configure_can_use_custom_env_reference(
     assert res.payload["entry"]["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
     data = tomllib.loads(target.read_text())
     provider = data["image_generation"]["providers"]["openrouter"]
-    assert provider["api_key"] == ""
+    # Sparse persistence omits the default empty api_key; either way the
+    # key material must not be baked into the file.
+    assert provider.get("api_key", "") == ""
     assert provider["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
 
 
@@ -650,7 +652,9 @@ async def test_image_generation_configure_can_save_missing_custom_env_reference(
     assert res.payload["entry"]["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
     data = tomllib.loads(target.read_text())
     provider = data["image_generation"]["providers"]["openrouter"]
-    assert provider["api_key"] == ""
+    # Sparse persistence omits the default empty api_key; either way the
+    # key material must not be baked into the file.
+    assert provider.get("api_key", "") == ""
     assert provider["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
 
 
@@ -679,7 +683,9 @@ async def test_image_generation_configure_can_disable_without_visible_key(
     assert res.payload["entry"]["api_key_source"] == "none"
 
     data = tomllib.loads(target.read_text())
-    assert data["image_generation"]["enabled"] is False
+    # Sparse persistence omits enabled=False (the built-in default); if the
+    # key is present it must record the disabled state.
+    assert data["image_generation"].get("enabled", False) is False
 
 
 @pytest.mark.asyncio
@@ -784,7 +790,10 @@ async def test_image_generation_configure_can_enable_llm_fallback(tmp_path, monk
 
     data = tomllib.loads(target.read_text())
     assert data["image_generation"]["enabled"] is True
-    assert data["image_generation"]["providers"]["openrouter"]["api_key"] == ""
+    # Sparse persistence omits untouched provider entries; either way no
+    # key material may be baked into the file for the llm_fallback source.
+    providers = data["image_generation"].get("providers", {})
+    assert providers.get("openrouter", {}).get("api_key", "") == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_rpc_onboarding_audio_sync.py
+++ b/tests/test_gateway/test_rpc_onboarding_audio_sync.py
@@ -100,7 +100,14 @@ def test_audio_onboarding_catalog_configure_and_status(tmp_path, monkeypatch) ->
 
     data = tomllib.loads(target.read_text())
     assert data["audio"]["enabled"] is True
-    assert data["audio"]["providers"]["elevenlabs"]["api_key_env"] == "ELEVENLABS_API_KEY"
+    # Sparse persistence omits provider fields equal to the built-in
+    # defaults (elevenlabs already defaults to ELEVENLABS_API_KEY); the
+    # effective reference is asserted through the RPC payload above.
+    providers = data["audio"].get("providers", {})
+    assert (
+        providers.get("elevenlabs", {}).get("api_key_env", "ELEVENLABS_API_KEY")
+        == "ELEVENLABS_API_KEY"
+    )
     assert data["audio"]["tts"]["voice"] == "voice_custom"
     assert data["audio"]["tts"]["model"] == "eleven_turbo_v2_5"
     assert data["audio"]["tts"]["language_code"] == "zh-CN"

--- a/tests/test_migration/test_env_file_writer.py
+++ b/tests/test_migration/test_env_file_writer.py
@@ -1,0 +1,117 @@
+"""Behavior pins for the shared migration secret ``.env`` writer.
+
+Complements ``test_secret_file_perms.py`` (which pins mode/atomicity/error
+propagation through the full migrators): these tests cover the two
+compatibility guarantees the consolidated writer adds — symlinked ``.env``
+files are written through (the link survives), and a writable ``.env``
+inside a non-writable directory falls back to an in-place rewrite instead
+of failing the migration partway through.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from opensquilla.migration.env_file import write_secret_env_file
+
+
+def test_write_secret_env_file_writes_through_symlink(tmp_path: Path) -> None:
+    real = tmp_path / "dotfiles" / "env-store"
+    real.parent.mkdir()
+    real.write_text("EXISTING_KEY=keep-me\n", encoding="utf-8")
+    link = tmp_path / ".env"
+    link.symlink_to(real)
+
+    write_secret_env_file(link, ["EXISTING_KEY=keep-me", "NEW_KEY=synthetic"])
+
+    # The dotfiles-managed link must survive and the target must receive
+    # the merged content — replacing the link with a regular file silently
+    # disconnects the user's env store.
+    assert link.is_symlink()
+    content = real.read_text(encoding="utf-8")
+    assert "EXISTING_KEY=keep-me" in content
+    assert "NEW_KEY=synthetic" in content
+    if os.name != "nt":
+        assert stat.S_IMODE(os.stat(real).st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are meaningless on Windows")
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0, reason="root bypasses file modes"
+)
+def test_write_secret_env_file_falls_back_when_directory_not_writable(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "opensquilla-home"
+    home.mkdir()
+    env_path = home / ".env"
+    env_path.write_text("OLD_KEY=old\n", encoding="utf-8")
+    os.chmod(home, 0o555)  # directory read/execute only; file stays writable
+    try:
+        write_secret_env_file(env_path, ["OLD_KEY=old", "NEW_KEY=synthetic"])
+    finally:
+        os.chmod(home, 0o755)
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "NEW_KEY=synthetic" in content
+    assert "OLD_KEY=old" in content
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are meaningless on Windows")
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0, reason="root bypasses file modes"
+)
+def test_write_secret_env_file_unwritable_dir_without_file_still_raises(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "opensquilla-home"
+    home.mkdir()
+    os.chmod(home, 0o555)
+    try:
+        with pytest.raises(PermissionError):
+            write_secret_env_file(home / ".env", ["KEY=synthetic"])
+    finally:
+        os.chmod(home, 0o755)
+
+
+def test_openclaw_migration_preserves_symlinked_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: a dotfiles-managed ~/.opensquilla/.env symlink survives a
+    secrets migration, with the merged content written through the link."""
+    from opensquilla.migration.openclaw import MigrationOptions, OpenClawMigrator
+
+    source = tmp_path / ".openclaw"
+    source.mkdir()
+    (source / "openclaw.json").write_text(
+        json.dumps({"agents": {"defaults": {}}}), encoding="utf-8"
+    )
+    (source / ".env").write_text("OPENAI_API_KEY=sk-dummy-openclaw\n", encoding="utf-8")
+
+    home = tmp_path / "opensquilla-home"
+    home.mkdir()
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+
+    real = tmp_path / "dotfiles-env"
+    real.write_text("EXISTING_KEY=keep-me\n", encoding="utf-8")
+    (home / ".env").symlink_to(real)
+
+    OpenClawMigrator(
+        MigrationOptions(
+            source=source,
+            config_path=tmp_path / "config.toml",
+            apply=True,
+            migrate_secrets=True,
+        )
+    ).migrate()
+
+    assert (home / ".env").is_symlink()
+    content = real.read_text(encoding="utf-8")
+    assert "EXISTING_KEY=keep-me" in content
+    assert "OPENAI_API_KEY=sk-dummy-openclaw" in content

--- a/tests/test_migration/test_hermes_e2e.py
+++ b/tests/test_migration/test_hermes_e2e.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from opensquilla.cli.main import app
+from opensquilla.onboarding.config_store import load_config
 
 runner = CliRunner()
 
@@ -85,7 +86,11 @@ telegram:
     config = tomllib.loads(config_path.read_text(encoding="utf-8"))
     assert config["host"] == "127.0.0.9"
     assert config["port"] == 19999
-    assert config["llm"]["provider"] == "openrouter"
+    # Sparse persistence omits values equal to the built-in default
+    # (provider "openrouter"); the effective provider must still resolve
+    # to the migrated value.
+    assert config["llm"].get("provider", "openrouter") == "openrouter"
+    assert load_config(config_path).llm.provider == "openrouter"
     assert config["llm"]["model"] == "anthropic/claude-3.5-sonnet"
     assert config["channels"]["channels"][0]["type"] == "telegram"
     assert (Path(report["output_dir"]) / "report.json").is_file()

--- a/tests/test_migration/test_hermes_migration_fixes.py
+++ b/tests/test_migration/test_hermes_migration_fixes.py
@@ -575,9 +575,11 @@ def test_unknown_provider_is_not_written_to_config(
 
     import tomllib
     data = tomllib.loads((home / "config.toml").read_text())
-    # Provider was NOT overwritten with the unknown value. The model id
-    # still came through because that's a free-form string.
-    assert data["llm"]["provider"] != "bedrock"
+    # Provider was NOT overwritten with the unknown value. Sparse persistence
+    # may omit the key entirely (it was left at the default), which satisfies
+    # the same invariant. The model id still came through because that's a
+    # free-form string.
+    assert data["llm"].get("provider") != "bedrock"
     assert data["llm"]["model"] == "claude-3-opus"
 
 

--- a/tests/test_migration/test_openclaw_migration.py
+++ b/tests/test_migration/test_openclaw_migration.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from opensquilla.engine.context import load_context_files
 from opensquilla.migration.openclaw import MigrationOptions, OpenClawMigrator
+from opensquilla.onboarding.config_store import load_config
 from opensquilla.provider.selector import build_provider
 from opensquilla.skills.loader import SkillLoader
 from opensquilla.skills.types import SkillLayer
@@ -307,7 +308,9 @@ def test_user_data_preset_skips_runtime_config_and_archives(
     assert (home / "skills" / "openclaw-imports" / "demo" / "SKILL.md").is_file()
     persisted = tomllib.loads(config_path.read_text(encoding="utf-8"))
     assert str(home / "skills" / "openclaw-imports") in persisted["skills"]["extra_dirs"]
-    assert persisted["llm"]["model"] != "deepseek-chat"
+    # The user-data preset skips model config entirely; with sparse
+    # persistence the llm section is not written at all.
+    assert persisted.get("llm", {}).get("model") != "deepseek-chat"
     assert not (Path(report["output_dir"]) / "archive" / "plugins-config.json").exists()
     assert not any(item["kind"] == "model-config" for item in report["items"])
 
@@ -512,7 +515,11 @@ def test_provider_keys_can_migrate_from_provider_config_when_opted_in(
     env_text = (home / ".env").read_text(encoding="utf-8")
     assert "OPENROUTER_API_KEY=sk-or-from-config" in env_text
     persisted = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    assert persisted["llm"]["provider"] == "openrouter"
+    # Sparse persistence omits values equal to the built-in default
+    # (provider "openrouter"); the effective provider must still resolve
+    # to the migrated value.
+    assert persisted["llm"].get("provider", "openrouter") == "openrouter"
+    assert load_config(config_path).llm.provider == "openrouter"
     assert persisted["llm"]["model"] == "deepseek/deepseek-v3.1"
     assert persisted["llm"]["api_key_env"] == "OPENROUTER_API_KEY"
     assert persisted["llm"]["base_url"] == "https://openrouter.example.test/api/v1"

--- a/tests/test_migration/test_secret_file_perms.py
+++ b/tests/test_migration/test_secret_file_perms.py
@@ -1,0 +1,253 @@
+"""Secret ``.env`` files written by migrators must be owner-only from birth.
+
+Both the Hermes and OpenClaw migrators can land provider keys and channel
+tokens in ``~/.opensquilla/.env`` when ``migrate_secrets=True``. These tests
+pin the secure-write contract:
+
+- the resulting file is mode 0600 (POSIX; mode bits are meaningless on
+  Windows, matching the ``persist_config`` test idiom),
+- the write is atomic (no leftover temp files),
+- a failed write surfaces as an error instead of being silently swallowed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from opensquilla.migration.hermes import HermesMigrationOptions, HermesMigrator
+from opensquilla.migration.openclaw import MigrationOptions, OpenClawMigrator
+
+
+@pytest.fixture()
+def permissive_umask() -> Iterator[None]:
+    """Force a typical 022 umask so a missing-chmod bug is deterministic."""
+    if os.name == "nt":
+        yield
+        return
+    previous = os.umask(0o022)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+def _assert_owner_only(path: Path) -> None:
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    if os.name == "nt":
+        assert mode & stat.S_IWRITE
+    else:
+        assert mode == 0o600
+
+
+def _assert_no_leftover_tmp(directory: Path) -> None:
+    leftovers = [p.name for p in directory.iterdir() if p.name.startswith(".env.")]
+    assert leftovers == [], f"leftover temp files with secret content: {leftovers}"
+
+
+def _make_hermes_source(root: Path) -> Path:
+    source = root / ".hermes"
+    source.mkdir(parents=True)
+    (source / "config.yaml").write_text("", encoding="utf-8")
+    (source / ".env").write_text("OPENAI_API_KEY=sk-dummy-hermes\n", encoding="utf-8")
+    return source
+
+
+def _make_openclaw_source(root: Path) -> Path:
+    source = root / ".openclaw"
+    source.mkdir(parents=True)
+    (source / "openclaw.json").write_text(
+        json.dumps({"agents": {"defaults": {}}}), encoding="utf-8"
+    )
+    (source / ".env").write_text("OPENAI_API_KEY=sk-dummy-openclaw\n", encoding="utf-8")
+    return source
+
+
+def test_hermes_secret_env_written_with_owner_only_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, permissive_umask: None
+) -> None:
+    source = _make_hermes_source(tmp_path)
+    home = tmp_path / "opensquilla-home"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+
+    HermesMigrator(
+        HermesMigrationOptions(
+            source=source,
+            config_path=tmp_path / "config.toml",
+            apply=True,
+            migrate_secrets=True,
+        )
+    ).migrate()
+
+    env_path = home / ".env"
+    assert "OPENAI_API_KEY=sk-dummy-hermes" in env_path.read_text(encoding="utf-8")
+    _assert_owner_only(env_path)
+    _assert_no_leftover_tmp(home)
+
+
+def test_hermes_secret_merge_tightens_preexisting_env_perms(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, permissive_umask: None
+) -> None:
+    source = _make_hermes_source(tmp_path)
+    home = tmp_path / "opensquilla-home"
+    home.mkdir()
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+    env_path = home / ".env"
+    env_path.write_text("EXISTING_KEY=keep-me\n", encoding="utf-8")
+    if os.name != "nt":
+        os.chmod(env_path, 0o644)
+
+    HermesMigrator(
+        HermesMigrationOptions(
+            source=source,
+            config_path=tmp_path / "config.toml",
+            apply=True,
+            migrate_secrets=True,
+        )
+    ).migrate()
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "EXISTING_KEY=keep-me" in content
+    assert "OPENAI_API_KEY=sk-dummy-hermes" in content
+    _assert_owner_only(env_path)
+    _assert_no_leftover_tmp(home)
+
+
+def test_openclaw_secret_env_written_with_owner_only_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, permissive_umask: None
+) -> None:
+    source = _make_openclaw_source(tmp_path)
+    home = tmp_path / "opensquilla-home"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+
+    OpenClawMigrator(
+        MigrationOptions(
+            source=source,
+            config_path=tmp_path / "config.toml",
+            apply=True,
+            migrate_secrets=True,
+        )
+    ).migrate()
+
+    env_path = home / ".env"
+    assert "OPENAI_API_KEY=sk-dummy-openclaw" in env_path.read_text(encoding="utf-8")
+    _assert_owner_only(env_path)
+    _assert_no_leftover_tmp(home)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are meaningless on Windows")
+def test_openclaw_secret_env_secure_even_when_chmod_is_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, permissive_umask: None
+) -> None:
+    # A post-hoc ``chmod`` used to be the only thing standing between the
+    # secret file and umask-default permissions, and its failure was silently
+    # swallowed. The file must now be owner-only from birth without relying
+    # on chmod at all.
+    source = _make_openclaw_source(tmp_path)
+    home = tmp_path / "opensquilla-home"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+
+    real_chmod = os.chmod
+
+    def chmod_denied_for_env(path: object, mode: int, *args: object, **kwargs: object) -> None:
+        if str(path).endswith(".env"):
+            raise OSError(1, "Operation not permitted")
+        real_chmod(path, mode, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(os, "chmod", chmod_denied_for_env)
+
+    OpenClawMigrator(
+        MigrationOptions(
+            source=source,
+            config_path=tmp_path / "config.toml",
+            apply=True,
+            migrate_secrets=True,
+        )
+    ).migrate()
+
+    env_path = home / ".env"
+    assert "OPENAI_API_KEY=sk-dummy-openclaw" in env_path.read_text(encoding="utf-8")
+    _assert_owner_only(env_path)
+
+
+def test_openclaw_secret_env_write_failure_surfaces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A failure to land the secret file must propagate instead of being
+    # silently swallowed, and no temp file holding the secret may remain.
+    source = _make_openclaw_source(tmp_path)
+    home = tmp_path / "opensquilla-home"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+
+    real_replace = os.replace
+
+    def replace_denied_for_env(src: object, dst: object, *args: object, **kwargs: object) -> None:
+        if str(dst).endswith(".env"):
+            raise OSError(13, "Permission denied")
+        real_replace(src, dst, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(os, "replace", replace_denied_for_env)
+
+    with pytest.raises(OSError):
+        OpenClawMigrator(
+            MigrationOptions(
+                source=source,
+                config_path=tmp_path / "config.toml",
+                apply=True,
+                migrate_secrets=True,
+            )
+        ).migrate()
+
+    assert not (home / ".env").exists()
+    secret_holders = [
+        path
+        for path in home.rglob("*")
+        if path.is_file() and "sk-dummy-openclaw" in path.read_text(errors="replace")
+    ]
+    assert secret_holders == [], f"secret leaked into: {secret_holders}"
+
+
+def test_hermes_secret_env_write_failure_surfaces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = _make_hermes_source(tmp_path)
+    home = tmp_path / "opensquilla-home"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+
+    real_replace = os.replace
+
+    def replace_denied_for_env(src: object, dst: object, *args: object, **kwargs: object) -> None:
+        if str(dst).endswith(".env"):
+            raise OSError(13, "Permission denied")
+        real_replace(src, dst, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(os, "replace", replace_denied_for_env)
+
+    with pytest.raises(OSError):
+        HermesMigrator(
+            HermesMigrationOptions(
+                source=source,
+                config_path=tmp_path / "config.toml",
+                apply=True,
+                migrate_secrets=True,
+            )
+        ).migrate()
+
+    assert not (home / ".env").exists()
+    secret_holders = [
+        path
+        for path in home.rglob("*")
+        if path.is_file() and "sk-dummy-hermes" in path.read_text(errors="replace")
+    ]
+    assert secret_holders == [], f"secret leaked into: {secret_holders}"

--- a/tests/test_onboarding/test_channel_specs.py
+++ b/tests/test_onboarding/test_channel_specs.py
@@ -142,7 +142,10 @@ def test_wecom_connection_mode_choices():
     assert spec.transport == "mixed"
     assert spec.requires_public_url is False
     assert field.field_type == "select"
-    assert field.default == "websocket"
+    # Must mirror WeComChannelEntry.connection_mode: a headless entry that
+    # omits connection_mode is validated in the pydantic default mode.
+    assert field.default == "webhook"
+    assert field.default == WeComChannelEntry.model_fields["connection_mode"].default
     assert field.choices == ("websocket", "webhook")
 
 
@@ -224,10 +227,14 @@ def test_channel_catalog_payload_exposes_ui_metadata():
     slack_fields = {f["name"]: f for f in slack["fields"]}
     assert slack_fields["app_token"]["showWhen"] == {"connection_mode": "socket"}
     wecom = next(c for c in payload if c["type"] == "wecom")
-    assert "Bot ID." in wecom["whatYouNeed"]
-    assert "Bot secret." in wecom["whatYouNeed"]
-    assert "Corp id." not in wecom["whatYouNeed"]
-    assert "Encoding AES key." not in wecom["whatYouNeed"]
+    # whatYouNeed follows the spec default mode, which mirrors the pydantic
+    # default (webhook): the advertised minimal setup names the fields that
+    # webhook-mode validation actually requires.
+    assert "Corp id." in wecom["whatYouNeed"]
+    assert "Corp secret." in wecom["whatYouNeed"]
+    assert "Encoding AES key." in wecom["whatYouNeed"]
+    assert "Bot ID." not in wecom["whatYouNeed"]
+    assert "Bot secret." not in wecom["whatYouNeed"]
 
 
 def test_matrix_encryption_choices():
@@ -294,3 +301,63 @@ def test_catalog_is_sorted():
 
 def test_returns_setup_spec_instance():
     assert isinstance(get_channel_setup_spec("slack"), ChannelSetupSpec)
+
+
+@pytest.mark.parametrize("type_name", sorted(ALL_TYPES))
+def test_spec_field_defaults_match_pydantic_defaults(type_name: str):
+    """Catalog defaults must mirror the gateway pydantic defaults.
+
+    A spec default that diverges from the model default (as wecom's
+    connection_mode once did) advertises a minimal setup that the headless
+    path then validates in a *different* mode, guaranteeing failure.
+    """
+    from pydantic_core import PydanticUndefined
+
+    spec = get_channel_setup_spec(type_name)
+    model = ENTRY_MODELS[type_name]
+    for field in spec.fields:
+        finfo = model.model_fields.get(field.name)
+        if finfo is None or finfo.default is PydanticUndefined or field.default is None:
+            continue
+        assert field.default == finfo.default, (
+            f"{type_name}.{field.name}: spec default {field.default!r} "
+            f"diverges from pydantic default {finfo.default!r}"
+        )
+
+
+_DUMMY_FIELD_VALUES = {
+    "text": "dummy-value",
+    "password": "dummy-secret",
+    "int": 1,
+    "float": 1.0,
+    "bool": True,
+}
+
+
+@pytest.mark.parametrize("type_name", sorted(ALL_TYPES))
+def test_advertised_minimal_setup_passes_model_validation(type_name: str):
+    """The catalog's minimal recipe must satisfy the pydantic validators.
+
+    Mirrors the headless path: fill exactly the required fields that are
+    visible under the spec defaults (what the catalog Try command asks for),
+    leave everything else to model defaults, and expect a valid entry.
+    """
+    spec = get_channel_setup_spec(type_name)
+    defaults = {field.name: field.default for field in spec.fields}
+    entry: dict[str, object] = {"name": "test-entry"}
+    for field in spec.fields:
+        if not field.required or field.name == "name":
+            continue
+        if field.show_when and any(
+            str(defaults.get(key, "")) != expected
+            for key, expected in field.show_when.items()
+        ):
+            continue
+        if field.field_type == "select":
+            entry[field.name] = field.default
+        else:
+            entry[field.name] = _DUMMY_FIELD_VALUES[field.field_type]
+
+    model = ENTRY_MODELS[type_name]
+    validated = model(**entry)
+    assert validated.name == "test-entry"

--- a/tests/test_onboarding/test_config_store.py
+++ b/tests/test_onboarding/test_config_store.py
@@ -281,8 +281,10 @@ def test_persist_omits_runtime_secret_paths(tmp_path):
     target = tmp_path / "config.toml"
     persist_config(cfg, path=target)
 
-    data = tomllib.loads(target.read_text())
-    assert "api_key" not in data["llm"]
+    text = target.read_text()
+    data = tomllib.loads(text)
+    assert "api_key" not in data.get("llm", {})
+    assert "from-env" not in text
 
 
 def test_env_sourced_llm_key_is_not_persisted(tmp_path, monkeypatch):

--- a/tests/test_onboarding/test_config_store_sparse_persist.py
+++ b/tests/test_onboarding/test_config_store_sparse_persist.py
@@ -1,0 +1,532 @@
+"""Regression tests for sparse, diff-based config persistence.
+
+Covers the onboarding persistence audit findings:
+
+* env-derived values (secrets and overrides) must never be baked into the
+  TOML by an unrelated save;
+* explicit mutations must always be written;
+* pre-existing TOML values and extra raw keys must survive a save;
+* a small config must stay small after an unrelated save;
+* saves must write through symlinks, fsync before the atomic rename, and
+  merge (not clobber) non-conflicting concurrent on-disk edits.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.onboarding.config_store import load_config, persist_config
+
+
+def _write_small_config(target) -> None:
+    target.write_text(
+        "\n".join(
+            [
+                "[llm]",
+                'provider = "openrouter"',
+                'model = "deepseek/deepseek-v4-flash"',
+                "",
+            ]
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# A1: env-derived values must not be baked into the file
+# ---------------------------------------------------------------------------
+
+
+def test_persist_does_not_bake_env_auth_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENSQUILLA_AUTH_TOKEN", "tok-synthetic-123")
+    target = tmp_path / "config.toml"
+    _write_small_config(target)
+
+    cfg = load_config(target)
+    assert cfg.auth.token == "tok-synthetic-123"  # env reached the model
+    cfg.port = 18795  # unrelated explicit change
+
+    persist_config(cfg, path=target)
+
+    text = target.read_text()
+    assert "tok-synthetic-123" not in text
+    data = tomllib.loads(text)
+    assert "auth" not in data
+    assert data["port"] == 18795
+
+
+def test_persist_missing_file_does_not_bake_env_secret(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENSQUILLA_AUTH_TOKEN", "tok-synthetic-456")
+    target = tmp_path / "config.toml"
+
+    cfg = load_config(target)  # first run: no config on disk yet
+    cfg.llm.model = "deepseek/deepseek-v4-flash"  # differs from the default
+    persist_config(cfg, path=target)
+
+    text = target.read_text()
+    assert "tok-synthetic-456" not in text
+    data = tomllib.loads(text)
+    assert "auth" not in data
+    assert data["llm"]["model"] == "deepseek/deepseek-v4-flash"
+
+
+def test_persist_fresh_model_does_not_bake_env_secret(tmp_path, monkeypatch):
+    """Even a config never routed through load_config must not leak env."""
+    monkeypatch.setenv("OPENSQUILLA_AUTH_TOKEN", "tok-synthetic-789")
+    target = tmp_path / "config.toml"
+
+    cfg = GatewayConfig()
+    cfg.llm.model = "deepseek/deepseek-v4-flash"  # differs from the default
+    persist_config(cfg, path=target)
+
+    text = target.read_text()
+    assert "tok-synthetic-789" not in text
+    data = tomllib.loads(text)
+    assert "auth" not in data
+    assert data["llm"]["model"] == "deepseek/deepseek-v4-flash"
+
+
+def test_persist_does_not_freeze_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENSQUILLA_MEMORY_FLUSH_ENABLED", "true")
+    target = tmp_path / "config.toml"
+    target.write_text("port = 18791\n")
+
+    cfg = load_config(target)
+    assert cfg.memory.flush_enabled is True
+    cfg.port = 18795
+    persist_config(cfg, path=target)
+
+    assert "flush_enabled" not in target.read_text()
+
+    # Removing the env override must restore the built-in default: the save
+    # above must not have frozen the env value into the file.
+    monkeypatch.delenv("OPENSQUILLA_MEMORY_FLUSH_ENABLED")
+    assert load_config(target).memory.flush_enabled is False
+
+
+def test_persist_writes_explicit_mutation(tmp_path):
+    target = tmp_path / "config.toml"
+    target.write_text("port = 18791\n")
+
+    cfg = load_config(target)
+    cfg.memory.flush_enabled = True
+    persist_config(cfg, path=target)
+
+    data = tomllib.loads(target.read_text())
+    assert data["memory"]["flush_enabled"] is True
+    assert load_config(target).memory.flush_enabled is True
+
+
+def test_repersist_same_object_writes_revert(tmp_path):
+    """A second save of the same object diffs against what was just written."""
+    target = tmp_path / "config.toml"
+    target.write_text("port = 18791\n")
+
+    cfg = load_config(target)
+    cfg.memory.flush_enabled = True
+    persist_config(cfg, path=target)
+    assert tomllib.loads(target.read_text())["memory"]["flush_enabled"] is True
+
+    cfg.memory.flush_enabled = False
+    persist_config(cfg, path=target)
+    data = tomllib.loads(target.read_text())
+    assert data.get("memory", {}).get("flush_enabled") is False
+
+
+def test_persist_preserves_existing_toml_values(tmp_path):
+    target = tmp_path / "config.toml"
+    target.write_text(
+        "\n".join(
+            [
+                "[llm]",
+                'provider = "openrouter"',
+                'model = "deepseek/deepseek-v4-flash"',
+                "",
+                "[memory]",
+                "flush_enabled = true",
+                "",
+            ]
+        )
+    )
+
+    cfg = load_config(target)
+    cfg.port = 18795
+    persist_config(cfg, path=target)
+
+    data = tomllib.loads(target.read_text())
+    assert data["llm"]["provider"] == "openrouter"
+    assert data["memory"]["flush_enabled"] is True
+    assert data["port"] == 18795
+
+
+def test_persist_preserves_extra_raw_keys(tmp_path):
+    target = tmp_path / "config.toml"
+    target.write_text(
+        "\n".join(
+            [
+                "[llm]",
+                'provider = "openrouter"',
+                'model = "deepseek/deepseek-v4-flash"',
+                "",
+                "[channels.demo_extra]",
+                'note = "keep-me"',
+                "",
+            ]
+        )
+    )
+
+    cfg = load_config(target)
+    cfg.port = 18795
+    persist_config(cfg, path=target)
+
+    data = tomllib.loads(target.read_text())
+    assert data["channels"]["demo_extra"]["note"] == "keep-me"
+    assert data["port"] == 18795
+
+
+# ---------------------------------------------------------------------------
+# A5: no full-default dump on an unrelated save
+# ---------------------------------------------------------------------------
+
+
+def test_persist_keeps_small_config_small(tmp_path):
+    target = tmp_path / "config.toml"
+    _write_small_config(target)
+
+    cfg = load_config(target)
+    cfg.port = 18795
+    persist_config(cfg, path=target)
+
+    text = target.read_text()
+    data = tomllib.loads(text)
+    assert set(data) <= {"llm", "port", "config_version"}
+    assert len(text.splitlines()) < 12
+
+
+# ---------------------------------------------------------------------------
+# A2: writes go through symlinks instead of replacing them
+# ---------------------------------------------------------------------------
+
+
+def test_persist_updates_symlink_target_in_place(tmp_path):
+    real = tmp_path / "real-config.toml"
+    real.write_text("port = 18791\n")
+    link = tmp_path / "config.toml"
+    link.symlink_to(real)
+
+    cfg = load_config(link)
+    cfg.port = 18795
+    persist_config(cfg, path=link)
+
+    assert link.is_symlink()
+    assert tomllib.loads(real.read_text())["port"] == 18795
+    assert tomllib.loads(link.read_text())["port"] == 18795
+
+
+# ---------------------------------------------------------------------------
+# A3: fsync the temp file before the atomic rename
+# ---------------------------------------------------------------------------
+
+
+def test_persist_fsyncs_tempfile_before_replace(tmp_path, monkeypatch):
+    calls: list[str] = []
+    real_fsync = os.fsync
+    real_replace = os.replace
+
+    def tracking_fsync(fd):
+        calls.append("fsync")
+        return real_fsync(fd)
+
+    def tracking_replace(src, dst):
+        calls.append("replace")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "fsync", tracking_fsync)
+    monkeypatch.setattr(os, "replace", tracking_replace)
+
+    target = tmp_path / "config.toml"
+    persist_config(GatewayConfig(), path=target)
+
+    assert "fsync" in calls
+    assert calls.index("fsync") < calls.index("replace")
+
+
+# ---------------------------------------------------------------------------
+# A4: non-conflicting concurrent edits survive a save
+# ---------------------------------------------------------------------------
+
+
+def test_persist_merges_concurrent_disk_edits(tmp_path):
+    target = tmp_path / "config.toml"
+    _write_small_config(target)
+
+    cfg = load_config(target)
+    cfg.port = 18793  # field X: mutated in memory
+
+    # Another writer (e.g. a Web-UI save) adds field Y while the wizard
+    # is still sitting at a prompt.
+    target.write_text(
+        "\n".join(
+            [
+                "[llm]",
+                'provider = "openrouter"',
+                'model = "deepseek/deepseek-v4-flash"',
+                "",
+                "[memory]",
+                "flush_enabled = true",
+                "",
+            ]
+        )
+    )
+
+    persist_config(cfg, path=target)
+
+    data = tomllib.loads(target.read_text())
+    assert data["port"] == 18793  # X survives
+    assert data["memory"]["flush_enabled"] is True  # Y survives
+    assert data["llm"]["provider"] == "openrouter"
+
+
+# ---------------------------------------------------------------------------
+# A6: baselines are instance-scoped — two live objects for the same path
+# must not contaminate each other's diffs (R4).
+# ---------------------------------------------------------------------------
+
+
+def test_second_object_for_same_path_does_not_revert_first_writers_save(tmp_path):
+    """Two load_config objects for one file: object B's save must not diff
+    against object A's post-persist snapshot and silently revert A's write."""
+    target = tmp_path / "config.toml"
+    target.write_text("port = 18791\n")
+
+    a = load_config(target)
+    b = load_config(target)
+
+    a.port = 1111
+    persist_config(a, path=target)
+    assert tomllib.loads(target.read_text())["port"] == 1111
+
+    b.memory.flush_enabled = True
+    persist_config(b, path=target)
+
+    data = tomllib.loads(target.read_text())
+    assert data["memory"]["flush_enabled"] is True
+    # B never touched port, so A's persisted 1111 must survive B's save.
+    assert data["port"] == 1111
+
+
+def test_disk_fallback_model_save_does_not_revert_other_writers_change(tmp_path):
+    """A config that outlived another writer's save (no fresher baseline than
+    its own load) must still not revert the on-disk change it never touched."""
+    target = tmp_path / "config.toml"
+    target.write_text("port = 18791\n")
+
+    b = load_config(target)
+
+    # Another PROCESS (no shared state at all) changes port on disk.
+    target.write_text("port = 2222\n")
+
+    b.memory.flush_enabled = True
+    persist_config(b, path=target)
+
+    data = tomllib.loads(target.read_text())
+    assert data["memory"]["flush_enabled"] is True
+    assert data["port"] == 2222
+
+
+def test_save_as_to_different_path_carries_loaded_values(tmp_path):
+    """The instance baseline only describes the file the config was loaded
+    from: persisting to a DIFFERENT path (save-as/copy) must not diff the
+    copy against the instance's own load snapshot — that would erase every
+    loaded value and write a near-empty file."""
+    source = tmp_path / "config.toml"
+    source.write_text('port = 18795\n[llm]\nprovider = "openrouter"\nmodel = "custom/model-x"\n')
+    other = tmp_path / "copy.toml"
+
+    cfg = load_config(source)
+    persist_config(cfg, path=other, backup=False)
+
+    data = tomllib.loads(other.read_text())
+    assert data["port"] == 18795
+    assert data["llm"]["model"] == "custom/model-x"
+    # Values equal to the built-in default (provider = "openrouter") may be
+    # omitted from the sparse copy; the copy must still LOAD equivalently.
+    reloaded = load_config(other)
+    assert reloaded.port == 18795
+    assert reloaded.llm.provider == "openrouter"
+    assert reloaded.llm.model == "custom/model-x"
+
+    # The save-as must not disturb the instance's association with its own
+    # file: a later save back to the source still diffs against the load
+    # snapshot (only the mutated field lands, nothing is erased).
+    cfg.memory.flush_enabled = True
+    persist_config(cfg, path=source, backup=False)
+    source_data = tomllib.loads(source.read_text())
+    assert source_data["memory"]["flush_enabled"] is True
+    assert source_data["port"] == 18795
+    assert source_data["llm"]["model"] == "custom/model-x"
+
+
+# ---------------------------------------------------------------------------
+# A7: explicit search_api_key must persist even when it equals the
+# env-absorbed value (R5).
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_search_key_persists_when_equal_to_env_value(tmp_path, monkeypatch):
+    from opensquilla.onboarding.mutations import upsert_search_provider
+
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_SEARCH_API_KEY", "tvly-synthetic-abc")
+    target = tmp_path / "config.toml"
+    target.write_text("port = 18791\n")
+
+    cfg = load_config(target)
+    res = upsert_search_provider(
+        cfg, provider_id="tavily", api_key="tvly-synthetic-abc"
+    )
+    assert res.public_payload["api_key_source"] == "explicit"
+    persist_config(res.config, path=target)
+
+    data = tomllib.loads(target.read_text())
+    assert data["search_provider"] == "tavily"
+    # The operator explicitly typed the key: it must be stored so search
+    # keeps working after the env var disappears.
+    assert data["search_api_key"] == "tvly-synthetic-abc"
+
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_SEARCH_API_KEY")
+    assert load_config(target).search_api_key == "tvly-synthetic-abc"
+
+
+def test_env_only_search_key_still_never_persisted(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_SEARCH_API_KEY", "tvly-synthetic-env")
+    target = tmp_path / "config.toml"
+    target.write_text("port = 18791\n")
+
+    cfg = load_config(target)
+    cfg.port = 18795  # unrelated explicit change
+    persist_config(cfg, path=target)
+
+    assert "tvly-synthetic-env" not in target.read_text()
+
+
+def test_explicit_audio_key_persists_when_equal_to_env_value(tmp_path, monkeypatch):
+    """Same env-coincidence class as search_api_key: the audio provider key
+    section is pydantic-settings-bound, so an explicit entry equal to the
+    env-absorbed value used to diff as unchanged and vanish from the file —
+    leaving audio enabled with no stored credential."""
+    from opensquilla.onboarding.mutations import upsert_audio_provider
+
+    monkeypatch.setenv(
+        "OPENSQUILLA_AUDIO_PROVIDERS__ELEVENLABS__API_KEY", "el-synthetic-abc"
+    )
+    target = tmp_path / "config.toml"
+    target.write_text("port = 18791\n")
+
+    cfg = load_config(target)
+    res = upsert_audio_provider(
+        cfg, provider_id="elevenlabs", api_key="el-synthetic-abc", enabled=True
+    )
+    assert res.public_payload["api_key_source"] == "explicit"
+    persist_config(res.config, path=target)
+
+    data = tomllib.loads(target.read_text())
+    assert data["audio"]["enabled"] is True
+    assert data["audio"]["providers"]["elevenlabs"]["api_key"] == "el-synthetic-abc"
+
+    monkeypatch.delenv("OPENSQUILLA_AUDIO_PROVIDERS__ELEVENLABS__API_KEY")
+    assert load_config(target).audio.providers.elevenlabs.api_key == "el-synthetic-abc"
+
+
+def test_env_only_audio_key_still_never_persisted(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "OPENSQUILLA_AUDIO_PROVIDERS__ELEVENLABS__API_KEY", "el-synthetic-env"
+    )
+    target = tmp_path / "config.toml"
+    target.write_text("port = 18791\n")
+
+    cfg = load_config(target)
+    cfg.port = 18795  # unrelated explicit change
+    persist_config(cfg, path=target)
+
+    assert "el-synthetic-env" not in target.read_text()
+
+
+def test_explicit_image_key_persists_when_equal_to_env_value(tmp_path, monkeypatch):
+    from opensquilla.onboarding.mutations import upsert_image_generation_provider
+
+    monkeypatch.setenv(
+        "OPENSQUILLA_IMAGE_GENERATION_PROVIDERS__OPENAI__API_KEY", "sk-img-synthetic"
+    )
+    target = tmp_path / "config.toml"
+    target.write_text("port = 18791\n")
+
+    cfg = load_config(target)
+    res = upsert_image_generation_provider(
+        cfg,
+        provider_id="openai",
+        primary="openai/gpt-image-1",
+        api_key="sk-img-synthetic",
+        enabled=True,
+    )
+    persist_config(res.config, path=target)
+
+    data = tomllib.loads(target.read_text())
+    assert (
+        data["image_generation"]["providers"]["openai"]["api_key"] == "sk-img-synthetic"
+    )
+
+    monkeypatch.delenv("OPENSQUILLA_IMAGE_GENERATION_PROVIDERS__OPENAI__API_KEY")
+    reloaded = load_config(target)
+    assert reloaded.image_generation.providers.openai.api_key == "sk-img-synthetic"
+
+
+# ---------------------------------------------------------------------------
+# A8: boot-time env resolutions of llm.base_url / llm.proxy must not be
+# baked into the file by an unrelated gateway persist (R13).
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_persist_does_not_bake_env_resolved_base_url_and_proxy(
+    tmp_path, monkeypatch
+):
+    from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://intranet-proxy.local:8080/v1")
+    monkeypatch.setenv("OPENSQUILLA_LLM_PROXY", "http://127.0.0.1:7890")
+    target = tmp_path / "config.toml"
+    target.write_text('[llm]\nprovider = "openai"\nmodel = "gpt-5"\n')
+
+    cfg = GatewayConfig.load_from_toml(target)
+    cfg.config_path = str(target)
+    runtime = resolve_llm_runtime_config(cfg)
+    assert runtime.base_url == "http://intranet-proxy.local:8080/v1"
+    assert cfg.llm.base_url == "http://intranet-proxy.local:8080/v1"
+    assert cfg.llm.proxy == "http://127.0.0.1:7890"
+
+    cfg.port = 18795  # unrelated change through the gateway persist path
+    persist_config(cfg, path=target)
+
+    text = target.read_text()
+    assert "intranet-proxy.local" not in text
+    assert "127.0.0.1:7890" not in text
+    assert tomllib.loads(text)["port"] == 18795
+
+
+def test_gateway_persist_keeps_operator_edit_over_env_override(tmp_path, monkeypatch):
+    """An operator change made after boot beats the env-override restore."""
+    from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://intranet-proxy.local:8080/v1")
+    target = tmp_path / "config.toml"
+    target.write_text('[llm]\nprovider = "openai"\nmodel = "gpt-5"\n')
+
+    cfg = GatewayConfig.load_from_toml(target)
+    cfg.config_path = str(target)
+    resolve_llm_runtime_config(cfg)
+
+    cfg.llm.base_url = "https://operator.example.test/v1"  # explicit hot edit
+    persist_config(cfg, path=target)
+
+    data = tomllib.loads(target.read_text())
+    assert data["llm"]["base_url"] == "https://operator.example.test/v1"

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -72,28 +72,36 @@ def test_flush_stdin_typeahead_uses_termios_on_unix_tty(monkeypatch):
 def test_interactive_provider_choice_offers_all_runtime_supported_providers():
     from opensquilla.onboarding.flow import OnboardOptions, _ask_provider_choice
 
-    captured: dict[str, list[str]] = {}
+    captured: dict[str, object] = {}
 
     class _Question:
         def ask(self) -> str:
             return "openrouter (OpenRouter)"
 
     class _Questionary:
-        def select(self, _message: str, *, choices: list[str], default: str) -> _Question:
+        def select(
+            self, _message: str, *, choices: list[str], default: str, **kwargs
+        ) -> _Question:
             captured["choices"] = choices
             captured["default"] = default
+            captured["kwargs"] = kwargs
             return _Question()
 
     _ask_provider_choice(_Questionary(), OnboardOptions())
 
-    assert captured["choices"][0] == "openrouter (OpenRouter)"
+    choices = captured["choices"]
+    assert choices[0] == "openrouter (OpenRouter)"
     assert captured["default"] == "openrouter (OpenRouter)"
-    offered = {choice.split(" ")[0] for choice in captured["choices"]}
+    offered = {choice.split(" ")[0] for choice in choices}
     from tests.test_onboarding.test_provider_specs import EXPECTED_SUPPORTED
 
     assert offered == EXPECTED_SUPPORTED
     # Experimental providers are offered, but with a visible caveat.
-    assert any("(experimental)" in choice for choice in captured["choices"])
+    assert any("(experimental)" in choice for choice in choices)
+    # ~30 entries: the select must let the operator type to filter.
+    kwargs = captured["kwargs"]
+    assert kwargs["use_search_filter"] is True
+    assert kwargs["use_jk_keys"] is False
 
 
 def test_interactive_router_supported_provider_does_not_prompt_for_model(monkeypatch):
@@ -1999,8 +2007,17 @@ def test_interactive_configure_memory_embedding_is_in_section_menu(
     class _Questionary(types.SimpleNamespace):
         def select(self, message: str, **kwargs):
             if message == "Section":
-                assert "memory-embedding" in kwargs["choices"]
-                return _Answer("memory-embedding")
+                titles = kwargs["choices"]
+                target_title = next(
+                    (t for t in titles if t.startswith("Memory embedding")), None
+                )
+                if target_title is not None and not getattr(self, "_dispatched", False):
+                    self._dispatched = True
+                    return _Answer(target_title)
+                done = next(
+                    t for t in titles if t in ("Done", "Exit (nothing changed)")
+                )
+                return _Answer(done)
             if message == "Memory embedding provider":
                 return _Answer("openai (OpenAI)")
             if message == "Memory API key source":

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -96,9 +96,14 @@ def test_interactive_provider_choice_offers_all_runtime_supported_providers():
     assert any("(experimental)" in choice for choice in captured["choices"])
 
 
-def test_interactive_router_supported_provider_does_not_prompt_for_model():
+def test_interactive_router_supported_provider_does_not_prompt_for_model(monkeypatch):
+    from opensquilla.onboarding import flow
     from opensquilla.onboarding.flow import OnboardOptions, _ask_provider_fields
     from opensquilla.onboarding.provider_specs import get_provider_setup_spec
+
+    # The router-supported pre-save probe is exercised in
+    # test_flow_provider_verify.py; here it degrades silently (offline).
+    monkeypatch.setattr(flow, "_run_provider_probe", lambda **_kw: None)
 
     class _Questionary:
         def text(self, message: str, **_kwargs):
@@ -117,10 +122,12 @@ def test_interactive_router_supported_provider_does_not_prompt_for_model():
 
 
 def test_interactive_provider_fields_default_to_pasted_api_key(monkeypatch):
+    from opensquilla.onboarding import flow
     from opensquilla.onboarding.flow import OnboardOptions, _ask_provider_fields
     from opensquilla.onboarding.provider_specs import get_provider_setup_spec
 
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(flow, "_run_provider_probe", lambda **_kw: None)
 
     class _Answer:
         def __init__(self, value):
@@ -164,10 +171,12 @@ def test_interactive_provider_fields_default_to_pasted_api_key(monkeypatch):
 
 
 def test_interactive_provider_fields_explains_detected_env_key(monkeypatch):
+    from opensquilla.onboarding import flow
     from opensquilla.onboarding.flow import OnboardOptions, _ask_provider_fields
     from opensquilla.onboarding.provider_specs import get_provider_setup_spec
 
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-from-env")
+    monkeypatch.setattr(flow, "_run_provider_probe", lambda **_kw: None)
 
     class _Answer:
         def __init__(self, value):
@@ -202,10 +211,12 @@ def test_interactive_provider_fields_explains_detected_env_key(monkeypatch):
 
 
 def test_interactive_provider_fields_requires_pasted_api_key(monkeypatch):
+    from opensquilla.onboarding import flow
     from opensquilla.onboarding.flow import OnboardOptions, _ask_provider_fields
     from opensquilla.onboarding.provider_specs import get_provider_setup_spec
 
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(flow, "_run_provider_probe", lambda **_kw: None)
 
     class _Answer:
         def __init__(self, value):
@@ -239,10 +250,12 @@ def test_interactive_provider_fields_requires_pasted_api_key(monkeypatch):
 
 
 def test_interactive_provider_fields_rejects_terminal_paste_escape(monkeypatch):
+    from opensquilla.onboarding import flow
     from opensquilla.onboarding.flow import OnboardOptions, _ask_provider_fields
     from opensquilla.onboarding.provider_specs import get_provider_setup_spec
 
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(flow, "_run_provider_probe", lambda **_kw: None)
 
     class _Answer:
         def __init__(self, value):
@@ -288,6 +301,7 @@ def test_interactive_onboard_prompts_router_defaults_before_persist(tmp_path, mo
     monkeypatch.setattr(flow, "_is_tty", lambda: True)
     monkeypatch.setattr(flow, "_wait_for_setup_start", lambda: calls.append("start gate"))
     monkeypatch.setattr(flow, "detect_default_sources", lambda: [])
+    monkeypatch.setattr(flow, "_run_provider_probe", lambda **_kw: None)
 
     calls: list[str] = []
 
@@ -347,11 +361,13 @@ def test_interactive_onboard_prompts_router_defaults_before_persist(tmp_path, mo
     assert calls[0] == "start gate"
     assert calls[1] == "LLM provider"
     assert calls.index("Router mode") < calls.index("Configure a messaging channel now?")
-    data = target.read_text()
-    assert 'api_key = ""' in data
-    assert 'api_key_env = "OPENROUTER_API_KEY"' in data
-    assert 'default_tier = "c2"' in data
-    assert 'model = "z-ai/glm-5.2"' in data
+    # Persistence is sparse (default-equal values may be omitted from the
+    # TOML), so pin the reloaded semantic state rather than raw file lines.
+    saved = flow.load_config(target)
+    assert saved.llm.api_key == ""
+    assert saved.llm.api_key_env == "OPENROUTER_API_KEY"
+    assert saved.squilla_router.default_tier == "c2"
+    assert saved.llm.model == "z-ai/glm-5.2"
 
 
 def test_interactive_onboard_migration_defaults_to_all_sources_and_keeps_imported_provider(
@@ -494,12 +510,15 @@ def test_interactive_onboard_migration_defaults_to_all_sources_and_keeps_importe
     assert "LLM provider" not in calls
     assert "Router mode" in calls
     data = tomllib.loads(target.read_text())
-    assert data["llm"]["provider"] == "openrouter"
-    assert data["llm"]["api_key_env"] == "OPENROUTER_API_KEY"
-    assert data["llm"]["model"] == "deepseek/deepseek-v4-pro"
-    assert data["squilla_router"]["enabled"] is True
-    assert data["squilla_router"]["tier_profile"] == "openrouter"
-    assert "api_key" not in data["llm"]
+    # Sparse persistence may omit default-equal keys from the raw TOML, so
+    # the enabled/provider pins go through the reloaded semantic state.
+    saved = flow.load_config(target)
+    assert saved.llm.provider == "openrouter"
+    assert saved.llm.api_key_env == "OPENROUTER_API_KEY"
+    assert saved.llm.model == "deepseek/deepseek-v4-pro"
+    assert saved.squilla_router.enabled is True
+    assert saved.squilla_router.tier_profile == "openrouter"
+    assert "api_key" not in data.get("llm", {})
 
 
 def test_interactive_onboard_imported_provider_prefers_inline_key_over_env(
@@ -637,6 +656,7 @@ def test_interactive_onboard_imported_provider_finalize_error_continues_setup(
         "_use_imported_provider_credentials_with_router_defaults",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("bad imported provider")),
     )
+    monkeypatch.setattr(flow, "_run_provider_probe", lambda **_kw: None)
 
     calls: list[str] = []
 
@@ -840,6 +860,7 @@ def test_interactive_onboard_migration_preview_failure_continues_provider_setup(
     monkeypatch.setattr(flow, "_wait_for_setup_start", lambda: calls.append("start gate"))
     detected = [flow.DetectedMigrationSource("openclaw", tmp_path / ".openclaw")]
     monkeypatch.setattr(flow, "detect_default_sources", lambda: detected)
+    monkeypatch.setattr(flow, "_run_provider_probe", lambda **_kw: None)
 
     calls: list[str] = []
     batches: list[tuple[tuple[str, ...], bool]] = []
@@ -912,9 +933,10 @@ def test_interactive_onboard_migration_preview_failure_continues_provider_setup(
     assert batches == [(("openclaw",), False)]
     assert "Apply this migration now?" not in calls
     assert "LLM provider" in calls
-    data = target.read_text()
-    assert 'provider = "openrouter"' in data
-    assert 'api_key_env = "OPENROUTER_API_KEY"' in data
+    # Sparse persistence may omit default-equal keys; pin the reloaded state.
+    saved = flow.load_config(target)
+    assert saved.llm.provider == "openrouter"
+    assert saved.llm.api_key_env == "OPENROUTER_API_KEY"
 
 
 def test_interactive_onboard_migration_prompts_for_missing_imported_provider_key(
@@ -1043,6 +1065,7 @@ def test_interactive_onboard_can_enable_image_generation(tmp_path, monkeypatch):
     monkeypatch.setattr(flow, "_is_tty", lambda: True)
     monkeypatch.setattr(flow, "_wait_for_setup_start", lambda: None)
     monkeypatch.setattr(flow, "detect_default_sources", lambda: [])
+    monkeypatch.setattr(flow, "_run_provider_probe", lambda **_kw: None)
 
     calls: list[str] = []
 
@@ -1220,7 +1243,6 @@ def test_onboard_if_needed_core_ready_repairs_memory_embedding_without_provider_
 
 def test_interactive_configure_image_generation_persists(tmp_path, monkeypatch):
     import sys
-    import tomllib
     import types
 
     from opensquilla.onboarding import flow
@@ -1277,9 +1299,10 @@ def test_interactive_configure_image_generation_persists(tmp_path, monkeypatch):
         "Image base URL",
         "Image generation enabled?",
     ]
-    data = tomllib.loads(target.read_text())
-    assert data["image_generation"]["enabled"] is True
-    assert data["image_generation"]["primary"] == "openai/gpt-image-1"
+    # Sparse persistence may omit default-equal keys; pin the reloaded state.
+    saved = flow.load_config(target)
+    assert saved.image_generation.enabled is True
+    assert saved.image_generation.primary == "openai/gpt-image-1"
 
 
 def test_interactive_configure_image_generation_uses_explicit_config_path(
@@ -1287,7 +1310,6 @@ def test_interactive_configure_image_generation_uses_explicit_config_path(
     monkeypatch,
 ):
     import sys
-    import tomllib
     import types
 
     from opensquilla.onboarding import flow
@@ -1333,9 +1355,10 @@ def test_interactive_configure_image_generation_uses_explicit_config_path(
 
     flow.run_interactive_configure("image-generation", config_path=target)
 
-    data = tomllib.loads(target.read_text())
-    assert data["image_generation"]["enabled"] is True
-    assert data["image_generation"]["providers"]["openai"]["api_key_env"] == "OPENAI_API_KEY"
+    # Sparse persistence may omit default-equal keys; pin the reloaded state.
+    saved = flow.load_config(target)
+    assert saved.image_generation.enabled is True
+    assert saved.image_generation.providers.openai.api_key_env == "OPENAI_API_KEY"
     assert not default_target.exists()
 
 
@@ -1882,17 +1905,15 @@ def test_noninteractive_provider_configure_writes_config(tmp_path, monkeypatch):
     assert "openrouter" in target.read_text()
 
 
-def test_noninteractive_channel_add_writes_config(tmp_path, monkeypatch):
-    target = tmp_path / "c.toml"
-    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
-    from opensquilla.onboarding.flow import run_noninteractive_channel_add
+def test_flow_module_exposes_no_engine_bypassing_noninteractive_writers():
+    """Headless channel/search writes go through the CLI's SetupEngine path;
+    the old module-level helpers persisted config while bypassing the
+    engine's restart/warning accumulation and must stay deleted."""
 
-    result = run_noninteractive_channel_add(
-        "slack",
-        {"name": "w", "token": "x", "signing_secret": "ss"},
-    )
-    assert result.path == target
-    assert "slack" in target.read_text()
+    from opensquilla.onboarding import flow
+
+    assert not hasattr(flow, "run_noninteractive_channel_add")
+    assert not hasattr(flow, "run_noninteractive_search_configure")
 
 
 def test_interactive_configure_search_uses_explicit_config_path(tmp_path, monkeypatch):
@@ -1945,7 +1966,10 @@ def test_interactive_configure_search_uses_explicit_config_path(tmp_path, monkey
     flow.run_interactive_configure("search", config_path=target)
 
     data = tomllib.loads(target.read_text())
-    assert data["search_provider"] == "duckduckgo"
+    # Sparse persistence may omit default-equal keys (duckduckgo is the
+    # default provider); pin the reloaded semantic state instead.
+    saved = flow.load_config(target)
+    assert saved.search_provider == "duckduckgo"
     assert data["search_max_results"] == 7
     assert not default_target.exists()
 
@@ -2143,3 +2167,195 @@ def test_interactive_configure_without_tty_does_not_create_config(
     assert "Headless provider:" not in out
     assert "Check status:" in out
     assert not target.exists()
+
+
+def test_interactive_configure_provider_scopes_out_migration_and_optional_sections(
+    tmp_path,
+    monkeypatch,
+):
+    """``onboard configure provider`` is a scoped key swap: it must not
+    re-trigger the legacy-migration pre-step or the optional image-generation
+    prompt that the full first-run wizard walks through."""
+
+    from opensquilla.onboarding import flow
+    from opensquilla.onboarding.config_store import PersistResult
+
+    target = tmp_path / "custom.toml"
+    seen = {}
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    def fake_run_interactive_onboard(options):
+        seen["options"] = options
+        return PersistResult(
+            path=target,
+            backup_path=None,
+            restart_required=False,
+            warnings=[],
+        )
+
+    monkeypatch.setattr(flow, "run_interactive_onboard", fake_run_interactive_onboard)
+
+    result = flow.run_interactive_configure("provider", config_path=target)
+
+    assert result is not None
+    options = seen["options"]
+    assert options.skip_migration is True
+    assert options.skip_image_generation is True
+    assert options.skip_channels is True
+    assert options.skip_search is True
+    assert options.config_path == target
+
+
+def test_interactive_configure_dispatches_short_image_and_memory_aliases(
+    tmp_path,
+    monkeypatch,
+):
+    """The CLI help advertises ``configure image`` / ``configure memory``;
+    the wizard dispatch must consume the setup engine's alias sets instead
+    of a hand-copied subset that dropped the short spellings and answered
+    "not yet supported"."""
+
+    from opensquilla.onboarding import flow
+    from opensquilla.onboarding.config_store import PersistResult
+
+    target = tmp_path / "custom.toml"
+    dispatched: list[str] = []
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    def _fake_runner(name):
+        def runner(config_path=None):
+            dispatched.append(name)
+            assert config_path == target
+            return PersistResult(
+                path=target,
+                backup_path=None,
+                restart_required=False,
+                warnings=[],
+            )
+
+        return runner
+
+    monkeypatch.setattr(
+        flow,
+        "run_interactive_image_generation_configure",
+        _fake_runner("image-generation"),
+    )
+    monkeypatch.setattr(
+        flow,
+        "run_interactive_memory_embedding_configure",
+        _fake_runner("memory-embedding"),
+    )
+
+    assert flow.run_interactive_configure("image", config_path=target) is not None
+    assert flow.run_interactive_configure("memory", config_path=target) is not None
+    assert dispatched == ["image-generation", "memory-embedding"]
+
+
+class _RecordingConsole:
+    def __init__(self):
+        self.messages: list[str] = []
+
+    def print(self, message="", *_a, **_kw):
+        self.messages.append(str(message))
+
+    def joined(self) -> str:
+        return "\n".join(self.messages)
+
+
+def test_interactive_configure_unknown_section_names_explicit_config_path(
+    tmp_path,
+    monkeypatch,
+):
+    """The unsupported-section notice must name the config file this run
+    would actually edit (the explicit ``--config`` path here), not a
+    hardcoded ``~/.opensquilla/config.toml``."""
+
+    from opensquilla.onboarding import flow
+
+    target = tmp_path / "custom.toml"
+    recorder = _RecordingConsole()
+    monkeypatch.setattr(flow, "console", recorder)
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    result = flow.run_interactive_configure(
+        "definitely-not-a-section", config_path=target
+    )
+
+    assert result is None
+    joined = recorder.joined()
+    assert str(target) in joined
+    assert "~/.opensquilla/config.toml" not in joined
+
+
+def test_interactive_configure_unknown_section_honours_env_config_path(
+    tmp_path,
+    monkeypatch,
+):
+    from opensquilla.onboarding import flow
+
+    target = tmp_path / "env-config.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    recorder = _RecordingConsole()
+    monkeypatch.setattr(flow, "console", recorder)
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    result = flow.run_interactive_configure("definitely-not-a-section")
+
+    assert result is None
+    joined = recorder.joined()
+    assert str(target) in joined
+    assert "~/.opensquilla/config.toml" not in joined
+
+
+def test_interactive_memory_embedding_configure_reports_mutation_restart_required(
+    tmp_path,
+    monkeypatch,
+):
+    """The embedding mutation reports ``restart_required`` when the setup
+    actually changed (embedding edits only take effect after a full gateway
+    restart); the interactive runner used to hardcode ``False`` over it."""
+
+    import sys
+    import types
+
+    from opensquilla.onboarding import flow
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-memory-env")
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    class _Answer:
+        def __init__(self, value):
+            self.value = value
+
+        def ask(self):
+            return self.value
+
+    class _Questionary(types.SimpleNamespace):
+        def select(self, message: str, **kwargs):
+            if message == "Memory embedding provider":
+                return _Answer("openai (OpenAI)")
+            if message == "Memory API key source":
+                return _Answer("Use environment variable OPENAI_API_KEY (detected)")
+            raise AssertionError(f"unexpected select prompt: {message}")
+
+        def text(self, message: str, **kwargs):
+            if message in {"Memory embedding model", "Memory embedding base URL"}:
+                return _Answer(kwargs.get("default"))
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+        def password(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected password prompt: {message}")
+
+        def confirm(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected confirm prompt: {message}")
+
+        def checkbox(self, message: str, **_kwargs):
+            raise AssertionError(f"unexpected checkbox prompt: {message}")
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    result = flow.run_interactive_memory_embedding_configure(config_path=target)
+
+    assert result.restart_required is True

--- a/tests/test_onboarding/test_flow_cancel.py
+++ b/tests/test_onboarding/test_flow_cancel.py
@@ -223,9 +223,13 @@ def test_optional_section_runner_swallows_keyboard_interrupt(monkeypatch):
 
 
 def test_optional_section_runner_propagates_value_error():
-    """ValueError must propagate — those usually indicate real validation
-    or programming errors, not user cancels. Swallowing them would let
-    "Onboarding Complete" print over a broken config."""
+    """ValueError must propagate — those indicate real validation or
+    programming errors, not user cancels. Swallowing them would let
+    "Onboarding Complete" print over a broken config.
+
+    Contract note: interactive numeric prompts now carry ``validate=`` hooks,
+    so a user typo re-prompts at the input line and never surfaces here as a
+    ValueError. Propagation stays pinned for genuine programming errors."""
 
     def _runner():
         raise ValueError("search provider 'brave' requires an api_key")
@@ -247,3 +251,531 @@ def test_optional_section_runner_propagates_unexpected_exception():
         flow._run_optional_section(
             section="search", label="search", runner=_runner
         )
+
+
+# ---------------------------------------------------------------------------
+# Image generation: cancel must never flow onward as ``None``.
+# ---------------------------------------------------------------------------
+
+
+def test_image_generation_provider_choice_cancel_raises_user_cancelled():
+    """A cancel at the provider select used to crash with
+    ``AttributeError: 'NoneType' object has no attribute 'split'`` — which
+    escapes ``_run_optional_section`` and kills the whole wizard."""
+
+    from opensquilla.gateway.config import GatewayConfig
+
+    q = _Questionary(select_value=None)
+    with pytest.raises(UserCancelledError) as exc_info:
+        flow._ask_image_generation_choice(q, GatewayConfig())
+    assert exc_info.value.section == "image-generation"
+
+
+def test_image_generation_enabled_confirm_cancel_raises_user_cancelled(monkeypatch):
+    """Cancelling the "Image generation enabled?" consent confirm used to
+    store ``None`` and persist ``enabled = false`` under a success banner."""
+
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.onboarding.image_generation_specs import (
+        get_image_generation_provider_setup_spec,
+    )
+
+    monkeypatch.setattr(flow, "console", _RecordingConsole())
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-image-env")
+
+    class _Prompted:
+        def select(self, message, **_kw):
+            if message == "Image API key source":
+                return _Prompt("Use environment variable OPENAI_API_KEY")
+            raise AssertionError(f"unexpected select prompt: {message}")
+
+        def text(self, message, **kwargs):
+            return _Prompt(kwargs.get("default"))
+
+        def confirm(self, message, **_kw):
+            assert message == "Image generation enabled?"
+            return _Prompt(None)
+
+        def password(self, message, **_kw):
+            raise AssertionError(f"unexpected password prompt: {message}")
+
+    with pytest.raises(UserCancelledError) as exc_info:
+        flow._ask_image_generation_fields(
+            _Prompted(),
+            get_image_generation_provider_setup_spec("openai"),
+            GatewayConfig(),
+        )
+    assert exc_info.value.section == "image-generation"
+
+
+def test_image_generation_configure_cancel_persists_nothing(tmp_path, monkeypatch):
+    """An end-to-end cancel at the consent confirm must leave the config
+    untouched instead of writing ``enabled = false`` and printing
+    "Image generation configured."."""
+
+    import sys
+    import types
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-image-env")
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    monkeypatch.setattr(flow, "console", _RecordingConsole())
+
+    class _Answer:
+        def __init__(self, value):
+            self.value = value
+
+        def ask(self):
+            return self.value
+
+    class _FakeQuestionary(types.SimpleNamespace):
+        def select(self, message, **kwargs):
+            if message == "Image generation provider":
+                return _Answer("openai (OpenAI Images)")
+            if message == "Image API key source":
+                return _Answer("Use environment variable OPENAI_API_KEY")
+            raise AssertionError(f"unexpected select prompt: {message}")
+
+        def text(self, message, **kwargs):
+            return _Answer(kwargs.get("default"))
+
+        def confirm(self, message, **_kw):
+            assert message == "Image generation enabled?"
+            return _Answer(None)
+
+        def password(self, message, **_kw):
+            raise AssertionError(f"unexpected password prompt: {message}")
+
+        def checkbox(self, message, **_kw):
+            raise AssertionError(f"unexpected checkbox prompt: {message}")
+
+    monkeypatch.setitem(sys.modules, "questionary", _FakeQuestionary())
+
+    with pytest.raises(UserCancelledError):
+        flow.run_interactive_image_generation_configure(config_path=target)
+
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# Channel wizard cancels.
+# ---------------------------------------------------------------------------
+
+
+def _channel_questionary_module(select_value):
+    import types
+
+    class _Answer:
+        def __init__(self, value):
+            self.value = value
+
+        def ask(self):
+            return self.value
+
+    class _FakeQuestionary(types.SimpleNamespace):
+        def select(self, message, **_kw):
+            return _Answer(select_value)
+
+        def text(self, message, **_kw):
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+        def password(self, message, **_kw):
+            raise AssertionError(f"unexpected password prompt: {message}")
+
+        def confirm(self, message, **_kw):
+            raise AssertionError(f"unexpected confirm prompt: {message}")
+
+        def checkbox(self, message, **_kw):
+            raise AssertionError(f"unexpected checkbox prompt: {message}")
+
+    return _FakeQuestionary()
+
+
+def test_channel_add_type_select_cancel_raises_user_cancelled(tmp_path, monkeypatch):
+    """Cancelling the channel-type select used to crash with
+    ``KeyError: "unknown channel type: None"``."""
+
+    import sys
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    monkeypatch.setitem(sys.modules, "questionary", _channel_questionary_module(None))
+
+    with pytest.raises(UserCancelledError) as exc_info:
+        flow.run_interactive_channel_add(None, config_path=target)
+    assert exc_info.value.section == "channels"
+    assert not target.exists()
+
+
+def test_channel_edit_picker_cancel_raises_user_cancelled(tmp_path, monkeypatch):
+    """Cancelling the channel-to-edit select used to crash with a bare
+    ``StopIteration`` from the entry lookup."""
+
+    import sys
+
+    from opensquilla.onboarding.setup_engine import SetupEngine
+
+    target = tmp_path / "c.toml"
+    engine = SetupEngine(path=target)
+    engine.apply(
+        "channels",
+        {
+            "type": "slack",
+            "name": "slack-main",
+            "token": "xoxb-stored",
+            "signing_secret": "ss-stored",
+        },
+    )
+    engine.persist()
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    monkeypatch.setattr(flow, "console", _RecordingConsole())
+    monkeypatch.setitem(sys.modules, "questionary", _channel_questionary_module(None))
+
+    before = target.read_text()
+    with pytest.raises(UserCancelledError) as exc_info:
+        flow.run_interactive_channel_edit(None, config_path=target)
+    assert exc_info.value.section == "channels"
+    assert target.read_text() == before
+
+
+@pytest.mark.parametrize(
+    ("field_type", "extra"),
+    [
+        ("select", {"choices": ("webhook", "socket")}),
+        ("bool", {"default": True}),
+        ("password", {"secret": True}),
+        ("int", {"default": 3}),
+        ("float", {"default": 1.5}),
+        ("text", {}),
+    ],
+)
+def test_channel_field_prompt_cancel_raises_user_cancelled(field_type, extra):
+    """Every channel field prompt must convert a cancel into the typed
+    error instead of storing ``None``/coerced garbage for pydantic to
+    reject much later."""
+
+    from opensquilla.onboarding.channel_specs import ChannelSetupField
+
+    field = ChannelSetupField(
+        name="sample",
+        label="Sample field",
+        field_type=field_type,
+        required=True,
+        **extra,
+    )
+
+    class _CancellingQuestionary(_Questionary):
+        def text(self, *_a, **_kw):
+            return _Prompt(None)
+
+    q = _CancellingQuestionary(
+        select_value=None, password_value=None, confirm_value=None
+    )
+    with pytest.raises(UserCancelledError) as exc_info:
+        flow._ask_channel_field(q, field, field.default)
+    assert exc_info.value.section == "channels"
+
+
+# ---------------------------------------------------------------------------
+# Router consent prompts.
+# ---------------------------------------------------------------------------
+
+
+def test_router_mode_cancel_raises_user_cancelled():
+    """Cancelling the "Router mode" consent select used to map ``None`` to
+    "recommended" and persist ``squilla_router.enabled = true``."""
+
+    from opensquilla.gateway.config import GatewayConfig
+
+    q = _Questionary(select_value=None)
+    with pytest.raises(UserCancelledError) as exc_info:
+        flow._ask_router_fields(
+            q,
+            GatewayConfig(),
+            provider_id="openrouter",
+            requested_mode="recommended",
+        )
+    assert exc_info.value.section == "router"
+
+
+def test_router_default_tier_cancel_raises_user_cancelled(monkeypatch):
+    """Cancelling the default-tier select must not silently persist c1."""
+
+    from opensquilla.gateway.config import GatewayConfig
+
+    monkeypatch.setattr(flow, "console", _RecordingConsole())
+
+    class _Prompted:
+        def select(self, message, **_kw):
+            if message == "Router mode":
+                return _Prompt("SquillaRouter")
+            if message == "Default text model":
+                return _Prompt(None)
+            raise AssertionError(f"unexpected select prompt: {message}")
+
+        def confirm(self, message, **_kw):
+            raise AssertionError(f"unexpected confirm prompt: {message}")
+
+    with pytest.raises(UserCancelledError) as exc_info:
+        flow._ask_router_fields(
+            _Prompted(),
+            GatewayConfig(),
+            provider_id="openrouter",
+            requested_mode="recommended",
+        )
+    assert exc_info.value.section == "router"
+
+
+# ---------------------------------------------------------------------------
+# Provider key-source select.
+# ---------------------------------------------------------------------------
+
+
+def test_provider_key_source_cancel_raises_before_password_prompt(monkeypatch):
+    """A cancel at the key-source select used to be indistinguishable from
+    "Paste API key now" and dropped the user into a required password
+    prompt."""
+
+    from opensquilla.onboarding.flow import OnboardOptions, _ask_provider_fields
+    from opensquilla.onboarding.provider_specs import get_provider_setup_spec
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    password_fired: list[str] = []
+
+    class _Prompted:
+        def select(self, message, **_kw):
+            assert message == "LLM API key source"
+            return _Prompt(None)
+
+        def password(self, message, **_kw):
+            password_fired.append(message)
+            return _Prompt("sk-should-never-be-asked")
+
+    with pytest.raises(UserCancelledError) as exc_info:
+        _ask_provider_fields(
+            _Prompted(),
+            get_provider_setup_spec("openrouter"),
+            OnboardOptions(),
+        )
+    assert exc_info.value.section == "provider"
+    assert password_fired == []
+
+
+# ---------------------------------------------------------------------------
+# Required provider stage: cancel propagates out of the wizard entry point.
+# ---------------------------------------------------------------------------
+
+
+def test_onboard_cancel_at_required_provider_stage_propagates(tmp_path, monkeypatch):
+    """Cancelling the required provider select must surface as a typed
+    cancellation from ``run_interactive_onboard`` (the CLI boundary decides
+    how to render it) and must not write any config."""
+
+    import sys
+    import types
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    monkeypatch.setattr(flow, "_wait_for_setup_start", lambda: None)
+    monkeypatch.setattr(flow, "detect_default_sources", lambda: [])
+    monkeypatch.setattr(flow, "console", _RecordingConsole())
+
+    class _Answer:
+        def __init__(self, value):
+            self.value = value
+
+        def ask(self):
+            return self.value
+
+    class _FakeQuestionary(types.SimpleNamespace):
+        def select(self, message, **_kw):
+            assert message == "LLM provider"
+            return _Answer(None)
+
+        def text(self, message, **_kw):
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+        def password(self, message, **_kw):
+            raise AssertionError(f"unexpected password prompt: {message}")
+
+        def confirm(self, message, **_kw):
+            raise AssertionError(f"unexpected confirm prompt: {message}")
+
+        def checkbox(self, message, **_kw):
+            raise AssertionError(f"unexpected checkbox prompt: {message}")
+
+    monkeypatch.setitem(sys.modules, "questionary", _FakeQuestionary())
+
+    with pytest.raises(UserCancelledError) as exc_info:
+        flow.run_interactive_onboard(flow.OnboardOptions())
+    assert exc_info.value.section == "provider"
+    assert not target.exists()
+
+
+def test_onboard_router_cancel_keeps_provider_and_skips_router(tmp_path, monkeypatch):
+    """Cancelling the router step of the full wizard must skip the router
+    section without persisting a fabricated router answer and without
+    discarding the provider credentials entered just before it."""
+
+    import sys
+    import types
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    monkeypatch.setattr(flow, "_wait_for_setup_start", lambda: None)
+    monkeypatch.setattr(flow, "detect_default_sources", lambda: [])
+    # The pre-save connection check is not under test here; degrade silently.
+    monkeypatch.setattr(flow, "_run_provider_probe", lambda **_kw: None)
+    recorder = _RecordingConsole()
+    monkeypatch.setattr(flow, "console", recorder)
+
+    real_upsert_router = flow.upsert_router
+    router_calls: list[dict[str, Any]] = []
+
+    def recording_upsert_router(*args: Any, **kwargs: Any) -> Any:
+        router_calls.append(kwargs)
+        return real_upsert_router(*args, **kwargs)
+
+    monkeypatch.setattr(flow, "upsert_router", recording_upsert_router)
+
+    class _Answer:
+        def __init__(self, value):
+            self.value = value
+
+        def ask(self):
+            return self.value
+
+    class _FakeQuestionary(types.SimpleNamespace):
+        def select(self, message, **_kw):
+            if message == "LLM provider":
+                return _Answer("openrouter (OpenRouter)")
+            if message == "LLM API key source":
+                return _Answer("Use environment variable OPENROUTER_API_KEY")
+            if message == "Router mode":
+                return _Answer(None)
+            raise AssertionError(f"unexpected select prompt: {message}")
+
+        def confirm(self, message, **_kw):
+            if message in {
+                "Configure a messaging channel now?",
+                "Configure web search now?",
+                "Enable image generation now?",
+            }:
+                return _Answer(False)
+            raise AssertionError(f"unexpected confirm prompt: {message}")
+
+        def text(self, message, **_kw):
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+        def password(self, message, **_kw):
+            raise AssertionError(f"unexpected password prompt: {message}")
+
+        def checkbox(self, message, **_kw):
+            raise AssertionError(f"unexpected checkbox prompt: {message}")
+
+    monkeypatch.setitem(sys.modules, "questionary", _FakeQuestionary())
+
+    flow.run_interactive_onboard(flow.OnboardOptions())
+
+    assert router_calls == [], "a cancelled router step must not call upsert_router"
+    joined = recorder.joined()
+    assert "router setup cancelled" in joined.lower()
+    assert "opensquilla onboard configure router" in joined
+    import tomllib
+
+    data = tomllib.loads(target.read_text())
+    # The credentials entered right before the router cancel are kept.
+    assert data["llm"]["api_key_env"] == "OPENROUTER_API_KEY"
+
+
+# ---------------------------------------------------------------------------
+# Router tier editor: Esc must cancel, not persist (R3).
+# ---------------------------------------------------------------------------
+
+
+def test_router_tier_editor_select_cancel_raises_user_cancelled():
+    """Esc at "Tier to edit" used to map to Done and let both callers run
+    upsert_router + persist_config — a destructive re-save on explicit
+    abort. It must raise the typed cancel like every sibling prompt."""
+
+    from opensquilla.gateway.config import GatewayConfig
+
+    q = _Questionary(select_value=None)
+    with pytest.raises(UserCancelledError) as exc_info:
+        flow._router_tier_overrides(q, GatewayConfig())
+    assert exc_info.value.section == "router"
+
+
+def test_router_tier_editor_text_prompt_cancel_raises_user_cancelled():
+    """Esc at the tier provider/model text prompts used to silently mean
+    keep-current-and-continue."""
+
+    from opensquilla.gateway.config import GatewayConfig
+
+    class _Prompted:
+        def select(self, message, **_kw):
+            assert message == "Tier to edit"
+            return _Prompt("Route c1")
+
+        def text(self, message, **_kw):
+            assert message == "c1 provider"
+            return _Prompt(None)
+
+    with pytest.raises(UserCancelledError) as exc_info:
+        flow._router_tier_overrides(_Prompted(), GatewayConfig())
+    assert exc_info.value.section == "router"
+
+
+def test_router_configure_tier_editor_cancel_persists_nothing(tmp_path, monkeypatch):
+    """End-to-end: `onboard configure router` -> SquillaRouter -> edit tiers
+    -> Esc at "Tier to edit" must not write config.toml (previously it
+    replaced a hand-edited inline ladder with the packaged profile)."""
+
+    import sys
+    import types
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    monkeypatch.setattr(flow, "console", _RecordingConsole())
+
+    class _Answer:
+        def __init__(self, value):
+            self.value = value
+
+        def ask(self):
+            return self.value
+
+    class _FakeQuestionary(types.SimpleNamespace):
+        def select(self, message, **_kw):
+            if message == "Router mode":
+                return _Answer("SquillaRouter")
+            if message == "Default text model":
+                return _Answer("Route c1")
+            if message == "Tier to edit":
+                return _Answer(None)  # Esc
+            raise AssertionError(f"unexpected select prompt: {message}")
+
+        def confirm(self, message, **_kw):
+            assert message == "Edit router tier models now?"
+            return _Answer(True)
+
+        def text(self, message, **_kw):
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+        def password(self, message, **_kw):
+            raise AssertionError(f"unexpected password prompt: {message}")
+
+        def checkbox(self, message, **_kw):
+            raise AssertionError(f"unexpected checkbox prompt: {message}")
+
+    monkeypatch.setitem(sys.modules, "questionary", _FakeQuestionary())
+
+    with pytest.raises(UserCancelledError) as exc_info:
+        flow.run_interactive_router_configure(config_path=target)
+    assert exc_info.value.section == "router"
+    assert not target.exists()

--- a/tests/test_onboarding/test_flow_ensemble.py
+++ b/tests/test_onboarding/test_flow_ensemble.py
@@ -258,8 +258,14 @@ def test_interactive_configure_offers_and_dispatches_ensemble(
     class _Questionary(_BaseQuestionary):
         def select(self, message: str, **kwargs: Any) -> _Answer:
             assert message == "Section"
-            assert "ensemble" in kwargs["choices"]
-            return _Answer("ensemble")
+            titles = kwargs["choices"]
+            ensemble_title = next(
+                (t for t in titles if t.startswith("Ensemble")), None
+            )
+            if ensemble_title is not None and "config_path" not in seen:
+                return _Answer(ensemble_title)
+            done = next(t for t in titles if t in ("Done", "Exit (nothing changed)"))
+            return _Answer(done)
 
     monkeypatch.setitem(sys.modules, "questionary", _Questionary())
 

--- a/tests/test_onboarding/test_flow_ensemble.py
+++ b/tests/test_onboarding/test_flow_ensemble.py
@@ -171,11 +171,14 @@ def test_interactive_ensemble_disable_is_a_single_answer(tmp_path, monkeypatch):
 
     flow.run_interactive_ensemble_configure()
 
-    data = tomllib.loads(target.read_text())
-    ensemble = data["llm_ensemble"]
-    assert ensemble["enabled"] is False
+    # Sparse persistence may omit default-equal keys (the ensemble ships
+    # disabled), so pin the reloaded semantic state instead of raw TOML.
+    from opensquilla.onboarding.config_store import load_config
+
+    saved = load_config(target)
+    assert saved.llm_ensemble.enabled is False
     # Tuning values stay untouched for a later re-enable.
-    assert ensemble["model_options"] == ["stored/model-a"]
+    assert list(saved.llm_ensemble.model_options) == ["stored/model-a"]
 
 
 def test_interactive_ensemble_configure_without_tty_prints_hint(
@@ -193,6 +196,42 @@ def test_interactive_ensemble_configure_without_tty_prints_hint(
     out = capsys.readouterr().out
     assert "Headless ensemble:" in out
     assert "opensquilla onboard configure ensemble --enabled" in out
+
+
+def test_ensemble_saved_message_directs_to_gateway_reload(tmp_path, monkeypatch):
+    """The CLI runner edits the config file on disk, and file edits are only
+    read at boot — the save message must direct the operator to a gateway
+    reload/restart instead of claiming the change applies to the next turn
+    (that is only true for the RPC hot-apply path)."""
+
+    from opensquilla.onboarding import flow
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    messages: list[str] = []
+
+    class _Console:
+        def print(self, message: Any = "", *_a: Any, **_kw: Any) -> None:
+            messages.append(str(message))
+
+    monkeypatch.setattr(flow, "console", _Console())
+
+    class _Questionary(_BaseQuestionary):
+        def confirm(self, message: str, **_kwargs: Any) -> _Answer:
+            if message == "Enable the LLM ensemble?":
+                return _Answer(False)
+            raise AssertionError(f"unexpected confirm prompt: {message}")
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    flow.run_interactive_ensemble_configure()
+
+    joined = "\n".join(messages)
+    assert "no restart needed" not in joined
+    assert "applies to the next turn" not in joined
+    assert "opensquilla gateway reload" in joined
 
 
 def test_interactive_configure_offers_and_dispatches_ensemble(
@@ -228,3 +267,55 @@ def test_interactive_configure_offers_and_dispatches_ensemble(
 
     assert result is not None
     assert seen["config_path"] == target
+
+
+class _ValidatedAnswer:
+    """Fake prompt honouring ``validate=`` like questionary: rejected input
+    is re-asked, so garbage can only leak through when no validator is set."""
+
+    def __init__(self, values: list[Any], validate: Any) -> None:
+        self._values = list(values)
+        self._validate = validate
+
+    def ask(self) -> Any:
+        while self._values:
+            candidate = self._values.pop(0)
+            if self._validate is None or self._validate(candidate) is True:
+                return candidate
+        raise AssertionError("prompt inputs exhausted without an accepted value")
+
+
+def test_interactive_ensemble_min_proposers_garbage_reprompts(tmp_path, monkeypatch):
+    """Typing a non-number used to blow up in the mutation layer with a raw
+    ``ValueError`` after every other answer had already been given."""
+
+    from opensquilla.onboarding import flow
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    class _Questionary(_BaseQuestionary):
+        def confirm(self, message: str, **_kwargs: Any) -> _Answer:
+            if message == "Enable the LLM ensemble?":
+                return _Answer(True)
+            raise AssertionError(f"unexpected confirm prompt: {message}")
+
+        def select(self, message: str, **kwargs: Any) -> _Answer:
+            if message in {"Ensemble selection mode", "Policy when all proposers fail"}:
+                return _Answer(kwargs["default"])
+            raise AssertionError(f"unexpected select prompt: {message}")
+
+        def text(self, message: str, **kwargs: Any):
+            if message.startswith("Ensemble model options"):
+                return _Answer("")
+            if message == "Minimum successful proposers":
+                return _ValidatedAnswer(["many", "0", "2"], kwargs.get("validate"))
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    flow.run_interactive_ensemble_configure()
+
+    data = tomllib.loads(target.read_text())
+    assert data["llm_ensemble"]["min_successful_proposers"] == 2

--- a/tests/test_onboarding/test_flow_keep_current.py
+++ b/tests/test_onboarding/test_flow_keep_current.py
@@ -1,0 +1,235 @@
+"""Wizard re-runs must seed prompts from the stored config, not factory
+defaults, and channel edits must survive a rename with blank secrets.
+
+Regression coverage for the destructive-re-save class: pressing Enter
+through a search or image-generation wizard re-run used to persist factory
+defaults over the operator's stored settings, and renaming a channel while
+leaving a secret blank (as the wizard hint instructs) crashed with an
+uncaught ValueError because the keep-current merge was keyed to the payload
+name.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+import types
+from typing import Any
+
+from opensquilla.onboarding import flow
+from opensquilla.onboarding.config_store import load_config
+from opensquilla.onboarding.image_generation_specs import (
+    get_image_generation_provider_setup_spec,
+)
+from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
+
+
+class _Answer:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+    def ask(self) -> Any:
+        return self.value
+
+
+class _RecordingConsole:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def print(self, message: str = "", *_a, **_kw) -> None:
+        self.messages.append(str(message))
+
+    def joined(self) -> str:
+        return "\n".join(self.messages)
+
+
+class _EnterThroughQuestionary(types.SimpleNamespace):
+    """Answers every prompt with its default (a plain Enter), recording the
+    defaults so tests can assert what the wizard offered."""
+
+    def __init__(self, *, password_value: str = "sk-new") -> None:
+        super().__init__()
+        self.defaults: dict[str, Any] = {}
+        self._password_value = password_value
+
+    def select(self, message, **kwargs):
+        self.defaults[message] = kwargs.get("default")
+        choices = list(kwargs.get("choices") or [])
+        return _Answer(kwargs.get("default") or (choices[0] if choices else None))
+
+    def text(self, message, **kwargs):
+        self.defaults[message] = kwargs.get("default")
+        return _Answer(kwargs.get("default"))
+
+    def confirm(self, message, **kwargs):
+        self.defaults[message] = kwargs.get("default")
+        return _Answer(kwargs.get("default"))
+
+    def password(self, message, **kwargs):
+        self.defaults[message] = None
+        return _Answer(self._password_value)
+
+    def checkbox(self, message, **kwargs):
+        raise AssertionError(f"unexpected checkbox prompt: {message}")
+
+
+# ---------------------------------------------------------------------------
+# R7 — search wizard re-run seeds stored values.
+# ---------------------------------------------------------------------------
+
+
+_STORED_SEARCH_TOML = (
+    'search_provider = "brave"\n'
+    'search_api_key = "brave-stored-key"\n'
+    "search_max_results = 10\n"
+    'search_proxy = "http://127.0.0.1:7890"\n'
+    "search_use_env_proxy = true\n"
+    'search_fallback_policy = "network"\n'
+    "search_diagnostics = true\n"
+)
+
+
+def test_search_fields_seed_defaults_from_stored_config(tmp_path, monkeypatch):
+    monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+    target = tmp_path / "c.toml"
+    target.write_text(_STORED_SEARCH_TOML, encoding="utf-8")
+    cfg = load_config(target)
+
+    q = _EnterThroughQuestionary(password_value="brave-rotated-key")
+    answers = flow._ask_search_fields(q, get_search_provider_setup_spec("brave"), cfg)
+
+    # An Enter-through key rotation keeps every stored global setting.
+    assert answers["api_key"] == "brave-rotated-key"
+    assert answers["max_results"] == 10
+    assert answers["proxy"] == "http://127.0.0.1:7890"
+    assert answers["use_env_proxy"] is True
+    assert answers["fallback_policy"] == "network"
+    assert answers["diagnostics"] is True
+    assert q.defaults["Max search results"] == "10"
+    assert q.defaults["Search HTTP proxy"] == "http://127.0.0.1:7890"
+
+
+def test_search_configure_rerun_enter_through_keeps_stored_settings(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+    target = tmp_path / "c.toml"
+    target.write_text(_STORED_SEARCH_TOML, encoding="utf-8")
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    monkeypatch.setattr(flow, "console", _RecordingConsole())
+
+    class _Q(_EnterThroughQuestionary):
+        def select(self, message, **kwargs):
+            if message == "Search provider":
+                return _Answer("brave (Brave Search)")
+            return super().select(message, **kwargs)
+
+    monkeypatch.setitem(
+        sys.modules, "questionary", _Q(password_value="brave-rotated-key")
+    )
+
+    flow.run_interactive_search_configure(config_path=target)
+
+    data = tomllib.loads(target.read_text())
+    assert data["search_api_key"] == "brave-rotated-key"
+    assert data["search_max_results"] == 10
+    assert data["search_proxy"] == "http://127.0.0.1:7890"
+    assert data["search_use_env_proxy"] is True
+    assert data["search_fallback_policy"] == "network"
+    assert data["search_diagnostics"] is True
+
+
+# ---------------------------------------------------------------------------
+# R7 — image-generation wizard re-run seeds stored values.
+# ---------------------------------------------------------------------------
+
+
+def test_image_generation_fields_seed_defaults_from_stored_config(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    target = tmp_path / "c.toml"
+    target.write_text(
+        "[image_generation]\n"
+        "enabled = false\n"
+        'primary = "openai/custom-image-model"\n'
+        "[image_generation.providers.openai]\n"
+        'api_key = "sk-image-old"\n'
+        'base_url = "https://images.example.test/v1"\n',
+        encoding="utf-8",
+    )
+    cfg = load_config(target)
+
+    q = _EnterThroughQuestionary(password_value="sk-image-new")
+    answers = flow._ask_image_generation_fields(
+        q, get_image_generation_provider_setup_spec("openai"), cfg
+    )
+
+    # An Enter-through key rotation keeps the stored custom model, base URL,
+    # and the deliberate enabled=false decision.
+    assert answers["primary"] == "openai/custom-image-model"
+    assert answers["base_url"] == "https://images.example.test/v1"
+    assert answers["enabled"] is False
+    assert q.defaults["Primary image model"] == "openai/custom-image-model"
+    assert q.defaults["Image base URL"] == "https://images.example.test/v1"
+    assert q.defaults["Image generation enabled?"] is False
+
+
+def test_image_generation_fields_fresh_config_defaults_unchanged(monkeypatch):
+    from opensquilla.gateway.config import GatewayConfig
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    spec = get_image_generation_provider_setup_spec("openai")
+
+    q = _EnterThroughQuestionary(password_value="sk-image-first")
+    answers = flow._ask_image_generation_fields(q, spec, GatewayConfig())
+
+    assert answers["primary"] == spec.default_model
+    assert answers["base_url"] == spec.default_base_url
+    assert answers["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# R8 — channel edit rename with a blank (keep-current) secret.
+# ---------------------------------------------------------------------------
+
+
+def test_channel_edit_rename_with_blank_secret_keeps_token(tmp_path, monkeypatch):
+    """Following the wizard's own "leave blank to keep the stored value"
+    hint while renaming the entry used to crash with an uncaught
+    ValueError ("channel field 'token' requires a non-empty value") because
+    the keep-current merge looked up the stored entry by the NEW name."""
+    from opensquilla.onboarding.setup_engine import SetupEngine
+
+    target = tmp_path / "c.toml"
+    engine = SetupEngine(path=target)
+    engine.apply(
+        "channels",
+        {"type": "telegram", "name": "t1", "token": "tg-stored-token"},
+    )
+    engine.persist()
+
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    monkeypatch.setattr(flow, "console", _RecordingConsole())
+
+    class _Q(_EnterThroughQuestionary):
+        def select(self, message, **kwargs):
+            if message == "Channel to edit":
+                return _Answer("t1")
+            return super().select(message, **kwargs)
+
+        def text(self, message, **kwargs):
+            if message == "Channel name":
+                return _Answer("t2")  # rename in the same edit
+            return super().text(message, **kwargs)
+
+        def password(self, message, **kwargs):
+            return _Answer("")  # blank = keep stored value, per the hint
+
+    monkeypatch.setitem(sys.modules, "questionary", _Q())
+
+    flow.run_interactive_channel_edit(None, config_path=target)
+
+    entries = {
+        e.name: e for e in load_config(target).channels.channels
+    }
+    assert "t2" in entries
+    assert entries["t2"].token == "tg-stored-token"

--- a/tests/test_onboarding/test_flow_preflight.py
+++ b/tests/test_onboarding/test_flow_preflight.py
@@ -1,0 +1,120 @@
+"""Config-directory writability preflight for the interactive wizard.
+
+An unwritable state/config directory used to surface as a raw
+``PermissionError`` traceback only at persist time — after the operator had
+already answered every prompt, including pasting the API key. The wizard now
+probes writability before the first prompt and exits with code 2 and an
+actionable message instead.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from io import StringIO
+from typing import Any
+
+import pytest
+from rich.console import Console
+
+from opensquilla.onboarding import flow
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="read-only directory permissions are not enforceable for this user",
+)
+
+
+class _NoPromptQuestionary(types.SimpleNamespace):
+    """Every prompt is a test failure: nothing may fire before the preflight."""
+
+    def _fail(self, message: str) -> Any:
+        raise AssertionError(f"prompt fired despite unwritable config dir: {message}")
+
+    def select(self, message: str, **_kwargs: Any) -> Any:
+        return self._fail(message)
+
+    def text(self, message: str, **_kwargs: Any) -> Any:
+        return self._fail(message)
+
+    def password(self, message: str, **_kwargs: Any) -> Any:
+        return self._fail(message)
+
+    def confirm(self, message: str, **_kwargs: Any) -> Any:
+        return self._fail(message)
+
+    def checkbox(self, message: str, **_kwargs: Any) -> Any:
+        return self._fail(message)
+
+
+def _capture_console(monkeypatch) -> StringIO:
+    output = StringIO()
+    monkeypatch.setattr(
+        flow,
+        "console",
+        Console(file=output, force_terminal=False, highlight=False, width=300),
+    )
+    return output
+
+
+def test_onboard_unwritable_config_dir_exits_2_before_any_prompt(tmp_path, monkeypatch):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    target = state_dir / "config.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    output = _capture_console(monkeypatch)
+    gate_fired: list[str] = []
+    monkeypatch.setattr(flow, "_wait_for_setup_start", lambda: gate_fired.append("start"))
+    monkeypatch.setattr(flow, "detect_default_sources", lambda: [])
+    monkeypatch.setitem(sys.modules, "questionary", _NoPromptQuestionary())
+
+    state_dir.chmod(0o500)
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            flow.run_interactive_onboard(flow.OnboardOptions())
+    finally:
+        state_dir.chmod(0o700)
+
+    assert exc_info.value.code == 2
+    # No input was wasted: not even the "Press Enter to start setup" gate ran.
+    assert gate_fired == []
+    out = output.getvalue()
+    assert "Setup directory not writable" in out
+    assert str(state_dir) in out
+    assert "--config" in out
+    assert not target.exists()
+
+
+def test_onboard_uncreatable_config_dir_exits_2(tmp_path, monkeypatch):
+    """A config path whose parent directory cannot even be created must fail
+    the same actionable way instead of crashing inside ``mkdir``."""
+
+    locked_root = tmp_path / "locked"
+    locked_root.mkdir()
+    target = locked_root / "nested" / "config.toml"
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    output = _capture_console(monkeypatch)
+    monkeypatch.setattr(flow, "_wait_for_setup_start", lambda: None)
+    monkeypatch.setattr(flow, "detect_default_sources", lambda: [])
+    monkeypatch.setitem(sys.modules, "questionary", _NoPromptQuestionary())
+
+    locked_root.chmod(0o500)
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            flow.run_interactive_onboard(flow.OnboardOptions(config_path=target))
+    finally:
+        locked_root.chmod(0o700)
+
+    assert exc_info.value.code == 2
+    assert "Setup directory not writable" in output.getvalue()
+
+
+def test_writability_preflight_creates_dir_and_leaves_no_probe_file(tmp_path):
+    target = tmp_path / "state" / "config.toml"
+
+    flow._ensure_config_dir_writable(target)
+
+    assert (tmp_path / "state").is_dir()
+    assert list((tmp_path / "state").iterdir()) == []

--- a/tests/test_onboarding/test_flow_provider_verify.py
+++ b/tests/test_onboarding/test_flow_provider_verify.py
@@ -559,16 +559,16 @@ def test_wizard_probe_suppresses_provider_log_noise(monkeypatch, capsys):
 
     monkeypatch.setattr(probe_module, "probe_llm_provider", _noisy_probe)
 
+    config_before = dict(structlog.get_config())
     result = flow._run_provider_probe(provider_id="openrouter", model="dummy/model")
 
     captured = capsys.readouterr()
     assert result is sentinel
     assert "chat_http_error" not in captured.out + captured.err
     assert "synthetic-401-body" not in captured.out + captured.err
-
-    structlog.get_logger("opensquilla.provider").warning("post.probe.event")
-    captured = capsys.readouterr()
-    assert "post.probe.event" in captured.out + captured.err
+    # The suppression must be scoped to the probe: whatever structlog config
+    # was active before (test runs share the process) is restored verbatim.
+    assert dict(structlog.get_config()) == config_before
 
 
 def test_wizard_discovery_suppresses_provider_log_noise(monkeypatch, capsys):

--- a/tests/test_onboarding/test_flow_provider_verify.py
+++ b/tests/test_onboarding/test_flow_provider_verify.py
@@ -322,9 +322,27 @@ def test_probe_failure_skips_discovery_and_offers_save_anyway(monkeypatch):
     assert "Incorrect API key provided" in output.getvalue()
 
 
-def test_router_supported_provider_skips_verify_and_discovery(monkeypatch):
-    monkeypatch.setattr(flow, "_run_provider_probe", _no_probe)
+def test_router_supported_provider_probes_the_default_tier_model(monkeypatch):
+    """A router-supported provider never types a direct model, so its bad
+    keys used to surface only at the first chat: the pre-save probe was
+    gated on a branch such a provider could never reach. It must now probe
+    with the model the save will actually use — the default tier's model
+    (the spec's ``default_direct_model``) — while still skipping discovery
+    and adding zero prompts on success."""
+
+    output = _capture_console(monkeypatch)
+    probe_calls: list[dict[str, Any]] = []
+
+    def fake_probe(**kwargs: Any) -> ProviderProbeResult:
+        probe_calls.append(kwargs)
+        return ProviderProbeResult(
+            ok=True, provider_id=kwargs["provider_id"], model=kwargs["model"]
+        )
+
+    monkeypatch.setattr(flow, "_run_provider_probe", fake_probe)
     monkeypatch.setattr(flow, "_run_provider_discovery", _no_discovery)
+
+    spec = get_provider_setup_spec("openrouter")
 
     class _Questionary:
         def text(self, message: str, **_kwargs: Any) -> _Answer:
@@ -338,7 +356,126 @@ def test_router_supported_provider_skips_verify_and_discovery(monkeypatch):
 
     answers = _ask_provider_fields(
         _Questionary(),
+        spec,
+        OnboardOptions(api_key="sk-live"),
+    )
+
+    assert spec.default_direct_model, "openrouter must expose a default tier model"
+    assert [call["model"] for call in probe_calls] == [spec.default_direct_model]
+    assert probe_calls[0]["api_key"] == "sk-live"
+    # The router still drives model selection: no direct model is stored.
+    assert answers["model"] == ""
+    assert "connection verified" in output.getvalue()
+
+
+def test_router_supported_provider_probe_failure_offers_save_anyway(monkeypatch):
+    output = _capture_console(monkeypatch)
+    monkeypatch.setattr(
+        flow,
+        "_run_provider_probe",
+        lambda **kwargs: ProviderProbeResult(
+            ok=False,
+            provider_id=kwargs["provider_id"],
+            model=kwargs["model"],
+            failure_kind="auth_invalid",
+            message="Incorrect API key provided",
+        ),
+    )
+    monkeypatch.setattr(flow, "_run_provider_discovery", _no_discovery)
+    prompts: list[str] = []
+
+    class _Questionary:
+        def confirm(self, message: str, **kwargs: Any) -> _Answer:
+            prompts.append(message)
+            assert message == "Save anyway?"
+            # Offline setup must keep working: the default answer is yes.
+            assert kwargs.get("default") is True
+            return _Answer(True)
+
+        def text(self, message: str, **_kwargs: Any) -> _Answer:
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+    answers = _ask_provider_fields(
+        _Questionary(),
         get_provider_setup_spec("openrouter"),
+        OnboardOptions(api_key="sk-bad"),
+    )
+
+    assert prompts == ["Save anyway?"]
+    assert answers["model"] == ""
+    out = output.getvalue()
+    assert "Could not verify openrouter" in out
+    assert "Incorrect API key provided" in out
+
+
+def test_router_supported_provider_probe_decline_cancels_provider_section(monkeypatch):
+    _capture_console(monkeypatch)
+    monkeypatch.setattr(
+        flow,
+        "_run_provider_probe",
+        lambda **kwargs: ProviderProbeResult(
+            ok=False,
+            provider_id=kwargs["provider_id"],
+            model=kwargs["model"],
+            failure_kind="auth_invalid",
+            message="Incorrect API key provided",
+        ),
+    )
+
+    class _Questionary:
+        def confirm(self, message: str, **_kwargs: Any) -> _Answer:
+            assert message == "Save anyway?"
+            return _Answer(False)
+
+    with pytest.raises(UserCancelledError) as exc_info:
+        _ask_provider_fields(
+            _Questionary(),
+            get_provider_setup_spec("openrouter"),
+            OnboardOptions(api_key="sk-bad"),
+        )
+    assert exc_info.value.section == "provider"
+
+
+def test_router_supported_provider_broken_probe_machinery_degrades_silently(monkeypatch):
+    # ``None`` means the probe could not even be attempted — it must never
+    # block the router-driven quick-start with an extra prompt.
+    _capture_console(monkeypatch)
+    monkeypatch.setattr(flow, "_run_provider_probe", lambda **_kw: None)
+    monkeypatch.setattr(flow, "_run_provider_discovery", _no_discovery)
+
+    class _Questionary:
+        def confirm(self, message: str, **_kwargs: Any) -> _Answer:
+            raise AssertionError(f"unexpected confirm prompt: {message}")
+
+        def text(self, message: str, **_kwargs: Any) -> _Answer:
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+    answers = _ask_provider_fields(
+        _Questionary(),
+        get_provider_setup_spec("openrouter"),
+        OnboardOptions(api_key="sk-live"),
+    )
+
+    assert answers["model"] == ""
+
+
+def test_router_supported_spec_without_default_model_skips_probe(monkeypatch):
+    """When no model can be determined for the probe there is nothing to
+    verify — behavior stays exactly as before the router-provider check."""
+
+    monkeypatch.setattr(flow, "_run_provider_probe", _no_probe)
+    monkeypatch.setattr(flow, "_run_provider_discovery", _no_discovery)
+
+    class _Questionary:
+        def text(self, message: str, **_kwargs: Any) -> _Answer:
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+        def confirm(self, message: str, **_kwargs: Any) -> _Answer:
+            raise AssertionError(f"unexpected confirm prompt: {message}")
+
+    answers = _ask_provider_fields(
+        _Questionary(),
+        _probing_spec(router_supported=True, default_direct_model=""),
         OnboardOptions(api_key="sk-live"),
     )
 
@@ -401,3 +538,56 @@ def test_broken_discovery_machinery_degrades_to_free_text(monkeypatch):
     )
 
     assert answers["model"] == "typed-model"
+
+
+def test_wizard_probe_suppresses_provider_log_noise(monkeypatch, capsys):
+    # The provider layer logs request/response details via structlog, which is
+    # unconfigured in the wizard process and would print raw records into the
+    # interactive prompt stream mid-probe. The seam must silence them for the
+    # duration of the probe and restore logging afterwards.
+    import structlog
+
+    from opensquilla.onboarding import probe as probe_module
+
+    sentinel = object()
+
+    async def _noisy_probe(**_kwargs: Any) -> Any:
+        structlog.get_logger("opensquilla.provider").warning(
+            "provider.chat_http_error", status_code=401, response_body="synthetic-401-body"
+        )
+        return sentinel
+
+    monkeypatch.setattr(probe_module, "probe_llm_provider", _noisy_probe)
+
+    result = flow._run_provider_probe(provider_id="openrouter", model="dummy/model")
+
+    captured = capsys.readouterr()
+    assert result is sentinel
+    assert "chat_http_error" not in captured.out + captured.err
+    assert "synthetic-401-body" not in captured.out + captured.err
+
+    structlog.get_logger("opensquilla.provider").warning("post.probe.event")
+    captured = capsys.readouterr()
+    assert "post.probe.event" in captured.out + captured.err
+
+
+def test_wizard_discovery_suppresses_provider_log_noise(monkeypatch, capsys):
+    import structlog
+
+    from opensquilla.onboarding import probe as probe_module
+
+    sentinel = object()
+
+    async def _noisy_discovery(**_kwargs: Any) -> Any:
+        structlog.get_logger("opensquilla.provider").warning(
+            "provider.models_http_error", status_code=401
+        )
+        return sentinel
+
+    monkeypatch.setattr(probe_module, "discover_provider_models", _noisy_discovery)
+
+    result = flow._run_provider_discovery(provider_id="openrouter")
+
+    captured = capsys.readouterr()
+    assert result is sentinel
+    assert "models_http_error" not in captured.out + captured.err

--- a/tests/test_onboarding/test_flow_settings_hub.py
+++ b/tests/test_onboarding/test_flow_settings_hub.py
@@ -1,0 +1,391 @@
+"""The multi-level settings entry points: the `onboard configure` section hub
+and the re-run fork in `opensquilla onboard`.
+
+Contract under test:
+- Bare `configure` on a TTY is a menu LOOP (edit a section, come back, Done
+  exits); an explicit section stays a one-shot edit.
+- Cancelling inside a section returns to the menu; cancelling at the menu
+  itself raises like every other wizard prompt.
+- Restart-required guidance survives multi-section sittings.
+- A full interactive re-run over a configured install offers
+  update / change-sections / start-fresh, and start-fresh backs the config
+  file up instead of deleting it.
+
+Everything is offline: prompts are faked at the questionary seam and section
+runners are monkeypatched.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from opensquilla.onboarding import flow
+from opensquilla.onboarding.config_store import PersistResult, load_config, persist_config
+from opensquilla.onboarding.errors import UserCancelledError
+from opensquilla.onboarding.flow import OnboardOptions
+from opensquilla.onboarding.mutations import upsert_llm_provider
+
+
+class _Answer:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+    def ask(self) -> Any:
+        return self.value
+
+
+class _BaseQuestionary(types.SimpleNamespace):
+    def confirm(self, message: str, **_kwargs: Any) -> _Answer:
+        raise AssertionError(f"unexpected confirm prompt: {message}")
+
+    def select(self, message: str, **_kwargs: Any) -> _Answer:
+        raise AssertionError(f"unexpected select prompt: {message}")
+
+    def text(self, message: str, **_kwargs: Any) -> _Answer:
+        raise AssertionError(f"unexpected text prompt: {message}")
+
+    def password(self, message: str, **_kwargs: Any) -> _Answer:
+        raise AssertionError(f"unexpected password prompt: {message}")
+
+    def checkbox(self, message: str, **_kwargs: Any) -> _Answer:
+        raise AssertionError(f"unexpected checkbox prompt: {message}")
+
+
+def _persist_result(target, *, restart_required=False, warnings=()):
+    return PersistResult(
+        path=target,
+        backup_path=None,
+        restart_required=restart_required,
+        warnings=list(warnings),
+    )
+
+
+def _pick_done(titles: list[str]) -> str:
+    return next(t for t in titles if t in ("Done", "Exit (nothing changed)"))
+
+
+def _seed_configured_install(target) -> None:
+    cfg = load_config(target)
+    res = upsert_llm_provider(
+        cfg,
+        provider_id="openrouter",
+        model="dummy/model",
+        api_key="sk-dummy-hub-test",
+    )
+    persist_config(res.config, path=target, restart_required=False, backup=False)
+
+
+# --- the configure hub -----------------------------------------------------
+
+
+def test_hub_loops_dispatching_multiple_sections_then_done(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    dispatched: list[str] = []
+
+    def _fake_runner(name, *, restart_required=False):
+        def runner(config_path=None):
+            assert config_path == target
+            dispatched.append(name)
+            return _persist_result(target, restart_required=restart_required)
+
+        return runner
+
+    monkeypatch.setattr(
+        flow, "run_interactive_search_configure", _fake_runner("search")
+    )
+    monkeypatch.setattr(
+        flow,
+        "run_interactive_image_generation_configure",
+        _fake_runner("image-generation", restart_required=True),
+    )
+
+    menus: list[list[str]] = []
+
+    class _Questionary(_BaseQuestionary):
+        def select(self, message: str, **kwargs: Any) -> _Answer:
+            assert message == "Section"
+            titles = kwargs["choices"]
+            menus.append(titles)
+            if len(menus) == 1:
+                return _Answer(next(t for t in titles if t.startswith("Web search")))
+            if len(menus) == 2:
+                return _Answer(
+                    next(t for t in titles if t.startswith("Image generation"))
+                )
+            return _Answer(_pick_done(titles))
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    result = flow.run_interactive_configure(config_path=target)
+
+    assert dispatched == ["search", "image-generation"]
+    assert len(menus) == 3, "the menu must reappear after each section"
+    assert result is not None
+    assert result.restart_required is True, "restart flag must stay sticky"
+
+
+def test_hub_menu_titles_carry_live_status_words(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    seen: dict[str, list[str]] = {}
+
+    class _Questionary(_BaseQuestionary):
+        def select(self, message: str, **kwargs: Any) -> _Answer:
+            seen["titles"] = kwargs["choices"]
+            return _Answer(_pick_done(kwargs["choices"]))
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    result = flow.run_interactive_configure(config_path=target)
+
+    assert result is None
+    titles = seen["titles"]
+    # Fresh install: provider setup is outstanding, search is a deliberate
+    # later. The exact words come from the shared SECTION_STATUS_DISPLAY map.
+    assert any(t.startswith("Provider — ") for t in titles)
+    assert "Provider — Missing" in titles
+    assert "Channels — Later" in titles
+    assert titles[-1] == "Exit (nothing changed)"
+    # Audio has no configure path and must not be offered as a menu entry.
+    assert not any(t.lower().startswith("voice audio") for t in titles)
+    assert not any(t.lower().startswith("audio") for t in titles)
+
+
+def test_hub_section_cancel_returns_to_menu_instead_of_aborting(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "c.toml"
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    attempts: list[str] = []
+
+    def _cancelling_runner(config_path=None):
+        attempts.append("search")
+        raise UserCancelledError("search")
+
+    monkeypatch.setattr(flow, "run_interactive_search_configure", _cancelling_runner)
+    menu_calls = {"n": 0}
+
+    class _Questionary(_BaseQuestionary):
+        def select(self, message: str, **kwargs: Any) -> _Answer:
+            menu_calls["n"] += 1
+            titles = kwargs["choices"]
+            if menu_calls["n"] == 1:
+                return _Answer(next(t for t in titles if t.startswith("Web search")))
+            return _Answer(_pick_done(titles))
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    result = flow.run_interactive_configure(config_path=target)
+
+    assert attempts == ["search"]
+    assert menu_calls["n"] == 2, "cancel inside a section must return to the menu"
+    assert result is None
+
+
+def test_hub_menu_cancel_raises_user_cancelled(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    class _Questionary(_BaseQuestionary):
+        def select(self, message: str, **kwargs: Any) -> _Answer:
+            return _Answer(None)  # questionary returns None on Esc/Ctrl-C
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    with pytest.raises(UserCancelledError):
+        flow.run_interactive_configure(config_path=target)
+
+
+def test_hub_merges_warnings_across_sections(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+
+    monkeypatch.setattr(
+        flow,
+        "run_interactive_search_configure",
+        lambda config_path=None: _persist_result(target, warnings=["w-search"]),
+    )
+    monkeypatch.setattr(
+        flow,
+        "run_interactive_image_generation_configure",
+        lambda config_path=None: _persist_result(target, warnings=["w-image"]),
+    )
+    step = {"n": 0}
+
+    class _Questionary(_BaseQuestionary):
+        def select(self, message: str, **kwargs: Any) -> _Answer:
+            step["n"] += 1
+            titles = kwargs["choices"]
+            if step["n"] == 1:
+                return _Answer(next(t for t in titles if t.startswith("Web search")))
+            if step["n"] == 2:
+                return _Answer(
+                    next(t for t in titles if t.startswith("Image generation"))
+                )
+            return _Answer(_pick_done(titles))
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    result = flow.run_interactive_configure(config_path=target)
+
+    assert result is not None
+    assert result.warnings == ["w-search", "w-image"]
+
+
+def test_explicit_section_stays_one_shot(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    dispatched: list[str] = []
+    monkeypatch.setattr(
+        flow,
+        "run_interactive_search_configure",
+        lambda config_path=None: (dispatched.append("search"), _persist_result(target))[1],
+    )
+
+    class _Questionary(_BaseQuestionary):
+        pass  # any menu render would raise via the base class
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    result = flow.run_interactive_configure("search", config_path=target)
+
+    assert dispatched == ["search"]
+    assert result is not None
+
+
+# --- the onboard re-run fork -------------------------------------------------
+
+
+def test_rerun_fork_routes_change_sections_to_the_hub(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    _seed_configured_install(target)
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    monkeypatch.setattr(flow, "_wait_for_setup_start", lambda: None)
+    monkeypatch.setattr(flow, "_ensure_config_dir_writable", lambda _path: None)
+    hub_calls: list[Any] = []
+    sentinel = _persist_result(target, restart_required=True)
+
+    def _fake_hub(questionary, *, config_path=None):
+        hub_calls.append(config_path)
+        return sentinel
+
+    monkeypatch.setattr(flow, "_run_configure_hub", _fake_hub)
+
+    class _Questionary(_BaseQuestionary):
+        def select(self, message: str, **kwargs: Any) -> _Answer:
+            assert message.startswith("This install is already configured")
+            assert kwargs["default"] == flow._ONBOARD_UPDATE_CHOICE
+            return _Answer(flow._ONBOARD_SECTIONS_CHOICE)
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    result = flow.run_interactive_onboard(OnboardOptions(config_path=target))
+
+    assert hub_calls == [target]
+    assert result is sentinel
+
+
+def test_rerun_fork_start_fresh_backs_up_config_and_restarts_walk(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "c.toml"
+    _seed_configured_install(target)
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    monkeypatch.setattr(flow, "_wait_for_setup_start", lambda: None)
+    monkeypatch.setattr(flow, "_ensure_config_dir_writable", lambda _path: None)
+    monkeypatch.setattr(
+        flow, "_run_onboard_migration_step", lambda *_a, **_kw: None
+    )
+
+    class _Questionary(_BaseQuestionary):
+        def select(self, message: str, **kwargs: Any) -> _Answer:
+            if message.startswith("This install is already configured"):
+                return _Answer(flow._ONBOARD_RESET_CHOICE)
+            if message == "LLM provider":
+                # The walk restarted from scratch; cancel here to end the test.
+                return _Answer(None)
+            raise AssertionError(f"unexpected select prompt: {message}")
+
+        def confirm(self, message: str, **kwargs: Any) -> _Answer:
+            assert message.startswith("Back up")
+            assert kwargs["default"] is False
+            return _Answer(True)
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    with pytest.raises(UserCancelledError):
+        flow.run_interactive_onboard(OnboardOptions(config_path=target))
+
+    backups = list(tmp_path.glob("c.toml.bak-*"))
+    assert len(backups) == 1, "start fresh must back the old config up, not delete it"
+    assert "sk-dummy-hub-test" in backups[0].read_text()
+    assert not target.exists() or "sk-dummy-hub-test" not in target.read_text()
+
+
+def test_rerun_fork_decline_reset_falls_back_to_update(tmp_path, monkeypatch):
+    target = tmp_path / "c.toml"
+    _seed_configured_install(target)
+    cfg = load_config(target)
+    status = flow.get_onboarding_status(cfg)
+
+    class _Questionary(_BaseQuestionary):
+        def select(self, message: str, **kwargs: Any) -> _Answer:
+            return _Answer(flow._ONBOARD_RESET_CHOICE)
+
+        def confirm(self, message: str, **kwargs: Any) -> _Answer:
+            return _Answer(False)
+
+    action = flow._ask_existing_setup_action(
+        _Questionary(), cfg, status, OnboardOptions(config_path=target)
+    )
+
+    assert action == "update"
+    assert target.exists()
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        OnboardOptions(skip_migration=True),
+        OnboardOptions(skip_channels=True),
+        OnboardOptions(skip_search=True),
+        OnboardOptions(skip_image_generation=True),
+        OnboardOptions(minimal=True),
+        OnboardOptions(if_needed=True),
+        OnboardOptions(provider_id="openrouter"),
+        OnboardOptions(api_key="sk-headless"),
+    ],
+)
+def test_rerun_fork_not_offered_for_scoped_or_headless_runs(
+    tmp_path, monkeypatch, options
+):
+    target = tmp_path / "c.toml"
+    _seed_configured_install(target)
+    cfg = load_config(target)
+    status = flow.get_onboarding_status(cfg)
+    options = OnboardOptions(
+        **{**options.__dict__, "config_path": target}
+    )
+
+    action = flow._ask_existing_setup_action(
+        _BaseQuestionary(), cfg, status, options
+    )
+
+    assert action is None
+
+
+def test_rerun_fork_not_offered_for_fresh_or_unfinished_installs(tmp_path):
+    target = tmp_path / "c.toml"
+    cfg = load_config(target)
+    status = flow.get_onboarding_status(cfg)
+
+    action = flow._ask_existing_setup_action(
+        _BaseQuestionary(), cfg, status, OnboardOptions(config_path=target)
+    )
+
+    assert action is None

--- a/tests/test_onboarding/test_flow_settings_hub.py
+++ b/tests/test_onboarding/test_flow_settings_hub.py
@@ -327,6 +327,21 @@ def test_rerun_fork_start_fresh_backs_up_config_and_restarts_walk(
     assert not target.exists() or "sk-dummy-hub-test" not in target.read_text()
 
 
+def test_start_fresh_backs_up_symlink_target_without_replacing_link(tmp_path):
+    real = tmp_path / "real-config.toml"
+    link = tmp_path / "config.toml"
+    real.write_text("port = 18791\n")
+    link.symlink_to(real)
+
+    flow._backup_and_reset_config(link)
+
+    assert link.is_symlink()
+    assert not real.exists()
+    backups = list(tmp_path.glob("real-config.toml.bak-*"))
+    assert len(backups) == 1
+    assert backups[0].read_text() == "port = 18791\n"
+
+
 def test_rerun_fork_decline_reset_falls_back_to_update(tmp_path, monkeypatch):
     target = tmp_path / "c.toml"
     _seed_configured_install(target)

--- a/tests/test_onboarding/test_flow_validation.py
+++ b/tests/test_onboarding/test_flow_validation.py
@@ -1,0 +1,455 @@
+"""Input validation and stored-value seeding in the interactive wizard.
+
+These tests drive the questionary seams with a validate-aware fake prompt:
+like the real library, a canned input is only returned once the prompt's
+``validate=`` hook accepts it, so garbage input re-prompts instead of leaking
+into ``int()``/pydantic and crashing the wizard mid-section.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from opensquilla.onboarding import flow
+from opensquilla.onboarding.channel_specs import ChannelSetupField
+from opensquilla.onboarding.errors import UserCancelledError
+from opensquilla.onboarding.flow import OnboardOptions
+from opensquilla.onboarding.provider_specs import get_provider_setup_spec
+from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
+from opensquilla.search.types import DEFAULT_SEARCH_MAX_RESULTS
+
+
+class _ValidatedPrompt:
+    """Fake prompt honouring ``validate=`` the way questionary does.
+
+    Rejected input is re-asked (the next canned value is tried), so a
+    garbage value can only be returned when the prompt carries no validator
+    — which is exactly the regression each test pins.
+    """
+
+    def __init__(self, values: list[Any], validate: Any) -> None:
+        self._values = list(values)
+        self._validate = validate
+
+    def ask(self) -> Any:
+        while self._values:
+            candidate = self._values.pop(0)
+            if candidate is None:
+                return None  # cancel short-circuits validation
+            if self._validate is None or self._validate(candidate) is True:
+                return candidate
+        raise AssertionError("prompt inputs exhausted without an accepted value")
+
+
+class _RecordingConsole:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def print(self, message: str = "", *_a, **_kw) -> None:
+        self.messages.append(str(message))
+
+    def joined(self) -> str:
+        return "\n".join(self.messages)
+
+
+# ---------------------------------------------------------------------------
+# C1-5 — numeric prompts re-prompt on garbage instead of raising ValueError.
+# ---------------------------------------------------------------------------
+
+
+def _duckduckgo_search_questionary(max_results_inputs: list[Any]):
+    class _Answer:
+        def __init__(self, value: Any) -> None:
+            self.value = value
+
+        def ask(self) -> Any:
+            return self.value
+
+    class _Questionary:
+        def text(self, message: str, **kwargs: Any):
+            if message == "Max search results":
+                return _ValidatedPrompt(max_results_inputs, kwargs.get("validate"))
+            if message == "Search HTTP proxy":
+                return _Answer("")
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+        def select(self, message: str, **kwargs: Any):
+            if message == "Search fallback policy":
+                return _Answer(kwargs.get("default"))
+            raise AssertionError(f"unexpected select prompt: {message}")
+
+        def confirm(self, message: str, **_kwargs: Any):
+            return _Answer(False)
+
+        def password(self, message: str, **_kwargs: Any):
+            raise AssertionError(f"unexpected password prompt: {message}")
+
+    return _Questionary()
+
+
+def test_search_max_results_garbage_reprompts_instead_of_crashing():
+    """Typing a non-number used to raise a raw ``ValueError`` that aborted
+    every remaining onboarding section and discarded the just-entered
+    search credentials."""
+
+    answers = flow._ask_search_fields(
+        _duckduckgo_search_questionary(["banana", "7"]),
+        get_search_provider_setup_spec("duckduckgo"),
+    )
+
+    assert answers["max_results"] == 7
+
+
+def test_search_max_results_blank_keeps_default():
+    answers = flow._ask_search_fields(
+        _duckduckgo_search_questionary([""]),
+        get_search_provider_setup_spec("duckduckgo"),
+    )
+
+    assert answers["max_results"] == DEFAULT_SEARCH_MAX_RESULTS
+
+
+def test_search_max_results_validator_enforces_minimum_of_one():
+    """The write side requires an integer >= 1; the prompt must reject the
+    same range up front instead of failing at persist time."""
+
+    answers = flow._ask_search_fields(
+        _duckduckgo_search_questionary(["0", "-3", "2"]),
+        get_search_provider_setup_spec("duckduckgo"),
+    )
+
+    assert answers["max_results"] == 2
+
+
+def test_channel_int_field_garbage_reprompts_instead_of_crashing():
+    field = ChannelSetupField(
+        name="poll_interval",
+        label="Poll interval",
+        field_type="int",
+        required=True,
+        default=3,
+    )
+
+    class _Questionary:
+        def text(self, message: str, **kwargs: Any):
+            assert message == "Poll interval"
+            return _ValidatedPrompt(["lots", "5"], kwargs.get("validate"))
+
+    assert flow._ask_channel_field(_Questionary(), field, field.default) == 5
+
+
+def test_channel_float_field_garbage_reprompts_instead_of_crashing():
+    field = ChannelSetupField(
+        name="timeout",
+        label="Timeout seconds",
+        field_type="float",
+        required=True,
+        default=1.5,
+    )
+
+    class _Questionary:
+        def text(self, message: str, **kwargs: Any):
+            assert message == "Timeout seconds"
+            return _ValidatedPrompt(["fast", "2.5"], kwargs.get("validate"))
+
+    assert flow._ask_channel_field(_Questionary(), field, field.default) == 2.5
+
+
+# ---------------------------------------------------------------------------
+# C1-6 — required base URL: validated input, Esc cancels.
+# ---------------------------------------------------------------------------
+
+
+def test_required_base_url_rejects_blank_and_non_http_schemes():
+    """Plain Enter used to coerce the answer to '' and kill the wizard with
+    a raw ``ValueError`` at persist time."""
+
+    captured: dict[str, Any] = {}
+
+    class _Questionary:
+        def text(self, message: str, **kwargs: Any):
+            assert message == "Base URL"
+            captured["validate"] = kwargs.get("validate")
+            return _ValidatedPrompt(
+                ["", "ftp://intranet.test", "http://localhost:8000/v1"],
+                kwargs.get("validate"),
+            )
+
+    answers = flow._ask_provider_fields(
+        _Questionary(),
+        get_provider_setup_spec("vllm"),
+        OnboardOptions(model="stub-model"),
+    )
+
+    assert answers["base_url"] == "http://localhost:8000/v1"
+    validate = captured["validate"]
+    assert validate is not None
+    assert validate("") is not True
+    assert validate("   ") is not True
+    assert validate("ftp://intranet.test") is not True
+    assert validate("https://example.test/v1") is True
+
+
+def test_required_base_url_cancel_raises_user_cancelled():
+    class _Questionary:
+        def text(self, message: str, **kwargs: Any):
+            assert message == "Base URL"
+            return _ValidatedPrompt([None], kwargs.get("validate"))
+
+    with pytest.raises(UserCancelledError) as exc_info:
+        flow._ask_provider_fields(
+            _Questionary(),
+            get_provider_setup_spec("vllm"),
+            OnboardOptions(model="stub-model"),
+        )
+    assert exc_info.value.section == "provider"
+
+
+# ---------------------------------------------------------------------------
+# C1-7 — wizard re-run seeds prompt defaults from the stored provider entry.
+# ---------------------------------------------------------------------------
+
+
+def _stored_config(provider: str, *, base_url: str, proxy: str) -> Any:
+    return types.SimpleNamespace(
+        llm=types.SimpleNamespace(provider=provider, base_url=base_url, proxy=proxy)
+    )
+
+
+def test_provider_rerun_seeds_base_url_prompt_and_keeps_proxy():
+    """Re-running the wizard for an already-stored provider must default the
+    Base URL prompt to the stored endpoint and keep the stored proxy —
+    accepting the defaults used to silently resave the spec defaults."""
+
+    captured: dict[str, Any] = {}
+
+    class _Questionary:
+        def text(self, message: str, **kwargs: Any):
+            assert message == "Base URL"
+            captured["default"] = kwargs.get("default")
+            return _ValidatedPrompt([kwargs.get("default")], kwargs.get("validate"))
+
+    answers = flow._ask_provider_fields(
+        _Questionary(),
+        get_provider_setup_spec("vllm"),
+        OnboardOptions(model="stub-model"),
+        config=_stored_config(
+            "vllm",
+            base_url="http://intranet.test:8000/v1",
+            proxy="http://proxy.test:3128",
+        ),
+    )
+
+    assert captured["default"] == "http://intranet.test:8000/v1"
+    assert answers["base_url"] == "http://intranet.test:8000/v1"
+    assert answers["proxy"] == "http://proxy.test:3128"
+
+
+def test_provider_rerun_keeps_stored_custom_base_url_without_prompt(monkeypatch):
+    """Providers that do not prompt for a base URL must still keep a stored
+    custom endpoint and proxy on re-run instead of resaving spec defaults."""
+
+    monkeypatch.setattr(flow, "_run_provider_probe", lambda **_kw: None)
+
+    class _Questionary:
+        def text(self, message: str, **_kwargs: Any):
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+    answers = flow._ask_provider_fields(
+        _Questionary(),
+        get_provider_setup_spec("openrouter"),
+        OnboardOptions(api_key_env="OPENROUTER_API_KEY"),
+        config=_stored_config(
+            "openrouter",
+            base_url="https://relay.internal.test/v1",
+            proxy="http://proxy.test:3128",
+        ),
+    )
+
+    assert answers["base_url"] == "https://relay.internal.test/v1"
+    assert answers["proxy"] == "http://proxy.test:3128"
+
+
+def test_provider_switch_ignores_other_providers_stored_endpoint(monkeypatch):
+    """Stored values belong to the stored provider only — selecting a
+    different provider must fall back to that provider's spec defaults."""
+
+    monkeypatch.setattr(flow, "_run_provider_probe", lambda **_kw: None)
+
+    class _Questionary:
+        def text(self, message: str, **_kwargs: Any):
+            raise AssertionError(f"unexpected text prompt: {message}")
+
+    spec = get_provider_setup_spec("openrouter")
+    answers = flow._ask_provider_fields(
+        _Questionary(),
+        spec,
+        OnboardOptions(api_key_env="OPENROUTER_API_KEY"),
+        config=_stored_config(
+            "groq",
+            base_url="https://groq-relay.internal.test/v1",
+            proxy="http://proxy.test:3128",
+        ),
+    )
+
+    assert answers["base_url"] == spec.default_base_url
+    assert answers["proxy"] == ""
+
+
+# ---------------------------------------------------------------------------
+# C1-8 — channel edit: blank keeps the stored secret.
+# ---------------------------------------------------------------------------
+
+
+def test_channel_secret_with_stored_value_allows_blank_and_hints(monkeypatch):
+    recorder = _RecordingConsole()
+    monkeypatch.setattr(flow, "console", recorder)
+
+    field = ChannelSetupField(
+        name="token",
+        label="Bot token",
+        field_type="password",
+        required=True,
+        secret=True,
+    )
+    captured: dict[str, Any] = {}
+
+    class _Questionary:
+        def password(self, message: str, **kwargs: Any):
+            assert message == "Bot token"
+            captured["validate"] = kwargs.get("validate")
+            return _ValidatedPrompt([""], kwargs.get("validate"))
+
+    result = flow._ask_channel_field(_Questionary(), field, "xoxb-stored")
+
+    # Blank resolves to the stored value at the prompt itself (not via the
+    # mutation's by-name merge), so the keep promise also holds when the
+    # operator renames the entry in the same edit.
+    assert result == "xoxb-stored"
+    validate = captured["validate"]
+    assert validate is not None
+    assert validate("") is True
+    # Broken terminal pastes are still rejected even in keep-current mode.
+    assert validate("\x1b[200~xoxb-new\x1b[201~") is not True
+    assert "leave blank to keep the stored value" in recorder.joined()
+
+
+def test_channel_secret_without_stored_value_still_requires_input():
+    field = ChannelSetupField(
+        name="token",
+        label="Bot token",
+        field_type="password",
+        required=True,
+        secret=True,
+    )
+    captured: dict[str, Any] = {}
+
+    class _Questionary:
+        def password(self, message: str, **kwargs: Any):
+            captured["validate"] = kwargs.get("validate")
+            return _ValidatedPrompt(["", "xoxb-new"], kwargs.get("validate"))
+
+    result = flow._ask_channel_field(_Questionary(), field, None)
+
+    assert result == "xoxb-new"
+    assert captured["validate"]("") is not True
+
+
+def test_channel_edit_blank_secrets_keep_stored_values(tmp_path, monkeypatch):
+    """End-to-end edit: leaving both secret prompts blank must round-trip the
+    stored credentials through the mutation layer's keep-current merge."""
+
+    target = tmp_path / "c.toml"
+    from opensquilla.onboarding.setup_engine import SetupEngine
+
+    engine = SetupEngine(path=target)
+    engine.apply(
+        "channels",
+        {
+            "type": "slack",
+            "name": "slack-main",
+            "token": "xoxb-stored",
+            "signing_secret": "ss-stored",
+        },
+    )
+    engine.persist()
+    monkeypatch.setattr(flow, "_is_tty", lambda: True)
+    monkeypatch.setattr(flow, "console", _RecordingConsole())
+
+    passwords: list[str] = []
+
+    class _Answer:
+        def __init__(self, value: Any) -> None:
+            self.value = value
+
+        def ask(self) -> Any:
+            return self.value
+
+    class _Questionary(types.SimpleNamespace):
+        def select(self, message: str, **kwargs: Any):
+            if message == "Channel to edit":
+                return _Answer("slack-main")
+            return _Answer(kwargs.get("default") or list(kwargs.get("choices") or [])[0])
+
+        def text(self, message: str, **kwargs: Any):
+            return _ValidatedPrompt([kwargs.get("default", "")], kwargs.get("validate"))
+
+        def password(self, message: str, **kwargs: Any):
+            passwords.append(message)
+            return _ValidatedPrompt([""], kwargs.get("validate"))
+
+        def confirm(self, message: str, **kwargs: Any):
+            return _Answer(bool(kwargs.get("default")))
+
+        def checkbox(self, message: str, **_kwargs: Any):
+            raise AssertionError(f"unexpected checkbox prompt: {message}")
+
+    monkeypatch.setitem(sys.modules, "questionary", _Questionary())
+
+    flow.run_interactive_channel_edit(None, config_path=target)
+
+    assert passwords, "the edit flow should have prompted for at least one secret"
+    data = target.read_text()
+    assert 'token = "xoxb-stored"' in data
+    assert 'signing_secret = "ss-stored"' in data
+
+
+# ---------------------------------------------------------------------------
+# C1-9 — free-text model prompt must reject a blank submit (R9).
+# ---------------------------------------------------------------------------
+
+
+def test_free_text_model_prompt_rejects_blank_then_accepts_model():
+    """Providers without a derivable default model raise ValueError('model
+    is required') deep in the mutation after the operator already typed the
+    API key — the model prompt must re-ask on a blank submit instead."""
+    captured: dict[str, Any] = {}
+
+    class _Questionary:
+        def text(self, message: str, **kwargs: Any):
+            assert message == "Model id"
+            captured["validate"] = kwargs.get("validate")
+            return _ValidatedPrompt(["", "   ", "my-model"], kwargs.get("validate"))
+
+    result = flow._prompt_free_text_model(_Questionary())
+
+    assert result == "my-model"
+    validate = captured["validate"]
+    assert validate is not None
+    assert validate("") is not True
+    assert validate("   ") is not True
+    assert validate("my-model") is True
+
+
+def test_free_text_model_prompt_cancel_raises_user_cancelled():
+    class _Questionary:
+        def text(self, message: str, **kwargs: Any):
+            return _ValidatedPrompt([None], kwargs.get("validate"))
+
+    with pytest.raises(UserCancelledError) as exc_info:
+        flow._prompt_free_text_model(_Questionary())
+    assert exc_info.value.section == "provider"

--- a/tests/test_onboarding/test_models_discover.py
+++ b/tests/test_onboarding/test_models_discover.py
@@ -35,6 +35,22 @@ def _patch_response(monkeypatch: Any, response_factory) -> list[httpx.Request]:
     return seen
 
 
+def _patch_transport_error(monkeypatch: Any, exc: Exception) -> None:
+    """Route provider HTTP through a transport that always fails to connect."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise exc
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("opensquilla.provider.openai.httpx.AsyncClient", patched_async_client)
+
+
 def _models_response() -> httpx.Response:
     return httpx.Response(
         200,
@@ -89,6 +105,50 @@ def test_discover_resolves_key_from_provider_env(monkeypatch: Any) -> None:
     result = _discover(provider_id="openai")
     assert result.ok is True
     assert seen[0].headers["authorization"] == "Bearer sk-from-env"
+
+
+def test_discover_classifies_rejected_key_as_auth_failure(monkeypatch: Any) -> None:
+    """A 401 during listing is a wrong key, never ok=True/source='none'."""
+    _patch_response(
+        monkeypatch,
+        lambda: httpx.Response(
+            401,
+            headers={"content-type": "application/json"},
+            content=b'{"error": {"message": "Incorrect API key provided"}}',
+        ),
+    )
+    result = _discover(provider_id="openai", api_key="sk-bad")
+    assert result.ok is False
+    assert result.failure_kind == ProviderFailureKind.AUTH_INVALID.value
+    assert result.source == "none"
+    assert result.models == []
+
+
+def test_discover_classifies_connection_failure_as_transport_transient(
+    monkeypatch: Any,
+) -> None:
+    _patch_transport_error(monkeypatch, httpx.ConnectError("connection refused"))
+    result = _discover(provider_id="openai", api_key="sk-test")
+    assert result.ok is False
+    assert result.failure_kind == ProviderFailureKind.TRANSPORT_TRANSIENT.value
+    assert result.models == []
+
+
+def test_discover_empty_catalog_stays_ok_with_no_live_source(monkeypatch: Any) -> None:
+    # Distinguishable from the auth failure above: the provider answered
+    # successfully but lists nothing.
+    _patch_response(
+        monkeypatch,
+        lambda: httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=b'{"data": []}',
+        ),
+    )
+    result = _discover(provider_id="openai", api_key="sk-test")
+    assert result.ok is True
+    assert result.source == "none"
+    assert result.models == []
 
 
 async def test_discover_rpc_reuses_stored_credentials_when_blank(

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -1087,3 +1087,195 @@ def test_upsert_image_generation_rejects_bad_fallback_reference():
             cfg, provider_id="openrouter", primary=_IMG_PRIMARY, api_key="sk-img",
             fallbacks=["no-slash-ref"],
         )
+
+
+def test_validate_channel_entry_error_never_echoes_secret_values():
+    secret = "tg-super-secret-token-value-1234567890"
+
+    with pytest.raises(ValueError, match="webhook_url") as exc_info:
+        validate_channel_entry(
+            {
+                "type": "telegram",
+                "name": "t",
+                "transport_name": "webhook",
+                "token": secret,
+            }
+        )
+
+    message = str(exc_info.value)
+    assert secret not in message
+    assert secret[-12:] not in message
+    assert "input_value" not in message
+
+
+def test_upsert_channel_error_never_echoes_secret_values():
+    cfg = GatewayConfig()
+    secret = "tg-super-secret-token-value-1234567890"
+
+    with pytest.raises(ValueError, match="webhook_url") as exc_info:
+        upsert_channel(
+            cfg,
+            entry_payload={
+                "type": "telegram",
+                "name": "t",
+                "transport_name": "webhook",
+                "token": secret,
+            },
+        )
+
+    message = str(exc_info.value)
+    assert secret not in message
+    assert secret[-12:] not in message
+
+
+def test_upsert_channel_rejects_blank_required_secret_for_new_entry():
+    cfg = GatewayConfig()
+    with pytest.raises(ValueError, match="token"):
+        upsert_channel(cfg, entry_payload={"type": "telegram", "name": "t", "token": ""})
+
+
+def test_upsert_channel_rejects_whitespace_only_required_secret_for_new_entry():
+    cfg = GatewayConfig()
+    with pytest.raises(ValueError, match="token"):
+        upsert_channel(cfg, entry_payload={"type": "telegram", "name": "t", "token": "   "})
+
+
+def test_validate_channel_entry_rejects_blank_required_secret():
+    with pytest.raises(ValueError, match="token"):
+        validate_channel_entry({"type": "telegram", "name": "t", "token": ""})
+
+
+def test_validate_channel_entry_blank_secret_skips_inapplicable_show_when_fields():
+    # slack socket mode: signing_secret is required only for webhook mode,
+    # so the blank-secret gate must not fire for it here.
+    out = validate_channel_entry(
+        {
+            "type": "slack",
+            "name": "w",
+            "token": "xoxb-test",
+            "connection_mode": "socket",
+            "app_token": "xapp-test",
+        }
+    )
+    assert out["connection_mode"] == "socket"
+
+
+def test_upsert_channel_whitespace_only_secret_keeps_existing_value():
+    cfg = GatewayConfig()
+    first = upsert_channel(
+        cfg,
+        entry_payload={"type": "telegram", "name": "t", "token": "tg-original"},
+    )
+    second = upsert_channel(
+        first.config,
+        entry_payload={"type": "telegram", "name": "t", "token": "   "},
+    )
+    raw = [e.model_dump(mode="python") for e in second.config.channels.channels]
+    entry = next(e for e in raw if e["name"] == "t")
+    assert entry["token"] == "tg-original"
+
+
+def test_router_reconcile_survives_out_of_band_llm_model_change():
+    """R6: a machine-seeded ladder must stay recognizable after llm.model
+    changed out-of-band (config.set RPC / TOML hand-edit): a re-save naming
+    the new model explicitly must reseed the tiers instead of leaving every
+    routed turn pinned to the old model."""
+    cfg = GatewayConfig()
+    seeded = upsert_llm_provider(
+        cfg,
+        provider_id="anthropic",
+        model="model-alpha",
+        api_key="sk-old",
+    ).config
+    for tier in ("c0", "c1", "c2", "c3"):
+        assert seeded.squilla_router.tiers[tier]["model"] == "model-alpha"
+
+    # Out-of-band hot-apply: llm.model changes without a provider save.
+    seeded.llm.model = "model-beta"
+
+    rotated = upsert_llm_provider(
+        seeded,
+        provider_id="anthropic",
+        model="model-beta",
+        api_key="sk-new",
+    ).config
+    assert rotated.llm.model == "model-beta"
+    for tier in ("c0", "c1", "c2", "c3"):
+        assert rotated.squilla_router.tiers[tier]["model"] == "model-beta"
+
+
+def test_router_reconcile_still_preserves_hand_authored_ladder():
+    """The R6 widening must not regress the hand-customized guard: a ladder
+    that matches no machine seeding survives a same-provider re-save."""
+    cfg = GatewayConfig()
+    seeded = upsert_llm_provider(
+        cfg,
+        provider_id="anthropic",
+        model="model-alpha",
+        api_key="sk-old",
+    ).config
+    router_payload = seeded.squilla_router.model_dump(mode="python")
+    router_payload["tiers"]["c0"]["model"] = "model-cheap"
+    router_payload["tiers"]["c3"]["model"] = "model-big"
+    from opensquilla.gateway.config import SquillaRouterConfig
+
+    seeded.squilla_router = SquillaRouterConfig(**router_payload)
+
+    rotated = upsert_llm_provider(
+        seeded,
+        provider_id="anthropic",
+        model="model-alpha",
+        api_key="sk-new",
+    ).config
+    assert rotated.squilla_router.tiers["c0"]["model"] == "model-cheap"
+    assert rotated.squilla_router.tiers["c3"]["model"] == "model-big"
+
+
+def test_upsert_router_non_registry_provider_gets_actionable_error():
+    """X1: a hand-edited non-registry llm.provider used to die on the cryptic
+    "router tier 'c0' must be an object"; the error must now name the
+    provider and point at the two runnable ways out."""
+    cfg = GatewayConfig()
+    cfg.llm.provider = "acme-llm"
+    cfg.llm.model = "acme-model"
+
+    with pytest.raises(ValueError) as exc_info:
+        upsert_router(cfg, mode="recommended", default_tier="c1")
+
+    message = str(exc_info.value)
+    assert "acme-llm" in message
+    assert "opensquilla onboard configure provider --provider" in message
+    assert "--router disabled" in message
+    assert "must be an object" not in message
+
+
+def test_upsert_router_non_registry_provider_disabled_still_works():
+    cfg = GatewayConfig()
+    cfg.llm.provider = "acme-llm"
+    cfg.llm.model = "acme-model"
+    res = upsert_router(cfg, mode="disabled")
+    assert res.config.squilla_router.enabled is False
+
+
+def test_image_generation_explicit_enabled_decision_is_force_persisted(tmp_path):
+    """R1: an explicit enabled=false on a fresh config equals the model
+    default, so the sparse diff alone would drop it — and a later key
+    rotation would re-enable image generation via configure-implies-enable.
+    The mutation must force the decision into the file."""
+    import tomllib as _tomllib
+
+    from opensquilla.onboarding.config_store import load_config, persist_config
+
+    target = tmp_path / "config.toml"
+    cfg = load_config(target)
+    res = upsert_image_generation_provider(
+        cfg,
+        provider_id="openai",
+        primary="openai/gpt-image-1",
+        api_key="sk-image-1",
+        enabled=False,
+    )
+    persist_config(res.config, path=target)
+
+    data = _tomllib.loads(target.read_text())
+    assert data["image_generation"]["enabled"] is False

--- a/tests/test_onboarding/test_mutations_keep_current.py
+++ b/tests/test_onboarding/test_mutations_keep_current.py
@@ -1,0 +1,301 @@
+"""Keep-current semantics for onboarding mutations.
+
+Omitted parameters (``None``) must never reset stored provider, search, or
+router settings — re-saving for a key rotation has to be loss-free.
+"""
+
+from __future__ import annotations
+
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.onboarding.mutations import (
+    upsert_llm_provider,
+    upsert_router,
+    upsert_search_provider,
+)
+
+_HAND_TIERS = {
+    "c0": {"provider": "openrouter", "model": "hand-c0"},
+    "c1": {"provider": "openrouter", "model": "hand-c1"},
+    "c2": {"provider": "openrouter", "model": "hand-c2"},
+    "c3": {"provider": "openrouter", "model": "hand-c3"},
+}
+
+
+def _config_with_hand_tiers() -> GatewayConfig:
+    return GatewayConfig(
+        llm={"provider": "openrouter", "model": "hand-c1", "api_key": "sk-old"},
+        squilla_router={
+            "enabled": True,
+            "tier_profile": None,
+            "tiers": {name: dict(tier) for name, tier in _HAND_TIERS.items()},
+        },
+    )
+
+
+def _configured_openrouter() -> GatewayConfig:
+    res = upsert_llm_provider(
+        GatewayConfig(),
+        provider_id="openrouter",
+        model="corp-model",
+        api_key="sk-old",
+        base_url="https://llm.corp.example/v1",
+        proxy="http://127.0.0.1:7890",
+        provider_routing={"corp-model": "corp-upstream"},
+    )
+    cfg = res.config
+    cfg.llm.max_tokens = 4096
+    cfg.llm.thinking = "high"
+    return cfg
+
+
+# --- B1-1: provider re-save keeps every field not explicitly passed ---------
+
+
+def test_upsert_llm_provider_same_provider_resave_keeps_unspecified_fields():
+    cfg = _configured_openrouter()
+
+    res = upsert_llm_provider(cfg, provider_id="openrouter", api_key="sk-rotated")
+
+    llm = res.config.llm
+    assert llm.api_key == "sk-rotated"
+    assert llm.model == "corp-model"
+    assert llm.base_url == "https://llm.corp.example/v1"
+    assert llm.proxy == "http://127.0.0.1:7890"
+    assert llm.provider_routing == {"corp-model": "corp-upstream"}
+    assert llm.max_tokens == 4096
+    assert llm.thinking == "high"
+
+
+def test_upsert_llm_provider_public_payload_reflects_kept_values():
+    cfg = _configured_openrouter()
+
+    res = upsert_llm_provider(cfg, provider_id="openrouter", api_key="sk-rotated")
+
+    assert res.public_payload["model"] == "corp-model"
+    assert res.public_payload["base_url"] == "https://llm.corp.example/v1"
+    assert res.public_payload["proxy"] == "http://127.0.0.1:7890"
+    assert res.public_payload["provider_routing"] == {"corp-model": "corp-upstream"}
+
+
+def test_upsert_llm_provider_explicit_values_still_override_stored():
+    cfg = _configured_openrouter()
+
+    res = upsert_llm_provider(
+        cfg,
+        provider_id="openrouter",
+        model="new-model",
+        api_key="sk-rotated",
+        base_url="https://other.example/v1",
+        proxy="",
+        provider_routing={},
+    )
+
+    llm = res.config.llm
+    assert llm.model == "new-model"
+    assert llm.base_url == "https://other.example/v1"
+    assert llm.proxy == ""
+    assert llm.provider_routing == {}
+
+
+def test_upsert_llm_provider_empty_model_string_keeps_legacy_default_chain():
+    # model="" (explicit empty, the legacy RPC spelling) still derives the
+    # router-tier default rather than keeping the stored model.
+    cfg = _configured_openrouter()
+
+    res = upsert_llm_provider(cfg, provider_id="openrouter", model="", api_key="sk-r")
+
+    assert res.config.llm.model != "corp-model"
+    assert res.config.llm.model
+
+
+def test_upsert_llm_provider_provider_switch_does_not_carry_unrelated_fields():
+    cfg = _configured_openrouter()
+
+    res = upsert_llm_provider(
+        cfg, provider_id="deepseek", model="deepseek-chat", api_key="sk-ds"
+    )
+
+    llm = res.config.llm
+    assert llm.provider == "deepseek"
+    assert llm.proxy == ""
+    assert llm.provider_routing == {}
+    assert llm.base_url != "https://llm.corp.example/v1"
+    assert llm.max_tokens == 0
+    assert llm.thinking is None
+
+
+def test_upsert_llm_provider_same_provider_resave_keeps_custom_router_tiers():
+    cfg = _config_with_hand_tiers()
+
+    res = upsert_llm_provider(cfg, provider_id="openrouter", api_key="sk-rotated")
+
+    router = res.config.squilla_router
+    assert router.tier_profile is None
+    for tier in ("c0", "c1", "c2", "c3"):
+        assert router.tiers[tier]["model"] == f"hand-{tier}"
+
+
+def test_upsert_llm_provider_same_provider_resave_still_reconciles_untouched_tiers():
+    # Guard for the skip rule: default (never hand-edited) tiers still get
+    # the packaged compact profile on a same-provider save.
+    res = upsert_llm_provider(
+        GatewayConfig(), provider_id="openrouter", model="m", api_key="sk-x"
+    )
+
+    assert res.config.squilla_router.tier_profile == "openrouter"
+
+
+def test_upsert_llm_provider_same_provider_model_change_reseeds_preset_seeded_tiers():
+    # Tiers a previous save seeded from the provider preset are not a
+    # hand-edited ladder: a model change must keep refreshing them.
+    first = upsert_llm_provider(
+        GatewayConfig(), provider_id="groq", model="model-a", api_key="sk-g"
+    )
+    second = upsert_llm_provider(
+        first.config, provider_id="groq", model="model-b", api_key=""
+    )
+
+    router = second.config.squilla_router
+    for tier in ("c0", "c1", "c2", "c3"):
+        assert router.tiers[tier]["model"] == "model-b"
+
+
+# --- B1-2: search re-save keeps omitted settings ------------------------------
+
+
+def test_upsert_search_provider_omitted_fields_keep_current():
+    first = upsert_search_provider(
+        GatewayConfig(),
+        provider_id="brave",
+        api_key="brave-key",
+        max_results=9,
+        proxy="http://127.0.0.1:7890",
+        use_env_proxy=True,
+        fallback_policy="network",
+        diagnostics=True,
+    )
+
+    second = upsert_search_provider(
+        first.config, provider_id="brave", api_key="brave-rotated"
+    )
+
+    cfg = second.config
+    assert cfg.search_api_key == "brave-rotated"
+    assert cfg.search_max_results == 9
+    assert cfg.search_proxy == "http://127.0.0.1:7890"
+    assert cfg.search_use_env_proxy is True
+    assert cfg.search_fallback_policy == "network"
+    assert cfg.search_diagnostics is True
+
+
+def test_upsert_search_provider_explicit_values_override_stored():
+    first = upsert_search_provider(
+        GatewayConfig(),
+        provider_id="brave",
+        api_key="brave-key",
+        max_results=9,
+        proxy="http://127.0.0.1:7890",
+        use_env_proxy=True,
+        fallback_policy="network",
+        diagnostics=True,
+    )
+
+    second = upsert_search_provider(
+        first.config,
+        provider_id="brave",
+        max_results=3,
+        proxy="",
+        use_env_proxy=False,
+        fallback_policy="off",
+        diagnostics=False,
+    )
+
+    cfg = second.config
+    assert cfg.search_api_key == "brave-key"  # blank key keeps current
+    assert cfg.search_max_results == 3
+    assert cfg.search_proxy == ""
+    assert cfg.search_use_env_proxy is False
+    assert cfg.search_fallback_policy == "off"
+    assert cfg.search_diagnostics is False
+
+
+def test_upsert_search_provider_keep_current_applies_across_provider_switch():
+    # max_results/proxy/... are global search settings, so they survive a
+    # provider switch when omitted.
+    first = upsert_search_provider(
+        GatewayConfig(),
+        provider_id="brave",
+        api_key="brave-key",
+        max_results=9,
+        diagnostics=True,
+    )
+
+    second = upsert_search_provider(first.config, provider_id="duckduckgo")
+
+    assert second.config.search_provider == "duckduckgo"
+    assert second.config.search_max_results == 9
+    assert second.config.search_diagnostics is True
+
+
+# --- B1-3: disable preserves the ladder; custom re-enable restores it --------
+
+
+def test_upsert_router_disable_preserves_inline_custom_tiers():
+    cfg = _config_with_hand_tiers()
+
+    res = upsert_router(cfg, mode="disabled")
+
+    router = res.config.squilla_router
+    assert router.enabled is False
+    assert router.tier_profile is None
+    for tier in ("c0", "c1", "c2", "c3"):
+        assert router.tiers[tier]["model"] == f"hand-{tier}"
+
+
+def test_upsert_router_disable_then_custom_reenable_restores_hand_built_tiers():
+    cfg = _config_with_hand_tiers()
+
+    disabled = upsert_router(cfg, mode="disabled")
+    reenabled = upsert_router(disabled.config, mode="custom")
+
+    router = reenabled.config.squilla_router
+    assert router.enabled is True
+    assert router.tier_profile is None
+    for tier in ("c0", "c1", "c2", "c3"):
+        assert router.tiers[tier]["model"] == f"hand-{tier}"
+
+
+def test_upsert_router_custom_keeps_inline_hand_tiers_when_tiers_omitted():
+    # Even without a disable/enable round trip, a custom-mode save that
+    # passes no tiers must not reset an inline hand-built ladder.
+    cfg = _config_with_hand_tiers()
+
+    res = upsert_router(cfg, mode="custom")
+
+    router = res.config.squilla_router
+    for tier in ("c0", "c1", "c2", "c3"):
+        assert router.tiers[tier]["model"] == f"hand-{tier}"
+
+
+def test_upsert_router_recommended_reenable_still_resets_to_packaged_profile():
+    # "recommended" remains an explicit reset to the packaged profile.
+    cfg = _config_with_hand_tiers()
+
+    disabled = upsert_router(cfg, mode="disabled")
+    reenabled = upsert_router(disabled.config, mode="recommended")
+
+    router = reenabled.config.squilla_router
+    assert router.enabled is True
+    assert router.tier_profile == "openrouter"
+    assert router.tiers["c0"]["model"] != "hand-c0"
+
+
+def test_upsert_router_disabled_ladder_survives_toml_round_trip():
+    cfg = _config_with_hand_tiers()
+
+    disabled = upsert_router(cfg, mode="disabled")
+    persisted = disabled.config.to_toml_dict()["squilla_router"]
+    reloaded = GatewayConfig(squilla_router=persisted, llm={"provider": "openrouter"})
+
+    assert reloaded.squilla_router.enabled is False
+    assert reloaded.squilla_router.tiers["c2"]["model"] == "hand-c2"

--- a/tests/test_onboarding/test_next_steps.py
+++ b/tests/test_onboarding/test_next_steps.py
@@ -216,3 +216,140 @@ def test_headless_setup_commands_cover_the_ensemble_section():
                 "opensquilla onboard configure ensemble --enabled",
             )
         ]
+
+
+def test_quote_cli_arg_uses_posix_quoting_off_windows(monkeypatch):
+    import shlex
+
+    from opensquilla.onboarding import next_steps
+
+    monkeypatch.setattr(next_steps.platform, "system", lambda: "Linux")
+
+    assert next_steps.quote_cli_arg("/tmp/plain.toml") == "/tmp/plain.toml"
+    assert next_steps.quote_cli_arg("/tmp/with space.toml") == shlex.quote(
+        "/tmp/with space.toml"
+    )
+    assert next_steps.quote_cli_arg("/tmp/it's.toml") == shlex.quote("/tmp/it's.toml")
+
+
+def test_quote_cli_arg_uses_powershell_quoting_on_windows(monkeypatch):
+    from opensquilla.onboarding import next_steps
+
+    monkeypatch.setattr(next_steps.platform, "system", lambda: "Windows")
+
+    # Plain values stay copyable as-is.
+    assert next_steps.quote_cli_arg("config.toml") == "config.toml"
+    # Values needing quotes get PowerShell literal strings, not the POSIX
+    # '"'"' dance that PowerShell cannot parse.
+    assert (
+        next_steps.quote_cli_arg("C:\\Setup Files\\config.toml")
+        == "'C:\\Setup Files\\config.toml'"
+    )
+    assert next_steps.quote_cli_arg("C:\\it's.toml") == "'C:\\it''s.toml'"
+    assert '"\'"' not in next_steps.quote_cli_arg("C:\\it's.toml")
+
+
+def test_config_cli_arg_is_powershell_safe_on_windows(monkeypatch):
+    from opensquilla.onboarding import next_steps
+
+    monkeypatch.setattr(next_steps.platform, "system", lambda: "Windows")
+
+    arg = next_steps._config_cli_arg("C:\\Setup Files\\config.toml")
+
+    assert arg == " --config 'C:\\Setup Files\\config.toml'"
+
+
+def test_set_env_command_is_bare_on_both_platforms(monkeypatch):
+    from opensquilla.onboarding import next_steps
+
+    monkeypatch.setattr(next_steps.platform, "system", lambda: "Linux")
+    assert next_steps.set_env_command("DUMMY_KEY") == 'export DUMMY_KEY="<your-key>"'
+    assert next_steps.set_env_hint("DUMMY_KEY") == 'export DUMMY_KEY="<your-key>"'
+
+    monkeypatch.setattr(next_steps.platform, "system", lambda: "Windows")
+    assert next_steps.set_env_command("DUMMY_KEY") == '$env:DUMMY_KEY = "<your-key>"'
+    # The human hint keeps the shell label; the bare command never carries it.
+    assert (
+        next_steps.set_env_hint("DUMMY_KEY")
+        == 'PowerShell: $env:DUMMY_KEY = "<your-key>"'
+    )
+
+
+def test_env_recovery_commands_carry_only_the_command_on_windows(monkeypatch):
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.onboarding import next_steps
+    from opensquilla.onboarding.status import get_onboarding_status
+
+    cfg = GatewayConfig()
+    cfg.llm.api_key = ""
+    cfg.llm.api_key_env = "DUMMY_UNSET_LLM_KEY"
+    monkeypatch.delenv("DUMMY_UNSET_LLM_KEY", raising=False)
+    monkeypatch.setattr(next_steps.platform, "system", lambda: "Windows")
+
+    commands = next_steps.env_recovery_commands(get_onboarding_status(cfg))
+
+    assert commands
+    for entry in commands:
+        assert set(entry) == {"section", "label", "command"}
+        assert entry["command"] == '$env:DUMMY_UNSET_LLM_KEY = "<your-key>"'
+        assert "PowerShell" not in entry["command"]
+
+
+def test_status_display_words_have_a_single_source_of_truth():
+    from opensquilla.cli import onboard_cmd
+    from opensquilla.onboarding import next_steps
+    from opensquilla.onboarding.section_status import SECTION_STATUS_DISPLAY
+
+    # The status table renders through the shared mapping object itself…
+    assert onboard_cmd._STATUS_DISPLAY is SECTION_STATUS_DISPLAY
+    # …and the capability summary uses a mechanically derived string view.
+    assert next_steps._CAPABILITY_STATUS_DISPLAY == {
+        status.value: display for status, display in SECTION_STATUS_DISPLAY.items()
+    }
+    assert set(next_steps._CAPABILITY_STATUS_DISPLAY) == {
+        "ok", "optional", "missing", "degraded", "unknown",
+    }
+
+
+def test_next_steps_mention_persistent_env_file_alongside_export_hint(
+    tmp_path, monkeypatch
+):
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.onboarding import next_steps
+
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "state-home"))
+    cfg = GatewayConfig()
+    cfg.llm.api_key = ""
+    cfg.llm.api_key_env = "DUMMY_UNSET_LLM_KEY"
+    monkeypatch.delenv("DUMMY_UNSET_LLM_KEY", raising=False)
+
+    text = next_steps.format_next_steps(cfg, config_path="/tmp/config.toml")
+
+    env_file = str(tmp_path / "state-home" / ".env")
+    assert (
+        f"Persist key across restarts: add DUMMY_UNSET_LLM_KEY=<your-key> to {env_file}"
+        in text
+    )
+    # The persist hint sits with the export hint in the Commands block.
+    commands = text.split("Commands:", 1)[1].split("Reference:", 1)[0]
+    assert "Set key before starting gateway:" in commands
+    assert "Persist key across restarts:" in commands
+
+
+def test_missing_env_warning_mentions_persistent_env_file(tmp_path, monkeypatch):
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.onboarding import next_steps
+
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "state-home"))
+    cfg = GatewayConfig()
+    cfg.llm.api_key = ""
+    cfg.llm.api_key_env = "DUMMY_UNSET_LLM_KEY"
+    monkeypatch.delenv("DUMMY_UNSET_LLM_KEY", raising=False)
+
+    warnings = next_steps.env_reference_warnings(cfg)
+
+    env_file = str(tmp_path / "state-home" / ".env")
+    assert any(
+        "DUMMY_UNSET_LLM_KEY=<your-key>" in warning and env_file in warning
+        for warning in warnings
+    )

--- a/tests/test_onboarding/test_next_steps.py
+++ b/tests/test_onboarding/test_next_steps.py
@@ -353,3 +353,61 @@ def test_missing_env_warning_mentions_persistent_env_file(tmp_path, monkeypatch)
         "DUMMY_UNSET_LLM_KEY=<your-key>" in warning and env_file in warning
         for warning in warnings
     )
+
+
+def test_next_steps_advertise_the_configure_hub(monkeypatch):
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.onboarding import next_steps
+
+    cfg = GatewayConfig()
+
+    text = next_steps.format_next_steps(cfg, config_path="/tmp/config.toml")
+
+    commands = text.split("Commands:", 1)[1].split("Reference:", 1)[0]
+    assert (
+        "Change settings anytime: opensquilla onboard configure --config /tmp/config.toml"
+        in commands
+    )
+
+
+def test_fix_next_names_the_exact_command_for_a_degraded_capability(monkeypatch):
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.onboarding import next_steps
+
+    cfg = GatewayConfig()
+    cfg.search_provider = "tavily"
+    cfg.search_api_key = ""
+    cfg.search_api_key_env = "DUMMY_UNSET_SEARCH_KEY"
+    monkeypatch.delenv("DUMMY_UNSET_SEARCH_KEY", raising=False)
+
+    text = next_steps.format_next_steps(cfg, config_path="/tmp/config.toml")
+
+    assert "Fix next:" in text
+    fix_block = text.split("Fix next:", 1)[1].split("Reference:", 1)[0]
+    assert "opensquilla onboard configure search --config /tmp/config.toml" in fix_block
+
+
+def test_fix_next_absent_when_nothing_needs_attention():
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.onboarding import next_steps
+
+    # Fresh defaults: every capability is either ready or a deliberate
+    # "Later" opt-out — nothing to nag about.
+    text = next_steps.format_next_steps(GatewayConfig(), config_path="/tmp/config.toml")
+
+    assert "Fix next:" not in text
+
+
+def test_fix_next_never_advertises_the_nonexistent_configure_audio(monkeypatch):
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.onboarding import next_steps
+
+    cfg = GatewayConfig()
+    cfg.audio.enabled = True  # enabled without any provider credential
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+
+    text = next_steps.format_next_steps(cfg, config_path="/tmp/config.toml")
+
+    assert "Fix next:" in text
+    assert "onboard configure audio" not in text
+    assert "opensquilla onboard catalog audio" in text

--- a/tests/test_onboarding/test_probe_model_listing.py
+++ b/tests/test_onboarding/test_probe_model_listing.py
@@ -1,0 +1,114 @@
+"""Adapter-level contract for the model listing used by onboarding discovery.
+
+Every runtime caller of ``list_models()`` relies on the historical
+swallow-errors default (an unreachable or unauthorized provider degrades to
+an empty list). Discovery instead needs failures surfaced so a wrong key and
+an empty catalog stay distinguishable, which is what the keyword-only
+``raise_on_error=True`` opt-in provides. Both sides are pinned here for the
+three adapters that support it (offline, stubbed transport).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from opensquilla.provider.ollama import OllamaProvider
+from opensquilla.provider.openai import OpenAIProvider
+from opensquilla.provider.openai_responses import OpenAIResponsesProvider
+
+_ADAPTER_MODULES = {
+    "openai": "opensquilla.provider.openai",
+    "ollama": "opensquilla.provider.ollama",
+    "openai_responses": "opensquilla.provider.openai_responses",
+}
+
+
+def _patch_response(monkeypatch: Any, module: str, response: httpx.Response) -> None:
+    transport = httpx.MockTransport(lambda request: response)
+    _patch_client(monkeypatch, module, transport)
+
+
+def _patch_transport_error(monkeypatch: Any, module: str, exc: Exception) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise exc
+
+    _patch_client(monkeypatch, module, httpx.MockTransport(handler))
+
+
+def _patch_client(monkeypatch: Any, module: str, transport: httpx.MockTransport) -> None:
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(f"{_ADAPTER_MODULES[module]}.httpx.AsyncClient", patched_async_client)
+
+
+def _build(module: str) -> Any:
+    if module == "openai":
+        return OpenAIProvider(api_key="sk-test", model="gpt-4o")
+    if module == "ollama":
+        return OllamaProvider(model="llama3")
+    return OpenAIResponsesProvider(api_key="sk-test", model="gpt-5.5")
+
+
+def _unauthorized() -> httpx.Response:
+    return httpx.Response(
+        401,
+        headers={"content-type": "application/json"},
+        content=b'{"error": {"message": "Incorrect API key provided"}}',
+    )
+
+
+def _garbled() -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers={"content-type": "application/json"},
+        content=b'{"data": [truncated',
+    )
+
+
+@pytest.mark.parametrize("module", sorted(_ADAPTER_MODULES))
+def test_list_models_default_swallows_http_errors(monkeypatch: Any, module: str) -> None:
+    _patch_response(monkeypatch, module, _unauthorized())
+    assert asyncio.run(_build(module).list_models()) == []
+
+
+@pytest.mark.parametrize("module", sorted(_ADAPTER_MODULES))
+def test_list_models_default_swallows_transport_errors(monkeypatch: Any, module: str) -> None:
+    _patch_transport_error(monkeypatch, module, httpx.ConnectError("connection refused"))
+    assert asyncio.run(_build(module).list_models()) == []
+
+
+@pytest.mark.parametrize("module", sorted(_ADAPTER_MODULES))
+def test_list_models_default_swallows_garbled_body(monkeypatch: Any, module: str) -> None:
+    _patch_response(monkeypatch, module, _garbled())
+    assert asyncio.run(_build(module).list_models()) == []
+
+
+@pytest.mark.parametrize("module", sorted(_ADAPTER_MODULES))
+def test_list_models_opt_in_raises_http_status_error(monkeypatch: Any, module: str) -> None:
+    _patch_response(monkeypatch, module, _unauthorized())
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        asyncio.run(_build(module).list_models(raise_on_error=True))
+    assert excinfo.value.response.status_code == 401
+
+
+@pytest.mark.parametrize("module", sorted(_ADAPTER_MODULES))
+def test_list_models_opt_in_raises_transport_error(monkeypatch: Any, module: str) -> None:
+    _patch_transport_error(monkeypatch, module, httpx.ConnectError("connection refused"))
+    with pytest.raises(httpx.ConnectError):
+        asyncio.run(_build(module).list_models(raise_on_error=True))
+
+
+@pytest.mark.parametrize("module", sorted(_ADAPTER_MODULES))
+def test_list_models_opt_in_raises_on_garbled_body(monkeypatch: Any, module: str) -> None:
+    _patch_response(monkeypatch, module, _garbled())
+    with pytest.raises(json.JSONDecodeError):
+        asyncio.run(_build(module).list_models(raise_on_error=True))

--- a/tests/test_onboarding/test_provider_probe.py
+++ b/tests/test_onboarding/test_provider_probe.py
@@ -11,6 +11,7 @@ import pytest
 
 from opensquilla.onboarding.probe import probe_llm_provider
 from opensquilla.provider.failures import ProviderFailureKind
+from opensquilla.provider.types import TextDeltaEvent
 
 
 def _sse_ok_body() -> bytes:
@@ -27,6 +28,22 @@ def _sse_ok_body() -> bytes:
 
 def _patch_response(monkeypatch: Any, response: httpx.Response) -> None:
     transport = httpx.MockTransport(lambda request: response)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("opensquilla.provider.openai.httpx.AsyncClient", patched_async_client)
+
+
+def _patch_transport_error(monkeypatch: Any, exc: Exception) -> None:
+    """Route provider HTTP through a transport that always fails to connect."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise exc
+
+    transport = httpx.MockTransport(handler)
     real_async_client = httpx.AsyncClient
 
     def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
@@ -100,3 +117,83 @@ def test_probe_rejects_unknown_provider_as_validation_error() -> None:
 def test_probe_requires_model() -> None:
     with pytest.raises(ValueError, match="Model is required"):
         _probe(provider_id="openai", model="", api_key="sk-test")
+
+
+def test_probe_classifies_connection_failure_as_transport_transient(monkeypatch: Any) -> None:
+    _patch_transport_error(monkeypatch, httpx.ConnectError("connection refused"))
+    result = _probe(provider_id="openai", model="gpt-4o", api_key="sk-test")
+    assert result.ok is False
+    assert result.failure_kind == ProviderFailureKind.TRANSPORT_TRANSIENT.value
+
+
+def test_probe_classifies_raised_stream_exception_as_transport_transient(
+    monkeypatch: Any,
+) -> None:
+    """An exception escaping the adapter's stream hits the probe's own guard."""
+
+    class _ExplodingProvider:
+        provider_name = "openai"
+
+        def chat(self, messages: Any, tools: Any = None, config: Any = None) -> Any:
+            async def _gen() -> Any:
+                raise RuntimeError("socket closed unexpectedly")
+                yield  # pragma: no cover - makes _gen an async generator
+
+            return _gen()
+
+        async def list_models(self) -> list[Any]:
+            return []
+
+    monkeypatch.setattr(
+        "opensquilla.onboarding.probe.build_provider",
+        lambda *args, **kwargs: _ExplodingProvider(),
+    )
+    result = _probe(provider_id="openai", model="gpt-4o", api_key="sk-test")
+    assert result.ok is False
+    assert result.failure_kind == ProviderFailureKind.TRANSPORT_TRANSIENT.value
+    assert "socket closed" in result.message
+
+
+def test_probe_classifies_truncated_stream_as_malformed_response(monkeypatch: Any) -> None:
+    """A stream that dies before its completion event is a malformed response."""
+
+    class _TruncatedProvider:
+        provider_name = "openai"
+
+        def chat(self, messages: Any, tools: Any = None, config: Any = None) -> Any:
+            async def _gen() -> Any:
+                yield TextDeltaEvent(text="pa")  # then the stream just stops
+
+            return _gen()
+
+        async def list_models(self) -> list[Any]:
+            return []
+
+    monkeypatch.setattr(
+        "opensquilla.onboarding.probe.build_provider",
+        lambda *args, **kwargs: _TruncatedProvider(),
+    )
+    result = _probe(provider_id="openai", model="gpt-4o", api_key="sk-test")
+    assert result.ok is False
+    assert result.failure_kind == ProviderFailureKind.MALFORMED_RESPONSE.value
+    assert "without a completion event" in result.message
+
+
+def test_probe_redacts_key_material_echoed_by_auth_errors(monkeypatch: Any) -> None:
+    """Provider 401 bodies can echo the bad key; the probe must never repeat it."""
+    leaked = "sk-verysecretsynthetictoken123"
+    _patch_response(
+        monkeypatch,
+        httpx.Response(
+            401,
+            headers={"content-type": "application/json"},
+            content=json.dumps(
+                {"error": {"message": f"Incorrect API key provided: {leaked}"}}
+            ).encode(),
+        ),
+    )
+    result = _probe(provider_id="openai", model="gpt-4o", api_key="sk-bad")
+    assert result.ok is False
+    assert result.failure_kind == ProviderFailureKind.AUTH_INVALID.value
+    assert leaked not in result.message
+    assert "***" in result.message

--- a/tests/test_onboarding/test_provider_specs.py
+++ b/tests/test_onboarding/test_provider_specs.py
@@ -138,6 +138,32 @@ def test_api_key_providers_expose_env_key_field_in_setup_spec():
     assert env_field.secret is False
 
 
+def test_api_key_field_describes_plaintext_config_storage_accurately():
+    """A pasted key is persisted as plaintext api_key in the config file and
+    is consulted ahead of the env var — the description must say so instead
+    of implying the paste lands under the env key."""
+    spec = get_provider_setup_spec("openrouter")
+    api_field = next(f for f in spec.fields if f.name == "api_key")
+
+    assert "Stored under env key" not in api_field.description
+    assert "plaintext api_key" in api_field.description
+    assert "config file" in api_field.description
+    assert "ahead of OPENROUTER_API_KEY" in api_field.description
+    assert "Leave blank to read OPENROUTER_API_KEY" in api_field.description
+
+
+def test_api_key_field_description_stays_accurate_without_an_env_key():
+    # Providers without a registry env key still persist pastes in plaintext.
+    for spec in list_provider_setup_specs():
+        api_field = next(f for f in spec.fields if f.name == "api_key")
+        if spec.env_key:
+            assert spec.env_key in api_field.description
+        else:
+            assert api_field.description == (
+                "Saved as plaintext api_key in the config file."
+            )
+
+
 def test_non_router_providers_explain_required_model_in_setup_spec():
     for provider_id in ("anthropic", "ollama", "qianfan", "openai_responses"):
         spec = get_provider_setup_spec(provider_id)

--- a/tests/test_onboarding/test_search_specs.py
+++ b/tests/test_onboarding/test_search_specs.py
@@ -73,3 +73,23 @@ def test_search_payload_marks_search_as_optional_capability():
     assert all(row["blocking"] is False for row in payload)
     assert all(row["canProbe"] is False for row in payload)
     assert all(row["readmeScenarios"] for row in payload)
+
+
+def test_search_api_key_description_states_plaintext_storage_and_env_fallback():
+    """The api_key hint must describe where the key actually goes: pasted
+    keys persist as plaintext ``search_api_key`` in the config file (taking
+    precedence over the env var); blank reads the env var instead. The old
+    "Stored under env key X." wording claimed the opposite."""
+    spec = get_search_provider_setup_spec("brave")
+    api_field = next(f for f in spec.fields if f.name == "api_key")
+
+    assert "Stored under env key" not in api_field.description
+    assert "plaintext search_api_key" in api_field.description
+    assert spec.env_key in api_field.description
+    assert "Leave blank" in api_field.description
+
+
+def test_search_api_key_description_empty_without_env_key():
+    spec = get_search_provider_setup_spec("duckduckgo")
+    api_field = next(f for f in spec.fields if f.name == "api_key")
+    assert api_field.description == ""

--- a/tests/test_onboarding/test_section_status.py
+++ b/tests/test_onboarding/test_section_status.py
@@ -497,3 +497,49 @@ def test_needs_onboarding_false_when_optional_section_unknown():
         "memory_embedding": SectionStatus.OK,
     }
     assert needs_onboarding(sections) is False
+
+
+# ── shared image-generation provider resolution ─────────────────────────────
+
+def test_image_generation_provider_resolution_has_a_single_implementation():
+    """status.py must reuse section_status's provider resolution verbatim.
+
+    The two modules once carried textually diverging copies of this ~50-line
+    helper; pin the import so any future re-fork fails loudly.
+    """
+    from opensquilla.onboarding import section_status, status
+
+    assert (
+        status._configured_image_generation_provider_ids
+        is section_status._configured_image_generation_provider_ids
+    )
+
+
+def test_default_image_generation_primary_matches_config_default():
+    from opensquilla.gateway.config import ImageGenerationConfig
+    from opensquilla.onboarding.section_status import DEFAULT_IMAGE_GENERATION_PRIMARY
+
+    assert (
+        DEFAULT_IMAGE_GENERATION_PRIMARY
+        == ImageGenerationConfig.model_fields["primary"].default
+    )
+    assert DEFAULT_IMAGE_GENERATION_PRIMARY == GatewayConfig().image_generation.primary
+
+
+def test_both_call_sites_resolve_the_same_providers(cfg, monkeypatch):
+    """Verifier and status annotations must agree on the resolved providers."""
+    from opensquilla.onboarding import section_status
+    from opensquilla.onboarding.status import get_onboarding_status
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openrouter/google/gemini-3.1-flash-image-preview"
+    cfg.image_generation.providers.openrouter.api_key = "sk-dummy-image"
+
+    resolved = section_status._configured_image_generation_provider_ids(cfg)
+    s = get_onboarding_status(cfg)
+
+    assert resolved == ["openrouter"]
+    assert s.image_generation_provider == "openrouter"
+    assert image_generation_section_status(cfg) is SectionStatus.OK
+    assert s.image_generation_configured is True

--- a/tests/test_onboarding/test_setup_engine.py
+++ b/tests/test_onboarding/test_setup_engine.py
@@ -1,7 +1,10 @@
 """Tests for the shared onboarding setup engine."""
 
+from __future__ import annotations
+
 import tomllib
 
+from opensquilla.onboarding.config_store import load_config
 from opensquilla.onboarding.setup_engine import SetupEngine
 
 
@@ -47,7 +50,7 @@ def test_setup_engine_can_derive_provider_model_from_router_default_tier(tmp_pat
     assert data["llm"]["provider"] == "deepseek"
     assert data["llm"]["model"] == "deepseek-v4-flash"
     assert data["squilla_router"]["tier_profile"] == "deepseek"
-    assert data["squilla_router"]["default_tier"] == "c1"
+    assert load_config(target).squilla_router.default_tier == "c1"
 
 
 def test_setup_engine_passes_preset_id_through_to_provider_upsert(tmp_path):
@@ -69,7 +72,7 @@ def test_setup_engine_passes_preset_id_through_to_provider_upsert(tmp_path):
 
     data = tomllib.loads(target.read_text())
     assert data["llm"]["provider"] == "groq"
-    assert data["squilla_router"]["enabled"] is True
+    assert load_config(target).squilla_router.enabled is True
     assert "tier_profile" not in data["squilla_router"]
     tier = data["squilla_router"]["tiers"]["c0"]
     assert tier["provider"] == "groq"
@@ -150,7 +153,7 @@ def test_setup_engine_image_generation_can_use_custom_env_reference(
 
     data = tomllib.loads(target.read_text())
     provider = data["image_generation"]["providers"]["openrouter"]
-    assert provider["api_key"] == ""
+    assert load_config(target).image_generation.providers.openrouter.api_key == ""
     assert provider["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
 
 
@@ -170,7 +173,7 @@ def test_setup_engine_accepts_short_capability_section_aliases(tmp_path, monkeyp
     engine.persist()
 
     data = tomllib.loads(target.read_text())
-    assert data["image_generation"]["enabled"] is False
+    assert load_config(target).image_generation.enabled is False
     assert data["memory"]["embedding"]["provider"] == "local"
     assert data["memory"]["embedding"]["local"]["onnx_dir"] == "models/bge"
 
@@ -228,10 +231,143 @@ def test_setup_engine_applies_ensemble_with_keep_current_semantics(tmp_path):
 
 
 def test_setup_engine_accepts_ensemble_section_aliases(tmp_path):
+    import tomllib as _tomllib
+
     for alias in ("ensemble", "llm-ensemble", "llm_ensemble"):
         target = tmp_path / f"{alias.replace('_', '-')}.toml"
+        # Seed the non-default state: the alias must observably apply the
+        # disable, not exit cleanly while persisting nothing (the effective
+        # value equals the model default on a fresh config, so a no-op
+        # would previously pass this test).
+        target.write_text("[llm_ensemble]\nenabled = true\n", encoding="utf-8")
         engine = SetupEngine(path=target)
         engine.apply(alias, {"enabled": False})
         engine.persist()
-        data = tomllib.loads(target.read_text())
-        assert data["llm_ensemble"]["enabled"] is False
+        data = _tomllib.loads(target.read_text())
+        assert data["llm_ensemble"]["enabled"] is False, alias
+        assert load_config(target).llm_ensemble.enabled is False
+
+
+def test_setup_engine_provider_none_payload_values_keep_stored_fields(tmp_path):
+    # None payload values mean "not passed": a same-provider re-save keeps
+    # the stored model/base_url/proxy instead of coercing None to "None" or
+    # resetting to derived defaults.
+    target = tmp_path / "config.toml"
+    target.write_text(
+        "[llm]\n"
+        'provider = "openrouter"\n'
+        'model = "custom/model-x"\n'
+        'api_key = "sk-old"\n'
+        'base_url = "https://gateway.example.test/v1"\n'
+        'proxy = "http://127.0.0.1:7890"\n',
+        encoding="utf-8",
+    )
+    engine = SetupEngine(path=target)
+
+    engine.apply(
+        "provider",
+        {
+            "providerId": "openrouter",
+            "model": None,
+            "apiKey": "sk-new",
+            "apiKeyEnv": None,
+            "baseUrl": None,
+            "proxy": None,
+        },
+    )
+    engine.persist()
+
+    cfg = load_config(target)
+    assert cfg.llm.model == "custom/model-x"
+    assert cfg.llm.base_url == "https://gateway.example.test/v1"
+    assert cfg.llm.proxy == "http://127.0.0.1:7890"
+    assert cfg.llm.api_key == "sk-new"
+
+
+def test_setup_engine_search_none_payload_values_keep_stored_settings(tmp_path):
+    target = tmp_path / "config.toml"
+    target.write_text(
+        'search_provider = "brave"\n'
+        'search_api_key = "sk-old"\n'
+        "search_max_results = 9\n"
+        'search_proxy = "http://127.0.0.1:7890"\n'
+        "search_use_env_proxy = true\n"
+        'search_fallback_policy = "network"\n'
+        "search_diagnostics = true\n",
+        encoding="utf-8",
+    )
+    engine = SetupEngine(path=target)
+
+    engine.apply(
+        "search",
+        {
+            "providerId": "brave",
+            "apiKey": "sk-new",
+            "maxResults": None,
+            "proxy": None,
+            "useEnvProxy": None,
+            "fallbackPolicy": None,
+            "diagnostics": None,
+        },
+    )
+    engine.persist()
+
+    cfg = load_config(target)
+    assert cfg.search_max_results == 9
+    assert cfg.search_proxy == "http://127.0.0.1:7890"
+    assert cfg.search_use_env_proxy is True
+    assert cfg.search_fallback_policy == "network"
+    assert cfg.search_diagnostics is True
+    assert cfg.search_api_key == "sk-new"
+
+
+def test_setup_engine_image_enabled_none_keeps_stored_disabled_flag(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("OPENSQUILLA_TEST_IMAGE_KEY", "sk-image-env")
+    target = tmp_path / "config.toml"
+    target.write_text(
+        "[image_generation]\n"
+        "enabled = false\n"
+        'primary = "openrouter/google/gemini-3.1-flash-image-preview"\n'
+        "\n"
+        "[image_generation.providers.openrouter]\n"
+        'api_key_env = "OPENSQUILLA_TEST_IMAGE_KEY"\n',
+        encoding="utf-8",
+    )
+    engine = SetupEngine(path=target)
+
+    engine.apply(
+        "image-generation",
+        {
+            "providerId": "openrouter",
+            "primary": "openrouter/google/gemini-3.1-flash-image-preview",
+            "apiKeyEnv": "OPENSQUILLA_TEST_IMAGE_KEY",
+            "enabled": None,
+        },
+    )
+    engine.persist()
+
+    assert load_config(target).image_generation.enabled is False
+
+
+def test_setup_engine_image_enabled_none_defaults_to_enabled_for_fresh_config(
+    tmp_path, monkeypatch
+):
+    # A config that never stored the flag keeps the legacy
+    # configure-implies-enable behavior for a first-time setup.
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-image-env")
+    target = tmp_path / "config.toml"
+    engine = SetupEngine(path=target)
+
+    engine.apply(
+        "image-generation",
+        {
+            "providerId": "openrouter",
+            "primary": "openrouter/google/gemini-3.1-flash-image-preview",
+            "enabled": None,
+        },
+    )
+    engine.persist()
+
+    assert load_config(target).image_generation.enabled is True

--- a/tests/test_onboarding/test_status.py
+++ b/tests/test_onboarding/test_status.py
@@ -1,5 +1,7 @@
 """Tests for OnboardingStatus derivation."""
 
+import pytest
+
 from opensquilla.gateway.config import GatewayConfig, LlmProviderConfig
 from opensquilla.onboarding.mutations import upsert_channel
 from opensquilla.onboarding.status import get_onboarding_status
@@ -169,6 +171,41 @@ def test_ollama_without_key_is_configured():
     assert s.section_details["channels"]["optional"] is True
 
 
+def test_no_key_provider_reports_not_required_source():
+    cfg = GatewayConfig()
+    cfg.llm = LlmProviderConfig(
+        provider="ollama",
+        model="llama3",
+        api_key="",
+        base_url="http://localhost:11434",
+    )
+
+    s = get_onboarding_status(cfg)
+
+    assert s.llm_source == "not_required"
+    assert s.section_details["llm"]["detail"] == "no key required"
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    ["byteplus_coding_plan", "volcengine_coding_plan"],
+)
+def test_runtime_unsupported_provider_is_not_reported_as_key_free(provider_id):
+    # Coding-plan stubs are registered with real env keys but have no runtime
+    # backend; the status must not collapse that into "no key required".
+    cfg = GatewayConfig()
+    cfg.llm = LlmProviderConfig(provider=provider_id, model="m", api_key="")
+
+    s = get_onboarding_status(cfg)
+
+    assert s.llm_configured is False
+    assert s.llm_source == "unsupported"
+    assert s.sections["llm"].value == "unknown"
+    detail = str(s.section_details["llm"]["detail"])
+    assert detail == "registered but not runtime-supported"
+    assert "no key required" not in detail
+
+
 def test_zero_channels_means_not_messaging_configured():
     cfg = GatewayConfig()
     s = get_onboarding_status(cfg)
@@ -290,3 +327,16 @@ def test_ensemble_section_detail_shows_disabled():
 
     assert s.sections["ensemble"].value == "optional"
     assert s.section_details["ensemble"]["detail"] == "disabled"
+
+
+def test_ensemble_credential_status_reports_unsupported_provider():
+    """The per-provider credential rows must use the same "unsupported"
+    enumerant as llm_source for a registered but runtime-unsupported
+    provider — never a satisfied-looking "not_required"."""
+    from opensquilla.onboarding.status import _llm_provider_credential_status
+
+    cfg = GatewayConfig()
+    row = _llm_provider_credential_status(cfg, "github_copilot")
+
+    assert row["source"] == "unsupported"
+    assert row["available"] is False

--- a/tests/test_onboarding/test_status_search_recovery.py
+++ b/tests/test_onboarding/test_status_search_recovery.py
@@ -1,0 +1,61 @@
+"""End-to-end check that the advertised search recovery one-liner is safe.
+
+``onboard status`` and the next-steps guidance advertise
+``opensquilla onboard configure search --search-provider duckduckgo`` as the
+headless recovery path. Re-running it on a config that already carries
+operator-tuned global search settings must keep those settings (keep-current
+semantics for every omitted flag), otherwise the recovery advice itself
+resets the operator's configuration.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from opensquilla.cli.main import app
+from opensquilla.onboarding.config_store import load_config
+from opensquilla.onboarding.next_steps import headless_setup_command
+
+runner = CliRunner()
+
+
+def test_advertised_search_recovery_one_liner_keeps_saved_settings(tmp_path):
+    target = tmp_path / "config.toml"
+
+    seeded = runner.invoke(
+        app,
+        [
+            "onboard", "configure", "search",
+            "--search-provider", "duckduckgo",
+            "--max-results", "9",
+            "--fallback-policy", "network",
+            "--diagnostics",
+            "--use-env-proxy",
+            "--proxy", "http://127.0.0.1:3128",
+            "--config", str(target),
+        ],
+    )
+    assert seeded.exit_code == 0, seeded.output
+    before = load_config(target)
+    assert before.search_max_results == 9
+    assert before.search_fallback_policy == "network"
+    assert before.search_diagnostics is True
+    assert before.search_use_env_proxy is True
+    assert before.search_proxy == "http://127.0.0.1:3128"
+
+    # Run the exact command the guidance advertises (not a re-typed copy).
+    entry = headless_setup_command("search")
+    assert entry is not None
+    _label, advertised = entry
+    tokens = advertised.split()
+    assert tokens[0] == "opensquilla"
+    result = runner.invoke(app, [*tokens[1:], "--config", str(target)])
+
+    assert result.exit_code == 0, result.output
+    after = load_config(target)
+    assert after.search_provider == "duckduckgo"
+    assert after.search_max_results == 9
+    assert after.search_fallback_policy == "network"
+    assert after.search_diagnostics is True
+    assert after.search_use_env_proxy is True
+    assert after.search_proxy == "http://127.0.0.1:3128"

--- a/tests/unit/test_env_loading.py
+++ b/tests/unit/test_env_loading.py
@@ -1,0 +1,112 @@
+"""Loading resilience for .env files.
+
+``load_env`` runs at CLI import time, so a broken ``~/.opensquilla/.env``
+(one latin-1 byte is enough) used to kill every command — including the
+onboarding wizard that could repair the file — with a raw
+``UnicodeDecodeError`` before Typer even started. These tests pin the
+recovery contract: a bad file is skipped with a single stderr warning while
+every valid file keeps loading exactly as before, and **stdout stays byte
+clean** — the warning used to also go through an unconfigured structlog
+logger whose PrintLogger writes to stdout, corrupting machine-readable
+output such as ``onboard status --json``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from opensquilla import env as env_mod
+
+
+def _isolate_global_env(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
+    home.mkdir()
+    monkeypatch.setattr(env_mod, "default_opensquilla_home", lambda: home)
+
+
+def test_load_env_survives_non_utf8_home_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home = tmp_path / "home"
+    _isolate_global_env(monkeypatch, home)
+    monkeypatch.delenv("OPENSQUILLA_ENV_TEST_BAD_KEY", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_ENV_TEST_GOOD_KEY", raising=False)
+
+    # \xe9 is latin-1 "e-acute" — a single byte that is invalid UTF-8.
+    (home / ".env").write_bytes(b"OPENSQUILLA_ENV_TEST_BAD_KEY=caf\xe9\n")
+    (tmp_path / ".env").write_text(
+        "OPENSQUILLA_ENV_TEST_GOOD_KEY=ok\n", encoding="utf-8"
+    )
+
+    injected = env_mod.load_env(tmp_path)
+
+    assert injected == 1
+    assert os.environ["OPENSQUILLA_ENV_TEST_GOOD_KEY"] == "ok"
+    assert "OPENSQUILLA_ENV_TEST_BAD_KEY" not in os.environ
+
+    captured = capsys.readouterr()
+    err = captured.err
+    assert str(home / ".env") in err
+    assert "UTF-8" in err
+    assert err.count("\n") == 1, f"expected a single concise stderr line, got: {err!r}"
+    # Machine-readable stdout must stay byte clean: the warning must never be
+    # emitted through an unconfigured structlog PrintLogger on stdout.
+    assert captured.out == "", f"env warning leaked to stdout: {captured.out!r}"
+
+    # The CLI loads env twice (import time and app callback); the warning
+    # must not repeat for the same file within one process.
+    env_mod.load_env(tmp_path)
+    repeat = capsys.readouterr()
+    assert repeat.err == ""
+    assert repeat.out == ""
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are meaningless on Windows")
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0, reason="root bypasses file modes"
+)
+def test_load_env_survives_unreadable_home_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home = tmp_path / "home"
+    _isolate_global_env(monkeypatch, home)
+    monkeypatch.delenv("OPENSQUILLA_ENV_TEST_BAD_KEY", raising=False)
+
+    env_file = home / ".env"
+    env_file.write_text("OPENSQUILLA_ENV_TEST_BAD_KEY=nope\n", encoding="utf-8")
+    os.chmod(env_file, 0)
+    try:
+        injected = env_mod.load_env(tmp_path)
+    finally:
+        os.chmod(env_file, 0o600)
+
+    assert injected == 0
+    assert "OPENSQUILLA_ENV_TEST_BAD_KEY" not in os.environ
+    captured = capsys.readouterr()
+    assert str(env_file) in captured.err
+    assert captured.out == "", f"env warning leaked to stdout: {captured.out!r}"
+
+
+def test_load_env_valid_files_still_load_the_same_values(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home = tmp_path / "home"
+    _isolate_global_env(monkeypatch, home)
+    monkeypatch.delenv("OPENSQUILLA_ENV_TEST_KEY", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_ENV_TEST_QUOTED", raising=False)
+
+    (home / ".env").write_text(
+        "# comment\n"
+        "\n"
+        "OPENSQUILLA_ENV_TEST_KEY=plain-value\n"
+        "OPENSQUILLA_ENV_TEST_QUOTED='quoted value'\n"
+        "not-an-assignment\n",
+        encoding="utf-8",
+    )
+
+    assert env_mod.load_env(tmp_path) == 2
+    assert os.environ["OPENSQUILLA_ENV_TEST_KEY"] == "plain-value"
+    assert os.environ["OPENSQUILLA_ENV_TEST_QUOTED"] == "quoted value"
+    assert capsys.readouterr().err == ""


### PR DESCRIPTION
Scope:
- Harden CLI onboarding persistence, keep-current behavior, wizard input handling, and headless command semantics.
- Add an interactive section hub for `opensquilla onboard configure` on TTYs, with live section status, immediate persistence, cancel-to-menu behavior, and sticky restart guidance.
- Add rerun choices for configured installs: update settings, change specific sections, or start fresh with timestamped config backup and explicit confirmation.
- Improve final onboarding next-step guidance and provider selection filtering.

Branch target:
- `main`

Linked issue:
- None

Release note status:
- Release note needed: CLI onboarding reruns and section-specific configuration are improved.

Test results:
- `uv run pytest tests/test_onboarding tests/test_cli/test_onboard_cmd.py tests/test_cli/test_onboard_cmd_headless_semantics.py tests/test_cli/test_onboard_status_json.py tests/test_gateway/test_rpc_onboarding.py tests/test_gateway/test_rpc_onboarding_audio_sync.py tests/test_contracts/test_onboarding_status.py -q`
- Result: 814 passed, 1 skipped, 1 warning

Safety notes:
- Start-fresh reruns back up existing config with a timestamped suffix instead of deleting it.
- Headless and scoped runs keep the previous linear behavior.
- Secrets and real user runtime data are not included.

Third-party origin details:
- None.