### PR TITLE
Bound staged-upload memory and workspace attachment disk usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Attachment resource ceilings: the in-memory staged-upload store now has an
+  aggregate RAM cap (`attachments.upload_store_max_total_bytes`, default
+  300 MiB) — when reached, new uploads are rejected with the additive HTTP
+  507 `UPLOAD_STORE_FULL` (retryable; staged entries expire within the TTL)
+  instead of evicting staged uploads — and attachment copies materialized
+  into agent workspaces are bounded by a disk budget
+  (`attachments.workspace_attachment_disk_budget_bytes`, default 1 GiB) that
+  degrades new materializations to an unavailable marker without evicting
+  existing files.
+
 - Added Tencent TokenHub providers for the Hunyuan hy3 family:
   `tencent_tokenhub` (OpenAI-compatible mainland endpoint,
   `TENCENT_TOKENHUB_API_KEY`), `tencent_tokenhub_anthropic` (the same

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -234,11 +234,14 @@ accept_opaque = true
 opaque_max_bytes = 31457280            # 30 MiB
 # Aggregate RAM ceiling for the in-memory staged-upload store. When reached,
 # new uploads get HTTP 507 UPLOAD_STORE_FULL (retryable; staged entries
-# expire within the 10-minute TTL). Requires a gateway restart to change.
+# expire within the 10-minute TTL); a payload larger than the cap itself is a
+# permanent 413. Non-positive or invalid values fall back to the default —
+# this cap can be raised but not disabled. Requires a gateway restart.
 upload_store_max_total_bytes = 314572800    # 300 MiB
 # Disk budget for attachment copies materialized into an agent workspace
 # (<workspace>/.opensquilla/attachments). When exceeded, new materializations
-# degrade to an unavailable marker; existing files are never evicted.
+# degrade to an unavailable marker; existing files are never evicted. Set to
+# 0 (or any non-positive value) to disable the budget entirely.
 workspace_attachment_disk_budget_bytes = 1073741824  # 1 GiB
 # Persist attachment bytes with session transcripts.
 persist_transcripts = true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,6 +232,14 @@ a provider prompt.
 accept_opaque = true
 # Per-file ceiling for opaque attachments (bytes).
 opaque_max_bytes = 31457280            # 30 MiB
+# Aggregate RAM ceiling for the in-memory staged-upload store. When reached,
+# new uploads get HTTP 507 UPLOAD_STORE_FULL (retryable; staged entries
+# expire within the 10-minute TTL). Requires a gateway restart to change.
+upload_store_max_total_bytes = 314572800    # 300 MiB
+# Disk budget for attachment copies materialized into an agent workspace
+# (<workspace>/.opensquilla/attachments). When exceeded, new materializations
+# degrade to an unavailable marker; existing files are never evicted.
+workspace_attachment_disk_budget_bytes = 1073741824  # 1 GiB
 # Persist attachment bytes with session transcripts.
 persist_transcripts = true
 # media_root = ""                      # default: resolved from the cache dir

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -86,6 +86,8 @@ frontend = "vue"
 # [attachments]
 # accept_opaque = true          # false = legacy rendered-types-only admission
 # opaque_max_bytes = 31457280   # 30 MiB per-file ceiling for opaque types
+# upload_store_max_total_bytes = 314572800   # 300 MiB staged-upload RAM ceiling
+# workspace_attachment_disk_budget_bytes = 1073741824  # 1 GiB workspace copies
 # persist_transcripts = true
 # transcript_disk_budget_bytes = 2147483648
 # artifact_max_bytes = 31457280

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -87,7 +87,9 @@ frontend = "vue"
 # accept_opaque = true          # false = legacy rendered-types-only admission
 # opaque_max_bytes = 31457280   # 30 MiB per-file ceiling for opaque types
 # upload_store_max_total_bytes = 314572800   # 300 MiB staged-upload RAM ceiling
+#                                             # (raise-only; <=0 = default)
 # workspace_attachment_disk_budget_bytes = 1073741824  # 1 GiB workspace copies
+#                                             # (<=0 = unbounded)
 # persist_transcripts = true
 # transcript_disk_budget_bytes = 2147483648
 # artifact_max_bytes = 31457280

--- a/src/opensquilla/attachment_workspace.py
+++ b/src/opensquilla/attachment_workspace.py
@@ -21,6 +21,12 @@ _UNSAFE_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9._@+=, -]+")
 _WHITESPACE = re.compile(r"\s+")
 
 
+class AttachmentWorkspaceBudgetError(ValueError):
+    """Materializing the payload would push the workspace attachment
+    directory past its disk budget. Existing files are never evicted; the
+    attachment degrades to an unavailable marker instead."""
+
+
 @dataclass(frozen=True)
 class AttachmentWorkspaceMaterialization:
     """Result of attempting to make an attachment available inside a workspace."""
@@ -31,6 +37,20 @@ class AttachmentWorkspaceMaterialization:
     size: int
     rel_path: str | None = None
     error: str | None = None
+
+
+def workspace_attachment_budget_from_config(config: Any) -> int | None:
+    """Resolve attachments.workspace_attachment_disk_budget_bytes, or None.
+
+    Guarded like every attachments-config read: absent section, non-int, or
+    non-positive values mean "unbounded" so config-less runners keep working.
+    """
+
+    attachments_cfg = getattr(config, "attachments", None)
+    value = getattr(attachments_cfg, "workspace_attachment_disk_budget_bytes", None)
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
 
 
 def is_materializable_attachment_mime(
@@ -69,12 +89,37 @@ class AttachmentWorkspaceMaterializer:
         media_root: Path,
         workspace_dir: str | Path,
         materializable_mimes: Collection[str] | None = None,
+        disk_budget_bytes: int | None = None,
     ) -> None:
         self._media_root = Path(media_root)
         self._workspace_root = Path(workspace_dir)
         self._materializable_mimes = (
             frozenset(materializable_mimes) if materializable_mimes is not None else None
         )
