### PR TITLE
Fail closed when Desktop gateway restart times out

### DIFF
--- a/desktop/electron/scripts/test-desktop-gateway-lifecycle.mjs
+++ b/desktop/electron/scripts/test-desktop-gateway-lifecycle.mjs
@@ -112,6 +112,8 @@ async function runPendingSpawnAdmissionCase() {
 
   assert.equal(lifecycleAllowsProcessSpawn(true, false), false)
   assert.equal(lifecycleAllowsProcessSpawn(false, true), false)
+  assert.equal(lifecycleAllowsProcessSpawn(false, false, 1), false)
+  assert.equal(lifecycleAllowsProcessSpawn(false, false, 0), true)
   assert.equal(published, false)
 }
 

--- a/desktop/electron/src/boot.html
+++ b/desktop/electron/src/boot.html
@@ -471,6 +471,7 @@
         stepProfile: 'Profile', stepGateway: 'Gateway', stepControl: 'Control',
         errorTitle: 'Startup needs attention',
         errorDefault: 'The gateway did not finish starting.',
+        profileInUse: 'The previous Gateway has not exited. Wait for it to finish, or quit every OpenSquilla app or terminal using this profile, then try again. If it will not exit, restart the computer. Do not delete profile lock files.',
         revealLog: 'Reveal log', resetSetup: 'Reset setup', quit: 'Quit', retry: 'Retry',
         startupPaused: 'Startup paused',
         resetConfirm: 'Reset desktop setup? This clears the saved provider credential and reopens onboarding. Your workspace path, identity, memory, and chat history are kept.',
@@ -498,6 +499,7 @@
         stepProfile: '配置', stepGateway: '网关', stepControl: '控制',
         errorTitle: '启动需要处理',
         errorDefault: '网关未能完成启动。',
+        profileInUse: '上一个网关尚未退出。请等待其结束，或退出所有正在使用此配置的 OpenSquilla 应用和终端后重试；若仍无法退出，请重启电脑。不要删除配置锁文件。',
         revealLog: '显示日志', resetSetup: '重新配置', quit: '退出', retry: '重试',
         startupPaused: '启动已暂停',
         resetConfirm: '要重置桌面设置吗？这会清除已保存的提供商凭据并重新进入引导。工作区路径、身份、记忆和聊天记录都会保留。',
@@ -525,6 +527,7 @@
         stepProfile: 'プロファイル', stepGateway: 'ゲートウェイ', stepControl: 'コントロール',
         errorTitle: '起動の確認が必要です',
         errorDefault: 'ゲートウェイの起動が完了しませんでした。',
+        profileInUse: '前のゲートウェイがまだ終了していません。終了を待つか、このプロファイルを使用しているすべての OpenSquilla アプリとターミナルを終了してから再試行してください。終了しない場合はコンピューターを再起動してください。プロファイルのロックファイルは削除しないでください。',
         revealLog: 'ログを表示', resetSetup: '設定をリセット', quit: '終了', retry: '再試行',
         startupPaused: '起動を一時停止しました',
         resetConfirm: 'デスクトップ設定をリセットしますか？保存済みのプロバイダー認証情報を消去してオンボーディングを再開します。ワークスペースのパス、ID、メモリ、チャット履歴は保持されます。',
@@ -552,6 +555,7 @@
         stepProfile: 'Profil', stepGateway: 'Passerelle', stepControl: 'Contrôle',
         errorTitle: 'Le démarrage nécessite votre attention',
         errorDefault: 'La passerelle n\'a pas terminé son démarrage.',
+        profileInUse: 'La passerelle précédente n’est pas terminée. Attendez sa fermeture, ou quittez toutes les applications et tous les terminaux OpenSquilla utilisant ce profil, puis réessayez. Si elle ne se ferme pas, redémarrez l’ordinateur. Ne supprimez pas les fichiers de verrouillage du profil.',
         revealLog: 'Afficher le journal', resetSetup: 'Réinitialiser', quit: 'Quitter', retry: 'Réessayer',
         startupPaused: 'Démarrage en pause',
         resetConfirm: 'Réinitialiser la configuration du bureau ? Cela efface les identifiants du fournisseur et relance l’onboarding. Le chemin de l’espace de travail, l’identité, la mémoire et l’historique des discussions sont conservés.',
