### PR TITLE
fix(engine): evict cache-break monitor state for terminal sessions

### DIFF
--- a/src/opensquilla/engine/cache_break_monitor.py
+++ b/src/opensquilla/engine/cache_break_monitor.py
@@ -14,6 +14,8 @@ from typing import Any
 
 from opensquilla.provider import ChatConfig, Message, ToolDefinition
 
+_MAX_TRACKED_SESSIONS = 512
+
 
 def _jsonable(value: Any) -> Any:
     """Return a stable JSON-ish shape for Pydantic models and dataclasses."""
@@ -152,14 +154,58 @@ class _CacheBaseline:
     cache_read_tokens: int
 
 
-class CacheBreakMonitor:
-    """Track cache-read drops and attribute them to prompt-state changes."""
+@dataclass(slots=True)
+class _SessionCacheState:
+    """Cache-break diagnostics retained for one reusable session key.
 
-    def __init__(self, *, min_drop_tokens: int = 2000, min_drop_ratio: float = 0.05) -> None:
-        self._baselines: dict[str, _CacheBaseline] = {}
-        self._reset_pending: set[str] = set()
+    Baseline and pending reset share one state object so capacity eviction can
+    never leave a pre-compaction baseline behind after dropping the marker that
+    suppresses its expected cache-read decline.
+    """
+
+    baseline: _CacheBaseline | None = None
+    reset_pending: bool = False
+
+
+class CacheBreakMonitor:
+    """Track cache-read drops without retaining unbounded session state.
+
+    Explicit session-identity disposal evicts state through
+    ``SessionManager.evict_session_runtime_state``. The shared LRU is a
+    backstop for reusable or abandoned session keys that do not cross that
+    boundary. Eviction only loses diagnostics: the next response initializes a
+    new baseline and cannot fabricate a cache-break report.
+    """
+
+    def __init__(
+        self,
+        *,
+        min_drop_tokens: int = 2000,
+        min_drop_ratio: float = 0.05,
+        max_sessions: int = _MAX_TRACKED_SESSIONS,
+    ) -> None:
+        self._sessions: OrderedDict[str, _SessionCacheState] = OrderedDict()
         self._min_drop_tokens = max(0, int(min_drop_tokens))
         self._min_drop_ratio = max(0.0, float(min_drop_ratio))
+        self._max_sessions = max(1, int(max_sessions))
+
+    @property
+    def tracked_session_count(self) -> int:
+        """Return the number of session keys currently holding diagnostics."""
+
+        return len(self._sessions)
+
+    def _touch(self, session_key: str) -> _SessionCacheState:
+        state = self._sessions.get(session_key)
+        if state is None:
+            state = _SessionCacheState()
+            self._sessions[session_key] = state
+        self._sessions.move_to_end(session_key)
+        return state
+
+    def _trim_to_max_sessions(self) -> None:
+        while len(self._sessions) > self._max_sessions:
+            self._sessions.popitem(last=False)
 
     def record_prompt_state(
         self,
@@ -198,11 +244,13 @@ class CacheBreakMonitor:
         cache_read_tokens: int,
     ) -> CacheBreakReport:
         current_tokens = max(0, int(cache_read_tokens or 0))
-        previous = self._baselines.get(session_key)
-        reset_pending = session_key in self._reset_pending
-        self._baselines[session_key] = _CacheBaseline(snapshot, current_tokens)
+        state = self._touch(session_key)
+        previous = state.baseline
+        reset_pending = state.reset_pending
+        state.baseline = _CacheBaseline(snapshot, current_tokens)
+        state.reset_pending = False
+        self._trim_to_max_sessions()
         if reset_pending:
