### PR TITLE
Mask bare secret tokens in scrubbed diagnostic text

### DIFF
--- a/src/opensquilla/observability/redact.py
+++ b/src/opensquilla/observability/redact.py
@@ -54,6 +54,36 @@ _ASSIGNMENT_RE = re.compile(
 # payloads are masked in full (over-masking a trailing "=" is fine; leaking a
 # token suffix is not).
 _BEARER_RE = re.compile(r"(?i)(?P<prefix>bearer\s+)(?P<value>[a-z0-9._\-+/=]+)")
+# Bare provider/service tokens with globally distinctive prefixes. Provider and
+# channel errors echo credentials verbatim with no key=value structure around
+# them ("Incorrect API key sk-... provided"), and those messages flow straight
+# into turn_errors and the public diagnostics bundle. Every branch is anchored
+# to word-run boundaries and length-floored so ordinary prose ("skill",
+# "risk-free", "eyJustSaying") never matches; over-masking token-shaped strings
+# is fine, leaking a token tail is not. The literal prefixes keep scanning
+# linear on megabyte log tails (each attempt fails on the first character).
+_RUN = r"[A-Za-z0-9_-]"
+_BARE_TOKEN_RE = re.compile(
+    rf"""(?x)
+    (?<!{_RUN})
+    (?:
+        sk-{_RUN}{{16,}}                          # OpenAI-style (incl. sk-proj-, sk-ant-)
+        |xox[abposr]-[A-Za-z0-9-]{{10,}}          # Slack bot/user/app/legacy tokens
+        |gh[pousr]_[A-Za-z0-9_]{{16,}}            # GitHub classic tokens (ghp/gho/ghu/ghs/ghr)
+        |github_pat_[A-Za-z0-9_]{{16,}}           # GitHub fine-grained PATs
+        |AKIA[0-9A-Z]{{16}}                       # AWS access key id
+        |eyJ{_RUN}{{5,}}(?:\.{_RUN}{{8,}}){{2,}}  # JWT-shaped dotted base64url runs
+        |AIza[0-9A-Za-z_-]{{35}}                  # Google API keys
+    )
+    (?!{_RUN})
+    """
+)
+# Slack incoming-webhook URLs carry the credential in the path; keep the host
+# recognizable and mask only the path. The path class excludes "[" so an
+# already-masked "services/[redacted]" cannot rematch (idempotent).
+_SLACK_WEBHOOK_RE = re.compile(
+    r"(?P<prefix>\bhooks\.slack\.com/services/)[A-Za-z0-9/_-]+"
+)
 
 
 def scrub_text(text: str) -> str:
@@ -62,6 +92,8 @@ def scrub_text(text: str) -> str:
         lambda m: f"{m.group('prefix')}{m.group('quote') or ''}{_REDACTED}", text
     )
     scrubbed = _BEARER_RE.sub(lambda m: f"{m.group('prefix')}{_REDACTED}", scrubbed)
+    scrubbed = _BARE_TOKEN_RE.sub(_REDACTED, scrubbed)
+    scrubbed = _SLACK_WEBHOOK_RE.sub(lambda m: f"{m.group('prefix')}{_REDACTED}", scrubbed)
     home = str(Path.home())
     if home and home != "/":
         scrubbed = scrubbed.replace(home, "~")

--- a/tests/test_observability/test_redact.py
+++ b/tests/test_observability/test_redact.py
@@ -8,6 +8,33 @@ from opensquilla.observability.redact import scrub_text
 
 FAKE_KEY = "sk-FAKE1234567890abcdef"
 
