### PR TITLE
Add additive backend telemetry and typed errors for the channel console

### DIFF
--- a/src/opensquilla/channels/manager.py
+++ b/src/opensquilla/channels/manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hashlib
+import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
@@ -82,6 +83,13 @@ class ChannelManager:
     _dispatch_states: dict[str, str] = field(default_factory=dict)
     _restart_counts: dict[str, int] = field(default_factory=dict)
     _start_errors: dict[str, dict[str, Any]] = field(default_factory=dict)
+    # Wall-clock epoch (ms) at which the dispatch loop last entered "running".
+    # Surfaced as ``connected_since`` so operators see uptime, cleared on stop.
+    _running_since: dict[str, int] = field(default_factory=dict)
+    # Leading-edge throttle for channel.status pushes: reconnect thrash can
+    # flip dispatch states back-to-back, so coalesce per channel.
+    _last_status_emit: dict[str, float] = field(default_factory=dict)
+    _status_emit_min_interval: float = 1.0
     # Inner-loop retry policy (overridable for tests).
     _max_retries: int = 5
     _retry_backoff_initial: float = 1.0
@@ -423,6 +431,44 @@ class ChannelManager:
                 else:
                     log.error("channel.dispatch_exhausted", channel=name)
 
+    def _set_dispatch_state(self, name: str, state: str) -> None:
+        """Update the dispatch state and push a ``channel.status`` event on change.
+
+        Every configured runtime surface (both channel UIs) subscribes to
+        ``channel.status``; emitting on real transitions turns the 30s poll
+        into a live view. Emission is best-effort and never blocks dispatch.
+        """
+        prev = self._dispatch_states.get(name)
+        self._dispatch_states[name] = state
+        if state == "running":
+            # First time running (or resumed after a restart): stamp uptime.
+            if prev != "running":
+                self._running_since[name] = int(time.time() * 1000)
+        elif state in {"dead", "exhausted"}:
+            self._running_since.pop(name, None)
+        if prev != state:
+            self._emit_status_event(name, state)
+
+    def _emit_status_event(self, name: str, state: str) -> None:
+        bridge = self._event_bridge
+        if bridge is None:
+            return
+        now = time.monotonic()
+        # Terminal states always emit; churny intermediates coalesce.
+        if state not in {"dead", "running"}:
+            if now - self._last_status_emit.get(name, 0.0) < self._status_emit_min_interval:
+                return
+        self._last_status_emit[name] = now
+        coro = bridge.broadcast_scoped(
+            "channel.status",
+            {"name": name, "status": state},
+            required_scope="operator.read",
+        )
+        try:
+            asyncio.get_running_loop().create_task(coro)
+        except RuntimeError:
+            coro.close()
+
     async def _dispatch_with_retry(
         self,
         name: str,
@@ -438,12 +484,12 @@ class ChannelManager:
         the loop exits. ``dead`` is operator-recoverable through
         ``restart_channel``.
         """
-        self._dispatch_states[name] = "running"
+        self._set_dispatch_state(name, "running")
         self._restart_counts.setdefault(name, 0)
         while True:
             await self._run_one_dispatch_cycle(name, key_builder, in_flight=in_flight)
 
-            self._dispatch_states[name] = "exhausted"
+            self._set_dispatch_state(name, "exhausted")
             log.warning(
                 "dispatch.running_to_exhausted",
                 channel=name,
@@ -451,7 +497,7 @@ class ChannelManager:
             )
 
             if self._restart_counts[name] >= self._max_restart_cycles:
-                self._dispatch_states[name] = "dead"
+                self._set_dispatch_state(name, "dead")
                 log.error(
                     "dispatch.restarting_to_dead",
                     channel=name,
@@ -460,7 +506,7 @@ class ChannelManager:
                 return
 
             self._restart_counts[name] += 1
-            self._dispatch_states[name] = "restarting"
+            self._set_dispatch_state(name, "restarting")
             log.warning(
                 "dispatch.exhausted_to_restarting",
                 channel=name,
@@ -468,7 +514,7 @@ class ChannelManager:
                 max_cycles=self._max_restart_cycles,
             )
             await asyncio.sleep(self._restart_delay_s)
-            self._dispatch_states[name] = "running"
+            self._set_dispatch_state(name, "running")
 
     async def stop_all(self) -> None:
         """Stop every managed channel (dispatch task + adapter)."""
@@ -512,6 +558,7 @@ class ChannelManager:
             if lease is not None and self._delivery_store is not None:
                 self._delivery_store.release_transport_lease(lease)
             self._unregister_tool_channel(name, adapter)
+            self._running_since.pop(name, None)
 
     async def restart_channel(self, name: str) -> None:
         """Stop then re-start a single channel.
@@ -540,6 +587,12 @@ class ChannelManager:
         for name, a in self._channels.items():
             health = await a.health_check()
             health.extra["dispatch_state"] = self._dispatch_states.get(name, "unknown")
+            # Mirror runtime telemetry the adapter itself does not report, so
+            # the status RPC can surface honest uptime and restart counts.
+            health.extra["restart_attempts"] = self._restart_counts.get(name, 0)
+            running_since = self._running_since.get(name)
+            if running_since is not None:
+                health.extra.setdefault("connected_since", running_since)
             lease = self._transport_leases.get(name)
             if lease is not None:
                 health.extra["transport_lease"] = {

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -785,6 +785,9 @@ class ServiceContainer:
 
 # Server boot timestamp (set once at first start)
 _boot_time_ms: int = 0
+# Per-boot identity token: lets clients tell "same process, config changed"
+# (a pending restart is still pending) from "process restarted" (apply it).
+_boot_id: str = ""
 
 
 def _configured_agent_ids(
@@ -2919,8 +2922,9 @@ async def start_gateway_server(
         raise
 
     # Record boot time for uptime calculation (gateway-specific)
-    global _boot_time_ms
+    global _boot_time_ms, _boot_id
     _boot_time_ms = int(time.time() * 1000)
+    _boot_id = secrets.token_hex(16)
 
     log.info(
         "gateway.starting",

--- a/src/opensquilla/gateway/rpc_channels.py
+++ b/src/opensquilla/gateway/rpc_channels.py
@@ -13,7 +13,7 @@ from opensquilla.channels.contract import (
     channel_capability_profile,
     channel_platform_manifest,
 )
-from opensquilla.gateway.rpc import RpcContext, get_dispatcher
+from opensquilla.gateway.rpc import RpcContext, RpcHandlerError, get_dispatcher
 from opensquilla.redaction import redact_error_text
 
 if TYPE_CHECKING:
@@ -303,7 +303,9 @@ async def _handle_channels_status(params: dict | None, ctx: RpcContext) -> dict[
             }
         )
 
-    return {"channels": channels}
+    from opensquilla.gateway.boot import _boot_id
+
+    return {"channels": channels, "bootId": _boot_id}
 
 
 @_d.method("channels.get", scope="operator.admin")
@@ -422,10 +424,15 @@ async def _handle_channels_restart(params: dict | None, ctx: RpcContext) -> dict
         channel_name = params.get("channel") or params.get("name")
     if not channel_name:
         raise ValueError("channel name required")
-    if ctx.channel_manager is None:
-        raise KeyError(f"Channel not found: {channel_name}")
-    if ctx.channel_manager.get(channel_name) is None:
-        raise KeyError(f"Channel not found: {channel_name}")
+    # A configured-but-not-loaded channel (e.g. added since the last gateway
+    # start) cannot be restarted in place; a stable code lets the UI say
+    # "restart the gateway" instead of surfacing a coarse NOT_FOUND.
+    if ctx.channel_manager is None or ctx.channel_manager.get(channel_name) is None:
+        raise RpcHandlerError(
+            "channels.adapter_not_loaded",
+            f"Channel {channel_name!r} is not loaded in this gateway process; "
+            "restart the gateway to start it.",
+        )
     await ctx.channel_manager.restart_channel(channel_name)
     return {"status": "restarted", "channel": channel_name}
 

--- a/src/opensquilla/gateway/rpc_onboarding.py
+++ b/src/opensquilla/gateway/rpc_onboarding.py
@@ -53,7 +53,14 @@ def _channel_error() -> Iterator[None]:
     except KeyError as exc:
         raise RpcHandlerError("onboarding.channel.not_found", str(exc)) from exc
     except ValueError as exc:
-        raise RpcHandlerError("onboarding.channel.invalid", str(exc)) from exc
+        # A ChannelValidationError additionally carries per-field detail so the
+        # Web UI can anchor errors to fields instead of parsing the message.
+        details = getattr(exc, "field_errors", None)
+        raise RpcHandlerError(
+            "onboarding.channel.invalid",
+            str(exc),
+            details={"fields": details} if details else None,
+        ) from exc
 
 _d = get_dispatcher()
 

--- a/src/opensquilla/health/evaluator.py
+++ b/src/opensquilla/health/evaluator.py
@@ -1322,6 +1322,7 @@ def evaluate_channels(payload: dict[str, Any]) -> list[HealthFinding]:
                     ),
                     evidence={
                         "name": name,
+                        "channelName": name,
                         "status": status,
                         "type": row.get("type"),
                         "errorClass": "auth_invalid",
@@ -1352,7 +1353,12 @@ def evaluate_channels(payload: dict[str, Any]) -> list[HealthFinding]:
                     surface="channels",
                     title=f"Channel {name} is disabled",
                     detail="The channel is configured but disabled on disk.",
-                    evidence={"name": name, "status": status, "type": row.get("type")},
+                    evidence={
+                        "name": name,
+                        "channelName": name,
+                        "status": status,
+                        "type": row.get("type"),
+                    },
                     fix_steps=[
                         FixStep(
                             label="Enable channel",
@@ -1372,7 +1378,12 @@ def evaluate_channels(payload: dict[str, Any]) -> list[HealthFinding]:
                     surface="channels",
                     title=f"Channel {name} is {status}",
                     detail="The configured channel is not able to receive or send messages.",
-                    evidence={"name": name, "status": status, "type": row.get("type")},
+                    evidence={
+                        "name": name,
+                        "channelName": name,
+                        "status": status,
+                        "type": row.get("type"),
+                    },
                     fix_steps=[
                         FixStep(
                             label="Restart channel",
@@ -1393,7 +1404,12 @@ def evaluate_channels(payload: dict[str, Any]) -> list[HealthFinding]:
                     surface="channels",
                     title=f"Channel {name} is stopped",
                     detail="The channel is configured and enabled but is not connected.",
-                    evidence={"name": name, "status": status, "type": row.get("type")},
+                    evidence={
+                        "name": name,
+                        "channelName": name,
+                        "status": status,
+                        "type": row.get("type"),
+                    },
                     fix_steps=[
                         FixStep(
                             label="Inspect channels",
@@ -1414,7 +1430,12 @@ def evaluate_channels(payload: dict[str, Any]) -> list[HealthFinding]:
                     surface="channels",
                     title=f"Channel {name} is restarting",
                     detail="The channel is recovering after dispatch errors.",
-                    evidence={"name": name, "status": status, "type": row.get("type")},
+                    evidence={
+                        "name": name,
+                        "channelName": name,
+                        "status": status,
+                        "type": row.get("type"),
+                    },
                     fix_steps=[
                         FixStep(
                             label="Inspect channels",
@@ -1434,7 +1455,12 @@ def evaluate_channels(payload: dict[str, Any]) -> list[HealthFinding]:
                         f"The channel reported status {status}, which is not recognized "
                         "as a ready state."
                     ),
-                    evidence={"name": name, "status": status, "type": row.get("type")},
+                    evidence={
+                        "name": name,
+                        "channelName": name,
+                        "status": status,
+                        "type": row.get("type"),
+                    },
                     fix_steps=[
                         FixStep(
                             label="Inspect channels",

--- a/src/opensquilla/onboarding/channel_specs.py
+++ b/src/opensquilla/onboarding/channel_specs.py
@@ -333,6 +333,8 @@ def _qq_spec() -> ChannelSetupSpec:
         dependency_extra=None,
         restart_required=True,
         docs_hint="https://bot.q.qq.com/wiki/",
+        # No non-mutating probe_connection on the QQ adapter yet.
+        can_probe=False,
         fields=(
             *_common_fields(),
             ChannelSetupField("app_id", "App id", "text", required=True),
@@ -374,6 +376,8 @@ def _matrix_spec() -> ChannelSetupSpec:
         dependency_extra="matrix",
         restart_required=True,
         docs_hint="https://matrix.org/docs/",
+        # No non-mutating probe_connection on the Matrix adapter yet.
+        can_probe=False,
         fields=(
             *_common_fields(),
             ChannelSetupField("homeserver_url", "Homeserver URL", "text",

--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -1325,6 +1325,29 @@ def list_channel_entries(config: GatewayConfig) -> list[dict[str, Any]]:
     return [redact_channel_entry(d.get("type", ""), d) for d in _channel_entries_as_dicts(config)]
 
 
+class ChannelValidationError(ValueError):
+    """A channel-entry validation failure carrying per-field detail.
+
+    Behaves like the plain ``ValueError`` callers already expect (the string
+    message is unchanged) while additionally exposing ``field_errors`` so the
+    RPC layer can return a structured envelope instead of only a joined string.
+    """
+
+    def __init__(self, message: str, field_errors: list[dict[str, str]]) -> None:
+        super().__init__(message)
+        self.field_errors = field_errors
+
+
+def _channel_validation_field_errors(exc: ValidationError) -> list[dict[str, str]]:
+    """Per-field ``{field, message}`` list; never echoes input values."""
+    out: list[dict[str, str]] = []
+    for error in exc.errors(include_url=False, include_context=False, include_input=False):
+        loc = ".".join(str(item) for item in error.get("loc", ()) or ())
+        msg = str(error.get("msg") or "invalid value")
+        out.append({"field": loc, "message": redact_error_text(msg, max_len=200)})
+    return out
+
+
 def _format_channel_validation_error(exc: ValidationError) -> str:
     """Render a channel-entry ValidationError as a field-naming summary.
 
@@ -1383,7 +1406,10 @@ def validate_channel_entry(payload: dict[str, Any]) -> dict[str, Any]:
     try:
         entry = parse_channel_entry(full)
     except ValidationError as exc:
-        raise ValueError(_format_channel_validation_error(exc)) from exc
+        raise ChannelValidationError(
+            _format_channel_validation_error(exc),
+            _channel_validation_field_errors(exc),
+        ) from exc
     normalized = entry.model_dump(mode="python")
     _require_non_blank_secret_fields(type_name, normalized)
     if (

--- a/tests/test_channels/test_manager_status_telemetry.py
+++ b/tests/test_channels/test_manager_status_telemetry.py
@@ -1,0 +1,75 @@
+"""B1/B3/B4 additive channel telemetry: status pushes, uptime, restart counts."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from opensquilla.channels.manager import ChannelManager
+from opensquilla.channels.types import ChannelHealth
+
+
+class _RecordingBridge:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict, str]] = []
+
+    async def broadcast_scoped(self, event_name, payload=None, *, required_scope):
+        self.events.append((event_name, payload or {}, required_scope))
+
+
+class _StubAdapter:
+    def __init__(self, connected: bool = True) -> None:
+        self._connected = connected
+
+    async def health_check(self) -> ChannelHealth:
+        return ChannelHealth(connected=self._connected)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_state_change_pushes_channel_status_event():
+    bridge = _RecordingBridge()
+    manager = ChannelManager({"slack": _StubAdapter()}, None, None, _event_bridge=bridge)
+
+    manager._set_dispatch_state("slack", "running")
+    manager._set_dispatch_state("slack", "running")  # no change → no event
+    manager._set_dispatch_state("slack", "dead")
+    await asyncio.sleep(0)  # let the fire-and-forget broadcast tasks run
+
+    names = [(e[0], e[1]["status"], e[2]) for e in bridge.events]
+    assert names == [
+        ("channel.status", "running", "operator.read"),
+        ("channel.status", "dead", "operator.read"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_no_bridge_is_a_silent_noop():
+    manager = ChannelManager({"slack": _StubAdapter()}, None, None)
+    manager._set_dispatch_state("slack", "running")  # must not raise
+    manager._set_dispatch_state("slack", "dead")
+
+
+@pytest.mark.asyncio
+async def test_running_stamps_connected_since_and_health_mirrors_telemetry():
+    manager = ChannelManager({"slack": _StubAdapter()}, None, None)
+    manager._restart_counts["slack"] = 2
+    manager._set_dispatch_state("slack", "running")
+
+    health = await manager.health()
+    extra = health["slack"].extra
+    assert extra["dispatch_state"] == "running"
+    assert extra["restart_attempts"] == 2
+    assert isinstance(extra["connected_since"], int) and extra["connected_since"] > 0
+
+
+@pytest.mark.asyncio
+async def test_dead_clears_connected_since():
+    manager = ChannelManager({"slack": _StubAdapter()}, None, None)
+    manager._set_dispatch_state("slack", "running")
+    assert "slack" in manager._running_since
+    manager._set_dispatch_state("slack", "dead")
+    assert "slack" not in manager._running_since
+
+    health = await manager.health()
+    assert "connected_since" not in health["slack"].extra

--- a/tests/test_gateway/test_rpc_channels.py
+++ b/tests/test_gateway/test_rpc_channels.py
@@ -402,3 +402,28 @@ async def test_channels_probe_redacts_provider_error_and_result_credentials(
     assert token not in repr(rpc_res.payload)
     assert "***" in rpc_res.payload["detail"]
     assert adapter.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_channels_status_echoes_boot_id():
+    ctx = _read_ctx()
+    ctx.config = GatewayConfig()
+    rpc_res = await get_dispatcher().dispatch("boot", "channels.status", {}, ctx)
+    assert rpc_res.error is None, rpc_res.error
+    # bootId is present (a hex string once booted, empty string in a bare test
+    # process) so clients can distinguish a config change from a restart.
+    assert "bootId" in rpc_res.payload
+    assert isinstance(rpc_res.payload["bootId"], str)
+
+
+@pytest.mark.asyncio
+async def test_channels_restart_unloaded_channel_returns_typed_error():
+    ctx = _admin_ctx()
+    ctx.config = GatewayConfig()
+    ctx.channel_manager = None
+    rpc_res = await get_dispatcher().dispatch(
+        "rs", "channels.restart", {"name": "ghost"}, ctx
+    )
+    assert rpc_res.error is not None
+    assert rpc_res.error.code == "channels.adapter_not_loaded"
+    assert "restart the gateway" in rpc_res.error.message

--- a/tests/test_gateway/test_rpc_onboarding_errors.py
+++ b/tests/test_gateway/test_rpc_onboarding_errors.py
@@ -84,3 +84,23 @@ def test_provider_configure_invalid_provider_yields_stable_code(tmp_path, monkey
     assert res.error.code == "onboarding.provider.invalid"
     # the granular code carries the original English detail, not a blank message
     assert res.error.message
+
+
+def test_channel_error_carries_structured_field_details():
+    from opensquilla.onboarding.mutations import ChannelValidationError
+
+    with pytest.raises(RpcHandlerError) as ei:
+        with _channel_error():
+            raise ChannelValidationError(
+                "invalid channel entry: name: Field required",
+                [{"field": "name", "message": "Field required"}],
+            )
+    assert ei.value.code == "onboarding.channel.invalid"
+    assert ei.value.details == {"fields": [{"field": "name", "message": "Field required"}]}
+
+
+def test_channel_error_plain_valueerror_has_no_details():
+    with pytest.raises(RpcHandlerError) as ei:
+        with _channel_error():
+            raise ValueError("unknown channel type")
+    assert ei.value.details is None

--- a/tests/test_health/test_evaluator.py
+++ b/tests/test_health/test_evaluator.py
@@ -712,6 +712,7 @@ def test_channels_evaluator_does_not_report_unknown_enabled_status_as_ready() ->
     assert "not recognized" in findings[0].detail
     assert findings[0].evidence == {
         "name": "slack-main",
+        "channelName": "slack-main",
         "status": "warming_up",
         "type": "slack",
     }

--- a/tests/test_onboarding/test_channel_specs.py
+++ b/tests/test_onboarding/test_channel_specs.py
@@ -407,3 +407,13 @@ def test_advertised_minimal_setup_passes_model_validation(type_name: str):
     model = ENTRY_MODELS[type_name]
     validated = model(**entry)
     assert validated.name == "test-entry"
+
+
+def test_can_probe_reflects_adapter_probe_support():
+    catalog = {c["type"]: c for c in channel_catalog_payload()}
+    # Adapters without a non-mutating probe_connection are honestly flagged.
+    assert catalog["matrix"]["canProbe"] is False
+    assert catalog["qq"]["canProbe"] is False
+    # Adapters that implement probe_connection stay probeable.
+    assert catalog["slack"]["canProbe"] is True
+    assert catalog["telegram"]["canProbe"] is True

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -1422,3 +1422,14 @@ def test_upsert_channel_same_name_different_type_replaces_without_secret_merge()
     assert len(raw_entries) == 1
     assert raw_entries[0].type == "discord"
     assert raw_entries[0].token == "dc-secret"
+
+
+def test_validate_channel_entry_raises_structured_field_errors():
+    from opensquilla.onboarding.mutations import ChannelValidationError, validate_channel_entry
+
+    with pytest.raises(ChannelValidationError) as ei:
+        validate_channel_entry({"type": "slack"})  # missing required name/token
+    assert ei.value.field_errors, "expected per-field detail"
+    assert all("field" in fe and "message" in fe for fe in ei.value.field_errors)
+    # The joined string message is preserved for callers that only read str(exc).
+    assert "invalid channel entry" in str(ei.value)


### PR DESCRIPTION
## Scope

Scope boundary: additive backend enablers for the channel console. Channel manager pushes channel.status events on dispatch-state transitions (coalesced per channel); connected_since is stamped and restart_attempts mirrored into health; channels.status echoes a per-boot bootId; channels.restart raises a typed channels.adapter_not_loaded code for unloaded channels; Matrix/QQ specs report canProbe=false; channel validation errors carry a structured per-field envelope (details.fields); doctor channel findings carry channelName. No existing contract changes — every field/code is additive and the frontend already reads or degrades without them.

Non-goals: consuming these in the UI (the frontend P2 PRs do that).

## Branch

Base branch: integration/channel-platform

Target exception: maintainer-approved

## Issue

Linked issue: None

If None, reason: implements the P2-E additive backend queue from the maintainer-approved channel UX plan (continues #634/#635/#638).

## Release Note

Release note: The Channels console now updates live as channel state changes, reports honest uptime and restart counts, distinguishes a pending config change from an applied restart, guides operators when a channel needs a gateway restart to load, marks channels without a safe connection test, and returns per-field validation errors.

## Tests

Ruff: `uv run ruff check src tests` clean

Pytest: `uv run pytest tests/test_contracts tests/test_onboarding tests/test_channels tests/test_health tests/test_gateway/test_rpc_channels.py tests/test_gateway/test_rpc_onboarding_errors.py -q` 1297 passed, 1 skipped; new suites cover status events, connected_since/restart_attempts, bootId, the typed restart error, honest canProbe, and structured field errors

Build: `uv run mypy src/opensquilla` clean (802 files); `uv build --wheel` succeeds

Regression tests: added

Notes: one existing evaluator test updated for the additive channelName evidence key.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: channel

## Safety

No secrets or channel identifiers; status-event payloads carry only the channel name and dispatch state. Validation-error details carry field paths and validator messages only, never input values.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
