### PR TITLE
Attribute OpenSquilla requests to TokenRhythm

### DIFF
--- a/src/opensquilla/engine/pricing.py
+++ b/src/opensquilla/engine/pricing.py
@@ -12,7 +12,7 @@ import httpx
 import structlog
 
 from opensquilla.env import trust_env as _trust_env
-from opensquilla.provider.openrouter_attribution import openrouter_app_headers
+from opensquilla.provider.app_attribution import provider_app_headers
 from opensquilla.secrets import clean_header_secret
 
 log = structlog.get_logger(__name__)
@@ -73,7 +73,7 @@ class PricingCache:
             "Authorization": f"Bearer {self._api_key}",
             "Content-Type": "application/json",
         }
-        headers.update(openrouter_app_headers(self._base_url))
+        headers.update(provider_app_headers(self._base_url))
         try:
             async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, trust_env=_trust_env()) as client:
                 resp = await client.get(url, headers=headers)
@@ -309,7 +309,7 @@ def _select_official_endpoint_price(data: dict, model_id: str) -> PriceEntry | N
 
 def _fetch_openrouter_json_sync(url: str) -> dict:
     with httpx.Client(timeout=_HTTP_TIMEOUT, trust_env=_trust_env()) as client:
-        resp = client.get(url, headers=openrouter_app_headers(url))
+        resp = client.get(url, headers=provider_app_headers(url))
         resp.raise_for_status()
         return cast(dict[Any, Any], resp.json())
 

--- a/src/opensquilla/memory/embedding.py
+++ b/src/opensquilla/memory/embedding.py
@@ -10,7 +10,7 @@ import httpx
 import structlog
 
 from opensquilla.env import trust_env as _trust_env
-from opensquilla.provider.openrouter_attribution import openrouter_app_headers
+from opensquilla.provider.app_attribution import provider_app_headers
 
 logger = structlog.get_logger(__name__)
 
@@ -119,7 +119,7 @@ class OpenAIEmbeddingProvider:
 
     def _headers(self) -> dict[str, str]:
         headers = {"Authorization": f"Bearer {self._api_key}"}
-        headers.update(openrouter_app_headers(self._base_url))
+        headers.update(provider_app_headers(self._base_url))
         headers.update(self._extra_headers)
         return headers
 

