### PR TITLE
修复:Anthropic 流式中途报错时保留已收到的部分用量

### DIFF
--- a/src/opensquilla/provider/anthropic.py
+++ b/src/opensquilla/provider/anthropic.py
@@ -586,6 +586,32 @@ class AnthropicProvider:
         # indices that were never opened at all remain protocol errors.
         non_tool_block_indices: set[Any] = set()
 
+        def _partial_usage_breakdown() -> list[dict[str, Any]]:
+            """Return a usage receipt row when the stream already reported tokens.
+
+            ``message_start`` carries the input-token bill; a mid-stream error
+            (invalid frame, incomplete stream, timeout, ...) must not discard
+            it, or the session ledger records a zero-cost turn even though the
+            provider billed partial input.  Before ``message_start`` nothing
+            billable has been reported, so the row is omitted and the
+            ErrorEvent stays unknown to the ledger (unchanged behavior).
+            """
+            if not message_started:
+                return []
+            return [
+                {
+                    "provider": self.provider_id,
+                    "model": self._model,
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "reasoning_tokens": 0,
+                    "cached_tokens": cached_tokens,
+                    "cache_write_tokens": cache_creation_tokens,
+                    "billed_cost": 0.0,
+                    "cost_source": "opensquilla_estimate",
+                }
+            ]
+
         try:
             async with httpx.AsyncClient(
                 timeout=cfg.timeout,
@@ -662,13 +688,18 @@ class AnthropicProvider:
                             yield ErrorEvent(
                                 message=message,
                                 code="invalid_stream_frame",
+                                model_usage_breakdown=_partial_usage_breakdown(),
                             )
                             return
 
                         if not isinstance(event, dict):
                             message = "Anthropic stream contained a non-object data frame"
                             trace.record_error(code="invalid_stream_frame", message=message)
-                            yield ErrorEvent(message=message, code="invalid_stream_frame")
+                            yield ErrorEvent(
+                                message=message,
+                                code="invalid_stream_frame",
+                                model_usage_breakdown=_partial_usage_breakdown(),
+                            )
                             return
                         etype = event.get("type", "")
                         # Error frames may echo the active credential.  They
@@ -685,7 +716,11 @@ class AnthropicProvider:
                         }:
                             message = "Anthropic stream mutated content after message_delta"
                             trace.record_error(code="invalid_stream_order", message=message)
-                            yield ErrorEvent(message=message, code="invalid_stream_order")
+                            yield ErrorEvent(
+                                message=message,
+                                code="invalid_stream_order",
+                                model_usage_breakdown=_partial_usage_breakdown(),
+                            )
                             return
                         if etype in {
                             "content_block_start",
@@ -702,7 +737,11 @@ class AnthropicProvider:
                             if message_started:
                                 message = "Anthropic stream repeated message_start"
                                 trace.record_error(code="invalid_stream_order", message=message)
-                                yield ErrorEvent(message=message, code="invalid_stream_order")
+                                yield ErrorEvent(
+                                    message=message,
+                                    code="invalid_stream_order",
+                                    model_usage_breakdown=_partial_usage_breakdown(),
+                                )
                                 return
                             message_started = True
                             message_id = event.get("message", {}).get("id")
@@ -971,13 +1010,21 @@ class AnthropicProvider:
                                 api_key=self._api_key,
                             )
                             trace.record_error(code=error_code, message=error_message)
-                            yield ErrorEvent(message=error_message, code=error_code)
+                            yield ErrorEvent(
+                                message=error_message,
+                                code=error_code,
+                                model_usage_breakdown=_partial_usage_breakdown(),
+                            )
                             return
 
                     if not message_stopped:
                         message = "Anthropic stream ended before message_stop"
                         trace.record_error(code="incomplete_stream", message=message)
-                        yield ErrorEvent(message=message, code="incomplete_stream")
+                        yield ErrorEvent(
+                            message=message,
+                            code="incomplete_stream",
+                            model_usage_breakdown=_partial_usage_breakdown(),
+                        )
                         return
 
                     pending_tool_calls = tools_acc.pending_raw_arguments()
