### PR TITLE
Make Coding mode a one-command toggle

### DIFF
--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -114,7 +114,10 @@ same session.
 Coding mode can be enabled from chat when you want code modifications routed
 through `opensquilla code-task`. With Coding mode on, code changes use the
 guarded host workflow described in [`cli.md`](cli.md#coding-mode-and-code-task)
-instead of ordinary in-session editing.
+instead of ordinary in-session editing. Enter `/coding` to toggle the mode.
+While it is enabled, the composer shows a `Coding ON` status control that can
+also turn the mode off. The explicit `/coding on`, `/coding off`, and
+`/coding status` forms remain available for compatibility.
 
 ## Manual Compaction
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -111,6 +111,10 @@ Use the session selector to switch between existing sessions. Copy the session
 key when reporting a bug or asking another OpenSquilla surface to inspect the
 same session.
 
+Slash command suggestions complete before they run. `Tab` always completes the
+active candidate, while `Enter` completes a partial match and runs only an
+exact command. Unknown commands remain in the composer with a recovery hint.
+
 Coding mode can be enabled from chat when you want code modifications routed
 through `opensquilla code-task`. With Coding mode on, code changes use the
 guarded host workflow described in [`cli.md`](cli.md#coding-mode-and-code-task)

--- a/opensquilla-webui/src/components/chat/ChatComposer.popovers.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatComposer.popovers.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, type App } from 'vue'
 import i18n from '@/i18n'
 import ChatComposer from './ChatComposer.vue'
@@ -64,6 +64,38 @@ beforeEach(() => {
 })
 
 describe('ChatComposer popovers', () => {
+  it('shows an accessible Coding ON chip that requests disabling the global mode', async () => {
+    const setCodingModeEnabled = vi.fn()
+    const { app, el } = await mountComposer({
+      codingModeEnabled: true,
+      onSetCodingModeEnabled: setCodingModeEnabled,
+    })
+
+    const chip = el.querySelector<HTMLButtonElement>('.chat-coding-mode-chip')
+    expect(chip?.textContent).toContain('Coding ON')
+    expect(chip?.getAttribute('aria-label')).toBe('Disable Coding mode')
+    chip?.click()
+    await nextTick()
+    expect(setCodingModeEnabled).toHaveBeenCalledWith(false)
+
+    app.unmount()
+  })
+
+  it('hides the Coding mode chip while off and disables it during a pending update', async () => {
+    const { app, el } = await mountComposer()
+    expect(el.querySelector('.chat-coding-mode-chip')).toBeNull()
+    app.unmount()
+
+    const busy = await mountComposer({
+      codingModeEnabled: true,
+      codingModeSettingsBusy: true,
+    })
+    const chip = busy.el.querySelector<HTMLButtonElement>('.chat-coding-mode-chip')
+    expect(chip?.disabled).toBe(true)
+    expect(chip?.getAttribute('aria-busy')).toBe('true')
+    busy.app.unmount()
+  })
+
   it('preserves the original single stop control while streaming', async () => {
     const { app, el } = await mountComposer({
       isStreaming: true,

--- a/opensquilla-webui/src/components/chat/ChatComposer.vue
+++ b/opensquilla-webui/src/components/chat/ChatComposer.vue
@@ -126,6 +126,19 @@
               <span>{{ t('workspaces.chooseProject') }}</span>
               <Icon class="chat-project-choose__chevron" name="chevronDown" :size="12" />
             </button>
+            <button
+              v-if="codingModeEnabled"
+              type="button"
+              class="chat-coding-mode-chip"
+              :title="t('chat.codingMode.disableLabel')"
+              :aria-label="t('chat.codingMode.disableLabel')"
+              :aria-busy="codingModeSettingsBusy ? 'true' : 'false'"
+              :disabled="codingModeSettingsBusy"
+              @click="emit('setCodingModeEnabled', false)"
+            >
+              <span>{{ t('chat.codingMode.activeLabel') }}</span>
+              <Icon name="x" :size="12" aria-hidden="true" />
+            </button>
             <div ref="modelRoutingAnchorEl" class="chat-settings-anchor">
               <button
                 class="btn btn--icon btn--ghost chat-model-routing-btn"
@@ -326,6 +339,8 @@ const props = withDefaults(defineProps<{
   runModeLockMessage: string
   modelRoutingMode: ModelRoutingMode
   modelRoutingSettingsBusy: boolean
+  codingModeEnabled?: boolean
+  codingModeSettingsBusy?: boolean
   voiceBusy: boolean
   voiceRecording: boolean
   voiceReady: boolean
@@ -342,6 +357,8 @@ const props = withDefaults(defineProps<{
   replanActive?: boolean
 }>(), {
   canChooseProject: true,
+  codingModeEnabled: false,
+  codingModeSettingsBusy: false,
 })
 
 const emit = defineEmits<{
@@ -356,6 +373,7 @@ const emit = defineEmits<{
   setBusySendMode: [mode: 'queue' | 'steer']
   setRunMode: [mode: 'standard' | 'trusted' | 'full']
   setModelRoutingMode: [mode: ModelRoutingMode]
+  setCodingModeEnabled: [enabled: boolean]
   setCollaborationMode: [mode: CollaborationMode]
   cancelReplan: []
   voiceInput: []
@@ -643,6 +661,41 @@ defineExpose<ChatComposerExpose>({
 .chat-project-chip[data-status="removed"],
 .chat-project-chip[data-status="error"] {
   background: color-mix(in srgb, var(--warn) 7%, transparent);
+}
+.chat-coding-mode-chip {
+  flex: 0 0 auto;
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 7px 3px 9px;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--accent) 9%, transparent);
+  color: var(--accent);
+  font: inherit;
+  font-size: var(--fs-xs);
+  font-weight: 650;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    border-color var(--dur-fast),
+    background var(--dur-fast),
+    color var(--dur-fast);
+}
+.chat-coding-mode-chip:hover,
+.chat-coding-mode-chip:focus-visible {
+  outline: 0;
+  border-color: color-mix(in srgb, var(--accent) 48%, transparent);
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent-hover);
+}
+.chat-coding-mode-chip:focus-visible {
+  box-shadow: var(--focus-ring);
+}
+.chat-coding-mode-chip:disabled {
+  cursor: default;
+  opacity: var(--state-disabled-opacity);
 }
 .chat-project-choose {
   flex-shrink: 0;

--- a/opensquilla-webui/src/components/chat/ChatComposerControls.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatComposerControls.test.ts
@@ -67,6 +67,13 @@ describe('ChatComposer control hierarchy', () => {
     expect(viewSource).toContain('setCodingModeEnabled,')
     expect(viewSource).toContain('@set-coding-mode-enabled="setComposerCodingModeEnabled"')
   })
+
+  it('completes Slash candidates without executing them from the suggestion menu', () => {
+    expect(viewSource).toContain('@click="completeSlashCmd(cmd)"')
+    expect(viewSource).not.toContain('@click="selectSlashCmd(cmd)"')
+    expect(slashSource).toContain('function completeSlashCmd')
+    expect(slashSource).toContain('function activateSlashCmd')
+  })
 })
 
 describe('ChatComposer model routing contract', () => {

--- a/opensquilla-webui/src/components/chat/ChatComposerControls.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatComposerControls.test.ts
@@ -56,13 +56,16 @@ describe('ChatComposer control hierarchy', () => {
     expect(composerSource).not.toContain('setVisualEffectsEnabled')
   })
 
-  it('makes Coding mode available only through the slash path in Web chat', () => {
-    expect(composerSource).not.toContain('codingModeEnabled')
-    expect(composerSource).not.toContain('setCodingModeEnabled')
+  it('keeps Coding mode command-first while exposing its active global state', () => {
+    expect(composerSource).toContain('v-if="codingModeEnabled"')
+    expect(composerSource).toContain('chat-coding-mode-chip')
+    expect(composerSource).toContain("emit('setCodingModeEnabled', false)")
     expect(slashSource).toContain("action === 'coding.mode'")
-    expect(slashSource).toContain("options.setCodingModeEnabled(mode === 'on')")
+    expect(slashSource).toContain('const enabled = !options.codingModeEnabled.value')
     expect(viewSource).toContain('codingModeEnabled,')
+    expect(viewSource).toContain('codingModeSettingsBusy,')
     expect(viewSource).toContain('setCodingModeEnabled,')
+    expect(viewSource).toContain('@set-coding-mode-enabled="setComposerCodingModeEnabled"')
   })
 })
 

--- a/opensquilla-webui/src/composables/chat/useChatComposerShortcuts.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatComposerShortcuts.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref } from 'vue'
 import { useChatComposerShortcuts } from './useChatComposerShortcuts'
+import type { ChatSlashCommand } from './useChatSlashCommands'
 import type { ChatMessage, ChatPendingItem } from '@/types/chat'
 
 // The composable gates the Alt+Arrow queue chords on caret position via
@@ -42,6 +43,8 @@ function harness(over: {
   pendingQueue?: ChatPendingItem[]
   canQueueMore?: boolean
   safari?: boolean
+  slashOpen?: boolean
+  filteredSlashCmds?: ChatSlashCommand[]
 } = {}) {
   const inputText = ref(over.inputText ?? '')
   const spies = {
@@ -51,7 +54,8 @@ function harness(over: {
     autoResizeTextarea: vi.fn(),
     handleSlashInput: vi.fn(),
     closeSlashMenu: vi.fn(),
-    selectSlashCmd: vi.fn(),
+    completeSlashCmd: vi.fn(),
+    activateSlashCmd: vi.fn(),
   }
   const api = useChatComposerShortcuts({
     inputText,
@@ -59,9 +63,9 @@ function harness(over: {
     messages: ref<ChatMessage[]>([]),
     pendingQueue: ref<ChatPendingItem[]>(over.pendingQueue ?? []),
     canQueueMore: ref(over.canQueueMore ?? true),
-    slashOpen: ref(false),
+    slashOpen: ref(over.slashOpen ?? false),
     slashIdx: ref(0),
-    filteredSlashCmds: ref([]),
+    filteredSlashCmds: ref(over.filteredSlashCmds ?? []),
     isStreaming: ref(false),
     isSafariWebKit: () => over.safari ?? false,
     ...spies,
@@ -98,6 +102,48 @@ function inputEvent(inputType: string, target: unknown): InputEvent {
 const QUEUE = [{ id: 'q1', text: 'queued' }] as unknown as ChatPendingItem[]
 
 describe('useChatComposerShortcuts', () => {
+  describe('Slash completion safety', () => {
+    const coding = {
+      name: '/coding',
+      cmd: '/coding',
+      label: '/coding',
+      desc: 'Toggle Coding mode',
+      aliases: [],
+      execution: { action: 'coding.mode' },
+    }
+
+    it('uses Tab only to complete the active candidate', () => {
+      const { api, spies } = harness({
+        inputText: '/co',
+        slashOpen: true,
+        filteredSlashCmds: [coding],
+      })
+      const e = keydown({ key: 'Tab', target: field('/co', 'end') })
+
+      api.onTextareaKeydown(e)
+
+      expect(spies.completeSlashCmd).toHaveBeenCalledWith(coding)
+      expect(spies.activateSlashCmd).not.toHaveBeenCalled()
+      expect(e.preventDefault).toHaveBeenCalled()
+    })
+
+    it('routes Enter through exact-aware activation instead of executing directly', () => {
+      const { api, spies } = harness({
+        inputText: '/co',
+        slashOpen: true,
+        filteredSlashCmds: [coding],
+      })
+      const e = keydown({ key: 'Enter', target: field('/co', 'end') })
+
+      api.onTextareaKeydown(e)
+
+      expect(spies.activateSlashCmd).toHaveBeenCalledWith(coding)
+      expect(spies.completeSlashCmd).not.toHaveBeenCalled()
+      expect(spies.sendCurrentInput).not.toHaveBeenCalled()
+      expect(e.preventDefault).toHaveBeenCalled()
+    })
+  })
+
   describe('IME composition guard', () => {
     it('does not send on Enter while the IME is composing (isComposing)', () => {
       const { api, spies } = harness({ inputText: '你好' })

--- a/opensquilla-webui/src/composables/chat/useChatComposerShortcuts.ts
+++ b/opensquilla-webui/src/composables/chat/useChatComposerShortcuts.ts
@@ -18,7 +18,8 @@ export interface UseChatComposerShortcutsOptions {
   autoResizeTextarea: () => void
   handleSlashInput: () => void
   closeSlashMenu: () => void
-  selectSlashCmd: (cmd: ChatSlashCommand) => void
+  completeSlashCmd: (cmd: ChatSlashCommand) => void
+  activateSlashCmd: (cmd: ChatSlashCommand) => void
   popPendingTail: () => boolean
   enqueuePendingInput: (text: string) => boolean
   sendCurrentInput: () => void
@@ -97,12 +98,16 @@ export function useChatComposerShortcuts(options: UseChatComposerShortcutsOption
         return
       }
       if (e.key === 'Enter' || e.key === 'Tab') {
-        if (options.filteredSlashCmds.value.length > 0) {
-          e.preventDefault()
-          clearTextareaUndoState()
-          options.selectSlashCmd(options.filteredSlashCmds.value[options.slashIdx.value])
-          return
+        const candidate = options.filteredSlashCmds.value[options.slashIdx.value]
+        if (!candidate) return
+        e.preventDefault()
+        clearTextareaUndoState()
+        if (e.key === 'Tab') {
+          options.completeSlashCmd(candidate)
+        } else {
+          options.activateSlashCmd(candidate)
         }
+        return
       }
       if (e.key === 'Escape') {
         e.preventDefault()

--- a/opensquilla-webui/src/composables/chat/useChatSlashCommands.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSlashCommands.test.ts
@@ -31,6 +31,7 @@ function harness(
   })
   const dispatchHidden = vi.fn()
   const dispatchPlanPrompt = vi.fn()
+  const notify = vi.fn()
   const api = useChatSlashCommands({
     rpc,
     catalogCallOptions,
@@ -41,7 +42,7 @@ function harness(
     resetCurrentSession: vi.fn(),
     setCompactInFlight: vi.fn(),
     showCompactStatus: vi.fn(),
-    notify: vi.fn(),
+    notify,
     dispatchHidden,
     dispatchPlanPrompt,
     activatePlanMode,
@@ -56,6 +57,7 @@ function harness(
     dispatchHidden,
     dispatchPlanPrompt,
     inputText,
+    notify,
     rpc,
     setCodingModeEnabled,
   }
@@ -260,5 +262,58 @@ describe('useChatSlashCommands Coding mode', () => {
     codingModeEnabled.value = true
     api.handleSlashInput()
     expect(api.filteredSlashCmds.value[0].desc).toBe('Disable Coding mode.')
+  })
+
+  it('completes a partial /coding candidate without toggling the mode', async () => {
+    const {
+      api,
+      inputText,
+      setCodingModeEnabled,
+    } = harness(false, [codingCommand])
+    await api.loadSlashCommands()
+    inputText.value = '/co'
+    api.handleSlashInput()
+    const candidate = api.filteredSlashCmds.value[0]
+
+    api.activateSlashCmd(candidate)
+
+    expect(inputText.value).toBe('/coding')
+    expect(setCodingModeEnabled).not.toHaveBeenCalled()
+    expect(api.slashOpen.value).toBe(false)
+  })
+
+  it('executes an exact /coding candidate only after completion', async () => {
+    const {
+      api,
+      inputText,
+      setCodingModeEnabled,
+    } = harness(false, [codingCommand])
+    await api.loadSlashCommands()
+    inputText.value = '/coding'
+    api.handleSlashInput()
+
+    api.activateSlashCmd(api.filteredSlashCmds.value[0])
+    await Promise.resolve()
+
+    expect(setCodingModeEnabled).toHaveBeenCalledWith(true)
+    expect(inputText.value).toBe('')
+  })
+})
+
+describe('useChatSlashCommands recovery', () => {
+  it('keeps an unknown slash command in the composer and shows a visible hint', async () => {
+    const {
+      api,
+      inputText,
+      notify,
+    } = harness(false)
+    inputText.value = '/codng'
+
+    const handled = await api.executeSlashCommand(inputText.value)
+
+    expect(handled).toBe(true)
+    expect(inputText.value).toBe('/codng')
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('/codng'))
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('//'))
   })
 })

--- a/opensquilla-webui/src/composables/chat/useChatSlashCommands.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSlashCommands.test.ts
@@ -196,18 +196,18 @@ describe('useChatSlashCommands plan compatibility', () => {
 describe('useChatSlashCommands Coding mode', () => {
   const codingCommand = {
     name: '/coding',
-    description: 'Enable Coding mode, or inspect and disable it.',
+    description: 'Turn Coding mode on or off.',
     aliases: [],
     execution: { action: 'coding.mode' },
-    argument_choices: [
-      { value: 'on', description: 'Enable Coding mode.' },
-      { value: 'off', description: 'Disable Coding mode.' },
-      { value: 'status', description: 'Show whether Coding mode is enabled.' },
-    ],
   }
 
-  it('enables Coding mode when /coding is entered without arguments', async () => {
-    const { api, inputText, setCodingModeEnabled } = harness(false, [codingCommand])
+  it('toggles Coding mode when /coding is entered without arguments', async () => {
+    const {
+      api,
+      codingModeEnabled,
+      inputText,
+      setCodingModeEnabled,
+    } = harness(false, [codingCommand])
     inputText.value = '/coding'
 
     await api.executeSlashCommand(inputText.value)
@@ -215,9 +215,14 @@ describe('useChatSlashCommands Coding mode', () => {
 
     expect(setCodingModeEnabled).toHaveBeenCalledWith(true)
     expect(inputText.value).toBe('')
+
+    codingModeEnabled.value = true
+    await api.executeSlashCommand('/coding')
+    await Promise.resolve()
+    expect(setCodingModeEnabled).toHaveBeenLastCalledWith(false)
   })
 
-  it('supports disabling and checking Coding mode from the slash command', async () => {
+  it('keeps explicit on, off, and status arguments compatible without advertising them', async () => {
     const {
       api,
       codingModeEnabled,
@@ -225,13 +230,35 @@ describe('useChatSlashCommands Coding mode', () => {
       setCodingModeEnabled,
     } = harness(false, [codingCommand])
 
+    await api.loadSlashCommands()
+    inputText.value = '/coding '
+    api.handleSlashInput()
+    expect(api.filteredSlashCmds.value).toEqual([])
+
+    await api.executeSlashCommand('/coding on')
+    await Promise.resolve()
+    expect(setCodingModeEnabled).toHaveBeenCalledWith(true)
+
     await api.executeSlashCommand('/coding off')
     await Promise.resolve()
     expect(setCodingModeEnabled).toHaveBeenCalledWith(false)
 
     codingModeEnabled.value = true
     await api.executeSlashCommand('/coding status')
-    expect(setCodingModeEnabled).toHaveBeenCalledTimes(1)
+    expect(setCodingModeEnabled).toHaveBeenCalledTimes(2)
     expect(inputText.value).toBe('')
+  })
+
+  it('describes the next /coding action from the current global state', async () => {
+    const { api, codingModeEnabled, inputText } = harness(false, [codingCommand])
+    await api.loadSlashCommands()
+    inputText.value = '/coding'
+
+    api.handleSlashInput()
+    expect(api.filteredSlashCmds.value[0].desc).toBe('Enable Coding mode.')
+
+    codingModeEnabled.value = true
+    api.handleSlashInput()
+    expect(api.filteredSlashCmds.value[0].desc).toBe('Disable Coding mode.')
   })
 })

--- a/opensquilla-webui/src/composables/chat/useChatSlashCommands.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSlashCommands.ts
@@ -263,14 +263,34 @@ export function useChatSlashCommands(options: UseChatSlashCommandsOptions) {
     filteredSlashCmds.value = []
   }
 
+  function completeSlashCmd(cmd: ChatSlashCommand) {
+    closeSlashMenu()
+    const needsArgument = !cmd.argValue && (cmd.argumentChoices?.length ?? 0) > 0
+    options.inputText.value = cmd.cmd + (needsArgument ? ' ' : '')
+    options.autoResizeTextarea()
+    if (needsArgument) handleSlashInput()
+  }
+
+  function activateSlashCmd(cmd: ChatSlashCommand) {
+    if (cmd.argValue) {
+      completeSlashCmd(cmd)
+      return
+    }
+    const typedKey = slashCommandKey(options.inputText.value)
+    const isExact = slashCommandKeys(cmd).includes(typedKey)
+    if (!isExact) {
+      completeSlashCmd(cmd)
+      return
+    }
+    selectSlashCmd(cmd)
+  }
+
   function selectSlashCmd(cmd: ChatSlashCommand, args = '') {
     const action = cmd?.execution?.action || cmd.cmd || cmd.name
     // Argument candidate ("/meta <skill>"): Tab-completes into the composer;
     // the user presses Enter to run it.
     if (cmd.argValue) {
-      closeSlashMenu()
-      options.inputText.value = cmd.cmd
-      options.autoResizeTextarea()
+      completeSlashCmd(cmd)
       return
     }
     // A command that takes arguments, selected with none yet: complete to
@@ -432,7 +452,7 @@ export function useChatSlashCommands(options: UseChatSlashCommandsOptions) {
     )
     if (!cmd) {
       closeSlashMenu()
-      console.warn('Unsupported command:', cmdText)
+      options.notify(i18n.global.t('chat.slashCommands.unknown', { command: cmdText }))
       return true
     }
     selectSlashCmd(cmd, rest.join(' '))
@@ -447,6 +467,8 @@ export function useChatSlashCommands(options: UseChatSlashCommandsOptions) {
     loadSlashCommands,
     handleSlashInput,
     closeSlashMenu,
+    completeSlashCmd,
+    activateSlashCmd,
     selectSlashCmd,
     executeSlashCommand,
     runMetaSkill,

--- a/opensquilla-webui/src/composables/chat/useChatSlashCommands.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSlashCommands.ts
@@ -207,6 +207,19 @@ export function useChatSlashCommands(options: UseChatSlashCommandsOptions) {
     }
   }
 
+  function withLiveDescription(command: ChatSlashCommand): ChatSlashCommand {
+    const action = command?.execution?.action || command.cmd || command.name
+    if (action !== 'coding.mode' && action !== '/coding') return command
+    return {
+      ...command,
+      desc: i18n.global.t(
+        options.codingModeEnabled.value
+          ? 'chat.codingMode.commandDisable'
+          : 'chat.codingMode.commandEnable',
+      ),
+    }
+  }
+
   function handleSlashInput() {
     const val = options.inputText.value
     if (val.startsWith('//') || !val.startsWith('/')) {
@@ -217,9 +230,11 @@ export function useChatSlashCommands(options: UseChatSlashCommandsOptions) {
     if (firstSpace === -1) {
       // Command-name completion: "/me" -> matching commands.
       const query = val.slice(1).toLowerCase()
-      const matches = slashCmds.value.filter(command =>
-        slashCommandKeys(command).some(key => key.slice(1).startsWith(query)),
-      )
+      const matches = slashCmds.value
+        .filter(command =>
+          slashCommandKeys(command).some(key => key.slice(1).startsWith(query)),
+        )
+        .map(withLiveDescription)
       const exactKey = slashCommandKey(val)
       const exactMatches = matches.filter(command =>
         slashCommandKeys(command).includes(exactKey),
@@ -294,7 +309,7 @@ export function useChatSlashCommands(options: UseChatSlashCommandsOptions) {
     }
     if (action === 'coding.mode' || action === '/coding') {
       closeSlashMenu()
-      const mode = String(args || 'on').trim().toLowerCase()
+      const mode = String(args || '').trim().toLowerCase()
       options.inputText.value = ''
       options.autoResizeTextarea()
       if (mode === 'status') {
@@ -306,6 +321,17 @@ export function useChatSlashCommands(options: UseChatSlashCommandsOptions) {
         return
       }
       if (mode !== 'on' && mode !== 'off') {
+        if (mode === '') {
+          const enabled = !options.codingModeEnabled.value
+          void options.setCodingModeEnabled(enabled).then((updated) => {
+            options.notify(i18n.global.t(
+              updated
+                ? (enabled ? 'chat.codingMode.enabled' : 'chat.codingMode.disabled')
+                : 'chat.codingMode.updateFailed',
+            ))
+          })
+          return
+        }
         options.notify(i18n.global.t('chat.codingMode.usage'))
         return
       }

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -3305,10 +3305,14 @@
       "sendingContinuing": "Antwort wird gesendet · Ausführung wird fortgesetzt…"
     },
     "codingMode": {
-      "enabled": "Coding mode aktiviert.",
+      "enabled": "Coding mode für alle Chats aktiviert.",
       "disabled": "Coding mode deaktiviert.",
-      "usage": "Verwende /coding, /coding on, /coding off oder /coding status.",
-      "updateFailed": "Coding mode konnte nicht aktualisiert werden."
+      "usage": "Verwende /coding zum Umschalten oder /coding on, /coding off bzw. /coding status.",
+      "updateFailed": "Coding mode konnte nicht aktualisiert werden.",
+      "commandEnable": "Coding mode aktivieren.",
+      "commandDisable": "Coding mode deaktivieren.",
+      "activeLabel": "Coding AN",
+      "disableLabel": "Coding mode deaktivieren"
     },
     "composer": {
       "executionMode": "Ausführungsmodus",

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -3304,6 +3304,9 @@
       "sendReply": "Antwort senden",
       "sendingContinuing": "Antwort wird gesendet · Ausführung wird fortgesetzt…"
     },
+    "slashCommands": {
+      "unknown": "Unbekannter Befehl {command}. Bearbeite ihn weiter oder verwende //, um ihn als Text zu senden."
+    },
     "codingMode": {
       "enabled": "Coding mode für alle Chats aktiviert.",
       "disabled": "Coding mode deaktiviert.",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -3304,6 +3304,9 @@
       "sendReply": "Send reply",
       "sendingContinuing": "Sending reply · continuing run…"
     },
+    "slashCommands": {
+      "unknown": "Unknown command {command}. Keep editing, or use // to send it as text."
+    },
     "codingMode": {
       "enabled": "Coding mode enabled for all chats.",
       "disabled": "Coding mode disabled.",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -3305,10 +3305,14 @@
       "sendingContinuing": "Sending reply · continuing run…"
     },
     "codingMode": {
-      "enabled": "Coding mode enabled.",
+      "enabled": "Coding mode enabled for all chats.",
       "disabled": "Coding mode disabled.",
-      "usage": "Use /coding, /coding on, /coding off, or /coding status.",
-      "updateFailed": "Coding mode could not be updated."
+      "usage": "Use /coding to toggle, or /coding on, /coding off, or /coding status.",
+      "updateFailed": "Coding mode could not be updated.",
+      "commandEnable": "Enable Coding mode.",
+      "commandDisable": "Disable Coding mode.",
+      "activeLabel": "Coding ON",
+      "disableLabel": "Disable Coding mode"
     },
     "composer": {
       "executionMode": "Execution mode",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -3304,6 +3304,9 @@
       "sendReply": "Enviar respuesta",
       "sendingContinuing": "Enviando respuesta · continuando la ejecución…"
     },
+    "slashCommands": {
+      "unknown": "Comando desconocido {command}. Sigue editándolo o usa // para enviarlo como texto."
+    },
     "codingMode": {
       "enabled": "Coding mode activado para todos los chats.",
       "disabled": "Coding mode desactivado.",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -3305,10 +3305,14 @@
       "sendingContinuing": "Enviando respuesta · continuando la ejecución…"
     },
     "codingMode": {
-      "enabled": "Coding mode activado.",
+      "enabled": "Coding mode activado para todos los chats.",
       "disabled": "Coding mode desactivado.",
-      "usage": "Usa /coding, /coding on, /coding off o /coding status.",
-      "updateFailed": "No se pudo actualizar Coding mode."
+      "usage": "Usa /coding para alternar, o /coding on, /coding off o /coding status.",
+      "updateFailed": "No se pudo actualizar Coding mode.",
+      "commandEnable": "Activar Coding mode.",
+      "commandDisable": "Desactivar Coding mode.",
+      "activeLabel": "Coding ACTIVO",
+      "disableLabel": "Desactivar Coding mode"
     },
     "composer": {
       "executionMode": "Modo de ejecución",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -3304,6 +3304,9 @@
       "sendReply": "Envoyer la réponse",
       "sendingContinuing": "Envoi de la réponse · poursuite de l'exécution…"
     },
+    "slashCommands": {
+      "unknown": "Commande inconnue {command}. Continuez à la modifier ou utilisez // pour l’envoyer comme texte."
+    },
     "codingMode": {
       "enabled": "Coding mode activé pour toutes les discussions.",
       "disabled": "Coding mode désactivé.",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -3305,10 +3305,14 @@
       "sendingContinuing": "Envoi de la réponse · poursuite de l'exécution…"
     },
     "codingMode": {
-      "enabled": "Coding mode activé.",
+      "enabled": "Coding mode activé pour toutes les discussions.",
       "disabled": "Coding mode désactivé.",
-      "usage": "Utilisez /coding, /coding on, /coding off ou /coding status.",
-      "updateFailed": "Impossible de mettre à jour Coding mode."
+      "usage": "Utilisez /coding pour basculer, ou /coding on, /coding off ou /coding status.",
+      "updateFailed": "Impossible de mettre à jour Coding mode.",
+      "commandEnable": "Activer Coding mode.",
+      "commandDisable": "Désactiver Coding mode.",
+      "activeLabel": "Coding ACTIVÉ",
+      "disableLabel": "Désactiver Coding mode"
     },
     "composer": {
       "executionMode": "Mode d'exécution",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -3304,6 +3304,9 @@
       "sendReply": "返信を送信",
       "sendingContinuing": "返信を送信中 · 実行を継続中…"
     },
+    "slashCommands": {
+      "unknown": "不明なコマンド {command} です。編集を続けるか、// を使用してテキストとして送信してください。"
+    },
     "codingMode": {
       "enabled": "すべてのチャットで Coding mode を有効にしました。",
       "disabled": "Coding mode を無効にしました。",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -3305,10 +3305,14 @@
       "sendingContinuing": "返信を送信中 · 実行を継続中…"
     },
     "codingMode": {
-      "enabled": "Coding mode を有効にしました。",
+      "enabled": "すべてのチャットで Coding mode を有効にしました。",
       "disabled": "Coding mode を無効にしました。",
-      "usage": "/coding、/coding on、/coding off、または /coding status を使用してください。",
-      "updateFailed": "Coding mode を更新できませんでした。"
+      "usage": "切り替えるには /coding、明示的に操作するには /coding on、/coding off、/coding status を使用してください。",
+      "updateFailed": "Coding mode を更新できませんでした。",
+      "commandEnable": "Coding mode を有効にする。",
+      "commandDisable": "Coding mode を無効にする。",
+      "activeLabel": "Coding 有効",
+      "disableLabel": "Coding mode を無効にする"
     },
     "composer": {
       "executionMode": "実行モード",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -3305,10 +3305,14 @@
       "sendingContinuing": "正在发送回复 · 继续运行…"
     },
     "codingMode": {
-      "enabled": "Coding mode 已开启。",
+      "enabled": "Coding mode 已为所有聊天开启。",
       "disabled": "Coding mode 已关闭。",
-      "usage": "请使用 /coding、/coding on、/coding off 或 /coding status。",
-      "updateFailed": "无法更新 Coding mode。"
+      "usage": "使用 /coding 切换，或使用 /coding on、/coding off、/coding status。",
+      "updateFailed": "无法更新 Coding mode。",
+      "commandEnable": "开启 Coding mode。",
+      "commandDisable": "关闭 Coding mode。",
+      "activeLabel": "Coding 已开启",
+      "disableLabel": "关闭 Coding mode"
     },
     "composer": {
       "executionMode": "执行模式",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -3304,6 +3304,9 @@
       "sendReply": "发送回复",
       "sendingContinuing": "正在发送回复 · 继续运行…"
     },
+    "slashCommands": {
+      "unknown": "未知命令 {command}。请继续编辑，或使用 // 将其作为普通文本发送。"
+    },
     "codingMode": {
       "enabled": "Coding mode 已为所有聊天开启。",
       "disabled": "Coding mode 已关闭。",

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -449,7 +449,7 @@
         :key="cmd.cmd"
         class="chat-slash-item"
         :class="{ 'chat-slash-item--active': i === slashIdx }"
-        @click="selectSlashCmd(cmd)"
+        @click="completeSlashCmd(cmd)"
       >
         <span class="chat-slash-cmd">{{ cmd.cmd }}</span>
         <span class="chat-slash-desc" :title="cmd.desc">{{ cmd.desc }}</span>
@@ -1768,7 +1768,8 @@ const {
   loadSlashCommands,
   handleSlashInput,
   closeSlashMenu,
-  selectSlashCmd,
+  completeSlashCmd,
+  activateSlashCmd,
   executeSlashCommand,
 } = chatSlashCommands
 
@@ -1785,7 +1786,8 @@ const chatComposerShortcuts = useChatComposerShortcuts({
   autoResizeTextarea,
   handleSlashInput,
   closeSlashMenu,
-  selectSlashCmd,
+  completeSlashCmd,
+  activateSlashCmd,
   popPendingTail,
   enqueuePendingInput,
   sendCurrentInput: () => sendCurrentInput(),

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -486,6 +486,8 @@
       :run-mode-lock-message="t('chat.composer.runModeLocked')"
       :model-routing-mode="modelRoutingMode"
       :model-routing-settings-busy="modelRoutingSettingsBusy"
+      :coding-mode-enabled="codingModeEnabled"
+      :coding-mode-settings-busy="codingModeSettingsBusy"
       :voice-busy="voiceBusy"
       :voice-recording="voiceRecording"
       :voice-ready="voiceReady"
@@ -510,6 +512,7 @@
       @set-busy-send-mode="busySendMode = $event"
       @set-run-mode="setComposerRunMode"
       @set-model-routing-mode="setComposerModelRoutingMode"
+      @set-coding-mode-enabled="setComposerCodingModeEnabled"
       @set-collaboration-mode="setCollaborationMode"
       @cancel-replan="cancelPlanRevision"
       @voice-input="onVoiceInput"
@@ -1175,6 +1178,7 @@ const {
   routerVisualEffectsEnabled,
   routerVisualMode,
   codingModeEnabled,
+  codingModeSettingsBusy,
   routerTierConfigs,
   loadFeatureToggles,
   setModelRoutingMode,
@@ -2621,6 +2625,15 @@ async function setComposerRunMode(mode: SandboxRunMode) {
 async function setComposerModelRoutingMode(mode: ModelRoutingMode) {
   await setModelRoutingMode(mode)
   scheduleHistorySync()
+}
+
+async function setComposerCodingModeEnabled(enabled: boolean) {
+  const updated = await setCodingModeEnabled(enabled)
+  pushToast(t(
+    updated
+      ? (enabled ? 'chat.codingMode.enabled' : 'chat.codingMode.disabled')
+      : 'chat.codingMode.updateFailed',
+  ))
 }
 
 // A suggestion chip is an explicit task choice. Route it through the same

--- a/src/opensquilla/engine/commands.py
+++ b/src/opensquilla/engine/commands.py
@@ -346,13 +346,8 @@ _COMMANDS: tuple[CommandDef, ...] = (
     CommandDef(
         name="/coding",
         usage="/coding [on|off|status]",
-        description="Enable Coding mode, or inspect and disable it.",
+        description="Turn Coding mode on or off.",
         execution={_W: _local("coding.mode")},
-        argument_choices=(
-            ArgumentChoice("on", "Enable Coding mode."),
-            ArgumentChoice("off", "Disable Coding mode."),
-            ArgumentChoice("status", "Show whether Coding mode is enabled."),
-        ),
         category=CommandCategory.CONTROL,
         busy_policy=CommandBusyPolicy.IMMEDIATE,
         presentation=CommandPresentation.NOTICE,

--- a/tests/test_engine/test_slash_command_registry.py
+++ b/tests/test_engine/test_slash_command_registry.py
@@ -79,7 +79,8 @@ def test_coding_mode_is_a_web_only_local_slash_command() -> None:
     cmd = DEFAULT_REGISTRY.find("/coding", Surface.WEB_CHAT)
     assert cmd is not None
     assert cmd.surfaces == frozenset({Surface.WEB_CHAT})
-    assert [choice.value for choice in cmd.argument_choices] == ["on", "off", "status"]
+    assert cmd.argument_choices == ()
+    assert cmd.usage == "/coding [on|off|status]"
 
     execution = cmd.execution_for(Surface.WEB_CHAT)
     assert execution is not None


### PR DESCRIPTION
## Scope

- make `/coding` toggle the global Coding mode directly
- show a clickable `Coding ON` status chip in the chat composer while the mode is enabled
- keep `/coding on`, `/coding off`, and `/coding status` working for compatibility without advertising them as completion choices
- separate Slash completion from execution: `Tab` and candidate clicks always complete, while `Enter` runs only an exact command
- retain unknown Slash commands in the composer and show a localized recovery hint, including the `//` literal-text escape
- localize the command state, status control, and recovery hint across all supported Web UI locales
- document the updated Web UI behavior

## Target

- Base: `main`
- Head: `feature/coding-mode-toggle`

## Linked issue

None.

## Release note

User-facing behavior is documented in `docs/web-ui.md`; no separate changelog entry was added.

## Validation

- `npm run test:unit` — 2,541 passed
- `uv run pytest -q tests/test_engine/test_slash_command_registry.py tests/test_engine/test_coding_mode.py tests/test_gateway/test_rpc_skills_coding_gate.py tests/test_gateway/test_rpc_config_persistence.py` — 82 passed
- `uv run ruff check src/opensquilla/engine/commands.py tests/test_engine/test_slash_command_registry.py`
- `npm run build` — architecture, security, theme, i18n, TypeScript, and production artifact checks passed
- `git diff --check`
- real Web UI verification against a disposable local gateway: partial Enter completion, exact Enter execution, Tab completion, click completion, unknown-command recovery, Coding chip disable, and clean browser console

## Safety and compatibility

- Coding mode still defaults to off.
- Existing persisted config and the `skills.coding_mode` key are unchanged.
- Explicit legacy command forms remain supported.
- Existing Slash execution remains available after exact completion; no public RPC or persistence contract changes.
- The change is platform-neutral and does not alter filesystem, process, sandbox, or OS-specific behavior.

## Third-party origin

No third-party code, assets, or generated implementation were copied into this change.