### PR TITLE
docs: add mermaid architecture diagrams and AGENTS.md to OpenSquilla

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,223 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, Codex, and others)
+when working on code in this repository. It is the **orientation layer**: it
+maps the whole repo and points at the per-module guides that own the depth. For
+anything inside a module, read that module's docs rather than expecting full
+detail here.
+
+The sibling `CLAUDE.md` imports this file via `@AGENTS.md` so Claude Code and
+other tools share one source of truth.
+
+## What is OpenSquilla
+
+OpenSquilla is a token-efficient, microkernel AI agent. A local model router
+(SquillaRouter) sends each turn to the cheapest model that can handle it, while
+persistent memory, a layered sandbox, built-in web search, and on-device
+embeddings round out a single shared turn loop.
+
+Every entry point — Web UI, CLI, terminal chat, and messaging channels
+(Telegram, Slack, Feishu/Lark, Discord, DingTalk, WeCom, Matrix, QQ) — runs
+through that same loop, so tool dispatch, retries, approvals, and decision
+logging behave identically everywhere. A pluggable provider layer speaks to
+TokenRhythm, OpenRouter, OpenAI, Anthropic, Ollama, DeepSeek, Gemini,
+Qwen/DashScope, and 20+ other LLM providers with no code or config-schema
+change.
+
+OpenSquilla 0.5.0 Preview 3 is the current preview release.
+
+For product-level orientation, start with
+[`README.product.md`](README.product.md) and the
+[`docs/README.md`](docs/README.md) documentation index.
+
+## Repository Map
+
+```
+opensquilla/
+├── AGENTS.md                      # This file — repo orientation for AI agents
+├── CLAUDE.md                      # One-liner that imports AGENTS.md (Claude Code)
+├── README.md / README.product.md  # Release & product-oriented READMEs (EN + 5 translations)
+├── pyproject.toml                 # Python package, hatchling build, ruff/mypy config
+├── uv.lock                        # Pinned transitive deps for uv
+├── install.sh / install.ps1       # Cross-platform install scripts
+├── start.sh / start.ps1           # Cross-platform launch scripts
+├── compose.yaml                   # Docker Compose for home-server / NAS deployment
+├── Dockerfile                     # Container image
+├── opensquilla.toml.example       # Template for the user config file
+├── src/opensquilla/               # Python package (the runtime)
+│   ├── cli/                       # Typer CLI entry points: opensquilla, gateway
+│   ├── gateway/                   # Local HTTP/WS server (Starlette) + control console
+│   ├── engine/                    # Core turn runner, agent loop, streaming
+│   ├── agents/                    # Durable agent profiles
+│   ├── channels/                  # IM adapters (telegram, slack, feishu, discord, ...)
+│   ├── mcp/                       # MCP tool registry consumed by the gateway
+│   ├── mcp_server/                # stdio MCP server bridge (the [mcp] extra)
+│   ├── skills/                    # Bundled + user skills (incl. bundled/, meta/, ...)
+│   ├── squilla_router/            # Local model router (ONNX + LightGBM)
+│   ├── provider/                  # LLM provider abstraction
+│   ├── memory/                    # Durable memory + recall
+│   ├── session/                   # Session store, transcript, replay
+│   ├── scheduler/                 # APScheduler-backed cron
+│   ├── tools/                     # Built-in tools (fs, shell, web, git, ...)
+│   ├── sandbox/                   # Sandboxed execution posture
+│   ├── safety/                    # Approvals, redaction
+│   ├── persistence/               # SQLite store + yoyo migrations
+│   ├── migrations/                # Hand-written SQL migrations (run by yoyo)
+│   ├── observability/             # structlog + diagnostics surfaces
+│   ├── onboarding/                # First-run wizard (`opensquilla onboard`)
+│   ├── identity/                  # User identity + auth tokens
+│   ├── contrib/                   # Vendored helpers (compat, redactors, ...)
+│   ├── eval/                      # Benchmarks + golden tasks
+│   └── ui.py                      # Shared rich/console helpers
+├── desktop/                       # Electron desktop shell (Vue control console)
+├── opensquilla-webui/             # Vue 3 control console served by the gateway
+├── service-units/                 # OS service definitions (systemd / launchd / Windows svc)
+├── Formula/                       # Homebrew tap formula
+├── migrations/                    # SQL migrations mirrored into the wheel
+├── scripts/                       # Maintenance, codegen, bench, replay, experiments
+├── tests/                         # Pytest tree (auto-discovered; marker-gated live tests)
+├── docs/                          # User-facing docs (gateway, channels, sessions, features/...)
+│   ├── README.md                  # Docs index
+│   ├── features/                  # One page per product feature
+│   ├── authoring/                 # Meta-skill authoring rules
+│   ├── releases/                  # Per-release notes
+│   └── diagrams/                  # Long-form architecture sources (puml, drawio)
+└── .github/                       # Issue + PR templates, CI workflows
+```
+
+## Service Topology
+
+OpenSquilla is structured as one local Python runtime plus optional
+co-located services. The smallest viable install is a single process.
+
+| Component            | Default port | Role                                              |
+| -------------------- | ------------ | ------------------------------------------------- |
+| **Gateway**          | `18791`      | Starlette HTTP + WebSocket. Web UI, RPC, channels. |
+| **Gateway WS**       | `18791/ws`   | Streaming RPC used by CLI, MCP bridge, channels.   |
+| **Desktop app**      | —            | Electron shell that spawns/owns the gateway.       |
+| **Web UI**           | `18791/`     | Vue 3 control console served by the gateway.       |
+| **Cron scheduler**   | in-process   | APScheduler-driven, persists jobs to SQLite.       |
+
+`gateway run --listen 0.0.0.0` exposes the gateway to other hosts — only do
+this behind a trusted network boundary and explicit token auth.
+
+## Per-Module Docs
+
+For depth, follow the per-module docs. Each `docs/<module>.md` is the user-facing
+guide; the source tree under `src/opensquilla/<module>/` owns the runtime.
+
+- [`docs/gateway.md`](docs/gateway.md) — gateway lifecycle, host/port, graceful drain.
+- [`docs/channels.md`](docs/channels.md) — IM adapters (Telegram, Slack, Feishu, ...).
+- [`docs/sessions.md`](docs/sessions.md) — durable conversations, resume, abort, export.
+- [`docs/agents.md`](docs/agents.md) — durable named agent profiles.
+- [`docs/mcp-server.md`](docs/mcp-server.md) — stdio MCP bridge for MCP-capable clients.
+- [`docs/cli.md`](docs/cli.md) — command groups and common workflows.
+- [`docs/tui.md`](docs/tui.md) — terminal chat usage, slash commands.
+- [`docs/web-ui.md`](docs/web-ui.md) — local control console.
+- [`docs/configuration.md`](docs/configuration.md) — config file locations and keys.
+- [`docs/providers-and-models.md`](docs/providers-and-models.md) — LLM provider catalog.
+- [`docs/tools-and-sandbox.md`](docs/tools-and-sandbox.md) — built-in tools and sandbox posture.
+- [`docs/approvals-and-permissions.md`](docs/approvals-and-permissions.md) — permissions + approvals.
+- [`docs/usage-and-cost.md`](docs/usage-and-cost.md) — token usage and cost reports.
+- [`docs/diagnostics-and-replay.md`](docs/diagnostics-and-replay.md) — diagnostics + read-only replay.
+- [`docs/scheduling.md`](docs/scheduling.md) — cron-style scheduled runs.
+- [`docs/docker.md`](docs/docker.md) — Docker / Compose deployment.
+- [`docs/operations.md`](docs/operations.md) — operational commands (doctor, migrate, ...).
+- [`docs/troubleshooting.md`](docs/troubleshooting.md) — common install/runtime issues.
+- [`docs/glossary.md`](docs/glossary.md) — user-facing terminology.
+
+### Feature deep-dives
+
+- [`docs/features.md`](docs/features.md) — feature catalog.
+- [`docs/features/squilla-router.md`](docs/features/squilla-router.md) — local model router.
+- [`docs/features/tui-frontend.md`](docs/features/tui-frontend.md) — TUI backends + plugin slots.
+- [`docs/features/tool-compression.md`](docs/features/tool-compression.md) — compact tool results.
+- [`docs/features/skills.md`](docs/features/skills.md) — skill discovery + lifecycle.
+- [`docs/features/meta-skills.md`](docs/features/meta-skills.md) — composable multi-step workflows.
+- [`docs/features/memory.md`](docs/features/memory.md) — durable recall.
+- [`docs/features/compaction-and-cache.md`](docs/features/compaction-and-cache.md) — long-session continuity.
+- [`docs/diagrams/architecture.md`](docs/diagrams/architecture.md) — long-form puml/drawio sources.
+
+## Commands
+
+The repo is a uv-managed Python project. Use `uv` for everything; `pip` is not
+the supported workflow.
+
+| Task                        | Command                                                                                          |
+| --------------------------- | ------------------------------------------------------------------------------------------------ |
+| Install (dev)               | `uv sync`                                                                                        |
+| Run CLI                     | `uv run opensquilla <cmd>`                                                                       |
+| Run gateway                 | `uv run opensquilla gateway run`                                                                 |
+| Lint                        | `uv run ruff check`                                                                              |
+| Format                      | `uv run ruff format`                                                                             |
+| Type check                  | `uv run mypy`                                                                                    |
+| Tests (offline)             | `uv run pytest -m "not llm and not live_channel and not live_search"`                            |
+| Tests (live, gated)         | `uv run pytest -m "llm_smoke"` (and the other `llm_*` markers in `pyproject.toml`)               |
+| Doctor                      | `uv run opensquilla doctor`                                                                      |
+| TUI replay bench            | `uv run python scripts/bench_tui_replay.py --renderer opentui --fixture long-stream`             |
+
+Marker-gated tests (LLM, channel, search) are opt-in; see the `markers` table in
+`pyproject.toml` for the full list.
+
+## Cross-Cutting Conventions
+
+**Python style.** `ruff` with `target-version = "py312"`, `line-length = 100`,
+rule selection `E F I N W UP`. Some long-line scripts under
+`src/opensquilla/skills/bundled/*/scripts/` and a vendored `video-merger/src/`
+have intentional `E501` ignores — leave those alone. `mypy` is strict
+(`warn_return_any = true`); many third-party modules are in
+`[[tool.mypy.overrides]]` with `ignore_missing_imports = true`.
+
+**Tests.** Pytest with `asyncio_mode = "auto"`. The tests tree lives at the
+repo root; `tests/_private`, `tests/fixtures`, `.omx`, `.codex`, `.claude` are
+excluded. Use the `llm_*`, `live_channel`, `live_search`, `webui_browser`,
+`tui_real_terminal`, and `local_golden` markers to gate anything that touches
+the network, the browser, a real terminal, or a slow synthetic golden task.
+
+**Dependencies.** Required dependencies and optional extras (`mcp`, `msg`,
+`memory`, `recommended`, `matrix`, `matrix-e2e`, `document-extras`, `swebench`)
+are declared in `pyproject.toml`. The default install uses the `recommended`
+extra (SquillaRouter + memory + local models). `OPENSQUILLA_INSTALL_PROFILE=core`
+omits the router deps for a minimal install.
+
+**Migrations.** SQL files under `migrations/` are mirrored into the wheel at
+`opensquilla/_migrations/` via `[tool.hatch.build.targets.wheel.force-include]`
+and run by `yoyo-migrations` on gateway startup. Do not hand-edit migrations
+that have already shipped — add a new file.
+
+**Skills.** Bundled user-facing skills live under
+`src/opensquilla/skills/bundled/`. `src/opensquilla/skills/exp/` is excluded
+from the wheel. New meta-skills follow
+[`docs/authoring/meta-skills.md`](docs/authoring/meta-skills.md).
+
+**Channels.** Adding a new channel adapter means implementing the adapter
+contract under `src/opensquilla/channels/` and registering it in
+`opensquilla channels types`. Webhook-mode channels (Slack webhook, WeCom)
+need a publicly reachable gateway URL.
+
+**Docs.** Documentation lives under `docs/`. The docs site is markdown-only;
+rendered previews go through GitHub. See
+[`docs/contributing-docs.md`](docs/contributing-docs.md) for the doc-only
+checklist. Independent features stay on independent pages under
+`docs/features/`. Read the diagrams index at
+[`docs/diagrams/architecture.md`](docs/diagrams/architecture.md) before adding
+or editing any `architecture.puml` / `architecture.drawio` source.
+
+**Logging.** `structlog` is the standard logger. Use bound context
+(`log.bind(...)`) for per-turn / per-session fields; avoid print-style
+formatting.
+
+**Safety.** Public gateway bind (`--listen 0.0.0.0`) is opt-in and requires
+explicit token auth. Provider keys, channel secrets, and MCP-client config
+must never appear in checked-in examples or fixtures. Redaction happens in
+`src/opensquilla/safety/` and `src/opensquilla/redaction.py`.
+
+## When in doubt
+
+- Read the linked docs first.
+- For runtime behavior, prefer `opensquilla doctor` and `opensquilla diagnostics on`
+  before diving into source.
+- Open an issue using the appropriate template (`.github/ISSUE_TEMPLATE/`) before
+  a large change.
+- For agent-specific tasks (Claude Code, Codex), follow this file plus the
+  module guide that owns the area you are touching.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+The repo's agent guidance lives in [AGENTS.md](AGENTS.md) so it is shared across coding agents (Claude Code, Codex, and others). Claude Code imports it below.
+
+@AGENTS.md

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -7,6 +7,29 @@ workspace, or a channel-facing assistant.
 The built-in `main` agent is always available. Additional agents are configured
 with `opensquilla agents`.
 
