### PR TITLE
Guard the cross-file invariants the channel series introduced

### DIFF
--- a/src/opensquilla/cli/doctor_cmd.py
+++ b/src/opensquilla/cli/doctor_cmd.py
@@ -17,7 +17,12 @@ from rich.table import Table
 from opensquilla.cli.gateway_rpc import default_gateway_url, gateway_url_from_config
 from opensquilla.cli.output import print_json
 from opensquilla.cli.url_utils import normalize_gateway_url
-from opensquilla.health.model import FixStep, HealthFinding, build_report
+from opensquilla.health.model import (
+    FixStep,
+    HealthFinding,
+    build_report,
+    summarize_impact_counts,
+)
 from opensquilla.health.recovery_commands import command_with_config as _command_with_config
 
 _LOCAL_GATEWAY_HOSTS = {"127.0.0.1", "::1", "localhost", "0.0.0.0"}
@@ -429,34 +434,6 @@ def _impact_text(finding: dict[str, Any]) -> str:
     return labels[_impact_value(finding)]
 
 
-def _summary_from_impact_counts(impact_counts: dict[str, int], *, attention_count: int = 0) -> str:
-    parts: list[str] = []
-    if impact_counts["blocks_ready"]:
-        label = "action" if impact_counts["blocks_ready"] == 1 else "actions"
-        parts.append(f"{impact_counts['blocks_ready']} {label} required")
-    if impact_counts["degrades"]:
-        label = "check" if impact_counts["degrades"] == 1 else "checks"
-        if not impact_counts["blocks_ready"]:
-            parts.append(f"Ready, {impact_counts['degrades']} degraded {label}")
-        else:
-            parts.append(f"{impact_counts['degrades']} degraded {label}")
-    if parts:
-        return ", ".join(parts)
-    if impact_counts["optional"]:
-        # Mirrors health/model.py: an optional-impact warn is an operator
-        # action item, not a setup suggestion.
-        setup_count = impact_counts["optional"] - attention_count
-        segments: list[str] = []
-        if attention_count:
-            label = "item" if attention_count == 1 else "items"
-            segments.append(f"{attention_count} {label} awaiting operator action")
-        if setup_count:
-            label = "item" if setup_count == 1 else "items"
-            segments.append(f"{setup_count} optional setup {label}")
-        return "Ready, " + ", ".join(segments)
-    return "Ready"
-
-
 def _same_config_path(left: str, right: str) -> bool:
     try:
         return Path(left).expanduser().resolve() == Path(right).expanduser().resolve()
@@ -494,7 +471,7 @@ def _refresh_report_readiness(report: dict[str, Any]) -> None:
         "degraded" if impact_counts["degrades"] else "ready"
     )
     report["ready"] = impact_counts["blocks_ready"] == 0
