### PR TITLE
Expand chat history lens only during interaction

### DIFF
--- a/opensquilla-webui/e2e/conversation-minimap.spec.ts
+++ b/opensquilla-webui/e2e/conversation-minimap.spec.ts
@@ -143,6 +143,78 @@ test.describe('Long conversation history rail', () => {
     expect(arrivalPaint.maxTransitionDuration).toBeLessThanOrEqual(0.00001)
   })
 
+  test('keeps idle markers compact until pointer hover or keyboard focus', async ({ page }) => {
+    await page.addInitScript(() => localStorage.removeItem('opensquilla.sidebar.width.v1'))
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await seedLongHistory(page)
+    await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(SESSION_KEY))
+    await page.waitForSelector('.conn-pill', { timeout: 10000 })
+
+    const thread = page.locator('.chat-thread')
+    const markers = page.getByTestId('conversation-minimap-marker')
+    await expect(markers).toHaveCount(12, { timeout: 10000 })
+
+    await thread.evaluate((element) => {
+      element.scrollTop = 0
+      element.dispatchEvent(new Event('scroll'))
+    })
+
+    const markerStyles = () => markers.evaluateAll(elements => elements.map(element => ({
+      active: element.getAttribute('aria-current') === 'location',
+      opacity: element.style.getPropertyValue('--conversation-minimap-line-opacity'),
+      scaleX: element.style.getPropertyValue('--conversation-minimap-line-scale-x'),
+      scaleY: element.style.getPropertyValue('--conversation-minimap-line-scale-y'),
+    })))
+
+    await expect.poll(markerStyles).toEqual([
+      { active: true, opacity: '1.0000', scaleX: '0.2667', scaleY: '1.0000' },
+      ...Array.from({ length: 11 }, () => ({
+        active: false,
+        opacity: '0.4500',
+        scaleX: '0.2667',
+        scaleY: '0.5000',
+      })),
+    ])
+
+    await thread.evaluate((element) => {
+      element.scrollTop = 1000
+      element.dispatchEvent(new Event('scroll'))
+    })
+    await expect.poll(async () => (
+      await markerStyles()
+    ).findIndex(marker => marker.active)).toBeGreaterThan(0)
+    expect((await markerStyles()).every(marker => marker.scaleX === '0.2667')).toBe(true)
+    const activeAfterScroll = (await markerStyles()).findIndex(marker => marker.active)
+
+    await markers.nth(5).hover()
+    await expect.poll(async () => (await markerStyles())[5]?.scaleX).toBe('1.0000')
+    const hoveredStyles = await markerStyles()
+    expect(Number(hoveredStyles[4]?.scaleX)).toBeGreaterThan(0.2667)
+    expect(hoveredStyles[activeAfterScroll]).toMatchObject({
+      active: true,
+      opacity: '1.0000',
+      scaleY: '1.0000',
+    })
+    expect(hoveredStyles[5]).toMatchObject({ active: false, opacity: '0.4500', scaleY: '0.5000' })
+
+    await page.mouse.move(700, 450)
+    await expect.poll(async () => (await markerStyles()).every(
+      marker => marker.scaleX === '0.2667',
+    )).toBe(true)
+
+    await markers.nth(6).focus()
+    await expect(markers.nth(6)).toBeFocused()
+    await expect.poll(async () => (await markerStyles())[6]?.scaleX).toBe('1.0000')
+    const focusedStyles = await markerStyles()
+    expect(Number(focusedStyles[5]?.scaleX)).toBeGreaterThan(0.2667)
+    expect(focusedStyles[activeAfterScroll]).toMatchObject({
+      active: true,
+      opacity: '1.0000',
+      scaleY: '1.0000',
+    })
+    expect(focusedStyles[6]).toMatchObject({ active: false, opacity: '0.4500', scaleY: '0.5000' })
+  })
+
   test('keeps the maximum lens clear of the centered conversation column', async ({ page }) => {
     await page.addInitScript(() => localStorage.removeItem('opensquilla.sidebar.width.v1'))
     await page.setViewportSize({ width: 1440, height: 900 })

--- a/opensquilla-webui/src/components/chat/ConversationMinimap.test.ts
+++ b/opensquilla-webui/src/components/chat/ConversationMinimap.test.ts
@@ -211,18 +211,36 @@ describe('ConversationMinimap', () => {
     await vi.waitFor(() => expect(host.querySelector('[role="tooltip"]')).toBeNull())
   })
 
-  it('interpolates the lens continuously between neighboring prompts while reading', async () => {
+  it('keeps idle markers short while tracking the current prompt with thickness and opacity', async () => {
     const { host, thread } = await mountMinimap()
-    thread.container.scrollTop = 20
+    thread.container.scrollTop = 1000
     thread.container.dispatchEvent(new Event('scroll'))
     await new Promise(resolve => window.requestAnimationFrame(() => resolve(undefined)))
 
     const rows = markers(host)
-    const scale = (index: number) => Number(rows[index].style.getPropertyValue('--conversation-minimap-line-scale-x'))
-    expect(scale(0)).toBeCloseTo(scale(1), 3)
-    expect(scale(0)).toBeGreaterThan(scale(2))
-    expect(rows[0].getAttribute('aria-current')).toBe('location')
+    const styleValue = (index: number, property: string) => (
+      Number(rows[index].style.getPropertyValue(property))
+    )
+    const widthScale = (index: number) => styleValue(
+      index,
+      '--conversation-minimap-line-scale-x',
+    )
+    const heightScale = (index: number) => styleValue(
+      index,
+      '--conversation-minimap-line-scale-y',
+    )
+    const opacity = (index: number) => styleValue(
+      index,
+      '--conversation-minimap-line-opacity',
+    )
+
+    expect(rows.map((_, index) => widthScale(index))).toEqual(Array(8).fill(0.2667))
+    expect(rows[2].getAttribute('aria-current')).toBe('location')
     expect(rows.filter(row => row.hasAttribute('aria-current'))).toHaveLength(1)
+    expect(heightScale(2)).toBe(1)
+    expect(opacity(2)).toBe(1)
+    expect(heightScale(1)).toBe(0.5)
+    expect(opacity(1)).toBe(0.45)
   })
 
   it('uses a continuous neighboring lens without remounting the preview while scrubbing', async () => {
@@ -245,7 +263,34 @@ describe('ConversationMinimap', () => {
     expect(scale(3)).toBeCloseTo(scale(4), 3)
     expect(scale(3)).toBeGreaterThan(scale(2))
     expect(scale(4)).toBeGreaterThan(scale(5))
+    expect(Number(
+      rows[0].style.getPropertyValue('--conversation-minimap-line-scale-y'),
+    )).toBe(1)
+    expect(Number(
+      rows[3].style.getPropertyValue('--conversation-minimap-line-scale-y'),
+    )).toBe(0.5)
     expect(host.querySelector('[role="tooltip"]')).toBe(initialTooltip)
+  })
+
+  it('collapses the pointer lens after leaving the rail', async () => {
+    const { host } = await mountMinimap()
+    const rows = markers(host)
+    const widthScale = (index: number) => Number(
+      rows[index].style.getPropertyValue('--conversation-minimap-line-scale-x'),
+    )
+
+    rows[3].dispatchEvent(new MouseEvent('mouseenter'))
+    await nextTick()
+    expect(widthScale(3)).toBe(1)
+    expect(widthScale(2)).toBeGreaterThan(0.2667)
+
+    host.querySelector<HTMLElement>('.conversation-minimap__list')?.dispatchEvent(
+      new MouseEvent('pointerleave'),
+    )
+    await nextTick()
+
+    expect(rows.map((_, index) => widthScale(index))).toEqual(Array(8).fill(0.2667))
+    await vi.waitFor(() => expect(host.querySelector('[role="tooltip"]')).toBeNull())
   })
 
   it('jumps to a prompt without forcing the conversation to the live edge', async () => {
@@ -339,6 +384,18 @@ describe('ConversationMinimap', () => {
     const next = markers(host)[3]
     expect(document.activeElement).toBe(next)
     expect(next.tabIndex).toBe(0)
+    expect(Number(
+      next.style.getPropertyValue('--conversation-minimap-line-scale-x'),
+    )).toBe(1)
+    expect(Number(
+      markers(host)[2].style.getPropertyValue('--conversation-minimap-line-scale-x'),
+    )).toBeGreaterThan(0.2667)
+    expect(Number(
+      markers(host)[2].style.getPropertyValue('--conversation-minimap-line-scale-y'),
+    )).toBe(1)
+    expect(Number(
+      next.style.getPropertyValue('--conversation-minimap-line-scale-y'),
+    )).toBe(0.5)
     next.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
     expect(thread.scrollTo).toHaveBeenLastCalledWith({ top: thread.offsets[3] - 16, behavior: 'smooth' })
     expect(document.activeElement).toBe(thread.container.querySelector('[data-chat-turn-key="user-3"]'))

--- a/opensquilla-webui/src/components/chat/ConversationMinimap.vue
+++ b/opensquilla-webui/src/components/chat/ConversationMinimap.vue
@@ -90,9 +90,10 @@ const EXIT_SCROLL_RANGE_RATIO = 1
 // not mount/unmount the rail on every sub-pixel wobble around one boundary.
 // A fresh rail must reach the enter threshold; once visible it is allowed to
 // remain until the conversation pane crosses the lower exit threshold.
-// The rail's 30px lens starts 14px from the shell edge; its focus ring reaches
-// another 4px. At the 1104px floor, the shared 980px conversation column still
-// leaves a stable gap after accounting for the thread's scrollbar gutter.
+// The rail's 30px interactive lens starts 14px from the shell edge; its focus
+// ring reaches another 4px. At the 1104px floor, the shared 980px conversation
+// column still leaves a stable gap after accounting for the thread's scrollbar
+// gutter.
 // Enter a little later than that floor so live sidebar resizing cannot flicker
 // the rail at the exact collision boundary.
 const ENTER_INLINE_SIZE = 1120
@@ -135,7 +136,6 @@ const listRef = ref<HTMLElement | null>(null)
 const tooltipRef = ref<HTMLElement | null>(null)
 const markerRefs = ref<HTMLButtonElement[]>([])
 const activeIndex = ref(0)
-const activeProgress = ref(0)
 const hoveredIndex = ref<number | null>(null)
 const focusedIndex = ref<number | null>(null)
 const pointerLensIndex = ref<number | null>(null)
@@ -199,11 +199,10 @@ const previewTurn = computed(() => {
   const index = previewIndex.value
   return index === null ? null : turns.value[index] || null
 })
-const visualFocusIndex = computed(() => (
+const visualFocusIndex = computed<number | null>(() => (
   pointerLensIndex.value
   ?? focusedIndex.value
   ?? hoveredIndex.value
-  ?? activeProgress.value
 ))
 
 function truncatePreview(text: string): string {
@@ -216,15 +215,19 @@ function setMarkerRef(el: Element | ComponentPublicInstance | null, index: numbe
 }
 
 function markerStyle(index: number): Record<string, string> {
-  const distance = Math.abs(index - visualFocusIndex.value)
-  const influence = Math.exp(-(distance * distance) / (2 * LENS_SIGMA * LENS_SIGMA))
-  const scaleX = MIN_LINE_SCALE_X + (1 - MIN_LINE_SCALE_X) * influence
-  const scaleY = MIN_LINE_SCALE_Y + (1 - MIN_LINE_SCALE_Y) * influence
-  const opacity = MIN_LINE_OPACITY + (1 - MIN_LINE_OPACITY) * influence
+  const isActive = index === activeIndex.value
+  const focusIndex = visualFocusIndex.value
+  let scaleX = MIN_LINE_SCALE_X
+  if (focusIndex !== null) {
+    const distance = Math.abs(index - focusIndex)
+    const influence = Math.exp(-(distance * distance) / (2 * LENS_SIGMA * LENS_SIGMA))
+    scaleX += (1 - MIN_LINE_SCALE_X) * influence
+  }
+
   return {
     '--conversation-minimap-line-scale-x': scaleX.toFixed(4),
-    '--conversation-minimap-line-scale-y': scaleY.toFixed(4),
-    '--conversation-minimap-line-opacity': opacity.toFixed(4),
+    '--conversation-minimap-line-scale-y': (isActive ? 1 : MIN_LINE_SCALE_Y).toFixed(4),
+    '--conversation-minimap-line-opacity': (isActive ? 1 : MIN_LINE_OPACITY).toFixed(4),
   }
 }
 
@@ -283,16 +286,13 @@ function updateActiveTurn() {
   const offsets = anchorOffsets.value
   if (!container || offsets.length === 0) {
     activeIndex.value = 0
-    activeProgress.value = 0
     return
   }
 
   const bottomGap = container.scrollHeight - container.scrollTop - container.clientHeight
   let nextIndex = 0
-  let nextProgress = 0
   if (bottomGap <= 2) {
     nextIndex = offsets.length - 1
-    nextProgress = nextIndex
   } else {
     const readingLine = container.scrollTop + Math.min(180, container.clientHeight * 0.3)
     let low = 0
@@ -306,16 +306,8 @@ function updateActiveTurn() {
         high = mid - 1
       }
     }
-    nextProgress = nextIndex
-    const nextOffset = offsets[nextIndex + 1]
-    const currentOffset = offsets[nextIndex]
-    if (Number.isFinite(currentOffset) && Number.isFinite(nextOffset) && nextOffset > currentOffset) {
-      const segmentProgress = Math.min(1, Math.max(0, (readingLine - currentOffset) / (nextOffset - currentOffset)))
-      nextProgress += segmentProgress
-    }
   }
 
-  activeProgress.value = nextProgress
   if (nextIndex !== activeIndex.value) {
     activeIndex.value = nextIndex
     void nextTick(keepActiveMarkerVisible)
@@ -597,7 +589,6 @@ function navigateTo(index: number, focusTarget = false) {
   }
   emit('navigate', index)
   activeIndex.value = index
-  activeProgress.value = index
   if (focusTarget) anchor.focus({ preventScroll: true })
   if (distance <= ARRIVAL_TOLERANCE_PX) {
     showArrivalHighlight(anchor)
@@ -642,7 +633,7 @@ function onListPointerMove(event: PointerEvent) {
       if (Math.abs(pitch) >= 1) {
         nextLensIndex = (pendingPointerClientY - firstCenter) / pitch
       } else {
-        nextLensIndex = hoveredIndex.value ?? activeProgress.value
+        nextLensIndex = hoveredIndex.value ?? focusedIndex.value ?? activeIndex.value
       }
     }
     pointerLensIndex.value = Math.min(turns.value.length - 1, Math.max(0, nextLensIndex))
@@ -704,7 +695,6 @@ watch(() => props.sessionKey, () => {
   clearArrivalHighlight()
   hasLongHistory.value = false
   activeIndex.value = 0
-  activeProgress.value = 0
   hoveredIndex.value = null
   focusedIndex.value = null
   pointerLensIndex.value = null
@@ -723,7 +713,6 @@ watch(turns, (nextTurns, previousTurns) => {
   hoveredIndex.value = remap(hoveredIndex.value)
   focusedIndex.value = remap(focusedIndex.value)
   activeIndex.value = remap(activeIndex.value) ?? 0
-  activeProgress.value = activeIndex.value
   pointerLensIndex.value = null
   markerRefs.value = []
   void nextTick(() => {


### PR DESCRIPTION
## Scope

- Keep conversation minimap markers uniformly compact during ordinary scrolling.
- Expand the local fish-eye lens only for pointer hover or keyboard focus.
- Keep the current reading marker thick and opaque while another marker is inspected.
- Add component and browser coverage for idle, hover, pointer leave, keyboard focus, and current-marker geometry.

## Why

The minimap previously derived its fish-eye position from continuous scroll progress. That made ordinary reading animate the full rail and weakened the distinction between the current reading position and the interaction target. This change separates passive reading state from explicit minimap interaction.

## User impact

Long chat histories now have a calmer compact rail while reading. Users still get the existing preview and neighboring fish-eye expansion when they intentionally hover or keyboard-focus a marker.

## Pull request details

- Target branch: `main`
- Linked issue: None
- Release note: Not added — scoped UI interaction refinement.

## Validation

- `npm run test:unit -- src/components/chat/ConversationMinimap.test.ts` — 21 tests passed.
- `OPENSQUILLA_PLAYWRIGHT_MANAGE_WEBUI=1 OPENSQUILLA_WEBUI_BASE_URL=http://127.0.0.1:4173 npm run test:e2e -- e2e/conversation-minimap.spec.ts --project=chromium` — 5 tests passed.
- `npm run build` — passed, including Vue type-checking and Web UI project guards.
- `git diff --check` — passed.
- Manual browser QA covered idle, pointer hover/leave, keyboard focus, click navigation, and console errors.

## Safety and compatibility

- Platform-neutral Vue/CSS behavior; no OS-specific code.
- No persisted data, configuration, RPC, CLI, or public protocol changes.
- Existing minimap breakpoints, coarse-pointer hiding, click navigation, scroll locking, and eligibility thresholds remain unchanged.

## Third-party origin

None. The implementation and tests are original OpenSquilla changes.