### PR TITLE
Reduce Gateway startup stalls without weakening ownership checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1011,6 +1011,7 @@ jobs:
             'primary-repair-accessibility:scripts/test-primary-repair-accessibility.mjs' \
             'profile-import-flow:scripts/test-profile-import-flow.mjs' \
             'desktop-cleanup-flow:scripts/test-desktop-cleanup-flow.mjs' \
+            'gateway-ownership:scripts/test-desktop-gateway-ownership.mjs' \
             'gateway-orphan-recovery-flow:scripts/test-desktop-gateway-orphan-recovery-flow.mjs' \
             'window-background-flow:scripts/test-desktop-window-background-flow.mjs' \
             'native-workbench-surface:scripts/test-native-workbench-surface-electron.mjs' \

--- a/desktop/electron/scripts/test-desktop-gateway-ownership.mjs
+++ b/desktop/electron/scripts/test-desktop-gateway-ownership.mjs
@@ -29,6 +29,9 @@ import {
   verifyDesktopGatewayOwnership,
   waitForDesktopGatewayOwnershipRelease,
 } from '../dist/desktop-gateway-ownership.js'
+import {
+  DesktopGatewayOwnershipVerificationCoordinator,
+} from '../dist/desktop-gateway-ownership-verification.js'
 
 const nonce = 'abcdefghijklmnopqrstuvwxyzABCDEFG'
 const challenge = '0123456789abcdef0123456789abcdef'
