### PR TITLE
Stabilize release upgrade verification

### DIFF
--- a/.github/scripts/verify-release-macos-upgrade.sh
+++ b/.github/scripts/verify-release-macos-upgrade.sh
@@ -98,7 +98,7 @@ configured_state = [
 assert len(configured_state) == 1, report
 assert Path(configured_state[0]["path"]).resolve() == home / "state", report
 PY
-python "${probe}" verify --home "${profile}" --label "${label}"
+python "${probe}" verify-runtime --home "${profile}" --label "${label}"
 
 python - "${install_root}/OpenSquilla.app" "${install_root}/OpenSquilla.rc3.app" <<'PY'
 import shutil
@@ -109,4 +109,4 @@ for app_path in sys.argv[1:]:
 PY
 test ! -e "${install_root}/OpenSquilla.app"
 test ! -e "${install_root}/OpenSquilla.rc3.app"
-python "${probe}" verify --home "${profile}" --label "${label}"
+python "${probe}" verify-runtime --home "${profile}" --label "${label}"

--- a/.github/scripts/verify-release-profile-preservation.py
+++ b/.github/scripts/verify-release-profile-preservation.py
@@ -157,6 +157,34 @@ def _config_text(home: Path, label: str) -> str:
     )
 
 
+def _runtime_config_text(home: Path) -> str:
+    """Return the deterministic config produced by the first current-runtime load."""
+
+    return (
+        f"state_dir = {json.dumps(str(home / 'state'))}\n"
+        f"workspace_dir = {json.dumps(str(home / 'workspace'))}\n"
+        'search_provider = "duckduckgo"\n'
+        "config_version = 1\n"
+        "\n"
+        "[llm]\n"
+        'provider = "ollama"\n'
+        'model = "opensquilla-release-session-recovery-smoke"\n'
+        'base_url = "http://127.0.0.1:11434"\n'
+        "\n"
+        "[squilla_router]\n"
+        "enabled = false\n"
+        "\n"
+        "[llm_ensemble]\n"
+        "enabled = false\n"
+        "\n"
+        "[privacy]\n"
+        "disable_network_observability = false\n"
+        "\n"
+        "[control_ui]\n"
+        'default_locale = "en"\n'
+    )
+
+
 def _long_history_message(label: str, index: int) -> str:
     return f"Synthetic retained history message {index:04d} ({label})"
 
@@ -246,7 +274,7 @@ def seed_profile(home: Path, label: str) -> None:
             raise RuntimeError(f"seeded sessions.db failed PRAGMA quick_check: {result!r}")
 
 
-def verify_profile(home: Path, label: str) -> None:
+def verify_profile(home: Path, label: str, *, runtime_migrated: bool = False) -> None:
     """Verify exact fixture bytes and a read-only SQLite integrity probe."""
 
     home = home.resolve()
@@ -258,8 +286,12 @@ def verify_profile(home: Path, label: str) -> None:
             raise AssertionError(f"{name} changed while installing or uninstalling Desktop")
 
     actual_config = (home / "config.toml").read_text(encoding="utf-8")
-    if actual_config != _config_text(home, label):
-        raise AssertionError("config.toml changed while installing or uninstalling Desktop")
+    expected_config = (
+        _runtime_config_text(home) if runtime_migrated else _config_text(home, label)
+    )
+    if actual_config != expected_config:
+        phase = "after expected runtime migration" if runtime_migrated else "during installation"
+        raise AssertionError(f"config.toml changed unexpectedly {phase}")
 
     database = state / "sessions.db"
     with sqlite3.connect(f"{database.as_uri()}?mode=ro", uri=True) as connection:
@@ -334,7 +366,7 @@ def verify_profile(home: Path, label: str) -> None:
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
-    parser.add_argument("operation", choices=("seed", "verify"))
+    parser.add_argument("operation", choices=("seed", "verify", "verify-runtime"))
     parser.add_argument("--home", type=Path, required=True)
     parser.add_argument("--label", type=_validated_label, required=True)
     return parser
@@ -347,8 +379,10 @@ def main() -> int:
             seed_profile(args.home, args.label)
             print(f"profile preservation fixture seeded: {args.home}")
         else:
