### PR TITLE
Unify WebUI support and diagnostics actions

### DIFF
--- a/opensquilla-webui/src/components/DiagnosticsBundleDialog.test.ts
+++ b/opensquilla-webui/src/components/DiagnosticsBundleDialog.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { App, Ref } from 'vue'
+
+const messages = vi.hoisted(() => ({
+  'monitorSupport.bundleTitle': 'Download redacted support bundle',
+  'monitorSupport.bundleSubtitle': 'Create a ZIP to share with OpenSquilla support.',
+  'monitorSupport.bundleDefaultIncludes': 'Included by default',
+  'monitorSupport.bundleReadiness': 'Readiness and diagnostics snapshot',
+  'monitorSupport.bundleConfig': 'Redacted configuration summary',
+  'monitorSupport.bundleLogs': 'Errors, logs, and trace information',
+  'monitorSupport.bundlePlatform': 'Version and platform information',
+  'monitorSupport.bundleScopeTitle': 'Recent diagnostic records (up to 1 day)',
+  'monitorSupport.bundleScopeBody': 'Error and trace records cover no more than one day; runtime logs follow local rotation, so actual coverage may differ.',
+  'monitorSupport.bundleIncludeContentTitle': 'Include conversation content',
+  'monitorSupport.bundleIncludeContentBody': 'Enable only when support explicitly asks; this may contain sensitive business information.',
+  'monitorSupport.bundleCredentialsTitle': 'Known credential fields are redacted',
+  'monitorSupport.bundleCredentialsBody': 'Recognized API key, token, and secret values are redacted before packaging.',
+  'monitorSupport.bundleCancel': 'Cancel',
+  'monitorSupport.bundleConfirm': 'Generate and download',
+  'common.close': 'Close',
+} as Record<string, string>))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => messages[key] ?? key }),
+}))
+
+vi.mock('@/components/Icon.vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    default: defineComponent({
+      name: 'IconStub',
+      props: { name: { type: String, default: '' } },
+      setup(props) {
+        return () => h('span', { 'data-icon': props.name })
+      },
+    }),
+  }
+})
+
+const mountedApps: Array<{ app: App; el: HTMLElement }> = []
+
+async function flush() {
+  const { nextTick } = await import('vue')
+  await nextTick()
+  await nextTick()
+}
+
+async function mountDialog() {
+  const { createApp, defineComponent, h, ref } = await import('vue')
+  const Dialog = (await import('./DiagnosticsBundleDialog.vue')).default
+  let open!: Ref<boolean>
+  const Host = defineComponent({
+    setup() {
+      open = ref(true)
+      return () => h(Dialog, {
+        open: open.value,
+        onClose: () => { open.value = false },
+      })
+    },
+  })
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  const app = createApp(Host)
+  app.mount(el)
+  mountedApps.push({ app, el })
+  await flush()
+  return { open }
+}
+
+afterEach(() => {
+  while (mountedApps.length) {
+    const { app, el } = mountedApps.pop()!
+    app.unmount()
+    el.remove()
+  }
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('DiagnosticsBundleDialog', () => {
+  it('shows the one-day scope as fixed guidance without a range selector', async () => {
+    await mountDialog()
+    const dialog = document.querySelector<HTMLElement>('[role="dialog"]')
+    expect(dialog).toBeTruthy()
+    expect(dialog?.textContent).toContain('Recent diagnostic records (up to 1 day)')
+    expect(dialog?.textContent).toContain(
+      'Error and trace records cover no more than one day; runtime logs follow local rotation, so actual coverage may differ.',
+    )
+    expect(dialog?.querySelector('select')).toBeNull()
+    expect(dialog?.textContent).not.toContain('3 days')
+    expect(document.activeElement?.textContent?.trim()).toBe('Cancel')
+  })
+
+  it('resets the conversation-content opt-in every time it opens', async () => {
+    const { open } = await mountDialog()
+    let checkbox = document.querySelector<HTMLInputElement>('[role="dialog"] input[type="checkbox"]')
+    expect(checkbox?.checked).toBe(false)
+
+    checkbox!.click()
+    await flush()
+    expect(checkbox?.checked).toBe(true)
+
+    open.value = false
+    await flush()
+    open.value = true
+    await flush()
+
+    checkbox = document.querySelector<HTMLInputElement>('[role="dialog"] input[type="checkbox"]')
+    expect(checkbox?.checked).toBe(false)
+  })
+})

--- a/opensquilla-webui/src/components/DiagnosticsBundleDialog.vue
+++ b/opensquilla-webui/src/components/DiagnosticsBundleDialog.vue
@@ -1,34 +1,88 @@
 <template>
   <Teleport to="body">
     <Transition name="modal">
-      <div v-if="open" class="modal-overlay" @click="emit('close')">
-        <div
+      <div v-if="open" class="modal-overlay" @click="!busy && emit('close')">
+        <section
           ref="modalRef"
           class="modal"
           role="dialog"
           aria-modal="true"
           aria-labelledby="diagnostics-bundle-title"
+          aria-describedby="diagnostics-bundle-description"
           @click.stop
         >
-          <h3 id="diagnostics-bundle-title" class="modal__title">
-            {{ t('usageLogs.logs.bundleTitle') }}
-          </h3>
+          <header class="modal__header">
+            <span class="modal__title-icon" aria-hidden="true">
+              <Icon name="download" :size="19" />
+            </span>
+            <div class="modal__title-copy">
+              <h3 id="diagnostics-bundle-title" class="modal__title">
+                {{ t('monitorSupport.bundleTitle') }}
+              </h3>
+              <p id="diagnostics-bundle-description" class="modal__subtitle">
+                {{ t('monitorSupport.bundleSubtitle') }}
+              </p>
+            </div>
+            <button
+              type="button"
+              class="btn btn--icon btn--ghost modal__close"
+              :disabled="busy"
+              :aria-label="t('common.close')"
+              :title="t('common.close')"
+              @click="emit('close')"
+            >
+              <Icon name="x" :size="16" />
+            </button>
+          </header>
+
           <div class="modal__body">
-            <p>{{ t('usageLogs.logs.bundleBody') }}</p>
+            <section class="bundle-dialog__contents" :aria-label="t('monitorSupport.bundleDefaultIncludes')">
+              <h4>{{ t('monitorSupport.bundleDefaultIncludes') }}</h4>
+              <div class="bundle-dialog__contents-grid">
+                <span><Icon name="check" :size="14" />{{ t('monitorSupport.bundleReadiness') }}</span>
+                <span><Icon name="check" :size="14" />{{ t('monitorSupport.bundleConfig') }}</span>
+                <span><Icon name="check" :size="14" />{{ t('monitorSupport.bundleLogs') }}</span>
+                <span><Icon name="check" :size="14" />{{ t('monitorSupport.bundlePlatform') }}</span>
+              </div>
+            </section>
+
+            <div class="bundle-dialog__scope" role="note" :aria-label="t('monitorSupport.bundleScopeTitle')">
+              <span class="bundle-dialog__scope-icon" aria-hidden="true">
+                <Icon name="clock" :size="16" />
+              </span>
+              <span>
+                <strong>{{ t('monitorSupport.bundleScopeTitle') }}</strong>
+                <small>{{ t('monitorSupport.bundleScopeBody') }}</small>
+              </span>
+            </div>
+
             <label class="bundle-dialog__option">
-              <input v-model="includeContent" type="checkbox" />
-              <span>{{ t('usageLogs.logs.bundleIncludeContent') }}</span>
+              <input v-model="includeContent" type="checkbox" :disabled="busy" />
+              <span>
+                <strong>{{ t('monitorSupport.bundleIncludeContentTitle') }}</strong>
+                <small>{{ t('monitorSupport.bundleIncludeContentBody') }}</small>
+              </span>
             </label>
+
+            <div class="bundle-dialog__privacy" role="note">
+              <Icon name="shield" :size="17" aria-hidden="true" />
+              <p>
+                <strong>{{ t('monitorSupport.bundleCredentialsTitle') }}</strong>
+                <span>{{ t('monitorSupport.bundleCredentialsBody') }}</span>
+              </p>
+            </div>
           </div>
-          <div class="modal__footer">
-            <button class="btn btn--primary" @click="emit('confirm', { includeContent })">
-              {{ t('usageLogs.logs.bundleConfirm') }}
+
+          <footer class="modal__footer">
+            <button ref="cancelBtn" type="button" class="btn btn--ghost" :disabled="busy" @click="emit('close')">
+              {{ t('monitorSupport.bundleCancel') }}
             </button>
-            <button ref="cancelBtn" class="btn btn--ghost" @click="emit('close')">
-              {{ t('usageLogs.logs.bundleCancel') }}
+            <button type="button" class="btn btn--primary" :disabled="busy" @click="emit('confirm', { includeContent })">
+              <Icon name="download" :size="16" />
+              {{ t('monitorSupport.bundleConfirm') }}
             </button>
-          </div>
-        </div>
+          </footer>
+        </section>
       </div>
     </Transition>
   </Teleport>
@@ -37,9 +91,12 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Icon from '@/components/Icon.vue'
 import { useDialogA11y } from '@/composables/useDialogA11y'
 
-const props = defineProps<{ open: boolean }>()
+const props = withDefaults(defineProps<{ open: boolean; busy?: boolean }>(), {
+  busy: false,
+})
 const emit = defineEmits<{
   (event: 'close'): void
   (event: 'confirm', payload: { includeContent: boolean }): void
@@ -48,7 +105,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const includeContent = ref(false)
 const modalRef = ref<HTMLElement | null>(null)
-const cancelBtn = ref<HTMLElement | null>(null)
+const cancelBtn = ref<HTMLButtonElement | null>(null)
 const isOpen = computed(() => props.open)
 
 // Privacy-sensitive opt-in: re-arm to unchecked every time the dialog opens so
@@ -63,8 +120,6 @@ useDialogA11y(modalRef, isOpen, () => emit('close'), { initialFocus: cancelBtn }
 </script>
 
 <style scoped>
-/* ConfirmModal's overlay/dialog skeleton is scoped to that component, so the
-   same token-based block is repeated here rather than reaching into it. */
 .modal-overlay {
   align-items: center;
   background: var(--scrim);
@@ -72,6 +127,7 @@ useDialogA11y(modalRef, isOpen, () => emit('close'), { initialFocus: cancelBtn }
   display: flex;
   justify-content: center;
   left: 0;
+  padding: var(--sp-4);
   position: fixed;
   right: 0;
   top: 0;
@@ -82,46 +138,207 @@ useDialogA11y(modalRef, isOpen, () => emit('close'), { initialFocus: cancelBtn }
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-modal);
-  max-width: 420px;
-  padding: var(--sp-5);
-  width: 90%;
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - (2 * var(--sp-4)));
+  max-width: 610px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.modal__header {
+  align-items: center;
+  border-bottom: 1px solid var(--hairline);
+  display: flex;
+  gap: var(--sp-3);
+  padding: var(--sp-4) var(--sp-5);
+}
+
+.modal__title-icon {
+  align-items: center;
+  background: var(--bg-surface-2);
+  border-radius: var(--radius-md);
+  color: var(--accent);
+  display: inline-flex;
+  flex: 0 0 38px;
+  height: 38px;
+  justify-content: center;
+}
+
+.modal__title-copy {
+  flex: 1;
+  min-width: 0;
 }
 
 .modal__title {
   font-size: var(--fs-md);
   font-weight: 600;
-  margin: 0 0 var(--sp-3);
-}
-
-.modal__body {
-  color: var(--text-muted);
-  font-size: var(--fs-sm);
-  line-height: 1.5;
-  margin-bottom: var(--sp-4);
-}
-
-.modal__body p {
   margin: 0;
 }
 
-.modal__footer {
+.modal__subtitle {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  line-height: 1.45;
+  margin: 3px 0 0;
+}
+
+.modal__close {
+  flex: 0 0 auto;
+}
+
+.modal__body {
   display: flex;
+  flex-direction: column;
   gap: var(--sp-3);
-  justify-content: flex-end;
+  overflow-y: auto;
+  padding: var(--sp-4) var(--sp-5);
+}
+
+.bundle-dialog__contents {
+  background: var(--bg-surface-2);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  padding: var(--sp-3);
+}
+
+.bundle-dialog__contents h4 {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  margin: 0 0 var(--sp-2);
+}
+
+.bundle-dialog__contents-grid {
+  display: grid;
+  gap: var(--sp-2) var(--sp-4);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.bundle-dialog__contents-grid span {
+  align-items: center;
+  color: var(--text);
+  display: flex;
+  font-size: var(--fs-xs);
+  gap: var(--sp-2);
+}
+
+.bundle-dialog__contents-grid :deep(.icon) {
+  color: var(--ok);
+}
+
+.bundle-dialog__scope {
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg-surface));
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--border));
+  border-radius: var(--radius-md);
+  display: grid;
+  gap: var(--sp-3);
+  grid-template-columns: 30px 1fr;
+  padding: var(--sp-3);
+}
+
+.bundle-dialog__scope-icon {
+  align-items: center;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border-radius: var(--radius-sm);
+  color: var(--accent);
+  display: inline-flex;
+  height: 30px;
+  justify-content: center;
+  width: 30px;
+}
+
+.bundle-dialog__scope strong,
+.bundle-dialog__scope small {
+  display: block;
+}
+
+.bundle-dialog__scope strong {
+  font-size: var(--fs-sm);
+  line-height: 1.35;
+}
+
+.bundle-dialog__scope small {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  line-height: 1.5;
+  margin-top: 3px;
 }
 
 .bundle-dialog__option {
-  align-items: center;
-  color: var(--text-muted);
+  align-items: flex-start;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text);
   cursor: pointer;
-  display: flex;
+  display: grid;
   font-size: var(--fs-sm);
   gap: var(--sp-2);
-  margin-top: var(--sp-3);
+  grid-template-columns: auto 1fr;
+  padding: var(--sp-3);
 }
 
 .bundle-dialog__option input {
-  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.bundle-dialog__option strong,
+.bundle-dialog__option small {
+  display: block;
+}
+
+.bundle-dialog__option strong {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+}
+
+.bundle-dialog__option small {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  line-height: 1.45;
+  margin-top: 2px;
+}
+
+.bundle-dialog__privacy {
+  align-items: flex-start;
+  background: color-mix(in srgb, var(--ok) 10%, var(--bg-surface));
+  border-radius: var(--radius-md);
+  color: var(--ok);
+  display: flex;
+  gap: var(--sp-2);
+  padding: var(--sp-3);
+}
+
+.bundle-dialog__privacy p {
+  margin: 0;
+}
+
+.bundle-dialog__privacy strong,
+.bundle-dialog__privacy span {
+  display: block;
+}
+
+.bundle-dialog__privacy strong {
+  font-size: var(--fs-xs);
+  font-weight: 600;
+}
+
+.bundle-dialog__privacy span {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  line-height: 1.45;
+  margin-top: 2px;
+}
+
+.modal__footer {
+  align-items: center;
+  background: var(--bg-surface-2);
+  border-top: 1px solid var(--hairline);
+  display: flex;
+  gap: var(--sp-2);
+  justify-content: flex-end;
+  padding: var(--sp-3) var(--sp-5);
 }
 
 .modal-enter-active,
@@ -132,5 +349,32 @@ useDialogA11y(modalRef, isOpen, () => emit('close'), { initialFocus: cancelBtn }
 .modal-enter-from,
 .modal-leave-to {
   opacity: 0;
+}
+
+@media (max-width: 560px) {
+  .modal-overlay {
+    padding: var(--sp-3);
+  }
+
+  .modal__header,
+  .modal__body,
+  .modal__footer {
+    padding-left: var(--sp-3);
+    padding-right: var(--sp-3);
+  }
+
+  .bundle-dialog__contents-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .modal__footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .modal__footer .btn {
+    justify-content: center;
+    width: 100%;
+  }
 }
 </style>

--- a/opensquilla-webui/src/components/SupportDiagnosticsMenu.test.ts
+++ b/opensquilla-webui/src/components/SupportDiagnosticsMenu.test.ts
@@ -1,0 +1,247 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { App } from 'vue'
+
+const mocks = vi.hoisted(() => ({
+  route: { path: '/overview' },
+  rpcCall: vi.fn(),
+  waitForConnection: vi.fn(),
+  pushToast: vi.fn(),
+  copyText: vi.fn(),
+  downloadBlob: vi.fn(),
+  filenameFromContentDisposition: vi.fn(),
+  fetch: vi.fn(),
+  messages: {
+    'monitorSupport.title': 'Support & diagnostics',
+    'monitorSupport.menuLabel': 'Support and diagnostics actions',
+    'monitorSupport.copyReport': 'Copy current readiness report',
+    'monitorSupport.copyReportDescription': 'Share the current connection, configuration, and runtime status',
+    'monitorSupport.copySuccess': 'Readiness report copied',
+    'monitorSupport.copyFailed': 'Could not copy readiness report: {error}',
+    'monitorSupport.downloadBundle': 'Download redacted support bundle',
+    'monitorSupport.downloadBundleDescription': 'Includes logs, a configuration summary, and diagnostic results',
+    'monitorSupport.privacySummary': 'Conversation content is excluded by default and known credentials are redacted',
+    'monitorSupport.bundleTitle': 'Download redacted support bundle',
+    'monitorSupport.bundleSubtitle': 'Create a ZIP to share with OpenSquilla support.',
+    'monitorSupport.bundleDefaultIncludes': 'Included by default',
+    'monitorSupport.bundleReadiness': 'Readiness and diagnostics snapshot',
+    'monitorSupport.bundleConfig': 'Redacted configuration summary',
+    'monitorSupport.bundleLogs': 'Errors, logs, and trace information',
+    'monitorSupport.bundlePlatform': 'Version and platform information',
+    'monitorSupport.bundleScopeTitle': 'Recent diagnostic records (up to 1 day)',
+    'monitorSupport.bundleScopeBody': 'Error and trace records cover no more than one day; runtime logs follow local rotation, so actual coverage may differ.',
+    'monitorSupport.bundleIncludeContentTitle': 'Include conversation content',
+    'monitorSupport.bundleIncludeContentBody': 'Enable only when support explicitly asks; this may contain sensitive business information.',
+    'monitorSupport.bundleCredentialsTitle': 'Known credential fields are redacted',
+    'monitorSupport.bundleCredentialsBody': 'Recognized API key, token, and secret values are redacted before packaging.',
+    'monitorSupport.bundleCancel': 'Cancel',
+    'monitorSupport.bundleConfirm': 'Generate and download',
+    'monitorSupport.bundleFailed': 'Support bundle download failed',
+    'monitorSupport.bundleReady': 'Support bundle downloaded',
+    'common.close': 'Close',
+  } as Record<string, string>,
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mocks.route,
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, values?: Record<string, unknown>) => {
+      let value = mocks.messages[key] ?? key
+      for (const [name, replacement] of Object.entries(values ?? {})) {
+        value = value.replace(`{${name}}`, String(replacement))
+      }
+      return value
+    },
+  }),
+}))
+
+vi.mock('@/stores/rpc', () => ({
+  useRpcStore: () => ({
+    call: mocks.rpcCall,
+    waitForConnection: mocks.waitForConnection,
+  }),
+}))
+
+vi.mock('@/composables/useToasts', () => ({
+  useToasts: () => ({ pushToast: mocks.pushToast }),
+}))
+
+vi.mock('@/utils/browser', () => ({
+  copyTextWithFallback: mocks.copyText,
+  downloadBlob: mocks.downloadBlob,
+  filenameFromContentDisposition: mocks.filenameFromContentDisposition,
+}))
+
+vi.mock('@/components/Icon.vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    default: defineComponent({
+      name: 'IconStub',
+      props: { name: { type: String, default: '' } },
+      setup(props) {
+        return () => h('span', { 'data-icon': props.name })
+      },
+    }),
+  }
+})
+
+const mountedApps: Array<{ app: App; el: HTMLElement }> = []
+
+async function flush() {
+  const { nextTick } = await import('vue')
+  for (let index = 0; index < 8; index += 1) await Promise.resolve()
+  await nextTick()
+  await nextTick()
+}
+
+async function mountMenu() {
+  const { createApp } = await import('vue')
+  const Component = (await import('./SupportDiagnosticsMenu.vue')).default
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  const app = createApp(Component)
+  app.mount(el)
+  mountedApps.push({ app, el })
+  await flush()
+  return { el }
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  window.sessionStorage.clear()
+  vi.clearAllMocks()
+
+  mocks.waitForConnection.mockResolvedValue(undefined)
+  mocks.rpcCall.mockResolvedValue({
+    status: 'degraded',
+    configPath: '/Users/dummyuser/.opensquilla/config.toml',
+    gatewayUrl: 'ws://127.0.0.1:18791/ws',
+  })
+  mocks.copyText.mockResolvedValue(undefined)
+  mocks.filenameFromContentDisposition.mockReturnValue('opensquilla-support.zip')
+  mocks.fetch.mockResolvedValue({
+    ok: true,
+    blob: vi.fn(async () => new Blob(['bundle'])),
+    headers: new Headers({
+      'content-disposition': 'attachment; filename="opensquilla-support.zip"',
+    }),
+  })
+  vi.stubGlobal('fetch', mocks.fetch)
+})
+
+afterEach(() => {
+  while (mountedApps.length) {
+    const { app, el } = mountedApps.pop()!
+    app.unmount()
+    el.remove()
+  }
+  window.sessionStorage.clear()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('SupportDiagnosticsMenu', () => {
+  it('exposes the readiness report and support bundle as shared menu actions', async () => {
+    const { el } = await mountMenu()
+    const trigger = el.querySelector<HTMLButtonElement>('[data-testid="support-diagnostics-trigger"]')
+    expect(trigger).toBeTruthy()
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false')
+
+    trigger!.click()
+    await flush()
+
+    expect(trigger?.getAttribute('aria-expanded')).toBe('true')
+    expect(el.querySelector('[role="menu"]')?.getAttribute('aria-label'))
+      .toBe('Support and diagnostics actions')
+    expect(el.querySelector('[data-testid="support-copy-readiness"]')?.textContent)
+      .toContain('Copy current readiness report')
+    expect(el.querySelector('[data-testid="support-download-bundle"]')?.textContent)
+      .toContain('Download redacted support bundle')
+  })
+
+  it('moves focus through the menu and restores it after closing the bundle dialog', async () => {
+    const { el } = await mountMenu()
+    const trigger = el.querySelector<HTMLButtonElement>('[data-testid="support-diagnostics-trigger"]')!
+    trigger.click()
+    await flush()
+
+    const copyItem = el.querySelector<HTMLButtonElement>('[data-testid="support-copy-readiness"]')!
+    const bundleItem = el.querySelector<HTMLButtonElement>('[data-testid="support-download-bundle"]')!
+    expect(document.activeElement).toBe(copyItem)
+
+    copyItem.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    await flush()
+    expect(document.activeElement).toBe(bundleItem)
+
+    bundleItem.click()
+    await flush()
+    const cancel = Array.from(document.querySelectorAll<HTMLButtonElement>('[role="dialog"] button'))
+      .find(button => button.textContent?.trim() === 'Cancel')
+    expect(document.activeElement).toBe(cancel)
+
+    cancel!.click()
+    await flush()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('copies a fresh doctor.status report after normalizing local home paths', async () => {
+    const { el } = await mountMenu()
+    el.querySelector<HTMLButtonElement>('[data-testid="support-diagnostics-trigger"]')!.click()
+    await flush()
+    el.querySelector<HTMLButtonElement>('[data-testid="support-copy-readiness"]')!.click()
+    await flush()
+
+    expect(mocks.waitForConnection).toHaveBeenCalledTimes(1)
+    expect(mocks.rpcCall).toHaveBeenCalledWith('doctor.status', {
+      agentId: 'main',
+      deep: true,
+    })
+    expect(mocks.copyText).toHaveBeenCalledTimes(1)
+
+    const copied = String(mocks.copyText.mock.calls[0][0])
+    expect(copied).not.toContain('dummyuser')
+    const report = JSON.parse(copied) as Record<string, unknown>
+    expect(report.configPath).toBe('~/.opensquilla/config.toml')
+    expect(report.gatewayUrl).toBe('ws://127.0.0.1:18791/ws')
+    expect(Number.isNaN(Date.parse(String(report.copiedAt)))).toBe(false)
+    expect(mocks.pushToast).toHaveBeenCalledWith('Readiness report copied', { tone: 'ok' })
+  })
+
+  it('always requests a one-day bundle and keeps conversation content opt-in', async () => {
+    window.sessionStorage.setItem('opensquilla.wsToken', 'test-owner-token')
+    const { el } = await mountMenu()
+    const trigger = el.querySelector<HTMLButtonElement>('[data-testid="support-diagnostics-trigger"]')!
+    trigger.click()
+    await flush()
+    el.querySelector<HTMLButtonElement>('[data-testid="support-download-bundle"]')!.click()
+    await flush()
+
+    const checkbox = document.querySelector<HTMLInputElement>('[role="dialog"] input[type="checkbox"]')
+    expect(checkbox?.checked).toBe(false)
+    const confirm = Array.from(document.querySelectorAll<HTMLButtonElement>('[role="dialog"] button'))
+      .find(button => button.textContent?.includes('Generate and download'))
+    expect(confirm).toBeTruthy()
+    confirm!.click()
+    await flush()
+
+    expect(mocks.fetch).toHaveBeenCalledTimes(1)
+    const [url, init] = mocks.fetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/diagnostics/bundle')
+    expect(init.method).toBe('POST')
+    expect(init.credentials).toBe('same-origin')
+    expect(init.headers).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-owner-token',
+    })
+    expect(JSON.parse(String(init.body))).toEqual({
+      include_content: false,
+      days: 1,
+    })
+    expect(mocks.downloadBlob).toHaveBeenCalledWith(expect.any(Blob), 'opensquilla-support.zip')
+    expect(mocks.pushToast).toHaveBeenCalledWith('Support bundle downloaded', { tone: 'ok' })
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/opensquilla-webui/src/components/SupportDiagnosticsMenu.vue
+++ b/opensquilla-webui/src/components/SupportDiagnosticsMenu.vue
@@ -1,0 +1,343 @@
+<template>
+  <div ref="wrapRef" class="support-diagnostics theme-menu-wrap">
+    <button
+      ref="triggerRef"
+      type="button"
+      class="btn btn--ghost support-diagnostics__trigger"
+      :class="{ 'is-open': menuOpen }"
+      aria-haspopup="menu"
+      :aria-expanded="menuOpen"
+      :title="t('monitorSupport.title')"
+      data-testid="support-diagnostics-trigger"
+      @click.stop="toggleMenu"
+      @keydown.down.prevent="openMenu('first')"
+      @keydown.up.prevent="openMenu('last')"
+    >
+      <Icon name="gauge" :size="16" />
+      <span>{{ t('monitorSupport.title') }}</span>
+      <Icon name="chevronDown" :size="13" />
+    </button>
+
+    <div
+      v-if="menuOpen"
+      ref="menuRef"
+      class="theme-menu support-diagnostics__menu"
+      role="menu"
+      :aria-label="t('monitorSupport.menuLabel')"
+      @keydown="onMenuKeydown"
+    >
+      <button
+        type="button"
+        class="theme-menu__item support-diagnostics__item"
+        role="menuitem"
+        :disabled="copyInFlight"
+        data-testid="support-copy-readiness"
+        @click="copyReadinessReport"
+      >
+        <span class="support-diagnostics__item-icon"><Icon name="copy" :size="16" /></span>
+        <span class="support-diagnostics__item-copy">
+          <strong>{{ t('monitorSupport.copyReport') }}</strong>
+          <small>{{ t('monitorSupport.copyReportDescription') }}</small>
+        </span>
+      </button>
+      <div class="support-diagnostics__divider" role="separator"></div>
+      <button
+        type="button"
+        class="theme-menu__item support-diagnostics__item"
+        role="menuitem"
+        data-testid="support-download-bundle"
+        @click="openBundleDialog"
+      >
+        <span class="support-diagnostics__item-icon"><Icon name="download" :size="16" /></span>
+        <span class="support-diagnostics__item-copy">
+          <strong>{{ t('monitorSupport.downloadBundle') }}</strong>
+          <small>{{ t('monitorSupport.downloadBundleDescription') }}</small>
+        </span>
+      </button>
+      <p class="support-diagnostics__privacy">
+        <Icon name="shield" :size="13" />
+        <span>{{ t('monitorSupport.privacySummary') }}</span>
+      </p>
+    </div>
+
+    <DiagnosticsBundleDialog
+      :open="bundleDialogOpen"
+      :busy="bundleInFlight"
+      @close="closeBundleDialog"
+      @confirm="downloadBundle"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { nextTick, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute } from 'vue-router'
+import DiagnosticsBundleDialog from '@/components/DiagnosticsBundleDialog.vue'
+import Icon from '@/components/Icon.vue'
+import { useDocumentEvent } from '@/composables/useDocumentEvent'
+import { useToasts } from '@/composables/useToasts'
+import { useRpcStore } from '@/stores/rpc'
+import {
+  copyTextWithFallback,
+  downloadBlob,
+  filenameFromContentDisposition,
+} from '@/utils/browser'
+import { normalizeHomePaths } from '@/utils/overviewDiagnostics'
+
+const SUPPORT_BUNDLE_DAYS = 1
+
+const { t } = useI18n()
+const route = useRoute()
+const rpc = useRpcStore()
+const { pushToast } = useToasts()
+const menuOpen = ref(false)
+const bundleDialogOpen = ref(false)
+const copyInFlight = ref(false)
+const bundleInFlight = ref(false)
+const wrapRef = ref<HTMLDivElement | null>(null)
+const triggerRef = ref<HTMLButtonElement | null>(null)
+const menuRef = ref<HTMLDivElement | null>(null)
+
+function gatewayContextUrl(): string {
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${proto}//${location.host}/ws`
+}
+
+function closeMenuAndRestoreFocus() {
+  menuOpen.value = false
+  void nextTick(() => triggerRef.value?.focus())
+}
+
+function menuItems(): HTMLButtonElement[] {
+  return Array.from(
+    menuRef.value?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not([disabled])') ?? [],
+  )
+}
+
+function focusMenuItem(position: 'first' | 'last') {
+  const items = menuItems()
+  const target = position === 'last' ? items[items.length - 1] : items[0]
+  target?.focus()
+}
+
+function openMenu(position: 'first' | 'last' = 'first') {
+  menuOpen.value = true
+  void nextTick(() => focusMenuItem(position))
+}
+
+function toggleMenu() {
+  if (menuOpen.value) {
+    closeMenuAndRestoreFocus()
+    return
+  }
+  openMenu()
+}
+
+function onMenuKeydown(event: KeyboardEvent) {
+  const items = menuItems()
+  if (!items.length) return
+  const current = items.indexOf(document.activeElement as HTMLButtonElement)
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeMenuAndRestoreFocus()
+    return
+  }
+  if (event.key === 'Tab') {
+    menuOpen.value = false
+    return
+  }
+  let nextIndex: number | null = null
+  if (event.key === 'ArrowDown') nextIndex = current < 0 ? 0 : (current + 1) % items.length
+  if (event.key === 'ArrowUp') nextIndex = current < 0 ? items.length - 1 : (current - 1 + items.length) % items.length
+  if (event.key === 'Home') nextIndex = 0
+  if (event.key === 'End') nextIndex = items.length - 1
+  if (nextIndex == null) return
+  event.preventDefault()
+  items[nextIndex]?.focus()
+}
+
+function openBundleDialog() {
+  menuOpen.value = false
+  bundleDialogOpen.value = true
+}
+
+function closeBundleDialog() {
+  bundleDialogOpen.value = false
+  void nextTick(() => triggerRef.value?.focus())
+}
+
+async function copyReadinessReport() {
+  if (copyInFlight.value) return
+  copyInFlight.value = true
+  menuOpen.value = false
+  await nextTick()
+  triggerRef.value?.focus()
+  try {
+    await rpc.waitForConnection()
+    const data = await rpc.call<Record<string, unknown>>('doctor.status', {
+      agentId: 'main',
+      deep: true,
+    })
+    const report = {
+      ...(data || {}),
+      gatewayUrl: data?.gatewayUrl || gatewayContextUrl(),
+      copiedAt: new Date().toISOString(),
+    }
+    await copyTextWithFallback(normalizeHomePaths(JSON.stringify(report, null, 2)))
+    pushToast(t('monitorSupport.copySuccess'), { tone: 'ok' })
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    pushToast(t('monitorSupport.copyFailed', { error: detail }), { tone: 'danger' })
+  } finally {
+    copyInFlight.value = false
+    void nextTick(() => triggerRef.value?.focus())
+  }
+}
+
+async function downloadBundle(options: { includeContent: boolean }) {
+  if (bundleInFlight.value) return
+  closeBundleDialog()
+  bundleInFlight.value = true
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    // Match the owner-authenticated diagnostics route used by the prior Logs
+    // action. Some hardened/embedded contexts reject sessionStorage access.
+    let token = ''
+    try { token = sessionStorage.getItem('opensquilla.wsToken') || '' } catch {}
+    if (token) headers.Authorization = `Bearer ${token}`
+    const response = await fetch('/api/v1/diagnostics/bundle', {
+      method: 'POST',
+      headers,
+      credentials: 'same-origin',
+      body: JSON.stringify({
+        include_content: options.includeContent,
+        days: SUPPORT_BUNDLE_DAYS,
+      }),
+    })
+    if (!response.ok) {
+      pushToast(t('monitorSupport.bundleFailed'), { tone: 'danger' })
+      return
+    }
+    const blob = await response.blob()
+    const filename = filenameFromContentDisposition(response.headers.get('content-disposition'))
+      || 'opensquilla-bundle.zip'
+    downloadBlob(blob, filename)
+    pushToast(t('monitorSupport.bundleReady'), { tone: 'ok' })
+  } catch {
+    pushToast(t('monitorSupport.bundleFailed'), { tone: 'danger' })
+  } finally {
+    bundleInFlight.value = false
+  }
+}
+
+useDocumentEvent('click', (event) => {
+  if (!menuOpen.value) return
+  if (event.target instanceof Node && !wrapRef.value?.contains(event.target)) {
+    menuOpen.value = false
+  }
+})
+
+useDocumentEvent('keydown', (event) => {
+  if (event.key === 'Escape' && menuOpen.value) {
+    event.preventDefault()
+    closeMenuAndRestoreFocus()
+  }
+})
+
+watch(() => route.path, () => {
+  menuOpen.value = false
+  bundleDialogOpen.value = false
+})
+</script>
+
+<style scoped>
+.support-diagnostics {
+  flex: 0 0 auto;
+}
+
+.support-diagnostics__trigger {
+  align-items: center;
+  display: inline-flex;
+  gap: var(--sp-2);
+  white-space: nowrap;
+}
+
+.support-diagnostics__trigger.is-open {
+  border-color: var(--border-focus);
+  color: var(--text);
+}
+
+.support-diagnostics__menu {
+  max-width: calc(100vw - (2 * var(--sp-3)));
+  min-width: min(360px, calc(100vw - (2 * var(--sp-3))));
+  padding: var(--sp-2);
+}
+
+.support-diagnostics__item {
+  align-items: flex-start;
+  gap: var(--sp-3);
+  padding: 10px;
+}
+
+.support-diagnostics__item:disabled {
+  cursor: progress;
+  opacity: 0.65;
+}
+
+.support-diagnostics__item-icon {
+  align-items: center;
+  background: var(--bg-surface-2);
+  border-radius: var(--radius-sm);
+  color: var(--accent);
+  display: inline-flex;
+  flex: 0 0 30px;
+  height: 30px;
+  justify-content: center;
+}
+
+.support-diagnostics__item-copy {
+  display: block;
+  min-width: 0;
+}
+
+.support-diagnostics__item-copy strong,
+.support-diagnostics__item-copy small {
+  display: block;
+}
+
+.support-diagnostics__item-copy strong {
+  color: var(--text);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.support-diagnostics__item-copy small {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  line-height: 1.45;
+  margin-top: 2px;
+}
+
+.support-diagnostics__divider {
+  border-top: 1px solid var(--hairline);
+  margin: var(--sp-1) 0;
+}
+
+.support-diagnostics__privacy {
+  align-items: center;
+  color: var(--ok);
+  display: flex;
+  font-size: var(--fs-xs);
+  gap: var(--sp-2);
+  margin: var(--sp-2) var(--sp-2) 2px;
+}
+
+@media (max-width: 600px) {
+  .support-diagnostics__trigger {
+    padding-left: var(--sp-2);
+    padding-right: var(--sp-2);
+  }
+}
+</style>

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -1871,6 +1871,34 @@
       "awaitingReview": "wartet auf Überprüfung"
     }
   },
+  "monitorSupport": {
+    "title": "Support und Diagnose",
+    "menuLabel": "Support- und Diagnoseaktionen",
+    "copyReport": "Aktuellen Bereitschaftsbericht kopieren",
+    "copyReportDescription": "Aktuellen Verbindungs-, Konfigurations- und Laufzeitstatus teilen",
+    "copySuccess": "Bereitschaftsbericht kopiert",
+    "copyFailed": "Bereitschaftsbericht konnte nicht kopiert werden: {error}",
+    "downloadBundle": "Bereinigtes Support-Paket herunterladen",
+    "downloadBundleDescription": "Enthält Protokolle, eine Konfigurationsübersicht und Diagnoseergebnisse",
+    "privacySummary": "Unterhaltungsinhalte sind standardmäßig ausgeschlossen und bekannte Zugangsdaten werden geschwärzt",
+    "bundleTitle": "Bereinigtes Support-Paket herunterladen",
+    "bundleSubtitle": "Erstellen Sie eine ZIP-Datei zum Teilen mit dem OpenSquilla-Support.",
+    "bundleDefaultIncludes": "Standardmäßig enthalten",
+    "bundleReadiness": "Momentaufnahme von Bereitschaft und Diagnose",
+    "bundleConfig": "Bereinigte Konfigurationsübersicht",
+    "bundleLogs": "Fehler, Protokolle und Trace-Informationen",
+    "bundlePlatform": "Versions- und Plattforminformationen",
+    "bundleScopeTitle": "Aktuelle Diagnosedaten (maximal 1 Tag)",
+    "bundleScopeBody": "Fehler- und Trace-Daten umfassen höchstens einen Tag; Laufzeitprotokolle folgen der lokalen Rotation, daher kann der tatsächliche Zeitraum abweichen.",
+    "bundleIncludeContentTitle": "Unterhaltungsinhalte einbeziehen",
+    "bundleIncludeContentBody": "Nur aktivieren, wenn der Support ausdrücklich darum bittet; dies kann vertrauliche Geschäftsinformationen enthalten.",
+    "bundleCredentialsTitle": "Bekannte Zugangsdatenfelder werden geschwärzt",
+    "bundleCredentialsBody": "API-Schlüssel, Token und andere erkannte geheime Werte werden vor dem Verpacken geschwärzt.",
+    "bundleConfirm": "Erstellen und herunterladen",
+    "bundleCancel": "Abbrechen",
+    "bundleFailed": "Support-Paket konnte nicht heruntergeladen werden",
+    "bundleReady": "Support-Paket heruntergeladen"
+  },
   "usageLogs": {
     "usage": {
       "title": "Nutzung",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -1871,6 +1871,34 @@
       "awaitingReview": "awaiting review"
     }
   },
+  "monitorSupport": {
+    "title": "Support & diagnostics",
+    "menuLabel": "Support and diagnostics actions",
+    "copyReport": "Copy current readiness report",
+    "copyReportDescription": "Share the current connection, configuration, and runtime status",
+    "copySuccess": "Readiness report copied",
+    "copyFailed": "Could not copy readiness report: {error}",
+    "downloadBundle": "Download redacted support bundle",
+    "downloadBundleDescription": "Includes logs, a configuration summary, and diagnostic results",
+    "privacySummary": "Conversation content is excluded by default and known credentials are redacted",
+    "bundleTitle": "Download redacted support bundle",
+    "bundleSubtitle": "Create a ZIP to share with OpenSquilla support.",
+    "bundleDefaultIncludes": "Included by default",
+    "bundleReadiness": "Readiness and diagnostics snapshot",
+    "bundleConfig": "Redacted configuration summary",
+    "bundleLogs": "Errors, logs, and trace information",
+    "bundlePlatform": "Version and platform information",
+    "bundleScopeTitle": "Recent diagnostic records (up to 1 day)",
+    "bundleScopeBody": "Error and trace records cover no more than one day; runtime logs follow local rotation, so actual coverage may differ.",
+    "bundleIncludeContentTitle": "Include conversation content",
+    "bundleIncludeContentBody": "Enable only when support explicitly asks; this may contain sensitive business information.",
+    "bundleCredentialsTitle": "Known credential fields are redacted",
+    "bundleCredentialsBody": "API keys, tokens, and other recognized secret values are redacted before packaging.",
+    "bundleConfirm": "Generate and download",
+    "bundleCancel": "Cancel",
+    "bundleFailed": "Support bundle download failed",
+    "bundleReady": "Support bundle downloaded"
+  },
   "usageLogs": {
     "usage": {
       "title": "Usage",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -1871,6 +1871,34 @@
       "awaitingReview": "a la espera de revisión"
     }
   },
+  "monitorSupport": {
+    "title": "Soporte y diagnóstico",
+    "menuLabel": "Acciones de soporte y diagnóstico",
+    "copyReport": "Copiar informe actual de disponibilidad",
+    "copyReportDescription": "Compartir el estado actual de conexión, configuración y ejecución",
+    "copySuccess": "Informe de disponibilidad copiado",
+    "copyFailed": "No se pudo copiar el informe de disponibilidad: {error}",
+    "downloadBundle": "Descargar paquete de soporte con datos confidenciales ocultos",
+    "downloadBundleDescription": "Incluye registros, un resumen de configuración y resultados del diagnóstico",
+    "privacySummary": "El contenido de las conversaciones se excluye de forma predeterminada y se ocultan las credenciales conocidas",
+    "bundleTitle": "Descargar paquete de soporte con datos confidenciales ocultos",
+    "bundleSubtitle": "Crea un archivo ZIP para compartir con el soporte de OpenSquilla.",
+    "bundleDefaultIncludes": "Incluido de forma predeterminada",
+    "bundleReadiness": "Instantánea de disponibilidad y diagnóstico",
+    "bundleConfig": "Resumen de configuración con datos confidenciales ocultos",
+    "bundleLogs": "Errores, registros e información de trazas",
+    "bundlePlatform": "Información de versión y plataforma",
+    "bundleScopeTitle": "Registros de diagnóstico recientes (1 día como máximo)",
+    "bundleScopeBody": "Los errores y las trazas cubren como máximo un día; los registros de ejecución siguen la rotación local, por lo que la cobertura real puede variar.",
+    "bundleIncludeContentTitle": "Incluir el contenido de las conversaciones",
+    "bundleIncludeContentBody": "Actívalo solo cuando el equipo de soporte lo solicite expresamente; puede contener información empresarial confidencial.",
+    "bundleCredentialsTitle": "Los campos de credenciales conocidos se ocultan",
+    "bundleCredentialsBody": "Las claves de API, los tokens y otros valores secretos reconocidos se ocultan antes de crear el paquete.",
+    "bundleConfirm": "Generar y descargar",
+    "bundleCancel": "Cancelar",
+    "bundleFailed": "No se pudo descargar el paquete de soporte",
+    "bundleReady": "Paquete de soporte descargado"
+  },
   "usageLogs": {
     "usage": {
       "title": "Uso",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -1871,6 +1871,34 @@
       "awaitingReview": "en attente d'examen"
     }
   },
+  "monitorSupport": {
+    "title": "Assistance et diagnostic",
+    "menuLabel": "Actions d’assistance et de diagnostic",
+    "copyReport": "Copier le rapport d’état actuel",
+    "copyReportDescription": "Partager l’état actuel de la connexion, de la configuration et de l’exécution",
+    "copySuccess": "Rapport d’état copié",
+    "copyFailed": "Impossible de copier le rapport d’état : {error}",
+    "downloadBundle": "Télécharger le paquet d’assistance expurgé",
+    "downloadBundleDescription": "Inclut les journaux, un résumé de la configuration et les résultats du diagnostic",
+    "privacySummary": "Le contenu des conversations est exclu par défaut et les identifiants connus sont masqués",
+    "bundleTitle": "Télécharger le paquet d’assistance expurgé",
+    "bundleSubtitle": "Créez un fichier ZIP à partager avec l’assistance OpenSquilla.",
+    "bundleDefaultIncludes": "Inclus par défaut",
+    "bundleReadiness": "Instantané de l’état de préparation et du diagnostic",
+    "bundleConfig": "Résumé expurgé de la configuration",
+    "bundleLogs": "Erreurs, journaux et informations de trace",
+    "bundlePlatform": "Informations de version et de plateforme",
+    "bundleScopeTitle": "Enregistrements de diagnostic récents (1 jour maximum)",
+    "bundleScopeBody": "Les erreurs et les traces couvrent au maximum un jour ; les journaux d’exécution suivent la rotation locale, la période réelle peut donc différer.",
+    "bundleIncludeContentTitle": "Inclure le contenu des conversations",
+    "bundleIncludeContentBody": "Activez cette option uniquement à la demande explicite de l’assistance ; elle peut inclure des informations professionnelles sensibles.",
+    "bundleCredentialsTitle": "Les champs d’identifiants connus sont masqués",
+    "bundleCredentialsBody": "Les clés API, les jetons et les autres valeurs secrètes reconnues sont masqués avant la création du paquet.",
+    "bundleConfirm": "Générer et télécharger",
+    "bundleCancel": "Annuler",
+    "bundleFailed": "Échec du téléchargement du paquet d’assistance",
+    "bundleReady": "Paquet d’assistance téléchargé"
+  },
   "usageLogs": {
     "usage": {
       "title": "Utilisation",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -1871,6 +1871,34 @@
       "awaitingReview": "レビュー待ち"
     }
   },
+  "monitorSupport": {
+    "title": "サポートと診断",
+    "menuLabel": "サポートと診断の操作",
+    "copyReport": "現在の準備状況レポートをコピー",
+    "copyReportDescription": "現在の接続、設定、実行状態を共有します",
+    "copySuccess": "準備状況レポートをコピーしました",
+    "copyFailed": "準備状況レポートをコピーできませんでした：{error}",
+    "downloadBundle": "機密情報を除去したサポートバンドルをダウンロード",
+    "downloadBundleDescription": "ログ、設定の要約、診断結果が含まれます",
+    "privacySummary": "会話内容はデフォルトで除外され、既知の認証情報は除去されます",
+    "bundleTitle": "機密情報を除去したサポートバンドルをダウンロード",
+    "bundleSubtitle": "OpenSquilla サポートと共有するための ZIP ファイルを作成します。",
+    "bundleDefaultIncludes": "デフォルトで含まれるもの",
+    "bundleReadiness": "準備状況と診断のスナップショット",
+    "bundleConfig": "機密情報を除去した設定の要約",
+    "bundleLogs": "エラー、ログ、トレース情報",
+    "bundlePlatform": "バージョンとプラットフォーム情報",
+    "bundleScopeTitle": "最近の診断記録（最大 1 日）",
+    "bundleScopeBody": "エラーとトレースの記録は最大 1 日分です。実行ログはローカルのローテーションに従うため、実際の対象期間は異なる場合があります。",
+    "bundleIncludeContentTitle": "会話内容を含める",
+    "bundleIncludeContentBody": "サポートから明示的に依頼された場合のみ有効にしてください。機密性の高い業務情報が含まれる可能性があります。",
+    "bundleCredentialsTitle": "既知の認証情報フィールドは除去されます",
+    "bundleCredentialsBody": "API キー、トークン、その他の認識された機密情報の値は、パッケージ化の前にマスキングされます。",
+    "bundleConfirm": "生成してダウンロード",
+    "bundleCancel": "キャンセル",
+    "bundleFailed": "サポートバンドルをダウンロードできませんでした",
+    "bundleReady": "サポートバンドルをダウンロードしました"
+  },
   "usageLogs": {
     "usage": {
       "title": "使用量",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -1871,6 +1871,34 @@
       "awaitingReview": "等待审阅"
     }
   },
+  "monitorSupport": {
+    "title": "支持与诊断",
+    "menuLabel": "支持与诊断操作",
+    "copyReport": "复制当前就绪报告",
+    "copyReportDescription": "用于快速排查当前连接、配置与运行状态",
+    "copySuccess": "当前就绪报告已复制",
+    "copyFailed": "复制就绪报告失败：{error}",
+    "downloadBundle": "下载脱敏支持包",
+    "downloadBundleDescription": "包含日志、配置摘要与诊断结果，可提交给支持人员",
+    "privacySummary": "默认不包含会话正文，已知凭据字段会脱敏",
+    "bundleTitle": "下载脱敏支持包",
+    "bundleSubtitle": "创建可与 OpenSquilla 支持人员分享的 ZIP 文件。",
+    "bundleDefaultIncludes": "默认包含",
+    "bundleReadiness": "就绪与诊断快照",
+    "bundleConfig": "脱敏后的配置摘要",
+    "bundleLogs": "错误、日志与 trace 信息",
+    "bundlePlatform": "版本与平台信息",
+    "bundleScopeTitle": "近期诊断记录（最多 1 天）",
+    "bundleScopeBody": "错误与追踪记录最多包含 1 天；运行日志按本地轮转收集，实际覆盖时间可能不同。",
+    "bundleIncludeContentTitle": "包含会话正文",
+    "bundleIncludeContentBody": "仅在支持人员明确要求时开启；可能含有敏感业务信息。",
+    "bundleCredentialsTitle": "已知凭据字段会脱敏",
+    "bundleCredentialsBody": "API 密钥、令牌和其他已识别的密钥值会在打包前脱敏。",
+    "bundleConfirm": "生成并下载",
+    "bundleCancel": "取消",
+    "bundleFailed": "支持包下载失败",
+    "bundleReady": "支持包已下载"
+  },
   "usageLogs": {
     "usage": {
       "title": "用量",

--- a/opensquilla-webui/src/views/LogsView.vue
+++ b/opensquilla-webui/src/views/LogsView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="lg-stage control-stage">
-    <header class="control-stage__header">
+    <header v-if="showStatusNotice" class="control-stage__header">
       <div class="control-stage__title-block">
         <span class="control-panel__eyebrow">{{ t('usageLogs.logs.eyebrow') }}</span>
         <h1 class="control-stage__title">{{ t('usageLogs.logs.title') }}</h1>
@@ -41,14 +41,6 @@
           :aria-label="`${t('usageLogs.logs.fileLogOff')}. ${fileLogTitleText}`"
           :title="fileLogTitleText"
         >{{ t('usageLogs.logs.fileLogOff') }}</span>
-        <button
-          class="btn btn--ghost"
-          :title="t('usageLogs.logs.bundleButtonTitle')"
-          @click="bundleDialogOpen = true"
-        >
-          <Icon name="download" :size="16" />
-          <span>{{ t('usageLogs.logs.bundleButton') }}</span>
-        </button>
       </div>
     </header>
 
@@ -174,12 +166,6 @@
       </aside>
     </div>
     </Transition>
-
-    <DiagnosticsBundleDialog
-      :open="bundleDialogOpen"
-      @close="bundleDialogOpen = false"
-      @confirm="downloadBundle"
-    />
   </div>
 </template>
 
@@ -188,11 +174,8 @@ import { ref, computed, onMounted, onUnmounted, onActivated, onDeactivated, watc
 import { useI18n } from 'vue-i18n'
 import { useRpcStore } from '@/stores/rpc'
 import { useFixedWindow } from '@/composables/useFixedWindow'
-import { useToasts } from '@/composables/useToasts'
-import { downloadBlob, filenameFromContentDisposition } from '@/utils/browser'
 import Icon from '@/components/Icon.vue'
 import ControlSwitch from '@/components/ControlSwitch.vue'
-import DiagnosticsBundleDialog from '@/components/DiagnosticsBundleDialog.vue'
 import RunTrace from '@/components/run/RunTrace.vue'
 import { useRunTrace } from '@/composables/run/useRunTrace'
 import { nodeStepsFromHistoryMessage } from '@/components/run/runTrace'
@@ -264,9 +247,6 @@ const WINDOW_MIN_WIDTH = '(min-width: 481px)'
 
 const { t } = useI18n()
 const rpc = useRpcStore()
-const { pushToast } = useToasts()
-const bundleDialogOpen = ref(false)
-const bundleInFlight = ref(false)
 const allLines = ref<LogLine[]>([])
 const cursor = ref(0)
 const searchText = ref('')
@@ -355,6 +335,12 @@ const rawLabel = computed(() =>
 
 const rawTitleText = computed(() =>
   t('usageLogs.logs.rawTitle', { source: rawSource.value, path: rawPath.value }))
+
+// The monitor hub hides this view's repeated title block. Once logging is in
+// its normal state there is no local action left to render, so omit the empty
+// header instead of leaving a blank toolbar row above the filters.
+const showStatusNotice = computed(() =>
+  !status.value || rawLogEnabled.value || !fileLogEnabled.value)
 
 // A run-bearing line carries structured tool_calls in its raw JSON payload; the
 // drawer renders those as a trace, falling back to the raw text otherwise.
@@ -536,41 +522,6 @@ function toggleLevel(level: string) {
     next.add(level)
   }
   activeLevels.value = next
-}
-
-async function downloadBundle(options: { includeContent: boolean }) {
-  bundleDialogOpen.value = false
-  if (bundleInFlight.value) return
-  bundleInFlight.value = true
-  try {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-    // Same-key Bearer auth as the approvals REST calls; sessionStorage access
-    // can throw in hardened/embedded contexts, so it is guarded.
-    let token = ''
-    try { token = sessionStorage.getItem('opensquilla.wsToken') || '' } catch {}
-    if (token) headers['Authorization'] = `Bearer ${token}`
-    const response = await fetch('/api/v1/diagnostics/bundle', {
-      method: 'POST',
-      headers,
-      credentials: 'same-origin',
-      // The gateway strict-checks `include_content is True`, so this must be a
-      // real JSON boolean — never a string.
-      body: JSON.stringify({ include_content: options.includeContent }),
-    })
-    if (!response.ok) {
-      pushToast(t('usageLogs.logs.bundleFailed'), { tone: 'danger' })
-      return
-    }
-    const blob = await response.blob()
-    const disposition = response.headers.get('content-disposition')
-    const filename = filenameFromContentDisposition(disposition) || 'opensquilla-bundle.zip'
-    downloadBlob(blob, filename)
-    pushToast(t('usageLogs.logs.bundleReady'), { tone: 'ok' })
-  } catch {
-    pushToast(t('usageLogs.logs.bundleFailed'), { tone: 'danger' })
-  } finally {
-    bundleInFlight.value = false
-  }
 }
 
 function openDetail(line: LogLine) {

--- a/opensquilla-webui/src/views/MonitorHubView.vue
+++ b/opensquilla-webui/src/views/MonitorHubView.vue
@@ -3,27 +3,30 @@
     <!-- One Monitor destination, four sections. Each former page keeps its full
          UI and its canonical URL: the tabs ARE the routes, so /usage and /logs
          deep links stay valid and the palette can target a specific section. -->
-    <nav class="monitor-hub__tabs" role="tablist" :aria-label="t('nav.groupMonitor')">
-      <router-link
-        v-for="tab in TABS"
-        :key="tab.path"
-        :to="tab.path"
-        custom
-        v-slot="{ navigate }"
-      >
-        <button
-          role="tab"
-          class="monitor-hub__tab"
-          :class="{ 'is-active': isActive(tab.path) }"
-          :aria-selected="isActive(tab.path)"
-          aria-controls="monitor-hub-panel"
-          @click="navigate"
+    <div class="monitor-hub__bar">
+      <nav class="monitor-hub__tabs" role="tablist" :aria-label="t('nav.groupMonitor')">
+        <router-link
+          v-for="tab in TABS"
+          :key="tab.path"
+          :to="tab.path"
+          custom
+          v-slot="{ navigate }"
         >
-          <Icon :name="tab.icon" :size="14" />
-          <span>{{ t(tab.label) }}</span>
-        </button>
-      </router-link>
-    </nav>
+          <button
+            role="tab"
+            class="monitor-hub__tab"
+            :class="{ 'is-active': isActive(tab.path) }"
+            :aria-selected="isActive(tab.path)"
+            aria-controls="monitor-hub-panel"
+            @click="navigate"
+          >
+            <Icon :name="tab.icon" :size="14" />
+            <span>{{ t(tab.label) }}</span>
+          </button>
+        </router-link>
+      </nav>
+      <SupportDiagnosticsMenu />
+    </div>
     <div id="monitor-hub-panel" role="tabpanel" class="monitor-hub__panel">
       <KeepAlive :max="4">
         <component :is="activeComponent" />
@@ -37,6 +40,7 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/Icon.vue'
+import SupportDiagnosticsMenu from '@/components/SupportDiagnosticsMenu.vue'
 import type { IconName } from '@/utils/icons'
 import OverviewView from '@/views/OverviewView.vue'
 import ChannelsView from '@/views/ChannelsView.vue'
@@ -70,10 +74,19 @@ const activeComponent = computed(() => {
   gap: var(--sp-4);
 }
 
+.monitor-hub__bar {
+  align-items: flex-start;
+  display: flex;
+  gap: var(--sp-3);
+  justify-content: space-between;
+  min-width: 0;
+}
+
 .monitor-hub__tabs {
   display: flex;
   gap: 2px;
-  align-self: flex-start;
+  flex: 0 1 auto;
+  min-width: 0;
   max-width: 100%;
   padding: 3px;
   background: var(--bg-surface-2);
@@ -137,5 +150,11 @@ const activeComponent = computed(() => {
 }
 .monitor-hub :deep(.control-stage__header) {
   justify-content: flex-end;
+}
+
+@media (max-width: 600px) {
+  .monitor-hub__bar {
+    align-items: center;
+  }
 }
 </style>

--- a/opensquilla-webui/src/views/OverviewView.diagnostics.test.ts
+++ b/opensquilla-webui/src/views/OverviewView.diagnostics.test.ts
@@ -2,10 +2,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
 
-// Mounted coverage for the Overview diagnostics actions: the copy-JSON
-// button, the conditional "diagnose with agent" hand-off, finding→settings
-// deep links, and the active-provider latency readout (with null guards for
-// backends that predate the latency field).
+// Mounted coverage for the Overview diagnostics actions: the conditional
+// "diagnose with agent" hand-off, finding→settings deep links, and the
+// active-provider latency readout (with null guards for older gateways).
 
 interface MountOptions {
   report?: Record<string, unknown> | null
@@ -173,7 +172,6 @@ afterEach(() => {
 // The buttons carry resolved translations in their title attributes; the
 // suite pins locale 'en' in mountOverview, so select by the en strings.
 const DIAGNOSE_SELECTOR = '[title="Diagnose with agent"]'
-const COPY_JSON_SELECTOR = '[title="Copy diagnostics JSON"]'
 
 describe('OverviewView diagnose-with-agent hand-off', () => {
   it('shows the button and routes a sanitized, escaped report into a new chat', async () => {
@@ -392,42 +390,6 @@ describe('OverviewView recovery activation copy', () => {
   })
 })
 
-describe('OverviewView copy diagnostics JSON', () => {
-  it('copies the normalized report with gatewayUrl and copiedAt attached', async () => {
-    const { el, copyText, pushToast, flush } = await mountOverview()
-    const button = el.querySelector<HTMLButtonElement>(COPY_JSON_SELECTOR)
-    expect(button).toBeTruthy()
-
-    button!.click()
-    await flush()
-
-    expect(copyText).toHaveBeenCalledTimes(1)
-    const text = copyText.mock.calls[0][0]
-    expect(text).not.toContain('dummyuser')
-    const parsed = JSON.parse(text) as Record<string, unknown>
-    expect(parsed.gatewayUrl).toBe('ws://127.0.0.1:18791/ws')
-    expect(parsed.configPath).toBe('~/dir/opensquilla.toml')
-    expect(typeof parsed.copiedAt).toBe('string')
-    expect(Number.isNaN(Date.parse(String(parsed.copiedAt)))).toBe(false)
-    expect(pushToast).toHaveBeenCalledWith('Diagnostics JSON copied', { tone: 'ok' })
-  })
-
-  it('disables the button when the doctor report is unavailable', async () => {
-    const { el, copyText, pushToast, flush } = await mountOverview({ report: null })
-    const button = el.querySelector<HTMLButtonElement>(COPY_JSON_SELECTOR)
-    expect(button).toBeTruthy()
-    expect(button!.disabled).toBe(true)
-    // The diagnose hand-off is hidden without a live report too.
-    expect(el.querySelector(DIAGNOSE_SELECTOR)).toBeNull()
-
-    // Even a forced click copies nothing and shows no success toast.
-    button!.click()
-    await flush()
-    expect(copyText).not.toHaveBeenCalled()
-    expect(pushToast).not.toHaveBeenCalled()
-  })
-})
-
 describe('OverviewView finding settings links', () => {
   it('links mapped surfaces to their settings section and skips the rest', async () => {
     const report = baseReport()
@@ -523,7 +485,7 @@ describe('OverviewView provider latency line', () => {
     expect(el.querySelector('.ov-readout__latency')).toBeNull()
     // The rest of the overview still rendered.
     expect(el.querySelector('.ov-statusline')).toBeTruthy()
-    expect(el.querySelector(COPY_JSON_SELECTOR)).toBeTruthy()
+    expect(el.querySelector(DIAGNOSE_SELECTOR)).toBeTruthy()
   })
 
   it('fetches providers.status on mount only, not on health reruns', async () => {

--- a/opensquilla-webui/src/views/OverviewView.vue
+++ b/opensquilla-webui/src/views/OverviewView.vue
@@ -39,16 +39,6 @@
           <Icon name="refresh" :size="16" />
           <span>{{ refreshing ? t('sessions.refreshing') : t('sessions.refresh') }}</span>
         </button>
-        <button
-          class="btn btn--ghost"
-          type="button"
-          :title="t('sessions.overview.copyDiagnostics')"
-          :disabled="healthLoading || !healthReport"
-          @click="copyDiagnostics"
-        >
-          <Icon :name="copiedCommandKey === DIAGNOSTICS_COPY_KEY ? 'check' : 'copy'" :size="16" />
-          <span>{{ t('sessions.overview.copyDiagnostics') }}</span>
-        </button>
         <button class="btn btn--primary" :title="t('sessions.overview.openChat')" @click="router.push('/chat')">
           <Icon name="chat" :size="16" />
           <span>{{ t('sessions.overview.openChat') }}</span>
@@ -764,7 +754,7 @@ function normalizedFixSteps(finding: Finding): Array<{ label: string; command?: 
   }))
 }
 
-// Shared check-icon swap (1600ms) for the command and diagnostics copies.
+// Shared check-icon swap (1600ms) for copyable environment commands.
 function markCopied(key: string) {
   copiedCommandKey.value = key
   clearCopiedCommandTimer()
@@ -780,31 +770,6 @@ async function copyCommand(command: string, key: string) {
     await copyTextWithFallback(command)
     markCopied(key)
     pushToast(t('setup.toast.copiedCommand'), { tone: 'ok' })
-  } catch (err) {
-    clearCopiedCommandTimer()
-    copiedCommandKey.value = ''
-    const error = err instanceof Error ? err.message : String(err)
-    pushToast(t('setup.toast.copyFailed', { error }), { tone: 'danger' })
-  }
-}
-
-const DIAGNOSTICS_COPY_KEY = 'diagnostics-json'
-
-// Full doctor report as pretty JSON for bug reports, with the gateway URL and
-// a copy timestamp attached and local home directories collapsed to `~/`.
-async function copyDiagnostics() {
-  // No live report (doctor failed or still loading) means nothing worth
-  // pasting into a bug report; the button is disabled in that state too.
-  if (!healthReport.value) return
-  const report = {
-    ...healthReport.value,
-    gatewayUrl: healthReport.value.gatewayUrl || gatewayContextUrl(),
-    copiedAt: new Date().toISOString(),
-  }
-  try {
-    await copyTextWithFallback(normalizeHomePaths(JSON.stringify(report, null, 2)))
-    markCopied(DIAGNOSTICS_COPY_KEY)
-    pushToast(t('sessions.overview.copiedDiagnostics'), { tone: 'ok' })
   } catch (err) {
     clearCopiedCommandTimer()
     copiedCommandKey.value = ''


### PR DESCRIPTION
## Scope

- add one shared **Support & diagnostics** menu across Overview, Channels, Usage, and Logs
- move readiness-report copying and redacted support-bundle generation into the shared menu
- remove the duplicate Overview and Logs actions
- make support-bundle scope explicit: diagnostic records cover at most one day, while runtime-log coverage follows local rotation
- keep conversation content opt-in and reset the choice whenever the dialog opens
- add keyboard/focus handling, responsive dialog behavior, six-locale copy, and regression coverage

## Why

Diagnostics actions were owned by individual monitor views. That split produced duplicate entry points, separated closely related support tasks, and left the WebUI request without an explicit time scope. The shared monitor-level entry keeps the actions discoverable without changing the existing routes or backend contract.

## User impact

Operators get one consistent support entry on every monitor tab. The support bundle request now explicitly sends `days: 1`, and the dialog accurately describes privacy and local log-rotation limits.

## Validation

- `npm run typecheck`
- `npm run test:unit` — 125 files, 1304 tests passed
- `npm run build` — production artifact verified, 157 files
- `uv run pytest tests/test_gateway/test_bundle_routes.py tests/test_observability/test_bundle.py -q` — 24 passed
- live clean-profile WebUI and gateway validation, including desktop and narrow layouts and an HTTP 200 bundle response
- `git diff --check`

## Safety and compatibility

- conversation content remains excluded by default and the opt-in resets on every open
- copy only claims redaction for recognized credential fields and secret values
- WebUI-only, platform-neutral change
- no persisted configuration, database state, public RPC/REST fields, or client compatibility contract changed

## Project metadata

- Target branch: `main`
- Linked issue: None
- Release note: Not required — focused WebUI support-flow correction
- Third-party code or assets: None
