### PR TITLE
Keep macOS upgrade profile bytes unchanged

### DIFF
--- a/.github/scripts/verify-release-macos-upgrade.sh
+++ b/.github/scripts/verify-release-macos-upgrade.sh
@@ -90,7 +90,7 @@ configured_state = [
 assert len(configured_state) == 1, report
 assert Path(configured_state[0]["path"]).resolve() == home / "state", report
 PY
-python "${probe}" verify-runtime --home "${profile}" --label "${label}"
+python "${probe}" verify --home "${profile}" --label "${label}"
 
 python - "${install_root}/OpenSquilla.app" "${install_root}/OpenSquilla.rc3.app" <<'PY'
 import shutil
@@ -101,4 +101,4 @@ for app_path in sys.argv[1:]:
 PY
 test ! -e "${install_root}/OpenSquilla.app"
 test ! -e "${install_root}/OpenSquilla.rc3.app"
-python "${probe}" verify-runtime --home "${profile}" --label "${label}"
+python "${probe}" verify --home "${profile}" --label "${label}"

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -497,8 +497,9 @@ def test_release_workflow_gates_built_and_downloaded_installers_on_profile_reten
         assert contract in session_recovery_smoke
     assert "page.clock" not in session_recovery_smoke
     assert "OPENSQUILLA_TESTING: '0'" in session_recovery_smoke
+    assert "verify-runtime" not in mac_helper
     assert "verify-runtime" not in windows_helper
-    assert mac_helper.count("verify-runtime") == 2
+    assert mac_helper.count("verify --home") == 3
     assert windows_helper.count("verify --home") == 3
 
     mac_audit = workflow[


### PR DESCRIPTION
## Scope

- make the macOS RC3 upgrade gate require exact unchanged profile bytes after normal candidate launch and uninstall
- leave the already-green Windows upgrade verifier unchanged
- update the release contract to require exact verification on both platforms

## Branch target

`main`

## Linked issue

None

## Release note

Not required: macOS release verification only.

## Tests

- `bash -n .github/scripts/verify-release-macos-upgrade.sh`
- `pytest -q tests/test_release_consistency.py -k release_workflow_gates_built_and_downloaded_installers_on_profile_retention` (1 passed)

## Safety and compatibility

No product, installer payload, persisted config, public API, or Windows behavior changes. After removal of the synthetic credential-writing fault injection, normal macOS launch must preserve the seeded RC3 config exactly instead of being required to rewrite it.

## Third-party origin

None.