@@ -990,7 +1037,11 @@ class AnthropicProvider:
                     ):
                         message = "Anthropic response ended with an incomplete tool call"
                         trace.record_error(code="incomplete_tool_call", message=message)
-                        yield ErrorEvent(message=message, code="incomplete_tool_call")
+                        yield ErrorEvent(
+                            message=message,
+                            code="incomplete_tool_call",
+                            model_usage_breakdown=_partial_usage_breakdown(),
+                        )
                         return
 
                     # Tool block completion is provisional until the response
@@ -1063,7 +1114,11 @@ class AnthropicProvider:
                 limit=exc.limit,
                 observed=exc.observed,
             )
-            yield ErrorEvent(message=message, code="candidate_artifact_limit_exceeded")
+            yield ErrorEvent(
+                message=message,
+                code="candidate_artifact_limit_exceeded",
+                model_usage_breakdown=_partial_usage_breakdown(),
+            )
         except httpx.TimeoutException as exc:
             message = redact_upstream_error_text(
                 f"Request timed out: {str(exc) or repr(exc)}",
@@ -1071,7 +1126,11 @@ class AnthropicProvider:
                 max_len=2000,
             )
             trace.record_error(code="timeout", message=message)
-            yield ErrorEvent(message=message, code="timeout")
+            yield ErrorEvent(
+                message=message,
+                code="timeout",
+                model_usage_breakdown=_partial_usage_breakdown(),
+            )
         except httpx.RequestError as exc:
             message = redact_upstream_error_text(
                 f"Request error: {str(exc) or repr(exc)}",
@@ -1079,7 +1138,11 @@ class AnthropicProvider:
                 max_len=2000,
             )
             trace.record_error(code="request_error", message=message)