-            self._reset_pending.discard(session_key)
             return CacheBreakReport(
                 break_detected=False,
                 reason="baseline_reset_after_compaction",
@@ -238,11 +286,17 @@ class CacheBreakMonitor:
 
     def notify_compaction(self, session_key: str) -> None:
         """Treat the next provider response for this session as a new baseline."""
-        self._reset_pending.add(session_key)
+
+        self._touch(session_key).reset_pending = True
+        self._trim_to_max_sessions()
+
+    def evict(self, session_key: str) -> bool:
+        """Drop cache-break diagnostics for one retired session key."""
+
+        return self._sessions.pop(session_key, None) is not None
 
     def clear(self) -> None:
-        self._baselines.clear()
-        self._reset_pending.clear()
+        self._sessions.clear()
 
 
 default_cache_break_monitor = CacheBreakMonitor()
@@ -361,6 +415,12 @@ def check_response_for_cache_break(
         snapshot,
         cache_read_tokens,
     )
+
+
+def evict_cache_break_state(session_key: str) -> bool:
+    """Drop process-wide cache-break diagnostics for one session key."""
+
+    return default_cache_break_monitor.evict(session_key)
 
 
 def notify_compaction(

--- a/src/opensquilla/session/manager.py
+++ b/src/opensquilla/session/manager.py
@@ -1044,12 +1044,13 @@ class SessionManager:
         *,
         session_id: str | None = None,
     ) -> None:
-        """Drop in-memory subagent and routing bookkeeping for ``session_key``.
+        """Drop in-memory state owned by one retired ``session_key``.
 
         History deletion calls this while its runtime/admission fences are
         still held. ``session_id`` identifies the deleted generation for
-        caches that intentionally survive same-key resets. Imports are local
-        to avoid cycles with engine/gateway packages.
+        generation-scoped caches. Session-key caches are evicted regardless of
+        whether that identifier is available. Imports are local to avoid cycles
+        with engine/gateway packages.
         """
         session_key = canonicalize_session_key(session_key)
         self._epoch_cache.pop(session_key, None)
@@ -1071,6 +1072,14 @@ class SessionManager:
             from opensquilla.tools.builtin.sessions import evict_spawn_lock
 
             evict_spawn_lock(session_key)
+        except Exception:
+            pass
+        try:
+            from opensquilla.engine.cache_break_monitor import (
+                evict_cache_break_state,
+            )
+
+            evict_cache_break_state(session_key)
         except Exception:
             pass
         if session_id:

--- a/tests/test_engine/test_cache_break_monitor.py
+++ b/tests/test_engine/test_cache_break_monitor.py
@@ -567,3 +567,176 @@ async def test_cancel_active_compactions_is_scoped_to_session(
     finally:
         other_session.cancel()
         await asyncio.gather(other_session, return_exceptions=True)
+
+
+def _record(monitor: CacheBreakMonitor, session_key: str, tokens: int = 5000) -> None:
+    snapshot = monitor.record_prompt_state(
+        messages=[
+            Message(role="user", content=f"old {session_key}"),
+            Message(role="user", content="now"),
+        ],
+        tools=None,
+        config=ChatConfig(system="stable system"),
+        model="model-a",
+    )
+    monitor.check_response_for_cache_break(session_key, snapshot, tokens)
+
+
+def test_evict_drops_all_cache_break_state_for_one_session() -> None:
+    monitor = CacheBreakMonitor(min_drop_tokens=10, min_drop_ratio=0.05)
+    _record(monitor, "agent:main:s1")
+    _record(monitor, "agent:main:s2")
+    monitor.notify_compaction("agent:main:s1")
+
+    assert monitor.evict("agent:main:s1") is True
+    assert monitor.tracked_session_count == 1
+
+    snapshot = monitor.record_prompt_state(
+        messages=[Message(role="user", content="fresh"), Message(role="user", content="now")],
+        tools=None,
+        config=ChatConfig(system="different system"),
+        model="model-b",
+    )
+    report = monitor.check_response_for_cache_break("agent:main:s1", snapshot, 0)
+
+    assert report.break_detected is False
+    assert report.reason == "baseline_initialized"
+
+
+def test_evict_reports_false_for_untracked_session() -> None:
+    assert CacheBreakMonitor().evict("agent:main:never-seen") is False
+
+
+@pytest.mark.asyncio
+async def test_module_level_eviction_targets_only_default_cache_break_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_compaction_lifecycle(monkeypatch)
+    monitor = CacheBreakMonitor()
+    monkeypatch.setattr(cache_break_monitor, "default_cache_break_monitor", monitor)
+    _record(monitor, "agent:main:s1")
+
+    async def _waiting_owner() -> None:
+        await asyncio.Event().wait()
+
+    owner = asyncio.create_task(_waiting_owner())
+    cache_break_monitor.register_active_compaction(
+        "agent:main:s1",
+        "compaction-still-owned",
+        owner,
+    )
+    try:
+        assert cache_break_monitor.evict_cache_break_state("agent:main:s1") is True
+        assert monitor.tracked_session_count == 0
+        assert cache_break_monitor.active_compaction_ids("agent:main:s1") == (
+            "compaction-still-owned",
+        )
+    finally:
+        owner.cancel()
+        await asyncio.gather(owner, return_exceptions=True)
+
+
+def test_tracked_sessions_stay_bounded_without_explicit_eviction() -> None:
+    monitor = CacheBreakMonitor(max_sessions=4)
+
+    for index in range(50):
+        _record(monitor, f"agent:main:s{index}")
+
+    assert monitor.tracked_session_count == 4
+
+
+def test_lru_eviction_never_reports_a_false_break() -> None:
+    monitor = CacheBreakMonitor(min_drop_tokens=10, min_drop_ratio=0.05, max_sessions=2)
+    _record(monitor, "agent:main:cold", tokens=5000)
+    _record(monitor, "agent:main:hot1")
+    _record(monitor, "agent:main:hot2")
+
+    changed = monitor.record_prompt_state(
+        messages=[Message(role="user", content="changed"), Message(role="user", content="now")],
+        tools=None,
+        config=ChatConfig(system="different system"),
+        model="model-b",
+    )
+    report = monitor.check_response_for_cache_break("agent:main:cold", changed, 0)
+
+    assert report.break_detected is False
+    assert report.reason == "baseline_initialized"
+
+
+def test_most_recently_used_session_survives_the_bound() -> None:
+    monitor = CacheBreakMonitor(min_drop_tokens=10, min_drop_ratio=0.05, max_sessions=2)
+    _record(monitor, "agent:main:keep", tokens=5000)
+    _record(monitor, "agent:main:filler1")
+    _record(monitor, "agent:main:keep", tokens=5000)
+    _record(monitor, "agent:main:filler2")
+
+    changed = monitor.record_prompt_state(
+        messages=[Message(role="user", content="changed"), Message(role="user", content="now")],
+        tools=None,
+        config=ChatConfig(system="different system"),
+        model="model-b",
+    )
+    report = monitor.check_response_for_cache_break("agent:main:keep", changed, 0)
+
+    assert report.break_detected is True
+    assert report.reason == "cache_read_drop"
+
+
+def test_pending_resets_stay_bounded_without_a_paired_baseline() -> None:
+    monitor = CacheBreakMonitor(max_sessions=4)
+
+    for index in range(50):
+        monitor.notify_compaction(f"agent:main:ghost{index}")
+
+    assert monitor.tracked_session_count == 4
+    snapshot = monitor.record_prompt_state(
+        messages=[Message(role="user", content="old"), Message(role="user", content="now")],
+        tools=None,
+        config=ChatConfig(system="stable system"),
+        model="model-a",
+    )
+    report = monitor.check_response_for_cache_break("agent:main:ghost49", snapshot, 0)
+    assert report.reason == "baseline_reset_after_compaction"
+
+
+def test_evict_reports_true_for_a_pending_reset_without_a_baseline() -> None:
+    monitor = CacheBreakMonitor()
+    monitor.notify_compaction("agent:main:pending-only")
+
+    assert monitor.evict("agent:main:pending-only") is True
+    assert monitor.tracked_session_count == 0
+    assert monitor.evict("agent:main:pending-only") is False
+
+
+def test_trimming_never_strands_a_baseline_without_its_reset_marker() -> None:
+    monitor = CacheBreakMonitor(min_drop_tokens=10, min_drop_ratio=0.05, max_sessions=2)
+    _record(monitor, "agent:main:compacted", tokens=5000)
+    monitor.notify_compaction("agent:main:compacted")
+
+    for index in range(10):
+        monitor.notify_compaction(f"agent:main:unrelated{index}")
+
+    after_compaction = monitor.record_prompt_state(
+        messages=[Message(role="user", content="shrunk"), Message(role="user", content="now")],
+        tools=None,
+        config=ChatConfig(system="rewritten by compaction"),
+        model="model-b",
+    )
+    report = monitor.check_response_for_cache_break(
+        "agent:main:compacted",
+        after_compaction,
+        100,
+    )
+
+    assert report.break_detected is False
+    assert report.reason == "baseline_initialized"
+
+
+def test_the_bound_counts_sessions_not_independent_state_maps() -> None:
+    monitor = CacheBreakMonitor(max_sessions=3)
+
+    for index in range(20):
+        _record(monitor, f"agent:main:with-baseline{index}")
+        monitor.notify_compaction(f"agent:main:pending-only{index}")
+
+    assert monitor.tracked_session_count == 3

--- a/tests/test_session/test_finish_evicts_runtime_state.py
+++ b/tests/test_session/test_finish_evicts_runtime_state.py
@@ -1,4 +1,4 @@
-"""SessionManager.finish drops module-level subagent + routing bookkeeping."""
+"""Session runtime disposal drops process-wide per-session bookkeeping."""
 
 from __future__ import annotations
 
@@ -6,8 +6,10 @@ import importlib
 
 import pytest
 
+from opensquilla.engine import cache_break_monitor
 from opensquilla.engine.steps.squilla_router import _history_store
 from opensquilla.gateway.subagent_announce import _tracker
+from opensquilla.provider import ChatConfig, Message
 from opensquilla.session.manager import SessionManager
 from opensquilla.session.models import SessionStatus
 
@@ -22,6 +24,19 @@ class _MemoryStorage:
     async def upsert_session(self, node, *, expected_session_id=None) -> None:
         assert expected_session_id is None or expected_session_id == node.session_id
         self._sessions[node.session_key] = node
+
+
+def _seed_cache_break_state(session_key: str) -> cache_break_monitor.CacheBreakMonitor:
+    monitor = cache_break_monitor.default_cache_break_monitor
+    snapshot = monitor.record_prompt_state(
+        messages=[Message(role="user", content="old"), Message(role="user", content="now")],
+        tools=None,
+        config=ChatConfig(system="stable system"),
+        model="model-a",
+    )
+    monitor.check_response_for_cache_break(session_key, snapshot, 5000)
+    monitor.notify_compaction(session_key)
+    return monitor
 
 
 @pytest.mark.asyncio
@@ -52,6 +67,33 @@ async def test_finish_evicts_spawn_group_tracker_and_routing_history() -> None:
     assert _history_store.get("agent:main:main") is None
 
 
+@pytest.mark.asyncio
+async def test_finish_evicts_cache_break_monitor_state() -> None:
+    from opensquilla.session.models import SessionNode
+
+    storage = _MemoryStorage()
+    session_key = "agent:main:cache-break-finish"
+    node = SessionNode(
+        session_key=session_key,
+        session_id="cache-break-generation",
+        agent_id="main",
+        created_at=1,
+        updated_at=1,
+        started_at=1,
+        status=SessionStatus.RUNNING,
+    )
+    await storage.upsert_session(node)
+    monitor = _seed_cache_break_state(session_key)
+
+    try:
+        manager = SessionManager(storage)  # type: ignore[arg-type]
+        await manager.finish(session_key, status=SessionStatus.DONE)
+
+        assert monitor.evict(session_key) is False
+    finally:
+        monitor.evict(session_key)
+
+
 def test_explicit_runtime_eviction_drops_all_session_identity_caches() -> None:
     from opensquilla.tools.builtin import sessions as sessions_tool
 
@@ -77,3 +119,16 @@ def test_explicit_runtime_eviction_drops_all_session_identity_caches() -> None:
     assert _history_store.get(session_key) is None
     assert session_key not in sessions_tool._spawn_locks
     assert session_id not in meta_resolution._meta_sticky_cache
+
+
+def test_runtime_eviction_drops_session_key_cache_without_generation_id() -> None:
+    session_key = "agent:main:webchat:cache-break-no-generation"
+    manager = SessionManager(_MemoryStorage())  # type: ignore[arg-type]
+    monitor = _seed_cache_break_state(session_key)
+
+    try:
+        manager.evict_session_runtime_state(session_key)
+
+        assert monitor.evict(session_key) is False
+    finally:
+        monitor.evict(session_key)


### PR DESCRIPTION
## Motivation

`default_cache_break_monitor` is a process-wide singleton. Before this change, every session that reached provider cache accounting could leave a baseline (and, after compaction, a pending-reset marker) alive until the gateway process exited. Terminal session cleanup already evicted routing, subagent, and spawn-lock state, but omitted this diagnostics-only state.

In a long-running gateway this made memory use grow with the number of historical session keys. The retained payload is small per session, so the immediate user symptom is gradual process growth rather than a per-request failure, but the lifetime contract was incorrect and unbounded.

## Scope and implementation

- Store each session's baseline and pending-reset marker in one `OrderedDict` entry so their lifetimes cannot diverge.
- Add `CacheBreakMonitor.evict(session_key)` and the precise module helper `evict_cache_break_state(session_key)`.
- Call that helper from `SessionManager._evict_session_runtime_state`, including when cleanup only has a session key and no persisted session ID.
- Bound the process-wide diagnostic state to 512 most-recently-used sessions as a backstop for abandoned/non-terminal sessions.
- Preserve current `main`'s active compaction lifecycle, heartbeat, and task tracking. Cache-break eviction intentionally does not cancel or detach an active compaction task.

The monitor remains diagnostics-only. If an old entry is evicted and that key is used again, its next response initializes a fresh baseline rather than reporting a fabricated cache-read drop.

Non-goals: no changes to cache-break thresholds, report fields, log events, provider behavior, routing decisions, persisted session data, RPC/CLI protocols, or active compaction lifecycle.

## Branch and issue

- Base branch: `main`
- Linked issue: None. This lifetime gap was found while reviewing prompt-cache accounting; #60 is related historical context but is not fixed or closed by this PR.

## Tests

- `pytest -q tests/test_engine/test_cache_break_monitor.py tests/test_session/test_finish_evicts_runtime_state.py` — 28 passed
- `pytest -q tests/test_engine tests/test_session` — 3107 passed, 1 skipped
- Targeted gateway deletion/lifecycle tests — 3 passed
- `ruff check src tests` — passed
- `mypy src/opensquilla/engine/cache_break_monitor.py src/opensquilla/session/manager.py --show-error-codes` — passed
- `npm run build` in `opensquilla-webui` — passed (including architecture, security, i18n, type, theme, and artifact guards)
- `uv build --wheel` — built `opensquilla-0.5.2-py3-none-any.whl`

Regression coverage includes explicit terminal cleanup, session-key-only cleanup, baseline/pending-reset atomicity, LRU/MRU behavior, pending-only sessions, re-use after eviction, sibling isolation, and preservation of active compaction state.

## Compatibility and safety

Platform-neutral in-memory Python change; no filesystem, signal, subprocess, or OS-specific behavior is introduced. No public or persisted contract changes, migration, client update, credential, transcript, or private fixture is involved. Eviction can only discard diagnostics history; it cannot alter user messages, routing, provider requests, or cache contents.

## Release note

Long-running gateway processes no longer retain prompt-cache diagnostic state for every historical session.

## Third-party origin

None.
