### PR TITLE
feat(ranking): derive a user profile from Dream-consolidated feedback

### DIFF
--- a/docs/features/LLM-ensemble-design.md
+++ b/docs/features/LLM-ensemble-design.md
@@ -472,9 +472,15 @@ Before ranking, runtime builds four replaceable inputs:
    and do not discard an otherwise valid task profile.
 3. **User profile** — controlled by
    `llm_ensemble.ranking_user_profile_enabled` (default `true`). When enabled,
-   the current implementation uses a versioned global mock with permissions,
-   cost/latency preference, and empty feedback priors. When disabled, runtime
-   does not build or send that mock and ranking receives no user profile.
+   runtime overlays the learned profile at `router/profile.json` — permissions,
+   cost/latency preference, and the feedback history derived from thumb
+   ratings — onto the `mock_user_profile` baseline, which supplies the shape
+   and every default the file does not carry. The file is refused whole and
+   the baseline used alone (`profile_source = fallback_mock`) when it is
+   missing, unreadable, or fails validation. When disabled, runtime builds no
+   profile at all and ranking receives none.
+
+   The profile is never sent to the task analyzer; only ranking reads it.
 4. **Model registry snapshot** — composed from the routed model, enabled
    `llm_ensemble.candidates`, non-default legacy `model_options`, configured
    SquillaRouter tiers, and the packaged twenty-model mock registry. Unknown
@@ -713,7 +719,7 @@ tunable Step2 behavior lives in
 | `task_profile_schema` | accepted task constraints and session intents |
 | `task_analyzer` | timeout, input/response limits, output tokens, temperature, thinking |
 | `fallback_task_profile` | deterministic analyzer-failure profile and tier risk |
-| `mock_user_profile` | current global mock permissions, preferences, and history |
+| `mock_user_profile` | baseline permissions, preferences, and history; the learned profile at `router/profile.json` is overlaid on it at the engine read seam, and it is used as-is when no valid file exists |
 | `synthetic_model` | facts and priors for deployments missing a catalog profile |
 | `hard_filter` | eligible/unavailable states and default required modalities |
 | `exploration` | reserved trace declaration; must remain `false` / propensity `1.0` until exploration is implemented |

--- a/docs/features/ranking-user-profile-spec.md
+++ b/docs/features/ranking-user-profile-spec.md
@@ -136,8 +136,6 @@ exactly.
 ```json
 {
   "schema_version": 1,
-  "profile_version": "<content hash>",
-  "profile_source": "global_json",
   "permission": {
     "allow_models": [],
     "deny_models": [],
@@ -147,8 +145,8 @@ exactly.
     "quality_latency_tradeoff": "balanced",
     "cost_sensitivity": "medium"
   },
+  "model_counts": {"<model_id>": {"up": 0, "down": 0}},
   "history": {
-    "model_counts": {"<model_id>": {"up": 0, "down": 0}},
     "positive_model_ids": [],
     "negative_model_ids": [],
     "feedback_count": 0,
@@ -177,9 +175,20 @@ vocabularies — `risk_allowlist` values, `quality_latency_tradeoff`,
 two cannot drift apart. Drift here is not a crash; it is a hand-edited value
 that one validator accepts and the other silently ignores.
 
-`profile_version` is a content hash of the profile body, so it changes exactly
-when the profile changes. `profile_source` is `global_json`, or `fallback_mock`
-when the file is missing or unreadable.
+**Provenance is not in the file.** `profile_version` and `profile_source`
+describe a *read* — which profile ranking got, and what was in it — so the read
+seam derives both and the writer stores neither. `profile_version` is a content
+hash of the resolved profile, taken after the overlay, so it changes exactly
+when what ranking ranked with changes; `profile_source` is `global_json`, or
+`fallback_mock` when the file is missing or unusable.
+
+Storing them would be worse than redundant. The file is hand-editable, so a
+stored `profile_source` lets it claim `fallback_mock` while ranking uses it, and
+a stored `profile_version` misses the one edit the file exists for: `deny_models`
+has no TOML key, and editing it never runs the write path that would stamp a new
+version. A stored hash would also be computed over a different body than the
+emitted one — two values under one name, so an operator matching a decision's
+version against the file finds a mismatch for an unchanged profile.
 
 Writes are atomic (`tmp` + `os.replace`) under a module-level `_write_lock`,
 mirroring `feedback.py:_write_lock` — RPC submissions run on worker threads and

--- a/docs/features/ranking-user-profile-spec.md
+++ b/docs/features/ranking-user-profile-spec.md
@@ -1,7 +1,8 @@
 # Ranking User Profile Spec
 
-Date: 2026-07-17
-Status: Draft
+Date: 2026-07-18
+Status: Draft (revised — profile history is now derived from Dream-consolidated
+memory rather than a standalone tally; see Design)
 
 ## Problem
 
@@ -39,10 +40,12 @@ events are clean, but the analyzer request is not. It costs nothing today
 
 ## Goals
 
-- Replace the hardcoded mock with a single global profile stored as one local
-  JSON file.
-- Derive `history` from the feedback that is already being collected, so
-  `S_user` varies per candidate and can affect ordering.
+- Replace the hardcoded mock with a single global profile. Its `history` is
+  *derived* from Dream-consolidated memory (not a store of its own); its
+  hand-editable `permission`/`preference` live in one local JSON file.
+- Derive `history` from the thumbs feedback that is already being collected — by
+  transcribing each thumb into a preference memory that rides the Dream
+  pipeline — so `S_user` varies per candidate and can affect ordering.
 - Stop sending the profile to the task analyzer.
 - Preserve the existing fail-open contract: no profile failure may fail a turn
   or abort ranking.
@@ -118,208 +121,178 @@ File layout precedent — `self_learning/store.py:1-17`:
 ```
 
 `active` establishes that a global file at the router root is an existing
-convention. Conventions to copy from `feedback.py` / `store.py`: pure
-functions, injectable `home`, no raw prompt text, best-effort writes wrapped so
-a turn never fails, `_write_lock` serializing read-modify-write.
+convention — this is where `profile.json` lives, sibling of `active`. Conventions
+carried over from `feedback.py` / `store.py`: pure functions, injectable `home`,
+no raw prompt text, best-effort reads that never fail a turn. (The profile no
+longer *writes* on the turn path — its learned half is derived from memory — so
+there is no read-modify-write lock to copy; the append to the Dream scan note is
+`O_APPEND`-atomic and needs none.)
 
 ## Design
 
-Four changes. Changes 1-3 are one unit (the file, its writer, its reader).
-Change 4 depends on nothing here and ships first on its own.
+The learned half of the profile — `history` — is not stored. It is **derived at
+read time** from the same Dream-consolidated memory the rest of the system
+already keeps, so there is no second evidence store to keep reconciled with the
+first. A thumb becomes a preference *memory*; Dream promotes it into `MEMORY.md`
+like any other durable fact; and the read seam projects the consolidated lines
+back into the history shape ranking already consumes.
 
-### 1. The file
+Four changes. Changes 1-3 are one unit (the transcription, the projection, the
+hand-edit file). Change 4 depends on nothing here and ships first on its own.
 
