### PR TITLE
Validate PPTX artifacts before publication

### DIFF
--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -30,6 +30,7 @@
     "tests/test_application/test_approval_patterns.py": 0.01,
     "tests/test_application/test_approval_rpc.py": 0.094,
     "tests/test_application/test_wizard.py": 0.01,
+    "tests/test_artifact_validation.py": 0.01,
     "tests/test_artifacts.py": 1.71,
     "tests/test_asyncio_utils.py": 0.01,
     "tests/test_attachment_workspace.py": 0.144,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,8 @@ select = ["E", "F", "I", "N", "W", "UP"]
 
 [tool.mypy]
 python_version = "3.12"
+# Match the canonical full-tree type-check target used by CI on every host.
+platform = "linux"
 warn_return_any = true
 warn_unused_configs = true
 exclude = [

--- a/src/opensquilla/artifact_validation.py
+++ b/src/opensquilla/artifact_validation.py
@@ -1,0 +1,1447 @@
+"""Format-aware validation for generated artifacts before delivery.
+
+The artifact store intentionally remains format-agnostic.  This module owns
+the narrower contract that a generated ``.pptx`` must be an objectively
+readable OOXML presentation before a delivery surface can call it published.
+"""
+
+from __future__ import annotations
+
+import io
+import posixpath
+import struct
+import xml.etree.ElementTree as ET
+import xml.parsers.expat as expat
+import zipfile
+import zlib
+from dataclasses import dataclass
+from typing import Never
+from urllib.parse import urlsplit
+
+import structlog
+
+from opensquilla.contracts.attachments import OLE_MAGIC, PPTX_MIME
+
+log = structlog.get_logger(__name__)
+
+__all__ = [
+    "PPTX_MIME",
+    "ArtifactValidationError",
+    "ArtifactValidationReport",
+    "is_pptx_candidate",
+    "validate_pptx_bytes",
+    "validate_artifact_for_delivery",
+]
+
+_MAX_INFLATED_BYTES = 200 * 1024 * 1024
+_MAX_CORE_XML_BYTES = 16 * 1024 * 1024
+_MAX_ZIP_MEMBERS = 10_000
+_MAX_CENTRAL_DIRECTORY_BYTES = 32 * 1024 * 1024
+_READ_CHUNK_BYTES = 1024 * 1024
+
+_LOCAL_FILE_HEADER = b"PK\x03\x04"
+_CENTRAL_DIRECTORY_HEADER = b"PK\x01\x02"
+_END_OF_CENTRAL_DIRECTORY = b"PK\x05\x06"
+_ZIP64_END_OF_CENTRAL_DIRECTORY = b"PK\x06\x06"
+_ZIP64_END_OF_CENTRAL_DIRECTORY_LOCATOR = b"PK\x06\x07"
+_MAX_ZIP_COMMENT_BYTES = 65_535
+_EOCD_BYTES = 22
+_LOCAL_FILE_HEADER_BYTES = 30
+_CENTRAL_DIRECTORY_HEADER_BYTES = 46
+_ZIP64_EOCD_MIN_SIZE = 44
+_ZIP64_EOCD_LOCATOR_BYTES = 20
+_DATA_DESCRIPTOR_SIGNATURE = b"PK\x07\x08"
+_ZIP64_EXTRA_FIELD_ID = 0x0001
+_SUPPORTED_ZIP_COMPRESSION = frozenset({zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED})
+_ASCII_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+_ASCII_UNRESERVED_BYTES = frozenset(
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+)
+_ASCII_LOWER_TRANSLATION = str.maketrans(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "abcdefghijklmnopqrstuvwxyz",
+)
+
+_CONTENT_TYPES_PART = "[Content_Types].xml"
+_ROOT_RELS_PART = "_rels/.rels"
+
+_CONTENT_TYPES_NAMESPACES = frozenset(
+    {
+        "http://schemas.openxmlformats.org/package/2006/content-types",
+        "http://purl.oclc.org/ooxml/package/content-types",
+    }
+)
+_PACKAGE_RELATIONSHIP_NAMESPACES = frozenset(
+    {
+        "http://schemas.openxmlformats.org/package/2006/relationships",
+        "http://purl.oclc.org/ooxml/package/relationships",
+    }
+)
+
+_TRANSITIONAL_RELATIONSHIP_NS = (
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+)
+_STRICT_RELATIONSHIP_NS = "http://purl.oclc.org/ooxml/officeDocument/relationships"
+_OFFICE_DOCUMENT_RELATIONSHIP_TYPES = frozenset(
+    {
+        f"{_TRANSITIONAL_RELATIONSHIP_NS}/officeDocument",
+        f"{_STRICT_RELATIONSHIP_NS}/officeDocument",
+    }
+)
+
+_TRANSITIONAL_PRESENTATION_NS = (
+    "http://schemas.openxmlformats.org/presentationml/2006/main"
+)
+_STRICT_PRESENTATION_NS = "http://purl.oclc.org/ooxml/presentationml/main"
+
+_PRESENTATION_CONTENT_TYPE = (
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"
+)
+_SLIDE_CONTENT_TYPE = (
+    "application/vnd.openxmlformats-officedocument.presentationml.slide+xml"
+)
+
+_GENERIC_USER_MESSAGE = (
+    "The PPTX was not attached because it is not a readable OOXML presentation. "
+    "Repair or regenerate it and try again."
+)
+_ENCRYPTED_USER_MESSAGE = (
+    "The PPTX was not attached because encrypted or legacy Office containers are not "
+    "supported. Save it as an unencrypted .pptx, or regenerate it, then try again."
+)
+_INFLATED_LIMIT_USER_MESSAGE = (
+    "The PPTX was not attached because its expanded contents exceed the safe validation "
+    "limit. Reduce or regenerate it and try again."
+)
+_PACKAGE_COMPLEXITY_USER_MESSAGE = (
+    "The PPTX was not attached because its package structure exceeds the safe validation "
+    "limit. Simplify or regenerate it and try again."
+)
+
+
+class ArtifactValidationError(ValueError):
+    """Blocking artifact validation failure safe to expose to a tool caller."""
+
+    def __init__(self, reason_code: str, user_message: str) -> None:
+        super().__init__(user_message)
+        self.reason_code = reason_code
+        self.user_message = user_message
+
+
+class _UnsafeXmlDeclarationError(ValueError):
+    """Raised by the non-resolving XML preflight when a DTD or entity is declared."""
+
+
+@dataclass(frozen=True)
+class ArtifactValidationReport:
+    """Successful validation result, optionally carrying compatibility warnings."""
+
+    warnings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class _Relationship:
+    relationship_id: str
+    relationship_type: str
+    target: str
+    target_mode: str | None
+
+
+@dataclass(frozen=True)
+class _ContentTypes:
+    defaults: dict[str, str]
+    overrides: dict[str, str]
+
+    def for_part(self, part_name: str) -> str | None:
+        override = self.overrides.get(_canonical_part_key(part_name))
+        if override is not None:
+            return override
+        filename = posixpath.basename(part_name)
+        extension = filename.rsplit(".", 1)[1].casefold() if "." in filename else ""
+        return self.defaults.get(extension)
+
+
+@dataclass(frozen=True)
+class _CentralDirectoryEntry:
+    decoded_name: str
+    raw_name: bytes
+    version_needed: int
+    flags: int
+    compression: int
+    modified_time: int
+    modified_date: int
+    crc: int
+    compressed_size: int
+    uncompressed_size: int
+    local_header_offset: int
+    uses_zip64_sizes: bool
+
+
+@dataclass(frozen=True)
+class _PackageParts:
+    """Case-insensitive OPC part keys mapped to their physical ZIP member names."""
+
+    by_key: dict[str, str]
+    case_fallback_names: dict[str, str]
+
+    def contains(self, part_name: str) -> bool:
+        return _canonical_part_key(part_name) in self.by_key
+
+    def physical_name(self, part_name: str) -> str:
+        physical_name = self.by_key.get(_canonical_part_key(part_name))
+        if physical_name is None:
+            raise KeyError(part_name)
+        return physical_name
+
+    def reference_requires_case_fallback(self, part_name: str) -> bool:
+        physical_name = self.physical_name(part_name)
+        normalised_reference = _normalise_package_path(part_name, base_parts=[])
+        normalised_physical = _normalise_package_path(physical_name, base_parts=[])
+        requires_fallback = normalised_reference != normalised_physical
+        if requires_fallback:
+            self.case_fallback_names.setdefault(physical_name, normalised_reference)
+        return requires_fallback
+
+
+def is_pptx_candidate(
+    *,
+    source_name: str | None = None,
+    name: str | None = None,
+    mime: str | None = None,
+) -> bool:
+    """Return whether any delivery signal identifies the artifact as PPTX."""
+
+    names = (source_name, name)
+    if any(
+        isinstance(value, str) and value.strip().casefold().endswith(".pptx")
+        for value in names
+    ):
+        return True
+    if not isinstance(mime, str):
+        return False
+    return mime.split(";", 1)[0].strip().casefold() == PPTX_MIME
+
+
+def validate_artifact_for_delivery(
+    payload: bytes,
+    *,
+    source_name: str | None,
+    name: str,
+    mime: str,
+    source: str,
+) -> ArtifactValidationReport:
+    """Validate a generated artifact at the final format-aware delivery boundary.
+
+    Non-PPTX artifacts intentionally remain opaque.  Logs contain only bounded
+    operational metadata; names, paths, exception strings, and content are not
+    emitted.
+    """
+
+    if not is_pptx_candidate(source_name=source_name, name=name, mime=mime):
+        return ArtifactValidationReport()
+
+    try:
+        report = validate_pptx_bytes(payload)
+    except ArtifactValidationError as exc:
+        log.warning(
+            "artifact_validation.completed",
+            source=source,
+            outcome="blocked",
+            reason_code=exc.reason_code,
+            size=len(payload),
+        )
+        raise
+
+    if report.warnings:
+        for warning in report.warnings:
+            log.warning(
+                "artifact_validation.completed",
+                source=source,
+                outcome="warning",
+                reason_code=warning,
+                size=len(payload),
+            )
+    else:
+        log.info(
+            "artifact_validation.completed",
+            source=source,
+            outcome="passed",
+            reason_code="ok",
+            size=len(payload),
+        )
+    return report
+
+
+def validate_pptx_bytes(payload: bytes) -> ArtifactValidationReport:
+    """Validate PPTX bytes and return any non-blocking compatibility warnings."""
+
+    if payload.startswith(OLE_MAGIC):
+        _fail("pptx_encrypted_or_legacy_container", _ENCRYPTED_USER_MESSAGE)
+
+    central_entries = _validate_zip_envelope(payload)
+    try:
+        with zipfile.ZipFile(io.BytesIO(payload), "r") as archive:
+            infos = archive.infolist()
+            if len(infos) != len(central_entries):
+                _fail("pptx_invalid_central_directory")
+
+            parts = _validate_zip_members(archive, infos, central_entries)
+            content_types = _parse_content_types(archive, parts)
+            root_relationships = _parse_relationships(
+                archive,
+                parts,
+                _ROOT_RELS_PART,
+                missing_reason="pptx_missing_root_relationships",
+            )
+            content_types_case_fallback = parts.reference_requires_case_fallback(
+                _CONTENT_TYPES_PART
+            )
+            root_rels_case_fallback = parts.reference_requires_case_fallback(_ROOT_RELS_PART)
+            parser_case_compatibility = (
+                content_types_case_fallback or root_rels_case_fallback
+            )
+            office_relationships = [
+                relationship
+                for relationship in root_relationships.values()
+                if relationship.relationship_type in _OFFICE_DOCUMENT_RELATIONSHIP_TYPES
+            ]
+            if len(office_relationships) != 1:
+                _fail("pptx_invalid_office_document_relationship")
+
+            office_relationship = office_relationships[0]
+            if office_relationship.target_mode == "External":
+                _fail("pptx_external_office_document")
+            presentation_part = _resolve_relationship_target(
+                source_part=None,
+                target=office_relationship.target,
+            )
+            if not parts.contains(presentation_part):
+                _fail("pptx_missing_presentation_part")
+            presentation_case_fallback = parts.reference_requires_case_fallback(
+                presentation_part
+            )
+            parser_case_compatibility = (
+                presentation_case_fallback or parser_case_compatibility
+            )
+            presentation_content_type = content_types.for_part(presentation_part)
+            if (
+                presentation_content_type is None
+                or presentation_content_type.casefold()
+                != _PRESENTATION_CONTENT_TYPE.casefold()
+            ):
+                _fail("pptx_invalid_presentation_content_type")
+            parser_case_compatibility = (
+                parser_case_compatibility
+                or presentation_content_type != _PRESENTATION_CONTENT_TYPE
+            )
+
+            is_strict = office_relationship.relationship_type.startswith(
+                _STRICT_RELATIONSHIP_NS
+            )
+            parser_case_compatibility = _validate_presentation(
+                archive,
+                parts,
+                content_types,
+                presentation_part,
+                is_strict=is_strict,
+            ) or parser_case_compatibility
+            parser_case_compatibility = (
+                _validate_reachable_relationship_targets(
+                    archive,
+                    parts,
+                    content_types,
+                    root_relationships,
+                    presentation_part=presentation_part,
+                )
+                or parser_case_compatibility
+            )
+    except ArtifactValidationError:
+        raise
+    except NotImplementedError:
+        _fail("pptx_unsupported_zip_feature")
+    except (
+        zipfile.BadZipFile,
+        zipfile.LargeZipFile,
+        zlib.error,
+        EOFError,
+        OSError,
+        RuntimeError,
+    ):
+        _fail("pptx_corrupt_zip_member")
+    except ValueError:
+        _fail("pptx_unsupported_zip_feature")
+
+    if is_strict:
+        return ArtifactValidationReport(warnings=("pptx_strict_ooxml_smoke_skipped",))
+    return _python_pptx_smoke_test(
+        payload,
+        allow_opc_case_compatibility=parser_case_compatibility,
+        case_fallback_names=parts.case_fallback_names,
+    )
+
+
+def _validate_zip_envelope(payload: bytes) -> tuple[_CentralDirectoryEntry, ...]:
+    if not payload.startswith(_LOCAL_FILE_HEADER):
+        _fail("pptx_not_zip")
+
+    minimum_offset = max(0, len(payload) - (_EOCD_BYTES + _MAX_ZIP_COMMENT_BYTES))
+    search_end = len(payload)
+    eocd_offset = -1
+    eocd_fields: tuple[int, ...] | None = None
+    while search_end > minimum_offset:
+        candidate = payload.rfind(_END_OF_CENTRAL_DIRECTORY, minimum_offset, search_end)
+        if candidate < 0:
+            break
+        if candidate + _EOCD_BYTES <= len(payload):
+            try:
+                fields = struct.unpack_from("<4H2LH", payload, candidate + 4)
+            except struct.error:
+                _fail("pptx_invalid_zip_envelope")
+            comment_length = fields[-1]
+            if candidate + _EOCD_BYTES + comment_length == len(payload):
+                eocd_offset = candidate
+                eocd_fields = fields
+                break
+        search_end = candidate
+
+    if eocd_fields is None:
+        _fail("pptx_invalid_zip_envelope")
+
+    disk_number, central_disk, disk_entries, total_entries, size, offset, _ = eocd_fields
+    uses_zip64 = (
+        disk_number == 0xFFFF
+        or central_disk == 0xFFFF
+        or disk_entries == 0xFFFF
+        or total_entries == 0xFFFF
+        or size == 0xFFFFFFFF
+        or offset == 0xFFFFFFFF
+    )
+    central_directory_end = eocd_offset
+    if uses_zip64:
+        (
+            disk_number,
+            central_disk,
+            disk_entries,
+            total_entries,
+            size,
+            offset,
+            central_directory_end,
+        ) = _read_zip64_directory_fields(
+            payload,
+            eocd_offset=eocd_offset,
+            legacy_fields=eocd_fields,
+        )
+
+    if disk_number != 0 or central_disk != 0 or disk_entries != total_entries:
+        _fail("pptx_multidisk_zip_unsupported")
+    if total_entries > _MAX_ZIP_MEMBERS:
+        _fail("pptx_member_count_limit", _PACKAGE_COMPLEXITY_USER_MESSAGE)
+    if size > _MAX_CENTRAL_DIRECTORY_BYTES:
+        _fail("pptx_central_directory_limit", _PACKAGE_COMPLEXITY_USER_MESSAGE)
+    if offset > central_directory_end or size != central_directory_end - offset:
+        _fail("pptx_invalid_central_directory")
+    entries = _validate_central_directory(
+        payload,
+        offset=offset,
+        size=size,
+        expected_entries=total_entries,
+    )
+    _validate_local_file_layout(payload, entries, central_directory_offset=offset)
+    return entries
+
+
+def _read_zip64_directory_fields(
+    payload: bytes,
+    *,
+    eocd_offset: int,
+    legacy_fields: tuple[int, ...],
+) -> tuple[int, int, int, int, int, int, int]:
+    locator_offset = eocd_offset - _ZIP64_EOCD_LOCATOR_BYTES
+    if (
+        locator_offset < 0
+        or payload[locator_offset : locator_offset + 4]
+        != _ZIP64_END_OF_CENTRAL_DIRECTORY_LOCATOR
+    ):
+        _fail("pptx_invalid_zip64_directory")
+    try:
+        locator_disk, zip64_offset, total_disks = struct.unpack_from(
+            "<LQL", payload, locator_offset + 4
+        )
+    except struct.error:
+        _fail("pptx_invalid_zip64_directory")
+    if locator_disk != 0 or total_disks != 1:
+        _fail("pptx_multidisk_zip_unsupported")
+    if (
+        zip64_offset < 0
+        or zip64_offset + 12 > locator_offset
+        or payload[zip64_offset : zip64_offset + 4] != _ZIP64_END_OF_CENTRAL_DIRECTORY
+    ):
+        _fail("pptx_invalid_zip64_directory")
+    try:
+        record_size = struct.unpack_from("<Q", payload, zip64_offset + 4)[0]
+    except struct.error:
+        _fail("pptx_invalid_zip64_directory")
+    if (
+        record_size < _ZIP64_EOCD_MIN_SIZE
+        or zip64_offset + 12 + record_size != locator_offset
+    ):
+        _fail("pptx_invalid_zip64_directory")
+    try:
+        (
+            _version_made_by,
+            _version_needed,
+            disk_number,
+            central_disk,
+            disk_entries,
+            total_entries,
+            size,
+            offset,
+        ) = struct.unpack_from("<2H2L4Q", payload, zip64_offset + 12)
+    except struct.error:
+        _fail("pptx_invalid_zip64_directory")
+
+    (
+        legacy_disk,
+        legacy_central_disk,
+        legacy_disk_entries,
+        legacy_total_entries,
+        legacy_size,
+        legacy_offset,
+        _,
+    ) = legacy_fields
+    pairs = (
+        (legacy_disk, 0xFFFF, disk_number),
+        (legacy_central_disk, 0xFFFF, central_disk),
+        (legacy_disk_entries, 0xFFFF, disk_entries),
+        (legacy_total_entries, 0xFFFF, total_entries),
+        (legacy_size, 0xFFFFFFFF, size),
+        (legacy_offset, 0xFFFFFFFF, offset),
+    )
+    if any(legacy != sentinel and legacy != actual for legacy, sentinel, actual in pairs):
+        _fail("pptx_invalid_zip64_directory")
+    return (
+        disk_number,
+        central_disk,
+        disk_entries,
+        total_entries,
+        size,
+        offset,
+        zip64_offset,
+    )
+
+
+def _validate_central_directory(
+    payload: bytes,
+    *,
+    offset: int,
+    size: int,
+    expected_entries: int,
+) -> tuple[_CentralDirectoryEntry, ...]:
+    cursor = offset
+    end = offset + size
+    entries: list[_CentralDirectoryEntry] = []
+    while cursor < end:
+        if len(entries) >= _MAX_ZIP_MEMBERS:
+            _fail("pptx_member_count_limit", _PACKAGE_COMPLEXITY_USER_MESSAGE)
+        if (
+            cursor + _CENTRAL_DIRECTORY_HEADER_BYTES > end
+            or payload[cursor : cursor + 4] != _CENTRAL_DIRECTORY_HEADER
+        ):
+            _fail("pptx_invalid_central_directory")
+        try:
+            (
+                _version_made_by,
+                version_needed,
+                flags,
+                compression,
+                modified_time,
+                modified_date,
+                crc,
+                raw_compressed_size,
+                raw_uncompressed_size,
+                filename_length,
+                extra_length,
+                comment_length,
+                disk_start,
+                _internal_attributes,
+                _external_attributes,
+                raw_local_header_offset,
+            ) = struct.unpack_from(
+                "<6H3L5H2L", payload, cursor + 4
+            )
+        except struct.error:
+            _fail("pptx_invalid_central_directory")
+        record_end = (
+            cursor
+            + _CENTRAL_DIRECTORY_HEADER_BYTES
+            + filename_length
+            + extra_length
+            + comment_length
+        )
+        if record_end > end:
+            _fail("pptx_invalid_central_directory")
+        name_start = cursor + _CENTRAL_DIRECTORY_HEADER_BYTES
+        raw_name = payload[name_start : name_start + filename_length]
+        extra_start = name_start + filename_length
+        extra = payload[extra_start : extra_start + extra_length]
+        decoded_name = _decode_and_validate_zip_member_name(raw_name, flags=flags)
+        (
+            uncompressed_size,
+            compressed_size,
+            local_header_offset,
+            resolved_disk_start,
+        ) = _resolve_zip64_entry_fields(
+            extra,
+            uncompressed_size=raw_uncompressed_size,
+            compressed_size=raw_compressed_size,
+            local_header_offset=raw_local_header_offset,
+            disk_start=disk_start,
+            reason_code="pptx_invalid_central_directory",
+        )
+        if local_header_offset is None or resolved_disk_start is None:
+            _fail("pptx_invalid_central_directory")
+        if resolved_disk_start != 0:
+            _fail("pptx_multidisk_zip_unsupported")
+        if flags & 0x1:
+            _fail("pptx_encrypted_zip_member", _ENCRYPTED_USER_MESSAGE)
+        if compression not in _SUPPORTED_ZIP_COMPRESSION:
+            _fail("pptx_unsupported_zip_compression")
+        entries.append(
+            _CentralDirectoryEntry(
+                decoded_name=decoded_name,
+                raw_name=raw_name,
+                version_needed=version_needed,
+                flags=flags,
+                compression=compression,
+                modified_time=modified_time,
+                modified_date=modified_date,
+                crc=crc,
+                compressed_size=compressed_size,
+                uncompressed_size=uncompressed_size,
+                local_header_offset=local_header_offset,
+                uses_zip64_sizes=(
+                    raw_compressed_size == 0xFFFFFFFF
+                    or raw_uncompressed_size == 0xFFFFFFFF
+                ),
+            )
+        )
+        cursor = record_end
+    if cursor != end or len(entries) != expected_entries:
+        _fail("pptx_invalid_central_directory")
+    return tuple(entries)
+
+
+def _resolve_zip64_entry_fields(
+    extra: bytes,
+    *,
+    uncompressed_size: int,
+    compressed_size: int,
+    local_header_offset: int | None,
+    disk_start: int | None,
+    reason_code: str,
+) -> tuple[int, int, int | None, int | None]:
+    zip64_payload: bytes | None = None
+    cursor = 0
+    while cursor < len(extra):
+        if cursor + 4 > len(extra):
+            _fail(reason_code)
+        field_id, field_size = struct.unpack_from("<HH", extra, cursor)
+        cursor += 4
+        field_end = cursor + field_size
+        if field_end > len(extra):
+            _fail(reason_code)
+        if field_id == _ZIP64_EXTRA_FIELD_ID:
+            if zip64_payload is not None:
+                _fail(reason_code)
+            zip64_payload = extra[cursor:field_end]
+        cursor = field_end
+
+    required = (
+        uncompressed_size == 0xFFFFFFFF
+        or compressed_size == 0xFFFFFFFF
+        or local_header_offset == 0xFFFFFFFF
+        or disk_start == 0xFFFF
+    )
+    if not required:
+        return uncompressed_size, compressed_size, local_header_offset, disk_start
+    if zip64_payload is None:
+        _fail(reason_code)
+
+    value_offset = 0
+
+    def read_value(width: int) -> int:
+        nonlocal value_offset
+        if value_offset + width > len(zip64_payload):
+            _fail(reason_code)
+        format_code = "<Q" if width == 8 else "<L"
+        value = int(struct.unpack_from(format_code, zip64_payload, value_offset)[0])
+        value_offset += width
+        return value
+
+    if uncompressed_size == 0xFFFFFFFF:
+        uncompressed_size = read_value(8)
+    if compressed_size == 0xFFFFFFFF:
+        compressed_size = read_value(8)
+    if local_header_offset == 0xFFFFFFFF:
+        local_header_offset = read_value(8)
+    if disk_start == 0xFFFF:
+        disk_start = read_value(4)
+    return uncompressed_size, compressed_size, local_header_offset, disk_start
+
+
+def _validate_local_file_layout(
+    payload: bytes,
+    entries: tuple[_CentralDirectoryEntry, ...],
+    *,
+    central_directory_offset: int,
+) -> None:
+    ordered = sorted(entries, key=lambda entry: entry.local_header_offset)
+    if not ordered or ordered[0].local_header_offset != 0:
+        _fail("pptx_invalid_local_file_layout")
+    if len({entry.local_header_offset for entry in ordered}) != len(ordered):
+        _fail("pptx_invalid_local_file_layout")
+
+    for index, entry in enumerate(ordered):
+        offset = entry.local_header_offset
+        boundary = (
+            ordered[index + 1].local_header_offset
+            if index + 1 < len(ordered)
+            else central_directory_offset
+        )
+        if (
+            offset < 0
+            or offset + _LOCAL_FILE_HEADER_BYTES > boundary
+            or payload[offset : offset + 4] != _LOCAL_FILE_HEADER
+        ):
+            _fail("pptx_invalid_local_file_header")
+        try:
+            (
+                version_needed,
+                flags,
+                compression,
+                modified_time,
+                modified_date,
+                local_crc,
+                raw_compressed_size,
+                raw_uncompressed_size,
+                filename_length,
+                extra_length,
+            ) = struct.unpack_from("<5H3L2H", payload, offset + 4)
+        except struct.error:
+            _fail("pptx_invalid_local_file_header")
+        name_start = offset + _LOCAL_FILE_HEADER_BYTES
+        data_start = name_start + filename_length + extra_length
+        if data_start > boundary:
+            _fail("pptx_invalid_local_file_header")
+        raw_name = payload[name_start : name_start + filename_length]
+        extra = payload[name_start + filename_length : data_start]
+        _decode_and_validate_zip_member_name(raw_name, flags=flags)
+
+        if (
+            raw_name != entry.raw_name
+            or version_needed != entry.version_needed
+            or flags != entry.flags
+            or compression != entry.compression
+            or modified_time != entry.modified_time
+            or modified_date != entry.modified_date
+        ):
+            _fail("pptx_invalid_local_file_header")
+        if compression not in _SUPPORTED_ZIP_COMPRESSION:
+            _fail("pptx_unsupported_zip_compression")
+
+        uses_data_descriptor = bool(flags & 0x08)
+        local_uses_zip64_sizes = (
+            raw_compressed_size == 0xFFFFFFFF
+            or raw_uncompressed_size == 0xFFFFFFFF
+        )
+        if uses_data_descriptor:
+            (
+                local_uncompressed_size,
+                local_compressed_size,
+                _,
+                _,
+            ) = _resolve_zip64_entry_fields(
+                extra,
+                uncompressed_size=raw_uncompressed_size,
+                compressed_size=raw_compressed_size,
+                local_header_offset=None,
+                disk_start=None,
+                reason_code="pptx_invalid_local_file_header",
+            )
+            if local_crc not in {0, entry.crc}:
+                _fail("pptx_invalid_local_file_header")
+            if local_compressed_size not in {0, entry.compressed_size}:
+                _fail("pptx_invalid_local_file_header")
+            if local_uncompressed_size not in {0, entry.uncompressed_size}:
+                _fail("pptx_invalid_local_file_header")
+        else:
+            (
+                local_uncompressed_size,
+                local_compressed_size,
+                _,
+                _,
+            ) = _resolve_zip64_entry_fields(
+                extra,
+                uncompressed_size=raw_uncompressed_size,
+                compressed_size=raw_compressed_size,
+                local_header_offset=None,
+                disk_start=None,
+                reason_code="pptx_invalid_local_file_header",
+            )
+            if (
+                local_crc != entry.crc
+                or local_compressed_size != entry.compressed_size
+                or local_uncompressed_size != entry.uncompressed_size
+            ):
+                _fail("pptx_invalid_local_file_header")
+
+        data_end = data_start + entry.compressed_size
+        if data_end > boundary:
+            _fail("pptx_invalid_local_file_layout")
+        if uses_data_descriptor:
+            _validate_data_descriptor(
+                payload[data_end:boundary],
+                entry,
+                uses_zip64=entry.uses_zip64_sizes or local_uses_zip64_sizes,
+            )
+        elif data_end != boundary:
+            _fail("pptx_invalid_local_file_layout")
+
+
+def _validate_data_descriptor(
+    descriptor: bytes,
+    entry: _CentralDirectoryEntry,
+    *,
+    uses_zip64: bool,
+) -> None:
+    expected_payload_size = 20 if uses_zip64 else 12
+    if len(descriptor) == expected_payload_size:
+        signature_bytes = 0
+    elif (
+        len(descriptor) == expected_payload_size + 4
+        and descriptor.startswith(_DATA_DESCRIPTOR_SIGNATURE)
+    ):
+        signature_bytes = 4
+    else:
+        _fail("pptx_invalid_data_descriptor")
+    cursor = signature_bytes
+    try:
+        crc = struct.unpack_from("<L", descriptor, cursor)[0]
+        cursor += 4
+        if uses_zip64:
+            compressed_size, uncompressed_size = struct.unpack_from("<QQ", descriptor, cursor)
+        else:
+            compressed_size, uncompressed_size = struct.unpack_from("<LL", descriptor, cursor)
+    except struct.error:
+        _fail("pptx_invalid_data_descriptor")
+    if (
+        crc != entry.crc
+        or compressed_size != entry.compressed_size
+        or uncompressed_size != entry.uncompressed_size
+    ):
+        _fail("pptx_invalid_data_descriptor")
+
+
+def _validate_zip_members(
+    archive: zipfile.ZipFile,
+    infos: list[zipfile.ZipInfo],
+    central_entries: tuple[_CentralDirectoryEntry, ...],
+) -> _PackageParts:
+    names: set[str] = set()
+    parts_by_key: dict[str, str] = {}
+    total = 0
+    for info, central_entry in zip(infos, central_entries, strict=True):
+        name = info.filename
+        if (
+            name != central_entry.decoded_name
+            or info.header_offset != central_entry.local_header_offset
+            or info.flag_bits != central_entry.flags
+            or info.compress_type != central_entry.compression
+            or info.CRC != central_entry.crc
+            or info.compress_size != central_entry.compressed_size
+            or info.file_size != central_entry.uncompressed_size
+        ):
+            _fail("pptx_invalid_central_directory")
+        if name in names:
+            _fail("pptx_duplicate_zip_member")
+        _validate_member_name(name)
+        names.add(name)
+        part_key = _canonical_part_key(name)
+        if part_key in parts_by_key:
+            _fail("pptx_duplicate_zip_member")
+        parts_by_key[part_key] = name
+        if info.flag_bits & 0x1:
+            _fail("pptx_encrypted_zip_member", _ENCRYPTED_USER_MESSAGE)
+        if info.compress_type not in _SUPPORTED_ZIP_COMPRESSION:
+            _fail("pptx_unsupported_zip_compression")
+
+        with archive.open(info, "r") as member:
+            while True:
+                block = member.read(_READ_CHUNK_BYTES)
+                if not block:
+                    break
+                total += len(block)
+                if total > _MAX_INFLATED_BYTES:
+                    _fail("pptx_inflated_size_limit", _INFLATED_LIMIT_USER_MESSAGE)
+    return _PackageParts(by_key=parts_by_key, case_fallback_names={})
+
+
+def _validate_member_name(name: str) -> None:
+    if (
+        not name
+        or "\\" in name
+        or name.startswith("/")
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in name)
+    ):
+        _fail("pptx_invalid_zip_member_name")
+    _validate_percent_encoding(name, reason_code="pptx_invalid_zip_member_name")
+    segments = name.split("/")
+    for index, segment in enumerate(segments):
+        if segment == "" and index == len(segments) - 1:
+            continue
+        if segment in {"", ".", ".."} or segment.endswith("."):
+            _fail("pptx_invalid_zip_member_name")
+
+
+def _decode_and_validate_zip_member_name(raw_name: bytes, *, flags: int) -> str:
+    if not raw_name or any(byte < 0x20 or byte == 0x7F for byte in raw_name):
+        _fail("pptx_invalid_zip_member_name")
+    encoding = "utf-8" if flags & 0x800 else "cp437"
+    try:
+        name = raw_name.decode(encoding, errors="strict")
+    except UnicodeDecodeError:
+        _fail("pptx_invalid_zip_member_name")
+    _validate_member_name(name)
+    return name
+
+
+def _validate_percent_encoding(value: str, *, reason_code: str) -> None:
+    cursor = 0
+    while cursor < len(value):
+        character = value[cursor]
+        if character != "%":
+            if character.isspace():
+                _fail(reason_code)
+            cursor += 1
+            continue
+        if (
+            cursor + 2 >= len(value)
+            or value[cursor + 1] not in _ASCII_HEX_DIGITS
+            or value[cursor + 2] not in _ASCII_HEX_DIGITS
+        ):
+            _fail(reason_code)
+        encoded = int(value[cursor + 1 : cursor + 3], 16)
+        if (
+            encoded in _ASCII_UNRESERVED_BYTES
+            or encoded < 0x20
+            or encoded == 0x7F
+            or encoded in {ord("/"), ord("\\")}
+        ):
+            _fail(reason_code)
+        cursor += 3
+
+
+def _parse_content_types(
+    archive: zipfile.ZipFile,
+    parts: _PackageParts,
+) -> _ContentTypes:
+    root = _read_xml(
+        archive,
+        parts,
+        _CONTENT_TYPES_PART,
+        missing_reason="pptx_missing_content_types",
+    )
+    namespace, local_name = _split_qname(root.tag)
+    if local_name != "Types" or namespace not in _CONTENT_TYPES_NAMESPACES:
+        _fail("pptx_invalid_content_types")
+
+    defaults: dict[str, str] = {}
+    overrides: dict[str, str] = {}
+    for child in root:
+        child_namespace, child_name = _split_qname(child.tag)
+        if child_namespace != namespace:
+            continue
+        if child_name == "Default":
+            extension = child.get("Extension", "").strip().casefold()
+            content_type = child.get("ContentType", "").strip()
+            if not extension or not content_type or extension in defaults:
+                _fail("pptx_invalid_content_types")
+            defaults[extension] = content_type
+        elif child_name == "Override":
+            raw_part_name = child.get("PartName", "").strip()
+            content_type = child.get("ContentType", "").strip()
+            if not raw_part_name or not content_type:
+                _fail("pptx_invalid_content_types")
+            part_name = _normalise_part_name(raw_part_name)
+            part_key = _canonical_part_key(part_name)
+            if part_key in overrides:
+                _fail("pptx_invalid_content_types")
+            overrides[part_key] = content_type
+    return _ContentTypes(defaults=defaults, overrides=overrides)
+
+
+def _parse_relationships(
+    archive: zipfile.ZipFile,
+    parts: _PackageParts,
+    part_name: str,
+    *,
+    missing_reason: str,
+) -> dict[str, _Relationship]:
+    root = _read_xml(archive, parts, part_name, missing_reason=missing_reason)
+    namespace, local_name = _split_qname(root.tag)
+    if local_name != "Relationships" or namespace not in _PACKAGE_RELATIONSHIP_NAMESPACES:
+        _fail("pptx_invalid_relationships")
+
+    relationships: dict[str, _Relationship] = {}
+    for child in root:
+        child_namespace, child_name = _split_qname(child.tag)
+        if child_namespace != namespace or child_name != "Relationship":
+            continue
+        relationship_id = child.get("Id", "").strip()
+        relationship_type = child.get("Type", "").strip()
+        target = child.get("Target", "").strip()
+        target_mode = child.get("TargetMode")
+        if target_mode is not None:
+            target_mode = target_mode.strip()
+        if (
+            not relationship_id
+            or not relationship_type
+            or not target
+            or relationship_id in relationships
+            or target_mode not in {None, "Internal", "External"}
+        ):
+            _fail("pptx_invalid_relationships")
+        relationships[relationship_id] = _Relationship(
+            relationship_id=relationship_id,
+            relationship_type=relationship_type,
+            target=target,
+            target_mode=target_mode,
+        )
+    return relationships
+
+
+def _validate_presentation(
+    archive: zipfile.ZipFile,
+    parts: _PackageParts,
+    content_types: _ContentTypes,
+    presentation_part: str,
+    *,
+    is_strict: bool,
+) -> bool:
+    root = _read_xml(
+        archive,
+        parts,
+        presentation_part,
+        missing_reason="pptx_missing_presentation_part",
+    )
+    presentation_ns = _STRICT_PRESENTATION_NS if is_strict else _TRANSITIONAL_PRESENTATION_NS
+    relationship_ns = _STRICT_RELATIONSHIP_NS if is_strict else _TRANSITIONAL_RELATIONSHIP_NS
+    if root.tag != f"{{{presentation_ns}}}presentation":
+        _fail("pptx_invalid_presentation_xml")
+
+    slide_ids = root.findall(f"{{{presentation_ns}}}sldIdLst/{{{presentation_ns}}}sldId")
+    if not slide_ids:
+        return False
+
+    relationships_part = _relationships_part_name(presentation_part)
+    relationships = _parse_relationships(
+        archive,
+        parts,
+        relationships_part,
+        missing_reason="pptx_missing_presentation_relationships",
+    )
+    expected_slide_type = f"{relationship_ns}/slide"
+    seen_relationship_ids: set[str] = set()
+    seen_slide_ids: set[int] = set()
+    seen_slide_parts: set[str] = set()
+    parser_case_compatibility = parts.reference_requires_case_fallback(relationships_part)
+
+    for slide_id in slide_ids:
+        # ST_SlideId restricts XSD 1.0 unsignedInt: whitespace collapses, then only
+        # ASCII decimal digits (without a sign) are in its lexical space.
+        raw_slide_id = slide_id.get("id", "").strip(" \t\r\n")
+        if not raw_slide_id or any(character not in "0123456789" for character in raw_slide_id):
+            _fail("pptx_invalid_slide_id")
+        numeric_slide_id = int(raw_slide_id, 10)
+        if not 256 <= numeric_slide_id <= 2_147_483_647:
+            _fail("pptx_invalid_slide_id")
+        if numeric_slide_id in seen_slide_ids:
+            _fail("pptx_duplicate_slide_id")
+        seen_slide_ids.add(numeric_slide_id)
+
+        relationship_id = slide_id.get(f"{{{relationship_ns}}}id", "").strip()
+        if not relationship_id or relationship_id in seen_relationship_ids:
+            _fail("pptx_invalid_slide_reference")
+        seen_relationship_ids.add(relationship_id)
+
+        relationship = relationships.get(relationship_id)
+        if relationship is None or relationship.relationship_type != expected_slide_type:
+            _fail("pptx_invalid_slide_reference")
+        if relationship.target_mode == "External":
+            _fail("pptx_external_slide_part")
+
+        slide_part = _resolve_relationship_target(
+            source_part=presentation_part,
+            target=relationship.target,
+        )
+        slide_part_key = _canonical_part_key(slide_part)
+        if slide_part_key in seen_slide_parts:
+            _fail("pptx_duplicate_slide_part")
+        seen_slide_parts.add(slide_part_key)
+        if not parts.contains(slide_part):
+            _fail("pptx_missing_slide_part")
+        slide_case_fallback = parts.reference_requires_case_fallback(slide_part)
+        parser_case_compatibility = slide_case_fallback or parser_case_compatibility
+        slide_content_type = content_types.for_part(slide_part)
+        if (
+            slide_content_type is None
+            or slide_content_type.casefold() != _SLIDE_CONTENT_TYPE.casefold()
+        ):
+            _fail("pptx_invalid_slide_content_type")
+        parser_case_compatibility = (
+            parser_case_compatibility or slide_content_type != _SLIDE_CONTENT_TYPE
+        )
+        slide_root = _read_xml(
+            archive,
+            parts,
+            slide_part,
+            missing_reason="pptx_missing_slide_part",
+        )
+        if slide_root.tag != f"{{{presentation_ns}}}sld":
+            _fail("pptx_invalid_slide_xml")
+    return parser_case_compatibility
+
+
+def _validate_reachable_relationship_targets(
+    archive: zipfile.ZipFile,
+    parts: _PackageParts,
+    content_types: _ContentTypes,
+    root_relationships: dict[str, _Relationship],
+    *,
+    presentation_part: str,
+) -> bool:
+    """Preflight every reachable internal relationship without fetching external targets."""
+
+    pending = [presentation_part]
+    seen: set[str] = set()
+    parser_case_compatibility = False
+
+    def enqueue_internal_target(
+        source_part: str | None,
+        relationship: _Relationship,
+    ) -> None:
+        nonlocal parser_case_compatibility
+        if relationship.target_mode == "External":
+            return
+        target_part = _resolve_relationship_target(
+            source_part=source_part,
+            target=relationship.target,
+            allow_fragment=True,
+        )
+        if not parts.contains(target_part):
+            _fail("pptx_missing_related_part")
+        # Relationships parts are discovered by their source-part convention;
+        # OPC does not permit another Relationship to target one directly.
+        if _is_relationship_part_name(target_part):
+            _fail("pptx_relationship_targets_relationship_part")
+        if content_types.for_part(target_part) is None:
+            _fail("pptx_missing_related_content_type")
+        target_case_fallback = parts.reference_requires_case_fallback(target_part)
+        parser_case_compatibility = target_case_fallback or parser_case_compatibility
+        if _canonical_part_key(target_part) not in seen:
+            pending.append(target_part)
+
+    for relationship in root_relationships.values():
+        enqueue_internal_target(None, relationship)
+
+    while pending:
+        source_part = pending.pop()
+        source_key = _canonical_part_key(source_part)
+        if source_key in seen:
+            continue
+        seen.add(source_key)
+        relationships_part = _relationships_part_name(source_part)
+        if not parts.contains(relationships_part):
+            continue
+        relationships_case_fallback = parts.reference_requires_case_fallback(relationships_part)
+        parser_case_compatibility = relationships_case_fallback or parser_case_compatibility
+        relationships = _parse_relationships(
+            archive,
+            parts,
+            relationships_part,
+            missing_reason="pptx_missing_related_part",
+        )
+        for relationship in relationships.values():
+            enqueue_internal_target(source_part, relationship)
+    return parser_case_compatibility
+
+
+def _read_xml(
+    archive: zipfile.ZipFile,
+    parts: _PackageParts,
+    part_name: str,
+    *,
+    missing_reason: str,
+) -> ET.Element:
+    if not parts.contains(part_name):
+        _fail(missing_reason)
+    with archive.open(parts.physical_name(part_name), "r") as member:
+        payload = member.read(_MAX_CORE_XML_BYTES + 1)
+    if len(payload) > _MAX_CORE_XML_BYTES:
+        _fail("pptx_core_xml_size_limit", _PACKAGE_COMPLEXITY_USER_MESSAGE)
+    try:
+        _reject_unsafe_xml_declarations(payload)
+    except _UnsafeXmlDeclarationError:
+        _fail("pptx_unsafe_xml_declaration")
+    except expat.ExpatError:
+        _fail("pptx_invalid_xml")
+    try:
+        return ET.fromstring(payload)
+    except (ET.ParseError, UnicodeError, ValueError):
+        _fail("pptx_invalid_xml")
+
+
+def _reject_unsafe_xml_declarations(payload: bytes) -> None:
+    parser = expat.ParserCreate()
+
+    def reject(*_args: object) -> None:
+        raise _UnsafeXmlDeclarationError
+
+    def reject_external(*_args: object) -> int:
+        raise _UnsafeXmlDeclarationError
+
+    parser.StartDoctypeDeclHandler = reject
+    parser.EntityDeclHandler = reject
+    parser.ExternalEntityRefHandler = reject_external
+    parser.Parse(payload, True)
+
+
+def _normalise_part_name(raw_part_name: str) -> str:
+    if (
+        not raw_part_name.startswith("/")
+        or raw_part_name.startswith("//")
+        or "\\" in raw_part_name
+        or any(
+            ord(character) < 0x20 or ord(character) == 0x7F
+            for character in raw_part_name
+        )
+    ):
+        _fail("pptx_invalid_part_name")
+    try:
+        parsed = urlsplit(raw_part_name)
+    except (UnicodeError, ValueError):
+        _fail("pptx_invalid_part_name")
+    if (
+        parsed.scheme
+        or parsed.netloc
+        or parsed.query
+        or parsed.fragment
+    ):
+        _fail("pptx_invalid_part_name")
+    part_name = parsed.path[1:]
+    if not part_name or part_name.endswith("/"):
+        _fail("pptx_invalid_part_name")
+    _validate_percent_encoding(part_name, reason_code="pptx_invalid_part_name")
+    if any(
+        segment in {"", ".", ".."} or segment.endswith(".")
+        for segment in part_name.split("/")
+    ):
+        _fail("pptx_invalid_part_name")
+    return part_name
+
+
+def _resolve_relationship_target(
+    *,
+    source_part: str | None,
+    target: str,
+    allow_fragment: bool = False,
+) -> str:
+    _validate_uri_reference_text(target)
+    try:
+        parsed = urlsplit(target)
+    except (UnicodeError, ValueError):
+        _fail("pptx_invalid_relationship_target")
+    if (
+        parsed.scheme
+        or parsed.netloc
+        or parsed.query
+        or (parsed.fragment and not allow_fragment)
+    ):
+        _fail("pptx_invalid_relationship_target")
+    raw_path = parsed.path
+    if not raw_path and allow_fragment and parsed.fragment and source_part is not None:
+        return _normalise_package_path(source_part, base_parts=[])
+    if raw_path.startswith("/"):
+        base_parts: list[str] = []
+    elif source_part is None:
+        base_parts = []
+    else:
+        base_parts = [part for part in posixpath.dirname(source_part).split("/") if part]
+    return _normalise_package_path(raw_path, base_parts=base_parts)
+
+
+def _normalise_package_path(raw_path: str, *, base_parts: list[str]) -> str:
+    if (
+        not raw_path
+        or "\\" in raw_path
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in raw_path)
+    ):
+        _fail("pptx_invalid_package_path")
+    _validate_percent_encoding(raw_path, reason_code="pptx_invalid_package_path")
+    stack = list(base_parts)
+    for segment in raw_path.split("/"):
+        if segment in {"", "."}:
+            continue
+        if segment == "..":
+            if not stack:
+                _fail("pptx_package_path_escape")
+            stack.pop()
+        else:
+            if segment.endswith("."):
+                _fail("pptx_invalid_package_path")
+            stack.append(segment)
+    if not stack:
+        _fail("pptx_invalid_package_path")
+    return "/".join(stack)
+
+
+def _validate_uri_reference_text(value: str) -> None:
+    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in value):
+        _fail("pptx_invalid_package_path")
+
+
+def _canonical_part_key(part_name: str) -> str:
+    """Return the ASCII case-insensitive OPC equivalence key for a part name."""
+
+    normalised = _normalise_package_path(part_name, base_parts=[])
+    return normalised.translate(_ASCII_LOWER_TRANSLATION)
+
+
+def _relationships_part_name(part_name: str) -> str:
+    parent, filename = posixpath.split(part_name)
+    return posixpath.join(parent, "_rels", f"{filename}.rels")
+
+
+def _is_relationship_part_name(part_name: str) -> bool:
+    """Return whether an OPC part name has the reserved Relationships-part shape."""
+
+    normalised = _normalise_package_path(part_name, base_parts=[])
+    segments = [segment.translate(_ASCII_LOWER_TRANSLATION) for segment in normalised.split("/")]
+    if segments == ["_rels", ".rels"]:
+        return True
+    return (
+        len(segments) >= 2
+        and segments[-2] == "_rels"
+        and segments[-1].endswith(".rels")
+        and segments[-1] != ".rels"
+    )
+
+
+def _split_qname(tag: str) -> tuple[str, str]:
+    if not tag.startswith("{") or "}" not in tag:
+        return "", tag
+    namespace, local_name = tag[1:].split("}", 1)
+    return namespace, local_name
+
+
+def _python_pptx_smoke_test(
+    payload: bytes,
+    *,
+    allow_opc_case_compatibility: bool = False,
+    case_fallback_names: dict[str, str] | None = None,
+) -> ArtifactValidationReport:
+    try:
+        from pptx import Presentation
+        from pptx.exc import InvalidXmlError, PackageNotFoundError
+    except ImportError:
+        _fail("pptx_parser_unavailable")
+
+    def load(candidate: bytes) -> None:
+        presentation = Presentation(io.BytesIO(candidate))
+        for slide in presentation.slides:
+            len(slide.shapes)
+
+    try:
+        load(payload)
+    except MemoryError:
+        raise
+    except (NotImplementedError, AttributeError, TypeError):
+        return ArtifactValidationReport(warnings=("pptx_parser_compatibility_warning",))
+    except (PackageNotFoundError, KeyError, ValueError):
+        if not allow_opc_case_compatibility:
+            _fail("pptx_parser_structural_failure")
+        compatibility_payload = _normalise_opc_case_for_parser(
+            payload,
+            case_fallback_names or {},
+        )
+        try:
+            load(compatibility_payload)
+        except MemoryError:
+            raise
+        except (NotImplementedError, AttributeError, TypeError):
+            return ArtifactValidationReport(warnings=("pptx_parser_compatibility_warning",))
+        except (
+            PackageNotFoundError,
+            KeyError,
+            ValueError,
+            InvalidXmlError,
+            OSError,
+            EOFError,
+            zipfile.BadZipFile,
+            SyntaxError,
+        ):
+            _fail("pptx_parser_structural_failure")
+        except Exception:  # noqa: BLE001 - unknown parser incompatibilities remain soft
+            return ArtifactValidationReport(warnings=("pptx_parser_compatibility_warning",))
+        return ArtifactValidationReport(warnings=("pptx_opc_case_compatibility_warning",))
+    except (
+        InvalidXmlError,
+        OSError,
+        EOFError,
+        zipfile.BadZipFile,
+        SyntaxError,
+    ):
+        _fail("pptx_parser_structural_failure")
+    except Exception:  # noqa: BLE001 - unknown parser incompatibilities are soft by contract
+        return ArtifactValidationReport(warnings=("pptx_parser_compatibility_warning",))
+    if allow_opc_case_compatibility:
+        return ArtifactValidationReport(warnings=("pptx_opc_case_compatibility_warning",))
+    return ArtifactValidationReport()
+
+
+def _normalise_opc_case_for_parser(
+    payload: bytes,
+    case_fallback_names: dict[str, str],
+) -> bytes:
+    """Create an in-memory parser probe with only proven OPC case mismatches repaired."""
+
+    output = io.BytesIO()
+    with (
+        zipfile.ZipFile(io.BytesIO(payload), "r") as source,
+        zipfile.ZipFile(output, "w") as destination,
+    ):
+        for info in source.infolist():
+            member_payload = source.read(info)
+            destination_name = case_fallback_names.get(info.filename, info.filename)
+            if _canonical_part_key(info.filename) == _canonical_part_key(_CONTENT_TYPES_PART):
+                root = ET.fromstring(member_payload)
+                for child in root:
+                    content_type = child.get("ContentType")
+                    if content_type is None:
+                        continue
+                    folded_content_type = content_type.casefold()
+                    if folded_content_type == _PRESENTATION_CONTENT_TYPE.casefold():
+                        child.set("ContentType", _PRESENTATION_CONTENT_TYPE)
+                    elif folded_content_type == _SLIDE_CONTENT_TYPE.casefold():
+                        child.set("ContentType", _SLIDE_CONTENT_TYPE)
+                member_payload = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+            destination.writestr(
+                destination_name,
+                member_payload,
+                compress_type=info.compress_type,
+            )
+    return output.getvalue()
+
+
+def _fail(reason_code: str, user_message: str = _GENERIC_USER_MESSAGE) -> Never:
+    raise ArtifactValidationError(reason_code, user_message)

