### PR TITLE
Reduce usage ledger contention during historical backfill

### DIFF
--- a/src/opensquilla/engine/outcome.py
+++ b/src/opensquilla/engine/outcome.py
@@ -53,6 +53,7 @@ _BLOCKED_CODES = frozenset(
         "approval_required",
         "external_dependency",
         "provider_unavailable",
+        "usage_accounting_busy",
         "usage_accounting_unavailable",
         "sandbox_threshold_exceeded",
         "tool_policy_denied",

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -3963,7 +3963,10 @@ class TurnRunner:
                 fallback_error_message=str(exc) or "Agent error",
             )
             if isinstance(exc, UsageAccountingUnavailableError):
-                event_code = UsageAccountingUnavailableError.code
+                event_code = str(
+                    getattr(exc, "code", UsageAccountingUnavailableError.code)
+                    or UsageAccountingUnavailableError.code
+                )
                 error_code = event_code
                 error_message = str(exc) or (
                     "Usage accounting is temporarily unavailable; retry the turn."

--- a/src/opensquilla/engine/usage_accounting.py
+++ b/src/opensquilla/engine/usage_accounting.py
@@ -50,6 +50,12 @@ class UsageAccountingUnavailableError(RuntimeError):
     retryable = True
 
 
+class UsageAccountingBusyError(UsageAccountingUnavailableError):
+    """A transient ledger lock remained busy after its bounded retry."""
+
+    code = "usage_accounting_busy"
+
+
 def usd_to_nanos(value: object) -> int:
     """Convert a non-negative USD value to an integer nano-USD amount.
 
@@ -713,6 +719,7 @@ def normalize_provider_usage(
 
 
 __all__ = [
+    "UsageAccountingBusyError",
     "UsageAccountingScope",
     "UsageAccountingUnavailableError",
     "UsageCallItem",

--- a/src/opensquilla/gateway/usage_backfill.py
+++ b/src/opensquilla/gateway/usage_backfill.py
@@ -28,6 +28,10 @@ from opensquilla.session.usage_ledger import (
 
 log = structlog.get_logger(__name__)
 
+_DEFAULT_BACKFILL_BATCH_SIZE = 50
+_SLOW_BACKFILL_OPERATION_SECONDS = 1.0
+_TERMINAL_BACKFILL_STATUSES = frozenset({"complete", "partial"})
+
 
 class UsageBackfillAnomalyError(ValueError):
     """A historical row cannot be converted without inventing accounting data."""
@@ -306,35 +310,59 @@ def normalize_usage_backfill_entry(entry: UsageBackfillEntry) -> UsageBackfillWr
 async def run_usage_backfill(
     storage: Any,
     *,
-    batch_size: int = 500,
+    batch_size: int = _DEFAULT_BACKFILL_BATCH_SIZE,
 ) -> None:
     """Resume backfill until the cutover prefix is exhausted.
 
     The storage layer owns the atomic ``events + cursor`` transaction.  Any
-    failure is converted into durable ``partial`` state and never propagates
+    failure is converted into durable ``failed`` state and never propagates
     into gateway readiness.
     """
 
     cursor = None
+    phase = "read_state"
+    batch_count = 0
+    source_row_count = 0
+    started = time.monotonic()
     try:
         state = await storage.get_usage_ledger_state()
-        if state is None or state.backfill_status == "complete":
+        if state is None or state.backfill_status in _TERMINAL_BACKFILL_STATUSES:
+            log.debug(
+                "usage.backfill_skipped",
+                status=getattr(state, "backfill_status", None),
+            )
             return
+        log.info(
+            "usage.backfill_started",
+            status=state.backfill_status,
+            batch_size=batch_size,
+        )
         prepare_indexes = getattr(storage, "prepare_usage_backfill_indexes", None)
         if callable(prepare_indexes):
+            phase = "prepare_indexes"
+            index_started = time.monotonic()
             await prepare_indexes()
+            index_duration = time.monotonic() - index_started
+            if index_duration >= _SLOW_BACKFILL_OPERATION_SECONDS:
+                log.warning(
+                    "usage.backfill_index_prepare_slow",
+                    duration_ms=int(index_duration * 1_000),
+                )
         if state.cursor_created_at_ms is not None:
             cursor = UsageBackfillCursor(
                 created_at_ms=state.cursor_created_at_ms,
                 session_id=state.cursor_session_id or "",
                 message_id=state.cursor_message_id or "",
             )
+        phase = "mark_running"
         await storage.update_usage_backfill_progress(
             status="running",
             cursor=cursor,
             now_ms=int(time.time() * 1000),
         )
         while True:
+            phase = "read_batch"
+            batch_started = time.monotonic()
             batch = await storage.get_usage_backfill_batch(
                 before_ms=state.ledger_started_at_ms,
                 after=cursor,
@@ -347,21 +375,55 @@ async def run_usage_backfill(
                     writes.append(normalize_usage_backfill_entry(entry))
                 except UsageBackfillAnomalyError:
                     anomalies += 1
-            cursor = batch.next_cursor or cursor
-            await storage.apply_usage_backfill_batch(
+            next_cursor = batch.next_cursor or cursor
+            phase = "apply_batch"
+            updated_state = await storage.apply_usage_backfill_batch(
                 writes,
-                cursor=cursor,
+                cursor=next_cursor,
                 exhausted=batch.exhausted,
                 anomaly_delta=anomalies,
                 now_ms=int(time.time() * 1000),
             )
+            cursor = next_cursor
+            batch_count += 1
+            source_row_count += len(batch.entries)
+            batch_duration = time.monotonic() - batch_started
+            batch_log = (
+                log.warning
+                if batch_duration >= _SLOW_BACKFILL_OPERATION_SECONDS
+                else log.debug
+            )
+            batch_log(
+                "usage.backfill_batch_completed",
+                batch=batch_count,
+                duration_ms=int(batch_duration * 1_000),
+                source_rows=len(batch.entries),
+                writes=len(writes),
+                anomalies=anomalies,
+                exhausted=batch.exhausted,
+            )
             if batch.exhausted:
+                log.info(
+                    "usage.backfill_completed",
+                    status=getattr(updated_state, "backfill_status", None),
+                    duration_ms=int((time.monotonic() - started) * 1_000),
+                    batches=batch_count,
+                    source_rows=source_row_count,
+                )
                 return
             await asyncio.sleep(0)
     except asyncio.CancelledError:
         raise
     except Exception as exc:  # noqa: BLE001 - backfill must never break gateway readiness
-        log.warning("usage.backfill_failed", error=type(exc).__name__)
+        log.warning(
+            "usage.backfill_failed",
+            phase=phase,
+            duration_ms=int((time.monotonic() - started) * 1_000),
+            batches=batch_count,
+            source_rows=source_row_count,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
         try:
             await storage.update_usage_backfill_progress(
                 status="failed",

--- a/src/opensquilla/gateway/usage_backfill.py
+++ b/src/opensquilla/gateway/usage_backfill.py
@@ -29,7 +29,6 @@ from opensquilla.session.usage_ledger import (
 log = structlog.get_logger(__name__)
 
 _DEFAULT_BACKFILL_BATCH_SIZE = 50
-_SLOW_BACKFILL_OPERATION_SECONDS = 1.0
 _TERMINAL_BACKFILL_STATUSES = frozenset({"complete", "partial"})
 
 
@@ -320,49 +319,25 @@ async def run_usage_backfill(
     """
 
     cursor = None
-    phase = "read_state"
-    batch_count = 0
-    source_row_count = 0
-    started = time.monotonic()
     try:
         state = await storage.get_usage_ledger_state()
         if state is None or state.backfill_status in _TERMINAL_BACKFILL_STATUSES:
-            log.debug(
-                "usage.backfill_skipped",
-                status=getattr(state, "backfill_status", None),
-            )
             return
-        log.info(
-            "usage.backfill_started",
-            status=state.backfill_status,
-            batch_size=batch_size,
-        )
         prepare_indexes = getattr(storage, "prepare_usage_backfill_indexes", None)
         if callable(prepare_indexes):
-            phase = "prepare_indexes"
-            index_started = time.monotonic()
             await prepare_indexes()
-            index_duration = time.monotonic() - index_started
-            if index_duration >= _SLOW_BACKFILL_OPERATION_SECONDS:
-                log.warning(
-                    "usage.backfill_index_prepare_slow",
-                    duration_ms=int(index_duration * 1_000),
-                )
         if state.cursor_created_at_ms is not None:
             cursor = UsageBackfillCursor(
                 created_at_ms=state.cursor_created_at_ms,
                 session_id=state.cursor_session_id or "",
                 message_id=state.cursor_message_id or "",
             )
-        phase = "mark_running"
         await storage.update_usage_backfill_progress(
             status="running",
             cursor=cursor,
             now_ms=int(time.time() * 1000),
         )
         while True:
-            phase = "read_batch"
-            batch_started = time.monotonic()
             batch = await storage.get_usage_backfill_batch(
                 before_ms=state.ledger_started_at_ms,
                 after=cursor,
@@ -376,8 +351,7 @@ async def run_usage_backfill(
                 except UsageBackfillAnomalyError:
                     anomalies += 1
             next_cursor = batch.next_cursor or cursor
-            phase = "apply_batch"
-            updated_state = await storage.apply_usage_backfill_batch(
+            await storage.apply_usage_backfill_batch(
                 writes,
                 cursor=next_cursor,
                 exhausted=batch.exhausted,
@@ -385,45 +359,13 @@ async def run_usage_backfill(
                 now_ms=int(time.time() * 1000),
             )
             cursor = next_cursor
-            batch_count += 1
-            source_row_count += len(batch.entries)
-            batch_duration = time.monotonic() - batch_started
-            batch_log = (
-                log.warning
-                if batch_duration >= _SLOW_BACKFILL_OPERATION_SECONDS
-                else log.debug
-            )
-            batch_log(
-                "usage.backfill_batch_completed",
-                batch=batch_count,
-                duration_ms=int(batch_duration * 1_000),
-                source_rows=len(batch.entries),
-                writes=len(writes),
-                anomalies=anomalies,
-                exhausted=batch.exhausted,
-            )
             if batch.exhausted:
-                log.info(
-                    "usage.backfill_completed",
-                    status=getattr(updated_state, "backfill_status", None),
-                    duration_ms=int((time.monotonic() - started) * 1_000),
-                    batches=batch_count,
-                    source_rows=source_row_count,
-                )
                 return
             await asyncio.sleep(0)
     except asyncio.CancelledError:
         raise
     except Exception as exc:  # noqa: BLE001 - backfill must never break gateway readiness
-        log.warning(
-            "usage.backfill_failed",
-            phase=phase,
-            duration_ms=int((time.monotonic() - started) * 1_000),
-            batches=batch_count,
-            source_rows=source_row_count,
-            error_type=type(exc).__name__,
-            error=str(exc),
-        )
+        log.warning("usage.backfill_failed", error=type(exc).__name__)
         try:
             await storage.update_usage_backfill_progress(
                 status="failed",

--- a/src/opensquilla/gateway/usage_ledger_runtime.py
+++ b/src/opensquilla/gateway/usage_ledger_runtime.py
@@ -19,6 +19,7 @@ import structlog
 
 from opensquilla.asyncio_utils import create_background_task
 from opensquilla.engine.usage_accounting import (
+    UsageAccountingBusyError,
     UsageAccountingScope,
     UsageAccountingUnavailableError,
     UsageCallItem,
@@ -27,6 +28,7 @@ from opensquilla.engine.usage_accounting import (
     UsageExecutionContext,
 )
 from opensquilla.gateway.session_services import get_session_storage
+from opensquilla.session.storage import StorageBusyError
 from opensquilla.session.usage_ledger import (
     UsageEventCompletion,
     UsageEventItem,
@@ -227,9 +229,13 @@ class SessionUsageEventSink:
         self,
         storage: Any,
         *,
+        start_retry_delays: tuple[float, ...] = (0.1,),
         retry_delays: tuple[float, ...] = (0.05, 0.2, 1.0, 5.0),
     ) -> None:
         self._storage = storage
+        self._start_retry_delays = tuple(
+            max(0.0, float(delay)) for delay in start_retry_delays
+        )
         self._retry_delays = retry_delays
         self._tasks: set[asyncio.Task[Any]] = set()
 
@@ -258,14 +264,35 @@ class SessionUsageEventSink:
         )
 
     async def start(self, call: UsageCallStart) -> None:
-        try:
-            await self._storage.start_usage_event(self._start_record(call))
-        except UsageLedgerStorageError:
-            raise
-        except Exception as exc:
-            raise UsageLedgerStorageError(
-                "usage ledger is temporarily unavailable; provider request was not sent"
-            ) from exc
+        record = self._start_record(call)
+        attempt = 0
+        while True:
+            try:
+                await self._storage.start_usage_event(record)
+                return
+            except StorageBusyError as exc:
+                if attempt >= len(self._start_retry_delays):
+                    raise UsageAccountingBusyError(
+                        "usage ledger is temporarily busy after retry; "
+                        "provider request was not sent"
+                    ) from exc
+                delay = self._start_retry_delays[attempt]
+                attempt += 1
+                log.info(
+                    "usage.ledger_start_retry",
+                    event_id=call.event_id,
+                    attempt=attempt,
+                    delay_ms=int(delay * 1_000),
+                    operation=exc.operation,
+                    waited_ms=exc.waited_ms,
+                )
+                await asyncio.sleep(delay)
+            except UsageLedgerStorageError:
+                raise
+            except Exception as exc:
+                raise UsageLedgerStorageError(
+                    "usage ledger is temporarily unavailable; provider request was not sent"
+                ) from exc
 
     async def finalize(self, call: UsageCallStart, result: UsageCallResult) -> None:
         completion = _completion(call, result)

--- a/tests/test_engine/test_usage_event_accounting.py
+++ b/tests/test_engine/test_usage_event_accounting.py
@@ -14,6 +14,7 @@ from opensquilla.engine.runtime import TurnRunner, _SelectorFallbackProvider
 from opensquilla.engine.types import DoneEvent as EngineDoneEvent
 from opensquilla.engine.types import ErrorEvent, ToolCall
 from opensquilla.engine.usage_accounting import (
+    UsageAccountingBusyError,
     UsageAccountingScope,
     UsageAccountingUnavailableError,
     UsageCallResult,
@@ -71,6 +72,12 @@ class _UnavailableSink(_RecordingSink):
     async def start(self, call: UsageCallStart) -> None:
         self.started.append(call)
         raise UsageAccountingUnavailableError("ledger busy")
+
+
+class _BusySink(_RecordingSink):
+    async def start(self, call: UsageCallStart) -> None:
+        self.started.append(call)
+        raise UsageAccountingBusyError("ledger remained busy")
 
 
 class _DoneProvider:
@@ -1330,13 +1337,23 @@ async def test_shared_turn_scope_keeps_helper_and_agent_call_indices_unique() ->
 
 
 @pytest.mark.asyncio
-async def test_turn_runner_preserves_retryable_ledger_start_error_code() -> None:
+@pytest.mark.parametrize(
+    ("sink_type", "expected_code"),
+    [
+        (_UnavailableSink, UsageAccountingUnavailableError.code),
+        (_BusySink, UsageAccountingBusyError.code),
+    ],
+)
+async def test_turn_runner_preserves_retryable_ledger_start_error_code(
+    sink_type,
+    expected_code: str,
+) -> None:
     storage = SessionStorage(":memory:")
     await storage.connect()
     manager = SessionManager(storage)
     session_key = "agent:main:usage-start-failure"
     await manager.create(session_key)
-    sink = _UnavailableSink()
+    sink = sink_type()
     provider = _SequenceProvider([[ProviderDone()]])
     runner = TurnRunner(
         provider_selector=_SingleProviderSelector(provider),
@@ -1362,5 +1379,8 @@ async def test_turn_runner_preserves_retryable_ledger_start_error_code() -> None
 
     errors = [event for event in events if isinstance(event, ErrorEvent)]
     assert len(errors) == 1
-    assert errors[0].code == UsageAccountingUnavailableError.code
+    assert errors[0].code == expected_code
     assert provider.calls == 0
+    outcome = outcome_from_error(code=expected_code)
+    assert outcome.kind == "blocked"
+    assert outcome.retryable is True

--- a/tests/test_gateway/test_usage_ledger_runtime.py
+++ b/tests/test_gateway/test_usage_ledger_runtime.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 from dataclasses import replace
 
 import pytest
 
 from opensquilla.engine.usage_accounting import (
+    UsageAccountingBusyError,
     UsageAccountingUnavailableError,
     UsageCallItem,
     UsageCallResult,
@@ -17,7 +19,7 @@ from opensquilla.gateway.usage_ledger_runtime import (
     UsageLedgerStorageError,
 )
 from opensquilla.provider.types import ProviderBillingReceipt
-from opensquilla.session.storage import SessionStorage
+from opensquilla.session.storage import SessionStorage, StorageBusyError
 
 
 def _call(**overrides) -> UsageCallStart:
@@ -87,6 +89,8 @@ def test_auto_propose_uses_stable_synthetic_session_and_unique_runs() -> None:
 
 class _Storage:
     def __init__(self) -> None:
+        self.start_attempts = []
+        self.start_failures: list[Exception] = []
         self.started = []
         self.finalized = []
         self.finalized_receipts = []
@@ -94,6 +98,9 @@ class _Storage:
         self.fail_finalize = 0
 
     async def start_usage_event(self, event):
+        self.start_attempts.append(event)
+        if self.start_failures:
+            raise self.start_failures.pop(0)
         self.started.append(event)
 
     async def finalize_usage_event(self, event_id, completion, *, items=(), receipts=()):
@@ -131,6 +138,98 @@ async def test_start_without_durable_session_fails_closed() -> None:
 
     assert storage.started == []
     assert issubclass(UsageLedgerStorageError, UsageAccountingUnavailableError)
+
+
+def _storage_busy() -> StorageBusyError:
+    return StorageBusyError(
+        "start_usage_event",
+        waited_ms=2_000,
+        retry_after_ms=100,
+        stage="begin",
+        resource="sessions.db",
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_retries_one_transient_storage_busy_failure() -> None:
+    storage = _Storage()
+    storage.start_failures = [_storage_busy()]
+    sink = SessionUsageEventSink(storage, start_retry_delays=(0.0,))
+
+    await sink.start(_call())
+
+    assert len(storage.start_attempts) == 2
+    assert storage.start_attempts[0] == storage.start_attempts[1]
+    assert len(storage.started) == 1
+
+
+@pytest.mark.asyncio
+async def test_start_busy_retry_exhaustion_has_specific_error_code() -> None:
+    storage = _Storage()
+    storage.start_failures = [_storage_busy(), _storage_busy()]
+    sink = SessionUsageEventSink(storage, start_retry_delays=(0.0,))
+
+    with pytest.raises(
+        UsageAccountingBusyError,
+        match="usage ledger is temporarily busy",
+    ) as caught:
+        await sink.start(_call())
+
+    assert len(storage.start_attempts) == 2
+    assert caught.value.code == "usage_accounting_busy"
+    assert isinstance(caught.value.__cause__, StorageBusyError)
+    assert storage.started == []
+
+
+@pytest.mark.asyncio
+async def test_start_does_not_retry_permanent_storage_failure() -> None:
+    storage = _Storage()
+    storage.start_failures = [RuntimeError("repro usage ledger start failure")]
+    sink = SessionUsageEventSink(storage, start_retry_delays=(0.0, 0.0))
+
+    with pytest.raises(
+        UsageLedgerStorageError,
+        match="usage ledger is temporarily unavailable",
+    ) as caught:
+        await sink.start(_call())
+
+    assert len(storage.start_attempts) == 1
+    assert type(caught.value) is UsageLedgerStorageError
+    assert isinstance(caught.value.__cause__, RuntimeError)
+    assert storage.started == []
+
+
+@pytest.mark.asyncio
+async def test_start_retries_real_sqlite_write_lock(tmp_path) -> None:
+    database = tmp_path / "sessions.db"
+    storage = await SessionStorage.open(str(database))
+    storage._busy_budget_seconds = 0.01
+    blocker = sqlite3.connect(database, isolation_level=None)
+    blocker.execute("BEGIN IMMEDIATE")
+    sink = SessionUsageEventSink(storage, start_retry_delays=(0.2,))
+
+    async def release_lock() -> None:
+        await asyncio.sleep(0.15)
+        blocker.rollback()
+
+    release = asyncio.create_task(release_lock())
+    try:
+        await sink.start(_call())
+
+        async with storage.conn.execute(
+            "SELECT status FROM usage_events WHERE event_id = ?",
+            ("event-1",),
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        assert row["status"] == "started"
+    finally:
+        await release
+        if blocker.in_transaction:
+            blocker.rollback()
+        blocker.close()
+        await sink.close()
+        await storage.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_persistence/test_usage_backfill.py
+++ b/tests/test_persistence/test_usage_backfill.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -16,13 +17,31 @@ from opensquilla.gateway.usage_backfill import (
 from opensquilla.session.models import SessionNode, TranscriptEntry
 from opensquilla.session.storage import SessionStorage
 from opensquilla.session.usage_ledger import (
+    UsageBackfillBatch,
     UsageBackfillCursor,
+    UsageBackfillEntry,
     UsageBackfillWrite,
     UsageEventCompletion,
     UsageEventItem,
     UsageEventStart,
     UsageLedgerConflictError,
 )
+
+
+def _backfill_state(
+    status: str,
+    *,
+    cursor: UsageBackfillCursor | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        ledger_started_at_ms=1_000,
+        backfill_status=status,
+        cursor_created_at_ms=cursor.created_at_ms if cursor else None,
+        cursor_session_id=cursor.session_id if cursor else None,
+        cursor_message_id=cursor.message_id if cursor else None,
+        last_error_code=None,
+        updated_at_ms=1_000,
+    )
 
 
 def _write(
@@ -51,6 +70,124 @@ def _write(
             cost_source="estimate",
         ),
     )
+
+
+@pytest.mark.asyncio
+async def test_usage_backfill_worker_uses_small_default_batches() -> None:
+    class RecordingStorage:
+        def __init__(self) -> None:
+            self.limits: list[int] = []
+
+        async def get_usage_ledger_state(self) -> SimpleNamespace:
+            return _backfill_state("pending")
+
+        async def prepare_usage_backfill_indexes(self) -> None:
+            return None
+
+        async def update_usage_backfill_progress(self, **_kwargs) -> None:
+            return None
+
+        async def get_usage_backfill_batch(
+            self,
+            *,
+            before_ms: int,
+            after: UsageBackfillCursor | None,
+            limit: int,
+        ) -> UsageBackfillBatch:
+            assert before_ms == 1_000
+            assert after is None
+            self.limits.append(limit)
+            return UsageBackfillBatch(entries=(), next_cursor=None, exhausted=True)
+
+        async def apply_usage_backfill_batch(self, *_args, **_kwargs) -> None:
+            return None
+
+    storage = RecordingStorage()
+
+    await run_usage_backfill(storage)
+
+    assert storage.limits == [50]
+
+
+@pytest.mark.asyncio
+async def test_usage_backfill_worker_does_not_repeat_terminal_partial_state() -> None:
+    class PartialStorage:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def get_usage_ledger_state(self) -> SimpleNamespace:
+            self.calls.append("read")
+            return _backfill_state("partial")
+
+        async def prepare_usage_backfill_indexes(self) -> None:
+            self.calls.append("prepare-indexes")
+
+        async def update_usage_backfill_progress(self, **_kwargs) -> None:
+            self.calls.append("update")
+
+        async def get_usage_backfill_batch(self, **_kwargs) -> UsageBackfillBatch:
+            self.calls.append("read-batch")
+            return UsageBackfillBatch(entries=(), next_cursor=None, exhausted=True)
+
+        async def apply_usage_backfill_batch(self, *_args, **_kwargs) -> None:
+            self.calls.append("apply-batch")
+
+    storage = PartialStorage()
+
+    await run_usage_backfill(storage)
+
+    assert storage.calls == ["read"]
+
+
+@pytest.mark.asyncio
+async def test_usage_backfill_failure_keeps_last_committed_cursor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed_cursor = UsageBackfillCursor(100, "session-1", "message-1")
+
+    class FailingStorage:
+        def __init__(self) -> None:
+            self.progress: list[dict] = []
+
+        async def get_usage_ledger_state(self) -> SimpleNamespace:
+            return _backfill_state("pending")
+
+        async def prepare_usage_backfill_indexes(self) -> None:
+            return None
+
+        async def update_usage_backfill_progress(self, **kwargs) -> None:
+            self.progress.append(kwargs)
+
+        async def get_usage_backfill_batch(self, **_kwargs) -> UsageBackfillBatch:
+            return UsageBackfillBatch(
+                entries=(
+                    UsageBackfillEntry(
+                        cursor=failed_cursor,
+                        agent_id="main",
+                        session_epoch=0,
+                        forked_from_parent=False,
+                        turn_usage={"input_tokens": 1},
+                        turn_context={"turn_id": "turn-1"},
+                    ),
+                ),
+                next_cursor=failed_cursor,
+                exhausted=True,
+            )
+
+        async def apply_usage_backfill_batch(self, *_args, **_kwargs) -> None:
+            raise RuntimeError("repro backfill batch failure")
+
+    monkeypatch.setattr(
+        "opensquilla.gateway.usage_backfill.normalize_usage_backfill_entry",
+        lambda _entry: _write("event-1", "execution-1"),
+    )
+    storage = FailingStorage()
+
+    await run_usage_backfill(storage)
+
+    assert [item["status"] for item in storage.progress] == ["running", "failed"]
+    assert storage.progress[0]["cursor"] is None
+    assert storage.progress[1]["cursor"] is None
 
 
 async def test_backfill_batch_is_canonical_stable_and_marks_forks(tmp_path: Path) -> None:
@@ -250,6 +387,62 @@ async def test_usage_backfill_worker_attributes_valid_history_without_changing_b
         baselines = await storage.list_usage_legacy_baselines()
         assert len(baselines) == 1
         assert baselines[0].cost_nanos == 100_000_000
+    finally:
+        await storage.close()
+
+
+async def test_failed_backfill_retries_from_last_committed_cursor(
+    tmp_path: Path,
+) -> None:
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    try:
+        await storage.upsert_session(
+            SessionNode(
+                session_key="agent:main:webchat:one",
+                session_id="session-1",
+            )
+        )
+        for index in range(2):
+            await storage.append_transcript_entry(
+                TranscriptEntry(
+                    session_id="session-1",
+                    session_key="agent:main:webchat:one",
+                    message_id=f"assistant-{index}",
+                    role="assistant",
+                    created_at=100 + index,
+                    turn_usage={"input_tokens": 1},
+                    turn_context={"turn_id": f"turn-{index}"},
+                )
+            )
+        await storage.initialize_usage_ledger(1_000)
+        await storage.conn.execute(
+            """
+            CREATE TRIGGER repro_usage_ledger_start_failure
+            BEFORE INSERT ON usage_events
+            BEGIN
+              SELECT RAISE(ABORT, 'repro usage ledger start failure');
+            END
+            """
+        )
+
+        await run_usage_backfill(storage, batch_size=1)
+
+        failed = await storage.get_usage_ledger_state()
+        assert failed is not None
+        assert failed.backfill_status == "failed"
+        assert failed.cursor_created_at_ms is None
+        assert await storage.query_usage_events(None, None) == []
+
+        await storage.conn.execute(
+            "DROP TRIGGER IF EXISTS repro_usage_ledger_start_failure"
+        )
+        await run_usage_backfill(storage, batch_size=1)
+
+        recovered = await storage.get_usage_ledger_state()
+        assert recovered is not None
+        assert recovered.backfill_status == "complete"
+        events = await storage.query_usage_events(None, None)
+        assert len(events) == 2
     finally:
         await storage.close()
 


### PR DESCRIPTION
## Summary

- retry a live usage-ledger `start` reservation once when SQLite reports a transient `StorageBusyError`
- reduce historical backfill batches from 500 rows to 50 so background transactions release the shared writer sooner
- treat exhausted `partial` backfill as terminal instead of re-running it on every Gateway start
- advance the persisted retry cursor only after a batch transaction commits, preventing failed batches from being skipped

## Root cause

The original live error was generic, so it could represent either transient contention or a permanent SQLite failure. Code review found two concrete contention sources:

1. The first historical backfill builds three indexes by scanning transcript history after Gateway readiness.
2. Each historical event performs roughly 8–9 SQLite operations; the previous 500-row batch could therefore hold the writer across roughly 4,000–4,500 async SQL operations.

The backfill state machine also retried `partial` on every Gateway start even though `partial` is only produced after the historical prefix is exhausted. Any unrecoverable legacy anomaly could therefore cause permanent startup work. A failed batch also moved the in-memory cursor before commit and could persist that uncommitted cursor in the failure state.

## Safety

Provider dispatch remains fail-closed: no provider request is sent until its durable `started` row commits. Only `StorageBusyError` is retried. Permanent storage failures still fail immediately. Historical backfill remains best-effort and cannot block Gateway readiness.

## Tests

New coverage verifies:

- the worker uses 50-row pages by default
- terminal `partial` state performs no index or batch work on later starts
- failed batches retain the last committed cursor
- a real SQLite trigger failure followed by recovery does not skip historical rows
- transient busy succeeds on bounded retry
- exhausted busy preserves `usage_accounting_busy` and never calls the provider
- permanent live-ledger failures are not retried

Validation completed locally:

- `ruff check src tests`
- `mypy src/opensquilla --show-error-codes` — 882 source files
- persistence suite — 144 passed, 2 skipped
- focused backfill/usage/engine suites after the final logging adjustment — 109 passed
- Engine suite — 2445 passed
- Gateway suite before the backfill-only follow-up — 2416 passed, 10 skipped; the one outer-sandbox Seatbelt failure passed when rerun outside that sandbox

## Manual validation still needed

The artificial SQLite trigger used to reproduce the permanent failure has been removed. A packaged Windows client should still verify that naturally short-lived contention is recovered without losing historical usage.