### PR TITLE
Fail closed when native Workbench surfaces become unresponsive

### DIFF
--- a/desktop/electron/scripts/test-native-workbench-surface-electron.mjs
+++ b/desktop/electron/scripts/test-native-workbench-surface-electron.mjs
@@ -62,7 +62,7 @@ try {
 
       const events = []
       const owner = new BrowserWindow({
-        show: false,
+        show: true,
         width: 900,
         height: 700,
         webPreferences: {
@@ -109,6 +109,17 @@ try {
           { reason: 'crashed', exitCode: 1 },
         )
         if (!handled) throw new Error('No renderer crash listener was registered.')
+      }
+
+      function emitUnresponsive(contents) {
+        const handled = contents.emit('unresponsive')
+        if (!handled) throw new Error('No renderer unresponsive listener was registered.')
+      }
+
+      function surfaceView(surfaceId) {
+        const view = manager.surfaces.get(surfaceId)?.view
+        if (!view) throw new Error(`Surface view ${surfaceId} was not found.`)
+        return view
       }
 
       function installSyntheticHttpsProtocol(contents) {
@@ -282,6 +293,60 @@ try {
       await manager.destroySurface('artifact:allowed')
       await waitFor(() => allowedContents.isDestroyed(), 'allowed surface destruction')
 
+      const lifecycleSurface = await manager.createSurface({
+        version: 1,
+        surfaceId: 'artifact:lifecycle',
+        kind: 'artifact-html',
+        payload: {
+          data: encoder.encode('<!doctype html><title>Lifecycle preview</title>'),
+          name: 'lifecycle.html',
+          mime: 'text/html',
+          scopeId: 'synthetic:lifecycle',
+          allowRemoteResources: false,
+        },
+      })
+      if (!lifecycleSurface.ok) {
+        throw new Error(lifecycleSurface.message || 'Lifecycle surface failed to load.')
+      }
+      const lifecycleContents = await waitFor(previewContents, 'lifecycle WebContents')
+      const lifecycleView = surfaceView('artifact:lifecycle')
+      const lifecycleRect = {
+        surfaceId: 'artifact:lifecycle',
+        x: 400,
+        y: 80,
+        width: 400,
+        height: 500,
+        visible: true,
+      }
+      const lifecyclePositioned = manager.setSurfaceRect(lifecycleRect)
+      await waitFor(() => lifecycleView.getVisible(), 'visible lifecycle surface')
+      const realIsVisible = owner.isVisible.bind(owner)
+      owner.isVisible = () => false
+      owner.emit('hide')
+      await waitFor(() => !lifecycleView.getVisible(), 'hidden owner surface')
+      const hiddenRectAccepted = manager.setSurfaceRect(lifecycleRect)
+      const hiddenActivation = manager.activateSurface('artifact:lifecycle')
+      const hiddenSurfaceStayedHidden = !lifecycleView.getVisible()
+      owner.isVisible = () => true
+      owner.emit('show')
+      await waitFor(() => lifecycleView.getVisible(), 'surface restored after owner show')
+      // Window-manager support varies in headless CI, especially macOS and
+      // Xvfb. Drive Electron's documented lifecycle event while overriding
+      // only the real BrowserWindow state query used by the manager.
+      const realIsMinimized = owner.isMinimized.bind(owner)
+      owner.isMinimized = () => true
+      owner.emit('minimize')
+      await waitFor(() => !lifecycleView.getVisible(), 'minimized owner surface')
+      const minimizedActivation = manager.activateSurface('artifact:lifecycle')
+      const minimizedSurfaceStayedHidden = !lifecycleView.getVisible()
+      owner.isMinimized = realIsMinimized
+      owner.emit('restore')
+      await waitFor(() => lifecycleView.getVisible(), 'surface restored with owner window')
+      const lifecycleSurfaceRestored = lifecycleView.getVisible()
+      owner.isVisible = realIsVisible
+      await manager.destroySurface('artifact:lifecycle')
+      await waitFor(() => lifecycleContents.isDestroyed(), 'lifecycle surface destruction')
+
       const loadErrorSurface = await manager.createSurface({
         version: 1,
         surfaceId: 'artifact:load-error',
@@ -383,6 +448,132 @@ try {
       })
       await manager.destroySurface('artifact:preview-crash')
 
+      const unresponsiveSurface = await manager.createSurface({
+        version: 1,
+        surfaceId: 'artifact:unresponsive',
+        kind: 'artifact-html',
+        payload: {
+          data: encoder.encode('<!doctype html><title>Unresponsive preview</title>'),
+          name: 'unresponsive.html',
+          mime: 'text/html',
+          scopeId: 'synthetic:unresponsive',
+          allowRemoteResources: false,
+        },
+      })
+      if (!unresponsiveSurface.ok) {
+        throw new Error(unresponsiveSurface.message || 'Unresponsive surface failed to load.')
+      }
+      const unresponsiveContents = await waitFor(
+        previewContents,
+        'unresponsive preview WebContents',
+      )
+      const unresponsiveView = surfaceView('artifact:unresponsive')
+      const unresponsiveRectRequest = {
+        surfaceId: 'artifact:unresponsive',
+        x: 400,
+        y: 80,
+        width: 400,
+        height: 500,
+        visible: true,
+      }
+      manager.setSurfaceRect(unresponsiveRectRequest)
+      await waitFor(() => unresponsiveView.getVisible(), 'visible unresponsive surface')
+      const unresponsiveSurfaceWasVisible = unresponsiveView.getVisible()
+      emitUnresponsive(unresponsiveContents)
+      await waitFor(
+        () => events.some(event =>
+          event.surfaceId === 'artifact:unresponsive'
+          && event.type === 'crashed'
+          && event.detail?.reason === 'unresponsive'),
+        'unresponsive renderer crash event',
+      )
+      await waitFor(
+        () => !unresponsiveView.getVisible(),
+        'unresponsive surface to become physically hidden',
+      )
+      emitUnresponsive(unresponsiveContents)
+      emitRendererGone(unresponsiveContents)
+      unresponsiveContents.emit(
+        'did-fail-load',
+        {},
+        -2,
+        'synthetic failure after unresponsive',
+        unresponsiveContents.getURL(),
+        true,
+      )
+      const unresponsiveTerminalEventCount = events.filter(event =>
+        event.surfaceId === 'artifact:unresponsive'
+        && (event.type === 'error' || event.type === 'crashed')).length
+      const unresponsiveActivation = manager.activateSurface('artifact:unresponsive')
+      const unresponsiveRect = manager.setSurfaceRect(unresponsiveRectRequest)
+      owner.emit('hide')
+      owner.emit('show')
+      owner.setSize(901, 701)
+      owner.webContents.emit('zoom-changed', {}, 'in')
+      await new Promise(resolveWait => setTimeout(resolveWait, 100))
+      const failedSurfaceStayedHidden = !unresponsiveView.getVisible()
+      await manager.destroySurface('artifact:unresponsive')
+
+      const ownerUnresponsiveSurfaceOne = await manager.createSurface({
+        version: 1,
+        surfaceId: 'artifact:owner-unresponsive-one',
+        kind: 'artifact-html',
+        payload: {
+          data: encoder.encode('<!doctype html><title>Owner unresponsive one</title>'),
+          name: 'owner-unresponsive-one.html',
+          mime: 'text/html',
+          scopeId: 'synthetic:owner-unresponsive-one',
+          allowRemoteResources: false,
+        },
+      })
+      const ownerUnresponsiveSurfaceTwo = await manager.createSurface({
+        version: 1,
+        surfaceId: 'artifact:owner-unresponsive-two',
+        kind: 'artifact-html',
+        payload: {
+          data: encoder.encode('<!doctype html><title>Owner unresponsive two</title>'),
+          name: 'owner-unresponsive-two.html',
+          mime: 'text/html',
+          scopeId: 'synthetic:owner-unresponsive-two',
+          allowRemoteResources: false,
+        },
+      })
+      if (!ownerUnresponsiveSurfaceOne.ok || !ownerUnresponsiveSurfaceTwo.ok) {
+        throw new Error('Owner-unresponsive surfaces failed to load.')
+      }
+      const ownerUnresponsiveViewOne = surfaceView('artifact:owner-unresponsive-one')
+      const ownerUnresponsiveViewTwo = surfaceView('artifact:owner-unresponsive-two')
+      manager.setSurfaceRect({
+        surfaceId: 'artifact:owner-unresponsive-one',
+        x: 400,
+        y: 80,
+        width: 400,
+        height: 500,
+        visible: true,
+      })
+      await waitFor(
+        () => ownerUnresponsiveViewOne.getVisible(),
+        'visible owner-unresponsive surface',
+      )
+      emitUnresponsive(owner.webContents)
+      await waitFor(
+        () => events.filter(event =>
+          event.type === 'crashed'
+          && event.detail?.reason === 'owner-unresponsive').length === 2,
+        'owner-unresponsive events for all surfaces',
+      )
+      const ownerUnresponsiveViewsHidden = !ownerUnresponsiveViewOne.getVisible()
+        && !ownerUnresponsiveViewTwo.getVisible()
+      const ownerUnresponsiveActivation = manager.activateSurface(
+        'artifact:owner-unresponsive-one',
+      )
+      emitUnresponsive(owner.webContents)
+      const ownerUnresponsiveTerminalEventCount = events.filter(event =>
+        event.type === 'crashed'
+        && event.detail?.reason === 'owner-unresponsive').length
+      owner.webContents.emit('responsive')
+      await manager.destroyAll()
+
       const ownerCrashSurface = await manager.createSurface({
         version: 1,
         surfaceId: 'artifact:owner-crash',
@@ -417,19 +608,34 @@ try {
         dialogsDisabled,
         downloadPrevented,
         downloadSeen,
+        failedSurfaceStayedHidden,
+        hiddenActivation,
+        hiddenRectAccepted,
+        hiddenSurfaceStayedHidden,
+        lifecyclePositioned,
+        lifecycleSurfaceRestored,
         loadErrorActivation,
+        minimizedActivation,
+        minimizedSurfaceStayedHidden,
         navigationWasBlocked,
         missingResourceEventCount,
         notificationPermission,
         offlineProbe,
         offlineRequestCount: offlineRequestCount(),
         offlineScriptResult,
+        ownerUnresponsiveActivation,
+        ownerUnresponsiveTerminalEventCount,
+        ownerUnresponsiveViewsHidden,
         popupCreated,
         popupWasBlocked,
         previewCrashActivation,
         previewCrashRect,
         raceBaseDestroyed,
         replacementCloseActivation,
+        unresponsiveActivation,
+        unresponsiveRect,
+        unresponsiveSurfaceWasVisible,
+        unresponsiveTerminalEventCount,
       }
     },
   )
@@ -483,6 +689,29 @@ try {
   assert.equal(result.notificationPermission, 'denied', 'preview permissions must be denied')
   assert.equal(result.downloadSeen, true, 'download policy must observe attempted downloads')
   assert.equal(result.downloadPrevented, true, 'download policy must prevent the download')
+  assert.equal(result.lifecyclePositioned.ok, true, 'a healthy visible surface must be positioned')
+  assert.equal(result.hiddenRectAccepted.ok, true, 'hidden windows must retain visible surface intent')
+  assert.equal(result.hiddenActivation.ok, true, 'hidden windows must retain surface activation')
+  assert.equal(
+    result.hiddenSurfaceStayedHidden,
+    true,
+    'a surface must remain physically hidden while its owner is hidden',
+  )
+  assert.equal(
+    result.minimizedActivation.ok,
+    true,
+    'minimized windows must retain surface activation',
+  )
+  assert.equal(
+    result.minimizedSurfaceStayedHidden,
+    true,
+    'a surface must remain physically hidden while its owner is minimized',
+  )
+  assert.equal(
+    result.lifecycleSurfaceRestored,
+    true,
+    'a healthy requested surface must return after its owner is restored',
+  )
   assert.equal(
     result.loadErrorActivation.ok,
     false,
@@ -507,6 +736,46 @@ try {
     result.previewCrashRect.ok,
     false,
     'a crashed preview renderer must reject visible bounds until it is recreated',
+  )
+  assert.equal(
+    result.unresponsiveSurfaceWasVisible,
+    true,
+    'the unresponsive contract must exercise a physically visible native surface',
+  )
+  assert.equal(
+    result.unresponsiveTerminalEventCount,
+    1,
+    'repeated terminal events must emit one final surface state',
+  )
+  assert.equal(
+    result.unresponsiveActivation.ok,
+    false,
+    'an unresponsive preview renderer must never be reactivated',
+  )
+  assert.equal(
+    result.unresponsiveRect.ok,
+    false,
+    'an unresponsive preview renderer must reject delayed visible bounds',
+  )
+  assert.equal(
+    result.failedSurfaceStayedHidden,
+    true,
+    'show, resize and zoom must not resurrect a failed native surface',
+  )
+  assert.equal(
+    result.ownerUnresponsiveViewsHidden,
+    true,
+    'an unresponsive owner must physically hide all of its child surfaces',
+  )
+  assert.equal(
+    result.ownerUnresponsiveActivation.ok,
+    false,
+    'owner-unresponsive surfaces must reject reactivation',
+  )
+  assert.equal(
+    result.ownerUnresponsiveTerminalEventCount,
+    2,
+    'each surface must emit one owner-unresponsive terminal event',
   )
   assert.equal(result.crashActivation.ok, false, 'owner crash must remove owned surfaces')
 

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -88,6 +88,7 @@ import {
   parseNativeWorkbenchCreateRequest,
   parseNativeWorkbenchSurfaceId,
   parseNativeWorkbenchSurfaceRectRequest,
+  type NativeWorkbenchSurfaceEvent,
 } from './native-workbench-surface-contract.js'
 import {
   NativeWorkbenchSurfaceManager,
@@ -398,6 +399,23 @@ function desktopLog(event: string, detail?: Record<string, unknown>): void {
   }
 }
 
+function nativeWorkbenchFailureReason(event: NativeWorkbenchSurfaceEvent): string {
+  if (event.type === 'error') return 'load-failed'
+  const reason = event.detail?.reason
+  if (
+    reason === 'unresponsive'
+    || reason === 'owner-unresponsive'
+    || reason === 'clean-exit'
+    || reason === 'abnormal-exit'
+    || reason === 'killed'
+    || reason === 'crashed'
+    || reason === 'oom'
+    || reason === 'launch-failed'
+    || reason === 'integrity-failure'
+  ) return reason
+  return 'unknown'
+}
+
 let gatewayStartPromise: Promise<GatewayState> | null = null
 let resolveOnboarding: ((credential: DesktopConnection) => void) | null = null
 let rejectOnboarding: ((error: Error) => void) | null = null
@@ -450,6 +468,12 @@ const gatewayState: GatewayState = {
 const nativeWorkbenchSurfaces = new NativeWorkbenchSurfaceManager({
   getWindow: () => currentMainWindow(),
   emit: event => {
+    if (event.type === 'error' || event.type === 'crashed') {
+      desktopLog('native_workbench_surface_failed', {
+        type: event.type,
+        reason: nativeWorkbenchFailureReason(event),
+      })
+    }
     const window = currentMainWindow()
     if (
       !window

--- a/desktop/electron/src/native-workbench-surface.ts
+++ b/desktop/electron/src/native-workbench-surface.ts
@@ -96,6 +96,7 @@ export class NativeWorkbenchSurfaceManager {
   private readonly surfaces = new Map<string, NativeWorkbenchSurfaceRecord>()
   private readonly surfaceQueues = new Map<string, Promise<void>>()
   private readonly hookedWindows = new WeakSet<BrowserWindow>()
+  private readonly unresponsiveWindows = new WeakSet<BrowserWindow>()
   private activeSurfaceId: string | null = null
 
   constructor(private readonly options: NativeWorkbenchSurfaceManagerOptions) {}
@@ -171,9 +172,12 @@ export class NativeWorkbenchSurfaceManager {
         await this.destroyRecord(record)
         return { ok: false, message: 'The native Workbench surface was closed.' }
       }
+      if (record.crashed) {
+        return { ok: false, message: 'The native Workbench surface renderer failed.' }
+      }
       return { ok: true }
     } catch (error) {
-      if (!record.disposed) this.emit(record, 'error', { message: errorMessage(error) })
+      this.failRecord(record, 'error', { message: errorMessage(error) })
       await this.destroyRecord(record)
       return { ok: false, message: errorMessage(error) }
     }
@@ -391,17 +395,15 @@ export class NativeWorkbenchSurfaceManager {
       if (!isMainFrame || record.disposed || errorCode === -3) return
       // A failed native document must yield to the DOM error state. Keeping the
       // child view visible would cover the recovery controls rendered by Vue.
-      record.crashed = true
-      record.visibleRequested = false
-      this.hideRecord(record)
-      this.emit(record, 'error', { message: errorDescription || `Load failed (${errorCode})` })
+      this.failRecord(record, 'error', {
+        message: errorDescription || `Load failed (${errorCode})`,
+      })
     })
     contents.on('render-process-gone', (_event, detail) => {
-      if (record.disposed) return
-      record.crashed = true
-      record.visibleRequested = false
-      this.hideRecord(record)
-      this.emit(record, 'crashed', { reason: detail.reason })
+      this.failRecord(record, 'crashed', { reason: detail.reason })
+    })
+    contents.on('unresponsive', () => {
+      this.failRecord(record, 'crashed', { reason: 'unresponsive' })
     })
   }
 
@@ -412,36 +414,94 @@ export class NativeWorkbenchSurfaceManager {
     }
     this.activeSurfaceId = record.id
     record.view.setBounds(record.rect)
-    record.view.setVisible(true)
+    this.setPhysicalVisibility(record, this.ownerCanShowSurfaces(record.owner))
   }
 
   private hideRecord(record: NativeWorkbenchSurfaceRecord): void {
     if (this.activeSurfaceId === record.id) this.activeSurfaceId = null
+    this.setPhysicalVisibility(record, false)
+  }
+
+  private setPhysicalVisibility(
+    record: NativeWorkbenchSurfaceRecord,
+    visible: boolean,
+  ): void {
     try {
-      record.view.setVisible(false)
+      record.view.setVisible(visible)
     } catch {}
   }
 
   private reapplyActiveBounds(owner: BrowserWindow): void {
     if (!this.activeSurfaceId) return
     const record = this.surfaces.get(this.activeSurfaceId)
+    if (record?.disposed || record?.crashed) {
+      this.hideRecord(record)
+      return
+    }
     if (!record || record.owner !== owner || !record.requestedRect || !record.visibleRequested) {
       return
     }
     record.rect = this.resolveSurfaceRect(record)
     if (!record.rect) {
-      this.hideRecord(record)
+      this.setPhysicalVisibility(record, false)
       return
     }
     record.view.setBounds(record.rect)
+    this.setPhysicalVisibility(record, this.ownerCanShowSurfaces(owner))
+  }
+
+  private ownerCanShowSurfaces(owner: BrowserWindow): boolean {
+    return !owner.isDestroyed()
+      && !this.unresponsiveWindows.has(owner)
+      && owner.isVisible()
+      && !owner.isMinimized()
+  }
+
+  private hideOwnedViews(owner: BrowserWindow): void {
+    for (const record of this.surfaces.values()) {
+      if (record.owner === owner) this.setPhysicalVisibility(record, false)
+    }
+  }
+
+  private failOwnedSurfaces(owner: BrowserWindow, reason: string): void {
+    for (const record of this.surfaces.values()) {
+      if (record.owner === owner) {
+        this.failRecord(record, 'crashed', { reason })
+      }
+    }
+  }
+
+  private failRecord(
+    record: NativeWorkbenchSurfaceRecord,
+    type: 'error' | 'crashed',
+    detail: NonNullable<NativeWorkbenchSurfaceEvent['detail']>,
+  ): boolean {
+    if (record.disposed || record.crashed) return false
+    record.crashed = true
+    record.visibleRequested = false
+    this.hideRecord(record)
+    this.emit(record, type, detail)
+    return true
   }
 
   private hookWindow(owner: BrowserWindow): void {
     if (this.hookedWindows.has(owner)) return
     this.hookedWindows.add(owner)
     owner.on('resize', () => this.reapplyActiveBounds(owner))
+    owner.on('hide', () => this.hideOwnedViews(owner))
+    owner.on('minimize', () => this.hideOwnedViews(owner))
+    owner.on('show', () => this.reapplyActiveBounds(owner))
+    owner.on('restore', () => this.reapplyActiveBounds(owner))
     owner.webContents.on('zoom-changed', () => this.reapplyActiveBounds(owner))
+    owner.webContents.on('unresponsive', () => {
+      this.unresponsiveWindows.add(owner)
+      this.failOwnedSurfaces(owner, 'owner-unresponsive')
+    })
+    owner.webContents.on('responsive', () => {
+      this.unresponsiveWindows.delete(owner)
+    })
     owner.webContents.on('render-process-gone', () => {
+      this.unresponsiveWindows.add(owner)
       void this.destroyAll()
     })
     owner.once('closed', () => {
@@ -454,7 +514,10 @@ export class NativeWorkbenchSurfaceManager {
     type: NativeWorkbenchSurfaceEvent['type'],
     detail?: NativeWorkbenchSurfaceEvent['detail'],
   ): void {
-    if (record.disposed) return
+    if (
+      record.disposed
+      || (record.crashed && type !== 'error' && type !== 'crashed')
+    ) return
     this.options.emit({
       version: NATIVE_WORKBENCH_PROTOCOL_VERSION,
       surfaceId: record.id,

--- a/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
+++ b/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
@@ -197,8 +197,16 @@ describe('artifact Workbench provider', () => {
       version: 1,
       surfaceId: item.id,
       type: 'crashed',
+      detail: { reason: 'unresponsive' },
     }, item)
     expect(renderState.nativeSurfaceState).toBe('crashed')
+    expect(destroySurface).toHaveBeenLastCalledWith(item.id)
+    expect(definition.getToolbarItems?.(item, {
+      active: true,
+      hostAvailable: true,
+      nativeSurface: true,
+      runtimeState: renderState,
+    })?.some(toolbarItem => toolbarItem.id === 'refresh')).toBe(true)
 
     await runtime.handleComponentEvent?.({
       type: 'native-html-ready',


### PR DESCRIPTION
## Summary

- fail closed on native Workbench `unresponsive`, load-failure, and renderer-gone terminal states so stale `WebContentsView` layers cannot intercept Control UI clicks
- physically hide healthy native views while the owner window is hidden or minimized, then restore only a healthy, requested, bounds-valid active view
- fail all owned native surfaces when the Vue owner renderer becomes unresponsive and reuse the existing v1 `crashed` recovery path
- write structured desktop failure logs containing only event type and a normalized reason
- cover physical visibility, duplicate terminal events, delayed activation/bounds, owner failures, window lifecycle, and DOM refresh recovery

## Target

- Base branch: `main`

## Linked issues

Fixes #846
Fixes #848

## Release note

- Desktop: native HTML Workbench previews now yield immediately to the clickable recovery UI if their renderer stops responding, without requiring an application restart.

## Tests

- `npm run test:desktop-workbench`
- `npx vitest run src/components/workbench/artifactWorkbenchProvider.test.ts src/workbench/runtime.test.ts`
- `npm run test:window-lifecycle`
- `npm run test:window-background-flow` (passed on rerun after the first isolated cold start timed out before the Control UI loaded)
- `npm run typecheck`
- `npm run build`
- `uv run pytest tests/test_desktop/test_electron_startup_contract.py -q` (103 passed)

## Compatibility and safety

- Native Workbench protocol remains v1; only existing `crashed.detail.reason` values are extended with `unresponsive` and `owner-unresponsive`.
- No Gateway RPC, database, configuration, artifact, session, or persistence formats change.
- Healthy previews remain keep-alive across background/restore; iframe fallback and non-HTML preview behavior are unchanged.
- The implementation is platform-neutral and uses Electron lifecycle/visibility APIs exercised by the existing macOS, Windows, and Linux/Xvfb test matrix.
- No heartbeat or custom timeout is added, so legitimate heavy HTML previews are not terminated early.
- Failure logs omit surface, artifact, scope, and session identifiers.

## Third-party origin

- None. The implementation and synthetic fixtures are repository-native.