-`~/.opensquilla/router/profile.json` — one global file, sibling of `active`.
-New module `self_learning/profile.py`, following `feedback.py`'s conventions
-exactly.
+Why derive instead of store: the earlier draft of this spec accumulated a
+standalone `model_counts` tally in `profile.json`, written on every thumb. That
+put a second system of record beside Dream's — one that could disagree with the
+operator's own consolidated memory, needed its own lock and atomic-write path,
+and its own retention story. Routing preference is a *memory* ("this operator
+prefers Sonnet for coding"), and the codebase already has a component whose job
+is to accumulate, deduplicate, and consolidate memories. Reusing it means the
+preference the operator can read in `MEMORY.md` and the preference ranking acts
+on are the *same* sentence, not two representations that drift.
 
-```json
-{
-  "schema_version": 1,
-  "permission": {
-    "allow_models": [],
-    "deny_models": [],
-    "risk_allowlist": ["low", "medium", "high"]
-  },
-  "preference": {
-    "quality_latency_tradeoff": "balanced",
-    "cost_sensitivity": "medium"
-  },
-  "model_counts": {"<model_id>": {"up": 0, "down": 0}},
-  "history": {
-    "positive_model_ids": [],
-    "negative_model_ids": [],
-    "feedback_count": 0,
-    "last_updated_at": "<iso8601>"
-  }
-}
-```
+### 1. Transcribing a thumb into a preference memory
 
-`permission` and `preference` are hand-editable — this file *is* the
-configuration surface, so no new TOML keys are needed. `history` is
-machine-written.
+On `router.feedback.submit`, after `write_feedback()` succeeds, the handler
+transcribes the thumb into one preference line and appends it to the Dream scan
+note. New module `self_learning/preference_projection.py`,
+`transcribe_thumb(model, rating) -> str | None`:
 
-`model_counts` is the raw per-model tally and the only new field. It is written
-and read only by `profile.py` and stripped before the profile reaches ranking,
-so what ranking receives is exactly the mapping shape its consumers already
-expect. `positive_model_ids` / `negative_model_ids` / `feedback_count` are
-derived from the tally on write. Keeping the raw tally is what lets a rating be
-revised or revoked without replaying the whole JSONL.
+- `up`   → `` - prefers routing to `model:<id>` ``
+- `down` → `` - do not route to `model:<id>` ``
+- `neutral`, or a model that cannot be resolved → `None` (write nothing).
 
-**The tally is the system of record, not a cache of the log.** Replay is not
-merely unimplemented, it is impossible: `feedback.jsonl` is pruned by
-`retention_days` (default 30) while `model_counts` accumulates forever, so the
-log is lossy by design and cannot rebuild the tally. Nothing reconciles the two
-because nothing can. This is the right trade — replay would mean retaining the
-log indefinitely, against the same retention and privacy posture that makes the
-file storable — but it is what puts the whole weight of correctness on the delta
-path: a lost or double-counted delta is permanent. That is why the merge-then-
-filter order in `load_feedback_map` and the lock spanning read-append-fold are
-tested rather than merely documented.
+The line is appended to `<global-workspace>/memory/routing-preferences.md`
+(`ROUTING_PREF_FILENAME`). That directory is exactly where Dream scans for
+evidence; the file is **not** `MEMORY.md`, which Dream treats as the
+consolidation *target* and skips as a scan source — a preference written
+straight there would never become evidence.
 
-**Validation.** `profile.py` needs its own loader-validator: the existing
-checks at `ranking_router.py:851-913` read
-`config["mock_user_profile"][...]` and validate the *ranking config*, not a
-free-standing profile file. The new validator must enforce the same
-vocabularies — `risk_allowlist` values, `quality_latency_tradeoff`,
-`cost_sensitivity` — and a test must pin both to the same enum sources so the
-two cannot drift apart. Drift here is not a crash; it is a hand-edited value
-that one validator accepts and the other silently ignores.
+**Two contracts make the line survive the pipeline.** Both are load-bearing and
+both are covered by tests:
 
-**Provenance is not in the file.** `profile_version` and `profile_source`
-describe a *read* — which profile ranking got, and what was in it — so the read
-seam derives both and the writer stores neither. `profile_version` is a content
-hash of the resolved profile, taken after the overlay, so it changes exactly
-when what ranking ranked with changes; `profile_source` is `global_json`, or
-`fallback_mock` when the file is missing or unusable.
+1. **The verb lands in Dream's classifier.** Dream's `classify_signal`
+   (`memory/dream/candidates.py`) buckets a line by keyword — `"prefers"` →
+   positive, `"do not"`/`"don't"` → correction. `transcribe_thumb` picks its
+   verbs to match, so a transcribed thumb is classified as evidence Dream will
+   promote rather than discarded as chatter.
+2. **The model id rides in a backticked marker.** Dream promotes by an LLM patch
+   that may reword a bullet, so the id cannot live in prose — it lives in an
+   inline-code token `` `model:<id>` ``. `promotion_patch_prompt`
+   (`memory/dream/prompts.py`) is instructed to preserve that token verbatim,
+   backticks and all, because splitting or unquoting it silently drops a routing
+   preference. The projection matches the marker, never the prose.
 
-Storing them would be worse than redundant. The file is hand-editable, so a
-stored `profile_source` lets it claim `fallback_mock` while ranking uses it, and
-a stored `profile_version` misses the one edit the file exists for: `deny_models`
-has no TOML key, and editing it never runs the write path that would stamp a new
-version. A stored hash would also be computed over a different body than the
-emitted one — two values under one name, so an operator matching a decision's
-version against the file finds a mismatch for an unchanged profile.
+**Which model the thumb names is still the load-bearing detail** — attributing
+to the wrong one trains on a model the user never read. The rated model is
+resolved exactly as before: on an ensemble turn it is the **aggregator**, in
+**config space** (`RankedModel.model_id`), the namespace `_user_score` matches
+against — not `usage.model` (response space, forensics only). When the model
+cannot be resolved, `transcribe_thumb` returns `None` and no line is written:
+fail closed, never credit a guess. (`executed_kind = "ensemble"` still credits
+the aggregator alone — provisional, see "Revisit".)
 
-Writes are atomic (`tmp` + `os.replace`) under a module-level `_write_lock`,
-mirroring `feedback.py:_write_lock` — RPC submissions run on worker threads and
-a lost rating is a defect.
+**No lock, no read-before-write, no decrement.** This is the whole payoff of
+deriving. Appending a line is `O_APPEND`-atomic for a short bullet, so
+concurrent submits need no `profile_update_lock` — the entire race class the
+standalone tally required is gone. A thumb toggled to `neutral` does not
+decrement anything: neutral simply writes nothing. A revocation is expressed the
+way memory expresses everything else — a later, contradicting line ("do not
+route to X" after "prefers X"), which the projection collapses to *neither*
+list. The tradeoff: a neutral cannot cleanly un-say a past `prefers`; only an
+explicit opposite thumb, or Dream consolidating the contradiction away, retracts
+it. For a single-operator preference nudge that is the honest behavior, and it
+buys the deletion of the lock, the ordering contract, and the "impossible
+replay" problem the tally had.
+
+**`feedback.jsonl` is untouched.** `write_feedback()` / `load_feedback_map()`
+still record the raw thumb stream for the offline trainer
+(`alignment`/`dataset`); this change only *adds* the transcription beside it. The
+effective-rating semantics that trainer relies on (merge-then-filter,
+last-write-wins) are unchanged and still tested.
 
 **Privacy contract.** Model identity tokens, enum tokens, and integers only. No
-prompt text, no response text. Same bar as `feedback.jsonl`.
+prompt text, no response text. The transcribed line carries a model id and a
+fixed verb, nothing from the request or reply — same bar as `feedback.jsonl`.
 
-### 2. Updating history on feedback
+### 2. Projecting memory into history
 
-`router.feedback.submit` **already resolves the decision row it needs**
-(`rpc_router.py:144-158`):
+`project_history(memory_text) -> {positive_model_ids, negative_model_ids,
+feedback_count}` (also in `preference_projection.py`) is a pure string function:
+it scans consolidated `MEMORY.md` text for `` `model:<id>` `` markers, reads each
+line's direction from the same verbs Dream classified on, and folds them into the
+history shape.
 
-```python
-record = await anyio.to_thread.run_sync(writer.get_decision, decision_id)
-if record is None:
-    return {"accepted": False, "reason": "decision_not_found"}
+Rules, chosen to say the same thing `_user_score` would compute anyway:
+
+- A model asserted in **both** directions lands in **neither** list. `_user_score`
+  computes `signal = int(in_positive) - int(in_negative)` (`:3000-3002`), so
+  membership in both cancels to zero; excluding it says so honestly and matches
+  how a consolidated contradiction reads.
+- `feedback_count` is the number of preference lines seen. It drives
+  `confidence = min(1.0, feedback_count / 20)`, so `S_user` ramps with how much
+  the memory actually says about routing rather than swinging to an extreme on
+  one line.
+- A line with no marker, or no preference verb, contributes nothing — ordinary
+  memories (`- The user likes dark mode`) are invisible to the projection.
+
+The projection imports only the standard library — no `provider`, `agents`, or
+`memory` — so it stays on the clean side of the `self_learning` layering rule
+and the engine seam owns path resolution.
+
+### 3. The hand-edit file and reading the profile
+
+`profile.json` **survives, but only as the hand-edit surface** for
+`permission`/`preference` — `deny_models` has no TOML key, so the file is the
+only place to set it. Its write path is deleted: `update_profile_for_rating`,
+`_apply`, `_derive_history`, `_atomic_write`, `profile_update_lock`, and the
+`model_counts` field are all gone. What remains in `self_learning/profile.py` is
+a read surface: `load_profile()` (absent/malformed/non-object → `None`), a
+mtime-keyed cache handing out copies, `content_version()`, and `profile_path()`.
+
+The read seam is `_resolve_user_profile` in `engine/runtime.py`, called from the
+runtime injection point (formerly `mock_user_profile(...)` at `runtime.py:5508`).
+It composes the two sources:
+
+```
+base      = mock_user_profile(ranking_config)          # deterministic skeleton
+memory    = read <global-workspace>/MEMORY.md          # None if absent/unreadable
+history   = project_history(memory or "")              # overlaid into base["history"]
+stored    = load_profile()                             # hand-edit permission/preference
 ```
 
-`get_decision` (`router_decision_writer.py:411`) selects every column of
-`_COLUMNS`, which includes `model` (`:65`) — already a sanitized token column
-(`_TEXT_TOKEN_COLUMNS`, `:81`). Its docstring names this exact use: "Reverse-
-lookup surface for **feedback attribution**".
+- The **global workspace** is `resolve_agent_workspace_dir("main", config)` —
+  the same resolution Dream uses at both its wiring sites, so the note Dream
+  scans, the `MEMORY.md` Dream writes, and the `MEMORY.md` this seam reads are
+  guaranteed the same file with no manager logic duplicated.
+- Projected history overlays **only keys the base already defines**. A hand-edit
+  file overlays **only** `permission`/`preference`, and only after passing
+  `validate_user_profile`; an invented key is dropped, an invalid enum
+  (`cost_sensitivity: "very_high"`) **refuses the whole file and drops the
+  derived history too** — a config the operator got half-wrong is untrustworthy
+  whole, and `_cost_latency_weights` would silently route as if the typo were
+  unmade.
 
-The lookup needs no new query and no new schema, and it is already off the event
-loop and already fail-open. **But the column does not yet hold the right value.**
-On ensemble turns `record["model"]` names the *classifier's* pick, not the model
-that authored the reply: `router_decision_record.py:227` stages the classifier's
-choice, and the realignment at `:268-273` is guarded `if not ensemble_enabled:`.
-Attributing feedback to it would train the profile on a model the user never
-read. Unit 2.A fixes the writer first; only then is the column a valid key.
+**Provenance describes the read, never the file.** `profile_source` is
+`"dream_memory"` when memory was read (even if it was present-but-empty) or a
+valid hand-edit file was used; `"fallback_mock"` only when neither source was
+read (memory absent *and* no valid file) or on any exception. Distinguishing
+present-empty from absent is why the memory read returns `None` (absent) vs `""`
+(present, says nothing about routing). `profile_version` is a content hash taken
+*after* the overlay, so it changes exactly when what ranking ranked with changes;
+a `profile_source`/`profile_version` written *into* the file is ignored, because
+a hand-editable file could otherwise claim `fallback_mock` while ranking uses it.
 
-The corrected key is `final_request["execution"]["model"]`, staged by
-`_member_execution_trace` (`ensemble.py:1457`) from `cfg.model`.
+Any failure — unreadable memory, malformed file, failed validation, an exception
+mid-resolution — degrades to a freshly rebuilt `mock_user_profile(...)` with
+`profile_source = "fallback_mock"` and logs a warning. Never raises, never fails
+a turn, never returns a half-merge.
 
-**Which namespace the key inhabits is the load-bearing detail**, and getting it
-wrong survived three review rounds. The key must live in **config space** — the
-same namespace as `RankedModel.model_id`, which is what `_user_score` matches
-`positive_model_ids`/`negative_model_ids` against. `cfg.model ≡
-RankedModel.model_id` holds by construction (`ensemble.py:1830` sets
-`model=decision.aggregator.model_id`; `_member_provider_config` only strips), so
-the join is safe. `usage.model` (`:1520`) is **response space** — what the
-provider reports it actually ran — and is forensics only. Sourcing the key there
-would silently mismatch the registry on any provider that renames or versions a
-model in its response. When the key cannot be resolved, fail **closed**: write
-`None` and skip the update rather than attribute to a guess.
-
-The change is: after `write_feedback()` succeeds, increment
-`model_counts[<key>][rating]` and rewrite the derived fields.
-
-Rules:
-
-- **Read `load_feedback_map()` before `write_feedback()` appends.** The
-  decrement rule below needs the *previous* effective rating for this
-  `decision_id`; reading after the append returns the new one and the decrement
-  silently becomes a no-op. Ordering is part of the contract, not an
-  implementation detail.
-- Use the effective rating, not the raw append. `load_feedback_map()`
-  (`feedback.py:149`) already resolves last-write-wins, so a thumb toggled back
-  to `neutral` must **decrement** the previous rating rather than be ignored.
-  Getting this wrong makes revocation impossible.
-- `neutral` contributes to neither list and does not count toward
-  `feedback_count`.
-- A model goes in `positive_model_ids` when `up > down`, `negative_model_ids`
-  when `down > up`, and **neither when equal**. `_user_score` computes `signal`
-  as `int(in_positive) - int(in_negative)` (`:3000-3002`), so membership in both
-  would silently cancel to zero — excluding it says the same thing honestly.
-- `feedback_count` is the total of non-neutral ratings. It drives
-  `confidence = min(1.0, feedback_count / 20)`, so `S_user` ramps in gradually
-  instead of swinging to an extreme on the first click.
-- `executed_kind = "ensemble"` attributes to the aggregator only. It authored
-  the text the user actually read; the proposers' drafts were never shown. This
-  is **provisional** — see "Revisit" below.
-- The whole update is wrapped `try/except` → `log.warning`. The RPC already
-  refuses to fail a client on a feedback write error (`rpc_router.py:194-198`);
-  a profile update failure must be no louder.
-
-Because counts accumulate in the file, they do not decay when
-`router_decision_writer` prunes at 30 days — the decision row only needs to
-exist at the moment the thumb is clicked. A thumb on a pruned decision already
-returns `decision_not_found` and writes no feedback at all
-(`rpc_router.py:151-158`); that is pre-existing behavior this spec neither
-worsens nor fixes.
-
-### 3. Reading it
-
-`runtime.py:5508` becomes:
-
-```python
-user_profile = load_profile() if ranking_user_profile_enabled else None
-```
-
-Cached in-process, **invalidated on mtime change** — not on write alone.
-
-The packaged ranking config is cached and requires a restart to pick up edits
-(design doc §3.9), but copying that here would be wrong. `profile.json` is
-unlike that file in one decisive way: it *rewrites itself* while the process
-runs, every time a thumb is clicked. So an invalidation path has to exist
-regardless. Keying it on write alone produces genuinely confusing behavior —
-the file updates itself when you click a thumb, but ignores you when you
-hand-edit `deny_models`. An `os.stat` per turn is microseconds against a turn
-that already spends seconds in LLM calls, and it makes the file behave the way
-its being hand-editable implies.
-
-Any failure — missing file, malformed JSON, failed validation — degrades to
-`mock_user_profile(ranking_config)` with `profile_source = "fallback_mock"` and
-logs a warning. Never raises, never fails a turn.
-
-`ensemble.py:1718` already prefers `inputs["user_profile"]`, so the runtime path
-needs no change there. Its `:1724` fallback **stays on `mock_user_profile()`**.
-Pointing it at `load_profile()` would be actively harmful: that fallback is what
-callers with no `inputs["user_profile"]` get — benchmarks and the routing
-experiment runner among them — and it would silently feed the operator's
-personal profile into runs that must stay deterministic and reproducible. The
-two seams *should* disagree: `runtime.py:5508` is the one place a real user's
-profile enters, and it is the only read seam this spec adds.
-
-`mock_user_profile()` and its JSON block **stay** — they are the deterministic
-test fixture and the `enabled = false` ablation baseline, and removing them
-would churn the config validator's exact-key-set contract for no benefit.
+`ensemble.py`'s fallback **stays on `mock_user_profile()`**. Pointing it at the
+derived profile would silently feed the operator's personal memory into
+benchmarks and the routing experiment runner, which must stay reproducible. The
+runtime seam is the one place a real profile enters. `mock_user_profile()` and
+its JSON block **stay** — the deterministic fixture and the `enabled = false`
+ablation baseline.
 
 ### 4. Analyzer de-exposure
 
@@ -411,50 +384,74 @@ Existing coverage to preserve:
   `test_task_analyzer_omits_user_profile_and_correlates_logs`; it keeps the
   `user_profile_enabled is False` log assertion for the `None` case.
 
-New coverage:
+New coverage, grouped by the seam each covers:
 
-- **Ordering changes.** The regression that matters most, and the one that
-  would fail today: a profile with non-empty history must produce a *different*
-  proposer set than the same turn with empty history. This is the entire point.
-- Revocation: `up` then `neutral` on one `decision_id` returns `model_counts` to
-  its prior state; `up` then `down` moves the model between lists.
-- Equal up/down lands in neither list.
-- `feedback_count` counts only non-neutral ratings; confidence clamps at 20.
-- Fail-open: missing file, malformed JSON, and a profile failing validation each
-  degrade to the mock and complete the turn. An unresolvable `decision_id` never
-  reaches the profile code — `rpc_router.py:151-158` returns early — so the
-  profile update must tolerate a `record["model"]` that is `NULL` or absent
-  rather than assume the row is well-formed.
-- Concurrency: parallel `router.feedback.submit` calls do not lose a rating
-  (the `feedback.py` read-rewrite-replace precedent).
-- Privacy: no prompt or response text can reach `profile.json`.
-- Seam agreement: `runtime.py` and `ensemble.py` resolve the same profile.
-- Hand-edit reload: writing a new `deny_models` to the file takes effect on the
-  next turn without a restart, and the mtime check does not re-read an unchanged
-  file.
-- Dropped fields fail loudly: a ranking config still carrying
-  `capability_prior`, `allow_tools`, `preferred_formats`, or
-  `preferred_format_bonus` is rejected by the exact-key-set validator; a
-  `profile.json` carrying them is rejected by the new loader rather than
-  silently ignored. This is what stops a stale hand-edited file from looking
-  like it still works.
-- Validator agreement: the `profile.py` loader and
-  `ranking_router.py:851-913` accept and reject the same vocabularies, pinned to
-  shared enum sources.
+*Transcription* (`test_gateway/test_rpc_router_decisions.py`):
+
+- A thumb-up submit writes a `prefers routing to \`model:<id>\`` line into
+  `memory/routing-preferences.md`, and `project_history` over that line yields
+  the model as positive — the end-to-end join from click to ranking-visible
+  history.
+- A neutral thumb appends nothing.
+- A down-after-up reads back through the projection as a contradiction (neither
+  list) — revocation without a decrement path.
+- Concurrent submits need no lock: N parallel appends all land, and the
+  projection folds them correctly.
+- The transcription is additive — the `feedback.jsonl` sidecar write still
+  happens (existing sidecar test unchanged).
+
+*Projection* (`test_router_self_learning_preference_projection.py`): direction
+by verb; the backticked marker is required (prose id ignored); both-directions →
+neither list; `feedback_count` = lines seen; non-preference memories invisible.
+
+*Read seam* (`test_engine/test_resolve_user_profile.py`):
+
+- **Ordering changes.** The point of the feature: memory carrying a preference
+  produces a different history than empty memory.
+- No memory and no file → `fallback_mock`; present-but-empty memory →
+  `dream_memory` (the honest "read it, it said nothing" case).
+- A valid hand-edited `deny_models` rides through beside the derived history; an
+  invented key is not overlaid; an invalid enum or risk level refuses the file
+  *and* drops the derived history to `fallback_mock`.
+- The file cannot pin provenance: a `profile_source`/`profile_version` written
+  into the file is ignored.
+- A hand-edit moves `profile_version`; a raise mid-resolution reports
+  `fallback_mock`, not a half-merge; a malformed file with no memory reports
+  `fallback_mock`.
+
+*Read surface* (`test_router_self_learning_profile.py`): absent/malformed/
+non-object file → `None`; `load_profile` hands out a copy; a hand-edit is picked
+up on mtime without a restart; `content_version` moves with the body and ignores
+the timestamp and its own stamped output.
+
+*Layering* (`test_router_self_learning_layering.py`): `preference_projection`
+imports only the standard library, so `self_learning` never reaches into
+`opensquilla.provider`.
+
+- Privacy: no prompt or response text can reach the transcribed line or
+  `profile.json`.
+- Dropped fields still fail loudly: a ranking config still carrying
+  `capability_prior`, `allow_tools`, or `preferred_formats` is rejected by the
+  exact-key-set validator.
 
 ## Rollout
 
 1. Change 4 (analyzer de-exposure) ships first, alone. It is a pure deletion,
    depends on nothing else here, and closes the exposure before any real data
    can flow.
-2. Changes 1-3 ship together. On first run there is no `profile.json`, so the
-   fallback is the mock and behavior is identical to today.
-3. The profile only starts affecting routing as feedback accumulates, and only
-   gradually — `confidence` saturates at 20 ratings, so early history moves
-   `S_user` very little by design.
+2. Changes 1-3 ship together. On first run there is no preference memory and no
+   `profile.json`, so memory reads empty, the projection is empty, and behavior
+   is identical to today.
+3. The profile only starts affecting routing after thumbs accumulate **and Dream
+   consolidates them into `MEMORY.md`** — the derivation is deliberately slower
+   than a direct write, trading immediacy for a single system of record. It also
+   ramps gradually: `confidence` saturates at 20 preference lines, so early
+   history moves `S_user` very little by design.
 
-No migration, no backfill. Existing installs have no `profile.json` and resolve
-to `fallback_mock` until the first thumb is clicked.
+No migration, no backfill. Existing installs have no preference memory and
+resolve to `fallback_mock` until the first thumb is clicked and consolidated. A
+transcribed line becomes ranking-visible only once Dream promotes it; between the
+click and the next consolidation the preference is pending, not lost.
 
 `docs/features/LLM-ensemble-design.md` §3.1 item 3, §3.9, and the
 `mock_user_profile` row of the §3.9 JSON table describe the mock as the
@@ -484,8 +481,8 @@ one click into N signals and would drive `feedback_count` toward its saturation
 of 20 on a handful of real clicks, making the profile look far more confident
 than the evidence supports.
 
-Revisit once `model_counts` holds real data. The signal to watch: an aggregator
-accumulating down-votes while its own single-model turns rate well suggests the
-blame is misplaced and proposer-level attribution is worth the complexity.
-Recording proposer-level counts as a separate, unscored field would make that
-diagnosable without changing `S_user`.
+Revisit once real preference memory accumulates. The signal to watch: an
+aggregator collecting `do not route` lines while its own single-model turns rate
+well suggests the blame is misplaced and proposer-level attribution is worth the
+complexity. Transcribing proposer-level preferences into a separate, unscored
+memory would make that diagnosable without changing `S_user`.

--- a/docs/features/ranking-user-profile-spec.md
+++ b/docs/features/ranking-user-profile-spec.md
@@ -166,6 +166,17 @@ expect. `positive_model_ids` / `negative_model_ids` / `feedback_count` are
 derived from the tally on write. Keeping the raw tally is what lets a rating be
 revised or revoked without replaying the whole JSONL.
 
+**The tally is the system of record, not a cache of the log.** Replay is not
+merely unimplemented, it is impossible: `feedback.jsonl` is pruned by
+`retention_days` (default 30) while `model_counts` accumulates forever, so the
+log is lossy by design and cannot rebuild the tally. Nothing reconciles the two
+because nothing can. This is the right trade — replay would mean retaining the
+log indefinitely, against the same retention and privacy posture that makes the
+file storable — but it is what puts the whole weight of correctness on the delta
+path: a lost or double-counted delta is permanent. That is why the merge-then-
+filter order in `load_feedback_map` and the lock spanning read-append-fold are
+tested rather than merely documented.
+
 **Validation.** `profile.py` needs its own loader-validator: the existing
 checks at `ranking_router.py:851-913` read
 `config["mock_user_profile"][...]` and validate the *ranking config*, not a

--- a/docs/features/ranking-user-profile-spec.md
+++ b/docs/features/ranking-user-profile-spec.md
@@ -1,0 +1,471 @@
+# Ranking User Profile Spec
+
+Date: 2026-07-17
+Status: Draft
+
+## Problem
+
+`docs/features/LLM-ensemble-design.md` §3.1 lists the user profile as one of
+four per-turn inputs to `router_dynamic` ranking. Every consumer of that input
+is built and wired. The input itself is not: it is a hardcoded global mock.
+
+The mock is inert, not merely approximate. With the shipped
+`mock_user_profile` block:
+
+- `permission.allow_models` and `permission.deny_models` are empty and
+  `permission.risk_allowlist` is `["low", "medium", "high"]`, so every
+  permission hard filter in `_hard_filter_reasons` is a no-op.
+- `history` is empty, so `_user_score` returns `neutral_score` (`0.50`) for
+  every candidate. Because `quality_clean = 0.85 * task_match + 0.15 * S_user`,
+  a constant `S_user` is a uniform offset across all candidates and **cannot
+  change model ordering**.
+
+The observable consequence: toggling `ranking_user_profile_enabled` today
+changes rankings only through `_proposer_bounds` and `_cost_latency_weights`,
+both of which read the same all-neutral mock preferences. The scoring half of
+the feature has never affected a routing decision.
+
+Meanwhile real thumbs up/down feedback is already collected and persisted
+(`self_learning/feedback.py`), with a live Web UI and RPC intake. Nothing reads
+it for routing.
+
+There is also a privacy defect that is latent today: `ranking_router.py:2069`
+places the entire profile into the task analyzer's prompt and ships it to a
+third-party provider unredacted. `_canonical_hash` is applied to `task_profile`
+and `request_context` but never to `user_profile`. This contradicts the design
+doc's §3.8 claim that routing events carry no "raw user-profile payload" — the
+events are clean, but the analyzer request is not. It costs nothing today
+(the mock is all-neutral) and costs something the moment the profile is real.
+
+## Goals
+
+- Replace the hardcoded mock with a single global profile stored as one local
+  JSON file.
+- Derive `history` from the feedback that is already being collected, so
+  `S_user` varies per candidate and can affect ordering.
+- Stop sending the profile to the task analyzer.
+- Preserve the existing fail-open contract: no profile failure may fail a turn
+  or abort ranking.
+- Keep `ranking_user_profile_enabled = false` a true ablation.
+
+## Non-Goals
+
+- **No new database tables, no new migration, no new sqlite schema.** The
+  profile is a file. The one existing table this reads (`router_decisions`,
+  V017) is read-only and already present.
+- **No user identity.** OpenSquilla is a local, single-operator application.
+  There is no `user_id` anywhere in the codebase and this spec does not add one.
+  "User" here means "the person using this install" — a set of size one.
+- **No per-agent profiles.** One global profile, matching the existing
+  `profile_source: "mock_global_default"` contract and the global `active` file
+  precedent. Feedback given to any agent updates the same profile.
+- Do not change the ranking formulas or the `user_score` JSON block. This spec
+  changes what feeds `S_user`, not how `S_user` is computed.
+- Do not change the four fixed/custom/tree selection modes.
+- Do not expose the profile in the Web UI settings surface.
+- Do not implement exploration; `exploration` stays `false` / propensity `1.0`.
+
+## Existing Surfaces
+
+Ranking consumers (all already built, none change):
+
+- `mock_user_profile()` — `ranking_router.py:1449`.
+- Profile shape validated at `ranking_router.py:851-913`; key whitelist at
+  `:366`, `:451-471`.
+- `_hard_filter_reasons(...)` — `ranking_router.py:2860`. Reads
+  `permission.allow_models` / `deny_models` / `risk_allowlist` (task risk
+  compared at `:2891`).
+- `_user_score(...)` — `ranking_router.py:3023`. Reads
+  `history.positive_model_ids`, `history.negative_model_ids`,
+  `history.feedback_count`, `preference.preferred_formats`.
+- `_cost_latency_weights(...)` — `:3128`. `_proposer_bounds(...)` — `:3536`.
+- None-vs-empty split — `:3713-3714`.
+- `_permission_matches` — `:2751`, case-insensitive against `model.model_id` or
+  `model.identity`.
+
+Injection seams (two; they must not diverge):
+
+- `runtime.py:5508` — `mock_user_profile(ranking_config) if ranking_user_profile_enabled else None`.
+- `ensemble.py:1715-1724` — prefers `inputs["user_profile"]` when supplied,
+  falls back to `mock_user_profile(ranking_config)`.
+
+Feedback:
+
+- `self_learning/feedback.py` — append-only JSONL. `write_feedback()` (`:73`),
+  `load_feedback_map()` (`:149`, effective rating per `decision_id`,
+  last-write-wins), `scan_feedback_stats()` (`:175`).
+- `FeedbackEntry` carries `rating` and `executed_kind` only — not the model. The
+  JSONL sidecar alone cannot answer "which model was rated".
+- RPC intake: `gateway/rpc_router.py:114` `router.feedback.submit`. The handler
+  resolves the full decision row before writing (`:144-158`) and already derives
+  `session_key`, `turn_index`, and `executed_kind` from it.
+- `RouterDecisionWriter.get_decision(decision_id)` —
+  `persistence/router_decision_writer.py:411`. Selects all of `_COLUMNS`,
+  including `model` (`:65`), a sanitized token column. Docstring: "Reverse-lookup
+  surface for feedback attribution."
+- `router_decisions` (V017) — `decision_id` PK, with `provider`, `model`,
+  `final_tier`, `executed_kind`. The only place `decision_id → model` exists,
+  and it is already being read on every feedback submit.
+
+File layout precedent — `self_learning/store.py:1-17`:
+
+```text
+~/.opensquilla/router/
+    data/<agent_id>/samples-YYYYMMDD.jsonl   # per-agent
+    data/<agent_id>/feedback.jsonl           # per-agent
+    learned/<version>/
+    active                                   # global, not agent-scoped
+```
+
+`active` establishes that a global file at the router root is an existing
+convention. Conventions to copy from `feedback.py` / `store.py`: pure
+functions, injectable `home`, no raw prompt text, best-effort writes wrapped so
+a turn never fails, `_write_lock` serializing read-modify-write.
+
+## Design
+
+Four changes. Changes 1-3 are one unit (the file, its writer, its reader).
+Change 4 depends on nothing here and ships first on its own.
+
+### 1. The file
+
+`~/.opensquilla/router/profile.json` — one global file, sibling of `active`.
+New module `self_learning/profile.py`, following `feedback.py`'s conventions
+exactly.
+
+```json
+{
+  "schema_version": 1,
+  "profile_version": "<content hash>",
+  "profile_source": "global_json",
+  "permission": {
+    "allow_models": [],
+    "deny_models": [],
+    "risk_allowlist": ["low", "medium", "high"]
+  },
+  "preference": {
+    "quality_latency_tradeoff": "balanced",
+    "cost_sensitivity": "medium"
+  },
+  "history": {
+    "model_counts": {"<model_id>": {"up": 0, "down": 0}},
+    "positive_model_ids": [],
+    "negative_model_ids": [],
+    "feedback_count": 0,
+    "last_updated_at": "<iso8601>"
+  }
+}
+```
+
+`permission` and `preference` are hand-editable — this file *is* the
+configuration surface, so no new TOML keys are needed. `history` is
+machine-written.
+
+`model_counts` is the raw per-model tally and the only new field. It is written
+and read only by `profile.py` and stripped before the profile reaches ranking,
+so what ranking receives is exactly the mapping shape its consumers already
+expect. `positive_model_ids` / `negative_model_ids` / `feedback_count` are
+derived from the tally on write. Keeping the raw tally is what lets a rating be
+revised or revoked without replaying the whole JSONL.
+
+**Validation.** `profile.py` needs its own loader-validator: the existing
+checks at `ranking_router.py:851-913` read
+`config["mock_user_profile"][...]` and validate the *ranking config*, not a
+free-standing profile file. The new validator must enforce the same
+vocabularies — `risk_allowlist` values, `quality_latency_tradeoff`,
+`cost_sensitivity` — and a test must pin both to the same enum sources so the
+two cannot drift apart. Drift here is not a crash; it is a hand-edited value
+that one validator accepts and the other silently ignores.
+
+`profile_version` is a content hash of the profile body, so it changes exactly
+when the profile changes. `profile_source` is `global_json`, or `fallback_mock`
+when the file is missing or unreadable.
+
+Writes are atomic (`tmp` + `os.replace`) under a module-level `_write_lock`,
+mirroring `feedback.py:_write_lock` — RPC submissions run on worker threads and
+a lost rating is a defect.
+
+**Privacy contract.** Model identity tokens, enum tokens, and integers only. No
+prompt text, no response text. Same bar as `feedback.jsonl`.
+
+### 2. Updating history on feedback
+
+`router.feedback.submit` **already resolves the decision row it needs**
+(`rpc_router.py:144-158`):
+
+```python
+record = await anyio.to_thread.run_sync(writer.get_decision, decision_id)
+if record is None:
+    return {"accepted": False, "reason": "decision_not_found"}
+```
+
+`get_decision` (`router_decision_writer.py:411`) selects every column of
+`_COLUMNS`, which includes `model` (`:65`) — already a sanitized token column
+(`_TEXT_TOKEN_COLUMNS`, `:81`). Its docstring names this exact use: "Reverse-
+lookup surface for **feedback attribution**".
+
+The lookup needs no new query and no new schema, and it is already off the event
+loop and already fail-open. **But the column does not yet hold the right value.**
+On ensemble turns `record["model"]` names the *classifier's* pick, not the model
+that authored the reply: `router_decision_record.py:227` stages the classifier's
+choice, and the realignment at `:268-273` is guarded `if not ensemble_enabled:`.
+Attributing feedback to it would train the profile on a model the user never
+read. Unit 2.A fixes the writer first; only then is the column a valid key.
+
+The corrected key is `final_request["execution"]["model"]`, staged by
+`_member_execution_trace` (`ensemble.py:1457`) from `cfg.model`.
+
+**Which namespace the key inhabits is the load-bearing detail**, and getting it
+wrong survived three review rounds. The key must live in **config space** — the
+same namespace as `RankedModel.model_id`, which is what `_user_score` matches
+`positive_model_ids`/`negative_model_ids` against. `cfg.model ≡
+RankedModel.model_id` holds by construction (`ensemble.py:1830` sets
+`model=decision.aggregator.model_id`; `_member_provider_config` only strips), so
+the join is safe. `usage.model` (`:1520`) is **response space** — what the
+provider reports it actually ran — and is forensics only. Sourcing the key there
+would silently mismatch the registry on any provider that renames or versions a
+model in its response. When the key cannot be resolved, fail **closed**: write
+`None` and skip the update rather than attribute to a guess.
+
+The change is: after `write_feedback()` succeeds, increment
+`model_counts[<key>][rating]` and rewrite the derived fields.
+
+Rules:
+
+- **Read `load_feedback_map()` before `write_feedback()` appends.** The
+  decrement rule below needs the *previous* effective rating for this
+  `decision_id`; reading after the append returns the new one and the decrement
+  silently becomes a no-op. Ordering is part of the contract, not an
+  implementation detail.
+- Use the effective rating, not the raw append. `load_feedback_map()`
+  (`feedback.py:149`) already resolves last-write-wins, so a thumb toggled back
+  to `neutral` must **decrement** the previous rating rather than be ignored.
+  Getting this wrong makes revocation impossible.
+- `neutral` contributes to neither list and does not count toward
+  `feedback_count`.
+- A model goes in `positive_model_ids` when `up > down`, `negative_model_ids`
+  when `down > up`, and **neither when equal**. `_user_score` computes `signal`
+  as `int(in_positive) - int(in_negative)` (`:3000-3002`), so membership in both
+  would silently cancel to zero — excluding it says the same thing honestly.
+- `feedback_count` is the total of non-neutral ratings. It drives
+  `confidence = min(1.0, feedback_count / 20)`, so `S_user` ramps in gradually
+  instead of swinging to an extreme on the first click.
+- `executed_kind = "ensemble"` attributes to the aggregator only. It authored
+  the text the user actually read; the proposers' drafts were never shown. This
+  is **provisional** — see "Revisit" below.
+- The whole update is wrapped `try/except` → `log.warning`. The RPC already
+  refuses to fail a client on a feedback write error (`rpc_router.py:194-198`);
+  a profile update failure must be no louder.
+
+Because counts accumulate in the file, they do not decay when
+`router_decision_writer` prunes at 30 days — the decision row only needs to
+exist at the moment the thumb is clicked. A thumb on a pruned decision already
+returns `decision_not_found` and writes no feedback at all
+(`rpc_router.py:151-158`); that is pre-existing behavior this spec neither
+worsens nor fixes.
+
+### 3. Reading it
+
+`runtime.py:5508` becomes:
+
+```python
+user_profile = load_profile() if ranking_user_profile_enabled else None
+```
+
+Cached in-process, **invalidated on mtime change** — not on write alone.
+
+The packaged ranking config is cached and requires a restart to pick up edits
+(design doc §3.9), but copying that here would be wrong. `profile.json` is
+unlike that file in one decisive way: it *rewrites itself* while the process
+runs, every time a thumb is clicked. So an invalidation path has to exist
+regardless. Keying it on write alone produces genuinely confusing behavior —
+the file updates itself when you click a thumb, but ignores you when you
+hand-edit `deny_models`. An `os.stat` per turn is microseconds against a turn
+that already spends seconds in LLM calls, and it makes the file behave the way
+its being hand-editable implies.
+
+Any failure — missing file, malformed JSON, failed validation — degrades to
+`mock_user_profile(ranking_config)` with `profile_source = "fallback_mock"` and
+logs a warning. Never raises, never fails a turn.
+
+`ensemble.py:1718` already prefers `inputs["user_profile"]`, so the runtime path
+needs no change there. Its `:1724` fallback **stays on `mock_user_profile()`**.
+Pointing it at `load_profile()` would be actively harmful: that fallback is what
+callers with no `inputs["user_profile"]` get — benchmarks and the routing
+experiment runner among them — and it would silently feed the operator's
+personal profile into runs that must stay deterministic and reproducible. The
+two seams *should* disagree: `runtime.py:5508` is the one place a real user's
+profile enters, and it is the only read seam this spec adds.
+
+`mock_user_profile()` and its JSON block **stay** — they are the deterministic
+test fixture and the `enabled = false` ablation baseline, and removing them
+would churn the config validator's exact-key-set contract for no benefit.
+
+### 4. Analyzer de-exposure
+
+Delete `analyzer_input["user_profile"] = user_profile`
+(`ranking_router.py:2069-2070`).
+
+The analyzer's job is to classify the *task* — capability, domain, tier, and
+constraint distributions. Those are properties of the request, not of who is
+asking. Every real consumer of the profile is local and deterministic, and
+nothing downstream reads a profile-derived field *from* the analyzer's
+response, so removing it from the prompt costs no signal.
+
+`analyze_task_with_provider(...)` keeps its `user_profile` parameter for one
+release, ignored except for the `user_profile_enabled` log field it already
+emits (`:1999`, `:2080`, `:2168`, `:2203`), then drops it. This avoids a
+same-release signature break at `runtime.py:5517-5531`.
+
+### Observability
+
+`user_profile_version` and `user_profile_source` are already written into the
+plan (`ranking_router.py:4040-4042`) and turn metadata (`runtime.py:5547-5559`),
+but `ensemble_observability.py` never reads them. Emit both on
+`llm_ensemble.routing.decision_completed`, next to the `user_profile_enabled`
+bit it already emits at `:314`. Without this, a decision influenced by a learned
+profile is not explainable after the fact — the log says a profile was on, but
+not which one. Both values are already safe to log: a hash and an enum.
+
+### Dead fields
+
+Three fields are validated but not honored. A real profile forces a decision on
+each rather than leaving them as false affordances:
+
+- **`history.capability_prior`** — validated at `:885-903`, read by nothing.
+  **Drop.** Thumbs up/down attributes a rating to a *model*, not a capability.
+  There is no signal that could populate it without inventing one.
+- **`permission.allow_tools`** — validated at `:853`, never consulted by
+  `_hard_filter_reasons`. **Drop.** Tool permissions are owned by
+  `safety/permission_matrix.py` and `safety/tool_tiers.py`. A second per-profile
+  tool list would be a competing authority over the same question.
+- **`preference.preferred_formats`** — gates a bonus at `:3054-3061`, but the
+  format *values* are never compared against the model; the bonus keys off
+  generic `format_following` strength, so `["json"]` and `["markdown"]` are
+  identical. **Drop**, for two reasons beyond the false name:
+
+  1. **The real format mechanism already exists and is untouched.** `_task_match`
+     (`:3008-3017`) handles a task-pinned format properly, multiplying match by
+     `format_base_multiplier + format_strength_multiplier * format_following`.
+     The `_user_score` branch fires only when the task did *not* pin a format
+     (`:3054`), so the two never overlap — deleting the user-side one loses no
+     format handling, only a vague "this user likes tidy output" nudge.
+  2. **Its magnitude is noise.** `0.05 * strength` (strength ≈ 0.7–0.97) lands in
+     `S_user`, which carries `quality.user_score_weight = 0.15` — a maximum
+     contribution of **0.0075** to quality, against a `risk_margin` quality floor
+     of 0.12–0.28. It cannot decide anything.
+
+  Deletion sites (the exact-key-set validator will catch a miss): `:467` and
+  `:527` (key whitelists), `:878-882` (validation), `:1015` (unit-interval
+  paths), `:3051-3061` (the branch), and `router_dynamic_ranking_config.json:118`
+  and `:198`. `format_following` stays — it is a capability dimension every model
+  declares, still consumed by `_task_match` and the capability distribution.
+
+  Note `_user_score`'s `task_profile` parameter becomes unused once the branch is
+  gone (`optional_constraints` was its only reader). Drop it from the signature.
+
+All three drops are config-schema changes guarded by the validator's
+exact-key-set contract, so they fail loudly rather than silently.
+
+`permission.risk_allowlist` stays. Note its `low`/`medium`/`high` vocabulary
+deliberately does **not** match `RiskTier`'s `SAFE`/`CONFIRM`/`ADMIN_ONLY`
+(`tool_tiers.py:31-36`): the profile's values are compared against
+`task_profile.constraints.risk` (`:2891`), a *task* risk level, not a tool tier.
+These are different axes and must not be unified.
+
+## Test Plan
+
+Existing coverage to preserve:
+
+- `tests/test_ranking_router.py:1051` —
+  `test_ranking_without_user_profile_bypasses_all_profile_effects`. The
+  `enabled = false` ablation must stay exact.
+- `tests/test_ranking_router.py:854` —
+  `test_task_analyzer_uses_provider_interface_and_validates_json`. This is the
+  test Change 4 inverts: it supplies a profile and asserts it reaches the
+  analyzer payload, which is the privacy defect itself. It now asserts absence.
+- `tests/test_ranking_router.py:858` —
+  `test_task_analyzer_omits_disabled_user_profile_and_correlates_logs`. Its
+  assertion still holds unchanged, but the name no longer describes it: omission
+  is unconditional now, not a property of the disabled path. Renamed to
+  `test_task_analyzer_omits_user_profile_and_correlates_logs`; it keeps the
+  `user_profile_enabled is False` log assertion for the `None` case.
+
+New coverage:
+
+- **Ordering changes.** The regression that matters most, and the one that
+  would fail today: a profile with non-empty history must produce a *different*
+  proposer set than the same turn with empty history. This is the entire point.
+- Revocation: `up` then `neutral` on one `decision_id` returns `model_counts` to
+  its prior state; `up` then `down` moves the model between lists.
+- Equal up/down lands in neither list.
+- `feedback_count` counts only non-neutral ratings; confidence clamps at 20.
+- Fail-open: missing file, malformed JSON, and a profile failing validation each
+  degrade to the mock and complete the turn. An unresolvable `decision_id` never
+  reaches the profile code — `rpc_router.py:151-158` returns early — so the
+  profile update must tolerate a `record["model"]` that is `NULL` or absent
+  rather than assume the row is well-formed.
+- Concurrency: parallel `router.feedback.submit` calls do not lose a rating
+  (the `feedback.py` read-rewrite-replace precedent).
+- Privacy: no prompt or response text can reach `profile.json`.
+- Seam agreement: `runtime.py` and `ensemble.py` resolve the same profile.
+- Hand-edit reload: writing a new `deny_models` to the file takes effect on the
+  next turn without a restart, and the mtime check does not re-read an unchanged
+  file.
+- Dropped fields fail loudly: a ranking config still carrying
+  `capability_prior`, `allow_tools`, `preferred_formats`, or
+  `preferred_format_bonus` is rejected by the exact-key-set validator; a
+  `profile.json` carrying them is rejected by the new loader rather than
+  silently ignored. This is what stops a stale hand-edited file from looking
+  like it still works.
+- Validator agreement: the `profile.py` loader and
+  `ranking_router.py:851-913` accept and reject the same vocabularies, pinned to
+  shared enum sources.
+
+## Rollout
+
+1. Change 4 (analyzer de-exposure) ships first, alone. It is a pure deletion,
+   depends on nothing else here, and closes the exposure before any real data
+   can flow.
+2. Changes 1-3 ship together. On first run there is no `profile.json`, so the
+   fallback is the mock and behavior is identical to today.
+3. The profile only starts affecting routing as feedback accumulates, and only
+   gradually — `confidence` saturates at 20 ratings, so early history moves
+   `S_user` very little by design.
+
+No migration, no backfill. Existing installs have no `profile.json` and resolve
+to `fallback_mock` until the first thumb is clicked.
+
+`docs/features/LLM-ensemble-design.md` §3.1 item 3, §3.9, and the
+`mock_user_profile` row of the §3.9 JSON table describe the mock as the
+implementation. Update them in the same change as 1-3.
+
+## Revisit: ensemble attribution
+
+Crediting the aggregator alone is provisional, and it is the one decision here
+taken against a standing precedent in this codebase. `feedback.py`'s module
+docstring warns that an ensemble rating "judges the whole
+candidates-plus-aggregator chain" and must not be naively attributed, and
+`FeedbackStats` acts on that warning: `downvote_rate` slices to
+`down_single / total_single`, so the rollback monitor consumes **no** ensemble
+ratings at all.
+
+This spec does not follow that precedent, because it cannot. The profile is
+consumed only by `router_dynamic` — an ensemble mode. Slicing ensemble ratings
+out would starve the profile of exactly the turns it exists to improve, leaving
+`S_user` constant and the feature inert, which is the problem this spec opens
+with.
+
+So the aggregator gets the signal, on the grounds that it authored the text the
+user judged. The known weakness: a bad answer may originate in a weak proposer
+that the aggregator faithfully relayed, and the aggregator is then blamed for
+carrying it. Attributing to every proposer instead is not a fix — it inflates
+one click into N signals and would drive `feedback_count` toward its saturation
+of 20 on a handful of real clicks, making the profile look far more confident
+than the evidence supports.
+
+Revisit once `model_counts` holds real data. The signal to watch: an aggregator
+accumulating down-votes while its own single-model turns rate well suggests the
+blame is misplaced and proposer-level attribution is worth the complexity.
+Recording proposer-level counts as a separate, unscored field would make that
+diagnosable without changing `S_user`.

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -2436,25 +2436,56 @@ class TurnRunner:
         return copy.deepcopy(route)
 
     @staticmethod
-    def _resolve_user_profile(ranking_config: Any) -> dict[str, Any]:
-        """The learned profile over the mock baseline — the only real read seam.
+    def _read_global_memory_md(config: Any) -> str | None:
+        """The consolidated global MEMORY.md text, or ``None`` when there is none.
 
-        The mock supplies the shape and every default the learned file does not
-        carry (risk_allowlist, preferences). Only keys the baseline already
-        defines are overlaid, so a hand-edited file can add ``deny_models`` but
-        cannot introduce a key ranking never validated.
+        Pinned to the ``main`` agent's workspace because the profile is global
+        (one operator), and resolved the *same* way Dream resolves the workspace
+        it consolidates into — ``resolve_agent_workspace_dir("main", config)``,
+        exactly what ``build_dream`` uses — so the projection reads the file
+        Dream actually writes. Never raises: an absent or unreadable memory is
+        an empty preference, not a failed turn. ``None`` (absent/unreadable) is
+        kept distinct from ``""`` (present but empty) so the caller can tell
+        "nothing of the operator's was read" from "read, no preference yet".
+        """
+        from opensquilla.agents.scope import resolve_agent_workspace_dir
 
-        Degrades to the baseline on any failure. This is deliberately NOT
-        wired into ``ensemble.py``'s own fallback: that path serves benchmarks
-        and the experiment runner, which must stay reproducible rather than
-        read whatever the operator happens to have thumbed.
+        try:
+            workspace = resolve_agent_workspace_dir("main", config)
+            return (workspace / "MEMORY.md").read_text(encoding="utf-8")
+        except (OSError, ValueError):
+            return None
+
+    @staticmethod
+    def _resolve_user_profile(ranking_config: Any, config: Any = None) -> dict[str, Any]:
+        """The resolved profile over the mock baseline — the only real read seam.
+
+        Two sources feed it, and neither is an accumulator of its own:
+
+        * ``history`` — which models the operator prefers or avoids — is a
+          read-time *projection* over Dream-consolidated memory. A thumb was
+          transcribed into a preference line, Dream promoted it into MEMORY.md,
+          and :func:`project_history` recovers the model ids here.
+        * ``permission``/``preference`` — ``deny_models`` and the tradeoff
+          enums — come from the hand-edited file, the only surface for them.
+
+        The mock supplies the shape and every default neither source carries.
+        Only keys the baseline already defines are overlaid, so a hand-edited
+        file can set ``deny_models`` but cannot introduce a key ranking never
+        validated. Degrades to the baseline on any failure. This is deliberately
+        NOT wired into ``ensemble.py``'s own fallback: that path serves
+        benchmarks and the experiment runner, which must stay reproducible
+        rather than read whatever the operator happens to have thumbed.
         """
         from opensquilla.provider.ranking_router import (
             mock_user_profile,
             validate_user_profile,
         )
-        from opensquilla.squilla_router.self_learning.profile import (
+        from opensquilla.squilla_router.self_learning.preference_projection import (
             PROFILE_SOURCE,
+            project_history,
+        )
+        from opensquilla.squilla_router.self_learning.profile import (
             content_version,
             load_profile,
             profile_path,
@@ -2462,37 +2493,54 @@ class TurnRunner:
 
         base = mock_user_profile(ranking_config)
         try:
+            # History: projected from Dream-consolidated global memory. Present
+            # but empty memory yields an empty projection — an operator who has
+            # expressed no preference, which is a real (empty) profile.
+            memory_text = TurnRunner._read_global_memory_md(config)
+            projected = project_history(memory_text or "")
+            history = dict(base.get("history") or {})
+            history.update({k: v for k, v in projected.items() if k in history})
+            base["history"] = history
+
+            # Permission/preference: the hand-edited file remains the only
+            # surface. Absent is fine — the mock baseline already stands in.
             stored = load_profile()
-            if stored is None:
-                # Missing or unreadable both mean the same thing to ranking:
-                # what it is about to score against is not the user's profile.
+            file_used = False
+            if stored is not None:
+                errors = validate_user_profile(stored, ranking_config)
+                if errors:
+                    # Refuse the whole file rather than route on the half of it
+                    # that parsed. This file is the only way to say deny_models,
+                    # so a typo that silently did nothing would be worse than one
+                    # that is loudly ignored.
+                    log.warning(
+                        "router_dynamic.user_profile_invalid",
+                        errors=errors,
+                        path=str(profile_path()),
+                    )
+                    fallback = mock_user_profile(ranking_config)
+                    fallback["profile_source"] = "fallback_mock"
+                    return fallback
+                file_used = True
+                for section in ("permission", "preference"):
+                    value = stored.get(section)
+                    if not isinstance(value, Mapping):
+                        continue
+                    merged = dict(base.get(section) or {})
+                    merged.update({k: v for k, v in value.items() if k in merged})
+                    base[section] = merged
+
+            if memory_text is None and not file_used:
+                # Neither source read: what ranking is about to score against is
+                # the bare mock, not the operator's profile. Say so, and stamp
+                # no version — there is no profile content to version.
                 base["profile_source"] = "fallback_mock"
                 return base
-            errors = validate_user_profile(stored, ranking_config)
-            if errors:
-                # Refuse the whole file rather than route on the half of it
-                # that parsed. This file is the only way to say deny_models,
-                # so a typo that silently did nothing would be worse than one
-                # that is loudly ignored.
-                log.warning(
-                    "router_dynamic.user_profile_invalid",
-                    errors=errors,
-                    path=str(profile_path()),
-                )
-                base["profile_source"] = "fallback_mock"
-                return base
-            for section in ("permission", "preference", "history"):
-                value = stored.get(section)
-                if not isinstance(value, Mapping):
-                    continue
-                merged = dict(base.get(section) or {})
-                merged.update({k: v for k, v in value.items() if k in merged})
-                base[section] = merged
-            # Provenance is what happened here, not what the file claims. Both
+            # Provenance is what happened here, not what any file claims. Both
             # fields are derived rather than read: the file is hand-editable, so
             # reading them would let it pin a source ranking never chose, and
             # would miss the one edit it exists for — ``deny_models`` has no TOML
-            # key, and editing it never touches the write path that stamps a
+            # key, and editing it never touches a write path that stamps a
             # version. Hash what was ranked with, after the overlay.
             base["profile_source"] = PROFILE_SOURCE
             base["profile_version"] = content_version(base)
@@ -5576,7 +5624,7 @@ class TurnRunner:
                             ranking_config=ranking_config,
                         )
                         user_profile = (
-                            self._resolve_user_profile(ranking_config)
+                            self._resolve_user_profile(ranking_config, self._config)
                             if ranking_user_profile_enabled
                             else None
                         )

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -2435,6 +2435,77 @@ class TurnRunner:
         self._router_dynamic_last_routes[session_key] = route
         return copy.deepcopy(route)
 
+    @staticmethod
+    def _resolve_user_profile(ranking_config: Any) -> dict[str, Any]:
+        """The learned profile over the mock baseline — the only real read seam.
+
+        The mock supplies the shape and every default the learned file does not
+        carry (risk_allowlist, preferences). Only keys the baseline already
+        defines are overlaid, so a hand-edited file can add ``deny_models`` but
+        cannot introduce a key ranking never validated.
+
+        Degrades to the baseline on any failure. This is deliberately NOT
+        wired into ``ensemble.py``'s own fallback: that path serves benchmarks
+        and the experiment runner, which must stay reproducible rather than
+        read whatever the operator happens to have thumbed.
+        """
+        from opensquilla.provider.ranking_router import (
+            mock_user_profile,
+            validate_user_profile,
+        )
+        from opensquilla.squilla_router.self_learning.profile import (
+            PROFILE_SOURCE,
+            content_version,
+            load_profile,
+            profile_path,
+        )
+
+        base = mock_user_profile(ranking_config)
+        try:
+            stored = load_profile()
+            if stored is None:
+                # Missing or unreadable both mean the same thing to ranking:
+                # what it is about to score against is not the user's profile.
+                base["profile_source"] = "fallback_mock"
+                return base
+            errors = validate_user_profile(stored, ranking_config)
+            if errors:
+                # Refuse the whole file rather than route on the half of it
+                # that parsed. This file is the only way to say deny_models,
+                # so a typo that silently did nothing would be worse than one
+                # that is loudly ignored.
+                log.warning(
+                    "router_dynamic.user_profile_invalid",
+                    errors=errors,
+                    path=str(profile_path()),
+                )
+                base["profile_source"] = "fallback_mock"
+                return base
+            for section in ("permission", "preference", "history"):
+                value = stored.get(section)
+                if not isinstance(value, Mapping):
+                    continue
+                merged = dict(base.get(section) or {})
+                merged.update({k: v for k, v in value.items() if k in merged})
+                base[section] = merged
+            # Provenance is what happened here, not what the file claims. Both
+            # fields are derived rather than read: the file is hand-editable, so
+            # reading them would let it pin a source ranking never chose, and
+            # would miss the one edit it exists for — ``deny_models`` has no TOML
+            # key, and editing it never touches the write path that stamps a
+            # version. Hash what was ranked with, after the overlay.
+            base["profile_source"] = PROFILE_SOURCE
+            base["profile_version"] = content_version(base)
+        except Exception:  # noqa: BLE001 — a broken profile must not fail a turn
+            log.warning("router_dynamic.user_profile_load_failed", exc_info=True)
+            # Rebuild rather than return ``base``: the overlay above mutates it
+            # section by section, so a raise partway through leaves a half-merged
+            # profile that would ship as if it were the user's own.
+            fallback = mock_user_profile(ranking_config)
+            fallback["profile_source"] = "fallback_mock"
+            return fallback
+        return base
+
     def _router_dynamic_task_analyzer_provider(
         self,
         inherited_provider_config: Any,
@@ -5453,7 +5524,6 @@ class TurnRunner:
                             analyze_task_with_provider,
                             build_request_context,
                             dynamic_output_token_budgets,
-                            mock_user_profile,
                             ranking_config_snapshot,
                         )
 
@@ -5506,7 +5576,7 @@ class TurnRunner:
                             ranking_config=ranking_config,
                         )
                         user_profile = (
-                            mock_user_profile(ranking_config)
+                            self._resolve_user_profile(ranking_config)
                             if ranking_user_profile_enabled
                             else None
                         )

--- a/src/opensquilla/engine/steps/router_decision_record.py
+++ b/src/opensquilla/engine/steps/router_decision_record.py
@@ -238,6 +238,32 @@ def stage_router_decision(
         log.warning("router_decision_record.stage_failed", exc_info=True)
 
 
+def _final_request_model(ensemble_trace: Mapping[str, Any] | None) -> str | None:
+    """The configured id of the model whose text the user actually read.
+
+    Sourced from the final request's *execution* trace, which carries the
+    member's ``provider_config.model`` — the same namespace as
+    ``RankedModel.model_id``, which is what ``positive_model_ids`` /
+    ``negative_model_ids`` are matched against. The sibling ``usage.model``
+    reports what the provider says it ran and is forensics only: a provider
+    that resolves an alias to a dated snapshot would emit an id the registry
+    cannot join.
+
+    Returns ``None`` when the trace cannot name the model. Attribution then
+    fails closed — writing a guess would train the profile on the wrong model,
+    which is worse than not learning from this turn.
+    """
+    if not isinstance(ensemble_trace, Mapping):
+        return None
+    final_request = ensemble_trace.get("final_request")
+    if not isinstance(final_request, Mapping):
+        return None
+    execution = final_request.get("execution")
+    if not isinstance(execution, Mapping):
+        return None
+    return _token(execution.get("model"))
+
+
 def _complete_pending_record(
     metadata: dict[str, Any],
     *,
@@ -271,6 +297,12 @@ def _complete_pending_record(
             executed_model = _token(metadata.get("routed_model"))
             if executed_model is not None:
                 record["model"] = executed_model
+        else:
+            # On an ensemble turn decision.model names the *classifier's* pick,
+            # which never authored the reply — the final request did. Attributing
+            # feedback to the classifier's pick would train the profile on a
+            # model the user never read.
+            record["model"] = _final_request_model(ensemble_trace)
     except Exception:  # noqa: BLE001 — decision records must never fail a turn
         log.warning("router_decision_record.flush_failed", exc_info=True)
         return None

--- a/src/opensquilla/gateway/rpc_router.py
+++ b/src/opensquilla/gateway/rpc_router.py
@@ -12,7 +12,9 @@ of erroring.
 Privacy: the table stores enum tokens and numbers only — no prompt text
 (V017 contract, test-enforced) — so every value surfaced here is already
 operator-safe and, unlike ``meta.runs.list``, read-only principals need no
-per-session gating. These handlers observe routing; they never change it.
+per-session gating. The list and get surfaces observe routing without changing
+it. ``router.feedback.submit`` is the one handler that writes: its rating folds
+into the user profile ranking reads on the next turn — see its docstring.
 """
 
 from __future__ import annotations
@@ -123,8 +125,11 @@ async def _handle_router_feedback_submit(params: Any, ctx: RpcContext) -> dict[s
     returns ``accepted: false`` rather than an error — clients surface it as
     "this message's routing record expired".
 
-    The rating never mutates the ``router_decisions`` table or routing state;
-    consumption happens offline at dataset-build time.
+    The rating never mutates the ``router_decisions`` table, and the trainer
+    still consumes the sidecar offline at dataset-build time. It does feed one
+    live path: the same rating folds into the global user profile, which
+    ranking reads on the next dynamic-routing turn, so a thumb here shifts
+    ``S_user`` there.
     """
     p = params if isinstance(params, dict) else {}
     decision_id = sanitize_token(p.get("decisionId") or p.get("decision_id"))
@@ -168,9 +173,17 @@ async def _handle_router_feedback_submit(params: Any, ctx: RpcContext) -> dict[s
     )
 
     from opensquilla.session.keys import parse_agent_id
-    from opensquilla.squilla_router.self_learning.feedback import write_feedback
+    from opensquilla.squilla_router.self_learning.feedback import (
+        load_feedback_map,
+        write_feedback,
+    )
+    from opensquilla.squilla_router.self_learning.profile import (
+        profile_update_lock,
+        update_profile_for_rating,
+    )
 
     agent_id = parse_agent_id(session_key)
+    rated_model = str(record.get("model") or "") or None
     router_cfg = getattr(ctx.config, "squilla_router", None)
     sl_cfg = getattr(router_cfg, "self_learning", None)
     try:
@@ -179,16 +192,36 @@ async def _handle_router_feedback_submit(params: Any, ctx: RpcContext) -> dict[s
         retention_days = 30
 
     def _write() -> None:
-        write_feedback(
-            agent_id,
-            decision_id=decision_id,
-            session_key=session_key,
-            turn_index=turn_index,
-            rating=rating,
-            executed_kind=executed_kind,
-            decision_ts=decision_ts,
-            retention_days=retention_days,
-        )
+        with profile_update_lock():
+            # Read the effective rating BEFORE appending: the profile folds
+            # this thumb in as a delta and needs the rating it replaces.
+            # Reading after the append would return the new rating and the
+            # decrement would silently no-op, making a thumb unrevokable.
+            previous = load_feedback_map(agent_id).get(decision_id)
+            write_feedback(
+                agent_id,
+                decision_id=decision_id,
+                session_key=session_key,
+                turn_index=turn_index,
+                rating=rating,
+                executed_kind=executed_kind,
+                model=rated_model,
+                decision_ts=decision_ts,
+                retention_days=retention_days,
+            )
+            try:
+                update_profile_for_rating(
+                    model=rated_model,
+                    new_rating=rating,
+                    previous_rating=previous.rating if previous else None,
+                    previous_model=previous.model if previous else None,
+                )
+            except Exception as exc:  # noqa: BLE001 — a profile miss must not lose the rating
+                log.warning(
+                    "router_feedback.profile_update_failed",
+                    decision_id=decision_id,
+                    error=str(exc),
+                )
 
     try:
         await anyio.to_thread.run_sync(_write)

--- a/src/opensquilla/gateway/rpc_router.py
+++ b/src/opensquilla/gateway/rpc_router.py
@@ -126,10 +126,11 @@ async def _handle_router_feedback_submit(params: Any, ctx: RpcContext) -> dict[s
     "this message's routing record expired".
 
     The rating never mutates the ``router_decisions`` table, and the trainer
-    still consumes the sidecar offline at dataset-build time. It does feed one
-    live path: the same rating folds into the global user profile, which
-    ranking reads on the next dynamic-routing turn, so a thumb here shifts
-    ``S_user`` there.
+    still consumes the sidecar offline at dataset-build time. It also rides one
+    slower live path: the thumb is transcribed into a routing-preference memory
+    line, Dream consolidates it into MEMORY.md, and ranking projects that back
+    into the global user profile on a later dynamic-routing turn — so a thumb
+    here shifts ``S_user`` there, once consolidation has run.
     """
     p = params if isinstance(params, dict) else {}
     decision_id = sanitize_token(p.get("decisionId") or p.get("decision_id"))
@@ -172,14 +173,12 @@ async def _handle_router_feedback_submit(params: Any, ctx: RpcContext) -> dict[s
         else None
     )
 
+    from opensquilla.agents.scope import resolve_agent_workspace_dir
     from opensquilla.session.keys import parse_agent_id
-    from opensquilla.squilla_router.self_learning.feedback import (
-        load_feedback_map,
-        write_feedback,
-    )
-    from opensquilla.squilla_router.self_learning.profile import (
-        profile_update_lock,
-        update_profile_for_rating,
+    from opensquilla.squilla_router.self_learning.feedback import write_feedback
+    from opensquilla.squilla_router.self_learning.preference_projection import (
+        ROUTING_PREF_FILENAME,
+        transcribe_thumb,
     )
 
     agent_id = parse_agent_id(session_key)
@@ -192,36 +191,42 @@ async def _handle_router_feedback_submit(params: Any, ctx: RpcContext) -> dict[s
         retention_days = 30
 
     def _write() -> None:
-        with profile_update_lock():
-            # Read the effective rating BEFORE appending: the profile folds
-            # this thumb in as a delta and needs the rating it replaces.
-            # Reading after the append would return the new rating and the
-            # decrement would silently no-op, making a thumb unrevokable.
-            previous = load_feedback_map(agent_id).get(decision_id)
-            write_feedback(
-                agent_id,
+        write_feedback(
+            agent_id,
+            decision_id=decision_id,
+            session_key=session_key,
+            turn_index=turn_index,
+            rating=rating,
+            executed_kind=executed_kind,
+            model=rated_model,
+            decision_ts=decision_ts,
+            retention_days=retention_days,
+        )
+        # Transcribe the thumb into a routing-preference memory line, then let
+        # go: Dream consolidates memory/*.md into MEMORY.md on its own cadence,
+        # and _resolve_user_profile projects the consolidated lines back into
+        # history on a later turn. The note lands in the GLOBAL "main"
+        # workspace — the profile is global, so a thumb on any agent's decision
+        # shapes the one profile ranking reads — resolved the same way Dream
+        # resolves the workspace it scans (``resolve_agent_workspace_dir``).
+        line = transcribe_thumb(rated_model, rating)
+        if line is None:
+            # neutral revokes and an unresolvable model cannot be credited;
+            # either way there is nothing durable to append. The feedback row
+            # above still lands for the offline trainer.
+            return
+        try:
+            workspace = resolve_agent_workspace_dir("main", getattr(ctx, "config", None))
+            note = workspace / "memory" / ROUTING_PREF_FILENAME
+            note.parent.mkdir(parents=True, exist_ok=True)
+            with note.open("a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+        except Exception as exc:  # noqa: BLE001 — a memory-write miss must not lose the rating
+            log.warning(
+                "router_feedback.preference_memory_write_failed",
                 decision_id=decision_id,
-                session_key=session_key,
-                turn_index=turn_index,
-                rating=rating,
-                executed_kind=executed_kind,
-                model=rated_model,
-                decision_ts=decision_ts,
-                retention_days=retention_days,
+                error=str(exc),
             )
-            try:
-                update_profile_for_rating(
-                    model=rated_model,
-                    new_rating=rating,
-                    previous_rating=previous.rating if previous else None,
-                    previous_model=previous.model if previous else None,
-                )
-            except Exception as exc:  # noqa: BLE001 — a profile miss must not lose the rating
-                log.warning(
-                    "router_feedback.profile_update_failed",
-                    decision_id=decision_id,
-                    error=str(exc),
-                )
 
     try:
         await anyio.to_thread.run_sync(_write)

--- a/src/opensquilla/memory/dream/candidates.py
+++ b/src/opensquilla/memory/dream/candidates.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from pathlib import Path
 
 from opensquilla.memory.dream.models import RawDreamCandidate
 from opensquilla.memory.dream.quarantine import is_quarantined_path, is_quarantined_text
 
 _SNIPPET_MAX_CHARS = 4000
+
+# Marker that tags a line as one independent routing-preference claim. Mirrors
+# ``preference_projection._MARKER_RE`` (the source of truth for the format); kept
+# local so the Dream scanner takes no import edge on ``squilla_router``. A memory
+# file whose every non-blank line carries this marker is an append-only preference
+# log, so each line is scanned as its own candidate rather than collapsed into one.
+_ROUTING_MARKER_RE = re.compile(r"`model:([A-Za-z0-9._:/@-]{1,200})`")
 
 
 def _workspace_relative(workspace: Path, path: Path) -> str:
@@ -54,6 +62,47 @@ def classify_signal(text: str) -> str:
     return "neutral"
 
 
+def _build_candidate(
+    *,
+    agent_id: str,
+    rel_path: str,
+    stat_mtime_ns: int,
+    source_size: int,
+    source_day: str | None,
+    text: str,
+) -> RawDreamCandidate | None:
+    snippet = _normalize_snippet(text)
+    if len(snippet) > _SNIPPET_MAX_CHARS:
+        snippet = snippet[:_SNIPPET_MAX_CHARS].rstrip()
+    if not snippet:
+        return None
+    return RawDreamCandidate(
+        agent_id=agent_id,
+        source_path=rel_path,
+        source_kind="memory_file",
+        source_mtime_ns=stat_mtime_ns,
+        source_size=source_size,
+        snippet=snippet,
+        snippet_sha256=_sha256(snippet),
+        claim_sha256=_sha256(_normalize_snippet(snippet).lower()),
+        source_day=source_day,
+        signal_kind=classify_signal(snippet),
+    )
+
+
+def _split_units(raw: str) -> list[str]:
+    """Yield the independent claim units of a memory file.
+
+    An append-only preference log — every non-blank line carrying the routing
+    marker — is split so each line is its own candidate (one thumb, one signal);
+    otherwise the whole file is a single narrative candidate as before.
+    """
+    lines = [line.strip() for line in raw.splitlines() if line.strip()]
+    if lines and all(_ROUTING_MARKER_RE.search(line) for line in lines):
+        return lines
+    return [raw]
+
+
 def scan_dream_candidates(
     workspace: Path,
     *,
@@ -86,27 +135,17 @@ def scan_dream_candidates(
             continue
         if quarantine_enabled and is_quarantined_text(raw):
             continue
-        snippet = _normalize_snippet(raw)
-        if len(snippet) > _SNIPPET_MAX_CHARS:
-            snippet = snippet[:_SNIPPET_MAX_CHARS].rstrip()
-        if not snippet:
-            continue
-        candidates.append(
-            (
-                stat.st_mtime,
-                RawDreamCandidate(
-                    agent_id=agent_id,
-                    source_path=rel_path,
-                    source_kind="memory_file",
-                    source_mtime_ns=stat.st_mtime_ns,
-                    source_size=stat.st_size,
-                    snippet=snippet,
-                    snippet_sha256=_sha256(snippet),
-                    claim_sha256=_sha256(_normalize_snippet(snippet).lower()),
-                    source_day=_source_day(path),
-                    signal_kind=classify_signal(snippet),
-                ),
+        source_day = _source_day(path)
+        for unit in _split_units(raw):
+            candidate = _build_candidate(
+                agent_id=agent_id,
+                rel_path=rel_path,
+                stat_mtime_ns=stat.st_mtime_ns,
+                source_size=stat.st_size,
+                source_day=source_day,
+                text=unit,
             )
-        )
+            if candidate is not None:
+                candidates.append((stat.st_mtime, candidate))
     candidates.sort(key=lambda item: item[0])
     return [candidate for _mtime, candidate in candidates[: max(0, int(max_batch_size))]]

--- a/src/opensquilla/memory/dream/prompts.py
+++ b/src/opensquilla/memory/dream/prompts.py
@@ -31,7 +31,11 @@ def promotion_patch_prompt(current_memory_md: str, candidates: list[PromotionCan
     return (
         "You are updating OpenSquilla MEMORY.md as curated long-term memory.\n"
         "Return JSON only with an operations array. Do not write dated logs, scores, "
-        "or source metadata into MEMORY.md.\n\n"
+        "or source metadata into MEMORY.md.\n"
+        "Preserve any inline-code token of the form `model:<id>` exactly as written, "
+        "backticks and all. The prose around it may be reworded or merged freely, but "
+        "that token is a machine-read marker: changing, splitting, or unquoting it "
+        "silently drops a routing preference.\n\n"
         "Allowed operations:\n"
         '- {"op":"upsert","candidate_ids":["..."],"section":"User Preferences",'
         '"memory_id":"mem_short_stable_id","text":"- durable memory"}\n'

--- a/src/opensquilla/memory/dream/prompts.py
+++ b/src/opensquilla/memory/dream/prompts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 from typing import Any
 
 from opensquilla.memory.dream.models import (
@@ -12,7 +11,42 @@ from opensquilla.memory.dream.models import (
     PromotionPatchOperation,
 )
 
-_JSON_BLOCK_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+def _iter_json_objects(text: str) -> list[str]:
+    """Yield every brace-balanced ``{...}`` span in ``text``, outermost only.
+
+    A depth counter that ignores braces inside JSON strings (respecting ``\\``
+    escapes) isolates each top-level object. Unlike a greedy ``\\{.*\\}`` regex,
+    trailing prose or a second block after the payload does not get swallowed into
+    one unparseable span — the source of the recurrent "Extra data" apply errors
+    when the promotion model appends commentary after its JSON.
+    """
+    spans: list[str] = []
+    depth = 0
+    start = -1
+    in_string = False
+    escaped = False
+    for index, char in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}" and depth > 0:
+            depth -= 1
+            if depth == 0 and start >= 0:
+                spans.append(text[start : index + 1])
+                start = -1
+    return spans
 
 
 def promotion_patch_prompt(current_memory_md: str, candidates: list[PromotionCandidate]) -> str:
@@ -50,13 +84,21 @@ def promotion_patch_prompt(current_memory_md: str, candidates: list[PromotionCan
 
 
 def _json_payload(text: str) -> dict[str, Any]:
-    match = _JSON_BLOCK_RE.search(text)
-    if not match:
+    dicts: list[dict[str, Any]] = []
+    for span in _iter_json_objects(text):
+        try:
+            parsed = json.loads(span)
+        except ValueError:
+            continue
+        if isinstance(parsed, dict):
+            dicts.append(parsed)
+    if not dicts:
         raise ValueError(f"Dream response did not contain JSON: {text[:300]}")
-    payload = json.loads(match.group(0))
-    if not isinstance(payload, dict):
-        raise ValueError("Dream response JSON must be an object")
-    return payload
+    # Prefer the patch object; preamble examples or trailing notes may parse too.
+    for parsed in dicts:
+        if "operations" in parsed:
+            return parsed
+    return dicts[0]
 
 
 def parse_promotion_patch(text: str, candidates: list[PromotionCandidate]) -> PromotionPatch:

--- a/src/opensquilla/provider/anthropic.py
+++ b/src/opensquilla/provider/anthropic.py
@@ -430,6 +430,7 @@ class AnthropicProvider:
         text_parts: list[str] = []
         trace_tool_calls: list[dict[str, Any]] = []
         response_ids: set[str] = set()
+        response_model = ""
 
         def _trace_tool_call(end_event: ToolUseEndEvent, raw: str) -> None:
             # The trace mirrors the emitted ToolUseEndEvent; the raw fragment
@@ -518,6 +519,9 @@ class AnthropicProvider:
                             message_id = event.get("message", {}).get("id")
                             if isinstance(message_id, str) and message_id:
                                 response_ids.add(message_id)
+                            reported_model = event.get("message", {}).get("model")
+                            if isinstance(reported_model, str) and reported_model:
+                                response_model = reported_model
                             usage = event.get("message", {}).get("usage", {})
                             base_input_tokens = _coerce_int(usage.get("input_tokens"))
                             (
@@ -632,7 +636,7 @@ class AnthropicProvider:
                             "cache_write_tokens": cache_creation_tokens,
                         },
                         stop_reason=stop_reason,
-                        actual_model=self._model,
+                        actual_model=response_model or self._model,
                         assistant_text="".join(text_parts),
                         reasoning_content=reasoning_content,
                         tool_calls=trace_tool_calls,
@@ -646,6 +650,7 @@ class AnthropicProvider:
                         thinking_signature=thinking_signature,
                         cached_tokens=cached_tokens,
                         cache_write_tokens=cache_creation_tokens,
+                        model=response_model or self._model,
                     )
 
         except httpx.TimeoutException as exc:

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -1074,6 +1074,7 @@ class EnsembleProvider:
         final_request_role: str,
         selected_candidates: Sequence[_CandidateResult] | None = None,
         final_request_member: EnsembleMemberConfig | None = None,
+        final_request_model: str | None = None,
         final_request_config: ChatConfig | None = None,
         final_request_tools: list[ToolDefinition] | None = None,
         final_request_messages: Sequence[Message] | None = None,
@@ -1126,13 +1127,23 @@ class EnsembleProvider:
                     final_request_member
                 ),
             )
-        elif final_request_config is not None or final_request_tools is not None:
-            final_request["execution"] = _request_execution_trace(
+        elif (
+            final_request_config is not None
+            or final_request_tools is not None
+            or final_request_model
+        ):
+            execution = _request_execution_trace(
                 role=final_request_role,
                 chat_config=final_request_config,
                 tools=final_request_tools,
                 timeout_seconds=final_request_timeout_seconds,
             )
+            # No EnsembleMemberConfig on this path, so the request trace cannot
+            # name the model. Feedback attribution reads it, so supply the
+            # configured id rather than leave the key absent.
+            if final_request_model:
+                execution["model"] = final_request_model
+            final_request["execution"] = execution
         if final_request_messages is not None:
             final_request["input"] = _messages_trace(
                 final_request_messages,
@@ -1324,6 +1335,7 @@ class EnsembleProvider:
             fallback_reason=reason,
             final_request_role="fallback_single",
             selected_candidates=[candidate for candidate in candidates if candidate.ok],
+            final_request_model=_provider_model_id(self.fallback_provider),
             final_request_config=config,
             final_request_tools=tools,
             final_request_messages=messages,
@@ -1484,6 +1496,21 @@ def _member_execution_trace(
         }
     )
     return payload
+
+
+def _provider_model_id(provider: Any) -> str | None:
+    """The configured model id a provider will run, via its public metadata.
+
+    ``provider_metadata()`` exists to expose exactly this without prying at
+    private state. Best-effort: a provider double that lacks it yields ``None``
+    and attribution fails closed rather than guessing.
+    """
+    try:
+        model = provider.provider_metadata().model
+    except Exception:  # noqa: BLE001 — trace enrichment must never fail a turn
+        return None
+    model = str(model or "").strip()
+    return model or None
 
 
 def _request_execution_trace(

--- a/src/opensquilla/provider/ensemble_observability.py
+++ b/src/opensquilla/provider/ensemble_observability.py
@@ -312,6 +312,12 @@ def log_ensemble_decision_steps(
             effective_tier=plan.get("effective_tier"),
             routing_confidence=plan.get("routing_confidence"),
             user_profile_enabled=plan.get("user_profile_enabled"),
+            # Which profile, not just whether one was on: a learned profile
+            # changes with every thumb, so the enabled bit alone cannot
+            # explain a decision after the fact. Both are safe to log — a
+            # content hash and an enum.
+            user_profile_version=plan.get("user_profile_version"),
+            user_profile_source=plan.get("user_profile_source"),
             selected_P=selected_p,
             selected_A=selected_a,
             proposer_count=len(selected_p),

--- a/src/opensquilla/provider/ollama.py
+++ b/src/opensquilla/provider/ollama.py
@@ -200,6 +200,7 @@ class OllamaProvider:
 
         input_tokens = 0
         output_tokens = 0
+        response_model = ""
         assistant_text_parts: list[str] = []
         # Ollama tool calls accumulate in the full response (not streamed per-chunk)
         pending_tool_calls: list[dict[str, Any]] = []
@@ -240,6 +241,9 @@ class OllamaProvider:
                             continue
 
                         trace.record_chunk(chunk)
+                        reported_model = chunk.get("model")
+                        if isinstance(reported_model, str) and reported_model:
+                            response_model = reported_model
                         msg_chunk = chunk.get("message", {})
 
                         # Text content
@@ -289,7 +293,7 @@ class OllamaProvider:
                             "output_tokens": output_tokens,
                         },
                         stop_reason="stop",
-                        actual_model=self._model,
+                        actual_model=response_model or self._model,
                         assistant_text="".join(assistant_text_parts),
                         tool_calls=[
                             {
@@ -305,6 +309,7 @@ class OllamaProvider:
                         stop_reason="stop",
                         input_tokens=input_tokens,
                         output_tokens=output_tokens,
+                        model=response_model or self._model,
                     )
 
         except httpx.TimeoutException as exc:

--- a/src/opensquilla/provider/ranking_router.py
+++ b/src/opensquilla/provider/ranking_router.py
@@ -458,16 +458,13 @@ def _validate_ranking_config(raw: Any) -> _ValidatedRankingConfig:
         ("mock_user_profile", "permission"): {
             "allow_models",
             "deny_models",
-            "allow_tools",
             "risk_allowlist",
         },
         ("mock_user_profile", "preference"): {
             "quality_latency_tradeoff",
             "cost_sensitivity",
-            "preferred_formats",
         },
         ("mock_user_profile", "history"): {
-            "capability_prior",
             "positive_model_ids",
             "negative_model_ids",
             "feedback_count",
@@ -525,7 +522,6 @@ def _validate_ranking_config(raw: Any) -> _ValidatedRankingConfig:
             "neutral_score",
             "history_signal_weight",
             "feedback_saturation_count",
-            "preferred_format_bonus",
         },
         ("quality",): {"task_match_weight", "user_score_weight"},
         ("penalties",): {
@@ -849,7 +845,7 @@ def _validate_ranking_config(raw: Any) -> _ValidatedRankingConfig:
             "router_dynamic fallback_task_profile.session_intent.type is invalid"
         )
 
-    for key in ("allow_models", "deny_models", "allow_tools"):
+    for key in ("allow_models", "deny_models"):
         _ranking_string_list(config, "mock_user_profile", "permission", key)
     if not _ranking_string_set(
         config, "mock_user_profile", "permission", "risk_allowlist"
@@ -873,35 +869,6 @@ def _validate_ranking_config(raw: Any) -> _ValidatedRankingConfig:
         raise DynamicRankingError(
             "router_dynamic mock_user_profile.preference.cost_sensitivity is invalid"
         )
-    if not set(
-        _ranking_string_list(
-            config, "mock_user_profile", "preference", "preferred_formats"
-        )
-    ).issubset(set(FORMATS)):
-        raise DynamicRankingError(
-            "router_dynamic mock_user_profile.preference.preferred_formats is invalid"
-        )
-
-    capability_prior = _ranking_mapping(
-        config, "mock_user_profile", "history", "capability_prior"
-    )
-    if not set(capability_prior).issubset(set(CAPABILITIES)):
-        raise DynamicRankingError(
-            "router_dynamic mock_user_profile.history.capability_prior is invalid"
-        )
-    for capability in capability_prior:
-        prior = _ranking_number(
-            config,
-            "mock_user_profile",
-            "history",
-            "capability_prior",
-            str(capability),
-        )
-        if not 0.0 <= prior <= 1.0:
-            raise DynamicRankingError(
-                "router_dynamic mock_user_profile.history.capability_prior values "
-                "must be between 0 and 1"
-            )
     _ranking_string_list(config, "mock_user_profile", "history", "positive_model_ids")
     _ranking_string_list(config, "mock_user_profile", "history", "negative_model_ids")
     if _ranking_int(config, "mock_user_profile", "history", "feedback_count") < 0:
@@ -1012,7 +979,6 @@ def _validate_ranking_config(raw: Any) -> _ValidatedRankingConfig:
         ("task_match", "missing_role_fit_default"),
         ("user_score", "neutral_score"),
         ("user_score", "history_signal_weight"),
-        ("user_score", "preferred_format_bonus"),
         ("session", "intent_confidence_threshold"),
         ("session", "default_quality_feedback"),
         ("session", "score_delta"),
@@ -2066,8 +2032,6 @@ async def analyze_task_with_provider(
         ),
         "request_context": request_context,
     }
-    if user_profile is not None:
-        analyzer_input["user_profile"] = user_profile
     log.info(
         "llm_ensemble.router_dynamic.task_analyzer_started",
         decision_id=decision_id,
@@ -3021,7 +2985,6 @@ def _task_match(
 def _user_score(
     model: RankedModel,
     user_profile: Mapping[str, Any],
-    task_profile: Mapping[str, Any],
     ranking_config: Mapping[str, Any],
 ) -> float:
     history = user_profile.get("history")
@@ -3048,17 +3011,6 @@ def _user_score(
     ) + _ranking_number(
         ranking_config, "user_score", "history_signal_weight"
     ) * signal * confidence
-    optional = task_profile.get("optional_constraints")
-    preference = user_profile.get("preference")
-    preference_map = preference if isinstance(preference, Mapping) else {}
-    if not isinstance(optional, Mapping) or not optional.get("format"):
-        preferred = preference_map.get("preferred_formats")
-        if isinstance(preferred, Sequence) and preferred:
-            score += _ranking_number(
-                ranking_config, "user_score", "preferred_format_bonus"
-            ) * _strength(
-                model, "capability_dist_prior", "format_following", ranking_config
-            )
     return _clamp(score)
 
 
@@ -3198,7 +3150,7 @@ def _base_score_row(
         model, task_profile, ranking_config, role="proposer"
     )
     user_score = (
-        _user_score(model, user_profile, task_profile, ranking_config)
+        _user_score(model, user_profile, ranking_config)
         if user_profile is not None
         else 0.0
     )

--- a/src/opensquilla/provider/ranking_router.py
+++ b/src/opensquilla/provider/ranking_router.py
@@ -1421,6 +1421,84 @@ def mock_user_profile(
     return copy.deepcopy(dict(_ranking_mapping(effective_config, "mock_user_profile")))
 
 
+def validate_user_profile(
+    profile: Mapping[str, Any],
+    ranking_config: Mapping[str, Any] | None = None,
+) -> list[str]:
+    """Reasons a stored profile cannot be trusted; empty when it is fine.
+
+    ``profile.json`` is hand-editable and is the *only* configuration surface
+    for ``deny_models``. A typo there must be rejected rather than silently
+    ignored: ``_cost_latency_weights`` falls back to a default on an unknown
+    ``cost_sensitivity``, so an invalid edit would route exactly as if it had
+    never been made, and say nothing.
+
+    This lives here rather than in ``profile.py`` because the vocabularies are
+    defined here, and ``self_learning`` must not import from ``provider``.
+    Reading them from the same ranking config as the mock validator
+    (``_validate_ranking_config``) is what stops the two from drifting apart —
+    a shared source rather than two lists that agree today.
+
+    Only keys the file actually carries are checked; a partial profile is
+    normal, and the seam fills the rest from the mock baseline.
+    """
+
+    effective = _resolve_ranking_config(ranking_config)
+    errors: list[str] = []
+
+    permission = profile.get("permission")
+    if isinstance(permission, Mapping):
+        risk_values = _ranking_string_set(
+            effective, "task_profile_schema", "constraint_values", "risk"
+        )
+        allowlist = permission.get("risk_allowlist")
+        if allowlist is not None:
+            if not isinstance(allowlist, list) or not all(
+                isinstance(v, str) for v in allowlist
+            ):
+                errors.append("permission.risk_allowlist must be a list of strings")
+            elif not set(allowlist).issubset(risk_values):
+                unknown = sorted(set(allowlist) - risk_values)
+                errors.append(f"permission.risk_allowlist has unknown values: {unknown}")
+        for key in ("allow_models", "deny_models"):
+            value = permission.get(key)
+            if value is not None and (
+                not isinstance(value, list) or not all(isinstance(v, str) for v in value)
+            ):
+                errors.append(f"permission.{key} must be a list of strings")
+
+    preference = profile.get("preference")
+    if isinstance(preference, Mapping):
+        tradeoff = preference.get("quality_latency_tradeoff")
+        if tradeoff is not None and tradeoff not in _USER_TRADEOFFS:
+            errors.append(
+                f"preference.quality_latency_tradeoff {tradeoff!r} is not one of "
+                f"{sorted(_USER_TRADEOFFS)}"
+            )
+        sensitivity = preference.get("cost_sensitivity")
+        if sensitivity is not None:
+            known = _ranking_mapping(effective, "penalties", "user_cost_sensitivity_weights")
+            if sensitivity not in known:
+                errors.append(
+                    f"preference.cost_sensitivity {sensitivity!r} is not one of "
+                    f"{sorted(known)}"
+                )
+
+    history = profile.get("history")
+    if isinstance(history, Mapping):
+        for key in ("positive_model_ids", "negative_model_ids"):
+            value = history.get(key)
+            if value is not None and (
+                not isinstance(value, list) or not all(isinstance(v, str) for v in value)
+            ):
+                errors.append(f"history.{key} must be a list of strings")
+        count = history.get("feedback_count")
+        if count is not None and (not isinstance(count, int) or count < 0):
+            errors.append("history.feedback_count must be a non-negative integer")
+
+    return errors
+
+
 def build_request_context(
     *,
     message: str,

--- a/src/opensquilla/provider/router_dynamic_ranking_config.json
+++ b/src/opensquilla/provider/router_dynamic_ranking_config.json
@@ -100,25 +100,13 @@
     "permission": {
       "allow_models": [],
       "deny_models": [],
-      "allow_tools": [
-        "code_execution",
-        "web_search",
-        "retrieval",
-        "database",
-        "file_system",
-        "calculator",
-        "browser",
-        "api_call"
-      ],
       "risk_allowlist": ["low", "medium", "high"]
     },
     "preference": {
       "quality_latency_tradeoff": "balanced",
-      "cost_sensitivity": "medium",
-      "preferred_formats": []
+      "cost_sensitivity": "medium"
     },
     "history": {
-      "capability_prior": {},
       "positive_model_ids": [],
       "negative_model_ids": [],
       "feedback_count": 0,
@@ -194,8 +182,7 @@
   "user_score": {
     "neutral_score": 0.50,
     "history_signal_weight": 0.50,
-    "feedback_saturation_count": 20,
-    "preferred_format_bonus": 0.05
+    "feedback_saturation_count": 20
   },
   "quality": {
     "task_match_weight": 0.85,

--- a/src/opensquilla/squilla_router/self_learning/feedback.py
+++ b/src/opensquilla/squilla_router/self_learning/feedback.py
@@ -26,7 +26,10 @@ from pathlib import Path
 
 from opensquilla.squilla_router.self_learning.store import agent_data_dir
 
-FEEDBACK_SCHEMA_VERSION = 1
+# v2 adds ``model``: the id of the model whose text the user actually rated.
+# Rows written at v1 simply lack it and read back as ``None`` — the profile
+# skips them rather than guessing an attribution.
+FEEDBACK_SCHEMA_VERSION = 2
 FEEDBACK_FILENAME = "feedback.jsonl"
 
 RATINGS = frozenset({"up", "down", "neutral"})
@@ -39,6 +42,9 @@ class FeedbackEntry:
 
     rating: str  # "up" | "down"
     executed_kind: str  # "single" | "ensemble"
+    # The model the rating attributes to — the aggregator on an ensemble turn,
+    # since it authored the only text the user saw. None on v1 rows.
+    model: str | None = None
 
 
 @dataclass(frozen=True)
@@ -78,6 +84,7 @@ def write_feedback(
     turn_index: int,
     rating: str,
     executed_kind: str = "single",
+    model: str | None = None,
     decision_ts: str | None = None,
     home: Path | None = None,
     now: datetime | None = None,
@@ -101,6 +108,7 @@ def write_feedback(
         "turn_index": int(turn_index),
         "rating": rating,
         "executed_kind": kind,
+        "model": str(model) if model else None,
         "ts": stamp,
         "decision_ts": decision_ts or stamp,
         "schema_version": FEEDBACK_SCHEMA_VERSION,
@@ -165,9 +173,11 @@ def load_feedback_map(
         if rating not in ("up", "down"):
             continue
         kind = row.get("executed_kind")
+        model = row.get("model")
         out[decision_id] = FeedbackEntry(
             rating=str(rating),
             executed_kind=kind if kind in EXECUTED_KINDS else "single",
+            model=str(model) if isinstance(model, str) and model else None,
         )
     return out
 

--- a/src/opensquilla/squilla_router/self_learning/preference_projection.py
+++ b/src/opensquilla/squilla_router/self_learning/preference_projection.py
@@ -1,0 +1,116 @@
+"""Project routing model-preferences out of Dream-consolidated memory.
+
+The user profile that Step-2 ranking scores against (``S_user``) is not an
+accumulator of its own. Preferences ride the memory pipeline: a thumb is
+transcribed into a preference line in ``memory/routing-preferences.md``, Dream
+consolidates it into ``MEMORY.md``, and this module projects the consolidated
+lines back into the ``history.positive_model_ids`` / ``negative_model_ids`` /
+``feedback_count`` shape that ``ranking_router._user_score`` consumes.
+
+Two consumers constrain the line format, and the verbs are chosen to satisfy
+both at once:
+
+* Dream's ``classify_signal`` (``memory/dream/candidates.py``) tags a line by
+  keyword — ``"prefers"`` → positive, ``"do not"``/``"don't"`` → correction —
+  which is how a raw thumb becomes evidence Dream will promote.
+* This projection matches the same verbs to decide the list, and reads the
+  model id from a backticked ``model:<id>`` marker rather than from prose. The
+  marker is the load-bearing part: Dream promotes via an LLM patch that may
+  reword a bullet, so the id must survive as an inline-code token the promotion
+  prompt is told to keep verbatim — matching prose would silently lose the id
+  the moment it was paraphrased.
+
+Pure string functions only: no ``provider``, ``agents``, or ``memory`` imports,
+so the module stays on the clean side of the ``self_learning`` layering rule and
+the engine seam owns path resolution.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# The scanned note a thumb is transcribed into. NOT ``MEMORY.md`` — Dream skips
+# that file as a scan source and treats it as the consolidation target, so a
+# preference written straight there would never become evidence.
+ROUTING_PREF_FILENAME = "routing-preferences.md"
+
+# The enum ranking reads for provenance when a real projection was produced.
+PROFILE_SOURCE = "dream_memory"
+
+# ``model:<id>`` inside inline-code backticks. Same id alphabet as the profile
+# store used, so a token that would never be a model id cannot be extracted.
+_MARKER_RE = re.compile(r"`model:([A-Za-z0-9._:/@-]{1,200})`")
+
+# Substrings that make a line a preference, split by direction. Kept in sync
+# with Dream's ``classify_signal`` so a transcribed line is classified the same
+# way on both sides of the pipeline.
+_PREFER_MARKERS = ("prefers", "prefer ")
+_AVOID_MARKERS = ("do not", "don't")
+
+
+def transcribe_thumb(model: str | None, rating: str) -> str | None:
+    """Render one thumb as a memory bullet, or ``None`` if it says nothing.
+
+    ``neutral`` revokes rather than asserts, and an unresolvable model cannot be
+    credited — both produce ``None`` so the caller writes no line. The verb is
+    chosen to land in Dream's positive/correction buckets; the id rides in a
+    backticked marker so it survives consolidation.
+    """
+    token = (model or "").strip()
+    if not token or _MARKER_RE.search(f"`model:{token}`") is None:
+        return None
+    if rating == "up":
+        return f"- prefers routing to `model:{token}`"
+    if rating == "down":
+        return f"- do not route to `model:{token}`"
+    return None
+
+
+def _direction(line: str) -> str | None:
+    lowered = line.lower()
+    # Avoid wins a tie: "do not prefer X" is an avoidance, not a preference.
+    if any(marker in lowered for marker in _AVOID_MARKERS):
+        return "negative"
+    if any(marker in lowered for marker in _PREFER_MARKERS):
+        return "positive"
+    return None
+
+
+def project_history(memory_text: str) -> dict[str, Any]:
+    """Derive the ranking-visible history from consolidated memory text.
+
+    A model asserted in both directions lands in neither list — the same honest
+    encoding ``_user_score`` would compute anyway, since a +1/-1 signal cancels
+    to zero. ``feedback_count`` is the number of preference lines seen, so
+    confidence ramps with how much the memory actually says about routing.
+    """
+    positive: set[str] = set()
+    negative: set[str] = set()
+    seen = 0
+    for raw_line in memory_text.splitlines():
+        marker = _MARKER_RE.search(raw_line)
+        if marker is None:
+            continue
+        direction = _direction(raw_line)
+        if direction is None:
+            continue
+        seen += 1
+        model_id = marker.group(1)
+        (positive if direction == "positive" else negative).add(model_id)
+    contradictory = positive & negative
+    positive -= contradictory
+    negative -= contradictory
+    return {
+        "positive_model_ids": sorted(positive),
+        "negative_model_ids": sorted(negative),
+        "feedback_count": seen,
+    }
+
+
+__all__ = [
+    "PROFILE_SOURCE",
+    "ROUTING_PREF_FILENAME",
+    "project_history",
+    "transcribe_thumb",
+]

--- a/src/opensquilla/squilla_router/self_learning/profile.py
+++ b/src/opensquilla/squilla_router/self_learning/profile.py
@@ -1,0 +1,293 @@
+"""The learned user profile that Step-2 ranking scores models against.
+
+One file, one user. OpenSquilla runs locally for a single operator, so there
+is no per-agent or per-identity split: every thumb feeds the same profile, and
+``S_user`` reads it on every dynamic-ranking turn.
+
+The file is hand-editable on purpose — ``deny_models`` is the only way to say
+"never route to this" — so reads invalidate on mtime rather than on write.
+
+Privacy contract, identical to ``feedback.jsonl``: model identity tokens, enum
+tokens, and integers only. No prompt text, no response text, ever. The profile
+is derived from ratings, and a rating is a thumb, not a transcript.
+
+Layering: this module knows nothing about ``opensquilla.provider``. The mock
+fallback and the ranking-config defaults compose one layer up, at the engine
+read seam, which keeps the provider/self_learning edge count at zero.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import threading
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from opensquilla.squilla_router.self_learning.store import router_data_root
+
+PROFILE_SCHEMA_VERSION = 1
+PROFILE_FILENAME = "profile.json"
+
+# The enum ranking reads on the plan. The engine seam substitutes
+# ``fallback_mock`` when there is no usable file to read.
+PROFILE_SOURCE = "global_json"
+
+# Provenance: derived by the read seam, never stored. A hand-edited file must
+# not be able to name the source ranking chose or stamp a version for content
+# it does not have. Stripped on write so a file that somehow carries them
+# cannot keep asserting them.
+_DERIVED_AT_READ = frozenset({"profile_source", "profile_version"})
+
+# Model ids are identity tokens (``anthropic/claude-sonnet-4-5``, ``qwen3:4b``).
+# Anything outside this alphabet is not a model id and never reaches the file.
+_SAFE_MODEL_RE = re.compile(r"^[A-Za-z0-9._:/@-]{1,200}$")
+
+# Outer lock: an update is read-modify-write, so concurrent thumbs would
+# otherwise lose one another's counts. Reentrant because a caller folding a
+# rating in holds it across its own read (see ``profile_update_lock``) and
+# ``update_profile_for_rating`` takes it again underneath.
+#
+# Lock order is load-bearing: this one is outer, the feedback log's is inner,
+# and _cache_lock below is innermost. Taking them in another order risks a
+# deadlock.
+_profile_lock = threading.RLock()
+
+# path -> ((st_mtime_ns, st_size), parsed profile). An os.stat per turn costs
+# microseconds against a turn that already spends seconds in LLM calls.
+_cache: dict[str, tuple[tuple[int, int], dict[str, Any]]] = {}
+_cache_lock = threading.Lock()
+
+
+def profile_path(home: Path | None = None) -> Path:
+    """The single global profile file."""
+
+    return router_data_root(home) / PROFILE_FILENAME
+
+
+@contextmanager
+def profile_update_lock() -> Iterator[None]:
+    """Hold the profile across a read-decide-write that spans other files.
+
+    Folding a rating in is not one step: the caller must read the rating this
+    decision already carried, append the new one, and only then fold the
+    delta. ``update_profile_for_rating`` locking its own read-modify-write is
+    not enough — two thumbs on one decision can both read "no previous
+    rating", and both then increment. One click becomes two ratings, and the
+    model can land in neither list.
+
+    That is unrecoverable rather than merely wrong: the profile accumulates a
+    tally instead of replaying the log, so nothing later reconciles it against
+    ``feedback.jsonl``. Wrap the whole sequence:
+
+        with profile_update_lock():
+            previous = load_feedback_map(agent_id).get(decision_id)
+            write_feedback(...)
+            update_profile_for_rating(..., previous_rating=...)
+
+    The read must stay inside the lock *and* before the append — reading after
+    would return the row just written and the decrement would no-op.
+    """
+
+    with _profile_lock:
+        yield
+
+
+def _safe_model(model: Any) -> str | None:
+    token = str(model or "").strip()
+    return token if _SAFE_MODEL_RE.match(token) else None
+
+
+def content_version(payload: Mapping[str, Any]) -> str:
+    """A hash of the profile body, so the version changes exactly when it does.
+
+    A constant here would be worse than no version at all: every learned
+    decision would log the same id, and a routing decision could not be traced
+    back to the profile that produced it.
+
+    ``profile_version`` is excluded — it is the output — and ``last_updated_at``
+    with it, so re-rating the same way twice is recognisably the same profile
+    rather than a new one that happens to route identically.
+
+    Public because the read seam must hash the profile it actually ranked with,
+    not this file's stored field: the file is hand-editable, and an edit to
+    ``deny_models`` never touches the write path that would refresh it.
+    """
+
+    body = {k: v for k, v in payload.items() if k != "profile_version"}
+    history = body.get("history")
+    if isinstance(history, Mapping):
+        body["history"] = {k: v for k, v in history.items() if k != "last_updated_at"}
+    canonical = json.dumps(body, sort_keys=True, separators=(",", ":"), default=str)
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+def _read_raw(path: Path) -> dict[str, Any] | None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def load_profile(home: Path | None = None) -> dict[str, Any] | None:
+    """The stored profile, or ``None`` when there isn't a usable one.
+
+    ``None`` covers every failure — absent file, malformed JSON, wrong shape —
+    so the caller can degrade to the mock baseline. Never raises: a broken
+    profile must not fail a turn.
+    """
+
+    path = profile_path(home)
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    key = str(path)
+    stamp = (stat.st_mtime_ns, stat.st_size)
+    with _cache_lock:
+        hit = _cache.get(key)
+        if hit is not None and hit[0] == stamp:
+            return json.loads(json.dumps(hit[1]))
+    data = _read_raw(path)
+    if data is None:
+        return None
+    with _cache_lock:
+        _cache[key] = (stamp, data)
+    return json.loads(json.dumps(data))
+
+
+def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    """Replace the file in one step so a reader never sees a partial profile."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(f".{os.getpid()}.tmp")
+    try:
+        tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", "utf-8")
+        os.replace(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _derive_history(counts: dict[str, dict[str, int]], *, stamp: str) -> dict[str, Any]:
+    """Recompute the ranking-visible lists from the counts.
+
+    A model with ``up == down`` lands in neither list: ``_user_score`` computes
+    ``signal`` as ``int(in_positive) - int(in_negative)``, so listing it twice
+    would cancel to zero anyway — saying nothing is the honest encoding.
+    """
+    positive = sorted(m for m, c in counts.items() if c.get("up", 0) > c.get("down", 0))
+    negative = sorted(m for m, c in counts.items() if c.get("down", 0) > c.get("up", 0))
+    total = sum(c.get("up", 0) + c.get("down", 0) for c in counts.values())
+    return {
+        "positive_model_ids": positive,
+        "negative_model_ids": negative,
+        "feedback_count": total,
+        "last_updated_at": stamp,
+    }
+
+
+def _apply(counts: dict[str, dict[str, int]], model: str, rating: str, delta: int) -> None:
+    if rating not in ("up", "down"):
+        return
+    bucket = counts.setdefault(model, {"up": 0, "down": 0})
+    bucket[rating] = max(0, int(bucket.get(rating, 0)) + delta)
+    if bucket["up"] == 0 and bucket["down"] == 0:
+        counts.pop(model, None)
+
+
+def update_profile_for_rating(
+    *,
+    model: str | None,
+    new_rating: str,
+    previous_rating: str | None = None,
+    previous_model: str | None = None,
+    home: Path | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Fold one rating into the profile as a delta, and return the new profile.
+
+    Call under :func:`profile_update_lock`, holding it across the read of
+    ``previous_rating`` as well.
+
+    ``previous_rating`` is the effective rating this decision already carried,
+    read *before* the new row was appended. Without it a thumb toggled back to
+    ``neutral`` could never be revoked, and a flip from up to down would count
+    twice.
+
+    ``previous_model`` names the model that rating was credited to, and must
+    be passed whenever ``previous_rating`` is a vote. An unresolvable value is
+    not "the same model as ``model``": it means that rating was never folded
+    in, so there is nothing to take away and the decrement is skipped. Guessing
+    ``model`` instead would decrement a count some *other* decision earned,
+    flipping a model the user likes into one ranking avoids.
+
+    Returns ``None`` without touching the file when ``model`` is unresolvable —
+    attribution fails closed, because crediting the wrong model is worse than
+    learning nothing from this turn.
+    """
+
+    token = _safe_model(model)
+    if token is None:
+        return None
+    previous_token = _safe_model(previous_model)
+    stamp = (now or datetime.now(UTC)).strftime("%Y-%m-%d")
+
+    with _profile_lock:
+        current = load_profile(home) or {}
+        raw_counts = current.get("model_counts")
+        counts: dict[str, dict[str, int]] = {}
+        if isinstance(raw_counts, dict):
+            for key, value in raw_counts.items():
+                safe_key = _safe_model(key)
+                if safe_key is None or not isinstance(value, dict):
+                    continue
+                counts[safe_key] = {
+                    "up": max(0, int(value.get("up") or 0)),
+                    "down": max(0, int(value.get("down") or 0)),
+                }
+
+        if previous_rating in ("up", "down") and previous_token is not None:
+            _apply(counts, previous_token, previous_rating, -1)
+        _apply(counts, token, new_rating, +1)
+
+        # No provenance in the file. ``profile_source`` and ``profile_version``
+        # describe a read — which profile ranking got, and what was in it — so
+        # the read seam derives them. Storing them here would put a second,
+        # differently-computed value under the same name: this body hashes
+        # ``model_counts``, the resolved profile hashes an overlay onto the mock
+        # baseline. An operator matching a decision's version against the file
+        # would find a mismatch for an unchanged profile.
+        updated = {
+            k: v for k, v in current.items() if k not in _DERIVED_AT_READ
+        }
+        updated["schema_version"] = PROFILE_SCHEMA_VERSION
+        updated["model_counts"] = counts
+        updated["history"] = _derive_history(counts, stamp=stamp)
+
+        path = profile_path(home)
+        _atomic_write(path, updated)
+        with _cache_lock:
+            _cache.pop(str(path), None)
+        return updated
+
+
+__all__ = [
+    "PROFILE_FILENAME",
+    "PROFILE_SCHEMA_VERSION",
+    "PROFILE_SOURCE",
+    "content_version",
+    "load_profile",
+    "profile_path",
+    "profile_update_lock",
+    "update_profile_for_rating",
+]

--- a/src/opensquilla/squilla_router/self_learning/profile.py
+++ b/src/opensquilla/squilla_router/self_learning/profile.py
@@ -1,15 +1,20 @@
-"""The learned user profile that Step-2 ranking scores models against.
+"""The hand-edited half of the profile Step-2 ranking scores models against.
 
-One file, one user. OpenSquilla runs locally for a single operator, so there
-is no per-agent or per-identity split: every thumb feeds the same profile, and
-``S_user`` reads it on every dynamic-ranking turn.
+One file, one user. OpenSquilla runs locally for a single operator, so there is
+no per-agent or per-identity split: this file is the whole surface for the
+``permission`` and ``preference`` sections, and ``S_user`` reads it on every
+dynamic-ranking turn.
 
 The file is hand-editable on purpose — ``deny_models`` is the only way to say
-"never route to this" — so reads invalidate on mtime rather than on write.
+"never route to this", and it has no TOML key — so reads invalidate on mtime
+rather than on write. Nothing writes it programmatically: the *learned* half of
+the profile (``history``: which models the operator prefers or avoids) is no
+longer accumulated here. It is derived at read time from Dream-consolidated
+memory by :mod:`preference_projection`, so a thumb rides the memory pipeline
+instead of folding into this file.
 
-Privacy contract, identical to ``feedback.jsonl``: model identity tokens, enum
-tokens, and integers only. No prompt text, no response text, ever. The profile
-is derived from ratings, and a rating is a thumb, not a transcript.
+Privacy contract: model identity tokens, enum tokens, and integers only. No
+prompt text, no response text, ever.
 
 Layering: this module knows nothing about ``opensquilla.provider``. The mock
 fallback and the ranking-config defaults compose one layer up, at the engine
@@ -20,12 +25,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
-import re
 import threading
-from collections.abc import Iterator, Mapping
-from contextlib import contextmanager
-from datetime import UTC, datetime
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -33,30 +34,6 @@ from opensquilla.squilla_router.self_learning.store import router_data_root
 
 PROFILE_SCHEMA_VERSION = 1
 PROFILE_FILENAME = "profile.json"
-
-# The enum ranking reads on the plan. The engine seam substitutes
-# ``fallback_mock`` when there is no usable file to read.
-PROFILE_SOURCE = "global_json"
-
-# Provenance: derived by the read seam, never stored. A hand-edited file must
-# not be able to name the source ranking chose or stamp a version for content
-# it does not have. Stripped on write so a file that somehow carries them
-# cannot keep asserting them.
-_DERIVED_AT_READ = frozenset({"profile_source", "profile_version"})
-
-# Model ids are identity tokens (``anthropic/claude-sonnet-4-5``, ``qwen3:4b``).
-# Anything outside this alphabet is not a model id and never reaches the file.
-_SAFE_MODEL_RE = re.compile(r"^[A-Za-z0-9._:/@-]{1,200}$")
-
-# Outer lock: an update is read-modify-write, so concurrent thumbs would
-# otherwise lose one another's counts. Reentrant because a caller folding a
-# rating in holds it across its own read (see ``profile_update_lock``) and
-# ``update_profile_for_rating`` takes it again underneath.
-#
-# Lock order is load-bearing: this one is outer, the feedback log's is inner,
-# and _cache_lock below is innermost. Taking them in another order risks a
-# deadlock.
-_profile_lock = threading.RLock()
 
 # path -> ((st_mtime_ns, st_size), parsed profile). An os.stat per turn costs
 # microseconds against a turn that already spends seconds in LLM calls.
@@ -68,41 +45,6 @@ def profile_path(home: Path | None = None) -> Path:
     """The single global profile file."""
 
     return router_data_root(home) / PROFILE_FILENAME
-
-
-@contextmanager
-def profile_update_lock() -> Iterator[None]:
-    """Hold the profile across a read-decide-write that spans other files.
-
-    Folding a rating in is not one step: the caller must read the rating this
-    decision already carried, append the new one, and only then fold the
-    delta. ``update_profile_for_rating`` locking its own read-modify-write is
-    not enough — two thumbs on one decision can both read "no previous
-    rating", and both then increment. One click becomes two ratings, and the
-    model can land in neither list.
-
-    That is unrecoverable rather than merely wrong, and not because
-    reconciliation is unimplemented — it is impossible. ``feedback.jsonl`` is
-    pruned by ``retention_days`` while ``model_counts`` accumulates forever, so
-    the log is lossy by design and can never rebuild the tally. This file is the
-    system of record, not a cache of the log. Wrap the whole sequence:
-
-        with profile_update_lock():
-            previous = load_feedback_map(agent_id).get(decision_id)
-            write_feedback(...)
-            update_profile_for_rating(..., previous_rating=...)
-
-    The read must stay inside the lock *and* before the append — reading after
-    would return the row just written and the decrement would no-op.
-    """
-
-    with _profile_lock:
-        yield
-
-
-def _safe_model(model: Any) -> str | None:
-    token = str(model or "").strip()
-    return token if _SAFE_MODEL_RE.match(token) else None
 
 
 def content_version(payload: Mapping[str, Any]) -> str:
@@ -118,7 +60,7 @@ def content_version(payload: Mapping[str, Any]) -> str:
 
     Public because the read seam must hash the profile it actually ranked with,
     not this file's stored field: the file is hand-editable, and an edit to
-    ``deny_models`` never touches the write path that would refresh it.
+    ``deny_models`` never touches a write path that would refresh it.
     """
 
     body = {k: v for k, v in payload.items() if k != "profile_version"}
@@ -168,128 +110,10 @@ def load_profile(home: Path | None = None) -> dict[str, Any] | None:
     return json.loads(json.dumps(data))
 
 
-def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
-    """Replace the file in one step so a reader never sees a partial profile."""
-
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(f".{os.getpid()}.tmp")
-    try:
-        tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", "utf-8")
-        os.replace(tmp, path)
-    finally:
-        tmp.unlink(missing_ok=True)
-
-
-def _derive_history(counts: dict[str, dict[str, int]], *, stamp: str) -> dict[str, Any]:
-    """Recompute the ranking-visible lists from the counts.
-
-    A model with ``up == down`` lands in neither list: ``_user_score`` computes
-    ``signal`` as ``int(in_positive) - int(in_negative)``, so listing it twice
-    would cancel to zero anyway — saying nothing is the honest encoding.
-    """
-    positive = sorted(m for m, c in counts.items() if c.get("up", 0) > c.get("down", 0))
-    negative = sorted(m for m, c in counts.items() if c.get("down", 0) > c.get("up", 0))
-    total = sum(c.get("up", 0) + c.get("down", 0) for c in counts.values())
-    return {
-        "positive_model_ids": positive,
-        "negative_model_ids": negative,
-        "feedback_count": total,
-        "last_updated_at": stamp,
-    }
-
-
-def _apply(counts: dict[str, dict[str, int]], model: str, rating: str, delta: int) -> None:
-    if rating not in ("up", "down"):
-        return
-    bucket = counts.setdefault(model, {"up": 0, "down": 0})
-    bucket[rating] = max(0, int(bucket.get(rating, 0)) + delta)
-    if bucket["up"] == 0 and bucket["down"] == 0:
-        counts.pop(model, None)
-
-
-def update_profile_for_rating(
-    *,
-    model: str | None,
-    new_rating: str,
-    previous_rating: str | None = None,
-    previous_model: str | None = None,
-    home: Path | None = None,
-    now: datetime | None = None,
-) -> dict[str, Any] | None:
-    """Fold one rating into the profile as a delta, and return the new profile.
-
-    Call under :func:`profile_update_lock`, holding it across the read of
-    ``previous_rating`` as well.
-
-    ``previous_rating`` is the effective rating this decision already carried,
-    read *before* the new row was appended. Without it a thumb toggled back to
-    ``neutral`` could never be revoked, and a flip from up to down would count
-    twice.
-
-    ``previous_model`` names the model that rating was credited to, and must
-    be passed whenever ``previous_rating`` is a vote. An unresolvable value is
-    not "the same model as ``model``": it means that rating was never folded
-    in, so there is nothing to take away and the decrement is skipped. Guessing
-    ``model`` instead would decrement a count some *other* decision earned,
-    flipping a model the user likes into one ranking avoids.
-
-    Returns ``None`` without touching the file when ``model`` is unresolvable —
-    attribution fails closed, because crediting the wrong model is worse than
-    learning nothing from this turn.
-    """
-
-    token = _safe_model(model)
-    if token is None:
-        return None
-    previous_token = _safe_model(previous_model)
-    stamp = (now or datetime.now(UTC)).strftime("%Y-%m-%d")
-
-    with _profile_lock:
-        current = load_profile(home) or {}
-        raw_counts = current.get("model_counts")
-        counts: dict[str, dict[str, int]] = {}
-        if isinstance(raw_counts, dict):
-            for key, value in raw_counts.items():
-                safe_key = _safe_model(key)
-                if safe_key is None or not isinstance(value, dict):
-                    continue
-                counts[safe_key] = {
-                    "up": max(0, int(value.get("up") or 0)),
-                    "down": max(0, int(value.get("down") or 0)),
-                }
-
-        if previous_rating in ("up", "down") and previous_token is not None:
-            _apply(counts, previous_token, previous_rating, -1)
-        _apply(counts, token, new_rating, +1)
-
-        # No provenance in the file. ``profile_source`` and ``profile_version``
-        # describe a read — which profile ranking got, and what was in it — so
-        # the read seam derives them. Storing them here would put a second,
-        # differently-computed value under the same name: this body hashes
-        # ``model_counts``, the resolved profile hashes an overlay onto the mock
-        # baseline. An operator matching a decision's version against the file
-        # would find a mismatch for an unchanged profile.
-        updated = {
-            k: v for k, v in current.items() if k not in _DERIVED_AT_READ
-        }
-        updated["schema_version"] = PROFILE_SCHEMA_VERSION
-        updated["model_counts"] = counts
-        updated["history"] = _derive_history(counts, stamp=stamp)
-
-        path = profile_path(home)
-        _atomic_write(path, updated)
-        with _cache_lock:
-            _cache.pop(str(path), None)
-        return updated
-
-
 __all__ = [
     "PROFILE_FILENAME",
     "PROFILE_SCHEMA_VERSION",
-    "PROFILE_SOURCE",
     "content_version",
     "load_profile",
     "profile_path",
-    "profile_update_lock",
-    "update_profile_for_rating",
 ]

--- a/src/opensquilla/squilla_router/self_learning/profile.py
+++ b/src/opensquilla/squilla_router/self_learning/profile.py
@@ -81,9 +81,11 @@ def profile_update_lock() -> Iterator[None]:
     rating", and both then increment. One click becomes two ratings, and the
     model can land in neither list.
 
-    That is unrecoverable rather than merely wrong: the profile accumulates a
-    tally instead of replaying the log, so nothing later reconciles it against
-    ``feedback.jsonl``. Wrap the whole sequence:
+    That is unrecoverable rather than merely wrong, and not because
+    reconciliation is unimplemented — it is impossible. ``feedback.jsonl`` is
+    pruned by ``retention_days`` while ``model_counts`` accumulates forever, so
+    the log is lossy by design and can never rebuild the tally. This file is the
+    system of record, not a cache of the log. Wrap the whole sequence:
 
         with profile_update_lock():
             previous = load_feedback_map(agent_id).get(decision_id)

--- a/tests/test_engine/test_resolve_user_profile.py
+++ b/tests/test_engine/test_resolve_user_profile.py
@@ -1,0 +1,217 @@
+"""The read seam: how a stored profile reaches ranking.
+
+``update_profile_for_rating`` writing a file and ranking reading one are only
+useful if they meet. The unit tests on either side both pass while the seam is
+disconnected, so these cover the join itself: a thumb goes in through the
+learning surface and comes back out of ``_resolve_user_profile`` as history
+that ``S_user`` can actually act on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opensquilla.engine.runtime import TurnRunner
+from opensquilla.squilla_router.self_learning.profile import (
+    profile_path,
+    update_profile_for_rating,
+)
+
+_MODEL = "anthropic/claude-sonnet-4-5"
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the profile's default home at a tmp dir.
+
+    The seam calls ``load_profile()`` with no argument on purpose — it reads
+    the operator's real profile — so redirecting the env is the only honest
+    way to exercise the path the runtime actually takes.
+    """
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_absent_profile_resolves_to_the_mock_baseline(home: Path) -> None:
+    profile = TurnRunner._resolve_user_profile(None)
+    assert profile["history"]["positive_model_ids"] == []
+    assert profile["profile_source"] == "fallback_mock"
+
+
+def test_a_thumb_up_reaches_ranking_as_history(home: Path) -> None:
+    """The end-to-end claim: rating the model changes what ranking reads."""
+    update_profile_for_rating(model=_MODEL, new_rating="up")
+
+    profile = TurnRunner._resolve_user_profile(None)
+    assert profile["history"]["positive_model_ids"] == [_MODEL]
+    assert profile["history"]["feedback_count"] == 1
+    assert profile["profile_source"] == "global_json"
+    assert profile["profile_version"].startswith("sha256:")
+
+
+def test_revoking_the_thumb_reaches_ranking_too(home: Path) -> None:
+    update_profile_for_rating(model=_MODEL, new_rating="up")
+    update_profile_for_rating(
+        model=_MODEL,
+        new_rating="neutral",
+        previous_rating="up",
+        previous_model=_MODEL,
+    )
+
+    profile = TurnRunner._resolve_user_profile(None)
+    assert profile["history"]["positive_model_ids"] == []
+
+
+def test_baseline_defaults_survive_the_overlay(home: Path) -> None:
+    """The stored file carries history only; the mock supplies the rest."""
+    baseline = TurnRunner._resolve_user_profile(None)
+    update_profile_for_rating(model=_MODEL, new_rating="up")
+
+    merged = TurnRunner._resolve_user_profile(None)
+    for section in ("permission", "preference"):
+        assert merged[section] == baseline[section], section
+
+
+def test_a_hand_edited_key_ranking_never_validated_is_not_overlaid(home: Path) -> None:
+    """Only keys the baseline already defines are allowed through."""
+    import json
+
+    update_profile_for_rating(model=_MODEL, new_rating="up")
+    path = profile_path(home)
+    stored = json.loads(path.read_text(encoding="utf-8"))
+    stored["history"]["invented_key"] = "should not survive"
+    path.write_text(json.dumps(stored), encoding="utf-8")
+
+    profile = TurnRunner._resolve_user_profile(None)
+    assert "invented_key" not in profile["history"]
+    assert profile["history"]["positive_model_ids"] == [_MODEL]
+
+
+def _edit_stored(home: Path, mutate) -> None:
+    import json
+
+    path = profile_path(home)
+    stored = json.loads(path.read_text(encoding="utf-8"))
+    mutate(stored)
+    path.write_text(json.dumps(stored), encoding="utf-8")
+
+
+def test_a_valid_hand_edit_is_honored(home: Path) -> None:
+    """deny_models has no TOML key — this file is the whole surface for it."""
+    update_profile_for_rating(model=_MODEL, new_rating="up")
+    _edit_stored(home, lambda s: s.setdefault("permission", {}).update(
+        {"deny_models": ["openai/gpt-5"]}
+    ))
+
+    profile = TurnRunner._resolve_user_profile(None)
+    assert profile["permission"]["deny_models"] == ["openai/gpt-5"]
+    assert profile["profile_source"] == "global_json"
+
+
+def test_a_hand_edit_changes_the_version_ranking_reports(home: Path) -> None:
+    """The version has to cover the edit the file exists to make.
+
+    ``deny_models`` is hard filtering and has no TOML key, so hand-editing it is
+    this file's primary purpose — and it is the one change that never runs the
+    write path. A version stamped only on a thumb would call two profiles with
+    different filtering the same profile, which is the failure a constant
+    version has, narrowed to the case that matters most.
+    """
+    update_profile_for_rating(model=_MODEL, new_rating="up")
+    before = TurnRunner._resolve_user_profile(None)["profile_version"]
+
+    _edit_stored(home, lambda s: s.setdefault("permission", {}).update(
+        {"deny_models": ["openai/gpt-5"]}
+    ))
+    after = TurnRunner._resolve_user_profile(None)["profile_version"]
+
+    assert before != after
+    assert after.startswith("sha256:")
+
+
+def test_the_file_cannot_pin_the_provenance_of_a_decision(home: Path) -> None:
+    """Provenance describes the read, so the file does not get a vote.
+
+    A stored ``profile_source``/``profile_version`` is the file describing
+    itself. Trusting it lets a hand-edited file claim ``fallback_mock`` while
+    ranking uses it, and stamp a version for content it does not have — the
+    forensic record saying the opposite of what happened.
+    """
+    update_profile_for_rating(model=_MODEL, new_rating="up")
+
+    def _lie(stored: dict) -> None:
+        stored["profile_source"] = "fallback_mock"
+        stored["profile_version"] = "sha256:deadbeefdeadbeef"
+
+    _edit_stored(home, _lie)
+
+    profile = TurnRunner._resolve_user_profile(None)
+    # The file was used, so it must say so.
+    assert profile["history"]["positive_model_ids"] == [_MODEL]
+    assert profile["profile_source"] == "global_json"
+    assert profile["profile_version"] != "sha256:deadbeefdeadbeef"
+
+
+def test_an_invalid_enum_is_rejected_rather_than_silently_ignored(home: Path) -> None:
+    """The failure this closes: ranking swallows a bad enum via its default.
+
+    ``_cost_latency_weights`` falls back on an unknown ``cost_sensitivity``,
+    so before validation a typo routed exactly as if the edit had never been
+    made — and said nothing. Refusing the file at least tells the truth.
+    """
+    update_profile_for_rating(model=_MODEL, new_rating="up")
+    _edit_stored(home, lambda s: s.setdefault("preference", {}).update(
+        {"cost_sensitivity": "very_high"}
+    ))
+
+    profile = TurnRunner._resolve_user_profile(None)
+    assert profile["profile_source"] == "fallback_mock"
+    # Refused whole: the history that parsed does not sneak through either.
+    assert profile["history"]["positive_model_ids"] == []
+
+
+def test_an_invalid_risk_allowlist_is_rejected(home: Path) -> None:
+    update_profile_for_rating(model=_MODEL, new_rating="up")
+    _edit_stored(home, lambda s: s.setdefault("permission", {}).update(
+        {"risk_allowlist": ["not_a_risk_level"]}
+    ))
+
+    assert TurnRunner._resolve_user_profile(None)["profile_source"] == "fallback_mock"
+
+
+def test_a_raise_mid_overlay_reports_fallback_and_not_a_half_merge(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The third degrade path, and the one the other two tests miss.
+
+    The overlay mutates ``base`` in place, so a raise partway through leaves it
+    half-merged. Ranking must hear ``fallback_mock`` here for the same reason it
+    does for a missing file — the spec's "any failure" — or a crashed load and
+    an absent one report differently for the same "not using your profile".
+    """
+    update_profile_for_rating(model=_MODEL, new_rating="up")
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("validator exploded")
+
+    monkeypatch.setattr(
+        "opensquilla.provider.ranking_router.validate_user_profile", _boom
+    )
+
+    profile = TurnRunner._resolve_user_profile(None)
+    assert profile["profile_source"] == "fallback_mock"
+    assert profile["history"]["positive_model_ids"] == []
+
+
+def test_unusable_profile_is_reported_not_passed_off_as_the_users_own(
+    home: Path,
+) -> None:
+    path = profile_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+
+    profile = TurnRunner._resolve_user_profile(None)
+    assert profile["profile_source"] == "fallback_mock"
+    assert profile["history"]["positive_model_ids"] == []

--- a/tests/test_engine/test_resolve_user_profile.py
+++ b/tests/test_engine/test_resolve_user_profile.py
@@ -1,197 +1,186 @@
-"""The read seam: how a stored profile reaches ranking.
+"""The read seam: how the derived profile reaches ranking.
 
-``update_profile_for_rating`` writing a file and ranking reading one are only
-useful if they meet. The unit tests on either side both pass while the seam is
-disconnected, so these cover the join itself: a thumb goes in through the
-learning surface and comes back out of ``_resolve_user_profile`` as history
-that ``S_user`` can actually act on.
+``history`` is projected from Dream-consolidated global memory; ``permission``/
+``preference`` come from the hand-edited file, the only surface for
+``deny_models``. The projection and the ranking side each pass in isolation
+while the seam is disconnected, so these cover the join: a preference written
+into MEMORY.md the way Dream would consolidate it comes back out of
+``_resolve_user_profile`` as history ``S_user`` can act on, and a hand-edited
+``deny_models`` rides through beside it.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
+from opensquilla.agents.scope import resolve_agent_workspace_dir
 from opensquilla.engine.runtime import TurnRunner
-from opensquilla.squilla_router.self_learning.profile import (
-    profile_path,
-    update_profile_for_rating,
-)
+from opensquilla.squilla_router.self_learning.profile import profile_path
 
 _MODEL = "anthropic/claude-sonnet-4-5"
+_OTHER = "openai/gpt-5"
 
 
 @pytest.fixture
 def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Point the profile's default home at a tmp dir.
+    """Point both sources' default home at a tmp dir.
 
-    The seam calls ``load_profile()`` with no argument on purpose — it reads
-    the operator's real profile — so redirecting the env is the only honest
-    way to exercise the path the runtime actually takes.
+    The seam resolves the global workspace with ``config=None`` here, so it
+    reads the same ``OPENSQUILLA_STATE_DIR`` the operator's real install would —
+    the only honest way to exercise the path the runtime takes.
     """
     monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path))
     return tmp_path
 
 
-def test_absent_profile_resolves_to_the_mock_baseline(home: Path) -> None:
-    profile = TurnRunner._resolve_user_profile(None)
+def _memory_md(home: Path) -> Path:
+    return resolve_agent_workspace_dir("main", None) / "MEMORY.md"
+
+
+def _write_memory(home: Path, text: str) -> None:
+    path = _memory_md(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_profile(home: Path, payload: dict) -> None:
+    path = profile_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _resolve() -> dict:
+    return TurnRunner._resolve_user_profile(None, None)
+
+
+def test_no_memory_no_file_is_the_mock_baseline(home: Path) -> None:
+    profile = _resolve()
     assert profile["history"]["positive_model_ids"] == []
     assert profile["profile_source"] == "fallback_mock"
 
 
-def test_a_thumb_up_reaches_ranking_as_history(home: Path) -> None:
-    """The end-to-end claim: rating the model changes what ranking reads."""
-    update_profile_for_rating(model=_MODEL, new_rating="up")
+def test_present_but_empty_memory_is_a_derived_empty_profile(home: Path) -> None:
+    """A memory that exists but says nothing is an empty *derived* profile.
 
-    profile = TurnRunner._resolve_user_profile(None)
+    Distinct from "nothing read": ranking IS scoring against the operator's
+    memory, it just carries no preference yet, so the source is honest about
+    having read it.
+    """
+    _write_memory(home, "## Long-Term Memory\n- The user likes dark mode\n")
+    profile = _resolve()
+    assert profile["history"]["positive_model_ids"] == []
+    assert profile["profile_source"] == "dream_memory"
+
+
+def test_a_preference_memory_reaches_ranking_as_history(home: Path) -> None:
+    """The end-to-end claim: a consolidated preference changes what ranking reads."""
+    _write_memory(
+        home,
+        "## Routing preferences\n"
+        f"- The operator prefers routing to `model:{_MODEL}` for coding\n",
+    )
+    profile = _resolve()
     assert profile["history"]["positive_model_ids"] == [_MODEL]
     assert profile["history"]["feedback_count"] == 1
-    assert profile["profile_source"] == "global_json"
+    assert profile["profile_source"] == "dream_memory"
     assert profile["profile_version"].startswith("sha256:")
 
 
-def test_revoking_the_thumb_reaches_ranking_too(home: Path) -> None:
-    update_profile_for_rating(model=_MODEL, new_rating="up")
-    update_profile_for_rating(
-        model=_MODEL,
-        new_rating="neutral",
-        previous_rating="up",
-        previous_model=_MODEL,
-    )
-
-    profile = TurnRunner._resolve_user_profile(None)
+def test_an_avoid_memory_reaches_ranking_as_negative(home: Path) -> None:
+    _write_memory(home, f"- we do not route to `model:{_OTHER}` anymore\n")
+    profile = _resolve()
+    assert profile["history"]["negative_model_ids"] == [_OTHER]
     assert profile["history"]["positive_model_ids"] == []
 
 
-def test_baseline_defaults_survive_the_overlay(home: Path) -> None:
-    """The stored file carries history only; the mock supplies the rest."""
-    baseline = TurnRunner._resolve_user_profile(None)
-    update_profile_for_rating(model=_MODEL, new_rating="up")
-
-    merged = TurnRunner._resolve_user_profile(None)
+def test_baseline_defaults_survive_the_derivation(home: Path) -> None:
+    """Memory carries history only; the mock supplies permission/preference."""
+    baseline = _resolve()
+    _write_memory(home, f"- prefers routing to `model:{_MODEL}`\n")
+    merged = _resolve()
     for section in ("permission", "preference"):
         assert merged[section] == baseline[section], section
 
 
-def test_a_hand_edited_key_ranking_never_validated_is_not_overlaid(home: Path) -> None:
-    """Only keys the baseline already defines are allowed through."""
-    import json
+def test_a_valid_hand_edit_is_honored_beside_the_derived_history(home: Path) -> None:
+    """deny_models has no TOML key — the file is the whole surface for it."""
+    _write_memory(home, f"- prefers routing to `model:{_MODEL}`\n")
+    _write_profile(home, {"permission": {"deny_models": [_OTHER]}})
 
-    update_profile_for_rating(model=_MODEL, new_rating="up")
-    path = profile_path(home)
-    stored = json.loads(path.read_text(encoding="utf-8"))
-    stored["history"]["invented_key"] = "should not survive"
-    path.write_text(json.dumps(stored), encoding="utf-8")
-
-    profile = TurnRunner._resolve_user_profile(None)
-    assert "invented_key" not in profile["history"]
+    profile = _resolve()
+    assert profile["permission"]["deny_models"] == [_OTHER]
     assert profile["history"]["positive_model_ids"] == [_MODEL]
-
-
-def _edit_stored(home: Path, mutate) -> None:
-    import json
-
-    path = profile_path(home)
-    stored = json.loads(path.read_text(encoding="utf-8"))
-    mutate(stored)
-    path.write_text(json.dumps(stored), encoding="utf-8")
-
-
-def test_a_valid_hand_edit_is_honored(home: Path) -> None:
-    """deny_models has no TOML key — this file is the whole surface for it."""
-    update_profile_for_rating(model=_MODEL, new_rating="up")
-    _edit_stored(home, lambda s: s.setdefault("permission", {}).update(
-        {"deny_models": ["openai/gpt-5"]}
-    ))
-
-    profile = TurnRunner._resolve_user_profile(None)
-    assert profile["permission"]["deny_models"] == ["openai/gpt-5"]
-    assert profile["profile_source"] == "global_json"
+    assert profile["profile_source"] == "dream_memory"
 
 
 def test_a_hand_edit_changes_the_version_ranking_reports(home: Path) -> None:
-    """The version has to cover the edit the file exists to make.
+    _write_memory(home, f"- prefers routing to `model:{_MODEL}`\n")
+    before = _resolve()["profile_version"]
 
-    ``deny_models`` is hard filtering and has no TOML key, so hand-editing it is
-    this file's primary purpose — and it is the one change that never runs the
-    write path. A version stamped only on a thumb would call two profiles with
-    different filtering the same profile, which is the failure a constant
-    version has, narrowed to the case that matters most.
-    """
-    update_profile_for_rating(model=_MODEL, new_rating="up")
-    before = TurnRunner._resolve_user_profile(None)["profile_version"]
-
-    _edit_stored(home, lambda s: s.setdefault("permission", {}).update(
-        {"deny_models": ["openai/gpt-5"]}
-    ))
-    after = TurnRunner._resolve_user_profile(None)["profile_version"]
+    _write_profile(home, {"permission": {"deny_models": [_OTHER]}})
+    after = _resolve()["profile_version"]
 
     assert before != after
     assert after.startswith("sha256:")
 
 
-def test_the_file_cannot_pin_the_provenance_of_a_decision(home: Path) -> None:
-    """Provenance describes the read, so the file does not get a vote.
+def test_a_hand_edited_key_ranking_never_validated_is_not_overlaid(home: Path) -> None:
+    """Only keys the baseline already defines are allowed through the file."""
+    _write_profile(
+        home, {"permission": {"deny_models": [_OTHER], "invented_key": "no"}}
+    )
+    profile = _resolve()
+    assert "invented_key" not in profile["permission"]
+    assert profile["permission"]["deny_models"] == [_OTHER]
 
-    A stored ``profile_source``/``profile_version`` is the file describing
-    itself. Trusting it lets a hand-edited file claim ``fallback_mock`` while
-    ranking uses it, and stamp a version for content it does not have — the
-    forensic record saying the opposite of what happened.
+
+def test_an_invalid_enum_refuses_the_file_and_drops_derived_history(home: Path) -> None:
+    """A broken hand-edit means the operator's config is untrustworthy.
+
+    ``_cost_latency_weights`` silently falls back on an unknown
+    ``cost_sensitivity``, so a typo would route as if unmade. Refuse the whole
+    profile — including the memory-derived history — rather than route on half
+    of a config the operator got wrong.
     """
-    update_profile_for_rating(model=_MODEL, new_rating="up")
+    _write_memory(home, f"- prefers routing to `model:{_MODEL}`\n")
+    _write_profile(home, {"preference": {"cost_sensitivity": "very_high"}})
 
-    def _lie(stored: dict) -> None:
-        stored["profile_source"] = "fallback_mock"
-        stored["profile_version"] = "sha256:deadbeefdeadbeef"
-
-    _edit_stored(home, _lie)
-
-    profile = TurnRunner._resolve_user_profile(None)
-    # The file was used, so it must say so.
-    assert profile["history"]["positive_model_ids"] == [_MODEL]
-    assert profile["profile_source"] == "global_json"
-    assert profile["profile_version"] != "sha256:deadbeefdeadbeef"
-
-
-def test_an_invalid_enum_is_rejected_rather_than_silently_ignored(home: Path) -> None:
-    """The failure this closes: ranking swallows a bad enum via its default.
-
-    ``_cost_latency_weights`` falls back on an unknown ``cost_sensitivity``,
-    so before validation a typo routed exactly as if the edit had never been
-    made — and said nothing. Refusing the file at least tells the truth.
-    """
-    update_profile_for_rating(model=_MODEL, new_rating="up")
-    _edit_stored(home, lambda s: s.setdefault("preference", {}).update(
-        {"cost_sensitivity": "very_high"}
-    ))
-
-    profile = TurnRunner._resolve_user_profile(None)
+    profile = _resolve()
     assert profile["profile_source"] == "fallback_mock"
-    # Refused whole: the history that parsed does not sneak through either.
     assert profile["history"]["positive_model_ids"] == []
 
 
-def test_an_invalid_risk_allowlist_is_rejected(home: Path) -> None:
-    update_profile_for_rating(model=_MODEL, new_rating="up")
-    _edit_stored(home, lambda s: s.setdefault("permission", {}).update(
-        {"risk_allowlist": ["not_a_risk_level"]}
-    ))
-
-    assert TurnRunner._resolve_user_profile(None)["profile_source"] == "fallback_mock"
+def test_an_invalid_risk_allowlist_refuses_the_file(home: Path) -> None:
+    _write_profile(home, {"permission": {"risk_allowlist": ["not_a_risk_level"]}})
+    assert _resolve()["profile_source"] == "fallback_mock"
 
 
-def test_a_raise_mid_overlay_reports_fallback_and_not_a_half_merge(
+def test_the_file_cannot_pin_the_provenance_of_a_decision(home: Path) -> None:
+    """Provenance describes the read, so the file does not get a vote."""
+    _write_memory(home, f"- prefers routing to `model:{_MODEL}`\n")
+    _write_profile(
+        home,
+        {
+            "permission": {"deny_models": [_OTHER]},
+            "profile_source": "fallback_mock",
+            "profile_version": "sha256:deadbeefdeadbeef",
+        },
+    )
+    profile = _resolve()
+    assert profile["history"]["positive_model_ids"] == [_MODEL]
+    assert profile["profile_source"] == "dream_memory"
+    assert profile["profile_version"] != "sha256:deadbeefdeadbeef"
+
+
+def test_a_raise_mid_resolution_reports_fallback_not_a_half_merge(
     home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The third degrade path, and the one the other two tests miss.
-
-    The overlay mutates ``base`` in place, so a raise partway through leaves it
-    half-merged. Ranking must hear ``fallback_mock`` here for the same reason it
-    does for a missing file — the spec's "any failure" — or a crashed load and
-    an absent one report differently for the same "not using your profile".
-    """
-    update_profile_for_rating(model=_MODEL, new_rating="up")
+    """Any failure degrades to the baseline, rebuilt clean, not half-merged."""
+    _write_memory(home, f"- prefers routing to `model:{_MODEL}`\n")
+    _write_profile(home, {"permission": {"deny_models": [_OTHER]}})
 
     def _boom(*_args: object, **_kwargs: object) -> None:
         raise RuntimeError("validator exploded")
@@ -199,19 +188,16 @@ def test_a_raise_mid_overlay_reports_fallback_and_not_a_half_merge(
     monkeypatch.setattr(
         "opensquilla.provider.ranking_router.validate_user_profile", _boom
     )
-
-    profile = TurnRunner._resolve_user_profile(None)
+    profile = _resolve()
     assert profile["profile_source"] == "fallback_mock"
     assert profile["history"]["positive_model_ids"] == []
 
 
-def test_unusable_profile_is_reported_not_passed_off_as_the_users_own(
-    home: Path,
-) -> None:
-    path = profile_path(home)
+def test_a_malformed_profile_file_with_no_memory_reports_fallback(home: Path) -> None:
+    path = profile_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("{not json", encoding="utf-8")
 
-    profile = TurnRunner._resolve_user_profile(None)
+    profile = _resolve()
     assert profile["profile_source"] == "fallback_mock"
     assert profile["history"]["positive_model_ids"] == []

--- a/tests/test_engine/test_router_decision_record.py
+++ b/tests/test_engine/test_router_decision_record.py
@@ -165,6 +165,55 @@ def test_flush_records_ensemble_execution_facts() -> None:
     assert record["ensemble_profile"] == "static_openrouter_b5"
 
 
+def test_ensemble_flush_attributes_to_the_aggregator_not_the_classifier() -> None:
+    """The record must name the model whose text the user actually read.
+
+    ``decision.model`` is the classifier's pick. On an ensemble turn it never
+    authored the reply — the aggregator did — so feedback keyed on it would
+    train the profile on a model the user never saw.
+    """
+    writer = _FakeWriter()
+    set_decision_writer(writer)
+    ctx = _ctx()
+    stage_router_decision(
+        ctx,
+        decision=_decision(model="classifier/pick"),
+        routing_extra=ROUTING_EXTRA,
+    )
+
+    ctx.metadata["ensemble_enabled"] = True
+    flush_router_decision(
+        ctx.metadata,
+        ensemble_trace={
+            "profile": "router_dynamic",
+            "final_request": {
+                "role": "aggregator",
+                "execution": {"model": "aggregator/that-ran"},
+                # Response space: what the provider says it ran. Forensics
+                # only — attribution must not key on it.
+                "usage": {"model": "aggregator/that-ran-20260101"},
+            },
+        },
+    )
+    assert writer.records[0]["model"] == "aggregator/that-ran"
+
+
+def test_ensemble_flush_fails_closed_when_the_trace_cannot_name_the_model() -> None:
+    """None, not a guess: crediting the wrong model is worse than not learning."""
+    writer = _FakeWriter()
+    set_decision_writer(writer)
+    ctx = _ctx()
+    stage_router_decision(
+        ctx,
+        decision=_decision(model="classifier/pick"),
+        routing_extra=ROUTING_EXTRA,
+    )
+
+    ctx.metadata["ensemble_enabled"] = True
+    flush_router_decision(ctx.metadata, ensemble_trace={"profile": "router_dynamic"})
+    assert writer.records[0]["model"] is None
+
+
 def test_flush_realigns_model_and_counts_fallback_hops() -> None:
     writer = _FakeWriter()
     set_decision_writer(writer)

--- a/tests/test_gateway/test_rpc_router_decisions.py
+++ b/tests/test_gateway/test_rpc_router_decisions.py
@@ -7,6 +7,7 @@ All fixture data is synthetic.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -261,6 +262,96 @@ async def test_feedback_submit_records_to_sidecar(
     assert fb["d" * 32].executed_kind == "single"
 
 
+async def test_feedback_submit_attributes_the_rating_to_the_recorded_model(
+    writer: RouterDecisionWriter, tmp_path: Path, monkeypatch
+) -> None:
+    """A thumb reaches the profile keyed on the model that authored the reply."""
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path))
+    writer.record_decision(_base_record())
+
+    await _handle_router_feedback_submit(
+        {"decisionId": "d" * 32, "rating": "up"},
+        RpcContext(conn_id="test"),
+    )
+
+    from opensquilla.squilla_router.self_learning.feedback import load_feedback_map
+    from opensquilla.squilla_router.self_learning.profile import load_profile
+
+    assert load_feedback_map("main", home=tmp_path)["d" * 32].model == (
+        "deepseek/deepseek-chat"
+    )
+    profile = load_profile(tmp_path)
+    assert profile is not None
+    assert profile["history"]["positive_model_ids"] == ["deepseek/deepseek-chat"]
+    assert profile["history"]["feedback_count"] == 1
+
+
+async def test_feedback_revocation_removes_the_model_from_the_profile(
+    writer: RouterDecisionWriter, tmp_path: Path, monkeypatch
+) -> None:
+    """Revocation only works if the previous rating is read before the append.
+
+    Reading after would return the row just written and the decrement would
+    silently no-op, leaving the thumb permanently baked into the profile.
+    """
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path))
+    writer.record_decision(_base_record())
+    ctx = RpcContext(conn_id="test")
+
+    await _handle_router_feedback_submit({"decisionId": "d" * 32, "rating": "up"}, ctx)
+    await _handle_router_feedback_submit(
+        {"decisionId": "d" * 32, "rating": "neutral"}, ctx
+    )
+
+    from opensquilla.squilla_router.self_learning.profile import load_profile
+
+    profile = load_profile(tmp_path)
+    assert profile is not None
+    assert profile["history"]["positive_model_ids"] == []
+    assert profile["history"]["feedback_count"] == 0
+
+
+async def test_concurrent_submits_on_one_decision_stay_consistent(
+    writer: RouterDecisionWriter, tmp_path: Path, monkeypatch
+) -> None:
+    """One decision cannot become two ratings, however the clicks interleave.
+
+    A double-click sends two submits onto worker threads. Unless the read of
+    the previous rating, the append, and the fold are one atomic step, both
+    read "no previous rating" and both increment: feedback_count 2 for a
+    single decision, and up==down so the model lands in neither list.
+    """
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path))
+    writer.record_decision(_base_record())
+    ctx = RpcContext(conn_id="test")
+
+    await asyncio.gather(
+        *(
+            _handle_router_feedback_submit({"decisionId": "d" * 32, "rating": r}, ctx)
+            for r in ("up", "down", "up", "down")
+        )
+    )
+
+    from opensquilla.squilla_router.self_learning.feedback import load_feedback_map
+    from opensquilla.squilla_router.self_learning.profile import load_profile
+
+    effective = load_feedback_map("main", home=tmp_path)["d" * 32].rating
+    profile = load_profile(tmp_path)
+    assert profile is not None
+
+    # One decision, one user: exactly one rating is in force, whichever
+    # thumb landed last, and the profile must agree with the log.
+    assert profile["history"]["feedback_count"] == 1
+    counts = profile["model_counts"]["deepseek/deepseek-chat"]
+    assert counts == {"up": 1, "down": 0} if effective == "up" else {"up": 0, "down": 1}
+    listed = (
+        profile["history"]["positive_model_ids"]
+        if effective == "up"
+        else profile["history"]["negative_model_ids"]
+    )
+    assert listed == ["deepseek/deepseek-chat"]
+
+
 async def test_feedback_submit_uses_configured_retention_days(
     writer: RouterDecisionWriter, tmp_path: Path, monkeypatch
 ) -> None:
@@ -403,6 +494,12 @@ def test_feedback_handler_is_dormant_static() -> None:
         # Feedback intake is this module's own job: append-only sidecar writes,
         # still nothing that routes, calibrates, or trains.
         "squilla_router.self_learning.feedback",
+        # The user profile is the second half of that same intake: a thumb is
+        # only worth recording if it folds into the profile ranking reads. It
+        # is a derived preference sidecar, not loop state — it trains nothing
+        # and promotes nothing, and it does not route here (runtime.py reads
+        # it at the ranking seam; this handler only writes).
+        "squilla_router.self_learning.profile",
     )
     forbidden = ("smart_routing", "router_control", "squilla_router", "calibration", "routing")
     for line in import_lines:

--- a/tests/test_gateway/test_rpc_router_decisions.py
+++ b/tests/test_gateway/test_rpc_router_decisions.py
@@ -262,10 +262,24 @@ async def test_feedback_submit_records_to_sidecar(
     assert fb["d" * 32].executed_kind == "single"
 
 
-async def test_feedback_submit_attributes_the_rating_to_the_recorded_model(
+def _routing_pref_note(tmp_path: Path) -> Path:
+    from opensquilla.agents.scope import resolve_agent_workspace_dir
+    from opensquilla.squilla_router.self_learning.preference_projection import (
+        ROUTING_PREF_FILENAME,
+    )
+
+    return resolve_agent_workspace_dir("main", None) / "memory" / ROUTING_PREF_FILENAME
+
+
+async def test_feedback_submit_transcribes_the_thumb_into_a_preference_memory(
     writer: RouterDecisionWriter, tmp_path: Path, monkeypatch
 ) -> None:
-    """A thumb reaches the profile keyed on the model that authored the reply."""
+    """A thumb becomes a routing-preference line keyed on the model that replied.
+
+    The line rides the Dream pipeline from here, so the seam's job is only to
+    write something ``classify_signal`` will promote and ``project_history`` can
+    read back — checked here by projecting the raw note.
+    """
     monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path))
     writer.record_decision(_base_record())
 
@@ -275,51 +289,74 @@ async def test_feedback_submit_attributes_the_rating_to_the_recorded_model(
     )
 
     from opensquilla.squilla_router.self_learning.feedback import load_feedback_map
-    from opensquilla.squilla_router.self_learning.profile import load_profile
+    from opensquilla.squilla_router.self_learning.preference_projection import (
+        project_history,
+    )
 
+    # The sidecar still attributes to the model that authored the reply.
     assert load_feedback_map("main", home=tmp_path)["d" * 32].model == (
         "deepseek/deepseek-chat"
     )
-    profile = load_profile(tmp_path)
-    assert profile is not None
-    assert profile["history"]["positive_model_ids"] == ["deepseek/deepseek-chat"]
-    assert profile["history"]["feedback_count"] == 1
+    note = _routing_pref_note(tmp_path)
+    text = note.read_text(encoding="utf-8")
+    assert "`model:deepseek/deepseek-chat`" in text
+    projected = project_history(text)
+    assert projected["positive_model_ids"] == ["deepseek/deepseek-chat"]
 
 
-async def test_feedback_revocation_removes_the_model_from_the_profile(
+async def test_a_neutral_thumb_appends_nothing(
     writer: RouterDecisionWriter, tmp_path: Path, monkeypatch
 ) -> None:
-    """Revocation only works if the previous rating is read before the append.
+    """Neutral revokes, and a memory-append model cannot un-say a prior line.
 
-    Reading after would return the row just written and the decrement would
-    silently no-op, leaving the thumb permanently baked into the profile.
+    So a neutral writes no preference: the ``up`` above stays until Dream
+    reconsolidates, and reversing a preference is done by thumbing ``down`` (a
+    contradiction the projection collapses), not by toggling to neutral. This is
+    the deliberate consequence of deriving from consolidated memory rather than
+    folding a delta into a file.
     """
     monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path))
     writer.record_decision(_base_record())
     ctx = RpcContext(conn_id="test")
 
-    await _handle_router_feedback_submit({"decisionId": "d" * 32, "rating": "up"}, ctx)
     await _handle_router_feedback_submit(
         {"decisionId": "d" * 32, "rating": "neutral"}, ctx
     )
-
-    from opensquilla.squilla_router.self_learning.profile import load_profile
-
-    profile = load_profile(tmp_path)
-    assert profile is not None
-    assert profile["history"]["positive_model_ids"] == []
-    assert profile["history"]["feedback_count"] == 0
+    # Accepted and logged, but no durable preference line was written.
+    assert not _routing_pref_note(tmp_path).exists()
 
 
-async def test_concurrent_submits_on_one_decision_stay_consistent(
+async def test_a_down_after_up_reads_back_as_a_contradiction(
     writer: RouterDecisionWriter, tmp_path: Path, monkeypatch
 ) -> None:
-    """One decision cannot become two ratings, however the clicks interleave.
+    """Reversing a preference: thumb down, and the projection cancels it out."""
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path))
+    writer.record_decision(_base_record())
+    ctx = RpcContext(conn_id="test")
 
-    A double-click sends two submits onto worker threads. Unless the read of
-    the previous rating, the append, and the fold are one atomic step, both
-    read "no previous rating" and both increment: feedback_count 2 for a
-    single decision, and up==down so the model lands in neither list.
+    await _handle_router_feedback_submit({"decisionId": "d" * 32, "rating": "up"}, ctx)
+    await _handle_router_feedback_submit({"decisionId": "d" * 32, "rating": "down"}, ctx)
+
+    from opensquilla.squilla_router.self_learning.preference_projection import (
+        project_history,
+    )
+
+    projected = project_history(_routing_pref_note(tmp_path).read_text(encoding="utf-8"))
+    # Asserted both ways → neither list, the same zero a +1/-1 signal computes.
+    assert projected["positive_model_ids"] == []
+    assert projected["negative_model_ids"] == []
+    assert projected["feedback_count"] == 2
+
+
+async def test_concurrent_submits_need_no_lock(
+    writer: RouterDecisionWriter, tmp_path: Path, monkeypatch
+) -> None:
+    """The append model has no read-modify-write, so a double-click cannot tear.
+
+    Four rapid submits land four independent lines; the projection is a pure
+    function of what is on disk, so the outcome is the same however the threads
+    interleave. No profile lock is needed — that whole class of races is gone
+    with the delta fold it protected.
     """
     monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path))
     writer.record_decision(_base_record())
@@ -332,24 +369,18 @@ async def test_concurrent_submits_on_one_decision_stay_consistent(
         )
     )
 
-    from opensquilla.squilla_router.self_learning.feedback import load_feedback_map
-    from opensquilla.squilla_router.self_learning.profile import load_profile
-
-    effective = load_feedback_map("main", home=tmp_path)["d" * 32].rating
-    profile = load_profile(tmp_path)
-    assert profile is not None
-
-    # One decision, one user: exactly one rating is in force, whichever
-    # thumb landed last, and the profile must agree with the log.
-    assert profile["history"]["feedback_count"] == 1
-    counts = profile["model_counts"]["deepseek/deepseek-chat"]
-    assert counts == {"up": 1, "down": 0} if effective == "up" else {"up": 0, "down": 1}
-    listed = (
-        profile["history"]["positive_model_ids"]
-        if effective == "up"
-        else profile["history"]["negative_model_ids"]
+    from opensquilla.squilla_router.self_learning.preference_projection import (
+        project_history,
     )
-    assert listed == ["deepseek/deepseek-chat"]
+
+    text = _routing_pref_note(tmp_path).read_text(encoding="utf-8")
+    marker = "`model:deepseek/deepseek-chat`"
+    # Every append landed intact (O_APPEND is atomic for a short line).
+    assert text.count(marker) == 4
+    projected = project_history(text)
+    # 2 prefers + 2 do-not → the model is asserted both ways → neither list.
+    assert projected["positive_model_ids"] == []
+    assert projected["negative_model_ids"] == []
 
 
 async def test_feedback_submit_uses_configured_retention_days(
@@ -494,12 +525,12 @@ def test_feedback_handler_is_dormant_static() -> None:
         # Feedback intake is this module's own job: append-only sidecar writes,
         # still nothing that routes, calibrates, or trains.
         "squilla_router.self_learning.feedback",
-        # The user profile is the second half of that same intake: a thumb is
-        # only worth recording if it folds into the profile ranking reads. It
-        # is a derived preference sidecar, not loop state — it trains nothing
-        # and promotes nothing, and it does not route here (runtime.py reads
-        # it at the ranking seam; this handler only writes).
-        "squilla_router.self_learning.profile",
+        # Transcribing a thumb into a routing-preference memory line is the
+        # second half of that same intake. It is a pure string function over
+        # the rating — it trains nothing, promotes nothing, and does not route
+        # here (runtime.py projects the consolidated memory at the ranking seam;
+        # this handler only writes the line the pipeline later reads).
+        "squilla_router.self_learning.preference_projection",
     )
     forbidden = ("smart_routing", "router_control", "squilla_router", "calibration", "routing")
     for line in import_lines:

--- a/tests/test_memory_dream_evidence.py
+++ b/tests/test_memory_dream_evidence.py
@@ -128,3 +128,37 @@ def test_scan_dream_candidates_extracts_top_level_memory_files(tmp_path: Path) -
     assert candidates[0].signal_kind == "positive"
     assert candidates[0].snippet_sha256
     assert candidates[0].claim_sha256
+
+
+def test_scan_splits_routing_preference_log_per_line(tmp_path: Path) -> None:
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / "routing-preferences.md").write_text(
+        "- prefers routing to `model:x-ai/grok-4.5`\n"
+        "- do not route to `model:openai/gpt-6`\n",
+        encoding="utf-8",
+    )
+
+    candidates = scan_dream_candidates(tmp_path, cursor=0.0, max_batch_size=10, agent_id="main")
+
+    # Each thumb is its own candidate with its own signal, not one collapsed blob.
+    assert len(candidates) == 2
+    by_signal = {candidate.signal_kind for candidate in candidates}
+    assert by_signal == {"positive", "correction"}
+    # Distinct claims → distinct dedup keys, so they accrue evidence independently.
+    assert len({candidate.claim_sha256 for candidate in candidates}) == 2
+
+
+def test_scan_keeps_narrative_note_whole(tmp_path: Path) -> None:
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    # A multi-line prose note has no routing marker: it stays one narrative candidate.
+    (memory_dir / "2026-05-22-note.md").write_text(
+        "User prefers real benchmark runs.\n"
+        "They do not want toy simulations in the report.\n",
+        encoding="utf-8",
+    )
+
+    candidates = scan_dream_candidates(tmp_path, cursor=0.0, max_batch_size=10, agent_id="main")
+
+    assert len(candidates) == 1

--- a/tests/test_memory_dream_prompts.py
+++ b/tests/test_memory_dream_prompts.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from opensquilla.memory.dream.models import PromotionCandidate
+from opensquilla.memory.dream.prompts import parse_promotion_patch
+
+
+def _candidate(candidate_id: str = "cand-1") -> PromotionCandidate:
+    return PromotionCandidate(
+        candidate_id=candidate_id,
+        source_path="memory/routing-preferences.md",
+        snippet="- prefers routing to `model:x-ai/grok-4.5`",
+        snippet_sha256="s",
+        claim_sha256="c",
+        score=0.9,
+        reasons=["positive_or_manual_signal"],
+        signal_counts={"positive": 1},
+    )
+
+
+_PATCH = (
+    '{"operations":[{"op":"upsert","candidate_ids":["cand-1"],'
+    '"section":"User Preferences","memory_id":"mem_grok",'
+    '"text":"- prefers routing to `model:x-ai/grok-4.5`"}]}'
+)
+
+
+def _op_ids(text: str) -> list[list[str]]:
+    patch = parse_promotion_patch(text, [_candidate()])
+    return [op.candidate_ids for op in patch.operations]
+
+
+def test_parses_clean_json() -> None:
+    assert _op_ids(_PATCH) == [["cand-1"]]
+
+
+def test_ignores_trailing_commentary_after_object() -> None:
+    # The recurrent deepseek failure: a valid object followed by prose the greedy
+    # regex used to swallow, yielding json.loads "Extra data".
+    text = _PATCH + "\n\nI preserved the `model:` marker verbatim as instructed."
+    assert _op_ids(text) == [["cand-1"]]
+
+
+def test_ignores_trailing_second_object() -> None:
+    text = _PATCH + '\n{"note":"done"}'
+    assert _op_ids(text) == [["cand-1"]]
+
+
+def test_skips_preamble_example_object() -> None:
+    # A leading example object (no operations) must not shadow the real patch.
+    text = 'Example: {"op":"skip"}\n\n' + _PATCH
+    assert _op_ids(text) == [["cand-1"]]
+
+
+def test_survives_markdown_fence() -> None:
+    text = "```json\n" + _PATCH + "\n```"
+    assert _op_ids(text) == [["cand-1"]]
+
+
+def test_braces_inside_string_do_not_break_balance() -> None:
+    text = (
+        '{"operations":[{"op":"upsert","candidate_ids":["cand-1"],'
+        '"section":"User Preferences","memory_id":"mem_grok",'
+        '"text":"- prefers routing to `model:x-ai/grok-4.5` {not a brace}"}]}'
+    )
+    patch = parse_promotion_patch(text, [_candidate()])
+    assert patch.operations[0].text.endswith("{not a brace}")
+
+
+def test_no_json_raises() -> None:
+    with pytest.raises(ValueError, match="did not contain JSON"):
+        parse_promotion_patch("no json here at all", [_candidate()])

--- a/tests/test_provider/golden/streams/anthropic/stop_reason_usage_cache.events.json
+++ b/tests/test_provider/golden/streams/anthropic/stop_reason_usage_cache.events.json
@@ -10,7 +10,7 @@
     "cost_source": "none",
     "ensemble_trace": null,
     "input_tokens": 146,
-    "model": "",
+    "model": "claude-test-1",
     "model_usage_breakdown": [],
     "output_tokens": 3,
     "reasoning_content": null,

--- a/tests/test_provider/golden/streams/anthropic/text_content_blocks.events.json
+++ b/tests/test_provider/golden/streams/anthropic/text_content_blocks.events.json
@@ -14,7 +14,7 @@
     "cost_source": "none",
     "ensemble_trace": null,
     "input_tokens": 10,
-    "model": "",
+    "model": "claude-test-1",
     "model_usage_breakdown": [],
     "output_tokens": 4,
     "reasoning_content": null,

--- a/tests/test_provider/golden/streams/anthropic/thinking_signature_then_text.events.json
+++ b/tests/test_provider/golden/streams/anthropic/thinking_signature_then_text.events.json
@@ -18,7 +18,7 @@
     "cost_source": "none",
     "ensemble_trace": null,
     "input_tokens": 15,
-    "model": "",
+    "model": "claude-test-1",
     "model_usage_breakdown": [],
     "output_tokens": 9,
     "reasoning_content": "Let me think about this.",

--- a/tests/test_provider/golden/streams/anthropic/tool_use_fragmented_input.events.json
+++ b/tests/test_provider/golden/streams/anthropic/tool_use_fragmented_input.events.json
@@ -35,7 +35,7 @@
     "cost_source": "none",
     "ensemble_trace": null,
     "input_tokens": 25,
-    "model": "",
+    "model": "claude-test-1",
     "model_usage_breakdown": [],
     "output_tokens": 12,
     "reasoning_content": null,

--- a/tests/test_provider/golden/streams/ollama/text_then_done.events.json
+++ b/tests/test_provider/golden/streams/ollama/text_then_done.events.json
@@ -14,7 +14,7 @@
     "cost_source": "none",
     "ensemble_trace": null,
     "input_tokens": 8,
-    "model": "",
+    "model": "test-model",
     "model_usage_breakdown": [],
     "output_tokens": 3,
     "reasoning_content": null,

--- a/tests/test_provider/golden/streams/ollama/whole_chunk_tool_call.events.json
+++ b/tests/test_provider/golden/streams/ollama/whole_chunk_tool_call.events.json
@@ -26,7 +26,7 @@
     "cost_source": "none",
     "ensemble_trace": null,
     "input_tokens": 9,
-    "model": "",
+    "model": "test-model",
     "model_usage_breakdown": [],
     "output_tokens": 2,
     "reasoning_content": null,

--- a/tests/test_provider_stream_contract.py
+++ b/tests/test_provider_stream_contract.py
@@ -13,6 +13,18 @@ These lock the chat() protocol invariants (provider/protocol.py):
 - Text-to-tool-call synthesis only runs for provider kinds that leak the
   MiniMax text protocol (minimax, openrouter), never for e.g. plain openai.
 - A non-UTF-8 HTTP error body from Ollama yields an ErrorEvent, not a crash.
+- ``DoneEvent.model`` names the model the response reported, degrading to the
+  configured id when the upstream omits it. Its default of ``""``
+  (``provider/types.py``) makes an omission silent rather than loud, which is
+  why Anthropic and Ollama assert it here; the OpenAI family already reported
+  it and is covered by the stream goldens.
+
+  This field is *response space*: a dated snapshot such as
+  ``claude-sonnet-4-5-20250929``, which no registry entry joins against. It is
+  forensics — it answers "what actually ran", and feeds ``usage.model``.
+  Feedback attribution deliberately keys on a different field, the configured
+  id at ``final_request.execution.model``; see ``_final_request_model`` in
+  ``engine/steps/router_decision_record.py``.
 """
 
 from __future__ import annotations
@@ -455,3 +467,77 @@ def test_ollama_non_utf8_error_body_yields_error_event(monkeypatch: Any) -> None
     assert len(errors) == 1
     assert errors[0].code == "500"
     assert "boom" in errors[0].message
+
+
+# ---------------------------------------------------------------------------
+# DoneEvent.model is always populated
+# ---------------------------------------------------------------------------
+
+
+def _ollama_ndjson(chunks: list[dict[str, Any]]) -> bytes:
+    return b"".join(f"{json.dumps(chunk)}\n".encode() for chunk in chunks)
+
+
+def _done_of(events: list[Any]) -> DoneEvent:
+    dones = [e for e in events if isinstance(e, DoneEvent)]
+    assert len(dones) == 1
+    return dones[0]
+
+
+def test_anthropic_done_model_reports_what_the_response_named(monkeypatch: Any) -> None:
+    """The executed model, not the configured alias.
+
+    An alias like ``claude-sonnet-4-5`` resolves server-side to a dated
+    snapshot, and only the response knows which one answered. Reporting the
+    alias back would throw that away and make the field a restatement of
+    config the caller already had.
+
+    This is forensics, not an attribution key: the registry holds aliases, so
+    a dated snapshot joins against nothing. Attribution keys on the configured
+    id instead.
+    """
+    body = _anthropic_sse(
+        [
+            {
+                "type": "message_start",
+                "message": {"id": "msg_1", "model": "claude-sonnet-4-5-20250929", "usage": {}},
+            },
+            {"type": "message_stop"},
+        ]
+    )
+    _patch_stream_body(monkeypatch, "anthropic", body)
+    provider = AnthropicProvider(model="claude-sonnet-4-5", api_key="k")
+    assert _done_of(_collect(provider)).model == "claude-sonnet-4-5-20250929"
+
+
+def test_anthropic_done_model_falls_back_to_configured_when_unreported(
+    monkeypatch: Any,
+) -> None:
+    body = _anthropic_sse(
+        [
+            {"type": "message_start", "message": {"id": "msg_1", "usage": {}}},
+            {"type": "message_stop"},
+        ]
+    )
+    _patch_stream_body(monkeypatch, "anthropic", body)
+    provider = AnthropicProvider(model="claude-sonnet-4-5", api_key="k")
+    assert _done_of(_collect(provider)).model == "claude-sonnet-4-5"
+
+
+def test_ollama_done_model_reports_what_the_response_named(monkeypatch: Any) -> None:
+    body = _ollama_ndjson(
+        [
+            {"model": "llama3:8b-instruct", "message": {"content": "hi"}},
+            {"model": "llama3:8b-instruct", "done": True, "eval_count": 2},
+        ]
+    )
+    _patch_stream_body(monkeypatch, "ollama", body)
+    provider = OllamaProvider(model="llama3")
+    assert _done_of(_collect(provider)).model == "llama3:8b-instruct"
+
+
+def test_ollama_done_model_falls_back_to_configured_when_unreported(monkeypatch: Any) -> None:
+    body = _ollama_ndjson([{"message": {"content": "hi"}}, {"done": True, "eval_count": 2}])
+    _patch_stream_body(monkeypatch, "ollama", body)
+    provider = OllamaProvider(model="llama3")
+    assert _done_of(_collect(provider)).model == "llama3"

--- a/tests/test_ranking_router.py
+++ b/tests/test_ranking_router.py
@@ -1074,6 +1074,60 @@ def test_hard_filter_records_availability_permission_modality_and_context_reason
     assert decision.proposers[0].model_id == "eligible"
 
 
+def _profile_with_history(*, positive: list[str], negative: list[str], count: int) -> dict:
+    profile = mock_user_profile()
+    profile["history"]["positive_model_ids"] = positive
+    profile["history"]["negative_model_ids"] = negative
+    profile["history"]["feedback_count"] = count
+    return profile
+
+
+def test_history_reorders_candidates_that_task_match_alone_would_not() -> None:
+    """The regression that matters: history must be able to change the order.
+
+    With an empty history every model gets the same neutral S_user, so the
+    0.15 * S_user term is a uniform offset and cannot reorder anything — the
+    profile is inert rather than approximate. A saturated history splits
+    S_user across models and the weaker-but-liked model wins.
+    """
+    liked = _model("liked", capability=0.80, aggregator_fit=0.80)
+    disliked = _model("disliked", capability=0.85, aggregator_fit=0.85)
+
+    neutral = _decision(liked, disliked, analysis=_analysis(tier=2))
+    assert [m.model_id for m in neutral.proposers][0] == "disliked"
+
+    opinionated = _decision(
+        liked,
+        disliked,
+        analysis=_analysis(tier=2),
+        user_profile=_profile_with_history(
+            positive=["liked"], negative=["disliked"], count=20
+        ),
+    )
+    assert [m.model_id for m in opinionated.proposers][0] == "liked"
+
+
+def test_history_confidence_ramps_in_with_feedback_count() -> None:
+    """One click must not swing the ranking to an extreme.
+
+    confidence = min(1, feedback_count / 20), so a single rating moves S_user
+    by 1/20th of the full signal — not enough to overturn a task-match gap
+    that a saturated history does overturn.
+    """
+    liked = _model("liked", capability=0.80, aggregator_fit=0.80)
+    disliked = _model("disliked", capability=0.85, aggregator_fit=0.85)
+
+    barely = _decision(
+        liked,
+        disliked,
+        analysis=_analysis(tier=2),
+        user_profile=_profile_with_history(
+            positive=["liked"], negative=["disliked"], count=1
+        ),
+    )
+    assert [m.model_id for m in barely.proposers][0] == "disliked"
+
+
 def test_ranking_without_user_profile_bypasses_all_profile_effects() -> None:
     preferred = _model("preferred", capability=0.95, aggregator_fit=0.95)
     backup = _model("backup", capability=0.80, aggregator_fit=0.80)

--- a/tests/test_ranking_router.py
+++ b/tests/test_ranking_router.py
@@ -851,11 +851,12 @@ async def test_task_analyzer_uses_provider_interface_and_validates_json() -> Non
     analyzer_payload = json.loads(str(provider.calls[0][0][0].content))
     assert analyzer_payload["allowed_constraints"]["risk"] == ["low", "medium", "high"]
     assert analyzer_payload["allowed_session_intents"] == ["new_task", "continue", "redo"]
-    assert "user_profile" in analyzer_payload
+    # The profile never reaches the analyzer provider, even when one is supplied.
+    assert "user_profile" not in analyzer_payload
 
 
 @pytest.mark.asyncio
-async def test_task_analyzer_omits_disabled_user_profile_and_correlates_logs() -> None:
+async def test_task_analyzer_omits_user_profile_and_correlates_logs() -> None:
     provider = _AnalyzerProvider(json.dumps(_task_profile(tier=2)))
 
     with structlog.testing.capture_logs() as captured:
@@ -886,6 +887,31 @@ async def test_task_analyzer_omits_disabled_user_profile_and_correlates_logs() -
         for row in analyzer_events
     )
     assert all(row["user_profile_enabled"] is False for row in analyzer_events)
+
+
+@pytest.mark.asyncio
+async def test_task_analyzer_logs_supplied_profile_without_sending_it() -> None:
+    provider = _AnalyzerProvider(json.dumps(_task_profile(tier=2)))
+
+    with structlog.testing.capture_logs() as captured:
+        await analyze_task_with_provider(
+            provider=provider,
+            message="implement a parser",
+            user_profile=mock_user_profile(),
+            request_context=_context(),
+            routed_tier="c1",
+            routing_confidence=0.8,
+            decision_id="decision-with-profile",
+        )
+
+    assert "user_profile" not in json.loads(str(provider.calls[0][0][0].content))
+    analyzer_events = [
+        row
+        for row in captured
+        if str(row["event"]).startswith("llm_ensemble.router_dynamic.task_analyzer_")
+    ]
+    assert analyzer_events
+    assert all(row["user_profile_enabled"] is True for row in analyzer_events)
 
 
 @pytest.mark.asyncio

--- a/tests/test_router_self_learning_feedback_merge_order.py
+++ b/tests/test_router_self_learning_feedback_merge_order.py
@@ -5,18 +5,17 @@
 order makes revocation work, and nothing about reading either function in
 isolation reveals that.
 
-Reverse it — filter to votes, then merge — and a revoking ``neutral`` row is
-skipped before it can supersede anything, so the stale ``up`` underneath is
-still returned as the effective rating. The rating surface passes that back as
-``previous_model``/``previous_rating`` on the *next* revision, and the profile
-decrements a vote it already took away. One count, silently, in the direction
-that pushes a model the user likes toward the list ranking avoids.
+``load_feedback_map`` is the effective-rating source the offline trainer joins
+on (``alignment``/``dataset``): each decision resolves to the one rating in
+force. Reverse the order — filter to votes, then merge — and a revoking
+``neutral`` row is skipped before it can supersede anything, so the stale ``up``
+underneath is still returned as the effective rating. The trainer then joins a
+retracted thumb to its sample as a live positive label, teaching toward a
+decision the user took back.
 
-The delta model rests on this: the tally is accumulated, never replayed against
-the log, so a double-decrement is not corrected later. It cannot be — the log is
-pruned by ``retention_days`` while the tally accumulates forever, so nothing can
-reconstruct the truth. That is what makes an ordering nobody would think to test
-worth a test.
+The log cannot self-correct: it is pruned by ``retention_days``, so once the
+neutral row ages out there is nothing left to reveal the ``up`` was revoked.
+That is what makes an ordering nobody would think to test worth a test.
 """
 
 from __future__ import annotations
@@ -48,9 +47,10 @@ def _submit(rating: str, home: Path, *, model: str | None = _MODEL) -> None:
 def test_a_revoking_neutral_supersedes_the_vote_it_revokes(tmp_path: Path) -> None:
     """The decision must be gone, not merely reported as neutral.
 
-    ``load_feedback_map`` is the sole source of ``previous_rating``. If the
-    revoked ``up`` survives here, the next revision decrements it a second
-    time — against a tally no replay can repair.
+    ``load_feedback_map`` is the sole source of each decision's effective
+    rating. If the revoked ``up`` survives here, the offline trainer joins a
+    retracted thumb to its sample as a live positive label — against a log that,
+    once pruned, can no longer reveal the retraction.
     """
     _submit("up", tmp_path)
     assert _DECISION in load_feedback_map(_AGENT, tmp_path)

--- a/tests/test_router_self_learning_feedback_merge_order.py
+++ b/tests/test_router_self_learning_feedback_merge_order.py
@@ -1,0 +1,103 @@
+"""Merge-then-filter in ``load_feedback_map``, and why the order is the point.
+
+``_merged_by_decision`` collapses to the last row per ``decision_id`` *before*
+``load_feedback_map`` drops non-votes. Both steps are obviously needed; only the
+order makes revocation work, and nothing about reading either function in
+isolation reveals that.
+
+Reverse it — filter to votes, then merge — and a revoking ``neutral`` row is
+skipped before it can supersede anything, so the stale ``up`` underneath is
+still returned as the effective rating. The rating surface passes that back as
+``previous_model``/``previous_rating`` on the *next* revision, and the profile
+decrements a vote it already took away. One count, silently, in the direction
+that pushes a model the user likes toward the list ranking avoids.
+
+The delta model rests on this: the tally is accumulated, never replayed against
+the log, so a double-decrement is not corrected later. It cannot be — the log is
+pruned by ``retention_days`` while the tally accumulates forever, so nothing can
+reconstruct the truth. That is what makes an ordering nobody would think to test
+worth a test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from opensquilla.squilla_router.self_learning.feedback import (
+    load_feedback_map,
+    write_feedback,
+)
+
+_AGENT = "agent-under-test"
+_DECISION = "decision-1"
+_MODEL = "anthropic/claude-sonnet-4-5"
+
+
+def _submit(rating: str, home: Path, *, model: str | None = _MODEL) -> None:
+    write_feedback(
+        _AGENT,
+        decision_id=_DECISION,
+        session_key="session-1",
+        turn_index=0,
+        rating=rating,
+        model=model,
+        home=home,
+    )
+
+
+def test_a_revoking_neutral_supersedes_the_vote_it_revokes(tmp_path: Path) -> None:
+    """The decision must be gone, not merely reported as neutral.
+
+    ``load_feedback_map`` is the sole source of ``previous_rating``. If the
+    revoked ``up`` survives here, the next revision decrements it a second
+    time — against a tally no replay can repair.
+    """
+    _submit("up", tmp_path)
+    assert _DECISION in load_feedback_map(_AGENT, tmp_path)
+
+    _submit("neutral", tmp_path)
+
+    assert load_feedback_map(_AGENT, tmp_path) == {}
+
+
+def test_the_last_row_wins_even_when_an_earlier_row_would_pass_the_filter(
+    tmp_path: Path,
+) -> None:
+    """Merge order, isolated from revocation.
+
+    Both rows are votes, so the rating filter cannot distinguish them: only
+    file order decides. This fails the moment merging stops being last-wins.
+    """
+    _submit("up", tmp_path)
+    _submit("down", tmp_path)
+
+    entry = load_feedback_map(_AGENT, tmp_path)[_DECISION]
+    assert entry.rating == "down"
+
+
+def test_a_vote_reinstated_after_a_revocation_is_live_again(tmp_path: Path) -> None:
+    """Revocation is not terminal — the merge has no memory of being emptied."""
+    _submit("up", tmp_path)
+    _submit("neutral", tmp_path)
+    _submit("up", tmp_path)
+
+    assert load_feedback_map(_AGENT, tmp_path)[_DECISION].rating == "up"
+
+
+def test_revoking_one_decision_leaves_its_neighbours_alone(tmp_path: Path) -> None:
+    """The merge keys on decision_id, so a revocation is scoped to one row."""
+    _submit("up", tmp_path)
+    write_feedback(
+        _AGENT,
+        decision_id="decision-2",
+        session_key="session-1",
+        turn_index=1,
+        rating="up",
+        model=_MODEL,
+        home=tmp_path,
+    )
+
+    _submit("neutral", tmp_path)
+
+    remaining = load_feedback_map(_AGENT, tmp_path)
+    assert set(remaining) == {"decision-2"}

--- a/tests/test_router_self_learning_layering.py
+++ b/tests/test_router_self_learning_layering.py
@@ -1,0 +1,62 @@
+"""The layering constraint that decides where the profile validator lives.
+
+``self_learning`` must not import from ``opensquilla.provider``. This is not
+housekeeping: it is the whole reason ``validate_user_profile`` sits in
+``ranking_router.py``, next to the vocabularies it enforces, and is called from
+the engine seam that already imports both sides.
+
+Without a test the constraint is a docstring. Someone adds one import to
+"simplify", nothing fails, and the justification for the split placement
+evaporates — at which point moving the validator back into ``profile.py`` looks
+like a cleanup rather than a layering break. The edge count is the thing that
+has to fail, because by the time the placement looks arbitrary the argument for
+it is already gone.
+
+Imports are read from the AST rather than grepped: ``profile.py``'s module
+docstring names ``opensquilla.provider`` to explain this rule, and a textual
+search cannot tell that apart from an actual import.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import opensquilla.squilla_router.self_learning as self_learning_pkg
+
+_FORBIDDEN = "opensquilla.provider"
+_PACKAGE_ROOT = Path(self_learning_pkg.__file__).parent
+
+
+def _imported_modules(source: str) -> set[str]:
+    """Every module named by an import in ``source``.
+
+    ``from x import y`` contributes ``x``; ``import x.y`` contributes ``x.y``.
+    Relative imports have no module path to compare and are in-package by
+    definition, so they cannot reach ``provider``.
+    """
+    modules: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_self_learning_never_imports_provider() -> None:
+    offenders: list[str] = []
+    files = sorted(_PACKAGE_ROOT.rglob("*.py"))
+    assert files, "found no modules to check — the glob is wrong, not the layer"
+
+    for path in files:
+        for module in _imported_modules(path.read_text(encoding="utf-8")):
+            if module == _FORBIDDEN or module.startswith(f"{_FORBIDDEN}."):
+                offenders.append(f"{path.relative_to(_PACKAGE_ROOT)} -> {module}")
+
+    assert offenders == [], (
+        "self_learning must not import from opensquilla.provider. This edge is "
+        "why validate_user_profile lives in ranking_router.py rather than in "
+        "profile.py; adding it makes that placement look arbitrary.\n"
+        + "\n".join(offenders)
+    )

--- a/tests/test_router_self_learning_preference_projection.py
+++ b/tests/test_router_self_learning_preference_projection.py
@@ -1,0 +1,98 @@
+"""The thumb -> memory -> consolidated -> projection round-trip.
+
+The profile no longer accumulates anything of its own; it is a projection over
+what Dream consolidated. The load-bearing risk is the round-trip: a thumb is
+transcribed to a memory line, Dream's LLM promotion may reword it, and the
+projection must still recover the exact model id and its direction. These tests
+pin both ends against the *real* ``classify_signal`` so the transcription verbs
+cannot drift out of the buckets Dream promotes on.
+"""
+
+from __future__ import annotations
+
+from opensquilla.memory.dream.candidates import classify_signal
+from opensquilla.squilla_router.self_learning.preference_projection import (
+    project_history,
+    transcribe_thumb,
+)
+
+_MODEL = "anthropic/claude-sonnet-4-5"
+_OTHER = "openai/gpt-5"
+
+
+def test_an_up_thumb_transcribes_to_a_line_dream_calls_positive() -> None:
+    line = transcribe_thumb(_MODEL, "up")
+    assert line is not None
+    # The transcription verb must land in Dream's positive bucket, or the line
+    # would never be promoted as a preference.
+    assert classify_signal(line) == "positive"
+    assert project_history(line)["positive_model_ids"] == [_MODEL]
+
+
+def test_a_down_thumb_transcribes_to_a_line_dream_calls_correction() -> None:
+    line = transcribe_thumb(_MODEL, "down")
+    assert line is not None
+    assert classify_signal(line) == "correction"
+    assert project_history(line)["negative_model_ids"] == [_MODEL]
+
+
+def test_the_id_survives_an_llm_rewording_that_keeps_the_marker() -> None:
+    """Dream promotes via an LLM patch; only the backticked marker is contracted
+    to survive. Prose around it may change freely."""
+    reworded = (
+        "## Routing preferences\n"
+        f"- The operator prefers routing to `model:{_MODEL}` for coding tasks\n"
+        f"- We do not route to `model:{_OTHER}` after repeated failures\n"
+    )
+    history = project_history(reworded)
+    assert history["positive_model_ids"] == [_MODEL]
+    assert history["negative_model_ids"] == [_OTHER]
+    assert history["feedback_count"] == 2
+
+
+def test_neutral_and_unresolvable_thumbs_say_nothing() -> None:
+    assert transcribe_thumb(_MODEL, "neutral") is None
+    assert transcribe_thumb(None, "up") is None
+    assert transcribe_thumb("   ", "up") is None
+    # A token outside the model-id alphabet is not a model id.
+    assert transcribe_thumb("has spaces", "up") is None
+
+
+def test_a_model_asserted_both_ways_lands_in_neither_list() -> None:
+    text = (
+        f"- prefers routing to `model:{_MODEL}`\n"
+        f"- do not route to `model:{_MODEL}`\n"
+    )
+    history = project_history(text)
+    assert history["positive_model_ids"] == []
+    assert history["negative_model_ids"] == []
+    # Both statements still count toward confidence.
+    assert history["feedback_count"] == 2
+
+
+def test_avoid_wins_a_mixed_line() -> None:
+    """A single line that says do-not-prefer is an avoidance, not a preference."""
+    line = f"- do not prefer `model:{_MODEL}`"
+    history = project_history(line)
+    assert history["negative_model_ids"] == [_MODEL]
+    assert history["positive_model_ids"] == []
+
+
+def test_lines_without_the_marker_are_ignored() -> None:
+    text = (
+        "## Long-Term Memory\n"
+        "- The user prefers dark mode in the editor\n"
+        "- Remember that the build uses uv\n"
+    )
+    history = project_history(text)
+    assert history == {
+        "positive_model_ids": [],
+        "negative_model_ids": [],
+        "feedback_count": 0,
+    }
+
+
+def test_empty_and_garbage_memory_never_raises() -> None:
+    for text in ("", "   ", "not markdown at all", "`model:` empty id"):
+        history = project_history(text)
+        assert history["feedback_count"] == 0

--- a/tests/test_router_self_learning_profile.py
+++ b/tests/test_router_self_learning_profile.py
@@ -1,0 +1,265 @@
+"""The learned user profile: delta folding, revocation, and fail-closed writes.
+
+The profile is the only thing that makes ``S_user`` do anything. With an empty
+history every model scores the same neutral constant, so the term is a uniform
+offset that cannot reorder candidates — inert, not merely approximate. These
+lock the behaviour that makes it non-inert, and the privacy bar that keeps it
+storable: identity tokens, enum tokens, and integers only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from opensquilla.squilla_router.self_learning.profile import (
+    content_version,
+    load_profile,
+    profile_path,
+    update_profile_for_rating,
+)
+
+_MODEL = "anthropic/claude-sonnet-4-5"
+_OTHER = "openai/gpt-5"
+
+
+def _history(home: Path) -> dict:
+    profile = load_profile(home)
+    assert profile is not None
+    return profile["history"]
+
+
+def test_absent_profile_loads_as_none(tmp_path: Path) -> None:
+    assert load_profile(tmp_path) is None
+
+
+def test_up_vote_puts_model_in_positive_list(tmp_path: Path) -> None:
+    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
+    history = _history(tmp_path)
+    assert history["positive_model_ids"] == [_MODEL]
+    assert history["negative_model_ids"] == []
+    assert history["feedback_count"] == 1
+
+
+def test_toggling_to_neutral_revokes_the_vote(tmp_path: Path) -> None:
+    """The decrement is the whole point: without it a thumb is unrevokable."""
+    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
+    update_profile_for_rating(
+        model=_MODEL,
+        new_rating="neutral",
+        previous_rating="up",
+        previous_model=_MODEL,
+        home=tmp_path,
+    )
+    history = _history(tmp_path)
+    assert history["positive_model_ids"] == []
+    assert history["feedback_count"] == 0
+
+
+def test_flipping_up_to_down_counts_once_not_twice(tmp_path: Path) -> None:
+    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
+    update_profile_for_rating(
+        model=_MODEL,
+        new_rating="down",
+        previous_rating="up",
+        previous_model=_MODEL,
+        home=tmp_path,
+    )
+    history = _history(tmp_path)
+    assert history["positive_model_ids"] == []
+    assert history["negative_model_ids"] == [_MODEL]
+    assert history["feedback_count"] == 1
+
+
+def test_equal_up_and_down_lands_in_neither_list(tmp_path: Path) -> None:
+    """_user_score computes int(in_positive) - int(in_negative).
+
+    Membership in both would cancel to zero anyway; excluding the model says
+    the same thing without pretending to an opinion.
+    """
+    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
+    update_profile_for_rating(model=_MODEL, new_rating="down", home=tmp_path)
+    history = _history(tmp_path)
+    assert history["positive_model_ids"] == []
+    assert history["negative_model_ids"] == []
+    assert history["feedback_count"] == 2
+
+
+def test_revocation_decrements_the_model_it_was_credited_to(tmp_path: Path) -> None:
+    """A revision must not move a count between models."""
+    update_profile_for_rating(model=_OTHER, new_rating="up", home=tmp_path)
+    update_profile_for_rating(
+        model=_MODEL,
+        new_rating="up",
+        previous_rating="up",
+        previous_model=_OTHER,
+        home=tmp_path,
+    )
+    history = _history(tmp_path)
+    assert history["positive_model_ids"] == [_MODEL]
+    assert history["feedback_count"] == 1
+
+
+def test_revising_a_row_that_was_never_credited_takes_nothing_away(
+    tmp_path: Path,
+) -> None:
+    """A rating with no attribution was never folded in — so it cannot be undone.
+
+    ``previous_model`` reads back as ``None`` for a row written at v1, before
+    the profile existed. Treating that as "the same model" decrements a count
+    the row never contributed: here the up belongs to a *different* decision,
+    and guessing flips a liked model into a disliked one. ``max(0, ...)`` in
+    ``_apply`` would hide the underflow, so only the sign is visible.
+    """
+    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
+
+    update_profile_for_rating(
+        model=_MODEL,
+        new_rating="down",
+        previous_rating="up",
+        previous_model=None,
+        home=tmp_path,
+    )
+
+    history = _history(tmp_path)
+    assert history["negative_model_ids"] == []
+    assert load_profile(tmp_path)["model_counts"] == {_MODEL: {"up": 1, "down": 1}}
+
+
+def test_a_previous_model_too_malformed_to_credit_is_not_guessed(
+    tmp_path: Path,
+) -> None:
+    """The other shape: stored on the row, but never credited to the profile.
+
+    ``update_profile_for_rating`` fails closed on an unsafe model, while the
+    feedback row keeps the raw string. Reading it back must reach the same
+    verdict the write did — uncreditable — rather than fall back to ``model``.
+    """
+    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
+
+    update_profile_for_rating(
+        model=_MODEL,
+        new_rating="down",
+        previous_rating="up",
+        previous_model="a model with spaces",
+        home=tmp_path,
+    )
+
+    assert load_profile(tmp_path)["model_counts"] == {_MODEL: {"up": 1, "down": 1}}
+
+
+def test_unresolvable_model_writes_nothing(tmp_path: Path) -> None:
+    """Fail closed: crediting a guess is worse than learning nothing."""
+    assert update_profile_for_rating(model=None, new_rating="up", home=tmp_path) is None
+    assert update_profile_for_rating(model="  ", new_rating="up", home=tmp_path) is None
+    assert not profile_path(tmp_path).exists()
+
+
+def test_model_id_alphabet_is_enforced(tmp_path: Path) -> None:
+    """Only identity tokens reach the file — never free text."""
+    assert (
+        update_profile_for_rating(
+            model="a model with spaces and a sentence",
+            new_rating="up",
+            home=tmp_path,
+        )
+        is None
+    )
+    assert not profile_path(tmp_path).exists()
+
+
+def test_version_changes_exactly_when_the_profile_changes(tmp_path: Path) -> None:
+    """A constant version cannot explain a decision after the fact.
+
+    ``last_updated_at`` is excluded so re-rating back to a previous state is
+    recognisably the same profile, rather than a new one that happens to route
+    identically.
+    """
+    first = update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
+    second = update_profile_for_rating(model=_OTHER, new_rating="up", home=tmp_path)
+    assert first is not None and second is not None
+    assert content_version(first) != content_version(second)
+
+    # Same content, later day: same profile, so the same version.
+    reverted = update_profile_for_rating(
+        model=_OTHER,
+        new_rating="neutral",
+        previous_rating="up",
+        previous_model=_OTHER,
+        home=tmp_path,
+    )
+    assert reverted is not None
+    assert content_version(reverted) == content_version(first)
+
+
+def test_profile_holds_only_tokens_counts_and_enums(tmp_path: Path) -> None:
+    """Privacy bar: same as feedback.jsonl. No prompt or response text."""
+    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
+    raw = json.loads(profile_path(tmp_path).read_text(encoding="utf-8"))
+    assert set(raw["model_counts"]) == {_MODEL}
+    assert raw["model_counts"][_MODEL] == {"up": 1, "down": 0}
+    assert set(raw) == {
+        "schema_version",
+        "history",
+        "model_counts",
+    }
+
+
+def test_the_file_does_not_carry_its_own_provenance(tmp_path: Path) -> None:
+    """Provenance describes a read, so the writer stores none of it.
+
+    A version stored here would be a hash of *this* body, while the one ranking
+    reports hashes the resolved overlay — two different values under one name,
+    so an operator matching a decision against the file finds a mismatch for an
+    unchanged profile. A hand-edit that puts them back is dropped on the next
+    thumb rather than left to keep asserting itself.
+    """
+    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
+    path = profile_path(tmp_path)
+    stored = json.loads(path.read_text(encoding="utf-8"))
+    stored["profile_source"] = "fallback_mock"
+    stored["profile_version"] = "sha256:deadbeefdeadbeef"
+    path.write_text(json.dumps(stored), encoding="utf-8")
+
+    update_profile_for_rating(model=_OTHER, new_rating="up", home=tmp_path)
+
+    reread = json.loads(path.read_text(encoding="utf-8"))
+    assert "profile_source" not in reread
+    assert "profile_version" not in reread
+
+
+def test_malformed_profile_degrades_to_none(tmp_path: Path) -> None:
+    path = profile_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    assert load_profile(tmp_path) is None
+
+
+def test_hand_edit_is_picked_up_without_a_restart(tmp_path: Path) -> None:
+    """The cache keys on mtime, not on write.
+
+    The file rewrites itself on every thumb, so an invalidation path has to
+    exist regardless; keying it on write alone would update on a click but
+    ignore a hand-edited deny_models, which is the file's whole point.
+    """
+    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
+    assert load_profile(tmp_path) is not None
+
+    path = profile_path(tmp_path)
+    edited = json.loads(path.read_text(encoding="utf-8"))
+    edited["permission"] = {"deny_models": [_OTHER]}
+    path.write_text(json.dumps(edited), encoding="utf-8")
+
+    reloaded = load_profile(tmp_path)
+    assert reloaded is not None
+    assert reloaded["permission"]["deny_models"] == [_OTHER]
+
+
+def test_load_returns_a_copy_callers_cannot_corrupt_the_cache(tmp_path: Path) -> None:
+    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
+    first = load_profile(tmp_path)
+    assert first is not None
+    first["history"]["positive_model_ids"].append("injected")
+    second = load_profile(tmp_path)
+    assert second is not None
+    assert second["history"]["positive_model_ids"] == [_MODEL]

--- a/tests/test_router_self_learning_profile.py
+++ b/tests/test_router_self_learning_profile.py
@@ -1,10 +1,13 @@
-"""The learned user profile: delta folding, revocation, and fail-closed writes.
+"""The hand-edited profile file: reads, caching, and content versioning.
 
-The profile is the only thing that makes ``S_user`` do anything. With an empty
-history every model scores the same neutral constant, so the term is a uniform
-offset that cannot reorder candidates — inert, not merely approximate. These
-lock the behaviour that makes it non-inert, and the privacy bar that keeps it
-storable: identity tokens, enum tokens, and integers only.
+The profile no longer accumulates anything of its own — the *learned* half
+(``history``) is projected from Dream-consolidated memory (see
+``test_router_self_learning_preference_projection.py``). What remains here is the
+hand-edit surface for ``permission``/``preference`` (``deny_models`` has no TOML
+key), so these lock the read behaviour that surface depends on: absent/broken
+files degrade to ``None``, a copy is handed out so the cache cannot be
+corrupted, a hand-edit is picked up on mtime, and ``content_version`` moves
+exactly when the body does.
 """
 
 from __future__ import annotations
@@ -16,216 +19,21 @@ from opensquilla.squilla_router.self_learning.profile import (
     content_version,
     load_profile,
     profile_path,
-    update_profile_for_rating,
 )
 
 _MODEL = "anthropic/claude-sonnet-4-5"
 _OTHER = "openai/gpt-5"
 
 
-def _history(home: Path) -> dict:
-    profile = load_profile(home)
-    assert profile is not None
-    return profile["history"]
+def _write(home: Path, payload: dict) -> Path:
+    path = profile_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
 
 
 def test_absent_profile_loads_as_none(tmp_path: Path) -> None:
     assert load_profile(tmp_path) is None
-
-
-def test_up_vote_puts_model_in_positive_list(tmp_path: Path) -> None:
-    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
-    history = _history(tmp_path)
-    assert history["positive_model_ids"] == [_MODEL]
-    assert history["negative_model_ids"] == []
-    assert history["feedback_count"] == 1
-
-
-def test_toggling_to_neutral_revokes_the_vote(tmp_path: Path) -> None:
-    """The decrement is the whole point: without it a thumb is unrevokable."""
-    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
-    update_profile_for_rating(
-        model=_MODEL,
-        new_rating="neutral",
-        previous_rating="up",
-        previous_model=_MODEL,
-        home=tmp_path,
-    )
-    history = _history(tmp_path)
-    assert history["positive_model_ids"] == []
-    assert history["feedback_count"] == 0
-
-
-def test_flipping_up_to_down_counts_once_not_twice(tmp_path: Path) -> None:
-    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
-    update_profile_for_rating(
-        model=_MODEL,
-        new_rating="down",
-        previous_rating="up",
-        previous_model=_MODEL,
-        home=tmp_path,
-    )
-    history = _history(tmp_path)
-    assert history["positive_model_ids"] == []
-    assert history["negative_model_ids"] == [_MODEL]
-    assert history["feedback_count"] == 1
-
-
-def test_equal_up_and_down_lands_in_neither_list(tmp_path: Path) -> None:
-    """_user_score computes int(in_positive) - int(in_negative).
-
-    Membership in both would cancel to zero anyway; excluding the model says
-    the same thing without pretending to an opinion.
-    """
-    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
-    update_profile_for_rating(model=_MODEL, new_rating="down", home=tmp_path)
-    history = _history(tmp_path)
-    assert history["positive_model_ids"] == []
-    assert history["negative_model_ids"] == []
-    assert history["feedback_count"] == 2
-
-
-def test_revocation_decrements_the_model_it_was_credited_to(tmp_path: Path) -> None:
-    """A revision must not move a count between models."""
-    update_profile_for_rating(model=_OTHER, new_rating="up", home=tmp_path)
-    update_profile_for_rating(
-        model=_MODEL,
-        new_rating="up",
-        previous_rating="up",
-        previous_model=_OTHER,
-        home=tmp_path,
-    )
-    history = _history(tmp_path)
-    assert history["positive_model_ids"] == [_MODEL]
-    assert history["feedback_count"] == 1
-
-
-def test_revising_a_row_that_was_never_credited_takes_nothing_away(
-    tmp_path: Path,
-) -> None:
-    """A rating with no attribution was never folded in — so it cannot be undone.
-
-    ``previous_model`` reads back as ``None`` for a row written at v1, before
-    the profile existed. Treating that as "the same model" decrements a count
-    the row never contributed: here the up belongs to a *different* decision,
-    and guessing flips a liked model into a disliked one. ``max(0, ...)`` in
-    ``_apply`` would hide the underflow, so only the sign is visible.
-    """
-    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
-
-    update_profile_for_rating(
-        model=_MODEL,
-        new_rating="down",
-        previous_rating="up",
-        previous_model=None,
-        home=tmp_path,
-    )
-
-    history = _history(tmp_path)
-    assert history["negative_model_ids"] == []
-    assert load_profile(tmp_path)["model_counts"] == {_MODEL: {"up": 1, "down": 1}}
-
-
-def test_a_previous_model_too_malformed_to_credit_is_not_guessed(
-    tmp_path: Path,
-) -> None:
-    """The other shape: stored on the row, but never credited to the profile.
-
-    ``update_profile_for_rating`` fails closed on an unsafe model, while the
-    feedback row keeps the raw string. Reading it back must reach the same
-    verdict the write did — uncreditable — rather than fall back to ``model``.
-    """
-    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
-
-    update_profile_for_rating(
-        model=_MODEL,
-        new_rating="down",
-        previous_rating="up",
-        previous_model="a model with spaces",
-        home=tmp_path,
-    )
-
-    assert load_profile(tmp_path)["model_counts"] == {_MODEL: {"up": 1, "down": 1}}
-
-
-def test_unresolvable_model_writes_nothing(tmp_path: Path) -> None:
-    """Fail closed: crediting a guess is worse than learning nothing."""
-    assert update_profile_for_rating(model=None, new_rating="up", home=tmp_path) is None
-    assert update_profile_for_rating(model="  ", new_rating="up", home=tmp_path) is None
-    assert not profile_path(tmp_path).exists()
-
-
-def test_model_id_alphabet_is_enforced(tmp_path: Path) -> None:
-    """Only identity tokens reach the file — never free text."""
-    assert (
-        update_profile_for_rating(
-            model="a model with spaces and a sentence",
-            new_rating="up",
-            home=tmp_path,
-        )
-        is None
-    )
-    assert not profile_path(tmp_path).exists()
-
-
-def test_version_changes_exactly_when_the_profile_changes(tmp_path: Path) -> None:
-    """A constant version cannot explain a decision after the fact.
-
-    ``last_updated_at`` is excluded so re-rating back to a previous state is
-    recognisably the same profile, rather than a new one that happens to route
-    identically.
-    """
-    first = update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
-    second = update_profile_for_rating(model=_OTHER, new_rating="up", home=tmp_path)
-    assert first is not None and second is not None
-    assert content_version(first) != content_version(second)
-
-    # Same content, later day: same profile, so the same version.
-    reverted = update_profile_for_rating(
-        model=_OTHER,
-        new_rating="neutral",
-        previous_rating="up",
-        previous_model=_OTHER,
-        home=tmp_path,
-    )
-    assert reverted is not None
-    assert content_version(reverted) == content_version(first)
-
-
-def test_profile_holds_only_tokens_counts_and_enums(tmp_path: Path) -> None:
-    """Privacy bar: same as feedback.jsonl. No prompt or response text."""
-    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
-    raw = json.loads(profile_path(tmp_path).read_text(encoding="utf-8"))
-    assert set(raw["model_counts"]) == {_MODEL}
-    assert raw["model_counts"][_MODEL] == {"up": 1, "down": 0}
-    assert set(raw) == {
-        "schema_version",
-        "history",
-        "model_counts",
-    }
-
-
-def test_the_file_does_not_carry_its_own_provenance(tmp_path: Path) -> None:
-    """Provenance describes a read, so the writer stores none of it.
-
-    A version stored here would be a hash of *this* body, while the one ranking
-    reports hashes the resolved overlay — two different values under one name,
-    so an operator matching a decision against the file finds a mismatch for an
-    unchanged profile. A hand-edit that puts them back is dropped on the next
-    thumb rather than left to keep asserting itself.
-    """
-    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
-    path = profile_path(tmp_path)
-    stored = json.loads(path.read_text(encoding="utf-8"))
-    stored["profile_source"] = "fallback_mock"
-    stored["profile_version"] = "sha256:deadbeefdeadbeef"
-    path.write_text(json.dumps(stored), encoding="utf-8")
-
-    update_profile_for_rating(model=_OTHER, new_rating="up", home=tmp_path)
-
-    reread = json.loads(path.read_text(encoding="utf-8"))
-    assert "profile_source" not in reread
-    assert "profile_version" not in reread
 
 
 def test_malformed_profile_degrades_to_none(tmp_path: Path) -> None:
@@ -235,31 +43,55 @@ def test_malformed_profile_degrades_to_none(tmp_path: Path) -> None:
     assert load_profile(tmp_path) is None
 
 
+def test_a_non_object_top_level_is_not_a_profile(tmp_path: Path) -> None:
+    path = profile_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+    assert load_profile(tmp_path) is None
+
+
+def test_load_returns_a_copy_callers_cannot_corrupt_the_cache(tmp_path: Path) -> None:
+    _write(tmp_path, {"permission": {"deny_models": [_MODEL]}})
+    first = load_profile(tmp_path)
+    assert first is not None
+    first["permission"]["deny_models"].append("injected")
+
+    second = load_profile(tmp_path)
+    assert second is not None
+    assert second["permission"]["deny_models"] == [_MODEL]
+
+
 def test_hand_edit_is_picked_up_without_a_restart(tmp_path: Path) -> None:
     """The cache keys on mtime, not on write.
 
-    The file rewrites itself on every thumb, so an invalidation path has to
-    exist regardless; keying it on write alone would update on a click but
-    ignore a hand-edited deny_models, which is the file's whole point.
+    ``deny_models`` is hand-edited and has no TOML key, so the invalidation path
+    must react to an edit made outside any write path — keying it on write alone
+    would ignore the one change the file exists to make.
     """
-    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
-    assert load_profile(tmp_path) is not None
+    _write(tmp_path, {"permission": {"deny_models": [_MODEL]}})
+    assert load_profile(tmp_path)["permission"]["deny_models"] == [_MODEL]
 
-    path = profile_path(tmp_path)
-    edited = json.loads(path.read_text(encoding="utf-8"))
-    edited["permission"] = {"deny_models": [_OTHER]}
-    path.write_text(json.dumps(edited), encoding="utf-8")
-
+    _write(tmp_path, {"permission": {"deny_models": [_OTHER]}})
     reloaded = load_profile(tmp_path)
     assert reloaded is not None
     assert reloaded["permission"]["deny_models"] == [_OTHER]
 
 
-def test_load_returns_a_copy_callers_cannot_corrupt_the_cache(tmp_path: Path) -> None:
-    update_profile_for_rating(model=_MODEL, new_rating="up", home=tmp_path)
-    first = load_profile(tmp_path)
-    assert first is not None
-    first["history"]["positive_model_ids"].append("injected")
-    second = load_profile(tmp_path)
-    assert second is not None
-    assert second["history"]["positive_model_ids"] == [_MODEL]
+def test_version_changes_when_the_body_changes(tmp_path: Path) -> None:
+    a = {"permission": {"deny_models": [_MODEL]}}
+    b = {"permission": {"deny_models": [_OTHER]}}
+    assert content_version(a) != content_version(b)
+
+
+def test_version_ignores_its_own_output_and_the_timestamp(tmp_path: Path) -> None:
+    """``profile_version`` is the output, and ``last_updated_at`` is noise.
+
+    Excluding both means the same effective profile hashes the same whether or
+    not a stale version is stamped on it and whichever day it was last touched.
+    """
+    base = {"history": {"positive_model_ids": [_MODEL], "last_updated_at": "2026-01-01"}}
+    stamped = {
+        "history": {"positive_model_ids": [_MODEL], "last_updated_at": "2026-07-18"},
+        "profile_version": "sha256:deadbeefdeadbeef",
+    }
+    assert content_version(base) == content_version(stamped)

--- a/tests/test_user_profile_validation.py
+++ b/tests/test_user_profile_validation.py
@@ -1,0 +1,147 @@
+"""``validate_user_profile``: what it rejects, and what it must not miss.
+
+``profile.json`` is hand-editable and is the only configuration surface for
+``deny_models``. The failure this validator closes is silent: a typo in
+``cost_sensitivity`` routes exactly as if the edit had never been made, because
+``_cost_latency_weights`` falls back to a default on an unknown value. Refusing
+the file at least says so.
+
+The coverage test is the load-bearing one. The seam overlays *any* key the mock
+baseline defines, while the validator hand-enumerates what it checks — two lists
+with nothing tying them together. This branch removed three keys from the mock
+profile, so re-adding one is a live motion, and a re-added key would be
+overlayable from the hand-edited file with zero validation while every
+neighbouring key is checked.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from opensquilla.provider.ranking_router import (
+    mock_user_profile,
+    validate_user_profile,
+)
+
+# One deliberately invalid value per overlayable key, and the fragment the
+# validator must name when it sees it. Driving the validator rather than
+# listing "keys it checks" is the point: a third hand-maintained list would
+# drift from the other two exactly like they drift from each other.
+_BAD_VALUES: dict[str, tuple[str, Any]] = {
+    "permission.allow_models": ("permission.allow_models", 123),
+    "permission.deny_models": ("permission.deny_models", 123),
+    "permission.risk_allowlist": ("permission.risk_allowlist", ["not_a_risk_level"]),
+    "preference.quality_latency_tradeoff": (
+        "preference.quality_latency_tradeoff",
+        "not_a_tradeoff",
+    ),
+    "preference.cost_sensitivity": ("preference.cost_sensitivity", "not_a_sensitivity"),
+    "history.positive_model_ids": ("history.positive_model_ids", 123),
+    "history.negative_model_ids": ("history.negative_model_ids", 123),
+    "history.feedback_count": ("history.feedback_count", -1),
+}
+
+# Overlayable but deliberately unvalidated, with the reason. Not a loophole: a
+# key lands here only by someone writing down why it needs no check.
+_EXEMPT: dict[str, str] = {
+    "history.last_updated_at": (
+        "A derived display stamp. Nothing routes on it, and content_version "
+        "excludes it so it cannot even change a decision's identity. A bad "
+        "value is visible in the file rather than silently altering routing."
+    ),
+}
+
+_OVERLAID_SECTIONS = ("permission", "preference", "history")
+
+
+def _overlayable_keys() -> set[str]:
+    """Every key the read seam will overlay from a hand-edited file.
+
+    Read from the mock baseline because that is what the seam gates on: it
+    overlays a key only when the baseline already defines it.
+    """
+    baseline = mock_user_profile()
+    keys: set[str] = set()
+    for section in _OVERLAID_SECTIONS:
+        for key in baseline.get(section, {}):
+            keys.add(f"{section}.{key}")
+    return keys
+
+
+def test_every_overlayable_key_is_validated_or_explicitly_exempt() -> None:
+    """The coverage invariant: adding a key must force a decision.
+
+    Without this, adding a key back to ``mock_user_profile`` silently widens
+    what a hand-edited file can set with no validation — reintroducing the
+    "typo does nothing, quietly" failure for that one key while its neighbours
+    stay checked. Failing here is the prompt to either validate it or say why
+    it needs no validation.
+    """
+    covered = set(_BAD_VALUES) | set(_EXEMPT)
+    uncovered = _overlayable_keys() - covered
+
+    assert uncovered == set(), (
+        "these keys are overlayable from the hand-edited profile but neither "
+        "validated nor exempted: "
+        f"{sorted(uncovered)}. Add a case to _BAD_VALUES, or exempt it in "
+        "_EXEMPT with the reason it needs no check."
+    )
+
+
+def test_the_exempt_list_cannot_quietly_outlive_the_keys_it_excuses() -> None:
+    """An exemption for a key that no longer exists is stale prose."""
+    stale = set(_EXEMPT) - _overlayable_keys()
+    assert stale == set(), f"_EXEMPT excuses keys that no longer exist: {sorted(stale)}"
+
+
+@pytest.mark.parametrize(("dotted", "case"), sorted(_BAD_VALUES.items()))
+def test_an_invalid_value_is_named_rather_than_swallowed(
+    dotted: str, case: tuple[str, Any]
+) -> None:
+    """Each checked key must actually reject, and say which key it was.
+
+    An error that does not name the key leaves the operator to guess which of
+    their edits was refused.
+    """
+    fragment, bad = case
+    section, key = dotted.split(".")
+
+    errors = validate_user_profile({section: {key: bad}})
+
+    assert errors, f"{dotted}={bad!r} was accepted"
+    assert any(fragment in e for e in errors), (
+        f"{dotted} was rejected but no error named it: {errors}"
+    )
+
+
+def test_the_baseline_itself_validates() -> None:
+    """The profile every fallback returns must not be one we would refuse.
+
+    If this fails, a refused file degrades to a baseline that is itself
+    invalid, and the whole degrade path is built on sand.
+    """
+    assert validate_user_profile(mock_user_profile()) == []
+
+
+def test_a_partial_profile_is_normal_and_not_an_error() -> None:
+    """The stored file carries history only; the seam fills the rest."""
+    assert validate_user_profile({}) == []
+    assert validate_user_profile({"history": {"feedback_count": 3}}) == []
+
+
+def test_a_valid_deny_models_edit_passes() -> None:
+    """The edit the file exists for must not be collateral damage."""
+    assert validate_user_profile({"permission": {"deny_models": ["openai/gpt-5"]}}) == []
+
+
+def test_every_reason_a_profile_is_refused_is_reported_not_just_the_first() -> None:
+    """The operator should fix one file once, not play whack-a-mole."""
+    errors = validate_user_profile(
+        {
+            "permission": {"risk_allowlist": ["not_a_risk_level"]},
+            "preference": {"cost_sensitivity": "not_a_sensitivity"},
+        }
+    )
+    assert len(errors) == 2, errors


### PR DESCRIPTION
## What this does

Step-2 dynamic ranking scores models with `quality_clean = 0.85*task_match + 0.15*S_user`, where `S_user` reads a user profile. That profile was a mock with empty history — which made `S_user` a **uniform constant across every candidate**. It was not merely approximate, it was structurally inert: a constant offset cannot reorder anything, so the 0.15 term could never change a single routing decision.

This branch makes the profile real. Its learned half — `history` — is **derived at read time from Dream-consolidated memory**, not stored in a tally of its own. A thumb becomes a preference *memory*; Dream promotes it into `MEMORY.md` like any other durable fact; and the ranking read seam projects the consolidated lines back into the history shape ranking already consumes. There is no second system of record to keep reconciled with the operator's own memory.

> **Design note (revised).** An earlier revision of this branch accumulated a standalone `model_counts` tally in `profile.json`, written on every thumb under a lock, with a decrement/ordering contract for revocation. That put a second evidence store beside Dream's — one that could drift from the operator's consolidated memory, and one whose retention story made replay impossible. Routing preference *is* a memory ("this operator prefers Sonnet for coding"), and the codebase already has a component that accumulates, deduplicates, and consolidates memories. The final design reuses it, so the preference the operator reads in `MEMORY.md` and the preference ranking acts on are the **same sentence**. The commit `refactor(ranking): derive user-profile history from Dream-consolidated memory` carries the pivot.

## The commits, in dependency order

**`docs: specify user-profile-driven ranking`** — the spec this implements (amended for the Dream-derived design).

**`fix(ranking): stop exposing user profile to task analyzer`** — a privacy fix, and the reason it ships first. The profile was being placed into the task analyzer's prompt and sent to an external model. Nothing in ranking needed it there.

**`fix(provider): report executed model in DoneEvent`** — `DoneEvent.model` defaulted to `""`, so a provider that never set it was silently wrong rather than loudly broken. Anthropic and Ollama now report the model the response actually named, falling back to the configured id. The 6 regenerated stream goldens are the evidence: their fixtures always carried the real model, and the goldens had frozen `"model": ""` — the bug preserved as an expectation.

**`feat(ranking): learn a user profile from feedback ratings`** — the original attribution-plus-profile work (standalone tally).

**`test(ranking): enforce the layering and validator-coverage invariants`** — three constraints that were docstring-only, turned into tests.

**`refactor(ranking): derive user-profile history from Dream-consolidated memory`** — the pivot to memory-derived history. Removes the write path, the lock, the decrement/ordering contract, and the "impossible replay" problem the tally carried.

**`fix(dream): scan preference logs per line, not as one blob`** — surfaced by a real end-to-end run. The Dream scanner collapsed a whole memory file into one snippet, so an append-only preference log (one thumb per line) was classified by a single `classify_signal` call. A file mixing a `prefers` line with a `do not` line was judged pure-negative — the positive signals were silently eaten, and under the negative-recurrence gate it never promoted at all. Now a file whose every non-blank line carries the `model:<id>` marker is split into per-line candidates, each accruing its own evidence entry / `seen_count` / signal counts; a like and a dislike are weighed independently. Narrative notes without the marker stay whole-file as before, and the marker regex is duplicated locally so the scanner takes no import edge on `squilla_router`.

**`fix(dream): extract JSON patch by brace-balance, not greedy regex`** — also surfaced live: the promotion model appended prose after its JSON object on ~4 of 5 real runs, and the greedy `\{.*\}` extractor swallowed that trailing text into one span, so `json.loads` failed with "Extra data" and the whole consolidation was skipped. Replaced with a string-aware brace-balance scan that isolates each top-level object and picks the first that parses to a dict carrying `operations`; it tolerates trailing notes, a leading example object, markdown fences, and braces inside string values. After the fix, 4 of 4 real runs applied cleanly.

## The pipeline

1. **Transcribe.** On `router.feedback.submit`, after `write_feedback()`, the handler renders the thumb as one line — `- prefers routing to `` `model:<id>` `` `` (up) or `- do not route to `` `model:<id>` `` `` (down); `neutral` or an unresolvable model writes nothing — and appends it to `<workspace>/memory/routing-preferences.md`, exactly where Dream scans for evidence. `new self_learning/preference_projection.py::transcribe_thumb`.
2. **Consolidate.** Dream's `classify_signal` buckets the line by verb (`prefers` → positive, `do not` → correction) and promotes it into `MEMORY.md` by an LLM patch. The promotion prompt is instructed to preserve the `` `model:<id>` `` marker **verbatim**, backticks and all, because a reworded bullet that splits or unquotes it silently drops a routing preference.
3. **Project.** At ranking time, `_resolve_user_profile` reads the global `MEMORY.md` and `project_history` folds the marked lines into `history.positive_model_ids` / `negative_model_ids` / `feedback_count`. Pure, stdlib-only.

## Load-bearing details

**Which model the thumb names.** On an ensemble turn the rated model is the **aggregator** — the one that authored the reply — resolved in **config space** (`RankedModel.model_id`, what `_user_score` matches against), never `usage.model` (response space, forensics only). When it cannot be resolved, `transcribe_thumb` returns `None` and nothing is written: fail closed, never credit a guess.

**One global workspace, one file.** Both the note Dream scans, the `MEMORY.md` Dream writes, and the `MEMORY.md` the read seam reads resolve through `resolve_agent_workspace_dir("main", config)` — the same resolution Dream uses at both its wiring sites — so they are guaranteed the same file with no manager logic duplicated.

**No lock, no decrement.** Appending a short bullet is `O_APPEND`-atomic, so concurrent submits need no lock — the entire race class the tally required is gone. A revocation is expressed the way memory expresses everything: a later contradicting line, which the projection collapses to *neither* list. The tradeoff, stated plainly: a `neutral` cannot cleanly un-say a past `prefers` — only an explicit opposite thumb, or Dream consolidating the contradiction away, retracts it. For a single-operator preference nudge that is the honest behavior.

**`profile.json` survives as the hand-edit surface** for `permission`/`preference` (`deny_models` has no TOML key). Its write path is deleted. It is validated on read against the vocabularies ranking enforces and refused **whole** if it fails — a config the operator got half-wrong is untrustworthy whole, so an invalid enum drops the derived history too rather than routing on a typo.

**Provenance describes the read, not the file.** `profile_source` is `dream_memory` when memory was read (even present-but-empty) or a valid file was used; `fallback_mock` only when neither was read or on any exception. `profile_version` is a content hash taken after the overlay. A `profile_source`/`profile_version` written *into* the file is ignored — a hand-editable file could otherwise claim `fallback_mock` while ranking used it.

**`self_learning` keeps zero import edges to `opensquilla.provider`**; `preference_projection` imports only the standard library, and the mock fallback composes one layer up at the engine seam. `ensemble.py`'s own `mock_user_profile()` fallback deliberately stays a mock — it serves benchmarks and the routing experiment runner, which must stay reproducible.

**`feedback.jsonl` is untouched.** The raw thumb stream and `load_feedback_map`'s effective-rating semantics (merge-then-filter, last-write-wins) still feed the offline trainer; this branch only *adds* the transcription beside it.

## Testing

- `tests/test_router_self_learning_preference_projection.py` — direction by verb, the backticked marker required (prose id ignored), both-directions → neither list, `feedback_count` = lines seen, non-preference memories invisible.
- `tests/test_gateway/test_rpc_router_decisions.py` — a thumb transcribes into a preference memory and reads back through the projection as positive; a neutral appends nothing; down-after-up reads back as a contradiction; concurrent submits need no lock; the `feedback.jsonl` sidecar write still happens.
- `tests/test_engine/test_resolve_user_profile.py` — the read seam: memory reorders candidates empty memory would not; present-but-empty → `dream_memory`; a valid hand-edited `deny_models` rides beside the derived history; an invalid enum refuses the file and drops the history; the file cannot pin provenance; a raise mid-resolution reports `fallback_mock`, not a half-merge.
- `tests/test_router_self_learning_profile.py` — the surviving read surface: absent/malformed/non-object → `None`, copy-on-read, mtime invalidation, `content_version` moves with the body and ignores the timestamp and its own stamp.
- `tests/test_router_self_learning_layering.py` — the zero-edge rule between `self_learning` and `provider` (AST-based).
- `tests/test_router_self_learning_feedback_merge_order.py` — merge-before-filter in `load_feedback_map`, now framed around the offline trainer that consumes the effective rating.
- `tests/test_memory_dream_evidence.py` — a routing-preference log splits per line (a `prefers` and a `do not` become two candidates with distinct claims and opposite signals), while a multi-line narrative note stays one candidate.
- `tests/test_memory_dream_prompts.py` — the patch extractor survives trailing commentary, a trailing second object, a leading example object, a markdown fence, and braces inside string values; empty-of-JSON still raises.

Both `fix(dream)` seams were also exercised against the real provider end-to-end: thumb → `routing-preferences.md` → Dream consolidation (real LLM) → `MEMORY.md` with the `model:<id>` marker preserved verbatim → projection recovering `positive_model_ids` / `negative_model_ids`. The per-line fix turned a collapsed pure-negative blob into independent `prefers`/`do not` evidence, and the brace-balance fix took real-run apply success from 1/5 to 4/4.

Full suite: **13548 passed**, 137 skipped. The 16 failures are pre-existing and environment-only (real-terminal TUI needing a tty, macOS seatbelt sandbox, CI shard budgets, experiment-ledger scripts) — none touch ranking, profile, dream, feedback, or the runtime seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
