### PR TITLE
Fit channel replies to each platform's length cap and counting unit

### DIFF
--- a/src/opensquilla/channels/_util.py
+++ b/src/opensquilla/channels/_util.py
@@ -20,6 +20,7 @@ from typing import Any, Literal
 import httpx
 import structlog
 
+from opensquilla.channels.contract import ChannelLengthUnit
 from opensquilla.http_retry import parse_retry_after
 
 log = structlog.get_logger(__name__)
@@ -344,36 +345,108 @@ async def retry_request(
     raise last_exc or RuntimeError("retry_request exhausted")
 
 
-def split_text_for_channel(text: str, limit: int) -> list[str]:
-    """Split ``text`` into chunks no longer than ``limit`` characters.
+def _measure_for(unit: ChannelLengthUnit) -> Callable[[str], int]:
+    if unit is ChannelLengthUnit.UTF8_BYTES:
+        return lambda s: len(s.encode("utf-8"))
+    if unit is ChannelLengthUnit.UTF16_UNITS:
+        return lambda s: len(s.encode("utf-16-le")) // 2
+    return len
+
+
+def measured_len(text: str, unit: ChannelLengthUnit = ChannelLengthUnit.CODE_POINTS) -> int:
+    """Length of ``text`` in the unit the platform counts in."""
+    return _measure_for(unit)(text)
+
+
+def _fit_cut(text: str, limit: int, measure: Callable[[str], int]) -> int:
+    """Largest code-point index whose measured prefix length is ``<= limit``.
+
+    Bisection over the code-point index — O(log n) measures. The index is a
+    Python string index, so an astral code point (emoji) is atomic: a prefix
+    either includes it whole or not at all, never a half surrogate.
+    """
+    lo, hi = 0, len(text)
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if measure(text[:mid]) <= limit:
+            lo = mid
+        else:
+            hi = mid - 1
+    # Always make progress even if a single leading code point exceeds limit.
+    return max(lo, 1)
+
+
+def _boundary_before(text: str, cut: int) -> int:
+    """Preferred split index in ``[0, cut)``: paragraph, then line, then word.
+
+    Returns the index just past the chosen separator so it stays with the
+    preceding chunk, or 0 when no boundary exists (caller hard-splits at cut).
+    """
+    paragraph_at = text.rfind("\n\n", 0, cut)
+    if paragraph_at >= 0:
+        return paragraph_at + 2
+    line_at = text.rfind("\n", 0, cut)
+    if line_at >= 0:
+        return line_at + 1
+    word_at = text.rfind(" ", 0, cut)
+    return word_at + 1 if word_at >= 0 else 0
+
+
+def split_text_for_channel(
+    text: str,
+    limit: int,
+    *,
+    unit: ChannelLengthUnit = ChannelLengthUnit.CODE_POINTS,
+) -> list[str]:
+    """Split ``text`` into chunks no longer than ``limit`` in ``unit``.
 
     Splitting prefers paragraph (blank-line) then line then word boundaries,
     hard-splitting only as a last resort for a single token longer than
     ``limit``. Used to keep outbound replies under a platform's per-message
-    length cap (Telegram 4096, Discord 2000, ...) instead of letting the API
-    reject the whole message. An empty ``text`` yields ``[""]`` so callers
-    always make at least one send; a non-positive ``limit`` disables splitting.
+    length cap (Telegram 4096 UTF-16 units, Discord 2000 code points, ...)
+    instead of letting the API reject the whole message. An empty ``text``
+    yields ``[""]`` so callers always make at least one send; a non-positive
+    ``limit`` disables splitting.
+
+    ``unit`` measures the fit test only; boundary search stays at code-point
+    granularity, so an astral character is never split mid-surrogate.
     """
-    if limit <= 0 or len(text) <= limit:
+    measure = _measure_for(unit)
+    if limit <= 0 or measure(text) <= limit:
         return [text]
 
     chunks: list[str] = []
     remaining = text
-    while len(remaining) > limit:
-        # Include the chosen separator in the preceding chunk. Splitting via
-        # ``str.split`` and reconstructing later loses blank lines/spaces when
-        # a boundary itself triggers a flush.
-        paragraph_at = remaining.rfind("\n\n", 0, limit)
-        if paragraph_at >= 0:
-            end = paragraph_at + 2
-        else:
-            line_at = remaining.rfind("\n", 0, limit)
-            if line_at >= 0:
-                end = line_at + 1
-            else:
-                word_at = remaining.rfind(" ", 0, limit)
-                end = word_at + 1 if word_at >= 0 else limit
+    while measure(remaining) > limit:
+        cut = _fit_cut(remaining, limit, measure)
+        end = _boundary_before(remaining, cut) or cut
         chunks.append(remaining[:end])
         remaining = remaining[end:]
     chunks.append(remaining)
     return chunks
+
+
+_TRUNCATE_FOOTER = "\n\n[message truncated to fit this channel's length limit]"
+
+
+def truncate_to_limit(
+    text: str,
+    limit: int,
+    *,
+    unit: ChannelLengthUnit = ChannelLengthUnit.CODE_POINTS,
+    footer: str = _TRUNCATE_FOOTER,
+) -> str:
+    """Cut ``text`` to ``limit`` in ``unit``, appending a footer when it fits.
+
+    The last resort for a single unsplittable unit that still overflows: a
+    delivered-but-truncated message beats a platform-rejected one.
+    """
+    measure = _measure_for(unit)
+    if measure(text) <= limit:
+        return text
+    budget = limit - measure(footer)
+    if budget <= 0:
+        return text[: _fit_cut(text, limit, measure)]
+    cut = _fit_cut(text, budget, measure)
+    end = _boundary_before(text, cut) or cut
+    return text[:end] + footer

--- a/src/opensquilla/channels/contract.py
+++ b/src/opensquilla/channels/contract.py
@@ -283,6 +283,20 @@ class ChannelSendResult:
         return self.status == ChannelSendStatus.SENT
 
 
+class ChannelLengthUnit(StrEnum):
+    """The unit a platform counts a message's length in.
+
+    A code-point cap measured in the wrong unit silently drops replies: an
+    emoji is two UTF-16 units and up to four UTF-8 bytes, so a reply that
+    looks in-budget by ``len()`` is rejected wholesale by a byte- or
+    UTF-16-counting provider.
+    """
+
+    CODE_POINTS = "code_points"  # Python len()
+    UTF8_BYTES = "utf8_bytes"  # len(s.encode("utf-8"))
+    UTF16_UNITS = "utf16_units"  # len(s.encode("utf-16-le")) // 2
+
+
 @dataclass(frozen=True)
 class ChannelCapabilityProfile:
     """Minimal typed capability declaration for channel adapters."""
@@ -313,6 +327,17 @@ class ChannelCapabilityProfile:
     artifact_delivery: bool = False
     transports: tuple[str, ...] = ()
     notes: tuple[str, ...] = ()
+    #: Per-message outbound length cap in ``length_unit``. 0 (default) means no
+    #: central cap is declared, so central chunk-or-truncate is skipped for this
+    #: channel — the safe passthrough for local transports with no platform cap.
+    max_message_len: int = 0
+    #: Unit ``max_message_len`` is measured in.
+    length_unit: ChannelLengthUnit = ChannelLengthUnit.CODE_POINTS
+    #: True when the adapter already splits over-length text inside its own
+    #: ``send()``; central dispatch must skip it to avoid double-processing.
+    #: Defaults False so an adapter that declares a cap but forgets to split
+    #: degrades to central handling rather than shipping over-cap messages.
+    splits_natively: bool = False
 
     def capability_tags(self) -> frozenset[str]:
         tags: set[str] = set()

--- a/src/opensquilla/channels/dingtalk.py
+++ b/src/opensquilla/channels/dingtalk.py
@@ -31,6 +31,7 @@ from pydantic import BaseModel, Field
 from opensquilla.channels._util import EventDedupeCache
 from opensquilla.channels.contract import (
     ChannelCapabilityProfile,
+    ChannelLengthUnit,
     ChannelPlatformCapability,
     ChannelPlatformCapabilityStatus,
     ChannelPlatformCategories,
@@ -162,6 +163,9 @@ class DingTalkChannel:
     def capability_profile(self) -> ChannelCapabilityProfile:
         return ChannelCapabilityProfile(
             channel_type="dingtalk",
+            max_message_len=16000,
+            length_unit=ChannelLengthUnit.UTF8_BYTES,
+            splits_natively=False,
             group_chat=True,
             mentions=True,
             reply=True,

--- a/src/opensquilla/channels/discord.py
+++ b/src/opensquilla/channels/discord.py
@@ -35,6 +35,7 @@ from opensquilla.channels._util import (
 from opensquilla.channels.contract import (
     ChannelCapabilities,
     ChannelCapabilityProfile,
+    ChannelLengthUnit,
     ChannelPlatformCapability,
     ChannelPlatformCapabilityStatus,
     ChannelPlatformCategories,
@@ -166,6 +167,9 @@ class DiscordChannel:
     def capability_profile(self) -> ChannelCapabilityProfile:
         return ChannelCapabilityProfile(
             channel_type="discord",
+            max_message_len=2000,
+            length_unit=ChannelLengthUnit.CODE_POINTS,
+            splits_natively=True,
             group_chat=True,
             mentions=True,
             typing_indicator=True,

--- a/src/opensquilla/channels/feishu.py
+++ b/src/opensquilla/channels/feishu.py
@@ -42,6 +42,7 @@ from opensquilla.channels._util import (
 from opensquilla.channels.contract import (
     ChannelCapabilities,
     ChannelCapabilityProfile,
+    ChannelLengthUnit,
     ChannelPlatformManifest,
     ChannelSendResult,
 )
@@ -768,6 +769,9 @@ class FeishuChannel:
     def capability_profile(self) -> ChannelCapabilityProfile:
         return ChannelCapabilityProfile(
             channel_type="feishu",
+            max_message_len=4000,
+            length_unit=ChannelLengthUnit.UTF8_BYTES,
+            splits_natively=False,
             group_chat=True,
             mentions=True,
             native_file_upload=True,

--- a/src/opensquilla/channels/matrix.py
+++ b/src/opensquilla/channels/matrix.py
@@ -48,6 +48,7 @@ from opensquilla.channels._util import EventDedupeCache
 from opensquilla.channels.contract import (
     ChannelCapabilities,
     ChannelCapabilityProfile,
+    ChannelLengthUnit,
     ChannelPlatformCapability,
     ChannelPlatformCapabilityStatus,
     ChannelPlatformCategories,
@@ -141,6 +142,9 @@ class MatrixChannel:
     def capability_profile(self) -> ChannelCapabilityProfile:
         return ChannelCapabilityProfile(
             channel_type="matrix",
+            max_message_len=20000,
+            length_unit=ChannelLengthUnit.UTF8_BYTES,
+            splits_natively=False,
             group_chat=True,
             mentions=True,
             native_file_upload=True,

--- a/src/opensquilla/channels/msteams.py
+++ b/src/opensquilla/channels/msteams.py
@@ -37,6 +37,7 @@ from starlette.routing import Route
 from opensquilla.channels._util import ChannelAccessPolicy, EventDedupeCache
 from opensquilla.channels.contract import (
     ChannelCapabilityProfile,
+    ChannelLengthUnit,
     ChannelPlatformCapability,
     ChannelPlatformCapabilityStatus,
     ChannelPlatformCategories,
@@ -130,6 +131,9 @@ class MSTeamsChannel:
     def capability_profile(self) -> ChannelCapabilityProfile:
         return ChannelCapabilityProfile(
             channel_type="msteams",
+            max_message_len=20000,
+            length_unit=ChannelLengthUnit.CODE_POINTS,
+            splits_natively=False,
             group_chat=True,
             mentions=True,
             reply=True,

--- a/src/opensquilla/channels/qq.py
+++ b/src/opensquilla/channels/qq.py
@@ -31,6 +31,7 @@ from pydantic import BaseModel
 from opensquilla.channels._util import EventDedupeCache
 from opensquilla.channels.contract import (
     ChannelCapabilityProfile,
+    ChannelLengthUnit,
     ChannelPlatformCapability,
     ChannelPlatformCapabilityStatus,
     ChannelPlatformCategories,
@@ -181,6 +182,9 @@ class QQChannel(_QQClientBase):  # type: ignore[misc, valid-type]
     def capability_profile(self) -> ChannelCapabilityProfile:
         return ChannelCapabilityProfile(
             channel_type="qq",
+            max_message_len=2000,
+            length_unit=ChannelLengthUnit.CODE_POINTS,
+            splits_natively=False,
             group_chat=True,
             mentions=True,
             reply=True,

--- a/src/opensquilla/channels/slack.py
+++ b/src/opensquilla/channels/slack.py
@@ -31,6 +31,7 @@ from opensquilla.channels._util import (
 from opensquilla.channels.contract import (
     ChannelCapabilities,
     ChannelCapabilityProfile,
+    ChannelLengthUnit,
     ChannelPlatformCapability,
     ChannelPlatformCapabilityStatus,
     ChannelPlatformCategories,
@@ -138,6 +139,9 @@ class SlackChannel:
     def capability_profile(self) -> ChannelCapabilityProfile:
         return ChannelCapabilityProfile(
             channel_type="slack",
+            max_message_len=40000,
+            length_unit=ChannelLengthUnit.CODE_POINTS,
+            splits_natively=True,
             group_chat=True,
             mentions=True,
             native_file_upload=True,

--- a/src/opensquilla/channels/telegram.py
+++ b/src/opensquilla/channels/telegram.py
@@ -29,6 +29,7 @@ from opensquilla.channels._util import (
 from opensquilla.channels.contract import (
     ChannelCapabilities,
     ChannelCapabilityProfile,
+    ChannelLengthUnit,
     ChannelPlatformCapability,
     ChannelPlatformCapabilityStatus,
     ChannelPlatformCategories,
@@ -154,6 +155,9 @@ class TelegramChannel:
     def capability_profile(self) -> ChannelCapabilityProfile:
         return ChannelCapabilityProfile(
             channel_type="telegram",
+            max_message_len=4096,
+            length_unit=ChannelLengthUnit.UTF16_UNITS,
+            splits_natively=True,
             group_chat=True,
             mentions=True,
             native_file_upload=True,
@@ -635,7 +639,14 @@ class TelegramChannel:
         # Telegram hard-rejects sendMessage when text exceeds 4096 chars, which
         # would otherwise drop the entire reply. Split long content into
         # sequential messages so the full answer is delivered.
-        chunks = split_text_for_channel(message.content, _TELEGRAM_MAX_MESSAGE_CHARS)
+        # Telegram counts the 4096 cap in UTF-16 code units, not code points:
+        # an astral char (emoji, some CJK) is two units, so a code-point split
+        # can still overflow and be rejected. Measure in the unit Telegram uses.
+        chunks = split_text_for_channel(
+            message.content,
+            _TELEGRAM_MAX_MESSAGE_CHARS,
+            unit=ChannelLengthUnit.UTF16_UNITS,
+        )
         result: Any = None
         for chunk in chunks:
             payload = self._build_send_payload(message)

--- a/src/opensquilla/channels/wecom.py
+++ b/src/opensquilla/channels/wecom.py
@@ -37,6 +37,7 @@ from opensquilla.channels._wecom_crypto import WeComCrypto
 from opensquilla.channels.contract import (
     ChannelCapabilities,
     ChannelCapabilityProfile,
+    ChannelLengthUnit,
     ChannelPlatformCapability,
     ChannelPlatformCapabilityStatus,
     ChannelPlatformCategories,
@@ -195,6 +196,9 @@ class WeComChannel:
         if self.config.connection_mode == "websocket":
             return ChannelCapabilityProfile(
                 channel_type="wecom",
+                max_message_len=2048,
+                length_unit=ChannelLengthUnit.UTF8_BYTES,
+                splits_natively=False,
                 group_chat=True,
                 mentions=True,
                 reply=True,
@@ -206,6 +210,9 @@ class WeComChannel:
             )
         return ChannelCapabilityProfile(
             channel_type="wecom",
+            max_message_len=2048,
+            length_unit=ChannelLengthUnit.UTF8_BYTES,
+            splits_natively=False,
             group_chat=True,
             mentions=True,
             native_file_upload=True,

--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -25,6 +25,11 @@ import structlog
 
 from opensquilla.agents.scope import resolve_agent_model
 from opensquilla.artifacts import artifact_payload
+from opensquilla.channels._util import (
+    measured_len,
+    split_text_for_channel,
+    truncate_to_limit,
+)
 from opensquilla.channels.admission import (
     ChannelAdmissionDecision,
     decide_channel_admission,
@@ -2295,6 +2300,56 @@ async def _notify_channel_reply_lost(
         )
 
 
+def _plan_outbound_pieces(channel: Any, message: OutgoingMessage) -> list[OutgoingMessage]:
+    """Split a reply to fit the channel's declared length cap.
+
+    A reply over a platform's per-message cap is rejected wholesale, and six
+    adapters declare no cap and pass content straight through. This is the one
+    place that enforces the capability contract's length budget centrally, in
+    the unit the platform counts in. Adapters that split inside their own
+    ``send()`` opt out via ``splits_natively`` and are returned unchanged.
+
+    Chunking is preferred; a single unsplittable unit that still overflows is
+    truncated with a footer — delivered-but-clipped beats platform-rejected.
+    """
+    profile = channel_capability_profile(channel)
+    if profile is None or profile.max_message_len <= 0 or profile.splits_natively:
+        return [message]
+    unit = profile.length_unit
+    limit = profile.max_message_len
+    content = message.content or ""
+    if measured_len(content, unit) <= limit:
+        return [message]
+
+    pieces: list[OutgoingMessage] = []
+    for idx, chunk in enumerate(split_text_for_channel(content, limit, unit=unit)):
+        if measured_len(chunk, unit) > limit:
+            chunk = truncate_to_limit(chunk, limit, unit=unit)
+        pieces.append(_as_chunk_message(message, chunk, first=idx == 0))
+    return pieces
+
+
+def _as_chunk_message(
+    message: OutgoingMessage, chunk: str, *, first: bool
+) -> OutgoingMessage:
+    """A one-chunk copy of ``message`` with a fresh outbox identity.
+
+    The delivery id is dropped so the outbox mints a distinct one per chunk —
+    otherwise ``begin_send``'s INSERT-OR-IGNORE collapses every chunk into a
+    single row and the last receipt wins. Attachments ride only the first
+    chunk so a long reply's files are not re-sent per piece.
+    """
+    metadata = dict(message.metadata or {})
+    metadata.pop("delivery_id", None)
+    return message.model_copy(
+        update={
+            "content": chunk,
+            "metadata": metadata,
+            "attachments": message.attachments if first else [],
+        }
+    )
+
+
 async def _deliver_reply_or_notify(
     channel: Any,
     message: OutgoingMessage,
@@ -2303,9 +2358,13 @@ async def _deliver_reply_or_notify(
     session_key: str,
 ) -> bool:
     """Send a reply; on final failure tell the user rather than going silent."""
-    error_class = await _send_channel_reply_guarded(
-        channel, message, session_key=session_key
-    )
+    error_class: str | None = None
+    for piece in _plan_outbound_pieces(channel, message):
+        error_class = await _send_channel_reply_guarded(
+            channel, piece, session_key=session_key
+        )
+        if error_class is not None:
+            break
     if error_class is None:
         return True
     log.error(

--- a/tests/test_channels/test_util_length.py
+++ b/tests/test_channels/test_util_length.py
@@ -1,0 +1,104 @@
+"""Unit-aware length measurement, splitting, and truncation.
+
+A cap measured in the wrong unit drops replies: our users send emoji-heavy
+Telegram chat (UTF-16) and CJK Feishu/WeCom traffic (UTF-8 bytes), both of
+which look in-budget by ``len()`` and are rejected by the provider.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from opensquilla.channels._util import (
+    measured_len,
+    split_text_for_channel,
+    truncate_to_limit,
+)
+from opensquilla.channels.contract import ChannelLengthUnit as U
+
+
+def _utf16(text: str) -> int:
+    return len(text.encode("utf-16-le")) // 2
+
+
+@pytest.mark.parametrize(
+    ("text", "unit", "expected"),
+    [
+        ("a" * 10, U.CODE_POINTS, 10),
+        ("a" * 10, U.UTF8_BYTES, 10),
+        ("a" * 10, U.UTF16_UNITS, 10),
+        ("字" * 10, U.CODE_POINTS, 10),
+        ("字" * 10, U.UTF8_BYTES, 30),
+        ("字" * 10, U.UTF16_UNITS, 10),
+        ("🎉" * 10, U.CODE_POINTS, 10),
+        ("🎉" * 10, U.UTF8_BYTES, 40),
+        ("🎉" * 10, U.UTF16_UNITS, 20),
+    ],
+)
+def test_measured_len_counts_in_the_declared_unit(text: str, unit: U, expected: int) -> None:
+    assert measured_len(text, unit) == expected
+
+
+def test_telegram_emoji_splits_by_utf16_units() -> None:
+    # 🎉×3000 is 3000 code points but 6000 UTF-16 units — in budget by len(),
+    # rejected wholesale by Telegram. Splitting in UTF-16 keeps every chunk
+    # under the 4096-unit cap.
+    text = "🎉" * 3000
+    chunks = split_text_for_channel(text, 4096, unit=U.UTF16_UNITS)
+    assert "".join(chunks) == text
+    assert len(chunks) >= 2
+    assert all(_utf16(chunk) <= 4096 for chunk in chunks)
+    # No half-surrogate: each chunk round-trips through UTF-16 cleanly.
+    for chunk in chunks:
+        assert chunk.encode("utf-16-le").decode("utf-16-le") == chunk
+
+
+def test_wecom_cjk_splits_by_utf8_bytes() -> None:
+    # 字×1000 is 1000 code points but 3000 UTF-8 bytes — over WeCom's 2048-byte
+    # cap while looking fine by len().
+    text = "字" * 1000
+    chunks = split_text_for_channel(text, 2048, unit=U.UTF8_BYTES)
+    assert "".join(chunks) == text
+    assert len(chunks) >= 2
+    assert all(len(chunk.encode("utf-8")) <= 2048 for chunk in chunks)
+
+
+def test_default_unit_is_backward_compatible() -> None:
+    # The 3 native-splitter callers pass no unit; behavior must be unchanged.
+    assert split_text_for_channel("a b c", 100) == ["a b c"]
+    assert split_text_for_channel("", 100) == [""]
+    assert split_text_for_channel("x" * 10, 0) == ["x" * 10]
+    # Paragraph boundary preferred, separator kept with the preceding chunk.
+    text = "para one\n\npara two that is quite long"
+    chunks = split_text_for_channel(text, 12)
+    assert "".join(chunks) == text
+    assert all(len(chunk) <= 12 for chunk in chunks)
+
+
+def test_split_prefers_boundaries_then_hard_splits() -> None:
+    # A single over-long token with no interior boundary is hard-split.
+    token = "x" * 50
+    chunks = split_text_for_channel(token, 10)
+    assert "".join(chunks) == token
+    assert all(len(chunk) <= 10 for chunk in chunks)
+    assert len(chunks) == 5
+
+
+def test_truncate_appends_a_footer_within_budget() -> None:
+    text = "字" * 1000
+    result = truncate_to_limit(text, 100, unit=U.UTF8_BYTES)
+    assert len(result.encode("utf-8")) <= 100
+    assert "truncated" in result
+    assert result.startswith("字")
+
+
+def test_truncate_without_footer_when_footer_alone_overflows() -> None:
+    # A cap smaller than the footer must still produce a within-cap result.
+    text = "hello world this is long"
+    result = truncate_to_limit(text, 5, unit=U.CODE_POINTS)
+    assert len(result) <= 5
+    assert "truncated" not in result
+
+
+def test_truncate_is_a_noop_when_already_within_limit() -> None:
+    assert truncate_to_limit("short", 100, unit=U.CODE_POINTS) == "short"

--- a/tests/test_gateway/test_channel_dispatch_chunking.py
+++ b/tests/test_gateway/test_channel_dispatch_chunking.py
@@ -1,0 +1,147 @@
+"""A reply over the channel's per-message cap is split before it is sent.
+
+Providers reject an over-length message wholesale, so the whole answer is
+lost. The dispatcher enforces each channel's declared cap centrally — in the
+unit that channel counts in — and splits or, as a last resort, truncates.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from opensquilla.channels.contract import (
+    ChannelCapabilityProfile,
+    ChannelLengthUnit,
+)
+from opensquilla.channels.types import Attachment, OutgoingMessage
+from opensquilla.gateway.channel_dispatch import (
+    _as_chunk_message,
+    _deliver_reply_or_notify,
+    _plan_outbound_pieces,
+)
+
+
+def _route() -> SimpleNamespace:
+    return SimpleNamespace(channel_id="chat-1", thread_id=None, channel_name="probe")
+
+
+class _Channel:
+    """Declares a capability profile and records every send."""
+
+    def __init__(self, profile: ChannelCapabilityProfile | None) -> None:
+        self._profile = profile
+        self.sent: list[OutgoingMessage] = []
+
+    def capability_profile(self) -> ChannelCapabilityProfile | None:
+        return self._profile
+
+    async def send(self, message: OutgoingMessage) -> None:
+        self.sent.append(message)
+
+
+def _profile(**kwargs: object) -> ChannelCapabilityProfile:
+    return ChannelCapabilityProfile(channel_type="probe", **kwargs)  # type: ignore[arg-type]
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _instant(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("opensquilla.gateway.channel_dispatch.asyncio.sleep", _instant)
+
+
+def test_in_budget_reply_is_sent_whole() -> None:
+    channel = _Channel(_profile(max_message_len=100))
+    pieces = _plan_outbound_pieces(channel, OutgoingMessage(content="hi", reply_to="chat-1"))
+    assert len(pieces) == 1
+    assert pieces[0].content == "hi"
+
+
+def test_no_profile_passes_the_message_through() -> None:
+    channel = _Channel(None)
+    pieces = _plan_outbound_pieces(channel, OutgoingMessage(content="x" * 999, reply_to="c"))
+    assert len(pieces) == 1
+
+
+def test_zero_cap_means_unbounded_passthrough() -> None:
+    channel = _Channel(_profile(max_message_len=0))
+    pieces = _plan_outbound_pieces(channel, OutgoingMessage(content="x" * 999, reply_to="c"))
+    assert len(pieces) == 1
+
+
+def test_native_splitter_is_left_untouched() -> None:
+    # An adapter that splits inside its own send() opts out; splitting here too
+    # would double-split.
+    channel = _Channel(_profile(max_message_len=10, splits_natively=True))
+    pieces = _plan_outbound_pieces(channel, OutgoingMessage(content="x" * 50, reply_to="c"))
+    assert len(pieces) == 1
+
+
+def test_over_cap_reply_is_split_by_utf16_units() -> None:
+    channel = _Channel(
+        _profile(max_message_len=4096, length_unit=ChannelLengthUnit.UTF16_UNITS)
+    )
+    text = "🎉" * 3000  # 6000 UTF-16 units
+    pieces = _plan_outbound_pieces(channel, OutgoingMessage(content=text, reply_to="c"))
+    assert len(pieces) >= 2
+    assert "".join(p.content for p in pieces) == text
+    assert all(len(p.content.encode("utf-16-le")) // 2 <= 4096 for p in pieces)
+
+
+def test_over_cap_reply_is_split_by_utf8_bytes() -> None:
+    channel = _Channel(
+        _profile(max_message_len=2048, length_unit=ChannelLengthUnit.UTF8_BYTES)
+    )
+    text = "字" * 1000  # 3000 UTF-8 bytes
+    pieces = _plan_outbound_pieces(channel, OutgoingMessage(content=text, reply_to="c"))
+    assert len(pieces) >= 2
+    assert "".join(p.content for p in pieces) == text
+    assert all(len(p.content.encode("utf-8")) <= 2048 for p in pieces)
+
+
+def test_each_chunk_gets_a_distinct_delivery_id() -> None:
+    # The outbox keys a row on delivery_id via INSERT-OR-IGNORE; if chunks
+    # shared one id, every chunk after the first would collapse into one row
+    # and the last receipt would win. Each chunk must mint a fresh id.
+    original = OutgoingMessage(
+        content="body", reply_to="c", metadata={"delivery_id": "shared-123"}
+    )
+    a = _as_chunk_message(original, "chunk-a", first=True)
+    b = _as_chunk_message(original, "chunk-b", first=False)
+    # The stamped id is dropped so the send guard mints a distinct one per chunk.
+    assert "delivery_id" not in a.metadata
+    assert "delivery_id" not in b.metadata
+    assert original.metadata["delivery_id"] == "shared-123"  # original untouched
+
+
+def test_attachments_ride_only_the_first_chunk() -> None:
+    attachment = Attachment(name="a.txt", url="file://a")
+    original = OutgoingMessage(
+        content="x" * 50, reply_to="c", attachments=[attachment]
+    )
+    first = _as_chunk_message(original, "part 1", first=True)
+    rest = _as_chunk_message(original, "part 2", first=False)
+    assert first.attachments == [attachment]
+    assert rest.attachments == []
+
+
+async def test_every_chunk_is_delivered_end_to_end() -> None:
+    channel = _Channel(
+        _profile(max_message_len=2048, length_unit=ChannelLengthUnit.UTF8_BYTES)
+    )
+    text = "字" * 1000
+    delivered = await _deliver_reply_or_notify(
+        channel,
+        OutgoingMessage(content=text, reply_to="chat-1"),
+        route_envelope=_route(),
+        session_key="s",
+    )
+    assert delivered is True
+    assert len(channel.sent) >= 2
+    assert "".join(m.content for m in channel.sent) == text
+    # Distinct outbox identity per chunk.
+    ids = [m.metadata.get("delivery_id") for m in channel.sent]
+    assert len(set(ids)) == len(ids)


### PR DESCRIPTION
## Scope

Enforce each channel's per-message length cap centrally, in the unit that platform actually counts in, so long replies are chunked (or, as a last resort, truncated) instead of rejected wholesale.

Two gaps this closes:

- **Six adapters declared no length handling** — WeCom, Matrix, Feishu, DingTalk, QQ, MS Teams passed content straight to the provider, so an over-cap reply on those channels was dropped with no recovery.
- **Wrong counting unit** — adapters that did split counted code points, but Telegram enforces its 4096 cap in UTF-16 code units (an emoji is two units) and byte-counting platforms (WeCom/Matrix/Feishu/DingTalk) in UTF-8 bytes (a CJK char is three). A reply in budget by `len()` still overflowed and was rejected.

Changes:
- `ChannelCapabilityProfile` gains `max_message_len`, `length_unit` (`code_points` / `utf8_bytes` / `utf16_units`), and `splits_natively`. All default to a no-op passthrough, so channels that declare nothing behave exactly as before.
- `_util.split_text_for_channel` / new `measured_len` / `truncate_to_limit` measure the fit test in the declared unit while keeping boundary search at code-point granularity (never cuts an astral char mid-surrogate).
- One central chunk-or-truncate step in reply dispatch (`_plan_outbound_pieces`). Adapters that split inside their own `send()` (Telegram, Discord, Slack) opt out via `splits_natively` to avoid double-processing; each chunk mints a fresh `delivery_id` so the outbox keeps one row per chunk rather than collapsing them under `INSERT OR IGNORE`.
- Telegram's own splitter now measures in UTF-16 units.

## Branch target

`integration/channel-platform` (channel-platform integration line; **not** `main`).

## Linked issue

Refs #659

## Release note

Channel replies that exceed a platform's per-message limit are now split to fit — measured in the unit each platform counts in (UTF-16 units for Telegram, UTF-8 bytes for WeCom/Matrix/Feishu/DingTalk) — instead of being rejected and lost. Adapters with no declared limit are unaffected.

## Tests

- New `tests/test_channels/test_util_length.py` (unit-aware measure/split/truncate, emoji UTF-16 + CJK UTF-8 cases, backward-compat defaults).
- New `tests/test_gateway/test_channel_dispatch_chunking.py` (plan/passthrough/native-opt-out, distinct delivery_id per chunk, attachments only on first chunk, end-to-end delivery).
- `uv run ruff check src tests` — clean.
- `uv run mypy src/opensquilla` — clean (803 files).
- `uv run pytest tests/test_channels tests/test_gateway/test_channel_dispatch_realtime.py tests/test_gateway/test_channel_dispatch_chunking.py tests/test_gateway/test_channel_reply_delivery_guard.py tests/test_gateway/test_rpc_channels.py tests/test_provider_capability_profiles.py` — 531 passed.

## Safety notes

No new external calls, credentials, or trust decisions. The new profile fields default to a passthrough (`max_message_len=0`), so unconfigured channels keep current behavior; truncation only ever removes text from an already-over-cap message and labels it.

## Third-party origin

None — original work.