### PR TITLE
Encode observability state path fixture

### DIFF
--- a/tests/test_observability/test_bundle.py
+++ b/tests/test_observability/test_bundle.py
@@ -233,7 +233,10 @@ def test_errors_collected_from_config_state_dir(
     # distinguishes the two databases.
     state = tmp_path / "custom-state"
     state.mkdir()
-    _hermetic_config.write_text(f'state_dir = "{state}"\n', encoding="utf-8")
+    _hermetic_config.write_text(
+        f"state_dir = {json.dumps(str(state))}\n",
+        encoding="utf-8",
+    )
     db = state / "sessions.db"
     apply_pending(str(db), MIGRATIONS_DIR)
     conn = sqlite3.connect(str(db))


### PR DESCRIPTION
## Scope

Scope boundary: Encode a synthetic configured `state_dir` as a valid TOML string on every platform.

Non-goals: Change observability bundle behavior, config parsing, profile migration, or runtime path resolution.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: The native Windows full suite exposed the invalid test fixture while validating RC4 profile compatibility contracts.

## Release Note

Release note: NONE

## Tests

Ruff: `.venv/bin/ruff check tests/test_observability/test_bundle.py`

Pytest: `PYTHONPATH=src .venv/bin/pytest tests/test_observability/test_bundle.py -q` (10 passed)

Build: not needed for a test-only fixture correction

Regression tests: not needed

Notes: Raw Windows backslashes made the synthetic TOML invalid, so the test silently exercised the fallback state database. JSON string encoding is valid TOML basic-string encoding for this synthetic path and preserves the intended configured-state assertion.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

This PR changes one synthetic test fixture and contains no runtime code.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
