### PR TITLE
Limit search fallback and terminal retries

### DIFF
--- a/docs/features/bocha-search-provider-design.md
+++ b/docs/features/bocha-search-provider-design.md
@@ -105,16 +105,21 @@ Rationale:
 
 Keep fallback semantics narrow:
 
-- `off`: surface the original provider error.
-- `network`: fallback only after network, timeout, rate-limit, retryable, or HTTP
-  provider errors.
+- `off`: send at most one provider network request and surface its error;
+  automatic routing may skip a missing-key candidate before any request.
+- `network`: after a provider-classified transient failure, try at most one
+  additional compatible provider. Automatic routing prefers the next ranked
+  provider with configured credentials and uses DuckDuckGo when no keyed
+  fallback is available.
 
 Do not fallback on:
 
 - empty results
 - low-quality results
-- parse errors, unless those are explicitly classified as retryable provider
-  failures later
+- authentication or missing-key errors
+- ordinary 4xx responses
+- blocked/challenge responses
+- parse errors
 
 This preserves cost, latency, and predictability for users who configured
 multiple paid providers.

--- a/docs/search.md
+++ b/docs/search.md
@@ -78,9 +78,14 @@ It identifies the provider tied to `search_api_key` and
 `search_api_key_env`; automatic searches without `--provider` still rank all
 available providers by mode, recency needs, and provider capabilities. Use
 `search_api_key_env` for an environment-variable reference, or paste a one-time
-key through onboarding. `search_fallback_policy = "network"` retries through
-DuckDuckGo only after network/timeout errors, while `search_diagnostics = true`
-includes provider-attempt details in tool results.
+key through onboarding. `search_fallback_policy = "network"` permits at most one
+additional compatible provider after a transient failure. Automatic searches
+prefer the next ranked provider with configured credentials and use DuckDuckGo
+when no keyed fallback is available. Each provider is called at most once per
+search. With `off`, automatic routing may skip a locally detected missing-key
+candidate, but it still sends at most one provider network request and never
+switches after a network failure. `search_diagnostics = true` includes
+provider-attempt details in tool results.
 
 Configuration matrix:
 

--- a/src/opensquilla/execution_status.py
+++ b/src/opensquilla/execution_status.py
@@ -6,6 +6,8 @@ import json
 import re
 from typing import Any, Literal, TypedDict
 
