### PR TITLE
feat: render HTML artifacts inline with sandboxed iframe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ module = [
     "src.router.*",
     "tiktoken.*",
     "tokenizers.*",
+    "websockets.*",
     "yaml.*",
     "yoyo.*",
 ]

--- a/src/opensquilla/channels/slack.py
+++ b/src/opensquilla/channels/slack.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import hmac
 import json
@@ -81,6 +82,11 @@ class SlackChannel:
     reply_in_thread: bool = False
     signing_secret: str | None = None
     status_reactions_enabled: bool = False
+    # Transport selection. ``socket`` uses Slack Socket Mode (an outbound
+    # websocket long-connection) and needs no public Request URL; it requires
+    # ``app_token`` (an ``xapp-`` App-Level Token with ``connections:write``).
+    connection_mode: str = "webhook"
+    app_token: str = ""
     # ``policy`` declares the admit/deny semantics consumed by
     # ``opensquilla.channels._util.evaluate_policy``. Slack admits DMs, admits
     # group messages only when the bot is mentioned, and applies no
@@ -105,7 +111,14 @@ class SlackChannel:
         init=False,
         repr=False,
     )
+    _socket_task: asyncio.Task | None = field(default=None, init=False, repr=False)
+    _socket_stop: asyncio.Event | None = field(default=None, init=False, repr=False)
     supports_slash_commands: bool = True
+
+    @property
+    def transport_name(self) -> str:
+        """``websocket`` in Socket Mode so the gateway skips webhook routing."""
+        return "websocket" if self.connection_mode == "socket" else "webhook"
 
     @property
     def capability_profile(self) -> ChannelCapabilityProfile:
@@ -121,7 +134,7 @@ class SlackChannel:
             thread_reply=True,
             edit=True,
             delete=True,
-            transports=("webhook",),
+            transports=(self.transport_name,),
         )
 
     @property
@@ -234,35 +247,62 @@ class SlackChannel:
             metadata=metadata,
         )
 
+    def build_reply_message(self, content: str, inbound: IncomingMessage) -> OutgoingMessage:
+        """Target the inbound conversation so batch replies need no static channel id."""
+        return OutgoingMessage(content=content, reply_to=inbound.channel_id)
+
+    def streaming_reply_kwargs(self, inbound: IncomingMessage) -> dict[str, Any]:
+        """Stream the reply into the inbound conversation."""
+        return {"channel": inbound.channel_id}
+
     # ------------------------------------------------------------------
     # Outbound
     # ------------------------------------------------------------------
 
     async def send(self, message: OutgoingMessage) -> None:
-        """Post a message to the Slack channel via chat.postMessage."""
-        payload: dict[str, Any] = {
-            "channel": self.slack_channel_id,
-            "text": message.content,
-        }
-        if message.reply_to:
-            payload["thread_ts"] = message.reply_to
-        elif self.reply_in_thread and self._last_thread_ts:
-            payload["thread_ts"] = self._last_thread_ts
-        if message.metadata:
-            if "thread_ts" in message.metadata and message.metadata["thread_ts"] is None:
-                payload.pop("thread_ts", None)
-            payload.update(
-                {key: value for key, value in message.metadata.items() if value is not None}
-            )
+        """Post a message to the originating Slack conversation.
+
+        The destination is resolved from ``reply_to`` — the gateway routes the
+        source conversation there — so the bot answers wherever it was
+        addressed without a statically configured ``slack_channel_id``. Slack
+        conversation ids are prefixed ``C``/``G``/``D``; a bare message
+        timestamp is treated as a thread anchor instead. An explicit
+        ``metadata['channel']`` / ``metadata['thread_ts']`` still wins.
+        """
+        meta = message.metadata or {}
+        channel = self.slack_channel_id
+        thread_ts: str | None = None
+        rt = (message.reply_to or "").strip()
+        if rt[:1] in ("C", "G", "D"):
+            channel = rt
+        elif rt:
+            thread_ts = rt
+        if meta.get("channel"):
+            channel = str(meta["channel"])
+        if "thread_ts" in meta:
+            thread_ts = meta["thread_ts"]
+        elif thread_ts is None and self.reply_in_thread and self._last_thread_ts:
+            thread_ts = self._last_thread_ts
+        if not channel:
+            log.error("slack.send_failed", channel="", error="no_target_channel")
+            raise RuntimeError("Slack send has no target channel")
+
+        payload: dict[str, Any] = {"channel": channel, "text": message.content}
+        if thread_ts:
+            payload["thread_ts"] = thread_ts
+        for key, value in meta.items():
+            if key in ("channel", "thread_ts") or value is None:
+                continue
+            payload[key] = value
 
         client = self._get_client()
         resp = await client.post("/chat.postMessage", json=payload)
         resp.raise_for_status()
         data = resp.json()
         if not data.get("ok"):
