### PR TITLE
Client Migration-Phase 1-Publish UI Foundation Compatibility Gates

### DIFF
--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -118,7 +118,7 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
     opensquilla-webui/*)
       mark_frontend_changed
       ;;
-    package.json | package-lock.json | tsconfig.ui-package.json | packages/ui-package-manifest.json | packages/ui-*/* | scripts/verify_ui_packages.mjs)
+    package.json | package-lock.json | tsconfig.ui-package.json | packages/UI_RELEASE.md | packages/ui-package-manifest.json | packages/ui-compatibility-matrix.json | packages/ui-*/* | contracts/ui-foundation/* | contracts/ui-foundation/*/* | scripts/*ui_package*.mjs | scripts/tests/ui_package*.test.mjs | tests/fixtures/ui-package-consumer/*)
       # Public UI Foundation packages are browser-safe client inputs. They
       # have their own cross-platform pack/install gate and never wake the
       # Python runtime or release-wheel path.
@@ -140,6 +140,11 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_full_required
       ;;
     .github/workflows/wheelhouse-release.yml)
+      mark_ci_changed
+      mark_release_changed
+      ;;
+    .github/workflows/ui-foundation-release.yml)
+      mark_frontend_changed
       mark_ci_changed
       mark_release_changed
       ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -114,6 +116,20 @@ jobs:
 
       - name: Verify public UI package boundaries
         run: npm run verify:ui-packages
+
+      - name: Enforce UI package semantic-version compatibility
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [[ -n "${BASE_REF}" ]]; then
+            baseline="origin/${BASE_REF}"
+          else
+            baseline="HEAD^"
+          fi
+          npm run check:ui-package-compat -- \
+            --baseline-ref "${baseline}" \
+            --allow-bootstrap
 
   ui-primitives-browser:
     name: Public UI primitives (browser matrix)
@@ -168,8 +184,12 @@ jobs:
           node-version-file: opensquilla-webui/.node-version
           cache: 'npm'
           cache-dependency-path: |
+            package-lock.json
             packages/client-sdk/package-lock.json
             opensquilla-webui/package-lock.json
+
+      - name: Install public UI release dependencies
+        run: npm ci --ignore-scripts
 
       - name: Install client SDK dependencies
         working-directory: packages/client-sdk
@@ -185,6 +205,21 @@ jobs:
       - name: Install frontend dependencies
         working-directory: opensquilla-webui
         run: npm ci
+
+      - name: Build and verify immutable public UI release assets
+        env:
+          UI_RELEASE_DIR: ${{ runner.temp }}/opensquilla-ui-release
+        run: |
+          npm run build:ui-packages
+          npm run check:ui-package-api
+          npm run build:ui-package-release -- \
+            --output-dir "${UI_RELEASE_DIR}" \
+            --source-ref "${GITHUB_REF_NAME}" \
+            --source-commit "${GITHUB_SHA}"
+          npm run verify:ui-package-release -- \
+            --artifacts-dir "${UI_RELEASE_DIR}"
+          npm run install:ui-package-release -- \
+            --artifacts-dir "${UI_RELEASE_DIR}"
 
       - name: Run frontend unit tests
         if: ${{ needs.classify-changes.outputs.frontend_changed == 'true' || needs.classify-changes.outputs.full_required == 'true' }}

--- a/.github/workflows/ui-foundation-release.yml
+++ b/.github/workflows/ui-foundation-release.yml
@@ -1,0 +1,130 @@
+name: Public UI Foundation Release
+
+"on":
+  push:
+    tags:
+      - "ui-foundation-v*"
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: UI Foundation release version from packages/ui-compatibility-matrix.json
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ui-foundation-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-release:
+    name: Build immutable public UI release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: opensquilla-webui/.node-version
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            opensquilla-webui/package-lock.json
+
+      - name: Install public UI release dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Resolve and validate release version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.release_version }}
+          REF_NAME: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          manifest_version="$(
+            node -p "require('./packages/ui-compatibility-matrix.json').current.releaseVersion"
+          )"
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            requested="${REF_NAME#ui-foundation-v}"
+            if [[ "${requested}" == "${REF_NAME}" ]]; then
+              echo "ERROR: release tag must use ui-foundation-v<semver>" >&2
+              exit 1
+            fi
+          else
+            requested="${INPUT_VERSION}"
+          fi
+          if [[ "${requested}" != "${manifest_version}" ]]; then
+            echo "ERROR: requested ${requested} but manifest declares ${manifest_version}" >&2
+            exit 1
+          fi
+          echo "version=${requested}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify package, API, and external-consumer gates
+        run: npm run verify:ui-packages
+
+      - name: Build immutable release assets
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          UI_RELEASE_DIR: ${{ runner.temp }}/opensquilla-ui-release
+        run: |
+          npm run build:ui-package-release -- \
+            --output-dir "${UI_RELEASE_DIR}" \
+            --release-version "${RELEASE_VERSION}" \
+            --source-ref "${GITHUB_REF_NAME}" \
+            --source-commit "${GITHUB_SHA}"
+          npm run verify:ui-package-release -- \
+            --artifacts-dir "${UI_RELEASE_DIR}"
+
+      - name: Install release tarballs into the complete public WebUI
+        run: |
+          npm ci --prefix opensquilla-webui
+          npm run install:ui-package-release -- \
+            --artifacts-dir "${RUNNER_TEMP}/opensquilla-ui-release"
+
+      - name: Build the complete public WebUI from release tarballs
+        run: npm run build --prefix opensquilla-webui
+
+      - name: Upload release-candidate evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: opensquilla-ui-foundation-${{ steps.version.outputs.version }}
+          path: ${{ runner.temp }}/opensquilla-ui-release/
+          if-no-files-found: error
+          retention-days: 31
+
+  publish:
+    name: Publish write-once GitHub Release
+    if: ${{ github.event_name == 'push' }}
+    needs: build-and-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Download verified release assets
+        uses: actions/download-artifact@v4
+        with:
+          name: opensquilla-ui-foundation-${{ needs.build-and-release.outputs.version }}
+          path: ${{ runner.temp }}/opensquilla-ui-release
+
+      - name: Publish write-once GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ needs.build-and-release.outputs.version }}
+        shell: bash
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            "${RUNNER_TEMP}"/opensquilla-ui-release/* \
+            --verify-tag \
+            --title "OpenSquilla UI Foundation ${RELEASE_VERSION}" \
+            --notes "Versioned public UI Foundation packages, API report, compatibility report, checksums, SPDX SBOM, and provenance. Assets are write-once; fixes require a new patch release."

--- a/contracts/ui-foundation/v1/api-report.json
+++ b/contracts/ui-foundation/v1/api-report.json
@@ -1,0 +1,1457 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "scripts/ui_package_api.mjs",
+  "releaseTrain": "public-ui-foundation",
+  "versionPolicy": "release-groups",
+  "compatibilityPolicy": "current-and-previous-minor",
+  "packages": [
+    {
+      "name": "@opensquilla/client-sdk",
+      "version": "0.1.0",
+      "releaseGroup": "client-sdk",
+      "publicExports": [
+        ".",
+        "./contract-coverage.json"
+      ],
+      "apiExports": [
+        "CLIENT_CONTRACT_DIGEST",
+        "CLIENT_CONTRACT_SCHEMA_VERSION",
+        "CLIENT_MAX_PROTOCOL",
+        "CLIENT_MIN_PROTOCOL",
+        "CapabilitySource",
+        "ClientFrame",
+        "ClientProtocolRange",
+        "ConnectParams",
+        "ConnectRequest",
+        "ConnectionClosedError",
+        "ContractInfo",
+        "ContractStatus",
+        "DECLARED_ERROR_CODES",
+        "DECLARED_EVENTS",
+        "DeclaredErrorCode",
+        "DeclaredEvent",
+        "EVENT_PATTERNS",
+        "ErrorShape",
+        "EventFrame",
+        "EventPattern",
+        "FeaturesInfo",
+        "FetchLike",
+        "Frame",
+        "GatewayCallOptions",
+        "GatewayClient",
+        "GatewayClientError",
+        "GatewayClientOptions",
+        "GatewayConnectionState",
+        "GatewayConnectionWaitOptions",
+        "GatewayEventHandler",
+        "GatewayHttpClient",
+        "GatewayHttpClientOptions",
+        "GatewayHttpError",
+        "GatewayTerminationAction",
+        "HandshakeError",
+        "HelloOk",
+        "Integer",
+        "KnownEvent",
+        "NormalizedHello",
+        "NormalizedRuntimeInfo",
+        "OBSERVED_CLIENT_EVENTS",
+        "ObservedClientEvent",
+        "PingFrame",
+        "PolicyInfo",
+        "PongFrame",
+        "ProtocolRangeInfo",
+        "RPC_METHOD_SCOPES",
+        "ReconnectPolicy",
+        "ReqFrame",
+        "RequestAbortError",
+        "RequestTimeoutError",
+        "ResFrame",
+        "RpcMethod",
+        "RpcScope",
+        "RuntimeInfo",
+        "SequenceGapError",
+        "ServerFrame",
+        "ServerInfo",
+        "SnapshotInfo",
+        "StateVersion",
+        "WebSocketFactory",
+        "WebSocketLike",
+        "WebSocketMessageLike",
+        "capabilitiesForMethods",
+        "normalizeHelloFrame"
+      ],
+      "runtimeExports": [
+        "CLIENT_CONTRACT_DIGEST",
+        "CLIENT_CONTRACT_SCHEMA_VERSION",
+        "CLIENT_MAX_PROTOCOL",
+        "CLIENT_MIN_PROTOCOL",
+        "ConnectionClosedError",
+        "DECLARED_ERROR_CODES",
+        "DECLARED_EVENTS",
+        "EVENT_PATTERNS",
+        "GatewayClient",
+        "GatewayClientError",
+        "GatewayHttpClient",
+        "GatewayHttpError",
+        "HandshakeError",
+        "OBSERVED_CLIENT_EVENTS",
+        "RPC_METHOD_SCOPES",
+        "RequestAbortError",
+        "RequestTimeoutError",
+        "SequenceGapError",
+        "capabilitiesForMethods",
+        "normalizeHelloFrame"
+      ],
+      "declarationsDigest": "sha256:092bafd923c4a3f4943e9a5e2175accb090ec5e30886df9df19d5635fbbaa4b3",
+      "declarations": [
+        {
+          "key": "client.d.ts#ClassDeclaration:GatewayClient",
+          "signature": "export declare class GatewayClient { private readonly options; private readonly webSocketFactory; private readonly protocolRange; private readonly connectTimeoutMs; private readonly requestTimeoutMs; private readonly reconnectEnabled; private readonly reconnectInitialDelayMs; private readonly reconnectMaxDelayMs; private readonly reconnectFactor; private readonly eventHandlers; private readonly stateHandlers; private readonly pending; private socket; private connectionState; private requestId; private connectionGeneration; private connectRequestId; private connectWaiter; private manualClose; private reconnectDelayMs; private reconnectTimer; private handshakeTimer; private pingTimer; private idleTimer; private lastFrameAt; private lastSequence; constructor(options: GatewayClientOptions); get state(): GatewayConnectionState; get pendingRequestCount(): number; connect(): Promise<NormalizedHello>; disconnect(): void; call<T = unknown>(method: RpcMethod | (string & {}), params?: Record<string, unknown>, timeoutOrOptions?: number | GatewayCallOptions): Promise<T>; on(eventOrPattern: string, handler: GatewayEventHandler): () => void; onState(handler: (state: GatewayConnectionState) => void): () => void; waitForConnection(timeoutMs?: number, signal?: AbortSignal, actions?: GatewayConnectionWaitOptions): Promise<void>; private openSocket; private handleMessage; private sendConnect; private acceptHello; private acceptResponse; private acceptEvent; private failHandshake; private handleClose; private startHealthChecks; private stopHealthChecks; private startHandshakeTimer; private stopHandshakeTimer; private scheduleReconnect; private recycleConnection; private clearReconnect; private isCurrentSocket; private rejectConnect; private rejectPending; private takeRequest; private rejectRequest; private setState; private notifyDiagnostic; }"
+        },
+        {
+          "key": "client.d.ts#ImportDeclaration:0",
+          "signature": "import type { EventFrame, RpcMethod } from './generated.js';"
+        },
+        {
+          "key": "client.d.ts#ImportDeclaration:1",
+          "signature": "import { type ClientProtocolRange, type NormalizedHello } from './hello.js';"
+        },
+        {
+          "key": "client.d.ts#InterfaceDeclaration:GatewayCallOptions",
+          "signature": "export interface GatewayCallOptions { timeoutMs?: number; signal?: AbortSignal; timeoutAction?: GatewayTerminationAction; abortAction?: GatewayTerminationAction; onSent?: (connectionGeneration: number) => void; }"
+        },
+        {
+          "key": "client.d.ts#InterfaceDeclaration:GatewayClientOptions",
+          "signature": "export interface GatewayClientOptions { endpoint: string; token?: string; auth?: Record<string, unknown>; client?: Record<string, unknown>; scopes?: string[]; protocolRange?: ClientProtocolRange; connectTimeoutMs?: number; requestTimeoutMs?: number; keepAliveIntervalMs?: number; reconnect?: ReconnectPolicy; /** * Compatibility escape hatch for legacy clients that sent RPC requests as * soon as the transport opened. New clients should wait for Hello. */ allowCallsDuringHandshake?: boolean; webSocketFactory?: WebSocketFactory; onStateChange?: (state: GatewayConnectionState) => void; onHello?: (hello: NormalizedHello) => void; onDiagnostic?: (error: Error) => void; }"
+        },
+        {
+          "key": "client.d.ts#InterfaceDeclaration:GatewayConnectionWaitOptions",
+          "signature": "export interface GatewayConnectionWaitOptions { timeoutAction?: GatewayTerminationAction; abortAction?: GatewayTerminationAction; }"
+        },
+        {
+          "key": "client.d.ts#InterfaceDeclaration:ReconnectPolicy",
+          "signature": "export interface ReconnectPolicy { enabled?: boolean; initialDelayMs?: number; maxDelayMs?: number; factor?: number; }"
+        },
+        {
+          "key": "client.d.ts#InterfaceDeclaration:WebSocketLike",
+          "signature": "export interface WebSocketLike { readonly readyState: number; onopen: (() => void) | null; onmessage: ((event: WebSocketMessageLike) => void) | null; onclose: (() => void) | null; onerror: (() => void) | null; send(data: string): void; close(code?: number, reason?: string): void; }"
+        },
+        {
+          "key": "client.d.ts#InterfaceDeclaration:WebSocketMessageLike",
+          "signature": "export interface WebSocketMessageLike { data: unknown; }"
+        },
+        {
+          "key": "client.d.ts#TypeAliasDeclaration:GatewayConnectionState",
+          "signature": "export type GatewayConnectionState = 'disconnected' | 'connecting' | 'connected';"
+        },
+        {
+          "key": "client.d.ts#TypeAliasDeclaration:GatewayEventHandler",
+          "signature": "export type GatewayEventHandler = (frame: EventFrame) => void;"
+        },
+        {
+          "key": "client.d.ts#TypeAliasDeclaration:GatewayTerminationAction",
+          "signature": "export type GatewayTerminationAction = 'reject' | 'reconnect';"
+        },
+        {
+          "key": "client.d.ts#TypeAliasDeclaration:WebSocketFactory",
+          "signature": "export type WebSocketFactory = (url: string) => WebSocketLike;"
+        },
+        {
+          "key": "errors.d.ts#ClassDeclaration:ConnectionClosedError",
+          "signature": "export declare class ConnectionClosedError extends Error { constructor(message?: string, options?: ErrorOptions); }"
+        },
+        {
+          "key": "errors.d.ts#ClassDeclaration:GatewayClientError",
+          "signature": "export declare class GatewayClientError extends Error { readonly code?: string; readonly details?: unknown; readonly retryable?: boolean; readonly retryAfterMs?: number; readonly accepted?: boolean; constructor(error: Partial<ErrorShape> | string | null | undefined, options?: ErrorOptions); }"
+        },
+        {
+          "key": "errors.d.ts#ClassDeclaration:GatewayHttpError",
+          "signature": "export declare class GatewayHttpError extends GatewayClientError { readonly status: number; readonly responseBody: unknown; constructor(status: number, responseBody: unknown, fallbackMessage: string); }"
+        },
+        {
+          "key": "errors.d.ts#ClassDeclaration:HandshakeError",
+          "signature": "export declare class HandshakeError extends Error { constructor(message: string, options?: ErrorOptions); }"
+        },
+        {
+          "key": "errors.d.ts#ClassDeclaration:RequestAbortError",
+          "signature": "export declare class RequestAbortError extends Error { readonly code = \"RPC_ABORTED\"; readonly method: string; constructor(method: string); }"
+        },
+        {
+          "key": "errors.d.ts#ClassDeclaration:RequestTimeoutError",
+          "signature": "export declare class RequestTimeoutError extends Error { readonly code = \"RPC_TIMEOUT\"; readonly requestId: string; readonly method: string; readonly timeoutMs: number; constructor(method: string, timeoutMs: number); constructor(requestId: string, method: string, timeoutMs: number); }"
+        },
+        {
+          "key": "errors.d.ts#ClassDeclaration:SequenceGapError",
+          "signature": "export declare class SequenceGapError extends Error { readonly expected: number; readonly actual: number; readonly event?: string; constructor(expected: number, actual: number, event?: string); }"
+        },
+        {
+          "key": "errors.d.ts#ImportDeclaration:0",
+          "signature": "import type { ErrorShape } from './generated.js';"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:ConnectParams",
+          "signature": "export interface ConnectParams { auth?: Record<string, unknown>; caps?: unknown | null; client?: unknown | null; commands?: unknown | null; locale?: unknown | null; maxProtocol?: Integer; minProtocol?: Integer; path_env?: unknown | null; permissions?: unknown | null; role?: string; scopes?: unknown | null; user_agent?: unknown | null; [key: string]: unknown; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:ContractInfo",
+          "signature": "export interface ContractInfo { digest: string; generatedFrom: string; schemaVersion: Integer; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:ErrorShape",
+          "signature": "export interface ErrorShape { accepted?: boolean | null; code: string; details?: unknown | null; message: string; retry_after_ms?: Integer | null; retryable?: boolean | null; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:EventFrame",
+          "signature": "export interface EventFrame { event: string; meta?: Record<string, unknown> | null; payload?: unknown | null; seq?: Integer | null; state_version?: StateVersion | null; type: \"event\"; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:FeaturesInfo",
+          "signature": "export interface FeaturesInfo { events: Array<string>; methods: Array<string>; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:HelloOk",
+          "signature": "export interface HelloOk { auth?: Record<string, unknown> | null; capabilities?: Array<string> | null; contract?: ContractInfo | null; extensions?: Array<string> | null; features: FeaturesInfo; id?: string | null; policy: PolicyInfo; protocol: Integer; protocolRange?: ProtocolRangeInfo | null; runtime?: RuntimeInfo | null; server: ServerInfo; snapshot: SnapshotInfo; type: \"hello-ok\"; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:PingFrame",
+          "signature": "export interface PingFrame { type: \"ping\"; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:PolicyInfo",
+          "signature": "export interface PolicyInfo { agent_stream_heartbeat_interval_ms?: Integer; agent_stream_idle_timeout_ms?: Integer; client_ws_keepalive_timeout_ms?: Integer; concurrent_history_reads?: boolean; max_buffered_bytes?: Integer; max_payload?: Integer; tick_interval_ms?: Integer; webui_stream_idle_grace_ms?: Integer; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:PongFrame",
+          "signature": "export interface PongFrame { type: \"pong\"; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:ProtocolRangeInfo",
+          "signature": "export interface ProtocolRangeInfo { max: Integer; min: Integer; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:ReqFrame",
+          "signature": "export interface ReqFrame { id: string; method: string; params?: unknown | null; type: \"req\"; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:ResFrame",
+          "signature": "export interface ResFrame { error?: ErrorShape | null; id: string; ok: boolean; payload?: unknown | null; type: \"res\"; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:RuntimeInfo",
+          "signature": "export interface RuntimeInfo { arch: string; buildCommit?: string | null; coreVersion: string; platform: string; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:ServerInfo",
+          "signature": "export interface ServerInfo { conn_id: string; version: string; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:SnapshotInfo",
+          "signature": "export interface SnapshotInfo { auth_mode?: string | null; config_path?: string | null; health?: unknown; presence?: Array<unknown>; state_dir?: string | null; state_version?: StateVersion; uptime_ms?: Integer; }"
+        },
+        {
+          "key": "generated.d.ts#InterfaceDeclaration:StateVersion",
+          "signature": "export interface StateVersion { health?: Integer; presence?: Integer; }"
+        },
+        {
+          "key": "generated.d.ts#TypeAliasDeclaration:ClientFrame",
+          "signature": "export type ClientFrame = ReqFrame | PingFrame | PongFrame;"
+        },
+        {
+          "key": "generated.d.ts#TypeAliasDeclaration:ConnectRequest",
+          "signature": "export type ConnectRequest = { id: string; method: \"connect\"; params: { auth?: Record<string, unknown>; client?: Record<string, unknown>; maxProtocol?: Integer; minProtocol?: Integer; role?: string; scopes?: Array<string>; [key: string]: unknown; }; type: \"req\"; [key: string]: unknown; };"
+        },
+        {
+          "key": "generated.d.ts#TypeAliasDeclaration:DeclaredErrorCode",
+          "signature": "export type DeclaredErrorCode = (typeof DECLARED_ERROR_CODES)[number];"
+        },
+        {
+          "key": "generated.d.ts#TypeAliasDeclaration:DeclaredEvent",
+          "signature": "export type DeclaredEvent = (typeof DECLARED_EVENTS)[number];"
+        },
+        {
+          "key": "generated.d.ts#TypeAliasDeclaration:EventPattern",
+          "signature": "export type EventPattern = (typeof EVENT_PATTERNS)[number];"
+        },
+        {
+          "key": "generated.d.ts#TypeAliasDeclaration:Frame",
+          "signature": "export type Frame = ReqFrame | ResFrame | EventFrame | HelloOk | PingFrame | PongFrame;"
+        },
+        {
+          "key": "generated.d.ts#TypeAliasDeclaration:Integer",
+          "signature": "export type Integer = number;"
+        },
+        {
+          "key": "generated.d.ts#TypeAliasDeclaration:KnownEvent",
+          "signature": "export type KnownEvent = DeclaredEvent | ObservedClientEvent;"
+        },
+        {
+          "key": "generated.d.ts#TypeAliasDeclaration:ObservedClientEvent",
+          "signature": "export type ObservedClientEvent = (typeof OBSERVED_CLIENT_EVENTS)[number];"
+        },
+        {
+          "key": "generated.d.ts#TypeAliasDeclaration:RpcMethod",
+          "signature": "export type RpcMethod = keyof typeof RPC_METHOD_SCOPES;"
+        },
+        {
+          "key": "generated.d.ts#TypeAliasDeclaration:RpcScope",
+          "signature": "export type RpcScope = (typeof RPC_METHOD_SCOPES)[RpcMethod];"
+        },
+        {
+          "key": "generated.d.ts#TypeAliasDeclaration:ServerFrame",
+          "signature": "export type ServerFrame = ResFrame | EventFrame | HelloOk | PingFrame | PongFrame;"
+        },
+        {
+          "key": "generated.d.ts#VariableStatement:CLIENT_CONTRACT_DIGEST",
+          "signature": "export declare const CLIENT_CONTRACT_DIGEST: \"sha256:9819d28398fd37609c8c86ae9b5bbf8133d122ae07f06b75817a4d5b3c30a79e\";"
+        },
+        {
+          "key": "generated.d.ts#VariableStatement:CLIENT_CONTRACT_SCHEMA_VERSION",
+          "signature": "export declare const CLIENT_CONTRACT_SCHEMA_VERSION: 1;"
+        },
+        {
+          "key": "generated.d.ts#VariableStatement:DECLARED_ERROR_CODES",
+          "signature": "export declare const DECLARED_ERROR_CODES: readonly [\"AGENT_TIMEOUT\", \"APPROVAL_NOT_FOUND\", \"INVALID_REQUEST\", \"METHOD_NOT_FOUND\", \"NOT_FOUND\", \"NOT_LINKED\", \"NOT_PAIRED\", \"UNAUTHORIZED\", \"UNAVAILABLE\"];"
+        },
+        {
+          "key": "generated.d.ts#VariableStatement:DECLARED_EVENTS",
+          "signature": "export declare const DECLARED_EVENTS: readonly [\"connect.challenge\", \"agent\", \"session.message\", \"sessions.changed\", \"presence\", \"tick\", \"shutdown\", \"health\", \"heartbeat\", \"cron\"];"
+        },
+        {
+          "key": "generated.d.ts#VariableStatement:EVENT_PATTERNS",
+          "signature": "export declare const EVENT_PATTERNS: readonly [\"session.event.*\", \"task.*\"];"
+        },
+        {
+          "key": "generated.d.ts#VariableStatement:OBSERVED_CLIENT_EVENTS",
+          "signature": "export declare const OBSERVED_CLIENT_EVENTS: readonly [\"channel.status\", \"collaboration_mode\", \"cron.run.finished\", \"exec.approval.requested\", \"exec.approval.resolved\", \"exec.approval.updated\", \"models.routing.changed\", \"plan_revision\", \"plan_run\", \"plugin.approval.requested\", \"plugin.approval.resolved\", \"plugin.approval.updated\", \"sandbox.run_mode.preference.changed\", \"session.epoch_changed\", \"session.event.artifact\", \"session.event.collaboration_mode\", \"session.event.compaction\", \"session.event.cron_result\", \"session.event.ensemble_progress\", \"session.event.input_disposition\", \"session.event.meta_preflight\", \"session.event.meta_run_announced\", \"session.event.meta_run_completed\", \"session.event.meta_step_state\", \"session.event.plan_revision\", \"session.event.plan_run\", \"session.event.router_control_replay\", \"session.event.router_decision\", \"session.event.run_heartbeat\", \"session.event.state_change\", \"session.event.subagent_completion\", \"session.event.task_group.done\", \"session.event.task_group.failed\", \"session.event.task_group.synthesizing\", \"session.event.task_group.waiting\", \"session.event.text_delta\", \"session.event.tool_result\", \"session.event.tool_use_delta\", \"session.event.tool_use_start\", \"session.event.warning\", \"sessions.changed\", \"task.queued\", \"task.running\"];"
+        },
+        {
+          "key": "generated.d.ts#VariableStatement:RPC_METHOD_SCOPES",
+          "signature": "export declare const RPC_METHOD_SCOPES: { readonly agent: \"operator.write\"; readonly \"agent.identity.get\": \"operator.read\"; readonly \"agent.wait\": \"operator.write\"; readonly \"agents.create\": \"operator.admin\"; readonly \"agents.delete\": \"operator.admin\"; readonly \"agents.files.get\": \"operator.read\"; readonly \"agents.files.list\": \"operator.read\"; readonly \"agents.files.set\": \"operator.admin\"; readonly \"agents.list\": \"operator.read\"; readonly \"agents.update\": \"operator.admin\"; readonly \"channels.admin.set\": \"operator.pairing\"; readonly \"channels.get\": \"operator.admin\"; readonly \"channels.logout\": \"operator.admin\"; readonly \"channels.pairing.approve\": \"operator.pairing\"; readonly \"channels.pairing.revoke\": \"operator.pairing\"; readonly \"channels.pairings\": \"operator.pairing\"; readonly \"channels.probe\": \"operator.admin\"; readonly \"channels.restart\": \"operator.admin\"; readonly \"channels.status\": \"operator.read\"; readonly \"chat.abort\": \"operator.write\"; readonly \"chat.clarify_submit\": \"operator.write\"; readonly \"chat.history\": \"operator.read\"; readonly \"chat.inject\": \"operator.admin\"; readonly \"chat.send\": \"operator.write\"; readonly \"commands.list_for_surface\": \"operator.read\"; readonly \"config.apply\": \"operator.admin\"; readonly \"config.effective\": \"operator.read\"; readonly \"config.get\": \"operator.read\"; readonly \"config.patch\": \"operator.admin\"; readonly \"config.patch.safe\": \"operator.write\"; readonly \"config.reload\": \"operator.admin\"; readonly \"config.schema\": \"operator.admin\"; readonly \"config.schema.lookup\": \"operator.read\"; readonly \"config.set\": \"operator.admin\"; readonly \"cron.add\": \"operator.admin\"; readonly \"cron.create\": \"operator.admin\"; readonly \"cron.list\": \"operator.read\"; readonly \"cron.remove\": \"operator.admin\"; readonly \"cron.run\": \"operator.admin\"; readonly \"cron.runs\": \"operator.read\"; readonly \"cron.status\": \"operator.read\"; readonly \"cron.subscribe\": \"operator.read\"; readonly \"cron.unsubscribe\": \"operator.read\"; readonly \"cron.update\": \"operator.admin\"; readonly \"diagnostics.set\": \"operator.admin\"; readonly \"diagnostics.status\": \"operator.read\"; readonly \"doctor.memory.status\": \"operator.read\"; readonly \"doctor.status\": \"operator.read\"; readonly \"exec.approval.extend\": \"operator.approvals\"; readonly \"exec.approval.forget\": \"operator.approvals\"; readonly \"exec.approval.request\": \"operator.approvals\"; readonly \"exec.approval.resolve\": \"operator.approvals\"; readonly \"exec.approval.snapshot\": \"operator.approvals\"; readonly \"exec.approval.status\": \"operator.approvals\"; readonly \"exec.approval.waitDecision\": \"operator.approvals\"; readonly \"exec.approvals.get\": \"operator.approvals\"; readonly \"exec.approvals.node.get\": \"operator.admin\"; readonly \"exec.approvals.node.set\": \"operator.admin\"; readonly \"exec.approvals.set\": \"operator.approvals\"; readonly \"exec.proposals.accept\": \"operator.admin\"; readonly \"exec.proposals.auto_enabled.disable\": \"operator.admin\"; readonly \"exec.proposals.auto_enabled.list\": \"operator.proposals\"; readonly \"exec.proposals.list\": \"operator.proposals\"; readonly \"exec.proposals.pending_count\": \"operator.proposals\"; readonly \"exec.proposals.reject\": \"operator.admin\"; readonly \"exec.proposals.settings.get\": \"operator.proposals\"; readonly \"exec.proposals.settings.set\": \"operator.admin\"; readonly \"exec.proposals.show\": \"operator.proposals\"; readonly \"gateway.identity.get\": \"operator.read\"; readonly health: \"operator.read\"; readonly \"last-heartbeat\": \"operator.read\"; readonly \"logs.status\": \"operator.read\"; readonly \"logs.tail\": \"operator.read\"; readonly \"logs.trace\": \"operator.read\"; readonly \"memory.import.apply\": \"operator.admin\"; readonly \"memory.import.cancel\": \"operator.admin\"; readonly \"memory.import.discard\": \"operator.admin\"; readonly \"memory.import.info\": \"operator.read\"; readonly \"memory.import.preview\": \"operator.admin\"; readonly \"memory.import.retry\": \"operator.admin\"; readonly \"memory.import.start\": \"operator.admin\"; readonly \"memory.import.status\": \"operator.admin\"; readonly \"memory.import.undo\": \"operator.admin\"; readonly \"memory.index\": \"operator.admin\"; readonly \"memory.list\": \"operator.read\"; readonly \"memory.raw_fallbacks.list\": \"operator.admin\"; readonly \"memory.raw_fallbacks.show\": \"operator.admin\"; readonly \"memory.repair.list\": \"operator.admin\"; readonly \"memory.repair.run\": \"operator.admin\"; readonly \"memory.repair.show\": \"operator.admin\"; readonly \"memory.search\": \"operator.read\"; readonly \"memory.show\": \"operator.read\"; readonly \"meta.list\": \"operator.read\"; readonly \"meta.run\": \"operator.write\"; readonly \"meta.runs.confirm_preflight\": \"operator.admin\"; readonly \"meta.runs.cost\": \"operator.read\"; readonly \"meta.runs.diff\": \"operator.admin\"; readonly \"meta.runs.draft\": \"operator.admin\"; readonly \"meta.runs.eval_baseline\": \"operator.admin\"; readonly \"meta.runs.failures\": \"operator.read\"; readonly \"meta.runs.list\": \"operator.read\"; readonly \"meta.runs.replay\": \"operator.admin\"; readonly \"meta.runs.show\": \"operator.admin\"; readonly \"meta.runs.validate\": \"operator.admin\"; readonly \"migration.sources.list\": \"operator.admin\"; readonly \"migration.sources.preview\": \"operator.admin\"; readonly \"models.list\": \"operator.read\"; readonly \"models.routing.get\": \"operator.read\"; readonly \"models.routing.set\": \"operator.write\"; readonly \"onboarding.audio.configure\": \"operator.admin\"; readonly \"onboarding.catalog\": \"operator.read\"; readonly \"onboarding.channel.disable\": \"operator.admin\"; readonly \"onboarding.channel.enable\": \"operator.admin\"; readonly \"onboarding.channel.probe\": \"operator.admin\"; readonly \"onboarding.channel.remove\": \"operator.admin\"; readonly \"onboarding.channel.upsert\": \"operator.admin\"; readonly \"onboarding.ensemble.configure\": \"operator.admin\"; readonly \"onboarding.imageGeneration.configure\": \"operator.admin\"; readonly \"onboarding.llmProfile.activate\": \"operator.admin\"; readonly \"onboarding.llmProfile.active.remove\": \"operator.admin\"; readonly \"onboarding.llmProfile.credential.clear\": \"operator.admin\"; readonly \"onboarding.llmProfile.draft.models.discover\": \"operator.admin\"; readonly \"onboarding.llmProfile.draft.probe\": \"operator.admin\"; readonly \"onboarding.llmProfile.models.discover\": \"operator.admin\"; readonly \"onboarding.llmProfile.probe\": \"operator.admin\"; readonly \"onboarding.llmProfile.remove\": \"operator.admin\"; readonly \"onboarding.llmProfile.upsert\": \"operator.admin\"; readonly \"onboarding.memory_embedding.configure\": \"operator.admin\"; readonly \"onboarding.models.discover\": \"operator.admin\"; readonly \"onboarding.provider.configure\": \"operator.admin\"; readonly \"onboarding.provider.credential.clear\": \"operator.admin\"; readonly \"onboarding.provider.credential.reveal\": \"operator.admin\"; readonly \"onboarding.provider.probe\": \"operator.admin\"; readonly \"onboarding.router.catalog\": \"operator.read\"; readonly \"onboarding.router.configure\": \"operator.admin\"; readonly \"onboarding.search.configure\": \"operator.admin\"; readonly \"onboarding.status\": \"operator.read\"; readonly \"plans.cancelRun\": \"operator.write\"; readonly \"plans.capabilities\": \"operator.read\"; readonly \"plans.implement\": \"operator.write\"; readonly \"plans.revise\": \"operator.write\"; readonly \"plans.setMode\": \"operator.write\"; readonly \"plugin.approval.extend\": \"operator.approvals\"; readonly \"plugin.approval.request\": \"operator.approvals\"; readonly \"plugin.approval.resolve\": \"operator.approvals\"; readonly \"plugin.approval.status\": \"operator.approvals\"; readonly \"plugin.approval.waitDecision\": \"operator.approvals\"; readonly \"providers.status\": \"operator.read\"; readonly \"router.decisions.list\": \"operator.read\"; readonly \"router.feedback.submit\": \"operator.write\"; readonly \"router.selflearning.status\": \"operator.read\"; readonly \"routing.hold.clear\": \"operator.admin\"; readonly \"routing.hold.get\": \"operator.read\"; readonly \"routing.hold.set\": \"operator.admin\"; readonly \"sandbox.bundle.disable\": \"operator.write\"; readonly \"sandbox.bundle.enable\": \"operator.write\"; readonly \"sandbox.domain.add\": \"operator.write\"; readonly \"sandbox.domain.remove\": \"operator.write\"; readonly \"sandbox.explain\": \"operator.read\"; readonly \"sandbox.mount.add\": \"operator.write\"; readonly \"sandbox.mount.remove\": \"operator.write\"; readonly \"sandbox.path.create-directory\": \"operator.write\"; readonly \"sandbox.path.list\": \"operator.read\"; readonly \"sandbox.path.pick\": \"operator.write\"; readonly \"sandbox.resume\": \"operator.write\"; readonly \"sandbox.run_context.get\": \"operator.read\"; readonly \"sandbox.run_context.set\": \"operator.write\"; readonly \"sandbox.run_mode.preference.get\": \"operator.read\"; readonly \"sandbox.run_mode.preference.set\": \"operator.write\"; readonly \"sandbox.setup.ensure\": \"operator.write\"; readonly \"sandbox.setup.status\": \"operator.read\"; readonly \"sandbox.status\": \"operator.read\"; readonly \"sandbox.workspace.set\": \"operator.write\"; readonly \"search.query\": \"operator.write\"; readonly \"search.status\": \"operator.read\"; readonly \"secrets.reload\": \"operator.admin\"; readonly \"secrets.resolve\": \"operator.admin\"; readonly send: \"operator.write\"; readonly \"sessions.abort\": \"operator.write\"; readonly \"sessions.bootstrap\": \"operator.read\"; readonly \"sessions.compact\": \"operator.write\"; readonly \"sessions.contextCompact\": \"operator.write\"; readonly \"sessions.create\": \"operator.write\"; readonly \"sessions.delete\": \"operator.write\"; readonly \"sessions.fork\": \"operator.write\"; readonly \"sessions.get\": \"operator.read\"; readonly \"sessions.list\": \"operator.read\"; readonly \"sessions.messages.hydrate\": \"operator.read\"; readonly \"sessions.messages.snapshot\": \"operator.read\"; readonly \"sessions.messages.subscribe\": \"operator.read\"; readonly \"sessions.messages.unsubscribe\": \"operator.read\"; readonly \"sessions.patch\": \"operator.admin\"; readonly \"sessions.preview\": \"operator.read\"; readonly \"sessions.reset\": \"operator.write\"; readonly \"sessions.resolve\": \"operator.read\"; readonly \"sessions.search\": \"operator.read\"; readonly \"sessions.send\": \"operator.write\"; readonly \"sessions.steer\": \"operator.write\"; readonly \"sessions.steer.v2\": \"operator.write\"; readonly \"sessions.subscribe\": \"operator.read\"; readonly \"sessions.truncate\": \"operator.write\"; readonly \"sessions.unsubscribe\": \"operator.read\"; readonly \"set-heartbeats\": \"operator.admin\"; readonly \"skills.bins\": \"node\"; readonly \"skills.deps.install\": \"operator.admin\"; readonly \"skills.get\": \"operator.read\"; readonly \"skills.install\": \"operator.admin\"; readonly \"skills.list\": \"operator.read\"; readonly \"skills.reload\": \"operator.admin\"; readonly \"skills.search\": \"operator.read\"; readonly \"skills.status\": \"operator.read\"; readonly \"skills.uninstall\": \"operator.admin\"; readonly \"skills.update\": \"operator.admin\"; readonly status: \"operator.read\"; readonly \"system-event\": \"operator.admin\"; readonly \"system-presence\": \"operator.read\"; readonly \"tools.catalog\": \"operator.read\"; readonly \"tools.effective\": \"operator.read\"; readonly \"tools.search_provider\": \"operator.read\"; readonly \"usage.cost\": \"operator.read\"; readonly \"usage.query\": \"operator.read\"; readonly \"usage.status\": \"operator.read\"; readonly wake: \"operator.write\"; readonly \"wizard.cancel\": \"operator.admin\"; readonly \"wizard.next\": \"operator.admin\"; readonly \"wizard.start\": \"operator.admin\"; readonly \"wizard.status\": \"operator.admin\"; readonly \"workspaces.history.delete\": \"operator.write\"; readonly \"workspaces.list\": \"operator.read\"; readonly \"workspaces.open\": \"operator.write\"; readonly \"workspaces.pin\": \"operator.write\"; readonly \"workspaces.remove\": \"operator.write\"; readonly \"workspaces.update\": \"operator.write\"; };"
+        },
+        {
+          "key": "hello.d.ts#FunctionDeclaration:capabilitiesForMethods",
+          "signature": "export declare function capabilitiesForMethods(methods: readonly string[]): string[];"
+        },
+        {
+          "key": "hello.d.ts#FunctionDeclaration:normalizeHelloFrame",
+          "signature": "export declare function normalizeHelloFrame(input: unknown, requestId: string, clientRange?: ClientProtocolRange): NormalizedHello;"
+        },
+        {
+          "key": "hello.d.ts#ImportDeclaration:0",
+          "signature": "import type { ContractInfo, PolicyInfo, ProtocolRangeInfo, RuntimeInfo } from './generated.js';"
+        },
+        {
+          "key": "hello.d.ts#InterfaceDeclaration:ClientProtocolRange",
+          "signature": "export interface ClientProtocolRange { min: number; max: number; }"
+        },
+        {
+          "key": "hello.d.ts#InterfaceDeclaration:NormalizedHello",
+          "signature": "export interface NormalizedHello { type: 'hello-ok'; id?: string; protocol: number; policy: PolicyInfo & Record<string, unknown>; features: { methods: string[]; events: string[]; }; server: { version: string; conn_id?: string; }; auth?: Record<string, unknown>; contract?: ContractInfo; contractStatus: ContractStatus; runtime: NormalizedRuntimeInfo; protocolRange: ProtocolRangeInfo; capabilities: string[]; capabilitySource: CapabilitySource; extensions: string[]; [key: string]: unknown; }"
+        },
+        {
+          "key": "hello.d.ts#InterfaceDeclaration:NormalizedRuntimeInfo",
+          "signature": "export interface NormalizedRuntimeInfo extends Omit<RuntimeInfo, 'arch' | 'platform'> { arch?: string; platform?: string; }"
+        },
+        {
+          "key": "hello.d.ts#TypeAliasDeclaration:CapabilitySource",
+          "signature": "export type CapabilitySource = 'hello' | 'features.methods' | 'none';"
+        },
+        {
+          "key": "hello.d.ts#TypeAliasDeclaration:ContractStatus",
+          "signature": "export type ContractStatus = 'advertised' | 'legacy-contract';"
+        },
+        {
+          "key": "hello.d.ts#VariableStatement:CLIENT_MAX_PROTOCOL",
+          "signature": "export declare const CLIENT_MAX_PROTOCOL: 3;"
+        },
+        {
+          "key": "hello.d.ts#VariableStatement:CLIENT_MIN_PROTOCOL",
+          "signature": "export declare const CLIENT_MIN_PROTOCOL: 3;"
+        },
+        {
+          "key": "http.d.ts#ClassDeclaration:GatewayHttpClient",
+          "signature": "export declare class GatewayHttpClient { private readonly baseUrl; private readonly fetcher; private readonly headers; constructor(options: GatewayHttpClientOptions); request<T>(path: string, init?: RequestInit): Promise<T>; get<T>(path: string, init?: Omit<RequestInit, 'method'>): Promise<T>; post<T>(path: string, body: unknown, init?: Omit<RequestInit, 'body' | 'method'>): Promise<T>; }"
+        },
+        {
+          "key": "http.d.ts#InterfaceDeclaration:GatewayHttpClientOptions",
+          "signature": "export interface GatewayHttpClientOptions { baseUrl: string; fetch?: FetchLike; headers?: HeadersInit; }"
+        },
+        {
+          "key": "http.d.ts#TypeAliasDeclaration:FetchLike",
+          "signature": "export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./client.js'",
+          "signature": "export * from './client.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./errors.js'",
+          "signature": "export * from './errors.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./generated.js'",
+          "signature": "export * from './generated.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./hello.js'",
+          "signature": "export * from './hello.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./http.js'",
+          "signature": "export * from './http.js';"
+        }
+      ],
+      "deprecations": []
+    },
+    {
+      "name": "@opensquilla/ui-tokens",
+      "version": "0.1.0",
+      "releaseGroup": "ui-foundation",
+      "publicExports": [
+        ".",
+        "./foundation.css",
+        "./themes.css",
+        "./theme-contract.json",
+        "./themes/*"
+      ],
+      "apiExports": [
+        "DERIVED_THEME_TOKEN_NAMES",
+        "DerivedThemeTokenName",
+        "PUBLIC_THEME_IDS",
+        "PublicThemeId",
+        "REQUIRED_THEME_TOKEN_NAMES",
+        "RequiredThemeTokenName",
+        "ResolvedThemeTokenValues",
+        "THEME_TOKEN_NAMES",
+        "ThemeCssVariableName",
+        "ThemeTokenDiagnostic",
+        "ThemeTokenDiagnosticCode",
+        "ThemeTokenDiagnosticReporter",
+        "ThemeTokenName",
+        "ThemeTokenValues",
+        "resolveThemeTokens",
+        "themeTokensToCssVariables"
+      ],
+      "runtimeExports": [
+        "DERIVED_THEME_TOKEN_NAMES",
+        "PUBLIC_THEME_IDS",
+        "REQUIRED_THEME_TOKEN_NAMES",
+        "THEME_TOKEN_NAMES",
+        "resolveThemeTokens",
+        "themeTokensToCssVariables"
+      ],
+      "declarationsDigest": "sha256:da9f3ef79a61b621ff241a3404d4a0cfa5daf1b79b7ab7813c22abcca1fd508a",
+      "declarations": [
+        {
+          "key": "index.d.ts#FunctionDeclaration:resolveThemeTokens",
+          "signature": "export declare function resolveThemeTokens(candidate: Readonly<Record<string, string | undefined>>, fallback: Readonly<Record<ThemeTokenName, string>>, report?: ThemeTokenDiagnosticReporter): ResolvedThemeTokenValues;"
+        },
+        {
+          "key": "index.d.ts#FunctionDeclaration:themeTokensToCssVariables",
+          "signature": "export declare function themeTokensToCssVariables(tokens: Readonly<ResolvedThemeTokenValues>): Record<ThemeCssVariableName, string>;"
+        },
+        {
+          "key": "index.d.ts#InterfaceDeclaration:ThemeTokenDiagnostic",
+          "signature": "export interface ThemeTokenDiagnostic { code: ThemeTokenDiagnosticCode; token: string; message: string; fallback?: string; }"
+        },
+        {
+          "key": "index.d.ts#TypeAliasDeclaration:DerivedThemeTokenName",
+          "signature": "export type DerivedThemeTokenName = (typeof DERIVED_THEME_TOKEN_NAMES)[number];"
+        },
+        {
+          "key": "index.d.ts#TypeAliasDeclaration:PublicThemeId",
+          "signature": "export type PublicThemeId = (typeof PUBLIC_THEME_IDS)[number];"
+        },
+        {
+          "key": "index.d.ts#TypeAliasDeclaration:RequiredThemeTokenName",
+          "signature": "export type RequiredThemeTokenName = (typeof REQUIRED_THEME_TOKEN_NAMES)[number];"
+        },
+        {
+          "key": "index.d.ts#TypeAliasDeclaration:ResolvedThemeTokenValues",
+          "signature": "export type ResolvedThemeTokenValues = Record<ThemeTokenName, string>;"
+        },
+        {
+          "key": "index.d.ts#TypeAliasDeclaration:ThemeCssVariableName",
+          "signature": "export type ThemeCssVariableName = `--${ThemeTokenName}`;"
+        },
+        {
+          "key": "index.d.ts#TypeAliasDeclaration:ThemeTokenDiagnosticCode",
+          "signature": "export type ThemeTokenDiagnosticCode = 'missing-required-token' | 'unknown-token';"
+        },
+        {
+          "key": "index.d.ts#TypeAliasDeclaration:ThemeTokenDiagnosticReporter",
+          "signature": "export type ThemeTokenDiagnosticReporter = (diagnostic: ThemeTokenDiagnostic) => void;"
+        },
+        {
+          "key": "index.d.ts#TypeAliasDeclaration:ThemeTokenName",
+          "signature": "export type ThemeTokenName = (typeof THEME_TOKEN_NAMES)[number];"
+        },
+        {
+          "key": "index.d.ts#TypeAliasDeclaration:ThemeTokenValues",
+          "signature": "export type ThemeTokenValues = Partial<Record<ThemeTokenName, string>>;"
+        },
+        {
+          "key": "index.d.ts#VariableStatement:DERIVED_THEME_TOKEN_NAMES",
+          "signature": "export declare const DERIVED_THEME_TOKEN_NAMES: readonly [\"elev-highlight\", \"elev-1\", \"elev-1-hover\", \"elev-2\", \"elev-3\", \"ok-fill\", \"warn-fill\", \"danger-fill\", \"info-fill\", \"queued-fill\", \"chart-2\", \"shadow\", \"shadow-color\", \"scrim\", \"grain-opacity\", \"msg-bubble\", \"msg-obj-border\", \"surface-2\", \"surface-3\", \"color-green\", \"color-red\", \"color-blue\", \"text-secondary\", \"sidebar-bg\", \"sidebar-control-bg\", \"sidebar-control-hover\", \"sidebar-item-hover\", \"sidebar-item-active\", \"sidebar-text-strong\", \"sidebar-text\", \"sidebar-text-soft\", \"sidebar-border\"];"
+        },
+        {
+          "key": "index.d.ts#VariableStatement:PUBLIC_THEME_IDS",
+          "signature": "export declare const PUBLIC_THEME_IDS: readonly [\"arctic\", \"crt-green\", \"dark\", \"ember\", \"light\", \"miami\", \"synthwave\", \"terminal\", \"vapor\"];"
+        },
+        {
+          "key": "index.d.ts#VariableStatement:REQUIRED_THEME_TOKEN_NAMES",
+          "signature": "export declare const REQUIRED_THEME_TOKEN_NAMES: readonly [\"bg\", \"bg-surface\", \"bg-surface-2\", \"bg-elevated\", \"bg-hover\", \"text\", \"text-muted\", \"text-dim\", \"border\", \"border-strong\", \"border-focus\", \"card\", \"hairline\", \"accent\", \"accent-hover\", \"accent-deep\", \"accent-secondary\", \"accent-foreground\", \"ok\", \"warn\", \"danger\", \"info\", \"queued\", \"syntax-comment\", \"syntax-keyword\", \"syntax-string\", \"syntax-literal\", \"syntax-title\", \"syntax-attr\"];"
+        },
+        {
+          "key": "index.d.ts#VariableStatement:THEME_TOKEN_NAMES",
+          "signature": "export declare const THEME_TOKEN_NAMES: readonly [\"bg\", \"bg-surface\", \"bg-surface-2\", \"bg-elevated\", \"bg-hover\", \"text\", \"text-muted\", \"text-dim\", \"border\", \"border-strong\", \"border-focus\", \"card\", \"hairline\", \"accent\", \"accent-hover\", \"accent-deep\", \"accent-secondary\", \"accent-foreground\", \"ok\", \"warn\", \"danger\", \"info\", \"queued\", \"syntax-comment\", \"syntax-keyword\", \"syntax-string\", \"syntax-literal\", \"syntax-title\", \"syntax-attr\", \"elev-highlight\", \"elev-1\", \"elev-1-hover\", \"elev-2\", \"elev-3\", \"ok-fill\", \"warn-fill\", \"danger-fill\", \"info-fill\", \"queued-fill\", \"chart-2\", \"shadow\", \"shadow-color\", \"scrim\", \"grain-opacity\", \"msg-bubble\", \"msg-obj-border\", \"surface-2\", \"surface-3\", \"color-green\", \"color-red\", \"color-blue\", \"text-secondary\", \"sidebar-bg\", \"sidebar-control-bg\", \"sidebar-control-hover\", \"sidebar-item-hover\", \"sidebar-item-active\", \"sidebar-text-strong\", \"sidebar-text\", \"sidebar-text-soft\", \"sidebar-border\"];"
+        }
+      ],
+      "deprecations": []
+    },
+    {
+      "name": "@opensquilla/ui-primitives",
+      "version": "0.1.0",
+      "releaseGroup": "ui-foundation",
+      "publicExports": [
+        ".",
+        "./styles.css"
+      ],
+      "apiExports": [
+        "UiButton",
+        "UiButtonSize",
+        "UiButtonVariant",
+        "UiCard",
+        "UiDialog",
+        "UiInput",
+        "UiStack",
+        "UiStackAlign",
+        "UiStackDirection",
+        "UiStackGap",
+        "UiStackJustify",
+        "UiSwitch"
+      ],
+      "runtimeExports": [
+        "UiButton",
+        "UiCard",
+        "UiDialog",
+        "UiInput",
+        "UiStack",
+        "UiSwitch"
+      ],
+      "declarationsDigest": "sha256:5bb798d118af8ab1ae48522690aa8d267667873a4539add9b992ce54bdf145dc",
+      "declarations": [
+        {
+          "key": "components/button.d.ts#TypeAliasDeclaration:UiButtonSize",
+          "signature": "export type UiButtonSize = 'small' | 'medium' | 'large';"
+        },
+        {
+          "key": "components/button.d.ts#TypeAliasDeclaration:UiButtonVariant",
+          "signature": "export type UiButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';"
+        },
+        {
+          "key": "components/dialogStack.d.ts#FunctionDeclaration:isTopmostDialog",
+          "signature": "export declare function isTopmostDialog(token: symbol): boolean;"
+        },
+        {
+          "key": "components/dialogStack.d.ts#FunctionDeclaration:registerDialog",
+          "signature": "export declare function registerDialog(token: symbol): void;"
+        },
+        {
+          "key": "components/dialogStack.d.ts#FunctionDeclaration:unregisterDialog",
+          "signature": "export declare function unregisterDialog(token: symbol): boolean;"
+        },
+        {
+          "key": "components/stack.d.ts#TypeAliasDeclaration:UiStackAlign",
+          "signature": "export type UiStackAlign = 'start' | 'center' | 'end' | 'stretch' | 'baseline';"
+        },
+        {
+          "key": "components/stack.d.ts#TypeAliasDeclaration:UiStackDirection",
+          "signature": "export type UiStackDirection = 'row' | 'column';"
+        },
+        {
+          "key": "components/stack.d.ts#TypeAliasDeclaration:UiStackGap",
+          "signature": "export type UiStackGap = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';"
+        },
+        {
+          "key": "components/stack.d.ts#TypeAliasDeclaration:UiStackJustify",
+          "signature": "export type UiStackJustify = 'start' | 'center' | 'end' | 'between' | 'around' | 'evenly';"
+        },
+        {
+          "key": "components/UiButton.vue.d.ts#ExportAssignment:default",
+          "signature": "export default _default;"
+        },
+        {
+          "key": "components/UiButton.vue.d.ts#ImportDeclaration:0",
+          "signature": "import type { UiButtonSize, UiButtonVariant } from './button.js';"
+        },
+        {
+          "key": "components/UiButton.vue.d.ts#TypeAliasDeclaration:__VLS_Props",
+          "signature": "type __VLS_Props = { variant?: UiButtonVariant; size?: UiButtonSize; type?: 'button' | 'submit' | 'reset'; disabled?: boolean; busy?: boolean; block?: boolean; };"
+        },
+        {
+          "key": "components/UiButton.vue.d.ts#TypeAliasDeclaration:__VLS_Slots",
+          "signature": "type __VLS_Slots = {} & { default?: (props: typeof __VLS_1) => any; };"
+        },
+        {
+          "key": "components/UiButton.vue.d.ts#TypeAliasDeclaration:__VLS_WithSlots",
+          "signature": "type __VLS_WithSlots<T, S> = T & { new (): { $slots: S; }; };"
+        },
+        {
+          "key": "components/UiButton.vue.d.ts#VariableStatement:__VLS_1",
+          "signature": "declare var __VLS_1: {};"
+        },
+        {
+          "key": "components/UiButton.vue.d.ts#VariableStatement:__VLS_component",
+          "signature": "declare const __VLS_component: import(\"vue\").DefineComponent<__VLS_Props, {}, {}, {}, {}, import(\"vue\").ComponentOptionsMixin, import(\"vue\").ComponentOptionsMixin, {}, string, import(\"vue\").PublicProps, Readonly<__VLS_Props> & Readonly<{}>, { variant: UiButtonVariant; size: UiButtonSize; type: \"button\" | \"submit\" | \"reset\"; disabled: boolean; busy: boolean; block: boolean; }, {}, {}, {}, string, import(\"vue\").ComponentProvideOptions, false, {}, any>;"
+        },
+        {
+          "key": "components/UiButton.vue.d.ts#VariableStatement:_default",
+          "signature": "declare const _default: __VLS_WithSlots<typeof __VLS_component, __VLS_Slots>;"
+        },
+        {
+          "key": "components/UiCard.vue.d.ts#ExportAssignment:default",
+          "signature": "export default _default;"
+        },
+        {
+          "key": "components/UiCard.vue.d.ts#TypeAliasDeclaration:__VLS_Props",
+          "signature": "type __VLS_Props = { as?: string; interactive?: boolean; padded?: boolean; };"
+        },
+        {
+          "key": "components/UiCard.vue.d.ts#TypeAliasDeclaration:__VLS_Slots",
+          "signature": "type __VLS_Slots = {} & { header?: (props: typeof __VLS_6) => any; } & { default?: (props: typeof __VLS_8) => any; } & { footer?: (props: typeof __VLS_10) => any; };"
+        },
+        {
+          "key": "components/UiCard.vue.d.ts#TypeAliasDeclaration:__VLS_WithSlots",
+          "signature": "type __VLS_WithSlots<T, S> = T & { new (): { $slots: S; }; };"
+        },
+        {
+          "key": "components/UiCard.vue.d.ts#VariableStatement:__VLS_6,__VLS_8,__VLS_10",
+          "signature": "declare var __VLS_6: {}, __VLS_8: {}, __VLS_10: {};"
+        },
+        {
+          "key": "components/UiCard.vue.d.ts#VariableStatement:__VLS_component",
+          "signature": "declare const __VLS_component: import(\"vue\").DefineComponent<__VLS_Props, {}, {}, {}, {}, import(\"vue\").ComponentOptionsMixin, import(\"vue\").ComponentOptionsMixin, {}, string, import(\"vue\").PublicProps, Readonly<__VLS_Props> & Readonly<{}>, { as: string; interactive: boolean; padded: boolean; }, {}, {}, {}, string, import(\"vue\").ComponentProvideOptions, false, {}, any>;"
+        },
+        {
+          "key": "components/UiCard.vue.d.ts#VariableStatement:_default",
+          "signature": "declare const _default: __VLS_WithSlots<typeof __VLS_component, __VLS_Slots>;"
+        },
+        {
+          "key": "components/UiDialog.vue.d.ts#ExportAssignment:default",
+          "signature": "export default _default;"
+        },
+        {
+          "key": "components/UiDialog.vue.d.ts#TypeAliasDeclaration:__VLS_Props",
+          "signature": "type __VLS_Props = { open: boolean; title?: string; description?: string; closeOnBackdrop?: boolean; closeOnEscape?: boolean; initialFocus?: 'first' | 'dialog'; teleportTo?: string; };"
+        },
+        {
+          "key": "components/UiDialog.vue.d.ts#TypeAliasDeclaration:__VLS_Slots",
+          "signature": "type __VLS_Slots = {} & { title?: (props: typeof __VLS_9) => any; } & { default?: (props: typeof __VLS_11) => any; } & { footer?: (props: typeof __VLS_13) => any; };"
+        },
+        {
+          "key": "components/UiDialog.vue.d.ts#TypeAliasDeclaration:__VLS_WithSlots",
+          "signature": "type __VLS_WithSlots<T, S> = T & { new (): { $slots: S; }; };"
+        },
+        {
+          "key": "components/UiDialog.vue.d.ts#VariableStatement:__VLS_9,__VLS_11,__VLS_13",
+          "signature": "declare var __VLS_9: {}, __VLS_11: {}, __VLS_13: {};"
+        },
+        {
+          "key": "components/UiDialog.vue.d.ts#VariableStatement:__VLS_component",
+          "signature": "declare const __VLS_component: import(\"vue\").DefineComponent<__VLS_Props, {}, {}, {}, {}, import(\"vue\").ComponentOptionsMixin, import(\"vue\").ComponentOptionsMixin, { close: () => any; }, string, import(\"vue\").PublicProps, Readonly<__VLS_Props> & Readonly<{ onClose?: () => any; }>, { closeOnBackdrop: boolean; closeOnEscape: boolean; initialFocus: \"first\" | \"dialog\"; teleportTo: string; }, {}, {}, {}, string, import(\"vue\").ComponentProvideOptions, false, {}, any>;"
+        },
+        {
+          "key": "components/UiDialog.vue.d.ts#VariableStatement:_default",
+          "signature": "declare const _default: __VLS_WithSlots<typeof __VLS_component, __VLS_Slots>;"
+        },
+        {
+          "key": "components/UiInput.vue.d.ts#ExportAssignment:default",
+          "signature": "export default _default;"
+        },
+        {
+          "key": "components/UiInput.vue.d.ts#TypeAliasDeclaration:__VLS_Props",
+          "signature": "type __VLS_Props = { modelValue?: string | number; id?: string; label?: string; description?: string; error?: string; type?: 'text' | 'email' | 'password' | 'number' | 'search' | 'url'; disabled?: boolean; required?: boolean; };"
+        },
+        {
+          "key": "components/UiInput.vue.d.ts#VariableStatement:_default",
+          "signature": "declare const _default: import(\"vue\").DefineComponent<__VLS_Props, {}, {}, {}, {}, import(\"vue\").ComponentOptionsMixin, import(\"vue\").ComponentOptionsMixin, { change: (args_0: Event) => any; \"update:modelValue\": (args_0: string | number) => any; }, string, import(\"vue\").PublicProps, Readonly<__VLS_Props> & Readonly<{ onChange?: (args_0: Event) => any; \"onUpdate:modelValue\"?: (args_0: string | number) => any; }>, { type: \"text\" | \"email\" | \"password\" | \"number\" | \"search\" | \"url\"; disabled: boolean; required: boolean; modelValue: string | number; }, {}, {}, {}, string, import(\"vue\").ComponentProvideOptions, false, {}, any>;"
+        },
+        {
+          "key": "components/UiStack.vue.d.ts#ExportAssignment:default",
+          "signature": "export default _default;"
+        },
+        {
+          "key": "components/UiStack.vue.d.ts#ImportDeclaration:0",
+          "signature": "import type { UiStackAlign, UiStackDirection, UiStackGap, UiStackJustify } from './stack.js';"
+        },
+        {
+          "key": "components/UiStack.vue.d.ts#TypeAliasDeclaration:__VLS_Props",
+          "signature": "type __VLS_Props = { as?: string; direction?: UiStackDirection; gap?: UiStackGap; align?: UiStackAlign; justify?: UiStackJustify; wrap?: boolean; };"
+        },
+        {
+          "key": "components/UiStack.vue.d.ts#TypeAliasDeclaration:__VLS_Slots",
+          "signature": "type __VLS_Slots = {} & { default?: (props: typeof __VLS_6) => any; };"
+        },
+        {
+          "key": "components/UiStack.vue.d.ts#TypeAliasDeclaration:__VLS_WithSlots",
+          "signature": "type __VLS_WithSlots<T, S> = T & { new (): { $slots: S; }; };"
+        },
+        {
+          "key": "components/UiStack.vue.d.ts#VariableStatement:__VLS_6",
+          "signature": "declare var __VLS_6: {};"
+        },
+        {
+          "key": "components/UiStack.vue.d.ts#VariableStatement:__VLS_component",
+          "signature": "declare const __VLS_component: import(\"vue\").DefineComponent<__VLS_Props, {}, {}, {}, {}, import(\"vue\").ComponentOptionsMixin, import(\"vue\").ComponentOptionsMixin, {}, string, import(\"vue\").PublicProps, Readonly<__VLS_Props> & Readonly<{}>, { as: string; direction: UiStackDirection; gap: UiStackGap; align: UiStackAlign; justify: UiStackJustify; wrap: boolean; }, {}, {}, {}, string, import(\"vue\").ComponentProvideOptions, false, {}, any>;"
+        },
+        {
+          "key": "components/UiStack.vue.d.ts#VariableStatement:_default",
+          "signature": "declare const _default: __VLS_WithSlots<typeof __VLS_component, __VLS_Slots>;"
+        },
+        {
+          "key": "components/UiSwitch.vue.d.ts#ExportAssignment:default",
+          "signature": "export default _default;"
+        },
+        {
+          "key": "components/UiSwitch.vue.d.ts#TypeAliasDeclaration:__VLS_Props",
+          "signature": "type __VLS_Props = { checked?: boolean; disabled?: boolean; busy?: boolean; label?: string; caption?: string; ariaLabel?: string; name?: string; id?: string; };"
+        },
+        {
+          "key": "components/UiSwitch.vue.d.ts#VariableStatement:_default",
+          "signature": "declare const _default: import(\"vue\").DefineComponent<__VLS_Props, {}, {}, {}, {}, import(\"vue\").ComponentOptionsMixin, import(\"vue\").ComponentOptionsMixin, { change: (args_0: boolean) => any; \"update:checked\": (args_0: boolean) => any; }, string, import(\"vue\").PublicProps, Readonly<__VLS_Props> & Readonly<{ onChange?: (args_0: boolean) => any; \"onUpdate:checked\"?: (args_0: boolean) => any; }>, { disabled: boolean; busy: boolean; checked: boolean; }, {}, {}, {}, string, import(\"vue\").ComponentProvideOptions, false, {}, any>;"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:{ default as UiButton }:'./components/UiButton.vue'",
+          "signature": "export { default as UiButton } from './components/UiButton.vue';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:{ default as UiCard }:'./components/UiCard.vue'",
+          "signature": "export { default as UiCard } from './components/UiCard.vue';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:{ default as UiDialog }:'./components/UiDialog.vue'",
+          "signature": "export { default as UiDialog } from './components/UiDialog.vue';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:{ default as UiInput }:'./components/UiInput.vue'",
+          "signature": "export { default as UiInput } from './components/UiInput.vue';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:{ default as UiStack }:'./components/UiStack.vue'",
+          "signature": "export { default as UiStack } from './components/UiStack.vue';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:{ default as UiSwitch }:'./components/UiSwitch.vue'",
+          "signature": "export { default as UiSwitch } from './components/UiSwitch.vue';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:{ UiButtonSize, UiButtonVariant, }:'./components/button.js'",
+          "signature": "export type { UiButtonSize, UiButtonVariant, } from './components/button.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:{ UiStackAlign, UiStackDirection, UiStackGap, UiStackJustify, }:'./components/stack.js'",
+          "signature": "export type { UiStackAlign, UiStackDirection, UiStackGap, UiStackJustify, } from './components/stack.js';"
+        }
+      ],
+      "deprecations": []
+    },
+    {
+      "name": "@opensquilla/ui-foundation",
+      "version": "0.1.0",
+      "releaseGroup": "ui-foundation",
+      "publicExports": [
+        "."
+      ],
+      "apiExports": [
+        "Awaitable",
+        "CapabilityId",
+        "CompositionContractError",
+        "CompositionContractErrorCode",
+        "ConnectionClosedError",
+        "ConnectionState",
+        "ContributionId",
+        "ContributionOwner",
+        "ContributionRegistrar",
+        "ContributionRegistrySnapshot",
+        "ContributionRequirements",
+        "CreateGatewayClientOptions",
+        "CreateNativeCapabilityAdapterOptions",
+        "CreateOpenSquillaAppOptions",
+        "EventFrame",
+        "FeatureCapabilityStatus",
+        "FeatureContributions",
+        "FeatureId",
+        "FeatureModuleContract",
+        "FinalizeContributionRegistryOptions",
+        "FoundationStoreContext",
+        "GatewayCallOptions",
+        "GatewayClientBindings",
+        "GatewayClientError",
+        "GatewayClientOptions",
+        "GatewayConnectionSettings",
+        "GatewayConnectionState",
+        "GatewayConnectionStorage",
+        "GatewayConnectionStorageOptions",
+        "GatewayConnectionWaitOptions",
+        "GatewayDataStore",
+        "GatewayHelloInput",
+        "GatewayHttpClient",
+        "GatewayHttpClientOptions",
+        "GatewayHttpError",
+        "GatewayQuery",
+        "GatewayQueryListener",
+        "GatewayQueryOptions",
+        "GatewayQueryRefs",
+        "GatewayQuerySnapshot",
+        "GatewayRequestClient",
+        "GatewayStateListener",
+        "GatewayStateRef",
+        "GatewayStateSnapshot",
+        "GatewayStateSource",
+        "GatewayTerminationAction",
+        "GatewayUiCallOptions",
+        "GatewayUiCapabilitySource",
+        "GatewayUiClient",
+        "GatewayUiConnectionState",
+        "GatewayUiConnectionWaitOptions",
+        "GatewayUiContract",
+        "GatewayUiContractStatus",
+        "GatewayUiEventHandler",
+        "GatewayUiProtocolRange",
+        "GatewayUiRuntime",
+        "HandshakeError",
+        "NATIVE_CAPABILITY_API_VERSION",
+        "NativeCapabilityAdapter",
+        "NativeCapabilityApiVersion",
+        "NativeCapabilityErrorCode",
+        "NativeCapabilityFailure",
+        "NativeCapabilityInvocation",
+        "NativeCapabilityResult",
+        "NavigationContribution",
+        "NavigationSlot",
+        "NormalizedHello",
+        "OpenSquillaAppComposition",
+        "PageContribution",
+        "PageLoadContext",
+        "PageLoader",
+        "PresentationAvailability",
+        "PresentationEnvironment",
+        "PresentationUnavailableReason",
+        "RegisteredNavigation",
+        "RegisteredPage",
+        "RegisteredRoute",
+        "RegisteredState",
+        "RequestAbortError",
+        "RequestTimeoutError",
+        "RouteContribution",
+        "RpcAbortError",
+        "RpcCallOptions",
+        "RpcClient",
+        "RpcClientError",
+        "RpcConnectionWaitOptions",
+        "RpcContractInfo",
+        "RpcErrorDetail",
+        "RpcEventHandler",
+        "RpcFrame",
+        "RpcProtocolRange",
+        "RpcRuntimeInfo",
+        "RpcTerminationAction",
+        "RpcTimeoutError",
+        "ScopedStateInstance",
+        "SequenceGapError",
+        "StateContribution",
+        "StateFactoryContext",
+        "StorageLike",
+        "UI_COMPOSITION_API_VERSION",
+        "UiCompositionApiVersion",
+        "UseGatewayQueryOptions",
+        "assertCapabilityId",
+        "capabilitiesForMethods",
+        "clearStoragePrefix",
+        "createContributionRegistrar",
+        "createFoundationStores",
+        "createGatewayClient",
+        "createGatewayConnectionStorage",
+        "createGatewayHttpClient",
+        "createGatewayQuery",
+        "createNativeCapabilityAdapter",
+        "createOpenSquillaApp",
+        "createWebNativeCapabilityAdapter",
+        "evaluatePresentationAvailability",
+        "normalizeCapabilities",
+        "normalizeHelloFrame",
+        "useGatewayQuery",
+        "useGatewayState"
+      ],
+      "runtimeExports": [
+        "CompositionContractError",
+        "ConnectionClosedError",
+        "ContributionRegistrar",
+        "GatewayClientError",
+        "GatewayDataStore",
+        "GatewayHttpClient",
+        "GatewayHttpError",
+        "GatewayQuery",
+        "HandshakeError",
+        "NATIVE_CAPABILITY_API_VERSION",
+        "RequestAbortError",
+        "RequestTimeoutError",
+        "RpcAbortError",
+        "RpcClient",
+        "RpcTimeoutError",
+        "SequenceGapError",
+        "UI_COMPOSITION_API_VERSION",
+        "assertCapabilityId",
+        "capabilitiesForMethods",
+        "clearStoragePrefix",
+        "createContributionRegistrar",
+        "createFoundationStores",
+        "createGatewayClient",
+        "createGatewayConnectionStorage",
+        "createGatewayHttpClient",
+        "createGatewayQuery",
+        "createNativeCapabilityAdapter",
+        "createOpenSquillaApp",
+        "createWebNativeCapabilityAdapter",
+        "evaluatePresentationAvailability",
+        "normalizeCapabilities",
+        "normalizeHelloFrame",
+        "useGatewayQuery",
+        "useGatewayState"
+      ],
+      "declarationsDigest": "sha256:6dfd968b8cf1ec10b7483ea486e241c08fa652f866e43de470fe6feaddac586f",
+      "declarations": [
+        {
+          "key": "composition/app.d.ts#FunctionDeclaration:createOpenSquillaApp",
+          "signature": "export declare function createOpenSquillaApp(options: CreateOpenSquillaAppOptions): Promise<OpenSquillaAppComposition>;"
+        },
+        {
+          "key": "composition/app.d.ts#ImportDeclaration:0",
+          "signature": "import { type CreateOpenSquillaAppOptions, type OpenSquillaAppComposition } from './types.js';"
+        },
+        {
+          "key": "composition/capabilities.d.ts#FunctionDeclaration:assertCapabilityId",
+          "signature": "export declare function assertCapabilityId(capability: CapabilityId): void;"
+        },
+        {
+          "key": "composition/capabilities.d.ts#FunctionDeclaration:createNativeCapabilityAdapter",
+          "signature": "export declare function createNativeCapabilityAdapter(options: CreateNativeCapabilityAdapterOptions): NativeCapabilityAdapter;"
+        },
+        {
+          "key": "composition/capabilities.d.ts#FunctionDeclaration:createWebNativeCapabilityAdapter",
+          "signature": "export declare function createWebNativeCapabilityAdapter(): NativeCapabilityAdapter;"
+        },
+        {
+          "key": "composition/capabilities.d.ts#FunctionDeclaration:evaluatePresentationAvailability",
+          "signature": "export declare function evaluatePresentationAvailability(requirements: ContributionRequirements | undefined, environment: PresentationEnvironment): PresentationAvailability;"
+        },
+        {
+          "key": "composition/capabilities.d.ts#FunctionDeclaration:normalizeCapabilities",
+          "signature": "export declare function normalizeCapabilities(capabilities: Iterable<CapabilityId>): readonly CapabilityId[];"
+        },
+        {
+          "key": "composition/capabilities.d.ts#ImportDeclaration:0",
+          "signature": "import { type CapabilityId, type ContributionRequirements, type NativeCapabilityAdapter, type NativeCapabilityInvocation, type NativeCapabilityResult, type PresentationAvailability, type PresentationEnvironment } from './types.js';"
+        },
+        {
+          "key": "composition/capabilities.d.ts#InterfaceDeclaration:CreateNativeCapabilityAdapterOptions",
+          "signature": "export interface CreateNativeCapabilityAdapterOptions { readonly bridgeVersion: string; readonly capabilities: readonly CapabilityId[]; invoke<T = unknown>(invocation: NativeCapabilityInvocation): Promise<NativeCapabilityResult<T>>; }"
+        },
+        {
+          "key": "composition/errors.d.ts#ClassDeclaration:CompositionContractError",
+          "signature": "export declare class CompositionContractError extends Error { readonly code: CompositionContractErrorCode; readonly details: Readonly<Record<string, unknown>>; constructor(code: CompositionContractErrorCode, message: string, details?: Readonly<Record<string, unknown>>, options?: ErrorOptions); }"
+        },
+        {
+          "key": "composition/errors.d.ts#TypeAliasDeclaration:CompositionContractErrorCode",
+          "signature": "export type CompositionContractErrorCode = 'invalid_feature_id' | 'duplicate_feature_id' | 'unsupported_feature_api_version' | 'unknown_feature_dependency' | 'feature_dependency_cycle' | 'invalid_contribution_id' | 'duplicate_contribution_id' | 'invalid_route' | 'duplicate_route_path' | 'duplicate_route_name' | 'unknown_page' | 'unknown_route' | 'undeclared_feature_reference' | 'invalid_state_namespace' | 'duplicate_state_namespace' | 'invalid_capability' | 'unknown_capability' | 'missing_required_capability' | 'unsupported_native_adapter_version' | 'state_initialization_failed' | 'unknown_state_namespace' | 'unknown_page_id' | 'composition_disposed';"
+        },
+        {
+          "key": "composition/registrar.d.ts#ClassDeclaration:ContributionRegistrar",
+          "signature": "export declare class ContributionRegistrar { #private; register(feature: FeatureModuleContract): this; registerMany(features: readonly FeatureModuleContract[]): this; finalize(options?: FinalizeContributionRegistryOptions): ContributionRegistrySnapshot; }"
+        },
+        {
+          "key": "composition/registrar.d.ts#FunctionDeclaration:createContributionRegistrar",
+          "signature": "export declare function createContributionRegistrar(features?: readonly FeatureModuleContract[]): ContributionRegistrar;"
+        },
+        {
+          "key": "composition/registrar.d.ts#ImportDeclaration:0",
+          "signature": "import { type CapabilityId, type ContributionRegistrySnapshot, type FeatureModuleContract } from './types.js';"
+        },
+        {
+          "key": "composition/registrar.d.ts#InterfaceDeclaration:FinalizeContributionRegistryOptions",
+          "signature": "export interface FinalizeContributionRegistryOptions { readonly knownCapabilities?: readonly CapabilityId[]; readonly capabilities?: readonly CapabilityId[]; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:ContributionOwner",
+          "signature": "export interface ContributionOwner { readonly featureId: FeatureId; readonly contributionId: ContributionId; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:ContributionRegistrySnapshot",
+          "signature": "export interface ContributionRegistrySnapshot { readonly apiVersion: UiCompositionApiVersion; readonly features: readonly FeatureModuleContract[]; readonly pages: readonly RegisteredPage[]; readonly routes: readonly RegisteredRoute[]; readonly navigation: readonly RegisteredNavigation[]; readonly state: readonly RegisteredState[]; readonly featureCapabilities: readonly FeatureCapabilityStatus[]; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:ContributionRequirements",
+          "signature": "export interface ContributionRequirements { /** * Presentation requirement only. Gateway authorization remains authoritative * even when the host reports every scope in this list. */ readonly gatewayScopes?: readonly string[]; readonly capabilities?: readonly CapabilityId[]; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:CreateOpenSquillaAppOptions",
+          "signature": "export interface CreateOpenSquillaAppOptions { readonly features: readonly FeatureModuleContract[]; readonly knownCapabilities?: readonly CapabilityId[]; readonly capabilities?: readonly CapabilityId[]; readonly gatewayScopes?: readonly string[]; readonly native?: NativeCapabilityAdapter; readonly services?: Readonly<Record<string, unknown>>; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:FeatureCapabilityStatus",
+          "signature": "export interface FeatureCapabilityStatus { readonly featureId: FeatureId; readonly missingOptionalCapabilities: readonly CapabilityId[]; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:FeatureContributions",
+          "signature": "export interface FeatureContributions { readonly pages?: readonly PageContribution[]; readonly routes?: readonly RouteContribution[]; readonly navigation?: readonly NavigationContribution[]; readonly state?: readonly StateContribution[]; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:FeatureModuleContract",
+          "signature": "export interface FeatureModuleContract { readonly id: FeatureId; readonly apiVersion: UiCompositionApiVersion; readonly dependsOn?: readonly FeatureId[]; readonly requiredCapabilities?: readonly CapabilityId[]; readonly optionalCapabilities?: readonly CapabilityId[]; readonly order?: number; readonly contributions?: FeatureContributions; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:NativeCapabilityAdapter",
+          "signature": "export interface NativeCapabilityAdapter { readonly apiVersion: NativeCapabilityApiVersion; readonly bridgeVersion: string | null; readonly capabilities: readonly CapabilityId[]; invoke<T = unknown>(invocation: NativeCapabilityInvocation): Promise<NativeCapabilityResult<T>>; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:NativeCapabilityFailure",
+          "signature": "export interface NativeCapabilityFailure { readonly code: NativeCapabilityErrorCode; readonly capability: CapabilityId; readonly message: string; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:NativeCapabilityInvocation",
+          "signature": "export interface NativeCapabilityInvocation { readonly capability: CapabilityId; readonly request?: unknown; readonly signal?: AbortSignal; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:NavigationContribution",
+          "signature": "export interface NavigationContribution { readonly id: ContributionId; readonly routeId: ContributionId; readonly slot: NavigationSlot; readonly label: string; readonly order?: number; readonly requirements?: ContributionRequirements; readonly metadata?: Readonly<Record<string, unknown>>; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:OpenSquillaAppComposition",
+          "signature": "export interface OpenSquillaAppComposition { readonly registry: ContributionRegistrySnapshot; readonly capabilities: ReadonlySet<CapabilityId>; readonly gatewayScopes: ReadonlySet<string>; readonly native: NativeCapabilityAdapter; readonly disposed: boolean; getState<T = unknown>(namespace: string): T; loadPage<TPage = unknown>(pageId: ContributionId): Promise<TPage>; availability(requirements?: ContributionRequirements): PresentationAvailability; dispose(): Promise<void>; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:PageContribution",
+          "signature": "export interface PageContribution<TPage = unknown> { readonly id: ContributionId; readonly load: PageLoader<TPage>; readonly order?: number; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:PageLoadContext",
+          "signature": "export interface PageLoadContext { readonly featureId: FeatureId; readonly capabilities: ReadonlySet<CapabilityId>; readonly native: NativeCapabilityAdapter; getOwnState<T = unknown>(namespace: string): T; getService<T = unknown>(id: string): T | undefined; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:PresentationAvailability",
+          "signature": "export interface PresentationAvailability { readonly available: boolean; readonly reasons: readonly PresentationUnavailableReason[]; readonly missingCapabilities: readonly CapabilityId[]; readonly missingGatewayScopes: readonly string[]; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:PresentationEnvironment",
+          "signature": "export interface PresentationEnvironment { readonly capabilities: ReadonlySet<CapabilityId>; readonly gatewayScopes?: ReadonlySet<string>; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:RegisteredNavigation",
+          "signature": "export interface RegisteredNavigation extends ContributionOwner { readonly contribution: NavigationContribution; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:RegisteredPage",
+          "signature": "export interface RegisteredPage extends ContributionOwner { readonly contribution: PageContribution; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:RegisteredRoute",
+          "signature": "export interface RegisteredRoute extends ContributionOwner { readonly contribution: RouteContribution; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:RegisteredState",
+          "signature": "export interface RegisteredState extends ContributionOwner { readonly contribution: StateContribution; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:RouteContribution",
+          "signature": "export interface RouteContribution { readonly id: ContributionId; readonly path: string; readonly name: string; readonly pageId: ContributionId; readonly order?: number; readonly requirements?: ContributionRequirements; readonly metadata?: Readonly<Record<string, unknown>>; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:ScopedStateInstance",
+          "signature": "export interface ScopedStateInstance<TState = unknown> { readonly value: TState; dispose?(): Awaitable<void>; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:StateContribution",
+          "signature": "export interface StateContribution<TState = unknown> { readonly id: ContributionId; readonly namespace: string; readonly order?: number; create(context: StateFactoryContext): Awaitable<ScopedStateInstance<TState>>; }"
+        },
+        {
+          "key": "composition/types.d.ts#InterfaceDeclaration:StateFactoryContext",
+          "signature": "export interface StateFactoryContext { readonly featureId: FeatureId; readonly namespace: string; readonly capabilities: ReadonlySet<CapabilityId>; readonly native: NativeCapabilityAdapter; getService<T = unknown>(id: string): T | undefined; }"
+        },
+        {
+          "key": "composition/types.d.ts#TypeAliasDeclaration:Awaitable",
+          "signature": "export type Awaitable<T> = T | Promise<T>;"
+        },
+        {
+          "key": "composition/types.d.ts#TypeAliasDeclaration:CapabilityId",
+          "signature": "export type CapabilityId = string;"
+        },
+        {
+          "key": "composition/types.d.ts#TypeAliasDeclaration:ContributionId",
+          "signature": "export type ContributionId = string;"
+        },
+        {
+          "key": "composition/types.d.ts#TypeAliasDeclaration:FeatureId",
+          "signature": "export type FeatureId = string;"
+        },
+        {
+          "key": "composition/types.d.ts#TypeAliasDeclaration:NativeCapabilityApiVersion",
+          "signature": "export type NativeCapabilityApiVersion = typeof NATIVE_CAPABILITY_API_VERSION;"
+        },
+        {
+          "key": "composition/types.d.ts#TypeAliasDeclaration:NativeCapabilityErrorCode",
+          "signature": "export type NativeCapabilityErrorCode = 'unsupported' | 'unavailable' | 'invalid_request' | 'denied' | 'failed';"
+        },
+        {
+          "key": "composition/types.d.ts#TypeAliasDeclaration:NativeCapabilityResult",
+          "signature": "export type NativeCapabilityResult<T = unknown> = { readonly ok: true; readonly value: T; } | { readonly ok: false; readonly error: NativeCapabilityFailure; };"
+        },
+        {
+          "key": "composition/types.d.ts#TypeAliasDeclaration:NavigationSlot",
+          "signature": "export type NavigationSlot = 'primary' | 'secondary' | 'footer';"
+        },
+        {
+          "key": "composition/types.d.ts#TypeAliasDeclaration:PageLoader",
+          "signature": "export type PageLoader<TPage = unknown> = (context: PageLoadContext) => Awaitable<TPage>;"
+        },
+        {
+          "key": "composition/types.d.ts#TypeAliasDeclaration:PresentationUnavailableReason",
+          "signature": "export type PresentationUnavailableReason = 'missing_capability' | 'missing_gateway_scope';"
+        },
+        {
+          "key": "composition/types.d.ts#TypeAliasDeclaration:UiCompositionApiVersion",
+          "signature": "export type UiCompositionApiVersion = typeof UI_COMPOSITION_API_VERSION;"
+        },
+        {
+          "key": "composition/types.d.ts#VariableStatement:NATIVE_CAPABILITY_API_VERSION",
+          "signature": "export declare const NATIVE_CAPABILITY_API_VERSION: 1;"
+        },
+        {
+          "key": "composition/types.d.ts#VariableStatement:UI_COMPOSITION_API_VERSION",
+          "signature": "export declare const UI_COMPOSITION_API_VERSION: 1;"
+        },
+        {
+          "key": "gateway/client.d.ts#ClassDeclaration:RpcAbortError",
+          "signature": "export declare class RpcAbortError extends Error implements RpcClientError { readonly method: string; readonly code = \"RPC_ABORTED\"; constructor(method: string); }"
+        },
+        {
+          "key": "gateway/client.d.ts#ClassDeclaration:RpcClient",
+          "signature": "export declare class RpcClient implements GatewayUiClient { private client; private readonly listeners; private connectionState; private currentPolicy; get state(): GatewayConnectionState; get policy(): Record<string, unknown>; get _pending(): { readonly size: number; }; connect(endpoint: string, token?: string): void; disconnect(): void; call<T = unknown>(method: string, params?: Record<string, unknown>, options?: GatewayCallOptions): Promise<T>; on(event: string, handler: GatewayUiEventHandler): () => void; waitForConnection(timeoutMs?: number, signal?: AbortSignal, actions?: GatewayConnectionWaitOptions): Promise<void>; private emit; }"
+        },
+        {
+          "key": "gateway/client.d.ts#ClassDeclaration:RpcTimeoutError",
+          "signature": "export declare class RpcTimeoutError extends Error implements RpcClientError { readonly method: string; readonly timeoutMs: number; readonly code = \"RPC_TIMEOUT\"; constructor(method: string, timeoutMs: number); }"
+        },
+        {
+          "key": "gateway/client.d.ts#ExportDeclaration:{ capabilitiesForMethods }:",
+          "signature": "export { capabilitiesForMethods };"
+        },
+        {
+          "key": "gateway/client.d.ts#ExportDeclaration:{ ConnectionClosedError, GatewayClientError, GatewayHttpError, HandshakeError, RequestAbortError, RequestTimeoutError, SequenceGapError, }:",
+          "signature": "export { ConnectionClosedError, GatewayClientError, GatewayHttpError, HandshakeError, RequestAbortError, RequestTimeoutError, SequenceGapError, };"
+        },
+        {
+          "key": "gateway/client.d.ts#ExportDeclaration:{ EventFrame, GatewayCallOptions, GatewayClientOptions, GatewayConnectionState, GatewayConnectionWaitOptions, GatewayTerminationAction, NormalizedHello, }:",
+          "signature": "export type { EventFrame, GatewayCallOptions, GatewayClientOptions, GatewayConnectionState, GatewayConnectionWaitOptions, GatewayTerminationAction, NormalizedHello, };"
+        },
+        {
+          "key": "gateway/client.d.ts#FunctionDeclaration:createGatewayClient",
+          "signature": "export declare function createGatewayClient(options: CreateGatewayClientOptions): GatewayClient;"
+        },
+        {
+          "key": "gateway/client.d.ts#FunctionDeclaration:normalizeHelloFrame",
+          "signature": "export declare function normalizeHelloFrame(data: RpcFrame, requestId: string): RpcFrame;"
+        },
+        {
+          "key": "gateway/client.d.ts#ImportDeclaration:0",
+          "signature": "import { capabilitiesForMethods, ConnectionClosedError, GatewayClient, GatewayClientError, GatewayHttpError, HandshakeError, RequestAbortError, RequestTimeoutError, SequenceGapError, type ContractInfo, type ErrorShape, type EventFrame, type GatewayCallOptions, type GatewayClientOptions, type GatewayConnectionWaitOptions, type GatewayConnectionState, type GatewayTerminationAction, type NormalizedHello, type NormalizedRuntimeInfo, type ProtocolRangeInfo } from '@opensquilla/client-sdk';"
+        },
+        {
+          "key": "gateway/client.d.ts#ImportDeclaration:1",
+          "signature": "import type { GatewayClientBindings, GatewayUiClient, GatewayUiEventHandler } from './types.js';"
+        },
+        {
+          "key": "gateway/client.d.ts#InterfaceDeclaration:CreateGatewayClientOptions",
+          "signature": "export interface CreateGatewayClientOptions extends Omit<GatewayClientOptions, 'endpoint' | 'onDiagnostic' | 'onHello' | 'onStateChange' | 'token'> { endpoint: string; token?: string; bindings?: Partial<GatewayClientBindings>; }"
+        },
+        {
+          "key": "gateway/client.d.ts#InterfaceDeclaration:RpcClientError",
+          "signature": "export interface RpcClientError extends Error { code?: string; details?: unknown; retryable?: boolean; retry_after_ms?: number; accepted?: boolean; }"
+        },
+        {
+          "key": "gateway/client.d.ts#InterfaceDeclaration:RpcFrame",
+          "signature": "export interface RpcFrame extends Record<string, unknown> { type?: string; id?: string; method?: string; params?: Record<string, unknown>; event?: string; payload?: unknown; meta?: Record<string, unknown>; ok?: boolean; error?: string | RpcErrorDetail; protocol?: number; policy?: Record<string, unknown>; features?: { methods?: string[]; events?: string[]; }; server?: { version?: string; conn_id?: string; }; auth?: Record<string, unknown>; contract?: Partial<RpcContractInfo>; runtime?: Partial<RpcRuntimeInfo>; protocolRange?: Partial<RpcProtocolRange>; capabilities?: string[]; extensions?: string[]; contractStatus?: 'advertised' | 'legacy-contract'; capabilitySource?: 'hello' | 'features.methods' | 'none'; seq?: number; }"
+        },
+        {
+          "key": "gateway/client.d.ts#TypeAliasDeclaration:ConnectionState",
+          "signature": "export type ConnectionState = GatewayConnectionState;"
+        },
+        {
+          "key": "gateway/client.d.ts#TypeAliasDeclaration:RpcCallOptions",
+          "signature": "export type RpcCallOptions = GatewayCallOptions;"
+        },
+        {
+          "key": "gateway/client.d.ts#TypeAliasDeclaration:RpcConnectionWaitOptions",
+          "signature": "export type RpcConnectionWaitOptions = GatewayConnectionWaitOptions;"
+        },
+        {
+          "key": "gateway/client.d.ts#TypeAliasDeclaration:RpcContractInfo",
+          "signature": "export type RpcContractInfo = ContractInfo;"
+        },
+        {
+          "key": "gateway/client.d.ts#TypeAliasDeclaration:RpcErrorDetail",
+          "signature": "export type RpcErrorDetail = Partial<ErrorShape>;"
+        },
+        {
+          "key": "gateway/client.d.ts#TypeAliasDeclaration:RpcEventHandler",
+          "signature": "export type RpcEventHandler = GatewayUiEventHandler;"
+        },
+        {
+          "key": "gateway/client.d.ts#TypeAliasDeclaration:RpcProtocolRange",
+          "signature": "export type RpcProtocolRange = ProtocolRangeInfo;"
+        },
+        {
+          "key": "gateway/client.d.ts#TypeAliasDeclaration:RpcRuntimeInfo",
+          "signature": "export type RpcRuntimeInfo = NormalizedRuntimeInfo;"
+        },
+        {
+          "key": "gateway/client.d.ts#TypeAliasDeclaration:RpcTerminationAction",
+          "signature": "export type RpcTerminationAction = GatewayTerminationAction;"
+        },
+        {
+          "key": "gateway/http.d.ts#ExportDeclaration:{ GatewayHttpClient }:",
+          "signature": "export { GatewayHttpClient };"
+        },
+        {
+          "key": "gateway/http.d.ts#ExportDeclaration:{ GatewayHttpClientOptions }:",
+          "signature": "export type { GatewayHttpClientOptions };"
+        },
+        {
+          "key": "gateway/http.d.ts#FunctionDeclaration:createGatewayHttpClient",
+          "signature": "export declare function createGatewayHttpClient(options: GatewayHttpClientOptions): GatewayHttpClient;"
+        },
+        {
+          "key": "gateway/http.d.ts#ImportDeclaration:0",
+          "signature": "import { GatewayHttpClient, type GatewayHttpClientOptions } from '@opensquilla/client-sdk';"
+        },
+        {
+          "key": "gateway/query.d.ts#ClassDeclaration:GatewayQuery",
+          "signature": "export declare class GatewayQuery<T> { private readonly options; private value; private readonly listeners; private runGeneration; private disposed; private activeAbort; constructor(options: GatewayQueryOptions<T>); get snapshot(): GatewayQuerySnapshot<T>; subscribe(listener: GatewayQueryListener<T>, emitCurrent?: boolean): () => void; execute(): Promise<T | null>; refresh(): Promise<T | null>; reset(): void; dispose(): void; private run; private publish; }"
+        },
+        {
+          "key": "gateway/query.d.ts#FunctionDeclaration:createGatewayQuery",
+          "signature": "export declare function createGatewayQuery<T>(options: GatewayQueryOptions<T>): GatewayQuery<T>;"
+        },
+        {
+          "key": "gateway/query.d.ts#ImportDeclaration:0",
+          "signature": "import type { GatewayUiCallOptions, GatewayUiConnectionWaitOptions } from './types.js';"
+        },
+        {
+          "key": "gateway/query.d.ts#InterfaceDeclaration:GatewayQueryOptions",
+          "signature": "export interface GatewayQueryOptions<T> { client: GatewayRequestClient; method: string; params?: (Record<string, unknown> | (() => Record<string, unknown> | undefined)); callOptions?: GatewayUiCallOptions | (() => GatewayUiCallOptions | undefined); waitTimeoutMs?: number; waitActions?: GatewayUiConnectionWaitOptions; onError?: (error: Error) => void; onSuccess?: (data: T) => void; }"
+        },
+        {
+          "key": "gateway/query.d.ts#InterfaceDeclaration:GatewayQuerySnapshot",
+          "signature": "export interface GatewayQuerySnapshot<T> { readonly data: T | null; readonly error: Error | null; readonly loading: boolean; }"
+        },
+        {
+          "key": "gateway/query.d.ts#InterfaceDeclaration:GatewayRequestClient",
+          "signature": "export interface GatewayRequestClient { call<T = unknown>(method: string, params?: Record<string, unknown>, options?: GatewayUiCallOptions): Promise<T>; waitForConnection(timeoutMs?: number, signal?: AbortSignal, actions?: GatewayUiConnectionWaitOptions): Promise<void>; }"
+        },
+        {
+          "key": "gateway/query.d.ts#TypeAliasDeclaration:GatewayQueryListener",
+          "signature": "export type GatewayQueryListener<T> = (snapshot: GatewayQuerySnapshot<T>) => void;"
+        },
+        {
+          "key": "gateway/state.d.ts#ClassDeclaration:GatewayDataStore",
+          "signature": "export declare class GatewayDataStore implements GatewayStateSource { private value; private readonly listeners; get snapshot(): GatewayStateSnapshot; subscribe(listener: GatewayStateListener, emitCurrent?: boolean): () => void; setConnectionState(state: GatewayUiConnectionState): void; applyHello(input: GatewayHelloInput): void; setDiagnostic(diagnostic: Error): void; markMethodUnavailable(method: string): void; supportsMethod(method: string): boolean; supportsCapability(capability: string): boolean; reset(): void; dispose(): void; private publish; }"
+        },
+        {
+          "key": "gateway/state.d.ts#FunctionDeclaration:createFoundationStores",
+          "signature": "export declare function createFoundationStores(context?: FoundationStoreContext): { gateway: GatewayDataStore; };"
+        },
+        {
+          "key": "gateway/state.d.ts#ImportDeclaration:0",
+          "signature": "import type { GatewayHelloInput, GatewayStateListener, GatewayStateSnapshot, GatewayStateSource, GatewayUiConnectionState } from './types.js';"
+        },
+        {
+          "key": "gateway/state.d.ts#InterfaceDeclaration:FoundationStoreContext",
+          "signature": "export interface FoundationStoreContext { gateway?: GatewayDataStore; }"
+        },
+        {
+          "key": "gateway/storage.d.ts#FunctionDeclaration:clearStoragePrefix",
+          "signature": "export declare function clearStoragePrefix(storage: StorageLike, prefix: string): void;"
+        },
+        {
+          "key": "gateway/storage.d.ts#FunctionDeclaration:createGatewayConnectionStorage",
+          "signature": "export declare function createGatewayConnectionStorage(options: GatewayConnectionStorageOptions): GatewayConnectionStorage;"
+        },
+        {
+          "key": "gateway/storage.d.ts#ImportDeclaration:0",
+          "signature": "import type { GatewayConnectionSettings } from './types.js';"
+        },
+        {
+          "key": "gateway/storage.d.ts#InterfaceDeclaration:GatewayConnectionStorage",
+          "signature": "export interface GatewayConnectionStorage { load(): GatewayConnectionSettings; save(settings: GatewayConnectionSettings): void; clear(): void; }"
+        },
+        {
+          "key": "gateway/storage.d.ts#InterfaceDeclaration:GatewayConnectionStorageOptions",
+          "signature": "export interface GatewayConnectionStorageOptions { persistent: StorageLike; session: StorageLike; defaultEndpoint: string; endpointKey?: string; tokenKey?: string; }"
+        },
+        {
+          "key": "gateway/storage.d.ts#InterfaceDeclaration:StorageLike",
+          "signature": "export interface StorageLike { readonly length: number; getItem(key: string): string | null; key(index: number): string | null; removeItem(key: string): void; setItem(key: string, value: string): void; }"
+        },
+        {
+          "key": "gateway/types.d.ts#ImportDeclaration:0",
+          "signature": "import type { CapabilitySource, ContractInfo, ContractStatus, GatewayCallOptions, GatewayConnectionState, GatewayConnectionWaitOptions, NormalizedHello, NormalizedRuntimeInfo, ProtocolRangeInfo } from '@opensquilla/client-sdk';"
+        },
+        {
+          "key": "gateway/types.d.ts#InterfaceDeclaration:GatewayClientBindings",
+          "signature": "export interface GatewayClientBindings { onStateChange(state: GatewayUiConnectionState): void; onHello(hello: NormalizedHello): void; onDiagnostic(error: Error): void; }"
+        },
+        {
+          "key": "gateway/types.d.ts#InterfaceDeclaration:GatewayConnectionSettings",
+          "signature": "export interface GatewayConnectionSettings { endpoint: string; token?: string; }"
+        },
+        {
+          "key": "gateway/types.d.ts#InterfaceDeclaration:GatewayHelloInput",
+          "signature": "export interface GatewayHelloInput { policy?: unknown; auth?: unknown; features?: { methods?: unknown; }; contract?: GatewayUiContract | null; contractStatus?: GatewayUiContractStatus; runtime?: GatewayUiRuntime | null; protocolRange?: GatewayUiProtocolRange | null; capabilities?: unknown; capabilitySource?: GatewayUiCapabilitySource; extensions?: unknown; }"
+        },
+        {
+          "key": "gateway/types.d.ts#InterfaceDeclaration:GatewayStateSnapshot",
+          "signature": "export interface GatewayStateSnapshot { readonly state: GatewayUiConnectionState; readonly policy: Readonly<Record<string, unknown>> | null; readonly auth: Readonly<Record<string, unknown>> | null; readonly methods: readonly string[]; readonly contract: GatewayUiContract | null; readonly contractStatus: GatewayUiContractStatus; readonly runtime: GatewayUiRuntime | null; readonly protocolRange: GatewayUiProtocolRange | null; readonly capabilities: readonly string[]; readonly capabilitySource: GatewayUiCapabilitySource; readonly extensions: readonly string[]; readonly unavailableMethods: ReadonlySet<string>; readonly diagnostic: Error | null; }"
+        },
+        {
+          "key": "gateway/types.d.ts#InterfaceDeclaration:GatewayStateSource",
+          "signature": "export interface GatewayStateSource { readonly snapshot: GatewayStateSnapshot; subscribe(listener: GatewayStateListener, emitCurrent?: boolean): () => void; }"
+        },
+        {
+          "key": "gateway/types.d.ts#InterfaceDeclaration:GatewayUiClient",
+          "signature": "export interface GatewayUiClient { readonly state: GatewayUiConnectionState; readonly policy: Record<string, unknown>; connect(endpoint: string, token?: string): void; disconnect(): void; call<T = unknown>(method: string, params?: Record<string, unknown>, options?: GatewayUiCallOptions): Promise<T>; on(event: string, handler: GatewayUiEventHandler): () => void; waitForConnection(timeoutMs?: number, signal?: AbortSignal, actions?: GatewayUiConnectionWaitOptions): Promise<void>; }"
+        },
+        {
+          "key": "gateway/types.d.ts#TypeAliasDeclaration:GatewayStateListener",
+          "signature": "export type GatewayStateListener = (snapshot: GatewayStateSnapshot) => void;"
+        },
+        {
+          "key": "gateway/types.d.ts#TypeAliasDeclaration:GatewayUiCallOptions",
+          "signature": "export type GatewayUiCallOptions = GatewayCallOptions;"
+        },
+        {
+          "key": "gateway/types.d.ts#TypeAliasDeclaration:GatewayUiCapabilitySource",
+          "signature": "export type GatewayUiCapabilitySource = CapabilitySource;"
+        },
+        {
+          "key": "gateway/types.d.ts#TypeAliasDeclaration:GatewayUiConnectionState",
+          "signature": "export type GatewayUiConnectionState = GatewayConnectionState;"
+        },
+        {
+          "key": "gateway/types.d.ts#TypeAliasDeclaration:GatewayUiConnectionWaitOptions",
+          "signature": "export type GatewayUiConnectionWaitOptions = GatewayConnectionWaitOptions;"
+        },
+        {
+          "key": "gateway/types.d.ts#TypeAliasDeclaration:GatewayUiContract",
+          "signature": "export type GatewayUiContract = ContractInfo;"
+        },
+        {
+          "key": "gateway/types.d.ts#TypeAliasDeclaration:GatewayUiContractStatus",
+          "signature": "export type GatewayUiContractStatus = ContractStatus;"
+        },
+        {
+          "key": "gateway/types.d.ts#TypeAliasDeclaration:GatewayUiEventHandler",
+          "signature": "export type GatewayUiEventHandler = { bivarianceHack(...args: unknown[]): void; }['bivarianceHack'];"
+        },
+        {
+          "key": "gateway/types.d.ts#TypeAliasDeclaration:GatewayUiProtocolRange",
+          "signature": "export type GatewayUiProtocolRange = ProtocolRangeInfo;"
+        },
+        {
+          "key": "gateway/types.d.ts#TypeAliasDeclaration:GatewayUiRuntime",
+          "signature": "export type GatewayUiRuntime = NormalizedRuntimeInfo;"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./composition/app.js'",
+          "signature": "export * from './composition/app.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./composition/capabilities.js'",
+          "signature": "export * from './composition/capabilities.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./composition/errors.js'",
+          "signature": "export * from './composition/errors.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./composition/registrar.js'",
+          "signature": "export * from './composition/registrar.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./composition/types.js'",
+          "signature": "export * from './composition/types.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./gateway/client.js'",
+          "signature": "export * from './gateway/client.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./gateway/http.js'",
+          "signature": "export * from './gateway/http.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./gateway/query.js'",
+          "signature": "export * from './gateway/query.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./gateway/state.js'",
+          "signature": "export * from './gateway/state.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./gateway/storage.js'",
+          "signature": "export * from './gateway/storage.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./gateway/types.js'",
+          "signature": "export * from './gateway/types.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:*:'./vue.js'",
+          "signature": "export * from './vue.js';"
+        },
+        {
+          "key": "vue.d.ts#FunctionDeclaration:useGatewayQuery",
+          "signature": "export declare function useGatewayQuery<T>(client: GatewayQueryOptions<T>['client'], method: string, params?: GatewayQueryOptions<T>['params'], options?: UseGatewayQueryOptions<T>): GatewayQueryRefs<T>;"
+        },
+        {
+          "key": "vue.d.ts#FunctionDeclaration:useGatewayState",
+          "signature": "export declare function useGatewayState(source: GatewayStateSource): GatewayStateRef;"
+        },
+        {
+          "key": "vue.d.ts#ImportDeclaration:0",
+          "signature": "import { type ComputedRef, type DeepReadonly, type ShallowRef } from 'vue';"
+        },
+        {
+          "key": "vue.d.ts#ImportDeclaration:1",
+          "signature": "import { type GatewayQueryOptions } from './gateway/query.js';"
+        },
+        {
+          "key": "vue.d.ts#ImportDeclaration:2",
+          "signature": "import type { GatewayStateSnapshot, GatewayStateSource } from './gateway/types.js';"
+        },
+        {
+          "key": "vue.d.ts#InterfaceDeclaration:GatewayQueryRefs",
+          "signature": "export interface GatewayQueryRefs<T> { readonly data: ComputedRef<T | null>; readonly error: ComputedRef<Error | null>; readonly loading: ComputedRef<boolean>; execute(): Promise<T | null>; refresh(): Promise<T | null>; }"
+        },
+        {
+          "key": "vue.d.ts#InterfaceDeclaration:UseGatewayQueryOptions",
+          "signature": "export interface UseGatewayQueryOptions<T> extends Omit<GatewayQueryOptions<T>, 'client' | 'method' | 'params'> { immediate?: boolean; }"
+        },
+        {
+          "key": "vue.d.ts#TypeAliasDeclaration:GatewayStateRef",
+          "signature": "export type GatewayStateRef = DeepReadonly<ShallowRef<GatewayStateSnapshot>>;"
+        }
+      ],
+      "deprecations": []
+    }
+  ]
+}

