### PR TITLE
feat(ensemble): simple-turn bypass for confident c0 conversational turns

### DIFF
--- a/docs/桥爷-Key与模型映射.md
+++ b/docs/桥爷-Key与模型映射.md
@@ -1,0 +1,68 @@
+# 桥爷 · Key 与模型映射
+
+> 最终方案（2026-07-21）。Key 只保存在 `~/.opensquilla/relay-keys.env`，不得写进项目配置、Git、聊天或日志。
+
+## 当前实际启用
+
+| Key | 通道 | 地址 | 当前用途 | 模型 |
+|---|---|---|---|---|
+| Key2 | a.99cy 中转 | `https://a.99cy.edu.kg/v1` | 图片、截图、图表问答 | `grok-4.5` |
+| Key3 | a.99cy 中转 | `https://a.99cy.edu.kg/v1` | 最高难度文字任务 | `glm-5.2` |
+| Key7 | TokenRhythm | `https://tokenrhythm.studio/v1` | 日常三档与四模型会诊 | 见下表 |
+
+Key1、Key4、Key5、Key6 仍安全保存在本机，但不进入当前默认路由。
+
+## 单模型智能路由（默认）
+
+每个问题只调用一个模型；系统根据整次请求的类型和难度自动选择，并非只看关键词。
+
+| 档位 | 适合任务 | 通道与模型 |
+|---|---|---|
+| c0 | 简单提取、短改写、低风险问答 | Key7 · `deepseek-v4-flash` |
+| c1 | 日常工作、普通分析、常规写作 | Key7 · `deepseek-v4-pro` |
+| c2 | 多步骤执行、代码工作、长内容综合 | Key7 · `kimi-k2.7-code` |
+| c3 | 深度规划、严格审查、复杂推理 | Key3 · `glm-5.2` |
+| image | 图片、截图、图表问答 | Key2 · `grok-4.5` |
+
+## 多模型会诊（默认关闭）
+
+重要问题时手动开启。一次会诊会产生 5 次模型调用：4 个模型分别作答，再由 1 个模型汇总，因此比日常模式更慢、更贵。
+
+全部走 Key7 TokenRhythm：
+
+1. `deepseek-v4-pro`
+2. `glm-5.2`
+3. `kimi-k2.7-code`
+4. `qwen3.7-max`
+5. `glm-5.2` 负责最终汇总
+
+## Key7 可用模型清单
+
+1. `deepseek-v4-flash`
+2. `deepseek-v4-pro`
+3. `glm-5`
+4. `glm-5.1`
+5. `minimax-m2.7`
+6. `kimi-k2.5`
+7. `kimi-k2.6`
+8. `minimax-m2.5`
+9. `mimo-v2.5-pro`
+10. `qwen3.7-max`
+11. `kimi-k2.7-code`
+12. `glm-5.2`
+
+## Key4 · Kimi 官方（当前备用）
+
+- 地址：`https://api.kimi.com/coding/v1`
+- 模型：`kimi-for-coding`、`kimi-for-coding-highspeed`、`k3`
+- Coding Plan 要求 `temperature=1`
+- 它不是 a.99cy 中转，不能使用中转地址。
+
+## 已完成的真实验证
+
+- c0：`deepseek-v4-flash`，成功
+- c1：`deepseek-v4-pro`，成功
+- c3：Key3 `glm-5.2`，成功
+- 图片：Key2 `grok-4.5`，成功识别真实图片
+- 会诊：4 个提案全部成功，`glm-5.2` 汇总成功
+- c2 模型已在会诊中真实调用成功；单模型路由尚未专门构造请求强制命中 c2