--- a/src/opensquilla/engine/artifact_delivery.py
+++ b/src/opensquilla/engine/artifact_delivery.py
@@ -4,20 +4,28 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 
+from opensquilla.artifact_validation import (
+    ArtifactValidationError,
+    is_pptx_candidate,
+    validate_artifact_for_delivery,
+)
 from opensquilla.artifacts import (
     DEFAULT_ARTIFACT_DISK_BUDGET_BYTES,
     DEFAULT_ARTIFACT_MAX_BYTES,
     INSTALLER_ARTIFACT_SUFFIXES,
     ArtifactBudgetError,
     ArtifactStore,
+    _safe_filename,
     artifact_mime_for_name,
     artifact_payload,
     artifact_publish_max_bytes_for_name,
 )
+from opensquilla.tools.path_aliases import resolve_workspace_alias
 from opensquilla.tools.types import ToolContext
 
 log = logging.getLogger(__name__)
@@ -42,6 +50,60 @@ _EXCLUDED_TOP_LEVEL_DIRS = frozenset({".claude", ".codex", ".omx", "memory"})
 class OmittedArtifactPublishResult:
     artifacts: list[dict[str, Any]] = field(default_factory=list)
     failure_summaries: list[str] = field(default_factory=list)
+    resolved_target_keys: list[str] = field(default_factory=list)
+
+
+def artifact_delivery_publish_target_key(
+    raw_target: str,
+    *,
+    workspace_dir: str | os.PathLike[str] | None,
+) -> str | None:
+    """Return the canonical identity used for workspace artifact delivery.
+
+    Match ``publish_artifact`` for accepted path forms, while best-effort mapping
+    a rejected foreign-platform sandbox spelling to the same corrected retry.
+    An absolute identity also prevents an auto-published nested file from
+    resolving a different same-named root file.
+    """
+
+    if not isinstance(raw_target, str) or not raw_target:
+        return None
+    try:
+        raw_path = Path(raw_target)
+        if workspace_dir is None:
+            normalized = os.path.normcase(os.path.normpath(str(raw_path)))
+        else:
+            workspace = Path(workspace_dir).resolve(strict=False)
+            alias_target = resolve_workspace_alias(raw_path, workspace)
+            if alias_target is None and not raw_path.is_absolute():
+                # A model can echo the sandbox path using the other platform's
+                # separators (for example ``C:\\workspace\\...`` on a POSIX
+                # gateway). The real publish tool may reject that foreign host
+                # spelling, but delivery-failure identity should still match a
+                # corrected retry for the same workspace-relative tail.
+                for foreign_path in (
+                    PureWindowsPath(raw_target),
+                    PurePosixPath(raw_target),
+                ):
+                    alias_target = resolve_workspace_alias(foreign_path, workspace)
+                    if alias_target is not None:
+                        break
+            target = (
+                alias_target
+                or (raw_path if raw_path.is_absolute() else workspace / raw_path)
+            ).resolve(strict=False)
+            normalized = os.path.normcase(os.path.normpath(str(target)))
+    except (OSError, RuntimeError, ValueError):
+        # Delivery notices are a best-effort backstop. A malformed model path
+        # must never turn a tool error into a stream-consumer failure.
+        return None
+    return f"path:{normalized}"
+
+
+def artifact_delivery_name_target_key(name: str) -> str:
+    """Return the ArtifactStore-canonical public-name delivery identity."""
+
+    return f"name:{_safe_filename(name)}"
 
 
 def _text_mentions_written_file(final_text: str, record: dict[str, Any]) -> bool:
