### PR TITLE
Run Windows full CI for provider onboarding risks

### DIFF
--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -134,6 +134,10 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_test_changed
       mark_platform_sensitive_changed
       ;;
+    tests/test_onboarding/* | tests/test_provider/* | tests/test_provider*.py)
+      mark_test_changed
+      mark_platform_sensitive_changed
+      ;;
     tests/*)
       mark_test_changed
       ;;
@@ -149,6 +153,10 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_desktop_changed
       ;;
     src/opensquilla/persistence/* | src/opensquilla/sandbox/* | src/opensquilla/tools/boundary.py | src/opensquilla/tools/builtin/code_exec.py | src/opensquilla/tools/builtin/filesystem.py | src/opensquilla/tools/builtin/git.py | src/opensquilla/tools/builtin/shell.py | src/opensquilla/tools/builtin/shell_policy.py | src/opensquilla/tools/path_* | src/opensquilla/tools/policy* | src/opensquilla/tools/write_*)
+      mark_runtime_changed
+      mark_platform_sensitive_changed
+      ;;
+    src/opensquilla/onboarding/* | src/opensquilla/provider/*)
       mark_runtime_changed
       mark_platform_sensitive_changed
       ;;

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -568,6 +568,29 @@ def test_ci_change_classifier_runs_windows_full_for_persistence_risk(
     )
 
 
+def test_ci_change_classifier_runs_windows_full_for_provider_onboarding_risk(
+    tmp_path: Path,
+) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [
+            "src/opensquilla/provider/registry.py",
+            "src/opensquilla/onboarding/provider_specs.py",
+            "tests/test_onboarding/test_mutations.py",
+            "tests/test_provider/test_spec_substrate.py",
+        ],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        runtime_changed="true",
+        test_changed="true",
+        windows_full_required="true",
+        python_changed="true",
+        platform_sensitive_changed="true",
+        build_wheel_required="true",
+    )
+
+
 def test_ci_change_classifier_tracks_desktop_changes(tmp_path: Path) -> None:
     outputs = _classify_changed_files(
         tmp_path,


### PR DESCRIPTION
## Summary
- classify provider and onboarding source changes as requiring Windows full tests
- classify provider/onboarding test changes the same way
- add a regression that models the #498 coverage gap before it reached main

## Tests
- uv run --extra dev pytest tests/test_ci/test_workflows.py::test_ci_change_classifier_runs_windows_full_for_provider_onboarding_risk -q
- uv run --extra dev pytest tests/test_ci/test_workflows.py -q
- uv run --extra dev ruff check tests/test_ci/test_workflows.py