### PR TITLE
Use profile root in packaged gateway smoke

### DIFF
--- a/desktop/electron/scripts/smoke-gateway.mjs
+++ b/desktop/electron/scripts/smoke-gateway.mjs
@@ -112,7 +112,7 @@ async function selectRuntimeGateway() {
   return sourceRuntimeGatewayDir
 }
 
-function smokeEnv(tempHome, stateDir, config) {
+function smokeEnv(tempHome, config) {
   const env = {}
   for (const [key, value] of Object.entries(process.env)) {
     if (key.startsWith('OPENSQUILLA_')) continue
@@ -125,7 +125,9 @@ function smokeEnv(tempHome, stateDir, config) {
     USERPROFILE: tempHome,
     OPENSQUILLA_DESKTOP: '1',
     OPENSQUILLA_INSTALL_METHOD: 'desktop',
-    OPENSQUILLA_STATE_DIR: stateDir,
+    // The Desktop contract treats OPENSQUILLA_STATE_DIR as the profile root H.
+    // Runtime databases still live below H/state; config must remain at H/config.toml.
+    OPENSQUILLA_STATE_DIR: tempHome,
     OPENSQUILLA_GATEWAY_CONFIG_PATH: config,
     PYTHONUNBUFFERED: '1',
     PYTHONUTF8: '1',
@@ -358,7 +360,7 @@ async function main() {
     const port = await findFreePort()
     child = spawn(gatewayBinary, ['gateway', 'run', '--port', String(port), '--bind', '127.0.0.1', '--config', config], {
       cwd: dirname(gatewayBinary),
-      env: smokeEnv(tempHome, stateDir, config),
+      env: smokeEnv(tempHome, config),
       windowsHide: true,
     })
 

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -1262,10 +1262,13 @@ def test_desktop_gateway_build_and_verifier_cover_runtime_capabilities() -> None
     assert "code-task', 'smoke-imports'" in verifier
     assert "code-task', 'smoke-router'" in verifier
     assert "timeout: 120000" in verifier
-    assert "OPENSQUILLA_GATEWAY_SMOKE_TIMEOUT_MS" in _read(
-        "desktop/electron/scripts/smoke-gateway.mjs"
-    )
-    assert "'90000'" in _read("desktop/electron/scripts/smoke-gateway.mjs")
+    gateway_smoke = _read("desktop/electron/scripts/smoke-gateway.mjs")
+    assert "OPENSQUILLA_GATEWAY_SMOKE_TIMEOUT_MS" in gateway_smoke
+    assert "'90000'" in gateway_smoke
+    assert "function smokeEnv(tempHome, config)" in gateway_smoke
+    assert "OPENSQUILLA_STATE_DIR: tempHome" in gateway_smoke
+    assert "OPENSQUILLA_STATE_DIR: stateDir" not in gateway_smoke
+    assert "env: smokeEnv(tempHome, config)" in gateway_smoke
 
 
 def test_windows_release_workflow_fails_fast_after_gateway_build_failure() -> None:


### PR DESCRIPTION
## Scope

Scope boundary: Correct the packaged Desktop gateway smoke environment so `OPENSQUILLA_STATE_DIR` selects the profile root containing `config.toml`.

Non-goals: No runtime guard, migration, profile layout, or user-data behavior changes.

## Branch

Base branch: main

Target exception: hotfix

## Issue

Linked issue: None

If None, reason: Release packaging regression found by the v0.5.0rc4 Windows asset workflow.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check tests/test_desktop/test_electron_startup_contract.py`

Pytest: `pytest -q tests/test_desktop/test_electron_startup_contract.py -k gateway_build_and_verifier_cover_runtime_capabilities` (1 passed)

Build: `node --check desktop/electron/scripts/smoke-gateway.mjs`

Regression tests: added

Notes: The release workflow will re-run the real packaged Windows gateway smoke after the protected RC4 tag is moved to the merged fix.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: release

Maintainer-only note: The v0.5.0rc4 Release Assets workflow is the live packaged-runtime verification.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation changes.
