### PR TITLE
Prepare OpenSquilla 0.5.1 release

### DIFF
--- a/.github/scripts/verify-release-profile-preservation.py
+++ b/.github/scripts/verify-release-profile-preservation.py
@@ -139,6 +139,21 @@ def _config_text(home: Path, label: str) -> str:
         f"# Synthetic {label} release-preservation profile\n"
         f"state_dir = {json.dumps(str(home / 'state'))}\n"
         f"workspace_dir = {json.dumps(str(home / 'workspace'))}\n"
+        'search_provider = "duckduckgo"\n'
+        "\n"
+        "[llm]\n"
+        'provider = "ollama"\n'
+        'model = "opensquilla-release-session-recovery-smoke"\n'
+        'base_url = "http://127.0.0.1:11434"\n'
+        "\n"
+        "[squilla_router]\n"
+        "enabled = false\n"
+        "\n"
+        "[llm_ensemble]\n"
+        "enabled = false\n"
+        "\n"
+        "[privacy]\n"
+        "disable_network_observability = false\n"
     )
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-29
+
 ### Added
 
+- Durable Plan mode, project workspaces, native macOS project-folder creation,
+  desktop deep links, richer artifact workbench previews, and general pasted
+  file attachments.
+- Qwen Token Plan and custom Anthropic-compatible providers.
+- Recoverable Desktop profile import and bounded primary-profile
+  consolidation.
 - New agent tool `audio_config`: configures the audio (TTS) provider through
   the same validated path as onboarding — atomic UTF-8 persistence with
   backup, live hot-apply, and `restartRequired: false`. Agent-driven setup is
@@ -17,6 +25,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Local-owner `bypass` again resolves to Full host execution consistently
+  across Web, CLI, TaskRuntime, and Cron. Full file, Shell, and Git operations
+  no longer initialize a sandbox worker or apply sandbox path checks.
+- Cron creation is atomically idempotent for identical tool requests, and
+  owner jobs preserve their host execution target.
+- Frozen macOS filesystem workers start through the packaged gateway's
+  dedicated worker entry point, while frozen Windows gateways resolve sandbox
+  setup paths correctly.
+- First-install provider and model routing state, long-session recovery,
+  reasoning timers, subagent usage accounting, and session deletion lifecycle
+  handling are more reliable.
+- Settings overlays cover the viewport, Skills navigation remains stable, and
+  project/chat activity, onboarding, assistant activity, and provider settings
+  are clearer.
 - The `gateway` tool no longer advertises capabilities it cannot deliver:
   `restart` and `config_set` now report their actual availability, audio
   settings point to `audio_config`, and `config_get` uses the canonical
