### PR TITLE
Recover reasoning-only length stops in ensemble aggregators

### DIFF
--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -1398,6 +1398,39 @@ class _IterationStreamTimeoutError(TimeoutError):
     """Raised when provider streaming exceeds the active Agent iteration budget."""
 
 
+def _terminal_physical_input_tokens(
+    provider_done: ProviderDoneEvent | None,
+    *,
+    fallback_input_tokens: int,
+) -> int:
+    """Return the last physical final-leg input size, not ensemble billing total."""
+
+    if provider_done is None:
+        return fallback_input_tokens
+    breakdown = getattr(provider_done, "model_usage_breakdown", None)
+    if not isinstance(breakdown, list):
+        return fallback_input_tokens
+    for row in reversed(breakdown):
+        if not isinstance(row, Mapping):
+            continue
+        if str(row.get("role") or "").strip().lower() not in {
+            "aggregator",
+            "fallback",
+            "single",
+        }:
+            continue
+        raw_input_tokens = row.get("input_tokens")
+        if raw_input_tokens is None or isinstance(raw_input_tokens, bool):
+            continue
+        try:
+            input_tokens = int(raw_input_tokens)
+        except (TypeError, ValueError):
+            continue
+        if input_tokens >= 0:
+            return input_tokens
+    return fallback_input_tokens
+
+
 def _is_large_context_invalid_response(
     kind: _ProviderAttemptKind,
     *,
@@ -6027,6 +6060,10 @@ class Agent:
                             output_tokens=iter_output_tokens,
                         )
                     if not _got_error and attempt_classification.kind != _ProviderAttemptKind.OK:
