### PR TITLE
Client Migration-Phase 1-Establish Public UI Package Baseline

### DIFF
--- a/.github/scripts/check_ci_results.py
+++ b/.github/scripts/check_ci_results.py
@@ -84,6 +84,11 @@ def check_ci_results(env: Mapping[str, str]) -> list[str]:
             or flags["desktop_changed"]
             or full,
         ),
+        (
+            "RESULT_UI_PACKAGES",
+            "Public UI package matrix",
+            flags["frontend_changed"] or full,
+        ),
         ("RESULT_TUI", "OpenTUI package tests", flags["tui_changed"] or full),
         ("RESULT_DESKTOP", "Desktop Electron unit tests", flags["desktop_changed"] or full),
         ("RESULT_UBUNTU", "Ubuntu quality gate", flags["python_changed"] or full),

--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -118,6 +118,12 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
     opensquilla-webui/*)
       mark_frontend_changed
       ;;
+    package.json | package-lock.json | tsconfig.ui-package.json | packages/ui-package-manifest.json | packages/ui-*/* | scripts/verify_ui_packages.mjs)
+      # Public UI Foundation packages are browser-safe client inputs. They
+      # have their own cross-platform pack/install gate and never wake the
+      # Python runtime or release-wheel path.
+      mark_frontend_changed
+      ;;
     contracts/client/* | packages/client-sdk/*)
       mark_client_contract_changed
       ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,33 @@ jobs:
       - name: Run actionlint
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color=false
 
+  ui-packages-check:
+    name: Public UI packages (${{ matrix.os }})
+    needs: classify-changes
+    if: ${{ needs.classify-changes.outputs.frontend_changed == 'true' || needs.classify-changes.outputs.full_required == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: opensquilla-webui/.node-version
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install public UI package dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Verify public UI package boundaries
+        run: npm run verify:ui-packages
+
   frontend-check:
     name: Frontend build, tests, and artifact
     needs: classify-changes
@@ -1188,6 +1215,7 @@ jobs:
       - classify-changes
       - workflow-lint
       - readme-locale-check
+      - ui-packages-check
       - frontend-check
       - webui-chat-recovery
       - tui-check
@@ -1235,6 +1263,7 @@ jobs:
           RESULT_CLASSIFY: ${{ needs.classify-changes.result }}
           RESULT_WORKFLOW_LINT: ${{ needs.workflow-lint.result }}
           RESULT_README_LOCALE: ${{ needs.readme-locale-check.result }}
+          RESULT_UI_PACKAGES: ${{ needs.ui-packages-check.result }}
           RESULT_FRONTEND: ${{ needs.frontend-check.result }}
           RESULT_TUI: ${{ needs.tui-check.result }}
           RESULT_DESKTOP: ${{ needs.desktop-check.result }}

--- a/.gitignore
+++ b/.gitignore
@@ -84,11 +84,15 @@ crontab-*
 tests/functional/reports/
 
 # Frontend build artifacts
+/node_modules/
 opensquilla-webui/node_modules/
 opensquilla-webui/dist/
 packages/client-sdk/node_modules/
 packages/client-sdk/dist/
 packages/client-sdk/*.tgz
+packages/ui-*/node_modules/
+packages/ui-*/dist/
+packages/ui-*/*.tgz
 src/opensquilla/gateway/static/dist/
 
 # Local-only release-hygiene tests that reference legacy artifact names

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,74 @@
+{
+  "name": "opensquilla-ui-package-workspace",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "opensquilla-ui-package-workspace",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "packages/ui-tokens",
+        "packages/ui-primitives",
+        "packages/ui-foundation"
+      ],
+      "devDependencies": {
+        "typescript": "^5.4.5"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@opensquilla/ui-foundation": {
+      "resolved": "packages/ui-foundation",
+      "link": true
+    },
+    "node_modules/@opensquilla/ui-primitives": {
+      "resolved": "packages/ui-primitives",
+      "link": true
+    },
+    "node_modules/@opensquilla/ui-tokens": {
+      "resolved": "packages/ui-tokens",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/ui-foundation": {
+      "name": "@opensquilla/ui-foundation",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "packages/ui-primitives": {
+      "name": "@opensquilla/ui-primitives",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "packages/ui-tokens": {
+      "name": "@opensquilla/ui-tokens",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "opensquilla-ui-package-workspace",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Build workspace for the public OpenSquilla UI Foundation packages",
+  "type": "module",
+  "packageManager": "npm@10.9.0",
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "workspaces": [
+    "packages/ui-tokens",
+    "packages/ui-primitives",
+    "packages/ui-foundation"
+  ],
+  "scripts": {
+    "build:ui-packages": "npm run build --workspaces --if-present",
+    "typecheck:ui-packages": "npm run typecheck --workspaces --if-present",
+    "verify:ui-packages": "npm run typecheck:ui-packages && npm run build:ui-packages && node scripts/verify_ui_packages.mjs"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/ui-foundation/README.md
+++ b/packages/ui-foundation/README.md
@@ -1,0 +1,9 @@
+# OpenSquilla UI Foundation
+
+Public, product-neutral composition contracts and shared client infrastructure.
+The initial package establishes a versioned distribution boundary; stable state
+and extension contracts will be added as they are extracted from the public
+WebUI.
+
+Only the package root is public. Imports from `src/` or other internal paths
+are unsupported.

--- a/packages/ui-foundation/package.json
+++ b/packages/ui-foundation/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@opensquilla/ui-foundation",
+  "version": "0.1.0",
+  "description": "Product-neutral composition contracts for OpenSquilla clients",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/opensquilla/opensquilla.git",
+    "directory": "packages/ui-foundation"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/ui-foundation/src/index.ts
+++ b/packages/ui-foundation/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Public entry point for product-neutral UI composition contracts.
+ *
+ * The package boundary is intentionally empty until its first stable
+ * composition contract is extracted from the public WebUI.
+ */
+export {}

