### PR TITLE
Make skill_exec Unicode-safe on Windows

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -678,6 +678,7 @@
       "tests/test_skills/test_nano_banana_openrouter_image.py",
       "tests/test_skills/test_retrieval_fingerprint.py",
       "tests/test_skills/test_skill_exec_python_resolution.py",
+      "tests/test_skills/test_skill_exec_subprocess_encoding.py",
       "tests/test_skills/test_sop_compiler.py",
       "tests/test_skills_hot_reload.py",
       "tests/test_skills_memory_contract.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -994,6 +994,7 @@
     "tests/test_skills/test_skill_disable_toggle.py": 0.031,
     "tests/test_skills/test_skill_exec_non_blocking.py": 3.06,
     "tests/test_skills/test_skill_exec_python_resolution.py": 0.222,
+    "tests/test_skills/test_skill_exec_subprocess_encoding.py": 0.01,
     "tests/test_skills/test_sop_compiler.py": 0.581,
     "tests/test_skills/test_swebench_skill.py": 1.845,
     "tests/test_skills/test_weather_skill_entrypoint.py": 0.01,

--- a/src/opensquilla/skills/meta/executors/skill_exec.py
+++ b/src/opensquilla/skills/meta/executors/skill_exec.py
@@ -26,6 +26,7 @@ import structlog
 
 from opensquilla.skills.meta.templating import _JINJA_ENV, render_with_args
 from opensquilla.skills.meta.types import MetaStep
+from opensquilla.subprocess_encoding import apply_utf8_child_env, decode_subprocess_output
 
 log = structlog.get_logger(__name__)
 
