### PR TITLE
Run Windows full CI for persistence risk changes

### DIFF
--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -130,6 +130,10 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_test_changed
       mark_platform_sensitive_changed
       ;;
+    tests/test_persistence/*)
+      mark_test_changed
+      mark_platform_sensitive_changed
+      ;;
     tests/*)
       mark_test_changed
       ;;
@@ -144,11 +148,15 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_platform_sensitive_changed
       mark_desktop_changed
       ;;
-    src/opensquilla/sandbox/* | src/opensquilla/tools/boundary.py | src/opensquilla/tools/builtin/code_exec.py | src/opensquilla/tools/builtin/filesystem.py | src/opensquilla/tools/builtin/git.py | src/opensquilla/tools/builtin/shell.py | src/opensquilla/tools/builtin/shell_policy.py | src/opensquilla/tools/path_* | src/opensquilla/tools/policy* | src/opensquilla/tools/write_*)
+    src/opensquilla/persistence/* | src/opensquilla/sandbox/* | src/opensquilla/tools/boundary.py | src/opensquilla/tools/builtin/code_exec.py | src/opensquilla/tools/builtin/filesystem.py | src/opensquilla/tools/builtin/git.py | src/opensquilla/tools/builtin/shell.py | src/opensquilla/tools/builtin/shell_policy.py | src/opensquilla/tools/path_* | src/opensquilla/tools/policy* | src/opensquilla/tools/write_*)
       mark_runtime_changed
       mark_platform_sensitive_changed
       ;;
-    src/* | scripts/* | migrations/*)
+    migrations/*)
+      mark_runtime_changed
+      mark_platform_sensitive_changed
+      ;;
+    src/* | scripts/*)
       mark_runtime_changed
       ;;
     docs/* | README.md | README.*.md | CHANGELOG.md | CODE_OF_CONDUCT.md | CONTRIBUTING.md | MIGRATION.md | SECURITY.md | SUPPORT.md | THIRD_PARTY_NOTICES.md | META_SKILL_GUIDE.md | .github/pull_request_template.md | .github/ISSUE_TEMPLATE/*)

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -546,6 +546,28 @@ def test_ci_change_classifier_tracks_platform_sensitive_changes(tmp_path: Path) 
     )
 
 
+def test_ci_change_classifier_runs_windows_full_for_persistence_risk(
+    tmp_path: Path,
+) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [
+            "src/opensquilla/persistence/migrator.py",
+            "tests/test_persistence/test_migrator.py",
+            "migrations/V999__example.py",
+        ],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        runtime_changed="true",
+        test_changed="true",
+        windows_full_required="true",
+        python_changed="true",
+        platform_sensitive_changed="true",
+        build_wheel_required="true",
+    )
+
+
 def test_ci_change_classifier_tracks_desktop_changes(tmp_path: Path) -> None:
     outputs = _classify_changed_files(
         tmp_path,


### PR DESCRIPTION
## Summary
- classify persistence, migration, and persistence-test changes as platform-sensitive
- require Windows high-risk/full tests for those PRs before merge
- add a classifier regression covering the #496/#515 failure mode

## Verification
- uv run pytest tests/test_ci/test_workflows.py::test_ci_change_classifier_runs_windows_full_for_persistence_risk -q (failed before classifier update, passed after)
- uv run pytest tests/test_ci/test_workflows.py -q
- uv run ruff check tests/test_ci/test_workflows.py