### PR TITLE
Channel-admin approval round-trip and pairing admin marking

### DIFF
--- a/src/opensquilla/channels/approval_prompt.py
+++ b/src/opensquilla/channels/approval_prompt.py
@@ -10,7 +10,7 @@ without binding to any single adapter:
   works on every adapter via the universal ``/approve``/``/deny`` commands.
 - :func:`parse_approval_action` recognises either a Feishu card action
   (``opensquilla_action == "approval_resolve"``) or the universal text
-  command and returns ``(code, approved)``.
+  command and returns ``(code, decision)``.
 
 The user-facing handle is a SHORT base32 code (default 4 chars,
 case-insensitive), never the raw approval/exec id. Raw ids leak in group
@@ -34,11 +34,20 @@ _CODE_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 _CODE_LENGTH = 4
 
 # Universal text command. A leading slash avoids bare-word collisions with
-# ordinary chat ("approve the budget" must not resolve anything).
+# ordinary chat ("approve the budget" must not resolve anything). The optional
+# trailing word extends an approval: ``/approve K7PQ always`` selects the
+# durable same-type grant when the approval offers one.
 _TEXT_COMMAND_RE = re.compile(
-    r"^\s*/(approve|deny)\b\s*([0-9A-Za-z]{2,12})?\s*$",
+    r"^\s*/(approve|deny)\b\s*([0-9A-Za-z]{2,12})?(?:\s+(always))?\s*$",
     re.IGNORECASE,
 )
+
+# Decisions returned by :func:`parse_approval_action`. "always" maps to the
+# approval's ``allow_same_type`` choice at the resolution site; the prompt only
+# advertises it when the approval actually carries that choice.
+DECISION_APPROVE = "approve"
+DECISION_DENY = "deny"
+DECISION_ALWAYS = "always"
 
 
 @dataclass(frozen=True)
@@ -47,7 +56,10 @@ class ApprovalPromptRequest:
 
     ``short_code`` is the human handle bound to ``approval_id`` server-side;
     ``session_key`` and ``namespace`` mirror the queue entry so the bridge can
-    route the prompt back to the originating channel.
+    route the prompt back to the originating channel. ``offer_always`` is set
+    when the underlying approval carries an ``allow_same_type`` choice, i.e.
+    approving "always" has real durable-grant semantics rather than being a
+    placebo.
     """
 
     approval_id: str
@@ -56,6 +68,7 @@ class ApprovalPromptRequest:
     command_or_tool: str
     agent: str
     short_code: str
+    offer_always: bool = False
 
 
 @dataclass(frozen=True)
@@ -154,11 +167,16 @@ def _adapter_supports_interactive_cards(profile: Any) -> bool:
 
 def _prompt_text(request: ApprovalPromptRequest) -> str:
     command = request.command_or_tool or "(unknown command)"
+    always_line = (
+        f"/approve {request.short_code} always to stop asking for this kind, or "
+        if request.offer_always
+        else ""
+    )
     return (
         "Approval needed to run a privileged command.\n"
         f"Command: {command}\n"
         f"Code: {request.short_code}\n"
-        f"Reply /approve {request.short_code} to allow, or "
+        f"Reply /approve {request.short_code} to allow, {always_line}"
         f"/deny {request.short_code} to refuse."
     )
 
@@ -171,16 +189,45 @@ def _interactive_card(request: ApprovalPromptRequest) -> dict[str, Any]:
     keys on, paralleling the existing clarify-card contract.
     """
     command = request.command_or_tool or "(unknown command)"
