### PR TITLE
Make ErrorBoundary diagnostics safe and actionable

### DIFF
--- a/opensquilla-webui/src/components/ErrorBoundary.test.ts
+++ b/opensquilla-webui/src/components/ErrorBoundary.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+
+const mocks = vi.hoisted(() => ({
+  copyText: vi.fn(),
+  revealLog: vi.fn(),
+  platform: {
+    gateway: {} as { revealLog?: () => Promise<boolean> },
+  },
+  messages: {
+    'errorBoundary.title': 'Something went wrong',
+    'errorBoundary.defaultMessage': 'An unexpected error occurred.',
+    'errorBoundary.reload': 'Reload page',
+    'errorBoundary.dismiss': 'Dismiss',
+    'errorBoundary.detailsLabel': 'Error details',
+    'errorBoundary.copyDetails': 'Copy details',
+    'errorBoundary.copied': 'Copied',
+    'errorBoundary.openLogs': 'Open logs folder',
+    'errorBoundary.privacyHint': 'Review before sharing.',
+    'errorBoundary.copyFailed': 'Copy failed. Select the details and copy them manually.',
+    'errorBoundary.openLogsFailed': 'Could not open the logs folder.',
+  } as Record<string, string>,
+}))
+
+vi.mock('@/platform', () => ({
+  usePlatform: () => mocks.platform,
+}))
+
+vi.mock('@/utils/browser', () => ({
+  copyTextWithFallback: mocks.copyText,
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => mocks.messages[key] ?? key,
+  }),
+}))
+
+import ErrorBoundary from './ErrorBoundary.vue'
+
+const mountedApps: Array<{ app: App; el: HTMLElement }> = []
+
+async function flush() {
+  for (let index = 0; index < 8; index += 1) await Promise.resolve()
+  await nextTick()
+  await nextTick()
+}
+
+async function mountBoundary(error: Error) {
+  const ThrowingChild = defineComponent({
+    name: 'ThrowingChild',
+    setup() {
+      return () => {
+        throw error
+      }
+    },
+  })
+  const Root = defineComponent({
+    setup() {
+      return () => h(ErrorBoundary, null, { default: () => h(ThrowingChild) })
+    },
+  })
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  const app = createApp(Root)
+  app.mount(el)
+  mountedApps.push({ app, el })
+  await flush()
+  return el
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  vi.clearAllMocks()
+  mocks.copyText.mockResolvedValue(undefined)
+  mocks.revealLog.mockResolvedValue(true)
+  mocks.platform.gateway = {}
+  vi.spyOn(console, 'error').mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+  while (mountedApps.length) {
+    const { app, el } = mountedApps.pop()!
+    app.unmount()
+    el.remove()
+  }
+  vi.restoreAllMocks()
+})
+
+describe('ErrorBoundary', () => {
+  it('shows a sanitized fallback and keeps the desktop-only action off the web', async () => {
+    const error = new Error('Failed at /Users/alice/project?token=secret-value')
+    error.stack = 'Error: Failed at /Users/alice/project?token=secret-value\n    at render (app.js:1)'
+    const el = await mountBoundary(error)
+
+    expect(el.textContent).toContain('Something went wrong')
+    expect(el.textContent).toContain('/Users/[user]/project?token=[redacted]')
+    expect(el.textContent).not.toContain('alice')
+    expect(el.textContent).not.toContain('secret-value')
+    expect(el.textContent).toContain('Review before sharing.')
+    expect(el.querySelector('[data-testid="error-boundary-open-logs"]')).toBeNull()
+    expect(console.error).toHaveBeenCalledWith(
+      '[ErrorBoundary]',
+      'Error: Failed at /Users/[user]/project?token=[redacted]\n    at render (app.js:1)',
+    )
+  })
+
+  it('copies only sanitized details and confirms success', async () => {
+    const error = new Error('API key api_key=sk-private')
+    error.stack = 'Error: API key api_key=sk-private\n    at send (client.ts:4)'
+    const el = await mountBoundary(error)
+
+    el.querySelector<HTMLButtonElement>('[data-testid="error-boundary-copy"]')!.click()
+    await flush()
+
+    expect(mocks.copyText).toHaveBeenCalledWith(
+      'Error: API key api_key=[redacted]\n    at send (client.ts:4)',
+    )
+    expect(el.querySelector('[data-testid="error-boundary-copy"]')?.textContent).toContain('Copied')
+  })
+
+  it('reports a clipboard failure without throwing out of the fallback', async () => {
+    mocks.copyText.mockRejectedValue(new Error('permission denied'))
+    const el = await mountBoundary(new Error('boom'))
+
+    el.querySelector<HTMLButtonElement>('[data-testid="error-boundary-copy"]')!.click()
+    await flush()
+
+    expect(el.querySelector('[data-testid="error-boundary-action-error"]')?.textContent)
+      .toContain('Copy failed')
+  })
+
+  it('offers desktop logs and reports a reveal failure inline', async () => {
+    mocks.revealLog.mockRejectedValue(new Error('shell unavailable'))
+    mocks.platform.gateway = { revealLog: mocks.revealLog }
+    const el = await mountBoundary(new Error('boom'))
+
+    el.querySelector<HTMLButtonElement>('[data-testid="error-boundary-open-logs"]')!.click()
+    await flush()
+
+    expect(mocks.revealLog).toHaveBeenCalledOnce()
+    expect(el.querySelector('[data-testid="error-boundary-action-error"]')?.textContent)
+      .toContain('Could not open the logs folder')
+  })
+})

