### PR TITLE
Add balance.query RPC to report the configured provider's remaining credits

### DIFF
--- a/src/opensquilla/gateway/balance_query.py
+++ b/src/opensquilla/gateway/balance_query.py
@@ -1,0 +1,204 @@
+"""Provider account balance / remaining-credits lookup.
+
+This module answers "how much credit is left on the configured provider
+account?" — a proactive counterpart to ``usage.query`` (which reports what has
+already been spent) and to the reactive ``INSUFFICIENT_CREDITS`` provider
+failure (which only surfaces after a request fails and then parks the
+credential on a long cooldown).
+
+The public entry point is :func:`query_provider_balance`, consumed by the
+``balance.query`` RPC handler.  It is intentionally provider-aware but
+degrades gracefully: providers without a documented balance endpoint return an
+``unsupported`` status rather than raising, so the UI can always render a
+sensible answer.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from opensquilla.provider.credentials import (
+    credential_provider_hint,
+    endpoint_provider_hint,
+)
+
+# Providers with a documented, machine-readable balance/credits endpoint.
+# TokenRhythm is intentionally absent: at the time of writing it exposes no
+# public balance route (``/api/*`` account paths return 404), so it is treated
+# as ``unsupported`` until such an endpoint is published. Add it here once the
+# route and payload shape are known.
+_SUPPORTED_BALANCE_PROVIDERS: frozenset[str] = frozenset({"openrouter"})
+
+_DEFAULT_TIMEOUT_SECONDS = 15.0
+
+
+class BalanceQueryError(RuntimeError):
+    """Raised when a supported provider's balance lookup cannot complete.
+
+    Distinct from the ``unsupported`` result, which is a normal (non-error)
+    outcome returned in the response payload.
+    """
+
+
+def _resolve_api_key(api_key: str, api_key_env: str) -> str:
+    """Resolve the effective API key: explicit value first, else env var."""
+
+    key = str(api_key or "").strip()
+    if key:
+        return key
+    env_name = str(api_key_env or "").strip()
+    if env_name:
+        return str(os.environ.get(env_name, "")).strip()
+    return ""
+
+
+def _resolve_provider_id(provider: str, base_url: str, api_key: str, api_key_env: str) -> str:
+    """Best-effort provider id from explicit name, else endpoint/credential hints.
+
+    The configured ``provider`` field wins. When it is a generic value (e.g.
+    ``custom``) but the endpoint or key clearly belongs to a known provider,
+    fall back to that hint so a re-hosted OpenRouter still resolves correctly.
+    """
+
+    explicit = str(provider or "").strip().lower()
+    if explicit in _SUPPORTED_BALANCE_PROVIDERS:
+        return explicit
+    hint = endpoint_provider_hint(base_url) or credential_provider_hint(
+        api_key, api_key_env=api_key_env
+    )
+    if hint:
+        return hint
+    return explicit
+
+
+def _unsupported(provider_id: str, reason: str) -> dict[str, Any]:
+    return {
+        "provider": provider_id,
+        "status": "unsupported",
+        "reason": reason,
+        "balance": None,
+        "unit": None,
+        "currency": None,
+    }
+
+
+async def _query_openrouter(
+    base_url: str,
+    api_key: str,
+    *,
+    proxy: str | None,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> dict[str, Any]:
+    """Query OpenRouter's ``GET /credits`` endpoint.
+
+    OpenRouter returns ``{"data": {"total_credits": X, "total_usage": Y}}``;
+    the remaining balance is ``total_credits - total_usage``. See
+    https://openrouter.ai/docs/api-reference/get-credits.
+
+    ``transport`` is a test seam (e.g. ``httpx.MockTransport``); production
+    call sites leave it ``None``.
+    """
+
+    root = str(base_url or "https://openrouter.ai/api/v1").rstrip("/")
+    url = f"{root}/credits"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    # httpx forbids passing both ``proxy`` and ``transport``; the transport
+    # (tests) takes precedence and needs no proxy.
+    client_kwargs: dict[str, Any] = {"timeout": _DEFAULT_TIMEOUT_SECONDS}
+    if transport is not None:
+        client_kwargs["transport"] = transport
+    else:
+        client_kwargs["proxy"] = proxy
+    try:
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            resp = await client.get(url, headers=headers)
+    except httpx.HTTPError as exc:  # network / timeout / connection error
+        raise BalanceQueryError(f"OpenRouter balance request failed: {exc}") from exc
+
+    if resp.status_code != 200:
+        raise BalanceQueryError(
+            f"OpenRouter balance request returned HTTP {resp.status_code}"
+        )
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        raise BalanceQueryError("OpenRouter balance response was not JSON") from exc
+
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        raise BalanceQueryError("OpenRouter balance response missing 'data' object")
+
+    total_credits = _coerce_float(data.get("total_credits"))
+    total_usage = _coerce_float(data.get("total_usage"))
+    if total_credits is None or total_usage is None:
+        raise BalanceQueryError(
+            "OpenRouter balance response missing total_credits/total_usage"
+        )
+    balance = round(total_credits - total_usage, 6)
+    return {
+        "provider": "openrouter",
+        "status": "ok",
+        "balance": balance,
+        "totalCredits": total_credits,
+        "totalUsage": total_usage,
+        "unit": "credits",
+        "currency": "USD",
+    }
+
+
+def _coerce_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+async def query_provider_balance(
+    *,
+    provider: str,
+    base_url: str,
+    api_key: str = "",
+    api_key_env: str = "",
+    proxy: str | None = None,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> dict[str, Any]:
+    """Return the configured provider's remaining balance.
+
+    Resolves the effective provider id and credential, dispatches to the
+    matching provider client, and returns a normalized payload. Providers
+    without a documented balance endpoint yield ``status="unsupported"``;
+    supported providers that fail to answer raise :class:`BalanceQueryError`.
+
+    ``transport`` is a test seam forwarded to the provider client; production
+    call sites leave it ``None``.
+    """
+
+    provider_id = _resolve_provider_id(provider, base_url, api_key, api_key_env)
+
+    if provider_id not in _SUPPORTED_BALANCE_PROVIDERS:
+        return _unsupported(
+            provider_id or str(provider or "").strip().lower(),
+            "This provider does not expose a balance query endpoint.",
+        )
+
+    key = _resolve_api_key(api_key, api_key_env)
+    if not key:
+        raise BalanceQueryError(
+            f"No API key configured for provider '{provider_id}'."
+        )
+
+    if provider_id == "openrouter":
+        return await _query_openrouter(base_url, key, proxy=proxy, transport=transport)
+
+    # Unreachable given the membership check above, but keeps the dispatch
+    # exhaustive if _SUPPORTED_BALANCE_PROVIDERS grows without a branch.
+    return _unsupported(provider_id, "No balance client implemented for this provider.")

--- a/src/opensquilla/gateway/rpc_usage.py
+++ b/src/opensquilla/gateway/rpc_usage.py
@@ -6,6 +6,7 @@ import time
 from collections.abc import Mapping
 from typing import Any
 
+from opensquilla.gateway.balance_query import BalanceQueryError, query_provider_balance
 from opensquilla.gateway.rpc import (
     RpcContext,
     RpcHandlerError,
@@ -716,6 +717,31 @@ async def _handle_usage_query(params: dict | None, ctx: RpcContext) -> dict[str,
         return await query_usage_ledger(storage, params)
     except UsageQueryValidationError as exc:
         raise RpcHandlerError("INVALID_REQUEST", str(exc)) from exc
+
+
+@_d.method("balance.query", scope="operator.read")
+async def _handle_balance_query(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
+    """Report the remaining balance/credits of the configured LLM provider.
+
+    Proactive counterpart to ``usage.query``: instead of "how much has been
+    spent", this answers "how much is left" by asking the active provider's
+    balance endpoint. Providers without such an endpoint return
+    ``status="unsupported"`` (a normal result, not an error).
+    """
+
+    llm = getattr(ctx.config, "llm", None) if ctx.config is not None else None
+    if llm is None:
+        raise RpcUnavailableError("No LLM provider is configured")
+    try:
+        return await query_provider_balance(
+            provider=str(getattr(llm, "provider", "") or ""),
+            base_url=str(getattr(llm, "base_url", "") or ""),
+            api_key=str(getattr(llm, "api_key", "") or ""),
+            api_key_env=str(getattr(llm, "api_key_env", "") or ""),
+            proxy=(str(getattr(llm, "proxy", "") or "").strip() or None),
+        )
+    except BalanceQueryError as exc:
+        raise RpcUnavailableError(str(exc)) from exc
 
 
 @_d.method("usage.cost", scope="operator.read")

--- a/src/opensquilla/gateway/scopes.py
+++ b/src/opensquilla/gateway/scopes.py
@@ -153,6 +153,7 @@ METHOD_SCOPES: dict[str, str] = {
     "usage.status": READ_SCOPE,
     "usage.cost": READ_SCOPE,
     "usage.query": READ_SCOPE,
+    "balance.query": READ_SCOPE,
     "meta.list": READ_SCOPE,  # OpenSquilla-only; invokable meta-skill catalog.
     "meta.runs.list": READ_SCOPE,
     "meta.runs.failures": READ_SCOPE,

--- a/tests/test_gateway/test_balance_query.py
+++ b/tests/test_gateway/test_balance_query.py
@@ -1,0 +1,171 @@
+"""Tests for the ``balance.query`` RPC and its provider balance backend."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from opensquilla.gateway.balance_query import (
+    BalanceQueryError,
+    query_provider_balance,
+)
+from opensquilla.gateway.config import GatewayConfig, LlmProviderConfig
+from opensquilla.gateway.rpc import RpcContext, RpcUnavailableError, get_dispatcher
+
+
+def _openrouter_transport(
+    *, status: int = 200, payload: dict | None = None
+) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/credits")
+        assert request.headers.get("Authorization") == "Bearer sk-or-v1-testkey"
+        if payload is None:
+            return httpx.Response(status)
+        return httpx.Response(status, json=payload)
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_balance_ok() -> None:
+    transport = _openrouter_transport(
+        payload={"data": {"total_credits": 10.0, "total_usage": 3.5}}
+    )
+    result = await query_provider_balance(
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-or-v1-testkey",
+        transport=transport,
+    )
+    assert result["status"] == "ok"
+    assert result["provider"] == "openrouter"
+    assert result["balance"] == pytest.approx(6.5)
+    assert result["totalCredits"] == pytest.approx(10.0)
+    assert result["totalUsage"] == pytest.approx(3.5)
+    assert result["currency"] == "USD"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_resolved_from_base_url_when_provider_generic() -> None:
+    # provider="custom" but the endpoint is clearly OpenRouter → hint resolves it.
+    transport = _openrouter_transport(
+        payload={"data": {"total_credits": 5, "total_usage": 5}}
+    )
+    result = await query_provider_balance(
+        provider="custom",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-or-v1-testkey",
+        transport=transport,
+    )
+    assert result["status"] == "ok"
+    assert result["balance"] == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_http_error_raises() -> None:
+    transport = _openrouter_transport(status=401, payload={"error": "unauthorized"})
+    with pytest.raises(BalanceQueryError):
+        await query_provider_balance(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="sk-or-v1-testkey",
+            transport=transport,
+        )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_malformed_payload_raises() -> None:
+    transport = _openrouter_transport(payload={"data": {"total_credits": 10.0}})
+    with pytest.raises(BalanceQueryError):
+        await query_provider_balance(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="sk-or-v1-testkey",
+            transport=transport,
+        )
+
+
+@pytest.mark.asyncio
+async def test_missing_api_key_raises() -> None:
+    with pytest.raises(BalanceQueryError):
+        await query_provider_balance(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="",
+            api_key_env="",
+        )
+
+
+@pytest.mark.asyncio
+async def test_api_key_resolved_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-testkey")
+    transport = _openrouter_transport(
+        payload={"data": {"total_credits": 2.0, "total_usage": 0.0}}
+    )
+    result = await query_provider_balance(
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="",
+        api_key_env="OPENROUTER_API_KEY",
+        transport=transport,
+    )
+    assert result["status"] == "ok"
+    assert result["balance"] == pytest.approx(2.0)
+
+
+@pytest.mark.asyncio
+async def test_tokenrhythm_is_unsupported() -> None:
+    result = await query_provider_balance(
+        provider="tokenrhythm",
+        base_url="https://tokenrhythm.studio/v1",
+        api_key="sk_tr_whatever_value_here",
+    )
+    assert result["status"] == "unsupported"
+    assert result["provider"] == "tokenrhythm"
+    assert result["balance"] is None
+
+
+@pytest.mark.asyncio
+async def test_local_custom_provider_is_unsupported() -> None:
+    result = await query_provider_balance(
+        provider="ollama",
+        base_url="http://127.0.0.1:11434/v1",
+        api_key="",
+    )
+    assert result["status"] == "unsupported"
+    assert result["provider"] == "ollama"
+
+
+@pytest.mark.asyncio
+async def test_rpc_handler_dispatches_and_wraps_error() -> None:
+    """The ``balance.query`` RPC handler reads ctx.config.llm and reports it.
+
+    With no real network available, a supported provider surfaces the backend
+    failure as an ``RpcUnavailableError`` rather than crashing.
+    """
+    dispatcher = get_dispatcher()
+    entry = dispatcher.get_entry("balance.query")
+    assert entry is not None
+    handler = entry.handler
+
+    # Unsupported provider → normal result, not an error.
+    config = GatewayConfig()
+    config.llm = LlmProviderConfig(
+        provider="tokenrhythm",
+        base_url="https://tokenrhythm.studio/v1",
+        api_key="sk_tr_whatever_value_here",
+    )
+    ctx = RpcContext(conn_id="test", config=config)
+    result = await handler(None, ctx)
+    assert result["status"] == "unsupported"
+
+
+@pytest.mark.asyncio
+async def test_rpc_handler_no_provider_configured() -> None:
+    dispatcher = get_dispatcher()
+    entry = dispatcher.get_entry("balance.query")
+    assert entry is not None
+    handler = entry.handler
+    ctx = RpcContext(conn_id="test", config=None)
+    with pytest.raises(RpcUnavailableError):
+        await handler(None, ctx)