--- a/contracts/ui-foundation/v1/api-report.json
+++ b/contracts/ui-foundation/v1/api-report.json
@@ -539,44 +539,8 @@
         "UiStack",
         "UiSwitch"
       ],
-      "declarationsDigest": "sha256:5bb798d118af8ab1ae48522690aa8d267667873a4539add9b992ce54bdf145dc",
+      "declarationsDigest": "sha256:0ae3010be35bf399b31e6ce7dad6a11d613f6a6a55c4aaa2e711d88a2cb8f110",
       "declarations": [
-        {
-          "key": "components/button.d.ts#TypeAliasDeclaration:UiButtonSize",
-          "signature": "export type UiButtonSize = 'small' | 'medium' | 'large';"
-        },
-        {
-          "key": "components/button.d.ts#TypeAliasDeclaration:UiButtonVariant",
-          "signature": "export type UiButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';"
-        },
-        {
-          "key": "components/dialogStack.d.ts#FunctionDeclaration:isTopmostDialog",
-          "signature": "export declare function isTopmostDialog(token: symbol): boolean;"
-        },
-        {
-          "key": "components/dialogStack.d.ts#FunctionDeclaration:registerDialog",
-          "signature": "export declare function registerDialog(token: symbol): void;"
-        },
-        {
-          "key": "components/dialogStack.d.ts#FunctionDeclaration:unregisterDialog",
-          "signature": "export declare function unregisterDialog(token: symbol): boolean;"
-        },
-        {
-          "key": "components/stack.d.ts#TypeAliasDeclaration:UiStackAlign",
-          "signature": "export type UiStackAlign = 'start' | 'center' | 'end' | 'stretch' | 'baseline';"
-        },
-        {
-          "key": "components/stack.d.ts#TypeAliasDeclaration:UiStackDirection",
-          "signature": "export type UiStackDirection = 'row' | 'column';"
-        },
-        {
-          "key": "components/stack.d.ts#TypeAliasDeclaration:UiStackGap",
-          "signature": "export type UiStackGap = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';"
-        },
-        {
-          "key": "components/stack.d.ts#TypeAliasDeclaration:UiStackJustify",
-          "signature": "export type UiStackJustify = 'start' | 'center' | 'end' | 'between' | 'around' | 'evenly';"
-        },
         {
           "key": "components/UiButton.vue.d.ts#ExportAssignment:default",
           "signature": "export default _default;"
@@ -722,6 +686,50 @@
           "signature": "declare const _default: import(\"vue\").DefineComponent<__VLS_Props, {}, {}, {}, {}, import(\"vue\").ComponentOptionsMixin, import(\"vue\").ComponentOptionsMixin, { change: (args_0: boolean) => any; \"update:checked\": (args_0: boolean) => any; }, string, import(\"vue\").PublicProps, Readonly<__VLS_Props> & Readonly<{ onChange?: (args_0: boolean) => any; \"onUpdate:checked\"?: (args_0: boolean) => any; }>, { disabled: boolean; busy: boolean; checked: boolean; }, {}, {}, {}, string, import(\"vue\").ComponentProvideOptions, false, {}, any>;"
         },
         {
+          "key": "components/button.d.ts#TypeAliasDeclaration:UiButtonSize",
+          "signature": "export type UiButtonSize = 'small' | 'medium' | 'large';"
+        },
+        {
+          "key": "components/button.d.ts#TypeAliasDeclaration:UiButtonVariant",
+          "signature": "export type UiButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';"
+        },
+        {
+          "key": "components/dialogStack.d.ts#FunctionDeclaration:isTopmostDialog",
+          "signature": "export declare function isTopmostDialog(token: symbol): boolean;"
+        },
+        {
+          "key": "components/dialogStack.d.ts#FunctionDeclaration:registerDialog",
+          "signature": "export declare function registerDialog(token: symbol): void;"
+        },
+        {
+          "key": "components/dialogStack.d.ts#FunctionDeclaration:unregisterDialog",
+          "signature": "export declare function unregisterDialog(token: symbol): boolean;"
+        },
+        {
+          "key": "components/stack.d.ts#TypeAliasDeclaration:UiStackAlign",
+          "signature": "export type UiStackAlign = 'start' | 'center' | 'end' | 'stretch' | 'baseline';"
+        },
+        {
+          "key": "components/stack.d.ts#TypeAliasDeclaration:UiStackDirection",
+          "signature": "export type UiStackDirection = 'row' | 'column';"
+        },
+        {
+          "key": "components/stack.d.ts#TypeAliasDeclaration:UiStackGap",
+          "signature": "export type UiStackGap = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';"
+        },
+        {
+          "key": "components/stack.d.ts#TypeAliasDeclaration:UiStackJustify",
+          "signature": "export type UiStackJustify = 'start' | 'center' | 'end' | 'between' | 'around' | 'evenly';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:{ UiButtonSize, UiButtonVariant, }:'./components/button.js'",
+          "signature": "export type { UiButtonSize, UiButtonVariant, } from './components/button.js';"
+        },
+        {
+          "key": "index.d.ts#ExportDeclaration:{ UiStackAlign, UiStackDirection, UiStackGap, UiStackJustify, }:'./components/stack.js'",
+          "signature": "export type { UiStackAlign, UiStackDirection, UiStackGap, UiStackJustify, } from './components/stack.js';"
+        },
+        {
           "key": "index.d.ts#ExportDeclaration:{ default as UiButton }:'./components/UiButton.vue'",
           "signature": "export { default as UiButton } from './components/UiButton.vue';"
         },
@@ -744,14 +752,6 @@
         {
           "key": "index.d.ts#ExportDeclaration:{ default as UiSwitch }:'./components/UiSwitch.vue'",
           "signature": "export { default as UiSwitch } from './components/UiSwitch.vue';"
-        },
-        {
-          "key": "index.d.ts#ExportDeclaration:{ UiButtonSize, UiButtonVariant, }:'./components/button.js'",
-          "signature": "export type { UiButtonSize, UiButtonVariant, } from './components/button.js';"
-        },
-        {
-          "key": "index.d.ts#ExportDeclaration:{ UiStackAlign, UiStackDirection, UiStackGap, UiStackJustify, }:'./components/stack.js'",
-          "signature": "export type { UiStackAlign, UiStackDirection, UiStackGap, UiStackJustify, } from './components/stack.js';"
         }
       ],
       "deprecations": []