+```mermaid
+graph LR
+    User[User / CLI / Web UI]
+    CLI[opensquilla agents add]
+    Cfg[(config.toml<br/>agents.*)]
+    GW[Gateway restart]
+    Main[main agent<br/>built-in]
+    Research[research agent]
+    Writing[writing agent]
+    Channel[channel-facing agent]
+    Sessions[Sessions filtered<br/>by --agent]
+    Cron[Scheduled jobs<br/>--agent X]
+    ChRoute[Channel routes<br/>to configured agent]
+
+    User --> CLI --> Cfg --> GW --> Research
+    GW --> Writing
+    GW --> Channel
+    Main -. always available .-> GW
+    Research --> Sessions
+    Research --> Cron
+    Channel --> ChRoute
+```
+
 ## When to Create an Agent
 
 Create a durable agent when you want a stable identity for:

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -5,6 +5,36 @@ agent runtime as the CLI and Web UI. Use channels when you want the same agent
 to answer from Slack, Telegram, Feishu/Lark, Discord, DingTalk, WeCom, Matrix,
 QQ, or another supported adapter.
 
+```mermaid
+graph LR
+    TG[Telegram]
+    SL[Slack]
+    FS[Feishu / Lark]
+    DS[Discord]
+    DT[DingTalk]
+    WC[WeCom]
+    MX[Matrix]
+    QQ[QQ Bot]
+    Worker[Channel worker<br/>websocket / webhook]
+    Bus[Message bus<br/>normalized events]
+    Disp[Dispatcher<br/>routes to agent]
+    Agent[Configured agent<br/>e.g. channel-facing]
+    Session[(Session store)]
+    Out[Reply via channel adapter]
+
+    TG --> Worker
+    SL --> Worker
+    FS --> Worker
+    DS --> Worker
+    DT --> Worker
+    WC --> Worker
+    MX --> Worker
+    QQ --> Worker
+    Worker --> Bus --> Disp --> Agent
+    Agent <--> Session
+    Agent --> Out
+```
+
 ## Supported Channel Types
 
 Inspect your local install:

