### PR TITLE
fix(webui): improve provider promo and usage popover

### DIFF
--- a/opensquilla-webui/src/components/chat/AssistantMessage.ensemble-meta.test.ts
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.ensemble-meta.test.ts
@@ -216,6 +216,13 @@ describe('AssistantMessage ensemble footer metadata', () => {
     expect(source).not.toContain('class="savings-indicator"')
   })
 
+  it('opens the info popover inward from the left edge of the message pane', () => {
+    const popoverRule = source.match(/\.msg-meta-popover\s*\{([^}]*)\}/)?.[1] || ''
+
+    expect(popoverRule).toMatch(/\bleft:\s*0;/)
+    expect(popoverRule).not.toContain('translateX(-50%)')
+  })
+
   it('does not toggle share selection for stopped-output notices', async () => {
     const onToggleShare = vi.fn()
     const { app, el } = await mountMessage(

--- a/opensquilla-webui/src/components/chat/AssistantMessage.vue
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.vue
@@ -1140,8 +1140,7 @@ function ensembleRole(role: string, label: string): string {
 .msg-meta-popover {
   position: absolute;
   bottom: calc(100% + 0.375rem);
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
   z-index: 20;
   display: flex;
   flex-direction: column;

--- a/opensquilla-webui/src/components/setup/SetupProviderCatalogDialog.vue
+++ b/opensquilla-webui/src/components/setup/SetupProviderCatalogDialog.vue
@@ -21,6 +21,7 @@ const inputRef = ref<HTMLInputElement | null>(null)
 const query = ref('')
 const activeIndex = ref(0)
 const FEATURED = ['tokenrhythm', 'openrouter', 'deepseek', 'gemini']
+const TOKENRHYTHM_REGISTRATION_URL = 'https://tokenrhythm.studio/'
 
 const configured = computed(() => new Set(
   props.configuredIds.map(id => id.trim().toLowerCase()),
@@ -197,29 +198,40 @@ watch(() => props.open, open => {
     >
       <section v-if="recommendedProviders.length" class="provider-picker__group" role="presentation">
         <p class="provider-picker__group-label">{{ t('setup.provider.recommendedProviders') }}</p>
-        <button
+        <div
           v-for="{ provider, index } in recommendedProviders"
-          :id="`setup-provider-catalog-option-${index}`"
           :key="provider.providerId"
-          type="button"
-          class="provider-picker__option"
-          :class="{ 'is-active': index === activeIndex }"
-          role="option"
-          tabindex="-1"
-          :disabled="isConfigured(provider.providerId)"
-          :aria-selected="index === activeIndex ? 'true' : 'false'"
-          :title="isConfigured(provider.providerId) ? t('setup.provider.alreadyConfigured') : undefined"
+          class="provider-picker__option-row"
           @mousemove="activeIndex = index"
-          @click="choose(provider.providerId)"
         >
-          <span class="provider-picker__option-copy">
-            <strong>{{ provider.label }}</strong>
-            <code>{{ provider.providerId }}</code>
-          </span>
-          <span class="control-pill provider-picker__offer">
+          <button
+            :id="`setup-provider-catalog-option-${index}`"
+            type="button"
+            class="provider-picker__option provider-picker__option--with-offer"
+            :class="{ 'is-active': index === activeIndex }"
+            role="option"
+            tabindex="-1"
+            :disabled="isConfigured(provider.providerId)"
+            :aria-selected="index === activeIndex ? 'true' : 'false'"
+            :title="isConfigured(provider.providerId) ? t('setup.provider.alreadyConfigured') : undefined"
+            @click="choose(provider.providerId)"
+          >
+            <span class="provider-picker__option-copy">
+              <strong>{{ provider.label }}</strong>
+              <code>{{ provider.providerId }}</code>
+            </span>
+          </button>
+          <a
+            class="control-pill provider-picker__offer"
+            :href="TOKENRHYTHM_REGISTRATION_URL"
+            target="_blank"
+            rel="noopener noreferrer"
+            :aria-label="t('setup.provider.recommendation.externalLabel')"
+          >
             {{ t('setup.provider.limitedFreeBadge') }}
-          </span>
-        </button>
+            <Icon name="externalLink" :size="12" aria-hidden="true" />
+          </a>
+        </div>
       </section>
       <section v-if="otherProviders.length" class="provider-picker__group" role="presentation">
         <p class="provider-picker__group-label">{{ t('setup.provider.otherProviders') }}</p>
@@ -371,6 +383,14 @@ watch(() => props.open, open => {
   padding: var(--sp-2) var(--sp-3);
   text-align: left;
 }
+.provider-picker__option-row {
+  min-width: 0;
+  position: relative;
+}
+.provider-picker__option--with-offer {
+  padding-right: clamp(148px, 38%, 190px);
+  width: 100%;
+}
 .provider-picker__option-copy {
   display: grid;
   gap: 1px;
@@ -382,10 +402,31 @@ watch(() => props.open, open => {
   overflow-wrap: anywhere;
 }
 .provider-picker__offer {
+  align-items: center;
   background: color-mix(in srgb, var(--accent) 12%, transparent);
   border-color: color-mix(in srgb, var(--accent) 25%, transparent);
   color: var(--accent-deep);
+  display: inline-flex;
   flex: 0 0 auto;
+  gap: 4px;
+  position: absolute;
+  right: var(--sp-3);
+  text-decoration: none;
+  top: 50%;
+  transform: translateY(-50%);
+  transition: background var(--dur-fast) var(--ease-out),
+              border-color var(--dur-fast) var(--ease-out),
+              box-shadow var(--dur-fast) var(--ease-out);
+}
+.provider-picker__offer:hover {
+  background: color-mix(in srgb, var(--accent) 19%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 42%, transparent);
+  text-decoration: none;
+}
+.provider-picker__offer:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 .provider-picker__option:hover,
 .provider-picker__option.is-active,
@@ -412,6 +453,7 @@ watch(() => props.open, open => {
 }
 @container provider-panel (max-width: 560px) {
   .provider-picker__option { align-items: center; gap: var(--sp-2); }
+  .provider-picker__option--with-offer { padding-right: clamp(136px, 46%, 172px); }
   .provider-picker__results-head { align-items: flex-start; flex-direction: column; gap: var(--sp-1); }
 }
 </style>

--- a/opensquilla-webui/src/components/setup/SetupProviderPanel.test.ts
+++ b/opensquilla-webui/src/components/setup/SetupProviderPanel.test.ts
@@ -612,6 +612,60 @@ describe('SetupProviderPanel — configured provider management', () => {
     app.unmount()
   })
 
+  it('keeps the TokenRhythm offer visible in the editor for a configured provider', async () => {
+    const onAddProvider = vi.fn()
+    const onUpdateProviderField = vi.fn()
+    const { app, el } = await mountPanel({
+      providerSelected: 'tokenrhythm',
+      runtimeProviders: [TOKENRHYTHM_PROVIDER, OPENROUTER_PROVIDER],
+      configuredProviders: [{
+        providerId: 'tokenrhythm',
+        label: 'TokenRhythm',
+        active: true,
+        ready: true,
+        credentialSource: 'explicit',
+        credentialEnv: '',
+        endpointSource: 'registry',
+        reason: '',
+      }],
+      credentialPanel: {
+        ...(panel().credentialPanel as Record<string, unknown>),
+        providerLabel: 'TokenRhythm',
+        envKey: 'TOKENRHYTHM_API_KEY',
+        masked: 'tr-••••1234',
+      },
+    }, { onAddProvider, onUpdateProviderField })
+
+    expect(el.querySelector('[data-testid="tokenrhythm-recommendation"]')).toBeNull()
+
+    el.querySelector<HTMLButtonElement>(
+      '[data-provider-id="tokenrhythm"] .setup-provider-card__select',
+    )?.click()
+    await nextTick()
+
+    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')!
+    const offer = dialog.querySelector<HTMLElement>('[data-testid="tokenrhythm-recommendation"]')
+    const link = offer?.querySelector<HTMLAnchorElement>('a')
+
+    expect(offer?.classList.contains('setup-provider-recommendation--compact')).toBe(true)
+    expect(offer?.textContent).toContain('Recommended: TokenRhythm')
+    expect(offer?.textContent).toContain('TokenRhythm API calls are free for a limited time.')
+    expect(offer?.querySelector('[data-testid="tokenrhythm-recommendation-step"]')).toBeNull()
+    expect(link?.href).toBe(TOKENRHYTHM_REGISTRATION_URL)
+    expect(link?.getAttribute('target')).toBe('_blank')
+    expect(link?.getAttribute('rel')).toBe('noopener noreferrer')
+    expect(link?.getAttribute('aria-label')).toContain('opens in a new tab')
+
+    link?.addEventListener('click', event => event.preventDefault(), { once: true })
+    link?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    await nextTick()
+
+    expect(onAddProvider).not.toHaveBeenCalled()
+    expect(onUpdateProviderField).not.toHaveBeenCalled()
+    expect(document.body.querySelector('[role="dialog"]')).toBeTruthy()
+    app.unmount()
+  })
+
   it('closes the inline picker with Escape and restores focus to Add provider', async () => {
     const { app, el } = await mountPanel({
       runtimeProviders: [

--- a/opensquilla-webui/src/components/setup/SetupProviderPanel.test.ts
+++ b/opensquilla-webui/src/components/setup/SetupProviderPanel.test.ts
@@ -35,6 +35,7 @@ const DISCOVERED: DiscoveredModel[] = [
 ]
 
 const TOKENRHYTHM_REGISTRATION_URL = 'https://tokenrhythm.studio/register'
+const TOKENRHYTHM_CATALOG_URL = 'https://tokenrhythm.studio/'
 const TOKENRHYTHM_PROVIDER = { providerId: 'tokenrhythm', label: 'TokenRhythm' }
 const OPENROUTER_PROVIDER = { providerId: 'openrouter', label: 'OpenRouter' }
 
@@ -580,6 +581,34 @@ describe('SetupProviderPanel — configured provider management', () => {
 
     options[0]?.click()
     expect(onAddProvider).toHaveBeenCalledWith('gemini')
+    app.unmount()
+  })
+
+  it('opens the TokenRhythm limited-time offer without selecting the provider', async () => {
+    const onAddProvider = vi.fn()
+    const { app, el } = await mountPanel({
+      configuredProviders: [],
+      runtimeProviders: [TOKENRHYTHM_PROVIDER, OPENROUTER_PROVIDER],
+    }, { onAddProvider })
+
+    Array.from(el.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.trim() === 'Add provider')?.click()
+    await nextTick()
+    await nextTick()
+
+    const offer = document.body.querySelector<HTMLAnchorElement>('.provider-picker__offer')
+    expect(offer?.href).toBe(TOKENRHYTHM_CATALOG_URL)
+    expect(offer?.getAttribute('target')).toBe('_blank')
+    expect(offer?.getAttribute('rel')).toBe('noopener noreferrer')
+    expect(offer?.getAttribute('aria-label')).toContain('opens in a new tab')
+    expect(offer?.textContent).toContain('Limited-time free access')
+
+    offer?.addEventListener('click', event => event.preventDefault(), { once: true })
+    offer?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    await nextTick()
+
+    expect(onAddProvider).not.toHaveBeenCalled()
+    expect(document.body.querySelector('[data-testid="provider-catalog-picker"]')).toBeTruthy()
     app.unmount()
   })
 
@@ -1177,7 +1206,7 @@ describe('SetupProviderPanel — configured provider management', () => {
     expect(document.body.querySelector('.provider-picker__list')).toBeTruthy()
     expect(Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
       .some(button => button.textContent?.includes('Browse all providers'))).toBe(false)
-    expect(document.body.querySelector('.provider-picker__option .control-pill')?.textContent)
+    expect(document.body.querySelector('.provider-picker__offer')?.textContent)
       .toContain('Limited-time free access')
 
     const search = document.body.querySelector<HTMLInputElement>('input[name="setup_provider_search"]')!

--- a/opensquilla-webui/src/components/setup/SetupProviderPanel.vue
+++ b/opensquilla-webui/src/components/setup/SetupProviderPanel.vue
@@ -1099,6 +1099,13 @@ const tokenRhythmCredentialReplacementRequired = computed(() => (
                   <strong>{{ selectedProviderLabel }}</strong>
                 </label>
 
+                <SetupProviderRecommendation
+                  v-if="tokenRhythmSelected"
+                  compact
+                  :token-rhythm-selected="tokenRhythmSelected"
+                  :credential-replacement-required="tokenRhythmCredentialReplacementRequired"
+                />
+
                 <section
                   v-if="endpointFields.length"
                   class="setup-provider-modal__endpoint"

--- a/opensquilla-webui/src/components/setup/SetupProviderRecommendation.vue
+++ b/opensquilla-webui/src/components/setup/SetupProviderRecommendation.vue
@@ -6,6 +6,7 @@ const { t } = useI18n()
 const props = defineProps<{
   tokenRhythmSelected: boolean
   credentialReplacementRequired: boolean
+  compact?: boolean
 }>()
 
 const registrationUrl = 'https://tokenrhythm.studio/register'
@@ -28,22 +29,36 @@ const stepKeys = computed(() => [
 <template>
   <div
     class="setup-provider-recommendation control-card control-card--compact control-card--accent"
+    :class="{ 'setup-provider-recommendation--compact': compact }"
     data-testid="tokenrhythm-recommendation"
   >
     <div class="setup-provider-recommendation__head">
-      <p
-        class="setup-provider-recommendation__title"
-        data-testid="tokenrhythm-recommendation-title"
-      >{{ t('setup.provider.recommendation.title') }}</p>
-      <span class="setup-provider-recommendation__scope">
-        {{ t('setup.provider.recommendationScope') }}
-      </span>
+      <div class="setup-provider-recommendation__message">
+        <div class="setup-provider-recommendation__title-row">
+          <p
+            class="setup-provider-recommendation__title"
+            data-testid="tokenrhythm-recommendation-title"
+          >{{ t('setup.provider.recommendation.title') }}</p>
+          <span class="setup-provider-recommendation__scope">
+            {{ t('setup.provider.recommendationScope') }}
+          </span>
+        </div>
+        <p
+          class="setup-provider-recommendation__copy"
+          data-testid="tokenrhythm-recommendation-value"
+        >{{ t('setup.provider.recommendation.value') }}</p>
+      </div>
+      <a
+        v-if="compact"
+        class="setup-provider-recommendation__link setup-provider-recommendation__link--compact btn btn--ghost"
+        :href="registrationUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        :aria-label="t('setup.provider.recommendation.externalLabel')"
+      >{{ t('setup.provider.recommendation.cta') }}</a>
     </div>
-    <p
-      class="setup-provider-recommendation__copy"
-      data-testid="tokenrhythm-recommendation-value"
-    >{{ t('setup.provider.recommendation.value') }}</p>
     <ol
+      v-if="!compact"
       class="setup-provider-recommendation__steps"
       :aria-label="t('setup.provider.recommendation.stepsLabel')"
     >
@@ -58,6 +73,7 @@ const stepKeys = computed(() => [
       </li>
     </ol>
     <a
+      v-if="!compact"
       class="setup-provider-recommendation__link btn btn--primary"
       :href="registrationUrl"
       target="_blank"
@@ -85,7 +101,18 @@ const stepKeys = computed(() => [
   font-weight: 700;
 }
 
+.setup-provider-recommendation__message {
+  display: grid;
+  gap: var(--sp-1);
+  min-width: 0;
+}
+
 .setup-provider-recommendation__head {
+  display: grid;
+  gap: var(--sp-2);
+}
+
+.setup-provider-recommendation__title-row {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
@@ -168,9 +195,49 @@ const stepKeys = computed(() => [
   outline-offset: 2px;
 }
 
+.setup-provider-recommendation--compact {
+  background: color-mix(in srgb, var(--accent) 5%, var(--bg-elevated));
+  box-shadow: none;
+  margin: 0;
+  padding: var(--sp-3);
+}
+
+.setup-provider-recommendation--compact .setup-provider-recommendation__head {
+  align-items: center;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.setup-provider-recommendation--compact .setup-provider-recommendation__scope {
+  justify-self: start;
+}
+
+.setup-provider-recommendation__link--compact {
+  align-items: center;
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+  color: var(--accent-deep);
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.setup-provider-recommendation__link--compact:hover {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
+}
+
 @media (max-width: 720px) {
   .setup-provider-recommendation__steps {
     grid-template-columns: 1fr;
+  }
+
+  .setup-provider-recommendation--compact .setup-provider-recommendation__head {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .setup-provider-recommendation__link--compact {
+    justify-content: center;
+    width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
## Scope

- Make the TokenRhythm limited-time offer a safe external registration link to https://tokenrhythm.studio/.
- Keep the registration action separate from provider selection.
- Show the optional TokenRhythm offer in the configured-provider editor without displacing save or delete actions.
- Align the assistant usage info popover inward so it is not clipped at the message pane edge.
- Add regression coverage for both UI behaviors.

Scope boundary: WebUI provider catalog, configured-provider editor, and assistant message metadata only.
Non-goals: Provider backend behavior, billing, or model routing changes.

## Branch

Base branch: main
Target exception: N/A

## Issue

Linked issue: None
If None, reason: Small UI fix without a tracked issue.

## Release Note

Release note: Improved TokenRhythm provider onboarding and fixed clipped assistant usage details.

## Tests

Ruff: N/A
Pytest: N/A
Build: `npm run build`
Regression tests: added
Notes: `npm run test:unit -- src/components/setup/SetupProviderPanel.test.ts src/components/chat/AssistantMessage.ensemble-meta.test.ts` (86 tests passed).

## Maintainer Live Check

Maintainer live check: no
Surface: N/A
Maintainer-only note: No credentials or live provider access are required for this change.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.