@@ -920,7 +920,7 @@
         "useGatewayQuery",
         "useGatewayState"
       ],
-      "declarationsDigest": "sha256:6dfd968b8cf1ec10b7483ea486e241c08fa652f866e43de470fe6feaddac586f",
+      "declarationsDigest": "sha256:5efc2aa468d21aadf90f2952adcd7e3fbce97624441a20682626633e300846d8",
       "declarations": [
         {
           "key": "composition/app.d.ts#FunctionDeclaration:createOpenSquillaApp",
@@ -1143,16 +1143,16 @@
           "signature": "export declare class RpcTimeoutError extends Error implements RpcClientError { readonly method: string; readonly timeoutMs: number; readonly code = \"RPC_TIMEOUT\"; constructor(method: string, timeoutMs: number); }"
         },
         {
-          "key": "gateway/client.d.ts#ExportDeclaration:{ capabilitiesForMethods }:",
-          "signature": "export { capabilitiesForMethods };"
-        },
-        {
           "key": "gateway/client.d.ts#ExportDeclaration:{ ConnectionClosedError, GatewayClientError, GatewayHttpError, HandshakeError, RequestAbortError, RequestTimeoutError, SequenceGapError, }:",
           "signature": "export { ConnectionClosedError, GatewayClientError, GatewayHttpError, HandshakeError, RequestAbortError, RequestTimeoutError, SequenceGapError, };"
         },
         {
           "key": "gateway/client.d.ts#ExportDeclaration:{ EventFrame, GatewayCallOptions, GatewayClientOptions, GatewayConnectionState, GatewayConnectionWaitOptions, GatewayTerminationAction, NormalizedHello, }:",
           "signature": "export type { EventFrame, GatewayCallOptions, GatewayClientOptions, GatewayConnectionState, GatewayConnectionWaitOptions, GatewayTerminationAction, NormalizedHello, };"
+        },
+        {
+          "key": "gateway/client.d.ts#ExportDeclaration:{ capabilitiesForMethods }:",
+          "signature": "export { capabilitiesForMethods };"
         },
         {
           "key": "gateway/client.d.ts#FunctionDeclaration:createGatewayClient",

--- a/opensquilla-webui/package-lock.json
+++ b/opensquilla-webui/package-lock.json
@@ -52,7 +52,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opensquilla/client-sdk": "0.1.0"
+        "@opensquilla/client-sdk": ">=0.1.0 <0.3.0"
       },
       "engines": {
         "node": ">=22.12.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1880,7 +1880,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opensquilla/client-sdk": "0.1.0"
+        "@opensquilla/client-sdk": ">=0.1.0 <0.3.0"
       },
       "engines": {
         "node": ">=22.12.0"

--- a/package.json
+++ b/package.json
@@ -16,10 +16,16 @@
   "scripts": {
     "build:client-sdk": "npm run build --prefix packages/client-sdk",
     "build:ui-packages": "npm run build:client-sdk && npm run build --workspaces --if-present",
+    "build:ui-package-release": "node scripts/build_ui_package_release.mjs",
+    "check:ui-package-api": "node scripts/ui_package_api.mjs --check",
+    "check:ui-package-compat": "node scripts/check_ui_package_compat.mjs",
+    "install:ui-package-release": "node scripts/install_ui_package_release.mjs",
     "test:ui-primitives:browser": "playwright test --config packages/ui-primitives/playwright.config.ts",
     "test:ui-packages": "npm run test --workspaces --if-present",
+    "test:ui-package-release": "node --test scripts/tests/ui_package_compat.test.mjs",
     "typecheck:ui-packages": "npm run typecheck --workspaces --if-present",
-    "verify:ui-packages": "npm run build:client-sdk && npm run typecheck:ui-packages && npm run test:ui-packages && npm run build:ui-packages && npm run verify:cross-surface --workspace @opensquilla/ui-tokens && npm run verify:boundaries --workspace @opensquilla/ui-primitives && npm run verify:boundaries --workspace @opensquilla/ui-foundation && node scripts/verify_ui_packages.mjs"
+    "verify:ui-package-release": "npm run build:ui-packages && npm run check:ui-package-api && npm run test:ui-package-release && node scripts/verify_ui_package_release.mjs",
+    "verify:ui-packages": "npm run build:client-sdk && npm run typecheck:ui-packages && npm run test:ui-packages && npm run build:ui-packages && npm run verify:cross-surface --workspace @opensquilla/ui-tokens && npm run verify:boundaries --workspace @opensquilla/ui-primitives && npm run verify:boundaries --workspace @opensquilla/ui-foundation && node scripts/verify_ui_packages.mjs && npm run verify:ui-package-release"
   },
   "devDependencies": {
     "@opensquilla/client-sdk": "file:packages/client-sdk",

--- a/packages/UI_RELEASE.md
+++ b/packages/UI_RELEASE.md
@@ -1,0 +1,52 @@
+# Public UI package release policy
+
+The public UI release contains four independently installable packages:
+`@opensquilla/client-sdk`, `@opensquilla/ui-tokens`,
+`@opensquilla/ui-primitives`, and `@opensquilla/ui-foundation`.
+The SDK has an independent version. The three UI packages use one fixed
+Foundation release version.
+
+## Compatibility
+
+- Pull requests regenerate `contracts/ui-foundation/v1/api-report.json` and
+  compare it with the target branch.
+- Additive API changes require a minor version. Breaking changes require a
+  major version after 1.0, or a minor version while the package is pre-1.0.
+- Export removal requires a recorded deprecation whose `removeAfter` version
+  has been reached.
+- `packages/ui-compatibility-matrix.json` records the current and previous
+  supported minor. The first 0.1.0 release is explicitly marked as bootstrap;
+  later releases must provide N-1 assets and pass both cross-version
+  Foundation/SDK combinations.
+- UI Foundation declares the supported independent Client SDK range in the
+  matrix and its package dependency; both N and N-1 SDK versions must satisfy
+  that range.
+- Gateway protocol ranges without an overlap fail. Missing optional
+  capabilities disable the affected feature; missing required capabilities
+  fail with an upgrade action.
+
+## Release
+
+The `Public UI Foundation Release` workflow accepts
+`ui-foundation-v<version>` tags or a manual dry run. It builds each tarball
+twice and requires identical SHA-256 digests, installs the packages into an
+external fixture, and builds the complete public WebUI from the tarballs.
+
+The GitHub Release contains:
+
+- four versioned npm tarballs;
+- the API and compatibility reports;
+- combined changelogs;
+- SHA-256 checksums;
+- an SPDX 2.3 SBOM;
+- an in-toto/SLSA-format provenance statement;
+- a machine-readable release manifest.
+
+Release assets are write-once. The workflow never uses `--clobber`; a failed
+or incorrect release is replaced by a new patch version. Rolling back means
+pinning the previous manifest and tarball digests. It does not overwrite an
+existing version.
+
+Public pull-request CI uses no registry token and never reads a private
+repository. A private product may pin these public tarballs by exact version
+and digest, then upgrade them on its own schedule.

--- a/packages/client-sdk/CHANGELOG.md
+++ b/packages/client-sdk/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Publish the versioned Gateway protocol client and contract metadata.

--- a/packages/client-sdk/package.json
+++ b/packages/client-sdk/package.json
@@ -16,6 +16,7 @@
   "files": [
     "dist",
     "contract-coverage.json",
+    "CHANGELOG.md",
     "README.md"
   ],
   "scripts": {
@@ -29,6 +30,15 @@
   },
   "devDependencies": {
     "typescript": "^5.4.5"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/opensquilla/opensquilla.git",
+    "directory": "packages/client-sdk"
   },
   "license": "Apache-2.0"
 }

--- a/packages/client-sdk/scripts/verify-package.mjs
+++ b/packages/client-sdk/scripts/verify-package.mjs
@@ -38,6 +38,7 @@ try {
   assert.ok(packed?.filename, 'npm pack did not report a tarball')
   const paths = packed.files.map((entry) => entry.path)
   const allowed = [
+    'CHANGELOG.md',
     'README.md',
     'contract-coverage.json',
     'package.json',

--- a/packages/ui-compatibility-matrix.json
+++ b/packages/ui-compatibility-matrix.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "policy": "current-and-previous-minor",
+  "bootstrap": true,
+  "current": {
+    "releaseVersion": "0.1.0",
+    "clientSdkRange": ">=0.1.0 <0.3.0",
+    "packages": {
+      "@opensquilla/client-sdk": "0.1.0",
+      "@opensquilla/ui-foundation": "0.1.0",
+      "@opensquilla/ui-primitives": "0.1.0",
+      "@opensquilla/ui-tokens": "0.1.0"
+    },
+    "gateway": {
+      "protocolMin": 3,
+      "protocolMax": 3,
+      "contractDigest": "sha256:9819d28398fd37609c8c86ae9b5bbf8133d122ae07f06b75817a4d5b3c30a79e"
+    },
+    "featureApi": {
+      "min": 1,
+      "max": 1
+    },
+    "nativeCapabilityApi": {
+      "min": 1,
+      "max": 1
+    }
+  },
+  "previous": null,
+  "failurePolicy": {
+    "protocolNoOverlap": "hard-fail",
+    "missingRequiredCapability": "hard-fail",
+    "missingOptionalCapability": "disable-feature",
+    "unknownNativeCapability": "unsupported"
+  }
+}

--- a/packages/ui-foundation/CHANGELOG.md
+++ b/packages/ui-foundation/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Publish the Gateway data, composition, contribution, state, and host contracts.

--- a/packages/ui-foundation/package.json
+++ b/packages/ui-foundation/package.json
@@ -14,6 +14,7 @@
   },
   "files": [
     "dist",
+    "CHANGELOG.md",
     "README.md"
   ],
   "scripts": {
@@ -23,7 +24,7 @@
     "verify:boundaries": "node scripts/check-boundaries.mjs"
   },
   "dependencies": {
-    "@opensquilla/client-sdk": "0.1.0"
+    "@opensquilla/client-sdk": ">=0.1.0 <0.3.0"
   },
   "peerDependencies": {
     "vue": "^3.5.0"

--- a/packages/ui-package-manifest.json
+++ b/packages/ui-package-manifest.json
@@ -1,14 +1,39 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "releaseTrain": "public-ui-foundation",
-  "versionPolicy": "independent",
+  "versionPolicy": "release-groups",
+  "compatibilityPolicy": "current-and-previous-minor",
+  "releaseGroups": [
+    {
+      "id": "client-sdk",
+      "versionPolicy": "independent",
+      "packages": [
+        "@opensquilla/client-sdk"
+      ]
+    },
+    {
+      "id": "ui-foundation",
+      "versionPolicy": "fixed",
+      "packages": [
+        "@opensquilla/ui-tokens",
+        "@opensquilla/ui-primitives",
+        "@opensquilla/ui-foundation"
+      ]
+    }
+  ],
   "packages": [
     {
       "name": "@opensquilla/client-sdk",
       "path": "packages/client-sdk",
       "version": "0.1.0",
       "role": "gateway-client-sdk",
-      "workspace": false
+      "workspace": false,
+      "releaseGroup": "client-sdk",
+      "publicExports": [
+        ".",
+        "./contract-coverage.json"
+      ],
+      "deprecations": []
     },
     {
       "name": "@opensquilla/ui-tokens",
@@ -16,6 +41,7 @@
       "version": "0.1.0",
       "role": "design-contracts",
       "workspace": true,
+      "releaseGroup": "ui-foundation",
       "publicExports": [
         ".",
         "./foundation.css",
@@ -30,7 +56,8 @@
         "THEME_TOKEN_NAMES",
         "resolveThemeTokens",
         "themeTokensToCssVariables"
-      ]
+      ],
+      "deprecations": []
     },
     {
       "name": "@opensquilla/ui-primitives",
@@ -38,6 +65,7 @@
       "version": "0.1.0",
       "role": "browser-safe-primitives",
       "workspace": true,
+      "releaseGroup": "ui-foundation",
       "publicExports": [
         ".",
         "./styles.css"
@@ -49,7 +77,8 @@
         "UiInput",
         "UiStack",
         "UiSwitch"
-      ]
+      ],
+      "deprecations": []
     },
     {
       "name": "@opensquilla/ui-foundation",
@@ -57,6 +86,7 @@
       "version": "0.1.0",
       "role": "product-neutral-composition",
       "workspace": true,
+      "releaseGroup": "ui-foundation",
       "publicExports": [
         "."
       ],
@@ -95,7 +125,8 @@
         "normalizeCapabilities",
         "useGatewayQuery",
         "useGatewayState"
-      ]
+      ],
+      "deprecations": []
     }
   ]
 }

