### PR TITLE
Fix MCP stdio readline 64 KB limit for large JSON-RPC responses

### DIFF
--- a/src/opensquilla/mcp/stdio.py
+++ b/src/opensquilla/mcp/stdio.py
@@ -32,6 +32,7 @@ class MCPStdioClient(MCPClient):
         self._process: asyncio.subprocess.Process | None = None
         self._request_id = 0
         self._request_lock = asyncio.Lock()
+        self._readahead: bytes = b""
 
     @staticmethod
     def _encode_request(request: dict[str, Any]) -> bytes:
@@ -128,6 +129,42 @@ class MCPStdioClient(MCPClient):
         self._process.stdin.write(encoded)
         await self._process.stdin.drain()
 
+    async def _readline_safe(self) -> bytes:
+        """Read a line from stdout without the 64 KB StreamReader limit.
+
+        ``asyncio.StreamReader.readline()`` raises ``LimitOverrunError`` when a
+        single line exceeds the reader's limit (default 64 KB). MCP tool
+        responses such as LSP diagnostics can be much larger, so we read in
+        chunks until we find a newline.
+        """
+        assert self._process is not None
+        assert self._process.stdout is not None
+
+        chunks: list[bytes] = []
+        while True:
+            if self._readahead:
+                nl_idx = self._readahead.find(b"\n")
+                if nl_idx >= 0:
+                    line = self._readahead[:nl_idx]
+                    self._readahead = self._readahead[nl_idx + 1 :]
+                    return line
+                # No newline in readahead; prepend it to the accumulated chunks.
+                chunks.append(self._readahead)
+                self._readahead = b""
+            data = await self._process.stdout.read(8192)
+            if not data:
+                if chunks:
+                    return b"".join(chunks)
+                return b""
+            nl_idx = data.find(b"\n")
+            if nl_idx >= 0:
+                chunks.append(data[:nl_idx])
+                remainder = data[nl_idx + 1 :]
+                if remainder:
+                    self._readahead = remainder
+                return b"".join(chunks)
+            chunks.append(data)
+
     async def _read_response(self, expected_id: int) -> dict[str, Any]:
         """Read newline-delimited JSON-RPC messages until the response arrives.
 
@@ -139,7 +176,7 @@ class MCPStdioClient(MCPClient):
         assert self._process.stdout is not None
 
         while True:
-            line = await self._process.stdout.readline()
+            line = await self._readline_safe()
             if not line:
                 raise ConnectionError("MCP stdio server closed the connection")
             try:

--- a/tests/test_mcp/test_stdio_client.py
+++ b/tests/test_mcp/test_stdio_client.py
@@ -95,9 +95,25 @@ class _RecordingStdin:
 class _QueuedStdout:
     def __init__(self) -> None:
         self.lines: asyncio.Queue[bytes] = asyncio.Queue()
+        self._readahead = b""
 
     async def readline(self) -> bytes:
         return await self.lines.get()
+
+    async def read(self, n: int) -> bytes:
+        """Read up to n bytes, compatible with _readline_safe chunked reads."""
+        if self._readahead:
+            chunk = self._readahead[:n]
+            self._readahead = self._readahead[n:]
+            return chunk
+        try:
+            data = await asyncio.wait_for(self.lines.get(), timeout=10.0)
+        except TimeoutError:
+            return b""
+        if len(data) > n:
+            self._readahead = data[n:]
+            return data[:n]
+        return data
 
     def respond(self, request_id: int) -> None:
         self.lines.put_nowait(
@@ -228,3 +244,57 @@ async def test_call_tool_honors_result_level_is_error_flag() -> None:
 
     assert "upstream API rejected" in result.content
     assert result.is_error is True
+
+
+class _ChunkedStdout:
+    """Mock stdout that delivers data via ``read(chunk_size)`` instead of ``readline()``.
+
+    Used to test ``_readline_safe()`` which avoids the 64 KB StreamReader limit
+    by reading in chunks and splitting on newlines itself.
+    """
+
+    def __init__(self, data: bytes) -> None:
+        self._buffer = data
+        self._pos = 0
+
+    async def read(self, n: int) -> bytes:
+        chunk = self._buffer[self._pos : self._pos + n]
+        self._pos += len(chunk)
+        return chunk
+
+
+@pytest.mark.asyncio
+async def test_readline_safe_handles_line_larger_than_64kb() -> None:
+    """_readline_safe must read a single line > 64 KB without error."""
+    payload = {"jsonrpc": "2.0", "id": 1, "result": {"data": "x" * 70_000}}
+    line = (json.dumps(payload) + "\n").encode()
+    assert len(line) > 65536, "test line must exceed 64 KB"
+
+    # Simulate the first chunk containing the full line.
+    process = _FakeProcess()
+    process.stdout = _ChunkedStdout(line)  # type: ignore[attr-defined]
+    client = _client_with_process(process)
+
+    result = await client._readline_safe()
+    assert result == line.rstrip(b"\n")
+    assert len(result) == len(line) - 1
+
+
+@pytest.mark.asyncio
+async def test_readline_safe_reassembles_lines_across_chunks() -> None:
+    """_readline_safe must reassemble a line split across multiple read calls."""
+    payload = {"jsonrpc": "2.0", "id": 1, "result": {"data": "hello"}}
+    line = (json.dumps(payload) + "\n").encode()
+    # Pad the line with a long key so it spans multiple 8KB reads.
+    long_key = "x" * 20_000
+    long_payload = {"jsonrpc": "2.0", "id": 1, "result": {"data": long_key}}
+    long_line = (json.dumps(long_payload) + "\n").encode()
+    assert len(long_line) > 16384, "line must span at least two 8192-byte reads"
+
+    process = _FakeProcess()
+    process.stdout = _ChunkedStdout(long_line)  # type: ignore[attr-defined]
+    client = _client_with_process(process)
+
+    result = await client._readline_safe()
+    assert result == long_line.rstrip(b"\n")
+    assert len(result) == len(long_line) - 1


### PR DESCRIPTION
## Scope

MCP stdio responses above asyncio's default 64 KiB limit fail during initialization or tool calls. Read newline-delimited JSON in bounded chunks so large server instructions and tool results succeed, while rejecting messages above 16 MiB (UTF-8 bytes excluding LF) and closing the connection before parsing can resume mid-frame.

Scope boundary: preserve blank-line/EOF handling, request serialization, multibyte data and frame read-ahead; discard read-ahead when closing or replacing a subprocess. The original contributor implementation and history are retained, with maintainer follow-up fixes.

Non-goals: additional transports or changes to the MCP protocol.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: this PR and its linked user comment directly track the large-response failure, including GitHub MCP initialization.

## Release Note

Release note: Accept large MCP stdio responses up to 16 MiB, including server initialization instructions, with bounded memory and preserved framing across requests.

## Tests

Ruff: `ruff check src tests` passed.

Mypy: `mypy src/opensquilla --show-error-codes` passed (1608 source files).

Pytest: `pytest tests/test_mcp -q` passed (33 tests), including a real Python subprocess serving 129 KiB initialize/list responses and a 1 MiB multibyte tool response.

Build: passed in the [final merge-queue CI](https://github.com/TokenRhythm/opensquilla/actions/runs/35279496803), together with Linux full-suite shards, Windows checks, macOS checks, and installation/upgrade acceptance. Its tested head matches merged commit `531306aba9cda3c4830ef6e0340eea740e8cfb3c`.

Regression tests: added for large/fragmented responses, per-frame byte boundaries with and without LF, buffered frames, oversize disconnect, blank lines, EOF, and process replacement.

Notes: local validation used macOS arm64 / Python 3.12.13 with locked dependencies. Shared framing code is platform-neutral; repository CI also selects Windows stdio/discovery coverage. The default test path remains offline, deterministic, credential-free, and safe for forks. Full-suite acceptance is not claimed from these focused checks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

The reported transport boundary is covered using real local subprocess pipes without external MCP credentials.

## Safety

Messages retain a finite byte limit; oversized frames fail clearly and invalidate the stream. Tests contain synthetic data only. No secrets, private transcripts, user identifiers or machine-specific paths are included.

## Third-Party Origin

Third-party origin: none

Original contribution: mengchao99; original commit retained in this PR history.

## Documentation Changes

The reader docstring and release note describe the 16 MiB message limit. No configuration change is required.

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
