### PR TITLE
Persist admission reasons and surface explain-why channel diagnostics

### DIFF
--- a/src/opensquilla/channels/delivery_store.py
+++ b/src/opensquilla/channels/delivery_store.py
@@ -150,6 +150,7 @@ class ChannelDeliveryStore:
                     message_json    TEXT NOT NULL,
                     state           TEXT NOT NULL,
                     disposition     TEXT NOT NULL DEFAULT '',
+                    reason          TEXT NOT NULL DEFAULT '',
                     claim_token     TEXT,
                     claim_started_at REAL,
                     attempts        INTEGER NOT NULL DEFAULT 0,
@@ -210,6 +211,7 @@ class ChannelDeliveryStore:
                 """
             )
             self._migrate_pairing_columns()
+            self._migrate_ingress_columns()
             self._conn.commit()
 
     def _migrate_pairing_columns(self) -> None:
@@ -223,7 +225,29 @@ class ChannelDeliveryStore:
             str(row["name"]) for row in self._conn.execute("PRAGMA table_info(channel_pairings)")
         }
         if "reply_to" not in existing:
-            self._conn.execute("ALTER TABLE channel_pairings ADD COLUMN reply_to TEXT")
+            self._add_column("channel_pairings", "reply_to TEXT")
+
+    def _migrate_ingress_columns(self) -> None:
+        """Add ingress columns introduced after the table shipped."""
+        existing = {
+            str(row["name"]) for row in self._conn.execute("PRAGMA table_info(channel_ingress)")
+        }
+        if "reason" not in existing:
+            self._add_column("channel_ingress", "reason TEXT NOT NULL DEFAULT ''")
+
+    def _add_column(self, table: str, column_ddl: str) -> None:
+        """ALTER-in a column, tolerating a concurrent opener winning the race.
+
+        The PRAGMA check and the ALTER are separate autocommit statements, so
+        two processes first-opening an un-migrated database can both see the
+        column missing; the loser's ALTER must read as "already migrated", not
+        crash its startup.
+        """
+        try:
+            self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {column_ddl}")
+        except sqlite3.OperationalError as exc:
+            if "duplicate column" not in str(exc).lower():
+                raise
 
     @staticmethod
     def _pairing_from_row(row: sqlite3.Row) -> ChannelPairing:
@@ -434,18 +458,26 @@ class ChannelDeliveryStore:
         claim: IngressClaim | None,
         disposition: str,
         *,
+        reason: str = "",
         scrub_payload: bool = False,
     ) -> None:
+        """Finalize a claimed inbound event.
+
+        ``reason`` carries the admission reason code so operators can later ask
+        *why* a message was denied (or on what basis it was admitted) — a
+        reason code only, never a sender identity.
+        """
         if claim is None or not claim.event_key:
             return
         with self._lock:
             self._conn.execute(
-                "UPDATE channel_ingress SET state = 'completed', disposition = ?, "
+                "UPDATE channel_ingress SET state = 'completed', disposition = ?, reason = ?, "
                 "message_json = CASE WHEN ? THEN '{}' ELSE message_json END, "
                 "claim_token = NULL, claim_started_at = NULL, updated_at = ? "
                 "WHERE event_key = ? AND claim_token = ?",
                 (
                     disposition,
+                    reason,
                     1 if scrub_payload else 0,
                     time.time(),
                     claim.event_key,
@@ -626,6 +658,32 @@ class ChannelDeliveryStore:
                 }
                 for row in leases
             ],
+        }
+
+    def admission_reason_counts(self, channel_name: str) -> dict[str, dict[str, Any]]:
+        """Per-reason admission tallies: ``{reason: {count, first_at, last_at}}``.
+
+        Tallies span the store's whole lifetime; ``first_at`` lets consumers
+        label that horizon so old denials are not mistaken for a live condition
+        under the current policy. Aggregate counts and timestamps only — reason
+        codes carry no sender identity, so this is safe to surface in operator
+        diagnostics verbatim.
+        """
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT reason, COUNT(*) AS count, "
+                "MIN(updated_at) AS first_at, MAX(updated_at) AS last_at "
+                "FROM channel_ingress WHERE channel_name = ? AND reason != '' "
+                "GROUP BY reason",
+                (channel_name,),
+            ).fetchall()
+        return {
+            str(row["reason"]): {
+                "count": int(row["count"]),
+                "first_at": float(row["first_at"]),
+                "last_at": float(row["last_at"]),
+            }
+            for row in rows
         }
 
     def acquire_transport_lease(

--- a/src/opensquilla/cli/doctor_cmd.py
+++ b/src/opensquilla/cli/doctor_cmd.py
@@ -429,7 +429,7 @@ def _impact_text(finding: dict[str, Any]) -> str:
     return labels[_impact_value(finding)]
 
 
-def _summary_from_impact_counts(impact_counts: dict[str, int]) -> str:
+def _summary_from_impact_counts(impact_counts: dict[str, int], *, attention_count: int = 0) -> str:
     parts: list[str] = []
     if impact_counts["blocks_ready"]:
         label = "action" if impact_counts["blocks_ready"] == 1 else "actions"
@@ -443,8 +443,17 @@ def _summary_from_impact_counts(impact_counts: dict[str, int]) -> str:
     if parts:
         return ", ".join(parts)
     if impact_counts["optional"]:
-        label = "item" if impact_counts["optional"] == 1 else "items"
-        return f"Ready, {impact_counts['optional']} optional setup {label}"
+        # Mirrors health/model.py: an optional-impact warn is an operator
+        # action item, not a setup suggestion.
+        setup_count = impact_counts["optional"] - attention_count
+        segments: list[str] = []
+        if attention_count:
+            label = "item" if attention_count == 1 else "items"
+            segments.append(f"{attention_count} {label} awaiting operator action")
+        if setup_count:
+            label = "item" if setup_count == 1 else "items"
+            segments.append(f"{setup_count} optional setup {label}")
+        return "Ready, " + ", ".join(segments)
     return "Ready"
 
 
@@ -458,6 +467,7 @@ def _same_config_path(left: str, right: str) -> bool:
 def _refresh_report_readiness(report: dict[str, Any]) -> None:
     counts = {"error": 0, "warn": 0, "info": 0, "ok": 0}
     impact_counts = {"blocks_ready": 0, "degrades": 0, "optional": 0, "none": 0}
+    attention_count = 0
     findings = list(report.get("findings") or [])
     for finding in findings:
         severity = str(finding.get("severity") or "info")
@@ -465,6 +475,8 @@ def _refresh_report_readiness(report: dict[str, Any]) -> None:
             severity = "info"
         counts[severity] += 1
         impact_counts[_impact_value(finding)] += 1
+        if severity == "warn" and _impact_value(finding) == "optional":
+            attention_count += 1
     severity_rank = {"error": 0, "warn": 1, "info": 2, "ok": 3}
     impact_rank = {"blocks_ready": 0, "degrades": 1, "optional": 2, "none": 3}
     ordered_findings = sorted(
@@ -482,7 +494,7 @@ def _refresh_report_readiness(report: dict[str, Any]) -> None:
         "degraded" if impact_counts["degrades"] else "ready"
     )
     report["ready"] = impact_counts["blocks_ready"] == 0
-    report["summary"] = _summary_from_impact_counts(impact_counts)
+    report["summary"] = _summary_from_impact_counts(impact_counts, attention_count=attention_count)
 
 
 def _apply_requested_config_context(

--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -457,6 +457,7 @@ async def run_channel_dispatch(
                 delivery_store.complete_inbound(
                     ingress_claim,
                     "admission_denied",
+                    reason=admission.reason,
                     scrub_payload=True,
                 )
             continue
@@ -472,7 +473,9 @@ async def run_channel_dispatch(
         if approval_reply is not None:
             await channel.send(_preserve_route_channel_metadata(approval_reply, route_envelope))
             if delivery_store is not None:
-                delivery_store.complete_inbound(ingress_claim, "approval_resolved")
+                delivery_store.complete_inbound(
+                    ingress_claim, "approval_resolved", reason=admission.reason
+                )
             continue
         # fmt: off
         if getattr(channel, "supports_slash_commands", False) and rpc_dispatcher is not None and channel_rpc_context_factory is not None:  # noqa: E501
@@ -490,7 +493,9 @@ async def run_channel_dispatch(
                 emit(event, command=command_reply.metadata.get("command"), method=command_reply.metadata.get("method"), session_key=session_key)  # noqa: E501
                 await channel.send(command_reply)
                 if delivery_store is not None:
-                    delivery_store.complete_inbound(ingress_claim, "command_dispatched")
+                    delivery_store.complete_inbound(
+                        ingress_claim, "command_dispatched", reason=admission.reason
+                    )
                 continue
         # fmt: on
 
@@ -578,7 +583,9 @@ async def run_channel_dispatch(
                 )
                 await status_reactor.completed(msg)
                 if delivery_store is not None:
-                    delivery_store.complete_inbound(ingress_claim, "capacity_rejected")
+                    delivery_store.complete_inbound(
+                        ingress_claim, "capacity_rejected", reason=admission.reason
+                    )
                 continue
 
             transcript_watermark = await _transcript_watermark(session_manager, session_key)
@@ -645,7 +652,9 @@ async def run_channel_dispatch(
                     )
                 )
                 if delivery_store is not None:
-                    delivery_store.complete_inbound(ingress_claim, "queue_rejected")
+                    delivery_store.complete_inbound(
+                        ingress_claim, "queue_rejected", reason=admission.reason
+                    )
             else:
                 await status_reactor.running(msg)
 
@@ -715,7 +724,9 @@ async def run_channel_dispatch(
 
                 reply_task.add_done_callback(_reply_done)
                 if delivery_store is not None:
-                    delivery_store.complete_inbound(ingress_claim, "turn_dispatched")
+                    delivery_store.complete_inbound(
+                        ingress_claim, "turn_dispatched", reason=admission.reason
+                    )
             continue
 
         # Gap 3: Start typing indicator (background task)
@@ -749,7 +760,9 @@ async def run_channel_dispatch(
                 "turn_complete",
             )
         if delivery_store is not None:
-            delivery_store.complete_inbound(ingress_claim, "turn_completed")
+            delivery_store.complete_inbound(
+                ingress_claim, "turn_completed", reason=admission.reason
+            )
 
 
 def _slash_command_head(content: str) -> str | None:

--- a/src/opensquilla/gateway/rpc_channels.py
+++ b/src/opensquilla/gateway/rpc_channels.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import structlog
 
+from opensquilla.channels._util import ChannelAccessPolicy
 from opensquilla.channels.contract import (
     channel_capability_evidence,
     channel_capability_profile,
@@ -126,6 +127,7 @@ def _diagnostics_payload(
     extra: dict[str, Any] | None = None,
     start_error: Any = None,
     delivery: dict[str, Any] | None = None,
+    admission: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {"network_probe": "not_run"}
     last_error = _diagnostic_from_start_error(start_error)
@@ -137,6 +139,8 @@ def _diagnostics_payload(
         payload["transport_lease"] = dict(extra["transport_lease"])
     if delivery is not None:
         payload["delivery"] = delivery
+    if admission is not None:
+        payload["admission"] = admission
     return payload
 
 
@@ -150,6 +154,72 @@ def _delivery_diagnostics(manager: Any | None, name: str) -> dict[str, Any] | No
     except Exception:
         return None
     return result if isinstance(result, dict) else None
+
+
+# The admission vocabulary's admit outcomes; every other reason is a denial.
+_ADMISSION_ADMIT_REASONS = frozenset({"dm_admitted", "group_admitted"})
+
+
+def _admission_diagnostics(manager: Any | None, name: str, adapter: Any) -> dict[str, Any] | None:
+    """Explain-why facts for a channel: policy mode + per-reason tallies.
+
+    Answers the operator question "why did that message not create a session?"
+    with the effective access mode and denial reason codes/counts — never a
+    sender identity. Absent entirely when there is nothing to explain (no
+    running adapter and no recorded decisions).
+    """
+    payload: dict[str, Any] = {}
+    if adapter is not None:
+        policy = getattr(adapter, "policy", None)
+        if not isinstance(policy, ChannelAccessPolicy):
+            # Admission treats a missing/foreign policy as the default policy,
+            # so the effective mode shown here must do the same.
+            policy = ChannelAccessPolicy()
+        payload["dmAccess"] = str(policy.dm_access)
+        payload["allowlist"] = {
+            "configured": bool(policy.allowlist),
+            "entryCount": len(policy.allowlist),
+            "blankEntryCount": sum(1 for e in policy.allowlist if not str(e).strip()),
+        }
+    store = getattr(manager, "_delivery_store", None)
+    counts_fn = getattr(store, "admission_reason_counts", None)
+    if callable(counts_fn):
+        try:
+            tallies = counts_fn(name)
+        except Exception:
+            tallies = None
+        if isinstance(tallies, dict) and tallies:
+            payload["reasons"] = {
+                reason: {
+                    "count": int(entry.get("count", 0)),
+                    "lastAt": _iso_timestamp(entry.get("last_at")),
+                }
+                for reason, entry in tallies.items()
+                if isinstance(entry, dict)
+            }
+            # Tallies are lifetime, not current-policy: label the horizon so a
+            # months-old denial under a since-changed policy reads as history.
+            first_ats = [
+                float(entry["first_at"])
+                for entry in tallies.values()
+                if isinstance(entry, dict) and isinstance(entry.get("first_at"), int | float)
+            ]
+            if first_ats:
+                payload["since"] = _iso_timestamp(min(first_ats))
+            denials: list[tuple[str, float]] = []
+            for reason, entry in tallies.items():
+                if not isinstance(entry, dict) or reason in _ADMISSION_ADMIT_REASONS:
+                    continue
+                last_at = entry.get("last_at")
+                if isinstance(last_at, int | float):
+                    denials.append((reason, float(last_at)))
+            if denials:
+                last_reason, last_denied_at = max(denials, key=lambda item: item[1])
+                payload["lastDenial"] = {
+                    "reason": last_reason,
+                    "at": _iso_timestamp(last_denied_at),
+                }
+    return payload or None
 
 
 def _pairing_store(ctx: RpcContext) -> Any:
@@ -289,6 +359,7 @@ async def _handle_channels_status(params: dict | None, ctx: RpcContext) -> dict[
                     extra=extra,
                     start_error=start_errors.get(name),
                     delivery=_delivery_diagnostics(ctx.channel_manager, name),
+                    admission=_admission_diagnostics(ctx.channel_manager, name, adapter),
                 ),
             }
         )
@@ -325,6 +396,7 @@ async def _handle_channels_status(params: dict | None, ctx: RpcContext) -> dict[
                     extra=extra,
                     start_error=start_errors.get(name),
                     delivery=_delivery_diagnostics(ctx.channel_manager, name),
+                    admission=_admission_diagnostics(ctx.channel_manager, name, adapter),
                 ),
             }
         )

--- a/src/opensquilla/health/evaluator.py
+++ b/src/opensquilla/health/evaluator.py
@@ -91,6 +91,26 @@ def _channel_last_error(row: dict[str, Any]) -> dict[str, Any] | None:
     return last_error if isinstance(last_error, dict) else None
 
 
+def _channel_outbox_unknown(row: dict[str, Any]) -> dict[str, Any] | None:
+    """The outbox 'unknown' bucket for a channel row, if it has entries."""
+    diagnostics = row.get("diagnostics")
+    if not isinstance(diagnostics, dict):
+        return None
+    delivery = diagnostics.get("delivery")
+    if not isinstance(delivery, dict):
+        return None
+    outbox = delivery.get("outbox")
+    if not isinstance(outbox, dict):
+        return None
+    unknown = outbox.get("unknown")
+    if not isinstance(unknown, dict):
+        return None
+    count = unknown.get("count")
+    if not isinstance(count, int) or isinstance(count, bool) or count <= 0:
+        return None
+    return unknown
+
+
 def evaluate_provider(payload: dict[str, Any]) -> list[HealthFinding]:
     raw_rows = payload.get("providers")
     if not isinstance(raw_rows, list):
@@ -1469,6 +1489,90 @@ def evaluate_channels(payload: dict[str, Any]) -> list[HealthFinding]:
                         FixStep(
                             label="Restart channel",
                             command=f"opensquilla channels restart {name_arg} --yes",
+                        ),
+                    ],
+                )
+            )
+        # Action items ride alongside the status finding: a connected channel
+        # can still be silently gating senders or losing replies, and "ready"
+        # must not paper over either.
+        pending_pairings = row.get("pendingPairings")
+        if (
+            isinstance(pending_pairings, int)
+            and not isinstance(pending_pairings, bool)
+            and pending_pairings > 0
+        ):
+            findings.append(
+                HealthFinding(
+                    id=f"channel.{name}.pending_pairings",
+                    severity="warn",
+                    # Awaiting a human decision, not a malfunction: surface it
+                    # without downgrading overall readiness.
+                    readiness_impact="optional",
+                    surface="channels",
+                    title=f"Channel {name} has pairing requests awaiting approval",
+                    detail=(
+                        f"{pending_pairings} sender(s) asked to pair and were told to "
+                        "wait for operator approval. Until someone approves or revokes "
+                        "the requests, their messages get no replies."
+                    ),
+                    evidence={
+                        "name": name,
+                        "channelName": name,
+                        "pendingPairings": pending_pairings,
+                    },
+                    fix_steps=[
+                        FixStep(
+                            label="Review pending pairings",
+                            detail=(
+                                "Open the control console Channels page and approve "
+                                "or revoke the pending requests."
+                            ),
+                        ),
+                        FixStep(
+                            label="Inspect channels",
+                            command=f"opensquilla channels status {name_arg} --json",
+                        ),
+                    ],
+                )
+            )
+        outbox_unknown = _channel_outbox_unknown(row)
+        if outbox_unknown is not None:
+            unknown_count = int(outbox_unknown["count"])
+            findings.append(
+                HealthFinding(
+                    id=f"channel.{name}.sends_unknown_outcome",
+                    severity="warn",
+                    # Unknown-outcome rows are terminal until a human resolves
+                    # them; letting them degrade readiness would flag the
+                    # channel forever after a single lost send.
+                    readiness_impact="optional",
+                    surface="channels",
+                    title=f"Channel {name} has sends with unknown outcome",
+                    detail=(
+                        f"{unknown_count} outbound send(s) raised mid-delivery, so "
+                        "whether they reached the recipient is unknown. These rows "
+                        "are kept for a human decision; nothing retries them "
+                        "automatically."
+                    ),
+                    evidence={
+                        "name": name,
+                        "channelName": name,
+                        "unknownSends": unknown_count,
+                        "oldestAt": outbox_unknown.get("oldest_at"),
+                    },
+                    fix_steps=[
+                        FixStep(
+                            label="Inspect channels",
+                            command=f"opensquilla channels status {name_arg} --json",
+                        ),
+                        FixStep(
+                            label="Confirm delivery with the recipient",
+                            detail=(
+                                "Check the conversation on the provider side; the "
+                                "outbox diagnostics carry an error class per "
+                                "affected send."
+                            ),
                         ),
                     ],
                 )

--- a/src/opensquilla/health/model.py
+++ b/src/opensquilla/health/model.py
@@ -81,7 +81,7 @@ def _readiness_impact(finding: HealthFinding) -> ReadinessImpact:
     return finding.readiness_impact or _DEFAULT_IMPACT_BY_SEVERITY[finding.severity]
 
 
-def _summary(impact_counts: dict[ReadinessImpact, int]) -> str:
+def _summary(impact_counts: dict[ReadinessImpact, int], *, attention_count: int = 0) -> str:
     parts: list[str] = []
     if impact_counts["blocks_ready"]:
         label = "action" if impact_counts["blocks_ready"] == 1 else "actions"
@@ -95,8 +95,18 @@ def _summary(impact_counts: dict[ReadinessImpact, int]) -> str:
     if parts:
         return ", ".join(parts)
     if impact_counts["optional"]:
-        label = "item" if impact_counts["optional"] == 1 else "items"
-        return f"Ready, {impact_counts['optional']} optional setup {label}"
+        # An optional-impact warn is an operator action item (senders waiting
+        # on approval, sends needing confirmation) — calling it a "setup item"
+        # would mislabel work someone is actively blocked on.
+        setup_count = impact_counts["optional"] - attention_count
+        segments: list[str] = []
+        if attention_count:
+            label = "item" if attention_count == 1 else "items"
+            segments.append(f"{attention_count} {label} awaiting operator action")
+        if setup_count:
+            label = "item" if setup_count == 1 else "items"
+            segments.append(f"{setup_count} optional setup {label}")
+        return "Ready, " + ", ".join(segments)
     return "Ready"
 
 
@@ -112,9 +122,12 @@ def _status(impact_counts: dict[ReadinessImpact, int]) -> HealthStatus:
 def build_report(findings: list[HealthFinding]) -> dict[str, Any]:
     counts: dict[HealthSeverity, int] = {key: 0 for key in _COUNT_KEYS}
     impact_counts: dict[ReadinessImpact, int] = {key: 0 for key in _IMPACT_KEYS}
+    attention_count = 0
     for finding in findings:
         counts[finding.severity] += 1
         impact_counts[_readiness_impact(finding)] += 1
+        if finding.severity == "warn" and _readiness_impact(finding) == "optional":
+            attention_count += 1
     status = _status(impact_counts)
     ordered_findings = sorted(
         enumerate(findings),
@@ -127,7 +140,7 @@ def build_report(findings: list[HealthFinding]) -> dict[str, Any]:
     return {
         "status": status,
         "ready": impact_counts["blocks_ready"] == 0,
-        "summary": _summary(impact_counts),
+        "summary": _summary(impact_counts, attention_count=attention_count),
         "counts": counts,
         "impactCounts": impact_counts,
         "findings": [finding.to_dict() for _, finding in ordered_findings],

--- a/tests/test_channels/test_admission_reason_persistence.py
+++ b/tests/test_channels/test_admission_reason_persistence.py
@@ -1,0 +1,146 @@
+"""Persisting the admission reason so operators can ask "why was this denied?".
+
+The admission decision is computed on every inbound message and was retained
+nowhere: a denied sender saw silence and the operator had no record of the
+reason. The ingress row now keeps the reason code — never a sender identity —
+and the store can aggregate per-reason tallies for diagnostics.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from opensquilla.channels.delivery_store import ChannelDeliveryStore
+from opensquilla.channels.types import (
+    IncomingMessage,
+    IngressProvenance,
+    IngressVerification,
+)
+
+
+def _message(event_id: str) -> IncomingMessage:
+    return IncomingMessage(
+        sender_id="user-1",
+        channel_id="chat-1",
+        content="hello",
+        metadata={"is_group": False, "native_message_id": event_id},
+        provenance=IngressProvenance(
+            provider="slack",
+            account_id="acct-1",
+            event_id=event_id,
+            verification=IngressVerification.WEBHOOK_SIGNATURE,
+        ),
+    )
+
+
+def _complete(store: ChannelDeliveryStore, event_id: str, disposition: str, reason: str) -> None:
+    message = _message(event_id)
+    assert store.accept_inbound("slack-main", message) is True
+    claim = store.claim_inbound("slack-main", message)
+    assert claim is not None
+    store.complete_inbound(claim, disposition, reason=reason)
+
+
+def test_complete_inbound_persists_the_reason_code(tmp_path: Path) -> None:
+    store = ChannelDeliveryStore(tmp_path / "delivery.sqlite")
+    _complete(store, "event-1", "admission_denied", "not_in_allowlist")
+    with sqlite3.connect(store.path) as connection:
+        row = connection.execute("SELECT disposition, reason FROM channel_ingress").fetchone()
+    assert row == ("admission_denied", "not_in_allowlist")
+    store.close()
+
+
+def test_reason_defaults_to_empty_for_callers_that_do_not_pass_one(tmp_path: Path) -> None:
+    store = ChannelDeliveryStore(tmp_path / "delivery.sqlite")
+    _complete(store, "event-1", "turn_completed", "")
+    with sqlite3.connect(store.path) as connection:
+        row = connection.execute("SELECT reason FROM channel_ingress").fetchone()
+    assert row == ("",)
+    assert store.admission_reason_counts("slack-main") == {}
+    store.close()
+
+
+def test_admission_reason_counts_aggregates_per_reason(tmp_path: Path) -> None:
+    store = ChannelDeliveryStore(tmp_path / "delivery.sqlite")
+    _complete(store, "event-1", "admission_denied", "pairing_required")
+    _complete(store, "event-2", "admission_denied", "pairing_required")
+    _complete(store, "event-3", "admission_denied", "not_in_allowlist")
+    _complete(store, "event-4", "turn_dispatched", "dm_admitted")
+
+    counts = store.admission_reason_counts("slack-main")
+
+    assert counts["pairing_required"]["count"] == 2
+    assert counts["not_in_allowlist"]["count"] == 1
+    assert counts["dm_admitted"]["count"] == 1
+    for entry in counts.values():
+        assert isinstance(entry["last_at"], float)
+        # first_at labels the tally horizon for consumers.
+        assert isinstance(entry["first_at"], float)
+        assert entry["first_at"] <= entry["last_at"]
+    # Scoped per channel: another channel sees nothing.
+    assert store.admission_reason_counts("other-channel") == {}
+    store.close()
+
+
+def test_reason_column_is_added_to_a_store_created_before_it_existed(tmp_path: Path) -> None:
+    # CREATE TABLE IF NOT EXISTS is a no-op on an existing database, so a
+    # database from an older release lacks the column until the guarded
+    # ALTER runs. Recreate that world with the pre-reason DDL.
+    path = tmp_path / "delivery.sqlite"
+    with sqlite3.connect(path) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE channel_ingress (
+                event_key       TEXT PRIMARY KEY,
+                channel_name    TEXT NOT NULL,
+                account_id      TEXT NOT NULL,
+                lane_key        TEXT NOT NULL,
+                message_json    TEXT NOT NULL,
+                state           TEXT NOT NULL,
+                disposition     TEXT NOT NULL DEFAULT '',
+                claim_token     TEXT,
+                claim_started_at REAL,
+                attempts        INTEGER NOT NULL DEFAULT 0,
+                last_error      TEXT NOT NULL DEFAULT '',
+                accepted_at     REAL NOT NULL,
+                updated_at      REAL NOT NULL
+            );
+            INSERT INTO channel_ingress (
+                event_key, channel_name, account_id, lane_key, message_json,
+                state, disposition, accepted_at, updated_at
+            ) VALUES (
+                'slack:acct-1:legacy-1', 'slack-main', 'acct-1', 'chat-1:user-1',
+                '{}', 'completed', 'turn_completed', 1.0, 1.0
+            );
+            """
+        )
+
+    store = ChannelDeliveryStore(path)
+    # Legacy rows read back with the default; new writes carry a reason.
+    with sqlite3.connect(store.path) as connection:
+        legacy = connection.execute(
+            "SELECT reason FROM channel_ingress WHERE event_key = 'slack:acct-1:legacy-1'"
+        ).fetchone()
+    assert legacy == ("",)
+    _complete(store, "event-9", "admission_denied", "dm_denied")
+    counts = store.admission_reason_counts("slack-main")
+    assert list(counts) == ["dm_denied"]
+    assert counts["dm_denied"]["count"] == 1
+    store.close()
+
+
+def test_migration_tolerates_losing_the_alter_race(tmp_path: Path) -> None:
+    # Two processes first-opening an un-migrated DB can both observe the
+    # column missing before either ALTER commits; the loser's "duplicate
+    # column" error must read as already-migrated, not crash startup.
+    store = ChannelDeliveryStore(tmp_path / "delivery.sqlite")
+    # Replay the ALTERs as the losing opener would: the columns already exist.
+    store._add_column("channel_ingress", "reason TEXT NOT NULL DEFAULT ''")
+    store._add_column("channel_pairings", "reply_to TEXT")
+    # Any other operational error still surfaces.
+    with pytest.raises(sqlite3.OperationalError):
+        store._add_column("channel_ingress", "reason2 SYNTAX ERROR (")
+    store.close()

--- a/tests/test_channels/test_channel_pairing.py
+++ b/tests/test_channels/test_channel_pairing.py
@@ -282,9 +282,11 @@ async def test_pending_pairing_notice_precedes_all_session_and_tool_side_effects
     assert len(notice.metadata["pairing_code"]) == 8
     with sqlite3.connect(store.path) as connection:
         persisted = connection.execute(
-            "SELECT state, disposition, message_json FROM channel_ingress"
+            "SELECT state, disposition, reason, message_json FROM channel_ingress"
         ).fetchone()
-    assert persisted == ("completed", "admission_denied", "{}")
+    # The payload is scrubbed but the WHY survives: the specific admission
+    # reason is kept as a code so operators can explain the silence later.
+    assert persisted == ("completed", "admission_denied", "pairing_required", "{}")
     store.close()
 
 

--- a/tests/test_gateway/test_rpc_channels.py
+++ b/tests/test_gateway/test_rpc_channels.py
@@ -146,7 +146,99 @@ async def test_channels_status_reports_adapter_capabilities_without_network_prob
     assert row["platform_manifest"]["capabilities"][ChannelPlatformCategories.DOCS][
         "status"
     ] == ChannelPlatformCapabilityStatus.UNSUPPORTED
-    assert row["diagnostics"] == {"network_probe": "not_run"}
+    assert row["diagnostics"] == {
+        "network_probe": "not_run",
+        # A running adapter without an explicit policy is governed by the
+        # default access policy; explain-why must show that, not hide it.
+        "admission": {
+            "dmAccess": "pairing",
+            "allowlist": {"configured": False, "entryCount": 0, "blankEntryCount": 0},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_channels_status_explains_admission_policy_and_denials():
+    from opensquilla.channels._util import ChannelAccessPolicy, ChannelDmAccess
+
+    class FakeHealth:
+        connected = True
+        bot_user_id = "bot-1"
+        extra: dict = {}
+
+    class FakeAdapter:
+        policy = ChannelAccessPolicy(
+            dm_access=ChannelDmAccess.ALLOWLIST,
+            allowlist=frozenset({"user-ok", "  "}),
+        )
+
+    class FakeStore:
+        def admission_reason_counts(self, name: str) -> dict:
+            assert name == "telegram-main"
+            return {
+                "dm_admitted": {"count": 9, "first_at": 1700000000.0, "last_at": 1700000300.0},
+                "not_in_allowlist": {"count": 4, "first_at": 1699999000.0, "last_at": 1700000100.0},
+                "pairing_required": {"count": 2, "first_at": 1700000150.0, "last_at": 1700000200.0},
+            }
+
+    class FakeManager:
+        _channel_types = {"telegram-main": "telegram"}
+        _delivery_store = FakeStore()
+
+        async def health(self):
+            return {"telegram-main": FakeHealth()}
+
+        def get(self, name: str):
+            assert name == "telegram-main"
+            return FakeAdapter()
+
+    ctx = _read_ctx()
+    ctx.channel_manager = FakeManager()
+
+    rpc_res = await get_dispatcher().dispatch("r1", "channels.status", {}, ctx)
+
+    assert rpc_res.error is None, rpc_res.error
+    admission = rpc_res.payload["channels"][0]["diagnostics"]["admission"]
+    assert admission["dmAccess"] == "allowlist"
+    # entryCount + blankEntryCount is the honest typo detector: entries are
+    # opaque strings, so "invalid" can only mean blank/whitespace.
+    assert admission["allowlist"] == {
+        "configured": True,
+        "entryCount": 2,
+        "blankEntryCount": 1,
+    }
+    assert admission["reasons"]["not_in_allowlist"]["count"] == 4
+    assert admission["reasons"]["dm_admitted"]["count"] == 9
+    assert admission["reasons"]["pairing_required"]["lastAt"].startswith("2023-11-1")
+    # Tallies are lifetime; the horizon label keeps months-old denials under a
+    # since-changed policy from reading as a live condition.
+    assert admission["since"].startswith("2023-11-1")
+    # The newest DENIAL wins, not the newer admitted decision.
+    assert admission["lastDenial"]["reason"] == "pairing_required"
+    # Reason codes and counts only — no sender identity anywhere in the block.
+    assert "user-ok" not in str(admission)
+
+
+@pytest.mark.asyncio
+async def test_channels_status_admission_block_absent_without_adapter_or_history():
+    # No running adapter and no recorded decisions: nothing to explain, so the
+    # key stays absent instead of implying a policy that is not in force.
+    ctx = _read_ctx()
+    res = upsert_channel(
+        GatewayConfig(),
+        entry_payload={
+            "type": "slack",
+            "name": "work",
+            "token": "xoxb-secret",
+            "signing_secret": "ss",
+        },
+    )
+    ctx.config = res.config
+
+    rpc_res = await get_dispatcher().dispatch("r1", "channels.status", {}, ctx)
+
+    assert rpc_res.error is None, rpc_res.error
+    assert "admission" not in rpc_res.payload["channels"][0]["diagnostics"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_health/test_evaluator.py
+++ b/tests/test_health/test_evaluator.py
@@ -1297,3 +1297,93 @@ def test_squilla_router_runtime_evaluator_describes_default_tier_degradation() -
     assert finding.severity == "warn"
     assert "default tier" in finding.detail
     assert 'routing source "heuristic"' not in finding.detail
+
+
+def _connected_row(name: str = "telegram-main", **overrides) -> dict:
+    row = {
+        "name": name,
+        "type": "telegram",
+        "enabled": True,
+        "configured": True,
+        "status": "connected",
+        "connected": True,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_channels_evaluator_surfaces_pending_pairings_without_degrading_ready() -> None:
+    # A healthy channel silently gating senders is exactly the state doctor
+    # used to call "ready": the sender was told to wait, the operator never was.
+    findings = evaluate_channels({"channels": [_connected_row(pendingPairings=2)]})
+
+    assert [f.id for f in findings] == ["channel.telegram-main.pending_pairings"]
+    finding = findings[0]
+    assert finding.severity == "warn"
+    # Awaiting a human decision, not a malfunction: visible but not degrading.
+    assert _impact(finding) == "optional"
+    assert finding.evidence == {
+        "name": "telegram-main",
+        "channelName": "telegram-main",
+        "pendingPairings": 2,
+    }
+    commands = [step.command for step in finding.fix_steps if step.command]
+    assert "opensquilla channels status telegram-main --json" in commands
+
+
+def test_channels_evaluator_surfaces_sends_with_unknown_outcome() -> None:
+    findings = evaluate_channels(
+        {
+            "channels": [
+                _connected_row(
+                    diagnostics={
+                        "delivery": {
+                            "outbox": {
+                                "sent": {"count": 40, "oldest_at": 1.0},
+                                "unknown": {"count": 3, "oldest_at": 99.0},
+                            }
+                        }
+                    }
+                )
+            ]
+        }
+    )
+
+    assert [f.id for f in findings] == ["channel.telegram-main.sends_unknown_outcome"]
+    finding = findings[0]
+    assert finding.severity == "warn"
+    # Unknown-outcome rows are terminal until a human resolves them; degrading
+    # readiness would flag the channel forever after one lost send.
+    assert _impact(finding) == "optional"
+    assert finding.evidence["unknownSends"] == 3
+    assert finding.evidence["oldestAt"] == 99.0
+    assert "3 outbound send(s)" in finding.detail
+
+
+def test_channels_evaluator_action_items_ride_alongside_status_findings() -> None:
+    # A dead channel with pending pairings reports both facts — the status
+    # chain picks one finding, but action items are appended independently.
+    findings = evaluate_channels(
+        {"channels": [_connected_row(status="dead", pendingPairings=1)]}
+    )
+
+    assert {f.id for f in findings} == {
+        "channel.telegram-main.dead",
+        "channel.telegram-main.pending_pairings",
+    }
+
+
+def test_channels_evaluator_ignores_malformed_action_item_shapes() -> None:
+    findings = evaluate_channels(
+        {
+            "channels": [
+                _connected_row(
+                    pendingPairings="2",
+                    diagnostics={"delivery": {"outbox": {"unknown": {"count": "3"}}}},
+                ),
+                _connected_row(name="feishu-main", pendingPairings=0, diagnostics={}),
+            ]
+        }
+    )
+
+    assert [f.id for f in findings] == ["channels.ready"]

--- a/tests/test_health/test_model.py
+++ b/tests/test_health/test_model.py
@@ -175,3 +175,31 @@ def test_build_report_orders_actionable_findings_before_informational_items() ->
         "channels.disabled",
         "gateway.rpc.ready",
     ]
+
+
+def test_build_report_labels_warn_optional_findings_as_operator_action_items() -> None:
+    # A warn-severity optional finding is work someone is blocked on (pending
+    # pairing approvals, unconfirmed sends) — not an "optional setup item".
+    report = build_report(
+        [
+            HealthFinding(
+                id="channel.telegram-main.pending_pairings",
+                severity="warn",
+                readiness_impact="optional",
+                surface="channels",
+                title="Channel telegram-main has pairing requests awaiting approval",
+                detail="2 sender(s) are waiting on operator approval.",
+            ),
+            HealthFinding(
+                id="image_generation.disabled",
+                severity="info",
+                surface="image_generation",
+                title="Image generation is disabled",
+                detail="Image generation is optional and is currently disabled.",
+            ),
+        ]
+    )
+
+    assert report["ready"] is True
+    assert report["status"] == "ready"
+    assert report["summary"] == "Ready, 1 item awaiting operator action, 1 optional setup item"


### PR DESCRIPTION
## Scope

Give operators an answer to "why did that message not create a session?" — and stop doctor from reporting all-clear while senders wait on approvals or replies sit with unknown delivery outcomes.

Before this change the admission decision (a stable 9-value reason vocabulary) was computed for every inbound message, logged once, and persisted nowhere: `channel_ingress.disposition` said only `admission_denied`, nothing ever read it back, and neither the status payload nor doctor carried any admission facts.

Changes:

- **Reason persistence** — `channel_ingress` gains a `reason` column (inline DDL plus a guarded `ALTER` for stores created before the column existed, tolerant of two processes racing the first open of an un-migrated database). All seven `complete_inbound` sites in reply dispatch now record the admission reason code beside the disposition: denied rows keep the specific denial reason (and their payload scrub), admitted rows record the admission basis.
- **`channels.status` explain-why block** — each row's diagnostics gains `admission`: effective `dmAccess` mode (including the default policy when an adapter declares none), allowlist facts (`configured`/`entryCount`/`blankEntryCount` — entries are opaque strings, so a blank entry is the only detectable typo), per-reason tallies with timestamps, `lastDenial {reason, at}`, and a `since` horizon label so lifetime tallies under a since-changed policy read as history, not a live condition. Reason codes and counts only — no sender identity anywhere in the block.
- **Doctor findings for silent action-needed states** — `evaluate_channels` now reports `channel.<name>.pending_pairings` (senders waiting on operator approval) and `channel.<name>.sends_unknown_outcome` (sends that raised mid-delivery and are kept for a human decision). Both are warn severity with `optional` readiness impact: visible on every doctor run without permanently degrading readiness, since unknown-outcome rows are terminal until a human resolves them. They ride alongside status findings rather than replacing them, and they suppress the `channels.ready` all-clear.
- **Report summary vocabulary** — a warn-level optional finding now renders as "N item(s) awaiting operator action" instead of "optional setup item", in both the report builder and the CLI readiness-refresh mirror.

## Branch target

`integration/channel-platform` (channel-platform integration line; **not** `main`).

## Linked issue

None

## Release note

Channel status diagnostics now explain admission decisions: the effective DM access mode, allowlist facts, per-reason counts, and the most recent denial are visible per channel (reason codes only, never sender identities). `opensquilla doctor` now reports pairing requests awaiting approval and sends with unknown delivery outcomes instead of declaring channels ready over them.

## Tests

- New `tests/test_channels/test_admission_reason_persistence.py`: reason persistence, per-reason aggregation with horizon timestamps, old-database column migration, ALTER-race tolerance.
- `tests/test_channels/test_channel_pairing.py`: the end-to-end denial test now asserts the persisted reason code alongside the scrubbed payload.
- `tests/test_gateway/test_rpc_channels.py`: admission block contents (mode, allowlist facts, tallies, `since`, `lastDenial` picks the newest denial, no sender identity), absence when there is nothing to explain, default-policy visibility.
- `tests/test_health/test_evaluator.py` + `test_model.py`: both new findings (severity, impact, evidence, real fix commands), action items riding alongside status findings, malformed-shape tolerance, and the new summary wording.
- `uv run ruff check src tests` — clean; `uv run mypy src/opensquilla` — clean (803 files); `uv build --wheel` — ok.
- Affected suites (`test_gateway`, `test_contracts`, `test_health`, `test_channels`, `test_cli` doctor/product-completeness): 2400+ passed. Full suite: green except pre-existing local failures (tmux real-terminal, seatbelt, exp_ledger/quarantine, workspace-write-deny) unrelated to this change.

## Safety notes

Privacy: the persisted reason and every diagnostics field are enum codes, counts, and timestamps — no sender identities, pairing ids, or message content; denied rows keep their existing payload scrub. The schema change is additive with a race-tolerant guard; older databases upgrade on first open. `channels.status` consumers that hand-pick fields are unaffected by the added `admission` key (verified against the CLI table, Web UI accessors, and doctor fixtures).

## Third-party origin

None — original work.