--- a/src/opensquilla/provider/app_attribution.py
+++ b/src/opensquilla/provider/app_attribution.py
@@ -1,0 +1,47 @@
+"""Host-gated application attribution for supported provider APIs."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+OPENSQUILLA_APP_REFERER = "https://opensquilla.ai"
+OPENSQUILLA_APP_TITLE = "OpenSquilla"
+
+_APP_ATTRIBUTION_ROOT_HOSTS = frozenset({"openrouter.ai", "tokenrhythm.studio"})
+
+
+def _normalized_hostname(url: str | None) -> str:
+    raw = str(url or "").strip()
+    if not raw:
+        return ""
+    try:
+        parsed = urlparse(raw if "://" in raw else f"https://{raw}")
+        if parsed.scheme.lower() not in {"http", "https"}:
+            return ""
+        host = (parsed.hostname or "").lower()
+        if ":" in host or "%" in host:
+            return ""
+        return host
+    except ValueError:
+        return ""
+
+
+def is_provider_app_host(url: str | None, root_host: str) -> bool:
+    """Return whether ``url`` is the allowlisted root host or its subdomain."""
+    root = str(root_host or "").strip().lower().lstrip(".")
+    if root not in _APP_ATTRIBUTION_ROOT_HOSTS:
+        return False
+    host = _normalized_hostname(url)
+    return host == root or host.endswith(f".{root}")
+
+
+def provider_app_headers(url: str | None) -> dict[str, str]:
+    """Return OpenSquilla attribution headers for allowlisted provider hosts."""
+    if not any(
+        is_provider_app_host(url, root) for root in _APP_ATTRIBUTION_ROOT_HOSTS
+    ):
+        return {}
+    return {
+        "HTTP-Referer": OPENSQUILLA_APP_REFERER,
+        "X-Title": OPENSQUILLA_APP_TITLE,
+    }

--- a/src/opensquilla/provider/image_generation.py
+++ b/src/opensquilla/provider/image_generation.py
@@ -10,7 +10,7 @@ from typing import Protocol
 import httpx
 
 from opensquilla.env import trust_env as _trust_env
-from opensquilla.provider.openrouter_attribution import openrouter_app_headers
+from opensquilla.provider.app_attribution import provider_app_headers
 from opensquilla.secrets import clean_header_secret
 
 
@@ -175,7 +175,7 @@ class OpenRouterImageGenerationProvider:
                 headers={
                     "Authorization": f"Bearer {api_key}",
                     "Content-Type": "application/json",
-                    **openrouter_app_headers(self._base_url),
+                    **provider_app_headers(self._base_url),
                 },
                 json=payload,
             )

--- a/src/opensquilla/provider/live_catalog.py
+++ b/src/opensquilla/provider/live_catalog.py
@@ -27,6 +27,7 @@ import structlog
 
 from opensquilla.env import trust_env as _trust_env
 
+from .app_attribution import provider_app_headers
 from .model_catalog import DEFAULT_MAX_TOKENS as _NEAR_WINDOW_MARGIN
 from .registry import UnknownProviderError, get_provider_spec
 
@@ -172,7 +173,7 @@ async def fetch_live_catalog_entries(
     async with httpx.AsyncClient(
         timeout=timeout, trust_env=_trust_env(), proxy=proxy or None
     ) as client:
-        resp = await client.get(url)
+        resp = await client.get(url, headers=provider_app_headers(url))
         resp.raise_for_status()
         payload = resp.json()
     return parser(payload if isinstance(payload, Mapping) else {})

--- a/src/opensquilla/provider/model_catalog.py
+++ b/src/opensquilla/provider/model_catalog.py
@@ -15,11 +15,11 @@ import structlog
 from opensquilla.env import trust_env as _trust_env
 from opensquilla.secrets import clean_header_secret
 
+from .app_attribution import provider_app_headers
 from .catalog_types import CatalogSource, ModelCatalogEntry, coerce_entry_field
 from .models_dev import lookup_limits as _models_dev_limits
 from .models_dev import lookup_model as _models_dev_model
 from .ollama import _OLLAMA_DEFAULT_NUM_CTX
-from .openrouter_attribution import openrouter_app_headers
 from .registry import LOCAL_RUNTIME_PROVIDERS
 from .types import ModelCapabilities, ModelInfo
 
@@ -501,7 +501,7 @@ class ModelCatalog:
         headers = {
             "Authorization": f"Bearer {clean_header_secret(api_key, label='OpenRouter API key')}"
         }
-        headers.update(openrouter_app_headers(base_url))
+        headers.update(provider_app_headers(base_url))
         async with httpx.AsyncClient(
             timeout=10.0, trust_env=_trust_env(), proxy=proxy or None
         ) as client:

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -18,11 +18,11 @@ from opensquilla.env import trust_env as _trust_env
 from opensquilla.execution_status import compact_provider_status, derive_is_error
 from opensquilla.secrets import clean_header_secret
 
+from .app_attribution import provider_app_headers
 from .compat_policy import OpenAICompatPolicy, compat_policy_for_kind
 from .context_capabilities import supports_openrouter_explicit_prompt_cache
 from .failures import retry_after_from_headers
 from .minimax_compat import contains_minimax_protocol, parse_minimax_tool_calls
-from .openrouter_attribution import openrouter_app_headers
 from .protocol import ProviderConnectionConfig, ProviderMetadata
 from .reasoning_dialects import (
     ReasoningDisableArgs,
@@ -2265,7 +2265,7 @@ class OpenAIProvider:
             "Content-Type": "application/json",
             "Accept": "text/event-stream",
         }
-        headers.update(openrouter_app_headers(self._base_url))
+        headers.update(provider_app_headers(self._base_url))
         if self._org_id:
             headers["OpenAI-Organization"] = self._org_id
 
@@ -3032,7 +3032,7 @@ class OpenAIProvider:
         (e.g. onboarding discovery) can classify it.
         """
         headers = {"Authorization": f"Bearer {self._api_key}"}
