### PR TITLE
fix(webui): stabilize Skills control cursor transitions

### DIFF
--- a/opensquilla-webui/src/views/SkillsView.cursor.test.ts
+++ b/opensquilla-webui/src/views/SkillsView.cursor.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(new URL('./SkillsView.vue', import.meta.url), 'utf8')
+
+function ruleBody(selectors: RegExp): string {
+  const match = source.match(new RegExp(`${selectors.source}\\s*\\{([^}]*)\\}`))
+  expect(match, `Missing CSS rule matching ${selectors.source}`).not.toBeNull()
+  return match?.[1] ?? ''
+}
+
+describe('Skills registry cursor boundaries', () => {
+  it('does not leave a default-cursor gap between inputs and buttons', () => {
+    const rowRule = ruleBody(/\.sk-registry__head,\s*\.sk-github-install/)
+
+    // Keep vertical spacing when controls wrap, but make their horizontal
+    // hit-test boundaries adjacent so the cursor changes only once.
+    expect(rowRule).toContain('gap: var(--sp-2) 0;')
+  })
+})

--- a/opensquilla-webui/src/views/SkillsView.vue
+++ b/opensquilla-webui/src/views/SkillsView.vue
@@ -846,7 +846,7 @@ async function uninstallSkillAndClose(name: string) {
 .sk-github-install {
   display: flex;
   align-items: center;
-  gap: var(--sp-2);
+  gap: var(--sp-2) 0;
   flex-wrap: wrap;
 }
 .sk-registry__results {


### PR DESCRIPTION
## Summary

- remove the horizontal flex gap between the Community Skills inputs and their adjacent action buttons
- preserve the existing vertical spacing when those controls wrap on narrow viewports
- add a focused CSS contract test for the cursor boundary

## Root cause and impact

The shared Skills registry row used the same 8px flex gap on both axes. On Windows, moving across an input, that gap, and its button therefore crossed text, default, and pointer cursor hit-test regions in only a few pixels. Custom cursor schemes made those rapid shape and hotspot changes look like flicker.

Using `gap: var(--sp-2) 0` keeps wrapped controls separated vertically while making the input and button hit-test boundaries horizontally adjacent. The cursor now transitions directly from text selection to the button pointer.

Fixes #775

## Validation

- `npm run test:unit -- src/views/SkillsView.cursor.test.ts`
- `npm run test:unit` — 1881 tests passed
- `npm run typecheck`
- `npm run build`
- independent code review: no findings

A final manual pass with a contrasting custom Windows cursor scheme is still recommended because Chromium automation cannot assert operating-system cursor assets.