### PR TITLE
Make coding and delivery guidance capability-aware

### DIFF
--- a/src/opensquilla/engine/steps/coding_mode.py
+++ b/src/opensquilla/engine/steps/coding_mode.py
@@ -1,11 +1,12 @@
 """Pre-turn step: enforce coding mode when the operator toggle is ON.
 
-Coding mode is an UNCONDITIONAL operator toggle, not an intent classifier.
-While it is ON, every turn gets a directive that steers code changes through
-the code-task plugin (``opensquilla code-task solve``) instead of letting the
-agent clone and hand-edit repositories itself (which skips the runner-verified
-red->green proof). No per-message detection is performed: the directive is
-injected on every turn while coding mode is on, and not at all while it is off.
+Coding mode is an operator toggle, not an intent classifier. While it is ON,
+turns with the complete code-task launch surface get a directive that steers
+code changes through the code-task plugin (``opensquilla code-task solve``)
+instead of letting the agent clone and hand-edit repositories itself (which
+skips the runner-verified red->green proof). Restricted surfaces that cannot
+launch code-task receive neither the directive nor the skill. No per-message
+detection is performed.
 
 The directive does NOT tell the agent to run a BARE ``opensquilla``: the gateway
 shell tools inherit the gateway process PATH, which frequently does NOT contain
@@ -35,6 +36,7 @@ log = structlog.get_logger(__name__)
 
 _CODE_TASK_PREFLIGHT_TIMEOUT = 15.0
 _PACKAGED_GATEWAY_EXECUTABLES = {"opensquilla-gateway", "opensquilla-gateway.exe"}
+_CODE_TASK_REQUIRED_TOOLS = frozenset({"background_process", "exec_command", "process"})
 
 
 def _runs_code_task(argv: list[str]) -> bool:
@@ -296,9 +298,27 @@ def _coding_mode_on(ctx: TurnContext) -> bool:
     return bool(getattr(skills_cfg, "coding_mode", False))
 
 
+def _missing_code_task_tools(ctx: TurnContext) -> set[str]:
+    """Return launch tools absent from this turn's already-filtered surface."""
+    available_tools = {
+        str(getattr(tool, "name", ""))
+        for tool in (getattr(ctx, "tool_defs", None) or [])
+    }
+    return set(_CODE_TASK_REQUIRED_TOOLS - available_tools)
+
+
 async def enforce_coding_mode(ctx: TurnContext) -> TurnContext:
-    """Inject the coding-mode directive + pin code-task while the toggle is on."""
+    """Inject and pin code-task when coding mode and its launch tools are available."""
     if not _coding_mode_on(ctx):
+        return ctx
+
+    missing_tools = _missing_code_task_tools(ctx)
+    if missing_tools:
+        # `filter_skills` independently gates the manifest on the same three
+        # tools. Do not leave a conflicting, mandatory code-task instruction
+        # on restricted callers such as ordinary channel users.
+        ctx.metadata["enforce_coding_mode__applied"] = False
+        log.info("coding_mode.skipped", missing_tools=sorted(missing_tools))
         return ctx
 
     # Resolve the code-task invocation off the event loop (cached after first).

