### PR TITLE
Quiesce session runtime before deleting sessions

### DIFF
--- a/opensquilla-webui/src/App.sidebar-contract.test.ts
+++ b/opensquilla-webui/src/App.sidebar-contract.test.ts
@@ -13,4 +13,21 @@ describe('App sidebar chrome contract', () => {
     expect(brandMarkup).not.toContain('@click')
     expect(brandMarkup).not.toContain('to="/overview"')
   })
+
+  it('clears app-wide approvals for local and cross-view session deletion', () => {
+    const crossViewStart = appSource.indexOf('function handleLocalSessionsDeleted')
+    const crossViewEnd = appSource.indexOf('async function deleteSessions', crossViewStart)
+    const crossViewDelete = appSource.slice(crossViewStart, crossViewEnd)
+    expect(crossViewDelete).toContain('appStore.removePendingApprovalsForSessions(deleted)')
+
+    const bulkStart = appSource.indexOf('async function onBulkDeleteSessions')
+    const bulkEnd = appSource.indexOf('async function onDeleteSession', bulkStart)
+    const bulkDelete = appSource.slice(bulkStart, bulkEnd)
+    expect(bulkDelete).toContain('appStore.removePendingApprovalsForSessions(deleted)')
+
+    const singleStart = appSource.indexOf('async function onDeleteSession')
+    const singleEnd = appSource.indexOf('// Topbar approval pill', singleStart)
+    const singleDelete = appSource.slice(singleStart, singleEnd)
+    expect(singleDelete).toContain('appStore.removePendingApprovalsForSessions(deleted)')
+  })
 })

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -1263,7 +1263,9 @@ function removeLocalSessions(keys: Set<string>) {
 function handleLocalSessionsDeleted(event: Event) {
   const detail = localSessionsDeletedDetail(event)
   if (!detail || detail.source === APP_SESSION_SYNC_SOURCE) return
-  removeLocalSessions(new Set(detail.keys))
+  const deleted = new Set(detail.keys)
+  removeLocalSessions(deleted)
+  appStore.removePendingApprovalsForSessions(deleted)
   void loadSessions()
 }
 
@@ -1293,6 +1295,7 @@ async function onBulkDeleteSessions(keys: string[]) {
     return
   }
   removeLocalSessions(deleted)
+  appStore.removePendingApprovalsForSessions(deleted)
   dispatchLocalSessionsDeleted(deleted, APP_SESSION_SYNC_SOURCE)
   const failedCount = Math.max(0, uniqueKeys.length - deleted.size)
   pushToast(t('shared.sidebar.bulkDeleteDone', { count: deleted.size }), { tone: 'ok' })
@@ -1318,6 +1321,7 @@ async function onDeleteSession(key: string) {
   pushToast('Session deleted', { tone: 'ok' })
   const deleted = new Set([key])
   removeLocalSessions(deleted)
+  appStore.removePendingApprovalsForSessions(deleted)
   dispatchLocalSessionsDeleted(deleted, APP_SESSION_SYNC_SOURCE)
   await loadSessions()
   if (wasCurrent) {

--- a/opensquilla-webui/src/stores/app.sidebar.test.ts
+++ b/opensquilla-webui/src/stores/app.sidebar.test.ts
@@ -112,3 +112,73 @@ describe('app store — approval focus request', () => {
     expect(second?.requestId).toBeGreaterThan(first?.requestId ?? 0)
   })
 })
+
+describe('app store — deleted-session approval cleanup', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    stubMatchMedia()
+  })
+
+  it('removes only matching session approvals and clears their focus request', () => {
+    const store = useAppStore()
+    store.setPendingApprovals([
+      {
+        approvalId: 'delete-me',
+        sessionKey: 'agent:main:webchat:deleted',
+        tool: 'exec_command',
+        command: 'printf deleted',
+      },
+      {
+        approvalId: 'keep-me',
+        sessionKey: 'agent:main:webchat:other',
+        tool: 'exec_command',
+        command: 'printf other',
+      },
+      {
+        approvalId: 'keep-unscoped',
+        sessionKey: '',
+        tool: 'plugin',
+        command: '',
+      },
+    ])
+    store.requestApprovalFocus(store.pendingApprovals[0]!)
+
+    store.removePendingApprovalsForSessions([
+      'agent:main:webchat:deleted',
+      'agent:main:webchat:deleted',
+      '',
+    ])
+    store.removePendingApprovalsForSessions(['agent:main:webchat:deleted'])
+
+    expect(store.pendingApprovals.map(item => item.approvalId)).toEqual([
+      'keep-me',
+      'keep-unscoped',
+    ])
+    expect(store.approvalCount).toBe(2)
+    expect(store.approvalFocusRequest).toBeNull()
+
+    // A delayed Gateway resolved event is safe after the local session purge.
+    store.removePendingApproval('delete-me')
+    expect(store.pendingApprovals.map(item => item.approvalId)).toEqual([
+      'keep-me',
+      'keep-unscoped',
+    ])
+  })
+
+  it('is idempotent when the resolved event arrives before session deletion', () => {
+    const store = useAppStore()
+    store.setPendingApprovals([{
+      approvalId: 'resolved-first',
+      sessionKey: 'agent:main:webchat:deleted',
+      tool: 'exec_command',
+      command: 'printf done',
+    }])
+
+    store.removePendingApproval('resolved-first')
+    store.removePendingApprovalsForSessions(['agent:main:webchat:deleted'])
+
+    expect(store.pendingApprovals).toEqual([])
+    expect(store.approvalCount).toBe(0)
+  })
+})

