### PR TITLE
Disable message edit button while the assistant is streaming

### DIFF
--- a/opensquilla-webui/src/components/chat/ChatMessageList.vue
+++ b/opensquilla-webui/src/components/chat/ChatMessageList.vue
@@ -19,6 +19,7 @@
       :copy-message="copyMessage"
       :download-attachment="downloadAttachment"
       :show-turn-outcome="isTurnTip(index)"
+      :is-streaming="isStreaming"
       @edit="$emit('editMessage', $event)"
       @toggle-share="$emit('toggleShareMessage', $event)"
     />
@@ -118,6 +119,7 @@ const props = defineProps<{
   forkBusy?: boolean
   planActionPending?: PlanCardAction | null
   planActionsDisabled?: boolean
+  isStreaming?: boolean
 }>()
 
 defineEmits<{

--- a/opensquilla-webui/src/components/chat/UserMessage.edit-streaming.test.ts
+++ b/opensquilla-webui/src/components/chat/UserMessage.edit-streaming.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, nextTick } from 'vue'
+import i18n from '@/i18n'
+import type { ChatRenderedMessage } from '@/types/chat'
+import UserMessage from './UserMessage.vue'
+
+const EDIT_LABEL = 'Edit'
+const EDIT_STREAMING_LABEL = 'Wait for the current reply to finish before editing'
+
+async function renderUserMessage(isStreaming: boolean) {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const message: ChatRenderedMessage = {
+    id: 'edit-1',
+    role: 'user',
+    displayRole: 'user',
+    roleLabel: 'You',
+    text: 'hello',
+    timeStr: '',
+    showHeader: false,
+  }
+  const app = createApp(UserMessage, {
+    message,
+    shareMode: false,
+    shareSelected: false,
+    shareMessageId: message.id,
+    stripTimePrefix: (value: string) => value,
+    copyMessage: async () => true,
+    downloadAttachment: async () => true,
+    isStreaming,
+  })
+  app.use(i18n)
+  app.mount(host)
+  await nextTick()
+  return { app, host }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  i18n.global.locale.value = 'en'
+})
+
+describe('UserMessage edit action', () => {
+  it('disables the edit button while the assistant is streaming', async () => {
+    const { app, host } = await renderUserMessage(true)
+
+    const editBtn = host.querySelector<HTMLButtonElement>(
+      `button[aria-label="${EDIT_STREAMING_LABEL}"]`,
+    )
+    expect(editBtn).not.toBeNull()
+    expect(editBtn?.disabled).toBe(true)
+    expect(editBtn?.classList.contains('msg-action--disabled')).toBe(true)
+    expect(editBtn?.title).toBe(EDIT_STREAMING_LABEL)
+    app.unmount()
+  })
+
+  it('keeps the edit button enabled when idle', async () => {
+    const { app, host } = await renderUserMessage(false)
+
+    const editBtn = host.querySelector<HTMLButtonElement>(
+      `button[aria-label="${EDIT_LABEL}"]`,
+    )
+    expect(editBtn).not.toBeNull()
+    expect(editBtn?.disabled).toBe(false)
+    expect(editBtn?.title).toBe(EDIT_LABEL)
+    app.unmount()
+  })
+})

--- a/opensquilla-webui/src/components/chat/UserMessage.vue
+++ b/opensquilla-webui/src/components/chat/UserMessage.vue
@@ -94,7 +94,15 @@
         <Icon :name="copyIconName" :size="12" />
       </button>
       <span class="msg-copy-live" aria-live="polite">{{ copyLiveText }}</span>
-      <button type="button" class="msg-action" :title="t('chat.edit')" :aria-label="t('chat.edit')" @click="$emit('edit', message)">
+      <button
+        type="button"
+        class="msg-action"
+        :class="{ 'msg-action--disabled': isStreaming }"
+        :title="isStreaming ? t('chat.pending.editWhileStreaming') : t('chat.edit')"
+        :aria-label="isStreaming ? t('chat.pending.editWhileStreaming') : t('chat.edit')"
+        :disabled="isStreaming"
+        @click="$emit('edit', message)"
+      >
         <Icon name="edit" :size="12" />
       </button>
       <time v-if="timeIso" class="msg-time" :datetime="timeIso" :title="timeFull">
