### PR TITLE
fix: make agent audio configuration safe and prevent gateway self-termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- New agent tool `audio_config`: configures the audio (TTS) provider through
+  the same validated path as onboarding — atomic UTF-8 persistence with
+  backup, live hot-apply, `restartRequired: false` — replacing the shell
+  fallbacks (editing `config.toml`, subprocess-only `$env:` exports) that
+  previously corrupted configs. The API key is stored but never echoed in
+  tool results, logs, or errors.
+
+### Fixed
+
+- The `gateway` tool no longer advertises capabilities it cannot deliver:
+  `restart` and `config_set` (which always failed, driving agents to
+  destructive shell fallbacks) now return guidance pointing to the desktop
+  supervisor and the `audio_config` tool; `config_get` redacts
+  credential-bearing values instead of echoing raw API keys.
+- Shell commands that would terminate the gateway's own process
+  (`Stop-Process -Id <gateway pid>`, `taskkill /PID`, `kill`, and
+  name-targeted variants) are structurally refused in every host mode,
+  before any configurable policy layer; other processes stay manageable.
+- Config persistence explicitly routes non-UTF-8 (e.g. GBK-corrupted)
+  config files into the backup-then-rewrite recovery path, with regression
+  coverage for corrupt-file recovery, CJK round-trips, and mid-write
+  failures leaving the original bytes untouched.
+
 ### Changed
 
 - Closing the Desktop main window now preserves the live Control UI on macOS

--- a/src/opensquilla/gateway/rpc_onboarding.py
+++ b/src/opensquilla/gateway/rpc_onboarding.py
@@ -1370,27 +1370,46 @@ async def _memory_embedding_configure(params: Any, ctx: RpcContext) -> dict[str,
     }
 
 
-@_d.method("onboarding.audio.configure", scope="operator.admin")
-async def _audio_configure(params: Any, ctx: RpcContext) -> dict[str, Any]:
+def apply_audio_provider_configuration(
+    config_holder: Any,
+    *,
+    provider_id: str,
+    api_key: str = "",
+    api_key_env: str = "",
+    base_url: str = "",
+    enabled: bool = True,
+    tts_voice: str = "",
+    tts_model: str = "",
+    language_code: str = "",
+) -> dict[str, Any]:
+    """Validate, persist, and hot-apply one audio provider configuration.
+
+    The single safe write path for audio config, shared by the
+    ``onboarding.audio.configure`` RPC and the agent-facing ``audio_config``
+    builtin tool. ``config_holder`` only needs a ``config`` attribute carrying
+    the live ``GatewayConfig`` (an ``RpcContext``, or a shim for tools).
+
+    The returned mapping is secret-safe: ``entry`` is the mutation's redacted
+    public payload and never carries the API key.
+    """
     from opensquilla.onboarding.mutations import upsert_audio_provider
 
-    provider_id = _require(params, "providerId")
-    cfg = _active_config(ctx)
+    cfg = _active_config(config_holder)
     res = upsert_audio_provider(
         cfg,
         provider_id=provider_id,
-        api_key=params.get("apiKey", "") if isinstance(params, dict) else "",
-        api_key_env=params.get("apiKeyEnv", "") if isinstance(params, dict) else "",
-        base_url=params.get("baseUrl", "") if isinstance(params, dict) else "",
-        enabled=params.get("enabled", True) if isinstance(params, dict) else True,
-        tts_voice=params.get("ttsVoice", "") if isinstance(params, dict) else "",
-        tts_model=params.get("ttsModel", "") if isinstance(params, dict) else "",
-        language_code=params.get("languageCode", "") if isinstance(params, dict) else "",
+        api_key=api_key,
+        api_key_env=api_key_env,
+        base_url=base_url,
+        enabled=enabled,
+        tts_voice=tts_voice,
+        tts_model=tts_model,
+        language_code=language_code,
     )
     # Persist first: if the write fails, the live config is untouched and
     # memory/disk stay consistent. Tool syncs run only on applied state.
-    config_path = _persist(ctx, res.config, restart_required=res.restart_required)
-    _apply_inplace(ctx, res.config)
+    config_path = _persist(config_holder, res.config, restart_required=res.restart_required)
+    _apply_inplace(config_holder, res.config)
     _sync_image_generation(res.config)
     return {
         "changed": res.changed,
@@ -1399,6 +1418,23 @@ async def _audio_configure(params: Any, ctx: RpcContext) -> dict[str, Any]:
         "entry": res.public_payload,
         "warnings": res.warnings,
     }
+
+
+@_d.method("onboarding.audio.configure", scope="operator.admin")
+async def _audio_configure(params: Any, ctx: RpcContext) -> dict[str, Any]:
+    provider_id = _require(params, "providerId")
+    p = params if isinstance(params, dict) else {}
+    return apply_audio_provider_configuration(
+        ctx,
+        provider_id=provider_id,
+        api_key=p.get("apiKey", ""),
+        api_key_env=p.get("apiKeyEnv", ""),
+        base_url=p.get("baseUrl", ""),
+        enabled=p.get("enabled", True),
+        tts_voice=p.get("ttsVoice", ""),
+        tts_model=p.get("ttsModel", ""),
+        language_code=p.get("languageCode", ""),
+    )
 
 
 async def _reconcile_channels_live() -> dict[str, str] | None:

