### PR TITLE
Prepare OpenSquilla 0.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-07-30
+
+### Added
+
+- Versioned same-turn steering now works consistently across the Web UI, CLI,
+  Gateway, and shared runtime for supported single-model and router turns.
+  Accepted input is idempotent and survives reconnects and eligible provider
+  fallback without rerouting the logical turn; older clients and gateways keep
+  their legacy or visible queue compatibility paths.
+
+### Fixed
+
+- Desktop and Gateway startup no longer wait on unnecessary recovery scans,
+  legacy-recovery maintenance, repeated ownership readiness windows, or
+  historical usage backfill.
+- Retained session history loads independently from interactive controls, so
+  navigation, controls, existing messages, and message sending remain usable
+  during hydration and recovery.
+- Recovery consolidation preserves historical usage for deduplicated sessions,
+  and usage backfill uses smaller transactions with bounded SQLite contention
+  handling.
+- Windows Desktop validates the Electron profile marker for sandbox setup, and
+  the macOS project picker supports folder creation, system-localized text, and
+  the intended initial directory.
+- Desktop HTML artifacts render when their native preview surface appears, and
+  preview mode switches no longer require an extra confirmation or overwrite
+  the saved default.
+- Custom compatible providers expose their Base URL fields again, the Usage
+  currency toggle applies consistently, and provider/usage presentation avoids
+  clipped or ambiguous actions.
+- Model Ensemble activity timing remains stable across generic channel
+  heartbeats, and the Desktop startup loader rotates in the expected direction.
+
 ## [0.5.1] - 2026-07-29
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,6 +26,17 @@ trailers.
 | [@ab2ence](https://github.com/ab2ence) | macOS Seatbelt backend execution, denial escalation, and release-candidate type-check cleanup. | [#46](https://github.com/opensquilla/opensquilla/pull/46), [`fb1e6225`](https://github.com/opensquilla/opensquilla/pull/46/commits/fb1e6225e4db9cb0801ea347a89c2066e3e0601b), [`f73ac3eb`](https://github.com/opensquilla/opensquilla/pull/46/commits/f73ac3eb0044c64c79cfd18f9ec03d1bba9128ff), [`cf3b046f`](https://github.com/opensquilla/opensquilla/pull/46/commits/cf3b046f42a42efc951320b0af80e9d066dcf7d2) |
 | [@kimjune01](https://github.com/kimjune01) | Provider stream timeout cleanup fix that prevents double-closing provider streams. | [#46](https://github.com/opensquilla/opensquilla/pull/46), [`06e3126d`](https://github.com/opensquilla/opensquilla/pull/46/commits/06e3126d8ebda4ad4cf349ca7be0d0804e0c008d) |
 
+## OpenSquilla 0.5.2
+
+The 0.5.2 maintenance release records new human contributor work after the
+0.5.1 stable release.
+
+| Contributor | 0.5.2 contribution | Evidence |
+| --- | --- | --- |
+| [@jiaoqingrui](https://github.com/jiaoqingrui) | Improved Desktop and Gateway startup, recovery and historical usage reliability, activity timing, custom-provider settings, and Windows sandbox setup. | [#877](https://github.com/opensquilla/opensquilla/pull/877), [#882](https://github.com/opensquilla/opensquilla/pull/882), [#884](https://github.com/opensquilla/opensquilla/pull/884), [#886](https://github.com/opensquilla/opensquilla/pull/886), [#890](https://github.com/opensquilla/opensquilla/pull/890), [#891](https://github.com/opensquilla/opensquilla/pull/891), [#897](https://github.com/opensquilla/opensquilla/pull/897), [#903](https://github.com/opensquilla/opensquilla/pull/903) |
+| [@Liu-RK](https://github.com/Liu-RK) | Brought the Desktop project picker into parity with the Web picker. | [#887](https://github.com/opensquilla/opensquilla/pull/887) |
+| [@joyfan621-png](https://github.com/joyfan621-png) | Improved provider onboarding and assistant usage presentation. | [#901](https://github.com/opensquilla/opensquilla/pull/901) |
+
 ## OpenSquilla 0.5.1
 
 The 0.5.1 maintenance release records new human contributor work after the

--- a/README.de.md
+++ b/README.de.md
@@ -49,7 +49,7 @@ Provider-Schicht spricht mit TokenRhythm, OpenRouter, OpenAI, Anthropic, Ollama,
 DeepSeek, Gemini, Qwen/DashScope und über 20 weiteren LLM-Providern —
 ohne Änderung an deinem Code oder deinem Konfigurationsschema.
 
-OpenSquilla 0.5.1 ist die aktuelle stabile Version.
+OpenSquilla 0.5.2 ist die aktuelle stabile Version.
 
 Für aufgabenorientierte Produktdokumentation beginnst du am besten mit
 dem [OpenSquilla-Produktleitfaden](README.product.md) oder dem
@@ -75,10 +75,10 @@ Python-Wheel-Installationen verwenden versionsbehaftete Wheel-Dateinamen,
 weil die Installationsprogramme die im Wheel-Dateinamen eingebettete
 Version prüfen.
 
-Für den Desktop-Einsatz von 0.5.1 bevorzugst du die gepackten
+Für den Desktop-Einsatz von 0.5.2 bevorzugst du die gepackten
 Desktop-Installationsprogramme aus dem GitHub-Release:
-`OpenSquilla-0.5.1-mac-arm64.dmg` unter macOS und
-`OpenSquilla-0.5.1-win-x64.exe` unter Windows.
+`OpenSquilla-0.5.2-mac-arm64.dmg` unter macOS und
+`OpenSquilla-0.5.2-win-x64.exe` unter Windows.
 
 | Weg | Zielgruppe | Wann verwenden |
 | --- | --- | --- |
@@ -129,11 +129,11 @@ Installationslinks: [Git](https://git-scm.com/downloads) ·
 
 ### Desktop-Installationsprogramme
 
-Die 0.5.0-Preview-4-Desktop-Installationsprogramme bündeln die Vue-Steuerkonsole
+Die 0.5.2-Desktop-Installationsprogramme bündeln die Vue-Steuerkonsole
 und die Gateway-Runtime in einer Electron-Hülle.
 
-- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg>
-- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe>
+- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-mac-arm64.dmg>
+- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-win-x64.exe>
 
 Für schnellere Downloads in Festlandchina verwende die direkten OSS-Download-Aliasse:
 - macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -183,7 +183,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. OpenSquilla installieren** — derselbe Befehl auf jeder Plattform.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl"
 ```
 
 Damit wird das OpenSquilla-Wheel von der Release-URL installiert;
@@ -211,7 +211,7 @@ opensquilla gateway run
 
 Für eine vollständig festgelegte Installation verwende die
 versionsbehaftete Wheel-URL:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl`.
 
 <a id="install-from-source"></a>
 

--- a/README.es.md
+++ b/README.es.md
@@ -40,7 +40,7 @@ OpenSquilla es un agente de IA con microkernel y eficiente en el uso de tokens. 
 
 Cada punto de entrada —Web UI, CLI y canales de chat— se ejecuta a través de ese mismo bucle, de modo que el envío de herramientas, los reintentos y el registro de decisiones se comportan de forma idéntica en todas partes. Una capa de proveedores conectable se comunica con TokenRhythm, OpenRouter, OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope y más de 20 proveedores de LLM adicionales, sin ningún cambio en tu código ni en el esquema de configuración.
 
-OpenSquilla 0.5.1 es la versión estable actual.
+OpenSquilla 0.5.2 es la versión estable actual.
 
 Para documentación de producto orientada a tareas, comienza por la [Guía de producto de OpenSquilla](README.product.md) o el [índice de documentación](docs/README.md).
 
@@ -54,7 +54,7 @@ Los instaladores de escritorio y la instalación rápida desde terminal te ofrec
 
 Los comandos de instalación de versiones usan los recursos de release publicados en GitHub. Las instalaciones del wheel de Python usan nombres de archivo de wheel con versión, porque los instaladores validan la versión incrustada en el nombre del archivo del wheel.
 
-Para el uso de escritorio de 0.5.1, opta por los instaladores de escritorio empaquetados de la Release de GitHub: `OpenSquilla-0.5.1-mac-arm64.dmg` en macOS y `OpenSquilla-0.5.1-win-x64.exe` en Windows.
+Para el uso de escritorio de 0.5.2, opta por los instaladores de escritorio empaquetados de la Release de GitHub: `OpenSquilla-0.5.2-mac-arm64.dmg` en macOS y `OpenSquilla-0.5.2-win-x64.exe` en Windows.
 
 | Ruta | Público | Cuándo usarla |
 | --- | --- | --- |
@@ -87,10 +87,10 @@ Enlaces de instalación: [Git](https://git-scm.com/downloads) ·
 
 ### Instaladores de escritorio
 
-Los instaladores de escritorio de 0.5.0 empaquetan la consola de control de Vue y el runtime del gateway en una carcasa de Electron.
+Los instaladores de escritorio de 0.5.2 empaquetan la consola de control de Vue y el runtime del gateway en una carcasa de Electron.
 
-- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg>
-- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe>
+- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-mac-arm64.dmg>
+- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-win-x64.exe>
 
 Para descargas más rápidas desde China continental, usa los alias de descarga directa de OSS:
 - macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -132,7 +132,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Instala OpenSquilla**: el mismo comando en todas las plataformas.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl"
 ```
 
 Esto instala el wheel de OpenSquilla desde la URL de la release y luego deja que `uv` descargue las dependencias declaradas por los extras seleccionados. El extra predeterminado `recommended` incluye dependencias del runtime de SquillaRouter como ONNX Runtime, LightGBM, NumPy y tokenizers, así que una primera instalación necesita acceso a la red salvo que esos wheels ya estén en caché. `uv` no instala runtimes nativos del sistema como `libomp` de macOS o el Visual C++ Redistributable de Windows; consulta [Solución de problemas](#troubleshooting) si el runtime del enrutador informa de un error de carga de biblioteca nativa.
@@ -148,7 +148,7 @@ opensquilla gateway run
 > Si no se encuentra `opensquilla` justo después de una instalación nueva con `uv`, abre una terminal nueva o vuelve a ejecutar la línea de PATH del paso 1.
 
 Para una instalación totalmente fijada, usa la URL del wheel con versión:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl`.
 
 <a id="install-from-source"></a>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -49,7 +49,7 @@ enfichable dialogue avec TokenRhythm, OpenRouter, OpenAI, Anthropic, Ollama, Dee
 Qwen/DashScope et plus de 20 autres fournisseurs de LLM, sans aucun changement dans
 votre code ni dans votre schéma de configuration.
 
-OpenSquilla 0.5.1 est la version stable actuelle.
+OpenSquilla 0.5.2 est la version stable actuelle.
 
 Pour une documentation produit orientée tâches, commencez par le
 [Guide produit OpenSquilla](README.product.md) ou par l'[index de la
@@ -74,9 +74,9 @@ GitHub publiées. Les installations de wheel Python utilisent des noms de fichie
 wheel versionnés, car les installateurs valident la version intégrée au nom de
 fichier du wheel.
 
-Pour un usage bureau en 0.5.1, préférez les installateurs de bureau empaquetés issus de la
-Release GitHub : `OpenSquilla-0.5.1-mac-arm64.dmg` sous macOS et
-`OpenSquilla-0.5.1-win-x64.exe` sous Windows.
+Pour un usage bureau en 0.5.2, préférez les installateurs de bureau empaquetés issus de la
+Release GitHub : `OpenSquilla-0.5.2-mac-arm64.dmg` sous macOS et
+`OpenSquilla-0.5.2-win-x64.exe` sous Windows.
 
 | Voie | Public | Quand l'utiliser |
 | --- | --- | --- |
@@ -125,11 +125,11 @@ Liens d'installation : [Git](https://git-scm.com/downloads) ·
 
 ### Installateurs de bureau
 
-Les installateurs de bureau 0.5.0 empaquettent la console de contrôle Vue et
+Les installateurs de bureau 0.5.2 empaquettent la console de contrôle Vue et
 l'environnement d'exécution de la passerelle dans une enveloppe Electron.
 
-- macOS Apple Silicon : <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg>
-- Windows x64 : <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe>
+- macOS Apple Silicon : <https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-mac-arm64.dmg>
+- Windows x64 : <https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-win-x64.exe>
 
 Pour des téléchargements plus rapides depuis la Chine continentale, utilisez les alias de téléchargement direct OSS :
 - macOS Apple Silicon : <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -178,7 +178,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Installer OpenSquilla** — la même commande sur toutes les plateformes.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl"
 ```
 
 Cela installe le wheel OpenSquilla depuis l'URL de release, puis laisse `uv`
@@ -203,7 +203,7 @@ opensquilla gateway run
 > nouveau terminal, ou réexécutez la ligne PATH de l'étape 1.
 
 Pour une installation entièrement épinglée, utilisez l'URL de wheel versionnée :
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl`.
 
 <a id="install-from-source"></a>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,7 +40,7 @@ OpenSquilla は、Token を効率的に使うマイクロカーネル AI Agent �
 
 すべての入口——Web UI、CLI、チャットチャネル——が同じループ上で動くため、ツールのディスパッチ、リトライ、判断ログの挙動はどこでも同一です。プラグイン可能なプロバイダ層は TokenRhythm、OpenRouter、OpenAI、Anthropic、Ollama、DeepSeek、Gemini、Qwen/DashScope をはじめとする 20 以上の LLM プロバイダと、あなたのコードや設定スキーマを変えることなくやり取りします。
 
-OpenSquilla 0.5.1 が現在の安定版リリースです。
+OpenSquilla 0.5.2 が現在の安定版リリースです。
 
 タスク指向の製品ドキュメントについては、[OpenSquilla 製品ガイド](README.product.md)または[ドキュメント索引](docs/README.md)から始めてください。
 
@@ -54,7 +54,7 @@ OpenSquilla は Windows、macOS、Linux で動作します。ご自身のユー�
 
 リリース版のインストールコマンドは、公開された GitHub リリースのアセットを使います。Python wheel のインストールでは、バージョン付きの wheel ファイル名を使います。インストーラーが wheel ファイル名に埋め込まれたバージョンを検証するためです。
 
-0.5.1 をデスクトップで使う場合は、GitHub リリースからパッケージ版デスクトップインストーラーを使うことをおすすめします。macOS では `OpenSquilla-0.5.1-mac-arm64.dmg`、Windows では `OpenSquilla-0.5.1-win-x64.exe` です。
+0.5.2 をデスクトップで使う場合は、GitHub リリースからパッケージ版デスクトップインストーラーを使うことをおすすめします。macOS では `OpenSquilla-0.5.2-mac-arm64.dmg`、Windows では `OpenSquilla-0.5.2-win-x64.exe` です。
 
 | 方法 | 対象 | 使うべき場面 |
 | --- | --- | --- |
@@ -87,10 +87,10 @@ macOS のターミナルインストールでは、SquillaRouter の LightGBM �
 
 ### デスクトップインストーラー
 
-0.5.1 のデスクトップインストーラーは、Vue 製コントロールコンソールとゲートウェイランタイムを Electron シェルにまとめています。
+0.5.2 のデスクトップインストーラーは、Vue 製コントロールコンソールとゲートウェイランタイムを Electron シェルにまとめています。
 
-- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg>
-- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe>
+- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-mac-arm64.dmg>
+- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-win-x64.exe>
 
 中国本土からより高速にダウンロードするには、OSS の直接ダウンロード用エイリアスを使用してください。
 - macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -127,7 +127,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. OpenSquilla をインストールする**——どのプラットフォームでも同じコマンドです。
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl"
 ```
 
 これはリリース URL から OpenSquilla wheel をインストールし、続いて `uv` が、選択した extra が宣言する依存関係をダウンロードします。デフォルトの `recommended` extra には、ONNX Runtime、LightGBM、NumPy、tokenizers といった SquillaRouter のランタイム依存関係が含まれるため、これらの wheel がすでにキャッシュされていない限り、初回インストールにはネットワークアクセスが必要です。`uv` は macOS の `libomp` や Windows の Visual C++ Redistributable のようなシステムネイティブのランタイムはインストールしません。ルーターランタイムがネイティブライブラリの読み込みエラーを報告した場合は、[トラブルシューティング](#troubleshooting)を参照してください。
@@ -143,7 +143,7 @@ opensquilla gateway run
 > 新規の `uv` インストール直後に `opensquilla` が見つからない場合は、新しいターミナルを開くか、ステップ 1 の PATH 設定の行を再実行してください。
 
 完全にバージョンを固定したインストールには、バージョン付きの wheel URL を使ってください:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`。
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl`。
 
 <a id="install-from-source"></a>
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ TokenRhythm, OpenRouter, OpenAI, Anthropic, Ollama, DeepSeek, Gemini,
 Qwen/DashScope, and 20+ other LLM providers with no change to your code or config
 schema.
 
-OpenSquilla 0.5.1 is the current stable release.
+OpenSquilla 0.5.2 is the current stable release.
 
 For task-oriented product documentation, start with the
 [OpenSquilla Product Guide](README.product.md) or the
@@ -65,9 +65,9 @@ contain that console, so their users do **not** need Node.js or npm.
 Release install commands use published GitHub release assets. Python wheel installs use versioned wheel filenames because installers validate the version
 embedded in the wheel filename.
 
-For 0.5.1 desktop use, prefer the packaged desktop installers from
-the GitHub Release: `OpenSquilla-0.5.1-mac-arm64.dmg` on macOS and
-`OpenSquilla-0.5.1-win-x64.exe` on Windows.
+For 0.5.2 desktop use, prefer the packaged desktop installers from
+the GitHub Release: `OpenSquilla-0.5.2-mac-arm64.dmg` on macOS and
+`OpenSquilla-0.5.2-win-x64.exe` on Windows.
 
 | Path | Audience | When to use |
 | --- | --- | --- |
@@ -113,11 +113,11 @@ Install links: [Git](https://git-scm.com/downloads) ·
 
 ### Desktop installers
 
-The 0.5.1 desktop installers package the Vue control console and
+The 0.5.2 desktop installers package the Vue control console and
 gateway runtime in an Electron shell.
 
-- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg>
-- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe>
+- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-mac-arm64.dmg>
+- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-win-x64.exe>
 
 For faster Mainland China downloads, use the OSS direct-download aliases:
 - macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -175,7 +175,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Install OpenSquilla** — the same command on every platform.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl"
 ```
 
 This installs the OpenSquilla wheel from the release URL, then lets
@@ -199,7 +199,7 @@ opensquilla gateway run
 > a new terminal, or re-run the PATH line from step 1.
 
 For a fully pinned install, use the versioned wheel URL:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl`.
 
 ### Install from source
 
@@ -621,8 +621,8 @@ to allow inbound TCP on that port. Do not expose the gateway with
 **Docker**
 
 Prebuilt multi-arch images (`amd64`/`arm64`) are published to
-`ghcr.io/opensquilla/opensquilla` on release tags. 0.5.1 is published as
-both `v0.5.1` and the moving `latest` tag —
+`ghcr.io/opensquilla/opensquilla` on release tags. 0.5.2 is published as
+both `v0.5.2` and the moving `latest` tag —
 [`docs/docker.md`](docs/docker.md) is the full container guide
 (home servers and NAS, LAN exposure with token auth, upgrades):
 

--- a/README.product.md
+++ b/README.product.md
@@ -14,7 +14,7 @@ This guide is the product and usage entry point. The existing
 1. Install OpenSquilla:
 
    ```sh
-   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
+   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl"
    ```
 
 2. Configure your provider:

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -43,7 +43,7 @@ OpenSquilla 是一个高效利用 Token 的微内核 AI Agent。本地模型路�
 Ollama、DeepSeek、Gemini、Qwen/DashScope 等 20 多个 LLM 提供商，无需改动你的代码或
 配置结构。
 
-OpenSquilla 0.5.1 是当前正式发布版本。
+OpenSquilla 0.5.2 是当前正式发布版本。
 
 如需面向任务的产品文档，请从
 [OpenSquilla 产品指南](README.product.md)或[文档索引](docs/README.md)开始。
@@ -59,8 +59,8 @@ OpenSquilla 可运行于 Windows、macOS 和 Linux。请选择与你的使用场
 发布版安装命令使用 GitHub 上已发布的 release 资源。Python wheel 安装使用带版本号的 wheel
 文件名，因为安装器会校验嵌入在 wheel 文件名中的版本号。
 
-对于 0.5.1 的桌面使用，建议从 GitHub Release 下载打包桌面安装包:macOS 上为
-`OpenSquilla-0.5.1-mac-arm64.dmg`，Windows 上为 `OpenSquilla-0.5.1-win-x64.exe`。
+对于 0.5.2 的桌面使用，建议从 GitHub Release 下载打包桌面安装包:macOS 上为
+`OpenSquilla-0.5.2-mac-arm64.dmg`，Windows 上为 `OpenSquilla-0.5.2-win-x64.exe`。
 
 | 安装方式 | 适合人群 | 何时使用 |
 | --- | --- | --- |
@@ -100,10 +100,10 @@ PowerShell 安装器会通过 `winget` 自动装好它；而**终端快速安装
 
 ### 桌面安装包
 
-0.5.1 桌面安装包将 Vue 控制台和网关运行时打包在一个 Electron 外壳中。
+0.5.2 桌面安装包将 Vue 控制台和网关运行时打包在一个 Electron 外壳中。
 
-- macOS Apple Silicon:<https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg>
-- Windows x64:<https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe>
+- macOS Apple Silicon:<https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-mac-arm64.dmg>
+- Windows x64:<https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-win-x64.exe>
 
 中国大陆下载可直接使用 OSS 的固定安装包链接：
 
@@ -146,7 +146,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. 安装 OpenSquilla**——所有平台命令相同。
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl"
 ```
 
 这会从 release URL 安装 OpenSquilla wheel，再由 `uv` 下载所选 extra 所声明的依赖。
@@ -167,7 +167,7 @@ opensquilla gateway run
 > PATH 设置命令。
 
 如需完全锁定版本的安装，请使用带版本号的 wheel URL:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`。
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl`。
 
 <a id="install-from-source"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 0.5.2 | v0.5.2 | 2026-07-30 | Maintenance: same-turn steering, responsive startup and session history, safer recovery and usage accounting, and Desktop/provider/UI fixes |
 | 0.5.1 | v0.5.1 | 2026-07-29 | Maintenance: Full host/Cron reliability, Plan mode and project workspaces, artifact previews, desktop recovery, and provider/UI improvements |
 | 0.5.0 | v0.5.0 | 2026-07-23 | Stable: Model Ensemble and multi-provider routing, safer upgrades and profile protection, signed macOS desktop updates, usage reporting, and the OSS download mirror |
 | 0.5.0rc4 | v0.5.0rc4 | 2026-07-13 | Preview: safe profile recovery, explicit Windows Portable transfer, Desktop data retention, update reliability, and OSS downloads |
@@ -29,7 +30,7 @@ updater metadata, the versioned Python wheel, and `SHA256SUMS`:
 - `SHA256SUMS`
 
 0.5.x preview releases are GitHub pre-releases and must not be marked as Latest;
-stable releases such as 0.5.1 are normal releases and may be marked Latest
+stable releases such as 0.5.2 are normal releases and may be marked Latest
 once verified.
 They do not publish Windows portable zips, Windows portable latest aliases,
 public wheelhouse zips, or separately branded macOS or Linux portable bundles.
@@ -100,9 +101,9 @@ already-installed Windows RC3 still requires a manual, in-place RC4 upgrade.
 
 README install commands must use tag-pinned URLs such as:
 
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg`
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe`
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-mac-arm64.dmg`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-win-x64.exe`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl`
 
 ## Release SOP
 
@@ -127,13 +128,13 @@ README install commands must use tag-pinned URLs such as:
    more time, then create the annotated tag on that exact SHA:
 
    ```sh
-   git tag -a v0.5.1 <verified-sha> -m "OpenSquilla 0.5.1"
-   git push origin v0.5.1
+   git tag -a v0.5.2 <verified-sha> -m "OpenSquilla 0.5.2"
+   git push origin v0.5.2
    ```
 
 8. Wait for both `.github/workflows/wheelhouse-release.yml` and
    `.github/workflows/docker-image.yml`. Review the draft GitHub Release. For
-   the `v0.5.1` stable, confirm it is not marked Pre-release, leave Latest
+   the `v0.5.2` stable, confirm it is not marked Pre-release, leave Latest
    unset until the maintainer explicitly confirms it at publish time, and
    confirm it contains only the Electron installers, updater metadata,
    versioned wheel, `SHA256SUMS`, plus GitHub's generated source archives. It
@@ -141,16 +142,16 @@ README install commands must use tag-pinned URLs such as:
    `OpenSquilla-windows-x64-portable.zip`.
 9. Verify GHCR before publishing broadly. For the first container release, make
    the newly created `ghcr.io/opensquilla/opensquilla` package public, then
-   confirm both `v0.5.1` and `latest` resolve to an amd64/arm64 manifest and
+   confirm both `v0.5.2` and `latest` resolve to an amd64/arm64 manifest and
    pass a gateway health smoke test.
 10. Publish the GitHub Release only after maintainer confirmation, then run the
    post-publish tag URL checks:
 
    ```sh
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-mac-arm64.dmg
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/OpenSquilla-0.5.1-win-x64.exe
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/SHA256SUMS
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-mac-arm64.dmg
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/OpenSquilla-0.5.2-win-x64.exe
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/SHA256SUMS
    ```
 
 11. If a release tag is wrong before publication, stop and report its peeled
@@ -169,15 +170,15 @@ These checks cannot be fully proven by local artifact generation:
 
 - The tag exists on GitHub and matches `pyproject.toml`.
 - The release workflow can fetch hydrated Git LFS router assets.
-- The draft GitHub Release title is `OpenSquilla 0.5.1`.
-- Preview drafts are marked Pre-release and never Latest; the `v0.5.1`
+- The draft GitHub Release title is `OpenSquilla 0.5.2`.
+- Preview drafts are marked Pre-release and never Latest; the `v0.5.2`
   stable draft is not marked Pre-release, and Latest is applied only at
   publish after explicit maintainer confirmation.
 - Preview GitHub Releases contain the Electron installers, updater metadata,
   versioned wheel, and `SHA256SUMS` after `gh release upload --clobber`.
 - Preview GitHub Releases do not contain Windows portable zips or portable
   latest aliases.
-- The GHCR package is public, and `v0.5.1` plus `latest` expose both amd64
+- The GHCR package is public, and `v0.5.2` plus `latest` expose both amd64
   and arm64 images that pass the gateway health smoke test.
 - After a preview GitHub Release is published, the tag-pinned release asset URLs
   resolve.

--- a/desktop/electron/package-lock.json
+++ b/desktop/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensquilla/desktop-electron",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensquilla/desktop-electron",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensquilla/desktop-electron",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "description": "Electron desktop shell for the OpenSquilla Control UI.",
   "repository": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ root release README with task-oriented guides.
 
 ## Surfaces and Operations
 
+- [`releases/0.5.2.md`](releases/0.5.2.md) - OpenSquilla 0.5.2 release notes.
 - [`releases/0.5.1.md`](releases/0.5.1.md) - OpenSquilla 0.5.1 release notes.
 - [`releases/0.5.0.md`](releases/0.5.0.md) - OpenSquilla 0.5.0 release notes.
 - [`releases/0.5.0rc3.md`](releases/0.5.0rc3.md) - OpenSquilla 0.5.0 Preview 3 release notes.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -147,7 +147,7 @@ combined with `--repo`.
 install path. It requires Docker plus the `swebench` extra.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,swebench] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,swebench] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl"
 opensquilla swebench pull django__django-16429 --dataset verified
 opensquilla swebench solve django__django-16429 --dataset verified --json
 opensquilla swebench eval predictions.jsonl --dataset verified

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -30,7 +30,7 @@ Python, no Git, no build tools.
 
 Prebuilt multi-arch images are published to
 [`ghcr.io/opensquilla/opensquilla`](https://github.com/opensquilla/opensquilla/pkgs/container/opensquilla)
-for each release tag. The immutable `v0.5.1` tag identifies the 0.5.1 stable release, while
+for each release tag. The immutable `v0.5.2` tag identifies the 0.5.2 stable release, while
 `latest` follows the most recently pushed release tag, including previews and
 backports. If a backport moves `latest`, the newest release workflow is rerun to
 restore the intended ordering. If the release you want predates image
@@ -45,8 +45,8 @@ Create a directory for the deployment and write this `compose.yaml`:
 ```yaml
 services:
   gateway:
-    # Pin v0.5.1 for reproducibility; latest follows the most recent tag push.
-    image: ghcr.io/opensquilla/opensquilla:v0.5.1
+    # Pin v0.5.2 for reproducibility; latest follows the most recent tag push.
+    image: ghcr.io/opensquilla/opensquilla:v0.5.2
     environment:
       # In-container bind. Keep it 0.0.0.0 — what the network can reach is
       # decided by `ports` below, not by this value.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -12,7 +12,7 @@ UI, CLI, channels, and gateway control console.
 Install OpenSquilla with the MCP extra when you need this bridge:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl"
 ```
 
 Start the OpenSquilla gateway:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -176,7 +176,7 @@ opensquilla mcp-server run
 Install with:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl"
 ```
 
 Use this when another MCP-capable client should access OpenSquilla-managed tools

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,7 +17,7 @@ UI, SquillaRouter, memory/search support, and safe local defaults.
 Install the current release wheel with the recommended extras:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.1/opensquilla-0.5.1-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl"
 ```
 
 The `recommended` extra includes SquillaRouter dependencies and memory/search

--- a/docs/releases/0.5.2.md
+++ b/docs/releases/0.5.2.md
@@ -1,0 +1,176 @@
+# OpenSquilla 0.5.2
+
+## Overview
+
+OpenSquilla 0.5.2 is a maintenance release for the 0.5 stable line. It keeps
+same-turn follow-ups consistent across clients, keeps Desktop and Gateway
+startup responsive, makes retained session history usable while it loads,
+restores custom-provider and usage settings, and fixes Desktop project
+selection and native HTML artifact previews.
+
+Existing gateway configuration, chats, Agents, memory, and scheduled jobs stay
+in place. Users upgrading from 0.5.1 should quit the running Desktop app or
+gateway, install 0.5.2 directly over the current installation, and restart
+OpenSquilla. Normal version upgrades do not require a data transfer.
+
+## ✨ What's Improved
+
+### Same-turn steering across clients
+
+- Follow-up messages can steer an active supported single-model or router turn
+  consistently from the Web UI and CLI without cancelling or recreating the
+  task. Ensemble turns, attachments, and control changes remain explicit
+  queue-only cases.
+- Accepted steer input is validated against the expected turn, persisted
+  idempotently, and resolved as applied, promoted, cancelled, or rejected.
+  Eligible provider fallback can still apply the input without rerunning the
+  turn's route decision.
+- The new Gateway capability is additive. Older clients retain their legacy
+  path, and newer clients talking to an older Gateway fall back to visible
+  queue behavior. No database or configuration migration is required.
+
+### Faster startup and safer recovery
+
+- Desktop no longer blocks an otherwise usable primary profile on unnecessary
+  recovery scans or legacy-recovery maintenance. Strict validation still runs
+  whenever real recovery work exists, and retained recovery data stays
+  available for a safe retry from Data maintenance.
+- Repeated Desktop ownership checks share a bounded readiness deadline without
+  weakening the fresh ownership and liveness checks that protect gateway
+  shutdown and replacement.
+- Historical usage backfill uses smaller transactions and bounded contention
+  handling. Recovery consolidation now preserves usage records even when it
+  deduplicates an existing conversation.
+
+### Sessions and activity
+
+- Retained session messages, controls, navigation, and message sending remain
+  usable while history loads or recovers. Gateway history reads no longer
+  occupy the serial interactive request path.
+- Model Ensemble activity timers continue across channel heartbeats instead of
+  restarting, and the Desktop startup loader now rotates in the expected
+  direction.
+- Usage backfill no longer repeats terminal partial work on every startup, and
+  committed progress is preserved when a later batch fails.
+
+### Desktop projects and artifact previews
+
+- The Desktop project picker now matches the Web picker on macOS: it supports
+  folder creation, uses system-localized dialog text, and opens at the intended
+  initial directory.
+- Windows Desktop accepts the validated Electron profile marker when preparing
+  its sandbox, while continuing to reject arbitrary marker paths.
+- HTML artifacts appear immediately in the Desktop right-side preview.
+  Full/offline mode changes apply without an extra confirmation, saved defaults
+  remain intact, and forced-offline policy stays authoritative.
+
+### Provider and usage settings
+
+- Custom OpenAI-compatible and Anthropic-compatible providers once again expose
+  their Base URL fields in the active provider editor.
+- The Usage currency toggle now applies to mixed, pending, and older usage rows
+  while preserving exact native receipt amounts when available.
+- TokenRhythm onboarding presents its optional registration action separately
+  from provider selection, and assistant usage details no longer clip against
+  the message pane edge.
+
+## Downloads
+
+Recommended desktop downloads:
+
+- macOS desktop installer: `OpenSquilla-0.5.2-mac-arm64.dmg`
+- macOS desktop zip: `OpenSquilla-0.5.2-mac-arm64.zip`
+- Windows desktop installer: `OpenSquilla-0.5.2-win-x64.exe`
+
+Users in Mainland China can use the stable direct installer links on the
+Alibaba Cloud OSS mirror:
+
+- macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
+- Windows x64: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-win-x64.exe>
+
+Each alias is replaced only after the published release passes checksum
+verification. Versioned OSS and GitHub Release files remain available for
+pinned downloads.
+
+The Windows desktop installer is currently unsigned. See the
+[code signing policy](https://github.com/opensquilla/opensquilla/blob/v0.5.2/docs/code-signing-policy.md)
+before installation.
+
+Terminal and automation downloads:
+
+- Python wheel: `opensquilla-0.5.2-py3-none-any.whl`
+- Checksums: `SHA256SUMS`
+
+Updater metadata:
+
+- `latest-mac.yml`
+- `latest.yml`
+- `*.blockmap`
+
+No Windows Portable assets are published for 0.5.2. Existing 0.4.x Portable
+downloads remain on their original release pages as legacy sources; do not
+expect a 0.5.2 Portable zip or a Portable `/releases/latest/download/` alias.
+
+Privacy and third-party attribution are documented in
+[`PRIVACY.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.2/PRIVACY.md)
+and
+[`THIRD_PARTY_NOTICES.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.2/THIRD_PARTY_NOTICES.md).
+
+Container users can pull the multi-architecture gateway image:
+
+```sh
+docker pull ghcr.io/opensquilla/opensquilla:v0.5.2
+```
+
+The versioned image supports `linux/amd64` and `linux/arm64`. The moving
+`latest` tag follows the most recently verified release tag.
+
+## Upgrading from 0.5.1
+
+Quit the running Desktop app and gateway before upgrading. Back up the active
+profile first if you may need to recover or roll back.
+
+Install 0.5.2 directly over 0.5.1. Existing configuration, chats, Agents,
+memory, and scheduled tasks remain in the active profile.
+
+> [!IMPORTANT]
+> On Windows, users coming from RC3 or an older pre-Preview-4 build must not
+> uninstall that build first: older uninstallers may delete
+> `%APPDATA%\OpenSquilla`. Back up that directory, then install 0.5.2 directly
+> over the existing installation. Preview 4, 0.5.0, 0.5.1, and 0.5.2
+> installers preserve profile data during a normal uninstall.
+
+On macOS, drag the new app into Applications, eject the DMG, and open the
+Applications copy.
+
+CLI users can reinstall the published wheel over the current tool environment:
+
+```sh
+uv tool install --python 3.12 --force --reinstall-package opensquilla \
+  "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.2/opensquilla-0.5.2-py3-none-any.whl"
+```
+
+Non-user-initiated network observability can be disabled before startup with
+`OPENSQUILLA_PRIVACY_DISABLE_NETWORK_OBSERVABILITY=true` or:
+
+```toml
+[privacy]
+disable_network_observability = true
+```
+
+The compatibility variables `OPENSQUILLA_TELEMETRY_DISABLED=true` and
+`OPENSQUILLA_UPDATE_CHECK_DISABLED=true` remain honored.
+
+## Acknowledgements
+
+Thanks to the human contributors whose work is newly present in 0.5.2:
+
+- [@jiaoqingrui](https://github.com/jiaoqingrui) for startup, recovery,
+  historical usage, activity, provider-settings, and Windows Desktop fixes.
+- [@Liu-RK](https://github.com/Liu-RK) for Desktop project-picker parity.
+- [@joyfan621-png](https://github.com/joyfan621-png) for provider onboarding
+  and assistant usage presentation improvements.
+
+See
+[`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.2/CONTRIBUTORS.md)
+for the release attribution ledger.

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v0.5.1'
+$defaultVersion = 'v0.5.2'
 $repoSlug = if ($env:OPENSQUILLA_REPOSITORY) { $env:OPENSQUILLA_REPOSITORY } else { 'opensquilla/opensquilla' }
 $pythonVersion = if ($env:OPENSQUILLA_PYTHON_VERSION) { $env:OPENSQUILLA_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -94,7 +94,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.5.1. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.5.2. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v0.5.1"
+default_version="v0.5.2"
 repo_slug="${OPENSQUILLA_REPOSITORY:-opensquilla/opensquilla}"
 python_version="${OPENSQUILLA_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v0.5.1|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v0.5.2|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  OPENSQUILLA_VERSION=v0.5.1
+  OPENSQUILLA_VERSION=v0.5.2
   OPENSQUILLA_INSTALL_PROFILE=recommended|core
   OPENSQUILLA_INSTALL_EXTRAS=matrix
   OPENSQUILLA_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported OPENSQUILLA_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.5.1." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.5.2." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/packages/opensquilla-tui-host/pyproject.toml
+++ b/packages/opensquilla-tui-host/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensquilla-tui-host"
-version = "0.5.1"
+version = "0.5.2"
 description = "Self-contained OpenTUI companion host for OpenSquilla"
 license = "Apache-2.0"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensquilla"
-version = "0.5.1"
+version = "0.5.2"
 description = "OpenSquilla — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -12,7 +12,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v0.5.1"
+CURRENT_RELEASE_TAG = "v0.5.2"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -1490,7 +1490,7 @@ def test_interactive_feishu_websocket_prompts_only_core_fields(tmp_path, monkeyp
     assert "uv tool install --python 3.12 --force" in normalized_out
     assert "opensquilla[recommended]" in normalized_out
     assert "https://github.com/opensquilla/opensquilla/releases/download/" in out
-    assert "v0.5.1" in out
+    assert "v0.5.2" in out
     assert "opensquilla.ai/install." not in normalized_out
     assert "uv sync --extra recommended" in normalized_out
     assert "--extra feishu" not in normalized_out

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -13,8 +13,8 @@ from pathlib import Path
 import pytest
 import yaml
 
-CURRENT_VERSION = "0.5.1"
-CURRENT_DESKTOP_VERSION = "0.5.1"
+CURRENT_VERSION = "0.5.2"
+CURRENT_DESKTOP_VERSION = "0.5.2"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 HISTORICAL_PREVIEW_VERSION = "0.2.0rc1"
 HISTORICAL_PREVIEW_TAG = f"v{HISTORICAL_PREVIEW_VERSION}"
@@ -938,7 +938,7 @@ def test_historical_040_release_notes_remain_available() -> None:
     assert "OpenSquilla-0.4.0-mac-arm64.dmg" in notes
 
 
-def test_current_release_notes_cover_host_execution_projects_upgrade_and_containers() -> None:
+def test_current_release_notes_cover_steering_startup_upgrade_and_containers() -> None:
     notes = Path(f"docs/releases/{CURRENT_VERSION}.md").read_text(encoding="utf-8")
 
     assert "## Downloads" in notes
@@ -946,23 +946,25 @@ def test_current_release_notes_cover_host_execution_projects_upgrade_and_contain
     assert f"OpenSquilla-{CURRENT_DESKTOP_VERSION}-mac-arm64.zip" in notes
     assert f"OpenSquilla-{CURRENT_DESKTOP_VERSION}-win-x64.exe" in notes
     assert f"opensquilla-{CURRENT_VERSION}-py3-none-any.whl" in notes
-    assert notes.index("### Full host execution and scheduled tasks") < notes.index(
-        "### Plan mode, projects, and artifacts"
+    assert notes.index("### Same-turn steering across clients") < notes.index(
+        "### Faster startup and safer recovery"
     )
-    assert notes.index("### Desktop startup and profile recovery") < notes.index(
-        "### Control console and providers"
+    assert notes.index("### Desktop projects and artifact previews") < notes.index(
+        "### Provider and usage settings"
     )
     assert notes.index("## ✨ What's Improved") < notes.index("## Downloads")
     assert "Normal version upgrades do not require a data transfer" in notes
-    assert "Full host execution" in notes
-    assert "atomic idempotency" in notes
-    assert "dedicated internal" in notes
-    assert "No Windows Portable assets are published for 0.5.1" in notes
-    assert "0.5.1 Portable zip" in notes
-    assert "## Upgrading from 0.5.0" in notes
+    assert "without cancelling or recreating" in notes
+    assert "No database or configuration migration is required" in notes
+    assert "legacy-recovery maintenance" in notes
+    assert "history loads or recovers" in notes
+    assert "Base URL fields" in notes
+    assert "No Windows Portable assets are published for 0.5.2" in notes
+    assert "0.5.2 Portable zip" in notes
+    assert "## Upgrading from 0.5.1" in notes
     assert "must not\n> uninstall that build first" in notes
     assert r"%APPDATA%\OpenSquilla" in notes
-    assert "ghcr.io/opensquilla/opensquilla:v0.5.1" in notes
+    assert "ghcr.io/opensquilla/opensquilla:v0.5.2" in notes
     assert "`latest` tag follows the most recently verified release tag" in notes
     assert (
         "https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/"
@@ -977,11 +979,9 @@ def test_current_release_notes_cover_host_execution_projects_upgrade_and_contain
     assert "release gate" not in notes
     assert "## Acknowledgements" in notes
     for login in [
-        "@HuaXiawithMoon",
         "@joyfan621-png",
         "@jiaoqingrui",
         "@Liu-RK",
-        "@TUOXI293",
     ]:
         assert login in notes
     assert "CONTRIBUTORS.md" in notes
@@ -994,21 +994,18 @@ def test_docs_index_links_current_release_notes() -> None:
     assert "releases/0.4.0.md" in index
 
 
-def test_current_contributor_ledger_records_051_attribution() -> None:
+def test_current_contributor_ledger_records_052_attribution() -> None:
     ledger = Path("CONTRIBUTORS.md").read_text(encoding="utf-8")
-    section = ledger.split("## OpenSquilla 0.5.1", 1)[1].split("## OpenSquilla 0.5.0", 1)[0]
+    section = ledger.split("## OpenSquilla 0.5.2", 1)[1].split("## OpenSquilla 0.5.1", 1)[0]
 
     expected = {
-        "@joyfan621-png": "#868",
-        "@jiaoqingrui": "#864",
-        "@Liu-RK": "#850",
-        "@HuaXiawithMoon": "#797",
-        "@TUOXI293": "#829",
-        "@JarvisPei": "#821",
+        "@jiaoqingrui": "#903",
+        "@Liu-RK": "#887",
+        "@joyfan621-png": "#901",
     }
     for login, evidence in expected.items():
         assert login in section
         assert evidence in section
-    assert "#845" in section
+    assert "#877" in section
     assert "Codex" not in section
     assert "Claude Code" not in section

--- a/uv.lock
+++ b/uv.lock
@@ -1993,7 +1993,7 @@ wheels = [
 
 [[package]]
 name = "opensquilla"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Scope

- Bump Python, Electron Desktop, development companion, installer defaults, and lock metadata to 0.5.2.
- Add user-facing 0.5.2 release notes, changelog and release-ledger entries, and contributor attribution for the v0.5.1 to main range.
- Advance version-pinned install, Desktop, container, quickstart, MCP, operations, and localized README pointers to v0.5.2.
- Update release consistency, installer, and onboarding contracts for the new stable version.

Target branch: main
Head branch: release/0.5.2

## Linked issue

None. This is the maintainer-requested 0.5.2 release preparation.

## Release note status

Complete in docs/releases/0.5.2.md. The notes cover same-turn steering, responsive startup and session history, recovery and usage reliability, Desktop project and HTML preview fixes, provider and usage settings, downloads, upgrade compatibility, and human contributor attribution.

## Validation

- Release consistency and public release hygiene: 46 passed.
- Installer and onboarding contracts: 71 passed, 2 platform skips.
- Ruff on changed Python tests: passed.
- uv lock --check: passed.
- WebUI typecheck, architecture/security/theme/i18n guards, production build, and artifact verification: passed.
- Electron Desktop TypeScript build: passed.
- Wheel build: opensquilla-0.5.2-py3-none-any.whl built successfully; metadata reports 0.5.2, includes the verified WebUI, and excludes the development-only TUI companion.

## Safety and compatibility

- Existing configuration, profiles, chats, Agents, memory, schedules, and database state require no release-prep migration.
- Existing v0.5.1 documentation and release records remain intact; only current stable pointers advance.
- Python and Electron versions use the same final-release spelling on Linux, macOS, and Windows.
- The Windows in-place upgrade warning for older preview installs remains present.
- No secrets, runtime data, private transcripts, local artifacts, or machine-specific paths are included.

## Third-party origin

None. The release preparation is repository-native and attributes merged human contributions through their GitHub pull requests.