### PR TITLE
Allow inline requests after /meta skill commands

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatSlashCommands.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSlashCommands.test.ts
@@ -196,6 +196,41 @@ describe('useChatSlashCommands plan compatibility', () => {
   })
 })
 
+describe('useChatSlashCommands meta requests', () => {
+  const metaCommand = {
+    name: '/meta',
+    description: 'Run a meta-skill.',
+    aliases: [],
+    execution: { action: 'meta.menu' },
+    argument_choices: [
+      { value: 'meta-skill-creator', description: 'Create a meta-skill.' },
+    ],
+  }
+
+  it('keeps the concrete request after the selected meta-skill name', async () => {
+    const { api, dispatchHidden, rpc } = harness(false, [metaCommand])
+    rpc.call.mockImplementation(async (method: string) => {
+      if (method === 'commands.list_for_surface') return { commands: [metaCommand] }
+      if (method === 'meta.run') return { ok: true }
+      return {}
+    })
+
+    await api.executeSlashCommand(
+      '/meta meta-skill-creator create a competitor research meta-skill',
+    )
+    await vi.waitFor(() => expect(dispatchHidden).toHaveBeenCalledOnce())
+
+    expect(rpc.call).toHaveBeenCalledWith('meta.run', {
+      name: 'meta-skill-creator',
+      sessionKey: 'agent:main:webchat:test',
+    })
+    expect(dispatchHidden).toHaveBeenCalledWith(
+      '/meta meta-skill-creator create a competitor research meta-skill',
+      '/meta meta-skill-creator create a competitor research meta-skill',
+    )
+  })
+})
+
 describe('useChatSlashCommands Coding mode', () => {
   const codingCommand = {
     name: '/coding',

--- a/opensquilla-webui/src/composables/chat/useChatSlashCommands.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSlashCommands.ts
@@ -430,16 +430,20 @@ export function useChatSlashCommands(options: UseChatSlashCommandsOptions) {
       case 'meta.menu': {
         // Bare "/meta" is handled by the argument-completion branch above
         // (it reopens the menu with the skill choices). Here we only reach the
-        // run path, with a skill name supplied (e.g. Enter on "/meta <skill>").
-        const skillName = String(args || '').trim()
+        // run path. Only the first argument is the skill name; all remaining
+        // text is the concrete request passed through on the launch turn.
+        const metaArgs = String(args || '').trim()
+        const separator = metaArgs.search(/\s/)
+        const skillName = separator === -1 ? metaArgs : metaArgs.slice(0, separator)
+        const request = separator === -1 ? '' : metaArgs.slice(separator).trim()
         if (!skillName) break
-        void runMetaSkill(skillName)
+        void runMetaSkill(skillName, request)
         break
       }
     }
   }
 
-  async function runMetaSkill(skillName: string): Promise<void> {
+  async function runMetaSkill(skillName: string, request = ''): Promise<void> {
     const name = String(skillName || '').trim()
     if (!name) return
     try {
@@ -448,7 +452,10 @@ export function useChatSlashCommands(options: UseChatSlashCommandsOptions) {
         sessionKey: options.sessionKey.value,
       })
       if (result?.ok) {
-        options.dispatchHidden('/meta ' + name, '/meta ' + name)
+        const launchText = ['/meta', name, String(request || '').trim()]
+          .filter(Boolean)
+          .join(' ')
+        options.dispatchHidden(launchText, launchText)
       } else {
         options.notify(result?.error || i18n.global.t('chat.metaRuns.couldNotRunSkill', { skill: name }))
       }

--- a/src/opensquilla/cli/tui/adapters/slash_gateway.py
+++ b/src/opensquilla/cli/tui/adapters/slash_gateway.py
@@ -690,7 +690,10 @@ async def _dispatch_gateway_slash_command(
         return True
 
     if parts := _slash_parts(cmd, "/meta"):
-        name = parts[1].strip() if len(parts) > 1 else ""
+        raw_args = parts[1].strip() if len(parts) > 1 else ""
+        meta_args = raw_args.split(maxsplit=1)
+        name = meta_args[0] if meta_args else ""
+        request = meta_args[1].strip() if len(meta_args) > 1 else ""
         if not name:
             payload = await client.call("meta.list", {})
             _print_meta_skills_table(payload)
@@ -703,6 +706,8 @@ async def _dispatch_gateway_slash_command(
             console.print(error_panel(error or f"Could not run meta-skill {name!r}."))
             return True
         prompt = f"/meta {name}"
+        if request:
+            prompt = f"{prompt} {request}"
         result = await stream(
             client,
             state.session_key,

--- a/src/opensquilla/engine/commands.py
+++ b/src/opensquilla/engine/commands.py
@@ -673,8 +673,8 @@ _COMMANDS: tuple[CommandDef, ...] = (
     ),
     CommandDef(
         name="/meta",
-        usage="/meta [skill-name]",
-        description="List meta-skills, or run one with /meta <skill-name>.",
+        usage="/meta [skill-name] [request]",
+        description="List meta-skills, or run one with /meta <skill-name> [request].",
         execution={
             _W: _local("meta.menu"),
             _T: _local("meta.menu"),

--- a/src/opensquilla/engine/steps/meta_command.py
+++ b/src/opensquilla/engine/steps/meta_command.py
@@ -82,15 +82,23 @@ def _is_launch_turn(ctx: TurnContext, name: str) -> bool:
     """True when this turn is the ``/meta <name>`` launch turn for ``name``.
 
     Every surface (web SPA, CLI/TUI, channel) stamps the launch via
-    ``meta.run`` and then sends a turn whose provider text is exactly
-    ``/meta <name>`` (bypassing client slash parsing). Matching that sentinel
-    is what binds the pending launch to the turn the surface deliberately
-    issued, so an unrelated normal message never claims it.
+    ``meta.run`` and then sends a turn whose provider text is ``/meta <name>``
+    followed by an optional concrete request (bypassing client slash parsing).
+    Matching the sentinel at a whitespace boundary binds the pending launch to
+    the turn the surface deliberately issued without accepting a different
+    skill whose name merely shares the same prefix.
     """
     sentinel = f"/meta {name}"
     for text in (getattr(ctx, "message", ""), getattr(ctx, "semantic_message", "")):
-        if isinstance(text, str) and text.strip() == sentinel:
+        if not isinstance(text, str):
+            continue
+        candidate = text.strip()
+        if candidate == sentinel:
             return True
+        if candidate.startswith(sentinel):
+            suffix = candidate[len(sentinel) :]
+            if suffix and suffix[0].isspace():
+                return True
     return False
 
 

--- a/tests/test_cli/test_tui_meta_command.py
+++ b/tests/test_cli/test_tui_meta_command.py
@@ -143,6 +143,52 @@ async def test_meta_run_ok_triggers_turn(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.mark.asyncio
+async def test_meta_run_keeps_inline_request_out_of_skill_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.cli.repl import slash_adapter
+    from opensquilla.cli.repl.slash_adapter import (
+        GatewaySlashContext,
+        handle_gateway_slash_command,
+    )
+
+    console, _buffer = _make_console()
+    monkeypatch.setattr(slash_adapter, "console", console)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_stream_response_gateway(
+        gateway_client: object,
+        session_key: str,
+        message: str,
+        elevated_state: dict[str, str | None],
+        attachments: list[dict[str, Any]] | None = None,
+        *,
+        tui_output: object | None = None,
+    ) -> TurnResult:
+        captured["message"] = message
+        return TurnResult(text="launched")
+
+    monkeypatch.setattr(slash_adapter, "stream_response_gateway", fake_stream_response_gateway)
+
+    client = _FakeGatewayClient(responses={"meta.run": {"ok": True}})
+    state = ChatSessionState(session_key="agent:main:test", model="local/test")
+    command = "/meta meta-tiny create a competitor research meta-skill"
+
+    handled = await handle_gateway_slash_command(
+        command,
+        GatewaySlashContext(state=state, client=client, elevated_state={"mode": None}),
+    )
+
+    assert handled is True
+    assert client.calls == [
+        ("meta.run", {"name": "meta-tiny", "sessionKey": "agent:main:test"}),
+    ]
+    assert captured["message"] == command
+    assert command in state.transcript.to_markdown()
+
+
+@pytest.mark.asyncio
 async def test_meta_run_not_ok_prints_error_and_skips_turn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_engine/test_meta_command_launch.py
+++ b/tests/test_engine/test_meta_command_launch.py
@@ -87,6 +87,32 @@ async def test_launch_turn_sentinel_tolerates_surrounding_whitespace() -> None:
 
 
 @pytest.mark.asyncio
+async def test_launch_turn_accepts_a_concrete_request_after_the_skill_name() -> None:
+    pending_meta_launch_put("S-request", "meta-tiny")
+
+    ctx = _make_ctx(
+        "S-request",
+        "/meta meta-tiny create a competitor research meta-skill",
+    )
+    await meta_command_launch(ctx)
+
+    assert ctx.metadata["meta_launch"] == {"name": "meta-tiny"}
+    assert pending_meta_launch_peek("S-request") is None
+
+
+@pytest.mark.asyncio
+async def test_launch_turn_rejects_a_skill_name_prefix_collision() -> None:
+    pending_meta_launch_put("S-prefix", "meta-tiny")
+
+    ctx = _make_ctx("S-prefix", "/meta meta-tiny-extra create something")
+    await meta_command_launch(ctx)
+
+    assert "meta_launch" not in ctx.metadata
+    assert pending_meta_launch_peek("S-prefix") == "meta-tiny"
+    pending_meta_launch_pop("S-prefix")
+
+
+@pytest.mark.asyncio
 async def test_meta_command_launch_no_pending_is_noop() -> None:
     # Ensure no residual entry for this session.
     pending_meta_launch_pop("S-empty")

--- a/tests/test_engine/test_meta_command_registration.py
+++ b/tests/test_engine/test_meta_command_registration.py
@@ -9,6 +9,7 @@ def test_meta_command_present_on_gateway_backed_surfaces() -> None:
     cmd = DEFAULT_REGISTRY.find("/meta")
     assert cmd is not None
     assert cmd.name == "/meta"
+    assert cmd.usage == "/meta [skill-name] [request]"
     for surface in (Surface.WEB_CHAT, Surface.CLI_GATEWAY, Surface.CHANNEL):
         assert cmd.execution_for(surface) is not None, surface
     assert cmd.execution_for(Surface.CLI_STANDALONE) is None


### PR DESCRIPTION
## Scope

Scope boundary: Allow a meta-skill launch command to include a concrete request after the selected skill name on both Web Chat and the Gateway TUI. The first argument remains the skill name, while the remaining text is preserved on the launch turn. The shared runtime accepts the request only at a whitespace boundary, so similarly prefixed skill names cannot claim the launch.

Non-goals: No changes to meta-skill execution, creation logic, standalone mode, channel list-only behavior, or unrelated slash commands.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Small self-contained command parsing and cross-surface consistency fix.

## Release Note

Release note: Users can now enter commands such as `/meta meta-skill-creator create a competitor research skill` in Web Chat or the Gateway TUI without losing the request text or treating it as part of the skill name.

## Tests

Ruff: `ruff check` passed for all changed Python source and test files.

Pytest: 30 passed across the MetaSkill launch marker, command registration, Gateway command catalog, and Gateway TUI command suites.

Build: `npm run typecheck` passed, including WebUI architecture and security guards.

Regression tests: added for Web Chat, shared launch matching, skill-name prefix collisions, Gateway TUI request forwarding, and command usage registration.

Notes: `npm run test:unit -- src/composables/chat/useChatSlashCommands.test.ts` passed (14 tests). Targeted mypy checks passed for the changed Python source files. The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: Web Chat and Gateway TUI

Maintainer-only note: No credentialed live check is required for this command parsing change.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] The shared command catalog now documents `/meta [skill-name] [request]`.
