### PR TITLE
Give pairing an operator CLI and bound the pairing store

### DIFF
--- a/src/opensquilla/channels/admission.py
+++ b/src/opensquilla/channels/admission.py
@@ -192,15 +192,21 @@ def decide_channel_admission(
                     # session yet. No inbound content is retained.
                     reply_to=msg.channel_id,
                 )
-                status = str(getattr(record, "status", "pending"))
-                pairing_id = str(getattr(record, "pairing_id", "") or "") or None
-                pairing_notice = int(getattr(record, "request_count", 0) or 0) == 1
-                if status == "pending":
+                if record is None:
+                    # The store refused a new pending row (queue full). Deny
+                    # exactly like an unapproved pairing, but without a
+                    # pairing code or notice — there is no row to approve.
                     pairing_status = "pending"
-                elif status == "approved":
-                    pairing_status = "approved"
-                elif status == "revoked":
-                    pairing_status = "revoked"
+                else:
+                    status = str(getattr(record, "status", "pending"))
+                    pairing_id = str(getattr(record, "pairing_id", "") or "") or None
+                    pairing_notice = int(getattr(record, "request_count", 0) or 0) == 1
+                    if status == "pending":
+                        pairing_status = "pending"
+                    elif status == "approved":
+                        pairing_status = "approved"
+                    elif status == "revoked":
+                        pairing_status = "revoked"
 
     access = evaluate_policy(
         policy,

--- a/src/opensquilla/channels/delivery_store.py
+++ b/src/opensquilla/channels/delivery_store.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import structlog
+
 from opensquilla.channels.contract import (
     ChannelSendResult,
     channel_capability_profile,
@@ -24,12 +26,28 @@ from opensquilla.channels.contract import (
 from opensquilla.channels.types import IncomingMessage, OutgoingMessage
 from opensquilla.paths import state_dir
 
+log = structlog.get_logger(__name__)
+
 _ERROR_SECRET = re.compile(
     r"(?i)\b(authorization|access[_ -]?token|app[_ -]?secret|bot[_ -]?token|"
     r"client[_ -]?secret|password|signing[_ -]?secret)\b"
     r"(\s*[=:]\s*|\s+)([^\s,;]+)"
 )
 _TELEGRAM_URL_TOKEN = re.compile(r"(?i)(/bot)[^/\s]+")
+
+# Pending pairing requests an operator never acted on are pruned after this
+# long; approved and revoked rows never expire — approval is a durable access
+# grant, and revocation only stays enforced while its row survives.
+PENDING_PAIRING_TTL_S = 7 * 24 * 3600.0
+# New pending rows a channel will hold at once. Every denied DM from a new
+# sender is a durable row, so without a cap one flood makes the operator's
+# approval queue unreadable and the disk grow without bound.
+MAX_PENDING_PAIRINGS_PER_CHANNEL = 25
+# Repeat requests inside this window skip the durable write when nothing
+# would change — a sender re-sending in a tight loop otherwise costs one
+# synchronous commit per message before admission even runs.
+PAIRING_REFRESH_WINDOW_S = 30.0
+_PAIRING_PRUNE_EVERY = 64
 
 
 @dataclass(frozen=True, slots=True)
@@ -113,9 +131,20 @@ def inbound_event_key(channel_name: str, message: IncomingMessage) -> str | None
 class ChannelDeliveryStore:
     """SQLite-backed at-least-once ingress and explicit outbound receipts."""
 
-    def __init__(self, db_path: str | Path | None = None) -> None:
+    def __init__(
+        self,
+        db_path: str | Path | None = None,
+        *,
+        pending_pairing_ttl_s: float = PENDING_PAIRING_TTL_S,
+        max_pending_pairings_per_channel: int = MAX_PENDING_PAIRINGS_PER_CHANNEL,
+        pairing_refresh_window_s: float = PAIRING_REFRESH_WINDOW_S,
+    ) -> None:
         self.path = Path(db_path) if db_path is not None else state_dir("channel_delivery.sqlite")
         self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._pending_pairing_ttl_s = pending_pairing_ttl_s
+        self._max_pending_pairings_per_channel = max_pending_pairings_per_channel
+        self._pairing_refresh_window_s = pairing_refresh_window_s
+        self._pairing_writes = 0
         self._lock = threading.RLock()
         self._conn = sqlite3.connect(
             os.fspath(self.path),
@@ -280,12 +309,19 @@ class ChannelDeliveryStore:
         sender_id: str,
         sender_name: str | None = None,
         reply_to: str | None = None,
-    ) -> ChannelPairing:
+    ) -> ChannelPairing | None:
         """Create or refresh a pending request without storing message content.
 
         ``reply_to`` is the address the request arrived on — kept so an
         approval can reach a sender who has no session yet. It is a route,
         never content.
+
+        Returns ``None`` only when the store refuses to create a NEW row
+        because the channel's pending queue is full. A sender with an existing
+        row — pending, approved, or revoked — always gets that row back, so a
+        full queue can never lock out an already-decided sender. Refusal is a
+        return value, never an exception: this runs on the admission path,
+        where an exception kills the channel's dispatch loop.
         """
         if not channel_name.strip() or not sender_id.strip():
             raise ValueError("channel_name and sender_id are required")
@@ -294,8 +330,41 @@ class ChannelDeliveryStore:
         safe_name = sender_name.strip()[:256] if isinstance(sender_name, str) else None
         safe_name = safe_name or None
         account = account_id.strip() or channel_name.strip()
+        clean_reply_to = (reply_to.strip() or None) if isinstance(reply_to, str) else None
         with self._lock:
+            self._pairing_writes += 1
+            if self._pairing_writes % _PAIRING_PRUNE_EVERY == 0:
+                self._prune_stale_pending_pairings(now)
             self._conn.execute("BEGIN IMMEDIATE")
+            existing = self._conn.execute(
+                "SELECT * FROM channel_pairings WHERE channel_name = ? "
+                "AND account_id = ? AND sender_id = ?",
+                (channel_name.strip(), account, sender_id.strip()),
+            ).fetchone()
+            if existing is not None:
+                # Flood guard: a repeat request that would change nothing
+                # skips the durable write entirely.
+                fresh = now - float(existing["last_seen_at"]) < self._pairing_refresh_window_s
+                same_route = clean_reply_to is None or clean_reply_to == existing["reply_to"]
+                same_name = safe_name is None or safe_name == existing["sender_name"]
+                if fresh and same_route and same_name:
+                    self._conn.rollback()
+                    return self._pairing_from_row(existing)
+            else:
+                pending = self._conn.execute(
+                    "SELECT COUNT(*) AS count FROM channel_pairings "
+                    "WHERE channel_name = ? AND status = 'pending'",
+                    (channel_name.strip(),),
+                ).fetchone()
+                if int(pending["count"]) >= self._max_pending_pairings_per_channel:
+                    self._conn.rollback()
+                    log.warning(
+                        "channel.pairing_queue_full",
+                        channel=channel_name.strip(),
+                        pending=int(pending["count"]),
+                        cap=self._max_pending_pairings_per_channel,
+                    )
+                    return None
             self._conn.execute(
                 "INSERT INTO channel_pairings "
                 "(pairing_id, channel_name, provider, account_id, sender_id, "
@@ -316,7 +385,7 @@ class ChannelDeliveryStore:
                     safe_name,
                     now,
                     now,
-                    (reply_to.strip() or None) if isinstance(reply_to, str) else None,
+                    clean_reply_to,
                 ),
             )
             row = self._conn.execute(
@@ -329,17 +398,52 @@ class ChannelDeliveryStore:
             raise RuntimeError("pairing request was not persisted")
         return self._pairing_from_row(row)
 
+    def _prune_stale_pending_pairings(self, now: float) -> None:
+        """Best-effort expiry of pending rows the operator never acted on.
+
+        Only ``pending`` rows expire. Approved rows are durable access grants,
+        and revoked rows must survive because revocation is enforced by the
+        row's status — deleting one would let the sender's next message
+        recreate a fresh pending request.
+        """
+        cutoff = now - self._pending_pairing_ttl_s
+        try:
+            cursor = self._conn.execute(
+                "DELETE FROM channel_pairings WHERE status = 'pending' AND last_seen_at < ?",
+                (cutoff,),
+            )
+            self._conn.commit()
+        except sqlite3.Error:
+            log.warning("channel.pairing_prune_failed", exc_info=True)
+            return
+        if cursor.rowcount:
+            log.info(
+                "channel.pairing_pruned",
+                rows=cursor.rowcount,
+                ttl_days=round(self._pending_pairing_ttl_s / 86400.0, 1),
+            )
+
     def list_pairings(
         self,
         *,
         channel_name: str | None = None,
         status: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[ChannelPairing]:
-        """List pairing records newest-first for operator review."""
+        """List pairing records newest-first for operator review.
+
+        ``limit``/``offset`` are opt-in: the default remains the full list, so
+        callers that summarize by status (badges, tab counts) stay complete.
+        """
         if status is not None and status not in {"pending", "approved", "revoked"}:
             raise ValueError("invalid pairing status")
+        if limit is not None and limit <= 0:
+            raise ValueError("limit must be positive")
+        if offset < 0:
+            raise ValueError("offset must not be negative")
         clauses: list[str] = []
-        values: list[str] = []
+        values: list[Any] = []
         if channel_name:
             clauses.append("channel_name = ?")
             values.append(channel_name)
@@ -347,10 +451,14 @@ class ChannelDeliveryStore:
             clauses.append("status = ?")
             values.append(status)
         where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        page = ""
+        if limit is not None:
+            page = " LIMIT ? OFFSET ?"
+            values.extend((limit, offset))
         with self._lock:
             rows = self._conn.execute(
                 f"SELECT * FROM channel_pairings{where} "  # noqa: S608
-                "ORDER BY last_seen_at DESC, pairing_id ASC",
+                f"ORDER BY last_seen_at DESC, pairing_id ASC{page}",
                 values,
             ).fetchall()
         return [self._pairing_from_row(row) for row in rows]

--- a/src/opensquilla/cli/channels_cmd.py
+++ b/src/opensquilla/cli/channels_cmd.py
@@ -571,3 +571,115 @@ def channels_certify(
 
     if not evidence_passed(evidence):
         raise typer.Exit(code=1)
+
+
+pairings_app = typer.Typer(help="Review and decide channel pairing requests.")
+channels_app.add_typer(pairings_app, name="pairings")
+
+
+def _render_pairings_table(records: list[dict[str, Any]], *, channel: str) -> None:
+    table = Table(title=f"Pairing requests: {channel}", header_style=ACCENT_HEADER)
+    table.add_column("Code")
+    table.add_column("Sender")
+    table.add_column("Status")
+    table.add_column("Requested")
+    table.add_column("Approved")
+    for record in records:
+        sender = str(record.get("senderName") or record.get("senderId") or "")
+        table.add_row(
+            str(record.get("pairingCode") or ""),
+            sender,
+            str(record.get("status") or ""),
+            str(record.get("createdAt") or ""),
+            str(record.get("approvedAt") or ""),
+        )
+    Console(width=140, force_terminal=False).print(table)
+    if not records:
+        typer.echo("No pairing requests.")
+
+
+@pairings_app.command("list")
+def pairings_list(
+    channel: str = typer.Argument(..., help="Channel name to inspect"),
+    status: str | None = typer.Option(
+        None, "--status", help="Filter by status: pending, approved, or revoked"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    config_path: Path | None = typer.Option(None, "--config", help="Override config path."),
+) -> None:
+    """List pairing requests for a channel, newest first."""
+
+    async def _run(client):
+        params: dict[str, Any] = {"channelName": channel}
+        if status:
+            params["status"] = status
+        return await client.call("channels.pairings", params)
+
+    payload = run_gateway_sync(_run, json_output=json_output, config_path=config_path)
+    if json_output:
+        print_json(payload)
+        return
+    _render_pairings_table(list(payload.get("pairings") or []), channel=channel)
+
+
+@pairings_app.command("approve")
+def pairings_approve(
+    channel: str = typer.Argument(..., help="Channel name"),
+    pairing: str = typer.Argument(..., help="Pairing code (8 chars) or full pairing id"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    config_path: Path | None = typer.Option(None, "--config", help="Override config path."),
+) -> None:
+    """Approve a pairing request; the sender is notified they can start."""
+
+    confirm_or_exit(
+        f"Approve pairing {pairing!r} on channel {channel!r}? "
+        "The sender gains conversational access.",
+        yes=yes,
+        json_output=json_output,
+    )
+
+    async def _run(client):
+        return await client.call(
+            "channels.pairing.approve",
+            {"channelName": channel, "pairingCode": pairing},
+        )
+
+    payload = run_gateway_sync(_run, json_output=json_output, config_path=config_path)
+    if json_output:
+        print_json(payload)
+        return
+    record = payload.get("pairing") or {}
+    sender = str(record.get("senderName") or record.get("senderId") or "")
+    typer.echo(f"Pairing approved: {record.get('pairingCode', pairing)} ({sender})")
+
+
+@pairings_app.command("revoke")
+def pairings_revoke(
+    channel: str = typer.Argument(..., help="Channel name"),
+    pairing: str = typer.Argument(..., help="Pairing code (8 chars) or full pairing id"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    config_path: Path | None = typer.Option(None, "--config", help="Override config path."),
+) -> None:
+    """Revoke a pairing; the sender loses conversational access."""
+
+    confirm_or_exit(
+        f"Revoke pairing {pairing!r} on channel {channel!r}? "
+        "The sender loses conversational access.",
+        yes=yes,
+        json_output=json_output,
+    )
+
+    async def _run(client):
+        return await client.call(
+            "channels.pairing.revoke",
+            {"channelName": channel, "pairingCode": pairing},
+        )
+
+    payload = run_gateway_sync(_run, json_output=json_output, config_path=config_path)
+    if json_output:
+        print_json(payload)
+        return
+    record = payload.get("pairing") or {}
+    typer.echo(f"Pairing revoked: {record.get('pairingCode', pairing)}")

--- a/src/opensquilla/gateway/rpc_channels.py
+++ b/src/opensquilla/gateway/rpc_channels.py
@@ -540,21 +540,50 @@ async def _handle_channels_pairings(
     params: dict | None,
     ctx: RpcContext,
 ) -> dict[str, Any]:
-    channel_name = str((params or {}).get("channelName") or "").strip()
+    data = params or {}
+    channel_name = str(data.get("channelName") or "").strip()
     if not channel_name:
         raise ValueError("channelName required")
-    records = _pairing_store(ctx).list_pairings(channel_name=channel_name)
+    status = str(data.get("status") or "").strip() or None
+    limit_raw = data.get("limit")
+    offset_raw = data.get("offset")
+    limit = int(limit_raw) if limit_raw is not None else None
+    offset = int(offset_raw) if offset_raw is not None else 0
+    records = _pairing_store(ctx).list_pairings(
+        channel_name=channel_name,
+        status=status,
+        limit=limit,
+        offset=offset,
+    )
     return {"pairings": [_pairing_payload(record) for record in records]}
 
 
-def _pairing_mutation_params(params: dict | None) -> tuple[str, str]:
+def _pairing_mutation_params(params: dict | None, ctx: RpcContext) -> tuple[str, str]:
+    """Resolve the target pairing from ``pairingId`` or the 8-char ``pairingCode``.
+
+    The code is what a sender's pairing notice shows and what the operator
+    list renders, so mutations accept it directly instead of making operators
+    hunt for the full id.
+    """
     channel_name = str((params or {}).get("channelName") or "").strip()
     pairing_id = str((params or {}).get("pairingId") or "").strip()
+    pairing_code = str((params or {}).get("pairingCode") or "").strip()
     if not channel_name:
         raise ValueError("channelName required")
-    if not pairing_id:
-        raise ValueError("pairingId required")
-    return channel_name, pairing_id
+    if pairing_id:
+        return channel_name, pairing_id
+    if not pairing_code:
+        raise ValueError("pairingId or pairingCode required")
+    matches = [
+        record
+        for record in _pairing_store(ctx).list_pairings(channel_name=channel_name)
+        if str(getattr(record, "pairing_id", "")).startswith(pairing_code)
+    ]
+    if not matches:
+        raise KeyError(f"no pairing matches code {pairing_code!r}")
+    if len(matches) > 1:
+        raise ValueError(f"pairing code {pairing_code!r} is ambiguous; use the full pairingId")
+    return channel_name, str(matches[0].pairing_id)
 
 
 def _channel_entry(ctx: RpcContext, channel_name: str) -> dict[str, Any] | None:
@@ -615,7 +644,7 @@ async def _handle_channels_pairing_approve(
     params: dict | None,
     ctx: RpcContext,
 ) -> dict[str, Any]:
-    channel_name, pairing_id = _pairing_mutation_params(params)
+    channel_name, pairing_id = _pairing_mutation_params(params, ctx)
     store = _pairing_store(ctx)
     # Re-approving an already-approved pairing must not re-notify the sender.
     was_approved = _pairing_status_of(store, channel_name, pairing_id) == "approved"
@@ -634,7 +663,7 @@ async def _handle_channels_pairing_revoke(
     params: dict | None,
     ctx: RpcContext,
 ) -> dict[str, Any]:
-    channel_name, pairing_id = _pairing_mutation_params(params)
+    channel_name, pairing_id = _pairing_mutation_params(params, ctx)
     record = _pairing_store(ctx).set_pairing_status(
         channel_name=channel_name,
         pairing_id=pairing_id,

--- a/src/opensquilla/health/evaluator.py
+++ b/src/opensquilla/health/evaluator.py
@@ -1524,9 +1524,10 @@ def evaluate_channels(payload: dict[str, Any]) -> list[HealthFinding]:
                     fix_steps=[
                         FixStep(
                             label="Review pending pairings",
+                            command=f"opensquilla channels pairings list {name_arg}",
                             detail=(
-                                "Open the control console Channels page and approve "
-                                "or revoke the pending requests."
+                                "Approve or revoke each request from this list or "
+                                "the control console Channels page."
                             ),
                         ),
                         FixStep(

--- a/tests/test_channels/test_channel_pairing.py
+++ b/tests/test_channels/test_channel_pairing.py
@@ -458,3 +458,102 @@ def test_pairing_request_captures_and_refreshes_the_reply_address(tmp_path):
         assert kept.reply_to == "dm-2"
     finally:
         store.close()
+
+
+def test_full_pairing_queue_denies_without_code_or_notice(tmp_path: Path) -> None:
+    # A refused pairing (queue full) must deny exactly like an unapproved one
+    # — same reason code, but no pairing code to approve and no outbound
+    # notice — and must never raise into the dispatch loop.
+    store = ChannelDeliveryStore(
+        tmp_path / "delivery.sqlite", max_pending_pairings_per_channel=1
+    )
+    channel = _Channel()
+    channel._delivery_store = store
+    channel._delivery_channel_name = "telegram-main"
+    first = decide_channel_admission(channel, _message(), "agent:main:telegram:dm:user-42")
+    assert first.reason == "pairing_required" and first.pairing_id
+
+    overflow = IncomingMessage(
+        sender_id="user-99",
+        channel_id="dm-99",
+        content="hello",
+        metadata={"is_group": False, "conversation_kind": "dm"},
+        provenance=IngressProvenance(
+            provider="telegram",
+            account_id="bot-account",
+            transport="polling",
+            verification=IngressVerification.OAUTH_TOKEN,
+            event_id="event-99",
+            principal=AuthenticatedPrincipal(subject_id="user-99", display_name="Bob"),
+        ),
+    )
+    decision = decide_channel_admission(channel, overflow, "agent:main:telegram:dm:user-99")
+
+    assert decision.admit is False
+    assert decision.reason == "pairing_required"
+    assert decision.pairing_id is None
+    assert decision.pairing_notice is False
+    # The refused sender left no durable row behind.
+    senders = {p.sender_id for p in store.list_pairings(channel_name="telegram-main")}
+    assert senders == {"user-42"}
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_pairing_rpc_accepts_status_filter_pagination_and_code(tmp_path: Path) -> None:
+    store = ChannelDeliveryStore(tmp_path / "delivery.sqlite")
+    records = [
+        store.request_pairing(
+            channel_name="telegram-main",
+            provider="telegram",
+            account_id="bot-account",
+            sender_id=f"user-{i}",
+        )
+        for i in range(3)
+    ]
+    assert all(records)
+
+    class Manager:
+        _delivery_store = store
+
+    admin = RpcContext(
+        conn_id="admin",
+        principal=Principal(
+            role="operator",
+            scopes=frozenset({"operator.admin"}),
+            is_owner=True,
+            authenticated=True,
+        ),
+        channel_manager=Manager(),
+    )
+
+    page = await get_dispatcher().dispatch(
+        "r1",
+        "channels.pairings",
+        {"channelName": "telegram-main", "status": "pending", "limit": 2, "offset": 1},
+        admin,
+    )
+    assert page.error is None
+    assert len(page.payload["pairings"]) == 2
+
+    # Approving by the 8-char code the sender's notice shows.
+    target = records[0]
+    assert target is not None
+    approved = await get_dispatcher().dispatch(
+        "r2",
+        "channels.pairing.approve",
+        {"channelName": "telegram-main", "pairingCode": target.pairing_id[:8]},
+        admin,
+    )
+    assert approved.error is None
+    assert approved.payload["pairing"]["pairingId"] == target.pairing_id
+    assert approved.payload["pairing"]["status"] == "approved"
+
+    unknown = await get_dispatcher().dispatch(
+        "r3",
+        "channels.pairing.revoke",
+        {"channelName": "telegram-main", "pairingCode": "ffffffff"},
+        admin,
+    )
+    assert unknown.error is not None
+    store.close()

--- a/tests/test_channels/test_pairing_store_bounds.py
+++ b/tests/test_channels/test_pairing_store_bounds.py
@@ -1,0 +1,116 @@
+"""Bounds on the pairing store: pending cap, TTL prune, and write suppression.
+
+Every denied DM used to be an unconditional durable write with no deletion
+path — one flood and the operator's approval queue is unreadable forever.
+The bounds must never touch decided rows: approval is a durable grant, and
+revocation only stays enforced while its row survives.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+from opensquilla.channels.delivery_store import (
+    ChannelDeliveryStore,
+)
+
+
+def _request(store: ChannelDeliveryStore, sender: str, **kwargs):
+    return store.request_pairing(
+        channel_name="telegram-main",
+        provider="telegram",
+        account_id="bot-1",
+        sender_id=sender,
+        **kwargs,
+    )
+
+
+def test_pending_cap_refuses_new_senders_without_locking_out_decided_ones(
+    tmp_path: Path,
+) -> None:
+    store = ChannelDeliveryStore(
+        tmp_path / "delivery.sqlite", max_pending_pairings_per_channel=3
+    )
+    approved = _request(store, "veteran")
+    assert approved is not None
+    store.set_pairing_status(
+        channel_name="telegram-main", pairing_id=approved.pairing_id, status="approved"
+    )
+    for i in range(3):
+        assert _request(store, f"stranger-{i}") is not None
+
+    # Queue full: a brand-new sender is refused with a value, not an exception.
+    assert _request(store, "stranger-overflow") is None
+    # An approved sender still gets their row back at cap.
+    veteran = _request(store, "veteran")
+    assert veteran is not None and veteran.status == "approved"
+    # An already-pending sender also still gets their row back.
+    repeat = _request(store, "stranger-1")
+    assert repeat is not None and repeat.status == "pending"
+    # Other channels are not affected by this channel's full queue.
+    other = store.request_pairing(
+        channel_name="slack-main", provider="slack", account_id="bot-2", sender_id="new"
+    )
+    assert other is not None
+    store.close()
+
+
+def test_prune_expires_only_stale_pending_rows(tmp_path: Path) -> None:
+    store = ChannelDeliveryStore(tmp_path / "delivery.sqlite", pending_pairing_ttl_s=3600.0)
+    stale_pending = _request(store, "ghost")
+    approved = _request(store, "grantee")
+    revoked = _request(store, "banned")
+    assert stale_pending and approved and revoked
+    store.set_pairing_status(
+        channel_name="telegram-main", pairing_id=approved.pairing_id, status="approved"
+    )
+    store.set_pairing_status(
+        channel_name="telegram-main", pairing_id=revoked.pairing_id, status="revoked"
+    )
+    # Backdate everything past the TTL: only the pending row may expire —
+    # approval is a durable grant, and deleting a revoked row would let the
+    # sender's next message recreate a fresh pending request.
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("UPDATE channel_pairings SET last_seen_at = last_seen_at - 90000")
+
+    store._prune_stale_pending_pairings(time.time())
+
+    statuses = {p.sender_id: p.status for p in store.list_pairings(channel_name="telegram-main")}
+    assert statuses == {"grantee": "approved", "banned": "revoked"}
+    store.close()
+
+
+def test_repeat_request_in_window_skips_the_durable_write(tmp_path: Path) -> None:
+    store = ChannelDeliveryStore(tmp_path / "delivery.sqlite", pairing_refresh_window_s=3600.0)
+    first = _request(store, "user-1", reply_to="dm-1")
+    assert first is not None and first.request_count == 1
+
+    # Same sender, same route, inside the window: no write happens.
+    repeat = _request(store, "user-1", reply_to="dm-1")
+    assert repeat is not None
+    assert repeat.request_count == 1
+    assert repeat.last_seen_at == first.last_seen_at
+
+    # A changed reply address must write through — the approval notice depends
+    # on the freshest route.
+    moved = _request(store, "user-1", reply_to="dm-2")
+    assert moved is not None
+    assert moved.reply_to == "dm-2"
+    assert moved.request_count == 2
+    store.close()
+
+
+def test_list_pairings_pagination_is_opt_in(tmp_path: Path) -> None:
+    store = ChannelDeliveryStore(tmp_path / "delivery.sqlite")
+    for i in range(5):
+        assert _request(store, f"sender-{i}") is not None
+
+    everything = store.list_pairings(channel_name="telegram-main")
+    assert len(everything) == 5
+
+    page = store.list_pairings(channel_name="telegram-main", limit=2, offset=2)
+    assert len(page) == 2
+    assert [p.sender_id for p in page] == [p.sender_id for p in everything[2:4]]
+    store.close()

--- a/tests/test_cli/test_channels_cmd.py
+++ b/tests/test_cli/test_channels_cmd.py
@@ -308,3 +308,111 @@ def test_channels_add_echoes_resolved_path_and_source(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.stdout
     assert str(project / "opensquilla.toml") in result.stdout
     assert "cwd" in result.stdout.lower()
+
+
+class _FakePairingGatewayClient:
+    """Records pairing RPC calls and replays canned payloads."""
+
+    calls: list[tuple[str, dict]] = []
+    payloads: dict[str, dict] = {}
+
+    async def connect(self, url: str, *, token=None) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    async def call(self, method: str, params: dict | None = None) -> dict:
+        type(self).calls.append((method, params or {}))
+        return type(self).payloads.get(method, {})
+
+
+def _install_fake_gateway(monkeypatch) -> type[_FakePairingGatewayClient]:
+    _FakePairingGatewayClient.calls = []
+    monkeypatch.setattr(
+        "opensquilla.cli.gateway_client.GatewayClient", _FakePairingGatewayClient
+    )
+    return _FakePairingGatewayClient
+
+
+def test_pairings_list_renders_codes_and_passes_status_filter(tmp_path, monkeypatch):
+    _setenv(monkeypatch, tmp_path)
+    fake = _install_fake_gateway(monkeypatch)
+    fake.payloads = {
+        "channels.pairings": {
+            "pairings": [
+                {
+                    "pairingId": "abcdef1234567890",
+                    "pairingCode": "abcdef12",
+                    "channelName": "telegram-main",
+                    "senderId": "user-42",
+                    "senderName": "Alice",
+                    "status": "pending",
+                    "createdAt": "2026-07-16T09:00:00+00:00",
+                    "approvedAt": None,
+                }
+            ]
+        }
+    }
+
+    result = runner.invoke(
+        app,
+        ["channels", "pairings", "list", "telegram-main", "--status", "pending"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake.calls == [
+        ("channels.pairings", {"channelName": "telegram-main", "status": "pending"})
+    ]
+    assert "abcdef12" in result.stdout
+    assert "Alice" in result.stdout
+
+
+def test_pairings_approve_requires_confirmation_and_sends_code(tmp_path, monkeypatch):
+    _setenv(monkeypatch, tmp_path)
+    fake = _install_fake_gateway(monkeypatch)
+    fake.payloads = {
+        "channels.pairing.approve": {
+            "pairing": {"pairingCode": "abcdef12", "senderId": "user-42", "status": "approved"}
+        }
+    }
+
+    # --json without --yes must refuse before any RPC happens.
+    refused = runner.invoke(
+        app, ["channels", "pairings", "approve", "telegram-main", "abcdef12", "--json"]
+    )
+    assert refused.exit_code == 2
+    assert fake.calls == []
+
+    result = runner.invoke(
+        app, ["channels", "pairings", "approve", "telegram-main", "abcdef12", "--yes"]
+    )
+    assert result.exit_code == 0, result.output
+    assert fake.calls == [
+        (
+            "channels.pairing.approve",
+            {"channelName": "telegram-main", "pairingCode": "abcdef12"},
+        )
+    ]
+    assert "approved" in result.stdout.lower()
+
+
+def test_pairings_revoke_uses_the_revoke_rpc(tmp_path, monkeypatch):
+    _setenv(monkeypatch, tmp_path)
+    fake = _install_fake_gateway(monkeypatch)
+    fake.payloads = {
+        "channels.pairing.revoke": {"pairing": {"pairingCode": "abcdef12", "status": "revoked"}}
+    }
+
+    result = runner.invoke(
+        app, ["channels", "pairings", "revoke", "telegram-main", "abcdef12", "--yes"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake.calls == [
+        (
+            "channels.pairing.revoke",
+            {"channelName": "telegram-main", "pairingCode": "abcdef12"},
+        )
+    ]
+    assert "revoked" in result.stdout.lower()

--- a/tests/test_health/test_evaluator.py
+++ b/tests/test_health/test_evaluator.py
@@ -1328,6 +1328,8 @@ def test_channels_evaluator_surfaces_pending_pairings_without_degrading_ready() 
         "pendingPairings": 2,
     }
     commands = [step.command for step in finding.fix_steps if step.command]
+    # The first step is the actionable one: the list every decision starts from.
+    assert commands[0] == "opensquilla channels pairings list telegram-main"
     assert "opensquilla channels status telegram-main --json" in commands
 
 

--- a/tests/test_health/test_recovery_commands.py
+++ b/tests/test_health/test_recovery_commands.py
@@ -29,6 +29,7 @@ _PLACEHOLDER_VALUES = {
 
 _COMMAND_HELP_PATHS = (
     ("channels", "enable"),
+    ("channels", "pairings", "list"),
     ("channels", "restart"),
     ("channels", "status"),
     ("config", "set"),
@@ -293,6 +294,21 @@ def _sample_findings() -> list[HealthFinding]:
                         "configured": True,
                         "status": "dead",
                         "connected": False,
+                    }
+                ]
+            }
+        ),
+        evaluate_channels(
+            {
+                "channels": [
+                    {
+                        "name": "tele gram",
+                        "type": "telegram",
+                        "enabled": True,
+                        "configured": True,
+                        "status": "connected",
+                        "connected": True,
+                        "pendingPairings": 2,
                     }
                 ]
             }


### PR DESCRIPTION
## Scope

Pairing approval could only happen in the control console, and the store behind it grew without bound: every denied DM from a new sender was an unconditional durable write with **no deletion path anywhere**, so one flood made the operator's approval queue unreadable forever.

- **Pairing CLI** — `opensquilla channels pairings list|approve|revoke <channel> <code>`, following the repo's nested-Typer, `--yes`/`--json`, `run_gateway_sync` conventions. Mutations take the 8-char pairing code the sender's notice shows; the approve/revoke RPCs now resolve an optional `pairingCode` param as an alternative to `pairingId` (ambiguous prefix → explicit error). The `channel.<name>.pending_pairings` doctor finding now leads with the real list command instead of a command-less console pointer.
- **Store bounds** — three, none of which can touch a decided row:
  - *Per-channel pending cap* (default 25). A full queue refuses **new** senders with a typed `None` — never an exception, which would kill the channel's dispatch loop — and admission denies them exactly like an unapproved pairing, minus the code and notice. Senders with an existing row (pending, approved, or revoked) always get it back, so a full queue can never lock out an approved user.
  - *Prune-on-write TTL* (default 7 days, every 64th write) for **pending rows only**. Approved rows are durable access grants; revoked rows must survive because revocation is enforced by the row's status — deleting one would let the sender's next message recreate a fresh pending request.
  - *Refresh window* (default 30s) that skips the durable write when a repeat request changes nothing — a re-sending client no longer costs one synchronous commit per message before admission even runs. A changed reply address always writes through, since the approval notice depends on the freshest route.
- **Pagination** — `channels.pairings` accepts opt-in `status`/`limit`/`offset`; the default response stays the complete list, so the Web UI's client-side status buckets and badge counts are unaffected.

## Branch target

`integration/channel-platform` (channel-platform integration line; **not** `main`).

## Linked issue

None

## Release note

Operators can now review and decide pairing requests from the CLI: `opensquilla channels pairings list|approve|revoke`, using the 8-character pairing code from the request notice. The pairing store is bounded — stale pending requests expire after 7 days, each channel holds at most 25 pending requests (approved and revoked pairings are never touched), and repeated requests from the same sender no longer cost a disk write per message.

## Tests

- New `tests/test_channels/test_pairing_store_bounds.py`: cap refusal without locking out decided senders, TTL prune sparing approved/revoked rows, write-suppression window with reply-address write-through, opt-in pagination.
- `tests/test_channels/test_channel_pairing.py`: full-queue admission denial (same reason, no code, no notice, no dispatch-loop exception, no durable row) and the new RPC params (status/limit/offset, approve-by-code, unknown code error).
- `tests/test_cli/test_channels_cmd.py`: pairings list/approve/revoke against a fake gateway — RPC shapes, confirmation gating (`--json` without `--yes` exits 2 before any RPC), rendering.
- `tests/test_health/test_recovery_commands.py`: the new fix command validates against real CLI `--help` (including a channel name that needs shell quoting).
- `uv run ruff check src tests` — clean; `uv run mypy src/opensquilla` — clean (803 files).
- `tests/test_channels tests/test_health tests/test_cli tests/test_gateway`: 3335 passed.

## Safety notes

Refusal is a return value on the admission path, never an exception (an exception there kills the channel dispatch loop). The bounds cannot expire or delete approved/revoked rows, so access grants and revocations remain durable. RPC changes are additive and opt-in; the default `channels.pairings` response is unchanged. No new dependencies; no Web UI changes required.

## Third-party origin

None — original work.