### PR TITLE
Fix image generation configuration

### DIFF
--- a/opensquilla-webui/src/components/setup/SetupCapabilitiesPanel.vue
+++ b/opensquilla-webui/src/components/setup/SetupCapabilitiesPanel.vue
@@ -100,7 +100,7 @@ const emit = defineEmits<{
   updateField: [group: 'search' | 'memory' | 'image' | 'audio', key: string, value: string | number | boolean]
   searchProviderChange: []
   memoryProviderChange: []
-  imageProviderChange: []
+  imageProviderChange: [providerId: string]
   saveSearch: []
   saveMemory: []
   saveImage: []
@@ -119,8 +119,7 @@ function onMemoryProviderSelect(event: Event) {
 }
 
 function onImageProviderSelect(event: Event) {
-  emit('updateField', 'image', 'provider', (event.target as HTMLSelectElement).value)
-  emit('imageProviderChange')
+  emit('imageProviderChange', (event.target as HTMLSelectElement).value)
 }
 </script>
 

--- a/opensquilla-webui/src/composables/setup/useSetupCapabilitiesForm.test.ts
+++ b/opensquilla-webui/src/composables/setup/useSetupCapabilitiesForm.test.ts
@@ -1,28 +1,343 @@
-import { describe, it, expect } from 'vitest'
-import { buildImagePayload, parseImageFallbacks } from './useSetupCapabilitiesForm'
+import { describe, expect, it } from 'vitest'
+import {
+  buildImagePayload,
+  imageModelForDisplay,
+  imageModelRefForPayload,
+  parseImageFallbacks,
+  useSetupCapabilitiesForm,
+} from './useSetupCapabilitiesForm'
 
-// Image generation: size / output_format / fallbacks are honored at runtime but
-// were unreachable from the UI. These cover the payload shaping for the new fields.
+const imageProviders = [
+  {
+    providerId: 'openai',
+    envKey: 'OPENAI_API_KEY',
+    requiresApiKey: true,
+    defaultBaseUrl: 'https://api.openai.com/v1',
+    defaultModel: 'gpt-image-1',
+  },
+  {
+    providerId: 'openrouter',
+    envKey: 'OPENROUTER_API_KEY',
+    requiresApiKey: true,
+    defaultBaseUrl: 'https://openrouter.ai/api/v1',
+    defaultModel: 'google/gemini-3.1-flash-image-preview',
+  },
+]
+
+const baseValues = {
+  providerId: 'openrouter',
+  enabled: true,
+  primary: 'google/gemini-3.1-flash-image-preview',
+  apiKey: '',
+  apiKeyEnv: '',
+  baseUrl: '',
+  size: '1024x1024',
+  outputFormat: 'png',
+  fallbacks: '',
+}
+
+describe('image model references', () => {
+  it('removes exactly one routing prefix from the provider-local model name', () => {
+    expect(imageModelForDisplay(
+      'openrouter',
+      'openrouter/google/gemini-3.1-flash-image-preview',
+    )).toBe('google/gemini-3.1-flash-image-preview')
+    expect(imageModelForDisplay(
+      'openrouter',
+      'openrouter/openrouter/auto',
+    )).toBe('openrouter/auto')
+  })
+
+  it('adds exactly one provider prefix to the RPC primary reference', () => {
+    expect(imageModelRefForPayload(
+      'openrouter',
+      'google/gemini-3.1-flash-image-preview',
+    )).toBe('openrouter/google/gemini-3.1-flash-image-preview')
+    expect(imageModelRefForPayload(
+      'openrouter',
+      'openrouter/google/gemini-3.1-flash-image-preview',
+    )).toBe('openrouter/google/gemini-3.1-flash-image-preview')
+    expect(imageModelRefForPayload(
+      'openrouter',
+      'openrouter/auto',
+    )).toBe('openrouter/openrouter/auto')
+    expect(imageModelRefForPayload(
+      'openai',
+      'openai/gpt-image-1',
+    )).toBe('openai/gpt-image-1')
+  })
+})
 
 describe('parseImageFallbacks', () => {
-  it('splits on commas and newlines, trims, and drops empties', () => {
+  it('splits on commas and newlines, canonicalizes OpenRouter auto, and drops empties', () => {
     expect(parseImageFallbacks('a/b, c/d\n , e/f')).toEqual(['a/b', 'c/d', 'e/f'])
+    expect(parseImageFallbacks('openrouter/auto')).toEqual(['openrouter/openrouter/auto'])
     expect(parseImageFallbacks('   ')).toEqual([])
   })
 })
 
-describe('buildImagePayload — size/format/fallbacks', () => {
-  const base = { providerId: 'openrouter', enabled: true, primary: 'openrouter/x', apiKey: '', apiKeyEnv: '', baseUrl: '' }
+describe('buildImagePayload', () => {
+  it('normalizes primary and includes size, format, and explicitly edited fallbacks', () => {
+    const payload = buildImagePayload({
+      ...baseValues,
+      size: '1536x1024',
+      outputFormat: 'webp',
+      fallbacks: 'openai/gpt-image-1, openrouter/google/gemini-2.5-flash-image',
+    }, new Set(['fallbacks'] as const))
 
-  it('includes size, outputFormat, and parsed fallbacks', () => {
-    const p = buildImagePayload({ ...base, size: '1536x1024', outputFormat: 'webp', fallbacks: 'openai/gpt-image-1, openrouter/y' })
-    expect(p.size).toBe('1536x1024')
-    expect(p.outputFormat).toBe('webp')
-    expect(p.fallbacks).toEqual(['openai/gpt-image-1', 'openrouter/y'])
+    expect(payload).toMatchObject({
+      primary: 'openrouter/google/gemini-3.1-flash-image-preview',
+      size: '1536x1024',
+      outputFormat: 'webp',
+      fallbacks: ['openai/gpt-image-1', 'openrouter/google/gemini-2.5-flash-image'],
+    })
   })
 
-  it('sends an empty fallbacks array when none entered (backend keeps current)', () => {
-    const p = buildImagePayload({ ...base, size: '1024x1024', outputFormat: 'png', fallbacks: '' })
-    expect(p.fallbacks).toEqual([])
+  it('keeps a pasted canonical primary reference canonical in the payload', () => {
+    const payload = buildImagePayload({
+      ...baseValues,
+      primary: 'openrouter/google/gemini-3.1-flash-image-preview',
+    })
+
+    expect(payload.primary).toBe('openrouter/google/gemini-3.1-flash-image-preview')
+  })
+
+  it('omits untouched base URL and fallbacks so a save preserves persisted values', () => {
+    const payload = buildImagePayload({
+      ...baseValues,
+      baseUrl: 'https://openrouter.example.test/v1',
+      fallbacks: 'openai/gpt-image-1',
+    })
+
+    expect(payload).not.toHaveProperty('baseUrl')
+    expect(payload).not.toHaveProperty('fallbacks')
+  })
+
+  it('sends explicit empty values when base URL and fallbacks are cleared', () => {
+    const payload = buildImagePayload(
+      baseValues,
+      new Set(['baseUrl', 'fallbacks'] as const),
+    )
+
+    expect(payload.baseUrl).toBe('')
+    expect(payload.fallbacks).toEqual([])
+    expect(payload).not.toHaveProperty('clearFallbacks')
+
+    const explicitClear = buildImagePayload(
+      baseValues,
+      new Set(['fallbacks'] as const),
+      { clearFallbacks: true },
+    )
+    expect(explicitClear.clearFallbacks).toBe(true)
+  })
+
+  it('does not send a fallback clear flag when a replacement is nonempty', () => {
+    const payload = buildImagePayload({
+      ...baseValues,
+      fallbacks: 'openai/gpt-image-1',
+    }, new Set(['fallbacks'] as const), { clearFallbacks: true })
+
+    expect(payload.fallbacks).toEqual(['openai/gpt-image-1'])
+    expect(payload).not.toHaveProperty('clearFallbacks')
+  })
+
+  it('never sends both direct and env credentials from inconsistent input', () => {
+    const payload = buildImagePayload({
+      ...baseValues,
+      apiKey: 'sk-direct',
+      apiKeyEnv: 'OPENROUTER_API_KEY',
+    }, new Set(['apiKey', 'apiKeyEnv'] as const))
+
+    expect(payload.apiKey).toBe('sk-direct')
+    expect(payload).not.toHaveProperty('apiKeyEnv')
+    expect(payload.credentialMode).toBe('direct')
+  })
+
+  it('adds a credential mode only when a credential field was edited', () => {
+    const untouched = buildImagePayload({
+      ...baseValues,
+      apiKey: 'sk-untracked',
+      apiKeyEnv: 'UNTRACKED_ENV',
+    })
+    expect(untouched).not.toHaveProperty('credentialMode')
+    expect(untouched).not.toHaveProperty('apiKey')
+    expect(untouched).not.toHaveProperty('apiKeyEnv')
+
+    const env = buildImagePayload({
+      ...baseValues,
+      apiKeyEnv: 'OPENROUTER_API_KEY',
+    }, new Set(['apiKeyEnv'] as const))
+    expect(env).toMatchObject({
+      credentialMode: 'env',
+      apiKeyEnv: 'OPENROUTER_API_KEY',
+    })
+  })
+})
+
+describe('useSetupCapabilitiesForm image hydration', () => {
+  it('uses the primary provider over a stale credential-provider status', () => {
+    const form = useSetupCapabilitiesForm()
+
+    form.initImageFromConfig({}, {
+      imageGenerationProvider: 'openai',
+      imageGenerationPrimary: 'openrouter/google/gemini-3.1-flash-image-preview',
+    }, imageProviders)
+
+    expect(form.selectedImageProvider.value).toBe('openrouter')
+    expect(form.imagePrimaryValue.value).toBe('google/gemini-3.1-flash-image-preview')
+    expect(form.imagePayload().primary)
+      .toBe('openrouter/google/gemini-3.1-flash-image-preview')
+  })
+
+  it('keeps a redacted saved key as boolean state without filling the key input', () => {
+    const form = useSetupCapabilitiesForm()
+
+    form.initImageFromConfig({
+      image_generation: {
+        providers: {
+          openrouter: {
+            api_key: '[redacted]',
+            api_key_env: 'STALE_OPENROUTER_ENV',
+          },
+        },
+      },
+    }, {
+      imageGenerationProvider: 'openrouter',
+      imageGenerationPrimary: 'openrouter/google/gemini-3.1-flash-image-preview',
+    }, imageProviders)
+
+    expect(form.imageKeyConfiguredValue.value).toBe(true)
+    expect(form.imageApiKeyValue.value).toBe('')
+    expect(form.imageApiKeyEnvValue.value).toBe('')
+    expect(form.imagePayload()).not.toHaveProperty('apiKey')
+    expect(form.imagePayload()).not.toHaveProperty('apiKeyEnv')
+    expect(form.imagePayload()).not.toHaveProperty('credentialMode')
+  })
+})
+
+describe('useSetupCapabilitiesForm provider drafts', () => {
+  it('restores each provider model and endpoint across the 0.5.0 event order', () => {
+    const form = useSetupCapabilitiesForm()
+    const openrouter = imageProviders[1]
+
+    form.initImageFromConfig({
+      image_generation: {
+        providers: {
+          openai: { base_url: 'https://saved.openai.example/v1' },
+          openrouter: { base_url: 'https://saved.openrouter.example/v1' },
+        },
+      },
+    }, {
+      imageGenerationProvider: 'openai',
+      imageGenerationPrimary: 'openai/gpt-image-1',
+    }, imageProviders)
+    form.updateField('image', 'primary', 'custom-openai-image')
+
+    // The old panel first emitted updateField(provider), then this dedicated
+    // event. Both now go through the same idempotent switch operation.
+    form.updateField('image', 'provider', 'openrouter')
+    expect(form.imagePrimaryValue.value).toBe('google/gemini-3.1-flash-image-preview')
+    expect(form.imageBaseUrlValue.value).toBe('https://saved.openrouter.example/v1')
+    form.onImageProviderChange(openrouter)
+
+    expect(form.selectedImageProvider.value).toBe('openrouter')
+    expect(form.imagePrimaryValue.value).toBe('google/gemini-3.1-flash-image-preview')
+    expect(form.imageBaseUrlValue.value).toBe('https://saved.openrouter.example/v1')
+
+    form.updateField('image', 'provider', 'openai')
+    expect(form.imagePrimaryValue.value).toBe('custom-openai-image')
+    expect(form.imageBaseUrlValue.value).toBe('https://saved.openai.example/v1')
+  })
+
+  it('does not carry a transient pasted key to another provider or back again', () => {
+    const form = useSetupCapabilitiesForm()
+
+    form.initImageFromConfig({}, {
+      imageGenerationProvider: 'openai',
+      imageGenerationPrimary: 'openai/gpt-image-1',
+    }, imageProviders)
+    form.updateField('image', 'apiKey', 'sk-transient')
+    expect(form.imagePayload().apiKey).toBe('sk-transient')
+
+    form.onImageProviderChange(imageProviders[1])
+    expect(form.imageApiKeyValue.value).toBe('')
+    expect(form.imagePayload()).not.toHaveProperty('apiKey')
+
+    form.onImageProviderChange(imageProviders[0])
+    expect(form.imageApiKeyValue.value).toBe('')
+    expect(form.imagePayload()).not.toHaveProperty('apiKey')
+  })
+
+  it('keeps direct and env credential edits mutually exclusive in both directions', () => {
+    const form = useSetupCapabilitiesForm()
+
+    form.initImageFromConfig({}, {
+      imageGenerationProvider: 'openrouter',
+      imageGenerationPrimary: 'openrouter/google/gemini-3.1-flash-image-preview',
+    }, imageProviders)
+
+    form.updateField('image', 'apiKey', 'sk-direct')
+    expect(form.imageApiKeyEnvValue.value).toBe('')
+    expect(form.imagePayload()).toMatchObject({
+      apiKey: 'sk-direct',
+      credentialMode: 'direct',
+    })
+    expect(form.imagePayload()).not.toHaveProperty('apiKeyEnv')
+
+    form.updateField('image', 'apiKeyEnv', 'CUSTOM_OPENROUTER_KEY')
+    expect(form.imageApiKeyValue.value).toBe('')
+    expect(form.imagePayload()).toMatchObject({
+      apiKeyEnv: 'CUSTOM_OPENROUTER_KEY',
+      credentialMode: 'env',
+    })
+    expect(form.imagePayload()).not.toHaveProperty('apiKey')
+
+    form.updateField('image', 'apiKey', '')
+    expect(form.imagePayload()).toMatchObject({ credentialMode: 'direct' })
+    expect(form.imagePayload()).not.toHaveProperty('apiKey')
+  })
+
+  it('distinguishes untouched optional fields from explicit clearing', () => {
+    const form = useSetupCapabilitiesForm()
+
+    form.initImageFromConfig({
+      image_generation: {
+        fallbacks: ['openai/gpt-image-1'],
+        providers: {
+          openrouter: { base_url: 'https://saved.openrouter.example/v1' },
+        },
+      },
+    }, {
+      imageGenerationProvider: 'openrouter',
+      imageGenerationPrimary: 'openrouter/google/gemini-3.1-flash-image-preview',
+    }, imageProviders)
+
+    expect(form.imagePayload()).not.toHaveProperty('baseUrl')
+    expect(form.imagePayload()).not.toHaveProperty('fallbacks')
+
+    form.updateField('image', 'baseUrl', '')
+    form.updateField('image', 'fallbacks', '')
+    expect(form.imagePayload()).toMatchObject({
+      baseUrl: '',
+      fallbacks: [],
+      clearFallbacks: true,
+    })
+
+    form.onImageProviderChange(imageProviders[0])
+    expect(form.imagePayload()).toMatchObject({ fallbacks: [], clearFallbacks: true })
+    expect(form.imagePayload()).not.toHaveProperty('baseUrl')
+  })
+
+  it('does not mark an initially empty fallback field as an explicit clear', () => {
+    const form = useSetupCapabilitiesForm()
+
+    form.initImageFromConfig({}, {
+      imageGenerationProvider: 'openrouter',
+      imageGenerationPrimary: 'openrouter/google/gemini-3.1-flash-image-preview',
+    }, imageProviders)
+    form.updateField('image', 'fallbacks', '')
+
+    expect(form.imagePayload().fallbacks).toEqual([])
+    expect(form.imagePayload()).not.toHaveProperty('clearFallbacks')
   })
 })

--- a/opensquilla-webui/src/composables/setup/useSetupCapabilitiesForm.ts
+++ b/opensquilla-webui/src/composables/setup/useSetupCapabilitiesForm.ts
@@ -34,7 +34,7 @@ interface ConfigData {
     size?: string
     output_format?: string
     fallbacks?: string[]
-    providers?: Record<string, { api_key_env?: string; base_url?: string }>
+    providers?: Record<string, { api_key?: string; api_key_env?: string; base_url?: string }>
   }
 }
 
@@ -119,13 +119,58 @@ export interface ImageFormValues {
   fallbacks: string
 }
 
+export type ImageTouchedField = 'apiKey' | 'apiKeyEnv' | 'baseUrl' | 'fallbacks'
+
+interface ImagePayloadOptions {
+  clearFallbacks?: boolean
+}
+
+interface ImageProviderDraft {
+  primary: string
+  apiKeyEnv: string
+  baseUrl: string
+  keyConfigured: boolean
+  touched: Set<ImageTouchedField>
+}
+
 // Fallbacks are entered as one comma/newline-separated string; split to the
 // provider/model array the backend expects.
 export function parseImageFallbacks(raw: string): string[] {
   return raw
     .split(/[\n,]/)
     .map((s) => s.trim())
+    .map((model) => model === 'openrouter/auto' ? 'openrouter/openrouter/auto' : model)
     .filter(Boolean)
+}
+
+export function imageModelForDisplay(providerId: string, raw: string): string {
+  const provider = providerId.trim()
+  const model = raw.trim()
+  const prefix = provider ? `${provider}/` : ''
+  return prefix && model.startsWith(prefix)
+    ? model.slice(prefix.length).trim()
+    : model
+}
+
+function isCanonicalImageModelRef(providerId: string, raw: string): boolean {
+  const provider = providerId.trim()
+  const model = raw.trim()
+  const prefix = provider ? `${provider}/` : ''
+  if (!prefix || !model.startsWith(prefix)) return false
+
+  const nestedModel = model.slice(prefix.length)
+  // `openrouter/auto` is a valid OpenRouter wire model, not a routing prefix
+  // followed by the local model `auto`. Provider catalogs use a second slash
+  // for canonical OpenRouter references such as `openrouter/google/...`.
+  return provider !== 'openrouter' || nestedModel.includes('/')
+}
+
+export function imageModelRefForPayload(providerId: string, raw: string): string {
+  const provider = providerId.trim()
+  const model = isCanonicalImageModelRef(provider, raw)
+    ? imageModelForDisplay(provider, raw)
+    : raw.trim()
+  return provider && model ? `${provider}/${model}` : ''
 }
 
 export function buildSearchPayload(values: SearchFormValues): Record<string, unknown> {
@@ -150,19 +195,36 @@ export function buildMemoryPayload(values: MemoryFormValues): Record<string, unk
   return params
 }
 
-export function buildImagePayload(values: ImageFormValues): Record<string, unknown> {
+export function buildImagePayload(
+  values: ImageFormValues,
+  touched: ReadonlySet<ImageTouchedField> = new Set(),
+  options: ImagePayloadOptions = {},
+): Record<string, unknown> {
+  const apiKey = values.apiKey.trim()
+  const apiKeyEnv = values.apiKeyEnv.trim()
   const params: Record<string, unknown> = {
-    providerId: values.providerId,
+    providerId: values.providerId.trim(),
     enabled: values.enabled,
   }
-  if (values.primary) params.primary = values.primary
-  if (values.apiKey) params.apiKey = values.apiKey
-  if (values.apiKeyEnv) params.apiKeyEnv = values.apiKeyEnv
-  if (values.baseUrl) params.baseUrl = values.baseUrl
-  if (values.size) params.size = values.size
-  if (values.outputFormat) params.outputFormat = values.outputFormat
-  // Empty array is "keep current" backend-side; send the parsed list either way.
-  params.fallbacks = parseImageFallbacks(values.fallbacks)
+  const primary = imageModelRefForPayload(values.providerId, values.primary)
+  if (primary) params.primary = primary
+  // UI edits keep these mutually exclusive. Prefer the direct key as a final
+  // payload guard if a caller constructs an inconsistent form value.
+  if (touched.has('apiKey')) {
+    params.credentialMode = 'direct'
+    if (apiKey) params.apiKey = apiKey
+  } else if (touched.has('apiKeyEnv')) {
+    params.credentialMode = 'env'
+    if (apiKeyEnv) params.apiKeyEnv = apiKeyEnv
+  }
+  if (touched.has('baseUrl')) params.baseUrl = values.baseUrl.trim()
+  if (values.size.trim()) params.size = values.size.trim()
+  if (values.outputFormat.trim()) params.outputFormat = values.outputFormat.trim()
+  if (touched.has('fallbacks')) {
+    const fallbacks = parseImageFallbacks(values.fallbacks)
+    params.fallbacks = fallbacks
+    if (options.clearFallbacks && fallbacks.length === 0) params.clearFallbacks = true
+  }
   return params
 }
 
@@ -192,6 +254,11 @@ export function useSetupCapabilitiesForm() {
   const imageSize = ref('1024x1024')
   const imageOutputFormat = ref('png')
   const imageFallbacks = ref('')
+  const imageKeyConfigured = ref(false)
+  const imageTouchedFields = ref<Set<ImageTouchedField>>(new Set())
+  const imageGlobalTouchedFields = ref<Set<ImageTouchedField>>(new Set())
+  const imageClearFallbacks = ref(false)
+  const imageProviderDrafts = new Map<string, ImageProviderDraft>()
 
   const searchSerialized = computed(() => JSON.stringify([
     searchProvider.value, searchMaxResults.value, searchApiKey.value, searchApiKeyEnv.value,
@@ -224,6 +291,10 @@ export function useSetupCapabilitiesForm() {
   const searchApiKeyEnvValue = computed(() => searchApiKeyEnv.value)
   const memoryApiKeyEnvValue = computed(() => memoryApiKeyEnv.value)
   const imageApiKeyEnvValue = computed(() => imageApiKeyEnv.value)
+  const imageApiKeyValue = computed(() => imageApiKey.value)
+  const imagePrimaryValue = computed(() => imagePrimary.value)
+  const imageBaseUrlValue = computed(() => imageBaseUrl.value)
+  const imageKeyConfiguredValue = computed(() => imageKeyConfigured.value)
   const memoryRemoteOptionsOpen = computed(() => memoryProvider.value !== 'auto' || Boolean(memoryModel.value || memoryApiKey.value || memoryApiKeyEnv.value || memoryBaseUrl.value))
   const memoryRemoteOptionsSummary = computed(() => i18n.global.t(memoryProvider.value === 'auto' ? 'setup.memory.remoteFallbackOptions' : 'setup.memory.connectionOptions'))
   const memoryModelPlaceholder = computed(() => memoryProvider.value === 'ollama' ? 'nomic-embed-text' : (memoryRemoteControlEnabled.value ? 'remote-embedding-model' : i18n.global.t('setup.memory.notUsedByProvider')))
@@ -259,18 +330,117 @@ export function useSetupCapabilitiesForm() {
 
   function initImageFromConfig(config: ConfigData, status: StatusData, providers: ProviderSpec[]) {
     const imageConfig = config.image_generation || {}
-    const selected = status.imageGenerationProvider || (status.imageGenerationPrimary || '').split('/')[0] || providers[0]?.providerId || 'openrouter'
+    const primaryRef = (status.imageGenerationPrimary || '').trim()
+    const primaryProvider = primaryRef.split('/', 1)[0]
+    const selected = providers.find(p => p.providerId === primaryProvider)?.providerId
+      || providers.find(p => p.providerId === status.imageGenerationProvider)?.providerId
+      || providers[0]?.providerId
+      || 'openrouter'
+    imageProviderDrafts.clear()
+    imageGlobalTouchedFields.value = new Set()
+    imageClearFallbacks.value = false
+    for (const spec of providers) {
+      const providerConfig = (imageConfig.providers || {})[spec.providerId] || {}
+      const configuredPrimary = spec.providerId === primaryProvider ? primaryRef : ''
+      const keyConfigured = Boolean(providerConfig.api_key)
+      imageProviderDrafts.set(spec.providerId, {
+        primary: imageModelForDisplay(
+          spec.providerId,
+          configuredPrimary || spec.defaultModel || '',
+        ),
+        apiKeyEnv: keyConfigured
+          ? ''
+          : (providerConfig.api_key_env || (spec.requiresApiKey ? spec.envKey || '' : '')),
+        baseUrl: providerConfig.base_url || spec.defaultBaseUrl || '',
+        keyConfigured,
+        touched: new Set(),
+      })
+    }
     imageProvider.value = selected
-    imagePrimary.value = status.imageGenerationPrimary || ''
-    const providerConfig = (imageConfig.providers || {})[selected] || {}
-    imageApiKeyEnv.value = providerConfig.api_key_env || ''
-    imageBaseUrl.value = providerConfig.base_url || ''
+    applyImageProviderDraft(
+      imageProviderDrafts.get(selected) || createDefaultImageProviderDraft(
+        providers.find(p => p.providerId === selected),
+      ),
+    )
     imageEnabled.value = status.imageGenerationEnabled !== false
     imageSize.value = imageConfig.size || '1024x1024'
     imageOutputFormat.value = imageConfig.output_format || 'png'
     imageFallbacks.value = (imageConfig.fallbacks || []).join(', ')
-    imageApiKey.value = ''
     imageBaseline.value = imageSerialized.value
+  }
+
+  function createDefaultImageProviderDraft(
+    spec: ProviderSpec | null | undefined,
+  ): ImageProviderDraft {
+    return {
+      primary: imageModelForDisplay(spec?.providerId || '', spec?.defaultModel || ''),
+      apiKeyEnv: spec?.requiresApiKey ? spec.envKey || '' : '',
+      baseUrl: spec?.defaultBaseUrl || '',
+      keyConfigured: false,
+      touched: new Set(),
+    }
+  }
+
+  function applyImageProviderDraft(draft: ImageProviderDraft) {
+    imagePrimary.value = draft.primary
+    imageApiKey.value = ''
+    imageApiKeyEnv.value = draft.apiKeyEnv
+    imageBaseUrl.value = draft.baseUrl
+    imageKeyConfigured.value = draft.keyConfigured
+    imageTouchedFields.value = new Set(draft.touched)
+  }
+
+  function saveCurrentImageProviderDraft() {
+    const draft = imageProviderDrafts.get(imageProvider.value)
+    if (!draft) return
+    draft.primary = imagePrimary.value
+    draft.baseUrl = imageBaseUrl.value
+    draft.touched = new Set(imageTouchedFields.value)
+    // A pasted key is write-only and must not survive a provider switch. Keep
+    // the prior env-reference draft when discarding that transient secret.
+    if (imageApiKey.value.trim()) {
+      draft.touched.delete('apiKey')
+      draft.touched.delete('apiKeyEnv')
+    } else {
+      draft.apiKeyEnv = imageApiKeyEnv.value
+    }
+  }
+
+  function switchImageProvider(
+    providerId: string,
+    spec?: ProviderSpec | null,
+  ) {
+    const nextProviderId = providerId.trim()
+    if (!nextProviderId) return
+
+    if (nextProviderId === imageProvider.value) {
+      // The 0.5.0 panel emitted updateField(provider) before the dedicated
+      // provider-change event. The first event now performs the switch; the
+      // second must be harmless while still allowing a pre-init caller to
+      // supply the provider defaults that updateField did not have.
+      if (!imageProviderDrafts.has(nextProviderId)) {
+        const draft = createDefaultImageProviderDraft(spec)
+        imageProviderDrafts.set(nextProviderId, draft)
+        applyImageProviderDraft(draft)
+      }
+      return
+    }
+
+    saveCurrentImageProviderDraft()
+    const draft = imageProviderDrafts.get(nextProviderId)
+      || createDefaultImageProviderDraft(spec)
+    imageProviderDrafts.set(nextProviderId, draft)
+    imageProvider.value = nextProviderId
+    applyImageProviderDraft(draft)
+  }
+
+  function touchImageField(field: ImageTouchedField) {
+    const fields = field === 'fallbacks'
+      ? imageGlobalTouchedFields
+      : imageTouchedFields
+    const next = new Set(fields.value)
+    next.add(field)
+    fields.value = next
   }
 
   function onSearchProviderChange(spec: ProviderSpec | null | undefined) {
@@ -290,9 +460,7 @@ export function useSetupCapabilitiesForm() {
 
   function onImageProviderChange(spec: ProviderSpec | null | undefined) {
     if (!spec) return
-    imageApiKeyEnv.value = spec.requiresApiKey ? (spec.envKey || '') : ''
-    if (!imagePrimary.value) imagePrimary.value = spec.defaultModel || ''
-    if (!imageBaseUrl.value) imageBaseUrl.value = spec.defaultBaseUrl || ''
+    switchImageProvider(spec.providerId, spec)
   }
 
   function updateField(
@@ -320,15 +488,38 @@ export function useSetupCapabilitiesForm() {
       else if (key === 'onnxDir') memoryOnnxDir.value = String(value)
       return
     }
-    if (key === 'provider') imageProvider.value = String(value)
+    if (key === 'provider') switchImageProvider(String(value))
     else if (key === 'primary') imagePrimary.value = String(value)
-    else if (key === 'apiKey') imageApiKey.value = String(value)
-    else if (key === 'apiKeyEnv') imageApiKeyEnv.value = String(value)
-    else if (key === 'baseUrl') imageBaseUrl.value = String(value)
+    else if (key === 'apiKey') {
+      imageApiKey.value = String(value)
+      imageApiKeyEnv.value = ''
+      const next = new Set(imageTouchedFields.value)
+      next.delete('apiKeyEnv')
+      next.add('apiKey')
+      imageTouchedFields.value = next
+    } else if (key === 'apiKeyEnv') {
+      imageApiKeyEnv.value = String(value)
+      imageApiKey.value = ''
+      const next = new Set(imageTouchedFields.value)
+      next.delete('apiKey')
+      next.add('apiKeyEnv')
+      imageTouchedFields.value = next
+    } else if (key === 'baseUrl') {
+      imageBaseUrl.value = String(value)
+      touchImageField('baseUrl')
+    }
     else if (key === 'enabled') imageEnabled.value = Boolean(value)
     else if (key === 'size') imageSize.value = String(value)
     else if (key === 'outputFormat') imageOutputFormat.value = String(value)
-    else if (key === 'fallbacks') imageFallbacks.value = String(value)
+    else if (key === 'fallbacks') {
+      const nextFallbacks = String(value)
+      const hadFallbacks = parseImageFallbacks(imageFallbacks.value).length > 0
+      const hasFallbacks = parseImageFallbacks(nextFallbacks).length > 0
+      imageFallbacks.value = nextFallbacks
+      if (hasFallbacks) imageClearFallbacks.value = false
+      else if (hadFallbacks) imageClearFallbacks.value = true
+      touchImageField('fallbacks')
+    }
   }
 
   function searchPayload(): Record<string, unknown> {
@@ -356,6 +547,10 @@ export function useSetupCapabilitiesForm() {
   }
 
   function imagePayload(): Record<string, unknown> {
+    const touchedFields = new Set([
+      ...imageTouchedFields.value,
+      ...imageGlobalTouchedFields.value,
+    ])
     return buildImagePayload({
       providerId: imageProvider.value,
       enabled: imageEnabled.value,
@@ -366,7 +561,7 @@ export function useSetupCapabilitiesForm() {
       size: imageSize.value,
       outputFormat: imageOutputFormat.value,
       fallbacks: imageFallbacks.value,
-    })
+    }, touchedFields, { clearFallbacks: imageClearFallbacks.value })
   }
 
   function createPanel(context: CapabilitiesPanelContext) {
@@ -457,6 +652,10 @@ export function useSetupCapabilitiesForm() {
     searchApiKeyEnvValue,
     memoryApiKeyEnvValue,
     imageApiKeyEnvValue,
+    imageApiKeyValue,
+    imagePrimaryValue,
+    imageBaseUrlValue,
+    imageKeyConfiguredValue,
     memoryRemoteOptionsOpen,
     memoryRemoteOptionsSummary,
     memoryModelPlaceholder,

--- a/opensquilla-webui/src/composables/setup/useSetupCatalog.ts
+++ b/opensquilla-webui/src/composables/setup/useSetupCatalog.ts
@@ -280,7 +280,10 @@ interface ConfigData {
     }
   }
   image_generation?: {
-    providers?: Record<string, { api_key_env?: string; base_url?: string }>
+    size?: string
+    output_format?: string
+    fallbacks?: string[]
+    providers?: Record<string, { api_key?: string; api_key_env?: string; base_url?: string }>
   }
   audio?: {
     enabled?: boolean
@@ -2355,8 +2358,10 @@ function onMemoryProviderChange() {
   capabilitiesForm.onMemoryProviderChange(memorySpec.value, memoryApiKeyEnabled.value)
 }
 
-function onImageProviderChange() {
-  capabilitiesForm.onImageProviderChange(imageSpec.value)
+function onImageProviderChange(providerId: string) {
+  capabilitiesForm.onImageProviderChange(
+    imageProviders.value.find(provider => provider.providerId === providerId),
+  )
 }
 
 function updateCapabilityField(
@@ -2417,6 +2422,11 @@ function searchStatusText(): string {
 function _imageGenerationStatusText(): string {
   if (status.value.imageGenerationEnabled === false) {
     return t('setup.image.statusDisabled')
+  }
+  const detail = (status.value.sectionDetails || {}).image_generation || {}
+  const actionableDetail = String(detail.detail || '').trim()
+  if ((detail.blocking || detail.actionRequired || detail.status === 'unknown') && actionableDetail) {
+    return actionableDetail
   }
   if (status.value.imageGenerationConfigured === true) {
     if (status.value.imageGenerationSource === 'llm_fallback') {

--- a/src/opensquilla/gateway/rpc_onboarding.py
+++ b/src/opensquilla/gateway/rpc_onboarding.py
@@ -1308,17 +1308,25 @@ async def _image_generation_configure(params: Any, ctx: RpcContext) -> dict[str,
     cfg = _active_config(ctx)
     fallbacks = params.get("fallbacks") if isinstance(params, dict) else None
     with _validation_error("onboarding.imageGeneration.invalid"):
+        if fallbacks is not None and not isinstance(fallbacks, list):
+            raise ValueError("fallbacks must be a list of provider/model references")
         res = upsert_image_generation_provider(
             cfg,
             provider_id=provider_id,
             primary=params.get("primary", "") if isinstance(params, dict) else "",
             api_key=params.get("apiKey", "") if isinstance(params, dict) else "",
             api_key_env=params.get("apiKeyEnv", "") if isinstance(params, dict) else "",
-            base_url=params.get("baseUrl", "") if isinstance(params, dict) else "",
+            base_url=params.get("baseUrl") if isinstance(params, dict) else None,
             enabled=params.get("enabled", True) if isinstance(params, dict) else True,
             size=params.get("size", "") if isinstance(params, dict) else "",
             output_format=params.get("outputFormat", "") if isinstance(params, dict) else "",
-            fallbacks=list(fallbacks) if isinstance(fallbacks, list) else None,
+            fallbacks=list(fallbacks) if fallbacks is not None else None,
+            clear_fallbacks=(
+                params.get("clearFallbacks", False) if isinstance(params, dict) else False
+            ),
+            credential_mode=(
+                params.get("credentialMode") if isinstance(params, dict) else None
+            ),
         )
     # Persist first: if the write fails, the live config is untouched and
     # memory/disk stay consistent. Tool syncs run only on applied state.

--- a/src/opensquilla/onboarding/image_generation_specs.py
+++ b/src/opensquilla/onboarding/image_generation_specs.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from opensquilla.provider.image_generation_policy import (
+    IMAGE_GENERATION_OFFICIAL_BASE_URLS,
+)
+
 FieldType = Literal["text", "password", "select", "bool"]
 
 
@@ -42,14 +46,14 @@ _IMAGE_PROVIDER_DATA: dict[str, dict[str, Any]] = {
     "openai": {
         "label": "OpenAI Images",
         "env_key": "OPENAI_API_KEY",
-        "default_base_url": "https://api.openai.com/v1",
+        "default_base_url": IMAGE_GENERATION_OFFICIAL_BASE_URLS["openai"],
         "default_model": "openai/gpt-image-1",
         "suggested_models": ("openai/gpt-image-1",),
     },
     "openrouter": {
         "label": "OpenRouter Images",
         "env_key": "OPENROUTER_API_KEY",
-        "default_base_url": "https://openrouter.ai/api/v1",
+        "default_base_url": IMAGE_GENERATION_OFFICIAL_BASE_URLS["openrouter"],
         "default_model": "openrouter/google/gemini-3.1-flash-image-preview",
         "suggested_models": ("openrouter/google/gemini-3.1-flash-image-preview",),
     },

--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -50,6 +50,12 @@ from opensquilla.onboarding.redaction import (
 )
 from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
 from opensquilla.provider.environment import environment_value
+from opensquilla.provider.image_generation_policy import (
+    conflicting_image_generation_endpoint_provider,
+    image_generation_llm_endpoint_allows_credential_reuse,
+    is_valid_image_generation_base_url,
+    parse_image_generation_model_ref,
+)
 from opensquilla.provider.preset_registry import ProviderPreset, get_preset
 from opensquilla.router_tiers import (
     DEFAULT_TEXT_TIER,
@@ -1328,30 +1334,82 @@ def _image_generation_api_key_source(
         return "explicit"
     if env_key and os.environ.get(env_key):
         return "env"
-    # The primary LLM key is a credential for the LLM's endpoint only; a
-    # save that would bind it to a different image endpoint origin must fail
-    # closed so the operator enters a dedicated key. This mirrors the
-    # resolution-time gate in provider/image_generation.py: an llm base_url
-    # equal to the pydantic field default is derived for another provider,
-    # not chosen, and means the matched provider's own default endpoint.
-    field = type(config.llm).model_fields.get("base_url")
-    derived_default = str(getattr(field, "default", "") or "") if field is not None else ""
-    stored_llm_base = str(config.llm.base_url or "")
-    llm_base_url = (
-        stored_llm_base if stored_llm_base != derived_default else ""
-    ) or default_base_url
-    if (
-        config.llm.provider == provider_id
-        and config.llm.api_key
-        and base_url_allows_credential_reuse(llm_base_url, effective_base_url)
-    ):
+    if image_generation_llm_endpoint_allows_credential_reuse(
+        provider_id=provider_id,
+        llm_config=config.llm,
+        default_base_url=default_base_url,
+        effective_base_url=effective_base_url,
+    ) and config.llm.api_key:
         return "llm_fallback"
     return "none"
 
 
 ImageOutputFormat = Literal["png", "jpeg", "webp"]
+ImageGenerationCredentialMode = Literal["direct", "env"]
 _VALID_IMAGE_SIZES = ("1024x1024", "1536x1024", "1024x1536")
 _VALID_IMAGE_OUTPUT_FORMATS: tuple[ImageOutputFormat, ...] = ("png", "jpeg", "webp")
+
+
+def _normalize_image_generation_credential_mode(
+    value: str | None,
+) -> ImageGenerationCredentialMode | None:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if not normalized:
+        return None
+    if normalized not in {"direct", "env"}:
+        raise ValueError("credential_mode must be 'direct' or 'env'")
+    return cast(ImageGenerationCredentialMode, normalized)
+
+
+def _is_legacy_image_generation_provider_switch_payload(
+    *,
+    config: GatewayConfig,
+    provider_id: str,
+    target_spec: Any,
+    primary: str,
+    api_key_env: str,
+    base_url: str | None,
+    enabled: bool,
+    fallbacks: list[str] | None,
+    clear_fallbacks: bool,
+    credential_mode: str | None,
+) -> bool:
+    """Recognize a stale 0.5.0 provider-switch payload.
+
+    The old WebUI changed the selected provider and its default env-var name,
+    but retained the source provider's primary, endpoint, and fallback draft.
+    Anchor every stale field to the stored source configuration so an arbitrary
+    cross-provider RPC request is still rejected.
+    """
+
+    if (
+        enabled is not True
+        or credential_mode is not None
+        or clear_fallbacks is not False
+        or not isinstance(primary, str)
+        or not isinstance(base_url, str)
+        or fallbacks is None
+        or api_key_env != target_spec.env_key
+    ):
+        return False
+    stored_primary = str(getattr(config.image_generation, "primary", "") or "")
+    if primary != stored_primary:
+        return False
+    try:
+        source_provider_id, _source_model = parse_image_generation_model_ref(stored_primary)
+        source_spec = get_image_generation_provider_setup_spec(source_provider_id)
+        source_provider_cfg = _image_generation_provider_config(config, source_provider_id)
+    except (KeyError, ValueError):
+        return False
+    if source_provider_id == provider_id or not source_spec.runtime_supported:
+        return False
+    stored_base_url = str(getattr(source_provider_cfg, "base_url", "") or "")
+    return (
+        base_url == stored_base_url
+        and fallbacks == list(getattr(config.image_generation, "fallbacks", []) or [])
+    )
 
 
 def upsert_image_generation_provider(
@@ -1361,11 +1419,13 @@ def upsert_image_generation_provider(
     primary: str = "",
     api_key: str = "",
     api_key_env: str = "",
-    base_url: str = "",
+    base_url: str | None = None,
     enabled: bool = True,
     size: str = "",
     output_format: str = "",
     fallbacks: list[str] | None = None,
+    clear_fallbacks: bool = False,
+    credential_mode: str | None = None,
 ) -> MutationResult:
     spec = get_image_generation_provider_setup_spec(provider_id)
     if not spec.runtime_supported:
@@ -1373,9 +1433,37 @@ def upsert_image_generation_provider(
             f"image generation provider {provider_id!r} is not runtime-supported "
             "and cannot be configured"
         )
-    primary_model = primary or spec.default_model
-    primary_provider, sep, _model = primary_model.partition("/")
-    if not sep or primary_provider != provider_id:
+    if _is_legacy_image_generation_provider_switch_payload(
+        config=config,
+        provider_id=provider_id,
+        target_spec=spec,
+        primary=primary,
+        api_key_env=api_key_env,
+        base_url=base_url,
+        enabled=enabled,
+        fallbacks=fallbacks,
+        clear_fallbacks=clear_fallbacks,
+        credential_mode=credential_mode,
+    ):
+        primary = spec.default_model
+        base_url = spec.default_base_url
+    stored_primary = str(getattr(config.image_generation, "primary", "") or "")
+    requested_primary = primary or (
+        stored_primary if not enabled and stored_primary else spec.default_model
+    )
+    preserve_legacy_primary = not enabled and requested_primary == stored_primary
+    try:
+        primary_provider, primary_model_name = parse_image_generation_model_ref(
+            requested_primary
+        )
+    except ValueError:
+        if not preserve_legacy_primary:
+            raise
+        primary_provider = provider_id
+        primary_model = requested_primary
+    else:
+        primary_model = f"{primary_provider}/{primary_model_name}"
+    if primary_provider != provider_id and not preserve_legacy_primary:
         raise ValueError(
             "primary must be a provider/model reference for "
             f"image generation provider {provider_id!r}"
@@ -1392,25 +1480,106 @@ def upsert_image_generation_provider(
         raise ValueError(
             f"image output format must be one of {', '.join(_VALID_IMAGE_OUTPUT_FORMATS)}"
         )
-    # fallbacks: each must be a provider/model reference; an empty list keeps current.
-    cleaned_fallbacks = [f.strip() for f in (fallbacks or []) if f and f.strip()]
-    for fb in cleaned_fallbacks:
-        if "/" not in fb:
-            raise ValueError(
-                f"image fallback {fb!r} must be a provider/model reference"
-            )
-    effective_fallbacks = cleaned_fallbacks or list(config.image_generation.fallbacks)
+    if not isinstance(clear_fallbacks, bool):
+        raise ValueError("clear_fallbacks must be a boolean")
+    if clear_fallbacks and fallbacks is None:
+        raise ValueError("clear_fallbacks requires a fallbacks list")
+    credential_source = _normalize_image_generation_credential_mode(credential_mode)
+
+    # Older 0.5.0 clients always sent ``fallbacks: []`` for an untouched
+    # field, so an empty list remains keep-current unless the new additive
+    # clear intent is present. Non-empty lists still replace the chain.
+    current_fallbacks = list(config.image_generation.fallbacks)
+    cleaned_fallbacks: list[str] = []
+    preserve_legacy_fallbacks = (
+        not enabled
+        and fallbacks is not None
+        and list(fallbacks) == current_fallbacks
+    )
+    if preserve_legacy_fallbacks:
+        cleaned_fallbacks = current_fallbacks
+    elif fallbacks is not None:
+        for fallback in fallbacks:
+            if isinstance(fallback, str) and not fallback.strip():
+                continue
+            try:
+                fallback_provider, fallback_model = parse_image_generation_model_ref(fallback)
+            except ValueError as exc:
+                raise ValueError(
+                    f"image fallback {fallback!r} must be a provider/model reference"
+                ) from exc
+            cleaned_fallbacks.append(f"{fallback_provider}/{fallback_model}")
+    fallbacks_updated = (
+        not preserve_legacy_fallbacks
+        and (bool(cleaned_fallbacks) or clear_fallbacks)
+    )
+    effective_fallbacks = (
+        cleaned_fallbacks
+        if fallbacks_updated
+        else current_fallbacks
+    )
 
     current_provider_cfg = _image_generation_provider_config(config, provider_id)
-    if is_redacted_secret_sentinel(api_key):
+    api_key_is_redacted = is_redacted_secret_sentinel(api_key)
+    if api_key_is_redacted:
         # Round-tripped redaction mask: keep the stored key (see
         # upsert_llm_provider for the server-side trust-boundary rationale).
         api_key = ""
     explicit_env_key = _clean_optional_str(api_key_env)
-    if api_key and explicit_env_key:
-        raise ValueError("configure either api_key or api_key_env, not both")
+    if credential_source == "direct":
+        # New clients state which credential control was edited. The direct
+        # value wins even if a stale draft still carries an env name.
+        explicit_env_key = ""
+    elif credential_source == "env":
+        # Conversely, switching to an env reference intentionally replaces a
+        # stored direct key even when the write-only key field is redacted.
+        api_key = ""
+    elif api_key_is_redacted:
+        # A legacy read-modify-write echo is never an instruction to switch
+        # sources. Preserve the stored direct key and ignore display state.
+        explicit_env_key = ""
+    elif api_key and explicit_env_key:
+        # The 0.5.0 WebUI keeps the selected provider's default env name in
+        # the form while a user pastes a direct key. Treat only that default
+        # echo as non-authoritative; a custom env plus a direct key remains
+        # ambiguous and is rejected.
+        if explicit_env_key == spec.env_key:
+            explicit_env_key = ""
+        else:
+            raise ValueError("configure either api_key or api_key_env, not both")
+    elif (
+        not api_key
+        and explicit_env_key == spec.env_key
+        and bool(getattr(current_provider_cfg, "api_key", ""))
+    ):
+        # Old clients send their default env field during every save. Without
+        # a credentialMode it must not erase a stored direct key.
+        explicit_env_key = ""
     stored_base_url = str(getattr(current_provider_cfg, "base_url", "") or "")
-    effective_base_url = base_url or stored_base_url or spec.default_base_url
+    if base_url is None:
+        effective_base_url = stored_base_url or spec.default_base_url
+    else:
+        effective_base_url = str(base_url).strip() or spec.default_base_url
+    preserve_legacy_base_url = (
+        not enabled
+        and bool(stored_base_url)
+        and effective_base_url == stored_base_url
+    )
+    if (
+        not is_valid_image_generation_base_url(effective_base_url)
+        and not preserve_legacy_base_url
+    ):
+        raise ValueError("image base_url must be an absolute http:// or https:// URL")
+    conflicting_provider = conflicting_image_generation_endpoint_provider(
+        provider_id,
+        effective_base_url,
+    )
+    if enabled and conflicting_provider:
+        raise ValueError(
+            f"image generation provider {provider_id!r} cannot use the official "
+            f"{conflicting_provider!r} endpoint; use {spec.default_base_url!r} "
+            "or a custom compatible endpoint"
+        )
     # A stored credential must not follow a changed endpoint origin: on a
     # scheme/host/effective-port change every reusable secret source —
     # including the well-known registry default env var — is dropped
@@ -1425,12 +1594,20 @@ def upsert_image_generation_provider(
         if endpoint_allows_reuse
         else ""
     )
+    # A newly selected env reference replaces a stored direct key. Without
+    # this branch the runtime keeps preferring the old direct key, so the UI
+    # appears to switch sources while the effective credential does not.
+    replace_stored_api_key = credential_source == "env" or bool(explicit_env_key)
     effective_api_key = clean_header_secret(
-        api_key or stored_api_key,
+        api_key or ("" if replace_stored_api_key else stored_api_key),
         label="Image API key",
     )
     stored_env_key = str(getattr(current_provider_cfg, "api_key_env", spec.env_key) or "")
-    if not endpoint_allows_reuse and explicit_env_key == stored_env_key:
+    if (
+        not endpoint_allows_reuse
+        and credential_source != "env"
+        and explicit_env_key == stored_env_key
+    ):
         # Clients hydrate and re-send the stored env-var name verbatim: a
         # re-submitted value equal to the stored reference means "keep the
         # current credential", not a credential authored for the changed
@@ -1446,10 +1623,14 @@ def upsert_image_generation_provider(
         if base_url_allows_credential_reuse(spec.default_base_url, effective_base_url)
         else ""
     )
-    if api_key:
+    if credential_source == "direct" or api_key:
         env_key = ""
+    elif credential_source == "env":
+        env_key = explicit_env_key
+    elif explicit_env_key:
+        env_key = explicit_env_key
     else:
-        env_key = explicit_env_key or current_env_key or default_env_key
+        env_key = current_env_key or default_env_key
     has_saved_env_reference = bool(
         explicit_env_key or (current_env_key and current_env_key != spec.env_key)
     )
@@ -1461,16 +1642,6 @@ def upsert_image_generation_provider(
         effective_base_url=effective_base_url,
         default_base_url=spec.default_base_url,
     )
-    if (
-        enabled
-        and spec.requires_api_key
-        and api_key_source == "none"
-        and not has_saved_env_reference
-    ):
-        raise ValueError(
-            f"image generation provider {provider_id!r} requires an api_key, "
-            f"{spec.env_key}, or a matching configured LLM provider"
-        )
     if api_key_source == "none" and has_saved_env_reference:
         api_key_source = "missing_env"
 
@@ -1486,10 +1657,36 @@ def upsert_image_generation_provider(
     new_cfg.image_generation.size = effective_size
     new_cfg.image_generation.output_format = cast(ImageOutputFormat, effective_output_format)
     new_cfg.image_generation.fallbacks = effective_fallbacks
+    if fallbacks_updated:
+        new_cfg.mark_force_persist("image_generation.fallbacks")
     next_provider_cfg = _image_generation_provider_config(new_cfg, provider_id)
     next_provider_cfg.api_key = effective_api_key
     next_provider_cfg.api_key_env = env_key
     next_provider_cfg.base_url = effective_base_url
+    if (
+        enabled
+        and spec.requires_api_key
+        and api_key_source == "none"
+        and not has_saved_env_reference
+    ):
+        # Fallback routes are executable candidates, so a missing credential
+        # on this primary does not make an otherwise healthy chain unusable.
+        # Consult the shared onboarding verifier only after the prospective
+        # selected-provider state has been applied.
+        from opensquilla.onboarding.section_status import (
+            SectionStatus,
+            image_generation_section_status,
+        )
+
+        if image_generation_section_status(new_cfg) is not SectionStatus.OK:
+            raise ValueError(
+                f"image generation provider {provider_id!r} requires an api_key, "
+                f"{spec.env_key}, or a matching configured LLM provider"
+            )
+    if base_url is not None:
+        new_cfg.mark_force_persist(
+            f"image_generation.providers.{provider_id}.base_url"
+        )
     if explicit_env_key == spec.env_key and not base_url_allows_credential_reuse(
         spec.default_base_url,
         effective_base_url,

--- a/src/opensquilla/onboarding/section_status.py
+++ b/src/opensquilla/onboarding/section_status.py
@@ -24,6 +24,7 @@ from collections.abc import Callable, Collection
 from enum import StrEnum
 from typing import Any, cast
 
+from opensquilla.endpoint_identity import credential_env_for_endpoint
 from opensquilla.gateway.config import GatewayConfig, ImageGenerationConfig
 from opensquilla.onboarding.audio_specs import get_audio_provider_setup_spec
 from opensquilla.onboarding.image_generation_specs import (
@@ -32,6 +33,13 @@ from opensquilla.onboarding.image_generation_specs import (
 )
 from opensquilla.onboarding.provider_specs import get_provider_setup_spec
 from opensquilla.onboarding.search_specs import get_search_provider_setup_spec
+from opensquilla.provider.image_generation_policy import (
+    conflicting_image_generation_endpoint_provider,
+    image_generation_llm_endpoint_allows_credential_reuse,
+    is_valid_image_generation_base_url,
+    parse_image_generation_model_ref,
+    resolve_image_generation_base_url,
+)
 
 FIRST_RUN_REQUIRED_SECTIONS = frozenset({"llm"})
 
@@ -173,8 +181,25 @@ def image_generation_section_status(cfg: GatewayConfig) -> SectionStatus:
     image_cfg = getattr(cfg, "image_generation", None)
     if image_cfg is None or not bool(getattr(image_cfg, "enabled", False)):
         return SectionStatus.OPTIONAL
+    if _image_generation_has_invalid_model_reference(cfg):
+        return SectionStatus.UNKNOWN
+    provider_ids = _configured_image_generation_provider_ids(cfg)
+    # A fallback can keep generation available after a local primary failure,
+    # but it must not conceal a persisted provider/official-endpoint mismatch.
+    # The operator still needs to repair the primary routing before the section
+    # can honestly report a healthy configuration.
+    if any(
+        _image_generation_endpoint_conflict_provider(cfg, provider_id) is not None
+        for provider_id in provider_ids
+    ):
+        return SectionStatus.DEGRADED
+    if any(
+        _image_generation_endpoint_is_valid(cfg, provider_id) is False
+        for provider_id in provider_ids
+    ):
+        return SectionStatus.DEGRADED
     aggregate = SectionStatus.MISSING
-    for provider_id in _configured_image_generation_provider_ids(cfg):
+    for provider_id in provider_ids:
         credential = _image_generation_credential_state(cfg, provider_id)
         if credential is SectionStatus.OK:
             return SectionStatus.OK
@@ -257,20 +282,14 @@ def _image_generation_credential_state(
       2. operator-explicit env_key resolved in ``os.environ`` -> ``OK``
       3. operator-explicit env_key declared but absent -> ``DEGRADED``
       4. spec default env_key resolved in ``os.environ`` -> ``OK``
-      5. matching LLM provider with an explicit ``api_key`` (image-gen reuses it) -> ``OK``
-      6. otherwise -> ``MISSING``
+      5. matching LLM provider with an explicit ``api_key`` on the same endpoint -> ``OK``
+      6. matching LLM provider/key on another endpoint -> ``DEGRADED``
+      7. otherwise -> ``MISSING``
 
-    Known tradeoff: the config schema does not record whether the operator
-    explicitly picked the *default* env var name (e.g. ``OPENAI_API_KEY``)
-    or whether the value arrived from a Pydantic field default. The
-    ``cfg_env_key == spec_env_key`` test below treats matching values as
-    spec-default so a fresh ``GatewayConfig()`` does not flap to
-    ``DEGRADED`` whenever the spec env var happens to be unset. The cost:
-    an operator who deliberately picked the spec-default env var and later
-    loses that variable from the environment will see ``MISSING`` rather
-    than ``DEGRADED``. Recording an explicit credential source on the
-    provider config would close this gap and is left for a config schema
-    change.
+    The configured env provenance mirrors the runtime resolver: the registry
+    default env var follows only the registry endpoint, while any operator
+    authored reference (including an explicit default-name reference) may be
+    used for a custom compatible endpoint.
     """
     try:
         spec = get_image_generation_provider_setup_spec(provider_id)
@@ -284,34 +303,132 @@ def _image_generation_credential_state(
     if provider_cfg_any is not None and provider_cfg_any.api_key:
         return SectionStatus.OK
 
-    # An ``api_key_env`` value that matches the spec default arrives from
-    # field defaults rather than an operator decision, so it should not
-    # short-circuit to ``DEGRADED``. Only treat the reference as explicit
-    # when the operator overrode the spec default.
-    spec_env_key = (getattr(spec, "env_key", "") or "").strip()
-    cfg_env_key = ""
-    if provider_cfg is not None:
-        cfg_env_key = (getattr(provider_cfg, "api_key_env", "") or "").strip()
-    explicit_env_key = cfg_env_key if cfg_env_key and cfg_env_key != spec_env_key else ""
+    resolved_env_key, env_is_explicit = _image_generation_effective_env_key(
+        cfg,
+        provider_id,
+        spec,
+    )
+    if resolved_env_key:
+        if os.environ.get(resolved_env_key):
+            return SectionStatus.OK
+        if env_is_explicit:
+            return SectionStatus.DEGRADED
 
-    if explicit_env_key:
-        return (
-            SectionStatus.OK
-            if os.environ.get(explicit_env_key)
-            else SectionStatus.DEGRADED
-        )
-    if spec_env_key and os.environ.get(spec_env_key):
+    llm_key_reusable = _image_generation_llm_key_reusable(cfg, provider_id)
+    if llm_key_reusable is True:
         return SectionStatus.OK
-
-    llm = getattr(cfg, "llm", None)
-    if (
-        getattr(llm, "provider", "").strip().lower() == provider_id
-        and getattr(llm, "api_key", "")
-    ):
-        return SectionStatus.OK
+    if llm_key_reusable is False:
+        return SectionStatus.DEGRADED
 
     # Nothing produced an OK; classify how the operator left the provider.
     return SectionStatus.MISSING
+
+
+def _image_generation_effective_env_key(
+    cfg: GatewayConfig,
+    provider_id: str,
+    spec: Any,
+) -> tuple[str, bool]:
+    """Resolve the env source using the same endpoint provenance as runtime."""
+
+    providers = getattr(getattr(cfg, "image_generation", None), "providers", None)
+    provider_cfg = getattr(providers, provider_id, None) if providers is not None else None
+    cfg_env_key = (
+        str(getattr(provider_cfg, "api_key_env", "") or "").strip()
+        if provider_cfg is not None
+        else ""
+    )
+    fields_set = getattr(provider_cfg, "model_fields_set", None)
+    env_was_explicitly_configured = (
+        isinstance(fields_set, set) and "api_key_env" in fields_set
+    )
+    endpoint = _image_generation_effective_endpoint(cfg, provider_id)
+    if endpoint is None:
+        return "", False
+    default_base_url, effective_base_url = endpoint
+    spec_env_key = str(getattr(spec, "env_key", "") or "").strip()
+    resolved_env_key = credential_env_for_endpoint(
+        configured_env=cfg_env_key,
+        configured_explicitly=env_was_explicitly_configured,
+        default_env=spec_env_key,
+        default_base_url=default_base_url,
+        effective_base_url=effective_base_url,
+    )
+    env_is_explicit = bool(
+        resolved_env_key
+        and cfg_env_key
+        and (cfg_env_key != spec_env_key or env_was_explicitly_configured)
+    )
+    return resolved_env_key, env_is_explicit
+
+
+def _image_generation_endpoint_conflict_provider(
+    cfg: GatewayConfig,
+    provider_id: str,
+) -> str | None:
+    """Return the official provider that conflicts with this image endpoint."""
+
+    endpoint = _image_generation_effective_endpoint(cfg, provider_id)
+    if endpoint is None:
+        return None
+    _default_base_url, base_url = endpoint
+    return conflicting_image_generation_endpoint_provider(
+        provider_id,
+        base_url,
+    )
+
+
+def _image_generation_endpoint_is_valid(
+    cfg: GatewayConfig,
+    provider_id: str,
+) -> bool | None:
+    endpoint = _image_generation_effective_endpoint(cfg, provider_id)
+    if endpoint is None:
+        return None
+    return is_valid_image_generation_base_url(endpoint[1])
+
+
+def _image_generation_llm_key_reusable(
+    cfg: GatewayConfig,
+    provider_id: str,
+) -> bool | None:
+    llm = getattr(cfg, "llm", None)
+    if (
+        getattr(llm, "provider", "").strip().lower() != provider_id
+        or not getattr(llm, "api_key", "")
+    ):
+        return None
+    endpoint = _image_generation_effective_endpoint(cfg, provider_id)
+    if endpoint is None:
+        return None
+    default_base_url, effective_base_url = endpoint
+    return image_generation_llm_endpoint_allows_credential_reuse(
+        provider_id=provider_id,
+        llm_config=llm,
+        default_base_url=default_base_url,
+        effective_base_url=effective_base_url,
+    )
+
+
+def _image_generation_effective_endpoint(
+    cfg: GatewayConfig,
+    provider_id: str,
+) -> tuple[str, str] | None:
+    try:
+        spec = get_image_generation_provider_setup_spec(provider_id)
+    except KeyError:
+        return None
+    providers = getattr(getattr(cfg, "image_generation", None), "providers", None)
+    provider_cfg = getattr(providers, provider_id, None) if providers is not None else None
+    return (
+        spec.default_base_url,
+        resolve_image_generation_base_url(
+            provider_id=provider_id,
+            provider_config=provider_cfg,
+            llm_config=getattr(cfg, "llm", None),
+            default_base_url=spec.default_base_url,
+        ),
+    )
 
 
 def _image_generation_provider_has_operator_credential(
@@ -399,9 +516,28 @@ def _configured_image_generation_provider_ids(cfg: GatewayConfig) -> list[str]:
     seen: set[str] = set()
     result: list[str] = []
     for ref in refs:
-        provider_id, sep, _model = ref.partition("/")
-        provider_id = provider_id.strip()
-        if sep and provider_id and provider_id not in seen:
+        try:
+            provider_id, _model = parse_image_generation_model_ref(ref)
+        except ValueError:
+            continue
+        if provider_id not in seen:
             seen.add(provider_id)
             result.append(provider_id)
     return result
+
+
+def _image_generation_has_invalid_model_reference(cfg: GatewayConfig) -> bool:
+    image_cfg = cfg.image_generation
+    primary = str(getattr(image_cfg, "primary", "") or "")
+    fallbacks = list(getattr(image_cfg, "fallbacks", []) or [])
+    explicit_routing = bool(fallbacks) or bool(
+        primary and primary != DEFAULT_IMAGE_GENERATION_PRIMARY
+    )
+    if not explicit_routing:
+        return False
+    for ref in [primary, *fallbacks]:
+        try:
+            parse_image_generation_model_ref(ref)
+        except ValueError:
+            return True
+    return False

--- a/src/opensquilla/onboarding/setup_engine.py
+++ b/src/opensquilla/onboarding/setup_engine.py
@@ -218,14 +218,32 @@ class SetupEngine:
             if not enabled and not provider_id:
                 res = disable_image_generation(self.config)
             else:
+                fallbacks = payload.get("fallbacks")
+                if fallbacks is not None and not isinstance(fallbacks, list):
+                    raise ValueError("fallbacks must be a list of provider/model references")
                 res = upsert_image_generation_provider(
                     self.config,
                     provider_id=provider_id,
                     primary=str(payload.get("primary") or ""),
                     api_key=str(payload.get("apiKey") or ""),
                     api_key_env=str(payload.get("apiKeyEnv") or ""),
-                    base_url=str(payload.get("baseUrl") or ""),
+                    base_url=_optional_str(payload.get("baseUrl")),
                     enabled=enabled,
+                    size=str(payload.get("size") or ""),
+                    output_format=str(payload.get("outputFormat") or ""),
+                    fallbacks=(
+                        [str(fallback) for fallback in fallbacks]
+                        if fallbacks is not None
+                        else None
+                    ),
+                    clear_fallbacks=_strict_bool(
+                        payload.get("clearFallbacks"), field="clearFallbacks"
+                    ),
+                    credential_mode=(
+                        None
+                        if payload.get("credentialMode") is None
+                        else str(payload.get("credentialMode"))
+                    ),
                 )
         elif normalized in AUDIO_SECTION_ALIASES:
             res = upsert_audio_provider(

--- a/src/opensquilla/onboarding/status.py
+++ b/src/opensquilla/onboarding/status.py
@@ -30,6 +30,11 @@ from opensquilla.onboarding.section_status import (
     FIRST_RUN_REQUIRED_SECTIONS,
     SectionStatus,
     _configured_image_generation_provider_ids,
+    _image_generation_effective_env_key,
+    _image_generation_endpoint_conflict_provider,
+    _image_generation_endpoint_is_valid,
+    _image_generation_has_invalid_model_reference,
+    _image_generation_llm_key_reusable,
     audio_section_status,
     channels_section_status,
     ensemble_section_status,
@@ -814,26 +819,22 @@ def _image_generation_provider_source(
     if explicit_key:
         return "explicit", spec.env_key
 
-    spec_env_key = (getattr(spec, "env_key", "") or "").strip()
-    cfg_env_key = (
-        (getattr(provider_cfg, "api_key_env", "") or "").strip()
-        if provider_cfg
-        else ""
+    env_key, env_is_explicit = _image_generation_effective_env_key(
+        cfg,
+        provider_id,
+        spec,
     )
-    explicit_env_key = cfg_env_key if cfg_env_key and cfg_env_key != spec_env_key else ""
-    if explicit_env_key:
+    if env_key and os.environ.get(env_key):
+        return "env", env_key
+    if env_key and env_is_explicit:
         return (
-            ("env", explicit_env_key)
-            if os.environ.get(explicit_env_key)
-            else ("missing_env", explicit_env_key)
+            "missing_env",
+            env_key,
         )
-    if spec_env_key and os.environ.get(spec_env_key):
-        return "env", spec_env_key
 
-    llm = getattr(cfg, "llm", None)
-    if getattr(llm, "provider", "").strip().lower() == provider_id and getattr(llm, "api_key", ""):
+    if _image_generation_llm_key_reusable(cfg, provider_id) is True:
         return "llm_fallback", spec.env_key
-    return "", spec_env_key
+    return "", env_key or str(getattr(spec, "env_key", "") or "").strip()
 
 
 def _image_generation_annotations(
@@ -848,7 +849,59 @@ def _image_generation_annotations(
         source, env_key = _image_generation_provider_source(cfg, provider_id)
         if source:
             return source, provider_id, primary, env_key
+        try:
+            get_image_generation_provider_setup_spec(provider_id)
+        except KeyError:
+            return "none", provider_id, primary, ""
+        if _image_generation_llm_key_reusable(cfg, provider_id) is False:
+            return "none", provider_id, primary, env_key
     return "none", "", primary, ""
+
+
+def _image_generation_detail(
+    cfg: GatewayConfig,
+    status: SectionStatus,
+    source: str,
+    provider: str,
+    env_key: str,
+) -> str:
+    if status is SectionStatus.UNKNOWN and _image_generation_has_invalid_model_reference(cfg):
+        return "invalid image provider/model reference"
+    if status is SectionStatus.UNKNOWN and provider:
+        try:
+            get_image_generation_provider_setup_spec(provider)
+        except KeyError:
+            return _with_provider(provider, "unknown image provider")
+    if status is SectionStatus.DEGRADED:
+        for candidate_provider in _configured_image_generation_provider_ids(cfg):
+            if _image_generation_endpoint_is_valid(cfg, candidate_provider) is False:
+                return _with_provider(
+                    candidate_provider,
+                    "invalid image endpoint; use an absolute http:// or https:// URL",
+                )
+            conflicting_provider = _image_generation_endpoint_conflict_provider(
+                cfg,
+                candidate_provider,
+            )
+            if conflicting_provider is not None:
+                return _with_provider(
+                    candidate_provider,
+                    "endpoint/provider mismatch: "
+                    f"configured {conflicting_provider} official endpoint",
+                )
+            if _image_generation_llm_key_reusable(cfg, candidate_provider) is False:
+                return _with_provider(
+                    candidate_provider,
+                    "LLM key cannot be reused across image endpoint origins",
+                )
+    return _with_provider(
+        provider,
+        (
+            "same provider key"
+            if source == "llm_fallback"
+            else _source_detail(source, env_key)
+        ),
+    )
 
 
 def _memory_embedding_annotations(
@@ -958,13 +1011,12 @@ def get_onboarding_status(
         "router": _router_detail(config, llm_source),
         "ensemble": _ensemble_detail(config),
         "search": _source_detail(search_source, search_env_key),
-        "image_generation": _with_provider(
+        "image_generation": _image_generation_detail(
+            config,
+            image_status,
+            image_source,
             image_provider,
-            (
-                "same provider key"
-                if image_source == "llm_fallback"
-                else _source_detail(image_source, image_env_key)
-            ),
+            image_env_key,
         ),
         "audio": _with_provider(
             audio_provider,

--- a/src/opensquilla/provider/image_generation.py
+++ b/src/opensquilla/provider/image_generation.py
@@ -7,19 +7,25 @@ import base64
 import os
 import uuid
 from dataclasses import dataclass, field, replace
+from io import BytesIO
 from typing import Protocol
 
 import httpx
+from PIL import Image
 
-from opensquilla.endpoint_identity import (
-    base_url_allows_credential_reuse,
-    credential_env_for_endpoint,
-)
+from opensquilla.endpoint_identity import credential_env_for_endpoint
 from opensquilla.env import trust_env as _trust_env
 from opensquilla.provider.app_attribution import provider_app_headers
 from opensquilla.provider.correlation_context import (
     bind_provider_request_correlation,
     current_provider_request_correlation,
+)
+from opensquilla.provider.image_generation_policy import (
+    conflicting_image_generation_endpoint_provider,
+    image_generation_llm_endpoint_allows_credential_reuse,
+    is_valid_image_generation_base_url,
+    parse_image_generation_model_ref,
+    resolve_image_generation_base_url,
 )
 from opensquilla.provider.tokenrhythm_correlation import (
     tokenrhythm_correlation_headers,
@@ -99,6 +105,7 @@ class OpenAIImageGenerationProvider:
         return f"{self._base_url}{path}"
 
     async def generate(self, request: ImageGenerationRequest) -> ImageGenerationResult:
+        _raise_for_conflicting_official_endpoint(self.provider_id, self._base_url)
         api_key = self._resolve_api_key()
         if not api_key:
             raise RuntimeError(f"{self._api_key_env} is not set")
@@ -206,6 +213,7 @@ class OpenRouterImageGenerationProvider:
         return {"aspect_ratio": aspect_ratio, "image_size": "1K"}
 
     async def generate(self, request: ImageGenerationRequest) -> ImageGenerationResult:
+        _raise_for_conflicting_official_endpoint(self.provider_id, self._base_url)
         api_key = self._resolve_api_key()
         if not api_key:
             raise RuntimeError(f"{self._api_key_env} is not set")
@@ -288,6 +296,80 @@ def _decode_data_url(data_url: str) -> tuple[str, bytes]:
     return mime_type, base64.b64decode(encoded)
 
 
+def _raise_for_conflicting_official_endpoint(provider_id: str, base_url: str) -> None:
+    if not is_valid_image_generation_base_url(base_url):
+        raise RuntimeError(
+            f"Image generation provider {provider_id!r} has invalid endpoint "
+            f"{base_url!r}; set an absolute http:// or https:// image base URL"
+        )
+    conflicting_provider = conflicting_image_generation_endpoint_provider(
+        provider_id,
+        base_url,
+    )
+    if conflicting_provider is None:
+        return
+    raise RuntimeError(
+        f"Image generation provider {provider_id!r} cannot use "
+        f"{conflicting_provider!r}'s official endpoint {base_url!r}; "
+        f"set the {provider_id!r} image base URL before retrying"
+    )
+
+
+_IMAGE_OUTPUT_FORMATS: dict[str, tuple[str, str]] = {
+    "png": ("PNG", "image/png"),
+    "jpg": ("JPEG", "image/jpeg"),
+    "jpeg": ("JPEG", "image/jpeg"),
+    "webp": ("WEBP", "image/webp"),
+}
+
+
+def _normalize_generated_image(
+    result: ImageGenerationResult,
+    output_format: str,
+) -> ImageGenerationResult:
+    normalized_format = output_format.strip().lower()
+    format_spec = _IMAGE_OUTPUT_FORMATS.get(normalized_format)
+    if format_spec is None:
+        raise RuntimeError(f"Unsupported image output format: {output_format!r}")
+    pillow_format, mime_type = format_spec
+
+    try:
+        with Image.open(BytesIO(result.image_bytes)) as image:
+            image.verify()
+        with Image.open(BytesIO(result.image_bytes)) as image:
+            image.load()
+            output_image: Image.Image = image
+            if pillow_format == "JPEG" and image.mode != "RGB":
+                if image.mode in {"RGBA", "LA"} or (
+                    image.mode == "P" and "transparency" in image.info
+                ):
+                    rgba = image.convert("RGBA")
+                    try:
+                        output_image = Image.new("RGB", image.size, "white")
+                        output_image.paste(rgba, mask=rgba.getchannel("A"))
+                    finally:
+                        rgba.close()
+                else:
+                    output_image = image.convert("RGB")
+
+            buffer = BytesIO()
+            try:
+                output_image.save(buffer, format=pillow_format)
+            finally:
+                if output_image is not image:
+                    output_image.close()
+    except Exception as exc:
+        raise RuntimeError(
+            f"Image generation provider returned invalid image bytes: {exc}"
+        ) from exc
+
+    return replace(
+        result,
+        image_bytes=buffer.getvalue(),
+        mime_type=mime_type,
+    )
+
+
 _PROVIDERS: dict[str, ImageGenerationProvider] = {}
 
 
@@ -299,28 +381,6 @@ def _get_config_attr(config: object | None, name: str, default: str = "") -> str
 def _field_was_set(config: object | None, name: str) -> bool:
     fields_set = getattr(config, "model_fields_set", None)
     return isinstance(fields_set, set) and name in fields_set
-
-
-def _llm_provider_matches(llm_config: object | None, provider_id: str) -> bool:
-    provider = _get_config_attr(llm_config, "provider").strip().lower()
-    return provider == provider_id
-
-
-def _llm_chosen_base_url(llm_config: object | None) -> str:
-    """Return the LLM base URL only when it names an operator-chosen endpoint.
-
-    A value equal to the pydantic field default is derived for another
-    provider, not chosen for this one (the same value-vs-baseline rule the
-    LLM runtime resolution documents), so it must not be treated as the
-    LLM's endpoint here.
-    """
-    value = _get_config_attr(llm_config, "base_url")
-    if not value or llm_config is None:
-        return ""
-    fields = getattr(type(llm_config), "model_fields", None)
-    field = fields.get("base_url") if isinstance(fields, dict) else None
-    default = str(getattr(field, "default", "") or "") if field is not None else ""
-    return "" if value == default else value
 
 
 def _resolve_configured_api_key(
@@ -340,14 +400,17 @@ def _resolve_configured_api_key(
     if env_value:
         return env_value
 
-    if _llm_provider_matches(llm_config, provider_id):
+    if image_generation_llm_endpoint_allows_credential_reuse(
+        provider_id=provider_id,
+        llm_config=llm_config,
+        default_base_url=default_base_url,
+        effective_base_url=effective_base_url,
+    ):
         # The primary LLM key is a credential for the LLM's endpoint only:
         # it must not follow a custom image base_url to a different
         # scheme/host/effective port. Fail closed so generate() reports the
         # missing key and the operator enters one for the image endpoint.
-        llm_base_url = _llm_chosen_base_url(llm_config) or default_base_url
-        if base_url_allows_credential_reuse(llm_base_url, effective_base_url):
-            return _get_config_attr(llm_config, "api_key") or None
+        return _get_config_attr(llm_config, "api_key") or None
     return None
 
 
@@ -358,15 +421,12 @@ def _resolve_configured_base_url(
     llm_config: object | None,
     default_base_url: str,
 ) -> str:
-    base_url = _get_config_attr(provider_config, "base_url", default_base_url) or default_base_url
-    if not _field_was_set(provider_config, "base_url") and _llm_provider_matches(
-        llm_config, provider_id
-    ):
-        # Inherit only an operator-chosen LLM endpoint: a derived model
-        # default belongs to another provider and must not point this
-        # provider's requests (and the reused key) at it.
-        return _llm_chosen_base_url(llm_config) or base_url
-    return base_url
+    return resolve_image_generation_base_url(
+        provider_id=provider_id,
+        provider_config=provider_config,
+        llm_config=llm_config,
+        default_base_url=default_base_url,
+    )
 
 
 def register_image_generation_provider(provider: ImageGenerationProvider) -> None:
@@ -451,13 +511,6 @@ def get_image_generation_provider(provider_id: str) -> ImageGenerationProvider |
     return _PROVIDERS.get(provider_id)
 
 
-def parse_image_generation_model_ref(raw: str) -> tuple[str, str]:
-    provider, sep, model = raw.partition("/")
-    if not sep or not provider.strip() or not model.strip():
-        raise ValueError(f"Invalid image generation model ref: {raw!r}")
-    return provider.strip(), model.strip()
-
-
 def _is_image_generation_correlation(
     correlation: ProviderRequestCorrelation,
 ) -> bool:
@@ -528,6 +581,7 @@ async def generate_with_fallbacks(
                 )
             if not result.image_bytes:
                 raise RuntimeError("Image generation provider returned empty image")
+            result = _normalize_generated_image(result, request.output_format)
             result.attempts = attempts
             return result
         except Exception as exc:  # noqa: BLE001 - failures are summarized for fallback

--- a/src/opensquilla/provider/image_generation_policy.py
+++ b/src/opensquilla/provider/image_generation_policy.py
@@ -1,0 +1,181 @@
+"""Shared validation policy for image-generation routing and endpoints."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlsplit
+
+from opensquilla.endpoint_identity import base_url_allows_credential_reuse
+
+IMAGE_GENERATION_OFFICIAL_BASE_URLS: dict[str, str] = {
+    "openai": "https://api.openai.com/v1",
+    "openrouter": "https://openrouter.ai/api/v1",
+}
+_PROVIDER_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _has_unsafe_model_ref_character(value: str) -> bool:
+    return any(
+        character == "\\"
+        or character.isspace()
+        or ord(character) < 0x20
+        or ord(character) == 0x7F
+        for character in value
+    )
+
+
+def parse_image_generation_model_ref(raw: str) -> tuple[str, str]:
+    """Parse a syntactically safe ``provider/model[/...]`` image route.
+
+    ``openrouter/auto`` is OpenRouter's wire-model name. Preserve that nested
+    name even when an older config uses the ambiguous short route; callers that
+    serialize the parsed result produce the unambiguous canonical reference
+    ``openrouter/openrouter/auto``.
+    """
+    if not isinstance(raw, str):
+        raise ValueError(f"Invalid image generation model ref: {raw!r}")
+    normalized = raw.strip()
+    provider, sep, model = normalized.partition("/")
+    model_segments = model.split("/") if model else []
+    if (
+        not sep
+        or not _PROVIDER_TOKEN_RE.fullmatch(provider)
+        or not model_segments
+        or any(not segment for segment in model_segments)
+        or _has_unsafe_model_ref_character(model)
+    ):
+        raise ValueError(f"Invalid image generation model ref: {raw!r}")
+    if provider == "openrouter" and model == "auto":
+        return provider, "openrouter/auto"
+    return provider, model
+
+
+def conflicting_image_generation_endpoint_provider(
+    provider_id: str,
+    base_url: str,
+) -> str | None:
+    """Return the other known provider whose official origin owns ``base_url``.
+
+    Unknown custom compatible endpoints are intentionally allowed. Only an
+    endpoint on another registered image provider's official HTTP origin is a
+    deterministic provider mismatch.
+    """
+    candidate = str(base_url or "").strip()
+    if not candidate:
+        return None
+    for known_provider_id, official_base_url in (
+        IMAGE_GENERATION_OFFICIAL_BASE_URLS.items()
+    ):
+        if known_provider_id == provider_id:
+            continue
+        if base_url_allows_credential_reuse(official_base_url, candidate):
+            return known_provider_id
+    return None
+
+
+def is_valid_image_generation_base_url(value: str) -> bool:
+    """Return whether ``value`` is an absolute HTTP(S) endpoint.
+
+    Image providers pass this value straight to ``httpx``.  Validate it at
+    configuration/status boundaries so an invalid legacy value is actionable
+    instead of presenting as Ready and failing only when the tool is called.
+    """
+
+    untrimmed = str(value or "")
+    raw = untrimmed.strip()
+    if (
+        not raw
+        or raw != untrimmed
+        or any(character.isspace() or ord(character) < 0x20 for character in raw)
+        or "?" in raw
+        or "#" in raw
+    ):
+        return False
+    try:
+        parsed = urlsplit(raw)
+        # Accessing ``port`` validates both syntax and range.
+        _port = parsed.port
+        return (
+            parsed.scheme.lower() in {"http", "https"}
+            and bool(parsed.hostname)
+            and "\\" not in parsed.netloc
+            and parsed.username is None
+            and parsed.password is None
+            and not parsed.query
+            and not parsed.fragment
+        )
+    except (UnicodeError, ValueError):
+        return False
+
+
+def resolve_image_generation_base_url(
+    *,
+    provider_id: str,
+    provider_config: object | None,
+    llm_config: object | None,
+    default_base_url: str,
+) -> str:
+    """Resolve the image endpoint, including same-provider LLM inheritance.
+
+    Image-provider defaults are materialized by the config schema.  A base URL
+    absent from the stored image provider config therefore needs provenance,
+    not a value comparison, before an operator-selected LLM endpoint may be
+    inherited.
+    """
+
+    base_url = _config_string(provider_config, "base_url", default_base_url) or default_base_url
+    if not _field_was_set(provider_config, "base_url") and _llm_provider_matches(
+        llm_config,
+        provider_id,
+    ):
+        return _llm_chosen_base_url(llm_config) or base_url
+    return base_url
+
+
+def image_generation_llm_endpoint_allows_credential_reuse(
+    *,
+    provider_id: str,
+    llm_config: object | None,
+    default_base_url: str,
+    effective_base_url: str,
+) -> bool:
+    """Whether the active LLM credential belongs to this image endpoint."""
+
+    if not _llm_provider_matches(llm_config, provider_id):
+        return False
+    llm_base_url = _llm_chosen_base_url(llm_config) or default_base_url
+    return base_url_allows_credential_reuse(llm_base_url, effective_base_url)
+
+
+def _config_string(config: object | None, name: str, default: str = "") -> str:
+    value = getattr(config, name, default) if config is not None else default
+    return value if isinstance(value, str) else default
+
+
+def _field_was_set(config: object | None, name: str) -> bool:
+    fields_set = getattr(config, "model_fields_set", None)
+    return isinstance(fields_set, set) and name in fields_set
+
+
+def _llm_provider_matches(llm_config: object | None, provider_id: str) -> bool:
+    return _config_string(llm_config, "provider").strip().lower() == provider_id
+
+
+def _llm_chosen_base_url(llm_config: object | None) -> str:
+    value = _config_string(llm_config, "base_url")
+    if not value or llm_config is None:
+        return ""
+    fields = getattr(type(llm_config), "model_fields", None)
+    field = fields.get("base_url") if isinstance(fields, dict) else None
+    default = str(getattr(field, "default", "") or "") if field is not None else ""
+    return "" if value == default else value
+
+
+__all__ = [
+    "IMAGE_GENERATION_OFFICIAL_BASE_URLS",
+    "conflicting_image_generation_endpoint_provider",
+    "image_generation_llm_endpoint_allows_credential_reuse",
+    "is_valid_image_generation_base_url",
+    "parse_image_generation_model_ref",
+    "resolve_image_generation_base_url",
+]

--- a/src/opensquilla/tools/builtin/media.py
+++ b/src/opensquilla/tools/builtin/media.py
@@ -55,6 +55,10 @@ from opensquilla.provider.image_generation import (
     parse_image_generation_model_ref,
     reset_image_generation_providers,
 )
+from opensquilla.provider.image_generation_policy import (
+    conflicting_image_generation_endpoint_provider,
+    is_valid_image_generation_base_url,
+)
 from opensquilla.provider.protocol import provider_metadata
 from opensquilla.provider.types import ChatConfig, derive_provider_request_correlation
 from opensquilla.sandbox.operation_runtime import SandboxToolDescriptor
@@ -496,7 +500,7 @@ async def _call_vision_provider(b64_data: str, media_type: str, prompt: str) -> 
 )
 async def image_generate(
     prompt: str,
-    size: str = "1024x1024",
+    size: str | None = None,
     model: str | None = None,
     filename: str | None = None,
 ) -> str:
@@ -506,18 +510,21 @@ async def image_generate(
 async def _image_generate_impl(
     *,
     prompt: str,
-    size: str,
+    size: str | None,
     model: str | None,
     filename: str | None,
 ) -> str:
     if not prompt or not prompt.strip():
         raise ToolError("Prompt must not be empty")
 
-    valid_sizes = {"1024x1024", "1536x1024", "1024x1536"}
-    if size not in valid_sizes:
-        raise ToolError(f"Invalid size: {size}. Must be {' | '.join(sorted(valid_sizes))}")
-
     config = _resolve_image_generation_config()
+    effective_size = size if size is not None else getattr(config, "size", "1024x1024")
+    valid_sizes = {"1024x1024", "1536x1024", "1024x1536"}
+    if effective_size not in valid_sizes:
+        raise ToolError(
+            f"Invalid size: {effective_size}. Must be {' | '.join(sorted(valid_sizes))}"
+        )
+
     if not getattr(config, "enabled", False):
         raise ToolError("Image generation is disabled")
 
@@ -532,7 +539,7 @@ async def _image_generate_impl(
             request=ImageGenerationRequest(
                 prompt=prompt,
                 model=candidates[0],
-                size=size or getattr(config, "size", "1024x1024"),
+                size=effective_size,
                 output_format=output_format,
                 timeout_seconds=float(getattr(config, "timeout_seconds", 180.0)),
             ),
@@ -652,6 +659,19 @@ def image_generation_available(config: Any | None = None) -> bool:
 
 
 def _image_generation_provider_has_auth(provider: Any) -> bool:
+    provider_id = str(getattr(provider, "provider_id", "") or "")
+    missing_base_url = object()
+    configured_base_url = getattr(provider, "_base_url", missing_base_url)
+    # Third-party image providers are not required to expose an HTTP endpoint
+    # by the public protocol. Built-in HTTP adapters do, and retain endpoint
+    # validation before they are surfaced as available.
+    if configured_base_url is not missing_base_url:
+        base_url = str(configured_base_url or "")
+        if not is_valid_image_generation_base_url(base_url):
+            return False
+        if conflicting_image_generation_endpoint_provider(provider_id, base_url) is not None:
+            return False
+
     resolve_api_key = getattr(provider, "_resolve_api_key", None)
     if callable(resolve_api_key):
         try:
@@ -676,7 +696,7 @@ def _resolve_generated_image_path(filename: str | None, output_format: str) -> P
         else Path.cwd()
     )
     candidate = Path(raw).expanduser()
-    if not candidate.suffix:
+    if candidate.suffix.lower() != f".{ext}":
         candidate = candidate.with_suffix(f".{ext}")
 
     target = candidate if candidate.is_absolute() else root / candidate

--- a/tests/test_gateway/test_chat_view_static.py
+++ b/tests/test_gateway/test_chat_view_static.py
@@ -32,9 +32,7 @@ def test_chat_view_wires_middle_edit_branch_fork_id() -> None:
     send_end = view.index("})\nconst { onSend", send_start)
     assert "pendingForkBeforeMessageId," in view[send_start:send_end]
 
-    session_watch_start = view.index("watch(sessionKey, () => {")
-    session_watch_end = view.index("})", session_watch_start)
-    assert "pendingForkBeforeMessageId.value = null" in view[session_watch_start:session_watch_end]
+    assert "watch(sessionKey, () => {\n  pendingForkBeforeMessageId.value = null" in view
 
     assert "pendingForkBeforeMessageId: Ref<string | null>" in send
     assert "params.forkBeforeMessageId = forkBeforeMessageId" in send

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -668,6 +668,242 @@ async def test_image_generation_configure_redacts_api_key(tmp_path, monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_image_generation_configure_accepts_exact_legacy_direct_key_payload(
+    tmp_path,
+    monkeypatch,
+):
+    from opensquilla.gateway.config import GatewayConfig
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    ctx = _admin_ctx()
+    ctx.config = GatewayConfig(config_path=str(target))
+    dispatcher = get_dispatcher()
+
+    public = await dispatcher.dispatch("r0", "config.get", {}, ctx)
+    assert public.error is None, public.error
+    provider = public.payload["image_generation"]["providers"]["openrouter"]
+    # The 0.5.0 form hydrates the default env name, does not clear it when a
+    # direct key is entered, and always emits the fallback array.
+    legacy_payload = {
+        "providerId": "openrouter",
+        "primary": "openrouter/google/gemini-3.1-flash-image-preview",
+        "apiKey": "sk-legacy-direct",
+        "apiKeyEnv": provider["api_key_env"],
+        "baseUrl": provider["base_url"],
+        "fallbacks": [],
+    }
+
+    res = await dispatcher.dispatch(
+        "r1",
+        "onboarding.imageGeneration.configure",
+        legacy_payload,
+        ctx,
+    )
+
+    assert res.error is None, res.error
+    assert ctx.config.image_generation.providers.openrouter.api_key == "sk-legacy-direct"
+    assert ctx.config.image_generation.providers.openrouter.api_key_env == ""
+    assert res.payload["entry"]["api_key_source"] == "explicit"
+
+
+@pytest.mark.asyncio
+async def test_image_generation_configure_normalizes_0_5_0_provider_switch_payload(
+    tmp_path,
+    monkeypatch,
+):
+    from opensquilla.gateway.config import GatewayConfig
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    ctx = _admin_ctx()
+    ctx.config = GatewayConfig(config_path=str(target))
+    dispatcher = get_dispatcher()
+
+    public = await dispatcher.dispatch("r0", "config.get", {}, ctx)
+    assert public.error is None, public.error
+    image_config = public.payload["image_generation"]
+    # In 0.5.0, changing only the provider updates the env field but leaves
+    # the previous provider's non-empty default model and endpoint in place.
+    legacy_switch_payload = {
+        "providerId": "openrouter",
+        "primary": image_config["primary"],
+        "apiKey": "sk-legacy-switch",
+        "apiKeyEnv": image_config["providers"]["openrouter"]["api_key_env"],
+        "baseUrl": image_config["providers"]["openai"]["base_url"],
+        "enabled": True,
+        "fallbacks": [],
+    }
+
+    res = await dispatcher.dispatch(
+        "r1",
+        "onboarding.imageGeneration.configure",
+        legacy_switch_payload,
+        ctx,
+    )
+
+    assert res.error is None, res.error
+    image_config = ctx.config.image_generation
+    assert image_config.primary == "openrouter/google/gemini-3.1-flash-image-preview"
+    provider = image_config.providers.openrouter
+    assert provider.api_key == "sk-legacy-switch"
+    assert provider.api_key_env == ""
+    assert provider.base_url == "https://openrouter.ai/api/v1"
+
+
+@pytest.mark.asyncio
+async def test_image_generation_configure_normalizes_custom_0_5_0_provider_switch_payload(
+    tmp_path,
+    monkeypatch,
+):
+    from opensquilla.gateway.config import GatewayConfig
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    ctx = _admin_ctx()
+    ctx.config = GatewayConfig(
+        config_path=str(target),
+        image_generation={
+            "enabled": True,
+            "primary": "openai/custom-image-model",
+            "fallbacks": ["openai/gpt-image-1"],
+            "providers": {
+                "openai": {"base_url": "https://images.example.test/v1"},
+            },
+        },
+    )
+    dispatcher = get_dispatcher()
+
+    # 0.5.0 keeps all source-provider fields after changing the provider. The
+    # target env name is the only field its change handler replaces.
+    legacy_switch_payload = {
+        "providerId": "openrouter",
+        "primary": "openai/custom-image-model",
+        "apiKey": "sk-legacy-switch",
+        "apiKeyEnv": "OPENROUTER_API_KEY",
+        "baseUrl": "https://images.example.test/v1",
+        "enabled": True,
+        "fallbacks": ["openai/gpt-image-1"],
+    }
+
+    res = await dispatcher.dispatch(
+        "r1",
+        "onboarding.imageGeneration.configure",
+        legacy_switch_payload,
+        ctx,
+    )
+
+    assert res.error is None, res.error
+    image_config = ctx.config.image_generation
+    assert image_config.primary == "openrouter/google/gemini-3.1-flash-image-preview"
+    assert image_config.fallbacks == ["openai/gpt-image-1"]
+    provider = image_config.providers.openrouter
+    assert provider.api_key == "sk-legacy-switch"
+    assert provider.base_url == "https://openrouter.ai/api/v1"
+
+
+@pytest.mark.asyncio
+async def test_image_generation_legacy_config_get_resave_preserves_direct_key_and_fallbacks(
+    tmp_path,
+    monkeypatch,
+):
+    from opensquilla.gateway.config import GatewayConfig
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    ctx = _admin_ctx()
+    ctx.config = GatewayConfig(
+        config_path=str(target),
+        image_generation={
+            "enabled": True,
+            "primary": "openrouter/google/gemini-3.1-flash-image-preview",
+            "fallbacks": ["openai/gpt-image-1"],
+            "providers": {
+                "openrouter": {
+                    "api_key": "sk-stored-direct",
+                    "api_key_env": "OPENROUTER_API_KEY",
+                }
+            },
+        },
+    )
+    dispatcher = get_dispatcher()
+
+    public = await dispatcher.dispatch("r0", "config.get", {}, ctx)
+    assert public.error is None, public.error
+    provider = public.payload["image_generation"]["providers"]["openrouter"]
+    assert provider["api_key"] == "[redacted]"
+    legacy_payload = {
+        "providerId": "openrouter",
+        "primary": public.payload["image_generation"]["primary"],
+        # The write-only 0.5.0 key field stays blank, so apiKey is omitted.
+        "apiKeyEnv": provider["api_key_env"],
+        "baseUrl": provider["base_url"],
+        "fallbacks": [],
+    }
+
+    res = await dispatcher.dispatch(
+        "r1",
+        "onboarding.imageGeneration.configure",
+        legacy_payload,
+        ctx,
+    )
+
+    assert res.error is None, res.error
+    assert ctx.config.image_generation.providers.openrouter.api_key == "sk-stored-direct"
+    assert ctx.config.image_generation.fallbacks == ["openai/gpt-image-1"]
+    assert res.payload["entry"]["api_key_source"] == "explicit"
+
+
+@pytest.mark.asyncio
+async def test_image_generation_configure_replaces_direct_key_and_resets_optional_fields(
+    tmp_path,
+    monkeypatch,
+):
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    first = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.imageGeneration.configure",
+        {
+            "providerId": "openrouter",
+            "primary": "openrouter/google/gemini-3.1-flash-image-preview",
+            "apiKey": "sk-direct",
+            "baseUrl": "https://images.example.test/v1",
+            "fallbacks": ["openai/gpt-image-1"],
+        },
+        _admin_ctx(),
+    )
+    assert first.error is None, first.error
+
+    second = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.imageGeneration.configure",
+        {
+            "providerId": "openrouter",
+            "primary": "openrouter/google/gemini-3.1-flash-image-preview",
+            "apiKeyEnv": "OPENSQUILLA_TEST_IMAGE_KEY",
+            "credentialMode": "env",
+            "baseUrl": "",
+            "fallbacks": [],
+            "clearFallbacks": True,
+        },
+        _admin_ctx(),
+    )
+    assert second.error is None, second.error
+
+    data = tomllib.loads(target.read_text())
+    provider = data["image_generation"]["providers"]["openrouter"]
+    assert provider.get("api_key", "") == ""
+    assert provider["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
+    assert provider["base_url"] == "https://openrouter.ai/api/v1"
+    assert data["image_generation"]["fallbacks"] == []
+
+
+@pytest.mark.asyncio
 async def test_image_generation_configure_can_use_custom_env_reference(
     tmp_path,
     monkeypatch,
@@ -762,6 +998,56 @@ async def test_image_generation_configure_can_disable_without_visible_key(
 
 
 @pytest.mark.asyncio
+async def test_image_generation_configure_can_disable_legacy_invalid_config(
+    tmp_path,
+    monkeypatch,
+):
+    from opensquilla.gateway.config import GatewayConfig
+
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    ctx = _admin_ctx()
+    ctx.config = GatewayConfig(
+        config_path=str(target),
+        image_generation={
+            "enabled": True,
+            "primary": "openrouter/google//image",
+            "fallbacks": ["openai/"],
+            "providers": {
+                "openrouter": {
+                    "api_key": "sk-synthetic-image",
+                    "base_url": "not-a-url",
+                }
+            },
+        },
+    )
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "onboarding.imageGeneration.configure",
+        {
+            "providerId": "openrouter",
+            "primary": "openrouter/google//image",
+            "baseUrl": "not-a-url",
+            "fallbacks": ["openai/"],
+            "enabled": False,
+        },
+        ctx,
+    )
+
+    assert res.error is None, res.error
+    assert ctx.config.image_generation.enabled is False
+    data = tomllib.loads(target.read_text())
+    assert data["image_generation"]["enabled"] is False
+    assert data["image_generation"]["primary"] == "openrouter/google//image"
+    assert data["image_generation"]["fallbacks"] == ["openai/"]
+    assert (
+        data["image_generation"]["providers"]["openrouter"]["base_url"]
+        == "not-a-url"
+    )
+
+
+@pytest.mark.asyncio
 async def test_onboarding_status_requires_image_generation_enable_for_llm_fallback(
     tmp_path,
     monkeypatch,
@@ -781,6 +1067,40 @@ async def test_onboarding_status_requires_image_generation_enable_for_llm_fallba
     assert res.payload["imageGenerationEnabled"] is False
     assert res.payload["imageGenerationSource"] == "none"
     assert res.payload["imageGenerationProvider"] == ""
+
+
+@pytest.mark.asyncio
+async def test_onboarding_status_marks_legacy_image_endpoint_mismatch_degraded(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(tmp_path / "c.toml"))
+    from opensquilla.gateway.config import GatewayConfig
+
+    ctx = _read_ctx()
+    ctx.config = GatewayConfig()
+    ctx.config.image_generation.enabled = True
+    ctx.config.image_generation.primary = (
+        "openrouter/google/gemini-3.1-flash-image-preview"
+    )
+    openrouter_provider = ctx.config.image_generation.providers.openrouter
+    openrouter_provider.api_key = "sk-synthetic-image"
+    openrouter_provider.base_url = "https://api.openai.com/v1"
+
+    res = await get_dispatcher().dispatch("r1", "onboarding.status", {}, ctx)
+
+    assert res.error is None, res.error
+    assert res.payload["sections"]["image_generation"] == "degraded"
+    assert res.payload["imageGenerationConfigured"] is False
+    assert res.payload["imageGenerationEnabled"] is True
+    assert res.payload["imageGenerationProvider"] == "openrouter"
+    assert res.payload["imageGenerationSource"] == "explicit"
+    detail = res.payload["sectionDetails"]["image_generation"]
+    assert detail["actionRequired"] is True
+    assert detail["blocking"] is False
+    assert detail["detail"] == (
+        "openrouter (endpoint/provider mismatch: configured openai official endpoint)"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -1822,6 +1822,85 @@ def test_upsert_image_generation_provider_configures_openrouter(monkeypatch):
     assert res.public_payload["api_key_source"] == "explicit"
 
 
+def test_upsert_image_generation_redacted_key_keeps_direct_credential_with_env_echo(
+    monkeypatch,
+):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    first = upsert_image_generation_provider(
+        GatewayConfig(),
+        provider_id="openrouter",
+        api_key="sk-stored-direct-key",
+    )
+
+    res = upsert_image_generation_provider(
+        first.config,
+        provider_id="openrouter",
+        api_key="***",
+        api_key_env="OPENROUTER_API_KEY",
+    )
+
+    provider = res.config.image_generation.providers.openrouter
+    assert provider.api_key == "sk-stored-direct-key"
+    assert res.public_payload["api_key_source"] == "explicit"
+
+
+def test_upsert_image_generation_legacy_direct_key_accepts_default_env_echo(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    res = upsert_image_generation_provider(
+        GatewayConfig(),
+        provider_id="openrouter",
+        primary=_IMG_PRIMARY,
+        api_key="sk-new-direct-key",
+        api_key_env="OPENROUTER_API_KEY",
+    )
+
+    provider = res.config.image_generation.providers.openrouter
+    assert provider.api_key == "sk-new-direct-key"
+    assert provider.api_key_env == ""
+    assert res.public_payload["api_key_source"] == "explicit"
+
+
+def test_upsert_image_generation_legacy_default_env_echo_keeps_stored_direct_key(
+    monkeypatch,
+):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    cfg = GatewayConfig(
+        image_generation={
+            "enabled": True,
+            "primary": _IMG_PRIMARY,
+            "providers": {
+                "openrouter": {
+                    "api_key": "sk-stored-direct-key",
+                    "api_key_env": "OPENROUTER_API_KEY",
+                }
+            },
+        }
+    )
+
+    res = upsert_image_generation_provider(
+        cfg,
+        provider_id="openrouter",
+        primary=_IMG_PRIMARY,
+        api_key_env="OPENROUTER_API_KEY",
+    )
+
+    provider = res.config.image_generation.providers.openrouter
+    assert provider.api_key == "sk-stored-direct-key"
+    assert res.public_payload["api_key_source"] == "explicit"
+
+
+def test_upsert_image_generation_legacy_direct_key_rejects_custom_env_echo():
+    with pytest.raises(ValueError, match="either api_key or api_key_env"):
+        upsert_image_generation_provider(
+            GatewayConfig(),
+            provider_id="openrouter",
+            primary=_IMG_PRIMARY,
+            api_key="sk-new-direct-key",
+            api_key_env="CUSTOM_IMAGE_KEY",
+        )
+
+
 def test_upsert_image_generation_provider_can_use_matching_llm_key(monkeypatch):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     cfg = GatewayConfig()
@@ -2340,6 +2419,45 @@ def test_upsert_image_generation_applies_size_format_fallbacks():
     assert res.public_payload["fallbacks"] == ["openai/gpt-image-1", "openrouter/x"]
 
 
+def test_upsert_image_generation_canonicalizes_openrouter_auto_model():
+    res = upsert_image_generation_provider(
+        GatewayConfig(),
+        provider_id="openrouter",
+        primary="openrouter/auto",
+        api_key="sk-img",
+        fallbacks=["openrouter/auto"],
+    )
+
+    assert res.config.image_generation.primary == "openrouter/openrouter/auto"
+    assert res.config.image_generation.fallbacks == ["openrouter/openrouter/auto"]
+
+
+def test_upsert_image_generation_legacy_switch_normalization_requires_saved_source_fields():
+    cfg = GatewayConfig(
+        image_generation={
+            "enabled": True,
+            "primary": "openai/custom-image-model",
+            "fallbacks": ["openai/gpt-image-1"],
+            "providers": {
+                "openai": {"base_url": "https://images.example.test/v1"},
+            },
+        }
+    )
+
+    with pytest.raises(ValueError, match="primary must be a provider/model reference"):
+        upsert_image_generation_provider(
+            cfg,
+            provider_id="openrouter",
+            primary="openai/custom-image-model",
+            api_key="sk-img",
+            api_key_env="OPENROUTER_API_KEY",
+            # This differs from the stored source endpoint, so it is not an
+            # old-client draft and must not receive compatibility rewriting.
+            base_url="https://untrusted.example.test/v1",
+            fallbacks=["openai/gpt-image-1"],
+        )
+
+
 def test_upsert_image_generation_empty_keeps_current():
     cfg = GatewayConfig()
     cfg.image_generation.size = "1024x1536"
@@ -2352,6 +2470,175 @@ def test_upsert_image_generation_empty_keeps_current():
     assert ig.size == "1024x1536"
     assert ig.output_format == "jpeg"
     assert ig.fallbacks == ["openrouter/keep"]
+
+
+def test_upsert_image_generation_legacy_empty_fallbacks_keep_current():
+    cfg = GatewayConfig()
+    cfg.image_generation.fallbacks = ["openrouter/keep"]
+
+    res = upsert_image_generation_provider(
+        cfg,
+        provider_id="openrouter",
+        primary=_IMG_PRIMARY,
+        api_key="sk-img",
+        fallbacks=[],
+    )
+
+    assert res.config.image_generation.fallbacks == ["openrouter/keep"]
+
+
+def test_upsert_image_generation_explicit_empty_fallbacks_clear_current():
+    cfg = GatewayConfig()
+    cfg.image_generation.fallbacks = ["openrouter/keep"]
+
+    res = upsert_image_generation_provider(
+        cfg,
+        provider_id="openrouter",
+        primary=_IMG_PRIMARY,
+        api_key="sk-img",
+        fallbacks=[],
+        clear_fallbacks=True,
+    )
+
+    assert res.config.image_generation.fallbacks == []
+    assert res.public_payload["fallbacks"] == []
+
+
+def test_upsert_image_generation_allows_authenticated_fallback_on_primary_metadata_save(
+    monkeypatch,
+):
+    from opensquilla.onboarding.section_status import (
+        SectionStatus,
+        image_generation_section_status,
+    )
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    cfg = GatewayConfig(
+        image_generation={
+            "enabled": True,
+            "primary": _IMG_PRIMARY,
+            "fallbacks": ["openai/gpt-image-1"],
+            "providers": {"openai": {"api_key": "sk-fallback"}},
+        }
+    )
+
+    res = upsert_image_generation_provider(
+        cfg,
+        provider_id="openrouter",
+        primary=_IMG_PRIMARY,
+        output_format="webp",
+    )
+
+    assert res.config.image_generation.output_format == "webp"
+    assert res.config.image_generation.fallbacks == ["openai/gpt-image-1"]
+    assert image_generation_section_status(res.config) is SectionStatus.OK
+
+
+def test_upsert_image_generation_env_reference_replaces_stored_direct_key():
+    first = upsert_image_generation_provider(
+        GatewayConfig(),
+        provider_id="openrouter",
+        primary=_IMG_PRIMARY,
+        api_key="sk-image-direct",
+    )
+
+    replaced = upsert_image_generation_provider(
+        first.config,
+        provider_id="openrouter",
+        primary=_IMG_PRIMARY,
+        api_key_env="OPENSQUILLA_TEST_IMAGE_KEY",
+        credential_mode="env",
+    )
+
+    provider = replaced.config.image_generation.providers.openrouter
+    assert provider.api_key == ""
+    assert provider.api_key_env == "OPENSQUILLA_TEST_IMAGE_KEY"
+
+
+@pytest.mark.parametrize(
+    ("primary", "fallbacks"),
+    [
+        ("openrouter/", None),
+        ("openrouter/google//image", None),
+        ("openrouter/google image", None),
+        (_IMG_PRIMARY, ["openai/"]),
+        (_IMG_PRIMARY, ["openai/gpt image"]),
+    ],
+)
+def test_upsert_image_generation_rejects_malformed_model_references(primary, fallbacks):
+    with pytest.raises(ValueError, match="provider/model|Invalid image generation model ref"):
+        upsert_image_generation_provider(
+            GatewayConfig(),
+            provider_id="openrouter",
+            primary=primary,
+            api_key="sk-img",
+            fallbacks=fallbacks,
+        )
+
+
+def test_upsert_image_generation_rejects_foreign_official_endpoint():
+    with pytest.raises(ValueError, match="cannot use the official 'openai' endpoint"):
+        upsert_image_generation_provider(
+            GatewayConfig(),
+            provider_id="openrouter",
+            primary=_IMG_PRIMARY,
+            api_key="sk-img",
+            base_url="https://api.openai.com/v1",
+        )
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "not-a-url",
+        "https://openrouter.ai:invalid/v1",
+        "https://openrouter.ai:99999/v1",
+        "https://openrouter.ai/api/v1?tenant=test",
+        "https://openrouter.ai/api/v1#fragment",
+        "https://user:secret@openrouter.ai/api/v1",
+    ],
+)
+def test_upsert_image_generation_rejects_invalid_endpoint(base_url):
+    with pytest.raises(ValueError, match="absolute http:// or https:// URL"):
+        upsert_image_generation_provider(
+            GatewayConfig(),
+            provider_id="openrouter",
+            primary=_IMG_PRIMARY,
+            api_key="sk-img",
+            base_url=base_url,
+        )
+
+
+def test_upsert_image_generation_can_disable_unchanged_legacy_invalid_config():
+    cfg = GatewayConfig(
+        image_generation={
+            "enabled": True,
+            "primary": "openrouter/google//image",
+            "fallbacks": ["openai/"],
+            "providers": {
+                "openrouter": {
+                    "api_key": "sk-synthetic-image",
+                    "base_url": "not-a-url",
+                }
+            },
+        }
+    )
+
+    res = upsert_image_generation_provider(
+        cfg,
+        provider_id="openrouter",
+        primary=cfg.image_generation.primary,
+        fallbacks=list(cfg.image_generation.fallbacks),
+        enabled=False,
+    )
+
+    assert res.config.image_generation.enabled is False
+    assert res.config.image_generation.primary == "openrouter/google//image"
+    assert res.config.image_generation.fallbacks == ["openai/"]
+    provider = res.config.image_generation.providers.openrouter
+    assert provider.base_url == "not-a-url"
+    assert provider.api_key == "sk-synthetic-image"
 
 
 def test_upsert_image_generation_rejects_bad_size():

--- a/tests/test_onboarding/test_section_status.py
+++ b/tests/test_onboarding/test_section_status.py
@@ -508,7 +508,15 @@ def test_image_generation_unknown_provider_reference_is_unknown(cfg, monkeypatch
     cfg.image_generation.enabled = True
     cfg.image_generation.primary = "no-such-provider/no-such-model"
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    status = get_onboarding_status(cfg)
+
     assert image_generation_section_status(cfg) is SectionStatus.UNKNOWN
+    assert status.image_generation_configured is False
+    assert status.image_generation_provider == "no-such-provider"
+    assert status.section_details["image_generation"]["detail"] == (
+        "no-such-provider (unknown image provider)"
+    )
 
 
 def test_image_generation_env_key_reference_missing_is_degraded(cfg, monkeypatch):
@@ -554,6 +562,138 @@ def test_image_generation_custom_default_primary_is_not_masked_by_other_provider
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     assert image_generation_section_status(cfg) is SectionStatus.DEGRADED
+
+
+def test_image_generation_official_endpoint_provider_mismatch_is_degraded(cfg):
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openrouter/google/gemini-3.1-flash-image-preview"
+    openrouter_provider = cfg.image_generation.providers.openrouter
+    openrouter_provider.api_key = "sk-synthetic-image"
+    openrouter_provider.base_url = "https://api.openai.com/v1"
+
+    status = get_onboarding_status(cfg)
+
+    assert image_generation_section_status(cfg) is SectionStatus.DEGRADED
+    assert status.image_generation_configured is False
+    assert status.image_generation_provider == "openrouter"
+    assert status.image_generation_source == "explicit"
+    detail = status.section_details["image_generation"]
+    assert detail["status"] == "degraded"
+    assert detail["actionRequired"] is True
+    assert detail["blocking"] is False
+    assert detail["detail"] == (
+        "openrouter (endpoint/provider mismatch: configured openai official endpoint)"
+    )
+
+
+def test_image_generation_custom_compatible_endpoint_remains_ok(cfg):
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openrouter/google/gemini-3.1-flash-image-preview"
+    openrouter_provider = cfg.image_generation.providers.openrouter
+    openrouter_provider.api_key = "sk-synthetic-image"
+    openrouter_provider.base_url = "https://images.example.test/v1"
+
+    assert image_generation_section_status(cfg) is SectionStatus.OK
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "not-a-url",
+        " https://openrouter.ai/api/v1 ",
+        "https://openrouter.ai:invalid/v1",
+        "https://openrouter.ai:99999/v1",
+        "https://openrouter.ai/api/v1?tenant=test",
+        "https://openrouter.ai/api/v1#fragment",
+        "https://user:secret@openrouter.ai/api/v1",
+    ],
+)
+def test_image_generation_invalid_endpoint_is_degraded(cfg, base_url):
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openrouter/google/gemini-3.1-flash-image-preview"
+    openrouter_provider = cfg.image_generation.providers.openrouter
+    openrouter_provider.api_key = "sk-synthetic-image"
+    openrouter_provider.base_url = base_url
+
+    status = get_onboarding_status(cfg)
+
+    assert image_generation_section_status(cfg) is SectionStatus.DEGRADED
+    assert status.image_generation_configured is False
+    assert status.section_details["image_generation"]["detail"] == (
+        "openrouter (invalid image endpoint; use an absolute http:// or https:// URL)"
+    )
+
+
+def test_image_generation_malformed_legacy_model_ref_is_unknown(cfg):
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openrouter/"
+    cfg.image_generation.providers.openrouter.api_key = "sk-synthetic-image"
+
+    status = get_onboarding_status(cfg)
+
+    assert image_generation_section_status(cfg) is SectionStatus.UNKNOWN
+    assert status.image_generation_configured is False
+    assert status.section_details["image_generation"]["detail"] == (
+        "invalid image provider/model reference"
+    )
+
+
+def test_image_generation_mismatch_is_not_hidden_by_a_healthy_fallback(cfg):
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openrouter/google/gemini-3.1-flash-image-preview"
+    cfg.image_generation.fallbacks = ["openai/gpt-image-1"]
+    cfg.image_generation.providers.openrouter.api_key = "sk-synthetic-openrouter"
+    cfg.image_generation.providers.openrouter.base_url = "https://api.openai.com/v1"
+    cfg.image_generation.providers.openai.api_key = "sk-synthetic-openai"
+
+    assert image_generation_section_status(cfg) is SectionStatus.DEGRADED
+
+
+def test_image_generation_default_env_does_not_apply_to_custom_endpoint(cfg, monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-default-origin-key")
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openrouter/google/gemini-3.1-flash-image-preview"
+    cfg.image_generation.providers.openrouter.base_url = "https://images.example.test/v1"
+    cfg.llm = LlmProviderConfig(provider="openai", model="m", api_key="")
+
+    assert image_generation_section_status(cfg) is SectionStatus.MISSING
+
+
+def test_image_generation_inherited_llm_endpoint_mismatch_is_degraded(cfg):
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openrouter/google/gemini-3.1-flash-image-preview"
+    cfg.image_generation.providers.openrouter.api_key = "sk-synthetic-image"
+    cfg.llm = LlmProviderConfig(
+        provider="openrouter",
+        model="m",
+        api_key="sk-synthetic-llm",
+        base_url="https://api.openai.com/v1",
+    )
+
+    assert image_generation_section_status(cfg) is SectionStatus.DEGRADED
+
+
+def test_image_generation_cross_origin_llm_key_is_degraded(cfg, monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    cfg.image_generation.enabled = True
+    cfg.image_generation.primary = "openrouter/google/gemini-3.1-flash-image-preview"
+    cfg.image_generation.providers.openrouter.base_url = "https://images.example.test/v1"
+    cfg.llm = LlmProviderConfig(
+        provider="openrouter",
+        model="m",
+        api_key="sk-synthetic-llm",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    status = get_onboarding_status(cfg)
+
+    assert image_generation_section_status(cfg) is SectionStatus.DEGRADED
+    assert status.image_generation_configured is False
+    assert status.image_generation_source == "none"
+    assert status.image_generation_provider == "openrouter"
+    assert status.section_details["image_generation"]["detail"] == (
+        "openrouter (LLM key cannot be reused across image endpoint origins)"
+    )
 
 
 # ── memory embedding ────────────────────────────────────────────────────────

--- a/tests/test_onboarding/test_setup_engine.py
+++ b/tests/test_onboarding/test_setup_engine.py
@@ -6,7 +6,9 @@ import tomllib
 
 from opensquilla.gateway.config import GatewayConfig
 from opensquilla.onboarding.config_store import load_config
+from opensquilla.onboarding.section_status import SectionStatus
 from opensquilla.onboarding.setup_engine import SetupEngine
+from opensquilla.onboarding.status import get_onboarding_status
 
 
 def test_setup_engine_applies_provider_and_router_without_persisting_secret(tmp_path):
@@ -195,6 +197,42 @@ def test_setup_engine_image_generation_can_use_custom_env_reference(
     provider = data["image_generation"]["providers"]["openrouter"]
     assert load_config(target).image_generation.providers.openrouter.api_key == ""
     assert provider["api_key_env"] == "OPENSQUILLA_TEST_IMAGE_KEY"
+
+
+def test_setup_engine_forwards_image_format_size_fallbacks_and_explicit_resets(tmp_path):
+    target = tmp_path / "config.toml"
+    engine = SetupEngine(path=target)
+
+    engine.apply(
+        "image-generation",
+        {
+            "providerId": "openrouter",
+            "primary": "openrouter/google/gemini-3.1-flash-image-preview",
+            "apiKey": "sk-first",
+            "baseUrl": "https://images.example.test/v1",
+            "size": "1536x1024",
+            "outputFormat": "webp",
+            "fallbacks": ["openai/gpt-image-1"],
+        },
+    )
+    engine.apply(
+        "image-generation",
+        {
+            "providerId": "openrouter",
+            "primary": "openrouter/google/gemini-3.1-flash-image-preview",
+            "apiKey": "sk-second",
+            "baseUrl": "",
+            "fallbacks": [],
+            "clearFallbacks": True,
+        },
+    )
+    engine.persist()
+
+    saved = load_config(target).image_generation
+    assert saved.size == "1536x1024"
+    assert saved.output_format == "webp"
+    assert saved.fallbacks == []
+    assert saved.providers.openrouter.base_url == "https://openrouter.ai/api/v1"
 
 
 def test_setup_engine_accepts_short_capability_section_aliases(tmp_path, monkeypatch):
@@ -411,3 +449,25 @@ def test_setup_engine_image_enabled_none_defaults_to_enabled_for_fresh_config(
     engine.persist()
 
     assert load_config(target).image_generation.enabled is True
+
+
+def test_setup_engine_loads_legacy_image_endpoint_mismatch_as_degraded(tmp_path):
+    target = tmp_path / "config.toml"
+    target.write_text(
+        "[image_generation]\n"
+        "enabled = true\n"
+        'primary = "openrouter/google/gemini-3.1-flash-image-preview"\n'
+        "\n"
+        "[image_generation.providers.openrouter]\n"
+        'api_key = "sk-synthetic-image"\n'
+        'base_url = "https://api.openai.com/v1"\n',
+        encoding="utf-8",
+    )
+
+    engine = SetupEngine(path=target)
+    status = get_onboarding_status(engine.config)
+
+    assert engine.config.image_generation.enabled is True
+    assert status.sections["image_generation"] is SectionStatus.DEGRADED
+    assert status.image_generation_configured is False
+    assert status.section_details["image_generation"]["actionRequired"] is True

--- a/tests/test_provider_image_generation.py
+++ b/tests/test_provider_image_generation.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import base64
+import io
 import json
 from types import SimpleNamespace
 
 import pytest
+from PIL import Image
 
 from opensquilla.provider.image_generation import (
     ImageGenerationRequest,
@@ -12,6 +14,13 @@ from opensquilla.provider.image_generation import (
     OpenRouterImageGenerationProvider,
     get_image_generation_provider,
 )
+
+
+def _test_png_bytes() -> bytes:
+    buffer = io.BytesIO()
+    with Image.new("RGBA", (2, 1), (30, 120, 210, 128)) as image:
+        image.save(buffer, format="PNG")
+    return buffer.getvalue()
 
 
 def _clear_vision_provider_env(monkeypatch) -> None:
@@ -92,6 +101,213 @@ async def test_openrouter_image_provider_adds_app_attribution_headers(monkeypatc
         "X-Title": "OpenSquilla",
     }
     assert result.image_bytes == b"opensquilla"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("candidate", "wire_model"),
+    [
+        (
+            "openrouter/google/gemini-3.1-flash-image-preview",
+            "google/gemini-3.1-flash-image-preview",
+        ),
+        ("openrouter/auto", "openrouter/auto"),
+        ("openrouter/openrouter/auto", "openrouter/auto"),
+    ],
+)
+async def test_openrouter_model_ref_keeps_provider_for_routing_but_not_wire_model(
+    monkeypatch,
+    candidate,
+    wire_model,
+) -> None:
+    from opensquilla.provider import image_generation
+
+    captured: dict[str, object] = {}
+    encoded_image = base64.b64encode(_test_png_bytes()).decode("ascii")
+
+    class FakeResponse:
+        text = ""
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "images": [
+                                {
+                                    "image_url": {
+                                        "url": f"data:image/png;base64,{encoded_image}"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url, *, headers, json):
+            captured["url"] = url
+            captured["json"] = json
+            return FakeResponse()
+
+    monkeypatch.setattr(
+        image_generation.httpx,
+        "AsyncClient",
+        lambda **kwargs: FakeClient(),
+    )
+    provider = OpenRouterImageGenerationProvider(api_key="synthetic-openrouter-key")
+    image_generation.register_image_generation_provider(provider)
+    try:
+        result = await image_generation.generate_with_fallbacks(
+            request=ImageGenerationRequest(
+                prompt="draw a squid",
+                model=candidate,
+                size="1024x1024",
+            ),
+            candidates=[candidate],
+        )
+    finally:
+        image_generation.reset_image_generation_providers()
+
+    assert captured["url"] == "https://openrouter.ai/api/v1/chat/completions"
+    assert captured["json"]["model"] == wire_model
+    assert result.provider == "openrouter"
+    assert result.model == wire_model
+    assert result.mime_type == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_image_provider_rejects_foreign_official_endpoint_before_http(
+    monkeypatch,
+) -> None:
+    client_constructed = False
+
+    def fail_if_http_client_is_constructed(**_kwargs):
+        nonlocal client_constructed
+        client_constructed = True
+        raise AssertionError("HTTP client must not be constructed")
+
+    monkeypatch.setattr(
+        "opensquilla.provider.image_generation.httpx.AsyncClient",
+        fail_if_http_client_is_constructed,
+    )
+    provider = OpenRouterImageGenerationProvider(
+        api_key="synthetic-openrouter-key",
+        base_url="https://api.openai.com/v1",
+    )
+
+    with pytest.raises(RuntimeError, match="cannot use 'openai'.*official endpoint"):
+        await provider.generate(
+            ImageGenerationRequest(
+                prompt="draw a squid",
+                model="google/gemini-3.1-flash-image-preview",
+                size="1024x1024",
+            )
+        )
+
+    assert client_constructed is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        " https://openrouter.ai/api/v1 ",
+        "https://openrouter.ai:invalid/v1",
+        "https://openrouter.ai/api/v1?tenant=test",
+    ],
+)
+async def test_image_provider_rejects_invalid_endpoint_before_http(
+    monkeypatch,
+    base_url,
+) -> None:
+    client_constructed = False
+
+    def fail_if_http_client_is_constructed(**_kwargs):
+        nonlocal client_constructed
+        client_constructed = True
+        raise AssertionError("HTTP client must not be constructed")
+
+    monkeypatch.setattr(
+        "opensquilla.provider.image_generation.httpx.AsyncClient",
+        fail_if_http_client_is_constructed,
+    )
+    provider = OpenRouterImageGenerationProvider(
+        api_key="synthetic-openrouter-key",
+        base_url=base_url,
+    )
+
+    with pytest.raises(RuntimeError, match="invalid endpoint"):
+        await provider.generate(
+            ImageGenerationRequest(
+                prompt="draw a squid",
+                model="google/gemini-3.1-flash-image-preview",
+                size="1024x1024",
+            )
+        )
+
+    assert client_constructed is False
+
+
+def test_image_generation_availability_rejects_foreign_official_endpoint() -> None:
+    from opensquilla.gateway.config import ImageGenerationConfig
+    from opensquilla.tools.builtin.media import (
+        configure_image_generation,
+        image_generation_available,
+    )
+
+    config = ImageGenerationConfig(
+        enabled=True,
+        primary="openrouter/google/gemini-3.1-flash-image-preview",
+    )
+    config.providers.openrouter.base_url = "https://api.openai.com/v1"
+    config.providers.openrouter.api_key = "synthetic-openrouter-key"
+    configure_image_generation(config)
+    try:
+        assert image_generation_available() is False
+    finally:
+        configure_image_generation(None)
+
+
+def test_image_generation_availability_allows_endpointless_registered_provider() -> None:
+    from opensquilla.gateway.config import ImageGenerationConfig
+    from opensquilla.provider import image_generation
+    from opensquilla.tools.builtin.media import (
+        configure_image_generation,
+        image_generation_available,
+    )
+
+    class FakeProvider:
+        provider_id = "synthetic"
+        default_model = "image-model"
+        auth_env_vars: tuple[str, ...] = ()
+
+        async def generate(self, request: ImageGenerationRequest) -> ImageGenerationResult:
+            return ImageGenerationResult(
+                image_bytes=_test_png_bytes(),
+                mime_type="image/png",
+                model=request.model,
+                provider=self.provider_id,
+            )
+
+    configure_image_generation(
+        ImageGenerationConfig(enabled=True, primary="synthetic/image-model")
+    )
+    image_generation.register_image_generation_provider(FakeProvider())
+    try:
+        assert image_generation_available()
+    finally:
+        configure_image_generation(None)
 
 
 @pytest.mark.asyncio
@@ -217,7 +433,7 @@ async def test_image_generation_fallback_operation_derives_one_correlation() -> 
             if len(captured) == 1:
                 raise RuntimeError("first candidate failed")
             return ImageGenerationResult(
-                image_bytes=b"image",
+                image_bytes=_test_png_bytes(),
                 mime_type="image/png",
                 model=request.model,
                 provider=self.provider_id,
@@ -254,6 +470,52 @@ async def test_image_generation_fallback_operation_derives_one_correlation() -> 
         fallback_correlation.call_kind
         == "auxiliary.image_generation.provider_fallback"
     )
+
+
+@pytest.mark.asyncio
+async def test_invalid_provider_image_triggers_fallback_and_requested_format_conversion() -> None:
+    from opensquilla.provider import image_generation
+
+    generated_models: list[str] = []
+
+    class FakeProvider:
+        provider_id = "synthetic"
+        default_model = "image-model"
+        auth_env_vars: tuple[str, ...] = ()
+
+        async def generate(
+            self,
+            request: ImageGenerationRequest,
+        ) -> ImageGenerationResult:
+            generated_models.append(request.model)
+            image_bytes = b"not-an-image" if request.model == "broken" else _test_png_bytes()
+            return ImageGenerationResult(
+                image_bytes=image_bytes,
+                mime_type="image/png",
+                model=request.model,
+                provider=self.provider_id,
+            )
+
+    image_generation.register_image_generation_provider(FakeProvider())
+    try:
+        result = await image_generation.generate_with_fallbacks(
+            request=ImageGenerationRequest(
+                prompt="draw a squid",
+                model="synthetic/broken",
+                size="1024x1024",
+                output_format="webp",
+            ),
+            candidates=["synthetic/broken", "synthetic/working"],
+        )
+    finally:
+        image_generation.reset_image_generation_providers()
+
+    assert generated_models == ["broken", "working"]
+    assert len(result.attempts) == 1
+    assert "invalid image bytes" in result.attempts[0].error
+    assert result.mime_type == "image/webp"
+    with Image.open(io.BytesIO(result.image_bytes)) as image:
+        assert image.format == "WEBP"
 
 
 @pytest.mark.parametrize(
@@ -385,6 +647,63 @@ async def test_image_generate_does_not_auto_publish_artifact_for_subagent(
     assert result["status"] == "ok"
     assert "artifact" not in result
     assert ctx.published_artifacts == []
+
+
+@pytest.mark.asyncio
+async def test_image_generate_uses_configured_size_and_matching_output_suffix(
+    tmp_path,
+) -> None:
+    from opensquilla.gateway.config import ImageGenerationConfig
+    from opensquilla.provider import image_generation
+    from opensquilla.tools.builtin import media
+    from opensquilla.tools.types import ToolContext, current_tool_context
+
+    captured_requests: list[ImageGenerationRequest] = []
+
+    class FakeProvider:
+        provider_id = "synthetic"
+        default_model = "image-model"
+        auth_env_vars: tuple[str, ...] = ()
+
+        async def generate(
+            self,
+            request: ImageGenerationRequest,
+        ) -> ImageGenerationResult:
+            captured_requests.append(request)
+            return ImageGenerationResult(
+                image_bytes=_test_png_bytes(),
+                mime_type="image/png",
+                model=request.model,
+                provider=self.provider_id,
+            )
+
+    config = ImageGenerationConfig(
+        enabled=True,
+        primary="synthetic/image-model",
+        size="1536x1024",
+        output_format="webp",
+    )
+    media.configure_image_generation(config)
+    image_generation.register_image_generation_provider(FakeProvider())
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    try:
+        payload = json.loads(
+            await media.image_generate(
+                prompt="draw a squid",
+                filename="configured-format.png",
+            )
+        )
+    finally:
+        current_tool_context.reset(token)
+        media.configure_image_generation(None)
+
+    assert len(captured_requests) == 1
+    assert captured_requests[0].size == "1536x1024"
+    assert captured_requests[0].output_format == "webp"
+    assert payload["path"].endswith("configured-format.webp")
+    assert payload["mime_type"] == "image/webp"
+    with Image.open(payload["path"]) as image:
+        assert image.format == "WEBP"
 
 
 @pytest.mark.asyncio

--- a/tests/test_public_release_hygiene.py
+++ b/tests/test_public_release_hygiene.py
@@ -65,6 +65,8 @@ PATH_POLICY_FIXTURE_FILES = {
     "tests/test_tools/test_web_http_request.py",
     "tests/test_observability/test_decision_log_contract.py",
     "opensquilla-webui/src/components/SupportDiagnosticsMenu.test.ts",
+    "opensquilla-webui/src/composables/chat/useChatShareExport.test.ts",
+    "opensquilla-webui/src/utils/chat/activityToolDetails.test.ts",
     "opensquilla-webui/src/utils/overviewDiagnostics.test.ts",
     "opensquilla-webui/src/views/OverviewView.diagnostics.test.ts",
 }


### PR DESCRIPTION
Scope boundary: Image-generation configuration plus two narrow CI-contract repairs: the Vue capabilities form, onboarding RPC/setup path, provider routing validation, status reporting, image runtime behavior, static ChatView watcher coverage, and public-fixture path-policy registration. No unrelated provider, session, or channel behavior changed.

Base branch: `main`

Target exception: None.

Linked issue: None.

Release note: Fix image generation setup in the control UI, including exact compatibility handling for stale 0.5.0 client payloads and correct OpenRouter wire-model routing. The CI-contract repairs have no user-facing release note.

Tests:
- `uv run pytest tests/test_gateway/test_rpc_onboarding.py tests/test_onboarding/test_mutations.py tests/test_onboarding/test_section_status.py tests/test_onboarding/test_setup_engine.py tests/test_provider_image_generation.py -q` (`354 passed`)
- `uv run pytest tests/test_gateway/test_chat_view_static.py tests/test_public_release_hygiene.py -q` (`15 passed`)
- `npm run test:unit` (`1765 passed`)
- `npm run typecheck`
- `uv run ruff check src tests`
- `uv run ruff check tests/test_gateway/test_chat_view_static.py tests/test_public_release_hygiene.py`
- `uv run mypy src/opensquilla --show-error-codes`
- `npm run build` and `npm run verify:dist`
- Browser verification on an isolated gateway: provider switching updates model and endpoint; the OpenRouter model input remains provider-local.

Maintainer live check: Isolated gateway at `http://127.0.0.1:18795/control/`; enabled image generation, switched providers, and verified the persisted OpenRouter primary is `openrouter/google/gemini-3.1-flash-image-preview` without exposing a real credential.

Compatibility and safety: Exact stale 0.5.0 switch payloads are normalized only when every source field matches persisted configuration. The follow-up only makes existing CI contracts accurately identify an existing session-reset watcher and explicitly recognizes two synthetic redaction fixtures. Platform-neutral change; no filesystem, process, or signal behavior changed. No secrets, user transcripts, generated runtime data, or third-party code are included.

Third-party origin: None.