### PR TITLE
fix(webui): honor the Usage currency toggle

### DIFF
--- a/opensquilla-webui/src/composables/usage/nativeBilling.test.ts
+++ b/opensquilla-webui/src/composables/usage/nativeBilling.test.ts
@@ -58,7 +58,7 @@ describe('native billing display contract', () => {
       exactCny: null,
       useCanonicalUsd: true,
     })
-    expect(formatUsageCost(1, 'CNY', 7.25, 4, source)).toBe('$1.0000')
+    expect(formatUsageCost(1, 'CNY', 7.25, 4, source)).toBe('¥7.2500')
   })
 
   it('requires one confirmed CNY receipt for every billed physical request', () => {
@@ -70,7 +70,7 @@ describe('native billing display contract', () => {
       exactCny: null,
       useCanonicalUsd: true,
     })
-    expect(formatUsageCost(0, 'CNY', 7.25, 4, source)).toBe('$0.0000')
+    expect(formatUsageCost(0, 'CNY', 7.25, 4, source)).toBe('¥0.0000')
   })
 
   it('accepts multiple physical B5 receipts for one billed envelope', () => {
@@ -92,10 +92,10 @@ describe('native billing display contract', () => {
     delete source.nativeBillingMissingConfirmedReceiptCount
 
     expect(nativeBillingDisplay(source, 1).exactCny).toBeNull()
-    expect(formatUsageCost(1, 'CNY', 7.25, 4, source)).toBe('$1.0000')
+    expect(formatUsageCost(1, 'CNY', 7.25, 4, source)).toBe('¥7.2500')
   })
 
-  it('keeps pending and mixed-currency totals in canonical USD', () => {
+  it('converts pending and mixed-currency totals from canonical USD for CNY display', () => {
     const pending = {
       costSource: 'opensquilla_estimate',
       pendingBillingReceiptCount: 1,
@@ -120,13 +120,13 @@ describe('native billing display contract', () => {
       },
     }
 
-    expect(formatUsageCost(0.5, 'CNY', 7.25, 4, pending)).toBe('$0.5000')
+    expect(formatUsageCost(0.5, 'CNY', 7.25, 4, pending)).toBe('¥3.6250')
     expect(nativeBillingDisplay(mixed, 3)).toMatchObject({
       exactCny: null,
       useCanonicalUsd: true,
       subtotalText: '¥6.975 · $2',
     })
-    expect(formatUsageCost(3, 'CNY', 7.25, 4, mixed)).toBe('$3.0000')
+    expect(formatUsageCost(3, 'CNY', 7.25, 4, mixed)).toBe('¥21.7500')
   })
 
   it('retains the legacy approximate conversion when no receipt exists', () => {

--- a/opensquilla-webui/src/composables/usage/nativeBilling.ts
+++ b/opensquilla-webui/src/composables/usage/nativeBilling.ts
@@ -179,6 +179,9 @@ export function formatUsageCost(
   if (currency !== 'CNY') return '$' + canonicalUsd.toFixed(decimals)
   const native = nativeBillingDisplay(source, canonicalUsd)
   if (native.exactCny != null) return '¥' + native.exactCny.toFixed(decimals)
-  if (native.useCanonicalUsd) return '$' + canonicalUsd.toFixed(decimals)
+  // Native receipt coverage determines whether CNY can be shown as an exact
+  // provider-billed amount, but it must not override the user's display
+  // currency. Mixed, pending, and older rows still have a canonical USD total
+  // that can be converted with the snapshot's effective display rate.
   return '¥' + (canonicalUsd * cnyRate).toFixed(decimals)
 }

--- a/opensquilla-webui/src/composables/usage/useUsageTotals.test.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageTotals.test.ts
@@ -57,6 +57,50 @@ function summary(source: UsageTotals, selectedCurrency: 'USD' | 'CNY') {
 }
 
 describe('usage total native billing presentation', () => {
+  it('reactively converts mixed billing totals when the display currency changes', () => {
+    const source = totals({
+      cost: 3,
+      billedCost: 2,
+      estimatedCost: 1,
+      costSource: 'mixed',
+      costSourceCounts: { provider_billed: 2, opensquilla_estimate: 1 },
+      nativeBilledByCurrency: {
+        ...cnyReceipt(),
+        USD: {
+          amountNanos: '1000000000',
+          amount: '1',
+          usdEquivalentNanos: '1000000000',
+          receiptCount: 1,
+          normalizationRatesNativePerUsd: ['1'],
+        },
+      },
+    })
+    const currency = ref('USD')
+    const result = useUsageTotals({
+      visibleSessions: computed(() => []),
+      serverTotals: computed(() => source),
+      currency,
+      cnyRate: 7.25,
+      rowVal: (row, ...keys) => keys.map(key => row[key]).find(item => item != null),
+      fmtCost: (usd, options) => formatUsageCost(
+        usd,
+        currency.value,
+        7.25,
+        options?.decimals,
+        options?.source as Record<string, unknown> | undefined,
+      ),
+      sourceCompositionHint: () => '',
+    })
+
+    expect(result.totalCostDisplay.value).toBe('$3.0000')
+    expect(result.avgCostDisplay.value).toBe('$3.0000')
+
+    currency.value = 'CNY'
+
+    expect(result.totalCostDisplay.value).toBe('¥21.7500')
+    expect(result.avgCostDisplay.value).toBe('¥21.7500')
+  })
+
   it('uses exact CNY and the receipt conversion hint for a pure confirmed row', () => {
     const source = totals({
       nativeBilledByCurrency: cnyReceipt(),
@@ -75,7 +119,7 @@ describe('usage total native billing presentation', () => {
     expect(usd.costHintTitle.value).toContain('fixed normalization rate')
   })
 
-  it('keeps mixed native currency canonical and lists native subtotals', () => {
+  it('converts mixed native currency and lists native subtotals', () => {
     const source = totals({
       cost: 3,
       billedCost: 2,
@@ -95,13 +139,14 @@ describe('usage total native billing presentation', () => {
     })
     const result = summary(source, 'CNY')
 
-    expect(result.totalCostDisplay.value).toBe('$3.0000')
-    expect(result.avgCostDisplay.value).toBe('$3.0000')
+    expect(result.totalCostDisplay.value).toBe('¥21.7500')
+    expect(result.avgCostDisplay.value).toBe('¥21.7500')
+    expect(result.costHintText.value).toContain('≈ $3.0000 USD')
     expect(result.costHintText.value).toContain('Original receipts: ¥6.975 · $1')
-    expect(result.costHintTitle.value).toContain('canonical USD')
+    expect(result.costHintTitle.value).toContain('7.25')
   })
 
-  it('keeps pending billing canonical and surfaces the pending count', () => {
+  it('converts pending billing and surfaces the pending count', () => {
     const source = totals({
       cost: 0.5,
       billedCost: 0,
@@ -113,8 +158,9 @@ describe('usage total native billing presentation', () => {
     })
     const result = summary(source, 'CNY')
 
-    expect(result.totalCostDisplay.value).toBe('$0.5000')
-    expect(result.avgCostDisplay.value).toBe('$0.5000')
+    expect(result.totalCostDisplay.value).toBe('¥3.6250')
+    expect(result.avgCostDisplay.value).toBe('¥3.6250')
+    expect(result.costHintText.value).toContain('≈ $0.5000 USD')
     expect(result.costHintText.value).toContain('1 provider billing receipts are pending')
   })
 

--- a/opensquilla-webui/src/composables/usage/useUsageTotals.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageTotals.ts
@@ -88,6 +88,11 @@ export function useUsageTotals(options: {
     const totalCostUsd = usageTotals.value.cost
     const native = nativeDisplay.value
     if (native.useCanonicalUsd) {
+      if (options.currency.value === 'CNY') {
+        hints.push(`≈ $${Number(totalCostUsd).toFixed(4)} USD`)
+      } else {
+        hints.push(`≈ ¥${(Number(totalCostUsd) * toValue(options.cnyRate)).toFixed(4)} CNY`)
+      }
       if (native.subtotalText) {
         hints.push(t('usageLogs.nativeBillingSubtotals', { amounts: native.subtotalText }))
       }
@@ -108,7 +113,9 @@ export function useUsageTotals(options: {
 
   const costHintTitle = computed(() => {
     if (nativeDisplay.value.exactCny != null) return t('usageLogs.nativeCostHintTitle')
-    if (nativeDisplay.value.useCanonicalUsd) return t('usageLogs.nativeMixedCostHintTitle')
+    if (nativeDisplay.value.useCanonicalUsd && options.currency.value === 'USD') {
+      return t('usageLogs.nativeMixedCostHintTitle')
+    }
     return t('usageLogs.costHintTitle', { rate: toValue(options.cnyRate) })
   })
 


### PR DESCRIPTION
## Summary

- honor the selected USD/CNY display currency for mixed, pending, and older usage rows
- keep exact native CNY receipt amounts when coverage is complete
- preserve canonical USD and native receipt context in the explanatory hints
- add a reactive regression test that switches the same Usage totals from USD to CNY

## Root cause

`formatUsageCost()` treated mixed, pending, and incomplete native-billing coverage as a reason to force USD output. The currency preference changed correctly, but the formatter still returned a dollar amount, making the toggle appear non-functional.

## Validation

- `npm run test:unit` — 239 files / 2464 tests passed
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Closes #889
Linear: OSQ-587