### PR TITLE
Fix Desktop project picker focus

### DIFF
--- a/desktop/electron/scripts/test-project-workspace-picker.mjs
+++ b/desktop/electron/scripts/test-project-workspace-picker.mjs
@@ -32,6 +32,15 @@ assert.match(
   /ipcMain\.handle\('desktop:workspace:choose-directory',\s*async\s*\(event,\s*payload:\s*unknown\)/,
 )
 assert.match(workspaceHandler, /trustedControlUiIpc\(event\)/)
+assert.match(workspaceHandler, /const window = currentMainWindow\(\)/)
+assert.match(workspaceHandler, /if \(!window\) return null/)
+assert.match(
+  workspaceHandler,
+  /if \(process\.platform === 'darwin'\) app\.focus\(\{ steal: true \}\)/,
+)
+assert.match(workspaceHandler, /if \(window\.isMinimized\(\)\) window\.restore\(\)/)
+assert.match(workspaceHandler, /window\.show\(\)/)
+assert.match(workspaceHandler, /window\.focus\(\)/)
 assert.match(workspaceHandler, /projectDirectoryDialogOptions\(process\.platform,\s*payload\)/)
 assert.doesNotMatch(workspaceHandler, /title:\s*['"]Choose a project['"]/)
 assert.match(workspaceHandler, /choice\.canceled[\s\S]*return null/)

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -10123,8 +10123,14 @@ ipcMain.handle('desktop:preferences:save', async (event, payload: DesktopPrefere
 ipcMain.handle('desktop:artifact:open', async (_event, payload: ArtifactOpenRequest) => openArtifactWithDefaultApp(payload))
 ipcMain.handle('desktop:workspace:choose-directory', async (event, payload: unknown) => {
   if (!trustedControlUiIpc(event)) return null
+  const window = currentMainWindow()
+  if (!window) return null
+  if (process.platform === 'darwin') app.focus({ steal: true })
+  if (window.isMinimized()) window.restore()
+  window.show()
+  window.focus()
   const choice = await dialog.showOpenDialog(
-    currentMainWindow()!,
+    window,
     projectDirectoryDialogOptions(process.platform, payload),
   )
   if (choice.canceled || choice.filePaths.length !== 1) return null


### PR DESCRIPTION
## What changed

- activate the macOS app before presenting the native project directory picker
- restore, show, and focus the current main window before attaching the native dialog
- keep the existing trusted Control UI IPC boundary unchanged
- extend the Desktop picker contract test to cover the foregrounding sequence

## Why

The native directory panel could be created while OpenSquilla was not yet foregrounded, leaving the panel behind another app or on another Space. To the user, clicking **Choose project** appeared to do nothing.

## User impact

The packaged Desktop app now foregrounds OpenSquilla and presents the system directory picker visibly when a project is selected.

## Validation

- `npm run test:project-workspace-picker`
- `npm run test:window-lifecycle`
- `npm run test:unit -- src/components/ProjectWorkspacePickerDialog.test.ts src/components/chat/ChatComposer.workspace.test.ts` (25 tests)
- `npm run dist:local`
- packaged macOS app smoke test: foreground changed from Finder to OpenSquilla and the native directory panel was visible