@@ -128,6 +136,7 @@ const props = defineProps<{
   copyMessage: (message: ChatRenderedMessage) => Promise<boolean>
   downloadAttachment: (attachment: DisplayAttachment) => Promise<boolean>
   showTurnOutcome?: boolean
+  isStreaming?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -454,6 +463,19 @@ function attachmentMeta(attachment: DisplayAttachment): string {
 .msg-action:hover {
   color: var(--text-muted);
   background: var(--bg-hover);
+}
+
+.msg-action:disabled,
+.msg-action.msg-action--disabled {
+  cursor: not-allowed;
+  color: var(--text-dim);
+  opacity: 0.45;
+}
+
+.msg-action:disabled:hover,
+.msg-action.msg-action--disabled:hover {
+  color: var(--text-dim);
+  background: none;
 }
 
 .msg-action.msg-action--ok,

--- a/opensquilla-webui/src/composables/chat/useChatMessageActions.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatMessageActions.test.ts
@@ -147,6 +147,30 @@ describe('useChatMessageActions branching edits', () => {
     expect(options.notifyMessagePending).toHaveBeenCalledOnce()
   })
 
+  it('blocks edit while streaming with visible feedback instead of a silent no-op', () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', text: 'A', ts: null, messageId: 'msg-A' },
+    ]
+    const { api, options, pendingForkBeforeMessageId } = makeOptions(messages)
+    options.isStreaming.value = true
+    const notifyEditBlocked = vi.fn()
+    options.notifyEditBlocked = notifyEditBlocked
+
+    api.editMessage(renderedMessage({
+      role: 'user',
+      displayRole: 'user',
+      sourceIndex: 0,
+      messageId: 'msg-A',
+      text: 'A',
+    }))
+
+    expect(options.messages.value.map(message => message.text)).toEqual(['A'])
+    expect(options.inputText.value).toBe('')
+    expect(pendingForkBeforeMessageId.value).toBeNull()
+    expect(options.focusComposer).not.toHaveBeenCalled()
+    expect(notifyEditBlocked).toHaveBeenCalledOnce()
+  })
+
   it('does not regenerate as a parent send when the durable fork id is missing', async () => {
     const messages: ChatMessage[] = [
       { role: 'user', text: 'still saving', ts: null, clientId: 'client-only' },

--- a/opensquilla-webui/src/composables/chat/useChatMessageActions.ts
+++ b/opensquilla-webui/src/composables/chat/useChatMessageActions.ts
@@ -27,6 +27,12 @@ export interface UseChatMessageActionsOptions {
    * only trace of the refusal would be a console warning.
    */
   notifyMessagePending?: () => void
+  /**
+   * User-visible feedback when edit is clicked while the assistant is still
+   * streaming. The edit button is disabled in that state, but other entry
+   * points (keyboard, future surfaces) must not fail silently either.
+   */
+  notifyEditBlocked?: () => void
 }
 
 export function useChatMessageActions(options: UseChatMessageActionsOptions) {
@@ -134,6 +140,7 @@ export function useChatMessageActions(options: UseChatMessageActionsOptions) {
   function editMessage(message: ChatRenderedMessage) {
     if (options.isStreaming.value) {
       console.warn('Wait for the current response to finish')
+      options.notifyEditBlocked?.()
       return
     }
     const msgIndex = sourceMessageIndex(message)

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -3535,6 +3535,7 @@
       "queueHint": "Warteschlangenmodus: Diese Nachrichten werden der Reihe nach automatisch gesendet, wenn die aktuelle Antwort abgeschlossen ist",
       "clearAll": "Alle löschen",
       "editMessage": "Nachricht bearbeiten",
+      "editWhileStreaming": "Warten Sie, bis die aktuelle Antwort fertig ist, bevor Sie bearbeiten",
       "attachmentNeedsAttention": "Anhang prüfen",
       "fixAttachmentBeforeSteer": "Bearbeite diese Nachricht und wiederhole den fehlgeschlagenen Anhang oder entferne ihn, bevor du sendest",
       "clearQueue": "Warteschlange leeren",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -3586,6 +3586,7 @@
       "queueHint": "Queue mode: these messages auto-send in order when the current response finishes",
       "clearAll": "Clear all",
       "editMessage": "Edit message",
+      "editWhileStreaming": "Wait for the current reply to finish before editing",
       "attachmentNeedsAttention": "Needs attention",
       "fixAttachmentBeforeSteer": "Edit this message and retry or remove the failed attachment before sending",
       "clearQueue": "Clear queue",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -3535,6 +3535,7 @@
       "queueHint": "Modo cola: estos mensajes se envían automáticamente en orden cuando termina la respuesta actual",
       "clearAll": "Borrar todo",
       "editMessage": "Editar mensaje",
+      "editWhileStreaming": "Espera a que termine la respuesta actual antes de editar",
       "attachmentNeedsAttention": "Revisar adjunto",
       "fixAttachmentBeforeSteer": "Edita este mensaje y vuelve a intentar o elimina el adjunto fallido antes de enviarlo",
       "clearQueue": "Vaciar cola",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -3535,6 +3535,7 @@
       "queueHint": "Mode file d'attente : ces messages s'envoient automatiquement dans l'ordre à la fin de la réponse actuelle",
       "clearAll": "Tout effacer",
       "editMessage": "Modifier le message",
+      "editWhileStreaming": "Attendez la fin de la réponse en cours avant de modifier",
       "attachmentNeedsAttention": "Pièce jointe à vérifier",
       "fixAttachmentBeforeSteer": "Modifiez ce message, puis réessayez ou supprimez la pièce jointe en échec avant l'envoi",
       "clearQueue": "Vider la file",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -3535,6 +3535,7 @@
       "queueHint": "キューモード: これらのメッセージは現在の応答が完了すると順番に自動送信されます",
       "clearAll": "すべてクリア",
       "editMessage": "メッセージを編集",
+      "editWhileStreaming": "現在の返信が終わってから編集してください",
       "attachmentNeedsAttention": "添付を確認",
       "fixAttachmentBeforeSteer": "このメッセージを編集し、失敗した添付を再試行または削除してから送信してください",
       "clearQueue": "キューをクリア",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -3586,6 +3586,7 @@
       "queueHint": "排队模式：这些消息会在当前回复结束后按顺序自动发送",
       "clearAll": "全部清除",
       "editMessage": "编辑消息",
+      "editWhileStreaming": "等待当前回复完成后再编辑",
       "attachmentNeedsAttention": "附件需处理",
       "fixAttachmentBeforeSteer": "请先编辑这条消息，重试或移除失败的附件后再发送",
       "clearQueue": "清空队列",

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -150,6 +150,7 @@
           :fork-busy="forkInFlight"
           :plan-action-pending="planCardPendingAction"
           :plan-actions-disabled="planActionsDisabled"
+          :is-streaming="isStreaming"
           @fork-conversation="forkConversation"
           @edit-message="editMessage"
           @regenerate-message="regenerateMessage"
@@ -1538,6 +1539,7 @@ const chatMessageActions = useChatMessageActions({
     }
   },
   notifyMessagePending: () => pushToast(t('chat.toast.messageStillSaving'), { tone: 'info' }),
+  notifyEditBlocked: () => pushToast(t('chat.pending.editWhileStreaming'), { tone: 'info' }),
 })
 const {
   copyMessage,


### PR DESCRIPTION
助手流式输出期间点击用户消息的"编辑"按钮时,界面无任何反应——
只有控制台警告 "Wait for the current response to finish"。编辑动作
会截断本地历史并把草稿写回输入框,与进行中的回复冲突,因此流式期间
应明确禁用并给出提示。

- UserMessage 新增 isStreaming prop,流式期间禁用编辑按钮,
  悬停提示"等待当前回复完成后再编辑",并加灰显示;
- ChatMessageList 与 ChatView 将 isStreaming 透传给 UserMessage;
- useChatMessageActions.editMessage 保留流式守卫作为兜底,
  并新增 notifyEditBlocked 回调,非按钮入口也会弹出 toast
  而非静默失败;
- 新增 i18n key chat.pending.editWhileStreaming(6 种语言);
- 新增测试:按钮流式禁用/空闲可用 + composable 流式守卫反馈。

## Scope

Scope boundary:
仅修复聊天消息"编辑"按钮在流式输出期间的静默失效问题:
- UserMessage / ChatMessageList / ChatView 传递 isStreaming
- 编辑按钮流式期间禁用 + 提示文案 + 灰化样式
- editMessage 流式分支增加用户可见反馈(toast)

Non-goals:
不改"重新生成"按钮(regenerate)的既有行为;
不改后端;不改其他消息操作(复制、分享、附件)。

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1005 

If None, reason: N/A

## Release Note

Release note: 修复流式回复期间点击消息"编辑"按钮无反应的问题;
编辑按钮在回复进行中禁用并提示,其他入口触发时弹出提示。

## Tests

Ruff:
N/A — 本次改动为前端(TypeScript/Vue),无 Python 改动

Pytest:
4 passed, 1 skipped — tests/unit/test_env_loading.py + test_ui.py

Build:
vue-tsc --noEmit 0 错误;npm run build 全绿(架构检查 +
theme/runtime bundle guard + 产物校验 195 文件)

Regression tests: added

Notes:
新增 3 个测试:UserMessage 编辑按钮流式禁用、空闲可用
(UserMessage.edit-streaming.test.ts),以及 editMessage 流式守卫
触发 notifyEditBlocked 且不改状态(useChatMessageActions.test.ts);
vitest 16 passed(2 个测试文件)。

The default test path remains offline, deterministic, credential-free, and safe for forks.
默认测试路径保持离线、确定性、无需凭据,且对 fork 安全。

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note:
贡献者无需提供密钥或运行需要凭据的 live check。
维护者可以为 provider、browser、gateway、channel 或 release 冒烟覆盖
运行 `Live Release E2E`。

## Safety

密钥、仅限本地的工件、私有提示词/对话记录、渠道标识符、AI 会话工件、
非公开 fixture 以及 tests/_private/ 的内容一律不得提交。

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] 链接指向仓库内现有文件或稳定的外部页面。
- [x] 代码围栏与 Markdown 表格在 GitHub 上渲染正确。
- [x] 示例避免真实密钥、本地私有路径与私有对话记录。