-            log.error("slack.send_failed", error=data.get("error"), channel=self.slack_channel_id)
+            log.error("slack.send_failed", channel=channel, error=data.get("error"))
             raise RuntimeError(f"Slack API error: {data.get('error')}")
-        log.debug("slack.send", channel=self.slack_channel_id, ts=data.get("ts"))
+        log.debug("slack.send", channel=channel, ts=data.get("ts"))
 
     async def send_file(
         self,
@@ -349,25 +389,30 @@ class SlackChannel:
         self,
         chunks: AsyncIterator[str],
         *,
+        channel: str | None = None,
         thread_ts: str | None = None,
         update_interval_ms: int = 500,
     ) -> str | None:
         """Send a streaming message: post first chunk, update with subsequent chunks.
 
         Returns the message ``ts`` or ``None`` if the iterator was empty.
+        ``channel`` targets the originating conversation (defaulting to
+        ``slack_channel_id``) so a streamed reply lands where the bot was
+        addressed without a statically configured channel.
 
         Uses ``StreamThrottle`` so a fast producer cannot fire two
         concurrent ``chat.update`` calls and a single network failure
         does not lose accumulated text.
         """
         client = self._get_client()
+        target = channel or self.slack_channel_id
         throttle = StreamThrottle(interval_s=update_interval_ms / 1000.0)
         message_ts: str | None = None
 
         async def _post(text: str) -> None:
             nonlocal message_ts
             payload: dict[str, Any] = {
-                "channel": self.slack_channel_id,
+                "channel": target,
                 "text": text,
             }
             if thread_ts:
