### PR TITLE
Extend Windows full CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
     needs: classify-changes
     if: ${{ needs.classify-changes.outputs.windows_full_required == 'true' || needs.classify-changes.outputs.full_required == 'true' }}
     runs-on: windows-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     env:
       UV_PYTHON: "3.12"


### PR DESCRIPTION
## Summary
- raise the Windows high-risk/full test job timeout from 20 to 30 minutes
- unblock main CI after the full Windows suite was cancelled at the 20-minute limit while still progressing

## Verification
- inspected main CI run 28922352814: all other jobs passed; Windows high-risk/full was cancelled at ~20 minutes around 86% progress
- local diff review: only .github/workflows/ci.yml timeout-minutes changed for windows-full