### PR TITLE
Fix apply_patch receipt fingerprints on committed bytes

### DIFF
--- a/src/opensquilla/tools/builtin/patch.py
+++ b/src/opensquilla/tools/builtin/patch.py
@@ -838,7 +838,7 @@ async def apply_patch(
             path=item.resolved,
             operation=item.operation,
             before=item.before,
-            after=_fingerprint_content(item.after_content),
+            after=fingerprint_path(item.resolved),
             partial=False,
             metadata={
                 "patch_path": item.path,

--- a/tests/test_tools/test_apply_patch_atomic.py
+++ b/tests/test_tools/test_apply_patch_atomic.py
@@ -179,3 +179,43 @@ async def test_apply_patch_repeated_updates_to_same_file_compose_in_memory(
     assert receipt["before"] == before
     assert receipt["after"] == after
     assert receipt["operation_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_receipt_after_fingerprints_committed_file_bytes(
+    patch_context: tuple[Path, ToolContext, list[dict[str, Any]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, ctx, _events = patch_context
+    target = workspace / "src" / "app.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("alpha\nbeta\n", encoding="utf-8")
+    apply_patch = _original_async(patch_tool.apply_patch)
+    original_apply_ops = patch_tool._apply_ops
+
+    def apply_ops_with_disk_newlines(ops: Any, root: Any = None) -> Any:
+        result = original_apply_ops(ops, root)
+        target.write_bytes(
+            target.read_text(encoding="utf-8").replace("\n", "\r\n").encode("utf-8")
+        )
+        return result
+
+    monkeypatch.setattr(patch_tool, "_apply_ops", apply_ops_with_disk_newlines)
+
+    await apply_patch(
+        patch="""*** Begin Patch
+*** Update File: src/app.py
+@@ -1,1 +1,1 @@
+-alpha
++ALPHA
+*** Update File: src/app.py
+@@ -2,1 +2,1 @@
+-beta
++BETA
+*** End Patch"""
+    )
+
+    after = fingerprint_file(target)
+    planned_after = patch_tool._fingerprint_content("ALPHA\nBETA\n")
+    assert after["size"] != planned_after["size"]
+    assert ctx.workspace_mutation_receipts[0]["after"] == after


### PR DESCRIPTION
## Summary
- record apply_patch mutation receipt after fingerprints from committed disk bytes instead of planned in-memory text
- add a regression test that simulates Windows newline expansion so receipt fingerprints match the actual file

## Verification
- uv run pytest tests/test_tools/test_apply_patch_atomic.py::test_apply_patch_receipt_after_fingerprints_committed_file_bytes -q
- uv run pytest tests/test_tools/test_apply_patch_atomic.py::test_apply_patch_repeated_updates_to_same_file_compose_in_memory -q
- uv run pytest tests/test_tools/test_apply_patch_atomic.py -q
- uv run ruff check src/opensquilla/tools/builtin/patch.py src/opensquilla/tools/mutation_receipts.py tests/test_tools/test_apply_patch_atomic.py

Fixes the Windows high-risk/full failure on main CI run 28921161261 after #508.