### PR TITLE
Align RPC recovery command expectations

### DIFF
--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -13,9 +13,9 @@ from opensquilla.gateway.auth import Principal
 from opensquilla.gateway.rpc import RpcContext, get_dispatcher
 
 
-def _env_hint(env_key: str) -> str:
+def _env_command(env_key: str) -> str:
     if platform.system().lower().startswith("win"):
-        return f'PowerShell: $env:{env_key} = "<your-key>"'
+        return f'$env:{env_key} = "<your-key>"'
     return f'export {env_key}="<your-key>"'
 
 
@@ -711,10 +711,13 @@ async def test_onboarding_status_requires_image_generation_enable_for_llm_fallba
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("system_name", ["Linux", "Windows"])
 async def test_onboarding_status_exposes_missing_env_keys_for_optional_capabilities(
     tmp_path,
     monkeypatch,
+    system_name,
 ):
+    monkeypatch.setattr(platform, "system", lambda: system_name)
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(tmp_path / "c.toml"))
     from opensquilla.gateway.config import GatewayConfig
 
@@ -751,17 +754,17 @@ async def test_onboarding_status_exposes_missing_env_keys_for_optional_capabilit
         {
             "section": "memory_embedding",
             "label": "Set memory key",
-            "command": _env_hint("OPENAI_EMBEDDINGS_API_KEY"),
+            "command": _env_command("OPENAI_EMBEDDINGS_API_KEY"),
         },
         {
             "section": "search",
             "label": "Set search key",
-            "command": _env_hint("BRAVE_SEARCH_API_KEY"),
+            "command": _env_command("BRAVE_SEARCH_API_KEY"),
         },
         {
             "section": "image_generation",
             "label": "Set image key",
-            "command": _env_hint("OPENAI_IMAGE_KEY"),
+            "command": _env_command("OPENAI_IMAGE_KEY"),
         },
     ]
 

--- a/tests/test_gateway/test_rpc_onboarding_audio_sync.py
+++ b/tests/test_gateway/test_rpc_onboarding_audio_sync.py
@@ -6,14 +6,16 @@ import asyncio
 import platform
 import tomllib
 
+import pytest
+
 import opensquilla.gateway.rpc_onboarding  # noqa: F401  ensures registration
 from opensquilla.gateway.auth import Principal
 from opensquilla.gateway.rpc import RpcContext, get_dispatcher
 
 
-def _env_hint(env_key: str) -> str:
+def _env_command(env_key: str) -> str:
     if platform.system().lower().startswith("win"):
-        return f'PowerShell: $env:{env_key} = "<your-key>"'
+        return f'$env:{env_key} = "<your-key>"'
     return f'export {env_key}="<your-key>"'
 
 
@@ -41,7 +43,13 @@ def _read_ctx() -> RpcContext:
     )
 
 
-def test_audio_onboarding_catalog_configure_and_status(tmp_path, monkeypatch) -> None:
+@pytest.mark.parametrize("system_name", ["Linux", "Windows"])
+def test_audio_onboarding_catalog_configure_and_status(
+    tmp_path,
+    monkeypatch,
+    system_name,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: system_name)
     target = tmp_path / "c.toml"
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
     monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
@@ -92,7 +100,7 @@ def test_audio_onboarding_catalog_configure_and_status(tmp_path, monkeypatch) ->
             {
                 "section": "audio",
                 "label": "Set audio key",
-                "command": _env_hint("ELEVENLABS_API_KEY"),
+                "command": _env_command("ELEVENLABS_API_KEY"),
             }
         ]
 


### PR DESCRIPTION
## Scope

Scope boundary: Align the two remaining onboarding RPC test expectations with the machine-readable recovery-command contract introduced by PR #597, and freeze both Linux and Windows forms in those RPC tests.

Non-goals: Product behavior changes, human-facing onboarding labels, RC4 migration behavior, version changes, tags, or release publication.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Native Windows full CI exposed stale RPC test helpers while validating PR #596.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check tests/test_gateway/test_rpc_onboarding.py tests/test_gateway/test_rpc_onboarding_audio_sync.py` passed.

Pytest: `55 passed` across both complete RPC modules, the existing Windows machine-command contract, and the CLI onboarding JSON contract.

Build: N/A; test-only change.

Regression tests: strengthened

Notes: JSON and RPC `envRecoveryCommands[].command` values are shell-ready machine fields. Windows uses `$env:KEY = "<your-key>"`; only human-rendered output adds the `PowerShell:` label. The optional-capability and audio RPC cases are now parameterized for Linux and Windows on every runner. Independent review found 0 Critical, 0 Important, and 0 Minor issues.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: PR #596 should be rebased and replayed on native Windows full CI after this PR merges. The prior run reached 4,848 passing tests before this stale assertion.

## Safety

This PR changes tests only. It preserves the established split between machine-readable commands and human labels and does not change runtime output. No secrets, local artifacts, private prompts, transcripts, identifiers, or non-public fixtures are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No user documentation changes.
- [x] Test helper naming now distinguishes bare commands from human hints.
