### PR TITLE
feat(webui): add ThinkingOrb Vue component with 9 agent state animations

### DIFF
--- a/opensquilla-webui/e2e/assistant-activity.spec.ts
+++ b/opensquilla-webui/e2e/assistant-activity.spec.ts
@@ -739,17 +739,21 @@ test.describe('Live assistant activity lifecycle', () => {
     await expect(liveActivity.locator('[role="status"]')).toHaveCount(1)
     await expect(liveActivity.locator('.assistant-activity__live-failure')).toHaveCount(0)
     await expect(liveActivity.locator('.assistant-activity-status__row')).toHaveCount(0)
-    const liveMotion = await liveActivity.evaluate((element) => ({
-      dot: getComputedStyle(
-        element.querySelector<HTMLElement>('.assistant-activity__live-dot')!,
-      ).animationName,
-      label: getComputedStyle(
-        element.querySelector<HTMLElement>('.assistant-activity__live-label')!,
-      ).animationName,
-    }))
-    // The pulsing dot is the single working signal; the label is deliberately
-    // static (the shimmer gradient was removed as visual noise).
-    expect(liveMotion.dot).not.toBe('none')
+    const liveMotion = await liveActivity.evaluate((element) => {
+      const dot = element.querySelector<HTMLElement>('.assistant-activity__live-dot')
+      return {
+        orb: Boolean(element.querySelector('.assistant-activity__live-orb')),
+        dot: dot ? getComputedStyle(dot).animationName : 'absent',
+        label: getComputedStyle(
+          element.querySelector<HTMLElement>('.assistant-activity__live-label')!,
+        ).animationName,
+      }
+    })
+    // The live header carries exactly one working signal: the animated orb
+    // canvas, or — when the orb is degraded/unsupported — the pulsing CSS
+    // dot. The label stays deliberately static (the shimmer gradient was
+    // removed as visual noise).
+    expect(liveMotion.orb || liveMotion.dot !== 'none').toBe(true)
     expect(liveMotion.label).toBe('none')
 
     lifecycle.emit('session.event.tool_use_start', {
@@ -872,15 +876,23 @@ test.describe('Live assistant activity lifecycle', () => {
 
     const liveActivity = page.locator('.assistant-activity--live')
     await expect(liveActivity).toBeVisible()
-    const liveMotion = await liveActivity.evaluate((element) => ({
-      dot: getComputedStyle(
-        element.querySelector<HTMLElement>('.assistant-activity__live-dot')!,
-      ).animationName,
-      label: getComputedStyle(
-        element.querySelector<HTMLElement>('.assistant-activity__live-label')!,
-      ).animationName,
-    }))
-    expect(liveMotion).toEqual({ dot: 'none', label: 'none' })
+    const liveMotion = await liveActivity.evaluate((element) => {
+      const dot = element.querySelector<HTMLElement>('.assistant-activity__live-dot')
+      const orb = element.querySelector<HTMLElement>('.assistant-activity__live-orb')
+      return {
+        orbAnimation: orb ? getComputedStyle(orb).animationName : 'absent',
+        dot: dot ? getComputedStyle(dot).animationName : 'absent',
+        label: getComputedStyle(
+          element.querySelector<HTMLElement>('.assistant-activity__live-label')!,
+        ).animationName,
+      }
+    })
+    // Reduced motion must silence every CSS animation on the live header:
+    // the orb either mounts as a static single frame (no CSS animation) or
+    // degrades to the dot, which must also stay still under reduce.
+    expect(['absent', 'none']).toContain(liveMotion.orbAnimation)
+    expect(['absent', 'none']).toContain(liveMotion.dot)
+    expect(liveMotion.label).toBe('none')
   })
 })
 

--- a/opensquilla-webui/src/components/chat/ActivityDisclosure.test.ts
+++ b/opensquilla-webui/src/components/chat/ActivityDisclosure.test.ts
@@ -527,6 +527,40 @@ describe('ActivityDisclosure failure visibility', () => {
   })
 })
 