--- a/docs/桥爷-中转智能路由配置说明.md
+++ b/docs/桥爷-中转智能路由配置说明.md
@@ -1,0 +1,96 @@
+# 桥爷 · OpenSquilla 最终路由使用说明
+
+## 日常会看到什么
+
+默认是“单模型智能路由”：每次问题只选择一个最合适的模型，兼顾速度、质量和费用。
+
+- 简单任务：Key7 DeepSeek V4 Flash
+- 日常任务：Key7 DeepSeek V4 Pro
+- 多步骤与代码任务：Key7 Kimi K2.7 Code
+- 最高难度任务：Key3 GLM-5.2
+- 图片与截图：Key2 Grok-4.5
+
+重要方案才手动开启“四模型会诊”。会诊会让 4 个模型分别回答，再由 GLM-5.2 汇总，一次共调用 5 次，默认关闭。
+
+## 安全规则
+
+- Key 只保存在：`~/.opensquilla/relay-keys.env`
+- 文件权限必须为 600
+- Key 不写进项目配置、Git、聊天、日志或说明文档
+- 项目配置只写环境变量名称，不写 Key 本身
+
+## 项目配置位置
+
+```text
+/Users/linlang/04 AI鼓捣/Opensquilla/opensquilla-src/opensquilla.toml
+```
+
+## 模式切换
+
+在项目目录执行：
+
+```bash
+cd "/Users/linlang/04 AI鼓捣/Opensquilla/opensquilla-src"
+
+# 查看当前模式
+./scripts/switch-routing-mode.sh status
+
+# 日常：单模型智能路由
+./scripts/switch-routing-mode.sh single
+
+# 重要问题：四模型会诊
+./scripts/switch-routing-mode.sh multi
+```
+
+切换后，正在运行的网关必须重新读取配置。源码版可执行：
+
+```bash
+source ~/.opensquilla/relay-keys.env
+.venv/bin/opensquilla gateway reload --config "/Users/linlang/04 AI鼓捣/Opensquilla/opensquilla-src/opensquilla.toml"
+```
+
+桌面版使用自己的配置文件，不能只改源码配置；两边配置不同会被 `doctor` 报告为不一致。
+
+## 当前最终参数
+
+| 项目 | 当前设置 |
+|---|---|
+| 默认模式 | 单模型智能路由 |
+| 日常文字通道 | Key7 TokenRhythm |
+| 最高档 | Key3 GLM-5.2 |
+| 图片档 | Key2 Grok-4.5 |
+| 会诊模式 | Key7 TokenRhythm 官方固定四模型 |
+| 会诊最低成功数 | 3 个提案模型 |
+| 会诊全部失败 | 退回单模型 |
+
+## 常见问题
+
+### 切换后没有变化
+
+正在运行的桌面版可能读取另一份配置。执行体检时会显示实际读取位置：
+
+```bash
+.venv/bin/opensquilla doctor --config "/Users/linlang/04 AI鼓捣/Opensquilla/opensquilla-src/opensquilla.toml"
+```
+
+### 提示端口已有健康网关
+
+说明桌面版已经启动网关。不要直接再启动第二个，也不要强制杀进程；应修改桌面版实际使用的配置并让桌面版重新读取。
+
+### 返回 401
+
+通常是网关进程没有拿到 Key。不要把 Key 补进配置文件；应从安全 Key 文件加载后再启动网关。
+
+### TokenRhythm 已回答但最后报流顺序错误
+
+TokenRhythm 会在答案结束后补充计费信息。本地源码已兼容这些字段；未来更新源码时要确认这项修复没有被覆盖。
+
+## 已完成验收
+
+- 配置解析成功
+- 单模型模式切换成功
+- 多模型模式切换成功
+- c0、c1、c3 真实请求成功
+- 图片经 Key2 Grok-4.5 真实请求成功
+- 四模型会诊 4 个提案全部成功，GLM 汇总成功
+- TokenRhythm 答案结束后的计费信息兼容成功

--- a/scripts/add-key7-tokenrhythm.sh
+++ b/scripts/add-key7-tokenrhythm.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# 桥爷专用：只添加第 7 把 Key（TokenRhythm 官方）
+# 在系统「终端.app」里执行：
+#   bash "/Users/linlang/04 AI鼓捣/Opensquilla/opensquilla-src/scripts/add-key7-tokenrhythm.sh"
+
+set -euo pipefail
+
+STORE="${HOME}/.opensquilla/relay-keys.env"
+BASE_URL="https://tokenrhythm.studio/v1"
+
+echo "=========================================="
+echo "  添加第 7 把 Key（TokenRhythm）"
+echo "  地址: ${BASE_URL}"
+echo "=========================================="
+echo ""
+
+if [ ! -t 0 ]; then
+  echo "请用 Mac「终端」App 打开再运行，不要在别的地方跑。"
+  exit 1
+fi
+
+# 先加载已有 1～6（如果有）
+if [ -f "$STORE" ]; then
+  # shellcheck disable=SC1090
+  . "$STORE"
+  echo "已读到旧钥匙文件。"
+else
+  echo "还没有旧钥匙文件，将只保存 Key7（建议以后把 1～6 也再 setup 一次）。"
+fi
+
+echo ""
+echo "请粘贴 TokenRhythm 的 API Key，然后按回车。"
+echo "（粘贴时屏幕可能不显示字符，正常）"
+printf "Key7: "
+IFS= read -r KEY7 || true
+KEY7="$(printf '%s' "$KEY7" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+
+if [ -z "$KEY7" ]; then
+  echo "✗ 没有输入 Key，已取消。"
+  exit 1
+fi
+
+echo "✓ 收到 Key7，长度 ${#KEY7}"
+echo ""
+
+_escape() {
+  printf "%s" "$1" | sed "s/'/'\\\\''/g"
+}
+
+mkdir -p "${HOME}/.opensquilla"
+chmod 700 "${HOME}/.opensquilla" 2>/dev/null || true
+umask 077
+
+{
+  echo "# 桥爷 Keys — 勿发给别人"
+  echo "# 更新时间: $(date '+%Y-%m-%d %H:%M:%S')"
+  echo "export OPENSQUILLA_RELAY_KEY_COUNT='7'"
+  for i in 1 2 3 4 5 6; do
+    eval "v=\${OPENSQUILLA_RELAY_KEY_$i:-}"
+    echo "export OPENSQUILLA_RELAY_KEY_${i}='$(_escape "$v")'"
+  done
+  echo "export OPENSQUILLA_RELAY_KEY_7='$(_escape "$KEY7")'"
+  echo "export OPENSQUILLA_TOKENRHYTHM_BASE_URL='${BASE_URL}'"
+  echo 'export CUSTOM_LLM_API_KEY="$OPENSQUILLA_RELAY_KEY_1"'
+  echo 'export TOKENRHYTHM_API_KEY="$OPENSQUILLA_RELAY_KEY_7"'
+} > "$STORE"
+chmod 600 "$STORE"
+
+echo "✓ 已保存到: $STORE"
+echo ""
+
+# 自动拉模型列表（不打印 Key）
+echo "正在向 TokenRhythm 查询模型列表……"
+TMP="$(mktemp)"
+HTTP_CODE="$(
+  curl -sS -o "$TMP" -w "%{http_code}" \
+    -H "Authorization: Bearer ${KEY7}" \
+    -H "Content-Type: application/json" \
+    "${BASE_URL}/models" 2>/dev/null || echo "ERR"
+)"
+
+echo "HTTP 状态: ${HTTP_CODE}"
+if [ "$HTTP_CODE" = "200" ]; then
+  echo "---------- 模型列表（复制下面整段发给瓜娃子）----------"
+  # 尽量只抽出 id
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$TMP" <<'PY'
+import json, sys
+from pathlib import Path
+raw = Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace")
+try:
+    j = json.loads(raw)
+except Exception:
+    print(raw[:3000])
+    raise SystemExit
+ids = []
+if isinstance(j, dict) and isinstance(j.get("data"), list):
+    for x in j["data"]:
+        if isinstance(x, dict) and x.get("id"):
+            ids.append(str(x["id"]))
+elif isinstance(j, list):
+    for x in j:
+        if isinstance(x, dict) and x.get("id"):
+            ids.append(str(x["id"]))
+print(f"Key7 TokenRhythm 模型共 {len(ids)} 个：")
+for i, m in enumerate(ids, 1):
+    print(f"{i}. {m}")
+if not ids:
+    print(raw[:2000])
+PY
+  else
+    head -c 4000 "$TMP"
+    echo
+  fi
+  echo "----------------------------------------------------------"
+  # 另存一份无 Key 报告
+  REPORT="${HOME}/.opensquilla/tokenrhythm-models.txt"
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$TMP" "$REPORT" <<'PY'
+import json, sys
+from pathlib import Path
+raw = Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace")
+out = Path(sys.argv[2])
+try:
+    j = json.loads(raw)
+    ids = []
+    if isinstance(j, dict) and isinstance(j.get("data"), list):
+        for x in j["data"]:
+            if isinstance(x, dict) and x.get("id"):
+                ids.append(str(x["id"]))
+    lines = [f"Key7 TokenRhythm 模型共 {len(ids)} 个："] + [f"{i}. {m}" for i,m in enumerate(ids,1)]
+    out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+except Exception:
+    out.write_text(raw[:5000], encoding="utf-8")
+print(f"也已保存到: {out}")
+PY
+  fi
+else
+  echo "查询失败。可能是 Key 不对，或网络不通。"
+  echo "返回内容前几行："
+  head -c 500 "$TMP" 2>/dev/null || true
+  echo
+  echo "Key 已保存。你可以稍后把后台的 12 个模型名手抄发给瓜娃子。"
+fi
+rm -f "$TMP"
+
+echo ""
+echo "下一步："
+echo "  1) 把上面「模型列表」整段复制，发给瓜娃子"
+echo "  2) 不要发送完整 Key"
+echo "  3) 等瓜娃子给路由建议表，你确认后再改配置"

