### PR TITLE
Fix ensemble aggregator timeout fallback

### DIFF
--- a/docs/features/LLM-ensemble-design.md
+++ b/docs/features/LLM-ensemble-design.md
@@ -195,6 +195,13 @@ not a public configuration field:
 | `shuffle_candidates` | `True` | `False` |
 | `quorum_grace_seconds` | 0 (wait for every proposer) | 10 |
 
+The two timeout fields have intentionally different streaming semantics.
+`proposer_timeout_seconds` bounds each proposer's total execution time.
+`aggregator_timeout_seconds` is an idle/stall budget between upstream stream
+events, so an active aggregation may run longer than that value while a silent
+provider is still bounded. Host-generated keep-alive heartbeats do not reset
+the aggregator budget.
+
 `min_successful_proposers` is additionally clamped down to the actual proposer
 count. Both the configured and effective values (min-success, timeouts, shuffle)
 are recorded in the selection plan for debugging.
@@ -225,6 +232,9 @@ It also retries a timeout or a stream that ends before `DoneEvent` when that
 attempt has emitted no text, reasoning, or tool delta, reusing the completed
 proposer drafts. Once any user-visible delta has been emitted, the attempt is
 terminal so a retry cannot duplicate text or tool activity downstream.
+After the retry budget is exhausted without user-visible output,
+`fallback_single` makes exactly one request with the original conversation;
+the `error` policy remains terminal.
 
 Proposers never own an executable tool boundary. By default they receive no
 current tool schemas. Setting `proposer_tools = true` exposes those schemas only

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -259,7 +259,7 @@ all_failed_policy = "fallback_single"
 # proposer_tools = false              # expose tool schemas as non-executable advice
 # candidate_max_chars = 24000         # per-candidate transcript budget (0 = unlimited)
 # proposer_timeout_seconds = 3600.0
-# aggregator_timeout_seconds = 3600.0
+# aggregator_timeout_seconds = 3600.0 # idle/stall budget between stream events
 # shuffle_candidates = true           # shuffle candidate order before aggregation
 # record_candidates = false           # persist per-proposer candidates for replay/debug
 

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -207,10 +207,13 @@ async def _stream_with_heartbeats(
                         event = pending.result()
                     except StopAsyncIteration:
                         return
+                    yield event
                     pending = asyncio.ensure_future(stream_iter.__anext__())
                     if reset_deadline_on_event and timeout_budget is not None:
+                        # Consumer-side processing is not provider idle time.
+                        # Start the next idle budget only once the next provider
+                        # read is actually pending.
                         deadline = time.monotonic() + timeout_budget
-                    yield event
                     continue
                 wait_seconds = min(wait_seconds, remaining)
             done, _ = await asyncio.wait({pending}, timeout=wait_seconds)
@@ -221,12 +224,13 @@ async def _stream_with_heartbeats(
                 event = pending.result()
             except StopAsyncIteration:
                 return
-            if reset_deadline_on_event and timeout_budget is not None:
-                # Idle budget: a healthy stream that keeps producing events may
-                # run arbitrarily long; only a silent stall expires the wait.
-                deadline = time.monotonic() + timeout_budget
             yield event
             pending = asyncio.ensure_future(stream_iter.__anext__())
+            if reset_deadline_on_event and timeout_budget is not None:
+                # Idle budget: a healthy stream that keeps producing events may
+                # run arbitrarily long; only a silent provider read expires it.
+                # Exclude time spent by downstream consumers handling ``event``.
+                deadline = time.monotonic() + timeout_budget
     finally:
         cleanup_deadline = time.monotonic() + max(
             0.0,
@@ -1800,6 +1804,9 @@ class EnsembleProvider:
             prior_rows=proposer_rows,
             prior_missing_count=_candidate_missing_usage_count(candidates),
             trace=trace,
+            original_messages=messages,
+            original_config=config,
+            candidates=candidates,
         ):
             yield event
 
@@ -2363,6 +2370,7 @@ class EnsembleProvider:
             "proposer_max_retries": self.proposer_max_retries,
             "proposer_timeout_seconds": self.proposer_timeout_seconds,
             "aggregator_timeout_seconds": self.aggregator_timeout_seconds,
+            "aggregator_timeout_mode": "idle",
             "quorum_grace_seconds": self.quorum_grace_seconds,
             "content_max_chars": TRACE_CONTENT_MAX_CHARS,
             "final_request_role": final_request_role,
@@ -2421,6 +2429,9 @@ class EnsembleProvider:
         prior_rows: list[dict[str, Any]],
         prior_missing_count: int,
         trace: dict[str, Any],
+        original_messages: list[Message],
+        original_config: ChatConfig | None,
+        candidates: Sequence[_CandidateResult],
     ) -> AsyncIterator[StreamEvent]:
         final_text_parts: list[str] = []
         aggregator_started = time.monotonic()
@@ -2557,6 +2568,10 @@ class EnsembleProvider:
                     phase="ensemble_aggregator_wait",
                     message="Still waiting for ensemble aggregator response",
                     timeout_seconds=timeout_seconds,
+                    # Match provider read-timeout semantics: healthy aggregator
+                    # streams may run past this budget, but a silent stream may
+                    # not stall the turn indefinitely.
+                    reset_deadline_on_event=True,
                 )
                 async for event in heartbeat_stream:
                     if isinstance(event, DoneEvent):