--- a/packages/ui-foundation/tsconfig.json
+++ b/packages/ui-foundation/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.ui-package.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/ui-package-manifest.json
+++ b/packages/ui-package-manifest.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "releaseTrain": "public-ui-foundation",
+  "versionPolicy": "independent",
+  "packages": [
+    {
+      "name": "@opensquilla/client-sdk",
+      "path": "packages/client-sdk",
+      "version": "0.1.0",
+      "role": "gateway-client-sdk",
+      "workspace": false
+    },
+    {
+      "name": "@opensquilla/ui-tokens",
+      "path": "packages/ui-tokens",
+      "version": "0.1.0",
+      "role": "design-contracts",
+      "workspace": true
+    },
+    {
+      "name": "@opensquilla/ui-primitives",
+      "path": "packages/ui-primitives",
+      "version": "0.1.0",
+      "role": "browser-safe-primitives",
+      "workspace": true
+    },
+    {
+      "name": "@opensquilla/ui-foundation",
+      "path": "packages/ui-foundation",
+      "version": "0.1.0",
+      "role": "product-neutral-composition",
+      "workspace": true
+    }
+  ]
+}

--- a/packages/ui-primitives/README.md
+++ b/packages/ui-primitives/README.md
@@ -1,0 +1,8 @@
+# OpenSquilla UI Primitives
+
+Public, browser-safe UI primitives for OpenSquilla clients. The initial package
+establishes a versioned distribution boundary; stable primitives will be added
+only after their product-neutral contracts are defined.
+
+Only the package root is public. Imports from `src/` or other internal paths
+are unsupported.

--- a/packages/ui-primitives/package.json
+++ b/packages/ui-primitives/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@opensquilla/ui-primitives",
+  "version": "0.1.0",
+  "description": "Browser-safe UI primitives for OpenSquilla clients",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/opensquilla/opensquilla.git",
+    "directory": "packages/ui-primitives"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/ui-primitives/src/index.ts
+++ b/packages/ui-primitives/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Public entry point for browser-safe, product-neutral UI primitives.
+ *
+ * The package boundary is intentionally empty until its first stable
+ * primitive is extracted from the public WebUI.
+ */
+export {}

--- a/packages/ui-primitives/tsconfig.json
+++ b/packages/ui-primitives/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.ui-package.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/ui-tokens/README.md
+++ b/packages/ui-tokens/README.md
@@ -1,0 +1,8 @@
+# OpenSquilla UI Tokens
+
+Public, product-neutral design token and theme contracts for OpenSquilla
+clients. The initial package establishes a versioned distribution boundary;
+stable token exports will be added as they are extracted from the public WebUI.
+
+Only the package root is public. Imports from `src/` or other internal paths
+are unsupported.

