### PR TITLE
Fix Windows sandbox setup in frozen Desktop gateway

### DIFF
--- a/desktop/electron/scripts/gateway-entry.py
+++ b/desktop/electron/scripts/gateway-entry.py
@@ -26,6 +26,13 @@ if __name__ == "__main__":
     if sys.argv[1:] == [_DESKTOP_CA_PROBE_ARG]:
         raise SystemExit(_run_desktop_ca_probe())
 
+    if len(sys.argv) == 3 and sys.argv[1] == "--elevated-helper":
+        from opensquilla.sandbox.backend.windows_default_setup import (
+            elevated_setup_helper_main,
+        )
+
+        raise SystemExit(elevated_setup_helper_main(sys.argv[1:]))
+
     from opensquilla.cli.main import app
 
     app()

--- a/src/opensquilla/sandbox/backend/windows_default_setup.py
+++ b/src/opensquilla/sandbox/backend/windows_default_setup.py
@@ -216,13 +216,11 @@ def run_elevated_setup_helper(path: Path) -> None:
     except FileNotFoundError:
         pass
     payload = _encode_setup_helper_payload(path, user_sid=_current_windows_user_sid())
+    helper_args = ["--elevated-helper", payload]
+    if not getattr(sys, "frozen", False):
+        helper_args = ["-m", "opensquilla.sandbox.backend.windows_default_setup", *helper_args]
     parameters = subprocess.list2cmdline(
-        [
-            "-m",
-            "opensquilla.sandbox.backend.windows_default_setup",
-            "--elevated-helper",
-            payload,
-        ]
+        helper_args
     )
     exit_code = _shell_execute_runas_and_wait(
         executable=sys.executable,

--- a/tests/test_desktop/test_gateway_tls_runtime.py
+++ b/tests/test_desktop/test_gateway_tls_runtime.py
@@ -1,5 +1,6 @@
 import importlib.util
 import os
+import runpy
 import sys
 from collections.abc import Iterator
 from pathlib import Path
@@ -276,3 +277,38 @@ def test_desktop_build_and_smoke_wire_the_ca_contract() -> None:
         "SSL_CERT_FILE",
     ):
         assert f"'{name}'" in smoke_source
+
+
+def test_desktop_gateway_entry_routes_sandbox_helper_before_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry_path = ROOT / "desktop/electron/scripts/gateway-entry.py"
+    helper_arguments: list[list[str]] = []
+    app_called = False
+
+    def elevated_setup_helper_main(arguments: list[str]) -> int:
+        helper_arguments.append(arguments)
+        return 17
+
+    def app() -> None:
+        nonlocal app_called
+        app_called = True
+
+    helper_module = ModuleType("opensquilla.sandbox.backend.windows_default_setup")
+    helper_module.elevated_setup_helper_main = elevated_setup_helper_main
+    cli_module = ModuleType("opensquilla.cli.main")
+    cli_module.app = app
+    monkeypatch.setitem(
+        sys.modules,
+        "opensquilla.sandbox.backend.windows_default_setup",
+        helper_module,
+    )
+    monkeypatch.setitem(sys.modules, "opensquilla.cli.main", cli_module)
+    monkeypatch.setattr(sys, "argv", [str(entry_path), "--elevated-helper", "payload"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(entry_path), run_name="__main__")
+
+    assert helper_arguments == [["--elevated-helper", "payload"]]
+    assert exc_info.value.code == 17
+    assert app_called is False

--- a/tests/test_sandbox/test_windows_default_network.py
+++ b/tests/test_sandbox/test_windows_default_network.py
@@ -281,6 +281,34 @@ def test_run_elevated_setup_helper_launches_python_module_with_runas(
     assert (Path(launched["directory"]) / "opensquilla").exists()
 
 
+def test_run_elevated_setup_helper_launches_frozen_helper_without_python_module(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from opensquilla.sandbox.backend import windows_default_setup as mod
+
+    launched = {}
+    marker = tmp_path / "setup_marker.json"
+
+    monkeypatch.setattr(mod.sys, "executable", r"C:\Program Files\OpenSquilla\opensquilla-gateway.exe")
+    monkeypatch.setattr(mod.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(mod, "_current_windows_user_sid", lambda: "S-1-real")
+
+    def fake_runas(*, executable, parameters, directory):
+        launched["executable"] = executable
+        launched["parameters"] = parameters
+        launched["directory"] = directory
+        return 0
+
+    monkeypatch.setattr(mod, "_shell_execute_runas_and_wait", fake_runas)
+
+    mod.run_elevated_setup_helper(marker)
+
+    assert launched["executable"].endswith("opensquilla-gateway.exe")
+    assert launched["parameters"].startswith("--elevated-helper ")
+    assert "-m" not in launched["parameters"]
+
+
 def test_runas_setup_helper_uses_hidden_window() -> None:
     from opensquilla.sandbox.backend import windows_default_setup as mod
 

--- a/tests/test_sandbox/test_windows_default_network.py
+++ b/tests/test_sandbox/test_windows_default_network.py
@@ -290,7 +290,11 @@ def test_run_elevated_setup_helper_launches_frozen_helper_without_python_module(
     launched = {}
     marker = tmp_path / "setup_marker.json"
 
-    monkeypatch.setattr(mod.sys, "executable", r"C:\Program Files\OpenSquilla\opensquilla-gateway.exe")
+    monkeypatch.setattr(
+        mod.sys,
+        "executable",
+        r"C:\Program Files\OpenSquilla\opensquilla-gateway.exe",
+    )
     monkeypatch.setattr(mod.sys, "frozen", True, raising=False)
     monkeypatch.setattr(mod, "_current_windows_user_sid", lambda: "S-1-real")
 


### PR DESCRIPTION
## Summary

- launch the elevated Windows sandbox helper without Python's `-m` arguments when running from a PyInstaller-frozen Desktop gateway
- route `--elevated-helper PAYLOAD` through the Desktop gateway entry point before loading the normal Typer CLI
- preserve the existing source/wheel `python -m` helper path and all existing payload, profile, ACL, firewall, WFP, report, and exit-code handling

## Root cause

OpenSquilla Desktop uses the PyInstaller-frozen `opensquilla-gateway.exe` as `sys.executable`. The Windows sandbox setup path relaunched that executable with `-m opensquilla.sandbox.backend.windows_default_setup`, but the frozen executable treats its arguments as Typer CLI options. It rejected `-m` and exited with code 2 before the elevated helper ran or wrote a setup report, leaving the UI at the generic Windows sandbox setup failure state.

## User impact

After this change, Desktop installations can enter the existing elevated Windows sandbox setup helper instead of failing at argument parsing. Non-frozen installations retain their current behavior.

## Verification

- `uv run pytest tests/test_sandbox/test_windows_default_network.py tests/test_desktop/test_gateway_tls_runtime.py -q` — 35 passed, 3 skipped
- `uv run ruff check src/opensquilla/sandbox/backend/windows_default_setup.py desktop/electron/scripts/gateway-entry.py tests/test_sandbox/test_windows_default_network.py tests/test_desktop/test_gateway_tls_runtime.py` — all checks passed
- `git diff --check upstream/main...HEAD` — clean

The skipped tests are existing Windows integration cases whose host prerequisites are unavailable in the focused unit-test environment.