### PR TITLE
Make Web chat runtime cap opt-in

### DIFF
--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -27,9 +27,9 @@
 # agent_stream_heartbeat_interval_seconds = 15.0
 # agent_stream_idle_timeout_seconds = 180.0
 # webui_stream_idle_grace_seconds = 210.0
-# Absolute Agent deadline for ordinary interactive Web chat turns. Coding and
-# meta turns keep the regular runtime budget; 0 disables this Web-only cap.
-# web_chat_runtime_timeout_seconds = 1800.0
+# Optional absolute Agent deadline for ordinary interactive Web chat turns.
+# Disabled by default; set a positive value such as 1800.0 to enable the cap.
+# web_chat_runtime_timeout_seconds = 0.0
 
 # WebSocket per-connection outbound writer queue. When enabled (default),
 # each WS connection gets a bounded asyncio queue + dedicated writer task.

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -2179,10 +2179,10 @@ class GatewayConfig(BaseSettings):
     # Agent runtime timeout (whole turn lifecycle). ``None`` means use the
     # long built-in runtime default; ``0`` disables the runtime budget.
     agent_runtime_timeout_seconds: float | None = None
-    # Safety cap for ordinary interactive Web chat turns. Coding and meta
-    # turns retain the regular agent runtime budget. ``0`` disables this
-    # Web-specific cap; an explicit TurnRunner timeout still has priority.
-    web_chat_runtime_timeout_seconds: float = Field(default=1800.0, ge=0.0)
+    # Optional safety cap for ordinary interactive Web chat turns. Coding and
+    # meta turns retain the regular agent runtime budget. Disabled by default;
+    # an explicit TurnRunner timeout still has priority when the cap is enabled.
+    web_chat_runtime_timeout_seconds: float = Field(default=0.0, ge=0.0)
     # Per-iteration timeout: one LLM call + its tool executions. ``None``
     # means use the AgentConfig default.
     agent_iteration_timeout_seconds: float | None = None

--- a/tests/test_engine/test_runtime_web_chat_timeout.py
+++ b/tests/test_engine/test_runtime_web_chat_timeout.py
@@ -45,18 +45,21 @@ def _override(
     )
 
 
-def test_web_chat_runtime_timeout_defaults_to_thirty_minutes() -> None:
+def test_web_chat_runtime_timeout_defaults_to_disabled() -> None:
     config = GatewayConfig()
     runner = TurnRunner(provider_selector=None, config=config)
 
-    assert config.web_chat_runtime_timeout_seconds == 1800.0
-    assert _override(runner) == 1800.0
+    assert config.web_chat_runtime_timeout_seconds == 0.0
+    assert _override(runner) is None
 
 
 def test_web_chat_runtime_timeout_keeps_shorter_existing_budget() -> None:
     runner = TurnRunner(
         provider_selector=None,
-        config=GatewayConfig(agent_runtime_timeout_seconds=900.0),
+        config=GatewayConfig(
+            agent_runtime_timeout_seconds=900.0,
+            web_chat_runtime_timeout_seconds=1800.0,
+        ),
     )
 
     assert _override(runner) == 900.0
@@ -65,7 +68,10 @@ def test_web_chat_runtime_timeout_keeps_shorter_existing_budget() -> None:
 def test_web_chat_runtime_timeout_preserves_disable_semantics() -> None:
     runtime_disabled = TurnRunner(
         provider_selector=None,
-        config=GatewayConfig(agent_runtime_timeout_seconds=0.0),
+        config=GatewayConfig(
+            agent_runtime_timeout_seconds=0.0,
+            web_chat_runtime_timeout_seconds=1800.0,
+        ),
     )
     cap_disabled = TurnRunner(
         provider_selector=None,
@@ -97,7 +103,10 @@ def test_explicit_runtime_timeout_has_priority_over_web_cap() -> None:
     ],
 )
 def test_web_chat_runtime_timeout_exemptions(case: str) -> None:
-    runner = TurnRunner(provider_selector=None, config=GatewayConfig())
+    runner = TurnRunner(
+        provider_selector=None,
+        config=GatewayConfig(web_chat_runtime_timeout_seconds=1800.0),
+    )
     context = _web_context()
     input_mode = "user"
     metadata: dict[str, Any] = {}
@@ -136,8 +145,17 @@ def test_web_chat_runtime_timeout_rejects_negative_config() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config_kwargs", "expected_timeout"),
+    [
+        ({}, 48 * 60 * 60),
+        ({"web_chat_runtime_timeout_seconds": 1800.0}, 1800.0),
+    ],
+)
 async def test_web_chat_runtime_timeout_reaches_agent_config(
     monkeypatch: pytest.MonkeyPatch,
+    config_kwargs: dict[str, Any],
+    expected_timeout: float,
 ) -> None:
     seen_configs: list[dict[str, Any]] = []
     real_agent_config = AgentConfig
@@ -166,7 +184,7 @@ async def test_web_chat_runtime_timeout_reaches_agent_config(
     runner = TurnRunner(
         provider_selector=selector,
         session_manager=session_manager,
-        config=GatewayConfig(),
+        config=GatewayConfig(**config_kwargs),
     )
 
     async for _ in runner.run(
@@ -177,4 +195,4 @@ async def test_web_chat_runtime_timeout_reaches_agent_config(
     ):
         pass
 
-    assert any(config.get("timeout") == 1800.0 for config in seen_configs)
+    assert any(config.get("timeout") == expected_timeout for config in seen_configs)


### PR DESCRIPTION
## Scope

Scope boundary: Restore ordinary interactive Web chat to the regular Agent runtime budget by disabling the Web-only absolute cap by default, while preserving positive values as an explicit operator opt-in.

Non-goals: No changes to ensemble quorum, proposer/aggregator deadlines, fallback, cancellation cleanup, or retry behavior from #704.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #704

If None, reason: N/A

## Release Note

Release note: Ordinary Web chat no longer has a default 30-minute absolute runtime cap; operators can still enable the Web-only cap explicitly.

## Tests

Ruff: `ruff check src/opensquilla/gateway/config.py tests/test_engine/test_runtime_web_chat_timeout.py`

Pytest: `PYTHONPATH=src pytest -q tests/test_engine/test_runtime_web_chat_timeout.py` — 15 passed

Build: not run locally; this configuration-only change does not alter build artifacts.

Regression tests: added

Notes: Coverage verifies the disabled default, the restored 48-hour regular runtime budget, explicit opt-in capping, shorter existing budgets, disable semantics, explicit timeout precedence, and surface exemptions.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: gateway

Maintainer-only note: No credentials or live provider calls are required.

## Safety

The change is platform-neutral. Existing explicit positive `web_chat_runtime_timeout_seconds` values retain their current behavior, and `0` remains the disable value. No persisted state, protocol fields, secrets, transcripts, or local-only artifacts are changed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
