### PR TITLE
Complete WebUI handoff to forked chat sessions

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatMessageActions.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatMessageActions.test.ts
@@ -95,6 +95,48 @@ describe('useChatMessageActions branching edits', () => {
     expect(options.inputText.value).toBe('B')
     expect(options.sendCurrentInput).toHaveBeenCalledOnce()
   })
+
+  it('keeps an optimistic user row intact until its durable fork id arrives', () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', text: 'still saving', ts: null, clientId: 'client-only' },
+    ]
+    const { api, options, pendingForkBeforeMessageId } = makeOptions(messages)
+
+    api.editMessage(renderedMessage({
+      role: 'user',
+      displayRole: 'user',
+      sourceIndex: 0,
+      clientId: 'client-only',
+      text: 'still saving',
+    }))
+
+    expect(options.messages.value).toEqual(messages)
+    expect(options.inputText.value).toBe('')
+    expect(pendingForkBeforeMessageId.value).toBeNull()
+    expect(options.focusComposer).not.toHaveBeenCalled()
+  })
+
+  it('does not regenerate as a parent send when the durable fork id is missing', async () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', text: 'still saving', ts: null, clientId: 'client-only' },
+      { role: 'assistant', text: 'partial answer', ts: null, messageId: 'assistant-local' },
+    ]
+    const { api, options, pendingForkBeforeMessageId } = makeOptions(messages)
+
+    api.regenerateMessage(renderedMessage({
+      role: 'assistant',
+      displayRole: 'assistant',
+      sourceIndex: 1,
+      messageId: 'assistant-local',
+      text: 'partial answer',
+    }))
+    await nextTick()
+
+    expect(options.messages.value).toEqual(messages)
+    expect(options.inputText.value).toBe('')
+    expect(pendingForkBeforeMessageId.value).toBeNull()
+    expect(options.sendCurrentInput).not.toHaveBeenCalled()
+  })
 })
 
 describe('useChatMessageActions protocol-shaped copy text', () => {

--- a/opensquilla-webui/src/composables/chat/useChatMessageActions.ts
+++ b/opensquilla-webui/src/composables/chat/useChatMessageActions.ts
@@ -81,8 +81,14 @@ export function useChatMessageActions(options: UseChatMessageActionsOptions) {
       return
     }
 
-    const userText = options.messages.value[userMsgIndex]?.text || ''
-    options.pendingForkBeforeMessageId.value = options.messages.value[userMsgIndex]?.messageId || null
+    const userMessage = options.messages.value[userMsgIndex]
+    const forkBeforeMessageId = userMessage?.messageId || ''
+    if (!forkBeforeMessageId) {
+      console.warn('Wait for the message to finish saving before regenerating')
+      return
+    }
+    const userText = userMessage?.text || ''
+    options.pendingForkBeforeMessageId.value = forkBeforeMessageId
     options.messages.value = options.messages.value.slice(0, userMsgIndex)
     options.inputText.value = userText
     options.autoResizeTextarea()
@@ -97,8 +103,14 @@ export function useChatMessageActions(options: UseChatMessageActionsOptions) {
     const msgIndex = sourceMessageIndex(message)
     if (msgIndex < 0) return
     if (options.messages.value[msgIndex]?.role !== 'user') return
-    const text = options.messages.value[msgIndex].text || ''
-    options.pendingForkBeforeMessageId.value = options.messages.value[msgIndex]?.messageId || null
+    const sourceMessage = options.messages.value[msgIndex]
+    const forkBeforeMessageId = sourceMessage?.messageId || ''
+    if (!forkBeforeMessageId) {
+      console.warn('Wait for the message to finish saving before editing')
+      return
+    }
+    const text = sourceMessage.text || ''
+    options.pendingForkBeforeMessageId.value = forkBeforeMessageId
     options.messages.value = options.messages.value.slice(0, msgIndex)
     options.inputText.value = text
     options.autoResizeTextarea()

--- a/opensquilla-webui/src/composables/chat/useChatPendingQueue.ts
+++ b/opensquilla-webui/src/composables/chat/useChatPendingQueue.ts
@@ -5,7 +5,18 @@ const MAX_PENDING = 5
 
 export type BusySendMode = 'queue' | 'steer'
 
+export interface PendingQueueOwner {
+  ownerRequestId?: string
+}
+
+export interface PendingQueueOwnerContext {
+  sessionKey: string
+  ownerRequestId: string
+}
+
 export interface UseChatPendingQueueOptions {
+  sessionKey: Ref<string>
+  ownerContext?: Readonly<Ref<PendingQueueOwnerContext | null>>
   inputText: Ref<string>
   pendingAttachments: Ref<Attachment[]>
   pendingSessionIntent: Ref<string | null>
@@ -22,7 +33,9 @@ export interface UseChatPendingQueueOptions {
 
 export function useChatPendingQueue(options: UseChatPendingQueueOptions) {
   const pendingQueue = ref<ChatPendingItem[]>([])
+  const parkedQueues = new Map<string, ChatPendingItem[]>()
   let pendingDrainTimer: ReturnType<typeof setTimeout> | null = null
+  let deferredDrainRequested = false
 
   const canQueueMore = computed(() => pendingQueue.value.length < MAX_PENDING)
 
@@ -32,39 +45,61 @@ export function useChatPendingQueue(options: UseChatPendingQueueOptions) {
   // safe default whenever streaming stops.
   const busySendMode = ref<BusySendMode>('queue')
   watch(options.isStreaming, (streaming) => {
-    if (!streaming) busySendMode.value = 'queue'
+    if (!streaming) {
+      busySendMode.value = 'queue'
+      flushDeferredPendingDrain()
+    }
   })
 
-  function enqueuePendingInput(text: string) {
+  function resolveOwnerRequestId(owner?: PendingQueueOwner): string | undefined {
+    if (owner?.ownerRequestId) return owner.ownerRequestId
+    const context = options.ownerContext?.value
+    return context?.sessionKey === options.sessionKey.value
+      ? context.ownerRequestId
+      : undefined
+  }
+
+  function enqueuePendingInput(text: string, owner?: PendingQueueOwner) {
     if (pendingQueue.value.length >= MAX_PENDING) {
       console.warn(`Pending queue full (${MAX_PENDING})`)
       return false
     }
+    const ownerRequestId = resolveOwnerRequestId(owner)
     pendingQueue.value.push({
       text,
       attachments: options.pendingAttachments.value.map(a => ({ ...a })),
       intent: options.pendingSessionIntent.value,
+      ownerSessionKey: options.sessionKey.value,
+      ...(ownerRequestId ? { ownerRequestId } : {}),
     })
     options.inputText.value = ''
     options.pendingAttachments.value = []
     options.pendingSessionIntent.value = null
     options.autoResizeTextarea()
+    flushDeferredPendingDrain()
     return true
   }
 
-  function enqueueHiddenControl(item: { text: string; displayText: string }) {
+  function enqueueHiddenControl(
+    item: { text: string; displayText: string },
+    owner?: PendingQueueOwner,
+  ) {
     if (pendingQueue.value.length >= MAX_PENDING) {
       console.warn(`Pending queue full (${MAX_PENDING})`)
       return false
     }
     // A hidden-control send does NOT consume the composer draft/attachments.
+    const ownerRequestId = resolveOwnerRequestId(owner)
     pendingQueue.value.push({
       text: item.text,
       attachments: [],
       intent: null,
+      ownerSessionKey: options.sessionKey.value,
+      ...(ownerRequestId ? { ownerRequestId } : {}),
       hiddenControl: true,
       displayTextOverride: item.displayText,
     })
+    flushDeferredPendingDrain()
     return true
   }
 
@@ -75,6 +110,52 @@ export function useChatPendingQueue(options: UseChatPendingQueueOptions) {
   function clearPendingQueue() {
     clearPendingDrainAfterTerminalTimer()
     pendingQueue.value = []
+  }
+
+  function switchPendingQueue(targetSessionKey: string) {
+    clearPendingDrainAfterTerminalTimer()
+    const restored = (parkedQueues.get(targetSessionKey) || [])
+      .filter(item => !item.hiddenControl)
+    parkedQueues.delete(targetSessionKey)
+    // Explicit navigation keeps its historical behavior of discarding the
+    // active session's queue. Only items parked during an automatic response
+    // handoff can be restored when their parent is selected again.
+    pendingQueue.value = restored
+  }
+
+  function adoptPendingQueue(targetSessionKey: string, ownerRequestId: string) {
+    clearPendingDrainAfterTerminalTimer()
+    const sourceSessionKey = options.sessionKey.value
+    const carried: ChatPendingItem[] = []
+    const stayingVisible: ChatPendingItem[] = []
+    for (const item of pendingQueue.value) {
+      if (
+        ownerRequestId
+        && item.ownerSessionKey === sourceSessionKey
+        && item.ownerRequestId === ownerRequestId
+      ) {
+        carried.push({
+          ...item,
+          ownerSessionKey: targetSessionKey,
+          ownerRequestId: undefined,
+        })
+      } else if (!item.hiddenControl) {
+        // A hidden control is scoped to the run that created it. Carry the
+        // matching run's controls, but never resurrect an older confirmation
+        // after a later manual navigation back to the parent session.
+        stayingVisible.push(item)
+      }
+    }
+    if (stayingVisible.length > 0) {
+      parkedQueues.set(sourceSessionKey, [
+        ...(parkedQueues.get(sourceSessionKey) || []).filter(item => !item.hiddenControl),
+        ...stayingVisible,
+      ])
+    }
+    const targetItems = (parkedQueues.get(targetSessionKey) || [])
+      .filter(item => !item.hiddenControl)
+    parkedQueues.delete(targetSessionKey)
+    pendingQueue.value = [...targetItems, ...carried]
   }
 
   function popPendingTail() {
@@ -130,24 +211,51 @@ export function useChatPendingQueue(options: UseChatPendingQueueOptions) {
   }
 
   function schedulePendingDrainAfterTerminal() {
-    if (pendingQueue.value.length === 0) return
-    clearPendingDrainAfterTerminalTimer()
+    if (pendingQueue.value.length === 0) {
+      // A terminal subscription replay can arrive while response handoff is
+      // still hydrating, before the matching follow-up reaches the queue.
+      // Preserve that terminal signal until the blocker releases.
+      deferredDrainRequested = options.isBlocked()
+      return
+    }
+    deferredDrainRequested = true
+    armPendingDrainTimer()
+  }
+
+  function armPendingDrainTimer() {
+    cancelPendingDrainTimer()
     pendingDrainTimer = setTimeout(() => {
       pendingDrainTimer = null
-      if (options.isStreaming.value || options.isBlocked() || pendingQueue.value.length === 0) return
+      if (pendingQueue.value.length === 0) {
+        deferredDrainRequested = false
+        return
+      }
+      if (options.isStreaming.value || options.isBlocked()) return
+      deferredDrainRequested = false
       drainQueueHead()
     }, 50)
   }
 
-  function clearPendingDrainAfterTerminalTimer() {
+  function flushDeferredPendingDrain() {
+    if (!deferredDrainRequested || pendingQueue.value.length === 0) return
+    armPendingDrainTimer()
+  }
+
+  function cancelPendingDrainTimer() {
     if (pendingDrainTimer) {
       clearTimeout(pendingDrainTimer)
       pendingDrainTimer = null
     }
   }
 
+  function clearPendingDrainAfterTerminalTimer() {
+    cancelPendingDrainTimer()
+    deferredDrainRequested = false
+  }
+
   function cleanup() {
     clearPendingDrainAfterTerminalTimer()
+    parkedQueues.clear()
   }
 
   return {
@@ -159,9 +267,12 @@ export function useChatPendingQueue(options: UseChatPendingQueueOptions) {
     enqueueHiddenControl,
     removePendingChip,
     clearPendingQueue,
+    switchPendingQueue,
+    adoptPendingQueue,
     popPendingTail,
     popAllPendingIntoComposer,
     schedulePendingDrainAfterTerminal,
+    flushDeferredPendingDrain,
     clearPendingDrainAfterTerminalTimer,
     cleanup,
   }

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
@@ -33,6 +33,7 @@ function createHarness(options: {
     useReducer: ref(false),
   }
   const markEnsembleHandoff = vi.fn()
+  const schedulePendingDrainAfterTerminal = vi.fn()
   const scope = effectScope()
   const api = scope.run(() => useChatRpcEventHandlers({
     sessionKey: ref('agent:main:test'),
@@ -65,7 +66,7 @@ function createHarness(options: {
     handleRouterControlReplay: vi.fn(),
     showCompactionToast: vi.fn(),
     scheduleHistorySync: vi.fn(),
-    schedulePendingDrainAfterTerminal: vi.fn(),
+    schedulePendingDrainAfterTerminal,
     popAllPendingIntoComposer: vi.fn(() => false),
     saveWidgetState: vi.fn(),
     subscribeSession: vi.fn(),
@@ -79,6 +80,7 @@ function createHarness(options: {
     activeTaskGroups,
     applySessionRunState,
     markEnsembleHandoff,
+    schedulePendingDrainAfterTerminal,
     stop: () => scope.stop(),
   }
 }
@@ -133,6 +135,35 @@ describe('useChatRpcEventHandlers task group lifecycle', () => {
 
       expect(activeTaskGroups.value.size).toBe(0)
       expect(stream.endStreaming).toHaveBeenCalled()
+    } finally {
+      stop()
+    }
+  })
+
+  it('releases pending work when the last background-only task group finishes', () => {
+    const {
+      api,
+      activeTaskGroups,
+      stream,
+      schedulePendingDrainAfterTerminal,
+      stop,
+    } = createHarness()
+    stream.isStreaming.value = false
+
+    try {
+      api.handlers.onTaskGroupWaiting({
+        session_key: 'agent:main:test',
+        stream_seq: 1,
+        group_id: 'group-live',
+      })
+      api.handlers.onTaskGroupDone({
+        session_key: 'agent:main:test',
+        stream_seq: 2,
+        group_id: 'group-live',
+      })
+
+      expect(activeTaskGroups.value.size).toBe(0)
+      expect(schedulePendingDrainAfterTerminal).toHaveBeenCalledOnce()
     } finally {
       stop()
     }

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -487,6 +487,9 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
       run_status: terminalStatus === 'failed' ? 'failed' : 'idle',
       last_task: { ...(payload || {}), status: terminalStatus },
     })
+    if (!stream.isStreaming.value) {
+      options.schedulePendingDrainAfterTerminal()
+    }
   }
 
   function sessionChangeIsTerminal(payload: SessionEventPayload): boolean {

--- a/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import { useChatSend, type UseChatSendOptions } from './useChatSend'
+import { useChatMessageActions } from './useChatMessageActions'
 import type { FoldLiveTurnMode } from './useChatTurnLog'
-import type { Attachment, ChatMessage } from '@/types/chat'
+import type { Attachment, ChatMessage, ChatRenderedMessage } from '@/types/chat'
 import type { BusySendMode } from '@/composables/chat/useChatPendingQueue'
-import { FINISHED_STREAM_TASK_ID } from '@/utils/chat/streamEvents'
+import { FINISHED_STREAM_TASK_ID, STOPPED_STREAM_TASK_ID } from '@/utils/chat/streamEvents'
 
 const pushToast = vi.hoisted(() => vi.fn())
 
@@ -43,6 +44,7 @@ function makeOptions(overrides: Partial<UseChatSendOptions> = {}) {
     inputText: ref('hello'),
     messages: ref<ChatMessage[]>([]),
     sessionKey: ref('agent:main:webchat:test'),
+    pendingQueueOwnerContext: ref(null),
     busySendMode: ref<BusySendMode>('queue'),
     elevatedMode: ref(''),
     runMode: ref('trusted'),
@@ -55,8 +57,10 @@ function makeOptions(overrides: Partial<UseChatSendOptions> = {}) {
     autoScroll: ref(false),
     stream,
     normalizeElevatedMode: mode => mode,
-    persistSession: vi.fn(),
+    adoptResponseSession: vi.fn(),
     scheduleHistorySync: vi.fn(),
+    schedulePendingDrainAfterTerminal: vi.fn(),
+    flushDeferredPendingDrain: vi.fn(),
     isCompactInFlightForCurrentSession: () => false,
     hasPendingAttachmentWork: () => false,
     enqueuePendingInput: vi.fn(() => true),
@@ -325,6 +329,136 @@ describe('useChatSend attachment payloads', () => {
     expect(pendingForkBeforeMessageId.value).toBeNull()
   })
 
+  it('switches the session lifecycle when a stopped turn is edited into a child session', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const pendingForkBeforeMessageId = ref<string | null>(null)
+    const adoptResponseSession = vi.fn()
+    const rpcCall = vi.fn(async (method: string) => {
+      if (method === 'chat.send') {
+        return { sessionKey: childSessionKey, task_id: 'task-child' }
+      }
+      return { ok: true }
+    })
+    const rpc: UseChatSendOptions['rpc'] = {
+      call: rpcCall as unknown as UseChatSendOptions['rpc']['call'],
+    }
+    const { api, options, stream } = makeOptions({
+      rpc,
+      sessionKey: ref(parentSessionKey),
+      activeStreamSessionKey: ref(parentSessionKey),
+      pendingForkBeforeMessageId,
+      adoptResponseSession,
+    })
+    stream.isStreaming.value = true
+    vi.mocked(stream.endStreaming).mockImplementation(() => {
+      stream.isStreaming.value = false
+    })
+
+    api.onStop()
+    pendingForkBeforeMessageId.value = 'msg-B'
+    options.inputText.value = 'edited question'
+    await api.onSend()
+
+    expect(rpcCall).toHaveBeenCalledWith('chat.abort', {
+      sessionKey: parentSessionKey,
+      source: 'webui_stop',
+    })
+    expect(rpcCall).toHaveBeenCalledWith('chat.send', expect.objectContaining({
+      sessionKey: parentSessionKey,
+      forkBeforeMessageId: 'msg-B',
+      message: 'edited question',
+    }))
+    expect(adoptResponseSession).toHaveBeenCalledOnce()
+    expect(adoptResponseSession).toHaveBeenCalledWith(childSessionKey, expect.any(String))
+  })
+
+  it('binds the accepted user message id so stop then edit sends a real fork', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref(parentSessionKey)
+    const inputText = ref('original question')
+    const messages = ref<ChatMessage[]>([])
+    const pendingForkBeforeMessageId = ref<string | null>(null)
+    let sendCount = 0
+    const rpc = {
+      call: vi.fn(<T = unknown>(method: string, params?: Record<string, unknown>) => {
+        if (method === 'chat.abort') return Promise.resolve({ aborted: true }) as Promise<T>
+        sendCount += 1
+        if (sendCount === 1) {
+          return Promise.resolve({
+            sessionKey: parentSessionKey,
+            task_id: 'task-original',
+            user_message_id: 'message-original',
+            client_message_id: params?.clientMessageId,
+          }) as Promise<T>
+        }
+        return Promise.resolve({
+          sessionKey: childSessionKey,
+          task_id: 'task-edited',
+          user_message_id: 'message-edited',
+          client_message_id: params?.clientMessageId,
+        }) as Promise<T>
+      }) as UseChatSendOptions['rpc']['call'],
+    }
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+    })
+    const harness = makeOptions({
+      rpc,
+      sessionKey,
+      inputText,
+      messages,
+      pendingForkBeforeMessageId,
+      adoptResponseSession,
+    })
+    harness.stream.endStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = false
+    })
+    harness.stream.startStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = true
+    })
+    harness.stream.endStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = false
+    })
+
+    await harness.api.onSend()
+
+    const optimisticUser = messages.value[0]
+    expect(optimisticUser?.clientId).toBeTruthy()
+    expect(optimisticUser?.messageId).toBe('message-original')
+    expect(rpc.call).toHaveBeenNthCalledWith(1, 'chat.send', expect.objectContaining({
+      clientMessageId: optimisticUser?.clientId,
+    }))
+
+    harness.api.onStop()
+    const actions = useChatMessageActions({
+      messages,
+      inputText,
+      isStreaming: harness.stream.isStreaming,
+      sanitizeCopyText: text => text,
+      stripTimePrefix: text => text,
+      autoResizeTextarea: vi.fn(),
+      sendCurrentInput: vi.fn(),
+      focusComposer: vi.fn(),
+      pendingForkBeforeMessageId,
+    })
+    actions.editMessage({
+      ...optimisticUser,
+      sourceIndex: 0,
+    } as ChatRenderedMessage)
+    expect(pendingForkBeforeMessageId.value).toBe('message-original')
+
+    inputText.value = 'edited question'
+    await harness.api.onSend()
+
+    expect(rpc.call).toHaveBeenCalledWith('chat.send', expect.objectContaining({
+      sessionKey: parentSessionKey,
+      forkBeforeMessageId: 'message-original',
+    }))
+    expect(adoptResponseSession).toHaveBeenCalledWith(childSessionKey, expect.any(String))
+  })
+
   it('restores the pending fork target only when chat.send explicitly rejects the attempt', async () => {
     const pendingForkBeforeMessageId = ref<string | null>('msg-B')
     const rpc = {
@@ -380,6 +514,7 @@ describe('useChatSend attachment payloads', () => {
     const firstParams = rpc.call.mock.calls[0]?.[1]
     expect(firstParams).toMatchObject({
       clientRequestId: expect.any(String),
+      clientMessageId: expect.any(String),
       message: 'hello',
       sessionKey: 'agent:main:webchat:test',
       intent: 'NEW',
@@ -434,6 +569,133 @@ describe('useChatSend attachment payloads', () => {
 
     expect(rpc.call.mock.calls[1]?.[1]).toEqual(firstParams)
     expect(options.messages.value.filter(message => message.role === 'user')).toHaveLength(1)
+  })
+
+  it('keeps a recovered fork gated while its canonical child response is pending', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref(parentSessionKey)
+    const inputText = ref('edited question')
+    let resolveRetry!: (value: unknown) => void
+    let sendCount = 0
+    const rpcCall = vi.fn(<T = unknown>(method: string, _params?: Record<string, unknown>) => {
+      if (method !== 'chat.send') return Promise.resolve({}) as Promise<T>
+      sendCount += 1
+      if (sendCount === 1) {
+        return Promise.reject(Object.assign(new Error('database busy'), {
+          accepted: false,
+          retryable: true,
+        })) as Promise<T>
+      }
+      if (sendCount === 2) {
+        return new Promise<T>((resolve) => {
+          resolveRetry = resolve as (value: unknown) => void
+        })
+      }
+      return Promise.resolve({ sessionKey: parentSessionKey }) as Promise<T>
+    })
+    const rpc = { call: rpcCall as UseChatSendOptions['rpc']['call'] }
+    const enqueuePendingInput = vi.fn(() => true)
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+    })
+    const harness = makeOptions({
+      rpc,
+      sessionKey,
+      inputText,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      busySendMode: ref<BusySendMode>('steer'),
+      enqueuePendingInput,
+      adoptResponseSession,
+    })
+
+    await harness.api.onSend()
+    harness.stream.isStreaming.value = true
+    const retry = harness.api.onSend()
+    await vi.waitFor(() => expect(sendCount).toBe(2))
+    const ownerRequestId = String(rpcCall.mock.calls[1]?.[1]?.clientRequestId)
+
+    inputText.value = 'follow the recovered edit'
+    await harness.api.onSend()
+
+    expect(sendCount).toBe(2)
+    expect(enqueuePendingInput).toHaveBeenCalledWith('follow the recovered edit', {
+      ownerRequestId,
+    })
+
+    resolveRetry({ sessionKey: childSessionKey, task_id: 'task-child' })
+    await retry
+    expect(adoptResponseSession).toHaveBeenCalledWith(childSessionKey, ownerRequestId)
+  })
+
+  it('aborts a recovered fork child that resolves after Stop during an ambient run', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref(parentSessionKey)
+    const inputText = ref('edited question')
+    let resolveRetry!: (value: unknown) => void
+    let sendCount = 0
+    const rpcCall = vi.fn(<T = unknown>(method: string, params?: Record<string, unknown>) => {
+      if (method === 'chat.abort') {
+        if (params?.sessionKey === childSessionKey) {
+          return Promise.reject(new Error('socket closed')) as Promise<T>
+        }
+        return Promise.resolve({ aborted: true }) as Promise<T>
+      }
+      sendCount += 1
+      if (sendCount === 1) {
+        return Promise.reject(Object.assign(new Error('response lost'), {
+          accepted: false,
+          retryable: true,
+        })) as Promise<T>
+      }
+      return new Promise<T>((resolve) => {
+        resolveRetry = resolve as (value: unknown) => void
+      })
+    })
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+    })
+    const harness = makeOptions({
+      rpc: { call: rpcCall as UseChatSendOptions['rpc']['call'] },
+      sessionKey,
+      inputText,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      adoptResponseSession,
+    })
+    harness.stream.endStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = false
+    })
+
+    await harness.api.onSend()
+    harness.stream.isStreaming.value = true
+    harness.options.activeStreamSessionKey.value = parentSessionKey
+    const retry = harness.api.onSend()
+    await vi.waitFor(() => expect(sendCount).toBe(2))
+
+    // The ambient parent run can finish while the idempotent fork retry is
+    // still waiting for its canonical child response.
+    harness.stream.isStreaming.value = false
+    harness.api.onStop()
+    resolveRetry({ sessionKey: childSessionKey, task_id: 'task-child' })
+    await retry
+
+    expect(adoptResponseSession).toHaveBeenCalledWith(childSessionKey, expect.any(String))
+    expect(rpcCall).toHaveBeenCalledWith('chat.abort', {
+      sessionKey: childSessionKey,
+      taskId: 'task-child',
+      source: 'webui_stale_send',
+    })
+    expect(harness.options.aborted.value).toBe(true)
+    expect(harness.options.activeStreamTaskId.value).toBe(STOPPED_STREAM_TASK_ID)
+    expect(harness.options.activeStreamSessionKey.value).toBe(childSessionKey)
+    expect(harness.stream.isStreaming.value).toBe(false)
+    await vi.waitFor(() => expect(harness.options.messages.value).toContainEqual(
+      expect.objectContaining({
+        role: 'system',
+        text: 'Stop could not reach the server — the run may still be finishing.',
+      }),
+    ))
   })
 
   it('uses a new id when the user changes a recovered attempt before resending', async () => {
@@ -551,6 +813,750 @@ describe('useChatSend attachment payloads', () => {
       terminalNotice: true,
     })
     expect(options.scheduleHistorySync).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a child-session activation failure after the session handoff', async () => {
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref('agent:main:webchat:parent')
+    const messages = ref<ChatMessage[]>([])
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+      messages.value = []
+    })
+    const rpc = {
+      call: vi.fn().mockResolvedValue({
+        sessionKey: childSessionKey,
+        task_id: 'task-child-failed',
+        task_status: 'failed',
+        terminal_reason: 'activation_failed',
+        terminal_message: 'The edited question could not be activated.',
+      }),
+    }
+    const { api, options } = makeOptions({
+      rpc,
+      sessionKey,
+      messages,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      adoptResponseSession,
+    })
+
+    await api.onSend()
+
+    expect(adoptResponseSession).toHaveBeenCalledWith(childSessionKey, expect.any(String))
+    expect(options.messages.value[options.messages.value.length - 1]).toMatchObject({
+      role: 'error',
+      text: 'The edited question could not be activated.',
+      errorCode: 'activation_failed',
+      terminalNotice: true,
+    })
+  })
+
+  it('keeps a hidden child-session terminal failure after the session handoff', async () => {
+    const childSessionKey = 'agent:main:webchat:hidden-child'
+    const sessionKey = ref('agent:main:webchat:parent')
+    const messages = ref<ChatMessage[]>([])
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+      messages.value = []
+    })
+    const rpc = {
+      call: vi.fn().mockResolvedValue({
+        sessionKey: childSessionKey,
+        task_id: 'task-hidden-failed',
+        task_status: 'failed',
+        terminal_reason: 'activation_failed',
+        terminal_message: 'The confirmation could not be activated.',
+      }),
+    }
+    const { api, options } = makeOptions({ rpc, sessionKey, messages, adoptResponseSession })
+
+    await api.dispatchHiddenSend('provider confirmation', 'Confirmed')
+
+    expect(adoptResponseSession).toHaveBeenCalledWith(childSessionKey, expect.any(String))
+    expect(options.messages.value[options.messages.value.length - 1]).toMatchObject({
+      role: 'error',
+      text: 'The confirmation could not be activated.',
+      errorCode: 'activation_failed',
+      terminalNotice: true,
+    })
+  })
+
+  it('does not leak a child terminal failure after navigation during the handoff', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const otherSessionKey = 'agent:main:webchat:other'
+    const sessionKey = ref(parentSessionKey)
+    let finishHandoff!: () => void
+    const handoffGate = new Promise<void>((resolve) => {
+      finishHandoff = resolve
+    })
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+      await handoffGate
+    })
+    const rpc = {
+      call: vi.fn().mockResolvedValue({
+        sessionKey: childSessionKey,
+        task_id: 'task-child-failed',
+        task_status: 'failed',
+        terminal_reason: 'activation_failed',
+        terminal_message: 'This failure belongs to the child session.',
+      }),
+    }
+    const { api, options } = makeOptions({ rpc, sessionKey, adoptResponseSession })
+
+    const send = api.onSend()
+    await vi.waitFor(() => expect(adoptResponseSession).toHaveBeenCalledWith(
+      childSessionKey,
+      expect.any(String),
+    ))
+    sessionKey.value = otherSessionKey
+    finishHandoff()
+    await send
+
+    expect(options.messages.value.some(message => message.terminalNotice)).toBe(false)
+  })
+
+  it('queues instead of steering a new child input while response handoff hydrates', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref(parentSessionKey)
+    const inputText = ref('edited question')
+    let finishHandoff!: () => void
+    const handoffGate = new Promise<void>((resolve) => {
+      finishHandoff = resolve
+    })
+    let stream!: UseChatSendOptions['stream']
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+      // The real session runtime resets the parent live-turn state before
+      // child subscription/history hydration has completed.
+      stream.isStreaming.value = false
+      await handoffGate
+    })
+    let sendCount = 0
+    const rpc = {
+      call: vi.fn(<T = unknown>(method: string) => {
+        if (method !== 'chat.send') return Promise.resolve({}) as Promise<T>
+        sendCount += 1
+        if (sendCount === 1) {
+          return Promise.resolve({
+            sessionKey: childSessionKey,
+            task_id: 'task-child-old',
+            task_status: 'failed',
+            terminal_reason: 'activation_failed',
+            terminal_message: 'The edited question could not be activated.',
+          }) as Promise<T>
+        }
+        return Promise.resolve({ sessionKey: childSessionKey }) as Promise<T>
+      }) as UseChatSendOptions['rpc']['call'],
+    }
+    const enqueuePendingInput = vi.fn(() => true)
+    const harness = makeOptions({
+      rpc,
+      sessionKey,
+      inputText,
+      adoptResponseSession,
+      enqueuePendingInput,
+      busySendMode: ref<BusySendMode>('steer'),
+    })
+    stream = harness.stream
+    stream.startStreaming = vi.fn(() => {
+      stream.isStreaming.value = true
+    })
+    stream.endStreaming = vi.fn(() => {
+      stream.isStreaming.value = false
+    })
+
+    const oldSend = harness.api.onSend()
+    await vi.waitFor(() => expect(adoptResponseSession).toHaveBeenCalledWith(
+      childSessionKey,
+      expect.any(String),
+    ))
+
+    inputText.value = 'new child question'
+    await harness.api.onSend()
+    expect(sendCount).toBe(1)
+    expect(enqueuePendingInput).toHaveBeenCalledWith('new child question', {
+      ownerRequestId: expect.any(String),
+    })
+
+    finishHandoff()
+    await oldSend
+
+    expect(stream.endStreaming).toHaveBeenCalledTimes(1)
+    expect(stream.isStreaming.value).toBe(false)
+    expect(harness.options.schedulePendingDrainAfterTerminal).toHaveBeenCalledTimes(1)
+    expect(harness.options.flushDeferredPendingDrain).toHaveBeenCalledOnce()
+  })
+
+  it('schedules an adopted follow-up when terminal replay finishes before hydration', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref(parentSessionKey)
+    const inputText = ref('edited question')
+    const activeStreamTaskId = ref('')
+    let finishHydration!: () => void
+    const hydration = new Promise<void>((resolve) => {
+      finishHydration = resolve
+    })
+    let stream!: UseChatSendOptions['stream']
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+      stream.isStreaming.value = false
+      // A terminal replay can arrive while the handoff reset has streaming
+      // false; the event handler records the FINISHED sentinel and returns.
+      activeStreamTaskId.value = FINISHED_STREAM_TASK_ID
+      await hydration
+      return { authoritativeIdle: true }
+    })
+    const rpc = {
+      call: vi.fn().mockResolvedValue({
+        sessionKey: childSessionKey,
+        task_id: 'task-child-not-replayed',
+      }),
+    }
+    const enqueuePendingInput = vi.fn(() => true)
+    const harness = makeOptions({
+      rpc,
+      sessionKey,
+      inputText,
+      activeStreamTaskId,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      adoptResponseSession,
+      enqueuePendingInput,
+    })
+    stream = harness.stream
+    stream.startStreaming = vi.fn(() => {
+      stream.isStreaming.value = true
+    })
+
+    const forkSend = harness.api.onSend()
+    await vi.waitFor(() => expect(adoptResponseSession).toHaveBeenCalledOnce())
+    inputText.value = 'follow-up for idle child'
+    await harness.api.onSend()
+    expect(enqueuePendingInput).toHaveBeenCalledOnce()
+
+    finishHydration()
+    await forkSend
+
+    expect(harness.options.schedulePendingDrainAfterTerminal).toHaveBeenCalledOnce()
+    expect(harness.options.flushDeferredPendingDrain).toHaveBeenCalledOnce()
+  })
+
+  it('waits for a terminal event before draining a legacy child without a task id', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref(parentSessionKey)
+    const inputText = ref('edited question')
+    const activeStreamTaskId = ref('')
+    let finishHydration!: () => void
+    const hydration = new Promise<void>((resolve) => {
+      finishHydration = resolve
+    })
+    let stream!: UseChatSendOptions['stream']
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+      stream.isStreaming.value = false
+      activeStreamTaskId.value = ''
+      await hydration
+      return { authoritativeIdle: true }
+    })
+    const rpc = {
+      call: vi.fn().mockResolvedValue({ sessionKey: childSessionKey }),
+    }
+    const enqueuePendingInput = vi.fn(() => true)
+    const harness = makeOptions({
+      rpc,
+      sessionKey,
+      inputText,
+      activeStreamTaskId,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      adoptResponseSession,
+      enqueuePendingInput,
+    })
+    stream = harness.stream
+    stream.startStreaming = vi.fn(() => {
+      stream.isStreaming.value = true
+    })
+
+    const forkSend = harness.api.onSend()
+    await vi.waitFor(() => expect(adoptResponseSession).toHaveBeenCalledOnce())
+    inputText.value = 'follow-up for legacy child'
+    await harness.api.onSend()
+    expect(enqueuePendingInput).toHaveBeenCalledOnce()
+
+    finishHydration()
+    await forkSend
+
+    expect(harness.options.schedulePendingDrainAfterTerminal).not.toHaveBeenCalled()
+    expect(harness.options.flushDeferredPendingDrain).toHaveBeenCalledOnce()
+    expect(stream.startStreaming).toHaveBeenCalledTimes(2)
+    expect(stream.isStreaming.value).toBe(true)
+  })
+
+  it('drains a legacy child when terminal replay is authoritatively complete', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref(parentSessionKey)
+    const activeStreamTaskId = ref('')
+    let stream!: UseChatSendOptions['stream']
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+      stream.isStreaming.value = false
+      activeStreamTaskId.value = FINISHED_STREAM_TASK_ID
+      return { authoritativeIdle: true }
+    })
+    const harness = makeOptions({
+      rpc: { call: vi.fn().mockResolvedValue({ sessionKey: childSessionKey }) },
+      sessionKey,
+      activeStreamTaskId,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      adoptResponseSession,
+    })
+    stream = harness.stream
+    stream.startStreaming = vi.fn(() => {
+      stream.isStreaming.value = true
+    })
+
+    await harness.api.onSend()
+
+    expect(stream.startStreaming).toHaveBeenCalledOnce()
+    expect(stream.isStreaming.value).toBe(false)
+    expect(harness.options.schedulePendingDrainAfterTerminal).toHaveBeenCalledOnce()
+  })
+
+  it('does not treat a failed child subscription as authoritative idle', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref(parentSessionKey)
+    const inputText = ref('edited question')
+    let finishHydration!: () => void
+    const hydration = new Promise<void>((resolve) => {
+      finishHydration = resolve
+    })
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+      await hydration
+      return { authoritativeIdle: false }
+    })
+    const enqueuePendingInput = vi.fn(() => true)
+    const harness = makeOptions({
+      rpc: {
+        call: vi.fn().mockResolvedValue({
+          sessionKey: childSessionKey,
+          task_id: 'task-child-unknown',
+        }),
+      },
+      sessionKey,
+      inputText,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      adoptResponseSession,
+      enqueuePendingInput,
+    })
+    harness.stream.startStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = true
+    })
+
+    const forkSend = harness.api.onSend()
+    await vi.waitFor(() => expect(adoptResponseSession).toHaveBeenCalledOnce())
+    inputText.value = 'follow-up while subscription is unavailable'
+    await harness.api.onSend()
+    finishHydration()
+    await forkSend
+
+    expect(enqueuePendingInput).toHaveBeenCalledOnce()
+    expect(harness.options.schedulePendingDrainAfterTerminal).not.toHaveBeenCalled()
+  })
+
+  it('queues steer input while a fork send is awaiting its canonical session', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref(parentSessionKey)
+    const inputText = ref('edited question')
+    let resolveFork!: (value: unknown) => void
+    let sendCount = 0
+    const rpcCall = vi.fn(<T = unknown>(method: string, _params?: Record<string, unknown>) => {
+      if (method !== 'chat.send') return Promise.resolve({}) as Promise<T>
+      sendCount += 1
+      if (sendCount === 1) {
+        return new Promise<T>((resolve) => {
+          resolveFork = resolve as (value: unknown) => void
+        })
+      }
+      return Promise.resolve({ sessionKey: parentSessionKey }) as Promise<T>
+    })
+    const rpc = {
+      call: rpcCall as UseChatSendOptions['rpc']['call'],
+    }
+    const enqueuePendingInput = vi.fn(() => true)
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+    })
+    const harness = makeOptions({
+      rpc,
+      sessionKey,
+      inputText,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      busySendMode: ref<BusySendMode>('steer'),
+      enqueuePendingInput,
+      adoptResponseSession,
+    })
+    harness.stream.startStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = true
+    })
+
+    const forkSend = harness.api.onSend()
+    await vi.waitFor(() => expect(sendCount).toBe(1))
+    const ownerRequestId = String(rpcCall.mock.calls[0]?.[1]?.clientRequestId)
+
+    inputText.value = 'follow the edited question'
+    await harness.api.onSend()
+
+    expect(sendCount).toBe(1)
+    expect(enqueuePendingInput).toHaveBeenCalledWith('follow the edited question', {
+      ownerRequestId,
+    })
+
+    resolveFork({ sessionKey: childSessionKey, task_id: 'task-child' })
+    await forkSend
+  })
+
+  it('does not drain a follow-up over a restored fork draft after rejection', async () => {
+    const inputText = ref('edited question')
+    let rejectFork!: (reason: unknown) => void
+    const rpc = {
+      call: vi.fn(<T = unknown>() => new Promise<T>((_resolve, reject) => {
+        rejectFork = reject
+      })) as UseChatSendOptions['rpc']['call'],
+    }
+    const enqueuePendingInput = vi.fn(() => {
+      inputText.value = ''
+      return true
+    })
+    const harness = makeOptions({
+      rpc,
+      inputText,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      enqueuePendingInput,
+    })
+    harness.stream.startStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = true
+    })
+    harness.stream.endStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = false
+    })
+
+    const forkSend = harness.api.onSend()
+    await vi.waitFor(() => expect(rpc.call).toHaveBeenCalledOnce())
+    inputText.value = 'queued follow-up'
+    await harness.api.onSend()
+
+    rejectFork(Object.assign(new Error('database busy'), { accepted: false }))
+    await forkSend
+
+    expect(inputText.value).toBe('edited question')
+    expect(enqueuePendingInput).toHaveBeenCalledOnce()
+    expect(rpc.call).toHaveBeenCalledOnce()
+    expect(harness.options.flushDeferredPendingDrain).not.toHaveBeenCalled()
+    expect(harness.options.schedulePendingDrainAfterTerminal).not.toHaveBeenCalled()
+  })
+
+  it('does not let an old handoff gate queue input in a newly selected session', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const otherSessionKey = 'agent:main:webchat:other'
+    const sessionKey = ref(parentSessionKey)
+    const inputText = ref('edited question')
+    let finishHandoff!: () => void
+    const hydration = new Promise<void>((resolve) => {
+      finishHandoff = resolve
+    })
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+      await hydration
+    })
+    let sendCount = 0
+    const rpc = {
+      call: vi.fn(<T = unknown>(method: string, params?: Record<string, unknown>) => {
+        if (method !== 'chat.send') return Promise.resolve({}) as Promise<T>
+        sendCount += 1
+        if (sendCount === 1) {
+          return Promise.resolve({ sessionKey: childSessionKey, task_id: 'task-child' }) as Promise<T>
+        }
+        return Promise.resolve({ sessionKey: params?.sessionKey, task_id: 'task-other' }) as Promise<T>
+      }) as UseChatSendOptions['rpc']['call'],
+    }
+    const enqueuePendingInput = vi.fn(() => true)
+    const harness = makeOptions({
+      rpc,
+      sessionKey,
+      inputText,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      adoptResponseSession,
+      enqueuePendingInput,
+    })
+    harness.stream.startStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = true
+    })
+    harness.stream.endStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = false
+    })
+
+    const forkSend = harness.api.onSend()
+    await vi.waitFor(() => expect(adoptResponseSession).toHaveBeenCalledOnce())
+
+    sessionKey.value = otherSessionKey
+    harness.stream.isStreaming.value = false
+    inputText.value = 'question for other session'
+    await harness.api.onSend()
+
+    expect(sendCount).toBe(2)
+    expect(rpc.call).toHaveBeenLastCalledWith('chat.send', expect.objectContaining({
+      sessionKey: otherSessionKey,
+      message: 'question for other session',
+    }))
+    expect(enqueuePendingInput).not.toHaveBeenCalled()
+
+    finishHandoff()
+    await forkSend
+    expect(harness.options.flushDeferredPendingDrain).not.toHaveBeenCalled()
+  })
+
+  it('adopts and aborts a fork child when its response arrives after Stop', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref(parentSessionKey)
+    let resolveFork!: (value: unknown) => void
+    const rpc = {
+      call: vi.fn(<T = unknown>(method: string, params?: Record<string, unknown>) => {
+        if (method === 'chat.send') {
+          return new Promise<T>((resolve) => {
+            resolveFork = resolve as (value: unknown) => void
+          })
+        }
+        if (params?.sessionKey === childSessionKey) {
+          return Promise.reject(new Error('socket closed')) as Promise<T>
+        }
+        return Promise.resolve({ aborted: true }) as Promise<T>
+      }) as UseChatSendOptions['rpc']['call'],
+    }
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+    })
+    const harness = makeOptions({
+      rpc,
+      sessionKey,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      adoptResponseSession,
+    })
+    harness.stream.startStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = true
+    })
+    harness.stream.endStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = false
+    })
+
+    const forkSend = harness.api.onSend()
+    await vi.waitFor(() => expect(rpc.call).toHaveBeenCalledWith(
+      'chat.send',
+      expect.objectContaining({ sessionKey: parentSessionKey }),
+    ))
+    const optimisticClientId = harness.options.messages.value[0]?.clientId
+    harness.api.onStop()
+
+    resolveFork({
+      sessionKey: childSessionKey,
+      task_id: 'task-child',
+      user_message_id: 'message-child',
+    })
+    await forkSend
+
+    expect(adoptResponseSession).toHaveBeenCalledWith(childSessionKey, expect.any(String))
+    expect(rpc.call).toHaveBeenCalledWith('chat.abort', {
+      sessionKey: childSessionKey,
+      taskId: 'task-child',
+      source: 'webui_stale_send',
+    })
+    expect(harness.options.messages.value.find(
+      message => message.clientId === optimisticClientId,
+    )?.messageId).toBeUndefined()
+    expect(harness.options.aborted.value).toBe(true)
+    expect(harness.options.activeStreamTaskId.value).toBe(STOPPED_STREAM_TASK_ID)
+    expect(harness.options.activeStreamSessionKey.value).toBe(childSessionKey)
+    expect(harness.stream.isStreaming.value).toBe(false)
+  })
+
+  it('still aborts a stopped fork response after navigation to another session', async () => {
+    pushToast.mockClear()
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const otherSessionKey = 'agent:main:webchat:other'
+    const sessionKey = ref(parentSessionKey)
+    let resolveFork!: (value: unknown) => void
+    const rpc = {
+      call: vi.fn(<T = unknown>(method: string, params?: Record<string, unknown>) => {
+        if (method === 'chat.send') {
+          return new Promise<T>((resolve) => {
+            resolveFork = resolve as (value: unknown) => void
+          })
+        }
+        if (params?.sessionKey === childSessionKey) {
+          return Promise.reject(new Error('socket closed')) as Promise<T>
+        }
+        return Promise.resolve({ aborted: true }) as Promise<T>
+      }) as UseChatSendOptions['rpc']['call'],
+    }
+    const adoptResponseSession = vi.fn()
+    const harness = makeOptions({
+      rpc,
+      sessionKey,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      adoptResponseSession,
+    })
+    harness.stream.startStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = true
+    })
+    harness.stream.endStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = false
+    })
+
+    const forkSend = harness.api.onSend()
+    await vi.waitFor(() => expect(rpc.call).toHaveBeenCalledWith(
+      'chat.send',
+      expect.objectContaining({ sessionKey: parentSessionKey }),
+    ))
+    harness.api.onStop()
+    sessionKey.value = otherSessionKey
+    harness.options.activeStreamTaskId.value = ''
+
+    resolveFork({ sessionKey: childSessionKey, task_id: 'task-child-late' })
+    await forkSend
+
+    expect(rpc.call).toHaveBeenCalledWith('chat.abort', {
+      sessionKey: childSessionKey,
+      taskId: 'task-child-late',
+      source: 'webui_stale_send',
+    })
+    expect(adoptResponseSession).not.toHaveBeenCalled()
+    expect(sessionKey.value).toBe(otherSessionKey)
+    await Promise.resolve()
+    expect(harness.options.messages.value).not.toContainEqual(expect.objectContaining({
+      role: 'system',
+      text: 'Stop could not reach the server — the run may still be finishing.',
+    }))
+    expect(pushToast).toHaveBeenCalledWith(
+      'Stop could not reach the server — the run may still be finishing.',
+      { tone: 'warn', duration: 8000 },
+    )
+  })
+
+  it('binds an orphan message id and reconciles history for an accepted queue error', async () => {
+    const rpc = {
+      call: vi.fn().mockRejectedValue(Object.assign(new Error('queue bookkeeping failed'), {
+        accepted: true,
+        retryable: false,
+        details: { orphan_message_id: 'message-orphan' },
+      })),
+    }
+    const harness = makeOptions({ rpc })
+
+    await harness.api.onSend()
+
+    expect(harness.options.messages.value[0]).toMatchObject({
+      role: 'user',
+      messageId: 'message-orphan',
+    })
+    expect(harness.options.scheduleHistorySync).toHaveBeenCalledOnce()
+    expect(harness.options.inputText.value).toBe('')
+  })
+
+  it('adopts the child without binding its orphan id onto the parent after a dirty fork error', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref(parentSessionKey)
+    const messages = ref<ChatMessage[]>([])
+    const rpc = {
+      call: vi.fn().mockRejectedValue(Object.assign(new Error('queue bookkeeping failed'), {
+        code: 'QUEUE_FULL_DIRTY',
+        accepted: true,
+        retryable: false,
+        details: {
+          session_key: childSessionKey,
+          orphan_message_id: 'message-child-orphan',
+        },
+      })),
+    }
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+    })
+    const harness = makeOptions({
+      rpc,
+      sessionKey,
+      messages,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      adoptResponseSession,
+    })
+
+    await harness.api.onSend()
+
+    expect(adoptResponseSession).toHaveBeenCalledWith(childSessionKey, expect.any(String))
+    expect(messages.value.find(message => message.role === 'user')?.messageId).toBeUndefined()
+    expect(harness.options.scheduleHistorySync).toHaveBeenCalledOnce()
+    expect(harness.stream.startStreaming).toHaveBeenCalledOnce()
+    expect(harness.stream.endStreaming).toHaveBeenCalledOnce()
+    expect(harness.options.schedulePendingDrainAfterTerminal).toHaveBeenCalledOnce()
+    expect(sessionKey.value).toBe(childSessionKey)
+  })
+
+  it('does not abort unrelated child work for a stopped dirty fork rejection', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref(parentSessionKey)
+    let rejectSend!: (reason: unknown) => void
+    const rpcCall = vi.fn(<T = unknown>(method: string) => {
+      if (method === 'chat.abort') return Promise.resolve({ aborted: true }) as Promise<T>
+      return new Promise<T>((_resolve, reject) => {
+        rejectSend = reject
+      })
+    })
+    const adoptResponseSession = vi.fn(async (key: string) => {
+      sessionKey.value = key
+    })
+    const harness = makeOptions({
+      rpc: { call: rpcCall as UseChatSendOptions['rpc']['call'] },
+      sessionKey,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      adoptResponseSession,
+    })
+    harness.stream.startStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = true
+    })
+    harness.stream.endStreaming = vi.fn(() => {
+      harness.stream.isStreaming.value = false
+    })
+
+    const send = harness.api.onSend()
+    await vi.waitFor(() => expect(rpcCall).toHaveBeenCalledWith(
+      'chat.send',
+      expect.objectContaining({ sessionKey: parentSessionKey }),
+    ))
+    harness.api.onStop()
+    rejectSend(Object.assign(new Error('queue bookkeeping failed'), {
+      code: 'QUEUE_FULL_DIRTY',
+      accepted: true,
+      retryable: false,
+      details: {
+        session_key: childSessionKey,
+        orphan_message_id: 'message-child-orphan',
+      },
+    }))
+    await send
+
+    expect(adoptResponseSession).toHaveBeenCalledWith(childSessionKey, expect.any(String))
+    expect(rpcCall).not.toHaveBeenCalledWith('chat.abort', expect.objectContaining({
+      sessionKey: childSessionKey,
+    }))
   })
 
   it('surfaces a terminal steer failure without ending the existing stream', async () => {
@@ -723,25 +1729,40 @@ describe('useChatSend attachment payloads', () => {
       }) as UseChatSendOptions['rpc']['call'],
     }
     const inputText = ref('first')
+    const messages = ref<ChatMessage[]>([])
     const activeStreamTaskId = ref('')
-    const { api, stream } = makeOptions({ rpc, inputText, activeStreamTaskId })
+    const { api, stream } = makeOptions({ rpc, inputText, messages, activeStreamTaskId })
     stream.startStreaming = vi.fn(() => { stream.isStreaming.value = true })
     stream.endStreaming = vi.fn(() => { stream.isStreaming.value = false })
 
     const firstSend = api.onSend()
+    const firstClientMessageId = messages.value[0]?.clientId
     api.onStop()
 
     inputText.value = 'second'
     const secondSend = api.onSend()
+    const secondClientMessageId = messages.value[1]?.clientId
 
-    pendingResponses[1]({ sessionKey: 'agent:main:webchat:test', task_id: 'task-B' })
+    pendingResponses[1]({
+      sessionKey: 'agent:main:webchat:test',
+      task_id: 'task-B',
+      message_id: 'message-B',
+    })
     await secondSend
     expect(activeStreamTaskId.value).toBe('task-B')
+    expect(messages.value.find(message => message.clientId === secondClientMessageId)?.messageId)
+      .toBe('message-B')
 
-    pendingResponses[0]({ sessionKey: 'agent:main:webchat:test', task_id: 'task-A' })
+    pendingResponses[0]({
+      sessionKey: 'agent:main:webchat:test',
+      task_id: 'task-A',
+      user_message_id: 'message-A',
+    })
     await firstSend
 
     expect(activeStreamTaskId.value).toBe('task-B')
+    expect(messages.value.find(message => message.clientId === firstClientMessageId)?.messageId)
+      .toBe('message-A')
     expect(rpc.call).toHaveBeenCalledWith('chat.abort', {
       sessionKey: 'agent:main:webchat:test',
       taskId: 'task-A',

--- a/opensquilla-webui/src/composables/chat/useChatSend.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.ts
@@ -10,7 +10,11 @@ import type {
   ChatSendResponse,
 } from '@/types/rpc'
 import type { ChatRpcStreamApi } from '@/composables/chat/useChatRpcEventHandlers'
-import type { BusySendMode } from '@/composables/chat/useChatPendingQueue'
+import type {
+  BusySendMode,
+  PendingQueueOwner,
+  PendingQueueOwnerContext,
+} from '@/composables/chat/useChatPendingQueue'
 import { recordSessionNavigationDiag } from '@/utils/chat/sessionNavigationDiag'
 import { isSendableAttachment, serializeDisplayAttachment, serializeSendableAttachment, type SendableAttachment } from '@/utils/chat/attachments'
 import { createClientMessageId, createClientRequestId } from '@/utils/chat/messageIdentity'
@@ -25,10 +29,9 @@ type RpcClient = {
   call: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
 
-type PersistSessionOptions = { updateRoute?: boolean; source?: string }
-
 interface SendAttempt {
   clientRequestId: string
+  clientMessageId: string
   composerText: string
   requestSessionKey: string
   queueMode?: 'steer'
@@ -37,6 +40,21 @@ interface SendAttempt {
   intent: string | null
   forkBeforeMessageId: string | null
   params: ChatSendParams
+}
+
+interface ResponseHandoffGate {
+  requestSessionKey: string
+  ownerRequestId: string
+  targetSessionKey: string | null
+  stoppedByUser: boolean
+  acceptedTaskId: string
+  terminalResponse: boolean
+  authoritativeIdle: boolean
+  backgroundOnly: boolean
+}
+
+interface FreshSendToken {
+  stoppedByUser: boolean
 }
 
 export type SendResponseSessionDecision =
@@ -68,6 +86,27 @@ function shouldRestoreSendAttempt(err: unknown): boolean {
   // the exact attempt keeps its durable clientRequestId. Only a positive
   // accepted signal proves that restoring the composer would be misleading.
   return (err as RpcClientError | null | undefined)?.accepted !== true
+}
+
+interface AcceptedErrorInfo {
+  messageId: string
+  sessionKey: string
+  terminalWithoutTask: boolean
+}
+
+function acceptedErrorInfo(err: unknown): AcceptedErrorInfo | null {
+  const rpcError = err as RpcClientError | null | undefined
+  if (rpcError?.accepted !== true) return null
+  const details = rpcError.details && typeof rpcError.details === 'object'
+    ? rpcError.details as Record<string, unknown>
+    : {}
+  const rawMessageId = details.orphan_message_id ?? details.orphanMessageId
+  const rawSessionKey = details.session_key ?? details.sessionKey
+  return {
+    messageId: typeof rawMessageId === 'string' ? rawMessageId : '',
+    sessionKey: typeof rawSessionKey === 'string' ? rawSessionKey : '',
+    terminalWithoutTask: rpcError.code === 'QUEUE_FULL_DIRTY',
+  }
 }
 
 const TERMINAL_TASK_STATUSES = new Set([
@@ -143,6 +182,7 @@ export interface UseChatSendOptions {
   inputText: Ref<string>
   messages: Ref<ChatMessage[]>
   sessionKey: Ref<string>
+  pendingQueueOwnerContext: Ref<PendingQueueOwnerContext | null>
   busySendMode: Ref<BusySendMode>
   elevatedMode: Ref<string>
   runMode: Ref<SandboxRunMode>
@@ -158,16 +198,26 @@ export interface UseChatSendOptions {
   stream: ChatRpcStreamApi
   canStop?: () => boolean
   normalizeElevatedMode: (mode: string) => string
-  persistSession: (key: string, options?: PersistSessionOptions) => void
+  adoptResponseSession: (
+    key: string,
+    ownerRequestId: string,
+  ) => void
+    | { authoritativeIdle: boolean; backgroundOnly?: boolean }
+    | Promise<void | { authoritativeIdle: boolean; backgroundOnly?: boolean }>
   scheduleHistorySync: () => void
+  schedulePendingDrainAfterTerminal: () => void
+  flushDeferredPendingDrain: () => void
   // Event frames can beat the chat.send response. The event handler owns the
   // pending-terminal buffer and consumes only the task id accepted here.
   bindActiveStreamTask?: (taskId: string) => void
   isCompactInFlightForCurrentSession: () => boolean
   hasPendingAttachmentWork: () => boolean
   prepareAttachmentsForSend?: (options?: { isCurrent?: () => boolean }) => Promise<boolean>
-  enqueuePendingInput: (text: string) => boolean
-  enqueueHiddenControl?: (item: { text: string; displayText: string }) => boolean
+  enqueuePendingInput: (text: string, owner?: PendingQueueOwner) => boolean
+  enqueueHiddenControl?: (
+    item: { text: string; displayText: string },
+    owner?: PendingQueueOwner,
+  ) => boolean
   popAllPendingIntoComposer: () => boolean
   executeSlashCommand: (text: string) => Promise<boolean>
   closeSlashMenu: () => void
@@ -177,11 +227,12 @@ export interface UseChatSendOptions {
 
 export function useChatSend(options: UseChatSendOptions) {
   const { pushToast } = useToasts()
-  let activeFreshSendToken: symbol | null = null
+  let activeFreshSendToken: FreshSendToken | null = null
+  let activeResponseHandoff: ResponseHandoffGate | null = null
   let recoveredAttempt: SendAttempt | null = null
 
-  function beginFreshStream(requestSessionKey: string): symbol {
-    const token = Symbol('fresh-send')
+  function beginFreshStream(requestSessionKey: string): FreshSendToken {
+    const token: FreshSendToken = { stoppedByUser: false }
     activeFreshSendToken = token
     options.activeStreamTaskId.value = PENDING_STREAM_TASK_ID
     options.activeStreamSessionKey.value = requestSessionKey
@@ -190,7 +241,127 @@ export function useChatSend(options: UseChatSendOptions) {
     return token
   }
 
-  function freshSendStillOwnsStream(token: symbol | null, requestSessionKey: string): boolean {
+  function pendingQueueOwner(): PendingQueueOwner | undefined {
+    const context = options.pendingQueueOwnerContext.value
+    return context?.sessionKey === options.sessionKey.value
+      ? { ownerRequestId: context.ownerRequestId }
+      : undefined
+  }
+
+  function beginResponseHandoff(
+    requestSessionKey: string,
+    ownerRequestId: string,
+  ): ResponseHandoffGate {
+    const gate: ResponseHandoffGate = {
+      requestSessionKey,
+      ownerRequestId,
+      targetSessionKey: null,
+      stoppedByUser: false,
+      acceptedTaskId: '',
+      terminalResponse: false,
+      authoritativeIdle: false,
+      backgroundOnly: false,
+    }
+    activeResponseHandoff = gate
+    options.pendingQueueOwnerContext.value = { sessionKey: requestSessionKey, ownerRequestId }
+    return gate
+  }
+
+  function responseHandoffBlocksCurrentSession(): boolean {
+    const gate = activeResponseHandoff
+    if (!gate) return false
+    const currentSessionKey = options.sessionKey.value
+    return (
+      currentSessionKey === gate.requestSessionKey
+      || currentSessionKey === gate.targetSessionKey
+    )
+  }
+
+  async function handoffResponseSession(key: string, gate: ResponseHandoffGate) {
+    gate.targetSessionKey = key
+    if (activeResponseHandoff === gate) {
+      options.pendingQueueOwnerContext.value = {
+        sessionKey: key,
+        ownerRequestId: gate.ownerRequestId,
+      }
+    }
+    const adoption = await options.adoptResponseSession(key, gate.ownerRequestId)
+    gate.authoritativeIdle = adoption?.authoritativeIdle === true
+    gate.backgroundOnly = adoption?.backgroundOnly === true
+    if (gate.stoppedByUser && options.sessionKey.value === key) {
+      options.aborted.value = true
+      options.activeStreamTaskId.value = STOPPED_STREAM_TASK_ID
+      options.activeStreamSessionKey.value = key
+      if (options.stream.isStreaming.value) {
+        options.stream.endStreaming({ reason: 'aborted' })
+      }
+      options.popAllPendingIntoComposer()
+      return
+    }
+    const terminalReplayFinished = (
+      options.activeStreamTaskId.value === FINISHED_STREAM_TASK_ID
+      && gate.authoritativeIdle
+    )
+    const shouldPreserveAcceptedStream = (
+      options.sessionKey.value === key
+      && !gate.terminalResponse
+      && !terminalReplayFinished
+      && !gate.backgroundOnly
+      && (!gate.authoritativeIdle || !gate.acceptedTaskId)
+    )
+    if (shouldPreserveAcceptedStream && !options.stream.isStreaming.value) {
+      options.stream.startStreaming()
+      options.stream.showThinkingIndicator()
+    }
+    if (
+      shouldPreserveAcceptedStream
+      && gate.acceptedTaskId
+      && !options.activeStreamTaskId.value
+    ) {
+      bindAcceptedTask(gate.acceptedTaskId)
+    }
+    if (
+      shouldPreserveAcceptedStream
+      || (options.sessionKey.value === key && options.stream.isStreaming.value)
+    ) {
+      options.activeStreamSessionKey.value = key
+    }
+  }
+
+  function finishResponseHandoff(gate: ResponseHandoffGate | null) {
+    if (!gate || activeResponseHandoff !== gate) return
+    const adoptedTargetIsCurrent = Boolean(
+      gate.targetSessionKey
+      && options.sessionKey.value === gate.targetSessionKey,
+    )
+    activeResponseHandoff = null
+    if (options.pendingQueueOwnerContext.value?.ownerRequestId === gate.ownerRequestId) {
+      options.pendingQueueOwnerContext.value = null
+    }
+    if (adoptedTargetIsCurrent && !gate.stoppedByUser) {
+      options.flushDeferredPendingDrain()
+      // An idle subscription snapshot can be authoritative without replaying
+      // a terminal event. In that case there is no deferred signal to flush,
+      // so explicitly release the adopted follow-up after hydration finishes.
+      if (
+        (gate.acceptedTaskId || options.activeStreamTaskId.value === FINISHED_STREAM_TASK_ID)
+        && !gate.terminalResponse
+        && gate.authoritativeIdle
+        && !options.stream.isStreaming.value
+        && (
+          !options.activeStreamTaskId.value
+          || options.activeStreamTaskId.value === FINISHED_STREAM_TASK_ID
+        )
+      ) {
+        options.schedulePendingDrainAfterTerminal()
+      }
+    }
+  }
+
+  function freshSendStillOwnsStream(
+    token: FreshSendToken | null,
+    requestSessionKey: string,
+  ): boolean {
     return (
       token !== null &&
       activeFreshSendToken === token &&
@@ -202,6 +373,23 @@ export function useChatSend(options: UseChatSendOptions) {
     return response?.task_id || response?.taskId || ''
   }
 
+  function bindAcceptedUserMessage(
+    clientMessageId: string,
+    response: ChatSendResponse | null | undefined,
+  ) {
+    const messageId = response?.user_message_id || response?.message_id || ''
+    bindUserMessageId(clientMessageId, messageId)
+  }
+
+  function bindUserMessageId(clientMessageId: string, messageId: string) {
+    if (!clientMessageId || !messageId) return
+    const index = options.messages.value.findIndex(message => message.clientId === clientMessageId)
+    if (index < 0) return
+    const optimistic = options.messages.value[index]
+    if (!optimistic || optimistic.messageId === messageId) return
+    options.messages.value[index] = { ...optimistic, messageId }
+  }
+
   function bindAcceptedTask(taskId: string) {
     if (options.bindActiveStreamTask) {
       options.bindActiveStreamTask(taskId)
@@ -210,18 +398,40 @@ export function useChatSend(options: UseChatSendOptions) {
     options.activeStreamTaskId.value = taskId
   }
 
+  function reportAbortFailure(relevantSessionKeys?: string[]) {
+    const message = 'Stop could not reach the server — the run may still be finishing.'
+    if (
+      relevantSessionKeys
+      && !relevantSessionKeys.includes(options.sessionKey.value)
+    ) {
+      pushToast(message, { tone: 'warn', duration: 8000 })
+      return
+    }
+    options.messages.value.push({
+      role: 'system',
+      text: message,
+      ts: new Date().toISOString(),
+    })
+  }
+
   function handleTerminalResponse(
     response: ChatSendResponse,
-    freshSendToken: symbol | null,
+    freshSendToken: FreshSendToken | null,
     optionsForResponse: { finishFreshStream: boolean },
   ): boolean {
     const status = terminalResponseStatus(response)
     if (!status) return false
-    if (optionsForResponse.finishFreshStream) {
-      if (activeFreshSendToken === freshSendToken) activeFreshSendToken = null
+    let finalizedFreshStream = false
+    if (
+      optionsForResponse.finishFreshStream
+      && freshSendToken !== null
+      && activeFreshSendToken === freshSendToken
+    ) {
+      activeFreshSendToken = null
       options.activeStreamTaskId.value = FINISHED_STREAM_TASK_ID
       options.activeStreamSessionKey.value = ''
       options.stream.endStreaming(status === 'cancelled' ? { reason: 'aborted' } : undefined)
+      finalizedFreshStream = true
     }
     if (status !== 'succeeded') {
       options.messages.value.push({
@@ -233,18 +443,30 @@ export function useChatSend(options: UseChatSendOptions) {
       })
     }
     options.scheduleHistorySync()
+    if (finalizedFreshStream) {
+      if (status === 'cancelled') options.popAllPendingIntoComposer()
+      else options.schedulePendingDrainAfterTerminal()
+    }
     return true
   }
 
-  function abortStaleAcceptedTask(response: ChatSendResponse | null | undefined, requestSessionKey: string) {
-    if (options.sessionKey.value !== requestSessionKey) return
+  function abortStaleAcceptedTask(
+    response: ChatSendResponse | null | undefined,
+    requestSessionKey: string,
+    force = false,
+  ) {
+    if (!force && options.sessionKey.value !== requestSessionKey) return
     const taskId = acceptedTaskId(response)
-    if (!taskId) return
-    options.rpc.call('chat.abort', {
-      sessionKey: requestSessionKey,
-      taskId,
+    if (!taskId && !force) return
+    const acceptedSessionKey = response?.sessionKey || requestSessionKey
+    const params: Record<string, string> = {
+      sessionKey: acceptedSessionKey,
       source: 'webui_stale_send',
-    }).catch(() => {})
+    }
+    if (taskId) params.taskId = taskId
+    options.rpc.call('chat.abort', params).catch(() => {
+      if (force) reportAbortFailure([requestSessionKey, acceptedSessionKey])
+    })
   }
 
   async function onSend() {
@@ -252,6 +474,7 @@ export function useChatSend(options: UseChatSendOptions) {
     let sendableAttachments = options.pendingAttachments.value.filter(isSendableAttachment)
     let hasPayload = text || sendableAttachments.length > 0
     let isLiteralSlash = false
+    const handoffInFlight = responseHandoffBlocksCurrentSession()
 
     if (options.hasPendingAttachmentWork()) {
       pushToast(i18n.global.t('chat.toast.waitAttachments'), { tone: 'info' })
@@ -270,6 +493,7 @@ export function useChatSend(options: UseChatSendOptions) {
     // Deriving steer/followup again here would create a new fingerprint and
     // could duplicate a turn that the gateway already accepted.
     if (
+      !handoffInFlight &&
       recoveredAttempt &&
       matchesRecoveredDraft(recoveredAttempt, {
         requestSessionKey: options.sessionKey.value,
@@ -287,7 +511,7 @@ export function useChatSend(options: UseChatSendOptions) {
     }
 
     const compactInFlight = options.isCompactInFlightForCurrentSession()
-    if (options.stream.isStreaming.value || compactInFlight) {
+    if (options.stream.isStreaming.value || compactInFlight || handoffInFlight) {
       if (!isLiteralSlash && text.startsWith('/')) {
         pushToast(i18n.global.t(
           compactInFlight ? 'chat.toast.waitCompactionBeforeCommand' : 'chat.toast.waitResponseBeforeCommand',
@@ -298,7 +522,7 @@ export function useChatSend(options: UseChatSendOptions) {
       if (!hasPayload) return
       // Steer injects into the active run right away; compaction cannot be
       // steered, so those sends still queue until it finishes.
-      if (options.busySendMode.value === 'steer' && !compactInFlight) {
+      if (options.busySendMode.value === 'steer' && !compactInFlight && !handoffInFlight) {
         await dispatchSend(text, {
           composerText: options.inputText.value,
           queueMode: 'steer',
@@ -307,7 +531,7 @@ export function useChatSend(options: UseChatSendOptions) {
       }
       // Surface a full queue instead of silently dropping the send: the draft is
       // preserved (enqueue returns false before clearing the composer).
-      if (!options.enqueuePendingInput(text)) {
+      if (!options.enqueuePendingInput(text, pendingQueueOwner())) {
         pushToast(i18n.global.t('chat.toast.queueFull'), { tone: 'info' })
       }
       return
@@ -375,6 +599,7 @@ export function useChatSend(options: UseChatSendOptions) {
       const clientMessageId = createClientMessageId()
       const params: ChatSendParams = {
         clientRequestId: createClientRequestId(),
+        clientMessageId,
         message: text || 'Describe these attachments',
         sessionKey: requestSessionKey,
       }
@@ -388,6 +613,7 @@ export function useChatSend(options: UseChatSendOptions) {
       }
       attempt = {
         clientRequestId: params.clientRequestId!,
+        clientMessageId,
         composerText: sendOpts?.composerText ?? text,
         requestSessionKey,
         queueMode: sendOpts?.queueMode,
@@ -422,29 +648,64 @@ export function useChatSend(options: UseChatSendOptions) {
     // A steer send rides an already-active stream; restarting it would wipe
     // the partial output of the run being steered.
     const wasStreaming = options.stream.isStreaming.value
-    const freshSendToken = wasStreaming ? null : beginFreshStream(requestSessionKey)
+    const freshSendToken = wasStreaming
+      ? null
+      : beginFreshStream(requestSessionKey)
+    let responseHandoff = (
+      attempt.forkBeforeMessageId
+        ? beginResponseHandoff(requestSessionKey, attempt.clientRequestId)
+        : null
+    )
 
     try {
       const res = await options.rpc.call<ChatSendResponse>('chat.send', attempt.params)
-      if (!wasStreaming && !freshSendStillOwnsStream(freshSendToken, requestSessionKey)) {
-        abortStaleAcceptedTask(res, requestSessionKey)
+      const taskId = acceptedTaskId(res)
+      const terminalStatus = terminalResponseStatus(res)
+      if (responseHandoff) {
+        responseHandoff.acceptedTaskId = taskId
+        responseHandoff.terminalResponse = Boolean(terminalStatus)
+      }
+      const stoppedByUser = freshSendToken?.stoppedByUser === true
+        || responseHandoff?.stoppedByUser === true
+      const lostFreshStream = !wasStreaming
+        && !freshSendStillOwnsStream(freshSendToken, requestSessionKey)
+      if (stoppedByUser || lostFreshStream) {
+        const acceptedSessionKey = res?.sessionKey || requestSessionKey
+        // A same-session accepted row remains part of the visible parent even
+        // after Stop or a newer send. A child identity must never be written
+        // onto that parent row; the child history owns it after handoff.
+        if (
+          options.sessionKey.value === requestSessionKey
+          && acceptedSessionKey === requestSessionKey
+        ) {
+          bindAcceptedUserMessage(attempt.clientMessageId, res)
+        }
+        abortStaleAcceptedTask(res, requestSessionKey, stoppedByUser)
+        if (
+          stoppedByUser
+          && options.sessionKey.value === requestSessionKey
+          && acceptedSessionKey !== requestSessionKey
+        ) {
+          responseHandoff ||= beginResponseHandoff(
+            requestSessionKey,
+            attempt.clientRequestId,
+          )
+          responseHandoff.stoppedByUser = true
+          responseHandoff.acceptedTaskId = taskId
+          responseHandoff.terminalResponse = Boolean(terminalStatus)
+          await handoffResponseSession(acceptedSessionKey, responseHandoff)
+        }
         return
+      }
+      if ((res?.sessionKey || requestSessionKey) === requestSessionKey) {
+        bindAcceptedUserMessage(attempt.clientMessageId, res)
       }
       // Bind the live stream to this turn's task so a prior task's late events
       // can't bleed into it (issue #344). Only a fresh turn takes over rendering
       // — a steer/queue send rides the in-flight stream and must not rebind —
       // and only while this session is still the one on screen.
-      const taskId = acceptedTaskId(res)
-      const terminalStatus = terminalResponseStatus(res)
       const responseIsCurrent = options.sessionKey.value === requestSessionKey
-      if (terminalStatus && responseIsCurrent) {
-        handleTerminalResponse(res, freshSendToken, {
-          finishFreshStream: !wasStreaming,
-        })
-        // A terminal task response (including first-attempt activation failure)
-        // may have no future live event. Fresh turns close their spinner;
-        // steer responses only surface the result without ending the older run.
-      } else if (!terminalStatus && !wasStreaming && responseIsCurrent) {
+      if (!terminalStatus && !wasStreaming && responseIsCurrent) {
         options.activeStreamSessionKey.value = res?.sessionKey || requestSessionKey
         if (taskId) bindAcceptedTask(taskId)
       }
@@ -453,13 +714,19 @@ export function useChatSend(options: UseChatSendOptions) {
         currentSessionKey: options.sessionKey.value,
         responseSessionKey: res?.sessionKey,
       })
+      const terminalSessionKey = decision.action === 'persist'
+        ? decision.responseSessionKey
+        : requestSessionKey
       if (decision.action === 'persist') {
         recordSessionNavigationDiag('send.response.persist', {
           requestSession: requestSessionKey,
           responseSession: decision.responseSessionKey,
           current: options.sessionKey.value,
         })
-        options.persistSession(decision.responseSessionKey, { source: 'send.response' })
+        responseHandoff ||= beginResponseHandoff(requestSessionKey, attempt.clientRequestId)
+        responseHandoff.acceptedTaskId = taskId
+        responseHandoff.terminalResponse = Boolean(terminalStatus)
+        await handoffResponseSession(decision.responseSessionKey, responseHandoff)
       } else if (decision.reason === 'current_session_changed') {
         recordSessionNavigationDiag('send.response.stale', {
           requestSession: requestSessionKey,
@@ -468,7 +735,65 @@ export function useChatSend(options: UseChatSendOptions) {
           reason: decision.reason,
         })
       }
+      if (
+        terminalStatus
+        && responseIsCurrent
+        && options.sessionKey.value === terminalSessionKey
+      ) {
+        handleTerminalResponse(res, freshSendToken, {
+          finishFreshStream: !wasStreaming,
+        })
+        // A terminal task response (including first-attempt activation failure)
+        // may have no future live event. Fresh turns close their spinner;
+        // steer responses only surface the result without ending the older run.
+      }
     } catch (err: unknown) {
+      const acceptedError = acceptedErrorInfo(err)
+      const acceptedSessionKey = acceptedError?.sessionKey || requestSessionKey
+      const stoppedByUser = freshSendToken?.stoppedByUser === true
+        || responseHandoff?.stoppedByUser === true
+      if (
+        acceptedError
+        && stoppedByUser
+        && !acceptedError.terminalWithoutTask
+        && acceptedSessionKey !== requestSessionKey
+      ) {
+        abortStaleAcceptedTask(
+          { sessionKey: acceptedSessionKey },
+          requestSessionKey,
+          true,
+        )
+      }
+      if (
+        acceptedError
+        && options.sessionKey.value === requestSessionKey
+        && acceptedSessionKey !== requestSessionKey
+      ) {
+        if (!wasStreaming && activeFreshSendToken === freshSendToken) {
+          activeFreshSendToken = null
+          options.activeStreamTaskId.value = ''
+          options.activeStreamSessionKey.value = ''
+          options.stream.endStreaming()
+        }
+        responseHandoff ||= beginResponseHandoff(requestSessionKey, attempt.clientRequestId)
+        responseHandoff.stoppedByUser = stoppedByUser
+        responseHandoff.terminalResponse = acceptedError.terminalWithoutTask
+        await handoffResponseSession(acceptedSessionKey, responseHandoff)
+        options.scheduleHistorySync()
+        if (acceptedError.terminalWithoutTask && !stoppedByUser) {
+          options.schedulePendingDrainAfterTerminal()
+        }
+        options.messages.value.push({
+          role: 'error',
+          text: 'Send failed: ' + errorMessage(err),
+          ts: new Date().toISOString(),
+        })
+        return
+      }
+      if (acceptedError && options.sessionKey.value === requestSessionKey) {
+        bindUserMessageId(attempt.clientMessageId, acceptedError.messageId)
+        options.scheduleHistorySync()
+      }
       if (options.sessionKey.value !== requestSessionKey) {
         recordSessionNavigationDiag('send.error.stale', {
           requestSession: requestSessionKey,
@@ -481,7 +806,9 @@ export function useChatSend(options: UseChatSendOptions) {
         return
       }
       if (!wasStreaming) {
-        if (activeFreshSendToken === freshSendToken) activeFreshSendToken = null
+        if (activeFreshSendToken === freshSendToken) {
+          activeFreshSendToken = null
+        }
         options.activeStreamTaskId.value = ''
         options.activeStreamSessionKey.value = ''
         options.stream.endStreaming()
@@ -489,6 +816,8 @@ export function useChatSend(options: UseChatSendOptions) {
       if (shouldRestoreSendAttempt(err)) restoreSendAttempt(attempt)
       const message = errorMessage(err)
       options.messages.value.push({ role: 'error', text: 'Send failed: ' + message, ts: new Date().toISOString() })
+    } finally {
+      finishResponseHandoff(responseHandoff)
     }
   }
 
@@ -518,9 +847,15 @@ export function useChatSend(options: UseChatSendOptions) {
   }
 
   function onStop() {
-    if (!(options.canStop?.() ?? options.stream.isStreaming.value)) return
+    const handoffCanStop = responseHandoffBlocksCurrentSession()
+    if (!(handoffCanStop || (options.canStop?.() ?? options.stream.isStreaming.value))) return
     options.aborted.value = true
-    const abortSessionKey = options.activeStreamSessionKey.value || options.sessionKey.value
+    const handoff = handoffCanStop ? activeResponseHandoff : null
+    if (handoff) handoff.stoppedByUser = true
+    const abortSessionKey = handoff?.targetSessionKey
+      || options.activeStreamSessionKey.value
+      || options.sessionKey.value
+    if (activeFreshSendToken !== null) activeFreshSendToken.stoppedByUser = true
     activeFreshSendToken = null
     options.activeStreamTaskId.value = STOPPED_STREAM_TASK_ID
     // Be honest if the abort can't reach the gateway (e.g. the socket dropped):
@@ -528,11 +863,7 @@ export function useChatSend(options: UseChatSendOptions) {
     // know the server-side run may keep going rather than trust a false "stopped".
     const abortParams: Record<string, string> = { sessionKey: abortSessionKey, source: 'webui_stop' }
     options.rpc.call('chat.abort', abortParams).catch(() => {
-      options.messages.value.push({
-        role: 'system',
-        text: 'Stop could not reach the server — the run may still be finishing.',
-        ts: new Date().toISOString(),
-      })
+      reportAbortFailure([abortSessionKey])
     })
     options.stream.endStreaming({ reason: 'aborted' })
     options.popAllPendingIntoComposer()
@@ -551,8 +882,12 @@ export function useChatSend(options: UseChatSendOptions) {
     const requestSessionKey = options.sessionKey.value
     if (!requestSessionKey || !providerText) return
     const compactInFlight = options.isCompactInFlightForCurrentSession()
-    if (options.stream.isStreaming.value || compactInFlight) {
-      options.enqueueHiddenControl?.({ text: providerText, displayText })
+    const handoffInFlight = responseHandoffBlocksCurrentSession()
+    if (options.stream.isStreaming.value || compactInFlight || handoffInFlight) {
+      options.enqueueHiddenControl?.(
+        { text: providerText, displayText },
+        pendingQueueOwner(),
+      )
       return
     }
 
@@ -563,14 +898,21 @@ export function useChatSend(options: UseChatSendOptions) {
     })
     // Show the visible confirmation as a user bubble (NOT the marker text).
     const now = new Date().toISOString()
+    const clientMessageId = createClientMessageId()
     if (displayText) {
-      options.messages.value.push({ role: 'user', text: displayText, ts: now })
+      options.messages.value.push({
+        role: 'user',
+        text: displayText,
+        ts: now,
+        clientId: clientMessageId,
+      })
       options.autoScroll.value = true
       options.scrollToBottom()
     }
 
     const params: ChatSendParams = {
       clientRequestId: createClientRequestId(),
+      clientMessageId,
       message: providerText,
       sessionKey: requestSessionKey,
     }
@@ -578,22 +920,49 @@ export function useChatSend(options: UseChatSendOptions) {
     params._source = chatSourceMetadata(options)
 
     const wasStreaming = options.stream.isStreaming.value
-    const freshSendToken = wasStreaming ? null : beginFreshStream(requestSessionKey)
+    const freshSendToken = wasStreaming
+      ? null
+      : beginFreshStream(requestSessionKey)
+    let responseHandoff: ResponseHandoffGate | null = null
 
     try {
       const res = await options.rpc.call<ChatSendResponse>('chat.send', params)
-      if (!wasStreaming && !freshSendStillOwnsStream(freshSendToken, requestSessionKey)) {
-        abortStaleAcceptedTask(res, requestSessionKey)
+      const taskId = acceptedTaskId(res)
+      const terminalStatus = terminalResponseStatus(res)
+      const stoppedByUser = freshSendToken?.stoppedByUser === true
+      const lostFreshStream = !wasStreaming
+        && !freshSendStillOwnsStream(freshSendToken, requestSessionKey)
+      if (stoppedByUser || lostFreshStream) {
+        const acceptedSessionKey = res?.sessionKey || requestSessionKey
+        if (
+          options.sessionKey.value === requestSessionKey
+          && acceptedSessionKey === requestSessionKey
+        ) {
+          bindAcceptedUserMessage(clientMessageId, res)
+        }
+        abortStaleAcceptedTask(res, requestSessionKey, stoppedByUser)
+        if (
+          stoppedByUser
+          && options.sessionKey.value === requestSessionKey
+          && acceptedSessionKey !== requestSessionKey
+        ) {
+          responseHandoff = beginResponseHandoff(requestSessionKey, params.clientRequestId!)
+          responseHandoff.stoppedByUser = true
+          responseHandoff.acceptedTaskId = taskId
+          responseHandoff.terminalResponse = Boolean(terminalStatus)
+          await handoffResponseSession(acceptedSessionKey, responseHandoff)
+        }
         return
+      }
+      if ((res?.sessionKey || requestSessionKey) === requestSessionKey) {
+        bindAcceptedUserMessage(clientMessageId, res)
       }
       // Bind the live stream to this turn's task so a prior task's late events
       // can't bleed into it (issue #344). Only a fresh turn takes over rendering
       // — a steer/queue send rides the in-flight stream and must not rebind —
       // and only while this session is still the one on screen.
-      const taskId = acceptedTaskId(res)
-      if (handleTerminalResponse(res, freshSendToken, { finishFreshStream: !wasStreaming })) {
-        // See dispatchSend: a terminal response has no future lifecycle event.
-      } else if (!wasStreaming && options.sessionKey.value === requestSessionKey) {
+      const responseIsCurrent = options.sessionKey.value === requestSessionKey
+      if (!terminalStatus && !wasStreaming && responseIsCurrent) {
         options.activeStreamSessionKey.value = res?.sessionKey || requestSessionKey
         if (taskId) bindAcceptedTask(taskId)
       }
@@ -602,13 +971,19 @@ export function useChatSend(options: UseChatSendOptions) {
         currentSessionKey: options.sessionKey.value,
         responseSessionKey: res?.sessionKey,
       })
+      const terminalSessionKey = decision.action === 'persist'
+        ? decision.responseSessionKey
+        : requestSessionKey
       if (decision.action === 'persist') {
         recordSessionNavigationDiag('hiddenSend.response.persist', {
           requestSession: requestSessionKey,
           responseSession: decision.responseSessionKey,
           current: options.sessionKey.value,
         })
-        options.persistSession(decision.responseSessionKey, { source: 'hiddenSend.response' })
+        responseHandoff = beginResponseHandoff(requestSessionKey, params.clientRequestId!)
+        responseHandoff.acceptedTaskId = taskId
+        responseHandoff.terminalResponse = Boolean(terminalStatus)
+        await handoffResponseSession(decision.responseSessionKey, responseHandoff)
       } else if (decision.reason === 'current_session_changed') {
         recordSessionNavigationDiag('hiddenSend.response.stale', {
           requestSession: requestSessionKey,
@@ -617,7 +992,60 @@ export function useChatSend(options: UseChatSendOptions) {
           reason: decision.reason,
         })
       }
+      if (
+        terminalStatus
+        && responseIsCurrent
+        && options.sessionKey.value === terminalSessionKey
+      ) {
+        handleTerminalResponse(res, freshSendToken, { finishFreshStream: !wasStreaming })
+        // See dispatchSend: a terminal response has no future lifecycle event.
+      }
     } catch (err: unknown) {
+      const acceptedError = acceptedErrorInfo(err)
+      const acceptedSessionKey = acceptedError?.sessionKey || requestSessionKey
+      const stoppedByUser = freshSendToken?.stoppedByUser === true
+      if (
+        acceptedError
+        && stoppedByUser
+        && !acceptedError.terminalWithoutTask
+        && acceptedSessionKey !== requestSessionKey
+      ) {
+        abortStaleAcceptedTask(
+          { sessionKey: acceptedSessionKey },
+          requestSessionKey,
+          true,
+        )
+      }
+      if (
+        acceptedError
+        && options.sessionKey.value === requestSessionKey
+        && acceptedSessionKey !== requestSessionKey
+      ) {
+        if (!wasStreaming && activeFreshSendToken === freshSendToken) {
+          activeFreshSendToken = null
+          options.activeStreamTaskId.value = ''
+          options.activeStreamSessionKey.value = ''
+          options.stream.endStreaming()
+        }
+        responseHandoff = beginResponseHandoff(requestSessionKey, params.clientRequestId!)
+        responseHandoff.stoppedByUser = stoppedByUser
+        responseHandoff.terminalResponse = acceptedError.terminalWithoutTask
+        await handoffResponseSession(acceptedSessionKey, responseHandoff)
+        options.scheduleHistorySync()
+        if (acceptedError.terminalWithoutTask && !stoppedByUser) {
+          options.schedulePendingDrainAfterTerminal()
+        }
+        options.messages.value.push({
+          role: 'error',
+          text: 'Send failed: ' + errorMessage(err),
+          ts: new Date().toISOString(),
+        })
+        return
+      }
+      if (acceptedError && options.sessionKey.value === requestSessionKey) {
+        bindUserMessageId(clientMessageId, acceptedError.messageId)
+        options.scheduleHistorySync()
+      }
       if (options.sessionKey.value !== requestSessionKey) {
         recordSessionNavigationDiag('hiddenSend.error.stale', {
           requestSession: requestSessionKey,
@@ -630,13 +1058,17 @@ export function useChatSend(options: UseChatSendOptions) {
         return
       }
       if (!wasStreaming) {
-        if (activeFreshSendToken === freshSendToken) activeFreshSendToken = null
+        if (activeFreshSendToken === freshSendToken) {
+          activeFreshSendToken = null
+        }
         options.activeStreamTaskId.value = ''
         options.activeStreamSessionKey.value = ''
         options.stream.endStreaming()
       }
       const message = errorMessage(err)
       options.messages.value.push({ role: 'error', text: 'Send failed: ' + message, ts: new Date().toISOString() })
+    } finally {
+      finishResponseHandoff(responseHandoff)
     }
   }
 

--- a/opensquilla-webui/src/composables/chat/useChatSessionHandoff.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionHandoff.test.ts
@@ -1,0 +1,326 @@
+import { nextTick, ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  useChatPendingQueue,
+  type PendingQueueOwnerContext,
+} from '@/composables/chat/useChatPendingQueue'
+import type { Attachment, ChatMessage } from '@/types/chat'
+import type { FoldLiveTurnMode } from './useChatTurnLog'
+import { useChatSend, type UseChatSendOptions } from './useChatSend'
+import { useChatSessionRuntime } from './useChatSessionRuntime'
+
+vi.mock('@/composables/useToasts', () => ({
+  useToasts: () => ({ pushToast: vi.fn() }),
+}))
+
+describe('chat send session handoff', () => {
+  it('resumes one deferred queue drain after response hydration releases', async () => {
+    vi.useFakeTimers()
+    try {
+      const sessionKey = ref('agent:main:webchat:child')
+      const ownerContext = ref<PendingQueueOwnerContext | null>({
+        sessionKey: sessionKey.value,
+        ownerRequestId: 'request-child',
+      })
+      const inputText = ref('')
+      const pendingAttachments = ref<Attachment[]>([])
+      const pendingSessionIntent = ref<string | null>(null)
+      const isStreaming = ref(false)
+      const sendCurrentInput = vi.fn()
+      const pendingQueue = useChatPendingQueue({
+        sessionKey,
+        ownerContext,
+        inputText,
+        pendingAttachments,
+        pendingSessionIntent,
+        isStreaming,
+        isBlocked: () => ownerContext.value?.sessionKey === sessionKey.value,
+        autoResizeTextarea: vi.fn(),
+        sendCurrentInput,
+        resetInputHistory: vi.fn(),
+        hasComposer: () => true,
+      })
+
+      // The child terminal replay can precede both history hydration and the
+      // user's follow-up. Preserve it without draining through the handoff gate.
+      pendingQueue.schedulePendingDrainAfterTerminal()
+      inputText.value = 'follow-up after edit'
+      pendingQueue.enqueuePendingInput(inputText.value)
+      await vi.advanceTimersByTimeAsync(50)
+
+      expect(pendingQueue.pendingQueue.value).toHaveLength(1)
+      expect(sendCurrentInput).not.toHaveBeenCalled()
+
+      ownerContext.value = null
+      pendingQueue.flushDeferredPendingDrain()
+      await vi.advanceTimersByTimeAsync(50)
+      await nextTick()
+
+      expect(pendingQueue.pendingQueue.value).toHaveLength(0)
+      expect(inputText.value).toBe('follow-up after edit')
+      expect(sendCurrentInput).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('adopts a fork child response through the full session lifecycle', async () => {
+    const parentSessionKey = 'agent:main:webchat:parent'
+    const childSessionKey = 'agent:main:webchat:child'
+    const sessionKey = ref(parentSessionKey)
+    const messages = ref<ChatMessage[]>([
+      { role: 'assistant', text: 'stopped partial answer', ts: '2026-07-22T00:00:00Z' },
+    ])
+    const pendingSessionIntent = ref<string | null>(null)
+    const currentEpoch = ref(7)
+    const lastStreamSeq = ref(19)
+    const activeTaskGroups = ref(new Set(['parent-task-group']))
+    const aborted = ref(true)
+    const isStreaming = ref(false)
+    const activeStreamTaskId = ref('')
+    const activeStreamSessionKey = ref('')
+    const inputText = ref('edited question')
+    const pendingAttachments = ref<Attachment[]>([])
+    const pendingQueueOwnerContext = ref<PendingQueueOwnerContext | null>(null)
+    const trace: string[] = []
+    let resolveSend!: (value: unknown) => void
+    let sendCurrentInput: () => void = () => {}
+    let dispatchHiddenControl: (providerText: string, displayText: string) => void = () => {}
+
+    const persistSession = vi.fn((key: string) => {
+      trace.push(`persist:${key}`)
+      sessionKey.value = key
+      // The real event-handler watcher clears the prior task binding on the
+      // next Vue flush when the session key changes.
+      void Promise.resolve().then(() => {
+        activeStreamTaskId.value = ''
+      })
+    })
+    const unsubscribeSession = vi.fn(() => {
+      trace.push(`unsubscribe:${sessionKey.value}`)
+    })
+    const subscribeSession = vi.fn(async () => {
+      trace.push(`subscribe:${sessionKey.value}`)
+      await Promise.resolve()
+      // The child subscription snapshot is authoritative and restores the
+      // binding after the session-key watcher has cleared the parent state.
+      activeStreamTaskId.value = 'task-child'
+    })
+    const loadHistory = vi.fn(() => {
+      trace.push(`history:${sessionKey.value}:${messages.value.length}`)
+    })
+    const resetStreamLiveTurnState = vi.fn(() => {
+      trace.push(`reset:${sessionKey.value}`)
+      isStreaming.value = false
+    })
+    const pendingQueueRuntime = useChatPendingQueue({
+      sessionKey,
+      ownerContext: pendingQueueOwnerContext,
+      inputText,
+      pendingAttachments,
+      pendingSessionIntent,
+      isStreaming,
+      isBlocked: () => pendingQueueOwnerContext.value?.sessionKey === sessionKey.value,
+      autoResizeTextarea: vi.fn(),
+      sendCurrentInput: () => sendCurrentInput(),
+      resetInputHistory: vi.fn(),
+      hasComposer: () => true,
+      dispatchHiddenControl: (providerText, displayText) => {
+        dispatchHiddenControl(providerText, displayText)
+      },
+    })
+    inputText.value = 'existing parent follow-up'
+    pendingQueueRuntime.enqueuePendingInput(
+      inputText.value,
+      { ownerRequestId: 'older-parent-request' },
+    )
+    pendingQueueRuntime.enqueueHiddenControl(
+      { text: 'existing parent control', displayText: 'Existing parent control' },
+      { ownerRequestId: 'older-parent-request' },
+    )
+    inputText.value = 'edited question'
+
+    const sessionRuntime = useChatSessionRuntime({
+      sessionKey,
+      messages,
+      pendingSessionIntent,
+      routerDecisionPending: ref({ tier: 'c1' }),
+      currentEpoch,
+      lastStreamSeq,
+      activeTaskGroups,
+      aborted,
+      lastHeaderRole: ref('assistant'),
+      lastHeaderDay: ref('2026-07-22'),
+      usageAccum: ref({
+        input: 10,
+        output: 20,
+        cacheRead: 5,
+        cacheWrite: 2,
+        cost: 0.01,
+        routedTurns: 1,
+        sessionSaved: 1,
+      }),
+      usageModel: ref('test-model'),
+      createSessionKey: vi.fn(() => childSessionKey),
+      persistSession,
+      unsubscribeSession,
+      subscribeSession,
+      loadHistory,
+      loadCurrentSessionUsage: vi.fn(),
+      applySessionRunState: vi.fn(),
+      setCompactInFlight: vi.fn(),
+      hideCompactStatus: vi.fn(),
+      clearPendingQueue: pendingQueueRuntime.clearPendingQueue,
+      switchPendingQueue: pendingQueueRuntime.switchPendingQueue,
+      adoptPendingQueue: pendingQueueRuntime.adoptPendingQueue,
+      resetSavingsPopupCooldown: vi.fn(),
+      restoreWidgetState: vi.fn(),
+      resetStreamLiveTurnState,
+    })
+
+    const stream: UseChatSendOptions['stream'] = {
+      isStreaming,
+      streamBubble: ref(false),
+      streamHasVisibleOutput: ref(false),
+      startStreaming: vi.fn(() => {
+        isStreaming.value = true
+      }),
+      endStreaming: vi.fn(() => {
+        isStreaming.value = false
+      }),
+      appendDelta: vi.fn(),
+      scheduleRender: vi.fn(),
+      appendToolCall: vi.fn(),
+      appendToolDelta: vi.fn(),
+      appendToolResult: vi.fn(),
+      appendArtifact: vi.fn(),
+      reconcileFinalText: vi.fn(),
+      resetStreamIdleTimer: vi.fn(),
+      clearStreamIdleTimer: vi.fn(),
+      setStreamActivity: vi.fn(),
+      showThinkingIndicator: vi.fn(),
+      hideThinkingIndicator: vi.fn(),
+      appendFrame: vi.fn(),
+      useReducer: ref<FoldLiveTurnMode>(false),
+    }
+    const rpc = {
+      call: vi.fn(<T = unknown>() => new Promise<T>((resolve) => {
+        resolveSend = resolve as (value: unknown) => void
+      })) as UseChatSendOptions['rpc']['call'],
+    }
+    const send = useChatSend({
+      rpc,
+      inputText,
+      messages,
+      sessionKey,
+      pendingQueueOwnerContext,
+      busySendMode: pendingQueueRuntime.busySendMode,
+      elevatedMode: ref(''),
+      runMode: ref('trusted'),
+      pendingAttachments,
+      pendingSessionIntent,
+      pendingForkBeforeMessageId: ref('msg-B'),
+      aborted,
+      activeStreamTaskId,
+      activeStreamSessionKey,
+      autoScroll: ref(false),
+      stream,
+      normalizeElevatedMode: mode => mode,
+      adoptResponseSession: sessionRuntime.adoptResponseSession,
+      scheduleHistorySync: vi.fn(),
+      schedulePendingDrainAfterTerminal: pendingQueueRuntime.schedulePendingDrainAfterTerminal,
+      flushDeferredPendingDrain: pendingQueueRuntime.flushDeferredPendingDrain,
+      isCompactInFlightForCurrentSession: () => false,
+      hasPendingAttachmentWork: () => false,
+      enqueuePendingInput: pendingQueueRuntime.enqueuePendingInput,
+      enqueueHiddenControl: pendingQueueRuntime.enqueueHiddenControl,
+      popAllPendingIntoComposer: pendingQueueRuntime.popAllPendingIntoComposer,
+      executeSlashCommand: vi.fn(async () => false),
+      closeSlashMenu: vi.fn(),
+      autoResizeTextarea: vi.fn(),
+      scrollToBottom: vi.fn(),
+    })
+    sendCurrentInput = send.onSend
+    dispatchHiddenControl = send.dispatchHiddenSend
+
+    const firstSend = send.onSend()
+    await vi.waitFor(() => expect(rpc.call).toHaveBeenCalledWith(
+      'chat.send',
+      expect.objectContaining({ sessionKey: parentSessionKey }),
+    ))
+
+    inputText.value = 'queued follow-up'
+    pendingAttachments.value = [{
+      kind: 'staged',
+      local_id: 42,
+      name: 'queued.txt',
+      mime: 'text/plain',
+      file_uuid: 'file-queued',
+    }]
+    pendingQueueRuntime.enqueuePendingInput(inputText.value)
+    pendingQueueRuntime.enqueueHiddenControl({
+      text: 'hidden control',
+      displayText: 'Hidden control',
+    })
+    resolveSend({
+      sessionKey: childSessionKey,
+      task_id: 'task-child',
+    })
+    await firstSend
+
+    expect(rpc.call).toHaveBeenCalledWith('chat.send', expect.objectContaining({
+      sessionKey: parentSessionKey,
+      forkBeforeMessageId: 'msg-B',
+    }))
+    expect(trace).toEqual([
+      `unsubscribe:${parentSessionKey}`,
+      `persist:${childSessionKey}`,
+      `reset:${childSessionKey}`,
+      `subscribe:${childSessionKey}`,
+      `history:${childSessionKey}:0`,
+    ])
+    expect(sessionKey.value).toBe(childSessionKey)
+    expect(messages.value).toEqual([])
+    expect(currentEpoch.value).toBe(0)
+    expect(lastStreamSeq.value).toBe(0)
+    expect(activeTaskGroups.value.size).toBe(0)
+    expect(aborted.value).toBe(false)
+    expect(activeStreamTaskId.value).toBe('task-child')
+    expect(activeStreamSessionKey.value).toBe(childSessionKey)
+    expect(pendingQueueRuntime.pendingQueue.value).toHaveLength(2)
+    expect(pendingQueueRuntime.pendingQueue.value).toMatchObject([
+      {
+        text: 'queued follow-up',
+        attachments: [expect.objectContaining({ local_id: 42, file_uuid: 'file-queued' })],
+        intent: null,
+        ownerSessionKey: childSessionKey,
+      },
+      {
+        text: 'hidden control',
+        attachments: [],
+        intent: null,
+        hiddenControl: true,
+        displayTextOverride: 'Hidden control',
+        ownerSessionKey: childSessionKey,
+      },
+    ])
+
+    // The route watcher observes the child key after persistSession. It must be
+    // an idempotent no-op instead of repeating the handoff.
+    await sessionRuntime.switchToSession(childSessionKey)
+    expect(trace).toHaveLength(5)
+
+    // A visible parent item that predated this chat.send was parked instead of
+    // being misdelivered to the fork child. Stale hidden controls are dropped,
+    // because replaying them after returning to the parent would confirm an old run.
+    await sessionRuntime.switchToSession(parentSessionKey)
+    expect(pendingQueueRuntime.pendingQueue.value).toMatchObject([
+      {
+        text: 'existing parent follow-up',
+        ownerSessionKey: parentSessionKey,
+        ownerRequestId: 'older-parent-request',
+      },
+    ])
+  })
+})

--- a/opensquilla-webui/src/composables/chat/useChatSessionRuntime.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionRuntime.ts
@@ -4,6 +4,7 @@ import type {
   ChatRunStatusSource,
 } from '@/types/chat'
 import type { PersistSessionOptions } from '@/composables/chat/useChatSessionRoute'
+import type { SessionSubscriptionOutcome } from '@/composables/chat/useChatSessionSubscription'
 
 export interface ChatUsageAccumulator {
   input: number
@@ -13,6 +14,11 @@ export interface ChatUsageAccumulator {
   cost: number | null
   routedTurns: number
   sessionSaved: number
+}
+
+export interface ResponseSessionAdoptionResult {
+  authoritativeIdle: boolean
+  backgroundOnly: boolean
 }
 
 export interface UseChatSessionRuntimeOptions {
@@ -31,13 +37,15 @@ export interface UseChatSessionRuntimeOptions {
   createSessionKey: (agentId?: string) => string
   persistSession: (key: string, options?: PersistSessionOptions) => void
   unsubscribeSession: () => void | Promise<void>
-  subscribeSession: () => void | Promise<void>
+  subscribeSession: () => void | Promise<void | SessionSubscriptionOutcome>
   loadHistory: () => void | Promise<void>
   loadCurrentSessionUsage: () => void | Promise<void>
   applySessionRunState: (source: ChatRunStatusSource | null | undefined) => void
   setCompactInFlight: (active: boolean, key?: string) => void
   hideCompactStatus: () => void
   clearPendingQueue: () => void
+  switchPendingQueue: (targetSessionKey: string) => void
+  adoptPendingQueue: (targetSessionKey: string, ownerRequestId: string) => void
   resetSavingsPopupCooldown: () => void
   restoreWidgetState: () => void
   resetStreamLiveTurnState: () => void
@@ -80,32 +88,57 @@ export function useChatSessionRuntime(options: UseChatSessionRuntimeOptions) {
     options.resetSavingsPopupCooldown()
   }
 
-  function resetCompactAndQueueState() {
+  function resetCompactState() {
     options.setCompactInFlight(false)
     options.hideCompactStatus()
-    options.clearPendingQueue()
   }
 
   function resetCurrentSessionAfterSlash() {
     resetSessionRuntimeState()
-    resetCompactAndQueueState()
+    resetCompactState()
+    options.clearPendingQueue()
     resetSessionViewState()
   }
 
-  function switchToSession(key: string) {
+  async function switchSession(
+    key: string,
+    pendingQueuePolicy:
+      | { kind: 'navigate' }
+      | { kind: 'response_handoff'; ownerRequestId: string },
+  ): Promise<ResponseSessionAdoptionResult | undefined> {
     if (!key || key === options.sessionKey.value) return
 
     options.unsubscribeSession()
+    resetCompactState()
+    if (pendingQueuePolicy.kind === 'response_handoff') {
+      options.adoptPendingQueue(key, pendingQueuePolicy.ownerRequestId)
+    } else {
+      options.switchPendingQueue(key)
+    }
     options.persistSession(key, { source: 'runtime.switchToSession' })
     resetSessionRuntimeState()
     options.pendingSessionIntent.value = null
-    resetCompactAndQueueState()
     options.applySessionRunState({ run_status: 'idle' })
     resetSessionViewState()
     options.restoreWidgetState()
     options.loadCurrentSessionUsage()
-    options.subscribeSession()
-    options.loadHistory()
+    const subscription = options.subscribeSession()
+    const history = options.loadHistory()
+    const [subscriptionOutcome] = await Promise.all([subscription, history])
+    return {
+      authoritativeIdle: subscriptionOutcome?.authoritative === true
+        && subscriptionOutcome.live === false,
+      backgroundOnly: subscriptionOutcome?.authoritative === true
+        && subscriptionOutcome.backgroundOnly === true,
+    }
+  }
+
+  function switchToSession(key: string) {
+    return switchSession(key, { kind: 'navigate' })
+  }
+
+  function adoptResponseSession(key: string, ownerRequestId: string) {
+    return switchSession(key, { kind: 'response_handoff', ownerRequestId })
   }
 
   // Drafts keep their provisional key out of the URL and local storage; it
@@ -113,9 +146,10 @@ export function useChatSessionRuntime(options: UseChatSessionRuntimeOptions) {
   function startDraftSession(agentId?: string) {
     options.unsubscribeSession()
     const key = options.createSessionKey(agentId)
+    resetCompactState()
+    options.switchPendingQueue(key)
     options.sessionKey.value = key
     resetSessionRuntimeState()
-    resetCompactAndQueueState()
     options.pendingSessionIntent.value = 'new_chat'
     resetSessionViewState()
     options.subscribeSession()
@@ -125,5 +159,6 @@ export function useChatSessionRuntime(options: UseChatSessionRuntimeOptions) {
     resetCurrentSessionAfterSlash,
     startDraftSession,
     switchToSession,
+    adoptResponseSession,
   }
 }

--- a/opensquilla-webui/src/composables/chat/useChatSessionSubscription.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionSubscription.test.ts
@@ -50,9 +50,10 @@ describe('useChatSessionSubscription', () => {
   it('still clears a stale replay bubble when no interrupt is active', async () => {
     const { api, resetStreamLiveTurnState } = createSubscription(false)
 
-    await api.subscribeSession()
+    const outcome = await api.subscribeSession()
 
     expect(resetStreamLiveTurnState).toHaveBeenCalledOnce()
+    expect(outcome).toEqual({ authoritative: true, live: false, backgroundOnly: false })
   })
 })
 
@@ -64,10 +65,11 @@ describe('useChatSessionSubscription', () => {
       waitForConnection: vi.fn(async () => {}),
       call: <T = unknown>() => snapshot as Promise<T>,
     }
+    const lastStreamSeq = ref(0)
     const subscription = useChatSessionSubscription({
       rpc,
       sessionKey: ref('agent:main:webchat:test'),
-      lastStreamSeq: ref(0),
+      lastStreamSeq,
       runStatus: ref<ChatRunStatus>({ status: 'idle', label: '', task: null }),
       isStreaming: ref(false),
       hasActiveInterrupt: ref(false),
@@ -137,11 +139,96 @@ describe('useChatSessionSubscription', () => {
       resetStreamLiveTurnState: vi.fn(),
     })
 
-    await subscription.subscribeSession()
+    const outcome = await subscription.subscribeSession()
 
     expect(runStatus.value.status).toBe('running')
     expect(startStreaming).toHaveBeenCalledOnce()
     expect(activeStreamTaskId.value).toBe('task-live')
+    expect(outcome).toEqual({ authoritative: true, live: true, backgroundOnly: false })
+  })
+
+  it('reports a failed subscription as non-authoritative', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const rpc = {
+      waitForConnection: vi.fn(async () => {}),
+      call: vi.fn().mockRejectedValue(new Error('socket closed')),
+    }
+    const subscription = useChatSessionSubscription({
+      rpc,
+      sessionKey: ref('agent:main:webchat:test'),
+      lastStreamSeq: ref(0),
+      runStatus: ref<ChatRunStatus>({ status: 'idle', label: '', task: null }),
+      isStreaming: ref(false),
+      hasActiveInterrupt: ref(false),
+      activeStreamTaskId: ref(''),
+      activeTaskGroups: ref(new Set<string>()),
+      sessionRunStatus: () => ({ status: 'idle', label: '', task: null }),
+      startStreaming: vi.fn(),
+      loadHistory: vi.fn(),
+      resetStreamIdleTimer: vi.fn(),
+      resetStreamLiveTurnState: vi.fn(),
+    })
+
+    const outcome = await subscription.subscribeSession()
+
+    expect(outcome).toEqual({ authoritative: false, live: false, backgroundOnly: false })
+    warn.mockRestore()
+  })
+
+  it('does not let an older same-session snapshot claim authoritative idle', async () => {
+    const pendingSnapshots: Array<(value: unknown) => void> = []
+    const rpc = {
+      waitForConnection: vi.fn(async () => {}),
+      call: <T = unknown>() => new Promise<T>((resolve) => {
+        pendingSnapshots.push(resolve as (value: unknown) => void)
+      }),
+    }
+    const runStatus = ref<ChatRunStatus>({ status: 'idle', label: '', task: null })
+    const lastStreamSeq = ref(0)
+    const subscription = useChatSessionSubscription({
+      rpc,
+      sessionKey: ref('agent:main:webchat:test'),
+      lastStreamSeq,
+      runStatus,
+      isStreaming: ref(false),
+      hasActiveInterrupt: ref(false),
+      activeStreamTaskId: ref(''),
+      activeTaskGroups: ref(new Set<string>()),
+      sessionRunStatus: source => ({
+        status: String(source?.run_status || 'idle') as ChatRunStatusState,
+        label: '',
+        task: source?.active_task || null,
+      }),
+      startStreaming: vi.fn(),
+      loadHistory: vi.fn(),
+      resetStreamIdleTimer: vi.fn(),
+      resetStreamLiveTurnState: vi.fn(),
+    })
+
+    const older = subscription.subscribeSession()
+    await vi.waitFor(() => expect(pendingSnapshots).toHaveLength(1))
+    lastStreamSeq.value = 1
+    const newer = subscription.subscribeSession()
+    await vi.waitFor(() => expect(pendingSnapshots).toHaveLength(2))
+
+    pendingSnapshots[1]?.({
+      subscribed: true,
+      run_status: 'running',
+      active_task: { task_id: 'task-newer', status: 'running' },
+    })
+    await expect(newer).resolves.toEqual({
+      authoritative: true,
+      live: true,
+      backgroundOnly: false,
+    })
+    pendingSnapshots[0]?.({ subscribed: true, run_status: 'idle' })
+
+    await expect(older).resolves.toEqual({
+      authoritative: false,
+      live: false,
+      backgroundOnly: false,
+    })
+    expect(runStatus.value.status).toBe('running')
   })
 
   it('reconciles stale replayed task groups with an empty authoritative snapshot', async () => {
@@ -218,9 +305,44 @@ describe('useChatSessionSubscription', () => {
       resetStreamLiveTurnState: vi.fn(),
     })
 
-    await subscription.subscribeSession()
+    const outcome = await subscription.subscribeSession()
 
     expect([...activeTaskGroups.value]).toEqual(['group-live'])
     expect(runStatus.value.status).toBe('running')
+    expect(outcome).toEqual({ authoritative: true, live: true, backgroundOnly: true })
+  })
+
+  it('releases pending work when a reconnect later proves the session idle', async () => {
+    const onAuthoritativeIdle = vi.fn()
+    const rpc = {
+      waitForConnection: vi.fn(async () => {}),
+      call: vi.fn()
+        .mockRejectedValueOnce(new Error('socket closed'))
+        .mockResolvedValueOnce({ subscribed: true, run_status: 'idle' }),
+    }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const subscription = useChatSessionSubscription({
+      rpc,
+      sessionKey: ref('agent:main:webchat:test'),
+      lastStreamSeq: ref(0),
+      runStatus: ref<ChatRunStatus>({ status: 'idle', label: '', task: null }),
+      isStreaming: ref(false),
+      hasActiveInterrupt: ref(false),
+      activeStreamTaskId: ref(''),
+      activeTaskGroups: ref(new Set<string>()),
+      sessionRunStatus: () => ({ status: 'idle', label: '', task: null }),
+      startStreaming: vi.fn(),
+      loadHistory: vi.fn(),
+      resetStreamIdleTimer: vi.fn(),
+      resetStreamLiveTurnState: vi.fn(),
+      onAuthoritativeIdle,
+    })
+
+    await subscription.subscribeSession()
+    expect(onAuthoritativeIdle).not.toHaveBeenCalled()
+    await subscription.subscribeSession()
+
+    expect(onAuthoritativeIdle).toHaveBeenCalledOnce()
+    warn.mockRestore()
   })
 })

--- a/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
@@ -27,26 +27,66 @@ export interface UseChatSessionSubscriptionOptions {
   loadHistory: () => void | Promise<void>
   resetStreamIdleTimer: () => void
   resetStreamLiveTurnState: () => void
+  onAuthoritativeIdle?: () => void
 }
 
 const LIVE_RUN_STATES = ['queued', 'running', 'approval_pending']
 
+export interface SessionSubscriptionOutcome {
+  authoritative: boolean
+  live: boolean
+  backgroundOnly: boolean
+}
+
+const UNAVAILABLE_SUBSCRIPTION: SessionSubscriptionOutcome = {
+  authoritative: false,
+  live: false,
+  backgroundOnly: false,
+}
+
 export function useChatSessionSubscription(options: UseChatSessionSubscriptionOptions) {
   const isHydrating = ref(false)
   let subscriptionAttempt = 0
+  let activeSubscription: {
+    key: string
+    sinceStreamSeq: number
+    token: symbol
+    outcome: Promise<SessionSubscriptionOutcome>
+  } | null = null
 
-  async function subscribeSession() {
-    if (!options.sessionKey.value) return
+  function subscribeSession(): Promise<SessionSubscriptionOutcome> {
+    if (!options.sessionKey.value) return Promise.resolve(UNAVAILABLE_SUBSCRIPTION)
     const key = options.sessionKey.value
     const sinceStreamSeq = options.lastStreamSeq.value
+    if (
+      activeSubscription?.key === key
+      && activeSubscription.sinceStreamSeq === sinceStreamSeq
+    ) {
+      return activeSubscription.outcome
+    }
+    const token = Symbol('session-subscription')
+    const outcome = runSubscription(key, sinceStreamSeq, token)
+    activeSubscription = { key, sinceStreamSeq, token, outcome }
+    return outcome
+  }
+
+  async function runSubscription(
+    key: string,
+    sinceStreamSeq: number,
+    token: symbol,
+  ): Promise<SessionSubscriptionOutcome> {
     const attempt = ++subscriptionAttempt
     if (sinceStreamSeq === 0) isHydrating.value = true
     try {
       await options.rpc.waitForConnection()
-      if (key !== options.sessionKey.value) return
+      if (attempt !== subscriptionAttempt || key !== options.sessionKey.value) {
+        return UNAVAILABLE_SUBSCRIPTION
+      }
       const params: SessionMessagesSubscribeParams = { key, since_stream_seq: sinceStreamSeq }
       const res = await options.rpc.call<SessionMessagesSubscribeResponse>('sessions.messages.subscribe', params)
-      if (key !== options.sessionKey.value) return
+      if (attempt !== subscriptionAttempt || key !== options.sessionKey.value) {
+        return UNAVAILABLE_SUBSCRIPTION
+      }
       if (res && res.subscribed === false) throw new Error('No subscription manager available')
       applySessionRunState(res)
       // A pending inline interrupt is newer, stronger evidence than an idle
@@ -94,10 +134,21 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
         options.lastStreamSeq.value = Math.max(options.lastStreamSeq.value, res.current_stream_seq)
       }
       if (options.isStreaming.value) options.resetStreamIdleTimer()
+      const taskOrInterruptLive = liveTaskSnapshot || options.hasActiveInterrupt.value
+      const groupLive = options.activeTaskGroups.value.size > 0
+      const outcome = {
+        authoritative: true,
+        live: taskOrInterruptLive || groupLive,
+        backgroundOnly: groupLive && !taskOrInterruptLive,
+      }
+      if (!outcome.live) options.onAuthoritativeIdle?.()
+      return outcome
     } catch (err: unknown) {
       console.warn('Session stream subscription failed:', err instanceof Error ? err.message : err)
+      return UNAVAILABLE_SUBSCRIPTION
     } finally {
       if (attempt === subscriptionAttempt) isHydrating.value = false
+      if (activeSubscription?.token === token) activeSubscription = null
     }
   }
 

--- a/opensquilla-webui/src/types/chat.ts
+++ b/opensquilla-webui/src/types/chat.ts
@@ -33,6 +33,10 @@ export interface ChatPendingItem {
   text: string
   attachments: Attachment[]
   intent: string | null
+  /** Session that owned this item when it entered the in-memory queue. */
+  ownerSessionKey?: string
+  /** chat.send request whose canonical response may carry this item to a child. */
+  ownerRequestId?: string
   // Hidden control sends (e.g. meta-preflight confirmation) carry the provider
   // text in `text`, the visible bubble in `displayTextOverride`, and skip the
   // normal user-bubble push / composer consumption on drain.

--- a/opensquilla-webui/src/types/rpc.ts
+++ b/opensquilla-webui/src/types/rpc.ts
@@ -251,6 +251,8 @@ export interface ChatSendParams {
   sessionKey: string
   /** Stable idempotency key for one logical send attempt. */
   clientRequestId?: string
+  /** Stable client identity for reconciling the optimistic user row. */
+  clientMessageId?: string
   _source?: { elevated?: string; runMode?: 'standard' | 'trusted' | 'full' }
   intent?: string
   forkBeforeMessageId?: string
@@ -261,6 +263,10 @@ export interface ChatSendParams {
 
 export interface ChatSendResponse {
   sessionKey?: string
+  message_id?: string
+  user_message_id?: string
+  client_message_id?: string
+  clientMessageId?: string
   task_id?: string
   taskId?: string
   replayed?: boolean

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -535,7 +535,10 @@ import { useChatFeatureToggles } from '@/composables/chat/useChatFeatureToggles'
 import { useChatHistory } from '@/composables/chat/useChatHistory'
 import { useChatMarkdownExport } from '@/composables/chat/useChatMarkdownExport'
 import { useChatMessageActions } from '@/composables/chat/useChatMessageActions'
-import { useChatPendingQueue } from '@/composables/chat/useChatPendingQueue'
+import {
+  useChatPendingQueue,
+  type PendingQueueOwnerContext,
+} from '@/composables/chat/useChatPendingQueue'
 import { useChatShareExport } from '@/composables/chat/useChatShareExport'
 import type { ShareExportTheme } from '@/composables/chat/useChatShareExport'
 import { useMediaQuery } from '@/composables/chat/useMediaQuery'
@@ -581,7 +584,11 @@ import type { SandboxRunMode } from '@/types/sandbox'
 import type { InterruptViewState } from '@/types/parts'
 import { artifactDownloadUrl } from '@/utils/chat/artifacts'
 import { createHistoryNavigationScrollLock } from '@/utils/chat/historyNavigationScrollLock'
-import { isCurrentSessionPayload as payloadIsCurrentSession } from '@/utils/chat/streamEvents'
+import {
+  PENDING_STREAM_TASK_ID,
+  STOPPED_STREAM_TASK_ID,
+  isCurrentSessionPayload as payloadIsCurrentSession,
+} from '@/utils/chat/streamEvents'
 import { copyTextWithFallback, copyImageToClipboard, downloadBlob, shareCopyImageSupported } from '@/utils/browser'
 import { useCopyFeedback } from '@/composables/chat/useCopyFeedback'
 import { recordSessionNavigationDiag } from '@/utils/chat/sessionNavigationDiag'
@@ -799,12 +806,18 @@ let sendCurrentInput: () => void = () => {}
 let dispatchHiddenForMeta: (providerText: string, displayText: string) => void = () => {}
 let isCompactInFlightForCurrentSession: () => boolean = () => false
 let dispatchHiddenControl: (providerText: string, displayText: string) => void = () => {}
+const pendingQueueOwnerContext = ref<PendingQueueOwnerContext | null>(null)
 const chatPendingQueue = useChatPendingQueue({
+  sessionKey,
+  ownerContext: pendingQueueOwnerContext,
   inputText,
   pendingAttachments,
   pendingSessionIntent,
   isStreaming,
-  isBlocked: () => isCompactInFlightForCurrentSession(),
+  isBlocked: () => (
+    isCompactInFlightForCurrentSession()
+    || pendingQueueOwnerContext.value?.sessionKey === sessionKey.value
+  ),
   autoResizeTextarea,
   sendCurrentInput: () => sendCurrentInput(),
   resetInputHistory: () => resetComposerInputHistory(),
@@ -820,9 +833,12 @@ const {
   enqueueHiddenControl,
   removePendingChip,
   clearPendingQueue,
+  switchPendingQueue,
+  adoptPendingQueue,
   popPendingTail,
   popAllPendingIntoComposer,
   schedulePendingDrainAfterTerminal,
+  flushDeferredPendingDrain,
   cleanup: cleanupPendingQueue,
 } = chatPendingQueue
 
@@ -1105,6 +1121,16 @@ const chatSessionSubscription = useChatSessionSubscription({
   loadHistory,
   resetStreamIdleTimer,
   resetStreamLiveTurnState,
+  onAuthoritativeIdle: () => {
+    const taskId = activeStreamTaskId.value
+    if (
+      taskId
+      && taskId !== PENDING_STREAM_TASK_ID
+      && taskId !== STOPPED_STREAM_TASK_ID
+    ) {
+      schedulePendingDrainAfterTerminal()
+    }
+  },
 })
 const {
   isHydrating: isSessionHydrating,
@@ -1116,6 +1142,7 @@ const canStop = computed(() => !isSessionHydrating.value && (
   isStreaming.value
   || activeTaskGroups.value.size > 0
   || ['queued', 'running', 'approval_pending'].includes(runStatus.value.status)
+  || pendingQueueOwnerContext.value?.sessionKey === sessionKey.value
 ))
 
 const chatSessionRuntime = useChatSessionRuntime({
@@ -1141,6 +1168,8 @@ const chatSessionRuntime = useChatSessionRuntime({
   setCompactInFlight,
   hideCompactStatus,
   clearPendingQueue,
+  switchPendingQueue,
+  adoptPendingQueue,
   resetSavingsPopupCooldown,
   restoreWidgetState,
   resetStreamLiveTurnState,
@@ -1149,6 +1178,7 @@ const {
   resetCurrentSessionAfterSlash,
   startDraftSession,
   switchToSession,
+  adoptResponseSession,
 } = chatSessionRuntime
 
 const chatSlashCommands = useChatSlashCommands({
@@ -1204,6 +1234,7 @@ const chatSend = useChatSend({
   inputText,
   messages,
   sessionKey,
+  pendingQueueOwnerContext,
   busySendMode,
   elevatedMode,
   runMode,
@@ -1217,8 +1248,10 @@ const chatSend = useChatSend({
   stream: chatStream,
   canStop: () => canStop.value,
   normalizeElevatedMode,
-  persistSession,
+  adoptResponseSession,
   scheduleHistorySync,
+  schedulePendingDrainAfterTerminal,
+  flushDeferredPendingDrain,
   bindActiveStreamTask: taskId => bindActiveStreamTask(taskId),
   isCompactInFlightForCurrentSession,
   hasPendingAttachmentWork,

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -39,11 +39,21 @@ def test_chat_view_wires_middle_edit_branch_fork_id() -> None:
     assert "pendingForkBeforeMessageId: Ref<string | null>" in send
     assert "params.forkBeforeMessageId = forkBeforeMessageId" in send
     assert "options.pendingForkBeforeMessageId.value = null" in send
-    assert (
-        "options.pendingForkBeforeMessageId.value = "
-        "options.messages.value[userMsgIndex]?.messageId || null"
-    ) in actions
-    assert (
-        "options.pendingForkBeforeMessageId.value = "
-        "options.messages.value[msgIndex]?.messageId || null"
-    ) in actions
+    regenerate_start = actions.index("function regenerateMessage(")
+    regenerate_end = actions.index("function editMessage(", regenerate_start)
+    regenerate_body = actions[regenerate_start:regenerate_end]
+    assert "const forkBeforeMessageId = userMessage?.messageId || ''" in regenerate_body
+    assert "if (!forkBeforeMessageId)" in regenerate_body
+    assert "options.pendingForkBeforeMessageId.value = forkBeforeMessageId" in regenerate_body
+    assert regenerate_body.index("if (!forkBeforeMessageId)") < regenerate_body.index(
+        "options.messages.value = options.messages.value.slice(0, userMsgIndex)"
+    )
+
+    edit_start = actions.index("function editMessage(")
+    edit_body = actions[edit_start:]
+    assert "const forkBeforeMessageId = sourceMessage?.messageId || ''" in edit_body
+    assert "if (!forkBeforeMessageId)" in edit_body
+    assert "options.pendingForkBeforeMessageId.value = forkBeforeMessageId" in edit_body
+    assert edit_body.index("if (!forkBeforeMessageId)") < edit_body.index(
+        "options.messages.value = options.messages.value.slice(0, msgIndex)"
+    )

--- a/tests/test_gateway/test_turn_ingress_fork.py
+++ b/tests/test_gateway/test_turn_ingress_fork.py
@@ -131,18 +131,24 @@ def _table_counts(db_path: Path) -> dict[str, int]:
         connection.close()
 
 
-def _fork_params(fork_before_message_id: str) -> dict[str, str]:
+def _fork_params(
+    fork_before_message_id: str,
+    *,
+    fork_param_name: str = "forkBeforeMessageId",
+) -> dict[str, str]:
     return {
         "sessionKey": PARENT_KEY,
         "message": "B edited",
-        "forkBeforeMessageId": fork_before_message_id,
+        fork_param_name: fork_before_message_id,
         "clientRequestId": CLIENT_REQUEST_ID,
     }
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("fork_param_name", ["forkBeforeMessageId", "fork_before_message_id"])
 async def test_chat_send_fork_atomically_accepts_child_prefix_message_task_and_receipt(
     tmp_path: Path,
+    fork_param_name: str,
 ) -> None:
     async with _open_fork_stack(tmp_path / "sessions.db") as stack:
         fork_before_message_id = await _seed_parent(stack)
@@ -150,7 +156,7 @@ async def test_chat_send_fork_atomically_accepts_child_prefix_message_task_and_r
         response = await get_dispatcher().dispatch(
             "rpc-fork-success",
             "chat.send",
-            _fork_params(fork_before_message_id),
+            _fork_params(fork_before_message_id, fork_param_name=fork_param_name),
             stack.context,
         )
         await stack.wait_until_running()
@@ -190,6 +196,7 @@ async def test_chat_send_fork_atomically_accepts_child_prefix_message_task_and_r
             "revision": 1,
         }
         assert child_entries[-1].message_id == response.payload["message_id"]
+        assert response.payload["user_message_id"] == response.payload["message_id"]
         assert response.payload["turn_id"] == response.payload["task_id"]
         assert isinstance(response.payload["client_message_id"], str)
         assert response.payload["client_message_id"]


### PR DESCRIPTION
## Scope

- Hand off stop/edit/regenerate fork sends to the canonical child session.
- Keep pending input owned by the fork request across hydration, terminal replay, reconnect, and background task groups.
- Make Stop cancellation request-scoped and keep late child abort failures visible without polluting unrelated transcripts.
- Bind durable user-message identities required by edit and regenerate actions.
- Cover snake_case/camelCase fork RPC responses and legacy no-task-id paths.

## Base

`main`

## Linked issue

None (user support report)

## Release note

Fixes Web UI stop → edit/regenerate → resend flows that could leave follow-up input permanently queued or attached to the parent session.

## Tests

- Focused Web UI unit suite — 76 tests passed.
- `npm run typecheck` — passed, including architecture, security, theme, i18n, and Vue type checks.
- `npm run build:artifact` — passed; the 157-file Web UI artifact was verified.
- `npm run verify:release-dist` — passed.
- Targeted Python gateway/desktop suite — 104 tests passed.
- `uv run ruff check src tests` — passed.
- Fork Playwright E2E — 3 passed, 1 live-only test skipped.
- Remaining test matrix delegated to GitHub CI as requested.

## Safety and compatibility

- Platform-neutral Web UI and session-lifecycle change.
- No persisted schema or configuration changes.
- RPC additions are optional aliases/fields; existing clients and responses remain compatible.
- `src/opensquilla/gateway/static/dist/` is intentionally excluded; the mainline build contract generates it.
- No secrets, user transcripts, or runtime state are included.

## Third-party origin

None.