@@ -268,6 +269,7 @@ async def run_skill_exec_step(
             rendered_value = _render(value.replace("{baseDir}", base_dir))
             if rendered_value:
                 child_env[rendered_key] = rendered_value
+    apply_utf8_child_env(child_env)
 
     # Optional stdin: render Jinja template and pipe to the subprocess.
     stdin_raw = entrypoint.get("stdin")
@@ -343,8 +345,8 @@ async def run_skill_exec_step(
     returncode = completed.returncode
     stdout_bytes = completed.stdout
     stderr_bytes = completed.stderr
-    stdout_text = (stdout_bytes or b"").decode("utf-8", errors="replace")
-    stderr_text = (stderr_bytes or b"").decode("utf-8", errors="replace")
+    stdout_text = decode_subprocess_output(stdout_bytes)
+    stderr_text = decode_subprocess_output(stderr_bytes)
     if returncode != 0:
         raise RuntimeError(
             f"skill {effective_skill!r} exited {returncode}: "

--- a/tests/test_skills/test_skill_exec_subprocess_encoding.py
+++ b/tests/test_skills/test_skill_exec_subprocess_encoding.py
@@ -1,0 +1,208 @@
+"""Encoding contracts for ``skill_exec`` subprocess boundaries."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from opensquilla import subprocess_encoding
+from opensquilla.skills.meta.executors import skill_exec
+from opensquilla.skills.meta.types import MetaStep
+from opensquilla.skills.types import SkillLayer, SkillSpec
+
+
+class _Loader:
+    def __init__(self, spec: SkillSpec) -> None:
+        self._spec = spec
+
+    def get_by_name(self, name: str) -> SkillSpec | None:
+        return self._spec if name == self._spec.name else None
+
+
+def _spec(
+    base_dir: Path,
+    *,
+    parse: str = "text",
+    stdin: str | None = None,
+    env: dict[str, str] | None = None,
+    script: Path | None = None,
+) -> SkillSpec:
+    entrypoint: dict[str, object] = {
+        "command": "python",
+        "args": [str(script or (base_dir / "unused.py"))],
+        "parse": parse,
+        "timeout": 10.0,
+    }
+    if stdin is not None:
+        entrypoint["stdin"] = stdin
+    if env is not None:
+        entrypoint["env"] = env
+    return SkillSpec(
+        name="encoding-skill",
+        description="synthetic encoding probe",
+        layer=SkillLayer.BUNDLED,
+        always=False,
+        triggers=[],
+        content="",
+        base_dir=str(base_dir),
+        entrypoint=entrypoint,
+    )
+
+
+async def _run(spec: SkillSpec, base_dir: Path) -> str:
+    return await skill_exec.run_skill_exec_step(
+        MetaStep(id="encoding", kind="skill_exec", skill=spec.name),
+        effective_skill=spec.name,
+        inputs={},
+        outputs={},
+        skill_loader=_Loader(spec),
+        workspace_dir=str(base_dir),
+    )
+
+
+@pytest.mark.asyncio
+async def test_skill_exec_forces_utf8_for_windows_python_child(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A GBK-default child must emit lossless Unicode JSON through stdout."""
+
+    script = tmp_path / "unicode_json.py"
+    script.write_text(
+        "import json, os, sys\n"
+        "if 'PYTHONIOENCODING' not in os.environ:\n"
+        "    sys.stdout.reconfigure(encoding='gbk', errors='strict')\n"
+        "payload = json.loads(sys.stdin.buffer.read().decode('utf-8'))\n"
+        "sys.stdout.write(json.dumps(payload, ensure_ascii=False))\n",
+        encoding="utf-8",
+    )
+    payload = {
+        "author": "Badura, ś",
+        "title": "大型语言模型与 café – verified",
+    }
+    spec = _spec(
+        tmp_path,
+        parse="json",
+        stdin=json.dumps(payload, ensure_ascii=False),
+        script=script,
+    )
+
+    monkeypatch.delenv("PYTHONIOENCODING", raising=False)
+    monkeypatch.delenv("PYTHONUTF8", raising=False)
+    # Patch only the helper module's platform view. Mutating the shared
+    # ``os.name`` object would make pathlib try to construct WindowsPath on POSIX.
+    monkeypatch.setattr(subprocess_encoding, "os", SimpleNamespace(name="nt"))
+
+    output = await _run(spec, tmp_path)
+
+    assert json.loads(output) == payload
+
+
+@pytest.mark.asyncio
+async def test_skill_exec_forces_utf8_for_windows_python_stdin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """UTF-8 manifest stdin must not be decoded through a child's GBK default."""
+
+    script = tmp_path / "unicode_stdin.py"
+    script.write_text(
+        "import os, sys\n"
+        "if 'PYTHONIOENCODING' not in os.environ:\n"
+        "    sys.stdin.reconfigure(encoding='gbk', errors='strict')\n"
+        "text = sys.stdin.read()\n"
+        "sys.stdout.buffer.write(text.encode('utf-8'))\n",
+        encoding="utf-8",
+    )
+    expected = "大型语言模型对大学生批判性思维的影响"
+    spec = _spec(tmp_path, stdin=expected, script=script)
+
+    monkeypatch.delenv("PYTHONIOENCODING", raising=False)
+    monkeypatch.delenv("PYTHONUTF8", raising=False)
+    monkeypatch.setattr(subprocess_encoding, "os", SimpleNamespace(name="nt"))
+
+    output = await _run(spec, tmp_path)
+
+    assert output == expected
+
+
+@pytest.mark.asyncio
+async def test_skill_exec_decodes_legacy_gbk_stdout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {"query": "中文检索", "title": "大学生批判性思维"}
+    stdout = json.dumps(payload, ensure_ascii=False).encode("gbk")
+    decoded: list[bytes | None] = []
+
+    def decode_gbk(raw: bytes | None) -> str:
+        decoded.append(raw)
+        return subprocess_encoding.decode_subprocess_output(raw, fallback_encoding="gbk")
+
+    def fake_run(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr=b"")
+
+    monkeypatch.setattr(skill_exec, "decode_subprocess_output", decode_gbk)
+    monkeypatch.setattr(skill_exec.subprocess, "run", fake_run)
+
+    output = await _run(_spec(tmp_path, parse="json"), tmp_path)
+
+    assert json.loads(output) == payload
+    assert decoded == [stdout, b""]
+
+
+@pytest.mark.asyncio
+async def test_skill_exec_decodes_legacy_gbk_stderr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stderr = "检索失败：上游不可用".encode("gbk")
+
+    def decode_gbk(raw: bytes | None) -> str:
+        return subprocess_encoding.decode_subprocess_output(raw, fallback_encoding="gbk")
+
+    def fake_run(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(returncode=7, stdout=b"", stderr=stderr)
+
+    monkeypatch.setattr(skill_exec, "decode_subprocess_output", decode_gbk)
+    monkeypatch.setattr(skill_exec.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="检索失败：上游不可用"):
+        await _run(_spec(tmp_path), tmp_path)
+
+
+@pytest.mark.parametrize("source", ["ambient", "entrypoint"])
+@pytest.mark.asyncio
+async def test_skill_exec_preserves_explicit_python_encoding_env(
+    source: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    explicit = {"PYTHONIOENCODING": "gbk", "PYTHONUTF8": "0"}
+    captured: dict[str, str] = {}
+
+    monkeypatch.delenv("PYTHONIOENCODING", raising=False)
+    monkeypatch.delenv("PYTHONUTF8", raising=False)
+    if source == "ambient":
+        for key, value in explicit.items():
+            monkeypatch.setenv(key, value)
+        entrypoint_env = None
+    else:
+        entrypoint_env = explicit
+    monkeypatch.setattr(subprocess_encoding, "os", SimpleNamespace(name="nt"))
+
+    def fake_run(*_args: object, **kwargs: object) -> SimpleNamespace:
+        child_env = kwargs["env"]
+        assert isinstance(child_env, dict)
+        captured.update(child_env)
+        return SimpleNamespace(returncode=0, stdout=b"ok\n", stderr=b"")
+
+    monkeypatch.setattr(skill_exec.subprocess, "run", fake_run)
+
+    output = await _run(_spec(tmp_path, env=entrypoint_env), tmp_path)
+
+    assert output == "ok"
+    assert {key: captured[key] for key in explicit} == explicit


### PR DESCRIPTION
## Scope

- Apply the shared UTF-8 Python child environment to every skill_exec subprocess after manifest environment overrides are merged.
- Decode captured stdout and stderr through the shared Windows code-page-aware decoder.
- Add offline deterministic coverage for GBK Unicode output, UTF-8 stdin, legacy stdout/stderr decoding, and explicit encoding overrides.

Base branch: main

Non-goals: No skill-specific output workaround, encoding schema, UI change, or broader MetaSkill refactor.

## Issue

Fixes #935

## Release Note

Fixed skill_exec failures and garbled output on Windows systems using GBK/CP936 when skills read or emit non-ASCII text.

## Tests

- uv run pytest -q tests/test_skills/test_skill_exec_subprocess_encoding.py tests/test_subprocess_encoding.py tests/test_skill_multi_search_engine.py tests/test_skills/test_multi_search_engine_concurrency.py tests/test_skills/test_meta_paper_write_e2e.py tests/test_skill_docx.py tests/test_skills/test_skill_exec_python_resolution.py tests/test_skills/test_skill_exec_non_blocking.py tests/test_skills/test_meta_executor_gate.py tests/test_skills/test_meta_dsl_extensions.py tests/test_skills/test_meta_mvp.py
  - 182 passed
- uv run ruff check src/opensquilla/skills/meta/executors/skill_exec.py tests/test_skills/test_skill_exec_subprocess_encoding.py
  - All checks passed
- uv run ruff format --check tests/test_skills/test_skill_exec_subprocess_encoding.py
  - Already formatted
- uv run mypy src/opensquilla/skills/meta/executors/skill_exec.py --show-error-codes
  - Success, no issues found

Regression tests: added. They are offline, deterministic, credential-free, and do not depend on the CI hosts active Windows code page.

## Safety and Compatibility

- Existing subprocess argv, timeout, cwd containment, operator gating, and no-shell execution behavior are unchanged.
- Explicit parent or manifest PYTHONIOENCODING and PYTHONUTF8 values remain authoritative because the shared helper uses setdefault.
- POSIX behavior remains unchanged: the environment helper is a no-op and decoding keeps the previous UTF-8 replacement behavior.
- No database, persisted state, public config, RPC, CLI, or client contract changes; no migration is required.
- No secrets, runtime transcripts, user data, or machine-specific paths are included.

## Third-Party Origin

Third-party origin: none.

## Documentation

No documentation changes are required; this restores the existing shared subprocess encoding contract.