### PR TITLE
Align migration command integration tests

### DIFF
--- a/tests/test_gateway/test_boot_legacy_home_warning.py
+++ b/tests/test_gateway/test_boot_legacy_home_warning.py
@@ -42,11 +42,12 @@ def test_fresh_home_with_candidate_warns_once(
 ) -> None:
     warnings = _capture_warnings(monkeypatch)
     legacy = tmp_path / "legacy-home"
+    candidate = LegacyHomeCandidate(path=legacy, kind="cli-home")
     seen_targets: list[Path | None] = []
 
     def _detect(target: Path | None = None) -> LegacyHomeCandidate:
         seen_targets.append(target)
-        return LegacyHomeCandidate(path=legacy, kind="cli-home")
+        return candidate
 
     monkeypatch.setattr(legacy_detect, "detect_legacy_home", _detect)
 
@@ -57,9 +58,7 @@ def test_fresh_home_with_candidate_warns_once(
         "event": "build_services.legacy_home_detected",
         "legacy_home": str(legacy),
         "kind": "cli-home",
-        "migrate_command": (
-            f"opensquilla migrate opensquilla --kind cli-home --source {legacy}"
-        ),
+        "migrate_command": legacy_detect.suggested_migrate_command(candidate),
     }
     # Detection ran once, against the home the gateway actually booted from.
     assert seen_targets == [(tmp_path / "home").resolve()]

--- a/tests/test_gateway/test_rpc_doctor.py
+++ b/tests/test_gateway/test_rpc_doctor.py
@@ -1294,12 +1294,13 @@ def test_legacy_home_payload_reads_config_home_and_freshness(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     seen_targets: list[Path | None] = []
+    candidate = LegacyHomeCandidate(
+        path=tmp_path / "legacy-home", kind="windows-portable"
+    )
 
     def _detect(target: Path | None = None) -> LegacyHomeCandidate:
         seen_targets.append(target)
-        return LegacyHomeCandidate(
-            path=tmp_path / "legacy-home", kind="windows-portable"
-        )
+        return candidate
 
     monkeypatch.setattr(legacy_detect, "detect_legacy_home", _detect)
     cfg = GatewayConfig(state_dir=str(tmp_path / "home" / "state"))
@@ -1310,12 +1311,9 @@ def test_legacy_home_payload_reads_config_home_and_freshness(
     assert payload == {
         "detected": True,
         "targetFresh": True,
-        "path": str(tmp_path / "legacy-home"),
-        "kind": "windows-portable",
-        "command": (
-            "opensquilla migrate opensquilla --kind windows-portable "
-            f"--source {tmp_path / 'legacy-home'}"
-        ),
+        "path": str(candidate.path),
+        "kind": candidate.kind,
+        "command": legacy_detect.suggested_migrate_command(candidate),
     }
     # Detection targeted the home the gateway actually runs from.
     assert seen_targets == [(tmp_path / "home").resolve()]


### PR DESCRIPTION
## Scope

Scope boundary: Align the gateway boot-warning and doctor RPC integration expectations with the single platform-aware migration-command renderer introduced by PR #606.

Non-goals: Product behavior changes, quoting-rule changes, migration execution, profile data writes, RC4 recovery activation, version changes, tags, or release publication.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Native Windows full CI exposed one stale integration expectation while validating PR #596; the same audit found the equivalent doctor RPC expectation before the next fail-fast run.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check tests/test_gateway/test_boot_legacy_home_warning.py tests/test_gateway/test_rpc_doctor.py` passed.

Pytest: `34 passed` for both complete affected gateway modules.

Build: N/A; test-only change.

Regression tests: updated

Notes: Each integration test now creates one `LegacyHomeCandidate` and verifies that the surfaced command equals `suggested_migrate_command(candidate)`. Exact POSIX and PowerShell quoting remains covered independently by the focused migration unit tests, avoiding duplicate platform logic in integration tests. A full-tree audit confirmed that the remaining literal `/tmp` cases exercise the legacy evaluator fallback when no rendered command is present, not a real candidate path. Independent review found 0 Critical, 0 Important, and 0 Minor issues.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: PR #596 should be rebased and replayed on native Windows full CI after this PR merges. The prior run stopped after 3,694 passing tests on the first stale integration expectation.

## Safety

This PR changes tests only and does not alter command rendering or any migration operation. No secrets, local artifacts, private prompts, transcripts, identifiers, or non-public fixtures are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No user documentation changes.
- [x] Integration tests now defer exact shell syntax to the renderer contract.