@@ -579,6 +583,7 @@
         stepProfile: 'Profil', stepGateway: 'Gateway', stepControl: 'Control',
         errorTitle: 'Der Start erfordert Ihre Aufmerksamkeit',
         errorDefault: 'Das Gateway hat den Start nicht abgeschlossen.',
+        profileInUse: 'Das vorherige Gateway wurde noch nicht beendet. Warten Sie, bis es beendet ist, oder schließen Sie alle OpenSquilla-Apps und -Terminals, die dieses Profil verwenden, und versuchen Sie es erneut. Falls es nicht beendet wird, starten Sie den Computer neu. Löschen Sie keine Profilsperrdateien.',
         revealLog: 'Protokoll anzeigen', resetSetup: 'Zurücksetzen', quit: 'Beenden', retry: 'Wiederholen',
         startupPaused: 'Start angehalten',
         resetConfirm: 'Desktop-Einrichtung zurücksetzen? Die gespeicherten Anbieter-Zugangsdaten werden gelöscht und das Onboarding wird neu geöffnet. Arbeitsbereichspfad, Identität, Speicher und Chatverlauf bleiben erhalten.',
@@ -606,6 +611,7 @@
         stepProfile: 'Perfil', stepGateway: 'Pasarela', stepControl: 'Control',
         errorTitle: 'El inicio necesita atención',
         errorDefault: 'La pasarela no terminó de iniciarse.',
+        profileInUse: 'La pasarela anterior aún no ha terminado. Espera a que se cierre o sal de todas las aplicaciones y terminales de OpenSquilla que usen este perfil y vuelve a intentarlo. Si no se cierra, reinicia el equipo. No elimines los archivos de bloqueo del perfil.',
         revealLog: 'Mostrar registro', resetSetup: 'Restablecer', quit: 'Salir', retry: 'Reintentar',
         startupPaused: 'Inicio en pausa',
         resetConfirm: '¿Restablecer la configuración de escritorio? Esto borra la credencial del proveedor y vuelve a abrir la configuración inicial. Se conservan la ruta del espacio de trabajo, la identidad, la memoria y el historial de chat.',
@@ -700,7 +706,10 @@
     }
 
     function applyError(payload) {
-      const message = payload && payload.message ? String(payload.message) : msg.errorDefault;
+      const rawMessage = payload && payload.message ? String(payload.message) : msg.errorDefault;
+      const message = rawMessage.includes('OPENSQUILLA_PROFILE_IN_USE')
+        ? msg.profileInUse
+        : rawMessage;
       phase.textContent = msg.startupPaused;
       errorMessage.textContent = message;
       errorPanel.classList.add('visible');
@@ -852,12 +861,33 @@
         if (result && result.ok === false) {
           throw new Error(String(result.detail || result.error || msg.errorDefault));
         }
-        await api.retryStartup();
+        await retryStartup();
       } catch (err) {
         const message = err && err.message ? err.message : String(err);
         phase.textContent = msg.startupPaused;
         errorMessage.textContent = `${msg.resetFailed}: ${message}`;
         errorPanel.classList.add('visible');
+      }
+    }
+
+    let retryStartupInFlight = false;
+    async function retryStartup() {
+      if (!api || typeof api.retryStartup !== 'function' || retryStartupInFlight) return null;
+      const retryButton = document.getElementById('retry');
+      retryStartupInFlight = true;
+      retryButton.disabled = true;
+      try {
+        const result = await api.retryStartup();
+        if (result && result.ok === false) {
+          applyError({ message: result.error || msg.errorDefault });
+        }
+        return result;
+      } catch (error) {
+        applyError({ message: error && error.message ? error.message : String(error) });
+        return null;
+      } finally {
+        retryStartupInFlight = false;
+        retryButton.disabled = false;
       }
     }
 
@@ -881,7 +911,7 @@
         else if (state && state.error) applyError(state.error);
         else applyStatus(state && state.status ? state.status : null);
       }).catch(() => applyStatus(null));
-      document.getElementById('retry').addEventListener('click', () => api.retryStartup());
+      document.getElementById('retry').addEventListener('click', () => retryStartup());
       document.getElementById('revealLog').addEventListener('click', () => api.revealGatewayLog());
       document.getElementById('quit').addEventListener('click', () => api.quitApp());
       const resetButton = document.getElementById('resetSetup');

