### PR TITLE
Reject malformed WebSocket frames instead of dropping the connection

### DIFF
--- a/src/opensquilla/gateway/websocket.py
+++ b/src/opensquilla/gateway/websocket.py
@@ -326,9 +326,32 @@ class WsConnection:
                             seq=self.next_seq(),
                             meta=item.meta,
                         )
-                        await self.ws.send_text(wire.model_dump_json())
+                        text = wire.model_dump_json()
                     elif item.res_frame is not None:
-                        await self.ws.send_text(item.res_frame.model_dump_json())
+                        text = item.res_frame.model_dump_json()
+                    else:
+                        continue
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    # A frame that cannot be serialized (e.g. a lone surrogate
+                    # in a payload) must not silently kill this task: the
+                    # socket would stay open, requests would keep executing,
+                    # and no response would ever leave. Close instead so the
+                    # reader loop tears the connection down normally.
+                    log.warning(
+                        "gateway.ws_frame_serialize_failed",
+                        conn_id=self.conn_id,
+                        exc_info=True,
+                    )
+                    self._closing = True
+                    try:
+                        await self.ws.close(code=1011)
+                    except Exception:  # noqa: BLE001
+                        pass
+                    return
+                try:
+                    await self.ws.send_text(text)
                 except WebSocketDisconnect:
                     return
                 except asyncio.CancelledError:
@@ -523,6 +546,34 @@ def get_registry() -> ConnectionRegistry:
     return _registry
 
 
