### PR TITLE
修复 ClawHub 社区技能安装失败:支持聚合源镜像技能与重复 slug 消歧

### DIFF
--- a/src/opensquilla/skills/hub/clawhub.py
+++ b/src/opensquilla/skills/hub/clawhub.py
@@ -2,14 +2,87 @@
 
 from __future__ import annotations
 
+import io
+import posixpath
+import zipfile
+
 import structlog
 
 from opensquilla.env import trust_env as _trust_env
-from opensquilla.skills.hub.source import SkillBundle, SkillMeta, SkillSource
+from opensquilla.skills.hub.source import (
+    SkillBundle,
+    SkillFetchError,
+    SkillMeta,
+    SkillSource,
+)
 
 log = structlog.get_logger(__name__)
 
 _DEFAULT_BASE_URL = "https://clawhub.ai"
+_GITHUB_ARCHIVE_URL = (
+    "https://github.com/{owner}/{repo}/archive/refs/heads/{branch}.zip"
+)
+
+
+def _extract_skill_zip(
+    content: bytes, preferred_name: str | None = None
+) -> dict[str, str | bytes] | None:
+    """Extract a skill directory from a ZIP archive.
+
+    Handles three layouts:
+    - SKILL.md at the archive root (clawhub native downloads);
+    - a single top-level wrapper directory (GitHub archive zips);
+    - a multi-skill collection where the skill lives under ``skills/<name>/``
+      (skills.sh repos mirrored on GitHub).
+
+    Returns a ``{relative_path: content}`` mapping rooted at the skill
+    directory, or ``None`` when no SKILL.md can be found.
+    """
+    try:
+        with zipfile.ZipFile(io.BytesIO(content)) as zf:
+            names = [n for n in zf.namelist() if not n.endswith("/")]
+            if not names:
+                return None
+
+            candidates = sorted(
+                (n for n in names if n.rsplit("/", 1)[-1] == "SKILL.md"),
+                key=lambda n: n.count("/"),
+            )
+            if not candidates:
+                return None
+
+            if preferred_name:
+                exact = [
+                    n
+                    for n in candidates
+                    if n.rsplit("/", 1)[0].rsplit("/", 1)[-1] == preferred_name
+                ]
+                if exact:
+                    candidates = exact
+
+            skill_md_path = candidates[0]
+            skill_root = (
+                skill_md_path.rsplit("/", 1)[0] if "/" in skill_md_path else ""
+            )
+
+            files: dict[str, str | bytes] = {}
+            for name in names:
+                rel = name
+                if skill_root:
+                    if not rel.startswith(skill_root + "/"):
+                        continue
+                    rel = rel[len(skill_root) + 1 :]
+                rel = posixpath.normpath(rel)
+                if rel.startswith("..") or rel.startswith("/"):
+                    continue
+                raw = zf.read(name)
+                try:
+                    files[rel] = raw.decode("utf-8")
+                except UnicodeDecodeError:
+                    files[rel] = raw
+            return files
+    except (zipfile.BadZipFile, OSError, RuntimeError):
+        return None
 
 
 class ClawHubSource(SkillSource):
@@ -33,6 +106,32 @@ class ClawHubSource(SkillSource):
             h["Authorization"] = f"Bearer {self._token}"
         return h
 
+    def _skill_meta(self, item: dict) -> SkillMeta:
+        """Build SkillMeta from a raw /api/v1/search item."""
+        identity = item.get("sourceIdentity") or {}
+        owner = identity.get("owner") or ""
+        repo = identity.get("repo") or ""
+        fallback_url = ""
+        if owner and repo:
+            fallback_url = _GITHUB_ARCHIVE_URL.format(
+                owner=owner, repo=repo, branch="main"
+            )
+        return SkillMeta(
+            name=item.get("displayName", item.get("name", item.get("slug", ""))),
+            description=item.get("summary", item.get("description", "")),
+            version=item.get("version", ""),
+            author=item.get("ownerHandle", ""),
+            source_id=self.source_id,
+            trust_level=self.trust_level,
+            identifier=item.get("slug", item.get("name", "")),
+            homepage=item.get("homepage", ""),
+            license=item.get("license", ""),
+            tags=item.get("tags", []),
+            owner_handle=item.get("ownerHandle", ""),
+            fallback_source=item.get("source", ""),
+            fallback_url=fallback_url,
+        )
+
     async def search(self, query: str, limit: int = 20) -> list[SkillMeta]:
         import httpx
 
