### PR TITLE
Adopt byte-bounded Gateway history clients

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -249,6 +249,7 @@
       "tests/test_cli/test_gateway_reload_cmd.py",
       "tests/test_cli/test_gateway_rpc.py",
       "tests/test_cli/test_help_theme.py",
+      "tests/test_cli/test_history_export.py",
       "tests/test_cli/test_memory_dream_cmd.py",
       "tests/test_cli/test_memory_flush_cmd.py",
       "tests/test_cli/test_models_probe.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -1197,6 +1197,7 @@
     "tests/test_gateway/test_steer_restart_recovery.py": 0.01,
     "tests/test_gateway/test_rpc_capability_reset.py": 0.01,
     "tests/test_onboarding/test_image_generation_model_discovery.py": 0.01,
+    "tests/test_cli/test_history_export.py": 0.01,
     "tests/test_gateway/test_history_detail_spool.py": 0.01,
     "tests/test_gateway/test_python_client_transport_limits.py": 0.01,
     "tests/test_gateway/test_rpc_bootstrap_v2.py": 0.01,

--- a/src/opensquilla/cli/chat/gateway_runtime.py
+++ b/src/opensquilla/cli/chat/gateway_runtime.py
@@ -798,10 +798,28 @@ async def run_gateway_chat(
                     if session_context.session_key != slash_session_key and callable(
                         getattr(client, "subscribe_session_events", None)
                     ):
-                        switch_snapshot = await client.bootstrap_session(
-                            session_context.session_key,
-                            limit=1,
+                        switch_snapshot = session_context.state.gateway_bootstrap
+                        raw_applied_session = (
+                            switch_snapshot.get("session")
+                            if isinstance(switch_snapshot, dict)
+                            else None
                         )
+                        applied_session = (
+                            raw_applied_session
+                            if isinstance(raw_applied_session, dict)
+                            else {}
+                        )
+                        if (
+                            not isinstance(switch_snapshot, dict)
+                            or str(applied_session.get("session_key") or "")
+                            != session_context.session_key
+                        ):
+                            # Compatibility for custom slash adapters that
+                            # mutate state without applying a bootstrap.
+                            switch_snapshot = await client.bootstrap_session(
+                                session_context.session_key,
+                                limit=1,
+                            )
                         session_context.scope["bootstrap"] = switch_snapshot
                         raw_switch_session = switch_snapshot.get("session")
                         switch_session = (

--- a/src/opensquilla/cli/chat/session_state.py
+++ b/src/opensquilla/cli/chat/session_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 from opensquilla.cli.chat.turn import UsageCounter
 
@@ -89,6 +90,15 @@ class ChatSessionState:
     elevated: str | None = None
     transcript: ChatTranscript = field(default_factory=ChatTranscript)
     usage: UsageCounter = field(default_factory=UsageCounter)
+    # Most recent canonical Gateway snapshot applied to this state. Keeping the
+    # exact snapshot cursor lets a session switch subscribe from the same
+    # history boundary instead of taking a second snapshot and creating a
+    # replay gap between the two reads.
+    gateway_bootstrap: dict[str, Any] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
 
     def prompt_state(self) -> PromptState:
         return PromptState(model=self.model, elevated=self.elevated)

--- a/src/opensquilla/cli/gateway_client.py
+++ b/src/opensquilla/cli/gateway_client.py
@@ -15,6 +15,10 @@ from urllib.parse import urlparse
 from opensquilla.contracts.gateway_transport import (
     GATEWAY_CLIENT_MAX_MESSAGE_BYTES,
     GATEWAY_CLIENT_MAX_QUEUE,
+    GATEWAY_HISTORY_MAX_RESPONSE_BUDGET_BYTES,
+    GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+    GATEWAY_HISTORY_RESPONSE_RETRY_CODES,
+    gateway_feature_methods,
 )
 from opensquilla.session.terminal_reply import build_terminal_reply, sanitize_agent_error
 
@@ -361,6 +365,8 @@ class GatewayClient:
         self._heartbeat_interval: float = 48.0
         self._connection_error: ConnectionError | None = None
         self._closing = False
+        self._server_methods: frozenset[str] | None = None
+        self._known_missing_server_methods: set[str] = set()
         self._http_base: str | None = None
         self._auth_token: str | None = None
         self.surface_id = f"tui:{uuid.uuid4().hex}"
@@ -395,6 +401,7 @@ class GatewayClient:
         )
         if has_existing_connection:
             await self.close()
+        self._reset_server_capabilities()
         self._closing = False
         self._connection_error = None
         try:
@@ -479,6 +486,7 @@ class GatewayClient:
             raise SystemExit(f"Handshake failed: {hello!r}")
         if hello.get("type") != "hello-ok":
             raise SystemExit(f"Handshake failed: {hello}")
+        self._server_methods = gateway_feature_methods(hello)
         policy_value = hello.get("policy")
         policy = cast(dict[str, Any], policy_value) if isinstance(policy_value, dict) else {}
         self._heartbeat_interval = _heartbeat_interval_from_policy(policy)
@@ -491,6 +499,20 @@ class GatewayClient:
         """Cache a bearer token used for HTTP-side requests (e.g. uploads)."""
 
         self._auth_token = token
+
+    def _reset_server_capabilities(self) -> None:
+        self._server_methods = None
+        self._known_missing_server_methods.clear()
+
+    def _server_method_support(self, method: str) -> bool | None:
+        if method in self._known_missing_server_methods:
+            return False
+        if self._server_methods is None:
+            return None
+        return method in self._server_methods
+
+    def _mark_server_method_missing(self, method: str) -> None:
+        self._known_missing_server_methods.add(method)
 
     @property
     def is_local_gateway(self) -> bool:
@@ -708,20 +730,50 @@ class GatewayClient:
         *,
         limit: int = 200,
     ) -> dict[str, Any]:
-        """Return a session startup snapshot, including an rc4-daemon fallback.
+        """Return a bounded session startup snapshot, including old-daemon fallbacks.
 
-        ``sessions.bootstrap`` is additive.  A user can upgrade the CLI while
+        Both bootstrap methods are additive. A user can upgrade the CLI while
         an older Gateway process is still serving the same profile, so a
         method-missing response must not break either the plain rescue renderer
-        or the TUI before the user has a chance to restart that daemon.  The
-        legacy composition deliberately stays read-only and uses only RPCs
-        already present in Preview 4.
+        or the TUI before the user has a chance to restart that daemon.
         """
+
+        legacy_params = {"key": key, "limit": limit}
+        if self._server_method_support("sessions.bootstrap.v2") is not False:
+            try:
+                return cast(
+                    dict[str, Any],
+                    await self._call(
+                        "sessions.bootstrap.v2",
+                        {
+                            **legacy_params,
+                            "maxResponseBytes": GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+                        },
+                    ),
+                )
+            except GatewayRPCError as exc:
+                error_code = str(exc.code or "").upper()
+                if error_code in GATEWAY_HISTORY_RESPONSE_RETRY_CODES:
+                    return cast(
+                        dict[str, Any],
+                        await self._call(
+                            "sessions.bootstrap.v2",
+                            {
+                                **legacy_params,
+                                "maxResponseBytes": (
+                                    GATEWAY_HISTORY_MAX_RESPONSE_BUDGET_BYTES
+                                ),
+                            },
+                        ),
+                    )
+                if error_code != "METHOD_NOT_FOUND":
+                    raise
+                self._mark_server_method_missing("sessions.bootstrap.v2")
 
         try:
             return cast(
                 dict[str, Any],
-                await self._call("sessions.bootstrap", {"key": key, "limit": limit}),
+                await self._call("sessions.bootstrap", legacy_params),
             )
         except GatewayRPCError as exc:
             if str(exc.code or "").upper() != "METHOD_NOT_FOUND":
@@ -779,6 +831,41 @@ class GatewayClient:
             params["includeCanonical"] = include_canonical
         if include_summaries is not None:
             params["includeSummaries"] = include_summaries
+        if include_canonical is False:
+            return cast(
+                dict[str, Any],
+                await self._call("chat.history", params),
+            )
+        if self._server_method_support("chat.history.v2") is not False:
+            try:
+                return cast(
+                    dict[str, Any],
+                    await self._call(
+                        "chat.history.v2",
+                        {
+                            **params,
+                            "maxResponseBytes": GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+                        },
+                    ),
+                )
+            except GatewayRPCError as exc:
+                error_code = str(exc.code or "").upper()
+                if error_code in GATEWAY_HISTORY_RESPONSE_RETRY_CODES:
+                    return cast(
+                        dict[str, Any],
+                        await self._call(
+                            "chat.history.v2",
+                            {
+                                **params,
+                                "maxResponseBytes": (
+                                    GATEWAY_HISTORY_MAX_RESPONSE_BUDGET_BYTES
+                                ),
+                            },
+                        ),
+                    )
+                if error_code != "METHOD_NOT_FOUND":
+                    raise
+                self._mark_server_method_missing("chat.history.v2")
         return cast(
             dict[str, Any],
             await self._call("chat.history", params),
@@ -997,7 +1084,7 @@ class GatewayClient:
                     subscription.replay["replay_gap_reason"] = "client_backlog_window_missed"
                 subscription._activate(replay_frames)
                 return subscription
-            params: dict[str, Any] = {"key": session_key}
+            params: dict[str, Any] = {"key": session_key, "fast_ack": True}
             if since_stream_seq is not None:
                 params["since_stream_seq"] = since_stream_seq
             try:
@@ -1225,11 +1312,13 @@ class GatewayClient:
         self._session_event_backlog.clear()
         self._active_turn_ids.clear()
         self._pending_steer_v2.clear()
+        self._reset_server_capabilities()
         for subscription in tuple(self._event_subscriptions.values()):
             subscription._close_from_client()
         self._event_subscriptions.clear()
 
     def _mark_connection_failed(self, exc: BaseException) -> ConnectionError:
+        self._reset_server_capabilities()
         if isinstance(exc, ConnectionError) and str(exc).startswith("Gateway connection lost"):
             err = exc
         else:

--- a/src/opensquilla/cli/history_export.py
+++ b/src/opensquilla/cli/history_export.py
@@ -1,0 +1,681 @@
+"""Bounded-memory Gateway transcript exports.
+
+Gateway history pages are newest-first while transcript files are chronological.
+This module spools each bounded page to disk, then copies the page files in
+reverse page order into one atomically replaced destination. Oversized v2
+entries remain chunked throughout the export.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+from opensquilla.cli.chat.session_state import messages_to_markdown
+from opensquilla.cli.gateway_client import GatewayRPCError
+
+_DETAIL_METHOD = "chat.history.entry.v1"
+_DETAIL_CHUNK_BYTES = 128 * 1024
+_COPY_CHUNK_BYTES = 128 * 1024
+_ExportMode = Literal["json", "markdown"]
+
+
+class HistoryExportClient(Protocol):
+    """Gateway operations required by the streaming exporter."""
+
+    async def session_history(
+        self,
+        session_key: str,
+        limit: int = 1000,
+        *,
+        before: str | None = None,
+        after: str | None = None,
+        include_canonical: bool | None = None,
+        include_summaries: bool | None = None,
+    ) -> dict[str, Any]: ...
+
+    async def call(self, method: str, params: dict | None = None) -> Any: ...
+
+
+@dataclass(frozen=True)
+class HistoryExportResult:
+    """Small export receipt that never contains transcript messages."""
+
+    target: Path
+    message_count: int
+    page_count: int
+
+
+@dataclass(frozen=True)
+class _SpooledHistory:
+    root: Path
+    page_count: int
+    message_count: int
+    output_count: int
+    metadata: dict[str, Any]
+
+
+def _history_message_identity(message: dict[str, Any]) -> tuple[str, str] | None:
+    transcript_id = message.get("transcript_id")
+    if transcript_id not in (None, ""):
+        return "transcript", str(transcript_id)
+    message_id = message.get("message_id") or message.get("id")
+    if message_id not in (None, ""):
+        return "message", str(message_id)
+    return None
+
+
+def _history_cursor_key(value: object) -> tuple[int, int] | None:
+    raw = str(value or "").strip()
+    if not raw or "|" not in raw:
+        return None
+    created_at, transcript_id = raw.split("|", 1)
+    try:
+        return int(created_at), int(transcript_id)
+    except ValueError:
+        return None
+
+
+def _export_error(code: str, message: str, *, method: str = "chat.history") -> GatewayRPCError:
+    return GatewayRPCError(method, code=code, message=message)
+
+
+def _write_error(exc: OSError) -> GatewayRPCError:
+    return _export_error(
+        "TRANSCRIPT_EXPORT_WRITE_FAILED",
+        f"could not write transcript export: {exc}",
+        method="sessions.export",
+    )
+
+
+def _marker_path(root: Path, namespace: str, value: str) -> Path:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    return root / namespace / digest
+
+
+def _mark_once(root: Path, namespace: str, value: str) -> bool:
+    marker = _marker_path(root, namespace, value)
+    marker.parent.mkdir(exist_ok=True)
+    try:
+        marker.touch(exist_ok=False)
+    except FileExistsError:
+        return False
+    return True
+
+
+def _role_heading(message: dict[str, Any]) -> str:
+    role = str(message.get("role") or "message")
+    if role == "user":
+        return "You"
+    if role == "assistant":
+        return "Assistant"
+    return role.title()
+
+
+def _detail_reference(
+    message: dict[str, Any],
+    *,
+    session_key: str,
+) -> tuple[str, dict[str, Any]] | None:
+    raw = message.get("detail_ref")
+    if raw is None:
+        if message.get("truncated_by_bytes") is True:
+            raise _export_error(
+                "HISTORY_DETAIL_REFERENCE_MISSING",
+                "gateway returned a truncated history preview without a detail reference",
+            )
+        return None
+    if not isinstance(raw, dict):
+        raise _export_error(
+            "INVALID_HISTORY_DETAIL_REF",
+            "gateway returned a non-object history detail reference",
+        )
+    method = str(raw.get("method") or "").strip()
+    if method != _DETAIL_METHOD:
+        raise _export_error(
+            "INVALID_HISTORY_DETAIL_REF",
+            "gateway returned an unsupported history detail method",
+        )
+    ref_session_key = str(raw.get("sessionKey") or "").strip()
+    cursor = str(raw.get("cursor") or "").strip()
+    if ref_session_key != session_key or _history_cursor_key(cursor) is None:
+        raise _export_error(
+            "INVALID_HISTORY_DETAIL_REF",
+            "gateway returned an invalid history detail identity",
+        )
+    return method, {"sessionKey": ref_session_key, "cursor": cursor}
+
+
+def _chunk_int(payload: dict[str, Any], name: str) -> int:
+    value = payload.get(name)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise _export_error(
+            "INVALID_HISTORY_DETAIL_CHUNK",
+            f"gateway history detail chunk had an invalid {name}",
+            method=_DETAIL_METHOD,
+        )
+    return value
+
+
+async def _write_detail_chunks(
+    client: HistoryExportClient,
+    *,
+    method: str,
+    reference: dict[str, Any],
+    field: Literal["message", "text"],
+    write: Callable[[bytes], Any],
+    declared_total: int | None = None,
+) -> None:
+    offset = 0
+    expected_total: int | None = None
+    expected_digest: str | None = None
+    digest = hashlib.sha256()
+
+    while True:
+        payload = await client.call(
+            method,
+            {
+                **reference,
+                "field": field,
+                "offset": offset,
+                "chunkBytes": _DETAIL_CHUNK_BYTES,
+            },
+        )
+        if not isinstance(payload, dict):
+            raise _export_error(
+                "INVALID_HISTORY_DETAIL_CHUNK",
+                "gateway returned a non-object history detail chunk",
+                method=method,
+            )
+        if payload.get("encoding") != "base64" or payload.get("field") != field:
+            raise _export_error(
+                "INVALID_HISTORY_DETAIL_CHUNK",
+                "gateway history detail chunk changed encoding or field",
+                method=method,
+            )
+        chunk_offset = _chunk_int(payload, "offset")
+        total = _chunk_int(payload, "total")
+        if chunk_offset != offset:
+            raise _export_error(
+                "HISTORY_DETAIL_OFFSET_MISMATCH",
+                "gateway history detail chunk did not start at the requested offset",
+                method=method,
+            )
+
+        raw_digest = payload.get("sha256")
+        if not isinstance(raw_digest, str) or len(raw_digest) != 64:
+            raise _export_error(
+                "INVALID_HISTORY_DETAIL_CHUNK",
+                "gateway history detail chunk omitted its SHA-256 digest",
+                method=method,
+            )
+        try:
+            int(raw_digest, 16)
+        except ValueError as exc:
+            raise _export_error(
+                "INVALID_HISTORY_DETAIL_CHUNK",
+                "gateway history detail chunk returned an invalid SHA-256 digest",
+                method=method,
+            ) from exc
+        if expected_total is None:
+            if declared_total is not None and total != declared_total:
+                raise _export_error(
+                    "HISTORY_DETAIL_LENGTH_MISMATCH",
+                    "gateway history detail did not match its declared original byte length",
+                    method=method,
+                )
+            expected_total = total
+            expected_digest = raw_digest.lower()
+        elif total != expected_total or raw_digest.lower() != expected_digest:
+            raise _export_error(
+                "HISTORY_DETAIL_IDENTITY_CHANGED",
+                "gateway history detail changed while it was being exported",
+                method=method,
+            )
+
+        raw_chunk = payload.get("chunk_base64")
+        if not isinstance(raw_chunk, str):
+            raise _export_error(
+                "INVALID_HISTORY_DETAIL_CHUNK",
+                "gateway history detail chunk omitted base64 content",
+                method=method,
+            )
+        try:
+            chunk = base64.b64decode(raw_chunk, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise _export_error(
+                "INVALID_HISTORY_DETAIL_CHUNK",
+                "gateway history detail chunk contained invalid base64 content",
+                method=method,
+            ) from exc
+
+        end = offset + len(chunk)
+        if expected_total is None or end > expected_total:
+            raise _export_error(
+                "INVALID_HISTORY_DETAIL_CHUNK",
+                "gateway history detail chunk exceeded its declared byte length",
+                method=method,
+            )
+        write(chunk)
+        digest.update(chunk)
+
+        next_offset = payload.get("next")
+        if next_offset is None:
+            if end != expected_total:
+                raise _export_error(
+                    "HISTORY_DETAIL_INCOMPLETE",
+                    "gateway history detail ended before its declared byte length",
+                    method=method,
+                )
+            break
+        if (
+            isinstance(next_offset, bool)
+            or not isinstance(next_offset, int)
+            or next_offset != end
+            or next_offset <= offset
+            or next_offset >= expected_total
+        ):
+            raise _export_error(
+                "HISTORY_DETAIL_PAGINATION_STALLED",
+                "gateway history detail offset did not advance",
+                method=method,
+            )
+        offset = next_offset
+
+    if expected_digest is None or digest.hexdigest() != expected_digest:
+        raise _export_error(
+            "HISTORY_DETAIL_CHECKSUM_MISMATCH",
+            "gateway history detail failed its SHA-256 integrity check",
+            method=method,
+        )
+
+
+async def _spool_message(
+    client: HistoryExportClient,
+    message: dict[str, Any],
+    *,
+    session_key: str,
+    mode: _ExportMode,
+    target: Path,
+) -> None:
+    detail = _detail_reference(message, session_key=session_key)
+    with target.open("wb") as stream:
+        if mode == "json":
+            if detail is None:
+                stream.write(
+                    json.dumps(message, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+                )
+                return
+            method, reference = detail
+            original_bytes = message.get("original_bytes")
+            declared_total = (
+                original_bytes
+                if isinstance(original_bytes, int)
+                and not isinstance(original_bytes, bool)
+                and original_bytes >= 0
+                else None
+            )
+            await _write_detail_chunks(
+                client,
+                method=method,
+                reference=reference,
+                field="message",
+                write=stream.write,
+                declared_total=declared_total,
+            )
+            return
+
+        if detail is None:
+            stream.write(messages_to_markdown([message]).encode("utf-8"))
+            return
+        method, reference = detail
+        stream.write(f"## {_role_heading(message)}\n\n".encode())
+        await _write_detail_chunks(
+            client,
+            method=method,
+            reference=reference,
+            field="text",
+            write=stream.write,
+        )
+        stream.write(b"\n")
+
+
+def _page_message_paths(root: Path, page_index: int) -> list[Path]:
+    page = root / f"page-{page_index:08d}"
+    return sorted(page.glob("message-*.data"))
+
+
+async def _spool_page_messages(
+    client: HistoryExportClient,
+    raw_messages: list[Any],
+    *,
+    session_key: str,
+    root: Path,
+    page_index: int,
+    mode: _ExportMode,
+) -> tuple[int, int]:
+    page_path = root / f"page-{page_index:08d}"
+    page_path.mkdir()
+    message_count = 0
+    output_count = 0
+    for raw_message in raw_messages:
+        if not isinstance(raw_message, dict):
+            continue
+        message = dict(raw_message)
+        identity = _history_message_identity(message)
+        if identity is not None:
+            identity_marker = json.dumps(identity, separators=(",", ":"))
+            if not _mark_once(root, "identities", identity_marker):
+                continue
+        message_path = page_path / f"message-{output_count:08d}.data"
+        await _spool_message(
+            client,
+            message,
+            session_key=session_key,
+            mode=mode,
+            target=message_path,
+        )
+        message_count += 1
+        if mode == "markdown" and message_path.stat().st_size == 0:
+            message_path.unlink()
+            continue
+        output_count += 1
+    return message_count, output_count
+
+
+async def _spool_history(
+    client: HistoryExportClient,
+    session_key: str,
+    *,
+    root: Path,
+    mode: _ExportMode,
+    page_size: int,
+) -> _SpooledHistory:
+    limit = max(1, min(int(page_size), 200))
+    before: str | None = None
+    page_count = 0
+    message_count = 0
+    output_count = 0
+    newest_metadata: dict[str, Any] | None = None
+    oldest_metadata: dict[str, Any] | None = None
+
+    while True:
+        response = await client.session_history(
+            session_key,
+            limit=limit,
+            before=before,
+            include_canonical=True,
+            include_summaries=False,
+        )
+        if not isinstance(response, dict):
+            raise _export_error(
+                "INVALID_HISTORY_PAGE",
+                "gateway returned a non-object history page",
+            )
+        if response.get("canonical_available") is False:
+            raise _export_error(
+                "CANONICAL_HISTORY_UNAVAILABLE",
+                "complete canonical history is temporarily unavailable; export was cancelled",
+            )
+        if response.get("canonical_complete") is False:
+            raise _export_error(
+                "CANONICAL_HISTORY_INCOMPLETE",
+                "older original messages were not preserved; export was cancelled",
+            )
+        raw_messages = response.get("messages")
+        if not isinstance(raw_messages, list):
+            raise _export_error(
+                "INVALID_HISTORY_PAGE",
+                "gateway history page did not contain a messages list",
+            )
+
+        has_more = bool(response.get("has_more"))
+        next_before: str | None = None
+        if has_more:
+            raw_cursor = response.get("oldest_cursor")
+            next_before = str(raw_cursor).strip() if raw_cursor is not None else ""
+            if not next_before or next_before == before:
+                raise _export_error(
+                    "HISTORY_PAGINATION_STALLED",
+                    "gateway history cursor did not advance; export was cancelled",
+                )
+            if not _mark_once(root, "cursors", next_before):
+                raise _export_error(
+                    "HISTORY_PAGINATION_STALLED",
+                    "gateway history cursor did not advance; export was cancelled",
+                )
+        if before is not None:
+            requested_key = _history_cursor_key(before)
+            newest_key = _history_cursor_key(response.get("newest_cursor"))
+            if requested_key is None or newest_key is None or newest_key >= requested_key:
+                raise _export_error(
+                    "HISTORY_CURSOR_INVALIDATED",
+                    (
+                        "gateway history no longer precedes the requested cursor; "
+                        "the session may have changed and export was cancelled"
+                    ),
+                )
+
+        page_message_count, page_output_count = await _spool_page_messages(
+            client,
+            raw_messages,
+            session_key=session_key,
+            root=root,
+            page_index=page_count,
+            mode=mode,
+        )
+        message_count += page_message_count
+        output_count += page_output_count
+
+        metadata = {key: value for key, value in response.items() if key != "messages"}
+        newest_metadata = newest_metadata or metadata
+        oldest_metadata = metadata
+        # Do not retain a completed page while awaiting the next RPC response.
+        del raw_messages
+        response = {}
+        page_count += 1
+        if not has_more:
+            break
+        assert next_before is not None
+        before = next_before
+
+    result_metadata = dict(oldest_metadata or newest_metadata or {})
+    result_metadata["has_more"] = False
+    result_metadata["loaded_count"] = message_count
+    result_metadata["page_size"] = limit
+    result_metadata["truncated_by_bytes"] = False
+    result_metadata.pop("wire_bytes", None)
+    result_metadata.pop("byte_budget", None)
+    if newest_metadata is not None:
+        result_metadata["newest_cursor"] = newest_metadata.get("newest_cursor")
+    return _SpooledHistory(
+        root=root,
+        page_count=page_count,
+        message_count=message_count,
+        output_count=output_count,
+        metadata=result_metadata,
+    )
+
+
+def _copy_file(source: Path, target: Any) -> None:
+    with source.open("rb") as stream:
+        shutil.copyfileobj(stream, target, length=_COPY_CHUNK_BYTES)
+
+
+def _write_atomic(target: Path, writer: Callable[[Any], None]) -> None:
+    target = target.expanduser()
+    descriptor = -1
+    temporary_path: Path | None = None
+    try:
+        descriptor, raw_path = tempfile.mkstemp(
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            dir=str(target.parent),
+        )
+        temporary_path = Path(raw_path)
+        with os.fdopen(descriptor, "wb") as stream:
+            descriptor = -1
+            writer(stream)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_path, target)
+        temporary_path = None
+    except OSError as exc:
+        raise _write_error(exc) from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def _write_json_export(
+    stream: Any,
+    *,
+    spooled: _SpooledHistory,
+    resolved: dict[str, Any],
+    preview: dict[str, Any],
+) -> None:
+    stream.write(b'{\n  "resolved": ')
+    stream.write(json.dumps(resolved, ensure_ascii=False, indent=2).encode("utf-8"))
+    stream.write(b',\n  "preview": ')
+    stream.write(json.dumps(preview, ensure_ascii=False, indent=2).encode("utf-8"))
+    stream.write(b',\n  "history": {')
+    for key, value in spooled.metadata.items():
+        stream.write(b"\n    ")
+        stream.write(json.dumps(str(key), ensure_ascii=False).encode("utf-8"))
+        stream.write(b": ")
+        stream.write(json.dumps(value, ensure_ascii=False).encode("utf-8"))
+        stream.write(b",")
+    stream.write(b'\n    "messages": [')
+
+    wrote_message = False
+    for page_index in range(spooled.page_count - 1, -1, -1):
+        for path in _page_message_paths(spooled.root, page_index):
+            if wrote_message:
+                stream.write(b",")
+            stream.write(b"\n      ")
+            _copy_file(path, stream)
+            wrote_message = True
+    if wrote_message:
+        stream.write(b"\n    ")
+    stream.write(b"]\n  }\n}\n")
+
+
+def _write_markdown_export(
+    stream: Any,
+    *,
+    spooled: _SpooledHistory,
+    header: str,
+    fallback_markdown: str,
+) -> None:
+    if header:
+        stream.write(header.encode("utf-8"))
+    if not spooled.output_count:
+        stream.write(fallback_markdown.encode("utf-8"))
+        return
+
+    wrote_message = False
+    for page_index in range(spooled.page_count - 1, -1, -1):
+        for path in _page_message_paths(spooled.root, page_index):
+            if wrote_message:
+                stream.write(b"\n")
+            _copy_file(path, stream)
+            wrote_message = True
+
+
+async def export_session_history_json(
+    client: HistoryExportClient,
+    session_key: str,
+    target: Path,
+    *,
+    resolved: dict[str, Any],
+    preview: dict[str, Any],
+    page_size: int = 200,
+) -> HistoryExportResult:
+    """Stream a complete chronological history into the legacy JSON export shape."""
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="opensquilla-history-export-") as raw_root:
+            spooled = await _spool_history(
+                client,
+                session_key,
+                root=Path(raw_root),
+                mode="json",
+                page_size=page_size,
+            )
+            _write_atomic(
+                target,
+                lambda stream: _write_json_export(
+                    stream,
+                    spooled=spooled,
+                    resolved=resolved,
+                    preview=preview,
+                ),
+            )
+            return HistoryExportResult(
+                target=target,
+                message_count=spooled.message_count,
+                page_count=spooled.page_count,
+            )
+    except OSError as exc:
+        if isinstance(exc, ConnectionError):
+            raise
+        raise _write_error(exc) from exc
+
+
+async def export_session_history_markdown(
+    client: HistoryExportClient,
+    session_key: str,
+    target: Path,
+    *,
+    header: str = "",
+    fallback_markdown: str = "",
+    page_size: int = 200,
+) -> HistoryExportResult:
+    """Stream a complete chronological history into a Markdown transcript."""
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="opensquilla-history-export-") as raw_root:
+            spooled = await _spool_history(
+                client,
+                session_key,
+                root=Path(raw_root),
+                mode="markdown",
+                page_size=page_size,
+            )
+            _write_atomic(
+                target,
+                lambda stream: _write_markdown_export(
+                    stream,
+                    spooled=spooled,
+                    header=header,
+                    fallback_markdown=fallback_markdown,
+                ),
+            )
+            return HistoryExportResult(
+                target=target,
+                message_count=spooled.message_count,
+                page_count=spooled.page_count,
+            )
+    except OSError as exc:
+        if isinstance(exc, ConnectionError):
+            raise
+        raise _write_error(exc) from exc
+
+
+__all__ = [
+    "HistoryExportClient",
+    "HistoryExportResult",
+    "export_session_history_json",
+    "export_session_history_markdown",
+]

