### PR TITLE
Classify channel send failures into the taxonomy adapters declare

### DIFF
--- a/src/opensquilla/channels/_util.py
+++ b/src/opensquilla/channels/_util.py
@@ -20,6 +20,8 @@ from typing import Any, Literal
 import httpx
 import structlog
 
+from opensquilla.http_retry import parse_retry_after
+
 log = structlog.get_logger(__name__)
 
 
@@ -286,6 +288,23 @@ class FloodStrikeBackoff:
         self._fallback = False
 
 
+#: Defensive ceiling for a provider-supplied ``Retry-After``. A broken or
+#: hostile header must not park a channel for hours; generous enough that any
+#: realistic chat-provider hint is honored verbatim.
+MAX_RETRY_AFTER_S: float = 900.0
+
+
+def _retry_after_delay(response: httpx.Response, fallback: float) -> float:
+    """Seconds to wait before retrying, from ``Retry-After`` or ``fallback``.
+
+    Handles both RFC 9110 forms and rejects absent/negative/unparseable
+    values (a bare ``float()`` raises on the HTTP-date form). The honored
+    delay is capped so a hostile header cannot park the channel.
+    """
+    parsed = parse_retry_after(response.headers.get("Retry-After"))
+    return min(fallback if parsed is None else parsed, MAX_RETRY_AFTER_S)
+
+
 async def retry_request(
     func: Callable[..., Awaitable[httpx.Response]],
     *args: Any,
@@ -293,18 +312,24 @@ async def retry_request(
     base_delay: float = 1.0,
     **kwargs: Any,
 ) -> httpx.Response:
-    """Retry an httpx request with exponential backoff on transient errors."""
+    """Retry an httpx request with exponential backoff on transient errors.
+
+    On exhaustion the final response is returned rather than raised: a 429 or
+    5xx that survived every attempt is the provider's answer, and the caller
+    needs it to classify the failure.
+    """
     last_exc: Exception | None = None
     for attempt in range(max_retries + 1):
         try:
             resp = await func(*args, **kwargs)
-            if resp.status_code == 429:
-                retry_after = float(resp.headers.get("Retry-After", base_delay * (2**attempt)))
+            backoff = base_delay * (2**attempt)
+            if resp.status_code == 429 and attempt < max_retries:
+                retry_after = _retry_after_delay(resp, backoff)
                 log.warning("rate_limited", retry_after=retry_after, attempt=attempt)
                 await asyncio.sleep(retry_after)
                 continue
             if resp.status_code in {500, 502, 503, 504} and attempt < max_retries:
-                delay = base_delay * (2**attempt) + random.random()
+                delay = backoff + random.random()
                 log.warning("transient_error", status=resp.status_code, delay=delay)
                 await asyncio.sleep(delay)
                 continue

--- a/src/opensquilla/channels/contract.py
+++ b/src/opensquilla/channels/contract.py
@@ -60,6 +60,118 @@ REQUIRED_FATAL_ERROR_CLASSES: tuple[str, ...] = (
     "contract_violation",
 )
 
+#: Every value an adapter may declare. The classifier will not emit anything
+#: outside this set, and will not trust an adapter-declared value outside it.
+ALL_ERROR_CLASSES: frozenset[str] = frozenset(
+    REQUIRED_RETRYABLE_ERROR_CLASSES + REQUIRED_FATAL_ERROR_CLASSES
+)
+
+#: A send failure we cannot place in the taxonomy. Deliberately outside BOTH
+#: the retryable and fatal sets: guessing "transient" would retry a permanent
+#: failure forever, guessing "fatal" would discard a recoverable one. An
+#: unclassified failure parks for a human instead.
+UNCLASSIFIED_ERROR_CLASS: str = "unknown"
+
+#: HTTP status → taxonomy. Only statuses whose meaning is unambiguous across
+#: chat providers are mapped; anything else falls through to unclassified.
+_SEND_ERROR_STATUS_CLASSES: dict[int, str] = {
+    400: "payload_rejected",
+    401: "auth_invalid",
+    403: "auth_invalid",
+    404: "target_missing",
+    410: "target_missing",
+    413: "payload_rejected",
+    422: "payload_rejected",
+    429: "rate_limited",
+}
+
+
+def classify_send_error_status(status_code: int | None) -> str:
+    """Map an HTTP status from a send attempt onto the error taxonomy.
+
+    5xx is transport-transient: the request may well succeed on a retry.
+    Unmapped statuses are unclassified rather than guessed.
+    """
+    if status_code is None:
+        return UNCLASSIFIED_ERROR_CLASS
+    mapped = _SEND_ERROR_STATUS_CLASSES.get(status_code)
+    if mapped is not None:
+        return mapped
+    if 500 <= status_code <= 599:
+        return "transport_transient"
+    return UNCLASSIFIED_ERROR_CLASS
+
+
+def classify_channel_send_error(error: BaseException) -> str:
+    """Classify a provider send failure into the taxonomy adapters declare.
+
+    The taxonomy is enforced verbatim across every adapter, but nothing used
+    to produce it: the durable outbox stored ``type(error).__name__``, which
+    no consumer can act on. This is the single producer.
+
+    Resolution order, most authoritative first:
+
+    1. An explicit ``error_class`` the raising adapter set. An adapter knows
+       its own provider's semantics better than any generic rule; a value
+       outside the taxonomy is ignored rather than trusted.
+    2. A ``retry_after`` hint — only a rate limit carries one.
+    3. An HTTP status, from ``httpx.HTTPStatusError`` or a ``status_code``
+       attribute. Note that a bare ``code`` attribute is NOT read: several
+       providers number their own business errors there, and reading those as
+       HTTP statuses would misclassify confidently.
+    4. Transport-layer exceptions (connect/read/timeout) → transient.
+
+    Anything else is unclassified — never a benign default.
+    """
+    declared = getattr(error, "error_class", None)
+    if isinstance(declared, str) and declared in ALL_ERROR_CLASSES:
+        return declared
+
+    retry_after = getattr(error, "retry_after", None)
+    if isinstance(retry_after, int | float) and retry_after >= 0:
+        return "rate_limited"
+
+    response = getattr(error, "response", None)
+    status = getattr(response, "status_code", None)
+    if not isinstance(status, int):
+        status = getattr(error, "status_code", None)
+    if isinstance(status, int):
+        return classify_send_error_status(status)
+
+    # Duck-typed so this module stays importable by every adapter (importing
+    # httpx exception types here would invert the dependency direction).
+    if _is_transport_exception(error):
+        return "transport_transient"
+
+    return UNCLASSIFIED_ERROR_CLASS
+
+
+_TRANSPORT_EXCEPTION_NAMES: frozenset[str] = frozenset(
+    {
+        "ConnectError",
+        "ConnectTimeout",
+        "NetworkError",
+        "PoolTimeout",
+        "ProtocolError",
+        "ReadError",
+        "ReadTimeout",
+        "RemoteProtocolError",
+        "TimeoutException",
+        "WriteError",
+        "WriteTimeout",
+    }
+)
+
+
+def _is_transport_exception(error: BaseException) -> bool:
+    if isinstance(error, TimeoutError | ConnectionError):
+        return True
+    return any(
+        klass.__name__ in _TRANSPORT_EXCEPTION_NAMES
+        and klass.__module__.split(".")[0] == "httpx"
+        for klass in type(error).__mro__
+    )
+
 
 class ChannelCapabilities:
     """Capability tags an adapter may declare on its module.
@@ -609,6 +721,10 @@ def run_channel_contract(module: ModuleType) -> None:
 __all__ = [
     "ALLOWED_CAPABILITY_TIERS",
     "ALLOWED_DM_SAFETY_TIERS",
+    "ALL_ERROR_CLASSES",
+    "UNCLASSIFIED_ERROR_CLASS",
+    "classify_channel_send_error",
+    "classify_send_error_status",
     "PUBLIC_VENDOR_ADAPTERS",
     "REQUIRED_FATAL_ERROR_CLASSES",
     "REQUIRED_RETRYABLE_ERROR_CLASSES",

--- a/src/opensquilla/channels/delivery_store.py
+++ b/src/opensquilla/channels/delivery_store.py
@@ -18,6 +18,7 @@ from typing import Any
 from opensquilla.channels.contract import (
     ChannelSendResult,
     channel_capability_profile,
+    classify_channel_send_error,
     normalize_channel_send_result,
 )
 from opensquilla.channels.types import IncomingMessage, OutgoingMessage
@@ -566,13 +567,17 @@ class ChannelDeliveryStore:
         return normalized
 
     def fail_send(self, send_id: str, error: BaseException) -> None:
+        # error_class carries the taxonomy value every consumer branches on
+        # (doctor's auth_invalid alert, the console's operator cause lines);
+        # the concrete exception type stays in error_message so nothing is
+        # lost for debugging.
         with self._lock:
             self._conn.execute(
                 "UPDATE channel_outbox SET state = 'unknown', error_class = ?, "
                 "error_message = ?, updated_at = ? WHERE send_id = ?",
                 (
-                    type(error).__name__,
-                    _safe_error_text(error),
+                    classify_channel_send_error(error),
+                    f"{type(error).__name__}: {_safe_error_text(error)}"[:2000],
                     time.time(),
                     send_id,
                 ),

--- a/src/opensquilla/http_retry.py
+++ b/src/opensquilla/http_retry.py
@@ -1,0 +1,55 @@
+"""Shared parsing for HTTP retry-pacing headers.
+
+Neutral ground: both the LLM provider layer and the chat-channel layer talk
+HTTP to third parties that pace them with ``Retry-After``, and neither should
+depend on the other to read a header. The parsing rules are RFC 9110's, not
+any one provider's.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+
+__all__ = ["parse_retry_after"]
+
+
+def parse_retry_after(
+    value: str | None,
+    *,
+    now_utc: datetime | None = None,
+) -> float | None:
+    """Parse a ``Retry-After`` header value into non-negative seconds.
+
+    Accepts both RFC 9110 forms: delta-seconds (``"120"``; fractional values
+    are tolerated) and HTTP-date (``"Wed, 21 Oct 2026 07:28:00 GMT"``, resolved
+    against ``now_utc`` — wall clock — at parse time so the caller can keep
+    working in relative/monotonic seconds afterwards). Returns ``None`` for a
+    missing, empty, negative, non-finite, or unparseable value; a past
+    HTTP-date parses to ``0.0``.
+
+    Callers are expected to cap the result: a hostile or broken header must
+    not park a deployment for hours.
+    """
+    if value is None:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        seconds = float(text)
+    except ValueError:
+        seconds = None
+    if seconds is not None:
+        if not math.isfinite(seconds) or seconds < 0:
+            return None
+        return seconds
+    try:
+        when = parsedate_to_datetime(text)
+    except (TypeError, ValueError):
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=UTC)
+    reference = now_utc if now_utc is not None else datetime.now(UTC)
+    return max(0.0, (when - reference).total_seconds())

