### PR TITLE
Wait on locale outcomes instead of fixed ticks in i18n component tests

### DIFF
--- a/opensquilla-webui/src/components/i18n-components.test.ts
+++ b/opensquilla-webui/src/components/i18n-components.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { createApp, nextTick, type Component } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
 import i18n from '@/i18n'
@@ -23,7 +23,6 @@ async function mount(Comp: Component) {
   return { el, app }
 }
 
-const settle = () => new Promise((r) => setTimeout(r, 60))
 
 beforeEach(() => {
   i18n.global.locale.value = 'en'
@@ -50,14 +49,15 @@ describe('SettingsAppearancePanel — Language row', () => {
     const zh = el.querySelector('[data-testid="settings-language-zh-Hans"]') as HTMLInputElement
     zh.checked = true
     zh.dispatchEvent(new Event('change', { bubbles: true }))
-    await settle()
+    // setLocale lazy-imports the locale chunk; wait on the outcome, not a tick.
+    await vi.waitFor(() => expect(store.locale).toBe('zh-Hans'))
     await nextTick()
 
-    expect(store.locale).toBe('zh-Hans')
     expect(localStorage.getItem('opensquilla-locale')).toBe('zh-Hans')
     expect(document.documentElement.getAttribute('lang')).toBe('zh-Hans')
     // section title re-renders in Chinese (reactive t())
-    expect(el.querySelector('.control-section__title')!.textContent).toContain('外观')
+    await vi.waitFor(() =>
+      expect(el.querySelector('.control-section__title')!.textContent).toContain('外观'))
   })
 })
 
@@ -84,11 +84,10 @@ describe('LanguageSwitcher — topbar dropdown', () => {
     trigger.click()
     await nextTick()
     ;(el.querySelector('[data-testid="language-option-zh-Hans"]') as HTMLButtonElement).click()
-    await settle()
+    await vi.waitFor(() => expect(store.locale).toBe('zh-Hans'))
     await nextTick()
 
-    expect(store.locale).toBe('zh-Hans')
-    expect(trigger.textContent).toContain('中文')
+    await vi.waitFor(() => expect(trigger.textContent).toContain('中文'))
     expect(trigger.getAttribute('aria-expanded')).toBe('false')
   })
 })


### PR DESCRIPTION
## Scope

Scope boundary: test-only — make the two language-switch component tests wait on observable outcomes (vi.waitFor on store.locale and the re-rendered copy) instead of a fixed 60ms sleep that races the lazy locale-chunk import under full-suite load.

Non-goals: any runtime behavior change.

## Branch

Base branch: integration/channel-platform

Target exception: maintainer-approved

## Issue

Linked issue: None

If None, reason: intermittent test failure observed while validating channel UX PRs on this branch; fix keeps the branch's CI signal trustworthy.

## Release Note

Release note: NONE

## Tests

Ruff: not touched

Pytest: not touched

Build: `npm run test:unit` 869/869; the affected file passes 5/5 consecutive isolated runs

Regression tests: not needed

Notes: failure mode was "expected 'zh-Hans', received 'en'" only under full-suite load; passes in isolation.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

Test-only change; no secrets or fixtures involved.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
