### PR TITLE
Seed workspace for packaged update banner smoke

### DIFF
--- a/desktop/electron/scripts/test-packaged-update-banner.mjs
+++ b/desktop/electron/scripts/test-packaged-update-banner.mjs
@@ -81,6 +81,16 @@ async function writeSyntheticUpdateCache(userDataDir, baseVersion, timestamp) {
   )
 }
 
+async function writeSyntheticCanonicalWorkspace(userDataDir) {
+  const workspaceDir = resolve(userDataDir, 'opensquilla', 'workspace')
+  await mkdir(workspaceDir, { recursive: true })
+  await writeFile(
+    resolve(workspaceDir, 'SOUL.md'),
+    'synthetic packaged update-banner smoke\n',
+    { mode: 0o600 },
+  )
+}
+
 async function launchCandidate(
   executablePath,
   userDataDir,
@@ -208,6 +218,7 @@ try {
   app = null
 
   const beforePrivacyLaunch = requestCount
+  await writeSyntheticCanonicalWorkspace(privacyUserDataDir)
   privacyApp = await launchCandidate(
     executablePath,
     privacyUserDataDir,

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -302,6 +302,12 @@ def test_release_workflow_gates_built_and_downloaded_installers_on_profile_reten
     assert "requestCount, 1" in update_banner_smoke
     assert "OPENSQUILLA_PRIVACY_DISABLE_NETWORK_OBSERVABILITY" in update_banner_smoke
     assert "writeSyntheticUpdateCache(privacyUserDataDir, baseVersion, 0)" in update_banner_smoke
+    assert "writeSyntheticCanonicalWorkspace(privacyUserDataDir)" in update_banner_smoke
+    assert update_banner_smoke.index(
+        "writeSyntheticCanonicalWorkspace(privacyUserDataDir)"
+    ) < update_banner_smoke.index(
+        "privacyApp = await launchCandidate("
+    )
     assert "GITHUB_ACTIONS: '0'" in update_banner_smoke
 
     mac_audit = workflow[


### PR DESCRIPTION
## Scope
- seed a synthetic canonical workspace for the isolated privacy update-banner fixture
- assert the workspace is created before launching the packaged candidate

## Branch target
main

## Linked issue
None

## Release note
None; release-test fixture only.

## Tests
- `node --check desktop/electron/scripts/test-packaged-update-banner.mjs`
- focused release consistency and desktop recovery guard tests (2 passed)
- `git diff --check`

## Safety
The RC3 upgrade, uninstall, profile-preservation, privacy, and downloaded-asset gates remain unchanged. This only makes the independent synthetic privacy profile satisfy the existing RC4 recovery contract.

## Third-party origin
None.