--- a/packages/ui-primitives/CHANGELOG.md
+++ b/packages/ui-primitives/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Publish the browser-safe primitive component set.

--- a/packages/ui-primitives/package.json
+++ b/packages/ui-primitives/package.json
@@ -15,6 +15,7 @@
   },
   "files": [
     "dist",
+    "CHANGELOG.md",
     "README.md"
   ],
   "scripts": {

--- a/packages/ui-tokens/CHANGELOG.md
+++ b/packages/ui-tokens/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Publish the product-neutral token and theme contracts.

--- a/packages/ui-tokens/package.json
+++ b/packages/ui-tokens/package.json
@@ -18,6 +18,7 @@
   },
   "files": [
     "dist",
+    "CHANGELOG.md",
     "README.md"
   ],
   "scripts": {

--- a/scripts/build_ui_package_release.mjs
+++ b/scripts/build_ui_package_release.mjs
@@ -1,0 +1,605 @@
+import { createHash } from 'node:crypto'
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import {
+  apiReportPath,
+  generateApiReport,
+  manifestPath,
+  readJson,
+  repositoryRoot,
+  stableJson,
+  validatePackageManifest,
+} from './ui_package_api.mjs'
+
+const compatibilityMatrixPath = path.join(
+  repositoryRoot,
+  'packages',
+  'ui-compatibility-matrix.json',
+)
+const npmEntry = process.env.npm_execpath
+
+function run(command, args, cwd = repositoryRoot) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      npm_config_audit: 'false',
+      npm_config_fund: 'false',
+    },
+  })
+  if (result.status !== 0) {
+    throw new Error(
+      [`${path.basename(command)} ${args.join(' ')} failed`, result.stdout, result.stderr]
+        .filter(Boolean)
+        .join('\n'),
+    )
+  }
+  return result.stdout.trim()
+}
+
+function git(...args) {
+  return run('git', ['-C', repositoryRoot, ...args])
+}
+
+async function sha256(source) {
+  const hash = createHash('sha256')
+  hash.update(await readFile(source))
+  return hash.digest('hex')
+}
+
+function safeRef(value, label) {
+  if (
+    typeof value !== 'string'
+    || !value
+    || value.length > 160
+    || [...value].some((character) => character.charCodeAt(0) < 32)
+  ) {
+    throw new Error(`${label} must be a non-empty safe string`)
+  }
+  return value
+}
+
+function safeCommit(value) {
+  const commit = value.trim().toLowerCase()
+  if (!/^[0-9a-f]{7,64}$/.test(commit)) {
+    throw new Error('source commit must contain 7-64 lowercase hexadecimal characters')
+  }
+  return commit
+}
+
+function packageId(name) {
+  return `SPDXRef-Package-${name.replace(/[^A-Za-z0-9.-]+/g, '-')}`
+}
+
+function versionTuple(value, label) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(value)
+  if (!match) throw new Error(`${label} must use a valid semantic version`)
+  return [Number(match[1]), Number(match[2]), Number(match[3])]
+}
+
+function compareTuple(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] < right[index] ? -1 : 1
+  }
+  return 0
+}
+
+function satisfiesBoundedRange(version, range) {
+  const match = /^>=(\d+\.\d+\.\d+) <(\d+\.\d+\.\d+)$/.exec(range)
+  if (!match) {
+    throw new Error('clientSdkRange must use the form >=<semver> <<semver>')
+  }
+  const candidate = versionTuple(version, 'Client SDK version')
+  return (
+    compareTuple(candidate, versionTuple(match[1], 'Client SDK lower bound')) >= 0
+    && compareTuple(candidate, versionTuple(match[2], 'Client SDK upper bound')) < 0
+  )
+}
+
+async function assertEmptyOutput(outputDir) {
+  try {
+    const info = await stat(outputDir)
+    if (!info.isDirectory()) throw new Error(`${outputDir} is not a directory`)
+    const entries = await readdir(outputDir)
+    if (entries.length > 0) {
+      throw new Error(
+        `release output directory is not empty; immutable assets will not be overwritten: ${outputDir}`,
+      )
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error
+    await mkdir(outputDir, { recursive: true })
+  }
+}
+
+function validateCompatibilityMatrix(matrix, manifest, contract) {
+  if (matrix.schemaVersion !== 1) throw new Error('Unsupported compatibility matrix schema')
+  if (matrix.policy !== manifest.compatibilityPolicy) {
+    throw new Error('Compatibility matrix policy differs from the package manifest')
+  }
+  if (!matrix.current || typeof matrix.current !== 'object') {
+    throw new Error('Compatibility matrix current release is missing')
+  }
+  const expectedVersions = Object.fromEntries(
+    manifest.packages.map((record) => [record.name, record.version]),
+  )
+  if (
+    Object.keys(matrix.current.packages).length !== Object.keys(expectedVersions).length
+    || Object.entries(expectedVersions).some(
+      ([name, version]) => matrix.current.packages[name] !== version,
+    )
+  ) {
+    throw new Error('Compatibility matrix package versions are stale')
+  }
+  const foundationGroup = manifest.releaseGroups.find((group) => group.id === 'ui-foundation')
+  const foundationVersion = manifest.packages.find(
+    (record) => record.name === foundationGroup.packages[0],
+  ).version
+  if (matrix.current.releaseVersion !== foundationVersion) {
+    throw new Error('Compatibility matrix release version differs from the Foundation group')
+  }
+  if (matrix.current.gateway.contractDigest !== contract.digest) {
+    throw new Error('Compatibility matrix Gateway contract digest is stale')
+  }
+  if (
+    !Number.isInteger(matrix.current.gateway.protocolMin)
+    || !Number.isInteger(matrix.current.gateway.protocolMax)
+    || matrix.current.gateway.protocolMin > matrix.current.gateway.protocolMax
+  ) {
+    throw new Error('Compatibility matrix Gateway protocol range is invalid')
+  }
+  if (matrix.previous === null && matrix.bootstrap !== true) {
+    throw new Error('Only an explicit bootstrap release may omit the N-1 matrix entry')
+  }
+  if (matrix.previous !== null && matrix.bootstrap === true) {
+    throw new Error('A release with an N-1 entry may not remain in bootstrap mode')
+  }
+  return foundationVersion
+}
+
+async function packPackage(record, outputDir, temporaryRoot) {
+  if (!npmEntry) throw new Error('Run release packaging through npm so npm_execpath is available')
+  const packageRoot = path.join(repositoryRoot, record.path)
+  const firstRoot = path.join(temporaryRoot, 'pack-a')
+  const secondRoot = path.join(temporaryRoot, 'pack-b')
+  await mkdir(firstRoot, { recursive: true })
+  await mkdir(secondRoot, { recursive: true })
+  const pack = (destination) => {
+    const output = run(
+      process.execPath,
+      [
+        npmEntry,
+        'pack',
+        '--json',
+        '--ignore-scripts',
+        '--pack-destination',
+        destination,
+        packageRoot,
+      ],
+    )
+    const [result] = JSON.parse(output)
+    if (!result?.filename) throw new Error(`${record.name}: npm pack returned no tarball`)
+    return result
+  }
+  const first = pack(firstRoot)
+  const second = pack(secondRoot)
+  if (first.filename !== second.filename) {
+    throw new Error(`${record.name}: repeated npm pack changed the tarball name`)
+  }
+  const firstPath = path.join(firstRoot, first.filename)
+  const secondPath = path.join(secondRoot, second.filename)
+  const firstDigest = await sha256(firstPath)
+  const secondDigest = await sha256(secondPath)
+  if (firstDigest !== secondDigest) {
+    throw new Error(`${record.name}: repeated npm pack was not byte-for-byte deterministic`)
+  }
+  const outputPath = path.join(outputDir, first.filename)
+  await copyFile(firstPath, outputPath)
+  return {
+    name: first.filename,
+    package: record.name,
+    version: record.version,
+    sha256: firstDigest,
+    integrity: first.integrity,
+    shasum: first.shasum,
+    size: (await stat(outputPath)).size,
+  }
+}
+
+function buildSbom(releaseVersion, sourceRef, sourceCommit, packages, artifacts) {
+  const namespaceHash = createHash('sha256')
+    .update(stableJson(artifacts.map((entry) => [entry.name, entry.sha256])))
+    .digest('hex')
+  const relationships = []
+  for (const entry of packages) {
+    const packageJson = entry.packageJson
+    for (const dependency of Object.keys(packageJson.dependencies ?? {})) {
+      if (!packages.some((candidate) => candidate.record.name === dependency)) continue
+      relationships.push({
+        spdxElementId: packageId(entry.record.name),
+        relationshipType: 'DEPENDS_ON',
+        relatedSpdxElement: packageId(dependency),
+      })
+    }
+  }
+  return {
+    spdxVersion: 'SPDX-2.3',
+    dataLicense: 'CC0-1.0',
+    SPDXID: 'SPDXRef-DOCUMENT',
+    name: `OpenSquilla UI Foundation ${releaseVersion}`,
+    documentNamespace: `https://github.com/opensquilla/opensquilla/ui-sbom/${namespaceHash}`,
+    creationInfo: {
+      created: '1980-01-01T00:00:00Z',
+      creators: ['Tool: scripts/build_ui_package_release.mjs'],
+    },
+    documentDescribes: packages.map((entry) => packageId(entry.record.name)),
+    packages: packages.map((entry) => ({
+      SPDXID: packageId(entry.record.name),
+      name: entry.record.name,
+      versionInfo: entry.record.version,
+      downloadLocation: 'NOASSERTION',
+      filesAnalyzed: false,
+      licenseConcluded: 'Apache-2.0',
+      licenseDeclared: 'Apache-2.0',
+      supplier: 'Organization: OpenSquilla',
+      externalRefs: [
+        {
+          referenceCategory: 'PACKAGE-MANAGER',
+          referenceType: 'purl',
+          referenceLocator: `pkg:npm/${encodeURIComponent(entry.record.name)}@${entry.record.version}`,
+        },
+      ],
+      checksums: [
+        {
+          algorithm: 'SHA256',
+          checksumValue: artifacts.find(
+            (artifact) => artifact.package === entry.record.name,
+          ).sha256,
+        },
+      ],
+    })),
+    relationships: [
+      ...packages.map((entry) => ({
+        spdxElementId: 'SPDXRef-DOCUMENT',
+        relationshipType: 'DESCRIBES',
+        relatedSpdxElement: packageId(entry.record.name),
+      })),
+      ...relationships,
+    ],
+    annotations: [
+      {
+        annotationType: 'OTHER',
+        annotator: 'Tool: scripts/build_ui_package_release.mjs',
+        annotationDate: '1980-01-01T00:00:00Z',
+        comment: `Source ${sourceRef} at ${sourceCommit}`,
+      },
+    ],
+  }
+}
+
+function buildProvenance(sourceRef, sourceCommit, releaseVersion, subjects) {
+  return {
+    _type: 'https://in-toto.io/Statement/v1',
+    subject: subjects.map((entry) => ({
+      name: entry.name,
+      digest: { sha256: entry.sha256 },
+    })),
+    predicateType: 'https://slsa.dev/provenance/v1',
+    predicate: {
+      buildDefinition: {
+        buildType: 'https://github.com/opensquilla/opensquilla/ui-foundation-release/v1',
+        externalParameters: {
+          releaseTrain: 'public-ui-foundation',
+          releaseVersion,
+          sourceRef,
+        },
+        internalParameters: {},
+        resolvedDependencies: [
+          {
+            uri: 'git+https://github.com/opensquilla/opensquilla',
+            digest: { gitCommit: sourceCommit },
+          },
+        ],
+      },
+      runDetails: {
+        builder: {
+          id: 'https://github.com/opensquilla/opensquilla/.github/workflows/ui-foundation-release.yml',
+        },
+        metadata: {
+          invocationId: `${sourceRef}@${sourceCommit}`,
+        },
+      },
+    },
+  }
+}
+
+function parseArgs(argv) {
+  const options = {
+    outputDir: null,
+    releaseVersion: null,
+    sourceCommit: process.env.GITHUB_SHA || git('rev-parse', 'HEAD'),
+    sourceRef:
+      process.env.GITHUB_REF_NAME
+      || git('symbolic-ref', '--quiet', '--short', 'HEAD')
+      || 'detached',
+  }
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]
+    if (value === '--output-dir') options.outputDir = path.resolve(argv[++index])
+    else if (value === '--release-version') options.releaseVersion = argv[++index]
+    else if (value === '--source-commit') options.sourceCommit = argv[++index]
+    else if (value === '--source-ref') options.sourceRef = argv[++index]
+    else throw new Error(`Unknown argument: ${value}`)
+  }
+  if (!options.outputDir) throw new Error('--output-dir is required')
+  options.sourceRef = safeRef(options.sourceRef, 'source ref')
+  options.sourceCommit = safeCommit(options.sourceCommit)
+  return options
+}
+
+export async function buildRelease(options) {
+  await assertEmptyOutput(options.outputDir)
+  const temporaryRoot = await mkdtemp(path.join(tmpdir(), 'opensquilla-ui-release-'))
+  try {
+    const manifest = validatePackageManifest(await readJson(manifestPath))
+    const matrix = await readJson(compatibilityMatrixPath)
+    const contract = await readJson(
+      path.join(repositoryRoot, 'contracts', 'client', 'v3', 'contract.json'),
+    )
+    const releaseVersion = validateCompatibilityMatrix(matrix, manifest, contract)
+    if (options.releaseVersion && options.releaseVersion !== releaseVersion) {
+      throw new Error(
+        `requested release ${options.releaseVersion} differs from manifest ${releaseVersion}`,
+      )
+    }
+    const checkedInApi = await readJson(apiReportPath)
+    const generatedApi = await generateApiReport()
+    if (stableJson(checkedInApi) !== stableJson(generatedApi)) {
+      throw new Error('Checked-in UI package API report is stale')
+    }
+
+    const packageMetadata = []
+    const tarballs = []
+    for (const record of manifest.packages) {
+      const packageJson = await readJson(path.join(repositoryRoot, record.path, 'package.json'))
+      if (packageJson.private === true) throw new Error(`${record.name} must be publishable`)
+      if (
+        packageJson.publishConfig?.access !== 'public'
+        || packageJson.publishConfig?.provenance !== true
+      ) {
+        throw new Error(`${record.name} must declare public provenance-enabled publishing`)
+      }
+      packageMetadata.push({ record, packageJson })
+      tarballs.push(await packPackage(record, options.outputDir, temporaryRoot))
+    }
+    const foundationPackage = packageMetadata.find(
+      (entry) => entry.record.name === '@opensquilla/ui-foundation',
+    ).packageJson
+    if (
+      foundationPackage.dependencies?.['@opensquilla/client-sdk']
+      !== matrix.current.clientSdkRange
+    ) {
+      throw new Error(
+        'UI Foundation package dependency differs from the declared Client SDK range',
+      )
+    }
+    const currentSdkVersion = matrix.current.packages['@opensquilla/client-sdk']
+    if (!satisfiesBoundedRange(currentSdkVersion, matrix.current.clientSdkRange)) {
+      throw new Error('Current Client SDK is outside the UI Foundation support range')
+    }
+    if (
+      matrix.previous
+      && !satisfiesBoundedRange(
+        matrix.previous.packages['@opensquilla/client-sdk'],
+        matrix.current.clientSdkRange,
+      )
+    ) {
+      throw new Error('N-1 Client SDK is outside the UI Foundation support range')
+    }
+
+    const prefix = `opensquilla-ui-foundation-${releaseVersion}`
+    const apiName = `${prefix}.api-report.json`
+    await copyFile(apiReportPath, path.join(options.outputDir, apiName))
+    const apiArtifact = {
+      name: apiName,
+      sha256: await sha256(path.join(options.outputDir, apiName)),
+      size: (await stat(path.join(options.outputDir, apiName))).size,
+    }
+
+    const changelogName = `${prefix}.CHANGELOG.md`
+    const changelog = []
+    for (const { record } of packageMetadata) {
+      changelog.push(
+        `## ${record.name}\n`,
+        (await readFile(path.join(repositoryRoot, record.path, 'CHANGELOG.md'), 'utf8')).trim(),
+        '',
+      )
+    }
+    await writeFile(path.join(options.outputDir, changelogName), `${changelog.join('\n')}\n`)
+    const changelogArtifact = {
+      name: changelogName,
+      sha256: await sha256(path.join(options.outputDir, changelogName)),
+      size: (await stat(path.join(options.outputDir, changelogName))).size,
+    }
+
+    const compatibilityName = `${prefix}.compatibility.json`
+    const compatibility = {
+      schemaVersion: 1,
+      policy: matrix.policy,
+      status: matrix.bootstrap ? 'bootstrap-compatible' : 'compatible',
+      current: matrix.current,
+      previous: matrix.previous,
+      requiredCombinations: matrix.bootstrap
+        ? [
+            {
+              uiFoundation: matrix.current.releaseVersion,
+              clientSdk: matrix.current.packages['@opensquilla/client-sdk'],
+              gatewayProtocol: `${matrix.current.gateway.protocolMin}-${matrix.current.gateway.protocolMax}`,
+            },
+          ]
+        : [
+            {
+              uiFoundation: matrix.current.releaseVersion,
+              clientSdk: matrix.current.packages['@opensquilla/client-sdk'],
+              gatewayProtocol: `${matrix.current.gateway.protocolMin}-${matrix.current.gateway.protocolMax}`,
+            },
+            {
+              uiFoundation: matrix.current.releaseVersion,
+              clientSdk: matrix.previous.packages['@opensquilla/client-sdk'],
+              gatewayProtocol: `${matrix.previous.gateway.protocolMin}-${matrix.previous.gateway.protocolMax}`,
+            },
+            {
+              uiFoundation: matrix.previous.releaseVersion,
+              clientSdk: matrix.current.packages['@opensquilla/client-sdk'],
+              gatewayProtocol: `${matrix.current.gateway.protocolMin}-${matrix.current.gateway.protocolMax}`,
+            },
+          ],
+      evidence: [
+        'external-pack-install',
+        'typescript-public-api',
+        'runtime-public-exports',
+        'gateway-current-legacy-and-incompatible',
+        'public-webui-tarball-build',
+      ],
+      failurePolicy: matrix.failurePolicy,
+    }
+    await writeFile(
+      path.join(options.outputDir, compatibilityName),
+      stableJson(compatibility),
+    )
+    const compatibilityArtifact = {
+      name: compatibilityName,
+      sha256: await sha256(path.join(options.outputDir, compatibilityName)),
+      size: (await stat(path.join(options.outputDir, compatibilityName))).size,
+    }
+
+    const sbomName = `${prefix}.sbom.spdx.json`
+    const sbom = buildSbom(
+      releaseVersion,
+      options.sourceRef,
+      options.sourceCommit,
+      packageMetadata,
+      tarballs,
+    )
+    await writeFile(path.join(options.outputDir, sbomName), stableJson(sbom))
+    const sbomArtifact = {
+      name: sbomName,
+      sha256: await sha256(path.join(options.outputDir, sbomName)),
+      size: (await stat(path.join(options.outputDir, sbomName))).size,
+    }
+
+    const provenanceSubjects = [
+      ...tarballs,
+      apiArtifact,
+      changelogArtifact,
+      compatibilityArtifact,
+      sbomArtifact,
+    ]
+    const provenanceName = `${prefix}.provenance.json`
+    await writeFile(
+      path.join(options.outputDir, provenanceName),
+      stableJson(
+        buildProvenance(
+          options.sourceRef,
+          options.sourceCommit,
+          releaseVersion,
+          provenanceSubjects,
+        ),
+      ),
+    )
+    const provenanceArtifact = {
+      name: provenanceName,
+      sha256: await sha256(path.join(options.outputDir, provenanceName)),
+      size: (await stat(path.join(options.outputDir, provenanceName))).size,
+    }
+
+    const releaseManifestName = `${prefix}.manifest.json`
+    const releaseManifest = {
+      schemaVersion: 1,
+      releaseTrain: manifest.releaseTrain,
+      releaseVersion,
+      immutable: true,
+      source: {
+        repository: 'opensquilla/opensquilla',
+        ref: options.sourceRef,
+        commit: options.sourceCommit,
+      },
+      packages: tarballs.map((entry) => ({
+        name: entry.package,
+        version: entry.version,
+        tarball: entry.name,
+        sha256: entry.sha256,
+        integrity: entry.integrity,
+        size: entry.size,
+      })),
+      compatibility: {
+        policy: matrix.policy,
+        report: compatibilityName,
+        status: compatibility.status,
+      },
+      artifacts: [
+        ...tarballs,
+        apiArtifact,
+        changelogArtifact,
+        compatibilityArtifact,
+        sbomArtifact,
+        provenanceArtifact,
+      ].map(({ name, sha256: digest, size }) => ({ name, sha256: digest, size })),
+    }
+    await writeFile(
+      path.join(options.outputDir, releaseManifestName),
+      stableJson(releaseManifest),
+    )
+    const manifestArtifact = {
+      name: releaseManifestName,
+      sha256: await sha256(path.join(options.outputDir, releaseManifestName)),
+      size: (await stat(path.join(options.outputDir, releaseManifestName))).size,
+    }
+
+    const sumsName = `SHA256SUMS.ui-foundation-${releaseVersion}`
+    const sums = [...releaseManifest.artifacts, manifestArtifact]
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .map((entry) => `${entry.sha256}  ${entry.name}`)
+      .join('\n')
+    await writeFile(path.join(options.outputDir, sumsName), `${sums}\n`)
+    console.log(
+      `Built ${tarballs.length} immutable UI package tarballs for ${releaseVersion}`,
+    )
+    return {
+      releaseVersion,
+      manifest: path.join(options.outputDir, releaseManifestName),
+      checksums: path.join(options.outputDir, sumsName),
+      tarballs,
+    }
+  } catch (error) {
+    await rm(options.outputDir, { recursive: true, force: true })
+    throw error
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true })
+  }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  return buildRelease(parseArgs(argv))
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error(`UI package release build failed: ${error.message}`)
+    process.exitCode = 1
+  })
+}