+from opensquilla.search_tool_outcome import parse_web_tool_outcome
+
 ExecutionStatusValue = Literal["success", "error", "timeout", "cancelled", "unknown"]
 ExecutionStatusSource = Literal["tool_runtime", "adapter", "replay", "legacy", "unknown"]
 ExecutionStatusPreservation = Literal[
@@ -148,6 +150,20 @@ def compact_provider_status(status: Any) -> dict[str, Any]:
 
 def execution_status_for_tool_result(tool_name: str, content: Any) -> ExecutionStatus | None:
     """Map trusted built-in tool payloads to canonical execution status."""
+
+    web_outcome = parse_web_tool_outcome(tool_name, content)
+    if web_outcome is not None:
+        timed_out = web_outcome.error_kind == "timeout"
+        return {
+            "version": 1,
+            "status": "timeout" if timed_out else "error",
+            "exit_code": None,
+            "timed_out": timed_out,
+            "truncated": False,
+            "reason": f"search_{web_outcome.error_kind}",
+            "source": "adapter",
+            "preservation_class": "diagnostic",
+        }
 
     if not isinstance(content, str):
         return None

--- a/src/opensquilla/gateway/rpc_tools.py
+++ b/src/opensquilla/gateway/rpc_tools.py
@@ -10,6 +10,7 @@ from opensquilla.gateway.rpc import RpcContext, get_dispatcher
 from opensquilla.sandbox.integration import run_in_process_network_action
 from opensquilla.sandbox.types import DenialResult
 from opensquilla.tools.builtin.web import (
+    _search_plan_argv_token,
     get_active_provider,
     search_runtime_status,
 )
@@ -306,7 +307,15 @@ async def _handle_search_query(params: dict | None, ctx: RpcContext) -> dict[str
 
     payload_or_denial = await run_in_process_network_action(
         action_kind="web.fetch",
-        argv=("web_search", query, str(limit or "")),
+        argv=(
+            "web_search",
+            query,
+            str(limit or ""),
+            _search_plan_argv_token(
+                {"query": query, "provider": provider_name},
+                tool_name="web_discover",
+            ),
+        ),
         callback=_run_search,
     )
     if isinstance(payload_or_denial, DenialResult):
@@ -316,6 +325,7 @@ async def _handle_search_query(params: dict | None, ctx: RpcContext) -> dict[str
             "query": query,
             "provider": provider_name or get_active_provider(),
             "results": [],
+            "retry_allowed": False,
             "error": {
                 "kind": denial.reason.value,
                 "class": "SandboxDenied",
@@ -350,6 +360,7 @@ async def _handle_search_query(params: dict | None, ctx: RpcContext) -> dict[str
         "query": payload.get("query", query),
         "provider": payload.get("provider", provider_name or get_active_provider()),
         "results": payload.get("results", []),
+        "retry_allowed": False,
         "error": error,
     }
     if payload.get("attempts") is not None:

--- a/src/opensquilla/onboarding/search_specs.py
+++ b/src/opensquilla/onboarding/search_specs.py
@@ -98,8 +98,10 @@ def _fields_for(spec: SearchProviderSpec) -> tuple[SearchProviderSetupField, ...
             default="off",
             choices=("off", "network"),
             description=(
-                "network retries with DuckDuckGo only after timeout/network errors; "
-                "off surfaces the original provider error."
+                "network tries at most one additional configured, compatible provider "
+                "after a transient failure, using DuckDuckGo when no keyed fallback is "
+                "available; off sends at most one provider request and never switches "
+                "after a network failure."
             ),
         ),
         SearchProviderSetupField(

--- a/src/opensquilla/result_budget.py
+++ b/src/opensquilla/result_budget.py
@@ -20,6 +20,11 @@ from enum import StrEnum
 from typing import Any, TypeGuard
 
 from opensquilla.search.normalize import canonicalize_query_key
+from opensquilla.search_tool_outcome import (
+    WebRetrievalSemanticKey,
+    parse_web_tool_outcome,
+    web_retrieval_semantic_key,
+)
 
 WEB_FETCH_MIN_MAX_CHARS = 100
 WEB_SEARCH_MIN_MAX_CHARS_PER_SOURCE = 200
@@ -193,6 +198,28 @@ class ToolRunBudgetExceededError(RuntimeError):
         self.tool_name = tool_name
 
 
+class DuplicateRetrievalInFlightError(RuntimeError):
+    """Raised when the same semantic search is already executing this turn."""
+
+    def __init__(self, tool_name: str) -> None:
+        super().__init__(
+            f"Tool '{tool_name}' skipped a duplicate retrieval already in flight."
+        )
+        self.tool_name = tool_name
+
+
+class TerminalRetrievalReplayError(RuntimeError):
+    """Raised when a semantic search already ended in a terminal failure."""
+
+    def __init__(self, tool_name: str, *, error_kind: str) -> None:
+        super().__init__(
+            f"Tool '{tool_name}' skipped a retrieval that already failed "
+            "without retry permission this turn."
+        )
+        self.tool_name = tool_name
+        self.error_kind = error_kind
+
+
 @dataclass(frozen=True)
 class ToolRunBudgetReservation:
     tool_name: str
@@ -202,6 +229,7 @@ class ToolRunBudgetReservation:
     counted_as_search: bool = False
     counted_as_external_text: bool = False
     retrieval_key: RetrievalKey | None = None
+    semantic_retrieval_key: WebRetrievalSemanticKey | None = None
 
 
 class ToolRunBudgetTracker:
@@ -215,6 +243,8 @@ class ToolRunBudgetTracker:
         self._external_text_chars_used = 0
         self._external_text_chars_reserved = 0
         self._retrieval_keys_used: dict[RetrievalKey, int] = {}
+        self._inflight_retrieval_keys: set[WebRetrievalSemanticKey] = set()
+        self._terminal_retrieval_keys: dict[WebRetrievalSemanticKey, str] = {}
 
     async def reserve_tool_call(
         self,
@@ -225,6 +255,15 @@ class ToolRunBudgetTracker:
         args = dict(arguments)
         if tool_name in {"web_search", "web_discover"}:
             async with self._lock:
+                semantic_key = web_retrieval_semantic_key(args)
+                terminal_error_kind = self._terminal_retrieval_keys.get(semantic_key)
+                if terminal_error_kind is not None:
+                    raise TerminalRetrievalReplayError(
+                        tool_name,
+                        error_kind=terminal_error_kind,
+                    )
+                if semantic_key in self._inflight_retrieval_keys:
+                    raise DuplicateRetrievalInFlightError(tool_name)
                 self._check_call_budget(
                     tool_name=tool_name,
                     used=self._web_search_calls_used,
@@ -232,6 +271,7 @@ class ToolRunBudgetTracker:
                 )
                 self._check_external_text_available(tool_name)
                 retrieval_key = self._reserve_retrieval_key(tool_name, args)
+                self._inflight_retrieval_keys.add(semantic_key)
                 self._web_search_calls_used += 1
             return ToolRunBudgetReservation(
                 tool_name=tool_name,
@@ -239,6 +279,7 @@ class ToolRunBudgetTracker:
                 counted_as_search=True,
                 counted_as_external_text=True,
                 retrieval_key=retrieval_key,
+                semantic_retrieval_key=semantic_key,
             )
 
         if tool_name not in EXTERNAL_TOOL_NAMES:
@@ -268,9 +309,15 @@ class ToolRunBudgetTracker:
         if not reservation.counted_as_external_text:
             return
         text = content if isinstance(content, str) else str(content)
+        web_outcome = parse_web_tool_outcome(reservation.tool_name, content)
         async with self._lock:
             self._release_external_reservation(reservation)
             self._external_text_chars_used += len(text)
+            semantic_key = reservation.semantic_retrieval_key
+            if semantic_key is not None:
+                self._inflight_retrieval_keys.discard(semantic_key)
+                if web_outcome is not None and web_outcome.retry_allowed is False:
+                    self._terminal_retrieval_keys[semantic_key] = web_outcome.error_kind
 
     async def abort_tool_result(self, reservation: ToolRunBudgetReservation) -> None:
         if (
@@ -281,6 +328,10 @@ class ToolRunBudgetTracker:
             return
         async with self._lock:
             self._release_external_reservation(reservation)
+            if reservation.semantic_retrieval_key is not None:
+                self._inflight_retrieval_keys.discard(
+                    reservation.semantic_retrieval_key
+                )
             if reservation.counted_as_fetch:
                 self._web_fetch_calls_used = max(0, self._web_fetch_calls_used - 1)
             if reservation.counted_as_search and reservation.tool_name in {

--- a/src/opensquilla/sandbox/integration.py
+++ b/src/opensquilla/sandbox/integration.py
@@ -1759,8 +1759,16 @@ def _is_in_process_network_action(action_kind: str) -> bool:
 
 def _system_domain_grants_for_request(request: SandboxRequest) -> tuple[str, ...]:
     tool_name = request.argv[0] if request.argv else ""
-    if tool_name != "web_search":
+    if tool_name not in {"web_search", "web_discover"}:
         return ()
+    planned_providers = _search_plan_providers_from_argv(request.argv)
+    if planned_providers is not None:
+        planned_domains: list[str] = []
+        for provider in planned_providers:
+            for domain in _SEARCH_PROVIDER_SYSTEM_DOMAINS.get(provider, ()):
+                if domain not in planned_domains:
+                    planned_domains.append(domain)
+        return tuple(planned_domains)
     try:
         from opensquilla.tools.builtin.web import (
             get_active_provider,
@@ -1781,6 +1789,19 @@ def _system_domain_grants_for_request(request: SandboxRequest) -> tuple[str, ...
             if domain not in domains:
                 domains.append(domain)
     return tuple(domains)
+
+
+def _search_plan_providers_from_argv(argv: tuple[str, ...]) -> tuple[str, ...] | None:
+    for value in argv[1:]:
+        if not value.startswith("providers="):
+            continue
+        providers: list[str] = []
+        for provider in value.removeprefix("providers=").split(","):
+            normalized = provider.strip().lower()
+            if normalized and normalized not in providers:
+                providers.append(normalized)
+        return tuple(providers)
+    return None
 
 
 def _context_with_system_domain_grants(

--- a/src/opensquilla/search/canonical.py
+++ b/src/opensquilla/search/canonical.py
@@ -12,6 +12,8 @@ from dataclasses import asdict, replace
 from typing import Any, cast
 from urllib.parse import urlsplit, urlunsplit
 
+import httpx
+
 from opensquilla.search.normalize import (
     canonicalize_query_key,
     canonicalize_url,
@@ -24,6 +26,7 @@ from opensquilla.search.runtime_config import (
 )
 from opensquilla.search.types import (
     SearchDiagnostics,
+    SearchExecutionPlan,
     SearchHit,
     SearchOptions,
     SearchProvider,
@@ -67,17 +70,20 @@ async def run_canonical_web_search(
             diagnostics,
             error_kind="invalid_request",
             error="Search query must not be empty.",
+            provider_retryable=False,
+            error_class="ValueError",
         )
 
     resolved_runtime = runtime or get_resolved_search_runtime()
-    provider_names = resolved_runtime.provider_order(options)
+    execution_plan = resolved_runtime.execution_plan(options)
+    provider_names = execution_plan.provider_names
 
     cache_enabled = (
         runtime is None and provider_factory is None
         if use_cache is None
         else use_cache
     )
-    cache_key = _cache_key(options, provider_names)
+    cache_key = _cache_key(options, execution_plan)
     if cache_enabled:
         diagnostics.cache_status = "miss"
         cached_payload = _get_cached_payload(cache_key)
@@ -89,10 +95,9 @@ async def run_canonical_web_search(
     factory = provider_factory or resolved_runtime.build_provider
     selected_provider = ""
     raw_results: list[SearchResult] = []
-    terminal_error: Exception | None = None
     explicit_provider = options.provider is not None
 
-    for provider_name in provider_names:
+    for attempt_index, provider_name in enumerate(provider_names):
         try:
             provider = factory(provider_name)
             search_options, recency_supported, recency_degraded = (
@@ -103,13 +108,13 @@ async def run_canonical_web_search(
             )
             raw_results = await _search_provider(provider, search_options)
         except Exception as exc:  # noqa: BLE001 - orchestrator converts provider failures to payloads
-            terminal_error = exc
             search_error = _coerce_search_error(provider_name, exc)
             diagnostics.provider_attempts.append(
                 _provider_error_attempt(provider_name, search_error)
             )
 
-            if resolved_runtime.should_fallback(
+            has_next_provider = attempt_index + 1 < len(provider_names)
+            if has_next_provider and resolved_runtime.should_fallback(
                 search_error,
                 explicit_provider=explicit_provider,
             ):
@@ -120,6 +125,8 @@ async def run_canonical_web_search(
                 diagnostics,
                 error_kind=search_error.kind,
                 error=_public_error_message(provider_name, search_error.kind),
+                provider_retryable=search_error.retryable,
+                error_class=type(exc).__name__,
             )
 
         selected_provider = provider_name
@@ -130,14 +137,16 @@ async def run_canonical_web_search(
 
     if not selected_provider:
         search_error = _coerce_search_error(
-            provider_names[-1] if provider_names else "unknown",
-            terminal_error or RuntimeError("No search provider succeeded."),
+            "unknown",
+            RuntimeError("No search provider is available."),
         )
         return _failure_payload(
             options,
             diagnostics,
             error_kind=search_error.kind,
             error=_public_error_message(search_error.provider, search_error.kind),
+            provider_retryable=False,
+            error_class="RuntimeError",
         )
 
     diagnostics.selected_provider = selected_provider
@@ -262,13 +271,18 @@ async def _default_fetcher(url: str, max_chars: int) -> dict[str, Any]:
     )
 
 
-def _cache_key(options: SearchOptions, provider_names: tuple[str, ...]) -> tuple[Any, ...]:
+def _cache_key(
+    options: SearchOptions,
+    execution_plan: SearchExecutionPlan,
+) -> tuple[Any, ...]:
     return (
         canonicalize_query_key(options.query),
         options.provider or "auto",
         options.mode,
         options.recency or "",
-        provider_names,
+        execution_plan.provider_names,
+        execution_plan.selection_mode,
+        execution_plan.fallback_mode,
         options.max_results,
         options.fetch_top_k,
         options.max_chars_per_source,
@@ -302,6 +316,20 @@ def _provider_order(options: SearchOptions) -> tuple[str, ...]:
 def _coerce_search_error(provider_name: str, exc: Exception) -> SearchProviderError:
     if isinstance(exc, SearchProviderError):
         return exc
+    if isinstance(exc, httpx.TimeoutException):
+        return SearchProviderError(
+            provider=provider_name,
+            kind="timeout",
+            message=str(exc) or "Search request timed out.",
+            retryable=True,
+        )
+    if isinstance(exc, httpx.NetworkError):
+        return SearchProviderError(
+            provider=provider_name,
+            kind="network",
+            message=str(exc) or "Search network request failed.",
+            retryable=True,
+        )
     return SearchProviderError(
         provider=provider_name,
         kind="unknown",
@@ -541,6 +569,8 @@ def _failure_payload(
     *,
     error_kind: str,
     error: str,
+    provider_retryable: bool,
+    error_class: str,
 ) -> dict[str, Any]:
     diagnostics.returned_chars = 0
     return {
@@ -552,7 +582,10 @@ def _failure_payload(
         "sources": [],
         "results": [],
         "error_kind": error_kind,
+        "error_class": error_class,
         "error": error,
+        "provider_retryable": provider_retryable,
+        "retry_allowed": False,
     }
 
 

--- a/src/opensquilla/search/providers/bocha.py
+++ b/src/opensquilla/search/providers/bocha.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 
 from opensquilla.search.registry import register_provider
+from opensquilla.search.retry_policy import is_retryable_http_status
 from opensquilla.search.types import (
     Recency,
     SearchErrorKind,
@@ -131,6 +132,13 @@ class BochaSearchProvider:
                 message="Bocha search returned malformed JSON.",
                 retryable=False,
             ) from exc
+        if not isinstance(data, dict):
+            raise SearchProviderError(
+                provider=self.name,
+                kind="parse",
+                message="Bocha search returned an invalid response payload.",
+                retryable=False,
+            )
 
         _raise_for_api_error(data)
         return [
@@ -148,11 +156,8 @@ def _classify_status(status_code: int) -> SearchErrorKind:
 
 
 def _is_retryable_status(status_code: int, kind: SearchErrorKind) -> bool:
-    if status_code == 429:
-        return True
-    if kind == "http":
-        return True
-    return False
+    del kind
+    return is_retryable_http_status(status_code)
 
 
 def _raise_for_api_error(data: dict[str, Any]) -> None:
@@ -160,13 +165,17 @@ def _raise_for_api_error(data: dict[str, Any]) -> None:
     status_code = _api_status_code(code)
     if code is None or status_code == 200:
         return
-    kind = _classify_status(status_code or 500)
+    kind: SearchErrorKind = (
+        _classify_status(status_code) if status_code is not None else "http"
+    )
     message = str(data.get("msg") or data.get("message") or "Bocha search request failed.")
     raise SearchProviderError(
         provider="bocha",
         kind=kind,
         message=message,
-        retryable=_is_retryable_status(status_code or 500, kind),
+        retryable=(
+            _is_retryable_status(status_code, kind) if status_code is not None else False
+        ),
         status_code=status_code,
     )
 

--- a/src/opensquilla/search/providers/brave.py
+++ b/src/opensquilla/search/providers/brave.py
@@ -7,6 +7,7 @@ import os
 import httpx
 
 from opensquilla.search.registry import register_provider
+from opensquilla.search.retry_policy import is_retryable_http_status
 from opensquilla.search.types import Recency, SearchErrorKind, SearchProviderError, SearchResult
 from opensquilla.secrets import clean_header_secret
 
@@ -96,7 +97,7 @@ class BraveSearchProvider:
                 provider=self.name,
                 kind=kind,
                 message=str(exc) or f"Brave search failed with HTTP {status_code}.",
-                retryable=kind in {"rate_limit", "http"},
+                retryable=is_retryable_http_status(status_code),
                 status_code=status_code,
             ) from exc
         except httpx.HTTPError as exc:
@@ -107,7 +108,22 @@ class BraveSearchProvider:
                 retryable=True,
             ) from exc
 
-        data = response.json()
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise SearchProviderError(
+                provider=self.name,
+                kind="parse",
+                message="Brave search returned malformed JSON.",
+                retryable=False,
+            ) from exc
+        if not isinstance(data, dict):
+            raise SearchProviderError(
+                provider=self.name,
+                kind="parse",
+                message="Brave search returned an invalid response payload.",
+                retryable=False,
+            )
         results: list[SearchResult] = []
 
         for item in (data.get("web", {}).get("results") or [])[:max_results]:

--- a/src/opensquilla/search/providers/duckduckgo.py
+++ b/src/opensquilla/search/providers/duckduckgo.py
@@ -8,6 +8,7 @@ import httpx
 from bs4 import BeautifulSoup
 
 from opensquilla.search.registry import register_provider
+from opensquilla.search.retry_policy import is_retryable_http_status
 from opensquilla.search.types import SearchErrorKind, SearchProviderError, SearchResult
 
 _DDHTML_URL = "https://html.duckduckgo.com/html"
@@ -68,7 +69,7 @@ class DuckDuckGoProvider:
                 retryable = True
             elif isinstance(exc, httpx.HTTPStatusError):
                 kind = "http"
-                retryable = 500 <= exc.response.status_code < 600
+                retryable = is_retryable_http_status(exc.response.status_code)
             else:
                 kind = "network"
                 retryable = True
@@ -89,7 +90,7 @@ class DuckDuckGoProvider:
                 provider=self.name,
                 kind="blocked",
                 message="DuckDuckGo returned an anti-bot challenge.",
-                retryable=True,
+                retryable=False,
                 status_code=response.status_code,
             )
 
@@ -133,7 +134,7 @@ class DuckDuckGoProvider:
                 provider=self.name,
                 kind="parse",
                 message="DuckDuckGo search response did not contain parseable results.",
-                retryable=True,
+                retryable=False,
                 status_code=response.status_code,
             )
 

--- a/src/opensquilla/search/providers/exa.py
+++ b/src/opensquilla/search/providers/exa.py
@@ -9,6 +9,7 @@ from typing import Any
 import httpx
 
 from opensquilla.search.registry import register_provider
+from opensquilla.search.retry_policy import is_retryable_http_status
 from opensquilla.search.types import (
     Recency,
     SearchErrorKind,
@@ -135,7 +136,22 @@ class ExaSearchProvider:
                 retryable=True,
             ) from exc
 
-        data = response.json()
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise SearchProviderError(
+                provider=self.name,
+                kind="parse",
+                message="Exa search returned malformed JSON.",
+                retryable=False,
+            ) from exc
+        if not isinstance(data, dict):
+            raise SearchProviderError(
+                provider=self.name,
+                kind="parse",
+                message="Exa search returned an invalid response payload.",
+                retryable=False,
+            )
         return [
             _result_from_item(item, data)
             for item in (data.get("results") or [])[:result_limit]
@@ -155,11 +171,8 @@ def _classify_status(status_code: int) -> SearchErrorKind:
 
 
 def _is_retryable_status(status_code: int, kind: SearchErrorKind) -> bool:
-    if status_code == 429:
-        return True
-    if kind == "http":
-        return True
-    return False
+    del kind
+    return is_retryable_http_status(status_code)
 
 
 def _result_from_item(item: dict[str, Any], response_data: dict[str, Any]) -> SearchResult:

--- a/src/opensquilla/search/providers/iqs.py
+++ b/src/opensquilla/search/providers/iqs.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 
 from opensquilla.search.registry import register_provider
+from opensquilla.search.retry_policy import is_retryable_http_status
 from opensquilla.search.types import (
     Recency,
     SearchErrorKind,
@@ -176,11 +177,8 @@ def _classify_status(status_code: int) -> SearchErrorKind:
 
 
 def _is_retryable_status(status_code: int, kind: SearchErrorKind) -> bool:
-    if status_code == 429:
-        return True
-    if kind == "http":
-        return True
-    return False
+    del kind
+    return is_retryable_http_status(status_code)
 
 
 def _error_detail(response: httpx.Response) -> str:

--- a/src/opensquilla/search/providers/tavily.py
+++ b/src/opensquilla/search/providers/tavily.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 
 from opensquilla.search.registry import register_provider
+from opensquilla.search.retry_policy import is_retryable_http_status
 from opensquilla.search.types import Recency, SearchErrorKind, SearchProviderError, SearchResult
 from opensquilla.secrets import clean_header_secret
 
@@ -113,7 +114,22 @@ class TavilySearchProvider:
                 retryable=True,
             ) from exc
 
-        data = response.json()
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise SearchProviderError(
+                provider=self.name,
+                kind="parse",
+                message="Tavily search returned malformed JSON.",
+                retryable=False,
+            ) from exc
+        if not isinstance(data, dict):
+            raise SearchProviderError(
+                provider=self.name,
+                kind="parse",
+                message="Tavily search returned an invalid response payload.",
+                retryable=False,
+            )
         return [
             _result_from_item(item, data) for item in (data.get("results") or [])[:result_limit]
         ]
@@ -128,11 +144,8 @@ def _classify_status(status_code: int) -> SearchErrorKind:
 
 
 def _is_retryable_status(status_code: int, kind: SearchErrorKind) -> bool:
-    if status_code == 429:
-        return True
-    if kind == "http":
-        return True
-    return False
+    del kind
+    return is_retryable_http_status(status_code)
 
 
 def _result_from_item(item: dict[str, Any], response_data: dict[str, Any]) -> SearchResult:

--- a/src/opensquilla/search/retry_policy.py
+++ b/src/opensquilla/search/retry_policy.py
@@ -1,0 +1,14 @@
+"""Shared retry classification for search-provider HTTP responses."""
+
+from __future__ import annotations
+
+
+def is_retryable_http_status(status_code: int) -> bool:
+    """Return whether a failed HTTP response is transient enough for fallback.
+
+    Providers perform one network request per search. This flag is consumed by
+    the search orchestrator when deciding whether another provider may be tried;
+    it does not trigger an in-provider retry.
+    """
+
+    return status_code in {408, 429} or 500 <= status_code < 600

--- a/src/opensquilla/search/runtime_config.py
+++ b/src/opensquilla/search/runtime_config.py
@@ -7,7 +7,14 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-from opensquilla.search.types import SearchOptions, SearchProvider, SearchProviderError
+from opensquilla.search.retry_policy import is_retryable_http_status
+from opensquilla.search.types import (
+    SearchExecutionPlan,
+    SearchFallbackMode,
+    SearchOptions,
+    SearchProvider,
+    SearchProviderError,
+)
 
 CredentialSource = Literal["configured", "configured_env", "spec_env", "none"]
 
@@ -141,6 +148,40 @@ class ResolvedSearchRuntime:
             ),
         )
 
+    def execution_plan(self, options: SearchOptions) -> SearchExecutionPlan:
+        """Build the bounded, duplicate-free provider sequence for one request."""
+
+        ranked_names = tuple(dict.fromkeys(self.provider_order(options)))
+        # Automatic mode preselects one backup even with fallback disabled so a
+        # provider that discovers a missing key locally can be skipped without
+        # turning that skip into a second network attempt. All other failures
+        # still stop immediately under the ``off`` policy.
+        max_attempts = (
+            2
+            if self.fallback_policy == "network" or options.provider is None
+            else 1
+        )
+        provider_names = list(ranked_names[:max_attempts])
+        if (
+            (self.fallback_policy == "network" or options.provider is None)
+            and len(provider_names) == 1
+            and provider_names[0] != "duckduckgo"
+        ):
+            duckduckgo = self.providers.get("duckduckgo")
+            if duckduckgo is not None and duckduckgo.available:
+                provider_names.append("duckduckgo")
+        planned_provider_names = tuple(provider_names)
+        fallback_mode: SearchFallbackMode = "none"
+        if len(planned_provider_names) > 1:
+            fallback_mode = (
+                "network" if self.fallback_policy == "network" else "auth_missing"
+            )
+        return SearchExecutionPlan(
+            provider_names=planned_provider_names,
+            selection_mode="explicit" if options.provider is not None else "automatic",
+            fallback_mode=fallback_mode,
+        )
+
     def should_fallback(
         self,
         error: SearchProviderError,
@@ -153,7 +194,15 @@ class ResolvedSearchRuntime:
             return (not explicit_provider) and _is_missing_key_error(error)
         if self.fallback_policy != "network":
             return False
-        return error.retryable or error.kind in {"network", "timeout", "rate_limit", "http"}
+        if not error.retryable:
+            return False
+        if error.kind not in {"timeout", "network", "rate_limit", "http"}:
+            return False
+        if error.kind in {"timeout", "network"}:
+            return True
+        if error.status_code is not None:
+            return is_retryable_http_status(error.status_code)
+        return False
 
     def _explicit_provider_order(self, provider_id: str, *, recency: str | None) -> tuple[str, ...]:
         if (

--- a/src/opensquilla/search/types.py
+++ b/src/opensquilla/search/types.py
@@ -19,6 +19,8 @@ SearchErrorKind = Literal[
 ]
 SearchMode = Literal["auto", "news", "technical", "broad"]
 Recency = Literal["day", "week", "month", "year"]
+SearchSelectionMode = Literal["automatic", "explicit"]
+SearchFallbackMode = Literal["none", "auth_missing", "network"]
 
 # Single source of truth for the web-search result count.
 # DEFAULT_SEARCH_MAX_RESULTS is the count used when a caller does not request an
@@ -83,6 +85,35 @@ class SearchOptions:
         )
         object.__setattr__(self, "include_domains", _normalize_domains(self.include_domains))
         object.__setattr__(self, "exclude_domains", _normalize_domains(self.exclude_domains))
+
+
+@dataclass(frozen=True)
+class SearchExecutionPlan:
+    """Bounded provider sequence for one canonical search execution."""
+
+    provider_names: tuple[str, ...] = ()
+    selection_mode: SearchSelectionMode = "automatic"
+    fallback_mode: SearchFallbackMode = "none"
+
+    def __post_init__(self) -> None:
+        if len(self.provider_names) > 2:
+            raise ValueError("Search execution plans support at most two providers.")
+        if len(set(self.provider_names)) != len(self.provider_names):
+            raise ValueError("Search execution plans must not repeat providers.")
+        if self.fallback_mode != "none" and len(self.provider_names) < 2:
+            raise ValueError("A search fallback mode requires a fallback provider.")
+
+    @property
+    def primary_provider(self) -> str | None:
+        return self.provider_names[0] if self.provider_names else None
+
+    @property
+    def fallback_provider(self) -> str | None:
+        return self.provider_names[1] if len(self.provider_names) > 1 else None
+
+    @property
+    def planned_provider_ids(self) -> tuple[str, ...]:
+        return self.provider_names
 
 
 def _normalize_domains(value: str | Iterable[str]) -> tuple[str, ...]:

--- a/src/opensquilla/search_tool_outcome.py
+++ b/src/opensquilla/search_tool_outcome.py
@@ -1,0 +1,115 @@
+"""Trusted search-tool outcome parsing and semantic request keys.
+
+Only built-in web retrieval tools are allowed to promote a JSON ``ok: false``
+payload into runtime failure state. Keeping that trust boundary here avoids
+interpreting arbitrary third-party tool output as an OpenSquilla control
+contract while keeping the top-level execution-status module package-neutral.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from opensquilla.search.normalize import canonicalize_query_key
+
+WEB_RETRIEVAL_TOOL_NAMES: frozenset[str] = frozenset({"web_search", "web_discover"})
+type WebRetrievalSemanticKey = tuple[
+    str,
+    str,
+    str,
+    tuple[str, ...],
+    tuple[str, ...],
+]
+
+_ERROR_KIND_SEPARATOR_RE = re.compile(r"[^a-z0-9]+")
+
+
+@dataclass(frozen=True)
+class WebToolOutcome:
+    """A structured failure emitted by a trusted web retrieval tool."""
+
+    error_kind: str
+    retry_allowed: bool | None
+
+
+def parse_web_tool_outcome(tool_name: str, content: Any) -> WebToolOutcome | None:
+    """Parse an explicit ``ok: false`` result from a trusted search tool.
+
+    Missing, malformed, or non-boolean ``ok`` fields are intentionally ignored
+    for compatibility with legacy payloads. The retry decision also remains
+    unknown unless the tool emits an actual JSON boolean.
+    """
+
+    if tool_name not in WEB_RETRIEVAL_TOOL_NAMES:
+        return None
+    payload = _payload_mapping(content)
+    if payload is None or payload.get("ok") is not False:
+        return None
+    retry_allowed = payload.get("retry_allowed")
+    if not isinstance(retry_allowed, bool):
+        retry_allowed = None
+    return WebToolOutcome(
+        error_kind=_normalize_error_kind(payload.get("error_kind")),
+        retry_allowed=retry_allowed,
+    )
+
+
+def web_retrieval_semantic_key(
+    arguments: Mapping[str, Any],
+) -> WebRetrievalSemanticKey:
+    """Build the cross-provider identity of a web retrieval request.
+
+    Provider/tool choice and presentation limits do not change the underlying
+    information request. Query intent, mode, recency, and domain filters do.
+    """
+
+    query = canonicalize_query_key(str(arguments.get("query") or ""))
+    mode = _normalized_scalar(arguments.get("mode"), default="auto")
+    recency = _normalized_scalar(arguments.get("recency"), default="")
+    include_domains = _normalized_domains(arguments.get("include_domains"))
+    exclude_domains = _normalized_domains(arguments.get("exclude_domains"))
+    return (query, mode, recency, include_domains, exclude_domains)
+
+
+def _payload_mapping(content: Any) -> Mapping[str, Any] | None:
+    if isinstance(content, Mapping):
+        return content
+    if not isinstance(content, str):
+        return None
+    try:
+        payload = json.loads(content)
+    except (TypeError, ValueError):
+        return None
+    return payload if isinstance(payload, Mapping) else None
+
+
+def _normalize_error_kind(value: Any) -> str:
+    if not isinstance(value, str):
+        return "unknown"
+    normalized = _ERROR_KIND_SEPARATOR_RE.sub("_", value.strip().lower()).strip("_")
+    return normalized[:64] or "unknown"
+
+
+def _normalized_scalar(value: Any, *, default: str) -> str:
+    if not isinstance(value, str):
+        return default
+    return value.strip().lower() or default
+
+
+def _normalized_domains(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        candidates: Sequence[Any] = (value,)
+    elif isinstance(value, Sequence):
+        candidates = value
+    else:
+        return ()
+    normalized = {
+        candidate.strip().lower().strip(".")
+        for candidate in candidates
+        if isinstance(candidate, str) and candidate.strip().strip(".")
+    }
+    return tuple(sorted(normalized))

--- a/src/opensquilla/tools/builtin/web.py
+++ b/src/opensquilla/tools/builtin/web.py
@@ -117,6 +117,73 @@ def _network_search_request(args: Mapping[str, Any]) -> NetworkOperationRequest:
     )
 
 
+def _web_search_sandbox_argv(args: Mapping[str, Any]) -> tuple[str, ...]:
+    return (
+        "web_search",
+        str(args.get("query", "")),
+        str(args.get("fetch_top_k", "")),
+        _search_plan_argv_token(args, tool_name="web_search"),
+    )
+
+
+def _web_discover_sandbox_argv(args: Mapping[str, Any]) -> tuple[str, ...]:
+    return (
+        "web_discover",
+        str(args.get("query", "")),
+        str(args.get("max_results", "")),
+        _search_plan_argv_token(args, tool_name="web_discover"),
+    )
+
+
+def _search_plan_argv_token(args: Mapping[str, Any], *, tool_name: str) -> str:
+    """Encode only planned provider ids for managed-network domain grants."""
+
+    try:
+        from opensquilla.search.runtime_config import get_resolved_search_runtime
+
+        provider_value = args.get("provider")
+        provider = (
+            str(provider_value)
+            if isinstance(provider_value, str) and provider_value not in {"", "auto"}
+            else None
+        )
+        if (
+            tool_name == "web_discover"
+            and provider is None
+            and _active_provider not in _VALID_SEARCH_PROVIDERS
+        ):
+            provider = _active_provider
+        raw_mode = str(args.get("mode") or "auto")
+        mode = raw_mode if raw_mode in _VALID_SEARCH_MODES else "auto"
+        raw_recency = args.get("recency")
+        recency = (
+            str(raw_recency)
+            if isinstance(raw_recency, str) and raw_recency in _VALID_SEARCH_RECENCIES
+            else None
+        )
+        options = SearchOptions(
+            query=str(args.get("query") or ""),
+            mode=cast(SearchMode, mode),
+            include_domains=_search_plan_domains(args.get("include_domains")),
+            exclude_domains=_search_plan_domains(args.get("exclude_domains")),
+            recency=cast(Recency | None, recency),
+            provider=provider,
+        )
+        plan = get_resolved_search_runtime().execution_plan(options)
+        provider_names = plan.provider_names
+    except Exception:  # pragma: no cover - fail closed to the legacy known-provider grant
+        provider_names = (_active_provider,)
+        if _active_search_fallback_policy == "network" and _active_provider != "duckduckgo":
+            provider_names += ("duckduckgo",)
+    return "providers=" + ",".join(provider_names)
+
+
+def _search_plan_domains(value: object) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(str(item) for item in value if isinstance(item, str))
+
+
 def _search_benchmark_blocklist_enabled() -> bool:
     value = os.environ.get(_SEARCH_BENCHMARK_BLOCKLIST_ENV, "")
     return value.strip().lower() in {"1", "true", "yes", "on"}
@@ -593,6 +660,7 @@ def _search_failure_payload(payload: dict, *, retryable: bool = False) -> dict:
     error_kind = str(result.get("error_kind") or "unknown")
     error_class = str(result.get("error_class") or "")
     result["ok"] = False
+    result["retry_allowed"] = False
     result["errorMessage"] = message
     result["error"] = {
         "kind": error_kind,
@@ -653,7 +721,6 @@ async def run_web_discover_payload(
     from opensquilla.search.runtime_config import get_resolved_search_runtime
 
     _ensure_builtin_search_providers()
-    explicit_provider = provider_name is not None
     display_provider = provider_name or _active_provider
     runtime = get_resolved_search_runtime()
     marker = _sensitive_body_marker(query)
@@ -679,93 +746,110 @@ async def run_web_discover_payload(
     # an out-of-range configured/active value cannot ask an uncapped provider
     # (e.g. duckduckgo) for an unbounded number of results.
     limit = min(max(max_results or _active_max_results, 1), MAX_SEARCH_RESULTS)
-    provider_names = _web_discover_provider_order(
-        runtime,
+    effective_provider = provider_name
+    if effective_provider is None and _active_provider not in _VALID_SEARCH_PROVIDERS:
+        effective_provider = _active_provider
+    options = SearchOptions(
         query=query,
         max_results=limit,
-        provider_name=provider_name,
+        fetch_top_k=0,
+        provider=effective_provider,
     )
-    attempts: list[dict[str, str]] | None = [] if _active_search_diagnostics else None
-    terminal_provider = provider_names[0] if provider_names else display_provider
-    terminal_exc: Exception | None = None
-    fallback_from = ""
+    blocklist_meta: dict[str, Any] = {}
 
-    for candidate_provider in provider_names:
-        try:
-            provider = get_provider(
-                candidate_provider,
-                **_search_provider_kwargs(candidate_provider),
-            )
-            results = await provider.search(query, max_results=limit)
-            results, blocklist_meta = _filter_search_benchmark_results(
-                results,
-                terms=blocklist_terms,
-            )
-            if attempts is not None:
-                attempts.append({"provider": candidate_provider, "status": "success"})
-            return _search_success_payload(
-                _search_payload(
-                    query,
-                    candidate_provider,
-                    fallback_from=fallback_from,
-                    attempts=attempts,
-                    results=results,
-                ) | blocklist_meta
-            )
-        except Exception as exc:  # noqa: BLE001 - converted to structured payload below
-            terminal_provider = candidate_provider
-            terminal_exc = exc
-            classified = _classify_search_error(candidate_provider, exc)
-            if attempts is not None:
-                attempts.append(
-                    {
-                        "provider": candidate_provider,
-                        "status": "error",
-                        "error_kind": classified.kind if classified else "unknown",
-                    }
-                )
-
-            should_fallback = (
-                classified is not None
-                and runtime.should_fallback(classified, explicit_provider=explicit_provider)
-            )
-            if should_fallback:
-                fallback_from = fallback_from or candidate_provider
-                continue
-            return _search_failure_payload(
-                _search_error_payload(query, candidate_provider, exc, attempts=attempts),
-                retryable=bool(classified and classified.retryable),
-            )
-
-    if terminal_exc is None:
-        terminal_exc = ValueError("No search provider available for web_discover.")
-    classified = _classify_search_error(terminal_provider, terminal_exc)
-    return _search_failure_payload(
-        _search_error_payload(query, terminal_provider, terminal_exc, attempts=attempts),
-        retryable=bool(classified and classified.retryable),
-    )
-
-
-def _web_discover_provider_order(
-    runtime: Any,
-    *,
-    query: str,
-    max_results: int,
-    provider_name: str | None,
-) -> tuple[str, ...]:
-    order = runtime.provider_order(
-        SearchOptions(
-            query=query,
-            max_results=max_results,
-            fetch_top_k=0,
-            provider=provider_name,
+    def provider_factory(candidate_provider: str) -> Any:
+        provider = get_provider(
+            candidate_provider,
+            **_search_provider_kwargs(candidate_provider),
         )
+        if not blocklist_terms:
+            return provider
+        return _BenchmarkBlocklistSearchProvider(
+            provider,
+            terms=blocklist_terms,
+            meta=blocklist_meta,
+        )
+
+    canonical = await run_canonical_web_search(
+        options,
+        runtime=runtime,
+        provider_factory=provider_factory,
     )
-    if provider_name is None and _active_provider not in _VALID_SEARCH_PROVIDERS:
-        if runtime.fallback_policy == "network" and _active_provider != "duckduckgo":
-            return (_active_provider, "duckduckgo")
-        return (_active_provider,)
-    return order or (provider_name or _active_provider,)
+    canonical.update(blocklist_meta)
+    return _web_discover_payload_from_canonical(canonical, display_provider=display_provider)
+
+
+def _web_discover_payload_from_canonical(
+    payload: Mapping[str, Any],
+    *,
+    display_provider: str,
+) -> dict[str, Any]:
+    diagnostics = payload.get("diagnostics")
+    diagnostic_payload = diagnostics if isinstance(diagnostics, Mapping) else {}
+    raw_attempts = payload.get("provider_attempts")
+    attempts = list(raw_attempts) if isinstance(raw_attempts, list) else []
+    selected_provider = str(diagnostic_payload.get("selected_provider") or "")
+    terminal_provider = _last_search_attempt_provider(attempts)
+    provider = selected_provider or terminal_provider or display_provider
+    result: dict[str, Any] = {
+        "query": str(payload.get("query") or ""),
+        "provider": provider,
+        "results": [],
+    }
+    if _active_search_diagnostics:
+        result["attempts"] = attempts
+    for key in ("benchmark_blocklist_enabled", "blocked_query", "blocked_count"):
+        if key in payload:
+            result[key] = payload[key]
+
+    if payload.get("ok") is True:
+        raw_results = payload.get("results")
+        if isinstance(raw_results, list):
+            result["results"] = [
+                _lightweight_search_result(item)
+                for item in raw_results
+                if isinstance(item, Mapping)
+            ]
+        fallback_from = str(diagnostic_payload.get("fallback_from") or "")
+        if fallback_from:
+            result["fallback_from"] = fallback_from
+        return _search_success_payload(result)
+
+    result.update(
+        {
+            "error_class": str(payload.get("error_class") or "SearchProviderError"),
+            "error_kind": str(payload.get("error_kind") or "unknown"),
+            "error": str(payload.get("error") or "Search provider failed."),
+            "provider_attempts": attempts,
+            "diagnostics": dict(diagnostic_payload),
+        }
+    )
+    return _search_failure_payload(
+        result,
+        retryable=bool(payload.get("provider_retryable")),
+    )
+
+
+def _last_search_attempt_provider(attempts: list[Any]) -> str:
+    for attempt in reversed(attempts):
+        if isinstance(attempt, Mapping):
+            provider = str(attempt.get("provider") or "")
+            if provider:
+                return provider
+    return ""
+
+
+def _lightweight_search_result(item: Mapping[str, Any]) -> dict[str, object]:
+    result: dict[str, object] = {
+        "title": str(item.get("title") or ""),
+        "url": str(item.get("url") or ""),
+        "snippet": str(item.get("snippet") or ""),
+    }
+    for key in ("provider", "published_at", "score", "domain", "canonical_url"):
+        value = item.get(key)
+        if value not in (None, ""):
+            result[key] = value
+    return result
 
 
 async def run_web_search_payload(
@@ -904,6 +988,7 @@ def _invalid_search_request_payload(message: str) -> dict[str, object]:
         "ok": False,
         "error_kind": "invalid_request",
         "error": message,
+        "retry_allowed": False,
     }
 
 
@@ -1067,11 +1152,7 @@ def _search_error_payload(
     result_budget_class="external",
     sandbox=SandboxToolDescriptor.network(
         kind="web.fetch",
-        argv_factory=lambda a: (
-            "web_search",
-            str(a.get("query", "")),
-            str(a.get("fetch_top_k", "")),
-        ),
+        argv_factory=_web_search_sandbox_argv,
         request_factory=_network_search_request,
         record_payload=False,
     ),
@@ -1115,11 +1196,7 @@ async def web_search(
     result_budget_class="external",
     sandbox=SandboxToolDescriptor.network(
         kind="web.fetch",
-        argv_factory=lambda a: (
-            "web_discover",
-            str(a.get("query", "")),
-            str(a.get("max_results", "")),
-        ),
+        argv_factory=_web_discover_sandbox_argv,
         request_factory=_network_search_request,
         record_payload=False,
     ),
@@ -1127,9 +1204,10 @@ async def web_search(
 async def web_discover(query: str, max_results: int | None = None) -> str:
     payload = await run_web_discover_payload(query, max_results)
     tool_payload = dict(payload)
-    tool_payload.pop("ok", None)
-    tool_payload.pop("fallbackFrom", None)
-    tool_payload.pop("errorMessage", None)
+    if tool_payload.get("ok") is True:
+        tool_payload.pop("ok", None)
+        tool_payload.pop("fallbackFrom", None)
+        tool_payload.pop("errorMessage", None)
     if isinstance(tool_payload.get("error"), dict):
         tool_payload["error"] = tool_payload["error"].get("message", "")
     return json.dumps(tool_payload, ensure_ascii=False, indent=2)

--- a/src/opensquilla/tools/dispatch.py
+++ b/src/opensquilla/tools/dispatch.py
@@ -32,6 +32,8 @@ from opensquilla.execution_status import normalize_execution_status
 from opensquilla.result_budget import (
     DEFAULT_TOOL_RESULT_BUDGET_POLICY,
     DEFAULT_TOOL_RUN_BUDGET_POLICY,
+    DuplicateRetrievalInFlightError,
+    TerminalRetrievalReplayError,
     ToolResultBudgetPolicy,
     ToolResultBudgetTracker,
     ToolRunBudgetExceededError,
@@ -49,6 +51,7 @@ from opensquilla.sandbox.operation_runtime import (
     record_tool_operation_success,
     run_tool_handler_with_operation_guard,
 )
+from opensquilla.search_tool_outcome import parse_web_tool_outcome
 from opensquilla.tool_boundary import AgentToolHandler, ToolCall, ToolResult
 from opensquilla.tools.argument_normalization import (
     canonicalize_tool_arguments,
@@ -210,7 +213,14 @@ async def _emit_web_retrieval_tool_run_diagnostics(
     if not reservation.counted_as_external_text:
         return
     snapshot = await run_budget_tracker.snapshot()
-    if exception is None:
+    web_outcome = (
+        parse_web_tool_outcome(tool_call.tool_name, raw_result)
+        if exception is None
+        else None
+    )
+    if web_outcome is not None:
+        status = "error"
+    elif exception is None:
         status = "ok"
     elif isinstance(exception, ToolRunBudgetExceededError):
         status = "budget_exhausted"
@@ -231,6 +241,7 @@ async def _emit_web_retrieval_tool_run_diagnostics(
         reserved_external_text_chars=reservation.reserved_external_text_chars,
         counted_as_search=reservation.counted_as_search,
         counted_as_fetch=reservation.counted_as_fetch,
+        error_kind=web_outcome.error_kind if web_outcome is not None else None,
         **snapshot,
     )
 
@@ -272,6 +283,131 @@ def _build_run_budget_control_result(
         is_error=False,
         execution_status=normalize_execution_status(status),
     )
+
+
+def _build_duplicate_retrieval_control_result(
+    tool_call: ToolCall,
+    exc: DuplicateRetrievalInFlightError,
+) -> ToolResult:
+    payload = {
+        "status": "control",
+        "tool": tool_call.tool_name,
+        "reason": "duplicate_search_in_flight",
+        "user_message": (
+            "An equivalent search is already running in this turn. Continue with "
+            "other work and use the original result when it completes."
+        ),
+        "retry_allowed": False,
+    }
+    status = {
+        "version": 1,
+        "status": "unknown",
+        "exit_code": None,
+        "timed_out": False,
+        "truncated": False,
+        "reason": "duplicate_search_in_flight",
+        "source": "tool_runtime",
+        "preservation_class": "ephemeral",
+    }
+    log.info(
+        "dispatch.duplicate_search_in_flight",
+        tool=tool_call.tool_name,
+        tool_use_id=tool_call.tool_use_id,
+        message=str(exc),
+    )
+    return ToolResult(
+        tool_use_id=tool_call.tool_use_id,
+        tool_name=tool_call.tool_name,
+        content=json.dumps(payload),
+        is_error=False,
+        execution_status=normalize_execution_status(status),
+    )
+
+
+def _build_terminal_retrieval_replay_result(
+    tool_call: ToolCall,
+    exc: TerminalRetrievalReplayError,
+) -> ToolResult:
+    payload = {
+        "status": "error",
+        "tool": tool_call.tool_name,
+        "reason": "terminal_search_failure_replay",
+        "error_kind": exc.error_kind,
+        "user_message": (
+            "An equivalent search already ended in a non-retryable failure this turn. "
+            "Change the query, mode, recency, or domain filters before searching "
+            "again, or continue with available evidence."
+        ),
+        "retry_allowed": False,
+    }
+    status = {
+        "version": 1,
+        "status": "error",
+        "exit_code": None,
+        "timed_out": False,
+        "truncated": False,
+        "reason": "terminal_search_failure_replay",
+        "source": "tool_runtime",
+        "preservation_class": "diagnostic",
+    }
+    log.info(
+        "dispatch.terminal_search_failure_replay",
+        tool=tool_call.tool_name,
+        tool_use_id=tool_call.tool_use_id,
+        error_kind=exc.error_kind,
+        message=str(exc),
+    )
+    return ToolResult(
+        tool_use_id=tool_call.tool_use_id,
+        tool_name=tool_call.tool_name,
+        content=json.dumps(payload),
+        is_error=True,
+        execution_status=normalize_execution_status(status),
+    )
+
+
+def _notify_after_tool_hooks(
+    hooks: Sequence[ToolHook],
+    hook_call: ToolHookCall | None,
+    result: ToolResult,
+) -> None:
+    if hook_call is None:
+        return
+    for hook in hooks:
+        try:
+            hook.after_tool(hook_call, ToolHookResult(result=result))
+        except Exception as hook_exc:  # noqa: BLE001 - hooks must not break dispatch
+            log.warning(
+                "dispatch.tool_hook_failed",
+                hook=getattr(hook, "name", type(hook).__name__),
+                phase="after_tool",
+                error=str(hook_exc),
+            )
+
+
+async def _reserve_tool_call_with_runtime_guards(
+    *,
+    tracker: ToolRunBudgetTracker,
+    tool_call: ToolCall,
+    arguments: dict[str, Any],
+    ctx: ToolContext | None,
+) -> ToolRunBudgetReservation | ToolResult:
+    try:
+        policy = _resolve_run_budget_policy(ctx)
+        return await tracker.reserve_tool_call(
+            tool_name=tool_call.tool_name,
+            arguments=clamp_tool_arguments(
+                tool_call.tool_name,
+                arguments,
+                policy,
+            ),
+        )
+    except DuplicateRetrievalInFlightError as exc:
+        return _build_duplicate_retrieval_control_result(tool_call, exc)
+    except TerminalRetrievalReplayError as exc:
+        return _build_terminal_retrieval_replay_result(tool_call, exc)
+    except ToolRunBudgetExceededError as exc:
+        return _build_run_budget_control_result(tool_call, exc)
 
 
 def _check_injection_guard(
@@ -1189,30 +1325,16 @@ def build_tool_handler(
                 tool_call.continuation.approval_id,
             )
         run_budget_tracker = _run_budget_tracker_for(effective_ctx)
-        try:
-            run_budget_policy = _resolve_run_budget_policy(effective_ctx)
-            reservation = await run_budget_tracker.reserve_tool_call(
-                tool_name=tool_call.tool_name,
-                arguments=clamp_tool_arguments(
-                    tool_call.tool_name,
-                    execution_arguments,
-                    run_budget_policy,
-                ),
-            )
-        except ToolRunBudgetExceededError as exc:
-            envelope = _build_run_budget_control_result(tool_call, exc)
-            if hook_call is not None:
-                for hook in hooks:
-                    try:
-                        hook.after_tool(hook_call, ToolHookResult(result=envelope))
-                    except Exception as hook_exc:  # noqa: BLE001
-                        log.warning(
-                            "dispatch.tool_hook_failed",
-                            hook=getattr(hook, "name", type(hook).__name__),
-                            phase="after_tool",
-                            error=str(hook_exc),
-                        )
-            return envelope
+        reservation_or_control = await _reserve_tool_call_with_runtime_guards(
+            tracker=run_budget_tracker,
+            tool_call=tool_call,
+            arguments=execution_arguments,
+            ctx=effective_ctx,
+        )
+        if isinstance(reservation_or_control, ToolResult):
+            _notify_after_tool_hooks(hooks, hook_call, reservation_or_control)
+            return reservation_or_control
+        reservation = reservation_or_control
 
         token = current_tool_context.set(effective_ctx)
         tool_started_at = time.monotonic()

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -144,6 +144,10 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     # Provider argument repair reuses the tool alias/schema helpers (lazy import).
     ("provider", "tools"),
     ("result_budget.py", "search"),
+    # Trusted web-tool failure parsing reuses the canonical search query
+    # normalizer; the helper stays top-level so execution_status remains
+    # independent of package import side effects.
+    ("search_tool_outcome.py", "search"),
     ("router_control.py", "engine"),
     ("sandbox", "application"),
     ("sandbox", "gateway"),

--- a/tests/test_execution_status_contract.py
+++ b/tests/test_execution_status_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 
 
 def _execution_status_module():
@@ -93,3 +94,69 @@ def test_legacy_non_error_normalizes_to_unknown_normal_status() -> None:
     assert status["source"] == "legacy"
     assert status["reason"] == "legacy_missing_status"
     assert status["preservation_class"] == "normal"
+
+
+def test_web_search_explicit_failure_maps_to_error_status() -> None:
+    module = _execution_status_module()
+
+    status = module.execution_status_for_tool_result(
+        "web_search",
+        json.dumps(
+            {
+                "ok": False,
+                "error_kind": "blocked",
+                "retry_allowed": False,
+                "results": [],
+            }
+        ),
+    )
+
+    assert status is not None
+    assert status["status"] == "error"
+    assert status["reason"] == "search_blocked"
+    assert status["source"] == "adapter"
+    assert status["preservation_class"] == "diagnostic"
+    assert module.derive_is_error(status) is True
+
+
+def test_web_discover_explicit_timeout_maps_to_timeout_status() -> None:
+    module = _execution_status_module()
+
+    status = module.execution_status_for_tool_result(
+        "web_discover",
+        json.dumps(
+            {
+                "ok": False,
+                "error_kind": "timeout",
+                "retry_allowed": True,
+                "results": [],
+            }
+        ),
+    )
+
+    assert status is not None
+    assert status["status"] == "timeout"
+    assert status["timed_out"] is True
+    assert status["reason"] == "search_timeout"
+    assert module.derive_is_error(status) is True
+
+
+def test_web_outcome_mapper_only_trusts_explicit_failures_from_search_tools() -> None:
+    module = _execution_status_module()
+    failure = json.dumps({"ok": False, "error_kind": "network"})
+
+    assert module.execution_status_for_tool_result("untrusted_tool", failure) is None
+    assert (
+        module.execution_status_for_tool_result(
+            "web_search",
+            json.dumps({"ok": True, "results": []}),
+        )
+        is None
+    )
+    assert (
+        module.execution_status_for_tool_result(
+            "web_search",
+            json.dumps({"error_kind": "network", "results": []}),
+        )
+        is None
+    )

--- a/tests/test_gateway/test_rpc_product_cli_gaps.py
+++ b/tests/test_gateway/test_rpc_product_cli_gaps.py
@@ -1508,6 +1508,7 @@ async def test_search_query_provider_failure_is_ok_false_payload():
 
     assert res.error is None, res.error
     assert res.payload["ok"] is False
+    assert res.payload["retry_allowed"] is False
     assert res.payload["error"]["kind"] == "network"
     assert res.payload["error"]["retryable"] is True
 
@@ -1532,3 +1533,4 @@ async def test_search_sensitive_query_is_not_echoed_by_tool_or_rpc():
     assert repr(rpc_res.payload).find("API_KEY") == -1
     assert rpc_res.payload["query"] == "[redacted]"
     assert rpc_res.payload["ok"] is False
+    assert rpc_res.payload["retry_allowed"] is False

--- a/tests/test_onboarding/test_search_specs.py
+++ b/tests/test_onboarding/test_search_specs.py
@@ -75,6 +75,7 @@ def test_search_catalog_explains_fallback_and_diagnostics_fields():
     fields = {field.name: field for field in spec.fields}
 
     assert "DuckDuckGo" in fields["fallback_policy"].description
+    assert "at most one additional" in fields["fallback_policy"].description
     assert "attempt/error details" in fields["diagnostics"].description
 
 

--- a/tests/test_provider_execution_status_projection.py
+++ b/tests/test_provider_execution_status_projection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+from opensquilla.execution_status import execution_status_for_tool_result
 from opensquilla.provider.anthropic import _build_message_payload
 from opensquilla.provider.openai import _build_openai_messages
 from opensquilla.provider.types import ContentBlockToolResult, Message
@@ -65,3 +66,36 @@ def test_openai_failure_tool_result_includes_bounded_execution_status_envelope()
     }
     assert tool_content["output"].startswith("failure details")
     assert len(tool_content["output"]) < len(large_output)
+
+
+def test_search_failure_status_projects_as_provider_visible_tool_error() -> None:
+    content = json.dumps(
+        {
+            "ok": False,
+            "error_kind": "auth",
+            "retry_allowed": False,
+            "results": [],
+        }
+    )
+    status = execution_status_for_tool_result("web_search", content)
+    assert status is not None
+    message = Message(
+        role="user",
+        content=[
+            ContentBlockToolResult(
+                tool_use_id="call_search_failure",
+                content=content,
+                is_error=False,
+                execution_status=status,
+            )
+        ],
+    )
+
+    anthropic_payload = _build_message_payload(message)
+    openai_payload = _build_openai_messages(message)
+    openai_content = json.loads(openai_payload[0]["content"])
+
+    assert anthropic_payload["content"][0]["is_error"] is True
+    assert openai_content["execution_status"]["status"] == "error"
+    assert openai_content["execution_status"]["reason"] == "search_auth"
+    assert json.loads(openai_content["output"])["ok"] is False

--- a/tests/test_sandbox/test_inprocess_managed_network.py
+++ b/tests/test_sandbox/test_inprocess_managed_network.py
@@ -1481,6 +1481,80 @@ async def test_rpc_search_query_allows_search_provider_endpoint_under_managed_ne
 
 
 @pytest.mark.asyncio
+async def test_rpc_search_query_grants_only_auto_execution_plan_providers(
+    monkeypatch: pytest.MonkeyPatch,
+    managed_context: ToolContext,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class FakeProxy:
+        host = "127.0.0.1"
+        port = 28080
+
+        def __init__(self, decide: object, **kwargs: object) -> None:
+            self._decide = decide
+
+        async def start(self) -> None:
+            for host in ("api.bochaai.com", "api.tavily.com"):
+                decision = self._decide(host)
+                assert isinstance(decision, NetworkDecision)
+                seen[host] = decision.status
+            duckduckgo = self._decide("html.duckduckgo.com")
+            assert isinstance(duckduckgo, NetworkDecision)
+            seen["html.duckduckgo.com"] = duckduckgo.status
+            seen["html.duckduckgo.com.reason"] = duckduckgo.reason
+
+        async def stop(self) -> None:
+            return None
+
+    async def fake_search(*args: object, **kwargs: object) -> dict[str, object]:
+        seen["search_called"] = True
+        return {
+            "ok": True,
+            "query": "python packages",
+            "provider": "bocha",
+            "results": [],
+        }
+
+    for key in (
+        "BOCHA_SEARCH_API_KEY",
+        "BRAVE_SEARCH_API_KEY",
+        "IQS_SEARCH_API_KEY",
+        "TAVILY_API_KEY",
+        "EXA_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("BOCHA_SEARCH_API_KEY", "bocha-key")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
+    monkeypatch.setattr(rpc_tools, "run_web_search_payload", fake_search)
+    monkeypatch.setattr(integration_mod, "SandboxProxyServer", FakeProxy)
+    web_mod.configure_search("duckduckgo", fallback_policy="network")
+    ctx = RpcContext(
+        conn_id="c",
+        principal=Principal(
+            role="operator",
+            scopes=frozenset(["operator.write", "operator.read"]),
+            is_owner=True,
+            authenticated=True,
+        ),
+    )
+
+    try:
+        result = await rpc_tools._handle_search_query({"query": "python packages"}, ctx)
+    finally:
+        web_mod.reset_search_runtime()
+
+    assert result["ok"] is True
+    assert seen == {
+        "api.bochaai.com": "allow",
+        "api.tavily.com": "allow",
+        "html.duckduckgo.com": "allow",
+        "html.duckduckgo.com.reason": "default_allowlist",
+        "search_called": True,
+    }
+
+
+@pytest.mark.asyncio
 async def test_rpc_search_query_without_runtime_uses_provider_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_sandbox/test_search_provider_system_domains.py
+++ b/tests/test_sandbox/test_search_provider_system_domains.py
@@ -94,3 +94,77 @@ def test_system_domain_grants_cover_active_keyed_provider(
         assert _system_domain_grants_for_request(request) == expected  # type: ignore[arg-type]
     finally:
         web.reset_search_runtime()
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "providers", "expected"),
+    [
+        (
+            "web_search",
+            "bocha,tavily",
+            ("api.bochaai.com", "api.tavily.com"),
+        ),
+        (
+            "web_discover",
+            "exa,duckduckgo",
+            ("api.exa.ai", "html.duckduckgo.com"),
+        ),
+        ("web_search", "duckduckgo", ("html.duckduckgo.com",)),
+    ],
+)
+def test_system_domain_grants_follow_bounded_search_execution_plan(
+    tool_name: str,
+    providers: str,
+    expected: tuple[str, ...],
+) -> None:
+    request = SimpleNamespace(argv=(tool_name, "query", f"providers={providers}"))
+
+    assert _system_domain_grants_for_request(request) == expected  # type: ignore[arg-type]
+
+
+def test_web_search_sandbox_argv_uses_runtime_execution_plan(monkeypatch) -> None:
+    from opensquilla.tools.builtin import web
+
+    for key in (
+        "BOCHA_SEARCH_API_KEY",
+        "BRAVE_SEARCH_API_KEY",
+        "IQS_SEARCH_API_KEY",
+        "TAVILY_API_KEY",
+        "EXA_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("BOCHA_SEARCH_API_KEY", "bocha-key")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
+    web.configure_search("duckduckgo", fallback_policy="network")
+    try:
+        argv = web._web_search_sandbox_argv({"query": "python release"})
+        request = SimpleNamespace(argv=argv)
+
+        assert argv[-1] == "providers=bocha,tavily"
+        assert _system_domain_grants_for_request(request) == (  # type: ignore[arg-type]
+            "api.bochaai.com",
+            "api.tavily.com",
+        )
+    finally:
+        web.reset_search_runtime()
+
+
+def test_discover_plan_token_honors_explicit_provider_override(monkeypatch) -> None:
+    from opensquilla.tools.builtin import web
+
+    monkeypatch.setenv("EXA_API_KEY", "exa-key")
+    web.configure_search("duckduckgo", fallback_policy="network")
+    try:
+        token = web._search_plan_argv_token(
+            {"query": "python release", "provider": "exa"},
+            tool_name="web_discover",
+        )
+        request = SimpleNamespace(argv=("web_search", "python release", token))
+
+        assert token == "providers=exa,duckduckgo"
+        assert _system_domain_grants_for_request(request) == (  # type: ignore[arg-type]
+            "api.exa.ai",
+            "html.duckduckgo.com",
+        )
+    finally:
+        web.reset_search_runtime()

--- a/tests/test_search/test_bocha_provider.py
+++ b/tests/test_search/test_bocha_provider.py
@@ -114,8 +114,10 @@ async def test_bocha_missing_api_key_raises_auth_error(
 @pytest.mark.parametrize(
     ("status_code", "kind", "retryable"),
     [
+        (400, "http", False),
         (401, "auth", False),
         (403, "auth", False),
+        (408, "http", True),
         (429, "rate_limit", True),
         (500, "http", True),
     ],
@@ -125,7 +127,10 @@ async def test_bocha_http_errors_are_classified(
     kind: str,
     retryable: bool,
 ) -> None:
+    requests: list[httpx.Request] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         return httpx.Response(status_code, json={"error": "nope"})
 
     provider = BochaSearchProvider(
@@ -140,13 +145,16 @@ async def test_bocha_http_errors_are_classified(
     assert exc_info.value.kind == kind
     assert exc_info.value.retryable is retryable
     assert exc_info.value.status_code == status_code
+    assert len(requests) == 1
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("api_code", "kind", "retryable", "status_code"),
     [
+        ("400", "http", False, 400),
         ("401", "auth", False, 401),
+        ("408", "http", True, 408),
         ("429", "rate_limit", True, 429),
         ("500", "http", True, 500),
     ],
@@ -157,7 +165,10 @@ async def test_bocha_api_error_codes_are_classified(
     retryable: bool,
     status_code: int,
 ) -> None:
+    requests: list[httpx.Request] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         return httpx.Response(200, json={"code": api_code, "msg": "bocha error"})
 
     provider = BochaSearchProvider(
@@ -173,6 +184,81 @@ async def test_bocha_api_error_codes_are_classified(
     assert exc_info.value.retryable is retryable
     assert exc_info.value.status_code == status_code
     assert str(exc_info.value) == "bocha error"
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_bocha_nonnumeric_api_error_is_terminal() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"code": "INVALID_PARAMETER", "msg": "invalid request"},
+        )
+
+    provider = BochaSearchProvider(
+        api_key="dummy-bocha-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("OpenSquilla")
+
+    assert exc_info.value.kind == "http"
+    assert exc_info.value.retryable is False
+    assert exc_info.value.status_code is None
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_type", "kind"),
+    [(httpx.ReadTimeout, "timeout"), (httpx.ConnectError, "network")],
+)
+async def test_bocha_transport_errors_are_retryable_once(
+    error_type: type[httpx.HTTPError],
+    kind: str,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        raise error_type("transient failure", request=request)
+
+    provider = BochaSearchProvider(
+        api_key="dummy-bocha-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("OpenSquilla")
+
+    assert exc_info.value.kind == kind
+    assert exc_info.value.retryable is True
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_bocha_malformed_json_is_terminal_parse_error() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, text="not json")
+
+    provider = BochaSearchProvider(
+        api_key="dummy-bocha-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("OpenSquilla")
+
+    assert exc_info.value.kind == "parse"
+    assert exc_info.value.retryable is False
+    assert len(requests) == 1
 
 
 def test_bocha_provider_spec_is_runtime_supported_after_import() -> None:

--- a/tests/test_search/test_brave_config.py
+++ b/tests/test_search/test_brave_config.py
@@ -109,6 +109,92 @@ async def test_brave_provider_passes_recency_as_freshness() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_code", "kind", "retryable"),
+    [
+        (400, "http", False),
+        (401, "auth", False),
+        (403, "auth", False),
+        (408, "http", True),
+        (429, "rate_limit", True),
+        (500, "http", True),
+    ],
+)
+async def test_brave_http_errors_are_classified_once(
+    status_code: int,
+    kind: str,
+    retryable: bool,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(status_code, json={"error": "nope"})
+
+    provider = BraveSearchProvider(
+        api_key="brave-test-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("brave")
+
+    assert exc_info.value.kind == kind
+    assert exc_info.value.retryable is retryable
+    assert exc_info.value.status_code == status_code
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_type", "kind"),
+    [(httpx.ReadTimeout, "timeout"), (httpx.ConnectError, "network")],
+)
+async def test_brave_transport_errors_are_retryable_once(
+    error_type: type[httpx.HTTPError],
+    kind: str,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        raise error_type("transient failure", request=request)
+
+    provider = BraveSearchProvider(
+        api_key="brave-test-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("brave")
+
+    assert exc_info.value.kind == kind
+    assert exc_info.value.retryable is True
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_brave_malformed_json_is_terminal_parse_error() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, text="not json")
+
+    provider = BraveSearchProvider(
+        api_key="brave-test-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("brave")
+
+    assert exc_info.value.kind == "parse"
+    assert exc_info.value.retryable is False
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
 async def test_duckduckgo_provider_maps_provider_and_source() -> None:
     html = """
     <html>
@@ -144,7 +230,10 @@ async def test_duckduckgo_provider_treats_anomaly_challenge_as_blocked() -> None
     </html>
     """
 
+    requests: list[httpx.Request] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         return httpx.Response(202, text=html)
 
     provider = DuckDuckGoProvider(transport=httpx.MockTransport(handler))
@@ -154,7 +243,8 @@ async def test_duckduckgo_provider_treats_anomaly_challenge_as_blocked() -> None
 
     assert exc_info.value.provider == "duckduckgo"
     assert exc_info.value.kind == "blocked"
-    assert exc_info.value.retryable is True
+    assert exc_info.value.retryable is False
+    assert len(requests) == 1
 
 
 @pytest.mark.asyncio
@@ -167,19 +257,25 @@ async def test_duckduckgo_provider_allows_real_no_results() -> None:
     </html>
     """
 
+    requests: list[httpx.Request] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         return httpx.Response(200, text=html)
 
     provider = DuckDuckGoProvider(transport=httpx.MockTransport(handler))
 
     assert await provider.search("improbable query") == []
+    assert len(requests) == 1
 
 
 @pytest.mark.asyncio
 async def test_duckduckgo_provider_treats_unparseable_empty_page_as_parse_error() -> None:
     html = "<html><body><main>DuckDuckGo</main></body></html>"
+    requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         return httpx.Response(200, text=html)
 
     provider = DuckDuckGoProvider(transport=httpx.MockTransport(handler))
@@ -189,13 +285,24 @@ async def test_duckduckgo_provider_treats_unparseable_empty_page_as_parse_error(
 
     assert exc_info.value.provider == "duckduckgo"
     assert exc_info.value.kind == "parse"
-    assert exc_info.value.retryable is True
+    assert exc_info.value.retryable is False
+    assert len(requests) == 1
 
 
 @pytest.mark.asyncio
-async def test_duckduckgo_provider_surfaces_network_failures() -> None:
+@pytest.mark.parametrize(
+    ("status_code", "retryable"),
+    [(400, False), (401, False), (403, False), (408, True), (429, True), (500, True)],
+)
+async def test_duckduckgo_http_errors_are_classified_once(
+    status_code: int,
+    retryable: bool,
+) -> None:
+    requests: list[httpx.Request] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
-        raise httpx.ConnectError("network down", request=request)
+        requests.append(request)
+        return httpx.Response(status_code, text="upstream error")
 
     provider = DuckDuckGoProvider(transport=httpx.MockTransport(handler))
 
@@ -203,8 +310,36 @@ async def test_duckduckgo_provider_surfaces_network_failures() -> None:
         await provider.search("duck")
 
     assert exc_info.value.provider == "duckduckgo"
-    assert exc_info.value.kind == "network"
+    assert exc_info.value.kind == "http"
+    assert exc_info.value.retryable is retryable
+    assert exc_info.value.status_code == status_code
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_type", "kind"),
+    [(httpx.ReadTimeout, "timeout"), (httpx.ConnectError, "network")],
+)
+async def test_duckduckgo_transport_errors_are_retryable_once(
+    error_type: type[httpx.HTTPError],
+    kind: str,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        raise error_type("transient failure", request=request)
+
+    provider = DuckDuckGoProvider(transport=httpx.MockTransport(handler))
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("duck")
+
+    assert exc_info.value.provider == "duckduckgo"
+    assert exc_info.value.kind == kind
     assert exc_info.value.retryable is True
+    assert len(requests) == 1
 
 
 def test_search_payload_keeps_lightweight_metadata() -> None:

--- a/tests/test_search/test_canonical_web_search.py
+++ b/tests/test_search/test_canonical_web_search.py
@@ -120,6 +120,52 @@ class NetworkFailProvider:
         raise SearchProviderError("tavily", "network", "Network failed", retryable=True)
 
 
+class NamedNetworkFailProvider:
+    def __init__(self, name: str, calls: list[str]) -> None:
+        self.name = name
+        self._calls = calls
+
+    async def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+        self._calls.append(self.name)
+        raise SearchProviderError(
+            self.name,
+            "network",
+            f"{self.name} network failed",
+            retryable=True,
+        )
+
+
+class NamedSuccessProvider:
+    def __init__(self, name: str, calls: list[str]) -> None:
+        self.name = name
+        self._calls = calls
+
+    async def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+        self._calls.append(self.name)
+        return [
+            SearchResult(
+                title=f"{self.name} result",
+                url=f"https://{self.name}.example/result",
+                snippet=f"{self.name} snippet",
+                provider=self.name,
+                source=self.name,
+            )
+        ][:max_results]
+
+
+class NonRetryableHttpProvider:
+    name = "tavily"
+
+    async def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+        raise SearchProviderError(
+            self.name,
+            "http",
+            "Bad request",
+            retryable=False,
+            status_code=400,
+        )
+
+
 class BlockedProvider:
     def __init__(self, name: str = "duckduckgo") -> None:
         self.name = name
@@ -360,6 +406,8 @@ async def test_canonical_web_search_primary_auth_failure_does_not_silent_fallbac
 
     assert payload["ok"] is False
     assert payload["error_kind"] == "auth"
+    assert payload["provider_retryable"] is False
+    assert payload["retry_allowed"] is False
     assert payload["provider_attempts"] == [{"provider": "tavily", "status": "auth_failed"}]
 
 
@@ -579,6 +627,162 @@ async def test_canonical_web_search_falls_back_on_retryable_network_error() -> N
     ]
     assert payload["diagnostics"]["fallback_from"] == "tavily"
     assert payload["results"][0]["provider"] == "duckduckgo"
+    assert "retry_allowed" not in payload
+    assert "provider_retryable" not in payload
+
+
+@pytest.mark.asyncio
+async def test_canonical_web_search_auto_network_attempts_at_most_two_ranked_providers(
+    monkeypatch,
+) -> None:
+    for key in (
+        "BOCHA_SEARCH_API_KEY",
+        "TAVILY_API_KEY",
+        "BRAVE_SEARCH_API_KEY",
+        "EXA_API_KEY",
+        "IQS_SEARCH_API_KEY",
+    ):
+        monkeypatch.setenv(key, f"{key.lower()}-value")
+    calls: list[str] = []
+    runtime = resolve_search_runtime(
+        SearchRuntimeConfig(provider="duckduckgo", fallback_policy="network")
+    )
+
+    payload = await run_canonical_web_search(
+        SearchOptions(query="bounded fallback", fetch_top_k=0),
+        runtime=runtime,
+        provider_factory=lambda name: NamedNetworkFailProvider(name, calls),
+    )
+
+    assert payload["ok"] is False
+    assert payload["retry_allowed"] is False
+    assert payload["provider_retryable"] is True
+    assert calls == ["bocha", "tavily"]
+    assert payload["provider_attempts"] == [
+        {"provider": "bocha", "status": "error", "error_kind": "network"},
+        {"provider": "tavily", "status": "error", "error_kind": "network"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_canonical_web_search_auto_network_skips_runtime_missing_key_to_backup(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("EXA_API_KEY", "stale-exa-key")
+    monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "brave-key")
+    monkeypatch.delenv("BOCHA_SEARCH_API_KEY", raising=False)
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.delenv("IQS_SEARCH_API_KEY", raising=False)
+    attempted: list[str] = []
+
+    def provider_factory(name: str) -> MissingKeyAuthProvider | NamedSuccessProvider:
+        attempted.append(name)
+        if name == "exa":
+            return MissingKeyAuthProvider()
+        return NamedSuccessProvider(name, [])
+
+    payload = await run_canonical_web_search(
+        SearchOptions(query="python sqlite api docs", mode="technical", fetch_top_k=0),
+        runtime=resolve_search_runtime(
+            SearchRuntimeConfig(provider="duckduckgo", fallback_policy="network")
+        ),
+        provider_factory=provider_factory,
+    )
+
+    assert payload["ok"] is True
+    assert attempted == ["exa", "brave"]
+    assert payload["provider_attempts"] == [
+        {"provider": "exa", "status": "auth_missing"},
+        {"provider": "brave", "status": "success"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_canonical_web_search_auto_off_skips_local_auth_missing_once(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("EXA_API_KEY", "stale-exa-key")
+    monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "brave-key")
+    monkeypatch.delenv("BOCHA_SEARCH_API_KEY", raising=False)
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.delenv("IQS_SEARCH_API_KEY", raising=False)
+    attempted: list[str] = []
+
+    def provider_factory(name: str) -> MissingKeyAuthProvider | NamedSuccessProvider:
+        attempted.append(name)
+        if name == "exa":
+            return MissingKeyAuthProvider()
+        return NamedSuccessProvider(name, [])
+
+    payload = await run_canonical_web_search(
+        SearchOptions(query="python sqlite api docs", mode="technical", fetch_top_k=0),
+        runtime=resolve_search_runtime(
+            SearchRuntimeConfig(provider="duckduckgo", fallback_policy="off")
+        ),
+        provider_factory=provider_factory,
+    )
+
+    assert payload["ok"] is True
+    assert attempted == ["exa", "brave"]
+    assert payload["provider_attempts"] == [
+        {"provider": "exa", "status": "auth_missing"},
+        {"provider": "brave", "status": "success"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_canonical_web_search_auto_off_does_not_network_fallback(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("BOCHA_SEARCH_API_KEY", "bocha-key")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
+    monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+    monkeypatch.delenv("IQS_SEARCH_API_KEY", raising=False)
+    calls: list[str] = []
+
+    payload = await run_canonical_web_search(
+        SearchOptions(query="bounded off", fetch_top_k=0),
+        runtime=resolve_search_runtime(
+            SearchRuntimeConfig(provider="duckduckgo", fallback_policy="off")
+        ),
+        provider_factory=lambda name: NamedNetworkFailProvider(name, calls),
+    )
+
+    assert payload["ok"] is False
+    assert calls == ["bocha"]
+    assert payload["provider_attempts"] == [
+        {"provider": "bocha", "status": "error", "error_kind": "network"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_canonical_web_search_network_policy_respects_non_retryable_error() -> None:
+    attempted: list[str] = []
+
+    def provider_factory(name: str) -> NonRetryableHttpProvider | FallbackProvider:
+        attempted.append(name)
+        if name == "tavily":
+            return NonRetryableHttpProvider()
+        return FallbackProvider()
+
+    payload = await run_canonical_web_search(
+        SearchOptions(query="q", provider="tavily", fetch_top_k=0),
+        runtime=resolve_search_runtime(
+            SearchRuntimeConfig(
+                provider="tavily",
+                api_key="tavily-key",
+                fallback_policy="network",
+            )
+        ),
+        provider_factory=provider_factory,
+    )
+
+    assert payload["ok"] is False
+    assert payload["error_kind"] == "http"
+    assert payload["provider_retryable"] is False
+    assert payload["retry_allowed"] is False
+    assert attempted == ["tavily"]
 
 
 @pytest.mark.asyncio
@@ -612,6 +816,8 @@ async def test_canonical_web_search_surfaces_blocked_provider_failure() -> None:
 
     assert payload["ok"] is False
     assert payload["error_kind"] == "blocked"
+    assert payload["provider_retryable"] is True
+    assert payload["retry_allowed"] is False
     assert payload["provider_attempts"] == [
         {"provider": "duckduckgo", "status": "error", "error_kind": "blocked"}
     ]
@@ -619,8 +825,11 @@ async def test_canonical_web_search_surfaces_blocked_provider_failure() -> None:
 
 
 @pytest.mark.asyncio
-async def test_canonical_web_search_falls_back_on_retryable_blocked_error() -> None:
+async def test_canonical_web_search_does_not_fallback_on_retryable_blocked_error() -> None:
+    calls: list[str] = []
+
     def provider_factory(name: str) -> BlockedProvider | FallbackProvider:
+        calls.append(name)
         if name == "tavily":
             return BlockedProvider(name)
         return FallbackProvider()
@@ -633,12 +842,12 @@ async def test_canonical_web_search_falls_back_on_retryable_blocked_error() -> N
         provider_factory=provider_factory,
     )
 
-    assert payload["ok"] is True
+    assert payload["ok"] is False
+    assert payload["retry_allowed"] is False
     assert payload["provider_attempts"] == [
         {"provider": "tavily", "status": "error", "error_kind": "blocked"},
-        {"provider": "duckduckgo", "status": "success"},
     ]
-    assert payload["results"][0]["provider"] == "duckduckgo"
+    assert calls == ["tavily"]
 
 
 @pytest.mark.asyncio
@@ -772,7 +981,9 @@ async def test_canonical_web_search_no_key_auto_recency_uses_duckduckgo_soft_deg
 
 
 @pytest.mark.asyncio
-async def test_canonical_web_search_technical_mode_prefers_exa_then_brave(monkeypatch) -> None:
+async def test_canonical_web_search_technical_mode_off_uses_top_ranked_provider_once(
+    monkeypatch,
+) -> None:
     monkeypatch.setenv("EXA_API_KEY", "exa-key")
     monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "brave-key")
     monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
@@ -781,11 +992,9 @@ async def test_canonical_web_search_technical_mode_prefers_exa_then_brave(monkey
     monkeypatch.delenv("BOCHA_SEARCH_API_KEY", raising=False)
     attempted: list[str] = []
 
-    def provider_factory(name: str) -> MissingKeyAuthProvider | FallbackProvider:
+    def provider_factory(name: str) -> NamedSuccessProvider:
         attempted.append(name)
-        if name == "exa":
-            return MissingKeyAuthProvider()
-        return FallbackProvider()
+        return NamedSuccessProvider(name, [])
 
     payload = await run_canonical_web_search(
         SearchOptions(query="python sqlite api docs", mode="technical", fetch_top_k=0),
@@ -793,10 +1002,9 @@ async def test_canonical_web_search_technical_mode_prefers_exa_then_brave(monkey
     )
 
     assert payload["ok"] is True
-    assert attempted == ["exa", "brave"]
+    assert attempted == ["exa"]
     assert payload["provider_attempts"] == [
-        {"provider": "exa", "status": "auth_missing"},
-        {"provider": "brave", "status": "success"},
+        {"provider": "exa", "status": "success"},
     ]
 
 
@@ -966,3 +1174,43 @@ async def test_canonical_web_search_caches_complete_payload_for_repeated_request
     assert first["diagnostics"]["cache_status"] == "miss"
     assert second["diagnostics"]["cache_status"] == "hit"
     assert second["results"][0]["excerpt"] == "Fetched cache body"
+
+
+@pytest.mark.asyncio
+async def test_canonical_web_search_cache_key_includes_execution_plan(monkeypatch) -> None:
+    canonical_module.clear_canonical_web_search_cache_for_tests()
+    for key in (
+        "BOCHA_SEARCH_API_KEY",
+        "TAVILY_API_KEY",
+        "BRAVE_SEARCH_API_KEY",
+        "EXA_API_KEY",
+        "IQS_SEARCH_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("BOCHA_SEARCH_API_KEY", "bocha-key")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
+    calls: list[str] = []
+    options = SearchOptions(query="plan cache", fetch_top_k=0)
+
+    first = await run_canonical_web_search(
+        options,
+        runtime=resolve_search_runtime(
+            SearchRuntimeConfig(provider="duckduckgo", fallback_policy="network")
+        ),
+        provider_factory=lambda name: NamedSuccessProvider(name, calls),
+        use_cache=True,
+    )
+    second = await run_canonical_web_search(
+        options,
+        runtime=resolve_search_runtime(
+            SearchRuntimeConfig(provider="duckduckgo", fallback_policy="off")
+        ),
+        provider_factory=lambda name: NamedSuccessProvider(name, calls),
+        use_cache=True,
+    )
+
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert calls == ["bocha", "bocha"]
+    assert first["diagnostics"]["cache_status"] == "miss"
+    assert second["diagnostics"]["cache_status"] == "miss"

--- a/tests/test_search/test_exa_provider.py
+++ b/tests/test_search/test_exa_provider.py
@@ -125,8 +125,10 @@ async def test_exa_missing_api_key_raises_auth_error(monkeypatch: pytest.MonkeyP
 @pytest.mark.parametrize(
     ("status_code", "kind", "retryable"),
     [
+        (400, "http", False),
         (401, "auth", False),
         (403, "auth", False),
+        (408, "http", True),
         (429, "rate_limit", True),
         (500, "http", True),
     ],
@@ -138,7 +140,10 @@ async def test_exa_http_errors_are_classified(
 ) -> None:
     from opensquilla.search.providers.exa import ExaSearchProvider
 
+    requests: list[httpx.Request] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         return httpx.Response(status_code, json={"error": "nope"})
 
     provider = ExaSearchProvider(
@@ -153,6 +158,60 @@ async def test_exa_http_errors_are_classified(
     assert exc_info.value.kind == kind
     assert exc_info.value.retryable is retryable
     assert exc_info.value.status_code == status_code
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_type", "kind"),
+    [(httpx.ReadTimeout, "timeout"), (httpx.ConnectError, "network")],
+)
+async def test_exa_transport_errors_are_retryable_once(
+    error_type: type[httpx.HTTPError],
+    kind: str,
+) -> None:
+    from opensquilla.search.providers.exa import ExaSearchProvider
+
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        raise error_type("transient failure", request=request)
+
+    provider = ExaSearchProvider(
+        api_key="dummy-exa-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("python")
+
+    assert exc_info.value.kind == kind
+    assert exc_info.value.retryable is True
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_exa_malformed_json_is_terminal_parse_error() -> None:
+    from opensquilla.search.providers.exa import ExaSearchProvider
+
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, text="not json")
+
+    provider = ExaSearchProvider(
+        api_key="dummy-exa-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("python")
+
+    assert exc_info.value.kind == "parse"
+    assert exc_info.value.retryable is False
+    assert len(requests) == 1
 
 
 def test_exa_provider_spec_is_runtime_supported_after_import() -> None:

--- a/tests/test_search/test_iqs_provider.py
+++ b/tests/test_search/test_iqs_provider.py
@@ -161,9 +161,11 @@ async def test_iqs_missing_api_key_raises_auth_error(
 @pytest.mark.parametrize(
     ("status_code", "kind", "retryable"),
     [
+        (400, "http", False),
         (401, "auth", False),
         (403, "auth", False),
         (404, "auth", False),
+        (408, "http", True),
         (429, "rate_limit", True),
         (500, "http", True),
     ],
@@ -173,7 +175,10 @@ async def test_iqs_http_errors_are_classified(
     kind: str,
     retryable: bool,
 ) -> None:
+    requests: list[httpx.Request] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         return httpx.Response(status_code, json={"error": "nope"})
 
     provider = IqsSearchProvider(
@@ -188,6 +193,7 @@ async def test_iqs_http_errors_are_classified(
     assert exc_info.value.kind == kind
     assert exc_info.value.retryable is retryable
     assert exc_info.value.status_code == status_code
+    assert len(requests) == 1
 
 
 @pytest.mark.asyncio
@@ -228,9 +234,37 @@ async def test_iqs_http_error_with_non_json_body_is_classified() -> None:
         await provider.search("OpenSquilla")
 
     assert exc_info.value.kind == "http"
-    assert exc_info.value.retryable is True
+    assert exc_info.value.retryable is False
     assert exc_info.value.status_code == 400
     assert "EngineType deserialization failed" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_type", "kind"),
+    [(httpx.ReadTimeout, "timeout"), (httpx.ConnectError, "network")],
+)
+async def test_iqs_transport_errors_are_retryable_once(
+    error_type: type[httpx.HTTPError],
+    kind: str,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        raise error_type("transient failure", request=request)
+
+    provider = IqsSearchProvider(
+        api_key="dummy-iqs-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("OpenSquilla")
+
+    assert exc_info.value.kind == kind
+    assert exc_info.value.retryable is True
+    assert len(requests) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_search/test_search_runtime_config.py
+++ b/tests/test_search/test_search_runtime_config.py
@@ -4,7 +4,7 @@ import sys
 
 from opensquilla.search.providers.exa import ExaSearchProvider
 from opensquilla.search.runtime_config import SearchRuntimeConfig, resolve_search_runtime
-from opensquilla.search.types import SearchOptions
+from opensquilla.search.types import SearchOptions, SearchProviderError
 
 
 def _clear_search_env(monkeypatch) -> None:
@@ -177,6 +177,209 @@ def test_resolver_all_key_mode_tie_breakers_with_iqs(monkeypatch) -> None:
     assert runtime.provider_order(
         SearchOptions(query="q", include_domains=("python.org",))
     ) == ("tavily", "iqs", "exa")
+
+
+def test_execution_plan_bounds_auto_network_without_truncating_provider_order(
+    monkeypatch,
+) -> None:
+    _clear_search_env(monkeypatch)
+    monkeypatch.setenv("BOCHA_SEARCH_API_KEY", "bocha-key")
+    monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "brave-key")
+    monkeypatch.setenv("IQS_SEARCH_API_KEY", "iqs-key")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
+    monkeypatch.setenv("EXA_API_KEY", "exa-key")
+    runtime = resolve_search_runtime(
+        SearchRuntimeConfig(provider="duckduckgo", fallback_policy="network")
+    )
+    options = SearchOptions(query="q")
+
+    assert runtime.provider_order(options) == (
+        "bocha",
+        "tavily",
+        "iqs",
+        "brave",
+        "exa",
+        "duckduckgo",
+    )
+    plan = runtime.execution_plan(options)
+    assert plan.provider_names == ("bocha", "tavily")
+    assert plan.planned_provider_ids == ("bocha", "tavily")
+    assert plan.primary_provider == "bocha"
+    assert plan.fallback_provider == "tavily"
+    assert plan.selection_mode == "automatic"
+    assert plan.fallback_mode == "network"
+
+
+def test_execution_plan_auto_network_uses_next_capability_matched_provider(
+    monkeypatch,
+) -> None:
+    _clear_search_env(monkeypatch)
+    monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "brave-key")
+    monkeypatch.setenv("IQS_SEARCH_API_KEY", "iqs-key")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
+    monkeypatch.setenv("EXA_API_KEY", "exa-key")
+    runtime = resolve_search_runtime(
+        SearchRuntimeConfig(provider="duckduckgo", fallback_policy="network")
+    )
+    options = SearchOptions(query="q", include_domains=("python.org",))
+
+    assert runtime.provider_order(options) == ("tavily", "iqs", "exa")
+    assert runtime.execution_plan(options).provider_names == ("tavily", "iqs")
+
+
+def test_execution_plan_auto_network_uses_duckduckgo_when_no_keyed_candidate(
+    monkeypatch,
+) -> None:
+    _clear_search_env(monkeypatch)
+    runtime = resolve_search_runtime(
+        SearchRuntimeConfig(provider="duckduckgo", fallback_policy="network")
+    )
+
+    assert runtime.execution_plan(SearchOptions(query="q")).provider_names == (
+        "duckduckgo",
+    )
+
+
+def test_execution_plan_auto_network_uses_duckduckgo_when_no_keyed_backup(
+    monkeypatch,
+) -> None:
+    _clear_search_env(monkeypatch)
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
+    runtime = resolve_search_runtime(
+        SearchRuntimeConfig(provider="duckduckgo", fallback_policy="network")
+    )
+    options = SearchOptions(query="q", include_domains=("python.org",))
+
+    assert runtime.provider_order(options) == ("tavily",)
+    assert runtime.execution_plan(options).provider_names == (
+        "tavily",
+        "duckduckgo",
+    )
+
+
+def test_execution_plan_explicit_network_preserves_duckduckgo_fallback(monkeypatch) -> None:
+    _clear_search_env(monkeypatch)
+    runtime = resolve_search_runtime(
+        SearchRuntimeConfig(
+            provider="tavily",
+            api_key="tavily-key",
+            fallback_policy="network",
+        )
+    )
+
+    plan = runtime.execution_plan(SearchOptions(query="q", provider="tavily"))
+    assert plan.provider_names == ("tavily", "duckduckgo")
+    assert plan.selection_mode == "explicit"
+    assert plan.fallback_mode == "network"
+
+
+def test_execution_plan_off_preselects_only_one_auto_auth_skip(monkeypatch) -> None:
+    _clear_search_env(monkeypatch)
+    monkeypatch.setenv("BOCHA_SEARCH_API_KEY", "bocha-key")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
+    runtime = resolve_search_runtime(
+        SearchRuntimeConfig(provider="duckduckgo", fallback_policy="off")
+    )
+    options = SearchOptions(query="q")
+
+    assert runtime.provider_order(options) == ("bocha", "tavily", "duckduckgo")
+    plan = runtime.execution_plan(options)
+    assert plan.provider_names == ("bocha", "tavily")
+    assert plan.fallback_mode == "auth_missing"
+
+
+def test_off_policy_only_allows_auto_dynamic_auth_missing_skip(monkeypatch) -> None:
+    _clear_search_env(monkeypatch)
+    runtime = resolve_search_runtime(
+        SearchRuntimeConfig(provider="duckduckgo", fallback_policy="off")
+    )
+    error = SearchProviderError(
+        provider="bocha",
+        kind="auth",
+        message="Bocha API key not set",
+        retryable=False,
+    )
+
+    assert runtime.should_fallback(error, explicit_provider=False) is True
+    assert runtime.should_fallback(error, explicit_provider=True) is False
+
+
+def test_network_policy_requires_transient_classification_and_provider_permission(
+    monkeypatch,
+) -> None:
+    _clear_search_env(monkeypatch)
+    runtime = resolve_search_runtime(
+        SearchRuntimeConfig(provider="duckduckgo", fallback_policy="network")
+    )
+
+    for error in (
+        SearchProviderError("bocha", "blocked", "terminal", retryable=True),
+        SearchProviderError("bocha", "parse", "terminal", retryable=True),
+        SearchProviderError("bocha", "unknown", "terminal", retryable=True),
+    ):
+        assert runtime.should_fallback(
+            error,
+            explicit_provider=False,
+        ) is False
+    assert runtime.should_fallback(
+        SearchProviderError(
+            provider="bocha",
+            kind="blocked",
+            message="challenge surfaced as server error",
+            retryable=True,
+            status_code=500,
+        ),
+        explicit_provider=False,
+    ) is False
+    assert runtime.should_fallback(
+        SearchProviderError(
+            provider="bocha",
+            kind="http",
+            message="bad request",
+            retryable=True,
+            status_code=400,
+        ),
+        explicit_provider=False,
+    ) is False
+    assert runtime.should_fallback(
+        SearchProviderError(
+            provider="bocha",
+            kind="rate_limit",
+            message="rate limited without HTTP status",
+            retryable=True,
+        ),
+        explicit_provider=False,
+    ) is False
+    assert runtime.should_fallback(
+        SearchProviderError(
+            provider="bocha",
+            kind="rate_limit",
+            message="rate limited",
+            retryable=True,
+            status_code=429,
+        ),
+        explicit_provider=False,
+    ) is True
+    assert runtime.should_fallback(
+        SearchProviderError(
+            provider="bocha",
+            kind="http",
+            message="server error",
+            retryable=False,
+            status_code=500,
+        ),
+        explicit_provider=False,
+    ) is False
+    assert runtime.should_fallback(
+        SearchProviderError(
+            provider="bocha",
+            kind="http",
+            message="server error",
+            retryable=True,
+            status_code=500,
+        ),
+        explicit_provider=False,
+    ) is True
 
 
 def test_resolver_domain_constrained_auto_prefers_domain_filter_providers(

--- a/tests/test_search/test_tavily_provider.py
+++ b/tests/test_search/test_tavily_provider.py
@@ -148,8 +148,10 @@ async def test_tavily_missing_api_key_raises_auth_error(monkeypatch) -> None:
 @pytest.mark.parametrize(
     ("status_code", "kind", "retryable"),
     [
+        (400, "http", False),
         (401, "auth", False),
         (403, "auth", False),
+        (408, "http", True),
         (429, "rate_limit", True),
         (432, "rate_limit", False),
         (433, "rate_limit", False),
@@ -161,7 +163,10 @@ async def test_tavily_http_errors_are_classified(
     kind: str,
     retryable: bool,
 ) -> None:
+    requests: list[httpx.Request] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         return httpx.Response(status_code, json={"error": "nope"})
 
     provider = TavilySearchProvider(
@@ -176,11 +181,15 @@ async def test_tavily_http_errors_are_classified(
     assert exc_info.value.kind == kind
     assert exc_info.value.retryable is retryable
     assert exc_info.value.status_code == status_code
+    assert len(requests) == 1
 
 
 @pytest.mark.asyncio
 async def test_tavily_timeout_is_retryable_timeout() -> None:
+    requests: list[httpx.Request] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         raise httpx.ReadTimeout("timed out", request=request)
 
     provider = TavilySearchProvider(
@@ -193,11 +202,15 @@ async def test_tavily_timeout_is_retryable_timeout() -> None:
 
     assert exc_info.value.kind == "timeout"
     assert exc_info.value.retryable is True
+    assert len(requests) == 1
 
 
 @pytest.mark.asyncio
 async def test_tavily_network_error_is_retryable_network() -> None:
+    requests: list[httpx.Request] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         raise httpx.ConnectError("network down", request=request)
 
     provider = TavilySearchProvider(
@@ -210,3 +223,25 @@ async def test_tavily_network_error_is_retryable_network() -> None:
 
     assert exc_info.value.kind == "network"
     assert exc_info.value.retryable is True
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_tavily_malformed_json_is_terminal_parse_error() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, text="not json")
+
+    provider = TavilySearchProvider(
+        api_key="dummy-tavily-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SearchProviderError) as exc_info:
+        await provider.search("python")
+
+    assert exc_info.value.kind == "parse"
+    assert exc_info.value.retryable is False
+    assert len(requests) == 1

--- a/tests/test_tools/test_dispatch_envelope.py
+++ b/tests/test_tools/test_dispatch_envelope.py
@@ -2660,3 +2660,331 @@ async def test_dispatch_tracker_limits_concurrent_tool_results_per_turn() -> Non
 
     returned_total = sum(_strict_preview_chars(result.content) for result in results)
     assert returned_total <= 180
+
+
+@pytest.mark.asyncio
+async def test_dispatch_marks_explicit_web_search_failure_and_replays_terminal_outcome(
+    monkeypatch,
+) -> None:
+    registry = ToolRegistry()
+    calls = 0
+
+    async def web_search(
+        query: str,
+        mode: str = "auto",
+        max_results: int | None = None,
+        fetch_top_k: int | None = None,
+        max_chars_per_source: int | None = None,
+        provider: str | None = None,
+    ) -> str:
+        nonlocal calls
+        del query, mode, max_results, fetch_top_k, max_chars_per_source, provider
+        calls += 1
+        return json.dumps(
+            {
+                "ok": False,
+                "error_kind": "auth",
+                "retry_allowed": False,
+                "results": [],
+            }
+        )
+
+    registry.register(
+        ToolSpec(
+            name="web_search",
+            description="search",
+            parameters={
+                "query": {"type": "string"},
+                "mode": {"type": "string"},
+                "max_results": {"type": "integer"},
+                "provider": {"type": "string"},
+            },
+            required=["query"],
+            result_budget_class="external",
+        ),
+        web_search,
+    )
+    handler = build_tool_handler(
+        registry,
+        ToolContext(tool_run_budget_key="dispatch-terminal-search-outcome"),
+    )
+    log_events: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        dispatch_module.log,
+        "debug",
+        lambda event, **payload: log_events.append((event, payload)),
+    )
+
+    first = await handler(
+        ToolCall(
+            tool_use_id="tc-search-terminal-first",
+            tool_name="web_search",
+            arguments={
+                "query": "  OpenSquilla   release ",
+                "provider": "tavily",
+                "max_results": 3,
+            },
+        )
+    )
+    replay = await handler(
+        ToolCall(
+            tool_use_id="tc-search-terminal-replay",
+            tool_name="web_search",
+            arguments={
+                "query": "opensquilla release",
+                "provider": "duckduckgo",
+                "max_results": 10,
+            },
+        )
+    )
+
+    assert calls == 1
+    assert first.is_error is True
+    assert first.execution_status is not None
+    assert first.execution_status["status"] == "error"
+    assert first.execution_status["reason"] == "search_auth"
+    assert replay.is_error is True
+    assert replay.execution_status is not None
+    assert replay.execution_status["reason"] == "terminal_search_failure_replay"
+    replay_payload = json.loads(replay.content)
+    assert replay_payload["status"] == "error"
+    assert replay_payload["reason"] == "terminal_search_failure_replay"
+    assert replay_payload["error_kind"] == "auth"
+    assert replay_payload["retry_allowed"] is False
+
+    diagnostic = next(
+        payload
+        for event, payload in log_events
+        if event == "dispatch.web_retrieval_tool_run_diagnostics"
+    )
+    assert diagnostic["status"] == "error"
+    assert diagnostic["error_kind"] == "auth"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_terminal_search_cannot_be_replayed_via_web_discover() -> None:
+    registry = ToolRegistry()
+    calls: list[str] = []
+
+    async def web_search(
+        query: str,
+        mode: str = "auto",
+        max_results: int | None = None,
+        fetch_top_k: int | None = None,
+        max_chars_per_source: int | None = None,
+        provider: str | None = None,
+    ) -> str:
+        del query, mode, max_results, fetch_top_k, max_chars_per_source, provider
+        calls.append("web_search")
+        return json.dumps(
+            {
+                "ok": False,
+                "error_kind": "network",
+                "retry_allowed": False,
+                "results": [],
+            }
+        )
+
+    async def web_discover(query: str, max_results: int | None = None) -> str:
+        del query, max_results
+        calls.append("web_discover")
+        return json.dumps({"results": []})
+
+    registry.register(
+        ToolSpec(
+            name="web_search",
+            description="search",
+            parameters={
+                "query": {"type": "string"},
+                "mode": {"type": "string"},
+                "max_results": {"type": "integer"},
+                "provider": {"type": "string"},
+            },
+            required=["query"],
+            result_budget_class="external",
+        ),
+        web_search,
+    )
+    registry.register(
+        ToolSpec(
+            name="web_discover",
+            description="discover",
+            parameters={
+                "query": {"type": "string"},
+                "max_results": {"type": "integer"},
+            },
+            required=["query"],
+            result_budget_class="external",
+        ),
+        web_discover,
+    )
+    handler = build_tool_handler(
+        registry,
+        ToolContext(tool_run_budget_key="dispatch-cross-tool-terminal-search"),
+    )
+
+    first = await handler(
+        ToolCall(
+            tool_use_id="tc-cross-tool-search",
+            tool_name="web_search",
+            arguments={
+                "query": " OpenSquilla release ",
+                "provider": "tavily",
+                "max_results": 3,
+            },
+        )
+    )
+    replay = await handler(
+        ToolCall(
+            tool_use_id="tc-cross-tool-discover",
+            tool_name="web_discover",
+            arguments={"query": "opensquilla release", "max_results": 10},
+        )
+    )
+
+    assert first.is_error is True
+    assert replay.is_error is True
+    assert calls == ["web_search"]
+    assert replay.execution_status is not None
+    assert replay.execution_status["reason"] == "terminal_search_failure_replay"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_returns_neutral_control_for_duplicate_search_in_flight() -> None:
+    registry = ToolRegistry()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def web_search(
+        query: str,
+        mode: str = "auto",
+        max_results: int | None = None,
+        fetch_top_k: int | None = None,
+        max_chars_per_source: int | None = None,
+        provider: str | None = None,
+    ) -> str:
+        nonlocal calls
+        del query, mode, max_results, fetch_top_k, max_chars_per_source, provider
+        calls += 1
+        started.set()
+        await release.wait()
+        return json.dumps({"ok": True, "results": []})
+
+    registry.register(
+        ToolSpec(
+            name="web_search",
+            description="search",
+            parameters={
+                "query": {"type": "string"},
+                "provider": {"type": "string"},
+                "max_results": {"type": "integer"},
+            },
+            required=["query"],
+            result_budget_class="external",
+        ),
+        web_search,
+    )
+    handler = build_tool_handler(
+        registry,
+        ToolContext(tool_run_budget_key="dispatch-inflight-search"),
+    )
+
+    active_task = asyncio.create_task(
+        handler(
+            ToolCall(
+                tool_use_id="tc-search-inflight-active",
+                tool_name="web_search",
+                arguments={
+                    "query": "OpenSquilla",
+                    "provider": "tavily",
+                    "max_results": 3,
+                },
+            )
+        )
+    )
+    await started.wait()
+    duplicate = await handler(
+        ToolCall(
+            tool_use_id="tc-search-inflight-duplicate",
+            tool_name="web_search",
+            arguments={
+                "query": " opensquilla ",
+                "provider": "duckduckgo",
+                "max_results": 10,
+            },
+        )
+    )
+    release.set()
+    active = await active_task
+
+    assert calls == 1
+    assert active.is_error is False
+    assert duplicate.is_error is False
+    assert duplicate.execution_status is not None
+    assert duplicate.execution_status["status"] == "unknown"
+    assert duplicate.execution_status["reason"] == "duplicate_search_in_flight"
+    duplicate_payload = json.loads(duplicate.content)
+    assert duplicate_payload["status"] == "control"
+    assert duplicate_payload["reason"] == "duplicate_search_in_flight"
+    assert duplicate_payload["retry_allowed"] is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_terminal_search_ledger_isolated_by_turn_key() -> None:
+    registry = ToolRegistry()
+    calls = 0
+
+    async def web_search(
+        query: str,
+        max_results: int | None = None,
+        fetch_top_k: int | None = None,
+        max_chars_per_source: int | None = None,
+    ) -> str:
+        nonlocal calls
+        del query, max_results, fetch_top_k, max_chars_per_source
+        calls += 1
+        return json.dumps(
+            {
+                "ok": False,
+                "error_kind": "blocked",
+                "retry_allowed": False,
+                "results": [],
+            }
+        )
+
+    registry.register(
+        ToolSpec(
+            name="web_search",
+            description="search",
+            parameters={"query": {"type": "string"}},
+            required=["query"],
+            result_budget_class="external",
+        ),
+        web_search,
+    )
+    handler = build_tool_handler(registry)
+
+    async def call_in_turn(turn_key: str, tool_use_id: str):
+        token = current_tool_context.set(ToolContext(tool_run_budget_key=turn_key))
+        try:
+            return await handler(
+                ToolCall(
+                    tool_use_id=tool_use_id,
+                    tool_name="web_search",
+                    arguments={"query": "OpenSquilla"},
+                )
+            )
+        finally:
+            current_tool_context.reset(token)
+
+    first = await call_in_turn("turn-one", "tc-search-turn-one")
+    next_turn = await call_in_turn("turn-two", "tc-search-turn-two")
+
+    assert calls == 2
+    assert first.is_error is True
+    assert next_turn.is_error is True
+    assert first.execution_status is not None
+    assert next_turn.execution_status is not None
+    assert first.execution_status["reason"] == "search_blocked"
+    assert next_turn.execution_status["reason"] == "search_blocked"

--- a/tests/test_tools/test_loop_guard.py
+++ b/tests/test_tools/test_loop_guard.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import pytest
 
 from opensquilla.result_budget import (
+    DuplicateRetrievalInFlightError,
+    TerminalRetrievalReplayError,
     ToolRunBudgetExceededError,
     ToolRunBudgetPolicy,
     ToolRunBudgetTracker,
@@ -118,7 +120,7 @@ async def test_loop_guard_blocks_repeated_identical_web_search() -> None:
         ToolRunBudgetPolicy(max_repeated_retrievals_per_turn=2)
     )
 
-    await tracker.reserve_tool_call(
+    first = await tracker.reserve_tool_call(
         tool_name="web_search",
         arguments={
             "query": "  Python   Release  ",
@@ -126,10 +128,12 @@ async def test_loop_guard_blocks_repeated_identical_web_search() -> None:
             "mode": "auto",
         },
     )
-    await tracker.reserve_tool_call(
+    await tracker.commit_tool_result(first, '{"ok": true, "results": []}')
+    second = await tracker.reserve_tool_call(
         tool_name="web_search",
         arguments={"query": "python release", "provider": "tavily", "mode": "auto"},
     )
+    await tracker.commit_tool_result(second, '{"ok": true, "results": []}')
 
     with pytest.raises(ToolRunBudgetExceededError) as exc_info:
         await tracker.reserve_tool_call(
@@ -151,10 +155,11 @@ async def test_loop_guard_counts_web_search_repeated_queries_too() -> None:
         ToolRunBudgetPolicy(max_repeated_retrievals_per_turn=1)
     )
 
-    await tracker.reserve_tool_call(
+    first = await tracker.reserve_tool_call(
         tool_name="web_search",
         arguments={"query": "OpenSquilla"},
     )
+    await tracker.commit_tool_result(first, '{"ok": true, "results": []}')
 
     with pytest.raises(ToolRunBudgetExceededError):
         await tracker.reserve_tool_call(
@@ -169,10 +174,11 @@ async def test_loop_guard_counts_web_discover_repeated_queries_too() -> None:
         ToolRunBudgetPolicy(max_repeated_retrievals_per_turn=1)
     )
 
-    await tracker.reserve_tool_call(
+    first = await tracker.reserve_tool_call(
         tool_name="web_discover",
         arguments={"query": "OpenSquilla"},
     )
+    await tracker.commit_tool_result(first, '{"ok": true, "results": []}')
 
     with pytest.raises(ToolRunBudgetExceededError):
         await tracker.reserve_tool_call(
@@ -204,3 +210,159 @@ async def test_loop_guard_snapshot_exposes_counts() -> None:
             "count": 1,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_semantic_guard_blocks_duplicate_retrieval_while_first_is_in_flight() -> None:
+    tracker = ToolRunBudgetTracker()
+    first = await tracker.reserve_tool_call(
+        tool_name="web_search",
+        arguments={
+            "query": "  Python   Release ",
+            "mode": "news",
+            "recency": "week",
+            "include_domains": ["Example.COM", "docs.example.com"],
+            "provider": "tavily",
+            "max_results": 3,
+        },
+    )
+
+    with pytest.raises(DuplicateRetrievalInFlightError) as exc_info:
+        await tracker.reserve_tool_call(
+            tool_name="web_discover",
+            arguments={
+                "query": "python release",
+                "mode": "news",
+                "recency": "week",
+                "include_domains": ["docs.example.com", "example.com"],
+                "provider": "duckduckgo",
+                "max_results": 10,
+                "fetch_top_k": 0,
+            },
+        )
+
+    assert exc_info.value.tool_name == "web_discover"
+    await tracker.abort_tool_result(first)
+
+    replacement = await tracker.reserve_tool_call(
+        tool_name="web_discover",
+        arguments={
+            "query": "python release",
+            "mode": "news",
+            "recency": "week",
+            "include_domains": ["example.com", "docs.example.com"],
+        },
+    )
+    assert replacement.counted_as_search is True
+
+
+@pytest.mark.asyncio
+async def test_semantic_guard_replays_terminal_non_retryable_failure() -> None:
+    tracker = ToolRunBudgetTracker()
+    reservation = await tracker.reserve_tool_call(
+        tool_name="web_search",
+        arguments={
+            "query": "OpenSquilla release",
+            "mode": "auto",
+            "exclude_domains": ["EXAMPLE.com"],
+            "provider": "tavily",
+            "max_results": 3,
+        },
+    )
+    await tracker.commit_tool_result(
+        reservation,
+        '{"ok": false, "error_kind": "auth", "retry_allowed": false}',
+    )
+
+    with pytest.raises(TerminalRetrievalReplayError) as exc_info:
+        await tracker.reserve_tool_call(
+            tool_name="web_discover",
+            arguments={
+                "query": " opensquilla   RELEASE ",
+                "exclude_domains": ["example.com"],
+                "provider": "duckduckgo",
+                "max_results": 10,
+            },
+        )
+
+    assert exc_info.value.tool_name == "web_discover"
+    assert exc_info.value.error_kind == "auth"
+
+
+@pytest.mark.asyncio
+async def test_semantic_guard_does_not_ledger_success_or_retryable_failure() -> None:
+    tracker = ToolRunBudgetTracker(
+        ToolRunBudgetPolicy(max_repeated_retrievals_per_turn=None)
+    )
+    first = await tracker.reserve_tool_call(
+        tool_name="web_search",
+        arguments={"query": "OpenSquilla"},
+    )
+    await tracker.commit_tool_result(first, '{"ok": true, "results": []}')
+
+    second = await tracker.reserve_tool_call(
+        tool_name="web_search",
+        arguments={"query": "opensquilla", "provider": "duckduckgo"},
+    )
+    await tracker.commit_tool_result(
+        second,
+        '{"ok": false, "error_kind": "network", "retry_allowed": true}',
+    )
+
+    third = await tracker.reserve_tool_call(
+        tool_name="web_search",
+        arguments={"query": "opensquilla"},
+    )
+    assert third.counted_as_search is True
+
+
+@pytest.mark.asyncio
+async def test_semantic_guard_key_includes_mode_recency_and_domain_filters() -> None:
+    base = {
+        "query": "OpenSquilla",
+        "mode": "auto",
+        "recency": "week",
+        "include_domains": ["example.com"],
+        "exclude_domains": ["blocked.example"],
+    }
+
+    for changed in (
+        {**base, "query": "OpenSquilla docs"},
+        {**base, "mode": "technical"},
+        {**base, "recency": "month"},
+        {**base, "include_domains": ["docs.example.com"]},
+        {**base, "exclude_domains": ["other.example"]},
+    ):
+        tracker = ToolRunBudgetTracker()
+        terminal = await tracker.reserve_tool_call(tool_name="web_search", arguments=base)
+        await tracker.commit_tool_result(
+            terminal,
+            '{"ok": false, "error_kind": "blocked", "retry_allowed": false}',
+        )
+
+        allowed = await tracker.reserve_tool_call(
+            tool_name="web_search",
+            arguments=changed,
+        )
+        assert allowed.counted_as_search is True
+
+
+@pytest.mark.asyncio
+async def test_semantic_guard_isolated_between_trackers() -> None:
+    first_turn = ToolRunBudgetTracker()
+    reservation = await first_turn.reserve_tool_call(
+        tool_name="web_search",
+        arguments={"query": "OpenSquilla"},
+    )
+    await first_turn.commit_tool_result(
+        reservation,
+        '{"ok": false, "error_kind": "blocked", "retry_allowed": false}',
+    )
+
+    next_turn = ToolRunBudgetTracker()
+    allowed = await next_turn.reserve_tool_call(
+        tool_name="web_search",
+        arguments={"query": "OpenSquilla"},
+    )
+
+    assert allowed.counted_as_search is True

--- a/tests/test_tools/test_web_search_tool.py
+++ b/tests/test_tools/test_web_search_tool.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import json
 
+import httpx
 import pytest
 
 import opensquilla.tools.builtin.web as web_module
@@ -305,6 +306,7 @@ async def test_web_search_tool_rejects_invalid_args_without_calling_core(
         "ok": False,
         "error_kind": "invalid_request",
         "error": message,
+        "retry_allowed": False,
     }
 
 
@@ -352,6 +354,40 @@ async def test_web_discover_keeps_lightweight_result_shape(
             }
         ],
     }
+
+
+@pytest.mark.asyncio
+async def test_web_discover_keeps_explicit_failure_marker_for_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_run_web_discover_payload(
+        query: str,
+        max_results: int | None = None,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        return {
+            "ok": False,
+            "query": query,
+            "provider": "duckduckgo",
+            "results": [],
+            "error_kind": "blocked",
+            "error": {"message": "Search was blocked."},
+            "retry_allowed": False,
+        }
+
+    monkeypatch.setattr(
+        web_module,
+        "run_web_discover_payload",
+        fake_run_web_discover_payload,
+    )
+
+    bare_web_discover = inspect.unwrap(web_module.web_discover)
+    payload = json.loads(await bare_web_discover("python release"))
+
+    assert payload["ok"] is False
+    assert payload["error_kind"] == "blocked"
+    assert payload["error"] == "Search was blocked."
+    assert payload["retry_allowed"] is False
 
 
 @pytest.mark.asyncio
@@ -503,3 +539,89 @@ async def test_web_discover_preserves_network_fallback_for_custom_active_provide
         {"provider": "duckduckgo", "status": "success"},
     ]
     assert calls == [custom_provider, "duckduckgo"]
+
+
+@pytest.mark.asyncio
+async def test_web_discover_preserves_raw_custom_network_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import opensquilla.search.registry as registry
+    from opensquilla.search.registry import register_provider
+
+    custom_provider = "test_custom_discover_raw_network"
+    calls: list[str] = []
+
+    class FailingProvider:
+        name = custom_provider
+
+        async def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+            request = httpx.Request("GET", "https://custom.example/search")
+            raise httpx.ConnectError("network down", request=request)
+
+    class DuckProvider:
+        name = "duckduckgo"
+
+        async def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+            return [
+                SearchResult(
+                    title="Duck fallback",
+                    url="https://example.com",
+                    snippet=query,
+                )
+            ]
+
+    def fake_get_provider(name: str, **kwargs: object) -> FailingProvider | DuckProvider:
+        calls.append(name)
+        return FailingProvider() if name == custom_provider else DuckProvider()
+
+    register_provider(
+        custom_provider,
+        FailingProvider,
+        SearchProviderSpec(provider_id=custom_provider),
+    )
+    monkeypatch.setattr(registry, "get_provider", fake_get_provider)
+
+    try:
+        web_module.configure_search(
+            custom_provider,
+            fallback_policy="network",
+            diagnostics=True,
+        )
+        payload = await web_module.run_web_discover_payload("python release")
+    finally:
+        web_module.reset_search_runtime()
+
+    assert payload["ok"] is True
+    assert payload["fallbackFrom"] == custom_provider
+    assert payload["attempts"] == [
+        {"provider": custom_provider, "status": "error", "error_kind": "network"},
+        {"provider": "duckduckgo", "status": "success"},
+    ]
+    assert calls == [custom_provider, "duckduckgo"]
+
+
+def test_web_discover_failure_projection_preserves_canonical_diagnostics() -> None:
+    payload = web_module._web_discover_payload_from_canonical(
+        {
+            "ok": False,
+            "query": "python release",
+            "provider_attempts": [
+                {"provider": "custom", "status": "error", "error_kind": "parse"}
+            ],
+            "diagnostics": {"selected_provider": "", "fallback_from": ""},
+            "error_kind": "parse",
+            "error_class": "ValueError",
+            "error": "custom search request failed.",
+            "provider_retryable": False,
+            "retry_allowed": False,
+        },
+        display_provider="custom",
+    )
+
+    assert payload["ok"] is False
+    assert payload["retry_allowed"] is False
+    assert payload["error_class"] == "ValueError"
+    assert payload["provider_attempts"] == [
+        {"provider": "custom", "status": "error", "error_kind": "parse"}
+    ]
+    assert payload["diagnostics"] == {"selected_provider": "", "fallback_from": ""}


### PR DESCRIPTION
## Scope

- Build one bounded search execution plan shared by canonical search, discovery, gateway, and managed-network sandboxing.
- Skip locally unavailable providers, allow at most two real provider requests, and treat DuckDuckGo as a terminal attempt.
- Restrict provider fallback to explicitly retryable timeout, network, 408, 429, and 5xx failures.
- Preserve business-level search failures as JSON while projecting correct tool error/status sidecars.
- Prevent duplicate in-flight searches and same-turn replays of terminal search failures across `web_search` and `web_discover`.
- Add provider, runtime, tool-loop, gateway, sandbox, compatibility, and documentation coverage.

## Root cause

Provider selection and fallback were spread across multiple loops, while search payloads with `ok:false` could still be recorded as successful tool executions. This allowed the model to reissue the same search intent and could expand one user search into repeated provider and DuckDuckGo requests. Several provider adapters also treated ordinary 4xx or parse failures as retryable.

## Behavior and compatibility

- Target: `main`
- Head: `fix/search-retry-fallback`
- Existing `search_fallback_policy = "off" | "network"` values remain unchanged.
- No database migration, persistent configuration migration, or UI option is added.
- Explicit provider routing retains its existing transient `provider → DuckDuckGo` fallback contract.
- Empty search results remain successful and the gateway RPC envelope remains business-level `ok:false`.
- Upgrade compatibility is preserved for existing TOML, transcripts, gateway clients, and tool consumers.

## Validation

- `400 passed` across affected search, dispatch, execution-status, gateway, sandbox, onboarding, and architecture tests after rebasing onto current `main`.
- `.venv/bin/ruff check src tests`
- `.venv/bin/mypy src/opensquilla --show-error-codes` — no issues in 842 source files.
- Live provider validation: repository matrix passed for Tavily, Brave, IQS, and Exa; supplemental one-request smoke tests passed for Bocha and keyless DuckDuckGo.
- The broader public suite was exercised locally before the final rebase; remaining failures were attributable to unavailable optional UI/PDF dependencies and platform-specific local environment assumptions. Required GitHub CI remains authoritative.

## Safety

- One search intent performs at most two real provider network requests; each provider adapter still sends at most one request.
- Terminal failures cannot trigger another network request for the same normalized intent in the same user turn.
- No real API keys, transcripts, runtime state, or machine-specific paths are included.
- The change is platform-neutral and does not add filesystem, subprocess, or OS-specific behavior.
- Rollback requires only reverting this commit or setting the existing fallback policy to `off`; no data rollback is required.

## Release note

Required: bound search fallback attempts and stop repeated same-turn searches after terminal failure.

## Linked issue

None.

## Third-party origin

None. The implementation and tests were written specifically for OpenSquilla.