### PR TITLE
Give router-control replays their own usage execution identity

### DIFF
--- a/src/opensquilla/engine/turn_runner/harness.py
+++ b/src/opensquilla/engine/turn_runner/harness.py
@@ -882,7 +882,23 @@ class _TurnRunnerAgentFactoryAdapter(AgentFactoryPort):
         usage_event_sink = getattr(self._runner, "_usage_event_sink", None)
         usage_execution_context = None
         if usage_event_sink is not None:
+            # Usage identity is ``uuid5(f"…:{execution_id}:{call_index}")`` and
+            # ``call_index`` counts per ``UsageAccountingScope``, so two attempts
+            # of one turn must not share an ``execution_id``. A router-control
+            # replay re-enters the turn with the same ``turn_id`` and builds a
+            # fresh scope, so keying on the bare ``turn_id`` makes the replay's
+            # first leg re-derive the first attempt's identity; the ledger's
+            # start guard then rejects it as a reused identity and the turn fails
+            # closed before the provider is called. Attempt 0 keeps the bare
+            # ``turn_id`` so stored values keep their shape on the common path.
+            # Replay depth provides a deterministic attempt namespace without
+            # weakening the ledger's exact-start idempotency guard.
+            replay_depth = max(
+                0, int(getattr(tool_context, "router_control_replay_depth", 0) or 0)
+            )
             execution_id = turn_id or uuid.uuid4().hex
