### PR TITLE
Reject image input before Ensemble execution

### DIFF
--- a/opensquilla-webui/src/components/chat/ChatComposer.imageGuard.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatComposer.imageGuard.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick } from 'vue'
+import i18n from '@/i18n'
+import ChatComposer from './ChatComposer.vue'
+
+const BASE_PROPS = {
+  modelValue: 'describe this image',
+  'onUpdate:modelValue': () => {},
+  attachments: [],
+  busySendMode: 'queue',
+  hasSendContent: true,
+  isStreaming: false,
+  canStop: false,
+  isNewLanding: false,
+  placeholder: 'Send a message',
+  sendButtonTitle: 'Send',
+  runMode: 'trusted',
+  allowedRunModes: ['standard', 'trusted', 'full'],
+  modelRoutingMode: 'llm_ensemble',
+  modelRoutingSettingsBusy: false,
+  routerVisualEffectsEnabled: true,
+  codingModeEnabled: false,
+  codingModeSettingsBusy: false,
+  voiceBusy: false,
+  voiceRecording: false,
+  voiceReady: true,
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  i18n.global.locale.value = 'en'
+})
+
+describe('ChatComposer image-send guard', () => {
+  it('announces the block accessibly and prevents the send control from firing', async () => {
+    const onSend = vi.fn()
+    const message = 'Ensemble image input is unavailable.'
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    const app = createApp(ChatComposer, {
+      ...BASE_PROPS,
+      sendBlockedMessage: message,
+      onSend,
+    })
+    app.use(i18n)
+    app.mount(el)
+    await nextTick()
+
+    const status = el.querySelector<HTMLElement>('#chat-composer-image-send-status')
+    const textarea = el.querySelector<HTMLTextAreaElement>('.chat-textarea')
+    const send = el.querySelector<HTMLButtonElement>('.chat-send-btn')
+
+    expect(status?.textContent).toBe(message)
+    expect(status?.getAttribute('role')).toBe('status')
+    expect(status?.getAttribute('aria-live')).toBe('polite')
+    expect(status?.getAttribute('aria-atomic')).toBe('true')
+    expect(textarea?.getAttribute('aria-describedby')).toBe(status?.id)
+    expect(send?.getAttribute('aria-describedby')).toBe(status?.id)
+    expect(send?.title).toBe(message)
+    expect(send?.disabled).toBe(true)
+    send?.click()
+    expect(onSend).not.toHaveBeenCalled()
+
+    app.unmount()
+  })
+
+  it('keeps the send control enabled when no guard message is present', async () => {
+    const onSend = vi.fn()
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    const app = createApp(ChatComposer, { ...BASE_PROPS, onSend })
+    app.use(i18n)
+    app.mount(el)
+    await nextTick()
+
+    const send = el.querySelector<HTMLButtonElement>('.chat-send-btn')
+    expect(el.querySelector('#chat-composer-image-send-status')).toBeNull()
+    expect(send?.disabled).toBe(false)
+    send?.click()
+    expect(onSend).toHaveBeenCalledOnce()
+
+    app.unmount()
+  })
+})

--- a/opensquilla-webui/src/components/chat/ChatComposer.vue
+++ b/opensquilla-webui/src/components/chat/ChatComposer.vue
@@ -36,6 +36,7 @@
             :placeholder="placeholder"
             maxlength="100000"
             :aria-label="t('chat.messageToSend')"
+            :aria-describedby="sendBlockedMessage ? 'chat-composer-image-send-status' : undefined"
             @beforeinput="emit('beforeinput', $event)"
             @input="emit('input', $event)"
             @keydown="emit('keydown', $event)"
@@ -151,7 +152,15 @@
                 </button>
               </div>
             </Transition>
-            <button class="btn btn--icon btn--primary chat-send-btn" :class="{ 'is-ready': hasSendContent }" :title="sendButtonTitle" :aria-label="t('chat.send')" @click="emit('send')">
+            <button
+              class="btn btn--icon btn--primary chat-send-btn"
+              :class="{ 'is-ready': hasSendContent && !sendBlockedMessage }"
+              :title="sendBlockedMessage || sendButtonTitle"
+              :aria-label="t('chat.send')"
+              :aria-describedby="sendBlockedMessage ? 'chat-composer-image-send-status' : undefined"
+              :disabled="Boolean(sendBlockedMessage)"
+              @click="emit('send')"
+            >
               <Icon name="arrowUp" :size="17" />
             </button>
             <Transition name="composer-ctl">
@@ -162,6 +171,14 @@
           </div>
         </div>
       </div>
+      <p
+        v-if="sendBlockedMessage"
+        id="chat-composer-image-send-status"
+        class="chat-composer-send-status"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >{{ sendBlockedMessage }}</p>
       <p class="chat-ai-disclaimer" role="note">{{ t('chat.aiDisclaimer') }}</p>
     </div>
     <input