-    approve_value = {
-        "opensquilla_action": "approval_resolve",
-        "code": request.short_code,
-        "decision": "approve",
-    }
-    deny_value = {
-        "opensquilla_action": "approval_resolve",
-        "code": request.short_code,
-        "decision": "deny",
-    }
+
+    def _action_value(decision: str) -> dict[str, str]:
+        return {
+            "opensquilla_action": "approval_resolve",
+            "code": request.short_code,
+            "decision": decision,
+        }
+
+    actions: list[dict[str, Any]] = [
+        {
+            "tag": "button",
+            "text": {"tag": "plain_text", "content": "Approve"},
+            "type": "primary",
+            "value": _action_value(DECISION_APPROVE),
+        },
+    ]
+    if request.offer_always:
+        actions.append(
+            {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": "Always allow"},
+                "type": "default",
+                "value": _action_value(DECISION_ALWAYS),
+            }
+        )
+    actions.append(
+        {
+            "tag": "button",
+            "text": {"tag": "plain_text", "content": "Deny"},
+            "type": "danger",
+            "value": _action_value(DECISION_DENY),
+        }
+    )
+    note = f"Or reply /approve {request.short_code} or /deny {request.short_code}."
+    if request.offer_always:
+        note = (
+            f"Or reply /approve {request.short_code}, "
+            f"/approve {request.short_code} always, or /deny {request.short_code}."
+        )
     return {
         "config": {"wide_screen_mode": True},
         "header": {
@@ -200,29 +247,14 @@ def _interactive_card(request: ApprovalPromptRequest) -> dict[str, Any]:
             },
             {
                 "tag": "action",
-                "actions": [
-                    {
-                        "tag": "button",
-                        "text": {"tag": "plain_text", "content": "Approve"},
-                        "type": "primary",
-                        "value": approve_value,
-                    },
-                    {
-                        "tag": "button",
-                        "text": {"tag": "plain_text", "content": "Deny"},
-                        "type": "danger",
-                        "value": deny_value,
-                    },
-                ],
+                "actions": actions,
             },
             {
                 "tag": "note",
                 "elements": [
                     {
                         "tag": "plain_text",
-                        "content": (
-                            f"Or reply /approve {request.short_code} or /deny {request.short_code}."
-                        ),
+                        "content": note,
                     }
                 ],
             },
@@ -247,7 +279,7 @@ def render_approval_prompt(
     return payload
 
 
-def parse_approval_action(inbound: Any) -> tuple[str, bool] | None:
+def parse_approval_action(inbound: Any) -> tuple[str, str] | None:
     """Recognise an approval action from inbound channel data.
 
     Accepts either:
@@ -255,11 +287,14 @@ def parse_approval_action(inbound: Any) -> tuple[str, bool] | None:
     - a Feishu card action dict carrying
       ``value.opensquilla_action == "approval_resolve"`` (already-parsed
       ``IncomingMessage.metadata`` or a raw ``{"value": {...}}`` mapping), or
-    - a plain-text body of the form ``/approve <code>`` / ``/deny <code>``.
+    - a plain-text body of the form ``/approve <code>`` / ``/deny <code>`` /
+      ``/approve <code> always``.
 
-    Returns ``(short_code, approved)`` or ``None`` when the input is not an
-    approval action. A missing code yields ``None`` (treated as "no pending"
-    by the caller) rather than a silent no-op.
+    Returns ``(short_code, decision)`` with decision one of
+    :data:`DECISION_APPROVE` / :data:`DECISION_DENY` / :data:`DECISION_ALWAYS`,
+    or ``None`` when the input is not an approval action. A missing code
+    yields ``None`` (treated as "no pending" by the caller) rather than a
+    silent no-op.
     """
     card = _card_action(inbound)
     if card is not None:
@@ -273,11 +308,15 @@ def parse_approval_action(inbound: Any) -> tuple[str, bool] | None:
     code = match.group(2)
     if not code:
         return None
-    approved = match.group(1).lower() == "approve"
-    return normalize_code(code), approved
+    verb = match.group(1).lower()
+    if verb != "approve":
+        return normalize_code(code), DECISION_DENY
+    if match.group(3):
+        return normalize_code(code), DECISION_ALWAYS
+    return normalize_code(code), DECISION_APPROVE
 
 
-def _card_action(inbound: Any) -> tuple[str, bool] | None:
+def _card_action(inbound: Any) -> tuple[str, str] | None:
     value = _card_action_value(inbound)
     if value is None:
         return None
@@ -287,9 +326,9 @@ def _card_action(inbound: Any) -> tuple[str, bool] | None:
     if not isinstance(code, str) or not code.strip():
         return None
     decision = str(value.get("decision") or "").lower()
-    if decision not in {"approve", "deny"}:
+    if decision not in {DECISION_APPROVE, DECISION_DENY, DECISION_ALWAYS}:
         return None
-    return normalize_code(code), decision == "approve"
+    return normalize_code(code), decision
 
 
 def _card_action_value(inbound: Any) -> dict[str, Any] | None:

--- a/src/opensquilla/cli/channels_cmd.py
+++ b/src/opensquilla/cli/channels_cmd.py
@@ -626,24 +626,37 @@ def pairings_list(
 def pairings_approve(
     channel: str = typer.Argument(..., help="Channel name"),
     pairing: str = typer.Argument(..., help="Pairing code (8 chars) or full pairing id"),
+    admin: bool = typer.Option(
+        False,
+        "--admin",
+        help=(
+            "Also mark this sender as a channel admin (full tool surface; "
+            "privileged commands still confirm per call). Use for yourself "
+            "or someone you trust with the host."
+        ),
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
     config_path: Path | None = typer.Option(None, "--config", help="Override config path."),
 ) -> None:
     """Approve a pairing request; the sender is notified they can start."""
 
+    access = (
+        "The sender gains conversational access AND channel-admin privileges."
+        if admin
+        else "The sender gains conversational access."
+    )
     confirm_or_exit(
-        f"Approve pairing {pairing!r} on channel {channel!r}? "
-        "The sender gains conversational access.",
+        f"Approve pairing {pairing!r} on channel {channel!r}? {access}",
         yes=yes,
         json_output=json_output,
     )
 
     async def _run(client):
-        return await client.call(
-            "channels.pairing.approve",
-            {"channelName": channel, "pairingCode": pairing},
-        )
+        request: dict[str, object] = {"channelName": channel, "pairingCode": pairing}
+        if admin:
+            request["asAdmin"] = True
+        return await client.call("channels.pairing.approve", request)
 
     payload = run_gateway_sync(_run, json_output=json_output, config_path=config_path)
     if json_output:
@@ -651,7 +664,8 @@ def pairings_approve(
         return
     record = payload.get("pairing") or {}
     sender = str(record.get("senderName") or record.get("senderId") or "")
-    typer.echo(f"Pairing approved: {record.get('pairingCode', pairing)} ({sender})")
+    suffix = " [admin]" if payload.get("adminGranted") else ""
+    typer.echo(f"Pairing approved: {record.get('pairingCode', pairing)} ({sender}){suffix}")
 
 
 @pairings_app.command("revoke")

--- a/src/opensquilla/gateway/approval_notify.py
+++ b/src/opensquilla/gateway/approval_notify.py
@@ -7,9 +7,12 @@ session's delivery target is a direct chat) so the user who started the turn
 can approve or deny with an interactive card or the universal ``/approve
 <code>`` text command. On ``resolved`` it releases the short-code binding.
 
-Additive and best-effort: a missing session manager, channel manager, delivery
-target, or send failure is swallowed so notification never breaks queue state
-or the blocked run (which still expires on its own deadline).
+Additive: a missing session manager, channel manager, or delivery target is
+swallowed so notification never breaks queue state or the blocked run (which
+still expires on its own deadline). A failed SEND, however, denies the
+approval outright — the prompt's addressee is the only expected resolver, so
+an undeliverable prompt means the answer can never arrive and fast failure
+beats a silent multi-minute hang.
 """
 
 from __future__ import annotations
@@ -30,11 +33,28 @@ from opensquilla.channels.contract import channel_capability_profile
 log = structlog.get_logger(__name__)
 
 
+def _get_queue() -> Any:
+    from opensquilla.gateway.approval_queue import get_approval_queue
+
+    return get_approval_queue()
+
+
 def _command_summary(params: dict[str, Any]) -> str:
     command = str(params.get("command") or "")
     if command:
         return command
     return str(params.get("toolName") or params.get("action_kind") or "")
+
+
+def _offers_always(params: dict[str, Any]) -> bool:
+    """True when the approval carries a durable ``allow_same_type`` choice."""
+    choices = params.get("choices")
+    if not isinstance(choices, list):
+        return False
+    return any(
+        isinstance(choice, dict) and choice.get("id") == "allow_same_type"
+        for choice in choices
+    )
 
 
 async def _deliver_channel_prompt(
@@ -95,6 +115,7 @@ async def _deliver_channel_prompt(
         command_or_tool=_command_summary(params),
         agent=str(params.get("agent") or ""),
         short_code=short_code,
+        offer_always=_offers_always(params),
     )
     profile = channel_capability_profile(adapter)
     rendered = render_approval_prompt(profile, request)
@@ -114,7 +135,7 @@ async def _deliver_channel_prompt(
     )
     try:
         await adapter.send(message)
-    except Exception as exc:  # noqa: BLE001 - notification is best-effort.
+    except Exception as exc:  # noqa: BLE001 - deny below, never raise here.
         log.warning(
             "approval_notify.send_failed",
             channel=channel_name,
@@ -122,6 +143,19 @@ async def _deliver_channel_prompt(
             error_type=type(exc).__name__,
             error=str(exc),
         )
+        # The originating sender is the only party expected to resolve a
+        # channel approval; if the prompt cannot reach them, waiting out the
+        # full queue deadline just leaves the turn hanging in silence. Deny
+        # immediately so the agent reports the failure while the user is
+        # still looking at the chat. Racing an operator resolving from the
+        # Web UI is fine — resolve() then raises and we keep their answer.
+        try:
+            _get_queue().resolve(approval_id, False, elevated_mode=None)
+        except Exception:  # noqa: BLE001 - already resolved or expired.
+            log.info(
+                "approval_notify.fail_closed_deny_skipped",
+                approval_id=approval_id,
+            )
 
 
 def register_approval_channel_notifier(

--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -573,7 +573,12 @@ async def run_channel_dispatch(
             session_key=session_key,
             session_prefix=session_prefix,
         )
-        approval_reply = _maybe_resolve_channel_approval(msg=msg, session_key=session_key)
+        approval_reply = await _maybe_resolve_channel_approval(
+            msg=msg,
+            session_key=session_key,
+            config=config,
+            session_manager=session_manager,
+        )
         if approval_reply is not None:
             await channel.send(_preserve_route_channel_metadata(approval_reply, route_envelope))
             if delivery_store is not None:
@@ -961,30 +966,43 @@ def _slash_command_head(content: str) -> str | None:
     return stripped.split(maxsplit=1)[0]
 
 
-def _maybe_resolve_channel_approval(
+async def _maybe_resolve_channel_approval(
     *,
     msg: IncomingMessage,
     session_key: str,
+    config: Any = None,
+    session_manager: Any = None,
 ) -> OutgoingMessage | None:
     """Resolve a channel approval action without starting an agent turn.
 
     Recognises a Feishu ``approval_resolve`` card action or the universal
-    ``/approve <code>`` / ``/deny <code>`` text command, then resolves the
-    bound approval directly so the suspended tool call's ``wait()`` unblocks.
+    ``/approve <code>`` / ``/deny <code>`` / ``/approve <code> always`` text
+    command, then resolves the bound approval so the suspended tool call's
+    ``wait()`` unblocks. Sandbox-kind approvals go through the same
+    claim/finalize/apply-choice sequence as the Web UI resolver so their
+    choice semantics (durable same-type grants) actually take effect.
 
     Security: only the session owner (the ``sender_id`` that started the
     originating turn, recorded on the approval at request time) may resolve.
-    Any other sender is rejected without resolving. A channel approval forces
-    ``elevated_mode=None`` so it permits one gated command, never session-wide
-    elevation. Returns the reply to send, or ``None`` when the message is not
-    an approval action.
+    Any other sender is rejected without resolving. The ``always`` decision
+    additionally requires the sender to still be a configured channel admin
+    at resolution time — the card payload is never trusted for that. A plain
+    approval forces ``elevated_mode=None`` so it permits one gated command,
+    never session-wide elevation. Returns the reply to send, or ``None`` when
+    the message is not an approval action.
     """
-    from opensquilla.channels.approval_prompt import parse_approval_action, resolve_short_code
+    from opensquilla.channels.approval_prompt import (
+        DECISION_ALWAYS,
+        DECISION_DENY,
+        parse_approval_action,
+        resolve_short_code,
+    )
 
     parsed = parse_approval_action(msg)
     if parsed is None:
         return None
-    code, approved = parsed
+    code, decision = parsed
+    approved = decision != DECISION_DENY
     binding = resolve_short_code(code)
     if binding is None:
         log.info("channel.approval_unknown_code", code=code, session_key=session_key)
@@ -1029,13 +1047,35 @@ def _maybe_resolve_channel_approval(
             )
         )
 
+    if decision == DECISION_ALWAYS and not _sender_is_channel_admin(
+        config, binding.origin_channel_name, sender_id
+    ):
+        log.warning(
+            "channel.approval_always_requires_admin",
+            code=code,
+            session_key=session_key,
+            sender_id=sender_id,
+        )
+        return OutgoingMessage(
+            content=(
+                f"'Always' needs a channel admin. Reply /approve {code} "
+                "to allow just this once."
+            )
+        )
+
     from opensquilla.gateway.approval_queue import get_approval_queue
 
     queue = get_approval_queue()
     try:
-        # Force elevated_mode=None: a channel approval permits exactly the one
-        # gated command, never a session-wide bypass regardless of payload.
-        queue.resolve(binding.approval_id, approved, elevated_mode=None)
+        reply = await _resolve_channel_approval_decision(
+            queue,
+            approval_id=binding.approval_id,
+            code=code,
+            decision=decision,
+            approved=approved,
+            config=config,
+            session_manager=session_manager,
+        )
     except KeyError:
         log.info("channel.approval_expired", code=code, session_key=session_key)
         return OutgoingMessage(content=f"No pending approval {code}.")
@@ -1048,12 +1088,105 @@ def _maybe_resolve_channel_approval(
         "channel.approval_resolved",
         code=code,
         approved=approved,
+        always=decision == DECISION_ALWAYS,
         session_key=session_key,
         sender_id=sender_id,
     )
-    if approved:
-        return OutgoingMessage(content=f"Approved {code} — running …")
-    return OutgoingMessage(content=f"Denied {code}.")
+    return reply
+
+
+def _sender_is_channel_admin(config: Any, channel_name: str, sender_id: str) -> bool:
+    admin_senders = getattr(config, "channel_admin_senders", None)
+    if not isinstance(admin_senders, dict) or not channel_name or not sender_id:
+        return False
+    configured = admin_senders.get(channel_name)
+    if isinstance(configured, str):
+        return sender_id == configured
+    if not isinstance(configured, list | tuple | set | frozenset):
+        return False
+    return sender_id in {str(item) for item in configured}
+
+
+async def _resolve_channel_approval_decision(
+    queue: Any,
+    *,
+    approval_id: str,
+    code: str,
+    decision: str,
+    approved: bool,
+    config: Any,
+    session_manager: Any,
+) -> OutgoingMessage:
+    """Apply one parsed approval decision to the queue.
+
+    Sandbox-kind approvals replay the Web UI resolver's claim → finalize →
+    apply-choice → complete sequence so ``always`` (``allow_same_type``)
+    produces its durable grant; everything else keeps the original single
+    ``resolve()``. Raises ``KeyError``/``ValueError`` exactly like
+    ``queue.resolve`` so the caller's reply mapping stays unchanged.
+    """
+    from opensquilla.channels.approval_prompt import DECISION_ALWAYS
+    from opensquilla.sandbox.escalation import (
+        apply_sandbox_approval_choice,
+        deny_matching_pending_sandbox_approvals,
+        is_sandbox_approval_kind,
+        remember_sandbox_approval_denial,
+        validate_sandbox_approval_choice,
+    )
+
+    pending = queue.get(approval_id)
+    sandbox_approval = is_sandbox_approval_kind(pending.params.get("approvalKind"))
+    choice: str | None = None
+    if sandbox_approval and approved:
+        choice = "allow_same_type" if decision == DECISION_ALWAYS else None
+        validate_sandbox_approval_choice(pending.params, choice=choice, approved=True)
+        claim_token = queue.claim_resolution(approval_id)
+        try:
+            queue.finalize_claimed_resolution(
+                approval_id,
+                claim_token,
+                True,
+                elevated_mode=None,
+            )
+        except Exception:
+            queue.release_resolution_claim(approval_id, claim_token)
+            raise
+        try:
+            await apply_sandbox_approval_choice(
+                pending.params,
+                choice=choice,
+                approved=True,
+                session_manager=session_manager,
+                config=config,
+            )
+        except Exception:
+            queue.reopen_resolved_approval(approval_id, expected_approved=True)
+            raise
+        queue.complete_claimed_resolution(approval_id, claim_token)
+    else:
+        # Force elevated_mode=None: a channel approval permits exactly the one
+        # gated command, never a session-wide bypass regardless of payload.
+        queue.resolve(
+            approval_id,
+            approved,
+            elevated_mode=None,
+            allow_idempotent=not sandbox_approval,
+        )
+        if sandbox_approval and not approved:
+            remember_sandbox_approval_denial(pending.params, approval_id)
+            deny_matching_pending_sandbox_approvals(
+                queue,
+                pending.params,
+                exclude_approval_id=approval_id,
+            )
+
+    if not approved:
+        return OutgoingMessage(content=f"Denied {code}.")
+    if choice == "allow_same_type":
+        return OutgoingMessage(
+            content=f"Approved {code} — this kind won't ask again this session."
+        )
+    return OutgoingMessage(content=f"Approved {code} — running …")
 
 
 async def _dispatch_channel_slash_command(
@@ -1166,7 +1299,12 @@ async def _dispatch_combined_message_after_debounce(channel: Any, combined: Any,
         log.info("channel.admission_denied", channel=session_prefix, reason=admission.reason, is_group=admission.is_group)  # noqa: E501
         return
     route_envelope = build_channel_route_envelope(msg, session_key=session_key, session_prefix=session_prefix)  # noqa: E501
-    approval_reply = _maybe_resolve_channel_approval(msg=msg, session_key=session_key)
+    approval_reply = await _maybe_resolve_channel_approval(
+        msg=msg,
+        session_key=session_key,
+        config=config,
+        session_manager=session_manager,
+    )
     if approval_reply is not None:
         await channel.send(_preserve_route_channel_metadata(approval_reply, route_envelope))
         return
@@ -1545,23 +1683,11 @@ async def _emit_run_heartbeat(
 
 
 def _is_channel_admin_sender(config: Any, envelope: Any) -> bool:
-    admin_senders = getattr(config, "channel_admin_senders", None)
-    if not isinstance(admin_senders, dict):
-        return False
-
     source_name = getattr(envelope, "source_name", None)
     sender_id = getattr(envelope, "sender_id", None)
-    if not isinstance(source_name, str) or not source_name:
+    if not isinstance(source_name, str) or not isinstance(sender_id, str):
         return False
-    if not isinstance(sender_id, str) or not sender_id:
-        return False
-
-    configured = admin_senders.get(source_name)
-    if isinstance(configured, str):
-        return sender_id == configured
-    if not isinstance(configured, list | tuple | set | frozenset):
-        return False
-    return sender_id in {str(item) for item in configured}
+    return _sender_is_channel_admin(config, source_name, sender_id)
 
 
 async def _run_turn_with_streaming(

--- a/src/opensquilla/gateway/rpc_channels.py
+++ b/src/opensquilla/gateway/rpc_channels.py
@@ -645,6 +645,7 @@ async def _handle_channels_pairing_approve(
     ctx: RpcContext,
 ) -> dict[str, Any]:
     channel_name, pairing_id = _pairing_mutation_params(params, ctx)
+    as_admin = bool((params or {}).get("asAdmin", False))
     store = _pairing_store(ctx)
     # Re-approving an already-approved pairing must not re-notify the sender.
     was_approved = _pairing_status_of(store, channel_name, pairing_id) == "approved"
@@ -653,9 +654,62 @@ async def _handle_channels_pairing_approve(
         pairing_id=pairing_id,
         status="approved",
     )
+    payload: dict[str, Any] = {"pairing": _pairing_payload(record)}
+    if as_admin:
+        # Deliberate, narrow scope expansion: an operator.pairing caller may
+        # mark the sender they are approving RIGHT NOW as an admin of the
+        # channel they are approving them on — never an arbitrary config
+        # write. This is the "this is me" shortcut in the pairing flow.
+        payload["adminGranted"] = _grant_channel_admin_sender(
+            ctx,
+            channel_name=channel_name,
+            sender_id=str(getattr(record, "sender_id", "") or ""),
+        )
     if not was_approved:
         await _send_pairing_approved_notice(ctx, record)
-    return {"pairing": _pairing_payload(record)}
+    return payload
+
+
+def _grant_channel_admin_sender(
+    ctx: RpcContext,
+    *,
+    channel_name: str,
+    sender_id: str,
+) -> bool:
+    """Add ``sender_id`` to ``channel_admin_senders[channel_name]``.
+
+    Persist-before-apply: the updated mapping is written to the TOML first,
+    then swapped into the live config object (which channel dispatch reads
+    per message, so the grant is live from the next inbound message).
+    Idempotent; returns whether the sender is an admin afterwards.
+    """
+    sender_id = sender_id.strip()
+    if not sender_id or ctx.config is None:
+        return False
+    current = getattr(ctx.config, "channel_admin_senders", None)
+    admin_senders: dict[str, list[str]] = {
+        str(name): [
+            str(item)
+            for item in (values if isinstance(values, list | tuple) else [values])
+        ]
+        for name, values in (current or {}).items()
+    }
+    existing = admin_senders.get(channel_name, [])
+    if sender_id not in existing:
+        admin_senders[channel_name] = [*existing, sender_id]
+    from opensquilla.gateway.rpc_config import _persist_config
+
+    # Persist-before-apply: write the candidate to disk first so a failed
+    # write leaves memory and TOML agreeing on the old state.
+    candidate = ctx.config.model_copy(update={"channel_admin_senders": admin_senders})
+    _persist_config(candidate)
+    ctx.config.channel_admin_senders = admin_senders
+    log.info(
+        "channel.pairing_admin_granted",
+        channel=channel_name,
+        sender_id=sender_id,
+    )
+    return True
 
 
 @_d.method("channels.pairing.revoke", scope="operator.pairing")

--- a/src/opensquilla/sandbox/escalation.py
+++ b/src/opensquilla/sandbox/escalation.py
@@ -145,12 +145,22 @@ def request_sandbox_approval(
         raise ValueError("sandbox_approval_params_required")
 
     if _current_tool_context_is_channel():
-        return _approval_payload(
-            "approval_denied",
-            "",
-            params,
-            message=_channel_sandbox_approval_disabled_message(),
-        )
+        admin_identity = _channel_admin_approval_identity()
+        if admin_identity is None:
+            return _approval_payload(
+                "approval_denied",
+                "",
+                params,
+                message=_channel_sandbox_approval_disabled_message(),
+            )
+        # A channel-admin turn may ask for approval: stamping senderId routes
+        # the prompt back into the originating chat (card / ``/approve <code>``)
+        # where only that sender can resolve it. Non-admin channel callers keep
+        # the hard deny above — pairing alone never unlocks host-side asks.
+        sender_id, session_key = admin_identity
+        params.setdefault("senderId", sender_id)
+        if session_key:
+            params.setdefault("sessionKey", session_key)
 
     queue = get_approval_queue()
     if approval_id is None:
@@ -222,6 +232,29 @@ def _current_tool_context_is_channel() -> bool:
         return False
     caller_kind = getattr(ctx, "caller_kind", None)
     return caller_kind is CallerKind.CHANNEL or str(caller_kind) == CallerKind.CHANNEL.value
+
+
+def _channel_admin_approval_identity() -> tuple[str, str] | None:
+    """Sender/session identity for a channel-admin turn, else ``None``.
+
+    ``is_owner`` on a channel ToolContext is set from
+    ``channel_admin_senders`` at dispatch time; the sender id recorded here is
+    the one the channel resolver later compares against, so a missing sender
+    id means the prompt could never be resolved and we fall back to the deny.
+    """
+    try:
+        from opensquilla.tools.types import current_tool_context
+
+        ctx = current_tool_context.get()
+    except Exception:  # pragma: no cover - defensive
+        return None
+    if ctx is None or not getattr(ctx, "is_owner", False):
+        return None
+    sender_id = str(getattr(ctx, "sender_id", "") or "").strip()
+    if not sender_id:
+        return None
+    session_key = str(getattr(ctx, "session_key", "") or "").strip()
+    return sender_id, session_key
 
 
 def remember_sandbox_approval_denial(

--- a/tests/test_channels/test_approval_dispatch_intercept.py
+++ b/tests/test_channels/test_approval_dispatch_intercept.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -21,11 +22,17 @@ def _reset_state():
     reset_short_codes()
 
 
-def _pending_approval(owner_sender_id: str) -> tuple[str, str]:
+def _pending_approval(
+    owner_sender_id: str,
+    *,
+    origin_channel_name: str = "",
+    params: dict | None = None,
+) -> tuple[str, str]:
     queue = get_approval_queue()
     approval_id = queue.request(
         namespace="exec",
-        params={
+        params=params
+        or {
             "toolName": "exec_command",
             "command": "rm target.txt",
             "sessionKey": "agent:main:chat",
@@ -38,18 +45,24 @@ def _pending_approval(owner_sender_id: str) -> tuple[str, str]:
         namespace="exec",
         session_key="agent:main:chat",
         owner_sender_id=owner_sender_id,
+        origin_channel_name=origin_channel_name,
     )
     return approval_id, code
 
 
 def test_non_action_message_is_ignored() -> None:
     msg = IncomingMessage(sender_id="owner", channel_id="c1", content="hello there")
-    assert _maybe_resolve_channel_approval(msg=msg, session_key="agent:main:chat") is None
+    reply = asyncio.run(
+        _maybe_resolve_channel_approval(msg=msg, session_key="agent:main:chat")
+    )
+    assert reply is None
 
 
 def test_unknown_code_returns_no_pending() -> None:
     msg = IncomingMessage(sender_id="owner", channel_id="c1", content="/approve ZZZZ")
-    reply = _maybe_resolve_channel_approval(msg=msg, session_key="agent:main:chat")
+    reply = asyncio.run(
+        _maybe_resolve_channel_approval(msg=msg, session_key="agent:main:chat")
+    )
     assert reply is not None
     assert "No pending approval ZZZZ" in reply.content
 
@@ -58,7 +71,9 @@ def test_non_owner_cannot_resolve() -> None:
     approval_id, code = _pending_approval(owner_sender_id="owner-1")
     msg = IncomingMessage(sender_id="intruder-2", channel_id="c1", content=f"/approve {code}")
 
-    reply = _maybe_resolve_channel_approval(msg=msg, session_key="agent:main:chat")
+    reply = asyncio.run(
+        _maybe_resolve_channel_approval(msg=msg, session_key="agent:main:chat")
+    )
 
     assert reply is not None
     assert "Only the session owner" in reply.content
@@ -81,7 +96,9 @@ def test_owner_approve_resolves_and_forces_no_elevation() -> None:
         msg = IncomingMessage(
             sender_id="owner-1", channel_id="c1", content=f"/approve {code}"
         )
-        reply = _maybe_resolve_channel_approval(msg=msg, session_key="agent:main:chat")
+        reply = await _maybe_resolve_channel_approval(
+            msg=msg, session_key="agent:main:chat"
+        )
         assert reply is not None
         assert f"Approved {code}" in reply.content
         await asyncio.wait_for(waiter_task, timeout=5.0)
@@ -101,10 +118,147 @@ def test_owner_deny_resolves_to_not_approved() -> None:
     approval_id, code = _pending_approval(owner_sender_id="owner-1")
     msg = IncomingMessage(sender_id="owner-1", channel_id="c1", content=f"/deny {code}")
 
-    reply = _maybe_resolve_channel_approval(msg=msg, session_key="agent:main:chat")
+    reply = asyncio.run(
+        _maybe_resolve_channel_approval(msg=msg, session_key="agent:main:chat")
+    )
 
     assert reply is not None
     assert f"Denied {code}" in reply.content
+    entry = get_approval_queue().get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is False
+
+
+def _admin_config(channel_name: str, sender_id: str) -> SimpleNamespace:
+    return SimpleNamespace(channel_admin_senders={channel_name: [sender_id]})
+
+
+def test_always_requires_channel_admin() -> None:
+    approval_id, code = _pending_approval(
+        owner_sender_id="owner-1", origin_channel_name="feishu-main"
+    )
+    msg = IncomingMessage(
+        sender_id="owner-1", channel_id="c1", content=f"/approve {code} always"
+    )
+
+    # Owner of the turn but NOT a configured channel admin: rejected, and the
+    # approval stays pending so a plain /approve still works afterwards.
+    reply = asyncio.run(
+        _maybe_resolve_channel_approval(
+            msg=msg,
+            session_key="agent:main:chat",
+            config=SimpleNamespace(channel_admin_senders={}),
+        )
+    )
+    assert reply is not None
+    assert "needs a channel admin" in reply.content
+    assert get_approval_queue().get(approval_id).resolved is False
+
+
+def test_always_from_admin_resolves_plain_exec_approval() -> None:
+    # Non-sandbox (plain exec) approvals accept "always" as a plain approve —
+    # there is no durable-grant choice to apply.
+    approval_id, code = _pending_approval(
+        owner_sender_id="owner-1", origin_channel_name="feishu-main"
+    )
+    msg = IncomingMessage(
+        sender_id="owner-1", channel_id="c1", content=f"/approve {code} always"
+    )
+
+    reply = asyncio.run(
+        _maybe_resolve_channel_approval(
+            msg=msg,
+            session_key="agent:main:chat",
+            config=_admin_config("feishu-main", "owner-1"),
+        )
+    )
+
+    assert reply is not None
+    assert f"Approved {code}" in reply.content
+    entry = get_approval_queue().get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is True
+
+
+def test_always_from_admin_applies_sandbox_same_type_choice(monkeypatch) -> None:
+    applied: list[dict] = []
+
+    async def _fake_apply(params, *, choice, approved, session_manager, config):
+        applied.append({"params": params, "choice": choice, "approved": approved})
+
+    monkeypatch.setattr(
+        "opensquilla.sandbox.escalation.apply_sandbox_approval_choice", _fake_apply
+    )
+
+    approval_id, code = _pending_approval(
+        owner_sender_id="owner-1",
+        origin_channel_name="feishu-main",
+        params={
+            "approvalKind": "sandbox_network",
+            "host": "pypi.org",
+            "fingerprint": "fp-1",
+            "sessionKey": "agent:main:chat",
+            "senderId": "owner-1",
+            "choices": [
+                {"id": "allow_once", "label": "Allow once", "approved": True},
+                {"id": "allow_same_type", "label": "Allow same type", "approved": True},
+                {"id": "deny", "label": "Deny", "approved": False},
+            ],
+        },
+    )
+    msg = IncomingMessage(
+        sender_id="owner-1", channel_id="c1", content=f"/approve {code} always"
+    )
+
+    reply = asyncio.run(
+        _maybe_resolve_channel_approval(
+            msg=msg,
+            session_key="agent:main:chat",
+            config=_admin_config("feishu-main", "owner-1"),
+        )
+    )
+
+    assert reply is not None
+    assert "won't ask again" in reply.content
+    assert applied == [
+        {
+            "params": get_approval_queue().get(approval_id).params,
+            "choice": "allow_same_type",
+            "approved": True,
+        }
+    ]
+    entry = get_approval_queue().get(approval_id)
+    assert entry.resolved is True
+    assert entry.approved is True
+
+
+def test_sandbox_deny_remembers_and_fans_out(monkeypatch) -> None:
+    remembered: list[str] = []
+    monkeypatch.setattr(
+        "opensquilla.sandbox.escalation.remember_sandbox_approval_denial",
+        lambda params, approval_id: remembered.append(approval_id),
+    )
+
+    approval_id, code = _pending_approval(
+        owner_sender_id="owner-1",
+        origin_channel_name="feishu-main",
+        params={
+            "approvalKind": "sandbox_network",
+            "host": "pypi.org",
+            "fingerprint": "fp-1",
+            "sessionKey": "agent:main:chat",
+            "senderId": "owner-1",
+        },
+    )
+    msg = IncomingMessage(sender_id="owner-1", channel_id="c1", content=f"/deny {code}")
+
+    reply = asyncio.run(
+        _maybe_resolve_channel_approval(msg=msg, session_key="agent:main:chat")
+    )
+
+    assert reply is not None
+    assert f"Denied {code}" in reply.content
+    assert remembered == [approval_id]
     entry = get_approval_queue().get(approval_id)
     assert entry.resolved is True
     assert entry.approved is False

--- a/tests/test_channels/test_approval_notify.py
+++ b/tests/test_channels/test_approval_notify.py
@@ -144,3 +144,60 @@ def test_notifier_ignores_non_channel_requests() -> None:
 
     asyncio.run(_run())
     assert adapter.sent == []
+
+
+class _FailingAdapter(_FakeAdapter):
+    async def send(self, message) -> None:
+        raise RuntimeError("socket torn down")
+
+
+def test_send_failure_denies_the_approval_fail_closed() -> None:
+    adapter = _FailingAdapter(interactive_cards=False)
+    approval_id = _run_notifier(adapter, sender_id="owner-1")
+
+    entry = get_approval_queue().get(approval_id)
+    # The prompt's addressee is the only expected resolver; an undeliverable
+    # prompt is denied immediately instead of hanging until deadline expiry.
+    assert entry.resolved is True
+    assert entry.approved is False
+
+
+def test_prompt_offers_always_only_when_same_type_choice_exists() -> None:
+    adapter = _FakeAdapter(interactive_cards=True)
+
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        scheduled: list = []
+        remove = register_approval_channel_notifier(
+            get_approval_queue(),
+            session_manager=_FakeSessionManager(),
+            channel_manager_ref=lambda: _FakeChannelManager(adapter),
+            schedule=lambda coro: scheduled.append(loop.create_task(coro)),
+        )
+        try:
+            get_approval_queue().request(
+                namespace="exec",
+                params={
+                    "approvalKind": "sandbox_network",
+                    "host": "pypi.org",
+                    "sessionKey": "agent:main:chat",
+                    "senderId": "owner-1",
+                    "choices": [
+                        {"id": "allow_once", "label": "Allow once", "approved": True},
+                        {"id": "allow_same_type", "label": "Allow same type", "approved": True},
+                        {"id": "deny", "label": "Deny", "approved": False},
+                    ],
+                },
+            )
+            await asyncio.gather(*scheduled)
+        finally:
+            remove()
+
+    asyncio.run(_run())
+
+    assert len(adapter.sent) == 1
+    message = adapter.sent[0]
+    assert "always" in message.content
+    actions = message.metadata["card"]["elements"][1]["actions"]
+    decisions = [action["value"]["decision"] for action in actions]
+    assert decisions == ["approve", "always", "deny"]

--- a/tests/test_channels/test_approval_prompt.py
+++ b/tests/test_channels/test_approval_prompt.py
@@ -64,9 +64,13 @@ def test_render_with_none_profile_is_text_only() -> None:
 
 
 def test_parse_text_commands_are_case_insensitive() -> None:
-    assert parse_approval_action("/approve AB12") == ("AB12", True)
-    assert parse_approval_action("/deny ab12") == ("AB12", False)
-    assert parse_approval_action("  /APPROVE xy9z  ") == ("XY9Z", True)
+    assert parse_approval_action("/approve AB12") == ("AB12", "approve")
+    assert parse_approval_action("/deny ab12") == ("AB12", "deny")
+    assert parse_approval_action("  /APPROVE xy9z  ") == ("XY9Z", "approve")
+    assert parse_approval_action("/approve AB12 always") == ("AB12", "always")
+    assert parse_approval_action("/approve ab12 ALWAYS") == ("AB12", "always")
+    # "always" on a deny is meaningless and parses as a plain deny.
+    assert parse_approval_action("/deny AB12 always") == ("AB12", "deny")
 
 
 def test_parse_rejects_bare_word_and_missing_code() -> None:
@@ -78,7 +82,7 @@ def test_parse_rejects_bare_word_and_missing_code() -> None:
 
 def test_parse_incoming_message_text() -> None:
     msg = IncomingMessage(sender_id="u1", channel_id="c1", content="/deny AB12")
-    assert parse_approval_action(msg) == ("AB12", False)
+    assert parse_approval_action(msg) == ("AB12", "deny")
 
 
 def test_parse_card_action_from_metadata() -> None:
@@ -94,7 +98,7 @@ def test_parse_card_action_from_metadata() -> None:
             }
         },
     )
-    assert parse_approval_action(msg) == ("AB12", True)
+    assert parse_approval_action(msg) == ("AB12", "approve")
 
 
 def test_parse_card_action_requires_discriminator() -> None:

--- a/tests/test_channels/test_feishu_approval_card.py
+++ b/tests/test_channels/test_feishu_approval_card.py
@@ -39,7 +39,7 @@ def test_parse_approval_card_action_yields_inbound_message() -> None:
     assert msg.content == "/approve AB12"
     assert msg.metadata["approval_action"]["code"] == "AB12"
     # The shared parser recognises the carried action.
-    assert parse_approval_action(msg) == ("AB12", True)
+    assert parse_approval_action(msg) == ("AB12", "approve")
 
 
 def test_parse_ignores_clarify_and_unknown_actions() -> None:

--- a/tests/test_cli/test_channels_cmd.py
+++ b/tests/test_cli/test_channels_cmd.py
@@ -416,3 +416,31 @@ def test_pairings_revoke_uses_the_revoke_rpc(tmp_path, monkeypatch):
         )
     ]
     assert "revoked" in result.stdout.lower()
+
+
+def test_pairings_approve_admin_flag_passes_as_admin(tmp_path, monkeypatch):
+    _setenv(monkeypatch, tmp_path)
+    fake = _install_fake_gateway(monkeypatch)
+    fake.payloads = {
+        "channels.pairing.approve": {
+            "pairing": {"pairingCode": "abcdef12", "senderId": "user-42", "status": "approved"},
+            "adminGranted": True,
+        }
+    }
+
+    result = runner.invoke(
+        app,
+        [
+            "channels", "pairings", "approve", "telegram-main", "abcdef12",
+            "--admin", "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake.calls == [
+        (
+            "channels.pairing.approve",
+            {"channelName": "telegram-main", "pairingCode": "abcdef12", "asAdmin": True},
+        )
+    ]
+    assert "[admin]" in result.stdout

--- a/tests/test_gateway/test_rpc_channels.py
+++ b/tests/test_gateway/test_rpc_channels.py
@@ -713,3 +713,65 @@ async def test_pairing_approve_without_a_stored_address_is_silent():
 
     assert res.error is None, res.error
     assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_pairing_approve_as_admin_grants_and_persists(tmp_path, monkeypatch):
+    adapter = _NoticeAdapter()
+    ctx = _notice_ctx(adapter, _NoticeStore())
+    ctx.config.config_path = str(tmp_path / "config.toml")
+
+    rpc_res = await get_dispatcher().dispatch(
+        "r1",
+        "channels.pairing.approve",
+        {"channelName": "work", "pairingId": "p1", "asAdmin": True},
+        ctx,
+    )
+
+    assert rpc_res.error is None, rpc_res.error
+    assert rpc_res.payload["adminGranted"] is True
+    # Live config sees the grant immediately (dispatch reads it per message).
+    assert ctx.config.channel_admin_senders == {"work": ["U-1"]}
+    # And it survived to disk: persist-before-apply wrote the TOML.
+    text = (tmp_path / "config.toml").read_text()
+    assert "channel_admin_senders" in text
+    assert "U-1" in text
+
+
+@pytest.mark.asyncio
+async def test_pairing_approve_as_admin_is_idempotent(tmp_path):
+    adapter = _NoticeAdapter()
+    ctx = _notice_ctx(adapter, _NoticeStore())
+    ctx.config.config_path = str(tmp_path / "config.toml")
+    ctx.config.channel_admin_senders = {"work": ["U-1"], "other": ["Z-9"]}
+
+    rpc_res = await get_dispatcher().dispatch(
+        "r1",
+        "channels.pairing.approve",
+        {"channelName": "work", "pairingId": "p1", "asAdmin": True},
+        ctx,
+    )
+
+    assert rpc_res.error is None, rpc_res.error
+    assert rpc_res.payload["adminGranted"] is True
+    # No duplicate entry; unrelated channels' admins untouched.
+    assert ctx.config.channel_admin_senders == {"work": ["U-1"], "other": ["Z-9"]}
+
+
+@pytest.mark.asyncio
+async def test_pairing_approve_without_as_admin_changes_no_config(tmp_path):
+    adapter = _NoticeAdapter()
+    ctx = _notice_ctx(adapter, _NoticeStore())
+    ctx.config.config_path = str(tmp_path / "config.toml")
+
+    rpc_res = await get_dispatcher().dispatch(
+        "r1",
+        "channels.pairing.approve",
+        {"channelName": "work", "pairingId": "p1"},
+        ctx,
+    )
+
+    assert rpc_res.error is None, rpc_res.error
+    assert "adminGranted" not in rpc_res.payload
+    assert ctx.config.channel_admin_senders == {}
+    assert not (tmp_path / "config.toml").exists()

--- a/tests/test_sandbox/test_channel_approval_gate.py
+++ b/tests/test_sandbox/test_channel_approval_gate.py
@@ -1,0 +1,105 @@
+"""Channel-context behavior of ``request_sandbox_approval``.
+
+A plain channel caller must never open a sandbox approval (hard deny, ask an
+admin instead); a channel-admin turn opens one that is routed back to the
+originating chat via the ``senderId``/``sessionKey`` params the notifier keys
+on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from opensquilla.gateway.approval_queue import get_approval_queue, reset_approval_queue
+from opensquilla.sandbox.escalation import request_sandbox_approval
+from opensquilla.tools.types import CallerKind, ToolContext, current_tool_context
+
+
+@pytest.fixture(autouse=True)
+def _reset_queue():
+    reset_approval_queue()
+    yield
+    reset_approval_queue()
+
+
+def _channel_context(*, is_owner: bool, sender_id: str | None = "ou_admin") -> ToolContext:
+    return ToolContext(
+        is_owner=is_owner,
+        caller_kind=CallerKind.CHANNEL,
+        session_key="feishu:oc_demo",
+        channel_kind="feishu",
+        channel_id="oc_demo",
+        sender_id=sender_id,
+        source_name="feishu-main",
+    )
+
+
+def _params() -> dict[str, object]:
+    return {
+        "approvalKind": "sandbox_network",
+        "host": "pypi.org",
+        "fingerprint": "fp-test",
+        "choices": [
+            {"id": "allow_once", "label": "Allow once", "approved": True},
+            {"id": "allow_same_type", "label": "Allow same type", "approved": True},
+            {"id": "deny", "label": "Deny", "approved": False},
+        ],
+    }
+
+
+def _with_context(ctx: ToolContext | None, fn):
+    token = current_tool_context.set(ctx)
+    try:
+        return fn()
+    finally:
+        current_tool_context.reset(token)
+
+
+def test_non_admin_channel_caller_is_denied_without_a_request() -> None:
+    payload = _with_context(
+        _channel_context(is_owner=False),
+        lambda: request_sandbox_approval(_params(), message="ask"),
+    )
+
+    assert payload["status"] == "approval_denied"
+    assert payload["approval_id"] == ""
+    assert "admin" in str(payload["message"])
+    assert get_approval_queue().list_pending() == []
+
+
+def test_admin_channel_caller_opens_a_channel_routed_approval() -> None:
+    payload = _with_context(
+        _channel_context(is_owner=True),
+        lambda: request_sandbox_approval(_params(), message="ask"),
+    )
+
+    assert payload["status"] == "approval_required"
+    approval_id = str(payload["approval_id"])
+    entry = get_approval_queue().get(approval_id)
+    # The stamps the channel notifier keys on: without them the prompt would
+    # never reach the chat and the approval could not be resolved there.
+    assert entry.params["senderId"] == "ou_admin"
+    assert entry.params["sessionKey"] == "feishu:oc_demo"
+
+
+def test_admin_without_sender_identity_stays_denied() -> None:
+    # is_owner alone is not enough: without a sender id the resolver could
+    # never match the approval back to a person, so the deny stands.
+    payload = _with_context(
+        _channel_context(is_owner=True, sender_id=None),
+        lambda: request_sandbox_approval(_params(), message="ask"),
+    )
+
+    assert payload["status"] == "approval_denied"
+    assert get_approval_queue().list_pending() == []
+
+
+def test_non_channel_context_is_not_stamped() -> None:
+    payload = _with_context(
+        None,
+        lambda: request_sandbox_approval(_params(), message="ask"),
+    )
+
+    assert payload["status"] == "approval_required"
+    entry = get_approval_queue().get(str(payload["approval_id"]))
+    assert "senderId" not in entry.params


### PR DESCRIPTION
## Scope

Two steps that make privileged actions usable from a chat channel without weakening the default posture:

1. **Channel admins can resolve sandbox asks from the chat that raised them.** The channel approval pipeline (short-code bindings, interactive cards, universal `/approve <code>`) existed end to end but had no producer: `request_sandbox_approval` hard-denied every channel caller. Now a turn from a configured channel admin (`channel_admin_senders`) opens a real approval stamped with the sender and session; the prompt is delivered back to the originating chat and only that sender can resolve it. Non-admin channel callers keep the hard deny. Resolution gains an `always` decision (card button + `/approve <code> always`) mapped to the approval's existing `allow_same_type` choice — the durable same-type grant — with channel-admin status re-verified server-side at resolution time. Sandbox-kind approvals resolved from chat now use the same claim/finalize/apply-choice sequence as the Web UI resolver, so choices take effect, denials are remembered, and duplicate pending asks are fanned out. An undeliverable prompt is denied immediately instead of hanging the turn until deadline expiry.
2. **Pairing approval can mark the sender as channel admin.** `channels.pairing.approve` accepts an optional `asAdmin` flag (CLI: `channels pairings approve --admin`) appending the just-approved sender to the just-approved channel's admin list — a deliberately narrow config write with persist-before-apply ordering. This closes the "the first pairing is the operator themselves" loop without hand-editing TOML.

## Branch target

`integration/channel-platform`

## Linked issue

None

## Release note

Privileged commands asked for from a chat channel now work the way you'd expect for channel admins: the agent posts an approval card (or a `/approve <code>` prompt on channels without cards) in the same chat, and only the person who started the turn can approve, deny, or choose "always allow this kind". Non-admin channel users are unchanged. When approving a pairing you can now mark the sender as a channel admin in the same step (`--admin` on the CLI, `asAdmin` over RPC) — useful when the first pairing is you.

## Tests

- `uv run ruff check src tests` clean; `uv run mypy src/opensquilla` clean (809 files)
- `tests/test_channels tests/test_gateway tests/test_sandbox tests/test_cli tests/test_engine` — 6390 passed; the one failure is the known machine-local seatbelt test, unrelated
- New coverage: channel-admin passthrough vs non-admin deny vs missing-sender deny in `request_sandbox_approval`; `always` admin re-verification, same-type choice application, denial fan-out in dispatch; fail-closed deny on undeliverable prompts; `asAdmin` grant, idempotency, and no-flag no-write in the pairing RPC; CLI flag passthrough

## Safety notes

Net posture: channel callers without admin status behave exactly as before (hard deny). The new surface is opt-in twice — the operator must both configure the sender as a channel admin and approve each ask (or grant same-type durability explicitly). A channel approval still never grants session-wide elevation (`elevated_mode` stays forced off). The `asAdmin` flag is a scope-narrow config write: only the sender being approved, only on the channel they were approved for. Identity note: approvals are keyed to the adapter-reported sender id; on adapters whose authenticated provenance diverges from the raw sender id, resolution fails closed.

## Third-party origin

None.
