### PR TITLE
Scope config mode test to POSIX

### DIFF
--- a/tests/test_gateway/test_config_secret_inheritance.py
+++ b/tests/test_gateway/test_config_secret_inheritance.py
@@ -295,7 +295,8 @@ async def test_env_auth_token_rotation_survives_config_save(tmp_path, monkeypatc
     assert rebooted.auth.token == "tok-env-rotated"
 
 
-def test_persist_config_fresh_file_is_not_world_readable(tmp_path, monkeypatch) -> None:
+@pytest.mark.skipif(os.name == "nt", reason="Windows st_mode does not represent DACLs")
+def test_persist_config_fresh_file_has_owner_only_posix_mode(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("OPENSQUILLA_AUTH_TOKEN", "tok-env-original")
     old_umask = os.umask(0o022)
     try:


### PR DESCRIPTION
## Scope

Scope boundary: Restrict the fresh-config POSIX mode-bit confidentiality test to platforms where `st_mode` represents access permissions.

Non-goals: Windows DACL hardening, config persistence behavior, RC4 migration behavior, version changes, tags, or release publication.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Native Windows full CI exposed this pre-existing platform-invalid assertion while validating PR #596.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check tests/test_gateway/test_config_secret_inheritance.py` passed.

Pytest: `17 passed` for the complete config secret-inheritance module on POSIX.

Build: N/A; test-only change.

Regression tests: updated

Notes: Windows file confidentiality is governed by DACLs; Python `st_mode` commonly reports synthesized `0666` bits and cannot prove world readability. The existing umask and owner-only mode regression remains unchanged on Linux and macOS. Independent diagnosis reported no Critical issue and recommended this exact platform boundary.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: PR #596 will rerun the native Windows full suite after this fix merges. A separate Windows DACL hardening design may cover custom config files placed in shared directories.

## Safety

This PR does not weaken or change file creation. It removes a meaningless Windows POSIX-mode assertion rather than accepting `0666` as secure. No secrets, local artifacts, private prompts, transcripts, identifiers, or non-public fixtures are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No user documentation changes.
- [x] The skip reason states the actual Windows permission model.