### PR TITLE
Freeze RC4 profile layout upgrade contracts

### DIFF
--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -112,12 +112,21 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
     src/opensquilla/cli/tui/opentui/package/*)
       mark_tui_changed
       ;;
+    .github/workflows/ci.yml | .github/scripts/classify-ci-changes.sh)
+      # Changes to the gate itself must exercise every path it can suppress.
+      mark_full_required
+      ;;
     .github/workflows/wheelhouse-release.yml)
       mark_ci_changed
       mark_release_changed
       ;;
     .github/workflows/*)
       mark_ci_changed
+      ;;
+    .github/scripts/verify-release-profile-preservation.py)
+      mark_ci_changed
+      mark_release_changed
+      mark_platform_sensitive_changed
       ;;
     .github/scripts/*)
       mark_ci_changed
@@ -126,7 +135,7 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_test_changed
       mark_release_changed
       ;;
-    tests/test_tools/test_shell_* | tests/test_tools/test_path_* | tests/test_sandbox/* | tests/test_desktop/* | tests/test_compat/*)
+    tests/test_tools/test_shell_* | tests/test_tools/test_path_* | tests/test_sandbox/* | tests/test_desktop/* | tests/test_compat/* | tests/test_recovery/* | tests/test_migration/test_opensquilla_home_migration.py | tests/test_migration/test_source_snapshot_windows.py)
       mark_test_changed
       mark_platform_sensitive_changed
       ;;
@@ -152,11 +161,16 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
     install.sh | install.ps1 | start.sh | start.ps1 | README.release.md | RELEASES.md)
       mark_release_changed
       ;;
+    desktop/electron/scripts/test-packaged-update-policy.mjs)
+      mark_desktop_changed
+      mark_platform_sensitive_changed
+      mark_release_changed
+      ;;
     desktop/*)
       mark_platform_sensitive_changed
       mark_desktop_changed
       ;;
-    src/opensquilla/persistence/* | src/opensquilla/sandbox/* | src/opensquilla/tools/boundary.py | src/opensquilla/tools/builtin/code_exec.py | src/opensquilla/tools/builtin/filesystem.py | src/opensquilla/tools/builtin/git.py | src/opensquilla/tools/builtin/shell.py | src/opensquilla/tools/builtin/shell_policy.py | src/opensquilla/tools/path_* | src/opensquilla/tools/policy* | src/opensquilla/tools/write_*)
+    src/opensquilla/recovery/* | src/opensquilla/migration/* | src/opensquilla/persistence/* | src/opensquilla/sandbox/* | src/opensquilla/tools/boundary.py | src/opensquilla/tools/builtin/code_exec.py | src/opensquilla/tools/builtin/filesystem.py | src/opensquilla/tools/builtin/git.py | src/opensquilla/tools/builtin/shell.py | src/opensquilla/tools/builtin/shell_policy.py | src/opensquilla/tools/path_* | src/opensquilla/tools/policy* | src/opensquilla/tools/write_*)
       mark_runtime_changed
       mark_platform_sensitive_changed
       ;;

--- a/docs/features/desktop-profile-recovery.md
+++ b/docs/features/desktop-profile-recovery.md
@@ -1,0 +1,21 @@
+# Desktop Profile Recovery Contract
+
+## Stable layout
+
+`H` is an OpenSquilla profile root. Desktop passes `OPENSQUILLA_STATE_DIR=H`;
+the variable does not name the `state/` child.
+
+```text
+H/
+├── config.toml
+├── workspace/
+├── skills/
+├── media/
+├── session-archive/
+├── router/
+└── state/
+```
+
+Workspace selection changes identity, persona, and Markdown memory. Session and
+scheduler databases remain under `state/`; choosing a workspace never switches
+or merges chat history.

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -501,12 +501,18 @@ def test_ci_change_classifier_tracks_ci_dependency_and_release_changes(tmp_path:
 
     assert outputs == _expected_classifier_outputs(
         runtime_changed="true",
+        test_changed="true",
         ci_changed="true",
         dependency_changed="true",
         release_changed="true",
         windows_full_required="true",
+        frontend_changed="true",
+        tui_changed="true",
+        desktop_changed="true",
         python_changed="true",
+        platform_sensitive_changed="true",
         build_wheel_required="true",
+        full_required="true",
     )
 
 
@@ -557,6 +563,95 @@ def test_ci_change_classifier_tracks_platform_sensitive_changes(tmp_path: Path) 
         test_changed="true",
         windows_full_required="true",
         python_changed="true",
+        platform_sensitive_changed="true",
+    )
+
+
+def test_ci_change_classifier_runs_windows_full_for_native_source_snapshot(
+    tmp_path: Path,
+) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        ["tests/test_migration/test_source_snapshot_windows.py"],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        test_changed="true",
+        windows_full_required="true",
+        python_changed="true",
+        platform_sensitive_changed="true",
+    )
+
+
+def test_ci_change_classifier_runs_windows_full_for_native_source_snapshot_implementation(
+    tmp_path: Path,
+) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        ["src/opensquilla/migration/source_snapshot_windows.py"],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        runtime_changed="true",
+        windows_full_required="true",
+        python_changed="true",
+        platform_sensitive_changed="true",
+        build_wheel_required="true",
+    )
+
+
+def test_ci_change_classifier_runs_full_for_its_own_windows_gate(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [".github/workflows/ci.yml"],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        runtime_changed="true",
+        test_changed="true",
+        ci_changed="true",
+        dependency_changed="true",
+        release_changed="true",
+        windows_full_required="true",
+        frontend_changed="true",
+        tui_changed="true",
+        desktop_changed="true",
+        python_changed="true",
+        platform_sensitive_changed="true",
+        build_wheel_required="true",
+        full_required="true",
+    )
+
+
+def test_ci_change_classifier_runs_windows_release_gates_for_profile_verifier(
+    tmp_path: Path,
+) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [".github/scripts/verify-release-profile-preservation.py"],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        ci_changed="true",
+        release_changed="true",
+        windows_full_required="true",
+        python_changed="true",
+        platform_sensitive_changed="true",
+    )
+
+
+def test_ci_change_classifier_tracks_packaged_update_policy_probe_as_release_surface(
+    tmp_path: Path,
+) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        ["desktop/electron/scripts/test-packaged-update-policy.mjs"],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        release_changed="true",
+        windows_full_required="true",
+        desktop_changed="true",
         platform_sensitive_changed="true",
     )
 

--- a/tests/test_migration/fixtures/homes/desktop-0.4/config.toml
+++ b/tests/test_migration/fixtures/homes/desktop-0.4/config.toml
@@ -2,7 +2,7 @@
 # writeDesktopConfig from desktop-credential.json — a short generated file,
 # not a full schema dump. Pre-rc2 desktops emit t0-t3 tier keys; current code
 # canonicalizes them to c0-c3 on read. Synthetic values only.
-state_dir = "/home/dummyuser/Library/Application Support/OpenSquilla/opensquilla/state"
+state_dir = "/Users/dummyuser/Library/Application Support/OpenSquilla/opensquilla/state"
 search_provider = "brave"
 search_api_key_env = "BRAVE_API_KEY"
 

--- a/tests/test_migration/fixtures/homes/desktop-0.5rc/config.toml
+++ b/tests/test_migration/fixtures/homes/desktop-0.5rc/config.toml
@@ -2,7 +2,7 @@
 # c0-c3 rename landed in rc2), plus the rc1-era [privacy] section. The file
 # carries no config_version stamp — rc1 predates the stamp, so current code
 # treats it as version 0 and walks the gated migrations. Synthetic values.
-state_dir = "/home/dummyuser/Library/Application Support/OpenSquilla/opensquilla/state"
+state_dir = "/Users/dummyuser/Library/Application Support/OpenSquilla/opensquilla/state"
 search_provider = "brave"
 search_api_key_env = "BRAVE_API_KEY"
 

--- a/tests/test_recovery/__init__.py
+++ b/tests/test_recovery/__init__.py
@@ -1,0 +1,1 @@
+"""Desktop profile recovery contract tests."""

--- a/tests/test_recovery/fixtures/desktop/frozen-profile-snapshots.json
+++ b/tests/test_recovery/fixtures/desktop/frozen-profile-snapshots.json
@@ -1,0 +1,206 @@
+{
+  "schema_version": 1,
+  "provenance": {
+    "purpose": "Sanitized on-disk profile trees frozen from released Desktop tags; content is synthetic but paths and writer contracts are release-derived.",
+    "audit_method": "Each source record pins the annotated tag commit and the exact Git blobs containing the Electron writer and Python path contract."
+  },
+  "snapshots": [
+    {
+      "id": "v0.4.0-unpinned",
+      "release_tag": "v0.4.0",
+      "source": {
+        "release_commit": "5882266bbada7f6334367aa3f68ec86f5e1816a9",
+        "desktop_main_path": "desktop/electron/src/main.ts",
+        "desktop_main_blob": "3b8be4e29bdcbebc1d75f574d8dd92af9c76a67c",
+        "python_paths_path": "src/opensquilla/paths.py",
+        "python_paths_blob": "0871bcf73359ba2d198ee414d54a20e8c3e18dc2",
+        "state_dir_writer_line": 679,
+        "gateway_spawn_line": 2294,
+        "gateway_env_home": "H/state"
+      },
+      "tree": [
+        {"path": "config.toml", "kind": "config", "template": "released-configs/v0.4.0.toml"},
+        {"path": "state/sessions.db", "kind": "sqlite_sessions"},
+        {"path": "state/workspace/USER.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/SOUL.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/IDENTITY.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/MEMORY.md", "kind": "identity_markdown"},
+        {"path": "state/skills/synthetic-skill/SKILL.md", "kind": "text", "content": "# Synthetic historical skill\n"},
+        {"path": "state/skills-taps.json", "kind": "text", "content": "{\"taps\": []}\n"},
+        {"path": "state/skills-lock.json", "kind": "text", "content": "{\"skills\": []}\n"},
+        {"path": "state/session-archive/archive.json", "kind": "text", "content": "{\"synthetic\": true}\n"},
+        {"path": "state/router/calibration.json", "kind": "text", "content": "{\"synthetic\": true}\n"},
+        {"path": "state/.env", "kind": "text", "content": "SYNTHETIC_FIXTURE=true\n"},
+        {"path": "state/state/approvals.json", "kind": "text", "content": "{\"items\": []}\n"},
+        {"path": "media/synthetic.txt", "kind": "text", "content": "historical media stays at H/media\n"}
+      ]
+    },
+    {
+      "id": "v0.4.1-unpinned",
+      "release_tag": "v0.4.1",
+      "source": {
+        "release_commit": "714385e3e9c5bccbd0c0bca817ceb705fd119fdc",
+        "desktop_main_path": "desktop/electron/src/main.ts",
+        "desktop_main_blob": "9c3de1f49e1d2e39349a8f320ef39fd55bdcc4b7",
+        "python_paths_path": "src/opensquilla/paths.py",
+        "python_paths_blob": "0871bcf73359ba2d198ee414d54a20e8c3e18dc2",
+        "state_dir_writer_line": 728,
+        "gateway_spawn_line": 3037,
+        "gateway_env_home": "H/state"
+      },
+      "tree": [
+        {"path": "config.toml", "kind": "config", "template": "released-configs/v0.4.1.toml"},
+        {"path": "state/sessions.db", "kind": "sqlite_sessions"},
+        {"path": "state/workspace/USER.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/SOUL.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/IDENTITY.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/MEMORY.md", "kind": "identity_markdown"},
+        {"path": "state/skills/synthetic-skill/SKILL.md", "kind": "text", "content": "# Synthetic historical skill\n"},
+        {"path": "state/skills-taps.json", "kind": "text", "content": "{\"taps\": []}\n"},
+        {"path": "state/skills-lock.json", "kind": "text", "content": "{\"skills\": []}\n"},
+        {"path": "state/session-archive/archive.json", "kind": "text", "content": "{\"synthetic\": true}\n"},
+        {"path": "state/router/calibration.json", "kind": "text", "content": "{\"synthetic\": true}\n"},
+        {"path": "state/.env", "kind": "text", "content": "SYNTHETIC_FIXTURE=true\n"},
+        {"path": "state/state/approvals.json", "kind": "text", "content": "{\"items\": []}\n"},
+        {"path": "media/synthetic.txt", "kind": "text", "content": "historical media stays at H/media\n"}
+      ]
+    },
+    {
+      "id": "v0.5.0rc1-unpinned",
+      "release_tag": "v0.5.0rc1",
+      "source": {
+        "release_commit": "e3f06da26d52591bcc4a566bdb708187f35a8018",
+        "desktop_main_path": "desktop/electron/src/main.ts",
+        "desktop_main_blob": "7332533208b4107534ff8496cb7068c78c6036a2",
+        "python_paths_path": "src/opensquilla/paths.py",
+        "python_paths_blob": "8620e51f2e7105da693bda327acefa43627a4444",
+        "state_dir_writer_line": 836,
+        "gateway_spawn_line": 3304,
+        "gateway_env_home": "H/state"
+      },
+      "tree": [
+        {"path": "config.toml", "kind": "config", "template": "released-configs/v0.5.0rc1.toml"},
+        {"path": "state/sessions.db", "kind": "sqlite_sessions"},
+        {"path": "state/workspace/USER.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/SOUL.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/IDENTITY.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/MEMORY.md", "kind": "identity_markdown"},
+        {"path": "state/skills/synthetic-skill/SKILL.md", "kind": "text", "content": "# Synthetic historical skill\n"},
+        {"path": "state/skills-taps.json", "kind": "text", "content": "{\"taps\": []}\n"},
+        {"path": "state/skills-lock.json", "kind": "text", "content": "{\"skills\": []}\n"},
+        {"path": "state/session-archive/archive.json", "kind": "text", "content": "{\"synthetic\": true}\n"},
+        {"path": "state/router/calibration.json", "kind": "text", "content": "{\"synthetic\": true}\n"},
+        {"path": "state/.env", "kind": "text", "content": "SYNTHETIC_FIXTURE=true\n"},
+        {"path": "state/state/approvals.json", "kind": "text", "content": "{\"items\": []}\n"},
+        {"path": "media/synthetic.txt", "kind": "text", "content": "historical media stays at H/media\n"}
+      ]
+    },
+    {
+      "id": "v0.5.0rc2-unpinned",
+      "release_tag": "v0.5.0rc2",
+      "source": {
+        "release_commit": "ba9bf47ed6f691a64c4047c3267b189b76fa4da4",
+        "desktop_main_path": "desktop/electron/src/main.ts",
+        "desktop_main_blob": "abe03ae730d90497d5f1eece11e6f915888fba22",
+        "python_paths_path": "src/opensquilla/paths.py",
+        "python_paths_blob": "8620e51f2e7105da693bda327acefa43627a4444",
+        "state_dir_writer_line": 933,
+        "gateway_spawn_line": 3452,
+        "gateway_env_home": "H/state"
+      },
+      "tree": [
+        {"path": "config.toml", "kind": "config", "template": "released-configs/v0.5.0rc2.toml"},
+        {"path": "state/sessions.db", "kind": "sqlite_sessions"},
+        {"path": "state/workspace/USER.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/SOUL.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/IDENTITY.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/MEMORY.md", "kind": "identity_markdown"},
+        {"path": "state/skills/synthetic-skill/SKILL.md", "kind": "text", "content": "# Synthetic historical skill\n"},
+        {"path": "state/skills-taps.json", "kind": "text", "content": "{\"taps\": []}\n"},
+        {"path": "state/skills-lock.json", "kind": "text", "content": "{\"skills\": []}\n"},
+        {"path": "state/session-archive/archive.json", "kind": "text", "content": "{\"synthetic\": true}\n"},
+        {"path": "state/router/calibration.json", "kind": "text", "content": "{\"synthetic\": true}\n"},
+        {"path": "state/.env", "kind": "text", "content": "SYNTHETIC_FIXTURE=true\n"},
+        {"path": "state/state/approvals.json", "kind": "text", "content": "{\"items\": []}\n"},
+        {"path": "media/synthetic.txt", "kind": "text", "content": "historical media stays at H/media\n"}
+      ]
+    },
+    {
+      "id": "v0.5.0rc2-legacy-workspace-pin",
+      "release_tag": "v0.5.0rc2",
+      "source": {
+        "release_commit": "ba9bf47ed6f691a64c4047c3267b189b76fa4da4",
+        "desktop_main_path": "desktop/electron/src/main.ts",
+        "desktop_main_blob": "abe03ae730d90497d5f1eece11e6f915888fba22",
+        "python_paths_path": "src/opensquilla/paths.py",
+        "python_paths_blob": "8620e51f2e7105da693bda327acefa43627a4444",
+        "state_dir_writer_line": 933,
+        "gateway_spawn_line": 3452,
+        "gateway_env_home": "H/state"
+      },
+      "tree": [
+        {"path": "config.toml", "kind": "config", "template": "released-configs/v0.5.0rc2-pinned.toml"},
+        {"path": "state/sessions.db", "kind": "sqlite_sessions"},
+        {"path": "state/workspace/USER.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/SOUL.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/IDENTITY.md", "kind": "identity_markdown"},
+        {"path": "state/workspace/MEMORY.md", "kind": "identity_markdown"},
+        {"path": "media/synthetic.txt", "kind": "text", "content": "historical media stays at H/media\n"}
+      ]
+    },
+    {
+      "id": "v0.5.0rc3-relocated-clean",
+      "release_tag": "v0.5.0rc3",
+      "source": {
+        "release_commit": "789b4f98bb70df07fa028fe07e4404317197bbbb",
+        "desktop_main_path": "desktop/electron/src/main.ts",
+        "desktop_main_blob": "88f14e6e230276b6c6f1b5e098de177a1b2ba000",
+        "python_paths_path": "src/opensquilla/paths.py",
+        "python_paths_blob": "626d7689364136bf3f6bda0f902eb5a1b3772e1e",
+        "state_dir_writer_line": 1654,
+        "gateway_spawn_line": 5117,
+        "relocation_line": 267,
+        "gateway_env_home": "H"
+      },
+      "tree": [
+        {"path": "config.toml", "kind": "config", "template": "released-configs/v0.5.0rc3.toml"},
+        {"path": "state/sessions.db", "kind": "sqlite_sessions"},
+        {"path": "workspace/USER.md", "kind": "identity_markdown"},
+        {"path": "workspace/SOUL.md", "kind": "identity_markdown"},
+        {"path": "workspace/IDENTITY.md", "kind": "identity_markdown"},
+        {"path": "workspace/MEMORY.md", "kind": "identity_markdown"},
+        {"path": "desktop-layout-v2.json", "kind": "text", "content": "{\"migratedAt\":\"2026-07-10T12:00:00.000Z\",\"moved\":[\"workspace\"]}\n"},
+        {"path": "media/synthetic.txt", "kind": "text", "content": "historical media stays at H/media\n"}
+      ]
+    },
+    {
+      "id": "v0.5.0rc3-dual-workspace-after-stale-pin",
+      "release_tag": "v0.5.0rc3",
+      "source": {
+        "release_commit": "789b4f98bb70df07fa028fe07e4404317197bbbb",
+        "desktop_main_path": "desktop/electron/src/main.ts",
+        "desktop_main_blob": "88f14e6e230276b6c6f1b5e098de177a1b2ba000",
+        "python_paths_path": "src/opensquilla/paths.py",
+        "python_paths_blob": "626d7689364136bf3f6bda0f902eb5a1b3772e1e",
+        "state_dir_writer_line": 1654,
+        "gateway_spawn_line": 5117,
+        "relocation_line": 267,
+        "gateway_env_home": "H"
+      },
+      "tree": [
+        {"path": "config.toml", "kind": "config", "template": "released-configs/v0.5.0rc3-pinned.toml"},
+        {"path": "state/sessions.db", "kind": "sqlite_sessions"},
+        {"path": "workspace/USER.md", "kind": "identity_markdown", "identity": "rc2-preserved"},
+        {"path": "workspace/SOUL.md", "kind": "identity_markdown", "identity": "rc2-preserved"},
+        {"path": "workspace/IDENTITY.md", "kind": "identity_markdown", "identity": "rc2-preserved"},
+        {"path": "workspace/MEMORY.md", "kind": "identity_markdown", "identity": "rc2-preserved"},
+        {"path": "state/workspace/USER.md", "kind": "identity_markdown", "identity": "rc3-new"},
+        {"path": "state/workspace/SOUL.md", "kind": "identity_markdown", "identity": "rc3-new"},
+        {"path": "state/workspace/IDENTITY.md", "kind": "identity_markdown", "identity": "rc3-new"},
+        {"path": "state/workspace/MEMORY.md", "kind": "identity_markdown", "identity": "rc3-new"},
+        {"path": "desktop-layout-v2.json", "kind": "text", "content": "{\"migratedAt\":\"2026-07-10T12:00:00.000Z\",\"moved\":[\"workspace\"]}\n"},
+        {"path": "media/synthetic.txt", "kind": "text", "content": "historical media stays at H/media\n"}
+      ]
+    }
+  ]
+}

--- a/tests/test_recovery/fixtures/desktop/released-configs/v0.4.0.toml
+++ b/tests/test_recovery/fixtures/desktop/released-configs/v0.4.0.toml
@@ -1,0 +1,35 @@
+# Sanitized output shape from v0.4.0 Desktop writeDesktopConfig.
+state_dir = {{STATE_DIR_TOML}}
+search_provider = "duckduckgo"
+
+[llm]
+provider = "openrouter"
+model = "synthetic/model"
+api_key_env = "OPENROUTER_API_KEY"
+base_url = "https://openrouter.ai/api/v1"
+
+[squilla_router]
+enabled = true
+rollout_phase = "full"
+default_tier = "t1"
+tier_profile = "openrouter"
+
+[squilla_router.tiers.t0]
+provider = "openrouter"
+model = "synthetic/tier-0"
+
+[squilla_router.tiers.t1]
+provider = "openrouter"
+model = "synthetic/tier-1"
+
+[squilla_router.tiers.t2]
+provider = "openrouter"
+model = "synthetic/tier-2"
+
+[squilla_router.tiers.t3]
+provider = "openrouter"
+model = "synthetic/tier-3"
+
+[control_ui]
+enabled = true
+base_path = "/control"

--- a/tests/test_recovery/fixtures/desktop/released-configs/v0.4.1.toml
+++ b/tests/test_recovery/fixtures/desktop/released-configs/v0.4.1.toml
@@ -1,0 +1,35 @@
+# Sanitized output shape from v0.4.1 Desktop writeDesktopConfig.
+state_dir = {{STATE_DIR_TOML}}
+search_provider = "duckduckgo"
+
+[llm]
+provider = "openrouter"
+model = "synthetic/model"
+api_key_env = "OPENROUTER_API_KEY"
+base_url = "https://openrouter.ai/api/v1"
+
+[squilla_router]
+enabled = true
+rollout_phase = "full"
+default_tier = "t1"
+tier_profile = "openrouter"
+
+[squilla_router.tiers.t0]
+provider = "openrouter"
+model = "synthetic/tier-0"
+
+[squilla_router.tiers.t1]
+provider = "openrouter"
+model = "synthetic/tier-1"
+
+[squilla_router.tiers.t2]
+provider = "openrouter"
+model = "synthetic/tier-2"
+
+[squilla_router.tiers.t3]
+provider = "openrouter"
+model = "synthetic/tier-3"
+
+[control_ui]
+enabled = true
+base_path = "/control"

--- a/tests/test_recovery/fixtures/desktop/released-configs/v0.5.0rc1.toml
+++ b/tests/test_recovery/fixtures/desktop/released-configs/v0.5.0rc1.toml
@@ -1,0 +1,38 @@
+# Sanitized output shape from v0.5.0rc1 Desktop writeDesktopConfig.
+state_dir = {{STATE_DIR_TOML}}
+search_provider = "duckduckgo"
+
+[llm]
+provider = "openrouter"
+model = "synthetic/model"
+api_key_env = "OPENROUTER_API_KEY"
+base_url = "https://openrouter.ai/api/v1"
+
+[squilla_router]
+enabled = true
+rollout_phase = "full"
+default_tier = "t1"
+tier_profile = "openrouter"
+
+[squilla_router.tiers.t0]
+provider = "openrouter"
+model = "synthetic/tier-0"
+
+[squilla_router.tiers.t1]
+provider = "openrouter"
+model = "synthetic/tier-1"
+
+[squilla_router.tiers.t2]
+provider = "openrouter"
+model = "synthetic/tier-2"
+
+[squilla_router.tiers.t3]
+provider = "openrouter"
+model = "synthetic/tier-3"
+
+[privacy]
+disable_network_observability = false
+
+[control_ui]
+enabled = true
+base_path = "/control"

--- a/tests/test_recovery/fixtures/desktop/released-configs/v0.5.0rc2-pinned.toml
+++ b/tests/test_recovery/fixtures/desktop/released-configs/v0.5.0rc2-pinned.toml
@@ -1,0 +1,42 @@
+# Sanitized v0.5.0rc2 Desktop config after the settings UI persisted workspace_dir.
+state_dir = {{STATE_DIR_TOML}}
+workspace_dir = {{LEGACY_WORKSPACE_TOML}}
+search_provider = "duckduckgo"
+
+[llm]
+provider = "openrouter"
+model = "synthetic/model"
+api_key_env = "OPENROUTER_API_KEY"
+base_url = "https://openrouter.ai/api/v1"
+
+[squilla_router]
+enabled = true
+rollout_phase = "full"
+default_tier = "c1"
+tier_profile = "openrouter"
+
+[squilla_router.tiers.c0]
+provider = "openrouter"
+model = "synthetic/tier-0"
+
+[squilla_router.tiers.c1]
+provider = "openrouter"
+model = "synthetic/tier-1"
+
+[squilla_router.tiers.c2]
+provider = "openrouter"
+model = "synthetic/tier-2"
+
+[squilla_router.tiers.c3]
+provider = "openrouter"
+model = "synthetic/tier-3"
+
+[llm_ensemble]
+enabled = false
+
+[privacy]
+disable_network_observability = false
+
+[control_ui]
+enabled = true
+base_path = "/control"

--- a/tests/test_recovery/fixtures/desktop/released-configs/v0.5.0rc2.toml
+++ b/tests/test_recovery/fixtures/desktop/released-configs/v0.5.0rc2.toml
@@ -1,0 +1,41 @@
+# Sanitized output shape from v0.5.0rc2 Desktop writeDesktopConfig.
+state_dir = {{STATE_DIR_TOML}}
+search_provider = "duckduckgo"
+
+[llm]
+provider = "openrouter"
+model = "synthetic/model"
+api_key_env = "OPENROUTER_API_KEY"
+base_url = "https://openrouter.ai/api/v1"
+
+[squilla_router]
+enabled = true
+rollout_phase = "full"
+default_tier = "c1"
+tier_profile = "openrouter"
+
+[squilla_router.tiers.c0]
+provider = "openrouter"
+model = "synthetic/tier-0"
+
+[squilla_router.tiers.c1]
+provider = "openrouter"
+model = "synthetic/tier-1"
+
+[squilla_router.tiers.c2]
+provider = "openrouter"
+model = "synthetic/tier-2"
+
+[squilla_router.tiers.c3]
+provider = "openrouter"
+model = "synthetic/tier-3"
+
+[llm_ensemble]
+enabled = false
+
+[privacy]
+disable_network_observability = false
+
+[control_ui]
+enabled = true
+base_path = "/control"

--- a/tests/test_recovery/fixtures/desktop/released-configs/v0.5.0rc3-pinned.toml
+++ b/tests/test_recovery/fixtures/desktop/released-configs/v0.5.0rc3-pinned.toml
@@ -1,0 +1,42 @@
+# Sanitized v0.5.0rc3 config preserving an RC2 settings-written workspace_dir pin.
+state_dir = {{STATE_DIR_TOML}}
+workspace_dir = {{LEGACY_WORKSPACE_TOML}}
+search_provider = "duckduckgo"
+
+[llm]
+provider = "openrouter"
+model = "synthetic/model"
+api_key_env = "OPENROUTER_API_KEY"
+base_url = "https://openrouter.ai/api/v1"
+
+[squilla_router]
+enabled = true
+rollout_phase = "full"
+default_tier = "c1"
+tier_profile = "openrouter"
+
+[squilla_router.tiers.c0]
+provider = "openrouter"
+model = "synthetic/tier-0"
+
+[squilla_router.tiers.c1]
+provider = "openrouter"
+model = "synthetic/tier-1"
+
+[squilla_router.tiers.c2]
+provider = "openrouter"
+model = "synthetic/tier-2"
+
+[squilla_router.tiers.c3]
+provider = "openrouter"
+model = "synthetic/tier-3"
+
+[llm_ensemble]
+enabled = false
+
+[privacy]
+disable_network_observability = false
+
+[control_ui]
+enabled = true
+base_path = "/control"

--- a/tests/test_recovery/fixtures/desktop/released-configs/v0.5.0rc3.toml
+++ b/tests/test_recovery/fixtures/desktop/released-configs/v0.5.0rc3.toml
@@ -1,0 +1,41 @@
+# Sanitized output shape from v0.5.0rc3 Desktop writeDesktopConfig.
+state_dir = {{STATE_DIR_TOML}}
+search_provider = "duckduckgo"
+
+[llm]
+provider = "openrouter"
+model = "synthetic/model"
+api_key_env = "OPENROUTER_API_KEY"
+base_url = "https://openrouter.ai/api/v1"
+
+[squilla_router]
+enabled = true
+rollout_phase = "full"
+default_tier = "c1"
+tier_profile = "openrouter"
+
+[squilla_router.tiers.c0]
+provider = "openrouter"
+model = "synthetic/tier-0"
+
+[squilla_router.tiers.c1]
+provider = "openrouter"
+model = "synthetic/tier-1"
+
+[squilla_router.tiers.c2]
+provider = "openrouter"
+model = "synthetic/tier-2"
+
+[squilla_router.tiers.c3]
+provider = "openrouter"
+model = "synthetic/tier-3"
+
+[llm_ensemble]
+enabled = false
+
+[privacy]
+disable_network_observability = false
+
+[control_ui]
+enabled = true
+base_path = "/control"

--- a/tests/test_recovery/fixtures/desktop/released-profiles.json
+++ b/tests/test_recovery/fixtures/desktop/released-profiles.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": 1,
+  "provenance": {
+    "desktop_home_expression": "join(app.getPath('userData'), 'opensquilla')",
+    "python_home_contract": "OPENSQUILLA_STATE_DIR is the OpenSquilla profile home",
+    "config_state_dir_expression": "H/state",
+    "verified_source_paths": [
+      "desktop/electron/src/main.ts",
+      "src/opensquilla/paths.py"
+    ],
+    "rc3_relocation_allowlist": [
+      "skills",
+      "skills-taps.json",
+      "skills-lock.json",
+      "workspace",
+      "session-archive",
+      "router",
+      ".env",
+      "state/*"
+    ]
+  },
+  "cases": [
+    {
+      "id": "v0.4.0-unpinned",
+      "release_tag": "v0.4.0",
+      "desktop_package_version": "0.4.0",
+      "gateway_env_home": "H/state",
+      "layout_template": "pre-rc3-nested",
+      "config_template": "desktop-unpinned.toml",
+      "include_nested_roles": true,
+      "expected_inspect": ["recovery_required", "legacy_workspace_reconcile_available"],
+      "expected_reconcile": ["ready", "canonical_workspace"],
+      "expected_effective_workspace": "workspace"
+    },
+    {
+      "id": "v0.4.1-unpinned",
+      "release_tag": "v0.4.1",
+      "desktop_package_version": "0.4.1",
+      "gateway_env_home": "H/state",
+      "layout_template": "pre-rc3-nested",
+      "config_template": "desktop-unpinned.toml",
+      "include_nested_roles": true,
+      "expected_inspect": ["recovery_required", "legacy_workspace_reconcile_available"],
+      "expected_reconcile": ["ready", "canonical_workspace"],
+      "expected_effective_workspace": "workspace"
+    },
+    {
+      "id": "v0.5.0rc1-unpinned",
+      "release_tag": "v0.5.0rc1",
+      "desktop_package_version": "0.5.0-rc1",
+      "gateway_env_home": "H/state",
+      "layout_template": "pre-rc3-nested",
+      "config_template": "desktop-unpinned.toml",
+      "include_nested_roles": true,
+      "expected_inspect": ["recovery_required", "legacy_workspace_reconcile_available"],
+      "expected_reconcile": ["ready", "canonical_workspace"],
+      "expected_effective_workspace": "workspace"
+    },
+    {
+      "id": "v0.5.0rc2-unpinned",
+      "release_tag": "v0.5.0rc2",
+      "desktop_package_version": "0.5.0-rc2",
+      "gateway_env_home": "H/state",
+      "layout_template": "pre-rc3-nested",
+      "config_template": "desktop-unpinned.toml",
+      "include_nested_roles": true,
+      "expected_inspect": ["recovery_required", "legacy_workspace_reconcile_available"],
+      "expected_reconcile": ["ready", "canonical_workspace"],
+      "expected_effective_workspace": "workspace"
+    },
+    {
+      "id": "v0.5.0rc2-legacy-workspace-pin",
+      "release_tag": "v0.5.0rc2",
+      "desktop_package_version": "0.5.0-rc2",
+      "gateway_env_home": "H/state",
+      "layout_template": "pre-rc3-nested",
+      "config_template": "desktop-pinned-legacy.toml",
+      "include_nested_roles": false,
+      "expected_inspect": ["attention", "legacy_workspace_pinned"],
+      "expected_reconcile": ["attention", "legacy_workspace_pinned"],
+      "expected_effective_workspace": "state/workspace"
+    },
+    {
+      "id": "v0.5.0rc3-relocated-clean",
+      "release_tag": "v0.5.0rc3",
+      "desktop_package_version": "0.5.0-rc3",
+      "gateway_env_home": "H",
+      "layout_template": "rc3-relocated-clean",
+      "config_template": "desktop-unpinned.toml",
+      "include_nested_roles": false,
+      "expected_inspect": ["ready", "canonical_workspace"],
+      "expected_reconcile": ["ready", "canonical_workspace"],
+      "expected_effective_workspace": "workspace"
+    },
+    {
+      "id": "v0.5.0rc3-dual-workspace-after-stale-pin",
+      "release_tag": "v0.5.0rc3",
+      "desktop_package_version": "0.5.0-rc3",
+      "gateway_env_home": "H",
+      "layout_template": "rc3-dual-after-stale-pin",
+      "config_template": "desktop-pinned-legacy.toml",
+      "include_nested_roles": false,
+      "expected_inspect": ["attention", "workspace_conflict"],
+      "expected_reconcile": ["attention", "workspace_conflict"],
+      "expected_effective_workspace": "state/workspace"
+    }
+  ]
+}

--- a/tests/test_recovery/fixtures/portable/released-profiles.json
+++ b/tests/test_recovery/fixtures/portable/released-profiles.json
@@ -1,0 +1,158 @@
+{
+  "schema_version": 1,
+  "provenance": {
+    "verified_source_path": "scripts/build_wheelhouse_zip.py",
+    "canonical_home_expression": "<LOCALAPPDATA-or-TEMP>/OpenSquilla/portable/<release-id>",
+    "gateway_config": "<portable-home>/config.toml",
+    "opensquilla_state_dir": "<portable-home>",
+    "runtime_state": "<portable-home>/state",
+    "workspace": "<portable-home>/workspace",
+    "release_id_contract": "opaque 12-character lowercase hexadecimal directory name"
+  },
+  "published_releases": [
+    {
+      "release_tag": "v0.1.0rc1",
+      "release_id": "010000000001",
+      "expected_era_hint": "",
+      "source": {
+        "release_commit": "73a084d2e8fda508f0fb536a2b03a97a3f1b72c8",
+        "builder_path": "scripts/build_wheelhouse_zip.py",
+        "builder_blob": "4190a8f4fe7f338e100e7e2dcfd34bff1ede651d",
+        "config_path": "src/opensquilla/gateway/config.py",
+        "config_blob": "f5afd58f95a21c37634d20d25077a09d2867debb",
+        "latest_migration_path": "migrations/V009__transcript_reasoning_content.py",
+        "latest_migration_blob": "5f9164d654610428b24e6914e5a0b3a30f468fe8",
+        "latest_migration_id": "V009__transcript_reasoning_content",
+        "opensquilla_state_dir": "<portable-home>",
+        "gateway_state_dir": "<portable-home>/state",
+        "gateway_workspace_dir": "<portable-home>/workspace"
+      }
+    },
+    {
+      "release_tag": "v0.2.0rc1",
+      "release_id": "020000000001",
+      "expected_era_hint": "",
+      "source": {
+        "release_commit": "2158f56c1a0684168a013b4b4846233977d0067b",
+        "builder_path": "scripts/build_wheelhouse_zip.py",
+        "builder_blob": "6bf4440961e8311afc4f793eaffdcc5da3528dad",
+        "config_path": "src/opensquilla/gateway/config.py",
+        "config_blob": "2170965161378ccc1ee7749fd790aeda6d52bf10",
+        "latest_migration_path": "migrations/V009__transcript_reasoning_content.py",
+        "latest_migration_blob": "5f9164d654610428b24e6914e5a0b3a30f468fe8",
+        "latest_migration_id": "V009__transcript_reasoning_content",
+        "opensquilla_state_dir": "<portable-home>",
+        "gateway_state_dir": "<portable-home>/state",
+        "gateway_workspace_dir": "<portable-home>/workspace"
+      }
+    },
+    {
+      "release_tag": "v0.2.0",
+      "release_id": "020000000002",
+      "expected_era_hint": "",
+      "source": {
+        "release_commit": "417e53dbc29036e8c5fcf1e0d5970c03a3357ae2",
+        "builder_path": "scripts/build_wheelhouse_zip.py",
+        "builder_blob": "6bf4440961e8311afc4f793eaffdcc5da3528dad",
+        "config_path": "src/opensquilla/gateway/config.py",
+        "config_blob": "2170965161378ccc1ee7749fd790aeda6d52bf10",
+        "latest_migration_path": "migrations/V009__transcript_reasoning_content.py",
+        "latest_migration_blob": "5f9164d654610428b24e6914e5a0b3a30f468fe8",
+        "latest_migration_id": "V009__transcript_reasoning_content",
+        "opensquilla_state_dir": "<portable-home>",
+        "gateway_state_dir": "<portable-home>/state",
+        "gateway_workspace_dir": "<portable-home>/workspace"
+      }
+    },
+    {
+      "release_tag": "v0.2.1",
+      "release_id": "020100000001",
+      "expected_era_hint": "",
+      "source": {
+        "release_commit": "754253cd71b37bfaa453cb79b14236a4ef5ba964",
+        "builder_path": "scripts/build_wheelhouse_zip.py",
+        "builder_blob": "afb936153360ebb00d422e2f096dea818342ca10",
+        "config_path": "src/opensquilla/gateway/config.py",
+        "config_blob": "2170965161378ccc1ee7749fd790aeda6d52bf10",
+        "latest_migration_path": "migrations/V010__transcript_turn_usage.py",
+        "latest_migration_blob": "2652affdb5588ac352b63d959dea8c009d162b74",
+        "latest_migration_id": "V010__transcript_turn_usage",
+        "opensquilla_state_dir": "<portable-home>",
+        "gateway_state_dir": "<portable-home>/state",
+        "gateway_workspace_dir": "<portable-home>/workspace"
+      }
+    },
+    {
+      "release_tag": "v0.3.0",
+      "release_id": "030000000001",
+      "expected_era_hint": "",
+      "source": {
+        "release_commit": "d16fb6874ca0752a573f8d924212ccc8138aed3a",
+        "builder_path": "scripts/build_wheelhouse_zip.py",
+        "builder_blob": "2fb463f328603998022119306061db64a122a43a",
+        "config_path": "src/opensquilla/gateway/config.py",
+        "config_blob": "496194bad28f7fe500323011057f640ab76cd09d",
+        "latest_migration_path": "migrations/V014__meta_skill_run_steps_allow_user_input.py",
+        "latest_migration_blob": "99d333a8649cec3ed838cf99f08fba487c0936a5",
+        "latest_migration_id": "V014__meta_skill_run_steps_allow_user_input",
+        "opensquilla_state_dir": "<portable-home>",
+        "gateway_state_dir": "<portable-home>/state",
+        "gateway_workspace_dir": "<portable-home>/workspace"
+      }
+    },
+    {
+      "release_tag": "v0.3.1",
+      "release_id": "030100000001",
+      "expected_era_hint": "",
+      "source": {
+        "release_commit": "dc658e36b1fbb427915969b5d5590862fd17dc82",
+        "builder_path": "scripts/build_wheelhouse_zip.py",
+        "builder_blob": "2fb463f328603998022119306061db64a122a43a",
+        "config_path": "src/opensquilla/gateway/config.py",
+        "config_blob": "09a15cb6157ae821fb9aa6afd2a6316c64079e23",
+        "latest_migration_path": "migrations/V014__meta_skill_run_steps_allow_user_input.py",
+        "latest_migration_blob": "99d333a8649cec3ed838cf99f08fba487c0936a5",
+        "latest_migration_id": "V014__meta_skill_run_steps_allow_user_input",
+        "opensquilla_state_dir": "<portable-home>",
+        "gateway_state_dir": "<portable-home>/state",
+        "gateway_workspace_dir": "<portable-home>/workspace"
+      }
+    },
+    {
+      "release_tag": "v0.4.0",
+      "release_id": "040000000001",
+      "expected_era_hint": "",
+      "source": {
+        "release_commit": "5882266bbada7f6334367aa3f68ec86f5e1816a9",
+        "builder_path": "scripts/build_wheelhouse_zip.py",
+        "builder_blob": "a85c2c897e018e68d0c0ebdd7ef5918d6d4123e2",
+        "config_path": "src/opensquilla/gateway/config.py",
+        "config_blob": "a060426986d807bd573b12ea8d86f4aca0325111",
+        "latest_migration_path": "migrations/V016__meta_skill_runs_triggered_by_manual_command.py",
+        "latest_migration_blob": "c19f02581e83b8e5c6deff0afac28ee812004a0c",
+        "latest_migration_id": "V016__meta_skill_runs_triggered_by_manual_command",
+        "opensquilla_state_dir": "<portable-home>",
+        "gateway_state_dir": "<portable-home>/state",
+        "gateway_workspace_dir": "<portable-home>/workspace"
+      }
+    },
+    {
+      "release_tag": "v0.4.1",
+      "release_id": "040100000001",
+      "expected_era_hint": "",
+      "source": {
+        "release_commit": "714385e3e9c5bccbd0c0bca817ceb705fd119fdc",
+        "builder_path": "scripts/build_wheelhouse_zip.py",
+        "builder_blob": "a85c2c897e018e68d0c0ebdd7ef5918d6d4123e2",
+        "config_path": "src/opensquilla/gateway/config.py",
+        "config_blob": "44e50aeda7db93a080f5f5326fef04325646b567",
+        "latest_migration_path": "migrations/V016__meta_skill_runs_triggered_by_manual_command.py",
+        "latest_migration_blob": "c19f02581e83b8e5c6deff0afac28ee812004a0c",
+        "latest_migration_id": "V016__meta_skill_runs_triggered_by_manual_command",
+        "opensquilla_state_dir": "<portable-home>",
+        "gateway_state_dir": "<portable-home>/state",
+        "gateway_workspace_dir": "<portable-home>/workspace"
+      }
+    }
+  ]
+}

--- a/tests/test_recovery/fixtures/templates/desktop-pinned-legacy.toml
+++ b/tests/test_recovery/fixtures/templates/desktop-pinned-legacy.toml
@@ -1,0 +1,2 @@
+state_dir = {{STATE_DIR_TOML}}
+workspace_dir = {{LEGACY_WORKSPACE_TOML}}

--- a/tests/test_recovery/fixtures/templates/desktop-unpinned.toml
+++ b/tests/test_recovery/fixtures/templates/desktop-unpinned.toml
@@ -1,0 +1,1 @@
+state_dir = {{STATE_DIR_TOML}}

--- a/tests/test_recovery/test_fixture_contracts.py
+++ b/tests/test_recovery/test_fixture_contracts.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+FIXTURE_ROOT = Path(__file__).with_name("fixtures")
+DESKTOP_MANIFEST = FIXTURE_ROOT / "desktop" / "released-profiles.json"
+PORTABLE_MANIFEST = FIXTURE_ROOT / "portable" / "released-profiles.json"
+DESKTOP_SNAPSHOTS = FIXTURE_ROOT / "desktop" / "frozen-profile-snapshots.json"
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    return payload
+
+
+def test_released_desktop_manifest_freezes_verified_path_contract() -> None:
+    manifest = _load_manifest(DESKTOP_MANIFEST)
+    cases = manifest["cases"]
+    tags = {case["release_tag"] for case in cases}
+
+    assert tags == {"v0.4.0", "v0.4.1", "v0.5.0rc1", "v0.5.0rc2", "v0.5.0rc3"}
+    assert all(
+        case["gateway_env_home"] == "H/state"
+        for case in cases
+        if case["release_tag"] != "v0.5.0rc3"
+    )
+    assert all(
+        case["gateway_env_home"] == "H"
+        for case in cases
+        if case["release_tag"] == "v0.5.0rc3"
+    )
+    assert manifest["provenance"]["rc3_relocation_allowlist"] == [
+        "skills",
+        "skills-taps.json",
+        "skills-lock.json",
+        "workspace",
+        "session-archive",
+        "router",
+        ".env",
+        "state/*",
+    ]
+
+
+def test_released_desktop_cases_use_tag_proven_frozen_tree_snapshots() -> None:
+    manifest = _load_manifest(DESKTOP_MANIFEST)
+    snapshots = _load_manifest(DESKTOP_SNAPSHOTS)
+    by_id = {snapshot["id"]: snapshot for snapshot in snapshots["snapshots"]}
+
+    assert set(by_id) == {case["id"] for case in manifest["cases"]}
+    for case in manifest["cases"]:
+        snapshot = by_id[case["id"]]
+        source = snapshot["source"]
+        assert snapshot["release_tag"] == case["release_tag"]
+        assert re.fullmatch(r"[0-9a-f]{40}", source["release_commit"])
+        assert re.fullmatch(r"[0-9a-f]{40}", source["desktop_main_blob"])
+        assert re.fullmatch(r"[0-9a-f]{40}", source["python_paths_blob"])
+        assert source["desktop_main_path"] == "desktop/electron/src/main.ts"
+        assert source["python_paths_path"] == "src/opensquilla/paths.py"
+        assert source["gateway_env_home"] == case["gateway_env_home"]
+
+        seen: set[str] = set()
+        for entry in snapshot["tree"]:
+            relative = Path(entry["path"])
+            assert not relative.is_absolute()
+            assert ".." not in relative.parts
+            assert entry["path"] not in seen
+            seen.add(entry["path"])
+            if entry["kind"] == "config":
+                template = DESKTOP_SNAPSHOTS.parent / entry["template"]
+                assert template.is_file()
+
+        entries = {entry["path"]: entry for entry in snapshot["tree"]}
+        assert entries["config.toml"]["kind"] == "config"
+        assert entries["state/sessions.db"]["kind"] == "sqlite_sessions"
+        assert entries["media/synthetic.txt"]["kind"] == "text"
+        assert any(
+            path.endswith("/USER.md") and entry["kind"] == "identity_markdown"
+            for path, entry in entries.items()
+        )
+
+
+def test_published_portable_cases_pin_the_released_builder_blob() -> None:
+    releases = _load_manifest(PORTABLE_MANIFEST)["published_releases"]
+    for release in releases:
+        source = release["source"]
+        assert re.fullmatch(r"[0-9a-f]{40}", source["release_commit"])
+        assert re.fullmatch(r"[0-9a-f]{40}", source["builder_blob"])
+        assert re.fullmatch(r"[0-9a-f]{40}", source["config_blob"])
+        assert re.fullmatch(r"[0-9a-f]{40}", source["latest_migration_blob"])
+        assert source["builder_path"] == "scripts/build_wheelhouse_zip.py"
+        assert source["config_path"] == "src/opensquilla/gateway/config.py"
+        assert source["latest_migration_path"].startswith("migrations/V")
+        assert source["latest_migration_path"].endswith(".py")
+        assert source["latest_migration_id"] == Path(source["latest_migration_path"]).stem
+        assert source["opensquilla_state_dir"] == "<portable-home>"
+        assert source["gateway_state_dir"] == "<portable-home>/state"
+        assert source["gateway_workspace_dir"] == "<portable-home>/workspace"


### PR DESCRIPTION
## Scope

Scope boundary: Freeze the long-term Desktop profile layout contract, add synthetic tag-proven historical Desktop and legacy Portable fixtures, and make CI classification fail safe for recovery, migration, Windows snapshot, release-preservation, and packaged-updater paths.

Non-goals: Recovery runtime activation, filesystem migration, CLI registration, Electron IPC, user-facing recovery UI activation, version changes, tags, or release publication.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: This is compatibility infrastructure for the staged RC4 upgrade work.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check` passed for the changed Python tests.

Pytest: `101 passed` across fixture contracts, CI workflow contracts, and existing OpenSquilla home migration tests.

Build: `bash -n .github/scripts/classify-ci-changes.sh` and `git diff --check` passed.

Regression tests: added

Notes: The earlier Windows onboarding test correction is now provided by merged PR #597 and is no longer part of this diff. Historical tag commits and referenced blobs were independently checked against local tag objects.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: Native Windows CI remains required because this PR expands high-risk path classification.

## Safety

No production runtime, Electron, CLI, gateway, or WebUI code changes are included. Fixtures contain only synthetic identities, transcripts, paths, and dummy configuration values. Existing users see no behavior change when this PR merges.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] The profile contract document uses repository-owned terminology and synthetic paths.
- [x] No real secrets, private prompts, transcripts, or machine-specific paths are included.