@@ -2683,7 +2698,7 @@ class EnsembleProvider:
             except TimeoutError:
                 error = ErrorEvent(
                     message=(
-                        "ensemble aggregator timed out after "
+                        "ensemble aggregator stalled: no stream events for "
                         f"{self.aggregator_timeout_seconds:g}s"
                     ),
                     code="ensemble_aggregator_timeout",
@@ -2695,6 +2710,28 @@ class EnsembleProvider:
                     retry_error = error
                 else:
                     yield aggregator_progress("aggregator_finish", error=error.message)
+                    if (
+                        not content_streamed
+                        and self.all_failed_policy == "fallback_single"
+                        and self.fallback_provider is not None
+                    ):
+                        # Reuse the original conversation, not the synthetic
+                        # candidate bundle sent to the aggregator. Preserve
+                        # billed retry rows and count only attempts that ended
+                        # without a usage receipt as missing.
+                        async for fallback_event in self._fallback_or_error(
+                            original_messages,
+                            tools=tools,
+                            config=original_config,
+                            reason=error.message,
+                            code=error.code,
+                            candidates=candidates,
+                            prior_trace=trace,
+                            prior_usage_rows=retry_rows,
+                            extra_usage_missing_count=retry_missing_count + 1,
+                        ):
+                            yield fallback_event
+                        return
                     yield partial_error(error)
                     return
             except Exception as exc:  # noqa: BLE001 - provider boundary returns ErrorEvent
@@ -2776,15 +2813,26 @@ class EnsembleProvider:
         reason: str,
         code: str,
         candidates: Sequence[_CandidateResult],
+        prior_trace: Mapping[str, Any] | None = None,
+        prior_usage_rows: Sequence[Mapping[str, Any]] = (),
+        extra_usage_missing_count: int = 0,
     ) -> AsyncIterator[StreamEvent]:
         proposer_rows = _candidate_usage_rows(candidates, profile=self.profile_name)
+        final_path_rows = [
+            *proposer_rows,
+            *(dict(row) for row in prior_usage_rows),
+        ]
         proposer_missing_count = _candidate_missing_usage_count(candidates)
+        usage_missing_count = proposer_missing_count + max(
+            0,
+            int(extra_usage_missing_count),
+        )
 
         def proposer_error(event: ErrorEvent) -> ErrorEvent:
             return replace(
                 event,
-                model_usage_breakdown=list(proposer_rows),
-                usage_missing_count=proposer_missing_count,
+                model_usage_breakdown=list(final_path_rows),
+                usage_missing_count=usage_missing_count,
             )
 
         request_budget_error = _uniform_request_budget_error(candidates)
@@ -2857,17 +2905,31 @@ class EnsembleProvider:
             if request_budget_error is not None
             else code
         )
