### PR TITLE
Make packaged session recovery interception deterministic

### DIFF
--- a/desktop/electron/scripts/test-packaged-session-recovery.mjs
+++ b/desktop/electron/scripts/test-packaged-session-recovery.mjs
@@ -43,22 +43,32 @@ try {
       OPENSQUILLA_TESTING: '0',
     },
   })
-  const page = await app.firstWindow({ timeout: 60_000 })
-  await waitFor(() => page.url().includes('/control/chat'), 'candidate Control UI')
-
-  await page.routeWebSocket(/\/ws$/, (client) => {
-    socketCount += 1
+  await app.context().routeWebSocket(/\/ws$/, (client) => {
+    let targetSocketCounted = false
+    const countTargetSocket = () => {
+      if (targetSocketCounted) return
+      targetSocketCounted = true
+      socketCount += 1
+    }
     const server = client.connectToServer()
 
     client.onMessage((message) => {
       try {
         const frame = JSON.parse(String(message))
         if (frame?.type === 'req' && injectHang) {
-          if (frame.method === 'chat.history') {
+          if (
+            frame.method === 'chat.history'
+            && frame.params?.sessionKey === sessionKey
+          ) {
+            countTargetSocket()
             heldHistoryRequests += 1
             return
           }
-          if (frame.method === 'sessions.messages.subscribe') {
+          if (
+            frame.method === 'sessions.messages.subscribe'
+            && frame.params?.key === sessionKey
+          ) {
+            countTargetSocket()
             heldSubscribeRequests += 1
             return
           }
@@ -90,6 +100,13 @@ try {
       }
     })
   })
+
+  const page = await app.firstWindow({ timeout: 60_000 })
+  await waitFor(() => page.url().includes('/control/chat'), 'candidate Control UI')
+  // The preceding release-upgrade launch can persist this exact chat URL. In
+  // that case page.goto() below may not create a new socket, so explicitly
+  // reload after installing the context-wide route.
+  await page.reload({ waitUntil: 'domcontentloaded' })
 
   const sessionUrl = new URL(page.url())
   sessionUrl.pathname = '/control/chat'

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -1976,8 +1976,15 @@ def test_packaged_session_recovery_gate_uses_installed_electron_and_real_gateway
     assert "executablePath" in helpers
     assert "--user-data-dir=" in helpers
     assert "connectToServer()" in recovery
+    assert "app.context().routeWebSocket" in recovery
+    assert recovery.index("app.context().routeWebSocket") < recovery.index("app.firstWindow")
+    assert recovery.index("page.reload") < recovery.index("page.goto(sessionUrl")
     assert "chat.history" in recovery
     assert "sessions.messages.subscribe" in recovery
+    assert "frame.params?.sessionKey === sessionKey" in recovery
+    assert "frame.params?.key === sessionKey" in recovery
+    assert "let targetSocketCounted = false" in recovery
+    assert recovery.count("countTargetSocket()") == 2
     assert "client.onMessage" in recovery
     assert "server.onMessage" in recovery
     assert "server.send(message)" in recovery


### PR DESCRIPTION
## Scope

- register packaged recovery WebSocket interception at Electron context scope before waiting for the first window
- explicitly reload after route installation so a persisted same-session URL cannot reuse an unobserved socket
- hold and count only RPC traffic belonging to the synthetic target session
- add release contract coverage for route ordering, reload, and session filtering

## Branch target

`main`

## Linked issue

None

## Release note

Not required: release verification infrastructure only.

## Tests

- `node --check desktop/electron/scripts/test-packaged-session-recovery.mjs`
- `pytest -q tests/test_desktop/test_electron_startup_contract.py -k packaged_session_recovery_gate` (1 passed)

## Safety and compatibility

No product runtime or persisted contract changes. The extra reload and WebSocket interception apply only to the packaged release smoke on macOS and Windows.

## Third-party origin

None.