### PR TITLE
Fail code-task fast on unusable provider credentials

### DIFF
--- a/src/opensquilla/contrib/codetask/adapter.py
+++ b/src/opensquilla/contrib/codetask/adapter.py
@@ -245,6 +245,7 @@ class LocalAdapter:
         duration = time.time() - start
 
         envelope = _parse_json_envelope(stdout)
+        envelope_errors = [e for e in ((envelope or {}).get("errors") or []) if isinstance(e, dict)]
         if stalled:
             finish = "stalled"
         elif timed_out:
@@ -256,10 +257,9 @@ class LocalAdapter:
         else:
             status = envelope.get("status")
             text = (envelope.get("text") or "").strip()
-            errors = envelope.get("errors") or []
             if status == "ok" and text:
                 finish = "stop"
-            elif errors:
+            elif envelope_errors:
                 finish = "error"
             else:
                 finish = "empty"
@@ -274,6 +274,7 @@ class LocalAdapter:
             session_id=(envelope or {}).get("session_key"),
             usage=usage,
             error=stall_error or None,
+            errors=envelope_errors,
         )
 
 

--- a/src/opensquilla/contrib/codetask/preflight.py
+++ b/src/opensquilla/contrib/codetask/preflight.py
@@ -1,0 +1,158 @@
+"""Provider credential checks for code-task, before and during a run.
+
+A code-task run clones the repo, installs dependencies, and drives an agent
+for many minutes. When the configured provider has no usable credential the
+subagent only discovers it once it starts calling the model — after the
+expensive setup — and the failure surfaces as a misleading "no valid
+verification manifest" after burning retries. Two cheap guards fix that:
+
+* ``provider_preflight`` runs one throwaway request against the SAME provider
+  config the subagent will use, before any clone, and blocks the run with an
+  actionable message when the credential is missing or rejected.
+* ``provider_block_reason`` inspects the agent's JSON envelope so a credential
+  failure that happens mid-run (e.g. a balance hitting zero) stops honestly
+  instead of being retried into an opaque verification error.
+
+Only unambiguous credential/config failures block. Transient transport errors,
+model-not-found, rate limits, and unknown failures fail open — the run
+proceeds and its own error handling takes over — so a probe blip never turns a
+workable run into a hard stop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import structlog
+
+from opensquilla.contrib.codetask.agent_config import AgentConfigBundle
+from opensquilla.onboarding.probe import ProviderProbeResult, probe_llm_provider
+from opensquilla.provider.failures import ProviderFailureKind
+
+log = structlog.get_logger(__name__)
+
+# Probe failure kinds that mean "this credential cannot work" — block the run.
+# Everything else (transport_transient, model_not_found, rate_limited, unknown,
+# …) fails open.
+_CREDENTIAL_BLOCK_KINDS = frozenset(
+    {ProviderFailureKind.AUTH_INVALID.value, ProviderFailureKind.INSUFFICIENT_CREDITS.value}
+)
+
+# Envelope error codes/kinds from the child agent that mean the same thing.
+_CREDENTIAL_BLOCK_CODES = frozenset(
+    {
+        "no_provider",  # no provider/key configured at all
+        "401",
+        "403",
+        "auth_invalid",
+        "402",
+        "insufficient_credits",
+    }
+)
+
+
+def _effective_provider_config(
+    bundle: AgentConfigBundle, model_override: str
+) -> tuple[str, str, str, str, str] | None:
+    """Resolve (provider, model, api_key, base_url, proxy) the subagent will use.
+
+    Returns ``None`` if the bundle carries no usable ``[llm]`` (nothing to
+    probe). Mirrors the child's own resolution: build the config from the
+    per-run payload, then apply the same env/credential precedence.
+    """
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
+
+    try:
+        cfg = GatewayConfig(**bundle.payload)
+    except Exception:  # already validated in load_agent_config_bundle; defensive
+        return None
+    runtime = resolve_llm_runtime_config(cfg)
+    provider = (runtime.provider or "").strip()
+    if not provider:
+        return None
+    model = model_override.strip() or (runtime.model or "").strip()
+    # The child receives an explicit key through OPENSQUILLA_LLM_API_KEY (kept
+    # out of the on-disk payload); otherwise the key resolves from the env var
+    # named by api_key_env / the provider spec, which resolve_llm_runtime_config
+    # already applied.
+    api_key = bundle.child_env.get("OPENSQUILLA_LLM_API_KEY", "") or (runtime.api_key or "")
+    return provider, model, api_key, runtime.base_url or "", runtime.proxy or ""
+
+
+def provider_preflight(bundle: AgentConfigBundle, model_override: str = "") -> tuple[bool, str]:
+    """Return (ok, reason). ``ok`` False blocks the run with ``reason``.
+
+    Runs one live one-token request. Keyless providers (ollama, lm_studio, …)
+    and un-probeable configs pass without a network call.
+    """
+    from opensquilla.provider.registry import get_provider_spec
+
+    resolved = _effective_provider_config(bundle, model_override)
+    if resolved is None:
+        return True, ""
+    provider, model, api_key, base_url, proxy = resolved
+
+    try:
+        spec = get_provider_spec(provider)
+    except ValueError:
+        # Unknown provider id: not our call to make here — let the run surface it.
+        return True, ""
+    if not spec.requires_api_key():
+        return True, ""  # keyless / local provider — nothing to probe
+    if not model:
+        # Can't probe without a model; the run itself will report a bad config.
+        return True, ""
+
+    try:
+        probe: ProviderProbeResult = asyncio.run(
+            probe_llm_provider(
+                provider_id=provider,
+                model=model,
+                api_key=api_key,
+                base_url=base_url,
+                proxy=proxy,
+            )
+        )
+    except ValueError:
+        return True, ""  # validation-level probe issue — fail open
+    except Exception as exc:  # never let a probe bug block a run
+        log.warning("codetask.preflight.probe_error", error=str(exc))
+        return True, ""
+
+    if probe.ok:
+        return True, ""
+    if probe.failure_kind in _CREDENTIAL_BLOCK_KINDS:
+        return False, (
+            f"code-task's provider '{provider}' cannot authenticate for model "
+            f"'{model}': {probe.message} Configure a working provider (run "
+            "`opensquilla onboard`) or set that provider's API key, then retry."
+        )
+    # Non-credential failure (transport blip, model-not-found, …): fail open.
+    log.info(
+        "codetask.preflight.non_blocking_failure",
+        provider=provider,
+        failure_kind=probe.failure_kind,
+    )
+    return True, ""
+
+
+def provider_block_reason(errors: list[dict]) -> str | None:
+    """Actionable message if the agent's envelope errors are credential-class.
+
+    ``errors`` is the ``errors`` array from the agent JSON envelope (each item
+    ``{message, code}``). Returns ``None`` for non-credential errors so the run
+    keeps its existing verification path.
+    """
+    for err in errors:
+        code = str(err.get("code") or "").strip().lower()
+        if code in _CREDENTIAL_BLOCK_CODES:
+            message = str(err.get("message") or "").strip()
+            detail = f": {message}" if message else ""
+            return (
+                "code-task's provider rejected the request (the configured "
+                f"provider/credential is missing or invalid){detail} Configure a "
+                "working provider (run `opensquilla onboard`) or set that "
+                "provider's API key, then retry."
+            )
+    return None

--- a/src/opensquilla/contrib/codetask/preflight.py
+++ b/src/opensquilla/contrib/codetask/preflight.py
@@ -38,17 +38,11 @@ _CREDENTIAL_BLOCK_KINDS = frozenset(
     {ProviderFailureKind.AUTH_INVALID.value, ProviderFailureKind.INSUFFICIENT_CREDITS.value}
 )
 
-# Envelope error codes/kinds from the child agent that mean the same thing.
-_CREDENTIAL_BLOCK_CODES = frozenset(
-    {
-        "no_provider",  # no provider/key configured at all
-        "401",
-        "403",
-        "auth_invalid",
-        "402",
-        "insufficient_credits",
-    }
-)
+# Envelope error codes from the child agent that mean the same thing. The
+# engine emits "no_provider" (provider_and_tools_stage) and the HTTP status as
+# a string ("401"/"402"/"403", from the provider adapters); these are the codes
+# that actually reach result.errors.
+_CREDENTIAL_BLOCK_CODES = frozenset({"no_provider", "401", "402", "403"})
 
 
 def _effective_provider_config(
@@ -66,6 +60,12 @@ def _effective_provider_config(
     try:
         cfg = GatewayConfig(**bundle.payload)
     except Exception:  # already validated in load_agent_config_bundle; defensive
+        return None
+    # Cross-provider router tiers resolve credentials per tier from
+    # [llm_profiles]/pools that a primary-provider probe cannot see, and may
+    # bypass the primary entirely — probing only the primary would risk a
+    # false block. Skip the preflight for those (preview) configs.
+    if bool(getattr(getattr(cfg, "squilla_router", None), "cross_provider_tiers", False)):
         return None
     runtime = resolve_llm_runtime_config(cfg)
     provider = (runtime.provider or "").strip()
@@ -145,6 +145,8 @@ def provider_block_reason(errors: list[dict]) -> str | None:
     keeps its existing verification path.
     """
     for err in errors:
