### PR TITLE
Client Migration-Phase 1-Migrate Public WebUI to UI Foundation Composition

### DIFF
--- a/opensquilla-webui/e2e/public-composition.spec.ts
+++ b/opensquilla-webui/e2e/public-composition.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const CONTROL_URL = '/control/'
+
+interface RouteProbe {
+  readonly path: string
+  readonly expectedPath?: RegExp
+  readonly selector: string
+}
+
+const PUBLIC_ROUTE_PROBES: readonly RouteProbe[] = [
+  { path: 'chat/new', selector: '.chat-textarea' },
+  { path: 'sessions', selector: '.content' },
+  { path: 'overview', selector: '.content' },
+  { path: 'usage', selector: '.content' },
+  { path: 'logs', selector: '.content' },
+  { path: 'approvals', expectedPath: /\/control\/sessions$/, selector: '.content' },
+  { path: 'agents', selector: '.content' },
+  { path: 'skills', selector: '.content' },
+  { path: 'channels', selector: '.content' },
+  { path: 'cron', selector: '.content' },
+  { path: 'changelog', selector: '.content' },
+  { path: 'health', expectedPath: /\/control\/overview$/, selector: '.content' },
+  { path: 'settings', selector: '.settings-modal' },
+  { path: 'settings/appearance', selector: '.settings-modal' },
+  { path: 'config', expectedPath: /\/control\/settings$/, selector: '.settings-modal' },
+  { path: 'setup', expectedPath: /\/control\/settings\/auto$/, selector: '.settings-modal' },
+  { path: 'route-that-does-not-exist', selector: '.content' },
+]
+
+async function assertCompositionRoute(page: Page, probe: RouteProbe): Promise<void> {
+  const pageErrors: string[] = []
+  page.on('pageerror', error => pageErrors.push(error.message))
+
+  await page.goto(`${CONTROL_URL}${probe.path}`)
+  await expect(page.locator('.conn-pill')).toBeVisible({ timeout: 10_000 })
+  if (probe.expectedPath) {
+    await expect(page).toHaveURL(probe.expectedPath)
+  } else {
+    await expect(page).toHaveURL(new RegExp(`/control/${probe.path.replace('/', '\\/')}$`))
+  }
+  await expect(page.locator(probe.selector).first()).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByRole('alert', {
+    name: 'OpenSquilla could not start. Reload the page or update the client.',
+  })).toHaveCount(0)
+  expect(pageErrors).toEqual([])
+}
+
+test.describe('Public WebUI composition', () => {
+  for (const probe of PUBLIC_ROUTE_PROBES) {
+    test(`keeps the ${probe.path} route available`, async ({ page }) => {
+      await assertCompositionRoute(page, probe)
+    })
+  }
+})

--- a/opensquilla-webui/scripts/check-architecture.mjs
+++ b/opensquilla-webui/scripts/check-architecture.mjs
@@ -16,12 +16,18 @@ const bannedPatterns = [
     allow: allowedDesktopGlobal,
     message: 'Electron preload access must stay behind src/platform/.',
   },
+  {
+    pattern: 'opensquillaDesktop',
+    allow: allowedDesktopGlobal,
+    message: 'Desktop preload capabilities must be consumed through src/platform/.',
+  },
 ]
 const stalePlatformPatterns = [
   'activeProfile',
   'cloudUrl',
   'getDesktopRpcConnection',
   'desktop:rpc-connection',
+  'export const workbenchPanelRegistry',
 ]
 
 // live-turn fold fence: the append-only turn log and its pure reducer are an internal
@@ -66,6 +72,20 @@ for (const file of walkFiles(srcRoot, /\.(ts|vue)$/, { skipFile: isTestFile })) 
       if (body.includes(moduleId)) {
         failures.push(`${rel}: live-turn log "${moduleId}" must stay within src/composables/chat/ or views/ChatView.vue.`)
       }
+    }
+  }
+}
+
+const requiredCompositionMarkers = new Map([
+  ['src/main.ts', ['createPublicWebUiComposition', 'createPublicWebUiRouter']],
+  ['src/router/index.ts', ['composition.registry.routes', 'composition.loadPage']],
+  ['src/router/nav.ts', ['createPublicWebUiRegistry', 'registry.navigation']],
+])
+for (const [rel, markers] of requiredCompositionMarkers) {
+  const body = readFileSync(join(root, rel), 'utf8')
+  for (const marker of markers) {
+    if (!body.includes(marker)) {
+      failures.push(`${rel}: public WebUI composition marker is missing: "${marker}".`)
     }
   }
 }

--- a/opensquilla-webui/src/app/useNavigation.ts
+++ b/opensquilla-webui/src/app/useNavigation.ts
@@ -1,11 +1,13 @@
-import { computed } from 'vue'
+import { computed, inject } from 'vue'
 import { getNavigationItems, getWorkNavigationSection } from '@/router/nav'