--- a/opensquilla-webui/src/components/ErrorBoundary.vue
+++ b/opensquilla-webui/src/components/ErrorBoundary.vue
@@ -3,30 +3,76 @@
     <div class="error-boundary__content">
       <h2>{{ t('errorBoundary.title') }}</h2>
       <p class="error-boundary__message">{{ errorMessage || t('errorBoundary.defaultMessage') }}</p>
+
+      <details v-if="errorDetails" class="error-boundary__details">
+        <summary>{{ t('errorBoundary.detailsLabel') }}</summary>
+        <p class="error-boundary__privacy-hint">{{ t('errorBoundary.privacyHint') }}</p>
+        <pre class="error-boundary__stack">{{ errorDetails }}</pre>
+      </details>
+
       <div class="error-boundary__actions">
-        <button class="btn btn--primary" @click="reload">{{ t('errorBoundary.reload') }}</button>
-        <button class="btn btn--ghost" @click="clearError">{{ t('errorBoundary.dismiss') }}</button>
+        <button type="button" class="btn btn--primary" @click="reload">
+          {{ t('errorBoundary.reload') }}
+        </button>
+        <button
+          v-if="errorDetails"
+          type="button"
+          class="btn btn--ghost"
+          data-testid="error-boundary-copy"
+          @click="copyDetails"
+        >{{ copied ? t('errorBoundary.copied') : t('errorBoundary.copyDetails') }}</button>
+        <button
+          v-if="canRevealLog"
+          type="button"
+          class="btn btn--ghost"
+          data-testid="error-boundary-open-logs"
+          @click="openLogs"
+        >{{ t('errorBoundary.openLogs') }}</button>
+        <button type="button" class="btn btn--ghost" @click="clearError">
+          {{ t('errorBoundary.dismiss') }}
+        </button>
       </div>
+      <p
+        v-if="actionError"
+        class="error-boundary__action-error"
+        data-testid="error-boundary-action-error"
+        role="alert"
+      >{{ actionError }}</p>
     </div>
   </div>
   <slot v-else />
 </template>
 
 <script setup lang="ts">
