### PR TITLE
Keep session auto-naming models consistent with the active provider

### DIFF
--- a/src/opensquilla/session/naming.py
+++ b/src/opensquilla/session/naming.py
@@ -6,9 +6,13 @@ runs a single one-shot LLM call (mirroring the compaction summarizer's direct
 
 Model selection deliberately does NOT reuse the session model. It resolves, in
 order: ``naming.model`` (explicit) → ``naming.tier`` model → the router's
-``default_tier`` model → the session/provider model as a last resort. Connection
-credentials (api_key / base_url) come from the same provider the compaction path
-resolves, so an OpenRouter-backed gateway stays self-consistent.
+``default_tier`` model → the session/provider model as a last resort. A tier
+model is only eligible when the tier targets the active provider — matched on
+the configured provider id, with the wire kind accepted as an alias — or names
+no provider at all: tier model ids are spelled per provider catalog and are
+not portable across connections. Connection credentials (api_key / base_url)
+come from the same provider the compaction path resolves, so an
+OpenRouter-backed gateway stays self-consistent.
 
 The title is written to ``derived_title`` (not ``display_name``) so it sits below
 a user's manual rename in the precedence (see ``session_view._title``) and can
@@ -27,14 +31,21 @@ import structlog
 
 from opensquilla.env import trust_env as _trust_env
 from opensquilla.provider.app_attribution import provider_app_headers
-from opensquilla.provider.protocol import provider_connection_config
+from opensquilla.provider.protocol import (
+    configured_provider_id,
+    provider_connection_config,
+)
 from opensquilla.router_tiers import DEFAULT_TEXT_TIER, normalize_text_tier
 
 log = structlog.get_logger(__name__)
 
 _DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
 _MAX_INPUT_CHARS = 4000  # cap the untrusted first message fed to the namer
-_TITLE_MAX_TOKENS = 96
+# Reasoning-by-default models (e.g. DeepSeek V4 family) spend completion
+# tokens on thinking before the title, and some hosts offer no way to turn
+# that off — the budget must cover thinking plus the title or the response
+# ends at length with empty content.
+_TITLE_MAX_TOKENS = 512
 _OPENROUTER_REASONING_DEFAULT_MODELS = frozenset(
     {
         "deepseek/deepseek-v4",
@@ -118,7 +129,12 @@ def is_naming_eligible(naming_cfg: Any, surface: str, session_kind: str) -> bool
     return False
 
 
-def _tier_model(router_cfg: Any | None, tier_name: str | None) -> str | None:
+def _tier_model(
+    router_cfg: Any | None,
+    tier_name: str | None,
+    *,
+    provider_identities: frozenset[str] = frozenset(),
+) -> str | None:
     tiers = getattr(router_cfg, "tiers", None)
     if not isinstance(tiers, dict) or not tier_name:
         return None
@@ -127,10 +143,26 @@ def _tier_model(router_cfg: Any | None, tier_name: str | None) -> str | None:
         normalized = normalize_text_tier(tier_name)
         if normalized:
             cfg = tiers.get(normalized)
-    if isinstance(cfg, dict):
-        model = cfg.get("model")
-        return str(model).strip() or None if model else None
-    return None
+    if not isinstance(cfg, dict):
+        return None
+    # Tier model ids are spelled for the tier's own provider catalog. Naming
+    # can only send through the active provider's connection, so a tier that
+    # names a different provider is unusable here (its id would be rejected
+    # by the host, e.g. a vendor-prefixed id posted to a strict catalog).
+    # Tier tables spell ``provider`` as the configured registry id (the same
+    # vocabulary the routing mismatch policy compares); the wire kind stays
+    # accepted as an alias for hand-written tables.
+    tier_provider = str(cfg.get("provider") or "").strip().lower()
+    if tier_provider and provider_identities and tier_provider not in provider_identities:
+        log.debug(
+            "session_naming.tier_model_skipped_provider_mismatch",
+            tier=tier_name,
+            tier_provider=tier_provider,
+            provider_identities=sorted(provider_identities),
+        )
+        return None
+    model = cfg.get("model")
+    return str(model).strip() or None if model else None
 
 
 def resolve_naming_target(
@@ -146,13 +178,18 @@ def resolve_naming_target(
     """
 
     conn = provider_connection_config(provider)
+    provider_identities = frozenset(
+        identity.strip().lower()
+        for identity in (configured_provider_id(provider), conn.provider_kind)
+        if identity and identity.strip()
+    )
 
     tier_name = getattr(naming_cfg, "tier", None) or getattr(
         router_cfg, "default_tier", DEFAULT_TEXT_TIER
     )
     model = (
         getattr(naming_cfg, "model", None)
-        or _tier_model(router_cfg, tier_name)
+        or _tier_model(router_cfg, tier_name, provider_identities=provider_identities)
         or conn.model
         or fallback_model
     )

--- a/tests/test_session/test_naming.py
+++ b/tests/test_session/test_naming.py
@@ -51,9 +51,20 @@ async def mgr(storage):
 class _FakeProvider:
     """Provider stub exposing the connection config the namer reads."""
 
-    def __init__(self, *, api_key: str = "KEY", model: str = "", base_url: str = ""):
+    def __init__(
+        self,
+        *,
+        api_key: str = "KEY",
+        model: str = "",
+        base_url: str = "",
+        provider_kind: str = "openrouter",
+        provider_id: str = "",
+    ):
+        if provider_id:
+            # picked up by provider_metadata()'s attribute fallback
+            self.provider_id = provider_id
         self._conn = ProviderConnectionConfig(
-            provider_kind="openrouter",
+            provider_kind=provider_kind,
             model=model,
             api_key=api_key,
             base_url=base_url or "https://openrouter.ai/api/v1",
@@ -194,6 +205,97 @@ def test_resolve_target_none_without_api_key():
     assert resolve_naming_target(cfg, _router(), _FakeProvider(api_key=""), None) is None
 
 
+def _profile_router(default_tier="c1", tier_provider="openrouter"):
+    return SimpleNamespace(
+        tiers={
+            "c1": {"provider": tier_provider, "model": "deepseek/deepseek-v4-pro"},
+        },
+        default_tier=default_tier,
+    )
+
+
+def test_resolve_target_skips_tier_model_for_other_provider():
+    # Tier ids are spelled per provider catalog: an "openrouter" tier model
+    # must not be sent over a different provider's connection.
+    cfg = SimpleNamespace(tier=None, model=None, timeout_seconds=30.0)
+    provider = _FakeProvider(provider_kind="tokenrhythm", model="deepseek-v4-pro")
+    target = resolve_naming_target(cfg, _profile_router(), provider, None)
+    assert target.model == "deepseek-v4-pro"
+    assert target.provider == "tokenrhythm"
+
+
+def test_resolve_target_uses_tier_model_for_matching_provider():
+    cfg = SimpleNamespace(tier=None, model=None, timeout_seconds=30.0)
+    provider = _FakeProvider(provider_kind="openrouter", model="z-ai/glm-5.2")
+    target = resolve_naming_target(cfg, _profile_router(), provider, None)
+    assert target.model == "deepseek/deepseek-v4-pro"
+
+
+def test_resolve_target_provider_match_is_case_insensitive():
+    cfg = SimpleNamespace(tier=None, model=None, timeout_seconds=30.0)
+    # Connection-side mixed case.
+    provider = _FakeProvider(provider_kind="OpenRouter", model="z-ai/glm-5.2")
+    target = resolve_naming_target(
+        cfg, _profile_router(tier_provider="openrouter"), provider, None
+    )
+    assert target.model == "deepseek/deepseek-v4-pro"
+    # Tier-side mixed case (tier tables are free-form user TOML).
+    provider = _FakeProvider(provider_kind="openrouter", model="z-ai/glm-5.2")
+    target = resolve_naming_target(
+        cfg, _profile_router(tier_provider="OpenRouter"), provider, None
+    )
+    assert target.model == "deepseek/deepseek-v4-pro"
+
+
+def test_resolve_target_matches_tier_on_configured_provider_id():
+    # Registry id and wire kind diverge (e.g. minimax_openai runs on the
+    # "minimax" wire policy); a tier naming the registry id must still match.
+    cfg = SimpleNamespace(tier=None, model=None, timeout_seconds=30.0)
+    provider = _FakeProvider(
+        provider_kind="minimax",
+        provider_id="minimax_openai",
+        model="MiniMax-M3",
+    )
+    router = SimpleNamespace(
+        tiers={"c1": {"provider": "minimax_openai", "model": "MiniMax-M2.7"}},
+        default_tier="c1",
+    )
+    target = resolve_naming_target(cfg, router, provider, None)
+    assert target.model == "MiniMax-M2.7"
+
+
+def test_resolve_target_trusts_tier_when_provider_identity_unknown():
+    # A connection that reports no identity at all keeps the legacy behavior:
+    # a provider-qualified tier is not skipped on an empty comparison side.
+    cfg = SimpleNamespace(tier=None, model=None, timeout_seconds=30.0)
+    provider = _FakeProvider(provider_kind="", model="deepseek-v4-pro")
+    target = resolve_naming_target(cfg, _profile_router(), provider, None)
+    assert target.model == "deepseek/deepseek-v4-pro"
+
+
+def test_resolve_target_trusts_tier_model_without_tier_provider():
+    # A tier that names no provider keeps the legacy behavior even when the
+    # active connection is a different provider.
+    cfg = SimpleNamespace(tier=None, model=None, timeout_seconds=30.0)
+    provider = _FakeProvider(provider_kind="tokenrhythm", model="deepseek-v4-pro")
+    target = resolve_naming_target(cfg, _router("c1"), provider, None)
+    assert target.model == "deepseek/deepseek-v4-pro"
+
+
+def test_resolve_target_explicit_model_wins_over_mismatched_tier():
+    cfg = SimpleNamespace(tier=None, model="explicit-model", timeout_seconds=30.0)
+    provider = _FakeProvider(provider_kind="tokenrhythm", model="deepseek-v4-pro")
+    target = resolve_naming_target(cfg, _profile_router(), provider, None)
+    assert target.model == "explicit-model"
+
+
+def test_resolve_target_mismatched_tier_falls_through_to_fallback_model():
+    cfg = SimpleNamespace(tier=None, model=None, timeout_seconds=30.0)
+    provider = _FakeProvider(provider_kind="tokenrhythm", model="")
+    target = resolve_naming_target(cfg, _profile_router(), provider, "session-model")
+    assert target.model == "session-model"
+
+
 def test_tier_model_normalizes_alias():
     router = SimpleNamespace(tiers={"c1": {"model": "deepseek/deepseek-v4-pro"}})
     # t1 is a legacy alias for c1 (router_tiers.normalize_text_tier).
@@ -250,10 +352,12 @@ async def test_call_naming_llm_payload_and_sanitization(monkeypatch):
 
     # Response sanitized (quotes stripped).
     assert title == "Reset my password"
-    # Cheap, deterministic title-shaped request.
+    # Cheap, deterministic title-shaped request. The completion budget must
+    # cover reasoning-by-default models that spend thinking tokens before the
+    # title (a 96-token cap returned empty content at finish_reason=length).
     assert captured["url"] == "https://openrouter.ai/api/v1/chat/completions"
     assert captured["json"]["model"] == "deepseek/deepseek-v4-pro"
-    assert captured["json"]["max_tokens"] == 96
+    assert captured["json"]["max_tokens"] == 512
     assert captured["json"]["temperature"] == 0
     assert captured["json"]["stream"] is False
     # OpenRouter attribution headers are present (mirrors compaction path).
@@ -420,7 +524,15 @@ def _patch_provider_and_emit(monkeypatch, *, title: str | None):
     import opensquilla.session.naming as naming_mod
 
     monkeypatch.setattr(
-        rpc_chat_mod, "_resolve_compaction_provider", lambda ctx, session: _FakeProvider()
+        rpc_chat_mod,
+        "_resolve_compaction_provider",
+        # Match the packaged default config: the built-in tier table names the
+        # tokenrhythm provider, and the provider-consistency guard skips tiers
+        # aimed at another provider. The explicit model keeps resolution alive
+        # via the connection fallback if the default profile ever changes.
+        lambda ctx, session: _FakeProvider(
+            provider_kind="tokenrhythm", model="deepseek-v4-pro"
+        ),
     )
 
     calls: dict = {"llm": 0}


### PR DESCRIPTION
## Scope

Scope boundary: session auto-naming model resolution (`session/naming.py`) and its unit tests. The naming call resolved its model from the router tier table but sent it over the active provider's connection; when the tier targets a different provider (e.g. an `openrouter` tier profile over a `tokenrhythm` connection), the host rejects the foreign model id. Every eligible new session then logged one failed call with unknown cost — degrading the session's cost provenance badge to "mixed" even though all real turns were exactly billed — and auto-titling silently fell back to truncation. A tier model is now only eligible when the tier targets the active provider, matched on the configured provider id with the wire kind accepted as an alias (mirroring the routing mismatch vocabulary); a tier naming no provider, or a connection reporting no identity, keeps the legacy behavior. The title completion budget also rises 96 → 512 tokens: reasoning-by-default models spend completion tokens on thinking before the title, and on hosts with no reasoning toggle the 96-token cap ended at length with empty content.

Non-goals: other consumers of the tier table (vision gate, dream consolidation, auto-propose) are untouched; the Usage UI "mixed" tooltip wording and the model-breakdown display of slash-containing model ids are untouched.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: diagnosed from a live gateway's usage ledger (failed naming calls recorded as unknown-cost events); no tracking issue exists.

## Release Note

Release note: Session auto-naming now resolves its model against the active provider, so gateways whose router tier profile targets a different provider get titles again and new sessions no longer record a failed unknown-cost call; the title budget accommodates reasoning-by-default models.

## Tests

Ruff: `uv run ruff check src tests` — passed.

Pytest: `uv run pytest -q` — 15781 passed, 156 skipped; 17 failures are machine-specific (TUI real-terminal and sandbox seatbelt/bwrap) and reproduce identically on a clean `main` checkout in the same environment, none in session/provider/usage areas. `uv run pytest tests/test_session -q` — 296 passed.

Build: `uv build --wheel` — passed (after a local WebUI artifact rebuild; no frontend changes in this PR).

Regression tests: added

Notes: new cases cover the cross-provider skip, registry-id vs wire-kind matching, case-insensitive comparison on both sides, empty-identity and provider-less-tier legacy trust, explicit `naming.model` precedence, and the fallback chain; the payload test pins the new 512-token cap.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: provider

Live verification against tokenrhythm.studio: the previously resolved vendor-prefixed id reproduces the 400 rejection; post-fix, an openrouter tier profile over a tokenrhythm connection resolves the bare connection model and returns a real title, and the packaged tokenrhythm ladder still resolves its own tier model.

## Safety

No secrets, transcripts, channel identifiers, or machine-specific paths added; live checks read credentials from git-ignored env files by variable name only.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
