### PR TITLE
Add stderr event streaming and verify state-dir concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,27 @@ toolchain — not the local image build.
 
 </details>
 
+### Concurrent CLI Calls
+
+The `agent` command acquires a profile-wide writer lock on the OpenSquilla
+home directory, so two calls sharing the same home would serialize (the second
+raises `ProfileLockBusyError`). To run multiple `agent` calls concurrently,
+give each one its own state directory via `OPENSQUILLA_STATE_DIR`:
+
+```sh
+OPENSQUILLA_STATE_DIR=/tmp/agent-a opensquilla agent -m "task A" --json &
+OPENSQUILLA_STATE_DIR=/tmp/agent-b opensquilla agent -m "task B" --json &
+wait
+```
+
+Each directory hashes to its own profile lock key, so the calls do not
+contend. Model assets are bundled with the Python package (they are not
+stored in the profile directory), and API keys are read from environment
+variables, so an empty directory is sufficient — there is no need to seed a
+`config.toml` or any state before the first run. State and history written
+by each call stay under its own directory, keeping the concurrent runs fully
+isolated.
+
 Provider tiers, sandbox tuning, image generation, and concurrency
 settings live in `opensquilla.toml.example`.
 

--- a/README.md
+++ b/README.md
@@ -646,26 +646,49 @@ toolchain — not the local image build.
 
 </details>
 
-### Concurrent CLI Calls
+### Agent Subprocess Automation
+
+Add `--event-stream-stderr` to receive incrementally flushed agent events as
+JSONL on stderr while `--json` keeps the final result on stdout. Event records
+carry `"_event": true`; stderr can also contain ordinary diagnostics, so
+consumers should drain it continuously and parse it one line at a time. Event
+payloads can include model reasoning and tool arguments or results, so protect
+captured stderr as sensitive runtime data.
+
+#### Concurrent CLI Calls
 
 The `agent` command acquires a profile-wide writer lock on the OpenSquilla
-home directory, so two calls sharing the same home would serialize (the second
-raises `ProfileLockBusyError`). To run multiple `agent` calls concurrently,
-give each one its own state directory via `OPENSQUILLA_STATE_DIR`:
+home directory. Overlapping calls that share the same home do not serialize;
+the second exits with `ProfileLockBusyError`. To run multiple `agent` calls
+concurrently, give each one its own home via `OPENSQUILLA_STATE_DIR`:
 
 ```sh
-OPENSQUILLA_STATE_DIR=/tmp/agent-a opensquilla agent -m "task A" --json &
-OPENSQUILLA_STATE_DIR=/tmp/agent-b opensquilla agent -m "task B" --json &
+OPENSQUILLA_STATE_DIR=/tmp/agent-a \
+OPENSQUILLA_GATEWAY_STATE_DIR=/tmp/agent-a/state \
+  opensquilla agent -m "task A" --json &
+OPENSQUILLA_STATE_DIR=/tmp/agent-b \
+OPENSQUILLA_GATEWAY_STATE_DIR=/tmp/agent-b/state \
+  opensquilla agent -m "task B" --json &
 wait
 ```
 
-Each directory hashes to its own profile lock key, so the calls do not
-contend. Model assets are bundled with the Python package (they are not
-stored in the profile directory), and API keys are read from environment
-variables, so an empty directory is sufficient — there is no need to seed a
-`config.toml` or any state before the first run. State and history written
-by each call stay under its own directory, keeping the concurrent runs fully
-isolated.
+The example uses POSIX shell syntax; on Windows, set both variables in each
+child process environment. Each home hashes to its own profile lock key, while
+the second variable makes the effective persistent state root unambiguously
+per-child.
+
+`OPENSQUILLA_STATE_DIR` alone does not rewrite paths from a current-directory
+`opensquilla.toml` or `OPENSQUILLA_GATEWAY_CONFIG_PATH`. An empty home also
+does not inherit `~/.opensquilla/config.toml` or `~/.opensquilla/.env`, although
+those current-directory or explicit config sources can still be loaded. Supply
+the required model, provider, and credential settings deliberately.
+
+If an orchestrator copies `config.toml` or `.env` into each home, remove or
+rewrite any `state_dir` or `OPENSQUILLA_GATEWAY_STATE_DIR` value as well; the
+compatibility guard can still consider a state root declared in the copied
+profile. Explicitly shared `--session-db-path`, workspace, scratch, transcript,
+or usage paths also remain shared and must be unique when complete isolation
+is required.
 
 Provider tiers, sandbox tuning, image generation, and concurrency
 settings live in `opensquilla.toml.example`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,7 +107,15 @@ Useful automation flags:
 | `--permissions` | Select restricted, bypass, or full permission posture. |
 | `--transcript-path` | Write a JSONL transcript for automation. |
 | `--usage-path` | Write usage JSON. |