-            verify_profile(args.home, args.label)
-            print(f"profile preservation verified: {args.home}")
+            runtime_migrated = args.operation == "verify-runtime"
+            verify_profile(args.home, args.label, runtime_migrated=runtime_migrated)
+            suffix = " after runtime migration" if runtime_migrated else ""
+            print(f"profile preservation verified{suffix}: {args.home}")
     except (
         AssertionError,
         FileExistsError,

--- a/.github/scripts/verify-release-windows-upgrade.ps1
+++ b/.github/scripts/verify-release-windows-upgrade.ps1
@@ -127,7 +127,7 @@ try {
   ) {
     throw 'Candidate selected a different state directory after upgrade.'
   }
-  python $probe verify --home $profile --label $Label
+  python $probe verify-runtime --home $profile --label $Label
   if ($LASTEXITCODE -ne 0) { throw 'Candidate launch changed RC3 profile data.' }
 
   $uninstaller = Get-ChildItem -LiteralPath $installDir -Filter 'Uninstall*.exe' -File |
@@ -148,7 +148,7 @@ try {
   if (Test-Path -LiteralPath $app -PathType Leaf) {
     throw 'Candidate uninstaller did not remove OpenSquilla.exe.'
   }
-  python $probe verify --home $profile --label $Label
+  python $probe verify-runtime --home $profile --label $Label
   if ($LASTEXITCODE -ne 0) { throw 'Candidate uninstaller changed RC3 profile data.' }
 } finally {
   Stop-InstalledProcesses

--- a/.github/workflows/wheelhouse-release.yml
+++ b/.github/workflows/wheelhouse-release.yml
@@ -406,7 +406,10 @@ jobs:
   build-desktop-windows:
     name: Build unsigned Windows Electron installer
     needs: build-control-ui
-    runs-on: windows-latest
+    # Keep the v0.5.0rc3 upgrade baseline on the OS generation it shipped on.
+    # The legacy NSIS installer can crash with 0xC0000005 on Windows Server 2025
+    # before the candidate installer or profile-preservation checks run.
+    runs-on: windows-2022
     timeout-minutes: 150
     steps:
       - name: Checkout
@@ -959,7 +962,8 @@ jobs:
     name: Audit downloaded Windows draft asset
     if: ${{ github.event_name == 'push' || github.event.inputs.tag != '' }}
     needs: publish-release
-    runs-on: windows-latest
+    # Match the build-time upgrade gate while v0.5.0rc3 is the baseline.
+    runs-on: windows-2022
     timeout-minutes: 75
     permissions:
       contents: write

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -80,6 +80,15 @@ def test_release_workflow_builds_desktop_installers() -> None:
     assert 'gh release upload "${TAG}" dist/* --clobber' in workflow
 
 
+def test_release_workflow_runs_legacy_windows_upgrade_checks_on_server_2022() -> None:
+    workflow = yaml.safe_load(
+        Path(".github/workflows/wheelhouse-release.yml").read_text(encoding="utf-8")
+    )
+
+    assert workflow["jobs"]["build-desktop-windows"]["runs-on"] == "windows-2022"
+    assert workflow["jobs"]["audit-downloaded-windows-release"]["runs-on"] == "windows-2022"
+
+
 def test_tui_companion_remains_development_only() -> None:
     """A normal version tag must not publish the in-repo development host."""
 
@@ -254,6 +263,56 @@ def test_release_profile_preservation_probe_covers_identity_config_and_chat_db(
         320,
     )
     assert last_message == ("Synthetic retained history message 0320 (contract-probe)",)
+
+    runtime_config = (
+        f'state_dir = "{home / "state"}"\n'
+        f'workspace_dir = "{home / "workspace"}"\n'
+        'search_provider = "duckduckgo"\n'
+        "config_version = 1\n"
+        "\n"
+        "[llm]\n"
+        'provider = "ollama"\n'
+        'model = "opensquilla-release-session-recovery-smoke"\n'
+        'base_url = "http://127.0.0.1:11434"\n'
+        "\n"
+        "[squilla_router]\n"
+        "enabled = false\n"
+        "\n"
+        "[llm_ensemble]\n"
+        "enabled = false\n"
+        "\n"
+        "[privacy]\n"
+        "disable_network_observability = false\n"
+        "\n"
+        "[control_ui]\n"
+        'default_locale = "en"\n'
+    )
+    (home / "config.toml").write_text(runtime_config, encoding="utf-8", newline="")
+    runtime_verified = subprocess.run(
+        [
+            sys.executable,
+            str(probe),
+            "verify-runtime",
+            "--home",
+            str(home),
+            "--label",
+            label,
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    assert "profile preservation verified after runtime migration" in runtime_verified.stdout
+    install_phase_rejected = subprocess.run(
+        [sys.executable, str(probe), "verify", "--home", str(home), "--label", label],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    assert install_phase_rejected.returncode != 0
+    assert "during installation" in install_phase_rejected.stderr
+
+    (home / "config.toml").write_text(config_text, encoding="utf-8", newline="")
 
     reseed = subprocess.run(
         [sys.executable, str(probe), "seed", "--home", str(home), "--label", label],
@@ -444,6 +503,8 @@ def test_release_workflow_gates_built_and_downloaded_installers_on_profile_reten
     assert windows_helper.index(
         "test-packaged-session-recovery.mjs"
     ) < windows_helper.index("recovery inspect")
+    assert mac_helper.count("verify-runtime") == 2
+    assert windows_helper.count("verify-runtime") == 2
 
     mac_audit = workflow[
         workflow.index("  audit-downloaded-macos-release:") : workflow.index(

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -265,8 +265,8 @@ def test_release_profile_preservation_probe_covers_identity_config_and_chat_db(
     assert last_message == ("Synthetic retained history message 0320 (contract-probe)",)
 
     runtime_config = (
-        f'state_dir = "{home / "state"}"\n'
-        f'workspace_dir = "{home / "workspace"}"\n'
+        f"state_dir = {json.dumps(str(home / 'state'))}\n"
+        f"workspace_dir = {json.dumps(str(home / 'workspace'))}\n"
         'search_provider = "duckduckgo"\n'
         "config_version = 1\n"
         "\n"


### PR DESCRIPTION
## Scope

- pin the v0.5.0rc3 Windows upgrade baseline to Windows Server 2022 so the legacy NSIS installer does not crash on Server 2025 with 0xC0000005
- keep installation checks byte-exact, then verify the deterministic config_version/control_ui migration after the packaged runtime starts
- retain the migrated config contract through uninstall on macOS and Windows

## Branch target

main

## Linked issue

None

## Release note status

Internal release infrastructure fix; no user-facing release note required.

## Test results

- `tests/test_release_consistency.py`: 33 passed
- runtime verifier passed against the config produced by a real packaged macOS client
- Bash syntax, Python compile, and `git diff --check` passed

## Safety and compatibility

The product installer/runtime behavior is unchanged. The Windows runner pin applies only while v0.5.0rc3 is the upgrade baseline. Existing profiles remain protected: installation is still byte-exact, and post-launch verification accepts only the known deterministic migration before checking uninstall retention.

## Third-party origin

None.