### PR TITLE
Add Qwen Token Plan and custom Anthropic providers

### DIFF
--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -725,6 +725,7 @@
     "tests/test_provider_terminal_evidence.py": 0.01,
     "tests/test_provider_terminal_evidence_anthropic_codex.py": 0.01,
     "tests/test_provider_text_tool_normalization.py": 0.01,
+    "tests/test_provider_qwen_token_plan.py": 0.01,
     "tests/test_provider_tokenrhythm_correlation.py": 0.01,
     "tests/test_provider_tool_stream_accumulator.py": 0.01,
     "tests/test_provider_trace_recorder.py": 0.015,

--- a/docs/artifacts-and-media.md
+++ b/docs/artifacts-and-media.md
@@ -77,6 +77,11 @@ Configure image generation:
 opensquilla configure image-generation
 ```
 
+Supported built-in image providers include OpenAI Images, OpenRouter Images,
+and Qwen Token Plan (`wan2.7-image` / `wan2.7-image-pro`). Token Plan uses
+`QWEN_TOKEN_PLAN_API_KEY`; its image-generation provider is distinct from the
+Qwen model used to analyze image inputs.
+
 Then ask for images in chat:
 
 ```text

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -108,6 +108,117 @@ base URL (`https://api.openai.com/v1`):
 Both read the same key and base URL, so switching between them needs only a
 `provider` change.
 
+### Qwen Token Plan: OpenAI and Anthropic protocols
+
+Token Plan is separate from regular DashScope and Bailian Coding Plan. Use its
+dedicated `sk-sp-...` key; a standard Model Studio key cannot consume Token
+Plan Credits.
+
+OpenSquilla exposes the mainland China service through two verified provider
+ids:
+
+- `qwen_token_plan` — OpenAI-compatible Chat Completions at
+  `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`.
+- `qwen_token_plan_anthropic` — Anthropic Messages at
+  `https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic`
+  (+ `/v1/messages`), using bearer authentication.
+
+Both read `QWEN_TOKEN_PLAN_API_KEY` and default to
+`qwen3.8-max-preview`:
+
+```sh
+export QWEN_TOKEN_PLAN_API_KEY="sk-sp-..."
+opensquilla configure provider \
+  --provider qwen_token_plan \
+  --model qwen3.8-max-preview \
+  --api-key-env QWEN_TOKEN_PLAN_API_KEY
+```
+
+The packaged model catalog is the documented team-plan superset. Personal
+plans can use `qwen3.8-max-preview`, `qwen3.7-max`, `qwen3.7-plus`,
+`qwen3.6-flash`, `glm-5.2`, and `deepseek-v4-pro`; team plans additionally
+include `qwen3.6-plus`, DeepSeek V4 Flash / V3.2, Kimi K2.7 / K2.6 / K2.5,
+GLM 5.1 / 5, and MiniMax M2.5. Entitlement is enforced by the service.
+Settings and onboarding query the verified OpenAI-compatible `/models`
+endpoint so suggestions reflect the current key's entitlement. The Anthropic
+profile deliberately uses that same account catalog instead of presenting the
+packaged superset as a live result.
+
+The OpenAI-compatible adapter applies the model-family wire contracts required
+by this mixed catalog: forced thinking and the 0.6 temperature floor for
+Qwen 3.8, DeepSeek V4 effort and reasoning replay, Kimi tool-call reasoning
+replay, GLM `tool_stream`, and thinking-mode tool-choice normalization. The
+Anthropic adapter preserves signed thinking blocks and clamps Qwen 3.8's
+temperature floor. The included inline SquillaRouter preset uses Qwen 3.6
+Flash → Qwen 3.7 Plus → Qwen 3.7 Max → Qwen 3.8 Max Preview, with Qwen 3.7
+Plus as the image route.
+
+Token Plan also exposes native image generation through OpenSquilla's
+`image_generate` tool. This is separate from the router's image route: the
+router image model understands image *inputs*, while Wan creates new image
+artifacts. Configure either `wan2.7-image` or `wan2.7-image-pro`:
+
+```toml
+[image_generation]
+enabled = true
+primary = "qwen_token_plan/wan2.7-image"
+size = "768x768"
+
+[image_generation.providers.qwen_token_plan]
+api_key_env = "QWEN_TOKEN_PLAN_API_KEY"
+base_url = "https://token-plan.cn-beijing.maas.aliyuncs.com/api/v1"
+```
+
+The native adapter uses the documented multimodal-generation request shape,
+converts OpenSquilla's `WIDTHxHEIGHT` size to the service's `WIDTH*HEIGHT`
+form, and securely downloads the temporary signed result URL. When Token Plan
+is also the active LLM provider, the image provider can reuse its credential
+because both official endpoints have the same HTTPS origin; it does not reuse
+the incompatible chat API path.
+
+Token Plan is licensed for supported interactive AI programming and agent
+tools. It is not a replacement credential for unattended application
+backends or generic batch API workloads; follow the current plan terms for
+your subscription.
+
+### Custom OpenAI- and Anthropic-compatible endpoints
+
+Use `custom` for an OpenAI Chat Completions endpoint and
+`custom_anthropic` for an Anthropic Messages endpoint. Both require an
+explicit model and base URL; API keys are optional:
+
+```toml
+[llm]
+provider = "custom_anthropic"
+model = "vendor-model"
+base_url = "https://llm.example.com/anthropic"
+api_key_env = "CUSTOM_ANTHROPIC_API_KEY"
+```
+
+`custom_anthropic` appends `/v1/messages` and sends a bearer token.
+`custom` appends `/chat/completions` to versioned base URLs and reads
+`CUSTOM_LLM_API_KEY`.
+
+Unknown custom models keep the conservative 8k context default for upgrade
+compatibility. Declare the endpoint's real window under
+`[models.custom."<model>"]` or
+`[models.custom_anthropic."<model>"]`; this is important for both remote
+gateways and local servers with larger windows.
+
+The current custom-provider boundary is intentionally explicit:
+
+- protocol selection is available through the two fixed provider ids;
+- provider-scoped model overrides, base URL, proxy, and optional bearer key
+  are supported;
+- arbitrary user-named provider ids and arbitrary request headers are not yet
+  part of the persisted provider contract;
+- custom Anthropic auth is currently optional bearer only (`x-api-key` and
+  custom auth modes are not configurable), and custom protocol choices do not
+  yet include OpenAI Responses or native Gemini;
+- endpoint-wide `extra_body` / request-transform configuration is not exposed;
+- reasoning dialects are never inferred from an untrusted custom host—set
+  provider-scoped model metadata only when the endpoint contract is known.
+
 ### Volcengine Ark: regular vs coding-plan endpoints
 
 Use `volcengine` for regular Ark chat/completions models. Its default base URL

--- a/opensquilla-webui/src/composables/setup/useSetupCatalog.privacy.test.ts
+++ b/opensquilla-webui/src/composables/setup/useSetupCatalog.privacy.test.ts
@@ -3501,71 +3501,77 @@ describe('useSetupCatalog optional provider credentials', () => {
     })
   }
 
