### PR TITLE
Make staged SQLite snapshots replaceable

### DIFF
--- a/src/opensquilla/cli/tui/opentui/completion.py
+++ b/src/opensquilla/cli/tui/opentui/completion.py
@@ -6,6 +6,7 @@ import fnmatch
 import os
 import shutil
 import subprocess
+import sys
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any, Protocol
@@ -250,8 +251,10 @@ def _git_files(root: Path) -> list[str] | None:
     try:
         # -z: NUL-separated verbatim paths, so core.quotePath never C-quotes a
         # non-ASCII name into an octal-escape string that matches nothing on
-        # disk. Decoding with the filesystem rules (surrogateescape) means even
-        # undecodable path bytes can never crash completion.
+        # disk. Keep the platform's normal filesystem decoding first, then fall
+        # back to surrogateescape because Windows' surrogatepass handler can
+        # raise for malformed UTF-8 bytes. Completion must remain available for
+        # every Git path without changing valid Windows path decoding.
         result = subprocess.run(
             ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
             cwd=root,
@@ -263,10 +266,17 @@ def _git_files(root: Path) -> list[str] | None:
     if result.returncode != 0:
         return None
     return [
-        Path(os.fsdecode(entry)).as_posix()
+        Path(_decode_git_path(entry)).as_posix()
         for entry in result.stdout.split(b"\0")
         if entry
     ]
+
+
+def _decode_git_path(entry: bytes) -> str:
+    try:
+        return os.fsdecode(entry)
+    except UnicodeDecodeError:
+        return entry.decode(sys.getfilesystemencoding(), errors="surrogateescape")
 
 
 def _walk_files(root: Path, *, max_walk: int) -> list[str]:

--- a/src/opensquilla/migration/opensquilla_home.py
+++ b/src/opensquilla/migration/opensquilla_home.py
@@ -22,6 +22,7 @@ import os
 import re
 import shutil
 import sqlite3
+import stat
 import sys
 import tempfile
 import tomllib
@@ -1634,6 +1635,23 @@ class OpenSquillaHomeMigrator:
         else:
             path.unlink(missing_ok=True)
 
+    @staticmethod
+    def _unlink_staged_file_for_replacement(path: Path) -> None:
+        """Remove a copied staging file without changing its read-only source."""
+        try:
+            result = path.lstat()
+        except FileNotFoundError:
+            return
+        if not stat.S_ISREG(result.st_mode):
+            raise OSError(f"staged SQLite path is not a regular file: {path}")
+        try:
+            os.chmod(path, result.st_mode | stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            # Some filesystems reject chmod even when the containing directory
+            # still permits unlinking. Let unlink remain the authoritative gate.
+            pass
+        path.unlink(missing_ok=True)
+
     def _snapshot_sqlite_stores(self, staging: Path) -> None:
         """Create consistent WAL-aware SQLite snapshots and validate every store."""
         snapshot_root = self._staged_output_dir(staging) / "db-snapshots"
@@ -1677,9 +1695,11 @@ class OpenSquillaHomeMigrator:
                 )
                 raise OSError(f"sqlite snapshot failed for state/{relative}") from exc
 
-            destination.unlink(missing_ok=True)
+            self._unlink_staged_file_for_replacement(destination)
             for suffix in _SQLITE_SIDECAR_SUFFIXES:
-                destination.with_name(destination.name + suffix).unlink(missing_ok=True)
+                self._unlink_staged_file_for_replacement(
+                    destination.with_name(destination.name + suffix)
+                )
             os.replace(_ext(temporary), _ext(destination))
             try:
                 os.chmod(destination, (source_db.stat().st_mode & 0o777) | 0o600)

--- a/tests/test_migration/test_opensquilla_home_migration.py
+++ b/tests/test_migration/test_opensquilla_home_migration.py
@@ -926,7 +926,9 @@ def test_overwrite_publish_failure_restores_complete_original_target(
     def fail_staging_publish(src: str, dst: str) -> None:
         source_path = Path(src)
         destination_path = Path(dst)
-        if source_path.name.startswith(".opensquilla-import-") and destination_path == target:
+        if source_path.name.startswith(".opensquilla-import-") and destination_path == Path(
+            migration_module._ext(target)
+        ):
             raise OSError("synthetic publish failure")
         original_replace(src, dst)
 

--- a/tests/test_migration/test_opensquilla_home_migration.py
+++ b/tests/test_migration/test_opensquilla_home_migration.py
@@ -360,7 +360,9 @@ def test_read_only_source_directories_produce_writable_imported_runtime(
     tmp_path: Path,
 ) -> None:
     source = _build_source_home(tmp_path)
-    os.chmod(source / "state" / "sessions.db", 0o444)
+    source_sessions = source / "state" / "sessions.db"
+    source_sessions_bytes = source_sessions.read_bytes()
+    os.chmod(source_sessions, 0o444)
     os.chmod(source / "state", 0o555)
     os.chmod(source / "workspace", 0o555)
     target = tmp_path / "target-home"
@@ -368,6 +370,8 @@ def test_read_only_source_directories_produce_writable_imported_runtime(
     report = _run(source, target, apply=True)
 
     assert not _errors(report)
+    assert source_sessions.read_bytes() == source_sessions_bytes
+    assert source_sessions.stat().st_mode & 0o200 == 0
     if os.name != "nt":
         assert (target / "state").stat().st_mode & 0o700 == 0o700
         assert (target / "workspace").stat().st_mode & 0o700 == 0o700

--- a/tests/test_tools/test_workspace_write_deny_levers.py
+++ b/tests/test_tools/test_workspace_write_deny_levers.py
@@ -303,7 +303,7 @@ async def test_exec_command_reads_stay_unblocked_with_lever_on(
     workspace = tmp_path / "workspace"
     tests_dir = workspace / "tests"
     tests_dir.mkdir(parents=True)
-    (tests_dir / "test_a.py").write_text("assert a\n", encoding="utf-8")
+    (tests_dir / "test_a.py").write_bytes(b"assert a\n")
     _configure_ctx(workspace, ["tests/**"])
 
     result = await shell.exec_command("cat tests/test_a.py", workdir=str(workspace))

--- a/tests/unit/cli/tui/test_opentui_enumerate_files.py
+++ b/tests/unit/cli/tui/test_opentui_enumerate_files.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 import unicodedata
 from pathlib import Path
 from types import SimpleNamespace
@@ -121,6 +122,14 @@ def test_git_files_tolerates_undecodable_path_bytes(
     # it decodes through the filesystem rules (surrogateescape) instead.
     (tmp_path / ".git").mkdir()
     monkeypatch.setattr(completion.shutil, "which", lambda name: "/usr/bin/git")
+    # Windows uses surrogatepass for filesystem decoding, which still raises
+    # for this malformed UTF-8 byte. Simulate that handler on every platform so
+    # the fallback remains covered outside the Windows CI job too.
+    monkeypatch.setattr(
+        completion.os,
+        "fsdecode",
+        lambda entry: entry.decode("utf-8", errors="surrogatepass"),
+    )
     monkeypatch.setattr(
         completion.subprocess,
         "run",
@@ -131,7 +140,10 @@ def test_git_files_tolerates_undecodable_path_bytes(
 
     names = enumerate_workspace_files(tmp_path)
     assert "plain.txt" in names
-    assert os.fsdecode(b"caf\xe9.md") in names
+    expected = b"caf\xe9.md".decode(
+        sys.getfilesystemencoding(), errors="surrogateescape"
+    )
+    assert expected in names
 
 
 @pytest.mark.skipif(shutil.which("git") is None, reason="git is not on PATH")


### PR DESCRIPTION
## Scope

Scope boundary: Make copied SQLite database and sidecar files replaceable inside a new import staging directory when a legacy source profile is read-only.

Non-goals: Broad permission normalization, source mutation, target merging, or activation of the RC4 recovery engine.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: The native Windows full suite exposed this import regression while validating the RC4 layout-contract change.

## Release Note

Release note: Legacy profile imports now replace read-only staged SQLite copies safely on Windows without modifying the source.

## Tests

Ruff: `.venv/bin/ruff check src/opensquilla/migration/opensquilla_home.py tests/test_migration/test_opensquilla_home_migration.py`

Pytest: `PYTHONPATH=src .venv/bin/pytest tests/test_migration/test_opensquilla_home_migration.py -q` (52 passed)

Build: not needed for this scoped Python migration fix

Regression tests: added

Notes: The regression test verifies that source database bytes and read-only mode remain unchanged while the imported target database remains writable. Independent review found 0 critical, 0 important, and 0 minor findings. Native Windows full CI remains the merge gate.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

The change only adjusts copied staging files and never changes the source profile or an existing target.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
