### PR TITLE
Block case-aliased code-task migration roots

### DIFF
--- a/src/opensquilla/migration/opensquilla_home.py
+++ b/src/opensquilla/migration/opensquilla_home.py
@@ -264,12 +264,46 @@ def _paths_overlap(first: Path, second: Path) -> bool:
 def _path_is_relative_to_lexical(path: Path, root: Path) -> bool:
     """Return whether ``path`` is equal to or below ``root`` without following links."""
 
-    path_value = os.path.normcase(os.path.normpath(str(path.expanduser().absolute())))
-    root_value = os.path.normcase(os.path.normpath(str(root.expanduser().absolute())))
+    path_absolute = path.expanduser().absolute()
+    root_absolute = root.expanduser().absolute()
+    path_value = os.path.normcase(os.path.normpath(str(path_absolute)))
+    root_value = os.path.normcase(os.path.normpath(str(root_absolute)))
     try:
-        return os.path.commonpath([path_value, root_value]) == root_value
+        if os.path.commonpath([path_value, root_value]) == root_value:
+            return True
     except ValueError:
         return False
+
+    def plain_directory_identity(candidate: Path) -> tuple[int, int] | None:
+        try:
+            result = candidate.lstat()
+        except OSError:
+            return None
+        attributes = int(getattr(result, "st_file_attributes", 0) or 0)
+        if (
+            stat.S_ISLNK(result.st_mode)
+            or attributes & _REPARSE_POINT_ATTRIBUTE
+            or not stat.S_ISDIR(result.st_mode)
+        ):
+            return None
+        return int(result.st_dev), int(result.st_ino)
+
+    # Darwin's ``normcase`` is intentionally a no-op even on the usual
+    # case-insensitive APFS volume. Compare existing plain-directory identities
+    # so an alternate spelling such as CODE-TASK cannot bypass the lexical
+    # exclusion, while a distinct directory on a case-sensitive volume remains
+    # valid. Missing descendants are skipped until an existing ancestor is found.
+    root_identity = plain_directory_identity(root_absolute)
+    if root_identity is None:
+        return False
+    current = path_absolute
+    while True:
+        if plain_directory_identity(current) == root_identity:
+            return True
+        parent = current.parent
+        if parent == current:
+            return False
+        current = parent
 
 
 def is_valid_opensquilla_home(path: Path) -> bool:

--- a/tests/test_migration/test_opensquilla_home_migration.py
+++ b/tests/test_migration/test_opensquilla_home_migration.py
@@ -2185,6 +2185,46 @@ def test_configured_data_root_inside_source_code_task_blocks_import(
     assert not applied_target.exists()
 
 
+@pytest.mark.parametrize("configured_kind", ["workspace", "agent-workspace"])
+def test_case_alias_root_inside_source_code_task_blocks_import(
+    tmp_path: Path,
+    configured_kind: str,
+) -> None:
+    source = _build_source_home(tmp_path)
+    actual = source / "code-task" / "selected-subdir"
+    actual.mkdir(parents=True)
+    (actual / "must-not-migrate.txt").write_text(
+        "local run data\n",
+        encoding="utf-8",
+    )
+    configured = source / "CODE-TASK" / "selected-subdir"
+    try:
+        if not configured.samefile(actual):
+            pytest.skip("filesystem does not expose a case-insensitive alias")
+    except OSError:
+        pytest.skip("filesystem is case-sensitive")
+
+    payload = tomllib.loads((source / "config.toml").read_text(encoding="utf-8"))
+    if configured_kind == "workspace":
+        payload["workspace_dir"] = str(configured)
+    else:
+        payload["agents"] = [{"id": "research", "workspace": str(configured)}]
+    (source / "config.toml").write_text(tomli_w.dumps(payload), encoding="utf-8")
+    target = tmp_path / "target-home"
+
+    report = _run(source, target, apply=True)
+
+    data_root_errors = [
+        item
+        for item in _errors(report)
+        if item["kind"] == "preflight/data-root"
+        and item["source"] == str(configured)
+    ]
+    assert data_root_errors
+    assert data_root_errors[0]["details"]["stable_code"] == "configured_code_task_root"
+    assert not target.exists()
+
+
 def test_dotenv_data_root_inside_source_code_task_blocks_import(tmp_path: Path) -> None:
     source = _build_source_home(tmp_path)
     configured = source / "code-task"


### PR DESCRIPTION
## Scope

Scope boundary: Prevent case-insensitive filesystem aliases from routing configured data roots or agent workspaces into excluded machine-local `code-task` trees.

Non-goals: General filesystem case normalization, POSIX mount-boundary isolation, or changes to source-link import policy.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Follow-up to the profile migration review and merged PR #671.

## Release Note

Release note: Profile migration now rejects mixed-case aliases that resolve inside the source `code-task` directory on case-insensitive filesystems.

## Tests

Ruff: `uv run ruff check src/opensquilla/migration/opensquilla_home.py tests/test_migration/test_opensquilla_home_migration.py` passed.

Pytest: `.venv/bin/pytest -q tests/test_migration/test_opensquilla_home_migration.py` — 171 passed, 2 skipped.

Build: Not needed; Python-only migration preflight change.

Regression tests: added

Notes: The new regression covers configured workspace and agent-workspace aliases on case-insensitive filesystems. `uv run mypy src/opensquilla/migration/opensquilla_home.py --show-error-codes` and `git diff --check` passed.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are committed. The identity fallback uses no-follow metadata and rejects links and Windows reparse points.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.

## Platform Contract

- macOS case-insensitive volumes reject alternate-case aliases into `code-task`.
- Linux and case-sensitive volumes preserve distinct-directory behavior.
- Windows keeps its existing normalized lexical path behavior.
- No persisted state, database, CLI, RPC, or public wire contract changes.