### PR TITLE
Make POSIX mode tests portable

### DIFF
--- a/tests/test_migration/test_opensquilla_home_migration.py
+++ b/tests/test_migration/test_opensquilla_home_migration.py
@@ -336,7 +336,7 @@ def test_apply_imports_home_with_transforms(tmp_path: Path) -> None:
     assert DUMMY_INLINE_KEY not in json.dumps(report)
 
 
-def test_imported_config_and_env_are_owner_only_even_without_secret_rewrite(
+def test_imported_config_and_env_use_owner_only_posix_modes_when_supported(
     tmp_path: Path,
 ) -> None:
     source = _build_source_home(tmp_path)
@@ -351,8 +351,9 @@ def test_imported_config_and_env_are_owner_only_even_without_secret_rewrite(
     report = _run(source, target, apply=True)
 
     assert not _errors(report)
-    assert (target / "config.toml").stat().st_mode & 0o777 == 0o600
-    assert (target / ".env").stat().st_mode & 0o777 == 0o600
+    if os.name != "nt":
+        assert (target / "config.toml").stat().st_mode & 0o777 == 0o600
+        assert (target / ".env").stat().st_mode & 0o777 == 0o600
 
 
 def test_read_only_source_directories_produce_writable_imported_runtime(
@@ -367,9 +368,10 @@ def test_read_only_source_directories_produce_writable_imported_runtime(
     report = _run(source, target, apply=True)
 
     assert not _errors(report)
-    assert (target / "state").stat().st_mode & 0o700 == 0o700
-    assert (target / "workspace").stat().st_mode & 0o700 == 0o700
-    assert (target / "state" / "sessions.db").stat().st_mode & 0o600 == 0o600
+    if os.name != "nt":
+        assert (target / "state").stat().st_mode & 0o700 == 0o700
+        assert (target / "workspace").stat().st_mode & 0o700 == 0o700
+        assert (target / "state" / "sessions.db").stat().st_mode & 0o600 == 0o600
     connection = sqlite3.connect(target / "state" / "sessions.db")
     try:
         connection.execute("CREATE TABLE writable_after_import (id INTEGER)")

--- a/tests/test_onboarding/test_config_store_sparse_persist.py
+++ b/tests/test_onboarding/test_config_store_sparse_persist.py
@@ -271,7 +271,8 @@ def test_replace_is_commit_point_with_no_target_chmod_afterward(tmp_path, monkey
     persist_config(cfg, path=target, backup=False)
 
     assert tomllib.loads(target.read_text())["port"] == 18795
-    assert target.stat().st_mode & 0o777 == 0o600
+    if os.name != "nt":
+        assert target.stat().st_mode & 0o777 == 0o600
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_onboarding/test_flow_settings_hub.py
+++ b/tests/test_onboarding/test_flow_settings_hub.py
@@ -17,6 +17,7 @@ runners are monkeypatched.
 
 from __future__ import annotations
 
+import os
 import sys
 import types
 from typing import Any
@@ -558,7 +559,8 @@ def test_onboard_fork_hub_exit_without_changes_does_not_rewrite_config(
     assert target.read_text() == raw, "a no-change exit must not rewrite the file"
     assert after.st_ino == before.st_ino
     assert after.st_mtime_ns == before.st_mtime_ns
-    assert (after.st_mode & 0o777) == 0o644
+    if os.name != "nt":
+        assert (after.st_mode & 0o777) == 0o644
     assert result.path == target
     assert result.backup_path is None
     assert result.restart_required is False
@@ -599,8 +601,9 @@ def test_start_fresh_backup_uses_the_shared_backup_naming_scheme(tmp_path):
     assert backup.read_text() == 'api_key = "sk-dummy-reset"\n'
     # No stray files under the retired hand-rolled scheme.
     assert list(tmp_path.glob("config.toml.bak-*")) == []
-    # 0600: the backup holds the same secrets as the config it replaces.
-    assert (backup.stat().st_mode & 0o777) == 0o600
+    # POSIX mode 0600: the backup holds the same secrets as the config it replaces.
+    if os.name != "nt":
+        assert (backup.stat().st_mode & 0o777) == 0o600
 
 
 def test_rerun_fork_decline_reset_falls_back_to_update(tmp_path, monkeypatch):


### PR DESCRIPTION
## Scope

Scope boundary: Keep exact POSIX permission-bit assertions on Linux and macOS while preserving platform-neutral migration, backup, atomic replacement, and SQLite-writability coverage on Windows.

Non-goals: Windows DACL hardening, runtime behavior changes, RC4 migration behavior, version changes, tags, or release publication.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Native Windows full CI exposed additional pre-existing platform-invalid mode-bit assertions while validating PR #596.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check tests/test_migration/test_opensquilla_home_migration.py tests/test_onboarding/test_config_store_sparse_persist.py tests/test_onboarding/test_flow_settings_hub.py` passed.

Pytest: `115 passed` for the three complete affected modules.

Build: N/A; test-only change.

Regression tests: updated

Notes: Windows access control is governed by DACLs, while Python `st_mode` exposes synthesized bits that do not prove owner-only access. Linux and macOS continue to assert exact 0600, 0644, and 0700 modes. Windows still verifies import success, file contents, no-change inode/mtime behavior, backup naming/content, atomic replace behavior, and actual SQLite writes. Independent review found 0 Critical and 0 Important issues; its only naming concern was addressed before commit.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: PR #596 will rerun the native Windows full suite after this fix merges. Windows owner-only DACL hardening for custom files in shared directories remains a separate design task.

## Safety

This PR changes tests only. It does not accept synthesized Windows mode bits as proof of safety, does not change file creation or migration behavior, and preserves the meaningful POSIX security assertions. No secrets, local artifacts, private prompts, transcripts, identifiers, or non-public fixtures are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No user documentation changes.
- [x] Test naming and comments distinguish POSIX modes from Windows DACLs.
