### PR TITLE
Parse multi-document ossutil output in the OSS mirror versioning check

### DIFF
--- a/.github/workflows/mirror-release-to-oss.yml
+++ b/.github/workflows/mirror-release-to-oss.yml
@@ -475,11 +475,33 @@ jobs:
 
           path = Path("channel-assets/bucket-versioning.json")
           try:
-              payload = json.loads(path.read_text(encoding="utf-8"))
-          except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+              raw = path.read_text(encoding="utf-8")
+          except (OSError, UnicodeError) as exc:
               raise SystemExit(f"Unable to verify OSS bucket versioning state: {exc}") from exc
-          if not isinstance(payload, dict):
-              raise SystemExit("OSS bucket versioning response must be a JSON object")
+
+          # ossutil emits the JSON body followed by extra output (for example an
+          # elapsed-time trailer or additional metadata documents). Parse every
+          # leading JSON document and fail closed only when none can be parsed.
+          decoder = json.JSONDecoder()
+          documents = []
+          index = 0
+          while index < len(raw):
+              while index < len(raw) and raw[index].isspace():
+                  index += 1
+              if index >= len(raw):
+                  break
+              try:
+                  document, index = decoder.raw_decode(raw, index)
+              except json.JSONDecodeError:
+                  break
+              documents.append(document)
+
+          if not documents:
+              snippet = " ".join(raw.split())[:300]
+              raise SystemExit(
+                  "Unable to verify OSS bucket versioning state: no JSON document "
+                  f"in ossutil output: {snippet!r}"
+              )
 
           def statuses(value):
               if isinstance(value, dict):
@@ -491,7 +513,15 @@ jobs:
                   for nested in value:
                       yield from statuses(nested)
 
-          reported = [value for value in statuses(payload) if value not in (None, "")]
+          # Only real versioning states defeat x-oss-forbid-overwrite. Response
+          # envelopes may carry unrelated "status" fields (HTTP codes), so match
+          # the two states the OSS API can report for a versioned bucket.
+          reported = [
+              value
+              for document in documents
+              for value in statuses(document)
+              if isinstance(value, str) and value.casefold() in ("enabled", "suspended")
+          ]
           if reported:
               raise SystemExit(
                   "OSS release mirror bucket must be unversioned; reported Status: "

--- a/tests/test_release_oss_mirror_workflow.py
+++ b/tests/test_release_oss_mirror_workflow.py
@@ -92,8 +92,12 @@ def _install_fake_ossutil(tmp_path: Path) -> tuple[Path, Path, Path]:
                 return args[args.index(name) + 1]
 
             if args[:2] == ["api", "get-bucket-versioning"]:
+                # Real ossutil follows the JSON body with extra output (an
+                # elapsed-time trailer); reproduce that shape so the parser
+                # is exercised against production output, not idealized JSON.
                 status = os.environ.get("FAKE_OSS_VERSIONING_STATUS", "")
                 print(json.dumps({"Status": status} if status else {}))
+                print("0.062000(s) elapsed")
                 raise SystemExit(0)
 
             if args[:2] == ["api", "put-object"]:


### PR DESCRIPTION
## Scope

Fixes the v0.5.0 post-publish mirror failure. The bucket-versioning preflight (added in #677, after the last successful mirror run, so never exercised against the real bucket) assumed `ossutil api get-bucket-versioning --output-format json` emits one clean JSON document; production output carries extra content after the JSON body, so `json.loads` raised `Extra data` and the run failed closed before uploading anything.

- Parse every leading JSON document with `raw_decode`, tolerating the non-JSON trailer; fail closed (with a raw-output snippet for diagnosis) only when nothing parses.
- Treat only the real versioning states (`Enabled`/`Suspended`, the two states that defeat `x-oss-forbid-overwrite`) as blocking, so response-envelope status fields cannot false-positive.
- The fake ossutil in the workflow tests now prints the trailer after the JSON body, turning this incident into a regression test: the old parser fails the suite, the new one passes.

## Branch target

`main`

## Linked issue

None

## Release notes

Not needed (CI/release-infrastructure fix; no runtime behavior change).

## Tests

- `uv run pytest tests/test_release_oss_mirror_workflow.py -q` — 2 passed (the suite extracts and executes the real upload step script; the success path now exercises multi-document output, and Enabled/Suspended still fail closed before any upload)
- `uv run ruff check tests` — clean

## Safety notes

Fail-closed semantics preserved: unparseable output still aborts before any upload, and versioned buckets are still rejected. No secrets touched.

## Third-party origin

None; original work.