### PR TITLE
Mirror releases onto versioned OSS buckets without weakening write-once

### DIFF
--- a/.github/workflows/mirror-release-to-oss.yml
+++ b/.github/workflows/mirror-release-to-oss.yml
@@ -459,9 +459,12 @@ jobs:
             exit "${status}"
           }
 
-          # OSS ignores x-oss-forbid-overwrite when bucket versioning is enabled
-          # or suspended. Query the bucket through its standard regional
-          # endpoint and fail closed before relying on conditional writes.
+          # Version-scoped immutability is enforced by the existence check plus
+          # SHA256 verification in upload_immutable_asset; x-oss-forbid-overwrite
+          # only narrows the check-to-write race and is ignored by OSS while
+          # bucket versioning is enabled or suspended. Query and log the
+          # versioning state so every mirror run records which regime it ran
+          # under.
           versioning_endpoint="oss-${OSS_REGION}.aliyuncs.com"
           ossutil api get-bucket-versioning \
             --addressing-style virtual \
@@ -513,9 +516,9 @@ jobs:
                   for nested in value:
                       yield from statuses(nested)
 
-          # Only real versioning states defeat x-oss-forbid-overwrite. Response
-          # envelopes may carry unrelated "status" fields (HTTP codes), so match
-          # the two states the OSS API can report for a versioned bucket.
+          # Only real versioning states matter here. Response envelopes may
+          # carry unrelated "status" fields (HTTP codes), so match the two
+          # states the OSS API can report for a versioned bucket.
           reported = [
               value
               for document in documents
@@ -523,10 +526,15 @@ jobs:
               if isinstance(value, str) and value.casefold() in ("enabled", "suspended")
           ]
           if reported:
-              raise SystemExit(
-                  "OSS release mirror bucket must be unversioned; reported Status: "
+              print(
+                  "OSS bucket versioning is "
                   + ", ".join(repr(value) for value in reported)
+                  + "; x-oss-forbid-overwrite is advisory there. Version-scoped "
+                  "immutability remains enforced by the existence check plus "
+                  "SHA256 verification before every upload."
               )
+          else:
+              print("OSS bucket versioning is not configured.")
           PY
           trap rollback_promotions EXIT
 

--- a/tests/test_release_oss_mirror_workflow.py
+++ b/tests/test_release_oss_mirror_workflow.py
@@ -276,7 +276,8 @@ def test_aliyun_oss_release_mirror_workflow_contract() -> None:
     )[0]
     assert "--force" not in immutable_put
     assert "get-bucket-versioning" in workflow
-    assert "OSS release mirror bucket must be unversioned" in workflow
+    assert "OSS bucket versioning is " in workflow
+    assert "SHA256 verification before every upload" in workflow
     assert "Refusing to replace immutable OSS release object" in workflow
     assert "Publish corrected release assets under a new release tag" in workflow
     assert 'local_digest="$(sha256sum -- "${source}"' in workflow
@@ -392,6 +393,12 @@ def test_version_scoped_oss_objects_are_write_once_and_race_safe(tmp_path: Path)
     assert "Refusing to replace immutable OSS release object" in raced.stderr
     assert (remote_release / "racy.bin").read_bytes() == b"concurrent-writer"
 
+    # Versioned buckets no longer block the mirror: forbid-overwrite is
+    # advisory there, and immutability rests on the existence check plus
+    # SHA256 verification. An identical re-run stays idempotent and the run
+    # records which versioning regime it executed under.
+    racy_payload.write_bytes(b"concurrent-writer")
+    checksums.write_text("first-published-checksums\n", encoding="utf-8", newline="\n")
     for attempt, status in enumerate(("Enabled", "Suspended"), start=5):
         call_log.write_text("", encoding="utf-8")
         versioned = _run_upload_step(
@@ -402,7 +409,22 @@ def test_version_scoped_oss_objects_are_write_once_and_race_safe(tmp_path: Path)
             attempt=attempt,
             versioning_status=status,
         )
-        assert versioned.returncode != 0
-        assert "OSS release mirror bucket must be unversioned" in versioned.stderr
+        assert versioned.returncode == 0, versioned.stderr
+        assert f"OSS bucket versioning is {status!r}" in versioned.stdout
         versioned_calls = [json.loads(line) for line in call_log.read_text().splitlines()]
         assert not any(call[:2] == ["api", "put-object"] for call in versioned_calls)
+
+    # The write-once contract survives on a versioned bucket: divergent bytes
+    # for an already-mirrored object are still refused before any upload.
+    racy_payload.write_bytes(b"tampered-payload")
+    tampered = _run_upload_step(
+        tmp_path,
+        fake_bin,
+        remote_root,
+        call_log,
+        attempt=7,
+        versioning_status="Enabled",
+    )
+    assert tampered.returncode != 0
+    assert "Refusing to replace immutable OSS release object" in tampered.stderr
+    assert (remote_release / "racy.bin").read_bytes() == b"concurrent-writer"


### PR DESCRIPTION
## Scope

Unblocks the v0.5.0 OSS mirror. The release bucket reports versioning `Enabled`, and the preflight added in #677 hard-failed on that state because `x-oss-forbid-overwrite` is ignored on versioned buckets. Two facts make the hard failure wrong:

1. Version-scoped immutability never rested on that header alone — `upload_immutable_asset` already performs an existence check plus a download-and-SHA256 comparison on every object, refusing divergent bytes and skipping identical ones; `forbid-overwrite` only narrowed the check-to-write race.
2. OSS versioning is one-way: an Enabled bucket can only be Suspended, never returned to unversioned — so the preflight permanently blocked mirroring for this bucket.

The preflight now logs the versioning regime (still parsing the multi-document ossutil output from #779) and proceeds. Moving aliases and channel manifests are untouched — they are replaced in place by design.

## Branch target

`main`

## Linked issue

None

## Release notes

Not needed (release-infrastructure change; no runtime behavior change).

## Tests

- `uv run pytest tests/test_release_oss_mirror_workflow.py -q` — 2 passed. The suite executes the real upload step and now proves, on a versioned bucket: identical re-runs stay idempotent (no put-object), the run logs the versioning regime, and divergent bytes for an already-mirrored object are still refused before any upload.
- `uv run ruff check tests` — clean

## Safety notes

Write-once semantics preserved via existence check + SHA256 verification; tamper rejection is covered by a new regression test running under `Enabled`. Operational note: with versioning enabled, replaced aliases accumulate noncurrent versions — a bucket lifecycle rule for noncurrent-version cleanup is recommended (console-side, not part of this change).

## Third-party origin

None; original work.