+                        terminal_request_input_tokens = _terminal_physical_input_tokens(
+                            provider_done_for_log,
+                            fallback_input_tokens=iter_input_tokens,
+                        )
                         logger.warning(
                             "provider.invalid_response",
                             session_key=self._session_key,
@@ -6040,6 +6077,7 @@ class Agent:
                             got_done_event=_got_done_event,
                             stop_reason=stop_reason,
                             iter_input_tokens=iter_input_tokens,
+                            terminal_request_input_tokens=terminal_request_input_tokens,
                             iter_output_tokens=iter_output_tokens,
                             iter_reasoning_tokens=iter_reasoning_tokens,
                             reasoning_chars=len(iter_reasoning_content or ""),
@@ -6047,7 +6085,7 @@ class Agent:
 
                         large_context_invalid = _is_large_context_invalid_response(
                             attempt_classification.kind,
-                            input_tokens=iter_input_tokens,
+                            input_tokens=terminal_request_input_tokens,
                         )
                         supports_reasoning_replay = supports_reasoning_prefill_replay(
                             model_capabilities=self.config.model_capabilities,

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -61,6 +61,13 @@ _ENSEMBLE_CANCEL_CLEANUP_TIMEOUT_SECONDS = 5.0
 # this a single 429/5xx blip would discard the whole billed proposer round.
 _ENSEMBLE_AGGREGATOR_MAX_RETRIES = 2
 _ENSEMBLE_AGGREGATOR_RETRY_BACKOFF_SECONDS: tuple[float, ...] = (1.0, 4.0)
+# A completed aggregator request can still be unusable when a reasoning model
+# exhausts its completion allowance before emitting any text or tool call.  The
+# proposal round is already complete, so retry only this final physical leg.
+_ENSEMBLE_AGGREGATOR_REASONING_ONLY_RETRY_PROMPT = (
+    "Return the visible final answer or the appropriate tool call now. "
+    "Do not spend the remaining response budget expanding private reasoning."
+)
 _AGGREGATOR_RETRYABLE_FAILURE_KINDS = frozenset(
     {
         ProviderFailureKind.RATE_LIMITED,
@@ -1563,9 +1570,12 @@ class EnsembleProvider:
                 error=error,
             )
 
-        def ensemble_done(event: DoneEvent, *, aggregator_elapsed_ms: int) -> DoneEvent:
-            output_text = "".join(final_text_parts)
-            _attach_final_request_output(trace, event=event, output_text=output_text)
+        retried_aggregator_rows: list[dict[str, Any]] = []
+        missing_aggregator_receipts = 0
+
+        def aggregator_usage_row(
+            event: DoneEvent, *, aggregator_elapsed_ms: int
+        ) -> tuple[_AggregatorAccumulator, dict[str, Any]]:
             acc = _AggregatorAccumulator(
                 input_tokens=event.input_tokens,
                 output_tokens=event.output_tokens,
@@ -1577,8 +1587,8 @@ class EnsembleProvider:
                 billing_receipt=event.billing_receipt,
                 model=event.model or self.aggregator.provider_config.model,
             )
-            rows = [
-                *prior_rows,
+            return (
+                acc,
                 acc.usage_row(
                     profile=self.profile_name,
                     member=self.aggregator,
@@ -1586,7 +1596,15 @@ class EnsembleProvider:
                     label="aggregator",
                     elapsed_ms=aggregator_elapsed_ms,
                 ),
-            ]
+            )
+
+        def ensemble_done(event: DoneEvent, *, aggregator_elapsed_ms: int) -> DoneEvent:
+            output_text = "".join(final_text_parts)
+            _attach_final_request_output(trace, event=event, output_text=output_text)
+            acc, current_row = aggregator_usage_row(
+                event, aggregator_elapsed_ms=aggregator_elapsed_ms
+            )
+            rows = [*prior_rows, *retried_aggregator_rows, current_row]
             return replace(
                 event,
                 input_tokens=_summed_int(rows, "input_tokens"),
@@ -1600,28 +1618,32 @@ class EnsembleProvider:
                 cost_source=_rollup_cost_source(rows),
                 model_usage_breakdown=rows,
                 ensemble_trace=trace,
-                # Each retried aggregator attempt started a request that never
-                # produced a usage receipt.
-                usage_missing_count=prior_missing_count + attempt,
+                usage_missing_count=prior_missing_count + missing_aggregator_receipts,
                 billing_receipt=None,
             )
 
         def partial_error(event: ErrorEvent) -> ErrorEvent:
             return replace(
                 event,
-                model_usage_breakdown=list(prior_rows),
-                usage_missing_count=prior_missing_count + attempt + 1,
+                model_usage_breakdown=[*prior_rows, *retried_aggregator_rows],
+                usage_missing_count=(
+                    prior_missing_count + missing_aggregator_receipts + 1
+                ),
             )
 
         yield aggregator_progress("aggregator_start")
         attempt = 0
+        reasoning_only_retry_done = False
+        request_messages = messages
         while True:
             content_streamed = False
+            buffered_reasoning_events: list[ReasoningDeltaEvent] = []
             retry_error: ErrorEvent | None = None
+            retry_reason: str | None = None
             heartbeat_stream: AsyncIterator[StreamEvent] | None = None
             try:
                 _mark_final_request_started(trace)
-                stream = provider.chat(messages, tools=tools, config=config)
+                stream = provider.chat(request_messages, tools=tools, config=config)
                 timeout_seconds = (
                     self.aggregator_timeout_seconds
                     if self.aggregator_timeout_seconds > 0
@@ -1638,6 +1660,33 @@ class EnsembleProvider:
                         aggregator_elapsed_ms = int(
                             (time.monotonic() - aggregator_started) * 1000
                         )
+                        has_reasoning = bool(
+                            buffered_reasoning_events
+                            or (event.reasoning_content and event.reasoning_content.strip())
+                            or event.reasoning_tokens > 0
+                        )
+                        if (
+                            not reasoning_only_retry_done
+                            and not content_streamed
+                            and event.stop_reason == "length"
+                            and has_reasoning
+                        ):
+                            _, failed_row = aggregator_usage_row(
+                                event, aggregator_elapsed_ms=aggregator_elapsed_ms
+                            )
+                            retried_aggregator_rows.append(failed_row)
+                            reasoning_only_retry_done = True
+                            retry_reason = "reasoning_only_length"
+                            request_messages = [
+                                *messages,
+                                Message(
+                                    role="user",
+                                    content=_ENSEMBLE_AGGREGATOR_REASONING_ONLY_RETRY_PROMPT,
+                                ),
+                            ]
+                            break
+                        for reasoning_event in buffered_reasoning_events:
+                            yield reasoning_event
                         done_event = ensemble_done(
                             event,
                             aggregator_elapsed_ms=aggregator_elapsed_ms,
@@ -1678,30 +1727,42 @@ class EnsembleProvider:
                         )
                         if (
                             not content_streamed
+                            and not buffered_reasoning_events
                             and attempt < _ENSEMBLE_AGGREGATOR_MAX_RETRIES
                             and self._aggregator_error_is_retryable(
                                 message=safe_event.message,
                                 code=safe_event.code,
                             )
                         ):
+                            missing_aggregator_receipts += 1
                             retry_error = safe_event
                             break
+                        for reasoning_event in buffered_reasoning_events:
+                            yield reasoning_event
                         yield aggregator_progress(
                             "aggregator_finish",
                             error=safe_event.message,
                         )
                         yield partial_error(safe_event)
                         return
+                    elif isinstance(event, ReasoningDeltaEvent):
+                        if content_streamed:
+                            yield event
+                        else:
+                            buffered_reasoning_events.append(event)
                     elif isinstance(event, TextDeltaEvent):
+                        for reasoning_event in buffered_reasoning_events:
+                            yield reasoning_event
+                        buffered_reasoning_events.clear()
                         content_streamed = True
                         final_text_parts.append(event.text)
                         yield event
                     elif isinstance(event, ProviderHeartbeatEvent):
                         yield event
                     else:
-                        # Reasoning/tool-use deltas are user-visible; replaying
-                        # the aggregator after emitting them would duplicate
-                        # output downstream, so they pin this attempt.
+                        for reasoning_event in buffered_reasoning_events:
+                            yield reasoning_event
+                        buffered_reasoning_events.clear()
                         content_streamed = True
                         yield event
             except TimeoutError:
@@ -1723,6 +1784,7 @@ class EnsembleProvider:
                 )
                 if (
                     not content_streamed
+                    and not buffered_reasoning_events
                     and attempt < _ENSEMBLE_AGGREGATOR_MAX_RETRIES
                     and self._aggregator_error_is_retryable(
                         message=safe_message,
@@ -1741,7 +1803,7 @@ class EnsembleProvider:
                     yield aggregator_progress("aggregator_finish", error=error.message)
                     yield partial_error(error)
                     return
-            if retry_error is None:
+            if retry_error is None and retry_reason is None:
                 error = ErrorEvent(
                     message="ensemble aggregator stream ended before DoneEvent",
                     code="ensemble_aggregator_incomplete",
@@ -1757,8 +1819,25 @@ class EnsembleProvider:
             final_request = trace.get("final_request")
             if isinstance(final_request, dict):
                 final_request["retry_count"] = attempt
+                if retry_reason is not None:
+                    final_request["retry_reason"] = retry_reason
             # The retried attempt is one more real upstream request.
             trace["llm_request_count"] = int(trace.get("llm_request_count") or 0) + 1
+            if retry_reason == "reasoning_only_length":
+                log.warning(
+                    "ensemble.aggregator_reasoning_only_retry",
+                    attempt=attempt,
+                    provider=self.aggregator.provider_config.provider,
+                )
+                yield ProviderHeartbeatEvent(
+                    phase="ensemble_aggregator_reasoning_only_retry",
+                    message=(
+                        "Ensemble aggregator exhausted reasoning before visible output; "
+                        "retrying once"
+                    ),
+                )
+                continue
+            assert retry_error is not None
             log.warning(
                 "ensemble.aggregator_retry",
                 attempt=attempt,

--- a/tests/test_engine/test_agent_invalid_provider_response.py
+++ b/tests/test_engine/test_agent_invalid_provider_response.py
@@ -1016,6 +1016,52 @@ async def test_repeated_large_dashscope_reasoning_only_disables_thinking_after_n
 
 
 @pytest.mark.asyncio
+async def test_ensemble_usage_total_does_not_misclassify_small_final_aggregator_as_large_input(
+) -> None:
+    provider = _SequenceProvider(
+        [
+            [
+                ProviderDone(
+                    stop_reason="length",
+                    input_tokens=92_213,
+                    output_tokens=12_209,
+                    reasoning_tokens=10_580,
+                    reasoning_content="internal reasoning only",
+                    model_usage_breakdown=[
+                        {"role": "proposer", "input_tokens": 17_700},
+                        {"role": "proposer", "input_tokens": 14_378},
+                        {"role": "proposer", "input_tokens": 14_380},
+                        {"role": "proposer", "input_tokens": 14_379},
+                        {
+                            "role": "aggregator",
+                            "input_tokens": 26_399,
+                            "output_tokens": 12_209,
+                            "reasoning_tokens": 10_580,
+                        },
+                    ],
+                )
+            ]
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_provider_retries=0,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    error = next(event for event in events if event.kind == "error")
+    assert error.code == "empty_response"
+    assert "large input" not in error.message
+    assert len(provider.calls) == 1
+
+
+
+@pytest.mark.asyncio
 async def test_large_empty_response_without_fallback_surfaces_clear_error() -> None:
     provider = _SequenceProvider(
         [[ProviderDone(stop_reason="stop", input_tokens=35_000, output_tokens=0)]]

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -21,6 +21,7 @@ from opensquilla.provider import (
     ErrorEvent,
     Message,
     ProviderHeartbeatEvent,
+    ReasoningDeltaEvent,
     TextDeltaEvent,
     ToolDefinition,
     ToolInputSchema,
@@ -2526,6 +2527,152 @@ async def test_aggregator_transient_error_is_retried_in_place(
     ]
     assert len(finishes) == 1
     assert not finishes[0].error
+
+
+@pytest.mark.asyncio
+async def test_aggregator_reasoning_only_length_retries_in_place_without_replaying_proposers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, call_count = _flaky_aggregator_harness(
+        monkeypatch,
+        [
+            [
+                ReasoningDeltaEvent(text="discarded private reasoning"),
+                DoneEvent(
+                    stop_reason="length",
+                    input_tokens=10,
+                    output_tokens=20,
+                    reasoning_tokens=19,
+                    model="agg",
+                ),
+            ],
+            [
+                TextDeltaEvent(text="visible final"),
+                DoneEvent(
+                    stop_reason="stop",
+                    input_tokens=2,
+                    output_tokens=3,
+                    model="agg",
+                ),
+            ],
+        ],
+    )
+
+    events = await _collect(_retry_test_provider())
+
+    assert call_count[0] == 2
+    assert sum(call["model"] == "p1" for call in registry.calls) == 1
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    assert not any(
+        isinstance(event, ReasoningDeltaEvent)
+        and event.text == "discarded private reasoning"
+        for event in events
+    )
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    aggregator_rows = [
+        row for row in done.model_usage_breakdown if row.get("role") == "aggregator"
+    ]
+    assert len(aggregator_rows) == 2
+    assert done.input_tokens == 12
+    assert done.output_tokens == 23
+    assert done.reasoning_tokens == 19
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["final_request"]["retry_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_aggregator_reasoning_only_length_recovery_is_bounded_to_one_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, call_count = _flaky_aggregator_harness(
+        monkeypatch,
+        [
+            [
+                ReasoningDeltaEvent(text="first private reasoning"),
+                DoneEvent(
+                    stop_reason="length",
+                    input_tokens=10,
+                    output_tokens=20,
+                    reasoning_tokens=19,
+                    model="agg",
+                ),
+            ],
+            [
+                ReasoningDeltaEvent(text="second private reasoning"),
+                DoneEvent(
+                    stop_reason="length",
+                    input_tokens=2,
+                    output_tokens=3,
+                    reasoning_tokens=2,
+                    model="agg",
+                ),
+            ],
+        ],
+    )
+
+    events = await _collect(_retry_test_provider())
+
+    assert call_count[0] == 2
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.stop_reason == "length"
+    assert len(
+        [row for row in done.model_usage_breakdown if row.get("role") == "aggregator"]
+    ) == 2
+
+
+@pytest.mark.asyncio
+async def test_aggregator_length_after_visible_text_does_not_use_reasoning_only_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, call_count = _flaky_aggregator_harness(
+        monkeypatch,
+        [
+            [
+                TextDeltaEvent(text="partial"),
+                DoneEvent(
+                    stop_reason="length",
+                    input_tokens=10,
+                    output_tokens=20,
+                    model="agg",
+                ),
+            ],
+            [TextDeltaEvent(text="must not run"), DoneEvent(model="agg")],
+        ],
+    )
+
+    events = await _collect(_retry_test_provider())
+
+    assert call_count[0] == 1
+    assert any(
+        isinstance(event, DoneEvent) and event.stop_reason == "length" for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_aggregator_length_after_tool_use_does_not_use_reasoning_only_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, call_count = _flaky_aggregator_harness(
+        monkeypatch,
+        [
+            [
+                ToolUseStartEvent(tool_use_id="call-1", tool_name="read_file"),
+                DoneEvent(
+                    stop_reason="length",
+                    input_tokens=10,
+                    output_tokens=20,
+                    reasoning_tokens=19,
+                    model="agg",
+                ),
+            ],
+            [TextDeltaEvent(text="must not run"), DoneEvent(model="agg")],
+        ],
+    )
+
+    events = await _collect(_retry_test_provider())
+
+    assert call_count[0] == 1
+    assert any(isinstance(event, ToolUseStartEvent) for event in events)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

Recover an ensemble run when the final aggregator exhausts its completion allowance in private reasoning before emitting any visible text or tool call.

Scope boundary:

- Detect the narrow `stop_reason="length"` + reasoning-only + no-visible-output final-aggregator result.
- Retry only the final aggregator once, using the original candidate answers plus a short instruction to return the visible answer or tool call.
- Keep proposer calls single-shot and preserve usage accounting for both aggregator attempts.
- Classify invalid responses using the terminal physical request's input size rather than an ensemble-wide billing total.

Non-goals:

- Changing context compaction or model output-token limits.
- Retrying after partial visible text or tool use.
- Replaying the proposer round.
- Changing top-level ensemble usage totals used for billing and history.

## Root Cause

An ensemble `DoneEvent` reports aggregate usage across every proposer and the final aggregator. The Agent used that aggregate input-token count to decide whether an invisible response came from a large request. A normal-sized final aggregator request could therefore be mislabeled as a large-input failure when the combined proposer + aggregator total crossed the threshold.

Separately, the ensemble's existing in-place aggregator retry covered transient exceptions and provider error events, but not a successful stream completion with `stop_reason="length"` that contained private reasoning and no visible text or tool call. That left the Agent with no usable response and produced a misleading instruction to shorten or attach the input.

## Behavior After This Change

- The failed private reasoning stream is not exposed as a partial answer.
- The aggregator receives one bounded recovery attempt; proposers are not rerun.
- Visible text or tool activity disables this recovery path, avoiding duplicate user-visible work or side effects.
- Both physical aggregator attempts remain represented in `model_usage_breakdown`, and top-level totals remain additive.
- The Agent logs and uses the terminal final-leg input count for large-context classification, falling back to the previous total when no usable breakdown exists.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: no public issue currently describes this same ensemble-specific root cause. #742 reports the same user-facing error text for a true compaction/input overflow; this PR intentionally does not change or close that path.

## Release Note

Release note: Recover ensemble responses when a reasoning aggregator reaches its completion limit before emitting visible output, without rerunning proposer models.

## Tests

Ruff: `uv run --extra dev ruff check src tests` — passed

Pytest:

- `uv run --extra dev pytest tests/test_provider_ensemble.py tests/test_engine/test_agent_invalid_provider_response.py -q` — 130 passed
- `uv run --extra dev --extra recommended pytest -q` — 15,986 passed, 171 skipped, 20 failed
- The same 20 failures reproduce unchanged on an unmodified `origin/main` worktree; they are existing macOS sandbox/path/skill-environment failures and are not touched by this diff.

Type checking: `uv run --extra dev --extra recommended mypy src/opensquilla --show-error-codes` — passed (845 source files)

Build:

- `npm --prefix opensquilla-webui run build` — passed
- `uv build --wheel` — passed
- `git diff --check` — passed

Regression tests: added

Notes:

The new tests use synthetic usage values and provider events. They cover terminal-leg token classification, successful bounded recovery, no proposer replay, usage accounting, retry bounding, visible-text exclusion, and tool-use exclusion.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: provider

Suggested optional check: run an ensemble with a reasoning-capable final aggregator and a deliberately constrained completion allowance, then confirm that a reasoning-only length stop retries the aggregator once and returns visible output without rerunning proposers.

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included. The regression cases are synthetic and provider-independent.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

Documentation changes: N/A; this is an internal recovery and diagnostics correction with public regression coverage.

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