-            yield ErrorEvent(message=message, code="request_error")
+            yield ErrorEvent(
+                message=message,
+                code="request_error",
+                model_usage_breakdown=_partial_usage_breakdown(),
+            )
         except Exception as exc:  # noqa: BLE001 - chat() contract: ErrorEvent instead of raising
             message = redact_upstream_error_text(
                 f"Provider response handling failed: {str(exc) or repr(exc)}",
@@ -1100,6 +1163,7 @@ class AnthropicProvider:
             yield ErrorEvent(
                 message=message,
                 code="provider_internal",
+                model_usage_breakdown=_partial_usage_breakdown(),
             )
 
     async def list_models(self) -> list[ModelInfo]:

--- a/tests/test_provider_anthropic_usage.py
+++ b/tests/test_provider_anthropic_usage.py
@@ -696,3 +696,119 @@ def test_list_models_rows_match_retired_known_models_table() -> None:
     rows = asyncio.run(AnthropicProvider(api_key="test").list_models())
 
     assert rows == expected
+
+
+# ---------------------------------------------------------------------------
+# Error events must carry partial usage already reported by message_start
+# (issue #1016) so the session ledger does not record $0 for an errored turn
+# where the provider billed partial input tokens.
+# ---------------------------------------------------------------------------
+
+
+def _patch_anthropic_transport(monkeypatch, body: bytes) -> None:
+    """Serve ``body`` as the SSE response for the adapter's HTTP call."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=body,
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("opensquilla.provider.anthropic.httpx.AsyncClient", patched_async_client)
+
+
+def _collect_anthropic_error(provider, message) -> ErrorEvent:
+    async def _collect() -> ErrorEvent:
+        errors = []
+        async for ev in provider.chat([Message(role="user", content=message)], config=ChatConfig()):
+            if isinstance(ev, ErrorEvent):
+                errors.append(ev)
+        assert len(errors) == 1, f"expected exactly one ErrorEvent, got {len(errors)}"
+        return errors[0]
+
+    return asyncio.run(_collect())
+
+
+def _message_start_events() -> list[dict]:
+    return [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_t",
+                "model": "claude-test",
+                "usage": {"input_tokens": 100, "output_tokens": 0},
+            },
+        },
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "partial "},
+        },
+    ]
+
+
+def test_anthropic_error_event_carries_partial_usage_after_invalid_frame(monkeypatch) -> None:
+    """An invalid frame after message_start must not discard the 100 input tokens."""
+
+    body = _sse_body(_message_start_events()) + b"event: content_block_delta\ndata: {INVALID}\n\n"
+    _patch_anthropic_transport(monkeypatch, body)
+
+    err = _collect_anthropic_error(AnthropicProvider(api_key="test", model="claude-test"), "hi")
+
+    assert err.code == "invalid_stream_frame"
+    assert err.model_usage_breakdown, "partial usage from message_start must be carried"
+    row = err.model_usage_breakdown[0]
+    assert row["input_tokens"] == 100
+    assert row["output_tokens"] == 0
+    assert row["model"] == "claude-test"
+    assert row["cost_source"] == "opensquilla_estimate"
+
+    # Downstream: the usage ledger must finalize this as a known partial
+    # receipt instead of recording an unknown zero-cost turn.
+    from opensquilla.engine.usage_accounting import (
+        has_known_provider_usage_receipt,
+        normalize_provider_usage,
+    )
+
+    assert has_known_provider_usage_receipt(err) is True
+    result = normalize_provider_usage(
+        err,
+        default_provider="anthropic",
+        default_model="claude-test",
+        completed_at_ms=0,
+    )
+    assert result.input_tokens == 100
+
+
+def test_anthropic_error_event_carries_partial_usage_on_incomplete_stream(monkeypatch) -> None:
+    """A stream that ends before message_stop must still keep reported input tokens."""
+
+    body = _sse_body(_message_start_events())  # no message_stop
+    _patch_anthropic_transport(monkeypatch, body)
+
+    err = _collect_anthropic_error(AnthropicProvider(api_key="test", model="claude-test"), "hi")
+
+    assert err.code == "incomplete_stream"
+    assert err.model_usage_breakdown
+    assert err.model_usage_breakdown[0]["input_tokens"] == 100
+
+
+def test_anthropic_error_before_message_start_has_no_usage_breakdown(monkeypatch) -> None:
+    """An error before message_start means nothing was billed — keep the row empty."""
+
+    body = b"event: content_block_delta\ndata: {INVALID}\n\n"
+    _patch_anthropic_transport(monkeypatch, body)
+
+    err = _collect_anthropic_error(AnthropicProvider(api_key="test", model="claude-test"), "hi")
+
+    assert err.code == "invalid_stream_frame"
+    assert err.model_usage_breakdown == []


### PR DESCRIPTION
## Scope

Scope boundary: 修复 Anthropic 流式中途报错时丢失已收用量。message_start 已上报 input-token 账单,但中途错误(坏帧、断流、超时、连接断开)产出的 ErrorEvent 未填充 model_usage_breakdown,导致会话账本把该回合记为 $0。修复:在 anthropic.py 的 11 个 message_start 之后的错误产出点填充由累积计数器构建的部分用量收据行;message_start 之前出错保持空(未计费)。下游经既有 has_known_provider_usage_receipt / normalize_provider_usage 路径以"已知部分收据"入账。openai_codex.py 经查证 usage 仅在终止事件 response.completed 解析,中途错误无部分用量可携带,不属于同类问题。

Non-goals: 不改变 DoneEvent 成功路径的记账;不新增 ErrorEvent 字段;不修改 usage 账本聚合逻辑。

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1016

If None, reason: N/A

## Release Note

Release note: 修复 Anthropic 流式中途报错时已收到的 input token 用量被丢弃、账本记为 $0 的问题,错误回合现在按部分用量入账。

## Tests

Ruff: All checks passed(anthropic.py + test_provider_anthropic_usage.py)

Pytest: test_provider_anthropic_usage.py 22 passed(含 3 个新用例);test_provider/ 全目录 686 passed;usage 账本套件 101 passed;tests/unit 758 passed

Build: N/A(纯后端改动)

Regression tests: added

Notes:

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [ ] Links point to existing repository files or stable external pages.
- [ ] Code fences and Markdown tables render correctly on GitHub.
- [ ] Examples avoid real secrets, local private paths, and private transcripts.