-    report["summary"] = _summary_from_impact_counts(impact_counts, attention_count=attention_count)
+    report["summary"] = summarize_impact_counts(impact_counts, attention_count=attention_count)
 
 
 def _apply_requested_config_context(

--- a/src/opensquilla/health/model.py
+++ b/src/opensquilla/health/model.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -81,7 +82,14 @@ def _readiness_impact(finding: HealthFinding) -> ReadinessImpact:
     return finding.readiness_impact or _DEFAULT_IMPACT_BY_SEVERITY[finding.severity]
 
 
-def _summary(impact_counts: dict[ReadinessImpact, int], *, attention_count: int = 0) -> str:
+def summarize_impact_counts(impact_counts: Mapping[str, int], *, attention_count: int = 0) -> str:
+    """Human summary line for a readiness report.
+
+    Shared with the CLI's local readiness refresh so the operator-facing
+    wording cannot drift between the gateway report and ``opensquilla doctor``.
+    ``attention_count`` is the number of warn-severity optional-impact
+    findings — operator action items, labeled distinctly from setup items.
+    """
     parts: list[str] = []
     if impact_counts["blocks_ready"]:
         label = "action" if impact_counts["blocks_ready"] == 1 else "actions"
@@ -110,7 +118,7 @@ def _summary(impact_counts: dict[ReadinessImpact, int], *, attention_count: int 
     return "Ready"
 
 
-def _status(impact_counts: dict[ReadinessImpact, int]) -> HealthStatus:
+def _status(impact_counts: Mapping[str, int]) -> HealthStatus:
     # "unavailable" is reserved for callers that cannot reach doctor.status at all.
     if impact_counts["blocks_ready"]:
         return "action_required"
@@ -121,7 +129,9 @@ def _status(impact_counts: dict[ReadinessImpact, int]) -> HealthStatus:
 
 def build_report(findings: list[HealthFinding]) -> dict[str, Any]:
     counts: dict[HealthSeverity, int] = {key: 0 for key in _COUNT_KEYS}
-    impact_counts: dict[ReadinessImpact, int] = {key: 0 for key in _IMPACT_KEYS}
+    # str-keyed so the shared summary helper (Mapping[str, int]) accepts it;
+    # writes still come only from _IMPACT_KEYS.
+    impact_counts: dict[str, int] = {key: 0 for key in _IMPACT_KEYS}
     attention_count = 0
     for finding in findings:
         counts[finding.severity] += 1
@@ -140,7 +150,7 @@ def build_report(findings: list[HealthFinding]) -> dict[str, Any]:
     return {
         "status": status,
         "ready": impact_counts["blocks_ready"] == 0,
-        "summary": _summary(impact_counts, attention_count=attention_count),
+        "summary": summarize_impact_counts(impact_counts, attention_count=attention_count),
         "counts": counts,
         "impactCounts": impact_counts,
         "findings": [finding.to_dict() for _, finding in ordered_findings],

--- a/tests/test_channels/test_length_declaration_conformance.py
+++ b/tests/test_channels/test_length_declaration_conformance.py
@@ -1,0 +1,111 @@
+"""The length declarations in capability profiles must match adapter reality.
+
+Central dispatch trusts these declarations: ``splits_natively=True`` makes it
+skip an adapter entirely, and ``max_message_len`` is enforced in the declared
+unit. A declaration that drifts from the adapter's actual behavior either
+double-splits or ships over-cap messages — these tripwires make the drift a
+test failure instead of a production surprise.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+from opensquilla.channels.contract import ChannelLengthUnit, channel_capability_profile
+from opensquilla.channels.dingtalk import DingTalkChannel, DingTalkChannelConfig
+from opensquilla.channels.discord import DiscordChannel, DiscordChannelConfig
+from opensquilla.channels.feishu import FeishuChannel, FeishuChannelConfig
+from opensquilla.channels.matrix import MatrixChannel, MatrixChannelConfig
+from opensquilla.channels.msteams import MSTeamsChannel, MSTeamsChannelConfig
+from opensquilla.channels.qq import QQChannel, QQChannelConfig
+from opensquilla.channels.slack import SlackChannel
+from opensquilla.channels.telegram import TelegramChannel, TelegramChannelConfig
+from opensquilla.channels.wecom import WeComChannel, WeComChannelConfig
+
+_ADAPTERS = [
+    ("slack", lambda: SlackChannel(token="xoxb-token", slack_channel_id="C-default")),
+    ("discord", lambda: DiscordChannel(DiscordChannelConfig(token="token"))),
+    (
+        "feishu",
+        lambda: FeishuChannel(
+            FeishuChannelConfig(app_id="app", app_secret="secret", connection_mode="websocket")
+        ),
+    ),
+    ("dingtalk", lambda: DingTalkChannel(DingTalkChannelConfig())),
+    ("wecom", lambda: WeComChannel(WeComChannelConfig())),
+    ("qq", lambda: QQChannel(QQChannelConfig())),
+    ("msteams", lambda: MSTeamsChannel(MSTeamsChannelConfig())),
+    ("matrix", lambda: MatrixChannel(MatrixChannelConfig())),
+    ("telegram", lambda: TelegramChannel(TelegramChannelConfig(transport_name="webhook"))),
+]
+
+
+@pytest.mark.parametrize(("adapter_name", "make"), _ADAPTERS)
+def test_length_declaration_is_well_formed(adapter_name: str, make) -> None:
+    profile = channel_capability_profile(make())
+    assert profile is not None
+    assert profile.max_message_len >= 0
+    assert isinstance(profile.length_unit, ChannelLengthUnit)
+    if profile.splits_natively:
+        # An adapter may only opt out of central splitting if it declares the
+        # cap it splits to.
+        assert profile.max_message_len > 0
+
+
+@pytest.mark.parametrize(("adapter_name", "make"), _ADAPTERS)
+def test_native_splitter_declarations_are_backed_by_a_split_call(adapter_name: str, make) -> None:
+    # splits_natively=True makes central dispatch skip the adapter, so a
+    # declaration without an actual split in the adapter ships over-cap
+    # messages the platform rejects wholesale.
+    profile = channel_capability_profile(make())
+    assert profile is not None
+    if not profile.splits_natively:
+        return
+    module = importlib.import_module(f"opensquilla.channels.{adapter_name}")
+    assert "split_text_for_channel" in inspect.getsource(module), (
+        f"{adapter_name} declares splits_natively=True but never calls the "
+        "shared splitter; either split in send() or drop the declaration so "
+        "central dispatch handles it"
+    )
+
+
+@pytest.mark.parametrize(
+    ("adapter_name", "make", "constant_name"),
+    [
+        ("telegram", _ADAPTERS[8][1], "_TELEGRAM_MAX_MESSAGE_CHARS"),
+        ("discord", _ADAPTERS[1][1], "_DISCORD_MAX_MESSAGE_CHARS"),
+        ("slack", _ADAPTERS[0][1], "_SLACK_MAX_MESSAGE_CHARS"),
+    ],
+)
+def test_native_splitter_cap_matches_the_declared_profile_cap(
+    adapter_name: str, make, constant_name: str
+) -> None:
+    # The cap lives twice for native splitters: the module constant the
+    # adapter splits with, and the profile declaration everything else reads.
+    # If they drift, the contract advertises a limit the adapter won't honor.
+    module = importlib.import_module(f"opensquilla.channels.{adapter_name}")
+    profile = channel_capability_profile(make())
+    assert profile is not None
+    assert profile.max_message_len == getattr(module, constant_name)
+
+
+def test_wecom_profiles_declare_identical_length_handling() -> None:
+    # WeCom builds a different profile per connection mode; the platform cap
+    # does not change with the transport.
+    websocket = WeComChannel(WeComChannelConfig(connection_mode="websocket"))
+    webhook = WeComChannel(WeComChannelConfig())
+    ws_profile = channel_capability_profile(websocket)
+    wh_profile = channel_capability_profile(webhook)
+    assert ws_profile is not None and wh_profile is not None
+    assert (
+        ws_profile.max_message_len,
+        ws_profile.length_unit,
+        ws_profile.splits_natively,
+    ) == (
+        wh_profile.max_message_len,
+        wh_profile.length_unit,
+        wh_profile.splits_natively,
+    )

--- a/tests/test_cli/test_doctor_cmd.py
+++ b/tests/test_cli/test_doctor_cmd.py
@@ -1136,3 +1136,37 @@ def test_local_config_findings_explain_optional_env_references(monkeypatch) -> N
     detail_steps = " ".join(step.detail or "" for step in finding.fix_steps)
     assert "CUSTOM_SEARCH_KEY" in detail_steps
     assert "CUSTOM_IMAGE_KEY" in detail_steps
+
+
+def test_refresh_report_readiness_labels_operator_action_items() -> None:
+    # The CLI recomputes the summary locally after rewriting fix commands; a
+    # warn-severity optional finding must keep the "awaiting operator action"
+    # label the gateway report uses, not decay to "optional setup item".
+    from opensquilla.cli.doctor_cmd import _refresh_report_readiness
+
+    report: dict[str, Any] = {
+        "findings": [
+            {
+                "id": "channel.telegram-main.pending_pairings",
+                "severity": "warn",
+                "readinessImpact": "optional",
+                "surface": "channels",
+                "title": "Channel telegram-main has pairing requests awaiting approval",
+                "detail": "1 sender is waiting on operator approval.",
+            },
+            {
+                "id": "logs.gateway_file_log.disabled",
+                "severity": "info",
+                "readinessImpact": "optional",
+                "surface": "logs",
+                "title": "Gateway file logging is disabled",
+                "detail": "Persistent gateway file logging is optional.",
+            },
+        ]
+    }
+
+    _refresh_report_readiness(report)
+
+    assert report["ready"] is True
+    assert report["status"] == "ready"
+    assert report["summary"] == "Ready, 1 item awaiting operator action, 1 optional setup item"

--- a/tests/test_gateway/test_rpc_channels.py
+++ b/tests/test_gateway/test_rpc_channels.py
@@ -219,6 +219,20 @@ async def test_channels_status_explains_admission_policy_and_denials():
     assert "user-ok" not in str(admission)
 
 
+def test_admit_reason_set_tracks_the_admission_vocabulary():
+    # _ADMISSION_ADMIT_REASONS decides what counts as a denial for lastDenial;
+    # a new admit-outcome reason added to AdmissionReason but not here would be
+    # reported as the channel's most recent denial.
+    from typing import get_args
+
+    from opensquilla.channels.admission import AdmissionReason
+    from opensquilla.gateway.rpc_channels import _ADMISSION_ADMIT_REASONS
+
+    vocabulary = set(get_args(AdmissionReason))
+    assert _ADMISSION_ADMIT_REASONS <= vocabulary
+    assert _ADMISSION_ADMIT_REASONS == {r for r in vocabulary if r.endswith("_admitted")}
+
+
 @pytest.mark.asyncio
 async def test_channels_status_admission_block_absent_without_adapter_or_history():
     # No running adapter and no recorded decisions: nothing to explain, so the


### PR DESCRIPTION
## Scope

Test-and-dedup hardening for four invariants the recent channel work established but only documented in comments. No behavior change for users; one internal refactor.

- **Doctor summary dedup** — the report summary wording lived twice: `health/model.py` and a near-identical mirror in `cli/doctor_cmd.py`'s local readiness refresh, with only the model side pinned by tests. Both now call one shared `summarize_impact_counts`, and a new CLI-side test pins the "awaiting operator action" labeling through `_refresh_report_readiness`.
- **Admit-reason set cross-check** — `_ADMISSION_ADMIT_REASONS` in `rpc_channels.py` decides what counts as a denial for `lastDenial`; a new admit-outcome value added to `AdmissionReason` but not to the set would be reported as a denial. A test now derives the expected set from the `AdmissionReason` literal via `typing.get_args`.
- **`splits_natively` conformance tripwire** — the declaration makes central dispatch skip an adapter entirely, so declaring it without actually splitting ships over-cap messages. A parametrized test over all nine vendor adapters requires every `splits_natively=True` adapter to reference the shared splitter, declare the cap it splits to, and keep well-formed length fields.
- **Cap-constant consistency** — Telegram/Discord/Slack each declare their platform cap twice (the module constant their splitter uses, and the capability-profile field everything else reads); tests hold each pair equal, and hold WeCom's two per-transport profiles to identical length handling.

## Branch target

`integration/channel-platform` (channel-platform integration line; **not** `main`).

## Linked issue

None

## Release note

None — internal test hardening; no user-visible behavior change.

## Tests

- New `tests/test_channels/test_length_declaration_conformance.py` (22 tests across the nine vendor adapters).
- New vocabulary cross-check in `tests/test_gateway/test_rpc_channels.py`; new CLI summary test in `tests/test_cli/test_doctor_cmd.py`.
- `uv run ruff check src tests` — clean; `uv run mypy src/opensquilla` — clean (803 files).
- Affected suites (`test_channels`, `test_health`, `test_cli` doctor, `test_gateway` channels/doctor): 603 passed.

## Safety notes

No wire, schema, or config changes. The only src change is collapsing the duplicated summary function onto `health.model.summarize_impact_counts` (identical output, pinned by tests on both call paths).

## Third-party origin

None — original work.