### PR TITLE
Backport selected runtime fixes to report-opt-050rc4

### DIFF
--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -6268,7 +6268,24 @@ class Agent:
                             )
                             _call_attempt += 1
                             continue
-                        if not _fallback.should_retry(kind, _retry_attempt):
+                        should_retry = _fallback.should_retry(kind, _retry_attempt)
+                        retry_failed_call_safe = (
+                            getattr(
+                                self.provider,
+                                "retry_failed_call_safe",
+                                True,
+                            )
+                            is not False
+                        )
+                        if should_retry and not retry_failed_call_safe:
+                            _log.warning(
+                                "provider.retry_suppressed",
+                                reason="composite_provider",
+                                kind=kind.value,
+                                provider=getattr(self.provider, "provider_name", ""),
+                            )
+                            should_retry = False
+                        if not should_retry:
                             yield self._transition(AgentState.ERROR)
                             terminal_error = ErrorEvent(
                                 message=provider_error.message,

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -388,6 +388,13 @@ _FEISHU_READ_ONLY_TOOL_NAMES: frozenset[str] = frozenset(
 
 _MUTEX_TOOL_POLICY = _ToolConcurrencyPolicy(mode="mutex")
 _CONCURRENT_TOOL_POLICY = _ToolConcurrencyPolicy(mode="concurrent")
+# Image analysis crosses a provider boundary. Keep slide-thumbnail bursts below
+# the generic safe-tool cap so compatible vision endpoints are not saturated.
+_IMAGE_ANALYSIS_TOOL_POLICY = _ToolConcurrencyPolicy(
+    mode="concurrent",
+    max_inflight=2,
+    limit_key=("media", "image_analysis"),
+)
 _FEISHU_READ_TOOL_POLICY = _ToolConcurrencyPolicy(
     mode="concurrent",
     max_inflight=4,
@@ -401,6 +408,8 @@ def _get_tool_concurrency_policy(
     *,
     parent_session_key: str | None = None,
 ) -> _ToolConcurrencyPolicy:
+    if tool_name == "image":
+        return _IMAGE_ANALYSIS_TOOL_POLICY
     if tool_name in _SAFE_TOOL_NAMES:
         return _CONCURRENT_TOOL_POLICY
     if tool_name in _FEISHU_READ_ONLY_TOOL_NAMES:

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -1297,6 +1297,12 @@ class _SelectorFallbackProvider:
         return getattr(self._provider, name)
 
     @property
+    def retry_failed_call_safe(self) -> bool:
+        """Whether replaying the currently active provider call is safe."""
+
+        return getattr(self._provider, "retry_failed_call_safe", True) is not False
+
+    @property
     def provider_name(self) -> str:
         return getattr(self._provider, "provider_name", "")
 

--- a/src/opensquilla/provider/catalog_overrides.toml
+++ b/src/opensquilla/provider/catalog_overrides.toml
@@ -686,7 +686,7 @@ output_cost_per_mtok = 0.86
 
 [tokenrhythm."qwen3.7-max"]
 context_window = 1000000
-max_output_tokens = 256000
+max_output_tokens = 131072
 supports_reasoning = true
 supports_tools = true
 supports_vision = false

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -45,11 +45,82 @@ from .types import (
 
 TRACE_CONTENT_MAX_CHARS = 8_000
 _ENSEMBLE_HEARTBEAT_INTERVAL_SECONDS = 15.0
+_ENSEMBLE_CANCEL_CLEANUP_TIMEOUT_SECONDS = 5.0
 log = structlog.get_logger(__name__)
 
 
 def _ensemble_heartbeat_interval() -> float:
     return max(0.001, float(_ENSEMBLE_HEARTBEAT_INTERVAL_SECONDS))
+
+
+def _consume_task_result(task: asyncio.Future[Any]) -> None:
+    """Consume a detached task result so late failures are not reported globally."""
+
+    with contextlib.suppress(BaseException):
+        task.result()
+
+
+async def _bounded_task_cleanup(
+    tasks: Sequence[asyncio.Future[Any]],
+    *,
+    phase: str,
+    cleanup_deadline: float | None = None,
+) -> set[asyncio.Future[Any]]:
+    """Wait briefly for tasks and detach cancellation-resistant work."""
+
+    active = {task for task in tasks if not task.done()}
+    if not active:
+        return set()
+    cleanup_timeout = (
+        max(0.0, cleanup_deadline - time.monotonic())
+        if cleanup_deadline is not None
+        else max(0.0, float(_ENSEMBLE_CANCEL_CLEANUP_TIMEOUT_SECONDS))
+    )
+    _, lingering = await asyncio.wait(
+        active,
+        timeout=cleanup_timeout,
+    )
+    if lingering:
+        log.warning(
+            "ensemble.cancel_cleanup_timeout",
+            phase=phase,
+            pending_count=len(lingering),
+            timeout_seconds=cleanup_timeout,
+        )
+        for task in lingering:
+            task.add_done_callback(_consume_task_result)
+    return lingering
+
+
+async def _close_async_iterator(
+    stream_iter: AsyncIterator[StreamEvent],
+    *,
+    phase: str,
+    cleanup_deadline: float | None = None,
+) -> None:
+    """Close a provider iterator without letting cleanup mask the terminal event."""
+
+    aclose = getattr(stream_iter, "aclose", None)
+    if not callable(aclose):
+        return
+    try:
+        close_future = asyncio.ensure_future(aclose())
+    except Exception as exc:  # noqa: BLE001 - cleanup must not mask the root cause
+        log.warning(
+            "ensemble.stream_close_failed",
+            phase=phase,
+            error=str(exc),
+        )
+        return
+    lingering = await _bounded_task_cleanup(
+        [close_future],
+        phase=f"{phase}_close",
+        cleanup_deadline=cleanup_deadline,
+    )
+    if lingering:
+        close_future.cancel()
+    if close_future.done():
+        _consume_task_result(close_future)
 
 
 async def _stream_with_heartbeats(
@@ -85,14 +156,44 @@ async def _stream_with_heartbeats(
             yield event
             pending = asyncio.ensure_future(stream_iter.__anext__())
     finally:
+        cleanup_deadline = time.monotonic() + max(
+            0.0,
+            float(_ENSEMBLE_CANCEL_CLEANUP_TIMEOUT_SECONDS),
+        )
         if not pending.done():
             pending.cancel()
-            with contextlib.suppress(asyncio.CancelledError, StopAsyncIteration):
-                await pending
-        aclose = getattr(stream_iter, "aclose", None)
-        if callable(aclose):
-            with contextlib.suppress(Exception):
-                await aclose()
+            lingering = await _bounded_task_cleanup(
+                [pending],
+                phase=f"{phase}_stream",
+                cleanup_deadline=cleanup_deadline,
+            )
+            if lingering:
+                # A second cancellation interrupts providers that suppress the
+                # first CancelledError while unwinding their stream.
+                pending.cancel()
+        if pending.done():
+            _consume_task_result(pending)
+            await _close_async_iterator(
+                stream_iter,
+                phase=phase,
+                cleanup_deadline=cleanup_deadline,
+            )
+        else:
+            # If __anext__ ignored cancellation, close the iterator as soon as
+            # that in-flight call eventually yields or exits. This callback is
+            # detached so the user-facing timeout remains bounded.
+            def _close_after_pending(done: asyncio.Future[Any]) -> None:
+                _consume_task_result(done)
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    return
+                close_task = loop.create_task(
+                    _close_async_iterator(stream_iter, phase=phase)
+                )
+                close_task.add_done_callback(_consume_task_result)
+
+            pending.add_done_callback(_close_after_pending)
 
 
 @dataclass(frozen=True)
@@ -491,6 +592,10 @@ class EnsembleProvider:
     """G8 fusion provider: proposer candidates first, one aggregator stream after."""
 
     provider_name = "ensemble"
+    # Replaying one failed chat would rerun every proposer plus aggregation.
+    # Selector fallback may still hop to a single provider, whose default is
+    # retry-safe, before the Agent considers a same-provider retry.
+    retry_failed_call_safe = False
 
     def __init__(
         self,
@@ -779,29 +884,45 @@ class EnsembleProvider:
                 index += 1
         if not tasks:
             return []
-        if (
-            self.quorum_grace_seconds <= 0
-            or self.min_successful_proposers >= len(tasks)
-        ):
-            return sorted(
-                await asyncio.gather(*tasks),
-                key=lambda result: (result.index, result.sample_index),
-            )
 
         results: list[_CandidateResult] = []
         pending: set[asyncio.Task[_CandidateResult]] = set(tasks)
+        cancel_code = ""
+        cancel_message = ""
         try:
+            if len(pending) < self.min_successful_proposers:
+                cancel_code = "quorum_unreachable"
+                cancel_message = (
+                    "proposer cancelled because ensemble quorum is unreachable: "
+                    f"0 successful + {len(pending)} pending "
+                    f"< {self.min_successful_proposers} required"
+                )
             while pending:
+                if cancel_code:
+                    break
                 done, pending = await asyncio.wait(
                     pending,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
                 for task in done:
                     results.append(await task)
-                if sum(1 for result in results if result.ok) >= self.min_successful_proposers:
+
+                successful_count = sum(1 for result in results if result.ok)
+                if successful_count + len(pending) < self.min_successful_proposers:
+                    cancel_code = "quorum_unreachable"
+                    cancel_message = (
+                        "proposer cancelled because ensemble quorum became unreachable: "
+                        f"{successful_count} successful + {len(pending)} pending "
+                        f"< {self.min_successful_proposers} required"
+                    )
+                    break
+                if (
+                    self.quorum_grace_seconds > 0
+                    and successful_count >= self.min_successful_proposers
+                ):
                     break
 
-            if pending:
+            if pending and not cancel_code:
                 done, pending = await asyncio.wait(
                     pending,
                     timeout=self.quorum_grace_seconds,
@@ -810,23 +931,29 @@ class EnsembleProvider:
                     results.append(await task)
 
             if pending:
+                controlled_code = cancel_code or "quorum_cancelled"
+                controlled_message = cancel_message or (
+                    "proposer cancelled after "
+                    f"{self.quorum_grace_seconds:g}s ensemble quorum grace"
+                )
                 for task in pending:
-                    setattr(task, "_opensquilla_ensemble_cancel_code", "quorum_cancelled")
+                    setattr(task, "_opensquilla_ensemble_cancel_code", controlled_code)
                     setattr(
                         task,
                         "_opensquilla_ensemble_cancel_message",
-                        (
-                            "proposer cancelled after "
-                            f"{self.quorum_grace_seconds:g}s ensemble quorum grace"
-                        ),
+                        controlled_message,
                     )
                     task.cancel()
                 remaining = list(pending)
-                cancelled_results = await asyncio.gather(*remaining, return_exceptions=True)
-                for task, item in zip(remaining, cancelled_results, strict=True):
-                    if isinstance(item, _CandidateResult):
-                        results.append(item)
-                    else:
+                lingering = await _bounded_task_cleanup(remaining, phase="proposers")
+                for task in remaining:
+                    if task.done():
+                        with contextlib.suppress(BaseException):
+                            item = task.result()
+                            if isinstance(item, _CandidateResult):
+                                results.append(item)
+                                continue
+                    if task in lingering or task.done():
                         index, sample_index, member = task_meta[task]
                         cfg = member.provider_config
                         results.append(
@@ -836,8 +963,8 @@ class EnsembleProvider:
                                 label=member.label or f"proposer_{index + 1}",
                                 provider=cfg.provider,
                                 model=cfg.model,
-                                error=str(item),
-                                error_code=type(item).__name__,
+                                error=controlled_message,
+                                error_code=controlled_code,
                             )
                         )
             return sorted(results, key=lambda result: (result.index, result.sample_index))
@@ -846,7 +973,10 @@ class EnsembleProvider:
                 if not task.done():
                     task.cancel()
             if pending:
-                await asyncio.gather(*pending, return_exceptions=True)
+                await _bounded_task_cleanup(list(pending), phase="proposers_external_cancel")
+                for task in pending:
+                    if task.done():
+                        _consume_task_result(task)
             raise
 
     async def _collect_candidate(
@@ -1277,6 +1407,11 @@ class EnsembleProvider:
             else:
                 yield ErrorEvent(message=reason, code=code)
             return
+        fallback_timeout_seconds = float(
+            getattr(config, "timeout", ChatConfig().timeout)
+            if config is not None
+            else ChatConfig().timeout
+        )
         trace = self._trace_payload(
             candidates,
             successful_count=sum(1 for candidate in candidates if candidate.ok),
@@ -1287,42 +1422,64 @@ class EnsembleProvider:
             final_request_config=config,
             final_request_tools=tools,
             final_request_messages=messages,
-            final_request_timeout_seconds=(
-                float(getattr(config, "timeout", 0.0) or 0.0) if config is not None else None
-            ),
+            final_request_timeout_seconds=fallback_timeout_seconds,
         )
         proposer_rows = _candidate_usage_rows(candidates, profile=self.profile_name)
         final_text_parts: list[str] = []
-        async for event in self.fallback_provider.chat(messages, tools=tools, config=config):
-            if isinstance(event, DoneEvent):
-                output_text = "".join(final_text_parts)
-                _attach_final_request_output(trace, event=event, output_text=output_text)
-                fallback_row = _done_usage_row(
-                    event,
-                    role="fallback_single",
-                    profile=self.profile_name,
-                    label="fallback",
-                    provider=str(getattr(self.fallback_provider, "provider_name", "fallback")),
-                    model=event.model,
-                )
-                rows = [*proposer_rows, fallback_row]
-                yield replace(
-                    event,
-                    input_tokens=_summed_int(rows, "input_tokens"),
-                    output_tokens=_summed_int(rows, "output_tokens"),
-                    reasoning_tokens=_summed_int(rows, "reasoning_tokens"),
-                    cached_tokens=_summed_int(rows, "cached_tokens"),
-                    cache_write_tokens=_summed_int(rows, "cache_write_tokens"),
-                    billed_cost=_summed_float(rows, "billed_cost"),
-                    cost_source=_rollup_cost_source(rows),
-                    model_usage_breakdown=rows,
-                    ensemble_trace=trace,
-                )
-            elif isinstance(event, TextDeltaEvent):
-                final_text_parts.append(event.text)
+        yield ProviderHeartbeatEvent(
+            phase="ensemble_fallback",
+            message="Ensemble quorum unavailable; waiting for fallback model",
+        )
+        try:
+            async for event in _stream_with_heartbeats(
+                self.fallback_provider.chat(messages, tools=tools, config=config),
+                phase="ensemble_fallback_wait",
+                message="Waiting for ensemble fallback model",
+                timeout_seconds=fallback_timeout_seconds,
+            ):
+                if isinstance(event, DoneEvent):
+                    output_text = "".join(final_text_parts)
+                    _attach_final_request_output(trace, event=event, output_text=output_text)
+                    fallback_row = _done_usage_row(
+                        event,
+                        role="fallback_single",
+                        profile=self.profile_name,
+                        label="fallback",
+                        provider=str(
+                            getattr(self.fallback_provider, "provider_name", "fallback")
+                        ),
+                        model=event.model,
+                    )
+                    rows = [*proposer_rows, fallback_row]
+                    yield replace(
+                        event,
+                        input_tokens=_summed_int(rows, "input_tokens"),
+                        output_tokens=_summed_int(rows, "output_tokens"),
+                        reasoning_tokens=_summed_int(rows, "reasoning_tokens"),
+                        cached_tokens=_summed_int(rows, "cached_tokens"),
+                        cache_write_tokens=_summed_int(rows, "cache_write_tokens"),
+                        billed_cost=_summed_float(rows, "billed_cost"),
+                        cost_source=_rollup_cost_source(rows),
+                        model_usage_breakdown=rows,
+                        ensemble_trace=trace,
+                    )
+                    return
+                if isinstance(event, ErrorEvent):
+                    yield event
+                    return
+                if isinstance(event, TextDeltaEvent):
+                    final_text_parts.append(event.text)
                 yield event
-            else:
-                yield event
+        except TimeoutError:
+            yield ErrorEvent(
+                message=f"ensemble fallback timed out after {fallback_timeout_seconds:g}s",
+                code="ensemble_fallback_timeout",
+            )
+            return
+        yield ErrorEvent(
+            message="ensemble fallback stream ended before DoneEvent",
+            code="ensemble_fallback_incomplete",
+        )
 
 
 def _trace_content(text: str, *, max_chars: int = TRACE_CONTENT_MAX_CHARS) -> dict[str, Any]:

--- a/tests/test_engine/test_agent_retry_budget.py
+++ b/tests/test_engine/test_agent_retry_budget.py
@@ -40,6 +40,11 @@ class _SequenceProvider:
         return []
 
 
+class _CompositeSequenceProvider(_SequenceProvider):
+    provider_name = "ensemble"
+    retry_failed_call_safe = False
+
+
 def _reasoning_only_done() -> ProviderDone:
     return ProviderDone(
         stop_reason="stop",
@@ -224,6 +229,61 @@ async def test_timeout_error_code_retries_when_message_lacks_timeout_token() -> 
     assert len(provider.calls) == 2
     assert any(event.kind == "done" and event.text == "ok" for event in events)
     assert not any(event.kind == "error" and event.code == "timeout" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_composite_timeout_surfaces_without_replaying_full_call() -> None:
+    provider = _CompositeSequenceProvider(
+        [
+            [ProviderError(message="Request timed out: ", code="timeout")],
+            [ProviderText(text="should-not-run"), _ok_done()],
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_provider_retries=3,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert len(provider.calls) == 1
+    assert any(event.kind == "error" and event.code == "timeout" for event in events)
+    assert not any(
+        event.kind == "text_delta" and event.text == "should-not-run"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_composite_partial_timeout_does_not_duplicate_visible_text() -> None:
+    provider = _CompositeSequenceProvider(
+        [
+            [
+                ProviderText(text="partial"),
+                ProviderError(message="Request timed out: ", code="timeout"),
+            ],
+            [ProviderText(text="duplicate"), _ok_done()],
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_provider_retries=3,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert len(provider.calls) == 1
+    visible = [event.text for event in events if event.kind == "text_delta"]
+    assert visible == ["partial"]
+    assert any(event.kind == "error" and event.code == "timeout" for event in events)
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_ensemble_progress_forwarding.py
+++ b/tests/test_engine/test_ensemble_progress_forwarding.py
@@ -185,3 +185,74 @@ async def test_selector_fallback_control_events_remain_live_and_do_not_block_fal
         event.kind == "text_delta" and event.text == "synthesized answer"
         for event in events
     )
+
+
+@pytest.mark.asyncio
+async def test_selector_fallback_restores_single_provider_retry_safety() -> None:
+    from opensquilla.engine.runtime import _SelectorFallbackProvider
+
+    class _Composite:
+        provider_name = "ensemble"
+        retry_failed_call_safe = False
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def chat(self, messages: Any, tools: Any = None, config: Any = None) -> Any:
+            self.calls += 1
+            yield ProviderErrorEvent(message="rate limited", code="429")
+
+    class _Fallback:
+        provider_name = "openrouter"
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def chat(self, messages: Any, tools: Any = None, config: Any = None) -> Any:
+            self.calls += 1
+            if self.calls == 1:
+                yield ProviderErrorEvent(message="Request timed out: ", code="timeout")
+                return
+            yield ProviderText(text="fallback recovered")
+            yield ProviderDone(stop_reason="stop", input_tokens=1, output_tokens=1)
+
+    composite = _Composite()
+    fallback = _Fallback()
+
+    class _Selector:
+        current_config = type("Config", (), {"model": "ensemble/model"})()
+
+        def next_fallback_after_failure(self, exc: Exception) -> Any:
+            del exc
+            self.current_config = type("Config", (), {"model": "fallback/model"})()
+            return fallback
+
+    wrapper = _SelectorFallbackProvider(composite, _Selector())
+    agent = Agent(
+        provider=wrapper,
+        config=AgentConfig(
+            max_iterations=2,
+            max_provider_retries=1,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+        tool_definitions=[
+            ToolDefinition(
+                name="echo",
+                description="Echo.",
+                input_schema=ToolInputSchema(properties={}, required=[]),
+            )
+        ],
+        tool_handler=_tool_handler,
+    )
+
+    events = [event async for event in agent.run_turn("hi")]
+
+    assert composite.calls == 1
+    assert fallback.calls == 2
+    assert wrapper.retry_failed_call_safe is True
+    assert not any(event.kind == "error" for event in events)
+    assert any(
+        event.kind == "text_delta" and event.text == "fallback recovered"
+        for event in events
+    )

--- a/tests/test_engine/test_tool_concurrency.py
+++ b/tests/test_engine/test_tool_concurrency.py
@@ -229,6 +229,41 @@ async def test_feishu_read_only_tools_have_independent_inflight_cap() -> None:
 
 
 @pytest.mark.asyncio
+async def test_image_analysis_calls_have_dedicated_inflight_cap() -> None:
+    """Vision requests should not fan out at the generic safe-tool limit."""
+    tool_calls = [("image", {"path": f"slide-{i}.png"}) for i in range(6)]
+    in_flight = 0
+    max_in_flight = 0
+
+    async def _handler(tc: ToolCall) -> ToolResult:
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(_TOOL_SLEEP_S)
+        in_flight -= 1
+        return ToolResult(
+            tool_use_id=tc.tool_use_id,
+            tool_name=tc.tool_name,
+            content="ok",
+        )
+
+    provider = _FixedToolCallArgsProvider(tool_calls)
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(max_iterations=2, max_safe_tool_concurrency=6),
+        tool_definitions=[_tool_def("image")],
+        tool_handler=_handler,
+    )
+
+    t0 = time.monotonic()
+    await _collect(agent)
+    elapsed = time.monotonic() - t0
+
+    assert max_in_flight == 2
+    assert 3 * _TOOL_SLEEP_S - _SCHEDULER_TOLERANCE_S <= elapsed < 4 * _TOOL_SLEEP_S
+
+
+@pytest.mark.asyncio
 async def test_feishu_mutating_tools_remain_serial() -> None:
     """Feishu writes must remain mutex even when read-only Feishu tools batch."""
     tool_calls = [

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -41,6 +41,8 @@ class _FakePlan:
     events: list[StreamEvent]
     delay: float = 0.0
     gate: asyncio.Event | None = None
+    started: asyncio.Event | None = None
+    closed: asyncio.Event | None = None
 
 
 @dataclass
@@ -84,12 +86,18 @@ class _FakeProvider:
             }
         )
         plan = self._registry.plans[self._cfg.model]
-        if plan.delay > 0:
-            await asyncio.sleep(plan.delay)
-        if plan.gate is not None:
-            await plan.gate.wait()
-        for event in plan.events:
-            yield event
+        if plan.started is not None:
+            plan.started.set()
+        try:
+            if plan.delay > 0:
+                await asyncio.sleep(plan.delay)
+            if plan.gate is not None:
+                await plan.gate.wait()
+            for event in plan.events:
+                yield event
+        finally:
+            if plan.closed is not None:
+                plan.closed.set()
 
     async def list_models(self) -> list[Any]:
         return []
@@ -1092,6 +1100,137 @@ async def test_ensemble_uses_fallback_when_too_few_proposers_succeed(
 
 
 @pytest.mark.asyncio
+async def test_fallback_timeout_is_absolute_and_cleanup_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _FakeRegistry(
+        {"p1": _FakePlan([ErrorEvent(message="nope", code="boom")])}
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_HEARTBEAT_INTERVAL_SECONDS",
+        0.005,
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_CANCEL_CLEANUP_TIMEOUT_SECONDS",
+        0.01,
+    )
+    release = asyncio.Event()
+    cancellation_seen = asyncio.Event()
+    closed = asyncio.Event()
+    cancellation_count = 0
+
+    class _CancellationResistantFallback:
+        provider_name = "fallback"
+
+        def chat(
+            self,
+            messages: list[Message],
+            tools: list[ToolDefinition] | None = None,
+            config: ChatConfig | None = None,
+        ) -> AsyncIterator[StreamEvent]:
+            async def _stream() -> AsyncIterator[StreamEvent]:
+                nonlocal cancellation_count
+                try:
+                    while not release.is_set():
+                        try:
+                            await release.wait()
+                        except asyncio.CancelledError:
+                            cancellation_count += 1
+                            cancellation_seen.set()
+                    yield TextDeltaEvent(text="late-after-timeout")
+                    await asyncio.Event().wait()
+                finally:
+                    closed.set()
+
+            return _stream()
+
+        async def list_models(self) -> list[Any]:
+            return []
+
+    provider = EnsembleProvider(
+        profile_name="default",
+        proposers=[_member("p1")],
+        aggregator=_member("agg"),
+        fallback_provider=_CancellationResistantFallback(),
+        min_successful_proposers=1,
+        proposer_timeout_seconds=1,
+        aggregator_timeout_seconds=1,
+        shuffle_candidates=False,
+    )
+
+    started = time.monotonic()
+    events = [
+        event
+        async for event in provider.chat(
+            [Message(role="user", content="answer this")],
+            config=ChatConfig(timeout=0.02),
+        )
+    ]
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.3
+    assert cancellation_seen.is_set() is True
+    assert any(
+        isinstance(event, ProviderHeartbeatEvent)
+        and event.phase == "ensemble_fallback_wait"
+        for event in events
+    )
+    error = next(event for event in events if isinstance(event, ErrorEvent))
+    assert error.code == "ensemble_fallback_timeout"
+    release.set()
+    await asyncio.wait_for(closed.wait(), timeout=0.5)
+    assert cancellation_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_fallback_stream_without_done_returns_incomplete_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _FakeRegistry(
+        {"p1": _FakePlan([ErrorEvent(message="nope", code="boom")])}
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+
+    class _PartialFallback:
+        provider_name = "fallback"
+
+        def chat(
+            self,
+            messages: list[Message],
+            tools: list[ToolDefinition] | None = None,
+            config: ChatConfig | None = None,
+        ) -> AsyncIterator[StreamEvent]:
+            async def _stream() -> AsyncIterator[StreamEvent]:
+                yield TextDeltaEvent(text="partial")
+
+            return _stream()
+
+        async def list_models(self) -> list[Any]:
+            return []
+
+    provider = EnsembleProvider(
+        profile_name="default",
+        proposers=[_member("p1")],
+        aggregator=_member("agg"),
+        fallback_provider=_PartialFallback(),
+        min_successful_proposers=1,
+        proposer_timeout_seconds=1,
+        aggregator_timeout_seconds=1,
+        shuffle_candidates=False,
+    )
+
+    events = await _collect(provider)
+
+    assert any(
+        isinstance(event, TextDeltaEvent) and event.text == "partial"
+        for event in events
+    )
+    error = next(event for event in events if isinstance(event, ErrorEvent))
+    assert error.code == "ensemble_fallback_incomplete"
+
+
+@pytest.mark.asyncio
 async def test_openrouter_members_get_member_specific_reasoning_capabilities(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1325,6 +1464,8 @@ async def test_static_openrouter_b5_quorum_cancels_slow_proposer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     slow_gate = asyncio.Event()
+    slow_closed = asyncio.Event()
+    aggregator_started = asyncio.Event()
     registry = _FakeRegistry(
         {
             "p1": _FakePlan([TextDeltaEvent(text="d1"), DoneEvent(model="p1")]),
@@ -1333,12 +1474,14 @@ async def test_static_openrouter_b5_quorum_cancels_slow_proposer(
             "p4": _FakePlan(
                 [TextDeltaEvent(text="d4"), DoneEvent(model="p4")],
                 gate=slow_gate,
+                closed=slow_closed,
             ),
             "agg": _FakePlan(
                 [
                     TextDeltaEvent(text="final"),
                     DoneEvent(input_tokens=1, output_tokens=1, model="agg"),
-                ]
+                ],
+                started=aggregator_started,
             ),
         }
     )
@@ -1354,11 +1497,17 @@ async def test_static_openrouter_b5_quorum_cancels_slow_proposer(
         shuffle_candidates=False,
     )
 
-    started = time.monotonic()
-    events = await _collect(provider)
-    elapsed = time.monotonic() - started
+    consume_task = asyncio.create_task(_collect(provider))
+    try:
+        await asyncio.wait_for(aggregator_started.wait(), timeout=1.0)
+        events = await asyncio.wait_for(consume_task, timeout=1.0)
+    finally:
+        if not consume_task.done():
+            consume_task.cancel()
+        await asyncio.gather(consume_task, return_exceptions=True)
 
-    assert elapsed < 0.5
+    assert slow_gate.is_set() is False
+    assert slow_closed.is_set() is True
     assert [call["model"] for call in registry.calls] == ["p1", "p2", "p3", "p4", "agg"]
     done = next(event for event in events if isinstance(event, DoneEvent))
     assert done.ensemble_trace is not None
@@ -1376,6 +1525,284 @@ async def test_static_openrouter_b5_quorum_cancels_slow_proposer(
     assert "d2" in str(registry.calls[-1]["messages"][-1].content)
     assert "d3" in str(registry.calls[-1]["messages"][-1].content)
     assert "d4" not in str(registry.calls[-1]["messages"][-1].content)
+
+
+@pytest.mark.asyncio
+async def test_quorum_grace_keeps_a_final_proposer_that_finishes_in_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    slow_gate = asyncio.Event()
+    grace_started = asyncio.Event()
+    real_asyncio_wait = asyncio.wait
+
+    async def observed_wait(
+        futures: set[asyncio.Task[Any]],
+        **kwargs: Any,
+    ) -> tuple[set[asyncio.Task[Any]], set[asyncio.Task[Any]]]:
+        if kwargs.get("timeout") == 0.5:
+            grace_started.set()
+        return await real_asyncio_wait(futures, **kwargs)
+
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan([TextDeltaEvent(text="d1"), DoneEvent(model="p1")]),
+            "p2": _FakePlan([TextDeltaEvent(text="d2"), DoneEvent(model="p2")]),
+            "p3": _FakePlan([TextDeltaEvent(text="d3"), DoneEvent(model="p3")]),
+            "p4": _FakePlan(
+                [TextDeltaEvent(text="d4"), DoneEvent(model="p4")],
+                gate=slow_gate,
+            ),
+            "agg": _FakePlan([TextDeltaEvent(text="final"), DoneEvent(model="agg")]),
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    monkeypatch.setattr("opensquilla.provider.ensemble.asyncio.wait", observed_wait)
+    provider = EnsembleProvider(
+        profile_name="static_openrouter_b5",
+        proposers=[_member("p1"), _member("p2"), _member("p3"), _member("p4")],
+        aggregator=_member("agg"),
+        min_successful_proposers=3,
+        proposer_timeout_seconds=10,
+        aggregator_timeout_seconds=1,
+        quorum_grace_seconds=0.5,
+        shuffle_candidates=False,
+    )
+
+    consume_task = asyncio.create_task(_collect(provider))
+    try:
+        await asyncio.wait_for(grace_started.wait(), timeout=1.0)
+        assert slow_gate.is_set() is False
+        slow_gate.set()
+        events = await asyncio.wait_for(consume_task, timeout=1.0)
+    finally:
+        if not consume_task.done():
+            consume_task.cancel()
+        await asyncio.gather(consume_task, return_exceptions=True)
+
+    assert [call["model"] for call in registry.calls] == [
+        "p1",
+        "p2",
+        "p3",
+        "p4",
+        "agg",
+    ]
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["successful_proposers"] == 4
+    assert done.ensemble_trace["selected_candidate_indexes"] == [0, 1, 2, 3]
+    assert done.ensemble_trace["candidates"][3]["ok"] is True
+    assert "d4" in str(registry.calls[-1]["messages"][-1].content)
+
+
+@pytest.mark.asyncio
+async def test_failed_proposer_does_not_start_grace_before_success_quorum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    quorum_gate = asyncio.Event()
+    straggler_gate = asyncio.Event()
+    waiting_below_quorum = asyncio.Event()
+    grace_started = asyncio.Event()
+    real_asyncio_wait = asyncio.wait
+
+    async def observed_wait(
+        futures: set[asyncio.Task[Any]],
+        **kwargs: Any,
+    ) -> tuple[set[asyncio.Task[Any]], set[asyncio.Task[Any]]]:
+        timeout = kwargs.get("timeout")
+        if timeout is None and len(futures) == 2:
+            waiting_below_quorum.set()
+        elif timeout == 0.02:
+            grace_started.set()
+        return await real_asyncio_wait(futures, **kwargs)
+
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan([TextDeltaEvent(text="d1"), DoneEvent(model="p1")]),
+            "p2": _FakePlan([ErrorEvent(message="boom", code="upstream")]),
+            "p3": _FakePlan(
+                [TextDeltaEvent(text="d3"), DoneEvent(model="p3")],
+                gate=quorum_gate,
+            ),
+            "p4": _FakePlan(
+                [TextDeltaEvent(text="d4"), DoneEvent(model="p4")],
+                gate=straggler_gate,
+            ),
+            "agg": _FakePlan([TextDeltaEvent(text="final"), DoneEvent(model="agg")]),
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    monkeypatch.setattr("opensquilla.provider.ensemble.asyncio.wait", observed_wait)
+    provider = EnsembleProvider(
+        profile_name="static_openrouter_b5",
+        proposers=[_member("p1"), _member("p2"), _member("p3"), _member("p4")],
+        aggregator=_member("agg"),
+        min_successful_proposers=2,
+        proposer_timeout_seconds=10,
+        aggregator_timeout_seconds=1,
+        quorum_grace_seconds=0.02,
+        shuffle_candidates=False,
+    )
+
+    consume_task = asyncio.create_task(_collect(provider))
+    try:
+        await asyncio.wait_for(waiting_below_quorum.wait(), timeout=1.0)
+        assert grace_started.is_set() is False
+        quorum_gate.set()
+        await asyncio.wait_for(grace_started.wait(), timeout=1.0)
+        events = await asyncio.wait_for(consume_task, timeout=1.0)
+    finally:
+        if not consume_task.done():
+            consume_task.cancel()
+        await asyncio.gather(consume_task, return_exceptions=True)
+
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["successful_proposers"] == 2
+    assert done.ensemble_trace["selected_candidate_indexes"] == [0, 2]
+    assert done.ensemble_trace["candidates"][1]["error_code"] == "upstream"
+    assert done.ensemble_trace["candidates"][3]["error_code"] == "quorum_cancelled"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("quorum_grace_seconds", [0.0, 0.02])
+async def test_unreachable_quorum_cancels_pending_and_uses_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    quorum_grace_seconds: float,
+) -> None:
+    slow_gate = asyncio.Event()
+    p3_closed = asyncio.Event()
+    p4_closed = asyncio.Event()
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan([ErrorEvent(message="p1 failed", code="upstream")]),
+            "p2": _FakePlan([ErrorEvent(message="p2 failed", code="upstream")]),
+            "p3": _FakePlan(
+                [TextDeltaEvent(text="d3"), DoneEvent(model="p3")],
+                gate=slow_gate,
+                closed=p3_closed,
+            ),
+            "p4": _FakePlan(
+                [TextDeltaEvent(text="d4"), DoneEvent(model="p4")],
+                gate=slow_gate,
+                closed=p4_closed,
+            ),
+            "agg": _FakePlan([TextDeltaEvent(text="unused"), DoneEvent(model="agg")]),
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+
+    class _FallbackProvider:
+        provider_name = "fallback"
+
+        def chat(
+            self,
+            messages: list[Message],
+            tools: list[ToolDefinition] | None = None,
+            config: ChatConfig | None = None,
+        ) -> AsyncIterator[StreamEvent]:
+            async def _stream() -> AsyncIterator[StreamEvent]:
+                yield TextDeltaEvent(text="single")
+                yield DoneEvent(model="single")
+
+            return _stream()
+
+        async def list_models(self) -> list[Any]:
+            return []
+
+    provider = EnsembleProvider(
+        profile_name="static_openrouter_b5",
+        proposers=[_member("p1"), _member("p2"), _member("p3"), _member("p4")],
+        aggregator=_member("agg"),
+        fallback_provider=_FallbackProvider(),
+        min_successful_proposers=3,
+        proposer_timeout_seconds=10,
+        aggregator_timeout_seconds=1,
+        quorum_grace_seconds=quorum_grace_seconds,
+        shuffle_candidates=False,
+    )
+
+    events = await asyncio.wait_for(_collect(provider), timeout=1.0)
+
+    assert slow_gate.is_set() is False
+    assert p3_closed.is_set() is True
+    assert p4_closed.is_set() is True
+    assert "agg" not in [call["model"] for call in registry.calls]
+    progress = [event for event in events if isinstance(event, EnsembleProgressEvent)]
+    assert len([event for event in progress if event.event_type == "proposer_start"]) == 4
+    assert len([event for event in progress if event.event_type == "proposer_finish"]) == 4
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["successful_proposers"] == 0
+    assert done.ensemble_trace["total_candidates"] == 4
+    assert done.ensemble_trace["llm_request_count"] == 5
+    candidates = done.ensemble_trace["candidates"]
+    assert [candidate["error_code"] for candidate in candidates[:2]] == [
+        "upstream",
+        "upstream",
+    ]
+    assert [candidate["error_code"] for candidate in candidates[2:]] == [
+        "quorum_unreachable",
+        "quorum_unreachable",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_required_all_quorum_cancels_remaining_after_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    slow_gate = asyncio.Event()
+    slow_closed = asyncio.Event()
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan([ErrorEvent(message="p1 failed", code="upstream")]),
+            "p2": _FakePlan(
+                [TextDeltaEvent(text="d2"), DoneEvent(model="p2")],
+                gate=slow_gate,
+                closed=slow_closed,
+            ),
+            "agg": _FakePlan([TextDeltaEvent(text="unused"), DoneEvent(model="agg")]),
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+
+    class _FallbackProvider:
+        provider_name = "fallback"
+
+        def chat(
+            self,
+            messages: list[Message],
+            tools: list[ToolDefinition] | None = None,
+            config: ChatConfig | None = None,
+        ) -> AsyncIterator[StreamEvent]:
+            async def _stream() -> AsyncIterator[StreamEvent]:
+                yield TextDeltaEvent(text="single")
+                yield DoneEvent(model="single")
+
+            return _stream()
+
+        async def list_models(self) -> list[Any]:
+            return []
+
+    provider = EnsembleProvider(
+        profile_name="default",
+        proposers=[_member("p1"), _member("p2")],
+        aggregator=_member("agg"),
+        fallback_provider=_FallbackProvider(),
+        min_successful_proposers=2,
+        proposer_timeout_seconds=10,
+        aggregator_timeout_seconds=1,
+        quorum_grace_seconds=0,
+        shuffle_candidates=False,
+    )
+
+    events = await asyncio.wait_for(_collect(provider), timeout=1.0)
+
+    assert slow_gate.is_set() is False
+    assert slow_closed.is_set() is True
+    assert "agg" not in [call["model"] for call in registry.calls]
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["candidates"][1]["error_code"] == "quorum_unreachable"
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_model_catalog.py
+++ b/tests/test_provider_model_catalog.py
@@ -43,7 +43,12 @@ def test_provider_scoped_corrections_budget_outranks_snapshot_merge() -> None:
     assert catalog.resolve_context_window("kimi-k2.7-code", provider="tokenrhythm") == 256_000
     assert catalog.resolve_max_tokens("kimi-k2.7-code", provider="tokenrhythm") == 128_000
     assert catalog.resolve_context_window("qwen3.7-max", provider="tokenrhythm") == 1_000_000
-    assert catalog.resolve_max_tokens("qwen3.7-max", provider="tokenrhythm") == 256_000
+    assert catalog.resolve_max_tokens("qwen3.7-max", provider="tokenrhythm") == 131_072
+    # The correction is scoped to TokenRhythm. Direct/provider-less snapshot
+    # routes retain their own 65,536-token output limit.
+    assert catalog.resolve_max_tokens("qwen3.7-max") == 65_536
+    assert catalog.resolve_max_tokens("qwen3.7-max", provider="dashscope") == 65_536
+    assert catalog.resolve_max_tokens("qwen3.7-max", provider="openrouter") == 65_536
     # The same bare id on direct DeepSeek keeps its own snapshot-table
     # budgets — the provider-scoped layer never leaks across providers.
     assert catalog.resolve_context_window("deepseek-v4-flash", "deepseek") == 1_000_000


### PR DESCRIPTION
## Scope

Target branch: `report-opt-050rc4` (`d8041bd`, the v0.5.0rc4-based reporting branch).

- Correct TokenRhythm `qwen3.7-max` output metadata from 256,000 to 131,072 tokens, with provider-isolation assertions.
- Limit image-analysis tool execution to two in-flight requests per turn.
- Backport the backend Ensemble quorum, bounded cancellation cleanup, fallback timeout, and composite retry-safety fixes from #704.

## Why

This temporary release branch needs the reporting work from #736 plus a narrowly selected set of runtime bug fixes already proven on `main`, without inheriting the rest of `main`.

## Backport boundaries

- Qwen fix: adapted from `b679e593` / #685 as the minimal two-file change; the full 70-file commit is intentionally not included.
- Image concurrency: clean cherry-pick of `0c2fe0c` / #686.
- Ensemble: scoped adaptation of `b3cbc6c` / #704. It intentionally excludes the Web Chat 30-minute runtime cap, Gateway config changes, WebUI, docs, generated `static/dist`, and the B5 quorum-grace change. The rc4 30-second grace remains unchanged.

## Validation

- `uv run pytest -q tests/test_provider_model_catalog.py tests/test_engine/test_tool_concurrency.py tests/test_provider_ensemble.py tests/test_engine/test_agent_retry_budget.py tests/test_engine/test_ensemble_progress_forwarding.py tests/test_llm_ensemble_config.py` — 123 passed.
- `uv run ruff check` on all nine changed files — passed.
- `git diff --check origin/report-opt-050rc4...HEAD` — passed.

## Compatibility and safety

- Platform-neutral Python/TOML changes; no OS-specific behavior.
- No database, persisted configuration, RPC/protocol, or static-asset migration.
- Qwen metadata and image concurrency changes are low risk. The Ensemble backport is medium risk because impossible quorums now fail over earlier and composite calls are not replayed wholesale after failure.

Linked issue: None.

Release note: Included in the temporary v0.5.0rc4 reporting release notes.

Third-party origin: None; all adapted changes originate from commits in this repository.