-import { ref, onErrorCaptured } from 'vue'
+import { ref, computed, onErrorCaptured } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { usePlatform } from '@/platform'
+import { copyTextWithFallback } from '@/utils/browser'
+import { errorBoundaryMessage, errorBoundaryDetails } from './errorBoundaryDetails'
 
 // useScope:'global' so the outermost error boundary never depends on a scoped
 // i18n instance being present when it has to render.
 const { t } = useI18n({ useScope: 'global' })
+const platform = usePlatform()
 
 const hasError = ref(false)
 const errorMessage = ref('')
+const errorDetails = ref('')
+const copied = ref(false)
+const actionError = ref('')
+
+// Only shown on desktop, where a real log folder exists and can be revealed.
+// On the web there is no revealLog capability, so the button is hidden rather
+// than dead. Mirrors the pattern in DesktopRuntimePanel.
+const canRevealLog = computed(() => Boolean(platform.gateway.revealLog))
 
 onErrorCaptured((err: unknown) => {
   hasError.value = true
-  errorMessage.value = err instanceof Error ? err.message : String(err)
-  console.error('[ErrorBoundary]', err)
+  errorMessage.value = errorBoundaryMessage(err)
+  errorDetails.value = errorBoundaryDetails(err)
+  copied.value = false
+  actionError.value = ''
+  console.error('[ErrorBoundary]', errorDetails.value || errorMessage.value || 'Unknown error')
   return false // Prevent error from propagating
 })
 
