### PR TITLE
Restore custom provider Base URL fields

### DIFF
--- a/opensquilla-webui/src/components/setup/SetupProviderPanel.test.ts
+++ b/opensquilla-webui/src/components/setup/SetupProviderPanel.test.ts
@@ -359,6 +359,64 @@ describe('SetupProviderPanel — configured provider management', () => {
     app.unmount()
   })
 
+  it.each([
+    ['custom', 'Custom OpenAI-compatible endpoint'],
+    ['custom_anthropic', 'Custom Anthropic-compatible endpoint'],
+  ])('exposes and edits the Base URL for %s in the provider dialog', async (providerId, label) => {
+    const onUpdateProviderField = vi.fn()
+    const savedBaseUrl = `https://${providerId}.example.test/v1`
+    const { app, el } = await mountPanel({
+      providerSelected: providerId,
+      providerSummary: label,
+      runtimeProviders: [{ providerId, label }],
+      configuredProviders: [{
+        providerId,
+        label,
+        active: true,
+        ready: true,
+        credentialSource: 'explicit',
+        credentialEnv: '',
+        endpointSource: 'explicit',
+        reason: '',
+      }],
+      providerCoreFields: [{ name: 'model', label: 'Model', required: true }],
+      providerAdvancedFields: [
+        { name: 'base_url', label: 'Base URL', required: true },
+      ],
+      providerFieldValue: (field: { name: string }) => ({
+        model: 'test-model',
+        base_url: savedBaseUrl,
+      })[field.name] || '',
+      credentialPanel: {
+        ...(panel().credentialPanel as Record<string, unknown>),
+        providerLabel: label,
+        requiresApiKey: false,
+      },
+    }, { onUpdateProviderField })
+
+    el.querySelector<HTMLButtonElement>(
+      `[data-provider-id="${providerId}"] .setup-provider-card__select`,
+    )?.click()
+    await nextTick()
+
+    const endpoint = document.body.querySelector<HTMLElement>(
+      '[role="dialog"] [data-testid="setup-provider-modal-endpoint"]',
+    )
+    const input = endpoint?.querySelector<HTMLInputElement>(
+      'input[name="setup_provider_base_url"]',
+    )
+    expect(input?.value).toBe(savedBaseUrl)
+
+    input!.value = `https://${providerId}.new.example.test/v1`
+    input!.dispatchEvent(new Event('input', { bubbles: true }))
+    expect(onUpdateProviderField).toHaveBeenCalledWith(
+      'base_url',
+      `https://${providerId}.new.example.test/v1`,
+    )
+
+    app.unmount()
+  })
+
   it('selects the editor from the full information block with native click and Enter semantics', async () => {
     const onSelectConfiguredProvider = vi.fn()
     const { app, el } = await mountPanel({ configuredProviders: configured }, {

--- a/opensquilla-webui/src/components/setup/SetupProviderPanel.vue
+++ b/opensquilla-webui/src/components/setup/SetupProviderPanel.vue
@@ -1099,6 +1099,26 @@ const tokenRhythmCredentialReplacementRequired = computed(() => (
                   <strong>{{ selectedProviderLabel }}</strong>
                 </label>
 
+                <section
+                  v-if="endpointFields.length"
+                  class="setup-provider-modal__endpoint"
+                  data-testid="setup-provider-modal-endpoint"
+                >
+                  <div class="setup-provider-options__head">
+                    <h5>{{ t('setup.provider.endpointTitle', { provider: selectedProviderLabel }) }}</h5>
+                    <p>{{ t('setup.provider.endpointDesc', { provider: selectedProviderLabel }) }}</p>
+                  </div>
+                  <template v-for="field in endpointFields" :key="field.name">
+                    <SetupField
+                      :field="field"
+                      :value="panel.providerFieldValue(field)"
+                      scope="provider"
+                      stack
+                      @update="(name, val) => emit('updateProviderField', name, val)"
+                    />
+                  </template>
+                </section>
+
                 <SetupProviderCredentialCard
                   v-if="panel.credentialPanel"
                   compact
@@ -1791,6 +1811,7 @@ const tokenRhythmCredentialReplacementRequired = computed(() => (
   font-size: var(--fs-md);
 }
 
+.setup-provider-modal__endpoint,
 .setup-provider-modal__model {
   border-top: 1px solid var(--border);
   padding-top: var(--sp-4);


### PR DESCRIPTION
## Scope

Scope boundary: Restore endpoint fields in the visible Provider editor dialog and add regression coverage for Custom OpenAI-compatible and Custom Anthropic-compatible profiles.

Non-goals: Change provider registry metadata, credential storage, endpoint validation, probe behavior, or persistence semantics.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: The regression was reported and reproduced directly without a separate issue.

## Release Note

Release note: Restore Base URL configuration for custom OpenAI-compatible and Anthropic-compatible model providers.

## Root Cause

The provider catalog, form state, probe payload, and save payload continued to support `base_url`. When the visible Provider editor was moved into a modal, only the credential and model controls were included. Endpoint fields remained in the hidden legacy editor, leaving the active modal with no Base URL input.

The modal now renders its endpoint field group before credentials, so required endpoint values can be entered before connection verification. Existing values are hydrated through the same provider form contract and edits continue through the existing `updateProviderField` path.

## Tests

Ruff: N/A — no Python changes

Pytest: N/A — WebUI-only change

Build: `npm run typecheck` passed, including architecture checks and `vue-tsc --noEmit`

Regression tests: added

Notes: `npm run test:unit -- --run src/components/setup/SetupProviderPanel.test.ts src/composables/setup/useSetupCatalog.privacy.test.ts` passed all 198 tests; `git diff --check` passed.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: provider

Maintainer-only note: The visible modal, field hydration, update event, and existing save/probe payload paths are covered by deterministic WebUI tests.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents were not committed. The unrelated local `opensquilla-deep-link-test.html` remains untracked.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
