### PR TITLE
Preserve Unicode in observability path fixture

### DIFF
--- a/tests/test_observability/test_bundle.py
+++ b/tests/test_observability/test_bundle.py
@@ -234,7 +234,7 @@ def test_errors_collected_from_config_state_dir(
     state = tmp_path / "custom-state"
     state.mkdir()
     _hermetic_config.write_text(
-        f"state_dir = {json.dumps(str(state))}\n",
+        f"state_dir = {json.dumps(str(state), ensure_ascii=False)}\n",
         encoding="utf-8",
     )
     db = state / "sessions.db"


### PR DESCRIPTION
## Scope

Scope boundary: Preserve non-BMP Unicode characters when JSON quoting the synthetic TOML `state_dir` fixture introduced by #610.

Non-goals: Change observability bundle behavior, runtime config, path resolution, or migration behavior.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Follow-up review of #610 identified that JSON surrogate escapes are not valid TOML Unicode scalar escapes.

## Release Note

Release note: NONE

## Tests

Ruff: `.venv/bin/ruff check tests/test_observability/test_bundle.py`

Pytest: `PYTHONPATH=src .venv/bin/pytest tests/test_observability/test_bundle.py -q` (10 passed)

Build: not needed for a test-only one-line correction

Regression tests: not needed

Notes: A direct `tomllib` round-trip check also covers a Windows-style path containing an emoji. Independent review of this exact semantic change found 0 critical, 0 important, and 0 minor findings.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

This PR changes one argument in a synthetic test fixture and contains no runtime code.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
