### PR TITLE
Stabilize mid-budget nudge timing assertions

### DIFF
--- a/tests/test_engine/test_mid_budget_no_diff_nudge_lever.py
+++ b/tests/test_engine/test_mid_budget_no_diff_nudge_lever.py
@@ -194,9 +194,11 @@ async def test_nudge_fires_once_past_half_budget_without_diff() -> None:
     assert _nudge_texts(provider.calls[0]) == []
     nudges = _nudge_texts(provider.calls[1])
     assert len(nudges) == 1
-    # The message reports real elapsed budget, not the checkpoint constant:
-    # the 3.3s sleep guarantees at least 55% of the 6s budget was spent.
-    assert 55 <= _nudge_percent(nudges[0]) < 75
+    # The message reports real elapsed budget, not the checkpoint constant.
+    # Windows timers may wake just before the requested 3.3s boundary, and
+    # the displayed percentage is truncated, so assert the stable contract:
+    # it is beyond the 50% checkpoint but before the 75% checkpoint.
+    assert 50 < _nudge_percent(nudges[0]) < 75
 
 
 @pytest.mark.asyncio
@@ -246,12 +248,13 @@ async def test_nudge_fires_at_both_checkpoints_in_sequence() -> None:
     assert len(provider.calls) == 3
     second_call = _nudge_texts(provider.calls[1])
     assert len(second_call) == 1
-    assert 55 <= _nudge_percent(second_call[0]) < 75
+    assert 50 < _nudge_percent(second_call[0]) < 75
     third_call = _nudge_texts(provider.calls[2])
     assert len(third_call) == 2
-    assert 55 <= _nudge_percent(third_call[0]) < 75
-    # 3.3s + 1.5s of sleeps: at least 80% of the budget is truly spent.
-    assert _nudge_percent(third_call[1]) >= 80
+    assert 50 < _nudge_percent(third_call[0]) < 75
+    # The later message reports progress beyond the second checkpoint rather
+    # than echoing the checkpoint constant.
+    assert _nudge_percent(third_call[1]) > 75
 
 
 @pytest.mark.asyncio
@@ -266,9 +269,10 @@ async def test_crossing_both_checkpoints_at_once_fires_single_nudge() -> None:
     assert any(event.kind == "done" for event in events)
     nudges = _nudge_texts(provider.calls[1])
     assert len(nudges) == 1
-    # 4.8s of the 6s budget slept: real elapsed is at least 80%, and the
-    # message must say so rather than echo the 75% checkpoint constant.
-    assert _nudge_percent(nudges[0]) >= 80
+    # The message must report progress beyond the 75% checkpoint rather than
+    # echoing the checkpoint constant. Timer resolution may truncate 80% to
+    # 79% on platforms that wake just before the requested sleep boundary.
+    assert _nudge_percent(nudges[0]) > 75
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

Scope boundary: Make the mid-budget nudge timing tests assert checkpoint semantics instead of exact percentages derived from real cross-platform sleeps.

Non-goals: Runtime timing behavior, nudge text, checkpoint values, RC4 migration behavior, version changes, tags, or release publication.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: The Windows full suite exposed this pre-existing test flake while validating PR #596.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check tests/test_engine/test_mid_budget_no_diff_nudge_lever.py` passed.

Pytest: `15 passed` for the complete mid-budget nudge lever test module.

Build: N/A; test-only change.

Regression tests: updated

Notes: Windows full reached `2245 passed` before a nominal 55 percent assertion observed 54 percent. The assertions still require reported elapsed progress beyond the 50 and 75 percent checkpoints and preserve nudge count and ordering. Independent review reported Critical 0, Important 0, Minor 0.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: PR #596 will rerun the native Windows full suite after this test-only fix merges.

## Safety

No production code, secrets, local artifacts, private prompts, transcripts, identifiers, or non-public fixtures are changed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation changes.
- [x] Test comments explain the cross-platform timer boundary without machine-specific paths.