### PR TITLE
Retire legacy Control UI selection

### DIFF
--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -5,9 +5,10 @@ approvals, channels, logs, agents, usage, and operational status. It is the
 best surface when you want browser-based chat, visible tool activity, durable
 approvals, and a quick view of runtime health.
 
-The default Control UI in the 0.4 release line is the Vue product UI served by the gateway.
-The legacy frontend is kept only as a maintainer rollback fallback, not as the
-normal user path.
+The Control UI is the Vue product UI served by the gateway. The historical
+`control_ui.frontend = "legacy"` setting is accepted temporarily so existing
+profiles still start, but it is deprecated, normalized to `"vue"`, and no
+longer activates the vanilla-JS client.
 
 ## Start the Web UI
 

--- a/opensquilla-webui/e2e/fork.spec.ts
+++ b/opensquilla-webui/e2e/fork.spec.ts
@@ -3,7 +3,16 @@ import { test, expect, type Page } from '@playwright/test'
 const CONTROL_URL = '/control/'
 const LIVE = process.env.OPENSQUILLA_E2E_LIVE === '1'
 const SESSION_KEY = 'agent:main:webchat:e2efork'
+const EDIT_PARENT_KEY = 'agent:main:webchat:e2e-edit-parent'
+const EDIT_CHILD_KEY = 'agent:main:webchat:e2e-edit-child'
 const FORK_BUTTON = '[data-testid="fork-conversation"]'
+
+type CapturedEditSend = {
+  message?: string
+  sessionKey?: string
+  forkBeforeMessageId?: string
+  [key: string]: unknown
+}
 
 function sessionFromUrl(url: string): string {
   try {
@@ -76,6 +85,131 @@ async function seedHistoryWithTwoTurns(page: Page) {
   })
 }
 