--- a/scripts/check_ui_package_compat.mjs
+++ b/scripts/check_ui_package_compat.mjs
@@ -1,0 +1,296 @@
+import { execFileSync } from 'node:child_process'
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  apiReportPath,
+  readJson,
+  repositoryRoot,
+  stableJson,
+} from './ui_package_api.mjs'
+
+export function parseSemver(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(value)
+  if (!match) throw new Error(`Invalid semantic version: ${value}`)
+  return {
+    raw: value,
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ?? null,
+  }
+}
+
+function compareVersion(left, right) {
+  for (const key of ['major', 'minor', 'patch']) {
+    if (left[key] !== right[key]) return left[key] < right[key] ? -1 : 1
+  }
+  if (left.prerelease === right.prerelease) return 0
+  if (left.prerelease === null) return 1
+  if (right.prerelease === null) return -1
+  return left.prerelease.localeCompare(right.prerelease)
+}
+
+function requiredBump(oldVersion, newVersion, severity) {
+  if (severity === 'unchanged') return compareVersion(newVersion, oldVersion) >= 0
+  if (severity === 'additive') {
+    return (
+      newVersion.major > oldVersion.major
+      || (
+        newVersion.major === oldVersion.major
+        && newVersion.minor > oldVersion.minor
+      )
+    )
+  }
+  if (oldVersion.major === 0) {
+    return (
+      newVersion.major > 0
+      || (
+        newVersion.major === 0
+        && newVersion.minor > oldVersion.minor
+      )
+    )
+  }
+  return newVersion.major > oldVersion.major
+}
+
+function changesBetween(oldValues, newValues, kind) {
+  const previous = new Set(oldValues)
+  const current = new Set(newValues)
+  return [
+    ...[...previous].filter((value) => !current.has(value)).map((value) => ({
+      severity: 'breaking',
+      code: `${kind}-removed`,
+      target: value,
+    })),
+    ...[...current].filter((value) => !previous.has(value)).map((value) => ({
+      severity: 'additive',
+      code: `${kind}-added`,
+      target: value,
+    })),
+  ]
+}
+
+function compareSignatures(previous, current) {
+  const oldValues = new Map(previous.map((entry) => [entry.key, entry.signature]))
+  const newValues = new Map(current.map((entry) => [entry.key, entry.signature]))
+  const changes = []
+  for (const [key, signature] of oldValues) {
+    if (!newValues.has(key)) {
+      changes.push({ severity: 'breaking', code: 'declaration-removed', target: key })
+    } else if (newValues.get(key) !== signature) {
+      changes.push({ severity: 'breaking', code: 'declaration-changed', target: key })
+    }
+  }
+  for (const key of newValues.keys()) {
+    if (!oldValues.has(key)) {
+      changes.push({ severity: 'additive', code: 'declaration-added', target: key })
+    }
+  }
+  return changes
+}
+
+function removalAllowed(previous, current, exportName) {
+  const deprecation = previous.deprecations.find((entry) => entry.export === exportName)
+  if (!deprecation) return false
+  return compareVersion(
+    parseSemver(current.version),
+    parseSemver(deprecation.removeAfter),
+  ) >= 0
+}
+
+function packageSeverity(changes) {
+  if (changes.some((change) => change.severity === 'breaking')) return 'breaking'
+  if (changes.some((change) => change.severity === 'additive')) return 'additive'
+  return 'unchanged'
+}
+
+export function compareApiReports(previous, current) {
+  if (!previous) {
+    return {
+      schemaVersion: 1,
+      policy: current.compatibilityPolicy,
+      status: 'bootstrap',
+      blocking: false,
+      packages: current.packages.map((entry) => ({
+        name: entry.name,
+        previousVersion: null,
+        currentVersion: entry.version,
+        severity: 'bootstrap',
+        changes: [],
+        errors: [],
+      })),
+      errors: [],
+    }
+  }
+  if (previous.schemaVersion !== 1 || current.schemaVersion !== 1) {
+    throw new Error('Unsupported UI package API report schema')
+  }
+  const previousPackages = new Map(previous.packages.map((entry) => [entry.name, entry]))
+  const currentPackages = new Map(current.packages.map((entry) => [entry.name, entry]))
+  const packageReports = []
+  const errors = []
+
+  for (const [name, oldPackage] of previousPackages) {
+    const newPackage = currentPackages.get(name)
+    if (!newPackage) {
+      const message = `${name} was removed from the public release train`
+      errors.push(message)
+      packageReports.push({
+        name,
+        previousVersion: oldPackage.version,
+        currentVersion: null,
+        severity: 'breaking',
+        changes: [{ severity: 'breaking', code: 'package-removed', target: name }],
+        errors: [message],
+      })
+      continue
+    }
+    const changes = [
+      ...changesBetween(oldPackage.publicExports, newPackage.publicExports, 'package-path'),
+      ...changesBetween(oldPackage.apiExports, newPackage.apiExports, 'api-export'),
+      ...changesBetween(oldPackage.runtimeExports, newPackage.runtimeExports, 'runtime-export'),
+      ...compareSignatures(oldPackage.declarations, newPackage.declarations),
+    ]
+    const reportErrors = []
+    for (const change of changes) {
+      if (
+        change.severity === 'breaking'
+        && ['api-export-removed', 'runtime-export-removed'].includes(change.code)
+        && !removalAllowed(oldPackage, newPackage, change.target)
+      ) {
+        reportErrors.push(
+          `${name} removed ${change.target} without a completed deprecation window`,
+        )
+      }
+    }
+    const severity = packageSeverity(changes)
+    const oldVersion = parseSemver(oldPackage.version)
+    const newVersion = parseSemver(newPackage.version)
+    if (compareVersion(newVersion, oldVersion) < 0) {
+      reportErrors.push(`${name} version moved backwards`)
+    } else if (!requiredBump(oldVersion, newVersion, severity)) {
+      reportErrors.push(
+        `${name} ${severity} API change requires a larger semantic-version bump`,
+      )
+    }
+    packageReports.push({
+      name,
+      previousVersion: oldPackage.version,
+      currentVersion: newPackage.version,
+      severity,
+      changes,
+      errors: reportErrors,
+    })
+    errors.push(...reportErrors)
+  }
+
+  for (const [name, entry] of currentPackages) {
+    if (previousPackages.has(name)) continue
+    packageReports.push({
+      name,
+      previousVersion: null,
+      currentVersion: entry.version,
+      severity: 'additive',
+      changes: [{ severity: 'additive', code: 'package-added', target: name }],
+      errors: [],
+    })
+  }
+
+  const severities = packageReports.map((entry) => entry.severity)
+  const status = severities.includes('breaking')
+    ? 'breaking'
+    : severities.includes('additive')
+      ? 'additive'
+      : 'unchanged'
+  return {
+    schemaVersion: 1,
+    policy: current.compatibilityPolicy,
+    status,
+    blocking: errors.length > 0,
+    packages: packageReports.sort((left, right) => left.name.localeCompare(right.name)),
+    errors,
+  }
+}
+
+function loadGitReport(ref) {
+  try {
+    execFileSync(
+      'git',
+      ['-C', repositoryRoot, 'rev-parse', '--verify', `${ref}^{commit}`],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+  } catch {
+    throw new Error(`Unable to resolve UI package API baseline ref ${ref}`)
+  }
+  try {
+    const content = execFileSync(
+      'git',
+      ['-C', repositoryRoot, 'show', `${ref}:contracts/ui-foundation/v1/api-report.json`],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    return JSON.parse(content)
+  } catch (error) {
+    if (
+      error.status === 128
+      && /(?:does not exist in|exists on disk, but not in)/.test(error.stderr ?? '')
+    ) {
+      return null
+    }
+    throw error
+  }
+}
+
+function parseArgs(argv) {
+  const options = {
+    allowBootstrap: false,
+    baseline: null,
+    baselineRef: null,
+    candidate: apiReportPath,
+    output: null,
+  }
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]
+    if (value === '--allow-bootstrap') options.allowBootstrap = true
+    else if (value === '--baseline') options.baseline = path.resolve(argv[++index])
+    else if (value === '--baseline-ref') options.baselineRef = argv[++index]
+    else if (value === '--candidate') options.candidate = path.resolve(argv[++index])
+    else if (value === '--output') options.output = path.resolve(argv[++index])
+    else throw new Error(`Unknown argument: ${value}`)
+  }
+  if (options.baseline && options.baselineRef) {
+    throw new Error('--baseline and --baseline-ref are mutually exclusive')
+  }
+  return options
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv)
+  const current = await readJson(options.candidate)
+  const previous = options.baseline
+    ? await readJson(options.baseline)
+    : options.baselineRef
+      ? loadGitReport(options.baselineRef)
+      : null
+  if (!previous && !options.allowBootstrap) {
+    throw new Error('A UI package API baseline is required unless --allow-bootstrap is explicit')
+  }
+  const report = compareApiReports(previous, current)
+  if (options.output) await writeFile(options.output, stableJson(report))
+  console.log(
+    `UI package compatibility: ${report.status}; blocking=${String(report.blocking)}`,
+  )
+  if (report.blocking) {
+    for (const error of report.errors) console.error(`ERROR: ${error}`)
+    process.exitCode = 2
+  }
+  return report
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error(`UI package compatibility check failed: ${error.message}`)
+    process.exitCode = 1
+  })
+}

