### PR TITLE
feat(provider): add Agnes AI (Free and Token Plan) provider support

### DIFF
--- a/src/opensquilla/onboarding/provider_specs.py
+++ b/src/opensquilla/onboarding/provider_specs.py
@@ -72,6 +72,8 @@ _PROVIDER_LABELS: dict[str, str] = {
     "qianfan": "Baidu Qianfan",
     "siliconflow": "SiliconFlow",
     "aihubmix": "AIHubMix",
+    "agnes": "Agnes AI (Free)",
+    "agnes_token_plan": "Agnes AI (Token Plan)",
     "volcengine": "Volcengine Ark",
     "byteplus": "BytePlus Ark",
     "vllm": "vLLM (self-hosted)",

--- a/src/opensquilla/provider/catalog_overrides.toml
+++ b/src/opensquilla/provider/catalog_overrides.toml
@@ -369,3 +369,57 @@ supports_reasoning = false
 supports_tools = true
 supports_vision = false
 reasoning_format = "none"
+
+# Agnes AI (Free / Default tier): OpenAI-compatible endpoint. The text model
+# agnes-2.0-flash supports tool calling and image understanding.
+
+[agnes."agnes-2.0-flash"]
+display_name = "Agnes 2.0 Flash"
+context_window = 524288
+max_output_tokens = 65536
+supports_reasoning = false
+supports_tools = true
+supports_vision = true
+reasoning_format = "none"
+
+[agnes."agnes-2.5-flash"]
+display_name = "Agnes 2.5 Flash"
+context_window = 524288
+max_output_tokens = 65536
+supports_reasoning = false
+supports_tools = true
+supports_vision = true
+reasoning_format = "none"
+
+[agnes."*"]
+supports_reasoning = false
+supports_tools = true
+supports_vision = true
+reasoning_format = "none"
+
+# Agnes AI Token Plan: same models and wire behavior as the free tier, but with
+# a dedicated API-key env var and higher RPM / quota limits.
+
+[agnes_token_plan."agnes-2.0-flash"]
+display_name = "Agnes 2.0 Flash"
+context_window = 524288
+max_output_tokens = 65536
+supports_reasoning = false
+supports_tools = true
+supports_vision = true
+reasoning_format = "none"
+
+[agnes_token_plan."agnes-2.5-flash"]
+display_name = "Agnes 2.5 Flash"
+context_window = 524288
+max_output_tokens = 65536
+supports_reasoning = false
+supports_tools = true
+supports_vision = true
+reasoning_format = "none"
+
+[agnes_token_plan."*"]
+supports_reasoning = false
+supports_tools = true
+supports_vision = true
+reasoning_format = "none"

--- a/src/opensquilla/provider/registry.py
+++ b/src/opensquilla/provider/registry.py
@@ -321,6 +321,20 @@ for _provider_spec in [
         catalog_source=("siliconflow",),
     ),
     _spec(
+        "agnes",
+        "openai_compat",
+        "openai",
+        "AGNES_API_KEY",
+        "https://apihub.agnes-ai.com/v1",
+    ),
+    _spec(
+        "agnes_token_plan",
+        "openai_compat",
+        "openai",
+        "AGNES_TOKEN_PLAN_API_KEY",
+        "https://apihub.agnes-ai.com/v1",
+    ),
+    _spec(
         "aihubmix",
         "openai_compat",
         "aihubmix",

--- a/tests/test_provider/test_capability_ladder_parity.py
+++ b/tests/test_provider/test_capability_ladder_parity.py
@@ -53,6 +53,14 @@ _EXPECTED_CAPS: dict[tuple[str, str, str], tuple[bool, bool, bool, str]] = {
     ("aihubmix", "gemini-3-pro-preview", ""): (False, True, True, "none"),
     ("aihubmix", "o3-mini", ""): (False, True, False, "none"),
     ("aihubmix", "gpt-5.5", ""): (False, True, True, "none"),
+    # Agnes AI (Free / Default tier) — catch-all and specific model override.
+    ("agnes", "totally-unknown-model-x1", ""): (False, True, True, "none"),
+    ("agnes", "agnes-2.0-flash", ""): (False, True, True, "none"),
+    ("agnes", "agnes-2.5-flash", ""): (False, True, True, "none"),
+    # Agnes AI Token Plan — same wire behavior, separate API-key env var.
+    ("agnes_token_plan", "totally-unknown-model-x1", ""): (False, True, True, "none"),
+    ("agnes_token_plan", "agnes-2.0-flash", ""): (False, True, True, "none"),
+    ("agnes_token_plan", "agnes-2.5-flash", ""): (False, True, True, "none"),
     ("anthropic", "totally-unknown-model-x1", ""): (False, True, False, "none"),
     ("anthropic", "gpt-4o", ""): (False, True, False, "none"),
     ("anthropic", "deepseek-r1", ""): (False, True, False, "none"),
@@ -595,6 +603,8 @@ _EXPECTED_CAPS: dict[tuple[str, str, str], tuple[bool, bool, bool, str]] = {
 
 # ProviderSpec.requires_api_key() per provider id — frozen pre-migration.
 _EXPECTED_REQUIRES_API_KEY: dict[str, bool] = {
+    "agnes": True,
+    "agnes_token_plan": True,
     "aihubmix": True,
     "anthropic": True,
     "azure": True,
@@ -633,6 +643,8 @@ _EXPECTED_REQUIRES_API_KEY: dict[str, bool] = {
 # pre-migration. Providers in LOCAL_RUNTIME_PROVIDERS report the local
 # runtime window; everything else reports the cloud default.
 _EXPECTED_UNKNOWN_CONTEXT_WINDOW: dict[str, int] = {
+    "agnes": 200000,
+    "agnes_token_plan": 200000,
     "aihubmix": 200000,
     "anthropic": 200000,
     "azure": 200000,

--- a/tests/test_provider/test_spec_substrate.py
+++ b/tests/test_provider/test_spec_substrate.py
@@ -29,6 +29,10 @@ _CATALOG_SOURCE_WAIVERS: frozenset[str] = frozenset(
         # Hosted aggregator with no models.dev source mapped; the vendored
         # snapshot has never carried aihubmix rows.
         "aihubmix",
+        # Agnes AI (Free and Token Plan): OpenAI-compatible provider with no
+        # models.dev catalog source; model metadata is supplied by corrections.
+        "agnes",
+        "agnes_token_plan",
         # OAuth-only ChatGPT-backend provider: models are fixed by the
         # Codex subscription, not a public catalog.
         "openai_codex",


### PR DESCRIPTION
## Summary

Closes #662 

Add two new OpenAI-compatible providers for Agnes AI:

- `agnes`: free / default tier, env key `AGNES_API_KEY`
- `agnes_token_plan`: Token Plan subscription tier, env key `AGNES_TOKEN_PLAN_API_KEY`

Both use the same endpoint `https://apihub.agnes-ai.com/v1`. The API key type determines the RPM and quota pool.

## Changes

- `src/opensquilla/provider/registry.py`: register `agnes` and `agnes_token_plan`
- `src/opensquilla/provider/catalog_overrides.toml`: add model metadata
- `src/opensquilla/onboarding/provider_specs.py`: add display labels
- `tests/test_provider/test_spec_substrate.py`: catalog-source waivers
- `tests/test_provider/test_capability_ladder_parity.py`: expected caps

## Models Supported

- Text: `agnes-2.0-flash`, `agnes-2.5-flash` (coming soon)
- Image: `agnes-image-2.0-flash`, `agnes-image-2.1-flash`, `agnes-image-2.5-preview` (coming soon)
- Video: `agnes-video-v2.0`, `agnes-video-2.5-preview` (coming soon)

## How to Test

```bash
uv run ruff check src tests
uv run pytest tests/test_provider/test_spec_substrate.py tests/test_provider/test_capability_ladder_parity.py tests/test_provider/test_preset_registry.py -q