### PR TITLE
Add SERPdive web search provider

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -18,6 +18,7 @@ Runtime-supported providers in this build include:
 - Bocha
 - Brave Search
 - DuckDuckGo
+- SERPdive
 - Tavily
 - Exa
 
@@ -52,6 +53,13 @@ export BRAVE_SEARCH_API_KEY="..."
 opensquilla configure search --search-provider brave --api-key-env BRAVE_SEARCH_API_KEY
 ```
 
+SERPdive (returns extracted, answer-ready page content rather than snippets):
+
+```sh
+export SERPDIVE_API_KEY="..."
+opensquilla configure search --search-provider serpdive --api-key-env SERPDIVE_API_KEY
+```
+
 Tavily:
 
 ```sh
@@ -73,7 +81,7 @@ export IQS_SEARCH_API_KEY="..."
 opensquilla configure search --search-provider iqs --api-key-env IQS_SEARCH_API_KEY
 ```
 
-In configuration files, `search_provider` can be `"duckduckgo", "bocha", "brave", "iqs", "tavily", or "exa"`.
+In configuration files, `search_provider` can be `"duckduckgo", "bocha", "brave", "iqs", "serpdive", "tavily", or "exa"`.
 It identifies the provider tied to `search_api_key` and
 `search_api_key_env`; automatic searches without `--provider` still rank all
 available providers by mode, recency needs, and provider capabilities. Use
@@ -86,11 +94,11 @@ Configuration matrix:
 
 - **no-key**: choose DuckDuckGo, or leave search unconfigured and the runtime
   uses DuckDuckGo for general web search.
-- **partial-key**: configure one keyed provider, such as Bocha, IQS, Tavily, or Exa;
+- **partial-key**: configure one keyed provider, such as Bocha, IQS, SERPdive, Tavily, or Exa;
   the runtime uses that provider when it is available and can still use DuckDuckGo
   for no-key fallback paths.
 - **all-key**: expose `BOCHA_SEARCH_API_KEY`, `BRAVE_SEARCH_API_KEY`,
-  `IQS_SEARCH_API_KEY`, `TAVILY_API_KEY`, and `EXA_API_KEY`; runtime selection
+  `IQS_SEARCH_API_KEY`, `SERPDIVE_API_KEY`, `TAVILY_API_KEY`, and `EXA_API_KEY`; runtime selection
   ranks providers by mode, recency needs, and provider capabilities unless the
   request names an explicit provider.
 

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -2603,6 +2603,7 @@ async def build_services(
             import opensquilla.search.providers.duckduckgo  # noqa: F401 — registers provider
             import opensquilla.search.providers.exa  # noqa: F401 — registers provider
             import opensquilla.search.providers.iqs  # noqa: F401 — registers provider
+            import opensquilla.search.providers.serpdive  # noqa: F401 — registers provider
             import opensquilla.search.providers.tavily  # noqa: F401 — registers provider
             from opensquilla.tools.builtin.web import configure_search
 

--- a/src/opensquilla/onboarding/search_specs.py
+++ b/src/opensquilla/onboarding/search_specs.py
@@ -45,6 +45,7 @@ _SEARCH_PROVIDER_LABELS: dict[str, str] = {
     "brave": "Brave Search",
     "duckduckgo": "DuckDuckGo",
     "iqs": "Alibaba Cloud IQS",
+    "serpdive": "SERPdive",
     "tavily": "Tavily",
     "exa": "Exa",
     "perplexity": "Perplexity",

--- a/src/opensquilla/sandbox/default_allowlist.py
+++ b/src/opensquilla/sandbox/default_allowlist.py
@@ -24,6 +24,7 @@ DEFAULT_ALLOWLIST: dict[str, tuple[str, ...]] = {
         "duckduckgo.com",
         "api.bochaai.com",
         "api.exa.ai",
+        "api.serpdive.com",
         "api.tavily.com",
         "cloud-iqs.aliyuncs.com",
         "www.google.com",

--- a/src/opensquilla/sandbox/integration.py
+++ b/src/opensquilla/sandbox/integration.py
@@ -122,6 +122,7 @@ _SEARCH_PROVIDER_SYSTEM_DOMAINS: dict[str, tuple[str, ...]] = {
     "duckduckgo": ("html.duckduckgo.com",),
     "exa": ("api.exa.ai",),
     "iqs": ("cloud-iqs.aliyuncs.com",),
+    "serpdive": ("api.serpdive.com",),
     "tavily": ("api.tavily.com",),
 }
 

--- a/src/opensquilla/search/canonical.py
+++ b/src/opensquilla/search/canonical.py
@@ -217,6 +217,7 @@ def _ensure_builtin_search_providers() -> None:
     for module_name in (
         "opensquilla.search.providers.bocha",
         "opensquilla.search.providers.iqs",
+        "opensquilla.search.providers.serpdive",
         "opensquilla.search.providers.tavily",
         "opensquilla.search.providers.brave",
         "opensquilla.search.providers.exa",

--- a/src/opensquilla/search/providers/serpdive.py
+++ b/src/opensquilla/search/providers/serpdive.py
@@ -1,0 +1,146 @@
+"""SERPdive search provider — uses the SERPdive Search API."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from opensquilla.search.registry import register_provider
+from opensquilla.search.types import SearchErrorKind, SearchProviderError, SearchResult
+from opensquilla.secrets import clean_header_secret
+
+_API_URL = "https://api.serpdive.com/v1/search"
+_MAX_RESULTS_CAP = 10
+_RESULT_METADATA_EXCLUDE = {
+    "title",
+    "url",
+    "content",
+}
+
+
+class SerpdiveSearchProvider:
+    """Search provider using the SERPdive Search API."""
+
+    name: str = "serpdive"
+
+    def __init__(
+        self,
+        api_key: str = "",
+        proxy: str = "",
+        use_env_proxy: bool = False,
+        diagnostics: bool = False,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._api_key = clean_header_secret(
+            api_key or os.environ.get("SERPDIVE_API_KEY", ""),
+            label="SERPdive API key",
+        )
+        self._proxy = proxy or None
+        self._trust_env = bool(use_env_proxy) and not self._proxy
+        self._diagnostics = bool(diagnostics)
+        self._transport = transport
+
+    async def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+        if not self._api_key:
+            raise SearchProviderError(
+                provider=self.name,
+                kind="auth",
+                message="SERPdive API key not set",
+                retryable=False,
+            )
+
+        result_limit = min(max(int(max_results), 1), _MAX_RESULTS_CAP)
+        body = {
+            "query": query,
+            "max_results": result_limit,
+        }
+
+        try:
+            async with httpx.AsyncClient(
+                timeout=15.0,
+                proxy=self._proxy,
+                trust_env=self._trust_env,
+                transport=self._transport,
+            ) as client:
+                response = await client.post(
+                    _API_URL,
+                    json=body,
+                    headers={"Authorization": f"Bearer {self._api_key}"},
+                )
+                response.raise_for_status()
+        except httpx.TimeoutException as exc:
+            raise SearchProviderError(
+                provider=self.name,
+                kind="timeout",
+                message=str(exc) or "SERPdive search request timed out.",
+                retryable=True,
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            kind = _classify_status(status_code)
+            raise SearchProviderError(
+                provider=self.name,
+                kind=kind,
+                message=f"SERPdive search failed with HTTP {status_code}.",
+                retryable=_is_retryable_status(status_code, kind),
+                status_code=status_code,
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise SearchProviderError(
+                provider=self.name,
+                kind="network",
+                message=str(exc) or "SERPdive search network request failed.",
+                retryable=True,
+            ) from exc
+
+        data = response.json()
+        return [
+            _result_from_item(item, data) for item in (data.get("results") or [])[:result_limit]
+        ]
+
+
+def _classify_status(status_code: int) -> SearchErrorKind:
+    if status_code in {401, 403}:
+        return "auth"
+    if status_code == 429:
+        return "rate_limit"
+    return "http"
+
+
+def _is_retryable_status(status_code: int, kind: SearchErrorKind) -> bool:
+    if status_code == 429:
+        return True
+    if kind == "http":
+        return True
+    return False
+
+
+def _result_from_item(item: dict[str, Any], response_data: dict[str, Any]) -> SearchResult:
+    content = str(item.get("content") or "")
+    return SearchResult(
+        title=str(item.get("title", "")),
+        url=str(item.get("url", "")),
+        snippet=content,
+        source="serpdive",
+        provider="serpdive",
+        published_at=item.get("date"),
+        content=content,
+        raw_metadata=_safe_metadata(item, response_data),
+    )
+
+
+def _safe_metadata(item: dict[str, Any], response_data: dict[str, Any]) -> dict[str, Any]:
+    metadata = {
+        key: response_data[key]
+        for key in ("model", "response_time_ms")
+        if key in response_data
+    }
+    metadata.update(
+        {key: value for key, value in item.items() if key not in _RESULT_METADATA_EXCLUDE}
+    )
+    return metadata
+
+
+register_provider("serpdive", SerpdiveSearchProvider)

--- a/src/opensquilla/search/registry.py
+++ b/src/opensquilla/search/registry.py
@@ -28,6 +28,12 @@ _provider_specs: dict[str, SearchProviderSpec] = {
         env_key="IQS_SEARCH_API_KEY",
         capabilities=frozenset({"web", "freshness", "domain_filter", "content"}),
     ),
+    "serpdive": SearchProviderSpec(
+        provider_id="serpdive",
+        requires_api_key=True,
+        env_key="SERPDIVE_API_KEY",
+        capabilities=frozenset({"web", "content"}),
+    ),
     "tavily": SearchProviderSpec(
         provider_id="tavily",
         requires_api_key=True,

--- a/src/opensquilla/search/runtime_config.py
+++ b/src/opensquilla/search/runtime_config.py
@@ -11,8 +11,8 @@ from opensquilla.search.types import SearchOptions, SearchProvider, SearchProvid
 
 CredentialSource = Literal["configured", "configured_env", "spec_env", "none"]
 
-_GENERAL_TIE_BREAKER = ("bocha", "tavily", "iqs", "brave", "exa", "duckduckgo")
-_TECHNICAL_TIE_BREAKER = ("exa", "bocha", "brave", "tavily", "iqs", "duckduckgo")
+_GENERAL_TIE_BREAKER = ("bocha", "tavily", "iqs", "brave", "exa", "serpdive", "duckduckgo")
+_TECHNICAL_TIE_BREAKER = ("exa", "bocha", "brave", "tavily", "iqs", "serpdive", "duckduckgo")
 _FRESHNESS_TIE_BREAKER = ("bocha", "tavily", "iqs", "brave", "exa")
 
 
@@ -295,6 +295,7 @@ def _ensure_builtin_search_providers() -> None:
     for module_name in (
         "opensquilla.search.providers.bocha",
         "opensquilla.search.providers.iqs",
+        "opensquilla.search.providers.serpdive",
         "opensquilla.search.providers.tavily",
         "opensquilla.search.providers.brave",
         "opensquilla.search.providers.exa",

--- a/src/opensquilla/tools/builtin/web.py
+++ b/src/opensquilla/tools/builtin/web.py
@@ -85,7 +85,7 @@ _SEARCH_BENCHMARK_BLOCKLIST_DEFAULT_TERMS = (
 _VALID_SEARCH_MODES: frozenset[str] = frozenset({"auto", "news", "technical", "broad"})
 _VALID_SEARCH_RECENCIES: frozenset[str] = frozenset({"day", "week", "month", "year"})
 _VALID_SEARCH_PROVIDERS: frozenset[str] = frozenset(
-    {"auto", "bocha", "tavily", "brave", "duckduckgo", "exa", "iqs"}
+    {"auto", "bocha", "serpdive", "tavily", "brave", "duckduckgo", "exa", "iqs"}
 )
 
 def _network_http_request(args: Mapping[str, Any]) -> NetworkOperationRequest:
@@ -576,6 +576,7 @@ def _ensure_builtin_search_providers() -> None:
     import opensquilla.search.providers.duckduckgo  # noqa: F401
     import opensquilla.search.providers.exa  # noqa: F401
     import opensquilla.search.providers.iqs  # noqa: F401
+    import opensquilla.search.providers.serpdive  # noqa: F401
     import opensquilla.search.providers.tavily  # noqa: F401
 
 
@@ -1060,7 +1061,7 @@ def _search_error_payload(
         "provider": {
             "type": "string",
             "description": "Optional provider override.",
-            "enum": ["auto", "bocha", "tavily", "brave", "duckduckgo", "exa", "iqs"],
+            "enum": ["auto", "bocha", "serpdive", "tavily", "brave", "duckduckgo", "exa", "iqs"],
         },
     },
     required=["query"],

--- a/tests/test_search/test_search_runtime_config.py
+++ b/tests/test_search/test_search_runtime_config.py
@@ -12,6 +12,7 @@ def _clear_search_env(monkeypatch) -> None:
         "BOCHA_SEARCH_API_KEY",
         "BRAVE_SEARCH_API_KEY",
         "IQS_SEARCH_API_KEY",
+        "SERPDIVE_API_KEY",
         "TAVILY_API_KEY",
         "EXA_API_KEY",
         "CUSTOM_EXA_KEY",

--- a/tests/test_search/test_serpdive_provider.py
+++ b/tests/test_search/test_serpdive_provider.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from opensquilla.search.providers.serpdive import SerpdiveSearchProvider
+from opensquilla.search.types import SearchProviderError
+
+
+@pytest.mark.asyncio
+async def test_serpdive_search_posts_request_and_maps_results() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "query": "python release",
+                "model": "mako",
+                "response_time_ms": 1420,
+                "results": [
+                    {
+                        "title": "Python release",
+                        "url": "https://python.org/releases",
+                        "content": "Python 3.14 was released with these changes.",
+                        "date": "2026-06-19",
+                    }
+                ],
+            },
+        )
+
+    provider = SerpdiveSearchProvider(
+        api_key="dummy-serpdive-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    results = await provider.search("python release", max_results=3)
+
+    assert len(requests) == 1
+    assert requests[0].method == "POST"
+    assert str(requests[0].url) == "https://api.serpdive.com/v1/search"
+    assert requests[0].headers["Authorization"] == "Bearer dummy-serpdive-key"
+    body = json.loads(requests[0].content)
+    assert body == {
+        "query": "python release",
+        "max_results": 3,
+    }
+
+    result = results[0]
+    assert result.provider == "serpdive"
+    assert result.source == "serpdive"
+    assert result.title == "Python release"
+    assert result.url == "https://python.org/releases"
+    assert result.snippet == "Python 3.14 was released with these changes."
+    assert result.content == "Python 3.14 was released with these changes."
+    assert result.published_at == "2026-06-19"
+    assert result.raw_metadata["model"] == "mako"
+    assert result.raw_metadata["response_time_ms"] == 1420
+
+
+@pytest.mark.asyncio
+async def test_serpdive_search_clamps_max_results_to_api_cap() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"results": []})
+
+    provider = SerpdiveSearchProvider(
+        api_key="dummy-serpdive-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    await provider.search("python", max_results=20)
+
+    body = json.loads(requests[0].content)
+    assert body["max_results"] == 10
+
+
+@pytest.mark.asyncio
+async def test_serpdive_result_without_date_has_no_published_at() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "title": "Result",
+                        "url": "https://example.com",
+                        "content": "Some extracted sentences.",
+                    }
+                ]
+            },
+        )
+
+    provider = SerpdiveSearchProvider(
+        api_key="dummy-serpdive-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = (await provider.search("example"))[0]
+
+    assert result.snippet == "Some extracted sentences."
+    assert result.published_at is None
+
+
+@pytest.mark.asyncio
+async def test_serpdive_missing_api_key_raises_auth_error(monkeypatch) -> None:
+    monkeypatch.delenv("SERPDIVE_API_KEY", raising=False)
+    provider = SerpdiveSearchProvider()
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("python")
+
+    assert exc_info.value.provider == "serpdive"
+    assert exc_info.value.kind == "auth"
+    assert exc_info.value.retryable is False
+    assert str(exc_info.value) == "SERPdive API key not set"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_code", "kind", "retryable"),
+    [
+        (401, "auth", False),
+        (403, "auth", False),
+        (429, "rate_limit", True),
+        (500, "http", True),
+    ],
+)
+async def test_serpdive_http_errors_are_classified(
+    status_code: int,
+    kind: str,
+    retryable: bool,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, json={"error": "nope"})
+
+    provider = SerpdiveSearchProvider(
+        api_key="dummy-serpdive-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("python")
+
+    assert exc_info.value.provider == "serpdive"
+    assert exc_info.value.kind == kind
+    assert exc_info.value.retryable is retryable
+    assert exc_info.value.status_code == status_code
+
+
+@pytest.mark.asyncio
+async def test_serpdive_timeout_is_retryable_timeout() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("timed out", request=request)
+
+    provider = SerpdiveSearchProvider(
+        api_key="dummy-serpdive-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("python")
+
+    assert exc_info.value.kind == "timeout"
+    assert exc_info.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_serpdive_network_error_is_retryable_network() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("network down", request=request)
+
+    provider = SerpdiveSearchProvider(
+        api_key="dummy-serpdive-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("python")
+
+    assert exc_info.value.kind == "network"
+    assert exc_info.value.retryable is True

--- a/tests/test_tools/test_web_search_tool.py
+++ b/tests/test_tools/test_web_search_tool.py
@@ -255,7 +255,7 @@ async def test_web_search_benchmark_blocklist_blocks_query_without_calling_core(
         ({"query": 123}, "query must be a non-empty string."),
         (
             {"query": "python release", "provider": "serpapi"},
-            "Invalid provider. Expected one of: auto, bocha, brave, duckduckgo, exa, iqs, tavily.",
+            "Invalid provider. Expected one of: auto, bocha, brave, duckduckgo, exa, iqs, serpdive, tavily.",
         ),
         (
             {"query": "python release", "mode": "invalid"},


### PR DESCRIPTION
## Scope

Adds [SERPdive](https://serpdive.com) as a keyed web search provider, alongside the existing Tavily/Exa/Brave/Bocha/IQS providers. SERPdive returns extracted, answer-ready page content per result rather than snippets, which fits OpenSquilla's token-efficiency focus: on a [public 1,000-question benchmark](https://github.com/edendalexis/serpdive-benchmark) it won 60.7% of decided quality duels against Tavily's default (basic) search while returning 20.2% fewer tokens (1,001 vs 1,255 per query on average) at the same speed. Free tier available, no card.

Scope boundary: one new out-of-tree provider mirroring the Tavily provider exactly — provider module, registry spec, builtin registration lists, sandbox allowlist, onboarding display name, docs, and a provider test suite. No changes to existing providers or to the runtime's selection logic beyond adding SERPdive to the ordered lists.

Non-goals: no time-range/domain-filter capabilities (the API has no such parameters — the runtime already degrades those gracefully via query hints and post-filtering); no changes to the DuckDuckGo fallback behaviour; the advanced Tavily tier was not benchmarked.

Full disclosure: I built SERPdive. If an out-of-tree provider isn't something you want to carry, feel free to close — no hard feelings.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: net-new provider addition, no tracking issue was opened.

## Release Note

Release note: NONE

## Tests

Ruff: `uv run ruff check src tests` — clean

Pytest: `uv run pytest -q` — 15,656 passed. The only failures on my machine (macOS) are the pre-existing `test_windows_default_backend` / `test_workspace_write_deny_levers`, identical on a pristine checkout.

Build: n/a — no packaging or build changes.

Regression tests: added — `tests/test_search/test_serpdive_provider.py` mirrors the Tavily suite (request shape, `max_results` cap at the API's 10, error classification, timeout/network paths), plus the two provider-list updates in existing tests.

Notes: the default test path remains offline, deterministic, credential-free, and safe for forks — the provider test uses the same mock/transport pattern as the Tavily test and never contacts the live API.

## Maintainer Live Check

Maintainer live check: no

Surface: provider

Maintainer-only note: no credentialed live check was run. If you want provider smoke coverage, `Live Release E2E` against `api.serpdive.com` with a `SERPDIVE_API_KEY` would exercise it; a free key is available at https://serpdive.com/dashboard/keys.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are committed. The API key is read from the `SERPDIVE_API_KEY` environment variable only.

## Third-Party Origin

Third-party origin: adapted/ported

Details if non-none: the provider module and its test are adapted from this repository's own existing Tavily provider (`search/providers/tavily.py` and its test), kept in-tree, same license. No external code, rules, fixtures, or text were copied from outside the repo. SERPdive itself is reached as a network dependency over its public HTTP API (`api.serpdive.com`), not vendored.

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.

Docs updated: `docs/search.md` lists SERPdive with its capabilities and the `SERPDIVE_API_KEY` variable.