-        headers.update(openrouter_app_headers(self._base_url))
+        headers.update(provider_app_headers(self._base_url))
         try:
             async with httpx.AsyncClient(
                 timeout=10.0,

--- a/src/opensquilla/provider/openrouter_attribution.py
+++ b/src/opensquilla/provider/openrouter_attribution.py
@@ -1,33 +1,25 @@
-"""OpenRouter application attribution headers."""
+"""Backward-compatible OpenRouter application attribution facade."""
 
 from __future__ import annotations
 
-from urllib.parse import urlparse
+from .app_attribution import (
+    OPENSQUILLA_APP_REFERER,
+    OPENSQUILLA_APP_TITLE,
+    is_provider_app_host,
+    provider_app_headers,
+)
 
-OPENROUTER_APP_REFERER = "https://opensquilla.ai"
-OPENROUTER_APP_TITLE = "OpenSquilla"
+OPENROUTER_APP_REFERER = OPENSQUILLA_APP_REFERER
+OPENROUTER_APP_TITLE = OPENSQUILLA_APP_TITLE
 
 
 def is_openrouter_url(url: str | None) -> bool:
     """Return whether a URL points at OpenRouter's hosted API."""
-    if not url:
-        return False
-    raw = url.strip()
-    if not raw:
-        return False
-    parsed = urlparse(raw if "://" in raw else f"https://{raw}")
-    host = (parsed.hostname or "").lower()
-    return host == "openrouter.ai" or host.endswith(".openrouter.ai")
+    return is_provider_app_host(url, "openrouter.ai")
 
 
 def openrouter_app_headers(url: str | None) -> dict[str, str]:
     """Return attribution headers only for real OpenRouter API URLs."""
     if not is_openrouter_url(url):
         return {}
-    # OpenRouter's documented app-attribution headers are HTTP-Referer and
-    # X-Title; the previously sent X-OpenRouter-* variants were silently
-    # ignored upstream, so attribution never actually applied.
-    return {
-        "HTTP-Referer": OPENROUTER_APP_REFERER,
-        "X-Title": OPENROUTER_APP_TITLE,
-    }
+    return provider_app_headers(url)

--- a/src/opensquilla/session/compaction.py
+++ b/src/opensquilla/session/compaction.py
@@ -12,7 +12,7 @@ import httpx
 import structlog
 
 from opensquilla.env import trust_env as _trust_env
-from opensquilla.provider.openrouter_attribution import openrouter_app_headers
+from opensquilla.provider.app_attribution import provider_app_headers
 from opensquilla.provider.protocol import provider_connection_config
 from opensquilla.session.compaction_state import (
     build_structured_summary_from_text,
@@ -548,7 +548,7 @@ async def call_compaction_llm(
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
-    headers.update(openrouter_app_headers(url))
+    headers.update(provider_app_headers(url))
 
     try:
         async with httpx.AsyncClient(timeout=timeout, trust_env=_trust_env()) as client:

--- a/src/opensquilla/session/naming.py
+++ b/src/opensquilla/session/naming.py
@@ -25,7 +25,7 @@ import httpx
 import structlog
 
 from opensquilla.env import trust_env as _trust_env
-from opensquilla.provider.openrouter_attribution import openrouter_app_headers
+from opensquilla.provider.app_attribution import provider_app_headers
 from opensquilla.provider.protocol import provider_connection_config
 from opensquilla.router_tiers import DEFAULT_TEXT_TIER, normalize_text_tier
 
@@ -256,7 +256,7 @@ async def call_naming_llm(
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
-    headers.update(openrouter_app_headers(url))
+    headers.update(provider_app_headers(url))
 
     try:
         async with httpx.AsyncClient(timeout=timeout, trust_env=_trust_env()) as client:

--- a/tests/test_provider/test_live_catalog.py
+++ b/tests/test_provider/test_live_catalog.py
@@ -250,8 +250,13 @@ async def test_fetch_live_catalog_entries_uses_url_verbatim_without_auth() -> No
         )
 
     assert captured["url"] == "https://tokenrhythm.studio/api/models"
-    # The listing is keyless — no Authorization header may ever be sent.
-    assert "headers" not in captured["kwargs"]
+    # The listing stays keyless while carrying fixed public app attribution.
+    headers = captured["kwargs"]["headers"]
+    assert headers == {
+        "HTTP-Referer": "https://opensquilla.ai",
+        "X-Title": "OpenSquilla",
+    }
+    assert "Authorization" not in headers
     assert entries["deepseek-v4-pro"]["context_window"] == 900_000
 
 

--- a/tests/test_provider_app_attribution.py
+++ b/tests/test_provider_app_attribution.py
@@ -1,0 +1,61 @@
+import pytest
+
+from opensquilla.provider.app_attribution import (
+    OPENSQUILLA_APP_REFERER,
+    OPENSQUILLA_APP_TITLE,
+    is_provider_app_host,
+    provider_app_headers,
+)
+
+EXPECTED_HEADERS = {
+    "HTTP-Referer": "https://opensquilla.ai",
+    "X-Title": "OpenSquilla",
+}
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://openrouter.ai/api/v1",
+        "https://api.openrouter.ai/v1",
+        "https://tokenrhythm.studio/v1",
+        "https://api.tokenrhythm.studio/v1",
+        "tokenrhythm.studio/v1",
+    ],
+)
+def test_provider_app_headers_accept_official_hosts(url: str) -> None:
+    assert provider_app_headers(url) == EXPECTED_HEADERS
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        None,
+        "",
+        "   ",
+        "https://api.openai.com/v1",
+        "http://localhost:4000/v1",
+        "https://tokenrhythm.studio.example.com/v1",
+        "https://eviltokenrhythm.studio/v1",
+        "https://openrouter.ai.example.com/v1",
+        "https://evilopenrouter.ai/v1",
+        "https://[tokenrhythm.studio",
+        "http://[::1%.openrouter.ai]/v1",
+        "http://[::1%25.openrouter.ai]/v1",
+        "http://[fe80::1%.tokenrhythm.studio]/v1",
+        "ftp://tokenrhythm.studio/v1",
+    ],
+)
+def test_provider_app_headers_reject_untrusted_or_malformed_urls(
+    url: str | None,
+) -> None:
+    assert provider_app_headers(url) == {}
+
+
+def test_provider_app_identity_constants_are_fixed() -> None:
+    assert OPENSQUILLA_APP_REFERER == "https://opensquilla.ai"
+    assert OPENSQUILLA_APP_TITLE == "OpenSquilla"
+
+
+def test_is_provider_app_host_rejects_non_allowlisted_root() -> None:
+    assert not is_provider_app_host("https://example.com/v1", "example.com")

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -375,6 +375,50 @@ def test_dashscope_stream_timeout_emits_heartbeat_before_non_stream_fallback(
     )
 
 
