### PR TITLE
Harden Windows high-risk CI gates

### DIFF
--- a/.github/scripts/check_ci_results.py
+++ b/.github/scripts/check_ci_results.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Fail closed when required CI jobs or classifier outputs are incomplete."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Mapping
+from typing import Final
+
+BOOLEAN_FLAGS: Final[tuple[str, ...]] = (
+    "docs_only",
+    "runtime_changed",
+    "test_changed",
+    "ci_changed",
+    "dependency_changed",
+    "release_changed",
+    "windows_full_required",
+    "frontend_changed",
+    "tui_changed",
+    "desktop_changed",
+    "python_changed",
+    "platform_sensitive_changed",
+    "build_wheel_required",
+    "full_required",
+)
+
+ALWAYS_REQUIRED_RESULTS: Final[tuple[tuple[str, str], ...]] = (
+    ("RESULT_CLASSIFY", "Classify changed files"),
+    ("RESULT_WORKFLOW_LINT", "Workflow lint"),
+    ("RESULT_README_LOCALE", "README locale parity"),
+)
+
+
+def _flag_env(name: str) -> str:
+    return f"FLAG_{name.upper()}"
+
+
+def _read_flags(env: Mapping[str, str], errors: list[str]) -> dict[str, bool]:
+    flags: dict[str, bool] = {}
+    for name in BOOLEAN_FLAGS:
+        raw = env.get(_flag_env(name), "")
+        if raw not in {"true", "false"}:
+            errors.append(f"Classifier output {name} must be exactly true or false; got {raw!r}.")
+            continue
+        flags[name] = raw == "true"
+    return flags
+
+
+def _require_result(
+    env: Mapping[str, str],
+    errors: list[str],
+    variable: str,
+    label: str,
+    *,
+    required: bool,
+) -> None:
+    result = env.get(variable, "")
+    allowed = {"success"} if required else {"success", "skipped"}
+    if result not in allowed:
+        expectation = "succeed" if required else "be successful or intentionally skipped"
+        errors.append(f"{label} must {expectation}; got {result or 'missing'}.")
+
+
+def check_ci_results(env: Mapping[str, str]) -> list[str]:
+    """Return gate errors; an empty list means the aggregate check may pass."""
+
+    errors: list[str] = []
+    flags = _read_flags(env, errors)
+
+    for variable, label in ALWAYS_REQUIRED_RESULTS:
+        _require_result(env, errors, variable, label, required=True)
+
+    if len(flags) != len(BOOLEAN_FLAGS):
+        return errors
+
+    full = flags["full_required"]
+    conditional_results = (
+        ("RESULT_FRONTEND", "Frontend build and typecheck", flags["frontend_changed"] or full),
+        ("RESULT_TUI", "OpenTUI package tests", flags["tui_changed"] or full),
+        ("RESULT_DESKTOP", "Desktop Electron unit tests", flags["desktop_changed"] or full),
+        ("RESULT_UBUNTU", "Ubuntu quality gate", flags["python_changed"] or full),
+        (
+            "RESULT_WINDOWS_SMOKE",
+            "Windows compatibility smoke tests",
+            flags["python_changed"]
+            or flags["platform_sensitive_changed"]
+            or flags["dependency_changed"]
+            or flags["release_changed"]
+            or full,
+        ),
+        (
+            "RESULT_WINDOWS_FULL",
+            "Windows high-risk matrix",
+            flags["windows_full_required"] or full,
+        ),
+        (
+            "RESULT_RELEASE",
+            "Release packaging contracts",
+            flags["release_changed"] or full,
+        ),
+    )
+    for variable, label, required in conditional_results:
+        _require_result(env, errors, variable, label, required=required)
+
+    if flags["platform_sensitive_changed"] and not flags["windows_full_required"]:
+        errors.append("Platform-sensitive changes must require the Windows high-risk matrix.")
+
+    if full:
+        if flags["docs_only"]:
+            errors.append("A full CI run cannot be classified as docs-only.")
+        for name in BOOLEAN_FLAGS:
+            if name in {"docs_only", "full_required"}:
+                continue
+            if not flags[name]:
+                errors.append(f"Full CI classification must set {name}=true.")
+
+    if flags["docs_only"]:
+        active = [
+            name
+            for name in BOOLEAN_FLAGS
+            if name != "docs_only" and flags[name]
+        ]
+        if active:
+            errors.append(
+                "Docs-only classification cannot enable other flags: " + ", ".join(active)
+            )
+
+    return errors
+
+
+def main() -> int:
+    errors = check_ci_results(os.environ)
+    for variable, label in ALWAYS_REQUIRED_RESULTS:
+        print(f"{label}: {os.environ.get(variable, 'missing')}")
+    print(
+        "Classifier flags: "
+        + " ".join(
+            f"{name}={os.environ.get(_flag_env(name), 'missing')}" for name in BOOLEAN_FLAGS
+        )
+    )
+    if not errors:
+        print("All required CI results are complete and successful.")
+        return 0
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -112,7 +112,7 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
     src/opensquilla/cli/tui/opentui/package/*)
       mark_tui_changed
       ;;
-    .github/workflows/ci.yml | .github/scripts/classify-ci-changes.sh | .github/scripts/windows_test_shards.py)
+    .github/workflows/ci.yml | .github/scripts/classify-ci-changes.sh | .github/scripts/check_ci_results.py | .github/scripts/windows_test_shards.py)
       # Changes to the gate itself must exercise every path it can suppress.
       mark_full_required
       ;;
@@ -121,7 +121,7 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_release_changed
       ;;
     .github/workflows/*)
-      mark_ci_changed
+      mark_full_required
       ;;
     .github/scripts/verify-release-profile-preservation.py)
       mark_ci_changed
@@ -129,17 +129,13 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_platform_sensitive_changed
       ;;
     .github/scripts/*)
-      mark_ci_changed
+      mark_full_required
       ;;
     tests/test_scripts/test_build_wheelhouse_zip.py | tests/test_install_scripts.py | tests/test_root_start_scripts.py | tests/test_release_consistency.py | tests/test_public_release_hygiene.py)
       mark_test_changed
       mark_release_changed
       ;;
     tests/test_tools/test_shell_* | tests/test_tools/test_path_* | tests/test_sandbox/* | tests/test_desktop/* | tests/test_compat/* | tests/test_recovery/* | tests/test_migration/* | tests/test_migrations/* | tests/test_persistence/* | tests/test_session/* | tests/test_scheduler/* | tests/test_uninstall/* | tests/test_packaging/*)
-      mark_test_changed
-      mark_platform_sensitive_changed
-      ;;
-    tests/test_persistence/*)
       mark_test_changed
       mark_platform_sensitive_changed
       ;;

--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -112,7 +112,7 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
     src/opensquilla/cli/tui/opentui/package/*)
       mark_tui_changed
       ;;
-    .github/workflows/ci.yml | .github/scripts/classify-ci-changes.sh)
+    .github/workflows/ci.yml | .github/scripts/classify-ci-changes.sh | .github/scripts/windows_test_shards.py)
       # Changes to the gate itself must exercise every path it can suppress.
       mark_full_required
       ;;
@@ -135,7 +135,7 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_test_changed
       mark_release_changed
       ;;
-    tests/test_tools/test_shell_* | tests/test_tools/test_path_* | tests/test_sandbox/* | tests/test_desktop/* | tests/test_compat/* | tests/test_recovery/* | tests/test_migration/test_opensquilla_home_migration.py | tests/test_migration/test_source_snapshot_windows.py)
+    tests/test_tools/test_shell_* | tests/test_tools/test_path_* | tests/test_sandbox/* | tests/test_desktop/* | tests/test_compat/* | tests/test_recovery/* | tests/test_migration/* | tests/test_migrations/* | tests/test_persistence/* | tests/test_session/* | tests/test_scheduler/* | tests/test_uninstall/* | tests/test_packaging/*)
       mark_test_changed
       mark_platform_sensitive_changed
       ;;
@@ -152,7 +152,9 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_platform_sensitive_changed
       ;;
     tests/*)
+      # New or unclassified tests fail closed to the Windows high-risk suite.
       mark_test_changed
+      mark_platform_sensitive_changed
       ;;
     scripts/build_wheelhouse_zip.py | scripts/install_source.sh | scripts/install_source.ps1)
       mark_runtime_changed
@@ -170,7 +172,11 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_platform_sensitive_changed
       mark_desktop_changed
       ;;
-    src/opensquilla/recovery/* | src/opensquilla/migration/* | src/opensquilla/persistence/* | src/opensquilla/sandbox/* | src/opensquilla/tools/boundary.py | src/opensquilla/tools/builtin/code_exec.py | src/opensquilla/tools/builtin/filesystem.py | src/opensquilla/tools/builtin/git.py | src/opensquilla/tools/builtin/shell.py | src/opensquilla/tools/builtin/shell_policy.py | src/opensquilla/tools/path_* | src/opensquilla/tools/policy* | src/opensquilla/tools/write_*)
+    src/opensquilla/uninstall/*)
+      mark_runtime_changed
+      mark_release_changed
+      ;;
+    src/opensquilla/recovery/* | src/opensquilla/migration/* | src/opensquilla/persistence/* | src/opensquilla/memory/* | src/opensquilla/session/* | src/opensquilla/scheduler/* | src/opensquilla/sandbox/* | src/opensquilla/tools/boundary.py | src/opensquilla/tools/builtin/code_exec.py | src/opensquilla/tools/builtin/filesystem.py | src/opensquilla/tools/builtin/git.py | src/opensquilla/tools/builtin/shell.py | src/opensquilla/tools/builtin/shell_policy.py | src/opensquilla/tools/path_* | src/opensquilla/tools/policy* | src/opensquilla/tools/write_*)
       mark_runtime_changed
       mark_platform_sensitive_changed
       ;;
@@ -183,12 +189,16 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_platform_sensitive_changed
       ;;
     src/* | scripts/*)
+      # Unknown runtime surfaces are high risk until explicitly proven otherwise.
       mark_runtime_changed
+      mark_platform_sensitive_changed
       ;;
     docs/* | README.md | README.*.md | CHANGELOG.md | CODE_OF_CONDUCT.md | CONTRIBUTING.md | MIGRATION.md | SECURITY.md | SUPPORT.md | THIRD_PARTY_NOTICES.md | META_SKILL_GUIDE.md | .github/pull_request_template.md | .github/ISSUE_TEMPLATE/*)
       ;;
     *)
+      # Fail closed for new non-documentation paths.
       mark_runtime_changed
+      mark_platform_sensitive_changed
       ;;
   esac
 done < "${changed_files}"

--- a/.github/scripts/windows_test_shards.py
+++ b/.github/scripts/windows_test_shards.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+import tomllib
 import xml.etree.ElementTree as ET
 from pathlib import Path, PurePosixPath
 from typing import Final
@@ -65,14 +66,41 @@ _DESKTOP_INSTALLER_EXACT: Final[frozenset[str]] = frozenset(
         "tests/test_root_start_scripts.py",
     }
 )
+_CORE_EXACT: Final[frozenset[str]] = frozenset(
+    {
+        "tests/test_ci/test_router_artifact_manifest.py",
+    }
+)
 
 
 def discover_test_files(root: Path) -> tuple[str, ...]:
     """Return every pytest file below ``tests/`` as a repository-relative path."""
 
     tests_root = root / "tests"
+    excluded = _pytest_excluded_prefixes(root)
+    relative_paths = (
+        path.relative_to(root).as_posix() for path in tests_root.rglob("test_*.py")
+    )
     return tuple(
-        sorted(path.relative_to(root).as_posix() for path in tests_root.rglob("test_*.py"))
+        sorted(
+            relative
+            for relative in relative_paths
+            if not any(relative.startswith(prefix) for prefix in excluded)
+        )
+    )
+
+
+def _pytest_excluded_prefixes(root: Path) -> tuple[str, ...]:
+    pyproject = root / "pyproject.toml"
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ValueError(f"cannot read pytest collection contract from {pyproject}") from exc
+    configured = data.get("tool", {}).get("pytest", {}).get("ini_options", {})
+    return tuple(
+        f"{PurePosixPath(path).as_posix().rstrip('/')}/"
+        for path in configured.get("norecursedirs", ())
+        if PurePosixPath(path).as_posix().startswith("tests/")
     )
 
 
@@ -80,6 +108,8 @@ def matching_specialized_shards(path: str) -> tuple[str, ...]:
     """Return specialized shards whose responsibility rules match ``path``."""
 
     normalized = PurePosixPath(path).as_posix()
+    if normalized in _CORE_EXACT:
+        return ()
     name = PurePosixPath(normalized).name.casefold()
     prefix_matches: list[str] = []
     if normalized.startswith(_GATEWAY_SQLITE_PREFIXES):

--- a/.github/scripts/windows_test_shards.py
+++ b/.github/scripts/windows_test_shards.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Route offline pytest files into stable Windows CI responsibility shards."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path, PurePosixPath
+from typing import Final
+
+SHARD_NAMES: Final[tuple[str, ...]] = (
+    "core",
+    "gateway-sqlite",
+    "recovery-migration",
+    "desktop-installer-contracts",
+)
+
+_GATEWAY_SQLITE_PREFIXES: Final[tuple[str, ...]] = (
+    "tests/test_gateway/",
+    "tests/test_health/",
+    "tests/test_observability/",
+    "tests/test_persistence/",
+    "tests/test_scheduler/",
+    "tests/test_search/",
+    "tests/test_session/",
+)
+_RECOVERY_MIGRATION_PREFIXES: Final[tuple[str, ...]] = (
+    "tests/test_migration/",
+    "tests/test_migrations/",
+    "tests/test_recovery/",
+)
+_DESKTOP_INSTALLER_PREFIXES: Final[tuple[str, ...]] = (
+    "tests/test_desktop/",
+    "tests/test_dist/",
+    "tests/test_packaging/",
+    "tests/test_uninstall/",
+)
+
+_GATEWAY_SQLITE_NAME_TOKENS: Final[tuple[str, ...]] = (
+    "database",
+    "gateway",
+    "memory",
+    "scheduler",
+    "session",
+    "sqlite",
+)
+_RECOVERY_MIGRATION_NAME_TOKENS: Final[tuple[str, ...]] = (
+    "legacy_config",
+    "migrate",
+    "migration",
+    "recovery",
+)
+_DESKTOP_INSTALLER_NAME_TOKENS: Final[tuple[str, ...]] = (
+    "artifact",
+    "desktop",
+    "install",
+    "release",
+    "uninstall",
+    "wheelhouse",
+)
+_DESKTOP_INSTALLER_EXACT: Final[frozenset[str]] = frozenset(
+    {
+        "tests/test_compose_yaml_shape.py",
+        "tests/test_root_start_scripts.py",
+    }
+)
+
+
+def discover_test_files(root: Path) -> tuple[str, ...]:
+    """Return every pytest file below ``tests/`` as a repository-relative path."""
+
+    tests_root = root / "tests"
+    return tuple(
+        sorted(path.relative_to(root).as_posix() for path in tests_root.rglob("test_*.py"))
+    )
+
+
+def matching_specialized_shards(path: str) -> tuple[str, ...]:
+    """Return specialized shards whose responsibility rules match ``path``."""
+
+    normalized = PurePosixPath(path).as_posix()
+    name = PurePosixPath(normalized).name.casefold()
+    prefix_matches: list[str] = []
+    if normalized.startswith(_GATEWAY_SQLITE_PREFIXES):
+        prefix_matches.append("gateway-sqlite")
+    if normalized.startswith(_RECOVERY_MIGRATION_PREFIXES):
+        prefix_matches.append("recovery-migration")
+    if normalized.startswith(_DESKTOP_INSTALLER_PREFIXES):
+        prefix_matches.append("desktop-installer-contracts")
+    if prefix_matches:
+        return tuple(prefix_matches)
+
+    matches: list[str] = []
+    if any(token in name for token in _GATEWAY_SQLITE_NAME_TOKENS):
+        matches.append("gateway-sqlite")
+    if any(token in name for token in _RECOVERY_MIGRATION_NAME_TOKENS):
+        matches.append("recovery-migration")
+    if normalized in _DESKTOP_INSTALLER_EXACT or any(
+        token in name for token in _DESKTOP_INSTALLER_NAME_TOKENS
+    ):
+        matches.append("desktop-installer-contracts")
+
+    return tuple(matches)
+
+
+def shard_for_test(path: str) -> str:
+    """Return the one responsibility shard for ``path`` or fail on ambiguity."""
+
+    matches = matching_specialized_shards(path)
+    if len(matches) > 1:
+        joined = ", ".join(matches)
+        raise ValueError(f"test file matches multiple Windows shards: {path} ({joined})")
+    return matches[0] if matches else "core"
+
+
+def files_for_shard(root: Path, shard: str) -> tuple[str, ...]:
+    if shard not in SHARD_NAMES:
+        raise ValueError(f"unknown Windows shard: {shard}")
+    return tuple(path for path in discover_test_files(root) if shard_for_test(path) == shard)
+
+
+def _write_failure_summary(junit_path: Path, summary_path: Path, exit_code: int) -> None:
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"pytest_exit_code={exit_code}"]
+    if not junit_path.is_file():
+        lines.append("junit_status=unavailable")
+        summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return
+
+    try:
+        root = ET.parse(junit_path).getroot()
+    except (ET.ParseError, OSError) as exc:
+        lines.extend(("junit_status=unreadable", f"detail={type(exc).__name__}"))
+        summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return
+
+    for testcase in root.iter("testcase"):
+        failure = testcase.find("failure")
+        if failure is None:
+            failure = testcase.find("error")
+        if failure is None:
+            continue
+        class_name = testcase.get("classname", "")
+        test_name = testcase.get("name", "unknown")
+        node = f"{class_name}::{test_name}" if class_name else test_name
+        detail = (failure.text or failure.get("message") or "failure details unavailable").strip()
+        lines.extend(
+            (
+                "junit_status=failed",
+                f"first_failure={node}",
+                "detail:",
+                detail[:12_000],
+            )
+        )
+        break
+    else:
+        lines.append("junit_status=passed" if exit_code == 0 else "junit_status=no-test-failure")
+
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _run(args: argparse.Namespace) -> int:
+    import pytest
+
+    root = args.root.resolve()
+    files = files_for_shard(root, args.shard)
+    if not files:
+        print(f"Windows shard {args.shard!r} has no tests", file=sys.stderr)
+        return 2
+
+    args.junit.parent.mkdir(parents=True, exist_ok=True)
+    args.summary.parent.mkdir(parents=True, exist_ok=True)
+    args.summary.write_text("pytest_status=started\n", encoding="utf-8")
+
+    pytest_args = list(args.pytest_args)
+    if pytest_args[:1] == ["--"]:
+        pytest_args = pytest_args[1:]
+    pytest_args.extend(str(root / path) for path in files)
+    pytest_args.append(f"--junitxml={args.junit}")
+
+    print(f"Running {len(files)} test files in Windows shard {args.shard}")
+    exit_code = int(pytest.main(pytest_args))
+    _write_failure_summary(args.junit, args.summary, exit_code)
+    return exit_code
+
+
+def _list(args: argparse.Namespace) -> int:
+    for path in files_for_shard(args.root.resolve(), args.shard):
+        print(path)
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", help="list files assigned to one shard")
+    list_parser.add_argument("shard", choices=SHARD_NAMES)
+    list_parser.add_argument("--root", type=Path, default=Path.cwd())
+    list_parser.set_defaults(handler=_list)
+
+    run_parser = subparsers.add_parser("run", help="run one shard through pytest")
+    run_parser.add_argument("shard", choices=SHARD_NAMES)
+    run_parser.add_argument("--root", type=Path, default=Path.cwd())
+    run_parser.add_argument("--junit", type=Path, required=True)
+    run_parser.add_argument("--summary", type=Path, required=True)
+    run_parser.set_defaults(handler=_run)
+    return parser
+
+
+def main() -> int:
+    parser = _parser()
+    args, pytest_args = parser.parse_known_args()
+    if args.command != "run" and pytest_args:
+        parser.error(f"unrecognized arguments: {' '.join(pytest_args)}")
+    args.pytest_args = pytest_args
+    return int(args.handler(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,11 +346,19 @@ jobs:
             -q
 
   windows-full:
-    name: Windows high-risk/full tests (conditional)
+    name: Windows high-risk (${{ matrix.shard }})
     needs: classify-changes
     if: ${{ needs.classify-changes.outputs.windows_full_required == 'true' || needs.classify-changes.outputs.full_required == 'true' }}
     runs-on: windows-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - core
+          - gateway-sqlite
+          - recovery-migration
+          - desktop-installer-contracts
 
     env:
       UV_PYTHON: "3.12"
@@ -358,10 +366,26 @@ jobs:
       OPENSQUILLA_TURN_CALL_LOG: "0"
 
     steps:
+      - name: Prepare diagnostic report
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_dir="${RUNNER_TEMP}/ci-reports/${{ matrix.shard }}"
+          mkdir -p "${report_dir}"
+          printf 'CI_REPORT_DIR=%s\n' "${report_dir}" >> "${GITHUB_ENV}"
+          {
+            printf 'runner_os=%s\n' "${RUNNER_OS}"
+            printf 'runner_arch=%s\n' "${RUNNER_ARCH}"
+            printf 'commit_sha=%s\n' "${GITHUB_SHA}"
+            printf 'run_attempt=%s\n' "${GITHUB_RUN_ATTEMPT}"
+            printf 'shard=%s\n' "${{ matrix.shard }}"
+          } > "${report_dir}/environment.txt"
+          printf 'pytest_status=not_started\n' > "${report_dir}/first-failure.txt"
+
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          lfs: ${{ needs.classify-changes.outputs.full_required == 'true' }}
+          lfs: true
 
       - name: Configure runtime directories
         shell: bash
@@ -380,13 +404,13 @@ jobs:
           enable-cache: true
 
       - name: Set up Bun
-        if: ${{ needs.classify-changes.outputs.tui_changed == 'true' || needs.classify-changes.outputs.full_required == 'true' }}
+        if: ${{ matrix.shard == 'core' && (needs.classify-changes.outputs.tui_changed == 'true' || needs.classify-changes.outputs.full_required == 'true') }}
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
       - name: Install OpenTUI host dependencies
-        if: ${{ needs.classify-changes.outputs.tui_changed == 'true' || needs.classify-changes.outputs.full_required == 'true' }}
+        if: ${{ matrix.shard == 'core' && (needs.classify-changes.outputs.tui_changed == 'true' || needs.classify-changes.outputs.full_required == 'true') }}
         shell: bash
         run: bun install --frozen-lockfile --cwd=src/opensquilla/cli/tui/opentui/package
 
@@ -394,28 +418,45 @@ jobs:
         shell: bash
         run: uv sync --extra dev --extra recommended --extra mcp --frozen
 
-      - name: Test
+      - name: Record tool versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            python --version
+            uv --version
+            uv run pytest --version
+          } >> "${CI_REPORT_DIR}/environment.txt" 2>&1
+
+      - name: Test Windows shard
         shell: bash
         run: |
           set -euo pipefail
           markers="not llm and not live_search and not live_channel and not webui_browser and not tui_real_terminal and not local_golden and not agent_context_boundary and not llm_router_acc"
-
-          if [[ "${{ needs.classify-changes.outputs.full_required }}" == "true" ]]; then
-            uv run pytest tests -q -m "${markers}" --durations=50 --maxfail=1
-          else
-            uv run pytest \
-              tests/test_artifacts.py \
-              tests/test_compat \
-              tests/test_desktop \
-              tests/test_sandbox \
-              tests/test_tools/test_path_aliases.py \
-              tests/test_tools/test_path_policy.py \
-              tests/test_tools/test_shell_approval_policy.py \
-              tests/test_tools/test_shell_background_seatbelt.py \
-              tests/test_tools/test_shell_policy_windows.py \
-              tests/test_tools/test_shell_process_isolation.py \
-              -q -m "${markers}" --durations=50
+          maxfail_args=()
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            maxfail_args+=(--maxfail=3)
           fi
+
+          uv run python .github/scripts/windows_test_shards.py run \
+            "${{ matrix.shard }}" \
+            --junit "${CI_REPORT_DIR}/junit.xml" \
+            --summary "${CI_REPORT_DIR}/first-failure.txt" \
+            -- \
+            -q \
+            -m "${markers}" \
+            --durations=50 \
+            "${maxfail_args[@]}" \
+            2>&1 | tee "${CI_REPORT_DIR}/pytest.log"
+
+      - name: Upload Windows shard report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-high-risk-${{ matrix.shard }}-attempt-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/ci-reports/${{ matrix.shard }}
+          if-no-files-found: error
+          retention-days: 14
 
   release-packaging:
     name: Release packaging contracts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: ${{ matrix.shard == 'core' }}
 
       - name: Configure runtime directories
         shell: bash
@@ -404,13 +404,13 @@ jobs:
           enable-cache: true
 
       - name: Set up Bun
-        if: ${{ matrix.shard == 'core' && (needs.classify-changes.outputs.tui_changed == 'true' || needs.classify-changes.outputs.full_required == 'true') }}
+        if: ${{ matrix.shard == 'core' }}
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
       - name: Install OpenTUI host dependencies
-        if: ${{ matrix.shard == 'core' && (needs.classify-changes.outputs.tui_changed == 'true' || needs.classify-changes.outputs.full_required == 'true') }}
+        if: ${{ matrix.shard == 'core' }}
         shell: bash
         run: bun install --frozen-lockfile --cwd=src/opensquilla/cli/tui/opentui/package
 
@@ -535,109 +535,38 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Check required CI results
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          classify_result="${{ needs.classify-changes.result }}"
-          workflow_lint_result="${{ needs.workflow-lint.result }}"
-          readme_locale_result="${{ needs.readme-locale-check.result }}"
-          frontend_result="${{ needs.frontend-check.result }}"
-          tui_result="${{ needs.tui-check.result }}"
-          desktop_result="${{ needs.desktop-check.result }}"
-          ubuntu_result="${{ needs.ubuntu-quality.result }}"
-          windows_smoke_result="${{ needs.windows-compat.result }}"
-          windows_full_result="${{ needs.windows-full.result }}"
-          release_result="${{ needs.release-packaging.result }}"
-          docs_only="${{ needs.classify-changes.outputs.docs_only }}"
-          runtime_changed="${{ needs.classify-changes.outputs.runtime_changed }}"
-          test_changed="${{ needs.classify-changes.outputs.test_changed }}"
-          ci_changed="${{ needs.classify-changes.outputs.ci_changed }}"
-          dependency_changed="${{ needs.classify-changes.outputs.dependency_changed }}"
-          release_changed="${{ needs.classify-changes.outputs.release_changed }}"
-          windows_full_required="${{ needs.classify-changes.outputs.windows_full_required }}"
-          frontend_changed="${{ needs.classify-changes.outputs.frontend_changed }}"
-          tui_changed="${{ needs.classify-changes.outputs.tui_changed }}"
-          desktop_changed="${{ needs.classify-changes.outputs.desktop_changed }}"
-          python_changed="${{ needs.classify-changes.outputs.python_changed }}"
-          platform_sensitive_changed="${{ needs.classify-changes.outputs.platform_sensitive_changed }}"
-          build_wheel_required="${{ needs.classify-changes.outputs.build_wheel_required }}"
-          full_required="${{ needs.classify-changes.outputs.full_required }}"
-
-          require_success() {
-            local result="$1"
-            local label="$2"
-            if [[ "${result}" != "success" ]]; then
-              echo "${label} must succeed."
-              exit 1
-            fi
-          }
-
-          allow_success_or_skipped() {
-            local result="$1"
-            local label="$2"
-            if [[ "${result}" != "success" && "${result}" != "skipped" ]]; then
-              echo "${label} must not fail."
-              exit 1
-            fi
-          }
-
-          printf 'classify-changes: %s\n' "${classify_result}"
-          printf 'workflow-lint: %s\n' "${workflow_lint_result}"
-          printf 'readme-locale-check: %s\n' "${readme_locale_result}"
-          printf 'frontend-check: %s\n' "${frontend_result}"
-          printf 'tui-check: %s\n' "${tui_result}"
-          printf 'desktop-check: %s\n' "${desktop_result}"
-          printf 'ubuntu-quality: %s\n' "${ubuntu_result}"
-          printf 'windows-compat-smoke: %s\n' "${windows_smoke_result}"
-          printf 'windows-full: %s\n' "${windows_full_result}"
-          printf 'release-packaging: %s\n' "${release_result}"
-          printf 'docs_only=%s runtime_changed=%s test_changed=%s ci_changed=%s dependency_changed=%s release_changed=%s windows_full_required=%s frontend_changed=%s tui_changed=%s python_changed=%s platform_sensitive_changed=%s build_wheel_required=%s full_required=%s\n' \
-            "${docs_only}" "${runtime_changed}" "${test_changed}" "${ci_changed}" "${dependency_changed}" "${release_changed}" "${windows_full_required}" "${frontend_changed}" "${tui_changed}" "${python_changed}" "${platform_sensitive_changed}" "${build_wheel_required}" "${full_required}"
-
-          require_success "${classify_result}" "Classify changed files"
-          require_success "${workflow_lint_result}" "Workflow lint"
-          require_success "${readme_locale_result}" "README locale parity"
-
-          if [[ "${frontend_changed}" == "true" || "${full_required}" == "true" ]]; then
-            require_success "${frontend_result}" "Frontend build and typecheck"
-          else
-            allow_success_or_skipped "${frontend_result}" "Frontend build and typecheck"
-          fi
-
-          if [[ "${tui_changed}" == "true" || "${full_required}" == "true" ]]; then
-            require_success "${tui_result}" "OpenTUI package tests"
-          else
-            allow_success_or_skipped "${tui_result}" "OpenTUI package tests"
-          fi
-
-          if [[ "${desktop_changed}" == "true" || "${full_required}" == "true" ]]; then
-            require_success "${desktop_result}" "Desktop Electron unit tests"
-          else
-            allow_success_or_skipped "${desktop_result}" "Desktop Electron unit tests"
-          fi
-
-          if [[ "${python_changed}" == "true" || "${full_required}" == "true" ]]; then
-            require_success "${ubuntu_result}" "Ubuntu quality gate"
-          else
-            allow_success_or_skipped "${ubuntu_result}" "Ubuntu quality gate"
-          fi
-
-          if [[ "${python_changed}" == "true" || "${platform_sensitive_changed}" == "true" || "${dependency_changed}" == "true" || "${release_changed}" == "true" || "${full_required}" == "true" ]]; then
-            require_success "${windows_smoke_result}" "Windows compatibility smoke tests"
-          else
-            allow_success_or_skipped "${windows_smoke_result}" "Windows compatibility smoke tests"
-          fi
-
-          if [[ "${windows_full_required}" == "true" || "${full_required}" == "true" ]]; then
-            require_success "${windows_full_result}" "Windows full test suite"
-          else
-            allow_success_or_skipped "${windows_full_result}" "Windows full test suite"
-          fi
-
-          if [[ "${release_changed}" == "true" || "${full_required}" == "true" ]]; then
-            require_success "${release_result}" "Release packaging contracts"
-          else
-            allow_success_or_skipped "${release_result}" "Release packaging contracts"
-          fi
+        env:
+          RESULT_CLASSIFY: ${{ needs.classify-changes.result }}
+          RESULT_WORKFLOW_LINT: ${{ needs.workflow-lint.result }}
+          RESULT_README_LOCALE: ${{ needs.readme-locale-check.result }}
+          RESULT_FRONTEND: ${{ needs.frontend-check.result }}
+          RESULT_TUI: ${{ needs.tui-check.result }}
+          RESULT_DESKTOP: ${{ needs.desktop-check.result }}
+          RESULT_UBUNTU: ${{ needs.ubuntu-quality.result }}
+          RESULT_WINDOWS_SMOKE: ${{ needs.windows-compat.result }}
+          RESULT_WINDOWS_FULL: ${{ needs.windows-full.result }}
+          RESULT_RELEASE: ${{ needs.release-packaging.result }}
+          FLAG_DOCS_ONLY: ${{ needs.classify-changes.outputs.docs_only }}
+          FLAG_RUNTIME_CHANGED: ${{ needs.classify-changes.outputs.runtime_changed }}
+          FLAG_TEST_CHANGED: ${{ needs.classify-changes.outputs.test_changed }}
+          FLAG_CI_CHANGED: ${{ needs.classify-changes.outputs.ci_changed }}
+          FLAG_DEPENDENCY_CHANGED: ${{ needs.classify-changes.outputs.dependency_changed }}
+          FLAG_RELEASE_CHANGED: ${{ needs.classify-changes.outputs.release_changed }}
+          FLAG_WINDOWS_FULL_REQUIRED: ${{ needs.classify-changes.outputs.windows_full_required }}
+          FLAG_FRONTEND_CHANGED: ${{ needs.classify-changes.outputs.frontend_changed }}
+          FLAG_TUI_CHANGED: ${{ needs.classify-changes.outputs.tui_changed }}
+          FLAG_DESKTOP_CHANGED: ${{ needs.classify-changes.outputs.desktop_changed }}
+          FLAG_PYTHON_CHANGED: ${{ needs.classify-changes.outputs.python_changed }}
+          FLAG_PLATFORM_SENSITIVE_CHANGED: ${{ needs.classify-changes.outputs.platform_sensitive_changed }}
+          FLAG_BUILD_WHEEL_REQUIRED: ${{ needs.classify-changes.outputs.build_wheel_required }}
+          FLAG_FULL_REQUIRED: ${{ needs.classify-changes.outputs.full_required }}
+        run: python .github/scripts/check_ci_results.py

--- a/tests/test_ci/test_ci_result_gate.py
+++ b/tests/test_ci/test_ci_result_gate.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import runpy
+from typing import Any
+
+GATE_MODULE: dict[str, Any] = runpy.run_path(
+    ".github/scripts/check_ci_results.py", run_name="check_ci_results"
+)
+BOOLEAN_FLAGS: tuple[str, ...] = GATE_MODULE["BOOLEAN_FLAGS"]
+check_ci_results = GATE_MODULE["check_ci_results"]
+
+
+def _flag_env(name: str) -> str:
+    return f"FLAG_{name.upper()}"
+
+
+def _base_env() -> dict[str, str]:
+    env = {
+        "RESULT_CLASSIFY": "success",
+        "RESULT_WORKFLOW_LINT": "success",
+        "RESULT_README_LOCALE": "success",
+        "RESULT_FRONTEND": "skipped",
+        "RESULT_TUI": "skipped",
+        "RESULT_DESKTOP": "skipped",
+        "RESULT_UBUNTU": "skipped",
+        "RESULT_WINDOWS_SMOKE": "skipped",
+        "RESULT_WINDOWS_FULL": "skipped",
+        "RESULT_RELEASE": "skipped",
+    }
+    env.update({_flag_env(name): "false" for name in BOOLEAN_FLAGS})
+    env[_flag_env("docs_only")] = "true"
+    return env
+
+
+def _full_env() -> dict[str, str]:
+    env = _base_env()
+    env.update({_flag_env(name): "true" for name in BOOLEAN_FLAGS})
+    env[_flag_env("docs_only")] = "false"
+    for key in tuple(env):
+        if key.startswith("RESULT_"):
+            env[key] = "success"
+    return env
+
+
+def test_ci_result_gate_accepts_intentional_docs_only_skips() -> None:
+    assert check_ci_results(_base_env()) == []
+
+
+def test_ci_result_gate_accepts_complete_full_matrix() -> None:
+    assert check_ci_results(_full_env()) == []
+
+
+def test_ci_result_gate_rejects_missing_or_invalid_classifier_outputs() -> None:
+    missing = _base_env()
+    missing.pop(_flag_env("windows_full_required"))
+    invalid = _base_env()
+    invalid[_flag_env("python_changed")] = "yes"
+
+    assert any("windows_full_required" in error for error in check_ci_results(missing))
+    assert any("python_changed" in error for error in check_ci_results(invalid))
+
+
+def test_ci_result_gate_rejects_required_windows_matrix_skip() -> None:
+    env = _base_env()
+    env[_flag_env("docs_only")] = "false"
+    env[_flag_env("runtime_changed")] = "true"
+    env[_flag_env("python_changed")] = "true"
+    env[_flag_env("platform_sensitive_changed")] = "true"
+    env[_flag_env("windows_full_required")] = "true"
+    env[_flag_env("build_wheel_required")] = "true"
+    env["RESULT_UBUNTU"] = "success"
+    env["RESULT_WINDOWS_SMOKE"] = "success"
+
+    errors = check_ci_results(env)
+
+    assert any("Windows high-risk matrix" in error and "skipped" in error for error in errors)
+
+
+def test_ci_result_gate_rejects_failure_cancellation_and_missing_results() -> None:
+    for result in ("failure", "cancelled", ""):
+        env = _full_env()
+        env["RESULT_WINDOWS_FULL"] = result
+
+        errors = check_ci_results(env)
+
+        assert any("Windows high-risk matrix" in error for error in errors)
+
+
+def test_ci_result_gate_rejects_inconsistent_full_and_platform_flags() -> None:
+    incomplete_full = _full_env()
+    incomplete_full[_flag_env("release_changed")] = "false"
+    unsafe_platform = _base_env()
+    unsafe_platform[_flag_env("docs_only")] = "false"
+    unsafe_platform[_flag_env("platform_sensitive_changed")] = "true"
+
+    assert any("release_changed=true" in error for error in check_ci_results(incomplete_full))
+    assert any("Platform-sensitive" in error for error in check_ci_results(unsafe_platform))

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import runpy
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SHARD_SCRIPT = Path(".github/scripts/windows_test_shards.py")
+SHARD_MODULE: dict[str, Any] = runpy.run_path(
+    SHARD_SCRIPT.as_posix(), run_name="windows_test_shards"
+)
+SHARD_NAMES: tuple[str, ...] = SHARD_MODULE["SHARD_NAMES"]
+discover_test_files = SHARD_MODULE["discover_test_files"]
+files_for_shard = SHARD_MODULE["files_for_shard"]
+matching_specialized_shards = SHARD_MODULE["matching_specialized_shards"]
+shard_for_test = SHARD_MODULE["shard_for_test"]
+
+
+def test_every_pytest_file_belongs_to_exactly_one_windows_shard() -> None:
+    discovered = set(discover_test_files(Path.cwd()))
+    by_shard = {
+        shard: set(files_for_shard(Path.cwd(), shard)) for shard in SHARD_NAMES
+    }
+
+    assert set(SHARD_NAMES) == {
+        "core",
+        "gateway-sqlite",
+        "recovery-migration",
+        "desktop-installer-contracts",
+    }
+    assert all(by_shard.values())
+    assert set().union(*by_shard.values()) == discovered
+    assert sum(len(paths) for paths in by_shard.values()) == len(discovered)
+    assert all(len(matching_specialized_shards(path)) <= 1 for path in discovered)
+
+
+def test_windows_shard_responsibilities_cover_high_risk_surfaces() -> None:
+    expected = {
+        "tests/test_engine/test_agent_max_iterations.py": "core",
+        "tests/test_gateway/test_task_runtime_terminal_cleanup.py": "gateway-sqlite",
+        "tests/test_persistence/test_migrator.py": "gateway-sqlite",
+        "tests/test_session/test_manager.py": "gateway-sqlite",
+        "tests/test_migration/test_opensquilla_home_migration.py": "recovery-migration",
+        "tests/test_recovery/test_fixture_contracts.py": "recovery-migration",
+        "tests/test_cli/test_migrate_cmd.py": "recovery-migration",
+        "tests/test_desktop/test_electron_startup_contract.py": (
+            "desktop-installer-contracts"
+        ),
+        "tests/test_uninstall/test_safety.py": "desktop-installer-contracts",
+        "tests/test_install_scripts.py": "desktop-installer-contracts",
+    }
+
+    assert {path: shard_for_test(path) for path in expected} == expected
+
+
+def test_windows_shard_runner_preserves_failure_exit_and_summary(tmp_path: Path) -> None:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_failure.py").write_text(
+        "def test_failure():\n    assert False, 'synthetic shard failure'\n",
+        encoding="utf-8",
+    )
+    junit = tmp_path / "reports" / "junit.xml"
+    summary = tmp_path / "reports" / "first-failure.txt"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            SHARD_SCRIPT.resolve().as_posix(),
+            "run",
+            "core",
+            "--root",
+            tmp_path.as_posix(),
+            "--junit",
+            junit.as_posix(),
+            "--summary",
+            summary.as_posix(),
+            "--",
+            "-q",
+            "--maxfail=3",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 1
+    assert junit.is_file()
+    text = summary.read_text(encoding="utf-8")
+    assert "pytest_exit_code=1" in text
+    assert "junit_status=failed" in text
+    assert "synthetic shard failure" in text

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -33,11 +33,15 @@ def test_every_pytest_file_belongs_to_exactly_one_windows_shard() -> None:
     assert set().union(*by_shard.values()) == discovered
     assert sum(len(paths) for paths in by_shard.values()) == len(discovered)
     assert all(len(matching_specialized_shards(path)) <= 1 for path in discovered)
+    assert "tests/fixtures/meta_skill_inputs/code_review_dirty_repo/tests/test_app.py" not in (
+        discovered
+    )
 
 
 def test_windows_shard_responsibilities_cover_high_risk_surfaces() -> None:
     expected = {
         "tests/test_engine/test_agent_max_iterations.py": "core",
+        "tests/test_ci/test_router_artifact_manifest.py": "core",
         "tests/test_gateway/test_task_runtime_terminal_cleanup.py": "gateway-sqlite",
         "tests/test_persistence/test_migrator.py": "gateway-sqlite",
         "tests/test_session/test_manager.py": "gateway-sqlite",
@@ -55,6 +59,10 @@ def test_windows_shard_responsibilities_cover_high_risk_surfaces() -> None:
 
 
 def test_windows_shard_runner_preserves_failure_exit_and_summary(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.pytest.ini_options]\nnorecursedirs = ["tests/fixtures"]\n',
+        encoding="utf-8",
+    )
     tests_dir = tmp_path / "tests"
     tests_dir.mkdir()
     (tests_dir / "test_failure.py").write_text(

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -192,7 +192,7 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert "OpenTUI package tests" in text
     assert "Ubuntu quality gate" in text
     assert "Windows compatibility smoke tests" in text
-    assert "Windows high-risk/full tests" in text
+    assert "Windows high-risk" in text
     assert "Release packaging contracts" in text
     assert "CI result" in text
     assert 'push)\n              before="${{ github.event.before }}"' in text
@@ -844,24 +844,45 @@ def test_windows_smoke_does_not_install_bun_by_default() -> None:
     assert any("bun run test:bun" in step.get("run", "") for step in tui_steps)
 
 
-def test_windows_high_risk_job_uses_subset_until_full_ci() -> None:
+def test_windows_high_risk_job_runs_parallel_reported_shards() -> None:
     data = _workflow("ci.yml")
     jobs = data["jobs"]
     windows_full = jobs["windows-full"]
-    text = (WORKFLOW_DIR / "ci.yml").read_text(encoding="utf-8")
-
-    assert windows_full["name"] == "Windows high-risk/full tests (conditional)"
-    assert windows_full["timeout-minutes"] == 45
-    assert windows_full["steps"][0]["with"]["lfs"] == (
-        "${{ needs.classify-changes.outputs.full_required == 'true' }}"
+    steps = windows_full["steps"]
+    test_step = next(step for step in steps if step.get("name") == "Test Windows shard")
+    upload_step = next(
+        step for step in steps if step.get("name") == "Upload Windows shard report"
     )
-    assert 'uv run pytest tests -q -m "${markers}" --durations=50' in text
-    assert 'uv run pytest tests -q -m "${markers}" --durations=50 --maxfail=1' in text
-    assert "tests/test_compat" in text
-    assert "tests/test_sandbox" in text
-    assert "tests/test_tools/test_shell_policy_windows.py" in text
-    assert "tests/test_tools/test_shell_background_seatbelt.py" in text
-    assert "needs.classify-changes.outputs.tui_changed == 'true'" in text
+
+    assert windows_full["name"] == "Windows high-risk (${{ matrix.shard }})"
+    assert windows_full["timeout-minutes"] == 45
+    assert windows_full["strategy"] == {
+        "fail-fast": False,
+        "matrix": {
+            "shard": [
+                "core",
+                "gateway-sqlite",
+                "recovery-migration",
+                "desktop-installer-contracts",
+            ]
+        },
+    }
+    checkout = next(step for step in steps if step.get("name") == "Check out repository")
+    assert checkout["with"]["lfs"] is True
+    assert steps[0]["name"] == "Prepare diagnostic report"
+    assert "OPENSQUILLA_STATE_DIR" not in steps[0]["run"]
+    assert "PATH" not in steps[0]["run"]
+    assert "HOME" not in steps[0]["run"]
+    assert ".github/scripts/windows_test_shards.py run" in test_step["run"]
+    assert '"${{ github.event_name }}" == "pull_request"' in test_step["run"]
+    assert "--maxfail=3" in test_step["run"]
+    assert "--maxfail=1" not in test_step["run"]
+    assert "set -euo pipefail" in test_step["run"]
+    assert 'tee "${CI_REPORT_DIR}/pytest.log"' in test_step["run"]
+    assert upload_step["if"] == "${{ always() }}"
+    assert upload_step["uses"] == "actions/upload-artifact@v4"
+    assert upload_step["with"]["if-no-files-found"] == "error"
+    assert upload_step["with"]["retention-days"] == 14
 
 
 def test_ubuntu_quality_only_fetches_lfs_for_full_ci() -> None:

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -465,12 +465,14 @@ def test_ci_change_classifier_treats_runtime_markdown_as_runtime(tmp_path: Path)
 
     assert outputs == _expected_classifier_outputs(
         runtime_changed="true",
+        windows_full_required="true",
         python_changed="true",
+        platform_sensitive_changed="true",
         build_wheel_required="true",
     )
 
 
-def test_ci_change_classifier_tracks_test_changes_separately(tmp_path: Path) -> None:
+def test_ci_change_classifier_fails_closed_for_unclassified_tests(tmp_path: Path) -> None:
     outputs = _classify_changed_files(
         tmp_path,
         ["tests/test_ci/test_workflows.py"],
@@ -478,7 +480,9 @@ def test_ci_change_classifier_tracks_test_changes_separately(tmp_path: Path) -> 
 
     assert outputs == _expected_classifier_outputs(
         test_changed="true",
+        windows_full_required="true",
         python_changed="true",
+        platform_sensitive_changed="true",
     )
 
 
@@ -552,6 +556,60 @@ def test_ci_change_classifier_tracks_tui_changes_without_windows_full(tmp_path: 
         build_wheel_required="true",
     )
 
+
+def test_ci_change_classifier_fails_closed_for_unclassified_runtime_paths(
+    tmp_path: Path,
+) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        ["src/opensquilla/future_profile_store/transaction.py"],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        runtime_changed="true",
+        windows_full_required="true",
+        python_changed="true",
+        platform_sensitive_changed="true",
+        build_wheel_required="true",
+    )
+
+
+def test_ci_change_classifier_fails_closed_for_unknown_root_paths(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(tmp_path, ["future-runtime-policy.json"])
+
+    assert outputs == _expected_classifier_outputs(
+        runtime_changed="true",
+        windows_full_required="true",
+        python_changed="true",
+        platform_sensitive_changed="true",
+        build_wheel_required="true",
+    )
+
+
+def test_ci_change_classifier_covers_state_and_installation_boundaries(
+    tmp_path: Path,
+) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [
+            "src/opensquilla/session/manager.py",
+            "src/opensquilla/scheduler/persistence.py",
+            "src/opensquilla/memory/store.py",
+            "src/opensquilla/uninstall/actions.py",
+            "tests/test_recovery/test_new_contract.py",
+            "tests/test_uninstall/test_actions.py",
+        ],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        runtime_changed="true",
+        test_changed="true",
+        release_changed="true",
+        windows_full_required="true",
+        python_changed="true",
+        platform_sensitive_changed="true",
+        build_wheel_required="true",
+    )
 
 def test_ci_change_classifier_tracks_platform_sensitive_changes(tmp_path: Path) -> None:
     outputs = _classify_changed_files(

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -190,8 +190,8 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert "actionlint@v1.7.12" in text
     assert "Classify changed files" in text
     assert "OpenTUI package tests" in text
-    assert "Ubuntu quality gate" in text
-    assert "Windows compatibility smoke tests" in text
+    assert "Lint, test, and build (ubuntu-latest, 3.12)" in text
+    assert "Windows compatibility smoke (3.12)" in text
     assert "Windows high-risk" in text
     assert "Release packaging contracts" in text
     assert "CI result" in text
@@ -211,7 +211,7 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert "platform_sensitive_changed" in text
     assert "build_wheel_required" in text
     assert "full_required" in text
-    assert "allow_success_or_skipped" in text
+    assert ".github/scripts/check_ci_results.py" in text
     assert "code_changed" not in text
     assert "workflow_changed" not in text
 
@@ -681,6 +681,32 @@ def test_ci_change_classifier_runs_full_for_its_own_windows_gate(tmp_path: Path)
     )
 
 
+def test_ci_change_classifier_fails_closed_for_future_ci_surfaces(tmp_path: Path) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [
+            ".github/workflows/future-profile-safety.yml",
+            ".github/scripts/future_profile_gate.py",
+        ],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        runtime_changed="true",
+        test_changed="true",
+        ci_changed="true",
+        dependency_changed="true",
+        release_changed="true",
+        windows_full_required="true",
+        frontend_changed="true",
+        tui_changed="true",
+        desktop_changed="true",
+        python_changed="true",
+        platform_sensitive_changed="true",
+        build_wheel_required="true",
+        full_required="true",
+    )
+
+
 def test_ci_change_classifier_runs_windows_release_gates_for_profile_verifier(
     tmp_path: Path,
 ) -> None:
@@ -830,6 +856,47 @@ def test_default_ci_uses_layered_job_conditions() -> None:
     assert "desktop-check" in jobs["ci-result"]["needs"]
 
 
+def test_ci_result_gate_covers_every_conditional_job_and_classifier_flag() -> None:
+    jobs = _workflow("ci.yml")["jobs"]
+    gate = jobs["ci-result"]
+    gate_step = next(
+        step for step in gate["steps"] if step.get("name") == "Check required CI results"
+    )
+
+    assert gate["name"] == "CI result"
+    setup_python = next(step for step in gate["steps"] if step.get("name") == "Set up Python")
+    assert setup_python["with"]["python-version"] == "3.12"
+    assert set(gate["needs"]) == {
+        "classify-changes",
+        "workflow-lint",
+        "readme-locale-check",
+        "frontend-check",
+        "tui-check",
+        "desktop-check",
+        "ubuntu-quality",
+        "windows-compat",
+        "windows-full",
+        "release-packaging",
+    }
+    assert gate_step["run"] == "python .github/scripts/check_ci_results.py"
+    assert set(key for key in gate_step["env"] if key.startswith("FLAG_")) == {
+        "FLAG_DOCS_ONLY",
+        "FLAG_RUNTIME_CHANGED",
+        "FLAG_TEST_CHANGED",
+        "FLAG_CI_CHANGED",
+        "FLAG_DEPENDENCY_CHANGED",
+        "FLAG_RELEASE_CHANGED",
+        "FLAG_WINDOWS_FULL_REQUIRED",
+        "FLAG_FRONTEND_CHANGED",
+        "FLAG_TUI_CHANGED",
+        "FLAG_DESKTOP_CHANGED",
+        "FLAG_PYTHON_CHANGED",
+        "FLAG_PLATFORM_SENSITIVE_CHANGED",
+        "FLAG_BUILD_WHEEL_REQUIRED",
+        "FLAG_FULL_REQUIRED",
+    }
+
+
 def test_windows_smoke_does_not_install_bun_by_default() -> None:
     data = _workflow("ci.yml")
     jobs = data["jobs"]
@@ -868,7 +935,9 @@ def test_windows_high_risk_job_runs_parallel_reported_shards() -> None:
         },
     }
     checkout = next(step for step in steps if step.get("name") == "Check out repository")
-    assert checkout["with"]["lfs"] is True
+    assert checkout["with"]["lfs"] == "${{ matrix.shard == 'core' }}"
+    bun_step = next(step for step in steps if step.get("name") == "Set up Bun")
+    assert bun_step["if"] == "${{ matrix.shard == 'core' }}"
     assert steps[0]["name"] == "Prepare diagnostic report"
     assert "OPENSQUILLA_STATE_DIR" not in steps[0]["run"]
     assert "PATH" not in steps[0]["run"]
@@ -883,6 +952,23 @@ def test_windows_high_risk_job_runs_parallel_reported_shards() -> None:
     assert upload_step["uses"] == "actions/upload-artifact@v4"
     assert upload_step["with"]["if-no-files-found"] == "error"
     assert upload_step["with"]["retention-days"] == 14
+
+
+def test_windows_high_risk_job_cannot_wash_test_failures_green() -> None:
+    windows_full = _workflow("ci.yml")["jobs"]["windows-full"]
+    test_step = next(
+        step for step in windows_full["steps"] if step.get("name") == "Test Windows shard"
+    )
+    serialized = json.dumps(windows_full, sort_keys=True)
+
+    assert windows_full["strategy"]["fail-fast"] is False
+    assert all("continue-on-error" not in step for step in windows_full["steps"])
+    assert "--reruns" not in serialized
+    assert "pytest-rerunfailures" not in serialized
+    assert "continue-on-error" not in serialized
+    assert "|| true" not in test_step["run"]
+    assert "set -euo pipefail" in test_step["run"]
+    assert "github.run_attempt" in serialized
 
 
 def test_ubuntu_quality_only_fetches_lfs_for_full_ci() -> None:


### PR DESCRIPTION
## Scope

- Fail closed on unknown runtime, test, workflow, and CI-script changes.
- Partition every offline pytest file into one of four Windows responsibility shards.
- Run the Windows shards in parallel with `fail-fast: false` and PR `--maxfail=3`.
- Always upload per-attempt JUnit, pytest log, first-failure summary, and whitelisted diagnostics.
- Keep the stable `CI result` check while rejecting invalid classifier output and required jobs that fail, cancel, disappear, or skip unexpectedly.
- Lock high-risk jobs against `continue-on-error`, pytest reruns, retry plugins, and swallowed exit codes.

## Branch target

`main`

## Linked issue

None.

## Release note status

Not required. This changes repository CI enforcement and does not change OpenSquilla runtime behavior.

## Validation

- `uv run pytest tests/test_ci -q` — 106 passed, 1 skipped.
- `uv run pytest tests/test_ci/test_ci_result_gate.py tests/test_ci/test_windows_test_shards.py tests/test_ci/test_workflows.py -q` — 61 passed.
- Recovery/migration shard execution — 301 passed, 1 skipped.
- `uv run ruff check .github/scripts tests/test_ci` — passed.
- Python compilation checks for both new CI scripts — passed.
- The PR intentionally changes `ci.yml`, so its own remote CI run is required to validate actionlint and all four real Windows matrix jobs.

## Safety notes

- `CI result` retains its existing check name, so branch-protection configuration remains stable.
- Every discovered pytest file maps to exactly one shard; ambiguous mappings fail before tests run.
- Unknown non-documentation paths default to Windows high-risk coverage.
- Diagnostics whitelist runner OS, architecture, tool versions, commit, attempt, and shard; they do not dump environment variables, credentials, HOME, PATH, or runtime user data.
- The desktop/installer shard contains contracts only. Real installer-over-installer validation remains a release gate.
- No automatic retry or `continue-on-error` path can turn a failing high-risk test green.

## Third-party origin

None. The implementation and synthetic tests are repository-native.