--- a/docs/diagrams/architecture.md
+++ b/docs/diagrams/architecture.md
@@ -1,0 +1,164 @@
+# Architecture Diagrams
+
+This page collects the long-form architecture diagram source files shipped with
+OpenSquilla. The two source files below are kept under
+`src/opensquilla/skills/meta/` next to the meta-skill subsystem they describe;
+they are reproduced here as fenced source blocks so contributors can preview
+them in the docs site even without a PlantUML or draw.io renderer.
+
+If you have a renderer installed, the canonical commands are:
+
+```sh
+# PlantUML -> SVG (Java + plantuml.jar)
+plantuml -tsvg src/opensquilla/skills/meta/architecture.puml
+
+# drawio -> SVG (drawio CLI)
+drawio --export --format=svg \
+  src/opensquilla/skills/meta/architecture.drawio \
+  --output docs/diagrams/architecture-drawio.svg
+```
+
+If no renderer is available, the fenced source blocks below are still useful as
+the source of truth — open them in any PlantUML / draw.io editor to render.
+
+## Meta-Skill Subsystem (PlantUML source)
+
+`src/opensquilla/skills/meta/architecture.puml`
+
+```plantuml
+@startuml meta-skill-architecture
+skinparam packageStyle rectangle
+skinparam backgroundColor #FEFEFE
+skinparam shadowing false
+
+title Meta-Skill Subsystem Architecture
+caption src/opensquilla/skills/meta/
+
+' ===== Package declarations =====
+
+package "meta" #LightBlue {
+  [__init__.py] as init_py
+  [types.py] as types_py
+  [events.py] as events_py
+  [orchestrator.py] as orch_py
+  [parser.py] as parser_py
+  [scheduler.py] as sched_py
+  [templating.py] as templ_py
+  [sop_compiler.py] as sop_py
+
+  package "executors" #LightYellow {
+    [__init__.py] as exec_init
+    [agent.py] as exec_agent
+    [llm_classify.py] as exec_llm
+    [skill_exec.py] as exec_shell
+    [tool_call.py] as exec_tool
+  }
+}
+
+' ===== External packages (stubs) =====
+package "engine" as ext_engine #LightGray {
+  [types]
+  [agent]
+}
+package "provider" as ext_prov #LightGray {
+  [protocol]
+  [types]
+}
+package "persistence" as ext_pers #LightGray {
+  [meta_run_writer]
+}
+package "tool_boundary" as ext_tb #LightGray {
+  [ToolCall]
+}
+package "skills" as ext_skills #LightGray {
+  [types]
+}
+
+' ===== External libraries =====
+rectangle "jinja2" as lib_jinja #PaleGreen
+rectangle "asyncio" as lib_async #PaleGreen
+rectangle "graphlib" as lib_graph #PaleGreen
+rectangle "yaml" as lib_yaml #PaleGreen
+rectangle "structlog" as lib_log #PaleGreen
+
+' ===== Data flow =====
+
+types_py --> parser_py : exports dataclasses
+types_py --> orch_py
+types_py --> sched_py
+types_py --> templ_py
+types_py --> exec_agent
+types_py --> exec_llm
+types_py --> exec_shell
+types_py --> exec_tool
+
+parser_py --> sched_py : topological_order
+
+templ_py --> exec_agent : format_step_prompt, render_with_args
+templ_py --> exec_llm : _coerce_to_choice, _format_classify_prompt
+templ_py --> exec_shell : _JINJA_ENV, render_with_args
+templ_py --> exec_tool : render_with_args
+templ_py --> sched_py : resolve_route
+templ_py --> orch_py : re-exports
+
+events_py --> exec_agent : _StepDone
+events_py --> exec_llm : _StepDone
+events_py --> sched_py : _StepDone, _FailoverTriggered, yield_skill_view_preface
+events_py --> orch_py : yield_skill_view_preface
+
+sched_py --> orch_py : run_dag
+exec_agent --> sched_py : step events
+exec_llm --> sched_py
+exec_shell --> sched_py
+exec_tool --> sched_py
+
+sop_py --> parser_py : raises MetaPlanError
+sop_py --> ext_skills : uses SkillLoader
+
+orch_py --> ext_engine : AgentEvent, AgentConfig, TextDeltaEvent
+orch_py --> ext_prov : LLMProvider, ChatConfig
+orch_py --> ext_pers : MetaRunWriter
+orch_py --> ext_tb : ToolCall
+orch_py --> ext_skills : SkillSpec
+
+templ_py --> lib_jinja
+sched_py --> lib_async
+sched_py --> lib_log
+sop_py --> lib_yaml
+parser_py --> lib_graph
+
+exec_tool --> exec_llm : _drain_agent_runner
+
+init_py --> types_py : __all__ from types
+init_py --> parser_py : parse_meta_plan, topological_order
+
+legend right
+  **Hotspots (90d)**
+  orchestrator.py  19 commits
+  sop_compiler.py   9
+  scheduler.py      6
+  events.py         3
+  skill_exec.py     3
+  types.py          2
+  parser.py         2
+end legend
+
+@enduml
+```
+
+## Meta-Skill Subsystem (drawio source)
+
+`src/opensquilla/skills/meta/architecture.drawio`
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<mxfile host="app.diagrams.net" modified="2026-05-23T06:32:00.000Z" agent="opensquilla" version="24.2.5">
+  <diagram id="meta-skill-arch" name="Meta-Skill Architecture">
+    <!-- See src/opensquilla/skills/meta/architecture.drawio for the full source. -->
+  </diagram>
+</mxfile>
+```
+
+For the full drawio payload (including the gzipped diagram body), open
+`src/opensquilla/skills/meta/architecture.drawio` directly in the draw.io
+desktop app or at <https://app.diagrams.net>.

--- a/docs/features/compaction-and-cache.md
+++ b/docs/features/compaction-and-cache.md
@@ -7,6 +7,24 @@ keep long-running tasks moving.
 Compaction is separate from memory. Memory is durable recall. Compaction is an
 active-session continuity tool.
 
+```mermaid
+flowchart TB
+    Turn([Agent turn starts])
+    History[(Session history)]
+    Budget{Context budget<br/>exceeded?}
+    NoOp[Already within budget<br/>no compact applied]
+    Compact[Summarize older entries<br/>into durable summary]
+    Tail[Keep recent tail active]
+    Next[Next turn sees:<br/>summary + recent tail]
+    Cache[Cache-aware prompt:<br/>stable prefix + volatile tail]
+    LLM[Provider call]
+
+    Turn --> History --> Budget
+    Budget -->|no| NoOp --> Next
+    Budget -->|yes| Compact --> Tail --> Next
+    Next --> Cache --> LLM --> Turn
+```
+
 ## What Compaction Does
 
 When session history approaches the configured context budget, OpenSquilla can

--- a/docs/features/memory.md
+++ b/docs/features/memory.md
@@ -7,6 +7,24 @@ previous decisions, and notes that should survive across sessions.
 Memory is separate from skills. Skills teach the agent how to do a task; memory
 stores useful facts and context the agent may need later.
 
+```mermaid
+flowchart LR
+    User([User / chat surface])
+    Ask[Ask: Remember X]
+    Save[memory save]
+    Index[Memory index<br/>+ embeddings]
+    Store[(Memory store<br/>+ session-derived)]
+    Search[memory search]
+    Recall[Top-k recall injected<br/>into next prompt]
+    Flush[memory flush-session]
+    Repair[memory repair]
+
+    User --> Ask --> Save --> Index --> Store
+    Store --> Search --> Recall --> User
+    Session[Long session] --> Flush --> Store
+    Store --> Repair
+```
+
 ## What to Store
 
 Good memory entries are stable and reusable:

--- a/docs/features/meta-skills.md
+++ b/docs/features/meta-skills.md
@@ -8,6 +8,25 @@ For the full user-facing guide, read
 [`meta-skill-user-guide.md`](meta-skill-user-guide.md). For authoring rules,
 read [`../authoring/meta-skills.md`](../authoring/meta-skills.md).
 
+```mermaid
+flowchart LR
+    User([User])
+    Cmd["/meta meta-name<br/>(chat slash command)"]
+    Loader[MetaSkill loader]
+    Plan[Parse DAG plan<br/>topological order]
+    Steps[Step executor<br/>skills + tools + checks]
+    Draft[Intermediate drafts]
+    Synth[Final synthesis pass]
+    Run[(Run history<br/>skills meta runs)]
+    Proposal[(Proposals<br/>before promotion)]
+
+    User --> Cmd --> Loader --> Plan --> Steps
+    Steps --> Draft --> Steps
+    Steps --> Synth --> User
+    Steps --> Run
+    Steps -. meta-skill-creator .-> Proposal
+```
+
 ## Skills vs Meta-Skills
 
 | Capability | Use it for |

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -7,6 +7,24 @@ possible instruction into every prompt.
 Skills are separate from memory. Memory stores facts; skills describe repeatable
 ways to work.
 
+```mermaid
+flowchart LR
+    User([User request])
+    Catalog[(Installed skill catalog<br/>bundled + taps)]
+    Match{Skill description<br/>matches task?}
+    Load[Load skill instructions<br/>+ scripts]
+    Tools[Use skill tools<br/>on next turn]
+    Run[Run skill script]
+    Result[Skill result]
+
+    User --> Match
+    Catalog --> Match
+    Match -->|yes| Load --> Tools
+    Match -->|no| Catalog
+    Tools --> Run --> Result --> User
+    User -.skills install / tap add.-> Catalog
+```
+
 ## What Skills Are For
 
 Use skills for repeatable work patterns such as:

--- a/docs/features/squilla-router.md
+++ b/docs/features/squilla-router.md
@@ -7,6 +7,25 @@ run on the most expensive model.
 Use this page when you want to enable routing, understand what it changes, or
 decide whether a fixed provider/model is better for a specific run.
 
+```mermaid
+flowchart LR
+    Turn([Incoming turn])
+    Router[SquillaRouter<br/>local classifier]
+    Catalog[(Provider catalog<br/>OpenRouter, OpenAI, ...)]
+    Cheap[Cheap tier<br/>routine turns]
+    Strong[Strong tier<br/>hard reasoning]
+    Baseline[Baseline model<br/>when routing disabled]
+    Meta[Router metadata<br/>tier, confidence, fallback]
+    HUD[TUI Router HUD<br/>display-only]
+
+    Turn --> Router
+    Catalog --> Router
+    Router -->|easy| Cheap --> Meta
+    Router -->|hard| Strong --> Meta
+    Router -. disabled .-> Baseline --> Meta
+    Meta --> HUD
+```
+
 ## Why Use It
 
 SquillaRouter is useful when you want:

--- a/docs/features/tool-compression.md
+++ b/docs/features/tool-compression.md
@@ -9,6 +9,28 @@ This is a user-facing context-management feature. It does not change what the
 tool returned; it changes how much of that result is shown to the model for the
 next step.
 
+```mermaid
+flowchart LR
+    Tool([Tool call])
+    Raw[Raw result<br/>runtime view]
+    Mode{Compression mode}
+    Trunc[truncate:<br/>head + tail preview]
+    Summ[summarize:<br/>background model call]
+    Proj[Structured projection:<br/>logs / JSON / tables]
+    Preview[Compact preview<br/>provider view]
+    Handle[tool_result_handle<br/>out-of-band reference]
+    Next[Next turn prompt]
+    Export[Session export / diagnostics]
+
+    Tool --> Raw --> Mode
+    Mode -->|truncate| Trunc --> Preview
+    Mode -->|summarize| Summ --> Preview
+    Mode -->|structured| Proj --> Preview
+    Raw --> Handle
+    Preview --> Next
+    Raw --> Export
+```
+
 ## Why It Matters
 
 Tool compression helps when:

--- a/docs/features/tui-frontend.md
+++ b/docs/features/tui-frontend.md
@@ -23,6 +23,26 @@ The stable default terminal chat is Python-native and does not require Bun,
 npm, or OpenTUI node modules. OpenTUI is a source-checkout preview backend
 selected explicitly with `OPENSQUILLA_TUI_BACKEND=opentui`.
 
+```mermaid
+flowchart LR
+    Backend{OPENSQUILLA_TUI_BACKEND}
+    Native[Native backend<br/>stable default]
+    OpenTUI[OpenTUI preview backend]
+    Stream[Streaming plane<br/>batched token deltas]
+    UI[Structured UI plane<br/>TUI domain events]
+    Plugins[Plugin slots<br/>router_hud, status,<br/>tool_activity, usage, inspector]
+    HUD[Router HUD<br/>display-only]
+    Terminal[Terminal output]
+
+    Backend -->|unset / native| Native
+    Backend -->|opentui| OpenTUI
+    Native --> Stream --> Terminal
+    OpenTUI --> Stream --> Terminal
+    Native --> UI --> Plugins --> Terminal
+    OpenTUI --> UI --> Plugins
+    Plugins --> HUD
+```
+
 ## Plugin Slots
 
 Plugins consume renderer-independent events and publish small snapshots through

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -7,6 +7,30 @@ OpenSquilla surfaces work best when the gateway is running.
 Use this page when you want to start, stop, inspect, expose, or troubleshoot
 the gateway.
 
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client as Client<br/>(Web UI / CLI / Channel)
+    participant TCP as TCP bind<br/>127.0.0.1:18791
+    participant Auth as Auth / token check
+    participant Router as RPC router
+    participant Runtime as Agent runtime<br/>+ sessions
+    participant Disk as SQLite + artifacts
+
+    Client->>TCP: HTTP / WS connect
+    TCP->>Auth: parse headers & token
+    alt token valid
+        Auth->>Router: forward request
+        Router->>Runtime: invoke handler<br/>(chat / sessions / cron / ...)
+        Runtime->>Disk: load + persist session
+        Runtime-->>Router: result / stream
+        Router-->>Client: 200 OK or streaming events
+    else token missing / invalid
+        Auth-->>Client: 401 Unauthorized
+    end
+    Note over Client,TCP: Ctrl+C / SIGTERM / POST /api/system/shutdown<br/>triggers graceful drain of in-flight turns
+```
+
 ## Foreground Gateway
 
 Run the gateway in the current terminal:

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -7,6 +7,31 @@ workflows through the Model Context Protocol.
 The MCP bridge is an integration surface. It is separate from OpenSquilla's Web
 UI, CLI, channels, and gateway control console.
 