@@ -326,5 +329,276 @@ assert.equal(
 assert.equal(desktopProcessStartIdentity(0), null)
 assert.equal(desktopProcessStartIdentity(-1), null)
 assert.equal(desktopProcessStartIdentity(1.5), null)
+
+// --- readiness verification budget: one deadline per exact record instance ---
+
+{
+  let now = 0
+  let verifyCalls = 0
+  let livenessCalls = 0
+  let startIdentityCalls = 0
+  const coordinator = new DesktopGatewayOwnershipVerificationCoordinator({
+    identityReadyTimeoutMs: 100,
+    pollIntervalMs: 25,
+    now: () => now,
+    wait: async (timeoutMs) => {
+      now += timeoutMs
+    },
+    verify: async () => {
+      verifyCalls += 1
+      return false
+    },
+    load: () => ({ status: 'valid', record }),
+    processMayStillBeAlive: () => {
+      livenessCalls += 1
+      return true
+    },
+    processStartIdentity: () => {
+      startIdentityCalls += 1
+      return null
+    },
+    startIdentityConflicts: () => false,
+  })
+
+  assert.equal(await coordinator.verifyWhenReady('/profile/owner', record), false)
+  assert.equal(await coordinator.verifyWhenReady('/profile/owner', record), false)
+  assert.equal(await coordinator.verifyWhenReady('/profile/owner', record), false)
+  assert.equal(now, 100, 'three sequential startup phases share one total wait budget')
+  assert.equal(verifyCalls, 7, 'later phases still perform one fresh identity challenge')
+  assert.equal(livenessCalls, 7, 'every failed challenge gets a fresh process liveness probe')
+  assert.equal(startIdentityCalls, 3, 'later phases still perform a fresh liveness check')
+}
+
+{
+  let verifyCalls = 0
+  let releaseVerification
+  const verificationGate = new Promise((resolve) => {
+    releaseVerification = resolve
+  })
+  const coordinator = new DesktopGatewayOwnershipVerificationCoordinator({
+    verify: async () => {
+      verifyCalls += 1
+      return await verificationGate
+    },
+    load: () => ({ status: 'missing', record: null }),
+  })
+
+  const first = coordinator.verifyWhenReady('/profile/concurrent', record)
+  const second = coordinator.verifyWhenReady('/profile/concurrent', record)
+  releaseVerification(false)
+  assert.deepEqual(await Promise.all([first, second]), [false, false])
+  assert.equal(verifyCalls, 1, 'concurrent callers share one in-flight challenge')
+}
+
+{
+  let recoveryCalls = 0
+  let releaseRecovery
+  const recoveryGate = new Promise((resolve) => {
+    releaseRecovery = resolve
+  })
+  const coordinator = new DesktopGatewayOwnershipVerificationCoordinator({
+    load: () => ({ status: 'valid', record }),
+  })
+  const recover = async () => {
+    recoveryCalls += 1
+    await recoveryGate
+  }
+
+  const first = coordinator.runRecovery('/profile/recovery', record, recover)
+  const second = coordinator.runRecovery('/profile/recovery', record, recover)
+  releaseRecovery()
+  await Promise.all([first, second])
+  assert.equal(recoveryCalls, 1, 'concurrent callers share shutdown and release work')
+
+  await coordinator.runRecovery('/profile/recovery', record, async () => {
+    recoveryCalls += 1
+  })
+  assert.equal(recoveryCalls, 2, 'completed recovery outcomes are never cached as authority')
+
+  await assert.rejects(
+    coordinator.runRecovery('/profile/recovery', record, async () => {
+      recoveryCalls += 1
+      throw new Error('synthetic release failure')
+    }),
+    /synthetic release failure/,
+  )
+  await coordinator.runRecovery('/profile/recovery', record, async () => {
+    recoveryCalls += 1
+  })
+  assert.equal(recoveryCalls, 4, 'a failed recovery is retried and never cached as success')
+}
+
+{
+  const replacement = { ...record, version: '1.2.4' }
+  let currentRecord = record
+  let activeRecoveries = 0
+  let maxActiveRecoveries = 0
+  const order = []
+  let releaseFirst
+  const firstGate = new Promise((resolve) => {
+    releaseFirst = resolve
+  })
+  const coordinator = new DesktopGatewayOwnershipVerificationCoordinator({
+    load: () => ({ status: 'valid', record: currentRecord }),
+  })
+  const recover = async (fresh) => {
+    order.push(`${fresh.version}:start`)
+    activeRecoveries += 1
+    maxActiveRecoveries = Math.max(maxActiveRecoveries, activeRecoveries)
+    if (fresh.version === record.version) await firstGate
+    activeRecoveries -= 1
+    order.push(`${fresh.version}:end`)
+  }
+  const first = coordinator.runRecovery('/profile/serialized', record, recover)
+  currentRecord = replacement
+  const second = coordinator.runRecovery('/profile/serialized', replacement, recover)
+
+  await Promise.resolve()
+  assert.deepEqual(order, [`${record.version}:start`])
+  releaseFirst()
+  await Promise.all([first, second])
+  assert.equal(maxActiveRecoveries, 1, 'different records in one directory recover serially')
+  assert.deepEqual(order, [
+    `${record.version}:start`,
+    `${record.version}:end`,
+    `${replacement.version}:start`,
+    `${replacement.version}:end`,
+  ])
+}
+
+{
+  const replacement = { ...record, version: '1.2.5' }
+  let currentRecord = record
+  let releaseFirst
+  const firstGate = new Promise((resolve) => {
+    releaseFirst = resolve
+  })
+  const recoveredVersions = []
+  const coordinator = new DesktopGatewayOwnershipVerificationCoordinator({
+    load: () => ({ status: 'valid', record: currentRecord }),
+  })
+  const recover = async (fresh) => {
+    recoveredVersions.push(fresh.version)
+    if (fresh.version === record.version) {
+      await firstGate
+      throw new Error('old record failed')
+    }
+  }
+  const first = coordinator.runRecovery('/profile/replaced-error', record, recover)
+  currentRecord = replacement
+  const second = coordinator.runRecovery('/profile/replaced-error', replacement, recover)
+
+  releaseFirst()
+  const outcomes = await Promise.allSettled([first, second])
+  assert.equal(outcomes[0].status, 'rejected')
+  assert.equal(outcomes[1].status, 'fulfilled')
+  assert.deepEqual(
+    recoveredVersions,
+    [record.version, replacement.version],
+    'a replacement record does not inherit the old failure',
+  )
+}
+
+{
+  const replacement = { ...record, version: '1.2.6' }
+  let currentRecord = record
+  let releaseFirst
+  const firstGate = new Promise((resolve) => {
+    releaseFirst = resolve
+  })
+  const recoveredVersions = []
+  const coordinator = new DesktopGatewayOwnershipVerificationCoordinator({
+    load: () => ({ status: 'valid', record: currentRecord }),
+  })
+  const recover = async (fresh) => {
+    recoveredVersions.push(fresh.version)
+    if (fresh.version === record.version) await firstGate
+  }
+
+  const leader = coordinator.runRecovery('/profile/replaced-after-join', record, recover)
+  const follower = coordinator.runRecovery('/profile/replaced-after-join', record, recover)
+  currentRecord = replacement
+  releaseFirst()
+  await Promise.all([leader, follower])
+  assert.deepEqual(
+    recoveredVersions,
+    [record.version],
+    'a same-record recovery never expands its authority to a replacement',
+  )
+}
+
+{
+  let now = 0
+  let currentRecord = record
+  let verificationReady = false
+  let verifyCalls = 0
+  const coordinator = new DesktopGatewayOwnershipVerificationCoordinator({
+    identityReadyTimeoutMs: 40,
+    pollIntervalMs: 20,
+    now: () => now,
+    wait: async (timeoutMs) => {
+      now += timeoutMs
+    },
+    verify: async () => {
+      verifyCalls += 1
+      return verificationReady
+    },
+    load: () => ({ status: 'valid', record: currentRecord }),
+    processMayStillBeAlive: () => true,
+    processStartIdentity: () => null,
+    startIdentityConflicts: () => false,
+  })
+
+  assert.equal(await coordinator.verifyWhenReady('/profile/replaced', record), false)
+  assert.equal(now, 40)
+
+  verificationReady = true
+  assert.equal(
+    await coordinator.verifyWhenReady('/profile/replaced', record),
+    true,
+    'an orphan that becomes ready after the deadline still gets a fresh challenge',
+  )
+  assert.equal(now, 40, 'the later fresh challenge does not reset the expired budget')
+
+  verificationReady = false
+  currentRecord = { ...record, version: '1.2.4' }
+  assert.equal(
+    await coordinator.verifyWhenReady('/profile/replaced', currentRecord),
+    false,
+  )
+  assert.equal(now, 80, 'a change to any persisted record field receives a new budget')
+  assert.ok(verifyCalls >= 7)
+}
+
+{
+  let now = 0
+  let currentRecord = record
+  const coordinator = new DesktopGatewayOwnershipVerificationCoordinator({
+    identityReadyTimeoutMs: 20,
+    pollIntervalMs: 20,
+    maxRecordBudgetsPerDirectory: 2,
+    now: () => now,
+    wait: async (timeoutMs) => {
+      now += timeoutMs
+    },
+    verify: async () => false,
+    load: () => ({ status: 'valid', record: currentRecord }),
+    processMayStillBeAlive: () => true,
+    processStartIdentity: () => null,
+    startIdentityConflicts: () => false,
+  })
+
+  for (const version of ['1.0.0', '1.0.1']) {
+    currentRecord = { ...record, version }
+    assert.equal(
+      await coordinator.verifyWhenReady('/profile/churn', currentRecord),
+      false,
+    )
+  }
+  assert.equal(now, 40)
+  currentRecord = { ...record, version: '1.0.2' }
+  assert.equal(await coordinator.verifyWhenReady('/profile/churn', currentRecord), false)
+  assert.equal(now, 40, 'abnormal record churn cannot allocate unbounded wait budgets')
+}
 
 console.log('desktop gateway ownership checks passed')

--- a/desktop/electron/src/desktop-gateway-ownership-verification.ts
+++ b/desktop/electron/src/desktop-gateway-ownership-verification.ts
@@ -1,0 +1,264 @@
+import { performance } from 'node:perf_hooks'
+import { normalize, resolve } from 'node:path'
+
+import {
+  desktopGatewayStartIdentityConflict,
+  desktopProcessStartIdentity,
+  loadDesktopGatewayOwnershipRecord,
+  verifyDesktopGatewayOwnership,
+  type DesktopGatewayOwnershipRecord,
+  type DesktopGatewayOwnershipRecordLoad,
+} from './desktop-gateway-ownership.js'
+
+const DEFAULT_IDENTITY_READY_TIMEOUT_MS = 45_000
+const DEFAULT_POLL_INTERVAL_MS = 250
+const DEFAULT_CHALLENGE_TIMEOUT_MS = 750
+const DEFAULT_MAX_RECORD_BUDGETS_PER_DIRECTORY = 8
+
+interface OwnershipVerificationState {
+  deadlineMs: number
+  inFlight: Promise<boolean> | null
+}
+
+interface OwnershipRecoveryFlight {
+  recordKey: string
+  promise: Promise<void>
+}
+
+export interface DesktopGatewayOwnershipVerificationOptions {
+  identityReadyTimeoutMs?: number
+  pollIntervalMs?: number
+  challengeTimeoutMs?: number
+  maxRecordBudgetsPerDirectory?: number
+  now?: () => number
+  wait?: (timeoutMs: number) => Promise<void>
+  verify?: (record: DesktopGatewayOwnershipRecord, timeoutMs: number) => Promise<boolean>
+  load?: (ownershipDir: string) => DesktopGatewayOwnershipRecordLoad
+  processMayStillBeAlive?: (pid: number) => boolean
+  processStartIdentity?: (pid: number) => string | null
+  startIdentityConflicts?: (recorded: string, live: string | null) => boolean
+  onPidRecycled?: (record: DesktopGatewayOwnershipRecord) => void
+}
+
+function processIdMayStillBeAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    // EPERM still proves that a process occupies the PID. Only ESRCH is a
+    // reliable negative across supported Node platforms.
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+function ownershipRecordKey(
+  ownershipDir: string,
+  record: DesktopGatewayOwnershipRecord,
+): string {
+  // Include every persisted field. A replacement record — even one reusing a
+  // PID, port, or nonce — is a distinct instance and receives its own budget.
+  return JSON.stringify([
+    ownershipDirectoryKey(ownershipDir),
+    record.schema_version,
+    record.protocol,
+    record.profile_fingerprint,
+    record.pid,
+    record.start_identity,
+    record.port,
+    record.version,
+    record.instance_nonce,
+  ])
+}
+
+function ownershipDirectoryKey(ownershipDir: string): string {
+  const resolved = normalize(resolve(ownershipDir))
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved
+}
+
+/**
+ * Coordinates readiness verification for Desktop Gateway ownership records.
+ *
+ * Every exact record instance receives one process-local readiness budget.
+ * Concurrent callers share one poll, while later sequential callers still
+ * perform a fresh identity challenge and liveness check without resetting the
+ * deadline. Verification results never grant or cache shutdown authority.
+ */
+export class DesktopGatewayOwnershipVerificationCoordinator {
+  private readonly states = new Map<string, OwnershipVerificationState>()
+  private readonly budgetKeysByDirectory = new Map<string, Set<string>>()
+  private readonly recoveryFlights = new Map<string, OwnershipRecoveryFlight>()
+  private readonly identityReadyTimeoutMs: number
+  private readonly pollIntervalMs: number
+  private readonly challengeTimeoutMs: number
+  private readonly maxRecordBudgetsPerDirectory: number
+  private readonly now: () => number
+  private readonly wait: (timeoutMs: number) => Promise<void>
+  private readonly verify: (
+    record: DesktopGatewayOwnershipRecord,
+    timeoutMs: number,
+  ) => Promise<boolean>
+  private readonly load: (ownershipDir: string) => DesktopGatewayOwnershipRecordLoad
+  private readonly processMayStillBeAlive: (pid: number) => boolean
+  private readonly processStartIdentity: (pid: number) => string | null
+  private readonly startIdentityConflicts: (recorded: string, live: string | null) => boolean
+  private readonly onPidRecycled: (record: DesktopGatewayOwnershipRecord) => void
+
+  constructor(options: DesktopGatewayOwnershipVerificationOptions = {}) {
+    this.identityReadyTimeoutMs = Math.max(
+      0,
+      options.identityReadyTimeoutMs ?? DEFAULT_IDENTITY_READY_TIMEOUT_MS,
+    )
+    this.pollIntervalMs = Math.max(1, options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS)
+    this.challengeTimeoutMs = Math.max(
+      1,
+      options.challengeTimeoutMs ?? DEFAULT_CHALLENGE_TIMEOUT_MS,
+    )
+    this.maxRecordBudgetsPerDirectory = Math.max(
+      1,
+      options.maxRecordBudgetsPerDirectory ?? DEFAULT_MAX_RECORD_BUDGETS_PER_DIRECTORY,
+    )
+    this.now = options.now ?? (() => performance.now())
+    this.wait = options.wait ?? (
+      (timeoutMs) => new Promise((resolveWait) => setTimeout(resolveWait, timeoutMs))
+    )
+    this.verify = options.verify ?? (
+      (record, timeoutMs) => verifyDesktopGatewayOwnership(record, { timeoutMs })
+    )
+    this.load = options.load ?? loadDesktopGatewayOwnershipRecord
+    this.processMayStillBeAlive = options.processMayStillBeAlive ?? processIdMayStillBeAlive
+    this.processStartIdentity = options.processStartIdentity ?? desktopProcessStartIdentity
+    this.startIdentityConflicts = (
+      options.startIdentityConflicts ?? desktopGatewayStartIdentityConflict
+    )
+    this.onPidRecycled = options.onPidRecycled ?? (() => {})
+  }
+
+  async verifyWhenReady(
+    ownershipDir: string,
+    record: DesktopGatewayOwnershipRecord,
+  ): Promise<boolean> {
+    const [key, state] = this.stateFor(ownershipDir, record)
+    if (state.inFlight !== null) return await state.inFlight
+
+    const inFlight = this.pollUntilReady(ownershipDir, record, key, state.deadlineMs)
+    state.inFlight = inFlight
+    try {
+      return await inFlight
+    } finally {
+      if (state.inFlight === inFlight) state.inFlight = null
+    }
+  }
+
+  async runRecovery(
+    ownershipDir: string,
+    record: DesktopGatewayOwnershipRecord,
+    operation: (currentRecord: DesktopGatewayOwnershipRecord) => Promise<void>,
+  ): Promise<void> {
+    const directoryKey = ownershipDirectoryKey(ownershipDir)
+    const targetRecordKey = ownershipRecordKey(ownershipDir, record)
+    while (true) {
+      const existing = this.recoveryFlights.get(directoryKey)
+      if (existing !== undefined) {
+        if (existing.recordKey === targetRecordKey) {
+          await existing.promise
+          return
+        }
+        try {
+          await existing.promise
+        } catch {
+          // A different exact record owns the error. The caller's target is
+          // revalidated below after the directory becomes idle.
+        }
+        continue
+      }
+
+      const loaded = this.load(ownershipDir)
+      if (
+        loaded.status !== 'valid'
+        || ownershipRecordKey(ownershipDir, loaded.record) !== targetRecordKey
+      ) return
+
+      const promise = operation(loaded.record)
+      const flight = { recordKey: targetRecordKey, promise }
+      this.recoveryFlights.set(directoryKey, flight)
+      try {
+        await promise
+        return
+      } finally {
+        if (this.recoveryFlights.get(directoryKey) === flight) {
+          this.recoveryFlights.delete(directoryKey)
+        }
+      }
+    }
+  }
+
+  private stateFor(
+    ownershipDir: string,
+    record: DesktopGatewayOwnershipRecord,
+  ): [string, OwnershipVerificationState] {
+    const key = ownershipRecordKey(ownershipDir, record)
+    let state = this.states.get(key)
+    if (state === undefined) {
+      const directoryKey = ownershipDirectoryKey(ownershipDir)
+      let budgetKeys = this.budgetKeysByDirectory.get(directoryKey)
+      if (budgetKeys === undefined) {
+        budgetKeys = new Set()
+        this.budgetKeysByDirectory.set(directoryKey, budgetKeys)
+      }
+      if (budgetKeys.size >= this.maxRecordBudgetsPerDirectory) {
+        // Abnormal record churn must not create unbounded memory or a chain of
+        // fresh 45-second waits. Keep the mandatory fresh challenge/liveness
+        // checks, but give additional unknown records an already-expired budget.
+        return [
+          key,
+          {
+            deadlineMs: this.now(),
+            inFlight: null,
+          },
+        ]
+      }
+      state = {
+        deadlineMs: this.now() + this.identityReadyTimeoutMs,
+        inFlight: null,
+      }
+      this.states.set(key, state)
+      budgetKeys.add(key)
+    }
+    return [key, state]
+  }
+
+  private async pollUntilReady(
+    ownershipDir: string,
+    record: DesktopGatewayOwnershipRecord,
+    expectedKey: string,
+    deadlineMs: number,
+  ): Promise<boolean> {
+    let startIdentityChecked = false
+    while (true) {
+      // Always challenge first, including after the shared budget expires. This
+      // lets a later startup phase recover an orphan that became ready after
+      // the original poll, without granting authority from a cached result.
+      if (await this.verify(record, this.challengeTimeoutMs)) return true
+
+      const current = this.load(ownershipDir)
+      if (
+        current.status !== 'valid'
+        || ownershipRecordKey(ownershipDir, current.record) !== expectedKey
+        || !this.processMayStillBeAlive(record.pid)
+      ) return false
+
+      if (!startIdentityChecked) {
+        startIdentityChecked = true
+        const liveStartIdentity = this.processStartIdentity(record.pid)
+        if (this.startIdentityConflicts(record.start_identity, liveStartIdentity)) {
+          this.onPidRecycled(record)
+          return false
+        }
+      }
+
+      const remainingMs = deadlineMs - this.now()
+      if (remainingMs <= 0) return false
+      await this.wait(Math.min(this.pollIntervalMs, remainingMs))
+    }
+  }
+}

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -24,16 +24,15 @@ import { DesktopWriterAdmission } from './desktop-writer-admission.js'
 import {
   createDesktopGatewayInstanceNonce,
   desktopGatewayOwnershipMatchesLaunch,
-  desktopGatewayStartIdentityConflict,
-  desktopProcessStartIdentity,
   desktopProfileFingerprint,
   loadDesktopGatewayOwnershipRecord,
   requestVerifiedDesktopGatewayShutdown,
-  sameDesktopGatewayOwnershipInstance,
-  verifyDesktopGatewayOwnership,
   waitForDesktopGatewayOwnershipRelease,
   type DesktopGatewayOwnershipRecord,
 } from './desktop-gateway-ownership.js'
+import {
+  DesktopGatewayOwnershipVerificationCoordinator,
+} from './desktop-gateway-ownership-verification.js'
 import {
   lifecycleAllowsProcessSpawn,
   stopAndJoinLifecycleProcesses,
@@ -7619,7 +7618,11 @@ async function reuseHealthyGatewayState(): Promise<GatewayState | null> {
 }
 
 const VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS = 80_000
-const VERIFIED_ORPHAN_IDENTITY_READY_TIMEOUT_MS = 45_000
+const desktopGatewayOwnershipVerification = new DesktopGatewayOwnershipVerificationCoordinator({
+  onPidRecycled: (record) => {
+    desktopLog('gateway_ownership_pid_recycled', { pid: record.pid, port: record.port })
+  },
+})
 
 function verifiedOrphanGatewayError(detail: string): Error {
   return new Error(
@@ -7629,49 +7632,11 @@ function verifiedOrphanGatewayError(detail: string): Error {
   )
 }
 
-function processIdMayStillBeAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    // EPERM still proves that a process occupies the PID. Only ESRCH is a
-    // reliable negative across supported Node platforms.
-    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
-  }
-}
-
 async function verifyDesktopGatewayOwnershipWhenReady(
   ownershipDir: string,
   record: DesktopGatewayOwnershipRecord,
 ): Promise<boolean> {
-  const deadline = Date.now() + VERIFIED_ORPHAN_IDENTITY_READY_TIMEOUT_MS
-  let startIdentityChecked = false
-  do {
-    if (await verifyDesktopGatewayOwnership(record, { timeoutMs: 750 })) return true
-    const current = loadDesktopGatewayOwnershipRecord(ownershipDir)
-    if (
-      current.status !== 'valid'
-      || !sameDesktopGatewayOwnershipInstance(current.record, record)
-      || !processIdMayStillBeAlive(record.pid)
-    ) return false
-    if (!startIdentityChecked) {
-      // The liveness probe cannot tell a slowly-starting orphan from an
-      // unrelated process that recycled the recorded PID (EPERM also counts
-      // as alive). When the live process's start identity provably disagrees
-      // with the record, the record is stale: stop waiting out the full
-      // ready timeout for a Gateway that no longer exists. An unavailable
-      // probe keeps the conservative wait; it never grants stop authority.
-      startIdentityChecked = true
-      const liveStartIdentity = desktopProcessStartIdentity(record.pid)
-      if (desktopGatewayStartIdentityConflict(record.start_identity, liveStartIdentity)) {
-        desktopLog('gateway_ownership_pid_recycled', { pid: record.pid, port: record.port })
-        return false
-      }
-    }
-    if (Date.now() >= deadline) break
-    await new Promise((resolveWait) => setTimeout(resolveWait, 250))
-  } while (true)
-  return false
+  return await desktopGatewayOwnershipVerification.verifyWhenReady(ownershipDir, record)
 }
 
 /**
@@ -7693,42 +7658,47 @@ async function recoverVerifiedOrphanGatewayBeforeSpawn(
   }
 
   const record: DesktopGatewayOwnershipRecord = loaded.record
-  if (record.profile_fingerprint !== desktopProfileFingerprint(profile.home)) {
-    desktopLog('gateway_ownership_profile_mismatch', { pid: record.pid, port: record.port })
-    return
-  }
-  if (!await verifyDesktopGatewayOwnershipWhenReady(ownershipDir, record)) {
-    // A stale record after SIGKILL is harmless: the OS has already released the
-    // profile lock and the next admitted Gateway will replace the record. Do
-    // not unlink it or infer authority over whatever now owns the PID/port.
-    desktopLog('gateway_ownership_not_verified', { pid: record.pid, port: record.port })
-    return
-  }
+  await desktopGatewayOwnershipVerification.runRecovery(ownershipDir, record, async (current) => {
+    if (current.profile_fingerprint !== desktopProfileFingerprint(profile.home)) {
+      desktopLog('gateway_ownership_profile_mismatch', {
+        pid: current.pid,
+        port: current.port,
+      })
+      return
+    }
+    if (!await verifyDesktopGatewayOwnershipWhenReady(ownershipDir, current)) {
+      // A stale record after SIGKILL is harmless: the OS has already released the
+      // profile lock and the next admitted Gateway will replace the record. Do
+      // not unlink it or infer authority over whatever now owns the PID/port.
+      desktopLog('gateway_ownership_not_verified', { pid: current.pid, port: current.port })
+      return
+    }
 
-  desktopLog('gateway_orphan_verified', {
-    pid: record.pid,
-    port: record.port,
-    version: record.version,
+    desktopLog('gateway_orphan_verified', {
+      pid: current.pid,
+      port: current.port,
+      version: current.version,
+    })
+    const accepted = await requestVerifiedDesktopGatewayShutdown(current)
+    if (!accepted) {
+      // The verified process may have completed shutdown between the challenge
+      // and the authenticated request. The ownership record is removed only
+      // after its writer leases are released, so that disappearance is sufficient.
+      if (loadDesktopGatewayOwnershipRecord(ownershipDir).status === 'missing') return
+      throw verifiedOrphanGatewayError('The verified Gateway rejected the shutdown request.')
+    }
+    const released = await waitForDesktopGatewayOwnershipRelease(ownershipDir, current, {
+      timeoutMs: VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS,
+    })
+    desktopLog('gateway_orphan_shutdown_complete', {
+      pid: current.pid,
+      port: current.port,
+      released,
+    })
+    if (!released) {
+      throw verifiedOrphanGatewayError('The verified Gateway did not finish shutting down.')
+    }
   })
-  const accepted = await requestVerifiedDesktopGatewayShutdown(record)
-  if (!accepted) {
-    // The verified process may have completed shutdown between the challenge
-    // and the authenticated request. The ownership record is removed only
-    // after its writer leases are released, so that disappearance is sufficient.
-    if (loadDesktopGatewayOwnershipRecord(ownershipDir).status === 'missing') return
-    throw verifiedOrphanGatewayError('The verified Gateway rejected the shutdown request.')
-  }
-  const released = await waitForDesktopGatewayOwnershipRelease(ownershipDir, record, {
-    timeoutMs: VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS,
-  })
-  desktopLog('gateway_orphan_shutdown_complete', {
-    pid: record.pid,
-    port: record.port,
-    released,
-  })
-  if (!released) {
-    throw verifiedOrphanGatewayError('The verified Gateway did not finish shutting down.')
-  }
 }
 
 async function startGateway(): Promise<GatewayState> {

--- a/src/opensquilla/cli/gateway_cmd.py
+++ b/src/opensquilla/cli/gateway_cmd.py
@@ -7,6 +7,7 @@ import json
 import os
 import signal
 import socket
+import time
 from collections.abc import Callable
 
 import typer
@@ -125,6 +126,7 @@ def run_gateway(
     honoured as the fallback when no CLI flag or env var is supplied,
     matching what the field name promises.
     """
+    gateway_startup_started_at = time.monotonic()
     requested_config = config_path or os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH")
     if not desktop_config_path_is_profile_local(requested_config):
         console.print("DESKTOP_CONFIG_OUTSIDE_PROFILE")
@@ -213,6 +215,7 @@ def run_gateway(
             config=config,
             subscription_manager=subscription_mgr,
             run=True,
+            _startup_started_at=gateway_startup_started_at,
         )
         assert server._task is not None
 

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -72,6 +72,51 @@ _DEFAULT_GRACEFUL_TIMEOUT_S = 30.0
 _MAX_GRACEFUL_TIMEOUT_S = 120.0
 
 
+def _elapsed_monotonic_ms(started_at: float, ended_at: float | None = None) -> int:
+    end = time.monotonic() if ended_at is None else ended_at
+    return max(0, int((end - started_at) * 1000))
+
+
+def _log_gateway_startup_phase(
+    phase: str,
+    *,
+    startup_started_at: float,
+    phase_started_at: float,
+    status: str = "ready",
+) -> float:
+    completed_at = time.monotonic()
+    log.info(
+        "gateway.startup_phase",
+        phase=phase,
+        status=status,
+        duration_ms=_elapsed_monotonic_ms(phase_started_at, completed_at),
+        startup_elapsed_ms=_elapsed_monotonic_ms(startup_started_at, completed_at),
+    )
+    # Do not charge structured-log I/O to the phase that follows this one.
+    return time.monotonic()
+
+
+def _start_background_install_telemetry(config: GatewayConfig) -> None:
+    def _log_result(result: Any) -> None:
+        log.debug(
+            "gateway.install_telemetry",
+            skipped_reason=result.skipped_reason,
+            telemetry_event=result.event,
+            sent=result.sent,
+            uploaded=result.uploaded,
+            endpoint_configured=result.endpoint_configured,
+        )
+
+    try:
+        from opensquilla.observability.install_telemetry import (
+            start_background_install_telemetry,
+        )
+
+        start_background_install_telemetry(config=config, on_result=_log_result)
+    except Exception:
+        log.debug("gateway.install_telemetry_skipped", exc_info=True)
+
+
 def _auto_propose_usage_execution_context(
     agent_id: str,
     usage_event_sink: Any | None,
@@ -2348,6 +2393,8 @@ async def build_services(
 
     Returns a populated :class:`ServiceContainer`.
     """
+    services_started_at = time.monotonic()
+
     # ── Load .env files (cwd/.env > ~/.opensquilla/.env, never override existing) ──
     from opensquilla.env import load_env
 
@@ -2424,6 +2471,7 @@ async def build_services(
     if session_db_path != ":memory:":
         from opensquilla.persistence.migrator import _native_sqlite_path, apply_pending
 
+        migrations_started_at = time.monotonic()
         log.info("build_services.migrations_started")
         if "://" not in session_db_path:
             # 0o700: session transcripts are sensitive — keep a freshly created
@@ -2435,7 +2483,11 @@ async def build_services(
         applied = apply_pending(storage_db_path, migrations_dir)
         if applied:
             log.info("build_services.migrations_applied", count=len(applied), ids=applied)
-        log.info("build_services.migrations_ready", count=len(applied))
+        log.info(
+            "build_services.migrations_ready",
+            count=len(applied),
+            duration_ms=_elapsed_monotonic_ms(migrations_started_at),
+        )
 
     # ── Agent registry (built early so SessionManager can resolve agent configs) ─
     from opensquilla.agents.registry import AgentRegistry
@@ -2448,12 +2500,16 @@ async def build_services(
         from opensquilla.session.manager import SessionManager
         from opensquilla.session.storage import SessionStorage
 
+        session_storage_started_at = time.monotonic()
         log.info("build_services.session_storage_started")
         if storage_db_path != ":memory:" and "://" not in storage_db_path:
             os.makedirs(os.path.dirname(storage_db_path) or os.curdir, mode=0o700, exist_ok=True)
         storage = SessionStorage(storage_db_path)
         await storage.connect()
-        log.info("build_services.session_storage_ready")
+        log.info(
+            "build_services.session_storage_ready",
+            duration_ms=_elapsed_monotonic_ms(session_storage_started_at),
+        )
         session_manager = SessionManager(
             storage,
             agent_registry=agent_registry,
@@ -2655,11 +2711,14 @@ async def build_services(
     turn_capture_services: dict[str, Any] = {}
     memory_watchers: list[Any] = []
     _turn_runner_ref: list = []
+    memory_started_at = time.monotonic()
+    memory_degraded = False
     try:
         from opensquilla.memory.manager import build_memory_managers
         from opensquilla.tools.builtin.memory_tools import create_memory_tools
 
         agent_ids = _configured_agent_ids(config, extra_agent_ids)
+        log.info("build_services.memory_started", agents=len(agent_ids))
         memory_managers = await build_memory_managers(
             config,
             agent_ids,
@@ -2696,7 +2755,14 @@ async def build_services(
             )
             log.info("build_services.memory_tools_registered", agents=list(memory_stores))
     except Exception as e:
+        memory_degraded = True
         log.warning("build_services.memory_tools_failed", error=str(e))
+    log.info(
+        "build_services.memory_ready",
+        agents=len(memory_managers),
+        degraded=memory_degraded,
+        duration_ms=_elapsed_monotonic_ms(memory_started_at),
+    )
 
     # ── Skill loader (boot order 19) ────────────────────────────────
     skill_loader = None
@@ -2823,7 +2889,12 @@ async def build_services(
         from opensquilla.mcp.types import MCPServerConfig
 
         timeout = config.mcp.connect_timeout_seconds
-        for entry in config.mcp.servers:
+        mcp_started_at = time.monotonic()
+        mcp_registered = 0
+        mcp_failures = 0
+        log.info("build_services.mcp_discovery_started", servers=len(config.mcp.servers))
+        for server_index, entry in enumerate(config.mcp.servers):
+            server_started_at = time.monotonic()
             try:
                 mcp_cfg = MCPServerConfig(
                     name=entry.name,
@@ -2843,18 +2914,49 @@ async def build_services(
                     server=entry.name,
                     tools=len(names),
                 )
+                mcp_registered += 1
+                log.info(
+                    "build_services.mcp_server_timing",
+                    server_index=server_index,
+                    status="ready",
+                    duration_ms=_elapsed_monotonic_ms(server_started_at),
+                    tool_count=len(names),
+                )
             except TimeoutError:
+                mcp_failures += 1
                 log.warning(
                     "build_services.mcp_server_timeout",
                     server=entry.name,
                     timeout=timeout,
                 )
+                log.info(
+                    "build_services.mcp_server_timing",
+                    server_index=server_index,
+                    status="timeout",
+                    duration_ms=_elapsed_monotonic_ms(server_started_at),
+                    tool_count=0,
+                )
             except Exception as e:
+                mcp_failures += 1
                 log.warning(
                     "build_services.mcp_server_failed",
                     server=entry.name,
                     error=str(e),
                 )
+                log.info(
+                    "build_services.mcp_server_timing",
+                    server_index=server_index,
+                    status="failed",
+                    duration_ms=_elapsed_monotonic_ms(server_started_at),
+                    tool_count=0,
+                )
+        log.info(
+            "build_services.mcp_discovery_ready",
+            servers=len(config.mcp.servers),
+            registered=mcp_registered,
+            failures=mcp_failures,
+            duration_ms=_elapsed_monotonic_ms(mcp_started_at),
+        )
     elif config.mcp.enabled:
         log.info("build_services.mcp_enabled_no_servers")
 
@@ -3061,6 +3163,10 @@ async def build_services(
     )
     # Attach deferred callback ref so start_gateway_server can wire TurnRunner
     svc._turn_runner_ref = _turn_runner_ref  # type: ignore[attr-defined]
+    log.info(
+        "build_services.ready",
+        duration_ms=_elapsed_monotonic_ms(services_started_at),
+    )
     return svc
 
 
@@ -3178,6 +3284,7 @@ async def start_gateway_server(
     channel_manager: Any = None,
     usage_tracker: Any = None,
     run: bool = True,
+    _startup_started_at: float | None = None,
 ) -> GatewayServer:
     """
     Boot sequence:
@@ -3186,6 +3293,9 @@ async def start_gateway_server(
     3. Build ASGI app
     4. Start uvicorn server
     """
+    startup_started_at = time.monotonic() if _startup_started_at is None else _startup_started_at
+    startup_phase_started_at = startup_started_at
+
     # ── Gateway-specific config handling ─────────────────────────────
     if config is None:
         config = GatewayConfig.load(os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH"))
@@ -3233,6 +3343,11 @@ async def start_gateway_server(
     # Surface lexical degradation when the operator enabled filter_enabled=true
     # with a strategy that needs the local ONNX embedding backend.
     emit_skill_filter_banner(config.skills)
+    startup_phase_started_at = _log_gateway_startup_phase(
+        "config",
+        startup_started_at=startup_started_at,
+        phase_started_at=startup_phase_started_at,
+    )
 
     # ── PID file lock ───────────────────────────────────────────────
     # Prevents two gateway instances from sharing the same STATE_DIR.
@@ -3264,23 +3379,11 @@ async def start_gateway_server(
         except BaseException:
             _pid_lock.release()
             raise
-
-    # Anonymous install telemetry is best-effort: it must never block gateway
-    # startup. The built-in endpoint is intentionally empty until configured.
-    try:
-        from opensquilla.observability.install_telemetry import collect_install_telemetry
-
-        result = collect_install_telemetry(config=config)
-        log.debug(
-            "gateway.install_telemetry",
-            skipped_reason=result.skipped_reason,
-            telemetry_event=result.event,
-            sent=result.sent,
-            uploaded=result.uploaded,
-            endpoint_configured=result.endpoint_configured,
-        )
-    except Exception:
-        log.debug("gateway.install_telemetry_skipped", exc_info=True)
+    startup_phase_started_at = _log_gateway_startup_phase(
+        "ownership",
+        startup_started_at=startup_started_at,
+        phase_started_at=startup_phase_started_at,
+    )
 
     # Passive update-availability check is best-effort and runs in a background
     # daemon thread: it must never block startup. It powers the "a newer version
@@ -3305,6 +3408,11 @@ async def start_gateway_server(
     except BaseException:
         _pid_lock.release()
         raise
+    startup_phase_started_at = _log_gateway_startup_phase(
+        "services",
+        startup_started_at=startup_started_at,
+        phase_started_at=startup_phase_started_at,
+    )
 
     # An interrupted profile import may span USER.md and a separate memory
     # root. Recover those canonical files before TurnRunner, channels, or the
@@ -3328,25 +3436,11 @@ async def start_gateway_server(
         finally:
             _pid_lock.release()
         raise
-
-    # Daily usage uses the existing telemetry service's dedicated /v1/usage
-    # route and the same unified privacy switch. Upload once at startup and
-    # every hour while the gateway is running; failures remain pending.
-    try:
-        from opensquilla.observability.usage_telemetry import (
-            run_daily_usage_upload_loop,
-        )
-
-        daily_usage_storage = get_session_storage(svc.session_manager)
-        if daily_usage_storage is not None:
-            svc.daily_usage_telemetry_task = create_background_task(
-                run_daily_usage_upload_loop(
-                    daily_usage_storage,
-                    config=config,
-                )
-            )
-    except Exception:
-        log.debug("gateway.usage_telemetry_upload_skipped", exc_info=True)
+    startup_phase_started_at = _log_gateway_startup_phase(
+        "profile_recovery",
+        startup_started_at=startup_started_at,
+        phase_started_at=startup_phase_started_at,
+    )
 
     # Some embedding/tests provide a service-shaped object from an older
     # bootstrap contract.  Treat the ledger sink as an optional additive
@@ -4157,6 +4251,57 @@ async def start_gateway_server(
         shutdown_relay = _GatewayShutdownRelay()
         app.state.request_shutdown = shutdown_relay
         app.state.install_shutdown_handler = shutdown_relay.install
+    startup_phase_started_at = _log_gateway_startup_phase(
+        "app",
+        startup_started_at=startup_started_at,
+        phase_started_at=startup_phase_started_at,
+    )
+    listener_ready = False
+    runtime_state_ready = False
+    gateway_ready_phase_emitted = False
+    post_ready_observability_started = False
+    gateway_ready_wait_started_at = startup_phase_started_at
+
+    def _start_post_ready_observability() -> None:
+        nonlocal post_ready_observability_started
+        if post_ready_observability_started:
+            return
+        post_ready_observability_started = True
+
+        # Anonymous install telemetry is best-effort. Its daemon worker is
+        # never joined during shutdown, so a slow proxy cannot delay bind or
+        # exit. Daily usage keeps its existing owned/cancelled asyncio task.
+        _start_background_install_telemetry(config)
+        try:
+            from opensquilla.observability.usage_telemetry import (
+                run_daily_usage_upload_loop,
+            )
+
+            daily_usage_storage = get_session_storage(svc.session_manager)
+            if daily_usage_storage is not None:
+                svc.daily_usage_telemetry_task = create_background_task(
+                    run_daily_usage_upload_loop(
+                        daily_usage_storage,
+                        config=config,
+                    )
+                )
+        except Exception:
+            log.debug("gateway.usage_telemetry_upload_skipped", exc_info=True)
+
+    def _publish_gateway_ready_if_complete() -> None:
+        nonlocal gateway_ready_phase_emitted
+        if gateway_ready_phase_emitted or not listener_ready or not runtime_state_ready:
+            return
+        gateway_ready_phase_emitted = True
+        ready_at = time.monotonic()
+        log.info(
+            "gateway.startup_phase",
+            phase="gateway_ready",
+            status="ready",
+            duration_ms=_elapsed_monotonic_ms(gateway_ready_wait_started_at, ready_at),
+            startup_elapsed_ms=_elapsed_monotonic_ms(startup_started_at, ready_at),
+        )
+        _start_post_ready_observability()
 
     server_handle = GatewayServer(app=app, config=config)
     server_handle._pid_lock = _pid_lock
@@ -4211,11 +4356,34 @@ async def start_gateway_server(
                     category="listener_start_failed",
                 )
 
+        listener_scheduled_at = time.monotonic()
+        listener_phase_emitted = False
+
+        async def _notify_listener_ready() -> None:
+            nonlocal listener_phase_emitted, listener_ready
+            if listener_phase_emitted:
+                return
+            listener_phase_emitted = True
+            listener_ready = True
+            ready_at = time.monotonic()
+            log.info(
+                "gateway.startup_phase",
+                phase="listener",
+                status="ready",
+                duration_ms=_elapsed_monotonic_ms(listener_scheduled_at, ready_at),
+                startup_elapsed_ms=_elapsed_monotonic_ms(startup_started_at, ready_at),
+            )
+            _publish_gateway_ready_if_complete()
+
         uvicorn_kwargs: dict[str, Any] = {
             "app": app,
             "host": config.host,
             "port": config.port,
             "log_level": "info" if not config.debug else "debug",
+            # Uvicorn invokes this only after its socket server has been
+            # created. Keep the callback one-shot because callback_notify is
+            # also used for periodic worker health notifications.
+            "callback_notify": _notify_listener_ready,
             # Capability URLs and historical sessionKey query parameters are
             # bearer material. Keep request targets out of uvicorn's access
             # logger; structured gateway events remain available.
@@ -4238,6 +4406,7 @@ async def start_gateway_server(
         setattr(server, "install_signal_handlers", lambda: None)  # noqa: B010
         server_handle._server = server
 
+        listener_scheduled_at = time.monotonic()
         task = create_background_task(server.serve())
         server_handle._task = task
 
@@ -4282,6 +4451,17 @@ async def start_gateway_server(
         log.info("gateway.squilla_router_preload_skipped", reason="desktop_fast_start")
 
     app.state.gateway_ready = True
+    runtime_state_ready = True
+    _log_gateway_startup_phase(
+        "runtime_state",
+        startup_started_at=startup_started_at,
+        phase_started_at=startup_phase_started_at,
+    )
+    _publish_gateway_ready_if_complete()
+    if not run:
+        # Embedders/tests without a network listener still retain the existing
+        # telemetry lifecycle, but only after in-process readiness is visible.
+        _start_post_ready_observability()
     usage_storage = get_session_storage(svc.session_manager)
     if usage_storage is not None and hasattr(usage_storage, "get_usage_backfill_batch"):
         from opensquilla.gateway.usage_backfill import run_usage_backfill

--- a/src/opensquilla/observability/install_telemetry.py
+++ b/src/opensquilla/observability/install_telemetry.py
@@ -17,7 +17,10 @@ import re
 import socket
 import sys
 import tempfile
+import threading
 import uuid
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -45,6 +48,22 @@ _AUTO_SKIP_ENV_VARS = ("GITHUB_ACTIONS", "PYTEST_CURRENT_TEST", TELEMETRY_TESTIN
 _STABLE_INSTALL_ID_PREFIX = "opensquilla-install-v2"
 _STABLE_INSTALL_ID_SOURCES = {"stable-v2-mac", "stable-v2-ip"}
 _MAC_HEX_RE = re.compile(r"^[0-9a-f]{12}$")
+_COLLECT_LOCK = threading.Lock()
+_STATE_LOCK = threading.RLock()
+_STATE_TRANSACTION_TIMEOUT_SECONDS = 1.0
+
+
+@contextmanager
+def _state_transaction(path: Path) -> Iterator[None]:
+    """Serialize one short telemetry-state transaction across threads/processes."""
+    # Import lazily so merely importing telemetry during boot does not load the
+    # platform-specific lock implementation. The exact JSON path is the key, so
+    # this never contends with the long-lived profile-home operation lock.
+    from opensquilla.profile_operation_lock import ProfileOperationLock
+
+    with _STATE_LOCK:
+        with ProfileOperationLock(path, timeout=_STATE_TRANSACTION_TIMEOUT_SECONDS):
+            yield
 
 
 @dataclass(frozen=True)
@@ -83,52 +102,90 @@ def collect_install_telemetry(
             )
 
         current_version = (version or __version__ or "unknown").strip() or "unknown"
-        state = _load_or_create_state(path)
-        event = _next_event(state, current_version)
-        if event is None:
-            return InstallTelemetryResult(
-                state_path=path,
-                endpoint_configured=bool(endpoint),
-                skipped_reason="already_uploaded",
-            )
+        # Serialize install/version event selection, but do not hold the state
+        # lock across network I/O. Daily usage telemetry shares this state file
+        # for the anonymous install id and must remain free to read it.
+        with _COLLECT_LOCK:
+            with _state_transaction(path):
+                state = _load_or_create_state(path)
+                event = _next_event(state, current_version)
+                if event is None:
+                    return InstallTelemetryResult(
+                        state_path=path,
+                        endpoint_configured=bool(endpoint),
+                        skipped_reason="already_uploaded",
+                    )
 
-        if not endpoint:
-            state["last_skip_reason"] = "endpoint_empty"
-            _write_state(path, state)
+                if not endpoint:
+                    state["last_skip_reason"] = "endpoint_empty"
+                    _write_state(path, state)
+                    return InstallTelemetryResult(
+                        state_path=path,
+                        endpoint_configured=False,
+                        event=event,
+                        skipped_reason="endpoint_empty",
+                    )
+
+                now = _utc_now()
+                payload = _build_payload(
+                    state,
+                    event=event,
+                    current_version=current_version,
+                    sent_at=now,
+                )
+                skip_reason = _telemetry_skip_reason(config=config)
+                if skip_reason:
+                    return InstallTelemetryResult(
+                        state_path=path,
+                        endpoint_configured=True,
+                        disabled=True,
+                        event=event,
+                        skipped_reason=skip_reason,
+                    )
+                state["last_attempt_at"] = now
+                state["last_skip_reason"] = None
+                # Persist the selected install id before the background network
+                # call. A concurrent usage upload will then use the same id.
+                _write_state(path, state)
+
+            # The privacy setting is live-editable. Re-check at the last safe
+            # point before starting a new request; an already-entered socket
+            # operation cannot be recalled, but no later request should begin.
+            skip_reason = _telemetry_skip_reason(config=config)
+            if skip_reason:
+                return InstallTelemetryResult(
+                    state_path=path,
+                    endpoint_configured=True,
+                    disabled=True,
+                    event=event,
+                    skipped_reason=skip_reason,
+                )
+            uploaded, error = _post_payload(
+                endpoint,
+                payload,
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+            with _state_transaction(path):
+                # Merge the result into the latest state rather than overwriting
+                # another telemetry writer's atomic update.
+                state = _load_or_create_state(path)
+                if uploaded:
+                    state["last_success_at"] = now
+                    state["last_error"] = None
+                    state["uploaded_install"] = True
+                    _add_uploaded_version(state, current_version)
+                else:
+                    state["last_error"] = error or "upload_failed"
+                _write_state(path, state)
+
             return InstallTelemetryResult(
                 state_path=path,
-                endpoint_configured=False,
+                endpoint_configured=True,
                 event=event,
-                skipped_reason="endpoint_empty",
+                sent=True,
+                uploaded=uploaded,
+                error=error,
             )
-
-        now = _utc_now()
-        payload = _build_payload(
-            state,
-            event=event,
-            current_version=current_version,
-            sent_at=now,
-        )
-        state["last_attempt_at"] = now
-        state["last_skip_reason"] = None
-        uploaded, error = _post_payload(endpoint, payload, timeout=DEFAULT_TIMEOUT_SECONDS)
-        if uploaded:
-            state["last_success_at"] = now
-            state["last_error"] = None
-            state["uploaded_install"] = True
-            _add_uploaded_version(state, current_version)
-        else:
-            state["last_error"] = error or "upload_failed"
-
-        _write_state(path, state)
-        return InstallTelemetryResult(
-            state_path=path,
-            endpoint_configured=True,
-            event=event,
-            sent=True,
-            uploaded=uploaded,
-            error=error,
-        )
     except Exception as exc:  # pragma: no cover - defensive startup guard
         log.debug("Install telemetry skipped: %s", exc, exc_info=True)
         return InstallTelemetryResult(
@@ -137,6 +194,71 @@ def collect_install_telemetry(
             skipped_reason="error",
             error=str(exc),
         )
+
+
+def start_background_install_telemetry(
+    *,
+    config: Any | None = None,
+    state_path: str | Path | None = None,
+    version: str | None = None,
+    on_result: Callable[[InstallTelemetryResult], None] | None = None,
+) -> threading.Thread | None:
+    """Collect install telemetry in a daemon thread without delaying startup.
+
+    Privacy-disabled calls are resolved synchronously without creating state or
+    a thread. The returned thread exists only to let tests observe completion;
+    gateway shutdown deliberately never joins this best-effort worker.
+    """
+
+    def _notify_result(result: InstallTelemetryResult) -> None:
+        if on_result is None:
+            return
+        try:
+            on_result(result)
+        except Exception:  # pragma: no cover - caller diagnostic guard
+            log.debug("Install telemetry result callback failed", exc_info=True)
+
+    if _telemetry_skip_reason(config=config):
+        result = collect_install_telemetry(
+            config=config,
+            state_path=state_path,
+            version=version,
+        )
+        _notify_result(result)
+        return None
+
+    def _run() -> None:
+        result = collect_install_telemetry(
+            config=config,
+            state_path=state_path,
+            version=version,
+        )
+        _notify_result(result)
+
+    try:
+        thread = threading.Thread(
+            target=_run,
+            name="opensquilla-install-telemetry",
+            daemon=True,
+        )
+        thread.start()
+        return thread
+    except Exception:  # pragma: no cover - thread spawn failure
+        log.debug("Could not start install telemetry thread", exc_info=True)
+        return None
+
+
+def ensure_install_telemetry_id(
+    *,
+    config: Any | None = None,
+    state_path: str | Path | None = None,
+) -> str:
+    """Return and durably persist the shared anonymous install id."""
+    path = _state_path(config=config, explicit=state_path)
+    with _state_transaction(path):
+        state = _load_or_create_state(path)
+        _write_state(path, state)
+        return str(state["install_id"])
 
 
 def _state_path(*, config: Any | None, explicit: str | Path | None) -> Path:

--- a/src/opensquilla/observability/usage_telemetry.py
+++ b/src/opensquilla/observability/usage_telemetry.py
@@ -117,16 +117,24 @@ async def upload_pending_daily_usage(
     if not rows:
         return 0
 
-    state_path = install_telemetry._state_path(config=config, explicit=None)
-    state = install_telemetry._load_or_create_state(state_path)
-    install_telemetry._write_state(state_path, state)
+    install_id = await asyncio.to_thread(
+        install_telemetry.ensure_install_telemetry_id,
+        config=config,
+    )
+    if install_telemetry._telemetry_skip_reason(config=config) is not None:
+        return 0
+
     uploaded = 0
     for row in rows:
         payload = _daily_payload(
             row,
-            install_id=state["install_id"],
+            install_id=install_id,
             sent_at=_utc_now(),
         )
+        # The privacy flag is hot-reloadable. Do not start another request
+        # after an operator opts out while a multi-day batch is in flight.
+        if install_telemetry._telemetry_skip_reason(config=config) is not None:
+            break
         ok, error = await _post_payload(endpoint, payload)
         if not ok:
             log.debug("Daily usage telemetry upload failed: %s", error)

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -1097,6 +1097,7 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
     assert "test-primary-repair-accessibility.mjs" in run["run"]
     assert "test-profile-import-flow.mjs" in run["run"]
     assert "test-desktop-cleanup-flow.mjs" in run["run"]
+    assert "test-desktop-gateway-ownership.mjs" in run["run"]
     assert "test-unsafe-legacy-recovery-no-write.mjs" in run["run"]
     assert "exit 1" in run["run"]
     assert upload["if"] == "${{ always() }}"

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -682,8 +682,11 @@ def test_gateway_run_uses_config_host_port_when_flags_are_omitted(
         async def close(self, _reason):
             return None
 
-    async def fake_start_gateway_server(*, config, subscription_manager, run):
+    async def fake_start_gateway_server(
+        *, config, subscription_manager, run, _startup_started_at
+    ):
         captured["config"] = config
+        captured["startup_started_at"] = _startup_started_at
 
         async def done():
             return None
@@ -705,6 +708,7 @@ def test_gateway_run_uses_config_host_port_when_flags_are_omitted(
 
     assert captured["config"].host == "127.0.0.2"
     assert captured["config"].port == 19999
+    assert isinstance(captured["startup_started_at"], float)
 
 
 def test_gateway_run_records_cli_flags_as_runtime_overrides(
@@ -724,7 +728,9 @@ def test_gateway_run_records_cli_flags_as_runtime_overrides(
         async def close(self, _reason):
             return None
 
-    async def fake_start_gateway_server(*, config, subscription_manager, run):
+    async def fake_start_gateway_server(
+        *, config, subscription_manager, run, _startup_started_at
+    ):
         captured["config"] = config
 
         async def done():
@@ -769,7 +775,9 @@ def test_gateway_run_flags_do_not_leak_into_config_via_unrelated_persist(
         async def close(self, _reason):
             return None
 
-    async def fake_start_gateway_server(*, config, subscription_manager, run):
+    async def fake_start_gateway_server(
+        *, config, subscription_manager, run, _startup_started_at
+    ):
         captured["config"] = config
 
         async def done():
@@ -827,7 +835,9 @@ def test_gateway_run_keeps_missing_explicit_config_path_for_setup(
         async def close(self, _reason):
             return None
 
-    async def fake_start_gateway_server(*, config, subscription_manager, run):
+    async def fake_start_gateway_server(
+        *, config, subscription_manager, run, _startup_started_at
+    ):
         captured["config"] = config
 
         async def done():
@@ -1169,7 +1179,7 @@ class _ShutdownProbeServer:
 
 
 def _install_fake_start(server, holder, monkeypatch) -> None:
-    async def fake_start(*, config, subscription_manager, run):
+    async def fake_start(*, config, subscription_manager, run, _startup_started_at):
         server.spawn()
         holder["server"] = server
         return server

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -1125,10 +1125,11 @@ def test_desktop_recovers_only_cryptographically_verified_orphan_gateway() -> No
     start = _section(main_ts, "async function startGateway", "async function loadControlUi")
 
     assert "loadDesktopGatewayOwnershipRecord(ownershipDir)" in recovery
-    assert "record.profile_fingerprint !== desktopProfileFingerprint(profile.home)" in recovery
-    assert "await verifyDesktopGatewayOwnershipWhenReady(ownershipDir, record)" in recovery
-    assert "await requestVerifiedDesktopGatewayShutdown(record)" in recovery
-    assert "await waitForDesktopGatewayOwnershipRelease(ownershipDir, record" in recovery
+    assert "runRecovery(ownershipDir, record" in recovery
+    assert "current.profile_fingerprint !== desktopProfileFingerprint(profile.home)" in recovery
+    assert "await verifyDesktopGatewayOwnershipWhenReady(ownershipDir, current)" in recovery
+    assert "await requestVerifiedDesktopGatewayShutdown(current)" in recovery
+    assert "await waitForDesktopGatewayOwnershipRelease(ownershipDir, current" in recovery
     assert "process.kill(" not in recovery
     assert "hardTerminateGatewayProcess(" not in recovery
     assert "unlink(" not in recovery
@@ -1159,9 +1160,9 @@ def test_unverified_or_legacy_gateway_record_never_grants_stop_authority() -> No
     )
 
     verification = recovery.index(
-        "if (!await verifyDesktopGatewayOwnershipWhenReady(ownershipDir, record))"
+        "if (!await verifyDesktopGatewayOwnershipWhenReady(ownershipDir, current))"
     )
-    shutdown = recovery.index("requestVerifiedDesktopGatewayShutdown(record)")
+    shutdown = recovery.index("requestVerifiedDesktopGatewayShutdown(current)")
     assert verification < shutdown
     assert "gateway_ownership_record_untrusted" in recovery
     assert "gateway_ownership_not_verified" in recovery

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -76,6 +76,97 @@ def test_gateway_boot_bridges_compaction_notifications_to_session_stream() -> No
     assert "_compaction_listener_remove" in source
 
 
+def test_gateway_startup_phase_log_uses_bounded_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.gateway import boot
+
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    class FakeLog:
+        def info(self, event: str, **kwargs: Any) -> None:
+            events.append((event, kwargs))
+
+    monkeypatch.setattr(boot, "log", FakeLog())
+    ticks = iter((12.5, 12.75))
+    monkeypatch.setattr(boot.time, "monotonic", lambda: next(ticks))
+
+    completed_at = boot._log_gateway_startup_phase(
+        "services",
+        startup_started_at=10.0,
+        phase_started_at=11.5,
+    )
+
+    assert completed_at == 12.75
+    assert events == [
+        (
+            "gateway.startup_phase",
+            {
+                "phase": "services",
+                "status": "ready",
+                "duration_ms": 1000,
+                "startup_elapsed_ms": 2500,
+            },
+        )
+    ]
+
+
+def test_uvicorn_listener_callback_observes_a_real_bound_socket() -> None:
+    import httpx
+    import uvicorn
+
+    async def run_case() -> None:
+        callback_called = asyncio.Event()
+        callback_ports: list[int] = []
+        server: uvicorn.Server
+
+        async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+            assert scope["type"] == "http"
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 204,
+                    "headers": [],
+                }
+            )
+            await send({"type": "http.response.body", "body": b""})
+
+        async def listener_ready() -> None:
+            assert server.started is True
+            assert server.servers
+            sockets = server.servers[0].sockets
+            assert sockets
+            callback_ports.append(int(sockets[0].getsockname()[1]))
+            callback_called.set()
+
+        config = uvicorn.Config(
+            app=app,
+            host="127.0.0.1",
+            port=0,
+            lifespan="off",
+            access_log=False,
+            log_level="warning",
+            callback_notify=listener_ready,
+        )
+        server = uvicorn.Server(config)
+        setattr(server, "install_signal_handlers", lambda: None)
+        task = asyncio.create_task(server.serve())
+        try:
+            await asyncio.wait_for(callback_called.wait(), timeout=5)
+            assert len(callback_ports) == 1
+            async with httpx.AsyncClient(trust_env=False) as client:
+                response = await client.get(
+                    f"http://127.0.0.1:{callback_ports[0]}/healthz",
+                    timeout=5,
+                )
+            assert response.status_code == 204
+        finally:
+            server.should_exit = True
+            await asyncio.wait_for(task, timeout=5)
+
+    asyncio.run(run_case())
+
+
 def test_task_runtime_default_hard_deadline_is_unbounded() -> None:
     config = GatewayConfig()
 
@@ -133,6 +224,11 @@ def test_start_gateway_server_releases_pid_lock_when_build_services_fails(
         events.append("build_services")
         raise RuntimeError("service construction failed")
 
+    monkeypatch.setattr(
+        boot,
+        "_start_background_install_telemetry",
+        lambda config: events.append("install_telemetry"),
+    )
     monkeypatch.setattr(boot, "build_services", fail_build_services)
     monkeypatch.setattr(boot, "_setup_file_logging", lambda config: None)
     monkeypatch.setattr(boot, "emit_skill_filter_banner", lambda config: None)
@@ -160,20 +256,29 @@ def test_start_gateway_server_releases_pid_lock_when_build_services_fails(
     asyncio.run(run_case())
 
 
-def test_start_gateway_server_logs_install_telemetry_without_structlog_event_collision(
+def test_start_gateway_server_starts_telemetry_after_listener_and_runtime_are_ready(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from opensquilla.gateway import boot
 
     debug_logs: list[tuple[str, dict[str, Any]]] = []
+    call_order: list[str] = []
+    app_holder: dict[str, Any] = {}
 
     class FakeLog:
         def debug(self, event: str, **kwargs: Any) -> None:
             debug_logs.append((event, kwargs))
 
-        def info(self, _event: str, **_kwargs: Any) -> None:
-            return None
+        def info(self, event: str, **kwargs: Any) -> None:
+            if event != "gateway.startup_phase":
+                return
+            phase = kwargs.get("phase")
+            if phase == "runtime_state":
+                assert app_holder["app"].state.gateway_ready is True
+                call_order.append("runtime_state")
+            elif phase in {"listener", "gateway_ready"}:
+                call_order.append(str(phase))
 
         def warning(self, _event: str, **_kwargs: Any) -> None:
             return None
@@ -185,7 +290,17 @@ def test_start_gateway_server_logs_install_telemetry_without_structlog_event_col
         def set_session_lock_provider(self, _provider: Any) -> None:
             return None
 
+    class FakeUvicornServer:
+        def __init__(self, config: Any) -> None:
+            self.config = config
+            self.should_exit = False
+
+        async def serve(self) -> None:
+            call_order.append("listener_callback")
+            await self.config.callback_notify()
+
     async def fake_build_services(**kwargs: Any) -> Any:
+        call_order.append("build_services")
         config = kwargs["config"]
 
         async def close() -> None:
@@ -212,23 +327,55 @@ def test_start_gateway_server_logs_install_telemetry_without_structlog_event_col
             close=close,
         )
 
-    def fake_collect_install_telemetry(*, config: GatewayConfig) -> Any:
-        return SimpleNamespace(
-            skipped_reason=None,
-            event="install",
-            sent=True,
-            uploaded=False,
-            endpoint_configured=True,
+    def fake_start_background_install_telemetry(
+        *,
+        config: GatewayConfig,
+        on_result: Any,
+    ) -> None:
+        assert app_holder["app"].state.gateway_ready is True
+        call_order.append("install_telemetry")
+        on_result(
+            SimpleNamespace(
+                skipped_reason=None,
+                event="install",
+                sent=True,
+                uploaded=False,
+                endpoint_configured=True,
+            )
         )
+
+    def fake_daily_usage_loop(storage: Any, *, config: GatewayConfig) -> Any:
+        assert app_holder["app"].state.gateway_ready is True
+        call_order.append("daily_usage")
+
+        async def complete() -> None:
+            return None
+
+        return complete()
+
+    real_create_gateway_app = boot.create_gateway_app
+
+    def capture_gateway_app(*args: Any, **kwargs: Any) -> Any:
+        app = real_create_gateway_app(*args, **kwargs)
+        app_holder["app"] = app
+        return app
 
     monkeypatch.setattr(boot, "log", FakeLog())
     monkeypatch.setattr("opensquilla.engine.runtime.TurnRunner", FakeTurnRunner)
     monkeypatch.setattr(boot, "build_services", fake_build_services)
+    monkeypatch.setattr(boot, "create_gateway_app", capture_gateway_app)
+    monkeypatch.setattr(boot, "get_session_storage", lambda manager: object())
+    monkeypatch.setattr(boot.uvicorn, "Server", FakeUvicornServer)
+    monkeypatch.setattr(boot, "_desktop_router_preload_enabled", lambda: False)
     monkeypatch.setattr(boot, "_setup_file_logging", lambda config: None)
     monkeypatch.setattr(boot, "emit_skill_filter_banner", lambda config: None)
     monkeypatch.setattr(
-        "opensquilla.observability.install_telemetry.collect_install_telemetry",
-        fake_collect_install_telemetry,
+        "opensquilla.observability.install_telemetry.start_background_install_telemetry",
+        fake_start_background_install_telemetry,
+    )
+    monkeypatch.setattr(
+        "opensquilla.observability.usage_telemetry.run_daily_usage_upload_loop",
+        fake_daily_usage_loop,
     )
     monkeypatch.setattr(
         "opensquilla.gateway.pidlock.GatewayPidLock.acquire",
@@ -246,9 +393,11 @@ def test_start_gateway_server_logs_install_telemetry_without_structlog_event_col
     )
 
     async def run_case() -> None:
-        server = await boot.start_gateway_server(config=config, run=False)
+        server = await boot.start_gateway_server(config=config, run=True)
 
         try:
+            assert call_order == ["build_services", "runtime_state"]
+            await asyncio.sleep(0)
             telemetry_logs = [
                 kwargs for event, kwargs in debug_logs if event == "gateway.install_telemetry"
             ]
@@ -258,6 +407,15 @@ def test_start_gateway_server_logs_install_telemetry_without_structlog_event_col
             assert "gateway.install_telemetry_skipped" not in {
                 event for event, _kwargs in debug_logs
             }
+            assert call_order == [
+                "build_services",
+                "runtime_state",
+                "listener_callback",
+                "listener",
+                "gateway_ready",
+                "install_telemetry",
+                "daily_usage",
+            ]
         finally:
             await server.close()
 
@@ -1312,6 +1470,7 @@ def test_start_gateway_server_passes_tls_files_to_uvicorn(
             assert captured_config["ssl_keyfile"] == keyfile
             assert captured_config["ssl_certfile"] == certfile
             assert captured_config["access_log"] is False
+            assert callable(captured_config["callback_notify"])
         finally:
             await server.close()
 

--- a/tests/test_observability/test_install_telemetry.py
+++ b/tests/test_observability/test_install_telemetry.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
+import time
 from pathlib import Path
+from threading import Event
 from types import SimpleNamespace
 from typing import Any
 
@@ -212,6 +217,43 @@ def test_privacy_config_disable_skips_without_creating_state(tmp_path, monkeypat
     assert not state_path.exists()
 
 
+def test_hot_privacy_opt_out_before_post_starts_no_request(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    _set_stable_sources(monkeypatch, macs=["02:00:00:00:00:11"])
+    state_path = tmp_path / "install_telemetry.json"
+    config = SimpleNamespace(
+        privacy=SimpleNamespace(disable_network_observability=False),
+    )
+    original_build_payload = telemetry._build_payload
+    post_calls = 0
+
+    def build_payload(*args, **kwargs):
+        payload = original_build_payload(*args, **kwargs)
+        config.privacy.disable_network_observability = True
+        return payload
+
+    def unexpected_post(*args, **kwargs):
+        nonlocal post_calls
+        post_calls += 1
+        return True, None
+
+    monkeypatch.setattr(telemetry, "_build_payload", build_payload)
+    monkeypatch.setattr(telemetry, "_post_payload", unexpected_post)
+
+    result = telemetry.collect_install_telemetry(
+        config=config,
+        state_path=state_path,
+        version="1.0.0",
+    )
+
+    assert result.disabled is True
+    assert result.sent is False
+    assert result.skipped_reason == "disabled"
+    assert post_calls == 0
+    assert not state_path.exists()
+
+
 def test_github_actions_env_skips_without_creating_state(tmp_path, monkeypatch):
     _enable_telemetry_for_test(monkeypatch)
     monkeypatch.setenv("GITHUB_ACTIONS", "true")
@@ -397,3 +439,212 @@ def test_loopback_endpoint_host_does_not_influence_install_id(tmp_path, monkeypa
     expected = telemetry._stable_install_id("ip", ["10.0.0.9"])
     assert _load(state_path)["install_id"] == expected
     assert calls[0]["install_id"] == expected
+
+
+def test_background_collection_does_not_wait_for_blocked_post_and_preserves_state(
+    tmp_path,
+    monkeypatch,
+):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    _set_stable_sources(monkeypatch, macs=["02:00:00:00:00:10"])
+    state_path = tmp_path / "install_telemetry.json"
+    post_started = Event()
+    release_post = Event()
+    payloads: list[dict[str, Any]] = []
+    results: list[telemetry.InstallTelemetryResult] = []
+
+    def blocking_post(
+        endpoint: str,
+        payload: dict[str, Any],
+        *,
+        timeout: float,
+    ) -> tuple[bool, str | None]:
+        payloads.append(payload)
+        post_started.set()
+        if not release_post.wait(timeout=2):
+            return False, "test_release_timeout"
+        return True, None
+
+    monkeypatch.setattr(telemetry, "_post_payload", blocking_post)
+    thread = telemetry.start_background_install_telemetry(
+        state_path=state_path,
+        version="1.0.0",
+        on_result=results.append,
+    )
+    try:
+        assert thread is not None
+        assert thread.daemon is True
+        assert post_started.wait(timeout=1)
+        assert thread.is_alive()
+
+        # The worker persisted its install id before entering network I/O, so a
+        # concurrent usage uploader sees the same id and valid JSON.
+        install_id = telemetry.ensure_install_telemetry_id(state_path=state_path)
+        assert install_id == payloads[0]["install_id"]
+        assert _load(state_path)["install_id"] == install_id
+    finally:
+        release_post.set()
+        if thread is not None:
+            thread.join(timeout=2)
+
+    assert thread is not None and not thread.is_alive()
+    assert len(results) == 1
+    assert results[0].uploaded is True
+    state = _load(state_path)
+    assert state["uploaded_install"] is True
+    assert state["uploaded_versions"] == ["1.0.0"]
+
+
+def test_background_collection_honors_privacy_without_thread_or_state(
+    tmp_path,
+    monkeypatch,
+):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    state_path = tmp_path / "install_telemetry.json"
+    config = SimpleNamespace(
+        privacy=SimpleNamespace(disable_network_observability=True),
+    )
+    results: list[telemetry.InstallTelemetryResult] = []
+    post_calls = 0
+
+    def unexpected_post(*args, **kwargs):
+        nonlocal post_calls
+        post_calls += 1
+        return True, None
+
+    monkeypatch.setattr(telemetry, "_post_payload", unexpected_post)
+    thread = telemetry.start_background_install_telemetry(
+        config=config,
+        state_path=state_path,
+        version="1.0.0",
+        on_result=results.append,
+    )
+
+    assert thread is None
+    assert post_calls == 0
+    assert not state_path.exists()
+    assert len(results) == 1
+    assert results[0].disabled is True
+    assert results[0].skipped_reason == "disabled"
+
+
+def test_concurrent_process_results_merge_without_holding_lock_across_network(
+    tmp_path,
+    monkeypatch,
+):
+    _enable_telemetry_for_test(monkeypatch)
+    state_path = tmp_path / "state" / "install_telemetry.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "install_id": "synthetic-install-id",
+                "install_id_source": "stable-v2-mac",
+                "first_seen_at": "2026-01-01T00:00:00Z",
+                "uploaded_install": True,
+                "uploaded_versions": ["0.9.0"],
+                "future_field": {"preserve": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_TEST_PROFILE_LOCK_ROOT", "1")
+    monkeypatch.setenv("OPENSQUILLA_USER_STATE_DIR", str(tmp_path / "lock-state"))
+    from opensquilla.profile_operation_lock import ProfileOperationLock
+
+    # Seed the stable lock inode before the workers race. ProfileOperationLock
+    # deliberately fails closed if two untrusted paths race first creation;
+    # the daemon/restart overlap modelled here starts after an earlier collector
+    # has already established this exact telemetry lock.
+    with ProfileOperationLock(state_path):
+        pass
+
+    go_path = tmp_path / "go"
+    ready_paths = [tmp_path / "ready-a", tmp_path / "ready-b"]
+    worker_source = """
+import json
+import sys
+import time
+from pathlib import Path
+
+from opensquilla.observability import install_telemetry as telemetry
+
+state_path = Path(sys.argv[1])
+ready_path = Path(sys.argv[2])
+go_path = Path(sys.argv[3])
+version = sys.argv[4]
+
+def blocked_post(endpoint, payload, *, timeout):
+    ready_path.write_text("ready", encoding="utf-8")
+    deadline = time.monotonic() + 10
+    while not go_path.exists():
+        if time.monotonic() >= deadline:
+            return False, "barrier_timeout"
+        time.sleep(0.01)
+    return True, None
+
+telemetry._post_payload = blocked_post
+result = telemetry.collect_install_telemetry(
+    state_path=state_path,
+    version=version,
+)
+print(json.dumps({"uploaded": result.uploaded, "error": result.error}))
+"""
+    env = os.environ.copy()
+    env[telemetry.TELEMETRY_ENDPOINT_ENV] = TEST_ENDPOINT
+    workers = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                worker_source,
+                str(state_path),
+                str(ready_path),
+                str(go_path),
+                version,
+            ],
+            cwd=str(Path(__file__).resolve().parents[2]),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for ready_path, version in zip(
+            ready_paths,
+            ("1.0.0", "2.0.0"),
+            strict=True,
+        )
+    ]
+    outputs: list[tuple[str, str]] = []
+    try:
+        deadline = time.monotonic() + 10
+        while not all(path.exists() for path in ready_paths):
+            for worker in workers:
+                if worker.poll() is not None:
+                    stdout, stderr = worker.communicate()
+                    raise AssertionError(
+                        "telemetry worker exited before the network barrier: "
+                        f"rc={worker.returncode}, stdout={stdout!r}, stderr={stderr!r}"
+                    )
+            if time.monotonic() >= deadline:
+                raise AssertionError("both workers must reach the network barrier")
+            time.sleep(0.01)
+        # Both workers reaching this barrier proves the process lock is not held
+        # across the simulated network operation.
+        go_path.write_text("go", encoding="utf-8")
+        outputs = [worker.communicate(timeout=10) for worker in workers]
+    finally:
+        for worker in workers:
+            if worker.poll() is None:
+                worker.terminate()
+                worker.wait(timeout=5)
+
+    for worker, (stdout, stderr) in zip(workers, outputs, strict=True):
+        assert worker.returncode == 0, stderr
+        assert json.loads(stdout)["uploaded"] is True
+    state = _load(state_path)
+    assert set(state["uploaded_versions"]) == {"0.9.0", "1.0.0", "2.0.0"}
+    assert state["future_field"] == {"preserve": True}

--- a/tests/test_observability/test_usage_telemetry.py
+++ b/tests/test_observability/test_usage_telemetry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from datetime import UTC, date, datetime
 from types import SimpleNamespace
 from typing import Any
@@ -214,6 +215,142 @@ async def test_uploads_only_completed_days_and_marks_success(tmp_path, monkeypat
         assert await storage.list_pending_daily_usage(before_day="2026-07-22") == []
     finally:
         await storage.close()
+
+
+async def test_install_id_resolution_runs_off_the_event_loop(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv(
+        usage_telemetry.USAGE_TELEMETRY_ENDPOINT_ENV,
+        "https://example.test/v1/usage",
+    )
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    await storage.record_daily_usage(
+        day="2026-07-19",
+        input_tokens=1,
+        output_tokens=1,
+        cached_tokens=0,
+        cache_write_tokens=0,
+        updated_at=1,
+    )
+    event_loop_thread = threading.get_ident()
+    resolver_threads: list[int] = []
+
+    def fake_install_id(*, config: Any) -> str:
+        resolver_threads.append(threading.get_ident())
+        return "stable-test-install-id"
+
+    async def fake_post(endpoint: str, payload: dict[str, Any]):
+        return True, None
+
+    monkeypatch.setattr(install_telemetry, "ensure_install_telemetry_id", fake_install_id)
+    monkeypatch.setattr(usage_telemetry, "_post_payload", fake_post)
+    try:
+        assert (
+            await usage_telemetry.upload_pending_daily_usage(
+                storage,
+                config=_config(tmp_path),
+                today=date(2026, 7, 20),
+            )
+            == 1
+        )
+    finally:
+        await storage.close()
+
+    assert len(resolver_threads) == 1
+    assert resolver_threads[0] != event_loop_thread
+
+
+async def test_hot_opt_out_during_install_id_resolution_starts_no_request(
+    tmp_path,
+    monkeypatch,
+):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv(
+        usage_telemetry.USAGE_TELEMETRY_ENDPOINT_ENV,
+        "https://example.test/v1/usage",
+    )
+    config = _config(tmp_path)
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    await storage.record_daily_usage(
+        day="2026-07-19",
+        input_tokens=1,
+        output_tokens=1,
+        cached_tokens=0,
+        cache_write_tokens=0,
+        updated_at=1,
+    )
+    post_calls = 0
+
+    def disable_while_resolving(*, config: Any) -> str:
+        config.privacy.disable_network_observability = True
+        return "stable-test-install-id"
+
+    async def unexpected_post(endpoint: str, payload: dict[str, Any]):
+        nonlocal post_calls
+        post_calls += 1
+        return True, None
+
+    monkeypatch.setattr(
+        install_telemetry,
+        "ensure_install_telemetry_id",
+        disable_while_resolving,
+    )
+    monkeypatch.setattr(usage_telemetry, "_post_payload", unexpected_post)
+    try:
+        assert (
+            await usage_telemetry.upload_pending_daily_usage(
+                storage,
+                config=config,
+                today=date(2026, 7, 20),
+            )
+            == 0
+        )
+    finally:
+        await storage.close()
+
+    assert post_calls == 0
+
+
+async def test_hot_opt_out_stops_remaining_daily_requests(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv(
+        usage_telemetry.USAGE_TELEMETRY_ENDPOINT_ENV,
+        "https://example.test/v1/usage",
+    )
+    config = _config(tmp_path)
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    for day in ("2026-07-19", "2026-07-20"):
+        await storage.record_daily_usage(
+            day=day,
+            input_tokens=1,
+            output_tokens=1,
+            cached_tokens=0,
+            cache_write_tokens=0,
+            updated_at=1,
+        )
+    posted_days: list[str] = []
+
+    async def post_then_disable(endpoint: str, payload: dict[str, Any]):
+        posted_days.append(str(payload["day"]))
+        config.privacy.disable_network_observability = True
+        return True, None
+
+    monkeypatch.setattr(usage_telemetry, "_post_payload", post_then_disable)
+    try:
+        assert (
+            await usage_telemetry.upload_pending_daily_usage(
+                storage,
+                config=config,
+                today=date(2026, 7, 21),
+            )
+            == 1
+        )
+        pending = await storage.list_pending_daily_usage(before_day="2026-07-21")
+    finally:
+        await storage.close()
+
+    assert posted_days == ["2026-07-19"]
+    assert [row["day"] for row in pending] == ["2026-07-20"]
 
 
 async def test_new_turn_keeps_snapshot_pending_when_upload_is_in_flight(tmp_path, monkeypatch):


### PR DESCRIPTION
## Scope

- Share one bounded readiness deadline across repeated Desktop checks for the same exact ownership record, while preserving fresh HMAC/liveness verification and exact-record shutdown authority.
- Start install and daily-usage telemetry only after the real Uvicorn listener and runtime state are ready, and add bounded startup/MCP phase timings.
- Make telemetry state read-modify-write operations safe across threads and processes, preserve unknown fields, and recheck live privacy opt-out immediately before network requests.
- Run the Desktop ownership regression script natively on Ubuntu, macOS, and Windows.

Base: `main`

Linked issue: None

Release note: Yes — prevents potentially multi-minute Desktop Gateway startup stalls.

## Validation

- `npm run test:gateway-ownership` — passed
- `npm run test:gateway-orphan-recovery-flow` — passed with a real orphan/replacement process
- `npm run test:gateway-lifecycle` — passed
- `.venv/bin/pytest -q tests/test_observability tests/test_gateway/test_router_boot.py tests/test_cli/test_gateway_cmd.py tests/test_ci/test_workflows.py tests/test_desktop/test_electron_startup_contract.py` — 473 passed
- `.venv/bin/pytest -q tests/test_gateway` — 2415 passed, 10 skipped
- `.venv/bin/pytest -q tests/test_observability` — 178 passed
- `uv run ruff check src tests` — passed
- `uv run mypy src/opensquilla --show-error-codes` — passed (882 source files)
- `actionlint .github/workflows/ci.yml` — passed
- `uv build --wheel` — passed
- Real loopback telemetry blackhole: `/health` returned 200 in 9 ms while the telemetry connection remained blocked.
- Scaled real ownership reproduction (1.5 s timeout): repeated startup checks fell from 4534 ms to 1631 ms, corresponding to roughly three timeout windows becoming one shared window.

A full `pytest tests` run was also attempted locally. It reached 906 passed and 43 skipped before being stopped after 11 unrelated real-terminal TUI failures; the local checkout lacks the optional `@opentui/core` host dependency, and the resulting tmux sessions exited. All impacted suites above pass.

## Safety and compatibility

- No public config key, CLI flag, RPC/protocol field, database schema, or telemetry JSON schema changes.
- Ownership authorization remains tied to the exact persisted record and requires a fresh HMAC challenge; authority is never cached or inferred from PID/port alone.
- The existing `gateway.started` event remains in place for compatibility.
- Telemetry network I/O never holds the state lock, and live opt-out prevents new requests.
- The best-effort install telemetry daemon is intentionally not joined, so a fast process exit may abandon an upload instead of reintroducing startup or shutdown stalls.
- Existing config/state remains accepted and unknown telemetry JSON fields are preserved.
- The changes were reviewed for Windows, macOS, and Linux behavior; native ownership coverage now runs in the three-platform CI matrix.

## Review

Independent final review found no P0 or P1 issues. The only accepted P2 tradeoff is the intentionally unjoined best-effort telemetry daemon described above.

## Third-party origin

None. The implementation and tests are repository-native.