### PR TITLE
Fix OSS latest page metadata upload

### DIFF
--- a/.github/workflows/mirror-release-to-oss.yml
+++ b/.github/workflows/mirror-release-to-oss.yml
@@ -262,7 +262,7 @@ jobs:
           done < release-assets/CHECKSUMMED_ASSETS
           upload_asset "release-assets/SHA256SUMS" "SHA256SUMS"
           ossutil cp --force --addressing-style "${OSS_ADDRESSING_STYLE_NORMALIZED}" \
-            --meta "Content-Type:text/html; charset=utf-8#Cache-Control:no-cache" \
+            --meta="Content-Type:text/html; charset=utf-8#Cache-Control:no-cache" \
             "release-assets/latest.html" "${mirror_root}/latest.html"
           ossutil ls --addressing-style "${OSS_ADDRESSING_STYLE_NORMALIZED}" "${dest_prefix}/"
           ossutil ls --addressing-style "${OSS_ADDRESSING_STYLE_NORMALIZED}" "${mirror_root}/latest.html"


### PR DESCRIPTION
## Summary
- use the `ossutil cp` metadata syntax required by ossutil 2.3.0
- restore uploading `releases/latest.html` after release assets are mirrored

## Validation
- manual OSS mirror run #3 reached the final upload command
- release assets and checksums uploaded successfully; only the invalid metadata flag failed

Ref: https://github.com/opensquilla/opensquilla/actions/runs/29249191363