@@ -55,114 +154,143 @@ class ClawHubSource(SkillSource):
 
         results = []
         for item in data if isinstance(data, list) else data.get("results", data.get("skills", [])):
-            results.append(
-                SkillMeta(
-                    name=item.get("displayName", item.get("name", item.get("slug", ""))),
-                    description=item.get("summary", item.get("description", "")),
-                    version=item.get("version", ""),
-                    author=item.get("author", ""),
-                    source_id=self.source_id,
-                    trust_level=self.trust_level,
-                    identifier=item.get("slug", item.get("name", "")),
-                    homepage=item.get("homepage", ""),
-                    license=item.get("license", ""),
-                    tags=item.get("tags", []),
-                )
-            )
+            results.append(self._skill_meta(item))
         return results[:limit]
 
-    async def fetch(self, identifier: str) -> SkillBundle | None:
-        import io
-        import zipfile
+    async def _resolve(self, identifier: str) -> SkillMeta | None:
+        """Look up a skill listing by slug (registry search API)."""
+        results = await self.search(identifier, limit=20)
+        for meta in results:
+            if meta.identifier == identifier:
+                return meta
+        return None
 
+    async def _download(self, slug: str, owner_handle: str | None = None) -> bytes | None:
+        """GET /api/v1/download. Returns raw bytes, None on 404/other failure."""
         import httpx
 
-        url = f"{self._base_url}/api/v1/download"
+        params: dict[str, str] = {"slug": slug}
+        if owner_handle:
+            params["ownerHandle"] = owner_handle
         try:
             async with httpx.AsyncClient(timeout=30, trust_env=_trust_env()) as client:
-                resp = await client.get(url, params={"slug": identifier}, headers=self._headers())
-                resp.raise_for_status()
-        except Exception as exc:
-            log.warning("clawhub.fetch_failed", identifier=identifier, error=str(exc))
-            return None
-
-        # Detect error responses disguised as 200 (e.g. rate limiting)
-        if (
-            len(resp.content) < 50
-            and not resp.content.startswith(b"PK")
-            and not resp.content.startswith(b"---")
-        ):
-            text = resp.text.strip()
-            if (
-                "rate limit" in text.lower()
-                or "error" in text.lower()
-                or "not found" in text.lower()
-            ):
-                log.warning("clawhub.fetch_error_response", identifier=identifier, body=text[:100])
-                return None
-
-        files: dict[str, str | bytes] = {}
-        try:
-            with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
-                import posixpath
-
-                for name in zf.namelist():
-                    if name.endswith("/"):
-                        continue
-                    parts = name.split("/", 1)
-                    rel = parts[1] if len(parts) > 1 else parts[0]
-                    rel = posixpath.normpath(rel)
-                    if rel.startswith("..") or rel.startswith("/"):
-                        continue
-                    try:
-                        raw = zf.read(name)
-                        if rel == "SKILL.md":
-                            files[rel] = raw.decode("utf-8")
-                        else:
-                            try:
-                                files[rel] = raw.decode("utf-8")
-                            except UnicodeDecodeError:
-                                files[rel] = raw
-                    except UnicodeDecodeError:
-                        log.warning("clawhub.fetch_bad_skill_encoding", identifier=identifier)
-                        return None
-        except zipfile.BadZipFile:
-            # Might be raw SKILL.md content — validate it has frontmatter
-            if resp.text.strip().startswith("---"):
-                files["SKILL.md"] = resp.text
-            else:
-                log.warning(
-                    "clawhub.fetch_invalid_content", identifier=identifier, size=len(resp.content)
+                resp = await client.get(
+                    f"{self._base_url}/api/v1/download",
+                    params=params,
+                    headers=self._headers(),
                 )
-                return None
-
-        if "SKILL.md" not in files:
+            if resp.status_code == 200:
+                return resp.content
+            if resp.status_code == 429:
+                raise SkillFetchError(
+                    "ClawHub is rate-limited right now. Try again later."
+                )
+            log.warning(
+                "clawhub.download_failed",
+                slug=slug,
+                owner_handle=owner_handle,
+                status=resp.status_code,
+                body=resp.text[:100],
+            )
+            return None
+        except SkillFetchError:
+            raise
+        except Exception as exc:
+            log.warning("clawhub.download_error", slug=slug, error=str(exc))
             return None
 
-        return SkillBundle(name=identifier, files=files)
-
-    async def inspect(self, identifier: str) -> SkillMeta | None:
+    async def _fetch_fallback_zip(
+        self, fallback_url: str, identifier: str, fallback_source: str
+    ) -> dict[str, str | bytes] | None:
+        """Download an upstream archive zip (e.g. GitHub) for aggregated entries."""
         import httpx
 
-        url = f"{self._base_url}/api/v1/skills/{identifier}"
-        try:
-            async with httpx.AsyncClient(timeout=10, trust_env=_trust_env()) as client:
-                resp = await client.get(url, headers=self._headers())
-                resp.raise_for_status()
-                item = resp.json()
-        except Exception as exc:
-            log.warning("clawhub.inspect_failed", identifier=identifier, error=str(exc))
-            return None
+        urls = [fallback_url]
+        if fallback_url.endswith("/main.zip"):
+            urls.append(fallback_url.replace("/main.zip", "/master.zip"))
 
-        return SkillMeta(
-            name=item.get("name", item.get("slug", identifier)),
-            description=item.get("description", ""),
-            version=item.get("version", ""),
-            author=item.get("author", ""),
-            source_id=self.source_id,
-            trust_level=self.trust_level,
+        for url in urls:
+            try:
+                async with httpx.AsyncClient(timeout=30, trust_env=_trust_env()) as client:
+                    resp = await client.get(url, follow_redirects=True)
+                if resp.status_code != 200:
+                    continue
+                files = _extract_skill_zip(resp.content, preferred_name=identifier)
+                if files is not None:
+                    return files
+            except Exception as exc:
+                log.warning(
+                    "clawhub.fallback_fetch_error",
+                    identifier=identifier,
+                    url=url,
+                    error=str(exc),
+                )
+        log.warning(
+            "clawhub.fallback_fetch_failed",
             identifier=identifier,
-            homepage=item.get("homepage", ""),
-            license=item.get("license", ""),
-            tags=item.get("tags", []),
+            fallback_source=fallback_source,
         )
+        return None
+
+    async def fetch(self, identifier: str) -> SkillBundle | None:
+        """Download a skill, resolving duplicate slugs and aggregated entries.
+
+        Strategy:
+        1. Try ``/api/v1/download?slug=<identifier>`` (native clawhub entries).
+        2. When that fails, resolve the listing via the search API:
+           - aggregated entries (skills.sh, ...) are not served by the
+             download endpoint at all, so their artifact is pulled from the
+             upstream archive URL captured during search (GitHub zip);
+           - duplicate slugs are retried with the publisher ``ownerHandle``.
+        """
+        # 1. Native download path.
+        content = await self._download(identifier)
+        if content is not None:
+            files = _extract_skill_zip(content, preferred_name=identifier)
+            if files is None:
+                raise SkillFetchError(
+                    f"Could not parse the ClawHub archive for '{identifier}'."
+                )
+            return SkillBundle(name=identifier, files=files)
+
+        # 2. Resolve the listing to learn the publisher / upstream source.
+        meta = await self._resolve(identifier)
+
+        # 2a. Aggregated entries (skills.sh, ...) are not served by /download:
+        #     pull the artifact from the upstream archive URL instead.
+        if meta is not None and meta.fallback_url:
+            files = await self._fetch_fallback_zip(
+                meta.fallback_url, identifier, meta.fallback_source
+            )
+            if files is not None:
+                return SkillBundle(name=identifier, files=files)
+            raise SkillFetchError(
+                f"Skill '{identifier}' comes from {meta.fallback_source or 'an upstream source'}, "
+                "but its archive could not be downloaded."
+            )
+
+        # 2b. Ambiguous slug: retry with the publisher handle.
+        if meta is not None and meta.owner_handle:
+            content = await self._download(identifier, meta.owner_handle)
+            if content is not None:
+                files = _extract_skill_zip(content, preferred_name=identifier)
+                if files is None:
+                    raise SkillFetchError(
+                        f"Could not parse the ClawHub archive for '{identifier}'."
+                    )
+                return SkillBundle(name=identifier, files=files)
+
+        if meta is not None:
+            raise SkillFetchError(
+                f"ClawHub could not serve '{identifier}'. It may have been removed "
+                "or its publisher disabled downloads."
+            )
+
+        raise SkillFetchError(
+            f"Skill '{identifier}' was not found on ClawHub. It may have been "
+            "removed from the community registry."
+        )
+
+    async def inspect(self, identifier: str) -> SkillMeta | None:
+        """Get metadata for a skill without downloading."""
+        return await self._resolve(identifier)

--- a/src/opensquilla/skills/hub/installer.py
+++ b/src/opensquilla/skills/hub/installer.py
@@ -14,6 +14,7 @@ from opensquilla.paths import default_opensquilla_home
 from opensquilla.skills.hub.lockfile import LockEntry, Lockfile, compute_sha256
 from opensquilla.skills.hub.router import SourceRouter
 from opensquilla.skills.hub.scanner import ScanResult, scan_skill_bundle
+from opensquilla.skills.hub.source import SkillFetchError
 from opensquilla.skills.paths import default_managed_skills_dir
 
 log = structlog.get_logger(__name__)
@@ -78,7 +79,10 @@ class SkillInstaller:
     ) -> InstallResult:
         """Full install lifecycle: fetch → quarantine → scan → install → lockfile."""
         # 1. Fetch
-        bundle = await self._router.fetch(identifier, source_id)
+        try:
+            bundle = await self._router.fetch(identifier, source_id)
+        except SkillFetchError as exc:
+            return InstallResult(success=False, name=identifier, message=exc.reason)
         if bundle is None:
             return InstallResult(
                 success=False,

--- a/src/opensquilla/skills/hub/source.py
+++ b/src/opensquilla/skills/hub/source.py
@@ -21,6 +21,28 @@ class SkillMeta:
     license: str = ""
     tags: list[str] = field(default_factory=list)
     platforms: list[str] = field(default_factory=list)
+    # Publisher handle; disambiguates duplicate slugs on registries that
+    # allow the same slug under multiple publishers (e.g. clawhub).
+    owner_handle: str = ""
+    # For aggregated listings (e.g. clawhub entries mirrored from skills.sh),
+    # the registry download endpoint may not serve the artifact at all.
+    # fallback_source names the upstream registry and fallback_url points at
+    # a directly downloadable artifact (e.g. a GitHub archive zip).
+    fallback_source: str = ""
+    fallback_url: str = ""
+
+
+class SkillFetchError(Exception):
+    """Raised by a SkillSource when a fetch fails for a known, actionable reason.
+
+    The installer surfaces ``reason`` to the user so a 404, an ambiguous slug,
+    or a rate limit is not hidden behind one generic message.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
 
 
 @dataclass

--- a/tests/test_skills_hub_clawhub.py
+++ b/tests/test_skills_hub_clawhub.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import io
+import zipfile
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from opensquilla.skills.hub.clawhub import ClawHubSource, _extract_skill_zip
+from opensquilla.skills.hub.installer import SkillInstaller
+from opensquilla.skills.hub.router import SourceRouter
+from opensquilla.skills.hub.source import SkillFetchError
+
+
+def _zip_bytes(entries: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _skill_zip(slug: str = "foo", layout: str = "root") -> bytes:
+    if layout == "root":
+        return _zip_bytes(
+            {
+                "SKILL.md": b"---\nname: foo\n---\n# Foo\n",
+                "scripts/run.py": b"print('foo')\n",
+            }
+        )
+    if layout == "skills-sh":
+        return _zip_bytes(
+            {
+                f"{slug}-main/skills/{slug}/SKILL.md": b"---\nname: foo\n---\n# Foo\n",
+                f"{slug}-main/skills/{slug}/notes.md": b"details\n",
+                f"{slug}-main/skills/other/SKILL.md": b"---\nname: other\n---\n",
+                f"{slug}-main/README.md": b"repo readme\n",
+            }
+        )
+    raise AssertionError(f"unknown layout: {layout}")
+
+
+def _search_item(
+    slug: str,
+    owner_handle: str = "",
+    source: str = "clawhub",
+    identity_owner: str = "",
+    identity_repo: str = "",
+) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "displayName": slug,
+        "slug": slug,
+        "ownerHandle": owner_handle,
+        "source": source,
+        "summary": f"Summary of {slug}",
+    }
+    if identity_owner and identity_repo:
+        item["sourceIdentity"] = {"owner": identity_owner, "repo": identity_repo}
+    return item
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        status_code: int = 200,
+        content: bytes = b"",
+        json_data: Any = None,
+        text: str = "",
+    ) -> None:
+        self.status_code = status_code
+        self.content = content
+        self._json_data = json_data
+        self.text = text if text else content.decode("utf-8", errors="replace")
+
+    def json(self) -> Any:
+        return self._json_data
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class _FakeClient:
+    """Routes GET requests by URL and query params to canned responses.
+
+    Routes live on the class (like the existing hub test doubles) so the
+    adapter's own ``httpx.AsyncClient(...)`` construction picks them up.
+    """
+
+    routes: list[tuple[Callable, int, Any]] = []
+    requests: list[tuple[str, dict[str, str]]] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> _FakeClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def get(
+        self, url: str, params: dict[str, str] | None = None, **kwargs: Any
+    ) -> _FakeResponse:
+        params = params or {}
+        self.requests.append((url, dict(params)))
+        for match, status, payload in self.routes:
+            if match(url, params):
+                if isinstance(payload, bytes):
+                    return _FakeResponse(status, content=payload)
+                return _FakeResponse(status, json_data=payload)
+        raise AssertionError(f"unhandled request: {url} params={params}")
+
+
+def _download_route(
+    slug: str, *, owner_handle: str | None = None, status: int = 200, payload: Any = b""
+) -> tuple[Callable, int, Any]:
+    def match(url: str, params: dict[str, str]) -> bool:
+        if not url.endswith("/api/v1/download"):
+            return False
+        if params.get("slug") != slug:
+            return False
+        if owner_handle is not None:
+            return params.get("ownerHandle") == owner_handle
+        return "ownerHandle" not in params
+    return match, status, payload
+
+
+def _search_route(
+    query: str, items: list[dict[str, Any]], status: int = 200
+) -> tuple[Callable, int, Any]:
+    def match(url: str, params: dict[str, str]) -> bool:
+        return url.endswith("/api/v1/search") and params.get("q") == query
+    return match, status, {"results": items}
+
+
+def _github_route(
+    repo_full: str, *, branch: str, status: int = 200, payload: Any = b""
+) -> tuple[Callable, int, Any]:
+    url = f"https://github.com/{repo_full}/archive/refs/heads/{branch}.zip"
+
+    def match(url_: str, params: dict[str, str]) -> bool:
+        return url_ == url
+    return match, status, payload
+
+
+@pytest.mark.asyncio
+async def test_fetch_native_zip_root_skill_md(monkeypatch) -> None:
+    import httpx
+
+    _FakeClient.routes = [
+        _download_route("foo", status=200, payload=_skill_zip("foo", layout="root")),
+    ]
+    _FakeClient.requests = []
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+
+    bundle = await ClawHubSource().fetch("foo")
+
+    assert bundle is not None
+    assert bundle.name == "foo"
+    assert set(bundle.files) == {"SKILL.md", "scripts/run.py"}
+    assert bundle.files["scripts/run.py"] == "print('foo')\n"
+    # exactly one download attempt, no ownerHandle
+    assert len([r for r in _FakeClient.requests if "download" in r[0]]) == 1
+    assert _FakeClient.requests[0][1] == {"slug": "foo"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_ambiguous_slug_resolves_owner_handle(monkeypatch) -> None:
+    import httpx
+
+    _FakeClient.routes = [
+        _download_route(
+            "agent",
+            status=409,
+            payload=b'Ambiguous skill slug "agent". Multiple publishers use this slug.',
+        ),
+        _search_route("agent", [_search_item("agent", owner_handle="ivangdavila")]),
+        _download_route(
+            "agent",
+            owner_handle="ivangdavila",
+            status=200,
+            payload=_skill_zip("agent", layout="root"),
+        ),
+    ]
+    _FakeClient.requests = []
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+
+    bundle = await ClawHubSource().fetch("agent")
+
+    assert bundle is not None
+    assert bundle.name == "agent"
+    downloads = [r for r in _FakeClient.requests if "download" in r[0]]
+    assert len(downloads) == 2
+    assert downloads[1][1] == {"slug": "agent", "ownerHandle": "ivangdavila"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_skills_sh_entry_falls_back_to_github_archive(monkeypatch) -> None:
+    import httpx
+
+    slug = "make-interfaces-feel-better"
+    _FakeClient.routes = [
+        _download_route(slug, status=404, payload=b"Skill not found"),
+        _search_route(
+            slug,
+            [
+                _search_item(
+                    slug,
+                    owner_handle="jakubkrehel",
+                    source="skills-sh",
+                    identity_owner="jakubkrehel",
+                    identity_repo=slug,
+                )
+            ],
+        ),
+        _github_route("jakubkrehel/" + slug, branch="main", status=404, payload=b""),
+        _github_route(
+            "jakubkrehel/" + slug,
+            branch="master",
+            status=200,
+            payload=_skill_zip(slug, layout="skills-sh"),
+        ),
+    ]
+    _FakeClient.requests = []
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+
+    bundle = await ClawHubSource().fetch(slug)
+
+    assert bundle is not None
+    assert bundle.name == slug
+    # only the skill directory contents, with the wrapper and sibling skills
+    # stripped away.
+    assert set(bundle.files) == {"SKILL.md", "notes.md"}
+    github_hits = [r for r in _FakeClient.requests if "github.com" in r[0]]
+    assert len(github_hits) == 2
+    assert github_hits[0][0].endswith("/main.zip")
+    assert github_hits[1][0].endswith("/master.zip")
+
+
+@pytest.mark.asyncio
+async def test_fetch_rate_limited_raises_actionable_error(monkeypatch) -> None:
+    import httpx
+
+    _FakeClient.routes = [
+        _download_route("foo", status=429, payload=b"rate limit exceeded"),
+    ]
+    _FakeClient.requests = []
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+
+    with pytest.raises(SkillFetchError, match="rate-limited"):
+        await ClawHubSource().fetch("foo")
+
+
+@pytest.mark.asyncio
+async def test_fetch_not_found_without_fallback_raises(monkeypatch) -> None:
+    import httpx
+
+    _FakeClient.routes = [
+        _download_route("ghost", status=404, payload=b"Skill not found"),
+        _search_route("ghost", []),
+    ]
+    _FakeClient.requests = []
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+
+    with pytest.raises(SkillFetchError, match="was not found"):
+        await ClawHubSource().fetch("ghost")
+
+
+@pytest.mark.asyncio
+async def test_installer_surfaces_fetch_error_reason(monkeypatch, tmp_path) -> None:
+    import httpx
+
+    _FakeClient.routes = [
+        _download_route("foo", status=429, payload=b"rate limit exceeded"),
+    ]
+    _FakeClient.requests = []
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+
+    installer = SkillInstaller(
+        router=SourceRouter([ClawHubSource()]),
+        managed_dir=tmp_path / "managed",
+        quarantine_dir=tmp_path / "quarantine",
+        lockfile_path=tmp_path / "lock.json",
+    )
+
+    result = await installer.install("foo", "clawhub")
+
+    assert result.success is False
+    assert "rate-limited" in result.message
+
+
+def test_extract_skill_zip_prefers_matching_subdirectory() -> None:
+    slug = "target"
+    content = _skill_zip(slug, layout="skills-sh")
+    files = _extract_skill_zip(content, preferred_name=slug)
+    assert files is not None
+    assert set(files) == {"SKILL.md", "notes.md"}
+
+
+def test_extract_skill_zip_rejects_zip_slip_paths() -> None:
+    content = _zip_bytes(
+        {
+            "SKILL.md": b"---\nname: x\n---\n",
+            "../evil.txt": b"nope",
+        }
+    )
+    files = _extract_skill_zip(content, preferred_name=None)
+    assert files is not None
+    assert "evil.txt" not in files
+    assert "../evil.txt" not in files


### PR DESCRIPTION
ClawHub 的搜索结果混合了原生条目与从其他注册表(如 skills.sh)镜像来的聚合条目。
下载端点只服务原生条目,因此安装镜像技能时总是失败,并报出笼统的
"may not exist or the source is rate-limited" 错误;重复 slug 返回 409 时
也没有任何消歧尝试。

- SkillMeta 现在携带从搜索结果中捕获的 owner_handle 与
  fallback_source/fallback_url。
- fetch() 对歧义 slug 用 ownerHandle 重试,聚合条目则从其上游
  GitHub archive zip 拉取(main → master 探测)。
- ZIP 解包支持包装目录与多技能集合(skills/<name>/ 布局),
  不再要求 SKILL.md 必须位于压缩包根目录。
- SkillFetchError 携带可行动的原因;installer 将其透传给用户,
  取代千篇一律的笼统错误消息。
- 新增测试覆盖:原生、歧义、聚合、限流、技能不存在等路径。

## Scope

Scope boundary:
修复 ClawHub 社区技能源,使搜索结果中可安装的技能真正能装上:
- 重复 slug 带 ownerHandle 重试(处理 409 歧义)
- clawhub 下载端点 404 时,聚合条目(skills.sh 镜像)从上游
  GitHub archive zip 拉取
- 技能 ZIP 解包支持包装目录与多技能目录布局
- 通过 SkillFetchError 把可行动的失败原因透传给用户,
  取代原先千篇一律的笼统报错

Non-goals:
不改 Web UI;不改 GitHubSource 及其他技能源;不改技能扫描器
与 lockfile 格式。

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1003

If None, reason: N/A

## Release Note

Release note: 修复 ClawHub 社区技能安装失败——来自 skills.sh 等
镜像源的技能现在可正常安装;重复 slug 自动消歧;安装错误会
报告真实原因(不存在 / 歧义 / 限流)。

## Tests

Ruff:
全部通过(src/opensquilla/skills/hub/ + 新增测试)

Pytest:
19 passed — tests/test_skills_hub_clawhub.py(新增 8 个)+
test_skills_hub_github.py + test_skills_hub_installer_security.py;
6 passed — test_skills_community_copy_contract.py +
test_skills_provenance_contract.py

Build:
N/A — 纯 Python 改动,无需 Web UI/桌面构建

Regression tests: added

Notes:
新增测试 mock 了 httpx.AsyncClient(与既有 hub 测试同款模式);
无网络访问、无凭据、fork 安全。

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.