### PR TITLE
Allow release audits to inspect draft assets

### DIFF
--- a/.github/workflows/wheelhouse-release.yml
+++ b/.github/workflows/wheelhouse-release.yml
@@ -664,7 +664,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 75
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Checkout release verification helpers
         uses: actions/checkout@v4
@@ -812,7 +812,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 75
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Checkout release verification helpers
         uses: actions/checkout@v4

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -318,6 +318,8 @@ def test_release_workflow_gates_built_and_downloaded_installers_on_profile_reten
     windows_audit = workflow[workflow.index("  audit-downloaded-windows-release:") :]
     for audit in (mac_audit, windows_audit):
         assert "needs: publish-release" in audit
+        assert "contents: write" in audit
+        assert "contents: read" not in audit
         assert "gh release download" in audit
         assert "SHA256SUMS" in audit
         assert "isDraft" in audit


### PR DESCRIPTION
## Scope
- grant the two downloaded Draft release audit jobs push-level contents access so GitHub exposes Draft releases to their tokens
- pin the permission contract with a regression assertion

## Branch target
main

## Linked issue
None

## Release note
None; release workflow only.

## Tests
- focused release consistency test (1 passed)
- `git diff --check`

## Safety
The jobs remain read-only in their commands. This does not publish the Draft, alter assets, or weaken checksum, signature, upgrade, uninstall, or profile-preservation gates.

## Third-party origin
None.