+        self._disk_budget_bytes = disk_budget_bytes
+        # Lazily-scanned bytes under <workspace>/.opensquilla/attachments,
+        # kept current across this instance's writes so a batch of
+        # materializations pays for one directory walk.
+        self._usage_bytes: int | None = None
+
+    def _attachments_root(self) -> Path:
+        return self._workspace_root.resolve() / ".opensquilla" / "attachments"
+
+    def _current_usage_bytes(self) -> int:
+        if self._usage_bytes is None:
+            total = 0
+            root = self._attachments_root()
+            if root.is_dir():
+                for path in root.rglob("*"):
+                    try:
+                        if path.is_file() and not path.is_symlink():
+                            total += path.stat().st_size
+                    except OSError:
+                        # Session-delete cleanup may race the walk; a vanished
+                        # file simply stops counting.
+                        continue
+            self._usage_bytes = total
+        return self._usage_bytes
 
     def materialize(
         self,
@@ -197,6 +242,7 @@ class AttachmentWorkspaceMaterializer:
         sha: str,
         size: int,
     ) -> None:
+        existing_size: int | None = None
         if target.exists():
             if target.is_symlink():
                 pass
@@ -205,7 +251,19 @@ class AttachmentWorkspaceMaterializer:
             else:
                 existing = target.read_bytes()
                 if len(existing) == size and hashlib.sha256(existing).hexdigest() == sha:
+                    # Reuse is always free: an already-materialized file must
+                    # never flip to unavailable when the budget fills later.
                     return
+                existing_size = len(existing)
+        if self._disk_budget_bytes is not None:
+            usage = self._current_usage_bytes() - (existing_size or 0)
+            if usage + size > self._disk_budget_bytes:
+                raise AttachmentWorkspaceBudgetError(
+                    "workspace attachment budget exceeded "
+                    f"({usage} + {size} > {self._disk_budget_bytes} bytes); "
+                    "delete finished sessions or raise "
+                    "attachments.workspace_attachment_disk_budget_bytes"
+                )
         tmp_path = target.with_name(f".{target.name}.{secrets.token_hex(4)}.tmp")
         try:
             with open(tmp_path, "wb") as handle:
@@ -223,6 +281,8 @@ class AttachmentWorkspaceMaterializer:
         written = target.read_bytes()
         if len(written) != size or hashlib.sha256(written).hexdigest() != sha:
             raise ValueError("workspace material hash mismatch")