+def test_tokenrhythm_chat_adds_app_attribution_headers(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek-v4-flash",
+        base_url="https://tokenrhythm.studio/v1",
+        provider_kind="tokenrhythm",
+    )
+
+    _collect(provider, ChatConfig())
+
+    assert captured["url"] == "https://tokenrhythm.studio/v1/chat/completions"
+    assert captured["headers"].get("HTTP-Referer") == "https://opensquilla.ai"
+    assert captured["headers"].get("X-Title") == "OpenSquilla"
+
+
+def test_tokenrhythm_list_models_adds_app_attribution_headers(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_get_transport_response(
+        monkeypatch,
+        captured,
+        httpx.Response(
+            200,
+            json={"data": []},
+            request=httpx.Request("GET", "https://tokenrhythm.studio/v1/models"),
+        ),
+    )
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek-v4-flash",
+        base_url="https://tokenrhythm.studio/v1",
+        provider_kind="tokenrhythm",
+    )
+
+    assert asyncio.run(provider.list_models()) == []
+
+    assert captured["url"] == "https://tokenrhythm.studio/v1/models"
+    assert captured["headers"].get("HTTP-Referer") == "https://opensquilla.ai"
+    assert captured["headers"].get("X-Title") == "OpenSquilla"
+
+
 def test_openrouter_list_models_reports_openrouter_provider(monkeypatch: Any) -> None:
     captured: dict[str, Any] = {}
     _patch_get_transport_response(

--- a/tests/test_provider_openrouter_attribution.py
+++ b/tests/test_provider_openrouter_attribution.py
@@ -26,3 +26,9 @@ def test_openrouter_url_detection_accepts_openrouter_hosts_only() -> None:
 def test_openrouter_app_headers_skip_non_openrouter_urls() -> None:
     assert openrouter_app_headers("https://api.openai.com/v1") == {}
     assert openrouter_app_headers("http://localhost:4000/v1") == {}
+
+
+def test_openrouter_compat_headers_remain_openrouter_only() -> None:
+    url = "https://tokenrhythm.studio/v1"
+    assert not is_openrouter_url(url)
+    assert openrouter_app_headers(url) == {}

--- a/tests/test_session/test_compaction.py
+++ b/tests/test_session/test_compaction.py
@@ -534,6 +534,50 @@ async def test_call_compaction_llm_adds_openrouter_app_attribution(monkeypatch) 
 
 
 @pytest.mark.asyncio
+async def test_call_compaction_llm_adds_tokenrhythm_app_attribution(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"choices": [{"message": {"content": "summary"}}]}
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url, *, json, headers):
+            captured["url"] = url
+            captured["headers"] = headers
+            return FakeResponse()
+
+    monkeypatch.setattr(
+        "opensquilla.session.compaction.httpx.AsyncClient",
+        lambda **kwargs: FakeClient(),
+    )
+
+    result = await call_compaction_llm(
+        chunk_text="old conversation",
+        identifier_instruction="",
+        model="deepseek-v4-flash",
+        api_key="test-key",
+        base_url="https://tokenrhythm.studio/v1",
+    )
+
+    assert result == "summary"
+    assert captured["url"] == "https://tokenrhythm.studio/v1/chat/completions"
+    headers = captured["headers"]
+    assert isinstance(headers, dict)
+    assert headers["HTTP-Referer"] == "https://opensquilla.ai"
+    assert headers["X-Title"] == "OpenSquilla"
+
+
+@pytest.mark.asyncio
 async def test_call_compaction_llm_timeout_returns_none(monkeypatch) -> None:
     class FakeClient:
         async def __aenter__(self):