@@ -384,7 +429,7 @@ class SlackChannel:
             resp = await client.post(
                 "/chat.update",
                 json={
-                    "channel": self.slack_channel_id,
+                    "channel": target,
                     "ts": message_ts,
                     "text": text,
                 },
@@ -433,7 +478,8 @@ class SlackChannel:
     # ------------------------------------------------------------------
 
     async def start(self) -> None:
-        """Validate token via auth.test and store bot_user_id."""
+        """Validate the bot token, store ``bot_user_id``, and — in Socket Mode —
+        open the Slack Socket Mode long-connection."""
         client = self._get_client()
         resp = await client.post("/auth.test")
         resp.raise_for_status()
@@ -441,16 +487,104 @@ class SlackChannel:
         if not data.get("ok"):
             raise SlackAuthError(data.get("error", "unknown auth error"))
         self.bot_user_id = data["user_id"]
+        if self.connection_mode == "socket":
+            if not self.app_token:
+                raise SlackAuthError(
+                    "connection_mode='socket' requires app_token (an xapp- App-Level Token)"
+                )
+            self._socket_stop = asyncio.Event()
+            self._socket_task = asyncio.create_task(
+                self._run_socket_loop(), name="slack-socket-mode"
+            )
         self._connected = True
-        log.info("slack.started", bot_user_id=self.bot_user_id)
+        log.info("slack.started", bot_user_id=self.bot_user_id, mode=self.connection_mode)
 
     async def stop(self) -> None:
         """Gracefully shut down the channel adapter."""
+        if self._socket_stop is not None:
+            self._socket_stop.set()
+        if self._socket_task is not None:
+            self._socket_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._socket_task
+            self._socket_task = None
         if self._client is not None:
             await self._client.aclose()
             self._client = None
         self._connected = False
         log.info("slack.stopped")
+
+    # ------------------------------------------------------------------
+    # Socket Mode transport (no public Request URL required)
+    # ------------------------------------------------------------------
+
+    async def _open_socket_connection(self) -> str:
+        """Open a Socket Mode session and return the issued ``wss://`` url."""
+        client = self._get_client()
+        resp = await client.post(
+            "/apps.connections.open",
+            headers={"Authorization": f"Bearer {self.app_token}"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if not data.get("ok"):
+            raise SlackAuthError(f"apps.connections.open failed: {data.get('error')}")
+        return str(data["url"])
+
+    async def _run_socket_loop(self) -> None:
+        """Maintain the Socket Mode websocket, reconnecting with backoff."""
+        import websockets
+
+        backoff = 1.0
+        stop = self._socket_stop
+        while stop is None or not stop.is_set():
+            try:
+                ws_url = await self._open_socket_connection()
+                async with websockets.connect(
+                    ws_url, ping_interval=30, ping_timeout=20, max_size=None
+                ) as ws:
+                    self._connected = True
+                    backoff = 1.0
+                    log.info("slack.socket_mode.connected")
+                    async for raw in ws:
+                        if stop is not None and stop.is_set():
+                            break
+                        await self._handle_socket_frame(ws, raw)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._connected = False
+                log.warning("slack.socket_mode.reconnect", error=str(exc), backoff=backoff)
+                if stop is None:
+                    break
+                with contextlib.suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(stop.wait(), timeout=backoff)
+                if stop.is_set():
+                    break
+                backoff = min(backoff * 2, 30.0)
+
+    async def _handle_socket_frame(self, ws: Any, raw: str | bytes) -> None:
+        """Ack and dispatch a single Socket Mode frame."""
+        try:
+            msg = json.loads(raw)
+        except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
+            return
+        # Slack requires an ack (echo the envelope id) within 3 seconds.
+        envelope_id = msg.get("envelope_id")
+        if envelope_id:
+            with contextlib.suppress(Exception):
+                await ws.send(json.dumps({"envelope_id": envelope_id}))
+        mtype = msg.get("type")
+        if mtype == "disconnect":
+            # Slack rotates connections periodically; close so the loop reconnects.
+            with contextlib.suppress(Exception):
+                await ws.close()
+            return
+        if mtype != "events_api":
+            return
+        payload = msg.get("payload")
+        if isinstance(payload, dict) and payload.get("type") == "event_callback":
+            self._ingest_event_callback(payload)
 
     def is_connected(self) -> bool:
         """Return whether the adapter has been started and is connected."""
@@ -497,19 +631,36 @@ class SlackChannel:
             return JSONResponse({"challenge": challenge})
 
         if event_type == "event_callback":
-            event = data.get("event", {})
-            if event.get("type") == "message":
-                dedupe_key = str(
-                    data.get("event_id")
-                    or event.get("client_msg_id")
-                    or f"{event.get('channel', '')}:{event.get('ts', '')}"
-                ).strip(":")
-                if dedupe_key and not self._dedupe.check_and_add(dedupe_key):
-                    return Response(status_code=200)
-                msg = self.parse_event(event)
-                self.enqueue(msg)
+            self._ingest_event_callback(data)
 
         return Response(status_code=200)
+
+    def _ingest_event_callback(self, data: dict[str, Any]) -> None:
+        """Shared inbound path for an Events API ``event_callback`` payload,
+        used by both the webhook handler and the Socket Mode loop."""
+        event = data.get("event", {})
+        if not isinstance(event, dict) or event.get("type") != "message":
+            return
+        # Only plain user messages are input; drop edits/deletes/joins and the
+        # bot's own streaming-edit echoes (``message_changed`` etc.).
+        if event.get("subtype") not in (None, "file_share", "me_message", "thread_broadcast"):
+            return
+        if self._is_own_message(event):
+            return
+        dedupe_key = str(
+            data.get("event_id")
+            or event.get("client_msg_id")
+            or f"{event.get('channel', '')}:{event.get('ts', '')}"
+        ).strip(":")
+        if dedupe_key and not self._dedupe.check_and_add(dedupe_key):
+            return
+        self.enqueue(self.parse_event(event))
+
+    def _is_own_message(self, event: dict[str, Any]) -> bool:
+        """Drop the bot's own messages so replies never loop back as input."""
+        if event.get("subtype") == "bot_message" or event.get("bot_id"):
+            return True
+        return bool(self.bot_user_id and event.get("user") == self.bot_user_id)
 
     def _verify_signature(self, body: bytes, timestamp: str, signature: str) -> bool:
         """Verify Slack request signature using HMAC-SHA256."""

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -1095,6 +1095,11 @@ class SlackChannelEntry(ConfiguredChannelEntry):
     slack_channel_id: str = ""
     signing_secret: str | None = None
     reply_in_thread: bool = False
+    # ``socket`` uses Slack Socket Mode (an outbound websocket long-connection,
+    # like Feishu) and needs no public Request URL; ``webhook`` keeps the
+    # Events API webhook. Socket Mode additionally requires ``app_token``.
+    connection_mode: Literal["webhook", "socket"] = "webhook"
+    app_token: str = ""
 
 
 class FeishuChannelEntry(ConfiguredChannelEntry):

--- a/src/opensquilla/gateway/static/css/views/chat.css
+++ b/src/opensquilla/gateway/static/css/views/chat.css
@@ -1364,6 +1364,58 @@
   padding: 3px 8px;
 }
 
+.msg-artifact-html-preview {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-top: var(--sp-2);
+  overflow: hidden;
+  width: 100%;
+}
+
+.msg-artifact-html-preview__header {
+  align-items: center;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  font-size: var(--fs-xs);
+  justify-content: space-between;
+  padding: 6px 10px;
+}
+
+.msg-artifact-html-preview__name {
+  color: var(--text-2);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.msg-artifact-html-preview__download {
+  color: var(--accent);
+  flex-shrink: 0;
+  font-weight: 600;
+  margin-left: var(--sp-2);
+  text-decoration: none;
+}
+
+.msg-artifact-html-preview__download:hover {
+  text-decoration: underline;
+}
+
+.msg-artifact-html-preview__frame {
+  border: 0;
+  display: block;
+  height: 400px;
+  width: 100%;
+}
+
+.msg-artifact-html-preview__unavailable {
+  color: var(--text-3);
+  font-size: var(--fs-sm);
+  padding: var(--sp-4);
+  text-align: center;
+}
+
 .msg.user .msg-body.msg-body--has-attachments {
   align-items: flex-end;
   background: transparent;

--- a/src/opensquilla/gateway/static/js/views/chat.js
+++ b/src/opensquilla/gateway/static/js/views/chat.js
@@ -7793,6 +7793,22 @@ const ChatView = (() => {
           </span>
           <span class="msg-artifact-card__action" aria-hidden="true">Download</span>
         </a>`;
+      } else if (mime.startsWith('text/html') || _artifactExtension(name) === 'html' || _artifactExtension(name) === 'htm') {
+        const htmlPreviewUrl = _artifactPreviewUrl(artifact || {});
+        html += `<div class="msg-artifact-html-preview">
+          <div class="msg-artifact-html-preview__header">
+            <span class="msg-artifact-html-preview__name">${_esc(name)}</span>
+            <a class="msg-artifact-html-preview__download" href="${_escAttr(downloadHref)}" download="${_escAttr(name)}" title="Download ${_escAttr(name)}">Download</a>
+          </div>
+          ${htmlPreviewUrl
+            ? `<iframe class="msg-artifact-html-preview__frame"
+                src="${_escAttr(htmlPreviewUrl)}"
+                sandbox="allow-scripts"
+                loading="lazy"
+                title="${_escAttr(name)}"></iframe>`
+            : `<div class="msg-artifact-html-preview__unavailable">Preview unavailable</div>`
+          }
+        </div>`;
       } else {
         html += `<a class="msg-artifact-chip" href="${_escAttr(downloadHref)}" download="${_escAttr(name)}" data-artifact-category="${_escAttr(category)}" data-artifact-download="${_escAttr(downloadUrl)}" data-artifact-id="${_escAttr(artifact?.id || '')}" data-artifact-name="${_escAttr(name)}" title="${_escAttr(name)}">
           <span class="msg-file-chip__icon" aria-hidden="true">${_esc(_artifactCategoryLabel(category))}</span>

--- a/src/opensquilla/onboarding/channel_specs.py
+++ b/src/opensquilla/onboarding/channel_specs.py
@@ -62,25 +62,39 @@ def _slack_spec() -> ChannelSetupSpec:
     return ChannelSetupSpec(
         type="slack",
         label="Slack",
-        description="Slack workspace bot using bot token + signing secret.",
-        transport="webhook",
-        requires_public_url=True,
+        description="Slack workspace bot — Socket Mode (websocket) or Events API webhook.",
+        transport="mixed",
+        requires_public_url=False,
         dependency_extra=None,
         restart_required=True,
         docs_hint="https://api.slack.com/apps",
-        help="Slack webhooks require a public URL reachable by Slack.",
+        help=(
+            "connection_mode=socket uses Slack Socket Mode (an outbound websocket) and "
+            "needs no public URL — set app_token (xapp-...). connection_mode=webhook uses "
+            "the Events API and needs a public Request URL reachable by Slack."
+        ),
         fields=(
             *_common_fields(),
             ChannelSetupField("token", "Bot token (xoxb-...)", "password",
                               required=True, secret=True, group="credentials",
                               placeholder="xoxb-..."),
+            ChannelSetupField("app_token", "App-level token (xapp-...)", "password",
+                              required=False, secret=True, group="credentials",
+                              placeholder="xapp-...",
+                              show_when={"connection_mode": "socket"}),
             ChannelSetupField("slack_channel_id", "Default channel id", "text",
-                              required=False, default=""),
+                              required=False, default="",
+                              description="Optional; replies auto-target the incoming "
+                              "conversation when unset."),
             ChannelSetupField("signing_secret", "Signing secret", "password",
                               required=False, secret=True, group="credentials",
-                              advanced=True),
+                              advanced=True,
+                              show_when={"connection_mode": "webhook"}),
             ChannelSetupField("reply_in_thread", "Reply in thread", "bool",
                               required=False, default=False),
+            ChannelSetupField("connection_mode", "Connection mode", "select",
+                              required=False, default="webhook",
+                              choices=("webhook", "socket")),
         ),
     )
 

--- a/tests/test_channels/test_slack_socket_mode.py
+++ b/tests/test_channels/test_slack_socket_mode.py
@@ -1,0 +1,139 @@
+"""Slack Socket Mode transport, auto-target replies, and self-echo filtering."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from opensquilla.channels.slack import SlackAuthError, SlackChannel
+from opensquilla.channels.types import IncomingMessage, OutgoingMessage
+
+
+def _mk(**kwargs: Any) -> SlackChannel:
+    kwargs.setdefault("slack_channel_id", "")
+    ch = SlackChannel(token="xoxb-test", **kwargs)
+    ch.bot_user_id = "UBOT"
+    return ch
+
+
+class _FakeResp:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def post(
+        self, path: str, json: dict[str, Any] | None = None, headers: Any = None
+    ) -> _FakeResp:
+        self.calls.append((path, json))
+        if path == "/auth.test":
+            return _FakeResp({"ok": True, "user_id": "UBOT"})
+        return _FakeResp({"ok": True, "ts": "1700000000.000100"})
+
+
+# ── transport selection ───────────────────────────────────────────────────
+
+
+def test_transport_name_follows_connection_mode() -> None:
+    assert _mk().transport_name == "webhook"
+    assert _mk(connection_mode="socket").transport_name == "websocket"
+
+
+async def test_socket_mode_requires_app_token() -> None:
+    ch = _mk(connection_mode="socket")  # no app_token
+    ch._get_client = lambda: _FakeClient()  # type: ignore[method-assign]
+    with pytest.raises(SlackAuthError):
+        await ch.start()
+
+
+# ── inbound filtering (the self-echo / loop guard) ─────────────────────────
+
+
+def test_ingest_accepts_plain_user_message() -> None:
+    ch = _mk()
+    ch._ingest_event_callback(
+        {
+            "event_id": "Ev1",
+            "event": {
+                "type": "message",
+                "user": "UUSER",
+                "channel": "D123",
+                "text": "hi",
+                "ts": "1.1",
+            },
+        }
+    )
+    assert ch._queue.qsize() == 1
+    msg = ch._queue.get_nowait()
+    assert msg.channel_id == "D123"
+    assert msg.content == "hi"
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"type": "message", "bot_id": "B1", "channel": "D1", "text": "x", "ts": "2"},
+        {"type": "message", "user": "UBOT", "channel": "D1", "text": "x", "ts": "3"},
+        {"type": "message", "subtype": "bot_message", "channel": "D1", "text": "x", "ts": "4"},
+        {"type": "message", "subtype": "message_changed", "channel": "D1", "ts": "5"},
+        {"type": "message", "subtype": "message_deleted", "channel": "D1", "ts": "6"},
+    ],
+)
+def test_ingest_drops_self_echoes_and_non_user_subtypes(event: dict[str, Any]) -> None:
+    ch = _mk()
+    ch._ingest_event_callback({"event_id": f"e-{event.get('ts')}", "event": event})
+    assert ch._queue.qsize() == 0
+
+
+def test_ingest_dedupes_replayed_event() -> None:
+    ch = _mk()
+    payload = {
+        "event_id": "Dup1",
+        "event": {"type": "message", "user": "U", "channel": "D1", "text": "hi", "ts": "9"},
+    }
+    ch._ingest_event_callback(payload)
+    ch._ingest_event_callback(payload)
+    assert ch._queue.qsize() == 1
+
+
+# ── outbound: auto-target the originating conversation ─────────────────────
+
+
+async def test_send_auto_targets_reply_conversation() -> None:
+    ch = _mk()  # slack_channel_id empty on purpose
+    fake = _FakeClient()
+    ch._get_client = lambda: fake  # type: ignore[method-assign]
+    await ch.send(OutgoingMessage(content="hello", reply_to="D999"))
+    post = next(c for c in fake.calls if c[0] == "/chat.postMessage")
+    assert post[1] is not None
+    assert post[1]["channel"] == "D999"
+    # A conversation id must NOT be misused as a thread anchor.
+    assert "thread_ts" not in post[1]
+
+
+async def test_send_threads_only_on_message_ts() -> None:
+    ch = _mk(slack_channel_id="C1")
+    fake = _FakeClient()
+    ch._get_client = lambda: fake  # type: ignore[method-assign]
+    await ch.send(OutgoingMessage(content="hi", reply_to="1700000000.000200"))
+    post = next(c for c in fake.calls if c[0] == "/chat.postMessage")
+    assert post[1] is not None
+    assert post[1]["channel"] == "C1"
+    assert post[1]["thread_ts"] == "1700000000.000200"
+
+
+def test_reply_helpers_target_inbound_conversation() -> None:
+    ch = _mk()
+    inbound = IncomingMessage(sender_id="U", channel_id="D42", content="hi")
+    assert ch.build_reply_message("r", inbound).reply_to == "D42"
+    assert ch.streaming_reply_kwargs(inbound) == {"channel": "D42"}


### PR DESCRIPTION
Closes #737 (partial — HTML inline preview)

## What

HTML artifacts produced by skills (e.g. Q&A dialogs, reports) previously required opening an external browser or application. This change renders them inline in the chat.

## How it works

`_renderArtifacts` now detects `text/html` MIME type (including variants like `text/html; charset=utf-8`) and `.html`/`.htm` file extensions. Matching artifacts are rendered as a sandboxed `<iframe>` instead of a download chip.

**Security**: `sandbox="allow-scripts"` only — `allow-same-origin` is intentionally omitted so scripts inside the iframe cannot access the parent frame's localStorage, cookies, or DOM.

**Fallback**: if no preview URL can be resolved the iframe is replaced with a `"Preview unavailable"` message, preventing a blank `src=""` from reloading the current page.

## Files changed

- `src/opensquilla/gateway/static/js/views/chat.js` — new `else if` branch in `_renderArtifacts`
- `src/opensquilla/gateway/static/css/views/chat.css` — styles for `.msg-artifact-html-preview`, `__header`, `__name`, `__download`, `__frame`, `__unavailable`