### PR TITLE
Keep Windows sandbox setup from blocking startup

### DIFF
--- a/desktop/electron/package-lock.json
+++ b/desktop/electron/package-lock.json
@@ -62,9 +62,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -251,9 +251,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -890,9 +890,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1380,9 +1380,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1917,9 +1917,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2096,9 +2096,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2463,9 +2463,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -3459,9 +3459,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -613,6 +613,7 @@ class ServiceContainer:
     usage_tracker: UsageTracker | None = None
     usage_event_sink: Any = None
     usage_backfill_task: asyncio.Task[Any] | None = None
+    sandbox_setup_task: asyncio.Task[Any] | None = field(default=None, repr=False)
     cron_scheduler: SchedulerEngine | None = None
     model_catalog: ModelCatalog | None = None
     agent_registry: Any = None
@@ -662,6 +663,19 @@ class ServiceContainer:
             except (asyncio.CancelledError, Exception):
                 pass
             self.usage_backfill_task = None
+        sandbox_setup_task = self.sandbox_setup_task
+        self.sandbox_setup_task = None
+        if sandbox_setup_task is not None:
+            cancel = getattr(sandbox_setup_task, "cancel", None)
+            if callable(cancel):
+                cancel()
+            if inspect.isawaitable(sandbox_setup_task):
+                try:
+                    await sandbox_setup_task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    log.debug("gateway.sandbox_setup_close_failed", exc_info=True)
         remove_compaction_listener = getattr(self, "_compaction_listener_remove", None)
         if callable(remove_compaction_listener):
             try:
@@ -789,8 +803,12 @@ class ServiceContainer:
         # (or an in-process caller) cannot inherit stale Full Host semantics.
         try:
             from opensquilla.sandbox.integration import reset_runtime as reset_sandbox_runtime
+            from opensquilla.sandbox.setup_runtime import (
+                reset_sandbox_setup_runtime_state,
+            )
 
             reset_sandbox_runtime()
+            reset_sandbox_setup_runtime_state()
         except Exception:
             pass
         # Clear the shared catalog installed by build_services() so a torn-down
