### PR TITLE
Keep session history loading non-blocking

### DIFF
--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -1180,6 +1180,7 @@
     "tests/test_artifact_bundles.py": 0.01,
     "tests/test_gateway/test_artifact_preview.py": 0.01,
     "tests/test_gateway/test_artifact_preview_middleware.py": 0.01,
-    "tests/test_gateway/test_root_control_ui_security.py": 0.01
+    "tests/test_gateway/test_root_control_ui_security.py": 0.01,
+    "tests/test_gateway/test_websocket_request_concurrency.py": 0.01
   }
 }

--- a/desktop/electron/scripts/test-packaged-session-recovery.mjs
+++ b/desktop/electron/scripts/test-packaged-session-recovery.mjs
@@ -131,9 +131,9 @@ try {
   assert.equal(
     await page.locator(
       '[data-testid="chat-session-recovery-status"][data-recovery-state="history-loading"]',
-    ).isVisible(),
-    true,
-    'packaged history recovery must use the compact non-blocking status',
+    ).count(),
+    0,
+    'routine packaged history loading must not render a recovery notice',
   )
   assert.equal(
     await thread.getAttribute('aria-busy'),

--- a/opensquilla-webui/e2e/history-hydration.spec.ts
+++ b/opensquilla-webui/e2e/history-hydration.spec.ts
@@ -9,6 +9,16 @@ function successResponse(id: string, payload: unknown) {
   return JSON.stringify({ type: 'res', id, ok: true, payload })
 }
 
+function helloResponse(tickIntervalMs: number) {
+  return JSON.stringify({
+    protocol: 3,
+    policy: {
+      tick_interval_ms: tickIntervalMs,
+      concurrent_history_reads: true,
+    },
+  })
+}
+
 function basePayload(method: string): unknown {
   const payloads: Record<string, unknown> = {
     'agents.list': { agents: [] },
@@ -58,13 +68,13 @@ async function stubApprovals(page: Page) {
 }
 
 test('keeps the conversation usable while startup and long history are delayed', async ({ page }) => {
-  let releaseConfig: (() => void) | undefined
   let releaseHistory: (() => void) | undefined
+  let chatSendRequests = 0
   let usageRequests = 0
   const receivedMethods: string[] = []
   const sessionRequestOrder: string[] = []
 
-  await page.setViewportSize({ width: 390, height: 844 })
+  await page.setViewportSize({ width: 1280, height: 900 })
   await page.addInitScript(() => {
     const state = { emptySeen: false }
     Object.defineProperty(window, '__opensquillaHistoryHydrationTest', { value: state })
@@ -76,83 +86,99 @@ test('keeps the conversation usable while startup and long history are delayed',
   })
   await stubApprovals(page)
   await page.routeWebSocket(/\/ws$/, ws => {
-    const queue: Array<Record<string, unknown>> = []
-    let active: Record<string, unknown> | null = null
-    const finish = (frame: Record<string, unknown>, payload: unknown) => {
-      ws.send(successResponse(String(frame.id), payload))
-      active = null
-      drain()
-    }
-    const drain = () => {
-      if (active || queue.length === 0) return
-      const frame = queue.shift()!
-      active = frame
-      const method = String(frame.method || '')
-      if (method.startsWith('sessions.messages.') || method === 'chat.history') {
-        sessionRequestOrder.push(method)
-      }
-      if (method === 'config.get') {
-        releaseConfig = () => finish(frame, {
-          squilla_router: { enabled: false, rollout_phase: 'observe', tiers: {} },
-          permissions: {},
-          skills: {},
-        })
-        return
-      }
-      if (method === 'usage.status') {
-        usageRequests += 1
-        // Optional metadata remains intentionally stalled. It must only
-        // enter the serialized queue after history/live are terminal.
-        return
-      }
-      if (method === 'chat.history') {
-        releaseHistory = () => finish(frame, {
-          messages: longHistoryMessages(),
-          has_more: true,
-          oldest_cursor: 'cursor-50',
-          newest_cursor: 'cursor-100',
-          canonical_available: true,
-          canonical_complete: true,
-        })
-        return
-      }
-      if (method === 'sessions.messages.snapshot') {
-        finish(frame, {
-          key: SESSION_KEY,
-          events: [],
-          current_stream_seq: 0,
-        })
-        return
-      }
-      finish(frame, basePayload(method))
-    }
     ws.send(JSON.stringify({ type: 'event', event: 'connect.challenge', payload: {} }))
     ws.onMessage(message => {
       try {
         const frame = JSON.parse(String(message))
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
-          ws.send(JSON.stringify({ protocol: 3, policy: { tick_interval_ms: 30000 } }))
+          ws.send(helloResponse(30000))
           return
         }
-        receivedMethods.push(String(frame.method || ''))
-        queue.push(frame)
-        drain()
+        const method = String(frame.method || '')
+        receivedMethods.push(method)
+        if (method.startsWith('sessions.messages.') || method === 'chat.history') {
+          sessionRequestOrder.push(method)
+        }
+        if (method === 'chat.history') {
+          releaseHistory = () => ws.send(successResponse(String(frame.id), {
+            messages: longHistoryMessages(),
+            has_more: true,
+            oldest_cursor: 'cursor-50',
+            newest_cursor: 'cursor-100',
+            canonical_available: true,
+            canonical_complete: true,
+          }))
+          return
+        }
+        if (method === 'sessions.messages.snapshot') {
+          ws.send(successResponse(String(frame.id), {
+            key: SESSION_KEY,
+            events: [],
+            current_stream_seq: 0,
+          }))
+          return
+        }
+        if (method === 'sessions.messages.subscribe') {
+          ws.send(successResponse(String(frame.id), {
+            subscribed: true,
+            hydration_complete: false,
+            replay_complete: true,
+            current_stream_seq: 0,
+            run_status: 'idle',
+          }))
+          return
+        }
+        if (method === 'sessions.messages.hydrate') {
+          ws.send(successResponse(String(frame.id), {
+            hydration_complete: true,
+            workspaceId: null,
+            run_status: 'idle',
+          }))
+          return
+        }
+        if (method === 'sessions.list') {
+          ws.send(successResponse(String(frame.id), {
+            sessions: [{
+              key: SESSION_KEY,
+              title: 'Visible while history is pending',
+              sessionKind: 'chat',
+              surface: 'webchat',
+              conversationKind: 'direct',
+              effectiveAgentId: 'main',
+              updatedAt: 100,
+              messageCount: 50,
+              status: 'ok',
+              runStatus: 'idle',
+            }],
+            has_more: false,
+          }))
+          return
+        }
+        if (method === 'chat.send') {
+          chatSendRequests += 1
+          ws.send(successResponse(String(frame.id), {
+            sessionKey: SESSION_KEY,
+            status: 'accepted',
+            task_id: 'e2e-history-interactive-send',
+            message_id: 'e2e-history-interactive-message',
+          }))
+          return
+        }
+        if (method === 'usage.status') usageRequests += 1
+        ws.send(successResponse(String(frame.id), basePayload(method)))
       } catch {}
     })
   })
 
   await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(SESSION_KEY))
-  const recovery = page.locator(
+  const hiddenRecovery = page.locator(
     '[data-testid="chat-session-recovery-status"][data-recovery-state="history-loading"]',
   )
   const thread = page.locator('.chat-thread')
   const composer = page.getByRole('textbox', { name: 'Message to send' })
 
   await expect.poll(() => Boolean(releaseHistory)).toBe(true)
-  // Optional configuration must not be queued ahead of critical session
-  // recovery on the Gateway's serial dispatcher.
-  expect(releaseConfig).toBeUndefined()
   const criticalStartupOrder = [
     'sessions.messages.subscribe',
     'sessions.messages.snapshot',
@@ -164,41 +190,46 @@ test('keeps the conversation usable while startup and long history are delayed',
   expect(sessionRequestOrder.slice(0, criticalStartupOrder.length)).toEqual(
     criticalStartupOrder,
   )
+  // Critical ordering is preserved, but independent UI data starts as soon as
+  // those frames are queued instead of waiting for the history response.
   for (const optionalMethod of [
     'onboarding.status',
-    'sandbox.setup.status',
     'sessions.subscribe',
     'sessions.list',
     'agents.list',
-    'workspaces.list',
     'config.get',
     'commands.list_for_surface',
     'usage.status',
   ]) {
-    expect(receivedMethods).not.toContain(optionalMethod)
+    await expect.poll(() => receivedMethods).toContain(optionalMethod)
   }
-  await expect(recovery).toBeVisible()
-  await expect(recovery).toHaveAttribute('data-recovery-state', 'history-loading')
-  await expect(recovery).toHaveAttribute('role', 'status')
+  await expect.poll(() => receivedMethods).toContain('sessions.messages.hydrate')
+  await expect.poll(() => usageRequests).toBeGreaterThan(0)
+  await expect(hiddenRecovery).toHaveCount(0)
   await expect(page.getByTestId('chat-session-load-state')).toHaveCount(0)
   await expect(thread).toHaveAttribute('aria-busy', 'false')
+  await expect(
+    page.locator('.sidebar-history-row[data-session-key]')
+      .filter({ hasText: 'Visible while history is pending' }),
+  ).toBeVisible()
   await expect(composer).toBeEditable()
   await composer.fill('Draft remains editable while history loads.')
   await expect(composer).toHaveValue('Draft remains editable while history loads.')
+  await expect(page.getByRole('button', { name: 'Send', exact: true })).toBeEnabled()
   await expect(page.locator('.chat-empty')).toHaveCount(0)
+  const themeButton = page.getByRole('button', { name: 'Theme', exact: true })
+  await themeButton.click()
+  await expect(page.getByRole('menu', { name: 'Theme' })).toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('menu', { name: 'Theme' })).toHaveCount(0)
+  await page.getByRole('button', { name: 'Send', exact: true }).click()
+  await expect.poll(() => chatSendRequests).toBe(1)
 
-  // The session becomes usable before optional configuration and usage begin.
   releaseHistory?.()
   await expect(page.getByText('Hydration complete.')).toBeVisible()
-  await expect(recovery).toHaveCount(0)
-  await expect(thread).toHaveAttribute('aria-busy', 'false')
+  await expect(hiddenRecovery).toHaveCount(0)
   await expect(page.getByTestId('history-load-sentinel')).toBeAttached()
-  await expect(composer).toHaveValue('Draft remains editable while history loads.')
-  await expect.poll(() => Boolean(releaseConfig)).toBe(true)
-  releaseConfig?.()
-  await expect.poll(() => usageRequests).toBe(1)
-  await expect(page.getByText('Hydration complete.')).toBeVisible()
-  await expect(composer).toHaveValue('Draft remains editable while history loads.')
+  await expect(composer).toHaveValue('')
   await expect.poll(() => page.evaluate(() => {
     const state = (window as unknown as {
       __opensquillaHistoryHydrationTest?: { emptySeen?: boolean }
@@ -208,6 +239,99 @@ test('keeps the conversation usable while startup and long history are delayed',
   await expect.poll(() => page.evaluate(() => (
     document.documentElement.scrollWidth <= document.documentElement.clientWidth
   ))).toBe(true)
+})
+
+test('recovers from stuck automatic metadata before sending', async ({ page }) => {
+  let socketCount = 0
+  let heldConfigRequests = 0
+  let chatSendSocket = 0
+
+  await stubApprovals(page)
+  await page.routeWebSocket(/\/ws$/, ws => {
+    const socketNumber = ++socketCount
+    let metadataStuck = false
+    ws.send(JSON.stringify({ type: 'event', event: 'connect.challenge', payload: {} }))
+    ws.onMessage(message => {
+      try {
+        const frame = JSON.parse(String(message))
+        if (frame?.type !== 'req') return
+        const method = String(frame.method || '')
+        if (method === 'connect') {
+          ws.send(helloResponse(30000))
+          return
+        }
+        if (socketNumber === 1 && method === 'config.get') {
+          heldConfigRequests += 1
+          metadataStuck = true
+          return
+        }
+        // Model the Gateway's serial dispatcher: once the optional read is
+        // stuck, every later request on this socket remains queued behind it.
+        if (socketNumber === 1 && metadataStuck) return
+        if (method === 'sessions.messages.snapshot') {
+          ws.send(successResponse(String(frame.id), {
+            key: SESSION_KEY,
+            events: [],
+            current_stream_seq: 0,
+          }))
+          return
+        }
+        if (method === 'sessions.messages.subscribe') {
+          ws.send(successResponse(String(frame.id), {
+            subscribed: true,
+            hydration_complete: true,
+            replay_complete: true,
+            current_stream_seq: 0,
+            run_status: 'idle',
+          }))
+          return
+        }
+        if (method === 'sessions.messages.hydrate') {
+          ws.send(successResponse(String(frame.id), {
+            hydration_complete: true,
+            run_status: 'idle',
+          }))
+          return
+        }
+        if (method === 'chat.history') {
+          ws.send(successResponse(String(frame.id), {
+            messages: [],
+            has_more: false,
+            oldest_cursor: null,
+            newest_cursor: null,
+            canonical_available: true,
+            canonical_complete: true,
+          }))
+          return
+        }
+        if (method === 'chat.send') {
+          chatSendSocket = socketNumber
+          ws.send(successResponse(String(frame.id), {
+            sessionKey: SESSION_KEY,
+            status: 'accepted',
+            task_id: 'e2e-after-metadata-reconnect',
+            message_id: 'e2e-after-metadata-reconnect-message',
+          }))
+          return
+        }
+        ws.send(successResponse(String(frame.id), basePayload(method)))
+      } catch {}
+    })
+  })
+
+  await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(SESSION_KEY))
+  await expect.poll(() => heldConfigRequests).toBeGreaterThan(0)
+  await expect.poll(() => socketCount, { timeout: 10_000 }).toBeGreaterThan(1)
+
+  const composer = page.getByRole('textbox', { name: 'Message to send' })
+  const send = page.getByRole('button', { name: 'Send', exact: true })
+  await expect(composer).toBeEditable()
+  await composer.fill('Send after automatic metadata recovery.')
+  await expect(send).toBeEnabled()
+  await send.click()
+
+  await expect.poll(() => chatSendSocket).toBeGreaterThan(1)
+  await expect(composer).toHaveValue('')
 })
 
 test('shows a recoverable initial failure and retries it', async ({ page }) => {
@@ -222,7 +346,7 @@ test('shows a recoverable initial failure and retries it', async ({ page }) => {
         const frame = JSON.parse(String(message))
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
-          ws.send(JSON.stringify({ protocol: 3, policy: { tick_interval_ms: 30000 } }))
+          ws.send(helloResponse(30000))
           return
         }
         if (frame.method === 'config.get') {
@@ -333,7 +457,7 @@ test('terminates stalled history and live hydration despite ongoing ticks, then 
         const frame = JSON.parse(String(message))
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
-          ws.send(JSON.stringify({ protocol: 3, policy: { tick_interval_ms: 1000 } }))
+          ws.send(helloResponse(1000))
           return
         }
         if (frame.method === 'sessions.messages.snapshot') {
@@ -464,7 +588,7 @@ test('preserves a Sessions Hub auto-send draft when live recovery terminates', a
         const frame = JSON.parse(String(message))
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
-          ws.send(JSON.stringify({ protocol: 3, policy: { tick_interval_ms: 1000 } }))
+          ws.send(helloResponse(1000))
           return
         }
         if (frame.method === 'sessions.messages.snapshot') {
@@ -549,7 +673,7 @@ test('cancels delayed auto-send when the user edits the draft before live is rea
         const frame = JSON.parse(String(message))
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
-          ws.send(JSON.stringify({ protocol: 3, policy: { tick_interval_ms: 30000 } }))
+          ws.send(helloResponse(30000))
           return
         }
         if (frame.method === 'sessions.messages.snapshot') {
@@ -612,7 +736,7 @@ test('keeps loaded messages visible when an earlier page fails and retries inlin
         const frame = JSON.parse(String(message))
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
-          ws.send(JSON.stringify({ protocol: 3, policy: { tick_interval_ms: 30000 } }))
+          ws.send(helloResponse(30000))
           return
         }
         if (frame.method === 'config.get') {
@@ -700,7 +824,7 @@ test('ignores a late history response after navigating to another session', asyn
         const frame = JSON.parse(String(message))
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
-          ws.send(JSON.stringify({ protocol: 3, policy: { tick_interval_ms: 30000 } }))
+          ws.send(helloResponse(30000))
           return
         }
         if (frame.method === 'sessions.list') {

--- a/opensquilla-webui/src/App.sidebar-contract.test.ts
+++ b/opensquilla-webui/src/App.sidebar-contract.test.ts
@@ -39,4 +39,12 @@ describe('App sidebar chrome contract', () => {
     const singleDelete = appSource.slice(singleStart, singleEnd)
     expect(singleDelete).toContain('appStore.removePendingApprovalsForSessions(deleted)')
   })
+
+  it('bounds automatic sidebar RPCs after chat bootstrap admission', () => {
+    expect(appSource).toContain('useSessions(\n  optionalSessionRpcCallOptions,\n)')
+    expect(appSource).toContain('useAgentOptions(optionalSessionRpcCallOptions)')
+    expect(appSource).toContain(
+      'useSessionListSubscription({\n  rpc: rpcStore,\n  callOptions: optionalSessionRpcCallOptions,',
+    )
+  })
 })

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -508,7 +508,9 @@ const router = useRouter()
 watch(() => appStore.locale, () => {
   document.title = `${routeTitle($route)} — OpenSquilla`
 })
-const { allSessions, sessionListError, isLoading, loadSessions } = useSessions()
+const { allSessions, sessionListError, isLoading, loadSessions } = useSessions(
+  optionalSessionRpcCallOptions,
+)
 const { bottomRoutes, workNav } = useNavigation()
 // Axis-B: the active expressive skin for the routed content area (meta.skin).
 const { skinId, variants } = useSurfaceSkin()
@@ -554,7 +556,7 @@ const webConfigEnabled = getPlatform().capabilities.hasWebConfig
 installSessionNavigationDiagConsole()
 
 // Shared agents.list state + fetch (singleton) for sidebar session metadata.
-const { agents, loadAgents } = useAgentOptions()
+const { agents, loadAgents } = useAgentOptions(optionalSessionRpcCallOptions)
 const mobileKeyboardOpen = ref(false)
 const commandPaletteOpen = ref(false)
 const localChatSessions = ref<Record<string, { effectiveAgentId: string; title: string; updatedAt: number }>>({})
@@ -1420,6 +1422,7 @@ function refreshSidebarDataWhenAdmitted(): void | Promise<void> {
 
 const sessionListSubscription = useSessionListSubscription({
   rpc: rpcStore,
+  callOptions: optionalSessionRpcCallOptions,
   isConnected: () => rpcStore.isConnected,
   isAdmitted: () => optionalSessionRpcAllowed.value,
   refresh: refreshSidebarDataWhenAdmitted,

--- a/opensquilla-webui/src/composables/chat/sessionBootstrapAdmission.ts
+++ b/opensquilla-webui/src/composables/chat/sessionBootstrapAdmission.ts
@@ -1,5 +1,5 @@
 import { computed, ref } from 'vue'
-import type { RpcCallOptions } from '@/lib/rpc'
+import type { RpcCallOptions, RpcConnectionWaitOptions } from '@/lib/rpc'
 
 const activeHolds = ref(0)
 let primedRelease: (() => void) | null = null
@@ -7,15 +7,41 @@ let primedRelease: (() => void) | null = null
 /**
  * Optional, mount-time RPCs must not enter the Gateway's serialized dispatch
  * queue ahead of chat session recovery. ChatView acquires a hold synchronously
- * during setup (before child mounted hooks run) and releases it only after the
- * history/live phases reach terminal states.
+ * during setup (before child mounted hooks run) and releases it as soon as the
+ * critical request frames have been queued.
  */
 export const optionalSessionRpcAllowed = computed(() => activeHolds.value === 0)
 
 export const optionalSessionRpcCallOptions: RpcCallOptions = {
   timeoutMs: 2_000,
+  // These methods still use the Gateway's serial dispatcher. Retire the
+  // connection when one is abandoned so a stuck handler cannot keep later
+  // navigation and control requests trapped behind it.
   timeoutAction: 'reconnect',
   abortAction: 'reconnect',
+}
+
+type OptionalSessionRpcClient = {
+  waitForConnection: (
+    timeoutMs?: number,
+    signal?: AbortSignal,
+    actions?: RpcConnectionWaitOptions,
+  ) => Promise<unknown>
+}
+
+export function waitForSessionRpcConnection(
+  rpc: OptionalSessionRpcClient,
+  callOptions?: RpcCallOptions,
+): Promise<unknown> {
+  if (!callOptions) return rpc.waitForConnection()
+  return rpc.waitForConnection(
+    callOptions.timeoutMs,
+    callOptions.signal,
+    {
+      timeoutAction: callOptions.timeoutAction,
+      abortAction: callOptions.abortAction,
+    },
+  )
 }
 
 function createSessionBootstrapAdmission(): () => void {

--- a/opensquilla-webui/src/composables/chat/sessionBootstrapContract.ts
+++ b/opensquilla-webui/src/composables/chat/sessionBootstrapContract.ts
@@ -25,9 +25,14 @@ export interface SessionBootstrapPhaseContext {
    * Marks that this attempt's subscribe frame was synchronously sent. History
    * may then enter the serialized Gateway queue behind it.
    */
-  markLiveSubscribeSent?: () => void
-  /** Optional metadata hydration starts only after canonical history settles. */
-  waitForHistoryTerminal?: () => Promise<unknown>
+  markLiveSubscribeSent?: (socketGeneration: number) => void
+  /** Marks that the canonical history frame was synchronously sent. */
+  markHistoryRequestSent?: (socketGeneration: number) => void
+  /**
+   * Optional metadata may start once the critical frames are on the wire. It
+   * must not wait for a potentially slow history response.
+   */
+  waitForCriticalRequestsQueued?: () => Promise<void>
 }
 
 export interface SessionPhaseResult<T = void> {

--- a/opensquilla-webui/src/composables/chat/useChatFeatureToggles.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatFeatureToggles.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useChatFeatureToggles } from './useChatFeatureToggles'
 import source from './useChatFeatureToggles.ts?raw'
+import type { RpcCallOptions } from '@/lib/rpc'
 import type { ModelRoutingMode } from '@/types/modelRouting'
 
 type RpcResult = Record<string, unknown> | Error | Promise<unknown>
@@ -17,6 +18,7 @@ function createHarness(options: {
   configGetResults?: RpcResult[]
   routingGetResults?: RpcResult[]
   patchResults?: RpcResult[]
+  readCallOptions?: RpcCallOptions
 } = {}) {
   const configGetResults = [...(options.configGetResults ?? [{}])]
   const routingGetResults = [...(options.routingGetResults ?? [])]
@@ -55,6 +57,7 @@ function createHarness(options: {
   }
   const api = useChatFeatureToggles({
     rpc,
+    readCallOptions: options.readCallOptions,
     setGlobalElevatedMode,
     loadCurrentSessionUsage,
   })
@@ -82,13 +85,32 @@ afterEach(() => {
 
 describe('useChatFeatureToggles coding mode', () => {
   it('reads enabled coding mode from backend config', async () => {
-    const { api } = createHarness({
+    const readCallOptions: RpcCallOptions = {
+      timeoutMs: 2_000,
+      timeoutAction: 'reconnect',
+      abortAction: 'reconnect',
+    }
+    const { api, rpc } = createHarness({
       configGetResults: [{ skills: { coding_mode: true } }],
+      readCallOptions,
     })
 
     await api.loadFeatureToggles()
 
     expect(api.codingModeEnabled.value).toBe(true)
+    expect(rpc.waitForConnection).toHaveBeenCalledWith(
+      2_000,
+      undefined,
+      {
+        timeoutAction: 'reconnect',
+        abortAction: 'reconnect',
+      },
+    )
+    expect(rpc.call).toHaveBeenCalledWith(
+      'config.get',
+      undefined,
+      readCallOptions,
+    )
   })
 
   it.each([

--- a/opensquilla-webui/src/composables/chat/useChatFeatureToggles.ts
+++ b/opensquilla-webui/src/composables/chat/useChatFeatureToggles.ts
@@ -11,15 +11,28 @@ import {
   normalizeRouterVisualMode,
 } from '@/utils/chat/routerVisualMode'
 import { useRouterVisualEffectsPreference } from '@/composables/useRouterVisualEffectsPreference'
+import {
+  waitForSessionRpcConnection,
+} from '@/composables/chat/sessionBootstrapAdmission'
+import type { RpcCallOptions, RpcConnectionWaitOptions } from '@/lib/rpc'
 
 type RpcClient = {
-  waitForConnection: () => Promise<void>
-  call: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+  waitForConnection: (
+    timeoutMs?: number,
+    signal?: AbortSignal,
+    actions?: RpcConnectionWaitOptions,
+  ) => Promise<void>
+  call: <T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    callOptions?: RpcCallOptions,
+  ) => Promise<T>
   on?: (event: string, handler: (payload: unknown) => void) => () => void
 }
 
 export interface UseChatFeatureTogglesOptions {
   rpc: RpcClient
+  readCallOptions?: RpcCallOptions
   setGlobalElevatedMode: (mode: string) => void
   loadCurrentSessionUsage: () => void | Promise<void>
 }
@@ -142,11 +155,23 @@ export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
 
   async function loadFeatureToggles() {
     try {
-      await options.rpc.waitForConnection()
-      const cfg = await options.rpc.call<ChatFeatureConfig>('config.get')
+      await waitForSessionRpcConnection(options.rpc, options.readCallOptions)
+      const cfg = options.readCallOptions
+        ? await options.rpc.call<ChatFeatureConfig>(
+            'config.get',
+            undefined,
+            options.readCallOptions,
+          )
+        : await options.rpc.call<ChatFeatureConfig>('config.get')
       await applyFeatureConfig(cfg, { refreshUsage: true })
       try {
-        const routing = await options.rpc.call<ModelRoutingSnapshot>('models.routing.get')
+        const routing = options.readCallOptions
+          ? await options.rpc.call<ModelRoutingSnapshot>(
+              'models.routing.get',
+              undefined,
+              options.readCallOptions,
+            )
+          : await options.rpc.call<ModelRoutingSnapshot>('models.routing.get')
         applyModelRoutingSnapshot(routing)
       } catch {
         // Older Gateways have no canonical routing RPC; the config projection

--- a/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
@@ -12,6 +12,7 @@ function makeHistory(autoScroll = true, overrides: {
   preserveLiveTail?: boolean
   sessionKey?: Ref<string>
   threadRef?: Ref<HTMLElement | null>
+  concurrentHistoryReads?: boolean
 } = {}) {
   const response: ChatHistoryResponse = overrides.response || {
     messages: [
@@ -30,6 +31,9 @@ function makeHistory(autoScroll = true, overrides: {
   }
   const messages = ref<ChatMessage[]>(overrides.messages || [])
   const rpc = {
+    policy: {
+      concurrent_history_reads: overrides.concurrentHistoryReads ?? true,
+    },
     waitForConnection: vi.fn().mockResolvedValue(undefined),
     call: vi.fn().mockResolvedValue(response),
   }
@@ -69,13 +73,13 @@ describe('useChatHistory canonical pagination', () => {
     expect(rpc.call).toHaveBeenCalledWith('chat.history', expect.objectContaining({
       includeCanonical: true,
       includeSummaries: false,
-    }), expect.objectContaining({ timeoutAction: 'reconnect' }))
+    }), expect.objectContaining({ timeoutAction: 'reject' }))
     expect(api.historyState.value).toMatchObject({
       initialLoadStatus: 'ready',
     })
   })
 
-  it('applies the shared bootstrap deadline and reconnect-on-timeout contract', async () => {
+  it('applies the shared bootstrap deadline without recycling on history timeout', async () => {
     const { api, rpc } = makeHistory()
     const now = Date.now()
     const controller = new AbortController()
@@ -94,8 +98,8 @@ describe('useChatHistory canonical pagination', () => {
       expect.any(Number),
       expect.any(AbortSignal),
       {
-        timeoutAction: 'reconnect',
-        abortAction: 'reconnect',
+        timeoutAction: 'reject',
+        abortAction: 'reject',
       },
     )
     expect(rpc.call).toHaveBeenCalledWith(
@@ -104,6 +108,33 @@ describe('useChatHistory canonical pagination', () => {
       expect.objectContaining({
         timeoutMs: expect.any(Number),
         signal: expect.any(AbortSignal),
+        timeoutAction: 'reject',
+        abortAction: 'reject',
+        onSent: expect.any(Function),
+      }),
+    )
+  })
+
+  it('recycles a legacy serial Gateway when history is abandoned', async () => {
+    const { api, rpc } = makeHistory(true, {
+      concurrentHistoryReads: false,
+    })
+    const now = Date.now()
+
+    await api.loadHistory({}, {
+      generation: 1,
+      key: 'agent:main:webchat:test',
+      attempt: 0,
+      deadlineAt: now + 15_000,
+      attemptDeadlineAt: now + 7_000,
+      signal: new AbortController().signal,
+      skipSnapshot: false,
+    })
+
+    expect(rpc.call).toHaveBeenCalledWith(
+      'chat.history',
+      expect.any(Object),
+      expect.objectContaining({
         timeoutAction: 'reconnect',
         abortAction: 'reconnect',
       }),
@@ -427,7 +458,7 @@ describe('useChatHistory canonical pagination', () => {
 
     expect(rpc.call).toHaveBeenNthCalledWith(4, 'chat.history', expect.objectContaining({
       before: 'cursor-3',
-    }), expect.objectContaining({ timeoutAction: 'reconnect' }))
+    }), expect.objectContaining({ timeoutAction: 'reject' }))
     await vi.waitFor(() => {
       expect(messages.value.map(message => message.messageId)).toEqual(['m2', 'm3', 'm4', 'm5'])
     })
@@ -477,7 +508,7 @@ describe('useChatHistory canonical pagination', () => {
     expect(messages.value.map(message => message.messageId)).toEqual(['m2', 'm3', 'm4'])
     expect(rpc.call).toHaveBeenNthCalledWith(3, 'chat.history', expect.objectContaining({
       before: 'cursor-4',
-    }), expect.objectContaining({ timeoutAction: 'reconnect' }))
+    }), expect.objectContaining({ timeoutAction: 'reject' }))
   })
 
   it('keeps more than 200 loaded canonical messages during a latest-window refresh', async () => {
@@ -595,16 +626,16 @@ describe('useChatHistory canonical pagination', () => {
     expect(rpc.call).toHaveBeenNthCalledWith(4, 'chat.history', expect.objectContaining({
       after: 'cursor-299',
       limit: 200,
-    }), expect.objectContaining({ timeoutAction: 'reconnect' }))
+    }), expect.objectContaining({ timeoutAction: 'reject' }))
     expect(rpc.call).toHaveBeenNthCalledWith(5, 'chat.history', expect.objectContaining({
       after: 'cursor-499',
       limit: 200,
-    }), expect.objectContaining({ timeoutAction: 'reconnect' }))
+    }), expect.objectContaining({ timeoutAction: 'reject' }))
 
     await api.loadEarlierHistory()
     expect(rpc.call).toHaveBeenNthCalledWith(6, 'chat.history', expect.objectContaining({
       before: 'cursor-200',
-    }), expect.objectContaining({ timeoutAction: 'reconnect' }))
+    }), expect.objectContaining({ timeoutAction: 'reject' }))
   })
 
   it('bounds each disconnected forward bridge and resumes from the saved cursor', async () => {
@@ -673,7 +704,7 @@ describe('useChatHistory canonical pagination', () => {
     await vi.waitFor(() => expect(rpc.call).toHaveBeenCalledTimes(7))
     expect(rpc.call).toHaveBeenNthCalledWith(7, 'chat.history', expect.objectContaining({
       after: 'cursor-12',
-    }), expect.objectContaining({ timeoutAction: 'reconnect' }))
+    }), expect.objectContaining({ timeoutAction: 'reject' }))
     expect(messages.value.map(message => message.messageId)).toEqual([
       'm7', 'm8', 'm9', 'm10', 'm11', 'm12', 'm13', 'm14', 'm15', 'm16',
       'm17', 'm18', 'm19', 'm20',
@@ -752,7 +783,7 @@ describe('useChatHistory canonical pagination', () => {
     ])
     expect(rpc.call).toHaveBeenNthCalledWith(6, 'chat.history', expect.objectContaining({
       after: 'cursor-4',
-    }), expect.objectContaining({ timeoutAction: 'reconnect' }))
+    }), expect.objectContaining({ timeoutAction: 'reject' }))
   })
 
   it('stops a forward bridge when its cursor does not advance', async () => {

--- a/opensquilla-webui/src/composables/chat/useChatHistory.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.ts
@@ -25,7 +25,6 @@ import {
   SESSION_PHASE_ATTEMPT_BUDGET_MS,
   isRpcAbort,
   phaseCallOptions,
-  phaseConnectionWaitOptions,
   phaseTimeoutMs,
   type SessionBootstrapPhaseContext,
   type SessionPhaseResult,
@@ -33,6 +32,7 @@ import {
 import type { RpcCallOptions, RpcConnectionWaitOptions } from '@/lib/rpc'
 
 type RpcClient = {
+  policy?: Record<string, unknown> | null
   waitForConnection: (
     timeoutMs?: number,
     signal?: AbortSignal,
@@ -43,6 +43,16 @@ type RpcClient = {
     params?: Record<string, unknown>,
     options?: RpcCallOptions,
   ) => Promise<T>
+}
+
+function historyTerminationActions(rpc: RpcClient) {
+  const action = rpc.policy?.concurrent_history_reads === true
+    ? 'reject' as const
+    : 'reconnect' as const
+  return {
+    timeoutAction: action,
+    abortAction: action,
+  }
 }
 
 function recordArray<T extends Record<string, unknown>>(value: unknown): T[] {
@@ -280,11 +290,22 @@ export function useChatHistory(options: UseChatHistoryOptions) {
     request: Record<string, unknown>,
     bootstrap: SessionBootstrapPhaseContext,
   ): Promise<T> {
-    return options.rpc.call<T>(
+    const callOptions = {
+      ...phaseCallOptions(bootstrap, 'chat.history'),
+      // History is background content. A slow read may fail independently,
+      // without recycling a Gateway that advertises concurrent reads. Legacy
+      // serial Gateways still need a fresh connection to escape a stuck read.
+      ...historyTerminationActions(options.rpc),
+      onSent: (socketGeneration: number) => {
+        bootstrap.markHistoryRequestSent?.(socketGeneration)
+      },
+    }
+    const response = options.rpc.call<T>(
       'chat.history',
       request,
-      phaseCallOptions(bootstrap, 'chat.history'),
+      callOptions,
     )
+    return response
   }
 
   async function runHistoryLoad(
@@ -319,7 +340,7 @@ export function useChatHistory(options: UseChatHistoryOptions) {
       await options.rpc.waitForConnection(
         phaseTimeoutMs(bootstrap, 'chat.history'),
         bootstrap.signal,
-        phaseConnectionWaitOptions(),
+        historyTerminationActions(options.rpc),
       )
       if (!isCurrentRequest()) {
         if (requestSeq === historyRequestSeq) {

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
@@ -722,9 +722,13 @@ describe('useChatRpcEventHandlers ensemble activity', () => {
     }
   })
 
-  it('defers optional reconnect metadata until both bootstrap phases terminate', async () => {
+  it('refreshes reconnect metadata once critical requests are queued', async () => {
+    let resolveCriticalRequestsQueued!: () => void
     let resolveHistory!: () => void
     let resolveLive!: () => void
+    const criticalRequestsQueued = new Promise<void>(resolve => {
+      resolveCriticalRequestsQueued = resolve
+    })
     const history = new Promise<{ ok: boolean }>(resolve => {
       resolveHistory = () => resolve({ ok: true })
     })
@@ -741,6 +745,7 @@ describe('useChatRpcEventHandlers ensemble activity', () => {
     })
     const run: SessionBootstrapRun = {
       generation: 2,
+      criticalRequestsQueued,
       history,
       live,
     }
@@ -754,15 +759,15 @@ describe('useChatRpcEventHandlers ensemble activity', () => {
       expect(harness.loadCurrentSessionUsage).not.toHaveBeenCalled()
       expect(harness.refreshRunModePreference).not.toHaveBeenCalled()
 
-      resolveLive()
-      await Promise.resolve()
-      expect(harness.loadCurrentSessionUsage).not.toHaveBeenCalled()
-
-      resolveHistory()
+      resolveCriticalRequestsQueued()
       await vi.waitFor(() => {
         expect(harness.loadCurrentSessionUsage).toHaveBeenCalledOnce()
         expect(harness.refreshRunModePreference).toHaveBeenCalledOnce()
       })
+
+      resolveLive()
+      resolveHistory()
+      await Promise.all([live, history])
     } finally {
       harness.stop()
     }

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -1097,13 +1097,11 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
       const connectedSessionKey = sessionKey.value
       connectionLostNoted = false
       stream.hideThinkingIndicator()
-      // The Gateway intentionally dispatches RPCs serially. Optional usage
-      // metadata must not enter that queue ahead of snapshot/subscribe/history
-      // after reconnect, so wait for the coordinator's critical phases.
-      const criticalPhases = recovery
-        ? [recovery.history, recovery.live]
-        : []
-      void Promise.allSettled(criticalPhases).then(() => {
+      // Preserve critical frame ordering after reconnect without waiting for a
+      // potentially slow history response before refreshing independent UI.
+      const criticalRequestsQueued = recovery?.criticalRequestsQueued
+        ?? Promise.resolve()
+      void criticalRequestsQueued.then(() => {
         if (
           connectionStateGeneration === stateGeneration
           && sessionKey.value === connectedSessionKey

--- a/opensquilla-webui/src/composables/chat/useChatRunModePreference.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRunModePreference.test.ts
@@ -9,6 +9,7 @@ import {
   useChatRunModePreference,
   type RunModePolicy,
 } from './useChatRunModePreference'
+import type { RpcCallOptions } from '@/lib/rpc'
 
 function createRpc() {
   return {
@@ -20,11 +21,13 @@ function createRpc() {
 function runInScope(
   policy: ReturnType<typeof ref<RunModePolicy | null>>,
   rpc = createRpc(),
+  hydrateCallOptions?: RpcCallOptions,
 ) {
   const scope = effectScope()
   const api = scope.run(() => useChatRunModePreference({
     runModePolicy: () => policy.value,
     rpc,
+    hydrateCallOptions,
   }))!
   return { api, scope, rpc }
 }
@@ -69,12 +72,29 @@ describe('useChatRunModePreference', () => {
       allowedRunModes: ['standard', 'trusted', 'full'],
     })
     const rpc = createRpc()
+    const hydrateCallOptions: RpcCallOptions = {
+      timeoutMs: 2_000,
+      timeoutAction: 'reconnect',
+      abortAction: 'reconnect',
+    }
     rpc.call.mockResolvedValueOnce({ runMode: 'trusted', source: 'preference' })
-    const { api, scope } = runInScope(policy, rpc)
+    const { api, scope } = runInScope(policy, rpc, hydrateCallOptions)
 
     await api.hydrateRunModePreference()
 
-    expect(rpc.call).toHaveBeenCalledWith('sandbox.run_mode.preference.get')
+    expect(rpc.call).toHaveBeenCalledWith(
+      'sandbox.run_mode.preference.get',
+      undefined,
+      hydrateCallOptions,
+    )
+    expect(rpc.waitForConnection).toHaveBeenCalledWith(
+      2_000,
+      undefined,
+      {
+        timeoutAction: 'reconnect',
+        abortAction: 'reconnect',
+      },
+    )
     expect(api.runMode.value).toBe('trusted')
     expect(localStorage.getItem(RUN_MODE_STORAGE_KEY)).toBe('trusted')
     scope.stop()

--- a/opensquilla-webui/src/composables/chat/useChatRunModePreference.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRunModePreference.ts
@@ -1,5 +1,9 @@
 import { computed, ref, watch } from 'vue'
 
+import {
+  waitForSessionRpcConnection,
+} from '@/composables/chat/sessionBootstrapAdmission'
+import type { RpcCallOptions, RpcConnectionWaitOptions } from '@/lib/rpc'
 import { SANDBOX_RUN_MODES, isSandboxRunMode, type SandboxRunMode } from '@/types/sandbox'
 
 export const RUN_MODE_STORAGE_KEY = 'opensquilla.chat.runMode'
@@ -13,11 +17,20 @@ export interface RunModePolicy {
 interface UseChatRunModePreferenceOptions {
   runModePolicy: () => RunModePolicy | null | undefined
   rpc: RunModePreferenceRpc
+  hydrateCallOptions?: RpcCallOptions
 }
 
 interface RunModePreferenceRpc {
-  waitForConnection: (timeoutMs?: number) => Promise<void>
-  call: (method: string, params?: Record<string, unknown>) => Promise<unknown>
+  waitForConnection: (
+    timeoutMs?: number,
+    signal?: AbortSignal,
+    actions?: RpcConnectionWaitOptions,
+  ) => Promise<void>
+  call: (
+    method: string,
+    params?: Record<string, unknown>,
+    callOptions?: RpcCallOptions,
+  ) => Promise<unknown>
 }
 
 interface RunModeRpc {
@@ -164,8 +177,14 @@ export function useChatRunModePreference(options: UseChatRunModePreferenceOption
   }
 
   async function hydrateRunModePreference(): Promise<SandboxRunMode> {
-    await options.rpc.waitForConnection()
-    const payload = await options.rpc.call('sandbox.run_mode.preference.get')
+    await waitForSessionRpcConnection(options.rpc, options.hydrateCallOptions)
+    const payload = options.hydrateCallOptions
+      ? await options.rpc.call(
+          'sandbox.run_mode.preference.get',
+          undefined,
+          options.hydrateCallOptions,
+        )
+      : await options.rpc.call('sandbox.run_mode.preference.get')
     const source = payload && typeof payload === 'object'
       ? (payload as Record<string, unknown>).source
       : null

--- a/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.test.ts
@@ -32,13 +32,27 @@ function createBootstrap(overrides: {
   subscribeSession?: (
     context: SessionBootstrapPhaseContext,
   ) => Promise<SessionSubscriptionOutcome>
+  markCriticalRequestsSent?: boolean
 } = {}) {
-  const loadHistory = vi.fn(overrides.loadHistory || (async () => ({ ok: true })))
+  const loadHistoryImplementation = overrides.loadHistory || (async () => ({ ok: true }))
+  const loadHistory = vi.fn(async (
+    context: SessionBootstrapPhaseContext,
+    retry: boolean,
+  ) => {
+    // Production marks immediately after RpcClient synchronously sends the
+    // history frame.
+    if (overrides.markCriticalRequestsSent !== false) {
+      context.markHistoryRequestSent?.(context.attempt + 1)
+    }
+    return loadHistoryImplementation(context, retry)
+  })
   const subscribeImplementation = overrides.subscribeSession || (async () => LIVE_READY)
   const subscribeSession = vi.fn(async (context: SessionBootstrapPhaseContext) => {
     // The production subscription marks immediately after its subscribe frame
     // is synchronously sent. Test doubles must model the same wire boundary.
-    context.markLiveSubscribeSent?.()
+    if (overrides.markCriticalRequestsSent !== false) {
+      context.markLiveSubscribeSent?.(context.attempt + 1)
+    }
     return subscribeImplementation(context)
   })
   const cancelHistory = vi.fn()
@@ -69,6 +83,187 @@ afterEach(() => {
 })
 
 describe('useChatSessionBootstrap', () => {
+  it('releases optional traffic after critical frames are queued, not responses', async () => {
+    let resolveHistory!: (result: SessionPhaseResult) => void
+    let resolveLive!: (result: SessionSubscriptionOutcome) => void
+    const history = new Promise<SessionPhaseResult>(resolve => {
+      resolveHistory = resolve
+    })
+    const live = new Promise<SessionSubscriptionOutcome>(resolve => {
+      resolveLive = resolve
+    })
+    const { api } = createBootstrap({
+      loadHistory: async () => history,
+      subscribeSession: async () => live,
+    })
+
+    const run = api.startSessionBootstrap()
+    await run.criticalRequestsQueued
+
+    expect(api.historyPhase.value).toBe('loading')
+    expect(api.livePhase.value).toBe('connecting')
+
+    resolveHistory({ ok: true })
+    resolveLive(LIVE_READY)
+    await Promise.all([run.history, run.live])
+  })
+
+  it('retries a history-only timeout without waiting for a new live registration', async () => {
+    vi.useFakeTimers()
+    let historyAttempt = 0
+    const { api, loadHistory, subscribeSession } = createBootstrap({
+      loadHistory: async () => {
+        historyAttempt += 1
+        return historyAttempt === 1
+          ? {
+              ok: false,
+              error: new RpcTimeoutError('chat.history', 7_000),
+            }
+          : { ok: true }
+      },
+    })
+
+    const run = api.startSessionBootstrap()
+    await vi.runAllTimersAsync()
+    await Promise.all([run.history, run.live])
+
+    expect(loadHistory).toHaveBeenCalledTimes(2)
+    expect(subscribeSession).toHaveBeenCalledOnce()
+    expect(api.historyPhase.value).toBe('ready')
+    expect(api.livePhase.value).toBe('ready')
+  })
+
+  it('queues replacement live registration before retrying legacy history', async () => {
+    const order: string[] = []
+    let resolveFirstHistory!: (result: SessionPhaseResult) => void
+    const { api } = createBootstrap({
+      subscribeSession: async context => {
+        order.push(`subscribe:${context.attempt}`)
+        return LIVE_READY
+      },
+      loadHistory: async context => {
+        order.push(`history:${context.attempt}`)
+        if (context.attempt === 0) {
+          return new Promise(resolve => {
+            resolveFirstHistory = resolve
+          })
+        }
+        return { ok: true }
+      },
+    })
+
+    const run = api.startSessionBootstrap()
+    await run.live
+    api.handleConnectionState('disconnected')
+    resolveFirstHistory({
+      ok: false,
+      error: new RpcTimeoutError('chat.history', 7_000),
+    })
+    await Promise.all([run.history, api.handleConnectionState('connected')!.live])
+
+    expect(order).toEqual([
+      'subscribe:0',
+      'history:0',
+      'subscribe:1',
+      'history:1',
+    ])
+    expect(api.livePhase.value).toBe('ready')
+    expect(api.historyPhase.value).toBe('ready')
+  })
+
+  it('rearms the critical queue for a replacement socket', async () => {
+    let resolveFirstHistory!: (result: SessionPhaseResult) => void
+    let historyAttempt = 0
+    const connectionFailure = new Error('connection closed')
+    const { api, loadHistory, subscribeSession } = createBootstrap({
+      loadHistory: async () => {
+        historyAttempt += 1
+        if (historyAttempt === 1) {
+          return new Promise(resolve => {
+            resolveFirstHistory = resolve
+          })
+        }
+        return { ok: true }
+      },
+    })
+
+    const initial = api.startSessionBootstrap()
+    await initial.criticalRequestsQueued
+    await initial.live
+
+    const recovery = api.handleConnectionState('disconnected')!
+    let replacementQueued = false
+    void recovery.criticalRequestsQueued.then(() => {
+      replacementQueued = true
+    })
+    await Promise.resolve()
+    expect(replacementQueued).toBe(false)
+
+    resolveFirstHistory({ ok: false, error: connectionFailure })
+    await recovery.criticalRequestsQueued
+    await Promise.all([recovery.history, recovery.live])
+
+    expect(loadHistory).toHaveBeenCalledTimes(2)
+    expect(subscribeSession).toHaveBeenCalledTimes(2)
+    expect(replacementQueued).toBe(true)
+  })
+
+  it('keeps existing queue waiters blocked across a same-run reconnect', async () => {
+    let resolveFirstLive!: (result: SessionSubscriptionOutcome) => void
+    let liveAttempt = 0
+    const { api } = createBootstrap({
+      markCriticalRequestsSent: false,
+      subscribeSession: async context => {
+        liveAttempt += 1
+        if (liveAttempt === 1) {
+          return new Promise(resolve => {
+            resolveFirstLive = resolve
+          })
+        }
+        context.markLiveSubscribeSent?.(2)
+        return LIVE_READY
+      },
+      loadHistory: async context => {
+        context.markHistoryRequestSent?.(2)
+        return { ok: true }
+      },
+    })
+
+    const initial = api.startSessionBootstrap()
+    let initialQueued = false
+    void initial.criticalRequestsQueued.then(() => {
+      initialQueued = true
+    })
+
+    const firstRecovery = api.handleConnectionState('disconnected')!
+    let firstReplacementQueued = false
+    void firstRecovery.criticalRequestsQueued.then(() => {
+      firstReplacementQueued = true
+    })
+    const latestRecovery = api.handleConnectionState('disconnected')!
+    let latestReplacementQueued = false
+    void latestRecovery.criticalRequestsQueued.then(() => {
+      latestReplacementQueued = true
+    })
+    await Promise.resolve()
+    expect(initialQueued).toBe(false)
+    expect(firstReplacementQueued).toBe(false)
+    expect(latestReplacementQueued).toBe(false)
+
+    resolveFirstLive({
+      ...UNAVAILABLE_FOR_TEST,
+      error: new Error('connection closed'),
+    })
+    await latestRecovery.criticalRequestsQueued
+    await firstRecovery.criticalRequestsQueued
+    await Promise.all([latestRecovery.history, latestRecovery.live])
+
+    expect(initialQueued).toBe(true)
+    expect(firstReplacementQueued).toBe(true)
+    expect(latestReplacementQueued).toBe(true)
+    expect(liveAttempt).toBe(2)
+  })
+
   it('cancels delayed auto-send when text or attachments changed', () => {
     const attachment = { id: 1 }
     expect(autoSendDraftIsUnchanged(

--- a/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.ts
@@ -6,7 +6,6 @@ import {
   SESSION_BOOTSTRAP_BUDGET_MS,
   SESSION_PHASE_ATTEMPT_BUDGET_MS,
   isRpcAbort,
-  isRpcTimeout,
   retryAfterMs,
   shouldRetrySessionPhase,
   type SessionBootstrapPhaseContext,
@@ -24,11 +23,23 @@ interface PhaseRuntime<T> {
   skipSnapshot: boolean
 }
 
+interface CriticalRequestQueue {
+  promise: Promise<void>
+  resolve: () => void
+  released: boolean
+  historyRequired: boolean
+  liveSocketGeneration: number | null
+  historySocketGeneration: number | null
+  liveTerminal: boolean
+  historyTerminal: boolean
+}
+
 interface ActiveBootstrap {
   generation: number
   key: string
   includeHistory: boolean
   controller: AbortController
+  criticalQueue: CriticalRequestQueue
   liveQueueSequence: number
   liveQueueWaiters: Set<{
     minimum: number
@@ -41,6 +52,7 @@ interface ActiveBootstrap {
 
 export interface SessionBootstrapRun {
   generation: number
+  criticalRequestsQueued: Promise<void>
   history: Promise<SessionPhaseResult>
   live: Promise<SessionSubscriptionOutcome>
 }
@@ -126,21 +138,69 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
       skipSnapshot: phase.skipSnapshot,
       ...(phase === run.live
         ? {
-            markLiveSubscribeSent: () => markLiveSubscribeSent(run),
-            waitForHistoryTerminal: () => run.history.promise,
+            markLiveSubscribeSent: (socketGeneration: number) =>
+              markLiveSubscribeSent(run, socketGeneration),
+            waitForCriticalRequestsQueued: () => run.criticalQueue.promise,
           }
-        : {}),
+        : {
+            markHistoryRequestSent: (socketGeneration: number) =>
+              markHistoryRequestSent(run, socketGeneration),
+          }),
     }
   }
 
-  function markLiveSubscribeSent(run: ActiveBootstrap) {
+  function releaseCriticalRequestsIfReady(run: ActiveBootstrap) {
+    const queue = run.criticalQueue
+    if (queue.released) return
+    const liveQueued = queue.liveSocketGeneration !== null
+    const historyQueued = (
+      !queue.historyRequired
+      || queue.historySocketGeneration !== null
+    )
+    const queuedOnSameSocket = (
+      liveQueued
+      && historyQueued
+      && (
+        !queue.historyRequired
+        || queue.liveSocketGeneration === queue.historySocketGeneration
+      )
+    )
+    const terminalWithoutQueue = (
+      (queue.liveTerminal || (queue.historyRequired && queue.historyTerminal))
+      && (liveQueued || queue.liveTerminal)
+      && (
+        !queue.historyRequired
+        || historyQueued
+        || queue.historyTerminal
+      )
+    )
+    if (!queuedOnSameSocket && !terminalWithoutQueue) return
+    queue.released = true
+    queue.resolve()
+  }
+
+  function markLiveSubscribeSent(
+    run: ActiveBootstrap,
+    socketGeneration: number,
+  ) {
     if (!isCurrent(run)) return
+    run.criticalQueue.liveSocketGeneration = socketGeneration
     run.liveQueueSequence += 1
     for (const waiter of [...run.liveQueueWaiters]) {
       if (run.liveQueueSequence < waiter.minimum) continue
       run.liveQueueWaiters.delete(waiter)
       waiter.resolve(true)
     }
+    releaseCriticalRequestsIfReady(run)
+  }
+
+  function markHistoryRequestSent(
+    run: ActiveBootstrap,
+    socketGeneration: number,
+  ) {
+    if (!isCurrent(run)) return
+    run.criticalQueue.historySocketGeneration = socketGeneration
+    releaseCriticalRequestsIfReady(run)
   }
 
   async function waitForLiveSubscribeSent(
@@ -175,7 +235,6 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
   }
 
   function requiresFreshLiveQueue(error: unknown): boolean {
-    if (isRpcTimeout(error)) return true
     const message = error instanceof Error ? error.message.toLowerCase() : ''
     return (
       message.includes('connection')
@@ -276,6 +335,10 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
       if (isCurrent(run)) historyPhase.value = 'error'
       return lastResult
     })().finally(() => {
+      // A disconnected or exhausted phase may terminate before it can send.
+      // Optional UI traffic must not remain globally blocked in that case.
+      run.criticalQueue.historyTerminal = true
+      releaseCriticalRequestsIfReady(run)
       phase.running = false
       phase.result = null
     })
@@ -328,9 +391,54 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
       if (isCurrent(run)) livePhase.value = 'degraded'
       return lastResult
     })().finally(() => {
+      // Match the history fallback above: failure to queue a critical request
+      // is terminal for this attempt, not a reason to freeze the whole app.
+      run.criticalQueue.liveTerminal = true
+      releaseCriticalRequestsIfReady(run)
       phase.running = false
     })
     return phase.promise
+  }
+
+  function createCriticalQueue(
+    historyRequired: boolean,
+    liveSocketGeneration: number | null = null,
+  ): CriticalRequestQueue {
+    let resolve = () => {}
+    const promise = new Promise<void>(done => {
+      resolve = done
+    })
+    return {
+      promise,
+      resolve,
+      released: false,
+      historyRequired,
+      liveSocketGeneration,
+      historySocketGeneration: null,
+      liveTerminal: false,
+      historyTerminal: !historyRequired,
+    }
+  }
+
+  function rearmCriticalQueue(
+    run: ActiveBootstrap,
+    historyRequired: boolean,
+    liveSocketGeneration: number | null = null,
+  ) {
+    const previousQueue = run.criticalQueue
+    const replacementQueue = createCriticalQueue(
+      historyRequired,
+      liveSocketGeneration,
+    )
+    run.criticalQueue = replacementQueue
+    // Existing consumers hold the previous promise. Keep it pending across a
+    // same-run reconnect and release it only after the replacement socket has
+    // queued its critical frames. Repeated reconnects form a chain to the
+    // newest epoch; cancellation resolves the current epoch and unwinds it.
+    void replacementQueue.promise.then(() => {
+      previousQueue.released = true
+      previousQueue.resolve()
+    })
   }
 
   function createRun(key: string, includeHistory: boolean): ActiveBootstrap {
@@ -340,6 +448,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
       key,
       includeHistory,
       controller: new AbortController(),
+      criticalQueue: createCriticalQueue(includeHistory),
       liveQueueSequence: 0,
       liveQueueWaiters: new Set(),
       freshLiveOutageForHistoryRetry: false,
@@ -355,6 +464,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
   function publicRun(run: ActiveBootstrap): SessionBootstrapRun {
     return {
       generation: run.generation,
+      criticalRequestsQueued: run.criticalQueue.promise,
       history: run.history.promise,
       live: run.live.promise,
     }
@@ -369,6 +479,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     if (!key) {
       return {
         generation,
+        criticalRequestsQueued: Promise.resolve(),
         history: Promise.resolve(EMPTY_HISTORY_RESULT),
         live: Promise.resolve(UNAVAILABLE_LIVE_RESULT),
       }
@@ -383,7 +494,10 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
         if (Date.now() >= active.history.deadlineAt) {
           return startSessionBootstrap({ includeHistory: true, force: true })
         }
+        const liveSocketGeneration =
+          active.criticalQueue.liveSocketGeneration
         active.includeHistory = true
+        rearmCriticalQueue(active, true, liveSocketGeneration)
         active.history = historyRuntime(active.live.deadlineAt)
         active.history.promise = runHistoryPhase(active, false)
       }
@@ -446,6 +560,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     connectionRecoveryArmed = false
     cancelled?.controller.abort()
     if (cancelled) {
+      cancelled.criticalQueue.resolve()
       for (const waiter of cancelled.liveQueueWaiters) waiter.resolve(false)
       cancelled.liveQueueWaiters.clear()
     }
@@ -483,7 +598,12 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
         && !run.controller.signal.aborted
       if (currentRun && (run.history.running || run.live.running)) {
         const liveWasReady = livePhase.value === 'ready'
-        if (run.live.running || liveWasReady) {
+        const liveWillRecover = run.live.running || liveWasReady
+        if (liveWillRecover) {
+          rearmCriticalQueue(
+            run,
+            run.includeHistory && run.history.running,
+          )
           livePhase.value = 'connecting'
         }
         // A timeout/abort owned by this run may recycle the socket. Keep the
@@ -502,7 +622,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
           }
           run.live.promise = runLivePhase(run)
         }
-        if (run.live.running || liveWasReady) connectionRecoveryArmed = false
+        if (liveWillRecover) connectionRecoveryArmed = false
         return publicRun(run)
       }
       // Once a recovery budget reaches a terminal degraded state, background

--- a/opensquilla-webui/src/composables/chat/useChatSessionHandoff.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionHandoff.test.ts
@@ -128,6 +128,7 @@ describe('chat send session handoff', () => {
       loadHistory()
       return {
         generation: 1,
+        criticalRequestsQueued: Promise.resolve(),
         history: Promise.resolve({ ok: true }),
         live,
       }

--- a/opensquilla-webui/src/composables/chat/useChatSessionRuntime.draft.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionRuntime.draft.test.ts
@@ -34,6 +34,7 @@ describe('useChatSessionRuntime project drafts', () => {
       cancelSessionBootstrap: vi.fn(),
       startSessionBootstrap: vi.fn(() => ({
         generation: 1,
+        criticalRequestsQueued: Promise.resolve(),
         history: Promise.resolve({ ok: true }),
         live: Promise.resolve({
           authoritative: true,
@@ -60,10 +61,14 @@ describe('useChatSessionRuntime project drafts', () => {
     expect(resetDraftComposer).toHaveBeenCalledOnce()
   })
 
-  it('starts critical session bootstrap before optional usage and waits for both phases', async () => {
+  it('loads optional usage once critical requests are queued without waiting for history', async () => {
     const sessionKey = ref('agent:main:webchat:first')
+    let resolveCriticalRequestsQueued!: () => void
     let resolveHistory!: () => void
     let resolveLive!: () => void
+    const criticalRequestsQueued = new Promise<void>(resolve => {
+      resolveCriticalRequestsQueued = resolve
+    })
     const history = new Promise<{ ok: boolean }>(resolve => {
       resolveHistory = () => resolve({ ok: true })
     })
@@ -81,7 +86,12 @@ describe('useChatSessionRuntime project drafts', () => {
     const order: string[] = []
     const startSessionBootstrap = vi.fn(() => {
       order.push('bootstrap')
-      return { generation: 1, history, live }
+      return {
+        generation: 1,
+        criticalRequestsQueued,
+        history,
+        live,
+      }
     })
     const loadCurrentSessionUsage = vi.fn(() => {
       order.push('usage')
@@ -127,13 +137,17 @@ describe('useChatSessionRuntime project drafts', () => {
 
     const switching = runtime.switchToSession('agent:main:webchat:second')
     expect(order).toEqual(['bootstrap'])
+    expect(loadCurrentSessionUsage).not.toHaveBeenCalled()
+
+    resolveCriticalRequestsQueued()
+    await vi.waitFor(() => expect(loadCurrentSessionUsage).toHaveBeenCalledOnce())
+    expect(order).toEqual(['bootstrap', 'usage'])
 
     resolveLive()
     await switching
-    expect(loadCurrentSessionUsage).not.toHaveBeenCalled()
+    expect(loadCurrentSessionUsage).toHaveBeenCalledOnce()
 
     resolveHistory()
-    await vi.waitFor(() => expect(loadCurrentSessionUsage).toHaveBeenCalledOnce())
-    expect(order).toEqual(['bootstrap', 'usage'])
+    await history
   })
 })

--- a/opensquilla-webui/src/composables/chat/useChatSessionRuntime.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionRuntime.ts
@@ -128,10 +128,9 @@ export function useChatSessionRuntime(options: UseChatSessionRuntimeOptions) {
     // orthogonal. Response hand-off only waits for the authoritative live
     // snapshot; history can recover independently without blocking adoption.
     const bootstrap = options.startSessionBootstrap({ includeHistory: true })
-    // Usage is optional metadata. Let both critical bootstrap phases finish
-    // before it can enter the Gateway's serialized RPC queue; otherwise an
-    // unresponsive usage read can head-of-line block history and subscribe.
-    void Promise.allSettled([bootstrap.history, bootstrap.live]).then(() => {
+    // Usage is optional metadata. Start it once the critical request frames are
+    // queued; a slow history response must not withhold the rest of the UI.
+    void bootstrap.criticalRequestsQueued.then(() => {
       if (options.sessionKey.value === key) void options.loadCurrentSessionUsage()
     })
     const subscriptionOutcome = await bootstrap.live

--- a/opensquilla-webui/src/composables/chat/useChatSessionSubscription.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionSubscription.test.ts
@@ -782,7 +782,7 @@ describe('useChatSessionSubscription', () => {
     warn.mockRestore()
   })
 
-  it('keeps fast ACK defaults non-authoritative and hydrates project metadata separately', async () => {
+  it('hydrates project metadata after critical requests queue without waiting for history', async () => {
     const onSnapshot = vi.fn()
     const onSessionMetadata = vi.fn()
     const resetStreamLiveTurnState = vi.fn()
@@ -791,14 +791,26 @@ describe('useChatSessionSubscription', () => {
       label: 'Running',
       task: null,
     })
+    let resolveCriticalRequestsQueued!: () => void
     let resolveHistory!: () => void
-    const historyTerminal = new Promise<void>(resolve => {
+    let historySettled = false
+    const criticalRequestsQueued = new Promise<void>(resolve => {
+      resolveCriticalRequestsQueued = resolve
+    })
+    const history = new Promise<void>(resolve => {
       resolveHistory = resolve
+    }).then(() => {
+      historySettled = true
     })
     const markLiveSubscribeSent = vi.fn()
     const rpc = {
       waitForConnection: vi.fn(async () => {}),
-      call: async <T = unknown>(method: string) => {
+      call: async <T = unknown>(
+        method: string,
+        _params?: Record<string, unknown>,
+        callOptions?: RpcCallOptions,
+      ) => {
+        callOptions?.onSent?.(1)
         if (method === 'sessions.messages.subscribe') {
           return {
             subscribed: true,
@@ -855,14 +867,16 @@ describe('useChatSessionSubscription', () => {
       signal: new AbortController().signal,
       skipSnapshot: false,
       markLiveSubscribeSent,
-      waitForHistoryTerminal: () => historyTerminal,
+      waitForCriticalRequestsQueued: () => criticalRequestsQueued,
     })
 
     expect(markLiveSubscribeSent).toHaveBeenCalledOnce()
     expect(onSessionMetadata).not.toHaveBeenCalled()
+    expect(historySettled).toBe(false)
     expect(runStatus.value.status).toBe('running')
-    resolveHistory()
+    resolveCriticalRequestsQueued()
     await vi.waitFor(() => expect(onSessionMetadata).toHaveBeenCalledOnce())
+    expect(historySettled).toBe(false)
 
     expect(outcome.authoritative).toBe(true)
     expect(runStatus.value.status).toBe('running')
@@ -876,15 +890,24 @@ describe('useChatSessionSubscription', () => {
         projectWorkspace: undefined,
       },
     )
+    resolveHistory()
+    await history
   })
 
-  it('gives deferred metadata a fresh bounded window after history exhausts its budget', async () => {
+  it('gives deferred metadata a fresh bounded window after critical requests queue', async () => {
     let now = 10_000
     const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => now)
     const onSessionMetadata = vi.fn()
+    let resolveCriticalRequestsQueued!: () => void
     let resolveHistory!: () => void
-    const historyTerminal = new Promise<void>(resolve => {
+    let historySettled = false
+    const criticalRequestsQueued = new Promise<void>(resolve => {
+      resolveCriticalRequestsQueued = resolve
+    })
+    const history = new Promise<void>(resolve => {
       resolveHistory = resolve
+    }).then(() => {
+      historySettled = true
     })
     const call = vi.fn(async <T = unknown>(method: string, _params?: unknown, options?: {
         timeoutMs?: number
@@ -942,17 +965,22 @@ describe('useChatSessionSubscription', () => {
       attemptDeadlineAt: now + 100,
       signal: new AbortController().signal,
       skipSnapshot: true,
-      waitForHistoryTerminal: () => historyTerminal,
+      waitForCriticalRequestsQueued: () => criticalRequestsQueued,
     })
 
     expect(outcome.authoritative).toBe(true)
+    expect(onSessionMetadata).not.toHaveBeenCalled()
+    expect(historySettled).toBe(false)
     now += 101
-    resolveHistory()
+    resolveCriticalRequestsQueued()
     await vi.waitFor(() => expect(onSessionMetadata).toHaveBeenCalledOnce())
+    expect(historySettled).toBe(false)
     expect(call.mock.calls.map(([method]) => method)).toEqual([
       'sessions.messages.subscribe',
       'sessions.messages.hydrate',
     ])
+    resolveHistory()
+    await history
     dateNow.mockRestore()
   })
 

--- a/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
@@ -231,7 +231,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
   ) {
     void (async () => {
       try {
-        await bootstrap.waitForHistoryTerminal?.()
+        await bootstrap.waitForCriticalRequestsQueued?.()
         if (
           attempt !== subscriptionAttempt
           || metadataHydration !== metadataHydrationSequence
@@ -239,9 +239,9 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
           || bootstrap.signal.aborted
         ) return
         // Storage-backed metadata is deliberately outside the critical
-        // history/live bootstrap. Once history is terminal it receives its own
-        // bounded window; an exhausted history budget must not turn a healthy
-        // live registration into a permanently unusable composer.
+        // history/live bootstrap. Once their request frames are queued it
+        // receives its own bounded window; slow history must not keep a healthy
+        // project session permanently unresolved.
         const hydrationDeadlineAt = Date.now() + SESSION_PHASE_ATTEMPT_BUDGET_MS
         const hydrationContext = {
           ...bootstrap,
@@ -315,31 +315,66 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
         since_stream_seq: sinceStreamSeq,
         fast_ack: true,
       }
+      const onLiveSnapshot = options.onLiveSnapshot
+      const snapshotRequired = Boolean(
+        onLiveSnapshot && !bootstrap?.skipSnapshot,
+      )
+      let subscribeSocketGeneration: number | null = null
+      let snapshotSocketGeneration: number | null = null
+      let liveFramesMarked = false
+      const markLiveFramesSent = () => {
+        if (
+          !bootstrap
+          || liveFramesMarked
+          || subscribeSocketGeneration === null
+          || (snapshotRequired && snapshotSocketGeneration === null)
+          || (
+            snapshotSocketGeneration !== null
+            && snapshotSocketGeneration !== subscribeSocketGeneration
+          )
+        ) return
+        liveFramesMarked = true
+        bootstrap.markLiveSubscribeSent?.(subscribeSocketGeneration)
+      }
+      const subscribeCallOptions = bootstrap
+        ? {
+            ...phaseCallOptions(bootstrap, 'sessions.messages.subscribe'),
+            onSent: (socketGeneration: number) => {
+              subscribeSocketGeneration = socketGeneration
+              markLiveFramesSent()
+            },
+          }
+        : undefined
       const subscribePromise = bootstrap
         ? options.rpc.call<SessionMessagesSubscribeResponse>(
             'sessions.messages.subscribe',
             params,
-            phaseCallOptions(bootstrap, 'sessions.messages.subscribe'),
+            subscribeCallOptions,
           )
         : options.rpc.call<SessionMessagesSubscribeResponse>(
             'sessions.messages.subscribe',
             params,
           )
-      const onLiveSnapshot = options.onLiveSnapshot
       // Pipeline the in-memory snapshot directly behind subscribe. Only after
       // both frames are on the wire may history enter the serialized queue:
       // subscribe → snapshot → history. Slow storage metadata is deferred.
-      const snapshotPromise = onLiveSnapshot && !bootstrap?.skipSnapshot
+      const snapshotPromise = snapshotRequired
         ? (
             bootstrap
               ? options.rpc.call<SessionMessagesSnapshotResponse>(
                   'sessions.messages.snapshot',
                   { key },
-                  phaseCallOptions(
-                    bootstrap,
-                    'sessions.messages.snapshot',
-                    SESSION_SNAPSHOT_BUDGET_MS,
-                  ),
+                  {
+                    ...phaseCallOptions(
+                      bootstrap,
+                      'sessions.messages.snapshot',
+                      SESSION_SNAPSHOT_BUDGET_MS,
+                    ),
+                    onSent: (socketGeneration: number) => {
+                      snapshotSocketGeneration = socketGeneration
+                      markLiveFramesSent()
+                    },
+                  },
                 )
               : options.rpc.call<SessionMessagesSnapshotResponse>(
                   'sessions.messages.snapshot',
@@ -347,7 +382,6 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
                 )
           )
         : null
-      bootstrap?.markLiveSubscribeSent?.()
 
       const [subscribeResult, snapshotResult] = await Promise.allSettled([
         subscribePromise,

--- a/opensquilla-webui/src/composables/chat/useChatSlashCommands.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSlashCommands.test.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
 
 import { useChatSlashCommands } from './useChatSlashCommands'
+import type { RpcCallOptions } from '@/lib/rpc'
 
 function deferred() {
   let resolve!: () => void
@@ -15,6 +16,7 @@ function harness(
   planModeAvailable: boolean,
   commands: Array<Record<string, unknown>> = [],
   waitForConnection: Promise<void> = Promise.resolve(),
+  catalogCallOptions?: RpcCallOptions,
 ) {
   const inputText = ref('')
   const rpc = {
@@ -31,6 +33,7 @@ function harness(
   const dispatchPlanPrompt = vi.fn()
   const api = useChatSlashCommands({
     rpc,
+    catalogCallOptions,
     inputText,
     sessionKey: ref('agent:main:webchat:test'),
     autoResizeTextarea: vi.fn(),
@@ -60,8 +63,31 @@ function harness(
 
 describe('useChatSlashCommands plan compatibility', () => {
   it('adds and executes /plan when the connected gateway advertises plan mode', async () => {
-    const { api, inputText, activatePlanMode } = harness(true)
+    const catalogCallOptions: RpcCallOptions = {
+      timeoutMs: 2_000,
+      timeoutAction: 'reconnect',
+      abortAction: 'reconnect',
+    }
+    const { api, inputText, activatePlanMode, rpc } = harness(
+      true,
+      [],
+      Promise.resolve(),
+      catalogCallOptions,
+    )
     await api.loadSlashCommands()
+    expect(rpc.waitForConnection).toHaveBeenCalledWith(
+      2_000,
+      undefined,
+      {
+        timeoutAction: 'reconnect',
+        abortAction: 'reconnect',
+      },
+    )
+    expect(rpc.call).toHaveBeenCalledWith(
+      'commands.list_for_surface',
+      { surface: 'web_chat' },
+      catalogCallOptions,
+    )
     inputText.value = '/pl'
     api.handleSlashInput()
 

--- a/opensquilla-webui/src/composables/chat/useChatSlashCommands.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSlashCommands.ts
@@ -1,9 +1,21 @@
 import { computed, ref, type Ref } from 'vue'
 import i18n from '@/i18n'
+import {
+  waitForSessionRpcConnection,
+} from '@/composables/chat/sessionBootstrapAdmission'
+import type { RpcCallOptions, RpcConnectionWaitOptions } from '@/lib/rpc'
 
 type RpcClient = {
-  waitForConnection: () => Promise<void>
-  call: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+  waitForConnection: (
+    timeoutMs?: number,
+    signal?: AbortSignal,
+    actions?: RpcConnectionWaitOptions,
+  ) => Promise<void>
+  call: <T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    callOptions?: RpcCallOptions,
+  ) => Promise<T>
 }
 
 export interface ArgumentChoice {
@@ -50,6 +62,7 @@ interface UsageStatusResult {
 
 export interface UseChatSlashCommandsOptions {
   rpc: RpcClient
+  catalogCallOptions?: RpcCallOptions
   inputText: Ref<string>
   sessionKey: Ref<string>
   autoResizeTextarea: () => void
@@ -147,8 +160,18 @@ export function useChatSlashCommands(options: UseChatSlashCommandsOptions) {
 
   async function loadSlashCommands() {
     try {
-      await options.rpc.waitForConnection()
-      const res = await options.rpc.call<{ commands?: ChatSlashCommand[] }>('commands.list_for_surface', { surface: 'web_chat' })
+      await waitForSessionRpcConnection(options.rpc, options.catalogCallOptions)
+      const params = { surface: 'web_chat' }
+      const res = options.catalogCallOptions
+        ? await options.rpc.call<{ commands?: ChatSlashCommand[] }>(
+            'commands.list_for_surface',
+            params,
+            options.catalogCallOptions,
+          )
+        : await options.rpc.call<{ commands?: ChatSlashCommand[] }>(
+            'commands.list_for_surface',
+            params,
+          )
       slashCmds.value = (Array.isArray(res?.commands) ? res.commands : []).map(normalizeSlashCommand)
       if (
         options.activatePlanMode

--- a/opensquilla-webui/src/composables/chat/useChatUsageWidget.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatUsageWidget.test.ts
@@ -1,0 +1,48 @@
+import { ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useChatUsageWidget } from './useChatUsageWidget'
+import type { RpcCallOptions } from '@/lib/rpc'
+
+describe('useChatUsageWidget background reads', () => {
+  it('uses the injected bounded options without changing its public loader', async () => {
+    const readCallOptions: RpcCallOptions = {
+      timeoutMs: 2_000,
+      timeoutAction: 'reconnect',
+      abortAction: 'reconnect',
+    }
+    const rpc = {
+      waitForConnection: vi.fn().mockResolvedValue(undefined),
+      call: vi.fn().mockResolvedValue({
+        sessions: [{
+          sessionKey: 'agent:main:webchat:usage',
+          inputTokens: 12,
+          outputTokens: 8,
+        }],
+      }),
+    }
+    const api = useChatUsageWidget({
+      rpc,
+      readCallOptions,
+      sessionKey: ref('agent:main:webchat:usage'),
+      tokenVizEnabled: () => false,
+    })
+
+    await api.loadCurrentSessionUsage()
+
+    expect(rpc.waitForConnection).toHaveBeenCalledWith(
+      2_000,
+      undefined,
+      {
+        timeoutAction: 'reconnect',
+        abortAction: 'reconnect',
+      },
+    )
+    expect(rpc.call).toHaveBeenCalledWith(
+      'usage.status',
+      { sessionKey: 'agent:main:webchat:usage' },
+      readCallOptions,
+    )
+    expect(api.usageAccum.value).toMatchObject({ input: 12, output: 8 })
+  })
+})

--- a/opensquilla-webui/src/composables/chat/useChatUsageWidget.ts
+++ b/opensquilla-webui/src/composables/chat/useChatUsageWidget.ts
@@ -1,8 +1,20 @@
 import { computed, ref, type Ref } from 'vue'
+import {
+  waitForSessionRpcConnection,
+} from '@/composables/chat/sessionBootstrapAdmission'
+import type { RpcCallOptions, RpcConnectionWaitOptions } from '@/lib/rpc'
 
 type RpcClient = {
-  waitForConnection: () => Promise<void>
-  call: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+  waitForConnection: (
+    timeoutMs?: number,
+    signal?: AbortSignal,
+    actions?: RpcConnectionWaitOptions,
+  ) => Promise<void>
+  call: <T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    callOptions?: RpcCallOptions,
+  ) => Promise<T>
 }
 
 export interface ChatUsageAccumulator {
@@ -17,6 +29,7 @@ export interface ChatUsageAccumulator {
 
 export interface UseChatUsageWidgetOptions {
   rpc: RpcClient
+  readCallOptions?: RpcCallOptions
   sessionKey: Ref<string>
   tokenVizEnabled: () => boolean
 }
@@ -148,8 +161,15 @@ export function useChatUsageWidget(options: UseChatUsageWidgetOptions) {
   async function loadCurrentSessionUsage() {
     if (!options.sessionKey.value) return
     try {
-      await options.rpc.waitForConnection()
-      const usage = await options.rpc.call<UsageStatusResponse>('usage.status', { sessionKey: options.sessionKey.value })
+      await waitForSessionRpcConnection(options.rpc, options.readCallOptions)
+      const params = { sessionKey: options.sessionKey.value }
+      const usage = options.readCallOptions
+        ? await options.rpc.call<UsageStatusResponse>(
+            'usage.status',
+            params,
+            options.readCallOptions,
+          )
+        : await options.rpc.call<UsageStatusResponse>('usage.status', params)
       const sessions = usage?.sessions || []
       const current = sessions.find(s => (s.session || s.sessionKey || s.key) === options.sessionKey.value)
       if (current) {

--- a/opensquilla-webui/src/composables/useAgentOptions.ts
+++ b/opensquilla-webui/src/composables/useAgentOptions.ts
@@ -1,7 +1,11 @@
 import { ref } from 'vue'
+import {
+  waitForSessionRpcConnection,
+} from '@/composables/chat/sessionBootstrapAdmission'
 import { useRpcStore } from '@/stores/rpc'
 import { normalizeAgentId } from '@/utils/chat/sessionKeys'
 import type { AgentOption, AgentsListResponse } from '@/types/rpc'
+import type { RpcCallOptions } from '@/lib/rpc'
 
 /** The implicit default agent every chat surface can always start against. */
 const MAIN_AGENT: AgentOption = { id: 'main', name: 'Main Agent' }
@@ -18,7 +22,7 @@ let loadPromise: Promise<void> | null = null
  * Shared `agents.list` fetch for sidebar session metadata. IDs are normalized
  * once here so every sidebar consumer sees the same canonical value.
  */
-export function useAgentOptions() {
+export function useAgentOptions(readCallOptions?: RpcCallOptions) {
   const rpc = useRpcStore()
 
   function loadAgents(): Promise<void> {
@@ -26,8 +30,14 @@ export function useAgentOptions() {
     loadPromise = (async () => {
       agentListError.value = false
       try {
-        await rpc.waitForConnection()
-        const data = await rpc.call<AgentsListResponse>('agents.list')
+        await waitForSessionRpcConnection(rpc, readCallOptions)
+        const data = readCallOptions
+          ? await rpc.call<AgentsListResponse>(
+              'agents.list',
+              undefined,
+              readCallOptions,
+            )
+          : await rpc.call<AgentsListResponse>('agents.list')
         agents.value = (data?.agents || [])
           .map(a => ({
             id: normalizeAgentId(a.id || a.agentId || a.name || ''),

--- a/opensquilla-webui/src/composables/useRpc.test.ts
+++ b/opensquilla-webui/src/composables/useRpc.test.ts
@@ -19,7 +19,7 @@ import {
 } from '@/composables/chat/sessionBootstrapAdmission'
 
 describe('useRpcCall session bootstrap admission', () => {
-  it('defers and coalesces mount-time optional RPCs until recovery is terminal', async () => {
+  it('defers and coalesces mount-time optional RPCs until critical frames are queued', async () => {
     rpc.call.mockClear()
     const release = acquireSessionBootstrapAdmission()
     const component = defineComponent({
@@ -47,6 +47,10 @@ describe('useRpcCall session bootstrap admission', () => {
       undefined,
       optionalSessionRpcCallOptions,
     )
+    expect(optionalSessionRpcCallOptions).toMatchObject({
+      timeoutAction: 'reconnect',
+      abortAction: 'reconnect',
+    })
     app.unmount()
   })
 })

--- a/opensquilla-webui/src/composables/useSessionListSubscription.test.ts
+++ b/opensquilla-webui/src/composables/useSessionListSubscription.test.ts
@@ -67,8 +67,14 @@ describe('useSessionListSubscription', () => {
   it('subscribes once per connection and resubscribes after reconnect', async () => {
     const harness = makeRpc()
     const refresh = vi.fn(async () => {})
+    const callOptions = {
+      timeoutMs: 2_000,
+      timeoutAction: 'reconnect' as const,
+      abortAction: 'reconnect' as const,
+    }
     const subscription = useSessionListSubscription({
       rpc: harness.rpc,
+      callOptions,
       isConnected: harness.isConnected,
       refresh,
       scheduleRefresh: vi.fn(),
@@ -83,8 +89,18 @@ describe('useSessionListSubscription', () => {
     harness.emit('_state', 'connected')
     await flushAsyncWork()
 
-    expect(harness.rpc.call).toHaveBeenNthCalledWith(1, 'sessions.subscribe')
-    expect(harness.rpc.call).toHaveBeenNthCalledWith(2, 'sessions.subscribe')
+    expect(harness.rpc.call).toHaveBeenNthCalledWith(
+      1,
+      'sessions.subscribe',
+      undefined,
+      callOptions,
+    )
+    expect(harness.rpc.call).toHaveBeenNthCalledWith(
+      2,
+      'sessions.subscribe',
+      undefined,
+      callOptions,
+    )
     expect(refresh).toHaveBeenCalledTimes(2)
   })
 
@@ -95,8 +111,14 @@ describe('useSessionListSubscription', () => {
       .mockResolvedValue(undefined)
     const refresh = vi.fn(async () => {})
     const warn = vi.fn()
+    const callOptions = {
+      timeoutMs: 2_000,
+      timeoutAction: 'reconnect' as const,
+      abortAction: 'reconnect' as const,
+    }
     const subscription = useSessionListSubscription({
       rpc: harness.rpc,
+      callOptions,
       isConnected: harness.isConnected,
       refresh,
       scheduleRefresh: vi.fn(),
@@ -116,7 +138,11 @@ describe('useSessionListSubscription', () => {
     subscription.cleanup()
     await flushAsyncWork()
 
-    expect(harness.rpc.call).toHaveBeenLastCalledWith('sessions.unsubscribe')
+    expect(harness.rpc.call).toHaveBeenLastCalledWith(
+      'sessions.unsubscribe',
+      undefined,
+      callOptions,
+    )
     expect(harness.listenerCount('_state')).toBe(0)
     expect(harness.listenerCount('sessions.changed')).toBe(0)
   })

--- a/opensquilla-webui/src/composables/useSessionListSubscription.ts
+++ b/opensquilla-webui/src/composables/useSessionListSubscription.ts
@@ -1,7 +1,11 @@
-import type { ConnectionState, RpcEventHandler } from '@/lib/rpc'
+import type { ConnectionState, RpcCallOptions, RpcEventHandler } from '@/lib/rpc'
 
 type SessionListRpc = {
-  call(method: string, params?: Record<string, unknown>): Promise<unknown>
+  call(
+    method: string,
+    params?: Record<string, unknown>,
+    callOptions?: RpcCallOptions,
+  ): Promise<unknown>
   on(event: string, handler: RpcEventHandler): () => void
 }
 
@@ -12,6 +16,7 @@ export interface UseSessionListSubscriptionOptions {
   refresh: () => void | Promise<void>
   scheduleRefresh: () => void
   warn?: (message: string, error?: unknown) => void
+  callOptions?: RpcCallOptions
 }
 
 export function useSessionListSubscription(options: UseSessionListSubscriptionOptions) {
@@ -47,7 +52,15 @@ export function useSessionListSubscription(options: UseSessionListSubscriptionOp
     subscribeAttempt = attempt
     subscribeWork = (async () => {
       try {
-        await options.rpc.call('sessions.subscribe')
+        if (options.callOptions) {
+          await options.rpc.call(
+            'sessions.subscribe',
+            undefined,
+            options.callOptions,
+          )
+        } else {
+          await options.rpc.call('sessions.subscribe')
+        }
         if (!active || !options.isConnected() || generation !== connectionGeneration) return
         subscribed = true
         await options.refresh()
@@ -91,7 +104,14 @@ export function useSessionListSubscription(options: UseSessionListSubscriptionOp
     removeListeners = []
 
     if (shouldUnsubscribe && options.isConnected()) {
-      void options.rpc.call('sessions.unsubscribe').catch(error => {
+      const unsubscribe = options.callOptions
+        ? options.rpc.call(
+            'sessions.unsubscribe',
+            undefined,
+            options.callOptions,
+          )
+        : options.rpc.call('sessions.unsubscribe')
+      void unsubscribe.catch(error => {
         warn('Session list unsubscribe failed', error)
       })
     }

--- a/opensquilla-webui/src/composables/useSessions.ts
+++ b/opensquilla-webui/src/composables/useSessions.ts
@@ -1,6 +1,10 @@
 import { ref, computed } from 'vue'
 import i18n from '@/i18n'
+import {
+  waitForSessionRpcConnection,
+} from '@/composables/chat/sessionBootstrapAdmission'
 import { useRpcStore } from '@/stores/rpc'
+import type { RpcCallOptions } from '@/lib/rpc'
 import type { RawSessionItem, RawSessionListEntry, SessionsListResponse } from '@/types/rpc'
 import type { ProjectWorkspaceItem } from '@/types/rpc'
 
@@ -698,7 +702,7 @@ export function groupSessions(items: SessionItem[]): SessionGroup[] {
     .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0))
 }
 
-export function useSessions() {
+export function useSessions(readCallOptions?: RpcCallOptions) {
   const rpc = useRpcStore()
   const sessionsList = ref<RawSessionListEntry[]>([])
   const sessionListError = ref(false)
@@ -717,8 +721,15 @@ export function useSessions() {
     isLoading.value = true
     sessionListError.value = false
     try {
-      await rpc.waitForConnection()
-      const data = await rpc.call<SessionsListResponse>('sessions.list', { limit: 200, view: SESSION_LIST_VIEW })
+      await waitForSessionRpcConnection(rpc, readCallOptions)
+      const params = { limit: 200, view: SESSION_LIST_VIEW }
+      const data = readCallOptions
+        ? await rpc.call<SessionsListResponse>(
+            'sessions.list',
+            params,
+            readCallOptions,
+          )
+        : await rpc.call<SessionsListResponse>('sessions.list', params)
       const raw = data?.sessions || data?.keys || []
       sessionsList.value = raw.filter(s => !!itemKey(s))
     } catch (err: unknown) {

--- a/opensquilla-webui/src/lib/rpc.test.ts
+++ b/opensquilla-webui/src/lib/rpc.test.ts
@@ -141,6 +141,23 @@ describe('RpcClient', () => {
     client.disconnect()
   })
 
+  it('reports the socket generation only after a request frame is sent', async () => {
+    const client = new RpcClient()
+    const onSent = vi.fn()
+    client.connect('ws://rpc.test')
+    const socket = MockWebSocket.instances[0]
+
+    const result = client.call('chat.history', {}, { onSent })
+    const request = JSON.parse(socket.sent[0]) as { id: string }
+
+    expect(onSent).toHaveBeenCalledOnce()
+    expect(onSent).toHaveBeenCalledWith(expect.any(Number))
+
+    socket.receive({ type: 'res', id: request.id, ok: true, payload: {} })
+    await expect(result).resolves.toEqual({})
+    client.disconnect()
+  })
+
   it('rejects a bounded call with a typed timeout and ignores a late response', async () => {
     const client = new RpcClient()
     client.connect('ws://rpc.test')
@@ -257,13 +274,19 @@ describe('RpcClient', () => {
 
   it('cleans a call when send throws and recycles the failed socket', async () => {
     const client = new RpcClient()
+    const onSent = vi.fn()
     client.connect('ws://rpc.test')
     const socket = MockWebSocket.instances[0]
     socket.throwOnSend = true
 
-    const error = await client.call('chat.history').catch((caught: unknown) => caught)
+    const error = await client.call(
+      'chat.history',
+      {},
+      { onSent },
+    ).catch((caught: unknown) => caught)
 
     expect(error).toMatchObject({ message: 'send failed' })
+    expect(onSent).not.toHaveBeenCalled()
     expect(pendingCount(client)).toBe(0)
     expect(socket.readyState).toBe(MockWebSocket.CLOSED)
 

--- a/opensquilla-webui/src/lib/rpc.ts
+++ b/opensquilla-webui/src/lib/rpc.ts
@@ -24,6 +24,8 @@ export interface RpcCallOptions {
   signal?: AbortSignal;
   timeoutAction?: RpcTerminationAction;
   abortAction?: RpcTerminationAction;
+  /** Called synchronously only after the request frame is accepted by send(). */
+  onSent?: (socketGeneration: number) => void;
 }
 
 export interface RpcConnectionWaitOptions {
@@ -206,6 +208,13 @@ export class RpcClient {
           error instanceof Error ? error : new Error('Failed to send RPC request');
         this._rejectPending(id, sendError, generation);
         this._recycleConnection(generation, sendError);
+        return;
+      }
+      try {
+        options.onSent?.(generation);
+      } catch {
+        // A send receipt is observational. It must never fail a request whose
+        // frame is already on the wire.
       }
     });
   }

--- a/opensquilla-webui/src/utils/chat/sessionLoadState.test.ts
+++ b/opensquilla-webui/src/utils/chat/sessionLoadState.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   resolveChatHistoryRecoveryState,
   shouldShowConfirmedEmptySession,
+  visibleChatHistoryRecoveryState,
 } from './sessionLoadState'
 
 describe('resolveChatHistoryRecoveryState', () => {
@@ -39,6 +40,14 @@ describe('resolveChatHistoryRecoveryState', () => {
       initialHistoryStatus: 'loading',
       retrying: false,
     })).toBeNull()
+  })
+})
+
+describe('visibleChatHistoryRecoveryState', () => {
+  it('hides routine initial loading while preserving actionable recovery states', () => {
+    expect(visibleChatHistoryRecoveryState('history-loading')).toBeNull()
+    expect(visibleChatHistoryRecoveryState('history-retrying')).toBe('history-retrying')
+    expect(visibleChatHistoryRecoveryState('history-error')).toBe('history-error')
   })
 })
 

--- a/opensquilla-webui/src/utils/chat/sessionLoadState.ts
+++ b/opensquilla-webui/src/utils/chat/sessionLoadState.ts
@@ -31,6 +31,12 @@ export function resolveChatHistoryRecoveryState(
   return null
 }
 
+export function visibleChatHistoryRecoveryState(
+  state: ChatHistoryRecoveryState,
+): ChatHistoryRecoveryState {
+  return state === 'history-loading' ? null : state
+}
+
 export function shouldShowConfirmedEmptySession(options: {
   isDraftLanding: boolean
   isStreaming: boolean

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -90,9 +90,9 @@
           </div>
         </template>
         <ChatSessionRecoveryStatus
-          v-if="historyRecoveryState"
+          v-if="visibleHistoryRecoveryState"
           :key="`${sessionKey}:history`"
-          :state="historyRecoveryState"
+          :state="visibleHistoryRecoveryState"
           @retry="retryHistory"
         />
         <ChatSessionRecoveryStatus
@@ -743,6 +743,7 @@ import { clearAssistantActivityExpansionState } from '@/utils/chat/activityDiscl
 import {
   resolveChatHistoryRecoveryState,
   shouldShowConfirmedEmptySession,
+  visibleChatHistoryRecoveryState,
 } from '@/utils/chat/sessionLoadState'
 import {
   isSemanticActivityStatusStep,
@@ -889,6 +890,7 @@ const {
   applyRunModePreferenceChanged,
 } = useChatRunModePreference({
   rpc,
+  hydrateCallOptions: optionalSessionRpcCallOptions,
   runModePolicy: () => {
     const auth = rpc.auth as RpcAuthPayload | null
     return auth?.runModePolicy
@@ -1143,6 +1145,7 @@ const compactGaugeVisible = computed(() =>
 
 const chatUsageWidget = useChatUsageWidget({
   rpc,
+  readCallOptions: optionalSessionRpcCallOptions,
   sessionKey,
   tokenVizEnabled: () => appStore.features.tokenViz,
 })
@@ -1157,6 +1160,7 @@ const {
 
 const chatFeatureToggles = useChatFeatureToggles({
   rpc,
+  readCallOptions: optionalSessionRpcCallOptions,
   setGlobalElevatedMode,
   loadCurrentSessionUsage,
 })
@@ -1541,38 +1545,59 @@ function releaseOptionalRpcAdmissionAfter(
 }
 
 function trackSessionBootstrapAdmission<T extends {
-  history: Promise<unknown>
-  live: Promise<unknown>
+  criticalRequestsQueued: Promise<void>
 }>(run: T): T {
   const admissionGeneration = holdOptionalRpcAdmission()
   releaseOptionalRpcAdmissionAfter(
-    [run.history, run.live],
+    [run.criticalRequestsQueued],
     admissionGeneration,
   )
   return run
+}
+
+let postBootstrapMetadataStarted = false
+function schedulePostBootstrapMetadata(
+  run: {
+    generation: number
+    criticalRequestsQueued: Promise<void>
+  },
+  key: string,
+) {
+  if (postBootstrapMetadataStarted) return
+  void run.criticalRequestsQueued.then(() => {
+    if (
+      postBootstrapMetadataStarted
+      || chatViewDisposed
+      || sessionKey.value !== key
+      || !isSessionBootstrapCurrent(run.generation, key)
+    ) return
+    postBootstrapMetadataStarted = true
+    void refreshPostBootstrapMetadata()
+    void loadFeatureToggles().then(() => {
+      if (!chatViewDisposed) unsubs.push(bindFeatureRefresh(scheduleHistorySync))
+    })
+    loadSlashCommands()
+  })
 }
 
 function startSessionBootstrap(options?: {
   includeHistory?: boolean
   force?: boolean
 }) {
-  return trackSessionBootstrapAdmission(
+  const key = sessionKey.value
+  const run = trackSessionBootstrapAdmission(
     startSessionBootstrapCoordinator(options),
   )
+  schedulePostBootstrapMetadata(run, key)
+  return run
 }
 
 function retryHistory() {
-  const admissionGeneration = holdOptionalRpcAdmission()
-  const retry = retryHistoryCoordinator()
-  releaseOptionalRpcAdmissionAfter([retry], admissionGeneration)
-  return retry
+  return retryHistoryCoordinator()
 }
 
 function retryLive() {
-  const admissionGeneration = holdOptionalRpcAdmission()
-  const retry = retryLiveCoordinator()
-  releaseOptionalRpcAdmissionAfter([retry], admissionGeneration)
-  return retry
+  return retryLiveCoordinator()
 }
 
 function cancelSessionBootstrap() {
@@ -1708,6 +1733,7 @@ function switchToSession(nextSessionKey: string) {
 
 const chatSlashCommands = useChatSlashCommands({
   rpc,
+  catalogCallOptions: optionalSessionRpcCallOptions,
   inputText,
   sessionKey,
   autoResizeTextarea,
@@ -2304,6 +2330,10 @@ const historyRecoveryState = computed(() => {
     recoveryError: historyState.value.recoveryError,
   })
 })
+
+const visibleHistoryRecoveryState = computed(() => (
+  visibleChatHistoryRecoveryState(historyRecoveryState.value)
+))
 
 const liveRecoveryState = computed(() => {
   if (livePhase.value === 'degraded') return 'live-degraded' as const
@@ -3470,20 +3500,6 @@ onMounted(async () => {
     : sessionBootstrap.live.then(() =>
         syncDraftProjectFromRoute(initialDraftProjectGeneration!),
       )
-  void Promise.allSettled([
-    sessionBootstrap.history,
-    sessionBootstrap.live,
-    initialDraftProjectSync,
-  ]).then(async () => {
-    if (chatViewDisposed) return
-    await refreshPostBootstrapMetadata()
-    if (chatViewDisposed) return
-    void loadFeatureToggles().then(() => {
-      if (!chatViewDisposed) unsubs.push(bindFeatureRefresh(scheduleHistorySync))
-    })
-    loadSlashCommands()
-  })
-
   // Composer resize observer
   const composerEl = composerRef.value?.composerElement()
   if (composerEl) {

--- a/src/opensquilla/gateway/protocol.py
+++ b/src/opensquilla/gateway/protocol.py
@@ -142,6 +142,7 @@ class PolicyInfo(BaseModel):
     max_payload: int = MAX_PAYLOAD_BYTES
     max_buffered_bytes: int = MAX_BUFFERED_BYTES
     tick_interval_ms: int = TICK_INTERVAL_MS
+    concurrent_history_reads: bool = False
     agent_stream_heartbeat_interval_ms: int = 15_000
     agent_stream_idle_timeout_ms: int = 600_000
     webui_stream_idle_grace_ms: int = 630_000

--- a/src/opensquilla/gateway/websocket.py
+++ b/src/opensquilla/gateway/websocket.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import time
 import uuid
+from collections.abc import Coroutine
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -58,6 +59,9 @@ log = structlog.get_logger(__name__)
 # Any future addition to this set MUST be verified against the same
 # upstream invariant.
 _LOSSY_EVENTS: frozenset[str] = frozenset({"tick"})
+_DETACHED_READ_METHODS: frozenset[str] = frozenset({"chat.history"})
+_MAX_DETACHED_READS_PER_CONNECTION = 4
+_DETACHED_READ_STOP_TIMEOUT_SECONDS = 2.0
 _DIRECT_SEND_TIMEOUT_SECONDS = 2.0
 _DIRECT_CLOSE_TIMEOUT_SECONDS = 1.0
 
@@ -116,6 +120,11 @@ class WsConnection:
     _writer_queue_maxsize: int = field(default=512, init=False, repr=False)
     _outbox: asyncio.Queue[Any] | None = field(default=None, init=False, repr=False)
     _writer_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
+    _detached_read_tasks: set[asyncio.Task[None]] = field(
+        default_factory=set,
+        init=False,
+        repr=False,
+    )
     _closing: bool = field(default=False, init=False, repr=False)
 
     @property
@@ -142,6 +151,65 @@ class WsConnection:
             task.exception()
         except BaseException:
             pass
+
+    def _try_start_detached_read(
+        self,
+        awaitable: Coroutine[Any, Any, None],
+        *,
+        method: str,
+    ) -> bool:
+        # Session switches and bounded retries can briefly overlap history
+        # reads. Keep that overlap bounded without ever falling back to the
+        # serial receive loop, which would recreate head-of-line blocking.
+        if len(self._detached_read_tasks) >= _MAX_DETACHED_READS_PER_CONNECTION:
+            return False
+        task = asyncio.create_task(
+            awaitable,
+            name=f"ws-read-{method}-{self.conn_id}",
+        )
+        self._detached_read_tasks.add(task)
+        task.add_done_callback(self._handle_detached_read_result)
+        return True
+
+    def _handle_detached_read_result(self, task: asyncio.Task[None]) -> None:
+        self._detached_read_tasks.discard(task)
+        if task.cancelled():
+            return
+        try:
+            error = task.exception()
+        except BaseException:
+            return
+        if error is None:
+            return
+        log.warning(
+            "gateway.ws_detached_read_failed",
+            conn_id=self.conn_id,
+            task_name=task.get_name(),
+            error=str(error),
+        )
+        close_task = asyncio.create_task(
+            self.close(code=1011, reason="detached_read_failed"),
+            name=f"ws-close-detached-read-{self.conn_id}",
+        )
+        close_task.add_done_callback(self._consume_task_result)
+
+    async def _stop_detached_reads(self) -> None:
+        self._closing = True
+        tasks = tuple(self._detached_read_tasks)
+        self._detached_read_tasks.clear()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            _, pending = await asyncio.wait(
+                tasks,
+                timeout=_DETACHED_READ_STOP_TIMEOUT_SECONDS,
+            )
+            if pending:
+                log.warning(
+                    "gateway.ws_stop_detached_reads_timeout",
+                    conn_id=self.conn_id,
+                    pending_count=len(pending),
+                )
 
     async def _send_direct_text(self, text: str) -> None:
         """Bound legacy direct sends so a wedged socket cannot stall an RPC."""
@@ -452,6 +520,7 @@ class WsConnection:
                 try:
                     await self.ws.send_text(text)
                 except WebSocketDisconnect:
+                    self._closing = True
                     return
                 except asyncio.CancelledError:
                     raise
@@ -461,6 +530,11 @@ class WsConnection:
                         conn_id=self.conn_id,
                         exc_info=True,
                     )
+                    self._closing = True
+                    try:
+                        await self.ws.close(code=1011, reason="writer_send_failed")
+                    except Exception:  # noqa: BLE001
+                        pass
                     return
         except asyncio.CancelledError:
             raise
@@ -828,6 +902,7 @@ async def handle_ws_connection(
             auth_mode=config.auth.mode,
         ),
         policy=PolicyInfo(
+            concurrent_history_reads=True,
             agent_stream_heartbeat_interval_ms=int(
                 max(0.0, float(getattr(config, "agent_stream_heartbeat_interval_seconds", 15.0)))
                 * 1000
@@ -899,11 +974,11 @@ async def handle_ws_connection(
     except Exception as exc:
         log.error("ws.error", conn_id=conn_id, error=str(exc))
     finally:
-        # Stop the writer FIRST, before tick_task.cancel() and before
-        # registry.unregister. Otherwise an EventBridge.emit on another
-        # coroutine could still hold a reference to this connection while
-        # the writer task is mid-cancel, producing a "zombie writer"
-        # scenario.
+        # Detached reads can still enqueue responses, so retire them before the
+        # writer. Then stop the writer before tick_task.cancel() and before
+        # registry.unregister. Otherwise a producer could still hold a reference
+        # to this connection while the writer is mid-cancel.
+        await conn._stop_detached_reads()
         await conn._stop_writer()
         tick_task.cancel()
         try:
@@ -925,6 +1000,18 @@ async def _tick_loop(conn: WsConnection, tick_interval_ms: int) -> None:
         except Exception:
             log.debug("ws.tick_failed", conn_id=conn.conn_id, exc_info=True)
             return
+
+
+async def _dispatch_request(
+    conn: WsConnection,
+    dispatcher: RpcDispatcher,
+    req_id: str,
+    method: str,
+    params: Any,
+    ctx: RpcContext,
+) -> None:
+    res = await dispatcher.dispatch(req_id, method, params, ctx)
+    await conn.send_res(res)
 
 
 async def _message_loop(
@@ -1052,8 +1139,24 @@ async def _message_loop(
                 memory_stores=memory_stores or {},
                 memory_retrievers=memory_retrievers or {},
             )
-            res = await dispatcher.dispatch(req_id, method, params, ctx)
-            await conn.send_res(res)
+            request = _dispatch_request(conn, dispatcher, req_id, method, params, ctx)
+            if method in _DETACHED_READ_METHODS:
+                if conn._try_start_detached_read(request, method=method):
+                    # History reads may wait on storage while the client still
+                    # needs the same connection for navigation and controls.
+                    continue
+                request.close()
+                await conn.send_res(
+                    make_error_res(
+                        req_id,
+                        "STORAGE_BUSY",
+                        "Too many history reads are already in progress",
+                        retryable=True,
+                        retry_after_ms=100,
+                    )
+                )
+                continue
+            await request
         else:
             # repr keeps the echo serializable for any client value (lone
             # surrogates escape to backslash form).

--- a/tests/test_gateway/test_websocket_request_concurrency.py
+++ b/tests/test_gateway/test_websocket_request_concurrency.py
@@ -1,0 +1,382 @@
+"""Regression coverage for safe concurrent WebSocket request dispatch."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from starlette.websockets import WebSocketDisconnect, WebSocketState
+
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.protocol import make_ok_res
+from opensquilla.gateway.websocket import handle_ws_connection
+
+_CONNECT_FRAME = json.dumps(
+    {
+        "type": "req",
+        "id": "h",
+        "method": "connect",
+        "params": {"minProtocol": 1, "role": "operator", "auth": {}},
+    }
+)
+
+
+class _HistoryDispatcher:
+    def __init__(self) -> None:
+        self.history_started = asyncio.Event()
+        self.history_cancelled = asyncio.Event()
+        self.release_history = asyncio.Event()
+        self.quick_dispatched = asyncio.Event()
+
+    def list_methods(self) -> list[str]:
+        return ["chat.history", "noop"]
+
+    async def dispatch(self, req_id: str, method: str, params: Any, ctx: Any) -> Any:
+        if method == "chat.history":
+            self.history_started.set()
+            try:
+                await self.release_history.wait()
+            except asyncio.CancelledError:
+                self.history_cancelled.set()
+                raise
+        elif method == "noop":
+            self.quick_dispatched.set()
+        return make_ok_res(req_id, {"method": method})
+
+
+class _ConcurrentHistoryDispatcher:
+    def __init__(self, held_history_ids: set[str]) -> None:
+        self.held_history_ids = frozenset(held_history_ids)
+        self.history_started = {
+            req_id: asyncio.Event() for req_id in self.held_history_ids
+        }
+        self.release_history = {
+            req_id: asyncio.Event() for req_id in self.held_history_ids
+        }
+        self.quick_dispatched = asyncio.Event()
+
+    def list_methods(self) -> list[str]:
+        return ["chat.history", "noop"]
+
+    async def dispatch(self, req_id: str, method: str, params: Any, ctx: Any) -> Any:
+        if method == "chat.history":
+            started = self.history_started.setdefault(req_id, asyncio.Event())
+            started.set()
+            release = self.release_history.get(req_id)
+            if release is not None:
+                await release.wait()
+        elif method == "noop":
+            self.quick_dispatched.set()
+        return make_ok_res(req_id, {"method": method})
+
+    async def wait_for_histories(self, *req_ids: str) -> None:
+        await asyncio.gather(
+            *(self.history_started[req_id].wait() for req_id in req_ids)
+        )
+
+    def release(self, *req_ids: str) -> None:
+        for req_id in req_ids:
+            self.release_history[req_id].set()
+
+
+class _HistoryWebSocket:
+    client_state = WebSocketState.CONNECTED
+    client = SimpleNamespace(host="127.0.0.1", port=12345)
+
+    def __init__(
+        self,
+        frames: list[str],
+        dispatcher: Any,
+        *,
+        release_after_quick_response: bool = False,
+        after_frames: Callable[[_HistoryWebSocket], Awaitable[None]] | None = None,
+        fail_response_id: str | None = None,
+    ) -> None:
+        self._frames = list(frames)
+        self.dispatcher = dispatcher
+        self.release_after_quick_response = release_after_quick_response
+        self.after_frames = after_frames
+        self.fail_response_id = fail_response_id
+        self.sent: list[str] = []
+        self.close_codes: list[int] = []
+        self.close_event = asyncio.Event()
+        self.quick_response_sent = asyncio.Event()
+        self.history_response_sent = asyncio.Event()
+        self._response_events: dict[str, asyncio.Event] = {}
+
+    async def accept(self) -> None:
+        return None
+
+    async def send_text(self, text: str) -> None:
+        frame = json.loads(text)
+        if frame.get("type") == "res" and frame.get("id") == self.fail_response_id:
+            raise RuntimeError("synthetic detached response send failure")
+        self.sent.append(text)
+        if frame.get("type") != "res":
+            return
+        req_id = str(frame.get("id", ""))
+        self._response_events.setdefault(req_id, asyncio.Event()).set()
+        if req_id == "quick":
+            self.quick_response_sent.set()
+        elif req_id == "history":
+            self.history_response_sent.set()
+
+    async def receive_text(self) -> str:
+        if self._frames:
+            return self._frames.pop(0)
+        if self.after_frames is not None:
+            await self.after_frames(self)
+            raise WebSocketDisconnect(code=1000)
+        await asyncio.wait_for(self.dispatcher.history_started.wait(), timeout=1)
+        if self.release_after_quick_response:
+            await asyncio.wait_for(self.dispatcher.quick_dispatched.wait(), timeout=1)
+            await asyncio.wait_for(self.quick_response_sent.wait(), timeout=1)
+            self.dispatcher.release_history.set()
+            await asyncio.wait_for(self.history_response_sent.wait(), timeout=1)
+        raise WebSocketDisconnect(code=1000)
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.close_codes.append(code)
+        self.close_event.set()
+
+    def responses(self) -> list[dict[str, Any]]:
+        return [frame for frame in map(json.loads, self.sent) if frame.get("type") == "res"]
+
+    def hello(self) -> dict[str, Any]:
+        return next(
+            frame
+            for frame in map(json.loads, self.sent)
+            if frame.get("type") == "hello-ok"
+        )
+
+    async def wait_for_response(self, req_id: str) -> None:
+        event = self._response_events.setdefault(req_id, asyncio.Event())
+        await asyncio.wait_for(event.wait(), timeout=1)
+
+    def has_response(self, req_id: str) -> bool:
+        event = self._response_events.get(req_id)
+        return event is not None and event.is_set()
+
+
+@pytest.mark.parametrize("writer_queue_enabled", [False, True])
+async def test_slow_chat_history_does_not_block_later_interactive_rpc(
+    writer_queue_enabled: bool,
+) -> None:
+    dispatcher = _HistoryDispatcher()
+    ws = _HistoryWebSocket(
+        [
+            _CONNECT_FRAME,
+            json.dumps({
+                "type": "req",
+                "id": "history",
+                "method": "chat.history",
+                "params": {"sessionKey": "agent:main:webchat:slow-history"},
+            }),
+            json.dumps({"type": "req", "id": "quick", "method": "noop"}),
+        ],
+        dispatcher,
+        release_after_quick_response=True,
+    )
+
+    await asyncio.wait_for(
+        handle_ws_connection(
+            ws,
+            GatewayConfig(ws_writer_queue_enabled=writer_queue_enabled),
+            dispatcher=dispatcher,
+        ),
+        timeout=2,
+    )
+
+    responses = ws.responses()
+    quick_index = next(i for i, frame in enumerate(responses) if frame["id"] == "quick")
+    history_index = next(i for i, frame in enumerate(responses) if frame["id"] == "history")
+    assert quick_index < history_index
+    assert ws.hello()["policy"]["concurrent_history_reads"] is True
+    assert ws.close_codes == []
+
+
+@pytest.mark.parametrize("writer_queue_enabled", [False, True])
+async def test_slow_history_does_not_block_another_history_or_noop(
+    writer_queue_enabled: bool,
+) -> None:
+    dispatcher = _ConcurrentHistoryDispatcher({"history-a"})
+    observed: dict[str, bool] = {}
+
+    async def finish_after_concurrent_responses(socket: _HistoryWebSocket) -> None:
+        await dispatcher.wait_for_histories("history-a")
+        await socket.wait_for_response("history-b")
+        await socket.wait_for_response("quick")
+        observed["history_a_still_pending"] = not socket.has_response("history-a")
+        dispatcher.release("history-a")
+        await socket.wait_for_response("history-a")
+
+    ws = _HistoryWebSocket(
+        [
+            _CONNECT_FRAME,
+            json.dumps({
+                "type": "req",
+                "id": "history-a",
+                "method": "chat.history",
+                "params": {"sessionKey": "agent:main:webchat:slow-history-a"},
+            }),
+            json.dumps({
+                "type": "req",
+                "id": "history-b",
+                "method": "chat.history",
+                "params": {"sessionKey": "agent:main:webchat:quick-history-b"},
+            }),
+            json.dumps({"type": "req", "id": "quick", "method": "noop"}),
+        ],
+        dispatcher,
+        after_frames=finish_after_concurrent_responses,
+    )
+
+    await asyncio.wait_for(
+        handle_ws_connection(
+            ws,
+            GatewayConfig(ws_writer_queue_enabled=writer_queue_enabled),
+            dispatcher=dispatcher,
+        ),
+        timeout=2,
+    )
+
+    responses = ws.responses()
+    response_indexes = {
+        frame["id"]: index
+        for index, frame in enumerate(responses)
+        if frame["id"] in {"history-a", "history-b", "quick"}
+    }
+    assert observed["history_a_still_pending"]
+    assert response_indexes["history-b"] < response_indexes["history-a"]
+    assert response_indexes["quick"] < response_indexes["history-a"]
+    assert ws.close_codes == []
+
+
+@pytest.mark.parametrize("writer_queue_enabled", [False, True])
+async def test_detached_history_limit_rejects_fifth_without_blocking_noop(
+    writer_queue_enabled: bool,
+) -> None:
+    held_history_ids = tuple(f"history-{index}" for index in range(1, 5))
+    dispatcher = _ConcurrentHistoryDispatcher(set(held_history_ids))
+    observed: dict[str, bool] = {}
+
+    async def finish_after_busy_and_noop_responses(socket: _HistoryWebSocket) -> None:
+        await dispatcher.wait_for_histories(*held_history_ids)
+        await socket.wait_for_response("history-5")
+        await socket.wait_for_response("quick")
+        observed["held_histories_still_pending"] = all(
+            not socket.has_response(req_id) for req_id in held_history_ids
+        )
+        dispatcher.release(*held_history_ids)
+        await asyncio.gather(
+            *(socket.wait_for_response(req_id) for req_id in held_history_ids)
+        )
+
+    frames = [_CONNECT_FRAME]
+    frames.extend(
+        json.dumps({
+            "type": "req",
+            "id": req_id,
+            "method": "chat.history",
+            "params": {"sessionKey": f"agent:main:webchat:{req_id}"},
+        })
+        for req_id in (*held_history_ids, "history-5")
+    )
+    frames.append(json.dumps({"type": "req", "id": "quick", "method": "noop"}))
+    ws = _HistoryWebSocket(
+        frames,
+        dispatcher,
+        after_frames=finish_after_busy_and_noop_responses,
+    )
+
+    await asyncio.wait_for(
+        handle_ws_connection(
+            ws,
+            GatewayConfig(ws_writer_queue_enabled=writer_queue_enabled),
+            dispatcher=dispatcher,
+        ),
+        timeout=2,
+    )
+
+    responses = ws.responses()
+    responses_by_id = {frame["id"]: frame for frame in responses}
+    busy_response = responses_by_id["history-5"]
+    assert observed["held_histories_still_pending"]
+    assert "history-5" not in dispatcher.history_started
+    assert busy_response["ok"] is False
+    assert busy_response["error"]["code"] == "STORAGE_BUSY"
+    assert busy_response["error"]["retryable"] is True
+    assert busy_response["error"]["retry_after_ms"] == 100
+    assert responses_by_id["quick"]["ok"] is True
+    assert dispatcher.quick_dispatched.is_set()
+    assert ws.close_codes == []
+
+
+async def test_disconnect_cancels_in_flight_detached_history() -> None:
+    dispatcher = _HistoryDispatcher()
+    ws = _HistoryWebSocket(
+        [
+            _CONNECT_FRAME,
+            json.dumps({
+                "type": "req",
+                "id": "history",
+                "method": "chat.history",
+                "params": {"sessionKey": "agent:main:webchat:disconnect-history"},
+            }),
+        ],
+        dispatcher,
+        release_after_quick_response=False,
+    )
+
+    await asyncio.wait_for(
+        handle_ws_connection(
+            ws,
+            GatewayConfig(ws_writer_queue_enabled=True),
+            dispatcher=dispatcher,
+        ),
+        timeout=2,
+    )
+
+    assert dispatcher.history_cancelled.is_set()
+    assert all(frame["id"] != "history" for frame in ws.responses())
+
+
+@pytest.mark.parametrize("writer_queue_enabled", [False, True])
+async def test_detached_history_send_failure_closes_connection(
+    writer_queue_enabled: bool,
+) -> None:
+    dispatcher = _ConcurrentHistoryDispatcher(set())
+
+    async def finish_after_close(socket: _HistoryWebSocket) -> None:
+        await asyncio.wait_for(socket.close_event.wait(), timeout=1)
+
+    ws = _HistoryWebSocket(
+        [
+            _CONNECT_FRAME,
+            json.dumps({
+                "type": "req",
+                "id": "history-fail",
+                "method": "chat.history",
+                "params": {"sessionKey": "agent:main:webchat:history-fail"},
+            }),
+        ],
+        dispatcher,
+        after_frames=finish_after_close,
+        fail_response_id="history-fail",
+    )
+
+    await asyncio.wait_for(
+        handle_ws_connection(
+            ws,
+            GatewayConfig(ws_writer_queue_enabled=writer_queue_enabled),
+            dispatcher=dispatcher,
+        ),
+        timeout=2,
+    )
+
+    assert ws.close_codes == [1011]
+    assert all(frame["id"] != "history-fail" for frame in ws.responses())


### PR DESCRIPTION
## Scope

Scope boundary:

- Keep existing session messages and controls usable while canonical history loads or recovers.
- Remove the routine history-loading notice while retaining explicit failure/retry and live-degraded feedback.
- Dispatch bounded `chat.history` reads independently from the Gateway's serial interactive RPC path, with a per-connection concurrency cap and deterministic teardown.
- Release optional UI reads after subscribe/snapshot/history request frames are actually sent, then bound those automatic reads so an abandoned metadata request cannot trap later controls.
- Advertise concurrent history support as an additive policy capability; new clients conservatively reconnect when talking to older serial Gateways.
- Preserve drafts, stale-session guards, reconnect ordering, and packaged-session recovery contracts.

Non-goals:

- No session persistence, transcript schema, provider, or channel behavior changes.
- No database migration or configuration migration.
- No broad conversion of Gateway RPC handlers to concurrent execution.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Directly addresses a reported Control UI regression; no public issue number was supplied.

## Release Note

Release note: Fix the Control UI so session history recovery no longer hides retained messages or blocks navigation, controls, and message sending.

## Tests

Ruff: `uv run ruff check src/opensquilla/gateway/protocol.py src/opensquilla/gateway/websocket.py tests/test_gateway/test_websocket_request_concurrency.py` — passed.

Pytest: `uv run pytest tests/test_gateway -q` — 2422 passed, 10 skipped. The focused WebSocket concurrency suite passed 9/9 in both direct-send and writer-queue modes.

Build: `npm run build` — production typecheck, architecture/i18n/theme guards, Vite build, bundle guards, and artifact verification passed. `uv run mypy src/opensquilla/gateway/websocket.py src/opensquilla/gateway/protocol.py --show-error-codes` also passed.

Regression tests: added

- `npx vitest run --maxWorkers=1` — 240 files, 2474 tests passed.
- `e2e/history-hydration.spec.ts` — 8/8 Playwright tests passed, including a real send while history is pending and recovery from a stuck automatic metadata read onto a replacement socket.
- Packaged recovery script syntax checked with Node; its assertions now cover the removed blocking load page and hidden routine history notice.

Notes:

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and `tests/_private/` contents are not committed.

The protocol change is additive and defaults to conservative behavior: old clients ignore the new policy field, while new clients reconnect when an old Gateway does not advertise concurrent history reads. No persisted or public field is removed. The implementation is platform-neutral and does not alter filesystem, subprocess, signal, permission, or sandbox behavior.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A; implementation and tests were authored in-tree.

## Documentation Changes

No documentation files changed.

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.