### PR TITLE
Prevent conversation history rail overlap

### DIFF
--- a/opensquilla-webui/e2e/conversation-minimap.spec.ts
+++ b/opensquilla-webui/e2e/conversation-minimap.spec.ts
@@ -143,6 +143,56 @@ test.describe('Long conversation history rail', () => {
     expect(arrivalPaint.maxTransitionDuration).toBeLessThanOrEqual(0.00001)
   })
 
+  test('keeps the maximum lens clear of the centered conversation column', async ({ page }) => {
+    await page.addInitScript(() => localStorage.removeItem('opensquilla.sidebar.width.v1'))
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await seedLongHistory(page)
+    await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(SESSION_KEY))
+    await page.waitForSelector('.conn-pill', { timeout: 10000 })
+
+    const rail = page.getByTestId('conversation-minimap')
+    const markers = page.getByTestId('conversation-minimap-marker')
+    await expect(markers).toHaveCount(12, { timeout: 10000 })
+
+    // The 260px sidebar plus 5px resizer leaves a 1105px chat shell here:
+    // one pixel inside the rail's visible exit edge and closest to collision.
+    await page.setViewportSize({ width: 1370, height: 900 })
+    await expect.poll(async () => Math.round(
+      (await page.locator('.chat-thread-shell').boundingBox())?.width || 0,
+    )).toBe(1105)
+    await expect(markers).toHaveCount(12)
+
+    const marker = markers.nth(5)
+    await marker.focus()
+    await expect(marker).toBeFocused()
+    await expect(rail.getByRole('tooltip')).toBeVisible()
+
+    await expect.poll(async () => {
+      const [lineBox, messageBox, composerBox, shellBox] = await Promise.all([
+        marker.locator('.conversation-minimap__line').boundingBox(),
+        page.locator('.msg-ai').first().boundingBox(),
+        page.locator('.chat-composer').boundingBox(),
+        page.locator('.chat-thread-shell').boundingBox(),
+      ])
+      if (!lineBox || !messageBox || !composerBox || !shellBox) return null
+      const focusRingRight = lineBox.x + lineBox.width + 4
+      const center = (box: { x: number; width: number }) => box.x + box.width / 2
+      return {
+        focusRingHasSafeGap: messageBox.x - focusRingRight >= 8,
+        messageComposerCentersStayAligned:
+          Math.abs(center(messageBox) - center(composerBox)) <= 5,
+        messageShellCentersStayAligned:
+          Math.abs(center(messageBox) - center(shellBox)) <= 5,
+      }
+    }).toEqual({
+      // The thread's stable end-side scrollbar gutter accounts for this 5px
+      // optical offset; the minimap must not add another asymmetric shift.
+      focusRingHasSafeGap: true,
+      messageComposerCentersStayAligned: true,
+      messageShellCentersStayAligned: true,
+    })
+  })
+
   test('stays centered, clears focus when hidden, and respects sidebar hit-area spacing', async ({ page }) => {
     await page.addInitScript(() => localStorage.removeItem('opensquilla.sidebar.width.v1'))
     await page.setViewportSize({ width: 1440, height: 900 })
@@ -230,8 +280,8 @@ test.describe('Long conversation history rail', () => {
     await expect(rail).toHaveCount(0)
     await expect(page.getByRole('tooltip')).toHaveCount(0)
 
-    // 1057–1103px is the hidden middle band after an exit; only crossing the
-    // 1104px enter edge should remount the rail.
+    // 1105–1119px is the hidden middle band after an exit; only crossing the
+    // 1120px enter edge should remount the rail.
     const resizedHandle = await resizer.boundingBox()
     await page.mouse.move(resizedHandle!.x + 1, 420)
     await page.mouse.down()

--- a/opensquilla-webui/src/components/chat/ConversationMinimap.test.ts
+++ b/opensquilla-webui/src/components/chat/ConversationMinimap.test.ts
@@ -425,9 +425,9 @@ describe('ConversationMinimap', () => {
     expect(markers(host)).toHaveLength(8)
   })
 
-  it('enters only at the 1104px conversation-pane threshold', async () => {
+  it('enters only at the 1120px conversation-pane threshold', async () => {
     const rendered = messages(8)
-    const narrowThread = makeThread(rendered, 1103)
+    const narrowThread = makeThread(rendered, 1119)
     const narrowHost = document.createElement('div')
     document.body.appendChild(narrowHost)
     const narrowApp = createApp(ConversationMinimap, {
@@ -441,13 +441,13 @@ describe('ConversationMinimap', () => {
     await new Promise(resolve => window.setTimeout(resolve, 20))
 
     expect(narrowHost.querySelector('[data-testid="conversation-minimap"]')).toBeNull()
-    const wide = await mountMinimap(8, {}, { clientWidth: 1104 })
+    const wide = await mountMinimap(8, {}, { clientWidth: 1120 })
     expect(markers(wide.host)).toHaveLength(8)
   })
 
-  it('keeps the rail mounted until the pane crosses the 1056px exit threshold', async () => {
+  it('keeps the rail mounted until the pane crosses the 1104px collision floor', async () => {
     const observers = stubResizeObservers()
-    const { host, thread } = await mountMinimap(8, {}, { clientWidth: 1104 })
+    const { host, thread } = await mountMinimap(8, {}, { clientWidth: 1120 })
     const shellObserver = observers.find(observer => observer.targets.has(thread.container))!
     const resizeTo = async (width: number) => {
       Object.defineProperty(thread.container, 'clientWidth', { configurable: true, value: width })
@@ -455,13 +455,13 @@ describe('ConversationMinimap', () => {
       await nextTick()
     }
 
-    await resizeTo(1057)
+    await resizeTo(1105)
     expect(markers(host)).toHaveLength(8)
-    await resizeTo(1056)
-    await vi.waitFor(() => expect(host.querySelector('[data-testid="conversation-minimap"]')).toBeNull())
-    await resizeTo(1103)
-    expect(host.querySelector('[data-testid="conversation-minimap"]')).toBeNull()
     await resizeTo(1104)
+    await vi.waitFor(() => expect(host.querySelector('[data-testid="conversation-minimap"]')).toBeNull())
+    await resizeTo(1119)
+    expect(host.querySelector('[data-testid="conversation-minimap"]')).toBeNull()
+    await resizeTo(1120)
     await vi.waitFor(() => expect(markers(host)).toHaveLength(8))
   })
 

--- a/opensquilla-webui/src/components/chat/ConversationMinimap.vue
+++ b/opensquilla-webui/src/components/chat/ConversationMinimap.vue
@@ -90,8 +90,13 @@ const EXIT_SCROLL_RANGE_RATIO = 1
 // not mount/unmount the rail on every sub-pixel wobble around one boundary.
 // A fresh rail must reach the enter threshold; once visible it is allowed to
 // remain until the conversation pane crosses the lower exit threshold.
-const ENTER_INLINE_SIZE = 1104
-const EXIT_INLINE_SIZE = 1056
+// The rail's 30px lens starts 14px from the shell edge; its focus ring reaches
+// another 4px. At the 1104px floor, the shared 980px conversation column still
+// leaves a stable gap after accounting for the thread's scrollbar gutter.
+// Enter a little later than that floor so live sidebar resizing cannot flicker
+// the rail at the exact collision boundary.
+const ENTER_INLINE_SIZE = 1120
+const EXIT_INLINE_SIZE = 1104
 const ARRIVAL_HIGHLIGHT_MS = 650
 const ARRIVAL_TOLERANCE_PX = 4
 const MAX_PREVIEW_LENGTH = 220
@@ -923,9 +928,9 @@ onBeforeUnmount(() => {
   font-size: var(--fs-xs);
 }
 
-/* This is the hard safety floor only. JavaScript owns the 1104px enter / 1056px
+/* This is the hard safety floor only. JavaScript owns the 1120px enter / 1104px
    exit hysteresis; using the enter value here would defeat that hysteresis. */
-@container chat-thread-shell (max-width: 1056px) {
+@container chat-thread-shell (max-width: 1104px) {
   .conversation-minimap {
     display: none;
   }


### PR DESCRIPTION
## Scope

- raise the conversation minimap width hysteresis so the maximum lens and focus ring stay clear of the message column
- remove the asymmetric thread-padding workaround so messages and the composer remain centered
- add unit coverage for the 1120px enter and 1104px exit boundaries
- add a real Chromium geometry regression at the narrowest visible 1105px shell

## Branch target

`main`

## Linked issue

None

## Release note status

Not added; this is a focused WebUI layout regression fix.

## Test results

- `npm run test:unit -- src/components/chat/ConversationMinimap.test.ts` — 20 passed
- `npm run typecheck` — passed, including architecture, theme, motion, security, and i18n guards
- `npx playwright test e2e/conversation-minimap.spec.ts --project=chromium` — 4 passed
- scoped `git diff --check` — passed

## Safety and compatibility

- platform-neutral WebUI layout change; no filesystem, process, or platform API behavior
- no persisted state, configuration, RPC field, CLI flag, database, or public protocol changes
- existing installations and desktop clients require no migration
- coarse-pointer and reduced-motion behavior remains unchanged

## Third-party origin

None. The implementation and tests are original to OpenSquilla.