### PR TITLE
Prevent years from appearing as tool result counts

### DIFF
--- a/opensquilla-webui/src/components/run/RunTrace.copy.test.ts
+++ b/opensquilla-webui/src/components/run/RunTrace.copy.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref } from 'vue'
 import i18n from '@/i18n'
 import type { ChatStreamTimelineItem } from '@/types/chat'
+import type { NodeStep } from '@/types/runTrace'
 import { copyTextWithFallback } from '@/utils/browser'
 import RunTrace from './RunTrace.vue'
 
@@ -37,6 +38,25 @@ async function mountRunTrace(
   return { app, el, items }
 }
 
+async function mountFlatRunTrace(steps: NodeStep[]) {
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  const Host = defineComponent({
+    setup() {
+      return () => h(RunTrace, {
+        steps,
+        isToolGroupOpen: () => false,
+        isToolItemOpen: () => false,
+      })
+    },
+  })
+  const app = createApp(Host)
+  app.use(i18n)
+  app.mount(el)
+  await nextTick()
+  return { app, el }
+}
+
 beforeEach(() => {
   i18n.global.locale.value = 'en'
   document.body.innerHTML = ''
@@ -44,6 +64,35 @@ beforeEach(() => {
 })
 
 describe('RunTrace code block copy control', () => {
+  it('uses original tool identity for result counts in flat history traces', async () => {
+    const { app, el } = await mountFlatRunTrace([
+      {
+        id: 'fetch-year',
+        title: 'Read web page',
+        toolName: 'web_fetch',
+        operationKey: 'web.read',
+        state: 'output-available',
+        output: JSON.stringify({ text: 'AI industry 2026 results and outlook' }),
+      },
+      {
+        id: 'search-count',
+        title: 'Search web',
+        toolName: 'web_search',
+        operationKey: 'web.search',
+        state: 'output-available',
+        output: JSON.stringify({ results: [{ title: 'One' }, { title: 'Two' }] }),
+      },
+    ])
+
+    const rows = el.querySelectorAll<HTMLElement>('.tool-row')
+    expect(rows).toHaveLength(2)
+    expect(rows[0]?.querySelector('.tool-row__status')).toBeNull()
+    expect(rows[0]?.textContent).not.toContain('2026 results')
+    expect(rows[1]?.querySelector('.tool-row__status')?.textContent).toBe('2 results')
+
+    app.unmount()
+  })
+
   it('decorates code blocks that appear during same-key text updates', async () => {
     const { app, el, items } = await mountRunTrace([
       { type: 'text', key: 'streaming-text', html: '<p>partial result</p>' },

--- a/opensquilla-webui/src/components/run/RunTrace.vue
+++ b/opensquilla-webui/src/components/run/RunTrace.vue
@@ -630,7 +630,7 @@ function stepToRenderItem(step: NodeStep): ChatToolCallRenderItem {
   return {
     toolId: step.id,
     renderKey: step.id,
-    name: step.operationKey,
+    name: step.toolName || step.operationKey,
     displayName: step.title,
     inputRaw: step.input,
     inputPreview: step.inputPreview ?? '',
@@ -744,7 +744,7 @@ function groupBulletClass(group: ChatToolCallGroup) {
 
 function resultCountText(call: ChatToolCallRenderItem): string {
   if (call.isRunning || call.isError) return ''
-  const count = toolResultCount(call.result)
+  const count = toolResultCount(call.result, call.name)
   return count === null ? '' : t('shared.runTrace.resultsCount', { count })
 }
 

--- a/opensquilla-webui/src/components/run/runTrace.test.ts
+++ b/opensquilla-webui/src/components/run/runTrace.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ChatStreamTimelineItem } from '@/types/chat'
+import type { ChatHistoryMessage } from '@/types/rpc'
+import { nodeStepsFromHistoryMessage, nodeStepsFromTimeline } from './runTrace'
+
+describe('run trace tool identity', () => {
+  it('preserves the original tool name when flattening chat timeline items', () => {
+    const items: ChatStreamTimelineItem[] = [{
+      type: 'tool-group',
+      key: 'web-fetch-group',
+      group: {
+        groupId: 'web-fetch-group',
+        operationKey: 'web.read',
+        label: 'Read web page',
+        iconName: 'monitor',
+        calls: [{
+          toolId: 'fetch-1',
+          renderKey: 'fetch-1',
+          name: 'web_fetch',
+          displayName: 'web_fetch',
+          inputPreview: '',
+          isRunning: false,
+          status: 'success',
+          isError: false,
+          result: '2026 results',
+          resultPreview: '2026 results',
+          isOpen: false,
+        }],
+        secondary: '',
+        isRunning: false,
+        isError: false,
+        status: 'success',
+      },
+    }]
+
+    expect(nodeStepsFromTimeline(items)[0]).toMatchObject({
+      toolName: 'web_fetch',
+      operationKey: 'web.read',
+    })
+  })
+
+  it('preserves the original tool name when flattening persisted history', () => {
+    const message = {
+      role: 'assistant',
+      tool_calls: [{
+        tool_use_id: 'search-1',
+        name: 'MCPURLSearch',
+        result: 'Found 7 results.',
+      }],
+    } as ChatHistoryMessage
+
+    expect(nodeStepsFromHistoryMessage(message)[0]).toMatchObject({
+      toolName: 'MCPURLSearch',
+      operationKey: 'tool.mcpurlsearch',
+    })
+  })
+})

--- a/opensquilla-webui/src/components/run/runTrace.ts
+++ b/opensquilla-webui/src/components/run/runTrace.ts
@@ -57,6 +57,7 @@ function stepFromRenderItem(
     id: call.renderKey,
     parentId,
     title: call.displayName,
+    toolName: call.name,
     operationKey: operationKey || toolOperationKey(call.name),
     state: toolState(call),
     elapsedMs: null,
@@ -134,6 +135,7 @@ export function nodeStepsFromHistoryMessage(msg: ChatHistoryMessage): NodeStep[]
       id: pending.id,
       parentId: null,
       title: toolDisplayName(name, pending.input),
+      toolName: name,
       operationKey: toolOperationKey(name),
       // History is always terminal — no live running state (toParts.ts:9).
       state: toolState({ isRunning: false, status, result: output, isError }),

--- a/opensquilla-webui/src/types/runTrace.ts
+++ b/opensquilla-webui/src/types/runTrace.ts
@@ -10,6 +10,7 @@ export interface NodeStep {
   id: string
   parentId?: string | null
   title: string                 // displayName
+  toolName?: string             // original tool identity; survives flat history traces
   operationKey: string          // e.g. 'web.search' — drives icon + grouping
   state: ToolPartState          // single status enum (see runTrace.ts map)
   tokens?: number | null        // per-step token cost when known

--- a/opensquilla-webui/src/utils/chat/toolDisplay.test.ts
+++ b/opensquilla-webui/src/utils/chat/toolDisplay.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { toolResultCount } from '@/utils/chat/toolDisplay'
+
+describe('toolResultCount', () => {
+  it('counts structured result collections', () => {
+    expect(toolResultCount(JSON.stringify([{ id: 1 }, { id: 2 }]), 'web_search')).toBe(2)
+    expect(toolResultCount(
+      JSON.stringify({ results: [{ id: 1 }, { id: 2 }, { id: 3 }] }),
+      'web_search',
+    )).toBe(3)
+  })
+
+  it('preserves legacy plain-text summaries for result-producing tools', () => {
+    expect(toolResultCount('Search returned 3 results.', 'web_search')).toBe(3)
+    expect(toolResultCount('Found 4 results for "squid".\n1. One\n2. Two', 'webSearch')).toBe(4)
+    expect(toolResultCount('共找到 5 条结果。', 'mcp__catalog__search')).toBe(5)
+    expect(toolResultCount(JSON.stringify('6 results'), 'session_search')).toBe(6)
+    expect(toolResultCount('Found 7 results.', 'MCPURLSearch')).toBe(7)
+  })
+
+  it('does not treat a year in structured web content as a result count', () => {
+    const webFetchResult = JSON.stringify({
+      url: 'https://example.test/ai-news-today',
+      title: 'AI News Today',
+      text: 'The 2026 results will be published in the annual report.',
+    })
+
+    expect(toolResultCount(webFetchResult, 'web_fetch')).toBeNull()
+  })
+
+  it('does not infer counts from plain text returned by content tools', () => {
+    expect(toolResultCount('2026 results', 'web_fetch')).toBeNull()
+    expect(toolResultCount(JSON.stringify('2026 results'), 'web_fetch')).toBeNull()
+    expect(toolResultCount('The 2026 results will be published.', 'shell')).toBeNull()
+    expect(toolResultCount('Found 3 results for "squid".', 'research_article')).toBeNull()
+  })
+
+  it('does not scan search result bodies or treat a bare year as a count', () => {
+    expect(toolResultCount('[grep_search]\nreturned: 2\n---\n2026 results', 'grep_search')).toBeNull()
+    expect(toolResultCount('3 results.txt\nanother-file.txt', 'glob_search')).toBeNull()
+    expect(toolResultCount('2026 results\nanother-file.txt', 'glob_search')).toBeNull()
+    expect(toolResultCount('Found 2026 results.txt', 'web_search')).toBeNull()
+    expect(toolResultCount('2026 results', 'web_search')).toBeNull()
+    expect(toolResultCount('Found 2026 results.', 'web_search')).toBe(2026)
+  })
+
+  it('uses array structure before count-like result text', () => {
+    const results = [
+      { title: '2026 results' },
+      { title: 'Another result' },
+    ]
+
+    expect(toolResultCount(JSON.stringify({ results }), 'web_search')).toBe(2)
+  })
+})

--- a/opensquilla-webui/src/utils/chat/toolDisplay.ts
+++ b/opensquilla-webui/src/utils/chat/toolDisplay.ts
@@ -173,20 +173,77 @@ export function toolCallGroups(calls: ChatToolCall[] | undefined, ownerKey: stri
   return groups
 }
 
-export function toolResultCount(raw: string): number | null {
+const PLAIN_TEXT_RESULT_TOOL_TOKENS = new Set([
+  'discover',
+  'search',
+])
+const RAW_TEXT_SEARCH_TOOLS = new Set([
+  'glob_search',
+  'grep_search',
+])
+
+function supportsPlainTextResultCount(toolName: string): boolean {
+  const tokens = String(toolName || '')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+  if (RAW_TEXT_SEARCH_TOOLS.has(tokens.join('_'))) return false
+  return tokens.some(token => PLAIN_TEXT_RESULT_TOOL_TOKENS.has(token))
+}
+
+function isLikelyYear(value: string): boolean {
+  if (!/^\d{4}$/.test(value)) return false
+  const year = Number(value)
+  return year >= 1900 && year <= 2199
+}
+
+function plainTextResultCount(text: string): number | null {
+  const lines = text
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+  if (!lines.length) return null
+  const line = /^\[[^\]]+\]$/.test(lines[0]) && lines[1] ? lines[1] : lines[0]
+
+  const explicitPatterns = [
+    /^(?:(?:web\s+)?search\s+)?(?:found|returned|showing)\s*:?\s*(\d{1,4})\s+results?(?:\s+(?:for|matching)\b.*)?[.!]?$/i,
+    /^showing\s+\d+\s*[-–]\s*\d+\s+of\s+(\d{1,4})\s+results?[.!]?$/i,
+    /^(?:搜索\s*)?(?:共\s*)?(?:找到|返回|显示)\s*[:：]?\s*(\d{1,4})\s*(?:条|个)?\s*结果[。！.!]?$/,
+  ]
+  for (const pattern of explicitPatterns) {
+    const match = pattern.exec(line)
+    if (match) return Number(match[1])
+  }
+
+  const bareMatch = /^(?:about\s+)?(\d{1,4})\s*(?:results?|(?:条|个)?\s*结果)(?:\s+(?:found|returned|shown))?[.!。！:]?$/i.exec(line)
+  if (!bareMatch || isLikelyYear(bareMatch[1])) return null
+  return Number(bareMatch[1])
+}
+
+export function toolResultCount(raw: string, toolName: string): number | null {
   const text = String(raw || '').trim()
   if (!text) return null
-  // 结果 is the CJK word for "results", kept to parse localized tool output.
-  const match = /(?:^|\D)(\d{1,4})\s*(?:results?|结果)(?:\D|$)/i.exec(text)
-  if (match) return Number(match[1])
+  let summaryText = text
   try {
     const parsed = JSON.parse(text)
     if (Array.isArray(parsed)) return parsed.length
     for (const key of ['results', 'items', 'data', 'matches']) {
       if (Array.isArray(parsed?.[key])) return parsed[key].length
     }
+    // Structured tool payloads often contain arbitrary page or command output.
+    // Never infer a count from those nested strings: a phrase such as
+    // "2026 results" may be a year plus a heading, not a result summary.
+    if (parsed && typeof parsed === 'object') return null
+    if (typeof parsed === 'string') summaryText = parsed.trim()
+    else return null
   } catch {}
-  return null
+  // Preserve text summaries only for search operations, and only when the
+  // first summary line has an explicit count shape. Content-producing tools
+  // and arbitrary result bodies must not reinterpret years as metadata.
+  if (!supportsPlainTextResultCount(toolName)) return null
+  return plainTextResultCount(summaryText)
 }
 
 export function toolResultIsError(payload: unknown): boolean {
@@ -202,7 +259,7 @@ export function toolStatusText(toolCall: ChatToolCall): string {
   const t = i18n.global.t
   if (toolCall.isRunning) return t('chat.tool.running')
   if (toolCall.status === 'error') return t('chat.tool.failed')
-  const count = toolResultCount(toolCall.result)
+  const count = toolResultCount(toolCall.result, toolCall.name)
   if (count !== null) return t('chat.tool.results', { count })
   if (toolCall.status === 'success') return t('chat.tool.done')
   return t('chat.tool.pending')
@@ -212,7 +269,9 @@ export function toolGroupStatusText(group: ChatToolCallGroup): string {
   const t = i18n.global.t
   if (group.isRunning) return t('chat.tool.running')
   if (group.isError) return t('chat.tool.failed')
-  const counts = group.calls.map(toolCall => toolResultCount(toolCall.result)).filter((count): count is number => count !== null)
+  const counts = group.calls
+    .map(toolCall => toolResultCount(toolCall.result, toolCall.name))
+    .filter((count): count is number => count !== null)
   if (counts.length && group.calls.length === 1) return t('chat.tool.results', { count: counts[0] })
   if (counts.length) return t('chat.tool.results', { count: counts.reduce((sum, count) => sum + count, 0) })
   if (group.status === 'success') return t('chat.tool.done')


### PR DESCRIPTION
## Scope

- Parse structured tool output before considering human-readable summaries, so page content such as `2026 results` is not shown as a result count.
- Restrict plain-text count inference to search/discovery tools and explicit first-line summary shapes.
- Preserve the original tool name through flat/history run traces so count policy remains correct after reload.
- Add utility, trace conversion, and rendered component regression coverage.

**Target:** `main`  
**Linked issue:** None  
**Release note:** Not added; this is a backward-compatible UI correctness fix with no public API or configuration change.

## Validation

- `npm run test:unit` — 122 files, 1272 tests passed
- `npm run typecheck` — passed
- `npm run build` — passed, including architecture/security/design/i18n guards and production artifact verification
- Real browser verification with the current Vite frontend and Playwright:
  - Chinese `web_fetch` trace containing `2026 results` showed no numeric result badge
  - Chinese `web_search` trace with two structured results showed `2 条结果`
- Two independent review passes found no P0–P3 issues
- `git diff --check` — passed

## Safety and compatibility

- Frontend display logic only; no changes to tool execution, RPC payloads, persistence, permissions, or security boundaries.
- Existing saved sessions require no migration and re-render with the corrected display behavior.
- The change is platform-neutral across Linux, macOS, and Windows.
- Ambiguous/nonstandard plain-text summaries now fall back to the existing completed status instead of guessing a count.

## Third-party origin

None.