### PR TITLE
Send install identity to official TokenRhythm APIs

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -110,6 +110,7 @@
       "tests/test_provider/test_failure_injection.py",
       "tests/test_provider/test_live_catalog.py",
       "tests/test_provider/test_preset_registry.py",
+      "tests/test_provider/test_tokenrhythm_traceback_boundaries.py",
       "tests/test_provider_anthropic_sse_nospace.py",
       "tests/test_provider_app_attribution.py",
       "tests/test_provider_execution_status_projection.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -688,6 +688,7 @@
     "tests/test_provider/test_shared_catalog.py": 0.01,
     "tests/test_provider/test_spec_substrate.py": 0.01,
     "tests/test_provider/test_stream_goldens.py": 0.057,
+    "tests/test_provider/test_tokenrhythm_traceback_boundaries.py": 0.01,
     "tests/test_provider/test_trace_recorder.py": 0.011,
     "tests/test_provider_anthropic_sse_nospace.py": 0.01,
     "tests/test_provider_anthropic_usage.py": 0.05,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Official TokenRhythm HTTPS API requests can now include the optional
+  `X-OpenSquilla-Install-Id` header by default. It carries the existing
+  pseudonymous, cross-session installation identifier without exposing raw
+  MAC/IP values, is restricted to the two exact official hosts on port 443,
+  fails open when unavailable, and is suppressed by the unified privacy
+  control, the legacy telemetry opt-out, and CI/test detection. The update-check
+  opt-out alone does not suppress it. TokenRhythm must treat the value as
+  optional and untrusted, never as an authentication, authorization, billing,
+  rate-limiting, or anti-abuse signal.
+
 ## [0.5.2] - 2026-07-30
 
 ### Added

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -43,10 +43,13 @@ corresponding feature is enabled by configuration or user action.
 
 ## Network Observability Controls
 
-OpenSquilla groups non-user-initiated network observability under one switch.
-Set this before startup to disable automatic install telemetry, daily aggregate
-usage telemetry, passive update checks, and automatic desktop update checks at
-startup and during long-running app sessions:
+OpenSquilla groups background network observability and the optional
+pseudonymous installation identifier attached to official TokenRhythm API
+requests under one switch. Enable it to disable automatic install telemetry,
+daily aggregate usage telemetry, passive update checks, automatic desktop
+update checks, and that TokenRhythm request identifier. Changes to the
+TokenRhythm identifier policy apply to the next request without requiring a
+restart:
 
 ```sh
 OPENSQUILLA_PRIVACY_DISABLE_NETWORK_OBSERVABILITY=true
@@ -66,6 +69,10 @@ OPENSQUILLA_TELEMETRY_DISABLED=true
 OPENSQUILLA_UPDATE_CHECK_DISABLED=true
 ```
 
+`OPENSQUILLA_TELEMETRY_DISABLED=true` also suppresses the optional TokenRhythm
+installation identifier. Setting only
+`OPENSQUILLA_UPDATE_CHECK_DISABLED=true` does not suppress it.
+
 Manual user-initiated actions may still contact network services after user
 intent, including release downloads and configured providers, search, channels,
 automation, or integrations. Update-availability checks, including
@@ -74,10 +81,10 @@ unified or legacy opt-out controls.
 
 ## Installation Telemetry
 
-OpenSquilla uses anonymous installation telemetry to estimate install counts,
-version adoption, and runtime compatibility. Telemetry is sent on first gateway
-startup and once per OpenSquilla version. Uploads use a short timeout and never
-block startup.
+OpenSquilla uses pseudonymous installation telemetry to estimate install
+counts, version adoption, and runtime compatibility. Telemetry is sent on first
+gateway startup and once per OpenSquilla version. Uploads use a short timeout
+and never block startup.
 
 Telemetry payloads include:
 
@@ -103,6 +110,9 @@ Use the unified network observability switch above to opt out before startup.
 The legacy telemetry opt-out `OPENSQUILLA_TELEMETRY_DISABLED=true` remains
 honored for compatibility.
 
+CI and test environments automatically suppress installation telemetry before
+an installation identifier is generated or uploaded.
+
 Advanced deployments can direct installation and usage telemetry to independent
 routes on their own service:
 
@@ -110,6 +120,41 @@ routes on their own service:
 OPENSQUILLA_TELEMETRY_ENDPOINT=https://example.com/v1/install
 OPENSQUILLA_USAGE_TELEMETRY_ENDPOINT=https://example.com/v1/usage
 ```
+
+## TokenRhythm Installation Identifier
+
+By default, OpenSquilla may add this optional header to requests sent directly
+to the official TokenRhythm HTTPS API:
+
+```http
+X-OpenSquilla-Install-Id: <current install_id>
+```
+
+This is a pseudonymous installation-level identifier. It is stable across
+sessions and reuses the same locally persisted `install_id` described above,
+including its MAC-address, local-IP, and random persisted fallback order. Raw
+MAC addresses and raw IP addresses are never placed in the header or sent as
+part of the request. Identifier resolution happens in the background; if it is
+not ready or fails validation, OpenSquilla omits the header and continues the
+request normally.
+
+The header is allowed only for direct API targets on
+`https://tokenrhythm.studio` and `https://api.tokenrhythm.studio`, using the
+default HTTPS port or an explicit port `443`. OpenSquilla does not attach it to
+HTTP URLs, URLs with user information, nonstandard ports, lookalike domains,
+custom proxies, OpenRouter, other providers, browser registration pages,
+returned image or CDN downloads, or redirected nonofficial targets. It is not
+placed in request bodies or query strings, and provider traces record only
+whether it was present, not its value. The raw value is also excluded from
+logs, errors, and serialized configuration.
+
+The unified network-observability switch and the legacy telemetry opt-out both
+suppress generation and transmission of this header. CI and test environments
+suppress it automatically. The legacy update-check opt-out alone does not.
+
+TokenRhythm services must treat this header as optional and untrusted. It must
+not be used for authentication, authorization, billing, rate limiting, or
+anti-abuse decisions.
 
 ## Daily Aggregate Usage Telemetry
 

--- a/README.md
+++ b/README.md
@@ -387,9 +387,9 @@ full reference.
 
 ## Installation Privacy
 
-OpenSquilla uses anonymous installation telemetry to estimate install counts,
-version adoption, and runtime compatibility. Data is sent on first gateway
-startup and once per OpenSquilla version. It also records content-free daily
+OpenSquilla uses pseudonymous installation telemetry to estimate install
+counts, version adoption, and runtime compatibility. Data is sent on first
+gateway startup and once per OpenSquilla version. It also records content-free daily
 aggregates of completed top-level conversations and token usage by UTC date,
 and attempts to upload pending cumulative UTC-day snapshots to the telemetry
 service at startup and once per hour. OpenSquilla may also make
@@ -418,6 +418,15 @@ The `install_id` is a local one-way SHA-256 digest derived from usable MAC
 addresses, then local IP addresses when no MAC is available, with a random
 persisted fallback. Raw MAC/IP values are not uploaded.
 
+By default, requests sent directly to the official TokenRhythm HTTPS API may
+also carry the same pseudonymous, cross-session installation identifier in the
+optional `X-OpenSquilla-Install-Id` header. Only the exact official
+`tokenrhythm.studio` and `api.tokenrhythm.studio` HTTPS hosts on port 443 are
+eligible; custom proxies, OpenRouter, other providers, browser pages,
+redirected nonofficial targets, and returned image/CDN downloads are excluded.
+The raw MAC/IP values are never sent. The header is omitted if its background
+resolution is not ready or fails, so requests continue normally.
+
 What is not sent: usernames, hostnames, paths, API keys, provider config,
 chat/session/memory/agent content, file names, or file contents. Source IP may
 be visible to HTTP servers at the transport layer, but is not part of the
@@ -437,12 +446,14 @@ disable_network_observability = true
 ```
 
 That unified switch covers automatic install telemetry, daily aggregate usage
-telemetry, passive update checks,
-and automatic desktop update checks at startup and during long-running app
-sessions. Explicit update-availability checks remain disabled while the unified
-or legacy opt-out is active. Other user-initiated actions may still contact
-network services after user intent, including release downloads and configured
-providers, search, or channels.
+telemetry, passive update checks, and automatic desktop update checks at
+startup and during long-running app sessions, as well as the TokenRhythm
+installation header. Explicit update-availability checks remain disabled while
+the unified or legacy opt-out is active. CI and test environments also
+suppress the installation header and installation telemetry automatically.
+Other user-initiated actions may still
+contact network services after user intent, including release downloads and
+configured providers, search, or channels.
 
 Legacy opt-out environment variables remain honored:
 
@@ -450,6 +461,13 @@ Legacy opt-out environment variables remain honored:
 OPENSQUILLA_TELEMETRY_DISABLED=true
 OPENSQUILLA_UPDATE_CHECK_DISABLED=true
 ```