--- a/opensquilla-webui/src/stores/app.ts
+++ b/opensquilla-webui/src/stores/app.ts
@@ -367,6 +367,28 @@ export const useAppStore = defineStore('app', () => {
     }
   }
 
+  // A deleted session cannot own an actionable approval. Apply this locally
+  // as an idempotent latency guard; the Gateway remains authoritative and
+  // emits the matching `*.approval.resolved` events.
+  function removePendingApprovalsForSessions(sessionKeys: Iterable<string>) {
+    const keys = new Set(
+      [...sessionKeys]
+        .map(key => String(key || '').trim())
+        .filter(Boolean),
+    )
+    if (keys.size === 0) return
+    approvalsLive.value = true
+    pendingApprovals.value = pendingApprovals.value.filter(
+      approval => !keys.has(approval.sessionKey),
+    )
+    if (
+      approvalFocusRequest.value
+      && keys.has(approvalFocusRequest.value.sessionKey)
+    ) {
+      approvalFocusRequest.value = null
+    }
+  }
+
   function requestApprovalFocus(
     approval: Pick<PendingApproval, 'approvalId' | 'sessionKey'>,
   ) {
@@ -425,6 +447,7 @@ export const useAppStore = defineStore('app', () => {
     setPendingApprovals,
     upsertPendingApproval,
     removePendingApproval,
+    removePendingApprovalsForSessions,
     requestApprovalFocus,
     clearApprovalFocusRequest,
   }

--- a/opensquilla-webui/src/views/SessionsView.deletion.test.ts
+++ b/opensquilla-webui/src/views/SessionsView.deletion.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import sessionsViewSource from './SessionsView.vue?raw'
+
+describe('SessionsView deletion contract', () => {
+  it('removes deleted session keys from the local approval snapshot immediately', () => {
+    const applyStart = sessionsViewSource.indexOf('function applyLocalDeletedSessions')
+    const applyEnd = sessionsViewSource.indexOf(
+      'function handleLocalSessionsDeleted',
+      applyStart,
+    )
+    const applyDelete = sessionsViewSource.slice(applyStart, applyEnd)
+
+    expect(applyDelete).toContain(
+      'pendingApprovals.value = pendingApprovals.value.filter(key => !keys.has(key))',
+    )
+  })
+})

--- a/opensquilla-webui/src/views/SessionsView.vue
+++ b/opensquilla-webui/src/views/SessionsView.vue
@@ -344,6 +344,7 @@ function scheduleSessionRefresh() {
 function applyLocalDeletedSessions(keys: Set<string>) {
   if (keys.size === 0) return
   sessionsList.value = sessionsList.value.filter(item => !keys.has(itemKey(item)))
+  pendingApprovals.value = pendingApprovals.value.filter(key => !keys.has(key))
   if (inspectKey.value && keys.has(inspectKey.value)) closeInspect()
 }
 

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import re
 import sqlite3
@@ -18,6 +19,9 @@ from opensquilla.agents.scope import default_workspace_dir, resolve_agent_worksp
 from opensquilla.artifacts import enrich_artifact_event_dict
 from opensquilla.engine.cache_break_monitor import notify_compaction
 from opensquilla.engine.start_turn import reserve_turn_via_runtime, start_turn_via_runtime
+from opensquilla.engine.steps.router_decision_record import (
+    drain_pending_flushes_for_sessions,
+)
 from opensquilla.gateway import attachment_ingest as _attachment_ingest
 from opensquilla.gateway.agent_tasks import get_agent_task_registry
 from opensquilla.gateway.config import effective_agent_stream_idle_timeout_seconds
@@ -43,6 +47,9 @@ from opensquilla.gateway.session_services import (
 )
 from opensquilla.gateway.session_streams import get_session_streams
 from opensquilla.gateway.session_view import build_session_view_item, derive_transcript_title
+from opensquilla.gateway.subagent_announce import (
+    quiesce_background_completion_sessions,
+)
 from opensquilla.gateway.turn_ingress import (
     accepted_turn_payload,
     complete_durable_ingress,
@@ -4512,6 +4519,86 @@ def _reset_response(
     }
 
 
+async def _settle_session_delete_despite_cancellation(awaitable: Any) -> Any:
+    """Finish one fenced delete before propagating caller cancellation."""
+
+    operation = asyncio.ensure_future(awaitable)
+    cancellation: asyncio.CancelledError | None = None
+    while not operation.done():
+        try:
+            await asyncio.shield(operation)
+        except asyncio.CancelledError as exc:
+            cancellation = cancellation or exc
+    if cancellation is not None:
+        with contextlib.suppress(BaseException):
+            operation.result()
+        raise cancellation
+    return operation.result()
+
+
+async def _delete_session_with_lifecycle(
+    *,
+    canonical_key: str,
+    ctx: RpcContext,
+    storage: Any,
+) -> None:
+    """Quiesce every writer and fail closed before deleting one session."""
+
+    session_keys = [canonical_key]
+    async with contextlib.AsyncExitStack() as fences:
+        # Child completion can schedule a parent wake while the runtime task is
+        # draining, so fence that path before cancelling the task driver.
+        await fences.enter_async_context(
+            quiesce_background_completion_sessions(session_keys)
+        )
+
+        task_runtime = getattr(ctx, "task_runtime", None)
+        quiesce_runtime = getattr(task_runtime, "quiesce_sessions", None)
+        if callable(quiesce_runtime):
+            await fences.enter_async_context(quiesce_runtime(session_keys))
+
+        await fences.enter_async_context(
+            get_agent_task_registry().quiesce_sessions(session_keys)
+        )
+
+        lock = get_session_lock(ctx.turn_runner, canonical_key)
+        if lock is not None:
+            await fences.enter_async_context(lock)
+
+        # These durable writers may outlive the task coroutine that scheduled
+        # them. Settle both before the row and its generation disappear.
+        await drain_pending_flushes_for_sessions(session_keys)
+        drain_turn_writes = getattr(
+            ctx.turn_runner,
+            "drain_session_background_writes",
+            None,
+        )
+        if callable(drain_turn_writes):
+            await drain_turn_writes(session_keys)
+
+        get_session = getattr(storage, "get_session", None)
+        session = await get_session(canonical_key) if callable(get_session) else None
+        session_id = getattr(session, "session_id", None)
+        if not isinstance(session_id, str) or not session_id:
+            session_id = None
+
+        # Terminal task cleanup normally expires owned approvals. Repeat the
+        # operation here so already-orphaned and claimed approvals also fail
+        # closed before their session record is removed.
+        from opensquilla.gateway.approval_queue import get_approval_queue
+
+        get_approval_queue().expire_pending_for_session(canonical_key)
+        await storage.delete_session(canonical_key)
+
+        evict_runtime_state = getattr(
+            ctx.session_manager,
+            "evict_session_runtime_state",
+            None,
+        )
+        if callable(evict_runtime_state):
+            evict_runtime_state(canonical_key, session_id=session_id)
+
+
 @_d.method("sessions.delete", scope="operator.write")
 async def _handle_sessions_delete(params: dict | None, ctx: RpcContext) -> dict:
     """Delete one or more sessions. Accepts {key} for single or {keys} for bulk."""
@@ -4538,12 +4625,13 @@ async def _handle_sessions_delete(params: dict | None, ctx: RpcContext) -> dict:
     for k in keys:
         try:
             canonical_key = canonicalize_session_key(k)
-            lock = get_session_lock(ctx.turn_runner, canonical_key)
-            if lock is None:
-                await storage.delete_session(canonical_key)
-            else:
-                async with lock:
-                    await storage.delete_session(canonical_key)
+            await _settle_session_delete_despite_cancellation(
+                _delete_session_with_lifecycle(
+                    canonical_key=canonical_key,
+                    ctx=ctx,
+                    storage=storage,
+                )
+            )
             deleted.append(k)
         except Exception as exc:
             errors.append(f"{k}: {exc}")

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -4001,6 +4001,24 @@ class TestSessionsReset:
 
 
 class TestSessionsDelete:
+    @pytest.fixture(autouse=True)
+    def _isolated_approval_queue(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+    ):
+        from opensquilla.application.approval_queue import ApprovalQueue
+
+        queue = ApprovalQueue(db_path=str(tmp_path / "approval_queue.sqlite"))
+        monkeypatch.setattr(
+            "opensquilla.gateway.approval_queue.get_approval_queue",
+            lambda: queue,
+        )
+        try:
+            yield queue
+        finally:
+            queue.close()
+
     @pytest.mark.asyncio
     async def test_delete_valid(self, dispatcher, ctx_with_sessions, session):
         res = await dispatcher.dispatch(
@@ -4009,14 +4027,25 @@ class TestSessionsDelete:
         assert res.ok is True
 
     @pytest.mark.asyncio
-    async def test_delete_not_found(self, dispatcher, ctx_with_sessions):
+    async def test_delete_not_found(
+        self,
+        dispatcher,
+        ctx_with_sessions,
+        _isolated_approval_queue,
+    ):
+        missing_key = "agent:main:webchat:nonexistent"
+        approval_id = _isolated_approval_queue.request(
+            "exec",
+            {"sessionKey": missing_key, "toolName": "orphaned-shell"},
+        )
         res = await dispatcher.dispatch(
-            "r1", "sessions.delete", {"key": "nonexistent"}, ctx_with_sessions
+            "r1", "sessions.delete", {"key": missing_key}, ctx_with_sessions
         )
         # Bulk-delete returns ok=True but populates errors list for missing keys
         assert res.ok is True
         assert res.payload["deleted"] == []
         assert len(res.payload["errors"]) == 1
+        assert _isolated_approval_queue.get(approval_id).resolution == "expired"
 
     @pytest.mark.asyncio
     async def test_delete_waits_for_session_lock(self, dispatcher, session):
@@ -4073,6 +4102,322 @@ class TestSessionsDelete:
         assert res.ok is True
         assert res.payload["deleted"] == ["webchat:default"]
         assert await manager._storage.get_session(session.session_key) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_legacy_alias_expires_canonical_session_approval(
+        self,
+        dispatcher,
+        _isolated_approval_queue,
+    ):
+        session = FakeSession(session_key="agent:main:webchat:default")
+        manager = FakeSessionManager([session])
+        approval_id = _isolated_approval_queue.request(
+            "exec",
+            {"sessionKey": session.session_key, "toolName": "synthetic-shell"},
+        )
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.delete",
+            {"key": "webchat:default"},
+            make_ctx(session_manager=manager),
+        )
+
+        assert res.ok is True
+        assert res.payload == {"deleted": ["webchat:default"], "errors": []}
+        assert _isolated_approval_queue.get(approval_id).resolution == "expired"
+
+    @pytest.mark.asyncio
+    async def test_delete_expires_owned_approvals_and_evicts_runtime_state(
+        self,
+        dispatcher,
+        session,
+        _isolated_approval_queue,
+    ):
+        queue = _isolated_approval_queue
+        events: list[tuple[str, dict[str, Any]]] = []
+        queue.add_event_listener(lambda event, info: events.append((event, info)))
+        matching_ids = [
+            queue.request(
+                "exec",
+                {"sessionKey": session.session_key, "toolName": "synthetic-shell"},
+            ),
+            queue.request(
+                "plugin",
+                {"session_key": session.session_key, "pluginId": "synthetic-plugin"},
+            ),
+        ]
+        queue.claim_resolution(matching_ids[-1])
+        unrelated_id = queue.request(
+            "exec",
+            {"sessionKey": "agent:main:webchat:unrelated", "toolName": "other-shell"},
+        )
+        unscoped_id = queue.request("plugin", {"pluginId": "unscoped-plugin"})
+
+        manager = FakeSessionManager([session])
+        evicted: list[tuple[str, str | None]] = []
+
+        def evict_runtime_state(
+            session_key: str,
+            *,
+            session_id: str | None = None,
+        ) -> None:
+            evicted.append((session_key, session_id))
+
+        manager.evict_session_runtime_state = evict_runtime_state  # type: ignore[attr-defined]
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.delete",
+            {"key": session.session_key},
+            make_ctx(session_manager=manager),
+        )
+
+        assert res.ok is True
+        assert res.payload == {"deleted": [session.session_key], "errors": []}
+        assert await manager._storage.get_session(session.session_key) is None
+        assert evicted == [(session.session_key, session.session_id)]
+        for approval_id in matching_ids:
+            entry = queue.get(approval_id)
+            assert entry.resolved is True
+            assert entry.approved is False
+            assert entry.resolution == "expired"
+        assert queue.get(unrelated_id).resolved is False
+        assert queue.get(unscoped_id).resolved is False
+        assert {
+            info["id"]
+            for event, info in events
+            if event == "resolved"
+        } == set(matching_ids)
+
+    @pytest.mark.asyncio
+    async def test_delete_holds_lifecycle_fences_through_cleanup(
+        self,
+        dispatcher,
+        monkeypatch: pytest.MonkeyPatch,
+        session,
+        _isolated_approval_queue,
+    ):
+        order: list[str] = []
+        active_fences: set[str] = set()
+
+        @asynccontextmanager
+        async def fence(name: str, keys: list[str]):
+            assert keys == [session.session_key]
+            order.append(f"{name}:enter")
+            active_fences.add(name)
+            try:
+                yield
+            finally:
+                active_fences.remove(name)
+                order.append(f"{name}:exit")
+
+        class WriteLock:
+            async def __aenter__(self):
+                order.append("write:enter")
+                active_fences.add("write")
+
+            async def __aexit__(self, *_args):
+                active_fences.remove("write")
+                order.append("write:exit")
+
+        manager = FakeSessionManager([session])
+        original_delete = manager._storage.delete_session
+
+        async def observed_delete(key: str) -> None:
+            assert active_fences == {"background", "runtime", "direct", "write"}
+            order.append("delete")
+            await original_delete(key)
+
+        manager._storage.delete_session = observed_delete  # type: ignore[method-assign]
+
+        def evict_runtime_state(
+            session_key: str,
+            *,
+            session_id: str | None = None,
+        ) -> None:
+            assert session_key == session.session_key
+            assert session_id == session.session_id
+            assert active_fences == {"background", "runtime", "direct", "write"}
+            order.append("evict")
+
+        manager.evict_session_runtime_state = evict_runtime_state  # type: ignore[attr-defined]
+
+        async def drain_router(keys: list[str]) -> None:
+            assert keys == [session.session_key]
+            assert active_fences == {"background", "runtime", "direct", "write"}
+            order.append("router-drain")
+
+        async def drain_turn(keys: list[str]) -> None:
+            assert keys == [session.session_key]
+            assert active_fences == {"background", "runtime", "direct", "write"}
+            order.append("turn-drain")
+
+        original_expire = _isolated_approval_queue.expire_pending_for_session
+
+        def observed_expire(key: str) -> int:
+            assert key == session.session_key
+            assert active_fences == {"background", "runtime", "direct", "write"}
+            order.append("expire")
+            return original_expire(key)
+
+        monkeypatch.setattr(
+            rpc_sessions,
+            "quiesce_background_completion_sessions",
+            lambda keys: fence("background", keys),
+        )
+        monkeypatch.setattr(
+            rpc_sessions,
+            "get_agent_task_registry",
+            lambda: SimpleNamespace(
+                quiesce_sessions=lambda keys: fence("direct", keys),
+            ),
+        )
+        monkeypatch.setattr(
+            rpc_sessions,
+            "drain_pending_flushes_for_sessions",
+            drain_router,
+        )
+        monkeypatch.setattr(
+            _isolated_approval_queue,
+            "expire_pending_for_session",
+            observed_expire,
+        )
+        ctx = make_ctx(
+            session_manager=manager,
+            task_runtime=SimpleNamespace(
+                quiesce_sessions=lambda keys: fence("runtime", keys),
+            ),
+            turn_runner=SimpleNamespace(
+                get_session_lock=lambda _key: WriteLock(),
+                drain_session_background_writes=drain_turn,
+            ),
+        )
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.delete",
+            {"key": session.session_key},
+            ctx,
+        )
+
+        assert res.ok is True
+        assert order == [
+            "background:enter",
+            "runtime:enter",
+            "direct:enter",
+            "write:enter",
+            "router-drain",
+            "turn-drain",
+            "expire",
+            "delete",
+            "evict",
+            "write:exit",
+            "direct:exit",
+            "runtime:exit",
+            "background:exit",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_delete_finishes_after_rpc_cancellation(
+        self,
+        dispatcher,
+        session,
+        _isolated_approval_queue,
+    ):
+        manager = FakeSessionManager([session])
+        delete_started = asyncio.Event()
+        release_delete = asyncio.Event()
+        original_delete = manager._storage.delete_session
+        evicted: list[tuple[str, str | None]] = []
+
+        async def paused_delete(key: str) -> None:
+            delete_started.set()
+            await release_delete.wait()
+            await original_delete(key)
+
+        manager._storage.delete_session = paused_delete  # type: ignore[method-assign]
+        manager.evict_session_runtime_state = (  # type: ignore[attr-defined]
+            lambda key, *, session_id=None: evicted.append((key, session_id))
+        )
+        approval_id = _isolated_approval_queue.request(
+            "plugin",
+            {"session_key": session.session_key, "pluginId": "synthetic-plugin"},
+        )
+
+        deleting = asyncio.create_task(
+            dispatcher.dispatch(
+                "r1",
+                "sessions.delete",
+                {"key": session.session_key},
+                make_ctx(session_manager=manager),
+            )
+        )
+        await asyncio.wait_for(delete_started.wait(), timeout=1)
+        deleting.cancel()
+        await asyncio.sleep(0)
+        assert deleting.done() is False
+
+        release_delete.set()
+        with pytest.raises(asyncio.CancelledError):
+            await deleting
+
+        assert await manager._storage.get_session(session.session_key) is None
+        assert _isolated_approval_queue.get(approval_id).resolution == "expired"
+        assert evicted == [(session.session_key, session.session_id)]
+
+    @pytest.mark.asyncio
+    async def test_bulk_delete_isolates_failures_and_repeated_cleanup_is_idempotent(
+        self,
+        dispatcher,
+        session,
+        _isolated_approval_queue,
+    ):
+        missing_key = "agent:main:webchat:missing-bulk"
+        manager = FakeSessionManager([session])
+        matching_ids = [
+            _isolated_approval_queue.request(
+                "exec",
+                {"sessionKey": session.session_key, "toolName": "existing-shell"},
+            ),
+            _isolated_approval_queue.request(
+                "plugin",
+                {"session_key": missing_key, "pluginId": "orphaned-plugin"},
+            ),
+        ]
+        resolved_events: list[str] = []
+        _isolated_approval_queue.add_event_listener(
+            lambda event, info: (
+                resolved_events.append(str(info["id"]))
+                if event == "resolved"
+                else None
+            )
+        )
+        ctx = make_ctx(session_manager=manager)
+
+        first = await dispatcher.dispatch(
+            "r1",
+            "sessions.delete",
+            {"keys": [session.session_key, missing_key]},
+            ctx,
+        )
+        second = await dispatcher.dispatch(
+            "r2",
+            "sessions.delete",
+            {"keys": [session.session_key, missing_key]},
+            ctx,
+        )
+
+        assert first.ok is True
+        assert first.payload["deleted"] == [session.session_key]
+        assert len(first.payload["errors"]) == 1
+        assert second.ok is True
+        assert second.payload["deleted"] == []
+        assert len(second.payload["errors"]) == 2
+        assert {
+            _isolated_approval_queue.get(approval_id).resolution
+            for approval_id in matching_ids
+        } == {"expired"}
+        assert resolved_events == matching_ids
 
 
 class TestSessionsCompact:


### PR DESCRIPTION
## Summary

- fence and drain all known Session writers before persistent deletion
- expire owned exec/plugin approvals, emit the existing resolved events, and evict in-memory Session state
- remove deleted Session approvals from app-wide and Sessions-page UI state immediately
- preserve canonical-key handling, bulk partial-success responses, and exact-key (non-cascading) deletion

## Root cause

`sessions.delete` removed only the persisted Session row. Pending approvals and background writers could outlive that row, leaving the approval/needs-input Badge visible and allowing late writes to recreate deleted Session state.

## Target

`main`

## Linked issue

Fixes #847

## Release note

Fixed: deleting a Session now clears its pending approval/needs-input Badge and prevents late runtime writes from recreating deleted state.

## Validation

- `uv run pytest -q tests/test_gateway/test_rpc_sessions.py tests/test_gateway/test_approval_queue_persistence.py tests/test_gateway/test_approval_event_push.py tests/test_gateway/test_task_runtime_terminal_cleanup.py` — 254 passed, 1 skipped
- `cd opensquilla-webui && npm run test:unit` — 230 files, 2350 tests passed
- `cd opensquilla-webui && npm run typecheck && npm run build` — passed
- `uv run ruff check src/opensquilla/gateway/rpc_sessions.py tests/test_gateway/test_rpc_sessions.py` — passed
- `git diff --check` — passed

## Safety and compatibility

- no Gateway RPC shape, WebSocket event name, approval protocol, database schema, sandbox policy, or persisted format changes
- deletion remains exact-key only; child Sessions and unscoped/other-Session approvals are preserved
- modern runtime quiescing is capability-detected for compatibility with older contexts
- platform-neutral behavior across Windows, macOS, and Linux

## Third-party origin

None.