### PR TITLE
Limit concurrent image analysis requests

### DIFF
--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -387,6 +387,13 @@ _FEISHU_READ_ONLY_TOOL_NAMES: frozenset[str] = frozenset(
 
 _MUTEX_TOOL_POLICY = _ToolConcurrencyPolicy(mode="mutex")
 _CONCURRENT_TOOL_POLICY = _ToolConcurrencyPolicy(mode="concurrent")
+# Image analysis crosses a provider boundary. Keep slide-thumbnail bursts below
+# the generic safe-tool cap so compatible vision endpoints are not saturated.
+_IMAGE_ANALYSIS_TOOL_POLICY = _ToolConcurrencyPolicy(
+    mode="concurrent",
+    max_inflight=2,
+    limit_key=("media", "image_analysis"),
+)
 _FEISHU_READ_TOOL_POLICY = _ToolConcurrencyPolicy(
     mode="concurrent",
     max_inflight=4,
@@ -400,6 +407,8 @@ def _get_tool_concurrency_policy(
     *,
     parent_session_key: str | None = None,
 ) -> _ToolConcurrencyPolicy:
+    if tool_name == "image":
+        return _IMAGE_ANALYSIS_TOOL_POLICY
     if tool_name in _SAFE_TOOL_NAMES:
         return _CONCURRENT_TOOL_POLICY
     if tool_name in _FEISHU_READ_ONLY_TOOL_NAMES:

--- a/tests/test_engine/test_tool_concurrency.py
+++ b/tests/test_engine/test_tool_concurrency.py
@@ -229,6 +229,41 @@ async def test_feishu_read_only_tools_have_independent_inflight_cap() -> None:
 
 
 @pytest.mark.asyncio
+async def test_image_analysis_calls_have_dedicated_inflight_cap() -> None:
+    """Vision requests should not fan out at the generic safe-tool limit."""
+    tool_calls = [("image", {"path": f"slide-{i}.png"}) for i in range(6)]
+    in_flight = 0
+    max_in_flight = 0
+
+    async def _handler(tc: ToolCall) -> ToolResult:
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(_TOOL_SLEEP_S)
+        in_flight -= 1
+        return ToolResult(
+            tool_use_id=tc.tool_use_id,
+            tool_name=tc.tool_name,
+            content="ok",
+        )
+
+    provider = _FixedToolCallArgsProvider(tool_calls)
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(max_iterations=2, max_safe_tool_concurrency=6),
+        tool_definitions=[_tool_def("image")],
+        tool_handler=_handler,
+    )
+
+    t0 = time.monotonic()
+    await _collect(agent)
+    elapsed = time.monotonic() - t0
+
+    assert max_in_flight == 2
+    assert 3 * _TOOL_SLEEP_S - _SCHEDULER_TOLERANCE_S <= elapsed < 4 * _TOOL_SLEEP_S
+
+
+@pytest.mark.asyncio
 async def test_feishu_mutating_tools_remain_serial() -> None:
     """Feishu writes must remain mutex even when read-only Feishu tools batch."""
     tool_calls = [


### PR DESCRIPTION
## Scope

- add a dedicated concurrency policy for the built-in `image` analysis tool
- cap same-turn vision analysis calls at two while leaving the generic safe-tool cap unchanged
- add an offline regression test that verifies queued image calls never exceed that cap

Target branch: `main`

Linked issue: None

Release note: Not added; this is a narrow runtime reliability fix with no public API or configuration change.

## Root cause

The `image` tool was classified only as a generic read-only safe tool, so a slide-review turn could dispatch up to six provider-backed vision requests at once. The observed ten-slide run completed the first two requests, then left the remaining requests waiting until the 180-second tool deadline. Image analysis is mutation-safe, but it is not resource-equivalent to local file reads and needs its own provider-facing limit.

## Validation

- `.venv/bin/pytest -q tests/test_engine/test_tool_concurrency.py tests/test_tools/test_media_image.py tests/test_provider_image_generation.py` — 41 passed
- `uv run ruff check src tests` — passed
- `git diff --check` — passed
- `uv run pytest tests -q` — interrupted after 437 passed and 43 skipped; 10 real-terminal tests failed because the local tmux server was unavailable, and the router artifact manifest check differed because the sandboxed checkout could not process the Git LFS model artifact. These failures are unrelated to the changed runtime/test files and remain for CI to verify in the standard environment.

## Safety and compatibility

- platform-neutral asyncio scheduling change
- no persisted state, database, protocol, CLI, config, or desktop-client contract changes
- image requests remain concurrent; excess calls queue before their individual execution timeout starts
- other safe tools retain the existing global concurrency limit

## Third-party origin

None.