@@ -56,7 +118,10 @@ def _text_mentions_written_file(final_text: str, record: dict[str, Any]) -> bool
 
 def _published_artifact_keys(ctx: ToolContext) -> set[tuple[str, str]]:
     return {
-        (str(artifact.get("sha256")), str(artifact.get("name")))
+        (
+            str(artifact.get("sha256")),
+            _safe_filename(str(artifact.get("name"))),
+        )
         for artifact in ctx.published_artifacts
         if artifact.get("sha256") and artifact.get("name")
     }
@@ -92,6 +157,7 @@ def auto_publish_omitted_workspace_artifacts(
     store = ArtifactStore(ctx.artifact_media_root)
     published: list[dict[str, Any]] = []
     failure_summaries: list[str] = []
+    resolved_target_keys: list[str] = []
     seen_paths: set[Path] = set()
     known_artifact_keys = _published_artifact_keys(ctx)
 
@@ -119,11 +185,58 @@ def auto_publish_omitted_workspace_artifacts(
             continue
 
         try:
-            target_sha256 = hashlib.sha256(target.read_bytes()).hexdigest()
-            artifact_key = (target_sha256, target.name)
-            if artifact_key in known_artifact_keys:
-                continue
             artifact_mime = artifact_mime_for_name(target.name)
+            publish_max_bytes = artifact_publish_max_bytes_for_name(
+                target.name,
+                ctx.artifact_max_bytes
+                if ctx.artifact_max_bytes is not None
+                else DEFAULT_ARTIFACT_MAX_BYTES,
+            )
+            pptx_payload: bytes | None = None
+            target_is_pptx = is_pptx_candidate(
+                source_name=target.name,
+                name=target.name,
+                mime=artifact_mime,
+            )
+            if target_is_pptx:
+                target_size = target.stat().st_size
+                if publish_max_bytes is not None and target_size > publish_max_bytes:
+                    raise ArtifactBudgetError(
+                        "artifact exceeds per-file budget "
+                        f"({target_size} > {publish_max_bytes})"
+                    )
+                pptx_payload = target.read_bytes()
+                try:
+                    validate_artifact_for_delivery(
+                        pptx_payload,
+                        source_name=target.name,
+                        name=target.name,
+                        mime=artifact_mime,
+                        source="auto_publish_omitted",
+                    )
+                except ArtifactValidationError as exc:
+                    failure_summaries.append(
+                        f"auto-publish rejected {target.name}: {exc.user_message}"
+                    )
+                    continue
+
+            target_sha256 = hashlib.sha256(
+                pptx_payload if pptx_payload is not None else target.read_bytes()
+            ).hexdigest()
+            artifact_key = (target_sha256, _safe_filename(target.name))
+            target_key = artifact_delivery_publish_target_key(
+                str(target),
+                workspace_dir=workspace,
+            )
+            name_key = artifact_delivery_name_target_key(target.name)
+            if artifact_key in known_artifact_keys:
+                for resolved_key in (target_key, name_key):
+                    if (
+                        resolved_key is not None
+                        and resolved_key not in resolved_target_keys
+                    ):
+                        resolved_target_keys.append(resolved_key)
+                continue
             existing = store.find_existing_ref(
                 session_id=ctx.artifact_session_id,
                 session_key=ctx.session_key,
@@ -131,29 +244,53 @@ def auto_publish_omitted_workspace_artifacts(
                 name=target.name,
                 mime=artifact_mime,
             )
+            if existing is not None and any(
+                item.get("id") == existing.id for item in ctx.published_artifacts
+            ):
+                for resolved_key in (target_key, name_key):
+                    if (
+                        resolved_key is not None
+                        and resolved_key not in resolved_target_keys
+                    ):
+                        resolved_target_keys.append(resolved_key)
+                known_artifact_keys.add(artifact_key)
+                continue
             if existing is None:
-                ref = store.publish_file(
-                    target,
-                    session_id=ctx.artifact_session_id,
-                    session_key=ctx.session_key,
-                    name=target.name,
-                    mime=artifact_mime,
-                    source="auto_publish_omitted",
-                    max_bytes=artifact_publish_max_bytes_for_name(
-                        target.name,
-                        ctx.artifact_max_bytes
-                        if ctx.artifact_max_bytes is not None
-                        else DEFAULT_ARTIFACT_MAX_BYTES,
-                    ),
-                    disk_budget_bytes=ctx.artifact_disk_budget_bytes
+                disk_budget_bytes = (
+                    ctx.artifact_disk_budget_bytes
                     if ctx.artifact_disk_budget_bytes is not None
-                    else DEFAULT_ARTIFACT_DISK_BUDGET_BYTES,
+                    else DEFAULT_ARTIFACT_DISK_BUDGET_BYTES
                 )
+                if pptx_payload is not None:
+                    ref = store.publish_bytes(
+                        pptx_payload,
+                        session_id=ctx.artifact_session_id,
+                        session_key=ctx.session_key,
+                        name=target.name,
+                        mime=artifact_mime,
+                        source="auto_publish_omitted",
+                        max_bytes=publish_max_bytes,
+                        disk_budget_bytes=disk_budget_bytes,
+                    )
+                else:
+                    ref = store.publish_file(
+                        target,
+                        session_id=ctx.artifact_session_id,
+                        session_key=ctx.session_key,
+                        name=target.name,
+                        mime=artifact_mime,
+                        source="auto_publish_omitted",
+                        max_bytes=publish_max_bytes,
+                        disk_budget_bytes=disk_budget_bytes,
+                    )
             else:
                 ref = existing
             payload = artifact_payload(ref)
             ctx.published_artifacts.append(payload)
             published.append(payload)
+            for resolved_key in (target_key, name_key):
+                if resolved_key is not None and resolved_key not in resolved_target_keys:
+                    resolved_target_keys.append(resolved_key)
             known_artifact_keys.add(artifact_key)
         except (ArtifactBudgetError, OSError, ValueError) as exc:
             failure_summaries.append(f"auto-publish failed for {target.name}: {exc}")
@@ -165,4 +302,5 @@ def auto_publish_omitted_workspace_artifacts(
     return OmittedArtifactPublishResult(
         artifacts=published,
         failure_summaries=failure_summaries,
+        resolved_target_keys=resolved_target_keys,
     )

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -273,7 +273,9 @@ _T3_FLUSH_FAILED: Final[str] = "flush_failed"
 _T3_COMPACT_FAILED: Final[str] = "compact_failed"
 _IMAGE_GENERATION_TOOL_NAMES: Final[frozenset[str]] = frozenset({"image_generate"})
 _ARTIFACT_DELIVERY_FAILURE_MARKER: Final[str] = "File delivery failed:"
-_ARTIFACT_DELIVERY_TOOL_NAME: Final[str] = "publish_artifact"
+_ARTIFACT_DELIVERY_TOOL_NAMES: Final[frozenset[str]] = frozenset(
+    {"publish_artifact", "create_pptx"}
+)
 _ARTIFACT_DELIVERY_FAILURE_MAX_CHARS: Final[int] = 360
 _HOOKS_FEATURE_ENV: Final[str] = "OPENSQUILLA_HOOKS"
 
@@ -1115,7 +1117,7 @@ def _persisted_tool_result_segment(
 
 
 def _artifact_delivery_failure_summary(event: ToolResultEvent) -> str | None:
-    if event.tool_name != _ARTIFACT_DELIVERY_TOOL_NAME or not event.is_error:
+    if event.tool_name not in _ARTIFACT_DELIVERY_TOOL_NAMES or not event.is_error:
         return None
     raw = event.result.strip()
     summary = raw
@@ -1135,20 +1137,121 @@ def _artifact_delivery_failure_summary(event: ToolResultEvent) -> str | None:
     summary = " ".join(summary.split())
     if len(summary) > _ARTIFACT_DELIVERY_FAILURE_MAX_CHARS:
         summary = summary[: _ARTIFACT_DELIVERY_FAILURE_MAX_CHARS - 3].rstrip() + "..."
-    return summary or "publish_artifact failed"
+    return summary or f"{event.tool_name} failed"
 
+
+def _artifact_delivery_result_name(event: ToolResultEvent) -> str | None:
+    try:
+        parsed = json.loads(event.result)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    artifact = parsed.get("artifact")
+    if not isinstance(artifact, dict):
+        return None
+    name = artifact.get("name")
+    return name if isinstance(name, str) and name else None
+
+
+def _artifact_delivery_effective_publish_name(
+    arguments: dict[str, Any],
+    raw_target: str,
+) -> str | None:
+    """Mirror publish_artifact's effective public filename calculation."""
+
+    try:
+        target_name = Path(raw_target).name
+        raw_name = arguments.get("name")
+        requested_name = raw_name if isinstance(raw_name, str) else None
+        artifact_name = (requested_name or target_name).strip() or target_name
+        if (
+            requested_name
+            and not Path(artifact_name).suffix
+            and Path(target_name).suffix
+        ):
+            artifact_name = f"{artifact_name}{Path(target_name).suffix}"
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return artifact_name or None
+
+
+def _artifact_delivery_target_keys(
+    event: ToolResultEvent,
+    *,
+    tool_context: ToolContext | None = None,
+    include_publish_name: bool = False,
+) -> tuple[str, ...]:
+    if event.tool_name not in _ARTIFACT_DELIVERY_TOOL_NAMES:
+        return ()
+    arguments = event.arguments if isinstance(event.arguments, dict) else {}
+    from opensquilla.engine.artifact_delivery import (
+        artifact_delivery_name_target_key,
+        artifact_delivery_publish_target_key,
+    )
+
+    if event.tool_name == "publish_artifact":
+        raw_target = arguments.get("path")
+        if not isinstance(raw_target, str):
+            return ()
+        path_key = artifact_delivery_publish_target_key(
+            raw_target,
+            workspace_dir=tool_context.workspace_dir if tool_context is not None else None,
+        )
+        keys = [path_key] if path_key is not None else []
+        if not include_publish_name:
+            if "name" in arguments and isinstance(arguments.get("name"), str):
+                artifact_name = _artifact_delivery_effective_publish_name(
+                    arguments,
+                    raw_target,
+                )
+                if artifact_name is not None:
+                    return (artifact_delivery_name_target_key(artifact_name),)
+            return tuple(keys)
+
+        artifact_name = _artifact_delivery_result_name(event)
+        if artifact_name is None:
+            artifact_name = _artifact_delivery_effective_publish_name(
+                arguments,
+                raw_target,
+            )
+        if artifact_name is not None:
+            keys.append(artifact_delivery_name_target_key(artifact_name))
+        return tuple(dict.fromkeys(keys))
+
+    effective_name = _artifact_delivery_result_name(event) if not event.is_error else None
+    if effective_name is None:
+        raw_name = arguments.get("name") or "generated.pptx"
+        if not isinstance(raw_name, str):
+            return ()
+        # Match create_pptx's public name normalization: it publishes a basename
+        # and appends .pptx when omitted.
+        effective_name = Path(raw_name).name.strip()
+        if not effective_name or effective_name in {".", ".."}:
+            effective_name = "generated.pptx"
+        if not effective_name.lower().endswith(".pptx"):
+            effective_name = f"{effective_name}.pptx"
+    name_key = artifact_delivery_name_target_key(effective_name)
+    keys = [name_key]
+    if not event.is_error and tool_context is not None and tool_context.workspace_dir:
+        root_path_key = artifact_delivery_publish_target_key(
+            name_key.removeprefix("name:"),
+            workspace_dir=tool_context.workspace_dir,
+        )
+        if root_path_key is not None:
+            keys.append(root_path_key)
+    return tuple(dict.fromkeys(keys))
 
 def _artifact_delivery_failure_notice(*, partial: bool = False) -> str:
     if partial:
         return (
             f"{_ARTIFACT_DELIVERY_FAILURE_MARKER} some generated files were attached, "
             "but at least one file could not be attached. Ask me to resend the "
-            "missing file after I correct the generated file path."
+            "missing file after I correct or regenerate it."
         )
     return (
         f"{_ARTIFACT_DELIVERY_FAILURE_MARKER} no downloadable file was attached "
-        "to this response. Ask me to resend the file after I correct the generated "
-        "file path."
+        "to this response. Ask me to resend the file after I correct or regenerate it."
     )
 
 

--- a/src/opensquilla/engine/turn_runner/stream_consumer_stage.py
+++ b/src/opensquilla/engine/turn_runner/stream_consumer_stage.py
@@ -209,6 +209,7 @@ class _StreamState:
     turn_segments: list[dict] = field(default_factory=list)
     turn_artifacts: list[dict[str, Any]] = field(default_factory=list)
     artifact_delivery_failures: list[str] = field(default_factory=list)
+    artifact_delivery_failures_by_target: dict[str, str] = field(default_factory=dict)
     completed_meta_skill_without_text: str | None = None
 
 # ---------------------------------------------------------------------------
@@ -326,6 +327,16 @@ class _ToolUseStartHandler:
         )
         return event
 
+def _clear_artifact_delivery_failure(state: _StreamState, target_key: str) -> None:
+    failure_summary = state.artifact_delivery_failures_by_target.pop(target_key, None)
+    if failure_summary is None:
+        return
+    try:
+        state.artifact_delivery_failures.remove(failure_summary)
+    except ValueError:
+        pass
+
+
 class _ToolResultHandler:
     """Capture artifact-delivery failures and append the tool_result segment."""
 
@@ -333,17 +344,31 @@ class _ToolResultHandler:
         self,
         event: ToolResultEvent,
         state: _StreamState,
+        *,
+        tool_context: Any | None = None,
     ) -> ToolResultEvent:
         # Late imports keep the module import-cycle-free.
         from opensquilla.engine.runtime import (
             _artifact_delivery_failure_summary,
+            _artifact_delivery_target_keys,
             _persisted_tool_result_segment,
             _persisted_tool_use_input,
         )
 
         failure_summary = _artifact_delivery_failure_summary(event)
+        target_keys = _artifact_delivery_target_keys(
+            event,
+            tool_context=tool_context,
+            include_publish_name=not event.is_error,
+        )
         if failure_summary is not None:
+            for target_key in target_keys:
+                _clear_artifact_delivery_failure(state, target_key)
+                state.artifact_delivery_failures_by_target[target_key] = failure_summary
             state.artifact_delivery_failures.append(failure_summary)
+        elif not event.is_error:
+            for target_key in target_keys:
+                _clear_artifact_delivery_failure(state, target_key)
         if _is_completed_meta_invoke(event):
             state.completed_meta_skill_without_text = _meta_invoke_skill_name(event)
         if event.arguments is not None:
@@ -607,6 +632,8 @@ class _DoneHandler:
             artifact_event = _ArtifactEvent(**artifact)
             state.turn_artifacts.append(artifact)
             extra_yields.append(artifact_event)
+        for target_key in omitted_publish_result.resolved_target_keys:
+            _clear_artifact_delivery_failure(state, target_key)
         state.artifact_delivery_failures.extend(
             omitted_publish_result.failure_summaries
         )
@@ -1089,7 +1116,11 @@ class StreamConsumerStage:
             elif isinstance(event, ToolUseDeltaEvent):
                 transformed = event
             elif isinstance(event, ToolResultEvent):
-                transformed = self._tool_result_handler.handle(event, state)
+                transformed = self._tool_result_handler.handle(
+                    event,
+                    state,
+                    tool_context=inp.tool_context,
+                )
             elif isinstance(event, ArtifactEvent):
                 transformed = self._artifact_handler.handle(event, state)
             elif isinstance(event, ErrorEvent):

--- a/src/opensquilla/tools/builtin/artifacts.py
+++ b/src/opensquilla/tools/builtin/artifacts.py
@@ -8,6 +8,11 @@ import os
 from difflib import SequenceMatcher
 from pathlib import Path
 
+from opensquilla.artifact_validation import (
+    ArtifactValidationError,
+    is_pptx_candidate,
+    validate_artifact_for_delivery,
+)
 from opensquilla.artifacts import (
     DEFAULT_ARTIFACT_DISK_BUDGET_BYTES,
     DEFAULT_ARTIFACT_MAX_BYTES,
@@ -21,7 +26,13 @@ from opensquilla.sandbox.operation_runtime import SandboxToolDescriptor
 from opensquilla.tools.path_aliases import resolve_workspace_alias
 from opensquilla.tools.path_policy import reject_foreign_host_path
 from opensquilla.tools.registry import tool
-from opensquilla.tools.types import CallerKind, ToolContext, ToolError, current_tool_context
+from opensquilla.tools.types import (
+    CallerKind,
+    RetryableToolInputError,
+    ToolContext,
+    ToolError,
+    current_tool_context,
+)
 
 _MAX_MISSING_FILE_CANDIDATES = 5
 _MAX_MISSING_FILE_SCAN = 2000
@@ -211,7 +222,49 @@ async def publish_artifact(
     if not target.is_file():
         raise ToolError(f"artifact path is not a file: {path}")
 
-    target_sha256 = hashlib.sha256(target.read_bytes()).hexdigest()
+    artifact_name, artifact_mime = _publish_artifact_metadata(
+        target=target,
+        name=name,
+        mime=mime,
+    )
+    target_is_pptx = is_pptx_candidate(
+        source_name=target.name,
+        name=artifact_name,
+        mime=artifact_mime,
+    )
+    configured_max_bytes = (
+        ctx.artifact_max_bytes
+        if ctx.artifact_max_bytes is not None
+        else DEFAULT_ARTIFACT_MAX_BYTES
+    )
+    max_bytes = artifact_publish_max_bytes_for_name(
+        artifact_name,
+        configured_max_bytes,
+    )
+    target_payload: bytes | None = None
+    if target_is_pptx:
+        target_size = target.stat().st_size
+        if max_bytes is not None and target_size > max_bytes:
+            budget_error = ArtifactBudgetError(
+                "artifact exceeds per-file budget "
+                f"({target_size} > {max_bytes})"
+            )
+            raise ToolError(str(budget_error)) from budget_error
+        target_payload = target.read_bytes()
+        try:
+            validate_artifact_for_delivery(
+                target_payload,
+                source_name=target.name,
+                name=artifact_name,
+                mime=artifact_mime,
+                source="publish_artifact",
+            )
+        except ArtifactValidationError as exc:
+            raise RetryableToolInputError(exc.user_message) from exc
+
+    target_sha256 = hashlib.sha256(
+        target_payload if target_payload is not None else target.read_bytes()
+    ).hexdigest()
     for published in reversed(ctx.published_artifacts):
         if published.get("sha256") != target_sha256:
             continue
@@ -229,12 +282,6 @@ async def publish_artifact(
             },
             ensure_ascii=False,
         )
-
-    artifact_name, artifact_mime = _publish_artifact_metadata(
-        target=target,
-        name=name,
-        mime=mime,
-    )
 
     store = ArtifactStore(ctx.artifact_media_root)
     existing = store.find_existing_ref(
@@ -262,27 +309,35 @@ async def publish_artifact(
             },
             ensure_ascii=False,
         )
-    configured_max_bytes = (
-        ctx.artifact_max_bytes
-        if ctx.artifact_max_bytes is not None
-        else DEFAULT_ARTIFACT_MAX_BYTES
+    disk_budget_bytes = (
+        ctx.artifact_disk_budget_bytes
+        if ctx.artifact_disk_budget_bytes is not None
+        else DEFAULT_ARTIFACT_DISK_BUDGET_BYTES
     )
     try:
-        ref = store.publish_file(
-            target,
-            session_id=ctx.artifact_session_id,
-            session_key=ctx.session_key,
-            name=artifact_name,
-            mime=artifact_mime,
-            source="publish_artifact",
-            max_bytes=artifact_publish_max_bytes_for_name(
-                artifact_name,
-                configured_max_bytes,
-            ),
-            disk_budget_bytes=ctx.artifact_disk_budget_bytes
-            if ctx.artifact_disk_budget_bytes is not None
-            else DEFAULT_ARTIFACT_DISK_BUDGET_BYTES,
-        )
+        if target_is_pptx:
+            assert target_payload is not None
+            ref = store.publish_bytes(
+                target_payload,
+                session_id=ctx.artifact_session_id,
+                session_key=ctx.session_key,
+                name=artifact_name,
+                mime=artifact_mime,
+                source="publish_artifact",
+                max_bytes=max_bytes,
+                disk_budget_bytes=disk_budget_bytes,
+            )
+        else:
+            ref = store.publish_file(
+                target,
+                session_id=ctx.artifact_session_id,
+                session_key=ctx.session_key,
+                name=artifact_name,
+                mime=artifact_mime,
+                source="publish_artifact",
+                max_bytes=max_bytes,
+                disk_budget_bytes=disk_budget_bytes,
+            )
     except ArtifactBudgetError as exc:
         raise ToolError(str(exc)) from exc
     except FileNotFoundError as exc:

--- a/src/opensquilla/tools/builtin/file_authoring.py
+++ b/src/opensquilla/tools/builtin/file_authoring.py
@@ -11,6 +11,10 @@ from pathlib import Path
 from typing import Any
 from xml.sax.saxutils import escape
 
+from opensquilla.artifact_validation import (
+    ArtifactValidationError,
+    validate_artifact_for_delivery,
+)
 from opensquilla.artifacts import (
     DEFAULT_ARTIFACT_DISK_BUDGET_BYTES,
     DEFAULT_ARTIFACT_MAX_BYTES,
@@ -20,7 +24,7 @@ from opensquilla.artifacts import (
 )
 from opensquilla.sandbox.operation_runtime import SandboxToolDescriptor
 from opensquilla.tools.registry import tool
-from opensquilla.tools.types import ToolError, current_tool_context
+from opensquilla.tools.types import RetryableToolInputError, ToolError, current_tool_context
 
 _CSV_MIME = "text/csv"
 _XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
@@ -212,6 +216,17 @@ def _published_response(
         raise ToolError("artifact storage is not configured for this turn")
     if not ctx.artifact_session_id or not ctx.session_key:
         raise ToolError("artifact session scope is not configured for this turn")
+
+    try:
+        validate_artifact_for_delivery(
+            payload,
+            source_name=name,
+            name=name,
+            mime=mime,
+            source=source,
+        )
+    except ArtifactValidationError as exc:
+        raise RetryableToolInputError(exc.user_message) from exc
 
     target_sha256 = hashlib.sha256(payload).hexdigest()
     for published in reversed(ctx.published_artifacts):

--- a/tests/test_artifact_validation.py
+++ b/tests/test_artifact_validation.py
@@ -363,6 +363,7 @@ def test_member_count_is_bounded_before_zipfile_parsing(
         (_make_pptx()[:-10], "pptx_invalid_zip_envelope"),
         (_make_pptx() + b"trailing bytes", "pptx_invalid_zip_envelope"),
     ],
+    ids=("plain-non-zip", "prefixed-zip", "truncated-zip", "trailing-bytes"),
 )
 def test_non_pure_or_truncated_zip_is_rejected(payload: bytes, reason_code: str) -> None:
     with pytest.raises(ArtifactValidationError) as raised:

--- a/tests/test_artifact_validation.py
+++ b/tests/test_artifact_validation.py
@@ -1,0 +1,1244 @@
+from __future__ import annotations
+
+import base64
+import builtins
+import copy
+import io
+import struct
+import warnings
+import xml.etree.ElementTree as ET
+import zipfile
+import zlib
+from collections.abc import Callable
+from typing import IO
+
+import pytest
+import structlog.testing
+from pptx import Presentation
+from pptx.chart.data import ChartData
+from pptx.enum.chart import XL_CHART_TYPE
+from pptx.exc import PackageNotFoundError
+from pptx.util import Inches
+
+import opensquilla.artifact_validation as validation
+from opensquilla.artifact_validation import (
+    PPTX_MIME,
+    ArtifactValidationError,
+    ArtifactValidationReport,
+    is_pptx_candidate,
+    validate_artifact_for_delivery,
+    validate_pptx_bytes,
+)
+
+_PACKAGE_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+_TRANSITIONAL_REL_NS = (
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+)
+_STRICT_REL_NS = "http://purl.oclc.org/ooxml/officeDocument/relationships"
+_TRANSITIONAL_PRESENTATION_NS = (
+    "http://schemas.openxmlformats.org/presentationml/2006/main"
+)
+_STRICT_PRESENTATION_NS = "http://purl.oclc.org/ooxml/presentationml/main"
+
+
+class _UnseekableBytesIO(io.BytesIO):
+    def seekable(self) -> bool:
+        return False
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        raise io.UnsupportedOperation
+
+
+def _make_pptx(*, slides: int = 1, hyperlink: bool = False) -> bytes:
+    presentation = Presentation()
+    for index in range(slides):
+        slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+        text_box = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(4), Inches(1))
+        run = text_box.text_frame.paragraphs[0].add_run()
+        run.text = f"第 {index + 1} 页"
+        if hyperlink:
+            run.hyperlink.address = "https://example.invalid/presentation"
+    buffer = io.BytesIO()
+    presentation.save(buffer)
+    return buffer.getvalue()
+
+
+def _entries(payload: bytes) -> dict[str, bytes]:
+    with zipfile.ZipFile(io.BytesIO(payload), "r") as archive:
+        return {info.filename: archive.read(info) for info in archive.infolist()}
+
+
+def _pack(
+    entries: dict[str, bytes],
+    *,
+    comment: bytes = b"",
+    compression: int = zipfile.ZIP_DEFLATED,
+) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", compression) as archive:
+        for name, data in entries.items():
+            archive.writestr(name, data)
+        archive.comment = comment
+    return output.getvalue()
+
+
+def _pack_with_local_zip64_or_descriptors(
+    entries: dict[str, bytes],
+    *,
+    streaming: bool,
+    force_zip64: bool,
+) -> bytes:
+    output: io.BytesIO = _UnseekableBytesIO() if streaming else io.BytesIO()
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, data in entries.items():
+            if force_zip64:
+                with archive.open(name, "w", force_zip64=True) as member:
+                    member.write(data)
+            else:
+                archive.writestr(name, data)
+    return output.getvalue()
+
+
+def _case_variant_pptx() -> bytes:
+    entries = _entries(_make_pptx())
+    entries["ppt/slides/Slide1.xml"] = entries.pop("ppt/slides/slide1.xml")
+    entries["ppt/slides/_rels/Slide1.xml.rels"] = entries.pop(
+        "ppt/slides/_rels/slide1.xml.rels"
+    )
+    content_types = ET.fromstring(entries["[Content_Types].xml"])
+    for child in content_types:
+        if child.get("PartName") in {
+            "/ppt/presentation.xml",
+            "/ppt/slides/slide1.xml",
+        }:
+            child.set("ContentType", child.get("ContentType", "").upper())
+    entries["[Content_Types].xml"] = ET.tostring(
+        content_types,
+        encoding="utf-8",
+        xml_declaration=True,
+    )
+    return _pack(entries)
+
+
+def _with_unindexed_local_bytes(payload: bytes, extra: bytes) -> bytes:
+    eocd_offset = payload.rfind(b"PK\x05\x06")
+    assert eocd_offset >= 0
+    central_offset = struct.unpack_from("<L", payload, eocd_offset + 16)[0]
+    modified = bytearray(payload[:central_offset] + extra + payload[central_offset:])
+    struct.pack_into("<L", modified, eocd_offset + len(extra) + 16, central_offset + len(extra))
+    return bytes(modified)
+
+
+def _as_zip64(payload: bytes) -> bytes:
+    eocd_offset = payload.rfind(b"PK\x05\x06")
+    assert eocd_offset >= 0
+    fields = struct.unpack_from("<4H2LH", payload, eocd_offset + 4)
+    disk_number, central_disk, disk_entries, total_entries, size, offset, _ = fields
+    zip64_record = b"PK\x06\x06" + struct.pack(
+        "<Q2H2L4Q",
+        44,
+        45,
+        45,
+        disk_number,
+        central_disk,
+        disk_entries,
+        total_entries,
+        size,
+        offset,
+    )
+    locator = b"PK\x06\x07" + struct.pack("<LQL", 0, eocd_offset, 1)
+    legacy_eocd = bytearray(payload[eocd_offset:])
+    struct.pack_into("<2H2L", legacy_eocd, 8, 0xFFFF, 0xFFFF, 0xFFFFFFFF, 0xFFFFFFFF)
+    return payload[:eocd_offset] + zip64_record + locator + bytes(legacy_eocd)
+
+
+def _rewrite_xml(
+    payload: bytes,
+    part_name: str,
+    mutate: Callable[[ET.Element], None],
+) -> bytes:
+    entries = _entries(payload)
+    root = ET.fromstring(entries[part_name])
+    mutate(root)
+    entries[part_name] = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    return _pack(entries)
+
+
+def _remove_part(payload: bytes, part_name: str) -> bytes:
+    entries = _entries(payload)
+    entries.pop(part_name)
+    return _pack(entries)
+
+
+def _validate(payload: bytes, **overrides: str | None) -> ArtifactValidationReport:
+    arguments: dict[str, str | None] = {
+        "source_name": "generated.pptx",
+        "name": "generated.pptx",
+        "mime": PPTX_MIME,
+        "source": "test",
+    }
+    arguments.update(overrides)
+    return validate_artifact_for_delivery(
+        payload,
+        source_name=arguments["source_name"],
+        name=str(arguments["name"]),
+        mime=str(arguments["mime"]),
+        source=str(arguments["source"]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("source_name", "name", "mime"),
+    [
+        ("DECK.PPTX", "deck.bin", "application/octet-stream"),
+        ("deck.bin", "RESULT.PpTx", "application/octet-stream"),
+        (None, "deck.bin", f" {PPTX_MIME.upper()}; charset=binary"),
+    ],
+)
+def test_is_pptx_candidate_uses_any_delivery_signal(
+    source_name: str | None,
+    name: str,
+    mime: str,
+) -> None:
+    assert is_pptx_candidate(source_name=source_name, name=name, mime=mime)
+
+
+def test_non_pptx_is_an_opaque_noop() -> None:
+    assert validate_artifact_for_delivery(
+        b"not an office document",
+        source_name="report.bin",
+        name="report.bin",
+        mime="application/octet-stream",
+        source="test",
+    ) == ArtifactValidationReport()
+
+
+@pytest.mark.parametrize("slide_count", [0, 1, 3])
+def test_valid_transitional_pptx_is_deep_loaded(slide_count: int) -> None:
+    assert _validate(_make_pptx(slides=slide_count)) == ArtifactValidationReport()
+
+
+def test_external_hyperlinks_and_unknown_parts_are_allowed() -> None:
+    entries = _entries(_make_pptx(hyperlink=True))
+    entries["custom/unknown.bin"] = b"extension data"
+    entries["custom/兼容扩展.bin"] = b"tolerated non-canonical unknown entry"
+
+    assert _validate(_pack(entries)) == ArtifactValidationReport()
+
+
+def test_internal_relationship_fragment_is_allowed_without_network_access() -> None:
+    entries = _entries(_make_pptx())
+    relationships = ET.fromstring(entries["ppt/slides/_rels/slide1.xml.rels"])
+    ET.SubElement(
+        relationships,
+        f"{{{_PACKAGE_REL_NS}}}Relationship",
+        {
+            "Id": "rIdInternalLink",
+            "Type": f"{_TRANSITIONAL_REL_NS}/hyperlink",
+            "Target": "#section-1",
+            "TargetMode": "Internal",
+        },
+    )
+    entries["ppt/slides/_rels/slide1.xml.rels"] = ET.tostring(
+        relationships,
+        encoding="utf-8",
+        xml_declaration=True,
+    )
+
+    assert _validate(_pack(entries)) == ArtifactValidationReport()
+
+
+def test_complex_picture_chart_and_notes_pptx_is_accepted() -> None:
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUB"
+        "AScY42YAAAAASUVORK5CYII="
+    )
+    slide.shapes.add_picture(io.BytesIO(png), Inches(0.5), Inches(0.5), Inches(1), Inches(1))
+    chart_data = ChartData()
+    chart_data.categories = ["一月", "二月"]
+    chart_data.add_series("收入", (3, 5))
+    slide.shapes.add_chart(
+        XL_CHART_TYPE.COLUMN_CLUSTERED,
+        Inches(2),
+        Inches(1),
+        Inches(5),
+        Inches(3),
+        chart_data,
+    )
+    slide.notes_slide.notes_text_frame.text = "仅供讲者查看的备注"
+    output = io.BytesIO()
+    presentation.save(output)
+
+    assert validate_pptx_bytes(output.getvalue()) == ArtifactValidationReport()
+
+
+def test_zip_comment_is_allowed_when_eocd_reaches_exact_end() -> None:
+    assert _validate(_pack(_entries(_make_pptx()), comment=b"valid comment")) == (
+        ArtifactValidationReport()
+    )
+
+
+def test_valid_zip64_directory_is_supported() -> None:
+    assert _validate(_as_zip64(_make_pptx())) == ArtifactValidationReport()
+
+
+@pytest.mark.parametrize(
+    ("streaming", "force_zip64"),
+    [
+        (True, False),
+        (False, True),
+        (True, True),
+    ],
+)
+def test_valid_data_descriptors_and_entry_level_zip64_are_supported(
+    streaming: bool,
+    force_zip64: bool,
+) -> None:
+    payload = _pack_with_local_zip64_or_descriptors(
+        _entries(_make_pptx()),
+        streaming=streaming,
+        force_zip64=force_zip64,
+    )
+
+    assert _validate(payload) == ArtifactValidationReport()
+
+
+def test_unsigned_data_descriptor_crc_may_equal_optional_signature() -> None:
+    signature_as_crc = struct.unpack("<L", b"PK\x07\x08")[0]
+    entry = validation._CentralDirectoryEntry(
+        decoded_name="probe.bin",
+        raw_name=b"probe.bin",
+        version_needed=20,
+        flags=0x08,
+        compression=zipfile.ZIP_DEFLATED,
+        modified_time=0,
+        modified_date=0,
+        crc=signature_as_crc,
+        compressed_size=4,
+        uncompressed_size=4,
+        local_header_offset=0,
+        uses_zip64_sizes=False,
+    )
+    descriptor = struct.pack("<LLL", signature_as_crc, 4, 4)
+
+    validation._validate_data_descriptor(descriptor, entry, uses_zip64=False)
+
+
+def test_zip64_sentinel_without_directory_is_rejected() -> None:
+    payload = bytearray(_make_pptx())
+    eocd_offset = payload.rfind(b"PK\x05\x06")
+    struct.pack_into("<2H", payload, eocd_offset + 8, 0xFFFF, 0xFFFF)
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(bytes(payload))
+    assert raised.value.reason_code == "pptx_invalid_zip64_directory"
+
+
+def test_central_directory_must_end_immediately_before_eocd() -> None:
+    payload = _make_pptx()
+    eocd_offset = payload.rfind(b"PK\x05\x06")
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(payload[:eocd_offset] + b"unexpected-gap" + payload[eocd_offset:])
+    assert raised.value.reason_code == "pptx_invalid_central_directory"
+
+
+def test_member_count_is_bounded_before_zipfile_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(validation, "_MAX_ZIP_MEMBERS", 2)
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_make_pptx())
+    assert raised.value.reason_code == "pptx_member_count_limit"
+
+
+@pytest.mark.parametrize(
+    ("payload", "reason_code"),
+    [
+        (b"not a zip", "pptx_not_zip"),
+        (b"prefix" + _make_pptx(), "pptx_not_zip"),
+        (_make_pptx()[:-10], "pptx_invalid_zip_envelope"),
+        (_make_pptx() + b"trailing bytes", "pptx_invalid_zip_envelope"),
+    ],
+)
+def test_non_pure_or_truncated_zip_is_rejected(payload: bytes, reason_code: str) -> None:
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(payload)
+
+    assert raised.value.reason_code == reason_code
+    assert "generated.pptx" not in raised.value.user_message
+
+
+def test_ole_or_encrypted_container_has_actionable_safe_error() -> None:
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"encrypted")
+
+    assert raised.value.reason_code == "pptx_encrypted_or_legacy_container"
+    assert "unencrypted .pptx" in raised.value.user_message
+
+
+def test_duplicate_zip_member_is_rejected() -> None:
+    payload = _make_pptx()
+    output = io.BytesIO()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+            for name, data in _entries(payload).items():
+                archive.writestr(name, data)
+            archive.writestr("[Content_Types].xml", b"duplicate")
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(output.getvalue())
+    assert raised.value.reason_code == "pptx_duplicate_zip_member"
+
+
+@pytest.mark.parametrize("compression", [zipfile.ZIP_BZIP2, zipfile.ZIP_LZMA])
+def test_only_stored_and_deflated_zip_members_are_accepted(compression: int) -> None:
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(_entries(_make_pptx()), compression=compression))
+    assert raised.value.reason_code == "pptx_unsupported_zip_compression"
+
+
+@pytest.mark.parametrize(
+    "invalid_name",
+    [
+        "custom/bad%.bin",
+        "custom/%41.bin",
+        "custom/%2f.bin",
+        "custom/%5C.bin",
+        "custom/%00.bin",
+        "custom/%7f.bin",
+        "custom/a%41.bin",
+        "custom/ab%41.bin",
+    ],
+)
+def test_zip_member_names_follow_pack_uri_percent_encoding_rules(
+    invalid_name: str,
+) -> None:
+    entries = _entries(_make_pptx())
+    entries[invalid_name] = b"invalid OPC part name"
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(entries))
+    assert raised.value.reason_code == "pptx_invalid_zip_member_name"
+
+
+@pytest.mark.parametrize("raw_control", [b"\x00", b"\x01", b"\x7f"])
+def test_raw_central_directory_member_name_controls_are_rejected(
+    raw_control: bytes,
+) -> None:
+    entries = _entries(_make_pptx())
+    marker = b"custom/probe.bin"
+    entries[marker.decode()] = b"probe"
+    payload = _pack(entries)
+    assert payload.count(marker) == 2
+    replacement = marker[:7] + raw_control + marker[8:]
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(payload.replace(marker, replacement))
+    assert raised.value.reason_code == "pptx_invalid_zip_member_name"
+
+
+def test_percent_escape_hex_case_is_part_name_equivalent() -> None:
+    entries = _entries(_make_pptx())
+    entries["custom/my%2A.bin"] = b"first"
+    entries["custom/my%2a.bin"] = b"second"
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(entries))
+    assert raised.value.reason_code == "pptx_duplicate_zip_member"
+
+
+def test_local_header_filename_must_match_central_directory() -> None:
+    entries = _entries(_make_pptx())
+    marker = b"custom/probe.bin"
+    entries[marker.decode()] = b"probe"
+    payload = bytearray(_pack(entries))
+    local_name_offset = payload.find(marker)
+    central_name_offset = payload.rfind(marker)
+    assert 0 <= local_name_offset < central_name_offset
+    payload[local_name_offset] = ord("C")
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(bytes(payload))
+    assert raised.value.reason_code == "pptx_invalid_local_file_header"
+
+
+def test_local_header_compression_must_match_central_directory() -> None:
+    payload = bytearray(_make_pptx())
+    assert payload.startswith(b"PK\x03\x04")
+    central_method = struct.unpack_from("<H", payload, payload.find(b"PK\x01\x02") + 10)[0]
+    replacement = zipfile.ZIP_STORED if central_method == zipfile.ZIP_DEFLATED else 99
+    struct.pack_into("<H", payload, 8, replacement)
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(bytes(payload))
+    assert raised.value.reason_code == "pptx_invalid_local_file_header"
+
+
+def test_local_header_crc_must_match_central_directory() -> None:
+    payload = bytearray(_make_pptx())
+    local_crc = struct.unpack_from("<L", payload, 14)[0]
+    struct.pack_into("<L", payload, 14, local_crc ^ 0xFFFFFFFF)
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(bytes(payload))
+    assert raised.value.reason_code == "pptx_invalid_local_file_header"
+
+
+def test_unindexed_local_record_or_gap_is_rejected() -> None:
+    unindexed_record = b"PK\x03\x04" + (b"\x00" * 26)
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_with_unindexed_local_bytes(_make_pptx(), unindexed_record))
+    assert raised.value.reason_code == "pptx_invalid_local_file_layout"
+
+
+def test_overlapping_local_record_offsets_are_rejected() -> None:
+    payload = bytearray(_make_pptx())
+    eocd_offset = payload.rfind(b"PK\x05\x06")
+    central_offset = struct.unpack_from("<L", payload, eocd_offset + 16)[0]
+    first_local_offset = struct.unpack_from("<L", payload, central_offset + 42)[0]
+    name_length, extra_length, comment_length = struct.unpack_from(
+        "<3H", payload, central_offset + 28
+    )
+    second_central_entry = central_offset + 46 + name_length + extra_length + comment_length
+    assert payload[second_central_entry : second_central_entry + 4] == b"PK\x01\x02"
+    struct.pack_into("<L", payload, second_central_entry + 42, first_local_offset)
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(bytes(payload))
+    assert raised.value.reason_code == "pptx_invalid_local_file_layout"
+
+
+def test_crc_failure_is_rejected() -> None:
+    entries = _entries(_make_pptx())
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, data in entries.items():
+            archive.writestr(name, data)
+        archive.writestr("probe.bin", b"crc payload", compress_type=zipfile.ZIP_STORED)
+    corrupted = bytearray(output.getvalue())
+    marker = b"probe.bin"
+    header_offset = corrupted.find(b"PK\x03\x04", corrupted.find(marker) - 30)
+    filename_length, extra_length = struct.unpack_from("<HH", corrupted, header_offset + 26)
+    data_offset = header_offset + 30 + filename_length + extra_length
+    corrupted[data_offset] ^= 0x01
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(bytes(corrupted))
+    assert raised.value.reason_code == "pptx_corrupt_zip_member"
+
+
+def test_raw_zlib_failures_are_classified_as_corrupt_members(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _make_pptx()
+
+    def fail_open(*_args: object, **_kwargs: object) -> object:
+        raise zlib.error("synthetic damaged deflate stream")
+
+    monkeypatch.setattr(zipfile.ZipFile, "open", fail_open)
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(payload)
+    assert raised.value.reason_code == "pptx_corrupt_zip_member"
+
+
+def test_actual_inflated_bytes_are_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(validation, "_MAX_INFLATED_BYTES", 64)
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_make_pptx())
+    assert raised.value.reason_code == "pptx_inflated_size_limit"
+
+
+def test_core_xml_member_size_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(validation, "_MAX_CORE_XML_BYTES", 64)
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_make_pptx())
+    assert raised.value.reason_code == "pptx_core_xml_size_limit"
+
+
+@pytest.mark.parametrize(
+    ("part_name", "reason_code"),
+    [
+        ("[Content_Types].xml", "pptx_missing_content_types"),
+        ("_rels/.rels", "pptx_missing_root_relationships"),
+        ("ppt/presentation.xml", "pptx_missing_presentation_part"),
+    ],
+)
+def test_required_opc_parts_must_exist(part_name: str, reason_code: str) -> None:
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_remove_part(_make_pptx(), part_name))
+    assert raised.value.reason_code == reason_code
+
+
+def test_core_xml_must_parse() -> None:
+    entries = _entries(_make_pptx())
+    entries["[Content_Types].xml"] = b"<Types"
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(entries))
+    assert raised.value.reason_code == "pptx_invalid_xml"
+
+
+def test_doctype_text_inside_cdata_is_not_treated_as_a_declaration() -> None:
+    entries = _entries(_make_pptx())
+    entries["ppt/slides/slide1.xml"] = entries["ppt/slides/slide1.xml"].replace(
+        "第 1 页".encode(),
+        b"<![CDATA[<!DOCTYPE html>]]>",
+    )
+    payload = _pack(entries)
+
+    assert _validate(payload) == ArtifactValidationReport()
+    reloaded = Presentation(io.BytesIO(payload))
+    assert reloaded.slides[0].shapes[0].text == "<!DOCTYPE html>"
+
+
+def test_real_doctype_declaration_is_rejected() -> None:
+    entries = _entries(_make_pptx())
+    content_types = entries["[Content_Types].xml"]
+    declaration_end = content_types.find(b"?>") + 2
+    entries["[Content_Types].xml"] = (
+        content_types[:declaration_end]
+        + b"<!DOCTYPE Types>"
+        + content_types[declaration_end:]
+    )
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(entries))
+    assert raised.value.reason_code == "pptx_unsafe_xml_declaration"
+
+
+def test_root_must_have_one_office_document_relationship() -> None:
+    def duplicate_office_relationship(root: ET.Element) -> None:
+        office_relationship = next(
+            child for child in root if child.get("Type", "").endswith("/officeDocument")
+        )
+        clone = copy.deepcopy(office_relationship)
+        clone.set("Id", "duplicateOfficeDocument")
+        root.append(clone)
+
+    payload = _rewrite_xml(_make_pptx(), "_rels/.rels", duplicate_office_relationship)
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(payload)
+    assert raised.value.reason_code == "pptx_invalid_office_document_relationship"
+
+
+def test_explicit_internal_target_mode_is_accepted() -> None:
+    def mark_internal(root: ET.Element) -> None:
+        office_relationship = next(
+            child for child in root if child.get("Type", "").endswith("/officeDocument")
+        )
+        office_relationship.set("TargetMode", "Internal")
+
+    assert _validate(_rewrite_xml(_make_pptx(), "_rels/.rels", mark_internal)) == (
+        ArtifactValidationReport()
+    )
+
+
+@pytest.mark.parametrize(
+    "presentation_part",
+    [
+        "custom/presentation.xml",
+        "custom/presentation.v1.xml",
+        "custom/my%20deck.xml",
+    ],
+)
+@pytest.mark.parametrize("strict", [False, True])
+def test_main_presentation_part_can_use_nonstandard_opc_path(
+    presentation_part: str,
+    strict: bool,
+) -> None:
+    entries = _entries(_make_pptx())
+    main_xml = entries.pop("ppt/presentation.xml")
+    main_rels = ET.fromstring(entries.pop("ppt/_rels/presentation.xml.rels"))
+    for relationship in main_rels:
+        if relationship.get("TargetMode") != "External":
+            relationship.set("Target", f"../ppt/{relationship.get('Target')}")
+    entries[presentation_part] = main_xml
+    relationships_part = (
+        f"custom/_rels/{presentation_part.rsplit('/', 1)[-1]}.rels"
+    )
+    entries[relationships_part] = ET.tostring(
+        main_rels,
+        encoding="utf-8",
+        xml_declaration=True,
+    )
+
+    root_rels = ET.fromstring(entries["_rels/.rels"])
+    office_relationship = next(
+        child for child in root_rels if child.get("Type", "").endswith("/officeDocument")
+    )
+    office_relationship.set("Target", presentation_part)
+    entries["_rels/.rels"] = ET.tostring(root_rels, encoding="utf-8", xml_declaration=True)
+
+    content_types = ET.fromstring(entries["[Content_Types].xml"])
+    main_override = next(
+        child
+        for child in content_types
+        if child.get("PartName") == "/ppt/presentation.xml"
+    )
+    main_override.set("PartName", f"/{presentation_part}")
+    entries["[Content_Types].xml"] = ET.tostring(
+        content_types,
+        encoding="utf-8",
+        xml_declaration=True,
+    )
+
+    if strict:
+        for part_name, part_payload in list(entries.items()):
+            if part_name.endswith((".xml", ".rels")):
+                entries[part_name] = part_payload.replace(
+                    _TRANSITIONAL_PRESENTATION_NS.encode(),
+                    _STRICT_PRESENTATION_NS.encode(),
+                ).replace(_TRANSITIONAL_REL_NS.encode(), _STRICT_REL_NS.encode())
+
+    report = _validate(_pack(entries))
+    expected_warnings = ("pptx_strict_ooxml_smoke_skipped",) if strict else ()
+    assert report.warnings == expected_warnings
+
+
+@pytest.mark.parametrize("strict", [False, True])
+@pytest.mark.parametrize(
+    "invalid_part_name",
+    [
+        "//ppt/slides/slide1.xml",
+        "/ppt//slides/slide1.xml",
+        "/ppt/slides/./slide1.xml",
+        "/ppt/slides/../slides/slide1.xml",
+        "/ppt/slides/slide1.xml/",
+        "/ppt/slides/slide1.xml.",
+        "/ppt\\slides\\slide1.xml",
+        "/ppt/slides/slide%ZZ.xml",
+    ],
+)
+def test_content_type_override_part_name_is_not_path_normalised(
+    strict: bool,
+    invalid_part_name: str,
+) -> None:
+    entries = _entries(_make_pptx())
+    content_types = ET.fromstring(entries["[Content_Types].xml"])
+    slide_override = next(
+        child
+        for child in content_types
+        if child.get("PartName") == "/ppt/slides/slide1.xml"
+    )
+    slide_override.set("PartName", invalid_part_name)
+    entries["[Content_Types].xml"] = ET.tostring(
+        content_types,
+        encoding="utf-8",
+        xml_declaration=True,
+    )
+    if strict:
+        for part_name, part_payload in list(entries.items()):
+            if part_name.endswith((".xml", ".rels")):
+                entries[part_name] = part_payload.replace(
+                    _TRANSITIONAL_PRESENTATION_NS.encode(),
+                    _STRICT_PRESENTATION_NS.encode(),
+                ).replace(_TRANSITIONAL_REL_NS.encode(), _STRICT_REL_NS.encode())
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(entries))
+    assert raised.value.reason_code == "pptx_invalid_part_name"
+
+
+@pytest.mark.parametrize("strict", [False, True])
+def test_relationship_target_segment_cannot_end_with_dot(strict: bool) -> None:
+    def use_trailing_dot_target(root: ET.Element) -> None:
+        slide_relationship = next(
+            child for child in root if child.get("Type", "").endswith("/slide")
+        )
+        slide_relationship.set("Target", "slides/missing.xml.")
+
+    entries = _entries(
+        _rewrite_xml(
+            _make_pptx(),
+            "ppt/_rels/presentation.xml.rels",
+            use_trailing_dot_target,
+        )
+    )
+    if strict:
+        for part_name, part_payload in list(entries.items()):
+            if part_name.endswith((".xml", ".rels")):
+                entries[part_name] = part_payload.replace(
+                    _TRANSITIONAL_PRESENTATION_NS.encode(),
+                    _STRICT_PRESENTATION_NS.encode(),
+                ).replace(_TRANSITIONAL_REL_NS.encode(), _STRICT_REL_NS.encode())
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(entries))
+    assert raised.value.reason_code == "pptx_invalid_package_path"
+
+
+@pytest.mark.parametrize("member_name", ["custom/data.bin.", "custom/folder./"])
+def test_zip_member_segment_cannot_end_with_dot(member_name: str) -> None:
+    entries = _entries(_make_pptx())
+    entries[member_name] = b"ambiguous on Windows"
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(entries))
+    assert raised.value.reason_code == "pptx_invalid_zip_member_name"
+
+
+@pytest.mark.parametrize("strict", [False, True])
+def test_synchronised_trailing_dot_slide_part_is_rejected(strict: bool) -> None:
+    entries = _entries(_make_pptx())
+    entries["ppt/slides/slide1.xml."] = entries.pop("ppt/slides/slide1.xml")
+    entries["ppt/slides/_rels/slide1.xml..rels"] = entries.pop(
+        "ppt/slides/_rels/slide1.xml.rels"
+    )
+
+    presentation_relationships = ET.fromstring(
+        entries["ppt/_rels/presentation.xml.rels"]
+    )
+    slide_relationship = next(
+        child
+        for child in presentation_relationships
+        if child.get("Type", "").endswith("/slide")
+    )
+    slide_relationship.set("Target", "slides/slide1.xml.")
+    entries["ppt/_rels/presentation.xml.rels"] = ET.tostring(
+        presentation_relationships,
+        encoding="utf-8",
+        xml_declaration=True,
+    )
+
+    content_types = ET.fromstring(entries["[Content_Types].xml"])
+    slide_override = next(
+        child
+        for child in content_types
+        if child.get("PartName") == "/ppt/slides/slide1.xml"
+    )
+    slide_override.set("PartName", "/ppt/slides/slide1.xml.")
+    entries["[Content_Types].xml"] = ET.tostring(
+        content_types,
+        encoding="utf-8",
+        xml_declaration=True,
+    )
+    if strict:
+        for part_name, part_payload in list(entries.items()):
+            if part_name.endswith((".xml", ".rels")):
+                entries[part_name] = part_payload.replace(
+                    _TRANSITIONAL_PRESENTATION_NS.encode(),
+                    _STRICT_PRESENTATION_NS.encode(),
+                ).replace(_TRANSITIONAL_REL_NS.encode(), _STRICT_REL_NS.encode())
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(entries))
+    assert raised.value.reason_code == "pptx_invalid_zip_member_name"
+
+
+def test_opc_part_and_content_type_case_variants_still_run_parser_smoke(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import pptx
+
+    parser_calls = 0
+    real_presentation = pptx.Presentation
+
+    def record_parser_call(stream: str | IO[bytes] | None) -> object:
+        nonlocal parser_calls
+        parser_calls += 1
+        return real_presentation(stream)
+
+    monkeypatch.setattr(pptx, "Presentation", record_parser_call)
+
+    assert _validate(_case_variant_pptx()).warnings == (
+        "pptx_opc_case_compatibility_warning",
+    )
+    assert parser_calls >= 1
+
+
+@pytest.mark.parametrize(
+    "parser_error",
+    [
+        PackageNotFoundError("unrelated package failure"),
+        ValueError("unrelated structural failure"),
+        KeyError("unrelated missing part"),
+    ],
+)
+def test_opc_case_compatibility_does_not_hide_unrelated_parser_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    parser_error: Exception,
+) -> None:
+    import pptx
+
+    def fail_to_open(_stream: object) -> object:
+        raise parser_error
+
+    monkeypatch.setattr(pptx, "Presentation", fail_to_open)
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_case_variant_pptx())
+    assert raised.value.reason_code == "pptx_parser_structural_failure"
+
+
+def test_ascii_case_equivalent_zip_members_are_duplicates() -> None:
+    entries = _entries(_make_pptx())
+    entries["PPT/PRESENTATION.XML"] = entries["ppt/presentation.xml"]
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(entries))
+    assert raised.value.reason_code == "pptx_duplicate_zip_member"
+
+
+def test_strict_ooxml_slide_graph_is_structurally_checked_and_soft_warned() -> None:
+    entries = _entries(_make_pptx(slides=1))
+    for part_name, payload in list(entries.items()):
+        if part_name.endswith((".xml", ".rels")):
+            entries[part_name] = payload.replace(
+                _TRANSITIONAL_PRESENTATION_NS.encode(),
+                _STRICT_PRESENTATION_NS.encode(),
+            ).replace(_TRANSITIONAL_REL_NS.encode(), _STRICT_REL_NS.encode())
+
+    report = _validate(_pack(entries))
+    assert report.warnings == ("pptx_strict_ooxml_smoke_skipped",)
+
+
+def test_broken_slide_relationship_is_rejected() -> None:
+    def break_slide_target(root: ET.Element) -> None:
+        slide_relationship = next(
+            child for child in root if child.get("Type", "").endswith("/slide")
+        )
+        slide_relationship.set("Target", "slides/missing.xml")
+
+    payload = _rewrite_xml(
+        _make_pptx(),
+        "ppt/_rels/presentation.xml.rels",
+        break_slide_target,
+    )
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(payload)
+    assert raised.value.reason_code == "pptx_missing_slide_part"
+
+
+@pytest.mark.parametrize(
+    "slide_id",
+    [None, "", "one", "+256", "-1", "255", "2147483648"],
+)
+def test_slide_id_must_be_a_decimal_in_the_ooxml_range(slide_id: str | None) -> None:
+    def replace_slide_id(root: ET.Element) -> None:
+        node = root.find(
+            f"{{{_TRANSITIONAL_PRESENTATION_NS}}}sldIdLst/"
+            f"{{{_TRANSITIONAL_PRESENTATION_NS}}}sldId"
+        )
+        assert node is not None
+        if slide_id is None:
+            node.attrib.pop("id", None)
+        else:
+            node.set("id", slide_id)
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_rewrite_xml(_make_pptx(), "ppt/presentation.xml", replace_slide_id))
+    assert raised.value.reason_code == "pptx_invalid_slide_id"
+
+
+def test_slide_id_uses_xsd_whitespace_collapse() -> None:
+    def pad_slide_id(root: ET.Element) -> None:
+        node = root.find(
+            f"{{{_TRANSITIONAL_PRESENTATION_NS}}}sldIdLst/"
+            f"{{{_TRANSITIONAL_PRESENTATION_NS}}}sldId"
+        )
+        assert node is not None
+        node.set("id", " \t256\n ")
+
+    assert _validate(
+        _rewrite_xml(_make_pptx(), "ppt/presentation.xml", pad_slide_id)
+    ) == ArtifactValidationReport()
+
+
+def test_slide_ids_are_unique_as_numeric_values() -> None:
+    def duplicate_slide_id(root: ET.Element) -> None:
+        nodes = root.findall(
+            f"{{{_TRANSITIONAL_PRESENTATION_NS}}}sldIdLst/"
+            f"{{{_TRANSITIONAL_PRESENTATION_NS}}}sldId"
+        )
+        assert len(nodes) == 2
+        nodes[1].set("id", f"0{nodes[0].get('id')}")
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(
+            _rewrite_xml(_make_pptx(slides=2), "ppt/presentation.xml", duplicate_slide_id)
+        )
+    assert raised.value.reason_code == "pptx_duplicate_slide_id"
+
+
+def test_slide_list_targets_must_resolve_to_distinct_parts() -> None:
+    def duplicate_slide_target(root: ET.Element) -> None:
+        slide_relationships = [
+            child for child in root if child.get("Type", "").endswith("/slide")
+        ]
+        assert len(slide_relationships) == 2
+        slide_relationships[1].set("Target", slide_relationships[0].get("Target", ""))
+
+    payload = _rewrite_xml(
+        _make_pptx(slides=2),
+        "ppt/_rels/presentation.xml.rels",
+        duplicate_slide_target,
+    )
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(payload)
+    assert raised.value.reason_code == "pptx_duplicate_slide_part"
+
+
+@pytest.mark.parametrize("strict", [False, True])
+def test_every_reachable_internal_part_requires_a_content_type(strict: bool) -> None:
+    entries = _entries(_make_pptx())
+    slide_relationships = ET.fromstring(entries["ppt/slides/_rels/slide1.xml.rels"])
+    ET.SubElement(
+        slide_relationships,
+        f"{{{_PACKAGE_REL_NS}}}Relationship",
+        {
+            "Id": "rIdMissingContentType",
+            "Type": f"{_TRANSITIONAL_REL_NS}/customData",
+            "Target": "../custom/data.missingct",
+        },
+    )
+    entries["ppt/slides/_rels/slide1.xml.rels"] = ET.tostring(
+        slide_relationships,
+        encoding="utf-8",
+        xml_declaration=True,
+    )
+    entries["ppt/custom/data.missingct"] = b"custom data"
+    if strict:
+        for part_name, part_payload in list(entries.items()):
+            if part_name.endswith((".xml", ".rels")):
+                entries[part_name] = part_payload.replace(
+                    _TRANSITIONAL_PRESENTATION_NS.encode(),
+                    _STRICT_PRESENTATION_NS.encode(),
+                ).replace(_TRANSITIONAL_REL_NS.encode(), _STRICT_REL_NS.encode())
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(entries))
+    assert raised.value.reason_code == "pptx_missing_related_content_type"
+
+
+def test_root_relationship_targets_also_require_a_content_type() -> None:
+    entries = _entries(_make_pptx())
+    root_relationships = ET.fromstring(entries["_rels/.rels"])
+    ET.SubElement(
+        root_relationships,
+        f"{{{_PACKAGE_REL_NS}}}Relationship",
+        {
+            "Id": "rIdMissingContentType",
+            "Type": f"{_TRANSITIONAL_REL_NS}/customData",
+            "Target": "custom/data.missingct",
+        },
+    )
+    entries["_rels/.rels"] = ET.tostring(
+        root_relationships,
+        encoding="utf-8",
+        xml_declaration=True,
+    )
+    entries["custom/data.missingct"] = b"custom data"
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(entries))
+    assert raised.value.reason_code == "pptx_missing_related_content_type"
+
+
+@pytest.mark.parametrize("strict", [False, True])
+def test_relationship_parts_do_not_require_content_types_coverage(strict: bool) -> None:
+    entries = _entries(_make_pptx())
+    content_types = ET.fromstring(entries["[Content_Types].xml"])
+    rels_default = next(
+        child
+        for child in content_types
+        if child.get("Extension", "").casefold() == "rels"
+    )
+    content_types.remove(rels_default)
+    entries["[Content_Types].xml"] = ET.tostring(
+        content_types,
+        encoding="utf-8",
+        xml_declaration=True,
+    )
+    if strict:
+        for part_name, part_payload in list(entries.items()):
+            if part_name.endswith((".xml", ".rels")):
+                entries[part_name] = part_payload.replace(
+                    _TRANSITIONAL_PRESENTATION_NS.encode(),
+                    _STRICT_PRESENTATION_NS.encode(),
+                ).replace(_TRANSITIONAL_REL_NS.encode(), _STRICT_REL_NS.encode())
+
+    report = _validate(_pack(entries))
+    expected_warnings = ("pptx_strict_ooxml_smoke_skipped",) if strict else ()
+    assert report.warnings == expected_warnings
+
+
+@pytest.mark.parametrize("strict", [False, True])
+def test_ordinary_rels_suffix_part_still_requires_a_content_type(strict: bool) -> None:
+    entries = _entries(_make_pptx())
+    content_types = ET.fromstring(entries["[Content_Types].xml"])
+    rels_default = next(
+        child
+        for child in content_types
+        if child.get("Extension", "").casefold() == "rels"
+    )
+    content_types.remove(rels_default)
+    entries["[Content_Types].xml"] = ET.tostring(
+        content_types,
+        encoding="utf-8",
+        xml_declaration=True,
+    )
+
+    slide_relationships = ET.fromstring(entries["ppt/slides/_rels/slide1.xml.rels"])
+    ET.SubElement(
+        slide_relationships,
+        f"{{{_PACKAGE_REL_NS}}}Relationship",
+        {
+            "Id": "rIdOrdinaryRelsPart",
+            "Type": f"{_TRANSITIONAL_REL_NS}/customData",
+            "Target": "../custom/data.rels",
+        },
+    )
+    entries["ppt/slides/_rels/slide1.xml.rels"] = ET.tostring(
+        slide_relationships,
+        encoding="utf-8",
+        xml_declaration=True,
+    )
+    entries["ppt/custom/data.rels"] = b"ordinary part, not a Relationships part"
+
+    if strict:
+        for part_name, part_payload in list(entries.items()):
+            if part_name.endswith((".xml", ".rels")):
+                entries[part_name] = part_payload.replace(
+                    _TRANSITIONAL_PRESENTATION_NS.encode(),
+                    _STRICT_PRESENTATION_NS.encode(),
+                ).replace(_TRANSITIONAL_REL_NS.encode(), _STRICT_REL_NS.encode())
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(entries))
+    assert raised.value.reason_code == "pptx_missing_related_content_type"
+
+
+@pytest.mark.parametrize("strict", [False, True])
+def test_relationship_cannot_target_a_relationships_part(strict: bool) -> None:
+    entries = _entries(_make_pptx())
+    slide_relationships = ET.fromstring(entries["ppt/slides/_rels/slide1.xml.rels"])
+    ET.SubElement(
+        slide_relationships,
+        f"{{{_PACKAGE_REL_NS}}}Relationship",
+        {
+            "Id": "rIdRelationshipsPartTarget",
+            "Type": f"{_TRANSITIONAL_REL_NS}/customData",
+            "Target": "_rels/slide1.xml.rels",
+        },
+    )
+    entries["ppt/slides/_rels/slide1.xml.rels"] = ET.tostring(
+        slide_relationships,
+        encoding="utf-8",
+        xml_declaration=True,
+    )
+    if strict:
+        for part_name, part_payload in list(entries.items()):
+            if part_name.endswith((".xml", ".rels")):
+                entries[part_name] = part_payload.replace(
+                    _TRANSITIONAL_PRESENTATION_NS.encode(),
+                    _STRICT_PRESENTATION_NS.encode(),
+                ).replace(_TRANSITIONAL_REL_NS.encode(), _STRICT_REL_NS.encode())
+
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_pack(entries))
+    assert raised.value.reason_code == "pptx_relationship_targets_relationship_part"
+
+
+def test_slide_content_type_and_root_are_checked() -> None:
+    def change_content_type(root: ET.Element) -> None:
+        override = next(
+            child for child in root if child.get("PartName") == "/ppt/slides/slide1.xml"
+        )
+        override.set("ContentType", "application/xml")
+
+    invalid_content_type = _rewrite_xml(
+        _make_pptx(),
+        "[Content_Types].xml",
+        change_content_type,
+    )
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(invalid_content_type)
+    assert raised.value.reason_code == "pptx_invalid_slide_content_type"
+
+    def change_root(root: ET.Element) -> None:
+        root.tag = f"{{{_TRANSITIONAL_PRESENTATION_NS}}}not-a-slide"
+
+    invalid_root = _rewrite_xml(_make_pptx(), "ppt/slides/slide1.xml", change_root)
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(invalid_root)
+    assert raised.value.reason_code == "pptx_invalid_slide_xml"
+
+
+@pytest.mark.parametrize(
+    ("parser_error", "expected_warning"),
+    [
+        (NotImplementedError("unsupported feature"), True),
+        (AttributeError("unknown parser shape"), True),
+        (TypeError("unknown parser type"), True),
+        (RuntimeError("unknown parser compatibility"), True),
+        (ValueError("structural parser failure"), False),
+        (KeyError("missing parser part"), False),
+    ],
+)
+def test_python_pptx_parser_error_classification(
+    monkeypatch: pytest.MonkeyPatch,
+    parser_error: Exception,
+    expected_warning: bool,
+) -> None:
+    import pptx
+
+    def fail_to_open(_stream: object) -> object:
+        raise parser_error
+
+    monkeypatch.setattr(pptx, "Presentation", fail_to_open)
+    if expected_warning:
+        assert _validate(_make_pptx()).warnings == ("pptx_parser_compatibility_warning",)
+    else:
+        with pytest.raises(ArtifactValidationError) as raised:
+            _validate(_make_pptx())
+        assert raised.value.reason_code == "pptx_parser_structural_failure"
+
+
+def test_python_pptx_import_failure_blocks_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def fail_pptx_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "pptx" or name.startswith("pptx."):
+            raise ImportError("synthetic missing parser")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_pptx_import)
+    with pytest.raises(ArtifactValidationError) as raised:
+        _validate(_make_pptx())
+    assert raised.value.reason_code == "pptx_parser_unavailable"
+
+
+def test_validation_logs_only_safe_bounded_metadata() -> None:
+    with structlog.testing.capture_logs() as captured:
+        with pytest.raises(ArtifactValidationError):
+            validate_artifact_for_delivery(
+                b"invalid",
+                source_name="/secret/workspace/customer-deck.pptx",
+                name="private-title.pptx",
+                mime=PPTX_MIME,
+                source="publish_artifact",
+            )
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event["source"] == "publish_artifact"
+    assert event["outcome"] == "blocked"
+    assert event["reason_code"] == "pptx_not_zip"
+    assert event["size"] == 7
+    assert "secret" not in repr(event)
+    assert "private-title" not in repr(event)

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from pptx import Presentation
 
 from opensquilla.artifacts import (
     DEFAULT_ARTIFACT_DISK_BUDGET_BYTES,
@@ -20,8 +21,30 @@ from opensquilla.artifacts import (
     artifact_payload,
     strip_artifact_markers_from_text,
 )
+from opensquilla.engine.types import ToolCall
 from opensquilla.tools.builtin.artifacts import publish_artifact
-from opensquilla.tools.types import CallerKind, ToolContext, ToolError, current_tool_context
+from opensquilla.tools.dispatch import build_tool_handler
+from opensquilla.tools.registry import ToolRegistry
+from opensquilla.tools.types import (
+    CallerKind,
+    RetryableToolInputError,
+    ToolContext,
+    ToolError,
+    ToolSpec,
+    current_tool_context,
+)
+
+PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+
+
+def _valid_pptx_bytes(title: str = "Validated deliverable") -> bytes:
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[5])
+    assert slide.shapes.title is not None
+    slide.shapes.title.text = title
+    output = io.BytesIO()
+    presentation.save(output)
+    return output.getvalue()
 
 
 def test_artifact_store_round_trips_metadata_and_bytes(tmp_path: Path) -> None:
@@ -484,6 +507,347 @@ async def test_publish_artifact_tool_keeps_download_name_mime_when_source_is_gen
     assert payload["artifact"]["mime"] == "image/png"
 
 
+@pytest.mark.parametrize(
+    ("source_name", "artifact_name", "mime"),
+    [
+        ("broken.PPTX", "download.bin", "application/octet-stream"),
+        ("broken.bin", "download.PPTX", "application/octet-stream"),
+        ("broken.bin", "download.bin", PPTX_MIME),
+    ],
+)
+@pytest.mark.asyncio
+async def test_publish_artifact_tool_rejects_invalid_pptx_from_any_format_signal(
+    tmp_path: Path,
+    source_name: str,
+    artifact_name: str,
+    mime: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    output = workspace / source_name
+    output.write_bytes(b"not a zip package")
+    media_root = tmp_path / "media"
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        with pytest.raises(RetryableToolInputError) as exc_info:
+            await publish_artifact(path=source_name, name=artifact_name, mime=mime)
+    finally:
+        current_tool_context.reset(token)
+
+    assert exc_info.value.user_message
+    assert str(output.resolve()) not in exc_info.value.user_message
+    assert not ctx.published_artifacts
+    assert not list(media_root.rglob("meta.json"))
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_invalid_pptx_dispatch_is_safe_and_retryable(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    output = workspace / "brief.pptx"
+    output.write_bytes(b"not a zip package")
+    media_root = tmp_path / "media"
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+    )
+    registry = ToolRegistry()
+    registry.register(
+        ToolSpec(
+            name="publish_artifact",
+            description="Publish a generated artifact.",
+            parameters={
+                "path": {"type": "string"},
+                "name": {"type": "string"},
+                "mime": {"type": "string"},
+            },
+            required=["path"],
+        ),
+        publish_artifact,
+    )
+    handler = build_tool_handler(registry, ctx)
+
+    result = await handler(
+        ToolCall(
+            tool_use_id="tc-invalid-pptx",
+            tool_name="publish_artifact",
+            arguments={"path": output.name, "mime": PPTX_MIME},
+        )
+    )
+
+    envelope = json.loads(result.content)
+    assert result.is_error is True
+    assert set(envelope) == {
+        "status",
+        "tool",
+        "error_class",
+        "user_message",
+        "retry_allowed",
+    }
+    assert envelope["status"] == "error"
+    assert envelope["tool"] == "publish_artifact"
+    assert envelope["error_class"] == "RetryableToolInputError"
+    assert envelope["retry_allowed"] is True
+    assert envelope["user_message"]
+    assert "regenerate" in envelope["user_message"].lower()
+    assert "not a zip package" not in envelope["user_message"]
+    assert str(output.resolve()) not in envelope["user_message"]
+    assert result.artifacts == []
+    assert not ctx.published_artifacts
+    assert not list(media_root.rglob("meta.json"))
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_preflights_pptx_budget_before_read_or_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import opensquilla.tools.builtin.artifacts as artifacts_module
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    output = workspace / "brief.pptx"
+    output.write_bytes(_valid_pptx_bytes("Validated before budget"))
+    media_root = tmp_path / "media"
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+        artifact_max_bytes=4,
+    )
+
+    validation_calls = 0
+    def unexpected_validation(*args: object, **kwargs: object) -> None:
+        nonlocal validation_calls
+        validation_calls += 1
+
+    def unexpected_read(*args: object, **kwargs: object) -> None:
+        pytest.fail("oversized PPTX must be rejected before read_bytes")
+
+    monkeypatch.setattr(
+        artifacts_module,
+        "validate_artifact_for_delivery",
+        unexpected_validation,
+    )
+    monkeypatch.setattr(artifacts_module.Path, "read_bytes", unexpected_read)
+    token = current_tool_context.set(ctx)
+    try:
+        with pytest.raises(ToolError, match="artifact exceeds per-file budget"):
+            await publish_artifact(path=output.name, mime=PPTX_MIME)
+    finally:
+        current_tool_context.reset(token)
+
+    assert validation_calls == 0
+    assert not ctx.published_artifacts
+    assert not list(media_root.rglob("meta.json"))
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_rejects_oversized_pptx_before_historical_dedupe(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    payload = _valid_pptx_bytes("Historical valid deck")
+    output = workspace / "brief.pptx"
+    output.write_bytes(payload)
+    media_root = tmp_path / "media"
+    store = ArtifactStore(media_root)
+    store.publish_bytes(
+        payload,
+        session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+        name=output.name,
+        mime=PPTX_MIME,
+        source="legacy",
+        max_bytes=None,
+    )
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+        artifact_max_bytes=4,
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        with pytest.raises(ToolError, match="artifact exceeds per-file budget"):
+            await publish_artifact(path=output.name, mime=PPTX_MIME)
+    finally:
+        current_tool_context.reset(token)
+
+    assert ctx.published_artifacts == []
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_validates_pptx_before_current_turn_dedupe(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    invalid_payload = b"not a zip package"
+    output = workspace / "brief.pptx"
+    output.write_bytes(invalid_payload)
+    previous = {
+        "id": "art-existing",
+        "sha256": hashlib.sha256(invalid_payload).hexdigest(),
+        "name": "brief.pptx",
+        "mime": PPTX_MIME,
+    }
+    media_root = tmp_path / "media"
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+        published_artifacts=[previous],
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        with pytest.raises(RetryableToolInputError):
+            await publish_artifact(path=output.name, name=output.name, mime=PPTX_MIME)
+    finally:
+        current_tool_context.reset(token)
+
+    assert ctx.published_artifacts == [previous]
+    assert not list(media_root.rglob("meta.json"))
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_validates_pptx_before_persisted_dedupe(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    invalid_payload = b"not a zip package"
+    output = workspace / "brief.pptx"
+    output.write_bytes(invalid_payload)
+    media_root = tmp_path / "media"
+    store = ArtifactStore(media_root)
+    historical = store.publish_bytes(
+        invalid_payload,
+        session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+        name=output.name,
+        mime=PPTX_MIME,
+        source="legacy_publish_artifact",
+    )
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        with pytest.raises(RetryableToolInputError):
+            await publish_artifact(path=output.name, name=output.name, mime=PPTX_MIME)
+    finally:
+        current_tool_context.reset(token)
+
+    assert not ctx.published_artifacts
+    assert [path.parent for path in media_root.rglob("meta.json")] == [
+        store.path_for(historical).parent
+    ]
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_allows_valid_retry_after_invalid_pptx_is_replaced(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    output = workspace / "brief.pptx"
+    output.write_bytes(b"not a zip package")
+    media_root = tmp_path / "media"
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        with pytest.raises(RetryableToolInputError):
+            await publish_artifact(path=output.name, mime=PPTX_MIME)
+        valid_payload = _valid_pptx_bytes("Retry succeeded")
+        output.write_bytes(valid_payload)
+        result = json.loads(await publish_artifact(path=output.name, mime=PPTX_MIME))
+    finally:
+        current_tool_context.reset(token)
+
+    assert result["status"] == "published"
+    assert len(ctx.published_artifacts) == 1
+    _, material_path = ArtifactStore(media_root).resolve_for_download(
+        result["artifact"]["id"],
+        session_id="session-1",
+    )
+    assert material_path.read_bytes() == valid_payload
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_stores_the_exact_pptx_bytes_that_were_validated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import opensquilla.tools.builtin.artifacts as artifacts_module
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    validated_payload = _valid_pptx_bytes("Validated version")
+    replacement_payload = _valid_pptx_bytes("Replacement version")
+    output = workspace / "brief.pptx"
+    output.write_bytes(validated_payload)
+    media_root = tmp_path / "media"
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+    )
+    validate = artifacts_module.validate_artifact_for_delivery
+
+    def validate_then_replace(*args: object, **kwargs: object) -> object:
+        report = validate(*args, **kwargs)
+        output.write_bytes(replacement_payload)
+        return report
+
+    monkeypatch.setattr(
+        artifacts_module,
+        "validate_artifact_for_delivery",
+        validate_then_replace,
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        result = json.loads(await publish_artifact(path=output.name, mime=PPTX_MIME))
+    finally:
+        current_tool_context.reset(token)
+
+    _, material_path = ArtifactStore(media_root).resolve_for_download(
+        result["artifact"]["id"],
+        session_id="session-1",
+    )
+    assert output.read_bytes() == replacement_payload
+    assert material_path.read_bytes() == validated_payload
+
+
 @pytest.mark.asyncio
 async def test_publish_artifact_tool_hides_local_path_from_non_owner_channel(
     tmp_path: Path,
@@ -595,7 +959,7 @@ async def test_publish_artifact_tool_reuses_existing_session_deliverable_across_
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     output = workspace / "brief.pptx"
-    output.write_bytes(b"pptx bytes")
+    output.write_bytes(_valid_pptx_bytes())
     media_root = tmp_path / "media"
 
     ctx1 = ToolContext(
@@ -610,7 +974,7 @@ async def test_publish_artifact_tool_reuses_existing_session_deliverable_across_
             await publish_artifact(
                 path="brief.pptx",
                 name="brief.pptx",
-                mime="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                mime=PPTX_MIME,
             )
         )
     finally:
@@ -628,7 +992,7 @@ async def test_publish_artifact_tool_reuses_existing_session_deliverable_across_
             await publish_artifact(
                 path="brief.pptx",
                 name="brief.pptx",
-                mime="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                mime=PPTX_MIME,
             )
         )
     finally:

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -12,6 +12,9 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     ("agents", "identity"),
     ("agents", "onboarding"),
     ("agents", "session"),
+    # Format-specific delivery validation reuses canonical attachment MIME and
+    # container signatures; contracts remains implementation-free.
+    ("artifact_validation.py", "contracts"),
     ("channels", "engine"),
     ("channels", "contracts"),
     ("channels", "gateway"),

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -50,6 +50,7 @@ OFFLINE_MARKER_EXCLUSIONS = {
     "tests/test_skills/test_meta_skill_creator_smoke_live.py",
 }
 RECENTLY_ADDED_ACTIVE_TESTS = {
+    "tests/test_artifact_validation.py",
     "tests/test_ci/test_session_storage_connection_contract.py",
     "tests/test_channels/test_stream_terminal_routing.py",
     "tests/test_engine/test_agent_canonical_text_contract.py",

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -1226,15 +1226,16 @@ def test_artifact_delivery_target_key_preserves_whitespace_and_tolerates_nul(
     ],
 )
 def test_auto_publish_dedupes_current_artifact_by_store_safe_name(
-    tmp_path,
+    tmp_path_factory: pytest.TempPathFactory,
     target_name: str,
 ) -> None:
-    workspace = tmp_path / "workspace"
+    root = tmp_path_factory.mktemp("a")
+    workspace = root / "w"
     workspace.mkdir()
     target = workspace / target_name
     payload = b"<title>Already published</title>"
     target.write_bytes(payload)
-    media_root = tmp_path / "media"
+    media_root = root / "m"
     store = ArtifactStore(media_root)
     existing = store.publish_bytes(
         payload,

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -2,13 +2,22 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import json
+import os
 from collections.abc import AsyncIterator
+from io import BytesIO
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from pptx import Presentation
 
+from opensquilla.artifacts import ArtifactStore, artifact_payload
+from opensquilla.engine.artifact_delivery import (
+    artifact_delivery_publish_target_key,
+    auto_publish_omitted_workspace_artifacts,
+)
 from opensquilla.engine.runtime import TurnRunner
 from opensquilla.engine.types import ArtifactEvent, DoneEvent, TextDeltaEvent, ToolUseStartEvent
 from opensquilla.gateway.config import AttachmentsConfig, GatewayConfig, SquillaRouterConfig
@@ -22,7 +31,13 @@ from opensquilla.session.storage import SessionStorage
 from opensquilla.tools.builtin import filesystem
 from opensquilla.tools.builtin import patch as patch_tools
 from opensquilla.tools.registry import ToolRegistry, ToolSpec
-from opensquilla.tools.types import CallerKind, ToolContext, ToolError, current_tool_context
+from opensquilla.tools.types import (
+    CallerKind,
+    RetryableToolInputError,
+    ToolContext,
+    ToolError,
+    current_tool_context,
+)
 
 
 class _ArtifactProvider:
@@ -154,6 +169,36 @@ class _FailedPublishProvider:
         return []
 
 
+class _RetryPublishProvider(_FailedPublishProvider):
+    async def _stream(self, call_number: int) -> AsyncIterator[Any]:
+        yield ProviderText(text="Regenerating the presentation. ")
+        yield ProviderToolUseStart(
+            tool_use_id=f"publish-{call_number}",
+            tool_name="publish_artifact",
+        )
+        yield ProviderToolUseEnd(
+            tool_use_id=f"publish-{call_number}",
+            tool_name="publish_artifact",
+            arguments={"path": "report.pptx"},
+        )
+        yield ProviderDone(stop_reason="tool_use", input_tokens=1, output_tokens=1)
+
+
+class _FailedCreatePptxProvider(_FailedPublishProvider):
+    async def _stream(self, call_number: int) -> AsyncIterator[Any]:
+        if call_number == 1:
+            yield ProviderToolUseStart(tool_use_id="create-1", tool_name="create_pptx")
+            yield ProviderToolUseEnd(
+                tool_use_id="create-1",
+                tool_name="create_pptx",
+                arguments={"name": "report.pptx", "slides": [{"title": "Report"}]},
+            )
+            yield ProviderDone(stop_reason="tool_use", input_tokens=1, output_tokens=1)
+            return
+        yield ProviderText(text="Report file is ready for download.")
+        yield ProviderDone(stop_reason="stop", input_tokens=1, output_tokens=1)
+
+
 class _OmittedPublishProvider:
     provider_name = "test"
 
@@ -182,6 +227,40 @@ class _OmittedPublishProvider:
             yield ProviderDone(stop_reason="tool_use", input_tokens=1, output_tokens=1)
             return
         yield ProviderText(text="Created manual-big-write.html for you.")
+        yield ProviderDone(stop_reason="stop", input_tokens=1, output_tokens=1)
+
+    async def list_models(self) -> list[ModelInfo]:
+        return []
+
+
+class _OmittedInvalidPptxProvider:
+    provider_name = "test"
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.model = "test/model"
+
+    def chat(self, messages: list[Message], tools=None, config=None) -> AsyncIterator[Any]:
+        self.calls += 1
+        return self._stream(self.calls)
+
+    async def _stream(self, call_number: int) -> AsyncIterator[Any]:
+        if call_number == 1:
+            yield ProviderToolUseStart(
+                tool_use_id="write-1",
+                tool_name="write_file",
+            )
+            yield ProviderToolUseEnd(
+                tool_use_id="write-1",
+                tool_name="write_file",
+                arguments={
+                    "path": "broken.pptx",
+                    "content": "this is not a PowerPoint package",
+                },
+            )
+            yield ProviderDone(stop_reason="tool_use", input_tokens=1, output_tokens=1)
+            return
+        yield ProviderText(text="Created broken.pptx for you.")
         yield ProviderDone(stop_reason="stop", input_tokens=1, output_tokens=1)
 
     async def list_models(self) -> list[ModelInfo]:
@@ -546,6 +625,76 @@ def _failed_publish_registry() -> ToolRegistry:
     return registry
 
 
+def _retry_publish_registry() -> ToolRegistry:
+    registry = ToolRegistry()
+    calls = 0
+
+    async def publish_artifact(path: str) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RetryableToolInputError("Regenerate the invalid PPTX and try again.")
+        ctx = current_tool_context.get()
+        assert ctx is not None
+        ctx.published_artifacts.append(
+            {
+                "id": "art-retried",
+                "kind": "artifact_ref",
+                "name": path,
+                "mime": (
+                    "application/vnd.openxmlformats-officedocument."
+                    "presentationml.presentation"
+                ),
+                "size": 8,
+                "sha256": "d" * 64,
+                "session_id": ctx.artifact_session_id,
+                "session_key": ctx.session_key,
+                "source": "publish_artifact",
+                "created_at": "2026-07-20T00:00:00Z",
+                "download_url": "/api/v1/artifacts/art-retried",
+            }
+        )
+        return json.dumps({"status": "published", "artifact": {"name": path}})
+
+    registry.register(
+        ToolSpec(
+            name="publish_artifact",
+            description="Publish a generated artifact",
+            parameters={
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+        ),
+        publish_artifact,
+    )
+    return registry
+
+
+def _failed_create_pptx_registry() -> ToolRegistry:
+    registry = ToolRegistry()
+
+    async def create_pptx(slides: list[dict[str, Any]], name: str | None = None) -> str:
+        raise RetryableToolInputError("The PPTX was not attached; regenerate it.")
+
+    registry.register(
+        ToolSpec(
+            name="create_pptx",
+            description="Create a presentation",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "slides": {"type": "array", "items": {"type": "object"}},
+                },
+                "required": ["slides"],
+            },
+        ),
+        create_pptx,
+    )
+    return registry
+
+
 def _publish_then_forbidden_tool_registry() -> tuple[ToolRegistry, list[str]]:
     registry = ToolRegistry()
     forbidden_calls: list[str] = []
@@ -844,6 +993,385 @@ async def test_turn_runner_auto_publishes_deliverable_file_when_model_omits_publ
         await storage.close()
 
 
+def test_auto_publish_validates_and_publishes_pptx_from_same_bytes(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import opensquilla.engine.artifact_delivery as artifact_delivery
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "brief.pptx"
+    presentation = Presentation()
+    presentation.slides.add_slide(presentation.slide_layouts[1])
+    presentation.save(target)
+    expected = target.read_bytes()
+    replacement = Presentation()
+    replacement.slides.add_slide(replacement.slide_layouts[5])
+    replacement_output = BytesIO()
+    replacement.save(replacement_output)
+    replacement_payload = replacement_output.getvalue()
+    validate = artifact_delivery.validate_artifact_for_delivery
+
+    def validate_then_replace(*args: object, **kwargs: object) -> object:
+        report = validate(*args, **kwargs)
+        target.write_bytes(replacement_payload)
+        return report
+
+    monkeypatch.setattr(
+        artifact_delivery,
+        "validate_artifact_for_delivery",
+        validate_then_replace,
+    )
+
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-valid-pptx",
+        session_key="agent:main:webchat:valid-pptx",
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": target.name,
+            "name": target.name,
+        }
+    )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="Created brief.pptx for you.",
+    )
+
+    assert result.failure_summaries == []
+    assert len(result.artifacts) == 1
+    artifact = result.artifacts[0]
+    assert artifact["name"] == "brief.pptx"
+    store = ArtifactStore(str(tmp_path / "media"))
+    _, material_path = store.resolve_for_download(
+        str(artifact["id"]),
+        session_id="session-valid-pptx",
+    )
+    material = material_path.read_bytes()
+    assert target.read_bytes() == replacement_payload
+    assert material == expected
+    Presentation(BytesIO(material))
+
+
+def test_auto_publish_validates_invalid_pptx_before_persisted_dedupe(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "brief.pptx"
+    invalid_payload = b"not an OOXML package"
+    target.write_bytes(invalid_payload)
+    media_root = tmp_path / "media"
+    store = ArtifactStore(media_root)
+    historical = store.publish_bytes(
+        invalid_payload,
+        session_id="session-invalid-pptx",
+        session_key="agent:main:webchat:invalid-pptx",
+        name=target.name,
+        mime="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        source="legacy",
+    )
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="session-invalid-pptx",
+        session_key="agent:main:webchat:invalid-pptx",
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": target.name,
+            "name": target.name,
+        }
+    )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="Created brief.pptx for you.",
+    )
+
+    assert result.artifacts == []
+    assert len(result.failure_summaries) == 1
+    assert ctx.published_artifacts == []
+    assert store.path_for(historical).read_bytes() == invalid_payload
+
+
+def test_auto_publish_known_valid_pptx_reports_exact_resolved_target(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    reports = workspace / "reports"
+    reports.mkdir(parents=True)
+    target = reports / "brief.pptx"
+    presentation = Presentation()
+    presentation.slides.add_slide(presentation.slide_layouts[1])
+    presentation.save(target)
+    target_sha256 = hashlib.sha256(target.read_bytes()).hexdigest()
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-known-pptx",
+        session_key="agent:main:webchat:known-pptx",
+    )
+    ctx.published_artifacts.append(
+        {
+            "id": "already-present",
+            "sha256": target_sha256,
+            "name": target.name,
+        }
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": "reports/brief.pptx",
+            "name": target.name,
+        }
+    )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="Created reports/brief.pptx for you.",
+    )
+
+    assert result.artifacts == []
+    assert result.failure_summaries == []
+    assert set(result.resolved_target_keys) == {
+        "path:" + os.path.normcase(os.path.normpath(str(target.resolve()))),
+        "name:brief.pptx",
+    }
+
+
+def test_auto_publish_nested_target_does_not_report_basename_as_resolved(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    reports = workspace / "reports"
+    reports.mkdir(parents=True)
+    target = reports / "deck.html"
+    target.write_text("<title>Deck</title>", encoding="utf-8")
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-nested-target",
+        session_key="agent:main:webchat:nested-target",
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": "reports/deck.html",
+            "name": target.name,
+        }
+    )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="Created reports/deck.html for you.",
+    )
+
+    assert len(result.artifacts) == 1
+    assert set(result.resolved_target_keys) == {
+        "path:" + os.path.normcase(os.path.normpath(str(target.resolve()))),
+        "name:deck.html",
+    }
+    assert "path:" + os.path.normcase(os.path.normpath("deck.html")) not in (
+        result.resolved_target_keys
+    )
+
+
+def test_artifact_delivery_target_key_preserves_whitespace_and_tolerates_nul(
+    tmp_path,
+) -> None:
+    workspace = tmp_path / "workspace"
+
+    plain = artifact_delivery_publish_target_key(
+        "deck.pptx",
+        workspace_dir=workspace,
+    )
+    leading_space = artifact_delivery_publish_target_key(
+        " deck.pptx",
+        workspace_dir=workspace,
+    )
+
+    assert plain is not None
+    assert leading_space is not None
+    assert plain != leading_space
+    assert artifact_delivery_publish_target_key(
+        "bad\x00deck.pptx",
+        workspace_dir=workspace,
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "target_name",
+    [
+        pytest.param(
+            "deck:unsafe.html",
+            marks=pytest.mark.skipif(
+                os.name == "nt",
+                reason="colon is not a legal Windows workspace filename",
+            ),
+        ),
+        ("x" * 156) + ".html",
+    ],
+)
+def test_auto_publish_dedupes_current_artifact_by_store_safe_name(
+    tmp_path,
+    target_name: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / target_name
+    payload = b"<title>Already published</title>"
+    target.write_bytes(payload)
+    media_root = tmp_path / "media"
+    store = ArtifactStore(media_root)
+    existing = store.publish_bytes(
+        payload,
+        session_id="session-safe-name",
+        session_key="agent:main:webchat:safe-name",
+        name=target.name,
+        mime="text/html",
+        source="publish_artifact",
+    )
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(media_root),
+        artifact_session_id="session-safe-name",
+        session_key="agent:main:webchat:safe-name",
+        published_artifacts=[artifact_payload(existing)],
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": target.name,
+            "name": target.name,
+        }
+    )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text=f"Created {target.name} for you.",
+    )
+
+    assert result.artifacts == []
+    assert result.failure_summaries == []
+    assert len(ctx.published_artifacts) == 1
+
+
+def test_auto_publish_oversized_pptx_preflights_before_read_or_validation(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import opensquilla.engine.artifact_delivery as artifact_delivery
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "large.pptx"
+    target.write_bytes(b"oversized")
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-large-pptx",
+        session_key="agent:main:webchat:large-pptx",
+        artifact_max_bytes=4,
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": target.name,
+            "name": target.name,
+        }
+    )
+
+    def unexpected_call(*args: object, **kwargs: object) -> None:
+        pytest.fail("oversized PPTX must be rejected before reading or validation")
+
+    monkeypatch.setattr(artifact_delivery.Path, "read_bytes", unexpected_call)
+    monkeypatch.setattr(
+        artifact_delivery,
+        "validate_artifact_for_delivery",
+        unexpected_call,
+    )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="Created large.pptx for you.",
+    )
+
+    assert result.artifacts == []
+    assert len(result.failure_summaries) == 1
+    assert "per-file budget" in result.failure_summaries[0]
+    assert ctx.published_artifacts == []
+
+
+@pytest.mark.asyncio
+async def test_turn_runner_rejects_invalid_omitted_pptx_and_marks_delivery_failure(
+    tmp_path,
+) -> None:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    manager = SessionManager(storage)
+    session_key = "agent:main:webchat:artifact-invalid-pptx"
+    await manager.create(session_key)
+    runner = TurnRunner(
+        provider_selector=_ProviderSelector(_OmittedInvalidPptxProvider()),
+        tool_registry=_write_file_registry(),
+        session_manager=manager,
+        config=GatewayConfig(
+            attachments=AttachmentsConfig(media_root=str(tmp_path / "media")),
+            squilla_router=SquillaRouterConfig(enabled=False),
+        ),
+    )
+    tool_context = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(tmp_path / "workspace"),
+        allowed_tools={"write_file"},
+        elevated="full",
+    )
+
+    try:
+        events = [
+            event
+            async for event in runner.run(
+                "make a presentation",
+                session_key,
+                tool_context=tool_context,
+                history_has_persisted_user=False,
+                no_memory_capture=True,
+            )
+        ]
+
+        assert [event for event in events if isinstance(event, ArtifactEvent)] == []
+        done = next(event for event in events if isinstance(event, DoneEvent))
+        assert "File delivery failed:" in done.text
+        assert "correct or regenerate it" in done.text
+
+        transcript = await manager.get_transcript(session_key)
+        assistant = [entry for entry in transcript if entry.role == "assistant"][-1]
+        assert "File delivery failed:" in assistant.content
+        assert "artifacts" not in assistant.content
+    finally:
+        await storage.close()
+
+
 @pytest.mark.asyncio
 async def test_turn_runner_does_not_auto_publish_edited_config_json(tmp_path) -> None:
     storage = SessionStorage(":memory:")
