### PR TITLE
Extend Windows full CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,7 @@ jobs:
     needs: classify-changes
     if: ${{ needs.classify-changes.outputs.windows_full_required == 'true' || needs.classify-changes.outputs.full_required == 'true' }}
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     env:
       UV_PYTHON: "3.12"

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -698,6 +698,7 @@ def test_windows_high_risk_job_uses_subset_until_full_ci() -> None:
     text = (WORKFLOW_DIR / "ci.yml").read_text(encoding="utf-8")
 
     assert windows_full["name"] == "Windows high-risk/full tests (conditional)"
+    assert windows_full["timeout-minutes"] == 45
     assert windows_full["steps"][0]["with"]["lfs"] == (
         "${{ needs.classify-changes.outputs.full_required == 'true' }}"
     )


### PR DESCRIPTION
## Scope

Scope boundary: Give the complete Windows test job enough time to finish and pin that timeout in the workflow contract test.

Non-goals: Skip, shard, reorder, relax, or change any tests; change application runtime behavior; alter required-check policy.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Repeated native Windows full validation of RC4 profile contracts demonstrated that the complete suite no longer fits safely within the existing 30-minute cap.

## Release Note

Release note: NONE

## Tests

Ruff: `.venv/bin/ruff check tests/test_ci/test_workflows.py`

Pytest: `PYTHONPATH=src .venv/bin/pytest tests/test_ci/test_workflows.py -q` (41 passed)

Build: not needed for a CI timeout-only change

Regression tests: added

Notes: Windows run 29187993992 reached its first test failure after 11,691 passing tests and 28:58 of pytest time, with roughly 875 collected tests still remaining and a 30-minute job limit. Forty-five minutes provides bounded headroom while `--maxfail=1` still stops real failures immediately. Local actionlint was unavailable because Go is not installed; the existing GitHub workflow-lint job remains required and will validate the YAML.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

This PR increases only a CI job ceiling; it does not bypass failures or modify test selection.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