--- a/src/opensquilla/provider/failures.py
+++ b/src/opensquilla/provider/failures.py
@@ -8,16 +8,14 @@ is a data change (a new matcher row), not a new branch.
 
 from __future__ import annotations
 
-import math
 import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
-from email.utils import parsedate_to_datetime
 from enum import StrEnum
 
 import structlog
 
+from opensquilla.http_retry import parse_retry_after
 from opensquilla.redaction import redact_error_text
 
 from .registry import UnknownProviderError, get_provider_spec
@@ -354,43 +352,6 @@ def classify_provider_error(
         message_head=redact_error_text(message),
     )
     return ProviderFailureKind.UNKNOWN
-
-
-def parse_retry_after(
-    value: str | None,
-    *,
-    now_utc: datetime | None = None,
-) -> float | None:
-    """Parse a ``Retry-After`` header value into non-negative seconds.
-
-    Accepts both RFC 9110 forms: delta-seconds (``"120"``; fractional values
-    are tolerated) and HTTP-date (``"Wed, 21 Oct 2026 07:28:00 GMT"``, resolved
-    against ``now_utc`` — wall clock — at parse time so the caller can keep
-    working in relative/monotonic seconds afterwards). Returns ``None`` for a
-    missing, empty, negative, non-finite, or unparseable value; a past
-    HTTP-date parses to ``0.0``.
-    """
-    if value is None:
-        return None
-    text = value.strip()
-    if not text:
-        return None
-    try:
-        seconds = float(text)
-    except ValueError:
-        seconds = None
-    if seconds is not None:
-        if not math.isfinite(seconds) or seconds < 0:
-            return None
-        return seconds
-    try:
-        when = parsedate_to_datetime(text)
-    except (TypeError, ValueError):
-        return None
-    if when.tzinfo is None:
-        when = when.replace(tzinfo=UTC)
-    reference = now_utc if now_utc is not None else datetime.now(UTC)
-    return max(0.0, (when - reference).total_seconds())
 
 
 def retry_after_from_headers(

--- a/tests/test_channels/test_channel_delivery_store.py
+++ b/tests/test_channels/test_channel_delivery_store.py
@@ -4,9 +4,11 @@ import sqlite3
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from opensquilla.channels.contract import (
+    UNCLASSIFIED_ERROR_CLASS,
     ChannelCapabilities,
     ChannelCapabilityProfile,
     ChannelSendResult,
@@ -366,7 +368,57 @@ async def test_outbox_only_wraps_declared_operations_and_redacts_failure(
 
     with sqlite3.connect(store.path) as connection:
         row = connection.execute(
-            "SELECT capability, state, error_message FROM channel_outbox"
+            "SELECT capability, state, error_class, error_message FROM channel_outbox"
         ).fetchone()
-    assert row == ("send_streaming", "unknown", "bot token=[REDACTED]")
+    capability, state, error_class, error_message = row
+    assert (capability, state) == ("send_streaming", "unknown")
+    # A bare RuntimeError carries no status, no retry hint, and no declared
+    # class, so it must park rather than be guessed into the taxonomy.
+    assert error_class == UNCLASSIFIED_ERROR_CLASS
+    # The credential stays redacted; the exception type is retained alongside
+    # it now that error_class carries the taxonomy value instead.
+    assert error_message == "RuntimeError: bot token=[REDACTED]"
+    assert "do-not-persist" not in error_message
+    store.close()
+
+
+def test_fail_send_persists_the_taxonomy_class_not_the_exception_type(tmp_path) -> None:
+    # The outbox's error_class column is what doctor alerts on and what the
+    # console renders operator cause lines from. Storing type(error).__name__
+    # ("HTTPStatusError") made it unusable for any decision.
+    store = ChannelDeliveryStore(tmp_path / "channel_delivery.sqlite")
+    request = httpx.Request("POST", "https://provider.example/send")
+    response = httpx.Response(401, request=request)
+
+    send_id = store.begin_send(
+        "slack-main",
+        OutgoingMessage(content="hi", reply_to="C1"),
+    )
+    store.fail_send(send_id, httpx.HTTPStatusError("nope", request=request, response=response))
+
+    with sqlite3.connect(store.path) as connection:
+        state, error_class, error_message = connection.execute(
+            "SELECT state, error_class, error_message FROM channel_outbox WHERE send_id = ?",
+            (send_id,),
+        ).fetchone()
+
+    assert state == "unknown"
+    assert error_class == "auth_invalid"
+    # The concrete type stays available for debugging rather than being lost.
+    assert "HTTPStatusError" in error_message
+    store.close()
+
+
+def test_fail_send_parks_an_unclassifiable_error_without_guessing(tmp_path) -> None:
+    store = ChannelDeliveryStore(tmp_path / "channel_delivery.sqlite")
+    send_id = store.begin_send("slack-main", OutgoingMessage(content="hi", reply_to="C1"))
+
+    store.fail_send(send_id, ValueError("something bespoke"))
+
+    with sqlite3.connect(store.path) as connection:
+        error_class = connection.execute(
+            "SELECT error_class FROM channel_outbox WHERE send_id = ?", (send_id,)
+        ).fetchone()[0]
+
+    assert error_class == UNCLASSIFIED_ERROR_CLASS
     store.close()

--- a/tests/test_channels/test_send_error_classification.py
+++ b/tests/test_channels/test_send_error_classification.py
@@ -1,0 +1,223 @@
+"""The single producer of the channel error taxonomy, and the retry loop.
+
+Every adapter declares the taxonomy verbatim and doctor/console consumers
+branch on it, so a misclassification is worse than no classification: it
+sends a confident wrong answer to code that acts on it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from opensquilla.channels._util import MAX_RETRY_AFTER_S, retry_request
+from opensquilla.channels.contract import (
+    ALL_ERROR_CLASSES,
+    REQUIRED_FATAL_ERROR_CLASSES,
+    REQUIRED_RETRYABLE_ERROR_CLASSES,
+    UNCLASSIFIED_ERROR_CLASS,
+    classify_channel_send_error,
+    classify_send_error_status,
+)
+
+
+def _response(status: int, headers: dict[str, str] | None = None) -> httpx.Response:
+    return httpx.Response(
+        status,
+        headers=headers or {},
+        request=httpx.Request("POST", "https://provider.example/send"),
+    )
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    response = _response(status)
+    return httpx.HTTPStatusError("boom", request=response.request, response=response)
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def test_unclassified_is_outside_both_taxonomy_halves() -> None:
+    # The whole point of the sentinel: retrying a permanent failure forever and
+    # discarding a recoverable one are both worse than parking for a human.
+    assert UNCLASSIFIED_ERROR_CLASS not in REQUIRED_RETRYABLE_ERROR_CLASSES
+    assert UNCLASSIFIED_ERROR_CLASS not in REQUIRED_FATAL_ERROR_CLASSES
+    assert UNCLASSIFIED_ERROR_CLASS not in ALL_ERROR_CLASSES
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (400, "payload_rejected"),
+        (401, "auth_invalid"),
+        (403, "auth_invalid"),
+        (404, "target_missing"),
+        (410, "target_missing"),
+        (413, "payload_rejected"),
+        (422, "payload_rejected"),
+        (429, "rate_limited"),
+        (500, "transport_transient"),
+        (502, "transport_transient"),
+        (503, "transport_transient"),
+        (504, "transport_transient"),
+    ],
+)
+def test_http_status_maps_onto_the_taxonomy(status: int, expected: str) -> None:
+    assert classify_send_error_status(status) == expected
+    assert classify_channel_send_error(_http_status_error(status)) == expected
+    assert expected in ALL_ERROR_CLASSES
+
+
+@pytest.mark.parametrize("status", [None, 200, 302, 418])
+def test_unmapped_status_is_never_guessed(status: int | None) -> None:
+    assert classify_send_error_status(status) == UNCLASSIFIED_ERROR_CLASS
+
+
+def test_transport_exceptions_are_transient() -> None:
+    for exc in (
+        httpx.ConnectError("refused"),
+        httpx.ReadTimeout("slow"),
+        httpx.ConnectTimeout("slow"),
+        httpx.RemoteProtocolError("garbled"),
+        TimeoutError(),
+        ConnectionError(),
+    ):
+        assert classify_channel_send_error(exc) == "transport_transient"
+
+
+def test_adapter_declared_class_wins_over_generic_rules() -> None:
+    # An adapter knows its provider's semantics better than any status map:
+    # a 403 that really means "message rejected" must stay the adapter's call.
+    class DeclaredError(Exception):
+        error_class = "payload_rejected"
+        response = _response(403)
+
+    assert classify_channel_send_error(DeclaredError()) == "payload_rejected"
+
+
+def test_declared_class_outside_the_taxonomy_is_not_trusted() -> None:
+    class RogueError(Exception):
+        error_class = "totally_made_up"
+
+    assert classify_channel_send_error(RogueError()) == UNCLASSIFIED_ERROR_CLASS
+
+
+def test_retry_after_hint_means_rate_limited() -> None:
+    class FloodWaitError(RuntimeError):
+        retry_after = 30
+
+    assert classify_channel_send_error(FloodWaitError()) == "rate_limited"
+
+
+def test_business_code_is_not_read_as_an_http_status() -> None:
+    # The trap: several providers number their own business errors in `code`.
+    # Reading 99991663 as an HTTP status would misclassify confidently, and a
+    # provider code that happens to equal 404 would invent target_missing.
+    class BusinessError(Exception):
+        def __init__(self, code: int) -> None:
+            self.code = code
+            super().__init__("api said no")
+
+    assert classify_channel_send_error(BusinessError(99991663)) == UNCLASSIFIED_ERROR_CLASS
+    assert classify_channel_send_error(BusinessError(404)) == UNCLASSIFIED_ERROR_CLASS
+
+
+def test_unrecognized_error_is_unclassified() -> None:
+    assert classify_channel_send_error(ValueError("?")) == UNCLASSIFIED_ERROR_CLASS
+
+
+# ---------------------------------------------------------------------------
+# retry_request
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def no_real_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    slept: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def _fake(delay: float) -> None:
+        slept.append(delay)
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", _fake)
+    return slept
+
+
+async def test_exhausted_429_returns_the_response_instead_of_destroying_it(
+    no_real_sleep: list[float],
+) -> None:
+    # Regression: the 429 branch lacked the `attempt < max_retries` guard the
+    # 5xx branch has, so it slept past the final attempt and fell out of the
+    # loop with last_exc unset — raising RuntimeError and discarding the
+    # provider's actual answer, which the caller needs to classify.
+    async def always_rate_limited() -> httpx.Response:
+        return _response(429, {"Retry-After": "5"})
+
+    resp = await retry_request(always_rate_limited, max_retries=2)
+
+    assert resp.status_code == 429
+    assert classify_channel_send_error(_http_status_error(resp.status_code)) == "rate_limited"
+    # Three attempts, but the last one must not sleep before giving up.
+    assert no_real_sleep == [5.0, 5.0]
+
+
+async def test_hostile_retry_after_cannot_park_the_channel_for_hours(
+    no_real_sleep: list[float],
+) -> None:
+    async def long_park() -> httpx.Response:
+        return _response(429, {"Retry-After": "3600"})
+
+    await retry_request(long_park, max_retries=1)
+
+    assert no_real_sleep == [MAX_RETRY_AFTER_S]
+
+
+async def test_http_date_retry_after_does_not_raise(no_real_sleep: list[float]) -> None:
+    # `float("Wed, 21 Oct ...")` raised ValueError straight out of the retry
+    # loop; RFC 9110 allows the HTTP-date form.
+    async def dated() -> httpx.Response:
+        return _response(429, {"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"})
+
+    resp = await retry_request(dated, max_retries=1)
+
+    assert resp.status_code == 429
+    assert no_real_sleep == [MAX_RETRY_AFTER_S]
+
+
+async def test_unparseable_retry_after_falls_back_to_backoff(
+    no_real_sleep: list[float],
+) -> None:
+    async def junk() -> httpx.Response:
+        return _response(429, {"Retry-After": "soon"})
+
+    await retry_request(junk, max_retries=1, base_delay=2.0)
+
+    assert no_real_sleep == [2.0]
+
+
+async def test_exhausted_5xx_still_returns_the_response(no_real_sleep: list[float]) -> None:
+    async def always_503() -> httpx.Response:
+        return _response(503)
+
+    resp = await retry_request(always_503, max_retries=1)
+
+    assert resp.status_code == 503
+
+
+async def test_success_after_a_retry_returns_the_success(no_real_sleep: list[float]) -> None:
+    calls = 0
+
+    async def flaky() -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return _response(200) if calls > 1 else _response(429, {"Retry-After": "1"})
+
+    resp = await retry_request(flaky, max_retries=3)
+
+    assert resp.status_code == 200
+    assert calls == 2


### PR DESCRIPTION
## Scope

Scope boundary: produce the channel error taxonomy that adapters already declare and consumers already branch on, and fix the rate-limit path of the shared HTTP retry loop. Backend only; no config, RPC, or UI contract change.

- `classify_channel_send_error()` in `channels/contract.py` — the single producer, next to the taxonomy it must satisfy. `fail_send` stores the taxonomy value instead of `type(error).__name__`; the concrete type moves into `error_message`.
- `retry_request` — three fixes on the 429 path (missing `attempt < max_retries` guard, uncapped `Retry-After`, HTTP-date `ValueError`).
- `parse_retry_after` extracted from `provider/failures.py` to a neutral `opensquilla/http_retry.py`, re-exported from its old home so existing callers are unchanged.

Non-goals: send-level retry and the delivery-failure notice (next PR, depends on this); a dead-target registry; adapter re-declarations.

## Branch

Base branch: integration/channel-platform

Target exception: maintainer-approved

## Issue

Linked issue: None

If None, reason: first item of a maintainer-requested deep review of the channel subsystem.

## Release Note

Release note: Channel send failures are now recorded with a meaningful cause (credentials rejected, rate limited, target missing, …) instead of an internal exception name, so health checks and the Channels console can explain a failed delivery. A rate-limited channel also no longer risks being parked for hours by a single `Retry-After` header, and a rate limit that survives every retry no longer discards the provider's response.

## Tests

Ruff: `uv run ruff check src tests` — All checks passed

Pytest: `uv run pytest -q --ignore=tests/integration/cli/tui_real_terminal` — 13400 passed, 5 failed. All 5 failures reproduce on the unmodified base branch (verified by stashing): sandbox-seatbelt, two experiment-script suites, and a workspace-write lever — none touch channels. The `tui_real_terminal` suite is excluded as it requires a working tmux pane and fails on base for the same reason.

Mypy: `uv run mypy src/opensquilla` — Success, no issues in 803 source files

Build: not affected (no Web UI change)

Regression tests: added

Notes: `tests/test_channels/test_send_error_classification.py` pins the classifier (including that a provider business `code` is never read as an HTTP status, and that an adapter-declared class outside the taxonomy is not trusted) and each of the three retry defects. `test_channel_delivery_store.py` pins that `fail_send` persists the taxonomy value while keeping the credential redacted.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: channel

## Safety

No secrets. The outbox's existing credential redaction is preserved and now additionally asserted; `error_message` gains the exception type only.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