@@ -990,6 +1518,7 @@ async def test_turn_runner_marks_partial_omitted_artifact_delivery_failure(
         assert any("File delivery failed:" in text for text in text_deltas)
         assert "File delivery failed:" in done.text
         assert "some generated files were attached" in done.text
+        assert "correct or regenerate it" in done.text
         assert "no downloadable file was attached" not in done.text
 
         transcript = await manager.get_transcript(session_key)
@@ -1250,7 +1779,7 @@ async def test_turn_runner_marks_failed_artifact_delivery_in_final_text(tmp_path
         done = next(event for event in events if isinstance(event, DoneEvent))
         assert any("File delivery failed:" in text for text in text_deltas)
         assert "File delivery failed:" in done.text
-        assert "Ask me to resend the file after I correct the generated file path." in done.text
+        assert "Ask me to resend the file after I correct or regenerate it." in done.text
         assert "publish_artifact" not in done.text
         assert "active workspace" not in done.text
         assert "missing-report.pptx" not in done.text
@@ -1260,5 +1789,97 @@ async def test_turn_runner_marks_failed_artifact_delivery_in_final_text(tmp_path
         assert "Report file is ready for download." in assistant.content
         assert "File delivery failed:" in assistant.content
         assert "artifacts" not in assistant.content
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_turn_runner_clears_delivery_failure_after_same_target_retry_succeeds(
+    tmp_path,
+) -> None:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    manager = SessionManager(storage)
+    session_key = "agent:main:webchat:artifact-retry-success"
+    await manager.create(session_key)
+    provider = _RetryPublishProvider()
+    runner = TurnRunner(
+        provider_selector=_ProviderSelector(provider),
+        tool_registry=_retry_publish_registry(),
+        session_manager=manager,
+        config=GatewayConfig(
+            attachments=AttachmentsConfig(media_root=str(tmp_path / "media")),
+            squilla_router=SquillaRouterConfig(enabled=False),
+        ),
+    )
+    tool_context = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(tmp_path),
+    )
+
+    try:
+        events = [
+            event
+            async for event in runner.run(
+                "make report",
+                session_key,
+                tool_context=tool_context,
+                history_has_persisted_user=False,
+                no_memory_capture=True,
+            )
+        ]
+
+        done = next(event for event in events if isinstance(event, DoneEvent))
+        artifacts = [event for event in events if isinstance(event, ArtifactEvent)]
+        assert provider.calls == 2
+        assert [artifact.id for artifact in artifacts] == ["art-retried"]
+        assert "File delivery failed:" not in done.text
+
+        transcript = await manager.get_transcript(session_key)
+        assistant = [entry for entry in transcript if entry.role == "assistant"][-1]
+        assert "File delivery failed:" not in assistant.content
+        assert "art-retried" in assistant.content
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_turn_runner_marks_failed_create_pptx_delivery_in_final_text(tmp_path) -> None:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    manager = SessionManager(storage)
+    session_key = "agent:main:webchat:create-pptx-failed"
+    await manager.create(session_key)
+    runner = TurnRunner(
+        provider_selector=_ProviderSelector(_FailedCreatePptxProvider()),
+        tool_registry=_failed_create_pptx_registry(),
+        session_manager=manager,
+        config=GatewayConfig(
+            attachments=AttachmentsConfig(media_root=str(tmp_path / "media")),
+            squilla_router=SquillaRouterConfig(enabled=False),
+        ),
+    )
+    tool_context = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(tmp_path),
+    )
+
+    try:
+        events = [
+            event
+            async for event in runner.run(
+                "make report",
+                session_key,
+                tool_context=tool_context,
+                history_has_persisted_user=False,
+                no_memory_capture=True,
+            )
+        ]
+        done = next(event for event in events if isinstance(event, DoneEvent))
+        assert [event for event in events if isinstance(event, ArtifactEvent)] == []
+        assert "File delivery failed:" in done.text
+        assert "correct or regenerate it" in done.text
     finally:
         await storage.close()

--- a/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
@@ -577,6 +577,303 @@ def test_tool_result_handler_keeps_small_write_file_arguments() -> None:
     assert state.turn_segments[0]["input"] is arguments
 
 
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        ("publish_artifact", {"path": "deck.pptx"}),
+        ("create_pptx", {"name": "deck.pptx", "slides": [{"title": "Deck"}]}),
+    ],
+)
+def test_tool_result_handler_clears_delivery_failure_after_same_target_succeeds(
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> None:
+    state = _make_state()
+    handler = _ToolResultHandler()
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="failed",
+            tool_name=tool_name,
+            result=(
+                '{"status":"error","error_class":"RetryableToolInputError",'
+                '"user_message":"regenerate","retry_allowed":true}'
+            ),
+            is_error=True,
+            arguments=arguments,
+        ),
+        state,
+    )
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="succeeded",
+            tool_name=tool_name,
+            result='{"status":"published"}',
+            arguments=arguments,
+        ),
+        state,
+    )
+
+    assert state.artifact_delivery_failures == []
+    assert state.artifact_delivery_failures_by_target == {}
+
+
+def test_tool_result_handler_keeps_unrelated_delivery_failure_after_retry() -> None:
+    state = _make_state()
+    handler = _ToolResultHandler()
+    for target in ("first.pptx", "second.pptx"):
+        handler.handle(
+            ToolResultEvent(
+                tool_use_id=f"failed-{target}",
+                tool_name="publish_artifact",
+                result='{"status":"error","user_message":"regenerate"}',
+                is_error=True,
+                arguments={"path": target},
+            ),
+            state,
+        )
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="succeeded-first",
+            tool_name="publish_artifact",
+            result='{"status":"published"}',
+            arguments={"path": "first.pptx"},
+        ),
+        state,
+    )
+
+    assert state.artifact_delivery_failures == ["regenerate"]
+    assert set(state.artifact_delivery_failures_by_target) == {"path:second.pptx"}
+
+
+@pytest.mark.parametrize(
+    "failed_path",
+    [
+        "/workspace/reports/deck.pptx",
+        r"C:\workspace\reports\deck.pptx",
+        "reports/deck.pptx",
+    ],
+)
+def test_tool_result_handler_matches_publish_target_across_workspace_path_forms(
+    tmp_path,
+    failed_path: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    ctx = SimpleNamespace(workspace_dir=str(workspace))
+    canonical_path = workspace / "reports" / "deck.pptx"
+    state = _make_state()
+    handler = _ToolResultHandler()
+
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="failed",
+            tool_name="publish_artifact",
+            result='{"status":"error","user_message":"regenerate"}',
+            is_error=True,
+            arguments={"path": failed_path},
+        ),
+        state,
+        tool_context=ctx,
+    )
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="succeeded",
+            tool_name="publish_artifact",
+            result='{"status":"published"}',
+            arguments={"path": str(canonical_path)},
+        ),
+        state,
+        tool_context=ctx,
+    )
+
+    assert state.artifact_delivery_failures == []
+    assert state.artifact_delivery_failures_by_target == {}
+
+
+def test_tool_result_handler_uses_create_pptx_effective_basename_and_suffix() -> None:
+    state = _make_state()
+    handler = _ToolResultHandler()
+
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="failed",
+            tool_name="create_pptx",
+            result='{"status":"error","user_message":"regenerate"}',
+            is_error=True,
+            arguments={"name": "reports/deck"},
+        ),
+        state,
+    )
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="succeeded",
+            tool_name="create_pptx",
+            result='{"status":"published"}',
+            arguments={"name": "deck.pptx"},
+        ),
+        state,
+    )
+
+    assert state.artifact_delivery_failures == []
+    assert state.artifact_delivery_failures_by_target == {}
+
+
+def test_publish_success_clears_create_name_failure_but_not_other_path_failure(
+    tmp_path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    ctx = SimpleNamespace(workspace_dir=str(workspace))
+    state = _make_state()
+    handler = _ToolResultHandler()
+
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="create-failed",
+            tool_name="create_pptx",
+            result='{"status":"error","user_message":"create failed"}',
+            is_error=True,
+            arguments={"name": "deck.pptx"},
+        ),
+        state,
+        tool_context=ctx,
+    )
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="root-publish-failed",
+            tool_name="publish_artifact",
+            result='{"status":"error","user_message":"root path failed"}',
+            is_error=True,
+            arguments={"path": "deck.pptx"},
+        ),
+        state,
+        tool_context=ctx,
+    )
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="nested-publish-succeeded",
+            tool_name="publish_artifact",
+            result='{"status":"published","artifact":{"name":"deck.pptx"}}',
+            arguments={"path": "reports/deck.pptx"},
+        ),
+        state,
+        tool_context=ctx,
+    )
+
+    assert state.artifact_delivery_failures == ["root path failed"]
+    assert len(state.artifact_delivery_failures_by_target) == 1
+    assert next(iter(state.artifact_delivery_failures_by_target)).startswith("path:")
+
+
+@pytest.mark.parametrize(
+    ("failed_path_factory", "cleared"),
+    [
+        (lambda workspace: "deck.pptx", True),
+        (lambda workspace: str(workspace / "deck.pptx"), True),
+        (lambda workspace: "/workspace/deck.pptx", True),
+        (lambda workspace: "reports/deck.pptx", False),
+    ],
+)
+def test_create_pptx_success_only_clears_matching_root_publish_failure(
+    tmp_path,
+    failed_path_factory,
+    cleared: bool,
+) -> None:
+    workspace = tmp_path / "workspace"
+    ctx = SimpleNamespace(workspace_dir=str(workspace))
+    state = _make_state()
+    handler = _ToolResultHandler()
+    failed_path = failed_path_factory(workspace)
+
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="publish-failed",
+            tool_name="publish_artifact",
+            result='{"status":"error","user_message":"regenerate"}',
+            is_error=True,
+            arguments={"path": failed_path},
+        ),
+        state,
+        tool_context=ctx,
+    )
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="create-succeeded",
+            tool_name="create_pptx",
+            result='{"status":"published","artifact":{"name":"deck.pptx"}}',
+            arguments={"name": "deck.pptx", "slides": [{"title": "Deck"}]},
+        ),
+        state,
+        tool_context=ctx,
+    )
+
+    if cleared:
+        assert state.artifact_delivery_failures == []
+        assert state.artifact_delivery_failures_by_target == {}
+    else:
+        assert state.artifact_delivery_failures == ["regenerate"]
+        assert len(state.artifact_delivery_failures_by_target) == 1
+
+
+@pytest.mark.parametrize(
+    ("source_path", "explicit_name", "created_name", "cleared"),
+    [
+        ("reports/source.bin", "deck.pptx", "deck.pptx", True),
+        ("reports/source.pptx", "deck", "deck.pptx", True),
+        ("reports/source.bin", "deck", "deck.pptx", False),
+        ("reports/source.pptx", "  deck  ", "deck.pptx", True),
+        ("reports/deck.pptx", "", "deck.pptx", True),
+        ("reports/source.pptx", "de:ck", "de_ck.pptx", True),
+    ],
+)
+def test_explicit_publish_name_is_the_single_logical_failure_identity(
+    tmp_path,
+    source_path: str,
+    explicit_name: str,
+    created_name: str,
+    cleared: bool,
+) -> None:
+    workspace = tmp_path / "workspace"
+    ctx = SimpleNamespace(workspace_dir=str(workspace))
+    state = _make_state()
+    handler = _ToolResultHandler()
+
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="publish-failed",
+            tool_name="publish_artifact",
+            result='{"status":"error","user_message":"regenerate"}',
+            is_error=True,
+            arguments={"path": source_path, "name": explicit_name},
+        ),
+        state,
+        tool_context=ctx,
+    )
+
+    assert len(state.artifact_delivery_failures_by_target) == 1
+    assert next(iter(state.artifact_delivery_failures_by_target)).startswith("name:")
+
+    handler.handle(
+        ToolResultEvent(
+            tool_use_id="create-succeeded",
+            tool_name="create_pptx",
+            result=(
+                '{"status":"published","artifact":{"name":"'
+                + created_name
+                + '"}}'
+            ),
+            arguments={"name": created_name, "slides": [{"title": "Deck"}]},
+        ),
+        state,
+        tool_context=ctx,
+    )
+
+    if cleared:
+        assert state.artifact_delivery_failures == []
+        assert state.artifact_delivery_failures_by_target == {}
+    else:
+        assert state.artifact_delivery_failures == ["regenerate"]
+        assert len(state.artifact_delivery_failures_by_target) == 1
+
+
 def test_tool_result_handler_updates_tool_use_name_after_runtime_coercion() -> None:
     state = _make_state()
     state.turn_segments.append(

--- a/tests/test_gateway/test_artifacts_download.py
+++ b/tests/test_gateway/test_artifacts_download.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import hashlib
+import io
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from pptx import Presentation
 
 from opensquilla.artifacts import ArtifactStore
 
@@ -105,6 +108,67 @@ def test_artifact_download_serves_file_response_headers_and_ranges(tmp_path: Pat
     assert "report%20final.txt" in response.headers["content-disposition"]
     assert ranged.status_code == 206
     assert ranged.content == b"hello"
+
+
+def test_artifact_download_preserves_valid_pptx_bytes(tmp_path: Path) -> None:
+    pytest.importorskip("starlette.testclient")
+    from starlette.testclient import TestClient
+
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[5])
+    assert slide.shapes.title is not None
+    slide.shapes.title.text = "下载后仍可读取"
+    output = io.BytesIO()
+    presentation.save(output)
+    payload = output.getvalue()
+    ref = _publish(
+        tmp_path,
+        payload=payload,
+        name="课程总结.pptx",
+        mime=(
+            "application/vnd.openxmlformats-officedocument."
+            "presentationml.presentation"
+        ),
+    )
+
+    with TestClient(_app(tmp_path)) as client:
+        response = client.get(
+            f"/api/v1/artifacts/{ref.id}?sessionKey=agent:main:webchat:ok",
+            headers={"Authorization": "Bearer secret"},
+        )
+
+    assert response.status_code == 200
+    assert response.content == payload
+    assert ref.sha256 == hashlib.sha256(response.content).hexdigest()
+    assert response.headers["content-type"].startswith(ref.mime)
+    assert "%E8%AF%BE%E7%A8%8B%E6%80%BB%E7%BB%93.pptx" in response.headers[
+        "content-disposition"
+    ]
+    downloaded = Presentation(io.BytesIO(response.content))
+    assert downloaded.slides[0].shapes.title is not None
+    assert downloaded.slides[0].shapes.title.text == "下载后仍可读取"
+
+
+def test_artifact_download_keeps_historical_invalid_pptx_available(tmp_path: Path) -> None:
+    pytest.importorskip("starlette.testclient")
+    from starlette.testclient import TestClient
+
+    legacy_payload = b"historically stored bytes that are not OOXML"
+    ref = _publish(
+        tmp_path,
+        payload=legacy_payload,
+        name="legacy.pptx",
+        mime="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    )
+
+    with TestClient(_app(tmp_path)) as client:
+        response = client.get(
+            f"/api/v1/artifacts/{ref.id}?sessionKey=agent:main:webchat:ok",
+            headers={"Authorization": "Bearer secret"},
+        )
+
+    assert response.status_code == 200
+    assert response.content == legacy_payload
 
 
 def test_artifact_download_reports_not_found_and_integrity_errors(tmp_path: Path) -> None:

--- a/tests/test_tools/test_file_authoring_tools.py
+++ b/tests/test_tools/test_file_authoring_tools.py
@@ -10,13 +10,19 @@ from pptx import Presentation
 from pypdf import PdfReader
 
 from opensquilla.artifacts import ArtifactStore
+from opensquilla.tools.builtin import file_authoring
 from opensquilla.tools.builtin.file_authoring import (
     create_csv,
     create_pdf_report,
     create_pptx,
     create_xlsx,
 )
-from opensquilla.tools.types import CallerKind, ToolContext, current_tool_context
+from opensquilla.tools.types import (
+    CallerKind,
+    RetryableToolInputError,
+    ToolContext,
+    current_tool_context,
+)
 
 
 def _channel_artifact_context(tmp_path: Path) -> ToolContext:
@@ -123,6 +129,33 @@ async def test_create_pptx_publishes_channel_artifact(tmp_path: Path) -> None:
     slide = presentation.slides[0]
     assert slide.shapes.title.text == "Launch Readiness"
     assert "Group reply works" in slide.placeholders[1].text
+
+
+@pytest.mark.asyncio
+async def test_create_pptx_rejects_payload_that_fails_delivery_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _channel_artifact_context(tmp_path)
+    monkeypatch.setattr(
+        file_authoring,
+        "_normalize_zip_timestamps",
+        lambda _payload: b"not a PowerPoint package",
+    )
+    token = current_tool_context.set(ctx)
+    try:
+        with pytest.raises(RetryableToolInputError) as exc_info:
+            await create_pptx(
+                name="broken.pptx",
+                slides=[{"title": "Broken", "body": "This must not be published."}],
+            )
+    finally:
+        current_tool_context.reset(token)
+
+    assert "not attached" in exc_info.value.user_message
+    assert "regenerate" in exc_info.value.user_message.casefold()
+    assert ctx.published_artifacts == []
+    assert not (tmp_path / "media").exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

- Add format-aware PPTX validation at the delivery boundary for explicit publication, `create_pptx`, and omitted-artifact auto-publication.
- Validate the ZIP envelope, local/central records, CRCs, supported compression, OPC relationships, content types, presentation/slide structure, and Transitional parser reload behavior.
- Reject objectively invalid packages with the existing retryable tool-error envelope while retaining warnings for Strict OOXML and unknown parser compatibility cases.
- Keep validation ahead of SHA/current-turn/persisted deduplication and publish the same immutable bytes that were validated.
- Make delivery-failure recovery use canonical path/public-name identities without basename collisions, and include the new test file in Windows shard duration data.

## Root cause

Artifact publication previously guaranteed only that bytes were stored. It did not guarantee that a generated `.pptx` was a readable OOXML presentation, so malformed packages could be reported as published and downloaded successfully even though PowerPoint or `python-pptx` could not load them.

## User and developer impact

Invalid newly generated PPTX files are no longer attached as successful artifacts. The existing model tool loop can repair or regenerate and retry. Public tool schemas, successful JSON payloads, download APIs, Web UI behavior, generic `ArtifactStore`, non-PPTX delivery, and historical stored artifacts remain unchanged.

## Validation

- `279 passed` across the PPTX validator, publication integration, runtime/stream consumer, Gateway download, architecture, file-authoring, and Windows shard tests.
- `ruff check src tests`: passed.
- `mypy src/opensquilla --show-error-codes`: passed for 815 source files.
- `git diff --check`: passed.
- Fresh real-deck smoke test: 4 slides with Chinese text, an embedded PNG, native chart, four notes slides, and an external hyperlink; ZIP test, validator, `python-pptx` reload, exact published bytes/SHA, and LibreOffice rendering all passed.
- A truncated copy was rejected without artifact metadata or a published artifact event.
- Full public suite: 14,740 passed and 140 skipped; 45 local-environment failures remained in tmux real-terminal tests, Git LFS router artifacts, Seatbelt/system PDF dependencies, shell `python` lookup, and BSD `sed` behavior. No failure was in the changed PPTX paths.

## Safety and compatibility

- Expanded ZIP data is capped at 200 MiB and member/core XML complexity is bounded.
- Only Stored and Deflate members are accepted; encrypted/OLE containers are rejected with an actionable unsupported-encryption message.
- External relationships are never fetched.
- Validation logs contain bounded result metadata and no file content or path.
- Strict OOXML remains a structural-check warning path and intentionally skips the Transitional-only `python-pptx` smoke test.
- Windows 11 plus Microsoft PowerPoint manual acceptance remains pending before closing the issue.

## Release note

User-visible correctness fix; no configuration, database migration, RPC, schema, or frontend release-note migration is required.

## Third-party origin

None. The implementation and tests are original OpenSquilla changes; no reference-project code, comments, fixtures, or identifiers were copied.

Refs #718