### PR TITLE
Avoid Windows stdin close false timeouts

### DIFF
--- a/src/opensquilla/tools/builtin/shell.py
+++ b/src/opensquilla/tools/builtin/shell.py
@@ -5035,10 +5035,25 @@ async def _write_exec_stdin(proc: Any, stdin_bytes: bytes | None) -> None:
                 await wait_closed()
 
 
-async def _wait_exec_stdin_writer(writer_task: asyncio.Task[None], timeout: float) -> bool:
-    done, _ = await asyncio.wait({writer_task}, timeout=max(0.0, timeout))
-    if writer_task not in done:
-        return False
+async def _wait_exec_stdin_writer(
+    proc: Any, writer_task: asyncio.Task[None], timeout: float
+) -> bool:
+    """Wait for stdin closure without mistaking a completed process for a hang.
+
+    Windows' proactor pipe transport can leave ``StreamWriter.wait_closed()``
+    pending briefly after the child has consumed EOF and exited. The process exit
+    is authoritative in that case; the caller cancels the stale writer task after
+    observing the return code.
+    """
+
+    deadline = asyncio.get_running_loop().time() + max(0.0, timeout)
+    while not writer_task.done() and proc.returncode is None:
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            return writer_task.done() or proc.returncode is not None
+        await asyncio.wait({writer_task}, timeout=min(0.01, remaining))
+    if not writer_task.done():
+        return proc.returncode is not None
     with contextlib.suppress(BrokenPipeError, ConnectionResetError):
         await writer_task
     return True
@@ -5129,7 +5144,7 @@ async def _run_host_shell_command(
             try:
                 if stdin_bytes is not None:
                     stdin_writer = asyncio.create_task(_write_exec_stdin(proc, stdin_bytes))
-                    if not await _wait_exec_stdin_writer(stdin_writer, remaining):
+                    if not await _wait_exec_stdin_writer(proc, stdin_writer, remaining):
                         await _cancel_exec_stdin_writer(proc, stdin_writer)
                         await _terminate_exec_process_tree(proc)
                         return timeout_result()
@@ -5143,6 +5158,7 @@ async def _run_host_shell_command(
                 await _cancel_exec_stdin_writer(proc, stdin_writer)
                 await _terminate_exec_process_tree(proc)
                 return timeout_result()
+            await _cancel_exec_stdin_writer(proc, stdin_writer)
             if os.name == "posix":
                 _signal_exec_process_tree(proc, signal.SIGTERM)
 

--- a/tests/test_tools/test_shell_process_isolation.py
+++ b/tests/test_tools/test_shell_process_isolation.py
@@ -288,6 +288,33 @@ async def test_write_exec_stdin_waits_until_eof_is_delivered() -> None:
 
 
 @pytest.mark.asyncio
+async def test_wait_exec_stdin_writer_accepts_process_exit_before_pipe_close() -> None:
+    proc = _FakeProcess(returncode=None)
+    release_writer = asyncio.Event()
+
+    async def wait_for_pipe_close() -> None:
+        await release_writer.wait()
+
+    writer_task = asyncio.create_task(wait_for_pipe_close())
+
+    async def finish_process() -> None:
+        await asyncio.sleep(0.02)
+        proc.returncode = 0
+
+    process_task = asyncio.create_task(finish_process())
+    started = time.monotonic()
+    try:
+        assert await shell._wait_exec_stdin_writer(proc, writer_task, timeout=0.5)
+        assert time.monotonic() - started < 0.25
+        assert not writer_task.done()
+    finally:
+        await process_task
+        await shell._cancel_exec_stdin_writer(proc, writer_task)
+
+    assert writer_task.cancelled()
+
+
+@pytest.mark.asyncio
 @pytest.mark.skipif(os.name != "posix", reason="large pipe backpressure is POSIX-specific")
 async def test_exec_command_stdin_write_obeys_timeout() -> None:
     command = _python_shell_command("import time; time.sleep(5)")


### PR DESCRIPTION
## Scope

- Treat an already-exited subprocess as authoritative when Windows leaves `StreamWriter.wait_closed()` pending.
- Cancel the stale stdin writer after process completion.
- Add a regression test for the process-exit/pipe-close race.

## Target

`main`

## Linked issue

None.

## Root cause

Windows' proactor pipe transport can keep `wait_closed()` pending after the child has consumed EOF and exited. The host shell runner previously waited for pipe closure before observing process completion, so a successful short command could be reported as a five-second timeout.

## Validation

- `uv run pytest tests/test_tools/test_shell_process_isolation.py -q` — 32 passed
- `uv run ruff check src/opensquilla/tools/builtin/shell.py tests/test_tools/test_shell_process_isolation.py` — passed
- Main run 30806365368 attempt 2 passed on the same SHA after the previous smoke failure, confirming the failure is timing-sensitive.

## Safety and compatibility

- No public API, persisted state, configuration, packaging, or release asset changes.
- POSIX process-group cleanup remains unchanged.
- The normal stdin EOF wait remains intact; only an observed child-process exit can end the pipe-close wait early.

## Release note

Not required; CI/runtime reliability fix without a public interface change.

## Third-party origin

None.
