### PR TITLE
Seed workspace in packaged gateway smoke

### DIFF
--- a/desktop/electron/scripts/smoke-gateway.mjs
+++ b/desktop/electron/scripts/smoke-gateway.mjs
@@ -339,6 +339,7 @@ async function main() {
   const tempHome = await mkdtemp(join(tmpdir(), 'opensquilla-gateway-smoke-'))
   const config = join(tempHome, 'config.toml')
   const stateDir = join(tempHome, 'state')
+  const workspaceDir = join(tempHome, 'workspace')
   let child = null
   const stdoutTail = []
   const stderrTail = []
@@ -347,6 +348,8 @@ async function main() {
 
   try {
     await mkdir(stateDir, { recursive: true })
+    await mkdir(workspaceDir, { recursive: true })
+    await writeFile(join(workspaceDir, 'SOUL.md'), 'synthetic packaged gateway smoke\n', 'utf8')
     await writeFile(
       config,
       [

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -1269,6 +1269,37 @@ def test_desktop_gateway_build_and_verifier_cover_runtime_capabilities() -> None
     assert "OPENSQUILLA_STATE_DIR: tempHome" in gateway_smoke
     assert "OPENSQUILLA_STATE_DIR: stateDir" not in gateway_smoke
     assert "env: smokeEnv(tempHome, config)" in gateway_smoke
+    assert "const workspaceDir = join(tempHome, 'workspace')" in gateway_smoke
+    assert "await mkdir(workspaceDir, { recursive: true })" in gateway_smoke
+    assert "writeFile(join(workspaceDir, 'SOUL.md')" in gateway_smoke
+
+
+def test_packaged_gateway_smoke_profile_satisfies_recovery_guard(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from opensquilla.recovery import guard_desktop_profile
+
+    home = tmp_path / "opensquilla-gateway-smoke"
+    (home / "state").mkdir(parents=True)
+    workspace = home / "workspace"
+    workspace.mkdir()
+    (workspace / "SOUL.md").write_text(
+        "synthetic packaged gateway smoke\n",
+        encoding="utf-8",
+    )
+    (home / "config.toml").write_text('[auth]\nmode = "none"\n', encoding="utf-8")
+    monkeypatch.setenv("OPENSQUILLA_DESKTOP", "1")
+    monkeypatch.setenv("OPENSQUILLA_INSTALL_METHOD", "desktop")
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(home / "config.toml"))
+
+    report = guard_desktop_profile(home)
+
+    assert report is not None
+    assert report.outcome == "ready"
+    assert report.stable_code == "canonical_workspace"
+    assert report.effective_workspace == workspace
 
 
 def test_windows_release_workflow_fails_fast_after_gateway_build_failure() -> None:


### PR DESCRIPTION
## Scope

Scope boundary: Seed a synthetic canonical workspace so the packaged Desktop gateway smoke fixture satisfies the RC4 Recovery guard.

Non-goals: No runtime guard, migration, profile layout, or user-data behavior changes.

## Branch

Base branch: main

Target exception: hotfix

## Issue

Linked issue: None

If None, reason: Follow-up release fixture gap found by the v0.5.0rc4 Windows asset workflow after the profile-root fix.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check tests/test_desktop/test_electron_startup_contract.py`

Pytest: four focused Desktop/Recovery guard tests (4 passed)

Build: `node --check desktop/electron/scripts/smoke-gateway.mjs`

Regression tests: added

Notes: The focused regression invokes the real Recovery guard and verifies `ready / canonical_workspace`. The release workflow will re-run the packaged Windows and macOS gateway smoke after the protected RC4 tag is moved to the merged fix.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: release

Maintainer-only note: The v0.5.0rc4 Release Assets workflow is the live packaged-runtime verification.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation changes.
