### PR TITLE
Preserve reasoning timers across session replay

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { effectScope, ref } from 'vue'
+import { effectScope, nextTick, ref } from 'vue'
 import { useChatRpcEventHandlers, type ChatRpcStreamApi } from './useChatRpcEventHandlers'
 import type { ChatMessage, ChatRunStatus, ChatRunStatusSource } from '@/types/chat'
 
@@ -9,9 +9,10 @@ function createHarness(options: {
   sessionRunStatus?: (source: ChatRunStatusSource | null | undefined) => ChatRunStatus
 } = {}) {
   const messages = ref<ChatMessage[]>(options.messages ?? [])
+  const sessionKey = ref('agent:main:test')
+  const lastStreamSeq = ref(0)
   const activeTaskGroups = ref(new Set<string>())
   const activeStreamTaskId = ref('')
-  const lastStreamSeq = ref(0)
   const applySessionRunState = vi.fn()
   const stream: ChatRpcStreamApi = {
     isStreaming: ref(true),
@@ -41,7 +42,7 @@ function createHarness(options: {
   const showWarningToast = vi.fn()
   const scope = effectScope()
   const api = scope.run(() => useChatRpcEventHandlers({
-    sessionKey: ref('agent:main:test'),
+    sessionKey,
     currentEpoch: ref(0),
     lastStreamSeq,
     activeTaskGroups,
@@ -82,10 +83,11 @@ function createHarness(options: {
   return {
     api,
     messages,
+    sessionKey,
+    lastStreamSeq,
     stream,
     activeTaskGroups,
     activeStreamTaskId,
-    lastStreamSeq,
     applySessionRunState,
     markEnsembleHandoff,
     schedulePendingDrainAfterTerminal,
@@ -474,6 +476,147 @@ describe('useChatRpcEventHandlers done usage attachment', () => {
       expect(messages.value[1].output_tokens).toBe(1)
     } finally {
       stop()
+    }
+  })
+})
+
+describe('useChatRpcEventHandlers reasoning timer replay', () => {
+  it('keeps elapsed time across A to B to A replay without leaking into B', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(105_000)
+    const { api, sessionKey, lastStreamSeq, stop } = createHarness()
+
+    try {
+      api.handlers.onAny('session.event.thinking', {
+        session_key: 'agent:main:test',
+        stream_seq: 1,
+        text: 'first',
+        started_at: 100_000,
+      })
+      expect(api.streamThinkingElapsedText.value).toBe('5s')
+
+      vi.setSystemTime(108_000)
+      sessionKey.value = 'agent:main:other'
+      lastStreamSeq.value = 0
+      await nextTick()
+      expect(api.streamThinkingText.value).toBe('')
+
+      sessionKey.value = 'agent:main:test'
+      lastStreamSeq.value = 0
+      await nextTick()
+      api.handlers.onAny('session.event.thinking', {
+        session_key: 'agent:main:test',
+        stream_seq: 1,
+        text: 'first',
+        started_at: 100_000,
+      })
+      expect(api.streamThinkingElapsedText.value).toBe('8s')
+
+      vi.setSystemTime(110_000)
+      api.handlers.onAny('session.event.thinking', {
+        session_key: 'agent:main:test',
+        stream_seq: 2,
+        text: ' second',
+        started_at: 109_000,
+      })
+      expect(api.streamThinkingElapsedText.value).toBe('10s')
+    } finally {
+      stop()
+      vi.useRealTimers()
+    }
+  })
+
+  it('stops replayed reasoning at the original done emission time', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(120_000)
+    const { api, messages, stop } = createHarness({
+      endStreaming(list) {
+        list.push({ role: 'assistant', text: 'answer', ts: 'now' })
+      },
+    })
+
+    try {
+      api.handlers.onAny('session.event.thinking', {
+        session_key: 'agent:main:test',
+        stream_seq: 1,
+        text: 'reasoning',
+        started_at: 100_000,
+      })
+      api.handlers.onAny('session.event.done', {
+        session_key: 'agent:main:test',
+        stream_seq: 2,
+        text: 'answer',
+        reasoning_content: 'reasoning',
+        emitted_at: 108_000,
+      })
+
+      expect(messages.value[0].reasoning).toEqual({
+        text: 'reasoning',
+        seconds: 8,
+      })
+    } finally {
+      stop()
+      vi.useRealTimers()
+    }
+  })
+
+  it('falls back to the local clock for legacy, skewed, and invalid start times', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(5_000_000)
+
+    try {
+      for (const startedAt of [
+        undefined,
+        5_006_000,
+        5_000_000 - 60 * 60 * 1_000 - 1,
+        Number.NaN,
+      ]) {
+        const { api, stop } = createHarness()
+        try {
+          api.handlers.onAny('session.event.thinking', {
+            session_key: 'agent:main:test',
+            stream_seq: 1,
+            text: 'reasoning',
+            started_at: startedAt,
+          })
+          expect(api.streamThinkingElapsedText.value).toBe('0s')
+        } finally {
+          stop()
+        }
+      }
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('falls back to local completion time when emitted_at precedes the start', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(108_000)
+    const { api, messages, stop } = createHarness({
+      endStreaming(list) {
+        list.push({ role: 'assistant', text: 'answer', ts: 'now' })
+      },
+    })
+
+    try {
+      api.handlers.onAny('session.event.thinking', {
+        session_key: 'agent:main:test',
+        stream_seq: 1,
+        text: 'reasoning',
+        started_at: 100_000,
+      })
+      api.handlers.onAny('session.event.done', {
+        session_key: 'agent:main:test',
+        stream_seq: 2,
+        text: 'answer',
+        reasoning_content: 'reasoning',
+        emitted_at: 99_000,
+      })
+
+      expect(messages.value[0].reasoning?.seconds).toBe(8)
+    } finally {
+      stop()
+      vi.useRealTimers()
     }
   })
 })

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -150,6 +150,33 @@ type BufferedPendingStreamEvent = {
 
 const MAX_PENDING_TASK_BUCKETS = 8
 const MAX_PENDING_STREAM_EVENTS_PER_TASK = 64
+const SERVER_CLOCK_TOLERANCE_MS = 5_000
+const MAX_TRUSTED_REASONING_AGE_MS = 60 * 60 * 1_000
+
+type LiveThinking = {
+  text: string
+  startedAt: number
+  serverStartedAt: number | null
+}
+
+function trustedReasoningStartedAt(raw: unknown, now: number): number | null {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return null
+  if (raw > now + SERVER_CLOCK_TOLERANCE_MS) return null
+  if (raw < now - MAX_TRUSTED_REASONING_AGE_MS) return null
+  return raw
+}
+
+function trustedReasoningDoneAt(
+  raw: unknown,
+  serverStartedAt: number,
+  now: number,
+): number | null {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return null
+  if (raw < serverStartedAt) return null
+  if (raw > now + SERVER_CLOCK_TOLERANCE_MS) return null
+  if (raw - serverStartedAt > MAX_TRUSTED_REASONING_AGE_MS) return null
+  return raw
+}
 
 function doneTextSnapshot(
   donePayload: ChatDoneUsagePayload,
@@ -207,7 +234,7 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
   } = options
 
   // Live thinking deltas for the current turn (session.event.thinking).
-  const streamThinking = ref<{ text: string; startedAt: number } | null>(null)
+  const streamThinking = ref<LiveThinking | null>(null)
   const turnReasoningLog: TurnReasoningRecord[] = []
   const pendingTerminalEvents = new Map<string, BufferedTerminalEvent>()
   const pendingStreamEvents = new Map<string, BufferedPendingStreamEvent[]>()
@@ -386,13 +413,21 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     return `${seconds}s`
   })
 
-  function appendThinkingDelta(text: string) {
+  function appendThinkingDelta(text: string, payload: SessionEventPayload) {
     if (!text) return
     if (!stream.isStreaming.value) stream.startStreaming()
     const current = streamThinking.value
-    streamThinking.value = current
-      ? { text: current.text + text, startedAt: current.startedAt }
-      : { text, startedAt: Date.now() }
+    if (current) {
+      streamThinking.value = { ...current, text: current.text + text }
+    } else {
+      const now = Date.now()
+      const serverStartedAt = trustedReasoningStartedAt(payload.started_at, now)
+      streamThinking.value = {
+        text,
+        startedAt: serverStartedAt ?? now,
+        serverStartedAt,
+      }
+    }
     // The fold concats the same text into its thinkingText. Gating already
     // passed upstream (handleRpcAny), so this frame mirrors an accepted delta.
     if (stream.useReducer.value) stream.appendFrame({ kind: 'thinking', text, at: Date.now() })
@@ -930,7 +965,7 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
       const thinkingText = (payload as SessionEventPayload).text
       if (typeof thinkingText !== 'string' || !thinkingText) return
       stream.resetStreamIdleTimer()
-      appendThinkingDelta(thinkingText)
+      appendThinkingDelta(thinkingText, payload)
       return
     }
 
@@ -963,9 +998,21 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
         : ''
       const liveThinking = streamThinking.value
       const reasoningText = doneReasoning || liveThinking?.text.trim() || ''
-      const reasoningSeconds = liveThinking
-        ? Math.max(0, Math.floor((Date.now() - liveThinking.startedAt) / 1000))
-        : 0
+      const reasoningSeconds = (() => {
+        if (!liveThinking) return 0
+        const now = Date.now()
+        const serverStartedAt = liveThinking.serverStartedAt
+        let elapsedMs = now - liveThinking.startedAt
+        if (serverStartedAt != null) {
+          const serverDoneAt = trustedReasoningDoneAt(
+            (payload as SessionEventPayload).emitted_at,
+            serverStartedAt,
+            now,
+          )
+          if (serverDoneAt != null) elapsedMs = serverDoneAt - serverStartedAt
+        }
+        return Math.max(0, Math.floor(elapsedMs / 1000))
+      })()
       clearLiveThinking()
       const messageCountBeforeEnd = messages.value.length
       stream.endStreaming()

--- a/opensquilla-webui/src/types/rpc.ts
+++ b/opensquilla-webui/src/types/rpc.ts
@@ -209,6 +209,8 @@ export interface StreamEventEnvelope {
 export interface SessionEventPayload extends StreamEventEnvelope {
   task_id?: string
   taskId?: string
+  started_at?: number
+  emitted_at?: number
   reason?: string
   status?: string
   run_status?: string

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -4783,6 +4783,7 @@ class Agent:
         self._current_turn_message = message
         _meta_invoke_turn_count.set(0)
         usage_scope = current_usage_accounting_scope()
+        reasoning_started_at_ms = 0
 
         # ------ IDLE → THINKING ------
         yield self._transition(AgentState.THINKING)
@@ -6033,7 +6034,12 @@ class Agent:
                                 # answer: re-emit as ThinkingEvent and keep it
                                 # out of assistant_text_parts. The joined text
                                 # still arrives via DoneEvent.reasoning_content.
-                                yield ThinkingEvent(text=raw_ev.text)
+                                if raw_ev.text and reasoning_started_at_ms == 0:
+                                    reasoning_started_at_ms = time.time_ns() // 1_000_000
+                                yield ThinkingEvent(
+                                    text=raw_ev.text,
+                                    started_at=reasoning_started_at_ms,
+                                )
                                 if (
                                     wrapup_margin_seconds > 0
                                     and _total_deadline is not None

--- a/src/opensquilla/engine/types.py
+++ b/src/opensquilla/engine/types.py
@@ -57,6 +57,7 @@ class AgentState(StrEnum):
 class ThinkingEvent:
     kind: Literal["thinking"] = field(default="thinking", init=False)
     text: str = ""
+    started_at: int = 0
 
 
 @dataclass

--- a/src/opensquilla/gateway/session_streams.py
+++ b/src/opensquilla/gateway/session_streams.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import time
 from collections import deque
 from dataclasses import dataclass
 from typing import Any
+
+
+def _epoch_time_ms() -> int:
+    return time.time_ns() // 1_000_000
 
 
 @dataclass(frozen=True)
@@ -75,6 +80,7 @@ class SessionStreamRegistry:
         enriched = dict(payload or {})
         enriched["session_key"] = session_key
         enriched["stream_seq"] = stream_seq
+        enriched["emitted_at"] = _epoch_time_ms()
 
         event = BufferedSessionEvent(event_name=event_name, payload=enriched, stream_seq=stream_seq)
         events = self._events_by_session.setdefault(session_key, deque())

--- a/tests/test_engine/test_agent_reasoning_reemit.py
+++ b/tests/test_engine/test_agent_reasoning_reemit.py
@@ -44,6 +44,19 @@ class _ReasoningProvider:
         return []
 
 
+class _EmptyThenReasoningProvider(_ReasoningProvider):
+    async def _stream(self) -> AsyncIterator[Any]:
+        yield ProviderReasoning(text="")
+        yield ProviderReasoning(text="first")
+        yield ProviderReasoning(text=" second")
+        yield ProviderDone(
+            stop_reason="stop",
+            input_tokens=2,
+            output_tokens=2,
+            reasoning_content="first second",
+        )
+
+
 def test_agent_reemits_reasoning_as_thinking_event() -> None:
     import asyncio
 
@@ -55,6 +68,8 @@ def test_agent_reemits_reasoning_as_thinking_event() -> None:
 
     thinking = [e for e in events if isinstance(e, ThinkingEvent)]
     assert [t.text for t in thinking] == ["Let me ", "think."]
+    assert thinking[0].started_at > 0
+    assert thinking[1].started_at == thinking[0].started_at
 
     # reasoning must NOT be folded into the assistant answer text
     answer = "".join(
@@ -62,6 +77,28 @@ def test_agent_reemits_reasoning_as_thinking_event() -> None:
     )
     assert answer == "The answer."
     assert "think" not in answer
+
+
+def test_reasoning_timer_starts_on_first_nonempty_delta() -> None:
+    import asyncio
+
+    async def run() -> list[Any]:
+        agent = Agent(provider=_EmptyThenReasoningProvider(), config=AgentConfig(max_iterations=1))
+        return [event async for event in agent.run_turn("hi")]
+
+    thinking = [
+        event
+        for event in asyncio.run(run())
+        if isinstance(event, ThinkingEvent)
+    ]
+
+    assert [event.started_at for event in thinking[:1]] == [0]
+    assert thinking[1].started_at > 0
+    assert thinking[2].started_at == thinking[1].started_at
+
+
+def test_thinking_event_keeps_legacy_default_start_time() -> None:
+    assert ThinkingEvent(text="legacy").started_at == 0
 
 
 from opensquilla.engine import ToolResult  # noqa: E402

--- a/tests/test_gateway/test_emit_stream_task_id.py
+++ b/tests/test_gateway/test_emit_stream_task_id.py
@@ -15,7 +15,12 @@ from typing import Any
 
 import pytest
 
-from opensquilla.engine.types import ErrorEvent, TextDeltaEvent, ToolUseStartEvent
+from opensquilla.engine.types import (
+    ErrorEvent,
+    TextDeltaEvent,
+    ThinkingEvent,
+    ToolUseStartEvent,
+)
 from opensquilla.gateway.boot import (
     TaskRuntimeStreamError,
     _emit_task_runtime_stream_events,
@@ -82,6 +87,33 @@ async def test_emit_stamps_task_id_on_every_stream_event() -> None:
         "session.event.text_delta",
     ]
     assert all(payload.get("task_id") == "task-A" for _, _, payload in emitted)
+
+
+@pytest.mark.asyncio
+async def test_emit_preserves_thinking_start_time() -> None:
+    emitted: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def _stream():
+        yield ThinkingEvent(text="checking", started_at=1_234_567)
+
+    async def _emitter(session_key: str, event_name: str, payload: dict[str, Any]) -> None:
+        emitted.append((session_key, event_name, payload))
+
+    await _emit_task_runtime_stream_events(
+        _stream(),
+        SESSION,
+        _emitter,
+        idle_timeout=5.0,
+        heartbeat_interval=0.0,
+    )
+
+    assert emitted == [
+        (
+            SESSION,
+            "session.event.thinking",
+            {"text": "checking", "started_at": 1_234_567},
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -11,7 +11,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 
@@ -5096,6 +5096,7 @@ class TestSessionsMessagesSubscribe:
                         "text": "Inspecting",
                         "session_key": key,
                         "stream_seq": 1,
+                        "emitted_at": ANY,
                     },
                 }
             ],

--- a/tests/test_gateway/test_session_streams.py
+++ b/tests/test_gateway/test_session_streams.py
@@ -1,3 +1,4 @@
+from opensquilla.gateway import session_streams
 from opensquilla.gateway.session_streams import SessionStreamRegistry
 
 
@@ -23,6 +24,24 @@ def test_session_stream_registry_replays_events_after_cursor() -> None:
     assert replay.current_stream_seq == 2
     assert replay.replay_complete is True
     assert [event.payload["text"] for event in replay.events] == ["b"]
+
+
+def test_session_stream_registry_preserves_original_emitted_at_on_replay(
+    monkeypatch,
+) -> None:
+    registry = SessionStreamRegistry(max_events_per_session=5)
+    monkeypatch.setattr(session_streams, "_epoch_time_ms", lambda: 1_234)
+    recorded = registry.record(
+        "agent:main:test",
+        "session.event.done",
+        {"reason": "stop"},
+    )
+
+    monkeypatch.setattr(session_streams, "_epoch_time_ms", lambda: 9_999)
+    replay = registry.replay("agent:main:test", 0)
+
+    assert recorded["emitted_at"] == 1_234
+    assert replay.events[0].payload["emitted_at"] == 1_234
 
 
 def test_session_stream_registry_reports_incomplete_replay() -> None:


### PR DESCRIPTION
## Scope

- Target branch: `main`
- Head branch: `fix/reasoning-timer-session-replay`
- Linked issue: Fixes #842
- Release note: bug fix; no migration required

## What changed

- Stamp the first non-empty reasoning delta with a stable `ThinkingEvent.started_at` epoch timestamp and reuse it for the full turn.
- Stamp buffered `session.event.*` payloads with `emitted_at` at first record and preserve that timestamp during replay and live-snapshot compaction.
- Restore live reasoning elapsed time from trusted server timestamps after session switches.
- Settle completed reasoning with `done.emitted_at`, so time spent away after the task already finished is not overcounted.
- Fall back to the existing local clock behavior for old gateways, missing fields, invalid values, excessive clock skew, or implausible timestamps.

## Root cause and impact

Switching sessions clears the current live reasoning state and reconstructs it from buffered events. Thinking events previously carried only text, so the first replayed delta was treated as new and seeded with `Date.now()`, resetting the visible timer to zero. The new additive timestamps preserve the original temporal boundary without introducing a cross-session UI cache.

This restores continuous `Thinking · Ns` timing for A → B → A navigation and preserves the correct final reasoning duration when A finishes while B is open.

## Compatibility and safety

- `started_at` and `emitted_at` are additive wire fields; older clients ignore them.
- New clients retain the legacy local-clock fallback when connected to older gateways.
- No RPC names, database schema, persisted configuration, or session storage format changed.
- Timestamp validation rejects missing, non-finite, future-skewed, or implausibly old values and clamps elapsed output to non-negative values.
- The change is platform-neutral and does not touch filesystem, process, or OS-specific behavior.
- Third-party code or assets: none.

## Validation

- `uv run pytest -q tests/test_engine tests/test_gateway` — 4701 passed, 10 skipped.
- `uv run pytest -q tests/test_gateway/test_rpc_sessions.py` — 187 passed.
- Focused engine/gateway regression set — 21 passed.
- `npm run test:unit` — 226 files, 2320 tests passed.
- `npm run build` — typecheck, Vite build, theme/runtime guards, and 195-file artifact verification passed.
- Focused Python Ruff checks passed.
- Full `uv run pytest tests -q` completed with 17702 passed and 204 skipped. The remaining 21 failures are local baseline/environment failures outside this diff: missing OpenTUI/Bun host dependencies, stale router artifact manifest, macOS/Linux sandbox expectations, missing WeasyPrint system libraries, and BSD `sed -i` behavior. One additional exact live-snapshot payload assertion exposed by `emitted_at` was updated; its full 187-test file and the 4701-test engine/gateway suite pass afterward.