### PR TITLE
Clarify session IDs in the Web UI

### DIFF
--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -103,7 +103,7 @@ The chat UI supports:
 - pending message queue behavior while compaction or runtime work is in flight;
 - manual `/compact`;
 - per-turn usage and savings metadata when available;
-- copyable session keys;
+- copyable session IDs;
 - mobile tabs that keep chat, sessions, and operational views reachable on
   narrow screens.
 

--- a/opensquilla-webui/src/components/chat/ChatHeaderActions.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatHeaderActions.test.ts
@@ -25,7 +25,7 @@ const BASE_PROPS = {
 const messages = {
   chat: {
     copied: 'Copied',
-    copySessionKey: 'Copy session key',
+    copySessionKey: 'Copy session ID',
     deliverablesCount: 'Deliverables ({count})',
     sessionActions: 'Session actions',
     share: 'Share',

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -1772,10 +1772,10 @@
     "inspect": {
       "dialogLabel": "Sitzungsdetails: {title}",
       "subagentOf": "Subagent von {title}",
-      "copyKey": "Sitzungsschlüssel kopieren",
-      "keyCopied": "Sitzungsschlüssel kopiert",
+      "copyKey": "Sitzungs-ID kopieren",
+      "keyCopied": "Sitzungs-ID kopiert",
       "copied": "Kopiert",
-      "copyKeyFailed": "Der Sitzungsschlüssel konnte nicht kopiert werden.",
+      "copyKeyFailed": "Die Sitzungs-ID konnte nicht kopiert werden.",
       "updated": "aktualisiert {time}",
       "transcriptPreview": "Transkriptvorschau",
       "transcriptError": "Das Transkript konnte nicht geladen werden.",
@@ -2410,16 +2410,16 @@
         "reminder": "Statische Erinnerungen laufen isoliert und stellen die Antwort an den ursprünglichen Chat zu, sofern verfügbar.",
         "current": "Die geplante Agentenaufgabe wird in der aktiven Chat-Sitzung fortgesetzt.",
         "isolated": "Die geplante Agentenaufgabe läuft in ihrer eigenen Cron-Sitzung, getrennt von Main.",
-        "session": "Die geplante Agentenaufgabe wird im benannten Sitzungsschlüssel fortgesetzt.",
+        "session": "Die geplante Agentenaufgabe wird in der angegebenen Sitzungs-ID fortgesetzt.",
         "default": "Wählen Sie, wo diese Hintergrund-Agentenaufgabe ihren Unterhaltungskontext behält."
       },
       "targetSessionLabel": {
-        "current": "Aktueller Sitzungsschlüssel",
-        "named": "Benannter Sitzungsschlüssel"
+        "current": "Aktuelle Sitzungs-ID",
+        "named": "Bestimmte Sitzungs-ID"
       },
       "targetSessionHint": {
-        "current": "Aktuell wird beim Speichern des Jobs an den aktiven WebChat-Sitzungsschlüssel gebunden.",
-        "named": "Verwenden Sie einen vollständigen Sitzungsschlüssel aus der Chat-Kopfzeile."
+        "current": "Aktuell wird beim Speichern des Jobs an die aktive WebChat-Sitzungs-ID gebunden.",
+        "named": "Verwenden Sie die vollständige Sitzungs-ID aus der Chat-Kopfzeile."
       },
       "messageLabel": {
         "systemEvent": "Ereignistext",
@@ -2429,8 +2429,8 @@
       "toastNameRequired": "Name ist erforderlich",
       "toastIntervalInvalid": "Das Intervall muss eine ganze Zahl in Sekunden sein",
       "toastIsoTimeRequired": "ISO-Zeit ist erforderlich",
-      "toastCurrentSessionRequired": "Aktueller Sitzungsschlüssel ist erforderlich",
-      "toastNamedSessionRequired": "Benannter Sitzungsschlüssel ist erforderlich",
+      "toastCurrentSessionRequired": "Eine aktuelle Sitzungs-ID ist erforderlich",
+      "toastNamedSessionRequired": "Eine bestimmte Sitzungs-ID ist erforderlich",
       "toastUpdated": "Zeitplan aktualisiert",
       "toastCreated": "Zeitplan erstellt",
       "toastSaveFailed": "Speichern fehlgeschlagen: {error}"
@@ -2997,7 +2997,7 @@
     "chatWithSuffix": "Chat {suffix}",
     "copied": "Kopiert",
     "copy": "Kopieren",
-    "copySessionKey": "Sitzungsschlüssel kopieren",
+    "copySessionKey": "Sitzungs-ID kopieren",
     "sessionActions": "Sitzungsaktionen",
     "share": "Teilen",
     "shareSendFirst": "Senden Sie zuerst eine Nachricht, um zu teilen",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -1772,10 +1772,10 @@
     "inspect": {
       "dialogLabel": "Session details: {title}",
       "subagentOf": "Subagent of {title}",
-      "copyKey": "Copy session key",
-      "keyCopied": "Session key copied",
+      "copyKey": "Copy session ID",
+      "keyCopied": "Session ID copied",
       "copied": "Copied",
-      "copyKeyFailed": "Could not copy the session key.",
+      "copyKeyFailed": "Could not copy the session ID.",
       "updated": "updated {time}",
       "transcriptPreview": "Transcript preview",
       "transcriptError": "Could not load the transcript.",
@@ -2410,16 +2410,16 @@
         "reminder": "Static reminders run isolated and deliver back to the originating chat when one is available.",
         "current": "The scheduled agent task continues in the active chat session.",
         "isolated": "The scheduled agent task runs in its own cron session, separate from Main.",
-        "session": "The scheduled agent task continues in the named session key.",
+        "session": "The scheduled agent task continues in the specified session ID.",
         "default": "Choose where this background agent task keeps its conversation context."
       },
       "targetSessionLabel": {
-        "current": "Current session key",
-        "named": "Named session key"
+        "current": "Current session ID",
+        "named": "Specific session ID"
       },
       "targetSessionHint": {
-        "current": "Current is bound to the active WebChat session key when the job is saved.",
-        "named": "Use a full session key from the chat header."
+        "current": "Current is bound to the active WebChat session ID when the job is saved.",
+        "named": "Use the full session ID from the chat header."
       },
       "messageLabel": {
         "systemEvent": "Event text",
@@ -2429,8 +2429,8 @@
       "toastNameRequired": "Name is required",
       "toastIntervalInvalid": "Interval must be an integer number of seconds",
       "toastIsoTimeRequired": "ISO time is required",
-      "toastCurrentSessionRequired": "Current session key is required",
-      "toastNamedSessionRequired": "Named session key is required",
+      "toastCurrentSessionRequired": "Current session ID is required",
+      "toastNamedSessionRequired": "Specific session ID is required",
       "toastUpdated": "Schedule updated",
       "toastCreated": "Schedule created",
       "toastSaveFailed": "Save failed: {error}"
@@ -2997,7 +2997,7 @@
     "chatWithSuffix": "Chat {suffix}",
     "copied": "Copied",
     "copy": "Copy",
-    "copySessionKey": "Copy session key",
+    "copySessionKey": "Copy session ID",
     "sessionActions": "Session actions",
     "share": "Share",
     "shareSendFirst": "Send a message first to share",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -1772,10 +1772,10 @@
     "inspect": {
       "dialogLabel": "Detalles de la sesión: {title}",
       "subagentOf": "Subagente de {title}",
-      "copyKey": "Copiar clave de sesión",
-      "keyCopied": "Clave de sesión copiada",
+      "copyKey": "Copiar ID de sesión",
+      "keyCopied": "ID de sesión copiado",
       "copied": "Copiado",
-      "copyKeyFailed": "No se pudo copiar la clave de sesión.",
+      "copyKeyFailed": "No se pudo copiar el ID de sesión.",
       "updated": "actualizado {time}",
       "transcriptPreview": "Vista previa de la transcripción",
       "transcriptError": "No se pudo cargar la transcripción.",
@@ -2410,16 +2410,16 @@
         "reminder": "Los recordatorios estáticos se ejecutan de forma aislada y se entregan de vuelta al chat de origen cuando hay uno disponible.",
         "current": "La tarea de agente programada continúa en la sesión de chat activa.",
         "isolated": "La tarea de agente programada se ejecuta en su propia sesión cron, separada de la principal.",
-        "session": "La tarea de agente programada continúa en la clave de sesión con nombre.",
+        "session": "La tarea de agente programada continúa en el ID de sesión especificado.",
         "default": "Elige dónde mantiene esta tarea de agente en segundo plano su contexto de conversación."
       },
       "targetSessionLabel": {
-        "current": "Clave de sesión actual",
-        "named": "Clave de sesión con nombre"
+        "current": "ID de sesión actual",
+        "named": "ID de sesión específico"
       },
       "targetSessionHint": {
-        "current": "La actual se vincula a la clave de sesión de WebChat activa cuando se guarda la tarea.",
-        "named": "Usa una clave de sesión completa del encabezado del chat."
+        "current": "La actual se vincula al ID de sesión de WebChat activo cuando se guarda la tarea.",
+        "named": "Usa el ID de sesión completo del encabezado del chat."
       },
       "messageLabel": {
         "systemEvent": "Texto del evento",
@@ -2429,8 +2429,8 @@
       "toastNameRequired": "El nombre es obligatorio",
       "toastIntervalInvalid": "El intervalo debe ser un número entero de segundos",
       "toastIsoTimeRequired": "La hora ISO es obligatoria",
-      "toastCurrentSessionRequired": "La clave de sesión actual es obligatoria",
-      "toastNamedSessionRequired": "La clave de sesión con nombre es obligatoria",
+      "toastCurrentSessionRequired": "El ID de sesión actual es obligatorio",
+      "toastNamedSessionRequired": "El ID de sesión específico es obligatorio",
       "toastUpdated": "Programación actualizada",
       "toastCreated": "Programación creada",
       "toastSaveFailed": "Error al guardar: {error}"
@@ -2997,7 +2997,7 @@
     "chatWithSuffix": "Chat {suffix}",
     "copied": "Copiado",
     "copy": "Copiar",
-    "copySessionKey": "Copiar clave de sesión",
+    "copySessionKey": "Copiar ID de sesión",
     "sessionActions": "Acciones de la sesión",
     "share": "Compartir",
     "shareSendFirst": "Envía un mensaje primero para compartir",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -1772,10 +1772,10 @@
     "inspect": {
       "dialogLabel": "Détails de la session : {title}",
       "subagentOf": "Sous-agent de {title}",
-      "copyKey": "Copier la clé de session",
-      "keyCopied": "Clé de session copiée",
+      "copyKey": "Copier l’ID de session",
+      "keyCopied": "ID de session copié",
       "copied": "Copié",
-      "copyKeyFailed": "Impossible de copier la clé de session.",
+      "copyKeyFailed": "Impossible de copier l’ID de session.",
       "updated": "mis à jour {time}",
       "transcriptPreview": "Aperçu de la transcription",
       "transcriptError": "Impossible de charger la transcription.",
@@ -2410,16 +2410,16 @@
         "reminder": "Les rappels statiques s'exécutent de manière isolée et reviennent vers le chat d'origine lorsqu'il est disponible.",
         "current": "La tâche d'agent planifiée se poursuit dans la session de chat active.",
         "isolated": "La tâche d'agent planifiée s'exécute dans sa propre session cron, distincte de Principal.",
-        "session": "La tâche d'agent planifiée se poursuit dans la clé de session nommée.",
+        "session": "La tâche d'agent planifiée se poursuit dans l’ID de session indiqué.",
         "default": "Choisissez où cette tâche d'agent en arrière-plan conserve son contexte de conversation."
       },
       "targetSessionLabel": {
-        "current": "Clé de session actuelle",
-        "named": "Clé de session nommée"
+        "current": "ID de session actuel",
+        "named": "ID de session spécifique"
       },
       "targetSessionHint": {
-        "current": "« Actuelle » est liée à la clé de session WebChat active lors de l'enregistrement de la tâche.",
-        "named": "Utilisez une clé de session complète depuis l'en-tête du chat."
+        "current": "« Actuelle » est liée à l’ID de session WebChat actif lors de l'enregistrement de la tâche.",
+        "named": "Utilisez l’ID de session complet depuis l'en-tête du chat."
       },
       "messageLabel": {
         "systemEvent": "Texte de l'événement",
@@ -2429,8 +2429,8 @@
       "toastNameRequired": "Le nom est requis",
       "toastIntervalInvalid": "L'intervalle doit être un nombre entier de secondes",
       "toastIsoTimeRequired": "L'heure ISO est requise",
-      "toastCurrentSessionRequired": "La clé de session actuelle est requise",
-      "toastNamedSessionRequired": "La clé de session nommée est requise",
+      "toastCurrentSessionRequired": "L’ID de session actuel est requis",
+      "toastNamedSessionRequired": "L’ID de session spécifique est requis",
       "toastUpdated": "Planification mise à jour",
       "toastCreated": "Planification créée",
       "toastSaveFailed": "Échec de l'enregistrement : {error}"
@@ -2997,7 +2997,7 @@
     "chatWithSuffix": "Chat {suffix}",
     "copied": "Copié",
     "copy": "Copier",
-    "copySessionKey": "Copier la clé de session",
+    "copySessionKey": "Copier l’ID de session",
     "sessionActions": "Actions de la session",
     "share": "Partager",
     "shareSendFirst": "Envoyez d'abord un message pour partager",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -1772,10 +1772,10 @@
     "inspect": {
       "dialogLabel": "セッションの詳細: {title}",
       "subagentOf": "{title} のサブエージェント",
-      "copyKey": "セッションキーをコピー",
-      "keyCopied": "セッションキーをコピーしました",
+      "copyKey": "セッション ID をコピー",
+      "keyCopied": "セッション ID をコピーしました",
       "copied": "コピーしました",
-      "copyKeyFailed": "セッションキーをコピーできませんでした。",
+      "copyKeyFailed": "セッション ID をコピーできませんでした。",
       "updated": "{time} に更新",
       "transcriptPreview": "トランスクリプトのプレビュー",
       "transcriptError": "トランスクリプトを読み込めませんでした。",
@@ -2410,16 +2410,16 @@
         "reminder": "静的リマインダーは分離して実行され、発信元のチャットが利用可能な場合はそこに配信されます。",
         "current": "スケジュールされたエージェントタスクはアクティブなチャットセッションで続行されます。",
         "isolated": "スケジュールされたエージェントタスクはメインとは別に、独自のスケジュールセッションで実行されます。",
-        "session": "スケジュールされたエージェントタスクは指定したセッションキーで続行されます。",
+        "session": "スケジュールされたエージェントタスクは指定したセッション ID で続行されます。",
         "default": "このバックグラウンドエージェントタスクが会話コンテキストを保持する場所を選択してください。"
       },
       "targetSessionLabel": {
-        "current": "現在のセッションキー",
-        "named": "名前付きセッションキー"
+        "current": "現在のセッション ID",
+        "named": "指定したセッション ID"
       },
       "targetSessionHint": {
-        "current": "現在は、ジョブを保存した時点でアクティブな WebChat セッションキーにバインドされます。",
-        "named": "チャットヘッダーの完全なセッションキーを使用してください。"
+        "current": "現在は、ジョブを保存した時点でアクティブな WebChat セッション ID にバインドされます。",
+        "named": "チャットヘッダーの完全なセッション ID を使用してください。"
       },
       "messageLabel": {
         "systemEvent": "イベントテキスト",
@@ -2429,8 +2429,8 @@
       "toastNameRequired": "名前は必須です",
       "toastIntervalInvalid": "間隔は整数の秒数である必要があります",
       "toastIsoTimeRequired": "ISO 時刻は必須です",
-      "toastCurrentSessionRequired": "現在のセッションキーは必須です",
-      "toastNamedSessionRequired": "名前付きセッションキーは必須です",
+      "toastCurrentSessionRequired": "現在のセッション ID は必須です",
+      "toastNamedSessionRequired": "指定したセッション ID は必須です",
       "toastUpdated": "スケジュールを更新しました",
       "toastCreated": "スケジュールを作成しました",
       "toastSaveFailed": "保存に失敗しました: {error}"
@@ -2997,7 +2997,7 @@
     "chatWithSuffix": "チャット {suffix}",
     "copied": "コピーしました",
     "copy": "コピー",
-    "copySessionKey": "セッションキーをコピー",
+    "copySessionKey": "セッション ID をコピー",
     "sessionActions": "セッション操作",
     "share": "共有",
     "shareSendFirst": "共有するには、まずメッセージを送信してください",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -1772,10 +1772,10 @@
     "inspect": {
       "dialogLabel": "会话详情：{title}",
       "subagentOf": "{title} 的子智能体",
-      "copyKey": "复制会话标识",
-      "keyCopied": "会话标识已复制",
+      "copyKey": "复制会话 ID",
+      "keyCopied": "会话 ID 已复制",
       "copied": "已复制",
-      "copyKeyFailed": "无法复制会话标识。",
+      "copyKeyFailed": "无法复制会话 ID。",
       "updated": "更新于 {time}",
       "transcriptPreview": "记录预览",
       "transcriptError": "无法加载记录。",
@@ -2410,16 +2410,16 @@
         "reminder": "静态提醒独立运行，并在可用时投递回原始聊天。",
         "current": "定时智能体任务在当前活跃的聊天会话中继续。",
         "isolated": "定时智能体任务在其自己的定时任务会话中运行，与 Main 分离。",
-        "session": "定时智能体任务在指定的命名会话键中继续。",
+        "session": "定时智能体任务在指定的会话 ID 中继续。",
         "default": "选择此后台智能体任务保存其对话上下文的位置。"
       },
       "targetSessionLabel": {
-        "current": "当前会话键",
-        "named": "命名会话键"
+        "current": "当前会话 ID",
+        "named": "指定会话 ID"
       },
       "targetSessionHint": {
-        "current": "保存任务时，Current 会绑定到当前活跃的 WebChat 会话键。",
-        "named": "请使用聊天标题栏中的完整会话键。"
+        "current": "保存任务时，“当前”会绑定到当前活跃的 WebChat 会话 ID。",
+        "named": "请使用聊天标题栏中的完整会话 ID。"
       },
       "messageLabel": {
         "systemEvent": "事件文本",
@@ -2429,8 +2429,8 @@
       "toastNameRequired": "名称为必填项",
       "toastIntervalInvalid": "间隔必须为整数秒",
       "toastIsoTimeRequired": "ISO 时间为必填项",
-      "toastCurrentSessionRequired": "当前会话键为必填项",
-      "toastNamedSessionRequired": "命名会话键为必填项",
+      "toastCurrentSessionRequired": "当前会话 ID 为必填项",
+      "toastNamedSessionRequired": "指定会话 ID 为必填项",
       "toastUpdated": "定时任务已更新",
       "toastCreated": "定时任务已创建",
       "toastSaveFailed": "保存失败：{error}"
@@ -2997,7 +2997,7 @@
     "chatWithSuffix": "聊天 {suffix}",
     "copied": "已复制",
     "copy": "复制",
-    "copySessionKey": "复制会话密钥",
+    "copySessionKey": "复制会话 ID",
     "sessionActions": "会话操作",
     "share": "分享",
     "shareSendFirst": "先发送一条消息才能分享",


### PR DESCRIPTION
## Scope

- Rename user-facing “session key” terminology to “session ID” in chat actions, session details, and scheduled-task session targeting.
- Keep the terminology consistent across English, Simplified Chinese, Japanese, French, German, and Spanish.
- Update the Web UI documentation and the chat-header component test expectation.

## Why

“Session key” describes an internal identifier, but the wording can be mistaken for a credential or secret. “Session ID” communicates the user-facing purpose without changing the underlying runtime contract.

## Branch target

`main`

## Linked issue

None

## Release note

Not required — user-facing terminology clarification only.

## Validation

- `npm run typecheck`
- `npm run test:unit -- src/components/chat/ChatHeaderActions.test.ts src/components/sessions/SessionInspectDrawer.test.ts` (7 tests passed; only the existing chat-header test file matched)
- `node scripts/check-i18n.mjs`
- Desktop and 466×760 rendered checks for the chat copy action and success feedback
- `git diff --check`

## Safety and compatibility

- No RPC fields, persisted data, session routing, clipboard behavior, or backend `session_key` semantics changed.
- No upgrade migration is required and existing clients remain compatible.
- The change is platform-neutral.

## Third-party origin

None.