--- a/scripts/install_ui_package_release.mjs
+++ b/scripts/install_ui_package_release.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { lstat, readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const webuiRoot = path.join(repositoryRoot, 'opensquilla-webui')
+const npmEntry = process.env.npm_execpath
+
+async function sha256(source) {
+  const hash = createHash('sha256')
+  hash.update(await readFile(source))
+  return hash.digest('hex')
+}
+
+function parseArgs(argv) {
+  if (argv.length !== 2 || argv[0] !== '--artifacts-dir') {
+    throw new Error('usage: install_ui_package_release.mjs --artifacts-dir <directory>')
+  }
+  return path.resolve(argv[1])
+}
+
+async function main(argv = process.argv.slice(2)) {
+  if (!npmEntry) throw new Error('Run tarball installation through npm')
+  const directory = parseArgs(argv)
+  const manifests = (await readdir(directory))
+    .filter((entry) => /^opensquilla-ui-foundation-.+\.manifest\.json$/.test(entry))
+  assert.equal(manifests.length, 1, 'expected one UI release manifest')
+  const manifest = JSON.parse(await readFile(path.join(directory, manifests[0]), 'utf8'))
+  assert.equal(manifest.immutable, true)
+  const tarballs = []
+  for (const entry of manifest.packages) {
+    assert.equal(path.basename(entry.tarball), entry.tarball)
+    const tarball = path.join(directory, entry.tarball)
+    assert.equal(await sha256(tarball), entry.sha256, `${entry.name}: SHA-256 mismatch`)
+    tarballs.push(tarball)
+  }
+  const result = spawnSync(
+    process.execPath,
+    [
+      npmEntry,
+      'install',
+      '--ignore-scripts',
+      '--no-save',
+      '--package-lock=false',
+      ...tarballs,
+    ],
+    {
+      cwd: webuiRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        npm_config_audit: 'false',
+        npm_config_fund: 'false',
+      },
+    },
+  )
+  if (result.status !== 0) {
+    throw new Error(
+      ['unable to install release tarballs into public WebUI', result.stdout, result.stderr]
+        .filter(Boolean)
+        .join('\n'),
+    )
+  }
+  for (const entry of manifest.packages) {
+    const installedRoot = path.join(webuiRoot, 'node_modules', ...entry.name.split('/'))
+    assert.equal((await lstat(installedRoot)).isSymbolicLink(), false)
+    const packageJson = JSON.parse(
+      await readFile(path.join(installedRoot, 'package.json'), 'utf8'),
+    )
+    assert.equal(packageJson.version, entry.version)
+  }
+  console.log(
+    `Installed ${manifest.packages.length} immutable release tarballs into the public WebUI`,
+  )
+}
+
+main().catch((error) => {
+  console.error(`UI package release installation failed: ${error.message}`)
+  process.exitCode = 1
+})

