### PR TITLE
Encode dynamic paths in TOML fixtures

### DIFF
--- a/tests/test_migration/test_openclaw_migration.py
+++ b/tests/test_migration/test_openclaw_migration.py
@@ -195,8 +195,8 @@ def test_apply_defers_legacy_target_config_upgrade_to_final_persist(
     home = tmp_path / "opensquilla-home"
     config_path = tmp_path / "config.toml"
     original = (
-        f'workspace_dir = "{home / "workspace"}"\n'
-        f'state_dir = "{home / "state"}"\n'
+        f"workspace_dir = {json.dumps(str(home / 'workspace'))}\n"
+        f"state_dir = {json.dumps(str(home / 'state'))}\n"
         "\n[llm_ensemble]\n"
         "proposer_timeout_seconds = 120.0\n"
         "aggregator_timeout_seconds = 120.0\n"


### PR DESCRIPTION
## Scope

Scope boundary: Encode dynamic workspace and state paths as valid TOML basic strings in one OpenClaw migration test fixture on every platform.

Non-goals: Product code changes, migration behavior changes, profile data writes, RC4 recovery activation, version changes, tags, or release publication.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Native Windows full CI exposed the fixture's unescaped `C:\\...` path while validating PR #596.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check tests/test_migration/test_openclaw_migration.py` passed.

Pytest: `30 passed` for the complete OpenClaw migration module.

Build: N/A; test-only change.

Regression tests: updated

Notes: `json.dumps(str(path))` produces a quoted string accepted by both JSON and TOML basic-string syntax, escaping Windows backslashes and quotes without special-casing the platform. The test already imports `json`, and its backup-byte assertion continues to compare against the exact generated original. A full migration-test scan found no second unescaped dynamic-path/basic-string fixture. Independent review found 0 Critical, 0 Important, and 0 Minor issues.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: PR #596 should be rebased and replayed on native Windows full CI after this PR merges. The prior run reached 6,330 passing tests before this fixture parse error.

## Safety

This PR changes two fixture-construction lines in one test and does not alter production parsing or migration. No secrets, local artifacts, private prompts, transcripts, identifiers, or non-public fixtures are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No user documentation changes.
- [x] The fixture now follows the existing repository pattern for TOML-safe dynamic paths.