--- a/src/opensquilla/cli/sessions_cmd.py
+++ b/src/opensquilla/cli/sessions_cmd.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 from datetime import UTC, datetime
 from pathlib import Path
@@ -12,9 +11,11 @@ from typing import Any
 import typer
 from rich.table import Table
 
-from opensquilla.cli.chat.session_state import messages_to_markdown
-from opensquilla.cli.gateway_client import session_history_all
 from opensquilla.cli.gateway_rpc import run_gateway_sync
+from opensquilla.cli.history_export import (
+    export_session_history_json,
+    export_session_history_markdown,
+)
 from opensquilla.cli.output import print_json
 from opensquilla.cli.ui import ACCENT, ACCENT_HEADER, console, error_panel
 from opensquilla.cli.url_utils import normalize_gateway_url
@@ -284,23 +285,46 @@ def sessions_export(
     output: Path | None = typer.Option(None, "--output", "-o", help="Output file"),
     format: str = typer.Option("md", "--format", help="Export format: md|json"),
 ) -> None:
-    """Export session transcript and metadata.
-
-    Uses the existing chat.history RPC for persisted transcript messages and
-    falls back to session preview when no messages are available.
-    """
+    """Export session transcript and metadata without aggregating it in memory."""
     if format not in {"md", "json"}:
         console.print("[red]--format must be md or json[/red]")
         raise typer.Exit(2)
+
+    target = output or Path(f"{session_id.replace(':', '-')}.{format}")
 
     async def _run(client):
         resolved = await client.resolve_session(session_id)
         key = _resolved_key(resolved, session_id)
         preview = await client.preview_sessions(keys=[key])
-        history = await session_history_all(client.session_history, key)
-        return {"resolved": resolved, "preview": preview, "history": history}
+        if format == "json":
+            await export_session_history_json(
+                client,
+                key,
+                target,
+                resolved=resolved,
+                preview=preview,
+            )
+            return target
 
-    result: dict[str, Any] | None = asyncio.run(_with_client(_run))
+        previews = preview.get("previews", []) if isinstance(preview, dict) else []
+        first_preview = previews[0] if previews and isinstance(previews[0], dict) else {}
+        header = (
+            f"# Session {key}\n\n"
+            f"- Status: {resolved.get('status', '')}\n"
+            f"- Model: {resolved.get('model') or ''}\n"
+            f"- Updated: {resolved.get('updated_at', '')}\n\n"
+        )
+        fallback = f"## Preview\n\n{first_preview.get('lastMessage', '')}\n"
+        await export_session_history_markdown(
+            client,
+            key,
+            target,
+            header=header,
+            fallback_markdown=fallback,
+        )
+        return target
+
+    result = asyncio.run(_with_client(_run))
     if result is _CLIENT_UNAVAILABLE:
         console.print("[dim]Session export requires a running gateway.[/dim]")
         return
