### PR TITLE
Fix activity timing and startup loader direction

### DIFF
--- a/desktop/electron/src/boot.html
+++ b/desktop/electron/src/boot.html
@@ -135,7 +135,9 @@
       border-radius: 999px;
       background: var(--muted);
       opacity: 0.15;
-      transform: rotate(calc(var(--i) * 45deg));
+      /* Negative phase delays advance toward lower indices. Numbering the
+         segments counter-clockwise makes that visible motion clockwise. */
+      transform: rotate(calc(var(--i) * -45deg));
       transform-origin: 2px 26px;
       animation: loader-segment 1.1s linear infinite;
       animation-delay: calc(var(--i) * -0.1375s);

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
@@ -690,17 +690,20 @@ describe('useChatRpcEventHandlers ensemble activity', () => {
     }
   })
 
-  it('maps ensemble heartbeats to neutral proposer and aggregator phase copy', () => {
+  it('maps ensemble heartbeats without letting channel keepalives replace the phase', () => {
     const { api, stream, stop } = createHarness()
 
     try {
       api.handlers.onRunHeartbeat({ stream_seq: 1, phase: 'ensemble_proposers_wait' })
       expect(stream.setStreamActivity).toHaveBeenLastCalledWith('Generating candidates')
 
-      api.handlers.onRunHeartbeat({ stream_seq: 2, phase: 'ensemble_aggregator_stream' })
+      api.handlers.onRunHeartbeat({ stream_seq: 2, phase: 'channel' })
+      expect(stream.setStreamActivity).toHaveBeenCalledTimes(1)
+
+      api.handlers.onRunHeartbeat({ stream_seq: 3, phase: 'ensemble_aggregator_stream' })
       expect(stream.setStreamActivity).toHaveBeenLastCalledWith('Synthesizing candidates')
 
-      api.handlers.onRunHeartbeat({ stream_seq: 3, phase: 'provider_wait' })
+      api.handlers.onRunHeartbeat({ stream_seq: 4, phase: 'provider_wait' })
       expect(stream.setStreamActivity).toHaveBeenLastCalledWith('Planning next step')
     } finally {
       stop()

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -695,11 +695,15 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     stream.resetStreamIdleTimer()
     if (stream.streamBubble.value && !stream.streamHasVisibleOutput.value) {
       const phase = String(payload.phase || '')
+      // The channel wrapper emits a generic keepalive on the same cadence as
+      // ensemble heartbeats. It proves liveness but does not represent a phase
+      // transition, so changing the activity would restart its timer.
+      const isPhaseAgnosticKeepalive = phase === 'channel'
       if (phase.startsWith('ensemble_proposers')) {
         stream.setStreamActivity('Generating candidates')
       } else if (phase.startsWith('ensemble_aggregator')) {
         stream.setStreamActivity('Synthesizing candidates')
-      } else {
+      } else if (!isPhaseAgnosticKeepalive) {
         stream.setStreamActivity('Planning next step')
       }
     } else if (!stream.streamBubble.value) {


### PR DESCRIPTION
## Scope

Scope boundary: Preserve WebUI ensemble activity timing across generic channel heartbeats, make the desktop startup loader rotate clockwise, and cover the heartbeat behavior with a regression test.

Non-goals: Change heartbeat intervals, provider execution, routing behavior, whole-turn timing semantics, or other desktop startup behavior.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: This regression was diagnosed directly from a user report and does not yet have a separate issue.

## Release Note

Release note: Keep the smart ensemble proposal timer advancing across gateway heartbeats and correct the desktop startup loader rotation direction.

## Root Cause

### Ensemble activity timer

The ensemble provider and gateway channel wrapper both emit heartbeats on a 15-second cadence. When the generic `channel` heartbeat won the timing race, the WebUI changed the activity from `Generating candidates` to `Planning next step`; the following ensemble heartbeat changed it back. Each activity change replaced `startedAt`, so the visible counter restarted even though proposal execution had not restarted.

The generic channel heartbeat now refreshes the hard-idle timer without claiming an execution phase. Real transitions such as proposal generation to candidate synthesis continue to update the activity.

### Desktop startup loader

The loader segments were positioned in increasing clockwise order while negative animation delays advanced the highlighted segment toward lower indices. That combination made the visible highlight move counter-clockwise. The segments are now numbered counter-clockwise, so the existing negative phase progression is displayed clockwise without adding a staggered startup delay.

## Tests

Ruff: N/A — no Python changes

Pytest: N/A — WebUI and static desktop HTML change

Build: WebUI `npm run typecheck` passed, including architecture checks and `vue-tsc --noEmit`; Desktop Electron `npm run build` passed

Regression tests: added

Notes: `npm run test:unit -- --run src/composables/chat/useChatRpcEventHandlers.test.ts` passed all 20 tests; `git diff --check` passed.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: channel

Maintainer-only note: The heartbeat regression is covered at the RPC event-handler boundary. The final packaged-client visual check for clockwise startup rotation was not run locally because the Playwright browser binary is unavailable.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents were not committed. The unrelated local `opensquilla-deep-link-test.html` file remains untracked.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
