### PR TITLE
fix: set OSS latest page metadata after upload

### DIFF
--- a/.github/workflows/mirror-release-to-oss.yml
+++ b/.github/workflows/mirror-release-to-oss.yml
@@ -262,7 +262,9 @@ jobs:
           done < release-assets/CHECKSUMMED_ASSETS
           upload_asset "release-assets/SHA256SUMS" "SHA256SUMS"
           ossutil cp --force --addressing-style "${OSS_ADDRESSING_STYLE_NORMALIZED}" \
-            --meta="Content-Type:text/html; charset=utf-8#Cache-Control:no-cache" \
             "release-assets/latest.html" "${mirror_root}/latest.html"
+          ossutil set-meta "${mirror_root}/latest.html" \
+            "Content-Type:text/html; charset=utf-8#Cache-Control:no-cache" \
+            --update
           ossutil ls --addressing-style "${OSS_ADDRESSING_STYLE_NORMALIZED}" "${dest_prefix}/"
           ossutil ls --addressing-style "${OSS_ADDRESSING_STYLE_NORMALIZED}" "${mirror_root}/latest.html"

--- a/.github/workflows/mirror-release-to-oss.yml
+++ b/.github/workflows/mirror-release-to-oss.yml
@@ -262,9 +262,8 @@ jobs:
           done < release-assets/CHECKSUMMED_ASSETS
           upload_asset "release-assets/SHA256SUMS" "SHA256SUMS"
           ossutil cp --force --addressing-style "${OSS_ADDRESSING_STYLE_NORMALIZED}" \
+            --content-type "text/html; charset=utf-8" \
+            --cache-control "no-cache" \
             "release-assets/latest.html" "${mirror_root}/latest.html"
-          ossutil set-meta "${mirror_root}/latest.html" \
-            "Content-Type:text/html; charset=utf-8#Cache-Control:no-cache" \
-            --update
           ossutil ls --addressing-style "${OSS_ADDRESSING_STYLE_NORMALIZED}" "${dest_prefix}/"
           ossutil ls --addressing-style "${OSS_ADDRESSING_STYLE_NORMALIZED}" "${mirror_root}/latest.html"

--- a/tests/test_release_oss_mirror_workflow.py
+++ b/tests/test_release_oss_mirror_workflow.py
@@ -39,5 +39,6 @@ def test_aliyun_oss_release_mirror_workflow_contract() -> None:
     assert 'upload_asset "release-assets/SHA256SUMS" "SHA256SUMS"' in workflow
     assert "Build latest download page" in workflow
     assert 'release-assets/latest.html' in workflow
-    assert 'Content-Type:text/html; charset=utf-8#Cache-Control:no-cache' in workflow
+    assert '--content-type "text/html; charset=utf-8"' in workflow
+    assert '--cache-control "no-cache"' in workflow
     assert '"${mirror_root}/latest.html"' in workflow


### PR DESCRIPTION
Fixes the failed `latest.html` upload in the OSS mirror workflow.

Offline-validated with the official Windows build of `ossutil 2.3.0`:
- `cp --meta` is not supported and fails as an unknown flag.
- `cp --content-type "text/html; charset=utf-8" --cache-control "no-cache"` is accepted by the command parser.

The workflow now uses those native response-header flags while uploading `latest.html`. The post-merge manual mirror will verify the final public HTTP response headers.