### PR TITLE
Scope workspace selection to new tasks

### DIFF
--- a/opensquilla-webui/src/App.sidebar-contract.test.ts
+++ b/opensquilla-webui/src/App.sidebar-contract.test.ts
@@ -13,4 +13,13 @@ describe('App sidebar chrome contract', () => {
     expect(brandMarkup).not.toContain('@click')
     expect(brandMarkup).not.toContain('to="/overview"')
   })
+
+  it('keeps project selection out of the primary sidebar controls', () => {
+    const newTaskStart = appSource.indexOf('class="sidebar-new-session"')
+    const workNavStart = appSource.indexOf('<router-link', newTaskStart)
+    const primaryControls = appSource.slice(newTaskStart, workNavStart)
+
+    expect(primaryControls).not.toContain('@click="openProjectPicker"')
+    expect(primaryControls).not.toContain("t('workspaces.chooseProject')")
+  })
 })

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -59,16 +59,6 @@
              disabled (Settings → Keyboard), so it never advertises a dead key. -->
         <kbd v-if="newChatHint" class="sidebar-kbd" aria-hidden="true">{{ newChatHint }}</kbd>
       </button>
-      <button
-        v-if="rpcStore.canChooseProject"
-        type="button"
-        class="sidebar-fn-item"
-        :title="t('workspaces.chooseProject')"
-        @click="openProjectPicker"
-      >
-        <Icon name="sessions" :size="16" />
-        <span class="sidebar-fn-label">{{ t('workspaces.chooseProject') }}</span>
-      </button>
       <!-- Overview / Skills & Channels / Cron, single-sourced from route
            metadata so the rail, mobile drawer, and palette never drift. -->
       <router-link
@@ -362,15 +352,6 @@
 
   <ConfirmModal />
 
-  <ProjectWorkspacePickerDialog
-    v-if="rpcStore.canChooseProject"
-    :open="projectPickerOpen"
-    :enabled="rpcStore.canChooseProject"
-    :session-key="currentSessionKey || 'agent:main:webchat:workspace-picker'"
-    @close="projectPickerOpen = false"
-    @choose="onProjectPathChosen"
-  />
-
   <ProjectWorkspaceEditDialog
     v-if="rpcStore.canManageProjectWorkspaces"
     :open="Boolean(editingProject)"
@@ -408,7 +389,6 @@ import ErrorBoundary from './components/ErrorBoundary.vue'
 import ToastHost from './components/ToastHost.vue'
 import ConfirmModal from './components/ConfirmModal.vue'
 import ProjectWorkspaceEditDialog from './components/ProjectWorkspaceEditDialog.vue'
-import ProjectWorkspacePickerDialog from './components/ProjectWorkspacePickerDialog.vue'
 import UpdateBanner from './components/UpdateBanner.vue'
 import DesktopUpdateIndicator from './components/DesktopUpdateIndicator.vue'
 import SidebarConversations from './components/SidebarConversations.vue'
@@ -505,7 +485,6 @@ const { pushToast } = useToasts()
 const { confirm } = useConfirm()
 const projectWorkspaces = useProjectWorkspaces()
 const freshTaskDraft = useFreshTaskDraft()
-const projectPickerOpen = ref(false)
 const editingProjectId = ref('')
 const editingProject = computed(() =>
   editingProjectId.value
@@ -519,7 +498,6 @@ watch(
       void projectWorkspaces.loadWorkspaces().catch(() => undefined)
       return
     }
-    projectPickerOpen.value = false
     editingProjectId.value = ''
   },
 )
@@ -896,12 +874,6 @@ function startNewChatInstant() {
   void openDefaultDraft()
 }
 
-function openProjectPicker() {
-  if (!rpcStore.canChooseProject) return
-  handleNavClick()
-  projectPickerOpen.value = true
-}
-
 function startProjectTask(workspaceId: string) {
   if (!workspaceId || !rpcStore.canManageProjectWorkspaces) return
   handleNavClick()
@@ -910,24 +882,6 @@ function startProjectTask(workspaceId: string) {
     path: '/chat/new',
     query: { agent: 'main', project: workspaceId },
   })
-}
-
-async function onProjectPathChosen(path: string) {
-  projectPickerOpen.value = false
-  if (!rpcStore.canChooseProject) return
-  const trusted = await confirm({
-    title: t('workspaces.trustTitle'),
-    body: t('workspaces.trustBody', { path }),
-    primaryLabel: t('workspaces.trustConfirm'),
-    primaryClass: 'btn--primary',
-  })
-  if (!trusted) return
-  try {
-    const workspace = await projectWorkspaces.openWorkspace(path)
-    if (workspace) startProjectTask(workspace.id)
-  } catch (err) {
-    pushToast(t('workspaces.openFailed', { error: errorMessage(err) }), { tone: 'danger' })
-  }
 }
 
 async function onProjectPin(payload: { workspaceId: string; pinned: boolean }) {

--- a/opensquilla-webui/src/components/chat/ChatComposer.vue
+++ b/opensquilla-webui/src/components/chat/ChatComposer.vue
@@ -28,7 +28,7 @@
       </div>
       <div class="chat-input-panel">
         <div
-          v-if="projectWorkspace"
+          v-if="projectWorkspace && isNewLanding"
           class="chat-project-chip"
           :data-status="projectWorkspaceStatus || 'ready'"
           :title="projectWorkspace.path"

--- a/opensquilla-webui/src/components/chat/ChatComposer.workspace.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatComposer.workspace.test.ts
@@ -99,7 +99,7 @@ describe('ChatComposer project draft', () => {
     app.unmount()
   })
 
-  it('keeps a durable project chip visible without a close control', async () => {
+  it('hides the project chip after the draft becomes a durable task', async () => {
     const host = document.createElement('div')
     document.body.appendChild(host)
     const app = createApp(ChatComposer, composerProps({
@@ -110,8 +110,7 @@ describe('ChatComposer project draft', () => {
     app.mount(host)
     await nextTick()
 
-    expect(host.querySelector('.chat-project-chip__name')?.textContent).toBe('Project A')
-    expect(host.querySelector('.chat-project-chip button')).toBeNull()
+    expect(host.querySelector('.chat-project-chip')).toBeNull()
 
     app.unmount()
   })


### PR DESCRIPTION
Superseded by #857, which now carries this workspace-selection change together with the macOS native directory-picker stabilization and desktop keyboard zoom support.