+        if not isinstance(err, dict):
+            continue
         code = str(err.get("code") or "").strip().lower()
         if code in _CREDENTIAL_BLOCK_CODES:
             message = str(err.get("message") or "").strip()

--- a/src/opensquilla/contrib/codetask/runner.py
+++ b/src/opensquilla/contrib/codetask/runner.py
@@ -24,6 +24,7 @@ from opensquilla.contrib.codetask import config, envprobe, workspace
 from opensquilla.contrib.codetask.adapter import LocalAdapter, _kill_process_group
 from opensquilla.contrib.codetask.agent_config import AgentConfigError, load_agent_config_bundle
 from opensquilla.contrib.codetask.inputs import InputError, TaskSpec, render_task_md, resolve_task
+from opensquilla.contrib.codetask.preflight import provider_block_reason, provider_preflight
 from opensquilla.contrib.codetask.types import TaskResult, TaskState
 from opensquilla.contrib.codetask.verification import verify
 
@@ -247,6 +248,29 @@ def solve(
         )
         blocked.final_failure_reason = detail
         config.run_dir(run_id).mkdir(parents=True, exist_ok=True)
+        _persist(blocked)
+        return blocked
+
+    # Credential preflight: one throwaway request against the SAME provider the
+    # subagent will use, before the minutes-long clone/install, so a missing or
+    # rejected key fails loud and actionable now instead of opaquely mid-run.
+    config.run_dir(run_id).mkdir(parents=True, exist_ok=True)
+    _write_status(run_id, "provider_preflight", repo=repo)
+    preflight_ok, preflight_reason = provider_preflight(agent_config, model)
+    if not preflight_ok:
+        blocked = TaskResult(
+            task_slug="task",
+            run_id=run_id,
+            state=TaskState.ENVIRONMENT_BLOCKED,
+            repo=repo,
+            base_ref="",
+            branch="",
+            source="config",
+            artifact_dir=str(config.run_dir(run_id)),
+            error=preflight_reason,
+        )
+        blocked.final_failure_reason = preflight_reason
+        _write_status(run_id, "provider_preflight_failed", repo=repo, error=preflight_reason)
         _persist(blocked)
         return blocked
 
