### PR TITLE
Quote suggested migration paths safely

### DIFF
--- a/src/opensquilla/migration/legacy_detect.py
+++ b/src/opensquilla/migration/legacy_detect.py
@@ -10,7 +10,6 @@ layer, which requires a quiesced gateway.
 from __future__ import annotations
 
 import os
-import shlex
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -93,7 +92,6 @@ def _portable_bases_present() -> bool:
 
 
 def _command_path(path: Path) -> str:
-    raw = str(path)
-    if any(ch.isspace() for ch in raw):
-        return shlex.quote(raw)
-    return raw
+    from opensquilla.onboarding.next_steps import quote_cli_arg
+
+    return quote_cli_arg(path)

--- a/tests/test_migration/test_legacy_detect.py
+++ b/tests/test_migration/test_legacy_detect.py
@@ -237,19 +237,46 @@ def test_detection_swallows_os_errors(
 
 
 def test_suggested_migrate_command_renders_kind_and_source() -> None:
-    candidate = LegacyHomeCandidate(path=Path("/legacy/home"), kind="cli-home")
+    source = Path(os.sep) / "legacy" / "home"
+    candidate = LegacyHomeCandidate(path=source, kind="cli-home")
+    rendered_source = f"'{source}'" if os.name == "nt" else str(source)
 
     assert suggested_migrate_command(candidate) == (
-        "opensquilla migrate opensquilla --kind cli-home --source /legacy/home"
+        f"opensquilla migrate opensquilla --kind cli-home --source {rendered_source}"
     )
 
 
 def test_suggested_migrate_command_quotes_paths_with_spaces() -> None:
-    candidate = LegacyHomeCandidate(
-        path=Path("/legacy homes/data dir"), kind="windows-portable"
-    )
+    source = Path(os.sep) / "legacy homes" / "data dir"
+    candidate = LegacyHomeCandidate(path=source, kind="windows-portable")
 
     assert suggested_migrate_command(candidate) == (
         "opensquilla migrate opensquilla --kind windows-portable "
-        "--source '/legacy homes/data dir'"
+        f"--source '{source}'"
     )
+
+
+def test_suggested_migrate_command_quotes_posix_shell_metacharacters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.onboarding import next_steps
+
+    monkeypatch.setattr(next_steps.platform, "system", lambda: "Linux")
+    source = Path(os.sep) / "legacy$HOME"
+    candidate = LegacyHomeCandidate(path=source, kind="cli-home")
+
+    assert suggested_migrate_command(candidate).endswith(f"--source '{source}'")
+
+
+def test_suggested_migrate_command_uses_powershell_quoting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.onboarding import next_steps
+
+    monkeypatch.setattr(next_steps.platform, "system", lambda: "Windows")
+    source = Path("C:\\O'Brien Data\\profile")
+    candidate = LegacyHomeCandidate(path=source, kind="windows-portable")
+
+    command = suggested_migrate_command(candidate)
+    assert command.endswith("--source 'C:\\O''Brien Data\\profile'")
+    assert "'\"'\"'" not in command


### PR DESCRIPTION
## Scope

Scope boundary: Render suggested legacy-profile migration commands with native paths and the repository's established POSIX/PowerShell-aware argument quoting.

Non-goals: Candidate detection or ordering changes, migration execution changes, profile data writes, RC4 recovery activation, version changes, tags, or release publication.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Native Windows full CI exposed a hard-coded POSIX path expectation while validating PR #596; diagnosis also found unsafe quoting for shell metacharacters and PowerShell apostrophes.

## Release Note

Release note: Suggested legacy-data migration commands now remain copyable when profile paths contain spaces, shell metacharacters, or apostrophes on Windows and POSIX systems.

## Tests

Ruff: `ruff check src/opensquilla/migration/legacy_detect.py tests/test_migration/test_legacy_detect.py` passed.

Mypy: `mypy src/opensquilla/migration/legacy_detect.py --show-error-codes` passed.

Pytest: `19 passed` for the complete legacy-detection and architecture-import contract modules. Focused quoting and architecture selection also passed `10 passed`.

Build: N/A; no packaging files changed.

Regression tests: added

Notes: Existing tests now use host-native path separators. New regressions cover a no-whitespace POSIX `$HOME` metacharacter and PowerShell single-quote doubling while explicitly rejecting POSIX `shlex` apostrophe fragments on Windows. The shared quoting helper is imported only when a command is rendered; the existing migration-to-onboarding architecture edge remains unchanged. Independent review found 0 Critical, 0 Important, and 0 Minor issues.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: PR #596 should be rebased and replayed on native Windows full CI after this PR merges. The prior run reached 6,305 passing tests before the stale path assertion.

## Safety

The change affects only advisory command rendering. It does not move, copy, delete, merge, or otherwise mutate profile data. Quoting becomes stricter for unsafe paths and uses the already-tested PowerShell contract on Windows. No secrets, local artifacts, private prompts, transcripts, identifiers, or non-public fixtures are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No standalone documentation changes.
- [x] The release note describes the user-visible command-rendering correction.