+            if replay_depth:
+                execution_id = f"{execution_id}:{replay_depth}"
             usage_execution_context = UsageExecutionContext(
                 execution_id=execution_id,
                 agent_run_id=execution_id,

--- a/tests/test_engine/turn_runner/test_router_control_replay_event.py
+++ b/tests/test_engine/turn_runner/test_router_control_replay_event.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -9,12 +10,13 @@ import pytest
 
 from opensquilla.engine.runtime import TurnRunner
 from opensquilla.engine.steps import squilla_router as squilla_router_step
-from opensquilla.engine.types import DoneEvent, RouterControlReplayEvent
+from opensquilla.engine.types import DoneEvent, ErrorEvent, RouterControlReplayEvent
 from opensquilla.gateway.config import (
     GatewayConfig,
     SquillaRouterConfig,
     _router_tier_profile_defaults,
 )
+from opensquilla.gateway.usage_ledger_runtime import SessionUsageEventSink
 from opensquilla.provider import (
     DoneEvent as ProviderDone,
 )
@@ -23,6 +25,7 @@ from opensquilla.provider import (
 )
 from opensquilla.provider import ToolUseEndEvent as ProviderToolEnd
 from opensquilla.provider import ToolUseStartEvent as ProviderToolStart
+from opensquilla.session.storage import SessionStorage
 from opensquilla.tools import get_default_registry
 from opensquilla.tools.types import CallerKind, ToolContext
 
@@ -249,3 +252,84 @@ async def test_replayed_turn_keeps_user_message_binding(monkeypatch) -> None:
         assert sum(1 for t in users if t.startswith("First question A")) == 1
         assert not any("Second question B" in t for t in users)
         assert not any("Third question C" in t for t in users)
+
+
+@pytest.mark.asyncio
+async def test_router_control_replay_persists_distinct_usage_executions(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A router-control replay must persist both provider legs independently.
+
+    ``event_id`` is ``uuid5(f"opensquilla:usage:{execution_id}:{call_index}")`` and
+    the turn pipeline binds ``execution_id`` to ``turn_id``, while ``call_index``
+    counts per ``UsageAccountingScope``. A replay re-enters the pipeline with the
+    same ``turn_id`` and builds a fresh scope, so its first leg re-derives the
+    first attempt's identity. The ledger's start guard compares ``started_at_ms``
+    among the attribution fields, so the replayed leg is rejected as a reused
+    identity and the whole turn fails closed before the provider is called.
+    """
+    monkeypatch.setattr(squilla_router_step, "_get_strategy", lambda _cfg: _Strategy())
+    provider = _ReplayProvider()
+    manager = _FakeSessionManager()
+    key = "agent:main:router-control-replay-usage"
+    await manager.create(key)
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    sink = SessionUsageEventSink(storage, start_retry_delays=(), retry_delays=())
+    cfg = GatewayConfig(
+        llm={"provider": "openrouter"},
+        squilla_router=SquillaRouterConfig(
+            enabled=True,
+            rollout_phase="full",
+            require_router_runtime=False,
+            tiers=_router_tier_profile_defaults("openrouter"),
+        ),
+    )
+    runner = TurnRunner(
+        provider_selector=_Selector(provider),
+        session_manager=manager,
+        tool_registry=get_default_registry(),
+        config=cfg,
+        usage_event_sink=sink,
+    )
+
+    try:
+        events = [
+            event
+            async for event in runner.run(
+                "Use c3 for this",
+                key,
+                tool_context=ToolContext(is_owner=True, caller_kind=CallerKind.CLI),
+                history_has_persisted_user=False,
+                no_memory_capture=True,
+            )
+        ]
+        rows = await storage.query_usage_events(
+            None,
+            None,
+            statuses=("started", "finalized", "unknown"),
+        )
+    finally:
+        await sink.close(drain_timeout=0.0)
+        await storage.close()
+
+    # Guard the premise: the replay really ran, at two different models.
+    assert len([e for e in events if isinstance(e, RouterControlReplayEvent)]) == 1
+    assert not any(isinstance(e, ErrorEvent) for e in events)
+    assert provider.calls == ["deepseek/deepseek-v4-pro", "anthropic/claude-opus-4.8"]
+
+    # Both provider legs are real spend and must survive the ledger's identity
+    # guards as separate finalized rows under one logical turn.
+    assert len(rows) == 2
+    assert {row.status for row in rows} == {"finalized"}
+    rows_by_model = {row.model: row for row in rows}
+    first = rows_by_model["deepseek/deepseek-v4-pro"]
+    second = rows_by_model["anthropic/claude-opus-4.8"]
+    assert first.turn_id is not None
+    assert second.turn_id == first.turn_id
+    assert first.execution_id == first.turn_id
+    assert second.execution_id == f"{first.turn_id}:1"
+    assert first.agent_run_id == first.execution_id
+    assert second.agent_run_id == second.execution_id
+    assert first.call_index == second.call_index == 1
+    assert first.event_id != second.event_id


### PR DESCRIPTION
## Scope

Fix the fail-closed chat failure reported in #936 when Squilla Router performs a
`router_control` replay. The replay preserves the logical `turn_id` but creates a fresh
`UsageAccountingScope`, whose `call_index` starts again at 1. Because usage event identity is
derived from `(execution_id, call_index)` and the agent factory previously used the bare
`turn_id` as `execution_id`, the replay re-derived the original attempt's event ID.

The durable ledger correctly rejected that reused identity with different attribution:

```text
UsageLedgerConflictError: usage event identity was reused with different attribution
  -> UsageLedgerStorageError: usage ledger is temporarily unavailable; provider request was not sent
  -> Turn failed
```

The fix keeps one logical `turn_id` for transcript and trace correlation while giving each
replay attempt an independent usage execution namespace. It does not weaken the ledger's
exact-start idempotency guard.

## Changes

- `src/opensquilla/engine/turn_runner/harness.py`: qualify replay usage `execution_id` and
  `agent_run_id` with the existing `router_control_replay_depth`. Attempt 0 retains the bare
  `turn_id`; replay depth 1 uses `<turn_id>:1`, and so on.
- `tests/test_engine/turn_runner/test_router_control_replay_event.py`: exercise the real
  `SessionUsageEventSink` and SQLite `SessionStorage`, then assert that both provider legs
  finish without an engine error and persist as two finalized rows with distinct event and
  execution identities under the same logical turn.

## Branch target

`main` (rebased onto `95673be1b`).

## Linked issue

Fixes #936

The separate async-generator/`ContextVar` cleanup problem found in the same diagnostics is
tracked by #1064 and is intentionally not mixed into this ledger identity change.

## Release note

Required — with Squilla Router enabled, a mid-turn route/hold replay no longer causes the chat
request to fail locally because its usage event collides with the first provider attempt.

## Test results

- `pytest -q tests/test_engine/turn_runner/test_router_control_replay_event.py`: 3 passed.
- Router replay + usage accounting + gateway ledger + persistence ledger/backfill domains:
  104 passed.
- `ruff check src tests`: passed.
- `mypy src/opensquilla --show-error-codes`: passed; 926 source files checked.
- Updated-head GitHub Actions: all selected CI and CodeQL checks passed, including Windows
  high-risk core/gateway-SQLite/recovery-migration jobs and desktop recovery E2E on Linux,
  macOS, and Windows.

The new integration test uses the production ledger sink and a temporary SQLite database; it
fails without the execution-identity fix because the two replay legs cannot persist as two
distinct finalized rows.

## Safety and compatibility notes

- No schema, migration, configuration, RPC, CLI, or transcript contract changes.
- Normal non-replay turns retain the existing `execution_id == turn_id` value.
- Replays retain the root `turn_id` and durable `session_id`; only their usage execution
  identity becomes depth-qualified. Existing historical rows are untouched.
- A successful replay now records both real provider attempts instead of one row followed by a
  rejected ledger start. This is the intended accounting result and avoids under-reporting
  replay spend.
- The change is platform-neutral Python/SQLite logic with no filesystem-path, process, signal,
  shell, or OS-specific behavior. Cross-platform CI remains the final verification gate.
- The test uses synthetic prompts, session identifiers, and provider stubs. No user transcript,
  credential, provider response, or diagnostic bundle data is committed.
- Runtime cost is one integer read and string suffix only on replay attempts; normal turns keep
  their prior identity shape and behavior.
- Rollback is a single commit revert; no data rollback is required.

## Known adjacent issue

#1064 tracks `ValueError: ContextVar token was created in a different Context` during
interrupted replay stream cleanup. It can coexist with correctly finalized usage rows and needs
its own lifecycle-focused fix and regression test. It is not hidden or treated as fixed here.

## Third-party origin

None.
