### PR TITLE
fix: align CodeTask with sandbox-off host access

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -130,6 +130,14 @@ boundary. Work happens in an isolated run directory under the OpenSquilla state
 tree; the source repo is updated only after the workflow collects and verifies a
 productive change.
 
+The bundled trusted-repository policy runs the child agent in Full Host Access:
+read-side file tools, write-side file tools, patches, and shell commands all use
+the same sandbox-off posture. A custom CodeTask agent configuration that selects
+Standard-Sandbox or Managed Execution keeps strict reads and workspace/scratch
+write containment. In every posture, the disposable clone remains the intended
+working directory and the verified-change workflow controls when the source repo
+is updated.
+
 `--verification-mode red-green` is the default for existing repositories.
 `--verification-mode build` is for app or artifact delivery checks.
 `--verification-mode scratch` creates an empty throwaway repo and must not be

--- a/src/opensquilla/contrib/codetask/adapter.py
+++ b/src/opensquilla/contrib/codetask/adapter.py
@@ -79,6 +79,25 @@ _PROFILE_SCOPED_CHILD_ENV = frozenset(
 )
 
 
+def _agent_access_arguments(bundle: AgentConfigBundle) -> list[str]:
+    """Return child CLI access flags matching the effective sandbox run mode."""
+
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.sandbox.run_mode import RunMode, config_run_mode
+
+    config = GatewayConfig(**copy.deepcopy(bundle.payload))
+    run_mode = config_run_mode(config)
+    if run_mode is RunMode.FULL:
+        return ["--no-workspace-strict", "--permissions", "full"]
+    permission_profile = "restricted" if run_mode is RunMode.STANDARD else "bypass"
+    return [
+        "--workspace-strict",
+        "--workspace-lockdown",
+        "--permissions",
+        permission_profile,
+    ]
+
+
 class LocalAdapter:
     """Drives the host ``opensquilla agent`` CLI and returns a structured result."""
 
@@ -128,6 +147,7 @@ class LocalAdapter:
         if not usage_path.exists():
             usage_path.write_text("{}", encoding="utf-8")
 
+        bundle = self.agent_config or load_agent_config_bundle()
         argv: list[str] = [
             "opensquilla",
             "agent",
@@ -135,10 +155,7 @@ class LocalAdapter:
             prompt,
             "--workspace",
             str(repo),
-            # Read containment to the repo (codex review #9: explicit, not default).
-            "--workspace-strict",
-            # Write containment: writes must stay under workspace or scratch.
-            "--workspace-lockdown",
+            *_agent_access_arguments(bundle),
             "--scratch-dir",
             str(scratch_dir),
             "--stateless",
@@ -159,8 +176,6 @@ class LocalAdapter:
             str(transcript_path),
             "--usage-path",
             str(usage_path),
-            "--permissions",
-            "bypass",
         ]
         if self.model:
             argv += ["--model", self.model]
@@ -193,7 +208,6 @@ class LocalAdapter:
         # media_root_from_config(); tool_result_store_dir = media_root/tool-results.
         run_media_root = scratch_dir.expanduser().resolve() / "media"
         per_run_config = artifact_dir / "agent-config.toml"
-        bundle = self.agent_config or load_agent_config_bundle()
         _cfg = copy.deepcopy(bundle.payload)
         _attachments = _cfg.setdefault("attachments", {})
         if not isinstance(_attachments, dict):

--- a/src/opensquilla/contrib/codetask/adapter.py
+++ b/src/opensquilla/contrib/codetask/adapter.py
@@ -83,13 +83,12 @@ def _agent_access_arguments(bundle: AgentConfigBundle) -> list[str]:
     """Return child CLI access flags matching the effective sandbox run mode."""
 
     from opensquilla.gateway.config import GatewayConfig
-    from opensquilla.sandbox.run_mode import RunMode, config_run_mode
 
     config = GatewayConfig(**copy.deepcopy(bundle.payload))
