### PR TITLE
Use TokenRhythm when no LLM provider is configured

### DIFF
--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -96,18 +96,18 @@ frontend = "vue"
 # artifact_disk_budget_bytes = 536870912
 
 [llm]
-provider = "openrouter"
-model = "deepseek/deepseek-v4-pro"
-# api_key = ""          # OpenRouter API key; env OPENROUTER_API_KEY also works
-base_url = "https://openrouter.ai/api/v1"
+provider = "tokenrhythm"
+model = "deepseek-v4-pro"
+# api_key = ""          # TokenRhythm API key; env TOKENRHYTHM_API_KEY also works
+base_url = "https://tokenrhythm.studio/v1"
 # proxy = ""            # e.g. http://127.0.0.1:7890
 
 # Provider quick reference. Support levels marked compat_mock_verified are
 # verified by local mocked-contract tests, not by live vendor calls.
 #
 # provider      env var                 default base_url
-# openrouter    OPENROUTER_API_KEY       https://openrouter.ai/api/v1
 # tokenrhythm   TOKENRHYTHM_API_KEY      https://tokenrhythm.studio/v1
+# openrouter    OPENROUTER_API_KEY       https://openrouter.ai/api/v1
 # openai        OPENAI_API_KEY           https://api.openai.com/v1
 # openai_responses OPENAI_API_KEY        https://api.openai.com/v1  (native Responses-API shape; chat+responses)
 # anthropic     ANTHROPIC_API_KEY        https://api.anthropic.com
@@ -371,41 +371,38 @@ upgrade_to_c3_compaction_enabled = true
 # that executes on the active provider (or the default tier).
 # tier_provider_mismatch = "route"  # route | veto
 
+# TokenRhythm serves every model in reasoning-streaming mode and rejects
+# thinking-toggle request fields, so these tiers set no thinking_level.
 [squilla_router.tiers.c0]
-provider = "openrouter"
-model = "deepseek/deepseek-v4-flash"
+provider = "tokenrhythm"
+model = "deepseek-v4-flash"
 description = "Fast DeepSeek V4 Flash route for trivial chat, short rewrites, extraction, and low-risk simple Q&A"
 supports_image = false
-thinking_level = "high"
 
 [squilla_router.tiers.c1]
-provider = "openrouter"
-model = "deepseek/deepseek-v4-pro"
+provider = "tokenrhythm"
+model = "deepseek-v4-pro"
 description = "Default balanced text model for normal agent work, coding assistance, debugging, and moderate analysis"
 supports_image = false
-thinking_level = "high"
 
 [squilla_router.tiers.c2]
-provider = "openrouter"
-model = "z-ai/glm-5.2"
-description = "Stronger GLM 5.2 route for multi-step coding, structured reasoning, larger context synthesis, and harder analysis"
+provider = "tokenrhythm"
+model = "glm-5.1"
+description = "Stronger GLM 5.1 route for multi-step coding, structured reasoning, larger context synthesis, and harder analysis"
 supports_image = false
-thinking_level = "high"
 
 [squilla_router.tiers.c3]
-provider = "openrouter"
-model = "z-ai/glm-5.2"
-description = "Highest-tier GLM 5.2 route for difficult planning, deep review, complex debugging, and high-stakes synthesis"
+provider = "tokenrhythm"
+model = "qwen3.7-max"
+description = "Highest-tier Qwen 3.7 Max route with a very large context window for difficult planning, deep review, complex debugging, and high-stakes synthesis"
 supports_image = false
-thinking_level = "high"
 
 [squilla_router.tiers.image_model]
-provider = "openrouter"
-model = "moonshotai/kimi-k2.6"
+provider = "tokenrhythm"
+model = "kimi-k2.6"
 description = "Image model: vision-capable route for user-supplied image attachments, screenshots, diagrams, and visual question answering"
 supports_image = true
 image_only = true
-thinking_level = "medium"
 
 # Example: DashScope profile requires:
 # [llm]

--- a/src/opensquilla/cli/init_cmd.py
+++ b/src/opensquilla/cli/init_cmd.py
@@ -12,6 +12,8 @@ from opensquilla.paths import default_opensquilla_home
 
 def _default_model_for_provider(provider: str) -> str:
     normalized = provider.strip().lower()
+    if normalized == "tokenrhythm":
+        return "deepseek-v4-pro"
     if normalized == "openrouter":
         return "deepseek/deepseek-v4-pro"
     if normalized == "deepseek":
@@ -29,8 +31,8 @@ def run_init() -> None:
 
     provider = questionary.select(
         "Choose provider:",
-        choices=["openrouter", "openai", "anthropic", "deepseek", "custom"],
-        default="openrouter",
+        choices=["tokenrhythm", "openrouter", "openai", "anthropic", "deepseek", "custom"],
+        default="tokenrhythm",
     ).ask()
     if not provider:
         raise typer.Exit(1)

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -308,14 +308,23 @@ class TaskRuntimeConfig(BaseModel):
         return value
 
 
+# Pre-tokenrhythm built-in defaults. Configs authored while openrouter was
+# the built-in default may rely on them without naming a provider, so the
+# load-time resolution in ``GatewayConfig._resolve_default_llm_provider``
+# restores this trio whenever such a config is detected.
+LEGACY_DEFAULT_LLM_PROVIDER = "openrouter"
+LEGACY_DEFAULT_LLM_MODEL = "deepseek/deepseek-v4-pro"
+LEGACY_DEFAULT_LLM_BASE_URL = "https://openrouter.ai/api/v1"
+
+
 class LlmProviderConfig(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="OPENSQUILLA_LLM_")
 
-    provider: str = "openrouter"
-    model: str = "deepseek/deepseek-v4-pro"
+    provider: str = "tokenrhythm"
+    model: str = "deepseek-v4-pro"
     api_key: str = ""
     api_key_env: str = ""
