### PR TITLE
Enable folder creation in the macOS project picker

### DIFF
--- a/src/opensquilla/gateway/rpc_sandbox.py
+++ b/src/opensquilla/gateway/rpc_sandbox.py
@@ -153,25 +153,37 @@ def _path_entry_payload(path: Path, *, selection_kind: str) -> dict[str, Any]:
 
 
 _MACOS_DIRECTORY_PICKER_SCRIPT = """
-on run argv
-    set dialogPrompt to item 1 of argv
-    if (count of argv) > 1 then
-        set initialFolder to POSIX file (item 2 of argv)
-        set selectedFolder to choose folder with prompt dialogPrompt default location initialFolder
-    else
-        set selectedFolder to choose folder with prompt dialogPrompt
-    end if
-    return POSIX path of selectedFolder
-end run
+ObjC.import("AppKit");
+ObjC.import("Foundation");
+
+function run(argv) {
+    const panel = $.NSOpenPanel.openPanel;
+    panel.canChooseFiles = false;
+    panel.canChooseDirectories = true;
+    panel.allowsMultipleSelection = false;
+    panel.canCreateDirectories = true;
+    panel.resolvesAliases = true;
+    panel.prompt = panel.title;
+
+    if (argv.length > 0 && argv[0]) {
+        panel.directoryURL = $.NSURL.fileURLWithPath(argv[0]);
+    }
+
+    if (panel.runModal === $.NSModalResponseOK) {
+        return ObjC.unwrap(panel.URL.path);
+    }
+    return "";
+}
 """
 
 
 def _pick_directory_path_macos(initial_dir: str | None = None) -> str | None:
     command = [
         "osascript",
+        "-l",
+        "JavaScript",
         "-e",
         _MACOS_DIRECTORY_PICKER_SCRIPT,
-        "Choose a project folder",
     ]
     if initial_dir:
         command.append(initial_dir)
@@ -257,9 +269,7 @@ async def _pick_directory_path_windows(initial_dir: str | None = None) -> str | 
     try:
         payload = json.loads(stdout.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise RpcUnavailableError(
-            "Directory picker returned an invalid response."
-        ) from exc
+        raise RpcUnavailableError("Directory picker returned an invalid response.") from exc
     selected = payload.get("path")
     if selected is None:
         return None

--- a/tests/test_sandbox/test_rpc_sandbox_access.py
+++ b/tests/test_sandbox/test_rpc_sandbox_access.py
@@ -1835,10 +1835,10 @@ async def test_rpc_sandbox_path_pick_uses_permission_based_workspace_selection(
         _ctx(manager),
     )
 
-    assert result == {
-        "path": str(Path("/etc/shadow").resolve(strict=False)),
-        "kind": "workspace",
-    }
+    expected_path = (
+        "/etc/shadow" if os.name == "nt" else str(Path("/etc/shadow").resolve(strict=False))
+    )
+    assert result == {"path": expected_path, "kind": "workspace"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_sandbox/test_rpc_sandbox_access.py
+++ b/tests/test_sandbox/test_rpc_sandbox_access.py
@@ -1835,7 +1835,10 @@ async def test_rpc_sandbox_path_pick_uses_permission_based_workspace_selection(
         _ctx(manager),
     )
 
-    assert result == {"path": "/etc/shadow", "kind": "workspace"}
+    assert result == {
+        "path": str(Path("/etc/shadow").resolve(strict=False)),
+        "kind": "workspace",
+    }
 
 
 @pytest.mark.asyncio
@@ -1957,13 +1960,67 @@ def test_native_macos_picker_returns_path_and_passes_initial_directory_as_argume
 
     assert result == "/Volumes/workspace/My Project/"
     command, kwargs = run_calls[0]
-    assert command[:2] == ["osascript", "-e"]
+    assert command[:4] == ["osascript", "-l", "JavaScript", "-e"]
     assert command[-1] == "/Volumes/workspace"
     assert kwargs == {
         "capture_output": True,
         "check": False,
         "text": True,
     }
+
+
+def test_native_macos_picker_allows_creating_directories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import opensquilla.gateway.rpc_sandbox as rpc_sandbox
+
+    run_calls = []
+
+    def fake_run(command, **kwargs):
+        run_calls.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            returncode=0,
+            stdout="/Volumes/workspace/New Project\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rpc_sandbox._pick_directory_path_macos("/Volumes/workspace")
+
+    script = run_calls[0][4]
+    assert "NSOpenPanel.openPanel" in script
+    assert "canChooseFiles = false" in script
+    assert "canChooseDirectories = true" in script
+    assert "canCreateDirectories = true" in script
+
+
+def test_native_macos_picker_does_not_override_system_localized_copy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import opensquilla.gateway.rpc_sandbox as rpc_sandbox
+
+    run_calls = []
+
+    def fake_run(command, **kwargs):
+        run_calls.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            returncode=0,
+            stdout="/Volumes/workspace/项目\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rpc_sandbox._pick_directory_path_macos("/Volumes/workspace")
+
+    command = run_calls[0]
+    script = command[4]
+    assert "Choose a project folder" not in command
+    assert "panel.message" not in script
+    assert "panel.prompt = panel.title" in script
 
 
 def test_native_macos_picker_treats_user_cancellation_as_no_selection(


### PR DESCRIPTION
## What changed

- replace the macOS AppleScript folder chooser with an AppKit `NSOpenPanel` driven through the built-in JXA runtime
- enable the native directory-creation controls while keeping directory-only, single-selection behavior
- remove the hard-coded English prompt and reuse the system-localized panel title for the confirmation button
- make the macOS path-normalization assertion portable across `/etc` and `/private/etc`

## Why

The browser-hosted project picker opens a native chooser on the Gateway host. On macOS, the previous chooser did not expose the standard New Folder control and overrode part of the system UI with English text even when macOS was configured for Chinese.

## User impact

Users can create a project directory directly inside the native macOS chooser, and the panel follows the operating system language while preserving the existing one-click project-selection flow.

## Validation

- `106 passed` in `tests/test_sandbox/test_rpc_sandbox_access.py`
- Ruff checks and formatting checks pass
- mypy reports no issues for `src/opensquilla/gateway/rpc_sandbox.py`
- AppKit runtime probe confirms directory creation is enabled and the Chinese system title and confirmation label resolve to `打开`