+| `--event-stream-stderr` | Stream incrementally flushed agent-event JSONL on stderr. |
 | `--session-db-path` | Persist session replay across invocations. |
+
+With `--event-stream-stderr`, event records contain `"_event": true`, while
+stderr may also contain ordinary diagnostics. Subprocess consumers should
+continuously drain stderr and parse it one line at a time, accepting only
+records with that marker as events. The stream can include model reasoning and
+tool arguments or results, so treat captured stderr as sensitive runtime data.
+When combined with `--json`, stdout remains reserved for the final result.
 
 ## Coding Mode and Code-Task
 

--- a/src/opensquilla/cli/agent_cmd.py
+++ b/src/opensquilla/cli/agent_cmd.py
@@ -7,7 +7,8 @@ import copy
 import getpass
 import json
 import os
-from dataclasses import dataclass
+import sys
+from dataclasses import asdict, dataclass, is_dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -135,6 +136,7 @@ async def run_agent_once(
     length_capped_continuations: int | None = None,
     transcript_path: str | None = None,
     usage_path: str | None = None,
+    event_stream_stderr: bool = False,
     config: Any | None = None,
     session_db_path: str = ":memory:",
     no_memory_capture: bool = False,
@@ -344,6 +346,11 @@ async def run_agent_once(
             attachments=run_attachments,
             bootstrap_context_mode=bootstrap_context_mode,
         ):
+            if event_stream_stderr:
+                line = _event_to_jsonl(event)
+                if line is not None:
+                    print(line, file=sys.stderr, flush=True)
+
             if isinstance(event, TextDeltaEvent):
                 text_parts.append(event.text)
             elif isinstance(event, ErrorEvent):
@@ -688,6 +695,33 @@ def _to_transcript_usage(usage: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _json_safe(value: Any) -> Any:
+    """Convert enums and other non-JSON-native values to serializable forms."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    return str(value)
+
+
+def _event_to_jsonl(event: Any) -> str | None:
+    """Serialize an AgentEvent dataclass to a JSONL line with _event marker."""
+    if not is_dataclass(event):
+        return None
+    try:
+        raw = asdict(event)  # type: ignore[arg-type]
+    except TypeError:
+        raw = {"kind": getattr(event, "kind", "unknown")}
+    payload: dict[str, Any] = {"_event": True}
+    for key, value in raw.items():
+        payload[key] = _json_safe(value)
+    return json.dumps(payload, ensure_ascii=False, default=str)
+
+
 def _write_jsonl(path: str, rows: list[dict[str, Any]]) -> None:
     target = Path(path)
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -807,6 +841,11 @@ def run_agent_command(
         "", "--transcript-path", help="Write benchmark-compatible JSONL transcript"
     ),
     usage_path: str = typer.Option("", "--usage-path", help="Write usage JSON to this file"),
+    event_stream_stderr: bool = typer.Option(
+        False,
+        "--event-stream-stderr",
+        help="Write agent events as incrementally flushed JSONL to stderr",
+    ),
     session_db_path: str = typer.Option(
         ":memory:",
         "--session-db-path",
@@ -876,6 +915,7 @@ def run_agent_command(
     thinking = _unwrap_typer_default(thinking)
     transcript_path = _unwrap_typer_default(transcript_path)
     usage_path = _unwrap_typer_default(usage_path)
+    event_stream_stderr = _unwrap_typer_default(event_stream_stderr)
     session_db_path = _unwrap_typer_default(session_db_path)
     no_memory_capture = _unwrap_typer_default(no_memory_capture)
     file_paths = _unwrap_typer_default(file_paths)
@@ -910,6 +950,7 @@ def run_agent_command(
             length_capped_continuations=length_capped_continuations,
             transcript_path=transcript_path or None,
             usage_path=usage_path or None,
+            event_stream_stderr=event_stream_stderr,
             session_db_path=session_db_path,
             no_memory_capture=no_memory_capture,
             attachment_paths=list(file_paths or []),

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -1007,6 +1007,11 @@ def agent(
         "", "--transcript-path", help="Write benchmark-compatible JSONL transcript"
     ),
     usage_path: str = typer.Option("", "--usage-path", help="Write usage JSON to this file"),
+    event_stream_stderr: bool = typer.Option(
+        False,
+        "--event-stream-stderr",
+        help="Write agent events as incrementally flushed JSONL to stderr",
+    ),
     session_db_path: str = typer.Option(
         ":memory:",
         "--session-db-path",
@@ -1080,6 +1085,7 @@ def agent(
             length_capped_continuations=length_capped_continuations,
             transcript_path=transcript_path,
             usage_path=usage_path,
+            event_stream_stderr=event_stream_stderr,
             session_db_path=session_db_path,
             no_memory_capture=no_memory_capture,
             file_paths=file_paths,

--- a/tests/test_cli/test_agent_cmd.py
+++ b/tests/test_cli/test_agent_cmd.py
@@ -15,7 +15,16 @@ from opensquilla.cli.agent_cmd import (
     run_agent_command,
     run_agent_once,
 )
-from opensquilla.engine.types import ArtifactEvent, DoneEvent
+from opensquilla.engine.types import (
+    ArtifactEvent,
+    DoneEvent,
+    RouterDecisionEvent,
+    RunHeartbeatEvent,
+    TextDeltaEvent,
+    ThinkingEvent,
+    ToolResultEvent,
+    ToolUseStartEvent,
+)
 from opensquilla.gateway.config import AgentEntryConfig, GatewayConfig, PermissionsConfig
 from opensquilla.sandbox.config import SandboxSettings
 from opensquilla.tools.types import CallerKind, InteractionMode
@@ -1337,3 +1346,144 @@ def test_top_level_agent_command_rejects_invalid_length_capped_continuations() -
     assert "Invalid value" in output
     assert "--length-capped-continuations" in output
     assert "x>=1" in output
+
+
+@pytest.mark.asyncio
+async def test_event_stream_stderr_writes_all_events(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class FakeTurnRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def run(self, message: str, session_key: str, **kwargs: Any):
+            yield RouterDecisionEvent(tier="c1", model="deepseek-v4-pro", source="v4_phase3")
+            yield ThinkingEvent(text="analyzing...")
+            yield RunHeartbeatEvent(elapsed_ms=5000, idle_ms=1000)
+            yield ToolUseStartEvent(tool_use_id="call-1", tool_name="read_file")
+            yield ToolResultEvent(tool_use_id="call-1", tool_name="read_file", is_error=False)
+            yield TextDeltaEvent(text="The answer is...")
+            yield DoneEvent(text="The answer is 42", input_tokens=100)
+
+    async def fake_build_services(*, config: GatewayConfig, **kwargs: Any) -> _FakeServices:
+        return _FakeServices(config)
+
+    monkeypatch.setattr("opensquilla.engine.runtime.TurnRunner", FakeTurnRunner)
+    monkeypatch.setattr("opensquilla.gateway.build_services", fake_build_services)
+
+    await run_agent_once(
+        message="hello",
+        event_stream_stderr=True,
+        config=GatewayConfig(),
+    )
+
+    captured = capsys.readouterr()
+    lines = [json.loads(line) for line in captured.err.strip().split("\n") if line]
+
+    assert len(lines) == 7
+    assert all(line["_event"] is True for line in lines)
+    kinds = [line["kind"] for line in lines]
+    assert kinds == [
+        "router_decision",
+        "thinking",
+        "run_heartbeat",
+        "tool_use_start",
+        "tool_result",
+        "text_delta",
+        "done",
+    ]
+    assert lines[0]["tier"] == "c1"
+    assert lines[3]["tool_name"] == "read_file"
+    assert lines[6]["input_tokens"] == 100
+
+
+@pytest.mark.asyncio
+async def test_event_stream_stderr_disabled_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class FakeTurnRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def run(self, message: str, session_key: str, **kwargs: Any):
+            yield ThinkingEvent(text="thinking...")
+            yield DoneEvent(text="ok")
+
+    async def fake_build_services(*, config: GatewayConfig, **kwargs: Any) -> _FakeServices:
+        return _FakeServices(config)
+
+    monkeypatch.setattr("opensquilla.engine.runtime.TurnRunner", FakeTurnRunner)
+    monkeypatch.setattr("opensquilla.gateway.build_services", fake_build_services)
+
+    await run_agent_once(message="hello", config=GatewayConfig())
+
+    captured = capsys.readouterr()
+    assert "_event" not in captured.err
+
+
+@pytest.mark.asyncio
+async def test_event_stream_stderr_lines_are_valid_jsonl_with_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class FakeTurnRunner:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def run(self, message: str, session_key: str, **kwargs: Any):
+            yield ThinkingEvent(text="hmm")
+            yield TextDeltaEvent(text="partial")
+            yield DoneEvent(text="done", input_tokens=5, output_tokens=7)
+
+    async def fake_build_services(*, config: GatewayConfig, **kwargs: Any) -> _FakeServices:
+        return _FakeServices(config)
+
+    monkeypatch.setattr("opensquilla.engine.runtime.TurnRunner", FakeTurnRunner)
+    monkeypatch.setattr("opensquilla.gateway.build_services", fake_build_services)
+
+    await run_agent_once(
+        message="hello",
+        event_stream_stderr=True,
+        config=GatewayConfig(),
+    )
+
+    captured = capsys.readouterr()
+    raw_lines = [line for line in captured.err.split("\n") if line.strip()]
+    assert raw_lines
+    parsed: list[dict[str, Any]] = []
+    for raw in raw_lines:
+        obj = json.loads(raw)  # raises if not valid JSON
+        assert obj["_event"] is True
+        parsed.append(obj)
+    assert [obj["kind"] for obj in parsed] == ["thinking", "text_delta", "done"]
+    assert parsed[2]["input_tokens"] == 5
+    assert parsed[2]["output_tokens"] == 7
+
+
+def test_cli_passes_event_stream_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
+    from opensquilla.cli.main import app
+
+    captured: dict[str, Any] = {}
+
+    async def fake_run_agent_once(**kwargs: Any) -> AgentRunResult:
+        captured.update(kwargs)
+        return AgentRunResult(
+            status="ok",
+            agent_id="main",
+            session_key="agent:main:main",
+            text="ok",
+            usage={},
+            errors=[],
+        )
+
+    monkeypatch.setattr("opensquilla.cli.agent_cmd.run_agent_once", fake_run_agent_once)
+
+    result = CliRunner().invoke(
+        app,
+        ["agent", "--message", "test", "--json", "--event-stream-stderr"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured.get("event_stream_stderr") is True

--- a/tests/test_cli/test_stdio_encoding.py
+++ b/tests/test_cli/test_stdio_encoding.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import json
 import sys
 from io import BytesIO, TextIOWrapper
 
 import typer
 
+from opensquilla.cli.agent_cmd import _event_to_jsonl
 from opensquilla.cli.stdio import configure_stdio_for_unicode
+from opensquilla.engine.types import TextDeltaEvent
 
 
 def test_configure_stdio_for_unicode_allows_typer_echo_on_gbk_stream(
@@ -20,3 +23,24 @@ def test_configure_stdio_for_unicode_allows_typer_echo_on_gbk_stream(
     stream.flush()
 
     assert raw.getvalue().decode("utf-8").strip() == "hello 🦐"
+
+
+def test_configure_stdio_for_unicode_keeps_stderr_event_jsonl_utf8(
+    monkeypatch,
+) -> None:
+    raw = BytesIO()
+    stream = TextIOWrapper(raw, encoding="cp1252", errors="backslashreplace")
+    monkeypatch.setattr(sys, "stderr", stream)
+
+    configure_stdio_for_unicode()
+    line = _event_to_jsonl(TextDeltaEvent(text="你好🙂"))
+    assert line is not None
+    print(line, file=sys.stderr, flush=True)
+
+    payload = json.loads(raw.getvalue().decode("utf-8"))
+    assert payload == {
+        "_event": True,
+        "kind": "text_delta",
+        "text": "你好🙂",
+        "presentation": "answer",
+    }

--- a/tests/test_recovery/test_runtime_writer_guard.py
+++ b/tests/test_recovery/test_runtime_writer_guard.py
@@ -203,11 +203,11 @@ def test_runtime_writer_lock_keeps_read_only_cli_available_and_rejects_agent(
     assert writer.exitcode == 0
 
 
-def test_different_state_dirs_acquire_independent_profile_locks(
+def test_different_profile_homes_acquire_independent_profile_locks(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Two profile locks with different OPENSQUILLA_STATE_DIR do not conflict."""
+    """Two profile homes selected by OPENSQUILLA_STATE_DIR do not conflict."""
 
     from opensquilla.recovery import guarded_desktop_profile
     from opensquilla.recovery.locking import profile_lock_key, profile_lock_path
@@ -231,6 +231,42 @@ def test_different_state_dirs_acquire_independent_profile_locks(
     assert profile_lock_path(profile_a) != profile_lock_path(profile_b)
 
 
+def test_gateway_state_override_isolates_state_from_shared_cwd_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The documented override keeps runtime state per child despite cwd config."""
+
+    from opensquilla.gateway.config import GatewayConfig
+
+    _isolate_profile_locks(monkeypatch, tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "opensquilla.toml").write_text(
+        'state_dir = "shared-state"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(project)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+
+    resolved_state_dirs: list[Path] = []
+    profiles = (tmp_path / "profile-a", tmp_path / "profile-b")
+    for profile in profiles:
+        profile.mkdir()
+        monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(profile))
+        monkeypatch.setenv(
+            "OPENSQUILLA_GATEWAY_STATE_DIR",
+            str(profile / "state"),
+        )
+        cfg = GatewayConfig.load()
+        assert cfg.state_dir is not None
+        resolved_state_dirs.append(Path(cfg.state_dir))
+
+    assert resolved_state_dirs == [profile / "state" for profile in profiles]
+    assert len(set(resolved_state_dirs)) == 2
+    assert project / "shared-state" not in resolved_state_dirs
+
+
 def test_empty_state_dir_falls_back_to_default_config(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -240,6 +276,11 @@ def test_empty_state_dir_falls_back_to_default_config(
     from opensquilla.gateway.config import GatewayConfig
 
     _isolate_profile_locks(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_STATE_DIR", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_WORKSPACE_DIR", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_WORKSPACE_DIR", raising=False)
     empty_profile = tmp_path / "empty"
     empty_profile.mkdir()
     monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(empty_profile))

--- a/tests/test_recovery/test_runtime_writer_guard.py
+++ b/tests/test_recovery/test_runtime_writer_guard.py
@@ -4,6 +4,7 @@ import json
 import multiprocessing
 import os
 import sys
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -52,6 +53,11 @@ def _profile(home: Path) -> None:
         'state_dir = "state"\nworkspace_dir = "workspace"\n',
         encoding="utf-8",
     )
+
+
+def _isolate_profile_locks(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OPENSQUILLA_USER_STATE_DIR", str(tmp_path / "user-state"))
+    monkeypatch.setenv("OPENSQUILLA_TEST_PROFILE_LOCK_ROOT", "1")
 
 
 def test_unknown_desktop_layout_blocks_agent_before_profile_seed(
@@ -195,3 +201,81 @@ def test_runtime_writer_lock_keeps_read_only_cli_available_and_rejects_agent(
             writer.join(timeout=5)
 
     assert writer.exitcode == 0
+
+
+def test_different_state_dirs_acquire_independent_profile_locks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Two profile locks with different OPENSQUILLA_STATE_DIR do not conflict."""
+
+    from opensquilla.recovery import guarded_desktop_profile
+    from opensquilla.recovery.locking import profile_lock_key, profile_lock_path
+
+    _isolate_profile_locks(monkeypatch, tmp_path)
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    profile_a.mkdir()
+    profile_b.mkdir()
+
+    assert profile_lock_key(profile_a) != profile_lock_key(profile_b)
+
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(profile_a))
+    with guarded_desktop_profile():
+        monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(profile_b))
+        with guarded_desktop_profile():
+            pass
+
+    assert profile_lock_path(profile_a).is_file()
+    assert profile_lock_path(profile_b).is_file()
+    assert profile_lock_path(profile_a) != profile_lock_path(profile_b)
+
+
+def test_empty_state_dir_falls_back_to_default_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An empty OPENSQUILLA_STATE_DIR produces default config without error."""
+
+    from opensquilla.gateway.config import GatewayConfig
+
+    _isolate_profile_locks(monkeypatch, tmp_path)
+    empty_profile = tmp_path / "empty"
+    empty_profile.mkdir()
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(empty_profile))
+
+    cfg = GatewayConfig.load()
+
+    assert cfg.state_dir == str(empty_profile / "state")
+    assert not (empty_profile / "config.toml").exists()
+
+
+def test_same_state_dir_blocks_second_profile_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Same OPENSQUILLA_STATE_DIR blocks a second writer on another thread."""
+
+    from opensquilla.recovery import ProfileLockBusyError, guarded_desktop_profile
+
+    _isolate_profile_locks(monkeypatch, tmp_path)
+    profile = tmp_path / "shared"
+    profile.mkdir()
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(profile))
+    errors: list[BaseException] = []
+
+    def try_second_lock() -> None:
+        try:
+            with guarded_desktop_profile():
+                pass
+        except BaseException as exc:
+            errors.append(exc)
+
+    with guarded_desktop_profile():
+        second = threading.Thread(target=try_second_lock)
+        second.start()
+        second.join(timeout=5)
+
+    assert not second.is_alive()
+    assert len(errors) == 1
+    assert isinstance(errors[0], ProfileLockBusyError)


