### PR TITLE
feat(chat): render HTML artifacts inline in a sandboxed iframe

### DIFF
--- a/opensquilla-webui/src/components/chat/ChatArtifactList.native-open.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatArtifactList.native-open.test.ts
@@ -51,9 +51,18 @@ beforeEach(() => {
 })
 
 describe('ChatArtifactList native HTML open', () => {
-  it('posts HTML artifacts to the gateway native-open endpoint for owner Web sessions', async () => {
-    const fetchImpl = vi.fn(async () => new Response('{"ok":true}', { status: 202 }))
+  it('renders HTML artifacts inline in a sandboxed iframe for owner Web sessions', async () => {
+    // Inline preview fetches the artifact bytes (GET) and renders a blob object
+    // URL in a sandboxed iframe instead of POSTing to the gateway new-tab
+    // endpoint. Stub createObjectURL so happy-dom does not try to navigate the
+    // iframe to a real blob: URL (unsupported in the test environment).
+    const fetchImpl = vi.fn(async (_url: RequestInfo | URL, _opts?: RequestInit) => new Response('<h1>hi</h1>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    }))
     vi.stubGlobal('fetch', fetchImpl)
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('about:blank')
+    vi.spyOn(URL, 'revokeObjectURL').mockReturnValue(undefined)
     const { app, el } = await mountList({ isOwner: true })
 
     const open = Array.from(el.querySelectorAll<HTMLButtonElement>('.msg-artifact-action'))
@@ -61,15 +70,21 @@ describe('ChatArtifactList native HTML open', () => {
     expect(open).toBeTruthy()
     open?.click()
     await settle()
+    await settle()
 
-    expect(fetchImpl).toHaveBeenCalledWith('/api/v1/artifacts/art-html/open', {
-      method: 'POST',
-      headers: {
-        'x-opensquilla-session-key': 'agent:main:webchat:ok',
-        Authorization: 'Bearer secret',
-      },
-      credentials: 'same-origin',
-    })
+    // Fetches the artifact bytes with GET (not a POST to the /open endpoint).
+    expect(fetchImpl).toHaveBeenCalled()
+    const [calledUrl, calledOpts] = fetchImpl.mock.calls[0]
+    expect(String(calledUrl)).toContain('/api/v1/artifacts/art-html')
+    expect(String(calledUrl)).not.toContain('/open')
+    expect((calledOpts as RequestInit | undefined)?.method).toBe('GET')
+
+    // The inline preview dialog renders a sandboxed iframe (no allow-same-origin).
+    const dialog = el.querySelector('[role="dialog"]')
+    expect(dialog).toBeTruthy()
+    const iframe = dialog?.querySelector('iframe')
+    expect(iframe).toBeTruthy()
+    expect(iframe?.getAttribute('sandbox')).toBe('allow-scripts')
     app.unmount()
   })
 

--- a/opensquilla-webui/src/components/chat/ChatArtifactList.vue
+++ b/opensquilla-webui/src/components/chat/ChatArtifactList.vue
@@ -210,6 +210,69 @@
         </footer>
       </div>
     </div>
+
+    <!-- In-app HTML preview: the active-document artifact renders here in a
+         sandboxed iframe, never a new tab. sandbox="allow-scripts" without
+         allow-same-origin isolates it from the app origin. -->
+    <div
+      v-if="htmlActive"
+      class="deliv-preview"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="t('chat.previewOf', { title: artifactFileTitle(htmlActive) })"
+      @click.self="closeHtmlPreview"
+    >
+      <div class="deliv-preview__panel deliv-preview__panel--doc">
+        <header class="deliv-preview__head">
+          <span class="deliv-preview__title">{{ artifactFileTitle(htmlActive) }}</span>
+          <button
+            type="button"
+            class="btn btn--icon btn--ghost"
+            :aria-label="t('chat.closePreview')"
+            :title="t('chat.closePreview')"
+            @click="closeHtmlPreview"
+          >
+            <Icon name="x" :size="16" />
+          </button>
+        </header>
+        <div class="deliv-preview__body deliv-preview__body--doc">
+          <iframe
+            v-if="htmlState === 'loaded' && htmlUrl"
+            class="deliv-preview__frame"
+            :src="htmlUrl"
+            sandbox="allow-scripts"
+            :title="artifactFileTitle(htmlActive)"
+          />
+          <div
+            v-else-if="htmlState === 'timeout' || htmlState === 'error'"
+            class="deliv-preview__file"
+            role="status"
+          >
+            <p class="deliv-preview__meta">
+              {{ htmlState === 'timeout' ? t('chat.previewTimedOut') : t('chat.previewFailed') }}
+            </p>
+            <button type="button" class="btn btn--ghost" @click="retryHtmlPreview">
+              <Icon name="refresh" :size="14" />
+              <span>{{ t('chat.retry') }}</span>
+            </button>
+          </div>
+          <div
+            v-else
+            class="deliv-preview__loading"
+            role="status"
+            :aria-label="t('chat.loadingPreview')"
+          >
+            <span class="deliv-preview__progress-shimmer" aria-hidden="true" />
+          </div>
+        </div>
+        <footer class="deliv-preview__actions">
+          <button type="button" class="btn btn--primary" @click="$emit('download', htmlActive)">
+            <Icon name="download" :size="14" />
+            <span>{{ t('chat.download') }}</span>
+          </button>
+        </footer>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -375,6 +438,13 @@ function openPreview(artifact: ArtifactPayload) {
 // default app. Web keeps the in-browser new-tab path and its active-document
 // guard.
 async function openFile(artifact: ArtifactPayload) {
+  // Active documents (html/htm/xhtml) render inline in a sandboxed iframe
+  // instead of a new tab / OS app, so users never leave the app to view them.
+  if (isActiveDocumentArtifactCandidate(artifact)) {
+    openHtmlPreview(artifact)
+    return
+  }
+
   if (platform.capabilities.canOpenArtifactsNatively && platform.files.openArtifact) {
     const fetched = await fetchArtifactBlob(artifact, {
       baseOrigin: window.location.origin,
@@ -483,6 +553,87 @@ function retryFull() {
   fullController?.retry()
 }
 
+// ── In-app HTML preview ─────────────────────────────────────────────────────
+// Active-document artifacts (html/htm/xhtml) previously only opened in a new
+// browser tab / OS app. They now render inline in a sandboxed <iframe> whose
+// src is a fetched blob object URL. `sandbox="allow-scripts"` WITHOUT
+// `allow-same-origin` forces an opaque origin, so scripts in the artifact run
+// isolated and cannot reach the app's origin, storage, or cookies. The blob is
+// fetched with header auth (never a credential-bearing URL), matching the image
+// preview path and the chat-security guard.
+const htmlActive = ref<ArtifactPayload | null>(null)
+let htmlController: ArtifactPreviewController | null = null
+const htmlState = ref<ArtifactPreviewState>('idle')
+const htmlUrl = ref<string>('')
+let stopHtmlState: (() => void) | null = null
+let htmlInvoker: HTMLElement | null = null
+
+function disposeHtml() {
+  stopHtmlState?.()
+  stopHtmlState = null
+  htmlController?.dispose()
+  htmlController = null
+  htmlState.value = 'idle'
+  htmlUrl.value = ''
+}
+
+function loadHtmlPreview(artifact: ArtifactPayload) {
+  disposeHtml()
+  htmlController = createArtifactPreview({
+    resolveUrl: () => artifactDownloadUrl(artifact, window.location.origin, {
+      sessionKey: props.sessionKey,
+      includeSessionKey: false,
+    }),
+    headers: () => previewHeaders(artifactDownloadUrl(artifact, window.location.origin, {
+      sessionKey: props.sessionKey,
+      includeSessionKey: false,
+    })),
+    sameOrigin,
+    fullSize: true,
+  })
+  const ctrl = htmlController
+  stopHtmlState = watch(
+    [ctrl.state, ctrl.objectUrl],
+    ([s, u]) => {
+      htmlState.value = s as ArtifactPreviewState
+      htmlUrl.value = (u as string) || ''
+    },
+    { immediate: true },
+  )
+  ctrl.load()
+}
+
+function openHtmlPreview(artifact: ArtifactPayload) {
+  htmlInvoker = document.activeElement instanceof HTMLElement ? document.activeElement : null
+  htmlActive.value = artifact
+  loadHtmlPreview(artifact)
+  document.addEventListener('keydown', onHtmlKeydown)
+}
+
+function retryHtmlPreview() {
+  htmlController?.retry()
+}
+
+function closeHtmlPreview() {
+  if (!htmlActive.value) return
+  htmlActive.value = null
+  disposeHtml()
+  document.removeEventListener('keydown', onHtmlKeydown)
+  const invoker = htmlInvoker
+  htmlInvoker = null
+  nextTick(() => {
+    if (invoker && document.contains(invoker)) invoker.focus()
+  })
+}
+
+function onHtmlKeydown(event: KeyboardEvent) {
+  if (!htmlActive.value) return
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeHtmlPreview()
+  }
+}
+
 function showImageAt(index: number) {
   const artifact = navigationVisualArtifacts.value[index]
   if (!artifact) return
@@ -574,7 +725,9 @@ watch(
 
 onUnmounted(() => {
   document.removeEventListener('keydown', onLightboxKeydown)
+  document.removeEventListener('keydown', onHtmlKeydown)
   disposeFull()
+  disposeHtml()
   for (const controller of controllers.values()) controller.dispose()
   controllers.clear()
 })

--- a/opensquilla-webui/src/styles/chat-shared.css
+++ b/opensquilla-webui/src/styles/chat-shared.css
@@ -217,6 +217,24 @@
   height: 100%;
 }
 
+/* HTML/active-document previews fill a fixed sheet like images so the sandboxed
+   iframe has a stable box to render into. */
+.deliv-preview__panel--doc {
+  width: min(880px, 100%);
+  height: 100%;
+}
+
+.deliv-preview__body--doc {
+  padding: 0;
+}
+
+.deliv-preview__frame {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: var(--bg-surface);
+}
+
 .deliv-preview__head {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #737 (HTML inline preview)

## What

HTML / active-document artifacts (`.html` / `.htm` / `.xhtml`, `text/html`) previously only opened in a new browser tab or the OS default app. They now render **inline** in an in-app modal, so users never leave the app to view a skill-generated page (e.g. Q&A dialogs, reports).

This targets the **Vue** WebUI (`opensquilla-webui/`), the default frontend — not the frozen legacy `static/js` app.

## Security

The implementation follows the existing chat-security model:

- The artifact bytes are fetched with **header auth** (never a credential-bearing URL), then turned into a blob object URL via `URL.createObjectURL` — the same path the image preview uses, and what the `check-chat-security` guard requires.
- Rendered in `<iframe sandbox="allow-scripts">`. Omitting `allow-same-origin` forces an **opaque origin**, so scripts inside the artifact run isolated and cannot reach the app's origin, storage, or cookies.
- The existing owner / native-open access gating (`artifactCanOpen`) is **unchanged**, so this does not widen *who* can open an artifact — only *where* it renders.

## Implementation

- Reuses the existing `createArtifactPreview` controller (bounded concurrency queue, progress, timeout, LRU-tracked blob URL).
- Mirrors the existing image lightbox lifecycle: focus restore on close, Escape to dismiss, cleanup on unmount, loading / timeout / error / retry states.
- `openFile` routes active-document artifacts to the inline modal instead of the gateway new-tab endpoint; all other types keep their current behavior.

## Verification

- `npm run typecheck` (architecture + chat-security + color/motion/radius + i18n parity guards + `vue-tsc --noEmit`) — passes.
- Full unit suite — **1253 passed**. The `ChatArtifactList.native-open` test was updated to assert the new inline contract (GET fetch + sandboxed iframe) instead of the old gateway POST.

## Files changed

- `opensquilla-webui/src/components/chat/ChatArtifactList.vue` — inline HTML preview modal + state/controller, `openFile` routing.
- `opensquilla-webui/src/components/chat/ChatArtifactList.native-open.test.ts` — updated to the new inline contract.
- `opensquilla-webui/src/styles/chat-shared.css` — `.deliv-preview__panel--doc` / `__body--doc` / `__frame` styles (token-based).

No new i18n keys — reuses existing `chat.previewOf` / `chat.closePreview` / `chat.download` / `chat.retry` / `chat.previewTimedOut` / `chat.previewFailed` / `chat.loadingPreview`.