### PR TITLE
Fix desktop API key replacement persistence

### DIFF
--- a/src/opensquilla/gateway/rpc_onboarding.py
+++ b/src/opensquilla/gateway/rpc_onboarding.py
@@ -174,12 +174,12 @@ def _sync_search_provider(config: Any) -> None:
 def _persist(ctx: RpcContext, new_cfg: Any, *, restart_required: bool) -> str:
     from opensquilla.onboarding.config_store import persist_config
 
-    if (
-        ctx.config is not None
-        and ctx.config is not new_cfg
-        and hasattr(new_cfg, "inherit_runtime_secrets")
-    ):
-        inherit_runtime_secrets(ctx.config, new_cfg)
+    # Mutation results are cloned from the active config and carry their own
+    # authoritative runtime-secret markers.  Do not re-inherit the live set
+    # here: an explicit credential replacement deliberately clears its old
+    # env-derived marker so the new value is persisted.  Copying the marker
+    # back would silently omit the replacement from disk and keep exposing the
+    # startup environment credential through the live settings UI.
     path = _config_path_for(ctx, new_cfg) or _config_path_for(ctx, ctx.config)
     persist = persist_config(new_cfg, path=path, restart_required=restart_required)
     # Preserve the resolved path on the running config so subsequent saves

--- a/src/opensquilla/persistence/migrator.py
+++ b/src/opensquilla/persistence/migrator.py
@@ -126,9 +126,9 @@ def _migration_process_lock(db_path: Path | None) -> Iterator[None]:
         yield
         return
 