+import { PUBLIC_WEB_UI_COMPOSITION_KEY } from '@/composition/root'
 
 export function useNavigation() {
-  const bottomRoutes = computed(() => getNavigationItems('bottom'))
+  const composition = inject(PUBLIC_WEB_UI_COMPOSITION_KEY, undefined)
+  const bottomRoutes = computed(() => getNavigationItems('bottom', composition))
   // Flat primary rows, single-sourced from route metadata so the desktop rail,
   // mobile drawer, and command palette stay in the same order.
-  const workNav = computed(() => getWorkNavigationSection())
+  const workNav = computed(() => getWorkNavigationSection(composition))
 
   return {
     bottomRoutes,

--- a/opensquilla-webui/src/components/CommandPalette.vue
+++ b/opensquilla-webui/src/components/CommandPalette.vue
@@ -88,7 +88,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, inject, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import Icon from './Icon.vue'
@@ -100,6 +100,7 @@ import { highlightFtsSnippet } from '@/utils/searchSnippet'
 import type { SidebarSection } from '@/composables/useSessions'
 import type { IconName } from '@/utils/icons'
 import type { MessageSearchHit, SessionSearchHit, SessionsSearchResponse } from '@/types/rpc'
+import { PUBLIC_WEB_UI_COMPOSITION_KEY } from '@/composition/root'
 
 const props = defineProps<{
   open: boolean
@@ -123,6 +124,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const router = useRouter()
 const rpcStore = useRpcStore()
+const composition = inject(PUBLIC_WEB_UI_COMPOSITION_KEY, undefined)
 const { enabled: bgmEnabled, setEnabled: setBgmEnabled } = useBgm()
 
 const dialogRef = ref<HTMLElement | null>(null)
@@ -189,7 +191,7 @@ const allCommands = computed<Command[]>(() => {
   // Work: the pinned rail destinations, from the single Work-band helper so the
   // palette tracks the route taxonomy instead of a hardcoded path list (which
   // silently dropped promoted routes and double-listed demoted ones).
-  for (const item of getWorkNavigationSection()) {
+  for (const item of getWorkNavigationSection(composition)) {
     const searchAliases = item.path === '/usage' ? ' usage 用量' : ''
     out.push({
       id: `nav:${item.path}`,

--- a/opensquilla-webui/src/components/settings/DataMigrationPanel.vue
+++ b/opensquilla-webui/src/components/settings/DataMigrationPanel.vue
@@ -208,9 +208,7 @@ const { confirm } = useConfirm()
 const { pushToast } = useToasts()
 const platform = usePlatform()
 const rpc = useRpcStore()
-const desktopBridge = (globalThis as unknown as {
-  opensquillaDesktop?: DesktopMigrationBridge
-}).opensquillaDesktop
+const desktopBridge = platform.migration as unknown as DesktopMigrationBridge
 const hasDesktopMigrationBridge = computed(() => Boolean(
   platform.capabilities.isDesktop
   && desktopBridge?.migrationSummary

--- a/opensquilla-webui/src/components/workbench/AppWorkbench.vue
+++ b/opensquilla-webui/src/components/workbench/AppWorkbench.vue
@@ -141,6 +141,7 @@
 <script setup lang="ts">
 import {
   computed,
+  inject,
   nextTick,
   onBeforeUnmount,
   onMounted,
@@ -155,7 +156,10 @@ import { useToasts } from '@/composables/useToasts'
 import { usePlatform } from '@/platform'
 import type { NativeWorkbenchSurfaceEvent } from '@/platform/types'
 import type { ArtifactPayload } from '@/types/rpc'
-import { workbenchPanelRegistry } from '@/workbench/registry'
+import {
+  PUBLIC_WEB_UI_COMPOSITION_KEY,
+  getPublicWebUiRuntimeState,
+} from '@/composition/root'
 import {
   artifactWorkbenchItemId,
   createArtifactPreviewWorkbenchItem,
@@ -181,6 +185,7 @@ import {
   attachWorkbenchRuntime,
   WorkbenchRuntimeManager,
 } from '@/workbench/runtime'
+import { createWorkbenchPanelRegistry } from '@/workbench/registry'
 import { useWorkbenchStore } from '@/workbench/store'
 import type {
   NativeSurfaceRect,
@@ -211,7 +216,12 @@ const { t } = useI18n()
 const { confirm } = useConfirm()
 const { pushToast } = useToasts()
 const platform = usePlatform()
-const store = useWorkbenchStore()
+const composition = inject(PUBLIC_WEB_UI_COMPOSITION_KEY, null)
+const workbench = composition
+  ? getPublicWebUiRuntimeState(composition).workbench
+  : null
+const store = workbench?.store ?? useWorkbenchStore()
+const workbenchPanelRegistry = workbench?.registry ?? createWorkbenchPanelRegistry()
 const artifactImageLightbox = useArtifactImageLightbox()
 const nativeSurfaceOccluded = useNativeSurfaceOcclusionState()
 const surfaceBlocked = computed(() => props.modalBlocked || nativeSurfaceOccluded.value)

--- a/opensquilla-webui/src/composables/chat/useVoiceInput.ts
+++ b/opensquilla-webui/src/composables/chat/useVoiceInput.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import i18n from '@/i18n'
 import { useToasts } from '@/composables/useToasts'
 import { detectPlatformId } from '@/platform/capabilities'
+import { getPlatform } from '@/platform'
 
 interface TranscriptionResponse {
   text?: string
@@ -34,10 +35,6 @@ function recordingFailureKey(err: unknown): string {
     return 'chat.toast.voiceMicMissing'
   }
   return 'chat.toast.voiceRecordFailed'
-}
-
-interface DesktopWindowVisibilityBridge {
-  onWindowHidden?: (callback: () => void) => void | (() => void)
 }
 
 function authToken(): string {
@@ -259,10 +256,9 @@ export function useVoiceInput() {
   }
 
   if (typeof window !== 'undefined') {
-    const desktop = (window as unknown as {
-      opensquillaDesktop?: DesktopWindowVisibilityBridge
-    }).opensquillaDesktop
-    const unsubscribe = desktop?.onWindowHidden?.(() => cancelRecording({ notify: true }))
+    const unsubscribe = getPlatform().lifecycle.onWindowHidden?.(
+      () => cancelRecording({ notify: true }),
+    )
     if (typeof unsubscribe === 'function') unsubscribeWindowHidden = unsubscribe
   }
   if (typeof document !== 'undefined') {

--- a/opensquilla-webui/src/composition/catalog.ts
+++ b/opensquilla-webui/src/composition/catalog.ts
@@ -1,0 +1,248 @@
+import {
+  UI_COMPOSITION_API_VERSION,
+  createContributionRegistrar,
+  type ContributionRegistrySnapshot,
+  type FeatureModuleContract,
+  type NavigationContribution,
+  type PageContribution,
+  type RouteContribution,
+} from '@opensquilla/ui-foundation'
+import type { RouteRecordRaw } from 'vue-router'
+import type { Platform, PlatformId } from '@/platform'
+import { sharedRoutes } from '@/router/sharedRoutes'
+import { webRoutes } from '@/router/webRoutes'
+import { desktopRoutes } from '@/router/desktopRoutes'
+import {
+  createPublicWebUiStateContributions,
+  createPublicWebUiWorkbenchStateContribution,
+} from './state'
+import { PUBLIC_WEB_UI_NATIVE_CAPABILITIES } from './nativeAdapter'
+
+const NotFoundView = () => import('@/views/NotFoundView.vue')
+
+export const PUBLIC_WEB_UI_SHELL_FEATURE_ID = 'opensquilla.webui.shell'
+
+const FEATURE_ORDER = new Map<string, number>([
+  [PUBLIC_WEB_UI_SHELL_FEATURE_ID, 0],
+  ['opensquilla.webui.chat', 10],
+  ['opensquilla.webui.sessions', 20],
+  ['opensquilla.webui.observability', 30],
+  ['opensquilla.webui.agents', 40],
+  ['opensquilla.webui.capabilities', 50],
+  ['opensquilla.webui.automation', 60],
+  ['opensquilla.webui.editorial', 70],
+  ['opensquilla.webui.settings', 80],
+  ['opensquilla.webui.workbench', 90],
+  ['opensquilla.webui.fallback', 100],
+])
+
+interface OrderedRoute {
+  readonly record: RouteRecordRaw
+  readonly order: number
+}
+
+export interface PublicWebUiRedirectRoute {
+  readonly record: RouteRecordRaw
+  readonly order: number
+}
+
+function routePlatforms(record: RouteRecordRaw): readonly PlatformId[] {
+  const platforms = record.meta?.platforms
+  if (!Array.isArray(platforms)) return ['web', 'desktop']
+  return platforms.filter(
+    (platform): platform is PlatformId => platform === 'web' || platform === 'desktop',
+  )
+}
+
+function orderedRoutes(platform: Platform): readonly OrderedRoute[] {
+  const records: OrderedRoute[] = sharedRoutes.map((record, order) => ({ record, order }))
+  if (platform.capabilities.hasWebConfig) {
+    records.push(...webRoutes.map((record, index) => ({
+      record,
+      order: 100 + index,
+    })))
+  }
+  if (platform.capabilities.hasDesktopOnboarding) {
+    records.push(...desktopRoutes.map((record, index) => ({
+      record,
+      order: 200 + index,
+    })))
+  }
+  records.push({
+    record: {
+      path: '/:pathMatch(.*)*',
+      name: 'not-found',
+      component: NotFoundView,
+      meta: {
+        title: 'Not Found',
+        platforms: ['web', 'desktop'],
+      },
+    },
+    order: 1_000,
+  })
+  return records.filter(({ record }) => routePlatforms(record).includes(platform.id))
+}
+
+function featureIdForRoute(name: string): string {
+  if (name === 'chat' || name === 'chat-new') return 'opensquilla.webui.chat'
+  if (name === 'sessions') return 'opensquilla.webui.sessions'
+  if (name === 'overview' || name === 'usage' || name === 'logs') {
+    return 'opensquilla.webui.observability'
+  }
+  if (name === 'agents') return 'opensquilla.webui.agents'
+  if (name === 'skills' || name === 'channels') return 'opensquilla.webui.capabilities'
+  if (name === 'cron') return 'opensquilla.webui.automation'
+  if (name === 'changelog') return 'opensquilla.webui.editorial'
+  if (name === 'settings' || name === 'settings-section') {
+    return 'opensquilla.webui.settings'
+  }
+  if (name === 'not-found') return 'opensquilla.webui.fallback'
+  throw new Error(`Public WebUI route "${name}" has no feature owner`)
+}
+
+function contributionSegment(value: string): string {
+  const segment = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  if (!segment || !/^[a-z]/.test(segment)) {
+    throw new Error(`Invalid public WebUI contribution segment "${value}"`)
+  }
+  return segment
+}
+
+function routeName(record: RouteRecordRaw): string {
+  if (typeof record.name !== 'string' || !record.name) {
+    throw new Error(`Public WebUI page route "${record.path}" requires a string name`)
+  }
+  return record.name
+}
+
+function pageKey(record: RouteRecordRaw): string {
+  const viewKey = record.meta?.viewKey
+  return contributionSegment(typeof viewKey === 'string' && viewKey
+    ? viewKey
+    : routeName(record))
+}
+
+function pageLoader(record: RouteRecordRaw): PageContribution['load'] {
+  const component = record.component
+  if (!component) {
+    throw new Error(`Public WebUI route "${record.path}" requires a component`)
+  }
+  if (typeof component !== 'function') return async () => component
+  return async () => await (
+    component as unknown as () => unknown | Promise<unknown>
+  )()
+}
+
+function featureFromRoutes(
+  featureId: string,
+  records: readonly OrderedRoute[],
+): FeatureModuleContract {
+  const pages = new Map<string, PageContribution>()
+  const routes: RouteContribution[] = []
+  const navigation: NavigationContribution[] = []
+
+  for (const { record, order } of records) {
+    const name = routeName(record)
+    const routeSegment = contributionSegment(name)
+    const pageSegment = pageKey(record)
+    const pageId = `${featureId}.page.${pageSegment}`
+    const routeId = `${featureId}.route.${routeSegment}`
+    if (!pages.has(pageId)) {
+      pages.set(pageId, {
+        id: pageId,
+        order,
+        load: pageLoader(record),
+      })
+    }
+    routes.push({
+      id: routeId,
+      path: record.path,
+      name,
+      pageId,
+      order,
+      metadata: {
+        ...(record.meta ?? {}),
+        webUiOrder: order,
+      },
+    })
+    if (record.meta?.nav === 'primary' || record.meta?.nav === 'bottom') {
+      navigation.push({
+        id: `${featureId}.navigation.${routeSegment}`,
+        routeId,
+        slot: record.meta.nav === 'bottom' ? 'footer' : 'primary',
+        label: String(record.meta.title || name),
+        order: Number(record.meta.navOrder ?? order),
+        metadata: {
+          ...(record.meta ?? {}),
+          path: record.path,
+        },
+      })
+    }
+  }
+
+  return {
+    id: featureId,
+    apiVersion: UI_COMPOSITION_API_VERSION,
+    dependsOn: [PUBLIC_WEB_UI_SHELL_FEATURE_ID],
+    order: FEATURE_ORDER.get(featureId) ?? 500,
+    contributions: {
+      pages: [...pages.values()],
+      routes,
+      navigation,
+    },
+  }
+}
+
+export function createPublicWebUiFeatures(platform: Platform): readonly FeatureModuleContract[] {
+  const pageRoutes = orderedRoutes(platform).filter(({ record }) => Boolean(record.component))
+  const recordsByFeature = new Map<string, OrderedRoute[]>()
+  for (const route of pageRoutes) {
+    const name = routeName(route.record)
+    const featureId = featureIdForRoute(name)
+    const bucket = recordsByFeature.get(featureId) ?? []
+    bucket.push(route)
+    recordsByFeature.set(featureId, bucket)
+  }
+
+  const features: FeatureModuleContract[] = [{
+    id: PUBLIC_WEB_UI_SHELL_FEATURE_ID,
+    apiVersion: UI_COMPOSITION_API_VERSION,
+    order: FEATURE_ORDER.get(PUBLIC_WEB_UI_SHELL_FEATURE_ID),
+    contributions: {
+      state: createPublicWebUiStateContributions(),
+    },
+  }, {
+    id: 'opensquilla.webui.workbench',
+    apiVersion: UI_COMPOSITION_API_VERSION,
+    dependsOn: [PUBLIC_WEB_UI_SHELL_FEATURE_ID],
+    order: FEATURE_ORDER.get('opensquilla.webui.workbench'),
+    optionalCapabilities: ['opensquilla.host.native-workbench'],
+    contributions: {
+      state: [createPublicWebUiWorkbenchStateContribution()],
+    },
+  }]
+  for (const [featureId, records] of recordsByFeature) {
+    features.push(featureFromRoutes(featureId, records))
+  }
+  return features
+}
+
+export function createPublicWebUiRegistry(
+  platform: Platform,
+): ContributionRegistrySnapshot {
+  return createContributionRegistrar(createPublicWebUiFeatures(platform)).finalize({
+    knownCapabilities: PUBLIC_WEB_UI_NATIVE_CAPABILITIES,
+  })
+}
+
+export function createPublicWebUiRedirectRoutes(
+  platform: Platform,
+): readonly PublicWebUiRedirectRoute[] {
+  return orderedRoutes(platform)
+    .filter(({ record }) => !record.component && record.redirect !== undefined)
+    .map(({ record, order }) => ({ record, order }))
+}

--- a/opensquilla-webui/src/composition/nativeAdapter.ts
+++ b/opensquilla-webui/src/composition/nativeAdapter.ts
@@ -1,0 +1,196 @@
+import {
+  createNativeCapabilityAdapter,
+  createWebNativeCapabilityAdapter,
+  type NativeCapabilityAdapter,
+  type NativeCapabilityInvocation,
+  type NativeCapabilityResult,
+} from '@opensquilla/ui-foundation'
+import type { Platform } from '@/platform'
+
+export const PUBLIC_WEB_UI_NATIVE_CAPABILITIES = [
+  'opensquilla.host.gateway-status',
+  'opensquilla.host.gateway-reveal-log',
+  'opensquilla.host.gateway-retry',
+  'opensquilla.host.cli-invocation',
+  'opensquilla.host.open-artifact',
+  'opensquilla.host.choose-project-directory',
+  'opensquilla.host.desktop-settings',
+  'opensquilla.host.desktop-preferences',
+  'opensquilla.host.onboarding',
+  'opensquilla.host.updates',
+  'opensquilla.host.native-workbench',
+  'opensquilla.host.os-locale',
+  'opensquilla.host.native-theme',
+] as const
+
+type PublicWebUiNativeCapability = typeof PUBLIC_WEB_UI_NATIVE_CAPABILITIES[number]
+
+interface CapabilityRequest {
+  readonly action?: string
+  readonly payload?: unknown
+}
+
+function requestObject(value: unknown): CapabilityRequest {
+  return value !== null && typeof value === 'object'
+    ? value as CapabilityRequest
+    : {}
+}
+
+function success<T>(value: T): NativeCapabilityResult<T> {
+  return { ok: true, value }
+}
+
+function unavailable(
+  capability: PublicWebUiNativeCapability,
+  message: string,
+): NativeCapabilityResult {
+  return {
+    ok: false,
+    error: {
+      code: 'unavailable',
+      capability,
+      message,
+    },
+  }
+}
+
+function desktopCapabilities(platform: Platform): PublicWebUiNativeCapability[] {
+  const capabilities: PublicWebUiNativeCapability[] = [
+    'opensquilla.host.gateway-status',
+    'opensquilla.host.updates',
+    'opensquilla.host.os-locale',
+    'opensquilla.host.native-theme',
+  ]
+  if (platform.gateway.revealLog) capabilities.push('opensquilla.host.gateway-reveal-log')
+  if (platform.gateway.retryStartup) capabilities.push('opensquilla.host.gateway-retry')
+  if (platform.gateway.getCliInvocation) capabilities.push('opensquilla.host.cli-invocation')
+  if (platform.files.openArtifact) capabilities.push('opensquilla.host.open-artifact')
+  if (platform.files.chooseProjectDirectory) {
+    capabilities.push('opensquilla.host.choose-project-directory')
+  }
+  if (platform.settings.getDesktopSettings) {
+    capabilities.push('opensquilla.host.desktop-settings')
+  }
+  if (platform.settings.getDesktopPreferences) {
+    capabilities.push('opensquilla.host.desktop-preferences')
+  }
+  if (platform.onboarding.getDefaults) capabilities.push('opensquilla.host.onboarding')
+  if (platform.workbench.native) capabilities.push('opensquilla.host.native-workbench')
+  return capabilities
+}
+
+async function invokeDesktopCapability(
+  platform: Platform,
+  capability: PublicWebUiNativeCapability,
+  requestValue: unknown,
+): Promise<NativeCapabilityResult> {
+  const request = requestObject(requestValue)
+  switch (capability) {
+    case 'opensquilla.host.gateway-status':
+      return success(await platform.gateway.getStatus())
+    case 'opensquilla.host.gateway-reveal-log':
+      return platform.gateway.revealLog
+        ? success(await platform.gateway.revealLog())
+        : unavailable(capability, 'Gateway log reveal is unavailable')
+    case 'opensquilla.host.gateway-retry':
+      return platform.gateway.retryStartup
+        ? success(await platform.gateway.retryStartup())
+        : unavailable(capability, 'Gateway restart is unavailable')
+    case 'opensquilla.host.cli-invocation':
+      return platform.gateway.getCliInvocation
+        ? success(await platform.gateway.getCliInvocation())
+        : unavailable(capability, 'CLI invocation discovery is unavailable')
+    case 'opensquilla.host.open-artifact':
+      return platform.files.openArtifact
+        ? success(await platform.files.openArtifact(
+            request.payload as Parameters<NonNullable<typeof platform.files.openArtifact>>[0],
+          ))
+        : unavailable(capability, 'Native artifact opening is unavailable')
+    case 'opensquilla.host.choose-project-directory':
+      return platform.files.chooseProjectDirectory
+        ? success(await platform.files.chooseProjectDirectory(
+            request.payload as Parameters<
+              NonNullable<typeof platform.files.chooseProjectDirectory>
+            >[0],
+          ))
+        : unavailable(capability, 'Native directory selection is unavailable')
+    case 'opensquilla.host.desktop-settings':
+      if (request.action === 'get' && platform.settings.getDesktopSettings) {
+        return success(await platform.settings.getDesktopSettings())
+      }
+      if (request.action === 'save' && platform.settings.saveDesktopSettings) {
+        return success(await platform.settings.saveDesktopSettings(
+          request.payload as Parameters<
+            NonNullable<typeof platform.settings.saveDesktopSettings>
+          >[0],
+        ))
+      }
+      if (request.action === 'reset' && platform.settings.resetDesktopSettings) {
+        return success(await platform.settings.resetDesktopSettings())
+      }
+      return unavailable(capability, `Desktop settings action "${request.action || ''}" is unavailable`)
+    case 'opensquilla.host.desktop-preferences':
+      if (request.action === 'get' && platform.settings.getDesktopPreferences) {
+        return success(await platform.settings.getDesktopPreferences())
+      }
+      if (request.action === 'save' && platform.settings.saveDesktopPreferences) {
+        return success(await platform.settings.saveDesktopPreferences(
+          request.payload as Parameters<
+            NonNullable<typeof platform.settings.saveDesktopPreferences>
+          >[0],
+        ))
+      }
+      return unavailable(
+        capability,
+        `Desktop preferences action "${request.action || ''}" is unavailable`,
+      )
+    case 'opensquilla.host.onboarding':
+      if (request.action === 'get' && platform.onboarding.getDefaults) {
+        return success(await platform.onboarding.getDefaults())
+      }
+      if (request.action === 'save' && platform.onboarding.save) {
+        return success(await platform.onboarding.save(request.payload))
+      }
+      if (request.action === 'cancel' && platform.onboarding.cancel) {
+        return success(await platform.onboarding.cancel())
+      }
+      return unavailable(capability, `Onboarding action "${request.action || ''}" is unavailable`)
+    case 'opensquilla.host.updates':
+      if (request.action === 'check') return success(await platform.updates.check())
+      if (request.action === 'download') return success(await platform.updates.download())
+      if (request.action === 'relaunch') return success(await platform.updates.relaunch())
+      if (request.action === 'dismiss') return success(await platform.updates.dismiss())
+      return success(await platform.updates.getState())
+    case 'opensquilla.host.native-workbench':
+      return unavailable(
+        capability,
+        'Native Workbench uses its versioned surface API service',
+      )
+    case 'opensquilla.host.os-locale':
+      return success(await platform.getOsLocale())
+    case 'opensquilla.host.native-theme':
+      return success(await platform.setNativeTheme(
+        request.payload as Parameters<Platform['setNativeTheme']>[0],
+      ))
+  }
+}
+
+export function createPublicWebUiNativeAdapter(
+  platform: Platform,
+): NativeCapabilityAdapter {
+  if (platform.id === 'web') return createWebNativeCapabilityAdapter()
+  const capabilities = desktopCapabilities(platform)
+  return createNativeCapabilityAdapter({
+    bridgeVersion: 'desktop-platform-v1',
+    capabilities,
+    async invoke<T = unknown>(
+      { capability, request }: NativeCapabilityInvocation,
+    ): Promise<NativeCapabilityResult<T>> {
+      return await invokeDesktopCapability(
+        platform,
+        capability as PublicWebUiNativeCapability,
+        request,
+      ) as NativeCapabilityResult<T>
+    },
+  })
+}

--- a/opensquilla-webui/src/composition/publicWebUiComposition.test.ts
+++ b/opensquilla-webui/src/composition/publicWebUiComposition.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia } from 'pinia'
+import type { OpenSquillaAppComposition } from '@opensquilla/ui-foundation'
+import { createWebPlatform } from '@/platform/web'
+import { createPublicWebUiRoutes } from '@/router'
+import { createPublicWebUiComposition, getPublicWebUiRuntimeState } from './root'
+
+function installBrowserFixture(): void {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}
+
+describe('public WebUI composition', () => {
+  const compositions: OpenSquillaAppComposition[] = []
+
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    delete window.opensquillaDesktop
+    installBrowserFixture()
+  })
+
+  afterEach(async () => {
+    await Promise.all(compositions.splice(0).map(composition => composition.dispose()))
+  })
+
+  async function createComposition(): Promise<OpenSquillaAppComposition> {
+    const composition = await createPublicWebUiComposition({
+      pinia: createPinia(),
+      platform: createWebPlatform(),
+    })
+    compositions.push(composition)
+    return composition
+  }
+
+  it('registers every complete community route without changing deep links', async () => {
+    const composition = await createComposition()
+    const routes = createPublicWebUiRoutes(composition, createWebPlatform())
+
+    expect(routes.map(route => route.path)).toEqual([
+      '/',
+      '/chat',
+      '/chat/new',
+      '/sessions',
+      '/overview',
+      '/usage',
+      '/logs',
+      '/approvals',
+      '/agents',
+      '/skills',
+      '/channels',
+      '/cron',
+      '/changelog',
+      '/health',
+      '/settings',
+      '/settings/:section',
+      '/config',
+      '/setup',
+      '/:pathMatch(.*)*',
+    ])
+    expect(composition.registry.routes).toHaveLength(14)
+    expect(composition.registry.pages).toHaveLength(10)
+    expect(composition.registry.navigation).toHaveLength(4)
+    expect(composition.registry.state).toHaveLength(3)
+  })
+
+  it('keeps shared route views represented by one page contribution', async () => {
+    const composition = await createComposition()
+    const routes = createPublicWebUiRoutes(composition, createWebPlatform())
+    const routeAt = (path: string) => routes.find(route => route.path === path)
+
+    expect(routeAt('/chat')?.component).toBe(routeAt('/chat/new')?.component)
+    expect(routeAt('/overview')?.component).toBe(routeAt('/usage')?.component)
+    expect(routeAt('/skills')?.component).toBe(routeAt('/channels')?.component)
+    expect(routeAt('/logs')?.component).not.toBe(routeAt('/overview')?.component)
+  })
+
+  it('loads bundled pages through the Foundation page boundary', async () => {
+    const composition = await createComposition()
+
+    await expect(
+      composition.loadPage<Record<string, unknown>>(
+        'opensquilla.webui.fallback.page.not-found',
+      ),
+    ).resolves.toHaveProperty('default')
+  })
+
+  it('creates isolated app and RPC stores for separate product compositions', async () => {
+    const first = await createComposition()
+    const second = await createComposition()
+    const firstState = getPublicWebUiRuntimeState(first)
+    const secondState = getPublicWebUiRuntimeState(second)
+
+    expect(firstState.appStore).not.toBe(secondState.appStore)
+    expect(firstState.rpcStore).not.toBe(secondState.rpcStore)
+    expect(firstState.workbench.store).not.toBe(secondState.workbench.store)
+    expect(firstState.workbench.registry).not.toBe(secondState.workbench.registry)
+    firstState.appStore.setSidebarOpen(false)
+    expect(firstState.appStore.sidebarOpen).toBe(false)
+    expect(secondState.appStore.sidebarOpen).toBe(true)
+  })
+
+  it('uses structured unsupported results when no native host exists', async () => {
+    const composition = await createComposition()
+
+    expect(composition.native.bridgeVersion).toBeNull()
+    expect(composition.native.capabilities).toEqual([])
+    await expect(composition.native.invoke({
+      capability: 'opensquilla.host.open-artifact',
+    })).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: 'unsupported',
+        capability: 'opensquilla.host.open-artifact',
+      },
+    })
+  })
+
+  it('contains only public, product-neutral feature declarations', async () => {
+    const composition = await createComposition()
+    const serialized = JSON.stringify(composition.registry)
+
+    expect(composition.registry.features.map(feature => feature.id)).toEqual([
+      'opensquilla.webui.shell',
+      'opensquilla.webui.chat',
+      'opensquilla.webui.sessions',
+      'opensquilla.webui.observability',
+      'opensquilla.webui.agents',
+      'opensquilla.webui.capabilities',
+      'opensquilla.webui.automation',
+      'opensquilla.webui.editorial',
+      'opensquilla.webui.settings',
+      'opensquilla.webui.workbench',
+      'opensquilla.webui.fallback',
+    ])
+    expect(serialized).not.toMatch(/private|entitlement|product manifest/i)
+  })
+})

--- a/opensquilla-webui/src/composition/root.ts
+++ b/opensquilla-webui/src/composition/root.ts
@@ -1,0 +1,67 @@
+import type { Pinia } from 'pinia'
+import type { InjectionKey } from 'vue'
+import {
+  createOpenSquillaApp,
+  type OpenSquillaAppComposition,
+} from '@opensquilla/ui-foundation'
+import type { Platform } from '@/platform'
+import { createPublicWebUiFeatures } from './catalog'
+import {
+  APP_STATE_NAMESPACE,
+  PUBLIC_WEB_UI_PINIA_SERVICE,
+  PUBLIC_WEB_UI_PLATFORM_SERVICE,
+  RPC_STATE_NAMESPACE,
+  WORKBENCH_STATE_NAMESPACE,
+  type PublicWebUiAppStore,
+  type PublicWebUiRpcStore,
+  type PublicWebUiWorkbenchState,
+} from './state'
+import {
+  PUBLIC_WEB_UI_NATIVE_CAPABILITIES,
+  createPublicWebUiNativeAdapter,
+} from './nativeAdapter'
+
+export const PUBLIC_WEB_UI_COMPOSITION_KEY: InjectionKey<OpenSquillaAppComposition> = (
+  Symbol('opensquilla.public-webui.composition')
+)
+
+export interface CreatePublicWebUiCompositionOptions {
+  readonly pinia: Pinia
+  readonly platform: Platform
+  readonly gatewayScopes?: readonly string[]
+}
+
+export interface PublicWebUiRuntimeState {
+  readonly appStore: PublicWebUiAppStore
+  readonly rpcStore: PublicWebUiRpcStore
+  readonly workbench: PublicWebUiWorkbenchState
+}
+
+export async function createPublicWebUiComposition(
+  options: CreatePublicWebUiCompositionOptions,
+): Promise<OpenSquillaAppComposition> {
+  const native = createPublicWebUiNativeAdapter(options.platform)
+  return await createOpenSquillaApp({
+    features: createPublicWebUiFeatures(options.platform),
+    knownCapabilities: PUBLIC_WEB_UI_NATIVE_CAPABILITIES,
+    capabilities: native.capabilities,
+    gatewayScopes: options.gatewayScopes,
+    native,
+    services: {
+      [PUBLIC_WEB_UI_PINIA_SERVICE]: options.pinia,
+      [PUBLIC_WEB_UI_PLATFORM_SERVICE]: options.platform,
+    },
+  })
+}
+
+export function getPublicWebUiRuntimeState(
+  composition: OpenSquillaAppComposition,
+): PublicWebUiRuntimeState {
+  return {
+    appStore: composition.getState<PublicWebUiAppStore>(APP_STATE_NAMESPACE),
+    rpcStore: composition.getState<PublicWebUiRpcStore>(RPC_STATE_NAMESPACE),
+    workbench: composition.getState<PublicWebUiWorkbenchState>(
+      WORKBENCH_STATE_NAMESPACE,
+    ),
+  }
+}

--- a/opensquilla-webui/src/composition/state.ts
+++ b/opensquilla-webui/src/composition/state.ts
@@ -1,0 +1,85 @@
+import type { Pinia } from 'pinia'
+import type {
+  StateContribution,
+} from '@opensquilla/ui-foundation'
+import { useAppStore } from '@/stores/app'
+import { useRpcStore } from '@/stores/rpc'
+import { createWorkbenchPanelRegistry } from '@/workbench/registry'
+import type { WorkbenchPanelRegistry } from '@/workbench/runtime'
+import { useWorkbenchStore } from '@/workbench/store'
+
+export const PUBLIC_WEB_UI_PINIA_SERVICE = 'opensquilla.webui.pinia'
+export const PUBLIC_WEB_UI_PLATFORM_SERVICE = 'opensquilla.webui.platform'
+
+export const APP_STATE_NAMESPACE = 'opensquilla.webui.shell.app'
+export const RPC_STATE_NAMESPACE = 'opensquilla.webui.shell.rpc'
+export const WORKBENCH_STATE_NAMESPACE = 'opensquilla.webui.workbench.runtime'
+
+export type PublicWebUiAppStore = ReturnType<typeof useAppStore>
+export type PublicWebUiRpcStore = ReturnType<typeof useRpcStore>
+export type PublicWebUiWorkbenchStore = ReturnType<typeof useWorkbenchStore>
+
+export interface PublicWebUiWorkbenchState {
+  readonly store: PublicWebUiWorkbenchStore
+  readonly registry: WorkbenchPanelRegistry
+}
+
+function requiredPinia(getService: <T = unknown>(id: string) => T | undefined): Pinia {
+  const pinia = getService<Pinia>(PUBLIC_WEB_UI_PINIA_SERVICE)
+  if (!pinia) {
+    throw new Error('The public WebUI composition requires an isolated Pinia instance')
+  }
+  return pinia
+}
+
+export function createPublicWebUiStateContributions(): readonly StateContribution[] {
+  return [
+    {
+      id: 'opensquilla.webui.shell.state.app',
+      namespace: APP_STATE_NAMESPACE,
+      order: 10,
+      create({ getService }) {
+        const store = useAppStore(requiredPinia(getService))
+        return {
+          value: store,
+          dispose() {
+            store.destroyTheme()
+          },
+        }
+      },
+    },
+    {
+      id: 'opensquilla.webui.shell.state.rpc',
+      namespace: RPC_STATE_NAMESPACE,
+      order: 20,
+      create({ getService }) {
+        const store = useRpcStore(requiredPinia(getService))
+        return {
+          value: store,
+          dispose() {
+            store.disconnect()
+          },
+        }
+      },
+    },
+  ]
+}
+
+export function createPublicWebUiWorkbenchStateContribution(): StateContribution {
+  return {
+    id: 'opensquilla.webui.workbench.state.runtime',
+    namespace: WORKBENCH_STATE_NAMESPACE,
+    order: 10,
+    create({ getService }) {
+      const store = useWorkbenchStore(requiredPinia(getService))
+      const registry = createWorkbenchPanelRegistry()
+      return {
+        value: { store, registry } satisfies PublicWebUiWorkbenchState,
+        dispose() {
+          store.reset()
+          registry.clear()
+        },
+      }
+    },
+  }
+}

--- a/opensquilla-webui/src/main.ts
+++ b/opensquilla-webui/src/main.ts
@@ -1,10 +1,14 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
-import { router } from './router'
+import { createPublicWebUiRouter } from './router'
 import i18n from './i18n'
-import { useAppStore } from './stores/app'
-import { useRpcStore } from './stores/rpc'
+import { getPlatform } from './platform'
+import {
+  PUBLIC_WEB_UI_COMPOSITION_KEY,
+  createPublicWebUiComposition,
+  getPublicWebUiRuntimeState,
+} from './composition/root'
 import 'katex/dist/katex.min.css'
 import './assets/fonts.css'
 import '@opensquilla/ui-tokens/foundation.css'
@@ -17,23 +21,46 @@ import './styles/chat-markdown.css'
 import './styles/chat-shared.css'
 import './styles/apple-modern.css'
 
-const app = createApp(App)
-app.use(createPinia())
-app.use(router)
-app.use(i18n)
+async function bootstrap(): Promise<void> {
+  const app = createApp(App)
+  const pinia = createPinia()
+  const platform = getPlatform()
+  app.use(pinia)
+  app.use(i18n)
 
-const appStore = useAppStore()
-appStore.initTheme()
+  const composition = await createPublicWebUiComposition({ pinia, platform })
+  const router = createPublicWebUiRouter(composition, platform)
+  const { appStore, rpcStore } = getPublicWebUiRuntimeState(composition)
+  app.provide(PUBLIC_WEB_UI_COMPOSITION_KEY, composition)
+  app.use(router)
 
-const rpcStore = useRpcStore()
-rpcStore.init()
-router.afterEach(() => {
-  rpcStore.applyLinkTokenFromUrl()
-})
+  appStore.initTheme()
+  rpcStore.init()
+  router.afterEach(() => {
+    rpcStore.applyLinkTokenFromUrl()
+  })
 
-// Resolve + load the active locale before mounting so the first paint is
-// already in the right language (no English flash). initLocale never rejects
-// (it falls back to en internally); finally() guarantees the app still mounts.
-appStore.initLocale().finally(() => {
-  app.mount('#app')
+  // Resolve + load the active locale before mounting so the first paint is
+  // already in the right language (no English flash). Preserve the historical
+  // mount-on-locale-failure behavior: locale loading is not allowed to turn a
+  // usable community console into a blank startup error.
+  try {
+    await appStore.initLocale()
+  } finally {
+    app.mount('#app')
+  }
+
+  if (import.meta.hot) {
+    import.meta.hot.dispose(() => {
+      void composition.dispose()
+    })
+  }
+}
+
+void bootstrap().catch((error: unknown) => {
+  console.error('OpenSquilla WebUI composition failed to start', error)
+  const root = document.getElementById('app')
+  if (!root) return
+  root.textContent = 'OpenSquilla could not start. Reload the page or update the client.'
+  root.setAttribute('role', 'alert')
 })

--- a/opensquilla-webui/src/platform/desktop.ts
+++ b/opensquilla-webui/src/platform/desktop.ts
@@ -166,6 +166,100 @@ function desktopNativeWorkbenchApi(api: OpenSquillaDesktopApi): NativeWorkbenchA
   }
 }
 
+function desktopMigrationApi(api: OpenSquillaDesktopApi): Readonly<Record<string, unknown>> {
+  return Object.freeze({
+    ...(typeof api.getRecoveryState === 'function'
+      ? { getRecoveryState: () => requireDesktopApi().getRecoveryState!() }
+      : {}),
+    ...(typeof api.retryProfileConsolidation === 'function'
+      ? { retryProfileConsolidation: () => requireDesktopApi().retryProfileConsolidation!() }
+      : {}),
+    ...(typeof api.chooseLegacyAgentDataLocation === 'function'
+      ? {
+          chooseLegacyAgentDataLocation: (payload?: Record<string, never>) => (
+            requireDesktopApi().chooseLegacyAgentDataLocation!(payload)
+          ),
+        }
+      : {}),
+    ...(typeof api.migrationSummary === 'function'
+      ? {
+          migrationSummary: (payload?: { source?: string }) => (
+            requireDesktopApi().migrationSummary!(payload)
+          ),
+        }
+      : {}),
+    ...(typeof api.migrationRun === 'function'
+      ? {
+          migrationRun: (payload: { overwrite?: boolean; previewId: string }) => (
+            requireDesktopApi().migrationRun!(payload)
+          ),
+        }
+      : {}),
+    ...(typeof api.migrationBrowseSource === 'function'
+      ? {
+          migrationBrowseSource: (payload: { kind: string }) => (
+            requireDesktopApi().migrationBrowseSource!(payload as never)
+          ),
+        }
+      : {}),
+    ...(typeof api.migrationTakeLastResult === 'function'
+      ? { migrationTakeLastResult: () => requireDesktopApi().migrationTakeLastResult!() }
+      : {}),
+    ...(typeof api.migrationPeekLastResult === 'function'
+      ? { migrationPeekLastResult: () => requireDesktopApi().migrationPeekLastResult!() }
+      : {}),
+    ...(typeof api.migrationDismissLastResult === 'function'
+      ? { migrationDismissLastResult: () => requireDesktopApi().migrationDismissLastResult!() }
+      : {}),
+    ...(typeof api.revealRecoveryPath === 'function'
+      ? {
+          revealRecoveryPath: (payload: { target: 'backups' }) => (
+            requireDesktopApi().revealRecoveryPath!(payload)
+          ),
+        }
+      : {}),
+    ...(typeof api.onMigrationProgress === 'function'
+      ? {
+          onMigrationProgress: (callback: (state: { phase: string; detail?: string }) => void) => (
+            requireDesktopApi().onMigrationProgress!((payload: unknown) => {
+              if (!payload || typeof payload !== 'object') return
+              const state = payload as { phase?: unknown; detail?: unknown }
+              if (typeof state.phase !== 'string') return
+              callback({
+                phase: state.phase,
+                ...(typeof state.detail === 'string' ? { detail: state.detail } : {}),
+              })
+            })
+          ),
+        }
+      : {}),
+    ...(typeof api.inspectDesktopCleanup === 'function'
+      ? {
+          inspectDesktopCleanup: (payload: unknown) => (
+            requireDesktopApi().inspectDesktopCleanup!(payload as never)
+          ),
+        }
+      : {}),
+    ...(typeof api.discardDesktopCleanup === 'function'
+      ? {
+          discardDesktopCleanup: (payload: { previewId: string }) => (
+            requireDesktopApi().discardDesktopCleanup!(payload)
+          ),
+        }
+      : {}),
+    ...(typeof api.applyDesktopCleanup === 'function'
+      ? {
+          applyDesktopCleanup: (payload: unknown) => (
+            requireDesktopApi().applyDesktopCleanup!(payload as never)
+          ),
+        }
+      : {}),
+    ...(typeof api.revealDesktopUserData === 'function'
+      ? { revealDesktopUserData: () => requireDesktopApi().revealDesktopUserData!() }
+      : {}),
+  })
+}
+
 function idleUpdateState(canNativeInstall: boolean, managed = canNativeInstall): DesktopUpdateState {
   return {
     status: 'idle',
@@ -353,6 +447,16 @@ export function createDesktopPlatform(): Platform {
     workbench: {
       ...(nativeWorkbench ? { native: nativeWorkbench } : {}),
     },
+    lifecycle: {
+      ...(typeof desktopApi.onWindowHidden === 'function'
+        ? {
+            onWindowHidden: (callback: () => void) => (
+              requireDesktopApi().onWindowHidden!(callback)
+            ),
+          }
+        : {}),
+    },
+    migration: desktopMigrationApi(desktopApi),
     updates: {
       async getState() {
         const api = requireDesktopApi()

--- a/opensquilla-webui/src/platform/index.ts
+++ b/opensquilla-webui/src/platform/index.ts
@@ -42,6 +42,7 @@ export type {
   PlatformFilesApi,
   PlatformGatewayApi,
   PlatformId,
+  PlatformLifecycleApi,
   PlatformOnboardingApi,
   PlatformUpdatesApi,
   PlatformSettingsApi,

--- a/opensquilla-webui/src/platform/types.ts
+++ b/opensquilla-webui/src/platform/types.ts
@@ -377,6 +377,11 @@ export interface PlatformUpdatesApi {
   onState(callback: (state: DesktopUpdateState) => void): () => void
 }
 
+export interface PlatformLifecycleApi {
+  /** Subscribe to a host-level window hide event. Undefined in browsers. */
+  onWindowHidden?: (callback: () => void) => void | (() => void)
+}
+
 export interface Platform {
   id: PlatformId
   capabilities: PlatformCapabilities
@@ -386,6 +391,14 @@ export interface Platform {
   files: PlatformFilesApi
   workbench: PlatformWorkbenchApi
   updates: PlatformUpdatesApi
+  lifecycle: PlatformLifecycleApi
+  /**
+   * Legacy profile migration operations exposed by the desktop host. The
+   * settings feature owns their domain-specific payload validation; keeping
+   * the object here prevents feature code from reaching into the preload
+   * global directly.
+   */
+  migration: Readonly<Record<string, unknown>>
   /**
    * The host OS locale (BCP-47), used only to seed the initial UI language on
    * first run. Desktop reads it from Electron's app.getLocale(); web returns

--- a/opensquilla-webui/src/platform/web.ts
+++ b/opensquilla-webui/src/platform/web.ts
@@ -55,6 +55,8 @@ export function createWebPlatform(): Platform {
     onboarding: {},
     files: {},
     workbench: {},
+    lifecycle: {},
+    migration: {},
     updates: {
       getState: webUpdateState,
       check: webUpdateState,

--- a/opensquilla-webui/src/router/index.ts
+++ b/opensquilla-webui/src/router/index.ts
@@ -1,10 +1,14 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import type { RouteRecordRaw, RouteLocationNormalized } from 'vue-router'
-import { getPlatform } from '@/platform'
+import type {
+  RouteComponent,
+  RouteLocationNormalized,
+  RouteRecordRaw,
+  Router,
+} from 'vue-router'
+import type { OpenSquillaAppComposition } from '@opensquilla/ui-foundation'
+import { getPlatform, type Platform } from '@/platform'
+import { createPublicWebUiRedirectRoutes } from '@/composition/catalog'
 import i18n from '@/i18n'
-import { desktopRoutes } from './desktopRoutes'
-import { sharedRoutes } from './sharedRoutes'
-import { webRoutes } from './webRoutes'
 import { captureContentScroll, contentScrollBehavior } from './scrollMemory'
 import { saveLastRoute } from './lastRoute'
 import { legacyChannelHashRedirect } from './legacyRedirects'
@@ -13,27 +17,63 @@ import {
   primeSessionBootstrapAdmission,
 } from '@/composables/chat/sessionBootstrapAdmission'
 
-const basePath = (() => {
+function basePath(): string {
   const el = document.getElementById('opensquilla-data')
   const raw = el?.dataset.basePath || '/control'
   return raw.endsWith('/') ? raw : raw + '/'
-})()
+}
 
-const platform = getPlatform()
-const NotFoundView = () => import('@/views/NotFoundView.vue')
+function webUiOrder(metadata: Readonly<Record<string, unknown>> | undefined): number {
+  return typeof metadata?.webUiOrder === 'number' ? metadata.webUiOrder : 500
+}
 
-export const routes: RouteRecordRaw[] = [
-  ...sharedRoutes,
-  ...(platform.capabilities.hasWebConfig ? webRoutes : []),
-  ...(platform.capabilities.hasDesktopOnboarding ? desktopRoutes : []),
-  { path: '/:pathMatch(.*)*', name: 'not-found', component: NotFoundView, meta: { title: 'Not Found', platforms: ['web', 'desktop'] } },
-]
+export function createPublicWebUiRoutes(
+  composition: OpenSquillaAppComposition,
+  platform: Platform = getPlatform(),
+): RouteRecordRaw[] {
+  const pageLoaders = new Map<string, () => Promise<RouteComponent>>()
+  const registeredRoutes = composition.registry.routes
+    .filter(({ contribution }) => composition.availability(
+      contribution.requirements,
+    ).available)
+    .map(({ contribution }) => {
+      let component = pageLoaders.get(contribution.pageId)
+      if (!component) {
+        component = () => composition.loadPage<RouteComponent>(contribution.pageId)
+        pageLoaders.set(contribution.pageId, component)
+      }
+      const { webUiOrder: _webUiOrder, ...meta } = contribution.metadata ?? {}
+      return {
+        order: webUiOrder(contribution.metadata),
+        record: {
+          path: contribution.path,
+          name: contribution.name,
+          component,
+          meta,
+        } satisfies RouteRecordRaw,
+      }
+    })
+  const redirects = createPublicWebUiRedirectRoutes(platform).map(({ record, order }) => ({
+    order,
+    record,
+  }))
+  return [...registeredRoutes, ...redirects]
+    .sort((left, right) => left.order - right.order)
+    .map(({ record }) => record)
+}
 
-export const router = createRouter({
-  history: createWebHistory(basePath),
-  routes,
-  scrollBehavior: contentScrollBehavior,
-})
+export function createPublicWebUiRouter(
+  composition: OpenSquillaAppComposition,
+  platform: Platform = getPlatform(),
+): Router {
+  const router = createRouter({
+    history: createWebHistory(basePath()),
+    routes: createPublicWebUiRoutes(composition, platform),
+    scrollBehavior: contentScrollBehavior,
+  })
+  installRouterLifecycle(router)
+  return router
+}
 
 function isChatRoutePath(path: string): boolean {
   return path === '/chat' || path === '/chat/new'
@@ -44,22 +84,37 @@ function isChatRoutePath(path: string): boolean {
 // lazy route so optional shell RPCs cannot enter the Gateway's serialized
 // dispatcher ahead of session subscribe/snapshot/history. Query-only chat
 // navigation reuses the mounted view and owns its hold through the coordinator.
-router.beforeEach((to, from) => {
-  const enteringChat = isChatRoutePath(to.path) && !isChatRoutePath(from.path)
-  if (enteringChat) {
-    primeSessionBootstrapAdmission()
-  } else if (!isChatRoutePath(to.path)) {
+function installRouterLifecycle(router: Router): void {
+  router.beforeEach((to, from) => {
+    const enteringChat = isChatRoutePath(to.path) && !isChatRoutePath(from.path)
+    if (enteringChat) {
+      primeSessionBootstrapAdmission()
+    } else if (!isChatRoutePath(to.path)) {
+      clearPrimedSessionBootstrapAdmission()
+    }
+  })
+
+  // Capture the leaving route's content scroll offset so back/forward can restore it.
+  router.beforeEach((_to, from) => {
+    captureContentScroll(from)
+  })
+
+  // Stale channel-setup bookmarks (#channel-… hashes) land on the workspace.
+  router.beforeEach((to) => legacyChannelHashRedirect(to) ?? true)
+
+  router.afterEach((to, _from, failure) => {
+    if (failure || !isChatRoutePath(to.path)) {
+      clearPrimedSessionBootstrapAdmission()
+    }
+    document.title = `${routeTitle(to)} — OpenSquilla`
+    // Remember the current view (path only) so the next launch reopens here.
+    saveLastRoute(to.path)
+  })
+
+  router.onError(() => {
     clearPrimedSessionBootstrapAdmission()
-  }
-})
-
-// Capture the leaving route's content scroll offset so back/forward can restore it.
-router.beforeEach((_to, from) => {
-  captureContentScroll(from)
-})
-
-// Stale channel-setup bookmarks (#channel-… hashes) land on the workspace.
-router.beforeEach((to) => legacyChannelHashRedirect(to) ?? true)
+  })
+}
 
 // Localize the document title from the route name token (e.g. `nav.sessions`),
 // falling back to the English meta.title. `applyRouteTitle` is also re-run when
@@ -79,16 +134,3 @@ export function routeTitle(route: RouteLocationNormalized): string {
   }
   return (route.meta?.title as string) || 'OpenSquilla'
 }
-
-router.afterEach((to, _from, failure) => {
-  if (failure || !isChatRoutePath(to.path)) {
-    clearPrimedSessionBootstrapAdmission()
-  }
-  document.title = `${routeTitle(to)} — OpenSquilla`
-  // Remember the current view (path only) so the next launch reopens here.
-  saveLastRoute(to.path)
-})
-
-router.onError(() => {
-  clearPrimedSessionBootstrapAdmission()
-})

--- a/opensquilla-webui/src/router/nav.ts
+++ b/opensquilla-webui/src/router/nav.ts
@@ -1,11 +1,12 @@
 import { getPlatform } from '@/platform'
 import type { PlatformId } from '@/platform'
-import type { RouteRecordRaw } from 'vue-router'
 import type { IconName } from '@/utils/icons'
 import i18n from '@/i18n'
-import { desktopRoutes } from './desktopRoutes'
-import { sharedRoutes } from './sharedRoutes'
-import { webRoutes } from './webRoutes'
+import { createPublicWebUiRegistry } from '@/composition/catalog'
+import type {
+  ContributionRegistrySnapshot,
+  OpenSquillaAppComposition,
+} from '@opensquilla/ui-foundation'
 
 type NavigationSlot = 'primary' | 'bottom'
 
@@ -14,12 +15,6 @@ export interface NavigationItem {
   title: string
   icon: IconName
 }
-
-const navRoutes = [
-  ...sharedRoutes,
-  ...webRoutes,
-  ...desktopRoutes,
-]
 
 function routePlatforms(platforms: unknown): PlatformId[] {
   if (!Array.isArray(platforms)) return ['web', 'desktop']
@@ -30,44 +25,89 @@ function routePlatforms(platforms: unknown): PlatformId[] {
 // falling back to the English meta.title literal when no key exists. Called
 // inside the useNavigation() computeds, so reading the reactive i18n locale here
 // makes the rail/drawer/palette re-render on a language switch.
-function navTitle(route: RouteRecordRaw): string {
-  const explicitKey = route.meta?.navLabelKey
+function navTitle(
+  name: string,
+  label: string,
+  metadata: Readonly<Record<string, unknown>> | undefined,
+): string {
+  const explicitKey = metadata?.navLabelKey
   if (explicitKey) {
-    const translated = i18n.global.t(explicitKey)
+    const translated = i18n.global.t(String(explicitKey))
     if (translated !== explicitKey) return translated
   }
-  const name = typeof route.name === 'string' ? route.name : ''
   if (name) {
     const key = `nav.${name}`
     const translated = i18n.global.t(key)
     if (translated !== key) return translated
   }
-  return String(route.meta?.title || route.name || route.path)
+  return label
 }
 
-export function getNavigationItems(slot: NavigationSlot): NavigationItem[] {
+function navigationRegistry(
+  composition: OpenSquillaAppComposition | undefined,
+): ContributionRegistrySnapshot {
+  return composition?.registry ?? createPublicWebUiRegistry(getPlatform())
+}
+
+export function getNavigationItems(
+  slot: NavigationSlot,
+  composition?: OpenSquillaAppComposition,
+): NavigationItem[] {
   const platform = getPlatform()
-  return navRoutes
-    .filter((route) => route.meta?.nav === slot)
-    .filter((route) => routePlatforms(route.meta?.platforms).includes(platform.id))
-    .sort((a, b) => Number(a.meta?.navOrder || 0) - Number(b.meta?.navOrder || 0))
-    .map((route) => ({
-      path: route.path,
-      title: navTitle(route),
-      icon: (route.meta?.icon || 'home') as IconName,
-    }))
+  const registry = navigationRegistry(composition)
+  const routes = new Map(
+    registry.routes.map(({ contribution }) => [contribution.id, contribution]),
+  )
+  const foundationSlot = slot === 'bottom' ? 'footer' : 'primary'
+  return registry.navigation
+    .filter(({ contribution }) => contribution.slot === foundationSlot)
+    .filter(({ contribution }) => (
+      routePlatforms(contribution.metadata?.platforms).includes(platform.id)
+    ))
+    .sort((left, right) => (
+      Number(left.contribution.order ?? 0) - Number(right.contribution.order ?? 0)
+    ))
+    .map(({ contribution }) => {
+      const route = routes.get(contribution.routeId)
+      if (!route) {
+        throw new Error(`Navigation "${contribution.id}" references an unknown route`)
+      }
+      return {
+        path: route.path,
+        title: navTitle(route.name, contribution.label, contribution.metadata),
+        icon: (contribution.metadata?.icon || 'home') as IconName,
+        group: String(contribution.metadata?.group || 'Operate'),
+      }
+    })
+    .map(({ group: _group, ...item }) => item)
 }
 
 // The flat, always-visible destinations shared by the desktop rail, mobile
 // drawer, and command palette. Chat is excluded because the dedicated New-chat
 // action owns that destination.
-export function getWorkNavigationSection(): NavigationItem[] {
-  const groupOf = new Map(
-    navRoutes
-      .filter((route) => route.meta?.nav === 'primary')
-      .map((route) => [route.path, route.meta?.group ?? 'Operate']),
+export function getWorkNavigationSection(
+  composition?: OpenSquillaAppComposition,
+): NavigationItem[] {
+  const registry = navigationRegistry(composition)
+  const routes = new Map(
+    registry.routes.map(({ contribution }) => [contribution.id, contribution]),
   )
-  return getNavigationItems('primary').filter(
-    (item) => groupOf.get(item.path) === 'Work' && item.path !== '/chat',
-  )
+  return registry.navigation
+    .filter(({ contribution }) => contribution.slot === 'primary')
+    .filter(({ contribution }) => contribution.metadata?.group === 'Work')
+    .sort((left, right) => (
+      Number(left.contribution.order ?? 0) - Number(right.contribution.order ?? 0)
+    ))
+    .map(({ contribution }) => {
+      const route = routes.get(contribution.routeId)
+      if (!route) {
+        throw new Error(`Navigation "${contribution.id}" references an unknown route`)
+      }
+      return {
+        path: route.path,
+        title: navTitle(route.name, contribution.label, contribution.metadata),
+        icon: (contribution.metadata?.icon || 'home') as IconName,
+      }
+    })
+    .filter((item) => item.path !== '/chat')
 }

--- a/opensquilla-webui/src/router/sharedRoutes.test.ts
+++ b/opensquilla-webui/src/router/sharedRoutes.test.ts
@@ -1,12 +1,22 @@
 // @vitest-environment happy-dom
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { RouteLocationNormalized } from 'vue-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia } from 'pinia'
+import type {
+  RouteLocationNormalized,
+  RouteRecordRaw,
+} from 'vue-router'
+import type { OpenSquillaAppComposition } from '@opensquilla/ui-foundation'
 import i18n, { loadLocaleMessages } from '@/i18n'
+import { getPlatform } from '@/platform'
+import { createPublicWebUiComposition } from '@/composition/root'
 import { LAST_ROUTE_KEY } from './lastRoute'
 import { defaultRootRedirect } from './sharedRoutes'
-import { routeTitle, routes } from './index'
+import { createPublicWebUiRoutes, routeTitle } from './index'
 
-beforeEach(() => {
+let composition: OpenSquillaAppComposition
+let routes: RouteRecordRaw[]
+
+beforeEach(async () => {
   localStorage.clear()
   i18n.global.locale.value = 'en'
   delete window.opensquillaDesktop
@@ -20,6 +30,16 @@ beforeEach(() => {
     removeListener: vi.fn(),
     dispatchEvent: vi.fn(),
   }))
+  const platform = getPlatform()
+  composition = await createPublicWebUiComposition({
+    pinia: createPinia(),
+    platform,
+  })
+  routes = createPublicWebUiRoutes(composition, platform)
+})
+
+afterEach(async () => {
+  await composition.dispose()
 })
 
 describe('defaultRootRedirect', () => {

--- a/opensquilla-webui/src/workbench/registry.ts
+++ b/opensquilla-webui/src/workbench/registry.ts
@@ -1,9 +1,6 @@
 import { WorkbenchPanelRegistry } from './runtime'
 
-/**
- * Application-level provider registry. Built-in providers register when their
- * feature module loads; future Browser, Frontend Preview, Files, Diff and
- * Terminal providers can add renderers and runtime controllers without adding
- * another panel-kind switch to the Workbench host.
- */
-export const workbenchPanelRegistry = new WorkbenchPanelRegistry()
+/** Create a composition-scoped provider registry for one product instance. */
+export function createWorkbenchPanelRegistry(): WorkbenchPanelRegistry {
+  return new WorkbenchPanelRegistry()
+}


### PR DESCRIPTION
## Scope

- Make the complete public WebUI a formal consumer of the versioned UI Foundation composition root.
- Register the existing community pages, routes, navigation, and scoped state as product-neutral feature contributions.
- Route browser and desktop-native capabilities through the public platform adapter boundary.
- Scope Workbench state and panel registration to one application composition.
- Preserve every existing community route, deep link, redirect, browser mode, and Gateway-hosted production mode.

## Non-goals

- No private product features, entitlements, branding, or private repository dependency.
- No removal or reduction of the public community WebUI.
- No Gateway RPC, HTTP, persisted configuration, database, or release-cutover change.

## Branch target

`feature/client-migration-f05` -> `feature/client-migration`

## Linked issue

None

## Release note

None; internal public-client architecture migration with compatibility coverage.

## Verification

- `npm run build` (WebUI production artifact, architecture/i18n/theme/runtime guards)
- `npm run test:unit -- --run` (243 files, 2555 tests)
- `npm run verify:ui-packages` (SDK/Foundation/tokens/primitives type, test, build, boundary, and external-consumer checks)
- `npm run build` in `desktop/electron`
- `uv run pytest tests/test_ci/test_workflows.py tests/test_packaging/test_webui_build_contract.py -q` (80 tests)
- Production Gateway + Chromium `e2e/public-composition.spec.ts` (17 public routes and compatibility redirects)

## Compatibility and safety

- Existing route paths, names, metadata, redirects, lazy-view identity, and standalone browser behavior are preserved.
- Existing desktop preload calls used by migration and window lifecycle are wrapped behind the platform adapter without changing bridge payloads.
- Browser-native capability calls fail with structured unsupported results.
- No public protocol or persisted-state migration is required.
- Platform-neutral application changes were type-checked; the desktop host TypeScript build passed. CI remains authoritative for the Linux/macOS/Windows matrix.

## Third-party origin

None.