@@ -488,6 +512,23 @@ def solve(
                 attempt=attempt,
                 max_attempts=max_attempts,
                 error=result.error,
+            )
+            break
+        # A credential/config-class provider error is not retryable: stop with
+        # the real reason instead of falling through to verification (which
+        # would report a misleading "no valid manifest" and burn more attempts).
+        credential_block = provider_block_reason(getattr(outcome, "errors", []))
+        if outcome_finish_reason == "error" and credential_block is not None:
+            result.state = TaskState.ENVIRONMENT_BLOCKED
+            result.error = credential_block
+            result.final_failure_reason = credential_block
+            _write_status(
+                rid,
+                "provider_error",
+                run_dir=str(artifact_dir),
+                attempt=attempt,
+                max_attempts=max_attempts,
+                error=credential_block,
             )
             break
 

--- a/src/opensquilla/contrib/codetask/types.py
+++ b/src/opensquilla/contrib/codetask/types.py
@@ -106,6 +106,10 @@ class AgentOutcome:
     session_id: str | None = None
     usage: dict = field(default_factory=dict)
     error: str | None = None
+    # Provider/tool errors from the agent's JSON envelope (each {message, code});
+    # the child exits 0 in --json mode even when a turn errored, so this is the
+    # only channel carrying the real reason (e.g. code "no_provider"/"402").
+    errors: list[dict] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -43,6 +43,11 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     # schema before spawning (lazy import; gateway never imports contrib, so
     # no cycle).
     ("contrib", "gateway"),