--- a/src/opensquilla/skills/bundled/code-task/SKILL.md
+++ b/src/opensquilla/skills/bundled/code-task/SKILL.md
@@ -24,6 +24,10 @@ provenance:
   maintained_by: OpenSquilla
 metadata:
   {
+    "opensquilla":
+      {
+        "requires_tools": ["background_process", "exec_command", "process"],
+      },
     "platform":
       {
         "emoji": "🛠️",

--- a/src/opensquilla/skills/bundled/pptx/SKILL.md
+++ b/src/opensquilla/skills/bundled/pptx/SKILL.md
@@ -262,8 +262,10 @@ Plain bullets on white look generated. Apply each item before declaring done:
 - Pick a content-specific palette (one dominant color ~60% of weight, one
   support, one accent). Avoid generic blue.
 - Title slides and section dividers in dark; content slides in light.
-- Every slide carries one visual element: an icon, a stat callout, a chart,
-  or an image. No slide is title + bullets only.
+- Every slide carries one meaningful visual element: a topic-specific image,
+  chart, diagram, data graphic, or recognizable icon. Emoji, colored boxes,
+  and decorative lines do not satisfy this requirement. No slide is title +
+  bullets only.
 - Use varied layouts across slides — two-column, half-bleed image, stat
   grid, quote slide. Repeating one layout for ten pages is the strongest
   "AI-generated" tell.
@@ -274,14 +276,23 @@ Plain bullets on white look generated. Apply each item before declaring done:
 
 ---
 
-## Visual QA (required for paths B and C)
+## Visual QA (when render tools are available)
 
-A first render is rarely correct. Render to images and inspect.
+For paths B and C, when both `soffice` (LibreOffice) and `pdftoppm` (poppler)
+are available and the renderer runs, render the entire deck to images and
+inspect every page before `publish_artifact`.
 
 ```bash
 bash {baseDir}/scripts/render_thumbs.sh out.pptx
 # emits out-01.jpg, out-02.jpg, ... in cwd, plus out.pdf
 ```
+
+Do not pass `--range` for final QA. Count the emitted `out-*.jpg` files and
+inspect each one. A timeout, conversion error, missing thumbnail, or a review
+of only a subset of the pages means visual QA is incomplete. If inspection
+finds a defect, fix it, render the entire deck again, and re-inspect every
+page. If the full inspection finds no defect, publish without inventing an
+unnecessary edit just to force a rerender.
 
 The script needs `soffice` (LibreOffice) and `pdftoppm` (poppler) on PATH. If
 either is missing, the script tells you what to install for the host OS.
@@ -299,9 +310,15 @@ For each slide list:
   - Inconsistent spacing across analogous slides
   - Leftover placeholder text ("Lorem", "TODO", "{{...}}", "xxxx")
   - Misaligned columns or icons
-Report all findings. Do not declare clean unless one fix-and-reverify cycle
-has passed.
+Report all findings. When you found a defect, do not declare clean until its
+fix-and-reverify cycle has passed across every rendered page.
 ```
+
+If either render tool is unavailable, visual QA is unavailable. A B1 text-only
+edit may still be published after the file saves and the intended text is
+verified; state that visual QA was unavailable. For B2 or C work without a
+renderer, complete the available structural checks but do not claim that visual
+QA passed.
 
 ---
 
@@ -334,8 +351,16 @@ has passed.
   Debian/Ubuntu `sudo apt-get install -y poppler-utils`; Windows ships it
   inside the LibreOffice install or via `pdftoppm` from poppler-windows
   releases.
-- **PptxGenJS path fails with `MODULE_NOT_FOUND`**: `npm install -g pptxgenjs`
-  or run inside a Node project where it is a local dependency.
+- **PptxGenJS path fails with `MODULE_NOT_FOUND`**: do not use a global npm
+  install; Node does not resolve global packages from `require()`. Prefer the
+  Python path. If the JS path is necessary, create a disposable local project
+  outside the user's repository. Create a fresh per-run OS temporary directory
+  with `tempfile.mkdtemp(prefix="opensquilla-pptxgenjs-")`, use it as the
+  working directory for `npm install --ignore-scripts --no-save pptxgenjs` and
+  `node build_deck.js`, and keep the authoring script beside its
+  `node_modules` directory. Write the final `.pptx` into the active workspace
+  and remove the disposable directory after publishing it. Do not use a fixed
+  path or a shell-specific directory-creation command.
 
 ---
 

--- a/src/opensquilla/skills/bundled/pptx/references/pptxgenjs.md
+++ b/src/opensquilla/skills/bundled/pptx/references/pptxgenjs.md
@@ -7,10 +7,23 @@ PptxGenJS is MIT-licensed upstream.
 
 ## Install
 
-```bash
-npm install -g pptxgenjs            # global, for ad-hoc scripts
-npm install pptxgenjs                # local, in a Node project
+Create a fresh per-run OS temporary directory outside the target repository.
+For example, create it from the available Python runtime:
+
+```python
+from pathlib import Path
+import tempfile
+
+work_dir = Path(tempfile.mkdtemp(prefix="opensquilla-pptxgenjs-"))
 ```
+
+Use `work_dir` as the working directory for `npm install --ignore-scripts
+--no-save pptxgenjs` and `node build_deck.js`. Keep the authoring script in
+this disposable directory so Node resolves the local `node_modules/pptxgenjs`.
+Do not use `npm install -g`: global packages are not a reliable `require()`
+search path. Do not use a fixed path or a shell-specific directory-creation
+command. Write the final `.pptx` into the active workspace, then remove the
+temporary directory.
 
 ## Boilerplate
 

--- a/src/opensquilla/tools/policy/finalize.py
+++ b/src/opensquilla/tools/policy/finalize.py
@@ -45,7 +45,7 @@ _PENDING_APPROVAL_STATUSES: frozenset[str] = frozenset(
 
 _DISPATCH_TRUNCATION_RETRIEVE_HINT = (
     "This tool result was truncated before entering model context. "
-    "Use retrieve_tool_result with tool_result_handle to inspect the original raw output."
+    "Use retrieve_tool_result with handle=<tool_result_handle> to inspect the original raw output."
 )
 
 

--- a/tests/test_engine/test_coding_mode.py
+++ b/tests/test_engine/test_coding_mode.py
@@ -193,6 +193,10 @@ class TestDirectiveInjection:
             config=SimpleNamespace(skills=SimpleNamespace(coding_mode=coding_mode)),
             system_prompt="BASE",
             metadata={},
+            tool_defs=[
+                SimpleNamespace(name=name)
+                for name in ("background_process", "exec_command", "process")
+            ],
         )
 
     @pytest.mark.asyncio
@@ -205,6 +209,19 @@ class TestDirectiveInjection:
         assert "DISABLED while coding mode is on" in suffix
         assert "code-task" in ctx.metadata["pinned_skills"]
         assert ctx.metadata["coding_mode"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("missing_tool", ["background_process", "exec_command", "process"])
+    async def test_on_skips_directive_and_pin_without_required_launch_tool(self, missing_tool):
+        ctx = self._ctx(True)
+        ctx.tool_defs = [tool for tool in ctx.tool_defs if tool.name != missing_tool]
+
+        out = await enforce_coding_mode(ctx)
+
+        assert out.system_prompt == "BASE"
+        assert "pinned_skills" not in out.metadata
+        assert "coding_mode" not in out.metadata
+        assert out.metadata["enforce_coding_mode__applied"] is False
 
     @pytest.mark.asyncio
     async def test_directive_clarify_gate_asks_when_only_a_category(self):

--- a/tests/test_skill_pptx_delivery.py
+++ b/tests/test_skill_pptx_delivery.py
@@ -8,6 +8,7 @@ from opensquilla.skills.loader import SkillLoader
 
 ROOT = Path(__file__).resolve().parents[1]
 BUNDLED = ROOT / "src" / "opensquilla" / "skills" / "bundled"
+PPTXGENJS_REFERENCE = BUNDLED / "pptx" / "references" / "pptxgenjs.md"
 
 
 def test_pptx_skill_instructs_artifact_delivery() -> None:
@@ -23,3 +24,24 @@ def test_pptx_skill_instructs_artifact_delivery() -> None:
     assert "Ignore the Path B, Path C, and Visual QA sections below" in spec.content
     assert "Do not paste OOXML" in spec.content
     assert "final `.pptx`" in spec.content
+    assert "Emoji, colored boxes,\n  and decorative lines do not satisfy" in spec.content
+    assert "Visual QA (when render tools are available)" in spec.content
+    assert "Do not pass `--range` for final QA" in spec.content
+    assert "If inspection\nfinds a defect" in spec.content
+    assert "without inventing an\nunnecessary edit" in spec.content
+    assert "A B1 text-only\nedit may still be published" in spec.content
+    assert "do not use a global npm\n  install" in spec.content
+    assert "npm install -g pptxgenjs" not in spec.content
+    assert "required before publishing paths B and C" not in spec.content
+    assert "at least one fix-and-rerender cycle" not in spec.content
+    assert "Do not declare clean unless one fix-and-reverify cycle" not in spec.content
+    assert "/tmp/opensquilla-pptxgenjs" not in spec.content
+    assert "mkdir -p" not in spec.content
+
+    reference = PPTXGENJS_REFERENCE.read_text(encoding="utf-8")
+    assert 'tempfile.mkdtemp(prefix="opensquilla-pptxgenjs-")' in reference
+    assert "working directory" in reference
+    assert "Do not use `npm install -g`" in reference
+    assert "npm install -g pptxgenjs" not in reference
+    assert "/tmp/" not in reference
+    assert "mkdir -p" not in reference

--- a/tests/test_skill_pptx_delivery.py
+++ b/tests/test_skill_pptx_delivery.py
@@ -15,28 +15,29 @@ def test_pptx_skill_instructs_artifact_delivery() -> None:
     spec = SkillLoader(bundled_dir=BUNDLED).get_by_name("pptx")
 
     assert spec is not None
-    assert "publish_artifact" in spec.content
-    assert "file-authoring tools" in spec.content
-    assert "If none of those file-authoring tools are available" in spec.content
-    assert "If only `create_pptx` is available" in spec.content
-    assert "basic text-only deck" in spec.content
-    assert "Do not attempt to generate, save, or modify the `.pptx`" in spec.content
-    assert "Ignore the Path B, Path C, and Visual QA sections below" in spec.content
-    assert "Do not paste OOXML" in spec.content
-    assert "final `.pptx`" in spec.content
-    assert "Emoji, colored boxes,\n  and decorative lines do not satisfy" in spec.content
-    assert "Visual QA (when render tools are available)" in spec.content
-    assert "Do not pass `--range` for final QA" in spec.content
-    assert "If inspection\nfinds a defect" in spec.content
-    assert "without inventing an\nunnecessary edit" in spec.content
-    assert "A B1 text-only\nedit may still be published" in spec.content
-    assert "do not use a global npm\n  install" in spec.content
-    assert "npm install -g pptxgenjs" not in spec.content
-    assert "required before publishing paths B and C" not in spec.content
-    assert "at least one fix-and-rerender cycle" not in spec.content
-    assert "Do not declare clean unless one fix-and-reverify cycle" not in spec.content
-    assert "/tmp/opensquilla-pptxgenjs" not in spec.content
-    assert "mkdir -p" not in spec.content
+    content = "\n".join(spec.content.splitlines())
+    assert "publish_artifact" in content
+    assert "file-authoring tools" in content
+    assert "If none of those file-authoring tools are available" in content
+    assert "If only `create_pptx` is available" in content
+    assert "basic text-only deck" in content
+    assert "Do not attempt to generate, save, or modify the `.pptx`" in content
+    assert "Ignore the Path B, Path C, and Visual QA sections below" in content
+    assert "Do not paste OOXML" in content
+    assert "final `.pptx`" in content
+    assert "Emoji, colored boxes,\n  and decorative lines do not satisfy" in content
+    assert "Visual QA (when render tools are available)" in content
+    assert "Do not pass `--range` for final QA" in content
+    assert "If inspection\nfinds a defect" in content
+    assert "without inventing an\nunnecessary edit" in content
+    assert "A B1 text-only\nedit may still be published" in content
+    assert "do not use a global npm\n  install" in content
+    assert "npm install -g pptxgenjs" not in content
+    assert "required before publishing paths B and C" not in content
+    assert "at least one fix-and-rerender cycle" not in content
+    assert "Do not declare clean unless one fix-and-reverify cycle" not in content
+    assert "/tmp/opensquilla-pptxgenjs" not in content
+    assert "mkdir -p" not in content
 
     reference = PPTXGENJS_REFERENCE.read_text(encoding="utf-8")
     assert 'tempfile.mkdtemp(prefix="opensquilla-pptxgenjs-")' in reference

--- a/tests/test_skills/test_codetask_skill.py
+++ b/tests/test_skills/test_codetask_skill.py
@@ -31,6 +31,7 @@ def test_codetask_skill_loads(loader):
 def test_codetask_skill_declares_requirements(loader):
     spec = loader.get_by_name("code-task")
     assert spec is not None
+    assert set(spec.requires_tools) == {"background_process", "exec_command", "process"}
     meta = spec.metadata
     assert meta is not None
     assert meta.requires is not None

--- a/tests/test_skills_default_prompt_contract.py
+++ b/tests/test_skills_default_prompt_contract.py
@@ -249,6 +249,41 @@ async def test_coding_mode_on_surfaces_code_task(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("missing_tool", ["background_process", "exec_command", "process"])
+async def test_coding_mode_hides_code_task_without_required_launch_tool(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    missing_tool: str,
+) -> None:
+    monkeypatch.setattr(
+        skills_filter_step,
+        "_elig_ctx",
+        EligibilityContext(
+            os_name="linux",
+            has_bin_cache={"git": True},
+            env_cache={},
+        ),
+    )
+    loader = SkillLoader(bundled_dir=BUNDLED, snapshot_path=tmp_path / "snapshot.json")
+    tools = {"background_process", "exec_command", "process"}
+    tools.remove(missing_tool)
+    ctx = _ctx(
+        loader,
+        tools=tools,
+        skills_config=SimpleNamespace(
+            filter_enabled=False,
+            max_skills_prompt_chars=100_000,
+            injection_mode="system",
+            coding_mode=True,
+        ),
+    )
+
+    ctx = await filter_skills(ctx)
+
+    assert "<name>code-task</name>" not in ctx.system_prompt[1]
+
+
+@pytest.mark.asyncio
 async def test_pinned_catalog_avoids_reloading_during_skill_injection() -> None:
     spec = SkillSpec(
         name="catalog-pinned",

--- a/tests/test_tools/test_dispatch_envelope.py
+++ b/tests/test_tools/test_dispatch_envelope.py
@@ -1605,6 +1605,8 @@ async def test_dispatch_execution_policy_stores_raw_snapshot_for_truncated_exec_
     assert len(payload["preview"]) + len(payload["tail"]) <= 10_000
     assert payload["tool_result_handle"].startswith("tr-")
     assert "retrieve_tool_result" in payload["retrieve_hint"]
+    assert "handle=<tool_result_handle>" in payload["retrieve_hint"]
+    assert "with tool_result_handle" not in payload["retrieve_hint"]
     assert len(result.content) < 12_000
 
     stored = ToolResultStore(tmp_path / "tool-results").read(


### PR DESCRIPTION
## Scope

Scope boundary:
- Gate the coding-mode directive and bundled code-task skill on the complete `background_process`, `exec_command`, and `process` launch surface.
- Make truncated tool-result retrieval guidance use the actual `handle` argument.
- Make PPTX visual QA conditional on renderer availability, require rerender only after a real defect, and use an OS-managed per-run directory for PptxGenJS.

Non-goals:
- No channel admission, approval, Feishu transport, Desktop CA, persisted config, database, or frontend changes.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: This is the final capability and delivery-guidance split from superseded PR #806; no standalone public issue tracks it.

## Release Note

Release note: Restricted tool surfaces no longer receive impossible code-task instructions, and PPTX delivery guidance now handles renderer and platform capabilities accurately.

## Tests

Ruff: `uv run ruff check src tests` passed; focused changed-file Ruff also passed.

Pytest: `137 passed` across coding mode, skill prompt, PPTX delivery, and dispatch-envelope contracts.

Build: Not needed; no build artifact or frontend source changed.

Regression tests: added

Notes: `uv run mypy src/opensquilla --show-error-codes` passed for 856 source files; `git diff --check` passed. Two independent reviews found no blockers.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: no credentials or live channel checks are required for this capability-gating change.

## Safety

No secrets, channel identifiers, user transcripts, local-only artifacts, or persisted/public protocol fields are changed. Fully capable Web and verified-admin channel sessions keep existing code-task behavior; restricted surfaces stop receiving an unusable mandatory instruction. The guidance change is platform-neutral and removes a POSIX-only temporary-path assumption.

## Third-Party Origin

Third-party origin: modified upstream

Details if non-none: the existing bundled PPTX skill retains its in-file MIT-0 provenance. This PR changes OpenSquilla delivery guidance and tests only; it copies no new third-party code, fixtures, or wording.

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.