### PR TITLE
Reuse migrated database templates in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sys
 import tempfile
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import pytest
@@ -132,6 +133,66 @@ def _undo_leaked_cli_structlog_default():
             structlog.configure(**old_config)
         else:
             structlog.reset_defaults()
+
+
+@pytest.fixture(scope="session")
+def _migrated_db_template(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[Path]:
+    """Build one pristine latest-schema SQLite database per pytest session.
+
+    This fixture is only for ordinary tests that require the current schema.
+    Migration, rollback, schema-ahead, audit, and lock tests must continue to
+    create their databases from scratch and call the migrator explicitly.
+    """
+    import hashlib
+    import sqlite3
+
+    from opensquilla.persistence.migrator import apply_pending
+
+    template = tmp_path_factory.mktemp("migrated-db-template") / "template.db"
+    applied = apply_pending(str(template), _REPO_ROOT / "migrations")
+    assert applied, "fresh migrated test template did not apply any migrations"
+
+    connection = sqlite3.connect(template)
+    try:
+        assert connection.execute("PRAGMA quick_check").fetchone() == ("ok",)
+    finally:
+        connection.close()
+
+    sidecars = tuple(Path(f"{template}{suffix}") for suffix in ("-wal", "-shm"))
+    assert not any(path.exists() for path in sidecars)
+    pristine_digest = hashlib.sha256(template.read_bytes()).digest()
+
+    yield template
+
+    assert hashlib.sha256(template.read_bytes()).digest() == pristine_digest
+    assert not any(path.exists() for path in sidecars)
+
+
+@pytest.fixture
+def migrated_db_factory(
+    tmp_path: Path,
+    _migrated_db_template: Path,
+) -> Callable[[str | None], Path]:
+    """Return a factory that copies the pristine schema into isolated test DBs."""
+    import itertools
+    import shutil
+
+    sequence = itertools.count()
+
+    def copy_template(filename: str | None = None) -> Path:
+        destination = tmp_path / (filename or f"test-{next(sequence)}.db")
+        shutil.copyfile(_migrated_db_template, destination)
+        return destination
+
+    return copy_template
+
+
+@pytest.fixture
+def migrated_db(migrated_db_factory: Callable[[str | None], Path]) -> Path:
+    """Return an isolated latest-schema database for one test."""
+    return migrated_db_factory(None)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_cli/test_skills_meta_runs.py
+++ b/tests/test_cli/test_skills_meta_runs.py
@@ -10,10 +10,7 @@ from typer.testing import CliRunner
 
 from opensquilla.cli.main import app as cli_app
 from opensquilla.persistence.meta_run_writer import open_meta_run_writer
-from opensquilla.persistence.migrator import apply_pending
 from opensquilla.skills.meta.types import MetaPlan, MetaResult, MetaStep
-
-MIGRATIONS_DIR = Path(__file__).resolve().parents[1].parent / "migrations"
 
 
 @pytest.fixture
@@ -22,9 +19,8 @@ def runner() -> CliRunner:
 
 
 @pytest.fixture
-def seeded_db(tmp_path: Path, monkeypatch):
-    db = str(tmp_path / "test.db")
-    apply_pending(db, MIGRATIONS_DIR)
+def seeded_db(migrated_db: Path, monkeypatch):
+    db = str(migrated_db)
     w = open_meta_run_writer(db)
 
     plan_a = MetaPlan(
@@ -146,9 +142,8 @@ def test_runs_show_bad_id(runner: CliRunner, seeded_db) -> None:
     assert result.exit_code != 0
 
 
-def test_runs_list_empty(runner: CliRunner, tmp_path: Path, monkeypatch) -> None:
-    db = str(tmp_path / "empty.db")
-    apply_pending(db, MIGRATIONS_DIR)
+def test_runs_list_empty(runner: CliRunner, migrated_db: Path, monkeypatch) -> None:
+    db = str(migrated_db)
     monkeypatch.setenv("OPENSQUILLA_META_RUNS_DB", db)
     result = runner.invoke(cli_app, ["skills", "meta", "runs", "list", "--json"])
     assert result.exit_code == 0

--- a/tests/test_gateway/test_rpc_meta_runs.py
+++ b/tests/test_gateway/test_rpc_meta_runs.py
@@ -26,23 +26,18 @@ from opensquilla.gateway.rpc_meta_runs import (
 )
 from opensquilla.gateway.scopes import ADMIN_SCOPE, METHOD_SCOPES, READ_SCOPE
 from opensquilla.persistence.meta_run_writer import open_meta_run_writer
-from opensquilla.persistence.migrator import apply_pending
 from opensquilla.skills.meta.inputs import make_meta_inputs
 from opensquilla.skills.meta.scheduler import _preflight_missing_fields
 from opensquilla.skills.meta.types import MetaPlan, MetaResult, MetaStep
 
-MIGRATIONS_DIR = Path(__file__).resolve().parents[1].parent / "migrations"
-
 
 def _seed_writer(
-    tmp_path: Path,
+    migrated_db: Path,
     *,
     final_status: str = "ok",
     final_result: MetaResult | None = None,
 ):
-    db = str(tmp_path / "runs.db")
-    apply_pending(db, MIGRATIONS_DIR)
-    writer = open_meta_run_writer(db)
+    writer = open_meta_run_writer(str(migrated_db))
     plan = MetaPlan(
         name="alpha-skill",
         triggers=("alpha request",),
@@ -92,8 +87,8 @@ def _seed_writer(
     return writer, run_id
 
 
-def test_meta_runs_list_rpc_returns_summary(tmp_path: Path) -> None:
-    writer, run_id = _seed_writer(tmp_path)
+def test_meta_runs_list_rpc_returns_summary(migrated_db: Path) -> None:
+    writer, run_id = _seed_writer(migrated_db)
     try:
         ctx = RpcContext(conn_id="test", meta_run_writer=writer)
         payload = asyncio.run(_handle_meta_runs_list({"limit": 5}, ctx))
@@ -120,9 +115,9 @@ def test_meta_runs_list_rpc_returns_summary(tmp_path: Path) -> None:
     }
 
 
-def test_meta_runs_failures_rpc_returns_summary_only(tmp_path: Path) -> None:
+def test_meta_runs_failures_rpc_returns_summary_only(migrated_db: Path) -> None:
     writer, run_id = _seed_writer(
-        tmp_path,
+        migrated_db,
         final_status="failed",
         final_result=MetaResult(
             ok=False,
@@ -144,8 +139,8 @@ def test_meta_runs_failures_rpc_returns_summary_only(tmp_path: Path) -> None:
     assert "final_text" not in run
 
 
-def test_meta_runs_show_rpc_returns_steps(tmp_path: Path) -> None:
-    writer, run_id = _seed_writer(tmp_path)
+def test_meta_runs_show_rpc_returns_steps(migrated_db: Path) -> None:
+    writer, run_id = _seed_writer(migrated_db)
     try:
         ctx = RpcContext(conn_id="test", meta_run_writer=writer)
         payload = asyncio.run(_handle_meta_runs_show({"runId": run_id}, ctx))
@@ -158,8 +153,8 @@ def test_meta_runs_show_rpc_returns_steps(tmp_path: Path) -> None:
     assert run["summary"]["steps"][0]["output_chars"] == 4
 
 
-def test_meta_runs_draft_rpc_returns_author_seed(tmp_path: Path) -> None:
-    writer, run_id = _seed_writer(tmp_path)
+def test_meta_runs_draft_rpc_returns_author_seed(migrated_db: Path) -> None:
+    writer, run_id = _seed_writer(migrated_db)
     try:
         ctx = RpcContext(conn_id="test", meta_run_writer=writer)
         payload = asyncio.run(_handle_meta_runs_draft({"runId": run_id}, ctx))
@@ -173,8 +168,8 @@ def test_meta_runs_draft_rpc_returns_author_seed(tmp_path: Path) -> None:
     assert draft["eval_prompts"][0]["name"] == "brief"
 
 
-def test_meta_runs_confirm_preflight_requires_template_fields(tmp_path: Path) -> None:
-    writer, run_id = _seed_writer(tmp_path)
+def test_meta_runs_confirm_preflight_requires_template_fields(migrated_db: Path) -> None:
+    writer, run_id = _seed_writer(migrated_db)
     try:
         ctx = RpcContext(conn_id="test", meta_run_writer=writer)
         payload = asyncio.run(_handle_meta_runs_confirm_preflight({
@@ -209,8 +204,8 @@ def test_meta_runs_confirm_preflight_requires_template_fields(tmp_path: Path) ->
     ) == []
 
 
-def test_meta_runs_confirm_preflight_rejects_missing_fields(tmp_path: Path) -> None:
-    writer, run_id = _seed_writer(tmp_path)
+def test_meta_runs_confirm_preflight_rejects_missing_fields(migrated_db: Path) -> None:
+    writer, run_id = _seed_writer(migrated_db)
     try:
         ctx = RpcContext(conn_id="test", meta_run_writer=writer)
         with pytest.raises(Exception) as exc_info:
@@ -224,9 +219,9 @@ def test_meta_runs_confirm_preflight_rejects_missing_fields(tmp_path: Path) -> N
     assert "language" in str(exc_info.value)
 
 
-def test_meta_runs_replay_rpc_returns_bounded_replay_message(tmp_path: Path) -> None:
+def test_meta_runs_replay_rpc_returns_bounded_replay_message(migrated_db: Path) -> None:
     writer, run_id = _seed_writer(
-        tmp_path,
+        migrated_db,
         final_status="failed",
         final_result=MetaResult(ok=False, error="failed at writer", failed_step_id="s1"),
     )
@@ -247,9 +242,11 @@ def test_meta_runs_replay_rpc_returns_bounded_replay_message(tmp_path: Path) -> 
     assert replay["request"]["user_message"] == "Write an alpha brief"
 
 
-def test_meta_runs_replay_keeps_original_request_before_large_outputs(tmp_path: Path) -> None:
+def test_meta_runs_replay_keeps_original_request_before_large_outputs(
+    migrated_db: Path,
+) -> None:
     writer, run_id = _seed_writer(
-        tmp_path,
+        migrated_db,
         final_status="failed",
         final_result=MetaResult(ok=False, error="failed late", failed_step_id="s1"),
     )
@@ -274,8 +271,8 @@ def test_meta_runs_replay_keeps_original_request_before_large_outputs(tmp_path: 
     assert "...[truncated for replay]" in message
 
 
-def test_meta_runs_diff_rpc_compares_runs(tmp_path: Path) -> None:
-    writer, left_run_id = _seed_writer(tmp_path)
+def test_meta_runs_diff_rpc_compares_runs(migrated_db: Path) -> None:
+    writer, left_run_id = _seed_writer(migrated_db)
     plan = MetaPlan(
         name="alpha-skill",
         triggers=("alpha request",),
@@ -312,8 +309,8 @@ def test_meta_runs_diff_rpc_compares_runs(tmp_path: Path) -> None:
     assert diff["steps"][0]["step_id"] == "s1"
 
 
-def test_meta_runs_cost_rpc_aggregates_persisted_step_usage(tmp_path: Path) -> None:
-    writer, run_id = _seed_writer(tmp_path)
+def test_meta_runs_cost_rpc_aggregates_persisted_step_usage(migrated_db: Path) -> None:
+    writer, run_id = _seed_writer(migrated_db)
     writer.finish_step_sync(
         run_id=run_id,
         step_id="s1",
@@ -346,8 +343,8 @@ def test_meta_runs_cost_rpc_aggregates_persisted_step_usage(tmp_path: Path) -> N
     assert payload["runs"][0]["steps"][0]["usage"]["model"] == "gpt-test"
 
 
-def test_meta_runs_validate_rpc_exposes_spec_metadata(tmp_path: Path) -> None:
-    writer, run_id = _seed_writer(tmp_path)
+def test_meta_runs_validate_rpc_exposes_spec_metadata(migrated_db: Path) -> None:
+    writer, run_id = _seed_writer(migrated_db)
     try:
         ctx = RpcContext(conn_id="test", meta_run_writer=writer)
         payload = asyncio.run(_handle_meta_runs_validate({"runId": run_id}, ctx))
@@ -361,8 +358,10 @@ def test_meta_runs_validate_rpc_exposes_spec_metadata(tmp_path: Path) -> None:
     assert validation["eval_prompts"][0]["name"] == "brief"
 
 
-def test_meta_runs_eval_baseline_rpc_returns_deterministic_rubric(tmp_path: Path) -> None:
-    writer, run_id = _seed_writer(tmp_path)
+def test_meta_runs_eval_baseline_rpc_returns_deterministic_rubric(
+    migrated_db: Path,
+) -> None:
+    writer, run_id = _seed_writer(migrated_db)
     try:
         ctx = RpcContext(conn_id="test", meta_run_writer=writer)
         payload = asyncio.run(_handle_meta_runs_eval_baseline({"runId": run_id}, ctx))
@@ -390,8 +389,10 @@ def test_meta_runs_rpc_scope_contract() -> None:
 
 
 @pytest.mark.asyncio
-async def test_meta_runs_show_and_draft_deny_read_only_dispatch(tmp_path: Path) -> None:
-    writer, run_id = _seed_writer(tmp_path)
+async def test_meta_runs_show_and_draft_deny_read_only_dispatch(
+    migrated_db: Path,
+) -> None:
+    writer, run_id = _seed_writer(migrated_db)
     read_only = Principal(
         role="operator",
         scopes=frozenset({READ_SCOPE}),
@@ -410,8 +411,10 @@ async def test_meta_runs_show_and_draft_deny_read_only_dispatch(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
-async def test_meta_runs_read_only_requires_session_key_for_history(tmp_path: Path) -> None:
-    writer, _run_id = _seed_writer(tmp_path)
+async def test_meta_runs_read_only_requires_session_key_for_history(
+    migrated_db: Path,
+) -> None:
+    writer, _run_id = _seed_writer(migrated_db)
     read_only = Principal(
         role="operator",
         scopes=frozenset({READ_SCOPE}),
@@ -430,8 +433,10 @@ async def test_meta_runs_read_only_requires_session_key_for_history(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_meta_runs_read_only_allows_session_scoped_history(tmp_path: Path) -> None:
-    writer, run_id = _seed_writer(tmp_path)
+async def test_meta_runs_read_only_allows_session_scoped_history(
+    migrated_db: Path,
+) -> None:
+    writer, run_id = _seed_writer(migrated_db)
     other_plan = MetaPlan(
         name="beta-skill",
         triggers=("beta request",),
@@ -474,10 +479,10 @@ async def test_meta_runs_read_only_allows_session_scoped_history(tmp_path: Path)
 
 @pytest.mark.asyncio
 async def test_meta_runs_failures_read_only_allows_session_scoped_history(
-    tmp_path: Path,
+    migrated_db: Path,
 ) -> None:
     writer, run_id = _seed_writer(
-        tmp_path,
+        migrated_db,
         final_status="failed",
         final_result=MetaResult(ok=False, error="failed", failed_step_id="s1"),
     )
@@ -522,8 +527,10 @@ async def test_meta_runs_failures_read_only_allows_session_scoped_history(
 
 
 @pytest.mark.asyncio
-async def test_meta_runs_owner_read_scope_allows_session_history(tmp_path: Path) -> None:
-    writer, run_id = _seed_writer(tmp_path)
+async def test_meta_runs_owner_read_scope_allows_session_history(
+    migrated_db: Path,
+) -> None:
+    writer, run_id = _seed_writer(migrated_db)
     owner_read = Principal(
         role="operator",
         scopes=frozenset({READ_SCOPE}),

--- a/tests/test_persistence/test_meta_run_writer.py
+++ b/tests/test_persistence/test_meta_run_writer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
+from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -28,12 +30,29 @@ MIGRATIONS_DIR = Path(__file__).resolve().parents[1].parent / "migrations"
 
 
 @pytest.fixture
-def writer(tmp_path: Path):
-    db = str(tmp_path / "test.db")
-    apply_pending(db, MIGRATIONS_DIR)
-    w = open_meta_run_writer(db)
+def writer(migrated_db: Path) -> Iterator[MetaRunWriter]:
+    w = open_meta_run_writer(str(migrated_db))
     yield w
     w.close()
+
+
+def test_migrated_db_factory_produces_current_isolated_copies(
+    migrated_db_factory: Callable[[str | None], Path],
+) -> None:
+    first = migrated_db_factory("first.db")
+    second = migrated_db_factory("second.db")
+
+    assert apply_pending(str(first), MIGRATIONS_DIR) == []
+    with sqlite3.connect(first) as connection:
+        connection.execute("CREATE TABLE template_isolation_probe (value TEXT)")
+
+    with sqlite3.connect(second) as connection:
+        assert connection.execute("PRAGMA quick_check").fetchone() == ("ok",)
+        probe = connection.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'template_isolation_probe'"
+        ).fetchone()
+    assert probe is None
 
 
 def _make_plan(name: str = "demo") -> MetaPlan:
@@ -522,11 +541,9 @@ def test_cancelled_status_distinct(writer: MetaRunWriter) -> None:
     assert record.final_text is None
 
 
-def test_writer_failures_dont_raise(tmp_path: Path) -> None:
+def test_writer_failures_dont_raise(migrated_db: Path) -> None:
     """Fail-open contract: writer methods log + swallow."""
-    db = str(tmp_path / "test.db")
-    apply_pending(db, MIGRATIONS_DIR)
-    w = open_meta_run_writer(db)
+    w = open_meta_run_writer(str(migrated_db))
     w.close()  # connection now closed
     # Subsequent calls must not raise
     assert w.begin_run_sync(
@@ -594,19 +611,15 @@ _DAY_MS = 24 * 60 * 60 * 1000
 
 
 def _open_clocked_writer(
-    tmp_path: Path,
+    migrated_db: Path,
     *,
     retention_days: int = 90,
     prune_every: int = 1,
     prune_batch: int = 1_000,
 ) -> tuple[MetaRunWriter, dict[str, int]]:
     """Migrated writer with a mutable fake clock for retention tests."""
-    import sqlite3
-
-    db = str(tmp_path / "retention.db")
-    apply_pending(db, MIGRATIONS_DIR)
     clock = {"now_ms": 0}
-    conn = sqlite3.connect(db, check_same_thread=False, isolation_level=None)
+    conn = sqlite3.connect(migrated_db, check_same_thread=False, isolation_level=None)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys = ON")
     writer = MetaRunWriter(
@@ -630,8 +643,8 @@ def _begin(writer: MetaRunWriter, *, session_key: str | None) -> str:
     return run_id
 
 
-def test_retention_prunes_old_terminal_runs_and_cascades_steps(tmp_path: Path) -> None:
-    writer, clock = _open_clocked_writer(tmp_path, retention_days=90, prune_every=1)
+def test_retention_prunes_old_terminal_runs_and_cascades_steps(migrated_db: Path) -> None:
+    writer, clock = _open_clocked_writer(migrated_db, retention_days=90, prune_every=1)
     try:
         plan = _make_plan()
         old_ok = _begin(writer, session_key="s-old-ok")
@@ -671,8 +684,8 @@ def test_retention_prunes_old_terminal_runs_and_cascades_steps(tmp_path: Path) -
         writer.close()
 
 
-def test_retention_keeps_terminal_runs_inside_window(tmp_path: Path) -> None:
-    writer, clock = _open_clocked_writer(tmp_path, retention_days=90, prune_every=1)
+def test_retention_keeps_terminal_runs_inside_window(migrated_db: Path) -> None:
+    writer, clock = _open_clocked_writer(migrated_db, retention_days=90, prune_every=1)
     try:
         recent_ok = _begin(writer, session_key="s-recent")
         writer.finish_run_sync(run_id=recent_ok, status="ok", result=None)
@@ -685,8 +698,8 @@ def test_retention_keeps_terminal_runs_inside_window(tmp_path: Path) -> None:
         writer.close()
 
 
-def test_retention_prune_cadence_honours_prune_every(tmp_path: Path) -> None:
-    writer, clock = _open_clocked_writer(tmp_path, retention_days=90, prune_every=3)
+def test_retention_prune_cadence_honours_prune_every(migrated_db: Path) -> None:
+    writer, clock = _open_clocked_writer(migrated_db, retention_days=90, prune_every=3)
     try:
         old = _begin(writer, session_key="s-old")  # begin #1 — no prune
         writer.finish_run_sync(run_id=old, status="ok", result=None)
@@ -701,9 +714,9 @@ def test_retention_prune_cadence_honours_prune_every(tmp_path: Path) -> None:
         writer.close()
 
 
-def test_retention_pruning_is_bounded_and_keeps_live_runs(tmp_path: Path) -> None:
+def test_retention_pruning_is_bounded_and_keeps_live_runs(migrated_db: Path) -> None:
     writer, clock = _open_clocked_writer(
-        tmp_path,
+        migrated_db,
         retention_days=90,
         prune_every=8,
         prune_batch=2,
@@ -743,17 +756,15 @@ def test_retention_pruning_is_bounded_and_keeps_live_runs(tmp_path: Path) -> Non
         writer.close()
 
 
-def test_retention_defaults_via_open_meta_run_writer_kwargs(tmp_path: Path) -> None:
-    db = str(tmp_path / "kwargs.db")
-    apply_pending(db, MIGRATIONS_DIR)
-    w = open_meta_run_writer(db, retention_days=7, prune_every=16)
+def test_retention_defaults_via_open_meta_run_writer_kwargs(migrated_db: Path) -> None:
+    w = open_meta_run_writer(str(migrated_db), retention_days=7, prune_every=16)
     try:
         assert w._retention_days == 7
         assert w._prune_every == 16
     finally:
         w.close()
     # Backward-compatible positional-only call keeps working with defaults.
-    w2 = open_meta_run_writer(db)
+    w2 = open_meta_run_writer(str(migrated_db))
     try:
         assert w2._retention_days == 90
         assert w2._prune_every == 64

--- a/tests/test_persistence/test_meta_run_writer_clarify.py
+++ b/tests/test_persistence/test_meta_run_writer_clarify.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
-from yoyo import get_backend, read_migrations
 
 from opensquilla.persistence.meta_run_writer import (
     AwaitingPeek,
@@ -16,15 +16,14 @@ from opensquilla.persistence.meta_run_writer import (
 
 
 @pytest.fixture
-def writer(tmp_path: Path) -> MetaRunWriter:
-    db = tmp_path / "test.sqlite"
-    backend = get_backend(f"sqlite:///{db}")
-    backend.apply_migrations(read_migrations("migrations"))
-    conn = sqlite3.connect(db, check_same_thread=False)
+def writer(migrated_db: Path) -> Iterator[MetaRunWriter]:
+    conn = sqlite3.connect(migrated_db, check_same_thread=False)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA synchronous=NORMAL")
-    return MetaRunWriter(conn)
+    result = MetaRunWriter(conn)
+    yield result
+    result.close()
 
 
 def _seed_awaiting(writer: MetaRunWriter, *, run_id: str, session_key: str,
@@ -207,13 +206,9 @@ def test_increment_parse_failures_returns_new_count(writer):
     assert writer.increment_parse_failures(run_id="r1") == 3
 
 
-def test_increment_parse_failures_atomic_across_connections(tmp_path):
-    db = tmp_path / "test.sqlite"
-    backend = get_backend(f"sqlite:///{db}")
-    backend.apply_migrations(read_migrations("migrations"))
-
+def test_increment_parse_failures_atomic_across_connections(migrated_db: Path):
     def _open():
-        c = sqlite3.connect(db, check_same_thread=False, timeout=30.0)
+        c = sqlite3.connect(migrated_db, check_same_thread=False, timeout=30.0)
         c.row_factory = sqlite3.Row
         c.execute("PRAGMA journal_mode=WAL")
         c.execute("PRAGMA synchronous=NORMAL")
@@ -221,15 +216,19 @@ def test_increment_parse_failures_atomic_across_connections(tmp_path):
 
     w1 = _open()
     w2 = _open()
-    _seed_awaiting(w1, run_id="r1", session_key="S1")
+    try:
+        _seed_awaiting(w1, run_id="r1", session_key="S1")
 
-    seen = []
-    for w in (w1, w2, w1, w2, w1):
-        seen.append(w.increment_parse_failures(run_id="r1"))
+        seen = []
+        for w in (w1, w2, w1, w2, w1):
+            seen.append(w.increment_parse_failures(run_id="r1"))
 
-    assert seen == [1, 2, 3, 4, 5], (
-        f"increment_parse_failures must be atomic per connection; got {seen}"
-    )
+        assert seen == [1, 2, 3, 4, 5], (
+            f"increment_parse_failures must be atomic per connection; got {seen}"
+        )
+    finally:
+        w2.close()
+        w1.close()
 
 
 def test_increment_parse_failures_zero_for_non_awaiting(writer):


### PR DESCRIPTION
## Scope

Scope boundary: reuse one verified latest-schema SQLite template per pytest session and copy it into isolated per-test databases for four migration-heavy meta-run test modules.

Non-goals: production migration behavior, migration/rollback/schema-ahead tests, CI routing, Windows shard assignments, release workflows, and release assets.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: CI performance audit follow-up; no existing issue tracks this test-only optimization.

## Release Note

Release note: NONE

## Tests

Ruff: `.venv/bin/ruff check tests/conftest.py tests/test_cli/test_skills_meta_runs.py tests/test_gateway/test_rpc_meta_runs.py tests/test_persistence/test_meta_run_writer_clarify.py tests/test_persistence/test_meta_run_writer.py`

Pytest: 89 passed in the four optimized modules; 100 passed and 2 skipped in the core migration suites; 8 passed in the Windows shard governance suite.

Build: not needed; test-infrastructure-only change with no production or packaged files modified.

Regression tests: added

Notes: the four modules previously performed 68 fresh full-schema migrations. They now perform one full migration per pytest session/shard and use isolated file copies. On the same macOS checkout, the first before/after wall comparison improved from 6.70s to 4.64s; two warm confirmation runs completed in 2.35s and 2.10s.

Windows canary: CI run 30803348695 passed. Comparing JUnit for the same 88 pre-existing nodes against the latest green main run reduced their cumulative time from 199.702s to 24.034s, saving 175.668s (88.0%). No existing nodes disappeared; the only added node is the template currency/isolation contract. Per module, the saved time was 12.823s for CLI, 13.346s for RPC, 125.523s for the writer suite, and 23.976s for clarify-state tests. Whole-shard times remain noisy because each shard contains thousands of unrelated tests.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: no credentialed or live surface is involved.

## Safety

The template is built from a fresh database, checked with `PRAGMA quick_check`, required to have no WAL/SHM sidecars, and protected by a session-end SHA-256 integrity assertion. Every test receives an independent copy. Migration, rollback, schema-ahead, audit, and lock tests remain explicitly excluded and continue creating databases from scratch.

The mechanism uses cross-platform Python and SQLite APIs (`pathlib`, `shutil.copyfile`, and closed SQLite connections). No public interface, persisted user state, upgrade behavior, production migration behavior, release artifact, secret, local-only artifact, private prompt/transcript, channel identifier, AI session artifact, non-public fixture, or `tests/_private/` content is changed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] N/A — no documentation files changed.
