### PR TITLE
Stabilize Windows proxy pinning fixture

### DIFF
--- a/tests/test_tools/test_media_image.py
+++ b/tests/test_tools/test_media_image.py
@@ -11,6 +11,7 @@ import pytest
 from reportlab.pdfgen import canvas
 
 from opensquilla.tools.builtin import media
+from opensquilla.tools.ssrf import environment_proxy_url
 from opensquilla.tools.types import SafeToolError, ToolContext, ToolError, current_tool_context
 
 
@@ -245,22 +246,25 @@ async def test_fetch_image_url_uses_opted_in_environment_proxy_with_pinning(
     port = int(proxy.server_address[1])
     try:
         for name in (
+            "HTTP_PROXY",
             "HTTPS_PROXY",
             "ALL_PROXY",
+            "http_proxy",
             "https_proxy",
             "all_proxy",
             "NO_PROXY",
             "no_proxy",
         ):
             monkeypatch.delenv(name, raising=False)
+        monkeypatch.delenv("REQUEST_METHOD", raising=False)
         monkeypatch.setenv("OPENSQUILLA_TRUST_ENV", "1")
-        monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{port}")
-        monkeypatch.delenv("http_proxy", raising=False)
+        proxy_url = f"http://127.0.0.1:{port}"
+        target_url = f"http://proxy-target.test:{port}/image.png"
+        monkeypatch.setenv("HTTP_PROXY", proxy_url)
+        assert environment_proxy_url(target_url) == proxy_url
         monkeypatch.setattr(media, "validate_http_url_for_fetch", lambda url: ["127.0.0.1"])
 
-        image_bytes, media_type = await media._fetch_image_url(
-            f"http://proxy-target.test:{port}/image.png"
-        )
+        image_bytes, media_type = await media._fetch_image_url(target_url)
     finally:
         proxy.shutdown()
         proxy.server_close()


### PR DESCRIPTION
## Scope

Scope boundary: Make the opted-in proxy pinning integration fixture preserve its synthetic `HTTP_PROXY` value on Windows and assert proxy discovery before fetching.

Non-goals: Change SSRF validation, DNS pinning, media fetching, proxy opt-in behavior, HTTPX transports, or runtime networking.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: The native Windows full suite exposed the case-insensitive environment fixture while validating RC4 profile compatibility contracts.

## Release Note

Release note: NONE

## Tests

Ruff: `.venv/bin/ruff check tests/test_tools/test_media_image.py`

Pytest: focused proxy node passed and was repeated 20 times; the complete file passed (7 tests)

Build: not needed for a test-only fixture correction

Regression tests: not needed

Notes: Windows normalizes environment variable keys to uppercase, so deleting `http_proxy` after setting `HTTP_PROXY` removed the same value and made the test perform a direct pinned-IP request. The fixture now clears all aliases before setting the proxy, removes the CGI marker that intentionally disables uppercase `HTTP_PROXY`, and verifies proxy discovery before the integration request. Independent security validation suppressed the SSRF candidate at 0.98 confidence, and two final reviews found 0 critical, 0 important, and 0 minor issues.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

This PR only changes a synthetic loopback proxy test. It does not weaken or alter runtime SSRF and DNS-rebinding controls.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
