### PR TITLE
Refine project workspaces and chat activity UI

### DIFF
--- a/opensquilla-webui/e2e/assistant-activity.spec.ts
+++ b/opensquilla-webui/e2e/assistant-activity.spec.ts
@@ -226,9 +226,10 @@ test.describe('Completed assistant activity disclosure', () => {
     const activity = page.getByTestId('assistant-activity')
     await expect(activity).toBeVisible()
     await expect(activity).toHaveAttribute('data-share-expanded', 'false')
-    // The collapsed row leads with what the turn did (footprint summary)
-    // rather than the generic "Completed · N items" count.
-    await expect(activity).toContainText('1 web action')
+    // Completed history without timing metadata stays compact and never falls
+    // back to an arbitrary activity-item count.
+    await expect(activity.locator('.assistant-activity__summary')).toContainText('Completed')
+    await expect(activity.locator('.assistant-activity__summary')).not.toContainText('item')
 
     const answer = page.getByText('The canonical answer is complete.', { exact: true })
     await expect(answer).toBeVisible()
@@ -285,7 +286,11 @@ test.describe('Completed assistant activity disclosure', () => {
     await expect(activity).toHaveAttribute('data-share-expanded', 'true')
     await expect(row).toBeVisible()
     await expect(processPrefix).toBeVisible()
-    await expect(activity.locator('.thinking-block__body')).toContainText(
+    const reasoningFold = activity.locator('details.thinking-fold')
+    await expect(reasoningFold).not.toHaveAttribute('open', '')
+    await expect(reasoningFold.locator('.thinking-fold__body')).toBeHidden()
+    await reasoningFold.locator('summary').click()
+    await expect(reasoningFold.locator('.thinking-fold__body')).toContainText(
       'I compared the available evidence before answering.',
     )
 
@@ -356,7 +361,7 @@ test.describe('Completed assistant activity disclosure', () => {
     await expect(answer).toBeVisible()
   })
 
-  test('keeps recovered failures collapsed and exposes the full error on demand', async ({ page }) => {
+  test('omits failed work from the activity disclosure', async ({ page }) => {
     await mockActivityHistory(page, { failed: true })
     await page.setViewportSize({ width: 320, height: 844 })
     await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(`${SESSION_KEY}-failed`))
@@ -365,18 +370,15 @@ test.describe('Completed assistant activity disclosure', () => {
     const activity = page.getByTestId('assistant-activity')
     await expect(activity).toBeVisible()
     await expect(activity).toHaveAttribute('data-share-expanded', 'false')
-    await expect(activity).toContainText('1 failure recovered')
+    await expect(activity).not.toContainText('failure recovered')
 
     const errorRow = activity.locator('.tool-row--error')
-    await expect(errorRow).toBeHidden()
+    await expect(errorRow).toHaveCount(0)
     const summary = activity.locator('.assistant-activity__summary')
     await summary.press('Enter')
     await expect(activity).toHaveAttribute('data-share-expanded', 'true')
-    await expect(errorRow).toBeVisible()
-    await expect(errorRow).toHaveAttribute('aria-expanded', 'true')
-    await expect(activity.locator('.activity-tool-details__line--error')).toContainText(
-      'Search service unavailable',
-    )
+    await expect(errorRow).toHaveCount(0)
+    await expect(activity).not.toContainText('Search service unavailable')
     await expect(activity.locator('.tool-row-section--error')).toHaveCount(0)
     await expect(
       page.getByText('The canonical answer is complete.', { exact: true }),
@@ -411,20 +413,20 @@ test.describe('Live assistant activity lifecycle', () => {
     const liveActivity = page.locator('.assistant-activity--live')
     await expect(liveActivity).toBeVisible()
     await expect(page.locator('.work-card')).toHaveCount(0)
+    const liveSummary = liveActivity.locator('.assistant-activity__live-head')
+    await expect(liveSummary).toHaveAttribute('aria-expanded', 'false')
+    await liveSummary.click()
+    await expect(liveSummary).toHaveAttribute('aria-expanded', 'true')
     const liveStatus = liveActivity.locator('.assistant-activity__live-label')
     await expect(liveStatus).toHaveText('Working')
     await expect(liveStatus).toHaveAttribute('role', 'status')
     await expect(liveStatus).toHaveAttribute('aria-live', 'polite')
     await expect(liveStatus).toHaveAttribute('aria-atomic', 'true')
     await expect(liveActivity.getByText('Working', { exact: true })).toHaveCount(1)
-    // Exactly two deliberate polite regions with disjoint content: the phase
-    // label, and the always-mounted failure counter (empty until a failure
-    // lands, so it announces only when the count actually changes). Anything
-    // beyond these two would double-announce streaming updates.
-    await expect(liveActivity.locator('[role="status"]')).toHaveCount(2)
-    const liveFailureRegion = liveActivity.locator('.assistant-activity__live-failure')
-    await expect(liveFailureRegion).toHaveAttribute('aria-live', 'polite')
-    await expect(liveFailureRegion).toHaveText('')
+    // The phase label is the only polite live region. Failed work is omitted
+    // from the disclosure, so it must not mount a second announcement region.
+    await expect(liveActivity.locator('[role="status"]')).toHaveCount(1)
+    await expect(liveActivity.locator('.assistant-activity__live-failure')).toHaveCount(0)
     await expect(liveActivity.locator('.assistant-activity-status__row')).toHaveCount(0)
     const liveMotion = await liveActivity.evaluate((element) => ({
       dot: getComputedStyle(

--- a/opensquilla-webui/e2e/project-workspaces.spec.ts
+++ b/opensquilla-webui/e2e/project-workspaces.spec.ts
@@ -6,7 +6,7 @@ async function openControl(page: Page) {
   await page.goto(CONTROL_URL)
   await page.waitForSelector('.conn-pill', { timeout: 10000 })
   await page.waitForSelector('.conn-pill.connected', { timeout: 10000 }).catch(() => {})
-  await expect(page.getByRole('navigation', { name: 'Primary' })).toBeVisible()
+  await expect(page.locator('#sidebar-nav')).toBeVisible()
 }
 
 type RpcParams = Record<string, unknown>
@@ -284,10 +284,7 @@ test.describe('Project workspaces', () => {
     await installProjectLifecycleRpc(page)
     await openControl(page)
 
-    await page
-      .getByRole('navigation', { name: 'Control navigation' })
-      .getByRole('button', { name: 'Choose project' })
-      .click()
+    await page.getByRole('button', { name: 'Choose project', exact: true }).click()
 
     const picker = page.getByRole('dialog', { name: 'Choose project' })
     const list = picker.locator('.project-picker__entries')
@@ -305,7 +302,7 @@ test.describe('Project workspaces', () => {
     await expect.poll(() => list.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
   })
 
-  test('offers project selection from both the sidebar and an ordinary draft', async ({ page }) => {
+  test('offers project selection in an ordinary draft but not the sidebar navigation', async ({ page }) => {
     await installProjectLifecycleRpc(page)
     await openControl(page)
 
@@ -313,13 +310,13 @@ test.describe('Project workspaces', () => {
       page
         .getByRole('navigation', { name: 'Control navigation' })
         .getByRole('button', { name: 'Choose project' }),
-    ).toBeVisible()
+    ).toHaveCount(0)
     await page.locator('.sidebar-new-session').click()
     await expect(page).toHaveURL(/\/chat\/new\?agent=main$/)
-    await expect(page.getByRole('button', { name: 'Choose project' }).last()).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Choose project', exact: true })).toBeVisible()
   })
 
-  test('project names only disclose tasks while the pencil opens a project draft', async ({ page }) => {
+  test('project names only disclose tasks while the plus opens a project draft', async ({ page }) => {
     const state = await installProjectLifecycleRpc(page)
     state.projectPresent = true
     state.sent = true
@@ -328,7 +325,7 @@ test.describe('Project workspaces', () => {
 
     const disclosure = project.getByTestId('project-workspace-disclosure')
     const info = project.getByTestId('project-workspace-info')
-    const pencil = project.getByTestId('project-workspace-new-task')
+    const plus = project.getByTestId('project-workspace-new-task')
 
     await expect(info).toBeVisible()
     await expect(disclosure).toHaveAttribute('aria-expanded', /true|false/)
@@ -337,19 +334,21 @@ test.describe('Project workspaces', () => {
     await expect(disclosure).toHaveAttribute('aria-expanded', String(!startedExpanded))
     await expect(page).not.toHaveURL(/\/chat\?session=/)
 
-    await pencil.click()
+    await plus.click()
     await expect(page).toHaveURL(/\/chat\/new\?agent=main&project=[^&]+$/)
     await expect(page.locator('.chat-project-chip')).toBeVisible()
+    await expect(disclosure).toHaveAttribute('aria-expanded', 'true')
+    const draftRow = page.locator('[data-session-key^="draft:project:"]')
+    await expect(draftRow).toHaveCount(1)
+    await expect(draftRow.locator('.sidebar-history-item')).toHaveClass(/is-current/)
+    await expect(draftRow.locator('.sidebar-history-title')).not.toBeEmpty()
   })
 
   test('project picker, trust, first send, reload, remove, reopen, and history delete', async ({ page }) => {
     const state = await installProjectLifecycleRpc(page)
     await openControl(page)
 
-    await page
-      .getByRole('navigation', { name: 'Control navigation' })
-      .getByRole('button', { name: 'Choose project' })
-      .click()
+    await page.getByRole('button', { name: 'Choose project', exact: true }).click()
     await expect.poll(() => state.pathListRequests.length).toBe(1)
     expect(state.pathListRequests[0]).not.toHaveProperty('path')
     expect(state.pathListRequests[0]).toMatchObject({
@@ -387,7 +386,7 @@ test.describe('Project workspaces', () => {
     await expect(page.locator('.chat-project-chip')).toContainText('/repos/demo')
     const projectRow = page.locator('.sidebar-history-row--workspace').first()
     await projectRow.getByTestId('project-workspace-more').click()
-    await page.getByRole('menuitem', { name: 'Remove project' }).click()
+    await page.getByRole('menuitem', { name: 'Remove' }).click()
     await page.getByRole('button', { name: 'Remove project' }).click()
     await expect.poll(() => state.removed).toBe(true)
     await expect(page.locator('.chat-project-chip')).toContainText('/repos/demo')
@@ -396,10 +395,9 @@ test.describe('Project workspaces', () => {
     await expect(blockedSend).toBeDisabled()
     expect(state.sends).toHaveLength(1)
 
-    await page
-      .getByRole('navigation', { name: 'Control navigation' })
-      .getByRole('button', { name: 'Choose project' })
-      .click()
+    await page.locator('.sidebar-new-session').click()
+    await expect(page).toHaveURL(/\/chat\/new\?agent=main$/)
+    await page.getByRole('button', { name: 'Choose project', exact: true }).click()
     const reopenedPicker = page.getByRole('dialog', { name: 'Choose project' })
     await reopenedPicker.getByRole('option', { name: 'demo' }).click()
     await reopenedPicker
@@ -411,7 +409,7 @@ test.describe('Project workspaces', () => {
     const reopenedRow = page.locator('.sidebar-history-row--workspace').first()
     await reopenedRow.getByTestId('project-workspace-more').click()
     await page
-      .getByRole('menuitem', { name: 'Delete project task history' })
+      .getByRole('menuitem', { name: 'Delete history' })
       .click()
     await page.getByRole('button', { name: 'Delete history' }).click()
     await expect.poll(() => state.historyDeleted).toBe(true)
@@ -419,6 +417,7 @@ test.describe('Project workspaces', () => {
     await expect.poll(() => state.postDeleteSessionLists).toBeGreaterThan(0)
     expect(state.historyDeleteRequests).toEqual([{ workspaceId: 'project-demo' }])
     await expect(page.locator(`[data-session-key="${state.sessionKey}"]`)).toHaveCount(0)
-    await expect(page.locator('.sidebar-workspace-empty')).toHaveText('No tasks')
+    await expect(page.locator('.sidebar-workspace-empty')).toHaveCount(0)
+    await expect(page.locator('.sidebar-zone-empty__body')).toHaveText('No tasks yet.')
   })
 })

--- a/opensquilla-webui/e2e/project-workspaces.spec.ts
+++ b/opensquilla-webui/e2e/project-workspaces.spec.ts
@@ -252,7 +252,7 @@ test.describe('Project workspaces', () => {
 
     await page.goto(`/control/chat?session=${encodeURIComponent(state.sessionKey)}`)
     await expect(page.locator('.conn-pill.connected')).toBeVisible()
-    await expect(page.locator('.chat-project-chip')).toContainText('/repos/demo')
+    await expect(page.locator('.chat-project-chip')).toHaveCount(0)
     await expect(page.getByRole('button', { name: 'Choose project' })).toHaveCount(0)
 
     await page.getByRole('textbox', { name: 'Message to send' }).fill('continue')
@@ -284,6 +284,7 @@ test.describe('Project workspaces', () => {
     await installProjectLifecycleRpc(page)
     await openControl(page)
 
+    await page.locator('.sidebar-new-session').click()
     await page.getByRole('button', { name: 'Choose project', exact: true }).click()
 
     const picker = page.getByRole('dialog', { name: 'Choose project' })
@@ -316,6 +317,33 @@ test.describe('Project workspaces', () => {
     await expect(page.getByRole('button', { name: 'Choose project', exact: true })).toBeVisible()
   })
 
+  test('creates a project from the projects header without starting a task', async ({ page }) => {
+    const state = await installProjectLifecycleRpc(page)
+    await openControl(page)
+
+    await page.getByTestId('sidebar-create-project').click()
+
+    let creator = page.getByRole('dialog', { name: 'Create project' })
+    await expect(creator).toBeVisible()
+    await creator
+      .getByRole('button', { name: 'Add a folder OpenSquilla can read and edit', exact: true })
+      .click()
+
+    const picker = page.getByRole('dialog', { name: 'Choose project' })
+    await picker.getByRole('option', { name: 'demo', exact: true }).click()
+    await picker.getByRole('button', { name: 'Choose selected directory', exact: true }).click()
+
+    creator = page.getByRole('dialog', { name: 'Create project' })
+    await expect(creator.getByRole('textbox', { name: 'Project name' })).toHaveValue('demo')
+    await creator.getByRole('button', { name: 'Create project', exact: true }).click()
+    await page.getByRole('button', { name: 'Trust and open', exact: true }).click()
+
+    await expect.poll(() => state.projectPresent).toBe(true)
+    await expect(page.locator('.sidebar-history-row--workspace')).toHaveCount(1)
+    await expect(page.locator('[data-session-key^="draft:project:"]')).toHaveCount(0)
+    await expect(page).not.toHaveURL(/project=project-demo/)
+  })
+
   test('project names only disclose tasks while the plus opens a project draft', async ({ page }) => {
     const state = await installProjectLifecycleRpc(page)
     state.projectPresent = true
@@ -328,12 +356,15 @@ test.describe('Project workspaces', () => {
     const plus = project.getByTestId('project-workspace-new-task')
 
     await expect(info).toBeVisible()
+    await expect(plus).toHaveCSS('opacity', '0')
     await expect(disclosure).toHaveAttribute('aria-expanded', /true|false/)
     const startedExpanded = await disclosure.getAttribute('aria-expanded') === 'true'
     await disclosure.click()
     await expect(disclosure).toHaveAttribute('aria-expanded', String(!startedExpanded))
     await expect(page).not.toHaveURL(/\/chat\?session=/)
 
+    await project.hover()
+    await expect(plus).toHaveCSS('opacity', '1')
     await plus.click()
     await expect(page).toHaveURL(/\/chat\/new\?agent=main&project=[^&]+$/)
     await expect(page.locator('.chat-project-chip')).toBeVisible()
@@ -348,6 +379,7 @@ test.describe('Project workspaces', () => {
     const state = await installProjectLifecycleRpc(page)
     await openControl(page)
 
+    await page.locator('.sidebar-new-session').click()
     await page.getByRole('button', { name: 'Choose project', exact: true }).click()
     await expect.poll(() => state.pathListRequests.length).toBe(1)
     expect(state.pathListRequests[0]).not.toHaveProperty('path')
@@ -361,7 +393,8 @@ test.describe('Project workspaces', () => {
     await page.getByRole('button', { name: 'Trust and open' }).click()
     await expect(page).toHaveURL(/\/chat\/new\?agent=main&project=project-demo$/)
     const projectChip = page.locator('.chat-project-chip')
-    await expect(projectChip).toContainText('/repos/demo')
+    await expect(projectChip).toContainText('demo')
+    await expect(projectChip).not.toContainText('/repos/demo')
     await expect(projectChip).toHaveAttribute('data-status', 'ready')
     await expect.poll(
       () => state.requestMethods.filter(method => method === 'sessions.messages.subscribe').length,
@@ -380,16 +413,16 @@ test.describe('Project workspaces', () => {
     })
     expect(state.sends[0]._source).toMatchObject({ runMode: 'full' })
     await expect(page).toHaveURL(/\/chat\?session=/)
-    await expect(page.locator('.chat-project-chip')).toContainText('/repos/demo')
+    await expect(page.locator('.chat-project-chip')).toHaveCount(0)
 
     await page.reload()
-    await expect(page.locator('.chat-project-chip')).toContainText('/repos/demo')
+    await expect(page.locator('.chat-project-chip')).toHaveCount(0)
     const projectRow = page.locator('.sidebar-history-row--workspace').first()
     await projectRow.getByTestId('project-workspace-more').click()
     await page.getByRole('menuitem', { name: 'Remove' }).click()
     await page.getByRole('button', { name: 'Remove project' }).click()
     await expect.poll(() => state.removed).toBe(true)
-    await expect(page.locator('.chat-project-chip')).toContainText('/repos/demo')
+    await expect(page.locator('.chat-project-chip')).toContainText('demo')
     const blockedSend = page.getByRole('button', { name: 'Send' })
     await page.getByRole('textbox', { name: 'Message to send' }).fill('must stay')
     await expect(blockedSend).toBeDisabled()

--- a/opensquilla-webui/e2e/project-workspaces.spec.ts
+++ b/opensquilla-webui/e2e/project-workspaces.spec.ts
@@ -124,6 +124,7 @@ async function installProjectLifecycleRpc(
             currentPath: '/repos',
             path: '/repos',
             parentPath: '/',
+            systemPickerAvailable: false,
             entries: [
               {
                 name: 'demo',
@@ -330,6 +331,8 @@ test.describe('Project workspaces', () => {
       .click()
 
     const picker = page.getByRole('dialog', { name: 'Choose project' })
+    await expect.poll(() => state.pathListRequests.length).toBe(1)
+    expect(state.requestMethods).not.toContain('sandbox.path.pick')
     await picker.getByRole('option', { name: 'demo', exact: true }).click()
     await picker.getByRole('button', { name: 'Choose selected directory', exact: true }).click()
 

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -86,12 +86,14 @@
       :contract-debug-enabled="contractDebugEnabled"
       :search-hint="commandPaletteHint"
       :can-manage-projects="rpcStore.canManageProjectWorkspaces"
+      :can-create-projects="rpcStore.canChooseProject"
       @select="switchToSession"
       @refresh="loadSidebarData"
       @rename="onRenameSession"
       @delete="onDeleteSession"
       @bulk-delete="onBulkDeleteSessions"
       @new-chat="startNewChatInstant"
+      @new-project="openProjectCreator"
       @new-project-task="startProjectTask"
       @project-pin="onProjectPin"
       @project-edit="openProjectEditor"
@@ -352,12 +354,25 @@
 
   <ConfirmModal />
 
+  <ProjectWorkspaceCreateDialog
+    v-if="rpcStore.canChooseProject"
+    :open="projectCreateOpen && !projectPickerOpen && !projectCreateConfirming"
+    :name="projectCreateName"
+    :source-path="projectCreateSourcePath"
+    :busy="projectCreateBusy"
+    @update:name="projectCreateName = $event"
+    @choose-source="openProjectSourcePicker"
+    @close="closeProjectCreator"
+    @create="createProjectWorkspace"
+  />
+
   <ProjectWorkspacePickerDialog
     v-if="rpcStore.canChooseProject"
     :open="projectPickerOpen"
     :enabled="rpcStore.canChooseProject"
     :session-key="currentSessionKey || 'agent:main:webchat:workspace-picker'"
-    @close="projectPickerOpen = false"
+    :initial-path="projectCreateSourcePath"
+    @close="closeProjectSourcePicker"
     @choose="onProjectPathChosen"
   />
 
@@ -397,6 +412,7 @@ import Icon from './components/Icon.vue'
 import ErrorBoundary from './components/ErrorBoundary.vue'
 import ToastHost from './components/ToastHost.vue'
 import ConfirmModal from './components/ConfirmModal.vue'
+import ProjectWorkspaceCreateDialog from './components/ProjectWorkspaceCreateDialog.vue'
 import ProjectWorkspaceEditDialog from './components/ProjectWorkspaceEditDialog.vue'
 import ProjectWorkspacePickerDialog from './components/ProjectWorkspacePickerDialog.vue'
 import UpdateBanner from './components/UpdateBanner.vue'
@@ -495,6 +511,11 @@ const { pushToast } = useToasts()
 const { confirm } = useConfirm()
 const projectWorkspaces = useProjectWorkspaces()
 const freshTaskDraft = useFreshTaskDraft()
+const projectCreateOpen = ref(false)
+const projectCreateName = ref('')
+const projectCreateSourcePath = ref('')
+const projectCreateBusy = ref(false)
+const projectCreateConfirming = ref(false)
 const projectPickerOpen = ref(false)
 const editingProjectId = ref('')
 const editingProject = computed(() =>
@@ -509,6 +530,11 @@ watch(
       void projectWorkspaces.loadWorkspaces().catch(() => undefined)
       return
     }
+    projectCreateOpen.value = false
+    projectCreateName.value = ''
+    projectCreateSourcePath.value = ''
+    projectCreateBusy.value = false
+    projectCreateConfirming.value = false
     projectPickerOpen.value = false
     editingProjectId.value = ''
   },
@@ -979,21 +1005,83 @@ function startProjectTask(workspaceId: string) {
   })
 }
 
-async function onProjectPathChosen(path: string) {
+function projectNameFromPath(path: string): string {
+  const normalized = path.trim().replace(/[\\/]+$/, '')
+  return normalized.split(/[\\/]/).pop() || normalized
+}
+
+function resetProjectCreator() {
+  projectCreateOpen.value = false
+  projectCreateName.value = ''
+  projectCreateSourcePath.value = ''
+  projectCreateBusy.value = false
+  projectCreateConfirming.value = false
   projectPickerOpen.value = false
+}
+
+function openProjectCreator() {
   if (!rpcStore.canChooseProject) return
+  projectCreateName.value = ''
+  projectCreateSourcePath.value = ''
+  projectCreateBusy.value = false
+  projectCreateConfirming.value = false
+  projectPickerOpen.value = false
+  projectCreateOpen.value = true
+}
+
+function closeProjectCreator() {
+  if (projectCreateBusy.value) return
+  resetProjectCreator()
+}
+
+function openProjectSourcePicker() {
+  if (!projectCreateOpen.value || !rpcStore.canChooseProject || projectCreateBusy.value) return
+  projectPickerOpen.value = true
+}
+
+function closeProjectSourcePicker() {
+  projectPickerOpen.value = false
+}
+
+function onProjectPathChosen(path: string) {
+  projectPickerOpen.value = false
+  if (!projectCreateOpen.value || !rpcStore.canChooseProject) return
+  projectCreateSourcePath.value = path
+  if (!projectCreateName.value.trim()) {
+    projectCreateName.value = projectNameFromPath(path)
+  }
+}
+
+async function createProjectWorkspace(payload: { name: string; path: string }) {
+  if (!projectCreateOpen.value || !rpcStore.canChooseProject || projectCreateBusy.value) return
+  const name = payload.name.trim()
+  const path = payload.path.trim()
+  if (!name || !path) return
+  projectCreateConfirming.value = true
+  await nextTick()
   const trusted = await confirm({
     title: t('workspaces.trustTitle'),
     body: t('workspaces.trustBody', { path }),
     primaryLabel: t('workspaces.trustConfirm'),
     primaryClass: 'btn--primary',
   })
-  if (!trusted) return
+  if (!trusted) {
+    projectCreateConfirming.value = false
+    return
+  }
+  projectCreateBusy.value = true
   try {
     const workspace = await projectWorkspaces.openWorkspace(path)
-    if (workspace) startProjectTask(workspace.id)
+    if (!workspace) throw new Error('Gateway returned an empty project.')
+    if (workspace.name !== name) {
+      await projectWorkspaces.renameWorkspace(workspace.id, name)
+    }
+    resetProjectCreator()
+    pushToast(t('workspaces.projectCreated', { name }), { tone: 'ok' })
   } catch (err) {
-    pushToast(t('workspaces.openFailed', { error: errorMessage(err) }), { tone: 'danger' })
+    projectCreateBusy.value = false
+    projectCreateConfirming.value = false
+    pushToast(t('workspaces.createProjectFailed', { error: errorMessage(err) }), { tone: 'danger' })
   }
 }
 

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -59,16 +59,6 @@
              disabled (Settings → Keyboard), so it never advertises a dead key. -->
         <kbd v-if="newChatHint" class="sidebar-kbd" aria-hidden="true">{{ newChatHint }}</kbd>
       </button>
-      <button
-        v-if="rpcStore.canChooseProject"
-        type="button"
-        class="sidebar-fn-item"
-        :title="t('workspaces.chooseProject')"
-        @click="openProjectPicker"
-      >
-        <Icon name="sessions" :size="16" />
-        <span class="sidebar-fn-label">{{ t('workspaces.chooseProject') }}</span>
-      </button>
       <!-- Overview / Skills & Channels / Cron, single-sourced from route
            metadata so the rail, mobile drawer, and palette never drift. -->
       <router-link
@@ -92,7 +82,7 @@
       :sections="sidebarSections"
       :error="sessionListError"
       :loading="isLoading"
-      :current-key="currentSessionKey"
+      :current-key="sidebarCurrentKey"
       :contract-debug-enabled="contractDebugEnabled"
       :search-hint="commandPaletteHint"
       :can-manage-projects="rpcStore.canManageProjectWorkspaces"
@@ -616,6 +606,19 @@ const currentSessionKey = computed(() => {
 
 // Chat layout applies to both the session view and the draft route.
 const isChatRoute = computed(() => $route.path === '/chat' || $route.path === '/chat/new')
+const activeProjectDraftId = computed(() =>
+  $route.path === '/chat/new' ? String($route.query.project || '') : '',
+)
+const activeProjectDraftKey = computed(() => {
+  const workspaceId = activeProjectDraftId.value
+  if (!workspaceId) return ''
+  const request = freshTaskDraft.request.value
+  const requestId = request?.workspaceId === workspaceId ? request.id : 0
+  return `draft:project:${workspaceId}:${requestId}`
+})
+const sidebarCurrentKey = computed(() =>
+  currentSessionKey.value || activeProjectDraftKey.value,
+)
 
 watch(
   [
@@ -696,12 +699,22 @@ function syntheticChatSession(
   effectiveAgentId: string,
   title: string,
   updatedAt: number,
+  project?: {
+    id: string
+    name: string
+    path: string
+    provisional?: boolean
+  },
 ): SessionItem {
   return {
     key,
     title,
     subtitle: '',
     groupLabel: normalizeAgentId(effectiveAgentId),
+    workspace: project?.path,
+    workspaceId: project?.id,
+    workspaceLabel: project?.name,
+    workspaceDisplayPath: project?.path,
     effectiveAgentId,
     sessionKind: 'chat',
     surface: 'webchat',
@@ -715,9 +728,28 @@ function syntheticChatSession(
     messageCount: null,
     updatedAt,
     interactive: true,
+    provisional: project?.provisional,
     forkedFromParent: false,
     contractGaps: [],
     raw: { key },
+  }
+}
+
+function optimisticProjectForSession(key: string) {
+  const workspaceId = freshTaskDraft.materializedWorkspaceBySession.value[key]
+  return workspaceId ? projectWorkspaces.byId.value.get(workspaceId) || null : null
+}
+
+function withOptimisticProjectBinding(item: SessionItem): SessionItem {
+  if (item.workspaceId) return item
+  const project = optimisticProjectForSession(item.key)
+  if (!project) return item
+  return {
+    ...item,
+    workspace: project.path,
+    workspaceId: project.id,
+    workspaceLabel: project.name,
+    workspaceDisplayPath: project.path,
   }
 }
 
@@ -730,19 +762,60 @@ const sidebarSessionItems = computed((): SessionItem[] => {
   for (const item of allSessions.value) {
     if (!item.key || item.key === 'unknown') continue
     seen.add(item.key)
-    items.push(item)
+    items.push(withOptimisticProjectBinding(item))
   }
   for (const [key, local] of Object.entries(localChatSessions.value)) {
     if (seen.has(key)) continue
     seen.add(key)
-    items.push(syntheticChatSession(key, local.effectiveAgentId, local.title || t('chrome.newChat'), local.updatedAt))
+    const project = optimisticProjectForSession(key) || undefined
+    items.push(syntheticChatSession(
+      key,
+      local.effectiveAgentId,
+      local.title || t('chrome.newChat'),
+      local.updatedAt,
+      project,
+    ))
+  }
+  const draftWorkspaceId = activeProjectDraftId.value
+  const draftKey = activeProjectDraftKey.value
+  const draftProject = draftWorkspaceId
+    ? projectWorkspaces.byId.value.get(draftWorkspaceId)
+    : null
+  if (draftKey && draftProject && !seen.has(draftKey)) {
+    seen.add(draftKey)
+    items.push(syntheticChatSession(
+      draftKey,
+      'main',
+      t('chrome.newTask'),
+      Date.now(),
+      {
+        id: draftProject.id,
+        name: draftProject.name,
+        path: draftProject.path,
+        provisional: true,
+      },
+    ))
   }
   const current = currentSessionKey.value
   if (current && !seen.has(current)) {
     const currentAgentId = normalizeAgentId(current.split(':')[1] || 'main')
-    items.push(syntheticChatSession(current, currentAgentId, t('shared.sidebar.currentTask'), Date.now()))
+    const project = optimisticProjectForSession(current) || undefined
+    items.push(syntheticChatSession(
+      current,
+      currentAgentId,
+      t('shared.sidebar.currentTask'),
+      Date.now(),
+      project,
+    ))
   }
   return items
+})
+
+watch(allSessions, sessions => {
+  for (const item of sessions) {
+    if (!item.key || !item.workspaceId) continue
+    freshTaskDraft.confirmMaterializedProjectTask(item.key, item.workspaceId)
+  }
 })
 
 // Collapsible family sections (Chats / Channels / Automations). Row titles and
@@ -894,12 +967,6 @@ function openDefaultDraft() {
 function startNewChatInstant() {
   handleNavClick()
   void openDefaultDraft()
-}
-
-function openProjectPicker() {
-  if (!rpcStore.canChooseProject) return
-  handleNavClick()
-  projectPickerOpen.value = true
 }
 
 function startProjectTask(workspaceId: string) {

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -356,24 +356,15 @@
 
   <ProjectWorkspaceCreateDialog
     v-if="rpcStore.canChooseProject"
-    :open="projectCreateOpen && !projectPickerOpen && !projectCreateConfirming"
+    :open="projectCreateOpen && !projectCreateConfirming"
     :name="projectCreateName"
     :source-path="projectCreateSourcePath"
     :busy="projectCreateBusy"
+    :source-picking="projectCreateSourcePicking"
     @update:name="projectCreateName = $event"
-    @choose-source="openProjectSourcePicker"
+    @choose-source="chooseProjectSourceDirectory"
     @close="closeProjectCreator"
     @create="createProjectWorkspace"
-  />
-
-  <ProjectWorkspacePickerDialog
-    v-if="rpcStore.canChooseProject"
-    :open="projectPickerOpen"
-    :enabled="rpcStore.canChooseProject"
-    :session-key="currentSessionKey || 'agent:main:webchat:workspace-picker'"
-    :initial-path="projectCreateSourcePath"
-    @close="closeProjectSourcePicker"
-    @choose="onProjectPathChosen"
   />
 
   <ProjectWorkspaceEditDialog
@@ -414,7 +405,6 @@ import ToastHost from './components/ToastHost.vue'
 import ConfirmModal from './components/ConfirmModal.vue'
 import ProjectWorkspaceCreateDialog from './components/ProjectWorkspaceCreateDialog.vue'
 import ProjectWorkspaceEditDialog from './components/ProjectWorkspaceEditDialog.vue'
-import ProjectWorkspacePickerDialog from './components/ProjectWorkspacePickerDialog.vue'
 import UpdateBanner from './components/UpdateBanner.vue'
 import DesktopUpdateIndicator from './components/DesktopUpdateIndicator.vue'
 import SidebarConversations from './components/SidebarConversations.vue'
@@ -515,8 +505,8 @@ const projectCreateOpen = ref(false)
 const projectCreateName = ref('')
 const projectCreateSourcePath = ref('')
 const projectCreateBusy = ref(false)
+const projectCreateSourcePicking = ref(false)
 const projectCreateConfirming = ref(false)
-const projectPickerOpen = ref(false)
 const editingProjectId = ref('')
 const editingProject = computed(() =>
   editingProjectId.value
@@ -534,8 +524,8 @@ watch(
     projectCreateName.value = ''
     projectCreateSourcePath.value = ''
     projectCreateBusy.value = false
+    projectCreateSourcePicking.value = false
     projectCreateConfirming.value = false
-    projectPickerOpen.value = false
     editingProjectId.value = ''
   },
 )
@@ -1015,8 +1005,8 @@ function resetProjectCreator() {
   projectCreateName.value = ''
   projectCreateSourcePath.value = ''
   projectCreateBusy.value = false
+  projectCreateSourcePicking.value = false
   projectCreateConfirming.value = false
-  projectPickerOpen.value = false
 }
 
 function openProjectCreator() {
@@ -1024,8 +1014,8 @@ function openProjectCreator() {
   projectCreateName.value = ''
   projectCreateSourcePath.value = ''
   projectCreateBusy.value = false
+  projectCreateSourcePicking.value = false
   projectCreateConfirming.value = false
-  projectPickerOpen.value = false
   projectCreateOpen.value = true
 }
 
@@ -1034,17 +1024,7 @@ function closeProjectCreator() {
   resetProjectCreator()
 }
 
-function openProjectSourcePicker() {
-  if (!projectCreateOpen.value || !rpcStore.canChooseProject || projectCreateBusy.value) return
-  projectPickerOpen.value = true
-}
-
-function closeProjectSourcePicker() {
-  projectPickerOpen.value = false
-}
-
 function onProjectPathChosen(path: string) {
-  projectPickerOpen.value = false
   if (!projectCreateOpen.value || !rpcStore.canChooseProject) return
   projectCreateSourcePath.value = path
   if (!projectCreateName.value.trim()) {
@@ -1052,8 +1032,47 @@ function onProjectPathChosen(path: string) {
   }
 }
 
+async function chooseProjectSourceDirectory() {
+  if (
+    !projectCreateOpen.value
+    || !rpcStore.canChooseProject
+    || projectCreateBusy.value
+    || projectCreateSourcePicking.value
+  ) return
+
+  projectCreateSourcePicking.value = true
+  try {
+    const nativePicker = getPlatform().files.chooseProjectDirectory
+    const choice = typeof nativePicker === 'function'
+      ? await nativePicker()
+      : await rpcStore.call<{ path: string | null }>(
+          'sandbox.path.pick',
+          {
+            sessionKey: currentSessionKey.value || 'agent:main:webchat:workspace-picker',
+            kind: 'workspace',
+            ...(projectCreateSourcePath.value.trim()
+              ? { initialPath: projectCreateSourcePath.value.trim() }
+              : {}),
+          },
+        )
+    const selected = String(choice?.path || '').trim()
+    if (selected) onProjectPathChosen(selected)
+  } catch (err) {
+    pushToast(t('workspaces.directoryPickerFailed', { error: errorMessage(err) }), {
+      tone: 'danger',
+    })
+  } finally {
+    projectCreateSourcePicking.value = false
+  }
+}
+
 async function createProjectWorkspace(payload: { name: string; path: string }) {
-  if (!projectCreateOpen.value || !rpcStore.canChooseProject || projectCreateBusy.value) return
+  if (
+    !projectCreateOpen.value
+    || !rpcStore.canChooseProject
+    || projectCreateBusy.value
+    || projectCreateSourcePicking.value
+  ) return
   const name = payload.name.trim()
   const path = payload.path.trim()
   if (!name || !path) return

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -356,7 +356,7 @@
 
   <ProjectWorkspaceCreateDialog
     v-if="rpcStore.canChooseProject"
-    :open="projectCreateOpen && !projectCreateConfirming"
+    :open="projectCreateOpen && !projectCreateConfirming && !projectSourcePickerOpen"
     :name="projectCreateName"
     :source-path="projectCreateSourcePath"
     :busy="projectCreateBusy"
@@ -365,6 +365,16 @@
     @choose-source="chooseProjectSourceDirectory"
     @close="closeProjectCreator"
     @create="createProjectWorkspace"
+  />
+
+  <ProjectWorkspacePickerDialog
+    v-if="rpcStore.canChooseProject"
+    :open="projectCreateOpen && projectSourcePickerOpen"
+    :enabled="rpcStore.canChooseProject"
+    :session-key="currentSessionKey || 'agent:main:webchat:workspace-picker'"
+    :initial-path="projectCreateSourcePath"
+    @close="projectSourcePickerOpen = false"
+    @choose="onProjectSourcePathChosen"
   />
 
   <ProjectWorkspaceEditDialog
@@ -405,6 +415,7 @@ import ToastHost from './components/ToastHost.vue'
 import ConfirmModal from './components/ConfirmModal.vue'
 import ProjectWorkspaceCreateDialog from './components/ProjectWorkspaceCreateDialog.vue'
 import ProjectWorkspaceEditDialog from './components/ProjectWorkspaceEditDialog.vue'
+import ProjectWorkspacePickerDialog from './components/ProjectWorkspacePickerDialog.vue'
 import UpdateBanner from './components/UpdateBanner.vue'
 import DesktopUpdateIndicator from './components/DesktopUpdateIndicator.vue'
 import SidebarConversations from './components/SidebarConversations.vue'
@@ -507,6 +518,7 @@ const projectCreateSourcePath = ref('')
 const projectCreateBusy = ref(false)
 const projectCreateSourcePicking = ref(false)
 const projectCreateConfirming = ref(false)
+const projectSourcePickerOpen = ref(false)
 const editingProjectId = ref('')
 const editingProject = computed(() =>
   editingProjectId.value
@@ -526,6 +538,7 @@ watch(
     projectCreateBusy.value = false
     projectCreateSourcePicking.value = false
     projectCreateConfirming.value = false
+    projectSourcePickerOpen.value = false
     editingProjectId.value = ''
   },
 )
@@ -1007,6 +1020,7 @@ function resetProjectCreator() {
   projectCreateBusy.value = false
   projectCreateSourcePicking.value = false
   projectCreateConfirming.value = false
+  projectSourcePickerOpen.value = false
 }
 
 function openProjectCreator() {
@@ -1016,6 +1030,7 @@ function openProjectCreator() {
   projectCreateBusy.value = false
   projectCreateSourcePicking.value = false
   projectCreateConfirming.value = false
+  projectSourcePickerOpen.value = false
   projectCreateOpen.value = true
 }
 
@@ -1032,29 +1047,29 @@ function onProjectPathChosen(path: string) {
   }
 }
 
+function onProjectSourcePathChosen(path: string) {
+  projectSourcePickerOpen.value = false
+  onProjectPathChosen(path)
+}
+
 async function chooseProjectSourceDirectory() {
   if (
     !projectCreateOpen.value
     || !rpcStore.canChooseProject
     || projectCreateBusy.value
     || projectCreateSourcePicking.value
+    || projectSourcePickerOpen.value
   ) return
+
+  const nativePicker = getPlatform().files.chooseProjectDirectory
+  if (typeof nativePicker !== 'function') {
+    projectSourcePickerOpen.value = true
+    return
+  }
 
   projectCreateSourcePicking.value = true
   try {
-    const nativePicker = getPlatform().files.chooseProjectDirectory
-    const choice = typeof nativePicker === 'function'
-      ? await nativePicker()
-      : await rpcStore.call<{ path: string | null }>(
-          'sandbox.path.pick',
-          {
-            sessionKey: currentSessionKey.value || 'agent:main:webchat:workspace-picker',
-            kind: 'workspace',
-            ...(projectCreateSourcePath.value.trim()
-              ? { initialPath: projectCreateSourcePath.value.trim() }
-              : {}),
-          },
-        )
+    const choice = await nativePicker()
     const selected = String(choice?.path || '').trim()
     if (selected) onProjectPathChosen(selected)
   } catch (err) {
@@ -1072,6 +1087,7 @@ async function createProjectWorkspace(payload: { name: string; path: string }) {
     || !rpcStore.canChooseProject
     || projectCreateBusy.value
     || projectCreateSourcePicking.value
+    || projectSourcePickerOpen.value
   ) return
   const name = payload.name.trim()
   const path = payload.path.trim()

--- a/opensquilla-webui/src/assets/base.css
+++ b/opensquilla-webui/src/assets/base.css
@@ -1125,18 +1125,20 @@ pre {
   transition: opacity var(--dur-fast), background var(--dur-fast), color var(--dur-fast);
 }
 
-.sidebar-project-action--new-task {
-  opacity: 0.68;
-}
-
+.sidebar-project-action--new-task,
 .sidebar-project-action--new-task:disabled {
-  opacity: 0.28;
+  opacity: 0;
 }
 
 .sidebar-history-row--workspace:hover .sidebar-project-action,
 .sidebar-history-row--workspace:focus-within .sidebar-project-action,
 .sidebar-project-action[aria-expanded='true'] {
   opacity: 1;
+}
+
+.sidebar-history-row--workspace:hover .sidebar-project-action--new-task:disabled,
+.sidebar-history-row--workspace:focus-within .sidebar-project-action--new-task:disabled {
+  opacity: 0.34;
 }
 
 .sidebar-workspace-empty {
@@ -1179,6 +1181,33 @@ pre {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: 400;
+}
+
+.sidebar-project-create-btn {
+  width: 24px;
+  height: 24px;
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--sidebar-text-soft);
+  cursor: pointer;
+  transition: background var(--dur-fast), color var(--dur-fast);
+}
+
+.sidebar-project-create-btn:hover,
+.sidebar-project-create-btn:focus-visible {
+  background: var(--sidebar-item-hover);
+  color: var(--sidebar-text-strong);
+}
+
+.sidebar-project-create-btn + .sidebar-cmd-btn {
+  margin-left: 0;
 }
 
 .sidebar-history-row.is-selected .sidebar-history-item {

--- a/opensquilla-webui/src/assets/base.css
+++ b/opensquilla-webui/src/assets/base.css
@@ -708,6 +708,10 @@ pre {
   line-height: 20px;
 }
 
+.sidebar-recents-eyebrow + .sidebar-cmd-btn {
+  margin-left: auto;
+}
+
 .sidebar-history.is-selecting .sidebar-recents-eyebrow {
   color: var(--sidebar-text);
   letter-spacing: 0;
@@ -905,23 +909,6 @@ pre {
   font-weight: 500;
 }
 
-.sidebar-history-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-/* Spectral status dots: each run-state reads its own calibrated channel.
-   running reuses the strike (orange) with the live pulse; queued is the new
-   indigo channel; idle/cancelled stay quiet. */
-.sidebar-history-dot.status--idle { background: var(--sidebar-text-soft); }
-.sidebar-history-dot.status--running { background: var(--accent); animation: live-pulse var(--dur-pulse) var(--ease-standard) infinite; }
-.sidebar-history-dot.status--queued { background: var(--queued); }
-.sidebar-history-dot.status--interrupted { background: var(--warn-fill); }
-.sidebar-history-dot.status--failed { background: var(--danger); }
-.sidebar-history-dot.status--timeout { background: var(--danger); }
-.sidebar-history-dot.status--cancelled { background: var(--sidebar-text-soft); }
-
 @keyframes pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
@@ -969,6 +956,51 @@ pre {
 
 .sidebar-history-row--workspace {
   margin-top: var(--sp-2);
+}
+
+/* Project work stays grouped under its folder. The first unbound task opens a
+   second, deliberately separated "Recents" zone without introducing another
+   card or divider line into the quiet sidebar surface. */
+.sidebar-history-row--recent-start {
+  margin-top: 43px;
+}
+
+.sidebar-history-row--recent-start::before {
+  content: attr(data-zone-label);
+  position: absolute;
+  top: -35px;
+  left: calc(4px - var(--row-depth, 0) * 14px);
+  right: 4px;
+  display: flex;
+  align-items: center;
+  min-height: 28px;
+  color: var(--sidebar-text-soft);
+  font-size: var(--fs-sm);
+  font-weight: 400;
+  line-height: 20px;
+  pointer-events: none;
+}
+
+.sidebar-zone-empty {
+  margin-top: 13px;
+  padding: 0 4px 8px;
+}
+
+.sidebar-zone-empty__label {
+  display: flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 6px;
+  color: var(--sidebar-text-soft);
+  font-size: var(--fs-sm);
+  font-weight: 400;
+  line-height: 20px;
+}
+
+.sidebar-zone-empty__body {
+  padding: 6px 10px;
+  color: var(--sidebar-text-soft);
+  font-size: var(--fs-xs);
 }
 
 .sidebar-workspace-header {
@@ -1093,6 +1125,14 @@ pre {
   transition: opacity var(--dur-fast), background var(--dur-fast), color var(--dur-fast);
 }
 
+.sidebar-project-action--new-task {
+  opacity: 0.68;
+}
+
+.sidebar-project-action--new-task:disabled {
+  opacity: 0.28;
+}
+
 .sidebar-history-row--workspace:hover .sidebar-project-action,
 .sidebar-history-row--workspace:focus-within .sidebar-project-action,
 .sidebar-project-action[aria-expanded='true'] {
@@ -1112,8 +1152,25 @@ pre {
   min-height: 26px;
 }
 
-.sidebar-project-menu {
-  min-width: 210px;
+.sidebar-row-menu.sidebar-project-menu {
+  min-width: 152px;
+  padding: 5px;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+}
+
+.sidebar-project-menu .sidebar-row-menu__item {
+  min-height: 30px;
+  gap: 7px;
+  padding: 5px 8px;
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.sidebar-project-menu .sidebar-row-menu__item > svg {
+  flex: 0 0 auto;
+  opacity: 0.78;
 }
 
 .sidebar-workspace-label {
@@ -1121,6 +1178,7 @@ pre {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-weight: 400;
 }
 
 .sidebar-history-row.is-selected .sidebar-history-item {

--- a/opensquilla-webui/src/components/ProjectWorkspaceCreateDialog.test.ts
+++ b/opensquilla-webui/src/components/ProjectWorkspaceCreateDialog.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
+import { createI18n } from 'vue-i18n'
+import ProjectWorkspaceCreateDialog from './ProjectWorkspaceCreateDialog.vue'
+
+const mountedApps: App<Element>[] = []
+
+function i18n() {
+  return createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: {
+      en: {
+        common: { close: 'Close', cancel: 'Cancel' },
+        workspaces: {
+          createProject: 'Create project',
+          projectName: 'Project name',
+          projectNamePlaceholder: 'Project name',
+          sourceFolders: 'Source folders',
+          addSourceFolder: 'Add a folder OpenSquilla can read and edit',
+          creatingProject: 'Creating…',
+        },
+      },
+    },
+  })
+}
+
+async function mountDialog(options: { name?: string; sourcePath?: string; busy?: boolean } = {}) {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const name = ref(options.name || '')
+  const chooseSource = vi.fn()
+  const create = vi.fn()
+  const close = vi.fn()
+  const Root = defineComponent(() => () => h(ProjectWorkspaceCreateDialog, {
+    open: true,
+    name: name.value,
+    sourcePath: options.sourcePath || '',
+    busy: options.busy || false,
+    'onUpdate:name': (value: string) => { name.value = value },
+    onChooseSource: chooseSource,
+    onCreate: create,
+    onClose: close,
+  }))
+  const app = createApp(Root)
+  app.use(i18n())
+  app.mount(host)
+  mountedApps.push(app)
+  await nextTick()
+  return { name, chooseSource, create, close }
+}
+
+afterEach(() => {
+  mountedApps.splice(0).forEach(app => app.unmount())
+  document.body.innerHTML = ''
+})
+
+describe('ProjectWorkspaceCreateDialog', () => {
+  it('collects a project name and source folder before creating', async () => {
+    const events = await mountDialog({
+      name: 'Demo',
+      sourcePath: '/repos/demo',
+    })
+    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')
+    const source = dialog?.querySelector<HTMLButtonElement>('.project-create__source-picker')
+    const create = Array.from(dialog?.querySelectorAll<HTMLButtonElement>('button') || [])
+      .find(button => button.textContent?.trim() === 'Create project')
+
+    expect(dialog?.textContent).toContain('Source folders')
+    expect(dialog?.textContent).toContain('/repos/demo')
+    expect(create?.disabled).toBe(false)
+
+    source?.click()
+    create?.click()
+    await nextTick()
+
+    expect(events.chooseSource).toHaveBeenCalledOnce()
+    expect(events.create).toHaveBeenCalledWith({ name: 'Demo', path: '/repos/demo' })
+  })
+
+  it('keeps creation disabled until both fields are present', async () => {
+    await mountDialog()
+    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')
+    const create = Array.from(dialog?.querySelectorAll<HTMLButtonElement>('button') || [])
+      .find(button => button.textContent?.trim() === 'Create project')
+
+    expect(create?.disabled).toBe(true)
+  })
+})

--- a/opensquilla-webui/src/components/ProjectWorkspaceCreateDialog.test.ts
+++ b/opensquilla-webui/src/components/ProjectWorkspaceCreateDialog.test.ts
@@ -26,7 +26,12 @@ function i18n() {
   })
 }
 
-async function mountDialog(options: { name?: string; sourcePath?: string; busy?: boolean } = {}) {
+async function mountDialog(options: {
+  name?: string
+  sourcePath?: string
+  busy?: boolean
+  sourcePicking?: boolean
+} = {}) {
   const host = document.createElement('div')
   document.body.appendChild(host)
   const name = ref(options.name || '')
@@ -38,6 +43,7 @@ async function mountDialog(options: { name?: string; sourcePath?: string; busy?:
     name: name.value,
     sourcePath: options.sourcePath || '',
     busy: options.busy || false,
+    sourcePicking: options.sourcePicking || false,
     'onUpdate:name': (value: string) => { name.value = value },
     onChooseSource: chooseSource,
     onCreate: create,
@@ -86,5 +92,27 @@ describe('ProjectWorkspaceCreateDialog', () => {
       .find(button => button.textContent?.trim() === 'Create project')
 
     expect(create?.disabled).toBe(true)
+  })
+
+  it('prevents duplicate folder picks and creation while the system picker is open', async () => {
+    const events = await mountDialog({
+      name: 'Demo',
+      sourcePath: '/repos/demo',
+      sourcePicking: true,
+    })
+    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')
+    const source = dialog?.querySelector<HTMLButtonElement>('.project-create__source-picker')
+    const create = Array.from(dialog?.querySelectorAll<HTMLButtonElement>('button') || [])
+      .find(button => button.textContent?.trim() === 'Create project')
+
+    expect(source?.disabled).toBe(true)
+    expect(create?.disabled).toBe(true)
+
+    source?.click()
+    create?.click()
+    await nextTick()
+
+    expect(events.chooseSource).not.toHaveBeenCalled()
+    expect(events.create).not.toHaveBeenCalled()
   })
 })

--- a/opensquilla-webui/src/components/ProjectWorkspaceCreateDialog.vue
+++ b/opensquilla-webui/src/components/ProjectWorkspaceCreateDialog.vue
@@ -1,0 +1,269 @@
+<template>
+  <Teleport to="body">
+    <div v-if="open" class="modal-overlay" @click="close">
+      <form
+        ref="dialogRef"
+        class="modal project-create"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="project-workspace-create-title"
+        @click.stop
+        @submit.prevent="create"
+      >
+        <header class="project-create__header">
+          <h3 id="project-workspace-create-title">{{ t('workspaces.createProject') }}</h3>
+          <button
+            type="button"
+            class="btn btn--icon btn--ghost"
+            :aria-label="t('common.close')"
+            :disabled="busy"
+            @click="close"
+          >
+            <Icon name="x" :size="15" />
+          </button>
+        </header>
+
+        <label class="project-create__name">
+          <span class="sr-only">{{ t('workspaces.projectName') }}</span>
+          <span class="project-create__input-wrap">
+            <Icon name="folder" :size="16" />
+            <input
+              ref="nameInputRef"
+              :value="name"
+              type="text"
+              maxlength="120"
+              autocomplete="off"
+              :placeholder="t('workspaces.projectNamePlaceholder')"
+              :disabled="busy"
+              @input="updateName"
+            />
+          </span>
+        </label>
+
+        <div class="project-create__source">
+          <span class="project-create__source-label">{{ t('workspaces.sourceFolders') }}</span>
+          <button
+            type="button"
+            class="project-create__source-picker"
+            :disabled="busy"
+            @click="emit('choose-source')"
+          >
+            <Icon name="folder" :size="21" />
+            <span v-if="sourcePath" class="project-create__source-copy">
+              <strong>{{ sourceName }}</strong>
+              <small>{{ sourcePath }}</small>
+            </span>
+            <span v-else>{{ t('workspaces.addSourceFolder') }}</span>
+          </button>
+        </div>
+
+        <footer class="project-create__footer">
+          <button type="button" class="btn btn--ghost" :disabled="busy" @click="close">
+            {{ t('common.cancel') }}
+          </button>
+          <button type="submit" class="btn btn--primary" :disabled="!canCreate">
+            {{ busy ? t('workspaces.creatingProject') : t('workspaces.createProject') }}
+          </button>
+        </footer>
+      </form>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Icon from '@/components/Icon.vue'
+import { useDialogA11y } from '@/composables/useDialogA11y'
+
+const props = defineProps<{
+  open: boolean
+  name: string
+  sourcePath: string
+  busy: boolean
+}>()
+const emit = defineEmits<{
+  close: []
+  'update:name': [name: string]
+  'choose-source': []
+  create: [payload: { name: string; path: string }]
+}>()
+const { t } = useI18n()
+const dialogRef = ref<HTMLElement | null>(null)
+const nameInputRef = ref<HTMLInputElement | null>(null)
+
+const sourceName = computed(() => {
+  const normalized = props.sourcePath.replace(/[\\/]+$/, '')
+  return normalized.split(/[\\/]/).pop() || normalized
+})
+const canCreate = computed(() =>
+  !props.busy && Boolean(props.name.trim()) && Boolean(props.sourcePath.trim()),
+)
+
+function updateName(event: Event) {
+  emit('update:name', (event.target as HTMLInputElement).value)
+}
+
+function close() {
+  if (!props.busy) emit('close')
+}
+
+function create() {
+  if (!canCreate.value) return
+  emit('create', {
+    name: props.name.trim(),
+    path: props.sourcePath.trim(),
+  })
+}
+
+useDialogA11y(dialogRef, computed(() => props.open), close, {
+  initialFocus: nameInputRef,
+})
+</script>
+
+<style scoped>
+.sr-only {
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: grid;
+  place-items: center;
+  background: var(--scrim);
+}
+
+.project-create {
+  width: min(94vw, 520px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+  padding: var(--sp-5);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-modal);
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.project-create__header,
+.project-create__footer {
+  display: flex;
+  align-items: center;
+}
+
+.project-create__header h3 {
+  flex: 1;
+  margin: 0;
+  font-size: var(--fs-xl);
+}
+
+.project-create__name {
+  display: block;
+}
+
+.project-create__input-wrap {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: 0 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  background: var(--bg);
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.project-create__input-wrap:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+.project-create__input-wrap input {
+  width: 100%;
+  min-width: 0;
+  min-height: 40px;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+}
+
+.project-create__source {
+  display: grid;
+  gap: var(--sp-2);
+}
+
+.project-create__source-label {
+  color: var(--text);
+  font-size: var(--fs-sm);
+}
+
+.project-create__source-picker {
+  min-height: 98px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-3);
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: border-color var(--transition), background var(--transition), color var(--transition);
+}
+
+.project-create__source-picker:not(:disabled):hover,
+.project-create__source-picker:not(:disabled):focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.project-create__source-picker:disabled {
+  cursor: not-allowed;
+  opacity: var(--state-disabled-opacity);
+}
+
+.project-create__source-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+  text-align: left;
+}
+
+.project-create__source-copy strong,
+.project-create__source-copy small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-create__source-copy strong {
+  color: var(--text);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+}
+
+.project-create__source-copy small {
+  max-width: 390px;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+}
+
+.project-create__footer {
+  justify-content: flex-end;
+  gap: var(--sp-2);
+}
+</style>

--- a/opensquilla-webui/src/components/ProjectWorkspaceCreateDialog.vue
+++ b/opensquilla-webui/src/components/ProjectWorkspaceCreateDialog.vue
@@ -45,7 +45,7 @@
           <button
             type="button"
             class="project-create__source-picker"
-            :disabled="busy"
+            :disabled="busy || sourcePicking"
             @click="emit('choose-source')"
           >
             <Icon name="folder" :size="21" />
@@ -81,6 +81,7 @@ const props = defineProps<{
   name: string
   sourcePath: string
   busy: boolean
+  sourcePicking?: boolean
 }>()
 const emit = defineEmits<{
   close: []
@@ -97,7 +98,10 @@ const sourceName = computed(() => {
   return normalized.split(/[\\/]/).pop() || normalized
 })
 const canCreate = computed(() =>
-  !props.busy && Boolean(props.name.trim()) && Boolean(props.sourcePath.trim()),
+  !props.busy
+  && !props.sourcePicking
+  && Boolean(props.name.trim())
+  && Boolean(props.sourcePath.trim()),
 )
 
 function updateName(event: Event) {
@@ -185,10 +189,10 @@ useDialogA11y(dialogRef, computed(() => props.open), close, {
 
 .project-create__input-wrap:focus-within {
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 14%, transparent);
+  box-shadow: none;
 }
 
-.project-create__input-wrap input {
+.project-create__input-wrap input:not([type="radio"]):not([type="checkbox"]) {
   width: 100%;
   min-width: 0;
   min-height: 40px;
@@ -196,6 +200,13 @@ useDialogA11y(dialogRef, computed(() => props.open), close, {
   border: 0;
   outline: 0;
   background: transparent;
+  box-shadow: none;
+}
+
+.project-create__input-wrap input:not([type="radio"]):not([type="checkbox"]):focus {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
 }
 
 .project-create__source {
@@ -209,14 +220,14 @@ useDialogA11y(dialogRef, computed(() => props.open), close, {
 }
 
 .project-create__source-picker {
-  min-height: 98px;
+  min-height: 82px;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: var(--sp-3);
   padding: 16px;
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background: var(--bg);
   color: var(--text-muted);
   cursor: pointer;
@@ -225,9 +236,11 @@ useDialogA11y(dialogRef, computed(() => props.open), close, {
 
 .project-create__source-picker:not(:disabled):hover,
 .project-create__source-picker:not(:disabled):focus-visible {
-  border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
+  border-color: var(--border-strong);
   background: var(--bg-hover);
   color: var(--text);
+  outline: none;
+  box-shadow: none;
 }
 
 .project-create__source-picker:disabled {

--- a/opensquilla-webui/src/components/SidebarConversations.vue
+++ b/opensquilla-webui/src/components/SidebarConversations.vue
@@ -55,8 +55,10 @@ const props = withDefaults(defineProps<{
   /** Command-palette chord, shown in the search button's tooltip. */
   searchHint: string
   canManageProjects?: boolean
+  canCreateProjects?: boolean
 }>(), {
   canManageProjects: true,
+  canCreateProjects: true,
 })
 
 const emit = defineEmits<{
@@ -66,6 +68,7 @@ const emit = defineEmits<{
   (e: 'delete', key: string): void
   (e: 'bulk-delete', keys: string[]): void
   (e: 'new-chat'): void
+  (e: 'new-project'): void
   (e: 'new-project-task', workspaceId: string): void
   (e: 'project-pin', payload: { workspaceId: string; pinned: boolean }): void
   (e: 'project-edit', workspaceId: string): void
@@ -249,7 +252,6 @@ const projectRowKeys = computed(() => {
 })
 
 const firstRecentRowKey = computed(() => {
-  if (visibleProjectCount.value === 0) return ''
   for (const section of visibleSections.value) {
     const row = section.rows.find(item =>
       item.rowKind === 'session' && !projectRowKeys.value.has(item.key),
@@ -562,7 +564,7 @@ function onSelectRow(row: SidebarConversationItem) {
 
 <template>
   <div
-    v-if="error || totalRows > 0 || visibleProjectCount > 0"
+    v-if="error || totalRows > 0 || visibleProjectCount > 0 || props.canManageProjects"
     class="sidebar-section sidebar-history"
     :class="{
       'is-selecting': selectionMode,
@@ -577,7 +579,7 @@ function onSelectRow(row: SidebarConversationItem) {
             ? selectedCount > 0
               ? t('shared.sidebar.selectedCountLabel', { count: selectedCount })
               : t('shared.sidebar.selectionModeLabel')
-            : visibleProjectCount > 0
+            : props.canManageProjects
               ? t('workspaces.projects')
               : t('shared.sidebar.recents')
         }}
@@ -586,6 +588,17 @@ function onSelectRow(row: SidebarConversationItem) {
         v-if="!selectionMode && visibleProjectCount === 0 && totalRows > 0"
         class="sidebar-recents-count"
       >{{ totalRows }}</span>
+      <button
+        v-if="!selectionMode && props.canManageProjects && props.canCreateProjects"
+        type="button"
+        class="sidebar-project-create-btn"
+        data-testid="sidebar-create-project"
+        :aria-label="t('workspaces.createProject')"
+        :title="t('workspaces.createProject')"
+        @click="emit('new-project')"
+      >
+        <Icon name="plus" :size="13" />
+      </button>
       <!-- Conversation search lives on the recents header, beside the selection
            and refresh controls, because the palette's hits are these rows.
            Hidden while selecting: that mode owns the header's spare width. -->

--- a/opensquilla-webui/src/components/SidebarConversations.vue
+++ b/opensquilla-webui/src/components/SidebarConversations.vue
@@ -57,8 +57,8 @@ const props = withDefaults(defineProps<{
   canManageProjects?: boolean
   canCreateProjects?: boolean
 }>(), {
-  canManageProjects: true,
-  canCreateProjects: true,
+  canManageProjects: false,
+  canCreateProjects: false,
 })
 
 const emit = defineEmits<{

--- a/opensquilla-webui/src/components/SidebarConversations.vue
+++ b/opensquilla-webui/src/components/SidebarConversations.vue
@@ -166,6 +166,15 @@ function toggleProject(row: SidebarConversationItem) {
   writeSidebarCollapsedState(next)
 }
 
+function startProjectTask(row: SidebarConversationItem) {
+  if (!row.workspaceId || row.workspaceAvailable === false) return
+  const key = projectCollapseKey(row.workspaceId)
+  const next = { ...collapsed.value, [key]: false }
+  collapsed.value = next
+  writeSidebarCollapsedState(next)
+  emit('new-project-task', row.workspaceId)
+}
+
 function filterCollapsedProjectRows(rows: SidebarConversationItem[]): SidebarConversationItem[] {
   const hiddenProjects = new Set<string>()
   const result: SidebarConversationItem[] = []
@@ -190,16 +199,81 @@ const visibleSections = computed(() => {
         : section.rows
       return {
         ...section,
-        rows: filterCollapsedProjectRows(filteredRows),
+        rows: filterCollapsedProjectRows(filteredRows)
+          .filter(row => row.rowKind !== 'workspace-empty'),
       }
     })
     .filter(section => section.rows.length > 0)
 })
 
+const visibleProjectCount = computed(() =>
+  visibleSections.value.reduce(
+    (sum, section) => sum + section.rows.filter(row => row.rowKind === 'workspace').length,
+    0,
+  ),
+)
+
+/**
+ * `arrangeSidebarSections` emits project rows as a small ordered ledger:
+ * a workspace header followed by its task rows. Track those task keys without
+ * treating every session cwd as a project — ordinary tasks can still carry a
+ * workspace path even when they are not bound to a persisted project.
+ */
+const projectRowKeys = computed(() => {
+  const keys = new Set<string>()
+  const chats = props.sections.find(section => section.family === 'chats')
+  let project: SidebarConversationItem | null = null
+
+  for (const row of chats?.rows || []) {
+    if (row.rowKind === 'workspace') {
+      project = row
+      keys.add(row.key)
+      continue
+    }
+    if (row.rowKind === 'workspace-empty') {
+      if (project) keys.add(row.key)
+      continue
+    }
+    const belongsToProject = Boolean(
+      project
+      && (
+        project.workspaceId
+          ? row.workspaceId === project.workspaceId
+          : Boolean(project.workspace && row.workspace === project.workspace)
+      ),
+    )
+    if (belongsToProject) keys.add(row.key)
+    else project = null
+  }
+  return keys
+})
+
+const firstRecentRowKey = computed(() => {
+  if (visibleProjectCount.value === 0) return ''
+  for (const section of visibleSections.value) {
+    const row = section.rows.find(item =>
+      item.rowKind === 'session' && !projectRowKeys.value.has(item.key),
+    )
+    if (row) return row.key
+  }
+  return ''
+})
+
+const hasVisibleRecentRows = computed(() =>
+  visibleSections.value.some(section =>
+    section.rows.some(row =>
+      row.rowKind === 'session' && !projectRowKeys.value.has(row.key),
+    ),
+  ),
+)
+
 // Total rendered rows: drives the onboarding empty-state and the filter's
 // "No matches" message separately from a true first-run empty list.
 const totalRows = computed(() =>
-  props.sections.reduce((sum, section) => sum + section.rows.filter(row => !isWorkspaceRow(row)).length, 0),
+  props.sections.reduce(
+    (sum, section) => sum + section.rows.filter(row => row.rowKind === 'session').length,
+    0,
+  ),
 )
 
 const hasFilterMatches = computed(() =>
@@ -213,7 +287,9 @@ const selectionMode = ref(false)
 
 const visibleSelectableRows = computed(() =>
   visibleSections.value.flatMap(section =>
-    isCollapsed(section.family) ? [] : section.rows.filter(row => row.rowKind === 'session'),
+    isCollapsed(section.family)
+      ? []
+      : section.rows.filter(row => row.rowKind === 'session' && !row.provisional),
   ),
 )
 
@@ -333,11 +409,17 @@ function toggleMenu(key: string, event?: Event) {
   if (menuTriggerEl.value) {
     const r = menuTriggerEl.value.getBoundingClientRect()
     const openUp = r.bottom + 220 > window.innerHeight
+    const isProjectMenu = Boolean(
+      menuTriggerEl.value.closest('.sidebar-history-row--workspace'),
+    )
+    const openProjectMenuRight = isProjectMenu && r.right + 160 < window.innerWidth
     menuStyle.value = {
       position: 'fixed',
-      left: `${r.right}px`,
+      left: `${openProjectMenuRight ? r.right + 6 : r.right}px`,
       top: `${openUp ? r.top : r.bottom + 4}px`,
-      transform: openUp ? 'translate(-100%, -100%)' : 'translateX(-100%)',
+      transform: openProjectMenuRight
+        ? (openUp ? 'translateY(-100%)' : 'none')
+        : (openUp ? 'translate(-100%, -100%)' : 'translateX(-100%)'),
     }
   }
   // Move focus into the menu so keyboard users land on an actionable item.
@@ -468,6 +550,7 @@ function emitProjectRemove(row: SidebarConversationItem) {
 
 function onSelectRow(row: SidebarConversationItem) {
   if (row.rowKind !== 'session') return
+  if (row.provisional) return
   if (renamingKey.value === row.key) return
   if (selectionMode.value) {
     setRowSelected(row.key, !isRowSelected(row.key))
@@ -479,9 +562,12 @@ function onSelectRow(row: SidebarConversationItem) {
 
 <template>
   <div
-    v-if="error || totalRows > 0"
+    v-if="error || totalRows > 0 || visibleProjectCount > 0"
     class="sidebar-section sidebar-history"
-    :class="{ 'is-selecting': selectionMode }"
+    :class="{
+      'is-selecting': selectionMode,
+      'has-projects': visibleProjectCount > 0,
+    }"
     :aria-label="t('shared.sidebar.recentConversations')"
   >
     <div class="sidebar-recents-header">
@@ -491,13 +577,13 @@ function onSelectRow(row: SidebarConversationItem) {
             ? selectedCount > 0
               ? t('shared.sidebar.selectedCountLabel', { count: selectedCount })
               : t('shared.sidebar.selectionModeLabel')
-            : visibleSections.length === 1
-              ? visibleSections[0].label
+            : visibleProjectCount > 0
+              ? t('workspaces.projects')
               : t('shared.sidebar.recents')
         }}
       </span>
       <span
-        v-if="!selectionMode && visibleSections.length === 1 && totalRows > 0"
+        v-if="!selectionMode && visibleProjectCount === 0 && totalRows > 0"
         class="sidebar-recents-count"
       >{{ totalRows }}</span>
       <!-- Conversation search lives on the recents header, beside the selection
@@ -627,9 +713,12 @@ function onSelectRow(row: SidebarConversationItem) {
               'is-selected': row.rowKind === 'session' && isRowSelected(row.key),
               'sidebar-history-row--workspace': row.rowKind === 'workspace',
               'sidebar-history-row--workspace-empty': row.rowKind === 'workspace-empty',
+              'sidebar-history-row--recent-start': row.key === firstRecentRowKey,
               'is-unavailable': row.rowKind === 'workspace' && row.workspaceAvailable === false,
             }"
             :data-family="section.family"
+            :data-sidebar-zone="projectRowKeys.has(row.key) ? 'projects' : 'recents'"
+            :data-zone-label="row.key === firstRecentRowKey ? t('shared.sidebar.recents') : undefined"
             :data-depth="row.depth"
             :data-session-key="row.rowKind === 'session' ? row.key : undefined"
             :style="{ '--row-depth': row.depth }"
@@ -677,7 +766,7 @@ function onSelectRow(row: SidebarConversationItem) {
               >
                 <button
                   type="button"
-                  class="sidebar-project-action"
+                  class="sidebar-project-action sidebar-project-action--new-task"
                   data-testid="project-workspace-new-task"
                   :aria-label="row.workspaceAvailable === false
                     ? t('workspaces.unavailableProjectCannotStartTask')
@@ -686,11 +775,9 @@ function onSelectRow(row: SidebarConversationItem) {
                     ? t('workspaces.unavailableProjectCannotStartTask')
                     : t('workspaces.newTask')"
                   :disabled="row.workspaceAvailable === false"
-                  @click.stop="row.workspaceAvailable !== false
-                    && row.workspaceId
-                    && emit('new-project-task', row.workspaceId)"
+                  @click.stop="startProjectTask(row)"
                 >
-                  <Icon name="pencil" :size="13" />
+                  <Icon name="plus" :size="13" />
                 </button>
                 <button
                   type="button"
@@ -738,24 +825,17 @@ function onSelectRow(row: SidebarConversationItem) {
               class="sidebar-history-item"
               :class="{ 'is-current': row.key === currentKey }"
               :title="row.title"
-              :aria-pressed="selectionMode ? isRowSelected(row.key) : undefined"
+              :aria-pressed="selectionMode && !row.provisional ? isRowSelected(row.key) : undefined"
               @click="onSelectRow(row)"
             >
               <span
-                v-if="selectionMode"
+                v-if="selectionMode && !row.provisional"
                 class="sidebar-selection-box"
                 :class="{ 'is-checked': isRowSelected(row.key) }"
                 aria-hidden="true"
               >
                 <Icon v-if="isRowSelected(row.key)" name="check" :size="11" />
               </span>
-              <span
-                v-else
-                class="sidebar-history-dot"
-                :class="`status--${row.runStatus}`"
-                role="img"
-                :aria-label="t('shared.sidebar.statusLabel', { status: row.runLabel })"
-              />
               <span class="sidebar-history-title">{{ row.title }}</span>
               <span
                 v-if="contractDebugEnabled && row.hasContractGaps"
@@ -788,7 +868,7 @@ function onSelectRow(row: SidebarConversationItem) {
                   role="menuitem"
                   @click.stop="emitProjectPin(row)"
                 >
-                  <Icon name="arrowUp" :size="14" />
+                  <Icon name="arrowUp" :size="13" />
                   <span>{{ row.workspacePinned ? t('workspaces.unpin') : t('workspaces.pin') }}</span>
                 </button>
                 <button
@@ -798,18 +878,18 @@ function onSelectRow(row: SidebarConversationItem) {
                   role="menuitem"
                   @click.stop="emitProjectEdit(row)"
                 >
-                  <Icon name="pencil" :size="14" />
+                  <Icon name="pencil" :size="13" />
                   <span>{{ t('workspaces.editProject') }}</span>
                 </button>
                 <button
                   type="button"
-                  class="sidebar-row-menu__item sidebar-row-menu__item--danger"
+                  class="sidebar-row-menu__item"
                   data-project-action="delete-history"
                   role="menuitem"
                   @click.stop="requestProjectHistoryDelete(row)"
                 >
-                  <Icon name="trash" :size="14" />
-                  <span>{{ t('workspaces.deleteHistory') }}</span>
+                  <Icon name="trash" :size="13" />
+                  <span>{{ t('workspaces.menuDeleteHistory') }}</span>
                 </button>
                 <button
                   type="button"
@@ -818,14 +898,20 @@ function onSelectRow(row: SidebarConversationItem) {
                   role="menuitem"
                   @click.stop="emitProjectRemove(row)"
                 >
-                  <Icon name="x" :size="14" />
-                  <span>{{ t('workspaces.removeProject') }}</span>
+                  <Icon name="x" :size="13" />
+                  <span>{{ t('workspaces.menuRemove') }}</span>
                 </button>
               </div>
             </Teleport>
 
             <div
-              v-if="row.rowKind === 'session' && row.sessionKind === 'chat' && renamingKey !== row.key && !selectionMode"
+              v-if="
+                row.rowKind === 'session'
+                && row.sessionKind === 'chat'
+                && !row.provisional
+                && renamingKey !== row.key
+                && !selectionMode
+              "
               class="sidebar-row-menu-wrap"
             >
               <button
@@ -873,7 +959,13 @@ function onSelectRow(row: SidebarConversationItem) {
 
             <!-- Agent-initial badge: indicator + click-to-filter (Chats only) -->
             <button
-              v-else-if="row.rowKind === 'session' && shouldShowAgentFilterBadge(section.family, row) && renamingKey !== row.key && !selectionMode"
+              v-else-if="
+                row.rowKind === 'session'
+                && !row.provisional
+                && shouldShowAgentFilterBadge(section.family, row)
+                && renamingKey !== row.key
+                && !selectionMode
+              "
               type="button"
               class="sidebar-agent-badge"
               :class="{ 'is-active': agentFilter === row.effectiveAgentId }"
@@ -886,6 +978,13 @@ function onSelectRow(row: SidebarConversationItem) {
             </button>
           </div>
         </TransitionGroup>
+      </div>
+      <div
+        v-if="visibleProjectCount > 0 && !hasVisibleRecentRows"
+        class="sidebar-zone-empty"
+      >
+        <div class="sidebar-zone-empty__label">{{ t('shared.sidebar.recents') }}</div>
+        <div class="sidebar-zone-empty__body">{{ t('shared.sidebar.noConversations') }}</div>
       </div>
     </div>
   </div>

--- a/opensquilla-webui/src/components/SidebarConversations.workspaces.test.ts
+++ b/opensquilla-webui/src/components/SidebarConversations.workspaces.test.ts
@@ -66,7 +66,8 @@ function i18n() {
         shared: {
           sidebar: {
             recentConversations: 'Recent tasks',
-            recents: 'Tasks',
+            recents: 'Recents',
+            noConversations: 'No tasks yet.',
             refresh: 'Refresh',
             enterSelectionMode: 'Select tasks',
             rowActions: 'Actions for {title}',
@@ -76,6 +77,7 @@ function i18n() {
           },
         },
         workspaces: {
+          projects: 'Projects',
           projectInfo: '{path}; {count} tasks',
           taskCount: '{count} tasks',
           newTask: 'New project task',
@@ -86,6 +88,8 @@ function i18n() {
           editProject: 'Edit project',
           deleteHistory: 'Delete project task history',
           removeProject: 'Remove project',
+          menuDeleteHistory: 'Delete history',
+          menuRemove: 'Remove',
           deleteHistoryTitle: 'Delete project task history?',
           deleteHistoryBody: 'Delete {count} tasks from {name}.',
           deleteHistoryConfirm: 'Delete history',
@@ -142,6 +146,45 @@ afterEach(() => {
 })
 
 describe('SidebarConversations project workspaces', () => {
+  it('separates project work from ordinary recent tasks', async () => {
+    const { host } = await mountSidebar([
+      projectRow(),
+      taskRow(),
+      taskRow({
+        key: 'agent:main:webchat:ordinary',
+        title: 'Ordinary task',
+        depth: 0,
+        workspaceId: undefined,
+      }),
+    ])
+
+    expect(host.querySelector('.sidebar-recents-eyebrow')?.textContent?.trim()).toBe('Projects')
+    expect(
+      host.querySelector('[data-session-key="agent:main:webchat:task-a"]')
+        ?.getAttribute('data-sidebar-zone'),
+    ).toBe('projects')
+    const ordinary = host.querySelector('[data-session-key="agent:main:webchat:ordinary"]')
+    expect(ordinary?.getAttribute('data-sidebar-zone')).toBe('recents')
+    expect(ordinary?.getAttribute('data-zone-label')).toBe('Recents')
+  })
+
+  it('keeps an empty project compact and gives recents its own empty state', async () => {
+    const { host } = await mountSidebar([
+      projectRow({ workspaceTaskCount: 0 }),
+      {
+        ...taskRow(),
+        rowKind: 'workspace-empty',
+        key: 'workspace:project-a:empty',
+        title: 'No tasks',
+        sessionKind: 'workspace-empty',
+      },
+    ])
+
+    expect(host.querySelector('.sidebar-workspace-empty')).toBeNull()
+    expect(host.querySelector('.sidebar-zone-empty__label')?.textContent).toBe('Recents')
+    expect(host.querySelector('.sidebar-zone-empty__body')?.textContent).toBe('No tasks yet.')
+  })
+
   it('toggles a project without selecting it and keeps project details visible', async () => {
     const { host, events } = await mountSidebar([projectRow(), taskRow()])
     const disclosure = host.querySelector<HTMLButtonElement>('[data-testid="project-workspace-disclosure"]')
@@ -168,16 +211,42 @@ describe('SidebarConversations project workspaces', () => {
     expect(host.querySelector('[data-session-key="agent:main:webchat:task-a"]')).toBeNull()
   })
 
-  it('creates a project task from the pencil action', async () => {
+  it('creates a project task and expands its project from the persistent plus action', async () => {
     const { host, events } = await mountSidebar([projectRow(), taskRow()])
-    const pencil = host.querySelector<HTMLButtonElement>('[data-testid="project-workspace-new-task"]')
+    const plus = host.querySelector<HTMLButtonElement>('[data-testid="project-workspace-new-task"]')
+    const disclosure = host.querySelector<HTMLButtonElement>('[data-testid="project-workspace-disclosure"]')
 
-    expect(pencil).toBeTruthy()
-    pencil?.click()
+    expect(plus).toBeTruthy()
+    expect(plus?.classList.contains('sidebar-project-action--new-task')).toBe(true)
+    expect(plus?.querySelector('svg')).not.toBeNull()
+    disclosure?.click()
+    await nextTick()
+    expect(disclosure?.getAttribute('aria-expanded')).toBe('false')
+
+    plus?.click()
     await nextTick()
 
     expect(events.newProjectTask).toHaveBeenCalledWith('project-a')
     expect(events.select).not.toHaveBeenCalled()
+    expect(disclosure?.getAttribute('aria-expanded')).toBe('true')
+    expect(host.querySelector('[data-session-key="agent:main:webchat:task-a"]')).not.toBeNull()
+  })
+
+  it('keeps a provisional project task current and free of persisted-task actions', async () => {
+    const provisional = taskRow({
+      key: 'draft:project:project-a:1',
+      title: 'New task',
+      provisional: true,
+    })
+    const { host, events } = await mountSidebar([projectRow(), provisional])
+    const row = host.querySelector<HTMLElement>('[data-session-key="draft:project:project-a:1"]')
+
+    row?.querySelector<HTMLButtonElement>('.sidebar-history-item')?.click()
+    await nextTick()
+
+    expect(events.select).not.toHaveBeenCalled()
+    expect(row?.querySelector('.sidebar-row-menu-btn')).toBeNull()
+    expect(row?.querySelector('.sidebar-agent-badge')).toBeNull()
   })
 
   it('disables the new-task action for an unavailable project', async () => {
@@ -185,11 +254,11 @@ describe('SidebarConversations project workspaces', () => {
       projectRow({ workspaceAvailable: false }),
       taskRow(),
     ])
-    const pencil = host.querySelector<HTMLButtonElement>('[data-testid="project-workspace-new-task"]')
+    const plus = host.querySelector<HTMLButtonElement>('[data-testid="project-workspace-new-task"]')
 
-    expect(pencil?.disabled).toBe(true)
-    expect(pencil?.getAttribute('title')).toBe('This project directory is unavailable')
-    pencil?.click()
+    expect(plus?.disabled).toBe(true)
+    expect(plus?.getAttribute('title')).toBe('This project directory is unavailable')
+    plus?.click()
     await nextTick()
 
     expect(events.newProjectTask).not.toHaveBeenCalled()
@@ -198,9 +267,35 @@ describe('SidebarConversations project workspaces', () => {
   it('exposes pin, edit, delete-history, and remove through the project menu', async () => {
     const { host, events } = await mountSidebar([projectRow(), taskRow()])
     const more = host.querySelector<HTMLButtonElement>('[data-testid="project-workspace-more"]')
+    Object.defineProperty(more, 'getBoundingClientRect', {
+      value: () => ({
+        x: 170,
+        y: 20,
+        width: 20,
+        height: 20,
+        top: 20,
+        right: 190,
+        bottom: 40,
+        left: 170,
+        toJSON: () => ({}),
+      }),
+    })
 
     more?.click()
     await nextTick()
+    const menu = document.body.querySelector<HTMLElement>('.sidebar-project-menu')
+    expect(menu?.classList.contains('sidebar-row-menu')).toBe(true)
+    expect(menu?.querySelectorAll('.sidebar-row-menu__item')).toHaveLength(4)
+    expect(menu?.style.left).toBe('196px')
+    expect(menu?.style.transform).toBe('none')
+    expect(
+      Array.from(menu?.querySelectorAll('.sidebar-row-menu__item') || [])
+        .map(item => item.textContent?.trim()),
+    ).toEqual(['Pin project', 'Edit project', 'Delete history', 'Remove'])
+    expect(
+      menu?.querySelector('[data-project-action="delete-history"]')
+        ?.classList.contains('sidebar-row-menu__item--danger'),
+    ).toBe(false)
     document.body.querySelector<HTMLButtonElement>('[data-project-action="pin"]')?.click()
     expect(events.projectPin).toHaveBeenCalledWith({ workspaceId: 'project-a', pinned: true })
 
@@ -237,6 +332,25 @@ describe('SidebarConversations project workspaces', () => {
     )?.click()
     await nextTick()
     expect(events.select).toHaveBeenCalledWith('agent:main:webchat:task-a')
+  })
+
+  it('renders task rows without leading status dots', async () => {
+    const { host } = await mountSidebar([
+      projectRow(),
+      taskRow(),
+      taskRow({
+        key: 'agent:main:webchat:running',
+        title: 'Running task',
+        runStatus: 'running',
+        runLabel: 'Running',
+      }),
+    ])
+
+    expect(host.querySelector('.sidebar-history-dot')).toBeNull()
+    expect(host.querySelector('[data-session-key="agent:main:webchat:task-a"]')?.textContent)
+      .toContain('Project task')
+    expect(host.querySelector('[data-session-key="agent:main:webchat:running"]')?.textContent)
+      .toContain('Running')
   })
 
 })

--- a/opensquilla-webui/src/components/SidebarConversations.workspaces.test.ts
+++ b/opensquilla-webui/src/components/SidebarConversations.workspaces.test.ts
@@ -78,6 +78,7 @@ function i18n() {
         },
         workspaces: {
           projects: 'Projects',
+          createProject: 'Create project',
           projectInfo: '{path}; {count} tasks',
           taskCount: '{count} tasks',
           newTask: 'New project task',
@@ -107,6 +108,7 @@ async function mountSidebar(
   const sections: SidebarSection[] = [{ family: 'chats', label: 'Tasks', rows }]
   const events = {
     select: vi.fn(),
+    newProject: vi.fn(),
     newProjectTask: vi.fn(),
     projectPin: vi.fn(),
     projectEdit: vi.fn(),
@@ -124,6 +126,7 @@ async function mountSidebar(
     searchHint: 'Ctrl+K',
     canManageProjects,
     onSelect: events.select,
+    onNewProject: events.newProject,
     onNewProjectTask: events.newProjectTask,
     onProjectPin: events.projectPin,
     onProjectEdit: events.projectEdit,
@@ -146,6 +149,21 @@ afterEach(() => {
 })
 
 describe('SidebarConversations project workspaces', () => {
+  it('creates projects from the section header while project-row plus actions remain task scoped', async () => {
+    const { host, events } = await mountSidebar([projectRow(), taskRow()])
+    const createProject = host.querySelector<HTMLButtonElement>('[data-testid="sidebar-create-project"]')
+    const createTask = host.querySelector<HTMLButtonElement>('[data-testid="project-workspace-new-task"]')
+
+    expect(createProject?.getAttribute('aria-label')).toBe('Create project')
+    expect(createTask?.getAttribute('aria-label')).toBe('New project task')
+
+    createProject?.click()
+    await nextTick()
+
+    expect(events.newProject).toHaveBeenCalledOnce()
+    expect(events.newProjectTask).not.toHaveBeenCalled()
+  })
+
   it('separates project work from ordinary recent tasks', async () => {
     const { host } = await mountSidebar([
       projectRow(),
@@ -324,6 +342,7 @@ describe('SidebarConversations project workspaces', () => {
     )
 
     expect(host.querySelector('[data-testid="project-workspace-disclosure"]')).toBeTruthy()
+    expect(host.querySelector('[data-testid="sidebar-create-project"]')).toBeNull()
     expect(host.querySelector('[data-testid="project-workspace-new-task"]')).toBeNull()
     expect(host.querySelector('[data-testid="project-workspace-more"]')).toBeNull()
 

--- a/opensquilla-webui/src/components/SidebarConversations.workspaces.test.ts
+++ b/opensquilla-webui/src/components/SidebarConversations.workspaces.test.ts
@@ -104,6 +104,7 @@ function i18n() {
 async function mountSidebar(
   rows: SidebarSectionRow[],
   canManageProjects = true,
+  canCreateProjects = canManageProjects,
 ) {
   const sections: SidebarSection[] = [{ family: 'chats', label: 'Tasks', rows }]
   const events = {
@@ -125,6 +126,7 @@ async function mountSidebar(
     contractDebugEnabled: false,
     searchHint: 'Ctrl+K',
     canManageProjects,
+    canCreateProjects,
     onSelect: events.select,
     onNewProject: events.newProject,
     onNewProjectTask: events.newProjectTask,

--- a/opensquilla-webui/src/components/chat/ActivityDisclosure.test.ts
+++ b/opensquilla-webui/src/components/chat/ActivityDisclosure.test.ts
@@ -140,7 +140,7 @@ describe('ActivityDisclosure resting affordance', () => {
 })
 
 describe('ActivityDisclosure summary label', () => {
-  it('prefers a supplied summaryLabel and composes it with the failure chip', async () => {
+  it('prefers a supplied summaryLabel without surfacing failure metadata', async () => {
     const host = mountDisclosure({
       lifecycle: 'settled',
       stepCount: 9,
@@ -152,11 +152,11 @@ describe('ActivityDisclosure summary label', () => {
 
     expect(host.querySelector('.assistant-activity__label')?.textContent?.trim())
       .toBe('Searched the web, edited 2 files')
-    expect(host.querySelector('.assistant-activity__failure')?.textContent?.trim())
-      .toBe('2 failed')
+    expect(host.querySelector('.assistant-activity__failure')).toBeNull()
+    expect(host.textContent).not.toContain('2 failed')
   })
 
-  it('separates the label and failure chip with real text, not CSS content', async () => {
+  it('keeps recovered failures out of both summary and detail', async () => {
     const host = mountDisclosure({
       lifecycle: 'settled',
       stepCount: 3,
@@ -167,12 +167,13 @@ describe('ActivityDisclosure summary label', () => {
     await nextTick()
 
     // The button's textContent is reused verbatim as the share-export label
-    // and the accessible name, so the separator must live in the DOM.
+    // and the accessible name, so recovered failures move into the detail row.
     const button = host.querySelector<HTMLButtonElement>('.assistant-activity__summary')
     expect(button?.textContent?.replace(/\s+/g, ' ').trim())
-      .toBe('Worked for 12s · 1 failure recovered')
-    expect(activityDisclosureSource).not.toContain('.assistant-activity__failure::before')
-    expect(activityDisclosureSource).not.toContain('.assistant-activity__live-failure::before')
+      .toBe('Worked for 12s')
+    expect(host.querySelector('.assistant-activity__detail')).toBeNull()
+    expect(host.textContent).not.toContain('failure')
+    expect(host.textContent).not.toContain('failed')
   })
 
   it('keeps the duration/count fallback chain when summaryLabel is empty', async () => {
@@ -203,7 +204,30 @@ describe('ActivityDisclosure summary label', () => {
 })
 
 describe('ActivityDisclosure live header', () => {
-  it('renders step and failure counts during a live turn', async () => {
+  it('starts live work collapsed and expands from its status row', async () => {
+    const host = mountDisclosure({
+      lifecycle: 'working',
+      stepCount: 2,
+      failureCount: 0,
+    })
+    await nextTick()
+
+    const summary = host.querySelector<HTMLButtonElement>('.assistant-activity__live-head')
+    const body = host.querySelector<HTMLElement>('.assistant-activity__body')
+    expect(summary?.getAttribute('aria-expanded')).toBe('false')
+    expect(body?.getAttribute('aria-hidden')).toBe('true')
+    expect(body?.classList.contains('is-open')).toBe(false)
+    expect(host.querySelector('.assistant-activity')?.getAttribute('data-share-expanded')).toBe('false')
+
+    summary?.click()
+    await nextTick()
+
+    expect(summary?.getAttribute('aria-expanded')).toBe('true')
+    expect(body?.getAttribute('aria-hidden')).toBe('false')
+    expect(body?.classList.contains('is-open')).toBe(true)
+  })
+
+  it('renders live step count without surfacing failures', async () => {
     const host = mountDisclosure({
       lifecycle: 'working',
       stepCount: 4,
@@ -213,25 +237,16 @@ describe('ActivityDisclosure live header', () => {
     await nextTick()
 
     const step = host.querySelector('.assistant-activity__live-step')
-    const failure = host.querySelector('.assistant-activity__live-failure')
     const elapsed = host.querySelector('.assistant-activity__live-elapsed')
 
     expect(step?.textContent?.trim()).toBe('step 4')
-    expect(failure?.textContent?.trim()).toBe('3 failed')
-
-    // The failure count is real information — it must stay readable, while
-    // the per-second elapsed label stays hidden from screen readers.
-    expect(failure?.getAttribute('aria-hidden')).toBeNull()
     expect(step?.getAttribute('aria-hidden')).toBeNull()
     expect(elapsed?.getAttribute('aria-hidden')).toBe('true')
-
-    const failureRule = cssRule('.assistant-activity__live-failure')
-    expect(failureRule).toContain('color: var(--warn);')
-    expect(failureRule).toContain('flex: 0 0 auto;')
-    expect(failureRule).toContain('font-size: 0.75rem;')
+    expect(host.querySelector('.assistant-activity__live-failure')).toBeNull()
+    expect(host.textContent).not.toContain('3 failed')
   })
 
-  it('shows no step or failure text when their counts are zero', async () => {
+  it('shows no step or failure text when the step count is zero', async () => {
     const host = mountDisclosure({
       lifecycle: 'working',
       stepCount: 0,
@@ -242,42 +257,7 @@ describe('ActivityDisclosure live header', () => {
 
     expect(host.querySelector('.assistant-activity__live-step')).toBeNull()
     expect(host.querySelector('.assistant-activity__sep')).toBeNull()
-    // The failure region stays mounted (it is a live region) but must stay
-    // visually and textually empty at zero.
-    const failure = host.querySelector('.assistant-activity__live-failure')
-    expect(failure).not.toBeNull()
-    expect(failure?.textContent?.trim()).toBe('')
-  })
-
-  it('announces failure count changes through an always-mounted polite region', async () => {
-    const state = reactive({ failureCount: 0 })
-    const host = document.createElement('div')
-    document.body.appendChild(host)
-    const app = createApp({
-      render: () => h(ActivityDisclosure, {
-        lifecycle: 'working',
-        stepCount: 2,
-        failureCount: state.failureCount,
-      }, { default: () => 'Activity details' }),
-    })
-    mountedApps.push(app)
-    app.use(i18n)
-    app.mount(host)
-    await nextTick()
-
-    const region = host.querySelector('.assistant-activity__live-failure')
-    expect(region?.getAttribute('role')).toBe('status')
-    expect(region?.getAttribute('aria-live')).toBe('polite')
-    expect(region?.getAttribute('aria-atomic')).toBe('true')
-    expect(region?.textContent?.trim()).toBe('')
-
-    state.failureCount = 2
-    await nextTick()
-
-    // The same element must gain the text — a live region only announces
-    // content changes inside a node that was already in the tree.
-    expect(host.querySelector('.assistant-activity__live-failure')).toBe(region)
-    expect(region?.textContent?.trim()).toBe('2 failed')
+    expect(host.querySelector('.assistant-activity__live-failure')).toBeNull()
   })
 })
 
@@ -339,10 +319,21 @@ describe('ActivityDisclosure stale state', () => {
 })
 
 describe('ActivityDisclosure expanded boundary', () => {
-  it('contains the fold body with a 1px left rule and closes it with a separator', () => {
+  it('reveals its height progressively and closes it with a separator', () => {
     const bodyRule = cssRule('.assistant-activity__body')
-    expect(bodyRule).toContain('border-left: 1px solid var(--border);')
-    expect(bodyRule).toContain('padding: 0 0 0 0.75rem;')
+    expect(bodyRule).toContain('grid-template-rows: 0fr;')
+    expect(bodyRule).toContain('grid-template-rows var(--dur-base)')
+    expect(bodyRule).toContain('opacity: 0;')
+
+    const openRule = cssRule('.assistant-activity__body.is-open')
+    expect(openRule).toContain('grid-template-rows: 1fr;')
+    expect(openRule).toContain('opacity: 1;')
+
+    const innerRule = cssRule('.assistant-activity__body-inner')
+    expect(innerRule).toContain('overflow: hidden;')
+    expect(innerRule).toContain('border-left: 1px solid var(--border);')
+    expect(innerRule).toContain('padding: 0 0 0 0.75rem;')
+    expect(activityDisclosureSource).toContain('assistant-activity-item-enter')
 
     const separatorRule = cssRule(
       '.assistant-activity--settled[data-share-expanded="true"]::after',
@@ -352,12 +343,13 @@ describe('ActivityDisclosure expanded boundary', () => {
   })
 })
 
-describe('ActivityDisclosure failure tone', () => {
-  it('reserves danger for terminal turn failure summaries', () => {
-    expect(cssRule('.assistant-activity__failure'))
-      .toContain('color: var(--text-muted);')
-    expect(cssRule('.assistant-activity--failed .assistant-activity__failure'))
-      .toContain('color: var(--danger);')
+describe('ActivityDisclosure failure visibility', () => {
+  it('contains no failure label or failure-specific styling', () => {
+    expect(activityDisclosureSource).not.toContain('resolvedFailureLabel')
+    expect(activityDisclosureSource).not.toContain('showDetailFailure')
+    expect(activityDisclosureSource).not.toContain('showSummaryFailure')
+    expect(activityDisclosureSource).not.toContain('assistant-activity__failure')
+    expect(activityDisclosureSource).not.toContain('assistant-activity__live-failure')
   })
 })
 

--- a/opensquilla-webui/src/components/chat/ActivityDisclosure.vue
+++ b/opensquilla-webui/src/components/chat/ActivityDisclosure.vue
@@ -4,9 +4,17 @@
     class="assistant-activity assistant-activity--live"
     data-testid="assistant-activity"
     data-share-activity="true"
-    data-share-expanded="true"
+    :data-share-expanded="open ? 'true' : 'false'"
   >
-    <header class="assistant-activity__live-head" data-share-activity-label>
+    <button
+      type="button"
+      class="assistant-activity__live-head"
+      data-share-activity-label
+      data-share-control
+      :aria-expanded="open"
+      :aria-controls="bodyId"
+      @click.stop="open = !open"
+    >
       <span
         class="assistant-activity__live-dot"
         :class="{ 'is-active': !stale, 'is-stale': stale }"
@@ -31,22 +39,27 @@
       <span v-if="stepCount > 0" class="assistant-activity__live-step">
         {{ t('chat.activity.liveStep', { n: stepCount }) }}
       </span>
-      <span v-if="failureCount > 0" class="assistant-activity__sep" aria-hidden="true">·</span>
-      <!-- Always-mounted polite region so failures announce exactly when the
-           count changes, instead of riding along with phase-label updates. -->
-      <span
-        class="assistant-activity__live-failure"
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
-      >
-        <template v-if="failureCount > 0">
-          {{ t('chat.activityFailures', { count: failureCount }) }}
-        </template>
-      </span>
-    </header>
-    <div class="assistant-activity__body" data-share-activity-body>
-      <slot />
+      <Icon
+        class="assistant-activity__summary-arrow"
+        name="chevronRight"
+        :size="13"
+        aria-hidden="true"
+      />
+    </button>
+    <div
+      :id="bodyId"
+      class="assistant-activity__body"
+      :class="{ 'is-open': open }"
+      :aria-hidden="!open"
+      :inert="open ? undefined : true"
+      data-share-activity-body
+    >
+      <div class="assistant-activity__body-inner">
+        <div v-if="detailLabel" class="assistant-activity__detail">
+          {{ detailLabel }}
+        </div>
+        <slot />
+      </div>
     </div>
   </section>
 
@@ -71,12 +84,6 @@
       @click.stop="open = !open"
     >
       <span class="assistant-activity__label">{{ resolvedSummaryLabel }}</span>
-      <!-- Real DOM separator: the button's textContent doubles as the share
-           label and the accessible name, and ::before content reaches neither. -->
-      <span v-if="failureCount" class="assistant-activity__sep">{{ ' · ' }}</span>
-      <span v-if="failureCount" class="assistant-activity__failure">
-        {{ resolvedFailureLabel }}
-      </span>
       <Icon
         class="assistant-activity__summary-arrow"
         name="chevronRight"
@@ -84,8 +91,20 @@
         aria-hidden="true"
       />
     </button>
-    <div :id="bodyId" v-show="open" class="assistant-activity__body" data-share-activity-body>
-      <slot />
+    <div
+      :id="bodyId"
+      class="assistant-activity__body"
+      :class="{ 'is-open': open }"
+      :aria-hidden="!open"
+      :inert="open ? undefined : true"
+      data-share-activity-body
+    >
+      <div class="assistant-activity__body-inner">
+        <div v-if="detailLabel" class="assistant-activity__detail">
+          {{ detailLabel }}
+        </div>
+        <slot />
+      </div>
     </div>
   </section>
 </template>
@@ -106,6 +125,7 @@ const props = withDefaults(defineProps<{
   durationSeconds?: number
   completionConfirmed?: boolean
   summaryLabel?: string
+  detailLabel?: string
   phaseLabel?: string
   elapsedLabel?: string
   stale?: boolean
@@ -117,6 +137,7 @@ const props = withDefaults(defineProps<{
   durationSeconds: 0,
   completionConfirmed: false,
   summaryLabel: '',
+  detailLabel: '',
   phaseLabel: '',
   elapsedLabel: '',
   stale: false,
@@ -127,10 +148,7 @@ const props = withDefaults(defineProps<{
 
 const { t } = useI18n()
 const bodyId = `assistant-activity-body-${useId()}`
-const initialOpen = () =>
-  props.defaultOpen
-  || props.lifecycle === 'failed'
-  || props.lifecycle === 'interrupted'
+const initialOpen = () => props.defaultOpen
 const open = ref(readAssistantActivityExpansion(
   props.stateKey,
   initialOpen(),
@@ -146,16 +164,9 @@ watch(() => [props.stateKey, props.continuityKey] as const, ([key, continuityKey
 })
 
 watch(
-  () => [props.lifecycle, props.defaultOpen] as const,
-  ([lifecycle, defaultOpen], [previousLifecycle, previousDefaultOpen]) => {
-    const becameTerminal = (
-      lifecycle === 'failed'
-      || lifecycle === 'interrupted'
-    ) && (
-      previousLifecycle !== 'failed'
-      && previousLifecycle !== 'interrupted'
-    )
-    if (becameTerminal || (defaultOpen && !previousDefaultOpen)) {
+  () => props.defaultOpen,
+  (defaultOpen, previousDefaultOpen) => {
+    if (defaultOpen && !previousDefaultOpen) {
       open.value = true
     }
   },
@@ -184,15 +195,6 @@ const resolvedSummaryLabel = computed(() => {
     { count: Math.max(1, props.stepCount) },
   )
 })
-
-const resolvedFailureLabel = computed(() =>
-  t(
-    props.lifecycle === 'settled' && props.completionConfirmed
-      ? 'chat.activityFailuresRecovered'
-      : 'chat.activityFailures',
-    { count: props.failureCount },
-  ),
-)
 </script>
 
 <style scoped>
@@ -211,12 +213,29 @@ const resolvedFailureLabel = computed(() =>
 .assistant-activity__live-head {
   display: flex;
   align-items: center;
+  width: fit-content;
+  max-width: 100%;
   min-width: 0;
   min-height: 1.75rem;
   gap: 0.5rem;
+  padding: 0.1875rem 0.25rem;
+  border: 0;
+  background: transparent;
   color: color-mix(in srgb, var(--text) 90%, transparent);
+  cursor: pointer;
+  font: inherit;
   font-size: 0.875rem;
   line-height: 1.5;
+  text-align: left;
+}
+
+.assistant-activity__live-head:hover {
+  color: var(--text);
+}
+
+.assistant-activity__live-head:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .assistant-activity__live-dot {
@@ -260,23 +279,10 @@ const resolvedFailureLabel = computed(() =>
   font-variant-numeric: tabular-nums;
 }
 
-.assistant-activity__live-failure {
-  flex: 0 0 auto;
-  color: var(--warn);
-  font-size: 0.75rem;
-  white-space: nowrap;
-}
-
 .assistant-activity__live-step::before {
   content: "·";
   margin-right: 0.375rem;
   color: var(--text-dim);
-}
-
-.assistant-activity__sep {
-  flex: 0 0 auto;
-  color: var(--text-dim);
-  font-size: 0.75rem;
 }
 
 .assistant-activity__summary {
@@ -315,21 +321,6 @@ const resolvedFailureLabel = computed(() =>
   overflow-wrap: anywhere;
 }
 
-.assistant-activity__failure {
-  flex: 0 0 auto;
-  color: var(--text-muted);
-  white-space: nowrap;
-}
-
-.assistant-activity--failed .assistant-activity__failure {
-  color: var(--danger);
-}
-
-.assistant-activity--failed :deep(.tool-timeline--activity .tool-row--error .tool-row__status),
-.assistant-activity--failed :deep(.tool-timeline--activity .tool-row__activity-icon--error) {
-  color: var(--danger);
-}
-
 .assistant-activity__summary-arrow {
   flex: 0 0 auto;
   color: currentColor;
@@ -341,31 +332,92 @@ const resolvedFailureLabel = computed(() =>
 }
 
 .assistant-activity__summary:hover .assistant-activity__summary-arrow,
-.assistant-activity__summary:focus-visible .assistant-activity__summary-arrow {
+.assistant-activity__summary:focus-visible .assistant-activity__summary-arrow,
+.assistant-activity__live-head:hover .assistant-activity__summary-arrow,
+.assistant-activity__live-head:focus-visible .assistant-activity__summary-arrow {
   opacity: 0.8;
   transform: translateX(0);
 }
 
-.assistant-activity__summary[aria-expanded="true"] .assistant-activity__summary-arrow {
+.assistant-activity__summary[aria-expanded="true"] .assistant-activity__summary-arrow,
+.assistant-activity__live-head[aria-expanded="true"] .assistant-activity__summary-arrow {
   opacity: 0.55;
   transform: rotate(90deg);
 }
 
 .assistant-activity__summary[aria-expanded="true"]:hover .assistant-activity__summary-arrow,
-.assistant-activity__summary[aria-expanded="true"]:focus-visible .assistant-activity__summary-arrow {
+.assistant-activity__summary[aria-expanded="true"]:focus-visible .assistant-activity__summary-arrow,
+.assistant-activity__live-head[aria-expanded="true"]:hover .assistant-activity__summary-arrow,
+.assistant-activity__live-head[aria-expanded="true"]:focus-visible .assistant-activity__summary-arrow {
   opacity: 0.8;
   transform: rotate(90deg);
 }
 
 .assistant-activity__body {
   display: grid;
+  grid-template-rows: 0fr;
   min-width: 0;
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+  transform: translateY(-0.25rem);
+  transition:
+    grid-template-rows var(--dur-base) var(--ease-standard),
+    opacity var(--dur-fast) var(--ease-standard),
+    transform var(--dur-base) var(--ease-standard);
+}
+
+.assistant-activity__body.is-open {
+  grid-template-rows: 1fr;
+  opacity: 1;
+  pointer-events: auto;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.assistant-activity__body-inner {
+  display: grid;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
   gap: 0.25rem;
   margin: 0.125rem 0 0.25rem;
   padding: 0 0 0 0.75rem;
   border: 0;
   border-left: 1px solid var(--border);
   background: transparent;
+}
+
+.assistant-activity__detail {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.assistant-activity__body.is-open .assistant-activity__detail,
+.assistant-activity__body.is-open :deep(.thinking-block),
+.assistant-activity__body.is-open :deep(.assistant-activity-status__row),
+.assistant-activity__body.is-open :deep(.tool-row) {
+  animation: assistant-activity-item-enter var(--dur-base) var(--ease-standard) backwards;
+}
+
+.assistant-activity__body.is-open :deep(.thinking-block) {
+  animation-delay: 35ms;
+}
+
+.assistant-activity__body.is-open :deep(.assistant-activity-status__row:nth-child(1)),
+.assistant-activity__body.is-open :deep(.tool-row:nth-child(1)) {
+  animation-delay: 60ms;
+}
+
+.assistant-activity__body.is-open :deep(.assistant-activity-status__row:nth-child(2)),
+.assistant-activity__body.is-open :deep(.tool-row:nth-child(2)) {
+  animation-delay: 90ms;
+}
+
+.assistant-activity__body.is-open :deep(.assistant-activity-status__row:nth-child(n + 3)),
+.assistant-activity__body.is-open :deep(.tool-row:nth-child(n + 3)) {
+  animation-delay: 120ms;
 }
 
 .assistant-activity--settled[data-share-expanded="true"]::after {
@@ -379,6 +431,13 @@ const resolvedFailureLabel = computed(() =>
   0%,
   100% { opacity: 0.45; }
   50% { opacity: 1; }
+}
+
+@keyframes assistant-activity-item-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-0.1875rem);
+  }
 }
 
 @media (max-width: 480px) {
@@ -399,11 +458,19 @@ const resolvedFailureLabel = computed(() =>
 
 @media (prefers-reduced-motion: reduce) {
   .assistant-activity__summary,
-  .assistant-activity__summary-arrow {
+  .assistant-activity__summary-arrow,
+  .assistant-activity__body {
     transition: none;
   }
 
   .assistant-activity__live-dot.is-active {
+    animation: none;
+  }
+
+  .assistant-activity__body.is-open .assistant-activity__detail,
+  .assistant-activity__body.is-open :deep(.thinking-block),
+  .assistant-activity__body.is-open :deep(.assistant-activity-status__row),
+  .assistant-activity__body.is-open :deep(.tool-row) {
     animation: none;
   }
 }

--- a/opensquilla-webui/src/components/chat/ActivityNarration.test.ts
+++ b/opensquilla-webui/src/components/chat/ActivityNarration.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import i18n from '@/i18n'
+import ActivityNarration from './ActivityNarration.vue'
+import type { ChatStreamTimelineItem } from '@/types/chat'
+
+const mountedApps: App[] = []
+
+function narration(rawText: string): Extract<ChatStreamTimelineItem, { type: 'text' }> {
+  return {
+    type: 'text',
+    key: `narration:${rawText.length}`,
+    rawText,
+    html: `<p>${rawText}</p>`,
+  }
+}
+
+function mount(rawText: string) {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const app = createApp({
+    render: () => h(ActivityNarration, { item: narration(rawText) }),
+  })
+  mountedApps.push(app)
+  app.use(i18n)
+  app.mount(host)
+  return host
+}
+
+beforeEach(() => {
+  i18n.global.locale.value = 'en'
+  document.body.innerHTML = ''
+})
+
+afterEach(() => {
+  while (mountedApps.length) mountedApps.pop()?.unmount()
+  document.body.innerHTML = ''
+})
+
+describe('ActivityNarration progressive disclosure', () => {
+  it('keeps a short readable update directly visible', () => {
+    const host = mount('Checked the project and found the routing delay.')
+
+    expect(host.querySelector('details')).toBeNull()
+    expect(host.querySelector('.activity-narration--plain')?.textContent)
+      .toContain('Checked the project')
+  })
+
+  it('summarizes a long update and keeps its full body collapsed', () => {
+    const host = mount(
+      'I checked the project flow and verified the current session ownership. '.repeat(8),
+    )
+    const fold = host.querySelector<HTMLDetailsElement>('details.activity-narration')
+
+    expect(fold).not.toBeNull()
+    expect(fold?.open).toBe(false)
+    expect(fold?.querySelector('.activity-narration__summary-text')?.textContent)
+      .toMatch(/I checked the project flow/)
+    expect(fold?.querySelector('.activity-narration__hint')?.textContent)
+      .toContain('view details')
+  })
+
+  it('replaces command and error prose with a plain technical-details label', () => {
+    const technical = 'code-task failed with exit_code=1 and stderr=permission denied'
+    const host = mount(technical)
+    const fold = host.querySelector<HTMLDetailsElement>('details.activity-narration--technical')
+
+    expect(fold).not.toBeNull()
+    expect(fold?.open).toBe(false)
+    expect(fold?.querySelector('summary')?.textContent).toContain('Technical details')
+    expect(fold?.querySelector('summary')?.textContent).not.toContain('exit_code')
+  })
+})

--- a/opensquilla-webui/src/components/chat/ActivityNarration.vue
+++ b/opensquilla-webui/src/components/chat/ActivityNarration.vue
@@ -1,0 +1,169 @@
+<template>
+  <details
+    v-if="shouldFold"
+    class="activity-narration activity-narration--folded"
+    :class="{ 'activity-narration--technical': technical }"
+  >
+    <summary class="activity-narration__summary">
+      <Icon
+        class="activity-narration__chevron"
+        name="chevronRight"
+        :size="12"
+        aria-hidden="true"
+      />
+      <span class="activity-narration__summary-text">
+        {{ technical ? t('chat.activityTechnicalDetails') : preview }}
+      </span>
+      <span v-if="!technical" class="activity-narration__hint">
+        {{ t('shared.runTrace.activityViewDetails') }}
+      </span>
+    </summary>
+    <div class="activity-narration__body" v-html="item.html" />
+  </details>
+  <div
+    v-else
+    class="activity-narration activity-narration--plain"
+    v-html="item.html"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Icon from '@/components/Icon.vue'
+import type { ChatStreamTimelineItem } from '@/types/chat'
+
+const props = defineProps<{
+  item: Extract<ChatStreamTimelineItem, { type: 'text' }>
+}>()
+
+const { t } = useI18n()
+
+const normalizedText = computed(() =>
+  String(props.item.rawText || '')
+    .replace(/\s+/g, ' ')
+    .trim(),
+)
+
+const technical = computed(() => {
+  const text = normalizedText.value
+  if (!text) return false
+  return [
+    /(?:^|\s)(?:exit[_ -]?code|stdout|stderr|traceback|stack trace|permission denied|eperm|enoent)\b/i,
+    /(?:^|\s)(?:npm|pnpm|yarn|git|code-task)\s/i,
+    /(?:\/users\/|\/library\/|[a-z]:\\|\.vue\b|\.tsx?\b|\.py\b|\.json\b)/i,
+    /\b(?:session|task|process|pid|rpc|sandbox|profile[- ]?lock)\s*[:=#]/i,
+    /```|`[^`]{2,}`|--[a-z][\w-]*/i,
+  ].some(pattern => pattern.test(text))
+})
+
+const shouldFold = computed(() => {
+  const raw = String(props.item.rawText || '')
+  return technical.value
+    || normalizedText.value.length > 280
+    || raw.split(/\r\n|\r|\n/).length > 3
+})
+
+const preview = computed(() => {
+  const text = normalizedText.value
+  if (text.length <= 170) return text
+  const sentence = text.slice(0, 180).match(/^(.{40,170}?[。！？.!?])(?:\s|$)/)?.[1]
+  return `${(sentence || text.slice(0, 170)).trim()}…`
+})
+</script>
+
+<style scoped>
+.activity-narration {
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  line-height: 1.58;
+}
+
+.activity-narration--plain {
+  margin: 0.375rem 0 0.625rem 1.625rem;
+}
+
+.activity-narration--plain :deep(p),
+.activity-narration__body :deep(p) {
+  margin: 0;
+}
+
+.activity-narration--plain :deep(p + p),
+.activity-narration__body :deep(p + p) {
+  margin-top: 0.5rem;
+}
+
+.activity-narration--folded {
+  margin: 0.125rem 0 0.375rem;
+}
+
+.activity-narration__summary {
+  display: flex;
+  align-items: center;
+  min-height: 1.75rem;
+  gap: 0.5rem;
+  padding: 0.25rem 0.125rem;
+  color: color-mix(in srgb, var(--text) 68%, transparent);
+  cursor: pointer;
+  list-style: none;
+}
+
+.activity-narration__summary::-webkit-details-marker {
+  display: none;
+}
+
+.activity-narration__summary:hover {
+  color: var(--text);
+}
+
+.activity-narration__summary:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.activity-narration__chevron {
+  flex: 0 0 auto;
+  margin: 0 0.125rem;
+  opacity: 0.5;
+  transition: transform var(--dur-fast) var(--ease-standard);
+}
+
+.activity-narration[open] > .activity-narration__summary .activity-narration__chevron {
+  transform: rotate(90deg);
+}
+
+.activity-narration__summary-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-narration__hint {
+  flex: 0 0 auto;
+  margin-left: auto;
+  color: var(--text-dim);
+  font-size: 0.75rem;
+}
+
+.activity-narration--technical .activity-narration__summary {
+  color: var(--text-dim);
+}
+
+.activity-narration__body {
+  max-height: 18rem;
+  margin: 0.25rem 0 0.625rem 1.625rem;
+  padding-right: 0.5rem;
+  overflow-y: auto;
+  color: var(--text-muted);
+  white-space: normal;
+  word-break: break-word;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .activity-narration__chevron {
+    transition: none;
+  }
+}
+</style>

--- a/opensquilla-webui/src/components/chat/AssistantActivityTimeline.test.ts
+++ b/opensquilla-webui/src/components/chat/AssistantActivityTimeline.test.ts
@@ -158,7 +158,27 @@ describe('AssistantActivityTimeline', () => {
     ])
 
     expect(root.querySelectorAll('.step-card')).toHaveLength(2)
+    expect(root.querySelector('.assistant-activity-tool-batch')).toBeNull()
     expect(root.textContent).toContain('Checking the first change.')
+  })
+
+  it('folds consecutive tool purposes into a readable batch before call details', async () => {
+    const root = await mountTimeline([
+      group(toolCall('read-one', 'read_file')),
+      group(toolCall('run-one', 'execute_code')),
+    ])
+
+    const batch = root.querySelector<HTMLDetailsElement>('.assistant-activity-tool-batch')
+    expect(batch).not.toBeNull()
+    expect(batch?.open).toBe(false)
+    expect(batch?.querySelector('.assistant-activity-tool-batch__summary')?.textContent)
+      .toContain('Inspected files')
+    expect(batch?.querySelector('.assistant-activity-tool-batch__summary')?.textContent)
+      .toContain('Ran commands')
+    expect(batch?.querySelectorAll('.tool-row')).toHaveLength(2)
+
+    batch?.querySelector<HTMLElement>('summary')?.click()
+    expect(batch?.open).toBe(true)
   })
 
   it('keeps lifecycle phases out of the live action body', async () => {

--- a/opensquilla-webui/src/components/chat/AssistantActivityTimeline.vue
+++ b/opensquilla-webui/src/components/chat/AssistantActivityTimeline.vue
@@ -14,32 +14,82 @@
         <span>{{ t(step.label.code, step.label.params) }}</span>
       </li>
     </ol>
-    <ToolCallTimeline
-      v-if="items.length"
-      :items="items"
-      :variant="variant"
-      presentation="activity"
-      :state-scope="stateScope"
-      :is-tool-group-open="isToolGroupOpen"
-      :is-tool-item-open="isToolItemOpen"
-      :tool-group-status-text="toolGroupStatusText"
-      :tool-status-text="toolStatusText"
-      :tool-secondary-text="toolSecondaryText"
-      :tool-elapsed-text="toolElapsedText"
-      @toggle-group="$emit('toggleGroup', $event)"
-      @toggle-item="$emit('toggleItem', $event)"
-      @show-result="(content, title, context) => $emit('showResult', content, title, context)"
-    >
-      <template #interrupt="{ part }">
-        <slot name="interrupt" :part="part" />
-      </template>
-    </ToolCallTimeline>
+    <template v-for="segment in segments" :key="segment.key">
+      <ActivityNarration
+        v-if="segment.type === 'narration'"
+        :item="segment.item"
+      />
+      <details
+        v-else-if="segment.type === 'tools' && segment.items.length > 1"
+        class="assistant-activity-tool-batch"
+      >
+        <summary class="assistant-activity-tool-batch__summary">
+          <Icon
+            :name="segment.items[0]?.group.iconName || 'gear'"
+            :size="14"
+            aria-hidden="true"
+          />
+          <span class="assistant-activity-tool-batch__label">
+            {{ toolBatchSummary(segment.items) }}
+          </span>
+          <Icon
+            class="assistant-activity-tool-batch__chevron"
+            name="chevronRight"
+            :size="13"
+            aria-hidden="true"
+          />
+        </summary>
+        <div class="assistant-activity-tool-batch__body">
+          <ToolCallTimeline
+            :items="segment.items"
+            :variant="variant"
+            presentation="activity"
+            :state-scope="stateScope"
+            :is-tool-group-open="isToolGroupOpen"
+            :is-tool-item-open="isToolItemOpen"
+            :tool-group-status-text="toolGroupStatusText"
+            :tool-status-text="toolStatusText"
+            :tool-secondary-text="toolSecondaryText"
+            :tool-elapsed-text="toolElapsedText"
+            @toggle-group="$emit('toggleGroup', $event)"
+            @toggle-item="$emit('toggleItem', $event)"
+            @show-result="(content, title, context) => $emit('showResult', content, title, context)"
+          >
+            <template #interrupt="{ part }">
+              <slot name="interrupt" :part="part" />
+            </template>
+          </ToolCallTimeline>
+        </div>
+      </details>
+      <ToolCallTimeline
+        v-else
+        :items="segment.items"
+        :variant="variant"
+        presentation="activity"
+        :state-scope="stateScope"
+        :is-tool-group-open="isToolGroupOpen"
+        :is-tool-item-open="isToolItemOpen"
+        :tool-group-status-text="toolGroupStatusText"
+        :tool-status-text="toolStatusText"
+        :tool-secondary-text="toolSecondaryText"
+        :tool-elapsed-text="toolElapsedText"
+        @toggle-group="$emit('toggleGroup', $event)"
+        @toggle-item="$emit('toggleItem', $event)"
+        @show-result="(content, title, context) => $emit('showResult', content, title, context)"
+      >
+        <template #interrupt="{ part }">
+          <slot name="interrupt" :part="part" />
+        </template>
+      </ToolCallTimeline>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Icon from '@/components/Icon.vue'
+import ActivityNarration from '@/components/chat/ActivityNarration.vue'
 import ToolCallTimeline from '@/components/chat/ToolCallTimeline.vue'
 import type {
   ChatStreamTimelineItem,
@@ -150,6 +200,62 @@ const items = computed<ChatStreamTimelineItem[]>(() => {
 
   return props.projection.activityClusters.flatMap(cluster => clusterItem(cluster) ?? [])
 })
+
+type ToolTimelineItem = Extract<ChatStreamTimelineItem, { type: 'tool-group' }>
+type ActivitySegment =
+  | {
+      type: 'narration'
+      key: string
+      item: Extract<ChatStreamTimelineItem, { type: 'text' }>
+    }
+  | {
+      type: 'tools'
+      key: string
+      items: ToolTimelineItem[]
+    }
+  | {
+      type: 'interrupt'
+      key: string
+      items: Array<Extract<ChatStreamTimelineItem, { type: 'interrupt' }>>
+    }
+
+const segments = computed<ActivitySegment[]>(() => {
+  const result: ActivitySegment[] = []
+  for (const item of items.value) {
+    if (item.type === 'text') {
+      result.push({ type: 'narration', key: item.key, item })
+      continue
+    }
+    if (item.type === 'interrupt') {
+      result.push({ type: 'interrupt', key: item.key, items: [item] })
+      continue
+    }
+    const last = result[result.length - 1]
+    if (last?.type === 'tools') {
+      last.items.push(item)
+    } else {
+      result.push({ type: 'tools', key: `tool-batch:${item.key}`, items: [item] })
+    }
+  }
+  return result
+})
+
+function toolBatchSummary(batchItems: ChatStreamTimelineItem[]): string {
+  const groups = batchItems.filter(
+    (item): item is ToolTimelineItem => item.type === 'tool-group',
+  )
+  const labels = groups.map(item =>
+    [item.group.label, item.group.secondary].filter(Boolean).join(' · '),
+  )
+  const visible = labels.slice(0, 3)
+  if (labels.length > visible.length) {
+    const remainingCount = groups
+      .slice(visible.length)
+      .reduce((total, item) => total + item.group.calls.length, 0)
+    visible.push(String(t('chat.activity.more', { count: remainingCount })))
+  }
+  return visible.join(' · ')
+}
 </script>
 
 <style scoped>
@@ -193,5 +299,65 @@ const items = computed<ChatStreamTimelineItem[]>(() => {
 
 .assistant-activity-status__row--current .assistant-activity-status__dot {
   background: var(--accent);
+}
+
+.assistant-activity-tool-batch {
+  min-width: 0;
+}
+
+.assistant-activity-tool-batch__summary {
+  display: flex;
+  align-items: center;
+  min-height: 1.75rem;
+  gap: 0.625rem;
+  padding: 0.25rem 0.125rem;
+  color: color-mix(in srgb, var(--text) 76%, transparent);
+  cursor: pointer;
+  list-style: none;
+}
+
+.assistant-activity-tool-batch__summary::-webkit-details-marker {
+  display: none;
+}
+
+.assistant-activity-tool-batch__summary:hover {
+  color: var(--text);
+}
+
+.assistant-activity-tool-batch__summary:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.assistant-activity-tool-batch__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8125rem;
+}
+
+.assistant-activity-tool-batch__chevron {
+  flex: 0 0 auto;
+  margin-left: auto;
+  opacity: 0.5;
+  transition: transform var(--dur-fast) var(--ease-standard);
+}
+
+.assistant-activity-tool-batch[open]
+  > .assistant-activity-tool-batch__summary
+  .assistant-activity-tool-batch__chevron {
+  transform: rotate(90deg);
+}
+
+.assistant-activity-tool-batch__body {
+  min-width: 0;
+  padding-left: 1.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .assistant-activity-tool-batch__chevron {
+    transition: none;
+  }
 }
 </style>

--- a/opensquilla-webui/src/components/chat/AssistantMessage.activity-fold.test.ts
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.activity-fold.test.ts
@@ -212,7 +212,7 @@ afterEach(() => {
 })
 
 describe('AssistantMessage activity disclosure', () => {
-  it('keeps the canonical answer outside a collapsed recovered-failure activity', async () => {
+  it('keeps the canonical answer outside activity and hides failed tool content', async () => {
     const el = mountMessage(baseMessage())
     await nextTick()
 
@@ -225,19 +225,21 @@ describe('AssistantMessage activity disclosure', () => {
     expect(activity).not.toBeNull()
     expect(summary?.getAttribute('aria-expanded')).toBe('false')
     expect(activity?.dataset.shareExpanded).toBe('false')
-    expect(activity?.querySelectorAll('details')).toHaveLength(0)
+    const reasoningFold = activity?.querySelector<HTMLDetailsElement>('details.thinking-fold')
+    expect(reasoningFold).not.toBeNull()
+    expect(reasoningFold?.open).toBe(false)
     expect(activity?.querySelector('.assistant-activity__chevron')).toBeNull()
     expect(activity?.querySelector('.assistant-activity__summary-arrow')).not.toBeNull()
     expect(activity?.textContent).toContain('Checked the available evidence.')
     expect(activity?.textContent).toContain('Searched the web')
-    expect(activity?.textContent).toContain('1 web action')
-    expect(activity?.textContent).toContain('1 failure recovered')
-    expect(failedRow).not.toBeNull()
-    expect(failedRow?.getAttribute('aria-expanded')).toBe('true')
+    expect(activity?.textContent).not.toContain('1 web action')
+    expect(activity?.textContent).not.toContain('failure recovered')
+    expect(failedRow).toBeNull()
 
     expect(answer?.textContent).toBe('Canonical answer')
     expect(activity?.contains(answer ?? null)).toBe(false)
-    expect(el.querySelectorAll('.msg-ai-text')).toHaveLength(2)
+    expect(el.querySelectorAll('.msg-ai-text')).toHaveLength(1)
+    expect(activity?.querySelector('.activity-narration')?.textContent).toContain('Draft prefix')
     expect(activity?.textContent).toContain('Draft prefix')
     expect(el.textContent).not.toContain('Draft suffix')
   })
@@ -248,7 +250,9 @@ describe('AssistantMessage activity disclosure', () => {
 
     const summary = el.querySelector('.assistant-activity__summary')
     expect(summary?.getAttribute('aria-expanded')).toBe('false')
-    expect(summary?.textContent).toContain('1 web action')
+    expect(summary?.textContent).toContain('Completed · 7s')
+    expect(summary?.textContent).not.toContain('item')
+    expect(el.querySelector('.assistant-activity__detail')?.textContent).toContain('1 web action')
     expect(summary?.textContent).not.toContain('Activity ·')
     expect(el.querySelector('.assistant-activity')?.getAttribute('data-share-expanded')).toBe('false')
     expect(el.querySelector('.tool-row')).not.toBeNull()
@@ -324,7 +328,7 @@ describe('AssistantMessage activity disclosure', () => {
     expect(el.textContent).not.toContain('Inspecting files.Implementation complete.')
   })
 
-  it('keeps a terminal failure open at the failed tool', async () => {
+  it('does not render an activity disclosure containing only a failed tool', async () => {
     const timelineItems = failedTimeline().filter(item => item.type === 'tool-group')
     const el = mountMessage(baseMessage({
       text: '',
@@ -336,16 +340,47 @@ describe('AssistantMessage activity disclosure', () => {
     await nextTick()
 
     const activity = el.querySelector('.assistant-activity')
-    expect(activity?.classList.contains('assistant-activity--failed')).toBe(true)
-    expect(activity?.querySelector('.assistant-activity__summary')?.getAttribute('aria-expanded')).toBe('true')
-    expect(activity?.querySelector('.assistant-activity__summary')?.textContent)
-      .toContain('1 web action')
-    expect(activity?.querySelector('.assistant-activity__summary')?.textContent)
-      .not.toContain('Completed ·')
-    expect(activity?.querySelector('.tool-row--error')).not.toBeNull()
+    expect(activity).toBeNull()
+    expect(el.querySelector('.tool-row--error')).toBeNull()
   })
 
-  it('keeps interrupted activity open while leaving the answer outside', async () => {
+  it('hides restored failures whose error state only survived on the group', async () => {
+    const staleFailure = timelineGroup(successfulCall('stale-failure', 'execute_code'))
+    if (staleFailure.type !== 'tool-group') throw new Error('expected tool group')
+    staleFailure.group.isError = true
+    staleFailure.group.status = 'error'
+    const el = mountMessage(baseMessage({
+      timelineItems: [staleFailure],
+      parts: [],
+      statusHistory: [],
+    }))
+    await nextTick()
+
+    expect(el.querySelector('.assistant-activity')).toBeNull()
+    expect(el.querySelector('.tool-row')).toBeNull()
+    expect(el.textContent).not.toContain('Failed')
+  })
+
+  it('keeps successful calls while removing failed calls from a mixed group', async () => {
+    const success = successfulCall('successful-command', 'execute_code')
+    const mixed = timelineGroup(success)
+    if (mixed.type !== 'tool-group') throw new Error('expected tool group')
+    mixed.group.calls = [success, failedCall()]
+    mixed.group.isError = true
+    mixed.group.status = 'error'
+    const el = mountMessage(baseMessage({
+      timelineItems: [mixed],
+      parts: [],
+      statusHistory: [],
+    }))
+    await nextTick()
+
+    expect(el.querySelectorAll('.tool-row')).toHaveLength(1)
+    expect(el.querySelector('.tool-row--error')).toBeNull()
+    expect(el.textContent).not.toContain('Network unavailable')
+  })
+
+  it('keeps interrupted activity collapsed while leaving the answer outside', async () => {
     const el = mountMessage(baseMessage({
       interrupted: true,
       timelineItems: successfulTimeline(),
@@ -356,7 +391,8 @@ describe('AssistantMessage activity disclosure', () => {
     const answer = [...el.querySelectorAll<HTMLElement>('.msg-ai-text')]
       .find(node => !activity?.contains(node))
     expect(activity?.classList.contains('assistant-activity--interrupted')).toBe(true)
-    expect(activity?.querySelector('.assistant-activity__summary')?.getAttribute('aria-expanded')).toBe('true')
+    expect(activity?.querySelector('.assistant-activity__summary')?.getAttribute('aria-expanded'))
+      .toBe('false')
     expect(activity?.querySelector('.assistant-activity__summary')?.textContent)
       .not.toContain('Completed ·')
     expect(answer?.textContent).toBe('Canonical answer')
@@ -418,7 +454,7 @@ describe('AssistantMessage activity disclosure', () => {
     await nextTick()
 
     expect(el.querySelector('.assistant-activity__summary')?.textContent)
-      .toContain('Completed ·')
+      .toBe('Completed')
   })
 
   it('uses an exact local duration when the live status snapshot provides one', async () => {
@@ -432,7 +468,9 @@ describe('AssistantMessage activity disclosure', () => {
     }))
     await nextTick()
 
-    expect(el.querySelector('.assistant-activity__summary')?.textContent).toContain('Worked for 21s')
+    expect(el.querySelector('.assistant-activity__summary')?.textContent)
+      .toContain('Completed · 21s')
+    expect(el.querySelector('.assistant-activity__detail')?.textContent).toContain('Worked for 21s')
   })
 
   it('keeps the exact duration when same-session history replaces the local row', async () => {
@@ -446,7 +484,7 @@ describe('AssistantMessage activity disclosure', () => {
       timelineItems: successfulTimeline(),
     }))
     await nextTick()
-    expect(local.querySelector('.assistant-activity__summary')?.textContent).toContain('Worked for 21s')
+    expect(local.querySelector('.assistant-activity__detail')?.textContent).toContain('Worked for 21s')
 
     const restored = mountMessage(baseMessage({
       id: 'server-assistant',
@@ -455,10 +493,10 @@ describe('AssistantMessage activity disclosure', () => {
       timelineItems: successfulTimeline(),
     }))
     await nextTick()
-    expect(restored.querySelector('.assistant-activity__summary')?.textContent).toContain('Worked for 21s')
+    expect(restored.querySelector('.assistant-activity__detail')?.textContent).toContain('Worked for 21s')
   })
 
-  it('summarizes the collapsed row as footprint parts, overflow, then elapsed time last', async () => {
+  it('keeps the collapsed row compact and moves footprint and elapsed time into details', async () => {
     const el = mountMessage(baseMessage({
       ts: 1_725_000_022,
       statusHistory: [
@@ -473,9 +511,12 @@ describe('AssistantMessage activity disclosure', () => {
     }))
     await nextTick()
 
-    // Footprint first, the projection's own "{count} more" for the overflow,
-    // and the elapsed time strictly last — time must not lead the row.
     expect(el.querySelector('.assistant-activity__label')?.textContent)
+      .toBe('Completed · 21s')
+    // The expanded detail preserves the exact footprint and elapsed metadata.
+    expect(el.querySelector('.assistant-activity__label')?.textContent)
+      .not.toContain('item')
+    expect(el.querySelector('.assistant-activity__detail')?.textContent)
       .toBe('1 web action · 1 command · 2 more · Worked for 21s')
   })
 
@@ -502,8 +543,23 @@ describe('AssistantMessage activity disclosure', () => {
     }))
     await nextTick()
 
-    expect(restored.querySelector('.assistant-activity__label')?.textContent)
+    expect(restored.querySelector('.assistant-activity__detail')?.textContent)
       .toContain('Worked for 21s')
+  })
+
+  it('keeps streaming work collapsed until the user expands it', async () => {
+    const el = mountMessage(baseMessage({
+      isStreaming: true,
+      timelineItems: successfulTimeline(),
+    }))
+    await nextTick()
+
+    const summary = el.querySelector<HTMLButtonElement>('.assistant-activity__live-head')
+    const body = el.querySelector<HTMLElement>('.assistant-activity__body')
+    expect(summary?.getAttribute('aria-expanded')).toBe('false')
+    expect(summary?.textContent).toContain('Working')
+    expect(body?.getAttribute('aria-hidden')).toBe('true')
+    expect(body?.classList.contains('is-open')).toBe(false)
   })
 
   it('does not let the tool-detail preference force the outer activity open', async () => {
@@ -523,7 +579,7 @@ describe('AssistantMessage activity disclosure', () => {
     await nextTick()
 
     expect(el.querySelector('.assistant-activity__summary')?.getAttribute('aria-expanded')).toBe('false')
-    expect(el.querySelector('.thinking-block')).not.toBeNull()
+    expect(el.querySelector<HTMLDetailsElement>('.thinking-fold')?.open).toBe(false)
   })
 
   it('expands the settled activity from the whole summary row with a hover affordance', async () => {
@@ -539,7 +595,10 @@ describe('AssistantMessage activity disclosure', () => {
 
     expect(summary?.getAttribute('aria-expanded')).toBe('true')
     expect(activity?.dataset.shareExpanded).toBe('true')
-    expect(activity?.querySelector<HTMLElement>('.assistant-activity__body')?.style.display).not.toBe('none')
+    expect(activity?.querySelector('.assistant-activity__body')?.getAttribute('aria-hidden'))
+      .toBe('false')
+    expect(activity?.querySelector('.assistant-activity__body')?.classList.contains('is-open'))
+      .toBe(true)
   })
 
   it('keeps user expansion through a same-session history replacement', async () => {
@@ -589,7 +648,7 @@ describe('AssistantMessage activity disclosure', () => {
     expect(summary?.textContent).not.toContain('Worked for 21s')
   })
 
-  it('keeps partial output activity open when the turn ends with a terminal failure', async () => {
+  it('keeps partial output activity collapsed when the turn ends with a terminal failure', async () => {
     const el = mountMessage(baseMessage({
       text: 'Partial answer before failure.',
       terminalFailure: true,
@@ -600,11 +659,11 @@ describe('AssistantMessage activity disclosure', () => {
     const activity = el.querySelector('.assistant-activity')
     expect(activity?.classList.contains('assistant-activity--failed')).toBe(true)
     expect(activity?.querySelector('.assistant-activity__summary')?.getAttribute('aria-expanded'))
-      .toBe('true')
+      .toBe('false')
     expect(el.textContent).toContain('Partial answer before failure.')
   })
 
-  it('preserves legacy timeline order when no canonical answer exists', async () => {
+  it('preserves legacy narration but removes failed tool rows when no canonical answer exists', async () => {
     const el = mountMessage(baseMessage({
       text: '   ',
       parts: [],
@@ -616,8 +675,9 @@ describe('AssistantMessage activity disclosure', () => {
     expect(el.querySelector('.assistant-activity')).toBeNull()
     expect(text).toContain('Draft prefix')
     expect(text).toContain('Draft suffix')
-    expect(text.indexOf('Draft prefix')).toBeLessThan(text.indexOf('Search'))
-    expect(text.indexOf('Search')).toBeLessThan(text.indexOf('Draft suffix'))
+    expect(text).not.toContain('Search')
+    expect(text).not.toContain('Network unavailable')
+    expect(text.indexOf('Draft prefix')).toBeLessThan(text.indexOf('Draft suffix'))
   })
 
   it('keeps artifacts outside the activity disclosure and actionable', async () => {

--- a/opensquilla-webui/src/components/chat/AssistantMessage.ensemble-meta.test.ts
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.ensemble-meta.test.ts
@@ -74,7 +74,7 @@ describe('AssistantMessage ensemble footer metadata', () => {
     unsafe.app.unmount()
   })
 
-  it('shows the current message token counts in its usage popover', async () => {
+  it('keeps model, cost, and token details behind one info control', async () => {
     const { app, el } = await mountMessage(
       assistantMessage({
         meta: {
@@ -95,12 +95,17 @@ describe('AssistantMessage ensemble footer metadata', () => {
     el.querySelector<HTMLButtonElement>('.msg-meta__more-btn')?.click()
     await nextTick()
 
-    expect(el.querySelector('.msg-meta-popover__label')?.textContent).toBe('tokens')
-    expect(el.querySelector('.msg-meta-popover__value')?.textContent).toBe('↑120 ↓40')
+    expect(el.querySelectorAll('.msg-meta__more-btn')).toHaveLength(1)
+    expect(el.querySelector('.msg-meta__model')).toBeNull()
+    expect(el.querySelector('.msg-meta__cost')).toBeNull()
+    const rows = Array.from(el.querySelectorAll('.msg-meta-popover__row')).map(row => row.textContent)
+    expect(rows).toContain('modelglm-5.2-20260616')
+    expect(rows).toContain('cost$0.050328')
+    expect(rows).toContain('tokens↑120 ↓40')
     app.unmount()
   })
 
-  it('does not present ensemble aggregate metadata as single-model footer metadata', async () => {
+  it('keeps ensemble metadata behind the same single info control', async () => {
     const { app, el } = await mountMessage(
       assistantMessage({
         meta: {
@@ -133,7 +138,8 @@ describe('AssistantMessage ensemble footer metadata', () => {
     expect(el.querySelector('.msg-meta__model')).toBeNull()
     expect(el.querySelector('.msg-meta__cost')).toBeNull()
     expect(el.querySelector('.savings-indicator')).toBeNull()
-    expect(el.querySelector('.msg-meta__ensemble')?.textContent).toBe('Ensemble · 5 models')
+    expect(el.querySelector('.msg-meta__ensemble')).toBeNull()
+    expect(el.querySelectorAll('.msg-meta__more-btn')).toHaveLength(1)
     app.unmount()
   })
 
@@ -180,7 +186,7 @@ describe('AssistantMessage ensemble footer metadata', () => {
     app.unmount()
   })
 
-  it('keeps the savings badge for non-ensemble optimized messages', async () => {
+  it('does not show a savings badge beside the info control', async () => {
     const { app, el } = await mountMessage(
       assistantMessage({
         meta: {
@@ -198,13 +204,16 @@ describe('AssistantMessage ensemble footer metadata', () => {
       }),
     )
 
-    expect(el.querySelector('.savings-indicator')?.textContent).toBe('Saved ~92%')
+    expect(el.querySelector('.savings-indicator')).toBeNull()
+    expect(el.querySelectorAll('.msg-meta__more-btn')).toHaveLength(1)
     app.unmount()
   })
 
-  it('keeps the ensemble summary broad enough on compact layouts', () => {
-    expect(source).not.toContain('max-width: 7rem;')
-    expect(source).toContain('max-width: min(14rem, 100%);')
+  it('does not render inline model, cost, ensemble, or savings metadata', () => {
+    expect(source).not.toContain('class="msg-meta__model"')
+    expect(source).not.toContain('class="msg-meta__cost"')
+    expect(source).not.toContain('class="msg-meta__ensemble"')
+    expect(source).not.toContain('class="savings-indicator"')
   })
 
   it('does not toggle share selection for stopped-output notices', async () => {

--- a/opensquilla-webui/src/components/chat/AssistantMessage.vue
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.vue
@@ -40,22 +40,28 @@
           v-if="hasActivity"
           :lifecycle="activityLifecycle"
           :step-count="activityStepCount"
-          :failure-count="activityProjection.failureCount"
+          :failure-count="0"
           :duration-seconds="activityDurationSeconds"
           :summary-label="activitySummaryLabel"
+          :detail-label="activityDetailLabel"
           :completion-confirmed="activityCompletionConfirmed"
           :default-open="activityDefaultOpen"
           :state-key="activityStateKey"
           :continuity-key="activityContinuityKey"
         >
-          <ReasoningPart v-if="reasoningPart" :part="reasoningPart" embedded />
+          <ReasoningPart
+            v-if="reasoningPart"
+            :part="reasoningPart"
+            :live="activityLifecycle === 'working' || activityLifecycle === 'answering'"
+            nested
+          />
           <AssistantActivityTimeline
             v-if="
-              activityProjection.activityItems.length
+              visibleActivityItems.length
               || activityProjection.statusSteps.length
             "
-            :projection="activityProjection"
-            :timeline-items="activityProjection.activityItems"
+            :projection="visibleActivityProjection"
+            :timeline-items="visibleActivityItems"
             :state-scope="toolStateScope"
             :is-tool-group-open="isToolGroupOpen"
             :is-tool-item-open="isToolItemOpen"
@@ -93,7 +99,7 @@
       <template v-else>
         <ReasoningPart v-if="reasoningPart" :part="reasoningPart" />
         <ToolCallTimeline
-          :items="message.timelineItems ?? []"
+          :items="visibleLegacyTimelineItems"
           :state-scope="toolStateScope"
           :is-tool-group-open="isToolGroupOpen"
           :is-tool-item-open="isToolItemOpen"
@@ -151,10 +157,6 @@
           {{ t('chat.provenance.scheduled') }}
         </span>
         <div v-if="message.meta" class="msg-ai-meta">
-          <span v-if="message.meta.model && !message.meta.ensemble" class="msg-meta__model">{{ message.meta.modelShort }}</span>
-          <span v-if="message.meta.costUsd && !message.meta.ensemble" class="msg-meta__cost">${{ message.meta.costUsd.toFixed(6).replace(/\.?0+$/, '') }}</span>
-          <span v-if="message.meta.ensemble" class="msg-meta__ensemble">{{ t('chat.msgMeta.ensembleModels', { count: message.meta.ensemble.modelCount }) }}</span>
-          <span v-if="message.meta.hasSaved && !message.meta.ensemble" class="savings-indicator">{{ message.meta.savedLabel }}</span>
           <span
             v-if="hasMetaDetails"
             ref="metaMoreRef"
@@ -182,6 +184,14 @@
               role="group"
               :aria-label="t('chat.usageDetails')"
             >
+              <div v-if="message.meta.model && !message.meta.ensemble" class="msg-meta-popover__row">
+                <span class="msg-meta-popover__label">{{ t('chat.msgMeta.model') }}</span>
+                <span class="msg-meta-popover__value">{{ message.meta.modelShort }}</span>
+              </div>
+              <div v-if="message.meta.costUsd && !message.meta.ensemble" class="msg-meta-popover__row">
+                <span class="msg-meta-popover__label">{{ t('chat.msgMeta.cost') }}</span>
+                <span class="msg-meta-popover__value">{{ fmtUsd(message.meta.costUsd) }}</span>
+              </div>
               <div v-if="message.meta.hasTokens" class="msg-meta-popover__row">
                 <span class="msg-meta-popover__label">{{ t('chat.msgMeta.tokens') }}</span>
                 <span class="msg-meta-popover__value">&#8593;{{ fmtTok(message.meta.input) }} &#8595;{{ fmtTok(message.meta.output) }}</span>
@@ -278,8 +288,8 @@
           </button>
           <time v-if="timeIso" class="msg-time" :datetime="timeIso" :title="timeFull">
             <span class="msg-time__abs">{{ timeAbs }}</span>
-            <span class="msg-time__dot" aria-hidden="true">·</span>
-            <span class="msg-time__rel">{{ timeRel }}</span>
+            <span v-if="timeRel" class="msg-time__dot" aria-hidden="true">·</span>
+            <span v-if="timeRel" class="msg-time__rel">{{ timeRel }}</span>
           </time>
         </div>
       </div>
@@ -513,7 +523,14 @@ const showDoneBlock = computed(() =>
 const hasMetaDetails = computed(() => {
   const meta = props.message.meta
   if (!meta) return false
-  return meta.hasTokens || meta.cachedTokens > 0 || meta.reasoningTokens > 0 || !!meta.ensemble
+  return !!(
+    meta.model
+    || meta.costUsd
+    || meta.hasTokens
+    || meta.cachedTokens > 0
+    || meta.reasoningTokens > 0
+    || meta.ensemble
+  )
 })
 
 const ensembleSummary = computed(() => {
@@ -593,8 +610,9 @@ const activityLifecycle = computed<AssistantActivityLifecycle>(() => {
         item.type === 'tool-group'
         && item.group.calls.some(call => call.isError || call.status === 'error'),
       )
-    )
-  return hasTerminalFailure ? 'failed' : 'settled'
+  )
+  if (hasTerminalFailure) return 'failed'
+  return props.message.isStreaming ? 'working' : 'settled'
 })
 
 const activityProjection = computed(() =>
@@ -609,21 +627,82 @@ const activityProjection = computed(() =>
   ),
 )
 
+function withoutFailedActivity(
+  items: ChatStreamTimelineItem[],
+): ChatStreamTimelineItem[] {
+  return items.flatMap((item): ChatStreamTimelineItem[] => {
+    if (item.type !== 'tool-group') return [item]
+    const failedCalls = item.group.calls.filter(
+      call => call.isError || call.status === 'error',
+    )
+    // Some restored histories only carry the failure marker on the group.
+    // Treat that group-level state as authoritative when no call-level marker
+    // survived serialization.
+    if (
+      (item.group.isError || item.group.status === 'error')
+      && failedCalls.length === 0
+    ) {
+      return []
+    }
+    const calls = item.group.calls.filter(
+      call => !call.isError && call.status !== 'error',
+    )
+    if (calls.length === 0) return []
+    const isRunning = calls.some(call => call.isRunning)
+    return [{
+      ...item,
+      group: {
+        ...item.group,
+        calls,
+        isRunning,
+        isError: false,
+        status: isRunning
+          ? ''
+          : calls.every(call => call.status === 'success')
+            ? 'success'
+            : '',
+      },
+    }]
+  })
+}
+
+const visibleActivityItems = computed(() =>
+  withoutFailedActivity(activityProjection.value.activityItems),
+)
+const visibleLegacyTimelineItems = computed(() =>
+  withoutFailedActivity(props.message.timelineItems ?? []),
+)
+const visibleActivityCallKeys = computed(() => new Set(
+  visibleActivityItems.value.flatMap(item =>
+    item.type === 'tool-group'
+      ? item.group.calls.map(call => call.renderKey)
+      : [],
+  ),
+))
+const visibleActivityClusters = computed(() =>
+  activityProjection.value.activityClusters.filter(cluster =>
+    !cluster.isFailure
+    && cluster.calls.some(call => visibleActivityCallKeys.value.has(call.renderKey)),
+  ),
+)
+const visibleActivityProjection = computed(() => ({
+  ...activityProjection.value,
+  activityClusters: visibleActivityClusters.value,
+}))
+const hasVisibleActivityItem = computed(() => visibleActivityItems.value.length > 0)
 const hasActivity = computed(() =>
   !!reasoningPart.value
-  || activityProjection.value.activityItems.length > 0
+  || hasVisibleActivityItem.value
   || statusHistory.value.length > 0,
 )
 
 const activityStepCount = computed(() => Math.max(
   1,
-  activityProjection.value.activityClusters.length
+  visibleActivityClusters.value.length
     + activityProjection.value.statusSteps.length
     + (reasoningPart.value ? 1 : 0),
 ))
-const activityDefaultOpen = computed(() =>
-  activityLifecycle.value === 'failed' || activityLifecycle.value === 'interrupted',
-)
+const activityDefaultOpen = computed(() => false)
 const activityCompletionConfirmed = computed(() =>
   activityLifecycle.value === 'settled'
   && !props.message.isStreaming
@@ -653,10 +732,13 @@ const activityContinuityKey = computed(() =>
 const activityDurationSeconds = computed(() => {
   const measured = measuredActivityDurationSeconds.value
   if (measured > 0) return measured
-  return readAssistantActivityDuration(
+  const persisted = readAssistantActivityDuration(
     activityStateKey.value,
     activityContinuityKey.value,
   )
+  if (persisted > 0) return persisted
+  const reasoningSeconds = Math.floor(Number(reasoningPart.value?.seconds || 0))
+  return reasoningSeconds > 0 ? reasoningSeconds : 0
 })
 
 // Persisting a measured duration is a side effect, so it lives in a watcher
@@ -684,20 +766,49 @@ const activityElapsedLabel = computed(() => {
   })
 })
 
-// The collapsed row leads with what the turn did (the projection's footprint,
-// which already caps itself at two kinds plus a "{count} more" descriptor) and
-// appends the elapsed time last — time is the least important fact, so it must
-// not lead. An empty footprint passes '' so the disclosure keeps its own
-// duration/count fallback chain.
-const activitySummaryLabel = computed(() => {
-  const summary = activityProjection.value.footprintSummary
-  if (!summary.codes.length) return ''
-  const parts = summary.codes.map(part => String(t(part.code, part.params)))
-  if (summary.remaining) {
-    parts.push(String(t(summary.remaining.code, summary.remaining.params)))
+const activityCompactElapsedLabel = computed(() => {
+  const seconds = Math.max(0, Math.floor(activityDurationSeconds.value || 0))
+  if (seconds <= 0) return ''
+  if (seconds < 60) return String(t('chat.activityDurationSeconds', { seconds }))
+  return String(t('chat.activityDurationMinutes', {
+    minutes: Math.floor(seconds / 60),
+    seconds: seconds % 60,
+  }))
+})
+
+// Expanded metadata keeps the activity footprint (capped at two kinds plus a
+// "{count} more" descriptor) and the verbose elapsed copy. The collapsed,
+// completed row uses the compact elapsed label above instead of an arbitrary
+// item count.
+const activityDetailLabel = computed(() => {
+  const counts = new Map<string, number>()
+  for (const cluster of visibleActivityClusters.value) {
+    const code = cluster.footprint.code
+    const count = Number(cluster.footprint.params.count ?? cluster.callCount)
+    counts.set(code, (counts.get(code) ?? 0) + count)
+  }
+  const descriptors = [...counts].map(([code, count]) => ({ code, count }))
+  const parts = descriptors.slice(0, 2).map(part =>
+    String(t(part.code, { count: part.count })),
+  )
+  if (descriptors.length > 2) {
+    const remainingCount = descriptors
+      .slice(2)
+      .reduce((total, part) => total + part.count, 0)
+    parts.push(String(t('chat.activity.more', { count: remainingCount })))
   }
   if (activityElapsedLabel.value) parts.push(activityElapsedLabel.value)
   return parts.join(' · ')
+})
+
+const activitySummaryLabel = computed(() => {
+  if (activityCompletionConfirmed.value) {
+    return [
+      String(t('chat.activity.lifecycle.settled')),
+      activityCompactElapsedLabel.value,
+    ].filter(Boolean).join(' · ')
+  }
+  return activityDetailLabel.value
 })
 
 function onMessageClick(event: MouseEvent) {
@@ -990,35 +1101,8 @@ function ensembleRole(role: string, label: string): string {
 
 .msg-ai-meta {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
-  min-width: 0;
-  gap: 0.5rem;
-  font-size: 0.8125rem;
-  line-height: 1.35;
   color: color-mix(in srgb, var(--text-muted) 56%, transparent);
-}
-
-.msg-ai-meta > span:not(.savings-indicator):not(.msg-meta__more) {
-  opacity: 0.72;
-  transition: opacity var(--dur-base) var(--ease-standard), color var(--dur-base) var(--ease-standard);
-}
-
-.msg-ai:hover .msg-ai-meta > span:not(.savings-indicator):not(.msg-meta__more) {
-  opacity: 0.88;
-}
-
-.msg-meta__cost,
-.msg-meta__ensemble {
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
-
-.msg-meta__ensemble {
-  color: color-mix(in srgb, var(--accent) 70%, var(--text-muted));
-  max-width: 10rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .msg-meta__more {
@@ -1132,81 +1216,17 @@ function ensembleRole(role: string, label: string): string {
   font-variant-numeric: tabular-nums;
 }
 
-.savings-indicator {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  min-height: 1.25rem;
-  padding: 0 0.45rem;
-  overflow: hidden;
-  border: 1px solid color-mix(in srgb, var(--accent) 18%, transparent);
-  border-radius: var(--radius-full);
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--accent) 8%, var(--bg-surface)), var(--bg-surface) 48%, color-mix(in srgb, var(--ok) 8%, var(--bg-surface))),
-    radial-gradient(circle at 18% 0%, color-mix(in srgb, var(--warn) 34%, transparent), transparent 42%);
-  box-shadow:
-    inset 0 1px 0 color-mix(in srgb, var(--bg-surface) 85%, transparent),
-    0 5px 14px color-mix(in srgb, var(--accent) 8%, transparent);
-  color: var(--accent);
-  font-weight: 650;
-  isolation: isolate;
-}
-
-.savings-indicator::after {
-  content: '';
-  position: absolute;
-  inset: -40% auto -40% -60%;
-  width: 42%;
-  background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--bg-surface) 82%, transparent), transparent);
-  transform: skewX(-18deg);
-  animation: savingsSweep 5.6s ease-in-out infinite;
-  opacity: 0.55;
-  pointer-events: none;
-}
-
-@keyframes savingsSweep {
-  0%, 62% {
-    left: -60%;
-  }
-  84%, 100% {
-    left: 118%;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .savings-indicator::after {
-    animation: none;
-    display: none;
-  }
-}
-
 @media (max-width: 768px) {
   .msg-ai-footer {
     min-width: 0;
   }
 
   .msg-ai-meta {
-    flex: 1;
-    flex-wrap: nowrap;
-    gap: 0.375rem;
+    flex: 0 0 auto;
   }
 
-  .msg-meta__model {
-    flex: 0 1 auto;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .msg-meta__cost,
-  .savings-indicator,
   .msg-meta__more {
     flex-shrink: 0;
-  }
-
-  .msg-meta__ensemble {
-    max-width: min(14rem, 100%);
   }
 }
 

--- a/opensquilla-webui/src/components/chat/ChatComposer.voice.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatComposer.voice.test.ts
@@ -67,11 +67,29 @@ describe('ChatComposer voice-input gate', () => {
     const stop = el.querySelector<HTMLButtonElement>(
       `button[aria-label="${i18n.global.t('chat.stopResponse')}"]`,
     )
+    const send = el.querySelector<HTMLButtonElement>(
+      `button[aria-label="${i18n.global.t('chat.send')}"]`,
+    )
 
     expect(stop).toBeTruthy()
+    expect(send).toBeNull()
     stop?.click()
     await nextTick()
     expect(onStop).toHaveBeenCalledOnce()
+    app.unmount()
+  })
+
+  it('shows Send instead of Stop when no response can be stopped', async () => {
+    const { app, el } = await mount({ canStop: false })
+    const send = el.querySelector<HTMLButtonElement>(
+      `button[aria-label="${i18n.global.t('chat.send')}"]`,
+    )
+    const stop = el.querySelector<HTMLButtonElement>(
+      `button[aria-label="${i18n.global.t('chat.stopResponse')}"]`,
+    )
+
+    expect(send).toBeTruthy()
+    expect(stop).toBeNull()
     app.unmount()
   })
 

--- a/opensquilla-webui/src/components/chat/ChatComposer.vue
+++ b/opensquilla-webui/src/components/chat/ChatComposer.vue
@@ -28,28 +28,6 @@
       </div>
       <div class="chat-input-panel">
         <div
-          v-if="projectWorkspace"
-          class="chat-project-chip"
-          :data-status="projectWorkspaceStatus || 'ready'"
-          :title="projectWorkspace.path"
-        >
-          <Icon name="folder" :size="14" />
-          <span class="chat-project-chip__name">{{ projectWorkspace.name }}</span>
-          <span class="chat-project-chip__path">{{ projectWorkspace.path }}</span>
-          <span v-if="projectStatusMessage" class="chat-project-chip__status">
-            {{ projectStatusMessage }}
-          </span>
-          <button
-            v-if="canCloseProject"
-            type="button"
-            :aria-label="t('workspaces.closeProjectDraft')"
-            :title="t('workspaces.closeProjectDraft')"
-            @click="emit('closeProject')"
-          >
-            <Icon name="x" :size="12" />
-          </button>
-        </div>
-        <div
           v-if="replanActive"
           class="chat-replan-draft"
           role="status"
@@ -111,6 +89,27 @@
                 @attach-files="fileInputEl?.click()"
                 @close="addMenuOpen = false"
               />
+            </div>
+            <div
+              v-if="showProjectContext && projectWorkspace"
+              class="chat-project-chip"
+              :data-status="projectWorkspaceStatus || 'ready'"
+              :title="projectWorkspace.path"
+            >
+              <Icon name="folder" :size="14" />
+              <span class="chat-project-chip__name">{{ projectWorkspace.name }}</span>
+              <span v-if="projectStatusMessage" class="chat-project-chip__status">
+                {{ projectStatusMessage }}
+              </span>
+              <button
+                v-if="canCloseProject"
+                type="button"
+                :aria-label="t('workspaces.closeProjectDraft')"
+                :title="t('workspaces.closeProjectDraft')"
+                @click="emit('closeProject')"
+              >
+                <Icon name="x" :size="12" />
+              </button>
             </div>
             <button
               v-if="
@@ -373,6 +372,9 @@ const fileInputEl = ref<HTMLInputElement | null>(null)
 const addMenuOpen = ref(false)
 const modelRoutingOpen = ref(false)
 const moreActionsOpen = ref(false)
+const showProjectContext = computed(() =>
+  Boolean(props.projectWorkspace && (props.canCloseProject || props.projectStatusMessage)),
+)
 
 // "NEW" badge on the routing control — the single-model AI router is now the
 // default, so flag it until the user first opens the control, then never again.
@@ -581,39 +583,63 @@ defineExpose<ChatComposerExpose>({
 }
 
 .chat-project-chip {
+  flex: 0 1 auto;
+  min-width: 0;
   width: fit-content;
-  max-width: 100%;
+  max-width: min(220px, 42vw);
   display: inline-flex;
   align-items: center;
-  gap: var(--sp-2);
-  margin: 0.625rem 0.875rem 0;
-  padding: 4px 8px;
+  gap: 5px;
+  min-height: 30px;
+  padding: 3px 6px;
   border: 0;
-  border-radius: var(--radius-full);
-  background: color-mix(in srgb, var(--accent) 7%, var(--bg-surface));
+  border-radius: var(--radius-control);
+  background: transparent;
   color: var(--text-muted);
   font-size: var(--fs-xs);
 }
-.chat-project-chip__name,
-.chat-project-chip__path {
+.chat-project-chip > .icon {
+  flex: 0 0 auto;
+  color: var(--text-dim);
+}
+.chat-project-chip__name {
+  flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-weight: 400;
 }
-.chat-project-chip__name { flex-shrink: 0; font-weight: 650; }
-.chat-project-chip__path { color: var(--text-muted); font-family: var(--font-mono); }
 .chat-project-chip__status {
-  flex-shrink: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--warning, var(--text-muted));
   font-size: var(--fs-xs);
 }
 .chat-project-chip button {
+  flex: 0 0 auto;
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 2px;
   border: 0;
+  border-radius: var(--radius-full);
   background: transparent;
   color: inherit;
+  cursor: pointer;
+}
+.chat-project-chip button:hover,
+.chat-project-chip button:focus-visible {
+  outline: 0;
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.chat-project-chip[data-status="unavailable"],
+.chat-project-chip[data-status="removed"],
+.chat-project-chip[data-status="error"] {
+  background: color-mix(in srgb, var(--warn) 7%, transparent);
 }
 .chat-project-choose {
   flex-shrink: 0;

--- a/opensquilla-webui/src/components/chat/ChatComposer.vue
+++ b/opensquilla-webui/src/components/chat/ChatComposer.vue
@@ -235,20 +235,10 @@
             @set-mode="emit('setCollaborationMode', $event)"
           />
           <div class="chat-input-actions chat-input-actions--right">
-            <button
-              class="btn btn--icon btn--primary chat-send-btn"
-              :class="{ 'is-ready': hasSendContent && !sendBlockedMessage }"
-              :title="sendBlockedMessage || sendButtonTitle"
-              :aria-label="replanActive ? t('chat.plan.reviseSend') : t('chat.send')"
-              :aria-describedby="sendBlockedMessage ? 'chat-composer-send-status' : undefined"
-              :disabled="Boolean(sendBlockedMessage)"
-              @click="emit('send')"
-            >
-              <Icon name="arrowUp" :size="17" />
-            </button>
-            <Transition name="composer-ctl">
+            <Transition name="composer-ctl" mode="out-in">
               <button
                 v-if="canStop"
+                key="stop"
                 class="btn btn--icon btn--danger chat-send-btn"
                 :title="stopTargetsPlanRun
                   ? t('chat.planRun.stopExecutionEsc')
@@ -259,6 +249,19 @@
                 @click="emit('stop')"
               >
                 <Icon name="stop" :size="16" />
+              </button>
+              <button
+                v-else
+                key="send"
+                class="btn btn--icon btn--primary chat-send-btn"
+                :class="{ 'is-ready': hasSendContent && !sendBlockedMessage }"
+                :title="sendBlockedMessage || sendButtonTitle"
+                :aria-label="replanActive ? t('chat.plan.reviseSend') : t('chat.send')"
+                :aria-describedby="sendBlockedMessage ? 'chat-composer-send-status' : undefined"
+                :disabled="Boolean(sendBlockedMessage)"
+                @click="emit('send')"
+              >
+                <Icon name="arrowUp" :size="17" />
               </button>
             </Transition>
           </div>

--- a/opensquilla-webui/src/components/chat/ChatComposer.workspace.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatComposer.workspace.test.ts
@@ -23,6 +23,8 @@ describe('ChatComposer project draft', () => {
       sendButtonTitle: 'Send',
       runMode: 'trusted',
       allowedRunModes: ['standard', 'trusted', 'full'],
+      runModeLocked: false,
+      runModeLockMessage: '',
       modelRoutingMode: 'off',
       modelRoutingSettingsBusy: false,
       routerVisualEffectsEnabled: true,
@@ -78,7 +80,7 @@ describe('ChatComposer project draft', () => {
     app.unmount()
   })
 
-  it('shows both the project name and path and lets a blank draft close it', async () => {
+  it('shows a new project draft in the bottom toolbar and lets it close', async () => {
     const closeProject = vi.fn()
     const host = document.createElement('div')
     document.body.appendChild(host)
@@ -91,15 +93,17 @@ describe('ChatComposer project draft', () => {
     await nextTick()
 
     expect(host.querySelector('.chat-project-chip__name')?.textContent).toBe('Project A')
-    expect(host.querySelector('.chat-project-chip__path')?.textContent).toBe('D:\\repos\\project-a')
-    expect(host.querySelector('.chat-project-chip')?.closest('.chat-input-panel')).toBeTruthy()
+    expect(host.querySelector('.chat-project-chip__path')).toBeNull()
+    expect(host.querySelector('.chat-project-chip')?.getAttribute('title')).toBe('D:\\repos\\project-a')
+    expect(host.querySelector('.chat-project-chip')?.closest('.chat-input-footer')).toBeTruthy()
+    expect(host.querySelector('.chat-project-chip')?.parentElement?.classList.contains('chat-input-actions--left')).toBe(true)
     host.querySelector<HTMLButtonElement>('.chat-project-chip button')?.click()
     expect(closeProject).toHaveBeenCalledOnce()
 
     app.unmount()
   })
 
-  it('keeps a durable project chip visible without a close control', async () => {
+  it('hides redundant project context inside a durable project task', async () => {
     const host = document.createElement('div')
     document.body.appendChild(host)
     const app = createApp(ChatComposer, composerProps({
@@ -110,8 +114,7 @@ describe('ChatComposer project draft', () => {
     app.mount(host)
     await nextTick()
 
-    expect(host.querySelector('.chat-project-chip__name')?.textContent).toBe('Project A')
-    expect(host.querySelector('.chat-project-chip button')).toBeNull()
+    expect(host.querySelector('.chat-project-chip')).toBeNull()
 
     app.unmount()
   })
@@ -120,6 +123,8 @@ describe('ChatComposer project draft', () => {
     const host = document.createElement('div')
     document.body.appendChild(host)
     const app = createApp(ChatComposer, composerProps({
+      isNewLanding: false,
+      canCloseProject: false,
       modelValue: 'hello',
       hasSendContent: true,
       projectWorkspaceStatus: 'unavailable',

--- a/opensquilla-webui/src/components/chat/EmptyStateChips.test.ts
+++ b/opensquilla-webui/src/components/chat/EmptyStateChips.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, ref } from 'vue'
 import i18n from '@/i18n'
+import zhHans from '@/locales/zh-Hans.json'
 import EmptyStateChips from './EmptyStateChips.vue'
 
 vi.mock('@/composables/useRpc', () => ({
@@ -15,7 +16,7 @@ vi.mock('@/composables/useRpc', () => ({
 
 async function mountChips(props: {
   suppressed?: boolean
-  metaSkills?: Array<{ value: string; description: string }>
+  disabled?: boolean
   onPick?: (text: string) => void
 } = {}) {
   const el = document.createElement('div')
@@ -36,33 +37,63 @@ beforeEach(() => {
 })
 
 describe('EmptyStateChips', () => {
-  it('hides both task and meta-skill actions while suppressed', async () => {
+  it('hides task actions while suppressed', async () => {
     const { app, el } = await mountChips({
       suppressed: true,
-      metaSkills: [{ value: 'meta-paper-write', description: 'Draft a paper' }],
     })
 
     expect(el.querySelector('.empty-state__chips')).toBeNull()
-    expect(el.querySelector('.empty-state__meta')).toBeNull()
     expect(el.querySelector('.empty-state__greeting')).not.toBeNull()
     app.unmount()
   })
 
-  it('emits both ordinary and meta-skill choices when available', async () => {
+  it('emits an ordinary suggestion when selected', async () => {
     const onPick = vi.fn()
     const { app, el } = await mountChips({
-      metaSkills: [{ value: 'meta-paper-write', description: 'Draft a paper' }],
       onPick,
     })
 
     el.querySelector<HTMLButtonElement>('.empty-state__chip')
       ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    el.querySelector<HTMLButtonElement>('.empty-state__meta-chip')
-      ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await nextTick()
 
-    expect(onPick).toHaveBeenCalledTimes(2)
-    expect(onPick).toHaveBeenLastCalledWith('/meta meta-paper-write')
+    expect(onPick).toHaveBeenCalledTimes(1)
+    app.unmount()
+  })
+
+  it('uses the game label while emitting the full voxel-racing prompt', async () => {
+    i18n.global.setLocaleMessage('zh-Hans', zhHans)
+    i18n.global.locale.value = 'zh-Hans'
+    const onPick = vi.fn()
+    const { app, el } = await mountChips({ onPick })
+    const game = [...el.querySelectorAll<HTMLButtonElement>('.empty-state__chip')]
+      .find(button => button.textContent?.trim() === '帮我做个游戏')
+
+    expect(game).toBeTruthy()
+    game?.click()
+    await nextTick()
+
+    expect(onPick).toHaveBeenCalledWith(
+      '构建一个可玩的浏览器端体素竞速游戏原型，包含响应式操控、加速/刹车、可读赛道、碰撞检测、检查点、圈速计时和重启流程。用代码生成体素风格的赛车和场景，不使用付费素材。运行游戏、测试控制、修复阻塞性问题后交付。我希望风景更好,开放世界。且地图在有opensquilla和 tokenrhythm这两个标识 是赞助商彩蛋',
+    )
+    app.unmount()
+  })
+
+  it('keeps the suggestion row visible but inert while disabled', async () => {
+    const onPick = vi.fn()
+    const { app, el } = await mountChips({
+      disabled: true,
+      onPick,
+    })
+
+    const task = el.querySelector<HTMLButtonElement>('.empty-state__chip')
+    expect(task?.disabled).toBe(true)
+    expect(el.querySelector('.empty-state__chips')).not.toBeNull()
+    expect(el.querySelector('.empty-state__meta')).toBeNull()
+
+    task?.click()
+    await nextTick()
+    expect(onPick).not.toHaveBeenCalled()
     app.unmount()
   })
 })

--- a/opensquilla-webui/src/components/chat/EmptyStateChips.vue
+++ b/opensquilla-webui/src/components/chat/EmptyStateChips.vue
@@ -1,34 +1,21 @@
 <template>
   <div class="empty-state">
     <p class="empty-state__greeting">{{ greeting }}</p>
-    <div v-if="!suppressed" class="empty-state__chips" role="group" :aria-label="t('chat.suggestedTasks')">
-      <button
-        v-for="chip in chips"
-        :key="chip"
-        type="button"
-        class="empty-state__chip"
-        @click="emit('pick', chip)"
-      >{{ chip }}</button>
-    </div>
     <div
-      v-if="!suppressed && metaSkills.length"
-      class="empty-state__meta"
+      v-if="!suppressed"
+      class="empty-state__chips"
       role="group"
-      :aria-label="t('cronSkills.skillsView.metaSkillsTitle')"
+      :aria-label="t('chat.suggestedTasks')"
+      :aria-disabled="disabled || undefined"
     >
       <button
-        v-for="skill in metaSkills"
-        :key="skill.value"
+        v-for="chip in chips"
+        :key="chip.label"
         type="button"
-        class="empty-state__meta-chip"
-        :title="skill.description"
-        @click="emit('pick', `/meta ${skill.value}`)"
-      >
-        <span class="empty-state__meta-icon" aria-hidden="true">
-          <Icon :name="metaSkillIcon(skill.value)" :size="16" />
-        </span>
-        <span class="empty-state__meta-label">{{ metaSkillLabel(skill.value) }}</span>
-      </button>
+        class="empty-state__chip"
+        :disabled="disabled"
+        @click="emit('pick', chip.prompt)"
+      >{{ chip.label }}</button>
     </div>
   </div>
 </template>
@@ -36,9 +23,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import Icon from '@/components/Icon.vue'
 import { useRpcCall } from '@/composables/useRpc'
-import type { IconName } from '@/utils/icons'
 
 const { t } = useI18n()
 
@@ -51,23 +36,37 @@ interface CapabilityStatus {
 
 withDefaults(defineProps<{
   agentId: string
-  metaSkills?: Array<{ value: string; description: string }>
   suppressed?: boolean
+  disabled?: boolean
 }>(), {
-  metaSkills: () => [],
   suppressed: false,
+  disabled: false,
 })
 
 const emit = defineEmits<{
   pick: [text: string]
 }>()
 
+interface SuggestionChip {
+  label: string
+  prompt: string
+}
+
+function ordinaryChip(label: string): SuggestionChip {
+  return { label, prompt: label }
+}
+
+const buildGameChip = computed<SuggestionChip>(() => ({
+  label: t('chat.chips.buildGame'),
+  prompt: t('chat.chips.buildGamePrompt'),
+}))
+
 // Rendered immediately so a late capability lookup swaps labels in place
 // instead of shifting the landing layout, and kept whenever the lookup fails.
 const FALLBACK_CHIPS = computed(() => [
-  t('chat.chips.whatCanYouDo'),
-  t('chat.chips.summarizeWebpage'),
-  t('chat.chips.planWeek'),
+  buildGameChip.value,
+  ordinaryChip(t('chat.chips.summarizeWebpage')),
+  ordinaryChip(t('chat.chips.planWeek')),
 ])
 
 const capabilityStatus = useRpcCall<CapabilityStatus>('onboarding.status')
@@ -82,30 +81,18 @@ const greeting = computed(() => {
 const chips = computed(() => {
   const status = capabilityStatus.data.value
   if (!status) return FALLBACK_CHIPS.value
-  const derived: string[] = []
-  if (status.searchConfigured) derived.push(t('chat.chips.searchAiNews'))
+  const derived: SuggestionChip[] = []
+  if (status.searchConfigured) derived.push(ordinaryChip(t('chat.chips.searchAiNews')))
   if (status.imageGenerationConfigured && status.imageGenerationEnabled !== false) {
-    derived.push(t('chat.chips.generateImage'))
+    derived.push(ordinaryChip(t('chat.chips.generateImage')))
   }
-  derived.push(t('chat.chips.summarizeWebpage'), t('chat.chips.whatCanYouDo'))
-  if (derived.length < 3) derived.push(t('chat.chips.planWeek'))
+  derived.push(
+    ordinaryChip(t('chat.chips.summarizeWebpage')),
+    buildGameChip.value,
+  )
+  if (derived.length < 3) derived.push(ordinaryChip(t('chat.chips.planWeek')))
   return derived.slice(0, 4)
 })
-
-function metaSkillLabel(name: string): string {
-  const labels: Record<string, string> = {
-    AwesomeWebpageMetaSkill: t('chat.metaQuick.webpage'),
-    'meta-short-drama': t('chat.metaQuick.shortDrama'),
-    'meta-paper-write': t('chat.metaQuick.paperWriting'),
-  }
-  return labels[name] || name
-}
-
-function metaSkillIcon(name: string): IconName {
-  if (name === 'AwesomeWebpageMetaSkill') return 'fileCode'
-  if (name === 'meta-short-drama') return 'play'
-  return 'fileText'
-}
 </script>
 
 <style scoped>
@@ -188,60 +175,20 @@ function metaSkillIcon(name: string): IconName {
   color: var(--text);
 }
 
+.empty-state__chip:disabled {
+  cursor: default;
+  opacity: 0.72;
+}
+
+.empty-state__chip:disabled:hover {
+  background: var(--bg-elevated);
+  border-color: var(--border);
+  color: var(--text-muted);
+}
+
 .empty-state__chip:focus-visible {
   outline: none;
   box-shadow: var(--focus-ring);
-}
-
-.empty-state__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  justify-content: center;
-  margin-top: var(--sp-1);
-  max-width: 100%;
-}
-
-.empty-state__meta-chip {
-  align-items: center;
-  background: transparent;
-  border: 0;
-  border-radius: var(--radius-sm);
-  color: var(--text-muted);
-  cursor: pointer;
-  display: inline-flex;
-  font: inherit;
-  font-size: 13px;
-  font-weight: 600;
-  gap: 6px;
-  min-height: 32px;
-  padding: 5px 9px;
-  white-space: nowrap;
-  transition: background var(--transition), border-color var(--transition), color var(--transition);
-}
-
-.empty-state__meta-chip:hover {
-  background: color-mix(in srgb, var(--text) 5%, transparent);
-  color: var(--text);
-}
-
-.empty-state__meta-chip:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
-}
-
-.empty-state__meta-icon {
-  align-items: center;
-  color: var(--text-muted);
-  display: inline-flex;
-  flex: 0 0 16px;
-  height: 16px;
-  justify-content: center;
-  width: 16px;
-}
-
-.empty-state__meta-label {
-  line-height: 20px;
 }
 
 @media (max-width: 768px) {
@@ -253,13 +200,6 @@ function metaSkillIcon(name: string): IconName {
     min-height: 2.75rem;
   }
 
-  .empty-state__meta-chip {
-    min-height: 40px;
-  }
-
-  .empty-state__meta {
-    max-width: calc(100vw - 32px);
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -271,8 +211,5 @@ function metaSkillIcon(name: string): IconName {
     transition: none;
   }
 
-  .empty-state__meta-chip {
-    transition: none;
-  }
 }
 </style>

--- a/opensquilla-webui/src/components/chat/UserMessage.vue
+++ b/opensquilla-webui/src/components/chat/UserMessage.vue
@@ -87,8 +87,8 @@
       </button>
       <time v-if="timeIso" class="msg-time" :datetime="timeIso" :title="timeFull">
         <span class="msg-time__abs">{{ timeAbs }}</span>
-        <span class="msg-time__dot" aria-hidden="true">·</span>
-        <span class="msg-time__rel">{{ timeRel }}</span>
+        <span v-if="timeRel" class="msg-time__dot" aria-hidden="true">·</span>
+        <span v-if="timeRel" class="msg-time__rel">{{ timeRel }}</span>
       </time>
     </div>
   </div>

--- a/opensquilla-webui/src/components/chat/parts/ReasoningPart.test.ts
+++ b/opensquilla-webui/src/components/chat/parts/ReasoningPart.test.ts
@@ -34,7 +34,12 @@ function part(text: string, seconds: number): ReasoningChatPart {
   return { type: 'reasoning', key: `reasoning:${seconds}`, text, seconds }
 }
 
-function mount(props: { part: ReasoningChatPart; embedded?: boolean; live?: boolean }) {
+function mount(props: {
+  part: ReasoningChatPart
+  embedded?: boolean
+  live?: boolean
+  nested?: boolean
+}) {
   const host = document.createElement('div')
   document.body.appendChild(host)
   const app = createApp({ render: () => h(ReasoningPart, props) })
@@ -92,6 +97,13 @@ describe('ReasoningPart nested-in-activity variant', () => {
   it('marks the live fold as in-activity so the doubled left rule is dropped', () => {
     const host = mount({ part: part('t', 4), live: true })
     expect(host.querySelector('details.thinking-fold--in-activity')).not.toBeNull()
+  })
+
+  it('marks a settled nested fold without using live wording', () => {
+    const host = mount({ part: part('t', 4), nested: true })
+    expect(host.querySelector('details.thinking-fold--in-activity')).not.toBeNull()
+    expect(host.querySelector('.thinking-fold__summary')?.textContent)
+      .toContain('Thought for 4s')
   })
 
   it('keeps the standalone compat fold free of the in-activity modifier', () => {

--- a/opensquilla-webui/src/components/chat/parts/ReasoningPart.vue
+++ b/opensquilla-webui/src/components/chat/parts/ReasoningPart.vue
@@ -10,7 +10,11 @@
        as the nested-context marker: inside ActivityDisclosure the activity body
        already draws the fold's left rule, and a second rule here reads as
        doubled chrome. -->
-  <details v-else class="thinking-fold" :class="{ 'thinking-fold--in-activity': live }">
+  <details
+    v-else
+    class="thinking-fold"
+    :class="{ 'thinking-fold--in-activity': nested || live }"
+  >
     <summary class="thinking-fold__summary">
       <Icon class="thinking-fold__chevron" name="chevronRight" :size="12" />
       <span>{{ summary }}</span>
@@ -30,6 +34,8 @@ const { t } = useI18n()
 const props = defineProps<{
   part: Extract<ChatPart, { type: 'reasoning' }>
   embedded?: boolean
+  /** Nested inside the outer activity disclosure. */
+  nested?: boolean
   /** Streaming turn: label the fold "Thinking · Ns" (matching the live
    * elapsed ticker) instead of the settled "Thought for …" wording. */
   live?: boolean

--- a/opensquilla-webui/src/components/run/RunTrace.activity-presentation.test.ts
+++ b/opensquilla-webui/src/components/run/RunTrace.activity-presentation.test.ts
@@ -214,7 +214,7 @@ describe('RunTrace activity presentation', () => {
     ).toEqual(['Done', 'Failed'])
   })
 
-  it('neutralizes completed chrome while retaining failure state', async () => {
+  it('neutralizes completed chrome and omits failed activity', async () => {
     const el = await mountTimeline(
       [completedGroup, failedGroup],
       { presentation: 'activity' },
@@ -237,15 +237,16 @@ describe('RunTrace activity presentation', () => {
     expect(
       Array.from(el.querySelectorAll('.tool-row--group .tool-row__status'))
         .map(node => node.textContent),
-    ).toEqual(["Didn't complete"])
+    ).toEqual([])
     expect(
       el.querySelector('.tool-row--group')?.getAttribute('aria-expanded'),
     ).toBe('false')
     expect(el.querySelector('.tool-row__bullet--err')).toBeNull()
-    expect(el.querySelector('.tool-row__activity-icon--error')).not.toBeNull()
+    expect(el.querySelector('.tool-row__activity-icon--error')).toBeNull()
     expect(el.querySelector('.tool-row__state-icon--err')).toBeNull()
-    expect(el.querySelector('.activity-tool-details__line--error')).not.toBeNull()
+    expect(el.querySelector('.activity-tool-details__line--error')).toBeNull()
     expect(el.querySelector('.tool-row-section--error')).toBeNull()
+    expect(el.textContent).not.toContain('failed-group')
   })
 
   it('uses the running treatment without repeating a running status label', async () => {
@@ -260,7 +261,7 @@ describe('RunTrace activity presentation', () => {
     expect(el.querySelector('.tool-row--group .tool-row__status')).toBeNull()
   })
 
-  it('shows an accessible failure status for a single activity call', async () => {
+  it('omits a single failed activity call', async () => {
     const el = await mountTimeline([
       group('single-failure-group', [
         call('single-failure', {
@@ -272,22 +273,12 @@ describe('RunTrace activity presentation', () => {
       ]),
     ], { presentation: 'activity' })
 
-    // The failure is plain content of the row button, so it joins the row's
-    // accessible name; a live region mounted already-populated never announces.
-    const row = el.querySelector<HTMLButtonElement>('.tool-row--error')
-    const status = row?.querySelector('.tool-row__status')
-    expect(status?.textContent).toBe("Didn't complete")
-    expect(row?.textContent).toContain("Didn't complete")
+    expect(el.querySelector('.tool-row--error')).toBeNull()
+    expect(el.textContent).not.toContain('single-failure-group')
     expect(el.querySelector('[role="status"]')).toBeNull()
-    expect(el.querySelector('.tool-row__state-icon--err')).toBeNull()
-    expect(el.querySelector('.tool-row__activity-icon--error')).not.toBeNull()
-    expect(el.querySelector('.tool-row__activity-arrow')).not.toBeNull()
-    expect(
-      el.querySelector('.activity-tool-details__hit-target')?.hasAttribute('data-share-control'),
-    ).toBe(true)
   })
 
-  it('keeps injected cancellation copy visible for assistive technology', async () => {
+  it('omits cancelled activity even when it has injected status copy', async () => {
     const el = await mountTimeline([
       group('single-cancelled-group', [
         call('single-cancelled', {
@@ -302,13 +293,28 @@ describe('RunTrace activity presentation', () => {
       toolStatusText: () => 'Cancelled',
     })
 
-    const row = el.querySelector<HTMLButtonElement>('.tool-row--error')
-    expect(
-      row?.querySelector('.tool-row__status')?.textContent,
-    ).toBe('Cancelled')
-    // Read as part of the row's accessible name, not via a live region.
-    expect(row?.textContent).toContain('Cancelled')
+    expect(el.querySelector('.tool-row--error')).toBeNull()
+    expect(el.textContent).not.toContain('Cancelled')
     expect(el.querySelector('[role="status"]')).toBeNull()
+  })
+
+  it('keeps successful calls from a mixed activity group', async () => {
+    const el = await mountTimeline([
+      group('mixed-group', [
+        call('successful-call'),
+        call('failed-call', {
+          status: 'error',
+          isError: true,
+          result: 'failed',
+          resultPreview: 'failed',
+        }),
+      ]),
+    ], { presentation: 'activity' })
+
+    expect(el.querySelectorAll('.tool-row')).toHaveLength(1)
+    expect(el.querySelector('.tool-row--error')).toBeNull()
+    expect(el.textContent).toContain('mixed-group')
+    expect(el.textContent).not.toContain('failed-call')
   })
 
   it('keeps a successful activity call collapsed until explicitly opened', async () => {

--- a/opensquilla-webui/src/components/run/RunTrace.vue
+++ b/opensquilla-webui/src/components/run/RunTrace.vue
@@ -743,9 +743,51 @@ function decorateCodeBlocks() {
 // Chat passes `items` (proven group data); non-chat surfaces pass flat steps,
 // which compose into the same tool-group timeline shape so the markup never
 // branches on input source.
+function withoutFailedActivityRows(
+  items: ChatStreamTimelineItem[],
+): ChatStreamTimelineItem[] {
+  if (props.presentation !== 'activity') return items
+
+  return items.flatMap((item): ChatStreamTimelineItem[] => {
+    if (item.type !== 'tool-group') return [item]
+
+    const failedCalls = item.group.calls.filter(
+      call => call.isError || call.status === 'error',
+    )
+    // Restored histories can retain only the group-level failure marker. In
+    // that case none of the calls is safe to present as completed activity.
+    if (
+      (item.group.isError || item.group.status === 'error')
+      && failedCalls.length === 0
+    ) {
+      return []
+    }
+
+    const calls = item.group.calls.filter(
+      call => !call.isError && call.status !== 'error',
+    )
+    if (calls.length === 0) return []
+
+    const isRunning = calls.some(call => call.isRunning)
+    return [{
+      ...item,
+      group: {
+        ...item.group,
+        calls,
+        isRunning,
+        isError: false,
+        status: isRunning
+          ? ''
+          : calls.every(call => call.status === 'success')
+            ? 'success'
+            : '',
+      },
+    }]
+  })
+}
+
 const resolvedItems = computed<ChatStreamTimelineItem[]>(() => {
-  if (props.items) return props.items
-  return composeTree(props.steps ?? []).map((node): ChatStreamTimelineItem => {
+  const items = props.items ?? composeTree(props.steps ?? []).map((node): ChatStreamTimelineItem => {
     const members = node.children.length ? node.children.map(child => child.step) : [node.step]
     const calls = members.map(stepToRenderItem)
     const isError = calls.some(call => call.isError || call.status === 'error')
@@ -766,6 +808,7 @@ const resolvedItems = computed<ChatStreamTimelineItem[]>(() => {
     }
     return { type: 'tool-group', key: node.step.id, group }
   })
+  return withoutFailedActivityRows(items)
 })
 
 function stepToRenderItem(step: NodeStep): ChatToolCallRenderItem {

--- a/opensquilla-webui/src/composables/chat/useChatShareExport.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatShareExport.test.ts
@@ -296,7 +296,7 @@ describe('ActivityDisclosure share hook contract', () => {
     expect(stage.textContent).not.toContain('step output')
   })
 
-  it('exports live activity as expanded static content', () => {
+  it('drops live activity from the share image while it is collapsed', () => {
     const host = mountDisclosure({
       lifecycle: 'working',
       stepCount: 3,
@@ -305,15 +305,13 @@ describe('ActivityDisclosure share hook contract', () => {
     })
     const activity = host.querySelector<HTMLElement>('[data-share-activity]')
 
-    expect(activity?.dataset.shareExpanded).toBe('true')
+    expect(activity?.dataset.shareExpanded).toBe('false')
     expect(activity?.querySelector('[data-share-activity-label]')).not.toBeNull()
     expect(activity?.querySelector('[data-share-activity-body]')).not.toBeNull()
 
     const stage = buildShareDom([host])
 
-    expect(stage.querySelector('.chat-share-export-activity__label')?.textContent)
-      .toContain('Running commands')
-    expect(stage.querySelector('.chat-share-export-activity__body')?.textContent)
-      .toContain('step output')
+    expect(stage.querySelector('.chat-share-export-activity')).toBeNull()
+    expect(stage.textContent).not.toContain('step output')
   })
 })

--- a/opensquilla-webui/src/composables/usage/useUsageChartRows.test.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageChartRows.test.ts
@@ -24,7 +24,7 @@ function totals(input: number, output: number, cost: number): UsageTotals {
 }
 
 describe('usage ledger day chart', () => {
-  it('uses server calendar-day buckets and does not turn them into session links', () => {
+  it('shows server calendar-day buckets newest first without turning them into session links', () => {
     const chartMode = ref<'tokens' | 'cost'>('tokens')
     const { chartCaption, chartRows } = useUsageChartRows({
       visibleSessions: computed(() => [{ sessionKey: 'should-not-drive-chart', inputTokens: 999 }]),
@@ -40,10 +40,10 @@ describe('usage ledger day chart', () => {
     })
 
     expect(chartCaption.value).toBe('Daily usage')
-    expect(chartRows.value.map(row => row.label)).toEqual(['2026-07-19', '2026-07-20'])
+    expect(chartRows.value.map(row => row.label)).toEqual(['2026-07-20', '2026-07-19'])
     expect(chartRows.value.every(row => row.sessionKey === null)).toBe(true)
-    expect(chartRows.value[1].valueLabel).toBe('30')
-    expect(chartRows.value[1].totalPct).toBeCloseTo(100)
+    expect(chartRows.value[0].valueLabel).toBe('30')
+    expect(chartRows.value[0].totalPct).toBeCloseTo(100)
   })
 
   it('uses native billing context for exact CNY daily costs', () => {

--- a/opensquilla-webui/src/composables/usage/useUsageChartRows.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageChartRows.ts
@@ -40,7 +40,9 @@ export function useUsageChartRows(options: {
   const chartRows = computed((): ChartRow[] => {
     const days = options.serverDays?.value
     if (days) {
-      const visibleDays = days.slice(-30)
+      const visibleDays = [...days]
+        .sort((a, b) => b.date.localeCompare(a.date))
+        .slice(0, 30)
       if (visibleDays.length === 0) return []
       let maxValue = Math.max(...visibleDays.map(day => (
         options.chartMode.value === 'cost'

--- a/opensquilla-webui/src/composables/useFreshTaskDraft.test.ts
+++ b/opensquilla-webui/src/composables/useFreshTaskDraft.test.ts
@@ -23,4 +23,18 @@ describe('useFreshTaskDraft', () => {
 
     expect(drafts.request.value?.workspaceId).toBeNull()
   })
+
+  it('keeps a materialized project task bound until canonical metadata confirms it', () => {
+    const drafts = useFreshTaskDraft()
+    const sessionKey = 'agent:main:webchat:project-transition'
+
+    drafts.bindMaterializedProjectTask(sessionKey, 'project-a')
+    expect(drafts.materializedWorkspaceBySession.value[sessionKey]).toBe('project-a')
+
+    drafts.confirmMaterializedProjectTask(sessionKey, null)
+    expect(drafts.materializedWorkspaceBySession.value[sessionKey]).toBe('project-a')
+
+    drafts.confirmMaterializedProjectTask(sessionKey, 'project-a')
+    expect(drafts.materializedWorkspaceBySession.value[sessionKey]).toBeUndefined()
+  })
 })

--- a/opensquilla-webui/src/composables/useFreshTaskDraft.ts
+++ b/opensquilla-webui/src/composables/useFreshTaskDraft.ts
@@ -7,6 +7,7 @@ export interface FreshTaskDraftRequest {
 }
 
 const request = shallowRef<FreshTaskDraftRequest | null>(null)
+const materializedWorkspaceBySession = shallowRef<Record<string, string>>({})
 let nextRequestId = 0
 
 /**
@@ -25,8 +26,34 @@ export function useFreshTaskDraft() {
     }
   }
 
+  function bindMaterializedProjectTask(sessionKey: string, workspaceId: string) {
+    if (!sessionKey || !workspaceId) return
+    if (materializedWorkspaceBySession.value[sessionKey] === workspaceId) return
+    materializedWorkspaceBySession.value = {
+      ...materializedWorkspaceBySession.value,
+      [sessionKey]: workspaceId,
+    }
+  }
+
+  function confirmMaterializedProjectTask(sessionKey: string, workspaceId?: string | null) {
+    const optimisticWorkspaceId = materializedWorkspaceBySession.value[sessionKey]
+    if (!optimisticWorkspaceId || !workspaceId) return
+    const { [sessionKey]: _confirmed, ...remaining } = materializedWorkspaceBySession.value
+    materializedWorkspaceBySession.value = remaining
+  }
+
+  function forgetMaterializedProjectTask(sessionKey: string) {
+    if (!materializedWorkspaceBySession.value[sessionKey]) return
+    const { [sessionKey]: _forgotten, ...remaining } = materializedWorkspaceBySession.value
+    materializedWorkspaceBySession.value = remaining
+  }
+
   return {
     request: readonly(request),
+    materializedWorkspaceBySession: readonly(materializedWorkspaceBySession),
     requestFreshTask,
+    bindMaterializedProjectTask,
+    confirmMaterializedProjectTask,
+    forgetMaterializedProjectTask,
   }
 }

--- a/opensquilla-webui/src/composables/useSessions.projects.test.ts
+++ b/opensquilla-webui/src/composables/useSessions.projects.test.ts
@@ -49,6 +49,31 @@ describe('persisted project sidebar arrangement', () => {
       .toEqual(['workspace:b', 'workspace:a'])
   })
 
+  it('shows a provisional draft under its project and includes it in the visible count', () => {
+    const projects: ProjectWorkspaceItem[] = [
+      { id: 'project-a', name: 'Project A', path: '/repo/a', taskCount: 0, pinned: false, available: true },
+    ]
+    const draft = session({
+      key: 'draft:project:project-a:1',
+      title: 'New task',
+      updatedAt: 300,
+      workspaceId: 'project-a',
+    })
+    draft.provisional = true
+    draft.sessionKind = 'chat'
+    draft.surface = 'webchat'
+    const rows = arrangeSidebarSections([draft], projects)[0].rows
+
+    expect(rows.map(row => row.rowKind)).toEqual(['workspace', 'session'])
+    expect(rows[0].workspaceTaskCount).toBe(1)
+    expect(rows[1]).toMatchObject({
+      key: 'draft:project:project-a:1',
+      workspaceId: 'project-a',
+      provisional: true,
+      depth: 1,
+    })
+  })
+
   it('keeps workspace-bound tasks visible while the canonical project list is unavailable', () => {
     const rows = arrangeSidebarSections([
       session({

--- a/opensquilla-webui/src/composables/useSessions.ts
+++ b/opensquilla-webui/src/composables/useSessions.ts
@@ -30,6 +30,8 @@ export interface SessionItem {
   messageCount: number | null
   updatedAt: number
   interactive: boolean
+  /** Client-only draft that has not been materialized by its first send yet. */
+  provisional?: boolean
   /** True when this session was forked from its parent's transcript. */
   forkedFromParent: boolean
   contractGaps: string[]
@@ -421,6 +423,7 @@ export interface SidebarSectionRow {
   workspaceTaskCount?: number
   workspacePinned?: boolean
   workspaceAvailable?: boolean
+  provisional?: boolean
 }
 
 /** One collapsible family section with its recency-ordered rows. */
@@ -498,6 +501,7 @@ export function arrangeSidebarSections(
     workspaceId: item.workspaceId,
     workspaceLabel: item.workspaceLabel,
     workspaceDisplayPath: item.workspaceDisplayPath,
+    provisional: item.provisional,
   })
 
   type WorkspaceBucket = {
@@ -595,7 +599,8 @@ export function arrangeSidebarSections(
         workspaceId: project.id,
         workspaceLabel: project.name,
         workspaceDisplayPath: project.path,
-        workspaceTaskCount: project.taskCount,
+        workspaceTaskCount: project.taskCount
+          + projectEntries.filter(entry => entry.item.provisional).length,
         workspacePinned: project.pinned,
         workspaceAvailable: project.available,
       })

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -1,6 +1,13 @@
 {
   "workspaces": {
     "projects": "Projekte",
+    "createProject": "Projekt erstellen",
+    "projectNamePlaceholder": "Projektname",
+    "sourceFolders": "Quellordner",
+    "addSourceFolder": "Einen Ordner hinzufügen, den OpenSquilla lesen und bearbeiten kann",
+    "creatingProject": "Wird erstellt…",
+    "projectCreated": "Projekt „{name}“ erstellt",
+    "createProjectFailed": "Projekt konnte nicht erstellt werden: {error}",
     "noTasks": "Keine Aufgaben",
     "chooseProject": "Projekt auswählen",
     "webPickerScope": "Diese Pfade befinden sich auf dem Gateway-Host.",

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -1,5 +1,6 @@
 {
   "workspaces": {
+    "projects": "Projekte",
     "noTasks": "Keine Aufgaben",
     "chooseProject": "Projekt auswählen",
     "webPickerScope": "Diese Pfade befinden sich auf dem Gateway-Host.",
@@ -30,6 +31,8 @@
     "unpin": "Projekt lösen",
     "deleteHistory": "Projektaufgabenverlauf löschen",
     "removeProject": "Projekt entfernen",
+    "menuDeleteHistory": "Verlauf löschen",
+    "menuRemove": "Entfernen",
     "deleteHistoryTitle": "Projektaufgabenverlauf löschen?",
     "deleteHistoryBody": "{count} Aufgaben aus {name} werden dauerhaft gelöscht. Dateien im Projektordner bleiben erhalten.",
     "deleteHistoryConfirm": "Verlauf löschen",
@@ -2902,6 +2905,7 @@
     "thinkingForSeconds": "Denkt nach · {seconds}s",
     "thoughtForSeconds": "{seconds}s nachgedacht",
     "thoughtForMinutes": "{minutes}min {seconds}s nachgedacht",
+    "activityTechnicalDetails": "Technische Details",
     "toolResult": "Werkzeugergebnis",
     "subagentPrefix": "Subagent: ",
     "subagentCompletion": "Subagent-Abschluss",
@@ -2973,6 +2977,8 @@
     "activityWorking": "In Arbeit",
     "workedForSeconds": "{seconds} Sek. gearbeitet",
     "workedForMinutes": "{minutes} Min. {seconds} Sek. gearbeitet",
+    "activityDurationSeconds": "{seconds} Sek.",
+    "activityDurationMinutes": "{minutes} Min. {seconds} Sek.",
     "activity": {
       "lifecycle": {
         "working": "In Arbeit",
@@ -3242,6 +3248,8 @@
     },
     "chips": {
       "whatCanYouDo": "Was kannst du?",
+      "buildGame": "Baue mir ein Spiel",
+      "buildGamePrompt": "Erstelle einen spielbaren, browserbasierten Prototyp eines Voxel-Rennspiels mit reaktionsschneller Steuerung, Beschleunigen und Bremsen, einer gut lesbaren Strecke, Kollisionserkennung, Kontrollpunkten, Rundenzeitmessung und einem Neustart-Ablauf. Generiere Rennwagen und Landschaft im Voxel-Stil per Code und verwende keine kostenpflichtigen Assets. Starte das Spiel, teste die Steuerung, behebe blockierende Probleme und liefere es anschließend aus. Die Landschaft soll schöner und die Welt offen sein. Platziere OpenSquilla- und TokenRhythm-Schilder als Sponsor-Easter-Eggs auf der Karte.",
       "summarizeWebpage": "Fasse eine Webseite für mich zusammen",
       "planWeek": "Entwirf einen Plan für meine Woche",
       "searchAiNews": "Suche die heutigen AI-News",
@@ -3313,6 +3321,7 @@
     },
     "msgMeta": {
       "ensembleModels": "Ensemble · {count} Modelle",
+      "model": "Modell",
       "tokens": "Tokens",
       "cache": "Cache",
       "think": "Denken",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -1,5 +1,6 @@
 {
   "workspaces": {
+    "projects": "Projects",
     "noTasks": "No tasks",
     "chooseProject": "Choose project",
     "webPickerScope": "These paths are on the Gateway host.",
@@ -30,6 +31,8 @@
     "unpin": "Unpin project",
     "deleteHistory": "Delete project task history",
     "removeProject": "Remove project",
+    "menuDeleteHistory": "Delete history",
+    "menuRemove": "Remove",
     "deleteHistoryTitle": "Delete project task history?",
     "deleteHistoryBody": "Permanently delete {count} tasks from {name}. Files in the project directory will not be deleted.",
     "deleteHistoryConfirm": "Delete history",
@@ -2902,6 +2905,7 @@
     "thinkingForSeconds": "Thinking · {seconds}s",
     "thoughtForSeconds": "Thought for {seconds}s",
     "thoughtForMinutes": "Thought for {minutes}m {seconds}s",
+    "activityTechnicalDetails": "Technical details",
     "toolResult": "Tool Result",
     "subagentPrefix": "Subagent: ",
     "subagentCompletion": "Subagent completion",
@@ -2973,6 +2977,8 @@
     "activityWorking": "Working",
     "workedForSeconds": "Worked for {seconds}s",
     "workedForMinutes": "Worked for {minutes}m {seconds}s",
+    "activityDurationSeconds": "{seconds}s",
+    "activityDurationMinutes": "{minutes}m {seconds}s",
     "activity": {
       "lifecycle": {
         "working": "Working",
@@ -3242,6 +3248,8 @@
     },
     "chips": {
       "whatCanYouDo": "What can you do?",
+      "buildGame": "Build me a game",
+      "buildGamePrompt": "Build a playable browser-based voxel racing game prototype with responsive controls, acceleration and braking, a readable track, collision detection, checkpoints, lap timing, and a restart flow. Generate the voxel-style race car and scenery in code without paid assets. Run the game, test the controls, fix blocking issues, and then deliver it. Make the scenery more beautiful and the world open. Include OpenSquilla and TokenRhythm signage on the map as sponsor Easter eggs.",
       "summarizeWebpage": "Summarize a webpage for me",
       "planWeek": "Draft a plan for my week",
       "searchAiNews": "Search today's AI news",
@@ -3313,6 +3321,7 @@
     },
     "msgMeta": {
       "ensembleModels": "Ensemble · {count} models",
+      "model": "model",
       "tokens": "tokens",
       "cache": "cache",
       "think": "think",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -1,6 +1,13 @@
 {
   "workspaces": {
     "projects": "Projects",
+    "createProject": "Create project",
+    "projectNamePlaceholder": "Project name",
+    "sourceFolders": "Source folders",
+    "addSourceFolder": "Add a folder OpenSquilla can read and edit",
+    "creatingProject": "Creating…",
+    "projectCreated": "Created project “{name}”",
+    "createProjectFailed": "Could not create the project: {error}",
     "noTasks": "No tasks",
     "chooseProject": "Choose project",
     "webPickerScope": "These paths are on the Gateway host.",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -1,6 +1,13 @@
 {
   "workspaces": {
     "projects": "Proyectos",
+    "createProject": "Crear proyecto",
+    "projectNamePlaceholder": "Nombre del proyecto",
+    "sourceFolders": "Carpetas de origen",
+    "addSourceFolder": "Añadir una carpeta que OpenSquilla pueda leer y editar",
+    "creatingProject": "Creando…",
+    "projectCreated": "Proyecto «{name}» creado",
+    "createProjectFailed": "No se pudo crear el proyecto: {error}",
     "noTasks": "Sin tareas",
     "chooseProject": "Elegir proyecto",
     "webPickerScope": "Estas rutas pertenecen al host de Gateway.",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -1,5 +1,6 @@
 {
   "workspaces": {
+    "projects": "Proyectos",
     "noTasks": "Sin tareas",
     "chooseProject": "Elegir proyecto",
     "webPickerScope": "Estas rutas pertenecen al host de Gateway.",
@@ -30,6 +31,8 @@
     "unpin": "Desfijar proyecto",
     "deleteHistory": "Eliminar historial de tareas",
     "removeProject": "Quitar proyecto",
+    "menuDeleteHistory": "Eliminar historial",
+    "menuRemove": "Quitar",
     "deleteHistoryTitle": "¿Eliminar el historial de tareas del proyecto?",
     "deleteHistoryBody": "Se eliminarán permanentemente {count} tareas de {name}. No se borrarán los archivos del proyecto.",
     "deleteHistoryConfirm": "Eliminar historial",
@@ -2902,6 +2905,7 @@
     "thinkingForSeconds": "Razonando · {seconds} s",
     "thoughtForSeconds": "Razonó durante {seconds} s",
     "thoughtForMinutes": "Razonó durante {minutes} min {seconds} s",
+    "activityTechnicalDetails": "Detalles técnicos",
     "toolResult": "Resultado de la herramienta",
     "subagentPrefix": "Subagente: ",
     "subagentCompletion": "Finalización del subagente",
@@ -2973,6 +2977,8 @@
     "activityWorking": "Trabajando",
     "workedForSeconds": "Trabajó durante {seconds} s",
     "workedForMinutes": "Trabajó durante {minutes} min {seconds} s",
+    "activityDurationSeconds": "{seconds} s",
+    "activityDurationMinutes": "{minutes} min {seconds} s",
     "activity": {
       "lifecycle": {
         "working": "En curso",
@@ -3242,6 +3248,8 @@
     },
     "chips": {
       "whatCanYouDo": "¿Qué puedes hacer?",
+      "buildGame": "Hazme un juego",
+      "buildGamePrompt": "Construye un prototipo jugable en el navegador de un juego de carreras de vóxeles, con controles responsivos, aceleración y frenado, una pista legible, detección de colisiones, puntos de control, cronometraje de vueltas y un flujo de reinicio. Genera con código el coche de carreras y los escenarios de estilo vóxel, sin usar recursos de pago. Ejecuta el juego, prueba los controles, corrige los problemas bloqueantes y luego entrégalo. Quiero mejores paisajes y un mundo abierto. Incluye señalización de OpenSquilla y TokenRhythm en el mapa como guiños de patrocinadores.",
       "summarizeWebpage": "Resúmeme una página web",
       "planWeek": "Esboza un plan para mi semana",
       "searchAiNews": "Busca las noticias de IA de hoy",
@@ -3313,6 +3321,7 @@
     },
     "msgMeta": {
       "ensembleModels": "Conjunto · {count} modelos",
+      "model": "modelo",
       "tokens": "tokens",
       "cache": "caché",
       "think": "razonamiento",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -1,5 +1,6 @@
 {
   "workspaces": {
+    "projects": "Projets",
     "noTasks": "Aucune tâche",
     "chooseProject": "Choisir un projet",
     "webPickerScope": "Ces chemins se trouvent sur l’hôte Gateway.",
@@ -30,6 +31,8 @@
     "unpin": "Désépingler le projet",
     "deleteHistory": "Supprimer l’historique des tâches",
     "removeProject": "Retirer le projet",
+    "menuDeleteHistory": "Supprimer l’historique",
+    "menuRemove": "Retirer",
     "deleteHistoryTitle": "Supprimer l’historique des tâches du projet ?",
     "deleteHistoryBody": "Supprime définitivement {count} tâches de {name}. Les fichiers du projet ne seront pas supprimés.",
     "deleteHistoryConfirm": "Supprimer l’historique",
@@ -2902,6 +2905,7 @@
     "thinkingForSeconds": "Réflexion · {seconds} s",
     "thoughtForSeconds": "A réfléchi pendant {seconds} s",
     "thoughtForMinutes": "A réfléchi pendant {minutes} min {seconds} s",
+    "activityTechnicalDetails": "Détails techniques",
     "toolResult": "Résultat de l'outil",
     "subagentPrefix": "Sous-agent : ",
     "subagentCompletion": "Achèvement du sous-agent",
@@ -2973,6 +2977,8 @@
     "activityWorking": "Travail en cours",
     "workedForSeconds": "Travail effectué pendant {seconds} s",
     "workedForMinutes": "Travail effectué pendant {minutes} min {seconds} s",
+    "activityDurationSeconds": "{seconds} s",
+    "activityDurationMinutes": "{minutes} min {seconds} s",
     "activity": {
       "lifecycle": {
         "working": "En cours",
@@ -3242,6 +3248,8 @@
     },
     "chips": {
       "whatCanYouDo": "Que peux-tu faire ?",
+      "buildGame": "Crée-moi un jeu",
+      "buildGamePrompt": "Construis un prototype jouable dans le navigateur d’un jeu de course en voxels, avec des commandes réactives, accélération et freinage, une piste lisible, la détection des collisions, des points de contrôle, le chronométrage des tours et un parcours de redémarrage. Génère en code la voiture et les décors en style voxel, sans ressources payantes. Lance le jeu, teste les commandes, corrige les problèmes bloquants, puis livre-le. Je veux de plus beaux paysages et un monde ouvert. Ajoute sur la carte des enseignes OpenSquilla et TokenRhythm comme clins d’œil de sponsors.",
       "summarizeWebpage": "Résume une page web pour moi",
       "planWeek": "Ébauche un plan pour ma semaine",
       "searchAiNews": "Recherche les actualités IA du jour",
@@ -3313,6 +3321,7 @@
     },
     "msgMeta": {
       "ensembleModels": "Ensemble · {count} modèles",
+      "model": "modèle",
       "tokens": "jetons",
       "cache": "cache",
       "think": "raisonnement",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -1,6 +1,13 @@
 {
   "workspaces": {
     "projects": "Projets",
+    "createProject": "Créer un projet",
+    "projectNamePlaceholder": "Nom du projet",
+    "sourceFolders": "Dossiers source",
+    "addSourceFolder": "Ajouter un dossier que OpenSquilla peut lire et modifier",
+    "creatingProject": "Création…",
+    "projectCreated": "Projet « {name} » créé",
+    "createProjectFailed": "Impossible de créer le projet : {error}",
     "noTasks": "Aucune tâche",
     "chooseProject": "Choisir un projet",
     "webPickerScope": "Ces chemins se trouvent sur l’hôte Gateway.",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -1,5 +1,6 @@
 {
   "workspaces": {
+    "projects": "プロジェクト",
     "noTasks": "タスクなし",
     "chooseProject": "プロジェクトを選択",
     "webPickerScope": "ここには Gateway ホスト上のパスが表示されます。",
@@ -30,6 +31,8 @@
     "unpin": "ピン留めを解除",
     "deleteHistory": "プロジェクトのタスク履歴を削除",
     "removeProject": "プロジェクトを削除",
+    "menuDeleteHistory": "履歴を削除",
+    "menuRemove": "リストから外す",
     "deleteHistoryTitle": "プロジェクトのタスク履歴を削除しますか？",
     "deleteHistoryBody": "{name} の {count} 件のタスクを完全に削除します。プロジェクト内のファイルは削除されません。",
     "deleteHistoryConfirm": "履歴を削除",
@@ -2902,6 +2905,7 @@
     "thinkingForSeconds": "思考中 · {seconds} 秒",
     "thoughtForSeconds": "{seconds} 秒間思考",
     "thoughtForMinutes": "{minutes} 分 {seconds} 秒間思考",
+    "activityTechnicalDetails": "技術的な詳細",
     "toolResult": "ツールの結果",
     "subagentPrefix": "サブエージェント: ",
     "subagentCompletion": "サブエージェントの完了",
@@ -2973,6 +2977,8 @@
     "activityWorking": "作業中",
     "workedForSeconds": "{seconds} 秒間作業",
     "workedForMinutes": "{minutes} 分 {seconds} 秒間作業",
+    "activityDurationSeconds": "{seconds} 秒",
+    "activityDurationMinutes": "{minutes} 分 {seconds} 秒",
     "activity": {
       "lifecycle": {
         "working": "作業中",
@@ -3242,6 +3248,8 @@
     },
     "chips": {
       "whatCanYouDo": "何ができますか？",
+      "buildGame": "ゲームを作って",
+      "buildGamePrompt": "レスポンスの良い操作、加速とブレーキ、見やすいコース、衝突判定、チェックポイント、ラップタイム計測、リスタート手順を備えた、ブラウザで遊べるボクセルレーシングゲームのプロトタイプを構築してください。ボクセル調のレーシングカーと風景は有料素材を使わずコードで生成してください。ゲームを実行し、操作をテストし、進行を妨げる問題を修正してから納品してください。美しい風景とオープンワールドを実現し、マップ上にスポンサーのイースターエッグとして OpenSquilla と TokenRhythm の看板を配置してください。",
       "summarizeWebpage": "ウェブページを要約して",
       "planWeek": "今週の計画を立てて",
       "searchAiNews": "今日の AI ニュースを検索して",
@@ -3313,6 +3321,7 @@
     },
     "msgMeta": {
       "ensembleModels": "アンサンブル · {count} モデル",
+      "model": "モデル",
       "tokens": "トークン",
       "cache": "キャッシュ",
       "think": "推論",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -1,6 +1,13 @@
 {
   "workspaces": {
     "projects": "プロジェクト",
+    "createProject": "プロジェクトを作成",
+    "projectNamePlaceholder": "プロジェクト名",
+    "sourceFolders": "ソースフォルダ",
+    "addSourceFolder": "OpenSquilla が読み書きできるフォルダを追加",
+    "creatingProject": "作成中…",
+    "projectCreated": "プロジェクト「{name}」を作成しました",
+    "createProjectFailed": "プロジェクトを作成できませんでした: {error}",
     "noTasks": "タスクなし",
     "chooseProject": "プロジェクトを選択",
     "webPickerScope": "ここには Gateway ホスト上のパスが表示されます。",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -857,7 +857,7 @@
       "modeRecommended": "跟随当前服务商分层",
       "modeDisabled": "关",
       "routingDisabledHint": "开启 AI 智能单模型路由后可编辑模型分层。",
-      "routingEnsembleReadOnlyHint": "当前已启用 AI 智能聚合路由，普通模型分层设置暂不生效。",
+      "routingEnsembleReadOnlyHint": "当前已启用 AI 智能融合路由，普通模型分层设置暂不生效。",
       "defaultTextModel": "默认模型分层",
       "panelLabel": "模型分层表",
       "panelDesc": "分层表中的模型会通过各行的服务商发送，因此每个服务商都使用相同的路由表结构。",
@@ -874,9 +874,9 @@
       "save": "保存路由",
       "chooseProviderFirst": "请先选择服务商",
       "summaryDisabled": "关",
-      "summaryEnsemble": "AI 智能聚合路由",
-      "ensembleProfileTitle": "AI 智能聚合路由",
-      "ensembleProfileDesc": "模型分层表会为 AI 智能聚合路由提供候选模型。",
+      "summaryEnsemble": "AI 智能融合路由",
+      "ensembleProfileTitle": "AI 智能融合路由",
+      "ensembleProfileDesc": "模型分层表会为 AI 智能融合路由提供候选模型。",
       "visualMode": {
         "real_candidates": "真实路由候选",
         "legacy_grid": "三层可视化面板"
@@ -891,8 +891,8 @@
       }
     },
     "ensemble": {
-      "statusOn": "AI 智能聚合路由已开启——多个模型作答，由一个模型整合最终回复。",
-      "statusOff": "AI 智能聚合路由已关闭。",
+      "statusOn": "AI 智能融合路由已开启——多个模型作答，由一个模型整合最终回复。",
+      "statusOff": "AI 智能融合路由已关闭。",
       "allFailedFallback": "回退到单一模型",
       "allFailedError": "停止并报告错误"
     },
@@ -3176,7 +3176,7 @@
       "modelRoutingOffDesc": "每轮都发送到当前选定模型。",
       "modelRoutingSquillaRouter": "AI 智能单模型路由",
       "modelRoutingSquillaRouterDesc": "由 AI 为每轮智能选择一个合适模型，优先降低成本。",
-      "modelRoutingEnsemble": "AI 智能聚合路由",
+      "modelRoutingEnsemble": "AI 智能融合路由",
       "modelRoutingEnsembleDesc": "由 AI 协调多个模型协同生成，优先提升复杂任务能力。",
       "runMode": "执行模式",
       "runModeStandard": "每次询问",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -1,5 +1,6 @@
 {
   "workspaces": {
+    "projects": "项目",
     "noTasks": "无任务",
     "chooseProject": "选择项目",
     "webPickerScope": "这里显示的是网关主机上的目录。",
@@ -30,6 +31,8 @@
     "unpin": "取消置顶",
     "deleteHistory": "删除项目任务历史",
     "removeProject": "移除项目",
+    "menuDeleteHistory": "删除历史",
+    "menuRemove": "移除",
     "deleteHistoryTitle": "删除项目任务历史？",
     "deleteHistoryBody": "将永久删除 {name} 中的 {count} 个任务，但不会删除项目目录中的文件。",
     "deleteHistoryConfirm": "删除历史",
@@ -2902,6 +2905,7 @@
     "thinkingForSeconds": "思考中 · {seconds} 秒",
     "thoughtForSeconds": "思考了 {seconds} 秒",
     "thoughtForMinutes": "思考了 {minutes} 分 {seconds} 秒",
+    "activityTechnicalDetails": "技术细节",
     "toolResult": "工具结果",
     "subagentPrefix": "子智能体：",
     "subagentCompletion": "子智能体完成",
@@ -2973,6 +2977,8 @@
     "activityWorking": "正在工作",
     "workedForSeconds": "工作了 {seconds} 秒",
     "workedForMinutes": "工作了 {minutes} 分 {seconds} 秒",
+    "activityDurationSeconds": "{seconds} 秒",
+    "activityDurationMinutes": "{minutes} 分 {seconds} 秒",
     "activity": {
       "lifecycle": {
         "working": "正在工作",
@@ -3242,6 +3248,8 @@
     },
     "chips": {
       "whatCanYouDo": "你能做什么？",
+      "buildGame": "帮我做个游戏",
+      "buildGamePrompt": "构建一个可玩的浏览器端体素竞速游戏原型，包含响应式操控、加速/刹车、可读赛道、碰撞检测、检查点、圈速计时和重启流程。用代码生成体素风格的赛车和场景，不使用付费素材。运行游戏、测试控制、修复阻塞性问题后交付。我希望风景更好,开放世界。且地图在有opensquilla和 tokenrhythm这两个标识 是赞助商彩蛋",
       "summarizeWebpage": "帮我总结一个网页",
       "planWeek": "为我这一周拟定计划",
       "searchAiNews": "搜索今天的 AI 新闻",
@@ -3313,6 +3321,7 @@
     },
     "msgMeta": {
       "ensembleModels": "聚合 · {count} 个模型",
+      "model": "模型",
       "tokens": "令牌",
       "cache": "缓存",
       "think": "思考",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -1,6 +1,13 @@
 {
   "workspaces": {
     "projects": "项目",
+    "createProject": "创建项目",
+    "projectNamePlaceholder": "项目名称",
+    "sourceFolders": "源文件夹",
+    "addSourceFolder": "添加 OpenSquilla 可读取和编辑的文件夹",
+    "creatingProject": "正在创建…",
+    "projectCreated": "已创建项目“{name}”",
+    "createProjectFailed": "无法创建项目：{error}",
     "noTasks": "无任务",
     "chooseProject": "选择项目",
     "webPickerScope": "这里显示的是网关主机上的目录。",

--- a/opensquilla-webui/src/utils/chat/landingSuggestions.test.ts
+++ b/opensquilla-webui/src/utils/chat/landingSuggestions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import viewSource from '../../views/ChatView.vue?raw'
-import { shouldSuppressLandingSuggestions } from './landingSuggestions'
+import { shouldDisableLandingSuggestions } from './landingSuggestions'
 
 describe('landing suggestion protection', () => {
   it.each([
@@ -16,12 +16,12 @@ describe('landing suggestion protection', () => {
       name: 'an attachment in any state',
       state: { landingPrefilled: false, composerText: '', attachmentCount: 1 },
     },
-  ])('suppresses suggestions for $name', ({ state }) => {
-    expect(shouldSuppressLandingSuggestions(state)).toBe(true)
+  ])('disables suggestions for $name', ({ state }) => {
+    expect(shouldDisableLandingSuggestions(state)).toBe(true)
   })
 
   it('keeps suggestions available for an otherwise empty landing composer', () => {
-    expect(shouldSuppressLandingSuggestions({
+    expect(shouldDisableLandingSuggestions({
       landingPrefilled: false,
       composerText: '   ',
       attachmentCount: 0,
@@ -29,9 +29,10 @@ describe('landing suggestion protection', () => {
   })
 
   it('uses the same state for rendering and stale-click protection', () => {
-    expect(viewSource).toContain(':suppressed="landingSuggestionsSuppressed"')
+    expect(viewSource).toContain(':suppressed="landingSuggestionsHidden"')
+    expect(viewSource).toContain(':disabled="landingSuggestionsDisabled"')
     expect(viewSource).toMatch(
-      /function applyLandingSuggestion\(text: string\) \{\s+if \(landingSuggestionsSuppressed\.value\) return\s+sendComposerText\(text\)\s+\}/,
+      /function applyLandingSuggestion\(text: string\) \{\s+if \(landingSuggestionsDisabled\.value\) return\s+sendComposerText\(text\)\s+\}/,
     )
   })
 })

--- a/opensquilla-webui/src/utils/chat/landingSuggestions.ts
+++ b/opensquilla-webui/src/utils/chat/landingSuggestions.ts
@@ -4,7 +4,7 @@ interface LandingSuggestionState {
   attachmentCount: number
 }
 
-export function shouldSuppressLandingSuggestions({
+export function shouldDisableLandingSuggestions({
   landingPrefilled,
   composerText,
   attachmentCount,

--- a/opensquilla-webui/src/utils/messageTime.test.ts
+++ b/opensquilla-webui/src/utils/messageTime.test.ts
@@ -49,7 +49,9 @@ describe('relativeTime', () => {
     expect(relativeTime(now - 5_000, now)).toBe('just now')
     expect(relativeTime(now - 5 * 60_000, now)).toBe('5m ago')
     expect(relativeTime(now - 2 * 3_600_000, now)).toBe('2h ago')
-    expect(relativeTime(now - 3 * 86_400_000, now)).toBe('3d ago')
+    expect(relativeTime(now - 23 * 3_600_000, now)).toBe('23h ago')
+    expect(relativeTime(now - 86_400_000, now)).toBe('')
+    expect(relativeTime(now - 3 * 86_400_000, now)).toBe('')
   })
 
   it('clamps a future timestamp (clock skew) to "just now"', () => {
@@ -100,6 +102,10 @@ describe('absoluteTime', () => {
 
   it('produces a non-empty, digit-bearing local label', () => {
     expect(absoluteTime(Date.now())).toMatch(/\d/)
+  })
+
+  it('always includes the full local calendar year', () => {
+    expect(absoluteTime(MS_2026)).toContain(String(new Date(MS_2026).getFullYear()))
   })
 })
 

--- a/opensquilla-webui/src/utils/messageTime.ts
+++ b/opensquilla-webui/src/utils/messageTime.ts
@@ -22,7 +22,8 @@ export function messageDate(ts: string | number | null | undefined): Date | null
   return Number.isNaN(date.getTime()) ? null : date
 }
 
-// Coarse relative label: "just now" / "5m ago" / "2h ago" / "3d ago".
+// Coarse relative label for messages less than one day old. Older messages keep
+// their absolute timestamp without a redundant age suffix.
 // Pass a ticking `now` (epoch ms) to keep the label live without per-component
 // timers; it defaults to the current time for one-shot callers (e.g. export).
 export function relativeTime(
@@ -37,7 +38,7 @@ export function relativeTime(
   if (diff < 60) return 'just now'
   if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
   if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-  return `${Math.floor(diff / 86400)}d ago`
+  return ''
 }
 
 // Locale-aware coarse relative label for status readouts ("5 minutes ago",
@@ -62,22 +63,17 @@ export function localizedRelativeTime(
   return formatter.format(-Math.floor(diff / 86400), 'day')
 }
 
-// Compact absolute local time: time-only for today, "Mon DD, HH:MM" within the
-// current year, and a full date otherwise. Always in the browser locale + tz.
+// Full local date and minute-level time. Keeping the year visible makes every
+// message timestamp self-contained, regardless of how old the task is.
 export function absoluteTime(ts: string | number | null | undefined): string {
   const date = messageDate(ts)
   if (!date) return ''
   const time = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-  const startOfToday = new Date()
-  startOfToday.setHours(0, 0, 0, 0)
-  if (date.getTime() >= startOfToday.getTime()) return time
-  const sameYear = date.getFullYear() === startOfToday.getFullYear()
-  const day = date.toLocaleDateString(
-    [],
-    sameYear
-      ? { month: 'short', day: 'numeric' }
-      : { year: 'numeric', month: 'short', day: 'numeric' },
-  )
+  const day = date.toLocaleDateString([], {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
   return `${day}, ${time}`
 }
 

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -85,8 +85,8 @@
             <EmptyStateChips
               :key="landingAgentId"
               :agent-id="landingAgentId"
-              :meta-skills="metaSkillChoices"
-              :suppressed="landingSuggestionsSuppressed"
+              :suppressed="landingSuggestionsHidden"
+              :disabled="landingSuggestionsDisabled"
               @pick="applyLandingSuggestion"
             />
           </div>
@@ -745,7 +745,7 @@ import {
 } from '@/utils/chat/attachments'
 import { isShareableChatMessage } from '@/utils/chat/messageIdentity'
 import { agentIdFromSessionKey } from '@/utils/chat/sessionKeys'
-import { shouldSuppressLandingSuggestions } from '@/utils/chat/landingSuggestions'
+import { shouldDisableLandingSuggestions } from '@/utils/chat/landingSuggestions'
 import { clearAssistantActivityExpansionState } from '@/utils/chat/activityDisclosureState'
 import {
   resolveChatSessionLoadState,
@@ -1536,7 +1536,6 @@ const chatSlashCommands = useChatSlashCommands({
 const {
   slashOpen,
   slashIdx,
-  metaSkillChoices,
   filteredSlashCmds,
   loadSlashCommands,
   handleSlashInput,
@@ -1591,6 +1590,10 @@ const chatSend = useChatSend({
   pendingForkBeforeMessageId,
   materializeDraftSession: key => {
     if (!isDraftRoute()) return
+    const workspaceId = pendingWorkspaceId.value
+    if (workspaceId) {
+      freshTaskDraft.bindMaterializedProjectTask(key, workspaceId)
+    }
     persistSession(key, { source: 'chatView.draftAccepted' })
   },
   aborted,
@@ -1600,7 +1603,16 @@ const chatSend = useChatSend({
   stream: chatStream,
   canStop: () => canStop.value,
   normalizeElevatedMode,
-  adoptResponseSession,
+  adoptResponseSession: async (key, ownerRequestId) => {
+    const sourceKey = sessionKey.value
+    const workspaceId = freshTaskDraft.materializedWorkspaceBySession.value[sourceKey]
+      || boundWorkspaceId.value
+    if (workspaceId && key !== sourceKey) {
+      freshTaskDraft.bindMaterializedProjectTask(key, workspaceId)
+      freshTaskDraft.forgetMaterializedProjectTask(sourceKey)
+    }
+    return adoptResponseSession(key, ownerRequestId)
+  },
   scheduleHistorySync,
   schedulePendingDrainAfterTerminal,
   flushDeferredPendingDrain,
@@ -2162,7 +2174,8 @@ const currentPlanInHistory = computed(() => {
   )
 })
 
-const landingSuggestionsSuppressed = computed(() => shouldSuppressLandingSuggestions({
+const landingSuggestionsHidden = computed(() => landingPrefilled.value)
+const landingSuggestionsDisabled = computed(() => shouldDisableLandingSuggestions({
   landingPrefilled: landingPrefilled.value,
   composerText: inputText.value,
   attachmentCount: pendingAttachments.value.length,
@@ -2306,7 +2319,7 @@ async function setComposerModelRoutingMode(mode: ModelRoutingMode) {
 // composer-backed send path as every other message so routing, attachments,
 // optimistic state, and recovery behavior stay identical.
 function applyLandingSuggestion(text: string) {
-  if (landingSuggestionsSuppressed.value) return
+  if (landingSuggestionsDisabled.value) return
   sendComposerText(text)
 }
 

--- a/opensquilla-webui/src/views/UsageView.vue
+++ b/opensquilla-webui/src/views/UsageView.vue
@@ -530,8 +530,10 @@ async function refresh() {
   text-decoration: underline;
 }
 .usage-mono {
-  font-family: var(--font-mono);
-  font-variant-numeric: tabular-nums;
+  font-family: var(--font-sans);
+  font-variant-numeric: lining-nums tabular-nums;
+  font-feature-settings: "lnum" 1, "tnum" 1;
+  letter-spacing: -0.012em;
 }
 .usage-dim {
   color: var(--text-dim);


### PR DESCRIPTION
## Summary
- separate project workspaces from recent tasks and add project creation, task creation, and workspace actions
- keep project-scoped task creation in place without transient recent-list navigation
- simplify chat activity into progressive, user-readable disclosures and hide failed/internal details
- streamline composer metadata, landing suggestions, timestamps, and mutually exclusive send/stop controls
- open the system folder picker directly from project creation and reduce duplicate focus styling

## Validation
- `npm run typecheck`
- 16 related Vitest files: 143 tests passed