### PR TITLE
Do not lose the user's answer when a channel send fails

### DIFF
--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -17,6 +17,7 @@ import contextlib
 import inspect
 import json
 import re
+import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any, cast
 
@@ -46,7 +47,12 @@ from opensquilla.channels.artifact_delivery import (
 from opensquilla.channels.artifact_delivery import (
     strip_delivered_artifact_image_references as _strip_delivered_artifact_image_references,
 )
-from opensquilla.channels.contract import channel_capability_profile
+from opensquilla.channels.contract import (
+    REQUIRED_RETRYABLE_ERROR_CLASSES,
+    UNCLASSIFIED_ERROR_CLASS,
+    channel_capability_profile,
+    classify_channel_send_error,
+)
 from opensquilla.channels.stream_policy import resolve_channel_stream_policy
 from opensquilla.channels.types import IncomingMessage, OutgoingMessage
 from opensquilla.engine.start_turn import start_turn_via_runtime
@@ -2178,6 +2184,144 @@ def _build_runtime_reply_message(
     return _build_reply_message(channel, content, inbound)
 
 
+#: Attempts for a user-visible reply whose failure class can still succeed.
+#: Small on purpose: the answer is already computed, the user is waiting, and
+#: an unrecoverable channel should surface fast rather than stall the turn.
+_REPLY_SEND_ATTEMPTS: int = 3
+_REPLY_RETRY_BASE_DELAY_S: float = 1.0
+#: Same defensive ceiling the HTTP retry loop applies: a provider's pacing
+#: hint is honored, but cannot hold a finished answer hostage for hours.
+_REPLY_RETRY_MAX_DELAY_S: float = 60.0
+
+#: Failure classes where *any* send to this target fails, so a delivery-failure
+#: notice would fail identically — attempting one just burns another call.
+_REPLY_NOTICE_HOPELESS_CLASSES: frozenset[str] = frozenset(
+    {"auth_invalid", "target_missing"}
+)
+
+
+def _reply_retry_delay(error: BaseException, attempt: int) -> float:
+    """Backoff before re-sending a reply, honoring a provider pacing hint."""
+    hint = getattr(error, "retry_after", None)
+    if isinstance(hint, int | float) and not isinstance(hint, bool) and hint >= 0:
+        return min(float(hint), _REPLY_RETRY_MAX_DELAY_S)
+    backoff: float = _REPLY_RETRY_BASE_DELAY_S * (2**attempt)
+    return min(backoff, _REPLY_RETRY_MAX_DELAY_S)
+
+
+async def _send_channel_reply_guarded(
+    channel: Any,
+    message: OutgoingMessage,
+    *,
+    session_key: str,
+) -> str | None:
+    """Deliver a user-visible reply, surviving a provider send failure.
+
+    An unguarded send loses a fully-computed, already-paid-for answer: the
+    reply task dies, the outbox parks the row, and the user is left unable to
+    tell "still thinking" from "gone" — so they re-ask and buy the turn twice.
+
+    Retries are bounded and only for classes that can plausibly succeed later.
+    All attempts share one durable ``delivery_id`` so the outbox keeps a single
+    row per reply whose final state is the true outcome, rather than one row
+    per attempt.
+
+    Returns ``None`` on delivery, else the taxonomy class of the last failure.
+    """
+    metadata = dict(message.metadata or {})
+    metadata.setdefault("delivery_id", uuid.uuid4().hex)
+    message = message.model_copy(update={"metadata": metadata})
+
+    last_class = UNCLASSIFIED_ERROR_CLASS
+    for attempt in range(_REPLY_SEND_ATTEMPTS):
+        try:
+            await channel.send(message)
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:  # noqa: BLE001 - provider boundary
+            last_class = classify_channel_send_error(exc)
+            retryable = last_class in REQUIRED_RETRYABLE_ERROR_CLASSES
+            final = attempt == _REPLY_SEND_ATTEMPTS - 1
+            log.warning(
+                "channel_dispatch.reply_send_failed",
+                session_key=session_key,
+                error_class=last_class,
+                error_type=type(exc).__name__,
+                attempt=attempt,
+                will_retry=retryable and not final,
+            )
+            if not retryable or final:
+                return last_class
+            await asyncio.sleep(_reply_retry_delay(exc, attempt))
+            continue
+        else:
+            return None
+    return last_class
+
+
+async def _notify_channel_reply_lost(
+    channel: Any,
+    *,
+    route_envelope: Any,
+    session_key: str,
+    error_class: str,
+) -> None:
+    """Tell the user their answer exists but could not be delivered.
+
+    Best-effort by construction: this is itself a send on a channel that just
+    failed. It is skipped where every send to the target fails anyway, and it
+    never raises — a failed notice must not replace the failure it reports.
+    """
+    if error_class in _REPLY_NOTICE_HOPELESS_CLASSES:
+        return
+    try:
+        await channel.send(
+            _route_envelope_reply_message(
+                "I finished this reply but could not deliver it to this chat. "
+                "Ask again to have it re-sent, or check the gateway's channel "
+                "diagnostics if it keeps happening.",
+                route_envelope,
+                metadata={"delivery_failure_notice": True, "error_class": error_class},
+            )
+        )
+    except asyncio.CancelledError:
+        raise
+    except BaseException as exc:  # noqa: BLE001 - best effort by design
+        log.warning(
+            "channel_dispatch.reply_failure_notice_failed",
+            session_key=session_key,
+            error_class=error_class,
+            error_type=type(exc).__name__,
+        )
+
+
+async def _deliver_reply_or_notify(
+    channel: Any,
+    message: OutgoingMessage,
+    *,
+    route_envelope: Any,
+    session_key: str,
+) -> bool:
+    """Send a reply; on final failure tell the user rather than going silent."""
+    error_class = await _send_channel_reply_guarded(
+        channel, message, session_key=session_key
+    )
+    if error_class is None:
+        return True
+    log.error(
+        "channel_dispatch.reply_undelivered",
+        session_key=session_key,
+        error_class=error_class,
+    )
+    await _notify_channel_reply_lost(
+        channel,
+        route_envelope=route_envelope,
+        session_key=session_key,
+        error_class=error_class,
+    )
+    return False
+
+
 async def _deliver_runtime_channel_reply(
     *,
     channel: Any,
@@ -2257,13 +2401,16 @@ async def _deliver_runtime_channel_reply(
         content = _strip_delivered_artifact_image_references(content, artifacts)
         if _can_deliver_channel_files(channel):
             if content:
-                await channel.send(
+                await _deliver_reply_or_notify(
+                    channel,
                     _build_runtime_reply_message(
                         channel,
                         content,
                         inbound,
                         route_envelope,
-                    )
+                    ),
+                    route_envelope=route_envelope,
+                    session_key=session_key,
                 )
             undelivered = await _deliver_artifacts_as_channel_files(
                 channel,
@@ -2273,26 +2420,32 @@ async def _deliver_runtime_channel_reply(
             )
             fallback_lines = _artifact_fallback_lines(undelivered)
             if fallback_lines:
-                await channel.send(
+                await _deliver_reply_or_notify(
+                    channel,
                     _build_runtime_reply_message(
                         channel,
                         "\n".join(fallback_lines),
                         inbound,
                         route_envelope,
-                    )
+                    ),
+                    route_envelope=route_envelope,
+                    session_key=session_key,
                 )
         else:
             fallback_lines = _artifact_fallback_lines(artifacts)
             if fallback_lines:
                 content = "\n\n".join(part for part in (content, "\n".join(fallback_lines)) if part)
             if content:
-                await channel.send(
+                await _deliver_reply_or_notify(
+                    channel,
                     _build_runtime_reply_message(
                         channel,
                         content,
                         inbound,
                         route_envelope,
-                    )
+                    ),
+                    route_envelope=route_envelope,
+                    session_key=session_key,
                 )
 
 

--- a/tests/test_gateway/test_channel_reply_delivery_guard.py
+++ b/tests/test_gateway/test_channel_reply_delivery_guard.py
@@ -1,0 +1,164 @@
+"""A user-visible reply must survive — or explain — a provider send failure.
+
+Before the guard, ``_deliver_runtime_channel_reply`` did a bare
+``await channel.send(...)``: one raised exception killed the reply task and
+the user waited forever for an answer that was fully computed and paid for.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+
+from opensquilla.channels.types import OutgoingMessage
+from opensquilla.gateway.channel_dispatch import (
+    _REPLY_SEND_ATTEMPTS,
+    _deliver_reply_or_notify,
+    _send_channel_reply_guarded,
+)
+
+
+def _route() -> SimpleNamespace:
+    return SimpleNamespace(channel_id="chat-1", thread_id=None, channel_name="slack-main")
+
+
+def _http_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://p.example/send")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError("x", request=request, response=response)
+
+
+class _Channel:
+    """Records every send; fails the first ``fail_times`` with ``error``."""
+
+    def __init__(self, *, fail_times: int = 0, error: BaseException | None = None) -> None:
+        self.sent: list[OutgoingMessage] = []
+        self._fail_times = fail_times
+        self._error = error or _http_error(503)
+
+    async def send(self, message: OutgoingMessage) -> None:
+        self.sent.append(message)
+        if len(self.sent) <= self._fail_times:
+            raise self._error
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _instant(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("opensquilla.gateway.channel_dispatch.asyncio.sleep", _instant)
+
+
+async def test_delivered_first_try_returns_none() -> None:
+    channel = _Channel()
+    result = await _send_channel_reply_guarded(
+        channel, OutgoingMessage(content="hi", reply_to="chat-1"), session_key="s"
+    )
+    assert result is None
+    assert len(channel.sent) == 1
+
+
+async def test_transient_failure_is_retried_then_succeeds() -> None:
+    channel = _Channel(fail_times=2, error=_http_error(503))
+    result = await _send_channel_reply_guarded(
+        channel, OutgoingMessage(content="hi", reply_to="chat-1"), session_key="s"
+    )
+    assert result is None
+    assert len(channel.sent) == 3
+
+
+async def test_all_attempts_share_one_delivery_id() -> None:
+    # The outbox keys a row on delivery_id; retrying without a stable id would
+    # spray one row per attempt. Stamp it once and every attempt reuses it.
+    channel = _Channel(fail_times=_REPLY_SEND_ATTEMPTS, error=_http_error(503))
+    await _send_channel_reply_guarded(
+        channel, OutgoingMessage(content="hi", reply_to="chat-1"), session_key="s"
+    )
+    ids = {m.metadata.get("delivery_id") for m in channel.sent}
+    assert len(channel.sent) == _REPLY_SEND_ATTEMPTS
+    assert len(ids) == 1 and next(iter(ids))
+
+
+async def test_fatal_failure_is_not_retried() -> None:
+    # A 401 will fail identically on every attempt; retrying just stalls the
+    # turn. Surface it after one try.
+    channel = _Channel(fail_times=99, error=_http_error(401))
+    result = await _send_channel_reply_guarded(
+        channel, OutgoingMessage(content="hi", reply_to="chat-1"), session_key="s"
+    )
+    assert result == "auth_invalid"
+    assert len(channel.sent) == 1
+
+
+async def test_exhausted_retries_return_the_failure_class() -> None:
+    channel = _Channel(fail_times=99, error=_http_error(503))
+    result = await _send_channel_reply_guarded(
+        channel, OutgoingMessage(content="hi", reply_to="chat-1"), session_key="s"
+    )
+    assert result == "transport_transient"
+    assert len(channel.sent) == _REPLY_SEND_ATTEMPTS
+
+
+async def test_on_final_loss_the_user_gets_a_delivery_notice() -> None:
+    # A recoverable-looking class that never recovers: the reply is lost, but
+    # the user is told it exists rather than left in silence.
+    channel = _Channel(fail_times=99, error=_http_error(503))
+    delivered = await _deliver_reply_or_notify(
+        channel,
+        OutgoingMessage(content="the answer", reply_to="chat-1"),
+        route_envelope=_route(),
+        session_key="s",
+    )
+    assert delivered is False
+    # attempts for the reply, plus exactly one notice send.
+    notices = [m for m in channel.sent if m.metadata.get("delivery_failure_notice")]
+    assert len(notices) == 1
+
+
+async def test_no_notice_when_every_send_to_the_target_is_hopeless() -> None:
+    # target_missing: a notice would fail identically, so don't burn the call.
+    channel = _Channel(fail_times=99, error=_http_error(404))
+    delivered = await _deliver_reply_or_notify(
+        channel,
+        OutgoingMessage(content="the answer", reply_to="chat-1"),
+        route_envelope=_route(),
+        session_key="s",
+    )
+    assert delivered is False
+    assert not any(m.metadata.get("delivery_failure_notice") for m in channel.sent)
+
+
+async def test_a_failing_notice_never_masks_the_original_failure() -> None:
+    class _AlwaysFails:
+        def __init__(self) -> None:
+            self.sent: list[Any] = []
+
+        async def send(self, message: OutgoingMessage) -> None:
+            self.sent.append(message)
+            raise _http_error(503)
+
+    channel = _AlwaysFails()
+    # Must not raise even though the notice send also fails.
+    delivered = await _deliver_reply_or_notify(
+        channel,
+        OutgoingMessage(content="x", reply_to="chat-1"),
+        route_envelope=_route(),
+        session_key="s",
+    )
+    assert delivered is False
+
+
+async def test_success_after_notice_path_is_never_reached_on_delivery() -> None:
+    channel = _Channel()
+    delivered = await _deliver_reply_or_notify(
+        channel,
+        OutgoingMessage(content="hi", reply_to="chat-1"),
+        route_envelope=_route(),
+        session_key="s",
+    )
+    assert delivered is True
+    assert not any(m.metadata.get("delivery_failure_notice") for m in channel.sent)


### PR DESCRIPTION
## Scope

Scope boundary: make the user-visible channel reply survive — or explain — a provider send failure. The runtime reply path did an unguarded `await channel.send(...)`; a raised exception killed the reply task and the user was left with silence. Every reply send now routes through one guard: bounded retry for retryable classes (honoring a capped `retry_after`), a single shared `delivery_id` across attempts so the outbox keeps one row per reply, and a delivery-failure notice on final loss (skipped where a notice would fail identically, and itself best-effort). Backend only; depends on #693 (the classifier decides what is worth retrying).

Non-goals: a plain-text re-render fallback — `OutgoingMessage` has no format field so it is not generically expressible; provider-rejected formatting is the length-cap / render-hint work tracked separately in the deep review. Streaming and artifact-upload fallbacks already exist and are unchanged.

## Branch

Base branch: integration/channel-platform

Target exception: maintainer-approved

## Issue

Linked issue: None

If None, reason: second item of the maintainer-requested channel deep review; stacked on #693.

## Release Note

Release note: When a channel provider fails to deliver a computed reply, the gateway now retries recoverable failures with backoff and, if it still cannot deliver, tells the user their answer exists but could not be sent instead of leaving them in silence — so a transient hiccup no longer silently costs a full turn.

## Tests

Ruff: `uv run ruff check src tests` — All checks passed

Pytest: `uv run pytest tests/test_gateway/ tests/test_channels/ -q` — 2487 passed. New `test_channel_reply_delivery_guard.py` (9 tests) covers: delivered first try, transient retry-then-succeed, one shared delivery_id across attempts, fatal class not retried, exhaustion returns the class, notice on final loss, no-notice for hopeless classes, a failing notice never masking the original failure.

Mypy: `uv run mypy src/opensquilla` — Success, no issues in 803 source files

Build: not affected (no Web UI change)

Regression tests: added

Notes: the guard is pure send-path plumbing; the wider gateway+channels suites (2487 tests) pass unchanged.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: channel

## Safety

No secrets. The delivery-failure notice contains no message content — only a fixed prompt to ask again.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
