### PR TITLE
Make tilde expansion test portable

### DIFF
--- a/tests/test_gateway/test_config_path_expansion.py
+++ b/tests/test_gateway/test_config_path_expansion.py
@@ -7,7 +7,10 @@ from opensquilla.onboarding.config_store import resolve_config_path
 def test_gateway_load_expands_tilde_in_explicit_config_path(monkeypatch, tmp_path) -> None:
     fake_home = tmp_path / "home"
     fake_home.mkdir()
+    # pathlib follows the native platform convention: POSIX reads HOME,
+    # while Windows reads USERPROFILE when expanding ``~``.
     monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
 
     real_config = fake_home / "myconfig.toml"
     real_config.write_text("port = 4242\n", encoding="utf-8")


### PR DESCRIPTION
## Scope

Scope boundary: Isolate the explicit config-path tilde expansion test using the native home environment variable on both POSIX and Windows.

Non-goals: Product path resolution, config precedence, RC4 migration behavior, version changes, tags, or release publication.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Native Windows full CI exposed this pre-existing test setup bug while validating PR #596.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check tests/test_gateway/test_config_path_expansion.py` passed.

Pytest: `23 passed` across gateway config-path expansion and onboarding config-store tests.

Build: N/A; test-only change.

Regression tests: updated

Notes: `pathlib.Path.expanduser()` reads `HOME` on POSIX and `USERPROFILE` on Windows. The test now points both native conventions at the same synthetic temporary home. Independent review reported Critical 0, Important 0, Minor 0.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: PR #596 will rerun the native Windows full suite after this fix merges.

## Safety

No production code, secrets, local artifacts, private prompts, transcripts, identifiers, or non-public fixtures are changed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation changes.
- [x] Test paths remain synthetic and isolated.