@@ -32,6 +54,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- The packaged Desktop gateway carries its CA trust bundle, channel
+  administration approvals are aligned, and coding/delivery guidance now
+  reflects actual runtime capability.
 - Desktop now consolidates data from legacy recovery profiles into the single
   primary profile before startup. Existing primary settings remain
   authoritative; when the primary profile has no settings, the newest legacy

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,6 +26,22 @@ trailers.
 | [@ab2ence](https://github.com/ab2ence) | macOS Seatbelt backend execution, denial escalation, and release-candidate type-check cleanup. | [#46](https://github.com/opensquilla/opensquilla/pull/46), [`fb1e6225`](https://github.com/opensquilla/opensquilla/pull/46/commits/fb1e6225e4db9cb0801ea347a89c2066e3e0601b), [`f73ac3eb`](https://github.com/opensquilla/opensquilla/pull/46/commits/f73ac3eb0044c64c79cfd18f9ec03d1bba9128ff), [`cf3b046f`](https://github.com/opensquilla/opensquilla/pull/46/commits/cf3b046f42a42efc951320b0af80e9d066dcf7d2) |
 | [@kimjune01](https://github.com/kimjune01) | Provider stream timeout cleanup fix that prevents double-closing provider streams. | [#46](https://github.com/opensquilla/opensquilla/pull/46), [`06e3126d`](https://github.com/opensquilla/opensquilla/pull/46/commits/06e3126d8ebda4ad4cf349ca7be0d0804e0c008d) |
 
+## OpenSquilla 0.5.1
+
+The 0.5.1 maintenance release records new human contributor work after the
+0.5.0 stable release.
+
+| Contributor | 0.5.1 contribution | Evidence |
+| --- | --- | --- |
+| [@joyfan621-png](https://github.com/joyfan621-png) | Improved Desktop onboarding and startup presentation, project and chat UX, provider settings, and Settings overlay behavior. | [#819](https://github.com/opensquilla/opensquilla/pull/819), [#832](https://github.com/opensquilla/opensquilla/pull/832), [#836](https://github.com/opensquilla/opensquilla/pull/836), [#838](https://github.com/opensquilla/opensquilla/pull/838), [#856](https://github.com/opensquilla/opensquilla/pull/856), [#868](https://github.com/opensquilla/opensquilla/pull/868) |
+| [@jiaoqingrui](https://github.com/jiaoqingrui) | Added Desktop deep linking and consolidated recovery profiles without discarding existing recovery data. | [#800](https://github.com/opensquilla/opensquilla/pull/800), [#828](https://github.com/opensquilla/opensquilla/pull/828), [#864](https://github.com/opensquilla/opensquilla/pull/864) |
+| [@shixi-li](https://github.com/shixi-li) | Corrected subagent usage rollup into the parent turn. | [#845](https://github.com/opensquilla/opensquilla/pull/845) |
+| [@Liu-RK](https://github.com/Liu-RK) | Added and hardened project workspaces, improved the macOS project picker, and fixed frozen Windows gateway sandbox setup paths. | [#831](https://github.com/opensquilla/opensquilla/pull/831), [#850](https://github.com/opensquilla/opensquilla/pull/850), [#851](https://github.com/opensquilla/opensquilla/pull/851), [#857](https://github.com/opensquilla/opensquilla/pull/857) |
+| [@RickyYii](https://github.com/RickyYii) | Isolated ambient proxy state from direct-upstream sandbox checks. | [#817](https://github.com/opensquilla/opensquilla/pull/817) |
+| [@HuaXiawithMoon](https://github.com/HuaXiawithMoon) | Propagated reasoning levels through direct and custom Model Ensemble paths. | [#797](https://github.com/opensquilla/opensquilla/pull/797) |
+| [@TUOXI293](https://github.com/TUOXI293) | Refined Cron, Skills, and MetaSkill workflows. | [#829](https://github.com/opensquilla/opensquilla/pull/829) |
+| [@JarvisPei](https://github.com/JarvisPei) | Added safe audio configuration, corrected gateway tool capabilities, and prevented gateway self-termination through Shell tools. | [#821](https://github.com/opensquilla/opensquilla/pull/821), [#822](https://github.com/opensquilla/opensquilla/pull/822) |
+
 ## OpenSquilla 0.5.0
 
 The 0.5.0 stable release records new human contributor work after the 0.5.0

--- a/README.de.md
+++ b/README.de.md
@@ -49,7 +49,7 @@ Provider-Schicht spricht mit TokenRhythm, OpenRouter, OpenAI, Anthropic, Ollama,
 DeepSeek, Gemini, Qwen/DashScope und über 20 weiteren LLM-Providern —
 ohne Änderung an deinem Code oder deinem Konfigurationsschema.
 
-OpenSquilla 0.5.0 ist die aktuelle stabile Version.
+OpenSquilla 0.5.1 ist die aktuelle stabile Version.
 
 Für aufgabenorientierte Produktdokumentation beginnst du am besten mit
 dem [OpenSquilla-Produktleitfaden](README.product.md) oder dem
@@ -75,10 +75,10 @@ Python-Wheel-Installationen verwenden versionsbehaftete Wheel-Dateinamen,
 weil die Installationsprogramme die im Wheel-Dateinamen eingebettete
 Version prüfen.
 
-Für den Desktop-Einsatz von 0.5.0 bevorzugst du die gepackten
+Für den Desktop-Einsatz von 0.5.1 bevorzugst du die gepackten
 Desktop-Installationsprogramme aus dem GitHub-Release:
-`OpenSquilla-0.5.0-mac-arm64.dmg` unter macOS und
-`OpenSquilla-0.5.0-win-x64.exe` unter Windows.
+`OpenSquilla-0.5.1-mac-arm64.dmg` unter macOS und
+`OpenSquilla-0.5.1-win-x64.exe` unter Windows.
 
 | Weg | Zielgruppe | Wann verwenden |
 | --- | --- | --- |
@@ -132,8 +132,8 @@ Installationslinks: [Git](https://git-scm.com/downloads) ·
 Die 0.5.0-Preview-4-Desktop-Installationsprogramme bündeln die Vue-Steuerkonsole
 und die Gateway-Runtime in einer Electron-Hülle.
 
-- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-mac-arm64.dmg>
-- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-win-x64.exe>
+- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg>
+- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe>
 
 Für schnellere Downloads in Festlandchina verwende die direkten OSS-Download-Aliasse:
 - macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -183,7 +183,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. OpenSquilla installieren** — derselbe Befehl auf jeder Plattform.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
 ```
 
 Damit wird das OpenSquilla-Wheel von der Release-URL installiert;
@@ -211,7 +211,7 @@ opensquilla gateway run
 
 Für eine vollständig festgelegte Installation verwende die
 versionsbehaftete Wheel-URL:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`.
 
 <a id="install-from-source"></a>
 

--- a/README.es.md
+++ b/README.es.md
@@ -40,7 +40,7 @@ OpenSquilla es un agente de IA con microkernel y eficiente en el uso de tokens. 
 
 Cada punto de entrada —Web UI, CLI y canales de chat— se ejecuta a través de ese mismo bucle, de modo que el envío de herramientas, los reintentos y el registro de decisiones se comportan de forma idéntica en todas partes. Una capa de proveedores conectable se comunica con TokenRhythm, OpenRouter, OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope y más de 20 proveedores de LLM adicionales, sin ningún cambio en tu código ni en el esquema de configuración.
 
-OpenSquilla 0.5.0 es la versión estable actual.
+OpenSquilla 0.5.1 es la versión estable actual.
 
 Para documentación de producto orientada a tareas, comienza por la [Guía de producto de OpenSquilla](README.product.md) o el [índice de documentación](docs/README.md).
 
@@ -54,7 +54,7 @@ Los instaladores de escritorio y la instalación rápida desde terminal te ofrec
 
 Los comandos de instalación de versiones usan los recursos de release publicados en GitHub. Las instalaciones del wheel de Python usan nombres de archivo de wheel con versión, porque los instaladores validan la versión incrustada en el nombre del archivo del wheel.
 
-Para el uso de escritorio de 0.5.0, opta por los instaladores de escritorio empaquetados de la Release de GitHub: `OpenSquilla-0.5.0-mac-arm64.dmg` en macOS y `OpenSquilla-0.5.0-win-x64.exe` en Windows.
+Para el uso de escritorio de 0.5.1, opta por los instaladores de escritorio empaquetados de la Release de GitHub: `OpenSquilla-0.5.1-mac-arm64.dmg` en macOS y `OpenSquilla-0.5.1-win-x64.exe` en Windows.
 
 | Ruta | Público | Cuándo usarla |
 | --- | --- | --- |
@@ -89,8 +89,8 @@ Enlaces de instalación: [Git](https://git-scm.com/downloads) ·
 
 Los instaladores de escritorio de 0.5.0 empaquetan la consola de control de Vue y el runtime del gateway en una carcasa de Electron.
 
-- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-mac-arm64.dmg>
-- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-win-x64.exe>
+- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg>
+- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe>
 
 Para descargas más rápidas desde China continental, usa los alias de descarga directa de OSS:
 - macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -132,7 +132,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Instala OpenSquilla**: el mismo comando en todas las plataformas.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
 ```
 
 Esto instala el wheel de OpenSquilla desde la URL de la release y luego deja que `uv` descargue las dependencias declaradas por los extras seleccionados. El extra predeterminado `recommended` incluye dependencias del runtime de SquillaRouter como ONNX Runtime, LightGBM, NumPy y tokenizers, así que una primera instalación necesita acceso a la red salvo que esos wheels ya estén en caché. `uv` no instala runtimes nativos del sistema como `libomp` de macOS o el Visual C++ Redistributable de Windows; consulta [Solución de problemas](#troubleshooting) si el runtime del enrutador informa de un error de carga de biblioteca nativa.
@@ -148,7 +148,7 @@ opensquilla gateway run
 > Si no se encuentra `opensquilla` justo después de una instalación nueva con `uv`, abre una terminal nueva o vuelve a ejecutar la línea de PATH del paso 1.
 
 Para una instalación totalmente fijada, usa la URL del wheel con versión:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`.
 
 <a id="install-from-source"></a>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -49,7 +49,7 @@ enfichable dialogue avec TokenRhythm, OpenRouter, OpenAI, Anthropic, Ollama, Dee
 Qwen/DashScope et plus de 20 autres fournisseurs de LLM, sans aucun changement dans
 votre code ni dans votre schéma de configuration.
 
-OpenSquilla 0.5.0 est la version stable actuelle.
+OpenSquilla 0.5.1 est la version stable actuelle.
 
 Pour une documentation produit orientée tâches, commencez par le
 [Guide produit OpenSquilla](README.product.md) ou par l'[index de la
@@ -74,9 +74,9 @@ GitHub publiées. Les installations de wheel Python utilisent des noms de fichie
 wheel versionnés, car les installateurs valident la version intégrée au nom de
 fichier du wheel.
 
-Pour un usage bureau en 0.5.0, préférez les installateurs de bureau empaquetés issus de la
-Release GitHub : `OpenSquilla-0.5.0-mac-arm64.dmg` sous macOS et
-`OpenSquilla-0.5.0-win-x64.exe` sous Windows.
+Pour un usage bureau en 0.5.1, préférez les installateurs de bureau empaquetés issus de la
+Release GitHub : `OpenSquilla-0.5.1-mac-arm64.dmg` sous macOS et
+`OpenSquilla-0.5.1-win-x64.exe` sous Windows.
 
 | Voie | Public | Quand l'utiliser |
 | --- | --- | --- |
@@ -128,8 +128,8 @@ Liens d'installation : [Git](https://git-scm.com/downloads) ·
 Les installateurs de bureau 0.5.0 empaquettent la console de contrôle Vue et
 l'environnement d'exécution de la passerelle dans une enveloppe Electron.
 
-- macOS Apple Silicon : <https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-mac-arm64.dmg>
-- Windows x64 : <https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-win-x64.exe>
+- macOS Apple Silicon : <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg>
+- Windows x64 : <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe>
 
 Pour des téléchargements plus rapides depuis la Chine continentale, utilisez les alias de téléchargement direct OSS :
 - macOS Apple Silicon : <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -178,7 +178,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Installer OpenSquilla** — la même commande sur toutes les plateformes.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
 ```
 
 Cela installe le wheel OpenSquilla depuis l'URL de release, puis laisse `uv`
@@ -203,7 +203,7 @@ opensquilla gateway run
 > nouveau terminal, ou réexécutez la ligne PATH de l'étape 1.
 
 Pour une installation entièrement épinglée, utilisez l'URL de wheel versionnée :
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`.
 
 <a id="install-from-source"></a>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,7 +40,7 @@ OpenSquilla は、Token を効率的に使うマイクロカーネル AI Agent �
 
 すべての入口——Web UI、CLI、チャットチャネル——が同じループ上で動くため、ツールのディスパッチ、リトライ、判断ログの挙動はどこでも同一です。プラグイン可能なプロバイダ層は TokenRhythm、OpenRouter、OpenAI、Anthropic、Ollama、DeepSeek、Gemini、Qwen/DashScope をはじめとする 20 以上の LLM プロバイダと、あなたのコードや設定スキーマを変えることなくやり取りします。
 
-OpenSquilla 0.5.0 が現在の安定版リリースです。
+OpenSquilla 0.5.1 が現在の安定版リリースです。
 
 タスク指向の製品ドキュメントについては、[OpenSquilla 製品ガイド](README.product.md)または[ドキュメント索引](docs/README.md)から始めてください。
 
@@ -54,7 +54,7 @@ OpenSquilla は Windows、macOS、Linux で動作します。ご自身のユー�
 
 リリース版のインストールコマンドは、公開された GitHub リリースのアセットを使います。Python wheel のインストールでは、バージョン付きの wheel ファイル名を使います。インストーラーが wheel ファイル名に埋め込まれたバージョンを検証するためです。
 
-0.5.0 をデスクトップで使う場合は、GitHub リリースからパッケージ版デスクトップインストーラーを使うことをおすすめします。macOS では `OpenSquilla-0.5.0-mac-arm64.dmg`、Windows では `OpenSquilla-0.5.0-win-x64.exe` です。
+0.5.1 をデスクトップで使う場合は、GitHub リリースからパッケージ版デスクトップインストーラーを使うことをおすすめします。macOS では `OpenSquilla-0.5.1-mac-arm64.dmg`、Windows では `OpenSquilla-0.5.1-win-x64.exe` です。
 
 | 方法 | 対象 | 使うべき場面 |
 | --- | --- | --- |
@@ -87,10 +87,10 @@ macOS のターミナルインストールでは、SquillaRouter の LightGBM �
 
 ### デスクトップインストーラー
 
-0.5.0 のデスクトップインストーラーは、Vue 製コントロールコンソールとゲートウェイランタイムを Electron シェルにまとめています。
+0.5.1 のデスクトップインストーラーは、Vue 製コントロールコンソールとゲートウェイランタイムを Electron シェルにまとめています。
 
-- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-mac-arm64.dmg>
-- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-win-x64.exe>
+- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg>
+- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe>
 
 中国本土からより高速にダウンロードするには、OSS の直接ダウンロード用エイリアスを使用してください。
 - macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -127,7 +127,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. OpenSquilla をインストールする**——どのプラットフォームでも同じコマンドです。
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
 ```
 
 これはリリース URL から OpenSquilla wheel をインストールし、続いて `uv` が、選択した extra が宣言する依存関係をダウンロードします。デフォルトの `recommended` extra には、ONNX Runtime、LightGBM、NumPy、tokenizers といった SquillaRouter のランタイム依存関係が含まれるため、これらの wheel がすでにキャッシュされていない限り、初回インストールにはネットワークアクセスが必要です。`uv` は macOS の `libomp` や Windows の Visual C++ Redistributable のようなシステムネイティブのランタイムはインストールしません。ルーターランタイムがネイティブライブラリの読み込みエラーを報告した場合は、[トラブルシューティング](#troubleshooting)を参照してください。
@@ -143,7 +143,7 @@ opensquilla gateway run
 > 新規の `uv` インストール直後に `opensquilla` が見つからない場合は、新しいターミナルを開くか、ステップ 1 の PATH 設定の行を再実行してください。
 
 完全にバージョンを固定したインストールには、バージョン付きの wheel URL を使ってください:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl`。
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`。
 
 <a id="install-from-source"></a>
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ TokenRhythm, OpenRouter, OpenAI, Anthropic, Ollama, DeepSeek, Gemini,
 Qwen/DashScope, and 20+ other LLM providers with no change to your code or config
 schema.
 
-OpenSquilla 0.5.0 is the current stable release.
+OpenSquilla 0.5.1 is the current stable release.
 
 For task-oriented product documentation, start with the
 [OpenSquilla Product Guide](README.product.md) or the
@@ -65,9 +65,9 @@ contain that console, so their users do **not** need Node.js or npm.
 Release install commands use published GitHub release assets. Python wheel installs use versioned wheel filenames because installers validate the version
 embedded in the wheel filename.
 
-For 0.5.0 desktop use, prefer the packaged desktop installers from
-the GitHub Release: `OpenSquilla-0.5.0-mac-arm64.dmg` on macOS and
-`OpenSquilla-0.5.0-win-x64.exe` on Windows.
+For 0.5.1 desktop use, prefer the packaged desktop installers from
+the GitHub Release: `OpenSquilla-0.5.1-mac-arm64.dmg` on macOS and
+`OpenSquilla-0.5.1-win-x64.exe` on Windows.
 
 | Path | Audience | When to use |
 | --- | --- | --- |
@@ -113,11 +113,11 @@ Install links: [Git](https://git-scm.com/downloads) ·
 
 ### Desktop installers
 
-The 0.5.0 desktop installers package the Vue control console and
+The 0.5.1 desktop installers package the Vue control console and
 gateway runtime in an Electron shell.
 
-- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-mac-arm64.dmg>
-- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-win-x64.exe>
+- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg>
+- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe>
 
 For faster Mainland China downloads, use the OSS direct-download aliases:
 - macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -175,7 +175,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Install OpenSquilla** — the same command on every platform.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
 ```
 
 This installs the OpenSquilla wheel from the release URL, then lets
@@ -199,7 +199,7 @@ opensquilla gateway run
 > a new terminal, or re-run the PATH line from step 1.
 
 For a fully pinned install, use the versioned wheel URL:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`.
 
 ### Install from source
 
@@ -621,8 +621,8 @@ to allow inbound TCP on that port. Do not expose the gateway with
 **Docker**
 
 Prebuilt multi-arch images (`amd64`/`arm64`) are published to
-`ghcr.io/opensquilla/opensquilla` on release tags. 0.5.0 is published as
-both `v0.5.0` and the moving `latest` tag —
+`ghcr.io/opensquilla/opensquilla` on release tags. 0.5.1 is published as
+both `v0.5.1` and the moving `latest` tag —
 [`docs/docker.md`](docs/docker.md) is the full container guide
 (home servers and NAS, LAN exposure with token auth, upgrades):
 

--- a/README.product.md
+++ b/README.product.md
@@ -14,7 +14,7 @@ This guide is the product and usage entry point. The existing
 1. Install OpenSquilla:
 
    ```sh
-   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl"
+   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
    ```
 
 2. Configure your provider:

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -43,7 +43,7 @@ OpenSquilla 是一个高效利用 Token 的微内核 AI Agent。本地模型路�
 Ollama、DeepSeek、Gemini、Qwen/DashScope 等 20 多个 LLM 提供商，无需改动你的代码或
 配置结构。
 
-OpenSquilla 0.5.0 是当前正式发布版本。
+OpenSquilla 0.5.1 是当前正式发布版本。
 
 如需面向任务的产品文档，请从
 [OpenSquilla 产品指南](README.product.md)或[文档索引](docs/README.md)开始。
@@ -59,8 +59,8 @@ OpenSquilla 可运行于 Windows、macOS 和 Linux。请选择与你的使用场
 发布版安装命令使用 GitHub 上已发布的 release 资源。Python wheel 安装使用带版本号的 wheel
 文件名，因为安装器会校验嵌入在 wheel 文件名中的版本号。
 
-对于 0.5.0 的桌面使用，建议从 GitHub Release 下载打包桌面安装包:macOS 上为
-`OpenSquilla-0.5.0-mac-arm64.dmg`，Windows 上为 `OpenSquilla-0.5.0-win-x64.exe`。
+对于 0.5.1 的桌面使用，建议从 GitHub Release 下载打包桌面安装包:macOS 上为
+`OpenSquilla-0.5.1-mac-arm64.dmg`，Windows 上为 `OpenSquilla-0.5.1-win-x64.exe`。
 
 | 安装方式 | 适合人群 | 何时使用 |
 | --- | --- | --- |
@@ -100,10 +100,10 @@ PowerShell 安装器会通过 `winget` 自动装好它；而**终端快速安装
 
 ### 桌面安装包
 
-0.5.0 桌面安装包将 Vue 控制台和网关运行时打包在一个 Electron 外壳中。
+0.5.1 桌面安装包将 Vue 控制台和网关运行时打包在一个 Electron 外壳中。
 
-- macOS Apple Silicon:<https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-mac-arm64.dmg>
-- Windows x64:<https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-win-x64.exe>
+- macOS Apple Silicon:<https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg>
+- Windows x64:<https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe>
 
 中国大陆下载可直接使用 OSS 的固定安装包链接：
 
@@ -146,7 +146,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. 安装 OpenSquilla**——所有平台命令相同。
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
 ```
 
 这会从 release URL 安装 OpenSquilla wheel，再由 `uv` 下载所选 extra 所声明的依赖。
@@ -167,7 +167,7 @@ opensquilla gateway run
 > PATH 设置命令。
 
 如需完全锁定版本的安装，请使用带版本号的 wheel URL:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl`。
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`。
 
 <a id="install-from-source"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 0.5.1 | v0.5.1 | 2026-07-29 | Maintenance: Full host/Cron reliability, Plan mode and project workspaces, artifact previews, desktop recovery, and provider/UI improvements |
 | 0.5.0 | v0.5.0 | 2026-07-23 | Stable: Model Ensemble and multi-provider routing, safer upgrades and profile protection, signed macOS desktop updates, usage reporting, and the OSS download mirror |
 | 0.5.0rc4 | v0.5.0rc4 | 2026-07-13 | Preview: safe profile recovery, explicit Windows Portable transfer, Desktop data retention, update reliability, and OSS downloads |
 | 0.5.0rc3 | v0.5.0rc3 | 2026-07-10 | Preview: legacy-home migration, provider and routing expansion, desktop/Web UI improvements, runtime hardening, and container images |
@@ -28,7 +29,8 @@ updater metadata, the versioned Python wheel, and `SHA256SUMS`:
 - `SHA256SUMS`
 
 0.5.x preview releases are GitHub pre-releases and must not be marked as Latest;
-the 0.5.0 stable is a normal release and may be marked Latest once verified.
+stable releases such as 0.5.1 are normal releases and may be marked Latest
+once verified.
 They do not publish Windows portable zips, Windows portable latest aliases,
 public wheelhouse zips, or separately branded macOS or Linux portable bundles.
 The listed macOS `.zip` is the Electron desktop and updater artifact, not a
@@ -98,9 +100,9 @@ already-installed Windows RC3 still requires a manual, in-place RC4 upgrade.
 
 README install commands must use tag-pinned URLs such as:
 
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-mac-arm64.dmg`
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-win-x64.exe`
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`
 
 ## Release SOP
 
@@ -125,13 +127,13 @@ README install commands must use tag-pinned URLs such as:
    more time, then create the annotated tag on that exact SHA:
 
    ```sh
-   git tag -a v0.5.0 <verified-sha> -m "OpenSquilla 0.5.0"
-   git push origin v0.5.0
+   git tag -a v0.5.1 <verified-sha> -m "OpenSquilla 0.5.1"
+   git push origin v0.5.1
    ```
 
 8. Wait for both `.github/workflows/wheelhouse-release.yml` and
    `.github/workflows/docker-image.yml`. Review the draft GitHub Release. For
-   the `v0.5.0` stable, confirm it is not marked Pre-release, leave Latest
+   the `v0.5.1` stable, confirm it is not marked Pre-release, leave Latest
    unset until the maintainer explicitly confirms it at publish time, and
    confirm it contains only the Electron installers, updater metadata,
    versioned wheel, `SHA256SUMS`, plus GitHub's generated source archives. It
@@ -139,16 +141,16 @@ README install commands must use tag-pinned URLs such as:
    `OpenSquilla-windows-x64-portable.zip`.
 9. Verify GHCR before publishing broadly. For the first container release, make
    the newly created `ghcr.io/opensquilla/opensquilla` package public, then
-   confirm both `v0.5.0` and `latest` resolve to an amd64/arm64 manifest and
+   confirm both `v0.5.1` and `latest` resolve to an amd64/arm64 manifest and
    pass a gateway health smoke test.
 10. Publish the GitHub Release only after maintainer confirmation, then run the
    post-publish tag URL checks:
 
    ```sh
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-mac-arm64.dmg
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/OpenSquilla-0.5.0-win-x64.exe
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/SHA256SUMS
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/SHA256SUMS
    ```
 
 11. If a release tag is wrong before publication, stop and report its peeled
@@ -167,15 +169,15 @@ These checks cannot be fully proven by local artifact generation:
 
 - The tag exists on GitHub and matches `pyproject.toml`.
 - The release workflow can fetch hydrated Git LFS router assets.
-- The draft GitHub Release title is `OpenSquilla 0.5.0`.
-- Preview drafts are marked Pre-release and never Latest; the `v0.5.0`
+- The draft GitHub Release title is `OpenSquilla 0.5.1`.
+- Preview drafts are marked Pre-release and never Latest; the `v0.5.1`
   stable draft is not marked Pre-release, and Latest is applied only at
   publish after explicit maintainer confirmation.
 - Preview GitHub Releases contain the Electron installers, updater metadata,
   versioned wheel, and `SHA256SUMS` after `gh release upload --clobber`.
 - Preview GitHub Releases do not contain Windows portable zips or portable
   latest aliases.
-- The GHCR package is public, and `v0.5.0` plus `latest` expose both amd64
+- The GHCR package is public, and `v0.5.1` plus `latest` expose both amd64
   and arm64 images that pass the gateway health smoke test.
 - After a preview GitHub Release is published, the tag-pinned release asset URLs
   resolve.

--- a/desktop/electron/package-lock.json
+++ b/desktop/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensquilla/desktop-electron",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensquilla/desktop-electron",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensquilla/desktop-electron",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "Electron desktop shell for the OpenSquilla Control UI.",
   "repository": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ root release README with task-oriented guides.
 
 ## Surfaces and Operations
 
+- [`releases/0.5.1.md`](releases/0.5.1.md) - OpenSquilla 0.5.1 release notes.
 - [`releases/0.5.0.md`](releases/0.5.0.md) - OpenSquilla 0.5.0 release notes.
 - [`releases/0.5.0rc3.md`](releases/0.5.0rc3.md) - OpenSquilla 0.5.0 Preview 3 release notes.
 - [`releases/0.5.0rc2.md`](releases/0.5.0rc2.md) - OpenSquilla 0.5.0 Preview 2 release notes.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -147,7 +147,7 @@ combined with `--repo`.
 install path. It requires Docker plus the `swebench` extra.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,swebench] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,swebench] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
 opensquilla swebench pull django__django-16429 --dataset verified
 opensquilla swebench solve django__django-16429 --dataset verified --json
 opensquilla swebench eval predictions.jsonl --dataset verified

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -30,7 +30,7 @@ Python, no Git, no build tools.
 
 Prebuilt multi-arch images are published to
 [`ghcr.io/opensquilla/opensquilla`](https://github.com/opensquilla/opensquilla/pkgs/container/opensquilla)
-for each release tag. The immutable `v0.5.0` tag identifies the 0.5.0 stable release, while
+for each release tag. The immutable `v0.5.1` tag identifies the 0.5.1 stable release, while
 `latest` follows the most recently pushed release tag, including previews and
 backports. If a backport moves `latest`, the newest release workflow is rerun to
 restore the intended ordering. If the release you want predates image
@@ -45,8 +45,8 @@ Create a directory for the deployment and write this `compose.yaml`:
 ```yaml
 services:
   gateway:
-    # Pin v0.5.0 for reproducibility; latest follows the most recent tag push.
-    image: ghcr.io/opensquilla/opensquilla:latest
+    # Pin v0.5.1 for reproducibility; latest follows the most recent tag push.
+    image: ghcr.io/opensquilla/opensquilla:v0.5.1
     environment:
       # In-container bind. Keep it 0.0.0.0 — what the network can reach is
       # decided by `ports` below, not by this value.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -12,7 +12,7 @@ UI, CLI, channels, and gateway control console.
 Install OpenSquilla with the MCP extra when you need this bridge:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
 ```
 
 Start the OpenSquilla gateway:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -176,7 +176,7 @@ opensquilla mcp-server run
 Install with:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
 ```
 
 Use this when another MCP-capable client should access OpenSquilla-managed tools

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,7 +17,7 @@ UI, SquillaRouter, memory/search support, and safe local defaults.
 Install the current release wheel with the recommended extras:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.0/opensquilla-0.5.0-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
 ```
 
 The `recommended` extra includes SquillaRouter dependencies and memory/search

--- a/docs/releases/0.5.1.md
+++ b/docs/releases/0.5.1.md
@@ -1,0 +1,179 @@
+# OpenSquilla 0.5.1
+
+## Overview
+
+OpenSquilla 0.5.1 is a maintenance release for the 0.5 stable line. It
+improves host execution and scheduled-task reliability, adds durable Plan mode
+and project workspaces, expands artifact previews and desktop navigation, and
+hardens profile recovery across macOS and Windows.
+
+Existing gateway configuration, chats, Agents, memory, and scheduled jobs stay
+in place. Users upgrading from 0.5.0 should quit the running Desktop app or
+gateway, install 0.5.1 directly over the current installation, and restart
+OpenSquilla. Normal version upgrades do not require a data transfer.
+
+## ✨ What's Improved
+
+### Full host execution and scheduled tasks
+
+- The local owner `bypass` setting once again means Full host execution across
+  Web, CLI, TaskRuntime, and Cron. File, Shell, and Git tools do not initialize
+  a sandbox worker or apply sandbox path checks for those Full runs.
+- Owner-created Cron jobs preserve their host execution target, while
+  explicitly selected Standard or Trusted jobs remain sandboxed and non-owner
+  channels cannot inherit the local owner's bypass setting.
+- Tool-created Cron jobs now use atomic idempotency, preventing retries or one
+  model response from creating dozens of identical scheduled jobs.
+- Packaged macOS filesystem workers use the frozen gateway's dedicated internal
+  entry point instead of trying to run Python interpreter flags through the
+  gateway executable.
+
+### Plan mode, projects, and artifacts
+
+- Durable Plan mode keeps plans visible and actionable across the full turn
+  lifecycle, with clearer summaries in the execution dock.
+- Project workspaces have a first-class setup flow, improved chat activity
+  presentation, safer sandbox routing, and native folder creation in the macOS
+  project picker.
+- Artifact previews now support richer browser-grade rendering and a more
+  extensible workbench. Pasted files of any supported type can be attached
+  directly from the chat composer.
+- Desktop deep links can open the intended OpenSquilla destination directly,
+  and keyboard zoom plus project setup are more predictable.
+
+### Desktop startup and profile recovery
+
+- Desktop consolidates legacy recovery profiles into the primary profile
+  without silently merging two active profiles. Recovery stays bounded and
+  non-blocking, long-session history remains available, and profile
+  consolidation preserves existing recovery data.
+- Windows Desktop can recoverably import an existing profile, and its frozen
+  gateway now resolves sandbox setup paths correctly.
+- First-install provider and model routing state is retained, the packaged
+  Desktop gateway carries its CA trust bundle, and onboarding is simpler.
+- Session deletion now waits for the active runtime to quiesce, while replay
+  preserves reasoning timers and subagent usage rolls into the parent turn's
+  reported usage.
+
+### Control console and providers
+
+- The control console gains cleaner chat and provider settings, improved
+  assistant activity presentation, stable Skills navigation, safer Settings
+  overlays, and refined Cron, Skills, and MetaSkill workflows.
+- Qwen Token Plan and custom Anthropic-compatible providers are available as
+  first-class choices.
+- Channel administration approvals are consistent again, gateway
+  self-termination attempts are refused, and audio configuration uses a
+  dedicated validated tool path.
+
+## Downloads
+
+Recommended desktop downloads:
+
+- macOS desktop installer: `OpenSquilla-0.5.1-mac-arm64.dmg`
+- macOS desktop zip: `OpenSquilla-0.5.1-mac-arm64.zip`
+- Windows desktop installer: `OpenSquilla-0.5.1-win-x64.exe`
+
+Users in Mainland China can use the stable direct installer links on the
+Alibaba Cloud OSS mirror:
+
+- macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
+- Windows x64: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-win-x64.exe>
+
+Each alias is replaced only after the published release passes checksum
+verification. Versioned OSS and GitHub Release files remain available for
+pinned downloads.
+
+The Windows desktop installer is currently unsigned. See the
+[code signing policy](https://github.com/opensquilla/opensquilla/blob/v0.5.1/docs/code-signing-policy.md)
+before installation.
+
+Terminal and automation downloads:
+
+- Python wheel: `opensquilla-0.5.1-py3-none-any.whl`
+- Checksums: `SHA256SUMS`
+
+Updater metadata:
+
+- `latest-mac.yml`
+- `latest.yml`
+- `*.blockmap`
+
+No Windows Portable assets are published for 0.5.1. Existing 0.4.x Portable
+downloads remain on their original release pages as legacy sources; do not
+expect a 0.5.1 Portable zip or a Portable `/releases/latest/download/` alias.
+
+Privacy and third-party attribution are documented in
+[`PRIVACY.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.1/PRIVACY.md)
+and
+[`THIRD_PARTY_NOTICES.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.1/THIRD_PARTY_NOTICES.md).
+
+Container users can pull the multi-architecture gateway image:
+
+```sh
+docker pull ghcr.io/opensquilla/opensquilla:v0.5.1
+```
+
+The versioned image supports `linux/amd64` and `linux/arm64`. The moving
+`latest` tag follows the most recently verified release tag.
+
+## Upgrading from 0.5.0
+
+Quit the running Desktop app and gateway before upgrading. Back up the active
+profile first if you may need to recover or roll back.
+
+Install 0.5.1 directly over 0.5.0. Existing configuration, chats, Agents,
+memory, and scheduled tasks remain in the active profile.
+
+> [!IMPORTANT]
+> On Windows, users coming from RC3 or an older pre-Preview-4 build must not
+> uninstall that build first: older uninstallers may delete
+> `%APPDATA%\OpenSquilla`. Back up that directory, then install 0.5.1 directly
+> over the existing installation. Preview 4, 0.5.0, and 0.5.1 installers
+> preserve profile data during a normal uninstall.
+
+On macOS, drag the new app into Applications, eject the DMG, and open the
+Applications copy.
+
+CLI users can reinstall the published wheel over the current tool environment:
+
+```sh
+uv tool install --python 3.12 --force --reinstall-package opensquilla \
+  "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
+```
+
+Non-user-initiated network observability can be disabled before startup with
+`OPENSQUILLA_PRIVACY_DISABLE_NETWORK_OBSERVABILITY=true` or:
+
+```toml
+[privacy]
+disable_network_observability = true
+```
+
+The compatibility variables `OPENSQUILLA_TELEMETRY_DISABLED=true` and
+`OPENSQUILLA_UPDATE_CHECK_DISABLED=true` remain honored.
+
+## Acknowledgements
+
+Thanks to the human contributors whose work is newly present in 0.5.1:
+
+- [@joyfan621-png](https://github.com/joyfan621-png) for desktop onboarding,
+  project and chat UX, provider settings, startup presentation, and Settings
+  overlay fixes.
+- [@jiaoqingrui](https://github.com/jiaoqingrui) for desktop deep linking and
+  recovery-profile consolidation that preserves existing data.
+- [@shixi-li](https://github.com/shixi-li) for correct subagent usage rollup.
+- [@Liu-RK](https://github.com/Liu-RK) for project workspace and macOS picker
+  improvements plus Windows frozen-gateway sandbox setup fixes.
+- [@RickyYii](https://github.com/RickyYii) for isolating ambient proxy state
+  from direct-upstream sandbox checks.
+- [@HuaXiawithMoon](https://github.com/HuaXiawithMoon) for propagating
+  reasoning levels through direct and custom Model Ensemble paths.
+- [@TUOXI293](https://github.com/TUOXI293) for refined Cron, Skills, and
+  MetaSkill workflows.
+- [@JarvisPei](https://github.com/JarvisPei) for safe audio configuration,
+  honest gateway tool capabilities, and gateway self-termination protection.
+
+See
+[`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.1/CONTRIBUTORS.md)
+for the release attribution ledger.

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v0.5.0'
+$defaultVersion = 'v0.5.1'
 $repoSlug = if ($env:OPENSQUILLA_REPOSITORY) { $env:OPENSQUILLA_REPOSITORY } else { 'opensquilla/opensquilla' }
 $pythonVersion = if ($env:OPENSQUILLA_PYTHON_VERSION) { $env:OPENSQUILLA_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -94,7 +94,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.5.0. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.5.1. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v0.5.0"
+default_version="v0.5.1"
 repo_slug="${OPENSQUILLA_REPOSITORY:-opensquilla/opensquilla}"
 python_version="${OPENSQUILLA_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v0.5.0|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v0.5.1|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  OPENSQUILLA_VERSION=v0.5.0
+  OPENSQUILLA_VERSION=v0.5.1
   OPENSQUILLA_INSTALL_PROFILE=recommended|core
   OPENSQUILLA_INSTALL_EXTRAS=matrix
   OPENSQUILLA_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported OPENSQUILLA_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.5.0." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.5.1." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/packages/opensquilla-tui-host/pyproject.toml
+++ b/packages/opensquilla-tui-host/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensquilla-tui-host"
-version = "0.5.0"
+version = "0.5.1"
 description = "Self-contained OpenTUI companion host for OpenSquilla"
 license = "Apache-2.0"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensquilla"
-version = "0.5.0"
+version = "0.5.1"
 description = "OpenSquilla — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -12,7 +12,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v0.5.0"
+CURRENT_RELEASE_TAG = "v0.5.1"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -1490,7 +1490,7 @@ def test_interactive_feishu_websocket_prompts_only_core_fields(tmp_path, monkeyp
     assert "uv tool install --python 3.12 --force" in normalized_out
     assert "opensquilla[recommended]" in normalized_out
     assert "https://github.com/opensquilla/opensquilla/releases/download/" in out
-    assert "v0.5.0" in out
+    assert "v0.5.1" in out
     assert "opensquilla.ai/install." not in normalized_out
     assert "uv sync --extra recommended" in normalized_out
     assert "--extra feishu" not in normalized_out

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -13,8 +13,8 @@ from pathlib import Path
 import pytest
 import yaml
 
-CURRENT_VERSION = "0.5.0"
-CURRENT_DESKTOP_VERSION = "0.5.0"
+CURRENT_VERSION = "0.5.1"
+CURRENT_DESKTOP_VERSION = "0.5.1"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 HISTORICAL_PREVIEW_VERSION = "0.2.0rc1"
 HISTORICAL_PREVIEW_TAG = f"v{HISTORICAL_PREVIEW_VERSION}"
@@ -227,6 +227,11 @@ def test_release_profile_preservation_probe_covers_identity_config_and_chat_db(
         capture_output=True,
     )
     assert "profile preservation verified" in verified.stdout
+    config_text = (home / "config.toml").read_text(encoding="utf-8")
+    assert 'provider = "ollama"' in config_text
+    assert 'model = "opensquilla-release-session-recovery-smoke"' in config_text
+    assert 'base_url = "http://127.0.0.1:11434"' in config_text
+    assert "[squilla_router]\nenabled = false" in config_text
     with sqlite3.connect(home / "state" / "sessions.db") as connection:
         long_session = connection.execute(
             """
@@ -617,7 +622,7 @@ def test_release_docs_warn_rc3_users_to_upgrade_in_place() -> None:
     assert "must install the\nnew version directly over the existing installation" in releases
     assert "must not uninstall RC3\nfirst" in releases
     assert "deleteAppDataOnUninstall=false" in releases
-    assert "uninstall a pre-Preview-4 build first" in current_notes
+    assert "must not\n> uninstall that build first" in current_notes
 
 
 def test_privacy_docs_describe_network_observability_controls() -> None:
@@ -876,7 +881,7 @@ def test_historical_040_release_notes_remain_available() -> None:
     assert "OpenSquilla-0.4.0-mac-arm64.dmg" in notes
 
 
-def test_current_release_notes_cover_recovery_transfer_upgrade_and_containers() -> None:
+def test_current_release_notes_cover_host_execution_projects_upgrade_and_containers() -> None:
     notes = Path(f"docs/releases/{CURRENT_VERSION}.md").read_text(encoding="utf-8")
 
     assert "## Downloads" in notes
@@ -884,23 +889,23 @@ def test_current_release_notes_cover_recovery_transfer_upgrade_and_containers() 
     assert f"OpenSquilla-{CURRENT_DESKTOP_VERSION}-mac-arm64.zip" in notes
     assert f"OpenSquilla-{CURRENT_DESKTOP_VERSION}-win-x64.exe" in notes
     assert f"opensquilla-{CURRENT_VERSION}-py3-none-any.whl" in notes
-    assert notes.index("### Model Ensemble and multi-provider routing") < notes.index(
-        "### Safer upgrades, migration, and profile-data protection"
+    assert notes.index("### Full host execution and scheduled tasks") < notes.index(
+        "### Plan mode, projects, and artifacts"
     )
-    assert notes.index("### Channels and runtime reliability") < notes.index(
-        "### Container images and mainland-China downloads"
+    assert notes.index("### Desktop startup and profile recovery") < notes.index(
+        "### Control console and providers"
     )
-    assert notes.index("## Since Preview 4") < notes.index("## Downloads")
+    assert notes.index("## ✨ What's Improved") < notes.index("## Downloads")
     assert "Normal version upgrades do not require a data transfer" in notes
-    assert "not silently overwritten, deleted, or merged" in notes
-    assert "never silently merged" in notes
-    assert "automatic sync" in notes
-    assert "No Windows Portable assets are published for 0.5.0" in notes
-    assert "0.5.0 Portable zip" in notes
-    assert "## Upgrading from 0.4.1 or a 0.5.0 preview" in notes
-    assert "uninstall a pre-Preview-4 build first" in notes
+    assert "Full host execution" in notes
+    assert "atomic idempotency" in notes
+    assert "dedicated internal" in notes
+    assert "No Windows Portable assets are published for 0.5.1" in notes
+    assert "0.5.1 Portable zip" in notes
+    assert "## Upgrading from 0.5.0" in notes
+    assert "must not\n> uninstall that build first" in notes
     assert r"%APPDATA%\OpenSquilla" in notes
-    assert "ghcr.io/opensquilla/opensquilla:v0.5.0" in notes
+    assert "ghcr.io/opensquilla/opensquilla:v0.5.1" in notes
     assert "`latest` tag follows the most recently verified release tag" in notes
     assert (
         "https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/"
@@ -916,9 +921,10 @@ def test_current_release_notes_cover_recovery_transfer_upgrade_and_containers() 
     assert "## Acknowledgements" in notes
     for login in [
         "@HuaXiawithMoon",
-        "@ab2ence",
-        "@nice-code-la",
-        "@nankingjing",
+        "@joyfan621-png",
+        "@jiaoqingrui",
+        "@Liu-RK",
+        "@TUOXI293",
     ]:
         assert login in notes
     assert "CONTRIBUTORS.md" in notes
@@ -931,19 +937,21 @@ def test_docs_index_links_current_release_notes() -> None:
     assert "releases/0.4.0.md" in index
 
 
-def test_current_contributor_ledger_records_050rc4_attribution() -> None:
+def test_current_contributor_ledger_records_051_attribution() -> None:
     ledger = Path("CONTRIBUTORS.md").read_text(encoding="utf-8")
-    section = ledger.split("## OpenSquilla 0.5.0", 1)[1].split("## OpenSquilla 0.5.0rc3", 1)[0]
+    section = ledger.split("## OpenSquilla 0.5.1", 1)[1].split("## OpenSquilla 0.5.0", 1)[0]
 
     expected = {
-        "@HuaXiawithMoon": "#582",
-        "@ab2ence": "#586",
-        "@nice-code-la": "#588",
-        "@nankingjing": "#598",
+        "@joyfan621-png": "#868",
+        "@jiaoqingrui": "#864",
+        "@Liu-RK": "#850",
+        "@HuaXiawithMoon": "#797",
+        "@TUOXI293": "#829",
+        "@JarvisPei": "#821",
     }
     for login, evidence in expected.items():
         assert login in section
         assert evidence in section
-    assert "#636" in section
+    assert "#845" in section
     assert "Codex" not in section
     assert "Claude Code" not in section

--- a/uv.lock
+++ b/uv.lock
@@ -1993,7 +1993,7 @@ wheels = [
 
 [[package]]
 name = "opensquilla"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Scope

Prepare the stable OpenSquilla 0.5.1 release from current `main`.

- bump Python, Desktop, installer, lockfile, and download metadata to 0.5.1
- add 0.5.1 changelog, release notes, contributor ledger, and localized download pointers
- document the immutable Docker image `ghcr.io/opensquilla/opensquilla:v0.5.1` and moving `latest`
- keep the Windows RC3 profile-preservation gate byte-exact while making its synthetic config match the synthetic Ollama credential used by the packaged session-recovery smoke

## Branch target

`main`

## Linked issue

None.

## Release note

`docs/releases/0.5.1.md`

## Verification

- `uv run pytest tests/test_release_consistency.py tests/test_public_release_hygiene.py -q` — 45 passed
- `UV_CACHE_DIR=/private/tmp/opensquilla-release-uv-cache uv lock --check --offline`
- `git diff --check`

The earlier manual Release Assets preflight built and verified the wheel, Web UI, Windows installer, packaged gateway, and gateway smoke. Its remaining Windows failure was classified as a stale synthetic fixture: the session-recovery smoke injected an Ollama credential into a provider-less config, so the new provider reconciliation correctly changed the synthetic config. This PR aligns those synthetic inputs without weakening the exact profile-retention assertion.

## Safety and compatibility

- no production runtime behavior changes in this PR
- existing 0.5.0 configuration, sessions, workspaces, memory, and scheduled jobs remain compatible
- Windows installer remains unsigned and is documented accordingly
- tagged release workflows will publish Draft Release assets plus multi-architecture `linux/amd64` and `linux/arm64` GHCR images

## Third-party origin

None.