--- a/tests/test_session/test_naming.py
+++ b/tests/test_session/test_naming.py
@@ -258,7 +258,28 @@ async def test_call_naming_llm_payload_and_sanitization(monkeypatch):
     assert captured["json"]["stream"] is False
     # OpenRouter attribution headers are present (mirrors compaction path).
     assert captured["headers"]["Authorization"] == "Bearer test-key"
-    assert "X-Title" in captured["headers"]
+    assert captured["headers"]["HTTP-Referer"] == "https://opensquilla.ai"
+    assert captured["headers"]["X-Title"] == "OpenSquilla"
+
+
+@pytest.mark.asyncio
+async def test_call_naming_llm_adds_tokenrhythm_app_attribution(monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(
+        "opensquilla.session.naming.httpx.AsyncClient",
+        lambda **kwargs: _fake_client(captured),
+    )
+
+    await call_naming_llm(
+        "Help me reset my password please",
+        model="deepseek-v4-flash",
+        api_key="test-key",
+        base_url="https://tokenrhythm.studio/v1",
+    )
+
+    assert captured["url"] == "https://tokenrhythm.studio/v1/chat/completions"
+    assert captured["headers"]["HTTP-Referer"] == "https://opensquilla.ai"
+    assert captured["headers"]["X-Title"] == "OpenSquilla"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

- Add a shared, host-gated OpenSquilla application-attribution helper for OpenRouter and TokenRhythm.
- Send `HTTP-Referer: https://opensquilla.ai` and `X-Title: OpenSquilla` on TokenRhythm chat, model-list, naming, compaction, live-catalog, pricing, embedding, image, and model-catalog request paths.
- Preserve the existing OpenRouter-only compatibility API and reject non-HTTP, lookalike, malformed, and scoped-IPv6 hosts.
- Keep the public TokenRhythm catalog request unauthenticated.

## Branch target

- Base: `main`
- Head: `fix/tokenrhythm-app-attribution`
- Commits: one

## Linked issue

None.

## Release note status

Include as a provider-integration reliability improvement in the next release notes.

## Test results

- `228 passed` — focused attribution/provider/session tests.
- `609 passed` — broader provider regressions.
- Ruff: passed.
- mypy: passed for changed source modules.
- Live TokenRhythm validation: 5 single-model runs plus 5 static B5 ensemble runs; all 30 Chat Completions requests carried both attribution headers and completed successfully.
- Full-suite note: an earlier broad run was stopped at 17% after 9 real-terminal TUI failures in paths untouched by this change; 2,270 tests had passed at that point.

## Safety notes

- Attribution values are fixed public application metadata; no user, account, session, prompt, machine, or workspace identifiers are added.
- Header injection is limited to exact official hosts and their subdomains over HTTP(S).
- TokenRhythm public catalog traffic receives no Authorization header.
- No credentials or live transcripts are committed.

## Third-party origin

None. The implementation and tests are original OpenSquilla work; no external source code or fixtures were copied.