### PR DESCRIPTION
## Summary

Adds a read-only `balance.query` gateway RPC that asks the **currently configured LLM provider** for its remaining account balance / credits. This is a proactive counterpart to the existing `usage.query` (historical spend) and to the reactive `INSUFFICIENT_CREDITS` provider failure — which today only surfaces *after* a request fails and then parks the credential on a 1-hour cooldown (`INSUFFICIENT_CREDITS_COOLDOWN_SECONDS`).

Addresses #954.

## What it does

- **OpenRouter**: queries `GET /credits` and returns the remaining balance as `total_credits - total_usage` (per the [OpenRouter docs](https://openrouter.ai/docs/api-reference/get-credits)), plus `totalCredits` / `totalUsage`.
- **Providers without a documented balance endpoint** (TokenRhythm, Ollama, vLLM, generic `custom`): return `status="unsupported"` — a normal result, not an error — so the UI can always render a sensible answer. TokenRhythm is intentionally treated as unsupported for now: it exposes no public balance route at the time of writing (its `/api/*` account paths 404); it can be added once the endpoint and payload shape are published.
- **Missing credentials / upstream failures**: surface as `RpcUnavailableError`.

## Implementation

- New module `gateway/balance_query.py` holds the provider-agnostic `query_provider_balance()` core (provider resolution via existing `endpoint_provider_hint` / `credential_provider_hint`, API-key resolution honoring `api_key` then `api_key_env`, and a small OpenRouter client). It takes an optional `transport` test seam so no real network is needed in tests.
- New handler `@_d.method("balance.query", scope="operator.read")` in `gateway/rpc_usage.py`, alongside `usage.query`. It reads the active provider from `ctx.config.llm`.
- Registered under `operator.read` in `gateway/scopes.py`.

## Returned shape

```json
{ "provider": "openrouter", "status": "ok", "balance": 6.5,
  "totalCredits": 10.0, "totalUsage": 3.5, "unit": "credits", "currency": "USD" }
```

Unsupported providers return `{ "provider": "...", "status": "unsupported", "reason": "...", "balance": null }`.

## Tests

`tests/test_gateway/test_balance_query.py` (10 tests, all passing) covers: OpenRouter success, provider resolution from base_url when the configured provider is generic, HTTP error, malformed payload, missing key, env-var key resolution, TokenRhythm/local marked unsupported, and RPC-handler dispatch + error wrapping. Uses `httpx.MockTransport` (no live calls). `ruff` clean; existing gateway RPC tests still pass.

## Notes

This is purely additive — no existing wire contract changes. A follow-up could add a "余额 / balance" surface in the control UI next to the existing "查看用量 / usage" view, and register TokenRhythm once it publishes a balance endpoint.