--- a/desktop/electron/src/gateway-lifecycle.ts
+++ b/desktop/electron/src/gateway-lifecycle.ts
@@ -9,8 +9,13 @@ export interface LifecycleProcessDrainOptions<T> {
 export function lifecycleAllowsProcessSpawn(
   lifecycleClosing: boolean,
   profileWriterAdmissionClosed: boolean,
+  liveOwnedProcessCount = 0,
 ): boolean {
-  return !lifecycleClosing && !profileWriterAdmissionClosed
+  return (
+    !lifecycleClosing
+    && !profileWriterAdmissionClosed
+    && liveOwnedProcessCount === 0
+  )
 }
 
 /**

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -6504,6 +6504,15 @@ function gatewayExitLooksLikeProfileInUse(output: string): boolean {
   return /OPENSQUILLA_PROFILE_IN_USE/i.test(output)
 }
 
+function desktopGatewayStillRunningMessage(): string {
+  return (
+    'OPENSQUILLA_PROFILE_IN_USE: A previous Desktop Gateway has not exited. ' +
+    'Wait for it to finish, or quit every OpenSquilla app or terminal using this profile, ' +
+    'then try again. If it will not exit, restart the computer. ' +
+    'Do not delete profile lock files.'
+  )
+}
+
 function classifyGatewayExitMessage(message: string, outputTail: string): string {
   if (gatewayExitLooksLikeProfileInUse(outputTail)) {
     return (
@@ -6696,6 +6705,21 @@ async function startGateway(): Promise<GatewayState> {
 
   assertSupportedMacInstallLocation()
 
+  // Retry, recovery, update, or quit may already have moved a child out of the
+  // current slot while its graceful shutdown still owns the profile lock. A
+  // separate activate/second-instance open flow must not bypass that drain and
+  // publish a replacement. Retry remains the explicit join operation; ordinary
+  // resume entry points fail closed until the tracked child has exited.
+  const alreadyStoppingGateways = liveLifecycleOwnedGatewayProcesses().filter(
+    (child) => child !== gatewayProcess,
+  )
+  if (alreadyStoppingGateways.length > 0) {
+    desktopLog('gateway_spawn_blocked_by_stopping_processes', {
+      pids: alreadyStoppingGateways.map((child) => child.pid),
+    })
+    throw new Error(desktopGatewayStillRunningMessage())
+  }
+
   if (gatewayProcess && gatewayState.owned) {
     if (hasGatewayProcessExited(gatewayProcess)) {
       gatewayProcess = null
@@ -6709,9 +6733,7 @@ async function startGateway(): Promise<GatewayState> {
       stopGateway()
       const exited = await waitForGatewayProcessExit(previousChild)
       if (!exited) {
-        throw new Error(
-          'OPENSQUILLA_PROFILE_IN_USE: The previous Desktop Gateway did not finish shutting down. Try again after it exits.',
-        )
+        throw new Error(desktopGatewayStillRunningMessage())
       }
     }
     gatewayState.status = 'stopped'
@@ -6763,7 +6785,15 @@ async function startGateway(): Promise<GatewayState> {
   // close writer/lifecycle admission before draining current children; an
   // in-flight start that had not published its child must not appear after an
   // empty stop/join snapshot and race the installer or a profile write.
-  if (!lifecycleAllowsProcessSpawn(isQuitting, desktopWriters.closed)) {
+  const liveOwnedGatewayCount = liveLifecycleOwnedGatewayProcesses().length
+  if (!lifecycleAllowsProcessSpawn(
+    isQuitting,
+    desktopWriters.closed,
+    liveOwnedGatewayCount,
+  )) {
+    if (liveOwnedGatewayCount > 0) {
+      throw new Error(desktopGatewayStillRunningMessage())
+    }
     throw new Error('Gateway startup was cancelled by an active lifecycle or profile operation.')
   }
   const url = `http://127.0.0.1:${port}`
@@ -11048,13 +11078,22 @@ ipcMain.handle('desktop:boot:retry', async () => {
   }
 
   // Otherwise force a real runtime restart. "Restart runtime" must relaunch the
-  // child even when the current gateway is healthy, so always tear an owned
-  // gateway down and wait for it to release its port + PID lock before
-  // openOrResumeDesktopApp respawns it — never reuse the existing one here.
-  if (gatewayProcess && gatewayState.owned) {
-    const previousChild = gatewayProcess
-    stopGateway()
-    await waitForGatewayProcessExit(previousChild)
+  // child even when the current gateway is healthy, so join every lifecycle-
+  // owned child before openOrResumeDesktopApp may respawn. This includes a
+  // child whose stop was already initiated by another flow. Timeout fails
+  // closed: spawning while any previous writer is live would race the profile
+  // lock and recreate the startup failure this recovery action is meant to fix.
+  const exited = await stopAndJoinAllLifecycleOwnedGateways()
+  if (!exited) {
+    const message = desktopGatewayStillRunningMessage()
+    gatewayState.status = 'error'
+    gatewayState.error = message
+    desktopLog('gateway_restart_wait_timeout', {
+      pids: liveLifecycleOwnedGatewayProcesses().map((child) => child.pid),
+    })
+    sendBootError(message)
+    await restoreMainWindowToBootPage()
+    return { ok: false, error: message }
   }
   clearReusableGatewayState()
   bootError = null

--- a/opensquilla-webui/src/components/settings/DesktopRuntimePanel.restart.test.ts
+++ b/opensquilla-webui/src/components/settings/DesktopRuntimePanel.restart.test.ts
@@ -1,0 +1,186 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 20))
+
+function setDesktopApi(api: unknown): void {
+  ;(window as unknown as { opensquillaDesktop?: unknown }).opensquillaDesktop = api
+}
+
+function desktopApi(overrides: Record<string, unknown> = {}) {
+  return {
+    getOsLocale: async () => 'en',
+    isAutoUpdateEnabled: async () => true,
+    getGatewayStatus: async () => ({
+      url: 'http://127.0.0.1:1',
+      port: 1,
+      owned: true,
+      status: 'ready',
+      logPath: '',
+    }),
+    ...overrides,
+  }
+}
+
+async function mountPanel(api: ReturnType<typeof desktopApi>) {
+  vi.resetModules()
+  document.body.innerHTML = ''
+  setDesktopApi(api)
+  const { createApp, nextTick } = await import('vue')
+  const i18n = (await import('@/i18n')).default
+  i18n.global.locale.value = 'en'
+  const Component = (await import('./DesktopRuntimePanel.vue')).default
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  const app = createApp(Component)
+  app.use(i18n)
+  app.mount(el)
+  await settle()
+  await nextTick()
+  const { toasts } = (await import('@/composables/useToasts')).useToasts()
+  toasts.value = []
+  return { app, el, toasts }
+}
+
+function findRestartButton(el: HTMLElement): HTMLButtonElement {
+  const button = Array.from(el.querySelectorAll<HTMLButtonElement>('button'))
+    .find((candidate) => candidate.textContent?.includes('Restart runtime'))
+  if (!button) throw new Error('Restart runtime button was not rendered')
+  return button
+}
+
+beforeEach(() => setDesktopApi(undefined))
+
+describe('DesktopRuntimePanel runtime restart', () => {
+  it('announces restarting only when the desktop retry succeeds', async () => {
+    const getGatewayStatus = vi.fn(async () => ({
+      url: 'http://127.0.0.1:1',
+      port: 1,
+      owned: true,
+      status: 'ready' as const,
+      logPath: '',
+    }))
+    const retryStartup = vi.fn(async () => ({ ok: true }))
+    const { app, el, toasts } = await mountPanel(desktopApi({
+      getGatewayStatus,
+      retryStartup,
+    }))
+
+    findRestartButton(el).click()
+    await settle()
+
+    expect(retryStartup).toHaveBeenCalledTimes(1)
+    expect(getGatewayStatus).toHaveBeenCalledTimes(2)
+    expect(toasts.value[toasts.value.length - 1]).toMatchObject({
+      message: 'Restarting the local runtime…',
+      tone: 'info',
+    })
+    app.unmount()
+  })
+
+  it('surfaces an explicit retry failure without claiming the runtime is restarting', async () => {
+    const getGatewayStatus = vi.fn(async () => ({
+      url: 'http://127.0.0.1:1',
+      port: 1,
+      owned: true,
+      status: 'ready' as const,
+      logPath: '',
+    }))
+    const retryStartup = vi.fn(async () => ({
+      ok: false,
+      error: 'The previous gateway is still shutting down.',
+    }))
+    const { app, el, toasts } = await mountPanel(desktopApi({
+      getGatewayStatus,
+      retryStartup,
+    }))
+
+    findRestartButton(el).click()
+    await settle()
+
+    expect(retryStartup).toHaveBeenCalledTimes(1)
+    expect(getGatewayStatus).toHaveBeenCalledTimes(1)
+    expect(toasts.value.map((toast) => toast.message)).not.toContain(
+      'Restarting the local runtime…',
+    )
+    expect(toasts.value[toasts.value.length - 1]).toMatchObject({
+      message: 'Restart failed: The previous gateway is still shutting down.',
+      tone: 'danger',
+    })
+    app.unmount()
+  })
+
+  it('keeps a migration restart failure visible when the desktop retry is rejected', async () => {
+    const migrationDismissLastResult = vi.fn(async () => ({ ok: true }))
+    const retryStartup = vi.fn(async () => ({
+      ok: false,
+      error: 'The previous gateway is still shutting down.',
+    }))
+    const { app, el } = await mountPanel(desktopApi({
+      getDesktopProfileKind: async () => 'primary',
+      retryStartup,
+      migrationPeekLastResult: async () => ({
+        ok: false,
+        migrationApplied: true,
+        restartOk: false,
+        failureCode: 'gateway_restart_failed',
+        failureStage: 'restart',
+      }),
+      migrationDismissLastResult,
+      migrationSummary: async () => ({ ok: true }),
+      migrationRun: async () => ({ ok: true }),
+    }))
+
+    const restart = el.querySelector<HTMLButtonElement>('[data-testid="runtime-migration-restart"]')
+    expect(restart).toBeTruthy()
+    restart!.click()
+    await settle()
+
+    expect(retryStartup).toHaveBeenCalledTimes(1)
+    expect(migrationDismissLastResult).not.toHaveBeenCalled()
+    expect(el.querySelector('[data-testid="runtime-migration-applied-restart-failed"]'))
+      .toBeTruthy()
+    app.unmount()
+  })
+
+  it('keeps a migration restart failure visible when refreshed status cannot be read', async () => {
+    const migrationDismissLastResult = vi.fn(async () => ({ ok: true }))
+    const retryStartup = vi.fn(async () => ({ ok: true }))
+    const getGatewayStatus = vi.fn()
+      .mockResolvedValueOnce({
+        url: 'http://127.0.0.1:1',
+        port: 1,
+        owned: true,
+        status: 'ready' as const,
+        logPath: '',
+      })
+      .mockRejectedValueOnce(new Error('status unavailable'))
+    const { app, el } = await mountPanel(desktopApi({
+      getGatewayStatus,
+      getDesktopProfileKind: async () => 'primary',
+      retryStartup,
+      migrationPeekLastResult: async () => ({
+        ok: false,
+        migrationApplied: true,
+        restartOk: false,
+        failureCode: 'gateway_restart_failed',
+        failureStage: 'restart',
+      }),
+      migrationDismissLastResult,
+      migrationSummary: async () => ({ ok: true }),
+      migrationRun: async () => ({ ok: true }),
+    }))
+
+    const restart = el.querySelector<HTMLButtonElement>('[data-testid="runtime-migration-restart"]')
+    expect(restart).toBeTruthy()
+    restart!.click()
+    await settle()
+
+    expect(retryStartup).toHaveBeenCalledTimes(1)
+    expect(getGatewayStatus).toHaveBeenCalledTimes(2)
+    expect(migrationDismissLastResult).not.toHaveBeenCalled()
+    expect(el.querySelector('[data-testid="runtime-migration-applied-restart-failed"]'))
+      .toBeTruthy()
+    app.unmount()
+  })
+})

--- a/opensquilla-webui/src/components/settings/DesktopRuntimePanel.vue
+++ b/opensquilla-webui/src/components/settings/DesktopRuntimePanel.vue
@@ -173,12 +173,15 @@ const hasMigrationBridge = computed(
   () => Boolean(desktopBridge?.migrationSummary && desktopBridge?.migrationRun),
 )
 
-async function loadStatus() {
+async function loadStatus(): Promise<GatewayStatus | null> {
   loading.value = true
   try {
-    gateway.value = await platform.gateway.getStatus()
+    const status = await platform.gateway.getStatus()
+    gateway.value = status
+    return status
   } catch (err) {
     pushToast(t('setup.runtime.statusReadFailed', { error: err instanceof Error ? err.message : String(err) }), { tone: 'danger' })
+    return null
   } finally {
     loading.value = false
   }
@@ -195,14 +198,21 @@ async function revealLog() {
 }
 
 async function restartGateway() {
-  if (!platform.gateway.retryStartup) return
+  if (!platform.gateway.retryStartup) return null
   busy.value = true
   try {
-    await platform.gateway.retryStartup()
+    const result = await platform.gateway.retryStartup()
+    if (!result.ok) {
+      pushToast(t('setup.runtime.restartFailed', {
+        error: result.error || t('errorBoundary.defaultMessage'),
+      }), { tone: 'danger' })
+      return null
+    }
     pushToast(t('setup.runtime.restarting'))
-    await loadStatus()
+    return await loadStatus()
   } catch (err) {
     pushToast(t('setup.runtime.restartFailed', { error: err instanceof Error ? err.message : String(err) }), { tone: 'danger' })
+    return null
   } finally {
     busy.value = false
   }
@@ -794,8 +804,8 @@ async function recheckLastMigrationSource() {
 }
 
 async function restartAfterMigration() {
-  await restartGateway()
-  if (gateway.value?.status === 'ready') await dismissLastMigrationResult()
+  const refreshedGateway = await restartGateway()
+  if (refreshedGateway?.status === 'ready') await dismissLastMigrationResult()
 }
 
 async function revealMigrationBackups() {

--- a/opensquilla-webui/src/platform/types.ts
+++ b/opensquilla-webui/src/platform/types.ts
@@ -9,6 +9,11 @@ export interface GatewayStatus {
   error?: string
 }
 
+export interface DesktopRetryStartupResult {
+  ok: boolean
+  error?: string
+}
+
 export type DesktopUpdateStatus =
   | 'idle'
   | 'checking'
@@ -139,7 +144,7 @@ export interface CliInvocation {
 export interface PlatformGatewayApi {
   getStatus(): Promise<GatewayStatus>
   revealLog?: () => Promise<boolean>
-  retryStartup?: () => Promise<unknown>
+  retryStartup?: () => Promise<DesktopRetryStartupResult>
   /** null when the shell predates the bridge or the lookup fails; callers
    *  fall back to the raw command. */
   getCliInvocation?: () => Promise<CliInvocation | null>

--- a/opensquilla-webui/src/vite-env.d.ts
+++ b/opensquilla-webui/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 import type {
   ArtifactNativeOpenResult,
   ArtifactOpenRequest,
+  DesktopRetryStartupResult,
   DesktopUpdateState,
   DesktopSettings,
   DesktopSettingsPayload,
@@ -69,7 +70,7 @@ declare global {
     getBootState: () => Promise<unknown>
     getRecoveryState?: () => Promise<unknown>
     getDesktopProfileKind?: () => Promise<'primary' | 'recovery' | null>
-    retryStartup: () => Promise<unknown>
+    retryStartup: () => Promise<DesktopRetryStartupResult>
     quitApp: () => Promise<unknown>
     migrationSummary?: (payload?: { source?: string }) => Promise<unknown>
     migrationBrowseSource?: (payload: { kind: MigrationSourceKind }) => Promise<unknown>

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -60,13 +60,8 @@ def test_desktop_gateway_completion_uses_current_live_window() -> None:
     assert "if (mainWindow === window) mainWindow = null" in main_ts
 
 
-def test_desktop_activation_retry_and_second_instance_share_resume_helper() -> None:
+def test_desktop_activation_and_second_instance_share_resume_helper() -> None:
     main_ts = _read("desktop/electron/src/main.ts")
-    retry = _section(
-        main_ts,
-        "ipcMain.handle('desktop:boot:retry'",
-        "ipcMain.handle('desktop:boot:quit'",
-    )
 
     assert "if (process.platform !== 'darwin') app.quit()" in main_ts
     assert "app.on('activate', () => {\n  void openOrResumeDesktopApp()" in main_ts
@@ -85,15 +80,112 @@ def test_desktop_activation_retry_and_second_instance_share_resume_helper() -> N
         "})\n}",
     )
 
+
+def test_desktop_retry_waits_for_all_owned_gateways_and_fails_closed() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    retry = _section(
+        main_ts,
+        "ipcMain.handle('desktop:boot:retry'",
+        "ipcMain.handle('desktop:boot:quit'",
+    )
+
     # Retry backs both the boot-error button and the Control UI "Restart runtime"
     # action, so it forces a real restart: an in-flight start is joined (clearing
-    # the stale error), otherwise an owned gateway is torn down and awaited before
-    # respawn rather than reused, so a healthy-but-misbehaving runtime can restart.
+    # the stale error), otherwise every lifecycle-owned gateway is torn down and
+    # awaited before respawn rather than reused. The join result is a hard safety
+    # boundary: timing out must leave the old runtime authoritative and must not
+    # clear its reusable state or start a competing writer.
     assert "if (gatewayStartPromise)" in retry
-    assert "stopGateway()" in retry
-    assert "await waitForGatewayProcessExit(previousChild)" in retry
-    assert "clearReusableGatewayState()" in retry
-    assert "void openOrResumeDesktopApp()" in retry
+    join_call = "const exited = await stopAndJoinAllLifecycleOwnedGateways()"
+    assert join_call in retry
+    assert "if (!exited)" in retry
+    assert "stopGateway()" not in retry
+    assert "waitForGatewayProcessExit(" not in retry
+
+    failure = _section(retry, "if (!exited)", "clearReusableGatewayState()")
+    assert "gatewayState.status = 'error'" in failure
+    assert "gatewayState.error = message" in failure
+    assert "desktopLog('gateway_restart_wait_timeout'" in failure
+    assert "sendBootError(message)" in failure
+    assert "await restoreMainWindowToBootPage()" in failure
+    assert "return { ok: false, error: message }" in failure
+    assert "clearReusableGatewayState()" not in failure
+    assert "openOrResumeDesktopApp()" not in failure
+
+    join_index = retry.index(join_call)
+    failure_index = retry.index("if (!exited)", join_index)
+    clear_index = retry.index("clearReusableGatewayState()", failure_index)
+    open_index = retry.index("openOrResumeDesktopApp()", clear_index)
+    assert join_index < failure_index < clear_index < open_index
+
+    success = retry[clear_index:]
+    assert success.count("clearReusableGatewayState()") == 1
+    assert success.count("openOrResumeDesktopApp()") == 1
+    assert success.index("clearReusableGatewayState()") < success.index(
+        "openOrResumeDesktopApp()"
+    )
+    assert success.index("openOrResumeDesktopApp()") < success.index("return { ok: true }")
+
+
+def test_desktop_shared_spawn_gate_blocks_still_stopping_gateways() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    start = _section(
+        main_ts,
+        "async function startGateway()",
+        "async function startGatewayWithPortRecovery()",
+    )
+
+    # activate and second-instance both reach this shared boundary. A child that
+    # Retry already moved into the stopping set must therefore block every entry
+    # point, not only the original retry handler.
+    stopping_check = "const alreadyStoppingGateways = liveLifecycleOwnedGatewayProcesses()"
+    assert stopping_check in start
+    assert "if (alreadyStoppingGateways.length > 0)" in start
+    assert "throw new Error(desktopGatewayStillRunningMessage())" in start
+
+    final_gate = _section(
+        start,
+        "const liveOwnedGatewayCount = liveLifecycleOwnedGatewayProcesses().length",
+        "const url = `http://127.0.0.1:${port}`",
+    )
+    assert "lifecycleAllowsProcessSpawn(" in final_gate
+    assert "liveOwnedGatewayCount," in final_gate
+    assert "if (liveOwnedGatewayCount > 0)" in final_gate
+    assert "throw new Error(desktopGatewayStillRunningMessage())" in final_gate
+
+
+def test_boot_retry_surfaces_failed_restart_and_prevents_repeat_clicks() -> None:
+    boot_html = _read("desktop/electron/src/boot.html")
+    apply_error = _section(
+        boot_html,
+        "function applyError(payload)",
+        "function renderRecoveryState",
+    )
+    retry_flow = _section(
+        boot_html,
+        "async function retryStartup()",
+        "function updateTimer()",
+    )
+
+    assert "retryButton.disabled = true" in retry_flow
+    assert "const result = await api.retryStartup()" in retry_flow
+    assert "result && result.ok === false" in retry_flow
+    assert "result.error || msg.errorDefault" in retry_flow
+    assert "applyError({ message: result.error || msg.errorDefault })" in retry_flow
+    assert "errorPanel.classList.add('visible')" in apply_error
+    assert "retryButton.disabled = false" in retry_flow
+    assert retry_flow.index("retryButton.disabled = true") < retry_flow.index(
+        "await api.retryStartup()"
+    )
+    assert retry_flow.index("await api.retryStartup()") < retry_flow.index(
+        "retryButton.disabled = false"
+    )
+    assert (
+        "document.getElementById('retry').addEventListener('click', () => retryStartup())"
+        in boot_html
+    )
+    assert "rawMessage.includes('OPENSQUILLA_PROFILE_IN_USE')" in apply_error
+    assert boot_html.count("profileInUse:") == 6
 
 
 def test_boot_error_panel_exposes_reset_setup_recovery() -> None:
@@ -116,9 +208,9 @@ def test_boot_error_panel_exposes_reset_setup_recovery() -> None:
     assert "msg.resetFailed" in boot_html
     assert "workspace path, identity, memory, and chat history are kept" in boot_html
     assert "await api.resetDesktopSettings()" in reset_flow
-    assert "await api.retryStartup()" in reset_flow
+    assert "await retryStartup()" in reset_flow
     assert reset_flow.index("await api.resetDesktopSettings()") < reset_flow.index(
-        "await api.retryStartup()"
+        "await retryStartup()"
     )
     assert "errorPanel.classList.add('visible')" in reset_flow
 
@@ -1588,8 +1680,11 @@ def test_desktop_update_and_recovery_join_every_lifecycle_owned_gateway() -> Non
     )
 
     start = _section(main_ts, "async function startGateway", "async function loadControlUi")
-    admission = "lifecycleAllowsProcessSpawn(isQuitting, desktopWriters.closed)"
+    admission = "if (!lifecycleAllowsProcessSpawn("
     assert admission in start
+    assert "isQuitting," in start
+    assert "desktopWriters.closed," in start
+    assert "liveOwnedGatewayCount," in start
     assert start.index("const port = await findGatewayPort()") < start.index(admission)
     assert start.index(admission) < start.index("const child = spawn(")
 


### PR DESCRIPTION
## Scope

Ensure Desktop restart retries join every lifecycle-owned Gateway and fail closed when an earlier writer does not exit. Surface the failure through the localized boot page and Control UI, type the Desktop bridge result, add regression coverage, and rebuild the bundled Web UI assets.

Scope boundary: Electron Desktop startup/restart lifecycle and runtime-status feedback.

Non-goals: changing profile-lock semantics, deleting lock files, force-stopping unverified processes, or changing gateway/session/provider behavior.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #687

## Release Note

Release note: Prevent Desktop restart retries from spawning a second Gateway while the previous Gateway is still shutting down.

## Tests

Ruff: Not run (no Python source changes).

Pytest: `uv run pytest -q tests/test_desktop/test_electron_startup_contract.py tests/test_gateway/test_desktop_ownership.py tests/test_cli/test_gateway_cmd.py` — 155 passed.

Build:
- `cd desktop/electron && npm run build` — passed.
- `cd opensquilla-webui && npm run build` — passed, including typecheck, architecture, theme, and i18n guards.

Regression tests: added

Notes:
- Full Web UI unit suite: 1,256 passed across 120 files.
- Desktop Gateway lifecycle and ownership scripts passed.
- Real Electron orphan recovery passed and replaced the verified orphan PID.
- Profile recovery flow and six-locale accessibility flow passed.
- Local validation was on macOS; Windows/Linux behavior is delegated to the PR CI matrix.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: gateway

Maintainer-only note: no provider credentials are required for this change.

## Safety

The profile lock remains authoritative. Timeout paths do not clear reusable state, spawn a replacement writer, delete lock files, or stop a process that has not passed the existing ownership checks.

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included.

Upgrade compatibility: no config, database, session, or public RPC schema changes. Older runtimes retain the existing safe failure behavior.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

No documentation changes.