--- a/packages/ui-tokens/package.json
+++ b/packages/ui-tokens/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@opensquilla/ui-tokens",
+  "version": "0.1.0",
+  "description": "Product-neutral design token contracts for OpenSquilla clients",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/opensquilla/opensquilla.git",
+    "directory": "packages/ui-tokens"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/ui-tokens/src/index.ts
+++ b/packages/ui-tokens/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Public entry point for product-neutral design tokens and theme contracts.
+ *
+ * The package boundary is intentionally empty until its first stable contract
+ * is extracted from the public WebUI.
+ */
+export {}

--- a/packages/ui-tokens/tsconfig.json
+++ b/packages/ui-tokens/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.ui-package.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/scripts/verify_ui_packages.mjs
+++ b/scripts/verify_ui_packages.mjs
@@ -1,0 +1,254 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const manifestPath = path.join(repositoryRoot, 'packages', 'ui-package-manifest.json')
+const temporaryRoot = await mkdtemp(path.join(tmpdir(), 'opensquilla-ui-packages-'))
+const npmEntry = process.env.npm_execpath
+
+if (!npmEntry) {
+  throw new Error('Run package verification through npm so npm_execpath is available')
+}
+
+function run(command, args, cwd, extraEnv = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      npm_config_audit: 'false',
+      npm_config_cache: path.join(temporaryRoot, 'npm-cache'),
+      npm_config_fund: 'false',
+      ...extraEnv,
+    },
+  })
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `${path.basename(command)} ${args.join(' ')} failed`,
+        result.stdout,
+        result.stderr,
+      ].filter(Boolean).join('\n'),
+    )
+  }
+  return result.stdout
+}
+
+function npm(args, cwd) {
+  return run(process.execPath, [npmEntry, ...args], cwd)
+}
+
+function assertPackageMetadata(record, packageJson) {
+  assert.equal(packageJson.name, record.name)
+  assert.equal(packageJson.version, record.version)
+  assert.equal(packageJson.private, undefined, `${record.name} must remain publishable`)
+  assert.equal(packageJson.license, 'Apache-2.0')
+  assert.equal(packageJson.sideEffects, false)
+  assert.deepEqual(Object.keys(packageJson.exports), ['.'])
+  assert.equal(packageJson.exports['.'].types, './dist/index.d.ts')
+  assert.equal(packageJson.exports['.'].import, './dist/index.js')
+  assert.equal(packageJson.publishConfig.access, 'public')
+  assert.equal(packageJson.publishConfig.provenance, true)
+  assert.equal(packageJson.engines.node, '>=22.12.0')
+  assert.match(packageJson.version, /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)
+}
+
+function assertPackedFiles(record, packed) {
+  assert.ok(packed.filename, `${record.name}: npm pack did not report a tarball`)
+  assert.match(packed.integrity, /^sha512-/)
+  assert.match(packed.shasum, /^[0-9a-f]{40}$/)
+
+  const allowed = new Set([
+    'LICENSE',
+    'README.md',
+    'dist/index.d.ts',
+    'dist/index.js',
+    'package.json',
+  ])
+  const paths = packed.files.map((entry) => entry.path).sort()
+  for (const entry of paths) {
+    assert.ok(allowed.has(entry), `${record.name}: unexpected packaged file ${entry}`)
+    assert.ok(!entry.startsWith('src/'), `${record.name}: source directory leaked into package`)
+    assert.ok(!entry.endsWith('.map'), `${record.name}: source map leaked into package`)
+  }
+  assert.ok(paths.includes('README.md'), `${record.name}: README is missing`)
+  assert.ok(paths.includes('dist/index.js'), `${record.name}: JavaScript entry is missing`)
+  assert.ok(paths.includes('dist/index.d.ts'), `${record.name}: type entry is missing`)
+}
+
+function assertCleanArtifactText(record, text) {
+  const forbidden = [
+    repositoryRoot,
+    temporaryRoot,
+    '/private/tmp/',
+    '/Users/',
+    'C:\\Users\\',
+    'OPENSQUILLA_PRIVATE',
+    'PRIVATE_CLIENT_REPOSITORY',
+  ]
+  for (const value of forbidden) {
+    assert.ok(!text.includes(value), `${record.name}: artifact contains forbidden text ${value}`)
+  }
+  assert.ok(
+    !/(?:sk|ghp|xox[baprs])-[A-Za-z0-9_-]{16,}/.test(text),
+    `${record.name}: artifact contains a secret-shaped value`,
+  )
+}
+
+try {
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+  assert.equal(manifest.schemaVersion, 1)
+  assert.equal(manifest.releaseTrain, 'public-ui-foundation')
+  assert.equal(manifest.versionPolicy, 'independent')
+
+  const rootPackage = JSON.parse(
+    await readFile(path.join(repositoryRoot, 'package.json'), 'utf8'),
+  )
+  assert.equal(rootPackage.private, true)
+  assert.equal(rootPackage.packageManager, 'npm@10.9.0')
+  assert.equal(rootPackage.engines.node, '>=22.12.0')
+
+  const workspaceRecords = manifest.packages.filter((record) => record.workspace)
+  assert.deepEqual(
+    [...rootPackage.workspaces].sort(),
+    workspaceRecords.map((record) => record.path).sort(),
+  )
+
+  const packedTarballs = []
+  for (const record of manifest.packages) {
+    const packageRoot = path.join(repositoryRoot, record.path)
+    const packageJson = JSON.parse(
+      await readFile(path.join(packageRoot, 'package.json'), 'utf8'),
+    )
+    assert.equal(packageJson.name, record.name)
+    assert.equal(packageJson.version, record.version)
+
+    if (!record.workspace) {
+      continue
+    }
+
+    assertPackageMetadata(record, packageJson)
+    const output = npm(
+      [
+        'pack',
+        '--json',
+        '--ignore-scripts',
+        '--pack-destination',
+        temporaryRoot,
+        packageRoot,
+      ],
+      repositoryRoot,
+    )
+    const [packed] = JSON.parse(output)
+    assertPackedFiles(record, packed)
+    packedTarballs.push({
+      ...record,
+      tarball: path.join(temporaryRoot, packed.filename),
+    })
+  }
+
+  const consumer = path.join(temporaryRoot, 'consumer')
+  await mkdir(consumer)
+  await writeFile(
+    path.join(consumer, 'package.json'),
+    JSON.stringify({ name: 'external-ui-package-smoke', private: true, type: 'module' }),
+  )
+  npm(
+    [
+      'install',
+      '--ignore-scripts',
+      '--offline',
+      '--no-package-lock',
+      ...packedTarballs.map((record) => record.tarball),
+    ],
+    consumer,
+  )
+
+  const imports = packedTarballs
+    .map((record) => `import * as ${record.role.replaceAll('-', '_')} from '${record.name}'`)
+  const typeUses = packedTarballs
+    .map((record) => `void ${record.role.replaceAll('-', '_')}`)
+  await writeFile(
+    path.join(consumer, 'smoke.ts'),
+    [...imports, '', ...typeUses, ''].join('\n'),
+  )
+  await writeFile(
+    path.join(consumer, 'tsconfig.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          exactOptionalPropertyTypes: true,
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          noEmit: true,
+          strict: true,
+          target: 'ES2022',
+        },
+        include: ['smoke.ts'],
+      },
+      null,
+      2,
+    ),
+  )
+  run(
+    process.execPath,
+    [path.join(repositoryRoot, 'node_modules', 'typescript', 'bin', 'tsc'), '-p', 'tsconfig.json'],
+    consumer,
+  )
+
+  await writeFile(
+    path.join(consumer, 'smoke.mjs'),
+    [
+      "import assert from 'node:assert/strict'",
+      `const packageNames = ${JSON.stringify(packedTarballs.map((record) => record.name))}`,
+      'for (const packageName of packageNames) {',
+      '  const publicEntry = await import(packageName)',
+      "  assert.deepEqual(Object.keys(publicEntry), [], `${packageName}: initial boundary is not empty`)",
+      '  await assert.rejects(',
+      "    import(`${packageName}/src/index.js`),",
+      "    error => error?.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED',",
+      '  )',
+      '}',
+      '',
+    ].join('\n'),
+  )
+  run(process.execPath, ['smoke.mjs'], consumer)
+
+  for (const record of packedTarballs) {
+    const installedRoot = path.join(
+      consumer,
+      'node_modules',
+      ...record.name.split('/'),
+    )
+    const artifactText = (
+      await Promise.all(
+        ['README.md', 'dist/index.d.ts', 'dist/index.js', 'package.json'].map((entry) =>
+          readFile(path.join(installedRoot, entry), 'utf8'),
+        ),
+      )
+    ).join('\n')
+    assertCleanArtifactText(record, artifactText)
+  }
+
+  const sbom = JSON.parse(
+    npm(
+      ['sbom', '--package-lock-only', '--omit=dev', '--sbom-format=spdx'],
+      repositoryRoot,
+    ),
+  )
+  assert.equal(sbom.spdxVersion, 'SPDX-2.3')
+  const sbomNames = new Set(sbom.packages.map((entry) => entry.name))
+  for (const record of workspaceRecords) {
+    assert.ok(sbomNames.has(record.name), `${record.name}: missing from workspace SBOM`)
+  }
+
+  console.log(
+    `Verified ${packedTarballs.length} public UI packages in an external consumer`,
+  )
+} finally {
+  await rm(temporaryRoot, { recursive: true, force: true })
+}

