### PR TITLE
Stabilize provider probe latency assertions

### DIFF
--- a/tests/test_onboarding/test_provider_probe.py
+++ b/tests/test_onboarding/test_provider_probe.py
@@ -204,8 +204,9 @@ def test_probe_redacts_key_material_echoed_by_auth_errors(monkeypatch: Any) -> N
 def _delayed_provider(events: list[Any], delay_s: float = 0.02) -> Any:
     """Fake provider whose stream sleeps once, so latency is provably > 0.
 
-    ``asyncio.sleep`` never returns early, which makes the millisecond floor
-    deterministic even on a loaded CI box.
+    The reported integer can be slightly shorter than the requested sleep on
+    event loops with coarse timer resolution, so callers only rely on it being
+    positive.
     """
 
     class _DelayedProvider:
@@ -233,7 +234,7 @@ def test_probe_reports_latency_on_ok_path(monkeypatch: Any) -> None:
     result = _probe(provider_id="openai", model="gpt-4o", api_key="sk-test")
     assert result.ok is True
     assert isinstance(result.latency_ms, int)
-    assert result.latency_ms >= 20
+    assert result.latency_ms > 0
 
 
 def test_probe_reports_latency_on_classified_error_path(monkeypatch: Any) -> None:
@@ -247,4 +248,4 @@ def test_probe_reports_latency_on_classified_error_path(monkeypatch: Any) -> Non
     assert result.ok is False
     assert result.failure_kind == ProviderFailureKind.AUTH_INVALID.value
     assert isinstance(result.latency_ms, int)
-    assert result.latency_ms >= 20
+    assert result.latency_ms > 0


### PR DESCRIPTION
## Scope

Scope boundary: Make the two provider-probe latency contract tests portable across event-loop timer resolutions.

Non-goals: Change provider probing, latency measurement, onboarding behavior, timeout handling, or failure classification.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: The native Windows full suite exposed the over-constrained timing assertion while validating RC4 profile compatibility contracts.

## Release Note

Release note: NONE

## Tests

Ruff: `.venv/bin/ruff check tests/test_onboarding/test_provider_probe.py`

Pytest: `PYTHONPATH=src .venv/bin/pytest tests/test_onboarding/test_provider_probe.py -q` (12 passed)

Build: not needed for a test-only timing assertion correction

Regression tests: not needed

Notes: Both affected tests were also repeated 20 times locally. Windows measured a requested 20 ms sleep as 15 ms because of event-loop timer quantization; the probe still correctly returned an integer, positive latency. The tests now assert that actual public contract instead of a platform-specific wall-clock lower bound.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

This PR changes only two test assertions and their helper comment; no runtime code is changed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