+
+The legacy telemetry opt-out suppresses the TokenRhythm installation header;
+the update-check opt-out by itself does not. TokenRhythm must treat the header
+as optional and untrusted, and must not use it for authentication,
+authorization, billing, rate limiting, or anti-abuse decisions. See
+[`PRIVACY.md`](PRIVACY.md#tokenrhythm-installation-identifier) for the complete
+target and data-handling rules.
 
 Advanced deployments can use their own installation telemetry endpoint:
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -333,7 +333,7 @@ opensquilla uninstall --purge-all      # 全部（会要求你输入确认）
 
 ## 安装隐私
 
-OpenSquilla 使用匿名安装遥测来估算安装数量、版本采纳情况和运行时兼容性。数据只在网关
+OpenSquilla 使用伪匿名安装遥测来估算安装数量、版本采纳情况和运行时兼容性。数据只在网关
 首次启动时上报，并且每个 OpenSquilla 版本只上报一次。它还会在本地按 UTC 日期汇总已完成
 的顶层对话次数和 token 用量，并在启动时及此后每小时尝试向遥测服务上报待发送的 UTC
 当日累计快照。OpenSquilla 也可能执行被动更新检查，包括桌面启动时以及应用持续运行期间
@@ -354,6 +354,13 @@ OpenSquilla 使用匿名安装遥测来估算安装数量、版本采纳情况�
 `install_id` 是一个本地单向 SHA-256 摘要，由可用的 MAC 地址派生；无 MAC 时使用本地 IP
 地址，并以一个随机持久化值兜底。原始 MAC/IP 值不会被上传。
 
+默认情况下，直接发往 TokenRhythm 官方 HTTPS API 的请求还可能通过可选的
+`X-OpenSquilla-Install-Id` 请求头携带同一个跨会话伪匿名安装标识。只有端口 443 上严格匹配
+`tokenrhythm.studio` 和 `api.tokenrhythm.studio` 的 HTTPS 主机才符合条件；自定义代理、
+OpenRouter、其他提供商、浏览器页面、重定向后的非官方目标，以及返回的图片/CDN 下载均不
+携带该请求头。原始 MAC/IP 值绝不会发送。若后台解析尚未完成或失败，请求头会被省略，API
+请求仍会正常继续。
+
 不发送的内容:用户名、主机名、路径、API key、提供商配置、聊天/会话/记忆/Agent 内容、
 文件名或文件内容。源 IP 在传输层可能会被 HTTP 服务器看到，但它不在上传的数据内。
 
@@ -370,7 +377,11 @@ OPENSQUILLA_PRIVACY_DISABLE_NETWORK_OBSERVABILITY=true
 disable_network_observability = true
 ```
 
-这个统一开关覆盖自动安装遥测、每日汇总用量遥测、被动更新检查，以及桌面启动时和应用持续运行期间的自动更新检查。只要统一或兼容退出开关仍启用，用户显式触发的更新可用性检查也不会绕过它。其他用户主动操作仍可能在明确意图后访问网络服务，例如打开发布页、下载发布资产，以及使用已配置的提供商、搜索或渠道。
+这个统一开关覆盖自动安装遥测、每日汇总用量遥测、被动更新检查、桌面启动时和应用持续
+运行期间的自动更新检查，以及 TokenRhythm 安装标识请求头。只要统一或兼容退出开关仍启用，
+用户显式触发的更新可用性检查也不会绕过它。CI 和测试环境也会自动抑制安装标识请求头与
+安装遥测。其他用户主动操作仍可能在明确意图后访问网络服务，例如打开发布页、下载发布
+资产，以及使用已配置的提供商、搜索或渠道。
 
 旧环境变量仍兼容:
 
@@ -378,6 +389,11 @@ disable_network_observability = true
 OPENSQUILLA_TELEMETRY_DISABLED=true
 OPENSQUILLA_UPDATE_CHECK_DISABLED=true
 ```
+
+旧遥测退出开关会抑制 TokenRhythm 安装标识请求头；仅启用更新检查退出开关则不会。
+TokenRhythm 必须将此请求头视为可选且不可信，不得将其用于认证、授权、计费、限流或反滥用
+决策。完整的目标校验与数据处理规则见
+[`PRIVACY.md`](PRIVACY.md#tokenrhythm-installation-identifier)。
 
 进阶部署可以使用自己的安装遥测端点:
 

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -1447,7 +1447,7 @@
       "statusDisabled": "Netzwerkberichte sind ausgeschaltet.",
       "statusDisabledByEnv": "Netzwerkberichte sind ausgeschaltet, weil eine Umgebungsvariable sie deaktiviert.",
       "disableNetworkObservabilityLabel": "Netzwerkberichte ausschalten",
-      "disableNetworkObservabilityDesc": "Stoppt Installationstelemetrie, Updateprüfungen im Hintergrund und die anonymen Kennungen, die Anfragen einer Sitzung miteinander verknüpfen — diese Kennungen gehen ausschließlich an die offizielle TokenRhythm-API. Ihre eigenen Modellanfragen funktionieren weiterhin.",
+      "disableNetworkObservabilityDesc": "Stoppt Installations- und tägliche Nutzungstelemetrie, Updateprüfungen im Hintergrund sowie pseudonyme Sitzungskennungen und den standardmäßig gesendeten optionalen sitzungsübergreifenden Header X-OpenSquilla-Install-Id, die ausschließlich an die offizielle TokenRhythm-HTTPS-API gesendet werden. Die persistierte Installationskennung kann aus lokalen MAC-/IP-Daten abgeleitet werden; Rohadressen werden nie gesendet. CI/Tests und der alte Telemetrie-Opt-out unterdrücken sie ebenfalls, der reine Update-Opt-out dagegen nicht. Ihre eigenen Modellanfragen funktionieren weiterhin.",
       "memoryAutoCaptureLabel": "Automatisches Speichern",
       "memoryAutoCaptureDesc": "OpenSquilla darf nützliche Gesprächsinhalte im Langzeitspeicher sichern.",
       "save": "Datenschutz speichern"

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -1447,7 +1447,7 @@
       "statusDisabled": "Network reporting is off.",
       "statusDisabledByEnv": "Network reporting is off because an environment setting disables it.",
       "disableNetworkObservabilityLabel": "Turn off network reporting",
-      "disableNetworkObservabilityDesc": "Stops install telemetry, background update checks, and the anonymous identifiers that link requests from one session together — those identifiers are only ever sent to the official TokenRhythm API. Your own model requests keep working.",
+      "disableNetworkObservabilityDesc": "Stops install and daily usage telemetry, background update checks, pseudonymous session identifiers, and the optional cross-session X-OpenSquilla-Install-Id header sent by default only to the official TokenRhythm HTTPS API. That persisted ID may be derived from local MAC/IP data; raw addresses are never sent. CI/tests and the legacy telemetry opt-out also suppress it; the update-check opt-out alone does not. Your own model requests keep working.",
       "memoryAutoCaptureLabel": "Automatic memory capture",
       "memoryAutoCaptureDesc": "Allow OpenSquilla to save useful conversation highlights into long-term memory.",
       "save": "Save privacy"

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -1447,7 +1447,7 @@
       "statusDisabled": "Los informes de red están desactivados.",
       "statusDisabledByEnv": "Los informes de red están desactivados por una variable de entorno.",
       "disableNetworkObservabilityLabel": "Desactivar los informes de red",
-      "disableNetworkObservabilityDesc": "Detiene la telemetría de instalación, las comprobaciones de actualizaciones en segundo plano y los identificadores anónimos que vinculan las solicitudes de una misma sesión — esos identificadores solo se envían a la API oficial de TokenRhythm. Tus propias solicitudes de modelo siguen funcionando.",
+      "disableNetworkObservabilityDesc": "Detiene la telemetría de instalación y de uso diario, las comprobaciones de actualizaciones en segundo plano, los identificadores seudónimos de sesión y la cabecera opcional X-OpenSquilla-Install-Id entre sesiones, enviada de forma predeterminada solo a la API HTTPS oficial de TokenRhythm. El ID de instalación persistente puede derivarse de datos MAC/IP locales; nunca se envían las direcciones originales. Los entornos CI/pruebas y la exclusión heredada de telemetría también lo suprimen; desactivar solo las actualizaciones no. Tus propias solicitudes de modelo siguen funcionando.",
       "memoryAutoCaptureLabel": "Captura automática de memoria",
       "memoryAutoCaptureDesc": "Permite que OpenSquilla guarde información útil de las conversaciones en la memoria a largo plazo.",
       "save": "Guardar privacidad"

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -1447,7 +1447,7 @@
       "statusDisabled": "Les rapports réseau sont désactivés.",
       "statusDisabledByEnv": "Les rapports réseau sont désactivés par une variable d'environnement.",
       "disableNetworkObservabilityLabel": "Désactiver les rapports réseau",
-      "disableNetworkObservabilityDesc": "Arrête la télémétrie d'installation, les vérifications de mise à jour en arrière-plan et les identifiants anonymes qui relient les requêtes d'une même session — ces identifiants ne sont envoyés qu'à l'API officielle TokenRhythm. Vos propres requêtes de modèle continuent de fonctionner.",
+      "disableNetworkObservabilityDesc": "Arrête la télémétrie d'installation et d'usage quotidien, les vérifications de mise à jour en arrière-plan, les identifiants pseudonymes de session et l'en-tête intersession facultatif X-OpenSquilla-Install-Id, envoyé par défaut uniquement à l'API HTTPS officielle de TokenRhythm. L'identifiant d'installation persistant peut être dérivé de données MAC/IP locales ; les adresses brutes ne sont jamais envoyées. Les environnements CI/test et l'ancien refus de télémétrie le suppriment aussi ; le refus des seules mises à jour ne le fait pas. Vos propres requêtes de modèle continuent de fonctionner.",
       "memoryAutoCaptureLabel": "Capture automatique de la mémoire",
       "memoryAutoCaptureDesc": "Autorise OpenSquilla à enregistrer les informations utiles des conversations dans la mémoire à long terme.",
       "save": "Enregistrer la confidentialité"

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -1447,7 +1447,7 @@
       "statusDisabled": "ネットワーク報告はオフです。",
       "statusDisabledByEnv": "環境変数の設定により、ネットワーク報告はオフになっています。",
       "disableNetworkObservabilityLabel": "ネットワーク報告をオフにする",
-      "disableNetworkObservabilityDesc": "インストールテレメトリ、バックグラウンドの更新確認、同じセッションのリクエストを結び付ける匿名識別子を停止します。この識別子は公式の TokenRhythm API にのみ送信されます。自分で開始したモデルリクエストはそのまま動作します。",
+      "disableNetworkObservabilityDesc": "インストールおよび日次使用量テレメトリ、バックグラウンドの更新確認、公式 TokenRhythm HTTPS API にのみ送信されるセッション用の仮名識別子と、デフォルトで送信されるセッションをまたぐ任意の X-OpenSquilla-Install-Id ヘッダーを停止します。永続化されたインストール ID はローカルの MAC/IP データから派生する場合がありますが、生のアドレスは送信されません。CI/テスト環境および旧テレメトリ拒否設定でも抑制されますが、更新確認だけを無効にしても抑制されません。自分で開始したモデルリクエストはそのまま動作します。",
       "memoryAutoCaptureLabel": "自動メモリ",
       "memoryAutoCaptureDesc": "OpenSquilla が会話の有用な情報を長期メモリに保存することを許可します。",
       "save": "プライバシーを保存"

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -1447,7 +1447,7 @@
       "statusDisabled": "网络上报已关闭。",
       "statusDisabledByEnv": "网络上报已被环境变量设置关闭。",
       "disableNetworkObservabilityLabel": "关闭网络上报",
-      "disableNetworkObservabilityDesc": "停止安装遥测、后台更新检查，以及用于串联同一次会话请求的匿名标识——这些标识只会发送给官方 TokenRhythm API。你主动发起的模型请求不受影响。",
+      "disableNetworkObservabilityDesc": "停止安装与每日用量遥测、后台更新检查，以及仅发往官方 TokenRhythm HTTPS API 的会话级伪匿名标识和默认发送的可选跨会话 X-OpenSquilla-Install-Id 请求头。该持久化安装 ID 可能由本机 MAC/IP 派生，但绝不发送原始地址；CI/测试环境与旧遥测退出开关也会抑制它，单独关闭更新检查则不会。你主动发起的模型请求不受影响。",
       "memoryAutoCaptureLabel": "自动记忆",
       "memoryAutoCaptureDesc": "允许 OpenSquilla 将对话中有用的信息保存到长期记忆。",
       "save": "保存隐私设置"

--- a/src/opensquilla/cli/ensemble_cmd.py
+++ b/src/opensquilla/cli/ensemble_cmd.py
@@ -148,8 +148,12 @@ def ensemble_bench(
         else:
             # Config loading is a CLI concern; the eval harness owns provider coupling.
             from opensquilla.onboarding.config_store import load_config
+            from opensquilla.provider.tokenrhythm_correlation import (
+                prewarm_tokenrhythm_install_id,
+            )
 
             config = load_config(config_path)
+            prewarm_tokenrhythm_install_id(config=config)
             report = asyncio.run(
                 run_config_benchmark(
                     prompts=prompts,

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -237,8 +237,13 @@ def _build_cli_dream(agent: str, *, force: bool = False, need_provider: bool = T
 
     from opensquilla.gateway.config import GatewayConfig
     from opensquilla.memory.dream_factory import build_dream_factory
+    from opensquilla.provider.tokenrhythm_correlation import (
+        prewarm_tokenrhythm_install_id,
+    )
 
     gw = GatewayConfig.load(os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH"))
+    if need_provider:
+        prewarm_tokenrhythm_install_id(config=gw)
 
     dream = build_dream_factory(
         config=gw,

--- a/src/opensquilla/cli/models_cmd.py
+++ b/src/opensquilla/cli/models_cmd.py
@@ -7,6 +7,7 @@ import json
 import sys
 from dataclasses import dataclass, replace
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import typer
@@ -238,6 +239,25 @@ async def _run_probes(targets: list[_ProbeTarget], timeout: float) -> list[dict[
     return [await _probe_one(target, timeout) for target in targets]
 
 
+def _prewarm_draft_probe_install_id() -> None:
+    """Register the active privacy context before an unsaved live probe."""
+
+    from opensquilla.provider.tokenrhythm_correlation import (
+        prewarm_tokenrhythm_install_id,
+    )
+
+    config: Any
+    try:
+        config = load_config(None)
+    except Exception:
+        # A malformed local config must not break the desktop bridge, but it
+        # also must not fall back to an implicitly enabled privacy context.
+        config = SimpleNamespace(
+            privacy=SimpleNamespace(disable_network_observability=True)
+        )
+    prewarm_tokenrhythm_install_id(config=config)
+
+
 @app.command("probe-draft", hidden=True)
 def models_probe_draft() -> None:
     """Probe one unsaved provider draft supplied as JSON on stdin.
@@ -273,6 +293,7 @@ def models_probe_draft() -> None:
         )
         raise typer.Exit(code=2)
 
+    _prewarm_draft_probe_install_id()
     target = _ProbeTarget(
         provider_id=provider_id,
         model=model,
@@ -310,6 +331,11 @@ def models_probe(
     probe fails, 2 on invalid selection.
     """
     cfg = load_config(config_path)
+    from opensquilla.provider.tokenrhythm_correlation import (
+        prewarm_tokenrhythm_install_id,
+    )
+
+    prewarm_tokenrhythm_install_id(config=cfg)
     targets = _probe_targets(cfg)
     if provider:
         wanted = provider.strip().lower()

--- a/src/opensquilla/cli/onboard_cmd.py
+++ b/src/opensquilla/cli/onboard_cmd.py
@@ -450,8 +450,12 @@ def _probe_saved_provider(cfg) -> bool:
     import asyncio
 
     from opensquilla.onboarding.probe import probe_llm_provider
+    from opensquilla.provider.tokenrhythm_correlation import (
+        prewarm_tokenrhythm_install_id,
+    )
 
     llm = cfg.llm
+    prewarm_tokenrhythm_install_id(config=cfg)
     console.print(f"[{ACCENT_SOFT}]◆[/] Checking the connection…")
     try:
         result = asyncio.run(

--- a/src/opensquilla/contrib/codetask/agent_config.py
+++ b/src/opensquilla/contrib/codetask/agent_config.py
@@ -27,7 +27,14 @@ from opensquilla.paths import default_opensquilla_home
 # one provider 404 on another. [llm_ensemble] is deliberately NOT carried:
 # its static profiles opt back in on env-key presence alone, which would
 # re-pin the subagent to a provider the operator moved away from.
-OPERATOR_SECTIONS = ("llm", "squilla_router", "llm_profiles", "models", "model_catalog")
+OPERATOR_SECTIONS = (
+    "llm",
+    "squilla_router",
+    "llm_profiles",
+    "models",
+    "model_catalog",
+    "privacy",
+)
 
 # Field-level pydantic precedence is init (TOML) > env, and env fills fields
 # ABSENT from the TOML section — so a key stripped from the written file is
@@ -80,10 +87,32 @@ def load_agent_config_bundle() -> AgentConfigBundle:
     """Assemble and validate the subagent config for one code-task run."""
     override = agent_config_override()
     if override is not None:
-        # An explicit operator override is fully authoritative: no provider
-        # inheritance, so a hand-tuned subagent config (the documented #541
-        # escape hatch) is never partially rewritten.
-        payload = _validated(_read_payload(override), source=str(override))
+        # An explicit operator override remains authoritative for provider and
+        # run policy (the documented #541 escape hatch).  The gateway's
+        # explicitly configured privacy policy still applies to every child
+        # process, however, so it cannot be relaxed by a provider override.
+        payload = _read_payload(override)
+        try:
+            user_payload, _source = user_config_payload()
+        except AgentConfigError:
+            # The explicit override is the recovery path for a broken ordinary
+            # config. Keep it usable, but never silently enable installation
+            # metadata when the operator's privacy policy cannot be read.
+            payload["privacy"] = {"disable_network_observability": True}
+        else:
+            if "privacy" in user_payload:
+                privacy_payload = user_payload["privacy"]
+                try:
+                    from opensquilla.gateway.config import PrivacyConfig
+
+                    PrivacyConfig(**privacy_payload)
+                except Exception:
+                    payload["privacy"] = {
+                        "disable_network_observability": True
+                    }
+                else:
+                    payload["privacy"] = copy.deepcopy(privacy_payload)
+        payload = _validated(payload, source=str(override))
         return AgentConfigBundle(payload=payload, source_path=str(override))
     template_payload = _read_payload(agent_config_path())
     user_payload, source = user_config_payload()
@@ -100,8 +129,8 @@ def build_per_run_agent_config(
 
     Operator sections replace the template's wholesale (and are dropped when
     the operator has none, falling back to built-in defaults plus env), so
-    the subagent resolves provider, model, credentials, and router tiers
-    exactly like the operator's own gateway.
+    the subagent resolves provider, model, credentials, router tiers, and
+    network-observability privacy exactly like the operator's own gateway.
     """
     merged = copy.deepcopy(template_payload)
     child_env: dict[str, str] = {}

--- a/src/opensquilla/contrib/codetask/preflight.py
+++ b/src/opensquilla/contrib/codetask/preflight.py
@@ -22,12 +22,20 @@ workable run into a hard stop.
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING
 
 import structlog
 
 from opensquilla.contrib.codetask.agent_config import AgentConfigBundle
 from opensquilla.onboarding.probe import ProviderProbeResult, probe_llm_provider
 from opensquilla.provider.failures import ProviderFailureKind
+from opensquilla.provider.tokenrhythm_correlation import (
+    prewarm_tokenrhythm_install_id,
+    redact_tokenrhythm_install_ids,
+)
+
+if TYPE_CHECKING:
+    from opensquilla.gateway.config import GatewayConfig
 
 log = structlog.get_logger(__name__)
 
@@ -47,8 +55,8 @@ _CREDENTIAL_BLOCK_CODES = frozenset({"no_provider", "401", "402", "403"})
 
 def _effective_provider_config(
     bundle: AgentConfigBundle, model_override: str
-) -> tuple[str, str, str, str, str] | None:
-    """Resolve (provider, model, api_key, base_url, proxy) the subagent will use.
+) -> tuple[GatewayConfig, str, str, str, str, str] | None:
+    """Resolve the config and provider settings the subagent will use.
 
     Returns ``None`` if the bundle carries no usable ``[llm]`` (nothing to
     probe). Mirrors the child's own resolution: build the config from the
@@ -78,7 +86,7 @@ def _effective_provider_config(
     # named by api_key_env / the provider spec, which resolve_llm_runtime_config
     # already applied.
     api_key = bundle.child_env.get("OPENSQUILLA_LLM_API_KEY", "") or (runtime.api_key or "")
-    return provider, model, api_key, runtime.base_url or "", runtime.proxy or ""
+    return cfg, provider, model, api_key, runtime.base_url or "", runtime.proxy or ""
 
 
 def provider_preflight(bundle: AgentConfigBundle, model_override: str = "") -> tuple[bool, str]:
@@ -92,7 +100,12 @@ def provider_preflight(bundle: AgentConfigBundle, model_override: str = "") -> t
     resolved = _effective_provider_config(bundle, model_override)
     if resolved is None:
         return True, ""
-    provider, model, api_key, base_url, proxy = resolved
+    config, provider, model, api_key, base_url, proxy = resolved
+
+    # Register the exact effective child config before the probe can issue a
+    # TokenRhythm request.  Resolution remains asynchronous/fail-open inside
+    # the prewarmer, so this does not add blocking I/O to preflight.
+    prewarm_tokenrhythm_install_id(config=config)
 
     try:
         spec = get_provider_spec(provider)
@@ -118,15 +131,19 @@ def provider_preflight(bundle: AgentConfigBundle, model_override: str = "") -> t
     except ValueError:
         return True, ""  # validation-level probe issue — fail open
     except Exception as exc:  # never let a probe bug block a run
-        log.warning("codetask.preflight.probe_error", error=str(exc))
+        log.warning(
+            "codetask.preflight.probe_error",
+            error=redact_tokenrhythm_install_ids(str(exc)),
+        )
         return True, ""
 
     if probe.ok:
         return True, ""
     if probe.failure_kind in _CREDENTIAL_BLOCK_KINDS:
+        safe_probe_message = redact_tokenrhythm_install_ids(probe.message)
         return False, (
             f"code-task's provider '{provider}' cannot authenticate for model "
-            f"'{model}': {probe.message} Configure a working provider (run "
+            f"'{model}': {safe_probe_message} Configure a working provider (run "
             "`opensquilla onboard`) or set that provider's API key, then retry."
         )
     # Non-credential failure (transport blip, model-not-found, …): fail open.
@@ -150,7 +167,9 @@ def provider_block_reason(errors: list[dict]) -> str | None:
             continue
         code = str(err.get("code") or "").strip().lower()
         if code in _CREDENTIAL_BLOCK_CODES:
-            message = str(err.get("message") or "").strip()
+            message = redact_tokenrhythm_install_ids(
+                str(err.get("message") or "").strip()
+            )
             detail = f": {message}" if message else ""
             return (
                 "code-task's provider rejected the request (the configured "

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -117,6 +117,22 @@ def _start_background_install_telemetry(config: GatewayConfig) -> None:
         log.debug("gateway.install_telemetry_skipped", exc_info=True)
 
 
+def _prewarm_tokenrhythm_install_id(config: GatewayConfig) -> None:
+    """Prime the optional TokenRhythm install header without delaying boot."""
+
+    try:
+        from opensquilla.provider.tokenrhythm_correlation import (
+            prewarm_tokenrhythm_install_id,
+        )
+
+        prewarm_tokenrhythm_install_id(config=config)
+    except Exception:
+        # Install identity is best-effort request metadata.  A resolver or
+        # thread-start failure must never make the gateway/standalone runtime
+        # unavailable.
+        log.debug("gateway.tokenrhythm_install_id_prewarm_skipped", exc_info=True)
+
+
 def _auto_propose_usage_execution_context(
     agent_id: str,
     usage_event_sink: Any | None,
@@ -2405,6 +2421,7 @@ async def build_services(
         config = GatewayConfig.load(os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH"))
         if config.config_path:
             log.info("build_services.config_loaded", path=config.config_path)
+    _prewarm_tokenrhythm_install_id(config)
     deferred_warmups: list[Callable[[], Any]] = []
     sandbox_setup_task: asyncio.Task[Any] | None = None
     _warn_workspace_state_mismatch(config)

--- a/src/opensquilla/observability/network_policy.py
+++ b/src/opensquilla/observability/network_policy.py
@@ -17,6 +17,15 @@ _DISABLE_ENV_VARS = (
     LEGACY_TELEMETRY_DISABLED_ENV,
     LEGACY_UPDATE_CHECK_DISABLED_ENV,
 )
+_PROVIDER_INSTALL_ID_DISABLE_ENV_VARS = (
+    NETWORK_OBSERVABILITY_DISABLED_ENV,
+    LEGACY_TELEMETRY_DISABLED_ENV,
+)
+_AUTO_SUPPRESS_ENV_VARS = (
+    "GITHUB_ACTIONS",
+    "PYTEST_CURRENT_TEST",
+    "OPENSQUILLA_TESTING",
+)
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 
 
@@ -48,6 +57,46 @@ def provider_request_correlation_disabled(
     if _is_truthy(env_source.get(NETWORK_OBSERVABILITY_DISABLED_ENV)):
         return True
     return _config_disables_network_observability(config)
+
+
+def provider_install_id_disabled(
+    *,
+    config: Any | None = None,
+    env: Mapping[str, str | None] | None = None,
+) -> bool:
+    """Return whether the TokenRhythm installation identifier is disabled.
+
+    The installation identifier is passive telemetry metadata even though it
+    travels with a provider request.  It therefore honors both the unified
+    privacy switch and the legacy telemetry switch, but intentionally does not
+    inherit the update-check-only switch.  Automated CI/test environments use
+    the same suppression rules as installation telemetry so they neither
+    create telemetry state nor emit an identifier accidentally.
+    """
+
+    env_source = os.environ if env is None else env
+    if any(
+        _is_truthy(env_source.get(name))
+        for name in _PROVIDER_INSTALL_ID_DISABLE_ENV_VARS
+    ):
+        return True
+    if _config_disables_network_observability(config):
+        return True
+    return _provider_install_id_environment_suppressed(env_source)
+
+
+def _provider_install_id_environment_suppressed(
+    env: Mapping[str, str | None],
+) -> bool:
+    for name in _AUTO_SUPPRESS_ENV_VARS:
+        value = env.get(name)
+        if name == "PYTEST_CURRENT_TEST":
+            if isinstance(value, str) and value.strip():
+                return True
+            continue
+        if _is_truthy(value):
+            return True
+    return False
 
 
 def _config_disables_network_observability(config: Any | None) -> bool:

--- a/src/opensquilla/onboarding/flow.py
+++ b/src/opensquilla/onboarding/flow.py
@@ -1205,6 +1205,11 @@ def run_interactive_image_generation_configure(
     questionary = _styled(_qmod)
 
     cfg = load_config(config_path)
+    from opensquilla.provider.tokenrhythm_correlation import (
+        prewarm_tokenrhythm_install_id,
+    )
+
+    prewarm_tokenrhythm_install_id(config=cfg)
     spec, provider_id = _ask_image_generation_choice(questionary, cfg)
     _print_image_generation_intro(spec)
     answers = _ask_image_generation_fields(questionary, spec, cfg)
@@ -2409,7 +2414,13 @@ def _migration_result_path(
 
 def _reload_after_migration(config_path: Path, fallback: Any):
     try:
-        return load_config(config_path)
+        config = load_config(config_path)
+        from opensquilla.provider.tokenrhythm_correlation import (
+            prewarm_tokenrhythm_install_id,
+        )
+
+        prewarm_tokenrhythm_install_id(config=config)
+        return config
     except Exception as exc:
         console.print(
             warning_panel(
@@ -2776,6 +2787,11 @@ def _restore_reset_backup(reset_backup: tuple[Path, Path]) -> None:
 
 def run_interactive_onboard(options: OnboardOptions) -> PersistResult:
     cfg = load_config(options.config_path)
+    from opensquilla.provider.tokenrhythm_correlation import (
+        prewarm_tokenrhythm_install_id,
+    )
+
+    prewarm_tokenrhythm_install_id(config=cfg)
     status = get_onboarding_status(cfg)
     if options.if_needed and status.has_config and not status.needs_onboarding:
         return persist_config(

--- a/src/opensquilla/onboarding/image_generation_model_discovery.py
+++ b/src/opensquilla/onboarding/image_generation_model_discovery.py
@@ -9,6 +9,8 @@ fallback so model selection remains useful offline and on older deployments.
 
 from __future__ import annotations
 
+import asyncio
+import json
 from typing import Any
 
 import httpx
@@ -20,8 +22,13 @@ from opensquilla.onboarding.image_generation_specs import (
     get_image_generation_provider_setup_spec,
 )
 from opensquilla.provider.app_attribution import provider_app_headers
+from opensquilla.provider.error_redaction import redacted_httpx_error
 from opensquilla.provider.image_generation_policy import (
     IMAGE_GENERATION_OFFICIAL_BASE_URLS,
+)
+from opensquilla.provider.tokenrhythm_correlation import (
+    redact_tokenrhythm_install_ids,
+    tokenrhythm_install_id_headers,
 )
 
 log = structlog.get_logger(__name__)
@@ -164,19 +171,89 @@ async def _fetch_openrouter_image_models() -> list[dict[str, Any]]:
 
 
 async def _fetch_tokenrhythm_image_models() -> list[dict[str, Any]]:
-    async with httpx.AsyncClient(
-        timeout=_DISCOVERY_TIMEOUT_SECONDS,
-        trust_env=_trust_env(),
-    ) as client:
-        response = await client.get(
-            _TOKENRHYTHM_IMAGE_MODELS_URL,
-            headers={
-                "Accept": "application/json",
-                **provider_app_headers(_TOKENRHYTHM_IMAGE_MODELS_URL),
-            },
-        )
-        response.raise_for_status()
-        return parse_tokenrhythm_image_models(response.json())
+    safe_request_error: Exception | None = None
+    cancelled_request_error: asyncio.CancelledError | None = None
+    headers: dict[str, str] = {
+        "Accept": "application/json",
+        **provider_app_headers(_TOKENRHYTHM_IMAGE_MODELS_URL),
+    }
+    client: Any = None
+    response: Any = None
+    payload: Any = None
+    parsed: list[dict[str, Any]] | None = None
+    raw_message = ""
+    raw_state = ""
+    try:
+        async with httpx.AsyncClient(
+            timeout=_DISCOVERY_TIMEOUT_SECONDS,
+            trust_env=_trust_env(),
+            follow_redirects=False,
+        ) as client:
+            headers.update(
+                tokenrhythm_install_id_headers(
+                    "tokenrhythm",
+                    _TOKENRHYTHM_IMAGE_MODELS_URL,
+                )
+            )
+            response = await client.get(
+                _TOKENRHYTHM_IMAGE_MODELS_URL,
+                headers=headers,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            parsed = parse_tokenrhythm_image_models(payload)
+    except asyncio.CancelledError:
+        cancelled_request_error = asyncio.CancelledError()
+    except httpx.HTTPError as exc:
+        safe_request_error = redacted_httpx_error(exc, api_key="")
+    except json.JSONDecodeError as exc:
+        if redact_tokenrhythm_install_ids(exc.doc) == exc.doc:
+            exc.__cause__ = None
+            exc.__context__ = None
+            exc.__traceback__ = None
+            safe_request_error = exc
+        else:
+            safe_request_error = ValueError(
+                "TokenRhythm image catalog returned invalid JSON"
+            )
+    except Exception as exc:
+        raw_message = str(exc)
+        safe_message = redact_tokenrhythm_install_ids(raw_message)
+        raw_state = repr(getattr(exc, "__dict__", {}))
+        if (
+            safe_message != raw_message
+            or redact_tokenrhythm_install_ids(raw_state) != raw_state
+        ):
+            safe_request_error = RuntimeError(
+                safe_message
+                if safe_message != raw_message
+                else "TokenRhythm image catalog parsing failed"
+            )
+        else:
+            exc.__cause__ = None
+            exc.__context__ = None
+            exc.__traceback__ = None
+            safe_request_error = exc
+
+    if cancelled_request_error is not None:
+        headers.clear()
+        client = None
+        response = None
+        payload = None
+        parsed = None
+        raw_message = ""
+        raw_state = ""
+        raise cancelled_request_error
+    if safe_request_error is not None:
+        headers.clear()
+        client = None
+        response = None
+        payload = None
+        parsed = None
+        raw_message = ""
+        raw_state = ""
+        raise safe_request_error
+    return parsed or []
 
 
 async def discover_image_generation_models(provider_id: str) -> dict[str, Any]:

--- a/src/opensquilla/provider/error_redaction.py
+++ b/src/opensquilla/provider/error_redaction.py
@@ -8,7 +8,22 @@ import httpx
 
 from opensquilla.redaction import redact_error_text
 
+from .tokenrhythm_correlation import (
+    TOKENRHYTHM_INSTALL_ID_HEADER,
+    redact_tokenrhythm_install_ids,
+)
+
 _MIN_EXACT_SECRET_LENGTH = 4
+_PRESENT_HEADER_VALUE = "[PRESENT]"
+
+
+def _redact_exact_secrets(text: str, *, api_key: str) -> str:
+    """Redact unbounded text held by an exception object."""
+
+    text = redact_tokenrhythm_install_ids(text)
+    if len(api_key) >= _MIN_EXACT_SECRET_LENGTH:
+        text = text.replace(api_key, "***")
+    return text
 
 
 def redact_upstream_error_text(
@@ -25,6 +40,7 @@ def redact_upstream_error_text(
     applied.
     """
 
+    text = redact_tokenrhythm_install_ids(text)
     known_secrets = (api_key,) if len(api_key) >= _MIN_EXACT_SECRET_LENGTH else ()
     return redact_error_text(
         text,
@@ -36,13 +52,104 @@ def redact_upstream_error_text(
 def redact_upstream_error_code(code: str, *, api_key: str) -> str:
     """Exact-redact a provider code without changing its classification text."""
 
-    if len(api_key) < _MIN_EXACT_SECRET_LENGTH:
-        return code
-    return code.replace(api_key, "***")
+    return _redact_exact_secrets(code, api_key=api_key)
+
+
+def _redacted_httpx_headers(
+    headers: httpx.Headers,
+    *,
+    api_key: str,
+) -> list[tuple[str, str]]:
+    """Clone HTTP headers without retaining exact provider-bound secrets."""
+
+    safe_headers: list[tuple[str, str]] = []
+    install_id_header = TOKENRHYTHM_INSTALL_ID_HEADER.lower()
+    for name, value in headers.multi_items():
+        safe_name = _redact_exact_secrets(name, api_key=api_key)
+        safe_value = (
+            _PRESENT_HEADER_VALUE
+            if name.lower() == install_id_header
+            else _redact_exact_secrets(value, api_key=api_key)
+        )
+        safe_headers.append((safe_name, safe_value))
+    return safe_headers
+
+
+def _redacted_httpx_content(content: bytes, *, api_key: str) -> bytes:
+    """Exact-redact arbitrary HTTP bytes while preserving non-secret bytes."""
+
+    # Latin-1 is a lossless byte-to-text mapping. Install ids and header
+    # credentials are constrained to header-safe characters, so replacement
+    # remains reliable even when the surrounding payload is not UTF-8.
+    text = content.decode("latin-1")
+    return _redact_exact_secrets(text, api_key=api_key).encode("latin-1")
+
+
+def _request_content(request: httpx.Request) -> bytes:
+    try:
+        return request.content
+    except (httpx.RequestNotRead, httpx.StreamConsumed):
+        return b""
+
+
+def _response_content(response: httpx.Response) -> bytes:
+    try:
+        return response.content
+    except (httpx.ResponseNotRead, httpx.StreamConsumed):
+        return b""
+
+
+def _redacted_httpx_request(
+    request: httpx.Request | None,
+    *,
+    api_key: str,
+) -> httpx.Request | None:
+    if request is None:
+        return None
+    url = _redact_exact_secrets(str(request.url), api_key=api_key)
+    return httpx.Request(
+        request.method,
+        url,
+        headers=_redacted_httpx_headers(request.headers, api_key=api_key),
+        content=_redacted_httpx_content(_request_content(request), api_key=api_key),
+    )
+
+
+def _redacted_httpx_response(
+    response: httpx.Response,
+    *,
+    request: httpx.Request,
+    api_key: str,
+) -> httpx.Response:
+    return httpx.Response(
+        response.status_code,
+        headers=_redacted_httpx_headers(response.headers, api_key=api_key),
+        content=_redacted_httpx_content(_response_content(response), api_key=api_key),
+        request=request,
+    )
+
+
+def _scrub_original_httpx_error(
+    exc: httpx.HTTPError,
+    *,
+    message: str,
+    request: httpx.Request | None,
+    response: httpx.Response | None = None,
+) -> None:
+    """Remove secrets from an exception retained as ``__context__``."""
+
+    exc.args = (message,)
+    if hasattr(exc, "_request"):
+        exc._request = request  # type: ignore[attr-defined]  # httpx stores it here
+    if isinstance(exc, httpx.HTTPStatusError) and response is not None:
+        exc.response = response
+    exc.__cause__ = None
+    exc.__context__ = None
+    exc.__traceback__ = None
 
 
 def redacted_httpx_error(exc: httpx.HTTPError, *, api_key: str) -> httpx.HTTPError:
-    """Clone an httpx error with redacted text while retaining its semantics."""
+    """Clone an httpx error without retaining secret request/response state."""
 
     message = redact_upstream_error_text(
         str(exc) or repr(exc),
@@ -50,15 +157,30 @@ def redacted_httpx_error(exc: httpx.HTTPError, *, api_key: str) -> httpx.HTTPErr
         max_len=2000,
     )
     try:
-        request = exc.request
+        original_request = exc.request
     except RuntimeError:
-        request = None
+        original_request = None
+    request = _redacted_httpx_request(original_request, api_key=api_key)
     if isinstance(exc, httpx.HTTPStatusError):
+        if request is None:
+            request = httpx.Request("GET", "https://redacted.invalid/")
+        response = _redacted_httpx_response(
+            exc.response,
+            request=request,
+            api_key=api_key,
+        )
+        _scrub_original_httpx_error(
+            exc,
+            message=message,
+            request=request,
+            response=response,
+        )
         return httpx.HTTPStatusError(
             message,
-            request=exc.request,
-            response=exc.response,
+            request=request,
+            response=response,
         )
+    _scrub_original_httpx_error(exc, message=message, request=request)
     try:
         error_type: Any = type(exc)
         return cast("httpx.HTTPError", error_type(message, request=request))

--- a/src/opensquilla/provider/image_generation.py
+++ b/src/opensquilla/provider/image_generation.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import os
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from io import BytesIO
-from typing import Protocol
+from typing import Any, Protocol
 from urllib.parse import urljoin, urlsplit
 
 import httpx
@@ -22,6 +23,7 @@ from opensquilla.provider.correlation_context import (
     bind_provider_request_correlation,
     current_provider_request_correlation,
 )
+from opensquilla.provider.error_redaction import redacted_httpx_error
 from opensquilla.provider.image_generation_credentials import (
     ImageGenerationCredentialResolution,
     report_image_generation_pool_failure,
@@ -38,7 +40,10 @@ from opensquilla.provider.qwen_token_plan import (
     QWEN_TOKEN_PLAN_IMAGE_BASE_URL,
 )
 from opensquilla.provider.tokenrhythm_correlation import (
+    is_tokenrhythm_correlation_target,
+    redact_tokenrhythm_install_ids,
     tokenrhythm_correlation_headers,
+    tokenrhythm_install_id_headers,
 )
 from opensquilla.provider.types import (
     ProviderRequestCorrelation,
@@ -114,6 +119,46 @@ def _api_key_for_request(provider: object, request: ImageGenerationRequest) -> s
     return str(fallback() if callable(fallback) else "")
 
 
+def _install_id_safe_exception(
+    exc: Exception,
+    *,
+    api_key: str,
+) -> Exception | None:
+    """Return a safe replacement when an exception may retain provider secrets."""
+
+    if isinstance(exc, httpx.HTTPError):
+        # HTTPX errors retain their request and, for status errors, response
+        # objects. The install id may therefore be present even when str(exc)
+        # contains no echo of it.
+        return redacted_httpx_error(exc, api_key=api_key)
+
+    if isinstance(exc, json.JSONDecodeError):
+        safe_document = redact_tokenrhythm_install_ids(exc.doc)
+        if safe_document != exc.doc:
+            # JSONDecodeError retains the complete response body in ``doc``
+            # even though its normal string form only reports line/column.
+            return RuntimeError("Image generation provider returned invalid JSON")
+
+    raw_error = str(exc)
+    safe_error = redact_tokenrhythm_install_ids(raw_error)
+    if safe_error != raw_error:
+        return RuntimeError(safe_error)
+
+    retained_state = repr(getattr(exc, "__dict__", {}))
+    if redact_tokenrhythm_install_ids(retained_state) != retained_state:
+        return RuntimeError("Image generation provider request failed")
+    return None
+
+
+def _detach_exception(exc: Exception) -> Exception:
+    """Detach traceback links before re-raising from a scrubbed boundary."""
+
+    exc.__cause__ = None
+    exc.__context__ = None
+    exc.__traceback__ = None
+    return exc
+
+
 class OpenAIImageGenerationProvider:
     provider_id = "openai"
     default_model = "gpt-image-1"
@@ -148,6 +193,10 @@ class OpenAIImageGenerationProvider:
         api_key = _api_key_for_request(self, request)
         if not api_key:
             raise RuntimeError(f"{self._api_key_env} is not set")
+        protect_install_id = is_tokenrhythm_correlation_target(
+            self._provider_kind,
+            self._base_url,
+        )
 
         payload = {
             "model": request.model,
@@ -163,6 +212,11 @@ class OpenAIImageGenerationProvider:
             model=request.model,
             base_url=self._base_url,
         )
+        safe_request_error: Exception | None = None
+        cancelled_request_error: asyncio.CancelledError | None = None
+        client: Any = None
+        response: Any = None
+        data: Any = None
         try:
             async with httpx.AsyncClient(
                 timeout=request.timeout_seconds,
@@ -173,6 +227,10 @@ class OpenAIImageGenerationProvider:
                     self._api_url("/v1/images/generations"),
                     headers={
                         "Authorization": f"Bearer {api_key}",
+                        **tokenrhythm_install_id_headers(
+                            self._provider_kind,
+                            self._base_url,
+                        ),
                         **tokenrhythm_correlation_headers(
                             self._provider_kind,
                             self._base_url,
@@ -188,28 +246,127 @@ class OpenAIImageGenerationProvider:
                     raw_json=str(getattr(response, "text", "") or ""),
                 )
         except asyncio.CancelledError:
-            await usage.mark_unknown("cancelled")
-            raise
-        except Exception:
-            await usage.mark_unknown("direct_request_failed")
-            raise
+            if not protect_install_id:
+                await usage.mark_unknown("cancelled")
+                raise
+            client = None
+            response = None
+            data = None
+            payload = {}
+            try:
+                await usage.mark_unknown("cancelled")
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
+            cancelled_request_error = asyncio.CancelledError()
+        except Exception as exc:
+            if not protect_install_id:
+                await usage.mark_unknown("direct_request_failed")
+                raise
+            safe_error = _install_id_safe_exception(exc, api_key=api_key)
+            if safe_error is None:
+                safe_error = _detach_exception(exc)
+            client = None
+            response = None
+            data = None
+            payload = {}
+            try:
+                await usage.mark_unknown("direct_request_failed")
+            except asyncio.CancelledError:
+                cancelled_request_error = asyncio.CancelledError()
+            except Exception:
+                safe_request_error = safe_error
+            else:
+                safe_request_error = safe_error
 
-        items = data.get("data") or []
-        if not items:
-            raise RuntimeError("Image generation provider returned no images")
-        first = items[0]
-        b64_json = first.get("b64_json")
-        if not b64_json:
-            raise RuntimeError("Image generation provider returned no b64_json")
-        image_bytes = base64.b64decode(b64_json)
+        if cancelled_request_error is not None:
+            client = None
+            response = None
+            data = None
+            payload = {}
+            raise cancelled_request_error
+        if safe_request_error is not None:
+            client = None
+            response = None
+            data = None
+            payload = {}
+            # Raise outside the exception handler so the original exception is
+            # not retained as a secret-bearing ``__context__``.
+            raise safe_request_error
+
+        if not protect_install_id:
+            items = data.get("data") or []
+            if not items:
+                raise RuntimeError("Image generation provider returned no images")
+            first = items[0]
+            b64_json = first.get("b64_json")
+            if not b64_json:
+                raise RuntimeError(
+                    "Image generation provider returned no b64_json"
+                )
+            image_bytes = base64.b64decode(b64_json)
+            output_format = request.output_format.lower()
+            mime_type = (
+                "image/jpeg"
+                if output_format in {"jpg", "jpeg"}
+                else f"image/{output_format}"
+            )
+            return ImageGenerationResult(
+                image_bytes=image_bytes,
+                mime_type=mime_type,
+                model=request.model,
+                provider=self.provider_id,
+                revised_prompt=first.get("revised_prompt"),
+            )
+
+        postprocess_error: Exception | None = None
+        safe_items: Any = None
+        safe_first: Any = None
+        safe_b64_json: Any = None
+        raw_revised_prompt: Any = None
+        revised_prompt: str | None = None
+        try:
+            safe_items = data.get("data") or []
+            if not safe_items:
+                raise RuntimeError("Image generation provider returned no images")
+            safe_first = safe_items[0]
+            safe_b64_json = safe_first.get("b64_json")
+            if not safe_b64_json:
+                raise RuntimeError(
+                    "Image generation provider returned no b64_json"
+                )
+            image_bytes = base64.b64decode(safe_b64_json)
+            raw_revised_prompt = safe_first.get("revised_prompt")
+            if isinstance(raw_revised_prompt, str):
+                revised_prompt = redact_tokenrhythm_install_ids(raw_revised_prompt)
+        except Exception as exc:
+            safe_error = _install_id_safe_exception(exc, api_key=api_key)
+            postprocess_error = safe_error or _detach_exception(exc)
+
+        client = None
+        response = None
+        data = None
+        payload = {}
+        safe_items = None
+        safe_first = None
+        safe_b64_json = None
+        raw_revised_prompt = None
+        if postprocess_error is not None:
+            raise postprocess_error
+
         output_format = request.output_format.lower()
-        mime_type = "image/jpeg" if output_format in {"jpg", "jpeg"} else f"image/{output_format}"
+        mime_type = (
+            "image/jpeg"
+            if output_format in {"jpg", "jpeg"}
+            else f"image/{output_format}"
+        )
         return ImageGenerationResult(
             image_bytes=image_bytes,
             mime_type=mime_type,
             model=request.model,
             provider=self.provider_id,
-            revised_prompt=first.get("revised_prompt"),
+            revised_prompt=revised_prompt,
         )
 
 
@@ -256,6 +413,10 @@ class OpenRouterImageGenerationProvider:
         api_key = _api_key_for_request(self, request)
         if not api_key:
             raise RuntimeError(f"{self._api_key_env} is not set")
+        protect_install_id = is_tokenrhythm_correlation_target(
+            self._provider_kind,
+            self._base_url,
+        )
 
         payload = {
             "model": request.model,
@@ -271,6 +432,11 @@ class OpenRouterImageGenerationProvider:
             model=request.model,
             base_url=self._base_url,
         )
+        safe_request_error: Exception | None = None
+        cancelled_request_error: asyncio.CancelledError | None = None
+        client: Any = None
+        response: Any = None
+        data: Any = None
         try:
             async with httpx.AsyncClient(
                 timeout=request.timeout_seconds,
@@ -283,6 +449,10 @@ class OpenRouterImageGenerationProvider:
                         "Authorization": f"Bearer {api_key}",
                         "Content-Type": "application/json",
                         **provider_app_headers(self._base_url),
+                        **tokenrhythm_install_id_headers(
+                            self._provider_kind,
+                            self._base_url,
+                        ),
                         **tokenrhythm_correlation_headers(
                             self._provider_kind,
                             self._base_url,
@@ -298,16 +468,84 @@ class OpenRouterImageGenerationProvider:
                     raw_json=str(getattr(response, "text", "") or ""),
                 )
         except asyncio.CancelledError:
-            await usage.mark_unknown("cancelled")
-            raise
-        except Exception:
-            await usage.mark_unknown("direct_request_failed")
-            raise
+            if not protect_install_id:
+                await usage.mark_unknown("cancelled")
+                raise
+            client = None
+            response = None
+            data = None
+            payload = {}
+            try:
+                await usage.mark_unknown("cancelled")
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
+            cancelled_request_error = asyncio.CancelledError()
+        except Exception as exc:
+            if not protect_install_id:
+                await usage.mark_unknown("direct_request_failed")
+                raise
+            safe_error = _install_id_safe_exception(exc, api_key=api_key)
+            if safe_error is None:
+                safe_error = _detach_exception(exc)
+            client = None
+            response = None
+            data = None
+            payload = {}
+            try:
+                await usage.mark_unknown("direct_request_failed")
+            except asyncio.CancelledError:
+                cancelled_request_error = asyncio.CancelledError()
+            except Exception:
+                safe_request_error = safe_error
+            else:
+                safe_request_error = safe_error
 
-        image_url = _extract_openrouter_image_url(data)
-        if not image_url:
-            raise RuntimeError("Image generation provider returned no images")
-        mime_type, image_bytes = _decode_data_url(image_url)
+        if cancelled_request_error is not None:
+            client = None
+            response = None
+            data = None
+            payload = {}
+            raise cancelled_request_error
+        if safe_request_error is not None:
+            client = None
+            response = None
+            data = None
+            payload = {}
+            raise safe_request_error
+
+        if not protect_install_id:
+            image_url = _extract_openrouter_image_url(data)
+            if not image_url:
+                raise RuntimeError("Image generation provider returned no images")
+            mime_type, image_bytes = _decode_data_url(image_url)
+            return ImageGenerationResult(
+                image_bytes=image_bytes,
+                mime_type=mime_type,
+                model=request.model,
+                provider=self.provider_id,
+            )
+
+        postprocess_error: Exception | None = None
+        safe_image_url: str | None = None
+        try:
+            safe_image_url = _extract_openrouter_image_url(data)
+            if not safe_image_url:
+                raise RuntimeError("Image generation provider returned no images")
+            mime_type, image_bytes = _decode_data_url(safe_image_url)
+        except Exception as exc:
+            safe_error = _install_id_safe_exception(exc, api_key=api_key)
+            postprocess_error = safe_error or _detach_exception(exc)
+
+        client = None
+        response = None
+        data = None
+        payload = {}
+        safe_image_url = None
+        if postprocess_error is not None:
+            raise postprocess_error
+
         return ImageGenerationResult(
             image_bytes=image_bytes,
             mime_type=mime_type,
@@ -364,6 +602,11 @@ class TokenRhythmImageGenerationProvider:
             model=request.model,
             base_url=self._base_url,
         )
+        safe_request_error: Exception | None = None
+        cancelled_request_error: asyncio.CancelledError | None = None
+        client: Any = None
+        response: Any = None
+        data: Any = None
         try:
             async with httpx.AsyncClient(
                 timeout=request.timeout_seconds,
@@ -376,6 +619,10 @@ class TokenRhythmImageGenerationProvider:
                         "Authorization": f"Bearer {api_key}",
                         "Content-Type": "application/json",
                         **provider_app_headers(self._base_url),
+                        **tokenrhythm_install_id_headers(
+                            "tokenrhythm",
+                            self._base_url,
+                        ),
                         **tokenrhythm_correlation_headers(
                             "tokenrhythm",
                             self._base_url,
@@ -392,24 +639,83 @@ class TokenRhythmImageGenerationProvider:
                     allow_billing_only=True,
                 )
         except asyncio.CancelledError:
-            await usage.mark_unknown("cancelled")
-            raise
-        except Exception:
-            await usage.mark_unknown("direct_request_failed")
-            raise
+            client = None
+            response = None
+            data = None
+            payload = {}
+            try:
+                await usage.mark_unknown("cancelled")
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
+            cancelled_request_error = asyncio.CancelledError()
+        except Exception as exc:
+            safe_error = _install_id_safe_exception(exc, api_key=api_key)
+            if safe_error is None:
+                safe_error = _detach_exception(exc)
+            client = None
+            response = None
+            data = None
+            payload = {}
+            try:
+                await usage.mark_unknown("direct_request_failed")
+            except asyncio.CancelledError:
+                cancelled_request_error = asyncio.CancelledError()
+            except Exception:
+                safe_request_error = safe_error
+            else:
+                safe_request_error = safe_error
+
+        if cancelled_request_error is not None:
+            client = None
+            response = None
+            data = None
+            payload = {}
+            raise cancelled_request_error
+        if safe_request_error is not None:
+            client = None
+            response = None
+            data = None
+            payload = {}
+            raise safe_request_error
 
         items = data.get("data") if isinstance(data, dict) else None
         if not isinstance(items, list) or not items or not isinstance(items[0], dict):
+            client = None
+            response = None
+            data = None
+            payload = {}
+            items = None
             raise RuntimeError("Image generation provider returned no images")
-        first = items[0]
-        b64_json = first.get("b64_json")
+        first: Any = items[0]
+        b64_json: Any = first.get("b64_json")
+        image_url: Any = first.get("url")
+        raw_revised_prompt = first.get("revised_prompt")
+        revised_prompt = (
+            redact_tokenrhythm_install_ids(raw_revised_prompt)
+            if isinstance(raw_revised_prompt, str)
+            else None
+        )
+        client = None
+        response = None
+        data = None
+        payload = {}
+        items = None
+        first = None
+        raw_revised_prompt = None
         if isinstance(b64_json, str) and b64_json:
+            invalid_b64_json = False
             try:
                 image_bytes = base64.b64decode(b64_json)
-            except (ValueError, TypeError) as exc:
+            except (ValueError, TypeError):
+                invalid_b64_json = True
+            b64_json = None
+            image_url = None
+            if invalid_b64_json:
                 raise RuntimeError(
                     "Image generation provider returned invalid b64_json"
-                ) from exc
+                )
             output_format = request.output_format.lower()
             mime_type = (
                 "image/jpeg"
@@ -417,29 +723,44 @@ class TokenRhythmImageGenerationProvider:
                 else f"image/{output_format}"
             )
         else:
-            image_url = first.get("url")
             if not isinstance(image_url, str) or not image_url:
+                b64_json = None
+                image_url = None
                 raise RuntimeError(
                     "Image generation provider returned neither b64_json nor url"
                 )
+            download_error: Exception | None = None
+            download_cancelled: asyncio.CancelledError | None = None
             if image_url.startswith("data:"):
-                mime_type, image_bytes = _decode_data_url(image_url)
+                try:
+                    mime_type, image_bytes = _decode_data_url(image_url)
+                except Exception as exc:
+                    safe_error = _install_id_safe_exception(exc, api_key=api_key)
+                    download_error = safe_error or _detach_exception(exc)
             else:
-                mime_type, image_bytes = await _download_tokenrhythm_image(
-                    image_url,
-                    timeout_seconds=request.timeout_seconds,
-                )
+                try:
+                    mime_type, image_bytes = await _download_tokenrhythm_image(
+                        image_url,
+                        timeout_seconds=request.timeout_seconds,
+                    )
+                except asyncio.CancelledError:
+                    download_cancelled = asyncio.CancelledError()
+                except Exception as exc:
+                    safe_error = _install_id_safe_exception(exc, api_key=api_key)
+                    download_error = safe_error or _detach_exception(exc)
+            b64_json = None
+            image_url = None
+            if download_cancelled is not None:
+                raise download_cancelled
+            if download_error is not None:
+                raise download_error
 
         return ImageGenerationResult(
             image_bytes=image_bytes,
             mime_type=mime_type,
             model=request.model,
             provider=self.provider_id,
-            revised_prompt=(
-                first.get("revised_prompt")
-                if isinstance(first.get("revised_prompt"), str)
-                else None
-            ),
+            revised_prompt=revised_prompt,
         )
 
 
@@ -1092,10 +1413,12 @@ async def generate_with_fallbacks(
         try:
             provider_id, model = parse_image_generation_model_ref(candidate)
         except ValueError as exc:
+            raw_error = str(exc)
+            safe_error = redact_tokenrhythm_install_ids(raw_error)
             attempts.append(
-                ImageGenerationAttempt(provider="", model=candidate, error=str(exc))
+                ImageGenerationAttempt(provider="", model=candidate, error=safe_error)
             )
-            last_error = exc
+            last_error = exc if safe_error == raw_error else RuntimeError(safe_error)
             continue
         provider = get_image_generation_provider(provider_id)
         if provider is None:
@@ -1131,15 +1454,20 @@ async def generate_with_fallbacks(
             return result
         except Exception as exc:  # noqa: BLE001 - failures are summarized for fallback
             report_image_generation_pool_failure(credential_resolution, exc)
-            attempts.append(ImageGenerationAttempt(provider_id, model, str(exc)))
-            last_error = exc if isinstance(exc, Exception) else RuntimeError(str(exc))
+            raw_error = str(exc)
+            safe_error = redact_tokenrhythm_install_ids(raw_error)
+            attempts.append(ImageGenerationAttempt(provider_id, model, safe_error))
+            last_error = exc if safe_error == raw_error else RuntimeError(safe_error)
 
     if len(attempts) <= 1 and last_error is not None:
         raise last_error
     summary = " | ".join(
         f"{attempt.provider}/{attempt.model}: {attempt.error}" for attempt in attempts
     )
-    raise RuntimeError(f"All image generation models failed ({len(attempts)}): {summary}")
+    message = redact_tokenrhythm_install_ids(
+        f"All image generation models failed ({len(attempts)}): {summary}"
+    )
+    raise RuntimeError(message)
 
 
 reset_image_generation_providers()

--- a/src/opensquilla/provider/live_catalog.py
+++ b/src/opensquilla/provider/live_catalog.py
@@ -19,6 +19,8 @@ corrections ladder (a relay's streaming dialect is not listing data).
 
 from __future__ import annotations
 
+import asyncio
+import json
 import math
 from collections.abc import Callable, Iterable, Mapping
 from decimal import Decimal, InvalidOperation
@@ -30,9 +32,14 @@ import structlog
 from opensquilla.env import trust_env as _trust_env
 
 from .app_attribution import provider_app_headers
+from .error_redaction import redacted_httpx_error
 from .fx import TOKENRHYTHM_CNY_PER_USD
 from .model_catalog import DEFAULT_MAX_TOKENS as _NEAR_WINDOW_MARGIN
 from .registry import UnknownProviderError, get_provider_spec
+from .tokenrhythm_correlation import (
+    redact_tokenrhythm_install_ids,
+    tokenrhythm_install_id_headers,
+)
 
 if TYPE_CHECKING:
     from .model_catalog import ModelCatalog
@@ -221,13 +228,86 @@ async def fetch_live_catalog_entries(
     parser = _LIVE_CATALOG_PARSERS.get(shape)
     if parser is None:
         raise ValueError(f"unknown live catalog shape: {shape!r}")
-    async with httpx.AsyncClient(
-        timeout=timeout, trust_env=_trust_env(), proxy=proxy or None
-    ) as client:
-        resp = await client.get(url, headers=provider_app_headers(url))
-        resp.raise_for_status()
-        payload = resp.json()
-    return parser(payload if isinstance(payload, Mapping) else {})
+    safe_request_error: Exception | None = None
+    cancelled_request_error: asyncio.CancelledError | None = None
+    headers: dict[str, str] = {}
+    client: Any = None
+    resp: Any = None
+    payload: Any = None
+    parsed: dict[str, dict[str, Any]] | None = None
+    raw_message = ""
+    raw_state = ""
+    try:
+        async with httpx.AsyncClient(
+            timeout=timeout,
+            trust_env=_trust_env(),
+            proxy=proxy or None,
+            follow_redirects=False,
+        ) as client:
+            headers = provider_app_headers(url)
+            headers.update(
+                tokenrhythm_install_id_headers(shape, url, proxy=proxy or None)
+            )
+            resp = await client.get(url, headers=headers)
+            resp.raise_for_status()
+            payload = resp.json()
+            parsed = parser(payload if isinstance(payload, Mapping) else {})
+    except asyncio.CancelledError:
+        cancelled_request_error = asyncio.CancelledError()
+    except httpx.HTTPError as exc:
+        safe_request_error = redacted_httpx_error(exc, api_key="")
+    except json.JSONDecodeError as exc:
+        if redact_tokenrhythm_install_ids(exc.doc) == exc.doc:
+            exc.__cause__ = None
+            exc.__context__ = None
+            exc.__traceback__ = None
+            safe_request_error = exc
+        else:
+            safe_request_error = RuntimeError(
+                "Live provider catalog returned invalid JSON"
+            )
+    except Exception as exc:
+        raw_message = str(exc)
+        safe_message = redact_tokenrhythm_install_ids(raw_message)
+        raw_state = repr(getattr(exc, "__dict__", {}))
+        if (
+            safe_message != raw_message
+            or redact_tokenrhythm_install_ids(raw_state) != raw_state
+        ):
+            safe_request_error = RuntimeError(
+                safe_message
+                if safe_message != raw_message
+                else "Live provider catalog parsing failed"
+            )
+        else:
+            exc.__cause__ = None
+            exc.__context__ = None
+            exc.__traceback__ = None
+            safe_request_error = exc
+
+    if cancelled_request_error is not None:
+        headers.clear()
+        client = None
+        resp = None
+        payload = None
+        parsed = None
+        raw_message = ""
+        raw_state = ""
+        url = redact_tokenrhythm_install_ids(url)
+        proxy = redact_tokenrhythm_install_ids(proxy)
+        raise cancelled_request_error
+    if safe_request_error is not None:
+        headers.clear()
+        client = None
+        resp = None
+        payload = None
+        parsed = None
+        raw_message = ""
+        raw_state = ""
+        url = redact_tokenrhythm_install_ids(url)
+        proxy = redact_tokenrhythm_install_ids(proxy)
+        raise safe_request_error
+    return parsed or {}
 
 
 async def warm_live_provider_catalogs(
@@ -261,5 +341,9 @@ async def warm_live_provider_catalogs(
             counts[provider_id] = len(entries)
             log.info("live_catalog.ready", provider=provider_id, count=len(entries))
         except Exception as exc:  # noqa: BLE001 - a live listing degrades, never blocks boot
-            log.warning("live_catalog.failed", provider=provider_id, error=str(exc))
+            log.warning(
+                "live_catalog.failed",
+                provider=provider_id,
+                error=redact_tokenrhythm_install_ids(str(exc)),
+            )
     return counts

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import math
@@ -68,7 +69,12 @@ from .text_tool_normalizer import (
     classify_text_tool_segments,
     warn_for_unauthorized_plain_candidate,
 )
-from .tokenrhythm_correlation import tokenrhythm_correlation_headers
+from .tokenrhythm_correlation import (
+    TOKENRHYTHM_INSTALL_ID_HEADER,
+    redact_tokenrhythm_install_ids,
+    tokenrhythm_correlation_headers,
+    tokenrhythm_install_id_headers,
+)
 from .trace_recorder import LLMTraceRecorder
 from .types import (
     ChatConfig,
@@ -2889,7 +2895,30 @@ class OpenAIProvider:
         config: ChatConfig | None = None,
     ) -> AsyncIterator[StreamEvent]:
         cfg = config or ChatConfig()
-        return self._stream(messages, tools, cfg)
+        return self._stream_with_detached_cancellation(messages, tools, cfg)
+
+    async def _stream_with_detached_cancellation(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None,
+        cfg: ChatConfig,
+    ) -> AsyncIterator[StreamEvent]:
+        """Preserve cancellation without retaining the physical request frame."""
+
+        cancelled = False
+        event: StreamEvent | None = None
+        try:
+            async for event in self._stream(messages, tools, cfg):
+                yield event
+        except asyncio.CancelledError:
+            # The inner stream owns request headers and HTTPX response state.
+            # Drop its cancellation traceback and any last echoed event before
+            # propagating a fresh cancellation from this metadata-only frame.
+            event = None
+            cancelled = True
+
+        if cancelled:
+            raise asyncio.CancelledError from None
 
     async def _stream(
         self,
@@ -3148,6 +3177,13 @@ class OpenAIProvider:
             headers["Authorization"] = f"Bearer {self._api_key}"
         headers.update(provider_app_headers(self._base_url))
         headers.update(
+            tokenrhythm_install_id_headers(
+                self._provider_kind,
+                self._base_url,
+                proxy=self._proxy,
+            )
+        )
+        headers.update(
             tokenrhythm_correlation_headers(
                 self._provider_kind,
                 self._base_url,
@@ -3310,6 +3346,14 @@ class OpenAIProvider:
                 proxy=self._proxy,
                 follow_redirects=False,
             ) as client:
+                headers.pop(TOKENRHYTHM_INSTALL_ID_HEADER, None)
+                headers.update(
+                    tokenrhythm_install_id_headers(
+                        self._provider_kind,
+                        self._base_url,
+                        proxy=self._proxy,
+                    )
+                )
                 async with client.stream(
                     "POST",
                     endpoint,
@@ -4807,6 +4851,14 @@ class OpenAIProvider:
         cache_shape = _payload_cache_shape(fallback_payload, tools=tools)
         fallback_headers = dict(headers)
         fallback_headers["Accept"] = "application/json"
+        fallback_headers.pop(TOKENRHYTHM_INSTALL_ID_HEADER, None)
+        fallback_headers.update(
+            tokenrhythm_install_id_headers(
+                self._provider_kind,
+                self._base_url,
+                proxy=self._proxy,
+            )
+        )
         endpoint = self._api_url("/v1/chat/completions")
         trace = LLMTraceRecorder(
             provider=self._provider_kind,
@@ -4838,6 +4890,17 @@ class OpenAIProvider:
                 proxy=self._proxy,
                 follow_redirects=False,
             ) as client:
+                # ``AsyncClient.__aenter__`` is an await boundary. Refresh at
+                # the final send point so a privacy toggle that lands while
+                # the fallback client is opening cannot forward a stale id.
+                fallback_headers.pop(TOKENRHYTHM_INSTALL_ID_HEADER, None)
+                fallback_headers.update(
+                    tokenrhythm_install_id_headers(
+                        self._provider_kind,
+                        self._base_url,
+                        proxy=self._proxy,
+                    )
+                )
                 response = await client.post(
                     endpoint,
                     headers=fallback_headers,
@@ -5461,12 +5524,30 @@ class OpenAIProvider:
             else {}
         )
         headers.update(provider_app_headers(self._base_url))
+        safe_request_error: Exception | None = None
+        cancelled_request_error: asyncio.CancelledError | None = None
+        client: Any = None
+        resp: Any = None
+        data: Any = None
+        rows: Any = None
+        excluded_model_ids: Any = None
+        models: list[ModelInfo] | None = None
+        raw_message = ""
+        raw_state = ""
         try:
             async with httpx.AsyncClient(
                 timeout=10.0,
                 trust_env=_trust_env(),
                 proxy=self._proxy,
+                follow_redirects=False,
             ) as client:
+                headers.update(
+                    tokenrhythm_install_id_headers(
+                        self._provider_kind,
+                        self._base_url,
+                        proxy=self._proxy,
+                    )
+                )
                 resp = await client.get(self._api_url("/v1/models"), headers=headers)
                 resp.raise_for_status()
                 data = resp.json()
@@ -5481,7 +5562,7 @@ class OpenAIProvider:
                         for row in rows
                         if str(row.get("id", "")).lower() not in excluded_model_ids
                     ]
-                return [
+                models = [
                     ModelInfo(
                         provider=self._provider_kind,
                         model_id=m["id"],
@@ -5492,11 +5573,61 @@ class OpenAIProvider:
                     )
                     for m in rows
                 ]
+        except asyncio.CancelledError:
+            cancelled_request_error = asyncio.CancelledError()
         except httpx.HTTPError as exc:
             if raise_on_error:
-                raise redacted_httpx_error(exc, api_key=self._api_key) from None
-            return []
-        except Exception:
+                safe_request_error = redacted_httpx_error(
+                    exc,
+                    api_key=self._api_key,
+                )
+        except Exception as exc:
             if raise_on_error:
-                raise
-            return []
+                if isinstance(exc, json.JSONDecodeError):
+                    safe_document = redact_tokenrhythm_install_ids(exc.doc)
+                    if safe_document != exc.doc:
+                        safe_request_error = RuntimeError(
+                            "Provider model catalog returned invalid JSON"
+                        )
+                if safe_request_error is None:
+                    raw_message = str(exc)
+                    safe_message = redact_tokenrhythm_install_ids(raw_message)
+                    raw_state = repr(getattr(exc, "__dict__", {}))
+                    if (
+                        safe_message != raw_message
+                        or redact_tokenrhythm_install_ids(raw_state) != raw_state
+                    ):
+                        safe_request_error = RuntimeError(
+                            safe_message
+                            if safe_message != raw_message
+                            else "Provider model catalog parsing failed"
+                        )
+                    else:
+                        exc.__cause__ = None
+                        exc.__context__ = None
+                        exc.__traceback__ = None
+                        safe_request_error = exc
+
+        if cancelled_request_error is not None:
+            headers.clear()
+            client = None
+            resp = None
+            data = None
+            rows = None
+            excluded_model_ids = None
+            models = None
+            raw_message = ""
+            raw_state = ""
+            raise cancelled_request_error
+        if safe_request_error is not None:
+            headers.clear()
+            client = None
+            resp = None
+            data = None
+            rows = None
+            excluded_model_ids = None
+            models = None
+            raw_message = ""
+            raw_state = ""
+            raise safe_request_error
+        return models or []

--- a/src/opensquilla/provider/tokenrhythm_correlation.py
+++ b/src/opensquilla/provider/tokenrhythm_correlation.py
@@ -2,12 +2,25 @@
 
 from __future__ import annotations
 
+import ipaddress
+import json
 import os
 import re
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
+from opensquilla.env import trust_env
+from opensquilla.observability.network_policy import provider_install_id_disabled
+from opensquilla.paths import default_opensquilla_home
+
+from .environment import environment_value
 from .types import ProviderRequestCorrelation
 
+TOKENRHYTHM_INSTALL_ID_HEADER = "X-OpenSquilla-Install-Id"
 TOKENRHYTHM_SESSION_ID_HEADER = "X-OpenSquilla-Session-Id"
 TOKENRHYTHM_TURN_ID_HEADER = "X-OpenSquilla-Turn-Id"
 TOKENRHYTHM_EXECUTION_ID_HEADER = "X-OpenSquilla-Execution-Id"
@@ -46,6 +59,38 @@ _NETWORK_OBSERVABILITY_DISABLED_ENV = (
 )
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 _CALL_KIND_MAX_LENGTH = 96
+_INSTALL_ID_RETRY_SECONDS = 60.0
+_INSTALL_TELEMETRY_STATE_FILE = "install_telemetry.json"
+_INSTALL_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}")
+_RAW_MAC_HEX_RE = re.compile(r"[0-9A-Fa-f]{12}")
+_PROXY_ENV_VARS = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+)
+
+
+@dataclass(frozen=True)
+class _InstallIdContext:
+    config: Any | None
+    state_path: Path
+    cache_key: str
+
+
+@dataclass
+class _InstallIdCacheEntry:
+    install_id: str | None = field(default=None, repr=False)
+    loading: bool = False
+    retry_after: float = 0.0
+    thread: threading.Thread | None = None
+
+
+_INSTALL_ID_CACHE_LOCK = threading.RLock()
+_INSTALL_ID_CACHE: dict[str, _InstallIdCacheEntry] = {}
+_ACTIVE_INSTALL_ID_CONTEXT: _InstallIdContext | None = None
 
 
 def _safe_correlation_id(value: str | None) -> str:
@@ -93,7 +138,10 @@ def is_tokenrhythm_correlation_target(
     if str(provider_kind or "").strip().lower() != "tokenrhythm":
         return False
     try:
-        parsed = urlparse(str(base_url or "").strip())
+        candidate = str(base_url or "").strip()
+        if not candidate or any(ord(character) <= 0x20 for character in candidate):
+            return False
+        parsed = urlparse(candidate)
         if (
             parsed.scheme.lower() != "https"
             or parsed.username is not None
@@ -101,9 +149,300 @@ def is_tokenrhythm_correlation_target(
         ):
             return False
         host = (parsed.hostname or "").lower()
-        return host in _TOKENRHYTHM_CORRELATION_HOSTS and parsed.port in {None, 443}
+        canonical_netlocs = {host, f"{host}:443"}
+        return (
+            host in _TOKENRHYTHM_CORRELATION_HOSTS
+            and parsed.netloc.lower() in canonical_netlocs
+            and parsed.port in {None, 443}
+        )
     except ValueError:
         return False
+
+
+def prewarm_tokenrhythm_install_id(
+    *,
+    config: Any | None = None,
+    state_path: str | Path | None = None,
+) -> threading.Thread | None:
+    """Best-effort wrapper that never lets install-id prewarming affect startup."""
+
+    try:
+        return _prewarm_tokenrhythm_install_id(config=config, state_path=state_path)
+    except Exception:
+        return None
+
+
+def _prewarm_tokenrhythm_install_id(
+    *,
+    config: Any | None = None,
+    state_path: str | Path | None = None,
+) -> threading.Thread | None:
+    """Resolve the active install id in a best-effort daemon worker.
+
+    The active context is registered synchronously so transport helpers that do
+    not own the gateway configuration still select the correct profile and
+    observe live changes to its privacy object.  Disk, address discovery, and
+    state locking remain confined to the daemon worker.
+    """
+
+    context = _register_install_id_context(config=config, state_path=state_path)
+    if provider_install_id_disabled(config=context.config):
+        return None
+
+    with _INSTALL_ID_CACHE_LOCK:
+        entry = _INSTALL_ID_CACHE.setdefault(context.cache_key, _InstallIdCacheEntry())
+        if _safe_install_id(entry.install_id):
+            return None
+        if entry.loading:
+            return entry.thread
+        if time.monotonic() < entry.retry_after:
+            return None
+
+        def _resolve() -> None:
+            try:
+                # Re-check immediately before any state access. A privacy
+                # setting may have changed after the worker was scheduled.
+                if provider_install_id_disabled(config=context.config):
+                    with _INSTALL_ID_CACHE_LOCK:
+                        entry.loading = False
+                        entry.thread = None
+                    return
+
+                # ``ensure_install_telemetry_id`` normalizes telemetry state as
+                # it persists it.  Do not invoke it when an existing file has
+                # an explicitly unsafe id: transport validation must never
+                # repair or otherwise rewrite the user's telemetry state.
+                if _existing_state_blocks_install_id_resolution(context.state_path):
+                    install_id = ""
+                else:
+                    from opensquilla.observability.install_telemetry import (
+                        ensure_install_telemetry_id,
+                    )
+
+                    candidate = ensure_install_telemetry_id(
+                        config=context.config,
+                        state_path=context.state_path,
+                    )
+                    install_id = _safe_install_id(candidate)
+            except Exception:
+                install_id = ""
+
+            with _INSTALL_ID_CACHE_LOCK:
+                entry.loading = False
+                entry.thread = None
+                if install_id:
+                    entry.install_id = install_id
+                    entry.retry_after = 0.0
+                else:
+                    entry.install_id = None
+                    entry.retry_after = time.monotonic() + _INSTALL_ID_RETRY_SECONDS
+
+        try:
+            thread = threading.Thread(
+                target=_resolve,
+                name="opensquilla-tokenrhythm-install-id",
+                daemon=True,
+            )
+        except Exception:
+            entry.retry_after = time.monotonic() + _INSTALL_ID_RETRY_SECONDS
+            return None
+        entry.loading = True
+        entry.thread = thread
+        try:
+            thread.start()
+        except Exception:
+            entry.loading = False
+            entry.thread = None
+            entry.retry_after = time.monotonic() + _INSTALL_ID_RETRY_SECONDS
+            return None
+        return thread
+
+
+def tokenrhythm_install_id_headers(
+    provider_kind: str | None,
+    base_url: str | None,
+    *,
+    config: Any | None = None,
+    state_path: str | Path | None = None,
+    proxy: str | None = None,
+) -> dict[str, str]:
+    """Best-effort install-id headers that can never fail a provider request."""
+
+    try:
+        return _tokenrhythm_install_id_headers(
+            provider_kind,
+            base_url,
+            config=config,
+            state_path=state_path,
+            proxy=proxy,
+        )
+    except Exception:
+        return {}
+
+
+def _tokenrhythm_install_id_headers(
+    provider_kind: str | None,
+    base_url: str | None,
+    *,
+    config: Any | None = None,
+    state_path: str | Path | None = None,
+    proxy: str | None = None,
+) -> dict[str, str]:
+    """Return the cached install-id header for an official TokenRhythm origin.
+
+    This function never performs state-file I/O.  A cold cache schedules a
+    daemon resolver and omits the header from the current request; subsequent
+    requests use the cached value after resolution completes.
+    """
+
+    if (
+        str(proxy or "").strip()
+        or _trusted_environment_proxy_configured()
+        or not is_tokenrhythm_correlation_target(
+            provider_kind,
+            base_url,
+        )
+    ):
+        return {}
+
+    context = _current_or_register_install_id_context(
+        config=config,
+        state_path=state_path,
+    )
+    # This check deliberately happens for every physical request so a live
+    # privacy change stops transmission without invalidating persisted state.
+    if provider_install_id_disabled(config=context.config):
+        return {}
+
+    with _INSTALL_ID_CACHE_LOCK:
+        entry = _INSTALL_ID_CACHE.get(context.cache_key)
+        install_id = _safe_install_id(entry.install_id if entry is not None else None)
+    if install_id:
+        return {TOKENRHYTHM_INSTALL_ID_HEADER: install_id}
+
+    prewarm_tokenrhythm_install_id(
+        config=context.config,
+        state_path=context.state_path,
+    )
+    return {}
+
+
+def _current_or_register_install_id_context(
+    *,
+    config: Any | None,
+    state_path: str | Path | None,
+) -> _InstallIdContext:
+    if config is None and state_path is None:
+        with _INSTALL_ID_CACHE_LOCK:
+            active = _ACTIVE_INSTALL_ID_CONTEXT
+        if active is not None:
+            return active
+    return _register_install_id_context(config=config, state_path=state_path)
+
+
+def _register_install_id_context(
+    *,
+    config: Any | None,
+    state_path: str | Path | None,
+) -> _InstallIdContext:
+    path = _install_id_state_path(config=config, explicit=state_path)
+    normalized_path = Path(os.path.abspath(os.fspath(path)))
+    context = _InstallIdContext(
+        config=config,
+        state_path=normalized_path,
+        cache_key=os.path.normcase(os.fspath(normalized_path)),
+    )
+    global _ACTIVE_INSTALL_ID_CONTEXT
+    with _INSTALL_ID_CACHE_LOCK:
+        _ACTIVE_INSTALL_ID_CONTEXT = context
+    return context
+
+
+def _install_id_state_path(
+    *,
+    config: Any | None,
+    explicit: str | Path | None,
+) -> Path:
+    if explicit is not None:
+        return Path(explicit).expanduser()
+    configured_state_dir = getattr(config, "state_dir", None)
+    if isinstance(configured_state_dir, str) and configured_state_dir.strip():
+        root = Path(configured_state_dir.strip()).expanduser()
+    else:
+        root = default_opensquilla_home() / "state"
+    return root / _INSTALL_TELEMETRY_STATE_FILE
+
+
+def _safe_install_id(value: object) -> str:
+    if not isinstance(value, str) or _INSTALL_ID_RE.fullmatch(value) is None:
+        return ""
+    # Persisted ids are hashes or UUIDs. Fail closed if a damaged or hand-edited
+    # state file contains an address itself, even though that text would be a
+    # syntactically valid HTTP header value.
+    try:
+        ipaddress.ip_address(value)
+    except ValueError:
+        pass
+    else:
+        return ""
+    compact_mac = value.replace(":", "").replace("-", "").replace(".", "")
+    if _RAW_MAC_HEX_RE.fullmatch(compact_mac) is not None:
+        return ""
+    return value
+
+
+def redact_tokenrhythm_install_ids(text: str) -> str:
+    """Mask cached install ids in diagnostic text without ever raising."""
+
+    try:
+        with _INSTALL_ID_CACHE_LOCK:
+            install_ids = {
+                install_id
+                for entry in _INSTALL_ID_CACHE.values()
+                if (install_id := _safe_install_id(entry.install_id))
+            }
+        redacted = text
+        for install_id in sorted(install_ids, key=len, reverse=True):
+            # HTTP libraries normalize header names to lowercase. Treat case
+            # variants as the same secret so an upstream echo in a header name
+            # cannot evade exact cached-id redaction.
+            redacted = re.sub(re.escape(install_id), "***", redacted, flags=re.IGNORECASE)
+        return redacted
+    except Exception:
+        return "***"
+
+
+def _trusted_environment_proxy_configured() -> bool:
+    if not trust_env():
+        return False
+    return any(environment_value(name).strip() for name in _PROXY_ENV_VARS)
+
+
+def _existing_state_blocks_install_id_resolution(path: Path) -> bool:
+    """Return whether existing state must be left untouched by this feature."""
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return True
+    if not isinstance(data, dict) or "install_id" not in data:
+        return not isinstance(data, dict)
+    return not bool(_safe_install_id(data.get("install_id")))
+
+
+def _reset_tokenrhythm_install_id_cache_for_tests() -> None:
+    """Clear process cache state for deterministic unit tests."""
+
+    global _ACTIVE_INSTALL_ID_CONTEXT
+    with _INSTALL_ID_CACHE_LOCK:
+        _INSTALL_ID_CACHE.clear()
+        _ACTIVE_INSTALL_ID_CONTEXT = None
 
 
 def tokenrhythm_correlation_headers(

--- a/src/opensquilla/provider/trace_recorder.py
+++ b/src/opensquilla/provider/trace_recorder.py
@@ -22,8 +22,10 @@ from opensquilla.safety.secret_redaction import redact_secret_value
 from .tokenrhythm_correlation import (
     TOKENRHYTHM_CALL_KIND_HEADER,
     TOKENRHYTHM_EXECUTION_ID_HEADER,
+    TOKENRHYTHM_INSTALL_ID_HEADER,
     TOKENRHYTHM_SESSION_ID_HEADER,
     TOKENRHYTHM_TURN_ID_HEADER,
+    redact_tokenrhythm_install_ids,
 )
 
 _DEFAULT_TRACE_PATH = "/tmp/opensquilla-llm-calls.jsonl"
@@ -36,6 +38,7 @@ _PRESENT = "[PRESENT]"
 _CORRELATION_HEADER_NAMES = frozenset(
     name.lower()
     for name in (
+        TOKENRHYTHM_INSTALL_ID_HEADER,
         TOKENRHYTHM_SESSION_ID_HEADER,
         TOKENRHYTHM_TURN_ID_HEADER,
         TOKENRHYTHM_EXECUTION_ID_HEADER,
@@ -65,7 +68,22 @@ def _include_chunks_from_env() -> bool:
 
 
 def _redact(value: Any, *, key: str | None = None) -> Any:
-    return redact_secret_value(value, key=key)
+    return _redact_install_ids(redact_secret_value(value, key=key))
+
+
+def _redact_install_ids(value: Any) -> Any:
+    if isinstance(value, str):
+        return redact_tokenrhythm_install_ids(value)
+    if isinstance(value, dict):
+        return {
+            redact_tokenrhythm_install_ids(str(item_key)): _redact_install_ids(item_value)
+            for item_key, item_value in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_install_ids(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_install_ids(item) for item in value)
+    return value
 
 
 def _redact_request_headers(headers: dict[str, Any]) -> dict[str, Any]:
@@ -158,12 +176,12 @@ class LLMTraceRecorder:
                 "response": _redact(response or {}),
                 "response_sha256": _sha256(_redact(response or {})) if response else None,
                 "usage": _redact(usage or {}),
-                "stop_reason": stop_reason,
-                "actual_model": actual_model,
+                "stop_reason": _redact(stop_reason),
+                "actual_model": _redact(actual_model),
                 "assistant_text": _redact(assistant_text),
                 "reasoning_content": _redact(reasoning_content),
                 "tool_calls": _redact(tool_calls or []),
-                "response_ids": response_ids or [],
+                "response_ids": _redact(response_ids or []),
                 "metadata": _redact(metadata or {}),
             }
         )
@@ -180,7 +198,7 @@ class LLMTraceRecorder:
         self._append(
             {
                 "event": "llm.error",
-                "code": code,
+                "code": _redact(code),
                 "message": _redact(message),
                 "status_code": status_code,
                 "response_body": _redact(response_body),
@@ -209,5 +227,8 @@ class LLMTraceRecorder:
             with target.open("a", encoding="utf-8") as handle:
                 handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True, default=str))
                 handle.write("\n")
-        except OSError:
+        except Exception:
+            # Provider tracing is optional diagnostics. Invalid paths, custom
+            # serializers, or local filesystem failures must never affect the
+            # physical model request whose already-redacted row is being saved.
             return

--- a/src/opensquilla/session/compaction.py
+++ b/src/opensquilla/session/compaction.py
@@ -16,7 +16,9 @@ from opensquilla.env import trust_env as _trust_env
 from opensquilla.provider.app_attribution import provider_app_headers
 from opensquilla.provider.protocol import provider_connection_config
 from opensquilla.provider.tokenrhythm_correlation import (
+    redact_tokenrhythm_install_ids,
     tokenrhythm_correlation_headers,
+    tokenrhythm_install_id_headers,
 )
 from opensquilla.session.compaction_state import (
     build_structured_summary_from_text,
@@ -648,12 +650,17 @@ async def call_compaction_llm(
         base_url=url,
     )
 
+    cancelled = False
+    client: httpx.AsyncClient | None = None
+    resp: httpx.Response | None = None
+    data: Any = None
     try:
         async with httpx.AsyncClient(
             timeout=timeout,
             trust_env=_trust_env(),
             follow_redirects=False,
         ) as client:
+            headers.update(tokenrhythm_install_id_headers(provider, url))
             resp = await client.post(url, json=payload, headers=headers)
             resp.raise_for_status()
             data = resp.json()
@@ -661,14 +668,47 @@ async def call_compaction_llm(
                 data,
                 raw_json=str(getattr(resp, "text", "") or ""),
             )
-            return cast(str, data["choices"][0]["message"]["content"])
+            return redact_tokenrhythm_install_ids(
+                cast(str, data["choices"][0]["message"]["content"])
+            )
     except asyncio.CancelledError:
-        await usage.mark_unknown("cancelled")
-        raise
+        # A propagated cancellation retains this frame. Scrub request state before
+        # accounting and raise a fresh exception outside the handler so neither the
+        # original traceback nor its context can expose the installation header.
+        headers.clear()
+        client = None
+        resp = None
+        data = None
+        cancelled = True
+        try:
+            await usage.mark_unknown("cancelled")
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass
     except Exception as exc:
-        await usage.mark_unknown("direct_request_failed")
-        log.warning("compaction.llm_call_failed", model=model, error=str(exc))
-        return None
+        safe_error = redact_tokenrhythm_install_ids(str(exc))
+        headers.clear()
+        client = None
+        resp = None
+        data = None
+        try:
+            await usage.mark_unknown("direct_request_failed")
+        except asyncio.CancelledError:
+            cancelled = True
+        except Exception:
+            pass
+        if not cancelled:
+            log.warning(
+                "compaction.llm_call_failed",
+                model=model,
+                error=safe_error,
+            )
+            return None
+
+    if cancelled:
+        raise asyncio.CancelledError from None
+    return None
 
 
 def _merge_summaries(summaries: list[str]) -> str:

--- a/src/opensquilla/session/naming.py
+++ b/src/opensquilla/session/naming.py
@@ -36,7 +36,9 @@ from opensquilla.provider.protocol import (
     provider_connection_config,
 )
 from opensquilla.provider.tokenrhythm_correlation import (
+    redact_tokenrhythm_install_ids,
     tokenrhythm_correlation_headers,
+    tokenrhythm_install_id_headers,
 )
 from opensquilla.router_tiers import DEFAULT_TEXT_TIER, normalize_text_tier
 
@@ -329,12 +331,18 @@ async def call_naming_llm(
         base_url=url,
     )
 
+    cancelled = False
+    client: httpx.AsyncClient | None = None
+    resp: httpx.Response | None = None
+    data: Any = None
+    raw: str | None = None
     try:
         async with httpx.AsyncClient(
             timeout=timeout,
             trust_env=_trust_env(),
             follow_redirects=False,
         ) as client:
+            headers.update(tokenrhythm_install_id_headers(provider, url))
             resp = await client.post(url, json=payload, headers=headers)
             resp.raise_for_status()
             data = resp.json()
@@ -344,14 +352,46 @@ async def call_naming_llm(
             )
             raw = data["choices"][0]["message"]["content"]
     except asyncio.CancelledError:
-        await usage.mark_unknown("cancelled")
-        raise
+        # A propagated cancellation retains this frame. Scrub request state before
+        # accounting and raise a fresh exception outside the handler so neither the
+        # original traceback nor its context can expose the installation header.
+        headers.clear()
+        client = None
+        resp = None
+        data = None
+        raw = None
+        cancelled = True
+        try:
+            await usage.mark_unknown("cancelled")
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass
     except Exception as exc:  # noqa: BLE001 - naming is best-effort
-        await usage.mark_unknown("direct_request_failed")
-        log.warning("session_naming.llm_call_failed", model=model, error=str(exc))
-        return None
+        safe_error = redact_tokenrhythm_install_ids(str(exc))
+        headers.clear()
+        client = None
+        resp = None
+        data = None
+        raw = None
+        try:
+            await usage.mark_unknown("direct_request_failed")
+        except asyncio.CancelledError:
+            cancelled = True
+        except Exception:
+            pass
+        if not cancelled:
+            log.warning(
+                "session_naming.llm_call_failed",
+                model=model,
+                error=safe_error,
+            )
+            return None
 
-    return _sanitize_title(raw, max_chars)
+    if cancelled:
+        raise asyncio.CancelledError from None
+    safe_raw = redact_tokenrhythm_install_ids(raw) if isinstance(raw, str) else raw
+    return _sanitize_title(safe_raw, max_chars)
 
 
 async def generate_session_title(
@@ -449,4 +489,8 @@ async def generate_session_title(
         )
         log.info("session_naming.titled", session_key=session_key, title=title)
     except Exception as exc:  # noqa: BLE001 - never disturb the spawning turn
-        log.warning("session_naming.failed", session_key=session_key, error=str(exc))
+        log.warning(
+            "session_naming.failed",
+            session_key=session_key,
+            error=redact_tokenrhythm_install_ids(str(exc)),
+        )

--- a/src/opensquilla/tools/builtin/shell.py
+++ b/src/opensquilla/tools/builtin/shell.py
@@ -5035,6 +5035,10 @@ async def _write_exec_stdin(proc: Any, stdin_bytes: bytes | None) -> None:
                 await wait_closed()
 
 
+def _use_windows_blocking_exec_stdin() -> bool:
+    return os.name == "nt"
+
+
 async def _wait_exec_stdin_writer(
     proc: Any, writer_task: asyncio.Task[None], timeout: float
 ) -> bool:
@@ -5065,13 +5069,15 @@ async def _cancel_exec_stdin_writer(proc: Any, writer_task: asyncio.Task[None] |
     if proc.stdin is not None and not proc.stdin.is_closing():
         proc.stdin.close()
     writer_task.cancel()
+    done, _pending = await asyncio.wait({writer_task}, timeout=0.05)
+    if writer_task not in done:
+        return
     with contextlib.suppress(
-        TimeoutError,
         asyncio.CancelledError,
         BrokenPipeError,
         ConnectionResetError,
     ):
-        await asyncio.wait_for(writer_task, timeout=0.05)
+        await writer_task
 
 
 async def _await_bg_output_task(output_task: asyncio.Task[None]) -> None:
@@ -5081,6 +5087,91 @@ async def _await_bg_output_task(output_task: asyncio.Task[None]) -> None:
         output_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await output_task
+
+
+def _create_windows_host_shell_process(command: str, **kwargs: Any) -> Any:
+    return subprocess.Popen(_windows_direct_powershell_argv(command), **kwargs)
+
+
+def _terminate_windows_host_shell_process(proc: Any) -> None:
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=_EXEC_TERMINATE_TIMEOUT)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    proc.kill()
+    try:
+        proc.wait(timeout=_EXEC_KILL_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        log.warning("exec_command_termination_timeout", pid=proc.pid)
+
+
+async def _communicate_windows_host_shell_process(
+    proc: Any,
+    stdin_bytes: bytes,
+    timeout: float,
+) -> bool:
+    """Write finite Windows stdin outside Proactor and bound the worker wait."""
+
+    communicate_task = asyncio.create_task(
+        asyncio.to_thread(proc.communicate, input=stdin_bytes)
+    )
+    done, _pending = await asyncio.wait(
+        {communicate_task},
+        timeout=max(0.0, timeout),
+    )
+    if communicate_task in done:
+        await communicate_task
+        return True
+
+    await asyncio.to_thread(_terminate_windows_host_shell_process, proc)
+    done, _pending = await asyncio.wait(
+        {communicate_task},
+        timeout=_EXEC_TERMINATE_TIMEOUT + _EXEC_KILL_TIMEOUT,
+    )
+    if communicate_task in done:
+        with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+            await communicate_task
+    return False
+
+
+async def _run_windows_host_shell_command_with_stdin(
+    command: str,
+    *,
+    cwd: str | None,
+    env: dict[str, str],
+    stdin_bytes: bytes,
+    effective_timeout: float,
+) -> str:
+    try:
+        with tempfile.TemporaryFile() as output_file:
+            creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            proc = _create_windows_host_shell_process(
+                command,
+                stdin=subprocess.PIPE,
+                stdout=output_file,
+                stderr=subprocess.STDOUT,
+                cwd=cwd,
+                env=env,
+                creationflags=creationflags,
+            )
+            completed = await _communicate_windows_host_shell_process(
+                proc,
+                stdin_bytes,
+                effective_timeout,
+            )
+            output_file.flush()
+            output_file.seek(0)
+            raw_output = output_file.read()
+            if not completed:
+                return _exec_timeout_output(effective_timeout, command, raw_output)
+            output = decode_subprocess_output(raw_output)
+            return f"exit_code={proc.returncode}\n{output}"
+    except Exception as exc:
+        return f"[error] {exc}"
 
 
 def _exec_timeout_output(effective_timeout: float, command: str, raw: bytes | str) -> str:
@@ -5109,6 +5200,14 @@ async def _run_host_shell_command(
     stdin_bytes: bytes | None,
     effective_timeout: float,
 ) -> str:
+    if _use_windows_blocking_exec_stdin() and stdin_bytes is not None:
+        return await _run_windows_host_shell_command_with_stdin(
+            command,
+            cwd=cwd,
+            env=env,
+            stdin_bytes=stdin_bytes,
+            effective_timeout=effective_timeout,
+        )
     try:
         with tempfile.TemporaryFile() as output_file:
             subprocess_kwargs: dict[str, Any] = {

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -155,6 +155,10 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     ("persistence", "observability"),
     ("persistence", "skills"),
     ("provider", "engine"),
+    # Official TokenRhythm transports reuse the passive install identity and
+    # its shared privacy policy; observability remains a leaf and never imports
+    # provider back.
+    ("provider", "observability"),
     ("provider", "safety"),
     # Provider argument repair reuses the tool alias/schema helpers (lazy import).
     ("provider", "tools"),

--- a/tests/test_cli/test_ensemble_bench.py
+++ b/tests/test_cli/test_ensemble_bench.py
@@ -7,15 +7,27 @@ live invocation and is not covered here.
 
 from __future__ import annotations
 
+import inspect
 import json
 import textwrap
 from pathlib import Path
 
 from typer.testing import CliRunner
 
+from opensquilla.cli import ensemble_cmd
 from opensquilla.cli.main import app
 
 runner = CliRunner()
+
+
+def test_live_bench_prewarms_install_id_after_loading_config() -> None:
+    source = inspect.getsource(ensemble_cmd.ensemble_bench)
+
+    config_load = source.index("config = load_config(config_path)")
+    prewarm = source.index("prewarm_tokenrhythm_install_id(config=config)")
+    benchmark = source.index("run_config_benchmark(")
+
+    assert config_load < prewarm < benchmark
 
 
 def test_bench_dry_run_json_shape() -> None:

--- a/tests/test_cli/test_memory_dream_cmd.py
+++ b/tests/test_cli/test_memory_dream_cmd.py
@@ -33,3 +33,40 @@ def test_cli_dream_uses_configured_agent_workspace(
 
     assert dream.workspace == configured_workspace.joinpath(*expected_suffix)
     assert not (cwd / ".opensquilla").exists()
+
+
+def test_cli_dream_prewarms_install_id_before_building_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = GatewayConfig(
+        workspace_dir=str(tmp_path / "workspace"),
+        privacy={"disable_network_observability": True},
+    )
+    calls: list[tuple[str, GatewayConfig]] = []
+
+    monkeypatch.setattr(GatewayConfig, "load", classmethod(lambda cls, _path=None: cfg))
+
+    def _prewarm(*, config: GatewayConfig) -> None:
+        calls.append(("prewarm", config))
+
+    class _Dream:
+        def __call__(self, _agent_id: str):
+            return object()
+
+    def _build(*, config: GatewayConfig, turn_runner, need_provider: bool):
+        assert turn_runner is None
+        assert need_provider is True
+        calls.append(("build", config))
+        return _Dream()
+
+    monkeypatch.setattr(
+        "opensquilla.provider.tokenrhythm_correlation.prewarm_tokenrhythm_install_id",
+        _prewarm,
+    )
+    monkeypatch.setattr("opensquilla.memory.dream_factory.build_dream_factory", _build)
+
+    cli_main._build_cli_dream("main")
+
+    assert calls == [("prewarm", cfg), ("build", cfg)]
+    assert cfg.privacy.disable_network_observability is True

--- a/tests/test_cli/test_models_probe.py
+++ b/tests/test_cli/test_models_probe.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 from typer.testing import CliRunner
@@ -59,6 +60,32 @@ def _fake_discover(
         return results[kwargs["provider_id"]]
 
     return fake
+
+
+def _patch_draft_install_id_context(monkeypatch):
+    active_config = SimpleNamespace(
+        privacy=SimpleNamespace(disable_network_observability=True)
+    )
+    load_calls: list[Path | None] = []
+    prewarm_calls: list[Any] = []
+
+    def fake_load_config(path: Path | None):
+        load_calls.append(path)
+        return active_config
+
+    def fake_prewarm(*, config):
+        prewarm_calls.append(config)
+        return None
+
+    monkeypatch.setattr(
+        "opensquilla.cli.models_cmd.load_config",
+        fake_load_config,
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.tokenrhythm_correlation.prewarm_tokenrhythm_install_id",
+        fake_prewarm,
+    )
+    return active_config, load_calls, prewarm_calls
 
 
 def test_probe_ok_renders_table_and_exits_zero(tmp_path: Path, monkeypatch) -> None:
@@ -176,6 +203,9 @@ def test_probe_json_shape(tmp_path: Path, monkeypatch) -> None:
 
 def test_probe_draft_reads_unsaved_credential_from_stdin(monkeypatch) -> None:
     calls: list[dict[str, Any]] = []
+    active_config, load_calls, prewarm_calls = _patch_draft_install_id_context(
+        monkeypatch
+    )
     monkeypatch.setattr(
         "opensquilla.cli.models_cmd.probe_llm_provider",
         _fake_probe(
@@ -220,9 +250,12 @@ def test_probe_draft_reads_unsaved_credential_from_stdin(monkeypatch) -> None:
             "timeout": 30.0,
         }
     ]
+    assert load_calls == [None]
+    assert prewarm_calls == [active_config]
 
 
 def test_probe_draft_redacts_failed_provider_detail(monkeypatch) -> None:
+    _patch_draft_install_id_context(monkeypatch)
     monkeypatch.setattr(
         "opensquilla.cli.models_cmd.probe_llm_provider",
         _fake_probe(
@@ -258,6 +291,27 @@ def test_probe_draft_redacts_failed_provider_detail(monkeypatch) -> None:
     assert row["ok"] is False
     assert row["kind"] == "auth_invalid"
     assert "***" in row["detail"]
+
+
+def test_probe_draft_config_load_failure_registers_disabled_privacy(
+    monkeypatch,
+) -> None:
+    from opensquilla.cli import models_cmd
+
+    def fail_load_config(_path):
+        raise ValueError("synthetic invalid config")
+
+    captured: list[Any] = []
+    monkeypatch.setattr(models_cmd, "load_config", fail_load_config)
+    monkeypatch.setattr(
+        "opensquilla.provider.tokenrhythm_correlation.prewarm_tokenrhythm_install_id",
+        lambda *, config: captured.append(config),
+    )
+
+    models_cmd._prewarm_draft_probe_install_id()
+
+    assert len(captured) == 1
+    assert captured[0].privacy.disable_network_observability is True
 
 
 def test_probe_unknown_provider_filter_exits_two(tmp_path: Path) -> None:

--- a/tests/test_contrib/test_codetask/test_codetask_agent_config.py
+++ b/tests/test_contrib/test_codetask/test_codetask_agent_config.py
@@ -27,12 +27,14 @@ def test_operator_sections_replace_template_wholesale():
     user = {
         "llm": {"provider": "deepseek", "model": "deepseek-chat"},
         "models": {"deepseek": {"deepseek-chat": {"context_window": 128000}}},
+        "privacy": {"disable_network_observability": True},
     }
     bundle = build_per_run_agent_config(template, user)
     # Replaced, not field-merged: the template's max_tokens must not leak
     # under the operator's provider.
     assert bundle.payload["llm"] == {"provider": "deepseek", "model": "deepseek-chat"}
     assert bundle.payload["models"]["deepseek"]["deepseek-chat"]["context_window"] == 128000
+    assert bundle.payload["privacy"]["disable_network_observability"] is True
     # Template policy survives untouched.
     assert bundle.payload["tools"]["deny"] == ["memory*"]
     assert bundle.payload["meta_skill"]["enabled"] is False
@@ -158,20 +160,71 @@ def test_unparseable_operator_config_raises_actionably(monkeypatch, tmp_path):
     assert str(cfg) in str(exc.value)
 
 
-def test_override_env_skips_inheritance(monkeypatch, tmp_path):
+def test_override_preserves_provider_authority_and_inherits_operator_privacy(
+    monkeypatch,
+    tmp_path,
+):
     override = tmp_path / "override.toml"
     override.write_text(
-        '[llm]\nprovider = "deepseek"\nmodel = "deepseek-chat"\napi_key = "sk-keep"\n',
+        '[llm]\nprovider = "deepseek"\nmodel = "deepseek-chat"\napi_key = "sk-keep"\n'
+        "[privacy]\ndisable_network_observability = false\n",
         encoding="utf-8",
     )
     operator = tmp_path / "operator.toml"
-    operator.write_text('[llm]\nprovider = "moonshot"\nmodel = "kimi-k2.6"\n', "utf-8")
+    operator.write_text(
+        '[llm]\nprovider = "moonshot"\nmodel = "kimi-k2.6"\n'
+        "[privacy]\ndisable_network_observability = true\n",
+        "utf-8",
+    )
     monkeypatch.setenv("OPENSQUILLA_CODETASK_AGENT_CONFIG", str(override))
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(operator))
     bundle = load_agent_config_bundle()
     assert bundle.payload["llm"]["provider"] == "deepseek"
     assert bundle.payload["llm"]["api_key"] == "sk-keep"  # full authority, untouched
+    assert bundle.payload["privacy"]["disable_network_observability"] is True
     assert bundle.child_env == {}
+
+
+def test_override_survives_broken_operator_config_with_privacy_disabled(
+    monkeypatch,
+    tmp_path,
+):
+    override = tmp_path / "override.toml"
+    override.write_text(
+        '[llm]\nprovider = "deepseek"\nmodel = "deepseek-chat"\n',
+        encoding="utf-8",
+    )
+    operator = tmp_path / "broken.toml"
+    operator.write_text("[privacy\ndisable_network_observability =", encoding="utf-8")
+    monkeypatch.setenv("OPENSQUILLA_CODETASK_AGENT_CONFIG", str(override))
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(operator))
+
+    bundle = load_agent_config_bundle()
+
+    assert bundle.payload["llm"]["provider"] == "deepseek"
+    assert bundle.payload["privacy"]["disable_network_observability"] is True
+
+
+def test_override_fails_privacy_closed_when_operator_value_is_invalid(
+    monkeypatch,
+    tmp_path,
+):
+    override = tmp_path / "override.toml"
+    override.write_text(
+        '[llm]\nprovider = "deepseek"\nmodel = "deepseek-chat"\n',
+        encoding="utf-8",
+    )
+    operator = tmp_path / "operator.toml"
+    operator.write_text(
+        '[privacy]\ndisable_network_observability = "not-a-boolean"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_CODETASK_AGENT_CONFIG", str(override))
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(operator))
+
+    bundle = load_agent_config_bundle()
+
+    assert bundle.payload["privacy"]["disable_network_observability"] is True
 
 
 def test_blank_override_env_is_treated_as_unset(monkeypatch, tmp_path):

--- a/tests/test_contrib/test_codetask/test_codetask_preflight.py
+++ b/tests/test_contrib/test_codetask/test_codetask_preflight.py
@@ -39,6 +39,38 @@ def test_preflight_passes_on_ok_probe(monkeypatch):
     assert calls[0]["api_key"] == "sk-x"
 
 
+def test_preflight_prewarms_effective_private_config_before_probe(monkeypatch):
+    events = []
+
+    def _prewarm(*, config):
+        events.append(("prewarm", config))
+
+    async def _probe_after_prewarm(*, provider_id, model, **_kw):
+        events.append(("probe", None))
+        return ProviderProbeResult(ok=True, provider_id=provider_id, model=model)
+
+    monkeypatch.setattr(preflight_mod, "prewarm_tokenrhythm_install_id", _prewarm)
+    monkeypatch.setattr(preflight_mod, "probe_llm_provider", _probe_after_prewarm)
+    bundle = _bundle(
+        {
+            "llm": {
+                "provider": "tokenrhythm",
+                "model": "tokenrhythm-test",
+                "api_key": "synthetic-key",
+            },
+            "privacy": {"disable_network_observability": True},
+        }
+    )
+
+    ok, reason = provider_preflight(bundle)
+
+    assert ok is True and reason == ""
+    assert [event for event, _value in events] == ["prewarm", "probe"]
+    effective_config = events[0][1]
+    assert effective_config.privacy.disable_network_observability is True
+    assert effective_config.llm.provider == "tokenrhythm"
+
+
 def test_preflight_blocks_on_missing_key(monkeypatch):
     _probe(
         monkeypatch,
@@ -149,13 +181,31 @@ def test_preflight_skips_cross_provider_tier_configs(monkeypatch):
 
 
 def test_preflight_fails_open_on_probe_exception(monkeypatch):
+    warnings = []
+
     async def _boom(**_kw):
-        raise RuntimeError("probe exploded")
+        raise RuntimeError("probe exploded for i7")
+
+    class _Log:
+        def warning(self, event, **kwargs):
+            warnings.append((event, kwargs))
 
     monkeypatch.setattr(preflight_mod, "probe_llm_provider", _boom)
+    monkeypatch.setattr(preflight_mod, "log", _Log())
+    monkeypatch.setattr(
+        preflight_mod,
+        "redact_tokenrhythm_install_ids",
+        lambda text: text.replace("i7", "***"),
+    )
     bundle = _bundle({"llm": {"provider": "deepseek", "model": "deepseek-chat", "api_key": "k"}})
     ok, _reason = provider_preflight(bundle)
     assert ok is True
+    assert warnings == [
+        (
+            "codetask.preflight.probe_error",
+            {"error": "probe exploded for ***"},
+        )
+    ]
 
 
 def test_provider_block_reason_matches_credential_codes():
@@ -172,3 +222,42 @@ def test_provider_block_reason_ignores_non_credential_codes():
     assert provider_block_reason([]) is None
     # Non-dict items are tolerated (defensive) rather than crashing.
     assert provider_block_reason(["oops", None]) is None
+
+
+def test_preflight_operator_messages_redact_cached_install_id(monkeypatch):
+    install_id = "i7"
+    monkeypatch.setattr(
+        preflight_mod,
+        "redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
+    )
+    _probe(
+        monkeypatch,
+        ProviderProbeResult(
+            ok=False,
+            provider_id="deepseek",
+            model="deepseek-chat",
+            failure_kind=ProviderFailureKind.AUTH_INVALID.value,
+            message=f"credential rejected for {install_id}",
+        ),
+    )
+    bundle = _bundle(
+        {
+            "llm": {
+                "provider": "deepseek",
+                "model": "deepseek-chat",
+                "api_key": "k",
+            }
+        }
+    )
+
+    ok, reason = provider_preflight(bundle)
+    block_reason = provider_block_reason(
+        [{"code": "401", "message": f"upstream echoed {install_id}"}]
+    )
+
+    assert ok is False
+    assert install_id not in reason
+    assert install_id not in (block_reason or "")
+    assert "***" in reason
+    assert "***" in (block_reason or "")

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -76,6 +76,36 @@ def test_gateway_boot_bridges_compaction_notifications_to_session_stream() -> No
     assert "_compaction_listener_remove" in source
 
 
+def test_shared_service_boot_prewarms_tokenrhythm_install_id_after_config_load() -> None:
+    source = Path("src/opensquilla/gateway/boot.py").read_text(encoding="utf-8")
+    build_start = source.index("async def build_services(")
+    config_load = source.index("GatewayConfig.load(", build_start)
+    prewarm = source.index("_prewarm_tokenrhythm_install_id(config)", build_start)
+    provider_setup = source.index("# ── Provider selector", build_start)
+    live_catalog = source.index("await refresh_live_model_catalog(", build_start)
+
+    # build_services is shared by Gateway, one-shot agents, and --standalone.
+    assert config_load < prewarm < provider_setup < live_catalog
+
+
+def test_tokenrhythm_install_id_prewarm_never_breaks_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.gateway import boot
+    from opensquilla.provider import tokenrhythm_correlation
+
+    def fail_prewarm(**_kwargs: Any) -> None:
+        raise RuntimeError("synthetic resolver failure")
+
+    monkeypatch.setattr(
+        tokenrhythm_correlation,
+        "prewarm_tokenrhythm_install_id",
+        fail_prewarm,
+    )
+
+    boot._prewarm_tokenrhythm_install_id(GatewayConfig())
+
+
 def test_gateway_startup_phase_log_uses_bounded_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_observability/test_network_policy.py
+++ b/tests/test_observability/test_network_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from opensquilla.gateway.config import GatewayConfig, PrivacyConfig
 from opensquilla.observability.network_policy import (
     network_observability_disabled,
+    provider_install_id_disabled,
     provider_request_correlation_disabled,
 )
 
@@ -79,6 +80,43 @@ def test_provider_correlation_honors_config_without_base_settings() -> None:
         privacy = _Privacy()
 
     assert provider_request_correlation_disabled(config=_Config(), env={}) is True
+
+
+def test_provider_install_id_defaults_to_enabled() -> None:
+    assert provider_install_id_disabled(env={}) is False
+
+
+def test_provider_install_id_honors_config_and_unified_env() -> None:
+    config = GatewayConfig(
+        privacy=PrivacyConfig(disable_network_observability=True),
+    )
+
+    assert provider_install_id_disabled(config=config, env={}) is True
+    assert provider_install_id_disabled(env={GLOBAL_DISABLE_ENV: "on"}) is True
+
+
+def test_provider_install_id_honors_legacy_telemetry_disable_only() -> None:
+    assert provider_install_id_disabled(env={TELEMETRY_DISABLED_ENV: "yes"}) is True
+    assert provider_install_id_disabled(env={UPDATE_CHECK_DISABLED_ENV: "yes"}) is False
+
+
+def test_provider_install_id_is_suppressed_in_automated_environments() -> None:
+    assert provider_install_id_disabled(env={"GITHUB_ACTIONS": "true"}) is True
+    assert provider_install_id_disabled(env={"OPENSQUILLA_TESTING": "1"}) is True
+    assert provider_install_id_disabled(env={"PYTEST_CURRENT_TEST": "test_name"}) is True
+
+
+def test_provider_install_id_ignores_false_automated_environment_values() -> None:
+    assert (
+        provider_install_id_disabled(
+            env={
+                "GITHUB_ACTIONS": "false",
+                "OPENSQUILLA_TESTING": "off",
+                "PYTEST_CURRENT_TEST": "",
+            }
+        )
+        is False
+    )
 
 
 def test_false_env_does_not_override_config_disable() -> None:

--- a/tests/test_onboarding/test_image_generation_model_discovery.py
+++ b/tests/test_onboarding/test_image_generation_model_discovery.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+import httpx
 import pytest
 
 from opensquilla.onboarding import image_generation_model_discovery as discovery
@@ -120,6 +123,98 @@ def test_tokenrhythm_parser_keeps_online_image_models():
 
     assert [row["id"] for row in rows] == ["qwen-image-2.0", "wan2.7-image"]
     assert rows[0]["capabilitySource"] == "TokenRhythm"
+
+
+@pytest.mark.asyncio
+async def test_tokenrhythm_image_catalog_request_adds_install_id_header(monkeypatch):
+    captured: dict[str, object] = {}
+    entered = False
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"data": []}
+
+    class FakeClient:
+        async def __aenter__(self):
+            nonlocal entered
+            entered = True
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def get(self, url, *, headers):
+            captured.update(url=url, headers=headers)
+            return FakeResponse()
+
+    monkeypatch.setattr(discovery.httpx, "AsyncClient", lambda **_kwargs: FakeClient())
+    monkeypatch.setattr(
+        discovery,
+        "tokenrhythm_install_id_headers",
+        lambda _provider_kind, _base_url: (
+            {"X-OpenSquilla-Install-Id": "synthetic-install-id"}
+            if entered
+            else pytest.fail("install id resolved before the client entered")
+        ),
+    )
+
+    assert await discovery._fetch_tokenrhythm_image_models() == []
+    assert captured["url"] == "https://tokenrhythm.studio/api/models"
+    headers = captured["headers"]
+    assert isinstance(headers, dict)
+    assert headers["X-OpenSquilla-Install-Id"] == "synthetic-install-id"
+
+
+@pytest.mark.asyncio
+async def test_tokenrhythm_image_catalog_http_error_drops_retained_install_id(
+    monkeypatch,
+):
+    install_id = "i7"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            503,
+            request=request,
+            headers={f"X-Echo-{install_id}": install_id},
+            text=f"upstream echoed {install_id}",
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_async_client)
+    monkeypatch.setattr(
+        discovery,
+        "tokenrhythm_install_id_headers",
+        lambda *_args, **_kwargs: {
+            "X-OpenSquilla-Install-Id": install_id
+        },
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.error_redaction.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as raised:
+        await discovery._fetch_tokenrhythm_image_models()
+
+    assert raised.value.__context__ is None
+    assert raised.value.request.headers["X-OpenSquilla-Install-Id"] == "[PRESENT]"
+    retained = " ".join(
+        (
+            repr(raised.value.request.headers),
+            repr(raised.value.response.headers),
+            raised.value.response.text,
+        )
+    )
+    assert install_id not in retained
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider/test_error_secret_boundary.py
+++ b/tests/test_provider/test_error_secret_boundary.py
@@ -24,6 +24,7 @@ from opensquilla.provider.types import ChatConfig, ErrorEvent, Message
 # provider-boundary replacement must protect it solely because it is the active
 # credential; the prefix also exercises Google-style API key shapes.
 _API_KEY = "AIza"
+_SHORT_INSTALL_ID = "i7"
 
 
 def test_tiny_synthetic_key_does_not_corrupt_unrelated_error_words() -> None:
@@ -33,6 +34,130 @@ def test_tiny_synthetic_key_does_not_corrupt_unrelated_error_words() -> None:
         redact_upstream_error_text("document block malformed", api_key="k")
         == "document block malformed"
     )
+
+
+def test_install_id_is_redacted_from_upstream_error_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.provider.error_redaction import redact_upstream_error_code
+
+    monkeypatch.setattr(
+        "opensquilla.provider.error_redaction.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(_SHORT_INSTALL_ID, "***"),
+    )
+
+    assert (
+        redact_upstream_error_code(
+            f"install-{_SHORT_INSTALL_ID}-rejected",
+            api_key="synthetic-key",
+        )
+        == "install-***-rejected"
+    )
+
+
+async def test_short_install_id_is_redacted_from_openai_chat_and_model_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "opensquilla.provider.error_redaction.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(_SHORT_INSTALL_ID, "***"),
+    )
+    monkeypatch.setattr(
+        openai_module,
+        "tokenrhythm_install_id_headers",
+        lambda *_args, **_kwargs: {
+            "X-OpenSquilla-Install-Id": _SHORT_INSTALL_ID
+        },
+    )
+    provider = OpenAIProvider(
+        api_key="synthetic-key",
+        model="deepseek-v4-flash",
+        base_url="https://tokenrhythm.studio/v1",
+        provider_kind="tokenrhythm",
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            raise httpx.ConnectError(
+                f"model discovery echoed {_SHORT_INSTALL_ID}",
+                request=request,
+            )
+        return httpx.Response(
+            401,
+            request=request,
+            json={"error": {"message": f"request echoed {_SHORT_INSTALL_ID}"}},
+        )
+
+    _patch_transport(monkeypatch, handler)
+
+    events = await _events(provider)
+    errors = [event for event in events if isinstance(event, ErrorEvent)]
+    assert len(errors) == 1
+    assert _SHORT_INSTALL_ID not in errors[0].message
+    assert "***" in errors[0].message
+
+    with pytest.raises(httpx.ConnectError) as raised:
+        await provider.list_models(raise_on_error=True)
+    assert _SHORT_INSTALL_ID not in str(raised.value)
+    assert "model discovery echoed ***" in str(raised.value)
+    assert raised.value.request.headers["X-OpenSquilla-Install-Id"] == "[PRESENT]"
+    assert _SHORT_INSTALL_ID not in repr(raised.value.request.headers)
+    assert _SHORT_INSTALL_ID not in repr(raised.value.__context__)
+
+
+def test_http_status_error_clone_redacts_retained_request_and_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.provider.error_redaction import redacted_httpx_error
+
+    monkeypatch.setattr(
+        "opensquilla.provider.error_redaction.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(_SHORT_INSTALL_ID, "***"),
+    )
+    request = httpx.Request(
+        "POST",
+        f"https://tokenrhythm.studio/v1/models?echo={_SHORT_INSTALL_ID}",
+        headers={
+            "Authorization": f"Bearer {_API_KEY}",
+            "X-OpenSquilla-Install-Id": _SHORT_INSTALL_ID,
+            "X-Upstream-Echo": _SHORT_INSTALL_ID,
+        },
+        content=f'{{"echo":"{_SHORT_INSTALL_ID}"}}',
+    )
+    response = httpx.Response(
+        500,
+        request=request,
+        headers={
+            "X-Upstream-Echo": _SHORT_INSTALL_ID,
+            f"X-Echo-{_SHORT_INSTALL_ID}": "present",
+        },
+        text=f"upstream echoed {_SHORT_INSTALL_ID} and {_API_KEY}",
+    )
+    original = httpx.HTTPStatusError(
+        f"request failed for {_SHORT_INSTALL_ID} and {_API_KEY}",
+        request=request,
+        response=response,
+    )
+
+    safe = redacted_httpx_error(original, api_key=_API_KEY)
+
+    assert isinstance(safe, httpx.HTTPStatusError)
+    assert safe.response.request is safe.request
+    assert safe.request.headers["X-OpenSquilla-Install-Id"] == "[PRESENT]"
+    retained = " ".join(
+        (
+            str(safe),
+            repr(safe),
+            str(safe.request.url),
+            repr(safe.request.headers),
+            safe.request.content.decode("latin-1"),
+            repr(safe.response.headers),
+            safe.response.text,
+            repr(original.__dict__),
+        )
+    )
+    assert _SHORT_INSTALL_ID not in retained
+    assert _API_KEY not in retained
 
 
 class _CapturedLog:

--- a/tests/test_provider/test_live_catalog.py
+++ b/tests/test_provider/test_live_catalog.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from opensquilla.provider.live_catalog import (
@@ -372,7 +373,13 @@ async def test_fetch_live_catalog_entries_uses_url_verbatim_without_auth() -> No
     mock_response.raise_for_status = MagicMock()
     mock_response.json.return_value = {"code": 0, "data": [_tokenrhythm_row()]}
 
-    with patch("opensquilla.provider.live_catalog.httpx.AsyncClient") as mock_client_cls:
+    with (
+        patch("opensquilla.provider.live_catalog.httpx.AsyncClient") as mock_client_cls,
+        patch(
+            "opensquilla.provider.live_catalog.tokenrhythm_install_id_headers",
+            return_value={"X-OpenSquilla-Install-Id": "synthetic-install-id"},
+        ),
+    ):
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
@@ -395,9 +402,144 @@ async def test_fetch_live_catalog_entries_uses_url_verbatim_without_auth() -> No
     assert headers == {
         "HTTP-Referer": "https://opensquilla.ai",
         "X-Title": "OpenSquilla",
+        "X-OpenSquilla-Install-Id": "synthetic-install-id",
     }
     assert "Authorization" not in headers
     assert entries["deepseek-v4-pro"]["context_window"] == 900_000
+
+
+async def test_fetch_live_catalog_omits_install_id_with_explicit_proxy() -> None:
+    captured: dict[str, Any] = {}
+    helper_proxies: list[str | None] = []
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"code": 0, "data": []}
+
+    def install_headers(
+        _provider_kind: str,
+        _base_url: str,
+        *,
+        proxy: str | None = None,
+        **_kwargs: Any,
+    ) -> dict[str, str]:
+        helper_proxies.append(proxy)
+        return {} if proxy else {"X-OpenSquilla-Install-Id": "must-not-send"}
+
+    with (
+        patch("opensquilla.provider.live_catalog.httpx.AsyncClient") as mock_client_cls,
+        patch(
+            "opensquilla.provider.live_catalog.tokenrhythm_install_id_headers",
+            side_effect=install_headers,
+        ),
+    ):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        async def capture_get(url: str, **kwargs: Any) -> Any:
+            captured["url"] = url
+            captured["headers"] = kwargs["headers"]
+            return mock_response
+
+        mock_client.get = AsyncMock(side_effect=capture_get)
+        mock_client_cls.return_value = mock_client
+
+        await fetch_live_catalog_entries(
+            "https://tokenrhythm.studio/api/models",
+            "tokenrhythm",
+            proxy="http://company-proxy.example:8080",
+        )
+
+    assert helper_proxies == ["http://company-proxy.example:8080"]
+    assert "X-OpenSquilla-Install-Id" not in captured["headers"]
+    assert mock_client_cls.call_args.kwargs["proxy"] == "http://company-proxy.example:8080"
+
+
+async def test_fetch_live_catalog_redacts_install_id_from_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_id = "i7"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            502,
+            request=request,
+            headers={f"X-Echo-{install_id}": install_id},
+            text=f"upstream echoed {install_id}",
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_async_client)
+    monkeypatch.setattr(
+        "opensquilla.provider.live_catalog.tokenrhythm_install_id_headers",
+        lambda *_args, **_kwargs: {
+            "X-OpenSquilla-Install-Id": install_id
+        },
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.error_redaction.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as raised:
+        await fetch_live_catalog_entries(
+            "https://tokenrhythm.studio/api/models",
+            "tokenrhythm",
+        )
+
+    assert raised.value.__context__ is None
+    assert raised.value.request.headers["X-OpenSquilla-Install-Id"] == "[PRESENT]"
+    retained = " ".join(
+        (
+            repr(raised.value.request.headers),
+            repr(raised.value.response.headers),
+            raised.value.response.text,
+        )
+    )
+    assert install_id not in retained
+
+
+async def test_fetch_live_catalog_invalid_json_drops_retained_install_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_id = "i7"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            request=request,
+            text=f'{{"echo":"{install_id}"',
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_async_client)
+    monkeypatch.setattr(
+        "opensquilla.provider.live_catalog.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        await fetch_live_catalog_entries(
+            "https://tokenrhythm.studio/api/models",
+            "tokenrhythm",
+        )
+
+    assert str(raised.value) == "Live provider catalog returned invalid JSON"
+    assert raised.value.__context__ is None
+    assert not hasattr(raised.value, "doc")
+    assert install_id not in repr(raised.value.__dict__)
 
 
 async def test_fetch_live_catalog_entries_rejects_unknown_shape() -> None:
@@ -446,15 +588,28 @@ async def test_warm_ingests_only_providers_with_live_catalog_metadata(
 async def test_warm_degrades_per_provider_on_fetch_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    install_id = "i7"
+
     async def failing_fetch(*args: Any, **kwargs: Any) -> dict:
-        raise OSError("network unreachable")
+        raise OSError(f"network unreachable {install_id}")
 
     monkeypatch.setattr(
         "opensquilla.provider.live_catalog.fetch_live_catalog_entries", failing_fetch
     )
+    monkeypatch.setattr(
+        "opensquilla.provider.live_catalog.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
+    )
+    captured_log = MagicMock()
+    monkeypatch.setattr("opensquilla.provider.live_catalog.log", captured_log)
     catalog = _RecordingCatalog()
 
     counts = await warm_live_provider_catalogs(catalog, ["tokenrhythm"])
 
     assert counts == {}
     assert catalog.calls == []
+    captured_log.warning.assert_called_once_with(
+        "live_catalog.failed",
+        provider="tokenrhythm",
+        error="network unreachable ***",
+    )

--- a/tests/test_provider/test_tokenrhythm_traceback_boundaries.py
+++ b/tests/test_provider/test_tokenrhythm_traceback_boundaries.py
@@ -1,0 +1,505 @@
+"""Install identity never survives in outward provider traceback frames."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+import pytest
+
+from opensquilla.onboarding import image_generation_model_discovery as image_discovery
+from opensquilla.provider import image_generation, live_catalog, openai
+from opensquilla.provider.image_generation import (
+    ImageGenerationRequest,
+    OpenAIImageGenerationProvider,
+    OpenRouterImageGenerationProvider,
+    TokenRhythmImageGenerationProvider,
+)
+from opensquilla.provider.openai import OpenAIProvider
+from opensquilla.provider.types import ChatConfig, Message
+
+_INSTALL_ID = "synthetic-install-id-frame-boundary"
+_HEADER = "X-OpenSquilla-Install-Id"
+
+
+def _retained_value_text(
+    value: object,
+    *,
+    seen: set[int] | None = None,
+    depth: int = 0,
+) -> str:
+    """Recursively render only state reachable from one production frame."""
+
+    if seen is None:
+        seen = set()
+    if depth > 7:
+        return ""
+    if isinstance(value, (str, bytes, int, float, bool, type(None))):
+        return repr(value)
+    identity = id(value)
+    if identity in seen:
+        return ""
+    seen.add(identity)
+
+    children: list[object] = []
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            children.extend((key, item))
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        children.extend(value)
+    elif isinstance(value, httpx.Headers):
+        children.extend(value.multi_items())
+    elif isinstance(value, httpx.Request):
+        children.extend((str(value.url), value.headers))
+        try:
+            children.append(value.content)
+        except (httpx.RequestNotRead, httpx.StreamConsumed):
+            pass
+    elif isinstance(value, httpx.Response):
+        children.extend((value.headers, value.request))
+        try:
+            children.append(value.content)
+        except (httpx.ResponseNotRead, httpx.StreamConsumed):
+            pass
+    elif isinstance(value, BaseException):
+        children.extend((value.args, getattr(value, "__dict__", {})))
+        for name in ("request", "response", "__cause__", "__context__"):
+            try:
+                children.append(getattr(value, name))
+            except (AttributeError, RuntimeError):
+                pass
+    else:
+        state = getattr(value, "__dict__", None)
+        if isinstance(state, dict):
+            children.append(state)
+
+    return " ".join(
+        (
+            repr(value),
+            *(
+                _retained_value_text(item, seen=seen, depth=depth + 1)
+                for item in children
+            ),
+        )
+    )
+
+
+def _production_traceback_state(
+    exc: BaseException,
+    *,
+    file_fragment: str,
+    function_name: str,
+) -> str:
+    matched: list[str] = []
+    traceback = exc.__traceback__
+    while traceback is not None:
+        frame = traceback.tb_frame
+        filename = frame.f_code.co_filename.replace("\\", "/")
+        if file_fragment in filename and frame.f_code.co_name == function_name:
+            matched.append(_retained_value_text(dict(frame.f_locals)))
+        traceback = traceback.tb_next
+    assert matched, f"missing traceback frame {file_fragment}:{function_name}"
+    return " ".join(matched)
+
+
+def _patch_install_header(monkeypatch: pytest.MonkeyPatch, case: str) -> None:
+    module = {
+        "image": image_generation,
+        "openai-image": image_generation,
+        "openrouter-image": image_generation,
+        "live": live_catalog,
+        "discovery": image_discovery,
+        "models": openai,
+    }[case]
+    monkeypatch.setattr(
+        module,
+        "tokenrhythm_install_id_headers",
+        lambda *_args, **_kwargs: {_HEADER: _INSTALL_ID},
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.error_redaction.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(_INSTALL_ID, "***"),
+    )
+    monkeypatch.setattr(
+        module,
+        "redact_tokenrhythm_install_ids",
+        lambda text: text.replace(_INSTALL_ID, "***"),
+        raising=False,
+    )
+
+
+async def _call_boundary(case: str) -> object:
+    if case == "image":
+        provider = TokenRhythmImageGenerationProvider(api_key="synthetic-provider-key")
+        return await provider.generate(
+            ImageGenerationRequest(
+                prompt="draw a squid",
+                model="qwen-image-2.0",
+                size="1024x1024",
+            )
+        )
+    if case == "openrouter-image":
+        provider = OpenRouterImageGenerationProvider(
+            api_key="synthetic-provider-key",
+            base_url="https://api.tokenrhythm.studio/v1",
+            provider_kind="tokenrhythm",
+        )
+        return await provider.generate(
+            ImageGenerationRequest(
+                prompt="draw a squid",
+                model="image-model",
+                size="1024x1024",
+            )
+        )
+    if case == "openai-image":
+        provider = OpenAIImageGenerationProvider(
+            api_key="synthetic-provider-key",
+            base_url="https://api.tokenrhythm.studio/v1",
+            provider_kind="tokenrhythm",
+        )
+        return await provider.generate(
+            ImageGenerationRequest(
+                prompt="draw a squid",
+                model="image-model",
+                size="1024x1024",
+            )
+        )
+    if case == "live":
+        return await live_catalog.fetch_live_catalog_entries(
+            "https://tokenrhythm.studio/api/models",
+            "tokenrhythm",
+        )
+    if case == "discovery":
+        return await image_discovery._fetch_tokenrhythm_image_models()
+    provider = OpenAIProvider(
+        api_key="synthetic-provider-key",
+        model="deepseek-v4-flash",
+        base_url="https://tokenrhythm.studio/v1",
+        provider_kind="tokenrhythm",
+    )
+    return await provider.list_models(raise_on_error=True)
+
+
+_BOUNDARIES = (
+    pytest.param("image", "provider/image_generation.py", "generate", id="image"),
+    pytest.param(
+        "openai-image",
+        "provider/image_generation.py",
+        "generate",
+        id="openai-compatible-image",
+    ),
+    pytest.param(
+        "openrouter-image",
+        "provider/image_generation.py",
+        "generate",
+        id="openrouter-compatible-image",
+    ),
+    pytest.param("live", "provider/live_catalog.py", "fetch_live_catalog_entries", id="live"),
+    pytest.param(
+        "discovery",
+        "onboarding/image_generation_model_discovery.py",
+        "_fetch_tokenrhythm_image_models",
+        id="image-model-discovery",
+    ),
+    pytest.param("models", "provider/openai.py", "list_models", id="models"),
+)
+
+
+@pytest.mark.parametrize(("case", "file_fragment", "function_name"), _BOUNDARIES)
+async def test_http_error_scrubs_production_traceback_locals(
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    file_fragment: str,
+    function_name: str,
+) -> None:
+    client_options: list[dict[str, Any]] = []
+
+    class StatusClient:
+        def __init__(self) -> None:
+            self.retained_response: httpx.Response | None = None
+
+        async def __aenter__(self) -> StatusClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> bool:
+            return False
+
+        async def get(self, url: str, *, headers: dict[str, str]) -> httpx.Response:
+            return self._response("GET", url, headers)
+
+        async def post(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            json: object,
+        ) -> httpx.Response:
+            return self._response("POST", url, headers, json=json)
+
+        def _response(
+            self,
+            method: str,
+            url: str,
+            headers: dict[str, str],
+            *,
+            json: object | None = None,
+        ) -> httpx.Response:
+            request = httpx.Request(method, url, headers=headers, json=json)
+            self.retained_response = httpx.Response(
+                502,
+                request=request,
+                headers={"X-Upstream-Echo": _INSTALL_ID},
+                text=f"upstream echoed {_INSTALL_ID}",
+            )
+            return self.retained_response
+
+    def client_factory(**kwargs: Any) -> StatusClient:
+        client_options.append(kwargs)
+        return StatusClient()
+
+    monkeypatch.setattr(httpx, "AsyncClient", client_factory)
+    _patch_install_header(monkeypatch, case)
+
+    with pytest.raises(httpx.HTTPStatusError) as raised:
+        await _call_boundary(case)
+
+    state = _production_traceback_state(
+        raised.value,
+        file_fragment=file_fragment,
+        function_name=function_name,
+    )
+    assert _INSTALL_ID not in state
+    assert raised.value.__context__ is None
+    assert client_options[-1]["follow_redirects"] is False
+
+
+@pytest.mark.parametrize(("case", "file_fragment", "function_name"), _BOUNDARIES)
+async def test_cancellation_scrubs_production_traceback_locals(
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    file_fragment: str,
+    function_name: str,
+) -> None:
+    client_options: list[dict[str, Any]] = []
+
+    class CancellingClient:
+        def __init__(self) -> None:
+            self.retained_headers: dict[str, str] = {}
+
+        async def __aenter__(self) -> CancellingClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> bool:
+            return False
+
+        async def get(self, _url: str, *, headers: dict[str, str]) -> httpx.Response:
+            self.retained_headers = headers
+            raise asyncio.CancelledError()
+
+        async def post(
+            self,
+            _url: str,
+            *,
+            headers: dict[str, str],
+            json: object,
+        ) -> httpx.Response:
+            self.retained_headers = headers
+            raise asyncio.CancelledError()
+
+    def client_factory(**kwargs: Any) -> CancellingClient:
+        client_options.append(kwargs)
+        return CancellingClient()
+
+    monkeypatch.setattr(httpx, "AsyncClient", client_factory)
+    _patch_install_header(monkeypatch, case)
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await _call_boundary(case)
+
+    state = _production_traceback_state(
+        raised.value,
+        file_fragment=file_fragment,
+        function_name=function_name,
+    )
+    assert _INSTALL_ID not in state
+    assert raised.value.__context__ is None
+    assert client_options[-1]["follow_redirects"] is False
+
+
+@pytest.mark.parametrize(("case", "file_fragment", "function_name"), _BOUNDARIES)
+async def test_invalid_json_scrubs_response_and_payload_traceback_locals(
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    file_fragment: str,
+    function_name: str,
+) -> None:
+    class InvalidJsonClient:
+        async def __aenter__(self) -> InvalidJsonClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> bool:
+            return False
+
+        async def get(self, url: str, *, headers: dict[str, str]) -> httpx.Response:
+            return self._response("GET", url, headers)
+
+        async def post(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            json: object,
+        ) -> httpx.Response:
+            return self._response("POST", url, headers, json=json)
+
+        @staticmethod
+        def _response(
+            method: str,
+            url: str,
+            headers: dict[str, str],
+            *,
+            json: object | None = None,
+        ) -> httpx.Response:
+            request = httpx.Request(method, url, headers=headers, json=json)
+            return httpx.Response(
+                200,
+                request=request,
+                text=f'{{"echo":"{_INSTALL_ID}"',
+            )
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_kwargs: InvalidJsonClient())
+    _patch_install_header(monkeypatch, case)
+
+    with pytest.raises((RuntimeError, ValueError, json.JSONDecodeError)) as raised:
+        await _call_boundary(case)
+
+    state = _production_traceback_state(
+        raised.value,
+        file_fragment=file_fragment,
+        function_name=function_name,
+    )
+    assert _INSTALL_ID not in state
+    assert raised.value.__context__ is None
+
+
+@pytest.mark.parametrize("failure_kind", ("validation", "download", "download-cancel"))
+async def test_image_post_request_failures_drop_raw_response_state(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: str,
+) -> None:
+    image_url = f"https://cdn.example.test/{_INSTALL_ID}.png"
+
+    class PayloadClient:
+        async def __aenter__(self) -> PayloadClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> bool:
+            return False
+
+        async def post(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            json: object,
+        ) -> httpx.Response:
+            request = httpx.Request("POST", url, headers=headers, json=json)
+            data = (
+                {"data": [], "echo": _INSTALL_ID}
+                if failure_kind == "validation"
+                else {"data": [{"url": image_url}], "echo": _INSTALL_ID}
+            )
+            return httpx.Response(200, request=request, json=data)
+
+    async def failing_download(
+        _url: str,
+        *,
+        timeout_seconds: float,
+    ) -> tuple[str, bytes]:
+        assert timeout_seconds > 0
+        if failure_kind == "download-cancel":
+            raise asyncio.CancelledError()
+        raise RuntimeError("synthetic download failure")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_kwargs: PayloadClient())
+    monkeypatch.setattr(
+        image_generation,
+        "_download_tokenrhythm_image",
+        failing_download,
+    )
+    _patch_install_header(monkeypatch, "image")
+
+    expected_error = (
+        asyncio.CancelledError
+        if failure_kind == "download-cancel"
+        else RuntimeError
+    )
+    with pytest.raises(expected_error) as raised:
+        await _call_boundary("image")
+
+    state = _production_traceback_state(
+        raised.value,
+        file_fragment="provider/image_generation.py",
+        function_name="generate",
+    )
+    assert _INSTALL_ID not in state
+    assert raised.value.__context__ is None
+
+
+async def test_chat_cancellation_drops_physical_stream_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sent_headers: dict[str, str] = {}
+
+    class CancellingStream:
+        async def __aenter__(self) -> object:
+            raise asyncio.CancelledError()
+
+        async def __aexit__(self, *_args: object) -> bool:
+            return False
+
+    class CancellingClient:
+        async def __aenter__(self) -> CancellingClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> bool:
+            return False
+
+        def stream(self, *_args: object, **kwargs: Any) -> CancellingStream:
+            sent_headers.update(kwargs["headers"])
+            return CancellingStream()
+
+    monkeypatch.setattr(
+        openai.httpx,
+        "AsyncClient",
+        lambda **_kwargs: CancellingClient(),
+    )
+    _patch_install_header(monkeypatch, "models")
+    provider = OpenAIProvider(
+        api_key="synthetic-provider-key",
+        model="deepseek-v4-flash",
+        base_url="https://tokenrhythm.studio/v1",
+        provider_kind="tokenrhythm",
+    )
+
+    async def collect() -> None:
+        async for _event in provider.chat(
+            [Message(role="user", content="hello")],
+            config=ChatConfig(),
+        ):
+            pass
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await collect()
+
+    assert sent_headers[_HEADER] == _INSTALL_ID
+    state = _production_traceback_state(
+        raised.value,
+        file_fragment="provider/openai.py",
+        function_name="_stream_with_detached_cancellation",
+    )
+    assert _INSTALL_ID not in state
+    assert raised.value.__context__ is None

--- a/tests/test_provider_image_generation.py
+++ b/tests/test_provider_image_generation.py
@@ -5,6 +5,7 @@ import io
 import json
 from types import SimpleNamespace
 
+import httpx
 import pytest
 from PIL import Image
 
@@ -148,8 +149,6 @@ def test_image_generation_reports_an_exhausted_profile_key_pool(monkeypatch) -> 
 def test_image_generation_reports_pool_failure_through_gateway_capability(
     monkeypatch,
 ) -> None:
-    import httpx
-
     from opensquilla.gateway.config import GatewayConfig
     from opensquilla.gateway.llm_runtime import reset_profile_credential_pools
     from opensquilla.provider.image_generation_credentials import (
@@ -936,6 +935,70 @@ async def test_invalid_provider_image_triggers_fallback_and_requested_format_con
     assert result.mime_type == "image/webp"
     with Image.open(io.BytesIO(result.image_bytes)) as image:
         assert image.format == "WEBP"
+
+
+@pytest.mark.asyncio
+async def test_image_generation_fallback_redacts_install_id_from_attempts_and_error(
+    monkeypatch,
+) -> None:
+    from opensquilla.provider import image_generation
+
+    install_id = "i7"
+
+    class FakeProvider:
+        provider_id = "synthetic_redaction"
+        default_model = "image-model"
+        auth_env_vars: tuple[str, ...] = ()
+
+        async def generate(
+            self,
+            request: ImageGenerationRequest,
+        ) -> ImageGenerationResult:
+            if request.model == "working":
+                return ImageGenerationResult(
+                    image_bytes=_test_png_bytes(),
+                    mime_type="image/png",
+                    model=request.model,
+                    provider=self.provider_id,
+                )
+            raise RuntimeError(f"upstream echoed {install_id}")
+
+    monkeypatch.setattr(
+        image_generation,
+        "redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
+    )
+    image_generation.register_image_generation_provider(FakeProvider())
+    request = ImageGenerationRequest(
+        prompt="draw a squid",
+        model="synthetic_redaction/broken",
+        size="1024x1024",
+    )
+    try:
+        result = await image_generation.generate_with_fallbacks(
+            request=request,
+            candidates=[
+                "synthetic_redaction/broken",
+                "synthetic_redaction/working",
+            ],
+        )
+        with pytest.raises(RuntimeError) as raised:
+            await image_generation.generate_with_fallbacks(
+                request=request,
+                candidates=[
+                    "synthetic_redaction/broken-a",
+                    "synthetic_redaction/broken-b",
+                ],
+            )
+    finally:
+        image_generation.reset_image_generation_providers()
+
+    assert len(result.attempts) == 1
+    assert result.attempts[0].error == "upstream echoed ***"
+    assert install_id not in repr(result.attempts)
+    assert install_id not in str(raised.value)
+    assert install_id not in repr(raised.value)
+    assert "upstream echoed ***" in str(raised.value)
 
 
 @pytest.mark.parametrize(
@@ -2020,6 +2083,12 @@ async def test_tokenrhythm_image_provider_uses_images_api_and_b64_response(
         "opensquilla.provider.image_generation.httpx.AsyncClient",
         lambda **_kwargs: FakeClient(),
     )
+    monkeypatch.setattr(
+        "opensquilla.provider.image_generation.tokenrhythm_install_id_headers",
+        lambda _provider_kind, _base_url: {
+            "X-OpenSquilla-Install-Id": "synthetic-install-id"
+        },
+    )
 
     result = await TokenRhythmImageGenerationProvider(
         api_key="synthetic-tokenrhythm-key"
@@ -2041,11 +2110,178 @@ async def test_tokenrhythm_image_provider_uses_images_api_and_b64_response(
     assert headers[TOKENRHYTHM_TURN_ID_HEADER] == "turn-1"
     assert headers[TOKENRHYTHM_EXECUTION_ID_HEADER] == "image-execution-1"
     assert headers[TOKENRHYTHM_CALL_KIND_HEADER] == "auxiliary.image_generation"
+    assert headers["X-OpenSquilla-Install-Id"] == "synthetic-install-id"
+    assert "synthetic-install-id" not in str(captured["json"])
     assert result.provider == "tokenrhythm"
     assert result.model == "qwen-image-2.0"
     assert result.image_bytes == image_bytes
     assert result.mime_type == "image/png"
     assert result.revised_prompt == "a friendly squid"
+
+
+@pytest.mark.asyncio
+async def test_direct_image_provider_redacts_only_errors_that_echo_install_id(
+    monkeypatch,
+) -> None:
+    install_id = "i7"
+    leaking_error = ValueError(f"upstream echoed {install_id}")
+    ordinary_error = ValueError("ordinary upstream failure")
+    errors = iter((leaking_error, ordinary_error))
+
+    class FailingClient:
+        def __init__(self, error: Exception) -> None:
+            self.error = error
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url, *, headers, json):
+            raise self.error
+
+    monkeypatch.setattr(
+        "opensquilla.provider.image_generation.httpx.AsyncClient",
+        lambda **_kwargs: FailingClient(next(errors)),
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.image_generation.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
+    )
+    provider = TokenRhythmImageGenerationProvider(
+        api_key="synthetic-tokenrhythm-key"
+    )
+
+    with pytest.raises(RuntimeError) as redacted:
+        await provider.generate(_tokenrhythm_image_request())
+    with pytest.raises(ValueError) as unchanged:
+        await provider.generate(_tokenrhythm_image_request())
+
+    assert str(redacted.value) == "upstream echoed ***"
+    assert install_id not in repr(redacted.value)
+    assert unchanged.value is ordinary_error
+
+
+@pytest.mark.asyncio
+async def test_tokenrhythm_image_http_error_drops_retained_install_id(
+    monkeypatch,
+) -> None:
+    install_id = "i7"
+    original_errors: list[httpx.HTTPStatusError] = []
+
+    class FailingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url, *, headers, json):
+            request = httpx.Request("POST", url, headers=headers, json=json)
+            response = httpx.Response(
+                502,
+                request=request,
+                headers={"X-Upstream-Echo": install_id},
+                json={"error": f"upstream echoed {install_id}"},
+            )
+            error = httpx.HTTPStatusError(
+                "upstream rejected the request",
+                request=request,
+                response=response,
+            )
+            original_errors.append(error)
+            raise error
+
+    monkeypatch.setattr(
+        "opensquilla.provider.image_generation.httpx.AsyncClient",
+        lambda **_kwargs: FailingClient(),
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.image_generation.tokenrhythm_install_id_headers",
+        lambda *_args, **_kwargs: {
+            "X-OpenSquilla-Install-Id": install_id
+        },
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.error_redaction.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
+    )
+
+    provider = TokenRhythmImageGenerationProvider(
+        api_key="synthetic-tokenrhythm-key"
+    )
+    with pytest.raises(httpx.HTTPStatusError) as raised:
+        await provider.generate(_tokenrhythm_image_request())
+
+    assert raised.value.__context__ is None
+    assert raised.value.request.headers["X-OpenSquilla-Install-Id"] == "[PRESENT]"
+    assert raised.value.response.request is raised.value.request
+    retained = " ".join(
+        (
+            str(raised.value),
+            repr(raised.value),
+            repr(raised.value.request.headers),
+            raised.value.response.text,
+            repr(original_errors[0].__dict__),
+        )
+    )
+    assert install_id not in retained
+
+
+@pytest.mark.asyncio
+async def test_tokenrhythm_image_invalid_json_drops_retained_install_id(
+    monkeypatch,
+) -> None:
+    from opensquilla.provider import image_generation
+
+    install_id = "i7"
+
+    class InvalidJsonClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url, *, headers, json):
+            request = httpx.Request("POST", url, headers=headers, json=json)
+            return httpx.Response(
+                200,
+                request=request,
+                text=f'{{"echo":"{install_id}"',
+            )
+
+    monkeypatch.setattr(
+        "opensquilla.provider.image_generation.httpx.AsyncClient",
+        lambda **_kwargs: InvalidJsonClient(),
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.image_generation.tokenrhythm_install_id_headers",
+        lambda *_args, **_kwargs: {
+            "X-OpenSquilla-Install-Id": install_id
+        },
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.image_generation.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
+    )
+    image_generation.register_image_generation_provider(
+        TokenRhythmImageGenerationProvider(api_key="synthetic-tokenrhythm-key")
+    )
+    try:
+        with pytest.raises(RuntimeError) as raised:
+            await image_generation.generate_with_fallbacks(
+                request=_tokenrhythm_image_request(),
+                candidates=["tokenrhythm/qwen-image-2.0"],
+            )
+    finally:
+        image_generation.reset_image_generation_providers()
+
+    assert str(raised.value) == "Image generation provider returned invalid JSON"
+    assert raised.value.__context__ is None
+    assert not hasattr(raised.value, "doc")
+    assert install_id not in repr(raised.value.__dict__)
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -396,6 +396,12 @@ def test_stream_timeout_fallback_preserves_tokenrhythm_correlation_headers(
             yield DoneEvent(model="deepseek-v4-flash")
 
     monkeypatch.setattr("opensquilla.provider.openai.httpx.AsyncClient", TimeoutClient)
+    monkeypatch.setattr(
+        "opensquilla.provider.openai.tokenrhythm_install_id_headers",
+        lambda _provider_kind, _base_url, **_kwargs: {
+            "X-OpenSquilla-Install-Id": "synthetic-install-id"
+        },
+    )
     provider = CapturingFallbackProvider(
         api_key="test",
         model="deepseek-v4-flash",
@@ -426,6 +432,78 @@ def test_stream_timeout_fallback_preserves_tokenrhythm_correlation_headers(
     }
     assert {name: stream_headers[name] for name in expected} == expected
     assert {name: fallback_headers[name] for name in expected} == expected
+    assert stream_headers["X-OpenSquilla-Install-Id"] == "synthetic-install-id"
+    assert fallback_headers["X-OpenSquilla-Install-Id"] == "synthetic-install-id"
+
+
+def test_stream_timeout_fallback_drops_stale_install_id_after_hot_disable(
+    monkeypatch: Any,
+) -> None:
+    captured_headers: dict[str, str] = {}
+    install_header_checks = 0
+
+    class FailingResponse:
+        status_code = 503
+        text = "synthetic fallback failure"
+        headers: dict[str, str] = {}
+
+    class CapturingClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> CapturingClient:
+            return self
+
+        async def __aexit__(self, *_exc: Any) -> None:
+            return None
+
+        async def post(self, _url: str, *, headers: dict[str, str], json: Any):
+            captured_headers.update(headers)
+            return FailingResponse()
+
+    monkeypatch.setattr("opensquilla.provider.openai.httpx.AsyncClient", CapturingClient)
+    def install_headers(
+        _provider_kind: str,
+        _base_url: str,
+        **_kwargs: Any,
+    ) -> dict[str, str]:
+        nonlocal install_header_checks
+        install_header_checks += 1
+        if install_header_checks == 1:
+            return {"X-OpenSquilla-Install-Id": "stale-install-id"}
+        return {}
+
+    monkeypatch.setattr(
+        "opensquilla.provider.openai.tokenrhythm_install_id_headers",
+        install_headers,
+    )
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek-v4-flash",
+        base_url="https://tokenrhythm.studio/v1",
+        provider_kind="tokenrhythm",
+    )
+
+    async def collect_fallback() -> list[Any]:
+        return [
+            event
+            async for event in provider._complete_non_stream(
+                payload={"model": "deepseek-v4-flash", "messages": [], "stream": True},
+                headers={
+                    "Authorization": "Bearer test",
+                    "X-OpenSquilla-Install-Id": "stale-install-id",
+                },
+                cfg=ChatConfig(timeout=1.0),
+                tools=None,
+                timeout_exc=httpx.ReadTimeout("synthetic timeout"),
+            )
+        ]
+
+    events = asyncio.run(collect_fallback())
+
+    assert install_header_checks == 2
+    assert "X-OpenSquilla-Install-Id" not in captured_headers
+    assert any(isinstance(event, ErrorEvent) for event in events)
 
 
 def test_dashscope_stream_timeout_emits_heartbeat_before_non_stream_fallback(
@@ -501,6 +579,12 @@ def test_tokenrhythm_chat_adds_app_attribution_headers(
 ) -> None:
     captured: dict[str, Any] = {}
     _patch_transport(monkeypatch, captured)
+    monkeypatch.setattr(
+        "opensquilla.provider.openai.tokenrhythm_install_id_headers",
+        lambda _provider_kind, _base_url, **_kwargs: {
+            "X-OpenSquilla-Install-Id": "synthetic-install-id"
+        },
+    )
     provider = OpenAIProvider(
         api_key="test",
         model="deepseek-v4-flash",
@@ -513,6 +597,67 @@ def test_tokenrhythm_chat_adds_app_attribution_headers(
     assert captured["url"] == expected_url
     assert captured["headers"].get("HTTP-Referer") == "https://opensquilla.ai"
     assert captured["headers"].get("X-Title") == "OpenSquilla"
+    assert (
+        captured["headers"].get("X-OpenSquilla-Install-Id")
+        == "synthetic-install-id"
+    )
+    assert "synthetic-install-id" not in json.dumps(captured["payload"], sort_keys=True)
+
+
+def test_tokenrhythm_chat_omits_install_id_with_explicit_proxy(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    helper_proxies: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = request.headers
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=_sse_body(),
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        captured["client_proxy"] = kwargs.pop("proxy", None)
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    def install_headers(
+        _provider_kind: str,
+        _base_url: str,
+        *,
+        proxy: str | None = None,
+        **_kwargs: Any,
+    ) -> dict[str, str]:
+        helper_proxies.append(proxy)
+        return {} if proxy else {"X-OpenSquilla-Install-Id": "must-not-send"}
+
+    monkeypatch.setattr(
+        "opensquilla.provider.openai.httpx.AsyncClient",
+        patched_async_client,
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.openai.tokenrhythm_install_id_headers",
+        install_headers,
+    )
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek-v4-flash",
+        base_url="https://tokenrhythm.studio/v1",
+        provider_kind="tokenrhythm",
+        proxy="http://company-proxy.example:8080",
+    )
+
+    _collect(provider, ChatConfig())
+
+    assert captured["client_proxy"] == "http://company-proxy.example:8080"
+    assert helper_proxies
+    assert set(helper_proxies) == {"http://company-proxy.example:8080"}
+    assert "X-OpenSquilla-Install-Id" not in captured["headers"]
 
 
 def test_tokenrhythm_chat_adds_session_correlation_headers_only(
@@ -581,6 +726,12 @@ def test_tokenrhythm_chat_never_forwards_correlation_across_redirects(
         "opensquilla.provider.openai.httpx.AsyncClient",
         patched_async_client,
     )
+    monkeypatch.setattr(
+        "opensquilla.provider.openai.tokenrhythm_install_id_headers",
+        lambda _provider_kind, _base_url, **_kwargs: {
+            "X-OpenSquilla-Install-Id": "synthetic-install-id"
+        },
+    )
     provider = OpenAIProvider(
         api_key="test",
         model="deepseek-v4-flash",
@@ -611,6 +762,7 @@ def test_tokenrhythm_chat_never_forwards_correlation_across_redirects(
     assert client_options["follow_redirects"] is False
     assert len(requests) == 1
     assert requests[0].url.host == "tokenrhythm.studio"
+    assert requests[0].headers["X-OpenSquilla-Install-Id"] == "synthetic-install-id"
     assert requests[0].headers["X-OpenSquilla-Session-Id"] == "session-1"
     assert any(isinstance(event, ErrorEvent) for event in events)
 
@@ -667,6 +819,12 @@ def test_tokenrhythm_list_models_adds_app_attribution_headers(
             request=httpx.Request("GET", "https://tokenrhythm.studio/v1/models"),
         ),
     )
+    monkeypatch.setattr(
+        "opensquilla.provider.openai.tokenrhythm_install_id_headers",
+        lambda _provider_kind, _base_url, **_kwargs: {
+            "X-OpenSquilla-Install-Id": "synthetic-install-id"
+        },
+    )
     provider = OpenAIProvider(
         api_key="test",
         model="deepseek-v4-flash",
@@ -679,6 +837,10 @@ def test_tokenrhythm_list_models_adds_app_attribution_headers(
     assert captured["url"] == "https://tokenrhythm.studio/v1/models"
     assert captured["headers"].get("HTTP-Referer") == "https://opensquilla.ai"
     assert captured["headers"].get("X-Title") == "OpenSquilla"
+    assert (
+        captured["headers"].get("X-OpenSquilla-Install-Id")
+        == "synthetic-install-id"
+    )
 
 
 def test_openrouter_list_models_reports_openrouter_provider(monkeypatch: Any) -> None:

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -18,6 +18,9 @@ from opensquilla.provider.openai import (
     _tool_schema_accepts_arguments,
 )
 from opensquilla.provider.selector import build_provider
+from opensquilla.provider.tokenrhythm_correlation import (
+    is_tokenrhythm_correlation_target,
+)
 from opensquilla.provider.types import (
     ChatConfig,
     ContentBlockToolResult,
@@ -560,15 +563,17 @@ def test_dashscope_stream_timeout_emits_heartbeat_before_non_stream_fallback(
 
 
 @pytest.mark.parametrize(
-    ("base_url", "expected_url"),
+    ("base_url", "expected_url", "expects_install_id"),
     [
         (
             "https://tokenrhythm.studio/v1",
             "https://tokenrhythm.studio/v1/chat/completions",
+            True,
         ),
         (
             "https://api-tokenrhythm.example/v1",
             "https://api-tokenrhythm.example/v1/chat/completions",
+            False,
         ),
     ],
 )
@@ -576,14 +581,17 @@ def test_tokenrhythm_chat_adds_app_attribution_headers(
     monkeypatch: Any,
     base_url: str,
     expected_url: str,
+    expects_install_id: bool,
 ) -> None:
     captured: dict[str, Any] = {}
     _patch_transport(monkeypatch, captured)
     monkeypatch.setattr(
         "opensquilla.provider.openai.tokenrhythm_install_id_headers",
-        lambda _provider_kind, _base_url, **_kwargs: {
-            "X-OpenSquilla-Install-Id": "synthetic-install-id"
-        },
+        lambda provider_kind, request_base_url, **_kwargs: (
+            {"X-OpenSquilla-Install-Id": "synthetic-install-id"}
+            if is_tokenrhythm_correlation_target(provider_kind, request_base_url)
+            else {}
+        ),
     )
     provider = OpenAIProvider(
         api_key="test",
@@ -597,10 +605,13 @@ def test_tokenrhythm_chat_adds_app_attribution_headers(
     assert captured["url"] == expected_url
     assert captured["headers"].get("HTTP-Referer") == "https://opensquilla.ai"
     assert captured["headers"].get("X-Title") == "OpenSquilla"
-    assert (
-        captured["headers"].get("X-OpenSquilla-Install-Id")
-        == "synthetic-install-id"
-    )
+    if expects_install_id:
+        assert (
+            captured["headers"].get("X-OpenSquilla-Install-Id")
+            == "synthetic-install-id"
+        )
+    else:
+        assert "X-OpenSquilla-Install-Id" not in captured["headers"]
     assert "synthetic-install-id" not in json.dumps(captured["payload"], sort_keys=True)
 
 

--- a/tests/test_provider_tokenrhythm_correlation.py
+++ b/tests/test_provider_tokenrhythm_correlation.py
@@ -1,20 +1,80 @@
 from __future__ import annotations
 
+import json
+import os
+import threading
+from types import SimpleNamespace
+
 import pytest
 
+from opensquilla.observability import install_telemetry
+from opensquilla.observability.network_policy import provider_install_id_disabled
+from opensquilla.provider import tokenrhythm_correlation as tokenrhythm
 from opensquilla.provider.tokenrhythm_correlation import (
     TOKENRHYTHM_CALL_KIND_HEADER,
     TOKENRHYTHM_EXECUTION_ID_HEADER,
+    TOKENRHYTHM_INSTALL_ID_HEADER,
     TOKENRHYTHM_SESSION_ID_HEADER,
     TOKENRHYTHM_TURN_ID_HEADER,
+    _reset_tokenrhythm_install_id_cache_for_tests,
     is_tokenrhythm_correlation_target,
+    prewarm_tokenrhythm_install_id,
+    redact_tokenrhythm_install_ids,
     tokenrhythm_correlation_headers,
+    tokenrhythm_install_id_headers,
 )
 from opensquilla.provider.types import (
     ChatConfig,
     ProviderRequestCorrelation,
     derive_provider_request_correlation,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_install_id_cache(monkeypatch: pytest.MonkeyPatch):
+    _reset_tokenrhythm_install_id_cache_for_tests()
+    for name in (
+        "GITHUB_ACTIONS",
+        "OPENSQUILLA_TESTING",
+        "PYTEST_CURRENT_TEST",
+        "OPENSQUILLA_PRIVACY_DISABLE_NETWORK_OBSERVABILITY",
+        "OPENSQUILLA_TELEMETRY_DISABLED",
+        "OPENSQUILLA_UPDATE_CHECK_DISABLED",
+        "OPENSQUILLA_TRUST_ENV",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    # Pytest refreshes this variable between fixture setup and the test-call
+    # phase. Keep production's auto-suppression intact while allowing these
+    # focused resolver tests to opt out of pytest's own marker value.
+    def _policy_without_runner_marker(*, config=None):
+        env = dict(os.environ)
+        marker = env.get("PYTEST_CURRENT_TEST", "")
+        if marker.endswith((" (setup)", " (call)", " (teardown)")):
+            env.pop("PYTEST_CURRENT_TEST", None)
+        return provider_install_id_disabled(config=config, env=env)
+
+    monkeypatch.setattr(
+        tokenrhythm,
+        "provider_install_id_disabled",
+        _policy_without_runner_marker,
+    )
+    yield
+    _reset_tokenrhythm_install_id_cache_for_tests()
+
+
+def _config(state_dir, *, privacy_disabled: bool = False):
+    return SimpleNamespace(
+        state_dir=str(state_dir),
+        privacy=SimpleNamespace(
+            disable_network_observability=privacy_disabled,
+        ),
+    )
 
 
 @pytest.mark.parametrize(
@@ -40,6 +100,8 @@ def test_tokenrhythm_correlation_accepts_official_https_origins(
         ("tokenrhythm", "https://user@tokenrhythm.studio/v1"),
         ("tokenrhythm", "https://@tokenrhythm.studio/v1"),
         ("tokenrhythm", "https://tokenrhythm.studio:8443/v1"),
+        ("tokenrhythm", "https://tokenrhythm.studio:/v1"),
+        ("tokenrhythm", "https://tokenrhythm.studio:0443/v1"),
         ("tokenrhythm", "https://tokenrhythm.studio:invalid/v1"),
         ("tokenrhythm", "https://proxy.example.com/v1"),
         ("tokenrhythm", "tokenrhythm.studio/v1"),
@@ -306,3 +368,546 @@ def test_derive_provider_request_correlation_changes_only_requested_fields() -> 
         call_kind="subagent.chat",
     )
     assert derive_provider_request_correlation(None, call_kind="agent.chat") is None
+
+
+def test_install_id_prewarm_is_daemon_nonblocking_and_cached(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_id = "a" * 64
+    entered = threading.Event()
+    release = threading.Event()
+    calls: list[tuple[object, object, bool]] = []
+    config = _config(tmp_path / "profile-state")
+
+    def _ensure(*, config, state_path):
+        calls.append((config, state_path, threading.current_thread().daemon))
+        entered.set()
+        assert release.wait(timeout=2)
+        return install_id
+
+    monkeypatch.setattr(install_telemetry, "ensure_install_telemetry_id", _ensure)
+
+    worker = prewarm_tokenrhythm_install_id(config=config)
+    assert worker is not None
+    assert worker.daemon is True
+    assert entered.wait(timeout=2)
+
+    # The current request does not wait for state I/O.
+    assert (
+        tokenrhythm_install_id_headers(
+            "tokenrhythm",
+            "https://tokenrhythm.studio/v1",
+        )
+        == {}
+    )
+
+    release.set()
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+    assert calls == [
+        (
+            config,
+            tmp_path / "profile-state" / "install_telemetry.json",
+            True,
+        )
+    ]
+    assert tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        "https://tokenrhythm.studio/v1",
+    ) == {TOKENRHYTHM_INSTALL_ID_HEADER: install_id}
+    assert install_id not in repr(tokenrhythm._INSTALL_ID_CACHE)
+    assert prewarm_tokenrhythm_install_id(config=config) is None
+    assert len(calls) == 1
+
+
+def test_install_id_concurrent_cold_prewarm_uses_one_worker(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    call_count = 0
+    call_count_lock = threading.Lock()
+    config = _config(tmp_path / "state")
+
+    def _ensure(*, config, state_path):
+        del config, state_path
+        nonlocal call_count
+        with call_count_lock:
+            call_count += 1
+        entered.set()
+        assert release.wait(timeout=2)
+        return "b" * 64
+
+    monkeypatch.setattr(install_telemetry, "ensure_install_telemetry_id", _ensure)
+    barrier = threading.Barrier(8)
+    results: list[threading.Thread | None] = []
+
+    def _prewarm() -> None:
+        barrier.wait(timeout=2)
+        results.append(prewarm_tokenrhythm_install_id(config=config))
+
+    callers = [threading.Thread(target=_prewarm) for _ in range(8)]
+    for caller in callers:
+        caller.start()
+    for caller in callers:
+        caller.join(timeout=2)
+
+    assert entered.wait(timeout=2)
+    assert len(results) == 8
+    assert results[0] is not None
+    assert all(result is results[0] for result in results)
+    assert call_count == 1
+    release.set()
+    results[0].join(timeout=2)
+
+
+def test_install_id_cache_is_isolated_by_profile_state_path(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_config = _config(tmp_path / "first")
+    second_config = _config(tmp_path / "second")
+    paths = []
+
+    def _ensure(*, config, state_path):
+        del config
+        paths.append(state_path)
+        return "1" * 64 if state_path.parent.name == "first" else "2" * 64
+
+    monkeypatch.setattr(install_telemetry, "ensure_install_telemetry_id", _ensure)
+
+    first_worker = prewarm_tokenrhythm_install_id(config=first_config)
+    second_worker = prewarm_tokenrhythm_install_id(config=second_config)
+    assert first_worker is not None
+    assert second_worker is not None
+    first_worker.join(timeout=2)
+    second_worker.join(timeout=2)
+
+    assert tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        "https://tokenrhythm.studio/v1",
+        config=first_config,
+    ) == {TOKENRHYTHM_INSTALL_ID_HEADER: "1" * 64}
+    assert tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        "https://api.tokenrhythm.studio/v1",
+        config=second_config,
+    ) == {TOKENRHYTHM_INSTALL_ID_HEADER: "2" * 64}
+    assert {path.parent.name for path in paths} == {"first", "second"}
+
+
+def test_install_id_resolution_failure_retries_after_sixty_seconds(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = [100.0]
+    calls = 0
+
+    def _ensure(*, config, state_path):
+        del config, state_path
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("state unavailable")
+        return "c" * 64
+
+    monkeypatch.setattr(install_telemetry, "ensure_install_telemetry_id", _ensure)
+    monkeypatch.setattr(tokenrhythm.time, "monotonic", lambda: now[0])
+    state_path = tmp_path / "install_telemetry.json"
+
+    first = prewarm_tokenrhythm_install_id(state_path=state_path)
+    assert first is not None
+    first.join(timeout=2)
+    assert calls == 1
+
+    now[0] = 159.999
+    assert prewarm_tokenrhythm_install_id(state_path=state_path) is None
+    assert calls == 1
+
+    now[0] = 160.0
+    second = prewarm_tokenrhythm_install_id(state_path=state_path)
+    assert second is not None
+    second.join(timeout=2)
+    assert calls == 2
+    assert tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        "https://tokenrhythm.studio/v1",
+        state_path=state_path,
+    ) == {TOKENRHYTHM_INSTALL_ID_HEADER: "c" * 64}
+
+
+@pytest.mark.parametrize(
+    "unsafe_install_id",
+    [
+        "",
+        "a" * 129,
+        "contains a space",
+        "safe-prefix\r\nX-Injected: value",
+        "192.0.2.42",
+        "2001:db8::42",
+        "aabbccddeeff",
+        "aa:bb:cc:dd:ee:ff",
+        "aa-bb-cc-dd-ee-ff",
+        "aabb.ccdd.eeff",
+    ],
+)
+def test_unsafe_install_id_is_omitted_without_rewriting_state(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    unsafe_install_id: str,
+) -> None:
+    state_path = tmp_path / "install_telemetry.json"
+    original = (
+        '{"install_id": '
+        + json.dumps(unsafe_install_id)
+        + ', "install_id_source": "random-persisted", "custom": true}\n'
+    ).encode()
+    state_path.write_bytes(original)
+    ensure_calls = 0
+
+    def _ensure(*, config, state_path):
+        del config, state_path
+        nonlocal ensure_calls
+        ensure_calls += 1
+        return unsafe_install_id
+
+    monkeypatch.setattr(install_telemetry, "ensure_install_telemetry_id", _ensure)
+
+    worker = prewarm_tokenrhythm_install_id(state_path=state_path)
+    assert worker is not None
+    worker.join(timeout=2)
+
+    assert tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        "https://tokenrhythm.studio/v1",
+        state_path=state_path,
+    ) == {}
+    assert ensure_calls == 0
+    assert state_path.read_bytes() == original
+
+
+def test_install_id_accepts_safe_value_at_header_length_limit(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_id = "a" * 128
+    monkeypatch.setattr(
+        install_telemetry,
+        "ensure_install_telemetry_id",
+        lambda **_kwargs: install_id,
+    )
+    worker = prewarm_tokenrhythm_install_id(
+        state_path=tmp_path / "install_telemetry.json"
+    )
+    assert worker is not None
+    worker.join(timeout=2)
+
+    assert tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        "https://api.tokenrhythm.studio/v1",
+    ) == {TOKENRHYTHM_INSTALL_ID_HEADER: install_id}
+
+
+def test_install_id_privacy_config_is_rechecked_for_every_request(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path / "state")
+    monkeypatch.setattr(
+        install_telemetry,
+        "ensure_install_telemetry_id",
+        lambda **_kwargs: "d" * 64,
+    )
+    worker = prewarm_tokenrhythm_install_id(config=config)
+    assert worker is not None
+    worker.join(timeout=2)
+
+    assert TOKENRHYTHM_INSTALL_ID_HEADER in tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        "https://tokenrhythm.studio/v1",
+    )
+    config.privacy.disable_network_observability = True
+    assert (
+        tokenrhythm_install_id_headers(
+            "tokenrhythm",
+            "https://tokenrhythm.studio/v1",
+        )
+        == {}
+    )
+    config.privacy.disable_network_observability = False
+    assert TOKENRHYTHM_INSTALL_ID_HEADER in tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        "https://tokenrhythm.studio/v1",
+    )
+
+
+@pytest.mark.parametrize(
+    "disable_env",
+    [
+        "OPENSQUILLA_PRIVACY_DISABLE_NETWORK_OBSERVABILITY",
+        "OPENSQUILLA_TELEMETRY_DISABLED",
+        "GITHUB_ACTIONS",
+        "OPENSQUILLA_TESTING",
+        "PYTEST_CURRENT_TEST",
+    ],
+)
+def test_install_id_disable_environments_prevent_generation(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    disable_env: str,
+) -> None:
+    calls = 0
+
+    def _ensure(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return "e" * 64
+
+    monkeypatch.setattr(install_telemetry, "ensure_install_telemetry_id", _ensure)
+    monkeypatch.setenv(disable_env, "true")
+
+    assert (
+        prewarm_tokenrhythm_install_id(
+            state_path=tmp_path / "install_telemetry.json"
+        )
+        is None
+    )
+    assert (
+        tokenrhythm_install_id_headers(
+            "tokenrhythm",
+            "https://tokenrhythm.studio/v1",
+        )
+        == {}
+    )
+    assert calls == 0
+
+
+def test_update_check_disable_does_not_suppress_install_id(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_UPDATE_CHECK_DISABLED", "true")
+    monkeypatch.setattr(
+        install_telemetry,
+        "ensure_install_telemetry_id",
+        lambda **_kwargs: "f" * 64,
+    )
+
+    worker = prewarm_tokenrhythm_install_id(
+        state_path=tmp_path / "install_telemetry.json"
+    )
+    assert worker is not None
+    worker.join(timeout=2)
+    assert tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        "https://tokenrhythm.studio/v1",
+    ) == {TOKENRHYTHM_INSTALL_ID_HEADER: "f" * 64}
+
+
+@pytest.mark.parametrize(
+    ("provider_kind", "base_url"),
+    [
+        ("openrouter", "https://tokenrhythm.studio/v1"),
+        ("tokenrhythm", "http://tokenrhythm.studio/v1"),
+        ("tokenrhythm", "https://tokenrhythm.studio.example/v1"),
+        ("tokenrhythm", "https://user@tokenrhythm.studio/v1"),
+        ("tokenrhythm", "https://tokenrhythm.studio:444/v1"),
+        ("tokenrhythm", "https://proxy.example/v1"),
+    ],
+)
+def test_install_id_untrusted_targets_do_not_start_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    provider_kind: str,
+    base_url: str,
+) -> None:
+    calls = 0
+
+    def _ensure(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return "0" * 64
+
+    monkeypatch.setattr(install_telemetry, "ensure_install_telemetry_id", _ensure)
+
+    assert tokenrhythm_install_id_headers(provider_kind, base_url) == {}
+    assert calls == 0
+
+
+def test_install_id_rejects_explicit_proxy_before_and_after_prewarm(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def _ensure(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return "7" * 64
+
+    monkeypatch.setattr(install_telemetry, "ensure_install_telemetry_id", _ensure)
+    base_url = "https://tokenrhythm.studio/v1"
+    proxy = "https://company-proxy.example"
+
+    assert tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        base_url,
+        proxy=proxy,
+    ) == {}
+    assert calls == 0
+
+    worker = prewarm_tokenrhythm_install_id(
+        state_path=tmp_path / "install_telemetry.json"
+    )
+    assert worker is not None
+    worker.join(timeout=2)
+    assert calls == 1
+    assert tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        base_url,
+        proxy=proxy,
+    ) == {}
+    assert tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        base_url,
+        proxy="  ",
+    ) == {TOKENRHYTHM_INSTALL_ID_HEADER: "7" * 64}
+
+
+@pytest.mark.parametrize(
+    "proxy_env",
+    [
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+    ],
+)
+def test_install_id_trusted_environment_proxy_does_not_start_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    proxy_env: str,
+) -> None:
+    calls = 0
+
+    def _ensure(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return "8" * 64
+
+    monkeypatch.setattr(install_telemetry, "ensure_install_telemetry_id", _ensure)
+    monkeypatch.setenv("OPENSQUILLA_TRUST_ENV", "true")
+    monkeypatch.setenv(proxy_env, "http://127.0.0.1:3128")
+    monkeypatch.setenv("NO_PROXY", "tokenrhythm.studio")
+
+    assert (
+        tokenrhythm_install_id_headers(
+            "tokenrhythm",
+            "https://tokenrhythm.studio/v1",
+        )
+        == {}
+    )
+    assert calls == 0
+
+
+def test_install_id_ignores_environment_proxy_when_trust_env_is_off(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:3128")
+    monkeypatch.setenv("OPENSQUILLA_TRUST_ENV", "false")
+    monkeypatch.setattr(
+        install_telemetry,
+        "ensure_install_telemetry_id",
+        lambda **_kwargs: "6" * 64,
+    )
+    worker = prewarm_tokenrhythm_install_id(
+        state_path=tmp_path / "install_telemetry.json"
+    )
+    assert worker is not None
+    worker.join(timeout=2)
+
+    assert tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        "https://tokenrhythm.studio/v1",
+    ) == {TOKENRHYTHM_INSTALL_ID_HEADER: "6" * 64}
+
+
+def test_cached_short_install_id_is_redacted_from_diagnostic_text(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        install_telemetry,
+        "ensure_install_telemetry_id",
+        lambda **_kwargs: "AbC",
+    )
+    worker = prewarm_tokenrhythm_install_id(
+        state_path=tmp_path / "install_telemetry.json"
+    )
+    assert worker is not None
+    worker.join(timeout=2)
+
+    assert (
+        redact_tokenrhythm_install_ids("before AbC after abc and ABC")
+        == "before *** after *** and ***"
+    )
+    assert redact_tokenrhythm_install_ids("unrelated") == "unrelated"
+
+    def _broken_validator(_value):
+        raise RuntimeError("validator unavailable")
+
+    monkeypatch.setattr(tokenrhythm, "_safe_install_id", _broken_validator)
+    assert redact_tokenrhythm_install_ids("diagnostic text") == "***"
+
+
+def test_install_id_cold_header_starts_default_daemon(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+
+    def _ensure(**_kwargs):
+        entered.set()
+        assert release.wait(timeout=2)
+        return "9" * 64
+
+    monkeypatch.setattr(install_telemetry, "ensure_install_telemetry_id", _ensure)
+
+    assert (
+        tokenrhythm_install_id_headers(
+            "tokenrhythm",
+            "https://tokenrhythm.studio/v1",
+        )
+        == {}
+    )
+    assert entered.wait(timeout=2)
+    worker = prewarm_tokenrhythm_install_id()
+    assert worker is not None
+    release.set()
+    worker.join(timeout=2)
+    assert tokenrhythm_install_id_headers(
+        "tokenrhythm",
+        "https://tokenrhythm.studio/v1",
+    ) == {TOKENRHYTHM_INSTALL_ID_HEADER: "9" * 64}
+
+
+def test_install_id_helpers_fail_open_when_context_resolution_raises() -> None:
+    class _BrokenConfig:
+        @property
+        def state_dir(self):
+            raise RuntimeError("broken state path")
+
+    config = _BrokenConfig()
+
+    assert prewarm_tokenrhythm_install_id(config=config) is None
+    assert (
+        tokenrhythm_install_id_headers(
+            "tokenrhythm",
+            "https://tokenrhythm.studio/v1",
+            config=config,
+        )
+        == {}
+    )

--- a/tests/test_provider_tokenrhythm_correlation.py
+++ b/tests/test_provider_tokenrhythm_correlation.py
@@ -95,6 +95,7 @@ def test_tokenrhythm_correlation_accepts_official_https_origins(
     [
         ("openrouter", "https://tokenrhythm.studio/v1"),
         ("tokenrhythm", "http://tokenrhythm.studio/v1"),
+        ("tokenrhythm", "https://api-tokenrhythm.example/v1"),
         ("tokenrhythm", "https://tokenrhythm.studio.example.com/v1"),
         ("tokenrhythm", "https://eviltokenrhythm.studio/v1"),
         ("tokenrhythm", "https://user@tokenrhythm.studio/v1"),

--- a/tests/test_provider_trace_recorder.py
+++ b/tests/test_provider_trace_recorder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+from opensquilla.provider import trace_recorder as trace_recorder_module
 from opensquilla.provider.trace_recorder import LLMTraceRecorder
 
 
@@ -29,6 +30,7 @@ def test_llm_trace_recorder_writes_full_payload_and_redacts_headers(
         headers={
             "Authorization": "Bearer secret",
             "Content-Type": "application/json",
+            "X-OpenSquilla-Install-Id": "install-1",
             "X-OpenSquilla-Session-Id": "session-1",
             "X-OpenSquilla-Turn-Id": "turn-1",
             "X-OpenSquilla-Execution-Id": "execution-1",
@@ -52,11 +54,13 @@ def test_llm_trace_recorder_writes_full_payload_and_redacts_headers(
     ]
     assert rows[0]["payload"]["messages"][0]["content"] == "hi"
     assert rows[0]["headers"]["Authorization"] == "[REDACTED]"
+    assert rows[0]["headers"]["X-OpenSquilla-Install-Id"] == "[PRESENT]"
     assert rows[0]["headers"]["X-OpenSquilla-Session-Id"] == "[PRESENT]"
     assert rows[0]["headers"]["X-OpenSquilla-Turn-Id"] == "[PRESENT]"
     assert rows[0]["headers"]["X-OpenSquilla-Execution-Id"] == "[PRESENT]"
     assert rows[0]["headers"]["X-OpenSquilla-Call-Kind"] == "[PRESENT]"
     serialized = json.dumps(rows[0]["headers"], sort_keys=True)
+    assert "install-1" not in serialized
     assert "session-1" not in serialized
     assert "turn-1" not in serialized
     assert "execution-1" not in serialized
@@ -79,3 +83,64 @@ def test_llm_trace_recorder_off_does_not_write(tmp_path, monkeypatch) -> None:
     recorder.record_request(payload={"model": "z-ai/glm-5.1"})
 
     assert not path.exists()
+
+
+def test_llm_trace_recorder_invalid_path_never_affects_provider_call(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_LLM_TRACE_RECORDER", "full")
+    monkeypatch.setattr(
+        trace_recorder_module,
+        "_trace_path_from_env",
+        lambda: "invalid\x00trace.jsonl",
+    )
+    recorder = LLMTraceRecorder(
+        provider="tokenrhythm",
+        model="test-model",
+        base_url="https://tokenrhythm.studio/v1",
+        endpoint="https://tokenrhythm.studio/v1/chat/completions",
+        stream=True,
+    )
+
+    recorder.record_request(
+        payload={"model": "test-model"},
+        headers={"X-OpenSquilla-Install-Id": "must-not-escape"},
+    )
+
+
+def test_llm_trace_recorder_redacts_cached_install_id_from_error_text(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    path = tmp_path / "llm_calls.jsonl"
+    install_id = "cached-install-id"
+    monkeypatch.setenv("OPENSQUILLA_LLM_TRACE_RECORDER", "full")
+    monkeypatch.setenv("OPENSQUILLA_LLM_TRACE_PATH", str(path))
+    monkeypatch.setattr(
+        trace_recorder_module,
+        "redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
+    )
+    recorder = LLMTraceRecorder(
+        provider="tokenrhythm",
+        model="test-model",
+        base_url="https://tokenrhythm.studio/v1",
+        endpoint="https://tokenrhythm.studio/v1/chat/completions",
+        stream=False,
+    )
+
+    recorder.record_error(
+        code=f"provider_error-{install_id}",
+        message=f"request failed for {install_id}",
+        response_body=f'{{"diagnostic":"{install_id}"}}',
+        metadata={f"key-{install_id}": [f"value-{install_id}"]},
+    )
+    recorder.record_response(
+        stop_reason=f"stop-{install_id}",
+        actual_model=f"model-{install_id}",
+        response_ids=[f"response-{install_id}"],
+    )
+
+    serialized = json.dumps(_jsonl(path), sort_keys=True)
+    assert install_id not in serialized
+    assert "***" in serialized

--- a/tests/test_session/test_compaction.py
+++ b/tests/test_session/test_compaction.py
@@ -1,5 +1,7 @@
 """Tests for context window compaction logic."""
 
+import asyncio
+
 import pytest
 
 from opensquilla.provider.types import ProviderRequestCorrelation
@@ -751,13 +753,18 @@ async def test_call_compaction_llm_adds_openrouter_app_attribution(monkeypatch) 
 @pytest.mark.asyncio
 async def test_call_compaction_llm_adds_tokenrhythm_app_attribution(monkeypatch) -> None:
     captured: dict[str, object] = {}
+    install_id = "synthetic-install-id"
 
     class FakeResponse:
         def raise_for_status(self) -> None:
             return None
 
         def json(self) -> dict:
-            return {"choices": [{"message": {"content": "summary"}}]}
+            return {
+                "choices": [
+                    {"message": {"content": f"summary echoed {install_id}"}}
+                ]
+            }
 
     class FakeClient:
         async def __aenter__(self):
@@ -775,6 +782,16 @@ async def test_call_compaction_llm_adds_tokenrhythm_app_attribution(monkeypatch)
         "opensquilla.session.compaction.httpx.AsyncClient",
         lambda **kwargs: FakeClient(),
     )
+    monkeypatch.setattr(
+        "opensquilla.session.compaction.tokenrhythm_install_id_headers",
+        lambda _provider_kind, _base_url: {
+            "X-OpenSquilla-Install-Id": install_id
+        },
+    )
+    monkeypatch.setattr(
+        "opensquilla.session.compaction.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
+    )
 
     result = await call_compaction_llm(
         chunk_text="old conversation",
@@ -791,7 +808,7 @@ async def test_call_compaction_llm_adds_tokenrhythm_app_attribution(monkeypatch)
         ),
     )
 
-    assert result == "summary"
+    assert result == "summary echoed ***"
     assert captured["url"] == "https://tokenrhythm.studio/v1/chat/completions"
     headers = captured["headers"]
     assert isinstance(headers, dict)
@@ -801,6 +818,156 @@ async def test_call_compaction_llm_adds_tokenrhythm_app_attribution(monkeypatch)
     assert headers["X-OpenSquilla-Execution-Id"] == "compaction-1"
     assert headers["X-OpenSquilla-Call-Kind"] == "auxiliary.compaction"
     assert headers["X-Title"] == "OpenSquilla"
+    assert headers["X-OpenSquilla-Install-Id"] == install_id
+
+
+@pytest.mark.asyncio
+async def test_call_compaction_llm_cancellation_does_not_retain_install_id(
+    monkeypatch,
+) -> None:
+    install_id = "synthetic-cancelled-compaction-install-id"
+    sent_headers: dict[str, str] = {}
+    usage_reasons: list[str] = []
+
+    class RetainingResponse:
+        text = ""
+
+        def __init__(self, headers: dict[str, str]) -> None:
+            self.request_headers = dict(headers)
+
+        def __repr__(self) -> str:
+            return f"RetainingResponse(headers={self.request_headers!r})"
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {
+                "choices": [{"message": {"content": "unused"}}],
+                "echo": install_id,
+            }
+
+    class RetainingClient:
+        def __init__(self) -> None:
+            self.request_headers: dict[str, str] = {}
+
+        def __repr__(self) -> str:
+            return f"RetainingClient(headers={self.request_headers!r})"
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url, *, json, headers):
+            self.request_headers = dict(headers)
+            sent_headers.update(headers)
+            return RetainingResponse(headers)
+
+    class CancellingUsage:
+        async def finalize_openai_response(self, data, *, raw_json) -> None:
+            raise asyncio.CancelledError
+
+        async def mark_unknown(self, reason: str) -> None:
+            usage_reasons.append(reason)
+
+    async def reserve_direct_usage_call(**_kwargs):
+        return CancellingUsage()
+
+    monkeypatch.setattr(
+        "opensquilla.session.compaction.httpx.AsyncClient",
+        lambda **_kwargs: RetainingClient(),
+    )
+    monkeypatch.setattr(
+        "opensquilla.session.compaction.tokenrhythm_install_id_headers",
+        lambda _provider_kind, _base_url: {
+            "X-OpenSquilla-Install-Id": install_id
+        },
+    )
+    monkeypatch.setattr(
+        "opensquilla.engine.usage_http.reserve_direct_usage_call",
+        reserve_direct_usage_call,
+    )
+
+    task = asyncio.create_task(
+        call_compaction_llm(
+            chunk_text="old conversation",
+            identifier_instruction="",
+            model="deepseek-v4-flash",
+            api_key="test-key",
+            base_url="https://tokenrhythm.studio/v1",
+            provider="tokenrhythm",
+        )
+    )
+    with pytest.raises(asyncio.CancelledError) as caught:
+        await task
+
+    assert task.cancelled()
+    assert usage_reasons == ["cancelled"]
+    assert sent_headers["X-OpenSquilla-Install-Id"] == install_id
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+    traceback = caught.value.__traceback__
+    production_locals: list[str] = []
+    while traceback is not None:
+        frame = traceback.tb_frame
+        if (
+            frame.f_globals.get("__name__") == "opensquilla.session.compaction"
+            and frame.f_code.co_name == "call_compaction_llm"
+        ):
+            production_locals.append(repr(frame.f_locals))
+        traceback = traceback.tb_next
+    assert len(production_locals) == 1
+    assert install_id not in production_locals[0]
+
+
+@pytest.mark.asyncio
+async def test_call_compaction_llm_redacts_install_id_from_failure_log(monkeypatch) -> None:
+    install_id = "i7"
+    warnings: list[tuple[str, dict]] = []
+
+    class FailingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url, *, json, headers):
+            raise RuntimeError(f"upstream echoed {install_id}")
+
+    class CapturingLog:
+        def warning(self, event: str, **kwargs) -> None:
+            warnings.append((event, kwargs))
+
+    monkeypatch.setattr(
+        "opensquilla.session.compaction.httpx.AsyncClient",
+        lambda **_kwargs: FailingClient(),
+    )
+    monkeypatch.setattr("opensquilla.session.compaction.log", CapturingLog())
+    monkeypatch.setattr(
+        "opensquilla.session.compaction.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
+    )
+
+    result = await call_compaction_llm(
+        chunk_text="old conversation",
+        identifier_instruction="",
+        model="deepseek-v4-flash",
+        api_key="test-key",
+        base_url="https://tokenrhythm.studio/v1",
+        provider="tokenrhythm",
+    )
+
+    assert result is None
+    assert warnings == [
+        (
+            "compaction.llm_call_failed",
+            {"model": "deepseek-v4-flash", "error": "upstream echoed ***"},
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_session/test_naming.py
+++ b/tests/test_session/test_naming.py
@@ -371,12 +371,23 @@ async def test_call_naming_llm_payload_and_sanitization(monkeypatch):
 @pytest.mark.asyncio
 async def test_call_naming_llm_adds_tokenrhythm_app_attribution(monkeypatch):
     captured: dict = {}
+    install_id = "synthetic-install-id"
     monkeypatch.setattr(
         "opensquilla.session.naming.httpx.AsyncClient",
-        lambda **kwargs: _fake_client(captured),
+        lambda **kwargs: _fake_client(captured, content=f'"Echo {install_id}"'),
+    )
+    monkeypatch.setattr(
+        "opensquilla.session.naming.tokenrhythm_install_id_headers",
+        lambda _provider_kind, _base_url: {
+            "X-OpenSquilla-Install-Id": install_id
+        },
+    )
+    monkeypatch.setattr(
+        "opensquilla.session.naming.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
     )
 
-    await call_naming_llm(
+    title = await call_naming_llm(
         "Help me reset my password please",
         model="deepseek-v4-flash",
         api_key="test-key",
@@ -397,6 +408,155 @@ async def test_call_naming_llm_adds_tokenrhythm_app_attribution(monkeypatch):
     assert captured["headers"]["X-OpenSquilla-Turn-Id"] == "turn-1"
     assert captured["headers"]["X-OpenSquilla-Execution-Id"] == "naming-1"
     assert captured["headers"]["X-OpenSquilla-Call-Kind"] == "auxiliary.naming"
+    assert captured["headers"]["X-OpenSquilla-Install-Id"] == install_id
+    assert install_id not in str(captured["json"])
+    # Title sanitization removes the trailing redaction marker as punctuation.
+    assert title == "Echo"
+
+
+@pytest.mark.asyncio
+async def test_call_naming_llm_cancellation_does_not_retain_install_id(monkeypatch):
+    install_id = "synthetic-cancelled-naming-install-id"
+    sent_headers: dict[str, str] = {}
+    usage_reasons: list[str] = []
+
+    class RetainingResponse:
+        text = ""
+
+        def __init__(self, headers: dict[str, str]) -> None:
+            self.request_headers = dict(headers)
+
+        def __repr__(self) -> str:
+            return f"RetainingResponse(headers={self.request_headers!r})"
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {
+                "choices": [{"message": {"content": "unused"}}],
+                "echo": install_id,
+            }
+
+    class RetainingClient:
+        def __init__(self) -> None:
+            self.request_headers: dict[str, str] = {}
+
+        def __repr__(self) -> str:
+            return f"RetainingClient(headers={self.request_headers!r})"
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url, *, json, headers):
+            self.request_headers = dict(headers)
+            sent_headers.update(headers)
+            return RetainingResponse(headers)
+
+    class CancellingUsage:
+        async def finalize_openai_response(self, data, *, raw_json) -> None:
+            raise asyncio.CancelledError
+
+        async def mark_unknown(self, reason: str) -> None:
+            usage_reasons.append(reason)
+
+    async def reserve_direct_usage_call(**_kwargs):
+        return CancellingUsage()
+
+    monkeypatch.setattr(
+        "opensquilla.session.naming.httpx.AsyncClient",
+        lambda **_kwargs: RetainingClient(),
+    )
+    monkeypatch.setattr(
+        "opensquilla.session.naming.tokenrhythm_install_id_headers",
+        lambda _provider_kind, _base_url: {
+            "X-OpenSquilla-Install-Id": install_id
+        },
+    )
+    monkeypatch.setattr(
+        "opensquilla.engine.usage_http.reserve_direct_usage_call",
+        reserve_direct_usage_call,
+    )
+
+    task = asyncio.create_task(
+        call_naming_llm(
+            "Help me reset my password please",
+            model="deepseek-v4-flash",
+            api_key="test-key",
+            base_url="https://tokenrhythm.studio/v1",
+            provider="tokenrhythm",
+        )
+    )
+    with pytest.raises(asyncio.CancelledError) as caught:
+        await task
+
+    assert task.cancelled()
+    assert usage_reasons == ["cancelled"]
+    assert sent_headers["X-OpenSquilla-Install-Id"] == install_id
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+    traceback = caught.value.__traceback__
+    production_locals: list[str] = []
+    while traceback is not None:
+        frame = traceback.tb_frame
+        if (
+            frame.f_globals.get("__name__") == "opensquilla.session.naming"
+            and frame.f_code.co_name == "call_naming_llm"
+        ):
+            production_locals.append(repr(frame.f_locals))
+        traceback = traceback.tb_next
+    assert len(production_locals) == 1
+    assert install_id not in production_locals[0]
+
+
+@pytest.mark.asyncio
+async def test_call_naming_llm_redacts_install_id_from_failure_log(monkeypatch):
+    install_id = "i7"
+    warnings: list[tuple[str, dict]] = []
+
+    class FailingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url, *, json, headers):
+            raise RuntimeError(f"upstream echoed {install_id}")
+
+    class CapturingLog:
+        def warning(self, event: str, **kwargs) -> None:
+            warnings.append((event, kwargs))
+
+    monkeypatch.setattr(
+        "opensquilla.session.naming.httpx.AsyncClient",
+        lambda **_kwargs: FailingClient(),
+    )
+    monkeypatch.setattr("opensquilla.session.naming.log", CapturingLog())
+    monkeypatch.setattr(
+        "opensquilla.session.naming.redact_tokenrhythm_install_ids",
+        lambda text: text.replace(install_id, "***"),
+    )
+
+    title = await call_naming_llm(
+        "Help me reset my password please",
+        model="deepseek-v4-flash",
+        api_key="test-key",
+        base_url="https://tokenrhythm.studio/v1",
+        provider="tokenrhythm",
+    )
+
+    assert title is None
+    assert warnings == [
+        (
+            "session_naming.llm_call_failed",
+            {"model": "deepseek-v4-flash", "error": "upstream echoed ***"},
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools/test_shell_process_isolation.py
+++ b/tests/test_tools/test_shell_process_isolation.py
@@ -6,6 +6,7 @@ import os
 import shlex
 import subprocess
 import sys
+import threading
 import time
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -285,6 +286,95 @@ async def test_write_exec_stdin_waits_until_eof_is_delivered() -> None:
     assert stdin.writes == [b"payload"]
     assert stdin.closed is True
     assert stdin.close_waited is True
+
+
+@pytest.mark.asyncio
+async def test_windows_host_stdin_uses_blocking_communicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _CompletedProcess:
+        returncode = None
+        pid = 1
+
+        def communicate(self, *, input: bytes) -> tuple[None, None]:
+            captured["stdin_bytes"] = input
+            self.returncode = 0
+            return None, None
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+    def fake_create_subprocess(command: str, **kwargs: object):
+        captured["command"] = command
+        captured["stdin_target"] = kwargs["stdin"]
+        return _CompletedProcess()
+
+    monkeypatch.setattr(shell, "_use_windows_blocking_exec_stdin", lambda: True)
+    monkeypatch.setattr(shell, "_create_windows_host_shell_process", fake_create_subprocess)
+
+    result = await shell._run_host_shell_command(
+        "Write-Output ok",
+        cwd=None,
+        env={},
+        stdin_bytes=b"payload",
+        effective_timeout=1.0,
+    )
+
+    assert result == "exit_code=0\n"
+    assert captured == {
+        "command": "Write-Output ok",
+        "stdin_target": subprocess.PIPE,
+        "stdin_bytes": b"payload",
+    }
+
+
+@pytest.mark.asyncio
+async def test_windows_blocking_stdin_timeout_terminates_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release = threading.Event()
+    actions: list[str] = []
+
+    class _HangingProcess:
+        returncode = None
+        pid = 1
+
+        def communicate(self, *, input: bytes) -> tuple[None, None]:
+            assert input == b"payload"
+            assert release.wait(timeout=2)
+            return None, None
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+        def terminate(self) -> None:
+            actions.append("terminate")
+            self.returncode = -1
+            release.set()
+
+        def wait(self, *, timeout: float) -> int:
+            assert timeout == shell._EXEC_TERMINATE_TIMEOUT
+            return -1
+
+    monkeypatch.setattr(shell, "_use_windows_blocking_exec_stdin", lambda: True)
+    monkeypatch.setattr(
+        shell,
+        "_create_windows_host_shell_process",
+        lambda _command, **_kwargs: _HangingProcess(),
+    )
+
+    result = await shell._run_host_shell_command(
+        "Write-Output ok",
+        cwd=None,
+        env={},
+        stdin_bytes=b"payload",
+        effective_timeout=0.01,
+    )
+
+    assert result.startswith("[timeout after 0.01s]")
+    assert actions == ["terminate"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

- Add the optional `X-OpenSquilla-Install-Id` header to official TokenRhythm API requests.
- Resolve and cache the existing persisted install identity off the startup/event-loop critical path, with privacy hot-disable and 60-second failure retry behavior.
- Restrict transmission to exact official TokenRhythm HTTPS targets on port 443, excluding proxies, redirects, CDNs, OpenRouter, and other providers.
- Keep the install identity and correlation host gate strict even though public `HTTP-Referer` / `X-Title` attribution now supports alternate hostnames containing `tokenrhythm`.
- Redact the identifier from provider traces, exceptions, traceback locals, logs, request bodies, and query parameters.
- Cover chat, fallback and auxiliary model calls, image generation, catalogs/model discovery, onboarding probes, Gateway, standalone CLI, code-task, naming, compaction, and memory flows.
- Update PRIVACY.md, English/Chinese READMEs, six WebUI locales, and the Unreleased changelog.\n- Route finite Windows host-command stdin through blocking `subprocess.Popen.communicate()` in a worker so bytes and EOF bypass the Proactor pipe race, while keeping POSIX pipe backpressure and bounded cancellation.

## Branch target

`main`

## Linked issue

None.

## Release note

Included in `CHANGELOG.md` under Unreleased.

## Verification

- `3872 passed, 11 skipped` across the complete related provider/onboarding/session/observability/Gateway/CLI/code-task regression scope after rebasing onto current `origin/main`
- `53 passed, 191 deselected` in focused application-attribution/install-identity host-boundary coverage after integrating PR #977
- `uv run ruff check src tests`
- Mypy passed for all 18 changed Python source files
- `opensquilla-webui: npm run build` (typecheck, architecture, security, theme, i18n, Vite artifact verification)
- `67 passed, 5 skipped` for shell process isolation and Windows shell runtime contracts after the stdin fix\n- Ruff and Mypy passed for the changed shell implementation and tests\n- `git diff --check`
- Independent implementation audit: no blockers
- Manual two-hop CDN redirect check: no provider or install identity headers forwarded

## Safety and compatibility

- Fail-open for API availability: a missing, invalid, or unresolved ID simply omits the header.
- Network-observability privacy controls and CI/test suppression prevent both generation and transmission; runtime privacy changes apply on the next request.
- Alternate TokenRhythm-compatible hostnames receive only the public application attribution headers; they do not receive install identity or correlation headers.
- The server must treat the header as optional and untrusted, never as authentication, authorization, billing, rate-limiting, or anti-abuse input.
- Original MAC/IP values are never sent.
- The install-id header behavior remains platform-neutral. The CI-unblocking shell change is isolated to Windows finite stdin delivery through a bounded worker; Linux/macOS retain the existing pipe path.
- No database, configuration, Gateway RPC, WebSocket, or persisted-state migration; existing installations and clients remain compatible.

## Third-party origin

None; implementation and test changes are original to this repository.