### PR TITLE
Align coding-plan onboarding mutation contract

### DIFF
--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -164,10 +164,19 @@ def test_experimental_provider_configurable_with_required_fields():
     assert res.config.llm.provider == "azure"
 
 
-def test_coding_plan_provider_still_rejected():
+def test_coding_plan_provider_configurable_with_protocol_endpoint():
     cfg = GatewayConfig()
-    with pytest.raises(ValueError, match="not runtime-supported"):
-        upsert_llm_provider(cfg, provider_id="volcengine_coding_plan", model="x", api_key="k")
+    res = upsert_llm_provider(
+        cfg,
+        provider_id="volcengine_coding_plan",
+        model="x",
+        api_key="k",
+    )
+
+    assert res.config.llm.provider == "volcengine_coding_plan"
+    assert res.config.llm.model == "x"
+    assert res.config.llm.api_key == "k"
+    assert res.config.llm.base_url == "https://ark.cn-beijing.volces.com/api/coding/v3"
 
 
 def test_ollama_does_not_require_api_key():


### PR DESCRIPTION
## Summary
- update the onboarding mutation test now that Volcengine coding-plan is runtime-supported
- keep unsupported OAuth provider rejection covered by the existing github_copilot test
- assert the coding-plan configure path persists the protocol-specific base URL

## Tests
- uv run pytest tests/test_onboarding/test_mutations.py::test_unsupported_provider_rejected tests/test_onboarding/test_mutations.py::test_coding_plan_provider_configurable_with_protocol_endpoint -q
- uv run pytest tests/test_onboarding/test_mutations.py -q
- uv run --extra dev ruff check tests/test_onboarding/test_mutations.py
- uv run --extra dev pytest tests/test_onboarding -q