### PR TITLE
Hide Windows menu bar and sync native theme

### DIFF
--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -147,6 +147,7 @@ const defaultRepoRoot = resolve(packageRoot, '..', '..')
 const repoRoot = process.env.OPENSQUILLA_DESKTOP_REPO_ROOT
   ? resolve(process.env.OPENSQUILLA_DESKTOP_REPO_ROOT)
   : defaultRepoRoot
+const shouldUseNativeApplicationMenu = process.platform === 'darwin'
 
 let mainWindow: BrowserWindow | null = null
 let onboardingWindow: BrowserWindow | null = null
@@ -2190,6 +2191,10 @@ function desktopT(key: string): string {
 }
 
 function createApplicationMenu(): void {
+  if (!shouldUseNativeApplicationMenu) {
+    Menu.setApplicationMenu(null)
+    return
+  }
   const appSubmenu: Electron.MenuItemConstructorOptions[] = [{ role: 'about' }]
   if (desktopUpdateMenuEnabled()) {
     appSubmenu.push({ type: 'separator' })


### PR DESCRIPTION
## Scope

Scope boundary:
Hide the native Windows/Linux application menu bar in the desktop client and sync the Electron native shell theme with the selected Web UI theme.

Non-goals:
No changes to macOS native application menus. No backend or gateway behavior changes.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #460

If None, reason:

## Release Note

Release note: Hide the desktop app menu bar on Windows/Linux and make the native title area follow light/dark theme changes.

## Tests

Ruff: not run

Pytest: not run

Build: npm.cmd run build in desktop/electron

Regression tests: added

Notes:
Verified the desktop Electron build. Added unit coverage for syncing the Electron native shell theme when the Web UI theme changes.
Also ran npm.cmd run test:unit -- src/stores/app.theme.test.ts and npm.cmd run typecheck in opensquilla-webui.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: browser

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none:

## Documentation Changes

- [ ] Links point to existing repository files or stable external pages.
- [ ] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.