### PR TITLE
Client Migration-Phase 1-Decouple Gateway Control UI Assets

### DIFF
--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -10,6 +10,42 @@ The Control UI is the Vue product UI served by the gateway. The historical
 profiles still start, but it is deprecated, normalized to `"vue"`, and no
 longer activates the vanilla-JS client.
 
+## Control UI Asset Modes
+
+The Gateway resolves product UI assets independently from Core startup:
+
+```toml
+[control_ui]
+enabled = true
+assets_mode = "auto"       # auto | embedded | external | none
+assets_path = ""           # required only for external
+base_path = "/control"
+```
+
+- `auto` is the compatibility default. It uses a valid embedded bundle when
+  present and otherwise keeps the Gateway running with a neutral headless page.
+- `embedded` selects only the bundle packaged with OpenSquilla.
+- `external` selects an explicit local Vite `dist` directory (or its parent
+  containing `dist/`). The directory must include
+  `webui-artifact-manifest.json`; paths, inventory, sizes, SHA-256 digests,
+  symlinks, permissions, and entrypoint references are validated before files
+  are served.
+- `none` intentionally runs without a product UI. Gateway health/readiness,
+  WebSocket RPC, CLI, channels, Cron, and MCP do not depend on UI assets.
+- `enabled = false` removes the `/control` routes entirely.
+
+Relative `assets_path` values resolve from the Gateway config directory.
+Runtime overrides may use either
+`OPENSQUILLA_CONTROL_UI_ASSETS_MODE` / `OPENSQUILLA_CONTROL_UI_ASSETS_PATH`
+or the nested Gateway spellings
+`OPENSQUILLA_GATEWAY_CONTROL_UI__ASSETS_MODE` /
+`OPENSQUILLA_GATEWAY_CONTROL_UI__ASSETS_PATH`.
+
+External bundles are executable browser code. Do not point `assets_path` at an
+agent workspace, profile/state directory, session artifact, world-writable
+directory, symlink, junction, archive, or network URL. A rejected or missing
+bundle disables only the product UI; it does not make the Gateway unhealthy.
+
 ## Start the Web UI
 
 Run the gateway in the foreground:

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -58,6 +58,19 @@
 # diagnostics_enabled = false
 
 [control_ui]
+# Runtime asset selection. "auto" preserves current releases by using the
+# verified bundle embedded in the Python package and otherwise running
+# headless. "external" requires assets_path to name a local Vite dist directory
+# (or its parent containing dist/) with webui-artifact-manifest.json.
+# "embedded" requires the packaged bundle; "none" intentionally serves only a
+# neutral headless notice while Gateway health, RPC, CLI, and channels continue.
+# assets_mode = "auto"       # auto | embedded | external | none
+# assets_path = ""           # used only by external; relative to this config file
+#
+# Equivalent runtime overrides:
+# OPENSQUILLA_CONTROL_UI_ASSETS_MODE / OPENSQUILLA_CONTROL_UI_ASSETS_PATH
+# OPENSQUILLA_GATEWAY_CONTROL_UI__ASSETS_MODE / ...__ASSETS_PATH
+#
 # Vue is the only Control UI. The optional frontend key is retained temporarily
 # for config compatibility; historical "legacy" values are deprecated and are
 # treated as "vue" rather than selecting the retired vanilla-JS client.

--- a/src/opensquilla/gateway/__init__.py
+++ b/src/opensquilla/gateway/__init__.py
@@ -9,7 +9,12 @@ from opensquilla.gateway.boot import (
     start_gateway_server,
 )
 from opensquilla.gateway.config import GatewayConfig