+        if prior_trace is not None:
+            trace["llm_request_count"] = max(
+                int(trace.get("llm_request_count") or 0),
+                int(prior_trace.get("llm_request_count") or 0),
+            )
+            prior_final_request = prior_trace.get("final_request")
+            if isinstance(prior_final_request, Mapping):
+                archived_request = _json_safe(dict(prior_final_request))
+                if isinstance(archived_request, dict):
+                    archived_request["terminal_code"] = code
+                    archived_request["terminal_reason"] = reason
+                    trace["prior_final_request"] = archived_request
+
         def partial_error(event: ErrorEvent) -> ErrorEvent:
             return replace(
                 event,
-                model_usage_breakdown=list(proposer_rows),
-                usage_missing_count=proposer_missing_count + 1,
+                model_usage_breakdown=list(final_path_rows),
+                usage_missing_count=usage_missing_count + 1,
             )
+
         final_text_parts: list[str] = []
         _mark_final_request_started(trace)
         yield ProviderHeartbeatEvent(
             phase="ensemble_fallback",
-            message="Ensemble quorum unavailable; waiting for fallback model",
+            message="Ensemble final path unavailable; waiting for fallback model",
         )
         try:
             async for event in _stream_with_heartbeats(
@@ -2910,7 +2972,7 @@ class EnsembleProvider:
                         provider=executed_provider,
                         model=executed_model,
                     )
-                    rows = [*proposer_rows, fallback_row]
+                    rows = [*final_path_rows, fallback_row]
                     yield replace(
                         event,
                         input_tokens=_summed_int(rows, "input_tokens"),
@@ -2923,7 +2985,7 @@ class EnsembleProvider:
                         cost_source=_rollup_cost_source(rows),
                         model_usage_breakdown=rows,
                         ensemble_trace=trace,
-                        usage_missing_count=proposer_missing_count,
+                        usage_missing_count=usage_missing_count,
                         billing_receipt=None,
                     )
                     return

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field, replace
 from types import SimpleNamespace
 from typing import Any, Literal