+        if self._usage_bytes is not None:
+            self._usage_bytes += size - (existing_size or 0)
 
 
 def _coerce_attachment_ref(

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -40,6 +40,7 @@ from opensquilla.attachment_refs import (
 from opensquilla.attachment_workspace import (
     AttachmentWorkspaceMaterializer,
     render_attachment_material_marker,
+    workspace_attachment_budget_from_config,
 )
 from opensquilla.bootstrap_types import BootstrapFileReport
 from opensquilla.contracts.attachments import (
@@ -7008,6 +7009,9 @@ class TurnRunner:
                     media_root=self._attachment_media_root(),
                     session_id=attachment_replay_session_id,
                     workspace_dir=workspace_dir,
+                    workspace_attachment_budget_bytes=(
+                        workspace_attachment_budget_from_config(self._config)
+                    ),
                 )
             elif raw_content and entry.role == "assistant":
                 content = self._maybe_unpack_assistant_artifacts(raw_content)
@@ -7169,6 +7173,7 @@ class TurnRunner:
         media_root: Path | None = None,
         session_id: str | None = None,
         workspace_dir: str | Path | None = None,
+        workspace_attachment_budget_bytes: int | None = None,
     ) -> Any:
         """Reduce persisted attachment envelopes to text-only history.
 
@@ -7203,6 +7208,16 @@ class TurnRunner:
         omitted: list[str] = []
         replay_blocks: list[Any] = []
         preserved_image = False
+        historical_materializer: AttachmentWorkspaceMaterializer | None = None
+        if materialize_historical_attachments and session_id and workspace_dir:
+            # One instance per replay so the whole batch shares a single
+            # budget scan instead of re-walking the tree per attachment.
+            historical_materializer = AttachmentWorkspaceMaterializer(
+                media_root=media_root or Path("."),
+                workspace_dir=workspace_dir,
+                materializable_mimes=None,
+                disk_budget_bytes=workspace_attachment_budget_bytes,
+            )
         if preserve_image_attachments and text:
             from opensquilla.provider.types import ContentBlockText
 
@@ -7267,16 +7282,11 @@ class TurnRunner:
                         preserved_image = True
                     continue
             if (
-                materialize_historical_attachments
+                historical_materializer is not None
                 and session_id
-                and workspace_dir
                 and _is_materializable_attachment_mime(media_type)
             ):
-                materializer = AttachmentWorkspaceMaterializer(
-                    media_root=media_root or Path("."),
-                    workspace_dir=workspace_dir,
-                    materializable_mimes=None,
-                )
+                materializer = historical_materializer
                 result = None
                 if isinstance(sha_ref, str) and sha_ref and media_root is not None:
                     raw_size = att.get("size")
@@ -7360,6 +7370,7 @@ class TurnRunner:
         media_root: Path | None = None,
         workspace_dir: str | Path | None = None,
         session_id: str | None = None,
+        workspace_attachment_budget_bytes: int | None = None,
     ) -> list | None:
         """Build a multimodal user message that carries the attachments.
 
@@ -7387,6 +7398,16 @@ class TurnRunner:
 
         prompt_block = ContentBlockText(text=message)
         attachment_blocks: list[Any] = []
+        turn_materializer: AttachmentWorkspaceMaterializer | None = None
+        if workspace_dir:
+            # One instance per turn so the attachment batch shares a single
+            # budget scan instead of re-walking the tree per attachment.
+            turn_materializer = AttachmentWorkspaceMaterializer(
+                media_root=media_root or Path("."),
+                workspace_dir=workspace_dir,
+                materializable_mimes=None,
+                disk_budget_bytes=workspace_attachment_budget_bytes,
+            )
         for index, att in enumerate(attachments, start=1):
             att_type = att.get("type")
             media_type: str | None = att_type if isinstance(att_type, str) else None
@@ -7442,14 +7463,10 @@ class TurnRunner:
             filename = _sanitize_attachment_filename(name_raw)
             material_marker = ""
             if (
-                workspace_dir
+                turn_materializer is not None
                 and _is_materializable_attachment_mime(media_type)
             ):
-                materializer = AttachmentWorkspaceMaterializer(
-                    media_root=media_root or Path("."),
-                    workspace_dir=workspace_dir,
-                    materializable_mimes=None,
-                )
+                materializer = turn_materializer
                 if is_attachment_ref(att):
                     result = materializer.materialize(att, session_id=session_id)
                 else:

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -6982,6 +6982,16 @@ class TurnRunner:
             if attachment_replay_session_id is None:
                 attachment_replay_session_id = session_key
         last_entry_was_user = False
+        history_materializer: AttachmentWorkspaceMaterializer | None = None
+        if materialize_historical_attachments and workspace_dir and attachment_replay_session_id:
+            # One instance per history load so first-materialization replays
+            # pay for a single workspace-tree budget scan, not one per entry.
+            history_materializer = AttachmentWorkspaceMaterializer(
+                media_root=self._attachment_media_root(),
+                workspace_dir=workspace_dir,
+                materializable_mimes=None,
+                disk_budget_bytes=workspace_attachment_budget_from_config(self._config),
+            )
         for entry_index, entry in enumerate(transcript):
             if entry_index in bound_skip_indexes:
                 # The bound current prompt (re-appended by the caller) and any
@@ -7009,9 +7019,7 @@ class TurnRunner:
                     media_root=self._attachment_media_root(),
                     session_id=attachment_replay_session_id,
                     workspace_dir=workspace_dir,
-                    workspace_attachment_budget_bytes=(
-                        workspace_attachment_budget_from_config(self._config)
-                    ),
+                    historical_materializer=history_materializer,
                 )
             elif raw_content and entry.role == "assistant":
                 content = self._maybe_unpack_assistant_artifacts(raw_content)
@@ -7174,6 +7182,7 @@ class TurnRunner:
         session_id: str | None = None,
         workspace_dir: str | Path | None = None,
         workspace_attachment_budget_bytes: int | None = None,