--- a/tests/test_ci/test_ci_result_gate.py
+++ b/tests/test_ci/test_ci_result_gate.py
@@ -19,6 +19,7 @@ def _base_env() -> dict[str, str]:
         "RESULT_CLASSIFY": "success",
         "RESULT_WORKFLOW_LINT": "success",
         "RESULT_README_LOCALE": "success",
+        "RESULT_UI_PACKAGES": "skipped",
         "RESULT_FRONTEND": "skipped",
         "RESULT_TUI": "skipped",
         "RESULT_DESKTOP": "skipped",
@@ -204,6 +205,21 @@ def test_ci_result_gate_requires_desktop_recovery_e2e_for_frontend_changes() -> 
     errors = check_ci_results(env)
 
     assert any("Desktop recovery E2E matrix" in error and "skipped" in error for error in errors)
+
+
+def test_ci_result_gate_requires_public_ui_packages_for_frontend_changes() -> None:
+    env = _base_env()
+    env[_flag_env("docs_only")] = "false"
+    env[_flag_env("frontend_changed")] = "true"
+    env["RESULT_FRONTEND"] = "success"
+    env["RESULT_DESKTOP_RECOVERY_E2E"] = "success"
+    env["RESULT_CLIENT_CONTRACT"] = "success"
+
+    errors = check_ci_results(env)
+
+    assert any("Public UI package matrix" in error and "skipped" in error for error in errors)
+    env["RESULT_UI_PACKAGES"] = "success"
+    assert check_ci_results(env) == []
 
 
 def test_ci_result_gate_rejects_failed_or_missing_desktop_recovery_e2e() -> None:

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -610,6 +610,26 @@ def test_ci_change_classifier_routes_client_sdk_to_python_and_frontend(
     )
 
 
