### PR TITLE
Harden issue-link sync against PR-numbered refs and label API failures

### DIFF
--- a/.github/scripts/issue_link_sync.py
+++ b/.github/scripts/issue_link_sync.py
@@ -48,6 +48,12 @@ CLOSING_KEYWORDS = frozenset(
         "resolved",
     }
 )
+#: Mutation statuses that describe the target's state or the token's scope on
+#: that one target (labeling a pull request needs pull-requests write scope
+#: this workflow does not request; locked or deleted issues answer 403/410)
+#: rather than a broken sync setup — the affected action is logged and
+#: skipped instead of failing every remaining action in the job.
+TOLERATED_MUTATION_STATUSES = frozenset({403, 404, 410})
 REFERENCE_KEYWORDS = frozenset({"ref", "refs", "reference", "references"})
 OPEN_PR_ACTIONS = frozenset({"opened", "reopened", "edited"})
 KEYWORD_RE = re.compile(
@@ -129,6 +135,19 @@ class GitHubClient:
             return None
         return json.loads(raw.decode("utf-8"))
 
+    def get_issue(self, issue_number: int) -> dict[str, Any] | None:
+        """Fetch an issue, or None when it is missing or unreadable.
+
+        Pull requests are returned too (the REST issues endpoint covers
+        both) — callers use the ``pull_request`` key to tell them apart.
+        """
+        found = self.request_json(
+            "GET",
+            f"/issues/{issue_number}",
+            ignore_statuses=TOLERATED_MUTATION_STATUSES,
+        )
+        return found if isinstance(found, dict) else None
+
     def ensure_label(self, name: str) -> None:
         definition = LABEL_DEFINITIONS[name]
         label_name = quote(name, safe="")
@@ -147,6 +166,8 @@ class GitHubClient:
                 "color": definition["color"],
                 "description": definition["description"],
             },
+            # 422: another run created the label between the GET and here.
+            ignore_statuses=TOLERATED_MUTATION_STATUSES | {422},
         )
 
     def add_labels(self, issue_number: int, labels: list[str]) -> None:
@@ -156,6 +177,7 @@ class GitHubClient:
             "POST",
             f"/issues/{issue_number}/labels",
             payload={"labels": labels},
+            ignore_statuses=TOLERATED_MUTATION_STATUSES,
         )
 
     def remove_label(self, issue_number: int, label: str) -> None:
@@ -163,7 +185,7 @@ class GitHubClient:
         self.request_json(
             "DELETE",
             f"/issues/{issue_number}/labels/{label_name}",
-            ignore_statuses={404},
+            ignore_statuses=TOLERATED_MUTATION_STATUSES,
         )
 
     def list_comments(self, issue_number: int) -> list[dict[str, Any]]:
@@ -186,6 +208,9 @@ class GitHubClient:
             "POST",
             f"/issues/{issue_number}/comments",
             payload={"body": body},
+            # Locked conversations reject comments with 403; the labels above
+            # still applied, so the sync outcome is preserved.
+            ignore_statuses=TOLERATED_MUTATION_STATUSES,
         )
 
 
@@ -346,6 +371,24 @@ def apply_action(client: GitHubClient, action: IssueSyncAction) -> None:
     raise ValueError(f"Unsupported issue sync action: {action.kind}")
 
 
+def classify_sync_target(client: GitHubClient, issue_number: int) -> str:
+    """Classify a parsed ``#N`` reference before mutating it.
+
+    ``#N`` is textual and shares one number space between issues and pull
+    requests, so a PR body saying "the main path was fixed in #535" parses as
+    an issue link even though 535 is a pull request. Labeling a PR needs a
+    scope this workflow does not hold (and is not the sync's job), so only
+    ``"issue"`` targets are acted on; ``"pull_request"`` and ``"missing"``
+    are skipped by the caller.
+    """
+    found = client.get_issue(issue_number)
+    if found is None:
+        return "missing"
+    if found.get("pull_request"):
+        return "pull_request"
+    return "issue"
+
+
 def _load_event(path: str) -> dict[str, Any]:
     with open(path, encoding="utf-8") as handle:
         return json.load(handle)
@@ -374,6 +417,13 @@ def main() -> int:
 
     client = GitHubClient(token=token, repository=repository)
     for action in actions:
+        target_kind = classify_sync_target(client, action.issue_number)
+        if target_kind != "issue":
+            print(
+                f"Skipping {action.kind} for #{action.issue_number} "
+                f"from PR #{action.pr_number}: target is {target_kind}."
+            )
+            continue
         print(
             f"Applying {action.kind} for issue #{action.issue_number} "
             f"from PR #{action.pr_number}."

--- a/tests/test_github_issue_link_sync.py
+++ b/tests/test_github_issue_link_sync.py
@@ -335,6 +335,85 @@ def test_apply_closed_unmerged_action_only_removes_open_pr_label() -> None:
     assert client.calls == [("remove_label", 200, "has-linked-pr")]
 
 
+class ClassifyingClient:
+    """get_issue stub: maps issue number -> API response (or None)."""
+
+    def __init__(self, targets: dict[int, dict[str, Any] | None]) -> None:
+        self.targets = targets
+        self.lookups: list[int] = []
+
+    def get_issue(self, issue_number: int) -> dict[str, Any] | None:
+        self.lookups.append(issue_number)
+        return self.targets.get(issue_number)
+
+
+def test_classify_sync_target_distinguishes_issue_pr_and_missing() -> None:
+    sync = _load_sync_module()
+    client = ClassifyingClient(
+        {
+            100: {"number": 100},
+            535: {"number": 535, "pull_request": {"url": "https://example.invalid/pulls/535"}},
+        }
+    )
+
+    assert sync.classify_sync_target(client, 100) == "issue"
+    assert sync.classify_sync_target(client, 535) == "pull_request"
+    assert sync.classify_sync_target(client, 999) == "missing"
+
+
+class StatusRaisingClient:
+    """request_json stub that answers every mutation with a fixed HTTP status."""
+
+    def __init__(self, status: int) -> None:
+        self.status = status
+        self.calls: list[tuple[str, str]] = []
+
+    def request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        payload: dict[str, Any] | None = None,
+        ignore_statuses: set[int] | None = None,
+    ) -> Any:
+        self.calls.append((method, path))
+        if self.status in (ignore_statuses or set()):
+            return None
+        raise RuntimeError(f"GitHub API {method} {path} failed: {self.status}")
+
+    def ensure_label(self, name: str) -> None:
+        self.calls.append(("ENSURE", name))
+
+
+def test_label_and_comment_mutations_tolerate_403_and_410() -> None:
+    """A PR-numbered target or a locked/deleted issue must not fail the job."""
+    sync = _load_sync_module()
+
+    for status in (403, 404, 410):
+        client = StatusRaisingClient(status)
+        sync.GitHubClient.add_labels(client, 535, ["has-linked-pr"])
+        sync.GitHubClient.remove_label(client, 535, "has-linked-pr")
+        sync.GitHubClient.create_comment(client, 535, "body")
+        assert ("POST", "/issues/535/labels") in client.calls
+        assert ("POST", "/issues/535/comments") in client.calls
+
+
+def test_ensure_label_tolerates_create_race() -> None:
+    """A 422 from a concurrent run creating the same label is not an error."""
+    sync = _load_sync_module()
+
+    class LabelRaceClient(StatusRaisingClient):
+        def request_json(self, method: str, path: str, **kwargs: Any) -> Any:
+            if method == "GET":
+                self.calls.append((method, path))
+                return None  # label not found -> triggers POST /labels
+            return super().request_json(method, path, **kwargs)
+
+    client = LabelRaceClient(422)
+    sync.GitHubClient.ensure_label(client, "has-linked-pr")
+    assert ("POST", "/labels") in client.calls
+
+
 def test_list_comments_reads_all_pages_before_idempotency_check() -> None:
     sync = _load_sync_module()
     client = PaginatedGitHubClient(


### PR DESCRIPTION
## Scope

Hardens `.github/scripts/issue_link_sync.py` against two failure modes observed on PR #536's "Sync linked issue state" job:

1. **PR-numbered references parsed as issue links.** Issues and pull requests share one number space, and the keyword regex matches phrases like "the main path was fixed in #535" as a closing reference — but 535 is a pull request. Labeling a PR requires pull-requests write scope this workflow does not request, so the job died with `POST /issues/535/labels → 403`. Each planned action now classifies its target first (`GET /issues/N`, checking the `pull_request` key) and skips pull requests and missing targets with a log line.
2. **One bad target failed the entire job.** Label and comment mutations now tolerate 403/404/410 (token scope limits, locked conversations, deleted targets) instead of aborting every remaining action; label creation additionally tolerates the 422 race when a concurrent run creates the same label between the existence check and the POST.

The script stays safe for `pull_request_target`: it still treats PR text as data only, and the new lookup is a read-only GET with the same token.

## Branch target

`main`.

## Linked issue

None (workflow automation fix; failure observed on the "Sync linked issue state" run for PR #536).

## Release notes

Not needed — repository automation only, no user-facing behavior.

## Tests

New cases in `tests/test_github_issue_link_sync.py`: target classification (issue vs pull request vs missing), 403/404/410 tolerance on label add/remove and comment creation, and the 422 label-create race. Full file: 15 passed; `tests/test_ci/test_workflows.py`: 41 passed; `ruff` clean.

## Safety notes

Failure handling is loosened only for statuses that describe the target's state or the token's scope on that one target; genuine API errors (401, 5xx, rate limiting) still fail the job loudly. No new write scopes requested.

## Third-party origin

None. All code is original to this repository.