### PR TITLE
Default the per-turn objective reminder to off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- The per-turn `[Current user request reminder]` message appended after
+  tool-result turns is now off by default. Re-presenting the objective as a
+  fresh user message every turn re-triggered model reasoning on nearly every
+  request (observed 96–99% of requests emitting reasoning tokens, vs 14–31%
+  without it) and broke the provider prompt-cache suffix each turn, which in
+  internal evaluation cut agent throughput roughly 2.5× on long tool-loop
+  tasks without improving outcomes. Set
+  `OPENSQUILLA_TURN_OBJECTIVE_REMINDER=on` to restore the previous behavior
+  byte-identically, or `trim:<chars>` for a shortened variant.
 - An explicitly configured `llm.base_url` now wins over the provider's
   derived environment variable (`OPENAI_BASE_URL`, `OPENROUTER_BASE_URL`, …),
   mirroring the existing api_key rule. Previously the env var silently

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -201,20 +201,20 @@ _TURN_OBJECTIVE_REMINDER_TRIM_PREFIX = "trim:"
 
 
 def _resolve_turn_objective_reminder() -> tuple[bool, int]:
-    """Resolve the opt-in turn-objective reminder override.
+    """Resolve the turn-objective reminder override.
 
     ``OPENSQUILLA_TURN_OBJECTIVE_REMINDER`` accepts "on"/"off" or
     "trim:<chars>" (a positive integer replacing the default truncation cap).
-    Unset or "on" keeps the shipped reminder byte-identical; "off" suppresses
-    the per-turn "[Current user request reminder]" message entirely.
+    Unset or "off" suppresses the per-turn "[Current user request reminder]"
+    message; "on" restores it with the shipped truncation cap.
     Unrecognized values raise instead of being silently ignored so a run
     manifest cannot record an override the run did not actually apply.
     """
     env_value = os.environ.get(_TURN_OBJECTIVE_REMINDER_ENV, "").strip().lower()
-    if not env_value or env_value in _TURN_OBJECTIVE_REMINDER_ON:
-        return True, _TURN_OBJECTIVE_REMINDER_MAX_CHARS
-    if env_value in _TURN_OBJECTIVE_REMINDER_OFF:
+    if not env_value or env_value in _TURN_OBJECTIVE_REMINDER_OFF:
         return False, _TURN_OBJECTIVE_REMINDER_MAX_CHARS
+    if env_value in _TURN_OBJECTIVE_REMINDER_ON:
+        return True, _TURN_OBJECTIVE_REMINDER_MAX_CHARS
     if env_value.startswith(_TURN_OBJECTIVE_REMINDER_TRIM_PREFIX):
         raw_chars = env_value[len(_TURN_OBJECTIVE_REMINDER_TRIM_PREFIX) :]
         if raw_chars.isdigit() and int(raw_chars) > 0:

--- a/tests/test_engine/test_agent_mid_turn_injection.py
+++ b/tests/test_engine/test_agent_mid_turn_injection.py
@@ -191,7 +191,10 @@ async def test_multiple_pending_inputs_are_merged_into_one_user_message() -> Non
 
 
 @pytest.mark.asyncio
-async def test_no_pending_provider_anchors_current_request_after_tool_result() -> None:
+async def test_no_pending_provider_anchors_current_request_after_tool_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_TURN_OBJECTIVE_REMINDER", "on")
     provider = _ToolBoundaryProvider()
     agent = _agent(provider)
 
@@ -205,6 +208,23 @@ async def test_no_pending_provider_anchors_current_request_after_tool_result() -
     assert "run echo" in reminder_text
     assert not any(
         "Current user request" in _message_text(message) for message in agent._history
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_pending_default_sends_no_reminder_after_tool_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENSQUILLA_TURN_OBJECTIVE_REMINDER", raising=False)
+    provider = _ToolBoundaryProvider()
+    agent = _agent(provider)
+
+    _events = [event async for event in agent.run_turn("run echo")]
+
+    assert len(provider.calls) == 2
+    second_request = provider.calls[1]
+    assert not any(
+        "Current user request" in _message_text(message) for message in second_request
     )
 
 

--- a/tests/test_engine/test_turn_objective_reminder.py
+++ b/tests/test_engine/test_turn_objective_reminder.py
@@ -1,9 +1,9 @@
-"""Tests for the opt-in turn-objective reminder override.
+"""Tests for the turn-objective reminder override.
 
 OPENSQUILLA_TURN_OBJECTIVE_REMINDER gates the per-turn
 "[Current user request reminder]" user message appended after tool results.
-Unset/"on" must keep the shipped behavior byte-identical; "off" suppresses
-the message; "trim:<chars>" replaces the truncation cap.
+Unset/"off" suppresses the message (the default); "on" restores it;
+"trim:<chars>" restores it with a replacement truncation cap.
 """
 
 import pytest
