### PR TITLE
Propagate thinking_level to direct [llm] config path

### DIFF
--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -3638,6 +3638,18 @@ class TurnRunner:
         if explicit is not None and str(explicit).strip():
             return False
 
+        # [llm] thinking_level: alias accepted alongside thinking for parity
+        # with squilla_router.tiers. Only consulted when thinking is unset.
+        explicit_level = getattr(llm_cfg, "thinking_level", None)
+        parsed_level = self._parse_thinking_level(
+            explicit_level,
+            source="config.thinking_level",
+        )
+        if parsed_level is not None:
+            return parsed_level
+        if explicit_level is not None and str(explicit_level).strip():
+            return False
+
         metadata = getattr(turn, "metadata", {}) or {}
         if not metadata.get("thinking_requested"):
             return False

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -270,6 +270,10 @@ class LlmProviderConfig(BaseSettings):
     # Optional global thinking level: off|minimal|low|medium|high|xhigh|adaptive.
     # When unset, squilla_router may suggest thinking for selected tiers.
     thinking: str | None = None
+    # Alias for thinking: accepts the same values. When both are set,
+    # thinking_level takes precedence. This allows [llm] configs to use
+    # the same field name as squilla_router.tiers for consistency.
+    thinking_level: str | None = None
     # OpenRouter-only: map model id -> upstream provider name. Mapped models
     # send provider.order=[name] so the provider is preferred without disabling
     # OpenRouter fallback.


### PR DESCRIPTION
## Scope

Propagate the `thinking_level` configuration field to the direct `[llm]` config path so that forced-thinking models (e.g. DashScope models that require `enable_thinking=true`) work correctly outside the squilla_router tier path.

Scope boundary:

- Add `thinking_level` as an accepted alias for `thinking` in `LlmProviderConfig`.
- Make `_resolve_turn_thinking` fall back to `thinking_level` when `thinking` is unset.
- Preserve existing precedence: `thinking` wins when both are set.

Non-goals:

- Changing squilla_router tier logic (already correct).
- Modifying provider request serialization or reasoning dialects.
- Adding new thinking levels or changing budget mappings.

## Root Cause

`LlmProviderConfig` only declared a `thinking` field. Users who configured `thinking_level` in their `[llm]` block (matching the field name used in `squilla_router.tiers`) had the value silently ignored by Pydantic. `_resolve_turn_thinking` then returned `False`, so the provider never sent `enable_thinking=true`, and the upstream returned HTTP 400 for forced-thinking models.

The squilla_router tier path was unaffected because it writes `thinking_requested` and `thinking_level` into turn metadata, which `_resolve_turn_thinking` reads separately.

## Behavior After This Change

- `[llm] thinking_level = "high"` enables thinking on the direct config path, matching router-tier behavior.
- `[llm] thinking = "high"` continues to work as before.
- When both are set, `thinking` takes precedence (backward compatible).
- Invalid values in `thinking_level` are handled identically to invalid `thinking` values (logged, thinking disabled).

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: #794

## Release Note

Release note: Accept `thinking_level` in `[llm]` config so forced-thinking models work on the direct provider path without requiring the router.

## Tests

Pytest:

- `pytest tests/test_engine/test_resolve_turn_thinking.py -v` — 6 passed
- `pytest tests/test_llm_ensemble_config.py -k "not asyncio" -v` — 34 passed

Manual verification:

- `LlmProviderConfig(thinking_level="high")` correctly parses the field.
- `_resolve_turn_thinking` returns `ThinkingLevel.HIGH` when only `thinking_level` is set.
- `thinking` takes precedence over `thinking_level` when both are set.
- `thinking_level=None` falls through to router metadata as before.

Regression tests: existing coverage in `test_resolve_turn_thinking.py` passes unchanged.

## Maintainer Live Check

Maintainer live check: no

Surface: engine/config

Suggested optional check: configure `[llm]` with a forced-thinking model and `thinking_level = "high"`, confirm the request includes `enable_thinking=true` and no HTTP 400 is returned.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

Documentation changes: N/A; the field is self-documenting via the config schema and inline comments.

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.