### PR TITLE
Stabilize main push CI classification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,13 @@ jobs:
                 "${{ github.event.pull_request.head.sha }}" > "${changed_files}"
               ;;
             push)
-              printf '.ci/run-all\n' > "${changed_files}"
+              before="${{ github.event.before }}"
+              after="${{ github.event.after }}"
+              if [[ -n "${before}" && "${before}" != "0000000000000000000000000000000000000000" ]]; then
+                git diff --name-only "${before}" "${after}" > "${changed_files}"
+              else
+                printf '.ci/run-all\n' > "${changed_files}"
+              fi
               ;;
             *)
               printf '.ci/run-all\n' > "${changed_files}"
@@ -390,7 +396,7 @@ jobs:
           markers="not llm and not live_search and not live_channel and not webui_browser and not tui_real_terminal and not local_golden and not agent_context_boundary and not llm_router_acc"
 
           if [[ "${{ needs.classify-changes.outputs.full_required }}" == "true" ]]; then
-            uv run pytest tests -q -m "${markers}" --durations=50
+            uv run pytest tests -q -m "${markers}" --durations=50 --maxfail=1
           else
             uv run pytest \
               tests/test_artifacts.py \

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -195,7 +195,9 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert "Windows high-risk/full tests" in text
     assert "Release packaging contracts" in text
     assert "CI result" in text
-    assert 'push)\n              printf \'.ci/run-all\\n\' > "${changed_files}"' in text
+    assert 'push)\n              before="${{ github.event.before }}"' in text
+    assert 'git diff --name-only "${before}" "${after}" > "${changed_files}"' in text
+    assert 'printf \'.ci/run-all\\n\' > "${changed_files}"' in text
     assert "runtime_changed" in text
     assert "test_changed" in text
     assert "ci_changed" in text
@@ -212,6 +214,19 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert "allow_success_or_skipped" in text
     assert "code_changed" not in text
     assert "workflow_changed" not in text
+
+
+def test_default_ci_keeps_main_pushes_targeted_and_manual_runs_full() -> None:
+    ci_path = WORKFLOW_DIR / "ci.yml"
+    if not ci_path.exists():
+        return
+    text = ci_path.read_text(encoding="utf-8")
+
+    assert 'before="${{ github.event.before }}"' in text
+    assert 'after="${{ github.event.after }}"' in text
+    assert 'git diff --name-only "${before}" "${after}" > "${changed_files}"' in text
+    assert 'workflow_dispatch' in text
+    assert 'printf \'.ci/run-all\\n\' > "${changed_files}"' in text
 
 
 def test_ci_verifies_committed_frontend_dist_is_fresh() -> None:
@@ -687,6 +702,7 @@ def test_windows_high_risk_job_uses_subset_until_full_ci() -> None:
         "${{ needs.classify-changes.outputs.full_required == 'true' }}"
     )
     assert 'uv run pytest tests -q -m "${markers}" --durations=50' in text
+    assert 'uv run pytest tests -q -m "${markers}" --durations=50 --maxfail=1' in text
     assert "tests/test_compat" in text
     assert "tests/test_sandbox" in text
     assert "tests/test_tools/test_shell_policy_windows.py" in text


### PR DESCRIPTION
## Summary
- classify main push CI from the actual before/after diff instead of forcing .ci/run-all on every push
- keep workflow_dispatch as the explicit full-run path
- make the Windows full pytest branch fail fast so full-run failures report an actionable test instead of timing out without a summary

## Why
Main CI after #507 timed out in Windows high-risk/full at 30m while only reaching 78% of the full pytest suite. The PR CI had passed because it used targeted risk classification; the main push path forced full_required for every merge.

## Tests
- uv run --extra dev pytest tests/test_ci/test_workflows.py -q
- uv run --extra dev ruff check tests/test_ci/test_workflows.py
- bash -n .github/scripts/classify-ci-changes.sh

Note: local actionlint could not run because this environment does not have go/actionlint installed; the workflow-lint job will validate it in CI.