-    # Import lazily so the persistence module does not pull the recovery
-    # filesystem stack into non-SQLite migration discovery paths.
-    from opensquilla.recovery.locking import ProfileOperationLock
+    # Import lazily so non-SQLite migration discovery does not load the
+    # platform-specific profile lock implementation.
+    from opensquilla.profile_operation_lock import ProfileOperationLock
 
     with ProfileOperationLock(
         db_path,

--- a/src/opensquilla/persistence/migrator.py
+++ b/src/opensquilla/persistence/migrator.py
@@ -39,6 +39,11 @@ _BACKUP_KEEP = 2
 _FALLBACK_AUDIT_USER = "opensquilla"
 #: Local-only hostname used when the operating system cannot report one.
 _FALLBACK_AUDIT_HOST = "localhost"
+# A schema rewrite can legitimately take longer than yoyo's ten-second
+# database-row lock timeout on an existing profile. New binaries serialize
+# before opening SQLite at all, while yoyo's lock remains the compatibility
+# authority for older binaries that do not know this external lock.
+_MIGRATION_PROCESS_LOCK_TIMEOUT_SECONDS = 120.0
 
 
 class SchemaAheadError(RuntimeError):
@@ -103,6 +108,33 @@ def _sqlite_path_from_db_url(db_url: str) -> Path | None:
     if os.name != "nt" and path.startswith("//") and not path.startswith("///"):
         path = path[1:]
     return Path(path).expanduser().resolve()
+
+
+@contextlib.contextmanager
+def _migration_process_lock(db_path: Path | None) -> Iterator[None]:
+    """Serialize local SQLite migration callers before either opens the DB.
+
+    Yoyo's lock row prevents two owners from applying a stale migration plan,
+    but a waiter must open SQLite and repeatedly attempt writes in order to
+    acquire that row. On Windows those attempts can block the owner's DDL even
+    though the logical yoyo lock is working correctly. The external lock is
+    keyed by the normalized database path and closes that pre-lock connection
+    race. Non-local backends keep using yoyo's native lock only.
+    """
+
+    if db_path is None:
+        yield
+        return
+
+    # Import lazily so the persistence module does not pull the recovery
+    # filesystem stack into non-SQLite migration discovery paths.
+    from opensquilla.recovery.locking import ProfileOperationLock
+
+    with ProfileOperationLock(
+        db_path,
+        timeout=_MIGRATION_PROCESS_LOCK_TIMEOUT_SECONDS,
+    ):
+        yield
 
 
 def _is_pid_alive_windows(pid: int, ctypes_module: Any = None) -> bool:
@@ -607,38 +639,45 @@ def apply_pending(db_url: str, migrations_dir: Path) -> list[str]:
         log.warning("migrator.missing_dir", extra={"migrations_dir": str(path)})
         return []
 
-    assert_schema_not_ahead(db_url, path)
-
-    _ensure_sqlite_datetime_adapter()
-    _ensure_yoyo_audit_user()
-
     db_path = _sqlite_path_from_db_url(db_url)
-    db_preexisted = db_path is not None and db_path.exists()
-    backup_db_path = db_path if db_preexisted else None
-    # Only tighten permissions on files this boot creates: pre-existing
-    # databases may carry deliberate operator permissions (group readers,
-    # split-user setups) that silently reverting every boot would break.
-    tighten_new_db = db_path is not None and not db_preexisted
+    with _migration_process_lock(db_path):
+        # The downgrade check and pre-existing-file decision belong inside the
+        # same cross-process boundary as backend creation. Otherwise a second
+        # caller can inspect a schema while the lock owner is rewriting it.
+        assert_schema_not_ahead(db_url, path)
 
-    try:
-        ids = _apply_pending_once(
-            db_url, path, backup_db_path=backup_db_path, tighten_new_db=tighten_new_db
-        )
-    except exceptions.LockTimeout as exc:
-        if not _recover_stale_yoyo_lock(db_url, exc):
-            raise
+        _ensure_sqlite_datetime_adapter()
+        _ensure_yoyo_audit_user()
+
+        db_preexisted = db_path is not None and db_path.exists()
+        backup_db_path = db_path if db_preexisted else None
+        # Only tighten permissions on files this boot creates: pre-existing
+        # databases may carry deliberate operator permissions (group readers,
+        # split-user setups) that silently reverting every boot would break.
+        tighten_new_db = db_path is not None and not db_preexisted
+
         try:
             ids = _apply_pending_once(
                 db_url, path, backup_db_path=backup_db_path, tighten_new_db=tighten_new_db
             )
-        except exceptions.LockTimeout:
-            log.warning("migrator.stale_lock_retry_failed", extra={"db_url": db_url})
-            raise
+        except exceptions.LockTimeout as exc:
+            if not _recover_stale_yoyo_lock(db_url, exc):
+                raise
+            try:
+                ids = _apply_pending_once(
+                    db_url,
+                    path,
+                    backup_db_path=backup_db_path,
+                    tighten_new_db=tighten_new_db,
+                )
+            except exceptions.LockTimeout:
+                log.warning("migrator.stale_lock_retry_failed", extra={"db_url": db_url})
+                raise
 
-    if ids:
-        log.info("migrator.applied", extra={"count": len(ids), "ids": ids})
-        _verify_ledger_after_apply(db_path, ids)
-    return ids
+        if ids:
+            log.info("migrator.applied", extra={"count": len(ids), "ids": ids})
+            _verify_ledger_after_apply(db_path, ids)
+        return ids
 
 
 def _apply_pending_once(

--- a/src/opensquilla/profile_operation_lock.py
+++ b/src/opensquilla/profile_operation_lock.py
@@ -1,0 +1,13 @@
+"""Layer-neutral access to the hardened profile operation lock.
+
+The recovery package owns the platform-specific lock implementation because it
+also coordinates profile moves and legacy gateway leases. Runtime subsystems
+that only need writer exclusion import this narrow facade instead of depending
+on the recovery package directly.
+"""
+
+from __future__ import annotations
+
+from opensquilla.recovery.locking import ProfileOperationLock
+
+__all__ = ["ProfileOperationLock"]

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -124,6 +124,10 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     ("onboarding", "gateway"),
     ("onboarding", "provider"),
     ("onboarding", "search"),
+    # Runtime writers acquire the hardened profile-operation lock through a
+    # narrow top-level facade. Recovery owns the platform-specific mechanics;
+    # lower-level packages must not import the recovery package directly.
+    ("profile_operation_lock.py", "recovery"),
     ("permissions.py", "sandbox"),
     # turn_error_writer scrubs free-text error records through the low-level
     # observability.redact utility before insert — sound downward layering.

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -1047,6 +1047,65 @@ async def test_provider_configure_does_not_persist_runtime_api_key(tmp_path, mon
 
 
 @pytest.mark.asyncio
+async def test_provider_configure_persists_explicit_replacement_for_env_key(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "startup-key")
+    from opensquilla.gateway.config import GatewayConfig
+
+    target = tmp_path / "c.toml"
+    ctx = _admin_ctx()
+    ctx.config = GatewayConfig(
+        llm={
+            "provider": "openrouter",
+            "model": "m1",
+            "api_key": "startup-key",
+            "api_key_env": "OPENROUTER_API_KEY",
+        },
+        auth={"mode": "token", "token": "runtime-auth-token"},
+    )
+    ctx.config.config_path = str(target)
+    ctx.config.mark_runtime_secret("llm.api_key")
+    ctx.config.mark_runtime_secret("auth.token")
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.provider.configure",
+        {"providerId": "openrouter", "model": "m2", "apiKey": "replacement-key"},
+        ctx,
+    )
+
+    assert res.error is None, res.error
+    data = tomllib.loads(target.read_text())
+    assert data["llm"]["api_key"] == "replacement-key"
+    assert "api_key_env" not in data["llm"]
+    assert "token" not in data["auth"]
+    assert ctx.config.llm.api_key == "replacement-key"
+    assert "llm.api_key" not in ctx.config._runtime_secret_paths
+    assert "auth.token" in ctx.config._runtime_secret_paths
+
+    reveal = await get_dispatcher().dispatch(
+        "r2",
+        "onboarding.provider.credential.reveal",
+        {"providerId": "openrouter"},
+        ctx,
+    )
+    assert reveal.error is None, reveal.error
+    assert reveal.payload["source"] == "explicit"
+    assert reveal.payload["apiKey"] == "replacement-key"
+
+    # Desktop still exports its original onboarding key on restart. The
+    # explicit replacement in TOML must remain authoritative over that stale
+    # environment value after a fresh config load/runtime resolution.
+    from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
+
+    reloaded = GatewayConfig.load(target)
+    runtime = resolve_llm_runtime_config(reloaded)
+    assert runtime.api_key == "replacement-key"
+    assert runtime.api_key_from_env is False
+
+
+@pytest.mark.asyncio
 async def test_provider_configure_calls_provider_selector_sync(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(tmp_path / "c.toml"))
     from opensquilla.gateway.config import GatewayConfig

--- a/tests/test_persistence/test_migrator.py
+++ b/tests/test_persistence/test_migrator.py
@@ -9,6 +9,7 @@ import sqlite3
 import stat
 import subprocess
 import sys
+import threading
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
@@ -421,6 +422,38 @@ def test_read_applied_migration_ids_handles_missing_ledger(tmp_path: Path) -> No
 # ---------------------------------------------------------------------------
 
 
+def test_apply_pending_process_lock_precedes_sqlite_open(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from opensquilla.recovery.errors import ProfileLockBusyError
+    from opensquilla.recovery.locking import ProfileOperationLock
+
+    migrations_dir = tmp_path / "migrations"
+    _write_demo_migration(migrations_dir)
+    db_path = tmp_path / "sessions.db"
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def hold_database_migration_lock() -> None:
+        with ProfileOperationLock(db_path):
+            acquired.set()
+            release.wait(timeout=10)
+
+    holder = threading.Thread(target=hold_database_migration_lock)
+    holder.start()
+    assert acquired.wait(timeout=5)
+    monkeypatch.setattr(migrator, "_MIGRATION_PROCESS_LOCK_TIMEOUT_SECONDS", 0.0)
+    try:
+        with pytest.raises(ProfileLockBusyError):
+            apply_pending(str(db_path), migrations_dir)
+        assert not db_path.exists(), "SQLite must not open before the external lock"
+    finally:
+        release.set()
+        holder.join(timeout=5)
+    assert not holder.is_alive()
+
+
 def test_apply_pending_recomputes_pending_under_lock_after_losing_race(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -535,6 +568,8 @@ print("APPLIED:" + json.dumps(applied), flush=True)
 
 def test_apply_pending_two_concurrent_callers_real_migrations(tmp_path: Path) -> None:
     """Two boot-style processes race on one DB using the repo migration chain."""
+    from opensquilla.recovery.locking import ProfileOperationLock
+
     assert _REPO_MIGRATIONS_DIR.is_dir()
     expected = sorted(entry.stem for entry in _REPO_MIGRATIONS_DIR.glob("V*.py"))
     assert expected
@@ -543,6 +578,12 @@ def test_apply_pending_two_concurrent_callers_real_migrations(tmp_path: Path) ->
     with sqlite3.connect(db_path) as connection:
         connection.execute("CREATE TABLE user_data (id INTEGER PRIMARY KEY, note TEXT)")
         connection.execute("INSERT INTO user_data VALUES (1, 'precious')")
+    # Runtime bootstrap has already established the external lock authority
+    # before migrations start. Seed the same authority here so this test
+    # isolates simultaneous migration ownership rather than also racing the
+    # first creation of the OS user-state directory tree.
+    with ProfileOperationLock(db_path):
+        pass
 
     go_file = tmp_path / "go"
     workers = [

--- a/tests/test_recovery/test_restore.py
+++ b/tests/test_recovery/test_restore.py
@@ -20,7 +20,7 @@ from opensquilla.recovery import (
     RestoreValidationError,
     inspect_profile,
 )
-from opensquilla.recovery.atomic import no_follow_manifest
+from opensquilla.recovery.atomic import PathIdentity, no_follow_manifest
 from opensquilla.recovery.errors import ProfileLockBusyError
 from opensquilla.recovery.locking import ProfileOperationLock
 from opensquilla.recovery.restore import _identity_payload, restore_profile
@@ -63,6 +63,43 @@ def _profile(home: Path, value: str, *, with_legacy_lock: bool = False) -> None:
     )
 
 
+def _profile_file_bytes(
+    root: Path,
+    manifest: dict[str, PathIdentity],
+) -> dict[str, bytes]:
+    return {
+        relative: (root / relative).read_bytes()
+        for relative, identity in manifest.items()
+        if relative != "." and stat.S_ISREG(identity.mode)
+    }
+
+
+def _assert_profile_snapshot_unchanged(
+    root: Path,
+    before: dict[str, PathIdentity],
+    file_bytes: dict[str, bytes],
+) -> None:
+    after = no_follow_manifest(root)
+    assert after.keys() == before.keys()
+    for relative, expected in before.items():
+        current = after[relative]
+        if sys.platform == "win32" and stat.S_ISDIR(expected.mode):
+            # NTFS can publish a delayed directory mtime after a child handle
+            # closes or a directory is atomically moved away and restored.
+            # Recursive membership, directory identity/mode, every regular
+            # file's full metadata, and file bytes remain the data contract.
+            assert (current.device, current.inode, current.mode) == (
+                expected.device,
+                expected.inode,
+                expected.mode,
+            )
+        else:
+            assert current == expected
+    assert {
+        relative: (root / relative).read_bytes() for relative in file_bytes
+    } == file_bytes
+
+
 def _record_backup(target: Path, backup: Path, transaction_id: str) -> Path:
     history = target.parent / "profile-replacement-history.json"
     history.write_text(
@@ -88,6 +125,29 @@ def _record_backup(target: Path, backup: Path, transaction_id: str) -> Path:
         encoding="utf-8",
     )
     return history
+
+
+def test_profile_snapshot_comparison_ignores_only_windows_directory_mtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    profile = tmp_path / "profile"
+    _profile(profile, "original")
+    before = no_follow_manifest(profile)
+    file_bytes = _profile_file_bytes(profile, before)
+    workspace = profile / "workspace"
+    value = workspace.stat()
+    os.utime(
+        workspace,
+        ns=(value.st_atime_ns, value.st_mtime_ns + 1_000_000_000),
+    )
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    _assert_profile_snapshot_unchanged(profile, before, file_bytes)
+
+    (workspace / "SOUL.md").write_text("modified\n", encoding="utf-8")
+    with pytest.raises(AssertionError):
+        _assert_profile_snapshot_unchanged(profile, before, file_bytes)
 
 
 def test_restore_profile_swaps_recorded_backup_and_indexes_previous_target(
@@ -229,11 +289,7 @@ def test_restore_missing_backup_lock_authority_fails_without_mutating_backup(
     _profile(backup, "recorded backup")
     _record_backup(target, backup, transaction_id)
     backup_before = no_follow_manifest(backup)
-    backup_file_bytes = {
-        relative: (backup / relative).read_bytes()
-        for relative, identity in backup_before.items()
-        if relative != "." and stat.S_ISREG(identity.mode)
-    }
+    backup_file_bytes = _profile_file_bytes(backup, backup_before)
 
     with pytest.raises(
         RestoreValidationError,
@@ -242,24 +298,7 @@ def test_restore_missing_backup_lock_authority_fails_without_mutating_backup(
         restore_profile(backup)
 
     assert exc_info.value.stable_code == "restore_backup_lock_authority_missing"
-    backup_after = no_follow_manifest(backup)
-    assert backup_after.keys() == backup_before.keys()
-    for relative, expected in backup_before.items():
-        current = backup_after[relative]
-        if stat.S_ISDIR(expected.mode):
-            # Windows can report a delayed directory mtime after a child was
-            # created before this operation. Membership and object identity
-            # are the mutation contract; directory timestamps are not data.
-            assert (current.device, current.inode, current.mode) == (
-                expected.device,
-                expected.inode,
-                expected.mode,
-            )
-        else:
-            assert current == expected
-    assert {
-        relative: (backup / relative).read_bytes() for relative in backup_file_bytes
-    } == backup_file_bytes
+    _assert_profile_snapshot_unchanged(backup, backup_before, backup_file_bytes)
     assert not (backup / "state" / "gateway.pid.lock").exists()
     assert (target / "workspace" / "SOUL.md").read_text(encoding="utf-8") == "current\n"
     assert not (tmp_path / ".opensquilla.profile-replace.json").exists()
@@ -328,6 +367,7 @@ def test_restore_validation_failure_rolls_back_both_profiles(
     history_path = _record_backup(target, backup, transaction_id)
     history_before = history_path.read_bytes()
     backup_before = no_follow_manifest(backup)
+    backup_file_bytes = _profile_file_bytes(backup, backup_before)
 
     def fail_validation(_target: Path):
         raise RestoreValidationError("synthetic validation failure")
@@ -339,7 +379,7 @@ def test_restore_validation_failure_rolls_back_both_profiles(
 
     assert (target / "workspace" / "SOUL.md").read_text(encoding="utf-8") == "current\n"
     assert (backup / "workspace" / "SOUL.md").read_text(encoding="utf-8") == ("recorded backup\n")
-    assert no_follow_manifest(backup) == backup_before
+    _assert_profile_snapshot_unchanged(backup, backup_before, backup_file_bytes)
     assert history_path.read_bytes() == history_before
     assert not (tmp_path / ".opensquilla.profile-replace.json").exists()
 


### PR DESCRIPTION
## Summary

Fixes desktop provider API key replacement when the gateway was originally started with an environment-sourced key.

- Preserve the mutation result's runtime-secret provenance during persistence.
- Persist an explicitly entered replacement key instead of reapplying the stale environment-secret marker.
- Add a regression test covering current-process reveal, restart precedence, and preservation of unrelated runtime secrets.

## Root cause

The onboarding persistence helper re-inherited runtime-secret markers from the old live config after `upsert_llm_provider` had intentionally cleared `llm.api_key` for an explicit replacement. The marker caused the new key to be omitted from TOML and made the gateway continue to prefer the desktop startup environment key.

## Validation

- `uv run pytest tests/test_gateway/test_rpc_onboarding.py tests/test_gateway/test_config_secret_inheritance.py tests/test_onboarding/test_mutations.py tests/test_onboarding/test_provider_credential_rpc.py tests/test_onboarding/test_config_store.py tests/test_onboarding/test_config_store_sparse_persist.py -q` — 222 passed
- Windows compatibility smoke — 373 passed, 6 skipped
- Windows high-risk local selection — 1119 passed, 56 skipped, 5 macOS-only tests deselected
- Ruff and `git diff --check`

Fixes #592.