### PR TITLE
Skip unnecessary recovery profile scans

### DIFF
--- a/src/opensquilla/recovery/consolidate.py
+++ b/src/opensquilla/recovery/consolidate.py
@@ -387,7 +387,12 @@ def _validate_recovery_container_metadata(path: Path) -> None:
         )
 
 
-def _validate_base_paths(user_data: Path, primary_home: Path) -> None:
+def _validate_base_paths(
+    user_data: Path,
+    primary_home: Path,
+    *,
+    inspect_primary_tree: bool = True,
+) -> None:
     _plain_directory(user_data, label="Electron userData")
     expected = user_data / "opensquilla"
     if os.path.normcase(os.path.normpath(str(primary_home))) != os.path.normcase(
@@ -401,7 +406,8 @@ def _validate_base_paths(user_data: Path, primary_home: Path) -> None:
     else:
         if _is_link_or_reparse(primary_stat) or not stat.S_ISDIR(primary_stat.st_mode):
             raise UnsafePathError("primary home must be a real directory")
-        profile_no_follow_manifest(primary_home)
+        if inspect_primary_tree:
+            profile_no_follow_manifest(primary_home)
     _plain_optional_file(user_data / _CONTEXT_NAME, label="Desktop profile context")
 
 
@@ -4022,9 +4028,20 @@ def consolidate_recovery_profiles(
     primary_path = _absolute(primary_home)
     journal_path = user_data_path / _JOURNAL_NAME
     try:
-        _validate_base_paths(user_data_path, primary_path)
+        # Most launches have one healthy primary profile and no recovery work.
+        # Validate only the canonical boundary first so an unrelated nested
+        # link/reparse point in the active profile cannot turn that no-op
+        # preflight into a startup-blocking consolidation failure.
+        _validate_base_paths(
+            user_data_path,
+            primary_path,
+            inspect_primary_tree=False,
+        )
         journal = _load_journal(journal_path, user_data_path, primary_path)
         if journal is not None:
+            # A durable transaction may have moved or published the primary,
+            # so preserve the strict no-follow inspection before resuming it.
+            _validate_base_paths(user_data_path, primary_path)
             if not _restart_legacy_prepared_journal_if_safe(
                 user_data_path,
                 primary_path,
@@ -4087,6 +4104,9 @@ def consolidate_recovery_profiles(
                 revision=0,
             )
 
+        # Recursive primary inspection is required only when data will really
+        # be read from or written into the consolidation transaction.
+        _validate_base_paths(user_data_path, primary_path)
         transaction_id = str(uuid.uuid4())
         backup_path = user_data_path / _BACKUPS_RELATIVE / transaction_id
         receipt_path = backup_path / "receipt.json"

--- a/tests/test_recovery/test_consolidate.py
+++ b/tests/test_recovery/test_consolidate.py
@@ -1439,6 +1439,41 @@ def test_fresh_noop_ignores_unrelated_primary_directory_link(
         _remove_dangling_directory_link(unrelated_link)
 
 
+def test_consolidate_cli_no_recovery_ignores_primary_directory_link(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_USER_STATE_DIR", str(tmp_path / "locks"))
+    user_data = tmp_path / "user-data"
+    primary = user_data / "opensquilla"
+    primary.mkdir(parents=True)
+    (primary / "config.toml").write_text("primary = true\n", encoding="utf-8")
+    unrelated_link = primary / "unrelated-link"
+    _make_dangling_directory_link(unrelated_link)
+
+    try:
+        completed = CliRunner().invoke(
+            recovery_app,
+            [
+                "consolidate-profiles",
+                "--user-data",
+                str(user_data),
+                "--primary-home",
+                str(primary),
+                "--json",
+            ],
+        )
+
+        assert completed.exit_code == 0, completed.output
+        payload = json.loads(completed.stdout)
+        assert payload["outcome"] == "noop"
+        assert payload["stable_code"] == "no_recovery_profiles"
+        assert payload["errors"] == []
+        assert os.path.lexists(_native_io_path(unrelated_link))
+    finally:
+        _remove_dangling_directory_link(unrelated_link)
+
+
 def test_real_recovery_still_rejects_unsafe_primary_directory_link(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_recovery/test_consolidate.py
+++ b/tests/test_recovery/test_consolidate.py
@@ -1391,6 +1391,80 @@ def test_fresh_noop_does_not_create_context_or_follow_backup_symlink(
     assert not (user_data / "desktop-profile-context.json").exists()
 
 
+def test_fresh_noop_does_not_scan_primary_profile_tree(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_USER_STATE_DIR", str(tmp_path / "locks"))
+    user_data = tmp_path / "user-data"
+    primary = user_data / "opensquilla"
+    primary.mkdir(parents=True)
+    (primary / "config.toml").write_text("primary = true\n", encoding="utf-8")
+    consolidate_module = importlib.import_module("opensquilla.recovery.consolidate")
+
+    def fail_if_primary_is_scanned(_home: Path) -> object:
+        raise AssertionError("a primary-only startup must not scan the primary profile tree")
+
+    monkeypatch.setattr(
+        consolidate_module,
+        "profile_no_follow_manifest",
+        fail_if_primary_is_scanned,
+    )
+
+    result = consolidate_recovery_profiles(user_data, primary)
+
+    assert result.outcome == "noop"
+    assert result.stable_code == "no_recovery_profiles"
+
+
+def test_fresh_noop_ignores_unrelated_primary_directory_link(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_USER_STATE_DIR", str(tmp_path / "locks"))
+    user_data = tmp_path / "user-data"
+    primary = user_data / "opensquilla"
+    primary.mkdir(parents=True)
+    (primary / "config.toml").write_text("primary = true\n", encoding="utf-8")
+    unrelated_link = primary / "unrelated-link"
+    _make_dangling_directory_link(unrelated_link)
+
+    try:
+        result = consolidate_recovery_profiles(user_data, primary)
+
+        assert result.outcome == "noop"
+        assert result.stable_code == "no_recovery_profiles"
+        assert os.path.lexists(_native_io_path(unrelated_link))
+    finally:
+        _remove_dangling_directory_link(unrelated_link)
+
+
+def test_real_recovery_still_rejects_unsafe_primary_directory_link(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_USER_STATE_DIR", str(tmp_path / "locks"))
+    user_data = tmp_path / "user-data"
+    primary = user_data / "opensquilla"
+    primary.mkdir(parents=True)
+    (primary / "config.toml").write_text("primary = true\n", encoding="utf-8")
+    recovery_id = str(uuid.uuid4())
+    recovery_root = user_data / "recovery-profiles" / recovery_id
+    recovery_root.mkdir(parents=True)
+    unrelated_link = primary / "unrelated-link"
+    _make_dangling_directory_link(unrelated_link)
+
+    try:
+        result = consolidate_recovery_profiles(user_data, primary)
+
+        assert result.outcome == "blocked"
+        assert result.stable_code == "unsafe_path"
+        assert recovery_root.is_dir()
+        assert os.path.lexists(_native_io_path(unrelated_link))
+    finally:
+        _remove_dangling_directory_link(unrelated_link)
+
+
 def test_primary_configuration_still_validates_unsafe_credential_leaf(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Scope

Scope boundary: Make Desktop recovery consolidation a lightweight no-op on normal primary-only launches, while preserving strict validation whenever a real recovery profile or unfinished consolidation journal exists.

Non-goals: Remove recovery consolidation, weaken validation for active recovery work, change profile merge semantics, change credential adoption, or modify Electron window/startup behavior.

## Branch

Base branch: `main`

Head branch: `agent/skip-unneeded-profile-consolidation`

## Issue

Linked issue: None

If None, reason: This regression was diagnosed directly from a Windows 0.5.1 startup report with `stable_code=unsafe_path` and no recovery candidates.

## Release Note

Release note: Prevent normal primary-only Desktop launches from being blocked by recovery consolidation when no recovery work exists.

## Root Cause

Electron invokes the recovery consolidation command during startup so it can resume unfinished transactions, adopt a pending archived credential, or merge legacy recovery profiles. The Python entry point recursively generated a no-follow manifest of the primary profile before checking whether any journal or recovery profile existed.

On Windows, an unrelated nested link or reparse point in an otherwise usable primary profile therefore raised `unsafe_path` during a launch that had no recovery work. The failure recovery check scanned the same tree again, reported the primary as not intact, and Desktop displayed the primary-repair screen.

## Changes

- split base-path validation into a canonical boundary check and an optional primary-tree inspection
- perform only the boundary check before journal/recovery discovery
- return the existing `no_recovery_profiles` no-op without recursively scanning the primary tree
- retain strict primary-tree validation before resuming a durable journal or starting a real recovery consolidation
- add deterministic and filesystem-level regressions for the primary-only no-op
- add a CLI-boundary regression proving Electron receives `noop / no_recovery_profiles` instead of `unsafe_path`
- add a boundary test proving real recovery work still rejects an unsafe primary link

Pending credential receipt lookup and adoption remain on the no-recovery path.

## Tests

- `.venv/bin/ruff check src/opensquilla/recovery/consolidate.py tests/test_recovery/test_consolidate.py`
- `.venv/bin/pytest -q tests/test_recovery` — 378 passed, 45 skipped
- `.venv/bin/mypy src/opensquilla --show-error-codes` — no issues in 882 source files
- `git diff --check`

## Maintainer Live Check

Maintainer live check: no

Surface: Windows Desktop startup / recovery preflight

Maintainer-only note: The exact no-recovery link/reparse condition is covered at both the consolidation-function and CLI protocol boundaries. A newly packaged Windows client has not yet been installed for live verification.

## Safety

Strict no-follow validation remains mandatory for any actual recovery transaction. No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, or unrelated untracked files are included.