@@ -309,24 +333,4 @@ def sessions_export(
     if result is None:
         console.print("[red]Session export returned no data.[/red]")
         return
-    target = output or Path(f"{session_id.replace(':', '-')}.{format}")
-    if format == "json":
-        target.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
-    else:
-        resolved = result.get("resolved", {})
-        key = _resolved_key(resolved, session_id)
-        previews = result.get("preview", {}).get("previews", [])
-        preview = previews[0] if previews else {}
-        messages = result.get("history", {}).get("messages", [])
-        transcript = messages_to_markdown(messages) if isinstance(messages, list) else ""
-        if not transcript.strip():
-            transcript = f"## Preview\n\n{preview.get('lastMessage', '')}\n"
-        body = (
-            f"# Session {key}\n\n"
-            f"- Status: {resolved.get('status', '')}\n"
-            f"- Model: {resolved.get('model') or ''}\n"
-            f"- Updated: {resolved.get('updated_at', '')}\n\n"
-            f"{transcript}"
-        )
-        target.write_text(body, encoding="utf-8")
     console.print(f"[green]Exported:[/green] {target}")

--- a/src/opensquilla/cli/tui/adapters/runtime_bridge.py
+++ b/src/opensquilla/cli/tui/adapters/runtime_bridge.py
@@ -390,7 +390,8 @@ async def run_gateway_chat(
         if (
             session_id
             and (exc.code or "").upper() == "NOT_FOUND"
-            and exc.method in {"sessions.bootstrap", "sessions.resolve"}
+            and exc.method
+            in {"sessions.bootstrap", "sessions.bootstrap.v2", "sessions.resolve"}
         ):
             message = (
                 f"Session '{session_id}' was not found. Run `opensquilla sessions list` "

--- a/src/opensquilla/cli/tui/adapters/slash_gateway.py
+++ b/src/opensquilla/cli/tui/adapters/slash_gateway.py
@@ -17,9 +17,10 @@ from typing import Any, Protocol
 from rich.table import Table
 
 import opensquilla.cli.tui.adapters.input_bridge as _input_bridge
-from opensquilla.cli.chat.session_state import ChatSessionState, messages_to_markdown
+from opensquilla.cli.chat.session_state import ChatSessionState
 from opensquilla.cli.chat.turn import TurnResult
-from opensquilla.cli.gateway_client import GatewayRPCError, session_history_all
+from opensquilla.cli.gateway_client import GatewayRPCError
+from opensquilla.cli.history_export import export_session_history_markdown
 from opensquilla.cli.tui.adapters.commands import render_help_table, render_keys_table
 from opensquilla.cli.tui.adapters.slash_common import (
     compact_skipped_line,
@@ -31,7 +32,6 @@ from opensquilla.cli.tui.adapters.slash_common import (
     record_turn,
     registry_handler_words,
     resolve_transcript_target,
-    save_transcript_markdown,
 )
 from opensquilla.cli.tui.adapters.slash_common import (
     slash_parts as _slash_parts,
@@ -920,20 +920,16 @@ async def _save_gateway_transcript_command(
 ) -> None:
     target = resolve_transcript_target(cmd, state.session_key)
     try:
-        history = await session_history_all(client.session_history, state.session_key)
+        await export_session_history_markdown(
+            client,
+            state.session_key,
+            target,
+            fallback_markdown=state.transcript.to_markdown(),
+        )
     except GatewayRPCError as exc:
         console.print(error_panel(str(exc), title="Could not save transcript"))
         return
-    messages = history.get("messages") or []
-    markdown = messages_to_markdown(messages) if isinstance(messages, list) else ""
-    if not markdown.strip():
-        markdown = state.transcript.to_markdown()
-    save_transcript_markdown(
-        target,
-        markdown,
-        output_console=console,
-        error_panel_factory=error_panel,
-    )
+    console.print(f"[green]Saved transcript:[/green] {target}")
 
 
 def _image_prompt_from_command(command: str) -> str:

--- a/src/opensquilla/cli/tui/opentui/history.py
+++ b/src/opensquilla/cli/tui/opentui/history.py
@@ -49,6 +49,7 @@ def history_replace_from_bootstrap(
         has_more=bool(history.get("has_more")),
         loaded_count=int(history.get("loaded_count") or len(messages)),
         canonical_available=bool(history.get("canonical_available")),
+        truncated_by_bytes=bool(history.get("truncated_by_bytes")),
         messages=messages,
         compaction_summaries=summaries,
     )
@@ -63,6 +64,7 @@ def apply_bootstrap_to_state(
 
     raw_session = snapshot.get("session")
     session = raw_session if isinstance(raw_session, dict) else {}
+    state.gateway_bootstrap = snapshot
     state.session_key = history.session_key
     if "effective_model" in session or "model" in session:
         model = session.get("effective_model") or session.get("model")
@@ -138,6 +140,14 @@ def _history_message(row: dict[str, Any], *, ordinal: int) -> HistoryMessage:
     )
     raw_usage = row.get("usage") or row.get("turn_usage")
     usage = dict(raw_usage) if isinstance(raw_usage, dict) else _flattened_usage(row)
+    raw_original_bytes = row.get("original_bytes")
+    original_bytes = (
+        raw_original_bytes
+        if isinstance(raw_original_bytes, int)
+        and not isinstance(raw_original_bytes, bool)
+        and raw_original_bytes >= 0
+        else None
+    )
     return HistoryMessage(
         id=message_id,
         role=role,
@@ -153,6 +163,13 @@ def _history_message(row: dict[str, Any], *, ordinal: int) -> HistoryMessage:
             if isinstance(row.get("turn_context"), dict)
             else None
         ),
+        truncated_by_bytes=bool(row.get("truncated_by_bytes")),
+        original_bytes=original_bytes,
+        detail_ref=(
+            dict(row["detail_ref"])
+            if isinstance(row.get("detail_ref"), dict)
+            else None
+        ),
     )
 
 
@@ -160,6 +177,8 @@ def _display_text(row: dict[str, Any]) -> str:
     value = row.get("text")
     if value is None:
         value = row.get("content")
+    if value is None:
+        value = row.get("preview")
     return value if isinstance(value, str) else str(value or "")
 
 

--- a/src/opensquilla/cli/tui/opentui/messages.py
+++ b/src/opensquilla/cli/tui/opentui/messages.py
@@ -165,6 +165,9 @@ class HistoryMessage:
     tool_calls: tuple[dict[str, Any], ...] = ()
     usage: dict[str, Any] | None = None
     turn_context: dict[str, Any] | None = None
+    truncated_by_bytes: bool = False
+    original_bytes: int | None = None
+    detail_ref: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -176,6 +179,7 @@ class HistoryReplace:
     has_more: bool = False
     loaded_count: int = 0
     canonical_available: bool = False
+    truncated_by_bytes: bool = False
     messages: tuple[HistoryMessage, ...] = ()
     compaction_summaries: tuple[dict[str, Any], ...] = ()
 

--- a/src/opensquilla/cli/tui/opentui/package/src/history-renderer.test.mjs
+++ b/src/opensquilla/cli/tui/opentui/package/src/history-renderer.test.mjs
@@ -39,6 +39,7 @@ function harness() {
 test("history boundary labels complete, windowed, and compacted snapshots", () => {
   assert.equal(historyBoundaryText({ history_scope: "complete", loaded_count: 4 }), "history · complete · 4 messages");
   assert.equal(historyBoundaryText({ history_scope: "latest_window", loaded_count: 20 }), "history · latest 20 messages · older messages available");
+  assert.equal(historyBoundaryText({ history_scope: "latest_window", loaded_count: 1, truncated_by_bytes: true }), "history · latest 1 messages · byte-limited · older messages available");
   assert.equal(historyBoundaryText({ history_scope: "compacted", loaded_count: 8, compaction_summaries: [{ id: "s1" }] }), "history · compacted · 8 recent messages · 1 earlier summary");
   assert.equal(historyBoundaryText({ history_scope: "complete", loaded_count: 0 }), "");
 });
@@ -107,6 +108,46 @@ test("canonical history reuses live turn blocks and deduplicates durable ids", (
   ));
   assert.equal(events.filter((event) => event[0] === "finish").length, 1);
   assert.equal(events.some((event) => event.includes("duplicate")), false);
+});
+
+test("byte-truncated history labels user and assistant previews with a save hint", () => {
+  const { flow, views } = harness();
+  replayHistory({
+    flow,
+    nextId: (id) => `history-${id}`,
+    messages: [
+      {
+        id: "preview-user",
+        role: "user",
+        text: "partial question",
+        truncated_by_bytes: true,
+        original_bytes: 98_304,
+        detail_ref: { method: "chat.history.entry.v1", cursor: "1|1" },
+      },
+      {
+        id: "preview-assistant",
+        role: "assistant",
+        text: "partial answer",
+        truncated_by_bytes: true,
+        original_bytes: 2_048,
+        detail_ref: { method: "chat.history.entry.v1", cursor: "2|2" },
+      },
+      { id: "complete-assistant", role: "assistant", text: "complete answer" },
+    ],
+  });
+
+  const events = views.flatMap((view) => view.events);
+  const notices = events.filter(
+    (event) => event[0] === "begin"
+      && event[2] === "history-detail"
+      && event[1].endsWith("-byte-preview"),
+  );
+  assert.deepEqual(notices.map((event) => event[3].text), [
+    "byte-limited preview · full entry 96 KiB · use /save to export complete content",
+    "byte-limited preview · full entry 2 KiB · use /save to export complete content",
+  ]);
+  assert.ok(events.some((event) => event[0] === "append" && event[2] === "partial answer"));
+  assert.equal(notices.some((event) => event[1].includes("complete-assistant")), false);
 });
 
 test("causal turn identity groups prompt, reasoning, tools, and answer after hydrate", () => {

--- a/src/opensquilla/cli/tui/opentui/package/src/historyRenderer.mjs
+++ b/src/opensquilla/cli/tui/opentui/package/src/historyRenderer.mjs
@@ -18,6 +18,35 @@ function optionalNumber(value) {
   return Number.isFinite(number) && number >= 0 ? number : null;
 }
 
+function byteSizeText(value) {
+  const bytes = optionalNumber(value);
+  if (bytes === null) return "";
+  const units = ["B", "KiB", "MiB", "GiB"];
+  let amount = bytes;
+  let unit = 0;
+  while (amount >= 1024 && unit < units.length - 1) {
+    amount /= 1024;
+    unit += 1;
+  }
+  const digits = Number.isInteger(amount) || amount >= 10 ? 0 : 1;
+  return `${amount.toFixed(digits)} ${units[unit]}`;
+}
+
+function historyPreviewText(message) {
+  if (!message?.truncated_by_bytes) return "";
+  const originalSize = byteSizeText(message.original_bytes);
+  const size = originalSize ? ` · full entry ${originalSize}` : "";
+  return `byte-limited preview${size} · use /save to export complete content`;
+}
+
+function addHistoryPreviewNotice(view, message, blockPrefix) {
+  const text = historyPreviewText(message);
+  if (!text) return;
+  const blockId = `${blockPrefix}-byte-preview`;
+  view.begin(blockId, "history-detail", { text });
+  view.end(blockId);
+}
+
 function attachmentTail(message) {
   const names = Array.isArray(message?.attachments)
     ? message.attachments.map((item) => itemName(item, "attachment")).filter(Boolean)
@@ -150,14 +179,17 @@ function ensembleReceipt(message) {
 export function historyBoundaryText(message) {
   const count = Number(message?.loaded_count ?? message?.messages?.length ?? 0);
   const scope = String(message?.history_scope ?? "complete");
+  const byteTail = message?.truncated_by_bytes ? " · byte-limited" : "";
   if (scope === "compacted") {
     const summaries = Array.isArray(message?.compaction_summaries) ? message.compaction_summaries.length : 0;
     const summaryTail = summaries ? ` · ${summaries} earlier ${summaries === 1 ? "summary" : "summaries"}` : "";
-    return `history · compacted · ${count} recent messages${summaryTail}`;
+    return `history · compacted · ${count} recent messages${summaryTail}${byteTail}`;
   }
-  if (scope === "latest_window" || message?.has_more) return `history · latest ${count} messages · older messages available`;
+  if (scope === "latest_window" || message?.has_more) {
+    return `history · latest ${count} messages${byteTail} · older messages available`;
+  }
   if (count === 0) return "";
-  return `history · complete · ${count} messages`;
+  return `history · complete · ${count} messages${byteTail}`;
 }
 
 /** Clear old renderables, create a fresh flow, and synchronously replay one frame. */
@@ -209,6 +241,7 @@ export function replayHistory({ messages, flow, nextId }) {
         intent: safeText(context?.intent || "send"),
         disposition: safeText(context?.disposition || ""),
       });
+      addHistoryPreviewNotice(view, raw, blockPrefix);
       legacyAdjacentTurnOpen = true;
       continue;
     }
@@ -245,6 +278,7 @@ export function replayHistory({ messages, flow, nextId }) {
       if (kind !== "error") view.append(blockId, text);
       view.end(blockId);
     }
+    addHistoryPreviewNotice(view, raw, blockPrefix);
     const artifacts = artifactText(raw);
     if (artifacts) {
       const blockId = `${blockPrefix}-artifacts`;

--- a/src/opensquilla/contracts/gateway_transport.py
+++ b/src/opensquilla/contracts/gateway_transport.py
@@ -4,5 +4,36 @@ from __future__ import annotations
 
 GATEWAY_CLIENT_MAX_MESSAGE_BYTES = 32 * 1024 * 1024
 GATEWAY_CLIENT_MAX_QUEUE = 1
+GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES = 768 * 1024
+GATEWAY_HISTORY_MAX_RESPONSE_BUDGET_BYTES = 4 * 1024 * 1024
+GATEWAY_HISTORY_RESPONSE_RETRY_CODES = frozenset(
+    {
+        "BOOTSTRAP_RESPONSE_TOO_LARGE",
+        "HISTORY_RESPONSE_TOO_LARGE",
+        "RESPONSE_BUDGET_EXCEEDED",
+    }
+)
 
-__all__ = ["GATEWAY_CLIENT_MAX_MESSAGE_BYTES", "GATEWAY_CLIENT_MAX_QUEUE"]
+
+def gateway_feature_methods(hello: object) -> frozenset[str] | None:
+    """Return advertised RPC methods, or ``None`` when capabilities are unknown."""
+
+    if not isinstance(hello, dict):
+        return None
+    features = hello.get("features")
+    if not isinstance(features, dict):
+        return None
+    methods = features.get("methods")
+    if not isinstance(methods, list) or not all(isinstance(method, str) for method in methods):
+        return None
+    return frozenset(methods)
+
+
+__all__ = [
+    "GATEWAY_CLIENT_MAX_MESSAGE_BYTES",
+    "GATEWAY_CLIENT_MAX_QUEUE",
+    "GATEWAY_HISTORY_MAX_RESPONSE_BUDGET_BYTES",
+    "GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES",
+    "GATEWAY_HISTORY_RESPONSE_RETRY_CODES",
+    "gateway_feature_methods",
+]

--- a/src/opensquilla/gateway_client.py
+++ b/src/opensquilla/gateway_client.py
@@ -11,6 +11,10 @@ from urllib.parse import urlparse, urlunparse
 from opensquilla.contracts.gateway_transport import (
     GATEWAY_CLIENT_MAX_MESSAGE_BYTES,
     GATEWAY_CLIENT_MAX_QUEUE,
+    GATEWAY_HISTORY_MAX_RESPONSE_BUDGET_BYTES,
+    GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+    GATEWAY_HISTORY_RESPONSE_RETRY_CODES,
+    gateway_feature_methods,
 )
 
 
@@ -81,10 +85,13 @@ class GatewayRPCClient:
         self._heartbeat_interval = 48.0
         self._connection_error: ConnectionError | None = None
         self._closing = False
+        self._server_methods: frozenset[str] | None = None
+        self._known_missing_server_methods: set[str] = set()
 
     async def connect(self, url: str = "ws://localhost:18791/ws") -> None:
         if self._ws is not None:
             await self.close()
+        self._reset_server_capabilities()
         self._closing = False
         self._connection_error = None
         try:
@@ -129,6 +136,7 @@ class GatewayRPCClient:
             await self._close_failed_connect()
             raise
 
+        self._server_methods = gateway_feature_methods(hello)
         policy = hello.get("policy") if isinstance(hello.get("policy"), dict) else {}
         self._heartbeat_interval = _heartbeat_interval_from_policy(policy)
         self._listener_task = asyncio.create_task(self._listen())
@@ -163,11 +171,14 @@ class GatewayRPCClient:
             raise TimeoutError(f"{method} timed out after {self.request_timeout_s:g}s") from exc
         if not res.get("ok"):
             err = res.get("error", {})
+            raw_details = err.get("data")
+            if not isinstance(raw_details, dict):
+                raw_details = err.get("details")
             raise GatewayRPCError(
                 method,
                 code=err.get("code"),
                 message=err.get("message") or "RPC failed",
-                data=err.get("data") if isinstance(err.get("data"), dict) else None,
+                data=raw_details if isinstance(raw_details, dict) else None,
             )
         payload = res.get("payload")
         return {} if payload is None else payload
@@ -197,6 +208,41 @@ class GatewayRPCClient:
             params["includeCanonical"] = include_canonical
         if include_summaries is not None:
             params["includeSummaries"] = include_summaries
+        if include_canonical is False:
+            return cast(
+                dict[str, Any],
+                await self.call("chat.history", params),
+            )
+        if self._server_method_support("chat.history.v2") is not False:
+            try:
+                return cast(
+                    dict[str, Any],
+                    await self.call(
+                        "chat.history.v2",
+                        {
+                            **params,
+                            "maxResponseBytes": GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+                        },
+                    ),
+                )
+            except GatewayRPCError as exc:
+                error_code = str(exc.code or "").upper()
+                if error_code in GATEWAY_HISTORY_RESPONSE_RETRY_CODES:
+                    return cast(
+                        dict[str, Any],
+                        await self.call(
+                            "chat.history.v2",
+                            {
+                                **params,
+                                "maxResponseBytes": (
+                                    GATEWAY_HISTORY_MAX_RESPONSE_BUDGET_BYTES
+                                ),
+                            },
+                        ),
+                    )
+                if error_code != "METHOD_NOT_FOUND":
+                    raise
+                self._mark_server_method_missing("chat.history.v2")
         return cast(
             dict[str, Any],
             await self.call("chat.history", params),
@@ -222,8 +268,10 @@ class GatewayRPCClient:
         self._ws = None
         self._heartbeat_task = None
         self._listener_task = None
+        self._reset_server_capabilities()
 
     async def _close_failed_connect(self) -> None:
+        self._reset_server_capabilities()
         ws = self._ws
         self._ws = None
         if ws is not None:
@@ -262,6 +310,7 @@ class GatewayRPCClient:
             self._mark_connection_failed(exc)
 
     def _mark_connection_failed(self, exc: BaseException) -> ConnectionError:
+        self._reset_server_capabilities()
         if isinstance(exc, ConnectionError):
             err = exc
         else:
@@ -279,6 +328,20 @@ class GatewayRPCClient:
             if task is not None and task is not current_task and not task.done():
                 task.cancel()
         return err
+
+    def _reset_server_capabilities(self) -> None:
+        self._server_methods = None
+        self._known_missing_server_methods.clear()
+
+    def _server_method_support(self, method: str) -> bool | None:
+        if method in self._known_missing_server_methods:
+            return False
+        if self._server_methods is None:
+            return None
+        return method in self._server_methods
+
+    def _mark_server_method_missing(self, method: str) -> None:
+        self._known_missing_server_methods.add(method)
 
 
 def _heartbeat_interval_from_policy(policy: dict[str, Any]) -> float:

--- a/src/opensquilla/mcp_server/bridge.py
+++ b/src/opensquilla/mcp_server/bridge.py
@@ -2,13 +2,22 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
+import hashlib
+import io
 import json
 import os
+import tempfile
 import time
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any, Protocol
 
-from opensquilla.gateway_client import normalize_gateway_url
+from opensquilla.gateway_client import GatewayRPCError, normalize_gateway_url
+
+_DETAIL_METHOD = "chat.history.entry.v1"
+_DETAIL_CHUNK_BYTES = 128 * 1024
 
 
 class GatewayClientLike(Protocol):
@@ -20,7 +29,16 @@ class GatewayClientLike(Protocol):
 
     async def resolve_session(self, key: str) -> dict[str, Any]: ...
 
-    async def session_history(self, session_key: str, limit: int = 1000) -> dict[str, Any]: ...
+    async def session_history(
+        self,
+        session_key: str,
+        limit: int = 1000,
+        *,
+        before: str | None = None,
+        after: str | None = None,
+        include_canonical: bool | None = None,
+        include_summaries: bool | None = None,
+    ) -> dict[str, Any]: ...
 
     async def call(self, method: str, params: dict[str, Any] | None = None) -> Any: ...
 
@@ -71,9 +89,53 @@ class OpenSquillaMCPBridge:
         client = await self._ensure_client()
         return await client.resolve_session(key)
 
-    async def messages_read(self, key: str, limit: int = 1000) -> dict[str, Any]:
+    async def messages_read(
+        self,
+        key: str,
+        limit: int = 1000,
+        *,
+        before: str | None = None,
+        after: str | None = None,
+    ) -> dict[str, Any]:
         client = await self._ensure_client()
-        return await client.session_history(key, limit=limit)
+        kwargs: dict[str, Any] = {"limit": limit}
+        if before is not None:
+            kwargs["before"] = before
+        if after is not None:
+            kwargs["after"] = after
+        return await client.session_history(key, **kwargs)
+
+    async def message_detail_read(
+        self,
+        key: str,
+        cursor: str,
+        *,
+        offset: int = 0,
+        chunk_bytes: int = _DETAIL_CHUNK_BYTES,
+        field: str = "message",
+    ) -> dict[str, Any]:
+        """Read one bounded chunk from an oversized canonical history entry."""
+
+        if field not in {"message", "text"}:
+            raise ValueError("field must be message or text")
+        client = await self._ensure_client()
+        payload = await client.call(
+            _DETAIL_METHOD,
+            {
+                "sessionKey": key,
+                "cursor": cursor,
+                "offset": offset,
+                "chunkBytes": chunk_bytes,
+                "field": field,
+            },
+        )
+        if not isinstance(payload, dict):
+            raise _history_error(
+                _DETAIL_METHOD,
+                "INVALID_HISTORY_DETAIL_CHUNK",
+                "gateway returned a non-object history detail chunk",
+            )
+        return payload
 
     async def messages_send(
         self,
@@ -168,16 +230,280 @@ class OpenSquillaMCPBridge:
             await client.close()
 
     async def transcript_jsonl(self, key: str, limit: int = 1000) -> str:
-        history = await self.messages_read(key, limit=limit)
-        messages = history.get("messages", []) if isinstance(history, dict) else []
-        rows = [_message_to_event(row) for row in messages if isinstance(row, dict)]
-        flattened: list[dict[str, Any]] = []
-        for row in rows:
-            if isinstance(row, list):
-                flattened.extend(row)
-            else:
-                flattened.append(row)
-        return "\n".join(json.dumps(row, ensure_ascii=False, default=str) for row in flattened)
+        """Export at most ``limit`` newest messages in chronological JSONL order.
+
+        History pages start at the newest window. Page output is spooled to
+        temporary files and replayed in reverse page order so the bridge keeps
+        only the final MCP string plus the current message in memory. Callers
+        that need more than ``limit`` can page with ``messages_read`` and
+        ``message_detail_read`` without changing this public limit contract.
+        """
+
+        client = await self._ensure_client()
+        total_limit = max(1, int(limit))
+        page_size = min(total_limit, 200)
+        with tempfile.TemporaryDirectory(prefix="opensquilla-mcp-transcript-") as raw_root:
+            root = Path(raw_root)
+            before: str | None = None
+            seen_cursors: set[str] = set()
+            seen_messages: set[tuple[str, str]] = set()
+            page_paths: list[Path] = []
+            exported_messages = 0
+
+            while exported_messages < total_limit:
+                request_limit = min(page_size, total_limit - exported_messages)
+                history = await client.session_history(
+                    key,
+                    limit=request_limit,
+                    before=before,
+                    include_canonical=True,
+                    include_summaries=False,
+                )
+                messages, has_more = _history_page(history)
+                if len(messages) > request_limit:
+                    messages = messages[-request_limit:]
+                if before is not None:
+                    requested_key = _history_cursor_key(before)
+                    newest_key = _history_cursor_key(history.get("newest_cursor"))
+                    if (
+                        requested_key is None
+                        or newest_key is None
+                        or newest_key >= requested_key
+                    ):
+                        raise _history_error(
+                            "chat.history",
+                            "HISTORY_CURSOR_INVALIDATED",
+                            (
+                                "gateway history no longer precedes the requested cursor; "
+                                "transcript export was cancelled"
+                            ),
+                        )
+
+                page_path = root / f"page-{len(page_paths):08d}.jsonl"
+                with page_path.open("w", encoding="utf-8", newline="\n") as page_stream:
+                    for raw_message in messages:
+                        identity = _history_message_identity(raw_message)
+                        if identity is not None:
+                            if identity in seen_messages:
+                                continue
+                            seen_messages.add(identity)
+                        message = await self._resolve_history_detail(key, raw_message)
+                        row = _message_to_event(message)
+                        events = row if isinstance(row, list) else [row]
+                        for event in events:
+                            json.dump(
+                                event,
+                                page_stream,
+                                ensure_ascii=False,
+                                default=str,
+                            )
+                            page_stream.write("\n")
+                        exported_messages += 1
+                        if exported_messages >= total_limit:
+                            break
+                page_paths.append(page_path)
+
+                if exported_messages >= total_limit or not has_more:
+                    break
+                raw_cursor = history.get("oldest_cursor")
+                next_before = str(raw_cursor).strip() if raw_cursor is not None else ""
+                if (
+                    not next_before
+                    or next_before == before
+                    or next_before in seen_cursors
+                ):
+                    raise _history_error(
+                        "chat.history",
+                        "HISTORY_PAGINATION_STALLED",
+                        "gateway history cursor did not advance; transcript export was cancelled",
+                    )
+                seen_cursors.add(next_before)
+                before = next_before
+
+            output = io.StringIO()
+            first_line = True
+            for page_path in reversed(page_paths):
+                with page_path.open(encoding="utf-8") as page_stream:
+                    for line in page_stream:
+                        if not first_line:
+                            output.write("\n")
+                        output.write(line.removesuffix("\n"))
+                        first_line = False
+            return output.getvalue()
+
+    async def _resolve_history_detail(
+        self,
+        key: str,
+        message: dict[str, Any],
+    ) -> dict[str, Any]:
+        raw_reference = message.get("detail_ref")
+        if raw_reference is None:
+            if message.get("truncated_by_bytes") is True:
+                raise _history_error(
+                    "chat.history",
+                    "HISTORY_DETAIL_REFERENCE_MISSING",
+                    "gateway returned a truncated history preview without a detail reference",
+                )
+            return message
+        if not isinstance(raw_reference, dict):
+            raise _history_error(
+                "chat.history",
+                "INVALID_HISTORY_DETAIL_REF",
+                "gateway returned a non-object history detail reference",
+            )
+        method = str(raw_reference.get("method") or "")
+        reference_key = str(raw_reference.get("sessionKey") or "")
+        cursor = str(raw_reference.get("cursor") or "")
+        if method != _DETAIL_METHOD or reference_key != key or not cursor:
+            raise _history_error(
+                "chat.history",
+                "INVALID_HISTORY_DETAIL_REF",
+                "gateway returned an invalid history detail reference",
+            )
+
+        expected_original_bytes = message.get("original_bytes")
+        if (
+            isinstance(expected_original_bytes, bool)
+            or not isinstance(expected_original_bytes, int)
+            or expected_original_bytes < 0
+        ):
+            expected_original_bytes = None
+
+        offset = 0
+        expected_total: int | None = None
+        expected_digest: str | None = None
+        digest = hashlib.sha256()
+        with tempfile.TemporaryFile(mode="w+b") as detail_stream:
+            while True:
+                chunk = await self.message_detail_read(
+                    key,
+                    cursor,
+                    offset=offset,
+                    chunk_bytes=_DETAIL_CHUNK_BYTES,
+                    field="message",
+                )
+                raw_offset = _history_chunk_int(chunk, "offset")
+                total = _history_chunk_int(chunk, "total")
+                if raw_offset != offset:
+                    raise _history_error(
+                        _DETAIL_METHOD,
+                        "HISTORY_DETAIL_OFFSET_MISMATCH",
+                        "gateway history detail did not start at the requested offset",
+                    )
+                raw_digest = chunk.get("sha256")
+                if not isinstance(raw_digest, str) or not _valid_sha256(raw_digest):
+                    raise _history_error(
+                        _DETAIL_METHOD,
+                        "INVALID_HISTORY_DETAIL_CHUNK",
+                        "gateway history detail omitted a valid SHA-256 digest",
+                    )
+                if expected_total is None:
+                    if expected_original_bytes is not None and total != expected_original_bytes:
+                        raise _history_error(
+                            _DETAIL_METHOD,
+                            "HISTORY_DETAIL_LENGTH_MISMATCH",
+                            (
+                                "gateway history detail did not match its declared "
+                                "original byte length"
+                            ),
+                        )
+                    expected_total = total
+                    expected_digest = raw_digest.lower()
+                elif total != expected_total or raw_digest.lower() != expected_digest:
+                    raise _history_error(
+                        _DETAIL_METHOD,
+                        "HISTORY_DETAIL_IDENTITY_CHANGED",
+                        "gateway history detail changed while it was being exported",
+                    )
+                if chunk.get("encoding") != "base64" or chunk.get("field") != "message":
+                    raise _history_error(
+                        _DETAIL_METHOD,
+                        "INVALID_HISTORY_DETAIL_CHUNK",
+                        "gateway history detail changed encoding or field",
+                    )
+                encoded = chunk.get("chunk_base64")
+                if not isinstance(encoded, str):
+                    raise _history_error(
+                        _DETAIL_METHOD,
+                        "INVALID_HISTORY_DETAIL_CHUNK",
+                        "gateway history detail omitted base64 content",
+                    )
+                try:
+                    decoded = base64.b64decode(encoded, validate=True)
+                except (binascii.Error, ValueError) as exc:
+                    raise _history_error(
+                        _DETAIL_METHOD,
+                        "INVALID_HISTORY_DETAIL_CHUNK",
+                        "gateway history detail contained invalid base64 content",
+                    ) from exc
+                end = offset + len(decoded)
+                if expected_total is None or end > expected_total:
+                    raise _history_error(
+                        _DETAIL_METHOD,
+                        "INVALID_HISTORY_DETAIL_CHUNK",
+                        "gateway history detail exceeded its declared byte length",
+                    )
+                detail_stream.write(decoded)
+                digest.update(decoded)
+
+                next_offset = chunk.get("next")
+                if next_offset is None:
+                    if end != expected_total:
+                        raise _history_error(
+                            _DETAIL_METHOD,
+                            "HISTORY_DETAIL_INCOMPLETE",
+                            "gateway history detail ended before its declared byte length",
+                        )
+                    break
+                if (
+                    isinstance(next_offset, bool)
+                    or not isinstance(next_offset, int)
+                    or next_offset != end
+                    or next_offset <= offset
+                    or next_offset >= expected_total
+                ):
+                    raise _history_error(
+                        _DETAIL_METHOD,
+                        "HISTORY_DETAIL_PAGINATION_STALLED",
+                        "gateway history detail offset did not advance",
+                    )
+                offset = next_offset
+
+            if expected_digest is None or digest.hexdigest() != expected_digest:
+                raise _history_error(
+                    _DETAIL_METHOD,
+                    "HISTORY_DETAIL_CHECKSUM_MISMATCH",
+                    "gateway history detail failed its SHA-256 integrity check",
+                )
+            detail_stream.seek(0)
+            try:
+                with io.TextIOWrapper(detail_stream, encoding="utf-8") as text_stream:
+                    resolved = json.load(text_stream)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise _history_error(
+                    _DETAIL_METHOD,
+                    "INVALID_HISTORY_DETAIL_MESSAGE",
+                    "gateway history detail did not contain a UTF-8 JSON message object",
+                ) from exc
+        if not isinstance(resolved, dict):
+            raise _history_error(
+                _DETAIL_METHOD,
+                "INVALID_HISTORY_DETAIL_MESSAGE",
+                "gateway history detail did not contain a JSON message object",
+            )
+        preview_identity = _history_message_identity(message)
+        resolved_identity = _history_message_identity(resolved)
+        if (
+            preview_identity is not None
+            and resolved_identity is not None
+            and preview_identity != resolved_identity
+        ):
+            raise _history_error(
+                _DETAIL_METHOD,
+                "HISTORY_DETAIL_IDENTITY_CHANGED",
+                "gateway history detail identity did not match its preview",
+            )
+        return resolved
 
     async def _subscribe_messages(
         self,
@@ -188,9 +514,90 @@ class OpenSquillaMCPBridge:
     ) -> dict[str, Any]:
         result = await client.call(
             "sessions.messages.subscribe",
-            {"key": key, "since_stream_seq": since_stream_seq},
+            {
+                "key": key,
+                "since_stream_seq": since_stream_seq,
+                "fast_ack": True,
+            },
         )
         return result if isinstance(result, dict) else {}
+
+
+def _history_error(method: str, code: str, message: str) -> GatewayRPCError:
+    return GatewayRPCError(method, code=code, message=message)
+
+
+def _history_page(history: object) -> tuple[list[dict[str, Any]], bool]:
+    if not isinstance(history, dict):
+        raise _history_error(
+            "chat.history",
+            "INVALID_HISTORY_PAGE",
+            "gateway returned a non-object history page",
+        )
+    if history.get("canonical_available") is False:
+        raise _history_error(
+            "chat.history",
+            "CANONICAL_HISTORY_UNAVAILABLE",
+            "complete canonical history is temporarily unavailable; export was cancelled",
+        )
+    if history.get("canonical_complete") is False:
+        raise _history_error(
+            "chat.history",
+            "CANONICAL_HISTORY_INCOMPLETE",
+            "older original messages were not preserved; export was cancelled",
+        )
+    raw_messages = history.get("messages")
+    if not isinstance(raw_messages, list):
+        raise _history_error(
+            "chat.history",
+            "INVALID_HISTORY_PAGE",
+            "gateway history page did not contain a messages list",
+        )
+    return [message for message in raw_messages if isinstance(message, dict)], bool(
+        history.get("has_more")
+    )
+
+
+def _history_cursor_key(value: object) -> tuple[int, int] | None:
+    raw = str(value or "").strip()
+    if not raw or "|" not in raw:
+        return None
+    created_at, transcript_id = raw.split("|", 1)
+    try:
+        return int(created_at), int(transcript_id)
+    except ValueError:
+        return None
+
+
+def _history_message_identity(message: dict[str, Any]) -> tuple[str, str] | None:
+    transcript_id = message.get("transcript_id")
+    if transcript_id not in (None, ""):
+        return "transcript", str(transcript_id)
+    message_id = message.get("message_id") or message.get("id")
+    if message_id not in (None, ""):
+        return "message", str(message_id)
+    return None
+
+
+def _history_chunk_int(chunk: dict[str, Any], name: str) -> int:
+    value = chunk.get(name)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise _history_error(
+            _DETAIL_METHOD,
+            "INVALID_HISTORY_DETAIL_CHUNK",
+            f"gateway history detail had an invalid {name}",
+        )
+    return value
+
+
+def _valid_sha256(value: str) -> bool:
+    if len(value) != 64:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return True
 
 
 _TERMINAL_EVENTS = {

--- a/src/opensquilla/mcp_server/server.py
+++ b/src/opensquilla/mcp_server/server.py
@@ -40,10 +40,38 @@ def create_mcp_server(
         return await bridge.session_resolve(key)
 
     @mcp.tool(name="messages_read")
-    async def messages_read(key: str, limit: int = 1000) -> dict[str, Any]:
-        """Read persisted messages for an OpenSquilla session."""
+    async def messages_read(
+        key: str,
+        limit: int = 1000,
+        before: str | None = None,
+        after: str | None = None,
+    ) -> dict[str, Any]:
+        """Read one bounded page of persisted messages for a session."""
 
-        return await bridge.messages_read(key, limit=limit)
+        kwargs: dict[str, Any] = {"limit": limit}
+        if before is not None:
+            kwargs["before"] = before
+        if after is not None:
+            kwargs["after"] = after
+        return await bridge.messages_read(key, **kwargs)
+
+    @mcp.tool(name="message_detail_read")
+    async def message_detail_read(
+        key: str,
+        cursor: str,
+        offset: int = 0,
+        chunk_bytes: int = 128 * 1024,
+        field: str = "message",
+    ) -> dict[str, Any]:
+        """Read one bounded chunk referenced by a history message's detail_ref."""
+
+        return await bridge.message_detail_read(
+            key,
+            cursor,
+            offset=offset,
+            chunk_bytes=chunk_bytes,
+            field=field,
+        )
 
     @mcp.tool(name="messages_send")
     async def messages_send(key: str, message: str, intent: str = "continue") -> dict[str, Any]:

--- a/tests/test_cli/test_chat_cmd.py
+++ b/tests/test_cli/test_chat_cmd.py
@@ -1945,6 +1945,13 @@ async def test_gateway_slash_delete_resolves_and_reports_errors(monkeypatch) -> 
 
 @pytest.mark.asyncio
 async def test_gateway_slash_save_exports_persisted_history(monkeypatch, tmp_path) -> None:
+    def fail_if_history_is_aggregated(*args, **kwargs):
+        raise AssertionError("/save must stream pages instead of aggregating history")
+
+    monkeypatch.setattr(
+        "opensquilla.cli.gateway_client.session_history_all",
+        fail_if_history_is_aggregated,
+    )
     _FakeGatewayClient.instances.clear()
     monkeypatch.setattr("opensquilla.cli.gateway_client.GatewayClient", _FakeGatewayClient)
     fake = _FakeGatewayClient()

--- a/tests/test_cli/test_cli_product_completeness.py
+++ b/tests/test_cli/test_cli_product_completeness.py
@@ -743,6 +743,13 @@ def test_sessions_abort_resolves_then_aborts(monkeypatch):
 
 
 def test_sessions_export_reads_more_than_gateway_page_limit(tmp_path: Path, monkeypatch) -> None:
+    def fail_if_history_is_aggregated(*args, **kwargs):
+        raise AssertionError("sessions export must stream pages instead of aggregating history")
+
+    monkeypatch.setattr(
+        "opensquilla.cli.gateway_client.session_history_all",
+        fail_if_history_is_aggregated,
+    )
     fake = _install_fake_gateway(monkeypatch)
     fake.rpc_payloads = {
         "sessions.resolve": {

--- a/tests/test_cli/test_gateway_client_keepalive.py
+++ b/tests/test_cli/test_gateway_client_keepalive.py
@@ -19,6 +19,8 @@ from opensquilla.cli.gateway_client import (
 from opensquilla.contracts.gateway_transport import (
     GATEWAY_CLIENT_MAX_MESSAGE_BYTES,
     GATEWAY_CLIENT_MAX_QUEUE,
+    GATEWAY_HISTORY_MAX_RESPONSE_BUDGET_BYTES,
+    GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
 )
 
 _STOP = object()
@@ -122,13 +124,20 @@ def test_gateway_client_error_normalization_preserves_generic_error_detail() -> 
     assert payload["error_message"] == "Tool failed with exit code 2"
 
 
-def _handshake_frames(*, keepalive_ms: int = 60_000) -> list[dict[str, Any]]:
+def _handshake_frames(
+    *,
+    keepalive_ms: int = 60_000,
+    methods: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    hello: dict[str, Any] = {
+        "type": "hello-ok",
+        "policy": {"client_ws_keepalive_timeout_ms": keepalive_ms},
+    }
+    if methods is not None:
+        hello["features"] = {"methods": methods}
     return [
         {"type": "event", "event": "connect.challenge", "payload": {"nonce": "n"}},
-        {
-            "type": "hello-ok",
-            "policy": {"client_ws_keepalive_timeout_ms": keepalive_ms},
-        },
+        hello,
     ]
 
 
@@ -147,6 +156,7 @@ async def test_gateway_client_connect_uses_bounded_transport_limits(
 
     await client.connect("ws://127.0.0.1:18791/ws")
     try:
+        assert client._server_methods is None  # noqa: SLF001
         assert observed_connect == {
             "url": "ws://127.0.0.1:18791/ws",
             "max_size": GATEWAY_CLIENT_MAX_MESSAGE_BYTES,
@@ -154,6 +164,37 @@ async def test_gateway_client_connect_uses_bounded_transport_limits(
         }
     finally:
         await client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("methods", "expected_support"),
+    [
+        (["sessions.bootstrap.v2", "chat.history.v2"], True),
+        ([], False),
+    ],
+)
+async def test_gateway_client_saves_advertised_methods_and_close_resets_them(
+    monkeypatch: pytest.MonkeyPatch,
+    methods: list[str],
+    expected_support: bool,
+) -> None:
+    ws = _FakeWebSocket(_handshake_frames(methods=methods))
+    _install_fake_websockets(monkeypatch, ws)
+    client = GatewayClient()
+
+    await client.connect()
+
+    assert client._server_methods == frozenset(methods)  # noqa: SLF001
+    assert (  # noqa: SLF001
+        client._server_method_support("sessions.bootstrap.v2") is expected_support
+    )
+    assert client._server_method_support("sessions.bootstrap") is False  # noqa: SLF001
+
+    await client.close()
+
+    assert client._server_methods is None  # noqa: SLF001
+    assert client._known_missing_server_methods == set()  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -261,11 +302,15 @@ async def test_listener_close_stops_heartbeat_task() -> None:
 async def test_call_after_send_failure_raises_clear_connection_error() -> None:
     client = GatewayClient()
     client._ws = _BrokenSendWebSocket()  # noqa: SLF001
+    client._server_methods = frozenset({"chat.history.v2"})  # noqa: SLF001
+    client._known_missing_server_methods.add("sessions.bootstrap.v2")  # noqa: SLF001
 
     with pytest.raises(ConnectionError, match="Gateway connection lost"):
         await client._call("sessions.messages.subscribe", {"key": "agent:main:x"})  # noqa: SLF001
 
     assert client._pending == {}  # noqa: SLF001
+    assert client._server_methods is None  # noqa: SLF001
+    assert client._known_missing_server_methods == set()  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -307,6 +352,7 @@ async def test_bootstrap_session_uses_additive_snapshot_rpc(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = GatewayClient()
+    client._server_methods = frozenset({"sessions.bootstrap"})  # noqa: SLF001
     call = AsyncMock(return_value={"session": {"session_key": "agent:main:x"}})
     monkeypatch.setattr(client, "_call", call)
 
@@ -320,10 +366,110 @@ async def test_bootstrap_session_uses_additive_snapshot_rpc(
 
 
 @pytest.mark.asyncio
+async def test_bootstrap_session_prefers_advertised_bounded_v2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = GatewayClient()
+    client._server_methods = frozenset({"sessions.bootstrap.v2"})  # noqa: SLF001
+    rpc_call = AsyncMock(return_value={"session": {"session_key": "agent:main:x"}})
+    monkeypatch.setattr(client, "_call", rpc_call)
+
+    result = await client.bootstrap_session("agent:main:x", limit=75)
+
+    assert result["session"]["session_key"] == "agent:main:x"
+    rpc_call.assert_awaited_once_with(
+        "sessions.bootstrap.v2",
+        {
+            "key": "agent:main:x",
+            "limit": 75,
+            "maxResponseBytes": GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_session_retries_v2_at_bounded_max_without_legacy_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = GatewayClient()
+    rpc_call = AsyncMock(
+        side_effect=[
+            GatewayRPCError(
+                "sessions.bootstrap.v2",
+                code="BOOTSTRAP_RESPONSE_TOO_LARGE",
+                message="retry with a larger bounded response",
+            ),
+            {"session": {"session_key": "agent:main:x"}},
+        ]
+    )
+    monkeypatch.setattr(client, "_call", rpc_call)
+
+    result = await client.bootstrap_session("agent:main:x", limit=75)
+
+    assert result["session"]["session_key"] == "agent:main:x"
+    assert rpc_call.await_args_list == [
+        call(
+            "sessions.bootstrap.v2",
+            {
+                "key": "agent:main:x",
+                "limit": 75,
+                "maxResponseBytes": GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+            },
+        ),
+        call(
+            "sessions.bootstrap.v2",
+            {
+                "key": "agent:main:x",
+                "limit": 75,
+                "maxResponseBytes": GATEWAY_HISTORY_MAX_RESPONSE_BUDGET_BYTES,
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_session_unknown_capability_falls_back_once_and_remembers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = GatewayClient()
+    rpc_call = AsyncMock(
+        side_effect=[
+            GatewayRPCError(
+                "sessions.bootstrap.v2",
+                code="METHOD_NOT_FOUND",
+                message="Method not found: sessions.bootstrap.v2",
+            ),
+            {"session": {"session_key": "agent:main:x"}},
+            {"session": {"session_key": "agent:main:x"}},
+        ]
+    )
+    monkeypatch.setattr(client, "_call", rpc_call)
+
+    await client.bootstrap_session("agent:main:x", limit=75)
+    await client.bootstrap_session("agent:main:x", limit=25)
+
+    assert client._server_methods is None  # noqa: SLF001
+    assert client._server_method_support("sessions.bootstrap.v2") is False  # noqa: SLF001
+    assert rpc_call.await_args_list == [
+        call(
+            "sessions.bootstrap.v2",
+            {
+                "key": "agent:main:x",
+                "limit": 75,
+                "maxResponseBytes": GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+            },
+        ),
+        call("sessions.bootstrap", {"key": "agent:main:x", "limit": 75}),
+        call("sessions.bootstrap", {"key": "agent:main:x", "limit": 25}),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_bootstrap_session_composes_preview4_read_only_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = GatewayClient()
+    client._server_methods = frozenset()  # noqa: SLF001
     rpc_call = AsyncMock(
         side_effect=[
             GatewayRPCError(
@@ -371,6 +517,7 @@ async def test_session_history_forwards_optional_paging_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = GatewayClient()
+    client._server_methods = frozenset()  # noqa: SLF001
     calls: list[tuple[str, dict[str, Any]]] = []
 
     async def fake_call(method: str, params: dict[str, Any]) -> dict[str, Any]:
@@ -408,12 +555,147 @@ async def test_session_history_forwards_optional_paging_fields(
 
 
 @pytest.mark.asyncio
+async def test_session_history_prefers_advertised_bounded_v2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = GatewayClient()
+    client._server_methods = frozenset({"chat.history.v2"})  # noqa: SLF001
+    rpc_call = AsyncMock(return_value={"messages": []})
+    monkeypatch.setattr(client, "_call", rpc_call)
+
+    await client.session_history(
+        "agent:main:test",
+        limit=25,
+        before="12|message-12",
+        include_canonical=True,
+        include_summaries=False,
+    )
+
+    rpc_call.assert_awaited_once_with(
+        "chat.history.v2",
+        {
+            "sessionKey": "agent:main:test",
+            "limit": 25,
+            "before": "12|message-12",
+            "includeCanonical": True,
+            "includeSummaries": False,
+            "maxResponseBytes": GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_history_explicit_noncanonical_view_uses_legacy_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = GatewayClient()
+    client._server_methods = frozenset({"chat.history.v2"})  # noqa: SLF001
+    rpc_call = AsyncMock(return_value={"messages": []})
+    monkeypatch.setattr(client, "_call", rpc_call)
+
+    await client.session_history(
+        "agent:main:test",
+        limit=25,
+        before="12|message-12",
+        include_canonical=False,
+        include_summaries=False,
+    )
+
+    rpc_call.assert_awaited_once_with(
+        "chat.history",
+        {
+            "sessionKey": "agent:main:test",
+            "limit": 25,
+            "before": "12|message-12",
+            "includeCanonical": False,
+            "includeSummaries": False,
+        },
+    )
+    assert client._server_method_support("chat.history.v2") is True  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_session_history_retries_v2_at_bounded_max_without_legacy_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = GatewayClient()
+    rpc_call = AsyncMock(
+        side_effect=[
+            GatewayRPCError(
+                "chat.history.v2",
+                code="HISTORY_RESPONSE_TOO_LARGE",
+                message="retry with a larger bounded response",
+            ),
+            {"messages": []},
+        ]
+    )
+    monkeypatch.setattr(client, "_call", rpc_call)
+
+    await client.session_history("agent:main:test", limit=25)
+
+    assert rpc_call.await_args_list == [
+        call(
+            "chat.history.v2",
+            {
+                "sessionKey": "agent:main:test",
+                "limit": 25,
+                "maxResponseBytes": GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+            },
+        ),
+        call(
+            "chat.history.v2",
+            {
+                "sessionKey": "agent:main:test",
+                "limit": 25,
+                "maxResponseBytes": GATEWAY_HISTORY_MAX_RESPONSE_BUDGET_BYTES,
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_session_history_unknown_capability_falls_back_once_and_remembers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = GatewayClient()
+    rpc_call = AsyncMock(
+        side_effect=[
+            GatewayRPCError(
+                "chat.history.v2",
+                code="METHOD_NOT_FOUND",
+                message="Method not found: chat.history.v2",
+            ),
+            {"messages": []},
+            {"messages": []},
+        ]
+    )
+    monkeypatch.setattr(client, "_call", rpc_call)
+
+    await client.session_history("agent:main:test", limit=5)
+    await client.session_history("agent:main:test", limit=10)
+
+    assert client._server_method_support("chat.history.v2") is False  # noqa: SLF001
+    assert rpc_call.await_args_list == [
+        call(
+            "chat.history.v2",
+            {
+                "sessionKey": "agent:main:test",
+                "limit": 5,
+                "maxResponseBytes": GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+            },
+        ),
+        call("chat.history", {"sessionKey": "agent:main:test", "limit": 5}),
+        call("chat.history", {"sessionKey": "agent:main:test", "limit": 10}),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_bootstrap_session_does_not_mask_non_capability_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = GatewayClient()
     error = GatewayRPCError(
-        "sessions.bootstrap",
+        "sessions.bootstrap.v2",
         code="NOT_FOUND",
         message="Session not found",
     )
@@ -425,8 +707,12 @@ async def test_bootstrap_session_does_not_mask_non_capability_errors(
 
     assert raised.value is error
     rpc_call.assert_awaited_once_with(
-        "sessions.bootstrap",
-        {"key": "missing", "limit": 200},
+        "sessions.bootstrap.v2",
+        {
+            "key": "missing",
+            "limit": 200,
+            "maxResponseBytes": GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+        },
     )
 
 
@@ -469,7 +755,15 @@ async def test_event_multiplexer_broadcasts_without_cross_session_consumption(
     assert session_a.replay["current_stream_seq"] == 4
     call.assert_any_await(
         "sessions.messages.subscribe",
-        {"key": "agent:main:a", "since_stream_seq": 3},
+        {
+            "key": "agent:main:a",
+            "fast_ack": True,
+            "since_stream_seq": 3,
+        },
+    )
+    call.assert_any_await(
+        "sessions.messages.subscribe",
+        {"key": "agent:main:b", "fast_ack": True},
     )
 
     await session_a.close()

--- a/tests/test_cli/test_gateway_client_malformed_frames.py
+++ b/tests/test_cli/test_gateway_client_malformed_frames.py
@@ -70,9 +70,13 @@ def test_connect_challenge_handshake_malformed_json_raises_systemexit(
     _install_fake_websockets(monkeypatch, ws)
 
     client = GatewayClient()
+    client._server_methods = frozenset({"chat.history.v2"})  # noqa: SLF001
+    client._known_missing_server_methods.add("sessions.bootstrap.v2")  # noqa: SLF001
     with pytest.raises(SystemExit) as excinfo:
         asyncio.run(client.connect())
     assert "Malformed handshake frame" in str(excinfo.value)
+    assert client._server_methods is None  # noqa: SLF001
+    assert client._known_missing_server_methods == set()  # noqa: SLF001
 
 
 def test_connect_hello_handshake_malformed_json_raises_systemexit(

--- a/tests/test_cli/test_history_export.py
+++ b/tests/test_cli/test_history_export.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from opensquilla.cli.gateway_client import GatewayRPCError
+from opensquilla.cli.history_export import (
+    export_session_history_json,
+    export_session_history_markdown,
+)
+
+
+class _FakeHistoryClient:
+    def __init__(
+        self,
+        pages: dict[str | None, dict[str, Any]],
+        *,
+        detail_message: bytes | None = None,
+        detail_text: bytes | None = None,
+        chunk_width: int = 7,
+        corrupt: str | None = None,
+    ) -> None:
+        self.pages = pages
+        self.detail_message = detail_message
+        self.detail_text = detail_text
+        self.chunk_width = chunk_width
+        self.corrupt = corrupt
+        self.history_calls: list[dict[str, Any]] = []
+        self.detail_calls: list[dict[str, Any]] = []
+
+    async def session_history(
+        self,
+        session_key: str,
+        limit: int = 1000,
+        *,
+        before: str | None = None,
+        after: str | None = None,
+        include_canonical: bool | None = None,
+        include_summaries: bool | None = None,
+    ) -> dict[str, Any]:
+        self.history_calls.append(
+            {
+                "session_key": session_key,
+                "limit": limit,
+                "before": before,
+                "after": after,
+                "include_canonical": include_canonical,
+                "include_summaries": include_summaries,
+            }
+        )
+        return dict(self.pages[before])
+
+    async def call(self, method: str, params: dict | None = None) -> Any:
+        assert method == "chat.history.entry.v1"
+        assert params is not None
+        self.detail_calls.append(dict(params))
+        field = params["field"]
+        source = self.detail_message if field == "message" else self.detail_text
+        assert source is not None
+        offset = int(params["offset"])
+        end = min(len(source), offset + self.chunk_width)
+        chunk = source[offset:end]
+        reported_offset = offset
+        if self.corrupt == "offset" and offset > 0:
+            reported_offset += 1
+        digest = hashlib.sha256(source).hexdigest()
+        if self.corrupt == "sha256":
+            digest = "0" * 64
+        return {
+            "session_key": params["sessionKey"],
+            "cursor": params["cursor"],
+            "encoding": "base64",
+            "field": field,
+            "content_type": (
+                "application/json" if field == "message" else "text/plain; charset=utf-8"
+            ),
+            "chunk_base64": base64.b64encode(chunk).decode("ascii"),
+            "offset": reported_offset,
+            "next": end if end < len(source) else None,
+            "total": len(source),
+            "sha256": digest,
+        }
+
+
+def _message(index: int, text: str) -> dict[str, Any]:
+    return {
+        "message_id": f"message-{index}",
+        "transcript_id": index,
+        "timestamp": index,
+        "role": "user" if index % 2 else "assistant",
+        "text": text,
+    }
+
+
+def _detail_preview(index: int, *, original_bytes: int) -> dict[str, Any]:
+    return {
+        "message_id": f"message-{index}",
+        "transcript_id": index,
+        "timestamp": index,
+        "role": "assistant",
+        "preview": "分块预览",
+        "original_bytes": original_bytes,
+        "detail_ref": {
+            "method": "chat.history.entry.v1",
+            "sessionKey": "agent:main:export",
+            "cursor": f"{index}|{index}",
+        },
+        "truncated_by_bytes": True,
+    }
+
+
+def _two_page_history(newest_messages: list[dict[str, Any]]) -> dict[str | None, dict[str, Any]]:
+    return {
+        None: {
+            "messages": newest_messages,
+            "has_more": True,
+            "oldest_cursor": "3|3",
+            "newest_cursor": "4|4",
+            "canonical_available": True,
+            "canonical_complete": True,
+            "truncated_by_bytes": True,
+            "wire_bytes": 1234,
+            "byte_budget": 64 * 1024,
+        },
+        "3|3": {
+            "messages": [_message(1, "第一条"), _message(2, "second 🦐")],
+            "has_more": False,
+            "oldest_cursor": "1|1",
+            "newest_cursor": "2|2",
+            "canonical_available": True,
+            "canonical_complete": True,
+            "truncated_by_bytes": False,
+            "wire_bytes": 987,
+            "byte_budget": 64 * 1024,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_json_export_spools_newest_first_pages_and_detail_chunks(tmp_path: Path) -> None:
+    full_detail = _message(4, "尾页中文 🦐 \\\"quoted\\\"")
+    detail_bytes = json.dumps(
+        full_detail,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    pages = _two_page_history(
+        [_message(3, "third"), _detail_preview(4, original_bytes=len(detail_bytes))]
+    )
+    client = _FakeHistoryClient(
+        pages,
+        detail_message=detail_bytes,
+        chunk_width=3,
+    )
+    target = tmp_path / "session.json"
+
+    receipt = await export_session_history_json(
+        client,
+        "agent:main:export",
+        target,
+        resolved={"session_key": "agent:main:export", "status": "done"},
+        preview={"previews": [{"lastMessage": "尾页中文"}]},
+    )
+
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert [message["message_id"] for message in payload["history"]["messages"]] == [
+        "message-1",
+        "message-2",
+        "message-3",
+        "message-4",
+    ]
+    assert payload["history"]["messages"][-1] == full_detail
+    assert payload["history"]["loaded_count"] == 4
+    assert payload["history"]["has_more"] is False
+    assert payload["history"]["truncated_by_bytes"] is False
+    assert "wire_bytes" not in payload["history"]
+    assert "byte_budget" not in payload["history"]
+    assert receipt.message_count == 4
+    assert receipt.page_count == 2
+    assert [call["before"] for call in client.history_calls] == [None, "3|3"]
+    assert all(call["include_canonical"] is True for call in client.history_calls)
+    assert all(call["include_summaries"] is False for call in client.history_calls)
+    assert [call["offset"] for call in client.detail_calls] == list(
+        range(0, len(detail_bytes), 3)
+    )
+
+
+@pytest.mark.asyncio
+async def test_markdown_export_streams_utf8_text_detail_across_chunk_boundaries(
+    tmp_path: Path,
+) -> None:
+    text = "中文🦐跨块\\尾部"
+    encoded = text.encode("utf-8")
+    preview = _detail_preview(4, original_bytes=999_999)
+    pages = {
+        None: {
+            "messages": [preview],
+            "has_more": False,
+            "oldest_cursor": "4|4",
+            "newest_cursor": "4|4",
+            "canonical_available": True,
+            "canonical_complete": True,
+        }
+    }
+    client = _FakeHistoryClient(pages, detail_text=encoded, chunk_width=2)
+    target = tmp_path / "session.md"
+
+    await export_session_history_markdown(
+        client,
+        "agent:main:export",
+        target,
+        header="# Export\n\n",
+    )
+
+    assert target.read_text(encoding="utf-8") == f"# Export\n\n## Assistant\n\n{text}\n"
+    assert [call["offset"] for call in client.detail_calls] == list(range(0, len(encoded), 2))
+    assert all(call["field"] == "text" for call in client.detail_calls)
+
+
+@pytest.mark.parametrize(
+    ("corrupt", "expected_code"),
+    [
+        ("offset", "HISTORY_DETAIL_OFFSET_MISMATCH"),
+        ("sha256", "HISTORY_DETAIL_CHECKSUM_MISMATCH"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_detail_validation_failure_does_not_replace_existing_target(
+    tmp_path: Path,
+    corrupt: str,
+    expected_code: str,
+) -> None:
+    full_detail = _message(4, "中文🦐detail")
+    detail_bytes = json.dumps(
+        full_detail,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    pages = {
+        None: {
+            "messages": [_detail_preview(4, original_bytes=len(detail_bytes))],
+            "has_more": False,
+            "oldest_cursor": "4|4",
+            "newest_cursor": "4|4",
+            "canonical_available": True,
+            "canonical_complete": True,
+        }
+    }
+    client = _FakeHistoryClient(
+        pages,
+        detail_message=detail_bytes,
+        chunk_width=3,
+        corrupt=corrupt,
+    )
+    target = tmp_path / "existing.json"
+    target.write_text("existing export", encoding="utf-8")
+
+    with pytest.raises(GatewayRPCError) as exc_info:
+        await export_session_history_json(
+            client,
+            "agent:main:export",
+            target,
+            resolved={},
+            preview={},
+        )
+
+    assert exc_info.value.code == expected_code
+    assert target.read_text(encoding="utf-8") == "existing export"
+    assert list(tmp_path.glob(f".{target.name}.*.tmp")) == []
+
+
+@pytest.mark.asyncio
+async def test_detail_original_bytes_must_match_first_chunk_total(tmp_path: Path) -> None:
+    full_detail = _message(4, "detail")
+    detail_bytes = json.dumps(full_detail, separators=(",", ":")).encode()
+    pages = {
+        None: {
+            "messages": [_detail_preview(4, original_bytes=len(detail_bytes) + 1)],
+            "has_more": False,
+            "oldest_cursor": "4|4",
+            "newest_cursor": "4|4",
+        }
+    }
+    client = _FakeHistoryClient(pages, detail_message=detail_bytes)
+
+    with pytest.raises(GatewayRPCError) as exc_info:
+        await export_session_history_json(
+            client,
+            "agent:main:export",
+            tmp_path / "mismatch.json",
+            resolved={},
+            preview={},
+        )
+
+    assert exc_info.value.code == "HISTORY_DETAIL_LENGTH_MISMATCH"
+
+
+@pytest.mark.parametrize("preview_field", ["preview", "text"])
+@pytest.mark.asyncio
+async def test_truncated_preview_without_detail_ref_fails_without_replacing_target(
+    tmp_path: Path,
+    preview_field: str,
+) -> None:
+    pages = {
+        None: {
+            "messages": [
+                {
+                    **_message(4, ""),
+                    preview_field: "incomplete preview",
+                    "truncated_by_bytes": True,
+                    "original_bytes": 99_999,
+                }
+            ],
+            "has_more": False,
+            "oldest_cursor": "4|4",
+            "newest_cursor": "4|4",
+            "canonical_available": True,
+            "canonical_complete": True,
+        }
+    }
+    client = _FakeHistoryClient(pages)
+    target = tmp_path / "existing.json"
+    target.write_text("previous export", encoding="utf-8")
+
+    with pytest.raises(GatewayRPCError) as exc_info:
+        await export_session_history_json(
+            client,
+            "agent:main:export",
+            target,
+            resolved={},
+            preview={},
+        )
+
+    assert exc_info.value.code == "HISTORY_DETAIL_REFERENCE_MISSING"
+    assert target.read_text(encoding="utf-8") == "previous export"
+
+
+@pytest.mark.parametrize(
+    ("pages", "expected_code"),
+    [
+        (
+            {
+                None: {
+                    "messages": [],
+                    "has_more": False,
+                    "canonical_available": False,
+                }
+            },
+            "CANONICAL_HISTORY_UNAVAILABLE",
+        ),
+        (
+            {
+                None: {
+                    "messages": [],
+                    "has_more": False,
+                    "canonical_complete": False,
+                }
+            },
+            "CANONICAL_HISTORY_INCOMPLETE",
+        ),
+        (
+            {
+                None: {
+                    "messages": [_message(4, "new")],
+                    "has_more": True,
+                    "oldest_cursor": "4|4",
+                    "newest_cursor": "4|4",
+                },
+                "4|4": {
+                    "messages": [_message(3, "old")],
+                    "has_more": True,
+                    "oldest_cursor": "4|4",
+                    "newest_cursor": "3|3",
+                },
+            },
+            "HISTORY_PAGINATION_STALLED",
+        ),
+        (
+            {
+                None: {
+                    "messages": [_message(4, "new")],
+                    "has_more": True,
+                    "oldest_cursor": "4|4",
+                    "newest_cursor": "4|4",
+                },
+                "4|4": {
+                    "messages": [_message(5, "changed")],
+                    "has_more": False,
+                    "oldest_cursor": "5|5",
+                    "newest_cursor": "5|5",
+                },
+            },
+            "HISTORY_CURSOR_INVALIDATED",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_export_preserves_canonical_and_cursor_error_boundaries(
+    tmp_path: Path,
+    pages: dict[str | None, dict[str, Any]],
+    expected_code: str,
+) -> None:
+    client = _FakeHistoryClient(pages)
+    target = tmp_path / "boundary.json"
+    target.write_text("previous", encoding="utf-8")
+
+    with pytest.raises(GatewayRPCError) as exc_info:
+        await export_session_history_json(
+            client,
+            "agent:main:export",
+            target,
+            resolved={},
+            preview={},
+        )
+
+    assert exc_info.value.code == expected_code
+    assert target.read_text(encoding="utf-8") == "previous"

--- a/tests/test_gateway/test_python_client_transport_limits.py
+++ b/tests/test_gateway/test_python_client_transport_limits.py
@@ -73,6 +73,7 @@ async def _handshake(websocket: Any) -> None:
         _json_frame(
             {
                 "type": "hello-ok",
+                "features": {"methods": ["sessions.bootstrap"]},
                 "policy": {"client_ws_keepalive_timeout_ms": 120_000},
             }
         )

--- a/tests/test_mcp_server/test_bridge.py
+++ b/tests/test_mcp_server/test_bridge.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import base64
+import hashlib
 import json
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+from opensquilla.gateway_client import GatewayRPCError
 from opensquilla.mcp_server.bridge import OpenSquillaMCPBridge
 
 
@@ -32,8 +35,26 @@ class FakeGatewayClient:
         self.calls.append(("sessions.resolve", {"key": key}))
         return {"key": key, "session_id": "sid-1", "agent_id": "main"}
 
-    async def session_history(self, session_key: str, limit: int = 1000) -> dict[str, Any]:
-        self.calls.append(("chat.history", {"sessionKey": session_key, "limit": limit}))
+    async def session_history(
+        self,
+        session_key: str,
+        limit: int = 1000,
+        *,
+        before: str | None = None,
+        after: str | None = None,
+        include_canonical: bool | None = None,
+        include_summaries: bool | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"sessionKey": session_key, "limit": limit}
+        if before is not None:
+            params["before"] = before
+        if after is not None:
+            params["after"] = after
+        if include_canonical is not None:
+            params["includeCanonical"] = include_canonical
+        if include_summaries is not None:
+            params["includeSummaries"] = include_summaries
+        self.calls.append(("chat.history", params))
         return {
             "messages": [
                 {
@@ -95,6 +116,61 @@ class FakeGatewayClient:
         return await asyncio.wait_for(self.events.get(), timeout=timeout)
 
 
+class PagedHistoryGatewayClient(FakeGatewayClient):
+    def __init__(
+        self,
+        pages: dict[str | None, dict[str, Any]],
+        *,
+        detail_message: bytes | None = None,
+    ) -> None:
+        super().__init__()
+        self.pages = pages
+        self.detail_message = detail_message
+
+    async def session_history(
+        self,
+        session_key: str,
+        limit: int = 1000,
+        *,
+        before: str | None = None,
+        after: str | None = None,
+        include_canonical: bool | None = None,
+        include_summaries: bool | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"sessionKey": session_key, "limit": limit}
+        if before is not None:
+            params["before"] = before
+        if after is not None:
+            params["after"] = after
+        if include_canonical is not None:
+            params["includeCanonical"] = include_canonical
+        if include_summaries is not None:
+            params["includeSummaries"] = include_summaries
+        self.calls.append(("chat.history", params))
+        return dict(self.pages[before])
+
+    async def call(self, method: str, params: dict[str, Any] | None = None) -> Any:
+        if method != "chat.history.entry.v1":
+            return await super().call(method, params)
+        assert params is not None
+        assert self.detail_message is not None
+        self.calls.append((method, dict(params)))
+        offset = int(params["offset"])
+        end = min(len(self.detail_message), offset + int(params["chunkBytes"]))
+        return {
+            "session_key": params["sessionKey"],
+            "cursor": params["cursor"],
+            "encoding": "base64",
+            "field": params["field"],
+            "content_type": "application/json",
+            "chunk_base64": base64.b64encode(self.detail_message[offset:end]).decode("ascii"),
+            "offset": offset,
+            "next": end if end < len(self.detail_message) else None,
+            "total": len(self.detail_message),
+            "sha256": hashlib.sha256(self.detail_message).hexdigest(),
+        }
+
+
 @pytest.mark.asyncio
 async def test_bridge_reuses_gateway_read_rpcs() -> None:
     client = FakeGatewayClient()
@@ -116,6 +192,236 @@ async def test_bridge_reuses_gateway_read_rpcs() -> None:
         ("sessions.resolve", {"key": "agent:main:main"}),
         ("chat.history", {"sessionKey": "agent:main:main", "limit": 5}),
     ]
+
+
+@pytest.mark.asyncio
+async def test_bridge_messages_read_forwards_bounded_page_cursors() -> None:
+    client = FakeGatewayClient()
+    bridge = OpenSquillaMCPBridge(gateway_client_factory=lambda: client)
+
+    await bridge.messages_read("agent:main:main", limit=25, before="12|4")
+    await bridge.messages_read("agent:main:main", limit=10, after="18|9")
+
+    assert client.calls == [
+        (
+            "chat.history",
+            {"sessionKey": "agent:main:main", "limit": 25, "before": "12|4"},
+        ),
+        (
+            "chat.history",
+            {"sessionKey": "agent:main:main", "limit": 10, "after": "18|9"},
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transcript_jsonl_pages_up_to_total_limit_in_chronological_order() -> None:
+    pages = {
+        None: {
+            "messages": [
+                {"message_id": "m3", "role": "user", "text": "three", "timestamp": 3},
+                {
+                    "message_id": "m4",
+                    "role": "assistant",
+                    "text": "four",
+                    "timestamp": 4,
+                },
+            ],
+            "has_more": True,
+            "oldest_cursor": "3|3",
+            "newest_cursor": "4|4",
+            "canonical_available": True,
+            "canonical_complete": True,
+        },
+        "3|3": {
+            "messages": [
+                {"message_id": "m1", "role": "user", "text": "one", "timestamp": 1},
+                {
+                    "message_id": "m2",
+                    "role": "assistant",
+                    "text": "two",
+                    "timestamp": 2,
+                },
+            ],
+            "has_more": False,
+            "oldest_cursor": "1|1",
+            "newest_cursor": "2|2",
+            "canonical_available": True,
+            "canonical_complete": True,
+        },
+    }
+    client = PagedHistoryGatewayClient(pages)
+    bridge = OpenSquillaMCPBridge(gateway_client_factory=lambda: client)
+
+    transcript = await bridge.transcript_jsonl("agent:main:main", limit=4)
+
+    rows = [json.loads(line) for line in transcript.splitlines()]
+    assert [row["message"]["content"][0]["text"] for row in rows] == [
+        "one",
+        "two",
+        "three",
+        "four",
+    ]
+    history_calls = [params for method, params in client.calls if method == "chat.history"]
+    assert [params.get("before") for params in history_calls] == [None, "3|3"]
+    assert [params["limit"] for params in history_calls] == [4, 2]
+    assert all(params["includeCanonical"] is True for params in history_calls)
+    assert all(params["includeSummaries"] is False for params in history_calls)
+
+
+@pytest.mark.asyncio
+async def test_transcript_jsonl_limit_is_total_not_page_size() -> None:
+    pages = {
+        None: {
+            "messages": [
+                {"message_id": "m3", "role": "user", "text": "three", "timestamp": 3},
+                {"message_id": "m4", "role": "assistant", "text": "four", "timestamp": 4},
+            ],
+            "has_more": True,
+            "oldest_cursor": "3|3",
+            "newest_cursor": "4|4",
+            "canonical_available": True,
+            "canonical_complete": True,
+        },
+        "3|3": {
+            "messages": [
+                {"message_id": "m1", "role": "user", "text": "one", "timestamp": 1},
+                {"message_id": "m2", "role": "assistant", "text": "two", "timestamp": 2},
+            ],
+            "has_more": False,
+            "oldest_cursor": "1|1",
+            "newest_cursor": "2|2",
+            "canonical_available": True,
+            "canonical_complete": True,
+        },
+    }
+    client = PagedHistoryGatewayClient(pages)
+    bridge = OpenSquillaMCPBridge(gateway_client_factory=lambda: client)
+
+    transcript = await bridge.transcript_jsonl("agent:main:main", limit=2)
+
+    rows = [json.loads(line) for line in transcript.splitlines()]
+    assert [row["message"]["content"][0]["text"] for row in rows] == ["three", "four"]
+    history_calls = [params for method, params in client.calls if method == "chat.history"]
+    assert len(history_calls) == 1
+    assert history_calls[0]["limit"] == 2
+
+
+@pytest.mark.asyncio
+async def test_transcript_jsonl_resolves_giant_detail_without_dropping_preview() -> None:
+    content = "详情开头🦐" + ("x" * 1_100_000) + "详情结尾"
+    full_message = {
+        "message_id": "giant-message",
+        "transcript_id": 9,
+        "role": "assistant",
+        "text": content,
+        "timestamp": 9,
+    }
+    detail_message = json.dumps(
+        full_message,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    pages = {
+        None: {
+            "messages": [
+                {
+                    "message_id": "giant-message",
+                    "transcript_id": 9,
+                    "role": "assistant",
+                    "preview": "详情开头🦐",
+                    "timestamp": 9,
+                    "original_bytes": len(detail_message),
+                    "detail_ref": {
+                        "method": "chat.history.entry.v1",
+                        "sessionKey": "agent:main:main",
+                        "cursor": "9|9",
+                    },
+                    "truncated_by_bytes": True,
+                }
+            ],
+            "has_more": False,
+            "oldest_cursor": "9|9",
+            "newest_cursor": "9|9",
+            "canonical_available": True,
+            "canonical_complete": True,
+        }
+    }
+    client = PagedHistoryGatewayClient(pages, detail_message=detail_message)
+    bridge = OpenSquillaMCPBridge(gateway_client_factory=lambda: client)
+
+    transcript = await bridge.transcript_jsonl("agent:main:main")
+
+    row = json.loads(transcript)
+    assert row["message"]["role"] == "assistant"
+    assert row["message"]["content"][0]["text"] == content
+    detail_calls = [
+        params for method, params in client.calls if method == "chat.history.entry.v1"
+    ]
+    assert len(detail_calls) > 2
+    assert [params["offset"] for params in detail_calls] == [
+        index * 128 * 1024 for index in range(len(detail_calls))
+    ]
+    assert all(params["field"] == "message" for params in detail_calls)
+
+
+@pytest.mark.parametrize("preview_field", ["preview", "text"])
+@pytest.mark.asyncio
+async def test_transcript_jsonl_rejects_any_truncated_message_without_detail_ref(
+    preview_field: str,
+) -> None:
+    pages = {
+        None: {
+            "messages": [
+                {
+                    "message_id": "truncated-message",
+                    "transcript_id": 9,
+                    "role": "assistant",
+                    preview_field: "incomplete preview",
+                    "timestamp": 9,
+                    "truncated_by_bytes": True,
+                }
+            ],
+            "has_more": False,
+            "oldest_cursor": "9|9",
+            "newest_cursor": "9|9",
+            "canonical_available": True,
+            "canonical_complete": True,
+        }
+    }
+    client = PagedHistoryGatewayClient(pages)
+    bridge = OpenSquillaMCPBridge(gateway_client_factory=lambda: client)
+
+    with pytest.raises(GatewayRPCError) as exc_info:
+        await bridge.transcript_jsonl("agent:main:main")
+
+    assert exc_info.value.code == "HISTORY_DETAIL_REFERENCE_MISSING"
+
+
+@pytest.mark.asyncio
+async def test_bridge_message_detail_read_exposes_one_bounded_chunk() -> None:
+    detail_message = b'{"message_id":"m1","text":"hello"}'
+    client = PagedHistoryGatewayClient({}, detail_message=detail_message)
+    bridge = OpenSquillaMCPBridge(gateway_client_factory=lambda: client)
+
+    chunk = await bridge.message_detail_read(
+        "agent:main:main",
+        "1|1",
+        offset=5,
+        chunk_bytes=7,
+    )
+
+    assert base64.b64decode(chunk["chunk_base64"]) == detail_message[5:12]
+    assert client.calls[-1] == (
+        "chat.history.entry.v1",
+        {
+            "sessionKey": "agent:main:main",
+            "cursor": "1|1",
+            "offset": 5,
+            "chunkBytes": 7,
+            "field": "message",
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -148,7 +454,14 @@ async def test_messages_send_subscribes_before_accepting_turn() -> None:
     }
     assert client.closed is True
     assert client.calls == [
-        ("sessions.messages.subscribe", {"key": "agent:main:main", "since_stream_seq": None}),
+        (
+            "sessions.messages.subscribe",
+            {
+                "key": "agent:main:main",
+                "since_stream_seq": None,
+                "fast_ack": True,
+            },
+        ),
         (
             "sessions.send",
             {

--- a/tests/test_mcp_server/test_fastmcp_app.py
+++ b/tests/test_mcp_server/test_fastmcp_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import tomllib
 from collections.abc import Callable
 from pathlib import Path
@@ -41,8 +42,37 @@ class FakeBridge:
     async def session_resolve(self, key: str) -> dict[str, Any]:
         return {"key": key, "session_id": "sid-1"}
 
-    async def messages_read(self, key: str, limit: int = 1000) -> dict[str, Any]:
-        return {"messages": [{"role": "user", "text": key}], "limit": limit}
+    async def messages_read(
+        self,
+        key: str,
+        limit: int = 1000,
+        *,
+        before: str | None = None,
+        after: str | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "messages": [{"role": "user", "text": key}],
+            "limit": limit,
+            "before": before,
+            "after": after,
+        }
+
+    async def message_detail_read(
+        self,
+        key: str,
+        cursor: str,
+        *,
+        offset: int = 0,
+        chunk_bytes: int = 128 * 1024,
+        field: str = "message",
+    ) -> dict[str, Any]:
+        return {
+            "key": key,
+            "cursor": cursor,
+            "offset": offset,
+            "chunk_bytes": chunk_bytes,
+            "field": field,
+        }
 
     async def messages_send(
         self, key: str, message: str, intent: str = "continue"
@@ -78,6 +108,7 @@ def test_create_mcp_server_registers_product_tools_and_resources() -> None:
         "conversations_list",
         "session_resolve",
         "messages_read",
+        "message_detail_read",
         "messages_send",
         "events_wait",
         "transcript_export",
@@ -96,6 +127,44 @@ def test_create_mcp_server_has_no_benchmark_or_mock_public_tools() -> None:
     names = " ".join([*app.tools, *app.resources])
     assert "benchmark" not in names
     assert "mock" not in names
+
+
+def test_messages_read_tool_exposes_bounded_page_cursors() -> None:
+    app = create_mcp_server(FakeBridge(), fastmcp_cls=FakeFastMCP)
+
+    payload = asyncio.run(
+        app.tools["messages_read"](
+            "agent:main:main",
+            limit=25,
+            before="12|4",
+        )
+    )
+
+    assert payload["limit"] == 25
+    assert payload["before"] == "12|4"
+    assert payload["after"] is None
+
+
+def test_message_detail_read_tool_exposes_bounded_chunk_parameters() -> None:
+    app = create_mcp_server(FakeBridge(), fastmcp_cls=FakeFastMCP)
+
+    payload = asyncio.run(
+        app.tools["message_detail_read"](
+            "agent:main:main",
+            "9|9",
+            offset=128,
+            chunk_bytes=256,
+            field="text",
+        )
+    )
+
+    assert payload == {
+        "key": "agent:main:main",
+        "cursor": "9|9",
+        "offset": 128,
+        "chunk_bytes": 256,
+        "field": "text",
+    }
 
 
 def test_optional_mcp_dependency_minimum_supports_fastmcp() -> None:

--- a/tests/test_mcp_server/test_gateway_client.py
+++ b/tests/test_mcp_server/test_gateway_client.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock, call
 
 import pytest
 
 from opensquilla.contracts.gateway_transport import (
     GATEWAY_CLIENT_MAX_MESSAGE_BYTES,
     GATEWAY_CLIENT_MAX_QUEUE,
+    GATEWAY_HISTORY_MAX_RESPONSE_BUDGET_BYTES,
+    GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
 )
-from opensquilla.gateway_client import GatewayRPCClient, normalize_gateway_url
+from opensquilla.gateway_client import GatewayRPCClient, GatewayRPCError, normalize_gateway_url
 
 
 class _SilentWebSocket:
@@ -24,6 +28,28 @@ class _SilentWebSocket:
 
     async def close(self) -> None:
         self.closed = True
+
+
+class _HandshakeWebSocket(_SilentWebSocket):
+    def __init__(self, methods: list[str] | None) -> None:
+        super().__init__()
+        hello: dict[str, Any] = {"type": "hello-ok", "policy": {}}
+        if methods is not None:
+            hello["features"] = {"methods": methods}
+        self._recv_frames = [
+            {"type": "event", "event": "connect.challenge"},
+            hello,
+        ]
+
+    async def recv(self) -> str:
+        return json.dumps(self._recv_frames.pop(0))
+
+    def __aiter__(self) -> _HandshakeWebSocket:
+        return self
+
+    async def __anext__(self) -> str:
+        await asyncio.Future()
+        raise StopAsyncIteration
 
 
 def test_normalize_gateway_url_preserves_query_and_fragment() -> None:
@@ -49,10 +75,41 @@ async def test_gateway_rpc_call_times_out_and_clears_pending_request() -> None:
 
 
 @pytest.mark.asyncio
+async def test_gateway_rpc_error_preserves_server_details() -> None:
+    client = GatewayRPCClient()
+    ws = _SilentWebSocket()
+    client._ws = ws  # noqa: SLF001
+
+    call_task = asyncio.create_task(client.call("chat.history.v2", {}))
+    while not ws.sent:
+        await asyncio.sleep(0)
+    request_id = ws.sent[0]["id"]
+    client._pending[request_id].set_result(  # noqa: SLF001
+        {
+            "ok": False,
+            "error": {
+                "code": "RESPONSE_BUDGET_EXCEEDED",
+                "message": "response exceeds the requested byte budget",
+                "details": {"byte_budget": 64 * 1024, "wire_bytes": 70 * 1024},
+            },
+        }
+    )
+
+    with pytest.raises(GatewayRPCError) as raised:
+        await call_task
+
+    assert raised.value.data == {
+        "byte_budget": 64 * 1024,
+        "wire_bytes": 70 * 1024,
+    }
+
+
+@pytest.mark.asyncio
 async def test_session_history_supports_optional_cursors_without_changing_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = GatewayRPCClient()
+    client._server_methods = frozenset()  # noqa: SLF001
     calls: list[tuple[str, dict[str, object]]] = []
 
     async def fake_call(method: str, params: dict[str, object]) -> dict[str, object]:
@@ -86,6 +143,183 @@ async def test_session_history_supports_optional_cursors_without_changing_defaul
 
 
 @pytest.mark.asyncio
+async def test_session_history_prefers_advertised_bounded_v2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = GatewayRPCClient()
+    client._server_methods = frozenset({"chat.history.v2"})  # noqa: SLF001
+    rpc_call = AsyncMock(return_value={"messages": []})
+    monkeypatch.setattr(client, "call", rpc_call)
+
+    await client.session_history(
+        "agent:main:test",
+        limit=25,
+        after="12|12",
+        include_canonical=True,
+        include_summaries=False,
+    )
+
+    rpc_call.assert_awaited_once_with(
+        "chat.history.v2",
+        {
+            "sessionKey": "agent:main:test",
+            "limit": 25,
+            "after": "12|12",
+            "includeCanonical": True,
+            "includeSummaries": False,
+            "maxResponseBytes": GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_history_explicit_noncanonical_view_uses_legacy_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = GatewayRPCClient()
+    client._server_methods = frozenset({"chat.history.v2"})  # noqa: SLF001
+    rpc_call = AsyncMock(return_value={"messages": []})
+    monkeypatch.setattr(client, "call", rpc_call)
+
+    await client.session_history(
+        "agent:main:test",
+        limit=25,
+        after="12|12",
+        include_canonical=False,
+        include_summaries=False,
+    )
+
+    rpc_call.assert_awaited_once_with(
+        "chat.history",
+        {
+            "sessionKey": "agent:main:test",
+            "limit": 25,
+            "after": "12|12",
+            "includeCanonical": False,
+            "includeSummaries": False,
+        },
+    )
+    assert client._server_method_support("chat.history.v2") is True  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_session_history_retries_v2_at_bounded_max_without_legacy_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = GatewayRPCClient()
+    rpc_call = AsyncMock(
+        side_effect=[
+            GatewayRPCError(
+                "chat.history.v2",
+                code="RESPONSE_BUDGET_EXCEEDED",
+                message="retry with a larger bounded response",
+            ),
+            {"messages": []},
+        ]
+    )
+    monkeypatch.setattr(client, "call", rpc_call)
+
+    await client.session_history("agent:main:test", limit=25)
+
+    assert rpc_call.await_args_list == [
+        call(
+            "chat.history.v2",
+            {
+                "sessionKey": "agent:main:test",
+                "limit": 25,
+                "maxResponseBytes": GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+            },
+        ),
+        call(
+            "chat.history.v2",
+            {
+                "sessionKey": "agent:main:test",
+                "limit": 25,
+                "maxResponseBytes": GATEWAY_HISTORY_MAX_RESPONSE_BUDGET_BYTES,
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_session_history_unknown_capability_falls_back_once_and_remembers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = GatewayRPCClient()
+    rpc_call = AsyncMock(
+        side_effect=[
+            GatewayRPCError(
+                "chat.history.v2",
+                code="METHOD_NOT_FOUND",
+                message="Method not found: chat.history.v2",
+            ),
+            {"messages": []},
+            {"messages": []},
+        ]
+    )
+    monkeypatch.setattr(client, "call", rpc_call)
+
+    await client.session_history("agent:main:test", limit=5)
+    await client.session_history("agent:main:test", limit=10)
+
+    assert client._server_methods is None  # noqa: SLF001
+    assert client._server_method_support("chat.history.v2") is False  # noqa: SLF001
+    assert rpc_call.await_args_list == [
+        call(
+            "chat.history.v2",
+            {
+                "sessionKey": "agent:main:test",
+                "limit": 5,
+                "maxResponseBytes": GATEWAY_HISTORY_RESPONSE_BUDGET_BYTES,
+            },
+        ),
+        call("chat.history", {"sessionKey": "agent:main:test", "limit": 5}),
+        call("chat.history", {"sessionKey": "agent:main:test", "limit": 10}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_session_history_does_not_fallback_on_non_capability_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = GatewayRPCClient()
+    error = GatewayRPCError("chat.history.v2", code="STORAGE_BUSY", message="try later")
+    rpc_call = AsyncMock(side_effect=error)
+    monkeypatch.setattr(client, "call", rpc_call)
+
+    with pytest.raises(GatewayRPCError) as raised:
+        await client.session_history("agent:main:test")
+
+    assert raised.value is error
+    assert client._server_method_support("chat.history.v2") is None  # noqa: SLF001
+    rpc_call.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_gateway_connect_saves_advertised_methods_and_close_resets_them(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    methods = ["chat.history.v2"]
+    ws = _HandshakeWebSocket(methods)
+
+    async def connect(_url: str, **_kwargs: Any) -> _HandshakeWebSocket:
+        return ws
+
+    monkeypatch.setitem(sys.modules, "websockets", SimpleNamespace(connect=connect))
+    client = GatewayRPCClient()
+
+    await client.connect()
+
+    assert client._server_methods == frozenset(methods)  # noqa: SLF001
+    assert client._server_method_support("chat.history.v2") is True  # noqa: SLF001
+
+    await client.close()
+
+    assert client._server_methods is None  # noqa: SLF001
+    assert client._known_missing_server_methods == set()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_gateway_connect_closes_socket_after_bad_handshake(monkeypatch) -> None:
     class BadHandshakeWebSocket(_SilentWebSocket):
         async def recv(self) -> str:
@@ -100,12 +334,16 @@ async def test_gateway_connect_closes_socket_after_bad_handshake(monkeypatch) ->
 
     monkeypatch.setitem(sys.modules, "websockets", SimpleNamespace(connect=connect))
     client = GatewayRPCClient()
+    client._server_methods = frozenset({"chat.history.v2"})  # noqa: SLF001
+    client._known_missing_server_methods.add("sessions.bootstrap.v2")  # noqa: SLF001
 
     with pytest.raises(RuntimeError, match="Unexpected gateway handshake frame"):
         await client.connect("ws://127.0.0.1:18791/ws")
 
     assert ws.closed is True
     assert client._ws is None
+    assert client._server_methods is None  # noqa: SLF001
+    assert client._known_missing_server_methods == set()  # noqa: SLF001
     assert observed_connect == {
         "url": "ws://127.0.0.1:18791/ws",
         "max_size": GATEWAY_CLIENT_MAX_MESSAGE_BYTES,

--- a/tests/test_mcp_server/test_protocol_smoke.py
+++ b/tests/test_mcp_server/test_protocol_smoke.py
@@ -106,6 +106,22 @@ async def test_stdio_mcp_protocol_lists_calls_tools_and_reads_resources(tmp_path
                 async def messages_read(self, key, limit=1000):
                     return {"messages": [{"role": "user", "text": f"hello {key}"}], "limit": limit}
 
+                async def message_detail_read(
+                    self,
+                    key,
+                    cursor,
+                    offset=0,
+                    chunk_bytes=131072,
+                    field="message",
+                ):
+                    return {
+                        "key": key,
+                        "cursor": cursor,
+                        "offset": offset,
+                        "chunk_bytes": chunk_bytes,
+                        "field": field,
+                    }
+
                 async def messages_send(self, key, message, intent="continue"):
                     return {
                         "status": "accepted",
@@ -172,6 +188,7 @@ async def test_stdio_mcp_protocol_lists_calls_tools_and_reads_resources(tmp_path
                     "conversations_list",
                     "session_resolve",
                     "messages_read",
+                    "message_detail_read",
                     "messages_send",
                     "events_wait",
                     "transcript_export",
@@ -301,10 +318,10 @@ async def test_bridge_runs_against_real_gateway_websocket_session_flow(tmp_path:
 
                 async def append_message(self, key, role="user", content=""):
                     session = self._storage.sessions[key]
-                    message_id = (
-                        f"msg-{{len(self._storage.transcripts[session.session_id]) + 1}}"
-                    )
+                    transcript_id = len(self._storage.transcripts[session.session_id]) + 1
+                    message_id = f"msg-{{transcript_id}}"
                     entry = SimpleNamespace(
+                        id=transcript_id,
                         role=role,
                         content=content,
                         message_id=message_id,
@@ -319,6 +336,69 @@ async def test_bridge_runs_against_real_gateway_websocket_session_flow(tmp_path:
                     if session is None:
                         return []
                     return list(self._storage.transcripts.get(session.session_id, []))
+
+                async def get_canonical_transcript_cursor_page(
+                    self,
+                    key,
+                    *,
+                    limit,
+                    before=None,
+                    after=None,
+                ):
+                    entries = await self.get_transcript(key)
+                    if before is not None:
+                        entries = [
+                            entry
+                            for entry in entries
+                            if (entry.created_at, entry.id) < before
+                        ]
+                    elif after is not None:
+                        entries = [
+                            entry
+                            for entry in entries
+                            if (entry.created_at, entry.id) > after
+                        ]
+                    if after is not None and before is None:
+                        selected = entries[: limit + 1]
+                        has_more = len(selected) > limit
+                        selected = selected[:limit]
+                    else:
+                        selected = entries[-(limit + 1) :]
+                        has_more = len(selected) > limit
+                        selected = selected[-limit:]
+                    return (
+                        [
+                            SimpleNamespace(
+                                cursor=(entry.created_at, entry.id),
+                                stored_bytes=len(entry.content.encode("utf-8")),
+                                content_prefix=entry.content[:2048],
+                                message_id=entry.message_id,
+                                role=entry.role,
+                                provenance_kind=None,
+                                provenance_origin_session_id=None,
+                                provenance_source_session_key=None,
+                                provenance_source_channel=None,
+                                provenance_source_tool=None,
+                                turn_id=None,
+                            )
+                            for entry in selected
+                        ],
+                        has_more,
+                        True,
+                    )
+
+                async def get_canonical_transcript_entry_by_cursor(self, key, *, cursor):
+                    return next(
+                        (
+                            entry
+                            for entry in await self.get_transcript(key)
+                            if (entry.created_at, entry.id) == cursor
+                        ),
+                        None,
+                    )
+
+                async def get_summary_metadata(self, key):
+                    return [], False, 0
 
                 async def apply_intent(self, key, intent, **kwargs):
                     return self._storage.sessions[key], False

--- a/tests/unit/cli/repl/test_gateway_runtime.py
+++ b/tests/unit/cli/repl/test_gateway_runtime.py
@@ -340,6 +340,119 @@ async def test_gateway_runtime_dispatches_messages_slash_commands_and_exit(
 
 
 @pytest.mark.asyncio
+async def test_session_switch_subscribes_from_the_snapshot_applied_to_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.cli.repl import gateway_runtime
+    from opensquilla.cli.tui.opentui.history import (
+        apply_bootstrap_to_state,
+        history_replace_from_bootstrap,
+    )
+
+    old_key = "agent:main:old"
+    new_key = "agent:main:new"
+
+    class _Subscription:
+        def __init__(self) -> None:
+            self.queue: asyncio.Queue[None] = asyncio.Queue()
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self) -> dict[str, Any]:
+            await self.queue.get()
+            raise StopAsyncIteration
+
+        async def close(self) -> None:
+            self.queue.put_nowait(None)
+
+    class _Client:
+        instances: list[_Client] = []
+
+        def __init__(self) -> None:
+            self.bootstrap_calls: list[tuple[str, int]] = []
+            self.subscribe_calls: list[tuple[str, int | None]] = []
+            _Client.instances.append(self)
+
+        async def connect(self, url: str, *, token: str | None = None) -> None:
+            return None
+
+        async def create_session(self, model: str | None = None) -> str:
+            return old_key
+
+        async def bootstrap_session(self, key: str, *, limit: int = 200) -> dict[str, Any]:
+            self.bootstrap_calls.append((key, limit))
+            # A second snapshot of the switched session observes a later
+            # cursor. Subscribing from it would skip the event between the
+            # history replacement and subscription.
+            new_reads = sum(call_key == new_key for call_key, _ in self.bootstrap_calls)
+            cursor = 10 if key == old_key else 19 + new_reads
+            return {
+                "session": {"session_key": key, "model": "gateway/model"},
+                "history": {
+                    "messages": [],
+                    "history_scope": "complete",
+                    "loaded_count": 0,
+                    "canonical_available": True,
+                },
+                "stream_cursor": cursor,
+                "queue": {"running_count": 0, "queued_count": 0},
+            }
+
+        async def subscribe_session_events(
+            self,
+            key: str,
+            *,
+            since_stream_seq: int | None = None,
+        ) -> _Subscription:
+            self.subscribe_calls.append((key, since_stream_seq))
+            return _Subscription()
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("opensquilla.cli.gateway_client.GatewayClient", _Client)
+
+    async def handle_slash(
+        _cmd: str,
+        state: ChatSessionState,
+        client: _Client,
+        _elevated_state: dict[str, str | None],
+        *,
+        tui_output: object | None = None,
+    ) -> bool:
+        snapshot = await client.bootstrap_session(new_key, limit=200)
+        history = history_replace_from_bootstrap(
+            snapshot,
+            fallback_session_key=new_key,
+        )
+        apply_bootstrap_to_state(state, snapshot, history)
+        return True
+
+    async def input_loop(*, scope, dispatch, abort_active_turn=None) -> None:
+        assert await dispatch("/switch") is True
+        assert await dispatch("/exit") is False
+
+    deps = gateway_runtime.GatewayRuntimeDependencies(
+        stream_response=cast(Any, None),
+        handle_slash_command=handle_slash,
+        run_input_loop=input_loop,
+        get_tui_output=lambda _scope: None,
+        is_exit_command=lambda value: value == "/exit",
+        notify=lambda _notice: None,
+    )
+
+    await gateway_runtime.run_gateway_chat(model=None, session_id=None, deps=deps)
+
+    client = _Client.instances[-1]
+    assert client.subscribe_calls == [(old_key, 10), (new_key, 20)]
+    assert client.bootstrap_calls[:2] == [(old_key, 200), (new_key, 200)]
+    # The only later switched-session bootstrap is the bounded exit receipt,
+    # after the observer has already subscribed from cursor 20.
+    assert client.bootstrap_calls == [(old_key, 200), (new_key, 200), (new_key, 1)]
+
+
+@pytest.mark.asyncio
 async def test_gateway_abort_targets_active_turn_session_after_session_changes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1052,6 +1165,7 @@ async def test_external_turn_discovery_routes_interleaved_turns_once(
 
     session_key = "agent:main:shared"
     client = GatewayClient()
+    client._server_methods = frozenset({"sessions.bootstrap"})  # noqa: SLF001
 
     async def call(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         if method == "sessions.messages.subscribe":

--- a/tests/unit/cli/repl/test_runtime_bridge.py
+++ b/tests/unit/cli/repl/test_runtime_bridge.py
@@ -204,8 +204,10 @@ async def test_gateway_runtime_bridge_prints_failure_receipt_once(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("bootstrap_method", ["sessions.bootstrap", "sessions.bootstrap.v2"])
 async def test_gateway_runtime_bridge_formats_missing_resume_without_traceback(
     monkeypatch: pytest.MonkeyPatch,
+    bootstrap_method: str,
 ) -> None:
     from opensquilla.cli.gateway_client import GatewayRPCError
     from opensquilla.cli.repl import runtime_bridge
@@ -214,7 +216,7 @@ async def test_gateway_runtime_bridge_formats_missing_resume_without_traceback(
 
     async def fake_run_gateway_chat(**_kwargs: Any) -> gateway_runtime.SessionExitSummary:
         raise GatewayRPCError(
-            "sessions.bootstrap",
+            bootstrap_method,
             code="NOT_FOUND",
             message="Session not found: main",
         )

--- a/tests/unit/cli/tui/test_opentui_history.py
+++ b/tests/unit/cli/tui/test_opentui_history.py
@@ -59,6 +59,51 @@ def test_bootstrap_projection_preserves_scope_content_and_durable_ids() -> None:
     assert history.messages[1].artifacts == ({"id": "artifact-1"},)
 
 
+def test_bootstrap_projection_renders_one_bounded_v2_preview() -> None:
+    snapshot = _snapshot()
+    snapshot["history"] = {
+        "history_scope": "latest_window",
+        "has_more": True,
+        "loaded_count": 1,
+        "canonical_available": True,
+        "truncated_by_bytes": True,
+        "messages": [
+            {
+                "message_id": "large-message",
+                "role": "assistant",
+                "preview": "bounded preview",
+                "detail_ref": {
+                    "method": "chat.history.entry.v1",
+                    "sessionKey": "agent:main:canonical",
+                    "cursor": "1|1",
+                },
+                "original_bytes": 98_304,
+                "truncated_by_bytes": True,
+            }
+        ],
+    }
+
+    history = history_replace_from_bootstrap(
+        snapshot,
+        fallback_session_key="agent:main:alias",
+    )
+
+    assert history.history_scope == "latest_window"
+    assert history.has_more is True
+    assert history.loaded_count == 1
+    assert history.truncated_by_bytes is True
+    assert len(history.messages) == 1
+    message = history.messages[0]
+    assert message.text == "bounded preview"
+    assert message.truncated_by_bytes is True
+    assert message.original_bytes == 98_304
+    assert message.detail_ref == {
+        "method": "chat.history.entry.v1",
+        "sessionKey": "agent:main:canonical",
+        "cursor": "1|1",
+    }
+
+
 def test_bootstrap_replaces_local_transcript_without_partial_usage_total() -> None:
     state = ChatSessionState(session_key="agent:main:old", model="old")
     state.transcript.add("user", "stale")

--- a/tests/unit/cli/tui/test_opentui_messages.py
+++ b/tests/unit/cli/tui/test_opentui_messages.py
@@ -120,12 +120,19 @@ def test_python_message_to_json_serializes_atomic_history_replace() -> None:
             has_more=True,
             loaded_count=1,
             canonical_available=True,
+            truncated_by_bytes=True,
             messages=(
                 HistoryMessage(
                     id="message-1",
                     role="user",
                     text="你好",
                     attachments=({"name": "brief.pdf"},),
+                    truncated_by_bytes=True,
+                    original_bytes=98_304,
+                    detail_ref={
+                        "method": "chat.history.entry.v1",
+                        "cursor": "1|1",
+                    },
                 ),
             ),
         ),
@@ -134,6 +141,9 @@ def test_python_message_to_json_serializes_atomic_history_replace() -> None:
     assert payload.endswith("\n")
     assert '"type":"history.replace"' in payload
     assert '"history_scope":"latest_window"' in payload
+    assert '"truncated_by_bytes":true' in payload
+    assert '"original_bytes":98304' in payload
+    assert '"detail_ref":{"method":"chat.history.entry.v1","cursor":"1|1"}' in payload
     assert '"id":"message-1"' in payload
     assert '"attachments":[{"name":"brief.pdf"}]' in payload
 


### PR DESCRIPTION
## Scope

Scope boundary: Teach the CLI/TUI, general Python client, and MCP bridge to negotiate v2 capabilities, use one bounded newest history window at startup, preserve strict legacy fallback, show older-history/truncation hints, and page/chunk transcript exports without aggregating all history rows in memory.

Non-goals: No automatic background fetch of all older TUI history, no legacy RPC removal, and no persisted-session migration or rewrite.

## Branch

Base branch: `feature/gateway-byte-bounded-history` (stacked on PR2; retarget to `main` after PR2 merges)

Target exception: stacked dependency for review

## Issue

Linked issue: Refs #987

If None, reason: N/A

## Release Note

Release note: Load a bounded latest session window in TUI and stream transcript exports across byte-bounded history pages and detail chunks.

## Tests

Ruff: `ruff check src tests` passed.

Pytest: 261 focused PR3 client/TUI/MCP tests passed; the final cross-stack suite passed 466 tests with 1 skip.

Build: OpenTUI history renderer tests passed (7/7); no production asset change required.

Regression tests: added

Notes: Covers new client/old Gateway, old client/new Gateway, and new/new combinations; capability and `METHOD_NOT_FOUND` fallback; startup one-window behavior; session switch/replay gap; streaming JSON/Markdown export; chunk identity/hash validation; and a real Gateway MCP smoke. A full local run reached 18,672 passed and 212 skipped before two stack-related failures were corrected and rerun. The remaining 18 local failures reproduce only in unavailable/mismatched host facilities: missing OpenTUI/tmux dependencies, a local router artifact manifest mismatch, and sandbox/TMPDIR/profile assumptions.

## Maintainer Live Check

Maintainer live check: no

Surface: gateway

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and `tests/_private/` contents are not committed. New clients fall back only when the capability is explicitly absent or the method is not found; bounded-protocol errors are surfaced instead of silently issuing an unbounded legacy request. Existing session data is never changed, truncated, or migrated.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation files changed; behavior and rollout order are described above.