-    base_url: str = "https://openrouter.ai/api/v1"
+    base_url: str = "https://tokenrhythm.studio/v1"
     proxy: str = ""  # explicit HTTP proxy URL (e.g. http://127.0.0.1:7890)
     max_tokens: int = 0  # 0 = auto-resolve from model catalog; >0 = explicit override
     # 0 = auto-resolve from model catalog; >0 = explicit context-window override
@@ -1936,6 +1945,101 @@ class GatewayConfig(BaseSettings):
     privacy: PrivacyConfig = Field(default_factory=PrivacyConfig)
     diagnostics_enabled: bool = False
     channel_admin_senders: dict[str, list[str]] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _resolve_default_llm_provider(self) -> GatewayConfig:
+        """Resolve the built-in provider default for configs that never chose one.
+
+        The built-in default is tokenrhythm, but configs authored while
+        openrouter was the default may rely on it without naming a provider.
+        With ``llm.provider`` unset, openrouter intent is detected from
+        provider-coupled fields authored against the old default (an explicit
+        ``model``/``base_url``/``api_key``/``api_key_env``, or a persisted
+        ``squilla_router.tier_profile = "openrouter"``, which validation
+        requires to match the provider) or from the environment carrying only
+        the openrouter credential. Detected intent restores the full legacy
+        trio for whichever of provider/model/base_url is unset; the same
+        model/base_url backfill applies to an explicit ``provider =
+        "openrouter"``, whose unset fields meant the old defaults when they
+        were written. Runs before the router-profile validators so the
+        tier_profile match check sees the resolved provider.
+
+        Resolution never persists: it lands in the load-time sparse-persist
+        baseline, so saves keep the file provider-less and every boot
+        re-resolves against the then-current environment.
+        """
+        llm = self.llm
+        fields_set = set(getattr(llm, "model_fields_set", set()))
+        provider = str(llm.provider or "").strip().lower()
+        if "provider" not in fields_set:
+            profile = str(getattr(self.squilla_router, "tier_profile", "") or "")
+            legacy_intent = bool(
+                {"model", "base_url", "api_key", "api_key_env"} & fields_set
+            ) or profile.strip().lower() == LEGACY_DEFAULT_LLM_PROVIDER
+            env_openrouter = bool(os.environ.get("OPENROUTER_API_KEY", "").strip())
+            env_tokenrhythm = bool(os.environ.get("TOKENRHYTHM_API_KEY", "").strip())
+            if legacy_intent or (env_openrouter and not env_tokenrhythm):
+                provider = LEGACY_DEFAULT_LLM_PROVIDER
+        if provider != LEGACY_DEFAULT_LLM_PROVIDER:
+            return self
+        payload = llm.model_dump(mode="python")
+        payload["provider"] = LEGACY_DEFAULT_LLM_PROVIDER
+        if "model" not in fields_set:
+            payload["model"] = LEGACY_DEFAULT_LLM_MODEL
+        if "base_url" not in fields_set:
+            payload["base_url"] = LEGACY_DEFAULT_LLM_BASE_URL
+        if payload != llm.model_dump(mode="python"):
+            self.llm = LlmProviderConfig(**payload)
+            # The rebuild marks every field explicitly set; restore the
+            # operator's actual field provenance so fresh-install detection
+            # (e.g. onboard's keep-current router gate) still sees a config
+            # that never chose these values.
+            object.__setattr__(self.llm, "__pydantic_fields_set__", fields_set)
+        return self
+
+    @model_validator(mode="after")
+    def _default_squilla_router_tiers_for_tokenrhythm(self) -> GatewayConfig:
+        """Bind the default router ladder to tokenrhythm when it is the provider.
+
+        The ``tiers`` field default is the packaged openrouter preset, which a
+        tokenrhythm turn cannot execute (openrouter model ids on the active
+        provider's credentials). tokenrhythm has no packaged tier_profile —
+        the accepted set is pinned to the legacy nine by the downgrade
+        contract — so when the router is enabled with no profile and the
+        ladder was left at its default, expand the synthesized tokenrhythm
+        preset inline with empty tier models completed from the effective
+        ``llm.model``, the same shape a provider save writes. In-memory only:
+        the load-time sparse-persist baseline keeps it out of config.toml.
+        """
+        router = self.squilla_router
+        if not router or not getattr(router, "enabled", False):
+            return self
+        if getattr(router, "tier_profile", None):
+            return self
+        provider = str(getattr(self.llm, "provider", "") or "").strip().lower()
+        if provider != "tokenrhythm":
+            return self
+        if getattr(router, "tiers", {}) != _default_tiers():
+            return self
+        preset = get_preset(provider)
+        if preset is None or not preset.synthesized:
+            return self
+        tiers = preset.tier_defaults()
+        model = str(getattr(self.llm, "model", "") or "").strip()
+        for tier in tiers.values():
+            if not str(tier.get("model") or "").strip():
+                tier["model"] = model
+        router_fields_set = set(router.model_fields_set)
+        payload = router.model_dump(mode="python")
+        payload["tiers"] = tiers
+        self.squilla_router = SquillaRouterConfig(**payload)
+        # The rebuild marks every field explicitly set; restore the original
+        # provenance so a fresh default config still reads as one (onboard's
+        # keep-current router gate and custom-tiers detection rely on it).
+        object.__setattr__(
+            self.squilla_router, "__pydantic_fields_set__", router_fields_set
+        )
+        return self
 
     @model_validator(mode="after")
     def _default_squilla_router_profile_for_direct_provider(self) -> GatewayConfig:

--- a/src/opensquilla/provider/resolution.py
+++ b/src/opensquilla/provider/resolution.py
@@ -57,6 +57,7 @@ from opensquilla.provider.model_catalog import (
     ModelCatalog,
     resolve_effective_context_window,
 )
