### PR TITLE
Fix first-install provider and model routing state

### DIFF
--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -1018,6 +1018,27 @@ function canonicalTierKey(name: string): string {
 const ROUTER_PROFILE_IDS = new Set(['tokenrhythm', 'openrouter', 'dashscope', 'deepseek', 'gemini', 'volcengine', 'openai', 'zhipu', 'moonshot'])
 const INLINE_ROUTER_PROFILE_IDS = new Set(['tokenrhythm'])
 const TOKENRHYTHM_REGISTER_URL = 'https://tokenrhythm.studio/register'
+const DESKTOP_ENSEMBLE_PROFILES: Record<StaticEnsembleSelectionMode, {
+  provider: string
+  proposers: string[]
+  aggregator: string
+}> = {
+  static_tokenrhythm_b5: {
+    provider: 'tokenrhythm',
+    proposers: ['deepseek-v4-pro', 'glm-5.2', 'kimi-k2.7-code', 'qwen3.7-max'],
+    aggregator: 'glm-5.2',
+  },
+  static_openrouter_b5: {
+    provider: 'openrouter',
+    proposers: [
+      'deepseek/deepseek-v4-pro',
+      'z-ai/glm-5.2',
+      'moonshotai/kimi-k2.7-code',
+      'qwen/qwen3.7-max',
+    ],
+    aggregator: 'z-ai/glm-5.2',
+  },
+}
 
 const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
   {
@@ -1690,11 +1711,32 @@ function ensembleConfigTomlLines(credential: DesktopConnection): string[] {
   if (!selectionMode) {
     throw new Error(`LLM Ensemble is not supported for provider ${credential.provider}.`)
   }
+  const profile = DESKTOP_ENSEMBLE_PROFILES[selectionMode]
+  const roles = ['primary', 'contrast', 'fast_check', 'critic']
+  const candidates = profile.proposers.flatMap((model, index) => [
+    '',
+    '[[llm_ensemble.candidates]]',
+    `provider = ${tomlString(profile.provider)}`,
+    `model = ${tomlString(model)}`,
+    'source = "custom"',
+    'enabled = true',
+    `role = ${tomlString(roles[index] || '')}`,
+  ])
+  candidates.push(
+    '',
+    '[[llm_ensemble.candidates]]',
+    `provider = ${tomlString(profile.provider)}`,
+    `model = ${tomlString(profile.aggregator)}`,
+    'source = "custom"',
+    'enabled = true',
+    'role = "aggregator"',
+  )
   return [
     '',
     '[llm_ensemble]',
     'enabled = true',
-    `selection_mode = ${tomlString(selectionMode)}`,
+    'selection_mode = "custom_b5"',
+    ...candidates,
   ]
 }
 

--- a/opensquilla-webui/src/composables/setup/useSetupCatalog.ts
+++ b/opensquilla-webui/src/composables/setup/useSetupCatalog.ts
@@ -286,6 +286,14 @@ interface ConfigData {
   llm_ensemble?: {
     enabled?: boolean
     selection_mode?: string
+    selection_configured?: boolean
+    activation_preview?: {
+      selection_mode?: string
+      proposer_count?: number
+      member_providers?: string[]
+      candidates?: EnsembleCandidateConfig[]
+      blocked_reason?: string | null
+    }
     model_options?: string[]
     candidates?: EnsembleCandidateConfig[]
     min_successful_proposers?: number

--- a/opensquilla-webui/src/composables/setup/useSetupEnsembleForm.test.ts
+++ b/opensquilla-webui/src/composables/setup/useSetupEnsembleForm.test.ts
@@ -67,6 +67,29 @@ describe('useSetupEnsembleForm — init + dirty tracking', () => {
     expect(f.isDirty.value).toBe(false)
   })
 
+  it('uses the backend activation preview instead of the dormant legacy default', () => {
+    const f = useSetupEnsembleForm()
+    f.initFromConfig({
+      enabled: false,
+      selection_mode: 'static_openrouter_b5',
+      selection_configured: false,
+      activation_preview: {
+        selection_mode: CUSTOM_B5_SELECTION_MODE,
+        candidates: [
+          { provider: 'tokenrhythm', model: 'deepseek-v4-pro', role: 'primary' },
+          { provider: 'tokenrhythm', model: 'glm-5.2', role: 'aggregator' },
+        ],
+      },
+    })
+
+    expect(f.selectionMode.value).toBe(CUSTOM_B5_SELECTION_MODE)
+    expect(f.candidates.value.map((candidate) => candidate.provider)).toEqual([
+      'tokenrhythm',
+      'tokenrhythm',
+    ])
+    expect(f.isDirty.value).toBe(false)
+  })
+
   it('falls back to the shipped defaults for an empty or invalid config slice', () => {
     const f = useSetupEnsembleForm()
     f.initFromConfig({ selection_mode: 'bogus', all_failed_policy: 'bogus', min_successful_proposers: -3 })

--- a/opensquilla-webui/src/composables/setup/useSetupEnsembleForm.ts
+++ b/opensquilla-webui/src/composables/setup/useSetupEnsembleForm.ts
@@ -186,6 +186,12 @@ export interface EnsembleCustomLineupView {
 export interface EnsembleConfigSlice {
   enabled?: boolean
   selection_mode?: string
+  selection_configured?: boolean
+  activation_preview?: {
+    selection_mode?: string
+    candidates?: EnsembleCandidateConfig[]
+    blocked_reason?: string | null
+  }
   model_options?: string[]
   candidates?: EnsembleCandidateConfig[]
   min_successful_proposers?: number
@@ -464,9 +470,23 @@ export function useSetupEnsembleForm() {
 
   function initFromConfig(config: EnsembleConfigSlice) {
     enabled.value = config.enabled === true
-    selectionMode.value = normalizeSelectionMode(config.selection_mode)
+    const usePlannedActivation = (
+      config.enabled !== true && config.selection_configured === false
+    )
+    const plannedActivation = usePlannedActivation
+      ? config.activation_preview
+      : undefined
+    selectionMode.value = (
+      usePlannedActivation
+        ? normalizeSelectionMode(
+            plannedActivation?.selection_mode ?? CUSTOM_B5_SELECTION_MODE,
+          )
+        : normalizeSelectionMode(config.selection_mode)
+    )
     modelOptions.value = normalizeModelOptions(config.model_options)
-    candidates.value = normalizeCandidates(config.candidates)
+    candidates.value = normalizeCandidates(
+      plannedActivation?.candidates ?? config.candidates,
+    )
     minSuccessfulProposers.value = normalizeMinSuccessful(
       config.min_successful_proposers ?? DEFAULT_MIN_SUCCESSFUL_PROPOSERS,
     )

--- a/src/opensquilla/cli/doctor_cmd.py
+++ b/src/opensquilla/cli/doctor_cmd.py
@@ -481,13 +481,21 @@ async def _fetch_report(
     gateway_url: str,
     agent_id: str,
     deep: bool,
+    probe_providers: bool = False,
 ) -> dict[str, Any]:
     from opensquilla.cli import gateway_client as gateway_client_module
 
     client = gateway_client_module.GatewayClient()
     try:
         await client.connect(gateway_url)
-        payload = await client.call("doctor.status", {"agentId": agent_id, "deep": deep})
+        payload = await client.call(
+            "doctor.status",
+            {
+                "agentId": agent_id,
+                "deep": deep,
+                "probeProviders": probe_providers,
+            },
+        )
         return dict(payload)
     finally:
         await client.close()
@@ -739,6 +747,11 @@ def doctor_command(
         "--deep/--quick",
         help="Include deeper memory diagnostics; use --quick for shallow checks.",
     ),
+    probe_providers: bool = typer.Option(
+        False,
+        "--probe-providers",
+        help="Opt in to live provider model-list probes.",
+    ),
     gateway_url: str | None = typer.Option(None, "--gateway", envvar="OPENSQUILLA_GATEWAY_URL"),
     config_path: Path | None = typer.Option(
         None,
@@ -764,7 +777,14 @@ def doctor_command(
             gateway_url=gateway_url,
             config_path=config_path,
         )
-        report = asyncio.run(_fetch_report(gateway_url=target_url, agent_id=agent_id, deep=deep))
+        report = asyncio.run(
+            _fetch_report(
+                gateway_url=target_url,
+                agent_id=agent_id,
+                deep=deep,
+                probe_providers=probe_providers,
+            )
+        )
     except SystemExit as exc:
         report = _offline_report(
             exc,

--- a/src/opensquilla/cli/providers_cmd.py
+++ b/src/opensquilla/cli/providers_cmd.py
@@ -85,15 +85,30 @@ def providers_status(
     table.add_column("buildable", no_wrap=True)
     table.add_column("model")
     table.add_column("error")
+    if probe_models:
+        table.add_column("probe")
     for row in payload.get("providers", []):
-        table.add_row(
+        values = [
             str(row.get("providerId") or ""),
             "yes" if row.get("active") else "no",
             "yes" if row.get("configured") else "no",
             "yes" if row.get("buildable") else "no",
             str(row.get("model") or ""),
             str(row.get("error") or ""),
-        )
+        ]
+        if probe_models:
+            probe = row.get("modelProbe") or {}
+            status = str(probe.get("status") or "unavailable")
+            if status == "ok":
+                probe_text = f"ok ({int(probe.get('count') or 0)} models)"
+            elif status in {"error", "degraded"}:
+                kind = str(probe.get("failureKind") or status)
+                detail = str(probe.get("error") or "")
+                probe_text = f"{kind} — {detail}" if detail else kind
+            else:
+                probe_text = status
+            values.append(probe_text)
+        table.add_row(*values)
     console.print(table)
 
 

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -31,6 +31,10 @@ from opensquilla.gateway.config_migration import (
     migrate_config_payload,
 )
 from opensquilla.paths import default_opensquilla_home, native_io_path
+from opensquilla.provider.credentials import (
+    credential_provider_hint,
+    endpoint_provider_hint,
+)
 from opensquilla.provider.preset_registry import get_preset, legacy_profile_ids
 from opensquilla.router_tiers import (
     DEFAULT_TEXT_TIER,
@@ -345,6 +349,8 @@ class TaskRuntimeConfig(BaseModel):
 LEGACY_DEFAULT_LLM_PROVIDER = "openrouter"
 LEGACY_DEFAULT_LLM_MODEL = "deepseek/deepseek-v4-pro"
 LEGACY_DEFAULT_LLM_BASE_URL = "https://openrouter.ai/api/v1"
+TOKENRHYTHM_DEFAULT_LLM_PROVIDER = "tokenrhythm"
+TOKENRHYTHM_DEFAULT_LLM_BASE_URL = "https://tokenrhythm.studio/v1"
 
 
 class LlmProviderConfig(BaseSettings):
@@ -2217,15 +2223,123 @@ class GatewayConfig(BaseSettings):
         llm = self.llm
         fields_set = set(getattr(llm, "model_fields_set", set()))
         provider = str(llm.provider or "").strip().lower()
+        resolution = {
+            "status": "explicit",
+            "effective_provider": provider,
+            "source": "config",
+            "reason_code": "provider_explicit",
+            "action_required": False,
+            "action_recommended": False,
+        }
         if "provider" not in fields_set:
             profile = str(getattr(self.squilla_router, "tier_profile", "") or "")
+            router_fields_set = set(
+                getattr(self.squilla_router, "model_fields_set", set())
+            )
             legacy_intent = bool(
                 {"model", "base_url", "api_key", "api_key_env"} & fields_set
-            ) or profile.strip().lower() == LEGACY_DEFAULT_LLM_PROVIDER
+            ) or (
+                "tier_profile" in router_fields_set
+                and profile.strip().lower() == LEGACY_DEFAULT_LLM_PROVIDER
+            )
+            credential_hints = {
+                hint
+                for hint in (
+                    credential_provider_hint(
+                        llm.api_key if "api_key" in fields_set else ""
+                    ),
+                    credential_provider_hint(
+                        "",
+                        api_key_env=(
+                            llm.api_key_env if "api_key_env" in fields_set else ""
+                        ),
+                    ),
+                )
+                if hint
+            }
+            origin_hint = endpoint_provider_hint(
+                llm.base_url if "base_url" in fields_set else ""
+            )
+            explicit_profile_hint = (
+                LEGACY_DEFAULT_LLM_PROVIDER
+                if "tier_profile" in router_fields_set
+                and profile.strip().lower() == LEGACY_DEFAULT_LLM_PROVIDER
+                else ""
+            )
             env_openrouter = bool(os.environ.get("OPENROUTER_API_KEY", "").strip())
             env_tokenrhythm = bool(os.environ.get("TOKENRHYTHM_API_KEY", "").strip())
-            if legacy_intent or (env_openrouter and not env_tokenrhythm):
+            ambient_credential_hints = (
+                {
+                    hint
+                    for hint, available in (
+                        (LEGACY_DEFAULT_LLM_PROVIDER, env_openrouter),
+                        (TOKENRHYTHM_DEFAULT_LLM_PROVIDER, env_tokenrhythm),
+                    )
+                    if available
+                }
+                if not ({"api_key", "api_key_env"} & fields_set)
+                else set()
+            )
+            strong_hints = {
+                hint
+                for hint in (
+                    *credential_hints,
+                    *ambient_credential_hints,
+                    origin_hint,
+                    explicit_profile_hint,
+                )
+                if hint
+            }
+            if strong_hints == {TOKENRHYTHM_DEFAULT_LLM_PROVIDER}:
+                provider = TOKENRHYTHM_DEFAULT_LLM_PROVIDER
+                resolution = {
+                    "status": "recovered",
+                    "effective_provider": provider,
+                    "source": "strong_evidence",
+                    "reason_code": "providerless_tokenrhythm_recovered",
+                    "action_required": False,
+                    "action_recommended": True,
+                }
+            elif len(strong_hints) > 1:
                 provider = LEGACY_DEFAULT_LLM_PROVIDER
+                resolution = {
+                    "status": "conflict",
+                    "effective_provider": "",
+                    "source": "conflicting_evidence",
+                    "reason_code": "providerless_provider_conflict",
+                    "action_required": True,
+                    "action_recommended": True,
+                }
+            elif legacy_intent or (env_openrouter and not env_tokenrhythm):
+                provider = LEGACY_DEFAULT_LLM_PROVIDER
+                explicit_openrouter = (
+                    strong_hints == {LEGACY_DEFAULT_LLM_PROVIDER}
+                    or (env_openrouter and not env_tokenrhythm and not legacy_intent)
+                )
+                resolution = {
+                    "status": "legacy_inferred",
+                    "effective_provider": provider,
+                    "source": (
+                        "strong_evidence" if explicit_openrouter else "legacy_compat"
+                    ),
+                    "reason_code": (
+                        "providerless_openrouter_evidence"
+                        if explicit_openrouter
+                        else "providerless_ambiguous_legacy_openrouter"
+                    ),
+                    "action_required": False,
+                    "action_recommended": not explicit_openrouter,
+                }
+            else:
+                resolution = {
+                    "status": "default",
+                    "effective_provider": provider,
+                    "source": "built_in_default",
+                    "reason_code": "provider_unset_default_tokenrhythm",
+                    "action_required": False,
+                    "action_recommended": False,
+                }
+        self._provider_resolution = resolution
         if provider != LEGACY_DEFAULT_LLM_PROVIDER:
             return self
         payload = llm.model_dump(mode="python")
@@ -2576,6 +2690,7 @@ class GatewayConfig(BaseSettings):
     _persist_raw_base: dict[str, Any] | None = PrivateAttr(default=None)
     _runtime_field_overrides: dict[str, tuple[Any, Any]] = PrivateAttr(default_factory=dict)
     _force_persist_paths: set[tuple[str, ...]] = PrivateAttr(default_factory=set)
+    _provider_resolution: dict[str, Any] = PrivateAttr(default_factory=dict)
 
     def to_toml_dict(self) -> dict[str, Any]:
         """Convert config to a TOML-writable dict."""
@@ -2652,6 +2767,15 @@ class GatewayConfig(BaseSettings):
     def to_public_dict(self) -> dict[str, Any]:
         """Return a redacted config view safe for public control surfaces."""
         data = cast(dict[str, Any], redact_public_config(self.model_dump()))
+        ensemble = data.get("llm_ensemble")
+        if isinstance(ensemble, dict):
+            from opensquilla.gateway.model_routing import (
+                ensemble_activation_preview,
+                ensemble_selection_configured,
+            )
+
+            ensemble["selection_configured"] = ensemble_selection_configured(self)
+            ensemble["activation_preview"] = ensemble_activation_preview(self)
         privacy = data.get("privacy")
         if isinstance(privacy, dict):
             from opensquilla.observability.network_policy import (
@@ -2723,6 +2847,43 @@ class GatewayConfig(BaseSettings):
         self._persist_raw_base = copy.deepcopy(other._persist_raw_base)
         self._runtime_field_overrides = dict(other._runtime_field_overrides)
         self._force_persist_paths = set(other._force_persist_paths)
+        self._provider_resolution = dict(other._provider_resolution)
+
+    def provider_resolution(self) -> dict[str, Any]:
+        """Return non-secret provider identity provenance for diagnostics."""
+
+        if self._provider_resolution:
+            return dict(self._provider_resolution)
+        provider = str(getattr(self.llm, "provider", "") or "").strip().lower()
+        return {
+            "status": "explicit",
+            "effective_provider": provider,
+            "source": "config",
+            "reason_code": "provider_explicit",
+            "action_required": False,
+            "action_recommended": False,
+        }
+
+    def set_provider_resolution(
+        self,
+        *,
+        status: str,
+        effective_provider: str,
+        source: str,
+        reason_code: str,
+        action_required: bool = False,
+        action_recommended: bool = False,
+    ) -> None:
+        """Update runtime-only provider identity provenance after a mutation."""
+
+        self._provider_resolution = {
+            "status": str(status),
+            "effective_provider": str(effective_provider),
+            "source": str(source),
+            "reason_code": str(reason_code),
+            "action_required": bool(action_required),
+            "action_recommended": bool(action_recommended),
+        }
 
     def set_persist_snapshot(
         self,
@@ -2778,6 +2939,7 @@ class GatewayConfig(BaseSettings):
         self._persist_baseline = copy.deepcopy(other._persist_baseline)
         self._persist_raw_base = copy.deepcopy(other._persist_raw_base)
         self._force_persist_paths = set(other._force_persist_paths)
+        self._provider_resolution = dict(other._provider_resolution)
 
     def mark_force_persist(self, path: str) -> None:
         """Always write ``path`` on the next persist, even if it equals the

--- a/src/opensquilla/gateway/llm_runtime.py
+++ b/src/opensquilla/gateway/llm_runtime.py
@@ -203,6 +203,59 @@ def resolve_llm_runtime_config(config: Any) -> LlmRuntimeConfig:
     base_url_env_name = provider_base_url_env_name(provider) if spec is not None else ""
     env_base_url = environment_value(base_url_env_name) if base_url_env_name else ""
     api_key = credential.api_key
+    resolution_getter = getattr(config, "provider_resolution", None)
+    resolution = resolution_getter() if callable(resolution_getter) else {}
+    provider_resolution_blocked = bool(resolution.get("action_required", False))
+    from opensquilla.provider.credentials import (
+        credential_provider_hint,
+        endpoint_provider_hint,
+    )
+
+    credential_hint = credential_provider_hint(
+        api_key,
+        api_key_env=credential.env_name or getattr(llm, "api_key_env", ""),
+    )
+    credential_mismatch = bool(credential_hint and credential_hint != provider)
+    if provider_resolution_blocked or credential_mismatch:
+        reason_code = (
+            "credential_provider_mismatch"
+            if credential_mismatch
+            else str(resolution.get("reason_code") or "provider_resolution_blocked")
+        )
+        log.warning(
+            "llm_runtime.credential_withheld",
+            provider=provider,
+            credential_provider_hint=credential_hint or None,
+            reason_code=reason_code,
+        )
+        # Preserve an explicitly stored value across unrelated sparse saves,
+        # but remove it from every runtime-facing config path before any
+        # provider or ensemble can construct an Authorization header.
+        if (
+            api_key
+            and credential.source == "explicit"
+            and hasattr(config, "record_runtime_override")
+        ):
+            config.record_runtime_override(
+                "llm.api_key",
+                str(getattr(llm, "api_key", "") or ""),
+                "",
+            )
+        api_key = ""
+        setter = getattr(config, "set_provider_resolution", None)
+        if (
+            callable(setter)
+            and credential_mismatch
+            and not provider_resolution_blocked
+        ):
+            setter(
+                status="conflict",
+                effective_provider=provider,
+                source="credential_shape",
+                reason_code=reason_code,
+                action_required=True,
+                action_recommended=True,
+            )
     # Explicit config > derived env > spec default, mirroring the api_key
     # rule (#484): a base_url the operator chose must not be overridden by
     # OPENAI_BASE_URL-style vars on the next boot/reload. Derived stored
@@ -218,6 +271,42 @@ def resolve_llm_runtime_config(config: Any) -> LlmRuntimeConfig:
         base_url = stored_base_url
     else:
         base_url = env_base_url or (spec.default_base_url if spec else stored_base_url)
+    endpoint_hint = endpoint_provider_hint(base_url)
+    credential_endpoint_mismatch = bool(
+        api_key
+        and credential_hint
+        and endpoint_hint
+        and credential_hint != endpoint_hint
+    )
+    if credential_endpoint_mismatch:
+        reason_code = "credential_endpoint_provider_mismatch"
+        log.warning(
+            "llm_runtime.credential_withheld",
+            provider=provider,
+            credential_provider_hint=credential_hint,
+            endpoint_provider_hint=endpoint_hint,
+            reason_code=reason_code,
+        )
+        if (
+            credential.source == "explicit"
+            and hasattr(config, "record_runtime_override")
+        ):
+            config.record_runtime_override(
+                "llm.api_key",
+                str(getattr(llm, "api_key", "") or ""),
+                "",
+            )
+        api_key = ""
+        setter = getattr(config, "set_provider_resolution", None)
+        if callable(setter):
+            setter(
+                status="conflict",
+                effective_provider=provider,
+                source="credential_endpoint",
+                reason_code=reason_code,
+                action_required=True,
+                action_recommended=True,
+            )
     base_url_from_env = bool(env_base_url) and base_url == env_base_url
     proxy = environment_value("OPENSQUILLA_LLM_PROXY") or getattr(llm, "proxy", "")
 

--- a/src/opensquilla/gateway/model_routing.py
+++ b/src/opensquilla/gateway/model_routing.py
@@ -8,6 +8,7 @@ surface observes and mutates the same state machine.
 from __future__ import annotations
 
 import copy
+import os
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -54,6 +55,227 @@ def _clean(value: object) -> str:
     return str(value or "").strip().lower()
 
 
+def ensemble_selection_configured(config: Any) -> bool:
+    """Whether ``selection_mode`` came from an operator-owned config source."""
+
+    ensemble = getattr(config, "llm_ensemble", None)
+    if ensemble is None:
+        return False
+    force_paths = getattr(config, "force_persist_paths", None)
+    if callable(force_paths) and "llm_ensemble.selection_mode" in force_paths():
+        return True
+    raw = getattr(config, "_persist_raw_base", None)
+    if isinstance(raw, dict):
+        raw_ensemble = raw.get("llm_ensemble")
+        if isinstance(raw_ensemble, dict) and "selection_mode" in raw_ensemble:
+            return True
+        # A loaded/persisted raw snapshot is authoritative: rebuilding a
+        # Pydantic section from a partial mutation must not turn omitted
+        # defaults into operator-authored fields.
+        return bool(
+            os.environ.get("OPENSQUILLA_LLM_ENSEMBLE_SELECTION_MODE", "").strip()
+        )
+    fields_set = getattr(ensemble, "model_fields_set", None)
+    if fields_set is None:
+        # Config-like compatibility objects have no provenance channel; an
+        # existing selection value is therefore the only safe interpretation.
+        return bool(str(getattr(ensemble, "selection_mode", "") or "").strip())
+    return "selection_mode" in set(fields_set)
+
+
+def _custom_candidate(
+    provider: str,
+    model: str,
+    *,
+    role: str = "",
+) -> dict[str, Any]:
+    return {
+        "provider": provider,
+        "model": model,
+        "source": "custom",
+        "enabled": True,
+        "role": role,
+        "thinking_level": "",
+    }
+
+
+def _provider_is_runtime_supported(provider: str) -> bool:
+    """Whether a provider can structurally participate in model execution."""
+
+    from opensquilla.provider.registry import UnknownProviderError, get_provider_spec
+
+    try:
+        return bool(get_provider_spec(provider).runtime_supported)
+    except UnknownProviderError:
+        return False
+
+
+def _provider_ensemble_candidates(config: Any) -> list[dict[str, Any]]:
+    """Build the provider-aware first-activation custom lineup."""
+
+    provider = _clean(getattr(getattr(config, "llm", None), "provider", ""))
+    from opensquilla.provider.ensemble import (
+        CUSTOM_B5_PROPOSER_ROLES,
+        STATIC_B5_PROFILES,
+    )
+
+    static_profile = next(
+        (
+            profile
+            for profile in STATIC_B5_PROFILES.values()
+            if _clean(profile.provider_id) == provider
+        ),
+        None,
+    )
+    if static_profile is not None:
+        static_candidates = [
+            _custom_candidate(
+                static_profile.provider_id,
+                model,
+                role=(
+                    CUSTOM_B5_PROPOSER_ROLES[index]
+                    if index < len(CUSTOM_B5_PROPOSER_ROLES)
+                    else ""
+                ),
+            )
+            for index, model in enumerate(static_profile.proposer_models)
+        ]
+        static_candidates.append(
+            _custom_candidate(
+                static_profile.provider_id,
+                static_profile.aggregator_model,
+                role="aggregator",
+            )
+        )
+        return static_candidates
+
+    router = getattr(config, "squilla_router", None)
+    tiers = getattr(router, "tiers", {}) or {}
+    tier_order = ("c0", "c1", "c2", "c3")
+    role_by_tier = {
+        "c0": "fast_check",
+        "c1": "primary",
+        "c2": "contrast",
+        "c3": "critic",
+    }
+    seen: set[tuple[str, str]] = set()
+    candidates: list[dict[str, Any]] = []
+    if isinstance(tiers, dict):
+        normalized: dict[str, dict[str, Any]] = {}
+        for raw_tier, raw_cfg in tiers.items():
+            tier = _clean(raw_tier)
+            if tier.startswith("t") and tier[1:] in {"0", "1", "2", "3"}:
+                tier = f"c{tier[1:]}"
+            if tier in tier_order and isinstance(raw_cfg, dict):
+                normalized[tier] = raw_cfg
+        for tier in tier_order:
+            tier_cfg = normalized.get(tier)
+            if not tier_cfg:
+                continue
+            member_provider = _clean(tier_cfg.get("provider") or provider)
+            model = str(tier_cfg.get("model") or "").strip()
+            identity = (member_provider, model)
+            if (
+                not member_provider
+                or not model
+                or identity in seen
+                or not _provider_is_runtime_supported(member_provider)
+            ):
+                continue
+            seen.add(identity)
+            candidates.append(
+                _custom_candidate(
+                    member_provider,
+                    model,
+                    role=role_by_tier[tier],
+                )
+            )
+            if len(candidates) >= 6:
+                break
+    if len(candidates) < 2:
+        raise ValueError(
+            "Ensemble needs at least two distinct runtime-supported Router tier candidates; "
+            "configure the lineup before enabling it"
+        )
+    return candidates
+
+
+def ensemble_activation_patches(config: Any) -> dict[str, Any]:
+    """Return first-activation selection/candidate patches, or none."""
+
+    ensemble = getattr(config, "llm_ensemble", None)
+    if ensemble is None or bool(getattr(ensemble, "enabled", False)):
+        return {}
+    if ensemble_selection_configured(config):
+        return {}
+    return {
+        "llm_ensemble.selection_mode": "custom_b5",
+        "llm_ensemble.candidates": _provider_ensemble_candidates(config),
+    }
+
+
+def ensemble_activation_preview(config: Any) -> dict[str, Any]:
+    """Return a non-secret preview of the current or planned Ensemble lineup."""
+
+    ensemble = getattr(config, "llm_ensemble", None)
+    configured = ensemble_selection_configured(config)
+    if ensemble is None:
+        return {
+            "selection_mode": "",
+            "proposer_count": 0,
+            "member_providers": [],
+            "candidates": [],
+            "blocked_reason": "llm_ensemble_missing",
+        }
+    try:
+        patches = ensemble_activation_patches(config)
+    except ValueError as exc:
+        return {
+            "selection_mode": "custom_b5",
+            "proposer_count": 0,
+            "member_providers": [],
+            "candidates": [],
+            "blocked_reason": str(exc),
+        }
+    selection_mode = str(
+        patches.get("llm_ensemble.selection_mode")
+        or getattr(ensemble, "selection_mode", "")
+    )
+    candidates = patches.get("llm_ensemble.candidates")
+    if candidates is None:
+        candidates = [
+            candidate.model_dump(mode="python")
+            if hasattr(candidate, "model_dump")
+            else dict(candidate)
+            for candidate in list(getattr(ensemble, "candidates", []) or [])
+        ]
+    enabled_candidates = [
+        candidate
+        for candidate in candidates
+        if isinstance(candidate, dict) and candidate.get("enabled", True) is not False
+    ]
+    proposers = [
+        candidate
+        for candidate in enabled_candidates
+        if str(candidate.get("role") or "") != "aggregator"
+    ]
+    providers = sorted(
+        {
+            _clean(candidate.get("provider"))
+            for candidate in enabled_candidates
+            if _clean(candidate.get("provider"))
+        }
+    )
+    return {
+        "selection_mode": selection_mode,
+        "selection_configured": configured,
+        "proposer_count": len(proposers),
+        "member_providers": providers,
+        "candidates": enabled_candidates,
+        "blocked_reason": None,
+    }
+
+
 def model_routing_snapshot(config: Any) -> dict[str, Any]:
     """Return the additive public snapshot for the current runtime strategy."""
 
@@ -78,12 +300,19 @@ def model_routing_snapshot(config: Any) -> dict[str, Any]:
         "ensemble_enabled": ensemble_enabled,
         "rollout_phase": rollout_phase,
         "selection_mode": selection_mode,
+        "selection_configured": ensemble_selection_configured(config),
+        "activation_preview": ensemble_activation_preview(config),
         "router_required_by_ensemble": router_required,
         "applies_to": "next_accepted_turn",
     }
 
 
-def model_routing_patches(config: Any, mode: str) -> dict[str, Any]:
+def model_routing_patches(
+    config: Any,
+    mode: str,
+    *,
+    activation_config: Any = None,
+) -> dict[str, Any]:
     """Translate one public mode into the persisted config patch contract."""
 
     normalized = _clean(mode)
@@ -103,10 +332,14 @@ def model_routing_patches(config: Any, mode: str) -> dict[str, Any]:
             "squilla_router.rollout_phase": "full",
         }
 
+    planner_config = activation_config if activation_config is not None else config
+    patches = ensemble_activation_patches(planner_config)
     selection_mode = _clean(
-        getattr(getattr(config, "llm_ensemble", None), "selection_mode", "")
+        patches.get("llm_ensemble.selection_mode")
+        or getattr(getattr(config, "llm_ensemble", None), "selection_mode", "")
     )
     return {
+        **patches,
         "llm_ensemble.enabled": True,
         "squilla_router.enabled": selection_mode not in _INDEPENDENT_ENSEMBLE_MODES,
         "squilla_router.rollout_phase": "full",
@@ -206,7 +439,12 @@ def model_routing_mode_for_write(
     return None
 
 
-def apply_model_routing_mode(config: Any, mode: str) -> dict[str, Any]:
+def apply_model_routing_mode(
+    config: Any,
+    mode: str,
+    *,
+    activation_config: Any = None,
+) -> dict[str, Any]:
     """Apply one canonical mode to a config-like object in place.
 
     The returned mapping contains only fields whose values changed.  All three
@@ -215,11 +453,24 @@ def apply_model_routing_mode(config: Any, mode: str) -> dict[str, Any]:
     """
 
     changed: dict[str, Any] = {}
-    for path, value in model_routing_patches(config, mode).items():
+    for path, value in model_routing_patches(
+        config,
+        mode,
+        activation_config=activation_config,
+    ).items():
         section_name, field_name = path.split(".", 1)
         section = getattr(config, section_name, None)
         if section is None:
             continue
+        if path == "llm_ensemble.candidates":
+            from opensquilla.gateway.config import LlmEnsembleCandidateConfig
+
+            value = [
+                candidate
+                if isinstance(candidate, LlmEnsembleCandidateConfig)
+                else LlmEnsembleCandidateConfig.model_validate(candidate)
+                for candidate in list(value or [])
+            ]
         if getattr(section, field_name, None) != value:
             setattr(section, field_name, value)
             changed[path] = value
@@ -247,7 +498,20 @@ def reconcile_model_routing_write(
 
     mode = model_routing_mode_for_write(config, explicit_paths, previous=previous)
     if mode is not None:
-        return apply_model_routing_mode(config, mode)
+        activation_config = (
+            previous
+            if (
+                mode == "ensemble"
+                and previous is not None
+                and "llm_ensemble.selection_mode" not in explicit_paths
+            )
+            else None
+        )
+        return apply_model_routing_mode(
+            config,
+            mode,
+            activation_config=activation_config,
+        )
 
     if (
         "llm_ensemble.selection_mode" not in explicit_paths

--- a/src/opensquilla/gateway/rpc_config.py
+++ b/src/opensquilla/gateway/rpc_config.py
@@ -94,7 +94,32 @@ def _persist_config(config: Any) -> None:
     )
 
 
+_PUBLIC_DERIVED_CONFIG_PATHS = frozenset(
+    {
+        "llm_ensemble.selection_configured",
+        "llm_ensemble.activation_preview",
+        "privacy.network_observability_disabled_effective",
+    }
+)
+
+
+def _is_public_derived_config_path(path: str) -> bool:
+    return any(
+        path == derived or path.startswith(f"{derived}.")
+        for derived in _PUBLIC_DERIVED_CONFIG_PATHS
+    )
+
+
 def _strip_public_derived_config_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    ensemble = payload.get("llm_ensemble")
+    if isinstance(ensemble, dict) and (
+        "selection_configured" in ensemble or "activation_preview" in ensemble
+    ):
+        payload = dict(payload)
+        ensemble = dict(ensemble)
+        ensemble.pop("selection_configured", None)
+        ensemble.pop("activation_preview", None)
+        payload["llm_ensemble"] = ensemble
     privacy = payload.get("privacy")
     if isinstance(privacy, dict) and "network_observability_disabled_effective" in privacy:
         payload = dict(payload)
@@ -552,6 +577,8 @@ _SAFE_WRITE_PATCH_PATHS = frozenset(
         "skills.disabled",
         "skills.coding_mode",
         "llm_ensemble.enabled",
+        "llm_ensemble.selection_mode",
+        "llm_ensemble.candidates",
         "naming.enabled",
         "privacy.disable_network_observability",
         "control_ui.default_locale",
@@ -656,6 +683,25 @@ def _clear_runtime_override_paths(config: Any, paths: set[tuple[str, ...]]) -> N
         config.clear_runtime_override(".".join(path))
 
 
+def _mark_explicit_provider_resolution(config: Any, explicit_paths: set[str]) -> None:
+    """Make an operator-authored provider identity replace inference metadata."""
+
+    if "llm.provider" not in explicit_paths:
+        return
+    marker = getattr(config, "mark_force_persist", None)
+    if callable(marker):
+        marker("llm.provider")
+    setter = getattr(config, "set_provider_resolution", None)
+    if callable(setter):
+        provider = str(getattr(getattr(config, "llm", None), "provider", "") or "")
+        setter(
+            status="explicit",
+            effective_provider=provider,
+            source="operator",
+            reason_code="provider_explicit",
+        )
+
+
 @_d.method("config.set", scope="operator.admin")
 async def _handle_config_set(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     if not isinstance(params, dict) or "path" not in params or "value" not in params:
@@ -685,13 +731,22 @@ async def _handle_config_set(params: dict | None, ctx: RpcContext) -> dict[str, 
         )
     restored_value, redacted_paths = _restore_redacted_values(value, source_value, path)
     _set_path(cfg_dict, path, restored_value)
+    cfg_dict = _strip_public_derived_config_fields(cfg_dict)
 
-    explicit_paths = {path} | _collect_paths(value, path)
-    force_persist_paths = _collect_explicit_leaf_paths(
-        value,
-        tuple(path.split(".")),
-        empty_mapping_is_leaf=True,
-    )
+    explicit_paths = {
+        item
+        for item in ({path} | _collect_paths(value, path))
+        if not _is_public_derived_config_path(item)
+    }
+    force_persist_paths = {
+        item
+        for item in _collect_explicit_leaf_paths(
+            value,
+            tuple(path.split(".")),
+            empty_mapping_is_leaf=True,
+        )
+        if not _is_public_derived_config_path(".".join(item))
+    }
     linked_paths = _link_dream_for_self_learning_patch(ctx.config, cfg_dict, explicit_paths)
     explicit_paths.update(linked_paths)
     force_persist_paths.update(tuple(path.split(".")) for path in linked_paths)
@@ -715,6 +770,7 @@ async def _handle_config_set(params: dict | None, ctx: RpcContext) -> dict[str, 
     # resolution applies env values, so persist can un-bake them.
     if hasattr(new_config, "inherit_persist_provenance"):
         new_config.inherit_persist_provenance(ctx.config)
+    _mark_explicit_provider_resolution(new_config, explicit_paths)
     explicit_force_paths = force_persist_paths - {
         tuple(path.split(".")) for path in redacted_paths
     }
@@ -817,10 +873,19 @@ async def _handle_config_patch(
         cfg_dict = _deep_merge(cfg_dict, patch_data)
         force_persist_paths.update(_collect_explicit_leaf_paths(patch_data))
 
+    cfg_dict = _strip_public_derived_config_fields(cfg_dict)
     explicit_paths = set(dot_patches.keys()) | _collect_paths(patch_data)
     for path, value in dot_patches.items():
         explicit_paths.update(_collect_paths(value, path))
     explicit_paths -= _READONLY_PATHS
+    explicit_paths = {
+        path for path in explicit_paths if not _is_public_derived_config_path(path)
+    }
+    force_persist_paths = {
+        path
+        for path in force_persist_paths
+        if not _is_public_derived_config_path(".".join(path))
+    }
     _align_auto_router_profile_for_provider_patch(ctx.config, cfg_dict, explicit_paths)
     linked_paths = _link_dream_for_self_learning_patch(ctx.config, cfg_dict, explicit_paths)
     explicit_paths.update(linked_paths)
@@ -845,6 +910,7 @@ async def _handle_config_patch(
     # resolution applies env values, so persist can un-bake them.
     if hasattr(new_config, "inherit_persist_provenance"):
         new_config.inherit_persist_provenance(ctx.config)
+    _mark_explicit_provider_resolution(new_config, explicit_paths)
     explicit_force_paths = force_persist_paths - {
         tuple(path.split(".")) for path in redacted_paths
     }
@@ -956,6 +1022,10 @@ async def _handle_config_apply(params: dict | None, ctx: RpcContext) -> dict[str
     # resolution applies env values, so persist can un-bake them.
     if ctx.config is not None and hasattr(new_config, "inherit_persist_provenance"):
         new_config.inherit_persist_provenance(ctx.config)
+    _mark_explicit_provider_resolution(
+        new_config,
+        _collect_paths(config_payload),
+    )
     provider_config = _resolve_provider_selector_config(new_config)
     # Persist the candidate BEFORE mutating the live config: if the write
     # fails, memory and disk stay consistent (both keep the old state).

--- a/src/opensquilla/gateway/rpc_doctor.py
+++ b/src/opensquilla/gateway/rpc_doctor.py
@@ -8,11 +8,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from typing import Any, cast
 
-from opensquilla.gateway.config import (
-    STATIC_B5_SELECTION_MODE_PROVIDERS,
-    GatewayConfig,
-    static_b5_ensemble_enabled,
-)
+from opensquilla.gateway.config import GatewayConfig
 from opensquilla.gateway.rpc import RpcContext, get_dispatcher
 from opensquilla.gateway.rpc_channels import _handle_channels_status
 from opensquilla.gateway.rpc_logs import _build_logs_status
@@ -325,33 +321,33 @@ def _squilla_router_runtime_payload(ctx: RpcContext) -> dict[str, Any]:
 
 def _llm_ensemble_payload(ctx: RpcContext) -> dict[str, Any]:
     config = getattr(ctx, "config", None)
-    ensemble_cfg = getattr(config, "llm_ensemble", None) if config is not None else None
-    payload: dict[str, Any] = {
-        "enabled": bool(getattr(ensemble_cfg, "enabled", False)),
-        "selectionMode": str(getattr(ensemble_cfg, "selection_mode", "") or ""),
-        "activeProvider": str(
-            getattr(getattr(config, "llm", None), "provider", "") or ""
-        ),
+    if config is None:
+        return {
+            "enabled": False,
+            "selectionMode": "",
+            "activeProvider": "",
+            "runtimeStatus": "disabled",
+            "configurationReady": None,
+        }
+
+    from opensquilla.provider.ensemble import ensemble_runtime_status, static_b5_profile
+
+    payload = {
+        **ensemble_runtime_status(config),
+        "activeProvider": str(getattr(config.llm, "provider", "") or ""),
     }
-    if config is not None and static_b5_ensemble_enabled(config):
-        from opensquilla.provider.ensemble import static_b5_credential_available
+    static_profile = static_b5_profile(str(payload["selectionMode"]))
+    if static_profile is not None and payload["enabled"]:
         from opensquilla.provider.registry import get_provider_spec
 
-        selection_mode = str(getattr(ensemble_cfg, "selection_mode", "") or "")
-        member_provider = STATIC_B5_SELECTION_MODE_PROVIDERS.get(selection_mode, "openrouter")
-        payload["memberProvider"] = member_provider
-        payload["apiKeyEnv"] = str(get_provider_spec(member_provider).env_key or "")
-        payload["credentialAvailable"] = static_b5_credential_available(
-            config,
-            getattr(config, "llm", None),
-            selection_mode,
+        payload["memberProvider"] = static_profile.provider_id
+        payload["apiKeyEnv"] = str(
+            get_provider_spec(static_profile.provider_id).env_key or ""
         )
+        payload["credentialAvailable"] = bool(payload["configurationReady"])
     elif payload["enabled"] and payload["selectionMode"] == "custom_b5":
-        from opensquilla.provider.ensemble import custom_b5_lineup_ready
-
-        ready, reason = custom_b5_lineup_ready(config)
-        payload["lineupReady"] = ready
-        payload["lineupBlockedReason"] = reason
+        payload["lineupReady"] = bool(payload["configurationReady"])
+        payload["lineupBlockedReason"] = str(payload["blockedReason"] or "")
     return payload
 
 
@@ -416,6 +412,7 @@ async def _handle_doctor_status(params: dict | None, ctx: RpcContext) -> dict[st
     params = params or {}
     agent_id = normalize_agent_id(str(params.get("agentId") or "main"))
     deep = bool(params.get("deep", True))
+    probe_providers = bool(params.get("probeProviders", False))
 
     findings: list[HealthFinding] = [
         HealthFinding(
@@ -431,7 +428,10 @@ async def _handle_doctor_status(params: dict | None, ctx: RpcContext) -> dict[st
     collectors: list[tuple[str, Collector, Evaluator]] = [
         (
             "provider",
-            lambda: _handle_providers_status({"probeModels": False}, ctx),
+            lambda: _handle_providers_status(
+                {"probeModels": probe_providers},
+                ctx,
+            ),
             evaluate_provider,
         ),
         ("logs", lambda: _build_logs_status(ctx), evaluate_logs),

--- a/src/opensquilla/gateway/rpc_tools.py
+++ b/src/opensquilla/gateway/rpc_tools.py
@@ -7,6 +7,7 @@ import re
 from typing import Any
 
 from opensquilla.gateway.rpc import RpcContext, get_dispatcher
+from opensquilla.redaction import redact_error_text
 from opensquilla.sandbox.integration import run_in_process_network_action
 from opensquilla.sandbox.types import DenialResult
 from opensquilla.tools.builtin.web import (
@@ -174,15 +175,52 @@ async def _model_probe(provider_id: str, ctx: RpcContext) -> dict[str, Any]:
             "error": "No provider selector configured",
         }
     try:
-        rows = await selector.list_models()
+        detailed_listing = getattr(selector, "list_models_detailed", None)
+        if callable(detailed_listing):
+            detailed = await detailed_listing()
+            rows = list(getattr(detailed, "models", []) or [])
+            matching_errors = [
+                error
+                for error in list(getattr(detailed, "errors", []) or [])
+                if str(getattr(error, "provider", "") or "").strip().lower()
+                == provider_id.strip().lower()
+            ]
+        else:
+            rows = await selector.list_models()
+            matching_errors = []
         matching = [
             row
             for row in rows
-            if isinstance(row, dict) and str(row.get("provider") or "") == provider_id
+            if isinstance(row, dict)
+            and str(row.get("provider") or "").strip().lower()
+            == provider_id.strip().lower()
         ]
-        return {"attempted": True, "status": "ok", "count": len(matching), "error": None}
+        if matching_errors:
+            first = matching_errors[0]
+            detail = redact_error_text(str(getattr(first, "detail", "") or ""))
+            failure_kind = str(getattr(first, "kind", "") or "unknown")
+            return {
+                "attempted": True,
+                "status": "degraded" if matching else "error",
+                "count": len(matching),
+                "error": detail or failure_kind,
+                "failureKind": failure_kind,
+            }
+        return {
+            "attempted": True,
+            "status": "ok",
+            "count": len(matching),
+            "error": None,
+            "failureKind": None,
+        }
     except Exception as exc:  # noqa: BLE001 - diagnostic surface
-        return {"attempted": True, "status": "error", "count": 0, "error": str(exc)}
+        return {
+            "attempted": True,
+            "status": "error",
+            "count": 0,
+            "error": redact_error_text(str(exc)),
+            "failureKind": "unknown",
+        }
 
 
 @_d.method("providers.status", scope="operator.read")
@@ -205,6 +243,9 @@ async def _handle_providers_status(params: dict | None, ctx: RpcContext) -> dict
 
     active = _active_llm_provider(ctx)
     llm_cfg = getattr(getattr(ctx, "config", None), "llm", None)
+    resolution_getter = getattr(getattr(ctx, "config", None), "provider_resolution", None)
+    resolution = resolution_getter() if callable(resolution_getter) else {}
+    provider_resolution_blocked = bool(resolution.get("action_required", False))
     rows: list[dict[str, Any]] = []
     for spec in specs:
         is_active = spec.provider_id == active
@@ -212,35 +253,97 @@ async def _handle_providers_status(params: dict | None, ctx: RpcContext) -> dict
         api_key_configured = _provider_key_configured(spec.provider_id, api_key_env, ctx)
         api_key_shape = _provider_api_key_shape(spec.provider_id, api_key_env, ctx)
         base_url = _provider_base_url(spec.provider_id, spec.default_base_url, ctx)
+        if is_active:
+            from opensquilla.provider.credentials import (
+                credential_provider_hint,
+                endpoint_provider_hint,
+            )
+
+            credential_hint = credential_provider_hint(
+                _provider_key_material(spec.provider_id, api_key_env, ctx),
+                api_key_env=api_key_env,
+            )
+            endpoint_hint = endpoint_provider_hint(base_url)
+            mismatch_reason = ""
+            mismatch_source = ""
+            if credential_hint and credential_hint != spec.provider_id:
+                mismatch_reason = "credential_provider_mismatch"
+                mismatch_source = "credential_shape"
+            elif (
+                credential_hint
+                and endpoint_hint
+                and credential_hint != endpoint_hint
+            ):
+                mismatch_reason = "credential_endpoint_provider_mismatch"
+                mismatch_source = "credential_endpoint"
+            if mismatch_reason:
+                provider_resolution_blocked = True
+                if not bool(resolution.get("action_required", False)):
+                    resolution = {
+                        "status": "conflict",
+                        "effective_provider": spec.provider_id,
+                        "source": mismatch_source,
+                        "reason_code": mismatch_reason,
+                        "action_required": True,
+                        "action_recommended": True,
+                    }
         base_url_configured = bool(base_url)
         configured = (
             spec.runtime_supported
             and (not spec.requires_api_key or api_key_configured)
             and (not spec.requires_base_url or base_url_configured)
         )
+        if is_active and provider_resolution_blocked:
+            configured = False
         model = str(getattr(llm_cfg, "model", "") or "") if is_active else ""
         api_key = str(getattr(llm_cfg, "api_key", "") or "") if is_active else ""
         if is_active and not api_key and api_key_env:
             api_key = os.environ.get(api_key_env, "")
         error: str | None = None
         buildable = False
-        try:
-            build_provider(
-                spec.provider_id,
-                model or "diagnostic-model",
-                api_key=api_key,
-                base_url=base_url,
+        if is_active and provider_resolution_blocked:
+            error = str(
+                resolution.get("reason_code") or "provider_resolution_blocked"
             )
-            buildable = True
-        except ProviderBuildError as exc:
-            error = str(exc)
-        except Exception as exc:  # noqa: BLE001 - diagnostic surface
-            error = str(exc)
-        probe = (
-            await _model_probe(spec.provider_id, ctx)
-            if probe_models and is_active
-            else {"attempted": False, "status": "skipped", "count": 0, "error": None}
-        )
+        else:
+            try:
+                build_provider(
+                    spec.provider_id,
+                    model or "diagnostic-model",
+                    api_key=api_key,
+                    base_url=base_url,
+                )
+                buildable = True
+            except ProviderBuildError as exc:
+                error = str(exc)
+            except Exception as exc:  # noqa: BLE001 - diagnostic surface
+                error = str(exc)
+        if probe_models and is_active and provider_resolution_blocked:
+            probe = {
+                "attempted": False,
+                "status": "unavailable",
+                "count": 0,
+                "error": str(
+                    resolution.get("reason_code")
+                    or "provider_resolution_blocked"
+                ),
+                "failureKind": str(
+                    resolution.get("reason_code")
+                    or "provider_resolution_blocked"
+                ),
+            }
+        else:
+            probe = (
+                await _model_probe(spec.provider_id, ctx)
+                if probe_models and is_active
+                else {
+                    "attempted": False,
+                    "status": "skipped",
+                    "count": 0,
+                    "error": None,
+                    "failureKind": None,
+                }
+            )
         rows.append(
             {
                 "providerId": spec.provider_id,
@@ -262,7 +365,23 @@ async def _handle_providers_status(params: dict | None, ctx: RpcContext) -> dict
                 ),
             }
         )
-    return {"activeProvider": active, "providers": rows, "count": len(rows)}
+    effective_provider = resolution.get("effective_provider")
+    provider_resolution = {
+        "status": str(resolution.get("status") or "explicit"),
+        "effectiveProvider": str(
+            active if effective_provider is None else effective_provider
+        ),
+        "source": str(resolution.get("source") or "config"),
+        "reasonCode": str(resolution.get("reason_code") or "provider_explicit"),
+        "actionRequired": bool(resolution.get("action_required", False)),
+        "actionRecommended": bool(resolution.get("action_recommended", False)),
+    }
+    return {
+        "activeProvider": active,
+        "providerResolution": provider_resolution,
+        "providers": rows,
+        "count": len(rows),
+    }
 
 
 @_d.method("search.status", scope="operator.read")

--- a/src/opensquilla/health/evaluator.py
+++ b/src/opensquilla/health/evaluator.py
@@ -350,16 +350,60 @@ def evaluate_provider(payload: dict[str, Any]) -> list[HealthFinding]:
                 )
             )
         else:
-            findings.append(
-                HealthFinding(
-                    id="provider.active.ready",
-                    severity="ok",
-                    surface="provider",
-                    title="Active provider ready",
-                    detail=f"{provider_id} is configured and buildable.",
-                    evidence={"providerId": provider_id, "model": active_row.get("model")},
+            probe = active_row.get("modelProbe")
+            attempted = isinstance(probe, dict) and bool(probe.get("attempted"))
+            probe_status = str(probe.get("status") or "") if isinstance(probe, dict) else ""
+            if attempted and probe_status in {"error", "degraded"}:
+                failure_kind = str(probe.get("failureKind") or "unknown")
+                blocking = failure_kind in {"auth_invalid", "insufficient_credits"}
+                findings.append(
+                    HealthFinding(
+                        id=f"provider.active.probe.{failure_kind}",
+                        severity="error" if blocking else "warn",
+                        readiness_impact="blocks_ready" if blocking else "degrades",
+                        surface="provider",
+                        title="Active provider probe failed",
+                        detail=str(
+                            probe.get("error")
+                            or "The provider model-list probe did not succeed."
+                        ),
+                        evidence={
+                            "providerId": provider_id,
+                            "failureKind": failure_kind,
+                            "probeStatus": probe_status,
+                        },
+                        fix_steps=[
+                            FixStep(
+                                label="Inspect provider probe",
+                                command=(
+                                    "opensquilla providers status "
+                                    f"{provider_id} --probe-models"
+                                ),
+                            ),
+                            FixStep(
+                                label="Reconfigure provider",
+                                command=(
+                                    "opensquilla providers configure "
+                                    f"{provider_id} --api-key {_API_KEY_PLACEHOLDER}"
+                                ),
+                            ),
+                        ],
+                    )
                 )
-            )
+            else:
+                findings.append(
+                    HealthFinding(
+                        id="provider.active.ready",
+                        severity="ok",
+                        surface="provider",
+                        title="Active provider ready",
+                        detail=f"{provider_id} is configured and buildable.",
+                        evidence={
+                            "providerId": provider_id,
+                            "model": active_row.get("model"),
+                        },
+                    )
+                )
     return findings
 
 

--- a/src/opensquilla/onboarding/config_store.py
+++ b/src/opensquilla/onboarding/config_store.py
@@ -496,7 +496,9 @@ def restore_runtime_overrides(dump: dict[str, Any], config: GatewayConfig) -> No
     ``llm.proxy``) directly into the live model at boot. Those values must
     never be baked into config.toml by an unrelated save, so each recorded
     override is restored to its stored value — but only while the field
-    still equals the applied env value; an operator edit since boot wins.
+    still equals the applied env value. A missing serialized field also
+    represents an applied empty string because the TOML payload drops empty
+    values; an operator edit since boot still wins.
     Shared by the sparse persister here and the gateway RPC full-dump
     persist (``rpc_config._persist_config``).
     """
@@ -504,7 +506,10 @@ def restore_runtime_overrides(dump: dict[str, Any], config: GatewayConfig) -> No
     if overrides is None:
         return
     for path, (stored, applied) in overrides().items():
-        if _get_dotted(dump, path) == applied:
+        current = _get_dotted(dump, path)
+        if current == applied or (
+            current is None and applied == "" and stored not in (None, "")
+        ):
             _set_dotted(dump, path, stored)
 
 

--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -28,6 +28,7 @@ from opensquilla.gateway.config_secrets import (
 )
 from opensquilla.gateway.model_routing import (
     apply_model_routing_mode,
+    ensemble_activation_patches,
     reconcile_model_routing_write,
 )
 from opensquilla.onboarding.audio_specs import get_audio_provider_setup_spec
@@ -825,6 +826,19 @@ def upsert_llm_provider(
         }
     )
     new_cfg.llm = LlmProviderConfig(**llm_payload)
+    # ``provider_id`` is a required argument on this mutation, so it is an
+    # explicit operator identity decision even when it equals the built-in
+    # default. Sparse persistence must not erase that provenance: a
+    # provider-less file carrying only a key is intentionally interpreted as
+    # legacy OpenRouter on reload.
+    new_cfg.mark_force_persist("llm.provider")
+    new_cfg.clear_runtime_override("llm.api_key")
+    new_cfg.set_provider_resolution(
+        status="explicit",
+        effective_provider=provider_id,
+        source="operator",
+        reason_code="provider_explicit",
+    )
     _apply_primary_provider_router_policy(
         config,
         new_cfg,
@@ -1120,9 +1134,14 @@ def upsert_llm_ensemble(
     """
     current = config.llm_ensemble.model_dump(mode="python")
     merged = dict(current)
+    explicit_fields = set(
+        getattr(config.llm_ensemble, "model_fields_set", set())
+    )
+    generated_fields: set[str] = set()
 
     if enabled is not None:
         merged["enabled"] = bool(enabled)
+        explicit_fields.add("enabled")
     if selection_mode is not None:
         mode_clean = str(selection_mode).strip()
         if mode_clean not in _LLM_ENSEMBLE_SELECTION_MODES:
@@ -1131,10 +1150,12 @@ def upsert_llm_ensemble(
                 + ", ".join(_LLM_ENSEMBLE_SELECTION_MODES)
             )
         merged["selection_mode"] = mode_clean
+        explicit_fields.add("selection_mode")
     if model_options is not None:
         if not isinstance(model_options, (list, tuple)):
             raise ValueError("model_options must be a list of model ids")
         merged["model_options"] = [str(option) for option in model_options]
+        explicit_fields.add("model_options")
     if candidates is not None:
         if not isinstance(candidates, (list, tuple)):
             raise ValueError("candidates must be a list of candidate objects")
@@ -1169,10 +1190,12 @@ def upsert_llm_ensemble(
                 merged_row = incoming
             candidate_payloads.append(merged_row)
         merged["candidates"] = candidate_payloads
+        explicit_fields.add("candidates")
     if min_successful_proposers is not None:
         merged["min_successful_proposers"] = _positive_int(
             min_successful_proposers, label="min_successful_proposers"
         )
+        explicit_fields.add("min_successful_proposers")
     if all_failed_policy is not None:
         policy_clean = str(all_failed_policy).strip()
         if policy_clean not in _LLM_ENSEMBLE_ALL_FAILED_POLICIES:
@@ -1181,6 +1204,19 @@ def upsert_llm_ensemble(
                 + ", ".join(_LLM_ENSEMBLE_ALL_FAILED_POLICIES)
             )
         merged["all_failed_policy"] = policy_clean
+        explicit_fields.add("all_failed_policy")
+
+    if (
+        enabled is True
+        and not bool(current.get("enabled", False))
+        and selection_mode is None
+    ):
+        activation = ensemble_activation_patches(config)
+        if activation:
+            merged["selection_mode"] = activation["llm_ensemble.selection_mode"]
+            merged["candidates"] = activation["llm_ensemble.candidates"]
+            generated_fields.update({"selection_mode", "candidates"})
+            explicit_fields.update(generated_fields)
 
     try:
         new_ensemble = LlmEnsembleConfig(**merged)
@@ -1188,6 +1224,11 @@ def upsert_llm_ensemble(
         raise ValueError(str(exc)) from exc
 
     new_cfg = _clone(config)
+    object.__setattr__(
+        new_ensemble,
+        "__pydantic_fields_set__",
+        explicit_fields,
+    )
     new_cfg.llm_ensemble = new_ensemble
     routing_changes: dict[str, Any] = {}
     enabled_changed = enabled is not None and bool(enabled) != bool(
@@ -1216,6 +1257,10 @@ def upsert_llm_ensemble(
         # `configure ensemble --disabled` on a fresh config persists nothing
         # and is indistinguishable from a silent no-op.
         new_cfg.mark_force_persist("llm_ensemble.enabled")
+    if selection_mode is not None or "selection_mode" in generated_fields:
+        new_cfg.mark_force_persist("llm_ensemble.selection_mode")
+    if candidates is not None or "candidates" in generated_fields:
+        new_cfg.mark_force_persist("llm_ensemble.candidates")
 
     payload: dict[str, Any] = {
         "enabled": new_ensemble.enabled,

--- a/src/opensquilla/onboarding/section_status.py
+++ b/src/opensquilla/onboarding/section_status.py
@@ -92,6 +92,10 @@ def llm_section_status(cfg: GatewayConfig) -> SectionStatus:
     missing or undecidable LLM always blocks onboarding.
     """
     llm = cfg.llm
+    resolution_getter = getattr(cfg, "provider_resolution", None)
+    resolution = resolution_getter() if callable(resolution_getter) else {}
+    if bool(resolution.get("action_required", False)):
+        return SectionStatus.DEGRADED
     if not _str(llm, "provider") or not _str(llm, "model"):
         return SectionStatus.MISSING
     try:

--- a/src/opensquilla/onboarding/status.py
+++ b/src/opensquilla/onboarding/status.py
@@ -161,12 +161,23 @@ def _router_detail(cfg: GatewayConfig, llm_source: str) -> str:
 
 
 def _ensemble_detail(cfg: GatewayConfig) -> str:
-    ensemble = getattr(cfg, "llm_ensemble", None)
-    if ensemble is None or not bool(getattr(ensemble, "enabled", False)):
+    from opensquilla.provider.ensemble import ensemble_runtime_status
+
+    runtime = ensemble_runtime_status(cfg)
+    if not runtime["enabled"]:
         return "disabled"
-    mode = str(getattr(ensemble, "selection_mode", "") or "")
-    options = list(getattr(ensemble, "model_options", []) or [])
-    return f"selection mode: {mode} ({len(options)} models)"
+    mode = str(runtime["selectionMode"])
+    proposer_count = runtime.get("proposerCount")
+    if proposer_count is None:
+        proposer_range = runtime.get("proposerCountRange") or []
+        count_text = (
+            f"{proposer_range[0]}-{proposer_range[1]} proposers"
+            if len(proposer_range) == 2
+            else "dynamic proposers"
+        )
+    else:
+        count_text = f"{proposer_count} proposers"
+    return f"selection mode: {mode} ({count_text})"
 
 
 def _candidate_field(candidate: object, field_name: str) -> object:
@@ -1041,6 +1052,46 @@ def get_onboarding_status(
         section_details["router"]["routerProviderConflicts"] = list(
             _router_provider_conflicts(config)
         )
+    if "ensemble" in section_details:
+        from opensquilla.provider.ensemble import ensemble_runtime_status
+
+        section_details["ensemble"].update(ensemble_runtime_status(config))
+    resolution_getter = getattr(config, "provider_resolution", None)
+    provider_resolution = (
+        resolution_getter() if callable(resolution_getter) else {}
+    )
+    if "llm" in section_details and provider_resolution:
+        effective_provider = provider_resolution.get("effective_provider")
+        section_details["llm"]["providerResolution"] = {
+            "status": str(provider_resolution.get("status") or "explicit"),
+            "effectiveProvider": str(
+                getattr(config.llm, "provider", "")
+                if effective_provider is None
+                else effective_provider
+            ),
+            "source": str(provider_resolution.get("source") or "config"),
+            "reasonCode": str(
+                provider_resolution.get("reason_code") or "provider_explicit"
+            ),
+            "actionRequired": bool(
+                provider_resolution.get("action_required", False)
+            ),
+            "actionRecommended": bool(
+                provider_resolution.get("action_recommended", False)
+            ),
+        }
+
+    warnings: tuple[str, ...] = ()
+    if bool(provider_resolution.get("action_required", False)):
+        warnings = (
+            "Provider evidence conflicts; choose and save the intended provider "
+            "before sending model requests.",
+        )
+    elif bool(provider_resolution.get("action_recommended", False)):
+        warnings = (
+            "Provider was inferred for compatibility; save the intended provider "
+            "to make the identity explicit.",
+        )
 
     llm_profile_status = _llm_profile_status(config, probe_history=probe_history)
     return OnboardingStatus(
@@ -1079,6 +1130,7 @@ def get_onboarding_status(
         ),
         sections=sections,
         section_details=section_details,
+        warnings=warnings,
     )
 
 

--- a/src/opensquilla/provider/credentials.py
+++ b/src/opensquilla/provider/credentials.py
@@ -2,10 +2,52 @@
 
 from __future__ import annotations
 
+import re
 import threading
 import time
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+from urllib.parse import urlparse
+
+_TOKENRHYTHM_KEY_RE = re.compile(r"^sk_tr_[A-Za-z0-9_-]{16,}$")
+_OPENROUTER_KEY_RE = re.compile(r"^sk-or-v1-[A-Za-z0-9_-]{16,}$")
+
+
+def credential_provider_hint(
+    api_key: object = "",
+    *,
+    api_key_env: object = "",
+) -> str:
+    """Return a provider id only for globally distinctive credential evidence."""
+
+    key = str(api_key or "").strip()
+    if _TOKENRHYTHM_KEY_RE.fullmatch(key):
+        return "tokenrhythm"
+    if _OPENROUTER_KEY_RE.fullmatch(key):
+        return "openrouter"
+    env_name = str(api_key_env or "").strip().upper()
+    if env_name == "TOKENRHYTHM_API_KEY":
+        return "tokenrhythm"
+    if env_name == "OPENROUTER_API_KEY":
+        return "openrouter"
+    return ""
+
+
+def endpoint_provider_hint(base_url: object = "") -> str:
+    """Return a provider id only for another provider's distinctive official host."""
+
+    value = str(base_url or "").strip()
+    if not value:
+        return ""
+    try:
+        hostname = str(urlparse(value).hostname or "").strip().lower()
+    except ValueError:
+        return ""
+    if hostname == "tokenrhythm.studio":
+        return "tokenrhythm"
+    if hostname == "openrouter.ai":
+        return "openrouter"
+    return ""
 
 
 class NoCredentialsAvailable(RuntimeError):  # noqa: N818 - public compatibility name

--- a/src/opensquilla/provider/deployment.py
+++ b/src/opensquilla/provider/deployment.py
@@ -21,6 +21,7 @@ import structlog
 
 from opensquilla.endpoint_identity import base_url_allows_credential_reuse
 
+from .credentials import credential_provider_hint, endpoint_provider_hint
 from .environment import environment_value
 from .registry import UnknownProviderError, get_provider_spec
 from .selector import ProviderConfig
@@ -242,6 +243,17 @@ def resolve_provider_deployment(
         blocked_reason = "missing_credential"
     if not spec.requires_api_key() and not api_key:
         credential_source = "keyless"
+    credential_hint = credential_provider_hint(api_key)
+    if api_key and credential_hint and credential_hint != provider:
+        # Keep a known cross-provider credential out of every downstream
+        # ProviderConfig, including status/readiness callers that might
+        # otherwise accidentally reuse an unready resolution.
+        api_key = ""
+        credential_source = "none"
+        credential_env = ""
+        blocked_reason = "credential_provider_mismatch"
+        if turn_metadata is not None:
+            turn_metadata.pop("credential_pool", None)
 
     base_url = member_base_url
     endpoint_source = "member" if base_url else "none"
@@ -257,6 +269,19 @@ def resolve_provider_deployment(
         base_url = _text(spec.default_base_url)
         if base_url:
             endpoint_source = "registry"
+    endpoint_hint = endpoint_provider_hint(base_url)
+    if (
+        api_key
+        and credential_hint
+        and endpoint_hint
+        and credential_hint != endpoint_hint
+    ):
+        api_key = ""
+        credential_source = "none"
+        credential_env = ""
+        blocked_reason = "credential_endpoint_provider_mismatch"
+        if turn_metadata is not None:
+            turn_metadata.pop("credential_pool", None)
     if not base_url and spec.requires_base_url() and not blocked_reason:
         blocked_reason = "missing_base_url"
     if (

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -3335,7 +3335,9 @@ def custom_b5_lineup_ready(
         proxy=str(getattr(inherited, "proxy", "") or ""),
     )
     rows = _custom_b5_candidates(config)
-    if not [row for row in rows if row.role != "aggregator"]:
+    proposer_rows = [row for row in rows if row.role != "aggregator"]
+    aggregator_rows = [row for row in rows if row.role == "aggregator"]
+    if not proposer_rows:
         return False, "no_proposers"
     for row in rows:
         resolution = resolve_provider_deployment(
@@ -3352,6 +3354,21 @@ def custom_b5_lineup_ready(
         )
         if not resolution.ready:
             return False, f"{resolution.reason}:{row.provider}"
+    if not aggregator_rows:
+        aggregator_resolution = resolve_provider_deployment(
+            config,
+            inherited_cfg.provider,
+            inherited_cfg.model,
+            inherited_provider_config=inherited_cfg,
+            replay_provider_state=True,
+            credential_pool_acquirer=credential_pool_acquirer,
+            session_key=session_key,
+        )
+        if not aggregator_resolution.ready:
+            return (
+                False,
+                f"{aggregator_resolution.reason}:{inherited_cfg.provider}",
+            )
     return True, ""
 
 
@@ -3430,6 +3447,103 @@ def static_b5_credential_available(
         ).ready
         for model in member_models
     )
+
+
+def ensemble_runtime_status(config: Any) -> dict[str, Any]:
+    """Return a shared, local-only projection of Ensemble executability."""
+
+    ensemble = getattr(config, "llm_ensemble", None)
+    enabled = bool(getattr(ensemble, "enabled", False))
+    selection_mode = str(getattr(ensemble, "selection_mode", "") or "")
+    base: dict[str, Any] = {
+        "enabled": enabled,
+        "selectionMode": selection_mode,
+        "runtimeStatus": "disabled",
+        "configurationReady": None,
+        "blockedReason": None,
+        "proposerCount": 0,
+        "proposerCountRange": None,
+        "aggregatorCount": 0,
+        "perTurnCallCount": 0,
+        "perTurnCallCountRange": None,
+        "memberProviders": [],
+    }
+    if not enabled:
+        return base
+
+    static_profile = static_b5_profile(selection_mode)
+    if static_profile is not None:
+        ready = static_b5_credential_available(
+            config,
+            getattr(config, "llm", None),
+            selection_mode,
+        )
+        proposer_count = len(static_profile.proposer_models)
+        return {
+            **base,
+            "runtimeStatus": "ready" if ready else "blocked",
+            "configurationReady": ready,
+            "blockedReason": None if ready else "credential_missing",
+            "proposerCount": proposer_count,
+            "aggregatorCount": 1,
+            "perTurnCallCount": proposer_count + 1,
+            "memberProviders": [static_profile.provider_id],
+        }
+
+    if selection_mode == CUSTOM_B5_SELECTION_MODE:
+        rows = _custom_b5_candidates(config)
+        proposers = [row for row in rows if row.role != "aggregator"]
+        aggregators = [row for row in rows if row.role == "aggregator"]
+        ready, reason = custom_b5_lineup_ready(config)
+        providers = {row.provider for row in rows if row.provider}
+        if not aggregators:
+            inherited_provider = str(
+                getattr(getattr(config, "llm", None), "provider", "") or ""
+            ).strip().lower()
+            if inherited_provider:
+                providers.add(inherited_provider)
+        return {
+            **base,
+            "runtimeStatus": "ready" if ready else "blocked",
+            "configurationReady": ready,
+            "blockedReason": None if ready else reason,
+            "proposerCount": len(proposers),
+            "aggregatorCount": 1,
+            "perTurnCallCount": len(proposers) + 1,
+            "memberProviders": sorted(providers),
+        }
+
+    if selection_mode == "router_dynamic":
+        tiers = getattr(getattr(config, "squilla_router", None), "tiers", {}) or {}
+        providers = {
+            str((tier or {}).get("provider") or "").strip().lower()
+            for tier in tiers.values()
+            if isinstance(tier, dict)
+        }
+        providers.discard("")
+        inherited_provider = str(
+            getattr(getattr(config, "llm", None), "provider", "") or ""
+        ).strip().lower()
+        if inherited_provider:
+            providers.add(inherited_provider)
+        return {
+            **base,
+            "runtimeStatus": "conditional",
+            "configurationReady": None,
+            "proposerCount": None,
+            "proposerCountRange": [2, 4],
+            "aggregatorCount": 1,
+            "perTurnCallCount": None,
+            "perTurnCallCountRange": [3, 5],
+            "memberProviders": sorted(providers),
+        }
+
+    return {
+        **base,
+        "runtimeStatus": "blocked",
+        "configurationReady": False,
+        "blockedReason": "unknown_selection_mode",
+    }
 
 
 def _member_from_ref(

--- a/src/opensquilla/provider/selector.py
+++ b/src/opensquilla/provider/selector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field, replace
 
@@ -9,6 +10,7 @@ from opensquilla.redaction import redact_error_text
 
 from .anthropic import AnthropicProvider
 from .compat_policy import OpenAICompatPolicy
+from .credentials import credential_provider_hint, endpoint_provider_hint
 from .failures import classify_provider_error
 from .ollama import OllamaProvider
 from .openai import OpenAIProvider
@@ -76,6 +78,19 @@ class ModelListResult:
 
     models: list[dict] = field(default_factory=list)
     errors: list[ProviderListError] = field(default_factory=list)
+
+
+async def _list_provider_models_detailed(provider: LLMProvider) -> list:
+    """Ask adapters to surface listing failures when they expose that capability."""
+
+    list_models = provider.list_models
+    try:
+        supports_strict = "raise_on_error" in inspect.signature(list_models).parameters
+    except (TypeError, ValueError):
+        supports_strict = False
+    if supports_strict:
+        return await list_models(raise_on_error=True)  # type: ignore[call-arg]
+    return await list_models()
 
 
 class ProviderBuildError(Exception):
@@ -150,6 +165,19 @@ def _without_provider_state_replay(cfg: ProviderConfig) -> ProviderConfig:
 
 def _build_provider(cfg: ProviderConfig) -> LLMProvider:
     """Instantiate the correct provider class from a ProviderConfig."""
+    provider_id = str(cfg.provider or "").strip().lower()
+    credential_hint = credential_provider_hint(cfg.api_key)
+    if credential_hint and credential_hint != provider_id:
+        raise ProviderBuildError(
+            f"Credential format belongs to provider '{credential_hint}', "
+            f"not configured provider '{provider_id or '(unset)'}'"
+        )
+    endpoint_hint = endpoint_provider_hint(cfg.base_url)
+    if credential_hint and endpoint_hint and credential_hint != endpoint_hint:
+        raise ProviderBuildError(
+            f"Credential format belongs to provider '{credential_hint}', "
+            f"but the configured endpoint belongs to provider '{endpoint_hint}'"
+        )
     try:
         spec = get_provider_spec(cfg.provider)
     except UnknownProviderError as exc:
@@ -631,7 +659,7 @@ class ModelSelector:
         for cfg in self._chain:
             try:
                 provider = _build_provider(cfg)
-                provider_models = await provider.list_models()
+                provider_models = await _list_provider_models_detailed(provider)
                 result.models.extend(m.model_dump() for m in provider_models)
             except Exception as exc:
                 result.errors.append(

--- a/tests/test_cli/test_cli_product_completeness.py
+++ b/tests/test_cli/test_cli_product_completeness.py
@@ -1352,4 +1352,7 @@ def test_doctor_json_uses_gateway_doctor_rpc(monkeypatch):
 
     assert result.exit_code == 0, result.stdout
     assert json.loads(result.stdout)["ready"] is True
-    assert ("doctor.status", {"agentId": "main", "deep": True}) in fake.calls
+    assert (
+        "doctor.status",
+        {"agentId": "main", "deep": True, "probeProviders": False},
+    ) in fake.calls

--- a/tests/test_cli/test_doctor_cmd.py
+++ b/tests/test_cli/test_doctor_cmd.py
@@ -110,7 +110,10 @@ def test_doctor_json_calls_doctor_status(monkeypatch) -> None:
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
     assert payload["status"] == "action_required"
-    assert ("doctor.status", {"agentId": "main", "deep": True}) in _FakeGatewayClient.calls
+    assert (
+        "doctor.status",
+        {"agentId": "main", "deep": True, "probeProviders": False},
+    ) in _FakeGatewayClient.calls
 
 
 def test_doctor_quick_skips_deep_memory_diagnostics(monkeypatch) -> None:
@@ -120,7 +123,10 @@ def test_doctor_quick_skips_deep_memory_diagnostics(monkeypatch) -> None:
     result = runner.invoke(app, ["doctor", "--quick", "--json"])
 
     assert result.exit_code == 1
-    assert ("doctor.status", {"agentId": "main", "deep": False}) in _FakeGatewayClient.calls
+    assert (
+        "doctor.status",
+        {"agentId": "main", "deep": False, "probeProviders": False},
+    ) in _FakeGatewayClient.calls
 
 
 def test_doctor_config_targets_gateway_from_config_path(tmp_path, monkeypatch) -> None:
@@ -133,7 +139,23 @@ def test_doctor_config_targets_gateway_from_config_path(tmp_path, monkeypatch) -
 
     assert result.exit_code == 1
     assert ("connect", "ws://127.0.0.1:20002/ws") in _FakeGatewayClient.calls
-    assert ("doctor.status", {"agentId": "main", "deep": True}) in _FakeGatewayClient.calls
+    assert (
+        "doctor.status",
+        {"agentId": "main", "deep": True, "probeProviders": False},
+    ) in _FakeGatewayClient.calls
+
+
+def test_doctor_provider_probe_is_explicit_opt_in(monkeypatch) -> None:
+    _FakeGatewayClient.calls = []
+    monkeypatch.setattr("opensquilla.cli.gateway_client.GatewayClient", _FakeGatewayClient)
+
+    result = runner.invoke(app, ["doctor", "--probe-providers", "--json"])
+
+    assert result.exit_code == 1
+    assert (
+        "doctor.status",
+        {"agentId": "main", "deep": True, "probeProviders": True},
+    ) in _FakeGatewayClient.calls
 
 
 def test_doctor_config_derived_gateway_recovery_preserves_config_target(

--- a/tests/test_cli/test_providers_cmd.py
+++ b/tests/test_cli/test_providers_cmd.py
@@ -95,3 +95,34 @@ def test_providers_configure_vllm_requires_base_url(tmp_path, monkeypatch):
         ],
     )
     assert result.exit_code == 0
+
+
+def test_providers_status_probe_column_surfaces_failure_kind(monkeypatch):
+    monkeypatch.setattr(
+        "opensquilla.cli.providers_cmd.run_gateway_sync",
+        lambda *_args, **_kwargs: {
+            "providers": [
+                {
+                    "providerId": "openrouter",
+                    "active": True,
+                    "configured": True,
+                    "buildable": True,
+                    "model": "openrouter/model",
+                    "error": "",
+                    "modelProbe": {
+                        "status": "error",
+                        "count": 0,
+                        "failureKind": "auth_invalid",
+                        "error": "HTTP 401 invalid credential",
+                    },
+                }
+            ]
+        },
+    )
+
+    result = runner.invoke(app, ["providers", "status", "--probe-models"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "probe" in result.stdout
+    assert "auth_invalid" in result.stdout
+    assert "HTTP 401" in result.stdout

--- a/tests/test_contracts/test_onboarding_status.py
+++ b/tests/test_contracts/test_onboarding_status.py
@@ -102,9 +102,25 @@ SECTION_DETAIL_REQUIRED_KEYS = frozenset(
 # inferring the mode from (provider, tier_profile) pairs. Adding to this map is
 # the conscious decision the friction forces.
 SECTION_EXTRA_KEYS = {
+    "llm": frozenset({"providerResolution"}),
     "router": frozenset(
         {"routerMode", "routerBinding", "routerProviderConflicts"}
-    )
+    ),
+    "ensemble": frozenset(
+        {
+            "enabled",
+            "selectionMode",
+            "runtimeStatus",
+            "configurationReady",
+            "blockedReason",
+            "proposerCount",
+            "proposerCountRange",
+            "aggregatorCount",
+            "perTurnCallCount",
+            "perTurnCallCountRange",
+            "memberProviders",
+        }
+    ),
 }
 
 # Every mode value the router card may carry; matched verbatim by clients.

--- a/tests/test_cross_provider_tiers.py
+++ b/tests/test_cross_provider_tiers.py
@@ -114,6 +114,43 @@ def test_unresolvable_credentials_return_none(monkeypatch) -> None:
     assert resolve_tier_provider_config(cfg, "no-such-provider", "m") is None
 
 
+def test_shared_deployment_blocks_known_cross_provider_key_shape(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk_tr_abcdefghijklmnop")
+    cfg = _config_with_flag()
+
+    resolution = resolve_provider_deployment(
+        cfg,
+        "openrouter",
+        "openrouter/model",
+    )
+
+    assert resolution.ready is False
+    assert resolution.reason == "credential_provider_mismatch"
+    assert resolution.provider_config is not None
+    assert resolution.provider_config.api_key == ""
+
+
+def test_shared_deployment_blocks_key_for_conflicting_official_endpoint() -> None:
+    cfg = _config_with_flag()
+
+    resolution = resolve_provider_deployment(
+        cfg,
+        "tokenrhythm",
+        "deepseek-v4-pro",
+        overrides=SimpleNamespace(
+            api_key="sk_tr_abcdefghijklmnop",
+            base_url="https://openrouter.ai/api/v1",
+        ),
+    )
+
+    assert resolution.ready is False
+    assert resolution.reason == "credential_endpoint_provider_mismatch"
+    assert resolution.provider_config is not None
+    assert resolution.provider_config.api_key == ""
+
+
 def test_shared_resolution_reports_only_redacted_profile_provenance(monkeypatch) -> None:
     secret = "sk-test-profile-secret-never-render"
     monkeypatch.setenv("OPENAI_API_KEY", "sk-registry-loses")

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -960,7 +960,9 @@ def test_desktop_tokenrhythm_single_page_onboarding_defaults_to_router() -> None
     assert "routerDefaultTier: 'c1'," in onboarding_html
     assert "routerTiers," in onboarding_html
     assert "[data-model-routing-mode]" not in onboarding_html
-    assert "selection_mode = ${tomlString(selectionMode)}" in main_ts
+    assert "'selection_mode = \"custom_b5\"'" in main_ts
+    assert "'[[llm_ensemble.candidates]]'" in main_ts
+    assert "DESKTOP_ENSEMBLE_PROFILES[selectionMode]" in main_ts
 
     expected_models = (
         "deepseek-v4-flash",

--- a/tests/test_gateway/test_boot_provider_env.py
+++ b/tests/test_gateway/test_boot_provider_env.py
@@ -483,8 +483,15 @@ async def test_config_patch_safe_accepts_llm_ensemble_toggle(tmp_path) -> None:
     assert res["patched"] == ["llm_ensemble.enabled"]
     assert res["restartRequired"] is False
     assert ctx.config.llm_ensemble.enabled is True
+    assert ctx.config.llm_ensemble.selection_mode == "custom_b5"
+    assert len(ctx.config.llm_ensemble.candidates) == 5
+    assert {
+        candidate.provider for candidate in ctx.config.llm_ensemble.candidates
+    } == {"tokenrhythm"}
     persisted = tomllib.loads((tmp_path / "config.toml").read_text())
     assert persisted["llm_ensemble"]["enabled"] is True
+    assert persisted["llm_ensemble"]["selection_mode"] == "custom_b5"
+    assert len(persisted["llm_ensemble"]["candidates"]) == 5
 
 
 async def test_config_patch_safe_rejects_session_title_advanced_paths(tmp_path) -> None:

--- a/tests/test_gateway/test_rpc_config_persistence.py
+++ b/tests/test_gateway/test_rpc_config_persistence.py
@@ -23,6 +23,7 @@ import opensquilla.gateway.rpc_config as rpc_config
 from opensquilla.gateway.config import GatewayConfig
 from opensquilla.gateway.rpc import RpcContext
 from opensquilla.gateway.rpc_config import (
+    _handle_config_apply,
     _handle_config_patch_safe,
     _handle_config_set,
 )
@@ -65,6 +66,55 @@ async def test_config_set_is_sparse_and_preserves_foreign_disk_keys(cfg_path) ->
     assert "[memory]" not in text
     assert "host =" not in text
     assert len(text.splitlines()) < before_lines + 10
+
+
+async def test_config_apply_force_persists_explicit_default_provider(cfg_path) -> None:
+    cfg_path.write_text(
+        '[llm]\napi_key = "sk_tr_abcdefghijklmnop"\n',
+        encoding="utf-8",
+    )
+    cfg = GatewayConfig.load(str(cfg_path))
+    payload = cfg.model_dump(mode="python")
+    payload["config_path"] = str(cfg_path)
+    payload["llm"]["provider"] = "tokenrhythm"
+
+    await _handle_config_apply({"config": payload}, _ctx(cfg))
+
+    persisted = tomllib.loads(cfg_path.read_text())
+    assert persisted["llm"]["provider"] == "tokenrhythm"
+
+
+async def test_config_apply_accepts_public_ensemble_activation_fields(cfg_path) -> None:
+    cfg = GatewayConfig(config_path=str(cfg_path))
+    payload = cfg.to_public_dict()
+
+    await _handle_config_apply({"config": payload}, _ctx(cfg))
+
+    assert cfg.llm_ensemble.enabled is False
+    persisted = tomllib.loads(cfg_path.read_text())
+    ensemble = persisted.get("llm_ensemble", {})
+    assert "selection_configured" not in ensemble
+    assert "activation_preview" not in ensemble
+
+
+async def test_config_set_and_patch_accept_public_ensemble_slice(cfg_path) -> None:
+    cfg = GatewayConfig(config_path=str(cfg_path))
+    public_ensemble = dict(cfg.to_public_dict()["llm_ensemble"])
+    public_ensemble["min_successful_proposers"] = 2
+
+    await _handle_config_set(
+        {"path": "llm_ensemble", "value": public_ensemble},
+        _ctx(cfg),
+    )
+    assert cfg.llm_ensemble.min_successful_proposers == 2
+
+    public_ensemble = dict(cfg.to_public_dict()["llm_ensemble"])
+    public_ensemble["min_successful_proposers"] = 3
+    await rpc_config._handle_config_patch(
+        {"patch": {"llm_ensemble": public_ensemble}},
+        _ctx(cfg),
+    )
+    assert cfg.llm_ensemble.min_successful_proposers == 3
 
 
 async def test_config_set_preserves_known_field_edited_after_gateway_load(cfg_path) -> None:
@@ -161,9 +211,10 @@ async def test_routing_mode_toggle_persists_only_its_paths(cfg_path) -> None:
     }
     data = tomllib.loads(cfg_path.read_text())
     assert data["llm_ensemble"]["enabled"] is True
-    # The default static_openrouter_b5 ensemble is independent, so the
-    # canonical three-state reconciliation overrides the legacy conflicting
-    # router=true field while preserving the explicit full rollout marker.
+    # First activation materializes a provider-aware custom lineup, which is
+    # independent of Router execution. Canonical reconciliation therefore
+    # overrides the legacy conflicting router=true field while preserving
+    # the explicit full rollout marker.
     reloaded = GatewayConfig.load(str(cfg_path))
     assert reloaded.llm_ensemble.enabled is True
     assert reloaded.squilla_router.enabled is False
@@ -314,7 +365,13 @@ async def test_onboarding_live_snapshot_advances_after_successful_persist(cfg_pa
 
     await rpc_onboarding._ensemble_configure({"enabled": True}, ctx)
     assert cfg._persist_baseline["llm_ensemble"]["enabled"] is True
-    cfg_path.write_text(cfg_path.read_text().replace("enabled = true", "enabled = false"))
+    cfg_path.write_text(
+        cfg_path.read_text().replace(
+            "[llm_ensemble]\nenabled = true",
+            "[llm_ensemble]\nenabled = false",
+            1,
+        )
+    )
 
     await rpc_onboarding._search_configure({"providerId": "duckduckgo"}, ctx)
 
@@ -339,7 +396,13 @@ async def test_onboarding_first_save_establishes_path_and_snapshot(
 
     assert cfg.config_path == str(target)
     assert cfg._persist_baseline["llm_ensemble"]["enabled"] is True
-    target.write_text(target.read_text().replace("enabled = true", "enabled = false"))
+    target.write_text(
+        target.read_text().replace(
+            "[llm_ensemble]\nenabled = true",
+            "[llm_ensemble]\nenabled = false",
+            1,
+        )
+    )
 
     await rpc_onboarding._search_configure({"providerId": "duckduckgo"}, ctx)
 

--- a/tests/test_gateway/test_rpc_doctor.py
+++ b/tests/test_gateway/test_rpc_doctor.py
@@ -584,6 +584,45 @@ async def test_doctor_status_can_skip_deep_memory_diagnostics(monkeypatch) -> No
 
 
 @pytest.mark.asyncio
+async def test_doctor_provider_probe_is_disabled_by_default_and_opt_in(
+    monkeypatch,
+) -> None:
+    import opensquilla.gateway.rpc_doctor as rpc_doctor
+
+    seen_probe_values: list[bool] = []
+
+    async def provider_status(params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        seen_probe_values.append(bool(params.get("probeModels")))
+        return {
+            "activeProvider": "openrouter",
+            "providers": [
+                {
+                    "providerId": "openrouter",
+                    "active": True,
+                    "configured": True,
+                    "buildable": True,
+                }
+            ],
+        }
+
+    _patch_ready_support_surfaces(monkeypatch, rpc_doctor)
+    monkeypatch.setattr(rpc_doctor, "_handle_providers_status", provider_status)
+    ctx = RpcContext(conn_id="test", config=GatewayConfig())
+
+    first = await get_dispatcher().dispatch("req-default", "doctor.status", {}, ctx)
+    second = await get_dispatcher().dispatch(
+        "req-probe",
+        "doctor.status",
+        {"probeProviders": True},
+        ctx,
+    )
+
+    assert first.ok is True
+    assert second.ok is True
+    assert seen_probe_values == [False, True]
+
+
+@pytest.mark.asyncio
 async def test_doctor_status_explains_recovery_when_collection_fails(monkeypatch) -> None:
     import opensquilla.gateway.rpc_doctor as rpc_doctor
 

--- a/tests/test_gateway/test_rpc_model_routing.py
+++ b/tests/test_gateway/test_rpc_model_routing.py
@@ -14,6 +14,7 @@ from opensquilla.gateway.config import GatewayConfig
 from opensquilla.gateway.model_routing import (
     apply_model_routing_mode,
     capture_model_routing_config,
+    ensemble_activation_preview,
     model_routing_mode_for_write,
     model_routing_patches,
     model_routing_snapshot,
@@ -36,9 +37,215 @@ from opensquilla.gateway.rpc_onboarding import (
 )
 from opensquilla.gateway.scopes import ADMIN_SCOPE, METHOD_SCOPES, READ_SCOPE, WRITE_SCOPE
 from opensquilla.gateway.task_runtime import TaskRuntime
+from opensquilla.onboarding.mutations import upsert_llm_ensemble
 from opensquilla.session.models import AgentTaskRecord
 from opensquilla.tools.policy import apply_tool_policy_from_config
 from opensquilla.tools.types import ToolContext
+
+
+def test_fresh_tokenrhythm_ensemble_activation_materializes_custom_lineup() -> None:
+    cfg = GatewayConfig(
+        llm={
+            "provider": "tokenrhythm",
+            "api_key": "sk_tr_abcdefghijklmnop",
+        }
+    )
+
+    changed = upsert_llm_ensemble(cfg, enabled=True).config
+
+    assert changed.llm_ensemble.enabled is True
+    assert changed.llm_ensemble.selection_mode == "custom_b5"
+    assert len(changed.llm_ensemble.candidates) == 5
+    assert {
+        candidate.provider for candidate in changed.llm_ensemble.candidates
+    } == {"tokenrhythm"}
+    assert changed.llm_ensemble.candidates[-1].role == "aggregator"
+    assert "llm_ensemble.selection_mode" in changed.force_persist_paths()
+    assert "llm_ensemble.candidates" in changed.force_persist_paths()
+
+
+def test_fresh_openrouter_ensemble_activation_materializes_custom_lineup() -> None:
+    cfg = GatewayConfig(
+        llm={
+            "provider": "openrouter",
+            "api_key": "synthetic-openrouter-key",
+        }
+    )
+
+    changed = upsert_llm_ensemble(cfg, enabled=True).config
+
+    assert changed.llm_ensemble.selection_mode == "custom_b5"
+    assert len(changed.llm_ensemble.candidates) == 5
+    assert {
+        candidate.provider for candidate in changed.llm_ensemble.candidates
+    } == {"openrouter"}
+    assert changed.llm_ensemble.candidates[-1].model == "z-ai/glm-5.2"
+    assert changed.llm_ensemble.candidates[-1].role == "aggregator"
+
+
+def test_explicit_cross_provider_ensemble_selection_is_preserved() -> None:
+    cfg = GatewayConfig(
+        llm={"provider": "tokenrhythm", "api_key": "sk_tr_abcdefghijklmnop"},
+        llm_ensemble={"selection_mode": "static_openrouter_b5"},
+    )
+
+    changed = upsert_llm_ensemble(cfg, enabled=True).config
+
+    assert changed.llm_ensemble.selection_mode == "static_openrouter_b5"
+    assert changed.llm_ensemble.candidates == []
+
+
+def test_same_request_explicit_selection_wins_over_activation_planner() -> None:
+    cfg = GatewayConfig(
+        llm={"provider": "tokenrhythm", "api_key": "sk_tr_abcdefghijklmnop"}
+    )
+
+    changed = upsert_llm_ensemble(
+        cfg,
+        enabled=True,
+        selection_mode="static_openrouter_b5",
+    ).config
+
+    assert changed.llm_ensemble.enabled is True
+    assert changed.llm_ensemble.selection_mode == "static_openrouter_b5"
+    assert changed.llm_ensemble.candidates == []
+
+
+def test_reenable_preserves_first_generated_ensemble_selection() -> None:
+    cfg = GatewayConfig(
+        llm={"provider": "tokenrhythm", "api_key": "sk_tr_abcdefghijklmnop"}
+    )
+    enabled = upsert_llm_ensemble(cfg, enabled=True).config
+    original = [
+        candidate.model_dump(mode="python")
+        for candidate in enabled.llm_ensemble.candidates
+    ]
+    disabled = upsert_llm_ensemble(enabled, enabled=False).config
+
+    reenabled = upsert_llm_ensemble(disabled, enabled=True).config
+
+    assert reenabled.llm_ensemble.selection_mode == "custom_b5"
+    assert [
+        candidate.model_dump(mode="python")
+        for candidate in reenabled.llm_ensemble.candidates
+    ] == original
+
+
+def test_other_provider_activation_uses_distinct_router_tiers() -> None:
+    cfg = GatewayConfig(
+        llm={"provider": "openai", "model": "gpt-primary", "api_key": "sk-test-openai"},
+        squilla_router={
+            "tiers": {
+                "c0": {"provider": "openai", "model": "gpt-fast"},
+                "c3": {"provider": "openai", "model": "gpt-strong"},
+            }
+        },
+    )
+
+    changed = upsert_llm_ensemble(cfg, enabled=True).config
+
+    assert changed.llm_ensemble.selection_mode == "custom_b5"
+    assert [candidate.model for candidate in changed.llm_ensemble.candidates] == [
+        "gpt-fast",
+        "gpt-strong",
+    ]
+    assert all(
+        candidate.role != "aggregator"
+        for candidate in changed.llm_ensemble.candidates
+    )
+    assert changed.llm.model == "gpt-primary"
+
+
+def test_other_provider_activation_with_one_candidate_fails_atomically() -> None:
+    cfg = GatewayConfig(
+        llm={"provider": "openai", "model": "gpt-primary", "api_key": "sk-test-openai"},
+        squilla_router={
+            "tiers": {
+                "c0": {"provider": "openai", "model": "same-model"},
+                "c3": {"provider": "openai", "model": "same-model"},
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="at least two distinct runtime-supported"):
+        upsert_llm_ensemble(cfg, enabled=True)
+
+    assert cfg.llm_ensemble.enabled is False
+    assert cfg.llm_ensemble.candidates == []
+
+
+@pytest.mark.parametrize("invalid_provider", ["unknown-provider", "github_copilot"])
+def test_other_provider_activation_rejects_non_runtime_candidates_atomically(
+    invalid_provider: str,
+) -> None:
+    cfg = GatewayConfig(
+        llm={"provider": "openai", "model": "gpt-primary", "api_key": "sk-test-openai"},
+        squilla_router={
+            "tiers": {
+                "c0": {"provider": "openai", "model": "gpt-fast"},
+                "c1": {"provider": invalid_provider, "model": "invalid-model"},
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="at least two distinct runtime-supported"):
+        upsert_llm_ensemble(cfg, enabled=True)
+
+    assert cfg.llm_ensemble.enabled is False
+    assert cfg.llm_ensemble.candidates == []
+
+
+def test_other_provider_activation_excludes_non_runtime_candidates() -> None:
+    cfg = GatewayConfig(
+        llm={"provider": "openai", "model": "gpt-primary", "api_key": "sk-test-openai"},
+        squilla_router={
+            "tiers": {
+                "c0": {"provider": "openai", "model": "gpt-fast"},
+                "c1": {"provider": "unknown-provider", "model": "invalid-model"},
+                "c2": {"provider": "anthropic", "model": "claude-primary"},
+            }
+        },
+    )
+
+    changed = upsert_llm_ensemble(cfg, enabled=True).config
+
+    assert [
+        (candidate.provider, candidate.model)
+        for candidate in changed.llm_ensemble.candidates
+    ] == [
+        ("openai", "gpt-fast"),
+        ("anthropic", "claude-primary"),
+    ]
+
+
+def test_other_provider_activation_preview_reports_non_runtime_candidates_as_blocked() -> None:
+    cfg = GatewayConfig(
+        llm={"provider": "openai", "model": "gpt-primary"},
+        squilla_router={
+            "tiers": {
+                "c0": {"provider": "openai", "model": "gpt-fast"},
+                "c1": {"provider": "unknown-provider", "model": "invalid-model"},
+            }
+        },
+    )
+
+    preview = ensemble_activation_preview(cfg)
+
+    assert preview["proposer_count"] == 0
+    assert "runtime-supported" in preview["blocked_reason"]
+    assert cfg.llm_ensemble.enabled is False
+    assert cfg.llm_ensemble.candidates == []
+
+
+def test_unconfigured_ensemble_preview_does_not_present_openrouter_default() -> None:
+    preview = ensemble_activation_preview(GatewayConfig())
+
+    assert preview["selection_mode"] == "custom_b5"
+    assert preview["selection_configured"] is False
+    assert preview["proposer_count"] == 4
+    assert preview["member_providers"] == ["tokenrhythm"]
+    assert len(preview["candidates"]) == 5
+    assert preview["candidates"][-1]["role"] == "aggregator"
 
 
 def _ctx(config: GatewayConfig) -> RpcContext:
@@ -190,6 +397,37 @@ async def test_models_routing_set_persists_and_returns_canonical_snapshot(tmp_pa
     assert model_routing_snapshot(reloaded)["mode"] == "direct"
     persisted = tomllib.loads(path.read_text())
     assert persisted["squilla_router"]["enabled"] is False
+
+
+async def test_models_routing_set_first_tokenrhythm_activation_persists_plan(
+    tmp_path,
+) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        "\n".join(
+            [
+                "[llm]",
+                'provider = "tokenrhythm"',
+                'api_key = "sk_tr_abcdefghijklmnop"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    config = GatewayConfig.load(str(path))
+
+    result = await _handle_models_routing_set({"mode": "ensemble"}, _ctx(config))
+
+    assert result["mode"] == "ensemble"
+    assert result["selection_mode"] == "custom_b5"
+    assert result["selection_configured"] is True
+    assert len(config.llm_ensemble.candidates) == 5
+    persisted = tomllib.loads(path.read_text())
+    assert persisted["llm_ensemble"]["selection_mode"] == "custom_b5"
+    assert len(persisted["llm_ensemble"]["candidates"]) == 5
+    reloaded = GatewayConfig.load(str(path))
+    assert reloaded.llm_ensemble.selection_mode == "custom_b5"
+    assert len(reloaded.llm_ensemble.candidates) == 5
 
 
 async def test_models_routing_get_is_read_only() -> None:

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -1608,6 +1608,8 @@ async def test_provider_configure_refreshes_shared_live_catalog_before_return(
 
         assert res.error is None, res.error
         assert fetches == ["https://tokenrhythm.studio/api/models"]
+        persisted = tomllib.loads((tmp_path / "c.toml").read_text())
+        assert persisted["llm"]["provider"] == "tokenrhythm"
         assert catalog.resolve_entry("qwen3.7-max", provider="tokenrhythm").source == "live"
         assert catalog.resolve_max_tokens("qwen3.7-max", provider="tokenrhythm") == 131_072
     finally:

--- a/tests/test_gateway/test_rpc_product_cli_gaps.py
+++ b/tests/test_gateway/test_rpc_product_cli_gaps.py
@@ -1279,6 +1279,183 @@ async def test_providers_status_honors_configured_active_api_key_env(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_providers_status_probe_surfaces_classified_active_error(monkeypatch):
+    from opensquilla.provider.selector import ModelListResult, ProviderListError
+
+    leaked = "sk-or-v1-abcdefghijklmnopqrstuvwxyz"
+
+    class _Selector:
+        is_configured = True
+
+        async def list_models_detailed(self):
+            return ModelListResult(
+                errors=[
+                    ProviderListError(
+                        provider="openrouter",
+                        model_hint="openrouter/model",
+                        kind="auth_invalid",
+                        detail=f"HTTP 401 invalid key {leaked}",
+                    )
+                ]
+            )
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    cfg = GatewayConfig(
+        llm={
+            "provider": "openrouter",
+            "model": "openrouter/model",
+            "api_key": "synthetic-unclassified-key",
+        }
+    )
+
+    res = await get_dispatcher().dispatch(
+        "r1",
+        "providers.status",
+        {"provider": "openrouter", "probeModels": True},
+        _ctx(config=cfg, provider_selector=_Selector()),
+    )
+
+    assert res.error is None, res.error
+    probe = res.payload["providers"][0]["modelProbe"]
+    assert probe["status"] == "error"
+    assert probe["count"] == 0
+    assert probe["failureKind"] == "auth_invalid"
+    assert leaked not in repr(res.payload)
+
+
+@pytest.mark.asyncio
+async def test_providers_status_probe_distinguishes_empty_and_degraded_catalogs(
+    monkeypatch,
+):
+    from opensquilla.provider.selector import ModelListResult, ProviderListError
+
+    class _Selector:
+        is_configured = True
+
+        def __init__(self):
+            self.result = ModelListResult()
+
+        async def list_models_detailed(self):
+            return self.result
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    selector = _Selector()
+    cfg = GatewayConfig(
+        llm={
+            "provider": "openrouter",
+            "model": "openrouter/model",
+            "api_key": "synthetic-unclassified-key",
+        }
+    )
+    ctx = _ctx(config=cfg, provider_selector=selector)
+
+    empty = await get_dispatcher().dispatch(
+        "r-empty",
+        "providers.status",
+        {"provider": "openrouter", "probeModels": True},
+        ctx,
+    )
+    empty_probe = empty.payload["providers"][0]["modelProbe"]
+    assert empty_probe == {
+        "attempted": True,
+        "status": "ok",
+        "count": 0,
+        "error": None,
+        "failureKind": None,
+    }
+
+    selector.result = ModelListResult(
+        models=[{"provider": "openrouter", "model_id": "available/model"}],
+        errors=[
+            ProviderListError(
+                provider="openrouter",
+                model_hint="fallback/model",
+                kind="rate_limited",
+                detail="HTTP 429",
+            )
+        ],
+    )
+    degraded = await get_dispatcher().dispatch(
+        "r-degraded",
+        "providers.status",
+        {"provider": "openrouter", "probeModels": True},
+        ctx,
+    )
+    degraded_probe = degraded.payload["providers"][0]["modelProbe"]
+    assert degraded_probe["status"] == "degraded"
+    assert degraded_probe["count"] == 1
+    assert degraded_probe["failureKind"] == "rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_providers_status_conflict_blocks_probe_before_selector_call(monkeypatch):
+    calls = 0
+
+    class _Selector:
+        is_configured = True
+
+        async def list_models_detailed(self):
+            nonlocal calls
+            calls += 1
+            raise AssertionError("provider conflict must block the probe")
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("TOKENRHYTHM_API_KEY", raising=False)
+    cfg = GatewayConfig(
+        llm={
+            "api_key": "sk_tr_abcdefghijklmnop",
+            "base_url": "https://openrouter.ai/api/v1",
+        }
+    )
+
+    res = await get_dispatcher().dispatch(
+        "r-conflict",
+        "providers.status",
+        {"probeModels": True},
+        _ctx(config=cfg, provider_selector=_Selector()),
+    )
+
+    assert res.error is None, res.error
+    assert calls == 0
+    assert res.payload["providerResolution"]["actionRequired"] is True
+    assert res.payload["providerResolution"]["effectiveProvider"] == ""
+    assert res.payload["providerResolution"]["reasonCode"] == (
+        "providerless_provider_conflict"
+    )
+    active = next(row for row in res.payload["providers"] if row["active"])
+    assert active["configured"] is False
+    assert active["modelProbe"]["status"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_providers_status_blocks_key_for_conflicting_official_endpoint():
+    cfg = GatewayConfig(
+        llm={
+            "provider": "tokenrhythm",
+            "api_key": "sk_tr_abcdefghijklmnop",
+            "base_url": "https://openrouter.ai/api/v1",
+        }
+    )
+
+    res = await get_dispatcher().dispatch(
+        "r-endpoint-conflict",
+        "providers.status",
+        {"provider": "tokenrhythm", "probeModels": True},
+        _ctx(config=cfg),
+    )
+
+    assert res.error is None, res.error
+    assert res.payload["providerResolution"]["actionRequired"] is True
+    assert res.payload["providerResolution"]["reasonCode"] == (
+        "credential_endpoint_provider_mismatch"
+    )
+    active = res.payload["providers"][0]
+    assert active["configured"] is False
+    assert active["buildable"] is False
+    assert active["modelProbe"]["attempted"] is False
+
+
+@pytest.mark.asyncio
 async def test_providers_status_reports_ok_api_key_shape_and_null_latency(monkeypatch):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     cfg = GatewayConfig(

--- a/tests/test_gateway_config_default_provider.py
+++ b/tests/test_gateway_config_default_provider.py
@@ -37,6 +37,46 @@ def test_keyless_default_resolves_tokenrhythm() -> None:
     assert cfg.llm.base_url == TOKENRHYTHM_BASE_URL
 
 
+@pytest.mark.parametrize(
+    "llm",
+    [
+        {"api_key": "sk_tr_abcdefghijklmnop"},
+        {"api_key_env": "TOKENRHYTHM_API_KEY"},
+        {"base_url": TOKENRHYTHM_BASE_URL},
+    ],
+)
+def test_providerless_strong_tokenrhythm_evidence_recovers_in_memory(
+    llm: dict[str, str],
+) -> None:
+    cfg = GatewayConfig(llm=llm)
+
+    assert cfg.llm.provider == "tokenrhythm"
+    assert cfg.provider_resolution()["status"] == "recovered"
+    assert cfg.provider_resolution()["action_recommended"] is True
+
+
+def test_providerless_conflicting_evidence_is_action_required() -> None:
+    cfg = GatewayConfig(
+        llm={
+            "api_key": "sk_tr_abcdefghijklmnop",
+            "base_url": LEGACY_DEFAULT_LLM_BASE_URL,
+        }
+    )
+
+    assert cfg.llm.provider == "openrouter"
+    assert cfg.provider_resolution()["status"] == "conflict"
+    assert cfg.provider_resolution()["effective_provider"] == ""
+    assert cfg.provider_resolution()["action_required"] is True
+
+
+def test_providerless_ambiguous_key_keeps_legacy_openrouter() -> None:
+    cfg = GatewayConfig(llm={"api_key": "synthetic-ambiguous-key"})
+
+    assert cfg.llm.provider == "openrouter"
+    assert cfg.provider_resolution()["status"] == "legacy_inferred"
+    assert cfg.provider_resolution()["action_recommended"] is True
+
+
 def test_openrouter_env_key_alone_keeps_legacy_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -55,13 +95,17 @@ def test_tokenrhythm_env_key_resolves_tokenrhythm(
     monkeypatch.setenv("TOKENRHYTHM_API_KEY", "sk_tr_test")
     cfg = GatewayConfig()
     assert cfg.llm.provider == "tokenrhythm"
+    assert cfg.provider_resolution()["status"] == "recovered"
 
 
-def test_both_env_keys_prefer_tokenrhythm(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_both_env_keys_require_explicit_provider_choice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
     monkeypatch.setenv("TOKENRHYTHM_API_KEY", "sk_tr_test")
     cfg = GatewayConfig()
-    assert cfg.llm.provider == "tokenrhythm"
+    assert cfg.provider_resolution()["status"] == "conflict"
+    assert cfg.provider_resolution()["action_required"] is True
 
 
 @pytest.mark.parametrize(
@@ -218,3 +262,79 @@ def test_resolved_tokenrhythm_tiers_are_not_persisted(tmp_path: Path) -> None:
     data = tomllib.loads(target.read_text(encoding="utf-8"))
     assert "squilla_router" not in data
     assert "llm" not in data
+
+
+def test_runtime_withholds_known_cross_provider_key_without_erasing_disk(
+    tmp_path: Path,
+) -> None:
+    import tomllib
+
+    from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
+    from opensquilla.onboarding.config_store import load_config, persist_config
+
+    target = tmp_path / "config.toml"
+    target.write_text(
+        "\n".join(
+            [
+                "[llm]",
+                'provider = "openrouter"',
+                'api_key = "sk_tr_abcdefghijklmnop"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    cfg = load_config(target)
+
+    runtime = resolve_llm_runtime_config(cfg)
+    assert runtime.provider == "openrouter"
+    assert runtime.api_key == ""
+    assert cfg.provider_resolution()["reason_code"] == "credential_provider_mismatch"
+
+    cfg.log_level = "DEBUG"
+    persist_config(cfg, path=target, backup=False)
+    raw = tomllib.loads(target.read_text(encoding="utf-8"))
+    assert raw["llm"]["api_key"] == "sk_tr_abcdefghijklmnop"
+
+
+def test_runtime_withholds_key_from_conflicting_official_endpoint() -> None:
+    from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
+
+    cfg = GatewayConfig(
+        llm={
+            "provider": "tokenrhythm",
+            "api_key": "sk_tr_abcdefghijklmnop",
+            "base_url": LEGACY_DEFAULT_LLM_BASE_URL,
+        }
+    )
+
+    runtime = resolve_llm_runtime_config(cfg)
+
+    assert runtime.api_key == ""
+    assert (
+        cfg.provider_resolution()["reason_code"]
+        == "credential_endpoint_provider_mismatch"
+    )
+    assert cfg.provider_resolution()["action_required"] is True
+
+
+def test_providerless_tokenrhythm_recovery_does_not_rewrite_disk(
+    tmp_path: Path,
+) -> None:
+    import tomllib
+
+    from opensquilla.onboarding.config_store import load_config, persist_config
+
+    target = tmp_path / "config.toml"
+    target.write_text(
+        '[llm]\napi_key = "sk_tr_abcdefghijklmnop"\n',
+        encoding="utf-8",
+    )
+    cfg = load_config(target)
+    assert cfg.llm.provider == "tokenrhythm"
+
+    cfg.log_level = "DEBUG"
+    persist_config(cfg, path=target, backup=False)
+
+    raw = tomllib.loads(target.read_text(encoding="utf-8"))
+    assert "provider" not in raw["llm"]

--- a/tests/test_health/test_evaluator.py
+++ b/tests/test_health/test_evaluator.py
@@ -239,6 +239,58 @@ def test_provider_evaluator_reports_ready_active_provider() -> None:
     assert findings[0].severity == "ok"
 
 
+def test_provider_auth_probe_failure_blocks_readiness() -> None:
+    findings = evaluate_provider(
+        {
+            "activeProvider": "openrouter",
+            "providers": [
+                {
+                    "providerId": "openrouter",
+                    "active": True,
+                    "configured": True,
+                    "buildable": True,
+                    "modelProbe": {
+                        "attempted": True,
+                        "status": "error",
+                        "failureKind": "auth_invalid",
+                        "error": "HTTP 401 invalid credential",
+                    },
+                }
+            ],
+        }
+    )
+
+    assert findings[0].id == "provider.active.probe.auth_invalid"
+    assert findings[0].severity == "error"
+    assert _impact(findings[0]) == "blocks_ready"
+
+
+def test_provider_temporary_probe_failure_only_degrades_readiness() -> None:
+    findings = evaluate_provider(
+        {
+            "activeProvider": "openrouter",
+            "providers": [
+                {
+                    "providerId": "openrouter",
+                    "active": True,
+                    "configured": True,
+                    "buildable": True,
+                    "modelProbe": {
+                        "attempted": True,
+                        "status": "error",
+                        "failureKind": "network",
+                        "error": "temporary network failure",
+                    },
+                }
+            ],
+        }
+    )
+
+    assert findings[0].id == "provider.active.probe.network"
+    assert findings[0].severity == "warn"
+    assert _impact(findings[0]) == "degrades"
+
+
 def _healthy_active_row(**extra: object) -> dict[str, object]:
     row: dict[str, object] = {
         "providerId": "openrouter",

--- a/tests/test_onboarding/test_config_store_sparse_persist.py
+++ b/tests/test_onboarding/test_config_store_sparse_persist.py
@@ -20,6 +20,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from opensquilla.gateway.config import GatewayConfig
 from opensquilla.onboarding.config_store import load_config, persist_config
+from opensquilla.onboarding.mutations import upsert_llm_provider
 
 
 def _write_small_config(target) -> None:
@@ -766,6 +767,50 @@ def test_persist_never_loaded_missing_file_still_writes_sparse(tmp_path):
     data = tomllib.loads(target.read_text())
     assert data["port"] == 18795
     assert "memory" not in data  # defaults are not dumped wholesale
+
+
+def test_fresh_tokenrhythm_save_persists_explicit_provider_identity(tmp_path):
+    target = tmp_path / "config.toml"
+    before = load_config(target)
+
+    changed = upsert_llm_provider(
+        before,
+        provider_id="tokenrhythm",
+        api_key="sk_tr_abcdefghijklmnop",
+    ).config
+    persist_config(changed, path=target, backup=False)
+
+    raw = tomllib.loads(target.read_text())
+    assert raw["llm"]["provider"] == "tokenrhythm"
+    reloaded = load_config(target)
+    assert reloaded.llm.provider == changed.llm.provider == "tokenrhythm"
+    assert reloaded.llm.model == changed.llm.model
+    assert reloaded.llm.base_url == changed.llm.base_url
+    assert reloaded.squilla_router.preset_binding == "follow_primary"
+    assert reloaded.squilla_router.tiers == changed.squilla_router.tiers
+    assert {
+        tier["provider"] for tier in reloaded.squilla_router.tiers.values()
+    } == {"tokenrhythm"}
+
+
+def test_fresh_tokenrhythm_env_and_custom_endpoint_round_trip(tmp_path):
+    target = tmp_path / "config.toml"
+    changed = upsert_llm_provider(
+        load_config(target),
+        provider_id="tokenrhythm",
+        api_key_env="TOKENRHYTHM_API_KEY",
+        model="custom-tr-model",
+        base_url="https://tr-proxy.example/v1",
+    ).config
+    persist_config(changed, path=target, backup=False)
+
+    raw = tomllib.loads(target.read_text())
+    assert raw["llm"]["provider"] == "tokenrhythm"
+    assert raw["llm"]["api_key_env"] == "TOKENRHYTHM_API_KEY"
+    reloaded = load_config(target)
+    assert reloaded.llm.provider == "tokenrhythm"
+    assert reloaded.llm.model == "custom-tr-model"
+    assert reloaded.llm.base_url == "https://tr-proxy.example/v1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -37,6 +37,7 @@ from opensquilla.provider.ensemble import (
     _MemberRequestBudgetBinding,
     _stream_with_heartbeats,
     build_ensemble_provider_from_config,
+    ensemble_runtime_status,
 )
 from opensquilla.provider.selector import ProviderConfig
 from opensquilla.provider.types import (
@@ -3845,3 +3846,64 @@ def test_static_b5_credential_gate_agrees_with_config_side_floor_gate(
             config, config.llm, selection_mode
         )
         assert static_b5_ensemble_active(config) is expected
+
+
+def test_ensemble_runtime_status_counts_static_custom_and_dynamic() -> None:
+    static_cfg = GatewayConfig(
+        llm={"provider": "tokenrhythm", "api_key": "sk_tr_abcdefghijklmnop"},
+        llm_ensemble={"enabled": True, "selection_mode": "static_tokenrhythm_b5"},
+    )
+    static_status = ensemble_runtime_status(static_cfg)
+    assert static_status["runtimeStatus"] == "ready"
+    assert static_status["proposerCount"] == 4
+    assert static_status["aggregatorCount"] == 1
+    assert static_status["perTurnCallCount"] == 5
+
+    custom_cfg = GatewayConfig(
+        llm={"provider": "tokenrhythm", "api_key": "sk_tr_abcdefghijklmnop"},
+        llm_ensemble={
+            "enabled": True,
+            "selection_mode": "custom_b5",
+            "candidates": [
+                {"provider": "tokenrhythm", "model": "m1"},
+                {"provider": "tokenrhythm", "model": "m2"},
+            ],
+        },
+    )
+    custom_status = ensemble_runtime_status(custom_cfg)
+    assert custom_status["runtimeStatus"] == "ready"
+    assert custom_status["proposerCount"] == 2
+    assert custom_status["aggregatorCount"] == 1
+    assert custom_status["perTurnCallCount"] == 3
+
+    dynamic_cfg = GatewayConfig(
+        llm_ensemble={"enabled": True, "selection_mode": "router_dynamic"}
+    )
+    dynamic_status = ensemble_runtime_status(dynamic_cfg)
+    assert dynamic_status["runtimeStatus"] == "conditional"
+    assert dynamic_status["proposerCountRange"] == [2, 4]
+    assert dynamic_status["perTurnCallCountRange"] == [3, 5]
+
+
+def test_ensemble_runtime_status_checks_inherited_custom_aggregator_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TOKENRHYTHM_API_KEY", "synthetic-tokenrhythm-key")
+    cfg = GatewayConfig(
+        llm={"provider": "groq", "model": "groq-aggregator"},
+        llm_ensemble={
+            "enabled": True,
+            "selection_mode": "custom_b5",
+            "candidates": [
+                {"provider": "tokenrhythm", "model": "tr-proposer-1"},
+                {"provider": "tokenrhythm", "model": "tr-proposer-2"},
+            ],
+        },
+    )
+
+    status = ensemble_runtime_status(cfg)
+
+    assert status["runtimeStatus"] == "blocked"
+    assert status["configurationReady"] is False
+    assert status["aggregatorCount"] == 1
+    assert "groq" in str(status["blockedReason"])

--- a/tests/test_provider_selector.py
+++ b/tests/test_provider_selector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import httpx
 import pytest
 
 from opensquilla.provider.failures import ProviderFailureKind
@@ -177,6 +178,13 @@ class _HealthyProvider:
         return [ModelInfo(provider="ollama", model_id="test-model-good")]
 
 
+class _CompatibilityProviderThatSwallowsByDefault:
+    async def list_models(self, *, raise_on_error: bool = False) -> list[ModelInfo]:
+        if raise_on_error:
+            raise RuntimeError(f"HTTP 401: invalid api key {FAKE_LEAKED_KEY}")
+        return []
+
+
 def _selector_with_failing_primary(monkeypatch) -> ModelSelector:
     def fake_build_provider(cfg: ProviderConfig):
         if cfg.provider == "openrouter":
@@ -244,6 +252,100 @@ async def test_list_models_detailed_reports_every_failed_chain_link(monkeypatch)
         ("openrouter", "openrouter/auth-locked-a"),
         ("deepseek", "deepseek/auth-locked-b"),
     ]
+
+
+async def test_detailed_listing_enables_adapter_strict_mode(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "opensquilla.provider.selector._build_provider",
+        lambda _cfg: _CompatibilityProviderThatSwallowsByDefault(),
+    )
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig(
+                provider="openrouter",
+                model="openrouter/auth-locked",
+                api_key=FAKE_LEAKED_KEY,
+            )
+        )
+    )
+
+    result = await selector.list_models_detailed()
+
+    assert result.models == []
+    assert result.errors[0].kind == ProviderFailureKind.AUTH_INVALID.value
+    assert FAKE_LEAKED_KEY not in result.errors[0].detail
+    assert await selector.list_models() == []
+
+
+async def test_known_cross_provider_key_never_reaches_transport(monkeypatch) -> None:
+    requests: list[httpx.Request] = []
+    transport = httpx.MockTransport(
+        lambda request: (
+            requests.append(request)
+            or httpx.Response(200, json={"data": []}, request=request)
+        )
+    )
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_async_client)
+    leaked = "sk_tr_abcdefghijklmnop"
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig(
+                provider="openrouter",
+                model="openrouter/model",
+                api_key=leaked,
+                base_url="https://openrouter.ai/api/v1",
+            )
+        )
+    )
+
+    result = await selector.list_models_detailed()
+
+    assert requests == []
+    assert result.models == []
+    assert result.errors[0].kind == ProviderFailureKind.UNKNOWN.value
+    assert "tokenrhythm" in result.errors[0].detail
+    assert leaked not in result.errors[0].detail
+
+
+async def test_known_key_never_reaches_conflicting_official_host(monkeypatch) -> None:
+    requests: list[httpx.Request] = []
+    transport = httpx.MockTransport(
+        lambda request: (
+            requests.append(request)
+            or httpx.Response(200, json={"data": []}, request=request)
+        )
+    )
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_async_client)
+    leaked = "sk_tr_abcdefghijklmnop"
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig(
+                provider="tokenrhythm",
+                model="deepseek-v4-pro",
+                api_key=leaked,
+                base_url="https://openrouter.ai/api/v1",
+            )
+        )
+    )
+
+    result = await selector.list_models_detailed()
+
+    assert requests == []
+    assert result.models == []
+    assert "openrouter" in result.errors[0].detail
+    assert leaked not in result.errors[0].detail
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Scope

Scope boundary:

- Force-persist explicit LLM provider identity and conservatively resolve historical providerless configurations.
- Reject known credential/provider or credential/official-endpoint mismatches before any provider network request.
- Add one Gateway-owned, provider-aware Ensemble activation planner shared by RPC, onboarding, CLI, TUI, Chat, WebUI, and Desktop configuration paths.
- Make provider model probes, Doctor readiness, and Ensemble runtime status accurately distinguish blocked, degraded, empty, and healthy states.
- Preserve explicit cross-provider Ensemble selections and existing Desktop/static configurations.

Non-goals:

- No provider credential migration or automatic rewrite of ambiguous legacy providerless files.
- No database migration.
- No change to explicitly configured Ensemble execution or billing semantics.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: The first-install regression was reproduced directly and does not have a linked public issue.

## Release Note

Release note: Fix first-install provider persistence, provider-aware Ensemble activation, and model/provider diagnostics.

## Tests

Ruff: `uv run ruff check src tests` — passed

Pytest: all modified Python test files — `718 passed`

Build: full mypy (868 source files), WebUI typecheck/production build, Desktop TypeScript build, and wheel build — passed

Regression tests: added

Notes:

- Covers fresh TokenRhythm/OpenRouter/providerless loads, key/endpoint mismatch fail-closed behavior, zero-request transport assertions, explicit selection preservation, provider-aware Ensemble activation and atomic rollback, provider probe classification/redaction, Doctor network opt-in, and Desktop/WebUI contracts.
- The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: provider

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

No real secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included. Test credentials are synthetic. Known TokenRhythm credentials are prevented from reaching an OpenRouter endpoint before HTTP dispatch.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

No documentation files changed.

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