+    # code-task's credential preflight reuses the onboarding provider probe and
+    # the provider failure taxonomy / registry to classify results; neither
+    # onboarding nor provider imports contrib, so no cycle.
+    ("contrib", "onboarding"),
+    ("contrib", "provider"),
     # The diagnostics-bundle shim composes gateway redaction, the offline
     # doctor, and onboarding config resolution lazily for the bundle
     # generator; a top-level module (permissions.py precedent) so the

--- a/tests/test_contrib/test_codetask/conftest.py
+++ b/tests/test_contrib/test_codetask/conftest.py
@@ -2,6 +2,25 @@
 
 import pytest
 
+from opensquilla.contrib.codetask import preflight as _preflight
+from opensquilla.onboarding.probe import ProviderProbeResult
+
+
+@pytest.fixture(autouse=True)
+def _stub_provider_probe(monkeypatch):
+    """Make the credential preflight offline-safe by default.
+
+    The default suite runs keyless (the global conftest strips provider keys),
+    so a real probe would classify every run as auth_invalid and block it
+    before clone. Stub the network round-trip to succeed; tests that exercise
+    the preflight override this with their own probe result.
+    """
+
+    async def _ok(*, provider_id, model, **_kw):
+        return ProviderProbeResult(ok=True, provider_id=provider_id, model=model)
+
+    monkeypatch.setattr(_preflight, "probe_llm_provider", _ok)
+
 
 @pytest.fixture(autouse=True)
 def _isolate_agent_config_discovery(monkeypatch, tmp_path_factory):

--- a/tests/test_contrib/test_codetask/test_codetask_preflight.py
+++ b/tests/test_contrib/test_codetask/test_codetask_preflight.py
@@ -98,6 +98,23 @@ def test_preflight_skips_keyless_provider(monkeypatch):
     assert calls == []  # keyless: no network probe at all
 
 
+def test_preflight_skips_cross_provider_tier_configs(monkeypatch):
+    # Cross-provider tiers resolve credentials per tier from profiles/pools the
+    # primary-provider probe can't see, so the preflight must not false-block
+    # a keyless primary there — skip without probing.
+    calls = []
+    _probe(monkeypatch, calls=calls)
+    bundle = _bundle(
+        {
+            "llm": {"provider": "deepseek", "model": "deepseek-chat"},
+            "squilla_router": {"enabled": True, "cross_provider_tiers": True},
+        }
+    )
+    ok, reason = provider_preflight(bundle)
+    assert ok is True and reason == ""
+    assert calls == []
+
+
 def test_preflight_fails_open_on_probe_exception(monkeypatch):
     async def _boom(**_kw):
         raise RuntimeError("probe exploded")
@@ -109,13 +126,16 @@ def test_preflight_fails_open_on_probe_exception(monkeypatch):
 
 
 def test_provider_block_reason_matches_credential_codes():
+    # The engine emits code="no_provider" and str(status_code) for HTTP errors.
     assert provider_block_reason([{"code": "no_provider", "message": "none"}]) is not None
     assert provider_block_reason([{"code": "402", "message": "no credits"}]) is not None
     assert provider_block_reason([{"code": "401"}]) is not None
