### PR TITLE
Turn off CORS by default and add a same-origin guard to state-changing routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **Security:** the gateway no longer emits CORS headers by default —
+  `cors.allowed_origins` now defaults to `[]` instead of `"*"`. The Web UI
+  (served same-origin from the gateway), the CLI, curl, and the desktop app
+  are unaffected. Deployments that serve a separate frontend from another
+  origin must list that origin explicitly in `cors.allowed_origins` to
+  restore the previous behavior; configuring `"*"` together with
+  `cors.allow_credentials` now logs a boot-time warning.
+- **Security:** state-changing gateway HTTP routes (chat send, system
+  shutdown, approvals settings/resolve, elevated mode, channel logout, file
+  upload, audio transcription, artifact native open, diagnostics bundle) now
+  reject browser requests whose `Origin` is not the gateway itself with
+  `403 FORBIDDEN_ORIGIN`, extending the diagnostics-bundle same-origin guard
+  to the whole HTTP surface. Requests without an `Origin` header (curl, the
+  desktop client) and origins listed in `cors.allowed_origins` still pass.
 - `compose.yaml` now documents prebuilt-image selection, safe LAN exposure,
   and Web UI token auth, and the troubleshooting guide covers common Docker
   deployment failures.

--- a/opensquilla-webui/vite.config.ts
+++ b/opensquilla-webui/vite.config.ts
@@ -23,7 +23,17 @@ export default defineConfig({
   server: {
     proxy: {
       // REST endpoints (approvals, artifacts under /api/v1, file upload, audio, …).
-      '/api': { target: gatewayTarget, changeOrigin: true },
+      // Strip the browser's Origin header on the way through: the gateway's
+      // same-origin guard on state-changing routes would otherwise reject
+      // proxied POSTs (Origin says localhost:5173, Host says the gateway).
+      // Requests through this proxy are developer-initiated, not drive-by.
+      '/api': {
+        target: gatewayTarget,
+        changeOrigin: true,
+        configure: (proxy) => {
+          proxy.on('proxyReq', (proxyReq) => proxyReq.removeHeader('origin'))
+        },
+      },
       // RpcClient connects to ws://<host>/ws for the live chat/event stream.
       '/ws': { target: gatewayTarget, ws: true, changeOrigin: true },
       // Backend-owned static assets (brand mark, share-export images, …) that the

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -453,6 +453,15 @@ default_mode = "bypass"                 # off | on | bypass | full
 # mode = "none"         # none | token | password
 # token = ""
 
+# [cors]
+# Cross-origin browser access to the gateway HTTP API. Off by default: the
+# Web UI is served same-origin from the gateway itself and non-browser
+# clients (CLI, desktop app, curl) never need CORS. Only list origins here
+# if you host a separate frontend on another origin; avoid "*", especially
+# together with allow_credentials.
+# allowed_origins = []
+# allow_credentials = true
+
 # [channels]
 # [[channels.channels]]
 # name = "my-slack"

--- a/src/opensquilla/gateway/app.py
+++ b/src/opensquilla/gateway/app.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import functools
 import time
+from collections.abc import Awaitable, Callable
 from typing import Any
 
+import structlog
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
-from starlette.responses import JSONResponse, RedirectResponse
+from starlette.responses import JSONResponse, RedirectResponse, Response
 from starlette.routing import Route, WebSocketRoute
 from starlette.websockets import WebSocket
 
@@ -23,8 +26,15 @@ from opensquilla.gateway.middleware import (
     RateLimitMiddleware,
     SecurityHeadersMiddleware,
 )
+from opensquilla.gateway.origin_guard import (
+    extract_http_token,
+    forbidden_origin_response,
+    request_origin_allowed,
+)
 from opensquilla.gateway.rpc import RpcContext, get_dispatcher
 from opensquilla.gateway.websocket import handle_ws_connection
+
+log = structlog.get_logger(__name__)
 
 _start_time = time.time()
 
@@ -73,6 +83,25 @@ def create_gateway_app(
         if code == "UNAVAILABLE":
             return 503
         return default
+
+    def _same_origin(
+        handler: Callable[[Request], Awaitable[Response]],
+    ) -> Callable[[Request], Awaitable[Response]]:
+        """Wrap a state-changing handler with the shared same-origin guard.
+
+        Rejects browser-mediated cross-origin requests (403 FORBIDDEN_ORIGIN)
+        before the handler runs; requests without an Origin header (curl, the
+        desktop client) and same-origin Web UI requests pass through. Origins
+        explicitly listed in ``cors.allowed_origins`` are also accepted.
+        """
+
+        @functools.wraps(handler)
+        async def guarded(request: Request) -> Response:
+            if not request_origin_allowed(request, config):
+                return forbidden_origin_response()
+            return await handler(request)
+
+        return guarded
 
     # ── HTTP endpoint handlers ───────────────────────────────────────────────
 
@@ -199,22 +228,11 @@ def create_gateway_app(
         msg = result.error.message if result.error else "error"
         return JSONResponse({"error": msg}, status_code=_rpc_status_code(result))
 
-    def _extract_http_token(request: Request | None) -> str | None:
-        if request is None:
-            return None
-        auth_header = request.headers.get("authorization", "")
-        if auth_header.startswith("Bearer "):
-            return auth_header[7:]
-        token_header = request.headers.get("x-opensquilla-token")
-        if token_header:
-            return token_header
-        return request.query_params.get("token")
-
     def _make_ctx(request: Request | None = None, role_claim: str = "operator") -> RpcContext:
         from opensquilla.gateway.auth import Principal, resolve_auth
 
         auth_params: dict[str, str] = {}
-        token = _extract_http_token(request)
+        token = extract_http_token(request)
         if token:
             auth_params["token"] = token
         peer_ip = request.client.host if request is not None and request.client else None
@@ -507,19 +525,19 @@ def create_gateway_app(
         Route("/readyz", ready, methods=["GET"]),
         Route("/api/config", api_config, methods=["GET"]),
         Route("/api/sessions", api_sessions, methods=["GET"]),
-        Route("/api/chat", api_chat, methods=["POST"]),
+        Route("/api/chat", _same_origin(api_chat), methods=["POST"]),
         Route("/api/chat/history", api_chat_history, methods=["GET"]),
         Route("/api/agents", api_agents, methods=["GET"]),
         Route("/api/cron", api_cron, methods=["GET"]),
         Route("/api/system/status", api_system_status, methods=["GET"]),
-        Route("/api/system/shutdown", api_system_shutdown, methods=["POST"]),
+        Route("/api/system/shutdown", _same_origin(api_system_shutdown), methods=["POST"]),
         Route("/api/usage", api_usage, methods=["GET"]),
         Route("/api/channels/status", api_channels_status, methods=["GET"]),
-        Route("/api/channels/logout", api_channels_logout, methods=["POST"]),
+        Route("/api/channels/logout", _same_origin(api_channels_logout), methods=["POST"]),
         Route("/api/approvals", api_approvals, methods=["GET"]),
-        Route("/api/approvals/settings", api_approvals_settings, methods=["POST"]),
-        Route("/api/approvals/resolve", api_approvals_resolve, methods=["POST"]),
-        Route("/api/elevated-mode", api_elevated_mode, methods=["POST"]),
+        Route("/api/approvals/settings", _same_origin(api_approvals_settings), methods=["POST"]),
+        Route("/api/approvals/resolve", _same_origin(api_approvals_resolve), methods=["POST"]),
+        Route("/api/elevated-mode", _same_origin(api_elevated_mode), methods=["POST"]),
         WebSocketRoute("/ws", ws_endpoint),
     ]
 
@@ -532,19 +550,37 @@ def create_gateway_app(
 
     # ── Middleware ───────────────────────────────────────────────────────────
 
-    middleware = [
-        Middleware(ErrorHandlingMiddleware),
-        Middleware(
-            CORSMiddleware,
-            allow_origins=config.cors.allowed_origins,
-            allow_credentials=config.cors.allow_credentials,
-            allow_methods=config.cors.allowed_methods,
-            allow_headers=config.cors.allowed_headers,
-        ),
-        Middleware(RateLimitMiddleware, config=config),
-        Middleware(SecurityHeadersMiddleware, path_prefix=config.control_ui.base_path),
-        Middleware(AuthMiddleware, config=config),
-    ]
+    middleware = [Middleware(ErrorHandlingMiddleware)]
+    if config.cors.allowed_origins:
+        # CORS headers are opt-in: the default empty list installs no CORS
+        # middleware at all, so browsers refuse cross-origin reads. The Web UI
+        # is same-origin and non-browser clients never need CORS.
+        if "*" in config.cors.allowed_origins and config.cors.allow_credentials:
+            log.warning(
+                "gateway.cors_wildcard_with_credentials",
+                detail=(
+                    "cors.allowed_origins contains '*' with allow_credentials "
+                    "enabled, which lets any website the browser visits read "
+                    "authenticated gateway responses — list explicit origins "
+                    "instead."
+                ),
+            )
+        middleware.append(
+            Middleware(
+                CORSMiddleware,
+                allow_origins=config.cors.allowed_origins,
+                allow_credentials=config.cors.allow_credentials,
+                allow_methods=config.cors.allowed_methods,
+                allow_headers=config.cors.allowed_headers,
+            )
+        )
+    middleware.extend(
+        [
+            Middleware(RateLimitMiddleware, config=config),
+            Middleware(SecurityHeadersMiddleware, path_prefix=config.control_ui.base_path),
+            Middleware(AuthMiddleware, config=config),
+        ]
+    )
 
     app = Starlette(routes=routes, middleware=middleware, debug=config.debug)
     app.state.diagnostics_state = diagnostics_state

--- a/src/opensquilla/gateway/artifacts.py
+++ b/src/opensquilla/gateway/artifacts.py
@@ -24,6 +24,13 @@ from opensquilla.artifacts import (
     ArtifactStore,
 )
 from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.origin_guard import (
+    forbidden_origin_response,
+    request_origin_allowed,
+)
+from opensquilla.gateway.origin_guard import (
+    request_principal_is_owner as _request_principal_is_owner,
+)
 from opensquilla.paths import media_root_from_config
 
 _OPENABLE_HTML_MIMES = frozenset({"text/html", "application/xhtml+xml"})
@@ -54,28 +61,6 @@ async def _session_id_for_download(session_manager: Any, session_key: str) -> st
 
 def _media_root_from_config(config: GatewayConfig) -> Path:
     return media_root_from_config(config)
-
-
-def _extract_http_token(request: Request) -> str | None:
-    auth_header = request.headers.get("authorization", "")
-    if auth_header.startswith("Bearer "):
-        return auth_header[7:]
-    token_header = request.headers.get("x-opensquilla-token")
-    if token_header:
-        return token_header
-    return request.query_params.get("token")
-
-
-def _request_principal_is_owner(config: GatewayConfig, request: Request) -> bool:
-    from opensquilla.gateway.auth import resolve_auth
-
-    auth_params: dict[str, str] = {}
-    token = _extract_http_token(request)
-    if token:
-        auth_params["token"] = token
-    peer_ip = request.client.host if request.client is not None else None
-    principal = resolve_auth(config, auth_params, "operator", peer_ip=peer_ip)
-    return bool(principal and principal.is_owner)
 
 
 def _normalized_mime(value: str) -> str:
@@ -214,6 +199,8 @@ def register_artifact_routes(
         return FileResponse(path, media_type=ref.mime, filename=ref.name)
 
     async def open_handler(request: Request) -> JSONResponse:
+        if not request_origin_allowed(request, config):
+            return forbidden_origin_response()
         if not _request_principal_is_owner(config, request):
             return JSONResponse(
                 {"error": "Owner privileges required", "code": "OWNER_REQUIRED"},

--- a/src/opensquilla/gateway/audio_transcription.py
+++ b/src/opensquilla/gateway/audio_transcription.py
@@ -11,6 +11,7 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.origin_guard import forbidden_origin_response, request_origin_allowed
 from opensquilla.gateway.uploads import _extract_authorization_token
 from opensquilla.provider.audio import (
     ElevenLabsAudioProductionProvider,
@@ -38,6 +39,8 @@ def register_audio_transcription_routes(
     """Register POST /api/audio/transcribe for browser-recorded audio."""
 
     async def transcribe_handler(request: Request) -> JSONResponse:
+        if not request_origin_allowed(request, config):
+            return forbidden_origin_response()
         if config.auth.mode == "token":
             if config.auth.token and _extract_authorization_token(request) != config.auth.token:
                 return JSONResponse(

--- a/src/opensquilla/gateway/bundle_routes.py
+++ b/src/opensquilla/gateway/bundle_routes.py
@@ -16,7 +16,6 @@ import shutil
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
-from urllib.parse import urlsplit
 
 import structlog
 from starlette.applications import Starlette
@@ -26,71 +25,21 @@ from starlette.responses import FileResponse, JSONResponse
 from starlette.routing import Route
 
 from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.origin_guard import (
+    forbidden_origin_response,
+)
+from opensquilla.gateway.origin_guard import (
+    request_origin_allowed as _request_origin_allowed,
+)
+from opensquilla.gateway.origin_guard import (
+    request_principal_is_owner as _request_principal_is_owner,
+)
 
 log = structlog.get_logger(__name__)
 
 _DEFAULT_DAYS = 3
 _MIN_DAYS = 1
 _MAX_DAYS = 30
-
-
-def _extract_http_token(request: Request) -> str | None:
-    auth_header = request.headers.get("authorization", "")
-    if auth_header.startswith("Bearer "):
-        return auth_header[7:]
-    token_header = request.headers.get("x-opensquilla-token")
-    if token_header:
-        return token_header
-    return request.query_params.get("token")
-
-
-def _request_principal_is_owner(config: GatewayConfig, request: Request) -> bool:
-    from opensquilla.gateway.auth import resolve_auth
-
-    auth_params: dict[str, str] = {}
-    token = _extract_http_token(request)
-    if token:
-        auth_params["token"] = token
-    peer_ip = request.client.host if request.client is not None else None
-    principal = resolve_auth(config, auth_params, "operator", peer_ip=peer_ip)
-    return bool(principal and principal.is_owner)
-
-
-_DEFAULT_SCHEME_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443}
-
-
-def _effective_port(scheme: str, port: int | None) -> int | None:
-    if port is not None:
-        return port
-    return _DEFAULT_SCHEME_PORTS.get(scheme)
-
-
-def _request_origin_allowed(request: Request) -> bool:
-    """Reject browser requests whose Origin is not the gateway itself.
-
-    A hostile web page can make a loopback victim's browser POST here (the
-    permissive default CORS policy would even let it read the zip), so the
-    owner check alone is not enough. Browsers always attach ``Origin`` to
-    cross-origin fetches; the gateway-served Web UI is same-origin so its
-    ``Origin`` matches the request's own host. Requests without an ``Origin``
-    header (curl, the desktop node client) are not browser-mediated and pass.
-    """
-    origin = request.headers.get("origin")
-    if origin is None:
-        return True
-    try:
-        parsed = urlsplit(origin)
-    except ValueError:
-        return False
-    request_url = request.url
-    if not parsed.scheme or parsed.hostname is None or request_url.hostname is None:
-        return False  # includes the opaque "null" origin
-    return (
-        parsed.scheme == request_url.scheme
-        and parsed.hostname == request_url.hostname
-        and _effective_port(parsed.scheme, parsed.port)
-        == _effective_port(request_url.scheme, request_url.port)
-    )
 
 
 def _clamped_days(value: object) -> int:
@@ -105,11 +54,8 @@ def register_bundle_routes(app: Starlette, *, config: GatewayConfig) -> None:
     """Register POST /api/v1/diagnostics/bundle on the given Starlette app."""
 
     async def bundle_handler(request: Request) -> FileResponse | JSONResponse:
-        if not _request_origin_allowed(request):
-            return JSONResponse(
-                {"error": "cross-origin requests are not allowed", "code": "FORBIDDEN_ORIGIN"},
-                status_code=403,
-            )
+        if not _request_origin_allowed(request, config):
+            return forbidden_origin_response()
         if not _request_principal_is_owner(config, request):
             return JSONResponse(
                 {"error": "Owner privileges required", "code": "OWNER_REQUIRED"},

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -71,9 +71,18 @@ class AuthConfig(BaseSettings):
 
 
 class CorsConfig(BaseSettings):
+    """Cross-origin resource sharing headers for the gateway's HTTP surface.
+
+    ``allowed_origins`` defaults to empty — no CORS headers are emitted, so
+    browsers refuse cross-origin reads. The Web UI is served same-origin from
+    the gateway itself and non-browser clients (CLI, desktop app, curl) are
+    unaffected, so nothing needs CORS out of the box. Operators hosting a
+    separate frontend opt in by listing its exact origins here.
+    """
+
     model_config = SettingsConfigDict(env_prefix="OPENSQUILLA_CORS_")
 
-    allowed_origins: list[str] = Field(default_factory=lambda: ["*"])
+    allowed_origins: list[str] = Field(default_factory=list)
     allow_credentials: bool = True
     allowed_methods: list[str] = Field(default_factory=lambda: ["*"])
     allowed_headers: list[str] = Field(default_factory=lambda: ["*"])

--- a/src/opensquilla/gateway/origin_guard.py
+++ b/src/opensquilla/gateway/origin_guard.py
@@ -1,0 +1,105 @@
+"""Same-origin guard and HTTP auth helpers shared by gateway HTTP routes.
+
+A hostile web page can make a loopback victim's browser fire state-changing
+requests at the gateway (classic cross-site request forgery): simple POSTs
+execute server-side even when the browser withholds the response from the
+page. The diagnostics-bundle route shipped the first same-origin check; this
+module is the single shared implementation for every state-changing or
+sensitive owner route.
+
+Policy (matches the bundle-route precedent):
+
+* Requests without an ``Origin`` header pass — curl, the CLI, and the desktop
+  client's Node fetch are not browser-mediated and never send one.
+* Same-origin requests pass — the gateway serves the Web UI itself, so its
+  ``Origin`` always matches the request's own scheme/host/port.
+* Origins explicitly listed in ``cors.allowed_origins`` pass — an operator who
+  deliberately configured a separate frontend keeps a working deployment. The
+  ``"*"`` wildcard never bypasses the guard; it would reopen the exact
+  drive-by exposure this module exists to close.
+* Everything else — including the opaque ``"null"`` origin and unparsable
+  values — is rejected with 403 ``FORBIDDEN_ORIGIN``.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from opensquilla.gateway.config import GatewayConfig
+
+_DEFAULT_SCHEME_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443}
+
+
+def extract_http_token(request: Request | None) -> str | None:
+    """Pull the gateway token from an HTTP request (header or query string)."""
+    if request is None:
+        return None
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.startswith("Bearer "):
+        return auth_header[7:]
+    token_header = request.headers.get("x-opensquilla-token")
+    if token_header:
+        return token_header
+    return request.query_params.get("token")
+
+
+def request_principal_is_owner(config: GatewayConfig, request: Request) -> bool:
+    """Resolve the request's principal and report whether it is the owner."""
+    from opensquilla.gateway.auth import resolve_auth
+
+    auth_params: dict[str, str] = {}
+    token = extract_http_token(request)
+    if token:
+        auth_params["token"] = token
+    peer_ip = request.client.host if request.client is not None else None
+    principal = resolve_auth(config, auth_params, "operator", peer_ip=peer_ip)
+    return bool(principal and principal.is_owner)
+
+
+def _effective_port(scheme: str, port: int | None) -> int | None:
+    if port is not None:
+        return port
+    return _DEFAULT_SCHEME_PORTS.get(scheme)
+
+
+def request_origin_allowed(request: Request, config: GatewayConfig | None = None) -> bool:
+    """Reject browser requests whose Origin is not the gateway itself.
+
+    Browsers always attach ``Origin`` to cross-origin fetches and to
+    same-origin POSTs; the gateway-served Web UI is same-origin so its
+    ``Origin`` matches the request's own host. Requests without an ``Origin``
+    header (curl, the desktop node client) are not browser-mediated and pass.
+    Origins the operator explicitly listed in ``cors.allowed_origins`` pass
+    too, except the ``"*"`` wildcard, which never bypasses the guard.
+    """
+    origin = request.headers.get("origin")
+    if origin is None:
+        return True
+    if config is not None and any(
+        allowed == origin for allowed in config.cors.allowed_origins if allowed != "*"
+    ):
+        return True
+    try:
+        parsed = urlsplit(origin)
+    except ValueError:
+        return False
+    request_url = request.url
+    if not parsed.scheme or parsed.hostname is None or request_url.hostname is None:
+        return False  # includes the opaque "null" origin
+    return (
+        parsed.scheme == request_url.scheme
+        and parsed.hostname == request_url.hostname
+        and _effective_port(parsed.scheme, parsed.port)
+        == _effective_port(request_url.scheme, request_url.port)
+    )
+
+
+def forbidden_origin_response() -> JSONResponse:
+    """The uniform 403 payload for a rejected cross-origin request."""
+    return JSONResponse(
+        {"error": "cross-origin requests are not allowed", "code": "FORBIDDEN_ORIGIN"},
+        status_code=403,
+    )

--- a/src/opensquilla/gateway/uploads.py
+++ b/src/opensquilla/gateway/uploads.py
@@ -39,6 +39,7 @@ from opensquilla.contracts.attachments import (
     normalize_attachment_mime,
 )
 from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.origin_guard import forbidden_origin_response, request_origin_allowed
 
 log = logging.getLogger(__name__)
 
@@ -310,6 +311,8 @@ def register_upload_routes(
     """Register POST /api/v1/files/upload on the given Starlette app."""
 
     async def upload_handler(request: Request) -> JSONResponse:
+        if not request_origin_allowed(request, config):
+            return forbidden_origin_response()
         if config.auth.mode == "token":
             if config.auth.token and _extract_authorization_token(request) != config.auth.token:
                 return JSONResponse(

--- a/tests/test_gateway/test_origin_guard.py
+++ b/tests/test_gateway/test_origin_guard.py
@@ -1,0 +1,225 @@
+"""Same-origin guard on state-changing routes + CORS-off-by-default posture.
+
+A hostile page can make a loopback victim's browser fire simple POSTs at the
+gateway; those execute server-side even when the browser withholds the
+response. Every state-changing HTTP route must therefore reject requests
+whose ``Origin`` differs from the gateway itself (403 FORBIDDEN_ORIGIN),
+while same-origin Web UI requests and Origin-less non-browser clients (curl,
+the desktop app's Node fetch) keep working. CORS response headers are off by
+default and only appear for origins the operator explicitly configured.
+
+TestClient's default synthetic peer is not loopback, so owner-gated routes
+are exercised from an explicit loopback peer, mirroring
+tests/test_gateway/test_shutdown_endpoint.py. An autouse fixture pins config
+resolution to a synthetic TOML so no test reads the developer's real config.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import structlog.testing
+from starlette.testclient import TestClient
+
+from opensquilla.gateway.app import create_gateway_app
+from opensquilla.gateway.config import GatewayConfig
+
+# A loopback peer on a loopback-bound, no-auth gateway is the proven owner
+# (see gateway.auth.OpenScopeResolver).
+_OWNER_PEER = ("127.0.0.1", 51000)
+
+_FOREIGN_ORIGIN = "https://evil.example"
+# TestClient requests carry base URL http://testserver, so this is same-origin.
+_SAME_ORIGIN = "http://testserver"
+
+# Every state-changing HTTP route behind the shared guard. Bodies are the
+# minimal synthetic payloads that get each handler past input validation far
+# enough to prove the request was NOT rejected for its Origin. The expected
+# same-origin statuses come from running against a bare app (no session
+# manager, no channels, audio disabled) — none of them is 403.
+_PROTECTED_ENDPOINTS = [
+    pytest.param("/api/chat", {"sessionKey": "s", "message": "hi"}, id="chat"),
+    pytest.param("/api/system/shutdown", None, id="shutdown"),
+    pytest.param("/api/channels/logout", {"channel": "nope"}, id="channels-logout"),
+    pytest.param("/api/approvals/settings", {"mode": "prompt"}, id="approvals-settings"),
+    pytest.param(
+        "/api/approvals/resolve", {"id": "missing", "approved": False}, id="approvals-resolve"
+    ),
+    pytest.param(
+        "/api/elevated-mode", {"sessionKey": "agent:main:test", "mode": "off"}, id="elevated-mode"
+    ),
+    pytest.param("/api/v1/files/upload", None, id="upload"),
+    pytest.param("/api/audio/transcribe", None, id="audio-transcribe"),
+    pytest.param("/api/v1/artifacts/a-missing/open", {}, id="artifact-open"),
+    pytest.param("/api/v1/diagnostics/bundle", {}, id="diagnostics-bundle"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_path = tmp_path / "synthetic-config.toml"
+    config_path.write_text("# synthetic origin-guard-test config\n", encoding="utf-8")
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(config_path))
+    home = tmp_path / "state"
+    (home / "logs").mkdir(parents=True)
+    (home / "logs" / "debug.log").write_text("2026-07-08 [INFO] opensquilla: ok\n")
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    monkeypatch.setenv("OPENSQUILLA_LOG_DIR", str(home / "logs"))
+
+
+def _client(config: GatewayConfig | None = None) -> TestClient:
+    return TestClient(create_gateway_app(config or GatewayConfig()), client=_OWNER_PEER)
+
+
+def _post(client: TestClient, path: str, body: dict | None, origin: str | None):
+    headers = {"Origin": origin} if origin is not None else {}
+    if body is None:
+        return client.post(path, headers=headers)
+    return client.post(path, json=body, headers=headers)
+
+
+# ── Per-endpoint guard behavior ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(("path", "body"), _PROTECTED_ENDPOINTS)
+def test_foreign_origin_is_rejected(path: str, body: dict | None) -> None:
+    with _client() as client:
+        response = _post(client, path, body, _FOREIGN_ORIGIN)
+
+    assert response.status_code == 403, response.text
+    assert response.json()["code"] == "FORBIDDEN_ORIGIN"
+
+
+@pytest.mark.parametrize(("path", "body"), _PROTECTED_ENDPOINTS)
+def test_same_origin_passes_the_guard(path: str, body: dict | None) -> None:
+    # The gateway-served Web UI always sends its own origin; it must never
+    # trip the guard. Handlers may still fail later for unrelated reasons
+    # (missing session manager, audio disabled, unknown ids) but never with
+    # the guard's marker.
+    with _client() as client:
+        response = _post(client, path, body, _SAME_ORIGIN)
+
+    payload = response.json() if response.headers.get("content-type", "").startswith(
+        "application/json"
+    ) else {}
+    assert payload.get("code") != "FORBIDDEN_ORIGIN", response.text
+
+
+@pytest.mark.parametrize(("path", "body"), _PROTECTED_ENDPOINTS)
+def test_absent_origin_passes_the_guard(path: str, body: dict | None) -> None:
+    # curl and the desktop client's Node fetch send no Origin header; they are
+    # not browser-mediated and must keep working.
+    with _client() as client:
+        response = _post(client, path, body, None)
+
+    payload = response.json() if response.headers.get("content-type", "").startswith(
+        "application/json"
+    ) else {}
+    assert payload.get("code") != "FORBIDDEN_ORIGIN", response.text
+
+
+def test_foreign_origin_never_reaches_the_shutdown_trigger() -> None:
+    # End-to-end CSRF proof on the most destructive route: the drain trigger
+    # must not fire for a cross-origin request, and must fire for the
+    # same-origin Web UI and for an Origin-less client.
+    calls: list[str] = []
+    app = create_gateway_app(GatewayConfig())
+    app.state.request_shutdown = calls.append
+
+    with TestClient(app, client=_OWNER_PEER) as client:
+        forbidden = client.post("/api/system/shutdown", headers={"Origin": _FOREIGN_ORIGIN})
+        assert forbidden.status_code == 403
+        assert calls == []
+
+        same = client.post("/api/system/shutdown", headers={"Origin": _SAME_ORIGIN})
+        assert same.status_code == 202
+        no_origin = client.post("/api/system/shutdown")
+        assert no_origin.status_code == 202
+    assert calls == ["api_shutdown", "api_shutdown"]
+
+
+def test_configured_extra_origin_passes_the_guard() -> None:
+    # An operator hosting a separate frontend lists its origin explicitly;
+    # the guard honors that deliberate choice.
+    config = GatewayConfig()
+    config.cors.allowed_origins = ["https://frontend.example"]
+    with _client(config) as client:
+        response = client.post(
+            "/api/approvals/settings",
+            json={"mode": "prompt"},
+            headers={"Origin": "https://frontend.example"},
+        )
+
+    assert response.status_code == 200, response.text
+
+
+def test_wildcard_origin_does_not_bypass_the_guard() -> None:
+    # "*" widens CORS response headers only; it must never turn off the
+    # same-origin check, or the drive-by exposure returns.
+    config = GatewayConfig()
+    config.cors.allowed_origins = ["*"]
+    with _client(config) as client:
+        response = client.post(
+            "/api/approvals/settings",
+            json={"mode": "prompt"},
+            headers={"Origin": _FOREIGN_ORIGIN},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["code"] == "FORBIDDEN_ORIGIN"
+
+
+# ── CORS headers off by default, opt-in per origin ──────────────────────────
+
+
+def test_default_config_emits_no_cors_headers() -> None:
+    with _client() as client:
+        response = client.get("/api/config", headers={"Origin": _FOREIGN_ORIGIN})
+
+    assert response.status_code == 200
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_explicitly_configured_origin_still_gets_cors_headers() -> None:
+    # Upgrade compatibility: users who pinned origins in their TOML keep a
+    # working cross-origin deployment.
+    config = GatewayConfig()
+    config.cors.allowed_origins = ["https://frontend.example"]
+    with _client(config) as client:
+        allowed = client.get("/api/config", headers={"Origin": "https://frontend.example"})
+        foreign = client.get("/api/config", headers={"Origin": _FOREIGN_ORIGIN})
+
+    assert allowed.headers.get("access-control-allow-origin") == "https://frontend.example"
+    assert "access-control-allow-origin" not in foreign.headers
+
+
+# ── Boot-time wildcard warning ───────────────────────────────────────────────
+
+
+def test_wildcard_with_credentials_warns_once_at_boot() -> None:
+    config = GatewayConfig()
+    config.cors.allowed_origins = ["*"]
+    config.cors.allow_credentials = True
+
+    with structlog.testing.capture_logs() as captured:
+        create_gateway_app(config)
+
+    events = [e for e in captured if e["event"] == "gateway.cors_wildcard_with_credentials"]
+    assert len(events) == 1
+    assert events[0]["log_level"] == "warning"
+
+
+def test_no_wildcard_warning_for_default_or_explicit_origins() -> None:
+    explicit = GatewayConfig()
+    explicit.cors.allowed_origins = ["https://frontend.example"]
+    wildcard_without_credentials = GatewayConfig()
+    wildcard_without_credentials.cors.allowed_origins = ["*"]
+    wildcard_without_credentials.cors.allow_credentials = False
+
+    with structlog.testing.capture_logs() as captured:
+        create_gateway_app(GatewayConfig())
+        create_gateway_app(explicit)
+        create_gateway_app(wildcard_without_credentials)
+
+    assert not [e for e in captured if e["event"] == "gateway.cors_wildcard_with_credentials"]


### PR DESCRIPTION
## Scope

Defensive hardening of the gateway's browser-facing HTTP surface, extending the same-origin posture the diagnostics-bundle endpoint (#529) established to the whole API:

- `cors.allowed_origins` now defaults to `[]` — the CORS middleware is not installed and no `Access-Control-Allow-Origin` headers are emitted by default. The Web UI is served same-origin from the gateway (`/control/`) and non-browser clients (CLI, desktop app, curl) never needed CORS, so out-of-the-box deployments lose nothing.
- Every state-changing or sensitive owner HTTP route now rejects browser requests whose `Origin` differs from the gateway itself with `403 FORBIDDEN_ORIGIN`: `POST /api/chat`, `/api/system/shutdown`, `/api/approvals/settings`, `/api/approvals/resolve`, `/api/elevated-mode`, `/api/channels/logout`, `/api/v1/files/upload`, `/api/audio/transcribe`, `/api/v1/artifacts/{id}/open`, and `/api/v1/diagnostics/bundle`. Requests without an `Origin` header (curl, the desktop client's Node fetch) pass, same-origin Web UI requests pass, and origins explicitly listed in `cors.allowed_origins` pass (the `"*"` wildcard never bypasses the guard).
- The three duplicated copies of the HTTP token/owner helpers plus the bundle route's origin check are consolidated into a new `gateway/origin_guard.py`; `app.py`, `bundle_routes.py`, and `artifacts.py` now share one implementation.
- A wildcard origin configured together with `cors.allow_credentials` logs a one-line boot warning explaining the exposure.
- The Vite dev proxy strips the browser's `Origin` header so `npm run dev` keeps working against the guarded routes (dev-server-only change; the built bundle is same-origin and unaffected — no dist rebuild needed).
- `opensquilla.toml.example` documents the new `[cors]` posture and CHANGELOG carries both security notes.

## Branch target

`main`

## Linked issue

None

## Release-note status

REQUIRED — default behavior change. Deployments that rely on the old wildcard CORS default to serve a custom frontend from a different origin will see cross-origin reads blocked after upgrading; setting `cors.allowed_origins` to the frontend's exact origins in `opensquilla.toml` (or `OPENSQUILLA_CORS_ALLOWED_ORIGINS`) restores prior behavior. The stock Web UI, CLI, desktop app, and curl workflows are unaffected. CHANGELOG entries are included under Unreleased/Changed.

## Test results

- `uv run ruff check src tests` — clean
- `uv run mypy src/opensquilla --show-error-codes` — Success: no issues found in 758 source files
- `uv run pytest tests/test_gateway tests/test_contracts -q` — 1955 passed
- `uv run pytest -q` — 11791 passed, 112 skipped, 14 failed; all 14 are the known environment-baseline failures (tui_real_terminal integration, seatbelt real-sandbox, test_scripts exp_* ledger/quarantine, test_onboard_noninteractive_provider), unrelated to this change
- `npx vue-tsc --noEmit` (opensquilla-webui) — clean
- `uv build --wheel` — ok
- New `tests/test_gateway/test_origin_guard.py` (39 tests): per-endpoint foreign-Origin 403 / same-origin pass / absent-Origin pass, shutdown-trigger CSRF end-to-end proof, no ACAO header on default config, explicit-origin config still emits CORS headers, wildcard does not bypass the guard, and the boot warning fires exactly once (and not for explicit origins or wildcard without credentials)

## Safety notes

Defensive hardening only; follows the bundle-endpoint precedent from #529. The guard runs before owner/auth checks so a hostile page can never reach handler side effects via a victim's browser. Query-string token auth behavior is unchanged. Tests are offline and use synthetic data only.

## Third-party origin

None