@@ -37,6 +83,31 @@ function reload() {
 function clearError() {
   hasError.value = false
   errorMessage.value = ''
+  errorDetails.value = ''
+  copied.value = false
+  actionError.value = ''
+}
+
+async function copyDetails() {
+  if (!errorDetails.value) return
+  try {
+    await copyTextWithFallback(errorDetails.value)
+    copied.value = true
+    actionError.value = ''
+  } catch {
+    copied.value = false
+    actionError.value = t('errorBoundary.copyFailed')
+  }
+}
+
+async function openLogs() {
+  if (!platform.gateway.revealLog) return
+  try {
+    await platform.gateway.revealLog()
+    actionError.value = ''
+  } catch {
+    actionError.value = t('errorBoundary.openLogsFailed')
+  }
 }
 </script>
 
@@ -66,9 +137,48 @@ function clearError() {
   word-break: break-word;
 }
 
+.error-boundary__details {
+  margin-bottom: 1.5rem;
+  text-align: left;
+}
+
+.error-boundary__details summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+}
+
+.error-boundary__stack {
+  margin-top: 0.75rem;
+  max-height: 220px;
+  overflow: auto;
+  padding: 0.75rem;
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.error-boundary__privacy-hint,
+.error-boundary__action-error {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+}
+
+.error-boundary__privacy-hint {
+  margin: 0.75rem 0 0;
+}
+
+.error-boundary__action-error {
+  margin: 0.75rem 0 0;
+}
+
 .error-boundary__actions {
   display: flex;
   gap: 0.75rem;
   justify-content: center;
+  flex-wrap: wrap;
 }
 </style>

--- a/opensquilla-webui/src/components/errorBoundaryDetails.test.ts
+++ b/opensquilla-webui/src/components/errorBoundaryDetails.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import {
+  errorBoundaryDetails,
+  errorBoundaryMessage,
+  redactErrorBoundaryText,
+} from './errorBoundaryDetails'
+
+describe('errorBoundaryMessage', () => {
+  it('uses the Error message', () => {
+    expect(errorBoundaryMessage(new Error('boom'))).toBe('boom')
+  })
+
+  it('turns a multiline message into a single line', () => {
+    expect(errorBoundaryMessage(new Error('first\nsecond'))).toBe('first second')
+  })
+
+  it('passes a string through unchanged', () => {
+    expect(errorBoundaryMessage('plain failure')).toBe('plain failure')
+  })
+
+  it('serializes a non-Error object', () => {
+    expect(errorBoundaryMessage({ code: 42 })).toBe('{"code":42}')
+  })
+
+  it('falls back to String() when JSON serialization throws', () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+    expect(errorBoundaryMessage(circular)).toBe('[object Object]')
+  })
+
+  it('returns an empty message for undefined or an entirely hostile value', () => {
+    const hostile = new Proxy({}, {
+      get() {
+        throw new Error('blocked')
+      },
+      getPrototypeOf() {
+        throw new Error('blocked')
+      },
+    })
+    expect(errorBoundaryMessage(undefined)).toBe('')
+    expect(() => errorBoundaryMessage(hostile)).not.toThrow()
+    expect(errorBoundaryMessage(hostile)).toBe('')
+  })
+})
+
+describe('errorBoundaryDetails', () => {
+  it('uses a standard stack without duplicating its error heading', () => {
+    const err = new Error('kaboom')
+    err.stack = 'Error: kaboom\n    at somewhere (app.js:1:1)'
+    expect(errorBoundaryDetails(err)).toBe(
+      'Error: kaboom\n    at somewhere (app.js:1:1)',
+    )
+  })
+
+  it('keeps a non-standard stack after the error heading', () => {
+    const err = new Error('kaboom')
+    err.stack = 'at somewhere (app.js:1:1)'
+    expect(errorBoundaryDetails(err)).toBe(
+      'Error: kaboom\n\nat somewhere (app.js:1:1)',
+    )
+  })
+
+  it('handles an Error without a stack', () => {
+    const err = new Error('no stack')
+    err.stack = undefined
+    expect(errorBoundaryDetails(err)).toBe('Error: no stack')
+  })
+
+  it('handles a non-Error value', () => {
+    expect(errorBoundaryDetails('just a string')).toBe('just a string')
+  })
+
+  it('truncates an oversized stack with a locale-neutral marker', () => {
+    const err = new Error('big')
+    err.stack = 'x'.repeat(20000)
+    const details = errorBoundaryDetails(err)
+    expect(details.length).toBeLessThanOrEqual(8000)
+    expect(details.endsWith('\n…')).toBe(true)
+    expect(details).not.toContain('truncated')
+  })
+
+  it('does not throw when Error properties have hostile getters', () => {
+    const err = new Error('safe')
+    Object.defineProperties(err, {
+      message: { get: () => { throw new Error('blocked') } },
+      name: { get: () => { throw new Error('blocked') } },
+      stack: { get: () => { throw new Error('blocked') } },
+    })
+    expect(() => errorBoundaryDetails(err)).not.toThrow()
+    expect(errorBoundaryDetails(err)).toBe('Error')
+  })
+})
+
+describe('redactErrorBoundaryText', () => {
+  it('redacts macOS, Linux, and Windows home directory names', () => {
+    const input = [
+      '/Users/alice/.opensquilla/config.toml',
+      '/home/bob/.opensquilla/state.db',
+      String.raw`C:\Users\carol\AppData\Roaming\OpenSquilla`,
+      'D:/Users/dave/AppData/Roaming/OpenSquilla',
+    ].join('\n')
+    expect(redactErrorBoundaryText(input)).toBe([
+      '/Users/[user]/.opensquilla/config.toml',
+      '/home/[user]/.opensquilla/state.db',
+      String.raw`C:\Users\[user]\AppData\Roaming\OpenSquilla`,
+      'D:/Users/[user]/AppData/Roaming/OpenSquilla',
+    ].join('\n'))
+  })
+
+  it('redacts common secret assignments, URL credentials, and bearer tokens', () => {
+    const input = [
+      'https://alice:password@example.test/path?access_token=url-secret&mode=safe',
+      'https://example.test/path?token=plain-token&mode=safe',
+      'api_key="sk-example" password: hunter2',
+      'Authorization: Bearer abc.def-123',
+      'request failed with Bearer standalone-token',
+      '--password flag-secret',
+      'provider rejected sk-example123456',
+    ].join('\n')
+    const result = redactErrorBoundaryText(input)
+    expect(result).not.toContain('alice:password')
+    expect(result).not.toContain('url-secret')
+    expect(result).not.toContain('plain-token')
+    expect(result).not.toContain('sk-example')
+    expect(result).not.toContain('hunter2')
+    expect(result).not.toContain('abc.def-123')
+    expect(result).not.toContain('standalone-token')
+    expect(result).not.toContain('flag-secret')
+    expect(result).not.toContain('sk-example123456')
+    expect(result).toContain('access_token=[redacted]&mode=safe')
+  })
+})