+```mermaid
+graph TB
+    Host[Host MCP client<br/>e.g. Claude Desktop, IDE]
+    Bridge[opensquilla mcp-server run<br/>stdio MCP server]
+    Gateway[OpenSquilla gateway<br/>ws://localhost:18791/ws]
+    RPC[Gateway RPC surface]
+    Sessions[(Session store)]
+    Tools[Tool registry]
+    Memory[(Memory store)]
+    Channels[Channel adapters]
+    Cron[Cron scheduler]
+
+    Host <-->|stdio JSON-RPC| Bridge
+    Bridge <-->|websocket RPC| Gateway
+    Gateway --> RPC
+    RPC --> Sessions
+    RPC --> Tools
+    RPC --> Memory
+    RPC --> Channels
+    RPC --> Cron
+
+    classDef bridge fill:#fdf6b2,stroke:#946c00;
+    class Bridge bridge;
+```
+
 ## Requirements
 
 Install OpenSquilla with the MCP extra when you need this bridge:

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -12,6 +12,20 @@ Use sessions when you want to:
 - abort a long-running turn without deleting the session;
 - delete old sessions after you no longer need them.
 
+```mermaid
+stateDiagram-v2
+    [*] --> created: first message
+    created --> active: turn starts
+    active --> idle: turn finishes
+    idle --> active: new turn
+    active --> aborted: sessions abort
+    aborted --> idle: keep transcript
+    idle --> closed: sessions delete
+    active --> compacted: context pressure
+    compacted --> active: summary injected
+    closed --> [*]
+```
+
 ## Requirements
 
 Session commands use the gateway RPC surface. Start or connect to the gateway


