### PR TITLE
Fix Desktop project picker parity

### DIFF
--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -26,7 +26,7 @@
     "test:update-scheduler": "npm run build && node scripts/test-update-check-scheduler.mjs",
     "test:desktop-locale": "npm run build && node scripts/test-desktop-locale.mjs",
     "test:desktop-zoom": "npm run build && node scripts/test-desktop-zoom-shortcuts.mjs",
-    "test:project-workspace-picker": "node scripts/test-project-workspace-picker.mjs",
+    "test:project-workspace-picker": "npm run build && node scripts/test-project-workspace-picker.mjs",
     "test:gateway-ownership": "npm run build && node scripts/test-desktop-gateway-ownership.mjs",
     "test:gateway-lifecycle": "npm run build && node scripts/test-desktop-gateway-lifecycle.mjs",
     "test:window-lifecycle": "npm run build && node scripts/test-desktop-window-lifecycle.mjs",

--- a/desktop/electron/scripts/test-project-workspace-picker.mjs
+++ b/desktop/electron/scripts/test-project-workspace-picker.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
+import { projectDirectoryDialogOptions } from '../dist/project-directory-picker.js'
 
 const main = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8')
 const preload = readFileSync(new URL('../src/preload.cts', import.meta.url), 'utf8')
@@ -14,23 +15,55 @@ const picker = readFileSync(
   ),
   'utf8',
 )