--- a/opensquilla-webui/src/components/errorBoundaryDetails.ts
+++ b/opensquilla-webui/src/components/errorBoundaryDetails.ts
@@ -1,0 +1,98 @@
+// Pure helpers for the ErrorBoundary fallback. Caught values are untrusted:
+// proxies and custom Error subclasses can throw from property access,
+// serialization, or string conversion. Keep every conversion fail-closed so
+// the fallback itself cannot crash while trying to describe the first error.
+
+const MAX_MESSAGE_CHARS = 500
+const MAX_DETAILS_CHARS = 8000
+
+function safeString(value: unknown): string {
+  if (value === undefined) return ''
+  if (typeof value === 'string') return value
+  try {
+    const json = JSON.stringify(value)
+    if (typeof json === 'string') return json
+  } catch {
+    // Fall through to String() for circular and otherwise non-JSON values.
+  }
+  try {
+    return String(value)
+  } catch {
+    return ''
+  }
+}
+
+function safeProperty(value: object, key: 'message' | 'name' | 'stack'): string {
+  try {
+    return safeString(Reflect.get(value, key))
+  } catch {
+    return ''
+  }
+}
+
+function isError(value: unknown): value is Error {
+  try {
+    return value instanceof Error
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Remove high-risk local identifiers and credentials before details reach the
+ * UI, clipboard, or renderer console. This intentionally targets common error
+ * shapes rather than claiming to be a complete secret scanner.
+ */
+export function redactErrorBoundaryText(value: string): string {
+  return value
+    .replace(/\/(Users|home)\/[^/\s]+\//g, '/$1/[user]/')
+    .replace(/([A-Za-z]:[\\/]Users[\\/])[^\\/\s]+([\\/])/g, '$1[user]$2')
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+:[^@/\s]+@/gi, '$1[redacted]@')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [redacted]')
+    .replace(
+      /((?:--?|\/)\s*(?:api[_-]?key|token|password|secret|auth(?:orization)?))(?:\s+|=)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi,
+      '$1 [redacted]',
+    )
+    .replace(
+      /\b(access[_-]?token|token|api[_-]?key|apikey|secret|password|authorization|auth)\b(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;&#]+)/gi,
+      '$1$2[redacted]',
+    )
+    .replace(
+      /\b(?:sk-[a-z0-9_-]{8,}|sk_(?:live|test|proj)_[a-z0-9_]{8,}|gh[pousr]_[a-z0-9_]{12,}|xox[baprs]-[a-z0-9-]{12,}|AKIA[A-Z0-9]{12,}|eyJ[a-z0-9_-]{8,}\.[a-z0-9_-]{8,}\.[a-z0-9_-]{8,})\b/gi,
+      '[redacted]',
+    )
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value
+  const marker = '\n…'
+  return `${value.slice(0, maxChars - marker.length)}${marker}`
+}
+
+/** Short, sanitized, single-line message shown in the fallback heading area. */
+export function errorBoundaryMessage(err: unknown): string {
+  const raw = isError(err) ? safeProperty(err, 'message') : safeString(err)
+  const singleLine = redactErrorBoundaryText(raw).replace(/[\r\n]+/g, ' ').trim()
+  return truncate(singleLine, MAX_MESSAGE_CHARS).replace(/\n/g, '')
+}
+
+/**
+ * Sanitized copyable detail block. When a native stack already starts with the
+ * standard error heading, do not add that heading a second time.
+ */
+export function errorBoundaryDetails(err: unknown): string {
+  let raw = ''
+  if (isError(err)) {
+    const name = safeProperty(err, 'name').trim() || 'Error'
+    const message = safeProperty(err, 'message').trim()
+    const heading = message ? `${name}: ${message}` : name
+    const stack = safeProperty(err, 'stack').trim()
+    const stackIncludesHeading = stack === heading || stack.startsWith(`${heading}\n`)
+    raw = stack ? (stackIncludesHeading ? stack : `${heading}\n\n${stack}`) : heading
+  } else {
+    raw = safeString(err)
+  }
+
+  const sanitized = redactErrorBoundaryText(raw).trim()
+  return truncate(sanitized, MAX_DETAILS_CHARS)
+}

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -549,7 +549,14 @@
     "title": "Etwas ist schiefgelaufen",
     "defaultMessage": "Ein unerwarteter Fehler ist aufgetreten.",
     "reload": "Seite neu laden",
-    "dismiss": "Schließen"
+    "dismiss": "Schließen",
+    "detailsLabel": "Fehlerdetails",
+    "copyDetails": "Details kopieren",
+    "copied": "Kopiert",
+    "openLogs": "Protokollordner öffnen",
+    "privacyHint": "Prüfen Sie den Inhalt vor dem Teilen. Fehlerdetails können Pfade, URLs oder Kontoinformationen enthalten.",
+    "copyFailed": "Kopieren fehlgeschlagen. Wählen Sie die Details aus und kopieren Sie sie manuell.",
+    "openLogsFailed": "Der Protokollordner konnte nicht geöffnet werden."
   },
   "errors": {
     "saveFailed": "Speichern fehlgeschlagen",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -600,7 +600,14 @@
     "title": "Something went wrong",
     "defaultMessage": "An unexpected error occurred.",
     "reload": "Reload page",
-    "dismiss": "Dismiss"
+    "dismiss": "Dismiss",
+    "detailsLabel": "Error details",
+    "copyDetails": "Copy details",
+    "copied": "Copied",
+    "openLogs": "Open logs folder",
+    "privacyHint": "Review before sharing. Error details may contain paths, URLs, or account information.",
+    "copyFailed": "Copy failed. Select the details and copy them manually.",
+    "openLogsFailed": "Could not open the logs folder."
   },
   "errors": {
     "saveFailed": "Save failed",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -549,7 +549,14 @@
     "title": "Algo salió mal",
     "defaultMessage": "Se produjo un error inesperado.",
     "reload": "Recargar página",
-    "dismiss": "Descartar"
+    "dismiss": "Descartar",
+    "detailsLabel": "Detalles del error",
+    "copyDetails": "Copiar detalles",
+    "copied": "Copiado",
+    "openLogs": "Abrir carpeta de registros",
+    "privacyHint": "Revise el contenido antes de compartirlo. Los detalles pueden contener rutas, URL o información de la cuenta.",
+    "copyFailed": "No se pudo copiar. Seleccione los detalles y cópielos manualmente.",
+    "openLogsFailed": "No se pudo abrir la carpeta de registros."
   },
   "errors": {
     "saveFailed": "Error al guardar",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -549,7 +549,14 @@
     "title": "Une erreur s'est produite",
     "defaultMessage": "Une erreur inattendue s'est produite.",
     "reload": "Recharger la page",
-    "dismiss": "Ignorer"
+    "dismiss": "Ignorer",
+    "detailsLabel": "Détails de l'erreur",
+    "copyDetails": "Copier les détails",
+    "copied": "Copié",
+    "openLogs": "Ouvrir le dossier des journaux",
+    "privacyHint": "Vérifiez le contenu avant de le partager. Les détails peuvent contenir des chemins, des URL ou des informations de compte.",
+    "copyFailed": "La copie a échoué. Sélectionnez les détails et copiez-les manuellement.",
+    "openLogsFailed": "Impossible d’ouvrir le dossier des journaux."
   },
   "errors": {
     "saveFailed": "Échec de l'enregistrement",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -549,7 +549,14 @@
     "title": "問題が発生しました",
     "defaultMessage": "予期しないエラーが発生しました。",
     "reload": "ページを再読み込み",
-    "dismiss": "閉じる"
+    "dismiss": "閉じる",
+    "detailsLabel": "エラーの詳細",
+    "copyDetails": "詳細をコピー",
+    "copied": "コピーしました",
+    "openLogs": "ログフォルダーを開く",
+    "privacyHint": "共有する前に内容を確認してください。エラーの詳細にはパス、URL、アカウント情報が含まれる場合があります。",
+    "copyFailed": "コピーできませんでした。詳細を選択して手動でコピーしてください。",
+    "openLogsFailed": "ログフォルダーを開けませんでした。"
   },
   "errors": {
     "saveFailed": "保存に失敗しました",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -600,7 +600,14 @@
     "title": "出错了",
     "defaultMessage": "发生意外错误。",
     "reload": "重新加载页面",
-    "dismiss": "关闭"
+    "dismiss": "关闭",
+    "detailsLabel": "错误详情",
+    "copyDetails": "复制详情",
+    "copied": "已复制",
+    "openLogs": "打开日志文件夹",
+    "privacyHint": "分享前请先检查。错误详情可能包含文件路径、网址或账户信息。",
+    "copyFailed": "复制失败。请展开详情后手动复制。",
+    "openLogsFailed": "无法打开日志文件夹。"
   },
   "errors": {
     "saveFailed": "保存失败",


### PR DESCRIPTION
Relates to #991.

### Problem

When a routed view throws during render or lifecycle work, the existing ErrorBoundary replaces the view with a fallback, but users can only reload or dismiss it. On desktop—especially where DevTools is unavailable—that leaves no practical way to inspect or share the captured failure.

### Scope

- Add a collapsible, copyable error-detail block to the existing routed-view ErrorBoundary.
- Offer **Open logs folder** only when the desktop host exposes `platform.gateway.revealLog`; keep it hidden on web.
- Report clipboard and log-folder failures inline instead of failing silently.
- Add the new UI copy to all six supported locales.

### Safety and privacy

- Treat caught values as untrusted so hostile proxies, getters, serialization, or string conversion cannot crash the fallback.
- Remove duplicate stack headings and cap message/detail sizes.
- Redact common credentials, URL credentials, bearer tokens, and macOS/Linux/Windows home-directory usernames before details reach the UI, clipboard, or renderer console.
- Warn users to review details before sharing. Browser-side redaction is defense in depth, not a complete secret scanner.

### Explicit non-goals

This boundary still wraps `<router-view>`, not the whole application shell. The change does not introduce global `window` or Vue error handlers, does not turn async failures outside the boundary into the fallback, and does not change any stuck-state machine. It improves recovery and diagnostics for errors the existing boundary actually captures.

### Tests

- `npm run test:unit` — 280 files / 3002 tests passed locally.
- `npm run build` — architecture guards, `vue-tsc`, six-locale parity, production build, and artifact verification passed.
- CI exercises the frontend build/tests, WebUI chat recovery, and desktop recovery on Linux, macOS, and Windows.

### Compatibility

No persisted configuration, RPC fields, schemas, or public protocols change. Web keeps the desktop-only log action hidden; desktop reuses the optional existing bridge capability. Path-redaction coverage includes macOS, Linux, and Windows.

### Release note

User-facing WebUI recovery and diagnostic improvement.

### Third-party origin

No third-party code or wording was copied. The implementation is repository-native, and the original contributor attribution is preserved.