### PR TITLE
feat(chat): add collapse/expand-all control for tool call groups

### DIFF
--- a/opensquilla-webui/src/components/chat/AssistantMessage.vue
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.vue
@@ -25,6 +25,17 @@
     </button>
     <div class="msg-ai-main">
       <ReasoningPart v-if="reasoningPart" :part="reasoningPart" />
+      <button
+        v-if="hasMultipleToolGroups"
+        type="button"
+        class="msg-tool-collapse-btn"
+        :aria-expanded="anyToolGroupOpen"
+        :title="anyToolGroupOpen ? t('chat.tool.collapseAll') : t('chat.tool.expandAll')"
+        @click="toggleAllToolGroups"
+      >
+        <Icon :name="anyToolGroupOpen ? 'chevronDown' : 'chevronRight'" :size="13" />
+        <span>{{ anyToolGroupOpen ? t('chat.tool.collapseAll') : t('chat.tool.expandAll') }}</span>
+      </button>
       <ToolCallTimeline
         v-if="message.timelineItems?.length"
         :items="message.timelineItems"
@@ -438,6 +449,34 @@ const legacyTimelineItems = computed<ChatStreamTimelineItem[]>(() => {
   }))
 })
 
+// Group ids for whichever timeline is actually rendered (streaming items win;
+// otherwise the reconstructed legacy groups). Drives the message-level
+// collapse/expand-all control below.
+const toolGroupIds = computed<string[]>(() => {
+  const items = props.message.timelineItems?.length
+    ? props.message.timelineItems
+    : legacyTimelineItems.value
+  return items
+    .filter((item): item is Extract<ChatStreamTimelineItem, { type: 'tool-group' }> => item.type === 'tool-group')
+    .map(item => item.group.groupId)
+})
+
+// Only worth showing a bulk toggle once a turn has more than one tool group.
+const hasMultipleToolGroups = computed(() => toolGroupIds.value.length > 1)
+
+// Reactive via props.isToolGroupOpen, which reads the shared openToolGroups set.
+const anyToolGroupOpen = computed(() => toolGroupIds.value.some(id => props.isToolGroupOpen(id)))
+
+// Collapse every group when any is open, otherwise expand them all. Reuses the
+// existing per-group toggle so the shared open-state stays the single source of
+// truth; only groups whose state differs from the target are toggled.
+function toggleAllToolGroups() {
+  const targetOpen = !anyToolGroupOpen.value
+  for (const id of toolGroupIds.value) {
+    if (props.isToolGroupOpen(id) !== targetOpen) emit('toggleToolGroup', id)
+  }
+}
+
 function onMessageClick(event: MouseEvent) {
   if (!props.shareMode) return
   if (props.message.stopNotice) return
@@ -471,6 +510,40 @@ function ensembleRole(role: string, label: string): string {
   padding: 0.5rem 0;
   align-items: flex-start;
   max-width: calc(100% - 48px);
+}
+
+.msg-tool-collapse-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  align-self: flex-start;
+  margin-bottom: var(--sp-1);
+  padding: var(--sp-1) var(--sp-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  color: var(--text-dim);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color var(--dur-fast) var(--ease-standard), color var(--dur-fast) var(--ease-standard);
+}
+
+.msg-tool-collapse-btn:hover {
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
+  color: var(--text);
+}
+
+.msg-tool-collapse-btn:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .msg-tool-collapse-btn {
+    transition: none;
+  }
 }
 
 .msg-ai--share-mode {

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -2330,7 +2330,9 @@
       "results": "{count} Ergebnisse",
       "countRunning": "{count} laufen",
       "countDone": "{count} fertig",
-      "countFailed": "{count} fehlgeschlagen"
+      "countFailed": "{count} fehlgeschlagen",
+      "collapseAll": "Alle einklappen",
+      "expandAll": "Alle ausklappen"
     },
     "chips": {
       "whatCanYouDo": "Was kannst du?",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -2330,7 +2330,9 @@
       "results": "{count} results",
       "countRunning": "{count} running",
       "countDone": "{count} done",
-      "countFailed": "{count} failed"
+      "countFailed": "{count} failed",
+      "collapseAll": "Collapse all",
+      "expandAll": "Expand all"
     },
     "chips": {
       "whatCanYouDo": "What can you do?",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -2330,7 +2330,9 @@
       "results": "{count} resultados",
       "countRunning": "{count} en ejecución",
       "countDone": "{count} hechos",
-      "countFailed": "{count} fallidos"
+      "countFailed": "{count} fallidos",
+      "collapseAll": "Contraer todo",
+      "expandAll": "Expandir todo"
     },
     "chips": {
       "whatCanYouDo": "¿Qué puedes hacer?",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -2330,7 +2330,9 @@
       "results": "{count} résultats",
       "countRunning": "{count} en cours",
       "countDone": "{count} terminé(s)",
-      "countFailed": "{count} en échec"
+      "countFailed": "{count} en échec",
+      "collapseAll": "Tout réduire",
+      "expandAll": "Tout développer"
     },
     "chips": {
       "whatCanYouDo": "Que peux-tu faire ?",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -2330,7 +2330,9 @@
       "results": "{count} 件の結果",
       "countRunning": "{count} 件実行中",
       "countDone": "{count} 件完了",
-      "countFailed": "{count} 件失敗"
+      "countFailed": "{count} 件失敗",
+      "collapseAll": "すべて折りたたむ",
+      "expandAll": "すべて展開"
     },
     "chips": {
       "whatCanYouDo": "何ができますか？",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -2330,7 +2330,9 @@
       "results": "{count} 条结果",
       "countRunning": "{count} 项运行中",
       "countDone": "{count} 项完成",
-      "countFailed": "{count} 项失败"
+      "countFailed": "{count} 项失败",
+      "collapseAll": "全部折叠",
+      "expandAll": "全部展开"
     },
     "chips": {
       "whatCanYouDo": "你能做什么？",


### PR DESCRIPTION
Closes #739

## What

When an assistant turn contains more than one tool call group, a small toggle button appears above the tool timeline. Clicking it collapses every group at once, or expands them all when they are already collapsed. Single-group turns are unaffected (the control only renders when there are 2+ groups).

This targets the **Vue** WebUI (`opensquilla-webui/`), which is the default frontend — not the frozen legacy `static/js` app.

## How it works

The control reuses the existing per-group open state (`openToolGroups` in `useChatStream`) as the single source of truth:

- `anyToolGroupOpen` reads the existing `isToolGroupOpen` prop, so it stays reactive to the shared set.
- `toggleAllToolGroups` emits the existing `toggleToolGroup` event only for groups whose current state differs from the target, so no new streaming state or emit plumbing is introduced.
- Works for both the streaming timeline (`message.timelineItems`) and the reconstructed legacy timeline (`legacyTimelineItems`).

## i18n

Adds `chat.tool.collapseAll` / `chat.tool.expandAll` across all six supported locales (en, zh-Hans, ja, fr, de, es).

## Verification

- `npm run typecheck` (architecture + chat-security + color/motion/radius + i18n parity guards + `vue-tsc --noEmit`) — passes.
- Existing unit tests for AssistantMessage / RunTrace / i18n — 30 passed.

## Files changed

- `opensquilla-webui/src/components/chat/AssistantMessage.vue` — toggle button + `toolGroupIds` / `hasMultipleToolGroups` / `anyToolGroupOpen` / `toggleAllToolGroups`, plus scoped CSS (token-based).
- `opensquilla-webui/src/locales/*.json` — new i18n keys in all six locales.