-    assert provider_block_reason([{"code": "auth_invalid"}]) is not None
+    assert provider_block_reason([{"code": "403"}]) is not None
 
 
 def test_provider_block_reason_ignores_non_credential_codes():
     assert provider_block_reason([{"code": "429", "message": "rate limited"}]) is None
     assert provider_block_reason([{"code": "tool_error"}]) is None
     assert provider_block_reason([]) is None
+    # Non-dict items are tolerated (defensive) rather than crashing.
+    assert provider_block_reason(["oops", None]) is None

--- a/tests/test_contrib/test_codetask/test_codetask_preflight.py
+++ b/tests/test_contrib/test_codetask/test_codetask_preflight.py
@@ -1,0 +1,121 @@
+"""Unit tests for the code-task provider preflight + mid-run error mapping."""
+
+from opensquilla.contrib.codetask import preflight as preflight_mod
+from opensquilla.contrib.codetask.agent_config import build_per_run_agent_config
+from opensquilla.contrib.codetask.preflight import provider_block_reason, provider_preflight
+from opensquilla.onboarding.probe import ProviderProbeResult
+from opensquilla.provider.failures import ProviderFailureKind
+
+_TEMPLATE = {
+    "workspace_strict": False,
+    "sandbox": {"sandbox": False},
+    "tools": {"deny": ["memory*"]},
+    "meta_skill": {"enabled": False},
+}
+
+
+def _bundle(user):
+    return build_per_run_agent_config(dict(_TEMPLATE), user)
+
+
+def _probe(monkeypatch, result=None, *, calls=None):
+    async def _fake(*, provider_id, model, **kw):
+        if calls is not None:
+            calls.append({"provider_id": provider_id, "model": model, **kw})
+        return result or ProviderProbeResult(ok=True, provider_id=provider_id, model=model)
+
+    monkeypatch.setattr(preflight_mod, "probe_llm_provider", _fake)
+
+
+def test_preflight_passes_on_ok_probe(monkeypatch):
+    calls = []
+    _probe(monkeypatch, calls=calls)
+    bundle = _bundle({"llm": {"provider": "deepseek", "model": "deepseek-chat", "api_key": "sk-x"}})
+    ok, reason = provider_preflight(bundle)
+    assert ok is True and reason == ""
+    # Probes the operator's resolved provider/model with the transported key.
+    assert calls[0]["provider_id"] == "deepseek"
+    assert calls[0]["model"] == "deepseek-chat"
+    assert calls[0]["api_key"] == "sk-x"
+
+
+def test_preflight_blocks_on_missing_key(monkeypatch):
+    _probe(
+        monkeypatch,
+        ProviderProbeResult(
+            ok=False,
+            provider_id="deepseek",
+            model="deepseek-chat",
+            failure_kind=ProviderFailureKind.AUTH_INVALID.value,
+            message="No API key available (checked $DEEPSEEK_API_KEY).",
+        ),
+    )
+    bundle = _bundle({"llm": {"provider": "deepseek", "model": "deepseek-chat"}})
+    ok, reason = provider_preflight(bundle)
+    assert ok is False
+    assert "deepseek" in reason and "opensquilla onboard" in reason
+
+
+def test_preflight_blocks_on_insufficient_credits(monkeypatch):
+    _probe(
+        monkeypatch,
+        ProviderProbeResult(
+            ok=False,
+            provider_id="deepseek",
+            model="deepseek-chat",
+            failure_kind=ProviderFailureKind.INSUFFICIENT_CREDITS.value,
+            message="insufficient balance",
+        ),
+    )
+    bundle = _bundle({"llm": {"provider": "deepseek", "model": "deepseek-chat", "api_key": "k"}})
+    ok, _reason = provider_preflight(bundle)
+    assert ok is False
+
+
+def test_preflight_fails_open_on_transient(monkeypatch):
+    # A transport blip must not block a run that might otherwise succeed.
+    _probe(
+        monkeypatch,
+        ProviderProbeResult(
+            ok=False,
+            provider_id="deepseek",
+            model="deepseek-chat",
+            failure_kind=ProviderFailureKind.TRANSPORT_TRANSIENT.value,
+            message="timeout",
+        ),
+    )
+    bundle = _bundle({"llm": {"provider": "deepseek", "model": "deepseek-chat", "api_key": "k"}})
+    ok, reason = provider_preflight(bundle)
+    assert ok is True and reason == ""
+
+
+def test_preflight_skips_keyless_provider(monkeypatch):
+    calls = []
+    _probe(monkeypatch, calls=calls)
+    bundle = _bundle({"llm": {"provider": "ollama", "model": "llama3", "base_url": "http://x"}})
+    ok, reason = provider_preflight(bundle)
+    assert ok is True and reason == ""
+    assert calls == []  # keyless: no network probe at all
+
+
+def test_preflight_fails_open_on_probe_exception(monkeypatch):
+    async def _boom(**_kw):
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(preflight_mod, "probe_llm_provider", _boom)
+    bundle = _bundle({"llm": {"provider": "deepseek", "model": "deepseek-chat", "api_key": "k"}})
+    ok, _reason = provider_preflight(bundle)
+    assert ok is True
+
+
+def test_provider_block_reason_matches_credential_codes():
+    assert provider_block_reason([{"code": "no_provider", "message": "none"}]) is not None
+    assert provider_block_reason([{"code": "402", "message": "no credits"}]) is not None
+    assert provider_block_reason([{"code": "401"}]) is not None
+    assert provider_block_reason([{"code": "auth_invalid"}]) is not None
+
+
+def test_provider_block_reason_ignores_non_credential_codes():
+    assert provider_block_reason([{"code": "429", "message": "rate limited"}]) is None
+    assert provider_block_reason([{"code": "tool_error"}]) is None
+    assert provider_block_reason([]) is None

