### PR TITLE
Keep Windows upgrade profile bytes unchanged

### DIFF
--- a/.github/scripts/verify-release-windows-upgrade.ps1
+++ b/.github/scripts/verify-release-windows-upgrade.ps1
@@ -115,7 +115,7 @@ try {
   ) {
     throw 'Candidate selected a different state directory after upgrade.'
   }
-  python $probe verify-runtime --home $profile --label $Label
+  python $probe verify --home $profile --label $Label
   if ($LASTEXITCODE -ne 0) { throw 'Candidate launch changed RC3 profile data.' }
 
   $uninstaller = Get-ChildItem -LiteralPath $installDir -Filter 'Uninstall*.exe' -File |
@@ -136,7 +136,7 @@ try {
   if (Test-Path -LiteralPath $app -PathType Leaf) {
     throw 'Candidate uninstaller did not remove OpenSquilla.exe.'
   }
-  python $probe verify-runtime --home $profile --label $Label
+  python $probe verify --home $profile --label $Label
   if ($LASTEXITCODE -ne 0) { throw 'Candidate uninstaller changed RC3 profile data.' }
 } finally {
   Stop-InstalledProcesses

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -497,8 +497,9 @@ def test_release_workflow_gates_built_and_downloaded_installers_on_profile_reten
         assert contract in session_recovery_smoke
     assert "page.clock" not in session_recovery_smoke
     assert "OPENSQUILLA_TESTING: '0'" in session_recovery_smoke
+    assert "verify-runtime" not in windows_helper
     assert mac_helper.count("verify-runtime") == 2
-    assert windows_helper.count("verify-runtime") == 2
+    assert windows_helper.count("verify --home") == 3
 
     mac_audit = workflow[
         workflow.index("  audit-downloaded-macos-release:") : workflow.index(


### PR DESCRIPTION
## Scope

- make the Windows RC3 upgrade gate require exact unchanged profile bytes after normal candidate launch and uninstall
- leave the macOS upgrade verifier unchanged
- update the release contract to distinguish the platform-specific expectations

## Branch target

`main`

## Linked issue

None

## Release note

Not required: Windows release verification only.

## Tests

- `pytest -q tests/test_release_consistency.py -k release_workflow_gates_built_and_downloaded_installers_on_profile_retention` (1 passed)

## Safety and compatibility

No product, installer payload, persisted config, public API, or macOS behavior changes. After removal of the synthetic credential-writing fault injection, normal Windows launch must preserve the seeded RC3 config exactly instead of being required to rewrite it.

## Third-party origin

None.