+def test_ci_change_classifier_routes_public_ui_packages_to_frontend_only(
+    tmp_path: Path,
+) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [
+            "package.json",
+            "package-lock.json",
+            "tsconfig.ui-package.json",
+            "packages/ui-package-manifest.json",
+            "packages/ui-tokens/src/index.ts",
+            "packages/ui-primitives/package.json",
+            "packages/ui-foundation/README.md",
+            "scripts/verify_ui_packages.mjs",
+        ],
+    )
+
+    assert outputs == _expected_classifier_outputs(frontend_changed="true")
+
+
 def test_ci_change_classifier_tracks_ci_dependency_and_release_changes(tmp_path: Path) -> None:
     outputs = _classify_changed_files(
         tmp_path,
@@ -974,6 +994,7 @@ def test_default_ci_uses_layered_job_conditions() -> None:
     jobs = data["jobs"]
 
     assert "tui-check" in jobs
+    assert "frontend_changed == 'true'" in jobs["ui-packages-check"]["if"]
     assert "frontend_changed == 'true'" in jobs["frontend-check"]["if"]
     assert "full_required == 'true'" in jobs["frontend-check"]["if"]
     assert "build_wheel_required == 'true'" not in jobs["frontend-check"]["if"]
@@ -993,6 +1014,7 @@ def test_default_ci_uses_layered_job_conditions() -> None:
     assert "release_changed == 'true'" in jobs["release-packaging"]["if"]
     assert "build_wheel_required == 'true'" in jobs["release-packaging"]["if"]
     assert "tui-check" in jobs["ci-result"]["needs"]
+    assert "ui-packages-check" in jobs["ci-result"]["needs"]
     assert "webui-chat-recovery" in jobs["ci-result"]["needs"]
     assert "desktop-check" in jobs["ci-result"]["needs"]
     assert "ubuntu-full" in jobs["ci-result"]["needs"]
@@ -1061,6 +1083,7 @@ def test_ci_result_gate_covers_every_conditional_job_and_classifier_flag() -> No
         "classify-changes",
         "workflow-lint",
         "readme-locale-check",
+        "ui-packages-check",
         "frontend-check",
         "webui-chat-recovery",
         "tui-check",
@@ -1078,6 +1101,9 @@ def test_ci_result_gate_covers_every_conditional_job_and_classifier_flag() -> No
     assert gate_step["env"]["RESULT_UBUNTU_FULL"] == "${{ needs.ubuntu-full.result }}"
     assert gate_step["env"]["RESULT_CLIENT_CONTRACT"] == (
         "${{ needs.client-contract-compat.result }}"
+    )
+    assert gate_step["env"]["RESULT_UI_PACKAGES"] == (
+        "${{ needs.ui-packages-check.result }}"
     )
     assert gate_step["env"]["RESULT_MACOS_RECOVERY"] == (
         "${{ needs.macos-recovery.result }}"
@@ -1101,6 +1127,33 @@ def test_ci_result_gate_covers_every_conditional_job_and_classifier_flag() -> No
         "FLAG_BUILD_WHEEL_REQUIRED",
         "FLAG_FULL_REQUIRED",
     }
+
+
+def test_public_ui_package_gate_runs_pack_install_smoke_on_all_platforms() -> None:
+    job = _workflow("ci.yml")["jobs"]["ui-packages-check"]
+    steps = job["steps"]
+
+    assert job["strategy"]["fail-fast"] is False
+    assert job["strategy"]["matrix"]["os"] == [
+        "ubuntu-latest",
+        "macos-latest",
+        "windows-latest",
+    ]
+    setup_node = next(step for step in steps if step.get("name") == "Set up Node.js")
+    install = next(
+        step for step in steps
+        if step.get("name") == "Install public UI package dependencies"
+    )
+    verify = next(
+        step for step in steps
+        if step.get("name") == "Verify public UI package boundaries"
+    )
+
+    assert setup_node["with"]["node-version-file"] == "opensquilla-webui/.node-version"
+    assert setup_node["with"]["cache-dependency-path"] == "package-lock.json"
+    assert install["run"] == "npm ci --ignore-scripts"
+    assert verify["run"] == "npm run verify:ui-packages"
+    assert "secrets." not in json.dumps(job)
 
 
 def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> None:

--- a/tsconfig.ui-package.json
+++ b/tsconfig.ui-package.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Scope

Scope boundary: Establish versioned, publishable skeletons for @opensquilla/ui-tokens, @opensquilla/ui-primitives, and @opensquilla/ui-foundation; add an independent-version release manifest, explicit root exports, and a fork-safe Linux/macOS/Windows pack-install-TypeScript-SBOM gate.

Non-goals: No WebUI page, route, visual, Gateway, protocol, persisted-state, private-repository, or UI capability changes. Package exports remain intentionally empty until F-02 through F-04.

## Branch

Base branch: staging/collaboration

Target exception: maintainer-approved

## Issue

Linked issue: None

If None, reason: Planned F-01 work in the approved client migration program.

## Release Note

Release note: NONE

## Tests

Ruff: uv run ruff check src tests — passed

Pytest: 87 CI/workflow tests passed; 30 release-hygiene and packaging tests passed. Full local macOS suite: 18,314 passed, 220 skipped, 5 baseline failures; 2 pass outside the temporary worktree and the remaining 3 reproduce unchanged on clean main due macOS /tmp canonicalization and BSD sed behavior.

Build: npm 10.9.0 verify:ui-packages passed; client-sdk typecheck/13 tests/package verification passed; WebUI typecheck/2,549 tests/build/release artifact verification passed; mypy passed across 894 source files; headless wheel built without client files.

CI: run 30549564833 completed with 27/27 jobs successful, including three-platform public package verification, four Ubuntu shards, four Windows high-risk shards, and three-platform Desktop recovery E2E.

Regression tests: added

Notes: CI classification, three-platform package verification, and aggregate fail-closed coverage were added. The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: no secrets or external services are required.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, generated WebUI output, or docs/architecture files are included. Existing WebUI and client-sdk install boundaries remain independent.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No architecture documentation is included in this code PR.
- [x] Package READMEs contain only public, product-neutral guidance.
- [x] Examples avoid real secrets, local private paths, and private transcripts.