+def _is_wire_text(value: str) -> bool:
+    """True when ``value`` can be re-serialized onto the wire as UTF-8.
+
+    Valid JSON may carry lone-surrogate escapes (``"\\ud800"``); echoing one
+    into a response frame makes ``model_dump_json`` raise at send time, long
+    after the handler ran.
+    """
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return True
+
+
+def _wire_frame_id(raw_id: Any, fallback: str = "") -> str:
+    """Best-effort string id for correlating a response to a client frame.
+
+    ``ResFrame.id`` must be a string, but a client may send any JSON value.
+    Scalar ids are echoed back stringified so the client can still correlate
+    the error; container and non-encodable ids fall back to ``fallback``.
+    """
+    if isinstance(raw_id, str):
+        return raw_id if _is_wire_text(raw_id) else fallback
+    if isinstance(raw_id, bool | int | float):
+        return str(raw_id)
+    return fallback
+
+
 async def handle_ws_connection(
     ws: WebSocket,
     config: GatewayConfig,
@@ -577,9 +628,18 @@ async def handle_ws_connection(
     # Step 3: Parse the connect request
     try:
         data = json.loads(raw)
-    except json.JSONDecodeError:
+    except (ValueError, RecursionError):
+        # ValueError covers JSONDecodeError plus non-decode parse failures
+        # (e.g. the int-digit conversion limit); RecursionError covers
+        # pathological nesting depth.
         await conn.send_res(
             make_error_res("handshake", "INVALID_REQUEST", "Invalid JSON in connect frame")
+        )
+        await conn.close()
+        return
+    if not isinstance(data, dict):
+        await conn.send_res(
+            make_error_res("handshake", "INVALID_REQUEST", "Connect frame must be a JSON object")
         )
         await conn.close()
         return
@@ -587,7 +647,7 @@ async def handle_ws_connection(
     if data.get("type") != "req" or data.get("method") != "connect":
         await conn.send_res(
             make_error_res(
-                data.get("id", "handshake"),
+                _wire_frame_id(data.get("id"), "handshake"),
                 "INVALID_REQUEST",
                 "First message must be connect request",
             )
@@ -595,18 +655,25 @@ async def handle_ws_connection(
         await conn.close()
         return
 
-    req_id = data.get("id", "handshake")
-    params_raw = data.get("params", {}) or {}
+    req_id = _wire_frame_id(data.get("id"), "handshake")
+    params_raw = data.get("params")
+    if not isinstance(params_raw, dict):
+        params_raw = {}
 
     # Step 4: Resolve auth via server-side ScopeResolver
     from opensquilla.gateway.auth import resolve_auth
 
-    auth_params = params_raw.get("auth", {}) or {}
+    auth_params = params_raw.get("auth")
+    if not isinstance(auth_params, dict):
+        auth_params = {}
+    role_claim = params_raw.get("role", "operator")
+    if not isinstance(role_claim, str):
+        role_claim = "operator"
     peer_ip = ws.client.host if ws.client is not None else None
     principal = resolve_auth(
         config,
         auth_params=auth_params,
-        role_claim=params_raw.get("role", "operator"),
+        role_claim=role_claim,
         peer_ip=peer_ip,
     )
     if principal is None:
@@ -619,6 +686,17 @@ async def handle_ws_connection(
     # Step 5: Negotiate protocol version
     min_proto = params_raw.get("minProtocol", 1)
     max_proto = params_raw.get("maxProtocol", PROTOCOL_VERSION)
+    if not all(
+        isinstance(bound, int) and not isinstance(bound, bool)
+        for bound in (min_proto, max_proto)
+    ):
+        await conn.send_res(
+            make_error_res(
+                req_id, "INVALID_REQUEST", "minProtocol and maxProtocol must be integers"
+            )
+        )
+        await conn.close()
+        return
     negotiated = min(max_proto, PROTOCOL_VERSION)
     if negotiated < min_proto:
         await conn.send_res(
@@ -786,8 +864,16 @@ async def _message_loop(
 
         try:
             data = json.loads(raw)
-        except json.JSONDecodeError:
+        except (ValueError, RecursionError):
+            # ValueError covers JSONDecodeError plus non-decode parse failures
+            # (e.g. the int-digit conversion limit); RecursionError covers
+            # pathological nesting depth.
             await conn.send_res(make_error_res("", "INVALID_REQUEST", "Invalid JSON"))
+            continue
+        if not isinstance(data, dict):
+            await conn.send_res(
+                make_error_res("", "INVALID_REQUEST", "Frame must be a JSON object")
+            )
             continue
 
         frame_type = data.get("type")
@@ -802,6 +888,24 @@ async def _message_loop(
         if frame_type == "req":
             req_id = data.get("id", "")
             method = data.get("method", "")
+            if (
+                not isinstance(req_id, str)
+                or not isinstance(method, str)
+                or not _is_wire_text(req_id)
+                or not _is_wire_text(method)
+            ):
+                # A non-string or non-encodable id/method would fail ResFrame
+                # validation or serialization after the handler already ran;
+                # reject the frame here so one malformed request cannot kill
+                # the connection.
+                await conn.send_res(
+                    make_error_res(
+                        _wire_frame_id(req_id),
+                        "INVALID_REQUEST",
+                        "Frame id and method must be UTF-8-encodable strings",
+                    )
+                )
+                continue
             params = data.get("params")
 
             ctx = RpcContext(
@@ -832,8 +936,10 @@ async def _message_loop(
             res = await dispatcher.dispatch(req_id, method, params, ctx)
             await conn.send_res(res)
         else:
+            # repr keeps the echo serializable for any client value (lone
+            # surrogates escape to backslash form).
             await conn.send_res(
-                make_error_res("", "INVALID_REQUEST", f"Unknown frame type: {frame_type}")
+                make_error_res("", "INVALID_REQUEST", f"Unknown frame type: {frame_type!r}")
             )
 
 

--- a/tests/test_gateway/test_websocket_frame_validation.py
+++ b/tests/test_gateway/test_websocket_frame_validation.py
@@ -1,0 +1,308 @@
+"""Malformed client frames must produce INVALID_REQUEST, not kill the connection.
+
+Regression surface: a ``req`` frame whose ``id`` is a JSON number used to pass
+straight into ``ResFrame(id=...)`` construction, raise a pydantic
+``ValidationError`` after the handler had already run, and tear down the whole
+WebSocket connection (``ws.error`` + close) instead of answering the one bad
+frame.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any
+
+from starlette.websockets import WebSocketDisconnect, WebSocketState
+
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.protocol import make_ok_res
+from opensquilla.gateway.websocket import WsConnection, handle_ws_connection
+
+_CONNECT_FRAME = json.dumps(
+    {
+        "type": "req",
+        "id": "h",
+        "method": "connect",
+        "params": {"minProtocol": 1, "role": "operator", "auth": {}},
+    }
+)
+
+
+class _ScriptedWebSocket:
+    client_state = WebSocketState.CONNECTED
+    client = SimpleNamespace(host="127.0.0.1", port=12345)
+
+    def __init__(self, frames: list[str]) -> None:
+        self._frames = list(frames)
+        self.sent: list[str] = []
+        self.close_codes: list[int] = []
+        self.accepted = False
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(text)
+
+    async def receive_text(self) -> str:
+        if not self._frames:
+            raise WebSocketDisconnect(code=1000)
+        return self._frames.pop(0)
+
+    async def close(self, code: int = 1000) -> None:
+        self.close_codes.append(code)
+
+    def responses(self) -> list[dict[str, Any]]:
+        return [f for f in (json.loads(s) for s in self.sent) if f.get("type") == "res"]
+
+
+class _EchoDispatcher:
+    def list_methods(self) -> list[str]:
+        return ["noop"]
+
+    async def dispatch(self, req_id: str, method: str, params: Any, ctx: Any) -> Any:
+        return make_ok_res(req_id, {"method": method})
+
+
+def _config() -> GatewayConfig:
+    # Direct-send path keeps response ordering deterministic in the fake.
+    return GatewayConfig(ws_writer_queue_enabled=False)
+
+
+async def _run(frames: list[str]) -> _ScriptedWebSocket:
+    ws = _ScriptedWebSocket(frames)
+    await handle_ws_connection(ws, _config(), dispatcher=_EchoDispatcher())
+    return ws
+
+
+async def test_non_string_req_id_gets_error_res_and_connection_survives() -> None:
+    ws = await _run(
+        [
+            _CONNECT_FRAME,
+            json.dumps({"type": "req", "id": 1, "method": "noop", "params": {}}),
+            json.dumps({"type": "req", "id": "ok1", "method": "noop"}),
+        ]
+    )
+
+    responses = ws.responses()
+    errors = [r for r in responses if not r["ok"]]
+    assert len(errors) == 1
+    assert errors[0]["id"] == "1"
+    assert errors[0]["error"]["code"] == "INVALID_REQUEST"
+
+    # The connection outlived the bad frame: the next request still dispatched.
+    assert any(r["ok"] and r["id"] == "ok1" for r in responses)
+    assert ws.close_codes == []
+
+
+async def test_non_string_method_gets_error_res_and_connection_survives() -> None:
+    ws = await _run(
+        [
+            _CONNECT_FRAME,
+            json.dumps({"type": "req", "id": "x", "method": 5}),
+            json.dumps({"type": "req", "id": "ok2", "method": "noop"}),
+        ]
+    )
+
+    responses = ws.responses()
+    errors = [r for r in responses if not r["ok"]]
+    assert len(errors) == 1
+    assert errors[0]["id"] == "x"
+    assert errors[0]["error"]["code"] == "INVALID_REQUEST"
+    assert any(r["ok"] and r["id"] == "ok2" for r in responses)
+    assert ws.close_codes == []
+
+
+async def test_non_object_frame_gets_error_res_and_connection_survives() -> None:
+    ws = await _run(
+        [
+            _CONNECT_FRAME,
+            json.dumps([1, 2, 3]),
+            json.dumps({"type": "req", "id": "ok3", "method": "noop"}),
+        ]
+    )
+
+    responses = ws.responses()
+    errors = [r for r in responses if not r["ok"]]
+    assert len(errors) == 1
+    assert errors[0]["id"] == ""
+    assert errors[0]["error"]["code"] == "INVALID_REQUEST"
+    assert any(r["ok"] and r["id"] == "ok3" for r in responses)
+    assert ws.close_codes == []
+
+
+async def test_oversized_int_literal_gets_error_res_and_connection_survives() -> None:
+    # CPython's int-conversion limit makes json.loads raise a plain
+    # ValueError (not JSONDecodeError) for a 5000-digit number literal.
+    raw = '{"type": "req", "id": ' + "9" * 5000 + ', "method": "noop"}'
+    ws = await _run(
+        [
+            _CONNECT_FRAME,
+            raw,
+            json.dumps({"type": "req", "id": "ok4", "method": "noop"}),
+        ]
+    )
+
+    responses = ws.responses()
+    errors = [r for r in responses if not r["ok"]]
+    assert len(errors) == 1
+    assert errors[0]["error"]["code"] == "INVALID_REQUEST"
+    assert any(r["ok"] and r["id"] == "ok4" for r in responses)
+    assert ws.close_codes == []
+
+
+async def test_deeply_nested_frame_gets_error_res_and_connection_survives() -> None:
+    # Valid JSON, but deeper than the parser's recursion budget.
+    raw = "[" * 100_000 + "]" * 100_000
+    ws = await _run(
+        [
+            _CONNECT_FRAME,
+            raw,
+            json.dumps({"type": "req", "id": "ok5", "method": "noop"}),
+        ]
+    )
+
+    responses = ws.responses()
+    errors = [r for r in responses if not r["ok"]]
+    assert len(errors) == 1
+    assert errors[0]["error"]["code"] == "INVALID_REQUEST"
+    assert any(r["ok"] and r["id"] == "ok5" for r in responses)
+    assert ws.close_codes == []
+
+
+async def test_lone_surrogate_id_rejected_and_connection_survives() -> None:
+    # A lone surrogate survives json round-trips but cannot be re-serialized
+    # into a response frame, so it must be rejected, not echoed.
+    ws = await _run(
+        [
+            _CONNECT_FRAME,
+            json.dumps({"type": "req", "id": "\ud800", "method": "noop"}),
+            json.dumps({"type": "req", "id": "ok6", "method": "noop"}),
+        ]
+    )
+
+    responses = ws.responses()
+    errors = [r for r in responses if not r["ok"]]
+    assert len(errors) == 1
+    assert errors[0]["id"] == ""
+    assert errors[0]["error"]["code"] == "INVALID_REQUEST"
+    assert any(r["ok"] and r["id"] == "ok6" for r in responses)
+    assert ws.close_codes == []
+
+
+async def test_lone_surrogate_frame_type_error_still_serializes() -> None:
+    ws = await _run(
+        [
+            _CONNECT_FRAME,
+            json.dumps({"type": "\ud800"}),
+            json.dumps({"type": "req", "id": "ok7", "method": "noop"}),
+        ]
+    )
+
+    responses = ws.responses()
+    errors = [r for r in responses if not r["ok"]]
+    assert len(errors) == 1
+    assert "Unknown frame type" in errors[0]["error"]["message"]
+    assert any(r["ok"] and r["id"] == "ok7" for r in responses)
+    assert ws.close_codes == []
+
+
+async def test_unserializable_outbound_frame_closes_connection_not_zombifies() -> None:
+    # With the writer queue enabled (the production default), a frame whose
+    # payload cannot be serialized used to kill the writer task silently:
+    # the socket stayed open, requests kept executing, and no response ever
+    # left. The writer must close the connection instead.
+    ws = _ScriptedWebSocket([])
+    conn = WsConnection(conn_id="poisoned", ws=ws)
+    conn._start_writer(maxsize=8, enabled=True)
+
+    await conn.send_res(make_ok_res("x", {"v": "\ud800"}))
+    for _ in range(200):
+        if ws.close_codes:
+            break
+        await asyncio.sleep(0.005)
+
+    assert ws.close_codes == [1011]
+    await conn._stop_writer()
+
+
+async def test_handshake_tolerates_non_dict_params_and_auth() -> None:
+    connect = json.dumps(
+        {
+            "type": "req",
+            "id": "h",
+            "method": "connect",
+            "params": {"auth": "bogus", "role": 7, "client": None},
+        }
+    )
+    ws = await _run([connect, json.dumps({"type": "req", "id": "ok8", "method": "noop"})])
+
+    # The handshake completed on defaults and the loop dispatched the
+    # follow-up request instead of crashing on params_raw.get(...).
+    assert any(r["ok"] and r["id"] == "ok8" for r in ws.responses())
+    assert ws.close_codes == []
+
+    connect_scalar_params = json.dumps(
+        {"type": "req", "id": "h", "method": "connect", "params": "x"}
+    )
+    ws2 = await _run(
+        [connect_scalar_params, json.dumps({"type": "req", "id": "ok9", "method": "noop"})]
+    )
+    assert any(r["ok"] and r["id"] == "ok9" for r in ws2.responses())
+    assert ws2.close_codes == []
+
+
+async def test_handshake_rejects_non_integer_protocol_bounds() -> None:
+    connect = json.dumps(
+        {
+            "type": "req",
+            "id": "h",
+            "method": "connect",
+            "params": {"minProtocol": "3", "maxProtocol": None},
+        }
+    )
+    ws = await _run([connect])
+
+    responses = ws.responses()
+    assert len(responses) == 1
+    assert responses[0]["ok"] is False
+    assert responses[0]["id"] == "h"
+    assert responses[0]["error"]["code"] == "INVALID_REQUEST"
+    assert len(ws.close_codes) == 1
+
+
+async def test_handshake_survives_oversized_int_literal() -> None:
+    raw = '{"type": "req", "id": ' + "9" * 5000 + ', "method": "connect"}'
+    ws = await _run([raw])
+
+    responses = ws.responses()
+    assert len(responses) == 1
+    assert responses[0]["ok"] is False
+    assert responses[0]["id"] == "handshake"
+    assert responses[0]["error"]["code"] == "INVALID_REQUEST"
+    assert len(ws.close_codes) == 1
+
+
+async def test_handshake_rejects_non_connect_frame_with_numeric_id_gracefully() -> None:
+    ws = await _run([json.dumps({"type": "req", "id": 7, "method": "chat.send"})])
+
+    responses = ws.responses()
+    assert len(responses) == 1
+    assert responses[0]["ok"] is False
+    assert responses[0]["id"] == "7"
+    assert responses[0]["error"]["code"] == "INVALID_REQUEST"
+    # Graceful protocol-level close, not an unhandled exception path.
+    assert len(ws.close_codes) == 1
+
+
+async def test_handshake_rejects_non_object_connect_frame() -> None:
+    ws = await _run([json.dumps("not-an-object")])
+
+    responses = ws.responses()
+    assert len(responses) == 1
+    assert responses[0]["ok"] is False
+    assert responses[0]["id"] == "handshake"
+    assert responses[0]["error"]["code"] == "INVALID_REQUEST"
+    assert len(ws.close_codes) == 1


### PR DESCRIPTION
## Scope

Scope boundary: Validate client frames at the gateway WebSocket boundary so a malformed frame answers with `INVALID_REQUEST` instead of tearing down (or zombifying) the whole connection. Covered: non-string or non-UTF-8-encodable `id`/`method`, frames that parse to a non-object, frames `json.loads` rejects for non-`JSONDecodeError` reasons (int-digit conversion limit, recursion depth), unvalidated handshake params (non-dict `params`/`auth`, non-string `role`, non-integer protocol bounds), and outbound frames that fail serialization (the writer loop now closes the socket explicitly instead of exiting silently).

Non-goals: Change the wire contract for conforming clients, silently coerce non-string ids into accepted requests, or restructure dispatcher error handling.

## Problem

A frame such as `{"type":"req","id":1,"method":"chat.send",...}` used to run the handler to completion (for `chat.send`, the turn was already accepted and kept running), then raise a pydantic `ValidationError` while constructing the `ResFrame` (`id` must be a string). The recovery path rebuilt the error response with the same non-string id and raised again, escaping the message loop and tearing down the whole connection — the client got no response, lost all event subscriptions, and a retrying client re-executed the request each time. Numeric ids are valid JSON-RPC 2.0, so hand-written clients hit this on their first request.

The same crash class existed for non-string `method` values, valid-JSON-but-not-object frames, oversized int literals and pathological nesting (both raise non-`JSONDecodeError` exceptions from `json.loads`), several unvalidated connect-frame params (one path reachable before token validation), and lone-surrogate strings — the last of which failed at response serialization inside the writer task and left a zombie connection under the default writer-queue config: requests kept executing while no response ever left the socket.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Found while live-verifying the historical report #127; no public issue exists for this defect.

## Release Note

Release note: Fixed malformed WebSocket frames (non-string `id`/`method`, non-object frames, unparseable JSON edge cases, lone-surrogate strings, malformed connect params) killing or zombifying the entire gateway connection; such frames now receive an `INVALID_REQUEST` response and the connection stays alive, and unserializable outbound frames close the connection explicitly instead of silently stopping all responses.

## Tests

Ruff: `uv run ruff check src tests` (passed)

Mypy: `uv run mypy src/opensquilla --show-error-codes` (passed, 814 source files)

Pytest: `tests/test_gateway` in full: 2284 passed. All non-gateway suites that exercise the WebSocket stack (`tests/integration/cli/tui_real_terminal` with its real-gateway harness, `tests/test_mcp_server/test_protocol_smoke.py`, `tests/test_session/test_epoch_*`): 119 passed / 2 skipped. Full local run: 14633 passed / 139 skipped / 5 failed — all 5 failures are environment-only and reproduce identically on unmodified main in the same environment (3 require a local `docker` binary, 1 requires GNU sed, 1 exercises real macOS Seatbelt `/tmp` behavior).

Build: `uv build --wheel` (passed)

Regression tests: added

Notes: The 13 tests in `tests/test_gateway/test_websocket_frame_validation.py` were A/B-verified: each new guard's tests fail with that guard reverted and pass with it in place. A live gateway check against a throwaway state dir confirmed a numeric-id request now receives `INVALID_REQUEST` (id echoed as a string) and the same connection keeps serving subsequent requests.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: Local live verification used a throwaway state dir; no provider credentials are required to reproduce (the probe uses `connect` + read-only RPCs).

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and `tests/_private/` contents are not committed.

Upgrade compatibility: no config, RPC field, or schema changes. Frames rejected by the new guards never received a response before — they crashed the connection — so no conforming client observes a behavior change; the `INVALID_REQUEST` error code and response shape are pre-existing protocol vocabulary. Absent `id`/`method` still default to `""` and dispatch exactly as before. Two deliberate edge-case tightenings, both previously connection-killing rather than functional: non-integer `minProtocol`/`maxProtocol` connect values are now rejected with `INVALID_REQUEST`, and the unknown-frame-type error message now echoes the offending type via `repr`.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

No documentation files changed.

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