--- a/scripts/tests/ui_package_compat.test.mjs
+++ b/scripts/tests/ui_package_compat.test.mjs
@@ -5,7 +5,10 @@ import {
   compareApiReports,
   parseSemver,
 } from '../check_ui_package_compat.mjs'
-import { compareStableText } from '../ui_package_api.mjs'
+import {
+  canonicalJsonText,
+  compareStableText,
+} from '../ui_package_api.mjs'
 
 function packageReport(overrides = {}) {
   return {
@@ -51,6 +54,13 @@ test('API declaration ordering uses locale-independent code points', () => {
     'gateway/client.d.ts#A',
     'gateway/client.d.ts#z',
   ])
+})
+
+test('API report comparison ignores checkout line-ending conversion', () => {
+  assert.equal(
+    canonicalJsonText('{\r\n  "schemaVersion": 1\r\n}\r\n'),
+    '{\n  "schemaVersion": 1\n}\n',
+  )
 })
 
 test('bootstrap is explicit and non-blocking', () => {

--- a/scripts/tests/ui_package_compat.test.mjs
+++ b/scripts/tests/ui_package_compat.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  compareApiReports,
+  parseSemver,
+} from '../check_ui_package_compat.mjs'
+
+function packageReport(overrides = {}) {
+  return {
+    name: '@opensquilla/ui-foundation',
+    version: '0.1.0',
+    releaseGroup: 'ui-foundation',
+    publicExports: ['.'],
+    apiExports: ['createOpenSquillaApp'],
+    runtimeExports: ['createOpenSquillaApp'],
+    declarationsDigest: 'sha256:fixture',
+    declarations: [
+      {
+        key: 'index.d.ts#FunctionDeclaration:createOpenSquillaApp',
+        signature: 'export declare function createOpenSquillaApp(): unknown;',
+      },
+    ],
+    deprecations: [],
+    ...overrides,
+  }
+}
+
+function report(entry = packageReport()) {
+  return {
+    schemaVersion: 1,
+    generatedBy: 'fixture',
+    releaseTrain: 'public-ui-foundation',
+    versionPolicy: 'release-groups',
+    compatibilityPolicy: 'current-and-previous-minor',
+    packages: [entry],
+  }
+}
+
+test('bootstrap is explicit and non-blocking', () => {
+  const result = compareApiReports(null, report())
+  assert.equal(result.status, 'bootstrap')
+  assert.equal(result.blocking, false)
+})
+
+test('unchanged APIs may retain the same version', () => {
+  const result = compareApiReports(report(), report())
+  assert.equal(result.status, 'unchanged')
+  assert.equal(result.blocking, false)
+})
+
+test('additive APIs require a minor version bump', () => {
+  const current = packageReport({
+    apiExports: ['createOpenSquillaApp', 'createProductComposition'],
+    runtimeExports: ['createOpenSquillaApp', 'createProductComposition'],
+    declarations: [
+      ...packageReport().declarations,
+      {
+        key: 'index.d.ts#FunctionDeclaration:createProductComposition',
+        signature: 'export declare function createProductComposition(): unknown;',
+      },
+    ],
+  })
+  const blocked = compareApiReports(report(), report(current))
+  assert.equal(blocked.status, 'additive')
+  assert.equal(blocked.blocking, true)
+  assert.match(blocked.errors[0], /semantic-version bump/)
+
+  const accepted = compareApiReports(
+    report(),
+    report({ ...current, version: '0.2.0' }),
+  )
+  assert.equal(accepted.blocking, false)
+})
+
+test('changed declarations are breaking for pre-1.0 packages', () => {
+  const result = compareApiReports(
+    report(),
+    report(packageReport({
+      version: '0.2.0',
+      declarations: [
+        {
+          key: 'index.d.ts#FunctionDeclaration:createOpenSquillaApp',
+          signature: 'export declare function createOpenSquillaApp(required: string): unknown;',
+        },
+      ],
+    })),
+  )
+  assert.equal(result.status, 'breaking')
+  assert.equal(result.blocking, false)
+})
+
+test('removed exports require a completed deprecation window', () => {
+  const previous = packageReport({
+    deprecations: [
+      {
+        export: 'createOpenSquillaApp',
+        since: '0.1.0',
+        removeAfter: '0.2.0',
+        replacement: 'createProductComposition',
+      },
+    ],
+  })
+  const current = packageReport({
+    version: '0.2.0',
+    apiExports: [],
+    runtimeExports: [],
+    declarations: [],
+  })
+  const accepted = compareApiReports(report(previous), report(current))
+  assert.equal(accepted.status, 'breaking')
+  assert.equal(accepted.blocking, false)
+
+  const blocked = compareApiReports(
+    report(packageReport()),
+    report(current),
+  )
+  assert.equal(blocked.blocking, true)
+  assert.ok(blocked.errors.some((entry) => entry.includes('deprecation window')))
+})
+
+test('semantic versions are parsed without accepting loose values', () => {
+  assert.deepEqual(parseSemver('1.2.3'), {
+    raw: '1.2.3',
+    major: 1,
+    minor: 2,
+    patch: 3,
+    prerelease: null,
+  })
+  assert.throws(() => parseSemver('v1.2.3'), /Invalid semantic version/)
+})

--- a/scripts/tests/ui_package_compat.test.mjs
+++ b/scripts/tests/ui_package_compat.test.mjs
@@ -5,6 +5,7 @@ import {
   compareApiReports,
   parseSemver,
 } from '../check_ui_package_compat.mjs'
+import { compareStableText } from '../ui_package_api.mjs'
 
 function packageReport(overrides = {}) {
   return {
@@ -36,6 +37,21 @@ function report(entry = packageReport()) {
     packages: [entry],
   }
 }
+
+test('API declaration ordering uses locale-independent code points', () => {
+  const entries = [
+    'components/button.d.ts',
+    'components/UiButton.vue.d.ts',
+    'gateway/client.d.ts#z',
+    'gateway/client.d.ts#A',
+  ]
+  assert.deepEqual([...entries].sort(compareStableText), [
+    'components/UiButton.vue.d.ts',
+    'components/button.d.ts',
+    'gateway/client.d.ts#A',
+    'gateway/client.d.ts#z',
+  ])
+})
 
 test('bootstrap is explicit and non-blocking', () => {
   const result = compareApiReports(null, report())

--- a/scripts/ui_package_api.mjs
+++ b/scripts/ui_package_api.mjs
@@ -166,6 +166,11 @@ function normalizedNodeText(node, sourceFile) {
   return node.getText(sourceFile).replace(/\s+/g, ' ').trim()
 }
 
+export function compareStableText(left, right) {
+  if (left === right) return 0
+  return left < right ? -1 : 1
+}
+
 function declarationKey(node, sourceFile, index) {
   if (node.name && typeof node.name.getText === 'function') {
     return `${ts.SyntaxKind[node.kind]}:${node.name.getText(sourceFile)}`
@@ -207,7 +212,7 @@ async function extractDeclarations(packageRoot) {
       })
     })
   }
-  return signatures.sort((left, right) => left.key.localeCompare(right.key))
+  return signatures.sort((left, right) => compareStableText(left.key, right.key))
 }
 
 function compilerOptions() {

--- a/scripts/ui_package_api.mjs
+++ b/scripts/ui_package_api.mjs
@@ -30,6 +30,10 @@ export function stableJson(value) {
   return `${JSON.stringify(value, null, 2)}\n`
 }
 
+export function canonicalJsonText(source) {
+  return stableJson(JSON.parse(source))
+}
+
 function semver(value, label) {
   const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(value)
   if (!match) throw new Error(`${label} must use a valid semantic version`)
@@ -323,7 +327,7 @@ export async function main(argv = process.argv.slice(2)) {
   const options = parseArgs(argv)
   const generated = stableJson(await generateApiReport())
   if (options.check) {
-    const checkedIn = await readFile(options.output, 'utf8')
+    const checkedIn = canonicalJsonText(await readFile(options.output, 'utf8'))
     if (checkedIn !== generated) {
       throw new Error(
         `UI package API report is stale; run node scripts/ui_package_api.mjs --write`,

--- a/scripts/ui_package_api.mjs
+++ b/scripts/ui_package_api.mjs
@@ -1,0 +1,340 @@
+import { createHash } from 'node:crypto'
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL, fileURLToPath } from 'node:url'
+
+import ts from 'typescript'
+
+export const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+)
+export const manifestPath = path.join(
+  repositoryRoot,
+  'packages',
+  'ui-package-manifest.json',
+)
+export const apiReportPath = path.join(
+  repositoryRoot,
+  'contracts',
+  'ui-foundation',
+  'v1',
+  'api-report.json',
+)
+
+export async function readJson(source) {
+  return JSON.parse(await readFile(source, 'utf8'))
+}
+
+export function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`
+}
+
+function semver(value, label) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(value)
+  if (!match) throw new Error(`${label} must use a valid semantic version`)
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ?? null,
+  }
+}
+
+function compareSemver(left, right) {
+  for (const key of ['major', 'minor', 'patch']) {
+    if (left[key] !== right[key]) return left[key] < right[key] ? -1 : 1
+  }
+  if (left.prerelease === right.prerelease) return 0
+  if (left.prerelease === null) return 1
+  if (right.prerelease === null) return -1
+  return left.prerelease.localeCompare(right.prerelease)
+}
+
+function assertStringList(value, label) {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`${label} must be an array of strings`)
+  }
+}
+
+export function validatePackageManifest(manifest) {
+  if (manifest.schemaVersion !== 2) {
+    throw new Error('UI package manifest schemaVersion must be 2')
+  }
+  if (manifest.releaseTrain !== 'public-ui-foundation') {
+    throw new Error('Unexpected UI package release train')
+  }
+  if (manifest.versionPolicy !== 'release-groups') {
+    throw new Error('UI packages must use release-group versioning')
+  }
+  if (manifest.compatibilityPolicy !== 'current-and-previous-minor') {
+    throw new Error('UI package compatibility window must be current-and-previous-minor')
+  }
+  if (!Array.isArray(manifest.releaseGroups) || manifest.releaseGroups.length !== 2) {
+    throw new Error('UI package manifest must declare the SDK and Foundation release groups')
+  }
+  if (!Array.isArray(manifest.packages) || manifest.packages.length !== 4) {
+    throw new Error('UI package manifest must declare all four public packages')
+  }
+
+  const records = new Map()
+  for (const record of manifest.packages) {
+    if (!record || typeof record !== 'object') throw new Error('Invalid package record')
+    if (typeof record.name !== 'string' || !record.name.startsWith('@opensquilla/')) {
+      throw new Error('Public package names must use the @opensquilla scope')
+    }
+    if (records.has(record.name)) throw new Error(`Duplicate package ${record.name}`)
+    if (typeof record.path !== 'string' || !record.path.startsWith('packages/')) {
+      throw new Error(`${record.name} has an invalid package path`)
+    }
+    semver(record.version, `${record.name} version`)
+    assertStringList(record.publicExports, `${record.name} publicExports`)
+    if (!Array.isArray(record.deprecations)) {
+      throw new Error(`${record.name} must declare its deprecation inventory`)
+    }
+    for (const deprecation of record.deprecations) {
+      if (
+        !deprecation
+        || typeof deprecation !== 'object'
+        || typeof deprecation.export !== 'string'
+        || typeof deprecation.since !== 'string'
+        || typeof deprecation.removeAfter !== 'string'
+        || typeof deprecation.replacement !== 'string'
+      ) {
+        throw new Error(`${record.name} contains an invalid deprecation record`)
+      }
+      const since = semver(deprecation.since, `${record.name} deprecation since`)
+      const removeAfter = semver(
+        deprecation.removeAfter,
+        `${record.name} deprecation removeAfter`,
+      )
+      if (compareSemver(removeAfter, since) <= 0) {
+        throw new Error(
+          `${record.name} deprecation removeAfter must be later than since`,
+        )
+      }
+    }
+    records.set(record.name, record)
+  }
+
+  const assigned = new Set()
+  for (const group of manifest.releaseGroups) {
+    if (!group || typeof group !== 'object' || typeof group.id !== 'string') {
+      throw new Error('Invalid release group')
+    }
+    if (!['fixed', 'independent'].includes(group.versionPolicy)) {
+      throw new Error(`${group.id} has an invalid version policy`)
+    }
+    assertStringList(group.packages, `${group.id} packages`)
+    const versions = new Set()
+    for (const packageName of group.packages) {
+      const record = records.get(packageName)
+      if (!record) throw new Error(`${group.id} references unknown package ${packageName}`)
+      if (record.releaseGroup !== group.id) {
+        throw new Error(`${packageName} releaseGroup does not match ${group.id}`)
+      }
+      if (assigned.has(packageName)) {
+        throw new Error(`${packageName} belongs to more than one release group`)
+      }
+      assigned.add(packageName)
+      versions.add(record.version)
+    }
+    if (group.versionPolicy === 'fixed' && versions.size !== 1) {
+      throw new Error(`${group.id} packages must share one version`)
+    }
+  }
+  if (assigned.size !== records.size) {
+    throw new Error('Every public package must belong to exactly one release group')
+  }
+  return manifest
+}
+
+async function declarationFiles(root) {
+  const files = []
+  async function visit(directory) {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const source = path.join(directory, entry.name)
+      if (entry.isDirectory()) await visit(source)
+      else if (entry.isFile() && entry.name.endsWith('.d.ts')) files.push(source)
+    }
+  }
+  await visit(root)
+  return files.sort()
+}
+
+function normalizedNodeText(node, sourceFile) {
+  return node.getText(sourceFile).replace(/\s+/g, ' ').trim()
+}
+
+function declarationKey(node, sourceFile, index) {
+  if (node.name && typeof node.name.getText === 'function') {
+    return `${ts.SyntaxKind[node.kind]}:${node.name.getText(sourceFile)}`
+  }
+  if (ts.isVariableStatement(node)) {
+    const names = node.declarationList.declarations
+      .map((declaration) => declaration.name.getText(sourceFile))
+      .join(',')
+    return `VariableStatement:${names}`
+  }
+  if (ts.isExportDeclaration(node)) {
+    const target = node.moduleSpecifier?.getText(sourceFile) ?? ''
+    const clause = node.exportClause?.getText(sourceFile) ?? '*'
+    return `ExportDeclaration:${clause}:${target}`
+  }
+  if (ts.isExportAssignment(node)) return 'ExportAssignment:default'
+  return `${ts.SyntaxKind[node.kind]}:${index}`
+}
+
+async function extractDeclarations(packageRoot) {
+  const distRoot = path.join(packageRoot, 'dist')
+  const signatures = []
+  for (const source of await declarationFiles(distRoot)) {
+    const relative = path.relative(distRoot, source).split(path.sep).join('/')
+    const text = await readFile(source, 'utf8')
+    const sourceFile = ts.createSourceFile(
+      relative,
+      text,
+      ts.ScriptTarget.ES2022,
+      true,
+      ts.ScriptKind.TS,
+    )
+    sourceFile.statements.forEach((node, index) => {
+      const signature = normalizedNodeText(node, sourceFile)
+      if (!signature) return
+      signatures.push({
+        key: `${relative}#${declarationKey(node, sourceFile, index)}`,
+        signature,
+      })
+    })
+  }
+  return signatures.sort((left, right) => left.key.localeCompare(right.key))
+}
+
+function compilerOptions() {
+  return {
+    allowJs: false,
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.ES2022,
+  }
+}
+
+function extractApiExports(entrypoint) {
+  const program = ts.createProgram([entrypoint], compilerOptions())
+  const checker = program.getTypeChecker()
+  const source = program.getSourceFile(entrypoint)
+  if (!source) throw new Error(`Unable to load declaration entrypoint ${entrypoint}`)
+  const symbol = checker.getSymbolAtLocation(source)
+  if (!symbol) throw new Error(`Unable to resolve declaration module ${entrypoint}`)
+  return checker.getExportsOfModule(symbol)
+    .map((entry) => entry.getName())
+    .sort()
+}
+
+async function extractRuntimeExports(packageRoot) {
+  const entrypoint = path.join(packageRoot, 'dist', 'index.js')
+  const module = await import(`${pathToFileURL(entrypoint).href}?api-report=1`)
+  return Object.keys(module).sort()
+}
+
+function digestSignatures(signatures) {
+  const hash = createHash('sha256')
+  for (const entry of signatures) {
+    hash.update(entry.key)
+    hash.update('\0')
+    hash.update(entry.signature)
+    hash.update('\0')
+  }
+  return `sha256:${hash.digest('hex')}`
+}
+
+export async function generateApiReport(root = repositoryRoot) {
+  const manifest = validatePackageManifest(
+    await readJson(path.join(root, 'packages', 'ui-package-manifest.json')),
+  )
+  const packages = []
+  for (const record of manifest.packages) {
+    const packageRoot = path.join(root, record.path)
+    const packageJson = await readJson(path.join(packageRoot, 'package.json'))
+    if (packageJson.name !== record.name || packageJson.version !== record.version) {
+      throw new Error(`${record.name} manifest and package.json metadata differ`)
+    }
+    const publicExports = Object.keys(packageJson.exports)
+    if (JSON.stringify(publicExports) !== JSON.stringify(record.publicExports)) {
+      throw new Error(`${record.name} public exports differ from the package manifest`)
+    }
+    const signatures = await extractDeclarations(packageRoot)
+    const apiExports = extractApiExports(path.join(packageRoot, 'dist', 'index.d.ts'))
+    const runtimeExports = await extractRuntimeExports(packageRoot)
+    for (const deprecation of record.deprecations) {
+      if (!apiExports.includes(deprecation.export)) {
+        throw new Error(
+          `${record.name} deprecates unknown public export ${deprecation.export}`,
+        )
+      }
+    }
+    if (
+      record.runtimeExports
+      && JSON.stringify([...record.runtimeExports].sort()) !== JSON.stringify(runtimeExports)
+    ) {
+      throw new Error(`${record.name} runtime exports differ from the package manifest`)
+    }
+    packages.push({
+      name: record.name,
+      version: record.version,
+      releaseGroup: record.releaseGroup,
+      publicExports,
+      apiExports,
+      runtimeExports,
+      declarationsDigest: digestSignatures(signatures),
+      declarations: signatures,
+      deprecations: record.deprecations,
+    })
+  }
+  return {
+    schemaVersion: 1,
+    generatedBy: 'scripts/ui_package_api.mjs',
+    releaseTrain: manifest.releaseTrain,
+    versionPolicy: manifest.versionPolicy,
+    compatibilityPolicy: manifest.compatibilityPolicy,
+    packages,
+  }
+}
+
+function parseArgs(argv) {
+  const options = { check: false, output: apiReportPath }
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]
+    if (value === '--check') options.check = true
+    else if (value === '--write') options.check = false
+    else if (value === '--output') options.output = path.resolve(argv[++index])
+    else throw new Error(`Unknown argument: ${value}`)
+  }
+  return options
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv)
+  const generated = stableJson(await generateApiReport())
+  if (options.check) {
+    const checkedIn = await readFile(options.output, 'utf8')
+    if (checkedIn !== generated) {
+      throw new Error(
+        `UI package API report is stale; run node scripts/ui_package_api.mjs --write`,
+      )
+    }
+    console.log(`Verified UI package API report: ${path.relative(repositoryRoot, options.output)}`)
+    return
+  }
+  await mkdir(path.dirname(options.output), { recursive: true })
+  await writeFile(options.output, generated)
+  console.log(`Wrote UI package API report: ${path.relative(repositoryRoot, options.output)}`)
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error(`UI package API report failed: ${error.message}`)
+    process.exitCode = 1
+  })
+}

