### PR TITLE
Keep Settings pinned in empty sidebars

### DIFF
--- a/opensquilla-webui/e2e/sidebar.spec.ts
+++ b/opensquilla-webui/e2e/sidebar.spec.ts
@@ -460,10 +460,27 @@ test.describe('Sidebar', () => {
   })
 
   test('footer pins Settings; connection state shows in the topbar', async ({ page }) => {
-    await openControl(page)
+    await page.goto(CONTROL_URL)
+    await page.waitForSelector('.conn-pill', { timeout: 10000 })
+    await page.waitForSelector('.conn-pill.connected', { timeout: 10000 }).catch(() => {})
+    await page.waitForTimeout(800)
 
     const foot = page.locator('.sidebar-foot')
     await expect(foot.getByText('Settings', { exact: true })).toBeVisible()
+    // Empty profiles omit SidebarConversations entirely. Simulate that state
+    // after the shared fixture settles and verify the footer owns its bottom
+    // anchor instead of relying on the optional Recents region's flex growth.
+    await page.evaluate(() => document.querySelector('.sidebar-history')?.remove())
+    const footerGeometry = await page.evaluate(() => {
+      const sidebarElement = document.querySelector<HTMLElement>('.sidebar')!
+      const sidebar = sidebarElement.getBoundingClientRect()
+      const footer = document.querySelector('.sidebar-foot')!.getBoundingClientRect()
+      return {
+        bottomGap: sidebar.bottom - footer.bottom,
+        paddingBottom: Number.parseFloat(getComputedStyle(sidebarElement).paddingBottom),
+      }
+    })
+    expect(Math.abs(footerGeometry.bottomGap - footerGeometry.paddingBottom)).toBeLessThanOrEqual(1)
     // Connection state is shown once, in the global topbar pill — not duplicated
     // in the sidebar footer.
     await expect(foot.locator('.sidebar-conn')).toHaveCount(0)

--- a/opensquilla-webui/src/assets/base.css
+++ b/opensquilla-webui/src/assets/base.css
@@ -1092,6 +1092,10 @@ pre {
 
 /* Fixed footer: settings row + connection state */
 .sidebar-foot {
+  /* Own the bottom anchor instead of relying on the optional Recents region to
+     consume the sidebar's remaining space. Empty profiles do not render that
+     region, but Settings must stay in the footer position. */
+  margin-top: auto;
   padding: 8px 8px 0;
   border-top: 1px solid var(--sidebar-border);
   flex-shrink: 0;


### PR DESCRIPTION
## Scope

- Keep the sidebar Settings footer pinned to the bottom when an empty profile omits the optional recent-conversations region.
- Add an end-to-end regression assertion that removes the optional Recents region and verifies the footer remains aligned with the sidebar's bottom padding.

## Branch target

- Base: `main`
- Head: `fix/sidebar-settings-footer`

## Linked issue

None.

## Release note

Bug fix: Settings now remains at the bottom of the sidebar for empty profiles.

## Validation

- `cd opensquilla-webui && npm run typecheck`
- `OPENSQUILLA_WEBUI_BASE_URL=http://127.0.0.1:5174 npm run test:e2e -- e2e/sidebar.spec.ts --grep 'footer pins Settings'`
- `git diff --check`

## Safety and compatibility

- Platform-neutral CSS flexbox change with browser-level regression coverage.
- No persisted state, configuration, database, RPC, CLI, or public protocol contract changes.
- Existing profiles with recent conversations retain their current layout because the Recents region continues to consume the available flex space.

## Third-party origin

None.