@@ -203,6 +220,7 @@ defineProps<{
   isNewLanding: boolean
   placeholder: string
   sendButtonTitle: string
+  sendBlockedMessage?: string
   runMode: SandboxRunMode
   allowedRunModes: SandboxRunMode[]
   modelRoutingMode: ModelRoutingMode
@@ -415,6 +433,14 @@ defineExpose<ChatComposerExpose>({
   margin: 0.5rem 0 0;
   color: var(--text-muted);
   font-size: var(--fs-xs);
+  line-height: 1.5;
+  text-align: center;
+}
+
+.chat-composer-send-status {
+  margin: 0.5rem 0 0;
+  color: var(--warning, var(--text-muted));
+  font-size: var(--fs-sm);
   line-height: 1.5;
   text-align: center;
 }

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.issue344.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.issue344.test.ts
@@ -11,6 +11,7 @@
 // task-B's own events (and legacy untagged events) still flow.
 import { describe, expect, it, vi } from 'vitest'
 import { effectScope, ref, type Ref } from 'vue'
+import i18n, { loadLocaleMessages } from '@/i18n'
 import type { ChatMessage, ChatRunStatus, ChatRunStatusSource } from '@/types/chat'
 import type { ToolUsePayload } from '@/types/rpc'
 import {
@@ -219,6 +220,27 @@ describe('issue #344 — live stream is bound to a single task', () => {
     })
     expect(stream.endStreaming).toHaveBeenCalled()
     expect(messages.value.some((m) => m.role === 'error')).toBe(true)
+  })
+
+  it('localizes the stable Ensemble image error code and keeps the code attached', async () => {
+    await loadLocaleMessages('zh-Hans')
+    i18n.global.locale.value = 'zh-Hans'
+    const { api, messages, scope } = makeHarness('task-B')
+
+    api.handlers.onAny('task.failed', {
+      task_id: 'task-B',
+      session_key: SESSION,
+      code: 'ensemble_multimodal_unsupported',
+      terminal_message: 'server fallback text',
+    })
+
+    expect(messages.value[messages.value.length - 1]).toMatchObject({
+      role: 'error',
+      errorCode: 'ensemble_multimodal_unsupported',
+      text: 'Ensemble 暂不支持图片输入，请切换到单模型路由后重试。',
+    })
+    scope.stop()
+    i18n.global.locale.value = 'en'
   })
 
   it('binds activeStreamTaskId from task.running, then filters the prior task', () => {

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -41,6 +41,7 @@ import {
   taskTerminalStatus as eventTaskTerminalStatus,
 } from '@/utils/chat/streamEvents'
 import { stoppedOutputNoticeMessage } from '@/composables/chat/stoppedOutputNotice'
+import { localizedChatErrorMessage } from '@/utils/chat/errors'
 
 export interface ChatUsageAccumulator {
   input: number
@@ -978,9 +979,10 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
       stream.endStreaming()
       const rawErrorCode = (payload as { code?: unknown })?.code
       const errorCode = typeof rawErrorCode === 'string' ? rawErrorCode : undefined
+      const serverMessage = eventSessionErrorMessage(payload)
       messages.value.push({
         role: 'error',
-        text: eventSessionErrorMessage(payload),
+        text: localizedChatErrorMessage(errorCode, serverMessage),
         errorCode,
         terminalNotice: true,
         ts: new Date().toISOString(),

--- a/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { nextTick, ref } from 'vue'
 
 import { useChatSend, type UseChatSendOptions } from './useChatSend'
 import { useChatMessageActions } from './useChatMessageActions'
 import type { FoldLiveTurnMode } from './useChatTurnLog'
 import type { Attachment, ChatMessage, ChatRenderedMessage } from '@/types/chat'
-import type { BusySendMode } from '@/composables/chat/useChatPendingQueue'
+import {
+  useChatPendingQueue,
+  type BusySendMode,
+} from '@/composables/chat/useChatPendingQueue'
 import { FINISHED_STREAM_TASK_ID, STOPPED_STREAM_TASK_ID } from '@/utils/chat/streamEvents'
 
 const pushToast = vi.hoisted(() => vi.fn())
@@ -46,6 +49,8 @@ function makeOptions(overrides: Partial<UseChatSendOptions> = {}) {
     sessionKey: ref('agent:main:webchat:test'),
     pendingQueueOwnerContext: ref(null),
     busySendMode: ref<BusySendMode>('queue'),
+    modelRoutingMode: ref<'off'>('off'),
+    modelRoutingSettingsBusy: ref(false),
     elevatedMode: ref(''),
     runMode: ref('trusted'),
     pendingAttachments: ref<Attachment[]>([]),
@@ -1767,6 +1772,278 @@ describe('useChatSend attachment payloads', () => {
       sessionKey: 'agent:main:webchat:test',
       taskId: 'task-A',
       source: 'webui_stale_send',
+    })
+  })
+})
+
+describe('useChatSend Ensemble image guard', () => {
+  function readyAttachment(
+    mime: string,
+    overrides: Partial<Attachment> = {},
+  ): Attachment {
+    return {
+      kind: 'staged',
+      local_id: 91,
+      name: 'input.bin',
+      mime,
+      file_uuid: 'file-ready',
+      ...overrides,
+    }
+  }
+
+  it('blocks a direct Ensemble image send before any visible or RPC mutation', async () => {
+    const image = readyAttachment('image/png', { name: 'photo.png' })
+    const pendingAttachments = ref<Attachment[]>([image])
+    const inputText = ref('describe this')
+    const prepareAttachmentsForSend = vi.fn(async () => true)
+    const { api, options, rpc, stream } = makeOptions({
+      inputText,
+      pendingAttachments,
+      modelRoutingMode: ref<'llm_ensemble'>('llm_ensemble'),
+      prepareAttachmentsForSend,
+    })
+
+    await api.onSend()
+
+    expect(rpc.call).not.toHaveBeenCalled()
+    expect(prepareAttachmentsForSend).not.toHaveBeenCalled()
+    expect(options.messages.value).toEqual([])
+    expect(inputText.value).toBe('describe this')
+    expect(pendingAttachments.value).toEqual([image])
+    expect(options.pendingSessionIntent.value).toBeNull()
+    expect(options.closeSlashMenu).not.toHaveBeenCalled()
+    expect(stream.startStreaming).not.toHaveBeenCalled()
+  })
+
+  it('blocks image sends while routing settings are being written', async () => {
+    const image = readyAttachment('image/webp')
+    const pendingAttachments = ref<Attachment[]>([image])
+    const { api, options, rpc } = makeOptions({
+      pendingAttachments,
+      modelRoutingMode: ref<'off'>('off'),
+      modelRoutingSettingsBusy: ref(true),
+    })
+
+    await api.onSend()
+
+    expect(rpc.call).not.toHaveBeenCalled()
+    expect(options.messages.value).toEqual([])
+    expect(options.inputText.value).toBe('hello')
+    expect(pendingAttachments.value).toEqual([image])
+  })
+
+  it.each(['queue', 'steer'] as const)(
+    'does not consume an Ensemble image draft in %s mode',
+    async (busySendMode) => {
+      const image = readyAttachment('image/jpeg')
+      const pendingAttachments = ref<Attachment[]>([image])
+      const enqueuePendingInput = vi.fn(() => true)
+      const { api, options, rpc, stream } = makeOptions({
+        pendingAttachments,
+        busySendMode: ref<BusySendMode>(busySendMode),
+        modelRoutingMode: ref<'llm_ensemble'>('llm_ensemble'),
+        enqueuePendingInput,
+      })
+      stream.isStreaming.value = true
+
+      await api.onSend()
+
+      expect(rpc.call).not.toHaveBeenCalled()
+      expect(enqueuePendingInput).not.toHaveBeenCalled()
+      expect(options.messages.value).toEqual([])
+      expect(options.inputText.value).toBe('hello')
+      expect(pendingAttachments.value).toEqual([image])
+    },
+  )
+
+  it('rechecks routing after attachment preparation without consuming the draft', async () => {
+    const image = readyAttachment('image/gif')
+    const pendingAttachments = ref<Attachment[]>([image])
+    const modelRoutingMode = ref<'off' | 'llm_ensemble'>('off')
+    const prepareAttachmentsForSend = vi.fn(async () => {
+      modelRoutingMode.value = 'llm_ensemble'
+      return true
+    })
+    const { api, options, rpc } = makeOptions({
+      pendingAttachments,
+      modelRoutingMode,
+      prepareAttachmentsForSend,
+    })
+
+    await api.onSend()
+
+    expect(prepareAttachmentsForSend).toHaveBeenCalledOnce()
+    expect(rpc.call).not.toHaveBeenCalled()
+    expect(options.messages.value).toEqual([])
+    expect(options.inputText.value).toBe('hello')
+    expect(pendingAttachments.value).toEqual([image])
+  })
+
+  it('blocks a recovered image retry after the user switches to Ensemble', async () => {
+    const image = readyAttachment('image/jpg', { name: 'photo.jpg' })
+    const pendingAttachments = ref<Attachment[]>([image])
+    const modelRoutingMode = ref<'off' | 'llm_ensemble'>('off')
+    const rpc = {
+      call: vi.fn().mockRejectedValue(new Error('connection lost')),
+    }
+    const { api, options } = makeOptions({ rpc, pendingAttachments, modelRoutingMode })
+
+    await api.onSend()
+    expect(rpc.call).toHaveBeenCalledOnce()
+    modelRoutingMode.value = 'llm_ensemble'
+
+    await api.onSend()
+
+    expect(rpc.call).toHaveBeenCalledOnce()
+    expect(options.inputText.value).toBe('hello')
+    expect(pendingAttachments.value).toEqual([image])
+  })
+
+  it('preserves an auto-drained queued image after routing switches to Ensemble', async () => {
+    vi.useFakeTimers()
+    try {
+      const image = readyAttachment('image/png')
+      const inputText = ref('queued image')
+      const pendingAttachments = ref<Attachment[]>([image])
+      const pendingSessionIntent = ref<string | null>(null)
+      const sessionKey = ref('agent:main:webchat:test')
+      const modelRoutingMode = ref<'off' | 'llm_ensemble'>('off')
+      const { stream } = makeOptions()
+      stream.isStreaming.value = true
+      let sendCurrentInput: () => void = () => {}
+      const pending = useChatPendingQueue({
+        sessionKey,
+        inputText,
+        pendingAttachments,
+        pendingSessionIntent,
+        isStreaming: stream.isStreaming,
+        isBlocked: () => false,
+        autoResizeTextarea: vi.fn(),
+        sendCurrentInput: () => sendCurrentInput(),
+        resetInputHistory: vi.fn(),
+        hasComposer: () => true,
+      })
+      const { api, options, rpc } = makeOptions({
+        inputText,
+        pendingAttachments,
+        pendingSessionIntent,
+        sessionKey,
+        modelRoutingMode,
+        busySendMode: pending.busySendMode,
+        stream,
+        enqueuePendingInput: pending.enqueuePendingInput,
+        popAllPendingIntoComposer: pending.popAllPendingIntoComposer,
+      })
+      sendCurrentInput = () => { void api.onSend() }
+
+      await api.onSend()
+      expect(pending.pendingQueue.value).toHaveLength(1)
+      expect(inputText.value).toBe('')
+      expect(pendingAttachments.value).toEqual([])
+
+      modelRoutingMode.value = 'llm_ensemble'
+      pending.schedulePendingDrainAfterTerminal()
+      stream.isStreaming.value = false
+      await nextTick()
+      await vi.runAllTimersAsync()
+      await nextTick()
+
+      expect(pending.pendingQueue.value).toEqual([])
+      expect(rpc.call).not.toHaveBeenCalled()
+      expect(options.messages.value).toEqual([])
+      expect(inputText.value).toBe('queued image')
+      expect(pendingAttachments.value).toEqual([image])
+      pending.cleanup()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('lets a handled local slash command run without consuming attached images', async () => {
+    const image = readyAttachment('image/png')
+    const pendingAttachments = ref<Attachment[]>([image])
+    const inputText = ref('/status')
+    const executeSlashCommand = vi.fn(async () => true)
+    const { api, options, rpc } = makeOptions({
+      inputText,
+      pendingAttachments,
+      modelRoutingMode: ref<'llm_ensemble'>('llm_ensemble'),
+      executeSlashCommand,
+    })
+
+    await api.onSend()
+
+    expect(executeSlashCommand).toHaveBeenCalledWith('/status')
+    expect(rpc.call).not.toHaveBeenCalled()
+    expect(inputText.value).toBe('/status')
+    expect(pendingAttachments.value).toEqual([image])
+    expect(options.messages.value).toEqual([])
+  })
+
+  it.each(['application/pdf', 'image/svg+xml', 'image/tiff'])(
+    'does not block the non-model-image MIME %s in Ensemble mode',
+    async (mime) => {
+      const pendingAttachments = ref<Attachment[]>([readyAttachment(mime)])
+      const { api, rpc } = makeOptions({
+        pendingAttachments,
+        modelRoutingMode: ref<'llm_ensemble'>('llm_ensemble'),
+      })
+
+      await api.onSend()
+
+      expect(rpc.call).toHaveBeenCalledWith('chat.send', expect.objectContaining({
+        attachments: [expect.objectContaining({ mime })],
+      }))
+    },
+  )
+
+  it('localizes a defensive server rejection while preserving its error code', async () => {
+    const rpc = {
+      call: vi.fn().mockRejectedValue(Object.assign(new Error('server fallback text'), {
+        code: 'ensemble_multimodal_unsupported',
+        retryable: false,
+      })),
+    }
+    const { api, options } = makeOptions({ rpc })
+
+    await api.onSend()
+
+    expect(options.messages.value[options.messages.value.length - 1]).toMatchObject({
+      role: 'error',
+      errorCode: 'ensemble_multimodal_unsupported',
+      text: "Ensemble doesn't support image input yet. Switch to single-model routing and try again.",
+    })
+  })
+
+  it('localizes a terminal response code but leaves an unknown server message unchanged', async () => {
+    const knownRpc = {
+      call: vi.fn().mockResolvedValue({
+        sessionKey: 'agent:main:webchat:test',
+        task_status: 'failed',
+        terminal_reason: 'ensemble_multimodal_unsupported',
+        terminal_message: 'server fallback text',
+      }),
+    }
+    const known = makeOptions({ rpc: knownRpc })
+    await known.api.onSend()
+    expect(known.options.messages.value[known.options.messages.value.length - 1]).toMatchObject({
+      errorCode: 'ensemble_multimodal_unsupported',
+      text: "Ensemble doesn't support image input yet. Switch to single-model routing and try again.",
+    })
+
+    const unknownRpc = {
+      call: vi.fn().mockResolvedValue({
+        sessionKey: 'agent:main:webchat:test',
+        task_status: 'failed',
+        terminal_reason: 'provider_custom_failure',
+        terminal_message: 'Provider supplied this exact explanation.',
+      }),
+    }
+    const unknown = makeOptions({ rpc: unknownRpc })
+    await unknown.api.onSend()
+    expect(unknown.options.messages.value[unknown.options.messages.value.length - 1]).toMatchObject({
+      errorCode: 'provider_custom_failure',
+      text: 'Provider supplied this exact explanation.',
     })
   })
 })

--- a/opensquilla-webui/src/composables/chat/useChatSend.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.ts
@@ -3,6 +3,7 @@ import i18n from '@/i18n'
 import { useToasts } from '@/composables/useToasts'
 import type { RpcClientError } from '@/lib/rpc'
 import type { Attachment, ChatMessage } from '@/types/chat'
+import type { ModelRoutingMode } from '@/types/modelRouting'
 import type { SandboxRunMode } from '@/types/sandbox'
 import { normalizeSandboxRunMode } from '@/types/sandbox'
 import type {
@@ -16,7 +17,14 @@ import type {
   PendingQueueOwnerContext,
 } from '@/composables/chat/useChatPendingQueue'
 import { recordSessionNavigationDiag } from '@/utils/chat/sessionNavigationDiag'
-import { isSendableAttachment, serializeDisplayAttachment, serializeSendableAttachment, type SendableAttachment } from '@/utils/chat/attachments'
+import {
+  hasSendableModelInputImageAttachment,
+  isSendableAttachment,
+  serializeDisplayAttachment,
+  serializeSendableAttachment,
+  type SendableAttachment,
+} from '@/utils/chat/attachments'
+import { localizedChatErrorMessage } from '@/utils/chat/errors'
 import { createClientMessageId, createClientRequestId } from '@/utils/chat/messageIdentity'
 import {
   FINISHED_STREAM_TASK_ID,
@@ -79,6 +87,15 @@ export function decideSendResponseSession(input: {
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
+}
+
+function errorCode(err: unknown): string | undefined {
+  const code = (err as RpcClientError | null | undefined)?.code
+  return typeof code === 'string' && code ? code : undefined
+}
+
+function sendFailureMessage(err: unknown): string {
+  return localizedChatErrorMessage(errorCode(err), 'Send failed: ' + errorMessage(err))
 }
 
 function shouldRestoreSendAttempt(err: unknown): boolean {
@@ -184,6 +201,8 @@ export interface UseChatSendOptions {
   sessionKey: Ref<string>
   pendingQueueOwnerContext: Ref<PendingQueueOwnerContext | null>
   busySendMode: Ref<BusySendMode>
+  modelRoutingMode: Readonly<Ref<ModelRoutingMode>>
+  modelRoutingSettingsBusy: Readonly<Ref<boolean>>
   elevatedMode: Ref<string>
   runMode: Ref<SandboxRunMode>
   pendingAttachments: Ref<Attachment[]>
@@ -230,6 +249,12 @@ export function useChatSend(options: UseChatSendOptions) {
   let activeFreshSendToken: FreshSendToken | null = null
   let activeResponseHandoff: ResponseHandoffGate | null = null
   let recoveredAttempt: SendAttempt | null = null
+
+  function modelImageSendBlocked(attachments: readonly Attachment[]): boolean {
+    if (!hasSendableModelInputImageAttachment(attachments)) return false
+    return options.modelRoutingSettingsBusy.value
+      || options.modelRoutingMode.value === 'llm_ensemble'
+  }
 
   function beginFreshStream(requestSessionKey: string): FreshSendToken {
     const token: FreshSendToken = { stoppedByUser: false }
@@ -434,10 +459,11 @@ export function useChatSend(options: UseChatSendOptions) {
       finalizedFreshStream = true
     }
     if (status !== 'succeeded') {
+      const code = terminalReplayErrorCode(response, status)
       options.messages.value.push({
         role: 'error',
-        text: terminalReplayMessage(response, status),
-        errorCode: terminalReplayErrorCode(response, status),
+        text: localizedChatErrorMessage(code, terminalReplayMessage(response, status)),
+        errorCode: code,
         terminalNotice: true,
         ts: new Date().toISOString(),
       })
@@ -520,6 +546,9 @@ export function useChatSend(options: UseChatSendOptions) {
         return
       }
       if (!hasPayload) return
+      // Ensemble is text-only in P0. Do not consume the draft into Queue or
+      // Steer while the selected routing mode cannot accept its image blocks.
+      if (modelImageSendBlocked(sendableAttachments)) return
       // Steer injects into the active run right away; compaction cannot be
       // steered, so those sends still queue until it finishes.
       if (options.busySendMode.value === 'steer' && !compactInFlight && !handoffInFlight) {
@@ -554,6 +583,9 @@ export function useChatSend(options: UseChatSendOptions) {
     const requestSessionKey = options.sessionKey.value
     if (!requestSessionKey) return
     const initialSendableAttachments = options.pendingAttachments.value.filter(isSendableAttachment)
+    // This is deliberately before optimistic rendering, composer clearing,
+    // stream state, and chat.send. A blocked draft remains exactly editable.
+    if (modelImageSendBlocked(initialSendableAttachments)) return
     const retryCandidate = recoveredAttempt
     const isRecoveredRetry = Boolean(
       retryCandidate &&
@@ -581,6 +613,9 @@ export function useChatSend(options: UseChatSendOptions) {
       if (options.sessionKey.value !== requestSessionKey) return
     }
     const attachmentsToSend = retryAttempt?.attachments || options.pendingAttachments.value.filter((a): a is SendableAttachment => sendAttachmentIds.has(a.local_id) && isSendableAttachment(a))
+    // Routing can change while an expiring staged upload is refreshed. Recheck
+    // the authoritative live state before any visible or RPC mutation.
+    if (modelImageSendBlocked(attachmentsToSend)) return
     const attachmentsToKeep = options.pendingAttachments.value.filter(a => !sendAttachmentIds.has(a.local_id) || !isSendableAttachment(a))
     if (!text && attachmentsToSend.length === 0) return
 
@@ -785,7 +820,8 @@ export function useChatSend(options: UseChatSendOptions) {
         }
         options.messages.value.push({
           role: 'error',
-          text: 'Send failed: ' + errorMessage(err),
+          text: sendFailureMessage(err),
+          errorCode: errorCode(err),
           ts: new Date().toISOString(),
         })
         return
@@ -814,8 +850,12 @@ export function useChatSend(options: UseChatSendOptions) {
         options.stream.endStreaming()
       }
       if (shouldRestoreSendAttempt(err)) restoreSendAttempt(attempt)
-      const message = errorMessage(err)
-      options.messages.value.push({ role: 'error', text: 'Send failed: ' + message, ts: new Date().toISOString() })
+      options.messages.value.push({
+        role: 'error',
+        text: sendFailureMessage(err),
+        errorCode: errorCode(err),
+        ts: new Date().toISOString(),
+      })
     } finally {
       finishResponseHandoff(responseHandoff)
     }
@@ -1037,7 +1077,8 @@ export function useChatSend(options: UseChatSendOptions) {
         }
         options.messages.value.push({
           role: 'error',
-          text: 'Send failed: ' + errorMessage(err),
+          text: sendFailureMessage(err),
+          errorCode: errorCode(err),
           ts: new Date().toISOString(),
         })
         return
@@ -1065,8 +1106,12 @@ export function useChatSend(options: UseChatSendOptions) {
         options.activeStreamSessionKey.value = ''
         options.stream.endStreaming()
       }
-      const message = errorMessage(err)
-      options.messages.value.push({ role: 'error', text: 'Send failed: ' + message, ts: new Date().toISOString() })
+      options.messages.value.push({
+        role: 'error',
+        text: sendFailureMessage(err),
+        errorCode: errorCode(err),
+        ts: new Date().toISOString(),
+      })
     } finally {
       finishResponseHandoff(responseHandoff)
     }

--- a/opensquilla-webui/src/composables/chat/useChatSessionHandoff.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionHandoff.test.ts
@@ -216,6 +216,8 @@ describe('chat send session handoff', () => {
       sessionKey,
       pendingQueueOwnerContext,
       busySendMode: pendingQueueRuntime.busySendMode,
+      modelRoutingMode: ref<'off'>('off'),
+      modelRoutingSettingsBusy: ref(false),
       elevatedMode: ref(''),
       runMode: ref('trusted'),
       pendingAttachments,

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -2848,6 +2848,8 @@
       "routerAnimationOn": "Router-Animation ein",
       "routerAnimationOff": "Router-Animation aus",
       "modelRouting": "Modell-Routing",
+      "ensembleImageUnsupported": "Ensemble unterstützt derzeit keine Bildeingaben. Wechseln Sie zum Einzelmodell-Routing und versuchen Sie es erneut.",
+      "routingUpdateImageBlocked": "Das Modell-Routing wird aktualisiert. Warten Sie, bevor Sie Bilder senden.",
       "modelRoutingOff": "Aus",
       "modelRoutingOffDesc": "Jeden Durchlauf an das ausgewählte Modell senden.",
       "modelRoutingSquillaRouter": "AI-gestützter Einzelmodell-Router",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -2848,6 +2848,8 @@
       "routerAnimationOn": "Router animation on",
       "routerAnimationOff": "Router animation off",
       "modelRouting": "Model routing",
+      "ensembleImageUnsupported": "Ensemble doesn't support image input yet. Switch to single-model routing and try again.",
+      "routingUpdateImageBlocked": "Model routing is being updated. Wait before sending images.",
       "modelRoutingOff": "Off",
       "modelRoutingOffDesc": "Send every turn to the selected model.",
       "modelRoutingSquillaRouter": "AI-powered single-model router",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -2848,6 +2848,8 @@
       "routerAnimationOn": "Animación del enrutador activada",
       "routerAnimationOff": "Animación del enrutador desactivada",
       "modelRouting": "Enrutamiento de modelos",
+      "ensembleImageUnsupported": "Ensemble aún no admite entradas de imagen. Cambia al enrutamiento de un solo modelo e inténtalo de nuevo.",
+      "routingUpdateImageBlocked": "El enrutamiento de modelos se está actualizando. Espera antes de enviar imágenes.",
       "modelRoutingOff": "Desactivado",
       "modelRoutingOffDesc": "Envía cada turno al modelo seleccionado.",
       "modelRoutingSquillaRouter": "Enrutador monomodelo con IA",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -2848,6 +2848,8 @@
       "routerAnimationOn": "Animation du routeur activée",
       "routerAnimationOff": "Animation du routeur désactivée",
       "modelRouting": "Routage des modèles",
+      "ensembleImageUnsupported": "Ensemble ne prend pas encore en charge les images. Passez au routage à modèle unique, puis réessayez.",
+      "routingUpdateImageBlocked": "Le routage des modèles est en cours de mise à jour. Attendez avant d’envoyer des images.",
       "modelRoutingOff": "Désactivé",
       "modelRoutingOffDesc": "Envoie chaque tour au modèle sélectionné.",
       "modelRoutingSquillaRouter": "Routeur mono-modèle avec IA",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -2848,6 +2848,8 @@
       "routerAnimationOn": "ルーターアニメーション オン",
       "routerAnimationOff": "ルーターアニメーション オフ",
       "modelRouting": "モデルルーティング",
+      "ensembleImageUnsupported": "Ensemble はまだ画像入力に対応していません。単一モデルルーティングに切り替えて、もう一度お試しください。",
+      "routingUpdateImageBlocked": "モデルルーティングを更新しています。画像を送信する前にお待ちください。",
       "modelRoutingOff": "オフ",
       "modelRoutingOffDesc": "各ターンを選択中のモデルへ送信します。",
       "modelRoutingSquillaRouter": "AI搭載シングルモデルルーター",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -2848,6 +2848,8 @@
       "routerAnimationOn": "路由动画已开启",
       "routerAnimationOff": "路由动画已关闭",
       "modelRouting": "模型路由",
+      "ensembleImageUnsupported": "Ensemble 暂不支持图片输入，请切换到单模型路由后重试。",
+      "routingUpdateImageBlocked": "模型路由正在更新，请稍候再发送图片。",
       "modelRoutingOff": "关",
       "modelRoutingOffDesc": "每轮都发送到当前选定模型。",
       "modelRoutingSquillaRouter": "AI 智能单模型路由",

--- a/opensquilla-webui/src/utils/chat/attachments.test.ts
+++ b/opensquilla-webui/src/utils/chat/attachments.test.ts
@@ -1,12 +1,74 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  hasSendableModelInputImageAttachment,
   isImageDisplayAttachment,
+  isModelInputImageMime,
+  isSendableModelInputImageAttachment,
   normalizeDisplayAttachment,
   normalizeDisplayAttachments,
   serializeDisplayAttachment,
 } from './attachments'
 import type { Attachment } from '@/types/chat'
+
+describe('model-input image detection', () => {
+  it.each([
+    'image/png',
+    'IMAGE/JPEG',
+    'image/jpg',
+    'image/gif; charset=binary',
+    'image/webp',
+  ])('accepts the Gateway model-image MIME %s', (mime) => {
+    expect(isModelInputImageMime(mime)).toBe(true)
+  })
+
+  it.each([
+    'application/pdf',
+    'image/svg+xml',
+    'image/tiff',
+    'image/avif',
+    'text/plain',
+  ])('does not classify %s as a model image', (mime) => {
+    expect(isModelInputImageMime(mime)).toBe(false)
+  })
+
+  it('counts only ready inline and staged image attachments', () => {
+    const inline: Attachment = {
+      kind: 'inline',
+      local_id: 1,
+      name: 'inline.png',
+      mime: 'image/png',
+      data: 'aW1hZ2U=',
+    }
+    const staged: Attachment = {
+      kind: 'staged',
+      local_id: 2,
+      name: 'staged.jpg',
+      mime: 'image/jpg',
+      file_uuid: 'file-ready',
+    }
+    const uploading: Attachment = {
+      kind: 'uploading',
+      local_id: 3,
+      name: 'uploading.webp',
+      mime: 'image/webp',
+    }
+    const failed: Attachment = {
+      kind: 'failed',
+      local_id: 4,
+      name: 'failed.gif',
+      mime: 'image/gif',
+      error: 'failed',
+    }
+
+    expect(isSendableModelInputImageAttachment(inline)).toBe(true)
+    expect(isSendableModelInputImageAttachment(staged)).toBe(true)
+    expect(isSendableModelInputImageAttachment(uploading)).toBe(false)
+    expect(isSendableModelInputImageAttachment(failed)).toBe(false)
+    expect(hasSendableModelInputImageAttachment([uploading, failed])).toBe(false)
+    expect(hasSendableModelInputImageAttachment([uploading, staged])).toBe(true)
+  })
+})
 
 describe('attachment display normalization', () => {
   it('renders inline HTML history attachments as downloadable file chips without DOM data', () => {

--- a/opensquilla-webui/src/utils/chat/attachments.ts
+++ b/opensquilla-webui/src/utils/chat/attachments.ts
@@ -38,6 +38,27 @@ export function isImageDisplayAttachment(attachment: Pick<DisplayAttachment, 'mi
   return isImageAttachmentMime(attachment.mime)
 }
 
+const MODEL_INPUT_IMAGE_MIMES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+])
+
+/**
+ * Return the canonical MIME type for images the Gateway turns into model image
+ * blocks. Keep this narrower than the preview helper above: formats such as
+ * TIFF and SVG may be attachments, but they do not enter the model as images.
+ */
+export function normalizeModelInputImageMime(mime: unknown): string {
+  const essence = normalizeAttachmentMimeValue(mime, '').split(';', 1)[0].trim()
+  return essence === 'image/jpg' ? 'image/jpeg' : essence
+}
+
+export function isModelInputImageMime(mime: unknown): boolean {
+  return MODEL_INPUT_IMAGE_MIMES.has(normalizeModelInputImageMime(mime))
+}
+
 function safeImageDataUrl(value: unknown, declaredMime: string): string | undefined {
   if (typeof value !== 'string') return undefined
   const match = value.match(/^data:([^;,]+)(?:;[^,]*)?;base64,[a-z0-9+/=\s]*$/i)
@@ -53,6 +74,16 @@ export function isSendableAttachment(attachment: Attachment): attachment is Send
   if (attachment.kind === 'inline') return Boolean(attachment.data)
   if (attachment.kind === 'staged') return Boolean(attachment.file_uuid)
   return false
+}
+
+export function isSendableModelInputImageAttachment(
+  attachment: Attachment,
+): attachment is SendableAttachment {
+  return isSendableAttachment(attachment) && isModelInputImageMime(attachment.mime)
+}
+
+export function hasSendableModelInputImageAttachment(attachments: readonly Attachment[]): boolean {
+  return attachments.some(isSendableModelInputImageAttachment)
 }
 
 export function serializeSendableAttachment(attachment: SendableAttachment): ChatSendAttachmentPayload {

--- a/opensquilla-webui/src/utils/chat/errors.ts
+++ b/opensquilla-webui/src/utils/chat/errors.ts
@@ -1,0 +1,14 @@
+import i18n from '@/i18n'
+
+export const ENSEMBLE_MULTIMODAL_UNSUPPORTED = 'ensemble_multimodal_unsupported'
+
+/** Preserve server-authored text for unknown failures, but give the stable
+ * Ensemble image-input error an actionable message in the active UI locale. */
+export function localizedChatErrorMessage(
+  code: unknown,
+  fallback: string,
+): string {
+  return code === ENSEMBLE_MULTIMODAL_UNSUPPORTED
+    ? i18n.global.t('chat.composer.ensembleImageUnsupported')
+    : fallback
+}

--- a/opensquilla-webui/src/utils/chat/streamEvents.ts
+++ b/opensquilla-webui/src/utils/chat/streamEvents.ts
@@ -120,9 +120,13 @@ export function taskTerminalAsSessionEvent(event: string, payload: SessionEventP
   }
   if (!['task.failed', 'task.timeout', 'task.abandoned'].includes(event)) return null
   const status = event.replace('task.', '')
+  const rawCode = payload?.code
+  const payloadCode = typeof rawCode === 'string' ? rawCode.trim().toLowerCase() : ''
   const rawReason = payload?.terminal_reason
   const terminalReason = typeof rawReason === 'string' ? rawReason.trim().toLowerCase() : ''
-  const code = /^[a-z][a-z0-9_.-]*$/.test(terminalReason) ? terminalReason : status
+  const code = /^[a-z][a-z0-9_.-]*$/.test(payloadCode)
+    ? payloadCode
+    : /^[a-z][a-z0-9_.-]*$/.test(terminalReason) ? terminalReason : status
   return {
     event: 'session.event.error',
     payload: { ...(payload || {}), message: taskTerminalMessage(status, payload), code },

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -439,6 +439,7 @@
       :is-new-landing="isNewChatLanding"
       :placeholder="composerPlaceholder"
       :send-button-title="sendButtonTitle"
+      :send-blocked-message="modelImageSendBlockedMessage"
       :run-mode="runMode"
       :allowed-run-modes="allowedRunModes"
       :model-routing-mode="modelRoutingMode"
@@ -614,7 +615,10 @@ import {
   toolSecondaryText,
   toolStatusText,
 } from '@/utils/chat/toolDisplay'
-import { isSendableAttachment } from '@/utils/chat/attachments'
+import {
+  hasSendableModelInputImageAttachment,
+  isSendableAttachment,
+} from '@/utils/chat/attachments'
 import { isShareableChatMessage } from '@/utils/chat/messageIdentity'
 import { agentIdFromSessionKey } from '@/utils/chat/sessionKeys'
 
@@ -1267,6 +1271,8 @@ const chatSend = useChatSend({
   sessionKey,
   pendingQueueOwnerContext,
   busySendMode,
+  modelRoutingMode,
+  modelRoutingSettingsBusy,
   elevatedMode,
   runMode,
   pendingAttachments,
@@ -1539,7 +1545,18 @@ const hasSendContent = computed(() => {
   return inputText.value.trim().length > 0 || pendingAttachments.value.some(isSendableAttachment)
 })
 
+const modelImageSendBlockedMessage = computed(() => {
+  if (!hasSendableModelInputImageAttachment(pendingAttachments.value)) return ''
+  if (modelRoutingSettingsBusy.value) {
+    return t('chat.composer.routingUpdateImageBlocked')
+  }
+  return modelRoutingMode.value === 'llm_ensemble'
+    ? t('chat.composer.ensembleImageUnsupported')
+    : ''
+})
+
 const sendButtonTitle = computed(() => {
+  if (modelImageSendBlockedMessage.value) return modelImageSendBlockedMessage.value
   if (isCompactInFlightForCurrentSession()) return t('chat.sendQueuesUntilCompaction')
   if (isStreaming.value) {
     return busySendMode.value === 'steer'

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -141,7 +141,10 @@ from opensquilla.provider import (
     ToolUseStartEvent as ProviderToolUseStart,
 )
 from opensquilla.provider.failures import ProviderFailureKind, classify_provider_error
-from opensquilla.provider.protocol import project_provider_message_count
+from opensquilla.provider.protocol import (
+    project_provider_message_count,
+    validate_provider_chat_request,
+)
 from opensquilla.provider.types import (
     ContentBlockImage,
     FailureInjector,
@@ -4969,6 +4972,26 @@ class Agent:
                         runtime_context_insert_index=active_runtime_context_insert_index,
                         turn_objective_message=turn_objective_message,
                     )
+                    validation_error = validate_provider_chat_request(
+                        self.provider,
+                        request_messages,
+                    )
+                    if validation_error is not None:
+                        terminal_error = ErrorEvent(
+                            message=validation_error.message,
+                            code=validation_error.code,
+                        )
+                        self._write_turn_call_log(
+                            "turn_policy_decision",
+                            action="stop",
+                            reason=terminal_error.message,
+                            code=terminal_error.code,
+                            iteration=iterations,
+                            attempt=_call_attempt,
+                        )
+                        yield self._transition(AgentState.ERROR)
+                        yield terminal_error
+                        break
                     identical_request_action = self._identical_request_loop_break_action(
                         request_messages,
                         first_attempt=_call_attempt == 0,

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -203,6 +203,7 @@ from opensquilla.provider import (
     decide_recovery_action,
 )
 from opensquilla.provider.model_catalog import resolve_effective_context_window
+from opensquilla.provider.protocol import validate_provider_chat_request
 from opensquilla.provider.types import (
     EnsembleProgressEvent as ProviderEnsembleProgressEvent,
 )
@@ -1639,6 +1640,11 @@ class _SelectorFallbackProvider:
         tools: Any = None,
         config: Any = None,
     ) -> AsyncIterator[Any]:
+        validation_error = validate_provider_chat_request(self._provider, messages)
+        if validation_error is not None:
+            yield validation_error
+            return
+
         emitted_user_visible_content = False
         pre_text_buffer: list[Any] = []
 

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -30,6 +30,8 @@ from .protocol import (
 from .selector import ModelSelector, ProviderConfig, SelectorConfig
 from .types import (
     ChatConfig,
+    ContentBlockImage,
+    ContentBlockToolResult,
     DoneEvent,
     EnsembleProgressEvent,
     ErrorEvent,
@@ -52,6 +54,11 @@ from .types import (
 TRACE_CONTENT_MAX_CHARS = 8_000
 _ENSEMBLE_HEARTBEAT_INTERVAL_SECONDS = 15.0
 _ENSEMBLE_CANCEL_CLEANUP_TIMEOUT_SECONDS = 5.0
+ENSEMBLE_MULTIMODAL_UNSUPPORTED_CODE = "ensemble_multimodal_unsupported"
+ENSEMBLE_MULTIMODAL_UNSUPPORTED_MESSAGE = (
+    "Ensemble does not support image input yet. "
+    "Switch to a single-model routing mode and try again."
+)
 log = structlog.get_logger(__name__)
 
 
@@ -741,6 +748,29 @@ class EnsembleProvider:
             base_url="",
         )
 
+    def validate_chat_request(self, messages: list[Message]) -> ErrorEvent | None:
+        """Reject typed image input before any ensemble leg can start."""
+
+        for message in messages:
+            if not isinstance(message.content, list):
+                continue
+            for block in message.content:
+                if isinstance(block, ContentBlockImage):
+                    return ErrorEvent(
+                        message=ENSEMBLE_MULTIMODAL_UNSUPPORTED_MESSAGE,
+                        code=ENSEMBLE_MULTIMODAL_UNSUPPORTED_CODE,
+                    )
+                if not isinstance(block, ContentBlockToolResult):
+                    continue
+                if isinstance(block.content, list) and any(
+                    isinstance(item, ContentBlockImage) for item in block.content
+                ):
+                    return ErrorEvent(
+                        message=ENSEMBLE_MULTIMODAL_UNSUPPORTED_MESSAGE,
+                        code=ENSEMBLE_MULTIMODAL_UNSUPPORTED_CODE,
+                    )
+        return None
+
     async def list_models(self) -> list[ModelInfo]:
         models: list[ModelInfo] = []
         for member in [*self.proposers, self.aggregator]:
@@ -835,6 +865,11 @@ class EnsembleProvider:
         tools: list[ToolDefinition] | None = None,
         config: ChatConfig | None = None,
     ) -> AsyncIterator[StreamEvent]:
+        validation_error = self.validate_chat_request(messages)
+        if validation_error is not None:
+            yield validation_error
+            return
+
         if not self.proposers:
             async for event in self._fallback_or_error(
                 messages,

--- a/src/opensquilla/provider/failures.py
+++ b/src/opensquilla/provider/failures.py
@@ -177,6 +177,14 @@ _MODEL_UNAVAILABLE_SUBSTRINGS = (
 
 # Family-independent kinds checked before any family table.
 _SHARED_PRE_MATCHERS: tuple[FailureMatcher, ...] = (
+    # Local composite-provider validation.  This must classify before a
+    # provider-family "does not support" matcher can turn it into
+    # UNSUPPORTED_FEATURE: that kind deliberately hops to a fallback provider,
+    # which would bypass Ensemble's text-only contract.
+    FailureMatcher(
+        ProviderFailureKind.BAD_REQUEST,
+        raw_codes=frozenset({"ensemble_multimodal_unsupported"}),
+    ),
     FailureMatcher(
         ProviderFailureKind.CONTEXT_OVERFLOW,
         message_substrings=(

--- a/src/opensquilla/provider/protocol.py
+++ b/src/opensquilla/provider/protocol.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from .types import (
     ChatConfig,
+    ErrorEvent,
     Message,
     ModelInfo,
     ProviderMessageCountProjection,
@@ -175,6 +176,34 @@ def project_provider_message_count(
     except Exception:  # noqa: BLE001 - optional capability must stay best-effort
         return None
     return projection if isinstance(projection, ProviderMessageCountProjection) else None
+
+
+def validate_provider_chat_request(
+    provider: object | None,
+    messages: list[Message],
+) -> ErrorEvent | None:
+    """Run an optional, side-effect-free provider request preflight.
+
+    Validation is deliberately duck-typed instead of widening
+    :class:`LLMProvider`: ordinary providers keep the established chat
+    contract, while composite providers may reject requests before any
+    physical model call or usage-accounting envelope starts.
+
+    A missing, raising, or invalid optional implementation is ignored.  The
+    provider remains the authoritative fallback boundary and must repeat its
+    own validation immediately before starting work.
+    """
+
+    if provider is None:
+        return None
+    validation_fn = getattr(provider, "validate_chat_request", None)
+    if not callable(validation_fn):
+        return None
+    try:
+        validation_error = validation_fn(messages)
+    except Exception:  # noqa: BLE001 - optional preflight must stay best-effort
+        return None
+    return validation_error if isinstance(validation_error, ErrorEvent) else None
 
 
 @runtime_checkable

--- a/src/opensquilla/session/terminal_reply.py
+++ b/src/opensquilla/session/terminal_reply.py
@@ -8,6 +8,11 @@ from typing import Any
 from opensquilla.session.models import AgentTaskStatus
 
 CONTEXT_PAYLOAD_TOO_LARGE_CODE = "provider_request_too_large"
+ENSEMBLE_MULTIMODAL_UNSUPPORTED_CODE = "ensemble_multimodal_unsupported"
+ENSEMBLE_MULTIMODAL_UNSUPPORTED_MESSAGE = (
+    "Ensemble does not support image input yet. "
+    "Switch to a single-model routing mode and try again."
+)
 
 # Non-context budget-exhaustion codes. Context-window exhaustion has its own,
 # more specific message via ``is_context_payload_too_large`` and is intentionally
@@ -80,6 +85,11 @@ def build_terminal_reply(
     # Per-code phrasing for the non-provider terminal codes the agent loop emits,
     # so each surfaces a specific, actionable cause instead of the generic
     # "failed" sentence below.
+    if (
+        error_class == ENSEMBLE_MULTIMODAL_UNSUPPORTED_CODE
+        or reason == ENSEMBLE_MULTIMODAL_UNSUPPORTED_CODE
+    ):
+        return ENSEMBLE_MULTIMODAL_UNSUPPORTED_MESSAGE
     if error_class == "sandbox_threshold_exceeded" or reason == "sandbox_threshold_exceeded":
         return (
             "Automatic execution paused after repeated sandbox denials. Approve the "

--- a/tests/test_cli/test_chat_cmd.py
+++ b/tests/test_cli/test_chat_cmd.py
@@ -15,6 +15,7 @@ from rich.console import Console
 from typer.testing import CliRunner
 
 from opensquilla.cli import chat_cmd
+from opensquilla.cli.chat.turn_stream import turn_stream_error_message
 from opensquilla.cli.main import app
 from opensquilla.cli.repl import commands as repl_commands
 from opensquilla.cli.repl import slash_bridge
@@ -31,6 +32,18 @@ from opensquilla.session.compaction import CompactionConfig
 from opensquilla.tools.types import CallerKind, ToolContext
 
 runner = CliRunner()
+
+
+def test_cli_surfaces_actionable_ensemble_image_rejection() -> None:
+    event = SimpleNamespace(
+        code="ensemble_multimodal_unsupported",
+        message=(
+            "Ensemble does not support image input yet. "
+            "Switch to a single-model routing mode and try again."
+        ),
+    )
+
+    assert turn_stream_error_message(event) == event.message
 
 
 def _install_fake_inputs(monkeypatch, inputs: Iterable[str]) -> None:

--- a/tests/test_contracts/test_error_event_wire.py
+++ b/tests/test_contracts/test_error_event_wire.py
@@ -78,3 +78,18 @@ def test_channel_reply_carries_ref() -> None:
         event.error_id or None,
     )
     assert reply == "The task failed before it could finish. (ref: abcd1234)"
+
+
+def test_channel_reply_surfaces_actionable_ensemble_image_rejection() -> None:
+    from opensquilla.gateway.channel_dispatch import _terminal_payload_from_error_event
+    from opensquilla.session.terminal_reply import build_terminal_reply
+
+    event = ErrorEvent(
+        message=(
+            "Ensemble does not support image input yet. "
+            "Switch to a single-model routing mode and try again."
+        ),
+        code="ensemble_multimodal_unsupported",
+    )
+
+    assert build_terminal_reply(_terminal_payload_from_error_event(event)) == event.message

--- a/tests/test_engine/test_turn_outcome.py
+++ b/tests/test_engine/test_turn_outcome.py
@@ -24,3 +24,15 @@ def test_unknown_error_remains_failed() -> None:
 
     assert outcome.kind == "failed"
     assert outcome.retryable is False
+
+
+def test_ensemble_multimodal_rejection_is_failed_and_not_retryable() -> None:
+    outcome = outcome_from_error(
+        code="ensemble_multimodal_unsupported",
+        message="Switch to a single-model routing mode and try again.",
+    )
+
+    assert outcome.kind == "failed"
+    assert outcome.reason == "ensemble_multimodal_unsupported"
+    assert outcome.error_class == "ensemble_multimodal_unsupported"
+    assert outcome.retryable is False

--- a/tests/test_engine/test_usage_event_accounting.py
+++ b/tests/test_engine/test_usage_event_accounting.py
@@ -23,12 +23,14 @@ from opensquilla.engine.usage_accounting import (
     normalize_provider_usage,
     usd_to_nanos,
 )
-from opensquilla.provider import ChatConfig, Message
+from opensquilla.provider import ChatConfig, Message, ModelCapabilities
 from opensquilla.provider import DoneEvent as ProviderDone
 from opensquilla.provider import ErrorEvent as ProviderError
 from opensquilla.provider import TextDeltaEvent as ProviderText
+from opensquilla.provider.ensemble import EnsembleMemberConfig, EnsembleProvider
 from opensquilla.provider.preset_registry import get_preset
-from opensquilla.provider.types import ProviderBillingReceipt
+from opensquilla.provider.selector import ProviderConfig
+from opensquilla.provider.types import ContentBlockImage, ProviderBillingReceipt
 from opensquilla.session.manager import SessionManager
 from opensquilla.session.storage import SessionStorage
 from opensquilla.skills.meta.orchestrator import make_llm_chat_from_provider
@@ -226,6 +228,135 @@ def _context() -> UsageExecutionContext:
         agent_id="main",
         run_kind="webchat",
     )
+
+
+def _image_rejecting_ensemble(*, fallback_provider: Any | None = None) -> EnsembleProvider:
+    return EnsembleProvider(
+        profile_name="image-validation",
+        proposers=[],
+        aggregator=EnsembleMemberConfig(
+            provider_config=ProviderConfig(provider="fake", model="never-called")
+        ),
+        fallback_provider=fallback_provider,
+        fallback_provider_name="fake" if fallback_provider is not None else "",
+        fallback_model="fallback-model" if fallback_provider is not None else "",
+        all_failed_policy="fallback_single" if fallback_provider is not None else "error",
+    )
+
+
+def _image_message() -> Message:
+    return Message(
+        role="user",
+        content=[ContentBlockImage(media_type="image/png", data="aW1hZ2U=")],
+    )
+
+
+class _CapturingTurnLog:
+    def __init__(self) -> None:
+        self.records: list[dict[str, Any]] = []
+
+    def write(self, kind: str, payload: dict[str, Any]) -> None:
+        self.records.append({"kind": kind, "payload": payload})
+
+
+@pytest.mark.asyncio
+async def test_selector_preflight_rejects_ensemble_image_before_usage_or_fallback() -> None:
+    sink = _RecordingSink()
+    fallback = _PhysicalLegProvider(
+        "anthropic",
+        [ProviderText(text="must not run"), ProviderDone(model="fallback-model")],
+    )
+    wrapper = _SelectorFallbackProvider(
+        _image_rejecting_ensemble(fallback_provider=fallback),
+        _FallbackSelector(fallback),
+    )
+    scope = UsageAccountingScope(sink=sink, context=_context())
+
+    with bind_usage_accounting_scope(scope):
+        events = [event async for event in wrapper.chat([_image_message()])]
+
+    assert [getattr(event, "code", "") for event in events] == [
+        "ensemble_multimodal_unsupported"
+    ]
+    assert fallback.calls == 0
+    assert sink.started == []
+    assert sink.finalized == []
+    assert sink.unknown == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("image_location", ["current", "history"])
+@pytest.mark.parametrize("wrapped_by_selector", [False, True])
+async def test_agent_preflight_rejects_ensemble_image_before_call_accounting(
+    image_location: str,
+    wrapped_by_selector: bool,
+) -> None:
+    sink = _RecordingSink()
+    tracker = _RecordingTracker()
+    fallback = _PhysicalLegProvider(
+        "anthropic",
+        [ProviderText(text="must not run"), ProviderDone(model="fallback-model")],
+    )
+    observer_calls: list[dict[str, Any]] = []
+    turn_log = _CapturingTurnLog()
+    turn_metadata: dict[str, Any] = {}
+    ensemble = _image_rejecting_ensemble(fallback_provider=fallback)
+    provider: Any = (
+        _SelectorFallbackProvider(
+            ensemble,
+            _FallbackSelector(fallback),
+            turn_metadata,
+        )
+        if wrapped_by_selector
+        else ensemble
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_iterations=1,
+            max_provider_retries=3,
+            model_id="ensemble/image-validation",
+            model_capabilities=ModelCapabilities(supports_vision=True),
+            preserve_historical_images=True,
+            provider_call_observer=lambda **kwargs: observer_calls.append(kwargs),
+        ),
+        usage_tracker=tracker,
+        session_key="agent:main:image-validation",
+        turn_call_logger=turn_log,  # type: ignore[arg-type]
+        usage_event_sink=sink,
+        usage_execution_context=_context(),
+    )
+    if image_location == "history":
+        agent.set_history([_image_message()])
+        message = "continue"
+        extra_messages = None
+    else:
+        message = ""
+        extra_messages = [_image_message()]
+
+    events = [
+        event
+        async for event in agent.run_turn(
+            message,
+            extra_messages=extra_messages,
+        )
+    ]
+
+    errors = [event for event in events if isinstance(event, ErrorEvent)]
+    assert [error.code for error in errors] == ["ensemble_multimodal_unsupported"]
+    assert fallback.calls == 0
+    assert sink.started == []
+    assert sink.finalized == []
+    assert sink.unknown == []
+    assert tracker.rows == []
+    assert observer_calls == []
+    assert "router_fallback_hops" not in turn_metadata
+    assert not any(record["kind"] == "llm_request" for record in turn_log.records)
+    [decision] = [
+        record for record in turn_log.records if record["kind"] == "turn_policy_decision"
+    ]
+    assert decision["payload"]["code"] == "ensemble_multimodal_unsupported"
+    assert "messages" not in decision["payload"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_terminal_reply.py
+++ b/tests/test_gateway/test_terminal_reply.py
@@ -126,6 +126,15 @@ RAW_INTERNAL_STRINGS = (
             },
             "budget limit",
         ),
+        (
+            {
+                "status": "failed",
+                "terminal_reason": "error",
+                "error_class": "ensemble_multimodal_unsupported",
+                "error_message": "internal provider validation detail",
+            },
+            "single-model routing mode",
+        ),
     ],
 )
 def test_build_terminal_reply_returns_user_readable_messages(
@@ -156,6 +165,22 @@ def test_sandbox_pause_reply_is_distinct_from_generic_failure() -> None:
     )
     assert paused != generic
     assert "resume" in paused.lower()
+
+
+def test_ensemble_multimodal_reply_is_actionable_and_stable() -> None:
+    reply = build_terminal_reply(
+        {
+            "status": "failed",
+            "terminal_reason": "error",
+            "error_class": "ensemble_multimodal_unsupported",
+            "error_message": "raw detail must not win",
+        }
+    )
+
+    assert reply == (
+        "Ensemble does not support image input yet. "
+        "Switch to a single-model routing mode and try again."
+    )
 
 
 def test_build_terminal_reply_accepts_agent_task_record_like_objects() -> None:

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -6,7 +6,7 @@ import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field, replace
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
@@ -14,6 +14,9 @@ from opensquilla.engine.usage_accounting import normalize_provider_usage
 from opensquilla.gateway.config import GatewayConfig
 from opensquilla.provider import (
     ChatConfig,
+    ContentBlockDocument,
+    ContentBlockText,
+    ContentBlockToolResult,
     DoneEvent,
     ErrorEvent,
     Message,
@@ -32,6 +35,7 @@ from opensquilla.provider.ensemble import (
 )
 from opensquilla.provider.selector import ProviderConfig
 from opensquilla.provider.types import (
+    ContentBlockImage,
     EnsembleProgressEvent,
     ProviderBillingReceipt,
     ProviderMessageCountProjection,
@@ -562,6 +566,203 @@ async def test_tokenrhythm_b5_strict_quorum_partial_failure_preserves_fallback_r
     assert result.cache_read_tokens == sum(item.cache_read_tokens for item in result.items)
     assert result.cache_write_tokens == sum(item.cache_write_tokens for item in result.items)
     assert [item.billing_receipt for item in result.items] == receipts
+
+
+def _ensemble_for_validation(
+    *,
+    proposers: list[EnsembleMemberConfig] | None = None,
+    fallback_provider: _FakeProvider | None = None,
+    all_failed_policy: Literal["error", "fallback_single"] = "error",
+) -> EnsembleProvider:
+    return EnsembleProvider(
+        profile_name="image-validation",
+        proposers=proposers if proposers is not None else [_member("p1")],
+        aggregator=_member("agg"),
+        fallback_provider=fallback_provider,
+        fallback_provider_name="fake" if fallback_provider is not None else "",
+        fallback_model="fallback" if fallback_provider is not None else "",
+        all_failed_policy=all_failed_policy,
+        shuffle_candidates=False,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "messages",
+    [
+        [
+            Message(
+                role="user",
+                content=[
+                    ContentBlockImage(
+                        source_type="base64",
+                        media_type="image/png",
+                        data="aW1hZ2U=",
+                    )
+                ],
+            )
+        ],
+        [
+            Message(
+                role="user",
+                content=[
+                    ContentBlockImage(
+                        source_type="url",
+                        media_type="image/jpeg",
+                        data="https://example.invalid/image.jpg",
+                    )
+                ],
+            ),
+            Message(role="user", content="continue from the prior image"),
+        ],
+        [
+            Message(
+                role="user",
+                content=[
+                    ContentBlockText(text="describe this"),
+                    ContentBlockImage(
+                        source_type="base64",
+                        media_type="image/webp",
+                        data="aW1hZ2U=",
+                    ),
+                ],
+            )
+        ],
+        [
+            Message(
+                role="user",
+                content=[
+                    ContentBlockToolResult(
+                        tool_use_id="call-image",
+                        content=[
+                            ContentBlockImage(
+                                source_type="base64",
+                                media_type="image/gif",
+                                data="aW1hZ2U=",
+                            )
+                        ],
+                    )
+                ],
+            )
+        ],
+    ],
+    ids=["base64", "historical-url", "mixed", "typed-tool-result"],
+)
+async def test_ensemble_rejects_typed_images_before_starting_any_leg(
+    monkeypatch: pytest.MonkeyPatch,
+    messages: list[Message],
+) -> None:
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan([DoneEvent(model="p1")]),
+            "agg": _FakePlan([DoneEvent(model="agg")]),
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    provider = _ensemble_for_validation()
+
+    events = [event async for event in provider.chat(messages)]
+
+    assert len(events) == 1
+    assert isinstance(events[0], ErrorEvent)
+    assert events[0].code == "ensemble_multimodal_unsupported"
+    assert events[0].message == (
+        "Ensemble does not support image input yet. "
+        "Switch to a single-model routing mode and try again."
+    )
+    assert registry.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("all_failed_policy", ["error", "fallback_single"])
+async def test_ensemble_image_validation_precedes_empty_lineup_fallback(
+    all_failed_policy: Literal["error", "fallback_single"],
+) -> None:
+    registry = _FakeRegistry(
+        {
+            "fallback": _FakePlan([DoneEvent(model="fallback")]),
+        }
+    )
+    fallback = _FakeProvider(
+        ProviderConfig(provider="fake", model="fallback"),
+        registry,
+    )
+    provider = _ensemble_for_validation(
+        proposers=[],
+        fallback_provider=fallback,
+        all_failed_policy=all_failed_policy,
+    )
+    messages = [
+        Message(
+            role="user",
+            content=[ContentBlockImage(media_type="image/png", data="aW1hZ2U=")],
+        )
+    ]
+
+    events = [event async for event in provider.chat(messages)]
+
+    assert [getattr(event, "code", "") for event in events] == [
+        "ensemble_multimodal_unsupported"
+    ]
+    assert registry.calls == []
+
+
+def test_ensemble_image_validation_does_not_guess_untyped_or_document_content() -> None:
+    provider = _ensemble_for_validation()
+    messages = [
+        Message(role="user", content="the word image/png is plain text"),
+        Message(
+            role="user",
+            content=[
+                ContentBlockDocument(
+                    media_type="application/pdf",
+                    data="cGRm",
+                ),
+                ContentBlockToolResult(
+                    tool_use_id="call-dict",
+                    content=[
+                        {
+                            "type": "image",
+                            "source_type": "base64",
+                            "media_type": "image/png",
+                            "data": "aW1hZ2U=",
+                        }
+                    ],
+                ),
+            ],
+        ),
+    ]
+
+    assert provider.validate_chat_request(messages) is None
+
+
+@pytest.mark.asyncio
+async def test_ensemble_text_block_input_still_executes_normally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan(
+                [TextDeltaEvent(text="draft"), DoneEvent(model="p1")]
+            ),
+            "agg": _FakePlan(
+                [TextDeltaEvent(text="final"), DoneEvent(model="agg")]
+            ),
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    provider = _ensemble_for_validation()
+    messages = [
+        Message(
+            role="user",
+            content=[ContentBlockText(text="text extracted from an attachment")],
+        )
+    ]
+
+    events = [event async for event in provider.chat(messages)]
+
+    assert [call["model"] for call in registry.calls] == ["p1", "agg"]
+    assert any(isinstance(event, TextDeltaEvent) and event.text == "final" for event in events)
 
 
 def test_ensemble_message_count_projection_includes_aggregator_bundle(

--- a/tests/test_provider_failures.py
+++ b/tests/test_provider_failures.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import pytest
 import structlog
 
+from opensquilla.engine.fallback import FallbackPolicy
 from opensquilla.provider.failures import (
     FailureMatcher,
     ProviderFailureKind,
+    ProviderRecoveryAction,
     classify_provider_error,
+    decide_recovery_action,
 )
 from opensquilla.provider.openai import _http_error_body_text
 
@@ -33,6 +36,25 @@ def test_provider_request_budget_exhausted_is_context_overflow() -> None:
         )
         is ProviderFailureKind.CONTEXT_OVERFLOW
     )
+
+
+@pytest.mark.parametrize("provider_name", ["ensemble", "openrouter"])
+def test_ensemble_multimodal_rejection_is_surfaced_without_fallback(
+    provider_name: str,
+) -> None:
+    kind = classify_provider_error(
+        provider_name=provider_name,
+        status_code=None,
+        raw_code="ensemble_multimodal_unsupported",
+        message=(
+            "Ensemble does not support image input yet. "
+            "Switch to a single-model routing mode and try again."
+        ),
+    )
+
+    assert kind is ProviderFailureKind.BAD_REQUEST
+    assert decide_recovery_action(kind) is ProviderRecoveryAction.SURFACE
+    assert FallbackPolicy().should_retry(kind, attempt=0) is False
 
 
 def test_unknown_classification_emits_redacted_fingerprint_event() -> None:


### PR DESCRIPTION
## Scope

- reject typed image blocks before any Ensemble proposer, aggregator, Ensemble fallback, or selector fallback starts
- run the optional provider preflight after final request sanitization and before LLM call counting, usage accounting, provider observation, and request logging
- classify `ensemble_multimodal_unsupported` as non-retryable `BAD_REQUEST → SURFACE` and expose an actionable terminal reply to CLI and channels
- block sendable PNG/JPEG/GIF/WebP attachments in the WebUI while Ensemble is selected or routing settings are updating
- preserve drafts and attachments across direct send, Queue, Steer, automatic drain, and recovered retry paths
- add accessible inline status plus six-locale and stable-error-code handling

## Root cause

Ensemble accepted multimodal request messages without validating that every physical leg could consume image blocks. A routed image request could therefore reach a text-only member and fail upstream with HTTP 400 after accounting and fallback machinery had already started.

## User impact

Ensemble is now explicitly text-only. Image drafts remain editable and instruct the user to switch to single-model routing. Pure text and attachments already converted to text continue to work unchanged.

## Compatibility and safety

- Target: `main`
- Linked issue: [OSQ-543](https://linear.app/opensquilla/issue/OSQ-543/bug-systemerror-tokenrhythm-chat-request-failed-http-400-model)
- Release note: include as an Ensemble multimodal input guard
- No config, database, migration, or public RPC schema changes
- Platform-neutral behavior
- Third-party origin: None

## Validation

- `197 passed` across provider, Agent/usage, failure classification, outcome, CLI/channel, and terminal reply suites
- `1569 passed` WebUI unit tests
- `ruff check src tests`
- `mypy src/opensquilla --show-error-codes`
- WebUI architecture checks, six-locale parity, typecheck, and production build
- Full local Python suite was attempted; managed-sandbox restrictions blocked environment-dependent loopback, tmux, network-build, and host-sandbox tests. CI is expected to provide those capabilities.