+# Synthetic bare tokens (no key=value structure around them), as they appear
+# verbatim inside provider/channel error messages.
+FAKE_OPENAI = "sk-FAKEabc123def456ghi789"
+FAKE_OPENAI_PROJ = "sk-proj-FAKEabc123def456ghi789"
+FAKE_OPENAI_ANT = "sk-ant-api03-FAKEabc123def456ghi789"
+FAKE_SLACK_BOT = "xoxb-FAKE1234567890-abcdefghij"
+FAKE_SLACK_WEBHOOK = "https://hooks.slack.com/services/T0FAKE123/B0FAKE456/FAKEabcdefFAKE"
+# Assembled at runtime so the tracked source never contains a GitHub-token-
+# shaped literal (the public-release hygiene scan flags those shapes).
+FAKE_GITHUB_PAT = "ghp_" + "FAKEabc123def456ghi789jkl"
+FAKE_GITHUB_FINE_PAT = "github_pat_" + "FAKE1234567890abcdef_FAKEmoretail"
+FAKE_AWS_KEY_ID = "AKIAFAKE0123456789AB"
+FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJGQUtFIjoidHJ1ZSJ9.FAKEsig1234567890"
+FAKE_GOOGLE_KEY = "AIzaFAKE0123456789abcdefghijklmnopqrstu"
+
+BARE_TOKENS = [
+    FAKE_OPENAI,
+    FAKE_OPENAI_PROJ,
+    FAKE_OPENAI_ANT,
+    FAKE_SLACK_BOT,
+    FAKE_GITHUB_PAT,
+    FAKE_GITHUB_FINE_PAT,
+    FAKE_AWS_KEY_ID,
+    FAKE_JWT,
+    FAKE_GOOGLE_KEY,
+]
+
 
 def test_masks_secret_shaped_assignments() -> None:
     text = (
@@ -55,6 +82,10 @@ TRICKY_INPUTS = [
     "password:\nRestarting the gateway",
     "api_key=[redacted]",
     'secret_key=abc123 private-key: xyz789 "secret_access_key": "AKIAFAKE999"',
+    *(f"provider said: {token} was rejected" for token in BARE_TOKENS),
+    f"error posting to {FAKE_SLACK_WEBHOOK} (404)",
+    f'{{"error": {{"message": "Incorrect API key {FAKE_OPENAI} provided"}}}}',
+    "no tokens here: skill risk-free eyJustSaying task-1234 AKIAplan",
 ]
 
 
@@ -93,3 +124,62 @@ def test_session_key_stays_readable() -> None:
 def test_bare_label_does_not_mask_next_line() -> None:
     text = "password:\nRestarting the gateway"
     assert scrub_text(text) == text
+
+
+def test_masks_bare_tokens_in_prose() -> None:
+    for token in BARE_TOKENS:
+        text = f"provider error: token {token} was rejected upstream"
+        scrubbed = scrub_text(text)
+        assert token not in scrubbed, f"bare token survived: {token!r}"
+        assert "[redacted]" in scrubbed
+        assert scrubbed.startswith("provider error: token ")
+        assert scrubbed.endswith(" was rejected upstream")
+
+
+def test_masks_bare_tokens_inside_json_blob() -> None:
+    for token in BARE_TOKENS:
+        text = f'{{"error": {{"message": "Incorrect API key {token} provided", "code": 401}}}}'
+        scrubbed = scrub_text(text)
+        assert token not in scrubbed, f"bare token survived in JSON: {token!r}"
+        assert '"code": 401' in scrubbed
+        assert "Incorrect API key" in scrubbed
+
+
+def test_masks_openai_style_error_message() -> None:
+    text = f"Incorrect API key {FAKE_OPENAI} provided. You can find your key at ..."
+    scrubbed = scrub_text(text)
+    assert FAKE_OPENAI not in scrubbed
+    assert "Incorrect API key [redacted] provided" in scrubbed
+
+
+def test_masks_slack_webhook_path() -> None:
+    text = f"channel delivery failed: POST {FAKE_SLACK_WEBHOOK} returned 404"
+    scrubbed = scrub_text(text)
+    assert "T0FAKE123" not in scrubbed
+    assert "FAKEabcdefFAKE" not in scrubbed
+    assert "hooks.slack.com/services/" in scrubbed
+    assert "returned 404" in scrubbed
+
+
+def test_bare_token_prose_non_matches() -> None:
+    # Ordinary words and short identifiers that resemble token prefixes must
+    # never be masked: word-boundary anchors + length floors.
+    for text in [
+        "the skill loader retried the task",
+        "this deployment is risk-free and reversible",
+        "eyJustSaying this is fine",
+        "sk-1 sk-short sk- and ghp_ alone",
+        "xoxb- with no tail; AKIA alone; AKIAlowercase123456",
+        "AIza too short to be a key",
+        "eyJab.eyJcd.ef segments below the floor",
+        "task-1234 completed in 20ms",
+        "see https://hooks.slack.com/services for docs",
+    ]:
+        assert scrub_text(text) == text, f"ordinary prose was mangled: {text!r}"
+
+
+def test_bare_token_masking_is_idempotent() -> None:
+    for token in BARE_TOKENS:
+        text = f"log line with {token} embedded"
+        once = scrub_text(text)
+        assert scrub_text(once) == once, f"double scrub diverged for {token!r}"


### PR DESCRIPTION
## Scope

`scrub_text()` (`src/opensquilla/observability/redact.py`) masked structured secrets (`key=value`, quoted values, Authorization headers, Bearer/Basic payloads) but let bare tokens with no surrounding structure survive — the exact shape provider/channel errors echo ("Incorrect API key sk-... provided", a Slack webhook URL in a delivery error), which lands in `turn_errors.message` → `errors.jsonl` in a public diagnostics bundle. Flagged in the final review of #529.

This adds bare-token masking to `[redacted]` while preserving surrounding text:

- OpenAI-style `sk-` keys (>=16 token chars; covers `sk-proj-`, `sk-ant-`)
- Slack `xox[abposr]-` tokens (>=10 chars) and `hooks.slack.com/services/...` webhook URLs (host kept recognizable, path masked)
- GitHub `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`/`github_pat_` tokens
- AWS access key ids (`AKIA` + 16 uppercase alnum, word-bounded)
- JWT-shaped dotted base64url runs (`eyJ` + 3 length-floored segments)
- Google API keys (`AIza` + 35 token chars)

Every pattern is word-run-anchored and length-floored so ordinary prose ("skill", "risk-free", "eyJustSaying") never matches; over-masking token-shaped strings is accepted, mangling normal log text is not. Double-scrub idempotency holds for all new shapes (corpus extended). Literal prefixes keep scanning linear: 5MB synthetic log tail scrubs in ~0.42s, and the historical worst case (5MB of unbroken base64-like word runs) in ~0.38s.

## Branch target

`main`

## Linked issue

None — follow-up to the redaction gap noted in the final review of #529.

## Release note

Worth a line: diagnostics-bundle redaction hardened — bare provider/service tokens (OpenAI, Slack, GitHub, AWS, JWT, Google) in error text are now masked.

## Test results

- `uv run pytest tests/test_observability -q` — 106 passed
- `uv run ruff check src tests` — clean
- `uv run mypy src/opensquilla --show-error-codes` — clean (757 files)
- `uv run pytest -q` — 11759 passed, 112 skipped, 15 env-baseline failures only (tui_real_terminal, seatbelt, test_scripts exp_*, test_onboard_noninteractive_provider); no new failures from this change

## Safety notes

Redaction-only change; strictly widens what gets masked before text leaves the machine. No config, RPC, or protocol surface touched. Test fixtures use synthetic FAKE-prefixed tokens only (GitHub-shaped fixtures are assembled at runtime so the public-release hygiene scan stays clean).

## Third-party origin

None