### PR TITLE
Stabilize tool timeout contract test

### DIFF
--- a/tests/test_engine/test_agent_llm_budget.py
+++ b/tests/test_engine/test_agent_llm_budget.py
@@ -3349,8 +3349,17 @@ async def test_large_tool_argument_stream_emits_progress_heartbeat() -> None:
 
 @pytest.mark.asyncio
 async def test_iteration_timeout_caps_tool_execution() -> None:
+    tool_started = asyncio.Event()
+    tool_cancelled = asyncio.Event()
+    never_complete = asyncio.Event()
+
     async def slow_tool(call: object) -> ToolResult:
-        await asyncio.sleep(0.5)
+        tool_started.set()
+        try:
+            await never_complete.wait()
+        except asyncio.CancelledError:
+            tool_cancelled.set()
+            raise
         return ToolResult(
             tool_use_id=getattr(call, "tool_use_id"),
             tool_name=getattr(call, "tool_name"),
@@ -3360,8 +3369,8 @@ async def test_iteration_timeout_caps_tool_execution() -> None:
     agent = Agent(
         provider=_ToolUseProvider(),
         config=AgentConfig(
-            iteration_timeout=0.05,
-            timeout=1.0,
+            iteration_timeout=0.1,
+            timeout=5.0,
             tool_timeout=5.0,
             max_provider_retries=0,
         ),
@@ -3375,8 +3384,10 @@ async def test_iteration_timeout_caps_tool_execution() -> None:
         tool_handler=slow_tool,
     )
 
-    events = await asyncio.wait_for(_collect_events(agent.run_turn("hello")), timeout=0.25)
+    events = await asyncio.wait_for(_collect_events(agent.run_turn("hello")), timeout=2.0)
 
+    assert tool_started.is_set()
+    assert tool_cancelled.is_set()
     assert any(
         isinstance(event, ErrorEvent) and event.code == "iteration_timeout" for event in events
     )


### PR DESCRIPTION
## Scope

Scope boundary: Make the tool-execution iteration-timeout regression deterministic across Windows and POSIX while strengthening proof that the runtime cancels a still-running tool.

Non-goals: Runtime timeout behavior changes, provider-stream timeout changes, RC4 migration behavior, version changes, tags, or release publication.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Native Windows full CI exposed a pre-existing 250 ms wall-clock race while validating PR #596.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check tests/test_engine/test_agent_llm_budget.py` passed.

Pytest: `77 passed` for the complete agent LLM-budget module after rebasing onto current main.

Stress: the focused test passed 20 consecutive subprocess runs locally.

Build: N/A; test-only change.

Regression tests: strengthened

Notes: The old test used a 50 ms iteration deadline, a tool that naturally completed after 500 ms, and a 250 ms outer watchdog. A scheduling pause on a shared Windows runner allowed the watchdog to race the internal timeout. The revised tool waits on a never-set event, records and re-raises cancellation, and uses a 100 ms iteration deadline with a 2 second outer watchdog. A passing test now proves the tool started, was cancelled by the runtime before the 5 second total/tool deadlines, and produced `iteration_timeout`. Independent review found 0 Critical and 0 Important issues.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: PR #596 should be rebased and replayed on native Windows full CI after this PR merges. PR #600 only changed provider-stream timeout classification and did not touch the tool-deadline path.

## Safety

This PR changes one test only and strengthens its behavioral evidence. It does not relax the iteration-timeout contract or alter product code. No secrets, local artifacts, private prompts, transcripts, identifiers, or non-public fixtures are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No user documentation changes.
- [x] The regression remains self-describing through explicit cancellation assertions.