--- a/scripts/export-relay-keys.sh
+++ b/scripts/export-relay-keys.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# 加载中转 Key 到当前终端（支持任意多把，不打印完整 Key）
+#
+# 用法：
+#   source scripts/export-relay-keys.sh
+# 或：
+#   source ~/.opensquilla/relay-keys.env
+
+STORE_FILE="${HOME}/.opensquilla/relay-keys.env"
+MAX_KEYS=20
+
+if [ -f "$STORE_FILE" ]; then
+  # shellcheck disable=SC1090
+  . "$STORE_FILE"
+fi
+
+# 还没有 KEY_1 时，尝试复用 Claude 的中转 Key
+if [ -z "${OPENSQUILLA_RELAY_KEY_1:-}" ] && [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+  export OPENSQUILLA_RELAY_KEY_1="$ANTHROPIC_AUTH_TOKEN"
+  export OPENSQUILLA_RELAY_KEY_COUNT="${OPENSQUILLA_RELAY_KEY_COUNT:-1}"
+fi
+
+_count=0
+for i in $(seq 1 "$MAX_KEYS"); do
+  eval "val=\${OPENSQUILLA_RELAY_KEY_$i:-}"
+  if [ -n "$val" ]; then
+    export OPENSQUILLA_RELAY_KEY_$i="$val"
+    _count=$((_count + 1))
+    echo "✓ OPENSQUILLA_RELAY_KEY_$i 已就绪（长度 ${#val}）"
+  fi
+done
+
+export OPENSQUILLA_RELAY_KEY_COUNT="${OPENSQUILLA_RELAY_KEY_COUNT:-$_count}"
+
+if [ -n "${OPENSQUILLA_RELAY_KEY_1:-}" ]; then
+  export CUSTOM_LLM_API_KEY="$OPENSQUILLA_RELAY_KEY_1"
+fi
+
+if [ "$_count" -eq 0 ]; then
+  echo "✗ 还没有 Key。"
+  echo "  请先在系统终端执行："
+  echo "    cd \"/Users/linlang/04 AI鼓捣/Opensquilla/opensquilla-src\""
+  echo "    bash scripts/setup-relay-keys.sh"
+  return 1 2>/dev/null || exit 1
+fi
+
+echo "共 ${_count} 把 Key 已加载"
+echo "中转: ${OPENSQUILLA_RELAY_BASE_URL:-https://a.99cy.edu.kg/v1}"
+if [ -f "$STORE_FILE" ]; then
+  echo "来源: $STORE_FILE"
+else
+  echo "来源: 当前环境 / ANTHROPIC_AUTH_TOKEN"
+fi

--- a/scripts/probe-relay-models.sh
+++ b/scripts/probe-relay-models.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# 探测：每把中转 Key 分别能用哪些模型（不打印完整 Key）
+# 支持 Key1…Key20（有多少探测多少）
+#
+# 用法：
+#   source ~/.opensquilla/relay-keys.env
+#   bash scripts/probe-relay-models.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+if [ -f "${HOME}/.opensquilla/relay-keys.env" ]; then
+  # shellcheck disable=SC1090
+  . "${HOME}/.opensquilla/relay-keys.env"
+fi
+if [ -z "${OPENSQUILLA_RELAY_KEY_1:-}" ] && [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+  export OPENSQUILLA_RELAY_KEY_1="$ANTHROPIC_AUTH_TOKEN"
+fi
+
+BASE_URL="${OPENSQUILLA_RELAY_BASE_URL:-https://a.99cy.edu.kg/v1}"
+BASE_URL="${BASE_URL%/}"
+export OPENSQUILLA_PROBE_BASE_URL="$BASE_URL"
+
+# 把已设置的 KEY_1..20 全部 export 给 python
+MAX_KEYS=20
+for i in $(seq 1 "$MAX_KEYS"); do
+  eval "val=\${OPENSQUILLA_RELAY_KEY_$i:-}"
+  if [ -n "$val" ]; then
+    export OPENSQUILLA_RELAY_KEY_$i="$val"
+  fi
+done
+export OPENSQUILLA_PROBE_MAX_KEYS="$MAX_KEYS"
+
+PY="python3"
+if [ -x "$ROOT/.venv/bin/python" ]; then
+  PY="$ROOT/.venv/bin/python"
+fi
+
+exec "$PY" - "$ROOT" <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+BASE = os.environ.get("OPENSQUILLA_PROBE_BASE_URL", "https://a.99cy.edu.kg/v1").rstrip("/")
+MAX_KEYS = int(os.environ.get("OPENSQUILLA_PROBE_MAX_KEYS", "20"))
+ROOT = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
+
+KEYS: list[tuple[int, str, str]] = []
+for i in range(1, MAX_KEYS + 1):
+    name = f"OPENSQUILLA_RELAY_KEY_{i}"
+    val = (os.environ.get(name) or "").strip()
+    if val:
+        KEYS.append((i, name, val))
+
+
+def mask(k: str) -> str:
+    if not k:
+        return "(空)"
+    if len(k) <= 10:
+        return k[:2] + "***" + k[-2:]
+    return k[:6] + "…" + k[-4:]
+
+
+def http_json(method: str, url: str, key: str, body: dict | None = None, timeout: float = 25.0):
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "x-api-key": key,
+        "Content-Type": "application/json",
+    }
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", "replace")
+            return resp.status, raw
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", "replace")
+        return e.code, raw
+    except Exception as e:
+        return "ERR", f"{type(e).__name__}: {e}"
+
+
+def list_models(key: str) -> tuple[str, list[str], str]:
+    code, raw = http_json("GET", f"{BASE}/models", key, timeout=20)
+    if code != 200:
+        return f"失败 HTTP {code}", [], raw[:300]
+    try:
+        j = json.loads(raw)
+    except json.JSONDecodeError:
+        return "失败 JSON", [], raw[:300]
+    ids: list[str] = []
+    if isinstance(j, dict) and isinstance(j.get("data"), list):
+        for item in j["data"]:
+            if isinstance(item, dict) and item.get("id"):
+                ids.append(str(item["id"]))
+    elif isinstance(j, list):
+        for item in j:
+            if isinstance(item, dict) and item.get("id"):
+                ids.append(str(item["id"]))
+    return "OK", sorted(set(ids)), ""
+
+
+def smoke_chat(key: str, model: str) -> str:
+    code, raw = http_json(
+        "POST",
+        f"{BASE}/chat/completions",
+        key,
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": "只回复: pong"}],
+            "max_tokens": 16,
+            "temperature": 0,
+        },
+        timeout=45,
+    )
+    if code != 200:
+        return f"对话失败 HTTP {code}: {raw[:160].replace(chr(10), ' ')}"
+    try:
+        j = json.loads(raw)
+        content = j.get("choices", [{}])[0].get("message", {}).get("content", "")
+        return f"对话OK → {content!r}"
+    except Exception:
+        return f"对话OK(解析粗略) len={len(raw)}"
+
+
+CHEAP_HINTS = ("flash", "mini", "haiku", "lite", "small", "nano", "instant", "fast", "air")
+STRONG_HINTS = ("opus", "max", "pro", "ultra", "reasoner", "r1", "o1", "o3", "thinking")
+VISION_HINTS = ("vision", "vl", "image", "gpt-4o", "gemini", "grok-4")
+IMAGE_GEN_HINTS = ("imagine", "dall", "image-gen", "flux", "sdxl", "draw")
+
+
+def guess_role(mid: str) -> str:
+    m = mid.lower()
+    if any(h in m for h in IMAGE_GEN_HINTS):
+        return "生图(一般不当聊天档)"
+    if any(h in m for h in VISION_HINTS) and "imagine" not in m:
+        return "可能看图"
+    if any(h in m for h in CHEAP_HINTS):
+        return "建议 c0 便宜"
+    if any(h in m for h in STRONG_HINTS):
+        return "建议 c2/c3 强"
+    return "建议 c1 默认"
+
+
+print("=" * 56)
+print("  中转模型探测（每把 Key 单独问中转站）")
+print("=" * 56)
+print(f"中转: {BASE}")
+print(f"已加载 Key 数量: {len(KEYS)}")
+print("说明: Key 本身看不出模型；必须用这把 Key 调 /v1/models")
+print()
+
+if not KEYS:
+    print("✗ 一个 Key 都没有。请先:")
+    print("  bash scripts/setup-relay-keys.sh")
+    sys.exit(1)
+
+reports: list[dict] = []
+key_by_idx = {i: k for i, _, k in KEYS}
+
+for idx, env_name, key in KEYS:
+    print("-" * 56)
+    print(f"【Key{idx}】{env_name}")
+    print(f"  指纹: {mask(key)}  长度: {len(key)}")
+    status, models, err = list_models(key)
+    if status != "OK":
+        print(f"  列表: {status}")
+        if err:
+            print(f"  详情: {err}")
+        reports.append({"idx": idx, "models": [], "ok": False, "smokes": {}})
+        continue
+    print(f"  列表: OK，共 {len(models)} 个模型")
+    if not models:
+        print("  （空列表 — 这把 Key 的 group 可能没开模型）")
+    for mid in models:
+        print(f"    · {mid:40s}  {guess_role(mid)}")
+    chat_candidates = [
+        m for m in models if not any(h in m.lower() for h in IMAGE_GEN_HINTS)
+    ][:3]
+    if not chat_candidates and models:
+        chat_candidates = models[:1]
+    print("  冒烟对话:")
+    smokes: dict[str, str] = {}
+    for mid in chat_candidates:
+        result = smoke_chat(key, mid)
+        smokes[mid] = result
+        print(f"    · {mid}: {result}")
+    reports.append({"idx": idx, "models": models, "ok": True, "smokes": smokes})
+
+print("-" * 56)
+
+all_models: list[str] = []
+seen: set[str] = set()
+for r in reports:
+    for m in r.get("models") or []:
+        if m not in seen:
+            seen.add(m)
+            all_models.append(m)
+
+print()
+print("=" * 56)
+print("  汇总")
+print("=" * 56)
+print(f"全部 Key 合起来不重复模型数: {len(all_models)}")
+for m in all_models:
+    owners = [f"Key{r['idx']}" for r in reports if m in (r.get("models") or [])]
+    print(f"  · {m:40s}  来自 {','.join(owners)}  | {guess_role(m)}")
+
+model_sets = [tuple(r.get("models") or []) for r in reports if r.get("ok")]
+if len(model_sets) >= 2 and len(set(model_sets)) > 1:
+    print()
+    print("⚠ 不同 Key 的模型列表不一致 → 可能是不同套餐/group。")
+    print("  主路径默认用 Key1；Key2+ 目前是失败轮换，不会自动「按模型选 Key」。")
+    print("  若某模型只在 Key5 有，告诉我，我再帮你设计映射。")
+
+chat_models = [m for m in all_models if not any(h in m.lower() for h in IMAGE_GEN_HINTS)]
+cheap = [m for m in chat_models if guess_role(m).startswith("建议 c0")]
+strong = [m for m in chat_models if "c2/c3" in guess_role(m)]
+mid = [m for m in chat_models if m not in cheap and m not in strong]
+c0 = cheap[0] if cheap else (mid[0] if mid else (chat_models[0] if chat_models else ""))
+c1 = mid[0] if mid else c0
+c2 = strong[0] if strong else (mid[1] if len(mid) > 1 else c1)
+c3 = strong[-1] if strong else c2
+img = next(
+    (
+        m
+        for m in all_models
+        if "imagine" not in m.lower()
+        and any(h in m.lower() for h in ("vision", "vl", "4o", "gemini"))
+    ),
+    c1,
+)
+
+print()
+print("=" * 56)
+print("  建议档位草稿（按名字猜，仅供参考）")
+print("=" * 56)
+if not chat_models:
+    print("  没有可用聊天模型，无法建议。")
+else:
+    print(f"  c0 便宜: {c0}")
+    print(f"  c1 默认: {c1}")
+    print(f"  c2 较强: {c2}")
+    print(f"  c3 最强: {c3}")
+    print(f"  看图:   {img}")
+    print()
+    print("  → 把本终端从「Key1」到「汇总」整段复制发给瓜娃子，")
+    print("    我按真实名单改 opensquilla.toml 路由档位。")
+
+out = Path.home() / ".opensquilla" / "relay-models-report.json"
+out.parent.mkdir(parents=True, exist_ok=True)
+payload = {
+    "base_url": BASE,
+    "key_count": len(KEYS),
+    "keys": [
+        {
+            "index": r["idx"],
+            "ok": r.get("ok"),
+            "models": r.get("models") or [],
+            "smokes": r.get("smokes") or {},
+            "fingerprint": mask(key_by_idx.get(r["idx"], "")),
+        }
+        for r in reports
+    ],
+    "union_models": all_models,
+    "suggested_tiers": {
+        "c0": c0,
+        "c1": c1,
+        "c2": c2,
+        "c3": c3,
+        "image_model": img,
+    }
+    if chat_models
+    else {},
+}
+out.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+print()
+print(f"报告已保存: {out}")
+print("（不含完整 Key，只有指纹和模型名）")
+PY

