### PR TITLE
Resolve Dream provider credentials explicit-config-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Dream (memory consolidation) now resolves its provider credentials through
+  the shared explicit-config-first resolver: previously `OPENROUTER_API_KEY` /
+  `OPENROUTER_BASE_URL` in the gateway environment unconditionally overrode
+  the configured key and endpoint — even when the configured provider was not
+  OpenRouter — silently redirecting Dream turns away from the operator's
+  endpoint.
 - Fixed managed-network sandbox domain grants missing the Bocha, Tavily, and
   Exa search API hosts: `web_search` runs with those providers active were
   blocked under the managed-network sandbox. All runtime search providers now

--- a/src/opensquilla/memory/dream_factory.py
+++ b/src/opensquilla/memory/dream_factory.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -46,17 +45,26 @@ def build_dream_provider_selector(config: Any) -> Any | None:
     if llm_cfg is None:
         return None
 
-    api_key = os.environ.get("OPENROUTER_API_KEY", "") or getattr(llm_cfg, "api_key", "")
+    from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
+    from opensquilla.provider.selector import ModelSelector, ProviderConfig, SelectorConfig
+
+    # Resolve credentials through the shared explicit-config-first resolver
+    # (config > derived provider env > spec default) instead of a local
+    # openrouter-env-first chain, so a shell holding OPENROUTER_* variables
+    # cannot hijack a non-openrouter Dream provider or an operator-chosen
+    # endpoint. Resolved on a throwaway deep copy: the resolver materializes
+    # values into the model in place, and Dream must not mutate the live
+    # gateway config.
+    runtime = resolve_llm_runtime_config(config.model_copy(deep=True))
+    api_key = runtime.api_key
     if not api_key:
         return None
 
-    from opensquilla.provider.selector import ModelSelector, ProviderConfig, SelectorConfig
-
     provider, model = _dream_provider_target(config)
-    base_url = os.environ.get("OPENROUTER_BASE_URL", "") or getattr(llm_cfg, "base_url", "")
+    base_url = runtime.base_url
     if base_url.endswith("/v1"):
         base_url = base_url[:-3]
-    proxy = os.environ.get("OPENSQUILLA_LLM_PROXY", "") or getattr(llm_cfg, "proxy", "")
+    proxy = runtime.proxy
 
     return ModelSelector(
         SelectorConfig(

--- a/tests/test_memory_dream_factory.py
+++ b/tests/test_memory_dream_factory.py
@@ -68,3 +68,47 @@ def test_dream_provider_uses_legacy_router_default_alias_when_router_active() ->
 def test_dream_rejects_dream_specific_model_override() -> None:
     with pytest.raises(ValidationError):
         GatewayConfig(memory={"dream": {"model_override": "dream/custom-model"}})
+
+
+def test_dream_provider_prefers_configured_credentials_over_openrouter_env(
+    monkeypatch,
+) -> None:
+    """Configured key/endpoint must not be hijacked by openrouter env vars.
+
+    Dream previously read OPENROUTER_API_KEY / OPENROUTER_BASE_URL before the
+    config unconditionally — even when the configured provider was not
+    openrouter — so a shell with openrouter credentials silently redirected
+    Dream turns away from the operator's endpoint.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-env-key")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://openrouter-env.example/api/v1")
+    config = GatewayConfig(
+        llm={
+            "provider": "openai",
+            "model": "gpt-5.5",
+            "api_key": "sk-configured",
+            "base_url": "https://user-endpoint.example/v1",
+        },
+        squilla_router={"enabled": False},
+    )
+
+    selector = build_dream_provider_selector(config)
+
+    primary = _primary_config(selector)
+    assert primary.provider == "openai"
+    assert primary.api_key == "sk-configured"
+    assert primary.base_url == "https://user-endpoint.example"
+
+
+def test_dream_provider_falls_back_to_env_when_config_has_no_key(monkeypatch) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-env-key")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    config = GatewayConfig(
+        llm={"provider": "openrouter", "model": "user/custom-model", "api_key": ""},
+        squilla_router={"enabled": False},
+    )
+
+    selector = build_dream_provider_selector(config)
+
+    primary = _primary_config(selector)
+    assert primary.api_key == "or-env-key"


### PR DESCRIPTION
## Scope

Follow-up to #535, fixing the same defect class in the Dream (memory consolidation) provider path. `build_dream_provider_selector` read `OPENROUTER_API_KEY` / `OPENROUTER_BASE_URL` before the configured values **unconditionally** — even when the configured provider was not OpenRouter — so a shell holding OpenRouter credentials silently redirected Dream turns to the wrong key and endpoint (e.g. an `openai` provider with a custom base_url got the OpenRouter env key and URL instead).

The builder now delegates to `resolve_llm_runtime_config` — the shared resolver that #535 made explicit-config-first (config > derived provider env > spec default) — on a throwaway deep copy, since the resolver materializes values into the model in place and Dream must not mutate the live gateway config. This also means Dream now honors the *configured provider's own* derived env var (`OPENAI_BASE_URL` for openai, etc.) rather than hardcoding the OpenRouter pair, and picks up `api_key_env` references, both for free from the shared resolver.

Also audited `tools/builtin/media.py` for the same class: its configured-provider path (`_configured_provider_config`) is already config-first (env only fills empty values, verified empirically), and `_resolve_provider_config` is a deliberate env-only fallback for explicit `OPENSQUILLA_<SCOPE>_*` overrides — no change needed there.

## Branch target

`main`.

## Linked issue

Refs #484 (same defect class; the main LLM path was fixed in PR #535, already merged; no dedicated issue was filed for the Dream path).

## Release notes

Included in `CHANGELOG.md` under Unreleased → Fixed.

## Tests

- New: `test_dream_provider_prefers_configured_credentials_over_openrouter_env` (openrouter env vars set + non-openrouter configured provider → configured key/endpoint win) and `test_dream_provider_falls_back_to_env_when_config_has_no_key` (env fallback preserved when config has no key).
- Existing dream suites (`test_memory_dream_*`, `test_scheduler/test_dream_handler.py`) and the #535 precedence suites all pass; `tests/test_gateway` + `tests/test_onboarding` + image-generation media tests: 2603 passed. `ruff` / `mypy` clean, wheel builds.

## Safety notes

Credential-flow change is strictly toward operator intent: configured credentials can no longer be hijacked by unrelated env vars. No new network or persistence behavior; the resolver runs on a deep copy so no live-config mutation is introduced.

## Third-party origin

None. All code is original to this repository.