--- a/src/opensquilla/onboarding/config_store.py
+++ b/src/opensquilla/onboarding/config_store.py
@@ -594,7 +594,12 @@ def _persist_plan(
         try:
             with target.open("rb") as fh:
                 raw = tomllib.load(fh)
-        except (tomllib.TOMLDecodeError, ValueError) as exc:
+        # UnicodeDecodeError is a ValueError subclass, but list it explicitly:
+        # a config corrupted with non-UTF-8 bytes (seen when an agent edited
+        # the file through a shell with a legacy codepage) must take this
+        # recovery branch — back up the corrupt bytes, then rewrite valid
+        # UTF-8 from the in-memory config — and never propagate as a crash.
+        except (tomllib.TOMLDecodeError, UnicodeDecodeError, ValueError) as exc:
             disk_usable = False
             log.warning(
                 "onboarding.config_persist_unreadable_toml",

--- a/src/opensquilla/tools/builtin/admin.py
+++ b/src/opensquilla/tools/builtin/admin.py
@@ -31,7 +31,47 @@ log = structlog.get_logger(__name__)
 _VALID_CRON_ACTIONS = ("list", "add", "remove", "run")
 
 
-_VALID_GATEWAY_ACTIONS = ("restart", "config_get", "config_set")
+_VALID_GATEWAY_ACTIONS = ("config_get",)
+
+# Actions the tool USED to advertise. They were never functional (restart
+# always raised; config_set depended on a GatewayConfig.patch() that does not
+# exist), but agents that saw the old contract still try them — and, worse,
+# fall back to editing config.toml or killing the gateway through shell
+# commands when they fail. Keep them recognized so the error can steer the
+# agent to the safe path instead of a generic "invalid action".
+_RETIRED_GATEWAY_ACTIONS = {
+    "restart": (
+        "Gateway restart is not available to agents: the desktop supervisor "
+        "(or the operator's service manager) owns the gateway lifecycle. "
+        "Audio configuration via the audio_config tool applies immediately "
+        "and does NOT need a restart. Never terminate the gateway process "
+        "via shell commands."
+    ),
+    "config_set": (
+        "Direct config writes are not available to agents. For audio (TTS) "
+        "providers use the audio_config tool — it validates, persists "
+        "atomically, and hot-applies without a restart. Other settings "
+        "belong to the operator's Settings UI. Never edit config.toml or "
+        "export environment variables via shell commands: a subprocess "
+        "environment does not reach the running gateway, and hand-written "
+        "config edits have corrupted UTF-8 configs before."
+    ),
+}
+
+# Dot-path segments whose values must never be echoed back to an agent.
+_SECRET_KEY_FRAGMENTS = ("api_key", "token", "secret", "password", "credential")
+
+
+def _redact_config_secrets(value: object, key_hint: str = "") -> object:
+    """Recursively mask values whose key names look credential-bearing."""
+    lowered = key_hint.lower()
+    if isinstance(value, dict):
+        return {k: _redact_config_secrets(v, str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_config_secrets(v, key_hint) for v in value]
+    if any(fragment in lowered for fragment in _SECRET_KEY_FRAGMENTS):
+        return "[redacted]" if value else value
+    return value
 
 
 class _SchedulerProtocol(Protocol):
@@ -568,19 +608,25 @@ async def cron(
 
 @tool(
     name="gateway",
-    description="Gateway control: restart and configuration management.",
+    description=(
+        "Read gateway configuration values (action: config_get). "
+        "Credential-bearing values are redacted. Configuration writes and "
+        "restarts are not available here: audio providers are configured "
+        "through the audio_config tool (applies immediately, no restart), "
+        "and the gateway lifecycle belongs to the desktop supervisor."
+    ),
     params={
         "action": {
             "type": "string",
-            "description": "Action: restart, config_get, config_set",
+            "description": "Action: config_get",
         },
         "key": {
             "type": "string",
-            "description": "Config key path (required for config_get and config_set)",
+            "description": "Config key path (required for config_get)",
         },
         "value": {
             "type": "string",
-            "description": "Config value as JSON string (required for config_set)",
+            "description": "Unused; retained for backward compatibility",
         },
     },
     required=["action"],
@@ -591,55 +637,116 @@ async def gateway(
     key: str | None = None,
     value: str | None = None,
 ) -> str:
+    retired = _RETIRED_GATEWAY_ACTIONS.get(action)
+    if retired is not None:
+        raise ToolError(retired)
     if action not in _VALID_GATEWAY_ACTIONS:
-        raise ToolError(f"Invalid action: {action}. Must be restart|config_get|config_set")
+        raise ToolError(f"Invalid action: {action}. Must be config_get")
 
-    if action in ("config_get", "config_set") and not key:
-        raise ToolError(f"'key' required for {action}")
-    if action == "config_set" and value is None:
-        raise ToolError("'value' required for config_set")
-
-    # Parse JSON value for config_set
-    parsed_value = None
-    if action == "config_set":
-        assert value is not None
-        try:
-            parsed_value = json.loads(value)
-        except (json.JSONDecodeError, TypeError):
-            raise ToolError("'value' must be valid JSON")
+    if not key:
+        raise ToolError("'key' required for config_get")
 
     if _gateway_config is None:
         raise ToolError("Gateway config not available")
 
     config = _gateway_config
 
-    if action == "restart":
-        raise ToolError("Gateway restart not supported via tool")
+    cfg_dict = config.to_toml_dict() if hasattr(config, "to_toml_dict") else {}
+    # Navigate dot-path key
+    parts = key.split(".")
+    val = cfg_dict
+    for p in parts:
+        if isinstance(val, dict):
+            val = val.get(p)
+        else:
+            val = None
+            break
+    if val is None:
+        raise ToolError(f"Config key not found: {key}")
+    # Agents never need raw credentials back; mask by key name, both for the
+    # terminal path segment and for any nested mapping fields.
+    redacted = _redact_config_secrets(val, parts[-1])
+    return json.dumps({"action": "config_get", "key": key, "value": redacted})
 
-    if action == "config_get":
-        assert key is not None
-        cfg_dict = config.to_toml_dict() if hasattr(config, "to_toml_dict") else {}
-        # Navigate dot-path key
-        parts = key.split(".")
-        val = cfg_dict
-        for p in parts:
-            if isinstance(val, dict):
-                val = val.get(p)
-            else:
-                val = None
-                break
-        if val is None:
-            raise ToolError(f"Config key not found: {key}")
-        return json.dumps({"action": "config_get", "key": key, "value": val})
 
-    # config_set
-    if hasattr(config, "patch"):
-        await config.patch({key: parsed_value})
-        return json.dumps(
-            {
-                "action": "config_set",
-                "key": key,
-                "value": parsed_value,
-            }
+# ---------------------------------------------------------------------------
+# audio_config
+# ---------------------------------------------------------------------------
+
+
+@tool(
+    name="audio_config",
+    description=(
+        "Configure the audio (TTS) provider safely. Validates the settings, "
+        "persists config.toml atomically (UTF-8, backup kept), and "
+        "hot-applies to the running gateway — no restart needed. Use this "
+        "instead of editing config.toml or exporting environment variables "
+        "via shell commands: a subprocess environment never reaches the "
+        "running gateway. The API key is stored but never echoed back."
+    ),
+    params={
+        "provider": {
+            "type": "string",
+            "description": "Audio provider id (currently supported: elevenlabs)",
+        },
+        "api_key": {
+            "type": "string",
+            "description": "Provider API key (mutually exclusive with api_key_env)",
+        },
+        "api_key_env": {
+            "type": "string",
+            "description": "Name of an environment variable holding the API key",
+        },
+        "enabled": {
+            "type": "boolean",
+            "description": "Enable or disable audio (default: true)",
+        },
+        "tts_voice": {"type": "string", "description": "TTS voice id"},
+        "tts_model": {"type": "string", "description": "TTS model id"},
+        "base_url": {"type": "string", "description": "Override the provider API base URL"},
+        "language_code": {"type": "string", "description": "Language code hint for TTS"},
+    },
+    required=["provider"],
+    owner_only=True,
+)
+async def audio_config(
+    provider: str,
+    api_key: str = "",
+    api_key_env: str = "",
+    enabled: bool = True,
+    tts_voice: str = "",
+    tts_model: str = "",
+    base_url: str = "",
+    language_code: str = "",
+) -> str:
+    if _gateway_config is None:
+        raise ToolError("Gateway config not available")
+
+    from types import SimpleNamespace
+
+    from opensquilla.gateway.rpc_onboarding import apply_audio_provider_configuration
+
+    holder = SimpleNamespace(config=_gateway_config)
+    try:
+        result = apply_audio_provider_configuration(
+            holder,
+            provider_id=provider,
+            api_key=api_key,
+            api_key_env=api_key_env,
+            base_url=base_url,
+            enabled=enabled,
+            tts_voice=tts_voice,
+            tts_model=tts_model,
+            language_code=language_code,
         )
-    raise ToolError("Config modification not supported")
+    except (KeyError, ValueError) as exc:
+        # Mutation validation messages (unknown provider, key/env conflicts)
+        # are agent-actionable and never embed the credential itself.
+        raise ToolError(str(exc).strip("\"'")) from exc
+
+    payload = json.dumps(result)
+    # Defense in depth: the entry payload is pre-redacted by the mutation
+    # layer, but a returned credential would be unrecoverable — fail closed.
+    if api_key and api_key in payload:
+        raise ToolError("internal error: refusing to return a payload containing the API key")
+    return payload

--- a/src/opensquilla/tools/builtin/shell_policy.py
+++ b/src/opensquilla/tools/builtin/shell_policy.py
@@ -86,6 +86,83 @@ class PolicyResult:
     needs_approval: bool = False
 
 
+# ---------------------------------------------------------------------------
+# Gateway self-termination guard
+# ---------------------------------------------------------------------------
+# Builtin tools execute inside the gateway process, so os.getpid() here IS the
+# gateway PID. Agents that fall back to shell commands after a failed config
+# attempt have been observed running `Stop-Process -Id <gateway pid> -Force`
+# (and the taskkill/kill equivalents), killing the very process that hosts
+# them. This guard is structural: it runs before the allow/deny/warn layers,
+# cannot be disabled through the OPENSQUILLA_SAFE_BIN_* environment knobs, and
+# applies in every host mode, including full/auto host access. Other PIDs and
+# process names remain the user's business.
+
+_SELF_KILL_GUIDANCE = (
+    "the gateway process may not be terminated from a tool: restarts are "
+    "managed by the desktop supervisor (or your service manager). Do not kill "
+    "the gateway or edit its config.toml through shell commands — use the "
+    "audio_config tool or the Settings UI for configuration changes."
+)
+
+# Process-name fragments that unambiguously refer to the gateway.
+_GATEWAY_NAME_FRAGMENT = re.compile(r"opensquilla", re.IGNORECASE)
+
+# PID-bearing kill invocations. Each pattern captures the argument tail that
+# carries PIDs; digits found there are compared against the gateway PID.
+_PID_KILL_PATTERNS: list[re.Pattern[str]] = [
+    # PowerShell: Stop-Process -Id 123[,456]  (also the spps alias)
+    re.compile(r"\b(?:stop-process|spps)\b(?P<tail>[^|;\n&]*)", re.IGNORECASE),
+    # Windows: taskkill /PID 123 [/PID 456]
+    re.compile(r"\btaskkill\b(?P<tail>[^|;\n&]*)", re.IGNORECASE),
+    # POSIX: kill [-9|-SIGTERM] 123 456 — also path-invoked (/bin/kill), but
+    # not words merely ending in "kill" (taskkill has its own pattern above).
+    re.compile(r"(?<![\w.-])(?:[^\s|;&]*[/\\])?kill\b(?P<tail>[^|;\n&]*)", re.IGNORECASE),
+]
+
+# Name-targeting kill invocations (no PID needed to hit the gateway).
+_NAME_KILL_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(
+        r"\b(?:stop-process|spps)\b[^|;\n&]*-(?:name|processname)\s+(?P<name>[^\s|;&]+)",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\btaskkill\b[^|;\n&]*/im\s+(?P<name>[^\s|;&]+)", re.IGNORECASE),
+    re.compile(r"\b(?:pkill|killall)\b(?P<name>[^|;\n&]*)", re.IGNORECASE),
+]
+
+_PID_TOKEN = re.compile(r"(?<![\w.-])(\d{2,})(?![\w.-])")
+
+
+def check_gateway_self_kill(command: str, *, gateway_pid: int | None = None) -> str | None:
+    """Return a refusal reason when ``command`` targets the gateway process.
+
+    ``gateway_pid`` is injectable for tests; it defaults to the current
+    process, which is the gateway for in-process builtin tools.
+    """
+    pid = os.getpid() if gateway_pid is None else gateway_pid
+    for pattern in _PID_KILL_PATTERNS:
+        for match in pattern.finditer(command):
+            tail = match.group("tail") or ""
+            # `kill` as a substring of e.g. `taskkill` is prevented by the
+            # lookbehind; `kill -0` style signal flags are digits too, so
+            # only compare tokens that stand alone as candidate PIDs and are
+            # not signal numbers attached to a dash.
+            tail_wo_signals = re.sub(r"-\s*\d+", " ", tail)
+            for token in _PID_TOKEN.findall(tail_wo_signals):
+                if int(token) == pid:
+                    return (
+                        f"command targets the gateway process (pid {pid}): {_SELF_KILL_GUIDANCE}"
+                    )
+    for pattern in _NAME_KILL_PATTERNS:
+        for match in pattern.finditer(command):
+            target = match.group("name") or ""
+            if _GATEWAY_NAME_FRAGMENT.search(target):
+                return (
+                    f"command targets the gateway by process name: {_SELF_KILL_GUIDANCE}"
+                )
+    return None
+
+
 @dataclass
 class SafeBinPolicy:
     denylist: list[str]  # regex patterns — if any match, command is denied
@@ -114,6 +191,12 @@ class SafeBinPolicy:
 
     def check(self, command: str) -> PolicyResult:
         """Check command against policy layers: allowlist → denylist → warnlist."""
+        # Structural guard first: killing the gateway from inside a tool is
+        # never valid, regardless of how the env-configurable layers are set.
+        self_kill = check_gateway_self_kill(command)
+        if self_kill is not None:
+            return PolicyResult(allowed=False, reason=self_kill)
+
         # Allowlist check: if non-empty, command must match at least one pattern
         if self.allowlist:
             matched = any(

--- a/tests/test_gateway/test_config_persist_corruption.py
+++ b/tests/test_gateway/test_config_persist_corruption.py
@@ -1,0 +1,94 @@
+"""Persistence stays safe around corrupted configs and interrupted writes.
+
+A real incident: an agent edited config.toml through a shell whose codepage
+wrote non-UTF-8 bytes, after which every load raised UnicodeDecodeError and
+the gateway crash-looped. The persist layer must (a) never produce such a
+file itself, (b) recover over one — backing up the corrupt bytes first — and
+(c) leave the original untouched when a write fails midway.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+
+import pytest
+
+from opensquilla.onboarding.config_store import load_config, persist_config
+from opensquilla.onboarding.mutations import upsert_audio_provider
+
+# Valid GBK-encoded Chinese ("配置"), invalid as UTF-8 — the observed corruption.
+GBK_BYTES = "# 配置\n".encode("gbk")
+
+
+def _fresh_config(tmp_path, monkeypatch):
+    target = tmp_path / "config.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+    return load_config(path=target), target
+
+
+def test_persist_recovers_over_non_utf8_config_with_backup(tmp_path, monkeypatch) -> None:
+    cfg, target = _fresh_config(tmp_path, monkeypatch)
+    mutated = upsert_audio_provider(cfg, provider_id="elevenlabs", api_key="k-123").config
+
+    # Corrupt the on-disk file the way the incident did.
+    target.write_bytes(GBK_BYTES)
+
+    result = persist_config(mutated, path=target)
+
+    # The rewritten file is strict UTF-8 and loadable end to end.
+    text = target.read_bytes().decode("utf-8", errors="strict")
+    tomllib.loads(text)
+    assert load_config(path=target).audio.enabled is True
+
+    # The corrupt original was preserved byte-for-byte in a backup.
+    backups = sorted(tmp_path.glob("config.toml.backup.*"))
+    assert backups, "no backup of the corrupt config was kept"
+    assert any(b.read_bytes() == GBK_BYTES for b in backups)
+    assert result.path == target
+
+
+def test_chinese_content_round_trips_as_utf8(tmp_path, monkeypatch) -> None:
+    cfg, target = _fresh_config(tmp_path, monkeypatch)
+    mutated = upsert_audio_provider(
+        cfg,
+        provider_id="elevenlabs",
+        api_key="k-456",
+        tts_voice="温柔的中文声音",
+    ).config
+
+    persist_config(mutated, path=target)
+
+    text = target.read_bytes().decode("utf-8", errors="strict")
+    assert "温柔的中文声音" in text
+    reloaded = load_config(path=target)
+    providers = reloaded.audio.providers
+    entry = providers.get("elevenlabs") if isinstance(providers, dict) else providers.elevenlabs
+    assert getattr(entry, "tts_voice", None) == "温柔的中文声音" or "温柔的中文声音" in text
+
+
+def test_failed_write_leaves_original_bytes_untouched(tmp_path, monkeypatch) -> None:
+    cfg, target = _fresh_config(tmp_path, monkeypatch)
+    first = upsert_audio_provider(cfg, provider_id="elevenlabs", api_key="k-first").config
+    persist_config(first, path=target)
+    original_bytes = target.read_bytes()
+
+    # Reload so the second mutation diffs against the committed baseline.
+    cfg2 = load_config(path=target)
+    second = upsert_audio_provider(cfg2, provider_id="elevenlabs", api_key="k-second").config
+
+    real_replace = os.replace
+
+    def failing_replace(src, dst, *args, **kwargs):
+        if str(dst) == str(target):
+            raise OSError("simulated mid-write failure")
+        return real_replace(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(os, "replace", failing_replace)
+    with pytest.raises(OSError):
+        persist_config(second, path=target, backup=False)
+    monkeypatch.setattr(os, "replace", real_replace)
+
+    assert target.read_bytes() == original_bytes
+    assert "k-second" not in target.read_bytes().decode("utf-8", "strict")

--- a/tests/test_tools/test_admin_audio_config.py
+++ b/tests/test_tools/test_admin_audio_config.py
@@ -1,0 +1,113 @@
+"""The agent-facing audio_config tool: safe persistence, hot apply, no leaks.
+
+This is the supported alternative to the shell fallbacks that have corrupted
+config.toml before (non-UTF-8 writes, subprocess-only env vars). It reuses the
+onboarding mutation + persist path, so the file stays valid UTF-8, the running
+gateway is updated in place, and no restart is needed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import tomllib
+
+import pytest
+
+import opensquilla.tools.builtin.admin as admin_mod
+import opensquilla.tools.builtin.media as media_mod
+from opensquilla.onboarding.config_store import load_config
+from opensquilla.tools.builtin.admin import audio_config as audio_config_tool
+from opensquilla.tools.types import ToolError
+
+SECRET = "elevenlabs-key-1a2b3c4d5e6f"
+
+
+@pytest.fixture()
+def live_config(tmp_path, monkeypatch):
+    target = tmp_path / "config.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+    cfg = load_config(path=target)
+    admin_mod.set_gateway_config(cfg)
+    yield cfg, target
+    admin_mod.set_gateway_config(None)
+
+
+@pytest.mark.asyncio
+async def test_configures_elevenlabs_without_restart_and_without_leaking(
+    live_config, caplog
+) -> None:
+    cfg, target = live_config
+    hot_applied: list[object] = []
+    real_configure_audio = media_mod.configure_audio
+    media_mod.configure_audio = lambda audio_cfg: hot_applied.append(audio_cfg)
+    try:
+        with caplog.at_level(logging.DEBUG):
+            raw = await audio_config_tool(
+                provider="elevenlabs",
+                api_key=SECRET,
+                enabled=True,
+                tts_voice="中文声音",
+                tts_model="eleven_turbo_v2_5",
+                language_code="zh-CN",
+            )
+    finally:
+        media_mod.configure_audio = real_configure_audio
+
+    result = json.loads(raw)
+    # ElevenLabs config never needs a gateway restart.
+    assert result["restartRequired"] is False
+    assert result["changed"] is True
+    assert result["configPath"] == str(target)
+
+    # The key is stored but never echoed: not in the tool result, not in logs.
+    assert SECRET not in raw
+    assert SECRET not in caplog.text
+
+    # On-disk artifact is strict UTF-8, valid TOML, and a loadable config —
+    # including the non-ASCII voice name round-tripping intact.
+    data = target.read_bytes()
+    text = data.decode("utf-8", errors="strict")
+    assert "中文声音" in text
+    parsed = tomllib.loads(text)
+    assert parsed["audio"]["providers"]["elevenlabs"]["api_key"] == SECRET
+    reloaded = load_config(path=target)
+    assert reloaded.audio.enabled is True
+
+    # Hot apply: the running config was updated in place and pushed into the
+    # audio tool layer without a restart.
+    assert cfg.audio.enabled is True
+    assert hot_applied, "configure_audio() was not invoked for the live config"
+    assert hot_applied[-1] is cfg.audio or getattr(hot_applied[-1], "enabled", None) is True
+
+
+@pytest.mark.asyncio
+async def test_validation_errors_are_actionable_and_secret_free(live_config, caplog) -> None:
+    _cfg, target = live_config
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(ToolError) as exc_info:
+            await audio_config_tool(
+                provider="elevenlabs",
+                api_key=SECRET,
+                api_key_env="ELEVENLABS_API_KEY",
+            )
+    message = str(exc_info.value)
+    assert "api_key" in message
+    assert SECRET not in message
+    assert SECRET not in caplog.text
+    # A refused configuration writes nothing.
+    assert not target.exists() or SECRET not in target.read_bytes().decode("utf-8", "replace")
+
+
+@pytest.mark.asyncio
+async def test_unsupported_provider_is_refused(live_config) -> None:
+    with pytest.raises(ToolError):
+        await audio_config_tool(provider="not-a-provider")
+
+
+@pytest.mark.asyncio
+async def test_requires_a_wired_gateway_config() -> None:
+    admin_mod.set_gateway_config(None)
+    with pytest.raises(ToolError):
+        await audio_config_tool(provider="elevenlabs", api_key=SECRET)

--- a/tests/test_tools/test_admin_gateway_contract.py
+++ b/tests/test_tools/test_admin_gateway_contract.py
@@ -1,0 +1,90 @@
+"""The gateway tool's advertised contract matches what it can actually do.
+
+Historically the tool advertised restart/config_get/config_set while restart
+always raised and config_set depended on a GatewayConfig.patch() that does not
+exist. Agents that hit those dead ends fell back to shell commands that
+corrupted config.toml and killed the gateway. The contract is now: config_get
+only (with credential redaction), and the retired actions return guidance
+pointing at the safe paths instead of a bare failure.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import opensquilla.tools.builtin.admin as admin_mod
+from opensquilla.onboarding.config_store import load_config
+from opensquilla.onboarding.mutations import upsert_audio_provider
+from opensquilla.tools.builtin.admin import gateway as gateway_tool
+from opensquilla.tools.types import ToolError
+
+SECRET = "elevenlabs-key-9z8y7x6w"
+
+
+@pytest.fixture()
+def wired_config(tmp_path, monkeypatch):
+    target = tmp_path / "config.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+    cfg = load_config(path=target)
+    cfg = upsert_audio_provider(cfg, provider_id="elevenlabs", api_key=SECRET).config
+    admin_mod.set_gateway_config(cfg)
+    yield cfg
+    admin_mod.set_gateway_config(None)
+
+
+@pytest.mark.asyncio
+async def test_restart_returns_supervisor_guidance(wired_config) -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await gateway_tool(action="restart")
+    message = str(exc_info.value)
+    assert "supervisor" in message
+    assert "audio_config" in message
+    assert "shell" in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_config_set_returns_safe_path_guidance(wired_config) -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await gateway_tool(action="config_set", key="audio.enabled", value="true")
+    message = str(exc_info.value)
+    assert "audio_config" in message
+    assert "config.toml" in message
+    # The old dead-end phrasings are gone.
+    assert "not supported" not in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_unknown_actions_advertise_only_config_get(wired_config) -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await gateway_tool(action="mystery")
+    message = str(exc_info.value)
+    assert "config_get" in message
+    assert "restart" not in message
+    assert "config_set" not in message
+
+
+@pytest.mark.asyncio
+async def test_config_get_redacts_credentials_at_the_leaf(wired_config) -> None:
+    raw = await gateway_tool(action="config_get", key="audio.providers.elevenlabs.api_key")
+    payload = json.loads(raw)
+    assert payload["value"] == "[redacted]"
+    assert SECRET not in raw
+
+
+@pytest.mark.asyncio
+async def test_config_get_redacts_credentials_inside_sections(wired_config) -> None:
+    raw = await gateway_tool(action="config_get", key="audio")
+    assert SECRET not in raw
+    payload = json.loads(raw)
+    providers = payload["value"]["providers"]["elevenlabs"]
+    assert providers["api_key"] == "[redacted]"
+
+
+@pytest.mark.asyncio
+async def test_config_get_still_returns_ordinary_values(wired_config) -> None:
+    raw = await gateway_tool(action="config_get", key="audio.enabled")
+    payload = json.loads(raw)
+    assert payload["value"] is True

--- a/tests/test_tools/test_shell_self_kill_policy.py
+++ b/tests/test_tools/test_shell_self_kill_policy.py
@@ -1,0 +1,116 @@
+"""Structural guard: shell commands can never terminate the gateway process.
+
+Agents observed failing an audio-config attempt have fallen back to
+``Stop-Process -Id <gateway pid> -Force`` (and taskkill/kill equivalents),
+killing the process that hosts them. The guard runs before every configurable
+policy layer, so neither environment overrides nor full host access modes can
+disable it, while other PIDs and process names stay manageable.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from opensquilla.tools.builtin.shell_policy import (
+    SafeBinPolicy,
+    check_gateway_self_kill,
+    check_safe_bin,
+    get_policy,
+    set_policy,
+)
+
+GW_PID = 43210
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        f"Stop-Process -Id {GW_PID} -Force",
+        f"stop-process -id {GW_PID}",
+        f"Stop-Process -Force -Id {GW_PID}",
+        f"spps -Id {GW_PID}",
+        f"taskkill /PID {GW_PID}",
+        f"taskkill /F /PID {GW_PID}",
+        f"TASKKILL /f /pid {GW_PID}",
+        f"kill {GW_PID}",
+        f"kill -9 {GW_PID}",
+        f"kill -SIGTERM {GW_PID}",
+        f"kill -TERM {GW_PID} 99999",
+        f"/bin/kill {GW_PID}",
+    ],
+)
+def test_pid_directed_kills_of_the_gateway_are_refused(command: str) -> None:
+    reason = check_gateway_self_kill(command, gateway_pid=GW_PID)
+    assert reason is not None
+    assert "desktop supervisor" in reason
+    assert "config.toml" in reason
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "Stop-Process -Name opensquilla-gateway",
+        "Stop-Process -ProcessName OpenSquilla-Gateway -Force",
+        "taskkill /IM opensquilla-gateway.exe /F",
+        "pkill -f opensquilla-gateway",
+        "pkill -f opensquilla",
+        "killall opensquilla-gateway",
+    ],
+)
+def test_name_directed_kills_of_the_gateway_are_refused(command: str) -> None:
+    assert check_gateway_self_kill(command, gateway_pid=GW_PID) is not None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        f"kill -9 {GW_PID + 1}",
+        f"taskkill /PID {GW_PID + 1}",
+        f"Stop-Process -Id {GW_PID + 1}",
+        "Stop-Process -Name notepad",
+        "taskkill /IM chrome.exe",
+        "pkill -f my-training-script",
+        "killall Dock",
+        f"echo pid is {GW_PID}",
+        f"ls {GW_PID}",
+        f"kill -{GW_PID}",  # a signal number is not a PID
+        "git log --oneline",
+    ],
+)
+def test_other_processes_and_ordinary_commands_stay_allowed(command: str) -> None:
+    assert check_gateway_self_kill(command, gateway_pid=GW_PID) is None
+
+
+def test_guard_uses_the_real_gateway_pid_by_default() -> None:
+    assert check_gateway_self_kill(f"kill {os.getpid()}") is not None
+    assert check_gateway_self_kill(f"kill {os.getpid() + 1}") is None
+
+
+def test_guard_survives_permissive_and_custom_policies() -> None:
+    """Env-configurable layers cannot re-allow gateway termination."""
+    original = get_policy()
+    try:
+        # Everything-allowed policy: empty deny/warn, allowlist matching all.
+        set_policy(SafeBinPolicy(denylist=[], allowlist=[r".*"], warnlist=[]))
+        result = check_safe_bin(f"Stop-Process -Id {os.getpid()} -Force")
+        assert not result.allowed
+        assert "desktop supervisor" in result.reason
+
+        # Other commands still pass through the permissive policy.
+        assert check_safe_bin("echo ok").allowed
+    finally:
+        set_policy(original)
+
+
+def test_guard_applies_before_the_denylist_reason() -> None:
+    """The refusal names the self-kill guard, not a generic deny pattern."""
+    original = get_policy()
+    try:
+        set_policy(SafeBinPolicy(denylist=[r"never-matches"], allowlist=[], warnlist=[]))
+        result = check_safe_bin(f"taskkill /F /PID {os.getpid()}")
+        assert not result.allowed
+        assert "gateway process" in result.reason
+    finally:
+        set_policy(original)


### PR DESCRIPTION
## Summary

An agent asked to configure `ELEVENLABS_API_KEY` walked into a chain of failures that ended with a corrupted config and a crash-looping gateway:

1. The `gateway` tool advertises `restart`/`config_get`/`config_set`, but `restart` always raises ("Gateway restart not supported via tool") and `config_set` depends on a `GatewayConfig.patch()` that does not exist ("Config modification not supported").
2. Hitting those dead ends, the agent fell back to `exec_command`: exporting the key in a PowerShell subprocess (which never reaches the running gateway and does not survive a restart), hand-editing `config.toml` (writing non-UTF-8 bytes — every subsequent load then raised `UnicodeDecodeError: 'utf-8' codec can't decode bytes…`, `gateway exited code=1`), and in a similar case `Stop-Process -Id <gateway pid> -Force` — killing the process hosting the tool.

This PR fixes the root causes — a tool contract promising what it cannot deliver, the missing safe entry point, and the shell fallback's ability to destroy the config and the process — rather than removing the audio capability.

**New `audio_config` tool** (`tools/builtin/admin.py`). The agent-facing entry point for audio (TTS) provider setup. It reuses the existing onboarding machinery — `upsert_audio_provider` validation, `persist_config`'s atomic UTF-8 write (temp file + fsync + rename, backup kept, 0600), in-place live apply, `configure_audio()` hot sync — through a shared `apply_audio_provider_configuration()` helper in `rpc_onboarding.py` that the `onboarding.audio.configure` RPC now also calls (single source of truth; no duplicated provenance/runtime-secret handling). ElevenLabs applies immediately with `restartRequired: false`. The API key never appears in tool results, logs, or error messages, with a fail-closed guard refusing any return payload that would contain it.

**Honest `gateway` tool contract.** Valid actions collapse to `config_get`. The retired `restart` and `config_set` actions return targeted guidance — the gateway lifecycle belongs to the desktop supervisor; audio goes through `audio_config`; never edit `config.toml` or export env vars via shell — instead of the bare failures that drove agents to those exact fallbacks. `config_get` now redacts credential-bearing values (`api_key`/`token`/`secret`/`password`/`credential`, at any nesting depth) instead of echoing raw keys to the agent.

**Gateway self-kill guard** (`tools/builtin/shell_policy.py`). A structural check runs before the configurable allowlist/denylist/warnlist layers: PID-directed terminations of the gateway's own process (`Stop-Process -Id`, `spps`, `taskkill /PID`, `kill`, path-invoked `/bin/kill`) and name-directed ones (`-Name`/`-ProcessName`, `taskkill /IM`, `pkill`, `killall` targeting opensquilla) are refused with a message pointing at the supervisor. Because it sits inside `SafeBinPolicy.check()`, it covers both `exec_command` and background processes, cannot be disabled through the `OPENSQUILLA_SAFE_BIN_*` environment knobs, and applies in every host mode including full/auto host access. Other PIDs and process names remain untouched (signal numbers like `kill -9` are not mistaken for PIDs).

**Persistence hardening** (`onboarding/config_store.py`). The corrupt-file recovery branch lists `UnicodeDecodeError` explicitly (previously covered only through its `ValueError` inheritance), documenting the incident shape: back up the corrupt bytes, then rewrite valid UTF-8 from the in-memory config.

Manually verified in the desktop shell: an agent asked to set up ElevenLabs now goes straight through `audio_config` (config valid on disk, key absent from logs), and a follow-up "restart the gateway" request produced an honest refusal citing the supervisor — explicitly declining to fabricate a restart result — instead of the previous shell fallbacks.

## Linked issues

None.

## Third-party code origins

None — all changes are original to this PR.

## Testing

45 new tests across four files, all offline and deterministic:

- `tests/test_tools/test_admin_audio_config.py` — configuring ElevenLabs through the tool yields a strict-UTF-8, `tomllib`-parseable, `GatewayConfig`-reloadable `config.toml` (CJK voice names round-trip); the running config is hot-applied and `configure_audio()` invoked; `restartRequired` is `false`; the key appears nowhere in results, logs, or validation errors; refused configurations write nothing.
- `tests/test_tools/test_admin_gateway_contract.py` — retired actions return supervisor/`audio_config` guidance (old dead-end phrasing gone); unknown actions advertise only `config_get`; `config_get` redacts credentials at the leaf and inside sections while ordinary values pass through.
- `tests/test_tools/test_shell_self_kill_policy.py` — 12 PID-directed and 6 name-directed kill forms refused across case/flag variants; 11 ordinary commands and other-PID kills allowed; the guard holds under an allow-everything policy and a custom denylist, i.e. environment configuration cannot bypass it.
- `tests/test_gateway/test_config_persist_corruption.py` — persisting over a GBK-corrupted config backs up the corrupt bytes byte-for-byte and rewrites strict UTF-8; CJK content round-trips; an injected `os.replace` failure leaves the original file byte-identical.

Gates: `uv run ruff check src tests` clean. `uv run pytest -q` — 16894 passed; the related existing suites (`test_rpc_onboarding_audio_sync`, `test_rpc_config_persistence`, shell policy suites) are green, and the remaining local failures are pre-existing environmental issues verified by re-running the same set with this diff stashed on clean `main` (identical failures: macOS BSD `sed`, sandboxed tmux, missing docker, and gitignored personal webui files perturbing the sdist fingerprint — the packaging tests pass once those files are absent, as on CI). `uv build --wheel` succeeds after `npm run build` per the untracked-dist convention from #749.