--- a/scripts/setup-relay-keys.sh
+++ b/scripts/setup-relay-keys.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# 桥爷专用：一次性把「任意多个」中转 Key 存到本机
+# 用法：在系统「终端.app」里执行
+#   cd "/Users/linlang/04 AI鼓捣/Opensquilla/opensquilla-src"
+#   bash scripts/setup-relay-keys.sh
+#
+# 会写入：~/.opensquilla/relay-keys.env（仅你可读写）
+# 可以 1 个、3 个、10 个…… 有多少填多少；空行结束
+
+set -euo pipefail
+
+STORE_DIR="${HOME}/.opensquilla"
+STORE_FILE="${STORE_DIR}/relay-keys.env"
+# 安全上限，防止误操作狂贴；真要更多改这个数即可
+MAX_KEYS=20
+
+mkdir -p "$STORE_DIR"
+chmod 700 "$STORE_DIR" 2>/dev/null || true
+
+echo "=========================================="
+echo "  OpenSquilla 中转 Key 设置向导"
+echo "=========================================="
+echo ""
+echo "有多少把 Key 就填多少把（最多 ${MAX_KEYS} 把）。"
+echo "某一把直接回车 = 结束输入。"
+echo "粘贴时屏幕可能不显示字符，正常；输完按回车。"
+echo ""
+
+if [ ! -t 0 ]; then
+  echo "当前不是交互终端，无法现场输入。"
+  echo "请在系统「终端.app」里执行本脚本。"
+  exit 1
+fi
+
+if [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+  echo "检测到本机已有 ANTHROPIC_AUTH_TOKEN（Claude 在用的那把）。"
+  echo "第 1 把若直接回车，会自动复用它。"
+  echo ""
+fi
+
+# 读入多把 Key
+KEYS=()
+i=1
+while [ "$i" -le "$MAX_KEYS" ]; do
+  if [ "$i" -eq 1 ] && [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+    printf "第 %d 把 Key（必填；回车=复用 Claude 那把）: " "$i"
+  elif [ "$i" -eq 1 ]; then
+    printf "第 %d 把 Key（必填）: " "$i"
+  else
+    printf "第 %d 把 Key（没有了就直接回车结束）: " "$i"
+  fi
+  IFS= read -r val || true
+  # 去掉首尾空白
+  val="$(printf '%s' "$val" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+
+  if [ -z "$val" ]; then
+    if [ "$i" -eq 1 ] && [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+      val="$ANTHROPIC_AUTH_TOKEN"
+      echo "  → 已复用 ANTHROPIC_AUTH_TOKEN（长度 ${#val}）"
+      KEYS+=("$val")
+      i=$((i + 1))
+      continue
+    fi
+    if [ "$i" -eq 1 ]; then
+      echo "✗ 至少需要 1 把 Key" >&2
+      exit 1
+    fi
+    echo "  → 结束输入（共 $((i - 1)) 把）"
+    break
+  fi
+
+  KEYS+=("$val")
+  echo "  → 已收下第 $i 把（长度 ${#val}）"
+  i=$((i + 1))
+done
+
+n=${#KEYS[@]}
+if [ "$n" -eq 0 ]; then
+  echo "✗ 没有收到任何 Key" >&2
+  exit 1
+fi
+
+_escape() {
+  printf "%s" "$1" | sed "s/'/'\\\\''/g"
+}
+
+umask 077
+{
+  echo "# 由 setup-relay-keys.sh 生成 — 勿提交 git、勿发给别人"
+  echo "# 生成时间: $(date '+%Y-%m-%d %H:%M:%S')"
+  echo "# 共 ${n} 把 Key"
+  echo "export OPENSQUILLA_RELAY_KEY_COUNT='${n}'"
+  idx=1
+  for k in "${KEYS[@]}"; do
+    echo "export OPENSQUILLA_RELAY_KEY_${idx}='$(_escape "$k")'"
+    idx=$((idx + 1))
+  done
+  # 清空可能残留的旧 KEY（上次填了 10 把、这次只填 4 把）
+  for ((j = n + 1; j <= MAX_KEYS; j++)); do
+    echo "unset OPENSQUILLA_RELAY_KEY_${j} 2>/dev/null || true"
+  done
+  echo 'export CUSTOM_LLM_API_KEY="$OPENSQUILLA_RELAY_KEY_1"'
+} > "$STORE_FILE"
+chmod 600 "$STORE_FILE"
+
+echo ""
+echo "✓ 已保存 ${n} 把 Key → $STORE_FILE"
+echo "  权限: 仅你自己可读写"
+echo ""
+idx=1
+for k in "${KEYS[@]}"; do
+  echo "  Key${idx}: 长度 ${#k}"
+  idx=$((idx + 1))
+done
+
+echo ""
+echo "是否写入 ~/.zshrc，让以后每个新终端自动加载？(y/N)"
+printf "> "
+IFS= read -r ans || true
+if [ "${ans:-}" = "y" ] || [ "${ans:-}" = "Y" ]; then
+  MARKER="# OpenSquilla relay keys (auto)"
+  ZSHRC="${HOME}/.zshrc"
+  touch "$ZSHRC"
+  if grep -Fq "$MARKER" "$ZSHRC" 2>/dev/null; then
+    echo "· ~/.zshrc 里已有自动加载行，跳过"
+  else
+    {
+      echo ""
+      echo "$MARKER"
+      echo "[ -f \"\$HOME/.opensquilla/relay-keys.env\" ] && source \"\$HOME/.opensquilla/relay-keys.env\""
+    } >> "$ZSHRC"
+    echo "✓ 已写入 ~/.zshrc（新开终端自动带 Key）"
+  fi
+fi
+
+echo ""
+echo "下一步（复制整段执行）："
+echo "  source \"$STORE_FILE\""
+echo "  cd \"/Users/linlang/04 AI鼓捣/Opensquilla/opensquilla-src\""
+echo "  bash scripts/probe-relay-models.sh"
+echo ""
+echo "探测脚本会告诉你：第几把 Key → 能用哪些模型。"
+echo "把终端输出发我，我帮你写进路由档位。"

--- a/scripts/switch-routing-mode.sh
+++ b/scripts/switch-routing-mode.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# 在「单模型智能路由」和「多模型集成」之间切换
+#
+#   ./scripts/switch-routing-mode.sh single   # 默认：省钱智能路由
+#   ./scripts/switch-routing-mode.sh multi    # 多模型一起答再融合
+#   ./scripts/switch-routing-mode.sh status
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CFG="$ROOT/opensquilla.toml"
+MODE="${1:-}"
+
+if [[ ! -f "$CFG" ]]; then
+  echo "找不到 $CFG" >&2
+  exit 1
+fi
+
+_py_toggle() {
+  local mode="$1"
+  python3 - "$CFG" "$mode" <<'PY'
+import re, sys
+from pathlib import Path
+path = Path(sys.argv[1])
+mode = sys.argv[2]
+text = path.read_text(encoding="utf-8")
+
+def set_in_section(text, section, key, value):
+    # very small TOML patcher for boolean keys we own
+    pat = re.compile(
+        rf"(?ms)^(\[{re.escape(section)}\][^\[]*?)(^{re.escape(key)}\s*=\s*)(true|false)",
+        re.MULTILINE,
+    )
+    def repl(m):
+        return m.group(1) + m.group(2) + value
+    new, n = pat.subn(repl, text, count=1)
+    if n != 1:
+        raise SystemExit(f"无法在 [{section}] 找到 {key}=true|false，请手改 opensquilla.toml")
+    return new
+
+if mode == "single":
+    text = set_in_section(text, "llm_ensemble", "enabled", "false")
+    text = set_in_section(text, "squilla_router", "enabled", "true")
+elif mode == "multi":
+    text = set_in_section(text, "llm_ensemble", "enabled", "true")
+    text = set_in_section(text, "squilla_router", "enabled", "false")
+else:
+    raise SystemExit("mode must be single|multi")
+
+path.write_text(text, encoding="utf-8")
+print(f"已切换为 {mode}: {path}")
+PY
+}
+
+_status() {
+  python3 - "$CFG" <<'PY'
+import re, sys
+from pathlib import Path
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+def grab(section, key):
+    m = re.search(rf"(?ms)^\[{re.escape(section)}\][^\[]*?^{re.escape(key)}\s*=\s*(true|false)", text, re.M)
+    return m.group(1) if m else "?"
+ens = grab("llm_ensemble", "enabled")
+rt = grab("squilla_router", "enabled")
+print(f"llm_ensemble.enabled = {ens}")
+print(f"squilla_router.enabled = {rt}")
+if ens == "true" and rt == "false":
+    print("当前模式: multi（多模型集成）")
+elif ens == "false" and rt == "true":
+    print("当前模式: single（单模型智能路由）")
+else:
+    print("当前模式: 自定义/混合（请检查 toml）")
+PY
+}
+
+case "$MODE" in
+  single|multi)
+    _py_toggle "$MODE"
+    echo "记得: opensquilla gateway reload"
+    ;;
+  status|"")
+    _status
+    if [[ -z "$MODE" ]]; then
+      echo "用法: $0 single|multi|status"
+    fi
+    ;;
+  *)
+    echo "用法: $0 single|multi|status" >&2
+    exit 1
+    ;;
+esac

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -5223,6 +5223,37 @@ class TurnRunner:
 
         ensemble_cfg = getattr(self._config, "llm_ensemble", None)
         if provider is not None and getattr(ensemble_cfg, "enabled", False):
+            # -- simple-turn bypass --
+            # When simple_turn_bypass="adaptive", skip the ensemble wrap for
+            # turns the squilla router confidently classified as c0 (short
+            # conversational) with no code blocks or attachments. The router's
+            # anti_downgrade stage already holds final_tier at the previous
+            # turn's level within the KV-cache window, so a brief "ok" after
+            # a c2 code task stays c2 and the ensemble fires normally.
+            bypass_mode = str(
+                getattr(ensemble_cfg, "simple_turn_bypass", "never") or "never"
+            )
+            if bypass_mode == "adaptive":
+                _extra = turn.metadata.get("routing_extra") or {}
+                _final_tier = normalize_text_tier(_extra.get("final_tier"))
+                # dict.get returns None (not the default) when the key
+                # exists with value None, so guard float() with "or 0.0".
+                _margin = float(_extra.get("margin") or 0.0)
+                if (
+                    _final_tier == "c0"
+                    and _margin >= 0.6
+                    and not turn.attachments
+                    and "```" not in (turn.semantic_message or "")
+                ):
+                    turn.metadata["ensemble_wrap_skipped_reason"] = (
+                        "simple_turn_bypass"
+                    )
+                    log.info(
+                        "llm_ensemble.simple_turn_bypass",
+                        tier=_final_tier,
+                        margin=round(_margin, 4),
+                    )
+                    return turn, provider
             from opensquilla.provider.ensemble import (
                 CUSTOM_B5_SELECTION_MODE,
                 build_ensemble_provider_from_config,

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -461,6 +461,9 @@ class LlmEnsembleConfig(BaseSettings):
     aggregator_timeout_seconds: float = Field(default=3600.0, gt=0.0)
     shuffle_candidates: bool = True
     record_candidates: bool = False
+    # When "adaptive", skip the ensemble wrap for turns the squilla router
+    # confidently classifies as c0 (short conversational). Default "never".
+    simple_turn_bypass: Literal["never", "adaptive"] = "never"
 
     @model_validator(mode="after")
     def _validate_model_options(self) -> LlmEnsembleConfig:

--- a/src/opensquilla/provider/compat_policy.py
+++ b/src/opensquilla/provider/compat_policy.py
@@ -303,7 +303,9 @@ _POLICIES_BY_KIND: dict[str, OpenAICompatPolicy] = {
         ),
         require_reasoning_content_model_ids=_DEEPSEEK_V4_MODEL_IDS,
         allow_post_terminal_noop_choice=True,
-        post_terminal_metadata_keys=frozenset({"cost_cny", "trace_id"}),
+        post_terminal_metadata_keys=frozenset(
+            {"billing_pending", "cost_cny", "reasoning_available", "trace_id"}
+        ),
     ),
     "lm_studio": OpenAICompatPolicy(display_name="LM Studio"),
     "ovms": OpenAICompatPolicy(display_name="OpenVINO Model Server"),


### PR DESCRIPTION
# PR: Ensemble simple-turn bypass

## What

When `llm_ensemble.simple_turn_bypass = "adaptive"`, turns that the squilla router
confidently classifies as c0 (short conversational, no code blocks, no attachments)
skip the ensemble wrap and run on a single model instead.

When `llm_ensemble.simple_turn_bypass = "never"` (default), behaviour is unchanged.

## Why

With `llm_ensemble.enabled = true`, every turn — including "好的", "可以",
"这个文件叫什么" — fires every proposer and the aggregator, costing 4–5× more
than a single-model turn. This is the most common complaint from paid users who
leave ensemble enabled.

The squilla router already classifies every turn into c0–c3 *before* the ensemble
wrap, and writes the result into `turn.metadata.routing_extra`. That classification
is currently recorded but never used to gate the ensemble decision. This PR closes
that gap.

## Design

### Why `final_tier` instead of raw `difficulty`?

The router's policy pipeline includes an `anti_downgrade` stage: within the
KV-cache window, the final tier is never lower than the previous turn's tier.
That means a brief "好的" after a c2 code task stays c2, and the bypass does
not fire — the ensemble fires normally. Using `final_tier` instead of the raw
difficulty score gives us this context-aware protection for free, no extra code.

### Bypass conditions (all must hold)

- `final_tier == "c0"` — the router classified the turn as short conversational
- `margin >= 0.6` — the router is confident (top-1 minus top-2 probability)
- no attachments, no code fences — content-level safety net
- `simple_turn_bypass != "never"` — config switch (default off)

### Why c0 only, not c0+c1?

c0 is the `short_conversational` tier; c1 is the default tier that catches a wide
band of borderline inputs. Restricting the bypass to c0 ensures we only skip
unambiguously trivial turns.

### Why margin 0.6?

Margin is top-1 minus top-2 probability. 0.6 means the router is very confident.
For a cost-saving decision like skipping the ensemble, we prefer false negatives
(missed savings) over false positives (wrongly skipping a complex turn).

## Changes

- `gateway/config.py`: +3 lines — `simple_turn_bypass` field on `LlmEnsembleConfig`
- `engine/runtime.py`: +31 lines — bypass check before the ensemble import+wrap block

No changes to `provider/ensemble.py` or the router step.

## Defensive checks

- `_margin = float(_extra.get("margin") or 0.0)` guards against `None` values
  written by the router step. `dict.get(key, default)` would still return `None`
  if the key exists with value `None`, causing `TypeError` on `float(None)`.
- `normalize_text_tier(None)` returns `None` (not an exception), so a missing
  `final_tier` safely fails the `== "c0"` check.
- Bypass uses the same `ensemble_wrap_skipped_reason` metadata key as the other
  skip paths (lines 5304, 5315), keeping the observability surface consistent.
  The `ensemble_enabled` flag is never set to `True`, so downstream code in
  `router_decision_record.py:261` correctly records `executed_kind = "single"`.

## Test cases

1. c0 + margin = 0.9 + "你好" → bypass fires, single model
2. c2 + any margin → no bypass, ensemble fires
3. c0 + margin = 0.3 → no bypass (classifier uncertain)
4. c0 + margin = 0.9 + code block → no bypass (content safety net)
5. `routing_extra` absent → no bypass (safety default)
6. `simple_turn_bypass = "never"` → no bypass (config off)
7. prev turn c2 + current "好的" → no bypass (anti_downgrade holds tier at c2)
8. `routing_extra.margin` is `None` → no bypass and no `TypeError`

## Backward compatibility

Default is `"never"`. Existing users see zero behaviour change.