--- a/tests/test_contrib/test_codetask/test_codetask_retry_loop.py
+++ b/tests/test_contrib/test_codetask/test_codetask_retry_loop.py
@@ -214,3 +214,59 @@ def test_solve_blocks_early_on_invalid_agent_config(monkeypatch, tmp_path):
     status = json.loads((run_dir / "status.json").read_text(encoding="utf-8"))
     assert status["phase"] == "completed"
     assert "tier_profile mismatch" in status["error"]
+
+
+def test_solve_blocks_before_clone_on_preflight_failure(monkeypatch, tmp_path):
+    """A rejected/missing credential fails the run before the clone, with the
+    actionable reason persisted for the calling agent."""
+    import json
+
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setattr(
+        runner, "provider_preflight", lambda *a, **k: (False, "provider X has no usable key")
+    )
+    cloned = []
+    monkeypatch.setattr(runner.workspace, "prepare_repo", lambda *a, **k: cloned.append(1))
+
+    res = runner.solve(repo="/tmp/x", task="do")
+
+    assert res.state == TaskState.ENVIRONMENT_BLOCKED
+    assert res.error == "provider X has no usable key"
+    assert res.final_failure_reason == res.error
+    assert cloned == []
+    run_dir = runner.config.run_dir(res.run_id)
+    status = json.loads((run_dir / "status.json").read_text(encoding="utf-8"))
+    assert status["phase"] == "completed"
+    assert "no usable key" in status["error"]
+
+
+class _ProviderErrorAdapter:
+    def __init__(self, **kw):
+        pass
+
+    def run(self, prompt, *, repo, scratch_dir, artifact_dir, **kw):
+        (artifact_dir / "agent_stdout.log").write_text("boom", encoding="utf-8")
+        return SimpleNamespace(
+            timeout=False,
+            finish_reason="error",
+            error=None,
+            errors=[{"code": "402", "message": "insufficient balance"}],
+            usage={},
+            duration_seconds=1.0,
+        )
+
+
+def test_solve_maps_midrun_credential_error_to_blocked(monkeypatch, tmp_path):
+    """A credential-class provider error mid-run stops as ENVIRONMENT_BLOCKED
+    with the real reason, instead of retrying into a misleading manifest error."""
+    _wire(monkeypatch, tmp_path, [])  # verify is never reached
+    monkeypatch.setattr(runner, "LocalAdapter", _ProviderErrorAdapter)
+    verify_calls = []
+    monkeypatch.setattr(runner, "verify", lambda **k: verify_calls.append(1))
+
+    res = runner.solve(repo="/tmp/x", task="do", max_attempts=3, timeout=3600)
+
+    assert res.state == TaskState.ENVIRONMENT_BLOCKED
+    assert res.attempts == 1  # not retried
+    assert verify_calls == []  # short-circuited before verification
+    assert "provider" in (res.error or "").lower()