+const workspaceHandlerStart = main.indexOf(
+  "ipcMain.handle('desktop:workspace:choose-directory'",
+)
+assert.notEqual(workspaceHandlerStart, -1)
+const nextHandlerStart = main.indexOf('\nipcMain.handle(', workspaceHandlerStart + 1)
+assert.notEqual(nextHandlerStart, -1)
+const workspaceHandler = main.slice(workspaceHandlerStart, nextHandlerStart)
 
 assert.match(
   preload,
-  /chooseProjectDirectory:\s*\(\)\s*=>\s*ipcRenderer\.invoke\('desktop:workspace:choose-directory'\)/,
+  /chooseProjectDirectory:\s*\(payload:\s*unknown\)\s*=>\s*\(\s*ipcRenderer\.invoke\('desktop:workspace:choose-directory',\s*payload\)/,
 )
 assert.match(
-  main,
-  /ipcMain\.handle\('desktop:workspace:choose-directory',\s*async\s*\(event\)/,
+  workspaceHandler,
+  /ipcMain\.handle\('desktop:workspace:choose-directory',\s*async\s*\(event,\s*payload:\s*unknown\)/,
 )
-assert.match(main, /trustedControlUiIpc\(event\)/)
-assert.match(main, /properties:\s*\['openDirectory'\]/)
-assert.match(main, /choice\.canceled[\s\S]*return null/)
-assert.match(main, /resolve\(choice\.filePaths\[0\]/)
+assert.match(workspaceHandler, /trustedControlUiIpc\(event\)/)
+assert.match(workspaceHandler, /projectDirectoryDialogOptions\(process\.platform,\s*payload\)/)
+assert.doesNotMatch(workspaceHandler, /title:\s*['"]Choose a project['"]/)
+assert.match(workspaceHandler, /choice\.canceled[\s\S]*return null/)
+assert.match(workspaceHandler, /resolve\(choice\.filePaths\[0\]/)
 assert.match(
   desktopPlatform,
-  /typeof api\.chooseProjectDirectory !== 'function'[\s\S]*return null/,
+  /chooseProjectDirectory\(request\)[\s\S]*api\.chooseProjectDirectory\(request\)/,
 )
+assert.match(picker, /nativePicker\(\{\s*initialPath:\s*props\.initialPath\?\.trim\(\)\s*\|\|\s*undefined,\s*\}\)/)
 assert.match(picker, /catch \(cause\)[\s\S]*phase\.value = 'desktop-error'/)
+
+assert.deepEqual(
+  projectDirectoryDialogOptions('darwin', { initialPath: ' /repos/current ' }),
+  {
+    defaultPath: '/repos/current',
+    properties: ['openDirectory', 'createDirectory'],
+  },
+)
+assert.deepEqual(
+  projectDirectoryDialogOptions('win32', { initialPath: 'C:\\repos\\current' }),
+  {
+    defaultPath: 'C:\\repos\\current',
+    properties: ['openDirectory'],
+  },
+)
+assert.deepEqual(
+  projectDirectoryDialogOptions('linux', { initialPath: 42 }),
+  { properties: ['openDirectory'] },
+)
+assert.equal(
+  Object.hasOwn(projectDirectoryDialogOptions('darwin', null), 'title'),
+  false,
+)
 
 console.log('project workspace picker contract checks passed')

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -89,6 +89,7 @@ import {
   desktopDeepLinkArguments,
   parseDesktopDeepLink,
 } from './desktop-deep-link.js'
+import { projectDirectoryDialogOptions } from './project-directory-picker.js'
 import {
   NATIVE_WORKBENCH_CAPABILITIES,
   NATIVE_WORKBENCH_ARTIFACT_SCHEME,
@@ -10120,12 +10121,12 @@ ipcMain.handle('desktop:preferences:save', async (event, payload: DesktopPrefere
   return await saveDesktopPreferences(payload)
 })
 ipcMain.handle('desktop:artifact:open', async (_event, payload: ArtifactOpenRequest) => openArtifactWithDefaultApp(payload))
-ipcMain.handle('desktop:workspace:choose-directory', async (event) => {
+ipcMain.handle('desktop:workspace:choose-directory', async (event, payload: unknown) => {
   if (!trustedControlUiIpc(event)) return null
-  const choice = await dialog.showOpenDialog(currentMainWindow()!, {
-    title: 'Choose a project',
-    properties: ['openDirectory'],
-  })
+  const choice = await dialog.showOpenDialog(
+    currentMainWindow()!,
+    projectDirectoryDialogOptions(process.platform, payload),
+  )
   if (choice.canceled || choice.filePaths.length !== 1) return null
   return { path: resolve(choice.filePaths[0]!) }
 })

--- a/desktop/electron/src/preload.cts
+++ b/desktop/electron/src/preload.cts
@@ -19,7 +19,9 @@ contextBridge.exposeInMainWorld('opensquillaDesktop', {
   saveDesktopPreferences: (payload: unknown) => ipcRenderer.invoke('desktop:preferences:save', payload),
   setNativeTheme: (payload: unknown) => ipcRenderer.invoke('desktop:theme:set', payload),
   openArtifact: (payload: unknown) => ipcRenderer.invoke('desktop:artifact:open', payload),
-  chooseProjectDirectory: () => ipcRenderer.invoke('desktop:workspace:choose-directory'),
+  chooseProjectDirectory: (payload: unknown) => (
+    ipcRenderer.invoke('desktop:workspace:choose-directory', payload)
+  ),
   getWorkbenchCapabilities: () => ipcRenderer.invoke('desktop:workbench:capabilities'),
   createArtifactPreviewLease: (payload: unknown) => (
     ipcRenderer.invoke('desktop:workbench:preview-lease:create', payload)

--- a/desktop/electron/src/project-directory-picker.ts
+++ b/desktop/electron/src/project-directory-picker.ts
@@ -1,0 +1,21 @@
+import type { OpenDialogOptions } from 'electron'
+
+function requestedInitialPath(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return undefined
+  const initialPath = (payload as Record<string, unknown>).initialPath
+  if (typeof initialPath !== 'string') return undefined
+  return initialPath.trim() || undefined
+}
+
+export function projectDirectoryDialogOptions(
+  platform: NodeJS.Platform,
+  payload: unknown,
+): OpenDialogOptions {
+  const initialPath = requestedInitialPath(payload)
+  return {
+    ...(initialPath ? { defaultPath: initialPath } : {}),
+    properties: platform === 'darwin'
+      ? ['openDirectory', 'createDirectory']
+      : ['openDirectory'],
+  }
+}

--- a/opensquilla-webui/src/components/ProjectWorkspacePickerDialog.test.ts
+++ b/opensquilla-webui/src/components/ProjectWorkspacePickerDialog.test.ts
@@ -10,7 +10,7 @@ const PICKER_KEY = 'agent:main:webchat:picker'
 const mocks = vi.hoisted(() => ({
   platform: {
     files: {} as {
-      chooseProjectDirectory?: () => Promise<{ path: string } | null>
+      chooseProjectDirectory?: (request?: { initialPath?: string }) => Promise<{ path: string } | null>
     },
   },
   rpcCall: vi.fn(),
@@ -483,10 +483,13 @@ describe('ProjectWorkspacePickerDialog', () => {
 
   it('uses the native desktop picker and closes on cancellation', async () => {
     mocks.platform.files.chooseProjectDirectory = vi.fn(async () => null)
-    const { events } = await mountPicker()
+    const { events } = await mountPicker({ initialPath: '/repos/current' })
     await flushPromises()
 
     expect(mocks.platform.files.chooseProjectDirectory).toHaveBeenCalledOnce()
+    expect(mocks.platform.files.chooseProjectDirectory).toHaveBeenCalledWith({
+      initialPath: '/repos/current',
+    })
     expect(events.choose).not.toHaveBeenCalled()
     expect(events.close).toHaveBeenCalledOnce()
     expect(mocks.rpcCall).not.toHaveBeenCalled()

--- a/opensquilla-webui/src/components/ProjectWorkspacePickerDialog.vue
+++ b/opensquilla-webui/src/components/ProjectWorkspacePickerDialog.vue
@@ -384,7 +384,9 @@ async function runNativePicker(epoch: number) {
   phase.value = 'native-picking'
   error.value = ''
   try {
-    const choice = await nativePicker()
+    const choice = await nativePicker({
+      initialPath: props.initialPath?.trim() || undefined,
+    })
     if (epoch !== openEpoch || !props.open) return
     if (choice?.path) {
       const selected = choice.path

--- a/opensquilla-webui/src/platform/desktop.ts
+++ b/opensquilla-webui/src/platform/desktop.ts
@@ -344,10 +344,10 @@ export function createDesktopPlatform(): Platform {
     },
     files: {
       openArtifact: (payload) => requireDesktopApi().openArtifact(payload),
-      async chooseProjectDirectory() {
+      async chooseProjectDirectory(request) {
         const api = requireDesktopApi()
         if (typeof api.chooseProjectDirectory !== 'function') return null
-        return api.chooseProjectDirectory()
+        return api.chooseProjectDirectory(request)
       },
     },
     workbench: {

--- a/opensquilla-webui/src/platform/types.ts
+++ b/opensquilla-webui/src/platform/types.ts
@@ -146,11 +146,18 @@ export interface ArtifactNativeOpenResult {
   message?: string
 }
 
+export interface ProjectDirectoryPickerRequest {
+  /** Directory the native picker should reveal when it opens. */
+  initialPath?: string
+}
+
 export interface PlatformFilesApi {
   /** Write the bytes to a temp file and open it with the OS default app. */
   openArtifact?: (payload: ArtifactOpenRequest) => Promise<ArtifactNativeOpenResult>
   /** Open the trusted host's native folder picker. Undefined on the web. */
-  chooseProjectDirectory?: () => Promise<{ path: string } | null>
+  chooseProjectDirectory?: (
+    request?: ProjectDirectoryPickerRequest,
+  ) => Promise<{ path: string } | null>
 }
 
 export interface NativeWorkbenchCreateSurfaceRequestV1 {

--- a/opensquilla-webui/src/vite-env.d.ts
+++ b/opensquilla-webui/src/vite-env.d.ts
@@ -18,6 +18,7 @@ import type {
   NativeWorkbenchSurfaceEvent,
   NativeWorkbenchSurfaceRectRequest,
   NativeWorkbenchSurfaceResult,
+  ProjectDirectoryPickerRequest,
   WorkbenchPreviewMode,
 } from './platform/types'
 
@@ -85,7 +86,9 @@ declare global {
     abandonCleanupTransaction?: () => Promise<unknown>
     setNativeTheme?: (payload: { source: 'light' | 'dark' | 'system' }) => Promise<unknown>
     openArtifact: (payload: ArtifactOpenRequest) => Promise<ArtifactNativeOpenResult>
-    chooseProjectDirectory: () => Promise<{ path: string } | null>
+    chooseProjectDirectory: (
+      request?: ProjectDirectoryPickerRequest,
+    ) => Promise<{ path: string } | null>
     createWorkbenchSurface?: (
       payload: NativeWorkbenchCreateSurfaceRequest,
     ) => Promise<NativeWorkbenchSurfaceResult>


### PR DESCRIPTION
## Summary

- enable folder creation in the macOS Electron project picker
- let the native system dialog provide all localized window text
- forward the new-task workspace as the native picker's initial directory
- strengthen the Desktop picker contract tests across the renderer, preload, and main process

## Root cause

The Web project picker and Electron App project picker use separate native implementations. The gateway-backed Web picker had already gained macOS folder creation, system localization, and initial-directory support, while the Electron IPC handler still used the older `openDirectory`-only dialog with a hard-coded English title and no request payload.

## Impact

The Desktop App now matches the Web behavior on macOS. Other platforms retain directory-only selection, and migration/recovery directory dialogs are unchanged.

## Validation

- `npm run test:unit` — 239 files, 2461 tests passed
- `npm run build` in `opensquilla-webui`
- `npm run test:project-workspace-picker`
- `npm run test:desktop-locale`
- `npm run test:desktop-zoom`
- `uv run pytest -q tests/test_sandbox/test_rpc_sandbox_access.py -k 'sandbox_path_pick or pick_directory_path'` — 4 passed