### PR DESCRIPTION
## Summary

Adds architecture diagrams to OpenSquilla's documentation:

- Renders the existing `docs/architecture.puml` and `docs/architecture.drawio` source files (or embeds them as fenced source blocks if no rendering tool is available in CI).
- Adds one mermaid diagram per doc across `docs/agents.md`, `docs/gateway.md`, `docs/mcp-server.md`, `docs/channels.md`, `docs/sessions.md`, and `docs/features/*` — capturing the flow described in each file's prose.
- Creates a root `AGENTS.md` mirroring `bytedance/deer-flow`'s structure: project overview, repo map, per-module docs links, commands, conventions.
- Adds a one-line `CLAUDE.md` that imports `AGENTS.md`.

## Why

OpenSquilla's docs are exclusively text-only prose. Recent diagram inventory across three repos (deer-flow, OpenViking, OpenSquilla) confirmed this is the largest documentation gap among our contribution targets.

Diagrams make the architecture immediately scannable for:
- New contributors orienting themselves
- Triagers answering questions in issues
- Reviewers verifying a change matches the documented design

## What I did NOT do

- Did not change any `*.py` or `*.ts` source files.
- Did not introduce new build/runtime dependencies (e.g. plantuml CLI). If rendering was not available locally, embedded puml/drawio as fenced source.
- Did not change any visible user-facing copy in `README.md` (only added a link to `AGENTS.md` if missing — preserve the original README structure).

## Note on root AGENTS.md / CLAUDE.md

The repo's `.gitignore` explicitly ignores top-level `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` (with a template exception at `src/opensquilla/identity/templates/bootstrap/AGENTS.md`). I force-added the new root files because the task requested a deer-flow-style orientation layer; reviewers are welcome to revisit that decision if the bootstrap-template convention is the project's deliberate preference.

## Test plan

- [ ] `uv run ruff check` clean (no source changes expected)
- [ ] All added mermaid blocks render in GitHub PR preview
- [ ] All embedded puml/drawio fence blocks are syntactically valid
- [ ] `AGENTS.md` links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)