+async function mockBranchingEditRpc(
+  page: Page,
+  capturedSends: CapturedEditSend[],
+  historyRequests: string[],
+) {
+  const parentMessages = [
+    {
+      role: 'user',
+      text: 'A marker',
+      message_id: 'msg-A',
+      timestamp: '2026-07-03T00:00:01.000Z',
+    },
+    {
+      role: 'assistant',
+      text: 'ack A',
+      message_id: 'msg-ack-A',
+      timestamp: '2026-07-03T00:00:02.000Z',
+    },
+    {
+      role: 'user',
+      text: 'B marker',
+      message_id: 'msg-B',
+      timestamp: '2026-07-03T00:00:03.000Z',
+    },
+    {
+      role: 'assistant',
+      text: 'ack B',
+      message_id: 'msg-ack-B',
+      timestamp: '2026-07-03T00:00:04.000Z',
+    },
+    {
+      role: 'user',
+      text: 'C marker must stay only on parent',
+      message_id: 'msg-C',
+      timestamp: '2026-07-03T00:00:05.000Z',
+    },
+  ]
+  const childMessages = [
+    parentMessages[0],
+    parentMessages[1],
+    {
+      role: 'user',
+      text: 'B edited',
+      message_id: 'child-msg-B-edited',
+      timestamp: '2026-07-03T00:00:06.000Z',
+    },
+  ]
+
+  await page.route('**/api/approvals', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ pending: [] }),
+  }))
+
+  await page.routeWebSocket(/\/ws$/, ws => {
+    ws.send(JSON.stringify({ type: 'event', event: 'connect.challenge', payload: {} }))
+    ws.onMessage(message => {
+      try {
+        const frame = JSON.parse(String(message))
+        if (frame?.type !== 'req') return
+        const method = String(frame.method || '')
+        if (method === 'connect') {
+          ws.send(JSON.stringify({ protocol: 3, policy: { tick_interval_ms: 30000 } }))
+          return
+        }
+        if (method === 'chat.send') {
+          capturedSends.push((frame.params || {}) as CapturedEditSend)
+          ws.send(JSON.stringify({
+            type: 'res',
+            id: frame.id,
+            ok: true,
+            payload: {
+              sessionKey: EDIT_CHILD_KEY,
+              status: 'accepted',
+              task_id: 'e2e-edit-task',
+            },
+          }))
+          return
+        }
+        if (method === 'chat.history') {
+          const key = String(frame.params?.sessionKey || '')
+          historyRequests.push(key)
+          ws.send(JSON.stringify({
+            type: 'res',
+            id: frame.id,
+            ok: true,
+            payload: {
+              messages: key === EDIT_CHILD_KEY ? childMessages : parentMessages,
+              history_scope: 'complete',
+              has_more: false,
+            },
+          }))
+          return
+        }
+
+        const payloads: Record<string, unknown> = {
+          'agents.list': { agents: [] },
+          'commands.list_for_surface': { commands: [] },
+          'config.get': {
+            squilla_router: { enabled: false, rollout_phase: 'observe', tiers: {} },
+            permissions: {},
+            skills: {},
+          },
+          'sessions.list': { sessions: [], has_more: false },
+          'sessions.messages.subscribe': {
+            subscribed: true,
+            replay_complete: true,
+            current_stream_seq: 0,
+            run_status: 'idle',
+          },
+          'usage.status': { sessions: [] },
+        }
+        ws.send(JSON.stringify({
+          type: 'res',
+          id: frame.id,
+          ok: true,
+          payload: payloads[method] ?? {},
+        }))
+      } catch (err) {
+        if (!(err instanceof SyntaxError)) throw err
+      }
+    })
+  })
+}
+
 test.describe('Conversation fork', () => {
   test('empty draft offers no fork action', async ({ page }) => {
     await page.goto(CONTROL_URL + 'chat/new')
@@ -98,6 +232,55 @@ test.describe('Conversation fork', () => {
     await expect(page.locator(FORK_BUTTON)).toHaveAttribute('aria-label', 'Fork conversation')
     // The retired follow-up row stays gone.
     await expect(page.locator('.done-card')).toHaveCount(0)
+  })
+
+  test('editing a middle message forks before it without leaking later history', async ({ page }) => {
+    const capturedSends: CapturedEditSend[] = []
+    const historyRequests: string[] = []
+    await mockBranchingEditRpc(page, capturedSends, historyRequests)
+
+    await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(EDIT_PARENT_KEY))
+    await page.waitForSelector('.conn-pill', { timeout: 10000 })
+    await expect(page.locator('.msg-user')).toHaveCount(3, { timeout: 10000 })
+    await expect(page.locator('.msg-user').last()).toContainText('C marker must stay only on parent')
+
+    const middleMessage = page.locator('.msg-user').nth(1)
+    await middleMessage.hover()
+    await middleMessage.getByRole('button', { name: 'Edit' }).click()
+
+    // Editing B rewinds the local transcript to the point before B. Neither
+    // B's old answer nor the later C turn may be carried into the new branch.
+    await expect(page.locator('.chat-textarea')).toHaveValue('B marker')
+    await expect(page.locator('.msg-user')).toHaveCount(1)
+    await expect(page.locator('.chat-thread')).not.toContainText('ack B')
+    await expect(page.locator('.chat-thread')).not.toContainText('C marker')
+
+    await page.locator('.chat-textarea').fill('B edited')
+    await page.locator('.chat-send-btn[aria-label="Send"]').click()
+    await expect.poll(() => capturedSends.length).toBe(1)
+
+    const send = capturedSends[0]
+    expect(send).toMatchObject({
+      message: 'B edited',
+      sessionKey: EDIT_PARENT_KEY,
+      forkBeforeMessageId: 'msg-B',
+    })
+    expect(send).not.toHaveProperty('messages')
+    expect(send).not.toHaveProperty('history')
+    expect(JSON.stringify(send)).not.toContain('ack B')
+    expect(JSON.stringify(send)).not.toContain('C marker')
+
+    await expect.poll(() => new URL(page.url()).searchParams.get('session')).toBe(EDIT_CHILD_KEY)
+
+    // A fresh load proves the URL now addresses the child transcript, whose
+    // canonical history ends at the edited B rather than replaying parent C.
+    await page.reload()
+    await page.waitForSelector('.conn-pill', { timeout: 10000 })
+    await expect.poll(() => historyRequests.filter(key => key === EDIT_CHILD_KEY).length).toBeGreaterThan(0)
+    await expect(page.locator('.msg-user')).toHaveCount(2, { timeout: 10000 })
+    await expect(page.locator('.chat-thread')).toContainText('B edited')
+    await expect(page.locator('.chat-thread')).not.toContainText('C marker')
+    expect(historyRequests).toContain(EDIT_PARENT_KEY)
   })
 
   test('live fork copies the thread into a new session with hub lineage', async ({ page }) => {

--- a/opensquilla-webui/src/composables/chat/useChatFeatureToggles.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatFeatureToggles.test.ts
@@ -241,6 +241,26 @@ describe('useChatFeatureToggles coding mode', () => {
   })
 })
 
+describe('useChatFeatureToggles router visual effects', () => {
+  it('persists router visual effects without a legacy browser global', () => {
+    const setItem = vi.fn()
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(() => null),
+      setItem,
+    })
+    const { api } = createHarness()
+
+    api.setRouterVisualEffectsEnabled(false)
+
+    expect(api.routerVisualEffectsEnabled.value).toBe(false)
+    expect(setItem).toHaveBeenCalledWith('opensquilla.routerFx', JSON.stringify({
+      enabled: false,
+      variant: 'default',
+    }))
+    expect(source).not.toContain('SavingsFX')
+  })
+})
+
 describe('useChatFeatureToggles model routing mode', () => {
   it('uses the canonical routing snapshot over legacy config inference', async () => {
     const { api } = createHarness({

--- a/opensquilla-webui/src/composables/chat/useChatFeatureToggles.ts
+++ b/opensquilla-webui/src/composables/chat/useChatFeatureToggles.ts
@@ -207,8 +207,6 @@ export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
   function setRouterVisualEffectsEnabled(enabled: boolean) {
     routerVisualEffectsEnabled.value = Boolean(enabled)
     saveRouterVisualEffectsPreference()
-    const savingsFx = (window as unknown as { SavingsFX?: { setEnabled?: (enabled: boolean) => void } }).SavingsFX
-    savingsFx?.setEnabled?.(routerVisualEffectsEnabled.value)
   }
 
   async function setRouterEnabled(enabled: boolean) {

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -58,10 +58,10 @@
 # diagnostics_enabled = false
 
 [control_ui]
-# Vue is the product UI. Use "legacy" only as a maintainer rollback fallback
-# for the frozen vanilla-JS frontend; changing this requires a gateway restart.
-# Env override: OPENSQUILLA_CONTROL_UI_FRONTEND=vue|legacy
-frontend = "vue"
+# Vue is the only Control UI. The optional frontend key is retained temporarily
+# for config compatibility; historical "legacy" values are deprecated and are
+# treated as "vue" rather than selecting the retired vanilla-JS client.
+# frontend = "vue"
 
 # Web search settings
 # Use DuckDuckGo for the no-key path, or configure Bocha, Brave, IQS, Tavily, or Exa.

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 import os
 import threading
 import warnings
@@ -42,6 +43,14 @@ from opensquilla.session.compaction_lifecycle import (
     DEFAULT_FLUSH_TRIGGERS,
     FlushTrigger,
     normalize_flush_triggers_strict,
+)
+
+logger = logging.getLogger(__name__)
+
+_LEGACY_CONTROL_UI_FRONTEND_WARNING = (
+    "control_ui.frontend='legacy' is deprecated and no longer selects the "
+    "retired vanilla-JS UI; Vue is always served. Remove this setting or set "
+    "it to 'vue'."
 )
 
 
@@ -129,7 +138,11 @@ class ControlUiConfig(BaseSettings):
 
     enabled: bool = True
     base_path: str = "/control"
-    frontend: Literal["vue", "legacy"] = "vue"
+    # Retained temporarily so existing TOML files and environment overrides do
+    # not fail gateway validation after the vanilla-JS client is retired. Vue
+    # is the only runtime value; the validator below maps the historical
+    # ``legacy`` spelling to it with a deprecation warning.
+    frontend: Literal["vue"] = "vue"
     # Default UI locale served on first paint when the browser has no saved
     # preference. The client (localStorage) and a manual switch always override
     # it. Anything zh* clamps to zh-Hans; anything else to en.
@@ -145,7 +158,16 @@ class ControlUiConfig(BaseSettings):
     @classmethod
     def _normalize_frontend(cls, v: object) -> object:
         if isinstance(v, str):
-            return v.strip().lower()
+            normalized = v.strip().lower()
+            if normalized == "legacy":
+                warnings.warn(
+                    _LEGACY_CONTROL_UI_FRONTEND_WARNING,
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                logger.warning(_LEGACY_CONTROL_UI_FRONTEND_WARNING)
+                return "vue"
+            return normalized
         return v
 
     @field_validator("default_locale", mode="before")

--- a/src/opensquilla/gateway/control_ui.py
+++ b/src/opensquilla/gateway/control_ui.py
@@ -268,21 +268,18 @@ def create_control_ui_routes(config: GatewayConfig) -> list[Route | Mount]:
         return []
 
     base = config.control_ui.base_path
-    frontend = config.control_ui.frontend
-    template_name = "legacy_index.html" if frontend == "legacy" else "index.html"
-    template = _get_jinja_env().get_template(template_name)
+    template = _get_jinja_env().get_template("index.html")
 
     async def serve_index(request: Request) -> HTMLResponse:
         ctx = _build_bootstrap_context(config, request)
-        if frontend == "vue":
-            # Re-read latest Vite assets on every request so rebuilds are picked up
-            # without restarting the gateway.
-            live_js, live_css_urls = _read_vite_assets(base)
-            ctx["vite_js_url"] = live_js
-            ctx["vite_css_urls"] = live_css_urls
-            ctx["webui_artifact_missing"] = not live_js
-            # Back-compat single URL (first) for any consumer expecting one.
-            ctx["vite_css_url"] = live_css_urls[0] if live_css_urls else ""
+        # Re-read latest Vite assets on every request so rebuilds are picked up
+        # without restarting the gateway.
+        live_js, live_css_urls = _read_vite_assets(base)
+        ctx["vite_js_url"] = live_js
+        ctx["vite_css_urls"] = live_css_urls
+        ctx["webui_artifact_missing"] = not live_js
+        # Back-compat single URL (first) for any consumer expecting one.
+        ctx["vite_css_url"] = live_css_urls[0] if live_css_urls else ""
         html = template.render(**ctx)
         response = HTMLResponse(html)
         response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"

--- a/src/opensquilla/gateway/templates/index.html
+++ b/src/opensquilla/gateway/templates/index.html
@@ -90,9 +90,5 @@
          data-update="{{ update | tojson | forceescape }}"
          style="display:none"></div>
 
-    <!-- Prism syntax highlighting (used by ChatView for code blocks) -->
-    <script src="{{ base_path }}/static/vendor/prism-core.min.js"></script>
-    <script src="{{ base_path }}/static/vendor/prism-autoloader.min.js"></script>
-    <script>if(window.Prism&&Prism.plugins.autoloader){Prism.plugins.autoloader.languages_path='{{ base_path }}/static/vendor/prism-langs/';}</script>
 </body>
 </html>

--- a/tests/functional/test_webui_browser_chat_e2e.py
+++ b/tests/functional/test_webui_browser_chat_e2e.py
@@ -3764,6 +3764,9 @@ def test_replayed_savings_done_restores_reply_without_replaying_popup_in_real_br
     assert payload["pageErrors"] == [], payload
 
 
+@pytest.mark.skip(
+    reason="Legacy Control UI retired; covered by opensquilla-webui/e2e/fork.spec.ts"
+)
 def test_webui_edit_middle_message_forks_without_history_leak(tmp_path: Path) -> None:
     if os.environ.get("OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E") != "1":
         pytest.skip("set OPENSQUILLA_WEBUI_BROWSER_CHAT_E2E=1 to run chat browser e2e")
@@ -4713,6 +4716,9 @@ def test_meta_skill_ribbon_renders_and_progresses_in_real_browser(tmp_path: Path
         assert "succeeded" in cls, f"chip class did not reach succeeded: {cls}"
 
 
+@pytest.mark.skip(
+    reason="Legacy Control UI retired; covered by Vue task-event guard unit tests"
+)
 def test_issue344_stale_task_events_do_not_leak_into_active_turn_in_real_browser(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_gateway/test_chat_static_assets.py
+++ b/tests/test_gateway/test_chat_static_assets.py
@@ -593,3 +593,5 @@ def test_control_index_loads_vue_entrypoint() -> None:
     assert 'id="opensquilla-data"' in index
     assert "vite_css_urls" in index
     assert "vite_js_url" in index
+    assert "Prism" not in index
+    assert "/static/vendor/" not in index

--- a/tests/test_gateway/test_static_cache_header.py
+++ b/tests/test_gateway/test_static_cache_header.py
@@ -8,6 +8,7 @@ shows up immediately.
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
@@ -165,26 +166,43 @@ def test_missing_vue_asset_recovery_is_in_troubleshooting_guide() -> None:
     assert "official release wheel" in normalized
 
 
-def test_control_ui_legacy_frontend_uses_static_bootstrap() -> None:
-    config = GatewayConfig()
-    config.control_ui.enabled = True
-    config.control_ui.frontend = "legacy"
+def test_control_ui_legacy_frontend_compat_input_serves_vue(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "index.html").write_text(
+        '<script type="module" crossorigin src="./assets/index.js"></script>'
+        '<link rel="stylesheet" crossorigin href="./assets/index.css">',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(control_ui, "_DIST_DIR", tmp_path)
+    with pytest.warns(DeprecationWarning, match="Vue is always served"):
+        control_config = ControlUiConfig(frontend="legacy")
+    config = GatewayConfig(control_ui=control_config)
     app = Starlette(routes=create_control_ui_routes(config))
     client = TestClient(app)
 
     response = client.get("/control/")
 
     assert response.status_code == 200
-    assert '/control/static/js/app.js' in response.text
-    assert '/control/static/dist/assets/' not in response.text
+    assert control_config.frontend == "vue"
+    assert '/control/static/dist/assets/index.js' in response.text
+    assert '/control/static/js/' not in response.text
 
 
-def test_control_ui_frontend_reads_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_control_ui_frontend_reads_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     monkeypatch.setenv("OPENSQUILLA_CONTROL_UI_FRONTEND", "legacy")
 
-    config = GatewayConfig()
+    with caplog.at_level(logging.WARNING, logger="opensquilla.gateway.config"):
+        with pytest.warns(DeprecationWarning, match="no longer selects"):
+            config = GatewayConfig()
 
-    assert config.control_ui.frontend == "legacy"
+    assert config.control_ui.frontend == "vue"
+    assert "Vue is always served" in caplog.text
+    assert "Remove this setting or set it to 'vue'" in caplog.text
 
 
 def test_control_ui_frontend_reads_toml_config(tmp_path) -> None:
@@ -194,9 +212,15 @@ def test_control_ui_frontend_reads_toml_config(tmp_path) -> None:
         encoding="utf-8",
     )
 
-    config = GatewayConfig.load_from_toml(config_path)
+    with pytest.warns(DeprecationWarning, match="Remove this setting"):
+        config = GatewayConfig.load_from_toml(config_path)
 
-    assert config.control_ui.frontend == "legacy"
+    assert config.control_ui.frontend == "vue"
+
+
+@pytest.mark.parametrize("value", ["vue", " VUE "])
+def test_control_ui_frontend_accepts_vue(value: str) -> None:
+    assert ControlUiConfig(frontend=value).frontend == "vue"
 
 
 def test_control_ui_frontend_rejects_invalid_value() -> None:
@@ -204,19 +228,27 @@ def test_control_ui_frontend_rejects_invalid_value() -> None:
         ControlUiConfig(frontend="retro")
 
 
-def test_control_ui_legacy_frontend_uses_configured_base_path() -> None:
-    config = GatewayConfig()
-    config.control_ui.enabled = True
-    config.control_ui.base_path = "/ops"
-    config.control_ui.frontend = "legacy"
+def test_control_ui_legacy_frontend_compat_uses_configured_base_path(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "index.html").write_text(
+        '<script type="module" crossorigin src="./assets/index.js"></script>',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(control_ui, "_DIST_DIR", tmp_path)
+    with pytest.warns(DeprecationWarning, match="Vue is always served"):
+        control_config = ControlUiConfig(base_path="/ops", frontend="legacy")
+    config = GatewayConfig(control_ui=control_config)
     app = Starlette(routes=create_control_ui_routes(config))
     client = TestClient(app)
 
     response = client.get("/ops/")
 
     assert response.status_code == 200
-    assert '/ops/static/js/app.js' in response.text
-    assert '/control/static/js/app.js' not in response.text
+    assert '/ops/static/dist/assets/index.js' in response.text
+    assert '/control/static/dist/assets/index.js' not in response.text
+    assert '/ops/static/js/' not in response.text
 
 
 def test_control_ui_bootstrap_ws_url_uses_client_reachable_wildcard_host() -> None:


### PR DESCRIPTION
## Summary

- make Vue the only Control UI runtime while mapping historical `frontend = "legacy"` config/env input to `vue` with a visible deprecation warning
- remove the unused Prism bootstrap and the dead `window.SavingsFX` bridge from Vue
- migrate the middle-message edit/fork history-isolation contract to Vue Playwright
- document the retired fallback and suspend the two opt-in tests that still target the Legacy DOM pending mechanical deletion

## Validation

- `84 passed` — focused Gateway/static/config tests
- `1254 passed` — full Vue unit suite
- Vue production build + artifact verification
- focused Vue Playwright edit/fork test in Chromium
- Ruff, mypy, TypeScript/architecture checks, and `git diff --check`

## Follow-up

A second PR will delete the now-unreachable Legacy template, JS/CSS/fonts/vendor assets, and Legacy-only static tests. Shared Vue assets and the Vite artifact pipeline remain.