### PR TITLE
Clarify health recovery guidance

### DIFF
--- a/opensquilla-webui/src/views/OverviewView.diagnostics.test.ts
+++ b/opensquilla-webui/src/views/OverviewView.diagnostics.test.ts
@@ -300,6 +300,98 @@ describe('OverviewView diagnose-with-agent hand-off', () => {
   })
 })
 
+describe('OverviewView recovery activation copy', () => {
+  it('keeps restart guidance on the concrete step without a finding-level restart claim', async () => {
+    const report = baseReport()
+    report.findings = [
+      {
+        id: 'provider.active.not_configured',
+        surface: 'provider',
+        severity: 'error',
+        readinessImpact: 'blocks_ready',
+        title: 'Active provider is not configured',
+        restartRequired: true,
+        fixSteps: [
+          {
+            label: 'Set provider environment variable',
+            detail: 'Set TOKENRHYTHM_API_KEY, then restart OpenSquilla.',
+          },
+          {
+            label: 'Restart gateway',
+            command: 'opensquilla gateway restart',
+          },
+        ],
+      },
+    ]
+
+    const { el } = await mountOverview({ report })
+
+    expect(el.textContent).not.toContain('Recovery requires restart')
+    expect(el.textContent).toContain('then restart OpenSquilla')
+    expect(el.textContent).toContain('Restart gateway')
+  })
+
+  it('keeps only the migration preview when the current target already has data', async () => {
+    const report = baseReport()
+    report.findings = [
+      {
+        id: 'migration.legacy_home_detected',
+        surface: 'migration',
+        severity: 'info',
+        readinessImpact: 'optional',
+        title: 'Legacy data found',
+        evidence: { target_fresh: false },
+        restartRequired: true,
+        fixSteps: [
+          {
+            label: 'Preview the import',
+            command: 'opensquilla migrate opensquilla --source /tmp/old',
+          },
+          {
+            label: 'Apply the import',
+            command: 'opensquilla migrate opensquilla --source /tmp/old --apply',
+          },
+        ],
+      },
+    ]
+
+    const { el } = await mountOverview({ report })
+
+    expect(el.textContent).toContain('Preview the import')
+    expect(el.textContent).not.toContain('Apply the import')
+    expect(el.textContent).not.toContain('--apply')
+  })
+
+  it('keeps the migration apply step for a fresh target', async () => {
+    const report = baseReport()
+    report.findings = [
+      {
+        id: 'migration.legacy_home_detected',
+        surface: 'migration',
+        severity: 'warn',
+        readinessImpact: 'degrades',
+        title: 'Legacy data found',
+        evidence: { targetFresh: true },
+        fixSteps: [
+          {
+            label: 'Preview the import',
+            command: 'opensquilla migrate opensquilla --source /tmp/old',
+          },
+          {
+            label: 'Apply the import',
+            command: 'opensquilla migrate opensquilla --source /tmp/old --apply',
+          },
+        ],
+      },
+    ]
+
+    const { el } = await mountOverview({ report })
+
+    expect(el.textContent).toContain('Apply the import')
+    expect(el.textContent).toContain('--apply')
+  })
+})
+
 describe('OverviewView copy diagnostics JSON', () => {
   it('copies the normalized report with gatewayUrl and copiedAt attached', async () => {
     const { el, copyText, pushToast, flush } = await mountOverview()

--- a/opensquilla-webui/src/views/OverviewView.vue
+++ b/opensquilla-webui/src/views/OverviewView.vue
@@ -146,7 +146,6 @@
                 >
                   {{ findingBadgeText(finding) }}
                 </span>
-                <span v-if="finding.restartRequired" class="health-chip">{{ t('sessions.overview.recoveryRestart') }}</span>
                 <button
                   v-if="findingSettingsLink(finding)"
                   type="button"
@@ -166,7 +165,7 @@
                 </span>
               </div>
               <AdvancedCliSteps
-                v-if="(finding.fixSteps || []).length"
+                v-if="normalizedFixSteps(finding).length"
                 :steps="normalizedFixSteps(finding)"
                 :heading="stepsHeading(findingGroupKind(finding))"
               />
@@ -750,7 +749,15 @@ function clearCopiedCommandTimer() {
 }
 
 function normalizedFixSteps(finding: Finding): Array<{ label: string; command?: string; detail?: string }> {
-  return (finding.fixSteps || []).map(step => ({
+  const targetFresh = finding.evidence?.target_fresh ?? finding.evidence?.targetFresh
+  const hideMigrationApply = finding.id === 'migration.legacy_home_detected'
+    && targetFresh === false
+
+  return (finding.fixSteps || []).filter((step) => {
+    if (!hideMigrationApply) return true
+    const command = String(step.command || '')
+    return !/(?:^|\s)--apply(?:\s|$)/.test(command)
+  }).map(step => ({
     label: step.label || t('sessions.overview.step'),
     command: step.command,
     detail: step.detail,


### PR DESCRIPTION
## Scope

- Remove the finding-level blanket “recovery requires restart” badge from the Health/Doctor view.
- Keep environment activation and gateway restart guidance on the concrete recovery steps where it is actionable.
- Hide the migration apply step when `target_fresh=false`, while retaining the preview command and preserving Apply for fresh targets.

## Why

`restartRequired` is a coarse diagnostic field. Presenting it as a universal finding-level fact overstated restart requirements, and the migration card exposed an Apply action even when the current installation already contained data.

## User impact

Health findings now distinguish between general status and the specific step that activates a change. Existing-data migration findings remain inspectable without encouraging an unsafe replacement action.

## Target

- Base branch: `main`
- Linked issue: None
- Release note: Not added; this is a corrective WebUI guidance change.

## Verification

- `npm run test:unit -- --run src/views/OverviewView.diagnostics.test.ts src/components/overview/AdvancedCliSteps.test.ts` — 21 tests passed.
- `npm run build` — WebUI build and repository frontend guards passed.
- Live local WebUI DOM verification confirmed the blanket badge is absent, concrete restart steps remain, and existing-data migration shows Preview without Apply.

## Safety and compatibility

- Frontend-only and platform-neutral.
- No persisted configuration or session-state changes.
- No backend or public protocol changes; `restartRequired` remains available to existing clients.

## Third-party origin

None.