### PR TITLE
Label Windows onboarding recovery commands

### DIFF
--- a/src/opensquilla/cli/onboard_cmd.py
+++ b/src/opensquilla/cli/onboard_cmd.py
@@ -34,6 +34,7 @@ from opensquilla.onboarding.next_steps import (
     env_reference_warnings,
     format_next_steps,
     headless_setup_commands,
+    human_env_command,
     quote_cli_arg,
     setup_catalog_command,
 )
@@ -317,7 +318,7 @@ def _headless_section_paths(
 
 def _missing_env_paths(status: OnboardingStatus) -> list[tuple[str, str, str]]:
     return [
-        (str(entry["label"]), str(entry["command"]), "")
+        (str(entry["label"]), human_env_command(str(entry["command"])), "")
         for entry in env_recovery_commands(status)
     ]
 

--- a/src/opensquilla/onboarding/next_steps.py
+++ b/src/opensquilla/onboarding/next_steps.py
@@ -154,10 +154,14 @@ def set_env_command(env_key: str) -> str:
     return f'export {env_key}="<your-key>"'
 
 
+def human_env_command(command: str) -> str:
+    """Label a bare environment command for human-facing output."""
+    return f"PowerShell: {command}" if _is_windows() else command
+
+
 def set_env_hint(env_key: str) -> str:
     """Human-facing variant of :func:`set_env_command` (labels the shell)."""
-    command = set_env_command(env_key)
-    return f"PowerShell: {command}" if _is_windows() else command
+    return human_env_command(set_env_command(env_key))
 
 
 def _set_env_hint(env_key: str) -> str:
@@ -204,7 +208,7 @@ def env_recovery_commands(status: Any) -> list[dict[str, str]]:
                 "section": section,
                 "label": label,
                 # Machine-readable field: the bare command only. Human
-                # renderers wanting a shell label wrap it via set_env_hint.
+                # renderers wanting a shell label wrap it via human_env_command.
                 "command": set_env_command(env_key),
             }
         )

--- a/tests/test_cli/test_onboard_cmd.py
+++ b/tests/test_cli/test_onboard_cmd.py
@@ -31,6 +31,12 @@ def _env_hint(env_key: str) -> str:
     return f'export {env_key}="<your-key>"'
 
 
+def _env_command(env_key: str) -> str:
+    if platform.system().lower().startswith("win"):
+        return f'$env:{env_key} = "<your-key>"'
+    return f'export {env_key}="<your-key>"'
+
+
 def _config_arg(path) -> str:
     return shlex.quote(str(path))
 
@@ -486,7 +492,13 @@ def test_onboard_status_uses_explicit_config_path(tmp_path, monkeypatch):
     assert not default_target.exists()
 
 
-def test_onboard_status_json_exposes_provider_section_alias(tmp_path, monkeypatch):
+@pytest.mark.parametrize("system_name", ["Linux", "Windows"])
+def test_onboard_status_json_exposes_provider_section_alias(
+    tmp_path,
+    monkeypatch,
+    system_name,
+):
+    monkeypatch.setattr(platform, "system", lambda: system_name)
     target = tmp_path / "custom.toml"
     target.write_text(
         '[llm]\n'
@@ -509,7 +521,7 @@ def test_onboard_status_json_exposes_provider_section_alias(tmp_path, monkeypatc
         {
             "section": "llm",
             "label": "Set provider key",
-            "command": _env_hint("CUSTOM_LLM_KEY"),
+            "command": _env_command("CUSTOM_LLM_KEY"),
         }
     ]
 
@@ -727,10 +739,13 @@ def test_onboard_status_table_uses_product_labels_and_scope_column(
     assert not default_target.exists()
 
 
+@pytest.mark.parametrize("system_name", ["Linux", "Windows"])
 def test_onboard_status_prioritizes_missing_env_recovery(
     tmp_path,
     monkeypatch,
+    system_name,
 ):
+    monkeypatch.setattr(platform, "system", lambda: system_name)
     target = tmp_path / "custom.toml"
     target.write_text(
         '[llm]\n'

--- a/tests/test_onboarding/test_next_steps.py
+++ b/tests/test_onboarding/test_next_steps.py
@@ -281,6 +281,18 @@ def test_set_env_command_is_bare_on_both_platforms(monkeypatch):
     )
 
 
+def test_human_env_command_labels_only_windows(monkeypatch):
+    from opensquilla.onboarding import next_steps
+
+    command = '$env:DUMMY_KEY = "<your-key>"'
+
+    monkeypatch.setattr(next_steps.platform, "system", lambda: "Linux")
+    assert next_steps.human_env_command(command) == command
+
+    monkeypatch.setattr(next_steps.platform, "system", lambda: "Windows")
+    assert next_steps.human_env_command(command) == f"PowerShell: {command}"
+
+
 def test_env_recovery_commands_carry_only_the_command_on_windows(monkeypatch):
     from opensquilla.gateway.config import GatewayConfig
     from opensquilla.onboarding import next_steps


### PR DESCRIPTION
## Scope

Scope boundary: Label Windows environment recovery commands only when rendering human-facing `opensquilla onboard status` output, while keeping JSON and RPC command fields shell-ready and label-free.

Non-goals: RC4 migration behavior, gateway lifecycle behavior, protocol shape changes, version changes, tags, or release publication.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: This existing Windows-only regression was discovered by the full Windows job while validating PR #596.

## Release Note

Release note: Windows onboarding status now identifies PowerShell environment recovery commands without changing machine-readable output.

## Tests

Ruff: `ruff check` passed for all four changed files.

Pytest: `146 passed` for `tests/test_cli/test_onboard_cmd.py` and `tests/test_onboarding/test_next_steps.py`.

Build: mypy passed for both changed source files.

Regression tests: added

Notes: Linux and Windows platform branches are explicitly parameterized. Independent review reported Critical 0, Important 0, and no behavioral blockers.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: No credentialed check is required. Native Windows CI is the merge gate.

## Safety

No secrets, local-only artifacts, private prompts or transcripts, channel identifiers, AI session artifacts, non-public fixtures, or private test content are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation changes.
- [x] Examples use synthetic environment variable names and placeholder values.