### PR TITLE
Persist the TUI theme and surface fallback, approval, and keybinding detail

### DIFF
--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -1101,6 +1101,8 @@
     "tests/unit/cli/tui/test_opentui_notice_capture.py": 0.02,
     "tests/unit/cli/tui/test_opentui_renderer.py": 0.057,
     "tests/unit/cli/tui/test_opentui_surface.py": 0.151,
+    "tests/unit/cli/tui/test_keys_cheatsheet.py": 0.05,
+    "tests/unit/cli/tui/test_opentui_prefs.py": 0.2,
     "tests/unit/cli/tui/test_opentui_themes.py": 0.015,
     "tests/unit/cli/tui/test_opentui_transport.py": 0.01,
     "tests/unit/cli/tui/test_output_binding.py": 0.01,

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.py[cod]
 *.egg-info/
+.coverage*
 /dist/
 /build/
 .venv/

--- a/src/opensquilla/cli/doctor_cmd.py
+++ b/src/opensquilla/cli/doctor_cmd.py
@@ -357,6 +357,93 @@ def _local_config_findings(config_path: str | Path | None = None) -> list[Health
     return _local_onboarding_findings(config, config_path=config_path)
 
 
+def _local_tui_findings() -> list[HealthFinding]:
+    """Explain which chat surface `--ui auto` selects on THIS terminal.
+
+    The gateway report cannot cover this: renderer availability (companion,
+    bun, terminal capabilities) is a property of the CLI process's machine, so
+    the finding is appended locally to both the online and offline reports. A
+    healthy full-screen selection reports nothing.
+    """
+    from opensquilla.cli.tui.backend.render_summary import sanitize_terminal_text
+    from opensquilla.cli.tui.renderers.selection import select_chat_ui_backend
+
+    try:
+        selection = select_chat_ui_backend("auto")
+    except Exception as exc:  # noqa: BLE001 - a UI probe must never crash doctor.
+        # Exception text can wrap host/subprocess output: same trust level and
+        # scrubbing as the fallback detail below.
+        crash_detail = (
+            sanitize_terminal_text(f"{type(exc).__name__}: {exc}")
+            .replace("\r", " ")
+            .replace("\n", " ")
+        )
+        return [
+            HealthFinding(
+                id="tui.selection_failed",
+                severity="warn",
+                readiness_impact="optional",
+                surface="cli",
+                title="Terminal UI selection failed",
+                detail=crash_detail,
+            )
+        ]
+    fallback = selection.fallback
+    if fallback is None:
+        return []
+    fix_steps: list[FixStep] = []
+    from opensquilla.cli.tui.source_checkout import resolve_tui_source_checkout_hint
+
+    hint = resolve_tui_source_checkout_hint()
+    if hint is not None:
+        fix_steps = [
+            FixStep(label="Install the TUI host dependencies", command=hint.install_command),
+            FixStep(label="Launch the full-screen TUI", command=hint.launch_command),
+        ]
+    detail = sanitize_terminal_text(fallback.detail).replace("\r", " ").replace("\n", " ")
+    return [
+        HealthFinding(
+            id="tui.opentui_unavailable",
+            severity="info",
+            readiness_impact="optional",
+            surface="cli",
+            title="Full-screen terminal UI not active — chat uses plain mode",
+            detail=detail,
+            evidence={
+                "reasonCode": fallback.code.value,
+                "selectedBackend": selection.backend.backend_id,
+            },
+            fix_steps=fix_steps,
+        )
+    ]
+
+
+def _append_local_tui_findings(report: dict[str, Any]) -> None:
+    """Merge the CLI-local terminal-UI findings into a finished report.
+
+    The whole report is re-derived through ``_refresh_report_readiness`` so
+    counts, impact counts, ordering, and the summary stay mutually consistent.
+    An offline report keeps its "unavailable" sentinel status/ready/summary —
+    those describe the failed gateway probe, which an optional UI capability
+    note must not rewrite.
+    """
+    findings = _local_tui_findings()
+    if not findings:
+        return
+    report_findings = report.setdefault("findings", [])
+    if not isinstance(report_findings, list):
+        return
+    report_findings.extend(finding.to_dict() for finding in findings)
+    offline_sentinel = (
+        (report.get("status"), report.get("ready"), report.get("summary"))
+        if report.get("status") == "unavailable"
+        else None
+    )
+    _refresh_report_readiness(report)
+    if offline_sentinel is not None:
+        report["status"], report["ready"], report["summary"] = offline_sentinel
+
+
 def _offline_report(
     error: BaseException,
     *,
@@ -693,6 +780,7 @@ def doctor_command(
             config_owns_target=config_owns_gateway_target,
         )
     report = copy.deepcopy(report)
+    _append_local_tui_findings(report)
     report.setdefault("gatewayUrl", target_url)
     report.setdefault("agentId", agent_id)
     if requested_config_path:

--- a/src/opensquilla/cli/tui/adapters/approvals.py
+++ b/src/opensquilla/cli/tui/adapters/approvals.py
@@ -260,12 +260,29 @@ async def _resolve_decision(
 
 
 def _host_request_payload(envelope: ApprovalEnvelope) -> dict[str, object]:
-    return {
+    # Envelope text is tool/model-derived and untrusted. The console path
+    # escapes Rich markup; the host draws raw cells, so the risk there is
+    # control bytes — strip them before the text crosses the IPC boundary
+    # (the surface send path sanitizes again as the shared choke point).
+    from opensquilla.cli.tui.backend.render_summary import (  # noqa: PLC0415
+        sanitize_terminal_text,
+    )
+
+    summary = sanitize_terminal_text(envelope.summary)
+    message = sanitize_terminal_text(envelope.message)
+    payload: dict[str, object] = {
         "id": envelope.approval_id,
         "tool": envelope.tool,
-        "summary": envelope.summary,
+        "summary": summary,
         "choices": [choice.id for choice in envelope.choices],
     }
+    # The console prompt prints the envelope's rationale line; the overlay must
+    # carry it too. Message-only envelopes already surface it as the summary,
+    # so only send a message that adds information — compared after
+    # sanitization, the same form the host will render.
+    if message and message != summary:
+        payload["message"] = message
+    return payload
 
 
 async def _handle_via_host(

--- a/src/opensquilla/cli/tui/adapters/commands.py
+++ b/src/opensquilla/cli/tui/adapters/commands.py
@@ -113,3 +113,111 @@ def render_help_table(surface: Surface | str = DEFAULT_SURFACE) -> Table:
             cell += f"  (alias: {', '.join(command.aliases)})"
         table.add_row(escape(cell), command.description)
     return table
+
+
+@dataclass(frozen=True)
+class KeyBinding:
+    """One ``/keys`` cheatsheet row plus the host-source literals that prove it.
+
+    ``js_literals`` are exact substrings of the keyboard-handler source in
+    ``package/src/<js_file>``. The cheatsheet is a hand-maintained mirror of
+    those imperative handlers, so each row pins the condition it documents;
+    ``tests/unit/cli/tui/test_keys_cheatsheet.py`` fails when a binding is
+    removed or renamed without updating this table (the same pattern that pins
+    ``THEME_NAMES`` to ``theme.mjs``).
+    """
+
+    keys: str
+    action: str
+    js_literals: tuple[str, ...] = ()
+    js_file: str = "composer.mjs"
+
+
+OPENTUI_KEY_BINDINGS: tuple[KeyBinding, ...] = (
+    KeyBinding(
+        "Enter",
+        "Send the message — while a turn runs, steer it",
+        ('key.name === "return"',),
+    ),
+    KeyBinding(
+        "Shift+Enter / Alt+Enter",
+        "Insert a newline",
+        ("key.shift || key.option || key.meta || key.alt",),
+    ),
+    KeyBinding(
+        "Tab",
+        "Queue the draft for the next turn (while one runs)",
+        ('key.name === "tab" && turnActive',),
+    ),
+    KeyBinding("Esc", "Cancel the running turn", ('key.name === "escape"',)),
+    KeyBinding(
+        "Ctrl+C",
+        "Clear the input — when empty, cancel the turn",
+        ('key.ctrl && key.name === "c"',),
+    ),
+    KeyBinding("Ctrl+D", "Exit chat", ('key.ctrl && key.name === "d"',)),
+    KeyBinding(
+        "Ctrl+O",
+        "Expand or collapse thinking and tool details",
+        ('key?.name !== "o"',),
+        js_file="main.mjs",
+    ),
+    KeyBinding(
+        "PageUp / PageDown",
+        "Scroll the transcript",
+        ('key.name === "pageup"', 'key.name === "pagedown"'),
+    ),
+    KeyBinding(
+        "Ctrl+G / Ctrl+End",
+        "Jump back to the latest output",
+        ('key.ctrl && key.name === "g"', 'key.ctrl && key.name === "end"'),
+    ),
+    KeyBinding("Ctrl+L", "Redraw the screen", ('key.ctrl && key.name === "l"',)),
+    KeyBinding(
+        "Ctrl+A / Ctrl+E · Home / End",
+        "Go to the start / end of the line",
+        ('key.ctrl && key.name === "a"', 'key.ctrl && key.name === "e"'),
+    ),
+    KeyBinding(
+        "Ctrl+U / Ctrl+K",
+        "Cut to the line start / end",
+        ('key.name === "u" || key.name === "k" || key.name === "w"',),
+    ),
+    KeyBinding(
+        "Ctrl+W / Alt+Backspace · Alt+D",
+        "Cut the previous / next word",
+        (
+            '(key.meta || key.alt || key.option) && key.name === "backspace"',
+            '(key.meta || key.alt || key.option) && key.name === "d"',
+        ),
+    ),
+    KeyBinding("Ctrl+Y", "Paste the last cut text", ('key.ctrl && key.name === "y"',)),
+    KeyBinding(
+        "Alt+B / Alt+F · Ctrl+←/→",
+        "Move back / forward one word",
+        ('key.ctrl && key.name === "left"', 'key.ctrl && key.name === "right"'),
+    ),
+    KeyBinding("@ · /", "Complete a file path · a command (at line start)"),
+)
+
+# The plain (native) backend keeps the standard terminal line editor; only the
+# bindings its runtime actually handles are documented, mirroring the launch
+# banner wording.
+NATIVE_KEY_BINDINGS: tuple[KeyBinding, ...] = (
+    KeyBinding("Enter", "Send the message"),
+    KeyBinding("Ctrl+C", "Clear the input, or cancel the running turn"),
+    KeyBinding("Ctrl+D", "Exit chat"),
+)
+
+
+def render_keys_table(*, opentui: bool = True) -> Table:
+    table = Table(title="Keyboard Shortcuts", show_header=True, header_style=ACCENT_HEADER)
+    table.add_column("Keys", style="bold")
+    table.add_column("Action")
+    for binding in OPENTUI_KEY_BINDINGS if opentui else NATIVE_KEY_BINDINGS:
+        table.add_row(escape(binding.keys), binding.action)
+    if not opentui:
+        table.caption = (
+            "Plain-mode keys. The full-screen TUI adds editing, scroll, and detail shortcuts."
+        )
+    return table

--- a/src/opensquilla/cli/tui/adapters/launch_bridge.py
+++ b/src/opensquilla/cli/tui/adapters/launch_bridge.py
@@ -26,6 +26,14 @@ ChatRunner = Callable[..., Coroutine[Any, Any, None]]
 # Backend id whose host renders its own full-screen UI, so the native launch
 # banner is suppressed to avoid a pre-launch flash. Mirrors OpenTuiRendererBackend.
 _OPENTUI_BACKEND_ID = "opentui"
+# Short human phrases for the once-per-(version, reason) fallback notice.
+# Keys are the stable RendererBackendUnavailableReason values; anything
+# unmapped prints its code, which is stable and doctor-searchable.
+_FALLBACK_NOTICE_PHRASES = {
+    "missing": "no OpenTUI companion in this install",
+    "version_mismatch": "OpenTUI companion version mismatch",
+    "terminal_unsupported": "this terminal is not supported",
+}
 _INTERACTIVE_STRUCTLOG_FILE: Any | None = None
 _INTERACTIVE_STDLIB_LOG_HANDLER: Any | None = None
 _INTERACTIVE_LOG_HANDLER_ATTR = "_opensquilla_interactive_log_handler"
@@ -95,9 +103,25 @@ def _print_tui_fallback_after_clear(
                 )
                 output_console.print("[dim]Continuing in plain mode for this launch.[/dim]")
                 return
-        # Installed packages and unsupported hosts stay quiet: this branch does
-        # not publish a companion, so only a verified source checkout gets an
-        # actionable development hint.
+        # Installed packages and unsupported hosts get one dim line per
+        # (product version, unavailability reason): the downgrade is explained
+        # without becoming a per-launch nag, and `opensquilla doctor` carries
+        # the actionable detail. Prefs IO is best effort — if the record cannot
+        # be written the notice repeats, which degrades loud rather than silent.
+        from opensquilla import __version__  # noqa: PLC0415
+        from opensquilla.cli.tui.opentui.prefs import (  # noqa: PLC0415
+            fallback_notice_due,
+            record_fallback_notice,
+        )
+
+        code = fallback.code.value
+        if fallback_notice_due(__version__, code):
+            phrase = _FALLBACK_NOTICE_PHRASES.get(code, code)
+            output_console.print(
+                f"[dim]Full-screen TUI unavailable ({phrase}); using plain mode. "
+                "Run 'opensquilla doctor' for details.[/dim]"
+            )
+            record_fallback_notice(__version__, code)
         return
 
     output_console.print(

--- a/src/opensquilla/cli/tui/adapters/slash_common.py
+++ b/src/opensquilla/cli/tui/adapters/slash_common.py
@@ -48,6 +48,21 @@ async def dispatch_theme_command(cmd: str, tui_output: TuiOutputHandle | None) -
     await handle_theme_command(cmd, tui_output)
 
 
+def output_supports_host_ui(tui_output: object | None) -> bool:
+    """True when the active chat surface is the OpenTUI host (IPC-capable).
+
+    Mirrors the capability probe in ``handle_theme_command``: the plugin
+    wrapper always exposes a callable ``send_message`` that silently no-ops on
+    the native backend, so prefer its explicit ``supports_send_message`` flag
+    and fall back to ``callable()`` only for an unwrapped handle.
+    """
+    send_message = getattr(tui_output, "send_message", None)
+    supports = getattr(tui_output, "supports_send_message", None)
+    if supports is None:
+        supports = callable(send_message)
+    return bool(supports) and callable(send_message)
+
+
 def record_turn(state: ChatSessionState, prompt: str, result: TurnResult) -> None:
     """Record a completed slash-driven turn on the in-memory session state."""
     state.transcript.add("user", prompt)
@@ -139,6 +154,7 @@ __all__ = [
     "compact_token_stats",
     "default_transcript_path",
     "dispatch_theme_command",
+    "output_supports_host_ui",
     "record_turn",
     "registry_handler_words",
     "resolve_transcript_target",

--- a/src/opensquilla/cli/tui/adapters/slash_gateway.py
+++ b/src/opensquilla/cli/tui/adapters/slash_gateway.py
@@ -20,13 +20,14 @@ import opensquilla.cli.tui.adapters.input_bridge as _input_bridge
 from opensquilla.cli.chat.session_state import ChatSessionState, messages_to_markdown
 from opensquilla.cli.chat.turn import TurnResult
 from opensquilla.cli.gateway_client import GatewayRPCError, session_history_all
-from opensquilla.cli.tui.adapters.commands import render_help_table
+from opensquilla.cli.tui.adapters.commands import render_help_table, render_keys_table
 from opensquilla.cli.tui.adapters.slash_common import (
     compact_skipped_line,
     compact_success_line,
     compact_summary_stats,
     compact_token_stats,
     dispatch_theme_command,
+    output_supports_host_ui,
     record_turn,
     registry_handler_words,
     resolve_transcript_target,
@@ -352,6 +353,10 @@ async def _dispatch_gateway_slash_command(
 
     if cmd == "/help":
         console.print(render_help_table(Surface.CLI_GATEWAY))
+        return True
+
+    if cmd in {"/keys", "/shortcuts"}:
+        console.print(render_keys_table(opentui=output_supports_host_ui(tui_output)))
         return True
 
     if _slash_parts(cmd, "/theme"):

--- a/src/opensquilla/cli/tui/adapters/slash_standalone.py
+++ b/src/opensquilla/cli/tui/adapters/slash_standalone.py
@@ -16,13 +16,14 @@ from uuid import uuid4
 import opensquilla.cli.tui.adapters.input_bridge as _input_bridge
 from opensquilla.cli.chat.session_state import ChatSessionState
 from opensquilla.cli.chat.turn import TurnResult
-from opensquilla.cli.tui.adapters.commands import render_help_table
+from opensquilla.cli.tui.adapters.commands import render_help_table, render_keys_table
 from opensquilla.cli.tui.adapters.slash_common import (
     compact_skipped_line,
     compact_success_line,
     compact_summary_stats,
     compact_token_stats,
     dispatch_theme_command,
+    output_supports_host_ui,
     record_turn,
     registry_handler_words,
     resolve_transcript_target,
@@ -530,6 +531,10 @@ async def handle_standalone_slash_command(
 
     if cmd == "/help":
         console.print(render_help_table(Surface.CLI_STANDALONE))
+        return True
+
+    if cmd in {"/keys", "/shortcuts"}:
+        console.print(render_keys_table(opentui=output_supports_host_ui(context.tui_output)))
         return True
 
     if _slash_parts(cmd, "/theme"):

--- a/src/opensquilla/cli/tui/opentui/bridge.py
+++ b/src/opensquilla/cli/tui/opentui/bridge.py
@@ -34,7 +34,9 @@ from opensquilla.cli.tui.opentui.messages import (
     host_message_from_json,
     python_message_to_json,
 )
+from opensquilla.cli.tui.opentui.prefs import load_theme_preference
 from opensquilla.cli.tui.opentui.terminal import create_terminal_guardian
+from opensquilla.cli.tui.opentui.themes import THEME_ENV_VAR
 from opensquilla.cli.tui.opentui.transport import HostConnection
 from opensquilla.cli.tui.renderers.selection import (
     RendererBackendAvailability,
@@ -110,6 +112,21 @@ def _host_handshake_mismatches(
             "required interactive capabilities missing=" + ",".join(missing_capabilities)
         )
     return mismatches
+
+
+def apply_theme_preference_env(env: dict[str, str]) -> None:
+    """Fill ``OPENSQUILLA_TUI_THEME`` from the persisted /theme choice.
+
+    A NON-EMPTY explicit environment value wins, preserving the documented
+    OPENSQUILLA_TUI_THEME contract. An empty exported value counts as unset —
+    the host maps it to the default theme anyway, so letting it mask the
+    preference would only make /theme appear to save and then never apply.
+    """
+    if env.get(THEME_ENV_VAR):
+        return
+    saved_theme = load_theme_preference()
+    if saved_theme:
+        env[THEME_ENV_VAR] = saved_theme
 
 
 def check_opentui_host_available(
@@ -204,6 +221,7 @@ class OpenTuiBridge:
 
         env = os.environ.copy()
         env.update(self.env)
+        apply_theme_preference_env(env)
         env.update(connection.environment)
         env["OPENSQUILLA_PRODUCT_VERSION"] = __version__
         env["OPENSQUILLA_OPENTUI_HOST_VERSION"] = artifact.host_version

--- a/src/opensquilla/cli/tui/opentui/messages.py
+++ b/src/opensquilla/cli/tui/opentui/messages.py
@@ -318,6 +318,18 @@ class HostApprovalResponse:
     choice: str | None = None
 
 
+@dataclass(frozen=True)
+class HostThemeSelected:
+    """Theme kept in the host's interactive picker.
+
+    The ``/theme <name>`` command path persists CLI-side because Python knows
+    the name it sent; a picker confirmation happens entirely in the host, so
+    it reports the kept name for the same persistence.
+    """
+
+    name: str
+
+
 type HostToPythonMessage = (
     HostReady
     | HostInputSubmit
@@ -328,6 +340,7 @@ type HostToPythonMessage = (
     | HostError
     | HostProtocolUnknown
     | HostApprovalResponse
+    | HostThemeSelected
 )
 
 
@@ -381,6 +394,7 @@ HOST_TO_PYTHON_TYPES: dict[str, type] = {
     "error": HostError,
     "protocol.unknown": HostProtocolUnknown,
     "approval.response": HostApprovalResponse,
+    "theme.selected": HostThemeSelected,
 }
 
 
@@ -459,6 +473,8 @@ def host_message_from_json(raw: str) -> HostToPythonMessage:
             approved=_required_bool(payload, "approval.response.approved", "approved"),
             choice=_optional_str(payload, "choice"),
         )
+    if message_type == "theme.selected":
+        return HostThemeSelected(name=_required_str(payload, "theme.selected.name", "name"))
 
     raise HostToPythonMessageError(f"Unknown OpenTUI host message type: {message_type}")
 

--- a/src/opensquilla/cli/tui/opentui/package/package.json
+++ b/src/opensquilla/cli/tui/opentui/package/package.json
@@ -7,7 +7,7 @@
     "start": "bun src/main.mjs",
     "smoke": "bun src/main.mjs --help",
     "test": "node --test --test-force-exit $(find src -name '*.test.mjs' ! -name '*.bun.test.mjs')",
-    "test:bun": "bun test src/*.bun.test.mjs",
+    "test:bun": "bun test --max-concurrency=1 src/*.bun.test.mjs",
     "test:all": "npm run test && npm run test:bun"
   },
   "dependencies": {

--- a/src/opensquilla/cli/tui/opentui/package/package.json
+++ b/src/opensquilla/cli/tui/opentui/package/package.json
@@ -7,7 +7,7 @@
     "start": "bun src/main.mjs",
     "smoke": "bun src/main.mjs --help",
     "test": "node --test --test-force-exit $(find src -name '*.test.mjs' ! -name '*.bun.test.mjs')",
-    "test:bun": "bun test --max-concurrency=1 src/*.bun.test.mjs",
+    "test:bun": "node scripts/run-bun-tests.mjs",
     "test:all": "npm run test && npm run test:bun"
   },
   "dependencies": {

--- a/src/opensquilla/cli/tui/opentui/package/scripts/run-bun-tests.mjs
+++ b/src/opensquilla/cli/tui/opentui/package/scripts/run-bun-tests.mjs
@@ -3,13 +3,8 @@ import { readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const packageRoot = fileURLToPath(new URL("../", import.meta.url));
-// Bun 1.3.14 can crash on Linux when these renderer-heavy files share a
-// process with the full native OpenTUI suite. Keep the shared suite together
-// for its theme state, but give the changed overlay files fresh processes.
-const isolatedTestFiles = new Set([
-  "src/approval-overlay.bun.test.mjs",
-  "src/theme-picker.bun.test.mjs",
-]);
+// Bun 1.3.14 can crash on Linux when native OpenTUI test files share a Bun
+// process. Give each file a fresh process and keep concurrency inside it at 1.
 const testFiles = readdirSync(new URL("../src/", import.meta.url), {
   withFileTypes: true,
 })
@@ -20,32 +15,19 @@ const testFiles = readdirSync(new URL("../src/", import.meta.url), {
 if (testFiles.length === 0) {
   throw new Error("No Bun test files found");
 }
-for (const isolatedTestFile of isolatedTestFiles) {
-  if (!testFiles.includes(isolatedTestFile)) {
-    throw new Error(`Missing isolated Bun test file: ${isolatedTestFile}`);
-  }
-}
 
 const bunExecutable = process.platform === "win32" ? "bun.exe" : "bun";
-const sharedTestFiles = testFiles.filter((testFile) => !isolatedTestFiles.has(testFile));
-const testRuns = [
-  {
-    label: "shared Bun suite",
-    args: ["test", ...sharedTestFiles],
-  },
-  ...[...isolatedTestFiles].map((testFile) => ({
-    label: testFile,
-    args: ["test", "--max-concurrency=1", testFile],
-  })),
-];
-
-for (const testRun of testRuns) {
-  console.log(`\n=== ${testRun.label} ===`);
+for (const testFile of testFiles) {
+  console.log(`\n=== ${testFile} ===`);
   const result = spawnSync(
     bunExecutable,
-    testRun.args,
+    ["test", "--max-concurrency=1", testFile],
     {
       cwd: packageRoot,
+      env: {
+        ...process.env,
+        OPENSQUILLA_TUI_COLOR: "truecolor",
+      },
       stdio: "inherit",
     },
   );

--- a/src/opensquilla/cli/tui/opentui/package/scripts/run-bun-tests.mjs
+++ b/src/opensquilla/cli/tui/opentui/package/scripts/run-bun-tests.mjs
@@ -1,0 +1,58 @@
+import { spawnSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = fileURLToPath(new URL("../", import.meta.url));
+// Bun 1.3.14 can crash on Linux when these renderer-heavy files share a
+// process with the full native OpenTUI suite. Keep the shared suite together
+// for its theme state, but give the changed overlay files fresh processes.
+const isolatedTestFiles = new Set([
+  "src/approval-overlay.bun.test.mjs",
+  "src/theme-picker.bun.test.mjs",
+]);
+const testFiles = readdirSync(new URL("../src/", import.meta.url), {
+  withFileTypes: true,
+})
+  .filter((entry) => entry.isFile() && entry.name.endsWith(".bun.test.mjs"))
+  .map((entry) => `src/${entry.name}`)
+  .sort();
+
+if (testFiles.length === 0) {
+  throw new Error("No Bun test files found");
+}
+for (const isolatedTestFile of isolatedTestFiles) {
+  if (!testFiles.includes(isolatedTestFile)) {
+    throw new Error(`Missing isolated Bun test file: ${isolatedTestFile}`);
+  }
+}
+
+const bunExecutable = process.platform === "win32" ? "bun.exe" : "bun";
+const sharedTestFiles = testFiles.filter((testFile) => !isolatedTestFiles.has(testFile));
+const testRuns = [
+  {
+    label: "shared Bun suite",
+    args: ["test", ...sharedTestFiles],
+  },
+  ...[...isolatedTestFiles].map((testFile) => ({
+    label: testFile,
+    args: ["test", "--max-concurrency=1", testFile],
+  })),
+];
+
+for (const testRun of testRuns) {
+  console.log(`\n=== ${testRun.label} ===`);
+  const result = spawnSync(
+    bunExecutable,
+    testRun.args,
+    {
+      cwd: packageRoot,
+      stdio: "inherit",
+    },
+  );
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/src/opensquilla/cli/tui/opentui/package/src/approval-overlay.bun.test.mjs
+++ b/src/opensquilla/cli/tui/opentui/package/src/approval-overlay.bun.test.mjs
@@ -8,7 +8,7 @@
 // Run with: bun test src/approval-overlay.bun.test.mjs
 import { test, expect } from "bun:test";
 
-import { createComposer, approvalKeyAction } from "./composer.mjs";
+import { approvalKeyAction, approvalRowPlan, createComposer } from "./composer.mjs";
 import { THEME, applyTheme } from "./theme.mjs";
 
 // Minimal fake renderable mirroring the add/remove/getChildren contract the
@@ -334,4 +334,154 @@ test("approval.dismiss with no overlay open is a safe no-op", () => {
   const { composer, overlayLayer } = makeHarness();
   composer.dismissApprovalOverlay("appr-1");
   expect(findDeep(overlayLayer, "approval-overlay")).toBeNull();
+});
+
+test("overlay renders the rationale message the console prompt prints", () => {
+  const { composer, overlayLayer } = makeHarness();
+  composer.openApprovalOverlay(request({ message: "Sandbox denied a write outside the workspace." }));
+
+  const overlay = findDeep(overlayLayer, "approval-overlay");
+  expect(findDeep(overlay, "approval-overlay-message").options.content)
+    .toContain("Sandbox denied a write");
+});
+
+test("a long summary wraps into rows instead of clipping to one line", () => {
+  const { composer, overlayLayer } = makeHarness();
+  const command = "uv run pytest tests/unit/cli/tui --maxfail 1 --durations 10 -k approval_overlay_and_more_selectors";
+  composer.openApprovalOverlay(request({ summary: command }));
+
+  const overlay = findDeep(overlayLayer, "approval-overlay");
+  const first = findDeep(overlay, "approval-overlay-summary").options.content;
+  const second = findDeep(overlay, "approval-overlay-summary-1")?.options.content ?? "";
+  // The full command must survive across the wrapped rows — the user is
+  // authorizing exactly this text.
+  expect(`${first} ${second}`.replace(/\s+/gu, " ")).toContain("approval_overlay_and_more_selectors");
+  expect(first.endsWith("…")).toBe(false);
+});
+
+test("a pathological summary is capped with an explicit tail marker", () => {
+  const { composer, overlayLayer } = makeHarness();
+  const huge = Array.from({ length: 40 }, (_, i) => `arg-number-${i}-padding-padding`).join(" ");
+  composer.openApprovalOverlay(request({ summary: huge }));
+
+  const overlay = findDeep(overlayLayer, "approval-overlay");
+  // Capped at six rows: row index 5 exists, row index 6 must not.
+  const last = findDeep(overlay, "approval-overlay-summary-5");
+  expect(last).not.toBeNull();
+  expect(findDeep(overlay, "approval-overlay-summary-6")).toBeNull();
+  expect(last.options.content).toContain("…");
+  // Choices and the key hint stay visible below the capped summary.
+  expect(findDeep(overlay, "approval-overlay-hint")).not.toBeNull();
+});
+
+test("a short terminal keeps the choices AND at least one summary row", () => {
+  // At height 14 (footer 6) the row budget is 7: borders + tool + 3 choices
+  // leave exactly one flexible row. That row must go to the summary — the
+  // user is authorizing that text — while the key hint (redundant with the
+  // y/n/esc keys themselves) is what gets dropped.
+  const { composer, overlayLayer } = makeHarness({ terminalHeight: 14 });
+  const huge = Array.from({ length: 40 }, (_, i) => `arg-number-${i}-padding-padding`).join(" ");
+  composer.openApprovalOverlay(request({
+    summary: huge,
+    message: "This tool call was gated by the standard policy tier.",
+    choices: CHOICES,
+  }));
+
+  const overlay = findDeep(overlayLayer, "approval-overlay");
+  CHOICES.forEach((_, index) => {
+    expect(findDeep(overlay, `approval-overlay-choice-${index}`)).not.toBeNull();
+  });
+  const summary = findDeep(overlay, "approval-overlay-summary");
+  expect(summary).not.toBeNull();
+  expect(summary.options.content).toContain("arg-number-0");
+  expect(summary.options.content).toContain("…"); // truncation is explicit
+  expect(findDeep(overlay, "approval-overlay-summary-1")).toBeNull(); // capped to the one row
+  expect(findDeep(overlay, "approval-overlay-hint")).toBeNull(); // hint is what gives way
+});
+
+test("one more row restores the hint before growing the summary", () => {
+  const { composer, overlayLayer } = makeHarness({ terminalHeight: 15 });
+  const huge = Array.from({ length: 40 }, (_, i) => `arg-number-${i}-padding-padding`).join(" ");
+  composer.openApprovalOverlay(request({ summary: huge, choices: CHOICES }));
+
+  const overlay = findDeep(overlayLayer, "approval-overlay");
+  expect(findDeep(overlay, "approval-overlay-summary")).not.toBeNull();
+  expect(findDeep(overlay, "approval-overlay-hint")).not.toBeNull();
+  expect(findDeep(overlay, "approval-overlay-summary-1")).toBeNull();
+});
+
+test("approvalRowPlan never zeroes the summary while rows remain", () => {
+  // Sweep realistic geometries: for every budget that can hold the immovable
+  // rows plus one more, the plan must include at least one summary row.
+  for (let maxRows = 4; maxRows <= 30; maxRows += 1) {
+    for (const choices of [0, 2, 3]) {
+      const plan = approvalRowPlan(maxRows, choices, 99, 99);
+      const immovable = 2 + 1 + choices;
+      if (maxRows > immovable) {
+        expect(plan.summaryRows).toBeGreaterThanOrEqual(1);
+      }
+      // The plan must always fit the budget it was given.
+      const used = immovable + plan.summaryRows + plan.messageRows + (plan.hint ? 1 : 0);
+      expect(used).toBeLessThanOrEqual(Math.max(maxRows, immovable));
+    }
+  }
+});
+
+test("a short summary rebates its unused reservation to the message", () => {
+  // maxRows 13 with 3 choices leaves a budget of 7. A one-row summary must
+  // not reserve the worst-case six rows and starve the rationale message.
+  const plan = approvalRowPlan(13, 3, 1, 3);
+  expect(plan.summaryRows).toBe(1);
+  expect(plan.hint).toBe(true);
+  expect(plan.messageRows).toBe(3);
+});
+
+test("the rationale message renders alongside a short summary on a 20-row terminal", () => {
+  const { composer, overlayLayer } = makeHarness({ terminalHeight: 20 });
+  composer.openApprovalOverlay(request({
+    summary: "touch demo.txt",
+    message: "This tool call was gated by the standard policy tier.",
+    choices: CHOICES,
+  }));
+
+  const overlay = findDeep(overlayLayer, "approval-overlay");
+  expect(findDeep(overlay, "approval-overlay-summary")).not.toBeNull();
+  expect(findDeep(overlay, "approval-overlay-message").options.content)
+    .toContain("standard policy tier");
+  expect(findDeep(overlay, "approval-overlay-hint")).not.toBeNull();
+});
+
+test("choice ids are stripped of control bytes for display only", () => {
+  const { composer, press, overlayLayer, sent } = makeHarness();
+  const hostile = "\u001b]0;pwn\u0007allow_once";
+  composer.openApprovalOverlay(request({ choices: [hostile, "deny"] }));
+
+  const overlay = findDeep(overlayLayer, "approval-overlay");
+  const label = findDeep(overlay, "approval-overlay-choice-0").options.content;
+  expect(label).not.toContain("\u001b");
+  expect(label).not.toContain("\u0007");
+  expect(label).toContain("allow once");
+
+  // The RAW id still round-trips in the response — display stripping must
+  // never desynchronize the decision protocol.
+  press({ name: "return" });
+  const response = sent.find((m) => m.type === "approval.response");
+  expect(response.choice).toBe(hostile);
+});
+
+test("a terminal too small for any summary row signposts the hidden text", () => {
+  // Height 13 (footer 6) leaves maxRows 6 = exactly the immovable rows for a
+  // 3-choice envelope: zero summary rows fit, so the title must say so.
+  const { composer, overlayLayer } = makeHarness({ terminalHeight: 13 });
+  composer.openApprovalOverlay(request({
+    summary: "rm -rf /tmp/demo",
+    choices: CHOICES,
+  }));
+
+  const overlay = findDeep(overlayLayer, "approval-overlay");
+  expect(findDeep(overlay, "approval-overlay-summary")).toBeNull();
+  expect(overlay.options.title).toContain("summary hidden");
+  CHOICES.forEach((_, index) => {
+    expect(findDeep(overlay, `approval-overlay-choice-${index}`)).not.toBeNull();
+  });
 });

--- a/src/opensquilla/cli/tui/opentui/package/src/composer.mjs
+++ b/src/opensquilla/cli/tui/opentui/package/src/composer.mjs
@@ -1,5 +1,5 @@
 import { THEME, THEME_NAMES, applyTheme, activeThemeName } from "./theme.mjs";
-import { cellWidth, clampFooterHeight, clipToCells, stripTerminalControls, textWidth } from "./primitives.mjs";
+import { cellWidth, clampFooterHeight, clipToCells, stripTerminalControls, textWidth, wrapToCells } from "./primitives.mjs";
 import {
   compactContextItems,
   emptyContextState,
@@ -44,6 +44,34 @@ export function routingPickerKeyAction(picker, keyName) {
   if (keyName === "return" || keyName === "tab") return { handled: true, action: "confirm", selected: sel };
   if (keyName === "escape") return { handled: true, action: "cancel", selected: sel };
   return { handled: true, action: "none", selected: sel };
+}
+
+// A long command or rationale wraps instead of clipping — the user is being
+// asked to authorize exactly this text, so hiding it is a trust problem. But
+// a modal must stay a modal: each section is capped so a multi-kilobyte
+// summary cannot grow without bound.
+export const APPROVAL_SUMMARY_MAX_ROWS = 6;
+export const APPROVAL_MESSAGE_MAX_ROWS = 4;
+
+// Row allocation for the approval overlay, in priority order: the tool line
+// and every choice are immovable; then ONE summary row — the user is
+// authorizing exactly that text, so it must never be fully invisible while
+// any flexible row remains; then the key hint (y/n/esc still work without
+// it); then the rest of the summary; then the rationale message. Needs are
+// the ACTUAL wrapped row counts, so a one-line summary never reserves rows
+// the message could have used.
+export function approvalRowPlan(maxRows, choicesCount, summaryNeed, messageNeed) {
+  let budget = Math.max(0, maxRows - 2 - 1 - choicesCount);
+  const summaryTarget = Math.min(Math.max(0, summaryNeed), APPROVAL_SUMMARY_MAX_ROWS);
+  const messageTarget = Math.min(Math.max(0, messageNeed), APPROVAL_MESSAGE_MAX_ROWS);
+  const summaryMin = summaryTarget > 0 && budget > 0 ? 1 : 0;
+  budget -= summaryMin;
+  const hint = budget > 0;
+  if (hint) budget -= 1;
+  const summaryExtra = Math.max(0, Math.min(summaryTarget - summaryMin, budget));
+  budget -= summaryExtra;
+  const messageRows = Math.max(0, Math.min(messageTarget, budget));
+  return { summaryRows: summaryMin + summaryExtra, messageRows, hint };
 }
 
 // Pure key handling for the tool-approval overlay. Modal like the theme picker
@@ -1024,7 +1052,12 @@ export function createComposer(deps) {
       themePicker.selected = result.selected;
       applyHostTheme(themePicker.names[result.selected]);
     } else if (result.action === "confirm") {
+      const confirmed = themePicker.names[themePicker.selected];
       closeThemePicker();
+      // Report the kept theme so the Python side can persist it — the /theme
+      // command path knows the name it sent, but a picker choice is made
+      // entirely in the host.
+      sendHostMessage({ type: "theme.selected", name: confirmed });
       renderer.requestRender?.();
     } else if (result.action === "cancel") {
       const original = themePicker.original;
@@ -1467,11 +1500,27 @@ export function createComposer(deps) {
   // The decision is sent back as one approval.response frame; the Python side
   // treats silence (timeout, teardown) as a deny, so the overlay never has to
   // guarantee delivery.
-  const APPROVAL_OVERLAY_WIDTH = 48;
+  const APPROVAL_OVERLAY_WIDTH = 72;
   let approvalOverlay = null;
 
   function approvalChoiceLabel(choice) {
-    return String(choice ?? "").replaceAll("_", " ");
+    // Ids are tool/model-derived and skip the Python display sanitizer (the
+    // raw id must round-trip in approval.response), so strip control bytes
+    // at the one place the id becomes visible text.
+    return stripTerminalControls(String(choice ?? "")).replaceAll("_", " ");
+  }
+
+  function approvalWrappedRows(text, cells) {
+    return String(text ?? "")
+      .split("\n")
+      .flatMap((line) => wrapToCells(line, cells));
+  }
+
+  function approvalTruncatedRows(rows, cells, maxRows) {
+    if (rows.length <= maxRows) return rows;
+    const kept = rows.slice(0, maxRows);
+    kept[maxRows - 1] = clipToCells(`${kept[maxRows - 1]} … +${rows.length - maxRows} rows`, cells);
+    return kept;
   }
 
   function renderApprovalOverlay() {
@@ -1480,7 +1529,29 @@ export function createComposer(deps) {
     const choices = approvalOverlay.choices;
     const geometry = overlayPanelGeometry(APPROVAL_OVERLAY_WIDTH);
     const maxRows = Math.max(1, viewportHeight() - effFooterHeight() - 1);
-    const bodyRows = 2 + choices.length + (approvalOverlay.summary ? 1 : 0);
+    const wrappedSummary = approvalOverlay.summary
+      ? approvalWrappedRows(approvalOverlay.summary, geometry.inner)
+      : [];
+    const wrappedMessage = approvalOverlay.message
+      ? approvalWrappedRows(approvalOverlay.message, geometry.inner)
+      : [];
+    const plan = approvalRowPlan(
+      maxRows,
+      choices.length,
+      wrappedSummary.length,
+      wrappedMessage.length,
+    );
+    const summaryRows = plan.summaryRows > 0
+      ? approvalTruncatedRows(wrappedSummary, geometry.inner, plan.summaryRows)
+      : [];
+    const messageRows = plan.messageRows > 0
+      ? approvalTruncatedRows(wrappedMessage, geometry.inner, plan.messageRows)
+      : [];
+    // On a terminal so small that not even one summary row fits, approving
+    // unseen text must at least be signposted.
+    const summaryHidden = wrappedSummary.length > 0 && summaryRows.length === 0;
+    const bodyRows =
+      1 + choices.length + summaryRows.length + messageRows.length + (plan.hint ? 1 : 0);
     const node = new BoxRenderable(renderer, {
       id: "approval-overlay",
       position: "absolute",
@@ -1491,7 +1562,7 @@ export function createComposer(deps) {
       borderStyle: "rounded",
       borderColor: THEME.warning,
       backgroundColor: THEME.overlayBg,
-      title: " approval ",
+      title: summaryHidden ? " approval · summary hidden " : " approval ",
       titleAlignment: "left",
       flexDirection: "column",
       paddingLeft: 1,
@@ -1502,13 +1573,22 @@ export function createComposer(deps) {
       content: clipToCells(approvalOverlay.tool, geometry.inner),
       fg: THEME.text,
     }));
-    if (approvalOverlay.summary) {
+    summaryRows.forEach((row, index) => {
       node.add(new TextRenderable(renderer, {
-        id: "approval-overlay-summary",
-        content: clipToCells(approvalOverlay.summary, geometry.inner),
+        id: index === 0 ? "approval-overlay-summary" : `approval-overlay-summary-${index}`,
+        content: row,
         fg: THEME.muted,
       }));
-    }
+    });
+    // The Python side's rationale line (why this needs approval) — the same
+    // text the plain-console prompt prints; the overlay must never show less.
+    messageRows.forEach((row, index) => {
+      node.add(new TextRenderable(renderer, {
+        id: index === 0 ? "approval-overlay-message" : `approval-overlay-message-${index}`,
+        content: row,
+        fg: THEME.detailText,
+      }));
+    });
     choices.forEach((choice, index) => {
       const active = index === approvalOverlay.selected;
       node.add(new TextRenderable(renderer, {
@@ -1520,16 +1600,18 @@ export function createComposer(deps) {
         fg: active ? THEME.brandAccentSoft : THEME.muted,
       }));
     });
-    node.add(new TextRenderable(renderer, {
-      id: "approval-overlay-hint",
-      content: clipToCells(
-        choices.length > 0
-          ? "↑↓ choose · enter confirm · y/n · esc deny"
-          : "y/enter approve · n/esc deny",
-        geometry.inner,
-      ),
-      fg: THEME.detailText,
-    }));
+    if (plan.hint) {
+      node.add(new TextRenderable(renderer, {
+        id: "approval-overlay-hint",
+        content: clipToCells(
+          choices.length > 0
+            ? "↑↓ choose · enter confirm · y/n · esc deny"
+            : "y/enter approve · n/esc deny",
+          geometry.inner,
+        ),
+        fg: THEME.detailText,
+      }));
+    }
     overlayLayer.add(node);
     overlayLayer.visible = true;
   }
@@ -1549,6 +1631,7 @@ export function createComposer(deps) {
       id,
       tool: String(message?.tool ?? "tool"),
       summary: String(message?.summary ?? ""),
+      message: String(message?.message ?? ""),
       choices: Array.isArray(message?.choices) ? message.choices.map(String) : [],
       selected: 0,
     };

--- a/src/opensquilla/cli/tui/opentui/package/src/light-theme-markdown.bun.test.mjs
+++ b/src/opensquilla/cli/tui/opentui/package/src/light-theme-markdown.bun.test.mjs
@@ -6,14 +6,18 @@
 //   a theme-tracked color, and onThemeApplied must refresh it on a live switch.
 //
 // Run with: bun test src/light-theme-markdown.bun.test.mjs
-import { test, expect } from "bun:test";
+import { beforeEach, test, expect } from "bun:test";
 import { createTestRenderer } from "@opentui/core/testing";
 import { SyntaxStyle } from "@opentui/core";
 
 import { registerThemeStyles } from "./syntaxTheme.mjs";
-import { applyTheme, THEME, onThemeApplied } from "./theme.mjs";
+import { applyTheme, THEME, onThemeApplied, setColorMode } from "./theme.mjs";
 
 const lum = (c) => 0.299 * c.r + 0.587 * c.g + 0.114 * c.b; // scale-free for comparisons
+
+beforeEach(() => {
+  setColorMode("truecolor");
+});
 
 test("a bare SyntaxStyle has no 'default' style — reproduces the faint-text bug", async () => {
   await createTestRenderer({ width: 10, height: 4 }); // initialize the native render lib

--- a/src/opensquilla/cli/tui/opentui/package/src/theme-picker.bun.test.mjs
+++ b/src/opensquilla/cli/tui/opentui/package/src/theme-picker.bun.test.mjs
@@ -161,3 +161,48 @@ test("paste while the picker is open never reaches the composer draft", async ()
   expect(sent.find((m) => m.type === "input.submit")?.text).toBe("X");
   renderer.destroy?.();
 });
+
+test("confirming a picker choice reports theme.selected for CLI-side persistence", async () => {
+  applyTheme("opensquilla-dark", { explicit: true });
+  const sent = [];
+  const { renderer } = await createTestRenderer({ width: 50, height: 20 });
+  const conversationBox = new BoxRenderable(renderer, {
+    id: "conversation", position: "absolute", left: 0, top: 0, right: 0, height: 14,
+  });
+  renderer.root.add(conversationBox);
+  const inputBox = new BoxRenderable(renderer, {
+    id: "input-region", position: "absolute", left: 0, right: 0, bottom: 0, height: 6,
+  });
+  renderer.root.add(inputBox);
+  const overlayLayer = new BoxRenderable(renderer, {
+    id: "overlay-layer", position: "absolute", left: 0, top: 0, right: 0, bottom: 0,
+    zIndex: 1000, shouldFill: false, visible: false,
+  });
+  renderer.root.add(overlayLayer);
+  const composer = createComposer({
+    renderer, BoxRenderable, TextRenderable, conversationBox, inputBox, overlayLayer,
+    footerHeight: 6, sendHostMessage: (m) => sent.push(m),
+  });
+  try {
+    composer.install();
+  } catch {
+    composer.rerender();
+  }
+
+  composer.openThemePicker();
+  renderer.keyInput.emit("keypress", { name: "down" }); // preview the next theme
+  renderer.keyInput.emit("keypress", { name: "return" }); // keep it
+
+  const reported = sent.filter((m) => m.type === "theme.selected");
+  expect(reported.length).toBe(1);
+  // The picker opened on the active theme (index 0) and moved down once, so
+  // the exact next palette must be what gets reported for persistence.
+  expect(reported[0].name).toBe(THEME_NAMES[1]);
+
+  // Escape reverts the live preview — a cancelled picker must persist nothing.
+  composer.openThemePicker();
+  renderer.keyInput.emit("keypress", { name: "down" });
+  renderer.keyInput.emit("keypress", { name: "escape" });
+  expect(sent.filter((m) => m.type === "theme.selected").length).toBe(1);
+  renderer.destroy?.();
+});

--- a/src/opensquilla/cli/tui/opentui/prefs.py
+++ b/src/opensquilla/cli/tui/opentui/prefs.py
@@ -1,0 +1,228 @@
+"""Per-machine preferences for the OpenTUI-backed terminal surface.
+
+One small schema-versioned JSON file (``<state>/tui/prefs.json``) holds state
+that must survive restarts but is deliberately NOT gateway config: it
+describes this terminal, not the agent, and gateway config may live on
+another machine entirely. It carries the persisted ``/theme`` choice and the
+shown-once bookkeeping for the plain-mode fallback notice — the launch
+adapter records that notice here because the notice is itself about OpenTUI
+availability on this machine.
+
+Failure posture mirrors ``opensquilla.onboarding.probe_history``: absence or
+corruption degrades to defaults, writes are atomic and best effort (logged,
+swallowed) — a read-only state dir must never break or delay chat launch. Two
+extra guards protect the read-modify-write cycle: an advisory lock serializes
+concurrent chat processes, and a file that exists but cannot be READ blocks
+the write entirely, so a transient EACCES/EIO can never clobber a good file
+with a truncated one. The acceptable failure mode is a repeated notice or an
+unsaved preference, never a crash and never lost sibling keys.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
+from pathlib import Path
+from typing import IO, Any, cast
+
+import structlog
+
+from opensquilla import paths
+
+log = structlog.get_logger(__name__)
+
+_PREFS_FILENAME = "prefs.json"
+_SCHEMA_VERSION = 1
+# Bounded history for the fallback notice: enough that alternating between a
+# few (version, reason) pairs never re-nags, small enough to stay one screen.
+_MAX_FALLBACK_NOTICES = 8
+
+
+def _prefs_path() -> Path:
+    return paths.state_dir() / "tui" / _PREFS_FILENAME
+
+
+# Non-blocking lock probes: enough to ride out a sibling's microsecond-scale
+# read-modify-write, bounded so a wedged holder costs ~100ms, never a hang.
+_LOCK_ATTEMPTS = 5
+_LOCK_RETRY_SECONDS = 0.02
+
+
+def _try_lock_once(handle: IO[bytes]) -> bool:
+    if os.name == "nt":  # pragma: no cover - exercised on Windows only
+        import msvcrt  # noqa: PLC0415
+
+        msvcrt_mod = cast(Any, msvcrt)
+        handle.seek(0)
+        msvcrt_mod.locking(handle.fileno(), msvcrt_mod.LK_NBLCK, 1)
+        return True
+    import fcntl  # noqa: PLC0415
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    return True
+
+
+@contextmanager
+def _advisory_lock() -> Iterator[None]:
+    """Best-effort cross-process lock for the read-modify-write cycle.
+
+    Uses a sidecar lock file with the same OS primitives as
+    ``opensquilla.onboarding.config_store``, but strictly NON-BLOCKING: a held
+    or unobtainable lock degrades to unlocked best-effort behavior after a few
+    bounded probes. A wedged sibling process must never be able to stall chat
+    launch or the /theme path behind this file.
+    """
+    handle: IO[bytes] | None = None
+    locked = False
+    lock_path = _prefs_path().with_suffix(".lock")
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(lock_path, "a+b")  # noqa: SIM115 - explicit unlock ordering
+        for attempt in range(_LOCK_ATTEMPTS):
+            try:
+                locked = _try_lock_once(handle)
+                break
+            except OSError:
+                if attempt + 1 < _LOCK_ATTEMPTS:
+                    time.sleep(_LOCK_RETRY_SECONDS)
+    except OSError:
+        pass
+    try:
+        yield
+    finally:
+        if handle is not None:
+            if locked:
+                with suppress(OSError):
+                    if os.name == "nt":  # pragma: no cover - Windows only
+                        import msvcrt  # noqa: PLC0415
+
+                        msvcrt_mod = cast(Any, msvcrt)
+                        handle.seek(0)
+                        msvcrt_mod.locking(handle.fileno(), msvcrt_mod.LK_UNLCK, 1)
+                    else:
+                        import fcntl  # noqa: PLC0415
+
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            with suppress(OSError):
+                handle.close()
+
+
+def _read() -> tuple[dict[str, Any], bool]:
+    """Return ``(prefs, writable)``.
+
+    ``writable`` is False only when the file exists but could not be read
+    (EACCES/EIO): the on-disk data may still be good, so overwriting from the
+    empty fallback would destroy it. A missing file or a corrupt one (nothing
+    recoverable) keeps writes enabled.
+    """
+    path = _prefs_path()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}, True
+    except OSError as exc:
+        log.warning("tui.prefs.read_failed", error=str(exc))
+        return {}, False
+    except ValueError:
+        return {}, True
+    if not isinstance(raw, dict):
+        return {}, True
+    raw.pop("schemaVersion", None)
+    return raw, True
+
+
+def _load() -> dict[str, Any]:
+    prefs, _writable = _read()
+    return prefs
+
+
+def _store(prefs: dict[str, Any]) -> None:
+    path = _prefs_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"schemaVersion": _SCHEMA_VERSION, **prefs}
+        fd, tmp_name = tempfile.mkstemp(prefix=_PREFS_FILENAME, dir=str(path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, ensure_ascii=False, indent=2)
+            os.replace(tmp_name, path)
+        except BaseException:
+            with suppress(OSError):
+                os.unlink(tmp_name)
+            raise
+    except OSError as exc:
+        log.warning("tui.prefs.write_failed", error=str(exc))
+
+
+def load_theme_preference() -> str | None:
+    """Return the persisted theme name, or ``None`` when unset or unknown.
+
+    Unknown names are ignored rather than surfaced: after a downgrade or a
+    theme rename, a stale preference silently falls back to the default
+    instead of failing launch over a cosmetic setting.
+    """
+    from opensquilla.cli.tui.opentui.themes import THEME_NAMES  # noqa: PLC0415
+
+    name = str(_load().get("theme") or "").strip().lower()
+    return name if name in THEME_NAMES else None
+
+
+def save_theme_preference(name: str) -> None:
+    """Persist a confirmed theme choice (best effort, validated)."""
+    from opensquilla.cli.tui.opentui.themes import THEME_NAMES  # noqa: PLC0415
+
+    cleaned = str(name or "").strip().lower()
+    if cleaned not in THEME_NAMES:
+        return
+    with _advisory_lock():
+        prefs, writable = _read()
+        if not writable or prefs.get("theme") == cleaned:
+            return
+        prefs["theme"] = cleaned
+        _store(prefs)
+
+
+def _notice_records(prefs: dict[str, Any]) -> list[dict[str, Any]]:
+    records = prefs.get("fallbackNotices")
+    if isinstance(records, list):
+        return [record for record in records if isinstance(record, dict)]
+    # One legacy singular record (earliest file layout) still counts.
+    legacy = prefs.get("fallbackNotice")
+    return [legacy] if isinstance(legacy, dict) else []
+
+
+def fallback_notice_due(product_version: str, reason_code: str) -> bool:
+    """True when the plain-mode fallback line was not yet shown for this
+    (product version, unavailability reason) pair.
+
+    The reason can change without an upgrade (e.g. ``missing`` becomes
+    ``version_mismatch``), and a changed reason is exactly when the user wants
+    one fresh line — but a previously seen pair stays quiet, so alternating
+    reasons never turn into a per-launch nag. Read failures fail open: the
+    notice repeats, which degrades loud rather than silent.
+    """
+    return not any(
+        str(record.get("productVersion") or "") == product_version
+        and str(record.get("reasonCode") or "") == reason_code
+        for record in _notice_records(_load())
+    )
+
+
+def record_fallback_notice(product_version: str, reason_code: str) -> None:
+    """Append the shown (version, reason) pair to the bounded record."""
+    with _advisory_lock():
+        prefs, writable = _read()
+        if not writable:
+            return
+        records = _notice_records(prefs)
+        entry = {"productVersion": product_version, "reasonCode": reason_code}
+        if entry in records:
+            return
+        records.append(entry)
+        prefs.pop("fallbackNotice", None)
+        prefs["fallbackNotices"] = records[-_MAX_FALLBACK_NOTICES:]
+        _store(prefs)

--- a/src/opensquilla/cli/tui/opentui/surface.py
+++ b/src/opensquilla/cli/tui/opentui/surface.py
@@ -40,6 +40,7 @@ from opensquilla.cli.tui.opentui.messages import (
     HostProtocolUnknown,
     HostReady,
     HostResize,
+    HostThemeSelected,
     RouterPluginState,
     ScrollbackWrite,
 )
@@ -83,6 +84,26 @@ class _OpenTuiBridgeLike(Protocol):
     async def send(self, message_type: str, payload: object | None = None) -> None: ...
 
     async def next_message(self) -> object | None: ...
+
+
+def _sanitized_approval_payload(request: dict[str, object]) -> dict[str, object]:
+    """Copy an approval.request payload with its display text made cell-safe.
+
+    This is the single choke point for every overlay payload — the canonical
+    tool-request path AND gateway-push previews — so tool/model-derived text
+    cannot smuggle control bytes into the host's raw cell renderer no matter
+    which caller built the dict.
+    """
+    from opensquilla.cli.tui.backend.render_summary import (  # noqa: PLC0415
+        sanitize_terminal_text,
+    )
+
+    payload = dict(request)
+    for key in ("summary", "message", "tool"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            payload[key] = sanitize_terminal_text(value)
+    return payload
 
 
 class OpenTuiOutputHandle:
@@ -270,7 +291,7 @@ class OpenTuiOutputHandle:
             future = asyncio.get_running_loop().create_future()
             self._approval_waiters[approval_id] = future
         assert future is not None
-        payload = dict(request)
+        payload = _sanitized_approval_payload(request)
         try:
             # A push-first overlay may be a deliberately small preview. The
             # canonical request owns the choices, so refresh only when its
@@ -332,7 +353,7 @@ class OpenTuiOutputHandle:
         # allowed to upgrade a preview with canonical details.
         if approval_id in self._approval_waiters:
             return True
-        payload = dict(request)
+        payload = _sanitized_approval_payload(request)
         future: asyncio.Future[HostApprovalResponse | ExternalApprovalResolution | None] = (
             asyncio.get_running_loop().create_future()
         )
@@ -446,6 +467,7 @@ class OpenTuiSurface:
         self._eof_emitted = False
         self._consecutive_host_errors = 0
         self._completion_task: asyncio.Task[None] | None = None
+        self._persist_tasks: set[asyncio.Task[None]] = set()
         self._last_resize: tuple[int, int] | None = None
         self._output_handle = OpenTuiOutputHandle(
             bridge,
@@ -506,6 +528,23 @@ class OpenTuiSurface:
                     "opentui.host.protocol_unknown",
                     message_type=message.message_type,
                 )
+                continue
+            if isinstance(message, HostThemeSelected):
+                # A picker confirmation happens entirely in the host; persist
+                # it here so the choice survives restarts like /theme <name>.
+                # Fire-and-forget: this loop IS the input pump — awaiting the
+                # write would queue the next input/cancel/approval frame
+                # behind prefs IO. The save is best-effort by contract, so a
+                # failure is logged by the prefs module, never raised here.
+                from opensquilla.cli.tui.opentui.prefs import (  # noqa: PLC0415
+                    save_theme_preference,
+                )
+
+                task = asyncio.get_running_loop().create_task(
+                    asyncio.to_thread(save_theme_preference, message.name)
+                )
+                self._persist_tasks.add(task)
+                task.add_done_callback(self._persist_tasks.discard)
                 continue
             if isinstance(message, HostResize):
                 self._last_resize = (message.width, message.height)

--- a/src/opensquilla/cli/tui/opentui/themes.py
+++ b/src/opensquilla/cli/tui/opentui/themes.py
@@ -63,8 +63,19 @@ async def handle_theme_command(cmd: str, tui_output: object | None) -> None:
     if len(parts) >= 2:
         name = parts[1].strip().lower()
         if name in THEME_NAMES:
+            import asyncio  # noqa: PLC0415
+
+            from opensquilla.cli.tui.opentui.prefs import (  # noqa: PLC0415
+                save_theme_preference,
+            )
+
             await send_message("theme.set", {"name": name})
+            # Off the loop: the save takes a file lock and does disk IO, and
+            # this handler runs on the chat event loop.
+            await asyncio.to_thread(save_theme_preference, name)
             return
 
     # No name, or an unknown one: open the interactive picker in the host.
+    # The picker's confirmed choice comes back as a ``theme.selected`` frame
+    # and is persisted by the surface loop.
     await send_message("theme.pick", {})

--- a/src/opensquilla/engine/commands.py
+++ b/src/opensquilla/engine/commands.py
@@ -355,6 +355,17 @@ _COMMANDS: tuple[CommandDef, ...] = (
         order=100,
     ),
     CommandDef(
+        name="/keys",
+        usage="/keys",
+        description="Show keyboard shortcuts.",
+        execution={_T: _local("keys.show"), _S: _local("keys.show")},
+        aliases=("/shortcuts",),
+        category=CommandCategory.QUERY,
+        busy_policy=CommandBusyPolicy.IMMEDIATE,
+        presentation=CommandPresentation.PANEL,
+        order=101,
+    ),
+    CommandDef(
         name="/theme",
         usage="/theme [name]",
         description="List or switch the OpenTUI color theme.",

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -49,6 +49,8 @@ OFFLINE_MARKER_EXCLUSIONS = {
     "tests/test_skills/test_meta_skill_creator_smoke_live.py",
 }
 RECENTLY_ADDED_ACTIVE_TESTS = {
+    "tests/unit/cli/tui/test_keys_cheatsheet.py",
+    "tests/unit/cli/tui/test_opentui_prefs.py",
     "tests/test_channels/test_admission_reason_persistence.py",
     "tests/test_channels/test_channel_admission.py",
     "tests/test_channels/test_channel_certification.py",

--- a/tests/test_cli/conftest.py
+++ b/tests/test_cli/conftest.py
@@ -1,0 +1,17 @@
+"""Shared fixtures for CLI command tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_local_tui_findings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize doctor's CLI-local terminal-UI probe for every CLI test.
+
+    Whether OpenTUI is available depends on the developer machine (companion
+    module, bun, node_modules), so any test that invokes ``opensquilla
+    doctor`` would otherwise be environment-dependent. Tests for the TUI
+    finding itself re-set ``_local_tui_findings`` explicitly.
+    """
+    monkeypatch.setattr("opensquilla.cli.doctor_cmd._local_tui_findings", lambda: [])

--- a/tests/test_cli/test_doctor_cmd.py
+++ b/tests/test_cli/test_doctor_cmd.py
@@ -6,9 +6,15 @@ from typing import Any
 
 from typer.testing import CliRunner
 
+from opensquilla.cli import doctor_cmd as _doctor_cmd
 from opensquilla.cli.main import app
 
 runner = CliRunner()
+
+# Captured at import time, before the autouse ``_no_local_tui_findings``
+# fixture in tests/test_cli/conftest.py stubs the module attribute per test;
+# the dedicated TUI-finding tests reinstate this real probe explicitly.
+_REAL_LOCAL_TUI_FINDINGS = _doctor_cmd._local_tui_findings
 
 
 def _config_arg(path: Any) -> str:
@@ -420,9 +426,12 @@ def test_doctor_table_shows_gateway_config_and_agent_context(tmp_path, monkeypat
     )
 
     assert result.exit_code == 0
-    assert "Gateway: ws://127.0.0.1:20003/ws" in result.stdout
-    assert f"Config: {target}" in result.stdout
-    assert "Agent: worker" in result.stdout
+    # The context line soft-wraps when the pytest tmp path is long, so compare
+    # against a wrap-insensitive projection of the output.
+    unwrapped = " ".join(result.stdout.split())
+    assert "Gateway: ws://127.0.0.1:20003/ws" in unwrapped
+    assert f"Config: {target}" in unwrapped
+    assert "Agent: worker" in unwrapped
 
 
 def test_doctor_config_reports_running_gateway_config_mismatch(
@@ -1004,11 +1013,10 @@ def test_doctor_gateway_unavailable_does_not_start_remote_gateway(monkeypatch) -
 
 
 def test_doctor_offline_prioritizes_local_config_before_gateway_restart(monkeypatch) -> None:
-    from opensquilla.cli import doctor_cmd
     from opensquilla.health.model import HealthFinding
 
     monkeypatch.setattr(
-        doctor_cmd,
+        _doctor_cmd,
         "_local_config_findings",
         lambda: [
             HealthFinding(
@@ -1022,7 +1030,7 @@ def test_doctor_offline_prioritizes_local_config_before_gateway_restart(monkeypa
         ],
     )
 
-    report = doctor_cmd._offline_report(
+    report = _doctor_cmd._offline_report(
         ConnectionError("connection refused"),
         gateway_url="ws://127.0.0.1:19999/ws",
     )
@@ -1037,11 +1045,10 @@ def test_doctor_offline_prioritizes_local_config_before_gateway_restart(monkeypa
 
 
 def test_doctor_offline_does_not_mix_local_config_into_remote_gateway(monkeypatch) -> None:
-    from opensquilla.cli import doctor_cmd
     from opensquilla.health.model import HealthFinding
 
     monkeypatch.setattr(
-        doctor_cmd,
+        _doctor_cmd,
         "_local_config_findings",
         lambda: [
             HealthFinding(
@@ -1054,7 +1061,7 @@ def test_doctor_offline_does_not_mix_local_config_into_remote_gateway(monkeypatc
         ],
     )
 
-    report = doctor_cmd._offline_report(
+    report = _doctor_cmd._offline_report(
         ConnectionError("connection refused"),
         gateway_url="wss://squilla.example.com/ws",
     )
@@ -1063,7 +1070,6 @@ def test_doctor_offline_does_not_mix_local_config_into_remote_gateway(monkeypatc
 
 
 def test_local_config_findings_explain_missing_llm_env(monkeypatch) -> None:
-    from opensquilla.cli import doctor_cmd
     from opensquilla.gateway.config import GatewayConfig
 
     monkeypatch.delenv("CUSTOM_LLM_KEY", raising=False)
@@ -1076,7 +1082,7 @@ def test_local_config_findings_explain_missing_llm_env(monkeypatch) -> None:
         }
     )
 
-    findings = doctor_cmd._local_onboarding_findings(cfg)
+    findings = _doctor_cmd._local_onboarding_findings(cfg)
 
     assert len(findings) == 1
     finding = findings[0]
@@ -1096,7 +1102,6 @@ def test_local_config_findings_explain_missing_llm_env(monkeypatch) -> None:
 
 
 def test_local_config_findings_explain_optional_env_references(monkeypatch) -> None:
-    from opensquilla.cli import doctor_cmd
     from opensquilla.gateway.config import GatewayConfig
 
     monkeypatch.delenv("CUSTOM_SEARCH_KEY", raising=False)
@@ -1123,7 +1128,7 @@ def test_local_config_findings_explain_optional_env_references(monkeypatch) -> N
         },
     )
 
-    findings = doctor_cmd._local_onboarding_findings(cfg)
+    findings = _doctor_cmd._local_onboarding_findings(cfg)
 
     assert len(findings) == 1
     finding = findings[0]
@@ -1170,3 +1175,207 @@ def test_refresh_report_readiness_labels_operator_action_items() -> None:
     assert report["ready"] is True
     assert report["status"] == "ready"
     assert report["summary"] == "Ready, 1 item awaiting operator action, 1 optional setup item"
+
+
+def test_doctor_appends_local_tui_finding_when_opentui_unavailable(monkeypatch) -> None:
+    from opensquilla.cli.tui.renderers.selection import (
+        ChatUiFallback,
+        ChatUiSelection,
+        RendererBackendUnavailableReason,
+    )
+
+    class _PlainBackend:
+        backend_id = "native"
+
+    monkeypatch.setattr(_doctor_cmd, "_local_tui_findings", _REAL_LOCAL_TUI_FINDINGS)
+    monkeypatch.setattr(
+        "opensquilla.cli.tui.renderers.selection.select_chat_ui_backend",
+        lambda mode=None: ChatUiSelection(
+            requested_mode="auto",
+            backend=_PlainBackend(),
+            fallback=ChatUiFallback(
+                code=RendererBackendUnavailableReason.MISSING,
+                detail="OpenTUI companion is not installed.",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "opensquilla.cli.tui.source_checkout.resolve_tui_source_checkout_hint",
+        lambda: None,
+    )
+    _ReadyGatewayClient.calls = []
+    monkeypatch.setattr("opensquilla.cli.gateway_client.GatewayClient", _ReadyGatewayClient)
+
+    result = runner.invoke(app, ["doctor", "--json"])
+
+    assert result.exit_code == 0
+    report = json.loads(result.stdout)
+    tui = [f for f in report["findings"] if f["id"] == "tui.opentui_unavailable"]
+    assert len(tui) == 1
+    assert tui[0]["severity"] == "info"
+    assert tui[0]["readinessImpact"] == "optional"
+    assert tui[0]["evidence"]["reasonCode"] == "missing"
+    assert tui[0]["evidence"]["selectedBackend"] == "native"
+    # An optional UI note never affects readiness.
+    assert report["ready"] is True
+
+    # The human rendering surfaces the same finding.
+    rendered = runner.invoke(app, ["doctor"])
+    assert "Full-screen terminal UI not active" in rendered.stdout
+
+
+def test_doctor_reports_nothing_when_opentui_is_active(monkeypatch) -> None:
+    from opensquilla.cli.tui.renderers.selection import ChatUiSelection
+
+    class _OpenTuiBackend:
+        backend_id = "opentui"
+
+    monkeypatch.setattr(_doctor_cmd, "_local_tui_findings", _REAL_LOCAL_TUI_FINDINGS)
+    monkeypatch.setattr(
+        "opensquilla.cli.tui.renderers.selection.select_chat_ui_backend",
+        lambda mode=None: ChatUiSelection(
+            requested_mode="auto",
+            backend=_OpenTuiBackend(),
+            fallback=None,
+        ),
+    )
+    _ReadyGatewayClient.calls = []
+    monkeypatch.setattr("opensquilla.cli.gateway_client.GatewayClient", _ReadyGatewayClient)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "No action needed" in result.stdout
+
+
+def test_local_tui_findings_reports_probe_crash_as_warn(monkeypatch) -> None:
+    def _boom(mode=None):
+        raise RuntimeError("selection exploded")
+
+    monkeypatch.setattr("opensquilla.cli.tui.renderers.selection.select_chat_ui_backend", _boom)
+
+    findings = _REAL_LOCAL_TUI_FINDINGS()
+
+    assert [f.id for f in findings] == ["tui.selection_failed"]
+    assert findings[0].severity == "warn"
+    assert findings[0].readiness_impact == "optional"
+    assert "selection exploded" in findings[0].detail
+
+
+def test_local_tui_findings_offers_source_checkout_fix_steps(monkeypatch) -> None:
+    from opensquilla.cli.tui.renderers.selection import (
+        ChatUiFallback,
+        ChatUiSelection,
+        RendererBackendUnavailableReason,
+    )
+    from opensquilla.cli.tui.source_checkout import TuiSourceCheckoutHint
+
+    class _PlainBackend:
+        backend_id = "native"
+
+    monkeypatch.setattr(
+        "opensquilla.cli.tui.renderers.selection.select_chat_ui_backend",
+        lambda mode=None: ChatUiSelection(
+            requested_mode="auto",
+            backend=_PlainBackend(),
+            fallback=ChatUiFallback(
+                code=RendererBackendUnavailableReason.MISSING,
+                detail="dependency @opentui/core is not installed\x1b[0m",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "opensquilla.cli.tui.source_checkout.resolve_tui_source_checkout_hint",
+        lambda: TuiSourceCheckoutHint(
+            install_command="bun install --cwd /repo/package",
+            launch_command="OPENSQUILLA_TUI_DEV_SOURCE_HOST=1 opensquilla chat --ui tui",
+        ),
+    )
+
+    findings = _REAL_LOCAL_TUI_FINDINGS()
+
+    assert [f.id for f in findings] == ["tui.opentui_unavailable"]
+    commands = [step.command for step in findings[0].fix_steps]
+    assert commands == [
+        "bun install --cwd /repo/package",
+        "OPENSQUILLA_TUI_DEV_SOURCE_HOST=1 opensquilla chat --ui tui",
+    ]
+    # Host-derived detail is sanitized before it reaches a report.
+    assert "\x1b" not in findings[0].detail
+
+
+def test_doctor_merge_keeps_counts_and_summary_consistent(monkeypatch) -> None:
+    from opensquilla.cli.tui.renderers.selection import (
+        ChatUiFallback,
+        ChatUiSelection,
+        RendererBackendUnavailableReason,
+    )
+
+    class _PlainBackend:
+        backend_id = "native"
+
+    monkeypatch.setattr(_doctor_cmd, "_local_tui_findings", _REAL_LOCAL_TUI_FINDINGS)
+    monkeypatch.setattr(
+        "opensquilla.cli.tui.renderers.selection.select_chat_ui_backend",
+        lambda mode=None: ChatUiSelection(
+            requested_mode="auto",
+            backend=_PlainBackend(),
+            fallback=ChatUiFallback(
+                code=RendererBackendUnavailableReason.MISSING,
+                detail="OpenTUI companion is not installed.",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "opensquilla.cli.tui.source_checkout.resolve_tui_source_checkout_hint",
+        lambda: None,
+    )
+    _ReadyGatewayClient.calls = []
+    monkeypatch.setattr("opensquilla.cli.gateway_client.GatewayClient", _ReadyGatewayClient)
+
+    result = runner.invoke(app, ["doctor", "--json"])
+
+    report = json.loads(result.stdout)
+    # Counts, impact counts, and the summary all reflect the merged findings.
+    assert report["counts"]["info"] == 1
+    assert report["impactCounts"]["optional"] == 1
+    assert report["summary"] == "Ready, 1 optional setup item"
+    assert report["ready"] is True
+    severities = [f["severity"] for f in report["findings"]]
+    assert severities.count("info") == 1
+
+
+def test_doctor_merge_preserves_offline_unavailable_sentinel(monkeypatch) -> None:
+    from opensquilla.cli.tui.renderers.selection import (
+        ChatUiFallback,
+        ChatUiSelection,
+        RendererBackendUnavailableReason,
+    )
+
+    class _PlainBackend:
+        backend_id = "native"
+
+    monkeypatch.setattr(_doctor_cmd, "_local_tui_findings", _REAL_LOCAL_TUI_FINDINGS)
+    monkeypatch.setattr(
+        "opensquilla.cli.tui.renderers.selection.select_chat_ui_backend",
+        lambda mode=None: ChatUiSelection(
+            requested_mode="auto",
+            backend=_PlainBackend(),
+            fallback=ChatUiFallback(
+                code=RendererBackendUnavailableReason.MISSING,
+                detail="OpenTUI companion is not installed.",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "opensquilla.cli.tui.source_checkout.resolve_tui_source_checkout_hint",
+        lambda: None,
+    )
+    monkeypatch.setattr("opensquilla.cli.gateway_client.GatewayClient", _OfflineGatewayClient)
+
+    result = runner.invoke(app, ["doctor", "--json"])
+
+    report = json.loads(result.stdout)
+    assert report["status"] == "unavailable"
+    assert report["ready"] is False
+    assert any(f["id"] == "tui.opentui_unavailable" for f in report["findings"])

--- a/tests/test_engine/test_slash_command_registry.py
+++ b/tests/test_engine/test_slash_command_registry.py
@@ -104,7 +104,7 @@ def test_cli_gateway_command_metadata_has_curated_order_and_compatibility() -> N
         key=lambda cmd: cmd.order,
     )
 
-    assert [cmd.name for cmd in palette[:11]] == [
+    assert [cmd.name for cmd in palette[:12]] == [
         "/model",
         "/strategy",
         "/sessions",
@@ -115,6 +115,7 @@ def test_cli_gateway_command_metadata_has_curated_order_and_compatibility() -> N
         "/usage",
         "/theme",
         "/help",
+        "/keys",
         "/exit",
     ]
 

--- a/tests/test_packaging/test_tui_host_companion.py
+++ b/tests/test_packaging/test_tui_host_companion.py
@@ -50,6 +50,16 @@ def test_companion_version_and_bun_are_exactly_pinned() -> None:
     assert "com.apple.security.cs.disable-library-validation" in entitlements
 
 
+def test_bun_native_tests_limit_concurrency() -> None:
+    package = json.loads(
+        (REPO_ROOT / "src/opensquilla/cli/tui/opentui/package/package.json").read_text()
+    )
+
+    assert package["scripts"]["test:bun"] == (
+        "bun test --max-concurrency=1 src/*.bun.test.mjs"
+    )
+
+
 def test_core_wheel_excludes_generated_tui_host_directories() -> None:
     data = tomllib.loads(CORE_PYPROJECT.read_text(encoding="utf-8"))
     excluded = set(data["tool"]["hatch"]["build"]["targets"]["wheel"]["exclude"])

--- a/tests/test_packaging/test_tui_host_companion.py
+++ b/tests/test_packaging/test_tui_host_companion.py
@@ -50,14 +50,21 @@ def test_companion_version_and_bun_are_exactly_pinned() -> None:
     assert "com.apple.security.cs.disable-library-validation" in entitlements
 
 
-def test_bun_native_tests_limit_concurrency() -> None:
+def test_bun_native_tests_run_in_isolated_processes() -> None:
     package = json.loads(
         (REPO_ROOT / "src/opensquilla/cli/tui/opentui/package/package.json").read_text()
     )
+    runner = (
+        REPO_ROOT
+        / "src/opensquilla/cli/tui/opentui/package/scripts/run-bun-tests.mjs"
+    ).read_text()
 
-    assert package["scripts"]["test:bun"] == (
-        "bun test --max-concurrency=1 src/*.bun.test.mjs"
-    )
+    assert package["scripts"]["test:bun"] == "node scripts/run-bun-tests.mjs"
+    assert 'entry.name.endsWith(".bun.test.mjs")' in runner
+    assert '"src/approval-overlay.bun.test.mjs"' in runner
+    assert '"src/theme-picker.bun.test.mjs"' in runner
+    assert '"--max-concurrency=1"' in runner
+    assert "spawnSync(" in runner
 
 
 def test_core_wheel_excludes_generated_tui_host_directories() -> None:

--- a/tests/test_packaging/test_tui_host_companion.py
+++ b/tests/test_packaging/test_tui_host_companion.py
@@ -61,9 +61,9 @@ def test_bun_native_tests_run_in_isolated_processes() -> None:
 
     assert package["scripts"]["test:bun"] == "node scripts/run-bun-tests.mjs"
     assert 'entry.name.endsWith(".bun.test.mjs")' in runner
-    assert '"src/approval-overlay.bun.test.mjs"' in runner
-    assert '"src/theme-picker.bun.test.mjs"' in runner
+    assert "for (const testFile of testFiles)" in runner
     assert '"--max-concurrency=1"' in runner
+    assert 'OPENSQUILLA_TUI_COLOR: "truecolor"' in runner
     assert "spawnSync(" in runner
 
 

--- a/tests/unit/cli/repl/test_launch_bridge.py
+++ b/tests/unit/cli/repl/test_launch_bridge.py
@@ -118,8 +118,9 @@ def test_bare_chat_ignores_stale_internal_backend_and_falls_back(
     assert os.environ[OPENSQUILLA_TUI_BACKEND_ENV] == "native"
 
 
-def test_bare_chat_keeps_installed_or_unsupported_fallback_quiet(
+def test_bare_chat_installed_fallback_notice_shows_once_per_version_and_reason(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     from opensquilla.cli.tui import source_checkout
@@ -131,14 +132,16 @@ def test_bare_chat_keeps_installed_or_unsupported_fallback_quiet(
         RendererBackendUnavailableReason,
     )
 
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path))
     original_backend = os.environ.pop(OPENSQUILLA_TUI_BACKEND_ENV, None)
+    reason_code = RendererBackendUnavailableReason.MISSING
     monkeypatch.setattr(
         opentui_bridge.OpenTuiRendererBackend,
         "is_available",
         lambda self: RendererBackendAvailability(
             available=False,
             reason="host missing",
-            reason_code=RendererBackendUnavailableReason.MISSING,
+            reason_code=reason_code,
         ),
     )
     monkeypatch.setattr(source_checkout, "resolve_tui_source_checkout_hint", lambda: None)
@@ -164,7 +167,7 @@ def test_bare_chat_keeps_installed_or_unsupported_fallback_quiet(
     async def fake_gateway(**_kwargs: Any) -> None:
         events.append("run")
 
-    try:
+    def launch() -> None:
         launch_bridge.launch_chat(
             model="",
             session_id="",
@@ -177,9 +180,27 @@ def test_bare_chat_keeps_installed_or_unsupported_fallback_quiet(
             output_console=output_console,
         )
 
+    try:
+        # First launch on this install: exactly one dim explanation with the
+        # remedy pointer, after the screen clear.
+        launch()
         assert events == ["validate", "preflight", "clear", "run"]
         assert os.environ[OPENSQUILLA_TUI_BACKEND_ENV] == "native"
-        assert output_console.prints == []
+        assert len(output_console.prints) == 1
+        notice = str(output_console.prints[0])
+        assert "Full-screen TUI unavailable" in notice
+        assert "using plain mode" in notice
+        assert "opensquilla doctor" in notice
+
+        # Second launch with the same version and reason: quiet again.
+        launch()
+        assert len(output_console.prints) == 1
+
+        # A different unavailability reason is new information: one fresh line.
+        reason_code = RendererBackendUnavailableReason.VERSION_MISMATCH
+        launch()
+        assert len(output_console.prints) == 2
+
         captured = capsys.readouterr()
         assert captured.out == ""
         assert captured.err == ""
@@ -729,3 +750,78 @@ def test_launch_chat_command_keeps_legacy_override_mapping() -> None:
             "gateway_runner": fake_gateway,
         }
     ]
+
+
+def test_fallback_notice_phrases_key_only_stable_reason_codes() -> None:
+    from opensquilla.cli.tui.adapters.launch_bridge import _FALLBACK_NOTICE_PHRASES
+    from opensquilla.cli.tui.renderers.selection import RendererBackendUnavailableReason
+
+    codes = {reason.value for reason in RendererBackendUnavailableReason}
+    assert set(_FALLBACK_NOTICE_PHRASES) <= codes
+
+
+def test_fallback_notice_prints_raw_code_for_unmapped_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from opensquilla.cli.tui import source_checkout
+    from opensquilla.cli.tui.adapters import launch_bridge
+    from opensquilla.cli.tui.renderers.selection import (
+        ChatUiFallback,
+        RendererBackendUnavailableReason,
+    )
+
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(source_checkout, "resolve_tui_source_checkout_hint", lambda: None)
+    console = FakeConsole()
+    selection = SimpleNamespace(
+        fallback=ChatUiFallback(
+            code=RendererBackendUnavailableReason.RUNTIME_CRASH,
+            detail="host exited 1",
+        )
+    )
+
+    launch_bridge._print_tui_fallback_after_clear(
+        selection, implicit_ui=True, output_console=console
+    )
+
+    assert len(console.prints) == 1
+    # No phrase mapping for runtime_crash: the stable code itself is printed.
+    assert "runtime_crash" in str(console.prints[0])
+
+
+def test_fallback_notice_repeats_when_the_record_cannot_be_written(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from opensquilla.cli.tui import source_checkout
+    from opensquilla.cli.tui.adapters import launch_bridge
+    from opensquilla.cli.tui.opentui import prefs
+    from opensquilla.cli.tui.renderers.selection import (
+        ChatUiFallback,
+        RendererBackendUnavailableReason,
+    )
+
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(source_checkout, "resolve_tui_source_checkout_hint", lambda: None)
+    monkeypatch.setattr(
+        "opensquilla.cli.tui.opentui.prefs._store",
+        lambda _prefs: None,  # simulate a write that silently fails
+    )
+    console = FakeConsole()
+    selection = SimpleNamespace(
+        fallback=ChatUiFallback(
+            code=RendererBackendUnavailableReason.MISSING,
+            detail="no companion",
+        )
+    )
+
+    for _ in range(2):
+        launch_bridge._print_tui_fallback_after_clear(
+            selection, implicit_ui=True, output_console=console
+        )
+
+    # Fail open: with no durable record the notice repeats — degrading loud,
+    # never silent.
+    assert len(console.prints) == 2
+    assert prefs.fallback_notice_due("x", "missing") is True

--- a/tests/unit/cli/tui/test_approvals.py
+++ b/tests/unit/cli/tui/test_approvals.py
@@ -314,9 +314,39 @@ async def test_handler_routes_through_host_overlay_and_resolves_approval() -> No
             "tool": "sandbox_network",
             "summary": "network access to packages.example.test",
             "choices": ["allow_once", "allow_same_type", "deny"],
+            "message": "Network access needs approval.",
         }
     ]
     assert resolver.calls == [("appr-1", True, "allow_once")]
+
+
+async def test_host_payload_omits_message_when_it_already_is_the_summary() -> None:
+    handler = tui_approval_handler(output_console=_FakeConsole())
+    resolver = _Resolver()
+    handle = _HostOutputHandle(_FakeResponse(True, choice=None))
+    renderer = _RecordingRenderer(handle)
+
+    # No command/path/host: the summary falls back to the message itself, so
+    # forwarding the message too would render the same line twice.
+    await handler(
+        {
+            "status": "approval_required",
+            "approval_id": "appr-3",
+            "tool": "custom_tool",
+            "message": "Custom action needs approval.",
+        },
+        renderer,
+        resolver,
+    )
+
+    assert handle.requests == [
+        {
+            "id": "appr-3",
+            "tool": "custom_tool",
+            "summary": "Custom action needs approval.",
+            "choices": [],
+        }
+    ]
 
 
 async def test_handler_host_choice_response_is_authoritative() -> None:
@@ -614,3 +644,33 @@ async def test_default_handler_resolves_through_host_capable_renderer() -> None:
 
     assert [request["id"] for request in handle.requests] == ["appr-2"]
     assert resolver.calls == [("appr-2", True, None)]
+
+
+async def test_host_payload_strips_control_bytes_and_dedups_after_sanitizing() -> None:
+    handler = tui_approval_handler(output_console=_FakeConsole())
+    resolver = _Resolver()
+    handle = _HostOutputHandle(_FakeResponse(True, choice=None))
+    renderer = _RecordingRenderer(handle)
+
+    # The message differs from the summary only by embedded control bytes:
+    # after sanitizing they render identically, so no message is forwarded.
+    await handler(
+        {
+            "status": "approval_required",
+            "approval_id": "appr-4",
+            "tool": "shell",
+            "command": "echo\x1b[31m ok\x07",
+            "message": "echo ok",
+        },
+        renderer,
+        resolver,
+    )
+
+    assert handle.requests == [
+        {
+            "id": "appr-4",
+            "tool": "shell",
+            "summary": "echo ok",
+            "choices": [],
+        }
+    ]

--- a/tests/unit/cli/tui/test_keys_cheatsheet.py
+++ b/tests/unit/cli/tui/test_keys_cheatsheet.py
@@ -1,0 +1,83 @@
+"""Pin the ``/keys`` cheatsheet to the OpenTUI host's keyboard-handler source.
+
+The cheatsheet in ``opensquilla.cli.tui.adapters.commands`` is a hand-written
+mirror of the imperative key handlers in ``package/src/composer.mjs`` and
+``package/src/main.mjs``. Each documented row carries the exact source
+literal it describes; these tests fail when a binding is removed or renamed
+without updating the table (the same pattern that pins ``THEME_NAMES`` to
+``theme.mjs``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opensquilla.cli.tui.adapters.commands import (
+    NATIVE_KEY_BINDINGS,
+    OPENTUI_KEY_BINDINGS,
+    render_keys_table,
+)
+
+_PACKAGE_SRC = (
+    Path(__file__).resolve().parents[4] / "src/opensquilla/cli/tui/opentui/package/src"
+)
+
+
+@pytest.mark.parametrize(
+    "binding",
+    [binding for binding in OPENTUI_KEY_BINDINGS if binding.js_literals],
+    ids=lambda binding: binding.keys,
+)
+def test_documented_chords_exist_in_host_source(binding) -> None:
+    source = (_PACKAGE_SRC / binding.js_file).read_text(encoding="utf-8")
+    for literal in binding.js_literals:
+        assert literal in source, (
+            f"/keys documents {binding.keys!r} via {literal!r}, which no longer "
+            f"appears in {binding.js_file}; update OPENTUI_KEY_BINDINGS to match "
+            "the host's handlers"
+        )
+
+
+def test_keys_table_lists_every_binding_for_each_backend() -> None:
+    opentui_table = render_keys_table(opentui=True)
+    assert opentui_table.row_count == len(OPENTUI_KEY_BINDINGS)
+    native_table = render_keys_table(opentui=False)
+    assert native_table.row_count == len(NATIVE_KEY_BINDINGS)
+    # The plain backend must never advertise host-only chords.
+    assert native_table.caption is not None
+
+
+def test_native_rows_match_the_launch_banner_vocabulary() -> None:
+    documented = " ".join(f"{binding.keys} {binding.action}" for binding in NATIVE_KEY_BINDINGS)
+    # The three affordances the native banner promises, and nothing OpenTUI-only.
+    assert "Enter" in documented
+    assert "Ctrl+C" in documented
+    assert "Ctrl+D" in documented
+    assert "Ctrl+O" not in documented
+    assert "PageUp" not in documented
+
+
+def test_output_supports_host_ui_prefers_the_wrapper_capability_flag() -> None:
+    from opensquilla.cli.tui.adapters.slash_common import output_supports_host_ui
+
+    class _Wrapped:
+        # The plugin wrapper always exposes a callable send_message that
+        # no-ops on the native backend; only the flag tells the truth.
+        supports_send_message = False
+
+        async def send_message(self, *_args: object) -> None: ...
+
+    class _Host:
+        supports_send_message = True
+
+        async def send_message(self, *_args: object) -> None: ...
+
+    class _Bare:
+        async def send_message(self, *_args: object) -> None: ...
+
+    assert output_supports_host_ui(None) is False
+    assert output_supports_host_ui(_Wrapped()) is False
+    assert output_supports_host_ui(_Host()) is True
+    assert output_supports_host_ui(_Bare()) is True  # unwrapped handle fallback

--- a/tests/unit/cli/tui/test_opentui_bridge.py
+++ b/tests/unit/cli/tui/test_opentui_bridge.py
@@ -545,3 +545,77 @@ def test_restore_terminal_writes_reset_sequence_once() -> None:
     assert data == TERMINAL_RESET_SEQUENCE
     assert b"\x1b[?1049l" in data
     assert b"\x1b[?25h" in data
+
+
+@pytest.mark.asyncio
+async def test_start_applies_persisted_theme_to_the_host_env(tmp_path, monkeypatch) -> None:
+    # Binds the call site, not just the helper: a saved /theme preference must
+    # reach the spawned host process as OPENSQUILLA_TUI_THEME.
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.delenv("OPENSQUILLA_TUI_THEME", raising=False)
+    from opensquilla.cli.tui.opentui.prefs import save_theme_preference
+
+    save_theme_preference("nord")
+
+    seen_theme = tmp_path / "seen_theme.txt"
+    host_script = tmp_path / "fake_host.py"
+    host_script.write_text(
+        textwrap.dedent(
+            f"""
+            import json
+            import os
+            import socket
+
+            open({str(seen_theme)!r}, "w").write(
+                os.environ.get("OPENSQUILLA_TUI_THEME", "<unset>")
+            )
+            sock = socket.create_connection((
+                os.environ["OPENSQUILLA_OPENTUI_IPC_HOST"],
+                int(os.environ["OPENSQUILLA_OPENTUI_IPC_PORT"]),
+            ))
+            stream = sock.makefile("rwb", buffering=0)
+            auth = {{
+                "type": "auth",
+                "token": os.environ["OPENSQUILLA_OPENTUI_IPC_TOKEN"],
+                "protocol": int(os.environ["OPENSQUILLA_OPENTUI_PROTOCOL_VERSION"]),
+            }}
+            stream.write((json.dumps(auth) + "\\n").encode())
+            assert json.loads(stream.readline())["type"] == "auth.ok"
+            ready = {{
+                "type": "ready",
+                "protocol": 1,
+                "productVersion": os.environ["OPENSQUILLA_PRODUCT_VERSION"],
+                "hostVersion": os.environ["OPENSQUILLA_OPENTUI_HOST_VERSION"],
+                "platform": os.environ["OPENSQUILLA_OPENTUI_HOST_PLATFORM"],
+                "arch": os.environ["OPENSQUILLA_OPENTUI_HOST_ARCH"],
+                "buildId": os.environ["OPENSQUILLA_OPENTUI_BUILD_ID"],
+                "screenMode": "alternate-screen",
+                "capabilities": [
+                    "jsonl",
+                    "loopback",
+                    "authenticated",
+                    "turn.identity.v2",
+                    "scroll.anchor.v1",
+                    "model.routing.control.v1",
+                ],
+            }}
+            stream.write((json.dumps(ready) + "\\n").encode())
+            for line in stream:
+                if json.loads(line).get("type") == "shutdown":
+                    break
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(host_runtime_module.shutil, "which", lambda _cmd: None)
+    resolver = HostArtifactResolver(
+        package_dir=tmp_path,
+        main_script=host_script,
+        companion_module=_fake_companion((sys.executable, str(host_script))),
+    )
+    bridge = OpenTuiBridge(package_dir=tmp_path, artifact_resolver=resolver)
+
+    await asyncio.wait_for(bridge.start(), timeout=5.0)
+    await asyncio.wait_for(bridge.close(), timeout=5.0)
+
+    assert seen_theme.read_text() == "nord"

--- a/tests/unit/cli/tui/test_opentui_completion_catalog.py
+++ b/tests/unit/cli/tui/test_opentui_completion_catalog.py
@@ -97,7 +97,7 @@ def test_gateway_catalog_projects_curated_order_aliases_and_arguments() -> None:
         item.label for item in commands if item.visible_by_default and not item.deprecated
     ]
 
-    assert default_labels[:11] == [
+    assert default_labels[:12] == [
         "/model",
         "/strategy",
         "/sessions",
@@ -108,6 +108,7 @@ def test_gateway_catalog_projects_curated_order_aliases_and_arguments() -> None:
         "/usage",
         "/theme",
         "/help",
+        "/keys",
         "/exit",
     ]
 

--- a/tests/unit/cli/tui/test_opentui_messages.py
+++ b/tests/unit/cli/tui/test_opentui_messages.py
@@ -217,6 +217,9 @@ def test_host_message_rejects_malformed_control_payloads() -> None:
     with pytest.raises(HostToPythonMessageError, match="resize.width"):
         host_message_from_json('{"type":"resize","height":36}')
 
+    with pytest.raises(HostToPythonMessageError, match="theme.selected.name"):
+        host_message_from_json('{"type":"theme.selected"}')
+
     with pytest.raises(HostToPythonMessageError, match="Unknown OpenTUI host"):
         host_message_from_json('{"type":"surprise"}')
 
@@ -368,6 +371,7 @@ def test_host_to_python_registry_round_trips_canonical_frames() -> None:
         "approval.response": (
             '{"type":"approval.response","id":"appr-1","approved":true,"choice":"allow_once"}'
         ),
+        "theme.selected": '{"type":"theme.selected","name":"nord"}',
     }
     assert set(samples) == set(HOST_TO_PYTHON_TYPES)
     for wire_type, raw in samples.items():

--- a/tests/unit/cli/tui/test_opentui_prefs.py
+++ b/tests/unit/cli/tui/test_opentui_prefs.py
@@ -1,0 +1,240 @@
+"""Persistence contract for the CLI-TUI preferences file.
+
+The theme choice and the fallback-notice bookkeeping live in one
+schema-versioned JSON under the state root. The failure posture matters more
+than the happy path: corruption degrades to defaults, unknown names are
+ignored, and write failures never raise — a read-only state dir must never
+break chat launch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from opensquilla.cli.tui.opentui import prefs
+from opensquilla.cli.tui.opentui.messages import HostInputSubmit, HostThemeSelected
+from opensquilla.cli.tui.opentui.themes import DEFAULT_THEME, handle_theme_command
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_theme_preference_round_trips() -> None:
+    assert prefs.load_theme_preference() is None
+    prefs.save_theme_preference("nord")
+    assert prefs.load_theme_preference() == "nord"
+    # Whitespace and case are normalized on save.
+    prefs.save_theme_preference("  EMBER ")
+    assert prefs.load_theme_preference() == "ember"
+
+
+def test_prefs_file_lives_under_the_state_root(tmp_path: Path) -> None:
+    # Guard against the path drifting away from what these tests hand-write:
+    # every fixture below builds files at exactly the module's own location.
+    assert prefs._prefs_path() == tmp_path / "state" / "tui" / "prefs.json"
+
+
+def test_unknown_theme_names_are_ignored_on_save_and_load() -> None:
+    prefs.save_theme_preference("solarized-nope")
+    assert prefs.load_theme_preference() is None
+
+    # A stale file naming a theme this binary does not know (downgrade after a
+    # rename) silently falls back instead of failing launch.
+    path = prefs._prefs_path()
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"schemaVersion": 1, "theme": "retired-theme"}))
+    assert prefs.load_theme_preference() is None
+
+
+def test_corrupt_prefs_file_degrades_to_defaults() -> None:
+    path = prefs._prefs_path()
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json")
+    assert prefs.load_theme_preference() is None
+    assert prefs.fallback_notice_due("0.5.0", "missing") is True
+    # A save over the corrupt file recovers it.
+    prefs.save_theme_preference("mono")
+    assert prefs.load_theme_preference() == "mono"
+
+
+def test_write_failures_are_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _deny(*args: object, **kwargs: object) -> None:
+        raise OSError("read-only state dir")
+
+    monkeypatch.setattr(Path, "mkdir", _deny)
+    prefs.save_theme_preference("nord")  # must not raise
+    prefs.record_fallback_notice("0.5.0", "missing")  # must not raise
+    assert prefs.load_theme_preference() is None
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="root and Windows bypass file modes",
+)
+def test_unreadable_file_blocks_writes_instead_of_clobbering() -> None:
+    # A file that exists but cannot be READ may still hold good data: writers
+    # must skip rather than rewrite it from the empty fallback.
+    prefs.save_theme_preference("nord")
+    path = prefs._prefs_path()
+    path.chmod(0o000)
+    try:
+        prefs.record_fallback_notice("0.5.0", "missing")  # must not clobber
+        prefs.save_theme_preference("ember")  # must not clobber
+    finally:
+        path.chmod(0o600)
+    assert prefs.load_theme_preference() == "nord"
+    assert prefs.fallback_notice_due("0.5.0", "missing") is True
+
+
+def test_transient_read_error_blocks_writes_on_any_platform(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Deterministic version of the chmod test: inject the read failure
+    # directly so the writable=False branch is exercised as root, on
+    # Windows, and on permission-ignoring filesystems alike.
+    prefs.save_theme_preference("nord")
+    real_read_text = Path.read_text
+
+    def _flaky_read(self: Path, *args: object, **kwargs: object) -> str:
+        if self == prefs._prefs_path():
+            raise PermissionError("transient EACCES")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _flaky_read)
+    prefs.record_fallback_notice("0.5.0", "missing")  # must not clobber
+    prefs.save_theme_preference("ember")  # must not clobber
+    monkeypatch.setattr(Path, "read_text", real_read_text)
+    assert prefs.load_theme_preference() == "nord"
+    assert prefs.fallback_notice_due("0.5.0", "missing") is True
+
+
+def test_saving_theme_preserves_the_notice_record_and_vice_versa() -> None:
+    prefs.save_theme_preference("nord")
+    prefs.record_fallback_notice("0.5.0", "missing")
+    assert prefs.load_theme_preference() == "nord"
+    assert prefs.fallback_notice_due("0.5.0", "missing") is False
+    prefs.save_theme_preference("slate")
+    assert prefs.fallback_notice_due("0.5.0", "missing") is False
+
+
+def test_fallback_notice_is_due_once_per_version_and_reason() -> None:
+    assert prefs.fallback_notice_due("0.5.0", "missing") is True
+    prefs.record_fallback_notice("0.5.0", "missing")
+    assert prefs.fallback_notice_due("0.5.0", "missing") is False
+    # A cause change within the same version is new information.
+    assert prefs.fallback_notice_due("0.5.0", "version_mismatch") is True
+    # So is the same cause after an upgrade.
+    assert prefs.fallback_notice_due("0.6.0", "missing") is True
+
+
+def test_alternating_reasons_never_renag() -> None:
+    prefs.record_fallback_notice("0.5.0", "missing")
+    prefs.record_fallback_notice("0.5.0", "version_mismatch")
+    # Both pairs were shown once; flip-flopping between them stays quiet.
+    assert prefs.fallback_notice_due("0.5.0", "missing") is False
+    assert prefs.fallback_notice_due("0.5.0", "version_mismatch") is False
+    # The record is bounded and duplicate pairs are not re-appended.
+    prefs.record_fallback_notice("0.5.0", "missing")
+    for build in range(20):
+        prefs.record_fallback_notice(f"0.{build}.0", "missing")
+    records = json.loads(prefs._prefs_path().read_text())["fallbackNotices"]
+    assert len(records) <= 8
+    # Eviction must drop the OLDEST pairs: keeping the oldest instead would
+    # evict each just-recorded pair and turn the notice into a per-launch nag.
+    assert prefs.fallback_notice_due("0.19.0", "missing") is False
+    assert prefs.fallback_notice_due("0.0.0", "missing") is True
+
+
+def test_legacy_singular_notice_record_still_counts() -> None:
+    path = prefs._prefs_path()
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "fallbackNotice": {"productVersion": "0.5.0", "reasonCode": "missing"},
+            }
+        )
+    )
+    assert prefs.fallback_notice_due("0.5.0", "missing") is False
+    assert prefs.fallback_notice_due("0.5.0", "version_mismatch") is True
+
+
+async def test_theme_command_persists_direct_choice() -> None:
+    class _Output:
+        supports_send_message = True
+
+        def __init__(self) -> None:
+            self.sent: list[tuple[str, dict[str, object]]] = []
+
+        async def send_message(self, message_type: str, payload: dict[str, object]) -> None:
+            self.sent.append((message_type, payload))
+
+    output = _Output()
+    await handle_theme_command("/theme nord", output)
+    assert output.sent == [("theme.set", {"name": "nord"})]
+    assert prefs.load_theme_preference() == "nord"
+
+    # Unknown names open the picker and persist nothing.
+    await handle_theme_command("/theme not-a-theme", output)
+    assert output.sent[-1][0] == "theme.pick"
+    assert prefs.load_theme_preference() == "nord"
+
+
+async def test_surface_persists_picker_confirmation() -> None:
+    from opensquilla.cli.tui.opentui.surface import OpenTuiSurface
+    from opensquilla.engine.commands import Surface
+    from tests.unit.cli.tui.test_opentui_surface import FakeOpenTuiBridge
+
+    bridge = FakeOpenTuiBridge()
+    surface = OpenTuiSurface(bridge, approval_surface=Surface.CLI_GATEWAY)
+
+    bridge.messages.put_nowait(HostThemeSelected(name="ember"))
+    bridge.messages.put_nowait(HostInputSubmit(text="next"))
+
+    assert await asyncio.wait_for(surface.next_line(), timeout=5) == "next"
+    # Persistence is fire-and-forget so the pump never stalls on prefs IO;
+    # drain the background task before asserting the durable effect.
+    await asyncio.gather(*surface._persist_tasks)
+    assert prefs.load_theme_preference() == "ember"
+    assert DEFAULT_THEME != "ember"  # the test would be vacuous otherwise
+
+
+def test_bridge_env_injection_prefers_explicit_env_over_pref() -> None:
+    from opensquilla.cli.tui.opentui.bridge import apply_theme_preference_env
+    from opensquilla.cli.tui.opentui.themes import THEME_ENV_VAR
+
+    prefs.save_theme_preference("nord")
+
+    # Unset: the persisted preference fills the gap.
+    env: dict[str, str] = {}
+    apply_theme_preference_env(env)
+    assert env[THEME_ENV_VAR] == "nord"
+
+    # A non-empty explicit value wins.
+    env = {THEME_ENV_VAR: "ember"}
+    apply_theme_preference_env(env)
+    assert env[THEME_ENV_VAR] == "ember"
+
+    # An exported-but-empty value counts as unset — the host would map "" to
+    # the default theme, silently masking the preference forever.
+    env = {THEME_ENV_VAR: ""}
+    apply_theme_preference_env(env)
+    assert env[THEME_ENV_VAR] == "nord"
+
+
+def test_bridge_env_injection_without_preference_is_a_no_op() -> None:
+    from opensquilla.cli.tui.opentui.bridge import apply_theme_preference_env
+    from opensquilla.cli.tui.opentui.themes import THEME_ENV_VAR
+
+    env: dict[str, str] = {}
+    apply_theme_preference_env(env)
+    assert THEME_ENV_VAR not in env

--- a/tests/unit/cli/tui/test_opentui_surface.py
+++ b/tests/unit/cli/tui/test_opentui_surface.py
@@ -1176,3 +1176,37 @@ async def test_stream_output_surfaces_write_failure_at_context_exit() -> None:
     with pytest.raises(RuntimeError, match="pipe down"):
         async with output.stream_output() as write:
             write("only")
+
+
+@pytest.mark.asyncio
+async def test_approval_payloads_are_sanitized_on_both_send_sites() -> None:
+    # The choke point must hold for the canonical request AND the gateway-push
+    # preview: reverting either call site to dict(request) must fail here.
+    hostile = {
+        "id": "appr-hostile",
+        "tool": "sh\x1b[31mell",
+        "summary": "echo\x1b]0;pwn\x07 ok",
+        "message": "why\x1b[2Jnot",
+        "choices": ["allow_once"],
+    }
+
+    bridge = FakeOpenTuiBridge()
+    output = OpenTuiOutputHandle(bridge, approval_surface=Surface.CLI_GATEWAY)
+    await output.request_approval(dict(hostile), timeout=0.01)
+    # The timeout appends an approval.dismiss; the request frame is first.
+    sent_type, sent_payload = bridge.sent[0]
+    assert sent_type == "approval.request"
+    assert sent_payload["tool"] == "shell"
+    assert sent_payload["summary"] == "echo ok"
+    assert sent_payload["message"] == "whynot"
+    # The raw id list is protocol data (round-trips in approval.response) and
+    # is display-stripped host-side instead.
+    assert sent_payload["choices"] == ["allow_once"]
+
+    preview_bridge = FakeOpenTuiBridge()
+    preview_output = OpenTuiOutputHandle(preview_bridge, approval_surface=Surface.CLI_GATEWAY)
+    assert await preview_output.present_gateway_approval(dict(hostile)) is True
+    preview_type, preview_payload = preview_bridge.sent[-1]
+    assert preview_type == "approval.request"
+    assert preview_payload["summary"] == "echo ok"
+    assert preview_payload["tool"] == "shell"

--- a/tests/unit/cli/tui/test_opentui_themes.py
+++ b/tests/unit/cli/tui/test_opentui_themes.py
@@ -22,6 +22,13 @@ _MAIN_MJS = (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolated_state_dir(tmp_path_factory: pytest.TempPathFactory, monkeypatch) -> None:
+    # handle_theme_command persists valid /theme choices; isolate the state
+    # root so these tests never write into the shared pytest-session state.
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path_factory.mktemp("state")))
+
+
 def _js_palette_names() -> list[str]:
     text = _THEME_MJS.read_text(encoding="utf-8")
     block = text.split("PALETTES = Object.freeze({", 1)[1].split("});", 1)[0]

--- a/tests/unit/cli/tui/test_slash_adapters.py
+++ b/tests/unit/cli/tui/test_slash_adapters.py
@@ -1426,3 +1426,41 @@ def test_record_turn_updates_transcript_and_usage() -> None:
     assert [turn.role for turn in state.transcript.turns] == ["user", "assistant"]
     assert state.transcript.turns[0].content == "ask"
     assert state.transcript.turns[1].content == "answer"
+
+
+class _HostCapableOutput:
+    supports_send_message = True
+
+    async def send_message(self, *_args: Any) -> None:
+        return None
+
+
+async def test_keys_dispatch_selects_cheatsheet_by_backend_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Binds the wiring, not the parts: a host-capable output must get the
+    # OpenTUI chords, and a native/absent output must get only the honest
+    # plain-mode rows — never OpenTUI-only shortcuts it cannot deliver.
+    gateway_recorder = _patch_gateway_io(monkeypatch)
+    handled = await handle_gateway_slash_command(
+        "/keys", _gateway_context(tui_output=_HostCapableOutput())
+    )
+    assert handled is True
+    table = gateway_recorder.entries[-1]
+    opentui_rows = "\n".join(str(cell) for column in table.columns for cell in column.cells)
+    assert "Ctrl+O" in opentui_rows
+
+    gateway_recorder.entries.clear()
+    handled = await handle_gateway_slash_command("/keys", _gateway_context(tui_output=None))
+    assert handled is True
+    table = gateway_recorder.entries[-1]
+    native_rows = "\n".join(str(cell) for column in table.columns for cell in column.cells)
+    assert "Ctrl+O" not in native_rows
+    assert "Ctrl+C" in native_rows
+
+    standalone_recorder = _patch_standalone_io(monkeypatch)
+    handled = await handle_standalone_slash_command("/shortcuts", _standalone_context())
+    assert handled is True
+    table = standalone_recorder.entries[-1]
+    native_rows = "\n".join(str(cell) for column in table.columns for cell in column.cells)
+    assert "Ctrl+O" not in native_rows


### PR DESCRIPTION
## Scope

Scope boundary: Terminal chat (CLI/TUI) UX only — three arcs in one PR: (1) `/theme` choices (direct and picker) persist across restarts via a per-machine prefs file under the state dir, applied at host launch when `OPENSQUILLA_TUI_THEME` is unset or empty; (2) the implicit `--ui auto` degradation to plain mode prints one dim explanation per (version, reason) with an `opensquilla doctor` pointer, and `doctor` gains a CLI-local finding explaining which chat surface `auto` selects and why; (3) the tool-approval overlay carries the envelope's rationale line, wraps instead of clipping, and keeps at least one summary row visible on small terminals with control-byte sanitization on both send paths; plus a `/keys` (`/shortcuts`) cheatsheet whose documented chords are pinned to the host's handler source by a conformance test.

Non-goals: No agent/provider/router behavior changes; no gateway config keys or RPC changes (the one protocol addition, `theme.selected`, rides the version-locked host IPC); no companion-wheel release CI (signing work is in flight separately); no change to explicit `--ui tui` hard-failure semantics.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: implements the terminal-UX review follow-ups agreed in maintainer review of the TUI surface; no pre-existing tracking issue.

## Release Note

Release note: The terminal chat theme chosen with `/theme` now persists across restarts. When the full-screen TUI is unavailable, `opensquilla chat` explains the plain-mode fallback once per release and `opensquilla doctor` reports the reason with fix steps. Tool-approval prompts show the full command and rationale (wrapped, never silently truncated), and `/keys` lists the keyboard shortcuts for the active chat surface.

## Tests

Ruff: `uv run ruff check src tests` — pass

Pytest: `uv run pytest -q` — 16,068 passed, 142 skipped; 7 failures are pre-existing macOS environment issues (real-Seatbelt execution, BSD `sed -i`, shard refresh budget) reproduced identically on a clean `main` checkout. `uv run mypy src/opensquilla` — clean (846 files). OpenTUI host: `bun test` — 339 pass.

Build: `uv build --wheel` — pass (Web UI dist rebuilt and verified beforehand)

Regression tests: added

Notes: New coverage binds the previously untested seams: host-env theme injection at the bridge spawn site, `/keys` backend selection at both dispatch sites, approval-payload sanitization on both send sites, prefs corruption/unreadable-file/lock posture, notice-record eviction direction, and a malformed-payload rejection case for the new `theme.selected` frame. The default test path remains offline, deterministic, credential-free, and safe for forks (a new `tests/test_cli/conftest.py` fixture neutralizes the machine-dependent TUI probe in doctor tests).

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No secrets, transcripts, channel identifiers, or machine-local artifacts are committed. The new `<state>/tui/prefs.json` stores only a theme name and shown-notice version/reason pairs; writes are atomic, best-effort, and non-blocking (a held lock or unreadable file degrades without stalling launch). `.coverage*` added to `.gitignore` to keep local coverage databases out of the tree.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