-  it('exposes an optional custom key and blocks probes until required fields exist', async () => {
-    rpcCall.mockImplementation(async (method: string) => {
-      if (method === 'onboarding.catalog') {
-        return {
-          providers: [
-            {
-              providerId: 'custom',
-              label: 'Custom OpenAI-compatible endpoint',
-              runtimeSupported: true,
-              acceptsApiKey: true,
-              requiresApiKey: false,
-              envKey: 'CUSTOM_LLM_API_KEY',
-              fields: [
-                { name: 'model', label: 'Model id', required: true, default: '' },
-                { name: 'api_key', label: 'API key', required: false, secret: true },
-                { name: 'base_url', label: 'Base URL', required: true, default: '' },
-              ],
-            },
-          ],
+  it.each([
+    ['custom', 'Custom OpenAI-compatible endpoint', 'CUSTOM_LLM_API_KEY'],
+    ['custom_anthropic', 'Custom Anthropic-compatible endpoint', 'CUSTOM_ANTHROPIC_API_KEY'],
+  ])(
+    'exposes an optional key and blocks %s probes until required fields exist',
+    async (providerId, label, envKey) => {
+      rpcCall.mockImplementation(async (method: string) => {
+        if (method === 'onboarding.catalog') {
+          return {
+            providers: [
+              {
+                providerId,
+                label,
+                runtimeSupported: true,
+                acceptsApiKey: true,
+                requiresApiKey: false,
+                envKey,
+                fields: [
+                  { name: 'model', label: 'Model id', required: true, default: '' },
+                  { name: 'api_key', label: 'API key', required: false, secret: true },
+                  { name: 'base_url', label: 'Base URL', required: true, default: '' },
+                ],
+              },
+            ],
+          }
         }
-      }
-      if (method === 'onboarding.status') {
-        return { hasConfig: false, llmConfigured: false, llmCredentialStatus: {} }
-      }
-      if (method === 'channels.status') return { channels: [] }
-      if (method === 'config.get') return {}
-      if (method === 'onboarding.provider.probe') {
-        return { ok: false, failureKind: 'transport_transient', message: 'offline' }
-      }
-      throw new Error(`Unexpected RPC method: ${method}`)
-    })
-    const { api, app } = await mountCatalog()
+        if (method === 'onboarding.status') {
+          return { hasConfig: false, llmConfigured: false, llmCredentialStatus: {} }
+        }
+        if (method === 'channels.status') return { channels: [] }
+        if (method === 'config.get') return {}
+        if (method === 'onboarding.provider.probe') {
+          return { ok: false, failureKind: 'transport_transient', message: 'offline' }
+        }
+        throw new Error(`Unexpected RPC method: ${method}`)
+      })
+      const { api, app } = await mountCatalog()
 
-    api.selectProvider('custom')
-    api.onProviderChange()
+      api.selectProvider(providerId)
+      api.onProviderChange()
 
-    let credential = api.providerPanel.value.credentialPanel
-    expect(credential).toMatchObject({
-      acceptsApiKey: true,
-      requiresApiKey: false,
-      source: 'not_required',
-      probeReady: false,
-    })
-    expect(credential?.probeDisabledReason).toBe(
-      'Complete required fields before verifying: Model, Base URL.',
-    )
+      let credential = api.providerPanel.value.credentialPanel
+      expect(credential).toMatchObject({
+        acceptsApiKey: true,
+        requiresApiKey: false,
+        source: 'not_required',
+        probeReady: false,
+      })
+      expect(credential?.probeDisabledReason).toBe(
+        'Complete required fields before verifying: Model, Base URL.',
+      )
 
-    api.probeProviderConnection()
-    expect(rpcCall.mock.calls.some(call => call[0] === 'onboarding.provider.probe')).toBe(false)
+      api.probeProviderConnection()
+      expect(rpcCall.mock.calls.some(call => call[0] === 'onboarding.provider.probe')).toBe(false)
 
-    api.updateProviderField('model', 'test-model')
-    api.updateProviderField('base_url', 'https://custom.example.test/v1')
-    credential = api.providerPanel.value.credentialPanel
-    expect(credential?.probeReady).toBe(true)
-    expect(credential?.probeDisabledReason).toBe('')
+      api.updateProviderField('model', 'test-model')
+      api.updateProviderField('base_url', 'https://custom.example.test/v1')
+      credential = api.providerPanel.value.credentialPanel
+      expect(credential?.probeReady).toBe(true)
+      expect(credential?.probeDisabledReason).toBe('')
 
-    api.probeProviderConnection()
-    await Promise.resolve()
-    expect(rpcCall).toHaveBeenCalledWith('onboarding.provider.probe', {
-      providerId: 'custom',
-      baseUrl: 'https://custom.example.test/v1',
-      model: 'test-model',
-    })
-    app.unmount()
-  })
+      api.probeProviderConnection()
+      await Promise.resolve()
+      expect(rpcCall).toHaveBeenCalledWith('onboarding.provider.probe', {
+        providerId,
+        baseUrl: 'https://custom.example.test/v1',
+        model: 'test-model',
+      })
+      app.unmount()
+    },
+  )
 
   it('falls back conservatively to requiresApiKey when an older gateway omits acceptsApiKey', async () => {
     rpcCall.mockImplementation(async (method: string) => {

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -159,6 +159,13 @@ base_url = "https://tokenrhythm.studio/v1"
 # # api_key is optional: set env CUSTOM_LLM_API_KEY (or api_key here) only if
 # # your endpoint enforces one. Declare the endpoint's real context window via
 # # [models.custom."qwen3-32b-awq"] — see the per-model overrides section below.
+#
+# Example custom Anthropic Messages endpoint:
+# provider = "custom_anthropic"
+# base_url = "https://llm.example.com/anthropic"
+# model = "vendor-model"
+# # api_key is optional; env CUSTOM_ANTHROPIC_API_KEY also works. The adapter
+# # appends /v1/messages and uses Authorization: Bearer when a key is present.
 
 # Pin each model to its native upstream provider on OpenRouter.
 # Sends provider.only=[slug] + allow_fallbacks=true per request.
@@ -284,17 +291,25 @@ all_failed_policy = "fallback_single"
 # max_output_tokens = 8192
 # supports_tools = true
 #
-# The generic `custom` provider (any self-hosted OpenAI-compatible endpoint;
-# see the [llm] example above) uses the same override table, keyed by its
-# served model id:
+# The generic `custom` and `custom_anthropic` providers use the same override
+# table shape, keyed by the served model id. Unknown custom models retain the
+# conservative 8k fallback for upgrade compatibility; both remote gateways
+# and local servers should declare their actual window:
 # [models.custom."qwen3-32b-awq"]
+# context_window = 131072
+# max_output_tokens = 8192
+# supports_tools = true
+#
+# [models.custom_anthropic."vendor-model"]
 # context_window = 131072
 # max_output_tokens = 8192
 # supports_tools = true
 #
 # [models.openrouter."z-ai/glm-5.2"]
 # # reasoning_format: openrouter | openai | deepseek | gemini | zai |
-# #                   dashscope | moonshot | volcengine | none
+# #                   dashscope | moonshot | volcengine | qwen_token_plan |
+# #                   qwen_token_plan_qwen | qwen_token_plan_deepseek |
+# #                   qwen_token_plan_glm | qwen_token_plan_kimi | none
 # reasoning_format = "openrouter"
 # supports_reasoning = true
 # input_cost_per_mtok = 0.5        # USD per million input tokens (example value)
@@ -444,6 +459,20 @@ image_only = true
 #
 # [squilla_router]
 # tier_profile = "dashscope"
+
+# Example: Qwen Token Plan native image generation. This uses the same
+# QWEN_TOKEN_PLAN_API_KEY as the qwen_token_plan LLM provider, but a distinct
+# official API path.
+#
+# [image_generation]
+# enabled = true
+# primary = "qwen_token_plan/wan2.7-image"
+# size = "768x768"
+# output_format = "png"
+#
+# [image_generation.providers.qwen_token_plan]
+# api_key_env = "QWEN_TOKEN_PLAN_API_KEY"
+# base_url = "https://token-plan.cn-beijing.maas.aliyuncs.com/api/v1"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Tool policy

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -1390,12 +1390,21 @@ class ImageGenerationOpenRouterProviderConfig(BaseModel):
     api_key_env: str = "OPENROUTER_API_KEY"
 
 
+class ImageGenerationQwenTokenPlanProviderConfig(BaseModel):
+    base_url: str = "https://token-plan.cn-beijing.maas.aliyuncs.com/api/v1"
+    api_key: str = ""
+    api_key_env: str = "QWEN_TOKEN_PLAN_API_KEY"
+
+
 class ImageGenerationProvidersConfig(BaseModel):
     openai: ImageGenerationOpenAIProviderConfig = Field(
         default_factory=ImageGenerationOpenAIProviderConfig
     )
     openrouter: ImageGenerationOpenRouterProviderConfig = Field(
         default_factory=ImageGenerationOpenRouterProviderConfig
+    )
+    qwen_token_plan: ImageGenerationQwenTokenPlanProviderConfig = Field(
+        default_factory=ImageGenerationQwenTokenPlanProviderConfig
     )
 
 

--- a/src/opensquilla/onboarding/image_generation_specs.py
+++ b/src/opensquilla/onboarding/image_generation_specs.py
@@ -57,6 +57,16 @@ _IMAGE_PROVIDER_DATA: dict[str, dict[str, Any]] = {
         "default_model": "openrouter/google/gemini-3.1-flash-image-preview",
         "suggested_models": ("openrouter/google/gemini-3.1-flash-image-preview",),
     },
+    "qwen_token_plan": {
+        "label": "Qwen Token Plan Images",
+        "env_key": "QWEN_TOKEN_PLAN_API_KEY",
+        "default_base_url": IMAGE_GENERATION_OFFICIAL_BASE_URLS["qwen_token_plan"],
+        "default_model": "qwen_token_plan/wan2.7-image",
+        "suggested_models": (
+            "qwen_token_plan/wan2.7-image",
+            "qwen_token_plan/wan2.7-image-pro",
+        ),
+    },
 }
 
 

--- a/src/opensquilla/onboarding/probe.py
+++ b/src/opensquilla/onboarding/probe.py
@@ -26,7 +26,7 @@ from typing import Any, cast
 import httpx
 import structlog
 
-from opensquilla.provider.app_attribution import is_provider_app_host
+from opensquilla.provider.app_attribution import is_host_or_subdomain
 from opensquilla.provider.failures import ProviderFailureKind, classify_provider_error
 from opensquilla.provider.protocol import LLMProvider
 from opensquilla.provider.registry import get_provider_spec
@@ -489,17 +489,37 @@ async def discover_selectable_provider_models(
     if (
         not uses_https
         or not spec.compat.official_host
-        or not is_provider_app_host(effective_base_url, spec.compat.official_host)
+        or not is_host_or_subdomain(effective_base_url, spec.compat.official_host)
     ):
         return ProviderModelsDiscoverResult(ok=True, provider_id=provider_id)
 
+    discovery_provider_id = (
+        spec.selectable_model_discovery_provider_id or provider_id
+    )
     discover_kwargs: dict[str, Any] = {
-        "provider_id": provider_id,
+        "provider_id": discovery_provider_id,
         "api_key": api_key,
         "api_key_env": api_key_env,
-        "base_url": base_url.strip(),
+        # A sibling discovery provider owns a different protocol path. Its
+        # registry default is the only trusted listing endpoint; never pass
+        # the configured chat base path across protocols.
+        "base_url": (
+            base_url.strip()
+            if discovery_provider_id == provider_id
+            else ""
+        ),
         "proxy": proxy,
     }
     if not allow_default_api_key_env:
         discover_kwargs["allow_default_api_key_env"] = False
-    return await discover_provider_models(**discover_kwargs)
+    result = await discover_provider_models(**discover_kwargs)
+    if result.provider_id == provider_id:
+        return result
+    return ProviderModelsDiscoverResult(
+        ok=result.ok,
+        provider_id=provider_id,
+        failure_kind=result.failure_kind,
+        detail=result.detail,
+        source=result.source,
+        models=result.models,
+    )

--- a/src/opensquilla/onboarding/provider_specs.py
+++ b/src/opensquilla/onboarding/provider_specs.py
@@ -62,6 +62,8 @@ _PROVIDER_LABELS: dict[str, str] = {
     "dashscope": "Aliyun DashScope",
     "bailian_coding": "Bailian Coding (International)",
     "bailian_coding_cn": "Bailian Coding (Mainland China)",
+    "qwen_token_plan": "Qwen Token Plan",
+    "qwen_token_plan_anthropic": "Qwen Token Plan (Anthropic)",
     "moonshot": "Moonshot AI",
     "kimi_coding_openai": "Kimi Coding OpenAI-compatible",
     "kimi_coding_anthropic": "Kimi Coding Anthropic-compatible",
@@ -89,6 +91,7 @@ _PROVIDER_LABELS: dict[str, str] = {
     "tokenrhythm": "TokenRhythm",
     "vllm": "vLLM (self-hosted)",
     "custom": "Custom OpenAI-compatible endpoint",
+    "custom_anthropic": "Custom Anthropic-compatible endpoint",
     "litellm_proxy": "LiteLLM Proxy",
     "lm_studio": "LM Studio (local)",
     "ovms": "OpenVINO Model Server",
@@ -136,6 +139,8 @@ _ONBOARDING_VERIFIED_PROVIDER_IDS = frozenset(
         "deepseek",
         "gemini",
         "dashscope",
+        "qwen_token_plan",
+        "qwen_token_plan_anthropic",
         "moonshot",
         "zhipu",
         "qianfan",
@@ -148,9 +153,15 @@ _ONBOARDING_VERIFIED_PROVIDER_IDS = frozenset(
 _LOCAL_PROVIDER_IDS = frozenset({"ollama", "vllm", "lm_studio", "ovms"})
 _OAUTH_PROVIDER_IDS = frozenset({"openai_codex", "github_copilot"})
 _BAILIAN_CODING_PROVIDER_IDS = frozenset({"bailian_coding", "bailian_coding_cn"})
+_DEDICATED_SK_SP_PROVIDER_IDS = _BAILIAN_CODING_PROVIDER_IDS | {
+    "qwen_token_plan",
+    "qwen_token_plan_anthropic",
+}
 _DIRECT_MODEL_DEFAULTS = {
     "bailian_coding": "qwen3.7-plus",
     "bailian_coding_cn": "qwen3.7-plus",
+    "qwen_token_plan": "qwen3.8-max-preview",
+    "qwen_token_plan_anthropic": "qwen3.8-max-preview",
 }
 
 
@@ -190,8 +201,8 @@ def _what_you_need(spec: ProviderSpec) -> tuple[str, ...]:
             else "A provider model id."
         )
     if spec.requires_api_key():
-        if spec.provider_id in _BAILIAN_CODING_PROVIDER_IDS:
-            needs.append("A dedicated Coding Plan API key starting with sk-sp-.")
+        if spec.provider_id in _DEDICATED_SK_SP_PROVIDER_IDS:
+            needs.append("A dedicated plan API key starting with sk-sp-.")
         else:
             needs.append(
                 f"API key via {spec.env_key} or a one-time paste."
@@ -239,10 +250,10 @@ def _fields_for(spec: ProviderSpec) -> tuple[ProviderSetupField, ...]:
     router_supported = _is_router_supported_provider(spec.provider_id)
     api_key_description = (
         (
-            "Use the dedicated Coding Plan API key starting with sk-sp-. "
+            "Use the dedicated plan API key starting with sk-sp-. "
             "Standard Model Studio keys are not interchangeable. "
         )
-        if spec.provider_id in _BAILIAN_CODING_PROVIDER_IDS
+        if spec.provider_id in _DEDICATED_SK_SP_PROVIDER_IDS
         else ""
     )
     api_key_description += (

--- a/src/opensquilla/provider/anthropic.py
+++ b/src/opensquilla/provider/anthropic.py
@@ -294,6 +294,9 @@ class AnthropicProvider:
         replay_provider_state: bool = True,
         auth_header_style: AuthHeaderStyle = "x-api-key",
         provider_id: str | None = None,
+        listing_model_ids: tuple[str, ...] | None = None,
+        temperature_floor_model_ids: frozenset[str] = frozenset(),
+        temperature_floor: float = 0.0,
     ) -> None:
         # The default auth style matches Anthropic proper so direct
         # construction (tests, embedding) against the default host behaves
@@ -309,6 +312,9 @@ class AnthropicProvider:
         # profiles such as MiniMax carry their own configured identity for
         # response attribution without changing Anthropic-shaped behavior.
         self.provider_id = (provider_id or self.provider_name).strip()
+        self._listing_model_ids = listing_model_ids
+        self._temperature_floor_model_ids = temperature_floor_model_ids
+        self._temperature_floor = temperature_floor
 
     @property
     def model(self) -> str:
@@ -382,7 +388,13 @@ class AnthropicProvider:
         if system_payload:
             payload["system"] = system_payload
         if cfg.temperature is not None and not cfg.thinking:
-            payload["temperature"] = cfg.temperature
+            temperature = cfg.temperature
+            if (
+                self._model.rsplit("/", 1)[-1].strip().lower()
+                in self._temperature_floor_model_ids
+            ):
+                temperature = max(temperature, self._temperature_floor)
+            payload["temperature"] = temperature
         if cfg.stop_sequences:
             payload["stop_sequences"] = cfg.stop_sequences
         if tools:
@@ -428,10 +440,11 @@ class AnthropicProvider:
             "content-type": "application/json",
             "accept": "text/event-stream",
         }
-        if self._auth_header_style == "bearer":
-            headers["Authorization"] = f"Bearer {self._api_key}"
-        else:
-            headers["x-api-key"] = self._api_key
+        if self._api_key:
+            if self._auth_header_style == "bearer":
+                headers["Authorization"] = f"Bearer {self._api_key}"
+            else:
+                headers["x-api-key"] = self._api_key
         endpoint = self._api_url("/v1/messages")
         trace = LLMTraceRecorder(
             provider="anthropic",
@@ -1024,20 +1037,27 @@ class AnthropicProvider:
             )
 
     async def list_models(self) -> list[ModelInfo]:
-        """Build listing rows for the adapter's SKUs from the shared catalog.
+        """Build listing rows for this provider identity from the shared catalog.
 
         The catalog's canonical costs are USD per million tokens; the
         ``ModelInfo`` wire contract carries per-1k floats (rpc_models
         renders per-1k), so entry costs are converted back (÷1000).
         Capability flags stay at ``ModelInfo`` defaults — the listing has
-        only ever advertised identity, windows, and pricing.
+        only ever advertised identity, windows, and pricing. Native Anthropic
+        uses its built-in SKU list; compatibility endpoints receive an exact
+        registry list or the configured model from the selector.
         """
         rows: list[ModelInfo] = []
-        for model_id in _LISTING_MODEL_IDS:
-            entry = shared_catalog().resolve_entry(model_id, provider=self.provider_name)
+        model_ids = (
+            _LISTING_MODEL_IDS
+            if self._listing_model_ids is None
+            else self._listing_model_ids
+        )
+        for model_id in model_ids:
+            entry = shared_catalog().resolve_entry(model_id, provider=self.provider_id)
             rows.append(
                 ModelInfo(
-                    provider=self.provider_name,
+                    provider=self.provider_id,
                     model_id=model_id,
                     display_name=entry.display_name or model_id,
                     context_window=entry.context_window,

--- a/src/opensquilla/provider/app_attribution.py
+++ b/src/opensquilla/provider/app_attribution.py
@@ -26,13 +26,21 @@ def _normalized_hostname(url: str | None) -> str:
         return ""
 
 
+def is_host_or_subdomain(url: str | None, root_host: str) -> bool:
+    """Return whether ``url`` uses ``root_host`` or one of its subdomains."""
+    root = str(root_host or "").strip().lower().lstrip(".")
+    if not root or ":" in root or "%" in root:
+        return False
+    host = _normalized_hostname(url)
+    return host == root or host.endswith(f".{root}")
+
+
 def is_provider_app_host(url: str | None, root_host: str) -> bool:
     """Return whether ``url`` is the allowlisted root host or its subdomain."""
     root = str(root_host or "").strip().lower().lstrip(".")
     if root not in _APP_ATTRIBUTION_ROOT_HOSTS:
         return False
-    host = _normalized_hostname(url)
-    return host == root or host.endswith(f".{root}")
+    return is_host_or_subdomain(url, root)
 
 
 def provider_app_headers(url: str | None) -> dict[str, str]:

--- a/src/opensquilla/provider/catalog_overrides.toml
+++ b/src/opensquilla/provider/catalog_overrides.toml
@@ -548,6 +548,131 @@ supports_tools = true
 supports_vision = false
 reasoning_format = "none"
 
+# qwen_token_plan: exact subscription allowlist shared by the OpenAI and
+# Anthropic protocol profiles. The Anthropic profile resolves through this
+# table via model_catalog's corrections alias. Costs stay unset because
+# Credits are subscription quota, not per-token USD billing.
+
+[qwen_token_plan."qwen3.8-max-preview"]
+context_window = 983616
+max_output_tokens = 131072
+supports_reasoning = true
+supports_tools = true
+supports_vision = true
+reasoning_format = "qwen_token_plan_qwen"
+
+[qwen_token_plan."qwen3.7-max"]
+context_window = 1000000
+max_output_tokens = 65536
+supports_reasoning = true
+supports_tools = true
+supports_vision = false
+reasoning_format = "qwen_token_plan_qwen"
+
+[qwen_token_plan."qwen3.7-plus"]
+context_window = 1000000
+max_output_tokens = 65536
+supports_reasoning = true
+supports_tools = true
+supports_vision = true
+reasoning_format = "qwen_token_plan_qwen"
+
+[qwen_token_plan."qwen3.6-plus"]
+context_window = 1000000
+max_output_tokens = 65536
+supports_reasoning = true
+supports_tools = true
+supports_vision = true
+reasoning_format = "qwen_token_plan_qwen"
+
+[qwen_token_plan."qwen3.6-flash"]
+context_window = 1000000
+max_output_tokens = 65536
+supports_reasoning = true
+supports_tools = true
+supports_vision = true
+reasoning_format = "qwen_token_plan_qwen"
+
+[qwen_token_plan."deepseek-v4-pro"]
+context_window = 1000000
+max_output_tokens = 393216
+supports_reasoning = true
+supports_tools = true
+supports_vision = false
+reasoning_format = "qwen_token_plan_deepseek"
+
+[qwen_token_plan."deepseek-v4-flash"]
+context_window = 1000000
+max_output_tokens = 393216
+supports_reasoning = true
+supports_tools = true
+supports_vision = false
+reasoning_format = "qwen_token_plan_deepseek"
+
+[qwen_token_plan."deepseek-v3.2"]
+context_window = 131072
+max_output_tokens = 65536
+supports_reasoning = true
+supports_tools = true
+supports_vision = false
+reasoning_format = "qwen_token_plan"
+
+[qwen_token_plan."kimi-k2.7-code"]
+context_window = 262144
+max_output_tokens = 16384
+supports_reasoning = true
+supports_tools = true
+supports_vision = true
+reasoning_format = "qwen_token_plan_kimi"
+
+[qwen_token_plan."kimi-k2.6"]
+context_window = 262144
+max_output_tokens = 98304
+supports_reasoning = true
+supports_tools = true
+supports_vision = true
+reasoning_format = "qwen_token_plan_kimi"
+
+[qwen_token_plan."kimi-k2.5"]
+context_window = 262144
+max_output_tokens = 32768
+supports_reasoning = true
+supports_tools = true
+supports_vision = true
+reasoning_format = "qwen_token_plan_kimi"
+
+[qwen_token_plan."glm-5.2"]
+context_window = 1000000
+max_output_tokens = 131072
+supports_reasoning = true
+supports_tools = true
+supports_vision = false
+reasoning_format = "qwen_token_plan_glm"
+
+[qwen_token_plan."glm-5.1"]
+context_window = 202752
+max_output_tokens = 131072
+supports_reasoning = true
+supports_tools = true
+supports_vision = false
+reasoning_format = "qwen_token_plan_glm"
+
+[qwen_token_plan."glm-5"]
+context_window = 202752
+max_output_tokens = 16384
+supports_reasoning = true
+supports_tools = true
+supports_vision = false
+reasoning_format = "qwen_token_plan_glm"
+
+[qwen_token_plan."minimax-m2.5"]
+context_window = 196608
+max_output_tokens = 32768
+supports_reasoning = true
+supports_tools = true
+supports_vision = false
+reasoning_format = "qwen_token_plan"
+
 # tokenrhythm (TokenRhythm aggregator, tokenrhythm.studio): not on
 # models.dev, so these rows are the offline metadata for its catalog —
 # the fallback beneath the boot-time live ingest of the platform's public

--- a/src/opensquilla/provider/compat_policy.py
+++ b/src/opensquilla/provider/compat_policy.py
@@ -20,6 +20,15 @@ from dataclasses import dataclass
 from fnmatch import fnmatchcase
 from typing import Literal
 
+from .qwen_token_plan import (
+    QWEN_TOKEN_PLAN_DEEPSEEK_V4_MODEL_IDS,
+    QWEN_TOKEN_PLAN_FORCE_THINKING_MODEL_IDS,
+    QWEN_TOKEN_PLAN_GLM_MODEL_IDS,
+    QWEN_TOKEN_PLAN_IMAGE_MODEL_IDS,
+    QWEN_TOKEN_PLAN_KIMI_MODEL_IDS,
+    QWEN_TOKEN_PLAN_PRESERVE_THINKING_MODEL_IDS,
+)
+
 TextToolDialect = Literal["qwen_tag", "minimax_xml", "plain_json"]
 
 TEXT_TOOL_DIALECT_QWEN_TAG: TextToolDialect = "qwen_tag"
@@ -161,6 +170,50 @@ class OpenAICompatPolicy:
     # openai.py, covering all five agent-loop disable sites at once.
     thinking_required_model_prefixes: tuple[str, ...] = ()
 
+    # Exact forced-thinking ids for multi-family endpoints where a prefix
+    # would be too broad. These models receive enable_thinking=True even
+    # when the local preference is off.
+    force_thinking_model_ids: frozenset[str] = frozenset()
+
+    # Models whose reasoning history can be replayed and whose request must
+    # opt into that continuity with preserve_thinking=True.
+    preserve_thinking_model_ids: frozenset[str] = frozenset()
+
+    # Reasoning models that require an assistant reasoning_content key only
+    # while thinking is enabled. The tool-call set is narrower: some models
+    # require the key only on assistant tool-call turns.
+    require_reasoning_content_when_thinking_model_ids: frozenset[str] = frozenset()
+    require_tool_call_reasoning_content_when_thinking_model_ids: frozenset[str] = (
+        frozenset()
+    )
+
+    # Thinking-mode tool choice accepts only auto/none on this endpoint.
+    thinking_tool_choice_auto_only: bool = False
+    # Models that are reasoning-only upstream even when the endpoint does not
+    # accept or emit an explicit enable_thinking toggle.  Their tool selector
+    # follows the same auto/none restriction as an explicitly enabled request.
+    implicit_thinking_tool_choice_model_ids: frozenset[str] = frozenset()
+    # When a non-forced model receives an explicit pinned tool selector,
+    # preserve the selector by disabling thinking instead of silently changing
+    # the selected function. Forced-thinking models still normalize to auto.
+    prefer_pinned_tool_choice_over_thinking: bool = False
+
+    # Models that require tool_stream=True whenever tools are present.
+    tool_stream_model_ids: frozenset[str] = frozenset()
+
+    # A thinking-only model may impose a minimum sampling temperature.
+    temperature_floor_model_ids: frozenset[str] = frozenset()
+    temperature_floor: float = 0.0
+
+    # Provider listings can mix non-chat products into the same /models
+    # response. Keep picker filtering declarative rather than branching in
+    # the generic OpenAI transport.
+    model_listing_excluded_ids: frozenset[str] = frozenset()
+
+    # Omit a framework-default thinking budget so the service can apply its
+    # own model default; an explicitly configured budget is still sent.
+    omit_implicit_thinking_budget: bool = False
+
     @property
     def text_tool_synthesis(self) -> bool:
         """Deprecated read-only compatibility view.
@@ -259,8 +312,38 @@ _POLICIES_BY_KIND: dict[str, OpenAICompatPolicy] = {
         supports_explicit_prompt_cache=True,
         stream_timeout_fallback=True,
         thinking_required_model_prefixes=("qwen3.8-",),
+        thinking_tool_choice_auto_only=True,
+        implicit_thinking_tool_choice_model_ids=_DEEPSEEK_V4_MODEL_IDS,
     ),
     "bailian_coding": OpenAICompatPolicy(display_name="Bailian Coding"),
+    "qwen_token_plan": OpenAICompatPolicy(
+        display_name="Qwen Token Plan",
+        official_host="token-plan.cn-beijing.maas.aliyuncs.com",
+        text_tool_profile=TextToolCompatProfile(
+            model_rules=(
+                TextToolModelRule(
+                    model_patterns=("qwen*",),
+                    dialects=frozenset({TEXT_TOOL_DIALECT_QWEN_TAG}),
+                ),
+            ),
+        ),
+        stream_timeout_fallback=True,
+        force_thinking_model_ids=QWEN_TOKEN_PLAN_FORCE_THINKING_MODEL_IDS,
+        preserve_thinking_model_ids=QWEN_TOKEN_PLAN_PRESERVE_THINKING_MODEL_IDS,
+        require_reasoning_content_when_thinking_model_ids=(
+            QWEN_TOKEN_PLAN_DEEPSEEK_V4_MODEL_IDS
+        ),
+        require_tool_call_reasoning_content_when_thinking_model_ids=(
+            QWEN_TOKEN_PLAN_KIMI_MODEL_IDS
+        ),
+        thinking_tool_choice_auto_only=True,
+        prefer_pinned_tool_choice_over_thinking=True,
+        tool_stream_model_ids=QWEN_TOKEN_PLAN_GLM_MODEL_IDS,
+        temperature_floor_model_ids=frozenset({"qwen3.8-max-preview"}),
+        temperature_floor=0.6,
+        model_listing_excluded_ids=frozenset(QWEN_TOKEN_PLAN_IMAGE_MODEL_IDS),
+        omit_implicit_thinking_budget=True,
+    ),
     "moonshot": OpenAICompatPolicy(
         display_name="Moonshot",
         fixed_sampling_model_prefixes=("kimi-k2.5", "kimi-k2.6", "kimi-k2.7"),

--- a/src/opensquilla/provider/image_generation.py
+++ b/src/opensquilla/provider/image_generation.py
@@ -9,6 +9,7 @@ import uuid
 from dataclasses import dataclass, field, replace
 from io import BytesIO
 from typing import Protocol
+from urllib.parse import urljoin, urlsplit
 
 import httpx
 from PIL import Image
@@ -26,6 +27,10 @@ from opensquilla.provider.image_generation_policy import (
     is_valid_image_generation_base_url,
     parse_image_generation_model_ref,
     resolve_image_generation_base_url,
+)
+from opensquilla.provider.qwen_token_plan import (
+    QWEN_TOKEN_PLAN_API_KEY_ENV,
+    QWEN_TOKEN_PLAN_IMAGE_BASE_URL,
 )
 from opensquilla.provider.tokenrhythm_correlation import (
     tokenrhythm_correlation_headers,
@@ -277,6 +282,114 @@ class OpenRouterImageGenerationProvider:
         )
 
 
+class QwenTokenPlanImageGenerationProvider:
+    """Native adapter for the Token Plan multimodal-generation API."""
+
+    provider_id = "qwen_token_plan"
+    default_model = "wan2.7-image"
+    auth_env_vars: tuple[str, ...] = (QWEN_TOKEN_PLAN_API_KEY_ENV,)
+    _generation_path = "/services/aigc/multimodal-generation/generation"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_key_env: str = QWEN_TOKEN_PLAN_API_KEY_ENV,
+        base_url: str = QWEN_TOKEN_PLAN_IMAGE_BASE_URL,
+    ) -> None:
+        self._api_key = api_key
+        self._api_key_env = api_key_env
+        self._base_url = base_url.rstrip("/")
+
+    def _resolve_api_key(self) -> str:
+        return clean_header_secret(
+            self._api_key or os.environ.get(self._api_key_env, ""),
+            label=f"{self.provider_id} image API key",
+        )
+
+    @staticmethod
+    def _wire_size(size: str) -> str:
+        normalized = str(size or "").strip().lower().replace("*", "x")
+        dimensions = normalized.split("x")
+        if (
+            len(dimensions) != 2
+            or not all(part.isdigit() for part in dimensions)
+            or any(int(part) <= 0 for part in dimensions)
+        ):
+            raise RuntimeError(f"Invalid Token Plan image size: {size!r}")
+        return "*".join(dimensions)
+
+    async def generate(self, request: ImageGenerationRequest) -> ImageGenerationResult:
+        _raise_for_conflicting_official_endpoint(self.provider_id, self._base_url)
+        api_key = self._resolve_api_key()
+        if not api_key:
+            raise RuntimeError(f"{self._api_key_env} is not set")
+
+        payload = {
+            "model": request.model,
+            "input": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"text": request.prompt}],
+                    }
+                ]
+            },
+            "parameters": {
+                "size": self._wire_size(request.size),
+                "n": 1,
+                "thinking_mode": False,
+            },
+        }
+        from opensquilla.engine.usage_http import reserve_direct_usage_call
+
+        usage = await reserve_direct_usage_call(
+            provider=self.provider_id,
+            model=request.model,
+            base_url=self._base_url,
+        )
+        try:
+            async with httpx.AsyncClient(
+                timeout=request.timeout_seconds,
+                trust_env=_trust_env(),
+                follow_redirects=False,
+            ) as client:
+                response = await client.post(
+                    f"{self._base_url}{self._generation_path}",
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+                response.raise_for_status()
+                data = response.json()
+                await usage.finalize_openai_response(
+                    data,
+                    raw_json=str(getattr(response, "text", "") or ""),
+                )
+        except asyncio.CancelledError:
+            await usage.mark_unknown("cancelled")
+            raise
+        except Exception:
+            await usage.mark_unknown("direct_request_failed")
+            raise
+
+        image_url = _extract_qwen_token_plan_image_url(data)
+        if not image_url:
+            raise RuntimeError("Image generation provider returned no images")
+        mime_type, image_bytes = await _download_qwen_token_plan_image(
+            image_url,
+            timeout_seconds=request.timeout_seconds,
+        )
+        return ImageGenerationResult(
+            image_bytes=image_bytes,
+            mime_type=mime_type,
+            model=request.model,
+            provider=self.provider_id,
+        )
+
+
 def _extract_openrouter_image_url(data: dict) -> str | None:
     for choice in data.get("choices") or []:
         message = choice.get("message") or {}
@@ -286,6 +399,107 @@ def _extract_openrouter_image_url(data: dict) -> str | None:
             if isinstance(url, str) and url:
                 return url
     return None
+
+
+def _extract_qwen_token_plan_image_url(data: dict) -> str | None:
+    output = data.get("output") or {}
+    for choice in output.get("choices") or []:
+        message = choice.get("message") or {}
+        for item in message.get("content") or []:
+            if not isinstance(item, dict):
+                continue
+            image_url = item.get("image") or item.get("image_url")
+            if isinstance(image_url, str) and image_url:
+                return image_url
+    return None
+
+
+_GENERATED_IMAGE_DOWNLOAD_LIMIT = 20 * 1024 * 1024
+_GENERATED_IMAGE_REDIRECT_LIMIT = 3
+
+
+async def _download_qwen_token_plan_image(
+    image_url: str,
+    *,
+    timeout_seconds: float,
+) -> tuple[str, bytes]:
+    """Download one signed result URL without exposing it in failures."""
+
+    from opensquilla.tools.ssrf import (
+        environment_proxy_url,
+        pinned_transport,
+        validate_http_url_for_fetch,
+    )
+
+    current_url = image_url
+    for redirect_count in range(_GENERATED_IMAGE_REDIRECT_LIMIT + 1):
+        try:
+            parsed = urlsplit(current_url)
+            if (
+                parsed.scheme.lower() != "https"
+                or not parsed.hostname
+                or parsed.username is not None
+                or parsed.password is not None
+                or parsed.fragment
+            ):
+                raise ValueError("unsafe generated image URL")
+            vetted_ips = validate_http_url_for_fetch(current_url)
+
+            transport_kwargs: dict[str, object] = {}
+            if _trust_env():
+                proxy_url = environment_proxy_url(current_url)
+                if proxy_url is not None:
+                    transport_kwargs["proxy"] = proxy_url
+            transport = pinned_transport(current_url, vetted_ips, **transport_kwargs)
+            client_kwargs: dict[str, object] = {
+                "timeout": timeout_seconds,
+                "follow_redirects": False,
+                "trust_env": _trust_env(),
+            }
+            if transport is not None:
+                client_kwargs["transport"] = transport
+
+            async with httpx.AsyncClient(**client_kwargs) as client:  # type: ignore[arg-type]
+                async with client.stream("GET", current_url) as response:
+                    if response.status_code in {301, 302, 303, 307, 308}:
+                        location = response.headers.get("location")
+                        if not location:
+                            raise ValueError("redirect without location")
+                        current_url = urljoin(current_url, location)
+                        continue
+
+                    response.raise_for_status()
+                    content_length = response.headers.get("content-length")
+                    if (
+                        content_length is not None
+                        and content_length.isdigit()
+                        and int(content_length) > _GENERATED_IMAGE_DOWNLOAD_LIMIT
+                    ):
+                        raise ValueError("generated image exceeds download limit")
+                    image_bytes = bytearray()
+                    async for chunk in response.aiter_bytes():
+                        image_bytes.extend(chunk)
+                        if len(image_bytes) > _GENERATED_IMAGE_DOWNLOAD_LIMIT:
+                            raise ValueError("generated image exceeds download limit")
+                    content_type = (
+                        response.headers.get("content-type", "image/png")
+                        .split(";", 1)[0]
+                        .strip()
+                        .lower()
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            raise RuntimeError(
+                "Failed to securely download the generated Token Plan image"
+            ) from None
+
+        if not image_bytes:
+            raise RuntimeError("Token Plan returned an empty generated image")
+        mime_type = content_type if content_type.startswith("image/") else "image/png"
+        return mime_type, bytes(image_bytes)
+
+    raise RuntimeError("Token Plan generated image exceeded the redirect limit")
 
 
 def _decode_data_url(data_url: str) -> tuple[str, bytes]:
@@ -442,6 +656,7 @@ def reset_image_generation_providers(
     providers_config = getattr(image_config, "providers", None)
     openai_config = getattr(providers_config, "openai", None)
     openrouter_config = getattr(providers_config, "openrouter", None)
+    qwen_token_plan_config = getattr(providers_config, "qwen_token_plan", None)
 
     openai_base_url = _resolve_configured_base_url(
         provider_id="openai",
@@ -499,6 +714,40 @@ def reset_image_generation_providers(
             ),
             api_key_env=openrouter_api_key_env,
             base_url=openrouter_base_url,
+        )
+    )
+    qwen_token_plan_base_url = _resolve_configured_base_url(
+        provider_id="qwen_token_plan",
+        provider_config=qwen_token_plan_config,
+        llm_config=llm_config,
+        default_base_url=QWEN_TOKEN_PLAN_IMAGE_BASE_URL,
+    )
+    qwen_token_plan_api_key_env = credential_env_for_endpoint(
+        configured_env=_get_config_attr(
+            qwen_token_plan_config,
+            "api_key_env",
+            QWEN_TOKEN_PLAN_API_KEY_ENV,
+        ),
+        configured_explicitly=_field_was_set(
+            qwen_token_plan_config,
+            "api_key_env",
+        ),
+        default_env=QWEN_TOKEN_PLAN_API_KEY_ENV,
+        default_base_url=QWEN_TOKEN_PLAN_IMAGE_BASE_URL,
+        effective_base_url=qwen_token_plan_base_url,
+    )
+    register_image_generation_provider(
+        QwenTokenPlanImageGenerationProvider(
+            api_key=_resolve_configured_api_key(
+                provider_id="qwen_token_plan",
+                provider_config=qwen_token_plan_config,
+                llm_config=llm_config,
+                api_key_env=qwen_token_plan_api_key_env,
+                default_base_url=QWEN_TOKEN_PLAN_IMAGE_BASE_URL,
+                effective_base_url=qwen_token_plan_base_url,
+            ),
+            api_key_env=qwen_token_plan_api_key_env,
+            base_url=qwen_token_plan_base_url,
         )
     )
 

--- a/src/opensquilla/provider/image_generation_policy.py
+++ b/src/opensquilla/provider/image_generation_policy.py
@@ -6,10 +6,12 @@ import re
 from urllib.parse import urlsplit
 
 from opensquilla.endpoint_identity import base_url_allows_credential_reuse
+from opensquilla.provider.qwen_token_plan import QWEN_TOKEN_PLAN_IMAGE_BASE_URL
 
 IMAGE_GENERATION_OFFICIAL_BASE_URLS: dict[str, str] = {
     "openai": "https://api.openai.com/v1",
     "openrouter": "https://openrouter.ai/api/v1",
+    "qwen_token_plan": QWEN_TOKEN_PLAN_IMAGE_BASE_URL,
 }
 _PROVIDER_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
@@ -124,6 +126,11 @@ def resolve_image_generation_base_url(
     """
 
     base_url = _config_string(provider_config, "base_url", default_base_url) or default_base_url
+    # Token Plan chat and image generation share an origin and credential but
+    # use different native path roots. Reuse its credential, never its chat
+    # base path, unless the image endpoint itself was explicitly overridden.
+    if provider_id == "qwen_token_plan":
+        return base_url
     if not _field_was_set(provider_config, "base_url") and _llm_provider_matches(
         llm_config,
         provider_id,

--- a/src/opensquilla/provider/model_catalog.py
+++ b/src/opensquilla/provider/model_catalog.py
@@ -92,6 +92,13 @@ _SYNTHESIZED_DEFAULTS: dict[str, Any] = {
     "supports_reasoning": False,
 }
 
+# Protocol variants that share one service-side model catalog. User and live
+# overrides remain keyed to the exact configured provider; only packaged
+# corrections use this alias.
+_CORRECTIONS_PROVIDER_ALIASES: dict[str, str] = {
+    "qwen_token_plan_anthropic": "qwen_token_plan",
+}
+
 
 def _normalize_corrections(payload: Mapping[str, Any]) -> dict[str, dict[str, dict[str, Any]]]:
     """Normalize a parsed catalog_overrides.toml payload.
@@ -160,6 +167,7 @@ def _provider_corrections_budget(provider_id: str, model_id: str) -> tuple[int, 
     consulted for budgets.
     """
     provider_l = (provider_id or "").strip().lower()
+    provider_l = _CORRECTIONS_PROVIDER_ALIASES.get(provider_l, provider_l)
     model_l = (model_id or "").strip().lower()
     if not provider_l or not model_l:
         return None
@@ -264,7 +272,9 @@ def _corrections_layer_fields(provider_id: str, model_id: str) -> dict[str, Any]
     """
     if not provider_id:
         return {}
-    table = _corrections_tables().get(provider_id)
+    provider_l = provider_id.strip().lower()
+    provider_l = _CORRECTIONS_PROVIDER_ALIASES.get(provider_l, provider_l)
+    table = _corrections_tables().get(provider_l)
     if not table:
         return {}
     model_l = model_id.strip().lower()

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -699,6 +699,72 @@ def _should_send_temperature(
     return True
 
 
+def _apply_compat_request_constraints(
+    payload: dict[str, Any],
+    *,
+    policy: OpenAICompatPolicy,
+    model: str,
+    cfg: ChatConfig,
+    has_tools: bool,
+) -> None:
+    """Apply declarative endpoint constraints after generic payload assembly."""
+
+    model_name = _model_basename(model)
+    force_thinking = model_name in policy.force_thinking_model_ids
+    if force_thinking:
+        payload["enable_thinking"] = True
+
+    if (
+        policy.thinking_tool_choice_auto_only
+        and (
+            payload.get("enable_thinking") is True
+            or model_name in policy.implicit_thinking_tool_choice_model_ids
+        )
+        and "tool_choice" in payload
+    ):
+        tool_choice = payload["tool_choice"]
+        pinned_tool_choice = False
+        if isinstance(tool_choice, Mapping):
+            tool_choice_type = tool_choice.get("type")
+            pinned_tool_choice = tool_choice_type in {"tool", "function"}
+        else:
+            tool_choice_type = tool_choice
+        if tool_choice_type in {"auto", "none"}:
+            payload["tool_choice"] = tool_choice_type
+        elif (
+            policy.prefer_pinned_tool_choice_over_thinking
+            and pinned_tool_choice
+            and not force_thinking
+        ):
+            payload["enable_thinking"] = False
+            payload.pop("thinking_budget", None)
+            payload.pop("reasoning_effort", None)
+            payload.pop("preserve_thinking", None)
+            for message in payload.get("messages", ()):
+                if isinstance(message, dict):
+                    message.pop("reasoning_content", None)
+        else:
+            # The endpoint rejects required/pinned choices while thinking.
+            # Preserve the requested reasoning mode and degrade the selector
+            # to the nearest accepted value.
+            payload["tool_choice"] = "auto"
+
+    if has_tools and model_name in policy.tool_stream_model_ids:
+        payload["tool_stream"] = True
+
+    if (
+        model_name in policy.temperature_floor_model_ids
+        and policy.temperature_floor > 0
+        and isinstance(payload.get("temperature"), int | float)
+    ):
+        payload["temperature"] = max(
+            float(payload["temperature"]), policy.temperature_floor
+        )
+
+    if policy.omit_implicit_thinking_budget and not cfg.thinking_budget_explicit:
+        payload.pop("thinking_budget", None)
+
+
 def _resolve_llm_proxy(proxy: str | None) -> str | None:
     if proxy is None:
         return os.environ.get("OPENSQUILLA_LLM_PROXY", "").strip() or None
@@ -2373,8 +2439,40 @@ def _reasoning_echo_allowed_indexes(
     return set(assistant_indexes[-echo_turns:])
 
 
-def _requires_assistant_reasoning_content(policy: OpenAICompatPolicy, model: str) -> bool:
-    return model.strip().lower() in policy.require_reasoning_content_model_ids
+def _requires_assistant_reasoning_content(
+    policy: OpenAICompatPolicy,
+    model: str,
+    *,
+    thinking: bool = False,
+) -> bool:
+    model_name = _model_basename(model)
+    return model.strip().lower() in policy.require_reasoning_content_model_ids or (
+        thinking
+        and model_name
+        in policy.require_reasoning_content_when_thinking_model_ids
+    )
+
+
+def _effective_policy_thinking(
+    policy: OpenAICompatPolicy,
+    model: str,
+    *,
+    thinking: bool,
+) -> bool:
+    return thinking or _model_basename(model) in policy.force_thinking_model_ids
+
+
+def _requires_tool_call_reasoning_content(
+    policy: OpenAICompatPolicy,
+    model: str,
+    *,
+    thinking: bool,
+) -> bool:
+    return (
+        thinking
+        and _model_basename(model)
+        in policy.require_tool_call_reasoning_content_when_thinking_model_ids
+    )
 
 
 def _should_replay_reasoning_content(
@@ -2384,12 +2482,24 @@ def _should_replay_reasoning_content(
     caps: ModelCapabilities | None,
     thinking: bool = False,
 ) -> bool:
-    if _requires_assistant_reasoning_content(policy, model):
+    model_name = _model_basename(model)
+    effective_thinking = _effective_policy_thinking(
+        policy, model, thinking=thinking
+    )
+    if _requires_assistant_reasoning_content(
+        policy, model, thinking=effective_thinking
+    ):
+        return True
+    if _requires_tool_call_reasoning_content(
+        policy, model, thinking=effective_thinking
+    ):
         return True
     if not caps or not caps.supports_reasoning:
         return False
+    if effective_thinking and model_name in policy.preserve_thinking_model_ids:
+        return True
     if caps.reasoning_format == "dashscope":
-        if not thinking:
+        if not effective_thinking:
             return False
         return _dashscope_supports_preserve_thinking(model)
     return bool(policy.replay_reasoning_format) and (
@@ -2402,6 +2512,7 @@ def _build_openai_messages(
     *,
     include_reasoning_content: bool = True,
     require_assistant_reasoning_content: bool = False,
+    require_tool_call_reasoning_content: bool = False,
     replay_provider_state: bool = True,
 ) -> list[dict[str, Any]]:
     """Convert a opensquilla Message into one or more OpenAI-format message dicts.
@@ -2487,7 +2598,10 @@ def _build_openai_messages(
                 msg,
                 result,
                 include_reasoning_content=include_reasoning_content,
-                require_assistant_reasoning_content=require_assistant_reasoning_content,
+                require_assistant_reasoning_content=(
+                    require_assistant_reasoning_content
+                    or require_tool_call_reasoning_content
+                ),
             )
         ]
 
@@ -2559,6 +2673,9 @@ def _build_openai_wire_messages(
         else None
     )
     for message_index, message in enumerate(messages):
+        effective_thinking = _effective_policy_thinking(
+            policy, model, thinking=cfg.thinking
+        )
         openai_messages.extend(
             _build_openai_messages(
                 message,
@@ -2568,7 +2685,14 @@ def _build_openai_wire_messages(
                     else message_index in reasoning_echo_allowed
                 ),
                 require_assistant_reasoning_content=(
-                    _requires_assistant_reasoning_content(policy, model)
+                    _requires_assistant_reasoning_content(
+                        policy, model, thinking=effective_thinking
+                    )
+                ),
+                require_tool_call_reasoning_content=(
+                    _requires_tool_call_reasoning_content(
+                        policy, model, thinking=effective_thinking
+                    )
                 ),
                 replay_provider_state=replay_provider_state,
             )
@@ -2774,7 +2898,13 @@ class OpenAIProvider:
                     "schema": cfg.output_json_schema,
                 },
             }
-        if self._provider_kind == "dashscope" and include_reasoning_content:
+        if (
+            include_reasoning_content
+            and _model_basename(self._model)
+            in self._compat.preserve_thinking_model_ids
+        ) or (
+            self._provider_kind == "dashscope" and include_reasoning_content
+        ):
             payload["preserve_thinking"] = True
         if _should_use_max_completion_tokens(
             self._compat,
@@ -2868,6 +2998,10 @@ class OpenAIProvider:
                 ReasoningEnableArgs(
                     thinking_level=cfg.thinking_level,
                     thinking_budget_tokens=cfg.thinking_budget_tokens,
+                    model=self._model,
+                    thinking_budget_explicit=bool(
+                        cfg.thinking_budget_explicit
+                    ),
                 ),
             )
             if reasoning_format == "dashscope":
@@ -2880,9 +3014,12 @@ class OpenAIProvider:
                 elif not cfg.thinking_budget_explicit:
                     payload.pop("thinking_budget", None)
         elif (
-            self._compat.thinking_required_model_prefixes
-            and self._model.strip().lower().startswith(
+            _model_basename(self._model) in self._compat.force_thinking_model_ids
+            or (
                 self._compat.thinking_required_model_prefixes
+                and self._model.strip().lower().startswith(
+                    self._compat.thinking_required_model_prefixes
+                )
             )
         ):
             # Forced-thinking endpoints reject enable_thinking=False; omit the
@@ -2904,6 +3041,14 @@ class OpenAIProvider:
                     ),
                 ),
             )
+
+        _apply_compat_request_constraints(
+            payload,
+            policy=self._compat,
+            model=self._model,
+            cfg=cfg,
+            has_tools=bool(tools),
+        )
 
         if self._provider_kind == "dashscope":
             log.info(
@@ -2961,10 +3106,11 @@ class OpenAIProvider:
             return
 
         headers: dict[str, str] = {
-            "Authorization": f"Bearer {self._api_key}",
             "Content-Type": "application/json",
             "Accept": "text/event-stream",
         }
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
         headers.update(provider_app_headers(self._base_url))
         headers.update(
             tokenrhythm_correlation_headers(
@@ -5274,7 +5420,11 @@ class OpenAIProvider:
         so callers that must distinguish a wrong key from an empty catalog
         (e.g. onboarding discovery) can classify it.
         """
-        headers = {"Authorization": f"Bearer {self._api_key}"}
+        headers = (
+            {"Authorization": f"Bearer {self._api_key}"}
+            if self._api_key
+            else {}
+        )
         headers.update(provider_app_headers(self._base_url))
         try:
             async with httpx.AsyncClient(
@@ -5285,6 +5435,17 @@ class OpenAIProvider:
                 resp = await client.get(self._api_url("/v1/models"), headers=headers)
                 resp.raise_for_status()
                 data = resp.json()
+                rows = data.get("data", [])
+                if self._compat.model_listing_excluded_ids:
+                    excluded_model_ids = {
+                        model_id.lower()
+                        for model_id in self._compat.model_listing_excluded_ids
+                    }
+                    rows = [
+                        row
+                        for row in rows
+                        if str(row.get("id", "")).lower() not in excluded_model_ids
+                    ]
                 return [
                     ModelInfo(
                         provider=self._provider_kind,
@@ -5294,7 +5455,7 @@ class OpenAIProvider:
                         max_output_tokens=(m.get("top_provider") or {}).get("max_completion_tokens")
                         or 0,
                     )
-                    for m in data.get("data", [])
+                    for m in rows
                 ]
         except httpx.HTTPError as exc:
             if raise_on_error:

--- a/src/opensquilla/provider/preset_registry.py
+++ b/src/opensquilla/provider/preset_registry.py
@@ -52,7 +52,9 @@ LEGACY_PROVIDER_PRESET_IDS: frozenset[str] = frozenset(
 # ``squilla_router.tier_profile`` id: the accepted set stays pinned to the
 # legacy nine (downgrade contract), so provider saves and boot defaults apply
 # these ladders as inline tiers instead.
-CURATED_INLINE_PRESET_IDS: frozenset[str] = frozenset({"tokenrhythm"})
+CURATED_INLINE_PRESET_IDS: frozenset[str] = frozenset(
+    {"qwen_token_plan", "tokenrhythm"}
+)
 
 _PRESETS_SUBDIR = "presets"
 

--- a/src/opensquilla/provider/presets/qwen_token_plan.toml
+++ b/src/opensquilla/provider/presets/qwen_token_plan.toml
@@ -1,0 +1,45 @@
+# Packaged SquillaRouter tier preset. Applied as inline tiers so older
+# releases that do not know this provider never need to parse a new
+# tier_profile enum value.
+[preset]
+id = "qwen_token_plan"
+provider = "qwen_token_plan"
+label = "Qwen Token Plan"
+description = "Curated Token Plan ladder for fast, balanced, advanced, and highest-capability agent turns."
+default_model = "qwen3.7-plus"
+
+[tiers.c0]
+provider = "qwen_token_plan"
+model = "qwen3.6-flash"
+description = "Fast route for short edits, extraction, simple questions, and low-risk tool work."
+thinking_level = "low"
+supports_image = true
+
+[tiers.c1]
+provider = "qwen_token_plan"
+model = "qwen3.7-plus"
+description = "Balanced default route for coding, debugging, normal agent work, and large-context synthesis."
+thinking_level = "medium"
+supports_image = true
+
+[tiers.c2]
+provider = "qwen_token_plan"
+model = "qwen3.7-max"
+description = "Advanced text route for multi-step implementation, complex debugging, and deep review."
+thinking_level = "high"
+supports_image = false
+
+[tiers.c3]
+provider = "qwen_token_plan"
+model = "qwen3.8-max-preview"
+description = "Highest-capability reasoning route for difficult planning, architecture, and high-stakes synthesis."
+thinking_level = "xhigh"
+supports_image = true
+
+[tiers.image_model]
+provider = "qwen_token_plan"
+model = "qwen3.7-plus"
+description = "Vision-capable route for screenshots, diagrams, and other image attachments."
+thinking_level = "medium"
+supports_image = true
+image_only = true

--- a/src/opensquilla/provider/qwen_token_plan.py
+++ b/src/opensquilla/provider/qwen_token_plan.py
@@ -1,0 +1,78 @@
+"""Stable Qwen Token Plan protocol and model identifiers.
+
+The subscription exposes one model allowlist through both OpenAI-compatible
+Chat Completions and Anthropic Messages endpoints.  Keep identifiers shared
+between registry metadata, request compatibility, and listing code so the
+two protocol profiles cannot drift.
+"""
+
+from __future__ import annotations
+
+QWEN_TOKEN_PLAN_API_KEY_ENV = "QWEN_TOKEN_PLAN_API_KEY"
+QWEN_TOKEN_PLAN_OPENAI_BASE_URL = (
+    "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+)
+QWEN_TOKEN_PLAN_ANTHROPIC_BASE_URL = (
+    "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic"
+)
+QWEN_TOKEN_PLAN_IMAGE_BASE_URL = (
+    "https://token-plan.cn-beijing.maas.aliyuncs.com/api/v1"
+)
+
+# Team is the superset of the personal plan.  Exact spellings matter: the
+# upstream rejects aliases and differently cased model ids.
+QWEN_TOKEN_PLAN_MODEL_IDS: tuple[str, ...] = (
+    "qwen3.8-max-preview",
+    "qwen3.7-max",
+    "qwen3.7-plus",
+    "qwen3.6-plus",
+    "qwen3.6-flash",
+    "deepseek-v4-pro",
+    "deepseek-v4-flash",
+    "deepseek-v3.2",
+    "kimi-k2.7-code",
+    "kimi-k2.6",
+    "kimi-k2.5",
+    "glm-5.2",
+    "glm-5.1",
+    "glm-5",
+    "MiniMax-M2.5",
+)
+QWEN_TOKEN_PLAN_IMAGE_MODEL_IDS: tuple[str, ...] = (
+    "wan2.7-image",
+    "wan2.7-image-pro",
+)
+
+QWEN_TOKEN_PLAN_DEEPSEEK_V4_MODEL_IDS = frozenset(
+    {"deepseek-v4-pro", "deepseek-v4-flash"}
+)
+QWEN_TOKEN_PLAN_KIMI_MODEL_IDS = frozenset(
+    {"kimi-k2.7-code", "kimi-k2.6", "kimi-k2.5"}
+)
+QWEN_TOKEN_PLAN_GLM_MODEL_IDS = frozenset({"glm-5.2", "glm-5.1", "glm-5"})
+
+# These models are documented or verified as reasoning-only on the plan
+# endpoint.  A local "thinking off" preference must not serialize an
+# upstream-rejected disable payload.
+QWEN_TOKEN_PLAN_FORCE_THINKING_MODEL_IDS = frozenset(
+    {"qwen3.8-max-preview", "kimi-k2.7-code", "minimax-m2.5"}
+)
+
+# preserve_thinking is accepted only by this documented subset. Kimi K2.5 is
+# intentionally absent even though it can reason.
+QWEN_TOKEN_PLAN_PRESERVE_THINKING_MODEL_IDS = frozenset(
+    {
+        "qwen3.8-max-preview",
+        "qwen3.7-max",
+        "qwen3.7-plus",
+        "qwen3.6-plus",
+        "kimi-k2.7-code",
+        "kimi-k2.6",
+    }
+)
+
+
+def qwen_token_plan_model_id(model: str) -> str:
+    """Normalize a configured model id for exact Token Plan comparisons."""
+
+    return model.rsplit("/", 1)[-1].strip().lower()

--- a/src/opensquilla/provider/reasoning_dialects.py
+++ b/src/opensquilla/provider/reasoning_dialects.py
@@ -87,6 +87,8 @@ class ReasoningEnableArgs:
 
     thinking_level: ThinkingLevel | None
     thinking_budget_tokens: int
+    model: str = ""
+    thinking_budget_explicit: bool = False
 
     @property
     def effort(self) -> str:
@@ -132,6 +134,52 @@ def _enable_thinking_object(payload: dict[str, Any], args: ReasoningEnableArgs) 
 def _enable_dashscope(payload: dict[str, Any], args: ReasoningEnableArgs) -> None:
     payload["enable_thinking"] = True
     payload["thinking_budget"] = args.thinking_budget_tokens
+
+
+def _enable_qwen_token_plan(payload: dict[str, Any], args: ReasoningEnableArgs) -> None:
+    payload["enable_thinking"] = True
+
+
+def _enable_qwen_token_plan_qwen(
+    payload: dict[str, Any], args: ReasoningEnableArgs
+) -> None:
+    payload["enable_thinking"] = True
+    if args.model.rsplit("/", 1)[-1].strip().lower() == "qwen3.8-max-preview":
+        if args.thinking_budget_explicit:
+            payload["thinking_budget"] = args.thinking_budget_tokens
+        else:
+            from opensquilla.engine.types import ThinkingLevel
+
+            if args.thinking_level in (ThinkingLevel.MINIMAL, ThinkingLevel.LOW):
+                payload["reasoning_effort"] = "low"
+            elif args.thinking_level in (ThinkingLevel.MEDIUM, ThinkingLevel.HIGH):
+                payload["reasoning_effort"] = "medium"
+            else:
+                payload["reasoning_effort"] = "xhigh"
+        return
+    payload["thinking_budget"] = args.thinking_budget_tokens
+
+
+def _enable_qwen_token_plan_deepseek(
+    payload: dict[str, Any], args: ReasoningEnableArgs
+) -> None:
+    payload["enable_thinking"] = True
+    payload["reasoning_effort"] = _resolve_deepseek_reasoning_effort(args.thinking_level)
+
+
+def _enable_qwen_token_plan_glm(
+    payload: dict[str, Any], args: ReasoningEnableArgs
+) -> None:
+    payload["enable_thinking"] = True
+    payload["reasoning_effort"] = _resolve_deepseek_reasoning_effort(
+        args.thinking_level
+    )
+
+
+def _disable_qwen_token_plan(
+    payload: dict[str, Any], args: ReasoningDisableArgs
+) -> None:
+    payload["enable_thinking"] = False
 
 
 def _disable_thinking_object(payload: dict[str, Any], args: ReasoningDisableArgs) -> None:
@@ -201,6 +249,31 @@ DIALECTS: dict[str, ReasoningDialect] = {
         name="dashscope",
         enable=_enable_dashscope,
         disable=_disable_dashscope,
+    ),
+    "qwen_token_plan": ReasoningDialect(
+        name="qwen_token_plan",
+        enable=_enable_qwen_token_plan,
+        disable=_disable_qwen_token_plan,
+    ),
+    "qwen_token_plan_qwen": ReasoningDialect(
+        name="qwen_token_plan_qwen",
+        enable=_enable_qwen_token_plan_qwen,
+        disable=_disable_qwen_token_plan,
+    ),
+    "qwen_token_plan_deepseek": ReasoningDialect(
+        name="qwen_token_plan_deepseek",
+        enable=_enable_qwen_token_plan_deepseek,
+        disable=_disable_qwen_token_plan,
+    ),
+    "qwen_token_plan_glm": ReasoningDialect(
+        name="qwen_token_plan_glm",
+        enable=_enable_qwen_token_plan_glm,
+        disable=_disable_qwen_token_plan,
+    ),
+    "qwen_token_plan_kimi": ReasoningDialect(
+        name="qwen_token_plan_kimi",
+        enable=_enable_qwen_token_plan,
+        disable=_disable_qwen_token_plan,
     ),
     "moonshot": ReasoningDialect(
         name="moonshot",

--- a/src/opensquilla/provider/registry.py
+++ b/src/opensquilla/provider/registry.py
@@ -12,28 +12,33 @@ from .context_capabilities import (
     OPENROUTER_CONTEXT_PROFILE,
     ProviderContextProfile,
 )
+from .qwen_token_plan import (
+    QWEN_TOKEN_PLAN_ANTHROPIC_BASE_URL,
+    QWEN_TOKEN_PLAN_API_KEY_ENV,
+    QWEN_TOKEN_PLAN_MODEL_IDS,
+    QWEN_TOKEN_PLAN_OPENAI_BASE_URL,
+)
 
 # ---------------------------------------------------------------------------
 # Named local-provider sets. ONE home, TWO deliberately distinct sets — they
 # answer different questions and must not be merged:
 #
 # - KEYLESS_PROVIDERS: providers whose API key is optional even when an
-#   env_key is declared — local runtimes plus the generic self-hosted
-#   ``custom`` endpoint (many self-hosted servers run without
-#   authentication). Drives ``ProviderSpec.requires_api_key``.
-# - LOCAL_RUNTIME_PROVIDERS: the superset the model catalog's context-window
-#   heuristic uses (model_catalog.py): runtimes that serve models from the
-#   local machine, whose unqualified model ids miss every catalog and would
-#   otherwise inherit the 200k cloud default. ``vllm`` and the bare
-#   ``local`` alias belong here but stay OUT of KEYLESS_PROVIDERS: local
-#   serving does not imply keyless onboarding (a vLLM deployment can front
-#   real auth), so folding them in would silently weaken requires_api_key.
+#   env_key is declared — local runtimes plus generic custom endpoints (many
+#   self-hosted servers run without authentication). Drives
+#   ``ProviderSpec.requires_api_key``.
+# - LOCAL_RUNTIME_PROVIDERS: providers whose unknown model ids keep the
+#   conservative 8k context fallback. Generic custom endpoints remain here
+#   for upgrade compatibility: existing installations have always received
+#   that bound, whether the configured endpoint is local or remote.
 #
-# The derivation is explicit (superset = keyless | extras) so the two sets
-# can never drift apart by accident.
+# Keyless and local-runtime status still answer independent questions;
+# today's local-window set happens to include every keyless provider.
 # ---------------------------------------------------------------------------
 
-KEYLESS_PROVIDERS: frozenset[str] = frozenset({"ollama", "lm_studio", "ovms", "custom"})
+KEYLESS_PROVIDERS: frozenset[str] = frozenset(
+    {"ollama", "lm_studio", "ovms", "custom", "custom_anthropic"}
+)
 
 LOCAL_RUNTIME_PROVIDERS: frozenset[str] = KEYLESS_PROVIDERS | {"vllm", "local"}
 
@@ -97,6 +102,14 @@ class ProviderSpec:
     live_catalog_url: str = ""
     live_catalog_shape: str = ""
     selectable_model_catalog: SelectableModelCatalog = "none"
+    # A protocol-specific profile can discover the same account entitlements
+    # through a sibling provider whose official endpoint exposes /models.
+    # Empty means use this provider directly.
+    selectable_model_discovery_provider_id: str = ""
+    # Optional exact model list for compatibility transports that do not
+    # expose a trustworthy model-list endpoint (notably Anthropic Messages
+    # gateways). Empty means the backend's normal listing behavior.
+    static_model_ids: tuple[str, ...] = ()
 
     def requires_api_key(self) -> bool:
         """True if onboarding must collect an API key for this provider."""
@@ -138,6 +151,8 @@ def _spec(
     live_catalog_url: str = "",
     live_catalog_shape: str = "",
     selectable_model_catalog: SelectableModelCatalog = "none",
+    selectable_model_discovery_provider_id: str = "",
+    static_model_ids: tuple[str, ...] = (),
 ) -> ProviderSpec:
     if required_fields is None:
         required_fields = frozenset({"api_key", "model"}) if env_key else frozenset({"model"})
@@ -159,6 +174,10 @@ def _spec(
         live_catalog_url=live_catalog_url,
         live_catalog_shape=live_catalog_shape,
         selectable_model_catalog=selectable_model_catalog,
+        selectable_model_discovery_provider_id=(
+            selectable_model_discovery_provider_id
+        ),
+        static_model_ids=static_model_ids,
     )
 
 
@@ -261,6 +280,30 @@ for _provider_spec in [
         "BAILIAN_API_KEY",
         "https://coding.dashscope.aliyuncs.com/v1",
         catalog_source=("alibaba-cn", "alibaba"),
+    ),
+    # Qwen Token Plan uses a dedicated sk-sp key and service host; neither is
+    # interchangeable with regular DashScope pay-as-you-go credentials.
+    _spec(
+        "qwen_token_plan",
+        "openai_compat",
+        "qwen_token_plan",
+        QWEN_TOKEN_PLAN_API_KEY_ENV,
+        QWEN_TOKEN_PLAN_OPENAI_BASE_URL,
+        capabilities=frozenset({"chat", "coding_plan"}),
+        selectable_model_catalog="verified_live",
+    ),
+    _spec(
+        "qwen_token_plan_anthropic",
+        "anthropic",
+        "qwen_token_plan",
+        QWEN_TOKEN_PLAN_API_KEY_ENV,
+        QWEN_TOKEN_PLAN_ANTHROPIC_BASE_URL,
+        failure_family="anthropic",
+        auth_header_style="bearer",
+        capabilities=frozenset({"chat", "coding_plan"}),
+        selectable_model_catalog="verified_live",
+        selectable_model_discovery_provider_id="qwen_token_plan",
+        static_model_ids=QWEN_TOKEN_PLAN_MODEL_IDS,
     ),
     _spec(
         "moonshot",
@@ -525,6 +568,18 @@ for _provider_spec in [
         "CUSTOM_LLM_API_KEY",
         required_fields=frozenset({"model", "base_url"}),
         failure_family="openai_compat",
+    ),
+    # Anthropic Messages counterpart to ``custom``.  Keeping a separate
+    # provider id preserves the existing OpenAI-compatible default while
+    # making protocol selection explicit and upgrade-safe.
+    _spec(
+        "custom_anthropic",
+        "anthropic",
+        "anthropic",
+        "CUSTOM_ANTHROPIC_API_KEY",
+        required_fields=frozenset({"model", "base_url"}),
+        failure_family="anthropic",
+        auth_header_style="bearer",
     ),
     _spec("vllm", "openai_compat", "openai"),
     _spec("lm_studio", "openai_compat", "lm_studio", default_base_url="http://localhost:1234/v1"),

--- a/src/opensquilla/provider/selector.py
+++ b/src/opensquilla/provider/selector.py
@@ -197,6 +197,7 @@ class ProviderBuildContext:
     # Spec-derived fields.
     auth_header_style: AuthHeaderStyle = "bearer"
     compat: OpenAICompatPolicy = field(default_factory=OpenAICompatPolicy)
+    static_model_ids: tuple[str, ...] = ()
 
 
 def _build_context(cfg: ProviderConfig, spec: ProviderSpec) -> ProviderBuildContext:
@@ -213,6 +214,7 @@ def _build_context(cfg: ProviderConfig, spec: ProviderSpec) -> ProviderBuildCont
         replay_provider_state=cfg.replay_provider_state,
         auth_header_style=spec.auth_header_style,
         compat=spec.compat,
+        static_model_ids=spec.static_model_ids,
     )
 
 
@@ -223,6 +225,16 @@ def _build_anthropic(ctx: ProviderBuildContext) -> LLMProvider:
         "replay_provider_state": ctx.replay_provider_state,
         "auth_header_style": ctx.auth_header_style,
         "provider_id": ctx.provider_id,
+        # Native Anthropic keeps its built-in SKU list. Compatibility
+        # endpoints use an exact registry list when present, otherwise the
+        # configured model only — never an unrelated Claude catalog.
+        "listing_model_ids": (
+            None
+            if ctx.provider_id == "anthropic"
+            else (ctx.static_model_ids or ((ctx.model,) if ctx.model else ()))
+        ),
+        "temperature_floor_model_ids": ctx.compat.temperature_floor_model_ids,
+        "temperature_floor": ctx.compat.temperature_floor,
     }
     if ctx.base_url:
         kwargs["base_url"] = ctx.base_url

--- a/tests/functional/test_llm_smoke.py
+++ b/tests/functional/test_llm_smoke.py
@@ -11,7 +11,9 @@ import uuid
 
 import pytest
 
+from opensquilla.provider.model_catalog import ModelCatalog
 from opensquilla.provider.openai import OpenAIProvider
+from opensquilla.provider.selector import ProviderConfig, _build_provider
 from opensquilla.provider.types import (
     ChatConfig,
     DoneEvent,
@@ -47,6 +49,54 @@ async def test_openrouter_live_smoke_returns_expected_token() -> None:
     ):
         if isinstance(event, ErrorEvent):
             pytest.fail(f"live LLM smoke failed: {event.code} {event.message}")
+        if isinstance(event, TextDeltaEvent):
+            text_parts.append(event.text)
+        if isinstance(event, DoneEvent):
+            done = True
+
+    assert done is True
+    assert _EXPECTED_TOKEN in "".join(text_parts).strip().lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provider_id",
+    ["qwen_token_plan", "qwen_token_plan_anthropic"],
+)
+async def test_qwen_token_plan_live_smoke_returns_expected_token(
+    provider_id: str,
+) -> None:
+    api_key = os.environ.get("QWEN_TOKEN_PLAN_API_KEY")
+    if not api_key:
+        pytest.skip("QWEN_TOKEN_PLAN_API_KEY not set")
+
+    model = os.environ.get("QWEN_TOKEN_PLAN_MODEL", "qwen3.7-plus")
+    provider = _build_provider(
+        ProviderConfig(
+            provider=provider_id,
+            model=model,
+            api_key=api_key,
+        )
+    )
+    caps = ModelCatalog().get_capabilities(
+        model,
+        provider_name=provider_id,
+    )
+    text_parts: list[str] = []
+    done = False
+
+    async for event in provider.chat(
+        [Message(role="user", content=f"Reply with exactly {_EXPECTED_TOKEN}.")],
+        config=ChatConfig(
+            max_tokens=128,
+            temperature=0.0,
+            thinking=False,
+            model_capabilities=caps,
+            timeout=90.0,
+        ),
+    ):
+        if isinstance(event, ErrorEvent):
+            pytest.fail(f"live Token Plan smoke failed: {event.code} {event.message}")
         if isinstance(event, TextDeltaEvent):
             text_parts.append(event.text)
         if isinstance(event, DoneEvent):

--- a/tests/test_contracts/test_onboarding_catalog.py
+++ b/tests/test_contracts/test_onboarding_catalog.py
@@ -119,7 +119,7 @@ FROZEN_ROUTER_PROFILE_IDS = frozenset(
 # Curated presets that are NOT persistable tier_profile ids: packaged tier
 # data applied as inline tiers (synthesized=False on the wire, but the id
 # stays outside FROZEN_ROUTER_PROFILE_IDS).
-FROZEN_CURATED_INLINE_PRESET_IDS = frozenset({"tokenrhythm"})
+FROZEN_CURATED_INLINE_PRESET_IDS = frozenset({"qwen_token_plan", "tokenrhythm"})
 
 
 async def test_onboarding_catalog_top_level_sections_are_frozen() -> None:

--- a/tests/test_onboarding/test_image_generation_specs.py
+++ b/tests/test_onboarding/test_image_generation_specs.py
@@ -10,10 +10,22 @@ from opensquilla.onboarding.image_generation_specs import (
 def test_image_generation_payload_exposes_optional_capability_metadata():
     payload = image_generation_provider_catalog_payload()
 
-    assert {row["providerId"] for row in payload} == {"openai", "openrouter"}
+    assert {row["providerId"] for row in payload} == {
+        "openai",
+        "openrouter",
+        "qwen_token_plan",
+    }
     for row in payload:
         assert row["blocking"] is False
         assert row["canProbe"] is False
         assert row["deployment"] == "cloud"
         assert row["whatYouNeed"]
         assert row["readmeScenarios"]
+
+    qwen = next(row for row in payload if row["providerId"] == "qwen_token_plan")
+    assert qwen["envKey"] == "QWEN_TOKEN_PLAN_API_KEY"
+    assert qwen["defaultModel"] == "qwen_token_plan/wan2.7-image"
+    assert qwen["suggestedModels"] == [
+        "qwen_token_plan/wan2.7-image",
+        "qwen_token_plan/wan2.7-image-pro",
+    ]

--- a/tests/test_onboarding/test_models_discover.py
+++ b/tests/test_onboarding/test_models_discover.py
@@ -95,7 +95,14 @@ def test_selectable_discovery_fails_closed_before_credentials_or_provider_build(
     assert result == ProviderModelsDiscoverResult(ok=True, provider_id="openai")
 
 
-@pytest.mark.parametrize("provider_id", ["openrouter", "tokenrhythm"])
+@pytest.mark.parametrize(
+    "provider_id",
+    [
+        "openrouter",
+        "tokenrhythm",
+        "qwen_token_plan",
+    ],
+)
 def test_selectable_discovery_delegates_verified_official_hosts(
     monkeypatch: Any, provider_id: str
 ) -> None:
@@ -127,11 +134,82 @@ def test_selectable_discovery_delegates_verified_official_hosts(
     ]
 
 
+def test_token_plan_anthropic_discovers_account_entitlements_through_openai_profile(
+    monkeypatch: Any,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_raw(**kwargs: Any) -> ProviderModelsDiscoverResult:
+        calls.append(kwargs)
+        return ProviderModelsDiscoverResult(
+            ok=True,
+            provider_id=kwargs["provider_id"],
+            source="live",
+            models=[{"id": "qwen3.7-plus"}],
+        )
+
+    monkeypatch.setattr(probe_module, "discover_provider_models", _fake_raw)
+
+    result = _discover_selectable(
+        provider_id="qwen_token_plan_anthropic",
+        api_key="synthetic-key",
+    )
+
+    assert result == ProviderModelsDiscoverResult(
+        ok=True,
+        provider_id="qwen_token_plan_anthropic",
+        source="live",
+        models=[{"id": "qwen3.7-plus"}],
+    )
+    assert calls == [
+        {
+            "provider_id": "qwen_token_plan",
+            "api_key": "synthetic-key",
+            "api_key_env": "",
+            "base_url": "",
+            "proxy": "",
+        }
+    ]
+
+
+def test_token_plan_anthropic_discovery_never_reuses_its_messages_path(
+    monkeypatch: Any,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_raw(**kwargs: Any) -> ProviderModelsDiscoverResult:
+        calls.append(kwargs)
+        return ProviderModelsDiscoverResult(
+            ok=True,
+            provider_id=kwargs["provider_id"],
+        )
+
+    monkeypatch.setattr(probe_module, "discover_provider_models", _fake_raw)
+
+    result = _discover_selectable(
+        provider_id="qwen_token_plan_anthropic",
+        api_key="synthetic-key",
+        base_url="https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+    )
+
+    assert result.provider_id == "qwen_token_plan_anthropic"
+    assert calls[0]["provider_id"] == "qwen_token_plan"
+    assert calls[0]["base_url"] == ""
+
+
 @pytest.mark.parametrize(
     ("provider_id", "base_url"),
     [
         ("openrouter", "https://openrouter.ai.attacker.example/v1"),
         ("tokenrhythm", "https://tokenrhythm.studio.attacker.example/v1"),
+        (
+            "qwen_token_plan",
+            "https://token-plan.cn-beijing.maas.aliyuncs.com.attacker.example/v1",
+        ),
+        (
+            "qwen_token_plan_anthropic",
+            "https://token-plan.cn-beijing.maas.aliyuncs.com.attacker.example/v1",
+        ),
     ],
 )
 def test_selectable_discovery_rejects_non_official_base_url_before_raw_discovery(
@@ -156,6 +234,14 @@ def test_selectable_discovery_rejects_non_official_base_url_before_raw_discovery
     [
         ("openrouter", "http://openrouter.ai/api/v1"),
         ("tokenrhythm", "http://tokenrhythm.studio/v1"),
+        (
+            "qwen_token_plan",
+            "http://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        ),
+        (
+            "qwen_token_plan_anthropic",
+            "http://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+        ),
     ],
 )
 def test_selectable_discovery_rejects_plain_http_before_credentials_or_raw_discovery(
@@ -187,14 +273,27 @@ def test_selectable_discovery_still_validates_unknown_provider() -> None:
 
 
 @pytest.mark.parametrize(
-    ("provider_id", "base_url"),
+    ("provider_id", "base_url", "discovery_base_url"),
     [
-        ("openrouter", "https://api.openrouter.ai/v1"),
-        ("tokenrhythm", "https://api.tokenrhythm.studio/v1"),
+        ("openrouter", "https://api.openrouter.ai/v1", "https://api.openrouter.ai/v1"),
+        ("tokenrhythm", "https://api.tokenrhythm.studio/v1", "https://api.tokenrhythm.studio/v1"),
+        (
+            "qwen_token_plan",
+            "https://api.token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+            "https://api.token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        ),
+        (
+            "qwen_token_plan_anthropic",
+            "https://api.token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+            "",
+        ),
     ],
 )
 def test_selectable_discovery_accepts_official_subdomains(
-    monkeypatch: Any, provider_id: str, base_url: str
+    monkeypatch: Any,
+    provider_id: str,
+    base_url: str,
+    discovery_base_url: str,
 ) -> None:
     calls: list[str] = []
 
@@ -207,7 +306,7 @@ def test_selectable_discovery_accepts_official_subdomains(
     result = _discover_selectable(provider_id=provider_id, base_url=base_url)
 
     assert result.ok is True
-    assert calls == [base_url]
+    assert calls == [discovery_base_url]
 
 
 def test_discover_reports_missing_key_without_network(monkeypatch: Any) -> None:

--- a/tests/test_onboarding/test_provider_specs.py
+++ b/tests/test_onboarding/test_provider_specs.py
@@ -60,7 +60,8 @@ from opensquilla.onboarding.provider_specs import (  # noqa: E402
 # Verified: the full agent stack has been exercised against these providers.
 EXPECTED_VERIFIED = {
     "openrouter", "openai", "openai_responses", "anthropic", "ollama", "deepseek",
-    "gemini", "dashscope", "moonshot", "zhipu", "qianfan",
+    "gemini", "dashscope", "qwen_token_plan", "qwen_token_plan_anthropic",
+    "moonshot", "zhipu", "qianfan",
     "volcengine", "byteplus", "tokenrhythm",
 }
 # Experimental: registry-runnable, offered with a visible caveat.
@@ -69,6 +70,7 @@ EXPECTED_EXPERIMENTAL = {
     "kimi_coding_anthropic", "minimax", "minimax_openai", "minimax_coding_openai",
     "minimax_coding_anthropic", "minimax_cn", "minimax_global", "mimo_openai",
     "mimo_anthropic", "mistral", "groq", "aihubmix", "vllm", "custom",
+    "custom_anthropic",
     "lm_studio", "siliconflow", "ovms", "litellm_proxy", "openai_codex",
     "volcengine_coding_plan", "volcengine_coding_plan_anthropic",
     "byteplus_coding_plan", "byteplus_coding_plan_anthropic",
@@ -293,6 +295,66 @@ def test_custom_provider_catalog_payload_semantics():
     fields = {f["name"]: f for f in row["fields"]}
     assert fields["base_url"]["required"] is True
     assert fields["api_key"]["required"] is False
+
+
+def test_custom_anthropic_provider_is_a_first_class_messages_endpoint():
+    spec = get_provider_setup_spec("custom_anthropic")
+
+    assert spec.runtime_supported is True
+    assert spec.backend == "anthropic"
+    assert spec.provider_kind == "anthropic"
+    assert spec.deployment == "custom"
+    assert spec.label.startswith("Custom Anthropic-compatible endpoint")
+    assert spec.requires_base_url is True
+    assert spec.default_base_url == ""
+    assert spec.accepts_api_key is True
+    assert spec.requires_api_key is False
+    assert spec.env_key == "CUSTOM_ANTHROPIC_API_KEY"
+
+    fields = {field.name: field for field in spec.fields}
+    assert fields["model"].required is True
+    assert fields["base_url"].required is True
+    assert fields["api_key"].required is False
+
+
+@pytest.mark.parametrize(
+    ("provider_id", "backend", "base_url"),
+    [
+        (
+            "qwen_token_plan",
+            "openai_compat",
+            "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        ),
+        (
+            "qwen_token_plan_anthropic",
+            "anthropic",
+            "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+        ),
+    ],
+)
+def test_qwen_token_plan_setup_contract(
+    provider_id: str,
+    backend: str,
+    base_url: str,
+) -> None:
+    spec = get_provider_setup_spec(provider_id)
+
+    assert spec.runtime_supported is True
+    assert spec.verification == "verified"
+    assert spec.backend == backend
+    assert spec.env_key == "QWEN_TOKEN_PLAN_API_KEY"
+    assert spec.default_base_url == base_url
+    assert spec.requires_api_key is True
+    assert spec.requires_base_url is False
+    assert spec.default_direct_model == "qwen3.8-max-preview"
+    assert any("sk-sp-" in item for item in spec.what_you_need)
+
+    fields = {field.name: field for field in spec.fields}
+    assert fields["model"].default == "qwen3.8-max-preview"
+    assert fields["api_key"].required is True
+    assert "not interchangeable" in fields["api_key"].description
+    assert fields["api_key_env"].default == "QWEN_TOKEN_PLAN_API_KEY"
+    assert fields["base_url"].default == base_url
 
 
 def test_oauth_provider_does_not_accept_an_api_key():

--- a/tests/test_packaging/test_router_presets_packaged.py
+++ b/tests/test_packaging/test_router_presets_packaged.py
@@ -28,7 +28,7 @@ LEGACY_PRESET_IDS = (
 )
 # Curated-inline presets also ship packaged TOML, but never persist as a
 # tier_profile id (applied as inline tiers instead).
-CURATED_INLINE_PRESET_IDS = ("tokenrhythm",)
+CURATED_INLINE_PRESET_IDS = ("qwen_token_plan", "tokenrhythm")
 PACKAGED_PRESET_IDS = LEGACY_PRESET_IDS + CURATED_INLINE_PRESET_IDS
 
 

--- a/tests/test_provider/golden/_harness.py
+++ b/tests/test_provider/golden/_harness.py
@@ -76,6 +76,10 @@ COMPAT_THINKING_MODELS: dict[str, tuple[str, str]] = {
     # qwen3 prefix ladder (model_catalog dashscope branch) -> "dashscope".
     "dashscope": ("qwen3-coder-plus", "dashscope"),
     "bailian_coding": (_NEUTRAL_MODEL, "none"),
+    # Qwen 3.8 is forced-thinking on Token Plan. The plain/tools/thinking
+    # matrix freezes enable_thinking, preserve_thinking, temperature floor,
+    # and the plan-specific reasoning dialect.
+    "qwen_token_plan": ("qwen3.8-max-preview", "qwen_token_plan_qwen"),
     # kimi-k2.7 ladder (model_catalog moonshot branch) -> "moonshot"; also in
     # fixed_sampling_model_prefixes so the non-default temperature is dropped.
     "moonshot": ("kimi-k2.7-code", "moonshot"),
@@ -266,6 +270,15 @@ def build_cases() -> list[GoldenCase]:
                 slug="tencent_token_plan_anthropic__plain",
                 provider_id="tencent_token_plan_anthropic",
                 model="hy3",
+            ),
+            # Qwen Token Plan's Anthropic-compatible service uses bearer auth,
+            # appends /v1/messages to /apps/anthropic, and applies the Qwen
+            # 3.8 temperature floor.
+            GoldenCase(
+                backend="anthropic",
+                slug="qwen_token_plan_anthropic__plain",
+                provider_id="qwen_token_plan_anthropic",
+                model="qwen3.8-max-preview",
             ),
         ]
     )

--- a/tests/test_provider/golden/requests/anthropic/qwen_token_plan_anthropic__plain.json
+++ b/tests/test_provider/golden/requests/anthropic/qwen_token_plan_anthropic__plain.json
@@ -1,0 +1,35 @@
+{
+  "auth_style": "bearer",
+  "body": {
+    "max_tokens": 16384,
+    "messages": [
+      {
+        "content": "What is the capital of Australia?",
+        "role": "user"
+      },
+      {
+        "content": "Canberra.",
+        "role": "assistant"
+      },
+      {
+        "content": "Repeat the answer as a single word.",
+        "role": "user"
+      },
+      {
+        "content": "Canberra",
+        "role": "assistant"
+      },
+      {
+        "content": "Now write it in uppercase.",
+        "role": "user"
+      }
+    ],
+    "model": "qwen3.8-max-preview",
+    "stream": true,
+    "system": "You are a synthetic assistant used to freeze provider request payloads.",
+    "temperature": 0.7
+  },
+  "content_type": "application/json",
+  "method": "POST",
+  "url": "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic/v1/messages"
+}

--- a/tests/test_provider/golden/requests/openai_compat/qwen_token_plan__plain.json
+++ b/tests/test_provider/golden/requests/openai_compat/qwen_token_plan__plain.json
@@ -1,0 +1,44 @@
+{
+  "auth_style": "bearer",
+  "body": {
+    "enable_thinking": true,
+    "max_tokens": 16384,
+    "messages": [
+      {
+        "content": "You are a synthetic assistant used to freeze provider request payloads.",
+        "role": "system"
+      },
+      {
+        "content": "What is the capital of Australia?",
+        "role": "user"
+      },
+      {
+        "content": "Canberra.",
+        "reasoning_content": "The capital is Canberra, not Sydney.",
+        "role": "assistant"
+      },
+      {
+        "content": "Repeat the answer as a single word.",
+        "role": "user"
+      },
+      {
+        "content": "Canberra",
+        "role": "assistant"
+      },
+      {
+        "content": "Now write it in uppercase.",
+        "role": "user"
+      }
+    ],
+    "model": "qwen3.8-max-preview",
+    "preserve_thinking": true,
+    "stream": true,
+    "stream_options": {
+      "include_usage": true
+    },
+    "temperature": 0.7
+  },
+  "content_type": "application/json",
+  "method": "POST",
+  "url": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/chat/completions"
+}

--- a/tests/test_provider/golden/requests/openai_compat/qwen_token_plan__thinking.json
+++ b/tests/test_provider/golden/requests/openai_compat/qwen_token_plan__thinking.json
@@ -1,0 +1,45 @@
+{
+  "auth_style": "bearer",
+  "body": {
+    "enable_thinking": true,
+    "max_tokens": 16384,
+    "messages": [
+      {
+        "content": "You are a synthetic assistant used to freeze provider request payloads.",
+        "role": "system"
+      },
+      {
+        "content": "What is the capital of Australia?",
+        "role": "user"
+      },
+      {
+        "content": "Canberra.",
+        "reasoning_content": "The capital is Canberra, not Sydney.",
+        "role": "assistant"
+      },
+      {
+        "content": "Repeat the answer as a single word.",
+        "role": "user"
+      },
+      {
+        "content": "Canberra",
+        "role": "assistant"
+      },
+      {
+        "content": "Now write it in uppercase.",
+        "role": "user"
+      }
+    ],
+    "model": "qwen3.8-max-preview",
+    "preserve_thinking": true,
+    "stream": true,
+    "stream_options": {
+      "include_usage": true
+    },
+    "temperature": 0.7,
+    "thinking_budget": 5000
+  },
+  "content_type": "application/json",
+  "method": "POST",
+  "url": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/chat/completions"
+}

--- a/tests/test_provider/golden/requests/openai_compat/qwen_token_plan__tools.json
+++ b/tests/test_provider/golden/requests/openai_compat/qwen_token_plan__tools.json
@@ -1,0 +1,95 @@
+{
+  "auth_style": "bearer",
+  "body": {
+    "enable_thinking": true,
+    "max_tokens": 16384,
+    "messages": [
+      {
+        "content": "You are a synthetic assistant used to freeze provider request payloads.",
+        "role": "system"
+      },
+      {
+        "content": "List the files in the workspace root.",
+        "role": "user"
+      },
+      {
+        "content": "I will list the files.",
+        "role": "assistant",
+        "tool_calls": [
+          {
+            "function": {
+              "arguments": "{\"path\": \".\", \"max_entries\": 3}",
+              "name": "list_files"
+            },
+            "id": "call_001",
+            "type": "function"
+          }
+        ]
+      },
+      {
+        "content": "README.md\nsrc\ntests",
+        "role": "tool",
+        "tool_call_id": "call_001"
+      }
+    ],
+    "model": "qwen3.8-max-preview",
+    "preserve_thinking": true,
+    "stream": true,
+    "stream_options": {
+      "include_usage": true
+    },
+    "temperature": 0.7,
+    "tools": [
+      {
+        "function": {
+          "description": "List files under a workspace-relative path.",
+          "name": "list_files",
+          "parameters": {
+            "properties": {
+              "filters": {
+                "default": [],
+                "items": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "maxItems": 5,
+                "minItems": 1,
+                "type": "array"
+              },
+              "max_entries": {
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "options": {
+                "additionalProperties": false,
+                "properties": {
+                  "include_hidden": {
+                    "default": false,
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              },
+              "path": {
+                "default": ".",
+                "description": "Workspace-relative directory to list.",
+                "maxLength": 200,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "type": "object"
+          }
+        },
+        "type": "function"
+      }
+    ]
+  },
+  "content_type": "application/json",
+  "method": "POST",
+  "url": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/chat/completions"
+}

--- a/tests/test_provider/test_capability_ladder_parity.py
+++ b/tests/test_provider/test_capability_ladder_parity.py
@@ -203,6 +203,24 @@ _EXPECTED_CAPS: dict[tuple[str, str, str], tuple[bool, bool, bool, str]] = {
     ("custom", "gemini-3-pro-preview", ""): (False, True, True, "none"),
     ("custom", "o3-mini", ""): (False, True, False, "none"),
     ("custom", "gpt-5.5", ""): (False, True, True, "none"),
+    ("custom_anthropic", "totally-unknown-model-x1", ""): (
+        False,
+        True,
+        False,
+        "none",
+    ),
+    ("qwen_token_plan", "qwen3.8-max-preview", ""): (
+        True,
+        True,
+        True,
+        "qwen_token_plan_qwen",
+    ),
+    ("qwen_token_plan_anthropic", "qwen3.8-max-preview", ""): (
+        True,
+        True,
+        True,
+        "qwen_token_plan_qwen",
+    ),
     ("dashscope", "totally-unknown-model-x1", ""): (False, True, False, "none"),
     ("dashscope", "gpt-4o", ""): (False, True, False, "none"),
     ("dashscope", "deepseek-r1", ""): (False, True, False, "none"),
@@ -846,6 +864,7 @@ _EXPECTED_REQUIRES_API_KEY: dict[str, bool] = {
     "byteplus_coding_plan": True,
     "byteplus_coding_plan_anthropic": True,
     "custom": False,
+    "custom_anthropic": False,
     "dashscope": True,
     "deepseek": True,
     "gemini": True,
@@ -872,6 +891,8 @@ _EXPECTED_REQUIRES_API_KEY: dict[str, bool] = {
     "openrouter": True,
     "ovms": False,
     "qianfan": True,
+    "qwen_token_plan": True,
+    "qwen_token_plan_anthropic": True,
     "siliconflow": True,
     "tencent_token_plan": True,
     "tencent_token_plan_anthropic": True,
@@ -899,6 +920,7 @@ _EXPECTED_UNKNOWN_CONTEXT_WINDOW: dict[str, int] = {
     "byteplus_coding_plan": 200000,
     "byteplus_coding_plan_anthropic": 200000,
     "custom": 8192,
+    "custom_anthropic": 8192,
     "dashscope": 200000,
     "deepseek": 200000,
     "gemini": 200000,
@@ -925,6 +947,8 @@ _EXPECTED_UNKNOWN_CONTEXT_WINDOW: dict[str, int] = {
     "openrouter": 200000,
     "ovms": 8192,
     "qianfan": 200000,
+    "qwen_token_plan": 200000,
+    "qwen_token_plan_anthropic": 200000,
     "siliconflow": 200000,
     "tencent_token_plan": 200000,
     "tencent_token_plan_anthropic": 200000,
@@ -977,17 +1001,21 @@ def test_unknown_model_context_window_parity_every_provider() -> None:
 
 
 def test_named_provider_sets_stay_distinct() -> None:
-    # Unifying membership would flip requires_api_key("vllm") — these MUST
-    # stay two distinct sets with an explicit superset derivation.
-    assert KEYLESS_PROVIDERS == frozenset({"ollama", "lm_studio", "ovms", "custom"})
+    assert KEYLESS_PROVIDERS == frozenset(
+        {"ollama", "lm_studio", "ovms", "custom", "custom_anthropic"}
+    )
     assert LOCAL_RUNTIME_PROVIDERS == KEYLESS_PROVIDERS | {"vllm", "local"}
     # vllm/local are local runtimes for the context heuristic but NOT keyless.
     assert "vllm" in LOCAL_RUNTIME_PROVIDERS
     assert "vllm" not in KEYLESS_PROVIDERS
     assert get_provider_spec("vllm").requires_api_key() is False  # no env_key, not keyless
-    # A vLLM-style deployment CAN carry auth; keyless status is not implied by
-    # being a local runtime. The custom endpoint is keyless AND local.
+    # Generic custom endpoints keep the established conservative local-window
+    # heuristic even when the configured URL is remote.
     assert "custom" in KEYLESS_PROVIDERS and "custom" in LOCAL_RUNTIME_PROVIDERS
+    assert (
+        "custom_anthropic" in KEYLESS_PROVIDERS
+        and "custom_anthropic" in LOCAL_RUNTIME_PROVIDERS
+    )
 
 
 def test_local_runtime_window_matches_membership() -> None:

--- a/tests/test_provider/test_catalog_layers.py
+++ b/tests/test_provider/test_catalog_layers.py
@@ -269,6 +269,7 @@ def test_packaged_corrections_file_parses_with_expected_tables() -> None:
         "qianfan",
         "tencent_tokenhub",
         "tencent_token_plan",
+        "qwen_token_plan",
         "tokenrhythm",
         "kimi_coding_openai",
         "kimi_coding_anthropic",

--- a/tests/test_provider/test_spec_substrate.py
+++ b/tests/test_provider/test_spec_substrate.py
@@ -20,9 +20,10 @@ _CATALOG_SOURCE_WAIVERS: frozenset[str] = frozenset(
         "lm_studio",
         "ovms",
         "vllm",
-        # Generic self-hosted OpenAI-compatible endpoint id: the model set is
-        # whatever the operator serves; no models.dev source exists.
+        # Generic custom endpoint ids: the model set is whatever the operator
+        # serves; no models.dev source exists.
         "custom",
+        "custom_anthropic",
         # Deployment-defined aggregation proxy: the model set is whatever
         # the operator's LiteLLM instance routes; no stable public catalog.
         "litellm_proxy",
@@ -40,6 +41,11 @@ _CATALOG_SOURCE_WAIVERS: frozenset[str] = frozenset(
         # (deepseek, zhipuai, ...) here would vendor entire foreign tables
         # with the origin providers' prices under this id.
         "tokenrhythm",
+        # Qwen Token Plan's exact subscription allowlist and service-specific
+        # limits ship in catalog_overrides.toml. Importing the general
+        # Alibaba catalog would expose models outside the subscription.
+        "qwen_token_plan",
+        "qwen_token_plan_anthropic",
         # OAuth-only ChatGPT-backend provider: models are fixed by the
         # Codex subscription, not a public catalog.
         "openai_codex",
@@ -121,16 +127,34 @@ def test_catalog_sources_match_the_migrated_script_mapping() -> None:
 
 
 def test_selectable_model_catalog_is_enabled_only_for_verified_providers() -> None:
-    """A picker must never turn an unverified/static adapter list into truth."""
+    """A picker must never turn an unverified adapter list into truth."""
     trusted = {
         spec.provider_id
         for spec in list_provider_specs()
         if spec.selectable_model_catalog == "verified_live"
     }
-    assert trusted == {"openrouter", "tokenrhythm"}
+    assert trusted == {
+        "openrouter",
+        "qwen_token_plan",
+        "qwen_token_plan_anthropic",
+        "tokenrhythm",
+    }
 
     assert get_provider_spec("openrouter").compat.official_host == "openrouter.ai"
     assert get_provider_spec("tokenrhythm").compat.official_host == "tokenrhythm.studio"
+    assert (
+        get_provider_spec("qwen_token_plan").compat.official_host
+        == "token-plan.cn-beijing.maas.aliyuncs.com"
+    )
+    token_plan_anthropic = get_provider_spec("qwen_token_plan_anthropic")
+    assert (
+        token_plan_anthropic.compat.official_host
+        == "token-plan.cn-beijing.maas.aliyuncs.com"
+    )
+    assert (
+        token_plan_anthropic.selectable_model_discovery_provider_id
+        == "qwen_token_plan"
+    )
 
 
 def test_anthropic_backend_auth_header_styles() -> None:

--- a/tests/test_provider_image_generation.py
+++ b/tests/test_provider_image_generation.py
@@ -12,7 +12,12 @@ from opensquilla.provider.image_generation import (
     ImageGenerationRequest,
     ImageGenerationResult,
     OpenRouterImageGenerationProvider,
+    QwenTokenPlanImageGenerationProvider,
     get_image_generation_provider,
+)
+from opensquilla.provider.qwen_token_plan import (
+    QWEN_TOKEN_PLAN_IMAGE_BASE_URL,
+    QWEN_TOKEN_PLAN_OPENAI_BASE_URL,
 )
 
 
@@ -101,6 +106,189 @@ async def test_openrouter_image_provider_adds_app_attribution_headers(monkeypatc
         "X-Title": "OpenSquilla",
     }
     assert result.image_bytes == b"opensquilla"
+
+
+@pytest.mark.asyncio
+async def test_qwen_token_plan_image_provider_uses_native_contract(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    image_url = "https://generated.example.test/result.png?signature=secret"
+
+    class FakeResponse:
+        text = ""
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {
+                "output": {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": [{"type": "image", "image": image_url}]
+                            }
+                        }
+                    ]
+                },
+                "usage": {
+                    "input_tokens": 12,
+                    "output_tokens": 2,
+                    "total_tokens": 14,
+                    "image_count": 1,
+                },
+            }
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url, *, headers, json):
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["json"] = json
+            return FakeResponse()
+
+    async def fake_download(url: str, *, timeout_seconds: float):
+        captured["download_url"] = url
+        captured["download_timeout"] = timeout_seconds
+        return "image/png", _test_png_bytes()
+
+    monkeypatch.setattr(
+        "opensquilla.provider.image_generation.httpx.AsyncClient",
+        lambda **kwargs: FakeClient(),
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.image_generation._download_qwen_token_plan_image",
+        fake_download,
+    )
+
+    provider = QwenTokenPlanImageGenerationProvider(api_key="synthetic-token-plan-key")
+    result = await provider.generate(
+        ImageGenerationRequest(
+            prompt="draw a friendly squid",
+            model="wan2.7-image-pro",
+            size="768x768",
+            timeout_seconds=12.0,
+        )
+    )
+
+    assert (
+        captured["url"]
+        == f"{QWEN_TOKEN_PLAN_IMAGE_BASE_URL}"
+        "/services/aigc/multimodal-generation/generation"
+    )
+    assert captured["headers"] == {
+        "Authorization": "Bearer synthetic-token-plan-key",
+        "Content-Type": "application/json",
+    }
+    assert captured["json"] == {
+        "model": "wan2.7-image-pro",
+        "input": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"text": "draw a friendly squid"}],
+                }
+            ]
+        },
+        "parameters": {
+            "size": "768*768",
+            "n": 1,
+            "thinking_mode": False,
+        },
+    }
+    assert captured["download_url"] == image_url
+    assert captured["download_timeout"] == 12.0
+    assert result.provider == "qwen_token_plan"
+    assert result.model == "wan2.7-image-pro"
+    assert result.image_bytes == _test_png_bytes()
+
+
+@pytest.mark.asyncio
+async def test_qwen_token_plan_generated_url_rejection_redacts_signature() -> None:
+    from opensquilla.provider.image_generation import (
+        _download_qwen_token_plan_image,
+    )
+
+    signed_url = "https://127.0.0.1/generated.png?signature=must-not-leak"
+    with pytest.raises(RuntimeError) as exc_info:
+        await _download_qwen_token_plan_image(
+            signed_url,
+            timeout_seconds=1.0,
+        )
+
+    message = str(exc_info.value)
+    assert message == "Failed to securely download the generated Token Plan image"
+    assert "must-not-leak" not in message
+    assert exc_info.value.__cause__ is None
+
+
+@pytest.mark.asyncio
+async def test_qwen_token_plan_generated_image_download_is_bounded(monkeypatch) -> None:
+    from opensquilla.provider import image_generation
+    from opensquilla.tools import ssrf
+
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        status_code = 200
+        headers = {
+            "content-type": "image/png",
+            "content-length": str(20 * 1024 * 1024 + 1),
+        }
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def raise_for_status(self) -> None:
+            return None
+
+        async def aiter_bytes(self):
+            yield _test_png_bytes()
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def stream(self, method, url):
+            captured["method"] = method
+            captured["url"] = url
+            return FakeResponse()
+
+    monkeypatch.setattr(
+        ssrf,
+        "validate_http_url_for_fetch",
+        lambda _url: ["203.0.113.10"],
+    )
+    monkeypatch.setattr(ssrf, "pinned_transport", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        image_generation.httpx,
+        "AsyncClient",
+        lambda **_kwargs: FakeClient(),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Failed to securely download",
+    ):
+        await image_generation._download_qwen_token_plan_image(
+            "https://generated.example.test/result.png?signature=redacted",
+            timeout_seconds=1.0,
+        )
+
+    assert captured == {
+        "method": "GET",
+        "url": "https://generated.example.test/result.png?signature=redacted",
+    }
 
 
 @pytest.mark.asyncio
@@ -902,6 +1090,31 @@ def test_image_generation_llm_key_reused_on_same_endpoint_origin(monkeypatch) ->
     provider = get_image_generation_provider("openai")
     assert provider is not None
     assert provider._resolve_api_key() == "sk-real"
+
+
+def test_qwen_token_plan_image_provider_reuses_key_but_not_chat_path(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("QWEN_TOKEN_PLAN_API_KEY", raising=False)
+
+    from opensquilla.gateway.config import ImageGenerationConfig, LlmProviderConfig
+    from opensquilla.tools.builtin.media import configure_image_generation
+
+    llm_config = LlmProviderConfig(
+        provider="qwen_token_plan",
+        model="qwen3.7-plus",
+        api_key="synthetic-token-plan-key",
+        base_url=QWEN_TOKEN_PLAN_OPENAI_BASE_URL,
+    )
+
+    configure_image_generation(ImageGenerationConfig(enabled=True), llm_config=llm_config)
+    try:
+        provider = get_image_generation_provider("qwen_token_plan")
+        assert provider is not None
+        assert provider._base_url == QWEN_TOKEN_PLAN_IMAGE_BASE_URL
+        assert provider._resolve_api_key() == "synthetic-token-plan-key"
+    finally:
+        configure_image_generation(None)
 
 
 def test_vision_provider_uses_configured_router_image_tier(monkeypatch) -> None:

--- a/tests/test_provider_mainstream_profiles.py
+++ b/tests/test_provider_mainstream_profiles.py
@@ -17,6 +17,7 @@ from opensquilla.provider.selector import ProviderBuildError, ProviderConfig, _b
         ("dashscope", "dashscope"),
         ("bailian_coding", "bailian_coding"),
         ("bailian_coding_cn", "bailian_coding"),
+        ("qwen_token_plan", "qwen_token_plan"),
         ("moonshot", "moonshot"),
         ("kimi_coding_openai", "moonshot"),
         ("minimax_coding_openai", "minimax"),
@@ -63,6 +64,11 @@ def test_new_openai_compatible_profiles_have_vendor_provider_kind(
             "bailian_coding_cn",
             "BAILIAN_API_KEY",
             "https://coding.dashscope.aliyuncs.com/v1",
+        ),
+        (
+            "qwen_token_plan",
+            "QWEN_TOKEN_PLAN_API_KEY",
+            "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
         ),
         ("moonshot", "MOONSHOT_API_KEY", "https://api.moonshot.ai/v1"),
         (
@@ -178,6 +184,61 @@ def test_model_selector_builds_tencent_token_plan_providers() -> None:
         ProviderConfig(provider="tencent_token_plan_anthropic", model="hy3", api_key="test-key")
     )
     assert isinstance(messages, AnthropicProvider)
+
+
+def test_qwen_token_plan_profiles_pin_documented_endpoints() -> None:
+    plan = get_provider_spec("qwen_token_plan")
+    assert plan.backend == "openai_compat"
+    assert plan.provider_kind == "qwen_token_plan"
+    assert plan.env_key == "QWEN_TOKEN_PLAN_API_KEY"
+    assert (
+        plan.default_base_url
+        == "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+    )
+    assert plan.capabilities == frozenset({"chat", "coding_plan"})
+
+    plan_anthropic = get_provider_spec("qwen_token_plan_anthropic")
+    assert plan_anthropic.backend == "anthropic"
+    assert plan_anthropic.provider_kind == "qwen_token_plan"
+    assert plan_anthropic.env_key == "QWEN_TOKEN_PLAN_API_KEY"
+    assert (
+        plan_anthropic.default_base_url
+        == "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic"
+    )
+    assert plan_anthropic.failure_family == "anthropic"
+    assert plan_anthropic.auth_header_style == "bearer"
+    assert plan_anthropic.capabilities == frozenset({"chat", "coding_plan"})
+    assert len(plan_anthropic.static_model_ids) == 15
+
+
+def test_model_selector_builds_qwen_token_plan_and_custom_anthropic() -> None:
+    chat = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan",
+            model="qwen3.8-max-preview",
+            api_key="test-key",
+        )
+    )
+    assert isinstance(chat, OpenAIProvider)
+
+    messages = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan_anthropic",
+            model="qwen3.8-max-preview",
+            api_key="test-key",
+        )
+    )
+    assert isinstance(messages, AnthropicProvider)
+
+    custom_messages = _build_provider(
+        ProviderConfig(
+            provider="custom_anthropic",
+            model="vendor-model",
+            api_key="optional",
+            base_url="https://llm.example.test/anthropic",
+        )
+    )
+    assert isinstance(custom_messages, AnthropicProvider)
 
 
 def test_model_selector_builds_tencent_tokenhub_anthropic_provider() -> None:

--- a/tests/test_provider_qwen_token_plan.py
+++ b/tests/test_provider_qwen_token_plan.py
@@ -1,0 +1,724 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+
+from opensquilla.engine.types import ThinkingLevel
+from opensquilla.provider.anthropic import AnthropicProvider
+from opensquilla.provider.model_catalog import ModelCatalog
+from opensquilla.provider.openai import OpenAIProvider
+from opensquilla.provider.preset_registry import get_preset
+from opensquilla.provider.qwen_token_plan import (
+    QWEN_TOKEN_PLAN_ANTHROPIC_BASE_URL,
+    QWEN_TOKEN_PLAN_IMAGE_MODEL_IDS,
+    QWEN_TOKEN_PLAN_MODEL_IDS,
+    QWEN_TOKEN_PLAN_OPENAI_BASE_URL,
+)
+from opensquilla.provider.registry import get_provider_spec
+from opensquilla.provider.selector import ProviderConfig, _build_provider
+from opensquilla.provider.types import (
+    ChatConfig,
+    ContentBlockToolUse,
+    Message,
+    StreamEvent,
+    ToolDefinition,
+    ToolInputSchema,
+)
+
+_TOOL = ToolDefinition(
+    name="read_file",
+    description="Read a synthetic file.",
+    input_schema=ToolInputSchema(
+        properties={"path": {"type": "string"}},
+        required=["path"],
+    ),
+)
+
+
+async def _consume(stream: AsyncIterator[StreamEvent]) -> None:
+    async for _event in stream:
+        pass
+
+
+def _patch_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    module: str,
+    captured: dict[str, Any],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = request.headers
+        captured["payload"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            400,
+            json={"error": {"message": "synthetic rejection after capture"}},
+            request=request,
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(
+        f"opensquilla.provider.{module}.httpx.AsyncClient",
+        patched_async_client,
+    )
+
+
+def _caps(model: str):
+    return ModelCatalog().get_capabilities(
+        model,
+        provider_name="qwen_token_plan",
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider_id", "base_url"),
+    [
+        ("qwen_token_plan", QWEN_TOKEN_PLAN_OPENAI_BASE_URL),
+        ("qwen_token_plan_anthropic", QWEN_TOKEN_PLAN_ANTHROPIC_BASE_URL),
+    ],
+)
+def test_token_plan_model_picker_trust_is_limited_to_the_official_host(
+    provider_id: str,
+    base_url: str,
+) -> None:
+    spec = get_provider_spec(provider_id)
+
+    assert spec.default_base_url == base_url
+    assert spec.selectable_model_catalog == "verified_live"
+    assert spec.compat.official_host == "token-plan.cn-beijing.maas.aliyuncs.com"
+
+
+@pytest.mark.asyncio
+async def test_openai_protocol_model_discovery_excludes_native_image_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    advertised_ids = (
+        "qwen3.8-max-preview",
+        "qwen3.7-max",
+        "qwen3.7-plus",
+        "qwen3.6-flash",
+        "glm-5.2",
+        "deepseek-v4-pro",
+        *QWEN_TOKEN_PLAN_IMAGE_MODEL_IDS,
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"data": [{"id": model_id} for model_id in advertised_ids]},
+            request=request,
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "opensquilla.provider.openai.httpx.AsyncClient",
+        patched_async_client,
+    )
+    provider = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan",
+            model="qwen3.7-plus",
+            api_key="sk-sp-test",
+        )
+    )
+
+    listed = await provider.list_models()
+
+    assert [item.model_id for item in listed] == list(advertised_ids[:-2])
+    assert not {item.model_id for item in listed} & set(QWEN_TOKEN_PLAN_IMAGE_MODEL_IDS)
+
+
+@pytest.mark.asyncio
+async def test_dashscope_deepseek_v4_normalizes_required_tool_choice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="openai", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="dashscope",
+            model="deepseek-v4-pro",
+            api_key="sk-ws-test",
+        )
+    )
+
+    await _consume(
+        provider.chat(
+            [Message(role="user", content="use the tool")],
+            tools=[_TOOL],
+            config=ChatConfig(
+                thinking=False,
+                tool_choice="required",
+                model_capabilities=ModelCatalog().get_capabilities(
+                    "deepseek-v4-pro",
+                    provider_name="dashscope",
+                ),
+            ),
+        )
+    )
+
+    payload = captured["payload"]
+    assert payload["tool_choice"] == "auto"
+    assert "enable_thinking" not in payload
+
+
+@pytest.mark.parametrize(
+    ("model", "context_window", "max_output", "vision", "reasoning_format"),
+    [
+        ("qwen3.8-max-preview", 983_616, 131_072, True, "qwen_token_plan_qwen"),
+        ("qwen3.7-max", 1_000_000, 65_536, False, "qwen_token_plan_qwen"),
+        ("qwen3.7-plus", 1_000_000, 65_536, True, "qwen_token_plan_qwen"),
+        ("qwen3.6-plus", 1_000_000, 65_536, True, "qwen_token_plan_qwen"),
+        ("qwen3.6-flash", 1_000_000, 65_536, True, "qwen_token_plan_qwen"),
+        (
+            "deepseek-v4-pro",
+            1_000_000,
+            393_216,
+            False,
+            "qwen_token_plan_deepseek",
+        ),
+        (
+            "deepseek-v4-flash",
+            1_000_000,
+            393_216,
+            False,
+            "qwen_token_plan_deepseek",
+        ),
+        ("deepseek-v3.2", 131_072, 65_536, False, "qwen_token_plan"),
+        ("kimi-k2.7-code", 262_144, 16_384, True, "qwen_token_plan_kimi"),
+        ("kimi-k2.6", 262_144, 98_304, True, "qwen_token_plan_kimi"),
+        ("kimi-k2.5", 262_144, 32_768, True, "qwen_token_plan_kimi"),
+        ("glm-5.2", 1_000_000, 131_072, False, "qwen_token_plan_glm"),
+        ("glm-5.1", 202_752, 131_072, False, "qwen_token_plan_glm"),
+        ("glm-5", 202_752, 16_384, False, "qwen_token_plan_glm"),
+        ("MiniMax-M2.5", 196_608, 32_768, False, "qwen_token_plan"),
+    ],
+)
+def test_token_plan_catalog_matches_documented_allowlist(
+    model: str,
+    context_window: int,
+    max_output: int,
+    vision: bool,
+    reasoning_format: str,
+) -> None:
+    catalog = ModelCatalog()
+    entry = catalog.resolve_entry(model, provider="qwen_token_plan")
+
+    assert entry.context_window == context_window
+    assert entry.max_output_tokens == max_output
+    assert entry.supports_reasoning is True
+    assert entry.supports_tools is True
+    assert entry.supports_vision is vision
+    assert entry.reasoning_format == reasoning_format
+
+
+def test_anthropic_protocol_reuses_exact_token_plan_catalog() -> None:
+    catalog = ModelCatalog()
+    openai_entry = catalog.resolve_entry(
+        "qwen3.8-max-preview",
+        provider="qwen_token_plan",
+    )
+    anthropic_entry = catalog.resolve_entry(
+        "qwen3.8-max-preview",
+        provider="qwen_token_plan_anthropic",
+    )
+
+    assert anthropic_entry.provider_id == "qwen_token_plan_anthropic"
+    assert anthropic_entry.model_id == openai_entry.model_id
+    assert anthropic_entry.context_window == openai_entry.context_window
+    assert anthropic_entry.max_output_tokens == openai_entry.max_output_tokens
+    assert anthropic_entry.supports_reasoning == openai_entry.supports_reasoning
+    assert anthropic_entry.supports_tools == openai_entry.supports_tools
+    assert anthropic_entry.supports_vision == openai_entry.supports_vision
+    assert anthropic_entry.reasoning_format == openai_entry.reasoning_format
+    assert catalog.resolve_context_window(
+        "qwen3.8-max-preview",
+        provider="qwen_token_plan_anthropic",
+    ) == 983_616
+
+
+@pytest.mark.asyncio
+async def test_qwen38_forces_thinking_and_normalizes_wire_constraints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="openai", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan",
+            model="qwen3.8-max-preview",
+            api_key="sk-sp-test",
+        )
+    )
+    assert isinstance(provider, OpenAIProvider)
+    messages = [
+        Message(
+            role="assistant",
+            content="prior answer",
+            reasoning_content="prior reasoning",
+        ),
+        Message(role="user", content="continue"),
+    ]
+
+    await _consume(
+        provider.chat(
+            messages,
+            tools=[_TOOL],
+            config=ChatConfig(
+                temperature=0.2,
+                tool_choice="required",
+                model_capabilities=_caps("qwen3.8-max-preview"),
+            ),
+        )
+    )
+
+    payload = captured["payload"]
+    assert captured["url"].endswith("/compatible-mode/v1/chat/completions")
+    assert captured["headers"]["authorization"] == "Bearer sk-sp-test"
+    assert payload["enable_thinking"] is True
+    assert payload["temperature"] == 0.6
+    assert payload["tool_choice"] == "auto"
+    assert payload["preserve_thinking"] is True
+    assert payload["messages"][0]["reasoning_content"] == "prior reasoning"
+    assert "thinking_budget" not in payload
+    assert "thinking" not in payload
+
+
+@pytest.mark.asyncio
+async def test_qwen_explicit_thinking_budget_is_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="openai", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan",
+            model="qwen3.7-plus",
+            api_key="sk-sp-test",
+        )
+    )
+
+    await _consume(
+        provider.chat(
+            [Message(role="user", content="think")],
+            config=ChatConfig(
+                thinking=True,
+                thinking_budget_tokens=7_000,
+                model_capabilities=_caps("qwen3.7-plus"),
+            ),
+        )
+    )
+
+    assert captured["payload"]["enable_thinking"] is True
+    assert captured["payload"]["thinking_budget"] == 7_000
+    assert captured["payload"]["preserve_thinking"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("level", "expected_effort"),
+    [
+        (ThinkingLevel.MINIMAL, "low"),
+        (ThinkingLevel.LOW, "low"),
+        (ThinkingLevel.MEDIUM, "medium"),
+        (ThinkingLevel.HIGH, "medium"),
+        (ThinkingLevel.XHIGH, "xhigh"),
+    ],
+)
+async def test_qwen38_maps_reasoning_effort_to_documented_values(
+    monkeypatch: pytest.MonkeyPatch,
+    level: ThinkingLevel,
+    expected_effort: str,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="openai", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan",
+            model="qwen3.8-max-preview",
+            api_key="sk-sp-test",
+        )
+    )
+
+    await _consume(
+        provider.chat(
+            [Message(role="user", content="think")],
+            config=ChatConfig(
+                thinking=True,
+                thinking_level=level,
+                model_capabilities=_caps("qwen3.8-max-preview"),
+            ),
+        )
+    )
+
+    payload = captured["payload"]
+    assert payload["enable_thinking"] is True
+    assert payload["reasoning_effort"] == expected_effort
+    assert "thinking_budget" not in payload
+
+
+@pytest.mark.asyncio
+async def test_qwen38_explicit_budget_does_not_conflict_with_reasoning_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="openai", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan",
+            model="qwen3.8-max-preview",
+            api_key="sk-sp-test",
+        )
+    )
+
+    await _consume(
+        provider.chat(
+            [Message(role="user", content="think")],
+            config=ChatConfig(
+                thinking=True,
+                thinking_level=ThinkingLevel.LOW,
+                thinking_budget_tokens=7_000,
+                model_capabilities=_caps("qwen3.8-max-preview"),
+            ),
+        )
+    )
+
+    payload = captured["payload"]
+    assert payload["thinking_budget"] == 7_000
+    assert "reasoning_effort" not in payload
+
+
+@pytest.mark.asyncio
+async def test_non_forced_model_preserves_pinned_tool_by_disabling_thinking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="openai", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan",
+            model="qwen3.7-plus",
+            api_key="sk-sp-test",
+        )
+    )
+    pinned = {"type": "function", "function": {"name": "read_file"}}
+
+    await _consume(
+        provider.chat(
+            [
+                Message(
+                    role="assistant",
+                    content="prior",
+                    reasoning_content="private reasoning",
+                ),
+                Message(role="user", content="use exactly this tool"),
+            ],
+            tools=[_TOOL],
+            config=ChatConfig(
+                thinking=True,
+                tool_choice=pinned,
+                model_capabilities=_caps("qwen3.7-plus"),
+            ),
+        )
+    )
+
+    payload = captured["payload"]
+    assert payload["enable_thinking"] is False
+    assert payload["tool_choice"] == pinned
+    assert "thinking_budget" not in payload
+    assert "preserve_thinking" not in payload
+    assert "reasoning_content" not in payload["messages"][0]
+
+
+@pytest.mark.asyncio
+async def test_deepseek_v4_thinking_replays_reasoning_and_maps_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="openai", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan",
+            model="deepseek-v4-pro",
+            api_key="sk-sp-test",
+        )
+    )
+
+    await _consume(
+        provider.chat(
+            [
+                Message(role="assistant", content="prior answer"),
+                Message(role="user", content="continue"),
+            ],
+            config=ChatConfig(
+                thinking=True,
+                thinking_level=ThinkingLevel.XHIGH,
+                model_capabilities=_caps("deepseek-v4-pro"),
+            ),
+        )
+    )
+
+    payload = captured["payload"]
+    assert payload["enable_thinking"] is True
+    assert payload["reasoning_effort"] == "max"
+    assert payload["messages"][0]["reasoning_content"] == ""
+    assert "thinking" not in payload
+
+
+@pytest.mark.asyncio
+async def test_deepseek_v4_thinking_off_drops_reasoning_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="openai", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan",
+            model="deepseek-v4-pro",
+            api_key="sk-sp-test",
+        )
+    )
+
+    await _consume(
+        provider.chat(
+            [
+                Message(
+                    role="assistant",
+                    content="prior answer",
+                    reasoning_content="private reasoning",
+                ),
+                Message(role="user", content="continue"),
+            ],
+            config=ChatConfig(
+                thinking=False,
+                model_capabilities=_caps("deepseek-v4-pro"),
+            ),
+        )
+    )
+
+    payload = captured["payload"]
+    assert payload["enable_thinking"] is False
+    assert "reasoning_effort" not in payload
+    assert "reasoning_content" not in payload["messages"][0]
+
+
+@pytest.mark.asyncio
+async def test_kimi_tool_turn_backfills_reasoning_and_normalizes_tool_choice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="openai", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan",
+            model="kimi-k2.6",
+            api_key="sk-sp-test",
+        )
+    )
+
+    await _consume(
+        provider.chat(
+            [
+                Message(
+                    role="assistant",
+                    content=[
+                        ContentBlockToolUse(
+                            id="call_1",
+                            name="read_file",
+                            input={"path": "synthetic.txt"},
+                        )
+                    ],
+                ),
+                Message(role="user", content="continue"),
+            ],
+            tools=[_TOOL],
+            config=ChatConfig(
+                thinking=True,
+                tool_choice="required",
+                model_capabilities=_caps("kimi-k2.6"),
+            ),
+        )
+    )
+
+    payload = captured["payload"]
+    assert payload["enable_thinking"] is True
+    assert payload["tool_choice"] == "auto"
+    assert payload["messages"][0]["reasoning_content"] == ""
+    assert "reasoning_effort" not in payload
+
+
+@pytest.mark.asyncio
+async def test_glm_tool_calls_enable_tool_stream_and_preserve_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="openai", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan",
+            model="glm-5.2",
+            api_key="sk-sp-test",
+        )
+    )
+
+    await _consume(
+        provider.chat(
+            [Message(role="user", content="use a tool")],
+            tools=[_TOOL],
+            config=ChatConfig(
+                thinking=True,
+                thinking_level=ThinkingLevel.HIGH,
+                model_capabilities=_caps("glm-5.2"),
+            ),
+        )
+    )
+
+    payload = captured["payload"]
+    assert payload["enable_thinking"] is True
+    assert payload["reasoning_effort"] == "high"
+    assert payload["tool_stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_glm_xhigh_maps_to_documented_max_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="openai", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan",
+            model="glm-5.2",
+            api_key="sk-sp-test",
+        )
+    )
+
+    await _consume(
+        provider.chat(
+            [Message(role="user", content="think deeply")],
+            config=ChatConfig(
+                thinking=True,
+                thinking_level=ThinkingLevel.XHIGH,
+                model_capabilities=_caps("glm-5.2"),
+            ),
+        )
+    )
+
+    assert captured["payload"]["reasoning_effort"] == "max"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_profile_uses_bearer_endpoint_and_exact_listing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="anthropic", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="qwen_token_plan_anthropic",
+            model="qwen3.8-max-preview",
+            api_key="sk-sp-test",
+        )
+    )
+    assert isinstance(provider, AnthropicProvider)
+
+    await _consume(
+        provider.chat(
+            [Message(role="user", content="hello")],
+            config=ChatConfig(temperature=0.2),
+        )
+    )
+
+    assert captured["url"].endswith("/apps/anthropic/v1/messages")
+    assert captured["headers"]["authorization"] == "Bearer sk-sp-test"
+    assert "x-api-key" not in captured["headers"]
+    assert captured["payload"]["temperature"] == 0.6
+
+    listed = await provider.list_models()
+    assert tuple(model.model_id for model in listed) == QWEN_TOKEN_PLAN_MODEL_IDS
+    assert {model.provider for model in listed} == {"qwen_token_plan_anthropic"}
+
+
+@pytest.mark.asyncio
+async def test_custom_anthropic_is_keyless_and_lists_only_configured_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="anthropic", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="custom_anthropic",
+            model="vendor-model",
+            base_url="https://llm.example.test/anthropic",
+        )
+    )
+    assert isinstance(provider, AnthropicProvider)
+
+    listed = await provider.list_models()
+
+    assert [(model.provider, model.model_id) for model in listed] == [
+        ("custom_anthropic", "vendor-model")
+    ]
+
+    await _consume(provider.chat([Message(role="user", content="hello")]))
+    assert captured["url"].endswith("/anthropic/v1/messages")
+    assert "authorization" not in captured["headers"]
+    assert "x-api-key" not in captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_custom_openai_keyless_request_omits_empty_bearer_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, module="openai", captured=captured)
+    provider = _build_provider(
+        ProviderConfig(
+            provider="custom",
+            model="vendor-model",
+            base_url="https://llm.example.test/v1",
+        )
+    )
+
+    await _consume(provider.chat([Message(role="user", content="hello")]))
+
+    assert captured["url"].endswith("/v1/chat/completions")
+    assert "authorization" not in captured["headers"]
+
+
+def test_custom_endpoints_keep_upgrade_safe_context_default() -> None:
+    catalog = ModelCatalog()
+
+    assert catalog.resolve_context_window("unknown-model", provider="custom") == (
+        8_192
+    )
+    assert catalog.resolve_context_window(
+        "unknown-model", provider="custom_anthropic"
+    ) == 8_192
+
+
+def test_qwen_token_plan_router_preset_is_curated_and_inline_safe() -> None:
+    preset = get_preset("qwen_token_plan")
+
+    assert preset is not None
+    assert preset.synthesized is False
+    assert preset.default_model == "qwen3.7-plus"
+    assert preset.tiers["c0"]["model"] == "qwen3.6-flash"
+    assert preset.tiers["c3"]["model"] == "qwen3.8-max-preview"
+    assert preset.tiers["image_model"]["supports_image"] is True


### PR DESCRIPTION
## Summary

- add verified `qwen_token_plan` and `qwen_token_plan_anthropic` profiles with dedicated `sk-sp` credentials, official endpoints, live entitlement-aware model discovery, provider-scoped catalog metadata, request-shape compatibility, golden payloads, and opt-in live smoke coverage
- add a packaged inline SquillaRouter ladder and native Wan image generation with bounded, SSRF-guarded signed-result downloads
- add `custom_anthropic` as a first-class Anthropic Messages endpoint with explicit model/base URL and optional bearer authentication, while preserving the existing `custom` OpenAI-compatible contract
- expose both additions through onboarding and Settings catalog flows, including optional-key probe behavior and model suggestions; update operator documentation and example configuration

## Target

- Base branch: `main`
- Head branch: `feature/qwen-token-plan-custom-anthropic`
- Based on `94370de36` (`origin/main` at final review)
- Linked issue: None

## Verification

- `uv run ruff check src tests` — passed
- `uv run mypy src/opensquilla --show-error-codes` — passed (869 source files)
- affected provider/onboarding/packaging suite — 1,684 passed, 5 skipped
- focused provider review suite — 265 passed
- WebUI unit suite with a 10-second local timeout — 2,346 passed; the three files that hit the default 5-second threshold under parallel machine load also passed independently (71 tests)
- `npm run build` — passed, including TypeScript, architecture, chat-security, theme, i18n, runtime-bundle, and artifact guards
- `uv build --wheel` — passed; the wheel contains the Qwen provider module, router preset, and verified WebUI artifact
- full backend attempt excluding real-terminal OpenTUI tests — 17,686 passed, 188 skipped, 23 failed; standard `uv run` rerun resolved 15, leaving 8 unrelated local/platform conditions (BSD `sed -i`, missing WeasyPrint system library, macOS Seatbelt `/tmp`/`.codex` worktree behavior, and protected-metadata policy)
- credential-backed live smoke tests remain opt-in and skipped in the clean final run because no key was exported

## Safety and compatibility

- no API keys, transcripts, or local runtime state are included; staged real-key signature scan passed
- selectable live discovery is restricted to the verified official HTTPS host (or its subdomains); the Anthropic profile uses the registry-owned OpenAI-compatible listing endpoint rather than reusing a Messages path
- generated-image downloads validate each HTTPS redirect, use DNS-pinned transport, cap payloads at 20 MiB, disable implicit redirects, and redact signed URLs from errors
- changes are additive: existing provider ids and persisted configurations keep their behavior, no schema migration is required, and unknown custom models retain the existing conservative 8k context fallback
- the implementation is platform-neutral except for existing shared HTTP and sandbox primitives; no new shell, path, signal, or process assumptions are introduced

## Release note

User-visible provider addition; provider documentation and example configuration are included. Please include Qwen Token Plan and custom Anthropic support in the next release notes.

## Third-party origin

Implemented from public Alibaba/Qwen Token Plan protocol documentation and service-contract validation. No third-party source code, comments, fixtures, or identifiers were copied.