### PR TITLE
Stabilize Windows attachment e2e task drain

### DIFF
--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -138,6 +138,10 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_test_changed
       mark_platform_sensitive_changed
       ;;
+    tests/functional/test_gateway_*_e2e.py)
+      mark_test_changed
+      mark_platform_sensitive_changed
+      ;;
     tests/*)
       mark_test_changed
       ;;

--- a/tests/functional/test_gateway_attachment_history_e2e.py
+++ b/tests/functional/test_gateway_attachment_history_e2e.py
@@ -50,6 +50,7 @@ _TEXT_MODEL = "test/text"
 _GATE_MODEL = "test/gate"
 _VISION_MODEL = "test/vision"
 _TURN_TERMINAL_EVENT_TIMEOUT_SECONDS = 30.0
+_TURN_TASK_DRAIN_TIMEOUT_SECONDS = 10.0
 
 
 class _RecordingProvider:
@@ -248,7 +249,16 @@ async def _send_session_turn(
         )
         if done_count > done_before:
             if task is not None:
-                await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(task),
+                        timeout=_TURN_TASK_DRAIN_TIMEOUT_SECONDS,
+                    )
+                except TimeoutError as exc:
+                    raise AssertionError(
+                        "timed out waiting for agent task to finish after done event; "
+                        f"events={sink.events!r}"
+                    ) from exc
             return
         new_errors = [
             payload

--- a/tests/functional/test_gateway_non_image_attachment_materialization_e2e.py
+++ b/tests/functional/test_gateway_non_image_attachment_materialization_e2e.py
@@ -45,6 +45,7 @@ _TEXT_MODEL = "test/text"
 _GATE_MODEL = "test/gate"
 _VISION_MODEL = "test/vision"
 _TURN_TERMINAL_EVENT_TIMEOUT_SECONDS = 30.0
+_TURN_TASK_DRAIN_TIMEOUT_SECONDS = 10.0
 
 _PNG_BYTES = (
     b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
@@ -291,7 +292,16 @@ async def _send_session_turn(
         )
         if done_count > done_before:
             if task is not None:
-                await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(task),
+                        timeout=_TURN_TASK_DRAIN_TIMEOUT_SECONDS,
+                    )
+                except TimeoutError as exc:
+                    raise AssertionError(
+                        "timed out waiting for agent task to finish after done event; "
+                        f"events={sink.events!r}"
+                    ) from exc
             return
         new_errors = [
             payload

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -591,6 +591,25 @@ def test_ci_change_classifier_runs_windows_full_for_provider_onboarding_risk(
     )
 
 
+def test_ci_change_classifier_runs_windows_full_for_gateway_functional_e2e(
+    tmp_path: Path,
+) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [
+            "tests/functional/test_gateway_non_image_attachment_materialization_e2e.py",
+            "tests/functional/test_gateway_attachment_history_e2e.py",
+        ],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        test_changed="true",
+        windows_full_required="true",
+        python_changed="true",
+        platform_sensitive_changed="true",
+    )
+
+
 def test_ci_change_classifier_tracks_desktop_changes(tmp_path: Path) -> None:
     outputs = _classify_changed_files(
         tmp_path,


### PR DESCRIPTION
## Summary
- allow attachment e2e helpers to wait up to a dedicated task-drain timeout after receiving session.event.done
- keep the agent task completion assertion and include captured events if the task still fails to drain
- apply the same helper fix to both attachment history and non-image materialization e2e suites

## Testing
- uv run --extra dev pytest tests/functional/test_gateway_non_image_attachment_materialization_e2e.py tests/functional/test_gateway_attachment_history_e2e.py -q
- uv run --extra dev ruff check tests/functional/test_gateway_non_image_attachment_materialization_e2e.py tests/functional/test_gateway_attachment_history_e2e.py