### PR TITLE
Hot-apply the first provider config on gateways booted without credentials

### DIFF
--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -3639,6 +3639,12 @@ class TurnRunner:
         """Clone the selector and resolve provider (no shared state mutation)."""
         if self._provider_selector is None:
             return None, None
+        # A gateway can boot with a selector that has no usable primary yet
+        # (no API key configured); treat it like "no provider" so the turn
+        # fails with the same clean no_provider error instead of raising.
+        # getattr default True keeps duck-typed test selectors working.
+        if not getattr(self._provider_selector, "is_configured", True):
+            return None, None
         cloned = self._provider_selector.clone()
         return cloned.resolve(), cloned
 

--- a/src/opensquilla/gateway/app.py
+++ b/src/opensquilla/gateway/app.py
@@ -165,7 +165,7 @@ def create_gateway_app(
     async def api_system_status(request: Request) -> JSONResponse:
         uptime = int((time.time() - _start_time) * 1000)
         provider_name = None
-        if provider_selector is not None:
+        if provider_selector is not None and getattr(provider_selector, "is_configured", True):
             # Report the *configured* provider id (e.g. "openrouter"), not the
             # wire-protocol backend class. OpenAI-compatible providers
             # (openrouter / deepseek / gemini) are all served by OpenAIProvider,

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -2104,43 +2104,44 @@ async def build_services(
     resolved_base = llm_runtime.base_url
     proxy = llm_runtime.proxy
     if provider_selector is None:
-        # Local providers (Ollama, LM Studio, …) need no API key, so gating
-        # provider setup on a key would leave the gateway with "no provider".
-        provider_requires_key = True
-        if llm_runtime.provider:
-            try:
-                from opensquilla.provider.registry import get_provider_spec
+        # Always build the selector, even before an API key exists: every
+        # service (TurnRunner, RPC contexts, flush, auto-propose) captures
+        # this one object at boot, and config hot-apply mutates it in place
+        # via sync_primary. Booting without a selector would strand the
+        # gateway on "No provider available" until a restart even after the
+        # operator configures a key in the Web UI. An unconfigured selector
+        # refuses resolve() cleanly (ProviderNotConfiguredError) instead.
+        from opensquilla.provider.selector import (
+            ModelSelector,
+            ProviderConfig,
+            SelectorConfig,
+        )
 
-                provider_requires_key = get_provider_spec(
-                    llm_runtime.provider
-                ).requires_api_key()
-            except Exception:
-                provider_requires_key = True
-        if llm_runtime.provider and (api_key or not provider_requires_key):
-            from opensquilla.provider.selector import (
-                ModelSelector,
-                ProviderConfig,
-                SelectorConfig,
-            )
-
-            if resolved_base.endswith("/v1"):
-                resolved_base = resolved_base[:-3]
-            provider_selector = ModelSelector(
-                SelectorConfig(
-                    primary=ProviderConfig(
-                        provider=llm_runtime.provider,
-                        model=llm_runtime.model,
-                        api_key=api_key,
-                        base_url=resolved_base,
-                        proxy=proxy,
-                        provider_routing=llm_runtime.provider_routing,
-                    )
+        if resolved_base.endswith("/v1"):
+            resolved_base = resolved_base[:-3]
+        provider_selector = ModelSelector(
+            SelectorConfig(
+                primary=ProviderConfig(
+                    provider=llm_runtime.provider,
+                    model=llm_runtime.model,
+                    api_key=api_key,
+                    base_url=resolved_base,
+                    proxy=proxy,
+                    provider_routing=llm_runtime.provider_routing,
                 )
             )
+        )
+        if provider_selector.is_configured:
             log.info(
                 "build_services.provider_ready",
                 provider=llm_runtime.provider,
                 model=llm_runtime.model,
+            )
+        else:
+            log.info(
+                "build_services.provider_pending_configuration",
+                provider=llm_runtime.provider or "",
+                hint="configure an API key via the Web UI or config.toml [llm]; applies live",
             )
 
     # ── Model catalog (boot order: after provider selector) ──────────
@@ -3195,7 +3196,9 @@ async def start_gateway_server(
             *,
             triggered_by: str,
         ) -> MetaOrchestrator:
-            if svc.provider_selector is None:
+            if svc.provider_selector is None or not getattr(
+                svc.provider_selector, "is_configured", True
+            ):
                 raise RuntimeError("auto_propose provider not configured")
             provider_selector = svc.provider_selector
             router_cfg = getattr(config, "squilla_router", None)

--- a/src/opensquilla/gateway/rpc/registry.py
+++ b/src/opensquilla/gateway/rpc/registry.py
@@ -278,7 +278,9 @@ async def _status(params: Any, ctx: RpcContext) -> dict[str, Any]:
     uptime = now - _boot_time_ms if _boot_time_ms > 0 else 0
 
     provider_name = None
-    if ctx.provider_selector is not None:
+    if ctx.provider_selector is not None and getattr(
+        ctx.provider_selector, "is_configured", True
+    ):
         # Configured provider id (e.g. "openrouter"), not the OpenAI-compatible
         # backend class physically serving it. See app.api_system_status.
         provider_name = getattr(ctx.provider_selector, "active_provider_id", None)

--- a/src/opensquilla/gateway/rpc_models.py
+++ b/src/opensquilla/gateway/rpc_models.py
@@ -55,7 +55,9 @@ async def _handle_models_list(params: dict | None, ctx: RpcContext) -> dict[str,
 
     models: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
-    if ctx.provider_selector is not None:
+    if ctx.provider_selector is not None and getattr(
+        ctx.provider_selector, "is_configured", True
+    ):
         try:
             detailed = await ctx.provider_selector.list_models_detailed()
             models = [_model_info_to_wire(m) for m in detailed.models]

--- a/src/opensquilla/gateway/rpc_tools.py
+++ b/src/opensquilla/gateway/rpc_tools.py
@@ -165,7 +165,7 @@ def _provider_base_url(provider_id: str, default_base_url: str, ctx: RpcContext)
 
 async def _model_probe(provider_id: str, ctx: RpcContext) -> dict[str, Any]:
     selector = getattr(ctx, "provider_selector", None)
-    if selector is None:
+    if selector is None or not getattr(selector, "is_configured", True):
         return {
             "attempted": True,
             "status": "unavailable",

--- a/src/opensquilla/provider/selector.py
+++ b/src/opensquilla/provider/selector.py
@@ -82,6 +82,17 @@ class ProviderBuildError(Exception):
     """Raised when a provider cannot be instantiated."""
 
 
+class ProviderNotConfiguredError(ProviderBuildError):
+    """Raised when resolving a selector whose active link is not usable yet.
+
+    A gateway can boot before the operator has supplied an API key; the
+    selector then exists in an unconfigured state so that a later
+    ``sync_primary`` (Web UI / RPC config edit) can bring it live in place
+    without a restart. Subclasses ``ProviderBuildError`` so every existing
+    resolve() error handler degrades the same way.
+    """
+
+
 def _unsupported_runtime_message(provider: str) -> str:
     return (
         f"Provider '{provider}' is registered but runtime support "
@@ -298,8 +309,33 @@ class ModelSelector:
         self._index = 0
         self._plugin = plugin
 
+    @property
+    def is_configured(self) -> bool:
+        """True when the active chain link can serve requests.
+
+        Mirrors the boot gate: a provider id must be set, and an API key must
+        be present unless the provider spec says none is required (Ollama,
+        LM Studio, …). A selector can exist unconfigured so config hot-apply
+        (``sync_primary``) can bring it live without a gateway restart.
+        """
+        cfg = self._chain[self._index]
+        if not (cfg.provider or "").strip():
+            return False
+        try:
+            requires_key = get_provider_spec(cfg.provider).requires_api_key()
+        except Exception:  # noqa: BLE001 - unknown providers still need a key
+            requires_key = True
+        return bool(cfg.api_key) or not requires_key
+
     def resolve(self) -> LLMProvider:
         """Return the current provider (primary on first call)."""
+        if not self.is_configured:
+            cfg = self._chain[self._index]
+            raise ProviderNotConfiguredError(
+                f"Provider '{cfg.provider or '(unset)'}' is not configured yet "
+                "(missing API key); add one via the Web UI settings or the "
+                "[llm] section of config.toml"
+            )
         return _build_provider(self._chain[self._index])
 
     @property

--- a/tests/test_gateway/test_cold_start_provider_hot_apply.py
+++ b/tests/test_gateway/test_cold_start_provider_hot_apply.py
@@ -1,0 +1,165 @@
+"""Cold-start provider hot-apply regression tests.
+
+Pins the fix for gateways that boot before any provider credentials exist.
+``build_services`` now always constructs the ``ModelSelector`` (unconfigured
+when no usable key is present) so that a Web UI / RPC config edit can bring
+it live in place via ``sync_primary``. Previously the selector stayed
+``None`` forever: the config file was saved, onboarding reported
+``restart_required=False``, the connectivity probe passed — yet every turn
+failed with "No provider available" until a full gateway restart.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from opensquilla.engine.runtime import TurnRunner
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.rpc.registry import RpcContext, _status
+from opensquilla.gateway.rpc_config import (
+    _sync_provider_selector as config_sync_provider_selector,
+)
+from opensquilla.gateway.rpc_onboarding import (
+    _sync_provider_selector as onboarding_sync_provider_selector,
+)
+from opensquilla.provider.selector import (
+    ModelSelector,
+    ProviderConfig,
+    SelectorConfig,
+)
+
+
+def _cold_boot_selector() -> ModelSelector:
+    """The selector shape build_services constructs when no API key exists."""
+    return ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig(
+                provider="openrouter",
+                model="deepseek/deepseek-v4-flash",
+                api_key="",
+            )
+        )
+    )
+
+
+def _ctx(selector: ModelSelector, config: GatewayConfig | None = None) -> RpcContext:
+    return RpcContext(
+        conn_id="c",
+        principal=SimpleNamespace(role="operator"),
+        provider_selector=selector,
+        config=config,
+    )
+
+
+def test_unconfigured_selector_yields_clean_no_provider() -> None:
+    """Before a key arrives, turns fail with no_provider — not an exception."""
+    runner = TurnRunner(provider_selector=_cold_boot_selector())
+    assert runner._resolve_provider() == (None, None)
+
+
+def test_config_sync_brings_cold_boot_selector_live_without_restart() -> None:
+    selector = _cold_boot_selector()
+    runner = TurnRunner(provider_selector=selector)
+    assert runner._resolve_provider() == (None, None)
+
+    config = GatewayConfig(
+        llm={
+            "provider": "openrouter",
+            "model": "deepseek/deepseek-v4-flash",
+            "api_key": "test-key",
+        }
+    )
+    config_sync_provider_selector(_ctx(selector, config), config)
+
+    assert selector.is_configured is True
+    provider, cloned = runner._resolve_provider()
+    assert provider is not None
+    assert cloned is not None
+    assert cloned.active_provider_id == "openrouter"
+
+
+def test_onboarding_sync_brings_cold_boot_selector_live_without_restart() -> None:
+    selector = _cold_boot_selector()
+    runner = TurnRunner(provider_selector=selector)
+    assert runner._resolve_provider() == (None, None)
+
+    config = GatewayConfig(
+        llm={
+            "provider": "openrouter",
+            "model": "deepseek/deepseek-v4-flash",
+            "api_key": "test-key",
+        }
+    )
+    onboarding_sync_provider_selector(_ctx(selector, config), config.llm)
+
+    assert selector.is_configured is True
+    provider, _ = runner._resolve_provider()
+    assert provider is not None
+
+
+async def test_status_hides_provider_until_configured() -> None:
+    selector = _cold_boot_selector()
+
+    before = await _status(None, _ctx(selector))
+    assert before["provider"] is None
+
+    selector.sync_primary(
+        ProviderConfig(
+            provider="openrouter",
+            model="deepseek/deepseek-v4-flash",
+            api_key="test-key",
+        )
+    )
+
+    after = await _status(None, _ctx(selector))
+    assert after["provider"] == "openrouter"
+
+
+async def test_build_services_constructs_unconfigured_selector_without_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A keyless boot must still yield a selector for hot-apply to mutate."""
+    from opensquilla.gateway.boot import build_services
+    from opensquilla.provider.model_catalog import set_shared_catalog
+    from opensquilla.sandbox.integration import reset_runtime
+
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "state"))
+    # A developer checkout may carry a repo-local .env with real keys;
+    # load_env would re-inject them mid-boot and make the selector
+    # configured. Run from an empty cwd so the cold-boot state is real.
+    monkeypatch.chdir(tmp_path)
+
+    def fail_background_sandbox_setup(coro):
+        close = getattr(coro, "close", None)
+        if callable(close):
+            close()
+        raise AssertionError("unit tests must not schedule real sandbox setup")
+
+    monkeypatch.setattr(
+        "opensquilla.gateway.boot.create_background_task",
+        fail_background_sandbox_setup,
+    )
+
+    config = GatewayConfig(
+        memory={"flush_enabled": False},
+        sandbox={"auto_setup": False},
+    )
+    services = await build_services(
+        config=config, session_db_path=":memory:", seed_agent_workspaces=False
+    )
+    try:
+        selector = services.provider_selector
+        assert selector is not None
+        assert selector.is_configured is False
+
+        selector.sync_primary(
+            ProviderConfig(provider="openrouter", model="m", api_key="test-key")
+        )
+        assert selector.is_configured is True
+    finally:
+        await services.close()
+        set_shared_catalog(None)
+        reset_runtime()

--- a/tests/test_gateway/test_status_version_provider.py
+++ b/tests/test_gateway/test_status_version_provider.py
@@ -30,7 +30,11 @@ def _ctx(**kwargs: object) -> RpcContext:
 def _openrouter_selector() -> ModelSelector:
     return ModelSelector(
         SelectorConfig(
-            primary=ProviderConfig(provider="openrouter", model="deepseek/deepseek-v4-flash")
+            primary=ProviderConfig(
+                provider="openrouter",
+                model="deepseek/deepseek-v4-flash",
+                api_key="test-key",
+            )
         )
     )
 

--- a/tests/test_provider_selector.py
+++ b/tests/test_provider_selector.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+import pytest
+
 from opensquilla.provider.failures import ProviderFailureKind
-from opensquilla.provider.selector import ModelSelector, ProviderConfig, SelectorConfig
+from opensquilla.provider.selector import (
+    ModelSelector,
+    ProviderBuildError,
+    ProviderConfig,
+    ProviderNotConfiguredError,
+    SelectorConfig,
+)
 from opensquilla.provider.types import ModelInfo
 
 HIGH_TIER_MODEL = "openrouter/high-tier-region-locked"
@@ -193,3 +201,51 @@ async def test_list_models_detailed_reports_every_failed_chain_link(monkeypatch)
         ("openrouter", "openrouter/auth-locked-a"),
         ("deepseek", "deepseek/auth-locked-b"),
     ]
+
+
+# ---------------------------------------------------------------------------
+# Unconfigured-selector state (cold-boot gateways)
+# ---------------------------------------------------------------------------
+
+
+def test_is_configured_false_without_key_for_key_requiring_provider() -> None:
+    selector = ModelSelector(
+        SelectorConfig(primary=ProviderConfig(provider="openrouter", model="m", api_key=""))
+    )
+    assert selector.is_configured is False
+
+
+def test_is_configured_false_without_provider_id() -> None:
+    selector = ModelSelector(
+        SelectorConfig(primary=ProviderConfig(provider="", model="", api_key=""))
+    )
+    assert selector.is_configured is False
+
+
+def test_is_configured_true_for_keyless_local_provider() -> None:
+    selector = ModelSelector(
+        SelectorConfig(primary=ProviderConfig(provider="ollama", model="llama3", api_key=""))
+    )
+    assert selector.is_configured is True
+
+
+def test_resolve_raises_not_configured_instead_of_building_keyless_provider() -> None:
+    selector = ModelSelector(
+        SelectorConfig(primary=ProviderConfig(provider="openrouter", model="m", api_key=""))
+    )
+    with pytest.raises(ProviderNotConfiguredError) as exc_info:
+        selector.resolve()
+    # Subclasses ProviderBuildError so existing resolve() handlers degrade the same.
+    assert isinstance(exc_info.value, ProviderBuildError)
+
+
+def test_sync_primary_transitions_unconfigured_selector_live() -> None:
+    selector = ModelSelector(
+        SelectorConfig(primary=ProviderConfig(provider="openrouter", model="m", api_key=""))
+    )
+    assert selector.is_configured is False
+
+    selector.sync_primary(ProviderConfig(provider="openrouter", model="m", api_key="test-key"))
+
+    assert selector.is_configured is True
+    assert selector.resolve() is not None


### PR DESCRIPTION
## Scope

A gateway that boots before any LLM credentials exist can never acquire a provider without a full restart. `build_services` skipped constructing the `ModelSelector` when no usable key was present, while every hot-apply path (`config.set`/`patch`/`apply`/`reload`, onboarding save) syncs provider changes by mutating the *existing* selector in place (`sync_primary`) — with no selector, `_sync_provider_selector` silently no-ops in both `rpc_config` and `rpc_onboarding`. The operator experience was a trap: onboarding saves the key, reports `restart_required=False`, its connectivity probe passes, yet every turn keeps failing with "No provider available" until the gateway is restarted.

Fix: `build_services` now always constructs the selector. Without a usable key it starts **unconfigured** (`ModelSelector.is_configured`, mirroring the old boot gate: provider id set, and a key present unless the provider spec requires none). Every boot-time holder — TurnRunner, per-request RPC contexts, session flush, auto-propose — therefore shares the one selector object, and the existing `sync_primary` hot-apply brings it live in place, cold boot or not.

Guard rails for the new unconfigured state:
- `resolve()` refuses with `ProviderNotConfiguredError` (a `ProviderBuildError` subclass, so every existing resolve() error handler degrades identically) — keyless boots build no request and make no outbound call.
- The turn loop maps it to the same clean `no_provider` failure as before.
- Status endpoints, `models.list`, and the provider model-probe keep their pre-fix "no provider" readouts until configuration, instead of advertising an unusable provider id.
- Boot logs `build_services.provider_pending_configuration` (with a hot-apply hint) instead of staying silent.

- Branch target: `main`
- Linked issue: None
- Release-note status: user-visible — configuring the first provider key via the Web UI/onboarding or `opensquilla gateway reload` now applies live on a gateway that booted without credentials; previously this required a gateway restart despite the UI reporting success.
- Third-party origin: none.

## Tests

- `uv run ruff check src tests` / `uv run mypy src/opensquilla` — clean; `uv build --wheel` — clean.
- Full suite: 12139 passed, 113 skipped; the 13 local failures are the known environment-only set (real-terminal TUI, macOS seatbelt execution, docker-dependent exp scripts), identical on clean `main`.
- New `tests/test_gateway/test_cold_start_provider_hot_apply.py`: cold TurnRunner yields `no_provider` cleanly; the `rpc_config` and `rpc_onboarding` syncs each bring the shared selector live without restart; status hides the provider until configured; `build_services` on a keyless boot yields an unconfigured (not `None`) selector that `sync_primary` activates.
- New selector-state unit tests: `is_configured` semantics (keyless key-requiring provider → False, empty provider id → False, keyless local provider → True), `resolve()` raising `ProviderNotConfiguredError`, and the unconfigured→live `sync_primary` transition.
- Manual end-to-end (the reported repro): gateway started from an empty state dir with no env keys → chat returns "No provider available"; write a key into `[llm]` and run `opensquilla gateway reload` (no restart) → the next turn reaches the provider (deliberately fake key → provider HTTP 401; a real key completes normally) and `/api/system/status` flips from no provider to the configured id.

## Safety notes

No new outbound behavior: an unconfigured selector refuses `resolve()` before any request is constructed, so keyless gateways make no empty-credential API calls. No config, RPC field, or CLI surface changes; the only new observable is the boot log event and the (previously impossible) live activation path.
