### PR TITLE
Center terminal plan summaries in the execution dock

### DIFF
--- a/opensquilla-webui/src/components/chat/PlanRunRibbon.test.ts
+++ b/opensquilla-webui/src/components/chat/PlanRunRibbon.test.ts
@@ -493,6 +493,12 @@ describe('PlanRunRibbon', () => {
     expect(host.querySelector('.plan-run__static-status')?.textContent.trim()).toBe('1/3')
   })
 
+  it('centers terminal summaries within the fixed-width execution ribbon', () => {
+    expect(planRunRibbonSource).toContain(
+      '.plan-run__static {\n  margin-inline: auto;\n}',
+    )
+  })
+
   it('counts completed and skipped todos in the completed summary', async () => {
     const host = mountRibbon(run({
       status: 'completed',

--- a/opensquilla-webui/src/components/chat/PlanRunRibbon.vue
+++ b/opensquilla-webui/src/components/chat/PlanRunRibbon.vue
@@ -541,6 +541,10 @@ function stepStatusLabel(status: PlanRunStepStatus): string {
     box-shadow var(--dur-fast) var(--ease-standard);
 }
 
+.plan-run__static {
+  margin-inline: auto;
+}
+
 .plan-run__summary::before {
   position: absolute;
   inset: -4px 0;


### PR DESCRIPTION
## Scope

Scope boundary: Center terminal plan-run summaries within the existing fixed-width execution ribbon and add a focused regression assertion.

Non-goals: No changes to plan state, RPC contracts, execution behavior, animation, copy, or assistive-technology semantics.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Direct user-reported visual defect with a locally reproduced root cause.

## Release Note

Release note: NONE

## Root Cause and Visual Verification

Inspectable plan states render through a three-column centering grid, while terminal states render the compact `.plan-run__static` summary directly inside the 440px ribbon. The terminal summary retained `width: max-content` but had no centering rule, so it stayed at the ribbon's left edge.

The actual component was rendered with repository design tokens at the same viewport and state before and after the change. Against the 440px execution-ribbon centerline:

- running summary: `-0.01px` center offset before and after
- completed summary before: `-159.68px`
- completed summary after: `-0.01px`
- completed pill width remained `120.65px`, confirming true centering rather than stretching

The CSS-only change preserves the existing DOM, status text, progress count, focus behavior, and screen-reader semantics.

## Tests

Ruff: Not run; WebUI-only CSS and TypeScript test change.

Pytest: Not run; no Python code changed.

Build: `npm run typecheck` passed, including architecture, chat security, color, motion, radius, theme, cross-surface token, i18n, channel catalog, README locale, and `vue-tsc` checks.

Regression tests: added

Notes: `npm run test:unit -- src/components/chat/PlanRunRibbon.test.ts` passed (39/39). `git diff --check` passed. The test remains offline, deterministic, credential-free, and fork-safe.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: browser

Maintainer-only note: no credentials or external services are needed; the component was visually verified in the local Web UI at an identical viewport before and after the fix.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and `tests/_private/` contents were not committed. This platform-neutral logical CSS change affects no security-sensitive behavior.

Upgrade compatibility: no persisted configuration, database state, generated assets, desktop-client contracts, RPC fields, CLI flags, or public protocols changed. Existing installations require no migration.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A. The change and test are repository-native.

## Documentation Changes

No documentation changes. Existing links, examples, and public documentation contracts are unaffected.