@@ -2173,6 +2191,7 @@ async def build_services(
         if config.config_path:
             log.info("build_services.config_loaded", path=config.config_path)
     deferred_warmups: list[Callable[[], Any]] = []
+    sandbox_setup_task: asyncio.Task[Any] | None = None
     _warn_workspace_state_mismatch(config)
 
     # Register session-material filesystem cleanup so deleting a session also
@@ -2217,7 +2236,7 @@ async def build_services(
             **effective.effective.as_dict(),
         )
         if getattr(effective.effective, "sandbox_enabled", True) and sandbox_settings.auto_setup:
-            create_background_task(_ensure_sandbox_setup_on_boot(config))
+            sandbox_setup_task = create_background_task(_ensure_sandbox_setup_on_boot(config))
     except Exception as e:  # pragma: no cover - boot diagnostics only
         log.exception("build_services.sandbox_configure_failed", error=str(e))
         raise
@@ -2852,6 +2871,7 @@ async def build_services(
         router_calibration_service=router_calibration_service,
         provider_stats=provider_stats,
         deferred_warmups=deferred_warmups,
+        sandbox_setup_task=sandbox_setup_task,
     )
     # Attach deferred callback ref so start_gateway_server can wire TurnRunner
     svc._turn_runner_ref = _turn_runner_ref  # type: ignore[attr-defined]

--- a/src/opensquilla/gateway/rpc_sandbox.py
+++ b/src/opensquilla/gateway/rpc_sandbox.py
@@ -46,11 +46,13 @@ from opensquilla.sandbox.run_mode_policy import (
     coerce_run_mode_for_principal,
     run_mode_allowed_for_principal,
 )
-from opensquilla.sandbox.setup_runtime import current_sandbox_setup_runtime_status
+from opensquilla.sandbox.setup_runtime import (
+    current_sandbox_setup_runtime_status,
+    ensure_sandbox_setup_auto,
+)
 from opensquilla.sandbox.setup_state import (
     SandboxSetupState,
     current_sandbox_setup_status,
-    ensure_sandbox_setup,
 )
 from opensquilla.sandbox.status import status_payload
 from opensquilla.session.keys import parse_agent_id
@@ -329,7 +331,7 @@ async def _handle_sandbox_setup_status(params: dict | None, ctx: RpcContext) -> 
 @_d.method("sandbox.setup.ensure", scope="operator.write")
 async def _handle_sandbox_setup_ensure(params: dict | None, ctx: RpcContext) -> dict:
     _require_owner(ctx, "sandbox.setup.ensure")
-    result = await ensure_sandbox_setup(ctx.config)
+    result = await ensure_sandbox_setup_auto(ctx.config)
     return result.to_payload()
 
 

--- a/src/opensquilla/sandbox/backend/windows_default_setup.py
+++ b/src/opensquilla/sandbox/backend/windows_default_setup.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 import json
 import os
 import secrets
@@ -22,6 +23,7 @@ from opensquilla.sandbox.backend.windows_default_network import WindowsNetworkSe
 SETUP_VERSION = 2
 OFFLINE_USERNAME = "OpenSquillaSandbox"
 SETUP_HELPER_REPORT = "setup_helper_report.json"
+SETUP_PROCESS_LOCK_TIMEOUT_MS = 10 * 60 * 1000
 
 
 @dataclass(frozen=True)
@@ -247,32 +249,40 @@ def elevated_setup_helper_main(argv: list[str] | None = None) -> int:
         print(f"windows_default_setup helper failed: {exc}", file=sys.stderr)
         return 2
     try:
-        with _secure_setup_directory_lease(marker_path, profile_path) as lease:
-            write_setup_helper_report(marker_path, state="running")
-            try:
-                network = establish_windows_network_setup(marker_path)
-                lock_persistent_sandbox_dirs(
-                    marker_path,
-                    offline_sid=network.offline_user_sid,
-                    real_user_sid=payload["userSid"],
-                    lease=lease,
-                )
-                _validate_setup_directory_lease(lease, recursive=True)
-                write_setup_marker(marker_path, network=network)
-                write_setup_helper_report(marker_path, state="ready", detail="setup_complete")
-                return 0
-            except Exception as exc:
-                try:
-                    _validate_setup_directory_lease(lease, recursive=True)
-                except Exception as lease_exc:
-                    print(
-                        f"windows_default_setup helper failed without report: {lease_exc}",
-                        file=sys.stderr,
+        with _windows_setup_process_lock(marker_path):
+            with _secure_setup_directory_lease(marker_path, profile_path) as lease:
+                if _windows_setup_is_ready(marker_path, profile_path):
+                    write_setup_helper_report(
+                        marker_path,
+                        state="ready",
+                        detail="already_ready",
                     )
-                    return 2
-                write_setup_helper_report(marker_path, state="failed", detail=str(exc))
-                print(f"windows_default_setup helper failed: {exc}", file=sys.stderr)
-                return 1
+                    return 0
+                write_setup_helper_report(marker_path, state="running")
+                try:
+                    network = establish_windows_network_setup(marker_path)
+                    lock_persistent_sandbox_dirs(
+                        marker_path,
+                        offline_sid=network.offline_user_sid,
+                        real_user_sid=payload["userSid"],
+                        lease=lease,
+                    )
+                    _validate_setup_directory_lease(lease, recursive=True)
+                    write_setup_marker(marker_path, network=network)
+                    write_setup_helper_report(marker_path, state="ready", detail="setup_complete")
+                    return 0
+                except Exception as exc:
+                    try:
+                        _validate_setup_directory_lease(lease, recursive=True)
+                    except Exception as lease_exc:
+                        print(
+                            f"windows_default_setup helper failed without report: {lease_exc}",
+                            file=sys.stderr,
+                        )
+                        return 2
+                    write_setup_helper_report(marker_path, state="failed", detail=str(exc))
+                    print(f"windows_default_setup helper failed: {exc}", file=sys.stderr)
+                    return 1
     except Exception as exc:
         print(f"windows_default_setup helper failed: {exc}", file=sys.stderr)
         return 2
@@ -363,6 +373,74 @@ def _windows_profile_path_for_sid(sid: str) -> Path:
 
 def _setup_path_key(path: Path) -> str:
     return os.path.normcase(os.path.abspath(str(path))).replace("\\", "/").rstrip("/")
+
+
+def _windows_setup_is_ready(marker_path: Path, profile_path: Path) -> bool:
+    marker = read_setup_marker(marker_path)
+    if marker is None or marker.network is None:
+        return False
+
+    from opensquilla.sandbox.backend.windows_default_support import (
+        probe_windows_default_support,
+    )
+
+    support = probe_windows_default_support(
+        home=profile_path,
+        proxy_ports=marker.network.allowed_proxy_ports,
+    )
+    return support.default_backend_available and support.proxy_allowlist_enforced
+
+
+@contextmanager
+def _windows_setup_process_lock(marker_path: Path) -> Iterator[None]:
+    """Serialize elevated setup helpers for one Windows profile.
+
+    Gateway restarts can leave an already-elevated helper running. A named
+    mutex prevents a replacement gateway from concurrently changing the
+    account, ACL, firewall, and WFP state. Windows releases the mutex if a
+    helper crashes; the bounded wait avoids an unbounded second helper.
+    """
+
+    if not sys.platform.startswith("win"):
+        yield
+        return
+
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateMutexW.argtypes = [wintypes.LPVOID, wintypes.BOOL, wintypes.LPCWSTR]
+    kernel32.CreateMutexW.restype = wintypes.HANDLE
+    kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.ReleaseMutex.argtypes = [wintypes.HANDLE]
+    kernel32.ReleaseMutex.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    digest = hashlib.sha256(_setup_path_key(marker_path).encode("utf-8")).hexdigest()[:32]
+    mutex_name = rf"Local\OpenSquillaSandboxSetup-{digest}"
+    handle = kernel32.CreateMutexW(None, False, mutex_name)
+    if not handle:
+        raise OSError(ctypes.get_last_error(), "windows_setup_mutex_create_failed")
+
+    wait_object_0 = 0x00000000
+    wait_abandoned = 0x00000080
+    wait_timeout = 0x00000102
+    acquired = False
+    try:
+        wait_result = int(kernel32.WaitForSingleObject(handle, SETUP_PROCESS_LOCK_TIMEOUT_MS))
+        if wait_result in (wait_object_0, wait_abandoned):
+            acquired = True
+        elif wait_result == wait_timeout:
+            raise OSError("windows_setup_mutex_timeout")
+        else:
+            raise OSError(ctypes.get_last_error(), "windows_setup_mutex_wait_failed")
+        yield
+    finally:
+        if acquired:
+            kernel32.ReleaseMutex(handle)
+        kernel32.CloseHandle(handle)
 
 
 def _is_reparse_path(path: Path) -> bool:

--- a/src/opensquilla/sandbox/integration.py
+++ b/src/opensquilla/sandbox/integration.py
@@ -146,9 +146,10 @@ class _ApprovalQueueLike(Protocol):
 class SandboxRuntime:
     """Process-wide sandbox runtime assembled from settings.
 
-    The object is immutable after construction from the caller's point of
-    view; callers either pass it around explicitly (tests) or fetch it via
-    :func:`get_runtime`.
+    Callers either pass it around explicitly (tests) or fetch it via
+    :func:`get_runtime`. The backend may be atomically promoted after a
+    successful platform setup; the gate, ledger, cache, queue, and settings
+    remain stable for the lifetime of the runtime.
     """
 
     settings: SandboxSettings
@@ -257,6 +258,33 @@ def get_runtime() -> SandboxRuntime | None:
     than relying on the ``None`` branch.
     """
     return _runtime
+
+
+def refresh_runtime_backend_after_setup() -> Backend | None:
+    """Promote an auto-configured unavailable backend after platform setup.
+
+    Runtime setup happens after gateway construction on Windows. Replacing
+    the whole runtime would discard approval and denial state, so this
+    function changes only the backend reference. Existing real backends and
+    sandbox-disabled runtimes are deliberately left untouched.
+    """
+
+    runtime = _runtime
+    if runtime is None:
+        return None
+    if not runtime.effective.sandbox_enabled:
+        return runtime.backend
+    if not isinstance(runtime.backend, UnavailableBackend):
+        return runtime.backend
+
+    backend = select_backend(runtime.settings)
+    if isinstance(backend, (NoopBackend, UnavailableBackend)):
+        raise SandboxBackendError(
+            "sandbox setup completed but no real sandbox backend became available"
+        )
+    runtime.backend = backend
+    log.info("sandbox.runtime_backend_promoted: backend=%s", backend.name)
+    return backend
 
 
 def active_file_system_profile(
@@ -2032,6 +2060,7 @@ __all__ = [
     "prepare_subprocess_managed_network_proxy",
     "request_with_managed_network_proxy_env",
     "record_success",
+    "refresh_runtime_backend_after_setup",
     "reset_runtime",
     "run_in_process_network_action",
     "run_under_backend",

--- a/src/opensquilla/sandbox/setup_runtime.py
+++ b/src/opensquilla/sandbox/setup_runtime.py
@@ -35,16 +35,28 @@ async def ensure_sandbox_setup_auto(config: Any) -> SetupResult:
 
     async with _LOCK:
         _SETTING_UP = True
+        setup_result: SetupResult | None = None
         try:
-            result = await ensure_sandbox_setup(config)
-            _LAST_RESULT = result
-            return result
+            setup_result = await ensure_sandbox_setup(config)
+            if (
+                setup_result.state is SandboxSetupState.READY
+                and setup_result.platform == "win32"
+            ):
+                from opensquilla.sandbox.integration import (
+                    refresh_runtime_backend_after_setup,
+                )
+
+                refresh_runtime_backend_after_setup()
+            _LAST_RESULT = setup_result
+            return setup_result
         except Exception as exc:  # noqa: BLE001
             result = SetupResult(
                 state=SandboxSetupState.FAILED,
-                platform="auto",
+                platform=setup_result.platform if setup_result is not None else "auto",
                 message="Sandbox setup failed.",
-                requires_admin=False,
+                requires_admin=(
+                    setup_result.requires_admin if setup_result is not None else False
+                ),
                 detail=str(exc),
             )
             _LAST_RESULT = result

--- a/src/opensquilla/sandbox/setup_state.py
+++ b/src/opensquilla/sandbox/setup_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from dataclasses import dataclass
 from enum import StrEnum
@@ -140,6 +141,13 @@ async def _windows_setup_status(config: Any) -> SetupResult:
 
 
 async def _ensure_windows_setup(config: Any) -> SetupResult:
+    # Windows setup can wait for UAC consent and for the elevated helper to
+    # finish. Keep that blocking Win32 work off the gateway event loop so
+    # health checks, shutdown, and setup-status RPCs stay responsive.
+    return await asyncio.to_thread(_ensure_windows_setup_sync, config)
+
+
+def _ensure_windows_setup_sync(config: Any) -> SetupResult:
     _ = config
     support = _probe_windows_sandbox_support()
     if support.default_backend_available and support.proxy_allowlist_enforced:

--- a/tests/test_desktop/test_electron_dependency_security.py
+++ b/tests/test_desktop/test_electron_dependency_security.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LOCK_PATH = ROOT / "desktop" / "electron" / "package-lock.json"
+
+
+def _packages() -> dict[str, dict[str, object]]:
+    payload = json.loads(LOCK_PATH.read_text(encoding="utf-8"))
+    packages = payload.get("packages")
+    assert isinstance(packages, dict)
+    return packages
+
+
+def _version_tuple(value: object) -> tuple[int, int, int]:
+    assert isinstance(value, str)
+    parts = value.split(".")
+    assert len(parts) == 3
+    major, minor, patch = (int(part) for part in parts)
+    return major, minor, patch
+
+
+def test_electron_runtime_yaml_parser_includes_merge_chain_dos_fix() -> None:
+    packages = _packages()
+    root = packages[""]
+    updater = packages["node_modules/electron-updater"]
+    js_yaml = packages["node_modules/js-yaml"]
+
+    assert "electron-updater" in root["dependencies"]
+    assert "js-yaml" in updater["dependencies"]
+    assert js_yaml.get("dev") is not True
+    assert _version_tuple(js_yaml["version"]) >= (4, 3, 0)
+
+
+def test_electron_build_dependencies_include_resource_exhaustion_fixes() -> None:
+    packages = _packages()
+    tar = packages["node_modules/tar"]
+    brace_versions = [
+        _version_tuple(package["version"])
+        for path, package in packages.items()
+        if path == "node_modules/brace-expansion"
+        or path.endswith("/node_modules/brace-expansion")
+    ]
+
+    assert tar.get("dev") is True
+    assert _version_tuple(tar["version"]) >= (7, 5, 19)
+    assert brace_versions
+    for version in brace_versions:
+        if version[0] == 1:
+            assert version >= (1, 1, 16)
+        elif version[0] == 2:
+            assert version >= (2, 1, 2)
+        else:
+            assert version >= (5, 0, 7)

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -554,6 +554,7 @@ async def test_build_services_schedules_sandbox_setup_after_runtime(
 
     events: list[str] = []
     scheduled: list[Any] = []
+    background_task = SimpleNamespace()
 
     async def fake_setup(config: GatewayConfig) -> None:
         events.append("setup")
@@ -570,7 +571,7 @@ async def test_build_services_schedules_sandbox_setup_after_runtime(
         close = getattr(coro, "close", None)
         if callable(close):
             close()
-        return SimpleNamespace()
+        return background_task
 
     monkeypatch.setattr(boot, "_ensure_sandbox_setup_on_boot", fake_setup)
     monkeypatch.setattr(boot, "create_background_task", fake_create_background_task)
@@ -600,9 +601,33 @@ async def test_build_services_schedules_sandbox_setup_after_runtime(
     try:
         assert events == ["runtime"]
         assert len(scheduled) == 1
+        assert services.sandbox_setup_task is background_task
     finally:
         await services.close()
     assert events == ["runtime", "runtime_reset"]
+
+
+@pytest.mark.asyncio
+async def test_service_container_close_cancels_owned_sandbox_setup_task() -> None:
+    from opensquilla.gateway import boot
+
+    entered = asyncio.Event()
+
+    async def blocked_setup() -> None:
+        entered.set()
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(blocked_setup())
+    services = boot.ServiceContainer(
+        config=GatewayConfig(),
+        sandbox_setup_task=task,
+    )
+    await entered.wait()
+
+    await services.close()
+
+    assert services.sandbox_setup_task is None
+    assert task.cancelled()
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_rpc_sandbox_setup.py
+++ b/tests/test_gateway/test_rpc_sandbox_setup.py
@@ -92,7 +92,7 @@ async def test_sandbox_setup_ensure_returns_platform_payload(monkeypatch) -> Non
             requires_admin=True,
         )
 
-    monkeypatch.setattr(rpc_sandbox, "ensure_sandbox_setup", fake_ensure)
+    monkeypatch.setattr(rpc_sandbox, "ensure_sandbox_setup_auto", fake_ensure)
 
     payload = await rpc_sandbox._handle_sandbox_setup_ensure({}, _ctx())
 

--- a/tests/test_sandbox/test_setup_runtime.py
+++ b/tests/test_sandbox/test_setup_runtime.py
@@ -80,6 +80,64 @@ async def test_auto_setup_failure_remains_visible_after_setup_finishes(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_windows_auto_setup_promotes_runtime_backend_after_setup(monkeypatch) -> None:
+    from opensquilla.sandbox import integration, setup_runtime
+
+    config = SimpleNamespace()
+    promotions = []
+
+    async def ready_setup(_config):
+        return SetupResult(
+            state=SandboxSetupState.READY,
+            platform="win32",
+            message="Windows default sandbox is ready.",
+            requires_admin=False,
+        )
+
+    monkeypatch.setattr(setup_runtime, "ensure_sandbox_setup", ready_setup)
+    monkeypatch.setattr(
+        integration,
+        "refresh_runtime_backend_after_setup",
+        lambda: promotions.append("promoted"),
+        raising=False,
+    )
+
+    result = await setup_runtime.ensure_sandbox_setup_auto(config)
+
+    assert result.state is SandboxSetupState.READY
+    assert promotions == ["promoted"]
+
+
+@pytest.mark.asyncio
+async def test_windows_auto_setup_reports_failed_when_runtime_cannot_be_promoted(
+    monkeypatch,
+) -> None:
+    from opensquilla.sandbox import integration, setup_runtime
+
+    async def ready_setup(_config):
+        return SetupResult(
+            state=SandboxSetupState.READY,
+            platform="win32",
+            message="Windows default sandbox is ready.",
+            requires_admin=False,
+        )
+
+    monkeypatch.setattr(setup_runtime, "ensure_sandbox_setup", ready_setup)
+    monkeypatch.setattr(
+        integration,
+        "refresh_runtime_backend_after_setup",
+        lambda: (_ for _ in ()).throw(RuntimeError("backend still unavailable")),
+        raising=False,
+    )
+
+    result = await setup_runtime.ensure_sandbox_setup_auto(SimpleNamespace())
+
+    assert result.state is SandboxSetupState.FAILED
+    assert result.platform == "win32"
+    assert result.detail == "backend still unavailable"
+
+
+@pytest.mark.asyncio
 async def test_reset_setup_runtime_state_delegates_to_current_probe_again(monkeypatch) -> None:
     from opensquilla.sandbox import setup_runtime
 

--- a/tests/test_sandbox/test_setup_state.py
+++ b/tests/test_sandbox/test_setup_state.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -209,6 +211,59 @@ async def test_ensure_windows_setup_requires_admin_before_mutating(
     assert result.requires_admin is False
     assert helper_calls == [marker]
     assert calls == []
+
+
+async def test_ensure_windows_setup_keeps_event_loop_responsive_during_elevation(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from opensquilla.sandbox import setup_state
+
+    marker = tmp_path / "setup_marker.json"
+
+    monkeypatch.setattr(setup_state.sys, "platform", "win32")
+    monkeypatch.setattr(setup_state, "_windows_setup_marker_path", lambda: marker)
+    monkeypatch.setattr(setup_state, "_windows_process_is_admin", lambda: False)
+    monkeypatch.setattr(
+        setup_state,
+        "_probe_windows_sandbox_support",
+        lambda: setup_state.WindowsSetupSupport(
+            default_backend_available=False,
+            ctypes_available=True,
+            token_api_available=True,
+            acl_api_available=True,
+            setup_ready=False,
+            proxy_allowlist_enforced=False,
+        ),
+    )
+
+    def slow_elevated_helper(_marker_path) -> None:
+        time.sleep(0.25)
+
+    monkeypatch.setattr(
+        setup_state,
+        "_run_windows_setup_helper_elevated",
+        slow_elevated_helper,
+    )
+    monkeypatch.setattr(
+        setup_state,
+        "_windows_default_setup_result",
+        lambda: setup_state.SetupResult(
+            state=setup_state.SandboxSetupState.READY,
+            platform="win32",
+            message="Windows default sandbox is ready.",
+            requires_admin=False,
+        ),
+    )
+
+    started = time.perf_counter()
+    task = asyncio.create_task(setup_state.ensure_sandbox_setup(SimpleNamespace()))
+    await asyncio.sleep(0.02)
+    scheduler_delay = time.perf_counter() - started
+    result = await task
+
+    assert scheduler_delay < 0.15
+    assert result.state is setup_state.SandboxSetupState.READY
 
 
 async def test_ensure_windows_setup_reports_elevated_helper_failure(

--- a/tests/test_sandbox/test_unavailable_backend.py
+++ b/tests/test_sandbox/test_unavailable_backend.py
@@ -12,6 +12,7 @@ from opensquilla.sandbox.integration import (
     configure_runtime,
     escalate_unavailable_backend_in_managed_mode,
     gate_action,
+    refresh_runtime_backend_after_setup,
     reset_runtime,
 )
 from opensquilla.sandbox.policy import LevelHints
@@ -148,6 +149,77 @@ async def test_standard_mode_unavailable_backend_does_not_request_host_retry(
         assert result is None
         assert queue.list_pending("exec") == []
     finally:
+        queue.close()
+
+
+def test_setup_refresh_promotes_only_backend_and_preserves_runtime_services(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from opensquilla.sandbox import integration
+
+    queue = ApprovalQueue(db_path=str(tmp_path / "approvals.sqlite"))
+    settings = SandboxSettings(sandbox=True, backend="auto", run_mode="standard")
+
+    monkeypatch.setattr(
+        integration,
+        "select_backend",
+        lambda _settings: (_ for _ in ()).throw(SandboxBackendError("setup required")),
+    )
+    runtime = configure_runtime(settings, approval_queue=queue, workspace=tmp_path)
+    original_services = (
+        runtime.gate,
+        runtime.ledger,
+        runtime.cache,
+        runtime.approval_queue,
+        runtime.workspace,
+    )
+    replacement = SimpleNamespace(name="windows_default")
+    monkeypatch.setattr(integration, "select_backend", lambda _settings: replacement)
+
+    try:
+        promoted = refresh_runtime_backend_after_setup()
+
+        assert promoted is replacement
+        assert integration.get_runtime() is runtime
+        assert runtime.backend is replacement
+        assert (
+            runtime.gate,
+            runtime.ledger,
+            runtime.cache,
+            runtime.approval_queue,
+            runtime.workspace,
+        ) == original_services
+    finally:
+        reset_runtime()
+        queue.close()
+
+
+def test_setup_refresh_does_not_replace_an_already_available_backend(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from opensquilla.sandbox import integration
+
+    queue = ApprovalQueue(db_path=str(tmp_path / "approvals.sqlite"))
+    original = SimpleNamespace(name="windows_default")
+    monkeypatch.setattr(integration, "select_backend", lambda _settings: original)
+    runtime = configure_runtime(
+        SandboxSettings(sandbox=True, backend="auto", run_mode="standard"),
+        approval_queue=queue,
+        workspace=tmp_path,
+    )
+    monkeypatch.setattr(
+        integration,
+        "select_backend",
+        lambda _settings: (_ for _ in ()).throw(AssertionError("must not reselect backend")),
+    )
+
+    try:
+        assert refresh_runtime_backend_after_setup() is original
+        assert runtime.backend is original
+    finally:
+        reset_runtime()
         queue.close()
 
 

--- a/tests/test_sandbox/test_windows_default_network.py
+++ b/tests/test_sandbox/test_windows_default_network.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import json
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -306,6 +307,113 @@ def test_elevated_setup_helper_main_writes_failure_report(monkeypatch, tmp_path)
     report = json.loads((marker.parent / "setup_helper_report.json").read_text())
     assert report["state"] == "failed"
     assert "Set-LocalUser access denied" in report["detail"]
+
+
+def test_elevated_setup_helper_serializes_mutation_and_rechecks_readiness(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from opensquilla.sandbox.backend import windows_default_setup as mod
+
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    marker = mod.default_setup_marker_path(profile)
+    payload = mod._encode_setup_helper_payload(marker, user_sid="S-1-real")
+    events = []
+
+    @contextmanager
+    def fake_process_lock(_marker_path):
+        events.append("lock_enter")
+        try:
+            yield
+        finally:
+            events.append("lock_exit")
+
+    monkeypatch.setattr(mod, "_windows_profile_path_for_sid", lambda _sid: profile)
+    monkeypatch.setattr(mod, "_windows_setup_process_lock", fake_process_lock, raising=False)
+    monkeypatch.setattr(
+        mod,
+        "_windows_setup_is_ready",
+        lambda _marker_path, _profile_path: events.append("ready_check") or False,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        mod,
+        "establish_windows_network_setup",
+        lambda _path: (_ for _ in ()).throw(OSError("stop after ordering check")),
+    )
+
+    assert mod.elevated_setup_helper_main(["--elevated-helper", payload]) == 1
+    assert events == ["lock_enter", "ready_check", "lock_exit"]
+
+
+def test_elevated_setup_helper_skips_duplicate_mutation_after_wait(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from opensquilla.sandbox.backend import windows_default_setup as mod
+
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    marker = mod.default_setup_marker_path(profile)
+    payload = mod._encode_setup_helper_payload(marker, user_sid="S-1-real")
+    reports = []
+
+    monkeypatch.setattr(mod, "_windows_profile_path_for_sid", lambda _sid: profile)
+    monkeypatch.setattr(mod, "_windows_setup_is_ready", lambda *_args: True, raising=False)
+    monkeypatch.setattr(
+        mod,
+        "establish_windows_network_setup",
+        lambda _path: (_ for _ in ()).throw(AssertionError("setup must not run twice")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "write_setup_helper_report",
+        lambda _path, *, state, detail=None: reports.append((state, detail)),
+    )
+
+    assert mod.elevated_setup_helper_main(["--elevated-helper", payload]) == 0
+    assert reports == [("ready", "already_ready")]
+
+
+def test_windows_setup_process_lock_releases_named_mutex(monkeypatch, tmp_path) -> None:
+    import ctypes
+
+    from opensquilla.sandbox.backend import windows_default_setup as mod
+
+    calls = []
+
+    class FakeApi:
+        def __init__(self, name, result):
+            self.name = name
+            self.result = result
+            self.argtypes = None
+            self.restype = None
+
+        def __call__(self, *args):
+            calls.append((self.name, args))
+            return self.result
+
+    kernel32 = type(
+        "FakeKernel32",
+        (),
+        {
+            "CreateMutexW": FakeApi("create", 123),
+            "WaitForSingleObject": FakeApi("wait", 0),
+            "ReleaseMutex": FakeApi("release", True),
+            "CloseHandle": FakeApi("close", True),
+        },
+    )()
+    monkeypatch.setattr(mod.sys, "platform", "win32")
+    monkeypatch.setattr(ctypes, "WinDLL", lambda *_args, **_kwargs: kernel32, raising=False)
+
+    with mod._windows_setup_process_lock(tmp_path / "setup_marker.json"):
+        calls.append(("body", ()))
+
+    assert [name for name, _args in calls] == ["create", "wait", "body", "release", "close"]
+    mutex_name = calls[0][1][2]
+    assert mutex_name.startswith("Local\\OpenSquillaSandboxSetup-")
+    assert calls[1][1] == (123, mod.SETUP_PROCESS_LOCK_TIMEOUT_MS)
 
 
 def test_elevated_setup_rejects_payload_path_before_any_report_write(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Scope

- move blocking Windows sandbox setup/elevation work off the Gateway event loop
- promote the unavailable runtime backend after successful setup and share serialization/status between automatic and manual setup
- own the setup task during Gateway teardown and serialize elevated helpers across retries or restarts
- update vulnerable transitive Electron dependencies within the existing semver ranges and add dependency regression coverage

## Target

`main`

## Issue

Fixes #705

## Root cause

The asynchronous boot task called the synchronous Windows elevation and wait path directly. When first-run setup exceeded Desktop's 45-second health window, the Gateway event loop could not answer `/healthz`, so Desktop reported startup failure even though initialization was still running.

## Validation

- 212 focused sandbox, Gateway, architecture, and Desktop startup tests passed
- 94 Desktop tests passed
- Ruff passed on all changed Python files
- targeted mypy checks passed
- Electron `npm audit --json`: 0 vulnerabilities
- Electron update resolver, scheduler, and mock update-flow tests passed
- Electron TypeScript build passed
- WebUI build and artifact verification passed
- Python wheel build passed

## Safety and compatibility

- no change to Desktop's 45-second timeout, sandbox marker version, config keys, or RPC payloads
- backend promotion preserves the existing gate, denial ledger, cache, approval queue, settings, and workspace
- elevated helper coordination is scoped per Windows profile, uses bounded waiting, and rechecks readiness after acquiring the mutex
- existing configured or ready installations remain no-op compatible
- no persisted-data or public-API migration is required
- a real packaged Windows first-run E2E was not available locally; Windows CI is required before merge

## Release note

Fixed Windows Desktop first-run startup failures when sandbox initialization takes longer than the Gateway health timeout.

## Third-party origin

No third-party code was copied. The lockfile update uses upstream patched releases of `js-yaml`, `tar`, and `brace-expansion`.