### PR TITLE
Fix Windows Desktop sandbox setup path

### DIFF
--- a/src/opensquilla/sandbox/backend/windows_default_setup.py
+++ b/src/opensquilla/sandbox/backend/windows_default_setup.py
@@ -24,6 +24,13 @@ SETUP_VERSION = 2
 OFFLINE_USERNAME = "OpenSquillaSandbox"
 SETUP_HELPER_REPORT = "setup_helper_report.json"
 SETUP_PROCESS_LOCK_TIMEOUT_MS = 10 * 60 * 1000
+_DESKTOP_PRIMARY_HOME_PARTS = (
+    "AppData",
+    "Roaming",
+    "@opensquilla",
+    "desktop-electron",
+    "opensquilla",
+)
 
 
 @dataclass(frozen=True)
@@ -219,9 +226,7 @@ def run_elevated_setup_helper(path: Path) -> None:
     helper_args = ["--elevated-helper", payload]
     if not getattr(sys, "frozen", False):
         helper_args = ["-m", "opensquilla.sandbox.backend.windows_default_setup", *helper_args]
-    parameters = subprocess.list2cmdline(
-        helper_args
-    )
+    parameters = subprocess.list2cmdline(helper_args)
     exit_code = _shell_execute_runas_and_wait(
         executable=sys.executable,
         parameters=parameters,
@@ -249,7 +254,7 @@ def elevated_setup_helper_main(argv: list[str] | None = None) -> int:
     try:
         with _windows_setup_process_lock(marker_path):
             with _secure_setup_directory_lease(marker_path, profile_path) as lease:
-                if _windows_setup_is_ready(marker_path, profile_path):
+                if _windows_setup_is_ready(marker_path):
                     write_setup_helper_report(
                         marker_path,
                         state="ready",
@@ -339,9 +344,16 @@ def _validated_elevated_setup_target(payload: dict[str, str]) -> tuple[Path, Pat
     if not sid:
         raise OSError("windows_setup_helper_real_user_sid_missing")
     profile_path = _windows_profile_path_for_sid(sid).expanduser().absolute()
-    expected = default_setup_marker_path(profile_path).absolute()
     supplied = Path(payload["markerPath"]).expanduser().absolute()
-    if _setup_path_key(supplied) != _setup_path_key(expected):
+    expected = next(
+        (
+            candidate
+            for candidate in _allowed_setup_marker_paths(profile_path)
+            if _setup_path_key(supplied) == _setup_path_key(candidate)
+        ),
+        None,
+    )
+    if expected is None:
         raise OSError("windows_setup_helper_marker_path_mismatch")
     _validate_existing_non_reparse_components(expected)
     profile_canonical = profile_path.resolve(strict=True)
@@ -351,6 +363,18 @@ def _validated_elevated_setup_target(payload: dict[str, str]) -> tuple[Path, Pat
     except ValueError as exc:
         raise OSError("windows_setup_helper_marker_outside_profile") from exc
     return expected, profile_path
+
+
+def _allowed_setup_marker_paths(profile_path: Path) -> tuple[Path, ...]:
+    # The SID-derived profile is the trusted anchor for both supported state
+    # layouts. Never trust OPENSQUILLA_STATE_DIR in the elevated process: it is
+    # inherited from the unelevated caller and could name an arbitrary path.
+    profile = profile_path.expanduser().absolute()
+    desktop_home = profile.joinpath(*_DESKTOP_PRIMARY_HOME_PARTS)
+    return (
+        default_setup_marker_path(profile).absolute(),
+        (desktop_home / "sandbox" / "setup_marker.json").absolute(),
+    )
 
 
 def _windows_profile_path_for_sid(sid: str) -> Path:
@@ -373,20 +397,13 @@ def _setup_path_key(path: Path) -> str:
     return os.path.normcase(os.path.abspath(str(path))).replace("\\", "/").rstrip("/")
 
 
-def _windows_setup_is_ready(marker_path: Path, profile_path: Path) -> bool:
+def _windows_setup_is_ready(marker_path: Path) -> bool:
     marker = read_setup_marker(marker_path)
     if marker is None or marker.network is None:
         return False
-
-    from opensquilla.sandbox.backend.windows_default_support import (
-        probe_windows_default_support,
+    return marker.setup_version == SETUP_VERSION and marker.network.is_current_for_ports(
+        marker.network.allowed_proxy_ports
     )
-
-    support = probe_windows_default_support(
-        home=profile_path,
-        proxy_ports=marker.network.allowed_proxy_ports,
-    )
-    return support.default_backend_available and support.proxy_allowlist_enforced
 
 
 @contextmanager
@@ -551,7 +568,7 @@ def _secure_setup_directory_lease(
     marker_path: Path,
     profile_path: Path,
 ) -> Iterator[_SetupDirectoryLease]:
-    opensquilla_root = profile_path / ".opensquilla"
+    opensquilla_root = marker_path.parent.parent
     roots = (
         opensquilla_root / "sandbox",
         opensquilla_root / "sandbox-secrets",

--- a/tests/test_sandbox/test_windows_default_network.py
+++ b/tests/test_sandbox/test_windows_default_network.py
@@ -355,6 +355,120 @@ def test_elevated_setup_helper_main_writes_failure_report(monkeypatch, tmp_path)
     assert "Set-LocalUser access denied" in report["detail"]
 
 
+def test_elevated_setup_helper_accepts_desktop_profile_marker(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from opensquilla.sandbox.backend import windows_default_setup as mod
+    from opensquilla.sandbox.backend.windows_default_network import (
+        FIREWALL_RULE_VERSION,
+        WFP_RULE_VERSION,
+        WindowsNetworkSetup,
+    )
+
+    profile = tmp_path / "profile"
+    desktop_home = (
+        profile / "AppData" / "Roaming" / "@opensquilla" / "desktop-electron" / "opensquilla"
+    )
+    desktop_home.mkdir(parents=True)
+    marker = desktop_home / "sandbox" / "setup_marker.json"
+    payload = mod._encode_setup_helper_payload(marker, user_sid="S-1-real")
+    network = WindowsNetworkSetup(
+        offline_user_sid="S-1-offline",
+        allowed_proxy_ports=(48123,),
+        allow_local_binding=False,
+        firewall_rule_version=FIREWALL_RULE_VERSION,
+        wfp_rule_version=WFP_RULE_VERSION,
+    )
+    locked_roots = []
+
+    def fake_lock(
+        marker_path,
+        *,
+        offline_sid,
+        real_user_sid,
+        lease,
+    ):
+        assert marker_path == marker
+        assert offline_sid == "S-1-offline"
+        assert real_user_sid == "S-1-real"
+        assert lease.profile_path == profile
+        locked_roots.extend(lease.roots)
+
+    monkeypatch.setattr(mod, "_windows_profile_path_for_sid", lambda _sid: profile)
+    monkeypatch.setattr(mod, "establish_windows_network_setup", lambda _path: network)
+    monkeypatch.setattr(mod, "lock_persistent_sandbox_dirs", fake_lock)
+
+    assert mod.elevated_setup_helper_main(["--elevated-helper", payload]) == 0
+    assert mod.read_setup_marker(marker) is not None
+    assert mod.read_setup_helper_report(marker) == {
+        "state": "ready",
+        "detail": "setup_complete",
+    }
+    assert locked_roots == [
+        desktop_home / "sandbox",
+        desktop_home / "sandbox-secrets",
+        desktop_home / "sandbox-bin",
+    ]
+
+
+def test_elevated_setup_rejects_unrecognized_marker_inside_profile(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from opensquilla.sandbox.backend import windows_default_setup as mod
+
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    marker = (
+        profile
+        / "AppData"
+        / "Roaming"
+        / "other-app"
+        / "opensquilla"
+        / "sandbox"
+        / "setup_marker.json"
+    )
+    payload = mod._encode_setup_helper_payload(marker, user_sid="S-1-real")
+    monkeypatch.setattr(mod, "_windows_profile_path_for_sid", lambda _sid: profile)
+
+    assert mod.elevated_setup_helper_main(["--elevated-helper", payload]) == 2
+    assert not marker.parent.exists()
+
+
+def test_windows_setup_readiness_uses_validated_desktop_marker(tmp_path) -> None:
+    from opensquilla.sandbox.backend import windows_default_setup as mod
+    from opensquilla.sandbox.backend.windows_default_network import (
+        FIREWALL_RULE_VERSION,
+        WFP_RULE_VERSION,
+        WindowsNetworkSetup,
+    )
+
+    profile = tmp_path / "profile"
+    marker = (
+        profile
+        / "AppData"
+        / "Roaming"
+        / "@opensquilla"
+        / "desktop-electron"
+        / "opensquilla"
+        / "sandbox"
+        / "setup_marker.json"
+    )
+    mod.write_setup_marker(
+        marker,
+        network=WindowsNetworkSetup(
+            offline_user_sid="S-1-offline",
+            allowed_proxy_ports=(48123,),
+            allow_local_binding=False,
+            firewall_rule_version=FIREWALL_RULE_VERSION,
+            wfp_rule_version=WFP_RULE_VERSION,
+        ),
+    )
+
+    assert mod._windows_setup_is_ready(marker) is True
+
+
 def test_elevated_setup_helper_serializes_mutation_and_rechecks_readiness(
     monkeypatch,
     tmp_path,
@@ -380,7 +494,7 @@ def test_elevated_setup_helper_serializes_mutation_and_rechecks_readiness(
     monkeypatch.setattr(
         mod,
         "_windows_setup_is_ready",
-        lambda _marker_path, _profile_path: events.append("ready_check") or False,
+        lambda _marker_path: events.append("ready_check") or False,
         raising=False,
     )
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- allow the elevated Windows sandbox helper to accept the Electron Desktop primary profile marker derived from the requesting user's SID
- keep the existing CLI marker path and reject arbitrary paths inside or outside the user profile
- apply the setup directory lease and readiness check to the validated OpenSquilla home
- add regression coverage for Desktop setup, invalid AppData paths, and Desktop marker readiness

## Root cause

Electron runs the gateway with `OPENSQUILLA_STATE_DIR` under:

`%APPDATA%\@opensquilla\desktop-electron\opensquilla`

The elevated helper previously recomputed only:

`%USERPROFILE%\.opensquilla`

As a result, every normal Desktop setup attempt failed before mutation with `windows_setup_helper_marker_path_mismatch`.

## Validation

- `pytest` targeted Windows setup and Desktop gateway tests: 65 passed, 5 skipped
- `ruff check src tests`
- `mypy src/opensquilla --show-error-codes`