### PR DESCRIPTION
## Scope

Scope boundary: Improve `opensquilla agent` as a subprocess interface for automation and orchestrators:

1. **Structured progress on stderr** — add `--event-stream-stderr`. When enabled, `run_agent_once()` serializes every engine event (router decisions, thinking, heartbeats, tool lifecycle, text deltas, state changes, errors, done, artifacts, warnings, compaction, and ensemble/meta events) as incrementally flushed JSONL on stderr. Every event line carries `_event: true`, so consumers can distinguish it from ordinary stderr diagnostics. Existing stdout behavior remains unchanged: `--json` still emits the final result payload on stdout.
2. **Concurrent state-dir isolation contract** — add regression tests proving that distinct `OPENSQUILLA_STATE_DIR` values acquire independent profile locks, the same state dir still rejects a cross-thread second writer, and an empty state dir loads default `GatewayConfig` values. Document the per-call state-dir pattern for concurrent CLI invocations.

These changes are paired because isolated state plus a structured progress stream form the generic contract needed by subprocess orchestrators.

Non-goals: No engine/event-type changes; no change to profile-lock or `GatewayConfig` runtime semantics; no runtime dependency on pi or any downstream extension.

## Motivation / Downstream Integration

The primary motivating consumer is [`opensquilla-subagent`](https://github.com/phloglucinol/opensquilla-subagent), a public pi extension/package that registers `opensquilla_subagent` and `opensquilla_chain` tools and executes `opensquilla agent --json` as a child process.

Its current v0.2.1 implementation has two workarounds that correspond directly to this PR:

- Both tools use pi's `executionMode: "sequential"`, and the extension reports `ProfileLockBusyError` when another Pi process uses the same OpenSquilla profile. A planned integration can allocate a distinct `OPENSQUILLA_STATE_DIR` per child process, allowing independent calls to run concurrently without sharing profile locks or state.
- Live progress currently polls `.opensquilla-cache/fs-worker` files. The extension documents this as best-effort and notes that concurrent writers make activity attribution unreliable. A planned integration can consume `--event-stream-stderr` instead, using the explicit `_event` marker and flush-per-line JSONL while reserving stdout for the final machine-readable result.

The OpenSquilla implementation remains extension-agnostic. This PR does not import pi code, reference pi at runtime, or copy implementation code from the extension; `opensquilla-subagent` is a concrete downstream consumer that motivated the generic CLI contract.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: This adds a generic subprocess contract motivated by the public `opensquilla-subagent` integration; no OpenSquilla issue currently tracks it.

## Release Note

Release note: Added `--event-stream-stderr` to `opensquilla agent` for incrementally flushed JSONL progress events while keeping the final result on stdout. Documented and regression-tested per-invocation `OPENSQUILLA_STATE_DIR` isolation for concurrent agent processes.

## Tests

Ruff: `ruff check` passes on all changed Python files.

Mypy: the changed runtime files (`agent_cmd.py` and `main.py`) pass. The CI environment installs the `recommended` extra before the full-repository mypy run (the local lightweight environment does not include its optional `lightgbm` dependency).

Pytest:
- `tests/test_cli/test_agent_cmd.py` — 46 passed (includes `--event-stream-stderr` coverage)
- `tests/test_recovery/test_runtime_writer_guard.py` — 6 passed, including 3 new state-dir cases (distinct locks, empty-profile defaults, same-state-dir contention)
- `tests/test_readme_links.py` — 1 passed
- Exact `ubuntu-quality` targeted PR suite from `.github/workflows/ci.yml` — 1412 passed, 25 skipped
- `opensquilla-webui/scripts/check-readme-locales.mjs` — passed for all 6 README locales

Build: N/A (no frontend or packaging changes)

Regression tests: added

Notes: `git diff --check` and ruff check are clean. The state-dir tests live in the existing runtime-writer test module so the Windows historical shard-weight budget remains within its fail-safe threshold. Tests remain offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: no provider credentials or live OpenSquilla/pi integration are required to validate this PR. The CLI subprocess contract is covered with deterministic tests.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, or `tests/_private/` contents are committed. The README example uses disposable `/tmp` paths and placeholder task text only.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A. The linked `opensquilla-subagent` repository is a downstream motivating consumer; no code, rules, fixtures, or text were copied from it into this PR.

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