### PR DESCRIPTION
## Scope

Follow-up to #551 (provider inheritance). Even with the subagent now using the configured provider, a missing or out-of-balance credential is still discovered late and reported opaquely: the run clones the repo, installs dependencies, boots the subagent, gets a 401/402, retries, and finally reports a misleading `invalid_acceptance_test` ("agent did not emit a valid verification.json manifest"). This PR makes credential failures fail fast and honestly.

- **Pre-clone credential preflight** (`contrib/codetask/preflight.py`): before any clone, `runner.solve` runs one throwaway one-token request (reusing `onboarding.probe.probe_llm_provider`) against the *same* provider config the subagent will use — resolved from the assembled per-run bundle (provider, model, base URL, and the key transported via `OPENSQUILLA_LLM_API_KEY` or resolved from the provider's env var). On a credential-class failure (missing key / `auth_invalid` / `insufficient_credits`) the run stops with `ENVIRONMENT_BLOCKED` and an actionable message naming the provider, the model, and how to fix it. Keyless providers (ollama, lm_studio, …) and un-probeable configs skip the network entirely.
- **Fail-open by design**: only unambiguous credential/config failures block. Transport blips, `model_not_found`, rate limits, and unknown failures let the run proceed, so a probe hiccup never turns a workable run into a hard stop.
- **Honest mid-run errors**: the agent's JSON envelope errors (the child exits 0 in `--json` mode even on error) are now threaded into `AgentOutcome.errors` — previously dropped. When a credential-class provider error surfaces mid-run (e.g. a balance hitting zero after the preflight passed), the run stops as `ENVIRONMENT_BLOCKED` with the real reason instead of falling through to verification and retrying into the misleading manifest error.
- New status phases `provider_preflight` / `provider_preflight_failed` / `provider_error` flow through the existing `status.json` → `process` tool → main-agent channel (no new fields; `error`/`final_failure_reason` carry the message). No new `TaskState`.

New architecture edges `contrib → onboarding` and `contrib → provider` (both lazy/acyclic; neither package imports contrib) are added to the import contract.

## Branch target

`main`. This builds on #551 (provider inheritance) — merge that first. The two PR2 commits here are **"Fail code-task fast on unusable provider credentials"** and **"Preflight review hardening: skip cross-provider-tier configs"**; the first two commits (**"Make code-task subagents inherit the configured provider"**, **"Address review: …"**) are #551 and drop out of this diff once it merges.

## Linked issue

Refs #541, #499 (completes the "provider errors surfaced but root cause not obvious" half of #499).

## Release note

Coding mode's code-task now checks the configured provider's credential before starting a run and stops immediately with an actionable message when it's missing or rejected, instead of failing opaquely after cloning and retrying. Credential failures that happen mid-run are also reported honestly rather than as a generic verification error.

## Tests

- `uv run ruff check src tests`, `uv run mypy src/opensquilla`, `uv build --wheel` — clean.
- `uv run pytest -q` — full suite green apart from the pre-existing environment-specific failures documented in #551.
- New `tests/test_contrib/test_codetask/test_codetask_preflight.py` (probe pass/block/keyless-skip/fail-open/exception, envelope-code classification) and runner tests for the pre-clone block (no clone happens) and the mid-run credential→`ENVIRONMENT_BLOCKED` mapping (not retried, verification never reached). A package `conftest.py` stubs the probe network call so the default offline suite neither blocks nor reaches the network.
- Manually exercised the real preflight end to end: a `deepseek` operator config with no key resolves provider+model and blocks before clone with the actionable reason.

## Safety notes

The preflight makes one minimal (max_tokens=1) live request to the operator's own configured provider; no new data leaves the machine beyond what the run would already send. Probe errors are redacted by the existing probe layer and never persisted.

## Third-party origin

None; original work in this repository.
