### PR TITLE
Classify deadline-limited provider waits correctly

### DIFF
--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -9617,12 +9617,15 @@ class Agent:
         stream_iter = stream.__aiter__()
         while True:
             wait_budget = max(0.001, self.config.iteration_timeout)
+            total_deadline_limits_wait = False
             if total_deadline is not None:
                 remaining_total = total_deadline - loop.time()
                 if remaining_total <= 0:
                     await self._close_provider_stream(stream_iter)
                     raise TimeoutError(f"Agent total timeout after {self.config.timeout}s")
-                wait_budget = min(wait_budget, remaining_total)
+                if remaining_total <= wait_budget:
+                    wait_budget = remaining_total
+                    total_deadline_limits_wait = True
 
             next_event: asyncio.Future[Any] = asyncio.ensure_future(stream_iter.__anext__())
             try:
@@ -9636,7 +9639,9 @@ class Agent:
                 next_event.cancel()
                 with contextlib.suppress(asyncio.CancelledError, StopAsyncIteration):
                     await next_event
-                if total_deadline is not None and loop.time() >= total_deadline:
+                if total_deadline_limits_wait or (
+                    total_deadline is not None and loop.time() >= total_deadline
+                ):
                     raise TimeoutError(f"Agent total timeout after {self.config.timeout}s")
                 raise _IterationStreamTimeoutError
             try:

--- a/tests/test_engine/test_runtime_agent_iteration_timeout.py
+++ b/tests/test_engine/test_runtime_agent_iteration_timeout.py
@@ -226,3 +226,38 @@ async def test_stream_iteration_timeout_does_not_double_close_provider_stream(
             pass
 
     assert close_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_total_deadline_limited_wait_stays_total_timeout_on_early_wake(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = Agent.__new__(Agent)
+    agent.config = SimpleNamespace(timeout=0.05, iteration_timeout=30.0)
+    observed_timeouts: list[float | None] = []
+
+    async def provider_stream() -> AsyncIterator[dict[str, str]]:
+        await asyncio.sleep(30.0)
+        yield {"type": "chunk", "data": "late"}
+
+    async def return_before_deadline(
+        futures: set[asyncio.Future[Any]],
+        *,
+        timeout: float | None = None,
+    ) -> tuple[set[asyncio.Future[Any]], set[asyncio.Future[Any]]]:
+        observed_timeouts.append(timeout)
+        return set(), futures
+
+    monkeypatch.setattr(asyncio, "wait", return_before_deadline)
+    fake_loop: Any = SimpleNamespace(time=lambda: 10.0)
+
+    with pytest.raises(TimeoutError, match="total timeout") as exc_info:
+        async for _event in agent._stream_provider_events_with_deadline(
+            provider_stream(),
+            loop=fake_loop,
+            total_deadline=10.05,
+        ):
+            pass
+
+    assert type(exc_info.value) is TimeoutError
+    assert observed_timeouts == [pytest.approx(0.05)]


### PR DESCRIPTION
## Scope

Scope boundary: Preserve total-timeout classification when the total deadline, rather than the per-iteration deadline, constrained a provider wait that returns a timer tick early.

Non-goals: Timeout values, retry policy, provider behavior, RC4 migration behavior, version changes, tags, or release publication.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Native Windows full CI exposed this pre-existing event-loop timer race while validating PR #596.

## Release Note

Release note: Provider timeout diagnostics now retain total-timeout classification at cross-platform timer boundaries.

## Tests

Ruff: `ruff check` passed for both changed files.

Pytest: `19 passed` across provider observer, iteration timeout, and provider stream cancellation tests.

Build: mypy passed for `src/opensquilla/engine/agent.py`.

Regression tests: added

Notes: The regression test deterministically simulates an early empty `asyncio.wait` result while the monotonic clock still reads just before the total deadline. Independent review reported Critical 0, Important 0, Minor 0.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: PR #596 will rerun the native Windows full suite after this fix merges.

## Safety

Cancellation and ordinary iteration-limited waits retain their prior behavior. No secrets, local artifacts, private prompts, transcripts, identifiers, or non-public fixtures are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation changes.
- [x] The deterministic test uses synthetic deadlines and no machine-specific paths.