-from opensquilla.gateway.control_ui import create_control_ui_routes
+from opensquilla.gateway.control_ui import create_control_ui_routes, resolve_control_ui_assets
+from opensquilla.gateway.control_ui_assets import (
+    ControlUiArtifactManifest,
+    ControlUiAssetResolver,
+    ControlUiAssets,
+)
 from opensquilla.gateway.protocol import (
     DECLARED_EVENTS,
     PROTOCOL_VERSION,
@@ -44,6 +49,10 @@ __all__ = [
     "GatewayConfig",
     # Control UI
     "create_control_ui_routes",
+    "resolve_control_ui_assets",
+    "ControlUiArtifactManifest",
+    "ControlUiAssetResolver",
+    "ControlUiAssets",
     # Protocol frames
     "PROTOCOL_VERSION",
     "DECLARED_EVENTS",

--- a/src/opensquilla/gateway/app.py
+++ b/src/opensquilla/gateway/app.py
@@ -21,6 +21,7 @@ from opensquilla.gateway.approval_events import build_approval_snapshot_item
 from opensquilla.gateway.approval_queue import get_approval_queue
 from opensquilla.gateway.config import GatewayConfig
 from opensquilla.gateway.control_ui import create_control_ui_routes
+from opensquilla.gateway.control_ui_assets import ControlUiAssets
 from opensquilla.gateway.hello_capabilities import CAPABILITY_ARTIFACTS
 from opensquilla.gateway.middleware import (
     AuthMiddleware,
@@ -85,6 +86,7 @@ def create_gateway_app(
     memory_retrievers: dict[str, Any] | None = None,
     extra_routes: list[Route] | None = None,
     upload_store: Any = None,
+    control_ui_assets: ControlUiAssets | None = None,
 ) -> Starlette:
     """Build and return the Starlette ASGI application."""
     if diagnostics_state is None:
@@ -729,7 +731,7 @@ def create_gateway_app(
         routes.extend(extra_routes)
 
     # ── Control UI routes ────────────────────────────────────────────────
-    routes.extend(create_control_ui_routes(config))
+    routes.extend(create_control_ui_routes(config, control_ui_assets))
 
     # ── Middleware ───────────────────────────────────────────────────────────
 

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -3162,19 +3162,39 @@ async def start_gateway_server(
         config.mark_runtime_secret("auth.token")
         log.info("gateway.auth_token_generated")
 
-    # Gateway-specific: resolve Control UI root directory (boot order 17)
+    # Gateway-specific: resolve Control UI assets (boot order 17). A missing or
+    # rejected UI bundle must never make Core health, RPC, CLI, or channels fail
+    # to boot; the resolver degrades to an explicit ``none`` description.
+    control_ui_assets = None
     if config.control_ui.enabled:
-        from opensquilla.gateway.control_ui import _STATIC_DIR, _TEMPLATE_DIR
+        from opensquilla.gateway.control_ui import resolve_control_ui_assets
 
-        if not _TEMPLATE_DIR.is_dir():
-            log.warning("gateway.control_ui.templates_missing", path=str(_TEMPLATE_DIR))
-        if not _STATIC_DIR.is_dir():
-            log.warning("gateway.control_ui.static_missing", path=str(_STATIC_DIR))
+        control_ui_assets = resolve_control_ui_assets(config)
+        if not control_ui_assets.template_root.is_dir():
+            log.warning(
+                "gateway.control_ui.templates_missing",
+                path=str(control_ui_assets.template_root),
+            )
+        if control_ui_assets.static_root is None:
+            log.warning("gateway.control_ui.static_missing")
         log.info(
             "gateway.control_ui.resolved",
             base_path=config.control_ui.base_path,
-            templates=str(_TEMPLATE_DIR),
-            static=str(_STATIC_DIR),
+            requested_mode=config.control_ui.assets_mode,
+            effective_mode=control_ui_assets.mode,
+            assets_available=control_ui_assets.available,
+            reason=control_ui_assets.reason,
+            templates=str(control_ui_assets.template_root),
+            static=(
+                str(control_ui_assets.static_root)
+                if control_ui_assets.static_root is not None
+                else ""
+            ),
+            dist=(
+                str(control_ui_assets.dist_root)
+                if control_ui_assets.dist_root is not None
+                else ""
+            ),
         )
     else:
         log.info("gateway.control_ui.disabled")
@@ -4044,6 +4064,7 @@ async def start_gateway_server(
         memory_stores=svc.memory_stores,
         memory_retrievers=svc.memory_retrievers,
         extra_routes=webhook_routes or None,
+        control_ui_assets=control_ui_assets,
     )
     app.state.gateway_ready = False
     app.state.desktop_gateway_ownership = _desktop_gateway_ownership

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -52,6 +52,16 @@ _LEGACY_CONTROL_UI_FRONTEND_WARNING = (
     "retired vanilla-JS UI; Vue is always served. Remove this setting or set "
     "it to 'vue'."
 )
+_CONTROL_UI_ASSET_ENV_KEYS = {
+    "assets_mode": (
+        "OPENSQUILLA_GATEWAY_CONTROL_UI__ASSETS_MODE",
+        "OPENSQUILLA_CONTROL_UI_ASSETS_MODE",
+    ),
+    "assets_path": (
+        "OPENSQUILLA_GATEWAY_CONTROL_UI__ASSETS_PATH",
+        "OPENSQUILLA_CONTROL_UI_ASSETS_PATH",
+    ),
+}
 
 
 class ContextOverflowPolicy(StrEnum):
@@ -138,6 +148,12 @@ class ControlUiConfig(BaseSettings):
 
     enabled: bool = True
     base_path: str = "/control"
+    # ``auto`` preserves current installs: use the verified bundle embedded in
+    # the Python package when present, otherwise keep the Gateway headless.
+    # ``external`` is an explicit, manifest-validated client/deployment input;
+    # the Gateway never scans workspaces or profile directories for a bundle.
+    assets_mode: Literal["auto", "embedded", "external", "none"] = "auto"
+    assets_path: str = ""
     # Retained temporarily so existing TOML files and environment overrides do
     # not fail gateway validation after the vanilla-JS client is retired. Vue
     # is the only runtime value; the validator below maps the historical
@@ -154,6 +170,16 @@ class ControlUiConfig(BaseSettings):
     @classmethod
     def _strip_trailing_slash(cls, v: str) -> str:
         return v.rstrip("/")
+
+    @field_validator("assets_mode", mode="before")
+    @classmethod
+    def _normalize_assets_mode(cls, v: object) -> object:
+        return v.strip().lower() if isinstance(v, str) else v
+
+    @field_validator("assets_path", mode="before")
+    @classmethod
+    def _normalize_assets_path(cls, v: object) -> object:
+        return v.strip() if isinstance(v, str) else v
 
     @field_validator("frontend", mode="before")
     @classmethod
@@ -2829,6 +2855,52 @@ class GatewayConfig(BaseSettings):
             cfg.record_runtime_override(field_name, stored, applied)
 
     @classmethod
+    def _apply_control_ui_asset_env_overrides(
+        cls,
+        cfg: GatewayConfig,
+        stored_payload: dict[str, Any] | None,
+    ) -> None:
+        """Apply both supported UI-asset env spellings without persisting them.
+
+        Nested Pydantic settings correctly handle either spelling for a bare
+        ``GatewayConfig()``, but explicit TOML constructor data has higher
+        source priority. Runtime configuration promises env-over-TOML
+        precedence, so disk-load boundaries apply these two fields explicitly
+        and record their stored values for sparse persistence.
+        """
+
+        raw_control_ui = (
+            stored_payload.get("control_ui")
+            if isinstance(stored_payload, dict)
+            else None
+        )
+        stored_section = raw_control_ui if isinstance(raw_control_ui, dict) else {}
+        updates: dict[str, str] = {}
+        stored_values: dict[str, Any] = {}
+        for field_name, keys in _CONTROL_UI_ASSET_ENV_KEYS.items():
+            selected = next((os.environ[key] for key in keys if key in os.environ), None)
+            if selected is None:
+                continue
+            updates[field_name] = selected
+            stored_values[field_name] = stored_section.get(
+                field_name,
+                ControlUiConfig.model_fields[field_name].default,
+            )
+        if not updates:
+            return
+
+        payload = cfg.control_ui.model_dump(mode="python")
+        payload.update(updates)
+        updated = ControlUiConfig(**payload)
+        cfg.control_ui = updated
+        for field_name, stored in stored_values.items():
+            cfg.record_runtime_override(
+                f"control_ui.{field_name}",
+                stored,
+                getattr(updated, field_name),
+            )
+
+    @classmethod
     def load_from_toml(cls, path: str | Path) -> GatewayConfig:
         """Load config from a TOML file."""
         import tomllib
@@ -2838,6 +2910,7 @@ class GatewayConfig(BaseSettings):
             data = tomllib.load(f)
         migration = migrate_config_payload(data)
         cfg = cls(**migration.payload)
+        cls._apply_control_ui_asset_env_overrides(cfg, migration.payload)
         cfg._mark_env_absorbed_secrets(data)
         cls._apply_profile_path_overrides(cfg, target)
         if migration.changed:
@@ -2877,6 +2950,7 @@ class GatewayConfig(BaseSettings):
                     data = tomllib.load(f)
                 migration = migrate_config_payload(data, emit_diagnostics=not read_only)
                 cfg = cls(**migration.payload)
+                cls._apply_control_ui_asset_env_overrides(cfg, migration.payload)
                 cls._apply_profile_path_overrides(cfg, path)
                 if migration.changed and not read_only:
                     _rewrite_migrated_config_best_effort(path, migration)
@@ -2886,6 +2960,7 @@ class GatewayConfig(BaseSettings):
                 return cfg
 
         cfg = cls()
+        cls._apply_control_ui_asset_env_overrides(cfg, None)
         default_config_path = (
             candidates[0]
             if candidates

--- a/src/opensquilla/gateway/control_ui.py
+++ b/src/opensquilla/gateway/control_ui.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
 import time
 from pathlib import Path, PurePosixPath
 
+import anyio
 import structlog
+from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import HTMLResponse
 from starlette.routing import Mount, Route
@@ -16,6 +19,11 @@ from starlette.staticfiles import StaticFiles
 
 from opensquilla import __version__
 from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.control_ui_assets import (
+    ControlUiArtifactManifest,
+    ControlUiAssetResolver,
+    ControlUiAssets,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -99,6 +107,95 @@ class _CachedStaticFiles(StaticFiles):
         return response
 
 
+class _ManifestStaticFiles(_CachedStaticFiles):
+    """Serve only files admitted by a validated external artifact manifest."""
+
+    def __init__(
+        self,
+        *,
+        directory: str,
+        manifest: ControlUiArtifactManifest,
+    ) -> None:
+        super().__init__(directory=directory, check_dir=False)
+        self._directory = Path(directory)
+        self._expected = {
+            entry.path: entry for entry in manifest.files if entry.path != "index.html"
+        }
+        self._integrity_cache: dict[str, tuple[int, int, int, int]] = {}
+
+    @staticmethod
+    def _sha256(path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            while chunk := handle.read(1024 * 1024):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    async def get_response(self, path: str, scope):  # type: ignore[override]
+        normalized = PurePosixPath(path.replace(os.sep, "/")).as_posix().lstrip("/")
+        expected = self._expected.get(normalized)
+        if expected is None:
+            raise HTTPException(status_code=404)
+        candidate = self._directory.joinpath(*PurePosixPath(normalized).parts)
+        if candidate.is_symlink():
+            raise HTTPException(status_code=404)
+        try:
+            file_stat = candidate.stat()
+        except OSError as error:
+            raise HTTPException(status_code=404) from error
+        cache_key = (
+            int(getattr(file_stat, "st_ino", 0)),
+            file_stat.st_size,
+            file_stat.st_mtime_ns,
+            file_stat.st_ctime_ns,
+        )
+        if file_stat.st_size != expected.size:
+            raise HTTPException(status_code=404)
+        if self._integrity_cache.get(normalized) != cache_key:
+            try:
+                digest = await anyio.to_thread.run_sync(self._sha256, candidate)
+            except OSError as error:
+                raise HTTPException(status_code=404) from error
+            if digest != expected.sha256:
+                raise HTTPException(status_code=404)
+            self._integrity_cache[normalized] = cache_key
+        return await super().get_response(path, scope)
+
+
+class _ControlUiStaticFiles(_CachedStaticFiles):
+    """Keep one public static mount while allowing the Vite dist root to vary."""
+
+    def __init__(self, assets: ControlUiAssets) -> None:
+        super().__init__(
+            directory=str(assets.static_root) if assets.static_root is not None else None,
+            check_dir=False,
+        )
+        self._dist: _CachedStaticFiles | None = None
+        if assets.dist_root is not None:
+            if assets.mode == "external" and assets.manifest is not None:
+                self._dist = _ManifestStaticFiles(
+                    directory=str(assets.dist_root),
+                    manifest=assets.manifest,
+                )
+            else:
+                self._dist = _CachedStaticFiles(
+                    directory=str(assets.dist_root),
+                    check_dir=False,
+                )
+
+    async def get_response(self, path: str, scope):  # type: ignore[override]
+        normalized = path.replace(os.sep, "/").lstrip("/")
+        if normalized.startswith("dist/"):
+            if self._dist is None:
+                raise HTTPException(status_code=404)
+            return await self._dist.get_response(normalized.removeprefix("dist/"), scope)
+        if normalized == "dist":
+            if self._dist is None:
+                raise HTTPException(status_code=404)
+            return await self._dist.get_response("", scope)
+        return await super().get_response(path, scope)
+
+
 _TEMPLATE_DIR = Path(__file__).parent / "templates"
 _STATIC_DIR = Path(__file__).parent / "static"
 _DIST_DIR = _STATIC_DIR / "dist"
@@ -108,16 +205,20 @@ _TEMPLATE_VERSION_SUFFIX = str(int(time.time()))
 _jinja_env = None
 
 
-def _get_jinja_env():
+def _get_jinja_env(template_root: Path | None = None):
     global _jinja_env
-    if _jinja_env is None:
+    root = template_root or _TEMPLATE_DIR
+    if _jinja_env is None or root != _TEMPLATE_DIR:
         import jinja2
 
-        _jinja_env = jinja2.Environment(
-            loader=jinja2.FileSystemLoader(str(_TEMPLATE_DIR)),
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(str(root)),
             autoescape=True,
         )
-        _jinja_env.filters["tojson"] = lambda v, **kw: json.dumps(v)
+        env.filters["tojson"] = lambda v, **kw: json.dumps(v)
+        if root != _TEMPLATE_DIR:
+            return env
+        _jinja_env = env
     return _jinja_env
 
 
@@ -233,7 +334,10 @@ def _vite_asset_url(raw_url: str, base_path: str) -> str:
     return raw_url
 
 
-def _read_vite_assets(base_path: str) -> tuple[str, list[str]]:
+def _read_vite_assets(
+    base_path: str,
+    dist_root: Path | None = None,
+) -> tuple[str, list[str]]:
     """Read the Vite-generated index.html and extract the main JS module and
     every entry stylesheet.
 
@@ -243,7 +347,7 @@ def _read_vite_assets(base_path: str) -> tuple[str, list[str]]:
     drops the main bundle and renders the page unstyled, so all of them must be
     injected.
     """
-    dist_index = _DIST_DIR / "index.html"
+    dist_index = (dist_root or _DIST_DIR) / "index.html"
     if not dist_index.exists():
         # The template turns this into an actionable diagnostic instead of a
         # blank Vue mount point. Standard distributions cannot reach this state
@@ -265,42 +369,133 @@ def _read_vite_assets(base_path: str) -> tuple[str, list[str]]:
     return (js_url, css_urls)
 
 
-def create_control_ui_routes(config: GatewayConfig) -> list[Route | Mount]:
-    """Create routes for the Control UI. Returns empty list if disabled."""
+def resolve_control_ui_assets(config: GatewayConfig) -> ControlUiAssets:
+    """Resolve assets using the compatibility globals existing tests may patch."""
+
+    return ControlUiAssetResolver(
+        config,
+        embedded_static_root=_STATIC_DIR,
+        embedded_dist_root=_DIST_DIR,
+        template_root=_TEMPLATE_DIR,
+    ).resolve()
+
+
+def _missing_assets_detail(assets: ControlUiAssets) -> str:
+    reason = assets.reason or "unavailable"
+    if reason == "explicit_none":
+        return (
+            "The Gateway is intentionally running without a product Control UI. "
+            "Use the CLI, a compatible client, or the public RPC interfaces."
+        )
+    if reason.startswith("external:"):
+        return (
+            "The configured external Control UI bundle was rejected by its path "
+            "or manifest validation. The Gateway core remains available."
+        )
+    return (
+        "The built Vue console was not found or failed validation, so the Control "
+        "UI will serve an 'assets are unavailable' notice instead of the console. "
+        "From a source checkout, build it with `cd opensquilla-webui && npm ci && "
+        "npm run build` (Node.js 22.12+ with npm) and restart or reload the page. "
+        "Release-wheel and Desktop installs should reinstall an official package."
+    )
+
+
+def _fallback_index_html(assets: ControlUiAssets) -> str:
+    reason = assets.reason or "unavailable"
+    if reason == "explicit_none":
+        title = "Gateway is running without a Control UI"
+        detail = "Use a compatible client, the CLI, or the Gateway RPC interfaces."
+    elif reason.startswith("external:"):
+        title = "Configured Control UI assets were rejected"
+        detail = "The Gateway core is healthy; verify the external bundle manifest."
+    else:
+        title = "Control UI assets are unavailable"
+        detail = "The Gateway core is healthy; reinstall or rebuild the Control UI bundle."
+    return (
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+        f"<title>{title}</title></head><body><main role=\"alert\"><h1>{title}</h1>"
+        f"<p>{detail}</p></main></body></html>"
+    )
+
+
+def create_control_ui_routes(
+    config: GatewayConfig,
+    assets: ControlUiAssets | None = None,
+) -> list[Route | Mount]:
+    """Create Control UI routes from a resolved, immutable asset description."""
+
     if not config.control_ui.enabled:
         return []
 
-    if not (_DIST_DIR / "index.html").exists():
-        # The served page already shows an actionable notice, but headless
-        # operators only watch logs — surface the same guidance at startup.
-        log.warning(
-            "control_ui.webui_assets_missing",
-            detail=(
-                "The built Vue console was not found, so the Control UI will "
-                "serve an 'assets are unavailable' notice instead of the "
-                "console. From a source checkout, build it with "
-                "`cd opensquilla-webui && npm ci && npm run build` "
-                "(Node.js 22.12+ with npm) and restart or reload the page. "
-                "Release-wheel and Desktop installs should reinstall an "
-                "official package."
-            ),
-            dist_dir=str(_DIST_DIR),
-        )
+    resolved = assets or resolve_control_ui_assets(config)
+    if not resolved.available:
+        detail = _missing_assets_detail(resolved)
+        if resolved.reason == "explicit_none":
+            log.info(
+                "control_ui.assets_disabled",
+                assets_mode="none",
+                detail=detail,
+            )
+        else:
+            # The served page already shows an actionable notice, but headless
+            # operators only watch logs — surface the same guidance at startup.
+            log.warning(
+                "control_ui.webui_assets_missing",
+                assets_mode=config.control_ui.assets_mode,
+                reason=resolved.reason,
+                detail=detail,
+                # Preserve the existing diagnostic field for embedded/source
+                # installs without exposing a configured external absolute path.
+                dist_dir=(
+                    str(_DIST_DIR)
+                    if config.control_ui.assets_mode in {"auto", "embedded"}
+                    else ""
+                ),
+            )
 
     base = config.control_ui.base_path
-    template = _get_jinja_env().get_template("index.html")
+    try:
+        template = _get_jinja_env(resolved.template_root).get_template("index.html")
+    except Exception:
+        template = None
+        log.warning(
+            "control_ui.template_missing",
+            detail="The neutral Control UI bootstrap template is unavailable.",
+        )
+    external_entry = (
+        (
+            _vite_asset_url(resolved.manifest.entry_scripts[0], base),
+            [
+                _vite_asset_url(relative, base)
+                for relative in resolved.manifest.entry_styles
+            ],
+        )
+        if resolved.mode == "external"
+        and resolved.manifest is not None
+        and resolved.manifest.entry_scripts
+        else None
+    )
 
     async def serve_index(request: Request) -> HTMLResponse:
         ctx = _build_bootstrap_context(config, request)
-        # Re-read latest Vite assets on every request so rebuilds are picked up
-        # without restarting the gateway.
-        live_js, live_css_urls = _read_vite_assets(base)
+        # Re-read the selected entrypoint on each request so an embedded source
+        # build is picked up without a restart. External entry URLs are frozen
+        # after validation and their files stay behind the manifest allowlist.
+        if external_entry is not None:
+            live_js, live_css_urls = external_entry
+        elif resolved.dist_root is not None:
+            live_js, live_css_urls = _read_vite_assets(base, resolved.dist_root)
+        else:
+            live_js, live_css_urls = ("", [])
         ctx["vite_js_url"] = live_js
         ctx["vite_css_urls"] = live_css_urls
         ctx["webui_artifact_missing"] = not live_js
+        ctx["control_ui_assets_mode"] = resolved.mode
+        ctx["control_ui_assets_reason"] = resolved.reason or ""
         # Back-compat single URL (first) for any consumer expecting one.
         ctx["vite_css_url"] = live_css_urls[0] if live_css_urls else ""
-        html = template.render(**ctx)
+        html = template.render(**ctx) if template is not None else _fallback_index_html(resolved)
         response = HTMLResponse(html)
         response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
         response.headers["Pragma"] = "no-cache"
@@ -310,7 +505,7 @@ def create_control_ui_routes(config: GatewayConfig) -> list[Route | Mount]:
     routes: list[Route | Mount] = [
         Mount(
             f"{base}/static",
-            app=_CachedStaticFiles(directory=str(_STATIC_DIR)),
+            app=_ControlUiStaticFiles(resolved),
             name="control_ui_static",
         ),
         Route(f"{base}/{{path:path}}", serve_index, methods=["GET"]),

--- a/src/opensquilla/gateway/control_ui_assets.py
+++ b/src/opensquilla/gateway/control_ui_assets.py
@@ -1,0 +1,575 @@
+"""Resolve and validate Control UI assets without coupling Gateway boot to a bundle."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+from dataclasses import dataclass, replace
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.paths import default_opensquilla_home, native_io_path
+
+CONTROL_UI_MANIFEST_NAME = "webui-artifact-manifest.json"
+_MAX_MANIFEST_BYTES = 4 * 1024 * 1024
+_MAX_ARTIFACT_FILES = 50_000
+_MAX_ARTIFACT_BYTES = 512 * 1024 * 1024
+_MAX_ARTIFACT_FILE_BYTES = 128 * 1024 * 1024
+_MAX_INDEX_BYTES = 5 * 1024 * 1024
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+_FORBIDDEN_FILE_NAMES = frozenset({".ds_store", ".env", ".npmrc"})
+_FORBIDDEN_FILE_SUFFIXES = frozenset({".key", ".pem"})
+
+ControlUiAssetsMode = Literal["embedded", "external", "none"]
+ControlUiAssetsRequestMode = Literal["auto", "embedded", "external", "none"]
+
+
+class ControlUiAssetError(ValueError):
+    """A configured UI bundle is missing, unsafe, or internally inconsistent."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.code = code
+        self.detail = detail
+
+
+@dataclass(frozen=True, slots=True)
+class ControlUiArtifactFile:
+    """One immutable file declared by the UI artifact manifest."""
+
+    path: str
+    size: int
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class ControlUiArtifactManifest:
+    """Validated metadata and serving allowlist for a Control UI bundle."""
+
+    schema_version: int
+    source_fingerprint: str
+    files: tuple[ControlUiArtifactFile, ...]
+    client_version: str | None = None
+    contract_digest: str | None = None
+    entry_scripts: tuple[str, ...] = ()
+    entry_styles: tuple[str, ...] = ()
+
+    @property
+    def allowed_paths(self) -> frozenset[str]:
+        return frozenset(item.path for item in self.files)
+
+
+@dataclass(frozen=True, slots=True)
+class ControlUiAssets:
+    """Read-only description consumed by the Control UI route factory."""
+
+    mode: ControlUiAssetsMode
+    static_root: Path | None
+    dist_root: Path | None
+    template_root: Path
+    manifest: ControlUiArtifactManifest | None
+    reason: str | None = None
+
+    @property
+    def available(self) -> bool:
+        return self.dist_root is not None
+
+
+def _is_junction(path: Path) -> bool:
+    checker = getattr(path, "is_junction", None)
+    if checker is None:
+        return False
+    try:
+        return bool(checker())
+    except OSError:
+        return False
+
+
+def _is_link(path: Path) -> bool:
+    try:
+        return path.is_symlink() or _is_junction(path)
+    except OSError:
+        return True
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _safe_manifest_path(raw: object) -> str:
+    if (
+        not isinstance(raw, str)
+        or not raw
+        or "\\" in raw
+        or any(ord(character) < 32 for character in raw)
+    ):
+        raise ControlUiAssetError(
+            "manifest_path_invalid",
+            "The Control UI manifest contains an invalid file path.",
+        )
+    pure = PurePosixPath(raw)
+    if (
+        pure.is_absolute()
+        or raw.startswith("/")
+        or any(part in {"", ".", ".."} for part in pure.parts)
+        or pure.as_posix() != raw
+    ):
+        raise ControlUiAssetError(
+            "manifest_path_escape",
+            "The Control UI manifest contains a path outside the asset root.",
+        )
+    return raw
+
+
+def _forbidden_artifact_path(relative: str) -> bool:
+    name = PurePosixPath(relative).name.lower()
+    return (
+        name in _FORBIDDEN_FILE_NAMES
+        or name.startswith(".env.")
+        or PurePosixPath(name).suffix in _FORBIDDEN_FILE_SUFFIXES
+    )
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(native_io_path(path), "rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _directory_files(root: Path) -> dict[str, Path]:
+    files: dict[str, Path] = {}
+    for path in sorted(
+        native_io_path(root).rglob("*"),
+        key=lambda value: value.as_posix().encode("utf-8", errors="surrogateescape"),
+    ):
+        if _is_link(path):
+            raise ControlUiAssetError(
+                "artifact_link_forbidden",
+                "The Control UI asset directory contains a symbolic link or junction.",
+            )
+        if os.name != "nt" and path.stat().st_mode & stat.S_IWOTH:
+            raise ControlUiAssetError(
+                "artifact_world_writable",
+                "The Control UI asset tree is writable by other users.",
+            )
+        if not path.is_file():
+            continue
+        try:
+            relative = path.relative_to(native_io_path(root)).as_posix()
+        except ValueError as error:
+            raise ControlUiAssetError(
+                "artifact_path_escape",
+                "A Control UI asset resolves outside the configured directory.",
+            ) from error
+        relative = _safe_manifest_path(relative)
+        if _forbidden_artifact_path(relative):
+            raise ControlUiAssetError(
+                "artifact_sensitive_file",
+                "The Control UI asset directory contains forbidden metadata or key material.",
+            )
+        files[relative] = path
+        if len(files) > _MAX_ARTIFACT_FILES:
+            raise ControlUiAssetError(
+                "artifact_file_limit",
+                "The Control UI asset directory contains too many files.",
+            )
+    return files
+
+
+def _entry_references(index: bytes) -> tuple[str, ...]:
+    try:
+        html = index.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ControlUiAssetError(
+            "index_encoding_invalid",
+            "The Control UI index is not valid UTF-8.",
+        ) from error
+
+    references: list[str] = []
+    for raw in re.findall(r'\b(?:src|href)="([^"]+)"', html):
+        if raw.startswith(("data:", "#")):
+            continue
+        if raw.startswith(("http://", "https://", "//")):
+            raise ControlUiAssetError(
+                "index_remote_asset",
+                "The Control UI index references a network asset.",
+            )
+        relative = raw.split("?", 1)[0].split("#", 1)[0]
+        marker = "/static/dist/"
+        if relative.startswith("/") and marker in relative:
+            relative = relative.split(marker, 1)[1]
+        else:
+            relative = relative.removeprefix("./")
+        if not relative:
+            continue
+        references.append(_safe_manifest_path(relative))
+    return tuple(references)
+
+
+def _parse_manifest(raw: object) -> ControlUiArtifactManifest:
+    if (
+        not isinstance(raw, dict)
+        or raw.get("schemaVersion") != 1
+        or not isinstance(raw.get("sourceFingerprint"), str)
+        or not isinstance(raw.get("files"), list)
+    ):
+        raise ControlUiAssetError(
+            "manifest_schema_unsupported",
+            "The Control UI manifest uses an unsupported schema.",
+        )
+
+    entries = raw["files"]
+    if len(entries) > _MAX_ARTIFACT_FILES:
+        raise ControlUiAssetError(
+            "manifest_file_limit",
+            "The Control UI manifest declares too many files.",
+        )
+
+    files: list[ControlUiArtifactFile] = []
+    seen: set[str] = set()
+    total_size = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ControlUiAssetError(
+                "manifest_record_invalid",
+                "The Control UI manifest contains an invalid file record.",
+            )
+        path = _safe_manifest_path(entry.get("path"))
+        size = entry.get("size")
+        digest = entry.get("sha256")
+        if (
+            path in seen
+            or not isinstance(size, int)
+            or isinstance(size, bool)
+            or size < 0
+            or size > _MAX_ARTIFACT_FILE_BYTES
+            or not isinstance(digest, str)
+            or _SHA256_RE.fullmatch(digest) is None
+        ):
+            raise ControlUiAssetError(
+                "manifest_record_invalid",
+                "The Control UI manifest contains an invalid file record.",
+            )
+        if _forbidden_artifact_path(path):
+            raise ControlUiAssetError(
+                "manifest_sensitive_file",
+                "The Control UI manifest declares forbidden metadata or key material.",
+            )
+        seen.add(path)
+        total_size += size
+        if total_size > _MAX_ARTIFACT_BYTES:
+            raise ControlUiAssetError(
+                "manifest_size_limit",
+                "The Control UI manifest declares an oversized asset bundle.",
+            )
+        files.append(
+            ControlUiArtifactFile(
+                path=path,
+                size=size,
+                sha256=digest.lower(),
+            )
+        )
+
+    client_version = raw.get("clientVersion")
+    if client_version is not None and not isinstance(client_version, str):
+        raise ControlUiAssetError(
+            "manifest_client_version_invalid",
+            "The Control UI manifest client version is invalid.",
+        )
+    contract_digest = raw.get("contractDigest")
+    if contract_digest is not None and (
+        not isinstance(contract_digest, str)
+        or re.fullmatch(r"sha256:[0-9a-fA-F]{64}", contract_digest) is None
+    ):
+        raise ControlUiAssetError(
+            "manifest_contract_digest_invalid",
+            "The Control UI manifest contract digest is invalid.",
+        )
+
+    return ControlUiArtifactManifest(
+        schema_version=1,
+        source_fingerprint=raw["sourceFingerprint"],
+        files=tuple(files),
+        client_version=client_version,
+        contract_digest=contract_digest.lower() if contract_digest else None,
+    )
+
+
+def validate_control_ui_artifact(
+    dist_root: Path,
+    *,
+    manifest_required: bool,
+) -> ControlUiArtifactManifest | None:
+    """Validate a bundle tree and return its manifest when one is present."""
+
+    dist_io = native_io_path(dist_root)
+    if _is_link(dist_io) or not dist_io.is_dir():
+        raise ControlUiAssetError(
+            "asset_directory_missing",
+            "The configured Control UI asset directory is unavailable.",
+        )
+
+    manifest_path = dist_io / CONTROL_UI_MANIFEST_NAME
+    if not manifest_path.is_file():
+        if manifest_required:
+            raise ControlUiAssetError(
+                "manifest_missing",
+                "The external Control UI manifest is missing.",
+            )
+        embedded_index_path = dist_io / "index.html"
+        if (
+            not embedded_index_path.is_file()
+            or embedded_index_path.stat().st_size == 0
+        ):
+            raise ControlUiAssetError(
+                "index_missing",
+                "The Control UI entrypoint is missing.",
+            )
+        return None
+
+    if _is_link(manifest_path) or manifest_path.stat().st_size > _MAX_MANIFEST_BYTES:
+        raise ControlUiAssetError(
+            "manifest_invalid",
+            "The Control UI manifest is not a safe regular file.",
+        )
+    try:
+        manifest_raw = json.loads(manifest_path.read_bytes())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ControlUiAssetError(
+            "manifest_invalid",
+            "The Control UI manifest is not valid JSON.",
+        ) from error
+    manifest = _parse_manifest(manifest_raw)
+
+    actual = _directory_files(dist_root)
+    actual.pop(CONTROL_UI_MANIFEST_NAME, None)
+    declared = {entry.path: entry for entry in manifest.files}
+    if set(actual) != set(declared):
+        raise ControlUiAssetError(
+            "manifest_inventory_mismatch",
+            "The Control UI files do not match the manifest inventory.",
+        )
+
+    for relative, entry in declared.items():
+        path = actual[relative]
+        file_stat = path.stat()
+        if file_stat.st_size != entry.size or _file_sha256(path) != entry.sha256:
+            raise ControlUiAssetError(
+                "manifest_digest_mismatch",
+                "A Control UI file does not match its manifest digest.",
+            )
+        if os.name != "nt" and file_stat.st_mode & stat.S_IWOTH:
+            raise ControlUiAssetError(
+                "artifact_world_writable",
+                "A Control UI file is writable by other users.",
+            )
+
+    validated_index_path = actual.get("index.html")
+    if (
+        validated_index_path is None
+        or declared["index.html"].size == 0
+        or declared["index.html"].size > _MAX_INDEX_BYTES
+    ):
+        raise ControlUiAssetError(
+            "index_missing",
+            "The Control UI entrypoint is missing.",
+        )
+    references = _entry_references(validated_index_path.read_bytes())
+    entry_scripts = tuple(
+        path for path in references if path.lower().endswith((".js", ".mjs"))
+    )
+    entry_styles = tuple(path for path in references if path.lower().endswith(".css"))
+    if not entry_scripts:
+        raise ControlUiAssetError(
+            "index_script_missing",
+            "The Control UI entrypoint has no JavaScript module.",
+        )
+    if not entry_styles:
+        raise ControlUiAssetError(
+            "index_stylesheet_missing",
+            "The Control UI entrypoint has no stylesheet.",
+        )
+    missing = sorted(set(references) - set(declared))
+    if missing:
+        raise ControlUiAssetError(
+            "index_reference_missing",
+            "The Control UI entrypoint references files outside its manifest.",
+        )
+    return replace(
+        manifest,
+        entry_scripts=entry_scripts,
+        entry_styles=entry_styles,
+    )
+
+
+class ControlUiAssetResolver:
+    """Resolve embedded, external, or intentionally absent Control UI assets."""
+
+    def __init__(
+        self,
+        config: GatewayConfig,
+        *,
+        embedded_static_root: Path,
+        embedded_dist_root: Path,
+        template_root: Path,
+    ) -> None:
+        self._config = config
+        self._embedded_static_root = embedded_static_root
+        self._embedded_dist_root = embedded_dist_root
+        self._template_root = template_root
+
+    def _static_root(self) -> Path | None:
+        root = self._embedded_static_root
+        return root if native_io_path(root).is_dir() else None
+
+    def _none(self, reason: str) -> ControlUiAssets:
+        return ControlUiAssets(
+            mode="none",
+            static_root=self._static_root(),
+            dist_root=None,
+            template_root=self._template_root,
+            manifest=None,
+            reason=reason,
+        )
+
+    def _embedded(self) -> ControlUiAssets:
+        manifest = validate_control_ui_artifact(
+            self._embedded_dist_root,
+            manifest_required=False,
+        )
+        return ControlUiAssets(
+            mode="embedded",
+            static_root=self._static_root(),
+            dist_root=self._embedded_dist_root,
+            template_root=self._template_root,
+            manifest=manifest,
+        )
+
+    def _external_path(self) -> Path:
+        raw = self._config.control_ui.assets_path.strip()
+        if not raw:
+            raise ControlUiAssetError(
+                "external_path_missing",
+                "External Control UI mode requires an asset directory.",
+            )
+        if raw.startswith(("\\\\", "//")):
+            raise ControlUiAssetError(
+                "external_network_path",
+                "External Control UI assets must come from a local directory.",
+            )
+
+        candidate = Path(raw).expanduser()
+        if not candidate.is_absolute():
+            config_path = str(self._config.config_path or "").strip()
+            base = Path(config_path).expanduser().parent if config_path else Path.cwd()
+            candidate = base / candidate
+        candidate = Path(os.path.abspath(os.fspath(candidate)))
+        if _is_link(native_io_path(candidate)):
+            raise ControlUiAssetError(
+                "external_root_link",
+                "The external Control UI root cannot be a symbolic link or junction.",
+            )
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError as error:
+            raise ControlUiAssetError(
+                "external_path_missing",
+                "The external Control UI asset directory is unavailable.",
+            ) from error
+        if not native_io_path(resolved).is_dir():
+            raise ControlUiAssetError(
+                "external_path_missing",
+                "The external Control UI asset path is not a directory.",
+            )
+
+        if (native_io_path(resolved) / "index.html").is_file():
+            dist_root = resolved
+        elif (native_io_path(resolved) / "dist" / "index.html").is_file():
+            dist_root = resolved / "dist"
+        else:
+            raise ControlUiAssetError(
+                "external_index_missing",
+                "The external Control UI entrypoint is missing.",
+            )
+        if _is_link(native_io_path(dist_root)):
+            raise ControlUiAssetError(
+                "external_dist_link",
+                "The external Control UI bundle cannot be a symbolic link or junction.",
+            )
+        return dist_root.resolve(strict=True)
+
+    def _reject_runtime_data_root(self, dist_root: Path) -> None:
+        roots: list[Path] = [default_opensquilla_home()]
+        for raw in (self._config.state_dir, self._config.workspace_dir):
+            if isinstance(raw, str) and raw.strip():
+                roots.append(Path(raw).expanduser())
+        for root in roots:
+            try:
+                resolved_root = root.resolve(strict=False)
+            except OSError:
+                continue
+            if dist_root == resolved_root or _is_within(dist_root, resolved_root):
+                raise ControlUiAssetError(
+                    "external_runtime_data_root",
+                    "External Control UI assets cannot be served from runtime data directories.",
+                )
+
+    def _external(self) -> ControlUiAssets:
+        dist_root = self._external_path()
+        self._reject_runtime_data_root(dist_root)
+        if os.name != "nt" and dist_root.stat().st_mode & stat.S_IWOTH:
+            raise ControlUiAssetError(
+                "external_world_writable",
+                "The external Control UI directory is writable by other users.",
+            )
+        manifest = validate_control_ui_artifact(dist_root, manifest_required=True)
+        assert manifest is not None
+        return ControlUiAssets(
+            mode="external",
+            static_root=self._static_root(),
+            dist_root=dist_root,
+            template_root=self._template_root,
+            manifest=manifest,
+        )
+
+    def resolve(self) -> ControlUiAssets:
+        if not self._config.control_ui.enabled:
+            return self._none("disabled")
+
+        requested: ControlUiAssetsRequestMode = self._config.control_ui.assets_mode
+        if requested == "none":
+            return self._none("explicit_none")
+
+        try:
+            if requested == "external":
+                return self._external()
+            return self._embedded()
+        except ControlUiAssetError as error:
+            prefix = "external" if requested == "external" else "embedded"
+            return self._none(f"{prefix}:{error.code}")
+        except OSError:
+            prefix = "external" if requested == "external" else "embedded"
+            return self._none(f"{prefix}:asset_io_error")
+
+
+__all__ = [
+    "CONTROL_UI_MANIFEST_NAME",
+    "ControlUiArtifactFile",
+    "ControlUiArtifactManifest",
+    "ControlUiAssetError",
+    "ControlUiAssetResolver",
+    "ControlUiAssets",
+    "ControlUiAssetsMode",
+    "ControlUiAssetsRequestMode",
+    "validate_control_ui_artifact",
+]

--- a/src/opensquilla/gateway/control_ui_assets.py
+++ b/src/opensquilla/gateway/control_ui_assets.py
@@ -8,6 +8,7 @@ import os
 import re
 import stat
 from dataclasses import dataclass, replace
+from html.parser import HTMLParser
 from pathlib import Path, PurePosixPath
 from typing import Literal
 
@@ -186,7 +187,68 @@ def _directory_files(root: Path) -> dict[str, Path]:
     return files
 
 
-def _entry_references(index: bytes) -> tuple[str, ...]:
+class _IndexReferenceParser(HTMLParser):
+    """Collect URL-bearing tags while preserving their entrypoint roles."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.references: list[str] = []
+        self.entry_scripts: list[str] = []
+        self.entry_styles: list[str] = []
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        attributes = {
+            name.lower(): value
+            for name, value in attrs
+            if value is not None
+        }
+        src = attributes.get("src")
+        href = attributes.get("href")
+        if src is not None:
+            self.references.append(src)
+        if href is not None:
+            self.references.append(href)
+
+        if (
+            tag.lower() == "script"
+            and attributes.get("type", "").strip().lower() == "module"
+            and src is not None
+        ):
+            self.entry_scripts.append(src)
+        if (
+            tag.lower() == "link"
+            and "stylesheet" in attributes.get("rel", "").lower().split()
+            and href is not None
+        ):
+            self.entry_styles.append(href)
+
+
+def _normalize_index_reference(raw: str) -> str | None:
+    if raw.startswith(("data:", "#")):
+        return None
+    if raw.lower().startswith(("http://", "https://", "//")):
+        raise ControlUiAssetError(
+            "index_remote_asset",
+            "The Control UI index references a network asset.",
+        )
+    relative = raw.split("?", 1)[0].split("#", 1)[0]
+    marker = "/static/dist/"
+    if relative.startswith("/") and marker in relative:
+        relative = relative.split(marker, 1)[1]
+    else:
+        relative = relative.removeprefix("./")
+    if not relative:
+        return None
+    return _safe_manifest_path(relative)
+
+
+def _index_references(
+    index: bytes,
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
     try:
         html = index.decode("utf-8")
     except UnicodeDecodeError as error:
@@ -195,25 +257,21 @@ def _entry_references(index: bytes) -> tuple[str, ...]:
             "The Control UI index is not valid UTF-8.",
         ) from error
 
-    references: list[str] = []
-    for raw in re.findall(r'\b(?:src|href)="([^"]+)"', html):
-        if raw.startswith(("data:", "#")):
-            continue
-        if raw.startswith(("http://", "https://", "//")):
-            raise ControlUiAssetError(
-                "index_remote_asset",
-                "The Control UI index references a network asset.",
-            )
-        relative = raw.split("?", 1)[0].split("#", 1)[0]
-        marker = "/static/dist/"
-        if relative.startswith("/") and marker in relative:
-            relative = relative.split(marker, 1)[1]
-        else:
-            relative = relative.removeprefix("./")
-        if not relative:
-            continue
-        references.append(_safe_manifest_path(relative))
-    return tuple(references)
+    parser = _IndexReferenceParser()
+    parser.feed(html)
+
+    def normalized(values: list[str]) -> tuple[str, ...]:
+        return tuple(
+            reference
+            for raw in values
+            if (reference := _normalize_index_reference(raw)) is not None
+        )
+
+    return (
+        normalized(parser.references),
+        normalized(parser.entry_scripts),
+        normalized(parser.entry_styles),
+    )
 
 
 def _parse_manifest(raw: object) -> ControlUiArtifactManifest:
@@ -384,11 +442,9 @@ def validate_control_ui_artifact(
             "index_missing",
             "The Control UI entrypoint is missing.",
         )
-    references = _entry_references(validated_index_path.read_bytes())
-    entry_scripts = tuple(
-        path for path in references if path.lower().endswith((".js", ".mjs"))
+    references, entry_scripts, entry_styles = _index_references(
+        validated_index_path.read_bytes()
     )
-    entry_styles = tuple(path for path in references if path.lower().endswith(".css"))
     if not entry_scripts:
         raise ControlUiAssetError(
             "index_script_missing",
@@ -481,7 +537,7 @@ class ControlUiAssetResolver:
             )
         try:
             resolved = candidate.resolve(strict=True)
-        except OSError as error:
+        except (OSError, RuntimeError) as error:
             raise ControlUiAssetError(
                 "external_path_missing",
                 "The external Control UI asset directory is unavailable.",
@@ -506,7 +562,13 @@ class ControlUiAssetResolver:
                 "external_dist_link",
                 "The external Control UI bundle cannot be a symbolic link or junction.",
             )
-        return dist_root.resolve(strict=True)
+        try:
+            return dist_root.resolve(strict=True)
+        except (OSError, RuntimeError) as error:
+            raise ControlUiAssetError(
+                "external_path_missing",
+                "The external Control UI asset directory is unavailable.",
+            ) from error
 
     def _reject_runtime_data_root(self, dist_root: Path) -> None:
         roots: list[Path] = [default_opensquilla_home()]
@@ -516,7 +578,7 @@ class ControlUiAssetResolver:
         for root in roots:
             try:
                 resolved_root = root.resolve(strict=False)
-            except OSError:
+            except (OSError, RuntimeError):
                 continue
             if dist_root == resolved_root or _is_within(dist_root, resolved_root):
                 raise ControlUiAssetError(

--- a/src/opensquilla/gateway/templates/index.html
+++ b/src/opensquilla/gateway/templates/index.html
@@ -70,10 +70,20 @@
     </noscript>
     {% if webui_artifact_missing %}
     <main role="alert" data-webui-artifact-missing
+          data-control-ui-assets-mode="{{ control_ui_assets_mode }}"
+          data-control-ui-assets-reason="{{ control_ui_assets_reason }}"
           style="padding:2rem;font-family:system-ui,-apple-system,sans-serif;color:#222;background:#fff;max-width:720px;margin:3rem auto;border:1px solid #d8d8d8;border-radius:8px;line-height:1.5">
+        {% if control_ui_assets_reason == "explicit_none" %}
+        <h1 style="font-size:1.25rem;margin:0 0 .75rem">Gateway is running without a Control UI</h1>
+        <p style="margin-bottom:0">Use a compatible client, the CLI, or the Gateway RPC interfaces. Core health and readiness are independent of product UI assets.</p>
+        {% elif control_ui_assets_reason.startswith("external:") %}
+        <h1 style="font-size:1.25rem;margin:0 0 .75rem">Configured Control UI assets were rejected</h1>
+        <p style="margin-bottom:0">The Gateway core remains available. Verify the external asset directory and its manifest before trying again.</p>
+        {% else %}
         <h1 style="font-size:1.25rem;margin:0 0 .75rem">Control UI assets are unavailable</h1>
         <p>This installation does not contain a usable Vue build. Release-wheel and Desktop users should reinstall an official package.</p>
         <p style="margin-bottom:0">When running from a source checkout, build it with <code>cd opensquilla-webui &amp;&amp; npm ci &amp;&amp; npm run build</code>, then reload this page.</p>
+        {% endif %}
     </main>
     {% else %}
     <div id="app"></div>

--- a/tests/test_gateway/test_control_ui_asset_provider.py
+++ b/tests/test_gateway/test_control_ui_asset_provider.py
@@ -1,0 +1,282 @@
+"""Control UI asset-mode resolution and Core/headless behavior."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from opensquilla.gateway import control_ui
+from opensquilla.gateway.app import create_gateway_app
+from opensquilla.gateway.config import ControlUiConfig, GatewayConfig
+from opensquilla.gateway.control_ui import create_control_ui_routes
+from opensquilla.gateway.control_ui_assets import (
+    ControlUiAssetResolver,
+    ControlUiAssets,
+)
+from opensquilla.onboarding.config_store import persist_config
+
+
+def _embedded_tree(root: Path) -> tuple[Path, Path]:
+    static_root = root / "static"
+    dist_root = static_root / "dist"
+    assets = dist_root / "assets"
+    assets.mkdir(parents=True)
+    (dist_root / "index.html").write_text(
+        '<script type="module" src="./assets/app.js"></script>'
+        '<link rel="stylesheet" href="./assets/app.css">',
+        encoding="utf-8",
+    )
+    (assets / "app.js").write_text("export {};\n", encoding="utf-8")
+    (assets / "app.css").write_text("body{}\n", encoding="utf-8")
+    return static_root, dist_root
+
+
+def _resolve(
+    config: GatewayConfig,
+    *,
+    static_root: Path,
+    dist_root: Path,
+    template_root: Path | None = None,
+) -> ControlUiAssets:
+    return ControlUiAssetResolver(
+        config,
+        embedded_static_root=static_root,
+        embedded_dist_root=dist_root,
+        template_root=template_root or control_ui._TEMPLATE_DIR,
+    ).resolve()
+
+
+def test_auto_uses_existing_embedded_bundle_without_requiring_new_manifest(
+    tmp_path: Path,
+) -> None:
+    static_root, dist_root = _embedded_tree(tmp_path)
+
+    assets = _resolve(
+        GatewayConfig(),
+        static_root=static_root,
+        dist_root=dist_root,
+    )
+
+    assert assets.mode == "embedded"
+    assert assets.static_root == static_root
+    assert assets.dist_root == dist_root
+    assert assets.manifest is None
+    assert assets.reason is None
+
+
+@pytest.mark.parametrize("mode", ["auto", "embedded"])
+def test_missing_embedded_bundle_degrades_to_none(
+    tmp_path: Path,
+    mode: str,
+) -> None:
+    static_root = tmp_path / "static"
+    static_root.mkdir()
+
+    assets = _resolve(
+        GatewayConfig(control_ui={"assets_mode": mode}),
+        static_root=static_root,
+        dist_root=static_root / "dist",
+    )
+
+    assert assets.mode == "none"
+    assert assets.dist_root is None
+    assert assets.reason == "embedded:asset_directory_missing"
+
+
+def test_explicit_none_does_not_probe_configured_asset_path(tmp_path: Path) -> None:
+    assets = _resolve(
+        GatewayConfig(
+            control_ui={
+                "assets_mode": "none",
+                "assets_path": str(tmp_path / "does-not-exist"),
+            }
+        ),
+        static_root=tmp_path / "static",
+        dist_root=tmp_path / "static" / "dist",
+    )
+
+    assert assets.mode == "none"
+    assert assets.reason == "explicit_none"
+
+
+def test_explicit_none_does_not_expose_an_existing_embedded_dist(tmp_path: Path) -> None:
+    static_root, dist_root = _embedded_tree(tmp_path)
+    config = GatewayConfig(control_ui={"assets_mode": "none"})
+    assets = _resolve(
+        config,
+        static_root=static_root,
+        dist_root=dist_root,
+    )
+    client = TestClient(Starlette(routes=create_control_ui_routes(config, assets)))
+
+    response = client.get("/control/static/dist/assets/app.js")
+
+    assert response.status_code == 404
+
+
+def test_disabled_control_ui_registers_no_routes(tmp_path: Path) -> None:
+    config = GatewayConfig(control_ui={"enabled": False, "assets_mode": "none"})
+    assets = _resolve(
+        config,
+        static_root=tmp_path / "static",
+        dist_root=tmp_path / "static" / "dist",
+    )
+
+    assert assets.reason == "disabled"
+    assert create_control_ui_routes(config, assets) == []
+
+
+def test_none_mode_keeps_core_health_and_readiness_available(tmp_path: Path) -> None:
+    config = GatewayConfig(control_ui={"assets_mode": "none"})
+    assets = _resolve(
+        config,
+        static_root=tmp_path / "static",
+        dist_root=tmp_path / "static" / "dist",
+    )
+    app = create_gateway_app(config, control_ui_assets=assets)
+    app.state.gateway_ready = True
+    client = TestClient(app)
+
+    assert client.get("/health").json() == {"ok": True, "status": "live"}
+    ready = client.get("/ready")
+    assert ready.status_code == 200
+    assert ready.json()["ready"] is True
+
+    response = client.get("/control/")
+    assert response.status_code == 200
+    assert "Gateway is running without a Control UI" in response.text
+    assert "npm ci" not in response.text
+    assert 'data-control-ui-assets-mode="none"' in response.text
+
+
+def test_auto_missing_bundle_keeps_source_checkout_recovery_guidance(
+    tmp_path: Path,
+) -> None:
+    config = GatewayConfig(control_ui={"assets_mode": "auto"})
+    assets = _resolve(
+        config,
+        static_root=tmp_path / "static",
+        dist_root=tmp_path / "static" / "dist",
+    )
+    app = Starlette(routes=create_control_ui_routes(config, assets))
+
+    response = TestClient(app).get("/control/")
+
+    assert response.status_code == 200
+    assert "Control UI assets are unavailable" in response.text
+    assert "npm ci &amp;&amp; npm run build" in response.text
+
+
+def test_missing_neutral_template_falls_back_without_breaking_route(
+    tmp_path: Path,
+) -> None:
+    config = GatewayConfig(control_ui={"assets_mode": "none"})
+    assets = ControlUiAssets(
+        mode="none",
+        static_root=None,
+        dist_root=None,
+        template_root=tmp_path / "missing-templates",
+        manifest=None,
+        reason="explicit_none",
+    )
+    app = Starlette(routes=create_control_ui_routes(config, assets))
+
+    response = TestClient(app).get("/control/")
+
+    assert response.status_code == 200
+    assert "Gateway is running without a Control UI" in response.text
+
+
+@pytest.mark.parametrize("value", ["AUTO", " Embedded ", "external", "none"])
+def test_assets_mode_normalizes_supported_values(value: str) -> None:
+    assert ControlUiConfig(assets_mode=value).assets_mode == value.strip().lower()
+
+
+def test_assets_mode_rejects_unknown_value() -> None:
+    with pytest.raises(ValidationError):
+        ControlUiConfig(assets_mode="discover")
+
+
+def test_control_ui_assets_read_direct_environment_spelling(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_CONTROL_UI_ASSETS_MODE", "external")
+    monkeypatch.setenv("OPENSQUILLA_CONTROL_UI_ASSETS_PATH", f"  {tmp_path}  ")
+
+    config = GatewayConfig()
+
+    assert config.control_ui.assets_mode == "external"
+    assert config.control_ui.assets_path == str(tmp_path)
+
+
+def test_control_ui_assets_read_gateway_nested_environment_spelling(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONTROL_UI__ASSETS_MODE", "external")
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONTROL_UI__ASSETS_PATH", str(tmp_path))
+
+    config = GatewayConfig()
+
+    assert config.control_ui.assets_mode == "external"
+    assert config.control_ui.assets_path == str(tmp_path)
+
+
+def test_new_asset_fields_coexist_with_legacy_frontend_toml(tmp_path: Path) -> None:
+    config_path = tmp_path / "opensquilla.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "[control_ui]",
+                'frontend = "legacy"',
+                'assets_mode = "none"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.warns(DeprecationWarning, match="Vue is always served"):
+        config = GatewayConfig.load_from_toml(config_path)
+
+    assert config.control_ui.frontend == "vue"
+    assert config.control_ui.assets_mode == "none"
+
+
+def test_asset_environment_override_wins_over_toml_without_being_persisted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "opensquilla.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "[control_ui]",
+                'assets_mode = "auto"',
+                'assets_path = "stored-ui"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    env_path = tmp_path / "runtime-only-ui"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONTROL_UI__ASSETS_MODE", "external")
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONTROL_UI__ASSETS_PATH", str(env_path))
+
+    config = GatewayConfig.load(config_path)
+
+    assert config.control_ui.assets_mode == "external"
+    assert config.control_ui.assets_path == str(env_path)
+
+    persist_config(config, path=config_path, backup=False)
+    with open(config_path, "rb") as handle:
+        persisted = tomllib.load(handle)
+
+    assert persisted["control_ui"]["assets_mode"] == "auto"
+    assert persisted["control_ui"]["assets_path"] == "stored-ui"

--- a/tests/test_gateway/test_control_ui_external_assets.py
+++ b/tests/test_gateway/test_control_ui_external_assets.py
@@ -1,0 +1,421 @@
+"""Manifest, path, and serving security for external Control UI assets."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from opensquilla.gateway import control_ui
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.control_ui import create_control_ui_routes
+from opensquilla.gateway.control_ui_assets import (
+    CONTROL_UI_MANIFEST_NAME,
+    ControlUiAssetResolver,
+    ControlUiAssets,
+)
+
+
+def _record(root: Path, relative: str) -> dict[str, object]:
+    content = (root / relative).read_bytes()
+    return {
+        "path": relative,
+        "size": len(content),
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }
+
+
+def _rewrite_manifest(
+    root: Path,
+    *,
+    client_version: str | None = "0.2.1",
+    contract_digest: str | None = "sha256:" + "1" * 64,
+) -> None:
+    relatives = sorted(
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_file() and path.name != CONTROL_UI_MANIFEST_NAME
+    )
+    manifest: dict[str, object] = {
+        "schemaVersion": 1,
+        "sourceFingerprint": "synthetic-external-ui",
+        "files": [_record(root, relative) for relative in relatives],
+    }
+    if client_version is not None:
+        manifest["clientVersion"] = client_version
+    if contract_digest is not None:
+        manifest["contractDigest"] = contract_digest
+    (root / CONTROL_UI_MANIFEST_NAME).write_text(
+        f"{json.dumps(manifest, indent=2)}\n",
+        encoding="utf-8",
+    )
+
+
+def _artifact(root: Path) -> Path:
+    assets = root / "assets"
+    assets.mkdir(parents=True)
+    (root / "index.html").write_text(
+        '<script type="module" src="./assets/app.js"></script>'
+        '<link rel="stylesheet" href="./assets/app.css">'
+        '<link rel="icon" href="./opensquilla-mark.png">',
+        encoding="utf-8",
+    )
+    (assets / "app.js").write_text("export const external = true;\n", encoding="utf-8")
+    (assets / "app.css").write_text("body{color:#123}\n", encoding="utf-8")
+    (root / "opensquilla-mark.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+    _rewrite_manifest(root)
+    return root
+
+
+def _resolve(config: GatewayConfig, tmp_path: Path) -> ControlUiAssets:
+    embedded_static = tmp_path / "embedded-static"
+    embedded_static.mkdir(exist_ok=True)
+    return ControlUiAssetResolver(
+        config,
+        embedded_static_root=embedded_static,
+        embedded_dist_root=embedded_static / "dist",
+        template_root=control_ui._TEMPLATE_DIR,
+    ).resolve()
+
+
+def test_external_bundle_with_spaces_and_unicode_is_served_from_existing_routes(
+    tmp_path: Path,
+) -> None:
+    dist = _artifact(tmp_path / "客户端 UI bundle")
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(dist),
+        }
+    )
+    resolved = _resolve(config, tmp_path)
+
+    assert resolved.mode == "external"
+    assert resolved.dist_root == dist.resolve()
+    assert resolved.manifest is not None
+    assert resolved.manifest.client_version == "0.2.1"
+    assert resolved.manifest.entry_scripts == ("assets/app.js",)
+    assert resolved.manifest.entry_styles == ("assets/app.css",)
+
+    app = Starlette(routes=create_control_ui_routes(config, resolved))
+    client = TestClient(app)
+    index = client.get("/control/")
+    script = client.get("/control/static/dist/assets/app.js")
+    raw_index = client.get("/control/static/dist/index.html")
+
+    assert index.status_code == 200
+    assert "/control/static/dist/assets/app.js" in index.text
+    assert script.status_code == 200
+    assert script.text == "export const external = true;\n"
+    assert script.headers["content-type"].startswith("text/javascript")
+    assert "max-age=2592000" in script.headers["cache-control"]
+    assert raw_index.status_code == 404
+
+
+def test_external_path_may_point_to_static_parent_containing_dist(tmp_path: Path) -> None:
+    static_root = tmp_path / "client-static"
+    dist = _artifact(static_root / "dist")
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(static_root),
+        }
+    )
+
+    resolved = _resolve(config, tmp_path)
+
+    assert resolved.mode == "external"
+    assert resolved.dist_root == dist.resolve()
+
+
+def test_relative_external_path_resolves_from_config_directory(tmp_path: Path) -> None:
+    profile = tmp_path / "operator-config"
+    profile.mkdir()
+    dist = _artifact(profile / "ui bundle")
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": "ui bundle",
+        }
+    )
+    config.config_path = str(profile / "opensquilla.toml")
+
+    resolved = _resolve(config, tmp_path)
+
+    assert resolved.mode == "external"
+    assert resolved.dist_root == dist.resolve()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "reason"),
+    [
+        ("digest", "external:manifest_digest_mismatch"),
+        ("extra", "external:manifest_inventory_mismatch"),
+        ("remote", "external:index_remote_asset"),
+        ("bad-contract", "external:manifest_contract_digest_invalid"),
+    ],
+)
+def test_external_manifest_or_inventory_failure_rejects_entire_bundle(
+    tmp_path: Path,
+    mutation: str,
+    reason: str,
+) -> None:
+    dist = _artifact(tmp_path / mutation)
+    if mutation == "digest":
+        (dist / "assets/app.js").write_text("tampered\n", encoding="utf-8")
+    elif mutation == "extra":
+        (dist / "assets/unlisted.js").write_text("unlisted\n", encoding="utf-8")
+    elif mutation == "remote":
+        (dist / "index.html").write_text(
+            '<script type="module" src="https://example.invalid/app.js"></script>',
+            encoding="utf-8",
+        )
+        _rewrite_manifest(dist)
+    else:
+        _rewrite_manifest(dist, contract_digest="sha256:not-a-digest")
+
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(dist),
+        }
+    )
+
+    resolved = _resolve(config, tmp_path)
+
+    assert resolved.mode == "none"
+    assert resolved.dist_root is None
+    assert resolved.reason == reason
+
+
+def test_external_manifest_path_escape_is_rejected(tmp_path: Path) -> None:
+    dist = _artifact(tmp_path / "path-escape")
+    manifest_path = dist / CONTROL_UI_MANIFEST_NAME
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["files"][0]["path"] = "../outside.js"
+    manifest_path.write_text(f"{json.dumps(manifest)}\n", encoding="utf-8")
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(dist),
+        }
+    )
+
+    resolved = _resolve(config, tmp_path)
+
+    assert resolved.mode == "none"
+    assert resolved.reason == "external:manifest_path_escape"
+
+
+def test_external_bundle_requires_manifest(tmp_path: Path) -> None:
+    dist = _artifact(tmp_path / "no-manifest")
+    (dist / CONTROL_UI_MANIFEST_NAME).unlink()
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(dist),
+        }
+    )
+
+    resolved = _resolve(config, tmp_path)
+
+    assert resolved.mode == "none"
+    assert resolved.reason == "external:manifest_missing"
+
+
+def test_external_bundle_rejects_symbolic_linked_file(tmp_path: Path) -> None:
+    dist = _artifact(tmp_path / "symlink-file")
+    outside = tmp_path / "outside.js"
+    outside.write_text("outside\n", encoding="utf-8")
+    link = dist / "assets/link.js"
+    try:
+        link.symlink_to(outside)
+    except OSError as error:
+        pytest.skip(f"symlinks unavailable on this platform: {error}")
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(dist),
+        }
+    )
+
+    resolved = _resolve(config, tmp_path)
+
+    assert resolved.mode == "none"
+    assert resolved.reason == "external:artifact_link_forbidden"
+
+
+def test_external_bundle_rejects_symbolic_linked_root(tmp_path: Path) -> None:
+    dist = _artifact(tmp_path / "real-dist")
+    linked = tmp_path / "linked-dist"
+    try:
+        linked.symlink_to(dist, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"directory symlinks unavailable on this platform: {error}")
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(linked),
+        }
+    )
+
+    resolved = _resolve(config, tmp_path)
+
+    assert resolved.mode == "none"
+    assert resolved.reason == "external:external_root_link"
+
+
+def test_external_bundle_cannot_live_under_runtime_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "agent-workspace"
+    dist = _artifact(workspace / "artifacts" / "ui")
+    config = GatewayConfig(
+        workspace_dir=str(workspace),
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(dist),
+        },
+    )
+
+    resolved = _resolve(config, tmp_path)
+
+    assert resolved.mode == "none"
+    assert resolved.reason == "external:external_runtime_data_root"
+
+
+def test_external_bundle_rejects_unc_or_network_share_path(tmp_path: Path) -> None:
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": "//server/share/control-ui",
+        }
+    )
+
+    resolved = _resolve(config, tmp_path)
+
+    assert resolved.mode == "none"
+    assert resolved.reason == "external:external_network_path"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX world-writable mode bits")
+def test_external_bundle_rejects_world_writable_root(tmp_path: Path) -> None:
+    dist = _artifact(tmp_path / "world-writable")
+    original_mode = stat_mode = dist.stat().st_mode
+    dist.chmod(stat_mode | 0o002)
+    try:
+        config = GatewayConfig(
+            control_ui={
+                "assets_mode": "external",
+                "assets_path": str(dist),
+            }
+        )
+        resolved = _resolve(config, tmp_path)
+    finally:
+        dist.chmod(original_mode)
+
+    assert resolved.mode == "none"
+    assert resolved.reason == "external:external_world_writable"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX world-writable mode bits")
+def test_external_bundle_rejects_world_writable_subdirectory(tmp_path: Path) -> None:
+    dist = _artifact(tmp_path / "world-writable-child")
+    child = dist / "assets"
+    original_mode = child.stat().st_mode
+    child.chmod(original_mode | 0o002)
+    try:
+        config = GatewayConfig(
+            control_ui={
+                "assets_mode": "external",
+                "assets_path": str(dist),
+            }
+        )
+        resolved = _resolve(config, tmp_path)
+    finally:
+        child.chmod(original_mode)
+
+    assert resolved.mode == "none"
+    assert resolved.reason == "external:artifact_world_writable"
+
+
+def test_manifest_allowlist_rejects_file_added_after_resolution(tmp_path: Path) -> None:
+    dist = _artifact(tmp_path / "post-resolution")
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(dist),
+        }
+    )
+    resolved = _resolve(config, tmp_path)
+    assert resolved.mode == "external"
+    (dist / "assets/late.js").write_text("late\n", encoding="utf-8")
+    client = TestClient(Starlette(routes=create_control_ui_routes(config, resolved)))
+
+    response = client.get("/control/static/dist/assets/late.js")
+
+    assert response.status_code == 404
+
+
+def test_manifest_digest_is_rechecked_after_resolution(tmp_path: Path) -> None:
+    dist = _artifact(tmp_path / "post-resolution-tamper")
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(dist),
+        }
+    )
+    resolved = _resolve(config, tmp_path)
+    assert resolved.mode == "external"
+    client = TestClient(Starlette(routes=create_control_ui_routes(config, resolved)))
+    (dist / "assets/app.js").write_text("tampered after validation\n", encoding="utf-8")
+
+    response = client.get("/control/static/dist/assets/app.js")
+
+    assert response.status_code == 404
+
+
+def test_external_entry_urls_are_frozen_from_validated_index(tmp_path: Path) -> None:
+    dist = _artifact(tmp_path / "post-resolution-index-tamper")
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(dist),
+        }
+    )
+    resolved = _resolve(config, tmp_path)
+    assert resolved.mode == "external"
+    (dist / "index.html").write_text(
+        '<script type="module" src="https://example.invalid/evil.js"></script>',
+        encoding="utf-8",
+    )
+    client = TestClient(Starlette(routes=create_control_ui_routes(config, resolved)))
+
+    response = client.get("/control/")
+
+    assert response.status_code == 200
+    assert "/control/static/dist/assets/app.js" in response.text
+    assert "example.invalid" not in response.text
+
+
+def test_rejected_external_error_page_does_not_echo_absolute_path(
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "secret operator path" / "missing"
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(missing),
+        }
+    )
+    resolved = _resolve(config, tmp_path)
+    client = TestClient(Starlette(routes=create_control_ui_routes(config, resolved)))
+
+    response = client.get("/control/")
+
+    assert response.status_code == 200
+    assert "Configured Control UI assets were rejected" in response.text
+    assert str(missing) not in response.text

--- a/tests/test_gateway/test_control_ui_external_assets.py
+++ b/tests/test_gateway/test_control_ui_external_assets.py
@@ -65,7 +65,7 @@ def _artifact(root: Path) -> Path:
         '<link rel="icon" href="./opensquilla-mark.png">',
         encoding="utf-8",
     )
-    (assets / "app.js").write_text("export const external = true;\n", encoding="utf-8")
+    (assets / "app.js").write_bytes(b"export const external = true;\n")
     (assets / "app.css").write_text("body{color:#123}\n", encoding="utf-8")
     (root / "opensquilla-mark.png").write_bytes(b"\x89PNG\r\n\x1a\n")
     _rewrite_manifest(root)
@@ -111,7 +111,7 @@ def test_external_bundle_with_spaces_and_unicode_is_served_from_existing_routes(
     assert index.status_code == 200
     assert "/control/static/dist/assets/app.js" in index.text
     assert script.status_code == 200
-    assert script.text == "export const external = true;\n"
+    assert script.content == b"export const external = true;\n"
     assert script.headers["content-type"].startswith("text/javascript")
     assert "max-age=2592000" in script.headers["cache-control"]
     assert raw_index.status_code == 404

--- a/tests/test_gateway/test_control_ui_external_assets.py
+++ b/tests/test_gateway/test_control_ui_external_assets.py
@@ -133,6 +133,31 @@ def test_external_path_may_point_to_static_parent_containing_dist(tmp_path: Path
     assert resolved.dist_root == dist.resolve()
 
 
+def test_external_entry_ignores_modulepreload_before_main_script(tmp_path: Path) -> None:
+    dist = _artifact(tmp_path / "modulepreload-first")
+    (dist / "assets/vendor.js").write_text("export const vendor = true;\n", encoding="utf-8")
+    (dist / "index.html").write_text(
+        '<link rel="modulepreload" href="./assets/vendor.js">'
+        '<link href="./assets/app.css" rel="stylesheet">'
+        '<script crossorigin src="./assets/app.js" type="module"></script>',
+        encoding="utf-8",
+    )
+    _rewrite_manifest(dist)
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(dist),
+        }
+    )
+
+    resolved = _resolve(config, tmp_path)
+
+    assert resolved.mode == "external"
+    assert resolved.manifest is not None
+    assert resolved.manifest.entry_scripts == ("assets/app.js",)
+    assert resolved.manifest.entry_styles == ("assets/app.css",)
+
+
 def test_relative_external_path_resolves_from_config_directory(tmp_path: Path) -> None:
     profile = tmp_path / "operator-config"
     profile.mkdir()
@@ -268,6 +293,27 @@ def test_external_bundle_rejects_symbolic_linked_root(tmp_path: Path) -> None:
 
     assert resolved.mode == "none"
     assert resolved.reason == "external:external_root_link"
+
+
+def test_external_bundle_symlink_loop_does_not_break_gateway_resolution(
+    tmp_path: Path,
+) -> None:
+    loop = tmp_path / "loop"
+    try:
+        loop.symlink_to(loop, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"symlinks unavailable on this platform: {error}")
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(loop / "dist"),
+        }
+    )
+
+    resolved = _resolve(config, tmp_path)
+
+    assert resolved.mode == "none"
+    assert resolved.reason == "external:external_path_missing"
 
 
 def test_external_bundle_cannot_live_under_runtime_workspace(tmp_path: Path) -> None:

--- a/tests/test_gateway/test_control_ui_missing_assets.py
+++ b/tests/test_gateway/test_control_ui_missing_assets.py
@@ -1,0 +1,88 @@
+"""Gateway behavior when product UI assets are absent or rejected."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from starlette.testclient import TestClient
+
+from opensquilla.gateway import control_ui
+from opensquilla.gateway.app import create_gateway_app
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.control_ui_assets import (
+    CONTROL_UI_MANIFEST_NAME,
+    ControlUiAssetResolver,
+)
+
+
+def _resolve(config: GatewayConfig, tmp_path: Path):
+    static_root = tmp_path / "static"
+    static_root.mkdir(exist_ok=True)
+    return ControlUiAssetResolver(
+        config,
+        embedded_static_root=static_root,
+        embedded_dist_root=static_root / "dist",
+        template_root=control_ui._TEMPLATE_DIR,
+    ).resolve()
+
+
+def test_corrupt_embedded_manifest_disables_ui_not_gateway(tmp_path: Path) -> None:
+    static_root = tmp_path / "static"
+    dist = static_root / "dist"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text(
+        '<script type="module" src="./app.js"></script>',
+        encoding="utf-8",
+    )
+    (dist / "app.js").write_text("export {};\n", encoding="utf-8")
+    (dist / CONTROL_UI_MANIFEST_NAME).write_text("{not-json", encoding="utf-8")
+    config = GatewayConfig(control_ui={"assets_mode": "embedded"})
+    assets = ControlUiAssetResolver(
+        config,
+        embedded_static_root=static_root,
+        embedded_dist_root=dist,
+        template_root=control_ui._TEMPLATE_DIR,
+    ).resolve()
+    app = create_gateway_app(config, control_ui_assets=assets)
+    app.state.gateway_ready = True
+    client = TestClient(app)
+
+    assert assets.mode == "none"
+    assert assets.reason == "embedded:manifest_invalid"
+    assert client.get("/health").status_code == 200
+    assert client.get("/ready").status_code == 200
+    response = client.get("/control/")
+    assert response.status_code == 200
+    assert "Control UI assets are unavailable" in response.text
+
+
+def test_rejected_external_bundle_leaves_rpc_route_tree_mounted(tmp_path: Path) -> None:
+    config = GatewayConfig(
+        control_ui={
+            "assets_mode": "external",
+            "assets_path": str(tmp_path / "missing"),
+        }
+    )
+    assets = _resolve(config, tmp_path)
+    app = create_gateway_app(config, control_ui_assets=assets)
+    app.state.gateway_ready = True
+    client = TestClient(app)
+
+    assert assets.mode == "none"
+    assert client.get("/healthz").status_code == 200
+    assert client.get("/ready").json()["ready"] is True
+    assert client.get("/control/").status_code == 200
+    assert client.get("/control/static/dist/unknown.js").status_code == 404
+
+
+def test_disabled_control_ui_does_not_register_control_routes(tmp_path: Path) -> None:
+    config = GatewayConfig(control_ui={"enabled": False})
+    assets = _resolve(config, tmp_path)
+    app = create_gateway_app(config, control_ui_assets=assets)
+    client = TestClient(app)
+
+    response = client.get("/control/", follow_redirects=False)
+
+    assert assets.reason == "disabled"
+    assert response.status_code == 404
+    assert client.get("/health").status_code == 200


### PR DESCRIPTION
## Scope

Scope boundary:
- Add a single Gateway Control UI asset resolver with `auto`, `embedded`, `external`, and `none` modes.
- Keep Gateway Core/RPC startup independent from product UI asset availability.
- Validate external UI artifact manifests, paths, inventory, sizes, hashes, permissions, links, and Vite entrypoint roles before serving them.
- Preserve the existing `/control` and `/control/static` route contract, cache headers, MIME behavior, locale handling, and origin checks.
- Add additive TOML/environment configuration, operator documentation, and regression coverage.

Non-goals:
- No removal of the embedded UI bundle.
- No Vue/Vite build-pipeline or headless-wheel change; that is O-05.
- No authentication or authorization change.
- No cryptographic signature for external UI artifacts in this phase; publisher authenticity remains a known residual risk and is deferred to the formal distribution gate.

## Branch

Base branch: `feature/client-migration`

Target exception: staging/collaboration — this is the approved Phase 1 integration flow; the integration branch will merge to `main` after the phase is complete.

The integration base and this head include the latest `origin/main` through `bf82ff44`.

## Issue

Linked issue: None

If None, reason: planned work item O-04 in the client-migration execution plan.

## Release Note

Release note: REQUIRED — Gateway supports `auto`, `embedded`, `external`, and `none` Control UI asset modes without coupling Core readiness to product UI availability.

## Review Findings Fixed

- A cyclic parent symlink could raise `RuntimeError` from `Path.resolve()` and escape the fail-soft UI resolver; it now degrades to rejected external assets without blocking Gateway startup.
- A valid Vite `modulepreload` placed before the main module could be selected as the executable entry; HTML entry parsing now distinguishes module scripts, stylesheets, and preload-only references.

## Tests

Static and contract checks:
- `uv run ruff check src tests scripts/generate_client_contracts.py` — passed.
- `uv run mypy src/opensquilla --show-error-codes` — passed (879 source files).
- `uv run python scripts/generate_client_contracts.py --check` — passed.
- Client contract/generator/public SDK suite — 132 passed.

Python regression:
- O-04 Control UI/Gateway compatibility plus the latest merged platform-sensitive tests — 175 passed.
- Full Gateway suite — 2337 passed, 10 skipped.
- CI targeted cross-subsystem suite — 1618 passed, 50 skipped.

Frontend and packaging, using the repository-pinned Node 22.12.0:
- Web UI typecheck and architecture gates — passed.
- Web UI unit suite — 227 files / 2330 tests passed.
- Production Vue artifact — verified (195 payload files).
- sdist-to-wheel round trip and byte-for-byte wheel artifact verification — passed (196 files including the manifest).
- Installed real-wheel smoke for `embedded`, `external`, and `none` modes — passed; external JS returned HTTP 200.

Regression tests: added

Notes: The default test path remains offline, deterministic, credential-free, and safe for forks. Platform-specific Windows behavior remains covered by GitHub CI.

## Maintainer Live Check

Maintainer live check: no

Surface: gateway

Maintainer-only note: no credentialed check is required; CI retains platform-specific coverage.

## Safety

- Existing installs remain on `auto`, preserving embedded UI behavior when bundled assets are present.
- Legacy `control_ui.frontend = "legacy"` TOML and environment spellings remain accepted and normalize to Vue.
- Environment-only asset paths are runtime overrides and are not persisted.
- Missing or rejected UI assets degrade only the Control UI; Gateway Core and RPC readiness remain available.
- External bundles reject traversal, extra/missing files, hash or size drift, forbidden sensitive files, unsafe symlinks/junctions, runtime-state roots, and UNC/network paths.
- Manifest inventory and SHA-256 protect integrity but do not prove publisher identity; unsigned external bundles are limited to internal migration or controlled-source validation until the signature gate is restored.
- No RPC field, WebSocket protocol, database schema, or persisted-state contract changed.
- POSIX permission checks and Windows-native path/junction/share handling are covered by platform-specific tests.
- `docs/architecture/**` has zero diff.
- No secrets, runtime transcripts, memory, machine-specific paths, or private fixtures are included.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