+        historical_materializer: AttachmentWorkspaceMaterializer | None = None,
     ) -> Any:
         """Reduce persisted attachment envelopes to text-only history.
 
@@ -7208,10 +7217,12 @@ class TurnRunner:
         omitted: list[str] = []
         replay_blocks: list[Any] = []
         preserved_image = False
-        historical_materializer: AttachmentWorkspaceMaterializer | None = None
-        if materialize_historical_attachments and session_id and workspace_dir:
-            # One instance per replay so the whole batch shares a single
-            # budget scan instead of re-walking the tree per attachment.
+        if not materialize_historical_attachments:
+            historical_materializer = None
+        elif historical_materializer is None and session_id and workspace_dir:
+            # Fallback for direct callers: the history loader passes one
+            # shared instance per load so the whole transcript shares a
+            # single budget scan instead of re-walking the tree per entry.
             historical_materializer = AttachmentWorkspaceMaterializer(
                 media_root=media_root or Path("."),
                 workspace_dir=workspace_dir,

--- a/src/opensquilla/engine/turn_runner/harness.py
+++ b/src/opensquilla/engine/turn_runner/harness.py
@@ -16,6 +16,9 @@ import inspect
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from opensquilla.attachment_workspace import (
+    workspace_attachment_budget_from_config,
+)
 from opensquilla.engine.turn_runner.agent_bootstrap_stage import (
     AgentConfigBuilderPort,
     AgentFactoryPort,
@@ -1024,6 +1027,9 @@ class _TurnRunnerAttachmentMessageBuilderAdapter(AttachmentMessageBuilderPort):
             workspace_dir=workspace_dir
             or getattr(self._runner._config, "workspace_dir", None),
             session_id=session_id,
+            workspace_attachment_budget_bytes=(
+                workspace_attachment_budget_from_config(self._runner._config)
+            ),
         )
 
 

--- a/src/opensquilla/gateway/app.py
+++ b/src/opensquilla/gateway/app.py
@@ -600,11 +600,18 @@ def create_gateway_app(
     # replace the default in-memory-only singleton; respect a test-injected store.
     _upload_store = get_upload_store()
     if getattr(_upload_store, "marker_dir", None) is None:
+        from opensquilla.gateway.uploads import (  # noqa: PLC0415
+            _DEFAULT_MAX_TOTAL_BYTES as _UPLOAD_STORE_DEFAULT_TOTAL,
+        )
         from opensquilla.paths import media_root_from_config  # noqa: PLC0415
 
+        _store_total_cap = getattr(config.attachments, "upload_store_max_total_bytes", None)
+        if not isinstance(_store_total_cap, int) or _store_total_cap <= 0:
+            _store_total_cap = _UPLOAD_STORE_DEFAULT_TOTAL
         _upload_store = UploadStore(
             marker_dir=media_root_from_config(config) / "uploads",
             accept_opaque=bool(getattr(config.attachments, "accept_opaque", True)),
+            max_total_bytes=_store_total_cap,
         )
         set_upload_store(_upload_store)
     register_upload_routes(app, config=config, store=_upload_store)

--- a/src/opensquilla/gateway/app.py
+++ b/src/opensquilla/gateway/app.py
@@ -607,6 +607,14 @@ def create_gateway_app(
 
         _store_total_cap = getattr(config.attachments, "upload_store_max_total_bytes", None)
         if not isinstance(_store_total_cap, int) or _store_total_cap <= 0:
+            if _store_total_cap is not None:
+                log.warning(
+                    "attachments.upload_store_max_total_bytes=%r is not a "
+                    "positive integer; using the %d byte default (this RAM "
+                    "cap can be raised but not disabled)",
+                    _store_total_cap,
+                    _UPLOAD_STORE_DEFAULT_TOTAL,
+                )
             _store_total_cap = _UPLOAD_STORE_DEFAULT_TOTAL
         _upload_store = UploadStore(
             marker_dir=media_root_from_config(config) / "uploads",

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -104,6 +104,15 @@ class AttachmentsConfig(BaseSettings):
     # tool access only. False restores the rendered-types-only admission gate.
     accept_opaque: bool = True
     opaque_max_bytes: int = 30 * 1024 * 1024
+    # Aggregate RAM ceiling for the in-memory staged-upload store. When
+    # reached, new uploads are rejected (HTTP 507 UPLOAD_STORE_FULL) instead
+    # of evicting staged entries, preserving the file_uuid TTL promise.
+    # Applied at gateway construction; changing it requires a restart.
+    upload_store_max_total_bytes: int = 300 * 1024 * 1024
+    # Disk budget for attachment copies materialized into an agent workspace
+    # (<workspace>/.opensquilla/attachments). When exceeded, new
+    # materializations degrade to an unavailable marker; nothing is evicted.
+    workspace_attachment_disk_budget_bytes: int = 1024 * 1024 * 1024
 
 
 class RateLimitConfig(BaseSettings):

--- a/src/opensquilla/gateway/uploads.py
+++ b/src/opensquilla/gateway/uploads.py
@@ -215,6 +215,14 @@ class UploadStore:
                 f"upload exceeds {max_bytes} byte cap for {normalized_mime} "
                 f"(got {len(payload)})"
             )
+        if len(payload) > self.max_total_bytes:
+            # A payload larger than the aggregate cap can never be staged, so
+            # this is a permanent per-payload condition (413), never the
+            # retryable store-full rejection.
+            raise UploadOversizeError(
+                f"upload of {len(payload)} bytes exceeds the "
+                f"{self.max_total_bytes} byte staged-upload store cap"
+            )
 
         file_uuid = f"u-{_uuid.uuid4().hex}"
         sha = hashlib.sha256(payload).hexdigest()

--- a/src/opensquilla/gateway/uploads.py
+++ b/src/opensquilla/gateway/uploads.py
@@ -53,6 +53,7 @@ log = logging.getLogger(__name__)
 _ALLOWED_MIMES: frozenset[str] = ALLOWED_MEDIA_TYPES
 
 _DEFAULT_MAX_FILE_BYTES = 30 * 1024 * 1024
+_DEFAULT_MAX_TOTAL_BYTES = 300 * 1024 * 1024
 _DEFAULT_TTL_SECONDS = 10 * 60
 
 
@@ -66,6 +67,14 @@ class UploadOversizeError(UploadStoreError):
 
 class UploadUnsupportedMimeError(UploadStoreError):
     pass
+
+
+class UploadStoreFullError(UploadStoreError):
+    """Admitting the payload would push staged bytes past the aggregate cap.
+
+    Raised instead of evicting: staged uuids carry a TTL promise to clients,
+    so the store rejects new work rather than breaking outstanding uploads.
+    """
 
 
 class AttachmentNotFoundError(UploadStoreError):
@@ -103,11 +112,14 @@ class UploadStore:
         ttl_seconds: float = _DEFAULT_TTL_SECONDS,
         max_file_bytes: int = _DEFAULT_MAX_FILE_BYTES,
         accept_opaque: bool = True,
+        *,
+        max_total_bytes: int = _DEFAULT_MAX_TOTAL_BYTES,
     ) -> None:
         self.marker_dir: Path | None = Path(marker_dir) if marker_dir is not None else None
         self.ttl_seconds = ttl_seconds
         self.max_file_bytes = max_file_bytes
         self.accept_opaque = accept_opaque
+        self.max_total_bytes = max_total_bytes
         self._entries: dict[str, _Entry] = {}
         self._locks: dict[str, asyncio.Lock] = {}
         self._lock_for_locks = asyncio.Lock()
@@ -221,17 +233,43 @@ class UploadStore:
         await self._sweep_expired_locked()
 
         lock = await self._get_uuid_lock(file_uuid)
+        admitted = False
         async with lock:
-            self._entries[file_uuid] = entry
-            self._write_marker(
-                file_uuid,
-                {
-                    "sha256": sha,
-                    "mime": normalized_mime,
-                    "name": name,
-                    "size": len(payload),
-                    "expires_at": expires_at,
-                },
+            # Aggregate cap, computed over ALL held entries (expired entries a
+            # concurrent resolver keeps locked past the sweep still occupy
+            # RAM). The check and the insert sit in one zero-await stretch, so
+            # concurrent puts cannot interleave between them and overshoot.
+            staged_total = sum(e.size for e in self._entries.values())
+            if staged_total + entry.size > self.max_total_bytes:
+                log.warning(
+                    "uploads.store_full staged=%d incoming=%d cap=%d",
+                    staged_total,
+                    entry.size,
+                    self.max_total_bytes,
+                )
+            else:
+                admitted = True
+                self._entries[file_uuid] = entry
+                self._write_marker(
+                    file_uuid,
+                    {
+                        "sha256": sha,
+                        "mime": normalized_mime,
+                        "name": name,
+                        "size": len(payload),
+                        "expires_at": expires_at,
+                    },
+                )
+        if not admitted:
+            # Drop the per-uuid lock minted for this rejected upload so bursts
+            # of rejections cannot grow the lock dict without bound.
+            async with self._lock_for_locks:
+                self._locks.pop(file_uuid, None)
+            raise UploadStoreFullError(
+                f"upload store is full ({staged_total} of {self.max_total_bytes} "
+                f"bytes staged); staged uploads expire within "
+                f"{int(self.ttl_seconds)}s — retry shortly or send pending "
+                "attachments first"
             )
         return file_uuid, expires_at
 
@@ -425,6 +463,12 @@ def register_upload_routes(
         except UploadUnsupportedMimeError as exc:
             return JSONResponse(
                 {"error": str(exc), "code": "UNSUPPORTED_MEDIA_TYPE"}, status_code=415
+            )
+        except UploadStoreFullError as exc:
+            # Retryable capacity condition (staged entries expire within the
+            # TTL), distinct from per-file 413 and rate-limit 429.
+            return JSONResponse(
+                {"error": str(exc), "code": "UPLOAD_STORE_FULL"}, status_code=507
             )
 
         return JSONResponse(

--- a/tests/test_attachment_workspace.py
+++ b/tests/test_attachment_workspace.py
@@ -207,3 +207,33 @@ def test_workspace_attachment_budget_from_config_guards() -> None:
         )
         is None
     )
+
+
+def test_budget_overwrite_of_mismatched_file_frees_replaced_bytes(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    payload = b"h" * 10
+    sha = hashlib.sha256(payload).hexdigest()
+    target_dir = workspace / ".opensquilla" / "attachments" / "session-a"
+    target_dir.mkdir(parents=True)
+    stale = target_dir / f"{sha[:12]}-h.bin"
+    stale.write_bytes(b"stale-different-content-12345")  # 29 bytes at the target path
+
+    materializer = _budgeted(tmp_path, budget=16)
+    # 29 stale bytes alone exceed the budget, but the overwrite frees them:
+    # (29 - 29) + 10 <= 16 must be admitted.
+    result = materializer.materialize_bytes(
+        payload, name="h.bin", mime="application/octet-stream", session_id="session-a"
+    )
+    assert result.available is True
+    assert stale.read_bytes() == payload
+
+    # Cached usage after the overwrite must be 10 (not 29 or 39): a 6-byte
+    # payload fits (10 + 6 <= 16), one more byte does not.
+    ok = materializer.materialize_bytes(
+        b"i" * 6, name="i.bin", mime="application/octet-stream", session_id="session-a"
+    )
+    assert ok.available is True
+    over = materializer.materialize_bytes(
+        b"j", name="j.bin", mime="application/octet-stream", session_id="session-a"
+    )
+    assert over.available is False

--- a/tests/test_attachment_workspace.py
+++ b/tests/test_attachment_workspace.py
@@ -92,3 +92,118 @@ def test_existing_materialized_file_is_reused_when_hash_matches(tmp_path: Path) 
     assert result.available is True
     assert existing.stat().st_mtime_ns == before_mtime_ns
     assert existing.read_bytes() == payload
+
+
+def _budgeted(tmp_path: Path, budget: int | None) -> AttachmentWorkspaceMaterializer:
+    return AttachmentWorkspaceMaterializer(
+        media_root=tmp_path / "media",
+        workspace_dir=tmp_path / "workspace",
+        materializable_mimes=None,
+        disk_budget_bytes=budget,
+    )
+
+
+def test_budget_rejects_materialization_that_would_exceed_it(tmp_path: Path) -> None:
+    materializer = _budgeted(tmp_path, budget=10)
+
+    result = materializer.materialize_bytes(
+        b"x" * 11,
+        name="big.bin",
+        mime="application/octet-stream",
+        session_id="session-a",
+    )
+
+    assert result.available is False
+    assert result.error is not None
+    assert "workspace attachment budget exceeded" in result.error
+    # The marker text names the remedy for the operator/model to see.
+    assert "workspace_attachment_disk_budget_bytes" in result.error
+    files = list((tmp_path / "workspace" / ".opensquilla" / "attachments").rglob("*-big.bin"))
+    assert files == []
+
+
+def test_budget_counts_existing_workspace_files(tmp_path: Path) -> None:
+    materializer = _budgeted(tmp_path, budget=16)
+    first = materializer.materialize_bytes(
+        b"a" * 10, name="a.bin", mime="application/octet-stream", session_id="session-a"
+    )
+    assert first.available is True
+
+    # A fresh instance re-scans the tree, so the 10 existing bytes count.
+    second = _budgeted(tmp_path, budget=16).materialize_bytes(
+        b"b" * 10, name="b.bin", mime="application/octet-stream", session_id="session-a"
+    )
+    assert second.available is False
+    assert "workspace attachment budget exceeded" in (second.error or "")
+
+    # A smaller payload that fits the remaining headroom is admitted.
+    third = _budgeted(tmp_path, budget=16).materialize_bytes(
+        b"c" * 6, name="c.bin", mime="application/octet-stream", session_id="session-a"
+    )
+    assert third.available is True
+
+
+def test_budget_reuse_of_existing_file_is_always_free(tmp_path: Path) -> None:
+    payload = b"d" * 12
+    first = _budgeted(tmp_path, budget=12).materialize_bytes(
+        payload, name="d.bin", mime="application/octet-stream", session_id="session-a"
+    )
+    assert first.available is True
+
+    # At-budget workspace: re-materializing the SAME content must stay
+    # available (reuse short-circuits before the budget check) so replay of
+    # already-materialized history never degrades when the budget fills.
+    again = _budgeted(tmp_path, budget=12).materialize_bytes(
+        payload, name="d.bin", mime="application/octet-stream", session_id="session-a"
+    )
+    assert again.available is True
+    assert again.rel_path == first.rel_path
+
+
+def test_budget_none_is_unbounded(tmp_path: Path) -> None:
+    result = _budgeted(tmp_path, budget=None).materialize_bytes(
+        b"e" * 4096, name="e.bin", mime="application/octet-stream", session_id="session-a"
+    )
+    assert result.available is True
+
+
+def test_budget_shared_across_one_instance_batch(tmp_path: Path) -> None:
+    # One materializer instance (one turn) tracks its own writes against the
+    # budget without re-walking the tree.
+    materializer = _budgeted(tmp_path, budget=16)
+    first = materializer.materialize_bytes(
+        b"f" * 10, name="f.bin", mime="application/octet-stream", session_id="session-a"
+    )
+    second = materializer.materialize_bytes(
+        b"g" * 10, name="g.bin", mime="application/octet-stream", session_id="session-a"
+    )
+    assert first.available is True
+    assert second.available is False
+
+
+def test_workspace_attachment_budget_from_config_guards() -> None:
+    from types import SimpleNamespace
+
+    from opensquilla.attachment_workspace import workspace_attachment_budget_from_config
+
+    good = SimpleNamespace(
+        attachments=SimpleNamespace(workspace_attachment_disk_budget_bytes=123)
+    )
+    assert workspace_attachment_budget_from_config(good) == 123
+    assert workspace_attachment_budget_from_config(None) is None
+    assert (
+        workspace_attachment_budget_from_config(
+            SimpleNamespace(
+                attachments=SimpleNamespace(workspace_attachment_disk_budget_bytes=0)
+            )
+        )
+        is None
+    )
+    assert (
+        workspace_attachment_budget_from_config(
+            SimpleNamespace(
+                attachments=SimpleNamespace(workspace_attachment_disk_budget_bytes="2")
+            )
+        )
+        is None
+    )

--- a/tests/test_engine/test_attachment_messages.py
+++ b/tests/test_engine/test_attachment_messages.py
@@ -903,3 +903,25 @@ def test_historical_non_rendered_image_is_not_replayed_for_vision() -> None:
     else:
         assert isinstance(out, str)
         assert "scan.tiff" in out
+
+
+def test_workspace_budget_degrades_materialization_to_marker(tmp_path: Path) -> None:
+    # An over-budget workspace degrades the workspace copy to an unavailable
+    # marker naming the remedy; the turn itself never fails.
+    payload = b"\x00\x01" + b"z" * 256
+    workspace = tmp_path / "workspace"
+    out = TurnRunner._build_attachment_messages(
+        "inspect",
+        [{"type": "application/x-unknown", "data": _b64(payload), "name": "blob.bin"}],
+        workspace_dir=workspace,
+        session_id="s-budget",
+        workspace_attachment_budget_bytes=8,
+    )
+
+    assert out is not None
+    text_blocks = [b for b in out[0].content if isinstance(b, ContentBlockText)]
+    wrapped = next(b for b in text_blocks if b.text.startswith("<file "))
+    assert "attachment unavailable" in wrapped.text
+    assert "workspace attachment budget exceeded" in wrapped.text
+    files = list((workspace / ".opensquilla" / "attachments").rglob("*-blob.bin"))
+    assert files == []

--- a/tests/test_engine/turn_runner/test_attachment_stage_harness_adapter.py
+++ b/tests/test_engine/turn_runner/test_attachment_stage_harness_adapter.py
@@ -25,6 +25,7 @@ def test_attachment_builder_adapter_prefers_resolved_workspace(tmp_path: Path) -
             media_root: Path | None = None,
             workspace_dir: str | Path | None = None,
             session_id: str | None = None,
+            workspace_attachment_budget_bytes: int | None = None,
         ) -> None:
             calls.append(
                 {
@@ -33,6 +34,7 @@ def test_attachment_builder_adapter_prefers_resolved_workspace(tmp_path: Path) -
                     "media_root": media_root,
                     "workspace_dir": workspace_dir,
                     "session_id": session_id,
+                    "workspace_attachment_budget_bytes": workspace_attachment_budget_bytes,
                 }
             )
             return None
@@ -54,5 +56,8 @@ def test_attachment_builder_adapter_prefers_resolved_workspace(tmp_path: Path) -
             "media_root": tmp_path / "media",
             "workspace_dir": agent_workspace,
             "session_id": "session-a",
+            # The fake config has no attachments section, so the budget
+            # resolver falls back to unbounded.
+            "workspace_attachment_budget_bytes": None,
         }
     ]

--- a/tests/test_gateway/test_uploads_endpoint.py
+++ b/tests/test_gateway/test_uploads_endpoint.py
@@ -33,6 +33,7 @@ from opensquilla.gateway.uploads import (
     AttachmentNotFoundError,
     UploadOversizeError,
     UploadStore,
+    UploadStoreFullError,
     UploadUnsupportedMimeError,
 )
 
@@ -818,7 +819,11 @@ def test_app_factory_wires_strict_admission_into_route_and_store(tmp_path: Path)
     set_upload_store(None)
     try:
         config = GatewayConfig(
-            attachments={"accept_opaque": False, "media_root": str(tmp_path / "media")},
+            attachments={
+                "accept_opaque": False,
+                "media_root": str(tmp_path / "media"),
+                "upload_store_max_total_bytes": 7 * 1024 * 1024,
+            },
         )
         app = create_gateway_app(config)
         with TestClient(app) as client:
@@ -829,6 +834,7 @@ def test_app_factory_wires_strict_admission_into_route_and_store(tmp_path: Path)
         assert response.status_code == 415
         assert response.json()["code"] == "UNSUPPORTED_MEDIA_TYPE"
         assert get_upload_store().accept_opaque is False
+        assert get_upload_store().max_total_bytes == 7 * 1024 * 1024
     finally:
         set_upload_store(original_store)
 
@@ -870,3 +876,81 @@ def test_file_uuid_opaque_reference_resolves_with_store_mime(tmp_path: Path) -> 
     assert resolved[0]["kind"] == "attachment_ref"
     assert resolved[0]["mime"] == "application/zip"
     assert resolved[0]["size"] == len(payload)
+
+
+# ---------------------------------------------------------------------------
+# Aggregate RAM cap: reject-on-full, never evict.
+# ---------------------------------------------------------------------------
+
+
+def _capped_store(tmp_path: Path, max_total_bytes: int, ttl_seconds: float = 600) -> UploadStore:
+    return UploadStore(
+        marker_dir=tmp_path / "inbound",
+        ttl_seconds=ttl_seconds,
+        max_file_bytes=30 * 1024 * 1024,
+        max_total_bytes=max_total_bytes,
+    )
+
+
+def test_store_full_rejects_without_insert_or_marker(tmp_path: Path) -> None:
+    store = _capped_store(tmp_path, max_total_bytes=1024)
+    ok_uuid = asyncio.run(store.put("a.txt", "text/plain", b"a" * 900))
+
+    with pytest.raises(UploadStoreFullError, match="upload store is full"):
+        asyncio.run(store.put("b.txt", "text/plain", b"b" * 200))
+
+    # The staged entry is untouched (reject, never evict) and the rejected
+    # upload left neither a marker nor a stranded per-uuid lock behind.
+    payload, _meta = asyncio.run(store.get(ok_uuid))
+    assert payload == b"a" * 900
+    markers = list((tmp_path / "inbound").glob("*.meta"))
+    assert [m.stem for m in markers] == [ok_uuid]
+    assert set(store._locks) <= {ok_uuid}
+
+
+def test_store_full_recovers_after_ttl_sweep(tmp_path: Path) -> None:
+    store = _capped_store(tmp_path, max_total_bytes=1024, ttl_seconds=0.01)
+    asyncio.run(store.put("a.txt", "text/plain", b"a" * 900))
+    time.sleep(0.05)
+
+    # The pre-insert sweep frees the expired entry, so the same-size payload
+    # is admitted again.
+    ok_uuid = asyncio.run(store.put("b.txt", "text/plain", b"b" * 900))
+    assert ok_uuid.startswith("u-")
+
+
+def test_store_full_boundary_admits_exact_fit(tmp_path: Path) -> None:
+    store = _capped_store(tmp_path, max_total_bytes=1000)
+    asyncio.run(store.put("a.txt", "text/plain", b"a" * 600))
+    ok_uuid = asyncio.run(store.put("b.txt", "text/plain", b"b" * 400))
+    assert ok_uuid.startswith("u-")
+    with pytest.raises(UploadStoreFullError):
+        asyncio.run(store.put("c.txt", "text/plain", b"c"))
+
+
+def test_upload_route_returns_507_when_store_full(tmp_path: Path) -> None:
+    store = _capped_store(tmp_path, max_total_bytes=64)
+    with _route_client(store=store) as client:
+        response = client.post(
+            "/api/v1/files/upload",
+            files={"file": ("big.txt", b"a" * 128, "text/plain")},
+        )
+
+    assert response.status_code == 507
+    body = response.json()
+    assert body["code"] == "UPLOAD_STORE_FULL"
+    assert "retry" in body["error"]
+
+
+def test_strict_mime_rejection_takes_precedence_over_full_store(tmp_path: Path) -> None:
+    # Validation precedes the capacity check, so strict mode keeps its
+    # documented 415 error precedence even when the store is at capacity.
+    strict = UploadStore(
+        marker_dir=tmp_path / "inbound",
+        ttl_seconds=600,
+        max_file_bytes=30 * 1024 * 1024,
+        accept_opaque=False,
+        max_total_bytes=1,
+    )
+    with pytest.raises(UploadUnsupportedMimeError):
+        asyncio.run(strict.put("x.sh", "application/x-shellscript", b"#!/bin/sh\n"))

--- a/tests/test_gateway/test_uploads_endpoint.py
+++ b/tests/test_gateway/test_uploads_endpoint.py
@@ -929,6 +929,25 @@ def test_store_full_boundary_admits_exact_fit(tmp_path: Path) -> None:
 
 
 def test_upload_route_returns_507_when_store_full(tmp_path: Path) -> None:
+    # A genuinely transient condition: the payload fits the cap on its own,
+    # but not while earlier staged entries are still alive.
+    store = _capped_store(tmp_path, max_total_bytes=1024)
+    asyncio.run(store.put("staged.txt", "text/plain", b"a" * 900))
+    with _route_client(store=store) as client:
+        response = client.post(
+            "/api/v1/files/upload",
+            files={"file": ("next.txt", b"b" * 200, "text/plain")},
+        )
+
+    assert response.status_code == 507
+    body = response.json()
+    assert body["code"] == "UPLOAD_STORE_FULL"
+    assert "retry" in body["error"]
+
+
+def test_payload_larger_than_total_cap_is_permanent_413(tmp_path: Path) -> None:
+    # A payload that can NEVER fit the aggregate cap is a permanent per-payload
+    # condition: 413 TOO_LARGE, not the retryable 507.
     store = _capped_store(tmp_path, max_total_bytes=64)
     with _route_client(store=store) as client:
         response = client.post(
@@ -936,10 +955,35 @@ def test_upload_route_returns_507_when_store_full(tmp_path: Path) -> None:
             files={"file": ("big.txt", b"a" * 128, "text/plain")},
         )
 
-    assert response.status_code == 507
-    body = response.json()
-    assert body["code"] == "UPLOAD_STORE_FULL"
-    assert "retry" in body["error"]
+    assert response.status_code == 413
+    assert response.json()["code"] == "TOO_LARGE"
+
+
+def test_non_positive_total_cap_falls_back_to_default(tmp_path: Path) -> None:
+    # The RAM cap can be raised but not disabled: a non-positive config value
+    # falls back to the default at app construction (with a boot warning).
+    pytest.importorskip("starlette.testclient")
+    from opensquilla.gateway.app import create_gateway_app
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.gateway.uploads import (
+        _DEFAULT_MAX_TOTAL_BYTES,
+        get_upload_store,
+        set_upload_store,
+    )
+
+    original_store = get_upload_store()
+    set_upload_store(None)
+    try:
+        config = GatewayConfig(
+            attachments={
+                "upload_store_max_total_bytes": 0,
+                "media_root": str(tmp_path / "media"),
+            },
+        )
+        create_gateway_app(config)
+        assert get_upload_store().max_total_bytes == _DEFAULT_MAX_TOTAL_BYTES
+    finally:
+        set_upload_store(original_store)
 
 
 def test_strict_mime_rejection_takes_precedence_over_full_store(tmp_path: Path) -> None:


### PR DESCRIPTION
## Scope

Two resource ceilings for the attachment system, closing the follow-ups recorded when any-file-type admission landed in #534:

1. **Staged-upload store RAM cap** — the in-memory `UploadStore` held staged bytes with per-file caps but no aggregate ceiling, so a burst of authenticated uploads (or a retrying client) could grow gateway RSS without bound. New config `attachments.upload_store_max_total_bytes` (default 300 MiB): when admitting a payload would cross the cap, the store rejects it instead of evicting staged entries (preserving the `file_uuid` TTL promise) and the route returns the additive HTTP 507 `UPLOAD_STORE_FULL` with retry guidance. A payload larger than the cap itself is a permanent 413. The check sums all held entries and sits in the same zero-await stretch as the insert, so concurrent puts cannot overshoot; rejections also drop the per-uuid lock they minted. Mime/size validation stays ahead of the capacity check, keeping strict-mode 415/413 precedence. Non-positive values fall back to the default with a boot warning (raise-only).

2. **Workspace attachment disk budget** — attachment copies materialized into `<workspace>/.opensquilla/attachments` accumulated across turns and sessions with no bound. New config `attachments.workspace_attachment_disk_budget_bytes` (default 1 GiB): when a new write would cross the budget, the attachment degrades to the existing unavailable marker (naming the config key and remedy) and the turn continues. Nothing is evicted — a stale workspace path already rendered into a prompt must keep working, mtime-ordered eviction would target the most actively reused files (reuse preserves mtime by pinned contract), and inline materializations without transcript persistence have no backing store to restore from. Reuse short-circuits before the budget check so existing history never degrades, both engine call sites share one materializer per batch (one tree scan per turn / per history load), and `0` disables the budget.

## Branch target

`main`.

## Linked issue

None (follow-up hardening recorded in #534's review notes).

## Release notes

CHANGELOG entry under `[Unreleased]` → Added.

## Tests

- `ruff check src tests`, `mypy src/opensquilla` (774 files), `uv build --wheel` pass.
- Full `pytest -q`: green for everything this branch touches (11,967 passed); the handful of machine-local failures (real-terminal TUI, real-Seatbelt, experiment-ledger scripts, one onboarding test) fail identically on an untouched `main` checkout.
- New coverage: reject-without-insert (entry/marker/lock-dict all untouched), recovery after TTL sweep, exact-fit boundary, transient 507 vs permanent 413, strict-mode 415 precedence over capacity, app-factory config wiring incl. non-positive fallback, budget rejection/marker text, existing-files accounting, reuse-is-free at budget, overwrite accounting (replaced bytes freed), per-instance batch caching, config-guard semantics, and the engine degrade-to-marker path.
- Adversarially reviewed (two-lens fan-out with independent verification); all four confirmed findings — misleading retry guidance for never-fits payloads, per-entry tree walks during history replay, undocumented non-positive semantics, and the overwrite-accounting test gap — are fixed in the final commit.

## Safety notes

Both ceilings are fail-closed additions with no wire-contract changes beyond the additive 507 code: no existing error code, message format, config key, or RPC field changes; absent/invalid config falls back to safe defaults; strict `accept_opaque=false` behavior and error precedence are unchanged.

## Third-party origin

None; all changes authored for this PR.