--- a/scripts/verify_ui_package_release.mjs
+++ b/scripts/verify_ui_package_release.mjs
@@ -1,0 +1,411 @@
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import {
+  copyFile,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { buildRelease } from './build_ui_package_release.mjs'
+import { readJson, repositoryRoot } from './ui_package_api.mjs'
+
+const npmEntry = process.env.npm_execpath
+const fixtureRoot = path.join(
+  repositoryRoot,
+  'tests',
+  'fixtures',
+  'ui-package-consumer',
+)
+
+function run(command, args, cwd, extraEnv = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      npm_config_audit: 'false',
+      npm_config_fund: 'false',
+      ...extraEnv,
+    },
+  })
+  if (result.status !== 0) {
+    throw new Error(
+      [`${path.basename(command)} ${args.join(' ')} failed`, result.stdout, result.stderr]
+        .filter(Boolean)
+        .join('\n'),
+    )
+  }
+  return result.stdout
+}
+
+function npm(args, cwd) {
+  if (!npmEntry) throw new Error('Run release verification through npm')
+  return run(process.execPath, [npmEntry, ...args], cwd)
+}
+
+async function sha256(source) {
+  const hash = createHash('sha256')
+  hash.update(await readFile(source))
+  return hash.digest('hex')
+}
+
+async function findReleaseManifest(directory) {
+  const candidates = (await readdir(directory))
+    .filter((entry) => /^opensquilla-ui-foundation-.+\.manifest\.json$/.test(entry))
+  assert.equal(candidates.length, 1, 'release directory must contain exactly one manifest')
+  return path.join(directory, candidates[0])
+}
+
+async function verifyChecksums(directory, manifest) {
+  for (const artifact of manifest.artifacts) {
+    const source = path.join(directory, artifact.name)
+    assert.equal(await sha256(source), artifact.sha256, `${artifact.name}: SHA-256 mismatch`)
+    assert.equal((await stat(source)).size, artifact.size, `${artifact.name}: size mismatch`)
+  }
+  const manifestPath = await findReleaseManifest(directory)
+  const sumsPath = path.join(
+    directory,
+    `SHA256SUMS.ui-foundation-${manifest.releaseVersion}`,
+  )
+  const expected = new Map(
+    (await readFile(sumsPath, 'utf8')).trim().split('\n').map((line) => {
+      const match = /^([0-9a-f]{64})  ([^/\\]+)$/.exec(line)
+      assert.ok(match, `invalid checksum line: ${line}`)
+      return [match[2], match[1]]
+    }),
+  )
+  for (const artifact of [...manifest.artifacts, {
+    name: path.basename(manifestPath),
+    sha256: await sha256(manifestPath),
+  }]) {
+    assert.equal(expected.get(artifact.name), artifact.sha256)
+  }
+  assert.equal(expected.size, manifest.artifacts.length + 1)
+}
+
+async function createVuePeer(temporaryRoot) {
+  const peerRoot = path.join(temporaryRoot, 'vue-peer')
+  await mkdir(peerRoot, { recursive: true })
+  await writeFile(
+    path.join(peerRoot, 'package.json'),
+    JSON.stringify({
+      name: 'vue',
+      version: '3.5.0',
+      type: 'module',
+      exports: { '.': { types: './index.d.ts', import: './index.js' } },
+      files: ['index.d.ts', 'index.js'],
+    }),
+  )
+  await writeFile(
+    path.join(peerRoot, 'index.js'),
+    [
+      'const passthrough = (...values) => values[0] ?? {}',
+      'export const Teleport = {}',
+      'export const Transition = {}',
+      'export const computed = passthrough',
+      'export const createBlock = passthrough',
+      'export const createCommentVNode = passthrough',
+      'export const createElementBlock = passthrough',
+      'export const createElementVNode = passthrough',
+      'export const createTextVNode = passthrough',
+      'export const createVNode = passthrough',
+      'export const defineComponent = passthrough',
+      'export const getCurrentInstance = () => undefined',
+      'export const getCurrentScope = () => undefined',
+      'export const mergeProps = passthrough',
+      'export const nextTick = passthrough',
+      'export const normalizeClass = passthrough',
+      'export const onBeforeUnmount = passthrough',
+      'export const onMounted = passthrough',
+      'export const onScopeDispose = passthrough',
+      'export const openBlock = passthrough',
+      'export const readonly = passthrough',
+      'export const ref = passthrough',
+      'export const renderSlot = passthrough',
+      'export const resolveDynamicComponent = passthrough',
+      'export const shallowRef = passthrough',
+      'export const toDisplayString = passthrough',
+      'export const unref = passthrough',
+      'export const useAttrs = passthrough',
+      'export const useId = passthrough',
+      'export const watch = passthrough',
+      'export const withCtx = passthrough',
+      'export const withKeys = passthrough',
+      'export const withModifiers = passthrough',
+      '',
+    ].join('\n'),
+  )
+  await writeFile(
+    path.join(peerRoot, 'index.d.ts'),
+    [
+      'export type ComponentOptionsMixin = Record<string, never>',
+      'export type ComponentProvideOptions = Record<PropertyKey, unknown>',
+      'export type PublicProps = Record<string, unknown>',
+      'export type DeepReadonly<T> = Readonly<T>',
+      'export interface ComputedRef<T> { readonly value: T }',
+      'export interface ShallowRef<T> { value: T }',
+      'export function getCurrentScope(): unknown',
+      'export function getCurrentInstance(): unknown',
+      'export function onScopeDispose(callback: () => void): void',
+      'export function onMounted(callback: () => void): void',
+      'export function readonly<T>(value: T): DeepReadonly<T>',
+      'export function shallowRef<T>(value: T): ShallowRef<T>',
+      'export type DefineComponent<',
+      '  A = unknown, B = unknown, C = unknown, D = unknown, E = unknown,',
+      '  F = unknown, G = unknown, H = unknown, I = unknown, J = unknown,',
+      '  K = unknown, L = unknown, M = unknown, N = unknown, O = unknown,',
+      '  P = unknown, Q = unknown, R = unknown, S = unknown, T = unknown,',
+      '> = unknown',
+      '',
+    ].join('\n'),
+  )
+  const [packed] = JSON.parse(
+    npm(
+      ['pack', '--json', '--ignore-scripts', '--pack-destination', temporaryRoot, peerRoot],
+      repositoryRoot,
+    ),
+  )
+  return path.join(temporaryRoot, packed.filename)
+}
+
+async function installAndTest(directory, manifest, tarballSelection, label, temporaryRoot) {
+  const consumer = path.join(temporaryRoot, label)
+  await mkdir(consumer)
+  await writeFile(
+    path.join(consumer, 'package.json'),
+    JSON.stringify({ name: `ui-release-${label}`, private: true, type: 'module' }),
+  )
+  for (const fixture of ['smoke.ts', 'smoke.mjs', 'gateway-compatibility.mjs']) {
+    await copyFile(path.join(fixtureRoot, fixture), path.join(consumer, fixture))
+  }
+  const vuePeer = await createVuePeer(path.join(temporaryRoot, `peer-${label}`))
+  npm(
+    [
+      'install',
+      '--ignore-scripts',
+      '--offline',
+      '--no-package-lock',
+      vuePeer,
+      ...tarballSelection.map((entry) => path.join(entry.directory ?? directory, entry.tarball)),
+    ],
+    consumer,
+  )
+  await writeFile(
+    path.join(consumer, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        exactOptionalPropertyTypes: true,
+        module: 'ESNext',
+        moduleResolution: 'Bundler',
+        noEmit: true,
+        strict: true,
+        target: 'ES2022',
+      },
+      include: ['smoke.ts'],
+    }),
+  )
+  run(
+    process.execPath,
+    [path.join(repositoryRoot, 'node_modules', 'typescript', 'bin', 'tsc'), '-p', 'tsconfig.json'],
+    consumer,
+  )
+  run(process.execPath, ['smoke.mjs'], consumer)
+  run(process.execPath, ['gateway-compatibility.mjs'], consumer)
+  for (const entry of tarballSelection) {
+    const installedRoot = path.join(consumer, 'node_modules', ...entry.name.split('/'))
+    assert.equal((await lstat(installedRoot)).isSymbolicLink(), false)
+    const packageJson = await readJson(path.join(installedRoot, 'package.json'))
+    assert.equal(packageJson.version, entry.version)
+    const packedText = (
+      await Promise.all(
+        (await readdir(installedRoot, { recursive: true, withFileTypes: true }))
+          .filter((item) => item.isFile())
+          .map((item) => path.join(item.parentPath, item.name))
+          .filter((item) => /\.(?:css|d\.ts|js|json|md)$/.test(item))
+          .map((item) => readFile(item, 'utf8')),
+      )
+    ).join('\n')
+    for (const forbidden of [
+      repositoryRoot,
+      temporaryRoot,
+      '/private/tmp/',
+      '/Users/',
+      'C:\\Users\\',
+      'PRIVATE_CLIENT_REPOSITORY',
+      'OPENSQUILLA_PRIVATE',
+    ]) {
+      assert.ok(!packedText.includes(forbidden), `${entry.name} leaked ${forbidden}`)
+    }
+    assert.ok(
+      !/(?:sk|ghp|xox[baprs])-[A-Za-z0-9_-]{16,}/.test(packedText),
+      `${entry.name} contains a secret-shaped value`,
+    )
+  }
+  return manifest
+}
+
+async function loadRelease(directory) {
+  const manifest = await readJson(await findReleaseManifest(directory))
+  assert.equal(manifest.schemaVersion, 1)
+  assert.equal(manifest.releaseTrain, 'public-ui-foundation')
+  assert.equal(manifest.immutable, true)
+  await verifyChecksums(directory, manifest)
+  return manifest
+}
+
+async function verifySupplyChain(directory, manifest) {
+  const prefix = `opensquilla-ui-foundation-${manifest.releaseVersion}`
+  const sbom = await readJson(path.join(directory, `${prefix}.sbom.spdx.json`))
+  assert.equal(sbom.spdxVersion, 'SPDX-2.3')
+  assert.deepEqual(
+    new Set(sbom.packages.map((entry) => entry.name)),
+    new Set(manifest.packages.map((entry) => entry.name)),
+  )
+  const provenance = await readJson(path.join(directory, `${prefix}.provenance.json`))
+  assert.equal(provenance._type, 'https://in-toto.io/Statement/v1')
+  assert.equal(provenance.predicateType, 'https://slsa.dev/provenance/v1')
+  const provenanceName = `${prefix}.provenance.json`
+  assert.deepEqual(
+    provenance.subject,
+    manifest.artifacts
+      .filter((artifact) => artifact.name !== provenanceName)
+      .map((artifact) => ({
+        name: artifact.name,
+        digest: { sha256: artifact.sha256 },
+      })),
+  )
+  for (const artifact of manifest.artifacts) {
+    if (artifact.name.endsWith('.tgz')) continue
+    const text = await readFile(path.join(directory, artifact.name), 'utf8')
+    for (const forbidden of [
+      repositoryRoot,
+      '/private/tmp/',
+      '/Users/',
+      'C:\\Users\\',
+      'PRIVATE_CLIENT_REPOSITORY',
+      'OPENSQUILLA_PRIVATE',
+    ]) {
+      assert.ok(!text.includes(forbidden), `${artifact.name} leaked ${forbidden}`)
+    }
+    assert.ok(
+      !/(?:sk|ghp|xox[baprs])-[A-Za-z0-9_-]{16,}/.test(text),
+      `${artifact.name} contains a secret-shaped value`,
+    )
+  }
+}
+
+function parseArgs(argv) {
+  const options = { artifactsDir: null, previousArtifactsDir: null }
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]
+    if (value === '--artifacts-dir') options.artifactsDir = path.resolve(argv[++index])
+    else if (value === '--previous-artifacts-dir') {
+      options.previousArtifactsDir = path.resolve(argv[++index])
+    } else throw new Error(`Unknown argument: ${value}`)
+  }
+  return options
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv)
+  const temporaryRoot = await mkdtemp(path.join(tmpdir(), 'opensquilla-ui-release-verify-'))
+  const artifactsDir = options.artifactsDir ?? path.join(temporaryRoot, 'release')
+  try {
+    if (!options.artifactsDir) {
+      await buildRelease({
+        outputDir: artifactsDir,
+        releaseVersion: null,
+        sourceCommit: '0000000',
+        sourceRef: 'verification',
+      })
+      await assert.rejects(
+        buildRelease({
+          outputDir: artifactsDir,
+          releaseVersion: null,
+          sourceCommit: '0000000',
+          sourceRef: 'verification',
+        }),
+        /immutable assets will not be overwritten/,
+      )
+    }
+    const current = await loadRelease(artifactsDir)
+    await verifySupplyChain(artifactsDir, current)
+    await installAndTest(
+      artifactsDir,
+      current,
+      current.packages,
+      'current',
+      temporaryRoot,
+    )
+    const matrix = await readJson(
+      path.join(repositoryRoot, 'packages', 'ui-compatibility-matrix.json'),
+    )
+    if (matrix.previous === null) {
+      assert.equal(matrix.bootstrap, true)
+    } else {
+      assert.ok(
+        options.previousArtifactsDir,
+        'N-1 release assets are required after the bootstrap release',
+      )
+      const previous = await loadRelease(options.previousArtifactsDir)
+      assert.equal(previous.releaseVersion, matrix.previous.releaseVersion)
+      const currentSdk = current.packages.find(
+        (entry) => entry.name === '@opensquilla/client-sdk',
+      )
+      const previousSdk = previous.packages.find(
+        (entry) => entry.name === '@opensquilla/client-sdk',
+      )
+      const currentUi = current.packages.filter(
+        (entry) => entry.name !== '@opensquilla/client-sdk',
+      )
+      const previousUi = previous.packages.filter(
+        (entry) => entry.name !== '@opensquilla/client-sdk',
+      )
+      await installAndTest(
+        artifactsDir,
+        current,
+        [
+          ...currentUi,
+          { ...previousSdk, directory: options.previousArtifactsDir },
+        ],
+        'current-ui-previous-sdk',
+        temporaryRoot,
+      )
+      await installAndTest(
+        artifactsDir,
+        current,
+        [
+          ...previousUi.map((entry) => ({
+            ...entry,
+            directory: options.previousArtifactsDir,
+          })),
+          currentSdk,
+        ],
+        'previous-ui-current-sdk',
+        temporaryRoot,
+      )
+    }
+    console.log(
+      `Verified UI release ${current.releaseVersion}: immutable assets, supply chain, external consumer, and compatibility matrix`,
+    )
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true })
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error(`UI package release verification failed: ${error.message}`)
+    process.exitCode = 1
+  })
+}

--- a/scripts/verify_ui_packages.mjs
+++ b/scripts/verify_ui_packages.mjs
@@ -57,7 +57,7 @@ function assertPackageMetadata(record, packageJson) {
 }
 
 function isAllowedPackedFile(record, file) {
-  if (['LICENSE', 'README.md', 'package.json'].includes(file)) return true
+  if (['CHANGELOG.md', 'LICENSE', 'README.md', 'package.json'].includes(file)) return true
   if (record.name === '@opensquilla/ui-foundation') {
     return /^dist\/(?:[\w.-]+\/)*[\w.-]+\.(?:d\.ts|js)$/.test(file)
   }
@@ -120,9 +120,10 @@ function assertCleanArtifactText(record, text) {
 
 try {
   const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
-  assert.equal(manifest.schemaVersion, 1)
+  assert.equal(manifest.schemaVersion, 2)
   assert.equal(manifest.releaseTrain, 'public-ui-foundation')
-  assert.equal(manifest.versionPolicy, 'independent')
+  assert.equal(manifest.versionPolicy, 'release-groups')
+  assert.equal(manifest.compatibilityPolicy, 'current-and-previous-minor')
 
   const rootPackage = JSON.parse(
     await readFile(path.join(repositoryRoot, 'package.json'), 'utf8'),

--- a/tests/fixtures/ui-package-consumer/gateway-compatibility.mjs
+++ b/tests/fixtures/ui-package-consumer/gateway-compatibility.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+
+import {
+  HandshakeError,
+  normalizeHelloFrame,
+} from '@opensquilla/client-sdk'
+
+const current = normalizeHelloFrame(
+  {
+    type: 'hello-ok',
+    id: 'connect-current',
+    protocol: 3,
+    protocolRange: { min: 3, max: 3 },
+    contract: {
+      schemaVersion: 1,
+      digest: 'sha256:9819d28398fd37609c8c86ae9b5bbf8133d122ae07f06b75817a4d5b3c30a79e',
+      generatedFrom: 'gateway',
+    },
+    runtime: { coreVersion: '0.5.2', platform: 'linux', arch: 'x64' },
+    capabilities: ['gateway.rpc', 'gateway.sessions'],
+    extensions: [],
+    features: { methods: ['chat.send'], events: ['agent'] },
+    policy: {},
+    server: { version: '0.5.2', conn_id: 'fixture-current' },
+    snapshot: {},
+  },
+  'connect-current',
+)
+assert.equal(current.contractStatus, 'advertised')
+assert.deepEqual(current.capabilities, ['gateway.rpc', 'gateway.sessions'])
+
+const legacy = normalizeHelloFrame(
+  {
+    type: 'hello-ok',
+    protocol: 3,
+    features: {
+      methods: ['chat.history', 'chat.send', 'sessions.list', 'sessions.resolve'],
+      events: [],
+    },
+    policy: {},
+    server: { version: '0.4.0', conn_id: 'fixture-legacy' },
+    snapshot: {},
+  },
+  'connect-legacy',
+)
+assert.equal(legacy.contractStatus, 'legacy-contract')
+assert.deepEqual(legacy.protocolRange, { min: 3, max: 3 })
+assert.ok(legacy.capabilities.includes('gateway.sessions'))
+
+assert.throws(
+  () => normalizeHelloFrame(
+    {
+      type: 'hello-ok',
+      protocol: 2,
+      features: { methods: [], events: [] },
+      policy: {},
+      server: { version: '0.3.0', conn_id: 'fixture-incompatible' },
+      snapshot: {},
+    },
+    'connect-incompatible',
+  ),
+  HandshakeError,
+)

--- a/tests/fixtures/ui-package-consumer/smoke.mjs
+++ b/tests/fixtures/ui-package-consumer/smoke.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+
+import {
+  CLIENT_CONTRACT_DIGEST,
+  CLIENT_MAX_PROTOCOL,
+  CLIENT_MIN_PROTOCOL,
+} from '@opensquilla/client-sdk'
+import {
+  NATIVE_CAPABILITY_API_VERSION,
+  UI_COMPOSITION_API_VERSION,
+  createOpenSquillaApp,
+  createWebNativeCapabilityAdapter,
+} from '@opensquilla/ui-foundation'
+import * as primitives from '@opensquilla/ui-primitives'
+import { PUBLIC_THEME_IDS, THEME_TOKEN_NAMES } from '@opensquilla/ui-tokens'
+
+assert.match(CLIENT_CONTRACT_DIGEST, /^sha256:[0-9a-f]{64}$/)
+assert.equal(CLIENT_MIN_PROTOCOL, 3)
+assert.equal(CLIENT_MAX_PROTOCOL, 3)
+assert.equal(UI_COMPOSITION_API_VERSION, 1)
+assert.equal(NATIVE_CAPABILITY_API_VERSION, 1)
+assert.ok(PUBLIC_THEME_IDS.includes('dark'))
+assert.ok(THEME_TOKEN_NAMES.includes('accent'))
+assert.deepEqual(
+  Object.keys(primitives).sort(),
+  ['UiButton', 'UiCard', 'UiDialog', 'UiInput', 'UiStack', 'UiSwitch'],
+)
+
+const community = await createOpenSquillaApp({
+  features: [{ id: 'community.chat', apiVersion: UI_COMPOSITION_API_VERSION }],
+  native: createWebNativeCapabilityAdapter(),
+})
+const product = await createOpenSquillaApp({
+  features: [{ id: 'product.private-example', apiVersion: UI_COMPOSITION_API_VERSION }],
+  native: createWebNativeCapabilityAdapter(),
+})
+assert.deepEqual(community.registry.features.map((feature) => feature.id), ['community.chat'])
+assert.deepEqual(
+  product.registry.features.map((feature) => feature.id),
+  ['product.private-example'],
+)
+await community.dispose()
+await product.dispose()

--- a/tests/fixtures/ui-package-consumer/smoke.ts
+++ b/tests/fixtures/ui-package-consumer/smoke.ts
@@ -1,0 +1,61 @@
+import {
+  CLIENT_CONTRACT_DIGEST,
+  CLIENT_MAX_PROTOCOL,
+  CLIENT_MIN_PROTOCOL,
+} from '@opensquilla/client-sdk'
+import {
+  NATIVE_CAPABILITY_API_VERSION,
+  UI_COMPOSITION_API_VERSION,
+  createOpenSquillaApp,
+  createWebNativeCapabilityAdapter,
+  type FeatureModuleContract,
+} from '@opensquilla/ui-foundation'
+import {
+  UiButton,
+  UiCard,
+  UiDialog,
+  UiInput,
+  UiStack,
+  UiSwitch,
+} from '@opensquilla/ui-primitives'
+import {
+  PUBLIC_THEME_IDS,
+  THEME_TOKEN_NAMES,
+  type ThemeTokenName,
+} from '@opensquilla/ui-tokens'
+
+const communityFeature: FeatureModuleContract = {
+  id: 'community.chat',
+  apiVersion: UI_COMPOSITION_API_VERSION,
+}
+const independentProductFeature: FeatureModuleContract = {
+  id: 'product.private-example',
+  apiVersion: UI_COMPOSITION_API_VERSION,
+  optionalCapabilities: ['native.window.lifecycle'],
+}
+
+void createOpenSquillaApp({
+  features: [communityFeature],
+  native: createWebNativeCapabilityAdapter(),
+})
+void createOpenSquillaApp({
+  features: [independentProductFeature],
+  native: createWebNativeCapabilityAdapter(),
+})
+void [
+  CLIENT_CONTRACT_DIGEST,
+  CLIENT_MIN_PROTOCOL,
+  CLIENT_MAX_PROTOCOL,
+  NATIVE_CAPABILITY_API_VERSION,
+  PUBLIC_THEME_IDS,
+  THEME_TOKEN_NAMES,
+  UiButton,
+  UiCard,
+  UiDialog,
+  UiInput,
+  UiStack,
+  UiSwitch,
+]
+
+const token: ThemeTokenName = 'accent'
+void token

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -623,6 +623,13 @@ def test_ci_change_classifier_routes_public_ui_packages_to_frontend_only(
             "packages/ui-tokens/src/index.ts",
             "packages/ui-primitives/package.json",
             "packages/ui-foundation/README.md",
+            "packages/ui-compatibility-matrix.json",
+            "packages/UI_RELEASE.md",
+            "contracts/ui-foundation/v1/api-report.json",
+            "scripts/build_ui_package_release.mjs",
+            "scripts/check_ui_package_compat.mjs",
+            "scripts/tests/ui_package_compat.test.mjs",
+            "tests/fixtures/ui-package-consumer/smoke.ts",
             "scripts/verify_ui_packages.mjs",
         ],
     )
@@ -1032,6 +1039,20 @@ def test_default_ci_uses_layered_job_conditions() -> None:
     )
     assert "npm run typecheck" in sdk_step["run"]
     assert "npm run verify:package" in sdk_step["run"]
+    release_step = next(
+        step
+        for step in frontend_steps
+        if step.get("name") == "Build and verify immutable public UI release assets"
+    )
+    assert "build:ui-package-release" in release_step["run"]
+    assert "verify:ui-package-release" in release_step["run"]
+    assert "install:ui-package-release" in release_step["run"]
+    unit_step_index = next(
+        index
+        for index, step in enumerate(frontend_steps)
+        if step.get("name") == "Run frontend unit tests"
+    )
+    assert frontend_steps.index(release_step) < unit_step_index
 
     quality_steps = jobs["ubuntu-quality"]["steps"]
     contract_step = next(
@@ -1154,12 +1175,53 @@ def test_public_ui_package_gate_runs_pack_install_smoke_on_all_platforms() -> No
         step for step in steps
         if step.get("name") == "Verify public UI package boundaries"
     )
+    compatibility = next(
+        step for step in steps
+        if step.get("name") == "Enforce UI package semantic-version compatibility"
+    )
+    checkout = next(
+        step for step in steps
+        if step.get("name") == "Check out repository"
+    )
 
+    assert checkout["with"]["fetch-depth"] == 0
     assert setup_node["with"]["node-version-file"] == "opensquilla-webui/.node-version"
     assert setup_node["with"]["cache-dependency-path"] == "package-lock.json"
     assert install["run"] == "npm ci --ignore-scripts"
     assert verify["run"] == "npm run verify:ui-packages"
+    assert "--baseline-ref" in compatibility["run"]
+    assert "--allow-bootstrap" in compatibility["run"]
     assert "secrets." not in json.dumps(job)
+
+
+def test_public_ui_release_workflow_is_write_once_and_private_repo_free() -> None:
+    workflow = _workflow("ui-foundation-release.yml")
+    text = Path(".github/workflows/ui-foundation-release.yml").read_text(
+        encoding="utf-8",
+    )
+    build_job = workflow["jobs"]["build-and-release"]
+    publish_job = workflow["jobs"]["publish"]
+    steps = build_job["steps"]
+
+    assert workflow["on"]["push"]["tags"] == ["ui-foundation-v*"]
+    assert workflow["on"]["workflow_dispatch"]["inputs"]["release_version"]["required"]
+    assert "permissions" not in build_job
+    assert publish_job["permissions"] == {"contents": "write"}
+    assert publish_job["needs"] == "build-and-release"
+    assert "github.event_name == 'push'" in publish_job["if"]
+    assert any(
+        step.get("name") == "Build the complete public WebUI from release tarballs"
+        for step in steps
+    )
+    publish = next(
+        step for step in publish_job["steps"]
+        if step.get("name") == "Publish write-once GitHub Release"
+    )
+    assert "gh release create" in publish["run"]
+    assert "--verify-tag" in publish["run"]
+    assert "--clobber" not in text
+    assert "secrets." not in text
+    assert "private" not in text.lower()
 
 
 def test_public_ui_primitive_browser_gate_covers_all_engines() -> None:

--- a/tests/test_packaging/test_ui_foundation_release_contract.py
+++ b/tests/test_packaging/test_ui_foundation_release_contract.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _json(relative: str) -> dict[str, object]:
+    return json.loads((ROOT / relative).read_text(encoding="utf-8"))
+
+
+def test_ui_release_manifest_owns_four_public_packages() -> None:
+    manifest = _json("packages/ui-package-manifest.json")
+    matrix = _json("packages/ui-compatibility-matrix.json")
+    packages = manifest["packages"]
+
+    assert manifest["schemaVersion"] == 2
+    assert manifest["versionPolicy"] == "release-groups"
+    assert manifest["compatibilityPolicy"] == "current-and-previous-minor"
+    assert {entry["name"] for entry in packages} == {
+        "@opensquilla/client-sdk",
+        "@opensquilla/ui-tokens",
+        "@opensquilla/ui-primitives",
+        "@opensquilla/ui-foundation",
+    }
+    assert matrix["current"]["packages"] == {
+        entry["name"]: entry["version"] for entry in packages
+    }
+    foundation = next(
+        group for group in manifest["releaseGroups"] if group["id"] == "ui-foundation"
+    )
+    assert foundation["versionPolicy"] == "fixed"
+    assert {
+        entry["version"] for entry in packages if entry["name"] in foundation["packages"]
+    } == {matrix["current"]["releaseVersion"]}
+    foundation_package = _json("packages/ui-foundation/package.json")
+    assert foundation_package["dependencies"]["@opensquilla/client-sdk"] == (
+        matrix["current"]["clientSdkRange"]
+    )
+
+
+def test_ui_release_matrix_matches_gateway_and_composition_contracts() -> None:
+    matrix = _json("packages/ui-compatibility-matrix.json")
+    contract = _json("contracts/client/v3/contract.json")
+    foundation_source = (
+        ROOT / "packages/ui-foundation/src/composition/types.ts"
+    ).read_text(encoding="utf-8")
+
+    assert matrix["current"]["gateway"] == {
+        "protocolMin": 3,
+        "protocolMax": 3,
+        "contractDigest": contract["digest"],
+    }
+    assert "UI_COMPOSITION_API_VERSION = 1" in foundation_source
+    assert "NATIVE_CAPABILITY_API_VERSION = 1" in foundation_source
+    assert matrix["current"]["featureApi"] == {"min": 1, "max": 1}
+    assert matrix["current"]["nativeCapabilityApi"] == {"min": 1, "max": 1}
+
+
+def test_ui_api_report_versions_match_release_manifest() -> None:
+    manifest = _json("packages/ui-package-manifest.json")
+    report = _json("contracts/ui-foundation/v1/api-report.json")
+
+    assert report["schemaVersion"] == 1
+    assert report["compatibilityPolicy"] == manifest["compatibilityPolicy"]
+    assert {
+        entry["name"]: entry["version"] for entry in report["packages"]
+    } == {
+        entry["name"]: entry["version"] for entry in manifest["packages"]
+    }
+    for entry in report["packages"]:
+        assert entry["apiExports"]
+        assert entry["runtimeExports"]
+        assert entry["declarationsDigest"].startswith("sha256:")
+        assert entry["declarations"]


### PR DESCRIPTION
## Scope

Complete F-06 by publishing a machine-verifiable public UI Foundation release path and enforcing API, semantic-version, deprecation, compatibility, and supply-chain gates.

## Branch target

feature/client-migration

## Linked issue

None

## Changes

- Define SDK-independent and fixed UI Foundation release groups plus a current/N-1 compatibility matrix.
- Generate and check the public TypeScript API report; block unversioned API drift and premature export removal.
- Build four deterministic npm tarballs with SHA-256, manifest, compatibility report, changelogs, SPDX 2.3 SBOM, and in-toto/SLSA-format provenance.
- Verify external pack/install, public exports, current/legacy/incompatible Gateway handshakes, write-once output, and future N/N-1 SDK/Foundation combinations.
- Build the complete public WebUI from release tarballs in CI and in the release workflow.
- Publish write-once GitHub Release assets without registry credentials, private-repository access, clobbering, or artifact signing.

## Verification

- npm run verify:ui-packages
- Public WebUI: 243 test files / 2555 tests passed from release tarballs; production build and artifact guards passed.
- Python CI/release/packaging contracts: 135 passed.
- uv run ruff check src tests
- uv run mypy src/opensquilla --show-error-codes
- UI compatibility bootstrap against origin/feature/client-migration passed; an unresolved baseline ref fails closed.

## Safety and compatibility

- No Gateway runtime, RPC/schema, persisted state, route, page, or desktop runtime behavior changes.
- Public WebUI remains complete and independently buildable.
- Initial 0.1.0 is explicitly bootstrap because no N-1 UI release exists; later releases must provide and test N-1 assets.
- Public CI uses no private source or secret. Signing remains out of scope; provenance is metadata, not an artifact signature.
- docs/architecture is intentionally excluded.

## Release note status

Internal/public package infrastructure; no end-user runtime release note required.

## Third-party origin

None.