+from opensquilla.provider.preset_registry import get_preset
 from opensquilla.provider.registry import UnknownProviderError, get_provider_spec
 
 FieldSource = Literal["default", "catalog", "preset", "config", "session"]
@@ -122,6 +123,31 @@ def _tier_preset_baseline(router_cfg: Any) -> dict[str, Any]:
     return tiers if isinstance(tiers, dict) else {}
 
 
+def _tier_synthesized_baseline(provider: str, model: str) -> dict[str, Any]:
+    """Synthesized-preset ladder for ``provider``, empty models completed.
+
+    Providers without a packaged tier_profile (e.g. tokenrhythm) get their
+    synthesized preset expanded inline — by the gateway's default-tiers
+    validator at load time and by provider saves — with empty tier model
+    slots completed from the effective ``llm.model``. A live tier table
+    matching that shape was derived, not operator-chosen, so it counts as a
+    ``preset`` baseline alongside the tier-profile table.
+    """
+    if not provider:
+        return {}
+    try:
+        preset = get_preset(provider)
+    except Exception:
+        return {}
+    if preset is None or not preset.synthesized:
+        return {}
+    tiers = preset.tier_defaults()
+    for tier in tiers.values():
+        if not str(tier.get("model") or "").strip():
+            tier["model"] = model
+    return tiers
+
+
 def _value_vs_baseline(value: Any, baselines: set[Any]) -> FieldSource:
     return "default" if value in baselines else "config"
 
@@ -150,8 +176,9 @@ def resolve_effective_llm(config: Any, catalog: ModelCatalog) -> dict[str, Resol
         )
 
         # Spec-default provenance: boot fills an unset base_url from the
