### PR TITLE
Round the skill group header bar on the Skills page

### DIFF
--- a/opensquilla-webui/src/views/SkillsView.vue
+++ b/opensquilla-webui/src/views/SkillsView.vue
@@ -1279,6 +1279,7 @@ async function uninstallSkillAndClose(name: string) {
 .sk-group--skills > .sk-group__head {
   border-bottom: 0;
   padding: 14px 2px 12px;
+  border-radius: var(--radius-lg);
 }
 .sk-group--skills > .sk-grid {
   padding: 16px 0 18px;


### PR DESCRIPTION
技能页"已安装"区域的分组(元技能/内置/托管)使用 sk-group--skills
变体,其设计意图是"开放分节,不做卡片套卡片"——容器被清零为
透明背景、无边框、无圆角。这导致白色标题栏(sk-group__head)
以直角长条渲染,与下方圆角技能卡片风格冲突。

修复:在标题栏规则中补充 border-radius: var(--radius-lg),
保持开放分节设计的同时,让标题栏呈现圆角条,与卡片圆角语言统一。

## Scope

Scope boundary:
仅修改 SkillsView.vue 中 sk-group--skills 标题栏的圆角:
- .sk-group--skills > .sk-group__head 增加
  border-radius: var(--radius-lg)

Non-goals:
不改 sk-group--skills 的开放分节设计(透明容器/无边框);
不改其他页面组件;不改卡片、网格等其他样式。

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1009 

If None, reason: N/A

## Release Note

Release note: 技能页已安装分组标题栏补齐圆角,与技能卡片风格统一。

## Tests

Ruff:
N/A — 本次改动为前端 CSS(无 Python 改动)

Pytest:
N/A — 未涉及后端逻辑

Build:
npm run build 全绿(含 WebUI radius guard 架构检查,
--radius-lg 为合法 token);vitest skills 组件 5 passed;
浏览器 DOM 实测 3 个分组标题栏 computed border-radius = 14px

Regression tests: added

Notes:
纯样式单行修改;已在浏览器实测(computed style + 截图确认
标题栏四角圆润,与卡片风格一致)。

The default test path remains offline, deterministic, credential-free, and safe for forks.
默认测试路径保持离线、确定性、无需凭据,且对 fork 安全。

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note:
贡献者无需提供密钥或运行需要凭据的 live check。
维护者可以为 provider、browser、gateway、channel 或 release 冒烟覆盖
运行 `Live Release E2E`。

## Safety

密钥、仅限本地的工件、私有提示词/对话记录、渠道标识符、AI 会话工件、
非公开 fixture 以及 tests/_private/ 的内容一律不得提交。

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] 链接指向仓库内现有文件或稳定的外部页面。
- [x] 代码围栏与 Markdown 表格在 GitHub 上渲染正确。
- [x] 示例避免真实密钥、本地私有路径与私有对话记录。