### PR TITLE
Broaden TokenRhythm application attribution hosts

### DIFF
--- a/src/opensquilla/provider/app_attribution.py
+++ b/src/opensquilla/provider/app_attribution.py
@@ -8,6 +8,7 @@ OPENSQUILLA_APP_REFERER = "https://opensquilla.ai"
 OPENSQUILLA_APP_TITLE = "OpenSquilla"
 
 _APP_ATTRIBUTION_ROOT_HOSTS = frozenset({"openrouter.ai", "tokenrhythm.studio"})
+_APP_ATTRIBUTION_HOST_MARKERS = frozenset({"tokenrhythm"})
 
 
 def _normalized_hostname(url: str | None) -> str:
@@ -44,10 +45,13 @@ def is_provider_app_host(url: str | None, root_host: str) -> bool:
 
 
 def provider_app_headers(url: str | None) -> dict[str, str]:
-    """Return OpenSquilla attribution headers for allowlisted provider hosts."""
-    if not any(
+    """Return OpenSquilla attribution headers for supported provider hosts."""
+    host = _normalized_hostname(url)
+    matches_root = any(
         is_provider_app_host(url, root) for root in _APP_ATTRIBUTION_ROOT_HOSTS
-    ):
+    )
+    matches_marker = any(marker in host for marker in _APP_ATTRIBUTION_HOST_MARKERS)
+    if not matches_root and not matches_marker:
         return {}
     return {
         "HTTP-Referer": OPENSQUILLA_APP_REFERER,

--- a/tests/test_provider_app_attribution.py
+++ b/tests/test_provider_app_attribution.py
@@ -21,9 +21,12 @@ EXPECTED_HEADERS = {
         "https://tokenrhythm.studio/v1",
         "https://api.tokenrhythm.studio/v1",
         "tokenrhythm.studio/v1",
+        "https://tokenrhythm.example/v1",
+        "https://api.tokenrhythm.example/v1",
+        "https://api-tokenrhythm.example/v1",
     ],
 )
-def test_provider_app_headers_accept_official_hosts(url: str) -> None:
+def test_provider_app_headers_accept_supported_hosts(url: str) -> None:
     assert provider_app_headers(url) == EXPECTED_HEADERS
 
 
@@ -35,10 +38,10 @@ def test_provider_app_headers_accept_official_hosts(url: str) -> None:
         "   ",
         "https://api.openai.com/v1",
         "http://localhost:4000/v1",
-        "https://tokenrhythm.studio.example.com/v1",
-        "https://eviltokenrhythm.studio/v1",
         "https://openrouter.ai.example.com/v1",
         "https://evilopenrouter.ai/v1",
+        "https://example.com/tokenrhythm/v1",
+        "https://example.com/v1?provider=tokenrhythm",
         "https://[tokenrhythm.studio",
         "http://[::1%.openrouter.ai]/v1",
         "http://[::1%25.openrouter.ai]/v1",

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -481,19 +481,36 @@ def test_dashscope_stream_timeout_emits_heartbeat_before_non_stream_fallback(
     )
 
 
-def test_tokenrhythm_chat_adds_app_attribution_headers(monkeypatch: Any) -> None:
+@pytest.mark.parametrize(
+    ("base_url", "expected_url"),
+    [
+        (
+            "https://tokenrhythm.studio/v1",
+            "https://tokenrhythm.studio/v1/chat/completions",
+        ),
+        (
+            "https://api-tokenrhythm.example/v1",
+            "https://api-tokenrhythm.example/v1/chat/completions",
+        ),
+    ],
+)
+def test_tokenrhythm_chat_adds_app_attribution_headers(
+    monkeypatch: Any,
+    base_url: str,
+    expected_url: str,
+) -> None:
     captured: dict[str, Any] = {}
     _patch_transport(monkeypatch, captured)
     provider = OpenAIProvider(
         api_key="test",
         model="deepseek-v4-flash",
-        base_url="https://tokenrhythm.studio/v1",
+        base_url=base_url,
         provider_kind="tokenrhythm",
     )
 
     _collect(provider, ChatConfig())
 
-    assert captured["url"] == "https://tokenrhythm.studio/v1/chat/completions"
+    assert captured["url"] == expected_url
     assert captured["headers"].get("HTTP-Referer") == "https://opensquilla.ai"
     assert captured["headers"].get("X-Title") == "OpenSquilla"
 


### PR DESCRIPTION
## Scope

Broaden OpenSquilla application attribution so provider API hostnames containing `tokenrhythm` receive the public `HTTP-Referer` and `X-Title` headers. Matching is based only on the parsed hostname; path and query text do not qualify. OpenRouter remains restricted to its allowlisted root domain.

Add focused helper and OpenAI-compatible request regression coverage for alternate TokenRhythm hostnames.

## Target

`main`

## Linked issue

None

## Release note

Not required. This is a narrow additive provider-attribution compatibility fix.

## Verification

- `UV_CACHE_DIR=/tmp/opensquilla-uv-cache uv run pytest tests/test_provider_app_attribution.py tests/test_provider_openrouter_attribution.py tests/test_provider_openai_compat_payloads.py -q` — 159 passed
- `UV_CACHE_DIR=/tmp/opensquilla-uv-cache uv run ruff check src/opensquilla/provider/app_attribution.py tests/test_provider_app_attribution.py tests/test_provider_openai_compat_payloads.py` — passed
- `git diff --check` — passed

## Safety and compatibility

Only public application identity headers are broadened. TokenRhythm correlation and billing-related host gates remain restricted to official origins. No persisted configuration, database state, public protocol fields, or platform-specific behavior changes.

## Third-party origin

None.