@@ -17,22 +17,18 @@ from opensquilla.engine.agent import (
 ENV = "OPENSQUILLA_TURN_OBJECTIVE_REMINDER"
 
 
-def test_resolver_defaults_on_with_shipped_cap(monkeypatch) -> None:
+def test_resolver_defaults_off(monkeypatch) -> None:
     monkeypatch.delenv(ENV, raising=False)
 
-    assert _resolve_turn_objective_reminder() == (
-        True,
-        _TURN_OBJECTIVE_REMINDER_MAX_CHARS,
-    )
+    enabled, _ = _resolve_turn_objective_reminder()
+    assert enabled is False
 
 
-def test_resolver_blank_env_keeps_default(monkeypatch) -> None:
+def test_resolver_blank_env_keeps_default_off(monkeypatch) -> None:
     monkeypatch.setenv(ENV, "  ")
 
-    assert _resolve_turn_objective_reminder() == (
-        True,
-        _TURN_OBJECTIVE_REMINDER_MAX_CHARS,
-    )
+    enabled, _ = _resolve_turn_objective_reminder()
+    assert enabled is False
 
 
 def test_resolver_on_keeps_shipped_cap(monkeypatch) -> None:
@@ -115,8 +111,16 @@ def test_agent_init_resolves_env(monkeypatch) -> None:
     assert agent._turn_objective_reminder_max_chars == 1234
 
 
-def test_agent_init_default_matches_shipped_behavior(monkeypatch) -> None:
+def test_agent_init_default_disables_reminder(monkeypatch) -> None:
     monkeypatch.delenv(ENV, raising=False)
+
+    agent = Agent(provider=object())
+
+    assert agent._turn_objective_reminder_enabled is False
+
+
+def test_agent_init_on_restores_shipped_behavior(monkeypatch) -> None:
+    monkeypatch.setenv(ENV, "on")
 
     agent = Agent(provider=object())
 


### PR DESCRIPTION
> **Stacked on #569** — this branch is based on `integrate/levers-onto-main-20260710`, which adds the `OPENSQUILLA_TURN_OBJECTIVE_REMINDER` lever this PR flips. Merge #569 first; this PR then reduces to the one default-flip commit.

The per-turn `[Current user request reminder]` message appended after every tool-result turn (introduced in #450) has three measurable costs on long tool-loop tasks:

1. It re-presents the objective as a fresh user message every turn, which re-triggers model reasoning on nearly every request (observed 96–99% of requests emitting reasoning tokens, vs 14–31% without it) without improving task outcomes.
2. It breaks the provider prompt-cache suffix on every turn, lowering cache hit rates and raising cost.
3. The extra reasoning collapses agent throughput (~2.5× fewer completions per hour in internal evaluation), which converts directly into deadline overruns on wall-clock-limited tasks.

In internal evaluation (N=2 runs to date, so treat the end-to-end score as provisional), defaulting the reminder off improved task completion under time limits, raised the prompt-cache hit rate to ~0.95, and showed no objective-drift regressions — no cases of the agent losing track of the task mid-loop. The activation and cache mechanisms above are the load-bearing evidence; they replicated cleanly and are independent of the end-to-end score.

The reminder remains fully available: `OPENSQUILLA_TURN_OBJECTIVE_REMINDER=on` restores the previous behavior byte-identically, and `trim:<chars>` restores it with a shorter truncation cap.

This changes default behavior, so unlike #569 it does not carry the byte-identical-when-unset guarantee.

## Changes

- `src/opensquilla/engine/agent.py`: unset (or `off`) now resolves to reminder-disabled; `on` restores the shipped behavior with the shipped truncation cap.
- `tests/test_engine/test_turn_objective_reminder.py`: default-off resolver and agent-init coverage; `on` asserted to restore shipped behavior.
- `tests/test_engine/test_agent_mid_turn_injection.py`: the reminder-anchoring test now opts in with `=on`; a new companion test asserts no reminder is sent by default.
- `CHANGELOG.md`: entry under Unreleased → Changed.

## Testing

Full suite on this branch: 12589 passed, 86 skipped, with only the same 7 environment-only failures that reproduce on current main in this container (stdin process-isolation, real-bubblewrap network, and the #563 `docs/superpowers/` gitignore-hygiene check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