-    run_mode = config_run_mode(config)
-    if run_mode is RunMode.FULL:
+    run_mode = config.effective_run_mode
+    if run_mode == "full":
         return ["--no-workspace-strict", "--permissions", "full"]
-    permission_profile = "restricted" if run_mode is RunMode.STANDARD else "bypass"
+    permission_profile = "restricted" if run_mode == "standard" else "bypass"
     return [
         "--workspace-strict",
         "--workspace-lockdown",

--- a/src/opensquilla/contrib/codetask/agent_config.py
+++ b/src/opensquilla/contrib/codetask/agent_config.py
@@ -4,10 +4,9 @@ The subagent loads its config through ``OPENSQUILLA_GATEWAY_CONFIG_PATH``,
 which REPLACES the normal config chain — so the bundled template used to pin
 the subagent to the template's own provider no matter what the operator
 configured (issue #541). Assembly keeps the template authoritative for run
-policy (tool deny list, sandbox posture, meta-skill gating, memory flush,
-workspace containment) while the operator's provider stack is carried into
-the per-run config, so the subagent talks to the same provider as every
-other surface.
+policy (tool deny list, sandbox and access posture, meta-skill gating, memory
+flush) while the operator's provider stack is carried into the per-run config,
+so the subagent talks to the same provider as every other surface.
 """
 
 from __future__ import annotations

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -2051,6 +2051,14 @@ class GatewayConfig(BaseSettings):
     diagnostics_enabled: bool = False
     channel_admin_senders: dict[str, list[str]] = Field(default_factory=dict)
 
+    @property
+    def effective_run_mode(self) -> str:
+        """Return the canonical sandbox run mode for this validated config."""
+
+        from opensquilla.sandbox.run_mode import config_run_mode
+
+        return config_run_mode(self).value
+
     @model_validator(mode="after")
     def _resolve_default_llm_provider(self) -> GatewayConfig:
         """Resolve the built-in provider default for configs that never chose one.

--- a/tests/test_contrib/test_codetask/test_codetask_adapter.py
+++ b/tests/test_contrib/test_codetask/test_codetask_adapter.py
@@ -7,6 +7,7 @@ import pytest
 
 from opensquilla.contrib.codetask import adapter
 from opensquilla.contrib.codetask.adapter import LocalAdapter, _agent_command
+from opensquilla.contrib.codetask.agent_config import AgentConfigBundle
 
 
 class FakePopen:
@@ -46,27 +47,109 @@ def _install_popen(monkeypatch, captured, **popen_kw):
     monkeypatch.setattr(adapter.subprocess, "Popen", fake_popen)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="code-task Windows support is WIP")
-def test_argv_has_host_containment_flags(monkeypatch, tmp_path):
+def _capture_agent_argv(monkeypatch, captured):
+    def fake_agent_command(executable, argv, py_code):
+        captured["argv"] = list(argv)
+        return [sys.executable, "-c", py_code]
+
+    monkeypatch.setattr(adapter, "_agent_command", fake_agent_command)
+
+
+def test_sandbox_off_uses_full_host_access_without_workspace_containment(
+    monkeypatch, tmp_path
+):
     captured = {}
     _install_popen(monkeypatch, captured, stdout='{"status": "ok", "text": "done", "usage": {}}')
+    _capture_agent_argv(monkeypatch, captured)
+    _isolate_operator_config(monkeypatch, tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
     out = LocalAdapter(model="m", timeout=10).run(
         "fix it", repo=repo, scratch_dir=tmp_path / "s", artifact_dir=tmp_path / "art"
     )
     assert out.success is True
-    code = captured["code"]
+    argv = captured["argv"]
     for flag in (
         "--workspace",
-        "--workspace-strict",
-        "--workspace-lockdown",
+        "--no-workspace-strict",
         "--scratch-dir",
         "--stateless",
         "--permissions",
     ):
-        assert flag in code
+        assert flag in argv
+    assert argv[argv.index("--permissions") + 1] == "full"
+    assert "--workspace-strict" not in argv
+    assert "--workspace-lockdown" not in argv
     assert captured["cwd"] == str(repo)
+
+
+def test_sandbox_on_keeps_workspace_containment(monkeypatch, tmp_path):
+    captured = {}
+    _install_popen(monkeypatch, captured, stdout='{"status": "ok", "text": "done", "usage": {}}')
+    _capture_agent_argv(monkeypatch, captured)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    bundle = AgentConfigBundle(
+        payload={
+            "sandbox": {
+                "sandbox": True,
+                "security_grading": True,
+                "run_mode": "trusted",
+            }
+        }
+    )
+
+    out = LocalAdapter(model="m", timeout=10, agent_config=bundle).run(
+        "fix it", repo=repo, scratch_dir=tmp_path / "s", artifact_dir=tmp_path / "art"
+    )
+
+    assert out.success is True
+    argv = captured["argv"]
+    assert argv[argv.index("--permissions") + 1] == "bypass"
+    assert "--workspace-strict" in argv
+    assert "--workspace-lockdown" in argv
+    assert "--no-workspace-strict" not in argv
+
+
+def test_standard_sandbox_uses_restricted_permission_profile(monkeypatch, tmp_path):
+    captured = {}
+    _install_popen(monkeypatch, captured, stdout='{"status": "ok", "text": "done"}')
+    _capture_agent_argv(monkeypatch, captured)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    bundle = AgentConfigBundle(
+        payload={
+            "sandbox": {
+                "sandbox": True,
+                "security_grading": True,
+                "run_mode": "standard",
+            }
+        }
+    )
+
+    out = LocalAdapter(agent_config=bundle).run(
+        "fix it", repo=repo, scratch_dir=tmp_path / "s", artifact_dir=tmp_path / "art"
+    )
+
+    assert out.success is True
+    argv = captured["argv"]
+    assert argv[argv.index("--permissions") + 1] == "restricted"
+    assert "--workspace-strict" in argv
+    assert "--workspace-lockdown" in argv
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="process-group signal differs on Windows")
+def test_agent_process_starts_in_its_own_posix_session(monkeypatch, tmp_path):
+    captured = {}
+    _install_popen(monkeypatch, captured, stdout='{"status": "ok", "text": "done", "usage": {}}')
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    out = LocalAdapter(model="m", timeout=10).run(
+        "fix it", repo=repo, scratch_dir=tmp_path / "s", artifact_dir=tmp_path / "art"
+    )
+
+    assert out.success is True
     # Descendant-killable process group (codex review #6).
     assert captured["new_session"] is True
 


### PR DESCRIPTION
## Summary

- derive CodeTask child-agent CLI access flags from the validated effective sandbox run mode
- use Full Host Access without hidden read or write containment when the bundled CodeTask policy disables sandboxing
- preserve strict workspace containment for Standard-Sandbox and Managed Execution overrides
- add platform-independent argument regression coverage and document the access contract

## Root cause

The bundled CodeTask configuration disabled the OS sandbox, but LocalAdapter unconditionally launched its child with workspace-strict, workspace-lockdown, and legacy bypass permissions. File tools therefore raised WorkspaceAccessError outside the disposable clone while shell execution followed the sandbox-off host path.

Scope boundary: CodeTask child-agent access argument construction, its focused tests, and CLI documentation only.

Base branch: main

Target exception: None; this PR targets the default main branch.

Linked issue: None; this fixes the reproduced sandbox-off CodeTask inconsistency.

Release note: Fixed CodeTask sandbox-off runs so filesystem and shell tools consistently use Full Host Access.

## Tests

- uv run ruff check src tests
- uv run mypy src/opensquilla --show-error-codes
- uv run pytest tests/test_contrib/test_codetask -q
- focused Full Host Access read, patch, shell, protected-write, and CLI context tests (6 passed)

Maintainer live check: Optional Windows desktop smoke using a repository outside the CodeTask run directory; automated Windows compatibility covers the generated argv contract.

Third-party origin: None.