-        # provider spec (and the class default is itself the openrouter spec
-        # URL), so anything matching either baseline was not operator-chosen.
+        # provider spec (and the class default is itself the default
+        # provider's spec URL), so anything matching either baseline was not
+        # operator-chosen.
         base_url = str(getattr(llm, "base_url", "") or "")
         base_url_baselines = {
             baseline
@@ -191,6 +218,11 @@ def resolve_effective_llm(config: Any, catalog: ModelCatalog) -> dict[str, Resol
     tiers = getattr(router_cfg, "tiers", None)
     if isinstance(tiers, dict):
         baseline_tiers = _tier_preset_baseline(router_cfg)
+        synthesized_tiers = (
+            {}
+            if getattr(router_cfg, "tier_profile", None)
+            else _tier_synthesized_baseline(provider, model)
+        )
         for tier_name in sorted(tiers):
             tier = tiers[tier_name]
             if not isinstance(tier, dict):
@@ -198,12 +230,18 @@ def resolve_effective_llm(config: Any, catalog: ModelCatalog) -> dict[str, Resol
             tier_baseline = baseline_tiers.get(tier_name)
             if not isinstance(tier_baseline, dict):
                 tier_baseline = {}
+            tier_synth = synthesized_tiers.get(tier_name)
+            if not isinstance(tier_synth, dict):
+                tier_synth = {}
             for key in ("provider", "model"):
                 if key not in tier:
                     continue
                 value = tier[key]
                 source: FieldSource = (
-                    "preset" if tier_baseline and tier_baseline.get(key) == value else "config"
+                    "preset"
+                    if (tier_baseline and tier_baseline.get(key) == value)
+                    or (tier_synth and tier_synth.get(key) == value)
+                    else "config"
                 )
                 fields[f"squilla_router.tiers.{tier_name}.{key}"] = ResolvedField(value, source)
 

--- a/tests/test_contracts/test_config_effective_wire.py
+++ b/tests/test_contracts/test_config_effective_wire.py
@@ -38,10 +38,13 @@ FIELD_RECORD_KEYS = frozenset({"value", "source"})
 # but is part of the contract so clients can pre-wire rendering for it.
 ALLOWED_SOURCES = frozenset({"default", "catalog", "preset", "config", "session"})
 
-# Exact field-path set for a default config (default router tiers c0-c3 +
-# image_model). Conscious decision required to change: each entry is an
-# individually vetted non-secret path — renames, removals, AND additions are
-# contract changes that must update clients and this list together.
+# Exact field-path set for a default config (the synthesized tokenrhythm
+# default ladder: text tiers c0-c3, no curated image tier). Tier paths follow
+# whichever tiers the config actually carries; an image_model tier emits its
+# provider/model paths when present. Conscious decision required to change:
+# each entry is an individually vetted non-secret path — renames, removals,
+# AND additions are contract changes that must update clients and this list
+# together.
 EXPECTED_FIELD_PATHS = frozenset(
     {
         "llm.provider",
@@ -59,8 +62,6 @@ EXPECTED_FIELD_PATHS = frozenset(
         "squilla_router.tiers.c2.model",
         "squilla_router.tiers.c3.provider",
         "squilla_router.tiers.c3.model",
-        "squilla_router.tiers.image_model.provider",
-        "squilla_router.tiers.image_model.model",
     }
 )
 
@@ -103,7 +104,10 @@ async def test_no_secret_value_ever_reaches_the_wire(
     monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "state"))
     cfg = GatewayConfig(
         config_path=str(tmp_path / "opensquilla.toml"),
-        llm=LlmProviderConfig(api_key=SYNTHETIC_SECRET),
+        # provider named explicitly: a bare api_key would resolve to the
+        # legacy openrouter default, whose curated ladder adds image_model
+        # paths beyond EXPECTED_FIELD_PATHS.
+        llm=LlmProviderConfig(provider="tokenrhythm", api_key=SYNTHETIC_SECRET),
         channels={
             "channels": [
                 {

--- a/tests/test_contracts/test_llm_ensemble_preservation.py
+++ b/tests/test_contracts/test_llm_ensemble_preservation.py
@@ -114,7 +114,9 @@ def test_router_recommended_save_preserves_llm_ensemble_subtree() -> None:
 
 
 def test_router_openrouter_mix_save_preserves_llm_ensemble_subtree() -> None:
-    cfg = _config_with_custom_ensemble()
+    # openrouter-mix is only valid for the openrouter provider, which is no
+    # longer the built-in default.
+    cfg = _config_with_custom_ensemble(llm={"provider": "openrouter"})
     assert cfg.llm.provider == "openrouter"
     before = _ensemble_subtree_bytes(cfg)
 

--- a/tests/test_contracts/test_onboarding_status.py
+++ b/tests/test_contracts/test_onboarding_status.py
@@ -147,8 +147,14 @@ async def test_router_mode_computation_is_frozen(tmp_path) -> None:
         payload = _status_payload(RpcContext(conn_id="contract", config=cfg))
         return payload["sectionDetails"]["router"]["routerMode"]
 
-    # Default config: openrouter provider, router enabled, no tier_profile.
-    assert mode_for(_synthetic_config(tmp_path)) == "openrouter-mix"
+    # Default config: tokenrhythm provider, router enabled, no tier_profile.
+    assert mode_for(_synthetic_config(tmp_path)) == "custom"
+
+    # Explicit openrouter with no tier_profile is the openrouter-mix alias.
+    assert (
+        mode_for(_synthetic_config(tmp_path, llm={"provider": "openrouter"}))
+        == "openrouter-mix"
+    )
 
     # Router off wins regardless of provider/profile.
     assert (

--- a/tests/test_engine/test_historical_image_followup.py
+++ b/tests/test_engine/test_historical_image_followup.py
@@ -140,7 +140,7 @@ def _message_has_image(message: Message) -> bool:
 async def test_image_followup_routes_vision_and_replays_inline_history_image() -> None:
     manager = _FakeSessionManager()
     key = "agent:main:image-followup-inline"
-    config = GatewayConfig()
+    config = GatewayConfig(llm={"provider": "openrouter"})
     runner = TurnRunner(provider_selector=MagicMock(), session_manager=manager, config=config)
     await manager.create(key)
     await manager.append_message(key, "user", _inline_image_envelope("Describe this image."))
@@ -212,7 +212,7 @@ async def test_image_followup_routes_vision_and_replays_inline_history_image() -
 @pytest.mark.asyncio
 async def test_gate_text_only_followup_does_not_image_route() -> None:
     key = "agent:main:image-followup-gate-text"
-    config = GatewayConfig()
+    config = GatewayConfig(llm={"provider": "openrouter"})
     provider = _GateThenCaptureProvider(
         '{"decision":"text_only","confidence":0.9,"reason":"new coding task"}'
     )
@@ -247,7 +247,7 @@ async def test_gate_text_only_followup_does_not_image_route() -> None:
 
 @pytest.mark.asyncio
 async def test_gate_unknown_recent_fallback_routes_image() -> None:
-    config = GatewayConfig()
+    config = GatewayConfig(llm={"provider": "openrouter"})
     provider = _GateThenCaptureProvider(
         '{"decision":"unknown","confidence":0.2,"reason":"ambiguous pronoun"}'
     )
@@ -281,7 +281,7 @@ async def test_gate_unknown_recent_fallback_routes_image() -> None:
 
 @pytest.mark.asyncio
 async def test_gate_unknown_old_fallback_uses_text_router() -> None:
-    config = GatewayConfig()
+    config = GatewayConfig(llm={"provider": "openrouter"})
     provider = _GateThenCaptureProvider(
         '{"decision":"unknown","confidence":0.2,"reason":"ambiguous but old"}'
     )
@@ -316,7 +316,7 @@ async def test_gate_unknown_old_fallback_uses_text_router() -> None:
 async def test_historical_image_ref_replays_from_real_material_store(tmp_path: Path) -> None:
     manager = _FakeSessionManager()
     key = "agent:main:image-followup-ref"
-    config = GatewayConfig()
+    config = GatewayConfig(llm={"provider": "openrouter"})
     config.attachments.media_root = str(tmp_path / "media")
     runner = TurnRunner(provider_selector=MagicMock(), session_manager=manager, config=config)
     node = await manager.create(key)
@@ -377,7 +377,7 @@ async def test_historical_image_ref_replays_from_real_material_store(tmp_path: P
 async def test_default_sticky_window_keeps_third_followup_active() -> None:
     manager = _FakeSessionManager()
     key = "agent:main:image-followup-third"
-    config = GatewayConfig()
+    config = GatewayConfig(llm={"provider": "openrouter"})
     runner = TurnRunner(provider_selector=MagicMock(), session_manager=manager, config=config)
 
     await manager.create(key)
@@ -403,7 +403,7 @@ async def test_default_sticky_window_keeps_third_followup_active() -> None:
 async def test_image_history_outside_sticky_window_does_not_route_or_replay() -> None:
     manager = _FakeSessionManager()
     key = "agent:main:image-followup-sticky-expired"
-    config = GatewayConfig()
+    config = GatewayConfig(llm={"provider": "openrouter"})
     config.squilla_router.vision_history_lookback_turns = 4
     config.squilla_router.vision_sticky_followup_turns = 1
     runner = TurnRunner(provider_selector=MagicMock(), session_manager=manager, config=config)
@@ -458,7 +458,7 @@ async def test_image_history_outside_sticky_window_does_not_route_or_replay() ->
 async def test_text_model_history_keeps_image_as_marker_not_provider_image() -> None:
     manager = _FakeSessionManager()
     key = "agent:main:image-followup-text-model"
-    config = GatewayConfig()
+    config = GatewayConfig(llm={"provider": "openrouter"})
     runner = TurnRunner(provider_selector=MagicMock(), session_manager=manager, config=config)
     await manager.create(key)
     await manager.append_message(key, "user", _inline_image_envelope("Describe this image."))
@@ -486,7 +486,7 @@ async def test_text_model_history_keeps_image_as_marker_not_provider_image() -> 
 async def test_text_only_followup_does_not_replay_history_image_on_vision_model() -> None:
     manager = _FakeSessionManager()
     key = "agent:main:image-followup-text-only-vision-model"
-    config = GatewayConfig()
+    config = GatewayConfig(llm={"provider": "openrouter"})
     runner = TurnRunner(provider_selector=MagicMock(), session_manager=manager, config=config)
     await manager.create(key)
     await manager.append_message(key, "user", _inline_image_envelope("Describe this image."))

--- a/tests/test_engine/test_vision_followup_gate.py
+++ b/tests/test_engine/test_vision_followup_gate.py
@@ -126,7 +126,7 @@ class _RecordingSelector:
 
 
 def _ctx(message: str, metadata: dict[str, Any] | None = None) -> TurnContext:
-    config = GatewayConfig()
+    config = GatewayConfig(llm={"provider": "openrouter"})
     return TurnContext(
         message=message,
         session_key="agent:main:test",
@@ -209,7 +209,8 @@ async def test_gate_prefers_dedicated_gate_chat_over_primary_provider() -> None:
 
 @pytest.mark.asyncio
 async def test_runtime_gate_chat_uses_configured_lightweight_tier_model() -> None:
-    runner = TurnRunner(provider_selector=None, config=GatewayConfig())
+    config = GatewayConfig(llm={"provider": "openrouter"})
+    runner = TurnRunner(provider_selector=None, config=config)
     selector = _RecordingSelector()
 
     chat, model = runner._make_vision_followup_gate_chat(selector)

--- a/tests/test_engine/turn_runner/test_router_control_replay_event.py
+++ b/tests/test_engine/turn_runner/test_router_control_replay_event.py
@@ -96,12 +96,13 @@ async def test_router_control_replay_event_replays_turn_once(monkeypatch) -> Non
     monkeypatch.setattr(squilla_router_step, "_get_strategy", lambda _cfg: _Strategy())
     provider = _ReplayProvider()
     cfg = GatewayConfig(
+        llm={"provider": "openrouter"},
         squilla_router=SquillaRouterConfig(
             enabled=True,
             rollout_phase="full",
             require_router_runtime=False,
             tiers=_router_tier_profile_defaults("openrouter"),
-        )
+        ),
     )
     runner = TurnRunner(
         provider_selector=_Selector(provider),

--- a/tests/test_gateway/test_router_tier_presets.py
+++ b/tests/test_gateway/test_router_tier_presets.py
@@ -245,7 +245,13 @@ def test_full_default_tree_round_trips_via_to_toml_dict(tmp_path: Path) -> None:
     dump2 = cfg.to_toml_dict()
 
     assert dump2 == dump1
-    assert cfg.squilla_router.tiers == _golden()["openrouter"]
+    # The default tree carries the synthesized tokenrhythm ladder (the
+    # built-in default provider has no packaged tier_profile).
+    tiers = cfg.squilla_router.tiers
+    assert set(tiers) == {"c0", "c1", "c2", "c3"}
+    for tier in tiers.values():
+        assert tier["provider"] == "tokenrhythm"
+        assert tier["model"] == "deepseek-v4-pro"
 
 
 # --- H4: downgrade chokepoint at to_toml_dict --------------------------------

--- a/tests/test_gateway/test_rpc_config_effective.py
+++ b/tests/test_gateway/test_rpc_config_effective.py
@@ -59,8 +59,8 @@ async def test_effective_envelope_and_provenance(cfg: GatewayConfig) -> None:
     result = await rpc_config._handle_config_effective(None, _ctx(cfg))
     assert set(result) == {"fields"}
     fields = result["fields"]
-    assert fields["llm.provider"] == {"value": "openrouter", "source": "default"}
-    assert fields["llm.model"] == {"value": "deepseek/deepseek-v4-pro", "source": "default"}
+    assert fields["llm.provider"] == {"value": "tokenrhythm", "source": "default"}
+    assert fields["llm.model"] == {"value": "deepseek-v4-pro", "source": "default"}
     assert fields["squilla_router.tiers.c1.model"]["source"] == "preset"
     for record in fields.values():
         assert set(record) == {"value", "source"}

--- a/tests/test_gateway_config_default_provider.py
+++ b/tests/test_gateway_config_default_provider.py
@@ -1,0 +1,211 @@
+"""Built-in default provider resolution in GatewayConfig.
+
+The built-in default is tokenrhythm, but configs authored while openrouter
+was the default must keep resolving to openrouter: an unset ``llm.provider``
+falls back to openrouter when provider-coupled fields were explicitly set,
+when ``squilla_router.tier_profile`` pins openrouter, or when the
+environment carries only the openrouter credential. The resolution is
+load-time only and must never be baked into config.toml by unrelated saves.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opensquilla.gateway.config import (
+    LEGACY_DEFAULT_LLM_BASE_URL,
+    LEGACY_DEFAULT_LLM_MODEL,
+    LEGACY_DEFAULT_LLM_PROVIDER,
+    GatewayConfig,
+    _default_tiers,
+)
+
+TOKENRHYTHM_BASE_URL = "https://tokenrhythm.studio/v1"
+
+
+# ---------------------------------------------------------------------------
+# Provider resolution
+# ---------------------------------------------------------------------------
+
+
+def test_keyless_default_resolves_tokenrhythm() -> None:
+    cfg = GatewayConfig()
+    assert cfg.llm.provider == "tokenrhythm"
+    assert cfg.llm.model == "deepseek-v4-pro"
+    assert cfg.llm.base_url == TOKENRHYTHM_BASE_URL
+
+
+def test_openrouter_env_key_alone_keeps_legacy_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    cfg = GatewayConfig()
+    assert cfg.llm.provider == LEGACY_DEFAULT_LLM_PROVIDER
+    assert cfg.llm.model == LEGACY_DEFAULT_LLM_MODEL
+    assert cfg.llm.base_url == LEGACY_DEFAULT_LLM_BASE_URL
+    # The legacy default keeps the packaged openrouter ladder untouched.
+    assert cfg.squilla_router.tiers == _default_tiers()
+
+
+def test_tokenrhythm_env_key_resolves_tokenrhythm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TOKENRHYTHM_API_KEY", "sk_tr_test")
+    cfg = GatewayConfig()
+    assert cfg.llm.provider == "tokenrhythm"
+
+
+def test_both_env_keys_prefer_tokenrhythm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.setenv("TOKENRHYTHM_API_KEY", "sk_tr_test")
+    cfg = GatewayConfig()
+    assert cfg.llm.provider == "tokenrhythm"
+
+
+@pytest.mark.parametrize(
+    "llm_overrides",
+    [
+        {"api_key": "sk-or-raw"},
+        {"api_key_env": "MY_OPENROUTER_KEY"},
+        {"model": "anthropic/claude-sonnet-5"},
+        {"base_url": "https://openrouter.ai/api/v1"},
+    ],
+)
+def test_provider_coupled_fields_without_provider_mean_openrouter(
+    llm_overrides: dict,
+) -> None:
+    # These fields were authored against the pre-tokenrhythm default and must
+    # keep binding to openrouter when the provider was never named.
+    cfg = GatewayConfig(llm=llm_overrides)
+    assert cfg.llm.provider == LEGACY_DEFAULT_LLM_PROVIDER
+    if "model" not in llm_overrides:
+        assert cfg.llm.model == LEGACY_DEFAULT_LLM_MODEL
+    else:
+        assert cfg.llm.model == llm_overrides["model"]
+    if "base_url" not in llm_overrides:
+        assert cfg.llm.base_url == LEGACY_DEFAULT_LLM_BASE_URL
+
+
+def test_openrouter_tier_profile_without_provider_means_openrouter() -> None:
+    # tier_profile must match the provider, so a persisted openrouter profile
+    # from the pre-tokenrhythm era must keep loading (not raise).
+    cfg = GatewayConfig(squilla_router={"tier_profile": "openrouter"})
+    assert cfg.llm.provider == LEGACY_DEFAULT_LLM_PROVIDER
+    assert cfg.squilla_router.tier_profile == "openrouter"
+
+
+def test_explicit_openrouter_backfills_legacy_model_and_base_url() -> None:
+    # provider = "openrouter" written while model/base_url fell back to the
+    # old field defaults must keep meaning those defaults.
+    cfg = GatewayConfig(llm={"provider": "openrouter", "api_key": "x"})
+    assert cfg.llm.model == LEGACY_DEFAULT_LLM_MODEL
+    assert cfg.llm.base_url == LEGACY_DEFAULT_LLM_BASE_URL
+
+
+def test_explicit_openrouter_keeps_explicit_model_and_base_url() -> None:
+    cfg = GatewayConfig(
+        llm={
+            "provider": "openrouter",
+            "model": "z-ai/glm-5.2",
+            "base_url": "https://proxy.example/v1",
+        }
+    )
+    assert cfg.llm.model == "z-ai/glm-5.2"
+    assert cfg.llm.base_url == "https://proxy.example/v1"
+
+
+def test_explicit_other_provider_is_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    cfg = GatewayConfig(llm={"provider": "deepseek", "model": "deepseek-chat"})
+    assert cfg.llm.provider == "deepseek"
+    assert cfg.llm.model == "deepseek-chat"
+
+
+# ---------------------------------------------------------------------------
+# Default router ladder under the tokenrhythm default
+# ---------------------------------------------------------------------------
+
+
+def test_tokenrhythm_default_binds_router_tiers_to_tokenrhythm() -> None:
+    cfg = GatewayConfig()
+    tiers = cfg.squilla_router.tiers
+    for name in ("c0", "c1", "c2", "c3"):
+        assert tiers[name]["provider"] == "tokenrhythm"
+        assert tiers[name]["model"] == "deepseek-v4-pro"
+    # Synthesized presets carry no curated image tier.
+    assert "image_model" not in tiers
+    assert cfg.squilla_router.tier_profile is None
+
+
+def test_tokenrhythm_tiers_follow_the_effective_model() -> None:
+    cfg = GatewayConfig(llm={"provider": "tokenrhythm", "model": "glm-5.1"})
+    assert cfg.squilla_router.tiers["c1"]["model"] == "glm-5.1"
+
+
+def test_tokenrhythm_custom_tiers_are_preserved() -> None:
+    custom = {"c1": {"provider": "tokenrhythm", "model": "kimi-k2.6"}}
+    cfg = GatewayConfig(llm={"provider": "tokenrhythm"}, squilla_router={"tiers": custom})
+    assert cfg.squilla_router.tiers["c1"]["model"] == "kimi-k2.6"
+
+
+def test_tokenrhythm_disabled_router_keeps_default_tiers() -> None:
+    cfg = GatewayConfig(squilla_router={"enabled": False})
+    assert cfg.squilla_router.tiers == _default_tiers()
+
+
+def test_legacy_nine_auto_profile_still_applies() -> None:
+    # The direct-provider auto tier_profile default must survive the new
+    # validators running ahead of it.
+    cfg = GatewayConfig(llm={"provider": "deepseek", "model": "deepseek-chat"})
+    assert cfg.squilla_router.tier_profile == "deepseek"
+
+
+# ---------------------------------------------------------------------------
+# Resolution must not be baked into config.toml
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_legacy_provider_is_not_persisted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tomllib
+
+    from opensquilla.onboarding.config_store import load_config, persist_config
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    target = tmp_path / "config.toml"
+    target.write_text('log_level = "INFO"\n', encoding="utf-8")
+
+    cfg = load_config(target)
+    assert cfg.llm.provider == LEGACY_DEFAULT_LLM_PROVIDER
+
+    cfg.log_level = "DEBUG"
+    persist_config(cfg, path=target, backup=False)
+
+    data = tomllib.loads(target.read_text(encoding="utf-8"))
+    assert data["log_level"] == "DEBUG"
+    assert "llm" not in data
+    assert "squilla_router" not in data
+
+
+def test_resolved_tokenrhythm_tiers_are_not_persisted(tmp_path: Path) -> None:
+    import tomllib
+
+    from opensquilla.onboarding.config_store import load_config, persist_config
+
+    target = tmp_path / "config.toml"
+    target.write_text('log_level = "INFO"\n', encoding="utf-8")
+
+    cfg = load_config(target)
+    assert cfg.squilla_router.tiers["c1"]["provider"] == "tokenrhythm"
+
+    cfg.log_level = "DEBUG"
+    persist_config(cfg, path=target, backup=False)
+
+    data = tomllib.loads(target.read_text(encoding="utf-8"))
+    assert "squilla_router" not in data
+    assert "llm" not in data

--- a/tests/test_model_router_behavior.py
+++ b/tests/test_model_router_behavior.py
@@ -98,7 +98,10 @@ def make_context(
     raw_message: str | None = None,
     attachments: list[dict] | None = None,
 ) -> TurnContext:
-    config = GatewayConfig()
+    # Pin the packaged openrouter ladder: these tests assert tier moves by
+    # their distinct per-tier models, which the tokenrhythm default's uniform
+    # synthesized ladder cannot express.
+    config = GatewayConfig(llm={"provider": "openrouter"})
     config.squilla_router.rollout_phase = rollout_phase
     return TurnContext(
         message=message,

--- a/tests/test_model_router_defaults.py
+++ b/tests/test_model_router_defaults.py
@@ -328,8 +328,8 @@ def test_example_toml_enables_runtime_router_defaults() -> None:
     data = tomllib.loads(example.read_text(encoding="utf-8"))
     squilla_router = data["squilla_router"]
 
-    assert data["llm"]["provider"] == "openrouter"
-    assert data["llm"]["model"] == "deepseek/deepseek-v4-pro"
+    assert data["llm"]["provider"] == "tokenrhythm"
+    assert data["llm"]["model"] == "deepseek-v4-pro"
     assert squilla_router["enabled"] is True
     assert squilla_router["auto_thinking"] is True
     assert squilla_router["rollout_phase"] == "full"
@@ -346,15 +346,16 @@ def test_example_toml_enables_runtime_router_defaults() -> None:
     assert squilla_router["require_router_runtime"] is True
 
     tiers = squilla_router["tiers"]
-    assert tiers["c0"]["model"] == "deepseek/deepseek-v4-flash"
-    assert tiers["c0"]["thinking_level"] == "high"
-    assert tiers["c1"]["model"] == "deepseek/deepseek-v4-pro"
-    assert tiers["c1"]["thinking_level"] == "high"
-    assert tiers["c2"]["model"] == "z-ai/glm-5.2"
-    assert tiers["c2"]["thinking_level"] == "high"
-    assert tiers["c3"]["model"] == "z-ai/glm-5.2"
-    assert tiers["c3"]["thinking_level"] == "high"
-    assert tiers["image_model"]["model"] == "moonshotai/kimi-k2.6"
+    # TokenRhythm rejects thinking-toggle request fields, so the example
+    # ladder deliberately carries no thinking_level.
+    for name in ("c0", "c1", "c2", "c3", "image_model"):
+        assert tiers[name]["provider"] == "tokenrhythm"
+        assert "thinking_level" not in tiers[name]
+    assert tiers["c0"]["model"] == "deepseek-v4-flash"
+    assert tiers["c1"]["model"] == "deepseek-v4-pro"
+    assert tiers["c2"]["model"] == "glm-5.1"
+    assert tiers["c3"]["model"] == "qwen3.7-max"
+    assert tiers["image_model"]["model"] == "kimi-k2.6"
     assert tiers["image_model"]["supports_image"] is True
     assert tiers["image_model"]["image_only"] is True
 

--- a/tests/test_model_strategy_settings_contract.py
+++ b/tests/test_model_strategy_settings_contract.py
@@ -42,6 +42,9 @@ def test_non_packaged_chat_model_save_seeds_synthesized_router_tiers() -> None:
 
 def test_legacy_openrouter_mix_exact_preset_save_writes_canonical_recommended() -> None:
     cfg = GatewayConfig(
+        # openrouter-mix requires the openrouter provider, which is no longer
+        # the built-in default.
+        llm={"provider": "openrouter"},
         squilla_router={
             "enabled": True,
             "tier_profile": None,
@@ -60,6 +63,9 @@ def test_legacy_openrouter_mix_model_difference_saves_custom_inline_tiers() -> N
     tiers = _router_tier_profile_defaults("openrouter")
     tiers["c3"] = dict(tiers["c3"], model="anthropic/claude-opus-4.8")
     cfg = GatewayConfig(
+        # openrouter-mix requires the openrouter provider, which is no longer
+        # the built-in default.
+        llm={"provider": "openrouter"},
         squilla_router={
             "enabled": True,
             "tier_profile": None,
@@ -79,6 +85,9 @@ def test_legacy_openrouter_mix_description_difference_saves_custom_inline_tiers(
     tiers = _router_tier_profile_defaults("openrouter")
     tiers["c1"] = dict(tiers["c1"], description="Operator edited description.")
     cfg = GatewayConfig(
+        # openrouter-mix requires the openrouter provider, which is no longer
+        # the built-in default.
+        llm={"provider": "openrouter"},
         squilla_router={
             "enabled": True,
             "tier_profile": None,

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -1409,7 +1409,11 @@ def test_router_tier_overrides_edit_only_selected_tiers():
                 return _Answer("custom/reasoner")
             raise AssertionError(f"unexpected text prompt: {message}")
 
-    overrides = _router_tier_overrides(_Questionary(), GatewayConfig())
+    # Pin the packaged openrouter ladder: the prompt list and per-tier
+    # defaults asserted above include its curated image tier.
+    overrides = _router_tier_overrides(
+        _Questionary(), GatewayConfig(llm={"provider": "openrouter"})
+    )
 
     assert calls == ["Tier to edit", "c2 provider", "c2 model", "Tier to edit"]
     assert overrides == {"c2": {"provider": "openrouter", "model": "custom/reasoner"}}

--- a/tests/test_onboarding/test_section_status.py
+++ b/tests/test_onboarding/test_section_status.py
@@ -138,11 +138,16 @@ def test_ensemble_never_blocks_onboarding(cfg):
 
 def test_ensemble_status_reports_candidate_provider_credentials(cfg, monkeypatch):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-    cfg.llm = LlmProviderConfig(
-        provider="deepseek",
-        model="deepseek-v4-flash",
-        api_key="sk-deepseek",
-        base_url="https://api.deepseek.com",
+    # Construct with the llm section so the router ladder follows the provider;
+    # a post-construction reassignment would leave the built-in default
+    # provider's ladder in place and add its provider to the credential list.
+    cfg = GatewayConfig(
+        llm={
+            "provider": "deepseek",
+            "model": "deepseek-v4-flash",
+            "api_key": "sk-deepseek",
+            "base_url": "https://api.deepseek.com",
+        }
     )
     cfg.llm_ensemble.enabled = True
     cfg.llm_ensemble.selection_mode = "router_dynamic"

--- a/tests/test_provider/test_resolution.py
+++ b/tests/test_provider/test_resolution.py
@@ -49,22 +49,24 @@ def _catalog_with_model() -> ModelCatalog:
 
 def test_default_llm_identity_fields_report_default() -> None:
     fields = resolve_effective_llm(_config(), ModelCatalog())
-    assert fields["llm.provider"] == ResolvedField("openrouter", "default")
-    assert fields["llm.model"] == ResolvedField("deepseek/deepseek-v4-pro", "default")
-    assert fields["llm.base_url"] == ResolvedField("https://openrouter.ai/api/v1", "default")
+    assert fields["llm.provider"] == ResolvedField("tokenrhythm", "default")
+    assert fields["llm.model"] == ResolvedField("deepseek-v4-pro", "default")
+    assert fields["llm.base_url"] == ResolvedField("https://tokenrhythm.studio/v1", "default")
 
 
 def test_explicit_llm_identity_fields_report_config() -> None:
+    # The model deliberately differs from the field default: value-vs-baseline
+    # attribution cannot distinguish an explicit value that coincides with it.
     cfg = _config(
         llm=LlmProviderConfig(
             provider="deepseek",
-            model="deepseek-v4-pro",
+            model="deepseek-chat",
             base_url="https://proxy.example/v1",
         )
     )
     fields = resolve_effective_llm(cfg, ModelCatalog())
     assert fields["llm.provider"] == ResolvedField("deepseek", "config")
-    assert fields["llm.model"] == ResolvedField("deepseek-v4-pro", "config")
+    assert fields["llm.model"] == ResolvedField("deepseek-chat", "config")
     assert fields["llm.base_url"] == ResolvedField("https://proxy.example/v1", "config")
 
 


### PR DESCRIPTION
## Scope

Scope boundary: an install that never configured an LLM provider now resolves to tokenrhythm (`LlmProviderConfig` + the router ladder that follows it), with a load-time compatibility resolution so configs authored before the switch keep resolving to openrouter. Surface updates: init wizard first choice, `opensquilla.toml.example`, config.effective tier provenance for synthesized ladders.

Non-goals: no changes to openrouter-specific behavior (static_openrouter_b5 ensemble, packaged preset, catalog/pricing, openrouter-mix saves), provider registry entries, runtime routing policy, or the Web UI.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: follow-up to #546/#548 (verified-provider registration and ordering); the switch was decided out-of-band.

## Release Note

Release note: An install with no LLM provider configured now starts on TokenRhythm (`deepseek-v4-pro`). Existing setups are unaffected: an explicit provider is honored as-is, and configs that previously resolved to openrouter without naming it (an `OPENROUTER_API_KEY` in the environment, a stored key/model without a provider, or `tier_profile = "openrouter"`) keep resolving to openrouter with the previous model and endpoint.

## Tests

Ruff: pass (`ruff check src tests`)

Pytest: 12148 passed, 113 skipped; 13 failures are pre-existing environment-dependent tests (real-terminal TUI integration, macOS seatbelt, exp-ledger scripts) — verified identical on an unmodified tree

Build: `uv build --wheel` pass; mypy pass (777 files)

Regression tests: added — `tests/test_gateway_config_default_provider.py` covers every resolution branch (keyless resolution, env-key-only legacy, explicit key/model/base_url without provider, tier_profile pin, explicit-openrouter backfill, other providers untouched) plus sparse-persist non-baking for both the resolved provider and the synthesized ladder

Notes: tests that asserted the previous built-in values were updated; tests that exercise openrouter-ladder behavior (router tier moves, image tier, openrouter-mix contracts) now pin `provider = "openrouter"` explicitly, preserving their original intent. Rebased on #553 and re-ran its cold-start hot-apply and selector tests locally (pass). The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: provider

Verified locally against a live gateway: a keyless fresh state dir resolves tokenrhythm/deepseek-v4-pro with a tokenrhythm-bound ladder; a state dir with only `OPENROUTER_API_KEY` exported resolves openrouter with the previous model and the packaged openrouter ladder; neither resolution is written to config.toml by unrelated saves.

## Safety

No secrets, transcripts, channel identifiers, or private fixtures. All test credentials are synthetic.

## Third-Party Origin

Third-party origin: none