+describe('ActivityDisclosure ThinkingOrb integration', () => {
+  // In this DOM environment HTMLCanvasElement.getContext('2d') is unavailable,
+  // which is exactly the degraded path: the real ThinkingOrb must report an
+  // error and the header must fall back to the pulsing CSS dot.
+  it('falls back to the pulsing dot when the canvas context is unavailable', async () => {
+    const host = mountDisclosure({
+      lifecycle: 'working',
+      stepCount: 0,
+      failureCount: 0,
+    })
+    await nextTick()
+    await nextTick()
+
+    expect(host.querySelector('.assistant-activity__live-orb')).toBeNull()
+    const dot = host.querySelector('.assistant-activity__live-dot')
+    expect(dot).not.toBeNull()
+    expect(dot?.classList.contains('is-active')).toBe(true)
+    expect(dot?.classList.contains('is-stale')).toBe(false)
+  })
+
+  it('keeps the plain CSS dot for stale headers without touching the orb', async () => {
+    const host = mountDisclosure({
+      lifecycle: 'working',
+      stepCount: 0,
+      failureCount: 0,
+      stale: true,
+    })
+    await nextTick()
+    expect(host.querySelector('.assistant-activity__live-orb')).toBeNull()
+    const dot = host.querySelector('.assistant-activity__live-dot')
+    expect(dot?.classList.contains('is-stale')).toBe(true)
+  })
+})
+
 describe('ActivityDisclosure aria wiring', () => {
   it('links the summary button to the fold body via aria-controls', async () => {
     const host = mountDisclosure({

--- a/opensquilla-webui/src/components/chat/ActivityDisclosure.vue
+++ b/opensquilla-webui/src/components/chat/ActivityDisclosure.vue
@@ -21,7 +21,17 @@
       :aria-controls="bodyId"
       @click.stop="toggleOpen"
     >
+      <ThinkingOrb
+        v-if="showLiveOrb"
+        :state="orbState"
+        :size="28"
+        theme="auto"
+        class="assistant-activity__live-orb"
+        aria-hidden="true"
+        @error="orbFailed = true"
+      />
       <span
+        v-else
         class="assistant-activity__live-dot"
         :class="{ 'is-active': !stale, 'is-stale': stale }"
         aria-hidden="true"
@@ -91,6 +101,8 @@
 import { computed, ref, useId, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/Icon.vue'
+import ThinkingOrb from '@/components/thinking-orb/ThinkingOrb.vue'
+import { resolveOrbState } from '@/components/thinking-orb/purposeToOrbState'
 import {
   readAssistantActivityExpansion,
   writeAssistantActivityExpansion,
@@ -106,6 +118,8 @@ const props = withDefaults(defineProps<{
   detailLabel?: string
   phaseLabel?: string
   elapsedLabel?: string
+  /** 当前活动集群的 purpose code（`chat.activity.purpose.*` 或 `*Running.*`），用于细化 orb 动画状态 */
+  purposeCode?: string | null
   stale?: boolean
   defaultOpen?: boolean
   stateKey?: string
@@ -166,6 +180,12 @@ watch(
 const isLive = computed(() =>
   props.lifecycle === 'working' || props.lifecycle === 'answering',
 )
+
+// ThinkingOrb 只在活动栏的 live 且非 stale 状态出现；stale 或渲染失败时
+// 回退到原 CSS 脉冲点，保持与旧版完全一致的降级视觉。
+const orbFailed = ref(false)
+const showLiveOrb = computed(() => isLive.value && !props.stale && !orbFailed.value)
+const orbState = computed(() => resolveOrbState(props.lifecycle, props.purposeCode))
 
 const liveStatusLabel = computed(() => props.phaseLabel || t('chat.activityWorking'))
 
@@ -247,6 +267,11 @@ const resolvedSummaryLabel = computed(() => {
 
 .assistant-activity__live-dot.is-stale {
   background: var(--warn-fill);
+}
+
+.assistant-activity__live-orb {
+  flex: 0 0 auto;
+  vertical-align: middle;
 }
 
 .assistant-activity__live-label {

--- a/opensquilla-webui/src/components/thinking-orb/ThinkingOrb.vue
+++ b/opensquilla-webui/src/components/thinking-orb/ThinkingOrb.vue
@@ -1,0 +1,101 @@
+<template>
+  <canvas
+    v-if="!failed"
+    ref="canvasRef"
+    :style="canvasStyle"
+    role="img"
+    :aria-label="ariaLabel"
+  />
+</template>
+
+<script setup lang="ts">
+/**
+ * ThinkingOrb.vue — 点阵思维球体动画组件
+ *
+ * 专为 AI Agent UI 设计的 9 种状态动画指示器。
+ * 纯 Canvas 2D 渲染，无 WebGL，无需外部依赖。
+ *
+ * 独创性（与原版 thinking-orbs 的区别）：
+ * 1. Vue 3 组合式 API：用 composable 替代 React hooks
+ * 2. 类 + 插件注册系统：而非函数式 ModeDraw
+ * 3. 多层渲染管线：背景/主层/高亮层独立合成
+ * 4. 全局共享时钟：所有实例同步，自适应帧率
+ * 5. 可扩展形状注册：MorphMode 支持自定义形状
+ * 6. 任意尺寸：不限于 64/20，支持响应式
+ */
+
+import { ref, computed, watch } from 'vue'
+import { useOrbTheme, useReducedMotion, type OrbTheme } from './composables/useOrbTheme'
+import { useOrbAnimation } from './composables/useOrbAnimation'
+import { STATE_LABELS, type OrbState } from './presets'
+
+const props = withDefaults(defineProps<{
+  /** 动画状态 */
+  state?: OrbState
+  /** 尺寸（CSS px），默认 64，支持任意值 */
+  size?: number
+  /** 主题模式 */
+  theme?: OrbTheme
+  /** 速度倍率 */
+  speed?: number
+  /** 暂停动画 */
+  paused?: boolean
+  /** 自定义 aria-label */
+  'aria-label'?: string
+}>(), {
+  state: 'working',
+  size: 64,
+  theme: 'auto',
+  speed: 1,
+  paused: false,
+})
+
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+const stateRef = ref(props.state)
+const sizeRef = ref(props.size)
+const speedRef = ref(props.speed)
+const pausedRef = ref(props.paused)
+const themeRef = ref(props.theme)
+
+const isDark = useOrbTheme(themeRef, canvasRef)
+const reduced = useReducedMotion()
+
+const emit = defineEmits<{ (e: 'error'): void }>()
+const failed = ref(false)
+
+const controls = useOrbAnimation(
+  canvasRef,
+  stateRef,
+  sizeRef,
+  isDark,
+  speedRef,
+  pausedRef,
+  reduced,
+)
+
+// Canvas 上下文不可用 / 模式渲染异常：卸载 canvas 并通知宿主降级。
+// 宿主（如 ActivityDisclosure）监听 error 事件回退到 CSS 指示器。
+watch(controls.renderError, (isError) => {
+  if (isError && !failed.value) {
+    failed.value = true
+    emit('error')
+  }
+})
+
+// 监听 props 变化
+watch(() => props.state, (v) => { stateRef.value = v })
+watch(() => props.size, (v) => { sizeRef.value = v })
+watch(() => props.speed, (v) => { speedRef.value = v })
+watch(() => props.paused, (v) => { pausedRef.value = v })
+watch(() => props.theme, (v) => { themeRef.value = v })
+
+const canvasStyle = computed(() => ({
+  width: `${props.size}px`,
+  height: `${props.size}px`,
+  display: 'block',
+}))
+
+const ariaLabel = computed(() => {
+  return props['aria-label'] ?? STATE_LABELS[props.state] ?? '工作中…'
+})
+</script>

--- a/opensquilla-webui/src/components/thinking-orb/composables/useOrbAnimation.test.ts
+++ b/opensquilla-webui/src/components/thinking-orb/composables/useOrbAnimation.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment happy-dom
+import { createApp, nextTick, ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useOrbAnimation } from './useOrbAnimation'
+import { modeRegistry } from '../registry'
+import { resetClock } from '../engine/clock'
+import { registerBuiltinModes, type OrbState } from '../presets'
+
+const mountedApps: ReturnType<typeof createApp>[] = []
+
+let tickCb: FrameRequestCallback | null = null
+
+function fakeCtx() {
+  return {
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    strokeStyle: '',
+    fillStyle: '',
+    lineWidth: 1,
+    globalAlpha: 1,
+  }
+}
+
+function makeCanvas(getContext: () => CanvasRenderingContext2D | null) {
+  const canvas = document.createElement('canvas')
+  canvas.getContext = getContext as unknown as HTMLCanvasElement['getContext']
+  Object.defineProperty(canvas, 'width', { value: 0, writable: true })
+  Object.defineProperty(canvas, 'height', { value: 0, writable: true })
+  return canvas
+}
+
+/** Mount a throwaway host so onMounted/onUnmounted lifecycle hooks run. */
+function setupOrb(canvas: HTMLCanvasElement, reduced = false) {
+  const canvasRef = ref<HTMLCanvasElement | null>(canvas)
+  const state = ref<OrbState>('working')
+  const size = ref(28)
+  const dark = ref(true)
+  const speed = ref(1)
+  const paused = ref(false)
+  const reducedRef = ref(reduced)
+
+  let controls: ReturnType<typeof useOrbAnimation> | null = null
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const app = createApp({
+    setup() {
+      controls = useOrbAnimation(canvasRef, state, size, dark, speed, paused, reducedRef)
+      return () => null
+    },
+  })
+  mountedApps.push(app)
+  app.mount(host)
+  return { controls: controls!, reducedRef, state, paused }
+}
+
+/** Manually advance the fake rAF clock by one tick. */
+function pump(now: number) {
+  const cb = tickCb
+  tickCb = null
+  cb?.(now)
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  tickCb = null
+  vi.stubGlobal('requestAnimationFrame', vi.fn((cb: FrameRequestCallback) => {
+    tickCb = cb
+    return 1
+  }))
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  vi.stubGlobal('IntersectionObserver', undefined)
+})
+
+afterEach(() => {
+  while (mountedApps.length) mountedApps.pop()?.unmount()
+  document.body.innerHTML = ''
+  resetClock() // engine/clock is a module-level singleton; hard-isolate tests
+  vi.unstubAllGlobals()
+  // Undo any test-local registry surgery (patched instances live in _modes).
+  modeRegistry.unregister('web')
+  registerBuiltinModes()
+})
+
+describe('useOrbAnimation degraded modes', () => {
+  it('reports renderError when the 2D context is unavailable', async () => {
+    const canvas = makeCanvas(() => null)
+    const { controls } = setupOrb(canvas)
+    await nextTick()
+    expect(controls!.renderError.value).toBe(true)
+    expect(controls!.isRunning.value).toBe(false)
+  })
+
+  it('joins the shared clock in motion mode and leaves it on unmount', async () => {
+    const ctx = fakeCtx()
+    const canvas = makeCanvas(() => ctx as unknown as CanvasRenderingContext2D)
+    const { controls } = setupOrb(canvas)
+    await nextTick()
+    expect(controls!.isRunning.value).toBe(true)
+    expect(requestAnimationFrame).toHaveBeenCalled()
+    expect(ctx.clearRect).toHaveBeenCalled()
+
+    mountedApps.pop()?.unmount()
+    expect(controls!.isRunning.value).toBe(false)
+  })
+
+  it('reduced motion paints exactly one static frame and never joins the clock', async () => {
+    const ctx = fakeCtx()
+    const canvas = makeCanvas(() => ctx as unknown as CanvasRenderingContext2D)
+    const { controls } = setupOrb(canvas, true)
+    await nextTick()
+    expect(controls!.isRunning.value).toBe(false)
+    expect(controls!.renderError.value).toBe(false)
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+    // exactly one frame drawn…
+    expect(ctx.clearRect).toHaveBeenCalledTimes(1)
+  })
+
+  it('static frame repaints when the orb state changes under reduced motion', async () => {
+    const ctx = fakeCtx()
+    const canvas = makeCanvas(() => ctx as unknown as CanvasRenderingContext2D)
+    const { controls, state } = setupOrb(canvas, true)
+    await nextTick()
+    const before = ctx.clearRect.mock.calls.length
+    state.value = 'searching'
+    await nextTick()
+    expect(ctx.clearRect.mock.calls.length).toBeGreaterThan(before)
+    expect(controls!.isRunning.value).toBe(false)
+  })
+
+  it('toggling reduced motion at runtime stops the loop', async () => {
+    const ctx = fakeCtx()
+    const canvas = makeCanvas(() => ctx as unknown as CanvasRenderingContext2D)
+    const { controls, reducedRef } = setupOrb(canvas, false)
+    await nextTick()
+    expect(controls!.isRunning.value).toBe(true)
+    reducedRef.value = true
+    await nextTick()
+    expect(controls!.isRunning.value).toBe(false)
+    expect(cancelAnimationFrame).toHaveBeenCalled()
+  })
+
+  it('three consecutive mode failures escalate to renderError instead of an endless blank canvas', async () => {
+    const ctx = fakeCtx()
+    const canvas = makeCanvas(() => ctx as unknown as CanvasRenderingContext2D)
+    const { controls } = setupOrb(canvas)
+    await nextTick()
+    // Mount paints frame #1 with the healthy builtin mode. Now sabotage the
+    // cached instance (registry.get returns it on every following frame):
+    // setup-time registerBuiltinModes() would override any constructor we
+    // inject before mount, so patch the instance instead.
+    const cached = modeRegistry.get('working')
+    cached!.update = () => { throw new Error('mode exploded') }
+    // clock tick #1 → failure #1, #2 → failure #2 (still tolerating),
+    // #3 → escalate to renderError.
+    pump(1000)
+    expect(controls!.renderError.value).toBe(false)
+    pump(1200)
+    expect(controls!.renderError.value).toBe(false)
+    pump(1400)
+    expect(controls!.renderError.value).toBe(true)
+    expect(controls!.isRunning.value).toBe(false)
+  })
+
+  it('hides the canvas after a render error (host sees the v-if removal)', async () => {
+    // ThinkingOrb contract: renderError → emit('error') and unmount the
+    // canvas so the host falls back to its CSS indicator. Asserted at the
+    // composable level: the flag flips and stays flipped.
+    const canvas = makeCanvas(() => null)
+    const { controls } = setupOrb(canvas)
+    await nextTick()
+    expect(controls!.renderError.value).toBe(true)
+    pump(1000)
+    expect(controls!.renderError.value).toBe(true)
+  })
+})

--- a/opensquilla-webui/src/components/thinking-orb/composables/useOrbAnimation.ts
+++ b/opensquilla-webui/src/components/thinking-orb/composables/useOrbAnimation.ts
@@ -1,0 +1,237 @@
+/**
+ * useOrbAnimation — 动画循环 composable
+ *
+ * 独创性设计：
+ * 1. 使用全局共享时钟（而非每个实例独立 rAF）
+ * 2. 支持 IntersectionObserver 离屏暂停
+ * 3. 支持 visibilitychange 标签页隐藏暂停
+ * 4. 支持自适应帧率（通过全局时钟）
+ * 5. 支持暂停/恢复控制
+ * 6. prefers-reduced-motion 下只渲染一帧静态画面（不接时钟、不闪缩）
+ * 7. Canvas 上下文 / 模式渲染异常时上报错误，由宿主降级为静态指示器
+ */
+
+import { ref, watch, onMounted, onUnmounted, type Ref } from 'vue'
+import { subscribeToClock } from '../engine/clock'
+import { renderLayers, emptyRenderResult } from '../engine/core'
+import type { RenderResult } from '../engine/core'
+import { resolvePreset, registerBuiltinModes, type OrbState } from '../presets'
+import { modeRegistry } from '../registry'
+
+export interface AnimationControls {
+  /** 是否正在运行 */
+  isRunning: Ref<boolean>
+  /** 当前帧率 */
+  currentFps: Ref<number>
+  /** Canvas 2D 上下文不可用或模式渲染抛出异常（宿主应降级为静态指示器） */
+  renderError: Ref<boolean>
+  /** 暂停/恢复 */
+  pause: () => void
+  resume: () => void
+}
+
+/** 静态帧的时间相位：取周期中段附近，保证各模式都呈现有代表性的形态 */
+const STATIC_PHASE = 1.5
+
+/**
+ * 驱动 Canvas 动画循环
+ */
+export function useOrbAnimation(
+  canvasRef: Ref<HTMLCanvasElement | null>,
+  state: Ref<OrbState>,
+  size: Ref<number>,
+  dark: Ref<boolean>,
+  speed: Ref<number>,
+  paused: Ref<boolean>,
+  reduced: Ref<boolean>,
+): AnimationControls {
+  const isRunning = ref(false)
+  const currentFps = ref(60)
+  const renderError = ref(false)
+
+  let unsubscribe: (() => void) | null = null
+  let io: IntersectionObserver | null = null
+  let visible = true
+  let lastSize = 0
+  let lastDpr = 1
+  let staticMode = false
+  let consecutiveModeErrors = 0
+
+  // 确保内置模式已注册
+  registerBuiltinModes()
+
+  /** 单帧绘制。返回 false 表示本帧渲染失败且已升级为不可恢复（内部已停循环）。 */
+  const paintFrame = (time: number): boolean => {
+    const canvas = canvasRef.value
+    if (!canvas) return true
+
+    const failHard = () => {
+      renderError.value = true
+      detachLoop()
+      isRunning.value = false
+      return false
+    }
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return failHard()
+
+    const dpr = Math.min(2, typeof devicePixelRatio !== 'undefined' ? devicePixelRatio : 1)
+    const currentSize = size.value
+
+    // 尺寸变化时重建 canvas buffer
+    if (currentSize !== lastSize || dpr !== lastDpr) {
+      canvas.width = Math.round(currentSize * dpr)
+      canvas.height = Math.round(currentSize * dpr)
+      lastSize = currentSize
+      lastDpr = dpr
+    }
+
+    const { speed: baseSpeed, density, opts } = resolvePreset(state.value, currentSize)
+    const effSpeed = baseSpeed * speed.value
+
+    const modeInstance = modeRegistry.get(state.value)
+
+    // 设置变换
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.clearRect(0, 0, currentSize, currentSize)
+
+    if (!modeInstance) {
+      // 注册表里找不到当前状态的绘制模式：无法产出任何视觉，上报降级
+      return failHard()
+    }
+
+    const frameCtx = {
+      time: time * effSpeed,
+      delta: 0.016,
+      size: currentSize,
+      dark: dark.value,
+      speed: effSpeed,
+      projector: createDummyProjector(),
+      opts: { ...opts, density },
+    }
+
+    let result: RenderResult
+    try {
+      result = modeInstance.update(frameCtx)
+    } catch {
+      consecutiveModeErrors += 1
+      result = emptyRenderResult()
+      if (consecutiveModeErrors >= 3) {
+        // 同一模式连续 3 帧抛异常：视为该模式不可用，交还给宿主做 CSS 降级，
+        // 而不是永久渲染一张空白画布。
+        return failHard()
+      }
+    }
+    if (result.main.particles.length || result.highlight.particles.length
+      || result.background.particles.length) {
+      consecutiveModeErrors = 0
+    }
+
+    renderLayers(ctx, result, dark.value)
+    return true
+  }
+
+  const _drawFrame = (time: number) => {
+    if (!canvasRef.value || !visible || paused.value || staticMode || renderError.value) return
+    paintFrame(time)
+  }
+
+  // reduced-motion 或 paused：不进 rAF 循环，只画一帧代表相位上的静态画面
+  const renderStaticFrame = () => {
+    staticMode = true
+    detachLoop()
+    paintFrame(STATIC_PHASE)
+    isRunning.value = false
+  }
+
+  function createDummyProjector() {
+    return (x: number, y: number, _z: number) => [x, y, 0] as [number, number, number]
+  }
+
+  const attachLoop = () => {
+    if (unsubscribe || !visible) return
+    unsubscribe = subscribeToClock(_drawFrame)
+    isRunning.value = true
+  }
+
+  const detachLoop = () => {
+    unsubscribe?.()
+    unsubscribe = null
+  }
+
+  onMounted(() => {
+    const canvas = canvasRef.value
+    if (!canvas) {
+      renderError.value = true
+      return
+    }
+
+    // 离屏检测 + 标签页可见性：隐藏时摘掉时钟订阅（全局共享时钟因此少一个
+    // 回调，多个 orb 全部离屏时时钟会自行休眠），恢复时立即重绘避免残帧。
+    const syncLoop = () => {
+      if (staticMode || renderError.value) return
+      if (visible && !documentHidden()) attachLoop()
+      else detachLoop()
+      isRunning.value = visible && !documentHidden()
+    }
+
+    if (typeof IntersectionObserver !== 'undefined') {
+      io = new IntersectionObserver(([entry]) => {
+        visible = entry.isIntersecting
+        syncLoop()
+        // 回到视口时立即补一帧，避免等待下一次时钟 tick 出现空白。
+        // 静态模式（reduced-motion）下不重绘，保持定格帧。
+        if (visible && !staticMode && !renderError.value) {
+          paintFrame(performance.now() / 1000)
+        }
+      })
+      io.observe(canvas)
+    }
+
+    const onVis = () => syncLoop()
+    document.addEventListener('visibilitychange', onVis)
+
+    if (reduced.value) {
+      renderStaticFrame()
+    } else {
+      attachLoop()
+      paintFrame(performance.now() / 1000)
+    }
+
+    // 运行中切换 prefers-reduced-motion（系统设置改变）：即时生效
+    watch(reduced, (isReduced) => {
+      if (isReduced) {
+        renderStaticFrame()
+      } else {
+        staticMode = false
+        consecutiveModeErrors = 0
+        syncLoop()
+        paintFrame(performance.now() / 1000)
+      }
+    })
+
+    // 静态模式下 state/size 变化需要重绘对应帧
+    watch([state, size, dark], () => {
+      if (staticMode) paintFrame(STATIC_PHASE)
+    })
+
+    onUnmounted(() => {
+      detachLoop()
+      io?.disconnect()
+      document.removeEventListener('visibilitychange', onVis)
+      isRunning.value = false
+    })
+  })
+
+  return {
+    isRunning,
+    currentFps,
+    renderError,
+    pause: () => { paused.value = true },
+    resume: () => { paused.value = false },
+  }
+}
+
+function documentHidden(): boolean {
+  return typeof document !== 'undefined' && document.visibilityState === 'hidden'
+}

--- a/opensquilla-webui/src/components/thinking-orb/composables/useOrbTheme.ts
+++ b/opensquilla-webui/src/components/thinking-orb/composables/useOrbTheme.ts
@@ -1,0 +1,107 @@
+/**
+ * useOrbTheme — 独创性主题检测 composable
+ *
+ * 原版 thinking-orbs 用 React hooks (useState + useEffect + MutationObserver)
+ * 本设计用 Vue 3 composable：
+ * - 使用 Vue 3 响应式系统（ref/computed）
+ * - 支持 data-theme / class / prefers-color-scheme 三层检测
+ * - 自动监听变化
+ * - 支持 SSR 安全
+ */
+
+import { ref, onMounted, onUnmounted, watch, type Ref } from 'vue'
+
+export type OrbTheme = 'auto' | 'dark' | 'light'
+
+function ancestorTheme(el: Element | null): boolean | null {
+  let node: Element | null = el
+  while (node) {
+    const attr = node.getAttribute('data-theme')
+    if (attr === 'dark') return true
+    if (attr === 'light') return false
+    if (node.classList.contains('dark')) return true
+    if (node.classList.contains('light')) return false
+    node = node.parentElement
+  }
+  return null
+}
+
+function systemDark(): boolean {
+  if (typeof matchMedia === 'undefined') return false
+  return matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+/**
+ * 解析暗色/亮色主题
+ * @param theme 主题模式
+ * @param hostRef 宿主元素的 ref
+ * @returns 是否为暗色主题
+ */
+export function useOrbTheme(theme: Ref<OrbTheme>, hostRef: Ref<HTMLElement | null>): Ref<boolean> {
+  const isDark = ref(true)
+
+  const resolve = () => {
+    if (theme.value === 'dark') {
+      isDark.value = true
+      return
+    }
+    if (theme.value === 'light') {
+      isDark.value = false
+      return
+    }
+    const fromTree = ancestorTheme(hostRef.value)
+    isDark.value = fromTree ?? systemDark()
+  }
+
+  // 监听主题变化
+  let mq: MediaQueryList | null = null
+  let mo: MutationObserver | null = null
+
+  onMounted(() => {
+    resolve()
+
+    // OS 主题切换
+    if (typeof matchMedia !== 'undefined') {
+      mq = matchMedia('(prefers-color-scheme: dark)')
+      mq.addEventListener('change', resolve)
+    }
+
+    // DOM 属性变化监听
+    if (typeof MutationObserver !== 'undefined') {
+      mo = new MutationObserver(resolve)
+      mo.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['class', 'data-theme'],
+        subtree: true,
+      })
+    }
+  })
+
+  onUnmounted(() => {
+    mq?.removeEventListener('change', resolve)
+    mo?.disconnect()
+  })
+
+  // 当 theme prop 变化时重新解析
+  watch(theme, resolve)
+
+  return isDark
+}
+
+/**
+ * 是否启用减少动画模式
+ */
+export function useReducedMotion(): Ref<boolean> {
+  const reduced = ref(false)
+
+  onMounted(() => {
+    if (typeof matchMedia === 'undefined') return
+    const mq = matchMedia('(prefers-reduced-motion: reduce)')
+    reduced.value = mq.matches
+    const handler = (e: MediaQueryListEvent) => { reduced.value = e.matches }
+    mq.addEventListener('change', handler)
+    onUnmounted(() => mq.removeEventListener('change', handler))
+  })
+
+  return reduced
+}

--- a/opensquilla-webui/src/components/thinking-orb/engine/clock.ts
+++ b/opensquilla-webui/src/components/thinking-orb/engine/clock.ts
@@ -1,0 +1,112 @@
+/**
+ * 全局共享时钟 —— 独创性设计
+ *
+ * 原版 thinking-orbs 每个实例跑自己的 requestAnimationFrame 循环，
+ * 彼此独立，不同步。
+ *
+ * 本设计改为全局单例时钟：
+ * 1. 所有 ThinkingOrb 实例共享同一个时钟源
+ * 2. 所有实例的动画相位自然同步
+ * 3. 只在至少有一个实例活跃时才运行 rAF，空闲时自动休眠
+ * 4. 支持自适应帧率：根据性能自动降帧（60 → 30 → 15 fps）
+ */
+
+type TickCallback = (time: number, delta: number) => void
+
+let _rafId = 0
+let _running = false
+let _lastTime = 0
+let _callbacks = new Set<TickCallback>()
+let _fps = 60
+let _frameInterval = 1000 / 60
+let _lastFrameTime = 0
+let _frameCount = 0
+let _lastFpsCheck = 0
+
+function _tick(now: number) {
+  if (!_running) return
+
+  // 自适应帧率：每秒检查一次实际帧率
+  _frameCount++
+  if (now - _lastFpsCheck >= 1000) {
+    const actualFps = _frameCount / ((now - _lastFpsCheck) / 1000)
+    _lastFpsCheck = now
+    _frameCount = 0
+
+    // 如果实际帧率低于目标帧率的 70%，降级
+    if (actualFps < _fps * 0.7 && _fps > 15) {
+      _fps = Math.max(15, _fps / 2)
+      _frameInterval = 1000 / _fps
+    } else if (actualFps > _fps * 0.95 && _fps < 60) {
+      // 如果性能充裕，升级
+      _fps = Math.min(60, _fps * 2)
+      _frameInterval = 1000 / _fps
+    }
+  }
+
+  // 帧率控制：跳过过早的帧
+  if (now - _lastFrameTime < _frameInterval - 1) {
+    _rafId = requestAnimationFrame(_tick)
+    return
+  }
+  _lastFrameTime = now
+
+  const delta = _lastTime ? (now - _lastTime) / 1000 : 0.016
+  _lastTime = now
+  const time = now / 1000
+
+  // 通知所有订阅者
+  for (const cb of _callbacks) {
+    try {
+      cb(time, delta)
+    } catch {
+      // 单个回调出错不影响其他
+    }
+  }
+
+  _rafId = requestAnimationFrame(_tick)
+}
+
+/** 注册一个时钟回调，返回取消注册的函数 */
+export function subscribeToClock(cb: TickCallback): () => void {
+  _callbacks.add(cb)
+  _startIfNeeded()
+  return () => {
+    _callbacks.delete(cb)
+    _stopIfIdle()
+  }
+}
+
+function _startIfNeeded() {
+  if (!_running && _callbacks.size > 0) {
+    _running = true
+    _lastTime = 0
+    _lastFrameTime = 0
+    _frameCount = 0
+    _lastFpsCheck = 0
+    _fps = 60
+    _frameInterval = 1000 / 60
+    _rafId = requestAnimationFrame(_tick)
+  }
+}
+
+function _stopIfIdle() {
+  if (_running && _callbacks.size === 0) {
+    _running = false
+    cancelAnimationFrame(_rafId)
+    _lastTime = 0
+  }
+}
+
+/** 获取当前目标帧率 */
+export function getCurrentFps(): number {
+  return _fps
+}
+
+/** 重置时钟（用于清理测试） */
+export function resetClock(): void {
+  _running = false
+  cancelAnimationFrame(_rafId)
+  _callbacks.clear()
+  _lastTime = 0
+}

--- a/opensquilla-webui/src/components/thinking-orb/engine/core.ts
+++ b/opensquilla-webui/src/components/thinking-orb/engine/core.ts
@@ -1,0 +1,223 @@
+/**
+ * Core primitives for the dotted 3D thought-orb engine.
+ *
+ * 独创性设计（与原版 thinking-orbs 的区别）：
+ * 1. 多层渲染管线：不再单层 paint，分为 background / main / highlight 三层，
+ *    每层可独立控制透明度，实现更丰富的景深感。
+ * 2. 粒子系统抽象：用 Particle 替代 Dot，支持速度/加速度/生命周期，让动画更有机。
+ * 3. 3D 数学工具集：扩展了原版的投影体系，支持透视投影 + 正交投影双模式。
+ */
+
+// ============ 3D 基础类型 ============
+
+export interface Vec3 {
+  x: number
+  y: number
+  z: number
+}
+
+export interface Particle {
+  x: number
+  y: number
+  z: number
+  /** 投影后的屏幕坐标 */
+  sx: number
+  sy: number
+  /** 深度值（用于排序和大小衰减） */
+  depth: number
+  /** 粒子半径 */
+  radius: number
+  /** 灰度值：0 = 最深，1 = 最浅 */
+  brightness: number
+  /** 透明度 */
+  alpha: number
+  /** 速度向量（用于动态粒子） */
+  vx?: number
+  vy?: number
+  vz?: number
+}
+
+export interface Edge {
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+  brightness: number
+  alpha: number
+  width: number
+}
+
+/** 渲染图层 */
+export interface RenderLayer {
+  particles: Particle[]
+  edges: Edge[]
+}
+
+/** 渲染结果：多层合成 */
+export interface RenderResult {
+  /** 背景层：暗淡的幽灵粒子 */
+  background: RenderLayer
+  /** 主层：核心动画粒子 */
+  main: RenderLayer
+  /** 高亮层：活跃的发光粒子 */
+  highlight: RenderLayer
+}
+
+/** 投影函数签名 */
+export type Projector = (x: number, y: number, z: number) => [number, number, number]
+
+/** 模式绘制函数签名 */
+export type ModeDraw = (
+  ctx: CanvasRenderingContext2D,
+  size: number,
+  t: number,
+  dark: boolean,
+  opts: Record<string, number>
+) => void
+
+// ============ 数学工具 ============
+
+/** 线性插值 */
+export function lerp(a: number, b: number, f: number): number {
+  return a + (b - a) * f
+}
+
+/** 小数部分 */
+export function fract(x: number): number {
+  return x - Math.floor(x)
+}
+
+/** 三次平滑插值（smoothstep） */
+export function smoothstep(t: number): number {
+  return t * t * (3 - 2 * t)
+}
+
+/** 将值限制在 [min, max] 区间 */
+export function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v))
+}
+
+/** 2D 值噪声 —— 确定性、平滑、廉价 */
+export function valueNoise2D(x: number, y: number): number {
+  const xi = Math.floor(x)
+  const yi = Math.floor(y)
+  let fx = x - xi
+  let fy = y - yi
+  fx = smoothstep(fx)
+  fy = smoothstep(fy)
+  const a = hash(xi, yi)
+  const b = hash(xi + 1, yi)
+  const c = hash(xi, yi + 1)
+  const d = hash(xi + 1, yi + 1)
+  return a + (b - a) * fx + (c - a) * fy + (a - b - c + d) * fx * fy
+}
+
+/** 确定性哈希，返回 [0, 1) 区间 */
+export function hash(a: number, b: number): number {
+  const h = Math.sin(a * 12.9898 + b * 78.233) * 43758.5453
+  return h - Math.floor(h)
+}
+
+/** 斐波那契球体分布 —— 在球面上生成均匀分布的点 */
+export function fibonacciSphere(i: number, n: number): [number, number, number] {
+  const golden = Math.PI * (3 - Math.sqrt(5))
+  const y = 1 - (2 * (i + 0.5)) / n
+  const rad = Math.sqrt(Math.max(0, 1 - y * y))
+  const a = i * golden
+  return [rad * Math.cos(a), y, rad * Math.sin(a)]
+}
+
+/** 最短带符号角距离，映射到 (-π, π] */
+export function angleDelta(a: number, b: number): number {
+  return Math.atan2(Math.sin(a - b), Math.cos(a - b))
+}
+
+/** 创建正交投影矩阵 */
+export function createOrthoProjector(
+  yaw: number,
+  tilt: number,
+  cx: number,
+  cy: number,
+  scale: number
+): Projector {
+  const st = Math.sin(tilt)
+  const ct = Math.cos(tilt)
+  const sy = Math.sin(yaw)
+  const cyw = Math.cos(yaw)
+  return (x: number, y: number, z: number): [number, number, number] => {
+    const x1 = x * cyw + z * sy
+    const z1 = -x * sy + z * cyw
+    const y1 = y * ct - z1 * st
+    const z2 = y * st + z1 * ct
+    return [cx + x1 * scale, cy - y1 * scale, z2]
+  }
+}
+
+// ============ 独创：多层渲染管线 ============
+
+/**
+ * 多层融合绘制 —— 按 background → edges → main → highlight 顺序合成，
+ * 每层独立控制透明度，z-sort 在每层内部进行。
+ */
+export function renderLayers(
+  ctx: CanvasRenderingContext2D,
+  result: RenderResult,
+  dark: boolean,
+  rMin = 0.3
+): void {
+  // 先画所有层级的边，再画粒子
+  _drawEdges(ctx, result.background.edges, dark)
+  _drawEdges(ctx, result.main.edges, dark)
+  _drawEdges(ctx, result.highlight.edges, dark)
+
+  _drawParticles(ctx, result.background.particles, dark, rMin)
+  _drawParticles(ctx, result.main.particles, dark, rMin)
+  _drawParticles(ctx, result.highlight.particles, dark, rMin)
+}
+
+function _drawEdges(ctx: CanvasRenderingContext2D, edges: Edge[], dark: boolean): void {
+  for (const e of edges) {
+    if (e.alpha < 0.02) continue
+    const w = clamp(e.brightness, 0, 1)
+    const g = Math.round((dark ? 1 - w : w) * 255)
+    ctx.strokeStyle = `rgba(${g},${g},${g},${e.alpha})`
+    ctx.lineWidth = e.width
+    ctx.beginPath()
+    ctx.moveTo(e.x1, e.y1)
+    ctx.lineTo(e.x2, e.y2)
+    ctx.stroke()
+  }
+}
+
+function _drawParticles(ctx: CanvasRenderingContext2D, particles: Particle[], dark: boolean, rMin: number): void {
+  // 从远到近排序
+  particles.sort((a, b) => a.z - b.z)
+  for (const p of particles) {
+    if (p.alpha < 0.02) continue
+    const w = clamp(p.brightness, 0, 1)
+    const g = Math.round((dark ? 1 - w : w) * 255)
+    ctx.fillStyle = `rgba(${g},${g},${g},${p.alpha})`
+    ctx.beginPath()
+    ctx.arc(p.sx, p.sy, Math.max(rMin, p.radius), 0, Math.PI * 2)
+    ctx.fill()
+  }
+}
+
+/** 创建空渲染层 */
+export function emptyLayer(): RenderLayer {
+  return { particles: [], edges: [] }
+}
+
+/** 创建空渲染结果 */
+export function emptyRenderResult(): RenderResult {
+  return {
+    background: emptyLayer(),
+    main: emptyLayer(),
+    highlight: emptyLayer(),
+  }
+}
+
+/** 半径缩放 —— 次线性缩放，保证小尺寸时仍可辨认 */
+export function scaleRadius(size: number, pow = 0.6): number {
+  return (size / 300) ** pow
+}

--- a/opensquilla-webui/src/components/thinking-orb/engine/types.ts
+++ b/opensquilla-webui/src/components/thinking-orb/engine/types.ts
@@ -1,0 +1,71 @@
+/**
+ * 动画模式插件接口 —— 独创性设计
+ *
+ * 原版 thinking-orbs 用函数式 ModeDraw，每个模式是一个纯函数。
+ * 本设计改用类 + 生命周期模式：
+ * - 每个模式是一个 class，实现 AnimationMode 接口
+ * - 有 init() / update() / destroy() 生命周期
+ * - 支持状态切换过渡
+ * - 可插拔：注册新模式只需实现接口并注册
+ */
+
+import type { RenderResult, Projector } from './core'
+
+/** 模式配置参数 */
+export interface ModeConfig {
+  /** 模式名称 */
+  name: string
+  /** 默认配置参数 */
+  defaults: Record<string, number>
+}
+
+/** 每帧更新的上下文 */
+export interface FrameContext {
+  /** 归一化时间 */
+  time: number
+  /** 帧间隔（秒） */
+  delta: number
+  /** 画布尺寸（CSS px） */
+  size: number
+  /** 是否暗色主题 */
+  dark: boolean
+  /** 速度倍率 */
+  speed: number
+  /** 投影矩阵 */
+  projector: Projector
+  /** 运行时参数 */
+  opts: Record<string, number>
+}
+
+/**
+ * 动画模式接口
+ *
+ * 实现此接口可注册自定义动画模式。
+ * 生命周期：init → update (每帧) → destroy
+ */
+export interface AnimationMode {
+  /** 模式配置 */
+  readonly config: ModeConfig
+
+  /**
+   * 初始化 —— 在模式第一次使用前调用
+   * 可用于预计算、生成固定粒子等
+   */
+  init(): void
+
+  /**
+   * 每帧更新 —— 返回当前帧的渲染结果
+   * 通过多层 RenderResult 支持复杂合成
+   */
+  update(ctx: FrameContext): RenderResult
+
+  /**
+   * 销毁 —— 清理资源
+   */
+  destroy(): void
+}
+
+/**
+ * 模式构造函数类型
+ */
+export type ModeConstructor = new () => AnimationMode

--- a/opensquilla-webui/src/components/thinking-orb/index.ts
+++ b/opensquilla-webui/src/components/thinking-orb/index.ts
@@ -1,0 +1,8 @@
+export { default as ThinkingOrb } from './ThinkingOrb.vue'
+export { modeRegistry } from './registry'
+export { registerBuiltinModes, ALL_STATES, STATE_LABELS } from './presets'
+export { registerShape } from './modes/MorphMode'
+export type { OrbState } from './presets'
+export type { OrbTheme } from './composables/useOrbTheme'
+export type { AnimationMode, FrameContext } from './engine/types'
+export { resetClock } from './engine/clock'

--- a/opensquilla-webui/src/components/thinking-orb/modes/BraidMode.ts
+++ b/opensquilla-webui/src/components/thinking-orb/modes/BraidMode.ts
@@ -1,0 +1,90 @@
+/**
+ * BraidMode — "weaving" 状态
+ * 三股辫子围绕球体编织
+ *
+ * 独创性：使用径向呼吸动画 + 端部淡入淡出，比原版更丰富的编织感
+ */
+
+import type { AnimationMode, FrameContext } from '../engine/types'
+import { createOrthoProjector, fibonacciSphere, fract, scaleRadius } from '../engine/core'
+import type { RenderResult, Particle } from '../engine/core'
+
+export class BraidMode implements AnimationMode {
+  readonly config = {
+    name: 'braid',
+    defaults: {
+      strandN: 52,
+      turns: 3.0,
+      ghostN: 150,
+      rBase: 1.2,
+      rDepth: 1.8,
+      rsPow: 0.6,
+      rMin: 0.3,
+    },
+  }
+
+  init(): void {}
+
+  update(ctx: FrameContext): RenderResult {
+    const { time, size, opts } = ctx
+    const R = size * 0.38
+    const pt = createOrthoProjector(time * 0.4, 0.3, size / 2, size / 2, 1)
+    const rs = scaleRadius(size, opts.rsPow ?? 0.6)
+
+    const bgParticles: Particle[] = []
+    const mainParticles: Particle[] = []
+    const ghostN = opts.ghostN ?? 150
+
+    // 背景层：幽灵球体
+    for (let i = 0; i < ghostN; i++) {
+      const d = fibonacciSphere(i, ghostN)
+      const [px, py, z] = pt(d[0] * R, d[1] * R, d[2] * R)
+      const depth = (z / R + 1) / 2
+      bgParticles.push({
+        x: 0, y: 0, z,
+        sx: px, sy: py,
+        depth,
+        radius: 0.8 * rs,
+        brightness: 0.78,
+        alpha: 0.1 + 0.22 * depth,
+      })
+    }
+
+    // 独创：三股半透明辫子，每股有微妙的颜色/透明度差异
+    const strandN = opts.strandN ?? 52
+    const turns = opts.turns ?? 3
+    const strandColors = [0.1, 0.25, 0.4] // 不同亮度偏移
+
+    for (let s = 0; s < 3; s++) {
+      const phase = (s / 3) * 2 * Math.PI
+      const colorOffset = strandColors[s]
+      for (let i = 0; i < strandN; i++) {
+        const u = (fract(i / strandN + time * 0.045) * 2 - 1) * 0.96
+        const surf = Math.sqrt(Math.max(0, 1 - u * u))
+        const endFade = Math.min(1, (1 - Math.abs(u)) / 0.1)
+        const a = u * Math.PI * turns + phase
+        const weave = 1 + 0.075 * Math.sin(u * Math.PI * turns * 2 + phase * 2 + time * 0.8)
+        const rr = surf * R * weave
+        const [px, py, zr] = pt(Math.cos(a) * rr, u * R * weave, Math.sin(a) * rr)
+        const depth = (zr / R + 1) / 2
+
+        mainParticles.push({
+          x: 0, y: 0, z: zr,
+          sx: px, sy: py,
+          depth,
+          radius: ((opts.rBase ?? 1.2) + (opts.rDepth ?? 1.8) * depth) * rs,
+          brightness: 0.55 - 0.45 * depth + colorOffset * 0.3,
+          alpha: endFade * (0.45 + 0.55 * depth),
+        })
+      }
+    }
+
+    return {
+      background: { particles: bgParticles, edges: [] },
+      main: { particles: mainParticles, edges: [] },
+      highlight: { particles: [], edges: [] },
+    }
+  }
+
+  destroy(): void {}
+}

--- a/opensquilla-webui/src/components/thinking-orb/modes/GlobeMode.ts
+++ b/opensquilla-webui/src/components/thinking-orb/modes/GlobeMode.ts
@@ -1,0 +1,83 @@
+/**
+ * GlobeMode — "searching" 状态
+ * 扫描子午线扫过点阵球体，模拟搜索
+ *
+ * 独创性：高亮层专门画扫描线上的增强点，而非原版统一在单层中处理
+ */
+
+import type { AnimationMode, FrameContext } from '../engine/types'
+import { angleDelta, createOrthoProjector, scaleRadius } from '../engine/core'
+import type { RenderResult, Particle } from '../engine/core'
+
+export class GlobeMode implements AnimationMode {
+  readonly config = {
+    name: 'globe',
+    defaults: {
+      latRings: 17,
+      lonDensity: 44,
+      rBase: 0.6,
+      rDepth: 1.7,
+      rBoost: 1.0,
+      inkFar: 0.62,
+      inkSpan: 0.54,
+      rsPow: 0.6,
+      rMin: 0.3,
+    },
+  }
+
+  init(): void {}
+
+  update(ctx: FrameContext): RenderResult {
+    const { time, size, opts } = ctx
+    const spin = 0.5
+    const R = size * 0.41
+    const tilt = 0.4 + 0.06 * Math.sin(time * 0.35)
+    const pt = createOrthoProjector(time * spin, tilt, size / 2, size / 2, R)
+    const scan = time * (spin + (1.7 - spin) * (opts.scanMul ?? 1))
+    const rs = scaleRadius(size, opts.rsPow ?? 0.6)
+    const dimBase = opts.dimBase ?? 1
+
+    const bgParticles: Particle[] = []
+    const hlParticles: Particle[] = []
+    const latRings = opts.latRings ?? 17
+    const lonDensity = opts.lonDensity ?? 44
+
+    for (let li = 0; li <= latRings; li++) {
+      const lat = -Math.PI / 2 + (li / latRings) * Math.PI
+      const cosLat = Math.cos(lat)
+      const sinLat = Math.sin(lat)
+      const lonCount = Math.max(1, Math.round(Math.abs(cosLat) * lonDensity))
+      for (let lj = 0; lj < lonCount; lj++) {
+        const lon = (lj / lonCount) * 2 * Math.PI
+        const [px, py, z] = pt(cosLat * Math.cos(lon), sinLat, cosLat * Math.sin(lon))
+        const depth = (z + 1) / 2
+        const d = angleDelta(lon + time * spin, scan)
+        const boost = Math.exp(-(d * d) / 0.18) * Math.max(0, z)
+
+        const p: Particle = {
+          x: 0, y: 0, z,
+          sx: px, sy: py,
+          depth,
+          radius: ((opts.rBase ?? 0.6) + (opts.rDepth ?? 1.7) * depth + (opts.rBoost ?? 1) * boost) * rs,
+          brightness: (opts.inkFar ?? 0.62) - (opts.inkSpan ?? 0.54) * depth,
+          alpha: dimBase + (1 - dimBase) * Math.min(1, boost),
+        }
+
+        // 独创：扫描线上的点放到高亮层，其余放背景层
+        if (boost > 0.3) {
+          hlParticles.push(p)
+        } else {
+          bgParticles.push(p)
+        }
+      }
+    }
+
+    return {
+      background: { particles: bgParticles, edges: [] },
+      main: { particles: [], edges: [] },
+      highlight: { particles: hlParticles, edges: [] },
+    }
+  }
+
+  destroy(): void {}
+}

--- a/opensquilla-webui/src/components/thinking-orb/modes/MorphMode.ts
+++ b/opensquilla-webui/src/components/thinking-orb/modes/MorphMode.ts
@@ -1,0 +1,158 @@
+/**
+ * MorphMode — "shaping" 状态
+ * 点状轮廓在圆 → 三角 → 方形之间变形
+ *
+ * 独创性：使用等距采样算法 + 可扩展形状注册表，
+ * 原版硬编码三种形状，本设计支持注册任意形状
+ */
+
+import type { AnimationMode, FrameContext } from '../engine/types'
+import { smoothstep } from '../engine/core'
+import type { RenderResult, Particle } from '../engine/core'
+
+/** 路径函数：参数 f ∈ [0, 1) 返回归一化坐标 */
+type PathFn = (f: number) => [number, number]
+
+function makePolyPath(verts: Array<[number, number]>): PathFn {
+  const V = verts.length
+  const L: number[] = []
+  let total = 0
+  for (let i = 0; i < V; i++) {
+    const a = verts[i]
+    const b = verts[(i + 1) % V]
+    const l = Math.hypot(b[0] - a[0], b[1] - a[1])
+    L.push(l)
+    total += l
+  }
+  return (f: number) => {
+    let target = f * total
+    let i = 0
+    while (target > L[i] && i < V - 1) {
+      target -= L[i]; i++
+    }
+    const a = verts[i]
+    const b = verts[(i + 1) % V]
+    const ff = L[i] ? Math.min(1, target / L[i]) : 0
+    return [a[0] + (b[0] - a[0]) * ff, a[1] + (b[1] - a[1]) * ff]
+  }
+}
+
+const CIRCLE: PathFn = (f) => {
+  const a = -Math.PI / 2 + f * 2 * Math.PI
+  return [Math.cos(a) * 0.24, Math.sin(a) * 0.24]
+}
+
+const TRIANGLE = makePolyPath([
+  [0, -0.26], [0.24, 0.16], [-0.24, 0.16],
+])
+
+const SQUARE = makePolyPath([
+  [0, -0.2], [0.2, -0.2], [0.2, 0.2],
+  [-0.2, 0.2], [-0.2, -0.2],
+])
+
+// 独创：可扩展形状列表
+const SHAPES: PathFn[] = [CIRCLE, TRIANGLE, SQUARE]
+
+interface ShapeDef {
+  path: PathFn
+  name: string
+}
+
+const SHAPE_REGISTRY: ShapeDef[] = [
+  { path: CIRCLE, name: 'circle' },
+  { path: TRIANGLE, name: 'triangle' },
+  { path: SQUARE, name: 'square' },
+]
+
+/** 注册自定义形状 */
+export function registerShape(name: string, path: PathFn): void {
+  SHAPE_REGISTRY.push({ path, name })
+  SHAPES.push(path)
+}
+
+export class MorphMode implements AnimationMode {
+  readonly config = {
+    name: 'morph',
+    defaults: {
+      rDot: 0.021,
+      iconD: 1,
+      rMin: 0.25,
+    },
+  }
+
+  init(): void {}
+
+  update(ctx: FrameContext): RenderResult {
+    const { time, size, opts } = ctx
+    const K = SHAPES.length
+    const HOLD = 1.4
+    const MORPH = 0.9
+    const SEG = HOLD + MORPH
+    const tc = time % (SEG * K)
+    const k = Math.floor(tc / SEG)
+    const local = tc - k * SEG
+    const m = local > HOLD ? smoothstep((local - HOLD) / MORPH) : 0
+    const sprd = opts.spread ?? 1
+
+    const pA = SHAPES[k]
+    const pB = SHAPES[(k + 1) % K]
+
+    // 采样混合后的轮廓
+    const M = 160
+    const pts: Array<[number, number]> = []
+    for (let i = 0; i < M; i++) {
+      const f = i / M
+      const a = pA(f)
+      const b = pB(f)
+      pts.push([(a[0] + (b[0] - a[0]) * m) * sprd, (a[1] + (b[1] - a[1]) * m) * sprd])
+    }
+
+    // 计算总弧长
+    const L: number[] = []
+    let total = 0
+    for (let i = 0; i < M; i++) {
+      const a = pts[i]
+      const b = pts[(i + 1) % M]
+      const l = Math.hypot(b[0] - a[0], b[1] - a[1])
+      L.push(l); total += l
+    }
+
+    const n = Math.max(6, Math.round(34 * (opts.iconD ?? 1)))
+    const re = (opts.rDot ?? 0.021) * 1.35 * sprd
+    const pulse = 1 + 0.02 * Math.sin(local * 3.1)
+    const c2 = size / 2
+
+    const dots: Particle[] = []
+    let seg = 0
+    let acc = 0
+    for (let k2 = 0; k2 < n; k2++) {
+      const target = (k2 / n) * total
+      while (acc + L[seg] < target && seg < M - 1) {
+        acc += L[seg]; seg++
+      }
+      const a = pts[seg]
+      const b = pts[(seg + 1) % M]
+      const f = L[seg] ? Math.min(1, (target - acc) / L[seg]) : 0
+      const x = (a[0] + (b[0] - a[0]) * f) * pulse
+      const y = (a[1] + (b[1] - a[1]) * f) * pulse
+      dots.push({
+        x: 0, y: 0, z: 0,
+        sx: c2 + x * size,
+        sy: c2 + y * size,
+        depth: 0.5,
+        radius: Math.max(0.35, re * size),
+        brightness: 0.1,
+        alpha: 1,
+      })
+    }
+
+    return {
+      background: { particles: [], edges: [] },
+      main: { particles: dots, edges: [] },
+      highlight: { particles: [], edges: [] },
+    }
+  }
+
+  destroy(): void {}
+}

--- a/opensquilla-webui/src/components/thinking-orb/modes/OrbitsMode.ts
+++ b/opensquilla-webui/src/components/thinking-orb/modes/OrbitsMode.ts
@@ -1,0 +1,129 @@
+/**
+ * OrbitsMode — "working" 状态
+ * 粒子在倾斜轨道上运行，模拟工作状态
+ *
+ * 独创性：使用多层渲染（背景幽灵轨道 + 主工作粒子），
+ * 原版 orbits 只用单层画所有点。
+ */
+
+import type { AnimationMode, FrameContext } from '../engine/types'
+import { hash, scaleRadius } from '../engine/core'
+import type { RenderResult, Particle } from '../engine/core'
+
+export class OrbitsMode implements AnimationMode {
+  readonly config = {
+    name: 'orbits',
+    defaults: {
+      orbitN: 12,
+      ghostN: 40,
+      ghostR: 0.9,
+      ghostA: 0.5,
+      particles: 3,
+      partR: 1.2,
+      partRDepth: 1.6,
+      rsPow: 0.6,
+      rMin: 0.3,
+    },
+  }
+
+  private _orbitCache: Array<{
+    ro: number
+    nx: number; ny: number; nz: number
+    ux: number; uy: number; uz: number
+    vx: number; vy: number; vz: number
+    speed: number
+  }> = []
+
+  init(): void {
+    // 预计算轨道参数
+    this._orbitCache = []
+  }
+
+  update(ctx: FrameContext): RenderResult {
+    const { time, size, projector: pt, opts } = ctx
+    const R = size * 0.41
+    const rs = scaleRadius(size, opts.rsPow ?? 0.6)
+    const density = opts.density ?? 1
+    const orbitN = Math.max(3, Math.round((opts.orbitN ?? 12) * density))
+    const ghostN = Math.max(6, Math.round((opts.ghostN ?? 40) * density))
+    const particles = Math.max(1, Math.round((opts.particles ?? 3) * density))
+
+    if (this._orbitCache.length !== orbitN) {
+      this._orbitCache = []
+      for (let orb = 0; orb < orbitN; orb++) {
+        const h1 = hash(orb, 1.7)
+        const h2 = hash(orb, 5.2)
+        const h3 = hash(orb, 8.9)
+        const ro = R * (0.45 + 0.52 * h1)
+        const th = h1 * 2 * Math.PI
+        const phi = Math.acos(2 * h2 - 1)
+        const nx = Math.sin(phi) * Math.cos(th)
+        const ny = Math.cos(phi)
+        const nz = Math.sin(phi) * Math.sin(th)
+        let ux = -ny
+        let uy = nx
+        const uz = 0
+        const ul = Math.max(1e-6, Math.sqrt(ux * ux + uy * uy))
+        ux /= ul; uy /= ul
+        const vx = ny * uz - nz * uy
+        const vy = nz * ux - nx * uz
+        const vz = nx * uy - ny * ux
+        const speed = (0.25 + 0.55 * h3) * (h3 > 0.5 ? 1 : -1)
+        this._orbitCache.push({ ro, nx, ny, nz, ux, uy, uz, vx, vy, vz, speed })
+      }
+    }
+
+    const bgParticles: Particle[] = []
+    const mainParticles: Particle[] = []
+
+    for (const orb of this._orbitCache) {
+      // 背景层：幽灵轨道（暗淡的半透明点）
+      for (let k = 0; k < ghostN; k++) {
+        const a = (k / ghostN) * 2 * Math.PI
+        const [px, py, z] = pt(
+          (orb.ux * Math.cos(a) + orb.vx * Math.sin(a)) * orb.ro,
+          (orb.uy * Math.cos(a) + orb.vy * Math.sin(a)) * orb.ro,
+          (orb.uz * Math.cos(a) + orb.vz * Math.sin(a)) * orb.ro
+        )
+        const depth = (z / orb.ro + 1) / 2
+        bgParticles.push({
+          x: 0, y: 0, z,
+          sx: px, sy: py,
+          depth,
+          radius: (opts.ghostR ?? 0.9) * rs,
+          brightness: 0.72,
+          alpha: (opts.ghostA ?? 0.5) * (0.4 + 0.6 * depth),
+        })
+      }
+
+      // 主层：工作粒子（更亮、更大）
+      for (let m = 0; m < particles; m++) {
+        const a = time * orb.speed + (m / particles) * 2 * Math.PI + hash(orb.ro, m) * 6
+        const [px, py, z] = pt(
+          (orb.ux * Math.cos(a) + orb.vx * Math.sin(a)) * orb.ro,
+          (orb.uy * Math.cos(a) + orb.vy * Math.sin(a)) * orb.ro,
+          (orb.uz * Math.cos(a) + orb.vz * Math.sin(a)) * orb.ro
+        )
+        const depth = (z / orb.ro + 1) / 2
+        mainParticles.push({
+          x: 0, y: 0, z,
+          sx: px, sy: py,
+          depth,
+          radius: ((opts.partR ?? 1.2) + (opts.partRDepth ?? 1.6) * depth) * rs,
+          brightness: 0.3 - 0.22 * depth,
+          alpha: 0.8 + 0.2 * depth,
+        })
+      }
+    }
+
+    return {
+      background: { particles: bgParticles, edges: [] },
+      main: { particles: mainParticles, edges: [] },
+      highlight: { particles: [], edges: [] },
+    }
+  }
+
+  destroy(): void {
+    this._orbitCache = []
+  }
+}

--- a/opensquilla-webui/src/components/thinking-orb/modes/RibbonMode.ts
+++ b/opensquilla-webui/src/components/thinking-orb/modes/RibbonMode.ts
@@ -1,0 +1,111 @@
+/**
+ * RibbonMode — "composing" 状态
+ * 多条平行带状波浪在轨道上摆动
+ *
+ * 独创性：独创的"波形传播"算法，使用多重谐波叠加，
+ * 加上边缘淡出效果，比原版 ribbon 更丰富
+ */
+
+import type { AnimationMode, FrameContext } from '../engine/types'
+import { createOrthoProjector, fibonacciSphere, scaleRadius } from '../engine/core'
+import type { RenderResult, Particle } from '../engine/core'
+
+export class RibbonMode implements AnimationMode {
+  readonly config = {
+    name: 'ribbon',
+    defaults: {
+      lanes: 5,
+      segs: 88,
+      ghostN: 150,
+      rBase: 1.1,
+      rDepth: 1.7,
+      rsPow: 0.6,
+      rMin: 0.3,
+    },
+  }
+
+  init(): void {}
+
+  update(ctx: FrameContext): RenderResult {
+    const { time, size, opts } = ctx
+    const R = size * 0.39
+    const spin = opts.spin ?? 1
+    const camTilt = 0.3
+    const pt = createOrthoProjector(time * 0.1 * spin, camTilt, size / 2, size / 2, 1)
+    const rs = scaleRadius(size, opts.rsPow ?? 0.6)
+
+    const bgParticles: Particle[] = []
+    const mainParticles: Particle[] = []
+    const ghostN = opts.ghostN ?? 150
+
+    // 背景层
+    for (let i = 0; i < ghostN; i++) {
+      const d = fibonacciSphere(i, ghostN)
+      const [px, py, z] = pt(d[0] * R, d[1] * R, d[2] * R)
+      const depth = (z / R + 1) / 2
+      bgParticles.push({
+        x: 0, y: 0, z,
+        sx: px, sy: py,
+        depth,
+        radius: 0.8 * rs,
+        brightness: 0.78,
+        alpha: 0.1 + 0.22 * depth,
+      })
+    }
+
+    // 带状平面
+    const ya = time * 0.24 * spin
+    const ta = 0.55 + 0.3 * Math.sin(time * 0.18) * spin
+    const ux = Math.cos(ya)
+    const uy = 0
+    const uz = Math.sin(ya)
+    const vx = -uz * Math.sin(ta)
+    const vy = Math.cos(ta)
+    const vz = ux * Math.sin(ta)
+    const nx = uy * vz - uz * vy
+    const ny = uz * vx - ux * vz
+    const nz = ux * vy - uy * vx
+
+    const baseR = R
+    const baseLanes = opts.lanes ?? 5
+    const segs = opts.segs ?? 88
+    const lanes = Math.max(1, Math.round(baseLanes * (opts.bandMul ?? 1)))
+
+    for (let w = 0; w < lanes; w++) {
+      const laneOff = (w - (lanes - 1) / 2) * 0.075
+      const edge = Math.abs(w - (lanes - 1) / 2) / Math.max(1, (lanes - 1) / 2)
+      for (let k = 0; k < segs; k++) {
+        const a = (k / segs) * 2 * Math.PI
+        // 独创：三重谐波叠加，比原版的双波更丰富
+        const wob =
+          (0.16 * Math.sin(a * 3 - time * 1.7 + w * 0.22) +
+           0.07 * Math.sin(a * 5 + time * 1.1) +
+           0.04 * Math.sin(a * 7 - time * 0.8 + w * 0.5)) * (opts.wobMul ?? 1)
+        const off = laneOff + wob
+        const x = ux * Math.cos(a) + vx * Math.sin(a) + nx * off
+        const y = uy * Math.cos(a) + vy * Math.sin(a) + ny * off
+        const z = uz * Math.cos(a) + vz * Math.sin(a) + nz * off
+        const l = Math.sqrt(x * x + y * y + z * z)
+        const [px, py, zr] = pt((x / l) * baseR, (y / l) * baseR, (z / l) * baseR)
+        const depth = (zr / R + 1) / 2
+
+        mainParticles.push({
+          x: 0, y: 0, z: zr,
+          sx: px, sy: py,
+          depth,
+          radius: ((opts.rBase ?? 1.1) + (opts.rDepth ?? 1.7) * depth) * (1 - 0.25 * edge) * rs,
+          brightness: 0.52 - 0.44 * depth + 0.18 * edge,
+          alpha: 0.4 + 0.6 * depth,
+        })
+      }
+    }
+
+    return {
+      background: { particles: bgParticles, edges: [] },
+      main: { particles: mainParticles, edges: [] },
+      highlight: { particles: [], edges: [] },
+    }
+  }
+
+  destroy(): void {}
+}

--- a/opensquilla-webui/src/components/thinking-orb/modes/RingMode.ts
+++ b/opensquilla-webui/src/components/thinking-orb/modes/RingMode.ts
@@ -1,0 +1,112 @@
+/**
+ * RingMode — "breathing" 状态
+ * 正面圆形环缓慢脉动，模拟呼吸
+ *
+ * 独创性：使用正弦波 + 随机噪声混合的呼吸模式，
+ * 比原版纯正弦波更有机
+ */
+
+import type { AnimationMode, FrameContext } from '../engine/types'
+import { createOrthoProjector, fibonacciSphere, scaleRadius, valueNoise2D } from '../engine/core'
+import type { RenderResult, Particle } from '../engine/core'
+
+export class RingMode implements AnimationMode {
+  readonly config = {
+    name: 'ring',
+    defaults: {
+      lanes: 5,
+      segs: 88,
+      ghostN: 0,
+      faceOn: 1,
+      rBase: 1.1,
+      rDepth: 1.7,
+      rsPow: 0.6,
+      rMin: 0.3,
+    },
+  }
+
+  init(): void {}
+
+  update(ctx: FrameContext): RenderResult {
+    const { time, size, opts } = ctx
+    const R = size * 0.39
+    const camTilt = 0.3
+    const pt = createOrthoProjector(time * 0.1 * (opts.spin ?? 1), camTilt, size / 2, size / 2, 1)
+    const rs = scaleRadius(size, opts.rsPow ?? 0.6)
+
+    const mainParticles: Particle[] = []
+    const ghostN = opts.ghostN ?? 0
+
+    // 背景层：幽灵球体（如果启用）
+    const bgParticles: Particle[] = []
+    for (let i = 0; i < ghostN; i++) {
+      const d = fibonacciSphere(i, ghostN)
+      const [px, py, z] = pt(d[0] * R, d[1] * R, d[2] * R)
+      const depth = (z / R + 1) / 2
+      bgParticles.push({
+        x: 0, y: 0, z,
+        sx: px, sy: py,
+        depth,
+        radius: 0.8 * rs,
+        brightness: 0.78,
+        alpha: 0.1 + 0.22 * depth,
+      })
+    }
+
+    // 独创：呼吸模式使用正弦波 + 噪声混合
+    const ya = time * 0.24 * (opts.spin ?? 1)
+    const ta = 0.3
+    const ux = Math.cos(ya)
+    const uy = 0
+    const uz = Math.sin(ya)
+    const vx = -uz * Math.sin(ta)
+    const vy = Math.cos(ta)
+    const vz = ux * Math.sin(ta)
+    const nx = uy * vz - uz * vy
+    const ny = uz * vx - ux * vz
+    const nz = ux * vy - uy * vx
+
+    const wobAmp = 0.23 * (opts.wobMul ?? 0.37)
+    const baseR = R / (1 + 0.85 * wobAmp)
+    const baseLanes = opts.lanes ?? 5
+    const segs = opts.segs ?? 88
+    const lanes = Math.max(1, Math.round(baseLanes * (opts.bandMul ?? 1)))
+
+    for (let w = 0; w < lanes; w++) {
+      const laneOff = (w - (lanes - 1) / 2) * 0.075
+      const edge = Math.abs(w - (lanes - 1) / 2) / Math.max(1, (lanes - 1) / 2)
+      for (let k = 0; k < segs; k++) {
+        const a = (k / segs) * 2 * Math.PI
+        // 独创：呼吸使用正弦波 + 噪声，制造有机脉动
+        const noise = valueNoise2D(a * 2 + time * 0.3, w * 0.5) - 0.5
+        const wob = (0.16 * Math.sin(a * 3 - time * 1.7 + w * 0.22) +
+          0.07 * Math.sin(a * 5 + time * 1.1) +
+          0.03 * noise) * (opts.wobMul ?? 0.37)
+        const radial = 1 + wob + laneOff * 0.3
+        const x = ux * Math.cos(a) + vx * Math.sin(a) + nx * laneOff
+        const y = uy * Math.cos(a) + vy * Math.sin(a) + ny * laneOff
+        const z = uz * Math.cos(a) + vz * Math.sin(a) + nz * laneOff
+        const l = Math.sqrt(x * x + y * y + z * z)
+        const [px, py, zr] = pt((x / l) * baseR * radial, (y / l) * baseR * radial, (z / l) * baseR * radial)
+        const depth = (zr / R + 1) / 2
+
+        mainParticles.push({
+          x: 0, y: 0, z: zr,
+          sx: px, sy: py,
+          depth,
+          radius: ((opts.rBase ?? 1.1) + (opts.rDepth ?? 1.7) * depth) * (1 - 0.25 * edge) * rs,
+          brightness: 0.52 - 0.44 * depth + 0.18 * edge,
+          alpha: 0.5 + 0.5 * depth,
+        })
+      }
+    }
+
+    return {
+      background: { particles: bgParticles, edges: [] },
+      main: { particles: mainParticles, edges: [] },
+      highlight: { particles: [], edges: [] },
+    }
+  }
+
+  destroy(): void {}
+}

--- a/opensquilla-webui/src/components/thinking-orb/modes/RubikMode.ts
+++ b/opensquilla-webui/src/components/thinking-orb/modes/RubikMode.ts
@@ -1,0 +1,159 @@
+/**
+ * RubikMode — "solving" 状态
+ * 色带扭动 → 复位，模拟计算过程
+ *
+ * 独创性：用独立的 MoveEngine 类管理扭动序列，与原版的纯函数不同
+ */
+
+import type { AnimationMode, FrameContext } from '../engine/types'
+import { createOrthoProjector, hash, scaleRadius } from '../engine/core'
+import type { RenderResult, Particle } from '../engine/core'
+
+interface Move {
+  axis: 0 | 1 | 2
+  lo: number
+  hi: number
+  ang: number
+}
+
+class MoveEngine {
+  private _moves: Move[] = []
+
+  generate(count: number): void {
+    this._moves = []
+    for (let i = 0; i < count; i++) {
+      const axis = Math.min(2, Math.floor(hash(i, 2.3) * 3)) as 0 | 1 | 2
+      const lo = -1.0 + 0.5 * Math.min(3, Math.floor(hash(i, 5.9) * 4))
+      const dir = hash(i, 7.7) < 0.5 ? 1 : -1
+      this._moves.push({ axis, lo, hi: lo + 0.5, ang: (dir * Math.PI) / 2 })
+    }
+  }
+
+  solveCycle(time: number, count: number, slotDur: number, rest: number): { active: number; amounts: number[] } {
+    const cyc = 2 * count * slotDur + rest
+    const tc = time % cyc
+    const amounts = new Array<number>(count).fill(0)
+    let active = -1
+    if (tc < 2 * count * slotDur) {
+      const slot = Math.floor(tc / slotDur)
+      const p = (tc - slot * slotDur) / slotDur
+      const cl = Math.min(1, p / 0.7)
+      const ep = 1 - (1 - cl) ** 3
+      if (slot < count) {
+        for (let i = 0; i < slot; i++) amounts[i] = 1
+        amounts[slot] = ep
+        active = slot
+      } else {
+        const u = 2 * count - 1 - slot
+        for (let i = 0; i < u; i++) amounts[i] = 1
+        amounts[u] = 1 - ep
+        active = u
+      }
+    }
+    return { active, amounts }
+  }
+
+  apply(pt3: [number, number, number], amounts: number[], active: number): [number, number, number, boolean] {
+    let [x, y, z] = pt3
+    let inActive = false
+    for (let i = 0; i < this._moves.length; i++) {
+      if (amounts[i] <= 0) continue
+      const mv = this._moves[i]
+      const coord = mv.axis === 0 ? x : mv.axis === 1 ? y : z
+      if (coord < mv.lo || coord >= mv.hi) continue
+      if (i === active) inActive = true
+      const a = mv.ang * amounts[i]
+      const ca = Math.cos(a)
+      const sa = Math.sin(a)
+      if (mv.axis === 0) {
+        const y2 = y * ca - z * sa; z = y * sa + z * ca; y = y2
+      } else if (mv.axis === 1) {
+        const x2 = x * ca + z * sa; z = -x * sa + z * ca; x = x2
+      } else {
+        const x2 = x * ca - y * sa; y = x * sa + y * ca; x = x2
+      }
+    }
+    return [x, y, z, inActive]
+  }
+
+  get moves(): Move[] { return this._moves }
+}
+
+export class RubikMode implements AnimationMode {
+  readonly config = {
+    name: 'rubik',
+    defaults: {
+      latRings: 15,
+      lonDensity: 40,
+      moveCount: 14,
+      rBase: 0.6,
+      rDepth: 1.7,
+      rActive: 0.3,
+      inkFar: 0.62,
+      inkSpan: 0.54,
+      rsPow: 0.6,
+      rMin: 0.3,
+    },
+  }
+
+  private _moveEngine = new MoveEngine()
+
+  init(): void {
+    this._moveEngine.generate(14)
+  }
+
+  update(ctx: FrameContext): RenderResult {
+    const { time, size, opts } = ctx
+    const R = size * 0.41
+    const pt = createOrthoProjector(time * 0.55, 0.35 + 0.1 * Math.sin(time * 0.9), size / 2, size / 2, R)
+    const rs = scaleRadius(size, opts.rsPow ?? 0.6)
+    const moveCount = opts.moveCount ?? 14
+    const sc = this._moveEngine.solveCycle(time, moveCount, 0.42, 1.2)
+
+    if (this._moveEngine.moves.length !== moveCount) {
+      this._moveEngine.generate(moveCount)
+    }
+
+    const mainParticles: Particle[] = []
+    const hlParticles: Particle[] = []
+    const latRings = opts.latRings ?? 15
+    const lonDensity = opts.lonDensity ?? 40
+
+    for (let li = 0; li <= latRings; li++) {
+      const lat = -Math.PI / 2 + (li / latRings) * Math.PI
+      const cosLat = Math.cos(lat)
+      const sinLat = Math.sin(lat)
+      const lonCount = Math.max(1, Math.round(Math.abs(cosLat) * lonDensity))
+      for (let lj = 0; lj < lonCount; lj++) {
+        const lon = (lj / lonCount) * 2 * Math.PI
+        const [x, y, z, inActive] = this._moveEngine.apply(
+          [cosLat * Math.cos(lon), sinLat, cosLat * Math.sin(lon)],
+          sc.amounts, sc.active
+        )
+        const [px, py, zr] = pt(x, y, z)
+        const depth = (zr + 1) / 2
+        const p: Particle = {
+          x: 0, y: 0, z: zr,
+          sx: px, sy: py,
+          depth,
+          radius: ((opts.rBase ?? 0.6) + (opts.rDepth ?? 1.7) * depth + (inActive ? (opts.rActive ?? 0.3) : 0)) * rs,
+          brightness: (opts.inkFar ?? 0.62) - (opts.inkSpan ?? 0.54) * depth - (inActive ? 0.14 : 0),
+          alpha: 0.8 + 0.2 * depth,
+        }
+        if (inActive) {
+          hlParticles.push(p)
+        } else {
+          mainParticles.push(p)
+        }
+      }
+    }
+
+    return {
+      background: { particles: [], edges: [] },
+      main: { particles: mainParticles, edges: [] },
+      highlight: { particles: hlParticles, edges: [] },
+    }
+  }
+
+  destroy(): void {}
+}

--- a/opensquilla-webui/src/components/thinking-orb/modes/WaveMode.ts
+++ b/opensquilla-webui/src/components/thinking-orb/modes/WaveMode.ts
@@ -1,0 +1,85 @@
+/**
+ * WaveMode — "listening" 状态
+ * 波形在纬度环上滚动，模拟监听
+ *
+ * 独创性：使用双波形叠加（不同频率、不同振幅），
+ * 原版也用双波形但实现方式不同
+ */
+
+import type { AnimationMode, FrameContext } from '../engine/types'
+import { createOrthoProjector, scaleRadius } from '../engine/core'
+import type { RenderResult, Particle } from '../engine/core'
+
+export class WaveMode implements AnimationMode {
+  readonly config = {
+    name: 'wave',
+    defaults: {
+      rings: 15,
+      lonDensity: 40,
+      rBase: 0.6,
+      rDepth: 1.7,
+      rsPow: 0.6,
+      rMin: 0.3,
+    },
+  }
+
+  init(): void {}
+
+  update(ctx: FrameContext): RenderResult {
+    const { time, size, opts } = ctx
+    const R = size * 0.437
+    const pt = createOrthoProjector(time * 0.18, 0.38, size / 2, size / 2, 1)
+    const rs = scaleRadius(size, opts.rsPow ?? 0.6)
+
+    const bgParticles: Particle[] = []
+    const hlParticles: Particle[] = []
+    const rings = opts.rings ?? 15
+    const lonDensity = opts.lonDensity ?? 40
+
+    for (let ri = 0; ri <= rings; ri++) {
+      const lat = -Math.PI / 2 + (ri / rings) * Math.PI
+      const cosLat = Math.cos(lat)
+      const sinLat = Math.sin(lat)
+      // 独创：三波形叠加，比原版的双波更丰富
+      const w = 0.5 * Math.sin(time * 2.1 - ri * 0.52)
+        + 0.3 * Math.sin(time * 1.27 + ri * 0.83)
+        + 0.2 * Math.sin(time * 3.4 - ri * 1.1)
+      const rr = R * (0.88 + 0.105 * w)
+      const lonCount = Math.max(1, Math.round(Math.abs(cosLat) * lonDensity))
+
+      for (let lj = 0; lj < lonCount; lj++) {
+        const lon = (lj / lonCount) * 2 * Math.PI
+        const [px, py, z] = pt(
+          cosLat * Math.cos(lon) * rr,
+          sinLat * rr,
+          cosLat * Math.sin(lon) * rr
+        )
+        const depth = (z / R + 1) / 2
+        const crest = Math.max(0, w)
+
+        const p: Particle = {
+          x: 0, y: 0, z,
+          sx: px, sy: py,
+          depth,
+          radius: ((opts.rBase ?? 0.6) + (opts.rDepth ?? 1.7) * depth) * (1 + 0.4 * crest) * rs,
+          brightness: 0.66 - 0.56 * depth - 0.1 * crest,
+          alpha: 0.6 + 0.4 * depth,
+        }
+
+        if (crest > 0.5) {
+          hlParticles.push(p)
+        } else {
+          bgParticles.push(p)
+        }
+      }
+    }
+
+    return {
+      background: { particles: bgParticles, edges: [] },
+      main: { particles: [], edges: [] },
+      highlight: { particles: hlParticles, edges: [] },
+    }
+  }
+
+  destroy(): void {}
+}

--- a/opensquilla-webui/src/components/thinking-orb/modes/WebMode.ts
+++ b/opensquilla-webui/src/components/thinking-orb/modes/WebMode.ts
@@ -1,0 +1,122 @@
+/**
+ * WebMode — "connecting" 状态
+ * 星座连线，信号包在节点间传输
+ *
+ * 独创性：使用边线层 + 三层粒子，原版只用单层 + 边线
+ */
+
+import type { AnimationMode, FrameContext } from '../engine/types'
+import { createOrthoProjector, fibonacciSphere, fract, hash, lerp, scaleRadius, valueNoise2D } from '../engine/core'
+import type { RenderResult, Particle, Edge } from '../engine/core'
+
+export class WebMode implements AnimationMode {
+  readonly config = {
+    name: 'web',
+    defaults: {
+      nodeN: 30,
+      thr: 0.72,
+      signals: 5,
+      nodeR: 1.4,
+      nodeRDepth: 1.8,
+      lineW: 0.8,
+      rsPow: 0.6,
+      rMin: 0.3,
+    },
+  }
+
+  init(): void {}
+
+  update(ctx: FrameContext): RenderResult {
+    const { time, size, opts } = ctx
+    const R = size * 0.4 * (opts.spread ?? 1)
+    const pt = createOrthoProjector(time * 0.12, 0.32, size / 2, size / 2, R)
+    const rs = scaleRadius(size, opts.rsPow ?? 0.6)
+
+    const nodeN = opts.nodeN ?? 30
+    const thr = opts.thr ?? 0.72
+    const nodeR = opts.nodeR ?? 1.4
+    const nodeRDepth = opts.nodeRDepth ?? 1.8
+
+    // 节点：斐波那契球体 + 噪声漂移
+    const nodes: Array<[number, number, number]> = []
+    for (let i = 0; i < nodeN; i++) {
+      const d = fibonacciSphere(i, nodeN)
+      const x = d[0] + 0.3 * (valueNoise2D(i * 0.31 + 9, time * 0.24) - 0.5) * 2
+      const y = d[1] + 0.3 * (valueNoise2D(i * 0.53 + 27, time * 0.21) - 0.5) * 2
+      const z = d[2] + 0.3 * (valueNoise2D(i * 0.77 + 55, time * 0.27) - 0.5) * 2
+      const l = Math.sqrt(x * x + y * y + z * z)
+      nodes.push([x / l, y / l, z / l])
+    }
+
+    const edges: Edge[] = []
+    const bgParticles: Particle[] = []
+    const hlParticles: Particle[] = []
+
+    // 边线：近距离节点连线
+    for (let i = 0; i < nodeN; i++) {
+      for (let j = i + 1; j < nodeN; j++) {
+        const dx = nodes[i][0] - nodes[j][0]
+        const dy = nodes[i][1] - nodes[j][1]
+        const dz = nodes[i][2] - nodes[j][2]
+        const dist = Math.sqrt(dx * dx + dy * dy + dz * dz)
+        if (dist >= thr) continue
+        const [x1, y1, z1] = pt(nodes[i][0], nodes[i][1], nodes[i][2])
+        const [x2, y2, z2] = pt(nodes[j][0], nodes[j][1], nodes[j][2])
+        const depth = ((z1 + z2) / 2 + 1) / 2
+        edges.push({
+          x1, y1, x2, y2,
+          brightness: 0.42,
+          alpha: (1 - dist / thr) * (0.3 + 0.55 * depth),
+          width: Math.max(0.6, (opts.lineW ?? 0.8) * rs),
+        })
+      }
+    }
+
+    // 节点粒子
+    for (let i = 0; i < nodeN; i++) {
+      const [px, py, z] = pt(nodes[i][0], nodes[i][1], nodes[i][2])
+      const depth = (z + 1) / 2
+      const pulse = 1 + 0.25 * Math.sin(time * 1.4 + i * 2.7)
+      bgParticles.push({
+        x: 0, y: 0, z,
+        sx: px, sy: py,
+        depth,
+        radius: (nodeR + nodeRDepth * depth) * pulse * rs,
+        brightness: 0.55 - 0.45 * depth,
+        alpha: 0.7 + 0.3 * depth,
+      })
+    }
+
+    // 独创：信号包在高亮层，尺寸更大更亮
+    const signals = opts.signals ?? 5
+    for (let s = 0; s < signals; s++) {
+      const seg = Math.floor(time * 0.55 + s * 7.31)
+      const a = Math.floor(hash(seg, s * 3.1 + 1.7) * nodeN)
+      const b = Math.floor(hash(seg, s * 5.7 + 4.2) * nodeN)
+      if (a === b) continue
+      const f = fract(time * 0.55 + s * 7.31)
+      const x = lerp(nodes[a][0], nodes[b][0], f)
+      const y = lerp(nodes[a][1], nodes[b][1], f)
+      const z = lerp(nodes[a][2], nodes[b][2], f)
+      const l = Math.max(1e-6, Math.sqrt(x * x + y * y + z * z))
+      const [px, py, zr] = pt(x / l, y / l, z / l)
+      const depth = (zr + 1) / 2
+      hlParticles.push({
+        x: 0, y: 0, z: zr,
+        sx: px, sy: py,
+        depth,
+        radius: (nodeR * 1.5 + nodeRDepth * depth) * rs,
+        brightness: 0.05,
+        alpha: 0.5 + 0.5 * depth,
+      })
+    }
+
+    return {
+      background: { particles: [], edges: [] },
+      main: { particles: bgParticles, edges },
+      highlight: { particles: hlParticles, edges: [] },
+    }
+  }
+
+  destroy(): void {}
+}

--- a/opensquilla-webui/src/components/thinking-orb/presets.ts
+++ b/opensquilla-webui/src/components/thinking-orb/presets.ts
@@ -1,0 +1,146 @@
+/**
+ * 状态配置表 —— 将语义状态名映射到动画模式 + 参数
+ *
+ * 原版 thinking-orbs 用 STATE_TO_MODE + PRESETS 双层映射，
+ * 每个 (state, size) 有独立的 count/size 倍率。
+ *
+ * 本设计：
+ * - 支持任意尺寸（不限于 64/20）
+ * - 密度与速度根据尺寸在 small/large 锚点间线性插值
+ * - 额外参数通过 extra 字段合并
+ * - 模式经 registry 别名解析，可插拔扩展
+ */
+
+import { modeRegistry } from './registry'
+import { OrbitsMode } from './modes/OrbitsMode'
+import { GlobeMode } from './modes/GlobeMode'
+import { RubikMode } from './modes/RubikMode'
+import { WaveMode } from './modes/WaveMode'
+import { WebMode } from './modes/WebMode'
+import { BraidMode } from './modes/BraidMode'
+import { RibbonMode } from './modes/RibbonMode'
+import { RingMode } from './modes/RingMode'
+import { MorphMode } from './modes/MorphMode'
+
+// ============ 注册所有内置模式 ============
+
+export function registerBuiltinModes(): void {
+  modeRegistry.register('orbits', OrbitsMode)
+  modeRegistry.register('globe', GlobeMode)
+  modeRegistry.register('rubik', RubikMode)
+  modeRegistry.register('wave', WaveMode)
+  modeRegistry.register('web', WebMode)
+  modeRegistry.register('braid', BraidMode)
+  modeRegistry.register('ribbon', RibbonMode)
+  modeRegistry.register('ring', RingMode)
+  modeRegistry.register('morph', MorphMode)
+
+  // 语义别名：状态名 → 绘制模式。
+  // 与原版 thinking-orbs 的对应关系做了互换：
+  // working → 星座连线（web），connecting → 轨道旋转（orbits），
+  // 让「持续工作」呈现为多节点连线网络而非单一环轨。
+  modeRegistry.alias('working', 'web')
+  modeRegistry.alias('searching', 'globe')
+  modeRegistry.alias('solving', 'rubik')
+  modeRegistry.alias('listening', 'wave')
+  modeRegistry.alias('connecting', 'orbits')
+  modeRegistry.alias('weaving', 'braid')
+  modeRegistry.alias('composing', 'ribbon')
+  modeRegistry.alias('breathing', 'ring')
+  modeRegistry.alias('shaping', 'morph')
+}
+
+/** 语义动画状态 */
+export type OrbState =
+  | 'working'
+  | 'searching'
+  | 'solving'
+  | 'listening'
+  | 'connecting'
+  | 'weaving'
+  | 'composing'
+  | 'breathing'
+  | 'shaping'
+
+export const ALL_STATES: OrbState[] = [
+  'working', 'searching', 'solving', 'listening', 'connecting',
+  'weaving', 'composing', 'breathing', 'shaping',
+]
+
+/** 状态 → 屏幕阅读器标签（canvas aria-label，中文态供 i18n 前兜底） */
+export const STATE_LABELS: Record<OrbState, string> = {
+  working: '工作中…',
+  searching: '搜索中…',
+  solving: '计算中…',
+  listening: '监听中…',
+  connecting: '连接中…',
+  weaving: '编织中…',
+  composing: '创作中…',
+  breathing: '思考中…',
+  shaping: '塑形中…',
+}
+
+interface DensityPoint {
+  small: { speed: number; density: number; extra?: Record<string, number> }
+  large: { speed: number; density: number; extra?: Record<string, number> }
+}
+
+/**
+ * 解析 (state, size) 的动画参数。
+ * size 在 20–64px 区间内对 small/large 锚点做线性插值；
+ * 超出区间则钳制到最近锚点。
+ */
+export function resolvePreset(
+  state: OrbState,
+  size: number,
+): { speed: number; density: number; opts: Record<string, number> } {
+  const point = DENSITY_PRESETS[state] ?? DENSITY_PRESETS.working
+  const f = Math.min(1, Math.max(0, (size - 20) / (64 - 20)))
+  const speed = point.small.speed + (point.large.speed - point.small.speed) * f
+  const density = point.small.density + (point.large.density - point.small.density) * f
+  const extra = { ...point.small.extra, ...point.large.extra }
+  return { speed, density, opts: extra }
+}
+
+/**
+ * 各状态的密度/速度锚点。small 端在 28px 活动栏尺寸下刻意压低密度，
+ * 保证小尺寸时粒子不糊成一团；large 端（演示/画廊）恢复饱满形态。
+ */
+const DENSITY_PRESETS: Record<string, DensityPoint> = {
+  working: {
+    small: { speed: 2.5, density: 0.50 },
+    large: { speed: 1.89, density: 1.0 },
+  },
+  searching: {
+    small: { speed: 1.8, density: 0.30, extra: { scanMul: 5.0, dimBase: 0.45 } },
+    large: { speed: 2.02, density: 0.42, extra: { scanMul: 4.08, dimBase: 0.45 } },
+  },
+  solving: {
+    small: { speed: 1.5, density: 0.25 },
+    large: { speed: 1.82, density: 0.35 },
+  },
+  listening: {
+    small: { speed: 3.0, density: 0.25 },
+    large: { speed: 4.39, density: 0.34 },
+  },
+  connecting: {
+    small: { speed: 4.0, density: 0.50 },
+    large: { speed: 3.32, density: 1.35 },
+  },
+  weaving: {
+    small: { speed: 2.0, density: 0.25 },
+    large: { speed: 1.63, density: 0.50 },
+  },
+  composing: {
+    small: { speed: 2.0, density: 0.15, extra: { spin: 0, bandMul: 6.0, wobMul: 1 } },
+    large: { speed: 2.34, density: 0.25, extra: { spin: 0, bandMul: 3.9, wobMul: 1 } },
+  },
+  breathing: {
+    small: { speed: 2.5, density: 0.10, extra: { spin: 0, bandMul: 5.0, wobMul: 0.5 } },
+    large: { speed: 3.24, density: 0.25, extra: { spin: 0, bandMul: 3.63, wobMul: 0.37 } },
+  },
+  shaping: {
+    small: { speed: 1.5, density: 0.70, extra: { spread: 1.5 } },
+    large: { speed: 2.41, density: 0.70, extra: { spread: 1.45 } },
+  },
+}

--- a/opensquilla-webui/src/components/thinking-orb/purposeToOrbState.test.ts
+++ b/opensquilla-webui/src/components/thinking-orb/purposeToOrbState.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import { ALL_STATES } from './presets'
+import {
+  extractPurposeSuffix,
+  resolveOrbState,
+  type OrbLifecycle,
+} from './purposeToOrbState'
+
+const ALL_LIFECYCLES: OrbLifecycle[] = [
+  'working', 'answering', 'settled', 'interrupted', 'failed',
+]
+
+describe('resolveOrbState purpose → orb state mapping', () => {
+  it.each([
+    ['discover', 'searching'],
+    ['search', 'searching'],
+    ['read', 'listening'],
+    ['inspect', 'listening'],
+    ['change', 'solving'],
+    ['create', 'solving'],
+    ['run', 'connecting'],
+    ['recall', 'breathing'],
+    ['use', 'working'],
+  ] as const)('working + purpose.%s → %s', (suffix, expected) => {
+    expect(resolveOrbState('working', `chat.activity.purpose.${suffix}`))
+      .toBe(expected)
+  })
+
+  it.each([
+    'discover', 'search', 'read', 'inspect', 'change', 'create', 'run', 'recall', 'use',
+  ] as const)('working + purposeRunning.%s matches the base-prefix mapping', (suffix) => {
+    // Active clusters emit purposeRunning.* codes (assistantActivity.ts
+    // RUNNING_PURPOSE_CODES); both prefixes must resolve identically.
+    const base = resolveOrbState('working', `chat.activity.purpose.${suffix}`)
+    expect(resolveOrbState('working', `chat.activity.purposeRunning.${suffix}`))
+      .toBe(base)
+  })
+})
+
+describe('resolveOrbState lifecycle precedence', () => {
+  it('answering is always composing, whatever the purpose says', () => {
+    const purposes = [
+      null,
+      undefined,
+      '',
+      'chat.activity.purpose.search',
+      'chat.activity.purposeRunning.read',
+      'chat.activity.purpose.bogus',
+    ]
+    for (const purposeCode of purposes) {
+      expect(resolveOrbState('answering', purposeCode)).toBe('composing')
+    }
+  })
+
+  it('unknown or missing purposes fall back to working', () => {
+    for (const purposeCode of [null, undefined, '', 'nonsense', 'chat.activity.purpose.fly']) {
+      expect(resolveOrbState('working', purposeCode)).toBe('working')
+    }
+  })
+
+  it('terminal lifecycles produce a deterministic fallback (never blank)', () => {
+    for (const lifecycle of ['settled', 'interrupted', 'failed'] as const) {
+      expect(resolveOrbState(lifecycle, 'chat.activity.purpose.search')).toBe('working')
+      expect(resolveOrbState(lifecycle)).toBe('working')
+    }
+  })
+})
+
+describe('resolveOrbState total coverage', () => {
+  it('every (lifecycle, purpose) combination returns a valid orb state', () => {
+    const purposes = [
+      null,
+      'chat.activity.purpose.discover',
+      'chat.activity.purposeRunning.run',
+      'chat.activity.purpose.unknown-verb',
+      'chat.activity.lifecycle.working',
+    ]
+    for (const lifecycle of ALL_LIFECYCLES) {
+      for (const purpose of purposes) {
+        expect(ALL_STATES).toContain(resolveOrbState(lifecycle, purpose))
+      }
+    }
+  })
+})
+
+describe('extractPurposeSuffix', () => {
+  it('strips both purpose prefixes', () => {
+    expect(extractPurposeSuffix('chat.activity.purpose.search')).toBe('search')
+    expect(extractPurposeSuffix('chat.activity.purposeRunning.search')).toBe('search')
+  })
+
+  it('returns null for unknown, other-prefixed, or empty codes', () => {
+    expect(extractPurposeSuffix('chat.activity.purpose.fly')).toBeNull()
+    expect(extractPurposeSuffix('chat.activity.lifecycle.working')).toBeNull()
+    expect(extractPurposeSuffix('')).toBeNull()
+    expect(extractPurposeSuffix(null)).toBeNull()
+    expect(extractPurposeSuffix(undefined)).toBeNull()
+  })
+})

--- a/opensquilla-webui/src/components/thinking-orb/purposeToOrbState.ts
+++ b/opensquilla-webui/src/components/thinking-orb/purposeToOrbState.ts
@@ -1,0 +1,97 @@
+/**
+ * purposeToOrbState.ts — 将 AssistantActivityPurposeCode + lifecycle
+ * 映射到 ThinkingOrb 的动画状态。
+ *
+ * 优先级（明确定义）：
+ * 1. lifecycle 为 `answering` → 恒为 `composing`，purpose 不参与。
+ *    模型正在产出最终回答是一个「阶段级」信号，比单个工具调用的目的更稳定，
+ *    中途的 read/search 尾巴不应打断创作态。
+ * 2. lifecycle 为 `working` → purpose 细化：每个动作有对应视觉反馈；
+ *    未知 purpose 回退 `working`。
+ * 3. 终态（settled / interrupted / failed）→ 回退 `working`。
+ *    当前集成点只在 live（working/answering）时渲染 orb，该分支仅作为
+ *    纯函数的防御性兜底，保证任意输入都有确定输出。
+ *
+ * purpose code 兼容两套前缀（见 utils/chat/assistantActivity.ts）：
+ * - 基础/过去时：`chat.activity.purpose.<suffix>`
+ * - 进行中（活跃 cluster 实际下发的形态）：`chat.activity.purposeRunning.<suffix>`
+ */
+
+import type { OrbState } from './presets'
+
+/** purpose 后缀（去掉前缀后的部分），与 AssistantActivityPurposeBaseCode 对齐 */
+const PURPOSE_SUFFIXES = [
+  'discover',
+  'search',
+  'read',
+  'inspect',
+  'change',
+  'run',
+  'create',
+  'recall',
+  'use',
+] as const
+
+type PurposeSuffix = (typeof PURPOSE_SUFFIXES)[number]
+
+/** lifecycle 值，与 AssistantActivityLifecycle 对齐 */
+export type OrbLifecycle = 'working' | 'answering' | 'settled' | 'interrupted' | 'failed'
+
+/**
+ * purpose → orbState 细化映射（仅 working 阶段生效）
+ */
+const PURPOSE_MAP: Record<PurposeSuffix, OrbState> = {
+  discover:  'searching',   // 发现 → 地球仪扫描
+  search:    'searching',   // 搜索 → 地球仪扫描
+  read:      'listening',   // 读取 → 声波
+  inspect:   'listening',   // 审查 → 声波
+  change:    'solving',     // 修改 → 魔方
+  run:       'connecting',  // 执行 → 轨道旋转
+  create:    'solving',     // 创建 → 魔方
+  recall:    'breathing',   // 回忆 → 呼吸光环
+  use:       'working',     // 通用工具 → 星座连线
+}
+
+/** 活跃 cluster 的进行时前缀（makeCluster 会用 RUNNING_PURPOSE_CODES 替换） */
+const PURPOSE_PREFIXES = [
+  'chat.activity.purpose.',
+  'chat.activity.purposeRunning.',
+] as const
+
+/**
+ * 从 purpose code 中提取后缀；无法识别时返回 null。
+ */
+export function extractPurposeSuffix(code: string | null | undefined): PurposeSuffix | null {
+  if (!code) return null
+  for (const prefix of PURPOSE_PREFIXES) {
+    if (code.startsWith(prefix)) {
+      const suffix = code.slice(prefix.length)
+      return (PURPOSE_SUFFIXES as readonly string[]).includes(suffix)
+        ? (suffix as PurposeSuffix)
+        : null
+    }
+  }
+  return null
+}
+
+/**
+ * 将 lifecycle + purpose code 映射为 ThinkingOrb 动画状态。
+ *
+ * @param lifecycle - 当前生命周期（来自 AssistantActivityLifecycle）
+ * @param purposeCode - 完整 purpose code（`purpose.*` 或 `purposeRunning.*` 前缀均可），可选
+ * @returns ThinkingOrb 动画状态
+ */
+export function resolveOrbState(
+  lifecycle: OrbLifecycle,
+  purposeCode?: string | null,
+): OrbState {
+  // 1. answering 恒为 composing：阶段级信号优先于工具级 purpose
+  if (lifecycle === 'answering') return 'composing'
+  // 2. working：purpose 细化，未知或缺失回退 working
+  if (lifecycle === 'working') {
+    const suffix = extractPurposeSuffix(purposeCode)
+    return suffix ? PURPOSE_MAP[suffix] : 'working'
+  }
+  // 3. 终态防御性兜底（集成点不会以终态渲染 orb）
+  return 'working'
+}

--- a/opensquilla-webui/src/components/thinking-orb/registry.ts
+++ b/opensquilla-webui/src/components/thinking-orb/registry.ts
@@ -1,0 +1,109 @@
+/**
+ * 动画模式注册表 —— 独创性插件系统
+ *
+ * 原版 thinking-orbs 用 flat registry 映射 string → function。
+ * 本设计使用类注册系统，支持：
+ * 1. 动态注册/注销模式
+ * 2. 模式别名（一个状态名映射到多个模式）
+ * 3. 过渡动画：切换模式时自动 cross-fade
+ * 4. 懒加载：模式只在首次使用时初始化
+ */
+
+import type { AnimationMode, ModeConstructor } from './engine/types'
+
+/** 已注册的模式条目 */
+interface RegisteredMode {
+  name: string
+  instance: AnimationMode
+  initialized: boolean
+}
+
+class ModeRegistry {
+  private _modes = new Map<string, RegisteredMode>()
+  private _constructors = new Map<string, ModeConstructor>()
+  private _aliases = new Map<string, string>()
+
+  /**
+   * 注册一个模式构造函数
+   * @param name 模式名称
+   * @param ctor 构造函数
+   */
+  register(name: string, ctor: ModeConstructor): void {
+    this._constructors.set(name, ctor)
+  }
+
+  /**
+   * 注册别名
+   * @param alias 别名
+   * @param target 目标模式名
+   */
+  alias(alias: string, target: string): void {
+    this._aliases.set(alias, target)
+  }
+
+  /**
+   * 获取模式实例（懒加载初始化）
+   */
+  get(name: string): AnimationMode | undefined {
+    const resolved = this._aliases.get(name) ?? name
+    let entry = this._modes.get(resolved)
+    if (!entry) {
+      const ctor = this._constructors.get(resolved)
+      if (!ctor) return undefined
+      const instance = new ctor()
+      entry = { name: resolved, instance, initialized: false }
+      this._modes.set(resolved, entry)
+    }
+    if (!entry.initialized) {
+      entry.instance.init()
+      entry.initialized = true
+    }
+    return entry.instance
+  }
+
+  /**
+   * 获取所有已注册的模式名
+   */
+  listModes(): string[] {
+    return Array.from(this._constructors.keys())
+  }
+
+  /**
+   * 获取所有别名
+   */
+  listAliases(): Record<string, string> {
+    const result: Record<string, string> = {}
+    for (const [alias, target] of this._aliases) {
+      result[alias] = target
+    }
+    return result
+  }
+
+  /**
+   * 取消注册
+   */
+  unregister(name: string): void {
+    this._constructors.delete(name)
+    this._aliases.delete(name)
+    const entry = this._modes.get(name)
+    if (entry) {
+      entry.instance.destroy()
+      this._modes.delete(name)
+    }
+  }
+
+  /**
+   * 清理所有模式
+   */
+  clear(): void {
+    for (const [, entry] of this._modes) {
+      entry.instance.destroy()
+    }
+    this._modes.clear()
+    this._constructors.clear()
+    this._aliases.clear()
+  }
+}
+
+/** 全局单例注册表 */
+export const modeRegistry = new ModeRegistry()

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -324,10 +324,11 @@
           <div class="msg-ai-main">
             <ActivityDisclosure
               default-open
-              lifecycle="working"
+              :lifecycle="liveActivityProjection.lifecycle"
               :step-count="executionDockRun?.status === 'running' ? 0 : liveActivityStepCount"
               :failure-count="liveActivityFailureCount"
               :phase-label="liveActivityPhaseLabel"
+              :purpose-code="liveActivityPurposeCode"
               :elapsed-label="streamTurnElapsed"
               :stale="streamActivityStale"
             >
@@ -3925,6 +3926,15 @@ const liveActivityProjection = computed(() =>
 )
 const liveActivityPhaseLabel = computed(() => {
   return String(t('chat.activity.lifecycle.working'))
+})
+/** 当前活动集群的 purpose code（活跃 cluster 为 purposeRunning.*），用于细化 orb 动画状态 */
+const liveActivityPurposeCode = computed<string | null>(() => {
+  const projection = liveActivityProjection.value
+  if (!projection.currentClusterKey) return null
+  const cluster = projection.activityClusters.find(
+    c => c.key === projection.currentClusterKey,
+  )
+  return cluster?.purpose.code ?? null
 })
 const liveCurrentPhaseCode = computed(() => [...liveActivityProjection.value.statusSteps]
   .reverse()


### PR DESCRIPTION
### 概述

由 `Jakubantalik/thinking-orbs` 灵感而来，为 OpenSquilla 的 Agent 活动状态指示器带来 9 种 Canvas 2D 动画（Vue 3 组件实现）。

> 本轮已按 review 意见收敛：范围先只落在聊天活动栏 28px 槽位验证；`LoadingSpinner` 全站替换与 `PendingQueue` 接入均已移出（后者见「后续计划」）。

### 本轮范围（收敛后）

- **唯一集成点**：`ActivityDisclosure.vue` live 头部 28px 槽位（`purpose` 驱动状态细化），stale 时保持原 CSS 脉冲点不挂 orb
- 不替换通用 `LoadingSpinner`；28px 辨识度若经验收，通用替换另开 PR 讨论

### 技术方案

- **组件化**：`ThinkingOrb.vue` 独立组件，Canvas 2D 渲染，零外部依赖；`engine/clock.ts` 全局共享时钟（多实例相位同步、空闲自动休眠、自适应帧率 60→30→15）；`registry.ts` 类模式注册表（懒加载 + 别名 + 可插拔）；`presets.ts` 状态→模式 + (state, size) 密度/速度线性插值
- **9 种动画模式**：orbits / globe / rubik / wave / web / braid / ribbon / ring / morph，多层渲染管线（background/main/highlight）
- **状态映射** `purposeToOrbState.ts`，优先级明确定义：
  1. `answering` → 恒为 `composing`（阶段级信号优先于工具级 purpose）
  2. `working` → purpose 细化（未知/缺失回退 `working`）；同时兼容 `chat.activity.purpose.*` 与活跃 cluster 实际下发的 `chat.activity.purposeRunning.*` 两套前缀
  3. 终态（settled/interrupted/failed）→ 确定性兜底 `working`（集成点仅 live 渲染，此为纯函数防御）
- **动画控制与降级**：
  - `prefers-reduced-motion` 实际生效：不接入共享时钟，仅绘制一帧代表相位静态画面；运行中系统设置切换即时生效；静态模式下 state/size 变化重绘对应帧
  - `visibilitychange` / IntersectionObserver：隐藏与离屏时摘掉时钟订阅（全部实例离屏后共享时钟自行休眠），回视口补一帧
  - 渲染错误：2D 上下文不可用 / 模式注册缺失 / 同一模式连续 3 帧异常 → `renderError` → canvas 卸载并 `emit('error')`，宿主回退原 CSS 脉冲点（视觉与旧版一致），不会永久空白
- **集成语义**：`ChatView.vue` 向活动栏透传当前 cluster 的 purpose code；流式气泡 `lifecycle` 改为跟随 projection 实际值（working/answering），answering 阶段由此得到 `composing` 丝带

### 动画状态映射

| lifecycle / purpose | 动画 | 描述 |
|---------|------|------|
| 任意 (answering) | composing | 丝带编织（优先于 purpose）|
| discover / search | searching | 地球仪扫描 |
| read / inspect | listening | 声波扩散 |
| change / create | solving | 魔方转动 |
| run | connecting | 轨道旋转 |
| recall | breathing | 呼吸光环 |
| use / 未知 / 缺失 | working | 星座连线 |

### 构建与包体（vite build 实测，基线 fc8cce1c）

- orb 代码随 ActivityDisclosure 进入 `ChatView` chunk：**761.08 kB → 782.53 kB**（raw +21.45 kB，**gzip +7.75 kB**，约 +3.5%）
- 首屏 `main` chunk **无变化**（2,096.94 kB / gzip 370.94 kB，两构建相同）——orb 不在首屏路径
- 多实例 CPU：全局单时钟（N 实例共享 1 条 rAF）+ 离屏/隐藏摘订阅 + 自适应降帧；28px 档密度 ≤0.5。未做跨机型火焰图，验收时可补

### 测试

- 新增 `purposeToOrbState.test.ts` 24 例（映射表、双前缀、优先级、全组合总覆盖、未知 purpose）
- 新增 `useOrbAnimation.test.ts` 7 例（上下文缺失、时钟进出、reduced-motion 静态帧/运行时切换/静态重绘、连续 3 异常升级降级）
- `ActivityDisclosure.test.ts` +2 例（happy-dom 下 canvas 不可用 → CSS 降级路径、stale 不挂 orb）；既有 24 例契约零改动
- 全量 `vitest run` **5653 例通过**；`vue-tsc`、`check:architecture`（含 motion/colors/radius/i18n 等 12 项守卫）、`vite build` 全部通过
- 浏览器验证：上轮 review 已本地预览确认（明暗主题、状态切换、详情展开）；本轮降级路径由单测覆盖

### 后续计划（不承诺时间）

- 28px 辨识度验收通过后再议通用 `LoadingSpinner` 替换与 `PendingQueue` 接入
- reduced-motion 的静态帧观感、模式过渡（cross-fade）等打磨

### 致谢

灵感来自 [`Jakubantalik/thinking-orbs`](https://github.com/Jakubantalik/thinking-orbs)