@@ -503,6 +503,28 @@ async def test_heartbeat_wrapper_still_times_out_when_no_event_completed(
         async for _ in wrapped:
             pass
     release.set()
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_wrapper_idle_timeout_excludes_consumer_processing() -> None:
+    async def _source() -> AsyncIterator[StreamEvent]:
+        yield TextDeltaEvent(text="first")
+        yield DoneEvent(model="m")
+
+    wrapped = _stream_with_heartbeats(
+        _source(),
+        phase="unit",
+        message="waiting",
+        timeout_seconds=0.02,
+        reset_deadline_on_event=True,
+    )
+    events: list[StreamEvent] = []
+    async for event in wrapped:
+        events.append(event)
+        if isinstance(event, TextDeltaEvent):
+            await asyncio.sleep(0.05)
+
+    assert [type(event) for event in events] == [TextDeltaEvent, DoneEvent]
 
 
 def _tool() -> ToolDefinition:
@@ -4123,13 +4145,537 @@ async def test_ensemble_emits_proposer_progress_events(
     assert next(row for row in rows if row["role"] == "aggregator")["elapsed_ms"] >= 0
 
 
+class _ScriptedProvider(_ExactProjectionMixin):
+    def __init__(
+        self,
+        stream_factory: Callable[[], AsyncIterator[StreamEvent]],
+        *,
+        provider_name: str,
+    ) -> None:
+        self._stream_factory = stream_factory
+        self.provider_name = provider_name
+        self.calls: list[dict[str, Any]] = []
+
+    def chat(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None = None,
+        config: ChatConfig | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        self.calls.append(
+            {
+                "messages": list(messages),
+                "tools": tools,
+                "config": config,
+            }
+        )
+        return self._stream_factory()
+
+    async def list_models(self) -> list[Any]:
+        return []
+
+
+def _aggregator_timeout_harness(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    aggregator_stream: Callable[[], AsyncIterator[StreamEvent]],
+    fallback_stream: Callable[[], AsyncIterator[StreamEvent]] | None,
+    proposer_done: DoneEvent | None = None,
+    timeout_seconds: float = 0.01,
+    all_failed_policy: Literal["fallback_single", "error"] = "fallback_single",
+    selection_plan: dict[str, Any] | None = None,
+) -> tuple[
+    EnsembleProvider,
+    _FakeRegistry,
+    _ScriptedProvider,
+    _ScriptedProvider | None,
+]:
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_AGGREGATOR_RETRY_BACKOFF_SECONDS",
+        (0.0,),
+    )
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan(
+                [
+                    TextDeltaEvent(text="draft"),
+                    proposer_done or DoneEvent(model="p1"),
+                ]
+            )
+        }
+    )
+    aggregator = _ScriptedProvider(aggregator_stream, provider_name="fake")
+    fallback = (
+        _ScriptedProvider(fallback_stream, provider_name="fallback")
+        if fallback_stream is not None
+        else None
+    )
+
+    def build_provider(cfg: ProviderConfig) -> Any:
+        if cfg.model == "agg":
+            return aggregator
+        return registry.provider_for(cfg)
+
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", build_provider)
+    provider = EnsembleProvider(
+        profile_name="default",
+        proposers=[_member("p1")],
+        aggregator=_member("agg"),
+        fallback_provider=fallback,
+        fallback_provider_name="fallback",
+        fallback_model="fallback",
+        all_failed_policy=all_failed_policy,
+        proposer_timeout_seconds=1,
+        aggregator_timeout_seconds=timeout_seconds,
+        shuffle_candidates=False,
+        selection_plan=selection_plan,
+    )
+    return provider, registry, aggregator, fallback
+
+
+@pytest.mark.asyncio
+async def test_aggregator_no_output_timeout_uses_single_fallback_and_preserves_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proposer_receipt = ProviderBillingReceipt(
+        currency="USD",
+        status="confirmed",
+        amount_nanos=1_000,
+        usd_equivalent_nanos=1_000,
+        fx_native_per_usd_nanos=1_000_000_000,
+    )
+    fallback_receipt = replace(
+        proposer_receipt,
+        amount_nanos=2_000,
+        usd_equivalent_nanos=2_000,
+    )
+
+    async def stalled_aggregator() -> AsyncIterator[StreamEvent]:
+        await asyncio.sleep(0.05)
+        yield DoneEvent(model="agg")
+
+    async def successful_fallback() -> AsyncIterator[StreamEvent]:
+        yield TextDeltaEvent(text="fallback")
+        yield DoneEvent(
+            input_tokens=11,
+            output_tokens=5,
+            billed_cost=0.000002,
+            cost_source="provider_billed",
+            model="fallback",
+            billing_receipt=fallback_receipt,
+        )
+
+    selection_plan = {
+        "configured_aggregator_timeout_seconds": 3600.0,
+        "effective_aggregator_timeout_seconds": 0.01,
+    }
+    provider, registry, aggregator, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=stalled_aggregator,
+        fallback_stream=successful_fallback,
+        proposer_done=DoneEvent(
+            input_tokens=7,
+            output_tokens=3,
+            billed_cost=0.000001,
+            cost_source="provider_billed",
+            model="p1",
+            billing_receipt=proposer_receipt,
+        ),
+        selection_plan=selection_plan,
+    )
+
+    events = await _collect(provider)
+
+    assert [call["model"] for call in registry.calls] == ["p1"]
+    assert len(aggregator.calls) == 3
+    assert fallback is not None and len(fallback.calls) == 1
+    fallback_messages = fallback.calls[0]["messages"]
+    assert [(message.role, message.content) for message in fallback_messages] == [
+        ("user", "answer this")
+    ]
+    assert "<CANDIDATE" not in str(fallback_messages)
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    assert [
+        event.text for event in events if isinstance(event, TextDeltaEvent)
+    ] == ["fallback"]
+
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert (done.input_tokens, done.output_tokens) == (18, 8)
+    assert [row["role"] for row in done.model_usage_breakdown] == [
+        "proposer",
+        "fallback_single",
+    ]
+    assert [row["billing_receipt"] for row in done.model_usage_breakdown] == [
+        proposer_receipt,
+        fallback_receipt,
+    ]
+    assert done.billing_receipt is None
+    assert done.usage_missing_count == 3
+
+    trace = done.ensemble_trace
+    assert trace is not None
+    assert trace["fallback_used"] is True
+    assert trace["fallback_code"] == "ensemble_aggregator_timeout"
+    assert "no stream events" in trace["fallback_reason"]
+    assert trace["aggregator_timeout_mode"] == "idle"
+    assert trace["selection_plan"] == selection_plan
+    assert trace["llm_request_count"] == 5
+    assert trace["final_request"]["role"] == "fallback_single"
+    assert trace["final_request"]["output"]["text"] == "fallback"
+    prior_request = trace["prior_final_request"]
+    assert prior_request["request_started"] is True
+    assert prior_request["execution"]["model"] == "agg"
+    assert prior_request["retry_count"] == 2
+    assert prior_request["terminal_code"] == "ensemble_aggregator_timeout"
+
+    aggregator_finish = next(
+        event
+        for event in events
+        if isinstance(event, EnsembleProgressEvent) and event.event_type == "aggregator_finish"
+    )
+    fallback_heartbeat = next(
+        event
+        for event in events
+        if isinstance(event, ProviderHeartbeatEvent) and event.phase == "ensemble_fallback"
+    )
+    fallback_delta = next(
+        event
+        for event in events
+        if isinstance(event, TextDeltaEvent) and event.text == "fallback"
+    )
+    assert (
+        events.index(aggregator_finish)
+        < events.index(fallback_heartbeat)
+        < events.index(fallback_delta)
+        < events.index(done)
+    )
+    usage = normalize_provider_usage(
+        done,
+        default_provider="ensemble",
+        default_model="fallback",
+        completed_at_ms=1234,
+    )
+    assert len(usage.items) == 2
+    assert usage.missing_usage_entries == 3
+
+
+@pytest.mark.asyncio
+async def test_aggregator_stream_survives_past_timeout_while_events_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def slow_steady_aggregator() -> AsyncIterator[StreamEvent]:
+        for index in range(6):
+            await asyncio.sleep(0.02)
+            yield TextDeltaEvent(text=f"chunk{index}")
+        yield DoneEvent(input_tokens=11, output_tokens=5, model="agg")
+
+    async def unused_fallback() -> AsyncIterator[StreamEvent]:
+        yield DoneEvent(model="fallback")
+
+    provider, _, _, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=slow_steady_aggregator,
+        fallback_stream=unused_fallback,
+        proposer_done=DoneEvent(input_tokens=7, output_tokens=3, model="p1"),
+        timeout_seconds=0.05,
+    )
+
+    events = await _collect(provider)
+
+    assert fallback is not None and fallback.calls == []
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    assert [event.text for event in events if isinstance(event, TextDeltaEvent)] == [
+        f"chunk{index}" for index in range(6)
+    ]
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert [row["role"] for row in done.model_usage_breakdown] == [
+        "proposer",
+        "aggregator",
+    ]
+    assert done.usage_missing_count == 0
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["llm_request_count"] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "partial_event",
+    [
+        TextDeltaEvent(text="partial"),
+        ReasoningDeltaEvent(text="thinking"),
+        ToolUseStartEvent(tool_use_id="call-1", tool_name="lookup"),
+    ],
+    ids=["text", "reasoning", "tool"],
+)
+async def test_aggregator_partial_output_idle_timeout_is_terminal_without_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    partial_event: StreamEvent,
+) -> None:
+    async def partial_aggregator() -> AsyncIterator[StreamEvent]:
+        yield partial_event
+        await asyncio.sleep(0.05)
+        yield DoneEvent(model="agg")
+
+    async def duplicate_fallback() -> AsyncIterator[StreamEvent]:
+        yield TextDeltaEvent(text="duplicate")
+        yield DoneEvent(model="fallback")
+
+    provider, _, _, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=partial_aggregator,
+        fallback_stream=duplicate_fallback,
+        proposer_done=DoneEvent(input_tokens=7, output_tokens=3, model="p1"),
+    )
+
+    events = await _collect(provider)
+
+    assert fallback is not None and fallback.calls == []
+    assert partial_event in events
+    assert not any(
+        isinstance(event, TextDeltaEvent) and event.text == "duplicate" for event in events
+    )
+    progress = [
+        event
+        for event in events
+        if isinstance(event, EnsembleProgressEvent) and event.event_type.startswith("aggregator_")
+    ]
+    error = next(event for event in events if isinstance(event, ErrorEvent))
+    assert [event.event_type for event in progress] == [
+        "aggregator_start",
+        "aggregator_finish",
+    ]
+    assert error.code == "ensemble_aggregator_timeout"
+    assert error.usage_missing_count == 1
+    assert events.index(progress[-1]) < events.index(error)
+
+
+@pytest.mark.asyncio
+async def test_aggregator_timeout_respects_error_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def stalled_aggregator() -> AsyncIterator[StreamEvent]:
+        await asyncio.sleep(0.05)
+        yield DoneEvent(model="agg")
+
+    async def unused_fallback() -> AsyncIterator[StreamEvent]:
+        yield DoneEvent(model="fallback")
+
+    provider, _, _, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=stalled_aggregator,
+        fallback_stream=unused_fallback,
+        all_failed_policy="error",
+    )
+
+    events = await _collect(provider)
+
+    assert fallback is not None and fallback.calls == []
+    error = next(event for event in events if isinstance(event, ErrorEvent))
+    assert error.code == "ensemble_aggregator_timeout"
+    assert error.usage_missing_count == 3
+
+
+@pytest.mark.asyncio
+async def test_aggregator_timeout_then_fallback_error_counts_both_missing_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def stalled_aggregator() -> AsyncIterator[StreamEvent]:
+        await asyncio.sleep(0.05)
+        yield DoneEvent(model="agg")
+
+    async def failing_fallback() -> AsyncIterator[StreamEvent]:
+        yield ErrorEvent(message="fallback failed", code="fallback_failed")
+
+    provider, _, _, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=stalled_aggregator,
+        fallback_stream=failing_fallback,
+        proposer_done=DoneEvent(input_tokens=7, output_tokens=3, model="p1"),
+    )
+
+    events = await _collect(provider)
+
+    assert fallback is not None and len(fallback.calls) == 1
+    errors = [event for event in events if isinstance(event, ErrorEvent)]
+    assert len(errors) == 1
+    assert errors[0].code == "fallback_failed"
+    assert [row["model"] for row in errors[0].model_usage_breakdown] == ["p1"]
+    assert errors[0].usage_missing_count == 4
+
+
+@pytest.mark.asyncio
+async def test_aggregator_retries_then_timeout_preserves_request_counts_in_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    aggregator_attempts = 0
+
+    def retry_then_stall() -> AsyncIterator[StreamEvent]:
+        nonlocal aggregator_attempts
+        aggregator_attempts += 1
+        attempt = aggregator_attempts
+
+        async def stream() -> AsyncIterator[StreamEvent]:
+            if attempt <= 2:
+                yield ErrorEvent(message="upstream rate limit", code="429")
+                return
+            await asyncio.sleep(0.05)
+            yield DoneEvent(model="agg")
+
+        return stream()
+
+    async def successful_fallback() -> AsyncIterator[StreamEvent]:
+        yield DoneEvent(input_tokens=11, output_tokens=5, model="fallback")
+
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_AGGREGATOR_RETRY_BACKOFF_SECONDS",
+        (0.0,),
+    )
+    provider, _, _, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=retry_then_stall,
+        fallback_stream=successful_fallback,
+        proposer_done=DoneEvent(input_tokens=7, output_tokens=3, model="p1"),
+    )
+
+    events = await _collect(provider)
+
+    assert aggregator_attempts == 3
+    assert fallback is not None and len(fallback.calls) == 1
+    assert (
+        len(
+            [
+                event
+                for event in events
+                if isinstance(event, EnsembleProgressEvent)
+                and event.event_type == "aggregator_finish"
+            ]
+        )
+        == 1
+    )
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.usage_missing_count == 3
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["llm_request_count"] == 5
+    assert done.ensemble_trace["prior_final_request"]["retry_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_aggregator_timeout_fallback_retains_reported_retry_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    aggregator_attempts = 0
+
+    def reported_error_then_stall() -> AsyncIterator[StreamEvent]:
+        nonlocal aggregator_attempts
+        aggregator_attempts += 1
+        attempt = aggregator_attempts
+
+        async def stream() -> AsyncIterator[StreamEvent]:
+            if attempt == 1:
+                yield DoneEvent(
+                    input_tokens=13,
+                    output_tokens=1,
+                    model="agg",
+                    stop_reason="error",
+                )
+                return
+            await asyncio.sleep(0.05)
+            yield DoneEvent(model="agg")
+
+        return stream()
+
+    async def successful_fallback() -> AsyncIterator[StreamEvent]:
+        yield DoneEvent(input_tokens=11, output_tokens=5, model="fallback")
+
+    provider, _, aggregator, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=reported_error_then_stall,
+        fallback_stream=successful_fallback,
+        proposer_done=DoneEvent(input_tokens=7, output_tokens=3, model="p1"),
+    )
+
+    events = await _collect(provider)
+
+    assert aggregator_attempts == 3
+    assert len(aggregator.calls) == 3
+    assert fallback is not None and len(fallback.calls) == 1
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert (done.input_tokens, done.output_tokens) == (31, 9)
+    assert [row["role"] for row in done.model_usage_breakdown] == [
+        "proposer",
+        "aggregator",
+        "fallback_single",
+    ]
+    retry_row = done.model_usage_breakdown[1]
+    assert retry_row["attempt_index"] == 1
+    assert retry_row["attempt_ok"] is False
+    assert retry_row["usage_reported"] is True
+    assert done.usage_missing_count == 2
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["llm_request_count"] == 5
+    assert done.ensemble_trace["prior_final_request"]["retry_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_aggregator_timeout_cleanup_is_bounded_before_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release = asyncio.Event()
+    cancellation_seen = asyncio.Event()
+    closed = asyncio.Event()
+
+    async def cancellation_resistant_aggregator() -> AsyncIterator[StreamEvent]:
+        try:
+            while not release.is_set():
+                try:
+                    await release.wait()
+                except asyncio.CancelledError:
+                    cancellation_seen.set()
+            yield TextDeltaEvent(text="late-after-timeout")
+            await asyncio.Event().wait()
+        finally:
+            closed.set()
+
+    async def successful_fallback() -> AsyncIterator[StreamEvent]:
+        yield TextDeltaEvent(text="fallback")
+        yield DoneEvent(model="fallback")
+
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_HEARTBEAT_INTERVAL_SECONDS",
+        0.005,
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_CANCEL_CLEANUP_TIMEOUT_SECONDS",
+        0.01,
+    )
+    provider, _, _, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=cancellation_resistant_aggregator,
+        fallback_stream=successful_fallback,
+        timeout_seconds=0.02,
+    )
+
+    started = time.monotonic()
+    events = await asyncio.wait_for(_collect(provider), timeout=0.5)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.3
+    assert cancellation_seen.is_set() is True
+    assert fallback is not None and len(fallback.calls) == 1
+    assert [
+        event.text for event in events if isinstance(event, TextDeltaEvent)
+    ] == ["fallback"]
+    release.set()
+    await asyncio.wait_for(closed.wait(), timeout=0.5)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("mode", "expected_code", "expected_error"),
     [
         ("error", "agg_failed", "aggregator rejected request"),
         ("incomplete", "ensemble_aggregator_incomplete", "ended before DoneEvent"),
-        ("timeout", "ensemble_aggregator_timeout", "timed out after"),
+        ("timeout", "ensemble_aggregator_timeout", "no stream events for"),
     ],
 )
 async def test_ensemble_emits_aggregator_finish_before_terminal_error(


### PR DESCRIPTION
## Scope

Scope boundary: Treat the ensemble final aggregator timeout as an idle/stall budget and use the existing single-provider fallback once when no user-visible aggregator output exists.

Non-goals: Rerunning proposers, falling back after partial aggregator output, or changing the `error` policy.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #880

If None, reason: N/A

## Release Note

Release note: Ensemble aggregation now uses an idle timeout and preserves `fallback_single` behavior when the aggregator stalls before producing output.

## Tests

Ruff: `ruff check src tests`

Pytest: `pytest -q tests/test_provider_ensemble.py tests/test_engine/test_usage_event_accounting.py tests/test_engine/test_agent_usage_tracker_billed_propagation.py tests/test_llm_ensemble_config.py`

Build: `npm --prefix opensquilla-webui run build`; `uv build --wheel`

Regression tests: added

Notes: Added deterministic coverage for active streams, consumer backpressure, partial output, retry/accounting, fallback failure, and cancellation-resistant cleanup.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: provider

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.

Closes https://github.com/opensquilla/opensquilla/issues/880
